### PR TITLE
fix(gateway): preserve queued replies during restart

### DIFF
--- a/src/gateway/scheduled-run-gateway-context.ts
+++ b/src/gateway/scheduled-run-gateway-context.ts
@@ -6,7 +6,10 @@
  * no context and fail mid-run. RPC-triggered runs already inherit a scope from
  * their caller and must keep it.
  */
-import { withPluginRuntimeGatewayContextResolver } from "../plugins/runtime/gateway-request-scope.js";
+import {
+  bindGatewayContextResolver,
+  withPluginRuntimeGatewayContextResolver,
+} from "../plugins/runtime/gateway-request-scope.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 
 type ScheduledGatewayContextResolver = () => GatewayRequestContext | undefined;
@@ -32,10 +35,13 @@ export function fenceScheduledGatewayContextResolver(
   if (!resolveGatewayContext) {
     return undefined;
   }
-  return () => {
+  const resolveScheduledContext = () => {
     const context = resolveGatewayContext();
     return context?.resolveGatewayContext?.() ?? undefined;
   };
+  // Keep the execution fence while retaining the host identity used by shutdown.
+  bindGatewayContextResolver(resolveScheduledContext, resolveGatewayContext);
+  return resolveScheduledContext;
 }
 
 /**

--- a/src/gateway/server-kernel-request-runtime.ts
+++ b/src/gateway/server-kernel-request-runtime.ts
@@ -1,6 +1,7 @@
 import { getRuntimeConfig } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
+import { bindGatewayContextResolver } from "../plugins/runtime/gateway-request-scope.js";
 import { createGatewayChatMetadataLifecycle } from "./server-chat-metadata-lifecycle.js";
 import type { startGatewayCoreRuntime } from "./server-core-runtime.js";
 import { attachInitialGatewayLifetimeSidecars } from "./server-lifetime-sidecars.js";
@@ -267,6 +268,12 @@ export async function prepareGatewayKernelRequestRuntime(params: {
   gatewayInstanceRuntimeRef.current = gatewayInstanceRuntime;
   gatewayRequestContext.resolveGatewayContext = () =>
     gatewayInstanceRuntime.isAvailable() ? gatewayRequestContext : undefined;
+  // Detached RPC replies retain this availability fence after the request ends.
+  // Shutdown must still recognize them as work owned by this exact Gateway.
+  bindGatewayContextResolver(
+    gatewayRequestContext.resolveGatewayContext,
+    runtime.resolvePluginGatewayContext,
+  );
   const hostLifecycle = params.hostLifecycle;
   if (hostLifecycle) {
     gatewayRequestContext.hostLifecycle = {

--- a/src/gateway/server-rpc-restart-owner.test.ts
+++ b/src/gateway/server-rpc-restart-owner.test.ts
@@ -1,0 +1,223 @@
+import { createServer } from "node:http";
+import { expect, it, vi } from "vitest";
+import { writeOpenAiResponsesText } from "../../test/helpers/openai-responses-sse.js";
+import { createDeferred } from "../../test/helpers/promise.js";
+import * as followupDelivery from "../auto-reply/reply/followup-delivery.js";
+import { replyRunRegistry } from "../auto-reply/reply/reply-run-registry.js";
+import * as sessionAccessor from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  captureGatewaySessionWorkAdmissions,
+  getSessionWorkAdmissionRelease,
+} from "../sessions/session-lifecycle-admission.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import type { GatewayContextResolver, GatewayRequestContext } from "./server-methods/types.js";
+import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
+import { buildMockOpenAiResponsesProvider } from "./test-openai-responses-model.js";
+
+it(
+  "records an actual RPC queued reply awaiting final delivery during restart",
+  { timeout: 120_000 },
+  async () => {
+    const token = "synthetic-rpc-owner-token";
+    const state = await createOpenClawTestState({
+      label: "rpc-restart-owner",
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: token,
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      },
+    });
+    const sessionKey = "agent:main:rpc-restart-owner";
+    const firstGate = createDeferred();
+    const finalGate = createDeferred();
+    const finalReached = createDeferred();
+    let firstReceived = false;
+    let followupReceived = false;
+    const tasks = new Set<Promise<void>>();
+    const providerServer = createServer((request, response) => {
+      const task = (async () => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of request) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+        if (request.method !== "POST" || request.url !== "/v1/responses") {
+          response.writeHead(404).end();
+          return;
+        }
+        const body = Buffer.concat(chunks).toString("utf8");
+        const followup = body.includes("SYNTHETIC_QUEUED_REPLY");
+        const first = !followup && body.includes("SYNTHETIC_FIRST_REPLY");
+        if (first) {
+          firstReceived = true;
+          await firstGate.promise;
+        }
+        if (followup) {
+          followupReceived = true;
+        }
+        if (!response.destroyed) {
+          writeOpenAiResponsesText(response, {
+            text: followup ? "QUEUED_REPLY_FOR_RECOVERY" : "FIRST_REPLY_COMPLETE",
+            messageId: followup ? "queued-message" : "first-message",
+            responseId: followup ? "queued-response" : "first-response",
+          });
+        }
+      })().catch((error: unknown) => {
+        if (!response.destroyed) {
+          response.writeHead(500).end(String(error));
+        }
+      });
+      tasks.add(task);
+      void task.finally(() => tasks.delete(task));
+    });
+    let gateway: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+    let closed = false;
+    let replyReleased: Promise<void> | undefined;
+    let hostResolver: GatewayContextResolver | undefined;
+    let context: GatewayRequestContext | undefined;
+    const kernel = await import("./server-kernel-request-runtime.js");
+    const prepare = kernel.prepareGatewayKernelRequestRuntime;
+    const startupSpy = vi
+      .spyOn(kernel, "prepareGatewayKernelRequestRuntime")
+      .mockImplementation(async (params) => {
+        hostResolver = params.coreRuntime.resolvePluginGatewayContext;
+        const result = await prepare(params);
+        context = result.gatewayRequestContext;
+        return result;
+      });
+    const deliver = followupDelivery.deliverFollowupDecision;
+    const deliverySpy = vi
+      .spyOn(followupDelivery, "deliverFollowupDecision")
+      .mockImplementation(async (params) => {
+        if (
+          params.decision.kind === "deliver" &&
+          params.kind !== "tool" &&
+          params.kind !== "block"
+        ) {
+          finalReached.resolve();
+          await finalGate.promise;
+        }
+        return await deliver(params);
+      });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        providerServer.once("error", reject);
+        providerServer.listen(0, "127.0.0.1", resolve);
+      });
+      const address = providerServer.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Synthetic provider did not bind");
+      }
+      const provider = buildMockOpenAiResponsesProvider(
+        `http://127.0.0.1:${address.port}/v1`,
+        "gpt-rpc-owner-proof",
+      );
+      const cfg = {
+        agents: {
+          defaults: {
+            workspace: state.workspaceDir,
+            skipBootstrap: true,
+            model: { primary: provider.modelRef },
+            models: {
+              [provider.modelRef]: { params: { transport: "sse", openaiWsWarmup: false } },
+            },
+          },
+          entries: { main: {} },
+        },
+        models: { mode: "replace", providers: { [provider.providerId]: provider.config } },
+        gateway: { auth: { mode: "token", token } },
+        plugins: { slots: { memory: "none" } },
+      } satisfies OpenClawConfig;
+      gateway = await startGatewayWithClient({ cfg, configPath: state.configPath, token });
+      startupSpy.mockRestore();
+      await gateway.server.startupSettled;
+      await gateway.client.request("chat.send", {
+        sessionKey,
+        message: "SYNTHETIC_FIRST_REPLY",
+        idempotencyKey: "rpc-first",
+        queueMode: "followup",
+      });
+      await vi.waitFor(() => expect(firstReceived).toBe(true), { timeout: 60_000 });
+      await gateway.client.request("chat.send", {
+        sessionKey,
+        message: "SYNTHETIC_QUEUED_REPLY",
+        idempotencyKey: "rpc-queued",
+        queueMode: "followup",
+      });
+      await vi.waitFor(() => expect(context?.chatQueuedTurns.has("rpc-queued")).toBe(true));
+      firstGate.resolve();
+      await finalReached.promise;
+      expect(followupReceived).toBe(true);
+      if (!context || !hostResolver || !context.resolveGatewayContext) {
+        throw new Error("Missing actual Gateway resolver");
+      }
+      const storePath = state.statePath("agents", "main", "sessions", "sessions.json");
+      const entry = sessionAccessor.loadSessionEntry({ storePath, sessionKey });
+      if (!entry) {
+        throw new Error("Real RPC did not create a session");
+      }
+      const target = { scope: storePath, sessionKey, sessionId: entry.sessionId };
+      replyReleased = getSessionWorkAdmissionRelease({
+        scope: storePath,
+        identities: [sessionKey],
+      });
+      expect(captureGatewaySessionWorkAdmissions(() => context).isActive(target)).toBe(false);
+      console.log(
+        "RPC_OWNER_BEFORE_CLOSE",
+        JSON.stringify({
+          status: entry.status,
+          operation: replyRunRegistry.get(sessionKey)?.turnKind,
+          activeChatRuns: context.chatAbortControllers.size,
+          queued: context.chatQueuedTurns.size,
+          hostCaptured: captureGatewaySessionWorkAdmissions(hostResolver).isActive(target),
+          rpcCaptured: captureGatewaySessionWorkAdmissions(context.resolveGatewayContext).isActive(
+            target,
+          ),
+        }),
+      );
+      await gateway.server.close({
+        reason: "synthetic queued reply restart",
+        restartExpectedMs: 123,
+        drainTimeoutMs: 0,
+      });
+      closed = true;
+      const after = sessionAccessor.loadSessionEntry({ storePath, sessionKey });
+      console.log(
+        "RPC_OWNER_AFTER_CLOSE",
+        JSON.stringify({
+          marker: after?.abortedLastRun === true,
+          safeTools: after?.restartRecoveryForceSafeTools === true,
+          status: after?.status,
+        }),
+      );
+      expect(after?.abortedLastRun).toBe(true);
+      expect(after?.restartRecoveryForceSafeTools).toBe(true);
+      expect(context.resolveGatewayContext()).toBeUndefined();
+    } finally {
+      startupSpy.mockRestore();
+      deliverySpy.mockRestore();
+      firstGate.resolve();
+      finalGate.resolve();
+      if (gateway) {
+        await disconnectGatewayClient(gateway.client).catch(() => undefined);
+        if (!closed) {
+          await gateway.server.close().catch(() => undefined);
+        }
+      }
+      await replyReleased;
+      providerServer.closeAllConnections();
+      if (providerServer.listening) {
+        await new Promise<void>((resolve) => {
+          providerServer.close(() => resolve());
+        });
+      }
+      await Promise.allSettled(tasks);
+      await state.cleanup();
+    }
+  },
+);

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -18,7 +18,9 @@ function waitForFast<T>(
 }
 
 import {
+  bindGatewayContextResolver,
   getPluginRuntimeGatewayRequestScope,
+  hasGatewayContextOwner,
   withPluginRuntimeGatewayRequestScope,
 } from "../plugins/runtime/gateway-request-scope.js";
 import { runtimeServiceMocks as hoisted } from "./server-runtime-services.test-harness.js";
@@ -337,17 +339,18 @@ describe("server-runtime-services", () => {
       terminalSessions: {},
       resolveGatewayContext: () => gatewayContext,
     } as never;
+    const resolveGatewayContext = () => gatewayContext;
+    const admittedOwner = {};
     let observed: unknown = "never-ran";
     let observedClient: unknown = "never-ran";
     hoisted.runHeartbeatOnce.mockImplementationOnce(async () => {
       const scope = getPluginRuntimeGatewayRequestScope();
+      bindGatewayContextResolver(admittedOwner, scope?.resolveGatewayContext);
       observed = scope?.resolveGatewayContext?.();
       observedClient = scope?.client;
       return { status: "ran", durationMs: 1 };
     });
-    const { services } = activateScheduledServicesForTest({
-      resolveGatewayContext: () => gatewayContext,
-    });
+    const { services } = activateScheduledServicesForTest({ resolveGatewayContext });
     const runnerParams = hoisted.startHeartbeatRunner.mock.calls[0]?.[0] as
       | { runOnce?: (opts: never) => Promise<unknown> }
       | undefined;
@@ -358,6 +361,8 @@ describe("server-runtime-services", () => {
 
     expect(observed).toBe(gatewayContext);
     expect(observedClient).toBeUndefined();
+    expect(hasGatewayContextOwner(admittedOwner, resolveGatewayContext)).toBe(true);
+    expect(hasGatewayContextOwner(admittedOwner, () => gatewayContext)).toBe(false);
     services.heartbeatRunner.stop();
   });
 

--- a/src/gateway/server-runtime-state-prepare.ts
+++ b/src/gateway/server-runtime-state-prepare.ts
@@ -94,6 +94,7 @@ export async function prepareGatewayKernelState(params: {
     ambientAutostartSuppressedChannelIds,
     minimalTestGateway,
     pluginGatewayContext,
+    resolvePluginGatewayContext,
   } = bootstrap;
   const pluginRuntime = {
     registry: pluginBootstrap.pluginRegistry,
@@ -134,7 +135,7 @@ export async function prepareGatewayKernelState(params: {
         return await workerModule.createGatewayWorkerEnvironmentRuntime({
           getPluginRegistry: () => pluginRuntime.registry,
           getPortalRuntime: () => pluginGatewayContext.current,
-          resolveGatewayContext: () => pluginGatewayContext.current,
+          resolveGatewayContext: resolvePluginGatewayContext,
           desktopSessionRegistry,
           nodeDesktopStreamBroker,
           startup: workerEnvironmentStartup,
@@ -469,7 +470,7 @@ export async function prepareGatewayKernelState(params: {
     pluginRegistry: pluginRuntime.registry,
     getPluginRouteRegistry: () => pluginRuntime.registry,
     isStartupPluginRuntimeReady: () => startupState.sidecarsReady,
-    getGatewayRequestContext: () => pluginGatewayContext.current,
+    getGatewayRequestContext: resolvePluginGatewayContext,
     deps,
     log,
     logHooks,


### PR DESCRIPTION
Closes #138564
Related: #138071

<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers with repository write access can edit it. GitHub reserves the fork-collaboration toggle for cross-repository PRs.

</details>

## What Problem This Solves

Fixes an issue where users sending queued followups through Gateway RPC could lose restart recovery when the original `chat.send` run had finished but the queued reply was still awaiting final delivery.

## Why This Change Was Made

Shutdown identifies work by its exact Gateway host. The RPC and scheduled lifetime resolvers preserved execution availability checks but did not record their host identity, so shutdown could miss the retained admission after the original chat-run registration disappeared.

Bind those resolvers at their creation and reuse the existing canonical host for HTTP hooks and worker dispatch. The execution fences and exact-owner matcher remain unchanged; there are no config, schema, stored-representation, or migration changes.

Production LOC: **+18/-4 (net +14)**. Tests: **+231/-3 (net +228)**. Production growth records the two required host bindings while preserving their executable lifecycle checks; two duplicate raw resolver closures are removed.

## User Impact

Queued RPC replies remain eligible for restart recovery through final delivery. Scheduled work and HTTP hooks retain the same exact Gateway owner when shutdown selects pending work.

## Evidence

The regression test sends two authenticated WebSocket `chat.send` requests through an actual Gateway and a synthetic loopback HTTP SSE provider. It pauses the existing queued final-delivery function after model completion. It creates no synthetic reply operations or admissions.

| Observation at restart | Before | After |
| --- | --- | --- |
| Original active chat-run registrations | 0 | 0 |
| Actual queued reply awaiting delivery | present | present |
| Closing Gateway recognizes retained admission | false | true |
| Durable restart-recovery marker | absent | present |
| Safe recovery tools requested | false | true |
| Session status after close | done | running |

- Captured failing Gateway reproduction before the repair; the same scenario passes afterward.
- Captured the standalone scheduled-heartbeat owner assertion failing before its producer binding was fixed.
- **254 tests passed** across the Gateway RPC regression, runtime services, cron, plugin runtime, and request-scope suites. After test-only lint cleanup, **41 affected tests passed again**.
- Full `scripts/check-changed.mjs` core/coreTests gate passed, including types, lint, dead-export scans, import cycles, and ownership guards.
- Independent Codex review found no actionable P0–P2 issues on the final diff.
- Current main `e449371c3b157d59292cbdee1aa9a9112fb1c7b6` has no changes intersecting these five files since the tested baseline.

Run the focused actual-Gateway proof with:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-rpc-restart-owner.test.ts
```

The proof reaches durable restart selection through real Gateway close. It does not claim a second-process resumed delivery, a public provider/channel call, or GUI/video coverage.
