### PR TITLE
docs(lobster): clarify plugin installation

### DIFF
--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -68,16 +68,23 @@ With Lobster, the same job is one call that halts for approval and resumes:
 
 ## How it works
 
-OpenClaw runs Lobster workflows **in-process** using the bundled
-`@clawdbot/lobster` package as an embedded runner. No external `lobster`
-subprocess is spawned; the tool call returns a JSON envelope directly. If the
-pipeline halts for approval, the envelope carries a resume token (or a short
-approval ID) so you can continue later.
+The separately installed official `@openclaw/lobster` plugin runs Lobster
+workflows **in-process** using its embedded `@clawdbot/lobster` runtime. No
+external `lobster` subprocess is spawned; the tool call returns a JSON envelope
+directly. If the pipeline halts for approval, the envelope carries a resume
+token (or a short approval ID) so you can continue later.
 
 ## Enable
 
-Lobster is an **optional** plugin tool, not enabled by default. It ships
-bundled, so no separate install step is required - just allow the tool:
+Lobster is an **optional** plugin tool, not installed or enabled by default.
+Install the official plugin, then restart the Gateway:
+
+```bash
+openclaw plugins install @openclaw/lobster
+openclaw gateway restart
+```
+
+After the Gateway restarts, allow the tool globally:
 
 ```json
 {
@@ -178,7 +185,7 @@ For a **structured LLM step** inside a workflow, enable the optional
 
 ### Important limitation: embedded Lobster vs `openclaw.invoke`
 
-The bundled Lobster plugin runs workflows **in-process** inside the gateway.
+The installed Lobster plugin runs workflows **in-process** inside the gateway.
 In that embedded mode, `openclaw.invoke` does **not** automatically inherit a
 gateway URL/auth context for nested OpenClaw CLI tool calls.
 


### PR DESCRIPTION
Closes #138476

## What Problem This Solves

Fixes an issue where operators enabling Lobster would be told that no installation is required even though the separately published official plugin must be installed and the Gateway restarted before the optional tool can register.

## Why This Change Was Made

The guide now identifies `@openclaw/lobster` as the separately installed official plugin and `@clawdbot/lobster` as its embedded runtime. It puts plugin installation and the Gateway restart before the existing global and per-agent tool-policy examples.

## User Impact

Operators following the Lobster guide now get the complete setup sequence and can distinguish installing the OpenClaw plugin from installing a standalone Lobster CLI.

## Evidence

- Reproduced the contradictory wording on current `main` and the `v2026.9.1` release.
- Verified the official plugin catalog and `extensions/lobster` package contract declare `@openclaw/lobster` as a separately installed npm plugin that embeds `@clawdbot/lobster`.
- `pnpm docs:list`
- `pnpm format:check`
- `pnpm config:docs:check`
- `pnpm plugins:inventory:check`
- `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=<clawhub-checkout> pnpm check:docs`
- `git diff --check origin/main...HEAD`

This is a documentation-only change; no visual UI surface changed, so screenshots are not applicable.
