### PR TITLE
feat(gateway): hot reload diagnostics service settings

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -612,6 +612,11 @@ stopped, and the Gateway keeps running.
 channels. Per-channel and per-account overrides still take precedence; turns
 already being processed retain their captured policy.
 
+`diagnostics.enabled` updates diagnostic dispatch and heartbeat ownership live.
+With `diagnostics-otel` loaded, `diagnostics.otel` restarts only its exporter service,
+flushing the old generation before starting the new one. Externally preloaded
+OpenTelemetry providers retain their transport and shutdown ownership.
+
 Operation settings apply at their next use; they do not restart in-flight runs
 or recreate provisioned workers. Approval expiry changes affect newly issued
 grants. Attachment retention changes apply on the next cleanup sweep, including

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -59,6 +59,20 @@ openclaw plugins install clawhub:@openclaw/diagnostics-otel
 
 Or enable the plugin from the CLI: `openclaw plugins enable diagnostics-otel`.
 
+With the plugin loaded, changes to `diagnostics.otel` hot-reload only its exporter
+service. The previous generation unsubscribes and flushes before the replacement
+starts with the new endpoint, headers, sampling, and signal settings. Other plugin
+services, channels, and Gateway connections stay running. A cleanup or startup
+failure requests Gateway recovery instead of leaving a partially replaced exporter.
+
+`diagnostics.enabled` also hot-applies to the shared dispatcher and its heartbeat.
+The Gateway owns that process-wide heartbeat; stopping a channel leaves it running.
+Standalone hosts using the plugin SDK own `startDiagnosticHeartbeat` and
+`stopDiagnosticHeartbeat` for their process, rather than each channel owning them.
+Disabling it stops diagnostic sampling and recovery listeners; enabling it starts
+them again. Preloaded OpenTelemetry SDKs keep ownership of their providers and
+transport: these changes do not shut down or reconfigure the host SDK.
+
 <Note>
 `diagnostics.otel.protocol` accepts only `http/protobuf`. If a persisted config,
 including a value supplied through `${VAR}` interpolation, still resolves this

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -1220,12 +1220,21 @@ already available to Gateway hooks: `list`, `add`, `update`, `remove`, and
 `removeStaleJobFamily`. Non-Gateway service hosts omit this getter.
 
 Use the service's `start()` and `stop()` methods to own recurring reconciliation.
-They run for plugin replacement as well as Gateway startup and shutdown;
+They run for service or plugin replacement as well as Gateway startup and shutdown;
 `gateway_start` and `gateway_stop` do not replay on plugin-only reload.
 Each returned scheduler handle belongs to one service lifetime and one scheduler
 instance. Calls, including queued writes, reject once service shutdown begins or
 that scheduler is replaced. Call `ctx.getCron()` again to obtain the replacement
 scheduler while the service remains active.
+
+A service can declare `reload: { configPrefixes: ["myConfig.service"] }` alongside
+its `id`, `start`, and `stop`. After a matching config change commits, the Gateway
+stops that service and calls `start(ctx)` again with the new `ctx.config`. Only
+loaded services declaring the matching prefix are replaced; overlapping owners
+all refresh. Existing narrower restart or no-op policies still take precedence.
+Each start receives a new capability lease and health reporter. Stop must release
+resources before resolving; failed replacement cleanup or startup triggers
+Gateway recovery. A full plugin replacement subsumes these service restarts.
 
 Long-lived services registered with `api.registerService(...)` receive a process-local
 `ctx.gatewayEvents` facade when the process runs a Gateway broadcaster; in runtimes without one the

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -58,7 +58,8 @@ Retained channel monitors can bind `createRuntimeConfigReader(cfg)` from
 runtime updates when the supplied config belongs to the active runtime, and
 preserves an explicitly scoped config otherwise, including when no runtime has
 been published yet. Read once per turn and carry that snapshot through admission
-and replies.
+and replies. Process-wide controls such as diagnostics should read at the point
+of emission.
 
 ## Reusable runtime utilities
 
@@ -1231,7 +1232,7 @@ A service can declare `reload: { configPrefixes: ["myConfig.service"] }` alongsi
 its `id`, `start`, and `stop`. After a matching config change commits, the Gateway
 stops that service and calls `start(ctx)` again with the new `ctx.config`. Only
 loaded services declaring the matching prefix are replaced; overlapping owners
-all refresh. Existing narrower restart or no-op policies still take precedence.
+all refresh. Existing equal or narrower restart or no-op policies still take precedence.
 Each start receives a new capability lease and health reporter. Stop must release
 resources before resolving; failed replacement cleanup or startup triggers
 Gateway recovery. A full plugin replacement subsumes these service restarts.

--- a/extensions/diagnostics-otel/src/service.restart.test.ts
+++ b/extensions/diagnostics-otel/src/service.restart.test.ts
@@ -161,79 +161,82 @@ function captureOtelDiagnostics(): string[] {
   return messages;
 }
 
-test("flushes each private generation and leaves global providers untouched", async () => {
-  const receiverA = startLocalOtlpReceiver();
-  const receiverB = startLocalOtlpReceiver();
-  const portA = await receiverA.listen();
-  const portB = await receiverB.listen();
-  releaseOtelGlobals();
-  const globalProviders = {
-    logs: registeredOtelLogs(),
-    metrics: registeredOtelGlobals()?.metrics,
-    trace: registeredOtelGlobals()?.trace,
-  };
-  const serviceA = createDiagnosticsOtelService();
-  const serviceB = createDiagnosticsOtelService();
-  const ctxA = createOtelContext(`http://127.0.0.1:${portA}`, {
-    traces: true,
-    metrics: true,
-    logs: true,
-  });
-  const ctxB = createOtelContext(`http://127.0.0.1:${portB}`, {
-    traces: true,
-    metrics: true,
-    logs: true,
-  });
-  ctxA.config.diagnostics!.otel!.flushIntervalMs = 60_000;
-  ctxB.config.diagnostics!.otel!.flushIntervalMs = 60_000;
+test.each(["replacement instance", "retained instance"])(
+  "flushes each private generation with a %s and leaves global providers untouched",
+  async (mode) => {
+    const receiverA = startLocalOtlpReceiver();
+    const receiverB = startLocalOtlpReceiver();
+    const portA = await receiverA.listen();
+    const portB = await receiverB.listen();
+    releaseOtelGlobals();
+    const globalProviders = {
+      logs: registeredOtelLogs(),
+      metrics: registeredOtelGlobals()?.metrics,
+      trace: registeredOtelGlobals()?.trace,
+    };
+    const serviceA = createDiagnosticsOtelService();
+    const serviceB = mode === "retained instance" ? serviceA : createDiagnosticsOtelService();
+    const ctxA = createOtelContext(`http://127.0.0.1:${portA}`, {
+      traces: true,
+      metrics: true,
+      logs: true,
+    });
+    const ctxB = createOtelContext(`http://127.0.0.1:${portB}`, {
+      traces: true,
+      metrics: true,
+      logs: true,
+    });
+    ctxA.config.diagnostics!.otel!.flushIntervalMs = 60_000;
+    ctxB.config.diagnostics!.otel!.flushIntervalMs = 60_000;
 
-  try {
-    expect(serviceA).not.toBe(serviceB);
-    await serviceA.start(ctxA);
-    const traceA = await emitRealSdkSignals("generation-a");
-    await serviceA.stop?.(ctxA);
-    const aRequestsAfterStop = receiverA.capturedRequests.length;
+    try {
+      await serviceA.start(ctxA);
+      const traceA = await emitRealSdkSignals("generation-a");
+      await serviceA.stop?.(ctxA);
+      const aRequestsAfterStop = receiverA.capturedRequests.length;
 
-    expect(new Set(receiverA.capturedRequests.map((request) => request.signal))).toEqual(
-      new Set(["traces", "metrics", "logs"]),
-    );
-    expect(receiverA.capturedMetrics.length).toBeGreaterThan(0);
-    assertCorrelatedGeneration(receiverA.capturedSpans, receiverA.capturedLogRecords, traceA);
-    expect(registeredOtelGlobals()?.trace).toBe(globalProviders.trace);
-    expect(registeredOtelGlobals()?.metrics).toBe(globalProviders.metrics);
-    expect(registeredOtelLogs()).toBe(globalProviders.logs);
+      expect(new Set(receiverA.capturedRequests.map((request) => request.signal))).toEqual(
+        new Set(["traces", "metrics", "logs"]),
+      );
+      expect(receiverA.capturedMetrics.length).toBeGreaterThan(0);
+      assertCorrelatedGeneration(receiverA.capturedSpans, receiverA.capturedLogRecords, traceA);
+      expect(registeredOtelGlobals()?.trace).toBe(globalProviders.trace);
+      expect(registeredOtelGlobals()?.metrics).toBe(globalProviders.metrics);
+      expect(registeredOtelLogs()).toBe(globalProviders.logs);
 
-    await emitRealSdkSignals("after-a-stop");
-    await waitForDiagnosticEventsDrained();
-    await sleep(50);
-    expect(receiverA.capturedRequests).toHaveLength(aRequestsAfterStop);
+      await emitRealSdkSignals("after-a-stop");
+      await waitForDiagnosticEventsDrained();
+      await sleep(50);
+      expect(receiverA.capturedRequests).toHaveLength(aRequestsAfterStop);
 
-    await serviceB.start(ctxB);
-    const traceB = await emitRealSdkSignals("generation-b");
-    await serviceB.stop?.(ctxB);
-    const bRequestsAfterStop = receiverB.capturedRequests.length;
+      await serviceB.start(ctxB);
+      const traceB = await emitRealSdkSignals("generation-b");
+      await serviceB.stop?.(ctxB);
+      const bRequestsAfterStop = receiverB.capturedRequests.length;
 
-    expect(receiverA.capturedRequests).toHaveLength(aRequestsAfterStop);
-    expect(new Set(receiverB.capturedRequests.map((request) => request.signal))).toEqual(
-      new Set(["traces", "metrics", "logs"]),
-    );
-    expect(receiverB.capturedMetrics.length).toBeGreaterThan(0);
-    assertCorrelatedGeneration(receiverB.capturedSpans, receiverB.capturedLogRecords, traceB);
-    expect(registeredOtelGlobals()?.trace).toBe(globalProviders.trace);
-    expect(registeredOtelGlobals()?.metrics).toBe(globalProviders.metrics);
-    expect(registeredOtelLogs()).toBe(globalProviders.logs);
+      expect(receiverA.capturedRequests).toHaveLength(aRequestsAfterStop);
+      expect(new Set(receiverB.capturedRequests.map((request) => request.signal))).toEqual(
+        new Set(["traces", "metrics", "logs"]),
+      );
+      expect(receiverB.capturedMetrics.length).toBeGreaterThan(0);
+      assertCorrelatedGeneration(receiverB.capturedSpans, receiverB.capturedLogRecords, traceB);
+      expect(registeredOtelGlobals()?.trace).toBe(globalProviders.trace);
+      expect(registeredOtelGlobals()?.metrics).toBe(globalProviders.metrics);
+      expect(registeredOtelLogs()).toBe(globalProviders.logs);
 
-    await emitRealSdkSignals("after-b-stop");
-    await waitForDiagnosticEventsDrained();
-    await sleep(50);
-    expect(receiverB.capturedRequests).toHaveLength(bRequestsAfterStop);
-  } finally {
-    await serviceA.stop?.(ctxA);
-    await serviceB.stop?.(ctxB);
-    await receiverA.close();
-    await receiverB.close();
-  }
-}, 30_000);
+      await emitRealSdkSignals("after-b-stop");
+      await waitForDiagnosticEventsDrained();
+      await sleep(50);
+      expect(receiverB.capturedRequests).toHaveLength(bRequestsAfterStop);
+    } finally {
+      await serviceA.stop?.(ctxA);
+      await serviceB.stop?.(ctxB);
+      await receiverA.close();
+      await receiverB.close();
+    }
+  },
+  30_000,
+);
 
 test("keeps preloaded host providers live and owned by the host after plugin stop", async () => {
   releaseOtelGlobals();

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -183,64 +183,53 @@ function diagnosticTraceContextFromSpanContext(spanContext: SpanContext): Diagno
   };
 }
 
