### PR TITLE
fix(memory): keep recall tools visible and clear stale disabled status

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -1740,6 +1740,72 @@ describe("active-memory plugin", () => {
     expect(hasDebugLine("active-memory: recall skipped reason=no-recall-intent")).toBe(true);
   });
 
+  it.each([
+    { mode: "escalate", reason: "no-recall-intent", hasStrongHit: false },
+    { mode: "off", reason: "mode-off", hasStrongHit: false },
+    { mode: "escalate", reason: "strong-lane-one-hit", hasStrongHit: true },
+  ])("clears denied-turn status when the next turn skips recall for $reason", async (testCase) => {
+    registerPluginConfig({ mode: testCase.mode });
+    const sessionKey = "agent:main:telegram:direct:owner";
+    const otherPluginEntry = { pluginId: "other-plugin", lines: ["Other plugin status"] };
+    seedSession(sessionKey, "status-transition", 25);
+    expectDefined(hoisted.sessionStore[sessionKey], "seeded status session").pluginDebugEntries = [
+      otherPluginEntry,
+    ];
+    const context = { sessionKey, messageProvider: "telegram", channelId: "owner" };
+    const event = { prompt: "Help when booking a flight" };
+
+    const denied = await runPromptBuild(event, {
+      ...context,
+      toolAuthority: {
+        fingerprint: "denied-memory-authority",
+        allows: () => false,
+        assertActive: () => undefined,
+      },
+    });
+
+    expect(denied).toBeUndefined();
+    expectLinesToContain(getActiveMemoryLines(sessionKey), "status=policy-disabled");
+    expect(hoisted.getActiveMemorySearchManager).not.toHaveBeenCalled();
+    if (testCase.hasStrongHit) {
+      hoisted.getActiveMemorySearchManager.mockResolvedValueOnce({
+        manager: {
+          search: vi.fn(async () => []),
+          listTriggerCandidates: vi.fn(async () => [
+            {
+              path: "MEMORY.md",
+              startLine: 1,
+              endLine: 1,
+              score: 1,
+              snippet: "Prefer aisle seats.",
+              source: "memory" as const,
+              provenance: {
+                originClass: "agent" as const,
+                sessionKind: "interactive" as const,
+                observedAt: 1,
+              },
+              triggers: "booking a flight",
+            },
+          ]),
+        },
+      } as never);
+    }
+
+    const allowed = await runPromptBuild(event, context);
+
+    if (testCase.hasStrongHit) {
+      expectPrependContextContains(allowed, "Prefer aisle seats.");
+    } else if (testCase.reason === "no-recall-intent") {
+      expectPrependContextContains(allowed, skippedRecallContext);
+    } else {
+      expect(allowed).toBeUndefined();
+    }
+    expect(hasDebugLine(`active-memory: recall skipped reason=${testCase.reason}`)).toBe(true);
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+    expect(hoisted.sessionStore[sessionKey]?.pluginDebugEntries).toEqual([otherPluginEntry]);
+    expect(hoisted.sessionStore[sessionKey]?.updatedAt).toBe(25);
+  });
+
   it("does not run deep recall when the live active-memory plugin entry is removed", async () => {
     configFile = {
       plugins: {
@@ -4755,6 +4821,20 @@ describe("active-memory plugin", () => {
 
   it("fails open at the live deadline when pre-recall session state stalls", async () => {
     vi.useFakeTimers();
+    const sessionKey = "agent:main:stalled-toggle";
+    seedSession(sessionKey, "stalled-toggle", 25);
+    await runPromptBuild(
+      { prompt: "what did we decide?" },
+      {
+        sessionKey,
+        toolAuthority: {
+          fingerprint: "denied-memory-authority",
+          allows: () => false,
+          assertActive: () => undefined,
+        },
+      },
+    );
+    expectLinesToContain(getActiveMemoryLines(sessionKey), "status=policy-disabled");
     testing.setMinimumTimeoutMsForTests(1);
     testing.setSetupGraceTimeoutMsForTests(0);
     api.pluginConfig = {
@@ -4773,9 +4853,7 @@ describe("active-memory plugin", () => {
 
     const resultPromise = runPromptBuild(
       { prompt: "what food do i usually order? stalled toggle lookup" },
-      {
-        sessionKey: "agent:main:stalled-toggle",
-      },
+      { sessionKey },
     );
     await vi.advanceTimersByTimeAsync(1_525);
 
@@ -4785,6 +4863,8 @@ describe("active-memory plugin", () => {
       .mocked(api.logger.warn)
       .mock.calls.map((call: unknown[]) => String(call[0]));
     expectLinesToContain(warnLines, "before_prompt_build preflight timed out after 1500ms");
+    expect(getActiveMemoryLines(sessionKey)).toEqual([]);
+    expect(hoisted.sessionStore[sessionKey]?.updatedAt).toBe(25);
     resolveLookup?.(undefined);
     await vi.advanceTimersByTimeAsync(0);
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
@@ -5199,11 +5279,23 @@ describe("active-memory plugin", () => {
   });
 
   it("returns undefined instead of throwing when an unexpected error escapes prompt building", async () => {
+    const sessionKey = "agent:main:escape-test";
+    seedSession(sessionKey, "escape-test", 25);
+    await runPromptBuild(
+      { prompt: "what did we decide?" },
+      {
+        sessionKey,
+        toolAuthority: {
+          fingerprint: "denied-memory-authority",
+          allows: () => false,
+          assertActive: () => undefined,
+        },
+      },
+    );
+    expectLinesToContain(getActiveMemoryLines(sessionKey), "status=policy-disabled");
     const result = await runPromptBuild(
       { prompt: "what should i eat? escape test", messages: undefined as never },
-      {
-        sessionKey: "agent:main:escape-test",
-      },
+      { sessionKey },
     );
 
     expect(result).toBeUndefined();
@@ -5211,6 +5303,8 @@ describe("active-memory plugin", () => {
       .mocked(api.logger.warn)
       .mock.calls.map((call: unknown[]) => String(call[0]));
     expectLinesToContain(warnLines, "before_prompt_build");
+    expect(getActiveMemoryLines(sessionKey)).toEqual([]);
+    expect(hoisted.sessionStore[sessionKey]?.updatedAt).toBe(25);
   });
 
   it("honors configured timeoutMs values above the former 60 000 ms ceiling", async () => {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -291,6 +291,14 @@ export default definePluginEntry({
               toolAuthority.assertActive();
               return undefined;
             }
+            // Status belongs to this turn. Clear it before awaited preflight work,
+            // which may time out without producing a replacement status.
+            await persistPluginStatusLines({
+              api,
+              agentId: effectiveAgentId,
+              sessionKey: resolvedSessionKey,
+            });
+            toolAuthority.assertActive();
             if (
               shouldSkipActiveMemoryForHarnessSession({
                 api,
@@ -307,11 +315,6 @@ export default definePluginEntry({
             deadlineController.signal.throwIfAborted();
             toolAuthority.assertActive();
             if (sessionDisabled) {
-              await persistPluginStatusLines({
-                api,
-                agentId: effectiveAgentId,
-                sessionKey: resolvedSessionKey,
-              });
               return undefined;
             }
             const sessionContext = {
@@ -319,11 +322,6 @@ export default definePluginEntry({
               sessionKey: resolvedSessionKey ?? ctx.sessionKey,
             };
             if (!isEligibleInteractiveSession(sessionContext)) {
-              await persistPluginStatusLines({
-                api,
-                agentId: effectiveAgentId,
-                sessionKey: resolvedSessionKey,
-              });
               return undefined;
             }
             const destinationContext = {
@@ -416,11 +414,6 @@ export default definePluginEntry({
               );
             }
             if (!activeMemoryAllowed && !productRecallAllowed) {
-              await persistPluginStatusLines({
-                api,
-                agentId: effectiveAgentId,
-                sessionKey: resolvedSessionKey,
-              });
               return laneOneContext ? { prependContext: laneOneContext } : undefined;
             }
             const escalationDecision = resolveRecallEscalationDecision({

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -102,10 +102,10 @@ function captureMemoryModelContract(initialConfig: OpenClawConfig) {
     getRuntimeConfig: () => initialConfig,
   };
   const search = factories.get("memory_search")?.(context) as
-    | { description: string; parameters: unknown }
+    | { description: string; parameters: unknown; catalogMode?: string }
     | undefined;
   const get = factories.get("memory_get")?.(context) as
-    | { description: string; parameters: unknown }
+    | { description: string; parameters: unknown; catalogMode?: string }
     | undefined;
   if (!search || !get || !promptBuilder) {
     throw new Error("expected memory model contract");
@@ -204,6 +204,10 @@ describe("buildPromptSection", () => {
       })
       .join("\n");
 
+    expect(lazy.search.catalogMode).toBe("direct-only");
+    expect(lazy.get.catalogMode).toBe("direct-only");
+    expect(eagerSearch.catalogMode).toBe("direct-only");
+    expect(eagerGet.catalogMode).toBe("direct-only");
     expect(lazy.search.parameters).toStrictEqual(eagerSearch.parameters);
     expect(lazy.get.parameters).toStrictEqual(eagerGet.parameters);
     expect(lazy.search.description).toBe(eagerSearch.description);

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -63,6 +63,9 @@ function createLazyMemoryTool(params: {
   return {
     label: params.contract.label,
     name: params.contract.name,
+    // Keep the deterministic recall tools model-visible under Tool Search catalog
+    // compaction; Active Memory disables itself when they are not on the direct surface.
+    catalogMode: "direct-only",
     description: params.contract.describe(initialContext.sources),
     parameters: params.contract.parameters,
     execute: async (toolCallId, toolParams, signal, onUpdate) => {

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -73,6 +73,7 @@ export function createMemoryTool(params: {
   return {
     label: params.contract.label,
     name: params.contract.name,
+    catalogMode: "direct-only",
     description: params.contract.describe(ctx.sources),
     parameters: params.contract.parameters,
     execute: async (toolCallId, toolParams, signal, onUpdate) => {

--- a/src/plugins/tool-descriptor-cache.test.ts
+++ b/src/plugins/tool-descriptor-cache.test.ts
@@ -143,11 +143,13 @@ describe("plugin tool descriptor cache keys", () => {
         outputSchema,
         requiredClientCaps: ["inline-widgets"],
         resultContentSource: "network",
+        catalogMode: "direct-only",
         execute: async () => ({ content: [], details: {} }),
       },
     });
 
     expect(cached.requiredClientCaps).toEqual(["inline-widgets"]);
+    expect(cached).toHaveProperty("catalogMode", "direct-only");
     expect(cached.descriptor.outputSchema).toBe(outputSchema);
     expect(cached).toHaveProperty("resultContentSource", "network");
   });
@@ -166,6 +168,7 @@ describe("plugin tool descriptor cache keys", () => {
     });
 
     expect(cached).not.toHaveProperty("resultContentSource");
+    expect(cached).not.toHaveProperty("catalogMode");
   });
 
   it("isolates descriptor caches by declared gateway client capabilities", () => {

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -18,6 +18,7 @@ export type CachedPluginToolDescriptor = {
   hideFromChannelProgress?: AnyAgentTool["hideFromChannelProgress"];
   requiredClientCaps?: string[];
   resultContentSource?: AnyAgentTool["resultContentSource"];
+  catalogMode?: AnyAgentTool["catalogMode"];
   optional: boolean;
 };
 
@@ -167,6 +168,7 @@ export function capturePluginToolDescriptor(params: {
     ...(params.tool.resultContentSource
       ? { resultContentSource: params.tool.resultContentSource }
       : {}),
+    ...(params.tool.catalogMode ? { catalogMode: params.tool.catalogMode } : {}),
     optional: params.optional,
     descriptor: {
       name: params.tool.name,

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -2429,6 +2429,7 @@ describe("resolvePluginTools optional tools", () => {
         ...makeTool("cached_tool"),
         displaySummary: "Cached tool summary",
         hideFromChannelProgress,
+        catalogMode: "direct-only" as const,
         outputSchema,
         async execute() {
           return { content: [{ type: "text", text: ctx.sessionId ?? "missing" }] };
@@ -2463,6 +2464,8 @@ describe("resolvePluginTools optional tools", () => {
     expect(second[0]).not.toBe(first[0]);
     expect(first[0]?.outputSchema).toBe(outputSchema);
     expect(second[0]?.outputSchema).toBe(outputSchema);
+    expect(first[0]?.catalogMode).toBe("direct-only");
+    expect(second[0]?.catalogMode).toBe("direct-only");
     expect(first[0]?.hideFromChannelProgress).toBe(true);
     expect(second[0]?.hideFromChannelProgress).toBe(true);
     expect(second[0]?.displaySummary).toBe("Cached tool summary");
@@ -2534,6 +2537,8 @@ describe("resolvePluginTools optional tools", () => {
 
     expect(fresh).not.toHaveProperty("resultContentSource");
     expect(cached).not.toHaveProperty("resultContentSource");
+    expect(fresh).not.toHaveProperty("catalogMode");
+    expect(cached).not.toHaveProperty("catalogMode");
     expect(fresh).not.toHaveProperty("hideFromChannelProgress");
     expect(cached).not.toHaveProperty("hideFromChannelProgress");
     expect(cached).not.toBe(fresh);

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -757,6 +757,7 @@ function createCachedDescriptorPluginTool(params: {
     ...(params.descriptor.resultContentSource
       ? { resultContentSource: params.descriptor.resultContentSource }
       : {}),
+    ...(params.descriptor.catalogMode ? { catalogMode: params.descriptor.catalogMode } : {}),
     prepareArguments(args) {
       const currentTool = requireRuntimeTool();
       return currentTool.prepareArguments ? currentTool.prepareArguments(args) : args;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users enabling Tool Search would lose the direct memory
recall tools, and where Active Memory could continue showing `status=policy-disabled`
on subsequent allowed turns even after the tool-visibility problem was corrected.
The stale footer also survived allowed preflight failures/timeouts; it was not
evidence that every later turn was still denied.

## Why This Change Was Made

Keep the two memory-core recall tools direct-only in both construction paths and
preserve plugin-authored catalog mode through descriptor caching. Clear Active
Memory's previous status immediately after the current turn passes tool authority,
before awaited preflight or early exits; denied turns still record their own
status, other plugins' status remains intact, and activity timestamps are preserved.
There is no privacy-policy bypass or session-cache/flush workaround.

## User Impact

Memory recall tools remain directly available with Tool Search enabled. Active
Memory's footer no longer carries an earlier denial into an allowed skipped or
failed turn. Clearing an old footer is deliberately not presented as proof that
recall succeeded on that turn.

## Evidence

- Active Memory: 429 tests pass, including denied-to-allowed no-intent, mode-off,
  strong-trigger, escaped-error and stalled-preflight regressions. The new
  transition cases failed before the respective fixes.
- Memory-core lazy/eager builders, plugin descriptor cache and optional plugin
  tools: 179 tests pass across four owner suites.
- Cached-descriptor reconstruction is explicitly covered as well as capture:
  direct-only survives both fresh and cached resolution, while ordinary
  descriptors omit the field. Removing only the production reconstruction spread
  makes the cached assertion fail; production was restored byte-for-byte.
- Complete changed-file gate passes for all nine PR paths: production/test types,
  lint, formatting, doctor contracts, dependency/plugin boundaries, dead exports,
  storage/runtime/security guards. No selected stages were skipped.
- Fresh independent Auto Review: no actionable P0-P2 findings. Its earlier
  cache-reconstruction test-coverage finding was addressed and re-reviewed.
- A real SQLite session-store probe verified deletion of the Active Memory status
  across database reopen while preserving another plugin's entry and activity.
- Live installed-equivalent repair on OpenClaw 2026.9.1: Tool Search directory
  mode was enabled and both memory tools appeared in the authorized direct set.
  A no-delivery run against the affected DM began with persisted
  `policy-disabled`, ended with it cleared, and the actual footer renderer logged
  no Active Memory status on the same reply. The cold preflight timed out; this
  proves stale-status recovery, not successful automatic recall.
- A later terminal-origin recall request completed but private tool execution was
  denied because the host did not prove owner authority. That boundary was not
  weakened. An authenticated Telegram-owner recall message remains the final
  end-to-end acceptance check; this PR stays draft until that is observed.
- The dedicated Telegram Test Server userbot harness was not run: the required
  authenticated Convex broker CLI is unavailable on this contributor host.

The earlier suggestion that a separate third tool-name list caused the continuing
footer was not substantiated. The owning SQLite entry retained the old status;
`sessions.list` omitted that field and was not a valid read of its contents.
Local logging/Astra configuration repairs are not included in this source PR.
