### PR TITLE
perf(media): normalize HEIC images without base64 round trips

### DIFF
--- a/src/media-understanding/image-input-normalize.ts
+++ b/src/media-understanding/image-input-normalize.ts
@@ -1,7 +1,7 @@
 // Image input normalization converts HEIC/HEIF payloads through the shared
 // input-file media path before provider execution.
 import { normalizeMimeType } from "@openclaw/media-core/mime";
-import { extractImageContentFromSource } from "../media/input-files.js";
+import { normalizeInputImageBuffer } from "../media/input-files.js";
 import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
 
 const HEIC_MIME_RE = /^image\/hei[cf](?:-sequence)?$/i;
@@ -27,23 +27,17 @@ export async function normalizeImageDescriptionInput(params: {
     return { buffer: params.buffer, mime: params.mime };
   }
   const sourceMime = normalizeMimeType(params.mime) ?? "image/heic";
-  // Reuse input-file extraction so HEIC conversion follows the same MIME and size guards.
-  const image = await extractImageContentFromSource(
-    {
-      type: "base64",
-      data: params.buffer.toString("base64"),
-      mediaType: sourceMime,
-    },
-    {
-      allowUrl: false,
+  // Keep owned bytes through the shared MIME and size guards; only API content needs base64.
+  const image = await normalizeInputImageBuffer({
+    buffer: params.buffer,
+    mimeType: sourceMime,
+    limits: {
       allowedMimes: new Set([sourceMime.toLowerCase(), "image/heic", "image/heif", "image/jpeg"]),
       maxBytes: params.maxBytes ?? DEFAULT_MAX_BYTES.image,
-      maxRedirects: 0,
-      timeoutMs: 0,
     },
-  );
+  });
   return {
-    buffer: Buffer.from(image.data, "base64"),
+    buffer: image.buffer,
     mime: image.mimeType,
   };
 }

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -271,11 +271,17 @@ function withInputFileTimeout<T>(params: {
   });
 }
 
-async function normalizeInputImage(params: {
+/** Validates owned image bytes and normalizes HEIC/HEIF without changing their representation. */
+export async function normalizeInputImageBuffer(params: {
   buffer: Buffer;
   mimeType?: string;
-  limits: InputImageLimits;
-}): Promise<InputImageContent> {
+  limits: Pick<InputImageLimits, "allowedMimes" | "maxBytes">;
+}): Promise<{ buffer: Buffer; mimeType: string }> {
+  if (params.buffer.byteLength > params.limits.maxBytes) {
+    throw new Error(
+      `Image too large: ${params.buffer.byteLength} bytes (limit: ${params.limits.maxBytes} bytes)`,
+    );
+  }
   const declaredMime = normalizeMimeType(params.mimeType) ?? "application/octet-stream";
   const detectedMime = normalizeMimeType(
     await detectMime({ buffer: params.buffer, headerMime: params.mimeType }),
@@ -292,11 +298,7 @@ async function normalizeInputImage(params: {
   }
 
   if (!HEIC_INPUT_IMAGE_MIMES.has(sourceMime)) {
-    return {
-      type: "image",
-      data: params.buffer.toString("base64"),
-      mimeType: sourceMime,
-    };
+    return { buffer: params.buffer, mimeType: sourceMime };
   }
 
   // Normalize HEIC/HEIF to JPEG because downstream model and channel surfaces expect common images.
@@ -306,11 +308,7 @@ async function normalizeInputImage(params: {
       `Image too large after HEIC conversion: ${normalizedBuffer.byteLength} bytes (limit: ${params.limits.maxBytes} bytes)`,
     );
   }
-  return {
-    type: "image",
-    data: normalizedBuffer.toString("base64"),
-    mimeType: NORMALIZED_INPUT_IMAGE_MIME,
-  };
+  return { buffer: normalizedBuffer, mimeType: NORMALIZED_INPUT_IMAGE_MIME };
 }
 
 /** Extracts and normalizes an input_image source from base64 or guarded URL input. */
@@ -318,26 +316,17 @@ export async function extractImageContentFromSource(
   source: InputImageSource,
   limits: InputImageLimits,
 ): Promise<InputImageContent> {
+  let buffer: Buffer;
+  let mimeType: string | undefined;
   if (source.type === "base64") {
     rejectOversizedBase64Payload({ data: source.data, maxBytes: limits.maxBytes, label: "Image" });
     const canonicalData = canonicalizeBase64(source.data);
     if (!canonicalData) {
       throw new Error("input_image base64 source has invalid 'data' field");
     }
-    const buffer = Buffer.from(canonicalData, "base64");
-    if (buffer.byteLength > limits.maxBytes) {
-      throw new Error(
-        `Image too large: ${buffer.byteLength} bytes (limit: ${limits.maxBytes} bytes)`,
-      );
-    }
-    return await normalizeInputImage({
-      buffer,
-      mimeType: normalizeMimeType(source.mediaType) ?? "image/png",
-      limits,
-    });
-  }
-
-  if (source.type === "url") {
+    buffer = Buffer.from(canonicalData, "base64");
+    mimeType = normalizeMimeType(source.mediaType) ?? "image/png";
+  } else if (source.type === "url") {
     if (!limits.allowUrl) {
       throw new Error("input_image URL sources are disabled by config");
     }
@@ -352,14 +341,13 @@ export async function extractImageContentFromSource(
       },
       auditContext: "openresponses.input_image",
     });
-    return await normalizeInputImage({
-      buffer: result.buffer,
-      mimeType: parseContentType(result.contentType).mimeType,
-      limits,
-    });
+    buffer = result.buffer;
+    mimeType = parseContentType(result.contentType).mimeType;
+  } else {
+    throw new Error(`Unsupported input_image source type: ${(source as { type: string }).type}`);
   }
-
-  throw new Error(`Unsupported input_image source type: ${(source as { type: string }).type}`);
+  const image = await normalizeInputImageBuffer({ buffer, mimeType, limits });
+  return { type: "image", data: image.buffer.toString("base64"), mimeType: image.mimeType };
 }
 
 /** Extracts model-visible text and images from an input_file source after MIME validation. */

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -271,7 +271,7 @@ function withInputFileTimeout<T>(params: {
   });
 }
 
