### PR TITLE
fix(ui): restore conversation when opening compact Home

### DIFF
--- a/ui/src/e2e/assistant-panel-context.e2e.test.ts
+++ b/ui/src/e2e/assistant-panel-context.e2e.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { expect, it } from "vitest";
 import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
 import {
+  controlUiBundledSettingsStorageKey,
   controlUiSessionUrl,
   defaultControlUiFeatureMethods,
   installMockGateway,
@@ -11,6 +12,97 @@ import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts"
 const suite = createControlUiE2eSuite({ name: "Control UI Home context updates" });
 
 suite.define(() => {
+  it.each(["workspace", "dashboard"] as const)(
+    "keeps the Home conversation usable with a saved %s main panel",
+    async (mainSlot) => {
+      const artifactDir = suite.artifactDir;
+      await suite.withPage(
+        { viewport: { width: 1280, height: 900 }, recordVideo: { dir: artifactDir } },
+        async ({ page }) => {
+          const workKey = "agent:main:parser";
+          const homeKey = "agent:main:main";
+          const savedLayout = {
+            columns: [
+              {
+                id: "side-panel-column",
+                side: "right",
+                panels: [
+                  { id: mainSlot, slot: mainSlot },
+                  { id: "conversation", slot: "conversation" },
+                ],
+                activePanelId: "conversation",
+                width: 480,
+                height: 360,
+              },
+            ],
+            mainPanelId: mainSlot,
+            open: true,
+          };
+          const settingsKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
+          await page.addInitScript(
+            ({ key, homeKey: homeSessionKey, workKey: workSessionKey, layout }) => {
+              localStorage.setItem(
+                key,
+                JSON.stringify({
+                  sessionKey: workSessionKey,
+                  sidebarSessionLayouts: { [homeSessionKey]: layout },
+                }),
+              );
+            },
+            { key: settingsKey, homeKey, workKey, layout: savedLayout },
+          );
+          const gateway = await installMockGateway(page, {
+            featureMethods: [
+              ...defaultControlUiFeatureMethods,
+              "board.get",
+              "chat.history",
+              "chat.send",
+            ],
+            sessionKey: workKey,
+            sessions: [workKey, homeKey].map((key) => ({
+              key,
+              kind: "direct",
+              updatedAt: Date.now(),
+              label: key === homeKey ? "Personal Home" : "Parser work",
+            })),
+            historyMessages: [{ role: "assistant", content: "Home is ready to help." }],
+            methodResponses: {
+              "board.get": {
+                sessionKey: homeKey,
+                revision: 1,
+                tabs: [{ tabId: "main", title: "Main", position: 0 }],
+                widgets: [],
+              },
+            },
+          });
+          await page.goto(controlUiSessionUrl(suite.server.baseUrl, workKey));
+          await gateway.waitForRequest("chat.startup");
+          await page.locator(".sidebar-footer-bar__home").click();
+          const panel = page.locator("openclaw-assistant-panel");
+          await panel.locator("openclaw-chat-pane").waitFor();
+          await gateway.waitForRequest("chat.startup", { after: 1 });
+          await page.screenshot({ path: path.join(artifactDir, "home-open.png") });
+          const composer = panel.locator(".agent-chat__composer-combobox textarea");
+          await expect.poll(() => composer.isVisible()).toBe(true);
+          await composer.fill("Help with the current work");
+          await composer.press("Enter");
+          expect((await gateway.waitForRequest("chat.send")).params).toMatchObject({
+            sessionKey: homeKey,
+          });
+          expect(
+            await page.evaluate(
+              ({ key, homeKey: homeSessionKey }) =>
+                JSON.parse(localStorage.getItem(key) ?? "{}").sidebarSessionLayouts[homeSessionKey]
+                  .mainPanelId,
+              { key: settingsKey, homeKey },
+            ),
+          ).toBe(mainSlot);
+          await page.screenshot({ path: path.join(artifactDir, "home-message-sent.png") });
+        },
+      );
+    },
+  );
+
   it("refreshes open Home context after a roster-only title update", async () => {
     const proofDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()
       ? suite.artifactDir

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -68,7 +68,13 @@ import { handleChatScrollTakeover } from "./scroll.ts";
 import type { ChatMessageCache } from "./session-message-cache.ts";
 import type { SessionSnapshotStore } from "./session-snapshot-store.ts";
 import type { SidebarLayout } from "./sidebar-layout-types.ts";
-import { closeSlot, isSidebarSlotVisible, openSlot, setSidebarOpen } from "./sidebar-layout.ts";
+import {
+  closeSlot,
+  isSidebarSlotVisible,
+  openSlot,
+  promoteSidebarPanel,
+  setSidebarOpen,
+} from "./sidebar-layout.ts";
 
 export abstract class ChatPaneBase extends OpenClawLightDomElement {
   // The first Lit update must render even while hidden; later hidden work parks.
@@ -300,6 +306,17 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
     const visible =
       state?.sessionKey === sessionKey && isSidebarSlotVisible(state.sidebarLayout, "companion");
     return visible ? "expanded" : "hidden";
+  }
+
+  protected restorePaneSidebarLayout(layout: SidebarLayout): SidebarLayout {
+    if (!this.compact) {
+      return layout;
+    }
+    // Home's visibility consumers share the restored Chat-first layout;
+    // the saved full-page task layout stays intact.
+    const conversation = layout.columns[0]?.panels.find((panel) => panel.slot === "conversation");
+    const restored = conversation ? promoteSidebarPanel(layout, conversation.id) : layout;
+    return { ...restored, open: false, expanded: false };
   }
 
   protected setChatSidePanelOpen(open: boolean, layout?: SidebarLayout): void {

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -434,14 +434,13 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       });
       const persistedLayout = sidebarSettings.sidebarSessionLayouts?.[sidebarSessionKey];
       if (persistedLayout !== undefined) {
-        state.sidebarLayout = normalizeSidebarLayout(persistedLayout);
+        state.sidebarLayout = this.restorePaneSidebarLayout(
+          normalizeSidebarLayout(persistedLayout),
+        );
       } else if (clientChanged) {
         state.sidebarLayout = { columns: [] };
       } else if (state.sidebarLayout.columns.length > 0) {
         state.updateSidebarLayout(state.sidebarLayout);
-      }
-      if (this.compact && clientChanged) {
-        state.sidebarLayout = { ...state.sidebarLayout, open: false };
       }
       state.sidebarFocusPanelId =
         sidebarSettings.sidebarSessionActivePanels?.[sidebarSessionKey] ?? "";

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -309,9 +309,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
       pageState.assistantAgentId = paneAgentId;
       pageState.agentsSelectedId = paneAgentId;
     }
-    if (this.compact) {
-      pageState.sidebarLayout = { ...pageState.sidebarLayout, open: false };
-    }
+    pageState.sidebarLayout = this.restorePaneSidebarLayout(pageState.sidebarLayout);
     pageState.getWorkContext = () => this.workContext;
     // Task tabs can precede main chat in DOM order; viewport reads and commands
     // must resolve through the same transcript owner.

--- a/ui/src/pages/chat/chat-pane-retained-presentation.test.ts
+++ b/ui/src/pages/chat/chat-pane-retained-presentation.test.ts
@@ -26,27 +26,50 @@ import {
 import { createTestChatPane, type TestChatPane } from "./chat-pane.test-support.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { readTaskTranscript, type TaskDetailHost } from "./components/chat-task-detail-state.ts";
-import { openSlot } from "./sidebar-layout.ts";
+import {
+  isSidebarSlotVisible,
+  openSlot,
+  promoteSidebarPanel,
+  sidebarMainPanel,
+} from "./sidebar-layout.ts";
 
 describe("chat pane retained presentation lifecycle", () => {
   afterEach(() => vi.unstubAllGlobals());
 
   it.each([false, true])(
-    "restores sidebar tabs without opening a compact=%s presentation",
+    "restores dormant sidebar tabs for compact=%s without replacing saved task preferences",
     (compact) => {
       vi.stubGlobal("localStorage", createStorageMock());
       const client = { request: vi.fn(async () => ({})) } as unknown as GatewayBrowserClient;
       const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
-      const layout = openSlot({ columns: [] }, "workspace");
+      const layout = promoteSidebarPanel(
+        openSlot(openSlot({ columns: [] }, "workspace"), "companion"),
+        "companion",
+      );
       patchSettings({ sidebarSessionLayouts: { [state.sessionKey]: layout } });
-      (pane as TestChatPane & { compact: boolean }).compact = compact;
+      const presentation = pane as TestChatPane & {
+        compact: boolean;
+        selectedSessionRailMode: (sessionKey: string) => "expanded" | "hidden";
+      };
+      presentation.compact = compact;
       pane.connectedClient = null;
 
       pane.applyGatewaySnapshot({ ...pane.context.gateway.snapshot, phase: "reconnecting" });
 
-      expect(state.sidebarLayout.columns[0]?.panels[0]?.slot).toBe("workspace");
+      expect(state.sidebarLayout.columns[0]?.panels).toEqual(layout.columns[0]?.panels);
+      expect(sidebarMainPanel(state.sidebarLayout)?.slot).toBe(
+        compact ? "conversation" : "companion",
+      );
       expect(state.sidebarLayout.open).toBe(!compact);
-      expect(loadSettings().sidebarSessionLayouts?.[state.sessionKey]?.open).toBe(true);
+      expect(isSidebarSlotVisible(state.sidebarLayout, "companion")).toBe(!compact);
+      expect(presentation.selectedSessionRailMode(state.sessionKey)).toBe(
+        compact ? "hidden" : "expanded",
+      );
+      expect(isSidebarSlotVisible(state.sidebarLayout, "conversation")).toBe(true);
+      expect(loadSettings().sidebarSessionLayouts?.[state.sessionKey]).toMatchObject(layout);
+      expect(isSidebarSlotVisible(openSlot(state.sidebarLayout, "workspace"), "workspace")).toBe(
+        true,
+      );
     },
   );
 


### PR DESCRIPTION
Closes #138547

<details>
<summary>Additional instructions</summary>

Maintainers can edit this repository-owned branch.

</details>

## What Problem This Solves

Fixes an issue where users opening compact Home would lose its conversation and composer after saving Files or Dashboard as the Home session’s main panel.

## Why This Change Was Made

A shared layout-restoration method promotes Conversation and closes auxiliary presentation for compact panes at initialization and saved-layout restoration. All visibility consumers read the same corrected state. Saved full-page task preferences and dormant tabs remain intact; full-page panes retain their selected main panel. Production: +22/-8 lines (net +14); tests: +121/-6 (net +115). The growth replaces two closed-only writes with one shared presentation owner.

## User Impact

Home remains usable beside the current work page. Users can send to Home without overwriting the layout they chose for its full-page conversation.

## Evidence

- Both saved Files and saved Dashboard scenarios failed in actual Chromium before the repair: the Home composer was hidden.
- Both pass after repair, including a real UI send to the Home session and verification that its saved main-panel preference stays unchanged. The browser uses a mocked Gateway, not a live provider.
- Four related UI files passed **71 tests**, covering retained presentation, sidebar layout, board visibility and panel toggling. Compact/full-page restoration and explicit auxiliary-panel reopening are covered.
- After rebasing onto current main, both Home scenarios and the canonical settings-copy smoke passed **3/3** in Chromium. The repair passed selected checks in Testbox, including core test and UI types, format, lint, i18n, dead exports and repository guards. Fresh managed Codex review of the product-only rebased candidate was clean through P2.

The [first CI attempt](https://github.com/openclaw/openclaw/actions/runs/33911902244) failed an inherited settings browser fixture that mixed script observations across replaced documents. #138482 fixed that shared fixture on main. This PR is rebased onto that repair and does not modify the settings fixture. Its active-page HTTP500 and script-exception negative controls still fail as intended.

Related: #138077.

![Before repair — scenario 1](https://github.com/user-attachments/assets/48053d5a-2d2c-4a70-805a-800a26421222)

![After repair — scenario 1](https://github.com/user-attachments/assets/3b52c289-7a3a-423e-95a4-8660181cbcf2)

![Before repair — scenario 2](https://github.com/user-attachments/assets/aac557dd-086f-4487-8cb3-66f993579dfd)

![After repair — scenario 2](https://github.com/user-attachments/assets/4d464d2f-ff03-45de-b1d3-6c7337253335)

## Review follow-through

The production-growth tradeoff identified in review is accepted: one shared restoration method serves initialization and reconnect/session restoration, replacing the two closed-only writes. The repair stays in shared pane state so board/workspace/observer visibility agrees with rendering; saved full-page settings are not rewritten. Both browser variants and the compact/full-page unit assertions remain.
