### PR TITLE
fix(gateway): use reloaded config for new native approvals

### DIFF
--- a/src/gateway/server-channels.approval-bootstrap.test.ts
+++ b/src/gateway/server-channels.approval-bootstrap.test.ts
@@ -125,6 +125,7 @@ describe("server-channels approval bootstrap", () => {
     const channelRuntime = createRuntimeChannel();
     const stopApprovalBootstrap = vi.fn(async () => {});
     const nativeApprovalRuntime = {
+      getRuntimeConfig: () => ({}),
       request: vi.fn(),
       requestRoute: vi.fn(),
       routeCoordinator: {} as never,

--- a/src/gateway/server-instance-runtime.test.ts
+++ b/src/gateway/server-instance-runtime.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "../../packages/gateway-client/src/timeouts.js";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { GatewayNativeApprovalMethod } from "../infra/approval-gateway-runtime-methods.js";
 import type { ExecApprovalRequest } from "../infra/exec-approvals.js";
 import {
@@ -45,6 +46,23 @@ function createRegistry(handlers: GatewayRequestHandlers) {
 }
 
 describe("createGatewayInstanceRuntime", () => {
+  it("reads approval config from its live instance and rejects access after close", () => {
+    let config: OpenClawConfig = {};
+    const context = createContext();
+    context.getRuntimeConfig = () => config;
+    const runtime = createGatewayInstanceRuntime({
+      getContext: () => context,
+      getMethodRegistry: () => createRegistry({}),
+      isDispatchAvailable: () => true,
+    });
+    onTestFinished(() => runtime.close());
+    expect(runtime.nativeApprovals.getRuntimeConfig()).toBe(config);
+    config = { gateway: { publicOrigin: "https://current.example.com" } };
+    expect(runtime.nativeApprovals.getRuntimeConfig()).toBe(config);
+    runtime.close();
+    expect(() => runtime.nativeApprovals.getRuntimeConfig()).toThrow("approval runtime is closed");
+  });
+
   it("uses the typed recovery path and fails closed when the owning instance closes", async () => {
     let available = false;
     const rawAgent = vi.fn<NonNullable<GatewayRequestHandlers["agent"]>>(({ respond }) => {

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -245,6 +245,12 @@ export function createGatewayInstanceRuntime(
       },
     },
     nativeApprovals: {
+      getRuntimeConfig: () => {
+        if (closed) {
+          throw new Error("Gateway instance approval runtime is closed");
+        }
+        return options.getContext().getRuntimeConfig();
+      },
       request: async <T>(
         method: GatewayNativeApprovalMethod,
         payload: Record<string, unknown>,

--- a/src/infra/approval-gateway-resolver.test.ts
+++ b/src/infra/approval-gateway-resolver.test.ts
@@ -34,6 +34,7 @@ vi.mock("../gateway/operator-approvals-client.js", () => ({
 function withApprovalAccountContext<T>(run: () => T): T {
   return withGatewayNativeApprovalRuntime(
     {
+      getRuntimeConfig: () => ({}),
       request: async <TResult>(method: string, params: Record<string, unknown>) =>
         (await hoisted.clientRequest(method, params)) as TResult,
       requestRoute: vi.fn(),
@@ -199,6 +200,7 @@ describe("resolveApprovalOverGateway", () => {
     const request = vi.fn(async () => ({ applied: true, approval: recordedApproval }));
     const result = await withGatewayNativeApprovalRuntime(
       {
+        getRuntimeConfig: () => ({}),
         request: request as GatewayNativeApprovalRuntime["request"],
         requestRoute: vi.fn(),
         routeCoordinator: {} as never,
@@ -250,6 +252,7 @@ describe("resolveApprovalOverGateway", () => {
     const injectedRequest = vi.fn(async () => ({ applied: true, approval: recordedApproval }));
     const scopedRequest = vi.fn();
     const runtime = {
+      getRuntimeConfig: () => ({}),
       request: async <T>(): Promise<T> => {
         scopedRequest();
         throw new Error("unexpected scoped approval request");

--- a/src/infra/approval-gateway-runtime.types.ts
+++ b/src/infra/approval-gateway-runtime.types.ts
@@ -1,3 +1,4 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { GatewayNativeApprovalMethod } from "./approval-gateway-runtime-methods.js";
 import type { ApprovalNativeRouteCoordinator } from "./approval-native-route-coordinator.js";
 import type { ApprovalRequest, ChannelApprovalKind } from "./approval-types.js";
@@ -20,6 +21,7 @@ export type GatewayApprovalEventSubscriber = {
 
 /** Gateway-owned authority and event transport for channel-native approval runtimes. */
 export type GatewayNativeApprovalRuntime = {
+  getRuntimeConfig: () => OpenClawConfig;
   request: <T = unknown>(
     method: GatewayNativeApprovalMethod,
     params: Record<string, unknown>,

--- a/src/infra/approval-handler-runtime.test.ts
+++ b/src/infra/approval-handler-runtime.test.ts
@@ -1,6 +1,13 @@
 // Covers approval handler runtime adapter creation and lazy wiring.
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
+import type { GatewayNativeApprovalRuntime } from "./approval-gateway-runtime.types.js";
 import {
   createChannelApprovalNativeRuntimeAdapter,
   createChannelApprovalHandlerFromCapability,
@@ -10,6 +17,8 @@ import {
   createApprovalNativeRuntimeAdapterStubs,
   type ApprovalNativeRuntimeAdapterStubParams,
 } from "./approval-handler.test-helpers.js";
+import { createApprovalNativeRouteCoordinator } from "./approval-native-route-coordinator.js";
+import { doesApprovalRequestSelectChannelAccount } from "./approval-request-account-binding.js";
 import type { NormalizedApprovalRequest } from "./approval-types.js";
 import type { ExecApprovalRequest } from "./exec-approvals.js";
 import type { PluginApprovalRequest } from "./plugin-approvals.js";
@@ -90,6 +99,18 @@ function createTestApprovalHandler(capability: ApprovalCapability) {
   });
 }
 
+function createApprovalGatewayRuntime(getRuntimeConfig: () => OpenClawConfig) {
+  const routeCoordinator = createApprovalNativeRouteCoordinator();
+  onTestFinished(() => routeCoordinator.close());
+  return {
+    getRuntimeConfig,
+    request: vi.fn().mockResolvedValue([]),
+    requestRoute: vi.fn(),
+    routeCoordinator,
+    subscribe: vi.fn<GatewayNativeApprovalRuntime["subscribe"]>(() => () => {}),
+  };
+}
+
 type ApprovalHandlerRuntime = NonNullable<Awaited<ReturnType<typeof createTestApprovalHandler>>>;
 
 function expectApprovalRuntime(
@@ -107,6 +128,215 @@ function firstCallArg(mock: ReturnType<typeof vi.fn>): unknown {
 }
 
 describe("createChannelApprovalHandlerFromCapability", () => {
+  it("checks the current Gateway config before its initial subscription", async () => {
+    const initial: OpenClawConfig = {};
+    const next: OpenClawConfig = { gateway: { publicOrigin: "https://current.example.com" } };
+    let current = initial;
+    const gatewayRuntime = createApprovalGatewayRuntime(() => current);
+    const capability = makeNativeApprovalCapability();
+    const isConfigured = vi.fn(({ cfg }: { cfg: OpenClawConfig }) => cfg === next);
+    capability.nativeRuntime!.availability.isConfigured = isConfigured;
+    const runtime = expectApprovalRuntime(
+      await withGatewayNativeApprovalRuntime(gatewayRuntime, () =>
+        createChannelApprovalHandlerFromCapability({
+          ...TEST_HANDLER_PARAMS,
+          capability,
+          cfg: initial,
+        }),
+      ),
+    );
+    onTestFinished(() => runtime.stop());
+
+    current = next;
+    await runtime.start();
+
+    expect(isConfigured).toHaveBeenCalledWith(expect.objectContaining({ cfg: next }));
+    expect(gatewayRuntime.subscribe).toHaveBeenCalledOnce();
+  });
+
+  it.each(["exec", "system-agent"] as const)(
+    "pins an admitted %s request through delayed delivery and resolution",
+    async (approvalKind) => {
+      const initial: OpenClawConfig = { gateway: { publicOrigin: "https://admitted.example.com" } };
+      let current = initial;
+      const gatewayRuntime = createApprovalGatewayRuntime(() => current);
+      const entered = createDeferred();
+      const release = createDeferred();
+      const deliverPending = vi.fn().mockResolvedValue({ messageId: "pinned" });
+      const buildResolvedResult = vi.fn().mockResolvedValue({ kind: "leave" });
+      const capability = makeNativeApprovalCapability({
+        eventKinds: [approvalKind],
+        deliverPending,
+        buildResolvedResult,
+      });
+      capability.nativeRuntime!.presentation.buildPendingPayload = async ({ cfg }) => {
+        entered.resolve();
+        await release.promise;
+        return { text: cfg.gateway?.publicOrigin };
+      };
+      const runtime = expectApprovalRuntime(
+        await withGatewayNativeApprovalRuntime(gatewayRuntime, () =>
+          createChannelApprovalHandlerFromCapability({
+            ...TEST_HANDLER_PARAMS,
+            capability,
+            cfg: initial,
+          }),
+        ),
+      );
+      onTestFinished(async () => {
+        release.resolve();
+        await runtime.stop();
+      });
+      await runtime.start();
+      const subscriber = gatewayRuntime.subscribe.mock.calls[0]?.[0];
+      if (!subscriber) {
+        throw new Error("Expected Gateway approval subscription");
+      }
+      const request =
+        approvalKind === "exec"
+          ? makeExecApprovalRequest("exec:admitted")
+          : {
+              approvalKind: "system-agent" as const,
+              id: "system-agent:admitted",
+              createdAtMs: Date.now(),
+              expiresAtMs: Date.now() + 60_000,
+              request: {
+                title: "OpenClaw change",
+                description: "Restart Gateway",
+                command: "Restart Gateway",
+                proposalHash: "a".repeat(64),
+                sessionId: "test-session",
+                allowedDecisions: ["allow-once", "deny"] as const,
+              },
+            };
+      expect(subscriber.shouldHandle(request)).toBe(true);
+      current = { gateway: { publicOrigin: "https://later.example.com" } };
+      subscriber.onRequested(request);
+      await withTestTimeout(entered.promise, 1_000, "approval presentation did not start");
+      current = {};
+      release.resolve();
+      await vi.waitFor(() => expect(deliverPending).toHaveBeenCalledOnce());
+      await runtime.handleResolved({ id: request.id, decision: "deny", ts: Date.now() });
+
+      expect(deliverPending).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cfg: initial,
+          pendingPayload: { text: "https://admitted.example.com" },
+        }),
+      );
+      expect(buildResolvedResult).toHaveBeenCalledWith(expect.objectContaining({ cfg: initial }));
+    },
+  );
+
+  it.each(["runtime", "isolated"] as const)(
+    "uses the applicable %s config for a new approval after publication",
+    async (ownership) => {
+      const initial: OpenClawConfig = { gateway: { publicOrigin: "https://before.example.com" } };
+      const isolated: OpenClawConfig = {
+        gateway: { publicOrigin: "https://isolated.example.com" },
+      };
+      const next: OpenClawConfig = { gateway: { publicOrigin: "https://after.example.com" } };
+      let current = initial;
+      const gatewayRuntime = createApprovalGatewayRuntime(() => current);
+      setRuntimeConfigSnapshot(initial, initial);
+      onTestFinished(clearRuntimeConfigSnapshot);
+      const capability = makeNativeApprovalCapability();
+      const pendingPayload = vi.fn(({ cfg }: { cfg: OpenClawConfig }) => ({
+        text: `${cfg.gateway?.publicOrigin}/approve`,
+      }));
+      capability.nativeRuntime!.presentation.buildPendingPayload = pendingPayload;
+      const runtime = expectApprovalRuntime(
+        await withGatewayNativeApprovalRuntime(
+          ownership === "runtime" ? gatewayRuntime : undefined,
+          () =>
+            createChannelApprovalHandlerFromCapability({
+              ...TEST_HANDLER_PARAMS,
+              capability,
+              cfg: ownership === "runtime" ? initial : isolated,
+            }),
+        ),
+      );
+      onTestFinished(() => runtime.stop());
+
+      setRuntimeConfigSnapshot(next, next);
+      current = next;
+      await runtime.handleRequested(makeExecApprovalRequest(`exec:${ownership}`));
+
+      expect(pendingPayload).toHaveBeenCalledOnce();
+      expect(pendingPayload.mock.results[0]?.value).toEqual({
+        text: `${ownership === "runtime" ? next.gateway?.publicOrigin : isolated.gateway?.publicOrigin}/approve`,
+      });
+    },
+  );
+
+  it.each(["exec", "plugin"] as const)(
+    "selects the new native account after %s forwarding targets hot-apply",
+    async (approvalKind) => {
+      const configForAccount = (accountId: string): OpenClawConfig => ({
+        approvals: {
+          [approvalKind]: {
+            enabled: true,
+            mode: "targets",
+            targets: [{ channel: "test", accountId, to: "approver" }],
+          },
+        },
+      });
+      const initial = configForAccount("first");
+      let current = initial;
+      const gatewayRuntime = createApprovalGatewayRuntime(() => current);
+      setRuntimeConfigSnapshot(initial, initial);
+      onTestFinished(clearRuntimeConfigSnapshot);
+      const deliveries: string[] = [];
+      const runtimes = await Promise.all(
+        ["first", "second"].map(async (accountId) => {
+          const capability = makeNativeApprovalCapability({
+            eventKinds: [approvalKind],
+            shouldHandle: ({ cfg, request }) =>
+              doesApprovalRequestSelectChannelAccount({
+                cfg,
+                request,
+                channel: "test",
+                accountId,
+                defaultAccountId: "first",
+                eligibleAccountIds: ["first", "second"],
+              }),
+            deliverPending: async () => {
+              deliveries.push(accountId);
+              return { messageId: accountId };
+            },
+          });
+          const runtime = expectApprovalRuntime(
+            await withGatewayNativeApprovalRuntime(gatewayRuntime, () =>
+              createChannelApprovalHandlerFromCapability({
+                ...TEST_HANDLER_PARAMS,
+                cfg: initial,
+                accountId,
+                capability,
+              }),
+            ),
+          );
+          onTestFinished(() => runtime.stop());
+          await runtime.start();
+          return runtime;
+        }),
+      );
+      const next = configForAccount("second");
+      setRuntimeConfigSnapshot(next, next);
+      current = next;
+      const request: ExecApprovalRequest | PluginApprovalRequest = {
+        ...makeExecApprovalRequest(`${approvalKind}:changed-target`),
+        ...(approvalKind === "exec"
+          ? { approvalKind, request: { command: "echo hi" } }
+          : { approvalKind, request: { title: "Plugin action", description: "Allow action" } }),
+      };
+      for (const runtime of runtimes) {
+        await runtime.handleRequested(request);
+      }
+
+      expect(deliveries).toEqual(["second"]);
+    },
+  );
+
   it("returns null when the capability does not expose a native runtime", async () => {
     await expect(
       createChannelApprovalHandlerFromCapability({

--- a/src/infra/approval-handler-runtime.ts
+++ b/src/infra/approval-handler-runtime.ts
@@ -5,6 +5,7 @@ import type {
 } from "../channels/plugins/types.adapters.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { getGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
 import {
   CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
   createLazyChannelApprovalNativeRuntimeAdapter,
@@ -23,7 +24,7 @@ import type {
   ChannelNativeApprovalTransportSpec,
 } from "./approval-native-runtime-types.js";
 import { createChannelNativeApprovalRuntime } from "./approval-native-runtime.js";
-import { normalizeApprovalRequest } from "./approval-types.js";
+import { normalizeApprovalRequest, type ApprovalRequestInput } from "./approval-types.js";
 import {
   buildExpiredApprovalView,
   buildPendingApprovalView,
@@ -324,6 +325,7 @@ type ChannelApprovalHandlerRuntimeSpec<TRequest extends ApprovalRequest> = {
   label: string;
   clientDisplayName: string;
   cfg: OpenClawConfig;
+  getRequestConfig?: (request: ApprovalRequestInput) => OpenClawConfig;
   gatewayUrl?: string;
   eventKinds?: readonly ChannelApprovalKind[];
   channel?: string;
@@ -427,6 +429,7 @@ export function createChannelApprovalHandler<
     label: adapter.runtime.label,
     clientDisplayName: adapter.runtime.clientDisplayName,
     cfg: adapter.runtime.cfg,
+    getRequestConfig: adapter.runtime.getRequestConfig,
     gatewayUrl: adapter.runtime.gatewayUrl,
     eventKinds: adapter.runtime.eventKinds,
     channel: adapter.runtime.channel,
@@ -475,11 +478,26 @@ export async function createChannelApprovalHandlerFromCapability(params: {
     const normalizedRequest = normalizeApprovalRequest(request);
     return nativeRuntime.resolveApprovalKind?.(normalizedRequest) ?? normalizedRequest.approvalKind;
   };
-  const baseContext: ChannelApprovalCapabilityHandlerContext = {
-    cfg: params.cfg,
+  const gatewayRuntime = getGatewayNativeApprovalRuntime();
+  const createContext = (): ChannelApprovalCapabilityHandlerContext => ({
+    cfg: gatewayRuntime ? gatewayRuntime.getRuntimeConfig() : params.cfg,
     accountId: params.accountId,
     gatewayUrl: params.gatewayUrl,
     context: params.context,
+  });
+  const requestContexts = new WeakMap<
+    ApprovalRequestInput["request"],
+    ChannelApprovalCapabilityHandlerContext
+  >();
+  const getRequestContext = (request: ApprovalRequestInput) => {
+    let context = requestContexts.get(request.request);
+    if (!context) {
+      // Normalization preserves the payload identity, so selection, delivery, and
+      // cleanup share the admitted config snapshot even when the wrapper changes.
+      context = createContext();
+      requestContexts.set(request.request, context);
+    }
+    return context;
   };
   return createChannelApprovalHandler<WrappedPendingEntry, unknown, WrappedPendingContent>({
     runtime: {
@@ -488,6 +506,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
       channel: params.channel,
       channelLabel: params.channelLabel,
       cfg: params.cfg,
+      getRequestConfig: (request) => getRequestContext(request).cfg,
       accountId: params.accountId,
       gatewayUrl: params.gatewayUrl,
       eventKinds: nativeRuntime.eventKinds,
@@ -495,11 +514,11 @@ export async function createChannelApprovalHandlerFromCapability(params: {
       ...(nativeRuntime.resolveApprovalKind
         ? { resolveApprovalKind: nativeRuntime.resolveApprovalKind }
         : {}),
-      isConfigured: () => nativeRuntime.availability.isConfigured(baseContext),
+      isConfigured: () => nativeRuntime.availability.isConfigured(createContext()),
       shouldHandle: (request) => {
         const approvalKind = resolveApprovalKind(request);
         return nativeRuntime.availability.shouldHandle({
-          ...baseContext,
+          ...getRequestContext(request),
           request,
           approvalKind,
         });
@@ -512,7 +531,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
         return {
           view,
           payload: await nativeRuntime.presentation.buildPendingPayload({
-            ...baseContext,
+            ...getRequestContext(request),
             request,
             approvalKind,
             nowMs,
@@ -524,7 +543,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
     transport: {
       prepareTarget: async ({ plannedTarget, request, approvalKind, pendingContent }) => {
         return await nativeRuntime.transport.prepareTarget({
-          ...baseContext,
+          ...getRequestContext(request),
           plannedTarget,
           request,
           approvalKind,
@@ -540,7 +559,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
         pendingContent,
       }) => {
         const entry = await nativeRuntime.transport.deliverPending({
-          ...baseContext,
+          ...getRequestContext(request),
           plannedTarget,
           preparedTarget,
           request,
@@ -559,7 +578,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
           // would violate its contract without a binding, so route cleanup
           // through the optional cancelDelivered hook, which takes the entry.
           await nativeRuntime.interactions?.cancelDelivered?.({
-            ...baseContext,
+            ...getRequestContext(request),
             entry,
             request,
             approvalKind,
@@ -567,7 +586,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
           return null;
         }
         const binding = await nativeRuntime.interactions?.bindPending?.({
-          ...baseContext,
+          ...getRequestContext(request),
           entry,
           request,
           approvalKind,
@@ -577,7 +596,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
         if (stopped) {
           if (binding !== undefined && binding !== null) {
             await nativeRuntime.interactions?.unbindPending?.({
-              ...baseContext,
+              ...getRequestContext(request),
               entry,
               binding,
               request,
@@ -589,7 +608,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
             // from both deliverPending and bindPending (e.g. Matrix) drain it
             // via the binding branch above; this branch covers the rest.
             await nativeRuntime.interactions?.cancelDelivered?.({
-              ...baseContext,
+              ...getRequestContext(request),
               entry,
               request,
               approvalKind,
@@ -614,7 +633,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
     lifecycle: {
       onDeliveryError: ({ error, plannedTarget, request, approvalKind, pendingContent }) => {
         nativeRuntime.observe?.onDeliveryError?.({
-          ...baseContext,
+          ...getRequestContext(request),
           error,
           plannedTarget,
           request,
@@ -631,7 +650,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
         pendingContent,
       }) => {
         nativeRuntime.observe?.onDuplicateSkipped?.({
-          ...baseContext,
+          ...getRequestContext(request),
           plannedTarget,
           preparedTarget,
           request,
@@ -649,7 +668,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
         entry,
       }) => {
         nativeRuntime.observe?.onDelivered?.({
-          ...baseContext,
+          ...getRequestContext(request),
           plannedTarget,
           preparedTarget,
           request,
@@ -671,7 +690,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
           runEntry: async (wrapped) => {
             if (wrapped.binding !== undefined) {
               await nativeRuntime.interactions?.unbindPending?.({
-                ...baseContext,
+                ...getRequestContext(request),
                 entry: wrapped.entry,
                 binding: wrapped.binding,
                 request,
@@ -679,7 +698,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
               });
             }
             const result = await nativeRuntime.presentation.buildResolvedResult({
-              ...baseContext,
+              ...getRequestContext(request),
               request,
               resolved,
               view,
@@ -687,7 +706,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
             });
             await applyApprovalFinalAction({
               nativeRuntime,
-              baseContext,
+              baseContext: getRequestContext(request),
               wrapped,
               request,
               approvalKind,
@@ -697,7 +716,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
           },
         });
         nativeRuntime.observe?.onFinalized?.({
-          ...baseContext,
+          ...getRequestContext(request),
           request,
           approvalKind,
           phase: "resolved",
@@ -715,7 +734,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
           runEntry: async (wrapped) => {
             if (wrapped.binding !== undefined) {
               await nativeRuntime.interactions?.unbindPending?.({
-                ...baseContext,
+                ...getRequestContext(request),
                 entry: wrapped.entry,
                 binding: wrapped.binding,
                 request,
@@ -723,14 +742,14 @@ export async function createChannelApprovalHandlerFromCapability(params: {
               });
             }
             const result = await nativeRuntime.presentation.buildExpiredResult({
-              ...baseContext,
+              ...getRequestContext(request),
               request,
               view,
               entry: wrapped.entry,
             });
             await applyApprovalFinalAction({
               nativeRuntime,
-              baseContext,
+              baseContext: getRequestContext(request),
               wrapped,
               request,
               approvalKind,
@@ -740,7 +759,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
           },
         });
         nativeRuntime.observe?.onFinalized?.({
-          ...baseContext,
+          ...getRequestContext(request),
           request,
           approvalKind,
           phase: "expired",
@@ -757,7 +776,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
             entries: activeRequest.entries,
             request: activeRequest.request,
             approvalKind: activeRequest.approvalKind,
-            baseContext,
+            baseContext: getRequestContext(activeRequest.request),
             nativeRuntime,
             log,
           });

--- a/src/infra/approval-native-runtime.ts
+++ b/src/infra/approval-native-runtime.ts
@@ -161,6 +161,7 @@ type ChannelNativeApprovalRuntimeAdapter<
     TPendingContent,
     TRequest
   > & {
+    getRequestConfig?: (request: ApprovalRequestInput) => OpenClawConfig;
     channel?: string;
     channelLabel?: string;
     accountId?: string | null;
@@ -205,7 +206,7 @@ export function createChannelNativeApprovalRuntime<
     shouldHandle: (request) => adapter.shouldHandle(request as NormalizedApprovalRequest<TRequest>),
     classifyRoute: (request) =>
       classifyApprovalRequestChannelRoute({
-        cfg: adapter.cfg,
+        cfg: adapter.getRequestConfig?.(request) ?? adapter.cfg,
         request,
         channel: adapter.channel ?? "",
       }),
@@ -295,7 +296,7 @@ export function createChannelNativeApprovalRuntime<
           nowMs: nowMs(),
         });
         const deliveryResult = await deliverApprovalRequestViaChannelNativePlan({
-          cfg: adapter.cfg,
+          cfg: adapter.getRequestConfig?.(request) ?? adapter.cfg,
           accountId: adapter.accountId,
           approvalKind,
           request,

--- a/src/infra/exec-approval-channel-runtime.test.ts
+++ b/src/infra/exec-approval-channel-runtime.test.ts
@@ -385,6 +385,7 @@ describe("createExecApprovalChannelRuntime", () => {
     const shouldHandle = vi.fn(() => true);
     const deliverRequested = vi.fn(async (approval: ExecApprovalRequest) => [{ id: approval.id }]);
     const gatewayRuntime: GatewayNativeApprovalRuntime = {
+      getRuntimeConfig: () => ({}),
       request: request as GatewayNativeApprovalRuntime["request"],
       requestRoute: vi.fn(),
       routeCoordinator: {} as never,


### PR DESCRIPTION
Closes #138552

<details>
<summary>Additional instructions</summary>

The branch is in `openclaw/openclaw`. GitHub exposes the fork-collaboration toggle only for cross-repository PRs.

</details>

## What Problem This Solves

Fixes an issue where operators changing the Gateway public origin or native approval forwarding targets could create new approval cards using the previous URL or account after the change hot-applied.

**Merge hold: real Telegram Test Server proof is pending.** The local owner and sibling tests below do not replace that proof.

## Why This Change Was Made

The existing Gateway-owned approval runtime now supplies its current config. The shared capability handler selects one snapshot when a request is admitted and carries it through account selection, route classification, presentation, delivery and finalization. Standalone handlers retain their explicitly supplied config, and existing Gateway authority and route revalidation remain intact.

This replaces the handler's frozen startup context. Production is +54/-26 (net +28); the growth provides the explicit instance-owned config capability and a weak request-lifetime cache needed to keep configuration consistent across awaits. Tests/support are +255/-2 (net +253). There are no new operator options, schema changes, normalization changes or persisted-state changes.

## User Impact

New native approvals use the latest applied origin and forwarding targets without requiring a channel restart. Approvals already in progress retain the configuration under which they were admitted.

## Evidence

- Required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33912286835/job/101158559385) passed on `332765700ee1b7a3f58d278c9654a589119a8650`; the exact-head checks have no pending or failing result.
- Before repair, the shared owner reproduction failed three cases: stale presentation URL, stale exec account target and stale plugin account target. Fifteen other cases passed, including explicit standalone config isolation.
- Final handler suite: 21 tests passed. Related native-runtime and request-view coverage: 15 tests passed. Gateway lifecycle/bootstrap, resolver and replay sibling suites also passed.
- Existing Telegram presentation, routing and delivery suites: 52 tests passed across three files.
- Final `check:changed` passed, including production and core-test typechecks, formatting, lint, plugin boundaries, dead-export scans, import cycles and repository guards.
- Fresh independent Codex autoreview through P2: no actionable findings.
- Current main `b1164348d55ca3bc221544daa86a908b70c100c6` has the same affected production modules as the reproduced baseline. The parent-relative patch for cbaa21e6 (#138112) makes the relevant settings hot and exposes this retained-owner bug.

Representative commands:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/infra/approval-handler-runtime.test.ts src/infra/approval-native-runtime.test.ts src/infra/approval-view-model.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/telegram/src/approval-handler.runtime.test.ts extensions/telegram/src/exec-approvals.test.ts extensions/telegram/src/approval-native.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs --base d58c93f334ce5f867707a07591c0d032f6d1f641 -- src/gateway/server-channels.approval-bootstrap.test.ts src/gateway/server-instance-runtime.test.ts src/gateway/server-instance-runtime.ts src/infra/approval-gateway-resolver.test.ts src/infra/approval-gateway-runtime.types.ts src/infra/approval-handler-runtime.test.ts src/infra/approval-handler-runtime.ts src/infra/approval-native-runtime.ts src/infra/exec-approval-channel-runtime.test.ts
```

The pending live scenario will retain one Gateway boot, hot-change forwarding targets to the running Telegram account, and require new native exec/plugin approval cards in the Test Server userbot timeline. No live result or merge-readiness claim is made yet.

### ClawSweeper follow-through

Read the September 4, 2026 19:55 UTC review of `332765700ee1` (updated 20:06 UTC). It found no correctness or security defects and endorsed the Gateway-owned snapshot repair. Production remains four files and net +28. The description distinguishes the implemented owner repair, local and exact-head CI validation, and remaining risk, addressing the review's description-clarity Rank-up move.

The live-evidence and confidence before-merge items remain pending under the explicit merge hold. The prepared one-bot scenario covers exec/plugin forwarding-target changes on a retained Gateway and channel. The Control UI Review URL is specific to system-agent cards, so that URL observation is a separate pending live case, not a claim made by the exec/plugin scenario.