-/** Validates owned image bytes and normalizes HEIC/HEIF without changing their representation. */
+/** Validates image bytes and converts HEIC/HEIF to JPEG, keeping the original Buffer otherwise. */
 export async function normalizeInputImageBuffer(params: {
   buffer: Buffer;
   mimeType?: string;


### PR DESCRIPTION
## What Problem This Solves

Describing a HEIC or HEIF image temporarily encoded and decoded the entire source image, then encoded and decoded the converted JPEG before sending its bytes to the image provider. Those four conversions added avoidable allocation and CPU work to both configured image descriptions and explicit-model descriptions.

## Why This Change Was Made

The shared input-image normalizer now accepts and returns owned image bytes. Source extraction still encodes the final public image-content result, while media understanding carries the normalized bytes directly to its provider. This removes the internal base64 detour and the duplicated source-specific normalization calls while preserving MIME sniffing, HEIC/HEIF sequence handling, and input/output limits.

Related: #122431 adds model-aware resizing after this normalization boundary; this refactor does not change resizing policy.

## User Impact

HEIC/HEIF descriptions produce the same JPEG bytes with less temporary conversion work. There is no change to settings, image limits, provider requests, or the public input-image shape. Production LOC: +30/-48 (net -18). Tests and docs: unchanged.

## Evidence

A before/after probe called the actual normalizer and Rastermill converter with two real, synthetic HEIC files. A 1,306,081-byte 1536×1024 HEIC produced an identical 1,606,548-byte JPEG before and after; the smaller 128×128 fixture also matched exactly. MIME, dimensions, public input-image content, PNG passthrough, spoofed-PDF rejection, and input/output byte-limit checks passed.

Instrumented conversions fell from two base64 encodes and two decodes per description to zero. For the larger fixture, that avoids encoding 2,912,629 bytes and decoding 3,883,508 base64 characters per call. These are observed conversion counts and input volumes, not exact V8 heap savings. Concurrent timing/RSS samples are not used as performance claims.

179 existing tests passed across the following five suites:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/media/input-files.extract.test.ts \
  src/media/input-files.fetch-guard.test.ts \
  src/media-understanding/runtime.test.ts \
  src/media-understanding/runtime.local-input.test.ts \
  src/media-understanding/apply.test.ts
```

The complete canonical changed-file gate passed, including both core typechecks and all guards. Independent managed Codex review through P2 returned no actionable findings. Existing boundary tests protect the unchanged behavior; no implementation-coupled permanent conversion-count test was added.
