### PR TITLE
feat(agents): plugin-declared human-approval tools exempt from harness tool watchdogs

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -13,6 +13,16 @@ import {
 } from "./dynamic-tool-execution.js";
 import type { CodexDynamicToolCallParams, CodexDynamicToolCallResponse } from "./protocol.js";
 
+// Override only the human-approval budget accessor; the module under test pulls
+// several other bindings from this barrel, so importActual keeps them real.
+vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importActual) => {
+  const actual = await importActual<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>();
+  return {
+    ...actual,
+    resolveHumanApprovalToolTimeoutMs: (tool: string) => (tool === "exec" ? 600_000 : undefined),
+  };
+});
+
 const dynamicCallContext = { threadId: "thread-1", turnId: "turn-1", namespace: null };
 
 const CODEX_DYNAMIC_TOOL_TIMEOUT_MS = 90_000;
@@ -81,6 +91,36 @@ describe("dynamic tool execution helpers", () => {
         config: undefined,
       }),
     ).toBe(timeoutMs);
+  });
+
+  it("gives a plugin-declared human-approval tool the human budget instead of the default", () => {
+    // `exec` is declared human-approval-gated (600s) via the mocked accessor; a
+    // call blocked on a human scan gets that budget instead of the 90s default.
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: { ...dynamicCallContext, callId: "hw-1", tool: "exec", arguments: {} },
+        config: undefined,
+      }),
+    ).toBe(CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS);
+    // A tool no plugin declared keeps the default per-call deadline.
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: { ...dynamicCallContext, callId: "hw-2", tool: "ungated_tool", arguments: {} },
+        config: undefined,
+      }),
+    ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
+    // An explicit per-call timeout still wins over the human budget.
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          ...dynamicCallContext,
+          callId: "hw-3",
+          tool: "exec",
+          arguments: { timeoutMs: 5_000 },
+        },
+        config: undefined,
+      }),
+    ).toBe(5_000);
   });
 
   it("uses configured image generation timeouts for Codex dynamic tool calls", () => {

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -6,6 +6,7 @@ import {
   embeddedAgentLog,
   formatToolExecutionErrorMessage,
   normalizeQuestionTimeoutSeconds,
+  resolveHumanApprovalToolTimeoutMs,
   resolveToolExecutionErrorKind,
   type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
@@ -554,6 +555,12 @@ export function resolveDynamicToolCallTimeoutMs(params: {
   return clampDynamicToolTimeoutMs(
     readDynamicToolCallTimeoutMs(params.call.arguments) ??
       readConfiguredDynamicToolTimeoutMs(params.call.tool, params.config) ??
+      // A tool a plugin declared human-approval-gated may legitimately block on
+      // a person for far longer than the default per-call deadline. Give it the
+      // declared human budget (clamped to the codex max) instead of killing the
+      // call at 90s and forcing the harness to retry — mirrors how ask_user is
+      // exempt, but driven by the plugin's declaration rather than a tool name.
+      resolveHumanApprovalToolTimeoutMs(params.call.tool) ??
       CODEX_DYNAMIC_TOOL_TIMEOUT_MS,
   );
 }

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -349,7 +349,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: explicit native page history and query preservation options.
       // +4: observed session query, result, snapshot, and subscription contracts.
       // +2: browser-safe Date timestamp validation and UTF-16 truncation primitives.
-      4428,
+      // +1: human-approval tool timeout accessor so harness watchdogs allow human waits.
+      4429,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -470,7 +471,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: final callable-tool availability projection for native harnesses.
       // +4: defineFeatureContract, createFeatureClient, defineFeaturePlugin, defineControlUiPlugin.
       // +2: browser-safe Date timestamp validation and UTF-16 truncation primitives.
-      2616,
+      // +1: human-approval tool timeout accessor so harness watchdogs allow human waits.
+      2617,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -122,6 +122,7 @@ export const agentHarnessAttemptTerminal = {
 export { projectAgentHarnessTranscriptMessageForDisplay } from "../agents/harness/transcript-visibility.js";
 export { restorePreparedUserTurnOperationalMetaForRuntime } from "../sessions/user-turn-transcript.metadata.js";
 export { fingerprintResolvedAuthProfileCredential } from "../agents/execution-auth-binding.js";
+export { resolveHumanApprovalToolTimeoutMs } from "../plugins/runtime.js";
 export type {
   AgentHarnessUserInputAnswers,
   AgentHarnessUserInputOption,

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -22,6 +22,7 @@ type BuildPluginApiParams = {
 
 const noops = {
   registerTool: () => {},
+  declareHumanApprovalTools: () => {},
   registerHook: () => {},
   registerHttpRoute: () => {},
   registerHostedMediaResolver: () => {},
@@ -138,6 +139,8 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     runtime: params.runtime,
     logger: params.logger,
     registerTool: handlers.registerTool ?? noops.registerTool,
+    declareHumanApprovalTools:
+      handlers.declareHumanApprovalTools ?? noops.declareHumanApprovalTools,
     registerHook: handlers.registerHook ?? noops.registerHook,
     registerHttpRoute: handlers.registerHttpRoute ?? noops.registerHttpRoute,
     registerHostedMediaResolver:

--- a/src/plugins/plugin-api.types.ts
+++ b/src/plugins/plugin-api.types.ts
@@ -209,6 +209,15 @@ export type OpenClawPluginApi = {
     tool: AnyAgentTool | OpenClawPluginToolFactory,
     opts?: OpenClawPluginToolOptions,
   ) => void;
+  /**
+   * Declare that the named tools may block on a human approval this plugin
+   * gates, so agent-harness per-tool-call watchdogs allow up to `timeoutMs`
+   * for those calls instead of killing them at the default deadline. The
+   * plugin owns this declaration (typically driven by its own config); the
+   * host only aggregates it. `timeoutMs` is the plugin's expected human wait
+   * and is clamped by each harness to its own maximum.
+   */
+  declareHumanApprovalTools: (declaration: { tools: readonly string[]; timeoutMs: number }) => void;
   registerHook: (
     events: string | string[],
     handler: InternalHookHandler,

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -181,6 +181,29 @@ export function createPluginApiFactory(
         ...(registrationCapabilities.capabilityHandlers
           ? {
               registerTool: (tool, opts) => registerTool(record, tool, opts),
+              declareHumanApprovalTools: (declaration) => {
+                // Record which tools this plugin gates behind a human approval,
+                // and the longest wait it expects, so harness watchdogs give
+                // those calls the human budget instead of the default per-call
+                // deadline. Like registerTool this writes into the current
+                // registry generation only; a discovery/retired generation
+                // writes to its own registry, which is never the active one a
+                // harness reads, so no per-call guard is needed here.
+                const timeoutMs = Math.floor(declaration.timeoutMs);
+                if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+                  return;
+                }
+                for (const tool of declaration.tools) {
+                  const name = tool.trim();
+                  if (!name) {
+                    continue;
+                  }
+                  const existing = registry.humanApprovalToolTimeouts.get(name) ?? 0;
+                  if (timeoutMs > existing) {
+                    registry.humanApprovalToolTimeouts.set(name, timeoutMs);
+                  }
+                }
+              },
               registerHook: (events, handler, opts) =>
                 registerHook(record, events, handler, opts, params.config, params.pluginConfig),
               registerHttpRoute: (routeParams) => registerHttpRoute(record, routeParams),

--- a/src/plugins/registry-empty.ts
+++ b/src/plugins/registry-empty.ts
@@ -6,6 +6,7 @@ export function createEmptyPluginRegistry(): PluginRegistry {
     plugins: [],
     tools: [],
     hooks: [],
+    humanApprovalToolTimeouts: new Map(),
     typedHooks: [],
     channels: [],
     channelSetups: [],

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -531,6 +531,12 @@ export type PluginRegistry = {
   plugins: PluginRecord[];
   tools: PluginToolRegistration[];
   hooks: PluginHookRegistration[];
+  // Tools a plugin declared may block on a human approval, mapped to the
+  // longest declared wait budget (ms). Agent harnesses consult this so a
+  // per-tool-call watchdog does not kill a call that is legitimately waiting
+  // on a human, instead of hardcoding tool names. Keyed by tool name; the max
+  // across declaring plugins wins.
+  humanApprovalToolTimeouts: Map<string, number>;
   typedHooks: TypedPluginHookRegistration[];
   channels: PluginChannelRegistration[];
   channelSetups: PluginChannelSetupRegistration[];

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -56,6 +56,40 @@ describe("plugin registry runtime config scope", () => {
     );
   });
 
+  it("aggregates human-approval tool declarations at the longest declared budget", () => {
+    const pluginRegistry = createTestRegistry(createPluginRuntime());
+    const recordA = createPluginRecord({
+      id: "gater-a",
+      source: "/plugins/gater-a/index.js",
+      origin: "global",
+      enabled: true,
+      configSchema: false,
+    });
+    pluginRegistry
+      .createApi(recordA, { config: {} as OpenClawConfig })
+      .declareHumanApprovalTools({ tools: ["exec", "shell"], timeoutMs: 120_000 });
+
+    const recordB = createPluginRecord({
+      id: "gater-b",
+      source: "/plugins/gater-b/index.js",
+      origin: "global",
+      enabled: true,
+      configSchema: false,
+    });
+    const apiB = pluginRegistry.createApi(recordB, { config: {} as OpenClawConfig });
+    apiB.declareHumanApprovalTools({ tools: ["exec"], timeoutMs: 600_000 });
+    apiB.declareHumanApprovalTools({ tools: [" "], timeoutMs: 600_000 });
+    apiB.declareHumanApprovalTools({ tools: ["deploy"], timeoutMs: 0 });
+
+    const map = pluginRegistry.registry.humanApprovalToolTimeouts;
+    // Longest budget across declaring plugins wins for a shared tool.
+    expect(map.get("exec")).toBe(600_000);
+    expect(map.get("shell")).toBe(120_000);
+    // Blank tool names and non-positive budgets are ignored.
+    expect(map.has("deploy")).toBe(false);
+    expect(map.has(" ")).toBe(false);
+  });
+
   it.each([
     {
       label: "bundled",

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -260,6 +260,16 @@ export function getActivePluginRegistry(): PluginRegistry | null {
   return asPluginRegistry(state.activeRegistry);
 }
 
+/**
+ * The longest human-approval wait (ms) any active plugin declared for `toolName`
+ * via `declareHumanApprovalTools`, or undefined when none did. Agent harnesses
+ * consult this so a per-tool-call watchdog gives an approval-blocked tool the
+ * human budget instead of its default deadline, without hardcoding tool names.
+ */
+export function resolveHumanApprovalToolTimeoutMs(toolName: string): number | undefined {
+  return getActivePluginRegistry()?.humanApprovalToolTimeouts.get(toolName);
+}
+
 export function getActivePluginRegistryWorkspaceDir(): string | undefined {
   return state.workspaceDir ?? undefined;
 }


### PR DESCRIPTION
## What Problem This Solves

A tool that blocks in a `before_tool_call` hook waiting for a **human approval**
(e.g. a World ID / operator verification) can legitimately take minutes. Under
the **codex** harness, such a dynamic-tool call is killed by the per-call
watchdog (`CODEX_DYNAMIC_TOOL_TIMEOUT_MS = 90s`) and the agent then retries the
tool — spawning duplicate approval prompts and a confusing, unusable HITL
experience. codex already exempts `ask_user`/`secrets` by **hardcoded tool
name**, which doesn't work for a pluggable approval system where any plugin can
gate any tool.

## Why This Change Was Made

Generalize the human-wait exemption from hardcoded names to a **plugin-owned,
contract-driven declaration**, so the host/harnesses never need editing when a
new plugin gates a new tool.

- New generic seam: `api.declareHumanApprovalTools({ tools, timeoutMs })` — a
  plugin declares which of its tools may block on a human approval and the
  longest wait it expects (typically from its own config; the host never reads
  plugin config directly).
- The registry aggregates declarations (longest budget per tool);
  `resolveHumanApprovalToolTimeoutMs(tool)` exposes the rollup to harnesses.
- codex's `resolveDynamicToolCallTimeoutMs` consults it: a declared tool gets
  the human budget (clamped to the codex max), otherwise the default. An
  explicit per-call `timeoutMs` still wins; undeclared tools are unchanged.

Harness generality: the built-in `openclaw` and `copilot` harnesses impose no
per-tool-call watchdog, so they need no change and already wait up to the core
approval budget; the signal is available for any future watchdog.

## User Impact

- HITL-gated tools under codex are no longer killed mid-scan and retried, so no
  duplicate approval prompts — the human simply completes the approval.
- Fully pluggable: any plugin opts in by declaring its tools; no core/codex/host
  edits. Fully customizable: the budget is the plugin's own configured value.
- Fail-closed preserved: this aligns the watchdog with the approval budget; a
  human who never responds within that budget still times out.

## Evidence

- Verified against `../codex`: the app-server awaits the `DynamicToolCall`
  response with **no per-call execution deadline** (only a 1s cancellation-
  propagation test and unrelated infra timeouts; MCP `tool_timeout_sec` applies
  only to MCP servers), so extending OpenClaw's wrapper budget is sufficient.
- Unit tests: registry aggregation (longest budget wins, blank/non-positive
  ignored) in `registry.runtime-config.test.ts`; codex resolver precedence
  (declared tool → human budget; undeclared → default; explicit arg wins) in
  `dynamic-tool-execution.test.ts`. `pnpm build` green; SDK surface budget
  updated (+1 accessor); `$autoreview` scoped-clean (0.98).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
