### PR TITLE
fix(commands): preserve dashboard skill selection in native commands

### DIFF
--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -73,6 +73,9 @@ function shouldRunNativeSlashCommandFastPath(ctx: MsgContext): boolean {
     commandName &&
     commandName !== "new" &&
     commandName !== "reset" &&
+    // Dashboard creates an agent prompt with exact skill selections. The full
+    // reply pipeline must consume that command once, without re-resolving its text.
+    commandName !== "dashboard" &&
     (isNativeCommandTurn(commandTurn) ||
       shouldRunInternalTextSlashCommandFastPath(ctx, commandTurn, commandName)),
   );

--- a/src/auto-reply/reply/get-reply.dashboard.test.ts
+++ b/src/auto-reply/reply/get-reply.dashboard.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { runEmbeddedAgent } from "../../agents/embedded-agent.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { withFullRuntimeReplyConfig } from "./get-reply-fast-path.js";
+import { getReplyFromConfig } from "./get-reply.js";
+import { finalizeInboundContext } from "./inbound-context.js";
+
+vi.mock("../../agents/embedded-agent.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/embedded-agent.js")>()),
+  runEmbeddedAgent: vi.fn(async () => ({
+    payloads: [{ text: "Dashboard prepared" }],
+    meta: { durationMs: 1 },
+  })),
+}));
+
+let state: OpenClawTestState | undefined;
+afterEach(async () => {
+  await state?.cleanup();
+  vi.clearAllMocks();
+});
+
+it.each([
+  { source: "text", authorized: true },
+  { source: "native", authorized: true },
+  { source: "native", authorized: false },
+] as const)(
+  "preserves dashboard skill ownership for $source with authorized=$authorized",
+  async ({ source, authorized }) => {
+    state = await createOpenClawTestState({
+      label: "dashboard-reply",
+      env: { OPENCLAW_TEST_FAST: "0" },
+    });
+    const skillDir = path.join(state.workspaceDir, "skills", "control-ui");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      "---\nname: control-ui\ndescription: Workspace dashboard skill collision.\n---\nWorkspace-specific instructions.\n",
+    );
+    const cfg = withFullRuntimeReplyConfig({
+      agents: {
+        defaults: {
+          workspace: state.workspaceDir,
+          skipBootstrap: true,
+          model: { primary: "mock-openai/gpt-5.6-luna" },
+          models: { "mock-openai/gpt-5.6-luna": { agentRuntime: { id: "openclaw" } } },
+        },
+      },
+      plugins: { enabled: false },
+      commands: { text: true },
+    });
+    await state.writeConfig(cfg);
+    const body = "/dashboard release health";
+    const sessionKey = "agent:main:dashboard-proof";
+    const reply = await getReplyFromConfig(
+      finalizeInboundContext({
+        Body: body,
+        RawBody: body,
+        BodyForAgent: body,
+        CommandBody: body,
+        CommandSource: source,
+        CommandAuthorized: authorized,
+        Provider: "webchat",
+        Surface: "webchat",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        ...(source === "native" ? { CommandTargetSessionKey: sessionKey } : {}),
+      }),
+      undefined,
+      cfg,
+    );
+    if (!authorized) {
+      expect([reply].flat()).toEqual([
+        expect.objectContaining({ text: "You are not authorized to use this command." }),
+      ]);
+      expect(runEmbeddedAgent).not.toHaveBeenCalled();
+      return;
+    }
+    expect([reply].flat()).toEqual([expect.objectContaining({ text: "Dashboard prepared" })]);
+    expect(runEmbeddedAgent).toHaveBeenCalledOnce();
+    const input = vi.mocked(runEmbeddedAgent).mock.calls[0]![0];
+    expect(input.explicitSkillSelections).toEqual([
+      { name: "control_ui", path: path.resolve("skills/control-ui/SKILL.md") },
+    ]);
+    expect(input.prompt).toContain("release health");
+    expect(input.prompt.match(/Use the following explicitly referenced skills/gu)).toHaveLength(1);
+  },
+);


### PR DESCRIPTION
Closes #138546

<details>
<summary>Additional instructions</summary>

Maintainers can edit this repository-owned branch.

</details>

## What Problem This Solves

Fixes an issue where users invoking native `/dashboard` could use a same-named workspace skill instead of the bundled dashboard workflow.

## Why This Change Was Made

Dashboard creates an agent prompt carrying an exact selected skill file. Its native preflight discarded that selection and reparsed the rewritten text. Dashboard now uses the existing full reply pipeline directly, which consumes the command once and retains the bundled selection through agent dispatch. Ordinary command fast paths and authorization checks remain covered. Production: +3/-0 lines; tests: +92/-0. The three production lines keep the command on its existing canonical owner rather than adding a second metadata handoff.

## User Impact

Native and ordinary text dashboard requests now choose the same bundled workflow, even when the workspace contains another skill named `control-ui`.

## Evidence

- Red before source changes: the full `getReplyFromConfig` pipeline selected the workspace file for a native request; its paired text request passed.
- Green: the new three-case full-pipeline test covers authorized text, authorized native, and unauthorized native turns with a physical workspace skill collision. Only the model boundary is mocked. Exact bundled selection and a single prompt expansion are asserted.
- The new test plus existing dashboard/native fast-path suites passed **62 tests**. A combined run also covered 13 independent Gateway projection tests; those are not dashboard coverage.
- Changed-file checks passed, including core/core-test types, formatter 0.65.0, lint and selected repository guards. Managed Codex review was clean through P2 on the frozen source; the split worktree matches the reviewed file hashes.
- Direct Codex `rust-v0.153.0` source inspection confirmed structured skill inputs preserve exact paths and suppress conflicting plain-name selection. No external native-channel or live model send is claimed.

Related: #137685.

## Review follow-through

The production-growth tradeoff identified in review is accepted: one command predicate plus its ownership comment keeps dashboard on the existing full reply path. The full-pipeline collision test remains in this PR, including authorized text/native and unauthorized native branches. A second fast-path metadata handoff would retain duplicate command consumption.