+type DiagnosticsOtelState = {
+  traceProvider?: BasicTracerProvider;
+  meterProvider?: MeterProvider;
+  logProvider?: LoggerProvider | null;
+  unsubscribe?: (() => void) | null;
+  unregisterTracePropagationBridge?: (() => void) | null;
+  stopActiveTrustedSpans?: (() => void) | null;
+  unregisterOwnedSdkRuntime?: (() => void) | null;
+  unregisterUnhandledRejectionHandler?: (() => void) | null;
+  retireExporterRoutes?: (preserveFailures?: boolean) => void;
+};
+
 export function createDiagnosticsOtelService(): OpenClawPluginService {
-  let traceProvider: BasicTracerProvider | null = null;
-  let meterProvider: MeterProvider | null = null;
-  let logProvider: LoggerProvider | null = null;
-  let unsubscribe: (() => void) | null = null;
-  let unregisterTracePropagationBridge: (() => void) | null = null;
-  let stopActiveTrustedSpans: (() => void) | null = null;
-  let unregisterOwnedSdkRuntime: (() => void) | null = null;
-  let unregisterUnhandledRejectionHandler: (() => void) | null = null;
-  let retireExporterRoutes: ((preserveFailures?: boolean) => void) | null = null;
+  let state: DiagnosticsOtelState = {};
   let preserveExporterRoutesOnNextStop = false;
 
   const stopStarted = async (options?: { preserveExporterRoutes?: boolean }) => {
-    const currentUnsubscribe = unsubscribe;
-    const currentUnregisterTracePropagationBridge = unregisterTracePropagationBridge;
-    const currentLogProvider = logProvider;
-    const currentTraceProvider = traceProvider;
-    const currentMeterProvider = meterProvider;
-    const currentStopActiveTrustedSpans = stopActiveTrustedSpans;
-    const currentUnregisterOwnedSdkRuntime = unregisterOwnedSdkRuntime;
-    const currentUnregisterUnhandledRejectionHandler = unregisterUnhandledRejectionHandler;
-    const currentRetireExporterRoutes = retireExporterRoutes;
+    const current = state;
+    state = options?.preserveExporterRoutes
+      ? { retireExporterRoutes: current.retireExporterRoutes }
+      : {};
 
-    unsubscribe = null;
-    unregisterTracePropagationBridge = null;
-    logProvider = null;
-    traceProvider = null;
-    meterProvider = null;
-    stopActiveTrustedSpans = null;
-    unregisterOwnedSdkRuntime = null;
-    unregisterUnhandledRejectionHandler = null;
-    retireExporterRoutes = options?.preserveExporterRoutes ? currentRetireExporterRoutes : null;
-
-    const settle = async (...stops: Array<(() => void | Promise<void>) | null>) =>
+    const settle = async (...stops: Array<(() => void | Promise<void>) | null | undefined>) =>
       (
         await Promise.allSettled(stops.map((stop) => Promise.resolve().then(() => stop?.())))
       ).flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
     // Preserve cleanup -> provider flush -> handler removal while attempting every step per phase.
     const failures = await settle(
-      currentUnregisterTracePropagationBridge,
-      currentUnsubscribe,
-      currentStopActiveTrustedSpans,
-      currentUnregisterOwnedSdkRuntime,
+      current.unregisterTracePropagationBridge,
+      current.unsubscribe,
+      current.stopActiveTrustedSpans,
+      current.unregisterOwnedSdkRuntime,
     );
     const providerFailures = await settle(
-      currentLogProvider ? () => currentLogProvider.shutdown() : null,
-      currentTraceProvider ? () => currentTraceProvider.shutdown() : null,
-      currentMeterProvider ? () => currentMeterProvider.shutdown() : null,
+      () => current.logProvider?.shutdown(),
+      () => current.traceProvider?.shutdown(),
+      () => current.meterProvider?.shutdown(),
     );
     failures.push(...providerFailures);
     if (!options?.preserveExporterRoutes) {
-      currentRetireExporterRoutes?.(providerFailures.length > 0);
+      current.retireExporterRoutes?.(providerFailures.length > 0);
     }
     if (providerFailures.length > 0) {
       // Keep final callback failures visible until the next lifecycle call retires them.
-      retireExporterRoutes = currentRetireExporterRoutes;
+      state.retireExporterRoutes = current.retireExporterRoutes;
     }
-    failures.push(...(await settle(currentUnregisterUnhandledRejectionHandler)));
+    failures.push(...(await settle(current.unregisterUnhandledRejectionHandler)));
 
     if (failures.length === 1) {
       throw failures[0];
@@ -255,9 +244,11 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
   return {
     id: "diagnostics-otel",
+    reload: { configPrefixes: ["diagnostics.otel", "diagnostics.enabled"] },
     async start(ctx) {
       preserveExporterRoutesOnNextStop = false;
       await stopStarted();
+      const active = state;
 
       const cfg = ctx.config.diagnostics;
       const otel = cfg?.otel;
@@ -268,7 +259,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const sdkDisabled = isOtelSdkDisabled(ctx.logger);
       const sdkPreloaded = hasPreloadedOtelSdk();
       if (!sdkPreloaded) {
-        unregisterOwnedSdkRuntime = registerOwnedSdkRuntime((message) => ctx.logger.warn(message));
+        active.unregisterOwnedSdkRuntime = registerOwnedSdkRuntime((message) =>
+          ctx.logger.warn(message),
+        );
       }
       if (!sdkPreloaded && sdkDisabled) {
         return;
@@ -333,7 +326,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         return;
       }
 
-      retireExporterRoutes = (preserveFailures = false) => {
+      active.retireExporterRoutes = (preserveFailures = false) => {
         for (const route of exporterRoutes.values()) {
           if (preserveFailures && route.status === "failure") {
             continue;
@@ -474,7 +467,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               })
             : undefined;
           if (metricReader) {
-            meterProvider = new MeterProvider({
+            active.meterProvider = new MeterProvider({
               resource: detectedResource,
               readers: [metricReader],
               sdkMetricsEnabled,
@@ -503,11 +496,11 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
                   ? Math.max(1000, otel.flushIntervalMs)
                   : readPositiveOtelNumber("OTEL_BSP_SCHEDULE_DELAY", 5000),
               exportTimeoutMillis: readPositiveOtelNumber("OTEL_BSP_EXPORT_TIMEOUT", 30_000),
-              ...(sdkMetricsEnabled && meterProvider
-                ? { selfObsMeterProvider: meterProvider }
+              ...(sdkMetricsEnabled && active.meterProvider
+                ? { selfObsMeterProvider: active.meterProvider }
                 : {}),
             });
-            traceProvider = new BasicTracerProvider({
+            active.traceProvider = new BasicTracerProvider({
               resource: detectedResource,
               spanProcessors: [spanProcessor],
               ...(sampleRate !== undefined
@@ -517,7 +510,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
                     }),
                   }
                 : {}),
-              ...(sdkMetricsEnabled && meterProvider ? { meterProvider } : {}),
+              ...(sdkMetricsEnabled && active.meterProvider
+                ? { meterProvider: active.meterProvider }
+                : {}),
             });
           }
         } catch (err) {
@@ -555,14 +550,14 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
       const meter = !metricsActive
         ? createNoopMeter()
-        : meterProvider
-          ? meterProvider.getMeter("openclaw")
+        : active.meterProvider
+          ? active.meterProvider.getMeter("openclaw")
           : metrics.getMeter("openclaw");
-      const tracer = traceProvider
-        ? traceProvider.getTracer("openclaw")
+      const tracer = active.traceProvider
+        ? active.traceProvider.getTracer("openclaw")
         : trace.getTracer("openclaw");
       const diagnosticsTrace = createDiagnosticsTraceRuntime(tracer);
-      stopActiveTrustedSpans = diagnosticsTrace.stopActiveTrustedSpans;
+      active.stopActiveTrustedSpans = diagnosticsTrace.stopActiveTrustedSpans;
       const diagnosticMetrics = createDiagnosticsMetrics(meter, otel.metricNamePrefix);
 
       const diagnosticsLogs = createDiagnosticsLogExporter({
@@ -579,7 +574,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         resource,
         serviceName,
       });
-      logProvider = diagnosticsLogs.logProvider;
+      active.logProvider = diagnosticsLogs.logProvider;
       const { recordLogRecord, recordSecurityEvent } = diagnosticsLogs;
 
       const recorderRuntime = createDiagnosticsRecorderRuntime({
@@ -596,7 +591,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         ...createToolAndSystemRecorders(recorderRuntime),
       };
 
-      unsubscribe = subscribe(
+      active.unsubscribe = subscribe(
         createDiagnosticsEventHandler({
           logger: ctx.logger,
           recorders,
@@ -613,7 +608,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         // Model/tool starts are queued while their lifecycle parents dispatch
         // synchronously. Prepare these child spans before outbound propagation,
         // then let the queued recorder reuse them instead of exporting duplicates.
-        unregisterTracePropagationBridge =
+        active.unregisterTracePropagationBridge =
           ctx.internalDiagnostics?.registerTracePropagationBridge?.({
             shouldPrepareEvent(event) {
               return event.type === "model.call.started" || event.type === "tool.execution.started";
@@ -635,7 +630,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
       // Preserve the shipped preloaded-SDK crash guard, but own no handler while disabled.
       if (hasOwnedOtlpSignal || (sdkPreloaded && !sdkDisabled)) {
-        unregisterUnhandledRejectionHandler = registerUnhandledRejectionHandler((reason) => {
+        active.unregisterUnhandledRejectionHandler = registerUnhandledRejectionHandler((reason) => {
           const otlpError = findOtlpExporterError(reason);
           if (!otlpError) {
             return false;

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -20,6 +20,10 @@ import {
   startDiagnosticHeartbeat,
   stopDiagnosticHeartbeat,
 } from "openclaw/plugin-sdk/logging-core";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 // Telegram tests cover webhook plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { WEBHOOK_RATE_LIMIT_DEFAULTS } from "openclaw/plugin-sdk/webhook-ingress";
@@ -624,28 +628,57 @@ async function runNearLimitPayloadTestAndExpectUpdate(
 }
 
 describe("startTelegramWebhook", () => {
-  it.each([false, true])(
-    "uses host diagnostics and preserves its heartbeat after closing (captured enabled=%s)",
-    async (enabled) => {
+  it.each([
+    { binding: "standalone", enabled: false },
+    { binding: "standalone", enabled: true },
+    { binding: "unrelated", enabled: false },
+    { binding: "late", enabled: false },
+    { binding: "runtime", enabled: false },
+    { binding: "source", enabled: false },
+  ] as const)(
+    "respects $binding diagnostics (enabled=$enabled) and preserves the host heartbeat",
+    async ({ binding, enabled }) => {
       vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
       const events: string[] = [];
       const unsubscribe = onDiagnosticEvent((event) => events.push(event.type));
       startDiagnosticHeartbeat({}, { sampleLiveness: () => null });
+      const config = { diagnostics: { enabled } };
+      const followsRuntime = binding === "runtime" || binding === "source";
+      if (followsRuntime) {
+        setRuntimeConfigSnapshot(binding === "runtime" ? config : { ...config }, config);
+      } else if (binding === "unrelated") {
+        setRuntimeConfigSnapshot(
+          { diagnostics: { enabled: true } },
+          { logging: { level: "debug" } },
+        );
+      }
       try {
         await withStartedWebhook(
           {
             secret: TELEGRAM_SECRET,
             path: TELEGRAM_WEBHOOK_PATH,
-            config: { diagnostics: { enabled } },
+            config: binding === "source" ? structuredClone(config) : config,
           },
           async ({ port, server }) => {
-            const response = await postWebhookJson({
-              url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
-              payload: "{}",
-            });
-            expect(response.status).toBe(401);
-            await waitForDiagnosticEventsDrained();
-            expect(events.filter((event) => event === "webhook.received")).toHaveLength(1);
+            if (binding === "late") {
+              setRuntimeConfigSnapshot({ diagnostics: { enabled: true } });
+            }
+            let expectedEvents = 0;
+            for (const currentEnabled of followsRuntime ? [false, true, false] : [enabled]) {
+              if (followsRuntime) {
+                setRuntimeConfigSnapshot({ diagnostics: { enabled: currentEnabled } });
+              }
+              const response = await postWebhookJson({
+                url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+                payload: "{}",
+              });
+              expect(response.status).toBe(401);
+              await waitForDiagnosticEventsDrained();
+              expectedEvents += currentEnabled ? 1 : 0;
+              expect(events.filter((event) => event === "webhook.received")).toHaveLength(
+                expectedEvents,
+              );
+            }
             expect(server.listening).toBe(true);
             expect(initSpy).toHaveBeenCalledOnce();
           },
@@ -655,6 +688,7 @@ describe("startTelegramWebhook", () => {
         await waitForDiagnosticEventsDrained();
         expect(events.filter((event) => event === "diagnostic.heartbeat")).toHaveLength(1);
       } finally {
+        clearRuntimeConfigSnapshot();
         stopDiagnosticHeartbeat();
         unsubscribe();
       }

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -11,6 +11,15 @@ import {
   createChannelIngressQueueForTests as createChannelIngressQueue,
 } from "openclaw/plugin-sdk/channel-ingress-test-runtime";
 import { DEFAULT_INGRESS_ADOPTION_STALL_MS } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  onDiagnosticEvent,
+  waitForDiagnosticEventsDrained,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
+import {
+  logWebhookReceived,
+  startDiagnosticHeartbeat,
+  stopDiagnosticHeartbeat,
+} from "openclaw/plugin-sdk/logging-core";
 // Telegram tests cover webhook plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { WEBHOOK_RATE_LIMIT_DEFAULTS } from "openclaw/plugin-sdk/webhook-ingress";
@@ -615,6 +624,42 @@ async function runNearLimitPayloadTestAndExpectUpdate(
 }
 
 describe("startTelegramWebhook", () => {
+  it.each([false, true])(
+    "uses host diagnostics and preserves its heartbeat after closing (captured enabled=%s)",
+    async (enabled) => {
+      vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+      const events: string[] = [];
+      const unsubscribe = onDiagnosticEvent((event) => events.push(event.type));
+      startDiagnosticHeartbeat({}, { sampleLiveness: () => null });
+      try {
+        await withStartedWebhook(
+          {
+            secret: TELEGRAM_SECRET,
+            path: TELEGRAM_WEBHOOK_PATH,
+            config: { diagnostics: { enabled } },
+          },
+          async ({ port, server }) => {
+            const response = await postWebhookJson({
+              url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+              payload: "{}",
+            });
+            expect(response.status).toBe(401);
+            await waitForDiagnosticEventsDrained();
+            expect(events.filter((event) => event === "webhook.received")).toHaveLength(1);
+            expect(server.listening).toBe(true);
+            expect(initSpy).toHaveBeenCalledOnce();
+          },
+        );
+        logWebhookReceived({ channel: "host" });
+        await vi.advanceTimersByTimeAsync(30_000);
+        await waitForDiagnosticEventsDrained();
+        expect(events.filter((event) => event === "diagnostic.heartbeat")).toHaveLength(1);
+      } finally {
+        stopDiagnosticHeartbeat();
+        unsubscribe();
+      }
+    },
+  );
   it("starts server, registers webhook, and serves health", async () => {
     initSpy.mockClear();
     createTelegramBotSpy.mockClear();

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -5,13 +5,10 @@ import net from "node:net";
 import { InputFile } from "grammy";
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { isDiagnosticsEnabled } from "openclaw/plugin-sdk/diagnostic-runtime";
 import {
   logWebhookError,
   logWebhookProcessed,
   logWebhookReceived,
-  startDiagnosticHeartbeat,
-  stopDiagnosticHeartbeat,
 } from "openclaw/plugin-sdk/logging-core";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { BackoffPolicy, RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -337,12 +334,10 @@ export async function startTelegramWebhook(opts: {
   status.noteWebhookStart();
   const webhookRegistrationRetryPolicy =
     opts.webhookRegistrationRetryPolicy ?? TELEGRAM_WEBHOOK_REGISTRATION_RETRY_POLICY;
-  const diagnosticsEnabled = isDiagnosticsEnabled(opts.config);
   const spoolDir = opts.spoolDir ?? resolveTelegramIngressSpoolDir({ accountId: opts.accountId });
   let shutDown = false;
   let ownedServer: ReturnType<typeof createServer> | undefined = undefined;
   let webhookIngressMonitor: ReturnType<typeof createTelegramTransportIngressMonitor> | undefined;
-  let diagnosticsStarted = false;
   const shutdownAbortController = new AbortController();
   const telegramAccountConfig = opts.config
     ? mergeTelegramAccountConfig(opts.config, opts.accountId ?? "default")
@@ -408,9 +403,6 @@ export async function startTelegramWebhook(opts: {
     await runShutdownPhase("transport close", closeTransportOnce);
     await runShutdownPhase("ingress drain", () => waitForWebhookIngressStop(ingressStopTask));
     await runShutdownPhase("status update", () => status.noteWebhookStop());
-    if (diagnosticsStarted) {
-      await runShutdownPhase("diagnostics stop", () => stopDiagnosticHeartbeat());
-    }
   };
   const runStartupPhase = async <T>(run: () => T | Promise<T>): Promise<T> => {
     try {
@@ -441,10 +433,6 @@ export async function startTelegramWebhook(opts: {
     maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
     maxTrackedKeys: WEBHOOK_RATE_LIMIT_DEFAULTS.maxTrackedKeys,
   });
-  if (diagnosticsEnabled) {
-    startDiagnosticHeartbeat(opts.config);
-    diagnosticsStarted = true;
-  }
 
   const log = (line: string) => runtime.log?.(line);
   const startWebhookSpoolDrain = () => {
@@ -491,9 +479,7 @@ export async function startTelegramWebhook(opts: {
       return;
     }
     const startTime = Date.now();
-    if (diagnosticsEnabled) {
-      logWebhookReceived({ channel: "telegram", updateType: "telegram-post" });
-    }
+    logWebhookReceived({ channel: "telegram", updateType: "telegram-post" });
     const secretHeader = resolveSingleHeaderValue(req.headers["x-telegram-bot-api-secret-token"]);
     if (!hasValidTelegramWebhookSecret(secretHeader, secret)) {
       // Authenticated Telegram delivery must not consume the abuse budget. Only
@@ -550,22 +536,18 @@ export async function startTelegramWebhook(opts: {
       res.setHeader(TELEGRAM_WEBHOOK_ACCEPTED_HEADER, TELEGRAM_WEBHOOK_ACCEPTED_VALUE);
       respondText(200);
       status.noteWebhookUpdateReceived();
-      if (diagnosticsEnabled) {
-        logWebhookProcessed({
-          channel: "telegram",
-          updateType: "telegram-post",
-          durationMs: Date.now() - startTime,
-        });
-      }
+      logWebhookProcessed({
+        channel: "telegram",
+        updateType: "telegram-post",
+        durationMs: Date.now() - startTime,
+      });
     })().catch((err: unknown) => {
       const errMsg = formatErrorMessage(err);
-      if (diagnosticsEnabled) {
-        logWebhookError({
-          channel: "telegram",
-          updateType: "telegram-post",
-          error: errMsg,
-        });
-      }
+      logWebhookError({
+        channel: "telegram",
+        updateType: "telegram-post",
+        error: errMsg,
+      });
       runtime.log?.(`webhook request failed: ${errMsg}`);
       respondText(500);
     });

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -5,12 +5,14 @@ import net from "node:net";
 import { InputFile } from "grammy";
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { isDiagnosticsEnabled } from "openclaw/plugin-sdk/diagnostic-runtime";
 import {
   logWebhookError,
   logWebhookProcessed,
   logWebhookReceived,
 } from "openclaw/plugin-sdk/logging-core";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
+import { createRuntimeConfigReader } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import type { BackoffPolicy, RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {
   computeBackoff,
@@ -315,6 +317,7 @@ export async function startTelegramWebhook(opts: {
   spoolDir?: string;
   setStatus?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
 }) {
+  const readConfig = createRuntimeConfigReader(opts.config ?? {});
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
   if (path === healthPath) {
@@ -479,7 +482,9 @@ export async function startTelegramWebhook(opts: {
       return;
     }
     const startTime = Date.now();
-    logWebhookReceived({ channel: "telegram", updateType: "telegram-post" });
+    if (isDiagnosticsEnabled(readConfig())) {
+      logWebhookReceived({ channel: "telegram", updateType: "telegram-post" });
+    }
     const secretHeader = resolveSingleHeaderValue(req.headers["x-telegram-bot-api-secret-token"]);
     if (!hasValidTelegramWebhookSecret(secretHeader, secret)) {
       // Authenticated Telegram delivery must not consume the abuse budget. Only
@@ -536,18 +541,22 @@ export async function startTelegramWebhook(opts: {
       res.setHeader(TELEGRAM_WEBHOOK_ACCEPTED_HEADER, TELEGRAM_WEBHOOK_ACCEPTED_VALUE);
       respondText(200);
       status.noteWebhookUpdateReceived();
-      logWebhookProcessed({
-        channel: "telegram",
-        updateType: "telegram-post",
-        durationMs: Date.now() - startTime,
-      });
+      if (isDiagnosticsEnabled(readConfig())) {
+        logWebhookProcessed({
+          channel: "telegram",
+          updateType: "telegram-post",
+          durationMs: Date.now() - startTime,
+        });
+      }
     })().catch((err: unknown) => {
       const errMsg = formatErrorMessage(err);
-      logWebhookError({
-        channel: "telegram",
-        updateType: "telegram-post",
-        error: errMsg,
-      });
+      if (isDiagnosticsEnabled(readConfig())) {
+        logWebhookError({
+          channel: "telegram",
+          updateType: "telegram-post",
+          error: errMsg,
+        });
+      }
       runtime.log?.(`webhook request failed: ${errMsg}`);
       respondText(500);
     });

--- a/qa/scenarios/observability/otel-generation-config-watcher.yaml
+++ b/qa/scenarios/observability/otel-generation-config-watcher.yaml
@@ -11,7 +11,7 @@ scenario:
     secondary:
       - gateway.restart-and-stop-gateway-restart
       - observability.trace-correlation-fields
-  objective: Prove a watched OTEL endpoint change replaces one private provider generation with another inside the same Gateway PID.
+  objective: Prove a mixed watched OTEL endpoint and restart-owned Control UI path edit replaces one private provider generation with another inside the same Gateway PID.
   successCriteria:
     - Collector A receives correlated traces, metrics, and logs before the watched config mutation.
     - The config watcher performs an OPENCLAW_NO_RESPAWN in-process restart without changing the Gateway PID.
@@ -41,4 +41,4 @@ scenario:
       - --output-dir
       - ${outputDir}
     timeoutMs: 300000
-    summary: Same-PID watched endpoint replacement with isolated trace, metric, and log exports.
+    summary: Same-PID mixed restart-required edit with isolated trace, metric, and log exports.

--- a/src/config/runtime-snapshot.test.ts
+++ b/src/config/runtime-snapshot.test.ts
@@ -158,8 +158,6 @@ describe("runtime snapshot state", () => {
 
       const readUnbound = createRuntimeConfigReader(scopedResolvedConfig);
 
-      const readUnbound = createRuntimeConfigReader(scopedResolvedConfig);
-
       expect(
         selectApplicableRuntimeConfig({
           inputConfig: cloneConfigWithResolutionFacts(sourceConfig),

--- a/src/config/runtime-snapshot.test.ts
+++ b/src/config/runtime-snapshot.test.ts
@@ -158,6 +158,8 @@ describe("runtime snapshot state", () => {
 
       const readUnbound = createRuntimeConfigReader(scopedResolvedConfig);
 
+      const readUnbound = createRuntimeConfigReader(scopedResolvedConfig);
+
       expect(
         selectApplicableRuntimeConfig({
           inputConfig: cloneConfigWithResolutionFacts(sourceConfig),

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -304,7 +304,9 @@ function getReloadPolicyCatalog() {
   ];
   const expand = (items: ReloadPolicy[]): ReloadRule[] =>
     items.flatMap(({ prefixes, ...policy }) => prefixes.map((prefix) => ({ ...policy, prefix })));
-  const ownedRules = expand(policies).toSorted((a, b) => b.prefix.length - a.prefix.length);
+  const ownedRules = expand([...policies, ...DEFAULT_RELOAD_POLICIES]).toSorted(
+    (a, b) => b.prefix.length - a.prefix.length,
+  );
   const rules = [
     ...ownedRules,
     // Narrow service declarations retain existing owner actions, including
@@ -316,7 +318,6 @@ function getReloadPolicyCatalog() {
         prefix,
       })),
     ),
-    ...expand(DEFAULT_RELOAD_POLICIES),
   ];
   for (const rule of rules) {
     rule.services = servicePolicies

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -31,6 +31,7 @@ export type GatewayReloadPlan = {
   reconcileSystemJobs?: boolean;
   reloadPlugins: boolean;
   restartChannels: Set<ChannelKind>;
+  restartServices?: Set<string>;
   disposeMcpRuntimes: boolean;
   /** Account targets; absent means no targeted restarts for hand-built plans. */
   restartChannelAccounts?: Map<ChannelKind, Set<string>>;
@@ -56,6 +57,7 @@ export function isNoopGatewayReloadPlan(plan: GatewayReloadPlan): boolean {
     plan.hotReasons.length === 0 &&
     RELOAD_ACTIONS.every((action) => !plan[action]) &&
     plan.restartChannels.size === 0 &&
+    (plan.restartServices?.size ?? 0) === 0 &&
     (plan.restartChannelAccounts?.size ?? 0) === 0
   );
 }
@@ -65,6 +67,7 @@ type ReloadPolicy = {
   kind: "restart" | "hot" | "none";
   actions?: readonly ReloadAction[];
   channels?: readonly ChannelPlugin[];
+  services?: readonly string[];
   accountScoped?: boolean;
 };
 type ReloadRule = Omit<ReloadPolicy, "prefixes"> & { prefix: string };
@@ -124,6 +127,7 @@ const CORE_RELOAD_POLICIES: ReloadPolicy[] = [
       "gateway.push.apns.relay",
       "gateway.terminal",
       "gateway.auth.rateLimit",
+      "diagnostics.enabled",
       "discovery.mdns.mode",
       "mcp.apps.sandboxOrigin",
       "agents.defaults",
@@ -227,7 +231,6 @@ const DEFAULT_RELOAD_POLICIES: ReloadPolicy[] = [
     ],
     kind: "hot",
   },
-  { prefixes: ["session.scope", "session.store"], kind: "hot", actions: ["refreshHooksPolicy"] },
   { prefixes: ["plugins"], kind: "hot", actions: ["reloadPlugins", "disposeMcpRuntimes"] },
   { prefixes: ["gateway", "discovery"], kind: "restart" },
 ];
@@ -249,6 +252,10 @@ function getReloadPolicyCatalog() {
     return cachedCatalog;
   }
   const channelPlugins = listChannelPlugins();
+  const servicePolicies = (registry?.services ?? []).map(({ service }) => ({
+    prefixes: service.reload?.configPrefixes ?? [],
+    services: [service.id],
+  }));
   const policies: ReloadPolicy[] = [
     ...CORE_RELOAD_POLICIES,
     ...(registry?.reloads ?? []).flatMap(({ registration }) =>
@@ -293,11 +300,29 @@ function getReloadPolicyCatalog() {
       kind: "hot",
       channels: channelPlugins,
     },
-    ...DEFAULT_RELOAD_POLICIES,
+    { prefixes: ["session.scope", "session.store"], kind: "hot", actions: ["refreshHooksPolicy"] },
   ];
-  const rules = policies.flatMap(({ prefixes, ...policy }) =>
-    prefixes.map((prefix) => ({ ...policy, prefix })),
-  );
+  const expand = (items: ReloadPolicy[]): ReloadRule[] =>
+    items.flatMap(({ prefixes, ...policy }) => prefixes.map((prefix) => ({ ...policy, prefix })));
+  const ownedRules = expand(policies).toSorted((a, b) => b.prefix.length - a.prefix.length);
+  const rules = [
+    ...ownedRules,
+    // Narrow service declarations retain existing owner actions, including
+    // channel account targeting, while supplying their own hot classification.
+    ...servicePolicies.flatMap(({ prefixes }) =>
+      prefixes.map((prefix): ReloadRule => ({
+        ...ownedRules.find((owner) => matchesPrefix(prefix, owner.prefix)),
+        kind: "hot",
+        prefix,
+      })),
+    ),
+    ...expand(DEFAULT_RELOAD_POLICIES),
+  ];
+  for (const rule of rules) {
+    rule.services = servicePolicies
+      .filter((service) => service.prefixes.some((owner) => matchesPrefix(rule.prefix, owner)))
+      .flatMap((service) => service.services);
+  }
   // Narrow config contracts must override broad owner fallbacks. Sort once per
   // registry snapshot so the hot path can retain first-match semantics.
   rules.sort((a, b) => b.prefix.length - a.prefix.length);
@@ -314,10 +339,12 @@ export function listConfigReloadRefinementPrefixes(): string[] {
   return getReloadPolicyCatalog().refinementPrefixes;
 }
 
+function matchesPrefix(path: string, prefix: string): boolean {
+  return path === prefix || path.startsWith(`${prefix}.`);
+}
+
 function matchRule(path: string): ReloadRule | undefined {
-  return getReloadPolicyCatalog().rules.find(
-    ({ prefix }) => path === prefix || path.startsWith(`${prefix}.`),
-  );
+  return getReloadPolicyCatalog().rules.find(({ prefix }) => matchesPrefix(path, prefix));
 }
 
 export function resolveConfigReloadMetadata(path: string): ConfigReloadMetadata {
@@ -447,6 +474,7 @@ export function buildGatewayReloadPlan(
     reconcileSystemJobs: false,
     reloadPlugins: false,
     restartChannels: new Set(),
+    restartServices: new Set(),
     disposeMcpRuntimes: false,
     restartChannelAccounts,
     noopPaths: [],
@@ -478,6 +506,9 @@ export function buildGatewayReloadPlan(
     plan.hotReasons.push(path);
     for (const action of rule?.actions ?? []) {
       plan[action] = true;
+    }
+    for (const service of rule?.services ?? []) {
+      plan.restartServices?.add(service);
     }
     for (const plugin of rule?.channels ?? []) {
       const accountId = rule?.accountScoped ? extractAccountIdFromPath(plugin.id, path) : null;

--- a/src/gateway/config-reload-recovery.ts
+++ b/src/gateway/config-reload-recovery.ts
@@ -100,6 +100,7 @@ export function reloadPlanNeedsRecovery(plan: GatewayReloadPlan): boolean {
     plan.restartCron ||
     plan.restartGmailWatcher ||
     plan.reloadPlugins ||
+    (plan.restartServices?.size ?? 0) > 0 ||
     plan.restartChannels.size > 0 ||
     (plan.restartChannelAccounts?.size ?? 0) > 0 ||
     shouldRefreshContextWindowCache(plan)

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -289,6 +289,50 @@ describe("diffConfigPaths", () => {
 
 describe("buildGatewayReloadPlan", () => {
   const emptyRegistry = createTestRegistry([]);
+  it("selects only attached service owners for their declared config and preserves unknown restart policy", () => {
+    const serviceRegistry = createTestRegistry([]);
+    serviceRegistry.services.push({
+      pluginId: "exporter",
+      source: "test",
+      origin: "workspace",
+      service: {
+        id: "exporter",
+        reload: { configPrefixes: ["diagnostics.otel", "diagnostics.enabled"] },
+        start() {},
+      },
+    });
+    setActivePluginRegistry(serviceRegistry);
+    const plan = buildGatewayReloadPlan(["diagnostics.otel.endpoint", "diagnostics.enabled"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartServices).toEqual(new Set(["exporter"]));
+    expect(plan.reloadPlugins).toBe(false);
+    expect(plan.restartChannels.size).toBe(0);
+    expect(resolveConfigReloadMetadata("diagnostics.otel.endpoint")).toEqual({ kind: "hot" });
+    expect(buildGatewayReloadPlan(["diagnostics.futurePolicy"]).restartGateway).toBe(true);
+    setActivePluginRegistry(emptyRegistry);
+    expect(buildGatewayReloadPlan(["diagnostics.otel.endpoint"]).restartGateway).toBe(true);
+  });
+  it("selects every service sharing a changed policy, including broader owners", () => {
+    const registry = createTestRegistry([]);
+    for (const [id, prefix] of [
+      ["parent", "shared.policy"],
+      ["first", "shared.policy.child"],
+      ["second", "shared.policy.child"],
+      ["sibling", "shared.other"],
+    ] as const) {
+      registry.services.push({
+        pluginId: id,
+        source: "test",
+        origin: "workspace",
+        service: { id, reload: { configPrefixes: [prefix] }, start() {} },
+      });
+    }
+    setActivePluginRegistry(registry);
+    expect(buildGatewayReloadPlan(["shared.policy.child.enabled"]).restartServices).toEqual(
+      new Set(["parent", "first", "second"]),
+    );
+    setActivePluginRegistry(emptyRegistry);
+  });
   const telegramPlugin: ChannelPlugin = {
     id: "telegram",
     meta: {
@@ -345,6 +389,50 @@ describe("buildGatewayReloadPlan", () => {
     { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
     { pluginId: "mattermost", plugin: mattermostPlugin, source: "test" },
   ]);
+  it.each([
+    { prefix: "channels.whatsapp", kind: "none", services: [] },
+    { prefix: "channels.whatsapp.exporter", kind: "hot", services: ["exporter"] },
+  ] as const)(
+    "preserves explicit policy precedence for service $prefix",
+    ({ prefix, kind, services }) => {
+      const serviceRegistry = createTestRegistry([
+        { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
+      ]);
+      serviceRegistry.services.push({
+        pluginId: "exporter",
+        source: "test",
+        origin: "workspace",
+        service: { id: "exporter", reload: { configPrefixes: [prefix] }, start() {} },
+      });
+      setActivePluginRegistry(serviceRegistry);
+      expect(resolveConfigReloadMetadata(`${prefix}.enabled`)).toEqual({ kind });
+      expect(buildGatewayReloadPlan([`${prefix}.enabled`]).restartServices).toEqual(
+        new Set(services),
+      );
+      setActivePluginRegistry(emptyRegistry);
+    },
+  );
+  it.each(["channels.mattermost", "channels.mattermost.accounts.work"])(
+    "preserves channel account ownership when a service reloads %s",
+    (prefix) => {
+      const serviceRegistry = createTestRegistry([
+        { pluginId: "mattermost", plugin: mattermostPlugin, source: "test" },
+      ]);
+      serviceRegistry.services.push({
+        pluginId: "exporter",
+        source: "test",
+        origin: "workspace",
+        service: { id: "exporter", reload: { configPrefixes: [prefix] }, start() {} },
+      });
+      setActivePluginRegistry(serviceRegistry);
+      const plan = buildGatewayReloadPlan(["channels.mattermost.accounts.work.token"]);
+      expect(plan.restartServices).toEqual(new Set(["exporter"]));
+      expect(plan.restartChannelAccounts).toEqual(new Map([["mattermost", new Set(["work"])]]));
+      expect(plan.restartChannels.size).toBe(0);
+      expect(plan.restartGateway).toBe(false);
+      setActivePluginRegistry(emptyRegistry);
+    },
+  );
   registry.reloads = [
     {
       pluginId: "browser",
@@ -428,7 +516,6 @@ describe("buildGatewayReloadPlan", () => {
     "plugins.load.paths.0",
     "gateway.auth.mode",
     "discovery.wideArea.domain",
-    "diagnostics.enabled",
     "diagnostics.otel.endpoint",
     "acp.backend",
     "memory.search.enabled",
@@ -891,6 +978,8 @@ describe("buildGatewayReloadPlan", () => {
       ...sharedChannelSettings.map(({ path }) => path),
       "channels.defaults.groupPolicy",
       "channels.modelByChannel.telegram",
+      "session.scope",
+      "session.store",
     ].flatMap((path) => [
       { path, registration: { restartPrefixes: [path] }, kind: "restart" },
       { path, registration: { hotPrefixes: [path] }, kind: "hot" },

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -390,28 +390,45 @@ describe("buildGatewayReloadPlan", () => {
     { pluginId: "mattermost", plugin: mattermostPlugin, source: "test" },
   ]);
   it.each([
-    { prefix: "channels.whatsapp", kind: "none", services: [] },
-    { prefix: "channels.whatsapp.exporter", kind: "hot", services: ["exporter"] },
-  ] as const)(
-    "preserves explicit policy precedence for service $prefix",
-    ({ prefix, kind, services }) => {
-      const serviceRegistry = createTestRegistry([
-        { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
-      ]);
-      serviceRegistry.services.push({
-        pluginId: "exporter",
-        source: "test",
-        origin: "workspace",
-        service: { id: "exporter", reload: { configPrefixes: [prefix] }, start() {} },
-      });
-      setActivePluginRegistry(serviceRegistry);
-      expect(resolveConfigReloadMetadata(`${prefix}.enabled`)).toEqual({ kind });
-      expect(buildGatewayReloadPlan([`${prefix}.enabled`]).restartServices).toEqual(
-        new Set(services),
-      );
-      setActivePluginRegistry(emptyRegistry);
+    { prefix: "gateway", path: "gateway.port", kind: "restart", services: [] },
+    { prefix: "discovery", path: "discovery.wideArea.enabled", kind: "restart", services: [] },
+    { prefix: "logging", path: "logging.level", kind: "none", services: [] },
+    { prefix: "mcp", path: "mcp.apps.enabled", kind: "restart", services: [] },
+    {
+      prefix: "plugins",
+      path: "plugins.entries.exporter.enabled",
+      kind: "hot",
+      services: ["exporter"],
     },
-  );
+    { prefix: "channels.whatsapp", path: "channels.whatsapp.enabled", kind: "none", services: [] },
+    {
+      prefix: "channels.whatsapp.exporter",
+      path: "channels.whatsapp.exporter.enabled",
+      kind: "hot",
+      services: ["exporter"],
+    },
+  ] as const)("preserves explicit policy precedence for service $prefix", (entry) => {
+    const { prefix, path: changedPath, kind, services } = entry;
+    const serviceRegistry = createTestRegistry([
+      { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
+    ]);
+    serviceRegistry.services.push({
+      pluginId: "exporter",
+      source: "test",
+      origin: "workspace",
+      service: { id: "exporter", reload: { configPrefixes: [prefix] }, start() {} },
+    });
+    setActivePluginRegistry(serviceRegistry);
+    expect(resolveConfigReloadMetadata(changedPath)).toEqual({ kind });
+    const plan = buildGatewayReloadPlan([changedPath]);
+    expect(plan.restartGateway).toBe(kind === "restart");
+    expect(plan.restartServices).toEqual(new Set(services));
+    if (prefix === "plugins") {
+      expect(plan.reloadPlugins).toBe(true);
+      expect(plan.disposeMcpRuntimes).toBe(true);
+    }
+    setActivePluginRegistry(emptyRegistry);
+  });
   it.each(["channels.mattermost", "channels.mattermost.accounts.work"])(
     "preserves channel account ownership when a service reloads %s",
     (prefix) => {

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -868,6 +868,7 @@ describe("createGatewayCloseHandler", () => {
     });
     const pluginCleanup = createDeferredCore();
     const pluginServices = {
+      reload: vi.fn(async () => {}),
       stop: vi.fn(() => pluginCleanup.promise),
     };
     const stopChannel = vi.fn(async () => undefined);

--- a/src/gateway/server-kernel.ts
+++ b/src/gateway/server-kernel.ts
@@ -179,7 +179,6 @@ export async function createGatewayKernel(
         port,
         log,
         logCron,
-        diagnosticsEnabled: bootstrap.diagnosticsEnabled,
         shutdownRuntime,
       }),
     );

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -3,6 +3,11 @@ import { fenceSessionSuspensionWritesForGatewayShutdown } from "../agents/sessio
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import { listLoadedChannelPluginsForRegistry } from "../channels/plugins/registry-loaded.js";
 import { getRuntimeConfig } from "../config/io.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  isDiagnosticsEnabled,
+  setDiagnosticsEnabledForProcess,
+} from "../infra/diagnostic-events.js";
 import { upsertPresence } from "../infra/system-presence.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
@@ -50,10 +55,9 @@ export async function prepareGatewayLifecycle(params: {
   port: number;
   log: GatewayLogger;
   logCron: GatewayLogger;
-  diagnosticsEnabled: boolean;
   shutdownRuntime: GatewayShutdownRuntime;
 }) {
-  const { runtime, port, log, logCron, diagnosticsEnabled, shutdownRuntime } = params;
+  const { runtime, port, log, logCron, shutdownRuntime } = params;
   const requestEntryLifetime = new GatewayRequestEntryLifetime();
   const {
     minimalTestGateway,
@@ -430,7 +434,7 @@ export async function prepareGatewayLifecycle(params: {
     disposeNodeConnectionNotifications(nodeRegistry);
     watchNodeHttpRuntime.close();
     await shutdownRuntime.runGatewayClosePrelude({
-      ...(diagnosticsEnabled ? { stopDiagnostics: stopDiagnosticHeartbeat } : {}),
+      stopDiagnostics: stopDiagnosticHeartbeat,
       clearSkillsRefreshTimer: () => {
         if (!runtimeState?.skillsRefreshTimer) {
           return;
@@ -617,7 +621,16 @@ export async function prepareGatewayLifecycle(params: {
     });
   };
 
-  if (diagnosticsEnabled) {
+  const configureDiagnostics = (config: OpenClawConfig) => {
+    if (lifecycle.closePreludeStarted) {
+      return;
+    }
+    const enabled = isDiagnosticsEnabled(config);
+    setDiagnosticsEnabledForProcess(enabled);
+    if (!enabled) {
+      stopDiagnosticHeartbeat();
+      return;
+    }
     // Gateway lifecycle owns both this existing heartbeat timer and the monitor
     // it samples, so startup failure and normal close tear them down together.
     startDiagnosticHeartbeat(undefined, {
@@ -639,10 +652,12 @@ export async function prepareGatewayLifecycle(params: {
         };
       },
     });
-  }
+  };
+  configureDiagnostics(cfgAtStart);
 
   return {
     ...runtime,
+    configureDiagnostics,
     requestEntryLifetime,
     subscribeSessionMessageEvents,
     unsubscribeSessionMessageEvents,

--- a/src/gateway/server-plugin-runtime-generation.test.ts
+++ b/src/gateway/server-plugin-runtime-generation.test.ts
@@ -37,7 +37,10 @@ describe("Gateway plugin runtime generation", () => {
     expect(acceptedReplacement.claim.publish(published)).toBe(true);
     expect(published).toHaveBeenCalledTimes(2);
 
-    const winningServices: PluginServicesHandle = { stop: vi.fn(async () => {}) };
+    const winningServices: PluginServicesHandle = {
+      reload: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+    };
     expect(owner.publishServices(startupClaim, winningServices)).toBe(false);
     expect(owner.publishServices(acceptedReplacement.claim, winningServices)).toBe(true);
     expect(owner.currentServices()).toBe(winningServices);
@@ -57,7 +60,7 @@ describe("Gateway plugin runtime generation", () => {
     replacement.retirePrevious();
     replacement.reject();
     await expect(previousUnblocked).resolves.toBe(false);
-    const services = { stop: vi.fn(async () => {}) };
+    const services = { reload: vi.fn(async () => {}), stop: vi.fn(async () => {}) };
     expect(owner.publishServices(previous, services)).toBe(false);
     const cancelledRetry = owner.reserve();
     cancelledRetry.reject();
@@ -88,7 +91,10 @@ describe("Gateway plugin runtime generation", () => {
       committed.commit();
       const pendingSuccessor = owner.reserve();
       const discoveryStop = vi.fn();
-      const services: PluginServicesHandle = { stop: vi.fn(async () => {}) };
+      const services: PluginServicesHandle = {
+        reload: vi.fn(async () => {}),
+        stop: vi.fn(async () => {}),
+      };
       let settled = false;
       const publication = committed.claim.waitForUnblocked().then((isCurrent) => {
         settled = true;

--- a/src/gateway/server-reload-contracts.ts
+++ b/src/gateway/server-reload-contracts.ts
@@ -147,6 +147,7 @@ export type GatewayReloadHandlerParams = {
   pruneInactiveChannelAccountState: (activeChannelIds: ReadonlySet<ChannelKind>) => void;
   getChannelAutostartSuppression?: GatewayChannelManager["getAutostartSuppression"];
   stopPostReadySidecars?: () => Promise<void> | void;
+  reloadPluginServices?: (config: OpenClawConfig, serviceIds: ReadonlySet<string>) => Promise<void>;
   reloadPlugins: (params: {
     nextConfig: OpenClawConfig;
     sourceConfig: OpenClawConfig;

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -2792,6 +2792,112 @@ describe("gateway hot reload model state", () => {
   });
 });
 
+describe("gateway targeted service reload", () => {
+  it("forwards the service owner through managed config publication", async () => {
+    vi.useFakeTimers();
+    const registry = createTestRegistry([]);
+    registry.services.push({
+      pluginId: "exporter",
+      source: "test",
+      origin: "workspace",
+      service: { id: "exporter", reload: { configPrefixes: ["diagnostics.otel"] }, start() {} },
+    });
+    setActivePluginRegistry(registry);
+    const initialConfig: OpenClawConfig = { diagnostics: { otel: { enabled: true } } };
+    const nextConfig: OpenClawConfig = { diagnostics: { otel: { enabled: false } } };
+    const listener = createConfigWriteListenerRef();
+    const reloadPluginServices = vi.fn(async () => {});
+    const reloader = startManagedGatewayConfigReloader({
+      initialConfig,
+      readSnapshot: async () => createValidConfigSnapshot(nextConfig, "otel-disabled"),
+      subscribeToWrites: captureConfigWriteListener(listener),
+      reloadPluginServices,
+    });
+    try {
+      const application = createRuntimeConfigWriteApplication();
+      if (!listener.current) {
+        throw new Error("Expected managed config write listener");
+      }
+      listener.current(
+        attachRuntimeConfigWriteApplication(
+          createConfigWriteNotification(nextConfig, "otel-disabled", 1, "runtime", "source"),
+          application,
+        ),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      await expect(application.result).resolves.toBe("applied");
+      expect(reloadPluginServices).toHaveBeenCalledExactlyOnceWith(
+        nextConfig,
+        new Set(["exporter"]),
+      );
+    } finally {
+      await reloader.stop();
+    }
+  });
+
+  it.each(["targeted", "full plugin", "service failure", "publication failure"] as const)(
+    "keeps committed service replacement and recovery ordered: %s",
+    async (mode) => {
+      vi.useFakeTimers();
+      const events: string[] = [];
+      const nextConfig: OpenClawConfig = { diagnostics: { otel: { enabled: false } } };
+      const selected = new Set(["exporter"]);
+      const failure = new Error(mode);
+      const requestRecoveryRestart = vi.fn(() => ({ status: "emitted" as const }));
+      const reloadPluginServices = vi.fn(async () => {
+        events.push("service");
+        if (mode === "service failure") {
+          throw failure;
+        }
+      });
+      const handlers = createGatewayReloadHandlers({
+        reloadPluginServices,
+        requestRecoveryRestart,
+        reloadPlugins: async ({ commitRuntime }) => {
+          await commitRuntime();
+          events.push("plugins");
+          return makePluginReloadResult();
+        },
+      });
+      try {
+        const applying = handlers.applyHotReload(
+          createHotTailPlan({ restartServices: selected, reloadPlugins: mode === "full plugin" }),
+          nextConfig,
+          {
+            sourceConfig: nextConfig,
+            isCurrent: () => true,
+            publish: async (commit) => {
+              if (mode === "publication failure") {
+                throw failure;
+              }
+              await commit();
+              events.push("published");
+            },
+          },
+        );
+        if (mode === "publication failure") {
+          await expect(applying).rejects.toBe(failure);
+          expect(events).toEqual([]);
+        } else {
+          await expect(applying).resolves.toBe(
+            mode === "service failure" ? "applied-restart-required" : "applied",
+          );
+          expect(events).toEqual(["published", mode === "full plugin" ? "plugins" : "service"]);
+        }
+        if (mode === "targeted" || mode === "service failure") {
+          expect(reloadPluginServices).toHaveBeenCalledExactlyOnceWith(nextConfig, selected);
+        } else {
+          expect(reloadPluginServices).not.toHaveBeenCalled();
+        }
+        await vi.advanceTimersByTimeAsync(500);
+        expect(requestRecoveryRestart).toHaveBeenCalledTimes(mode === "service failure" ? 1 : 0);
+      } finally {
+        handlers.stopRestartRetries();
+      }
+    },
+  );
+});
+
 describe("gateway hot reload superseded tail recovery", () => {
   it("rearms detached stale-tail recovery against an already accepted config", async () => {
     vi.useFakeTimers();

--- a/src/gateway/server-reload-hot.ts
+++ b/src/gateway/server-reload-hot.ts
@@ -530,6 +530,18 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       return "applied-restart-required";
     }
 
+    if (!plan.reloadPlugins && plan.restartServices?.size) {
+      try {
+        if (!params.reloadPluginServices) {
+          throw new Error("Plugin service reload owner is unavailable");
+        }
+        await params.reloadPluginServices(nextConfig, plan.restartServices);
+      } catch (err) {
+        scheduleRecoveryRestart("plugin services reload", err);
+        return "applied-restart-required";
+      }
+    }
+
     try {
       await mrReload.refreshModelRuntimeAfterHotReload({
         config: nextConfig,

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -149,36 +149,14 @@ export function startManagedGatewayConfigReloader(
     restoreConservativeRestartDebt,
     stopRestartRetries,
   } = createGatewayReloadHandlers({
-    deps: params.deps,
-    broadcast: params.broadcast,
-    ...(params.resolveGatewayContext
-      ? { resolveGatewayContext: params.resolveGatewayContext }
-      : {}),
-    getState: params.getState,
-    setState: params.setState,
-    getPluginMetadataSnapshot: params.getPluginMetadataSnapshot,
-    getPluginRegistry: params.getPluginRegistry,
-    startChannel: params.startChannel,
-    stopChannel: params.stopChannel,
+    ...params,
     pruneInactiveChannelAccountState: params.channelManager.pruneInactiveChannelAccountState,
-    getChannelAutostartSuppression: params.getChannelAutostartSuppression,
-    stopPostReadySidecars: params.stopPostReadySidecars,
-    reloadPlugins: params.reloadPlugins,
-    logHooks: params.logHooks,
-    logChannels: params.logChannels,
-    logCron: params.logCron,
-    logReload: params.logReload,
-    cronReconciliation: params.cronReconciliation,
     createGmailRestartAbortController,
     clearGmailRestartAbortController: (abortController) => {
       if (activeGmailRestartAbortController === abortController) {
         activeGmailRestartAbortController = null;
       }
     },
-    ...(params.onCronRestart ? { onCronRestart: params.onCronRestart } : {}),
-    ...(params.requestRecoveryRestart
-      ? { requestRecoveryRestart: params.requestRecoveryRestart }
-      : {}),
     assertRestartReady: () =>
       import("../state/openclaw-database-preflight.js").then(({ assertOpenClawDatabasesReady }) =>
         assertOpenClawDatabasesReady({ env: process.env, operation: "gateway-restart" }),

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -330,8 +330,7 @@ export async function prepareGatewayServerBootstrap(input: {
   const reloadAuthOverride = authBootstrap.generatedToken
     ? mergeGatewayAuthConfig(resolvedStartupAuthOverride, { token: authBootstrap.generatedToken })
     : resolvedStartupAuthOverride;
-  const diagnosticsEnabled = isDiagnosticsEnabled(cfgAtStart);
-  setDiagnosticsEnabledForProcess(diagnosticsEnabled);
+  setDiagnosticsEnabledForProcess(isDiagnosticsEnabled(cfgAtStart));
   setGatewaySigusr1RestartPolicy({ allowExternal: isRestartEnabled(cfgAtStart) });
   const activeTaskCount = { get: () => 0 };
   setPreRestartDeferralCheck(
@@ -567,7 +566,6 @@ export async function prepareGatewayServerBootstrap(input: {
     generatedStartupAuthToken: authBootstrap.generatedToken !== undefined,
     resolvedStartupAuthOverride,
     startupTailscaleOverride,
-    diagnosticsEnabled,
     activeTaskCount,
     applyFixedGatewayOverlays,
     prepareReloadCandidate,

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -443,6 +443,13 @@ export async function finishGatewayStartup(params: {
     getChannelAutostartSuppression: channelManager.getAutostartSuppression,
     stopPostReadySidecars: stopRegisteredPostReadySidecars,
     reloadPlugins: kernel.reloadPlugins,
+    reloadPluginServices: async (config, serviceIds) => {
+      const services = runtimeState.pluginServices;
+      if (!services) {
+        throw new Error("Plugin services are not attached");
+      }
+      await services.reload(config, serviceIds);
+    },
     logHooks,
     logChannels,
     logCron,
@@ -476,6 +483,7 @@ export async function finishGatewayStartup(params: {
       controlUiRootLifecycle.setEnabled(
         opts.controlUiEnabled ?? nextConfig.gateway?.controlUi?.enabled ?? true,
       );
+      runtime.configureDiagnostics(nextConfig);
       const rateLimit = nextConfig.gateway?.auth?.rateLimit;
       authRateLimiter.updateConfig(rateLimit);
       browserAuthRateLimiter.updateConfig({ ...rateLimit, exemptLoopback: false });

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { writeRestartSentinel } from "../infra/restart-sentinel.js";
 import type { PluginHookGatewayContext, PluginHookHandlerMap } from "../plugins/hook-types.js";
 import { registerPluginHttpRoute } from "../plugins/http-registry.js";
@@ -31,7 +32,7 @@ type PluginHookGatewayStartEvent = Parameters<PluginHookHandlerMap["gateway_star
 
 const hoisted = vi.hoisted(() => {
   const startPluginServices = vi.fn<typeof import("../plugins/services.js").startPluginServices>(
-    async () => ({ stop: async () => {} }),
+    async () => ({ reload: async () => {}, stop: async () => {} }),
   );
   const startGmailWatcherWithLogs = vi.fn(async () => {});
   const commitInternalHooks = vi.fn(() => true);
@@ -2270,7 +2271,10 @@ describe("startGatewayPostAttachRuntime", () => {
       async () => {
         let releaseChannels: (() => void) | undefined;
         const events: string[] = [];
-        const pluginServices: PluginServicesHandle = { stop: vi.fn(async () => {}) };
+        const pluginServices: PluginServicesHandle = {
+          reload: vi.fn(async () => {}),
+          stop: vi.fn(async () => {}),
+        };
         const onPluginServices = vi.fn();
         const onSidecarsReady = vi.fn();
         const startChannels = vi.fn(
@@ -2325,6 +2329,14 @@ describe("startGatewayPostAttachRuntime", () => {
           "plugin-services",
         ]);
         expect(onPluginServices).toHaveBeenCalledTimes(1);
+        const owner: PluginServicesHandle = onPluginServices.mock.calls[0]?.[0];
+        const config: OpenClawConfig = { diagnostics: { otel: { enabled: true } } };
+        const selected = new Set(["exporter"]);
+        await owner.reload(config, selected);
+        expect(pluginServices.reload).toHaveBeenCalledExactlyOnceWith(config, selected);
+        await owner.stop();
+        await expect(owner.reload(config, selected)).rejects.toThrow("stopping");
+        expect(pluginServices.reload).toHaveBeenCalledOnce();
       },
     );
   });
@@ -2641,7 +2653,7 @@ describe("startGatewayPostAttachRuntime", () => {
         }
         return cleanup.promise;
       });
-      const startedServices = { stop: serviceStop };
+      const startedServices = { reload: vi.fn(async () => {}), stop: serviceStop };
       const publishedOwner: { current: PluginServicesHandle | null } = { current: null };
       hoisted.startPluginServices.mockImplementationOnce(async (params) => {
         params.onHandle?.(startedServices);
@@ -3990,7 +4002,10 @@ describe("startGatewayPostAttachRuntime", () => {
     const recoveryLoadStarted = new Promise<void>((resolve) => {
       markRecoveryLoadStarted = resolve;
     });
-    const pluginServices = { stop: vi.fn(async () => {}) } as PluginServicesHandle;
+    const pluginServices: PluginServicesHandle = {
+      reload: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+    };
     const postReadySidecar = { stop: vi.fn(async () => {}) };
     const workerSidecar = { stop: vi.fn(async () => {}) };
     const unlockStartupMethods = vi.fn();

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -737,6 +737,13 @@ export async function startGatewaySidecars(params: {
   if (shouldStartPluginServices) {
     const ownedPluginServices = createDeferredCore<PluginServicesHandle | null>();
     const pluginServicesOwner: PluginServicesHandle = {
+      reload: async (config, serviceIds) => {
+        const handle = await ownedPluginServices.promise;
+        if (pluginServicesStopRequested || !handle) {
+          throw new Error("Plugin services are stopping");
+        }
+        await handle.reload(config, serviceIds);
+      },
       stop: (options) => {
         pluginServicesStopRequested = true;
         // Share the service owner, never a caller's expired replacement deadline.

--- a/src/gateway/server.diagnostics-policy.test.ts
+++ b/src/gateway/server.diagnostics-policy.test.ts
@@ -1,0 +1,81 @@
+import { expect, it, vi } from "vitest";
+import {
+  areDiagnosticsEnabledForProcess,
+  onDiagnosticEvent,
+  setDiagnosticsEnabledForProcess,
+  waitForDiagnosticEventsDrained,
+} from "../infra/diagnostic-events.js";
+import { logWebhookReceived } from "../logging/diagnostic.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { getFreePort } from "../test-utils/ports.js";
+import { createGatewayKernel } from "./server-kernel.js";
+
+it("owns diagnostic dispatch and heartbeat across initial disable, enable, disable, and close", async () => {
+  const previouslyEnabled = areDiagnosticsEnabledForProcess();
+  const state = await createOpenClawTestState({
+    label: "gateway-diagnostics-policy",
+    env: {
+      OPENCLAW_GATEWAY_TOKEN: undefined,
+      OPENCLAW_GATEWAY_PASSWORD: undefined,
+      OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+      OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+      OPENCLAW_SKIP_CANVAS_HOST: "1",
+      OPENCLAW_SKIP_CHANNELS: "1",
+      OPENCLAW_SKIP_CRON: "1",
+      OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+      OPENCLAW_SKIP_PROVIDERS: "1",
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    },
+  });
+  let kernel: Awaited<ReturnType<typeof createGatewayKernel>> | undefined;
+  let unsubscribe: (() => void) | undefined;
+  try {
+    const port = await getFreePort();
+    await state.writeConfig({
+      diagnostics: { enabled: false },
+      gateway: { mode: "local", port, auth: { mode: "none" }, controlUi: { enabled: false } },
+    });
+    state.applyEnv();
+    kernel = await createGatewayKernel(port, {
+      auth: { mode: "none" },
+      bind: "loopback",
+      controlUiEnabled: false,
+      sidecarStartup: "defer",
+    });
+    expect(areDiagnosticsEnabledForProcess()).toBe(false);
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const events: string[] = [];
+    unsubscribe = onDiagnosticEvent((event) => events.push(event.type));
+    const tick = async () => {
+      logWebhookReceived({ channel: "test" });
+      await vi.advanceTimersByTimeAsync(30_000);
+      await waitForDiagnosticEventsDrained();
+    };
+    await tick();
+    expect(events).toEqual([]);
+
+    kernel.configureDiagnostics({ diagnostics: { enabled: true } });
+    await tick();
+    expect(events.filter((event) => event === "webhook.received")).toHaveLength(1);
+    expect(events.filter((event) => event === "diagnostic.heartbeat")).toHaveLength(1);
+
+    kernel.configureDiagnostics({ diagnostics: { enabled: false } });
+    await tick();
+    expect(events.filter((event) => event === "webhook.received")).toHaveLength(1);
+    expect(events.filter((event) => event === "diagnostic.heartbeat")).toHaveLength(1);
+
+    kernel.configureDiagnostics({});
+    await tick();
+    expect(events.filter((event) => event === "diagnostic.heartbeat")).toHaveLength(2);
+    await kernel.closeOnStartupFailure();
+    kernel.configureDiagnostics({ diagnostics: { enabled: true } });
+    await tick();
+    expect(events.filter((event) => event === "diagnostic.heartbeat")).toHaveLength(2);
+  } finally {
+    unsubscribe?.();
+    await kernel?.closeOnStartupFailure();
+    vi.useRealTimers();
+    await state.cleanup();
+    setDiagnosticsEnabledForProcess(previouslyEnabled);
+  }
+}, 60_000);

--- a/src/logging/diagnostic-lifecycle.test.ts
+++ b/src/logging/diagnostic-lifecycle.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { recordCommandPoll } from "../agents/command-poll-backoff.js";
+import { detectToolCallLoop, recordToolCall } from "../agents/tool-loop-detection.js";
+import {
+  onDiagnosticEvent,
+  setDiagnosticsEnabledForProcess,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
+import {
+  getDiagnosticSessionState,
+  isDiagnosticSessionStateCurrent,
+  peekDiagnosticSessionState,
+} from "./diagnostic-session-state.js";
+import {
+  logMessageQueued,
+  logSessionStateChange,
+  logWebhookReceived,
+  startDiagnosticHeartbeat,
+  stopDiagnosticHeartbeat,
+} from "./diagnostic.js";
+import { resetDiagnosticStateForTest } from "./diagnostic.test-support.js";
+
+afterEach(() => {
+  resetDiagnosticStateForTest();
+  setDiagnosticsEnabledForProcess(true);
+  vi.useRealTimers();
+});
+
+it("preserves independent tool-loop and poll-backoff policy when diagnostic observation stops", () => {
+  const session = { sessionKey: "diagnostic-tool-history" };
+  const state = getDiagnosticSessionState(session);
+  const args = { path: "fixture.txt" };
+  for (let index = 0; index < 10; index += 1) {
+    recordToolCall(state, "read", args);
+  }
+  const before = detectToolCallLoop(state, "read", args, { enabled: true });
+  expect(before).toMatchObject({ stuck: true, detector: "generic_repeat", count: 10 });
+  expect(recordCommandPoll(state, "fixture-command", false)).toBe(5_000);
+  expect(recordCommandPoll(state, "fixture-command", false)).toBe(10_000);
+  setDiagnosticsEnabledForProcess(false);
+  stopDiagnosticHeartbeat();
+  const current = getDiagnosticSessionState(session);
+  expect(detectToolCallLoop(current, "read", args, { enabled: true })).toEqual(before);
+  expect(recordCommandPoll(current, "fixture-command", false)).toBe(30_000);
+});
+
+it("retires interrupted diagnostic observations before re-enable without reviving their authority", async () => {
+  vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+  setDiagnosticsEnabledForProcess(true);
+  const events: DiagnosticEventPayload[] = [];
+  const unsubscribe = onDiagnosticEvent((event) => events.push(event));
+  const session = { sessionKey: "diagnostic-lifecycle", sessionId: "diagnostic-lifecycle" };
+  try {
+    startDiagnosticHeartbeat({}, { sampleLiveness: () => null });
+    logMessageQueued({ ...session, source: "test" });
+    logSessionStateChange({ ...session, state: "processing" });
+    const generation = peekDiagnosticSessionState(session)?.generation;
+    expect(generation).toBeTypeOf("number");
+    setDiagnosticsEnabledForProcess(false);
+    stopDiagnosticHeartbeat();
+    logSessionStateChange({ ...session, state: "idle" });
+    setDiagnosticsEnabledForProcess(true);
+    startDiagnosticHeartbeat({}, { sampleLiveness: () => null });
+    logWebhookReceived({ channel: "test" });
+    await vi.advanceTimersByTimeAsync(30_000);
+    await waitForDiagnosticEventsDrained();
+    expect(events.findLast((event) => event.type === "diagnostic.heartbeat")).toMatchObject({
+      active: 0,
+      queued: 0,
+      waiting: 0,
+    });
+    logMessageQueued({ ...session, source: "test" });
+    logSessionStateChange({ ...session, state: "processing" });
+    expect(isDiagnosticSessionStateCurrent({ ...session, generation, state: "processing" })).toBe(
+      false,
+    );
+  } finally {
+    unsubscribe();
+  }
+});

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -214,6 +214,21 @@ export function peekDiagnosticSessionState(ref: SessionRef): SessionState | unde
   );
 }
 
+/** Retires collector observations without resetting independent tool-loop or poll policy. */
+export function retireDiagnosticSessionObservations(): void {
+  for (const state of diagnosticSessionStates.values()) {
+    // Recovery accepts one completion increment. A collector boundary must
+    // advance beyond that exception before this session can collect fresh work.
+    state.generation = (state.generation ?? 0) + 2;
+    state.state = "idle";
+    state.queueDepth = 0;
+    state.activeQueuedTurn = false;
+    state.lastActivity = Date.now();
+    state.lastStuckWarnAgeMs = undefined;
+    state.lastLongRunningWarnAgeMs = undefined;
+  }
+}
+
 /** Clears all process-local diagnostic session state for tests. */
 export function resetDiagnosticSessionStateForTest(): void {
   diagnosticSessionStates.clear();

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -53,6 +53,7 @@ import type {
 } from "./diagnostic-session-recovery.js";
 import {
   diagnosticSessionStates,
+  retireDiagnosticSessionObservations,
   getDiagnosticSessionState,
   isDiagnosticSessionStateCurrent,
   pruneDiagnosticSessionStates,
@@ -1324,6 +1325,7 @@ export function stopDiagnosticHeartbeat() {
   }
   lastDiagnosticHeartbeatTickAt = undefined;
   stopDiagnosticRunActivityTracking();
+  retireDiagnosticSessionObservations();
   stopDiagnosticLivenessSampler();
   stopDiagnosticStabilityRecorder();
   uninstallDiagnosticStabilityFatalHook();

--- a/src/plugins/plugin-registration.types.ts
+++ b/src/plugins/plugin-registration.types.ts
@@ -396,6 +396,8 @@ export type OpenClawPluginServiceContext = {
 /** Background service registered by a plugin during `register(api)`. */
 export type OpenClawPluginService = {
   id: string;
+  /** Restart this service with committed config when one of these paths changes. */
+  reload?: { configPrefixes: readonly string[] };
   start: (ctx: OpenClawPluginServiceContext) => void | Promise<void>;
   stop?: (ctx: OpenClawPluginServiceContext) => void | Promise<void>;
 };

--- a/src/plugins/services.cron.test.ts
+++ b/src/plugins/services.cron.test.ts
@@ -110,7 +110,7 @@ describe("plugin service scheduler ownership", () => {
     ]);
   });
 
-  it.each(["service stop", "scheduler replacement"] as const)(
+  it.each(["service stop", "service reload", "scheduler replacement"] as const)(
     "rejects reads and writes queued before %s without changing stored rows",
     async (retirement) => {
       const original = await createScheduler();
@@ -142,6 +142,8 @@ describe("plugin service scheduler ownership", () => {
       try {
         if (retirement === "service stop") {
           await handle.stop();
+        } else if (retirement === "service reload") {
+          await handle.reload({}, new Set(["maintenance"]));
         } else {
           current = replacement.cron;
           expect(context.getCron?.()).not.toBe(service);

--- a/src/plugins/services.reload.test.ts
+++ b/src/plugins/services.reload.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { registerPluginHttpRoute } from "./http-registry.js";
+import { createEmptyPluginRegistry } from "./registry.js";
+import { listPluginServiceHealthFailures } from "./service-health.js";
+import { startPluginServices, type PluginServicesHandle } from "./services.js";
+import type { OpenClawPluginServiceContext } from "./types.js";
+
+const handles = new Set<PluginServicesHandle>();
+afterEach(async () => {
+  await Promise.allSettled([...handles].map((handle) => handle.stop()));
+  handles.clear();
+});
+
+const configFor = (endpoint: string): OpenClawConfig => ({
+  diagnostics: { otel: { enabled: true, endpoint } },
+});
+
+it("replaces only selected services, retiring their routes and capabilities without losing sibling health", async () => {
+  const contexts: OpenClawPluginServiceContext[] = [];
+  const siblingContexts: OpenClawPluginServiceContext[] = [];
+  const stops: OpenClawConfig[] = [];
+  const broadcastPluginEvent = vi.fn();
+  const registry = createEmptyPluginRegistry();
+  registry.services.push(
+    {
+      pluginId: "exporter",
+      origin: "workspace",
+      source: "test",
+      service: {
+        id: "exporter",
+        start(ctx) {
+          contexts.push(ctx);
+          registerPluginHttpRoute({ path: "/exporter", auth: "plugin", handler: vi.fn() });
+        },
+        stop(ctx) {
+          stops.push(ctx.config);
+        },
+      },
+    },
+    {
+      pluginId: "sibling",
+      origin: "workspace",
+      source: "test",
+      service: {
+        id: "sibling",
+        start(ctx) {
+          siblingContexts.push(ctx);
+          ctx.serviceHealth?.reportFailure(new Error("unrelated service failure"));
+        },
+      },
+    },
+  );
+  const first = configFor("https://first.example");
+  const next = configFor("https://next.example");
+  const handle = await startPluginServices({ registry, config: first, broadcastPluginEvent });
+  handles.add(handle);
+  await handle.reload(next, new Set(["exporter"]));
+
+  expect(contexts.map((ctx) => ctx.config)).toEqual([first, next]);
+  expect(stops).toEqual([first]);
+  expect(siblingContexts).toHaveLength(1);
+  expect(registry.httpRoutes).toHaveLength(1);
+  expect(() => contexts[0]?.gatewayEvents?.emit("late", {}, { scope: "operator.read" })).toThrow(
+    "no longer active",
+  );
+  contexts[0]?.serviceHealth?.reportFailure(new Error("retired exporter"));
+  expect(listPluginServiceHealthFailures(registry)).toMatchObject([
+    { pluginId: "sibling", error: "unrelated service failure" },
+  ]);
+  siblingContexts[0]?.gatewayEvents?.emit("still_alive", {}, { scope: "operator.read" });
+  contexts[1]?.gatewayEvents?.emit("replacement", {}, { scope: "operator.read" });
+  expect(broadcastPluginEvent).toHaveBeenCalledTimes(2);
+
+  await handle.stop();
+  expect(stops).toEqual([first, next]);
+  expect(registry.httpRoutes).toEqual([]);
+});
+
+it("does not start a selected successor when Gateway shutdown overtakes its cleanup", async () => {
+  const entered = createDeferredCore();
+  const release = createDeferredCore();
+  const start = vi.fn();
+  const stop = vi.fn(() => {
+    entered.resolve();
+    return release.promise;
+  });
+  const registry = createEmptyPluginRegistry();
+  registry.services.push({
+    pluginId: "exporter",
+    origin: "workspace",
+    source: "test",
+    service: { id: "exporter", start, stop },
+  });
+  const handle = await startPluginServices({
+    registry,
+    config: configFor("https://first.example"),
+  });
+  handles.add(handle);
+  let result: Promise<unknown> | undefined;
+  try {
+    result = handle
+      .reload(configFor("https://next.example"), new Set(["exporter"]))
+      .catch((error: unknown) => error);
+    await entered.promise;
+    const stopping = handle.stop();
+    release.resolve();
+    await Promise.all([result, stopping]);
+    expect(start).toHaveBeenCalledOnce();
+    expect(stop).toHaveBeenCalledOnce();
+  } finally {
+    release.resolve();
+    await result;
+  }
+});
+
+it.each(["stop", "start"] as const)(
+  "reports selected service %s failure while leaving unrelated services live",
+  async (phase) => {
+    let starts = 0;
+    const siblingStop = vi.fn();
+    const registry = createEmptyPluginRegistry();
+    registry.services.push(
+      {
+        pluginId: "exporter",
+        origin: "workspace",
+        source: "test",
+        service: {
+          id: "exporter",
+          start() {
+            if (++starts > 1 && phase === "start") {
+              throw new Error("replacement start rejected");
+            }
+          },
+          stop() {
+            if (phase === "stop") {
+              throw new Error("replacement stop rejected");
+            }
+          },
+        },
+      },
+      {
+        pluginId: "sibling",
+        origin: "workspace",
+        source: "test",
+        service: { id: "sibling", start() {}, stop: siblingStop },
+      },
+    );
+    const handle = await startPluginServices({
+      registry,
+      config: configFor("https://first.example"),
+    });
+    handles.add(handle);
+    await expect(
+      handle.reload(configFor("https://next.example"), new Set(["exporter"])),
+    ).rejects.toThrow();
+    expect(starts).toBe(phase === "start" ? 2 : 1);
+    expect(siblingStop).not.toHaveBeenCalled();
+  },
+);

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -178,6 +178,7 @@ function createScopedPluginServiceStartupTrace(
 }
 
 export type PluginServicesHandle = {
+  reload: (config: OpenClawConfig, serviceIds: ReadonlySet<string>) => Promise<void>;
   stop: (options?: { strict: true; deadlineAtMs: number }) => Promise<void>;
 };
 
@@ -201,6 +202,8 @@ export async function startPluginServices(params: {
     id: string;
     pluginId: string;
     diagnosticsExporter: boolean;
+    registration: PluginServiceRegistration;
+    stopping: boolean;
     stop?: () => void | Promise<void>;
     cleanup?: Promise<void>;
     lease: PluginRuntimeCapabilityLease;
@@ -240,6 +243,7 @@ export async function startPluginServices(params: {
     failures?: unknown[],
     deadline?: number,
   ) => {
+    entry.stopping = true;
     try {
       if (entry.stop) {
         // Cleanup belongs to the service, not a caller's deadline. Keep even rejected
@@ -275,8 +279,73 @@ export async function startPluginServices(params: {
       entry.lease.revoke();
     }
   };
+  const stopServices = async (
+    entries: typeof ownedServices,
+    failures: unknown[],
+    strict: boolean,
+    deadline?: number,
+  ) => {
+    for (const entry of entries) {
+      entry.stopping = true;
+    }
+    const reversed = entries.toReversed();
+    const diagnosticsExporters = reversed.filter((entry) => entry.diagnosticsExporter);
+    for (const entry of reversed.filter((candidate) => !candidate.diagnosticsExporter)) {
+      await stopService(entry, strict ? failures : undefined, deadline);
+    }
+    if (diagnosticsExporters.length > 0) {
+      // Producers stop first; this barrier preserves their queued tail before exporters detach.
+      try {
+        await runBeforeDeadline(
+          waitForDiagnosticEventsDrained,
+          deadline,
+          "plugin diagnostic event drain",
+          diagnosticsExporters
+            .map((entry) => `plugin=${entry.pluginId}, service=${entry.id}`)
+            .join("; "),
+        );
+      } catch (error) {
+        if (!strict) {
+          throw error;
+        }
+        failures.push(error);
+      }
+    }
+    // Ordinary plugin cleanup stays warn-and-continue. Trusted diagnostics
+    // exporter failures propagate because they can mean telemetry was lost.
+    for (const entry of diagnosticsExporters) {
+      await stopService(entry, failures, deadline);
+    }
+  };
   let stopRequested = false;
+  let reloadTail = Promise.resolve();
   const handle: PluginServicesHandle = {
+    reload: (config, serviceIds) => {
+      const reloading = reloadTail.then(async () => {
+        await startupSettled;
+        if (stopRequested) {
+          throw new Error("Plugin services are stopping");
+        }
+        const selected = ownedServices.filter((entry) => serviceIds.has(entry.id));
+        const deadline = Date.now() + PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS;
+        const failures: unknown[] = [];
+        await stopServices(selected, failures, true, deadline);
+        if (failures.length > 0) {
+          throw new AggregateError(failures, "plugin service reload cleanup failed");
+        }
+        for (const entry of selected) {
+          ownedServices.splice(ownedServices.indexOf(entry), 1);
+        }
+        for (const entry of selected) {
+          if (stopRequested) {
+            return;
+          }
+          await startService(entry.registration, config, true);
+        }
+      });
+      reloadTail = reloading.catch(() => {});
+      return reloading;
+    },
     stop: (options) => {
       stopRequested = true;
       const strict = options?.strict === true;
@@ -287,7 +356,7 @@ export async function startPluginServices(params: {
         try {
           const starting = ownedServices.at(-1);
           await runBeforeDeadline(
-            () => startupSettled.catch(() => {}),
+            () => Promise.all([startupSettled.catch(() => {}), reloadTail]).then(() => {}),
             deadline,
             "plugin service startup settlement",
             starting ? `plugin=${starting.pluginId}, service=${starting.id}` : undefined,
@@ -299,34 +368,7 @@ export async function startPluginServices(params: {
             entry.lease.revoke();
           }
         }
-        const reversed = ownedServices.toReversed();
-        const diagnosticsExporters = reversed.filter((entry) => entry.diagnosticsExporter);
-        for (const entry of reversed.filter((candidate) => !candidate.diagnosticsExporter)) {
-          await stopService(entry, strict ? failures : undefined, deadline);
-        }
-        if (diagnosticsExporters.length > 0) {
-          // Producers stop first; this barrier preserves their queued tail before exporters detach.
-          try {
-            await runBeforeDeadline(
-              waitForDiagnosticEventsDrained,
-              deadline,
-              "plugin diagnostic event drain",
-              diagnosticsExporters
-                .map((entry) => `plugin=${entry.pluginId}, service=${entry.id}`)
-                .join("; "),
-            );
-          } catch (error) {
-            if (!strict) {
-              throw error;
-            }
-            failures.push(error);
-          }
-        }
-        // Ordinary plugin cleanup stays warn-and-continue. Trusted diagnostics
-        // exporter failures propagate because they can mean telemetry was lost.
-        for (const entry of diagnosticsExporters) {
-          await stopService(entry, failures, deadline);
-        }
+        await stopServices(ownedServices, failures, strict, deadline);
         if (!strict && failures.length === 1) {
           throw failures[0];
         }
@@ -345,72 +387,88 @@ export async function startPluginServices(params: {
   };
   params.onHandle?.(handle);
 
+  const startService = async (
+    entry: PluginServiceRegistration,
+    config: OpenClawConfig,
+    strict = false,
+  ): Promise<boolean> => {
+    const service = entry.service;
+    const traceName = createPluginServiceTraceName(entry);
+    const lease = createPluginRuntimeCapabilityLease("plugin service");
+    const scopedGatewayEvents = createScopedGatewayEvents({
+      pluginId: entry.pluginId,
+      broadcast: params.broadcastPluginEvent,
+      lease,
+    });
+    const serviceHealth = healthGeneration.createReporter(entry);
+    lease.retain(serviceHealth.revoke);
+    serviceHealth.health.clearFailure();
+    const serviceContext = createServiceContext({
+      config,
+      startupTrace: params.startupTrace,
+      workspaceDir: params.workspaceDir,
+      service: entry,
+      serviceHealth: serviceHealth.health,
+      gatewayEvents: scopedGatewayEvents.gatewayEvents,
+      ...(params.getCronService
+        ? {
+            getCron: createPluginServiceCronGetter({
+              getCron: params.getCronService,
+              lease,
+              isStopping: () => stopRequested || ownedService.stopping,
+            }),
+          }
+        : {}),
+      lease,
+    });
+    const ownedService: (typeof ownedServices)[number] = {
+      id: service.id,
+      registration: entry,
+      stopping: false,
+      pluginId: entry.pluginId,
+      diagnosticsExporter: serviceContext.internalDiagnostics !== undefined,
+      stop: service.stop ? () => service.stop?.(serviceContext) : undefined,
+      lease,
+    };
+    // Own capabilities before startup yields so a bounded replacement can revoke stale work.
+    ownedServices.push(ownedService);
+    try {
+      const invokeStart = () =>
+        withPluginHttpRouteRegistry(params.registry, () => service.start(serviceContext), lease);
+      if (params.startupTrace) {
+        await params.startupTrace.measure(traceName, invokeStart);
+      } else {
+        await invokeStart();
+      }
+      return true;
+    } catch (err) {
+      serviceContext.serviceHealth?.reportFailure(err);
+      const error = err as Error;
+      log.error(
+        `plugin service failed (${service.id}, plugin=${entry.pluginId}, root=${entry.rootDir ?? "unknown"}): ${error?.message ?? String(err)}`,
+      );
+      // A failed start can already own resources; revoke events only after its cleanup runs.
+      // Bound the cleanup: callers await startPluginServices without a timeout, so a hung
+      // stop here would wedge plugin reload/startup forever.
+      await stopService(
+        ownedService,
+        undefined,
+        Date.now() + PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS,
+      );
+      if (strict) {
+        throw err;
+      }
+      return false;
+    }
+  };
   const startupSettled = (async () => {
     let failedCount = 0;
     for (const entry of params.registry.services) {
       if (stopRequested) {
         break;
       }
-      const service = entry.service;
-      const traceName = createPluginServiceTraceName(entry);
-      const lease = createPluginRuntimeCapabilityLease("plugin service");
-      const scopedGatewayEvents = createScopedGatewayEvents({
-        pluginId: entry.pluginId,
-        broadcast: params.broadcastPluginEvent,
-        lease,
-      });
-      const serviceHealth = healthGeneration.createReporter(entry);
-      lease.retain(serviceHealth.revoke);
-      const serviceContext = createServiceContext({
-        config: params.config,
-        startupTrace: params.startupTrace,
-        workspaceDir: params.workspaceDir,
-        service: entry,
-        serviceHealth: serviceHealth.health,
-        gatewayEvents: scopedGatewayEvents.gatewayEvents,
-        ...(params.getCronService
-          ? {
-              getCron: createPluginServiceCronGetter({
-                getCron: params.getCronService,
-                lease,
-                isStopping: () => stopRequested,
-              }),
-            }
-          : {}),
-        lease,
-      });
-      const ownedService = {
-        id: service.id,
-        pluginId: entry.pluginId,
-        diagnosticsExporter: serviceContext.internalDiagnostics !== undefined,
-        stop: service.stop ? () => service.stop?.(serviceContext) : undefined,
-        lease,
-      };
-      // Own capabilities before startup yields so a bounded replacement can revoke stale work.
-      ownedServices.push(ownedService);
-      try {
-        const startService = () =>
-          withPluginHttpRouteRegistry(params.registry, () => service.start(serviceContext), lease);
-        if (params.startupTrace) {
-          await params.startupTrace.measure(traceName, startService);
-        } else {
-          await startService();
-        }
-      } catch (err) {
+      if (!(await startService(entry, params.config))) {
         failedCount += 1;
-        serviceContext.serviceHealth?.reportFailure(err);
-        const error = err as Error;
-        log.error(
-          `plugin service failed (${service.id}, plugin=${entry.pluginId}, root=${entry.rootDir ?? "unknown"}): ${error?.message ?? String(err)}`,
-        );
-        // A failed start can already own resources; revoke events only after its cleanup runs.
-        // Bound the cleanup: callers await startPluginServices without a timeout, so a hung
-        // stop here would wedge plugin reload/startup forever.
-        await stopService(
-          ownedService,
-          undefined,
-          Date.now() + PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS,
-        );
       }
     }
     params.startupTrace?.detail?.("sidecars.plugin-services.summary", [

--- a/test/e2e/qa-lab/runtime/gateway-config-hot-reload-otel.ts
+++ b/test/e2e/qa-lab/runtime/gateway-config-hot-reload-otel.ts
@@ -1,0 +1,295 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { createQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
+import { GatewayClientRequestError } from "../../../../src/gateway/client.js";
+import { runQaGatewayFixture, stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+import {
+  connectHotReloadClient,
+  waitForHotReloadFact,
+  type HotReloadConnection,
+} from "./gateway-config-hot-reload-fixtures.js";
+import { startLocalOtlpReceiver } from "./otel-test-support.js";
+
+type Receiver = ReturnType<typeof startLocalOtlpReceiver>;
+const HEADER = "x-openclaw-qa-generation";
+const FLUSH_MS = 1_000;
+
+export async function proveHotReloadOtel({
+  repoRoot,
+  outputDir,
+  appendLog,
+}: {
+  repoRoot: string;
+  outputDir: string;
+  appendLog: (text: string) => void;
+}) {
+  const owner = createQaGatewayChild();
+  const receiverA = startLocalOtlpReceiver([], [HEADER]);
+  const receiverB = startLocalOtlpReceiver([], [HEADER]);
+  const evidence: Array<{ prefix: string; observation: string; pid: number; bootId: string }> = [];
+  const failures: Array<{ prefix: string; message: string }> = [];
+  const observations: Array<Record<string, unknown>> = [];
+  let connection: HotReloadConnection | undefined;
+  const counts = () => [receiverA.capturedRequests.length, receiverB.capturedRequests.length];
+  const preserveToDir = path.join(outputDir, "otel-gateway");
+  await runQaGatewayFixture(
+    async () => {
+      const endpointA = `http://127.0.0.1:${await receiverA.listen()}`;
+      const endpointB = `http://127.0.0.1:${await receiverB.listen()}`;
+      const gateway = await owner.start({
+        repoRoot,
+        useRepoCli: true,
+        command: {
+          executablePath: process.execPath,
+          argsPrefix: [path.join(repoRoot, "dist/index.js")],
+          cwd: repoRoot,
+          usePackagedPlugins: true,
+        },
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        providerBaseUrl: "http://127.0.0.1:1/v1",
+        transportBaseUrl: "http://127.0.0.1:1",
+        enabledPluginIds: ["diagnostics-otel", "diagnostics-prometheus"],
+        controlUiEnabled: false,
+        runtimeEnvPatch: { OPENCLAW_OTEL_PRELOADED: "0", OTEL_SDK_DISABLED: "false" },
+        mutateConfig: (config) => ({
+          ...config,
+          logging: { level: "debug", consoleLevel: "warn" },
+          diagnostics: {
+            enabled: false,
+            otel: {
+              enabled: true,
+              endpoint: endpointA,
+              serviceName: "qa-otel-a",
+              headers: { [HEADER]: "generation-a" },
+              protocol: "http/protobuf",
+              traces: true,
+              metrics: true,
+              logs: true,
+              sampleRate: 1,
+              flushIntervalMs: FLUSH_MS,
+              captureContent: false,
+            },
+          },
+        }),
+      });
+      connection = await connectHotReloadClient(gateway);
+      const primary = connection;
+      const { pid } = gateway;
+      const { bootId } = primary;
+      assert(pid && bootId);
+      const rpc = <T>(method: string, params: unknown = {}) =>
+        primary.client.request<T>(method, params, { timeoutMs: 40_000 });
+      const patch = async (change: unknown) => {
+        const { hash } = await rpc<{ hash: string }>("config.get");
+        const apply = () =>
+          rpc<{ sentinel: { payload: { stats: { requiresRestart: boolean } } } }>("config.patch", {
+            baseHash: hash,
+            raw: JSON.stringify(change),
+          });
+        const result = await apply().catch(async (error: unknown) => {
+          if (
+            !(error instanceof GatewayClientRequestError) ||
+            !error.retryable ||
+            typeof error.retryAfterMs !== "number" ||
+            !error.message.startsWith("rate limit exceeded for config.patch")
+          ) {
+            throw error;
+          }
+          await delay(error.retryAfterMs);
+          return apply();
+        });
+        assert.equal(result.sentinel.payload.stats.requiresRestart, false);
+      };
+      const readPrometheus = async () => {
+        const response = await fetch(`${gateway.baseUrl}/api/diagnostics/prometheus`, {
+          headers: { authorization: `Bearer ${gateway.token}` },
+          signal: AbortSignal.timeout(10_000),
+        });
+        assert.equal(response.status, 200);
+        const text = await response.text();
+        return Number(
+          text.match(/^openclaw_gateway_rpc_requests_total\{method="health"\} (\d+)$/m)?.[1] ?? 0,
+        );
+      };
+      const health = async (times = 1) => {
+        for (let index = 0; index < times; index += 1) {
+          await rpc("health");
+        }
+      };
+      const quiet = async (before: number[]) => {
+        // Observe two real configured export intervals; this is a bounded negative witness.
+        await health(3);
+        await delay(FLUSH_MS * 2 + 200);
+        assert.deepEqual(counts(), before, "A retired exporter still sent data");
+      };
+      const signals = async (
+        receiver: Receiver,
+        generation: string,
+        serviceName: string,
+        prefix: string,
+      ) => {
+        await health();
+        await waitForHotReloadFact(`OTLP ${generation} traces, metrics, and logs`, () =>
+          receiver.capturedSpans.some(
+            (span) =>
+              span.name === "openclaw.gateway.rpc.response" && span.serviceName === serviceName,
+          ) &&
+          receiver.capturedMetrics.some(
+            (metric) => metric.name === `${prefix}gateway.rpc.requests`,
+          ) &&
+          ["traces", "metrics", "logs"].every((signal) =>
+            receiver.capturedRequests.some(
+              (request) =>
+                request.headerValues?.[HEADER] === generation && request.signal === signal,
+            ),
+          )
+            ? true
+            : undefined,
+        );
+        const requests = receiver.capturedRequests.filter(
+          (request) => request.headerValues?.[HEADER] === generation,
+        );
+        assert.deepEqual(
+          new Set(requests.map((request) => request.signal)),
+          new Set(["traces", "metrics", "logs"]),
+        );
+        assert(receiver.capturedRequests.every((request) => request.status === 200));
+        observations.push({ generation, serviceName, metricPrefix: prefix, requests });
+      };
+      const record = async (prefix: string, observation: string) => {
+        assert.equal((await rpc<{ pid: number }>("system.info")).pid, pid);
+        assert.equal(primary.hellos, 1);
+        assert.equal(primary.closes, 0);
+        const fresh = await connectHotReloadClient(gateway);
+        try {
+          assert.equal(fresh.bootId, bootId);
+        } finally {
+          await fresh.client.stopAndWait();
+        }
+        evidence.push({ prefix, observation, pid, bootId });
+        appendLog(`PASS ${prefix}: ${observation}\n`);
+      };
+
+      try {
+        await quiet([0, 0]);
+        assert.equal(await readPrometheus(), 0);
+        await patch({ diagnostics: { enabled: true } });
+        await signals(receiverA, "generation-a", "qa-otel-a", "openclaw.");
+        await health(8);
+        const retainedCounter = await readPrometheus();
+        assert(retainedCounter >= 9);
+        await record(
+          "diagnostics.enabled.start",
+          "Initially disabled diagnostics enabled on the same Gateway; real RPC traces, metrics, logs and Prometheus events appeared",
+        );
+
+        await patch({
+          diagnostics: {
+            otel: {
+              endpoint: endpointB,
+              headers: { [HEADER]: "generation-b" },
+              serviceName: "qa-otel-b",
+              metricNamePrefix: "qa_reload_b.",
+            },
+          },
+        });
+        const retiredA = receiverA.capturedRequests.length;
+        await signals(receiverB, "generation-b", "qa-otel-b", "qa_reload_b.");
+        assert.equal(receiverA.capturedRequests.length, retiredA);
+        assert(
+          (await readPrometheus()) > retainedCounter,
+          "OTel replacement reset the unrelated Prometheus service",
+        );
+        await record(
+          "diagnostics.otel.endpoint/headers/serviceName/metricNamePrefix",
+          "Export moved A→B with the new synthetic header, service resource and metric prefix; collector A stopped, Prometheus cumulative counters survived",
+        );
+
+        await patch({
+          diagnostics: {
+            otel: { traces: false, logs: false, metricNamePrefix: "qa_metrics_only." },
+          },
+        });
+        const traceCount = receiverB.capturedSpans.length;
+        const logCount = receiverB.capturedLogRecords.length;
+        await health();
+        await waitForHotReloadFact("metrics-only generation", () =>
+          receiverB.capturedMetrics.some(
+            (metric) => metric.name === "qa_metrics_only.gateway.rpc.requests",
+          )
+            ? true
+            : undefined,
+        );
+        assert.equal(receiverB.capturedSpans.length, traceCount);
+        assert.equal(receiverB.capturedLogRecords.length, logCount);
+        await record(
+          "diagnostics.otel.traces/logs",
+          "Trace and log export stopped while a new metrics-only generation continued exporting RPC counters",
+        );
+
+        await patch({ diagnostics: { otel: { enabled: false } } });
+        const activeCounter = await readPrometheus();
+        await quiet(counts());
+        assert((await readPrometheus()) > activeCounter);
+        await patch({
+          diagnostics: {
+            otel: {
+              enabled: true,
+              traces: true,
+              logs: true,
+              endpoint: endpointA,
+              headers: { [HEADER]: "generation-c" },
+              serviceName: "qa-otel-c",
+              metricNamePrefix: "qa_reload_c.",
+            },
+          },
+        });
+        await signals(receiverA, "generation-c", "qa-otel-c", "qa_reload_c.");
+        await record(
+          "diagnostics.otel.enabled",
+          "Exporter disabled without stopping Prometheus, then re-enabled at collector A with fresh signal providers",
+        );
+
+        await patch({ diagnostics: { enabled: false } });
+        const disabledCounter = await readPrometheus();
+        await quiet(counts());
+        assert.equal(await readPrometheus(), disabledCounter);
+        await patch({ diagnostics: { enabled: true } });
+        const resumedMetricCount = receiverA.capturedMetrics.length;
+        await health();
+        await waitForHotReloadFact("diagnostics resumed", () =>
+          receiverA.capturedMetrics.length > resumedMetricCount ? true : undefined,
+        );
+        assert((await readPrometheus()) > disabledCounter);
+        await record(
+          "diagnostics.enabled.resume",
+          "Shared diagnostics disabled and re-enabled; both exporter traffic and retained Prometheus counters obeyed the dispatcher switch without reconnecting",
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        failures.push({ prefix: "diagnostics", message });
+        appendLog(`FAIL diagnostics: ${message}\n`);
+      }
+    },
+    () => connection?.client.stopAndWait(),
+    () => stopQaGatewayFixture(owner, { preserveToDir }),
+    async () => {
+      const stopped = counts();
+      await delay(FLUSH_MS * 2 + 200);
+      assert.deepEqual(counts(), stopped, "Gateway shutdown left an exporter active");
+    },
+    () => receiverA.close(),
+    () => receiverB.close(),
+    async () => {
+      await fs.mkdir(outputDir, { recursive: true });
+      await fs.writeFile(
+        path.join(outputDir, "gateway-config-hot-reload-otel.json"),
+        `${JSON.stringify({ evidence, failures, observations }, null, 2)}\n`,
+      );
+    },
+  );
+  return { evidence, failures };
+}

--- a/test/e2e/qa-lab/runtime/gateway-config-hot-reload-runtime.ts
+++ b/test/e2e/qa-lab/runtime/gateway-config-hot-reload-runtime.ts
@@ -26,6 +26,7 @@ import {
 } from "./gateway-config-hot-reload-fixtures.js";
 import { proveHotReloadBrowserLaunch } from "./gateway-config-hot-reload-launch.js";
 import { proveHotReloadNodePolicies } from "./gateway-config-hot-reload-nodes.js";
+import { proveHotReloadOtel } from "./gateway-config-hot-reload-otel.js";
 import { prepareGatewayPairingFixture } from "./gateway-config-hot-reload-pairing.js";
 import { proveHotReloadPluginPolicy } from "./gateway-config-hot-reload-plugin-policy.js";
 import { proveHotReloadPolicyAdmission } from "./gateway-config-hot-reload-policy-admission.js";
@@ -653,6 +654,8 @@ async function runProof(repoRoot: string, outputDir: string, appendLog: (text: s
       failures.push(...terminalDeferred.failures);
       const servicePolicy = await proveHotReloadServicePolicy({ repoRoot, outputDir, appendLog });
       failures.push(...servicePolicy.failures);
+      const otel = await proveHotReloadOtel({ repoRoot, outputDir, appendLog });
+      failures.push(...otel.failures);
       await pluginPolicy;
       await proveGroup("attachments.ttlHours", () => retention!.completion);
       await checkContinuity();
@@ -661,14 +664,15 @@ async function runProof(repoRoot: string, outputDir: string, appendLog: (text: s
         channels.evidence.length +
         security.evidence.length +
         terminalDeferred.evidence.length +
-        servicePolicy.evidence.length;
+        servicePolicy.evidence.length +
+        otel.evidence.length;
       // Positive control: startup-owned Control UI routing must replace the boot.
       const beforeControl = await rpc<ConfigResult>("config.get");
       const control = await rpc<{ sentinel: { payload: { stats: { requiresRestart: boolean } } } }>(
         "config.patch",
         {
           baseHash: beforeControl.hash,
-          raw: JSON.stringify({ gateway: { controlUi: { enabled: false } } }),
+          raw: JSON.stringify({ gateway: { controlUi: { basePath: "/reload-proof" } } }),
         },
       );
       assert.equal(control.sentinel.payload.stats.requiresRestart, true);
@@ -679,6 +683,7 @@ async function runProof(repoRoot: string, outputDir: string, appendLog: (text: s
         primary.hellos > 1 && primary.bootId !== bootId ? true : undefined,
       );
       assert.equal((await http("/chat/qa")).status, 404);
+      assert.equal((await http("/reload-proof/chat/qa")).status, 200);
       summary = {
         passed: failures.length === 0,
         failures,
@@ -688,6 +693,7 @@ async function runProof(repoRoot: string, outputDir: string, appendLog: (text: s
         security,
         terminalDeferred,
         servicePolicy,
+        otel,
         counts: {
           passed: passedChecks,
           failed: failures.length,
@@ -696,9 +702,10 @@ async function runProof(repoRoot: string, outputDir: string, appendLog: (text: s
           security: security.evidence.length,
           terminalDeferred: terminalDeferred.evidence.length,
           servicePolicy: servicePolicy.evidence.length,
+          otel: otel.evidence.length,
         },
         startupOnlyControl: {
-          prefix: "gateway.controlUi.enabled",
+          prefix: "gateway.controlUi.basePath",
           closedPersistentSocket: true,
           originalBootId: bootId,
           replacementBootId: primary.bootId,
@@ -780,7 +787,7 @@ async function main() {
     await writer.write({
       status: passed ? "pass" : "fail",
       durationMs: Date.now() - started,
-      details: `${passedChecks} operation and config-admission checks passed across the primary, channel, security, deferred-restart, and service-policy Gateway fixtures; startup-only positive controls restarted${passed ? "" : `; failures: ${failures.map(({ prefix }) => prefix).join(", ")}`}`,
+      details: `${passedChecks} operation and config-admission checks passed across the primary, channel, security, deferred-restart, service-policy, and OTel Gateway fixtures; startup-only positive controls restarted${passed ? "" : `; failures: ${failures.map(({ prefix }) => prefix).join(", ")}`}`,
       artifacts: [
         { kind: "summary", filePath: summaryPath },
         ...[
@@ -788,6 +795,7 @@ async function main() {
           "channels",
           "terminal-deferred",
           "service-policy",
+          "otel",
           "policy",
           "policy-admission",
           "plugin-policy",

--- a/test/e2e/qa-lab/runtime/otel-generation-config-watcher-runtime.ts
+++ b/test/e2e/qa-lab/runtime/otel-generation-config-watcher-runtime.ts
@@ -437,6 +437,11 @@ function withOtelEndpoint(config: OpenClawConfig, endpoint: string): OpenClawCon
 async function updateWatchedEndpoint(configPath: string, endpoint: string): Promise<void> {
   const parsed = JSON.parse(await fs.readFile(configPath, "utf8")) as OpenClawConfig;
   const next = withOtelEndpoint(parsed, endpoint);
+  // Endpoint changes hot-apply; keep this separate full-restart generation proof explicit.
+  next.gateway = {
+    ...next.gateway,
+    controlUi: { ...next.gateway?.controlUi, basePath: "/otel-restart-proof" },
+  };
   await fs.writeFile(configPath, `${JSON.stringify(next, null, 2)}\n`, "utf8");
 }
 
@@ -501,7 +506,7 @@ async function probeOtelGenerationConfigWatcher(
     const restartLogOffset = gateway.logs().length;
     await updateWatchedEndpoint(gateway.configPath, receiverB.baseUrl);
     const restartLogObserved = await waitFor({
-      label: "in-process config watcher restart",
+      label: "in-process restart for mixed endpoint and startup-owned Control UI path edit",
       timeoutMs: RESTART_TIMEOUT_MS,
       read: () =>
         gateway!
@@ -591,7 +596,7 @@ function createWriter(options: RuntimeOptions) {
     repoRoot: options.repoRoot,
     target: {
       id: SCENARIO_ID,
-      title: "OTEL generation config watcher",
+      title: "OTEL generation across a mixed restart-required config edit",
       sourcePath: SOURCE_PATH,
       docsRefs: ["docs/gateway/opentelemetry.md", "docs/concepts/qa-e2e-automation.md"],
       codeRefs: [

--- a/test/e2e/qa-lab/runtime/otel-test-support.ts
+++ b/test/e2e/qa-lab/runtime/otel-test-support.ts
@@ -34,10 +34,12 @@ type OtlpScopeSpans = {
 };
 
 type OtlpResourceSpans = {
+  serviceName?: string;
   scopeSpans?: OtlpScopeSpans[];
 };
 
 export type CapturedRequest = {
+  headerValues?: Record<string, string | undefined>;
   bytes: number;
   contentEncoding?: string;
   logCount: number;
@@ -50,6 +52,7 @@ export type CapturedRequest = {
 };
 
 export type CapturedSpan = {
+  serviceName?: string;
   attributes: Record<string, string | number | boolean | string[]>;
   endTimeMs?: number;
   name: string;
@@ -498,15 +501,20 @@ function decodeScopeSpans(message: Uint8Array): OtlpScopeSpans {
 function decodeResourceSpans(message: Uint8Array): OtlpResourceSpans {
   const reader = new ProtoReader(message);
   const scopeSpans: OtlpScopeSpans[] = [];
+  let serviceName: string | undefined;
   while (!reader.done()) {
     const { field, wire } = reader.tag();
-    if (field === 2 && wire === 2) {
+    if (field === 1 && wire === 2) {
+      serviceName = decodeKeyValueList(reader.bytes()).values?.find(
+        (attribute) => attribute.key === "service.name",
+      )?.value?.stringValue;
+    } else if (field === 2 && wire === 2) {
       scopeSpans.push(decodeScopeSpans(reader.bytes()));
     } else {
       reader.skip(wire);
     }
   }
-  return { scopeSpans };
+  return { scopeSpans, serviceName };
 }
 
 function decodeTraceRequest(body: Buffer): CapturedSpan[] {
@@ -530,6 +538,7 @@ function decodeTraceRequest(body: Buffer): CapturedSpan[] {
         }
         spans.push({
           attributes: spanAttributes(span),
+          ...(resource.serviceName ? { serviceName: resource.serviceName } : {}),
           endTimeMs: span.endTimeMs,
           name,
           parent: (span.parentSpanId?.length ?? 0) > 0,
@@ -676,7 +685,10 @@ function closeLocalOtlpReceiverConnections(
   server.closeAllConnections();
 }
 
-export function startLocalOtlpReceiver(disallowedBodyNeedles: string[] = []) {
+export function startLocalOtlpReceiver(
+  disallowedBodyNeedles: string[] = [],
+  captureHeaderNames: string[] = [],
+) {
   const capturedRequests: CapturedRequest[] = [];
   const capturedSpans: CapturedSpan[] = [];
   const capturedMetrics: CapturedMetric[] = [];
@@ -753,6 +765,13 @@ export function startLocalOtlpReceiver(disallowedBodyNeedles: string[] = []) {
       capturedRequests.push({
         path: requestPath,
         signal,
+        ...(captureHeaderNames.length > 0
+          ? {
+              headerValues: Object.fromEntries(
+                captureHeaderNames.map((name) => [name, headerValue(req.headers[name])]),
+              ),
+            }
+          : {}),
         bytes: body.length,
         contentEncoding,
         receivedAtMs: Date.now(),

--- a/test/e2e/qa-lab/runtime/otel-test-support.ts
+++ b/test/e2e/qa-lab/runtime/otel-test-support.ts
@@ -107,7 +107,7 @@ export function createRecentTraceSummary() {
         }
       }
     },
-    read(): CapturedTraceSummary[] {
+    read: (): CapturedTraceSummary[] => {
       return [...traces].map(([traceId, names]) => ({
         traceId,
         names: Object.fromEntries(names),


### PR DESCRIPTION
## What Problem This Solves

Changes to `diagnostics.otel.*` and `diagnostics.enabled` take effect without restarting the Gateway or every plugin. Successful exporter replacements preserve unrelated services, sessions, channels, and operator connections while adopting the configured endpoint, headers, service name, metric prefix, and enabled signals.

## Why This Change Was Made

Plugin services can declare existing configuration paths through optional `reload.configPrefixes` metadata. The planner preserves established core, plugin, and channel policy before adding service ownership. The existing service lifecycle then replaces only the selected generations after configuration publication, using the same start/stop, lease, cron, and cleanup owners. Full plugin replacement subsumes selected service reload. If cleanup or startup fails, the existing Gateway recovery path takes over; this failure path can interrupt otherwise unrelated connections.

The Gateway owns diagnostic enablement, heartbeat, and shutdown together. Telegram webhook shutdown no longer stops the host heartbeat, and webhook diagnostics use the canonical retained-config reader at emission. Explicit standalone configurations remain scoped. Exporter cleanup uses one generation state object, and the managed reload wrapper forwards its existing owner callbacks directly.

## User Impact and Compatibility

No new or removed configuration keys, changed defaults, wire protocol, or storage schema. Existing host-owned OpenTelemetry SDK providers remain host-owned. The optional plugin-service reload metadata is an additive SDK capability explicitly accepted for this work and documented with precedence and failure-recovery semantics. The shared config reader and SDK budget increment landed in #138638 and are deduplicated here.

Production LOC: **+310/-196 (net +114)**; tests/test support **+1056/-88 (net +968)**; docs **+31/-2 (net +29)**. The production growth implements selected service generations, lease ownership, and recovery after consolidating duplicated lifecycle and callback plumbing.

## Validation

Failed-before regressions cover service fallback suppressing established reload policy, lost managed-owner callbacks, stale diagnostic observations after re-enable, and webhook teardown or scoped configuration affecting host diagnostics. Selected-service tests preserve sibling instances and counters, fence old capabilities and callbacks, and cover cleanup/start failure plus cron ownership.

The first main integration passed **1,040 tests in 14 files**, covering Gateway reload/planner/startup/close/generation, service/cron lifecycle, diagnostics, Telegram webhook, retained config, and OTLP receiver behavior. The complete changed gate passed formatting, guards, every type project, SDK boundaries, dead-code scans, typed lint, and import-cycle checks. Independent full review found only a duplicate test declaration introduced during rebase; the staged two-line removal passed a focused follow-up review. The subsequent registry-owner integration at `102452c8b93d566582b3e440987666341869a445`, based on pinned main `a592554b536c8d3ba6d833252718588451321b0d`, passed another **393 tests in 8 files**, core/core-test typechecking, merged-file formatting, and independent review. The only further conflict retained generic parameter forwarding, including main’s new Gateway registry callback. Final exact-head Linux proof and [required CI 33936454662](https://github.com/openclaw/openclaw/actions/runs/33936454662) both passed.

## Final Exact-Head Linux Proof

Built and exercised `102452c8b93d566582b3e440987666341869a445` on Linux in [run 33936577463](https://github.com/openclaw/openclaw/actions/runs/33936577463). Full build and all **five groups passed**: initial global enablement; endpoint/header/service-name/metric-prefix replacement; metrics-only operation; exporter disable/re-enable; and global disable/resume while retaining Prometheus counters. Real loopback collectors received OTLP protobuf traces, metrics, and logs with generation-specific headers/resources. Gateway PID **9721**, boot ID `aeae44c1-ed06-4728-9d24-5d456a824534`, and the existing operator connection survived throughout (one hello, zero closes). Joined shutdown produced no late exports for two configured intervals plus 200 ms. State and upstream traffic were synthetic, with no credentials or model/provider calls.

Command and wrapper exited **0**. The verified **17,039-byte** receipt archive has SHA-256 `5d0246ac0fea7bff904432d2876ab4293aac24a029c6bd5c000a1befc6a5ec2b`. Source and build identity both match the published head; verified tree `ce746af45c1ca2c80d15a8b0ceec471f4886bb2a`, transport carrier `f4b6f1ff178d0fefdb007ccd517257d5c7997d92`. The owned lease was stopped and native status confirmed completed. Full build took 236.5 seconds; the live phase took 39.9 seconds.

The scoped run invokes the committed helper. The aggregate hot-reload QA entrypoint also calls it; that aggregate and its startup-only `gateway.controlUi.basePath` positive control have static/type coverage. Externally preloaded SDK ownership and injected replacement failures are covered by focused lifecycle tests rather than this successful-transition collector run.

## Review Disposition

The latest completed ClawSweeper review of `55832bac` found no code or security defects. Its SDK-budget/integration rank-up is addressed by reusing the reader already on main and validating the combined owner paths. The documented recovery tradeoff is retained intentionally: failed replacement enters canonical recovery instead of leaving a partially replaced service generation active. Compatibility is unchanged apart from the accepted optional service metadata. Exact integrated CI and the final Linux proof both passed. No additional configuration, protocol, or storage changes were introduced by the main integration.
