### PR TITLE
fix(gateway): clear stale active model after recovery

### DIFF
--- a/src/gateway/session-event-payload.test.ts
+++ b/src/gateway/session-event-payload.test.ts
@@ -90,10 +90,14 @@ it("serializes merge tombstones without flattening row-only execution fields", (
   expect(snapshot).toMatchObject({
     agentStatus: null,
     observerDigest: null,
+    activeModel: null,
+    activeModelProvider: null,
     traceLevel: "full",
     session: {
       agentStatus: null,
       observerDigest: null,
+      activeModel: null,
+      activeModelProvider: null,
       traceLevel: "full",
       worktree: { id: "wt-1", branch: "feature", repoRoot: "/private/repo" },
       execNode: "private-node",
@@ -192,13 +196,24 @@ it.each(["user", "auto", null] as const)(
         updatedAt: 1,
         model: "model-a",
         modelProvider: "provider",
+        activeModel: "model-b",
+        activeModelProvider: "fallback-provider",
         modelOverrideSource,
       },
       lifecycle: true,
       includeSession: true,
     });
-    expect(snapshot.modelOverrideSource).toBeUndefined();
-    expect(snapshot.session).not.toHaveProperty("modelOverrideSource");
+    for (const field of [
+      "model",
+      "modelProvider",
+      "activeModel",
+      "activeModelProvider",
+      "modelOverrideSource",
+      "agentRuntime",
+    ]) {
+      expect(snapshot).not.toHaveProperty(field);
+      expect(snapshot.session).not.toHaveProperty(field);
+    }
   },
 );
 

--- a/src/gateway/session-event-payload.ts
+++ b/src/gateway/session-event-payload.ts
@@ -109,6 +109,8 @@ export function buildGatewaySessionEventFields(params: {
     effectiveResponseUsage: sessionRow.effectiveResponseUsage,
     modelProvider: sessionRow.modelProvider,
     model: sessionRow.model,
+    activeModelProvider: sessionRow.activeModelProvider ?? null,
+    activeModel: sessionRow.activeModel ?? null,
     modelOverrideSource: sessionRow.modelOverrideSource,
     agentRuntime: sessionRow.agentRuntime,
     status: params.status ?? sessionRow.status,
@@ -165,17 +167,11 @@ export function buildGatewaySessionSnapshot(params: {
   for (const key of ["thinkingLevels", "thinkingOptions", "thinkingDefault"] as const) {
     delete sessionRow[key];
   }
-  if (params.lifecycle) {
-    delete sessionRow.modelProvider;
-    delete sessionRow.model;
-    delete sessionRow.modelOverrideSource;
-    delete sessionRow.agentRuntime;
-    if (sessionRow.totalTokensFresh !== true) {
-      delete sessionRow.totalTokens;
-      delete sessionRow.totalTokensFresh;
-      delete sessionRow.contextTokens;
-      delete sessionRow.estimatedCostUsd;
-    }
+  if (params.lifecycle && sessionRow.totalTokensFresh !== true) {
+    delete sessionRow.totalTokens;
+    delete sessionRow.totalTokensFresh;
+    delete sessionRow.contextTokens;
+    delete sessionRow.estimatedCostUsd;
   }
   // Accepted terminal events outrank retained cleanup liveness; otherwise the
   // active owner, not a stale persisted row, supplies current run status.
@@ -194,6 +190,20 @@ export function buildGatewaySessionSnapshot(params: {
     // Presence means an exact set; null clears stale IDs when only liveness is known.
     activeRunIds: params.activeRunState ? (params.activeRunState.runIds ?? null) : undefined,
   });
+  if (params.lifecycle) {
+    // Lifecycle snapshots cannot replace selection metadata or clear an active fallback.
+    for (const field of [
+      "modelProvider",
+      "model",
+      "activeModelProvider",
+      "activeModel",
+      "modelOverrideSource",
+      "agentRuntime",
+    ] as const) {
+      delete sessionRow[field];
+      delete eventFields[field];
+    }
+  }
   const session: Record<string, unknown> | undefined = params.includeSession
     ? Object.assign(
         sessionRow,

--- a/ui/src/e2e/chat-composer-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-catalog.e2e.test.ts
@@ -1,5 +1,7 @@
 // Control UI E2E tests cover chat composer catalog discovery.
 import { expect, it } from "vitest";
+import { buildGatewaySessionSnapshot } from "../../../src/gateway/session-event-payload.ts";
+import type { GatewaySessionRow } from "../api/types.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiSessionUrl,
@@ -70,56 +72,95 @@ suite.define(() => {
     },
   );
 
-  it("shows the active fallback model while retaining the selected preference", async () => {
-    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
-      const selectedModel = { id: "gpt-5.5", name: "GPT-5.5", provider: "codex" };
-      const activeModel = { id: "qwen3.5:9b", name: "Qwen 3.5 9B", provider: "ollama" };
-      const gateway = await installMockGateway(page, {
-        agentModel: "codex/gpt-5.5",
-        models: [selectedModel, activeModel],
-        methodResponses: {
-          "sessions.list": {
-            count: 1,
-            defaults: { model: selectedModel.id, modelProvider: selectedModel.provider },
-            sessions: [
-              {
-                key: "main",
-                kind: "direct",
-                model: selectedModel.id,
-                modelProvider: selectedModel.provider,
-                activeModel: activeModel.id,
-                activeModelProvider: activeModel.provider,
-                status: "done",
-                updatedAt: Date.now(),
-              },
-            ],
-            path: "",
-            ts: Date.now(),
+  it("clears the active fallback model after recovery while retaining the selected preference", async () => {
+    const artifactDir = suite.artifactDir;
+    await suite.withPage(
+      { viewport: { width: 1280, height: 900 }, recordVideo: { dir: artifactDir } },
+      async ({ page }) => {
+        const selectedModel = { id: "gpt-5.5", name: "GPT-5.5", provider: "codex" };
+        const activeModel = { id: "qwen3.5:9b", name: "Qwen 3.5 9B", provider: "ollama" };
+        const session = {
+          key: "agent:main:fallback-recovery",
+          sessionId: "fallback-recovery-session",
+          kind: "direct",
+          model: selectedModel.id,
+          modelProvider: selectedModel.provider,
+          status: "done",
+          updatedAt: Date.now(),
+        } satisfies GatewaySessionRow;
+        const gateway = await installMockGateway(page, {
+          sessionKey: session.key,
+          agentModel: "codex/gpt-5.5",
+          models: [selectedModel, activeModel],
+          methodResponses: {
+            "sessions.list": {
+              count: 1,
+              defaults: { model: selectedModel.id, modelProvider: selectedModel.provider },
+              sessions: [
+                {
+                  ...session,
+                  activeModel: activeModel.id,
+                  activeModelProvider: activeModel.provider,
+                },
+              ],
+              path: "",
+              ts: Date.now(),
+            },
           },
-        },
-      });
+        });
 
-      await page.goto(`${suite.server.baseUrl}chat`);
-      await gateway.waitForRequest("chat.startup");
-      const composer = page.locator(".agent-chat__input");
-      const trigger = composer.locator('[data-chat-model-select="true"]');
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, session.key));
+        await gateway.waitForRequest("chat.startup");
+        const composer = page.locator(".agent-chat__input");
+        const trigger = composer.locator('[data-chat-model-select="true"]');
 
-      await expect.poll(() => trigger.textContent()).toContain("Qwen 3.5 9B");
-      await trigger.click();
-      await expect
-        .poll(() =>
-          composer
+        await expect.poll(() => trigger.textContent()).toContain("Qwen 3.5 9B");
+        await expect
+          .poll(() =>
+            composer
+              .locator('[data-chat-model-option="codex/gpt-5.5"]')
+              .getAttribute("aria-selected"),
+          )
+          .toBe("true");
+        await page.screenshot({ path: `${artifactDir}/active-fallback-model.png` });
+        const recovered = { ...session, updatedAt: session.updatedAt + 1 };
+        const message = {
+          role: "assistant",
+          content: "The selected model recovered.",
+          timestamp: recovered.updatedAt,
+        };
+        await gateway.setHistoryMessages([message]);
+        await gateway.setMethodResponse("chat.history", {
+          messages: [message],
+          sessionId: session.sessionId,
+          sessionInfo: recovered,
+        });
+        const listCount = (await gateway.getRequests("sessions.list")).length;
+        await gateway.emitGatewayEvent("session.message", {
+          sessionKey: session.key,
+          agentId: "main",
+          message,
+          messageId: "model-recovered",
+          messageSeq: 1,
+          ...buildGatewaySessionSnapshot({
+            sessionRow: recovered,
+            agentId: "main",
+            includeSession: true,
+            activeRunState: { active: false, runIds: [] },
+          }),
+        });
+        await gateway.waitForRequest("chat.history");
+        await page.getByText(message.content, { exact: true }).waitFor();
+        await page.screenshot({ path: `${artifactDir}/recovered-model.png` });
+        await expect.poll(() => trigger.textContent()).toContain(selectedModel.name);
+        expect(await gateway.getRequests("sessions.list")).toHaveLength(listCount);
+        expect(
+          await composer
             .locator('[data-chat-model-option="codex/gpt-5.5"]')
             .getAttribute("aria-selected"),
-        )
-        .toBe("true");
-      if (process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()) {
-        await composer.screenshot({
-          animations: "disabled",
-          path: `${suite.artifactDir}/active-fallback-model.png`,
-        });
-      }
-    });
+        ).toBe("true");
+      },
+    );
   });
 
   it("refreshes the configured usable catalog after advertised chat metadata", async () => {

--- a/ui/src/e2e/chat-composer-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-catalog.e2e.test.ts
@@ -4,6 +4,7 @@ import { buildGatewaySessionSnapshot } from "../../../src/gateway/session-event-
 import type { GatewaySessionRow } from "../api/types.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
+  type ControlUiMockGateway,
   controlUiSessionUrl,
   installMockGateway,
   navigateToControlUiSession,
@@ -135,30 +136,67 @@ suite.define(() => {
           sessionId: session.sessionId,
           sessionInfo: recovered,
         });
-        const listCount = (await gateway.getRequests("sessions.list")).length;
-        await gateway.emitGatewayEvent("session.message", {
-          sessionKey: session.key,
-          agentId: "main",
-          message,
-          messageId: "model-recovered",
-          messageSeq: 1,
-          ...buildGatewaySessionSnapshot({
-            sessionRow: recovered,
+        // Swarm child hydration shares sessions.list with the primary roster.
+        // Hold all later replies so only the event/history can repair this label.
+        const releaseLists = await page.evaluateHandle((row) => {
+          const fixture = (
+            window as Window & {
+              openclawControlUiE2eGateway?: ControlUiMockGateway;
+            }
+          ).openclawControlUiE2eGateway;
+          if (!fixture) {
+            throw new Error("Mock Gateway is not installed");
+          }
+          const waiting: Array<() => void> = [];
+          let released = false;
+          const snapshot = {
+            count: 1,
+            defaults: { model: row.model, modelProvider: row.modelProvider },
+            sessions: [row],
+            path: "",
+            ts: row.updatedAt,
+          };
+          fixture.setRequestHandler("sessions.list", ({ respond }) => {
+            if (released) {
+              respond(snapshot);
+            } else {
+              waiting.push(() => respond(snapshot));
+            }
+          });
+          return () => {
+            released = true;
+            for (const respond of waiting.splice(0)) {
+              respond();
+            }
+          };
+        }, recovered);
+        try {
+          await gateway.emitGatewayEvent("session.message", {
+            sessionKey: session.key,
             agentId: "main",
-            includeSession: true,
-            activeRunState: { active: false, runIds: [] },
-          }),
-        });
-        await gateway.waitForRequest("chat.history");
-        await page.getByText(message.content, { exact: true }).waitFor();
-        await page.screenshot({ path: `${artifactDir}/recovered-model.png` });
-        await expect.poll(() => trigger.textContent()).toContain(selectedModel.name);
-        expect(await gateway.getRequests("sessions.list")).toHaveLength(listCount);
-        expect(
-          await composer
-            .locator('[data-chat-model-option="codex/gpt-5.5"]')
-            .getAttribute("aria-selected"),
-        ).toBe("true");
+            message,
+            messageId: "model-recovered",
+            messageSeq: 1,
+            ...buildGatewaySessionSnapshot({
+              sessionRow: recovered,
+              agentId: "main",
+              includeSession: true,
+              activeRunState: { active: false, runIds: [] },
+            }),
+          });
+          await gateway.waitForRequest("chat.history");
+          await page.getByText(message.content, { exact: true }).waitFor();
+          await expect.poll(() => trigger.textContent()).toContain(selectedModel.name);
+          expect(
+            await composer
+              .locator('[data-chat-model-option="codex/gpt-5.5"]')
+              .getAttribute("aria-selected"),
+          ).toBe("true");
+          await page.screenshot({ path: `${artifactDir}/recovered-model.png` });
+        } finally {
+          await releaseLists.evaluate((release) => release());
+          await releaseLists.dispose();
+        }
       },
     );
   });


### PR DESCRIPTION
Closes #138548

<details>
<summary>Additional instructions</summary>

Maintainers can edit this repository-owned branch.

</details>

## What Problem This Solves

Fixes an issue where users whose session recovered from a fallback model could continue seeing the old fallback model in the composer.

## Why This Change Was Made

Ordinary authoritative session events now include null clearing values when no active fallback remains. The existing UI merge can therefore remove stale active-model fields. Lifecycle snapshots continue to omit selection/runtime metadata from both top-level and nested projections, preserving their narrower ownership. Production: +21/-11 lines (net +10); tests: +142/-48 (net +94). The additional lines express the existing event merge clearing contract and consolidate lifecycle exclusions; no schema or persistence change is introduced.

## User Impact

The composer returns to the selected model after recovery while retaining the user’s selected preference.

## Evidence

- Red before repair: the current pre-fix Gateway snapshot was serialized through a mocked WebSocket into Chromium. With later list responses held, the composer retained Qwen after the recovered reply and normal history hydration.
- Green: the exact fixed flow returns to GPT-5.5 and keeps the selected preference while list replies remain unavailable. Screenshots are captured after the label and preference assertions; every held reply is released before cleanup. This is mocked Gateway browser proof, not a live provider outage/recovery.
- All **13 Gateway session-event projection tests** passed, covering ordinary null clearing and lifecycle metadata omission. The final recovery case passed with exact pinned dependencies, along with the focused UI E2E type graph, lint and formatter 0.65.0. Prior selected repository gates also passed. Fresh managed Codex review of the full staged candidate was clean through P2.

Isolated **real Gateway → Chromium** proof also passed on `0792d5554ac6d3fb4c55fc5f8426f72442a39322`. The fixture creates its own state directory and loopback port, seeds an active fallback through the canonical SQLite session accessor, changes runtime state back to the selected model, and appends the recovery message through `appendAssistantMessageToSessionTranscript`. The production broadcaster emits `session.message` over a real WebSocket to the running Control UI. Later roster response delivery remains held until after the assertions.

With the pre-fix `43a7f624` event owner, the recovery message appeared but the label stayed Qwen. With the candidate, the label returned to GPT-5.4, the selected option remained selected, and SQLite retained the selected override. The actual event contained `activeModel: null` and `activeModelProvider: null` both at top level and inside `session`. Held responses, browser, Gateway, and temporary state all cleaned up. Plugins are disabled in this isolated fixture; it proves the persisted-state/event/UI boundary without external provider inference or an induced provider outage. The displayed credential warning reflects that deliberate unauthenticated provider setup.

![Real Gateway before repair — recovered transcript retains fallback](https://github.com/user-attachments/assets/31da093d-940a-4b7e-a4b3-883252a423ee)

![Real Gateway after repair — recovered transcript restores selection](https://github.com/user-attachments/assets/af68f3d7-acb5-439f-aeb5-71d7d1b76515)

https://github.com/user-attachments/assets/93268602-0e78-43ca-aed0-d10c0962986f

The response barrier also keeps legitimate Swarm child hydration, which shares the list method, from racing a total request-count assertion. Production polling and child hydration are unchanged.

The [initial CI failure](https://github.com/openclaw/openclaw/actions/runs/33911907498) was in the shared settings-copy browser fixture. #138482 fixed that fixture on main; this PR rebases onto it without modifying the fixture.

Related source change: https://github.com/openclaw/openclaw/commit/a45508ff0e66dbedda29d98dfba54d6ffd874135.

![Before repair — scenario 1](https://github.com/user-attachments/assets/a731175f-ca58-405d-80ff-56570746e7f8)

![After repair — scenario 1](https://github.com/user-attachments/assets/98fe621d-66b6-40d3-8b3f-4e5f74632bc5)

## Review follow-through

The production-growth tradeoff identified in review is accepted: the change stays limited to the two producer-owned active-model clearing fields and one shared lifecycle exclusion. Ordinary snapshots reuse the existing null-clearing merge contract; lifecycle snapshots remain unable to overwrite selection metadata. Both wire-projection and browser-recovery coverage remain.

The latest complete ClawSweeper review (22:16 UTC, published 22:43) requested live-Gateway proof and deliberate production growth. The real-Gateway screenshots/recording above address the proof and Rank-up move. The producer-owned +10-line tradeoff remains accepted as described above. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33923995788).
