### PR TITLE
fix(file-transfer): remove false channel-attachment promise from dir_fetch summary

### DIFF
--- a/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
@@ -219,6 +219,31 @@ describe("dir.fetch archive extraction", () => {
     );
   });
 
+  it("does not claim channel attachment in the summary text", async () => {
+    // Regression test for #138383: dir_fetch is not in TRUSTED_TOOL_RESULT_MEDIA,
+    // so filterToolResultMediaUrls strips local paths. The summary must not
+    // promise channel attachment.
+    const entries = Array.from({ length: 30 }, (_, i) => `file-${String(i).padStart(3, "0")}.txt`);
+    const tarBuffer = await createTarBuffer({
+      entries,
+      setup: async (sourceDir) => {
+        for (const name of entries) {
+          await fs.writeFile(path.join(sourceDir, name), `content-${name}`);
+        }
+      },
+    });
+    prepareArchive(tarBuffer);
+
+    const result = await executeDirFetch();
+    const summaryText = (result.content as Array<{ text: string }>)[0]!.text;
+
+    // Must NOT claim channel attachment
+    expect(summaryText).not.toMatch(/channel attaches/i);
+    // Must accurately describe what happened
+    expect(summaryText).toMatch(/\d+ of \d+ paths listed in details\.files/);
+    expect(summaryText).toMatch(/ask me to send them to share them/);
+  });
+
   it.each(["SymbolicLink", "Link", "CharacterDevice", "BlockDevice", "FIFO"] as const)(
     "rejects a Fleet-shaped archive containing a %s",
     async (type) => {

--- a/extensions/file-transfer/src/tools/dir-fetch-tool.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.ts
@@ -20,9 +20,8 @@ import {
 } from "./descriptors.js";
 import { invokeNodeToolPayload, readRequiredNodePath } from "./node-tool-invoke.js";
 
-// Cap how many local file paths we surface in details.media.mediaUrls.
-// Larger trees still land on disk but we don't spam the channel adapter
-// with hundreds of attachments.
+// Cap how many local file paths we surface in details.files.
+// Larger trees still land on disk but we keep the details payload bounded.
 const MEDIA_URL_CAP = 25;
 
 // Hard timeout for gateway-side archive extraction.
@@ -232,10 +231,11 @@ export function createDirFetchTool(): AnyAgentTool {
       const mediaUrls = allOrdered.slice(0, MEDIA_URL_CAP).map((f) => f.localPath);
 
       const shortHash = sha256.slice(0, 12);
-      const mediaNote = droppedFromMedia
-        ? ` (channel attaches first ${MEDIA_URL_CAP}; ${droppedFromMedia} more in details.files)`
+      const listedCount = Math.min(allOrdered.length, MEDIA_URL_CAP);
+      const fileNote = droppedFromMedia
+        ? ` (${listedCount} of ${allOrdered.length} paths listed in details.files; ask me to send them to share them)`
         : "";
-      const summaryText = `Fetched ${fileCount} files from ${canonicalPath} (${humanSize(tarBytes)} compressed, sha256:${shortHash}) — saved on the gateway under ${rootDir}/${mediaNote}`;
+      const summaryText = `Fetched ${fileCount} files from ${canonicalPath} (${humanSize(tarBytes)} compressed, sha256:${shortHash}) — saved on the gateway under ${rootDir}/${fileNote}`;
 
       await appendFileTransferAudit({
         op: "dir.fetch",


### PR DESCRIPTION
## What Problem This Solves

`dir_fetch` tells the model "channel attaches first 25" but always attaches 0. The tool is not in `TRUSTED_TOOL_RESULT_MEDIA` (so `filterToolResultMediaUrls` strips all local paths) and never calls `toolContext.delivery.send()`. The false promise has been in the string since at least May 2025 and causes the model to report files as delivered when nothing arrived.

## Fix

Option (i) from the issue — "say only what is true":

1. Removed the false `mediaNote` that claimed "channel attaches first N"
2. Replaced with an accurate `fileNote`: "N of M paths listed in details.files; ask me to send them to share them"
3. The `MEDIA_URL_CAP` slicing stays (it bounds the details.files list) but the false promise is gone

## Evidence

- Added regression test that creates 30 files (exceeding the 25 cap), asserts the summary does NOT contain "channel attaches", and asserts it DOES contain the accurate path-count text
- 27/30 tests pass (3 failures are pre-existing PAX/GNU override tests on clean origin/main, unrelated)

Closes #138383