### PR TITLE
fix: preserve live steering when runtime context is present

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1768,7 +1768,7 @@ src/agents/embedded-agent-runner/run/attempt-context-summary.ts	2
 src/agents/embedded-agent-runner/run/attempt-execution-phase.ts	1
 src/agents/embedded-agent-runner/run/attempt-finalize.ts	3
 src/agents/embedded-agent-runner/run/attempt-history.ts	17
-src/agents/embedded-agent-runner/run/attempt-llm-boundary.ts	19
+src/agents/embedded-agent-runner/run/attempt-llm-boundary.ts	18
 src/agents/embedded-agent-runner/run/attempt-normalization.ts	1
 src/agents/embedded-agent-runner/run/attempt-prompt-build.ts	1
 src/agents/embedded-agent-runner/run/attempt-prompt-helpers.ts	4

--- a/packages/ai/src/transports/openai-responses-async-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-async-replay.test.ts
@@ -28,6 +28,50 @@ const model: Model = {
 };
 
 it.each([
+  ["provider", convertProviderResponsesMessages],
+  ["transport", convertResponsesMessages],
+] as const)(
+  "%s keeps retained runtime carriers with their own users when steering is appended",
+  (_name, convert) => {
+    const user = (content: string) => ({ role: "user" as const, content, timestamp: 1 });
+    const answer = (text: string): AssistantMessage => ({
+      ...createOpenAIResponsesAssistantOutput(model),
+      content: [{ type: "text", text }],
+    });
+    const context: Context = {
+      messages: [
+        user("first"),
+        { ...user("first context"), runtimeContextCarrier: true },
+        answer("first answer"),
+        user("second"),
+        { ...user("second context"), runtimeContextCarrier: true },
+        answer("second answer"),
+      ],
+    };
+    const original = structuredClone(context);
+    const prefix = convert(model, context, new Set(["openai"]));
+    const withSteering = convert(
+      model,
+      { messages: [...context.messages, user("steering")] },
+      new Set(["openai"]),
+    );
+    expect(withSteering.slice(0, prefix.length)).toEqual(prefix);
+    expect(withSteering).toMatchObject(
+      [
+        "first",
+        "first context",
+        "first answer",
+        "second",
+        "second context",
+        "second answer",
+        "steering",
+      ].map((text) => ({ content: [{ text }] })),
+    );
+    expect(context).toEqual(original);
+  },
+);
+
+it.each([
   ["provider early result", convertProviderResponsesMessages, true, false],
   ["provider late result", convertProviderResponsesMessages, false, false],
   ["transport early result", convertResponsesMessages, true, false],

--- a/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
@@ -374,25 +374,28 @@ function convertResponsesMessagesWithStyle(
     ? [replayPlan.compaction, ...transformedMessages]
     : transformedMessages;
   // Responses continuation requires the complete prior input before tool output.
-  // Anchor context after the user or its compaction checkpoint, not each tool round.
-  // Other transports retain their tail placement for cross-turn prompt caching.
+  // Each carrier stays with its preceding user/checkpoint; moving it past an
+  // appended steering user would rewrite the already admitted request prefix.
   const isCarrier = (message: (typeof replayMessages)[number]) =>
     "role" in message && message.role === "user" && message.runtimeContextCarrier === true;
-  const carriers = replayMessages.filter(isCarrier);
-  if (carriers.length > 0) {
-    const stableMessages = replayMessages.filter((message) => !isCarrier(message));
-    const insertionIndex =
-      stableMessages.findLastIndex((message) =>
-        "role" in message ? message.role === "user" : message.type === "compaction",
-      ) + 1;
+  if (replayMessages.some(isCarrier)) {
+    const anchored: typeof replayMessages = [];
     // A canonical window is already emitted above; its checkpoint anchors an otherwise userless tail.
-    if (insertionIndex > 0 || replayPlan.compactedWindow) {
-      replayMessages = [
-        ...stableMessages.slice(0, insertionIndex),
-        ...carriers,
-        ...stableMessages.slice(insertionIndex),
-      ];
+    let insertionIndex = replayPlan.compactedWindow ? 0 : undefined;
+    for (const message of replayMessages) {
+      if (isCarrier(message) && insertionIndex !== undefined) {
+        anchored.splice(insertionIndex++, 0, message);
+        continue;
+      }
+      anchored.push(message);
+      if (
+        !isCarrier(message) &&
+        ("role" in message ? message.role === "user" : message.type === "compaction")
+      ) {
+        insertionIndex = anchored.length;
+      }
     }
+    replayMessages = anchored;
   }
   let msgIndex = 0;
   const appendAssistant = createResponsesInputReplay(model);

--- a/packages/ai/src/transports/openai-responses-steering.integration.test.ts
+++ b/packages/ai/src/transports/openai-responses-steering.integration.test.ts
@@ -198,6 +198,61 @@ afterEach(() => {
 });
 
 describe("Responses WebSocket steering handoff", () => {
+  it("keeps runtime context with its user through steering and the automatic successor", async () => {
+    const context: Context = {
+      messages: [
+        { role: "user", content: "original", timestamp: 0 },
+        {
+          role: "user",
+          content: "runtime context",
+          timestamp: 0,
+          runtimeContextCarrier: true,
+        },
+      ],
+    };
+    const ready = createDeferred<Parameters<NonNullable<StreamOptions["onActiveResponse"]>>[0]>();
+    const stream = createOpenAIResponsesTransportStreamFn();
+    const options = {
+      apiKey: "test-key",
+      sessionId: "runtime-context-steering",
+      transport: "websocket-cached" as const,
+    };
+    const first = (
+      await stream(model, context, {
+        ...options,
+        onActiveResponse: (control) => {
+          ready.resolve(control);
+        },
+      })
+    ).result();
+    await vi.waitFor(() => expect(sockets.instances).toHaveLength(1));
+    const socket = sockets.instances[0];
+    assert(socket);
+    socket.emit({ type: "response.created", response: { id: "resp_1" } });
+    const steeringUser = { role: "user" as const, content: "new requirement", timestamp: 1 };
+    const admission = (await ready.promise).steer([steeringUser]);
+    try {
+      await vi.waitFor(() => expect(socket.requests).toHaveLength(2));
+      expect(socket.requests[1]).toMatchObject({
+        type: "response.steer",
+        input: [{ role: "user", content: [{ type: "input_text", text: "new requirement" }] }],
+      });
+      socket.emit(accepted);
+      expect(await admission).toBe(true);
+    } finally {
+      socket.emit(completed("resp_1", [output("original answer")]));
+      await first;
+    }
+    context.messages.push(await first, steeringUser);
+    socket.emit({ type: "response.created", response: { id: "resp_2" } });
+    socket.emit(completed("resp_2", [output("steered answer", "msg_2")]));
+    const second = await (await stream(model, context, options)).result();
+    expect(second.stopReason).not.toBe("error");
+    expect(second.content).toMatchObject([{ type: "text", text: "steered answer" }]);
+    expect(socket.requests.filter((request) => request.type === "response.create")).toHaveLength(1);
+    expect(socket.streamCalls).toBe(1);
+  });
+
   it.each(["prune", "prepend"])(
     "handles %s payload projection against the active prefix",
     async (mode) => {

--- a/src/agents/embedded-agent-runner/run/attempt-history.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-history.ts
@@ -165,7 +165,11 @@ export function resolveUserTranscriptMessages(
         userMessageMatchesTranscriptContext(
           message,
           candidate,
-          index === activeUserMessageIndex ? override : undefined,
+          index === activeUserMessageIndex ||
+            (typeof override?.runtimeTimestamp === "number" &&
+              override.runtimeTimestamp === timestamp)
+            ? override
+            : undefined,
         ),
     );
     if (!context) {

--- a/src/agents/embedded-agent-runner/run/attempt-llm-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-llm-boundary.ts
@@ -6,7 +6,11 @@ import { buildTimestampPrefix } from "../../../gateway/server-methods/agent-time
 import { INTER_SESSION_PROMPT_PREFIX_BASE } from "../../../sessions/input-provenance.js";
 import { hasPersistedMedia, MEDIA_ONLY_USER_TEXT } from "../../../sessions/user-turn-media.js";
 import { buildLateMediaAttachedProjection } from "../../../sessions/user-turn-transcript.js";
-import { stripHistoricalRuntimeContextCustomMessages } from "../../internal-runtime-context.js";
+import {
+  resolveRuntimeContextPromptOwner,
+  retainRuntimeContextMessageForPrompt,
+  stripHistoricalRuntimeContextCustomMessages,
+} from "../../internal-runtime-context.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { stripToolResultDetails } from "../../session-transcript-repair.js";
 import { normalizeAssistantReplayContent } from "../replay-history.js";
@@ -21,7 +25,6 @@ import {
   type CurrentUserTimestampMatch,
   type UserTranscriptContext,
 } from "./attempt-history.js";
-import { sessionMessagesContainIdempotencyKey } from "./pre-persisted-user-turn.js";
 import type { RuntimeContextCustomMessage } from "./runtime-context-prompt.js";
 
 type LlmBoundaryOptions = {
@@ -32,6 +35,11 @@ type LlmBoundaryOptions = {
   userTranscriptContexts?: readonly UserTranscriptContext[];
   currentUserTimestampOverride?: CurrentUserTimestampMatch;
 };
+
+type PromptContextTransform = (
+  messages: AgentMessage[],
+  signal?: AbortSignal,
+) => Promise<AgentMessage[]>;
 
 /**
  * Matches a leading `[... YYYY-MM-DD HH:MM ...]` timestamp envelope — either
@@ -134,6 +142,7 @@ export function installRuntimeContextMessageForPrompt(params: {
     agent: {
       state: { messages: AgentMessage[] };
       continue?: () => Promise<void>;
+      transformContext?: PromptContextTransform;
     };
   };
   message?: RuntimeContextCustomMessage;
@@ -143,33 +152,64 @@ export function installRuntimeContextMessageForPrompt(params: {
   if (!message) {
     return () => undefined;
   }
-  const install = (placeMessage: typeof appendRuntimeContextMessageForPrompt) => {
-    if (!session.messages.includes(message)) {
-      session.agent.state.messages = placeMessage({
-        message,
-        messages: session.messages,
-      });
+  const owner = retainRuntimeContextMessageForPrompt(message);
+  const install = (retry: boolean) => {
+    const messages = session.messages;
+    if (messages.includes(message)) {
+      return;
     }
+    const canonicalUser = owner.transcriptUser ?? owner.user;
+    const canonicalKey =
+      typeof canonicalUser === "object" && canonicalUser !== null
+        ? Reflect.get(canonicalUser, "idempotencyKey")
+        : undefined;
+    const userIdempotencyKey =
+      owner.transcriptUser === undefined
+        ? (params.persistedUserIdempotencyKey ?? canonicalKey)
+        : canonicalKey;
+    const userIndex = userIdempotencyKey
+      ? messages.findIndex(
+          (candidate) =>
+            candidate.role === "user" &&
+            Reflect.get(candidate, "idempotencyKey") === userIdempotencyKey,
+        )
+      : owner.user
+        ? messages.findIndex(
+            (candidate) => candidate === owner.user || candidate === owner.transcriptUser,
+          )
+        : retry
+          ? findActiveUserMessageIndex(messages)
+          : -1;
+    // Compaction restores canonical transcript objects. Keep the original user's
+    // recorded key/reference; never attach its context to a later steering user.
+    if (retry && userIndex < 0) {
+      return;
+    }
+    const index = userIndex < 0 ? messages.length : userIndex;
+    session.agent.state.messages = [...messages.slice(0, index), message, ...messages.slice(index)];
   };
-  // Keyed retries can reuse their recorded user; transient context must precede
-  // that user so the boundary's current-turn filter retains it.
-  install(
-    params.persistedUserIdempotencyKey &&
-      sessionMessagesContainIdempotencyKey(session.messages, params.persistedUserIdempotencyKey)
-      ? insertRuntimeContextMessageForPrompt
-      : appendRuntimeContextMessageForPrompt,
-  );
+  install(false);
   const agent = session.agent;
+  const originalTransformContext = agent.transformContext;
+  agent.transformContext = async (messages, signal) => {
+    // Capture source identity before prompt hooks and replay sanitizers clone it.
+    owner.user ??= messages[resolveRuntimeContextPromptOwner(messages)?.userIndex ?? -1];
+    return originalTransformContext
+      ? await originalTransformContext.call(agent, messages, signal)
+      : messages;
+  };
   const originalContinue = Reflect.get(agent, "continue", agent) as unknown;
   if (typeof originalContinue === "function") {
     const continueWithAgent = originalContinue.bind(agent) as () => Promise<void>;
     agent.continue = function continueWithRuntimeContext(this: typeof agent): Promise<void> {
       // Pi overflow recovery can rebuild state from the persisted branch before retrying.
-      install(insertRuntimeContextMessageForPrompt);
+      install(true);
       return continueWithAgent();
     };
   }
   return () => {
+    owner.release();
+    agent.transformContext = originalTransformContext;
     if (typeof originalContinue === "function") {
       agent.continue = originalContinue as typeof agent.continue;
     }
@@ -177,54 +217,15 @@ export function installRuntimeContextMessageForPrompt(params: {
   };
 }
 
-function appendRuntimeContextMessageForPrompt(params: {
-  message: RuntimeContextCustomMessage;
+function replaceUserTextPrompt(params: {
   messages: AgentMessage[];
-}): AgentMessage[] {
-  if (params.messages.includes(params.message)) {
-    return params.messages;
-  }
-  return [...params.messages, params.message];
-}
-
-/**
- * Inserts runtime context before the active user turn on retry. Overflow rebuilds
- * can rehydrate a transcript ending in tool-call messages, so the active prompt
- * is found by walking backward through tool-call assistants.
- */
-function insertRuntimeContextMessageForPrompt(params: {
-  message: RuntimeContextCustomMessage;
-  messages: AgentMessage[];
-}): AgentMessage[] {
-  if (params.messages.includes(params.message)) {
-    return params.messages;
-  }
-  const activeUserMessageIndex = findActiveUserMessageIndex(params.messages);
-  if (activeUserMessageIndex === -1) {
-    return [...params.messages, params.message];
-  }
-  return [
-    ...params.messages.slice(0, activeUserMessageIndex),
-    params.message,
-    ...params.messages.slice(activeUserMessageIndex),
-  ];
-}
-
-function replaceLastUserTextPrompt(params: {
-  messages: AgentMessage[];
-  shouldCapture?: (message: AgentMessage) => boolean;
+  userIndex: number;
   transcriptText?: string;
   replace: (text: string) => string | undefined;
 }): AgentMessage[] {
-  const userIndex = params.messages.findLastIndex((message) => message.role === "user");
-  if (userIndex === -1) {
-    return params.messages;
-  }
+  const { userIndex } = params;
   const message = params.messages[userIndex];
   if (!message || message.role !== "user") {
-    return params.messages;
-  }
-  if (params.shouldCapture && !params.shouldCapture(message)) {
     return params.messages;
   }
   const content = (message as { content?: unknown }).content;
@@ -287,10 +288,7 @@ function composeModelPromptContext(params: {
 export function installModelPromptTransform(params: {
   session: {
     agent: {
-      transformContext?: (
-        messages: AgentMessage[],
-        signal?: AbortSignal,
-      ) => Promise<AgentMessage[]>;
+      transformContext?: PromptContextTransform;
     };
   };
   transcriptPrompt: string;
@@ -307,24 +305,49 @@ export function installModelPromptTransform(params: {
   }
   const agent = params.session.agent;
   const originalTransformContext = agent.transformContext;
-  let targetPromptTimestamp: number | undefined;
+  let targetPrompt: AgentMessage | undefined;
+  let promptOwner:
+    | NonNullable<ReturnType<typeof resolveRuntimeContextPromptOwner>>["owner"]
+    | undefined;
   agent.transformContext = async (messages, signal) => {
-    const promptMessages = replaceLastUserTextPrompt({
+    if (!targetPrompt && params.shouldCapturePrompt()) {
+      targetPrompt = messages[findActiveUserMessageIndex(messages)];
+      const retainedOwner = resolveRuntimeContextPromptOwner(messages)?.owner;
+      if (retainedOwner?.user === targetPrompt) {
+        promptOwner = retainedOwner;
+      }
+    }
+    const canonicalPrompt = promptOwner?.transcriptUser ?? targetPrompt;
+    const key =
+      typeof canonicalPrompt === "object" && canonicalPrompt !== null
+        ? Reflect.get(canonicalPrompt, "idempotencyKey")
+        : undefined;
+    let userIndex = messages.findIndex(
+      (message) => message === targetPrompt || message === canonicalPrompt,
+    );
+    if (userIndex < 0 && key) {
+      userIndex = messages.findIndex(
+        (message) => message.role === "user" && Reflect.get(message, "idempotencyKey") === key,
+      );
+    }
+    // Carrierless keyless transcript replay has no retained canonical reference.
+    // Preserve its timestamp match only when unique; a known owner never adopts
+    // a later user after compaction removes the original prompt.
+    if (userIndex < 0 && targetPrompt && !promptOwner && !key) {
+      const timestamp = Reflect.get(targetPrompt, "timestamp");
+      const matches = messages.flatMap((message, index) =>
+        message.role === "user" &&
+        typeof timestamp === "number" &&
+        Reflect.get(message, "timestamp") === timestamp
+          ? [index]
+          : [],
+      );
+      userIndex = matches.length === 1 ? (matches[0] ?? -1) : -1;
+    }
+    const promptMessages = replaceUserTextPrompt({
       messages,
+      userIndex,
       transcriptText: params.transcriptPrompt,
-      shouldCapture: (message) => {
-        const timestamp = (message as { timestamp?: unknown }).timestamp;
-        if (targetPromptTimestamp !== undefined) {
-          return timestamp === targetPromptTimestamp;
-        }
-        if (!params.shouldCapturePrompt()) {
-          return false;
-        }
-        if (typeof timestamp === "number") {
-          targetPromptTimestamp = timestamp;
-        }
-        return true;
-      },
       replace: (text) => {
         if (modelPrompt?.trim() && text === params.transcriptPrompt) {
           return modelPrompt;
@@ -468,6 +491,16 @@ function normalizeUserMessagesForLlmBoundary(
   options: LlmBoundaryOptions | undefined,
 ): AgentMessage[] {
   const activeUserMessageIndex = findActiveUserMessageIndex(messages);
+  const prompt = resolveRuntimeContextPromptOwner(messages);
+  const promptUserMessageIndex = prompt?.userIndex ?? -1;
+  if (prompt) {
+    // The persistence owner already records this exact pair, including keyless
+    // users and write-hook replacements. Retain it for same-attempt compaction.
+    prompt.owner.transcriptUser =
+      options?.userTranscriptContexts?.find(
+        (context) => context.runtimeMessage === prompt.owner.user,
+      )?.transcriptMessage ?? prompt.owner.transcriptUser;
+  }
   let changed = false;
   const nextMessages = messages.map((message, index) => {
     if (message.role !== "user") {
@@ -475,13 +508,17 @@ function normalizeUserMessagesForLlmBoundary(
     }
     const content = (message as { content?: unknown }).content;
     const injectMediaText = !hasNonBlankUserText(content) && hasPersistedMedia(message);
-    const isActive = index === activeUserMessageIndex;
+    const isActive =
+      index === activeUserMessageIndex ||
+      (promptUserMessageIndex >= 0 && index >= promptUserMessageIndex);
     const preserveInboundMetadata = isActive || options?.appendOnlyRuntimeContext === true;
     const override = options?.currentUserTimestampOverride;
     const runtimeTimestamp = (message as { timestamp?: unknown }).timestamp;
     const useCurrentUserTimestampOverride =
-      isActive &&
       override !== undefined &&
+      (isActive ||
+        (typeof override.runtimeTimestamp === "number" &&
+          override.runtimeTimestamp === runtimeTimestamp)) &&
       messageContentMatchesCurrentUserText(content, override) &&
       messageRuntimeTimestampMatchesCurrentUserOverride(runtimeTimestamp, override);
     const messageTimestamp = useCurrentUserTimestampOverride

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.steering.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.steering.test.ts
@@ -1,0 +1,313 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it } from "vitest";
+import { relocateCurrentRuntimeContextCarrierToTail } from "../../internal-runtime-context.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import { SessionManager } from "../../sessions/session-manager.js";
+import {
+  installRuntimeContextMessageForPrompt,
+  installModelPromptTransform,
+  normalizeMessagesForLlmBoundary,
+} from "./attempt-llm-boundary.js";
+import { createUserTranscriptContextRegistry } from "./attempt-user-transcript-context-registry.js";
+import { buildRuntimeContextCustomMessage } from "./runtime-context-prompt.js";
+
+describe("active prompt steering context", () => {
+  it.each([
+    ["replacement", true],
+    ["context", true],
+    ["replacement", false],
+    ["context", false],
+  ] as const)(
+    "keeps %s attached to the original keyed user with same-time steering (carrier: %s)",
+    async (mode, withCarrier) => {
+      const original = {
+        role: "user" as const,
+        content: "original",
+        timestamp: 1,
+        idempotencyKey: "original-user",
+      };
+      const steering = {
+        role: "user" as const,
+        content: "steering",
+        timestamp: 1,
+        idempotencyKey: "steering-user",
+      };
+      const session = {
+        get messages() {
+          return this.agent.state.messages;
+        },
+        agent: {
+          state: { messages: [] as AgentMessage[] },
+          continue: async () => undefined,
+          transformContext: async (messages: AgentMessage[]) => messages,
+        },
+      };
+      const originalTransform = session.agent.transformContext;
+      const originalContinue = session.agent.continue;
+      const cleanupPrompt = installModelPromptTransform({
+        session,
+        transcriptPrompt: "original",
+        ...(mode === "replacement"
+          ? { modelPrompt: "private model prompt" }
+          : { prependContext: "before", appendContext: "after" }),
+        shouldCapturePrompt: () => true,
+      });
+      const cleanupCarrier = installRuntimeContextMessageForPrompt({
+        session,
+        message: withCarrier ? buildRuntimeContextCustomMessage("original context") : undefined,
+      });
+      session.agent.state.messages.push(original);
+      const prefix = await session.agent.transformContext(session.messages);
+      session.agent.state.messages.push(steering);
+      const steered = await session.agent.transformContext(session.messages);
+      cleanupCarrier();
+      cleanupPrompt();
+      expect(steered.slice(0, prefix.length)).toEqual(prefix);
+      expect(steered.at(-1)).toBe(steering);
+      expect(session.agent.transformContext).toBe(originalTransform);
+      expect(session.agent.continue).toBe(originalContinue);
+    },
+  );
+  it.each(["keyless", "keyed", "rewritten key"])(
+    "restores the original %s transcript user after actual compaction rebuild",
+    async (mode) => {
+      const original = { role: "user" as const, content: "original", timestamp: 1 };
+      const steering = { role: "user" as const, content: "steering", timestamp: 1 };
+      const manager = SessionManager.inMemory();
+      const contexts = createUserTranscriptContextRegistry();
+      const session = {
+        get messages() {
+          return this.agent.state.messages;
+        },
+        agent: {
+          state: { messages: [] as AgentMessage[] },
+          continue: async () => undefined,
+          transformContext: async (messages: AgentMessage[]) => messages,
+        },
+      };
+      const message = buildRuntimeContextCustomMessage("original context");
+      const cleanupPrompt = installModelPromptTransform({
+        session,
+        transcriptPrompt: "original",
+        prependContext: "before",
+        shouldCapturePrompt: () => true,
+      });
+      const cleanup = installRuntimeContextMessageForPrompt({
+        session,
+        message,
+        ...(mode === "rewritten key" ? { persistedUserIdempotencyKey: "before-hook-key" } : {}),
+      });
+      session.agent.state.messages.push(original);
+      const persisted = manager.appendMessageWithTranscriptAnchor({
+        ...original,
+        ...(mode === "keyless" ? {} : { idempotencyKey: "canonical-key" }),
+      });
+      contexts.record(original, persisted.message);
+      normalizeMessagesForLlmBoundary(await session.agent.transformContext(session.messages), {
+        userTranscriptContexts: contexts.list(),
+      });
+      const persistedSteering = manager.appendMessageWithTranscriptAnchor(steering);
+      manager.appendCompaction("Earlier context was summarized.", persisted.entryId, 100);
+      session.agent.state.messages = manager.buildSessionContext().messages;
+      await session.agent.continue();
+      const retry = session.messages;
+      const projected = await session.agent.transformContext(retry);
+      cleanup();
+      cleanupPrompt();
+      expect(persisted.message).not.toBe(original);
+      expect(retry.slice(-3)).toEqual([message, persisted.message, persistedSteering.message]);
+      expect(projected.at(-2)).toMatchObject({ content: "before\n\noriginal" });
+      expect(projected.at(-1)).toBe(persistedSteering.message);
+      expect(session.messages).not.toContain(message);
+    },
+  );
+
+  it.each([false, true])(
+    "replays a carrierless keyless prompt only with an unambiguous canonical timestamp (%s)",
+    async (ambiguous) => {
+      const original: AgentMessage = { role: "user", content: "original", timestamp: 1 };
+      const manager = SessionManager.inMemory();
+      const session = { agent: { transformContext: async (messages: AgentMessage[]) => messages } };
+      const cleanup = installModelPromptTransform({
+        session,
+        transcriptPrompt: "original",
+        prependContext: "before",
+        shouldCapturePrompt: () => true,
+      });
+      await session.agent.transformContext([original]);
+      const persisted = manager.appendMessageWithTranscriptAnchor(original);
+      if (ambiguous) {
+        manager.appendMessage({ role: "user", content: "steering", timestamp: 1 });
+      }
+      manager.appendCompaction("Earlier context was summarized.", persisted.entryId, 100);
+      const canonical = manager.buildSessionContext().messages;
+      const projected = await session.agent.transformContext(canonical);
+      cleanup();
+      if (ambiguous) {
+        expect(projected).toEqual(canonical);
+      } else {
+        expect(projected.at(-1)).toMatchObject({ content: "before\n\noriginal" });
+      }
+    },
+  );
+
+  it("does not adopt same-time steering after compaction removes the owned prompt", async () => {
+    const original: AgentMessage = { role: "user", content: "original", timestamp: 1 };
+    const steering: AgentMessage = { role: "user", content: "steering", timestamp: 1 };
+    const session = {
+      get messages() {
+        return this.agent.state.messages;
+      },
+      agent: {
+        state: { messages: [] as AgentMessage[] },
+        continue: async () => undefined,
+        transformContext: async (messages: AgentMessage[]) => messages,
+      },
+    };
+    const cleanupPrompt = installModelPromptTransform({
+      session,
+      transcriptPrompt: "original",
+      prependContext: "before",
+      shouldCapturePrompt: () => true,
+    });
+    const cleanupCarrier = installRuntimeContextMessageForPrompt({
+      session,
+      message: buildRuntimeContextCustomMessage("original context"),
+    });
+    session.agent.state.messages.push(original);
+    await session.agent.transformContext(session.messages);
+    const manager = SessionManager.inMemory();
+    manager.appendMessage(original);
+    const kept = manager.appendMessageWithTranscriptAnchor(steering);
+    manager.appendCompaction("Original request was summarized.", kept.entryId, 100);
+    session.agent.state.messages = manager.buildSessionContext().messages;
+    await session.agent.continue();
+    const projected = await session.agent.transformContext(session.messages);
+    cleanupCarrier();
+    cleanupPrompt();
+    expect(projected.at(-1)).toBe(kept.message);
+  });
+  it("preserves the active prompt prefix through steering and retires it on cleanup", () => {
+    const messages: AgentMessage[] = [];
+    const session = {
+      get messages() {
+        return this.agent.state.messages;
+      },
+      agent: { state: { messages } },
+    };
+    const message = expectDefined(
+      buildRuntimeContextCustomMessage("inbound channel context"),
+      "runtime context fixture",
+    );
+    const cleanup = installRuntimeContextMessageForPrompt({ session, message });
+    const promptText =
+      'Conversation info: ⟦openclaw:ctx⟧\n```json\n{"channel":"discord"}\n```\n\nOriginal ask';
+    const prompt: AgentMessage = {
+      role: "user",
+      content: promptText,
+      timestamp: 1717574460000,
+    };
+    session.agent.state.messages.push(prompt);
+    const options = {
+      timezone: "UTC",
+      currentUserTimestampOverride: { timestamp: 1717570800000, text: promptText },
+    };
+    const project = () =>
+      relocateCurrentRuntimeContextCarrierToTail(
+        normalizeMessagesForLlmBoundary(session.messages, options),
+      );
+    const prefix = project();
+    session.agent.state.messages.push({
+      role: "user",
+      content: "new requirement",
+      timestamp: 1717570860000,
+    });
+    const steered = project();
+    cleanup();
+
+    expect(steered.slice(0, prefix.length)).toEqual(prefix);
+    expect(steered.at(-1)).toMatchObject({
+      role: "user",
+      content: expect.stringContaining("new requirement"),
+    });
+    expect(session.messages).not.toContain(message);
+    expect(project()[0]).toMatchObject({
+      content: expect.not.stringContaining("Conversation info:"),
+    });
+    // A retained reference must not confer active-prompt ownership after cleanup.
+    session.agent.state.messages.unshift(message);
+    expect(project()).not.toContain(message);
+  });
+
+  it("reinstalls retry context before its keyed original user after steering", async () => {
+    const original = {
+      role: "user",
+      content: "original",
+      timestamp: 1,
+      idempotencyKey: "original-turn",
+    } as AgentMessage;
+    const steering = { role: "user", content: "steering", timestamp: 2 } as AgentMessage;
+    const session = {
+      get messages() {
+        return this.agent.state.messages;
+      },
+      agent: { state: { messages: [original] }, continue: async () => undefined },
+    };
+    const message = buildRuntimeContextCustomMessage("original context");
+    const originalContinue = session.agent.continue;
+    const cleanup = installRuntimeContextMessageForPrompt({
+      session,
+      message,
+      persistedUserIdempotencyKey: "original-turn",
+    });
+    session.agent.state.messages = [structuredClone(original), steering];
+    await session.agent.continue();
+    const retry = session.messages;
+    cleanup();
+    expect(retry).toEqual([message, original, steering]);
+    expect(session.agent.continue).toBe(originalContinue);
+    expect(session.messages).toEqual([original, steering]);
+  });
+
+  it.each(["model prompt", "existing context hook"])(
+    "restores the unkeyed source user after a %s transform",
+    async (mode) => {
+      const original: AgentMessage = { role: "user", content: "original", timestamp: 1 };
+      const steering: AgentMessage = { role: "user", content: "steering", timestamp: 2 };
+      const session = {
+        get messages() {
+          return this.agent.state.messages;
+        },
+        agent: {
+          state: { messages: [] as AgentMessage[] },
+          continue: async () => undefined,
+          transformContext: async (messages: AgentMessage[]) =>
+            mode === "existing context hook"
+              ? messages.map((message) =>
+                  message.role === "user" ? { ...message, content: "projected" } : message,
+                )
+              : messages,
+        },
+      };
+      const originalTransform = session.agent.transformContext;
+      const cleanupPrompt = installModelPromptTransform({
+        session,
+        transcriptPrompt: "original",
+        modelPrompt: mode === "model prompt" ? "projected" : undefined,
+        shouldCapturePrompt: () => true,
+      });
+      const message = buildRuntimeContextCustomMessage("original context");
+      const cleanup = installRuntimeContextMessageForPrompt({ session, message });
+      session.agent.state.messages.push(original);
+      normalizeMessagesForLlmBoundary(await session.agent.transformContext(session.messages));
+      session.agent.state.messages = [original, steering];
+      await session.agent.continue();
+      const retry = session.messages;
+      cleanup();
+      cleanupPrompt();
+      expect(retry).toEqual([message, original, steering]);
+      expect(session.agent.transformContext).toBe(originalTransform);
+      expect(session.messages).toEqual([original, steering]);
+    },
+  );
+});

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
@@ -1,4 +1,5 @@
 // Coverage for sanitizing replay messages at the LLM boundary.
+import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import { markInboundContextLabel } from "../../../auto-reply/reply/inbound-context-marker.js";
 import { buildTimestampPrefix } from "../../../gateway/server-methods/agent-timestamp.js";
@@ -1034,6 +1035,10 @@ describe("normalizeMessagesForLlmBoundary", () => {
     const unarmed = await session.agent.transformContext(messages);
     armed = true;
     const armedResult = await session.agent.transformContext(messages);
+    const steeredResult = await session.agent.transformContext([
+      ...messages,
+      { role: "user", content: "steering update", timestamp: 2 },
+    ]);
     cleanup();
     const unarmedRecords = unarmed as Array<{ content?: unknown }>;
     const armedRecords = armedResult as Array<{ content?: unknown }>;
@@ -1046,7 +1051,29 @@ describe("normalizeMessagesForLlmBoundary", () => {
       "__openclawTranscriptPromptText",
       "visible transcript prompt",
     );
-    expect(captured).toHaveLength(2);
+    expect(steeredResult[0]).toEqual(armedResult[0]);
+    expect(steeredResult[1]).toMatchObject({ content: "steering update" });
+    const runtimeMessage = expectDefined(messages[0], "original prompt fixture");
+    const boundaryOptions = {
+      currentUserTimestampOverride: {
+        timestamp: 1,
+        runtimeTimestamp: 1,
+        text: "visible transcript prompt",
+        alternateText: "private model prompt",
+      },
+      userTranscriptContexts: [
+        {
+          runtimeMessage,
+          transcriptMessage: Object.assign({}, runtimeMessage, {
+            __openclaw: { senderName: "Alice" },
+          }),
+        },
+      ],
+    };
+    expect(normalizeMessagesForLlmBoundary(steeredResult, boundaryOptions)[0]).toEqual(
+      normalizeMessagesForLlmBoundary(armedResult, boundaryOptions)[0],
+    );
+    expect(captured).toHaveLength(3);
     expect(session.agent.transformContext).not.toBeUndefined();
   });
 

--- a/src/agents/internal-runtime-context.ts
+++ b/src/agents/internal-runtime-context.ts
@@ -318,7 +318,41 @@ function isUserMessage(message: unknown): boolean {
   );
 }
 
-/** Keeps only current-turn runtime context positioned immediately before the active user. */
+type RuntimeContextPromptOwner = { user?: unknown; transcriptUser?: unknown; release: () => void };
+const retainedRuntimeContextMessages = new WeakMap<object, RuntimeContextPromptOwner>();
+
+/** Prompt submission owns retention through streaming, steering, and retry, then releases it. */
+export function retainRuntimeContextMessageForPrompt(message: object): RuntimeContextPromptOwner {
+  const owner: RuntimeContextPromptOwner = {
+    release: () => {
+      retainedRuntimeContextMessages.delete(message);
+    },
+  };
+  retainedRuntimeContextMessages.set(message, owner);
+  return owner;
+}
+
+function isRetainedRuntimeContextMessage(message: unknown): boolean {
+  return (
+    typeof message === "object" && message !== null && retainedRuntimeContextMessages.has(message)
+  );
+}
+
+/** Steering extends this prompt; it does not retire its original user's context. */
+export function resolveRuntimeContextPromptOwner(messages: readonly unknown[]) {
+  const carrierIndex = messages.findIndex(isRetainedRuntimeContextMessage);
+  const carrier = messages[carrierIndex];
+  if (typeof carrier !== "object" || carrier === null) {
+    return undefined;
+  }
+  const userIndex = messages.findIndex(
+    (message, index) => index > carrierIndex && isUserMessage(message),
+  );
+  const owner = retainedRuntimeContextMessages.get(carrier);
+  return owner ? { owner, userIndex } : undefined;
+}
+
+/** Keeps the live prompt's context and unretained context immediately before the active user. */
 export function stripHistoricalRuntimeContextCustomMessages<T>(messages: T[]): T[] {
   if (!messages.some(isOpenClawRuntimeContextCustomMessage)) {
     return messages;
@@ -338,48 +372,37 @@ export function stripHistoricalRuntimeContextCustomMessages<T>(messages: T[]): T
     if (!isOpenClawRuntimeContextCustomMessage(message)) {
       return true;
     }
-    return currentRuntimeContextIndexes.has(index);
+    return currentRuntimeContextIndexes.has(index) || isRetainedRuntimeContextMessage(message);
   });
 }
 
 /**
- * Moves current-turn runtime-context carrier messages to the absolute tail of
- * the request (after the active user turn and any tool-call scaffolding).
- *
- * Prompt-cache rationale: a per-turn carrier that is stripped on replay makes
- * the next request diverge at the carrier's slot. Placed BEFORE the active user
- * turn, that slot precedes everything that gets reused, so the whole tail
- * (user turn + tool loop) re-bills every turn. Placed at the ABSOLUTE tail, the
- * divergence lands exactly where the next turn's new bytes (the assistant reply)
- * begin anyway, so the request is an append-only prefix-extension through the
- * active user turn — only the trailing carrier is ever re-billed.
- *
- * Runs after {@link stripHistoricalRuntimeContextCustomMessages}, so only the
- * current-turn carrier(s) remain. When there is no active user turn to anchor
- * after, messages are returned unchanged.
+ * Place prompt context after its own user's tool scaffolding, before a later
+ * steering user. Full-resend providers keep their cacheable tool prefix, while
+ * steering appends without relocating context already sent in the active request.
+ * Runs after historical context stripping; already-placed carriers stay put.
  */
 export function relocateCurrentRuntimeContextCarrierToTail<T>(messages: T[]): T[] {
-  const lastIndex = messages.length - 1;
-  if (lastIndex < 0 || !messages.some(isOpenClawRuntimeContextCustomMessage)) {
+  const carrierIndex = messages.findIndex(isOpenClawRuntimeContextCustomMessage);
+  const userIndex = messages.findIndex(
+    (message, index) => index > carrierIndex && isUserMessage(message),
+  );
+  if (carrierIndex < 0 || userIndex < 0) {
     return messages;
   }
-  // Already tail-placed (a contiguous carrier run ends the array): no-op so the
-  // serialized bytes stay stable across re-attempts of the same request.
-  let firstNonCarrierFromEnd = lastIndex;
-  while (
-    firstNonCarrierFromEnd >= 0 &&
-    isOpenClawRuntimeContextCustomMessage(messages[firstNonCarrierFromEnd])
-  ) {
-    firstNonCarrierFromEnd -= 1;
-  }
-  const rest = messages.filter((message) => !isOpenClawRuntimeContextCustomMessage(message));
-  // No active user turn to anchor after — leave placement to the strip pass.
-  if (!rest.some(isUserMessage)) {
-    return messages;
-  }
-  if (firstNonCarrierFromEnd === rest.length - 1) {
-    return messages;
-  }
+  const nextUserIndex = messages.findIndex(
+    (message, index) => index > userIndex && isUserMessage(message),
+  );
+  const boundary = nextUserIndex < 0 ? messages.length : nextUserIndex;
+  const prefix = messages
+    .slice(0, boundary)
+    .filter((message) => !isOpenClawRuntimeContextCustomMessage(message));
   const carriers = messages.filter(isOpenClawRuntimeContextCustomMessage);
-  return [...rest, ...carriers];
+  return [
+    ...prefix,
+    ...carriers,
+    ...messages
+      .slice(boundary)
+      .filter((message) => !isOpenClawRuntimeContextCustomMessage(message)),
+  ];
 }


### PR DESCRIPTION
Closes #138573

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users steering an OpenAI Responses session would wait for the current response to finish when the prompt included runtime context. The update was preserved for queued delivery, but never reached the active response.

The live-steering path added in #138046 exposed this interaction with existing prompt projection. This also fixes a connected, preexisting prompt-selection defect: distinct user messages with the same timestamp could move the original model prompt or its prepend/append context onto a steering user. That timestamp defect predates #138046.

## Why This Change Was Made

Prompt submission now retains its exact runtime-context message and original raw/canonical user ownership through streaming, steering and compaction retry, then releases them in the existing cleanup. Host and Responses projections keep context with its own user while preserving tool-prefix cache behavior. Both strict request-prefix guards and full-history custom transforms remain intact.

Original prompt replacement follows exact raw/canonical references and the canonical key. Existing carrierless, keyless transcript replay retains timestamp matching only when the candidate is unique. No configuration, schema, persisted identifier or agent-core API is added.

Production: +199/-132 (net +67). The growth carries prompt lifetime and raw-to-canonical ownership across compaction; two separate insertion helpers are removed. Tests: +440/-1. The assertion baseline shrinks by one after removing an unnecessary cast.

## User Impact

New requirements can steer a context-bearing response immediately. Original prompt context remains attached to the right user, including same-time messages and compaction recovery. Ordinary later turns release the transient context and restore their original hooks.

## Evidence

- Before repair, real host/provider projections rejected steering with runtime context while the context-free controls admitted it. A real Agent probe retained the rejected update and delivered it once on the following request.
- Regression tests reproduced carrier/prefix movement, source cloning and canonical compaction recovery. The final timestamp matrix had 9 failures and 5 passing controls before its repair.
- **200 tests passed across 11 host, agent-core and Responses suites**, including full-history hook rejection, cancellation, continuation, retained compaction and reasoning replay.
- Exact pinned-dependency `check:changed` passed: types, test types, format, lint, export scans, storage/boundary and import-cycle guards. Independent review found no actionable P0–P2 issue.
- **Official API live proof passed** through the actual Agent, host boundary, Responses transport and OpenAI SDK with synthetic same-timestamp users and distinct keys: one `response.create`, one `response.steer`, one acceptance, and two created/completed responses through the automatic successor. The update committed once, the queue emptied, the answer followed the new requirement, the context retired, and both original hooks were restored.

The first hosted CI attempt stalled twice in an unrelated tooling shard without an assertion failure. No source, assertion or timeout was changed. The same commit and 19-file manifest passed on macOS (646 passed, 1 skipped) and on a dedicated Linux Testbox (647 passed). The Linux Testbox used CI Node 24.19.0; the Mac used Node 26. Those focused runs did not reproduce the full preceding CI group and restored-cache path. The exact hosted tooling job and dependent CI gate then passed on the unchanged head in [CI run 33915215880](https://github.com/openclaw/openclaw/actions/runs/33915215880), exercising the canonical entrypoint, predecessor groups and cache setup. The original stall cause remains unresolved.

The live proof used synthetic inputs and the official API; it did not exercise a real chat channel or a persistent production session. The affected runtime owners are unchanged on main `4325289d470e23c5a0443d9692359450237e7349`. Contract checked against the [OpenAI steering guide](https://developers.openai.com/api/docs/guides/steering).

## Review disposition

The completed ClawSweeper review found no correctness/security findings or Rank-up moves. The maintainer accepted the bounded +67-line transient lifecycle risk after direct source and cleanup review. The data-model flag does not apply: ownership lives only in a module-private WeakMap and prompt closures, using the existing raw/canonical transcript pair. No stored representation, field, writer, schema or migration changes; the existing serialization function and commentary are unchanged. Canonical in-memory SessionManager compaction/replay tests cover keyed, keyless and rewritten-key users; no database migration is claimed. See the [source-backed disposition](https://github.com/openclaw/openclaw/pull/138575#issuecomment-5546990329).
