### PR TITLE
fix: preserve tasks following text directives

### DIFF
--- a/qa/scenarios/channels/telegram-queue-invalid-mode.yaml
+++ b/qa/scenarios/channels/telegram-queue-invalid-mode.yaml
@@ -19,7 +19,7 @@ scenario:
   codeRefs:
     - extensions/telegram/src/bot-native-commands.ts
     - src/auto-reply/reply/get-reply-directives.ts
-    - src/auto-reply/reply/directive-handling.native.ts
+    - src/auto-reply/reply/directive-handling.arguments.ts
     - src/auto-reply/reply/directive-handling.queue-validation.ts
   execution:
     kind: flow

--- a/src/auto-reply/commands-registry-normalize.ts
+++ b/src/auto-reply/commands-registry-normalize.ts
@@ -85,22 +85,25 @@ function getCommandRegistryLookup(): CommandRegistryLookup {
 
 /** Normalizes command text to canonical aliases, removing bot mentions when appropriate. */
 export function normalizeCommandBody(raw: string, options?: CommandNormalizeOptions): string {
-  const trimmed = raw.trim();
+  const trimmed = options?.preserveArguments ? raw.trimStart() : raw.trim();
   if (!trimmed.startsWith("/")) {
     return trimmed;
   }
 
-  const newline = trimmed.indexOf("\n");
+  const newline = options?.preserveArguments ? -1 : trimmed.indexOf("\n");
   const singleLine = newline === -1 ? trimmed : trimmed.slice(0, newline).trim();
   const multilineTail = newline === -1 ? undefined : trimmed.slice(newline + 1).trimStart();
 
   // `/cmd: value` is accepted as `/cmd value` because some channels insert colon syntax.
-  const colonMatch = singleLine.match(/^\/([^\s:]+)\s*:(.*)$/);
+  const colonMatch = singleLine.match(/^\/([^\s:]+)\s*:([\s\S]*)$/);
   const normalized = colonMatch
     ? (() => {
         const [, command, rest] = colonMatch;
-        const normalizedRest = expectDefined(rest, "commands registry normalize rest").trimStart();
-        return normalizedRest ? `/${command} ${normalizedRest}` : `/${command}`;
+        const commandRest = expectDefined(rest, "commands registry normalize rest");
+        const normalizedRest = options?.preserveArguments ? commandRest : commandRest.trimStart();
+        return normalizedRest
+          ? `/${command}${/^\s/.test(normalizedRest) ? "" : " "}${normalizedRest}`
+          : `/${command}`;
       })()
     : singleLine;
 
@@ -137,9 +140,11 @@ export function normalizeCommandBody(raw: string, options?: CommandNormalizeOpti
     return commandBody;
   }
   const normalizedRest = rest?.trimStart();
-  const normalizedHead = normalizedRest
-    ? `${tokenSpec.canonical} ${normalizedRest}`
-    : tokenSpec.canonical;
+  const normalizedHead = options?.preserveArguments
+    ? `${tokenSpec.canonical}${commandBody.slice(tokenKey.length)}`
+    : normalizedRest
+      ? `${tokenSpec.canonical} ${normalizedRest}`
+      : tokenSpec.canonical;
   return appendMultilineTail(normalizedHead, multilineTail, tokenSpec);
 }
 

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -99,6 +99,8 @@ export type NativeCommandSpec = {
 /** Extra context used when normalizing slash command text. */
 export type CommandNormalizeOptions = {
   botUsername?: string;
+  /** Keeps complete directive/task arguments, including whitespace and later lines. */
+  preserveArguments?: boolean;
   /** Strip an explicit command target only while channel bot identity is unavailable. */
   targetedCommandMode?: "pre-identity";
 };

--- a/src/auto-reply/reply.directive.parse.test.ts
+++ b/src/auto-reply/reply.directive.parse.test.ts
@@ -314,27 +314,27 @@ describe("directive parsing", () => {
 
   it("preserves the trailing /model --session scope for native slash commands", () => {
     const model = parseInlineSessionDirectives("/model openai/gpt-4.1-mini --session", {
-      nativeCommand: "model",
+      command: { kind: "native", name: "model" },
     });
 
     expect(model.cleaned).toBe("");
     expect(model.rawModelDirective).toBe("openai/gpt-4.1-mini");
     expect(model.modelScope).toBe("session");
-    expect(model.nativeCommand).toEqual({ name: "model" });
+    expect(model.command).toEqual({ name: "model" });
   });
 
   it.each(["--runtime codex -s", "-s --runtime codex", "runtime=codex -s", "-s harness=codex"])(
     "parses /model runtime and session options from %s",
     (options) => {
       const model = parseInlineSessionDirectives(`/model openai/gpt-4.1-mini ${options}`, {
-        nativeCommand: "model",
+        command: { kind: "native", name: "model" },
       });
 
       expect(model.cleaned).toBe("");
       expect(model.rawModelDirective).toBe("openai/gpt-4.1-mini");
       expect(model.rawModelRuntime).toBe("codex");
       expect(model.modelScope).toBe("session");
-      expect(model.nativeCommand).toEqual({ name: "model" });
+      expect(model.command).toEqual({ name: "model" });
     },
   );
 
@@ -353,13 +353,13 @@ describe("directive parsing", () => {
   it("rejects duplicate native /model options through unconsumed arguments", () => {
     const model = parseInlineSessionDirectives(
       "/model openai/gpt-4.1-mini --runtime codex --runtime acp",
-      { nativeCommand: "model" },
+      { command: { kind: "native", name: "model" } },
     );
 
     expect(model.rawModelDirective).toBe("openai/gpt-4.1-mini");
     expect(model.rawModelRuntime).toBe("codex");
     expect(model.cleaned).toBe("--runtime acp");
-    expect(model.nativeCommand).toEqual({
+    expect(model.command).toEqual({
       name: "model",
       unconsumedArguments: "--runtime acp",
     });
@@ -386,7 +386,7 @@ describe("directive parsing", () => {
     ["--global", "global"],
   ] as const)("preserves explicit /model %s scope", (option, scope) => {
     const model = parseInlineSessionDirectives(`/model openai/gpt-4.1-mini ${option}`, {
-      nativeCommand: "model",
+      command: { kind: "native", name: "model" },
     });
 
     expect(model.cleaned).toBe("");
@@ -576,11 +576,13 @@ describe("native directive commands own their complete argument boundary", () =>
   ])(
     "preserves the invalid first argument for native /$command",
     ({ body, command, invalidArgument, rawKey, trailingArguments }) => {
-      const parsed = parseInlineSessionDirectives(body, { nativeCommand: command });
+      const parsed = parseInlineSessionDirectives(body, {
+        command: { kind: "native", name: command },
+      });
 
       expect(parsed[rawKey]).toBe(invalidArgument);
       expect(parsed.cleaned).toBe(trailingArguments);
-      expect(parsed.nativeCommand).toEqual({
+      expect(parsed.command).toEqual({
         name: command,
         unconsumedArguments: trailingArguments,
       });
@@ -589,18 +591,20 @@ describe("native directive commands own their complete argument boundary", () =>
 
   it("retains unexpected arguments after a valid native queue mode", () => {
     const parsed = parseInlineSessionDirectives("/queue collect please help", {
-      nativeCommand: "queue",
+      command: { kind: "native", name: "queue" },
     });
 
     expect(parsed.queueMode).toBe("collect");
-    expect(parsed.nativeCommand).toEqual({
+    expect(parsed.command).toEqual({
       name: "queue",
       unconsumedArguments: "please help",
     });
   });
 
   it("does not interpret another directive inside native command arguments", () => {
-    const parsed = parseInlineSessionDirectives("/queue /think high", { nativeCommand: "queue" });
+    const parsed = parseInlineSessionDirectives("/queue /think high", {
+      command: { kind: "native", name: "queue" },
+    });
 
     expect(parsed.hasQueueDirective).toBe(true);
     expect(parsed.rawQueueMode).toBe("/think");
@@ -611,7 +615,7 @@ describe("native directive commands own their complete argument boundary", () =>
     const parsed = parseInlineSessionDirectives("/think about my deployment plan");
 
     expect(parsed.rawThinkLevel).toBeUndefined();
-    expect(parsed.nativeCommand).toBeUndefined();
+    expect(parsed.command).toBeUndefined();
     expect(parsed.cleaned).toBe("about my deployment plan");
   });
 });

--- a/src/auto-reply/reply/directive-handling.arguments.ts
+++ b/src/auto-reply/reply/directive-handling.arguments.ts
@@ -13,7 +13,8 @@ export function maybeHandleUnexpectedDirectiveArguments(
   }
 
   // One token is enough to explain the rejected boundary without echoing an unbounded prompt.
-  const unexpectedArgument = unconsumedArguments.split(/\s+/, 1)[0] ?? unconsumedArguments;
+  const unexpectedArgument =
+    unconsumedArguments.trimStart().split(/\s+/, 1)[0] ?? unconsumedArguments;
   return {
     text: `Unexpected argument "${unexpectedArgument}" for /${command.name}.`,
   };

--- a/src/auto-reply/reply/directive-handling.arguments.ts
+++ b/src/auto-reply/reply/directive-handling.arguments.ts
@@ -1,20 +1,20 @@
-/** Validates argument boundaries for explicitly invoked native session directives. */
+/** Validates argument boundaries for command-owned session directives. */
 import type { ReplyPayload } from "../types.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 
 /** Rejects prose left over after canonical command-specific validation succeeds. */
-export function maybeHandleUnexpectedNativeDirectiveArguments(
+export function maybeHandleUnexpectedDirectiveArguments(
   directives: InlineDirectives,
 ): ReplyPayload | undefined {
-  const nativeCommand = directives.nativeCommand;
-  const unconsumedArguments = nativeCommand?.unconsumedArguments;
-  if (!nativeCommand || !unconsumedArguments) {
+  const command = directives.command;
+  const unconsumedArguments = command?.unconsumedArguments;
+  if (!command || !unconsumedArguments) {
     return undefined;
   }
 
   // One token is enough to explain the rejected boundary without echoing an unbounded prompt.
   const unexpectedArgument = unconsumedArguments.split(/\s+/, 1)[0] ?? unconsumedArguments;
   return {
-    text: `Unexpected argument "${unexpectedArgument}" for /${nativeCommand.name}.`,
+    text: `Unexpected argument "${unexpectedArgument}" for /${command.name}.`,
   };
 }

--- a/src/auto-reply/reply/directive-handling.directive-only.ts
+++ b/src/auto-reply/reply/directive-handling.directive-only.ts
@@ -27,8 +27,8 @@ export function isDirectiveOnly(params: {
   ) {
     return false;
   }
-  // Native arguments belong to their command even when the inline parser leaves invalid prose.
-  if (directives.nativeCommand) {
+  // Command-owned arguments stay out of the agent prompt even when parsing leaves invalid prose.
+  if (directives.command) {
     return true;
   }
   const stripped = stripStructuralPrefixes(cleanedBody ?? "");

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -26,10 +26,10 @@ import {
   resolveSupportedThinkingLevel,
 } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
+import { maybeHandleUnexpectedDirectiveArguments } from "./directive-handling.arguments.js";
 import { applyModelRuntimeDirective } from "./directive-handling.model-runtime.js";
 import { resolveModelSelectionFromDirective } from "./directive-handling.model-selection.js";
 import { maybeHandleModelDirectiveInfo } from "./directive-handling.model.js";
-import { maybeHandleUnexpectedNativeDirectiveArguments } from "./directive-handling.native.js";
 import type { HandleDirectiveOnlyParams } from "./directive-handling.params.js";
 import { maybeHandleQueueDirective } from "./directive-handling.queue-validation.js";
 import {
@@ -370,7 +370,7 @@ export async function handleDirectiveOnly(
     if (invalidExecMessage) {
       return acknowledgeIgnoredDirective({ text: invalidExecMessage }, "hasExecDirective");
     }
-    const unexpectedExecArguments = maybeHandleUnexpectedNativeDirectiveArguments(directives);
+    const unexpectedExecArguments = maybeHandleUnexpectedDirectiveArguments(directives);
     if (unexpectedExecArguments) {
       return unexpectedExecArguments;
     }
@@ -404,9 +404,9 @@ export async function handleDirectiveOnly(
     return acknowledgeIgnoredDirective(queueAck, "hasQueueDirective");
   }
 
-  const unexpectedNativeArguments = maybeHandleUnexpectedNativeDirectiveArguments(directives);
-  if (unexpectedNativeArguments) {
-    return unexpectedNativeArguments;
+  const unexpectedArguments = maybeHandleUnexpectedDirectiveArguments(directives);
+  if (unexpectedArguments) {
+    return unexpectedArguments;
   }
 
   if (

--- a/src/auto-reply/reply/directive-handling.parse.ts
+++ b/src/auto-reply/reply/directive-handling.parse.ts
@@ -48,7 +48,7 @@ export function resolveReplyDirectiveCommand(
     : undefined;
 }
 
-type NativeDirectiveInvocation = {
+type DirectiveCommandInvocation = {
   name: ReplyDirectiveCommand;
   unconsumedArguments?: string;
 };
@@ -56,8 +56,8 @@ type NativeDirectiveInvocation = {
 /** Parsed inline directives removed from a user message before agent execution. */
 export type InlineDirectives = {
   cleaned: string;
-  /** Explicit native command ownership prevents prose-oriented inline cleanup from eating args. */
-  nativeCommand?: NativeDirectiveInvocation;
+  /** Command-owned arguments must be validated before they can become an agent task. */
+  command?: DirectiveCommandInvocation;
   hasThinkDirective: boolean;
   thinkLevel?: ThinkLevel;
   rawThinkLevel?: string;
@@ -120,10 +120,11 @@ export function parseInlineSessionDirectives(
     modelAliases?: string[];
     disableElevated?: boolean;
     allowStatusDirective?: boolean;
-    nativeCommand?: ReplyDirectiveCommand;
+    command?: { kind: "native" | "text"; name: ReplyDirectiveCommand };
   },
 ): InlineDirectives {
-  const nativeCommand = options?.nativeCommand;
+  const invocation = options?.command;
+  const nativeCommand = invocation?.kind === "native" ? invocation.name : undefined;
   let cleaned = body;
   let hasAnyDirective = false;
   const parseScopedDirective = <T extends { cleaned: string; hasDirective: boolean }>(
@@ -172,13 +173,18 @@ export function parseInlineSessionDirectives(
     }),
   );
   const queue = parseScopedDirective("queue", extractQueueDirective);
+  // Text directives may share a message with a task or each other. Only a bare
+  // /exec with unrecognized arguments needs command ownership instead of inline routing.
+  const command =
+    nativeCommand ??
+    (invocation?.name === "exec" && !exec.hasExecOptions && cleaned ? "exec" : undefined);
   // Later directives see text cleaned by earlier directives; preserve that ordering.
   return {
     cleaned,
-    ...(nativeCommand && hasAnyDirective
+    ...(command && hasAnyDirective
       ? {
-          nativeCommand: {
-            name: nativeCommand,
+          command: {
+            name: command,
             ...(cleaned ? { unconsumedArguments: cleaned } : {}),
           },
         }

--- a/src/auto-reply/reply/directive-handling.parse.ts
+++ b/src/auto-reply/reply/directive-handling.parse.ts
@@ -124,7 +124,18 @@ export function parseInlineSessionDirectives(
   },
 ): InlineDirectives {
   const invocation = options?.command;
-  const nativeCommand = invocation?.kind === "native" ? invocation.name : undefined;
+  // Inspect raw exec arguments before sibling directives can remove tokens and
+  // turn an invalid positional argument into a recognized option or state change.
+  const textExec =
+    invocation?.kind === "text" && invocation.name === "exec"
+      ? extractExecDirective(body)
+      : undefined;
+  const command =
+    invocation?.kind === "native"
+      ? invocation.name
+      : textExec?.hasDirective && !textExec.hasExecOptions && textExec.cleaned
+        ? "exec"
+        : undefined;
   let cleaned = body;
   let hasAnyDirective = false;
   const parseScopedDirective = <T extends { cleaned: string; hasDirective: boolean }>(
@@ -133,7 +144,7 @@ export function parseInlineSessionDirectives(
     enabled = true,
   ): T => {
     const parsed =
-      enabled && (!nativeCommand || nativeCommand === commandName)
+      enabled && (!command || command === commandName)
         ? extract(cleaned)
         : ({ cleaned, hasDirective: false } as T);
     cleaned = parsed.cleaned;
@@ -141,27 +152,27 @@ export function parseInlineSessionDirectives(
     return parsed;
   };
   const think = parseScopedDirective("think", (value) =>
-    extractThinkDirective(value, { strict: nativeCommand === "think" }),
+    extractThinkDirective(value, { strict: command === "think" }),
   );
   const verbose = parseScopedDirective("verbose", (value) =>
-    extractVerboseDirective(value, { strict: nativeCommand === "verbose" }),
+    extractVerboseDirective(value, { strict: command === "verbose" }),
   );
   const trace = parseScopedDirective("trace", (value) =>
-    extractTraceDirective(value, { strict: nativeCommand === "trace" }),
+    extractTraceDirective(value, { strict: command === "trace" }),
   );
   const fast = parseScopedDirective("fast", (value) =>
-    extractFastDirective(value, { strict: nativeCommand === "fast" }),
+    extractFastDirective(value, { strict: command === "fast" }),
   );
   const reasoning = parseScopedDirective("reasoning", (value) =>
-    extractReasoningDirective(value, { strict: nativeCommand === "reasoning" }),
+    extractReasoningDirective(value, { strict: command === "reasoning" }),
   );
   const elevated = parseScopedDirective(
     "elevated",
-    (value) => extractElevatedDirective(value, { strict: nativeCommand === "elevated" }),
+    (value) => extractElevatedDirective(value, { strict: command === "elevated" }),
     !options?.disableElevated,
   );
   const exec = parseScopedDirective("exec", extractExecDirective);
-  const allowStatusDirective = options?.allowStatusDirective !== false && !nativeCommand;
+  const allowStatusDirective = options?.allowStatusDirective !== false && !command;
   const { cleaned: statusCleaned, hasDirective: hasStatusDirective } = allowStatusDirective
     ? extractStatusDirective(cleaned)
     : { cleaned, hasDirective: false };
@@ -173,11 +184,6 @@ export function parseInlineSessionDirectives(
     }),
   );
   const queue = parseScopedDirective("queue", extractQueueDirective);
-  // Text directives may share a message with a task or each other. Only a bare
-  // /exec with unrecognized arguments needs command ownership instead of inline routing.
-  const command =
-    nativeCommand ??
-    (invocation?.name === "exec" && !exec.hasExecOptions && cleaned ? "exec" : undefined);
   // Later directives see text cleaned by earlier directives; preserve that ordering.
   return {
     cleaned,

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -16,10 +16,10 @@ import type { MsgContext } from "../templating.js";
 import type { ElevatedLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import type { CommandContext } from "./commands-types.js";
+import { maybeHandleUnexpectedDirectiveArguments } from "./directive-handling.arguments.js";
 import { isDirectiveOnly } from "./directive-handling.directive-only.js";
 import { resolveModelRuntimeDirective } from "./directive-handling.model-runtime.js";
 import { resolveModelSelectionFromDirective } from "./directive-handling.model-selection.js";
-import { maybeHandleUnexpectedNativeDirectiveArguments } from "./directive-handling.native.js";
 import type { HandleDirectiveOnlyParams } from "./directive-handling.params.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import { formatModelSelectionScopeAck } from "./directive-handling.shared.js";
@@ -337,11 +337,11 @@ export async function applyInlineDirectiveOverrides(params: {
   }
 
   // Model-only directives have a focused persistence service; reject leftovers before that mutation.
-  if (directives.nativeCommand?.name === "model") {
-    const unexpectedNativeArguments = maybeHandleUnexpectedNativeDirectiveArguments(directives);
-    if (unexpectedNativeArguments) {
+  if (directives.command?.name === "model") {
+    const unexpectedArguments = maybeHandleUnexpectedDirectiveArguments(directives);
+    if (unexpectedArguments) {
       typing.cleanup();
-      return { kind: "reply", reply: unexpectedNativeArguments };
+      return { kind: "reply", reply: unexpectedArguments };
     }
   }
 

--- a/src/auto-reply/reply/get-reply-directives-routing.ts
+++ b/src/auto-reply/reply/get-reply-directives-routing.ts
@@ -7,9 +7,7 @@ import { HISTORY_CONTEXT_MARKER } from "./history.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import { stripInlineStatus } from "./reply-inline.js";
 
-type NativeDirectiveCommand = NonNullable<
-  Parameters<typeof parseInlineSessionDirectives>[1]
->["nativeCommand"];
+type DirectiveCommand = NonNullable<Parameters<typeof parseInlineSessionDirectives>[1]>["command"];
 
 function hasInlineDirective(directives: InlineDirectives): boolean {
   return (
@@ -55,7 +53,7 @@ export function resolveReplyDirectiveRouting(params: {
   commandText: string;
   agentText: string;
   modelAliases: string[];
-  nativeCommand?: NativeDirectiveCommand;
+  command?: DirectiveCommand;
   canInterpretTextDirectives: boolean;
   isAuthorizedSender: boolean;
   isGroup: boolean;
@@ -74,7 +72,7 @@ export function resolveReplyDirectiveRouting(params: {
   let parsed = parseInlineSessionDirectives(params.commandText, {
     modelAliases: params.modelAliases,
     allowStatusDirective,
-    nativeCommand: params.nativeCommand,
+    command: params.command,
   });
   const hasInlineStatus = parsed.hasStatusDirective && parsed.cleaned.trim().length > 0;
   if (hasInlineStatus) {
@@ -102,7 +100,7 @@ export function resolveReplyDirectiveRouting(params: {
     parsed = clearExecInlineDirectives(parsed);
   }
 
-  if (params.canInterpretTextDirectives && hasInlineDirective(parsed) && !parsed.nativeCommand) {
+  if (params.canInterpretTextDirectives && hasInlineDirective(parsed) && !parsed.command) {
     const stripped = stripStructuralPrefixes(parsed.cleaned);
     const noMentions = params.isGroup
       ? stripMentions(stripped, params.ctx, params.cfg, params.agentId)
@@ -132,8 +130,7 @@ export function resolveReplyDirectiveRouting(params: {
 
   const unauthorizedReasoningDirectiveAttempt =
     !params.isAuthorizedSender && parsed.hasReasoningDirective;
-  const canInterpretDirectives =
-    params.canInterpretTextDirectives || parsed.nativeCommand !== undefined;
+  const canInterpretDirectives = params.canInterpretTextDirectives || parsed.command !== undefined;
   if (!canInterpretDirectives) {
     return {
       directives: clearInlineDirectives(params.commandText),

--- a/src/auto-reply/reply/get-reply-directives-utils.ts
+++ b/src/auto-reply/reply/get-reply-directives-utils.ts
@@ -22,7 +22,7 @@ const CLEARED_EXEC_FIELDS = {
 export function clearInlineDirectives(cleaned: string): InlineDirectives {
   return {
     cleaned,
-    nativeCommand: undefined,
+    command: undefined,
     hasThinkDirective: false,
     thinkLevel: undefined,
     rawThinkLevel: undefined,

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -23,6 +23,7 @@ import {
 } from "../../skills/discovery/chat-command-invocation.js";
 import type { SkillCommandSpec } from "../../skills/types.js";
 import { isExplicitCommandTurn, resolveCommandTurnContext } from "../command-turn-context.js";
+import { normalizeCommandBody } from "../commands-registry-normalize.js";
 import { shouldHandleTextCommands } from "../commands-text-routing.js";
 import { markCommandReplyForDelivery } from "../reply-payload.js";
 import type {
@@ -321,13 +322,15 @@ export async function resolveReplyDirectives(params: {
   );
   const directiveCommandText =
     explicitDirectiveCommand && commandTurn.kind === "text-slash"
-      ? command.commandBodyNormalized
+      ? normalizeCommandBody(commandText, { botUsername: ctx.BotUsername, preserveArguments: true })
       : commandText;
   const routedDirectives = resolveReplyDirectiveRouting({
     commandText: directiveCommandText,
-    agentText: sessionCtx.agentText,
+    agentText: sessionCtx.agentText === commandText ? directiveCommandText : sessionCtx.agentText,
     modelAliases: configuredAliases,
-    nativeCommand: explicitDirectiveCommand,
+    command: explicitDirectiveCommand
+      ? { kind: commandTurn.kind === "native" ? "native" : "text", name: explicitDirectiveCommand }
+      : undefined,
     canInterpretTextDirectives: canInterpretMessageDirectives,
     isAuthorizedSender: command.isAuthorizedSender,
     isGroup,

--- a/src/auto-reply/reply/get-reply-text-slash-directives.test.ts
+++ b/src/auto-reply/reply/get-reply-text-slash-directives.test.ts
@@ -117,6 +117,50 @@ describe("text slash directive ownership", () => {
     expect(loadExactSessionEntry({ sessionKey, storePath })?.entry.execHost).toBe("gateway");
   });
 
+  it.each([
+    { separator: " ", botUsername: undefined },
+    { separator: "\n", botUsername: undefined },
+    { separator: " ", botUsername: "openclaw" },
+    { separator: "\n", botUsername: "openclaw" },
+  ])("keeps a task after exec policy: %j", async ({ separator, botUsername }) => {
+    const { result } = await resolveTextSlashDirective(
+      `/exec${botUsername ? `@${botUsername}` : ""} security=deny ask=always${separator}Explain the output.`,
+      { botUsername },
+    );
+
+    expect(result).toMatchObject({
+      kind: "continue",
+      result: {
+        cleanedBody: "Explain the output.",
+        execOverrides: { security: "deny", ask: "always" },
+      },
+    });
+  });
+
+  it.each([" ", "\n"])("applies all text directives separated by %j", async (separator) => {
+    const { result, sessionKey, storePath } = await resolveTextSlashDirective(
+      `/verbose full${separator}/reasoning off`,
+    );
+
+    expect(result).toMatchObject({ kind: "reply" });
+    expect(loadExactSessionEntry({ sessionKey, storePath })?.entry).toMatchObject({
+      verboseLevel: "full",
+      reasoningLevel: "off",
+    });
+  });
+
+  it.each(["/exec@openclaw security=deny", "/verbose@openclaw:"])(
+    "preserves task whitespace after %s",
+    async (directive) => {
+      const task = "    if ready:\n        run('a  b')  \n";
+      const { result } = await resolveTextSlashDirective(`${directive}\r\n${task}`, {
+        botUsername: "openclaw",
+      });
+
+      expect(result).toMatchObject({ kind: "continue", result: { cleanedBody: task } });
+    },
+  );
+
   it("rejects positional exec arguments addressed to the current bot", async () => {
     const { result } = await resolveTextSlashDirective("/exec@openclaw gateway", {
       botUsername: "openclaw",

--- a/src/auto-reply/reply/get-reply-text-slash-directives.test.ts
+++ b/src/auto-reply/reply/get-reply-text-slash-directives.test.ts
@@ -98,14 +98,62 @@ async function resolveTextSlashDirective(
 }
 
 describe("text slash directive ownership", () => {
-  it("rejects positional exec arguments instead of sending them to the model", async () => {
-    const { result } = await resolveTextSlashDirective("/exec gateway");
+  it.each(
+    [
+      { directive: "/think high", field: "thinkingLevel" },
+      { directive: "/think: high", field: "thinkingLevel" },
+      { directive: "/t high", field: "thinkingLevel" },
+      { directive: "/think@openclaw high", field: "thinkingLevel" },
+      { directive: "/fast on", field: "fastMode" },
+      { directive: "/verbose on", field: "verboseLevel" },
+      { directive: "/reasoning off", field: "reasoningLevel" },
+      { directive: "/exec security=deny", field: "execSecurity" },
+      { directive: "/exec: security=deny", field: "execSecurity" },
+      { directive: "/exec@openclaw security=deny", field: "execSecurity" },
+    ].flatMap(({ directive, field }) =>
+      [" ", "\n"].map((separator) => ({ directive, field, separator })),
+    ),
+  )(
+    "preserves a task after $directive with separator $separator",
+    async ({ directive, field, separator }) => {
+      const task = "Please inspect this code:\n```python\nif True:\n    print('a  b')\n```";
+      const { result, sessionKey, storePath } = await resolveTextSlashDirective(
+        `${directive}${separator}${task}`,
+        { botUsername: "openclaw" },
+      );
 
-    expect(result).toMatchObject({
-      kind: "reply",
-      reply: { text: 'Unexpected argument "gateway" for /exec.' },
-    });
-  });
+      expect(result).toMatchObject({ kind: "continue", result: { cleanedBody: task } });
+      expect(loadExactSessionEntry({ sessionKey, storePath })?.entry).not.toHaveProperty(field);
+    },
+  );
+
+  it.each([
+    { argument: "gateway", unexpectedArgument: "gateway" },
+    { argument: " gateway", unexpectedArgument: "gateway" },
+    { argument: "\n  gateway", unexpectedArgument: "gateway" },
+    { argument: "/think high", unexpectedArgument: "/think" },
+    { argument: "/think high host=gateway", unexpectedArgument: "/think" },
+  ])(
+    "rejects positional exec argument $argument instead of sending it to the model",
+    async ({ argument, unexpectedArgument }) => {
+      const { result, sessionKey, storePath } = await resolveTextSlashDirective(
+        `/exec ${argument}`,
+      );
+
+      expect(result).toMatchObject({
+        kind: "reply",
+        reply: {
+          text: `Unexpected argument "${unexpectedArgument}" for /exec.`,
+        },
+      });
+      expect(loadExactSessionEntry({ sessionKey, storePath })?.entry).not.toHaveProperty(
+        "thinkingLevel",
+      );
+      expect(loadExactSessionEntry({ sessionKey, storePath })?.entry).not.toHaveProperty(
+        "execHost",
+      );
+    },
+  );
 
   it("preserves canonical exec key/value arguments", async () => {
     const { result, sessionKey, storePath } = await resolveTextSlashDirective("/exec host=gateway");
@@ -181,5 +229,17 @@ describe("text slash directive ownership", () => {
 
     expect(result).toMatchObject({ kind: "continue", result: { cleanedBody: body } });
     expect(loadExactSessionEntry({ sessionKey, storePath })?.entry.execHost).toBeUndefined();
+  });
+
+  it("preserves directives addressed to another bot", async () => {
+    const body = "/think@otherbot high\nKeep this task unchanged.";
+    const { result, sessionKey, storePath } = await resolveTextSlashDirective(body, {
+      botUsername: "openclaw",
+    });
+
+    expect(result).toMatchObject({ kind: "continue", result: { cleanedBody: body } });
+    expect(loadExactSessionEntry({ sessionKey, storePath })?.entry).not.toHaveProperty(
+      "thinkingLevel",
+    );
   });
 });

--- a/src/auto-reply/reply/get-reply.text-directives.test.ts
+++ b/src/auto-reply/reply/get-reply.text-directives.test.ts
@@ -1,0 +1,68 @@
+/** Exercises text directive policy and prompt handling through the complete reply pipeline. */
+import { afterEach, expect, it, vi } from "vitest";
+import { runEmbeddedAgent } from "../../agents/embedded-agent.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { withFullRuntimeReplyConfig } from "./get-reply-fast-path.js";
+import { getReplyFromConfig } from "./get-reply.js";
+import { finalizeInboundContext } from "./inbound-context.js";
+
+vi.mock("../../agents/embedded-agent.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/embedded-agent.js")>()),
+  runEmbeddedAgent: vi.fn(async () => ({
+    payloads: [{ text: "The output is ready." }],
+    meta: { durationMs: 1 },
+  })),
+}));
+
+let state: OpenClawTestState | undefined;
+afterEach(async () => {
+  await state?.cleanup();
+  vi.clearAllMocks();
+});
+
+it.each([" ", "\n"])("runs a task after text exec policy separated by %j", async (separator) => {
+  state = await createOpenClawTestState({
+    label: "text-directive-reply",
+    env: { OPENCLAW_TEST_FAST: "0" },
+  });
+  const cfg = withFullRuntimeReplyConfig({
+    agents: {
+      defaults: {
+        workspace: state.workspaceDir,
+        skipBootstrap: true,
+        model: { primary: "mock-openai/gpt-5.6-luna" },
+        models: { "mock-openai/gpt-5.6-luna": { agentRuntime: { id: "openclaw" } } },
+      },
+    },
+    plugins: { enabled: false },
+    commands: { text: true },
+  });
+  await state.writeConfig(cfg);
+  const body = `/exec security=deny ask=always${separator}Explain the output.`;
+  const reply = await getReplyFromConfig(
+    finalizeInboundContext({
+      Body: body,
+      RawBody: body,
+      BodyForAgent: body,
+      CommandBody: body,
+      CommandSource: "text",
+      CommandAuthorized: true,
+      Provider: "webchat",
+      Surface: "webchat",
+      ChatType: "direct",
+      SessionKey: "agent:main:text-directive-proof",
+    }),
+    undefined,
+    cfg,
+  );
+
+  expect([reply].flat()).toEqual([expect.objectContaining({ text: "The output is ready." })]);
+  expect(runEmbeddedAgent).toHaveBeenCalledOnce();
+  const input = vi.mocked(runEmbeddedAgent).mock.calls[0]![0];
+  expect(input.prompt).toContain("Explain the output.");
+  expect(input.prompt).not.toContain("/exec");
+  expect(input.execOverrides).toMatchObject({ security: "deny", ask: "always" });
+});


### PR DESCRIPTION
Closes #138530

<details>
<summary>Additional instructions</summary>

This branch is in `openclaw/openclaw`, available for maintainers to edit directly.

</details>

## Problem and fix

A text directive followed by a task could finish with an argument error or a settings acknowledgment instead of an agent reply. For example, `/exec security=deny ask=always Explain the output.` rejected `Explain`, while putting the task on the next line produced only an acknowledgment. The release Gateway regression also reproduced `/think high` followed by a multiline task completing without any provider request.

Text directives had acquired native commands' exclusive argument ownership and were parsed from canonical command text that discards later lines. This repair preserves complete text arguments during alias and bot-address normalization, then uses the existing inline directive parser. Native commands retain strict argument validation. The argument validator and metadata now describe command ownership rather than treating text as native.

Malformed text `/exec` arguments are classified from the original input before sibling directives can consume them. This prevents `/exec /think high` and `/exec /think high host=gateway` from applying sibling settings instead of rejecting `/think`. Leading spaces or newline indentation no longer produce an empty unexpected-argument diagnostic. Only the displayed diagnostic token is trimmed; task bytes remain intact.

## Behavior and scope

Valid text directives can precede same-line or multiline tasks, with code indentation, tabs, repeated spaces, and trailing whitespace preserved. Coverage includes colon syntax, aliases, addressed commands, multiple directives, disabled-text routing, per-turn overrides, and directives addressed to another bot. Invalid positional `/exec gateway` still receives a command error. No configuration, protocol, or persistence format changes.

Production grows by 20 lines and tests by 176 lines across the complete PR. The final follow-up contributes production +7 and tests +60: the parser adds six net lines to establish raw-argument ownership before destructive extraction, and the diagnostic expression wraps by one line. The preliminary parse reuses the canonical exec extractor and removes late classification; no separate argument policy is introduced. The QA scenario reference follows the validator rename to `directive-handling.arguments.ts`.

## Verification

Final source: `d0b816bc081317b60fe43d2a7fb9b608042fe6ba`. This is the exact tree tested before commit as base `5c6fbc77406dcb797bbc5c3af9ab65e73a7ef435` plus patch SHA-256 `4d394b0ef1b3097ec48430d86ca854d9b0f5f948d4c5462fcc82035bd52237bb`.

- The unchanged real Gateway whitespace test fails on frozen main `2329399cf6a9a2ca0c19d6c620b713a2768f9125`: the run returns `ok`, a thinking-level acknowledgment is recorded, and the first provider request is absent. It passes after the repair.
- Four malformed-exec regressions fail on the prior PR implementation; all pass with the final follow-up. The original policy-plus-task full-reply regressions also remain covered.
- Frozen dependency install and the complete changed-file gate pass, including core and test types, lint, dead exports, and repository guards. The first final gate caught a test-table `no-map-spread` violation; explicit fields fixed it, and the complete gate passed on retry.
- Canonical private-QA and AI runtime builds pass. All 300 tests across six directive/normalizer/native/full-reply files and all eight unchanged Gateway chat RPC tests pass: three shards in 400.27 seconds.
- Fresh isolated Codex review is scoped-clean through P2. Independent owner-boundary review found both malformed-exec defects resolved without a duplicate policy path.

The Gateway test uses a real ephemeral Gateway and a mock OpenAI-compatible HTTP provider. Two turns verify the first provider request's raw task whitespace, immediate directive removal, canonical chat history, and original directive replay on the second turn. Sibling Gateway cases cover explicit agent ownership, attachments, native dispatch, final-effect settings, and stale-send rejection.

The following is a maintainer summary of observed harness results, not a verdict file emitted by the harness:

```json
{
  "sourceCommit": "d0b816bc081317b60fe43d2a7fb9b608042fe6ba",
  "testedBase": "5c6fbc77406dcb797bbc5c3af9ab65e73a7ef435",
  "patchSha256": "4d394b0ef1b3097ec48430d86ca854d9b0f5f948d4c5462fcc82035bd52237bb",
  "build": "canonical private-QA and AI runtime passed",
  "unitTestsPassed": 300,
  "gatewayTestsPassed": 8,
  "gateway": "real ephemeral process",
  "provider": "mock HTTP provider",
  "firstRequestWhitespaceAndHistoryReplay": "passed across two turns",
  "telegramLive": "not run"
}
```

Reproduction and final proof commands:

```sh
CI=true pnpm install --frozen-lockfile
node scripts/check-changed.mjs --base 5c6fbc77406dcb797bbc5c3af9ab65e73a7ef435 --timed
OPENCLAW_E2E_WORKERS=1 node scripts/run-vitest.mjs \
  src/auto-reply/reply/get-reply-text-slash-directives.test.ts \
  src/auto-reply/commands-registry.test.ts \
  src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts \
  src/auto-reply/reply.directive.parse.test.ts \
  src/auto-reply/reply/directive-handling.mixed-inline.test.ts \
  src/auto-reply/reply/get-reply.text-directives.test.ts \
  test/e2e/qa-lab/runtime/gateway-rpc-chat.e2e.test.ts
```

The parent-relative patch in #137562 (`2f6a3d8fb126707b3661299894388a8c4f4e1d81`, parent `f959cc71e28ee298fdcf41119f5dac5092347f5c`) establishes the regression's source provenance. Existing directive documentation already describes the restored behavior.

## Remaining channel proof

ClawSweeper's latest review requested a Telegram Test Server event timeline and a rationale for production growth. The ownership rationale is above. Authenticated Telegram Test Server broker access was unavailable, so Telegram live proof was not run; no Telegram event proof or proof exception is claimed. Real Gateway/mock-provider evidence is identified separately above.

**Named follow-up: preserve multiline Telegram command projection at ingress.** Telegram separately normalizes its command body before this core boundary (`extensions/telegram/src/bot-message-context.session.ts`). That preexisting producer behavior can discard later setting lines. This PR's multiline directive proof uses intact core command text and does not claim to repair Telegram multiline settings.
