### PR TITLE
feat(providers): add current Google and Cerebras models

### DIFF
--- a/docs/providers/cerebras.md
+++ b/docs/providers/cerebras.md
@@ -17,7 +17,7 @@ read_when:
 | Direct CLI flag | `--cerebras-api-key <key>`                                |
 | API             | OpenAI-compatible (`openai-completions`)                  |
 | Base URL        | `https://api.cerebras.ai/v1`                              |
-| Default model   | `cerebras/gemma-4-31b`                                    |
+| Default model   | `cerebras/qwen-3.8-27b`                                   |
 
 ## Install plugin
 
@@ -98,23 +98,26 @@ seed as explicit config instead.
 
 ## Built-in catalog
 
-The three offline fallback models have a 131,072-token context window and a
-40,960-token max output. Prices for models still present in the native
-[public feed](https://api.cerebras.ai/public/v1/models) were refreshed from its
-August 31, 2026 response; absent legacy references retain their seed snapshots.
+The offline fallback mirrors Cerebras's public feed for active models and retains
+the deprecated GLM reference for existing explicit configurations. Qwen's limits
+follow the feed's September 4, 2026 response; its prompt and completion prices
+follow Cerebras's [published developer pricing](https://inference-docs.cerebras.ai/models/qwen-3.8-27b)
+because the unauthenticated metadata feed currently reports zero prices.
 
 | Model ref               | Name         | Reasoning | Notes                                                     |
 | ----------------------- | ------------ | --------- | --------------------------------------------------------- |
 | `cerebras/zai-glm-4.7`  | Z.ai GLM 4.7 | yes       | Deprecated August 17, 2026; retained for explicit configs |
 | `cerebras/gpt-oss-120b` | GPT OSS 120B | yes       | Production reasoning model                                |
-| `cerebras/gemma-4-31b`  | Gemma 4 31B  | yes       | Default; preview; text-and-image input                    |
+| `cerebras/gemma-4-31b`  | Gemma 4 31B  | yes       | Text-and-image input                                      |
+| `cerebras/qwen-3.8-27b` | Qwen 3.8 27B | yes       | Default; text-and-image agentic model                     |
 
 Cerebras's [deprecation notice](https://inference-docs.cerebras.ai/support/deprecation)
 marks `zai-glm-4.7` deprecated without naming a replacement. OpenClaw keeps the
 shipped reference rather than deleting it or rewriting existing selections;
 retention does not guarantee upstream availability.
 
-Fresh onboarding follows Cerebras's current [Gemma 4 recommendation](https://www.cerebras.ai/blog/gemma-4-on-cerebras-the-fastest-inference-is-now-multimodal). Cerebras describes Gemma 4 31B as its reference medium-size model for equal-or-higher intelligence than GPT OSS, with multimodal agentic support. It is a public-preview model and may change or be discontinued on shorter notice than the production GPT OSS endpoint; existing OpenClaw configurations keep their selected model.
+Fresh onboarding selects Qwen 3.8 27B, the newest multimodal reasoning model in
+Cerebras's public feed. Existing OpenClaw configurations keep their selected model.
 
 ## Manual config
 
@@ -125,7 +128,7 @@ Most setups only need the API key. Use explicit `models.providers.cerebras` conf
   env: { vars: { CEREBRAS_API_KEY: "csk-..." } },
   agents: {
     defaults: {
-      model: { primary: "cerebras/gemma-4-31b" },
+      model: { primary: "cerebras/qwen-3.8-27b" },
     },
   },
   models: {

--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -424,17 +424,17 @@ plugin's catalog; core only reads the generic compat field.
 
 Bundled provider catalogs currently flag these models as `"preferred"`:
 
-| Provider  | Models                                                                                                                                                           |
-| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| anthropic | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-mythos-5`, `claude-opus-4-8`, `claude-haiku-4-5`                                                   |
-| deepseek  | `deepseek-v4-pro`, `deepseek-v4-flash`                                                                                                                           |
-| google    | `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.6-flash`, `gemini-3.7-flash` |
-| kimi      | `k3`, `k3-256k`                                                                                                                                                  |
-| minimax   | `MiniMax-M3`                                                                                                                                                     |
-| moonshot  | `kimi-k3`                                                                                                                                                        |
-| openai    | `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.5-pro`                                                                              |
-| xiaomi    | `mimo-v2.5`                                                                                                                                                      |
-| zai       | `glm-5.3`, `glm-5.2`, `glm-5.1`                                                                                                                                  |
+| Provider  | Models                                                                                                                                                                               |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| anthropic | `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `claude-mythos-5`, `claude-opus-4-8`, `claude-haiku-4-5`                                                                       |
+| deepseek  | `deepseek-v4-pro`, `deepseek-v4-flash`                                                                                                                                               |
+| google    | `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.6-flash`, `gemini-3.7-flash`, `gemini-3.8-flash` |
+| kimi      | `k3`, `k3-256k`                                                                                                                                                                      |
+| minimax   | `MiniMax-M3`                                                                                                                                                                         |
+| moonshot  | `kimi-k3`                                                                                                                                                                            |
+| openai    | `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.5-pro`                                                                                                  |
+| xiaomi    | `mimo-v2.5`                                                                                                                                                                          |
+| zai       | `glm-5.3`, `glm-5.2`, `glm-5.1`                                                                                                                                                      |
 
 Everything else, including all Ollama-served local models, stays unflagged and
 keeps normal tool exposure under `"auto"`.

--- a/extensions/cerebras/index.ts
+++ b/extensions/cerebras/index.ts
@@ -20,7 +20,7 @@ export default defineSingleProviderPluginEntry({
       preserveExistingPrimary: true,
       applyConfig: applyCerebrasConfig,
       noteMessage: [
-        "Cerebras provides high-speed OpenAI-compatible inference for GPT OSS and GLM models.",
+        "Cerebras provides high-speed OpenAI-compatible inference for Qwen, Gemma, and GPT OSS models.",
         "Get your API key at: https://cloud.cerebras.ai",
       ].join("\n"),
       noteTitle: "Cerebras",

--- a/extensions/cerebras/onboard.test.ts
+++ b/extensions/cerebras/onboard.test.ts
@@ -95,7 +95,7 @@ describe("Cerebras onboarding", () => {
         CEREBRAS_DEFAULT_MODEL_REF,
       );
       expect(config.agents?.defaults?.models).toEqual({
-        [CEREBRAS_DEFAULT_MODEL_REF]: { alias: "Cerebras Gemma 4 31B" },
+        [CEREBRAS_DEFAULT_MODEL_REF]: { alias: "Cerebras Qwen 3.8 27B" },
       });
     },
   );
@@ -131,37 +131,47 @@ describe("Cerebras onboarding", () => {
     },
   );
 
-  it("preserves an existing primary during non-interactive auth setup", async () => {
-    const provider = await registerSingleProviderPlugin(plugin);
-    const method = provider.auth?.[0];
-    if (!method?.runNonInteractive) {
-      throw new Error("expected Cerebras non-interactive auth method");
-    }
+  it.each([
+    {
+      existingPrimary: "anthropic/claude-sonnet-4-6",
+      existingAlias: "Existing",
+    },
+    {
+      existingPrimary: "cerebras/gemma-4-31b",
+      existingAlias: "Cerebras Gemma 4 31B",
+    },
+  ])(
+    "preserves existing primary $existingPrimary during non-interactive auth setup",
+    async ({ existingPrimary, existingAlias }) => {
+      const provider = await registerSingleProviderPlugin(plugin);
+      const method = provider.auth?.[0];
+      if (!method?.runNonInteractive) {
+        throw new Error("expected Cerebras non-interactive auth method");
+      }
 
-    const result = await method.runNonInteractive({
-      authChoice: "cerebras-api-key",
-      config: {
-        agents: {
-          defaults: {
-            model: { primary: "anthropic/claude-sonnet-4-6" },
-            models: { "anthropic/claude-sonnet-4-6": { alias: "Existing" } },
+      const result = await method.runNonInteractive({
+        authChoice: "cerebras-api-key",
+        config: {
+          agents: {
+            defaults: {
+              model: { primary: existingPrimary },
+              models: { [existingPrimary]: { alias: existingAlias } },
+            },
           },
         },
-      },
-      opts: {},
-      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
-      resolveApiKey: vi.fn(async () => ({ key: "fixture-value", source: "profile" })),
-      toApiKeyCredential: vi.fn(() => null),
-    } as never);
+        opts: {},
+        runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+        resolveApiKey: vi.fn(async () => ({ key: "fixture-value", source: "profile" })),
+        toApiKeyCredential: vi.fn(() => null),
+      } as never);
 
-    expect(resolveAgentModelPrimaryValue(result?.agents?.defaults?.model)).toBe(
-      "anthropic/claude-sonnet-4-6",
-    );
-    expect(result?.agents?.defaults?.models).toEqual({
-      "anthropic/claude-sonnet-4-6": { alias: "Existing" },
-      [CEREBRAS_DEFAULT_MODEL_REF]: { alias: "Cerebras Gemma 4 31B" },
-    });
-  });
+      expect(resolveAgentModelPrimaryValue(result?.agents?.defaults?.model)).toBe(existingPrimary);
+      expect(result?.agents?.defaults?.models).toEqual({
+        [existingPrimary]: { alias: existingAlias },
+        [CEREBRAS_DEFAULT_MODEL_REF]: { alias: "Cerebras Qwen 3.8 27B" },
+      });
+    },
+  );
 });
 
 describe("Cerebras native catalog", () => {
@@ -278,7 +288,7 @@ describe("Cerebras native catalog", () => {
     },
   );
 
-  it("keeps static discovery offline and retains the shipped GLM reference", async () => {
+  it("keeps static discovery offline with the current Qwen default and shipped GLM reference", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
     const result = await provider.staticCatalog?.run(createCatalogContext());
 
@@ -290,6 +300,16 @@ describe("Cerebras native catalog", () => {
       manifest.modelCatalog.providers.cerebras.models.map((model) => model.id),
     );
     expect(result.provider.models).toContainEqual(expect.objectContaining({ id: "zai-glm-4.7" }));
+    expect(CEREBRAS_DEFAULT_MODEL_REF).toBe("cerebras/qwen-3.8-27b");
+    expect(result.provider.models).toContainEqual(
+      expect.objectContaining({
+        id: "qwen-3.8-27b",
+        input: ["text", "image"],
+        contextWindow: 65536,
+        maxTokens: 32768,
+        cost: { input: 0.99, output: 1.49, cacheRead: 0, cacheWrite: 0 },
+      }),
+    );
     const glm = manifest.modelCatalog.providers.cerebras.models.find(
       (model) => model.id === "zai-glm-4.7",
     );

--- a/extensions/cerebras/onboard.ts
+++ b/extensions/cerebras/onboard.ts
@@ -16,6 +16,6 @@ export const { applyConfig: applyCerebrasConfig } = createModelCatalogPresetAppl
     baseUrl: CEREBRAS_BASE_URL,
     // Replace mode skips discovery; merge mode must not persist generated pricing as authored pins.
     catalogModels: cfg.models?.mode === "replace" ? buildCerebrasCatalogModels() : [],
-    aliases: [{ modelRef: CEREBRAS_DEFAULT_MODEL_REF, alias: "Cerebras Gemma 4 31B" }],
+    aliases: [{ modelRef: CEREBRAS_DEFAULT_MODEL_REF, alias: "Cerebras Qwen 3.8 27B" }],
   }),
 });

--- a/extensions/cerebras/openclaw.plugin.json
+++ b/extensions/cerebras/openclaw.plugin.json
@@ -28,7 +28,7 @@
       "cerebras": {
         "baseUrl": "https://api.cerebras.ai/v1",
         "api": "openai-completions",
-        "defaultModel": "gemma-4-31b",
+        "defaultModel": "qwen-3.8-27b",
         "models": [
           {
             "id": "zai-glm-4.7",
@@ -66,6 +66,20 @@
             "reasoning": true,
             "contextWindow": 131072,
             "maxTokens": 40960,
+            "cost": {
+              "input": 0.99,
+              "output": 1.49,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "qwen-3.8-27b",
+            "name": "Qwen 3.8 27B",
+            "input": ["text", "image"],
+            "reasoning": true,
+            "contextWindow": 65536,
+            "maxTokens": 32768,
             "cost": {
               "input": 0.99,
               "output": 1.49,

--- a/extensions/google/google.live.test.ts
+++ b/extensions/google/google.live.test.ts
@@ -140,7 +140,7 @@ function registerGoogleRealtimeVoiceProvider() {
 }
 
 describeLive("google plugin live", () => {
-  it.each(["gemini-3.7-flash", "gemini-3.5-flash-lite"])(
+  it.each(["gemini-3.8-flash", "gemini-3.7-flash", "gemini-3.5-flash-lite"])(
     "discovers and completes through %s",
     async (modelId) => {
       const provider = await buildGoogleLiveCatalogProvider({

--- a/extensions/google/provider-catalog.test.ts
+++ b/extensions/google/provider-catalog.test.ts
@@ -27,9 +27,10 @@ describe("google provider catalog", () => {
         "gemini-3.5-flash-lite",
         "gemini-3.6-flash",
         "gemini-3.7-flash",
+        "gemini-3.8-flash",
       ]),
     );
-    expect(provider.models.find((model) => model.id === "gemini-3.7-flash")).toMatchObject({
+    expect(provider.models.find((model) => model.id === "gemini-3.8-flash")).toMatchObject({
       contextWindow: 1_048_576,
       maxTokens: 65_536,
       reasoning: true,
@@ -87,6 +88,14 @@ describe("google provider catalog", () => {
                   {
                     name: "models/gemini-3.7-flash",
                     displayName: "Gemini 3.7 Flash",
+                    inputTokenLimit: 1_048_576,
+                    outputTokenLimit: 65_536,
+                    supportedGenerationMethods: ["generateContent"],
+                    thinking: true,
+                  },
+                  {
+                    name: "models/gemini-3.8-flash",
+                    displayName: "Gemini 3.8 Flash",
                     inputTokenLimit: 1_048_576,
                     outputTokenLimit: 65_536,
                     supportedGenerationMethods: ["generateContent"],
@@ -151,6 +160,16 @@ describe("google provider catalog", () => {
       expect.objectContaining({
         id: "gemini-3.7-flash",
         name: "Gemini 3.7 Flash",
+        reasoning: true,
+        contextWindow: 1_048_576,
+        maxTokens: 65_536,
+        input: ["text", "image", "video"],
+        compat: { codeMode: "preferred" },
+        thinkingLevelMap: { minimal: null },
+      }),
+      expect.objectContaining({
+        id: "gemini-3.8-flash",
+        name: "Gemini 3.8 Flash",
         reasoning: true,
         contextWindow: 1_048_576,
         maxTokens: 65_536,

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -32,6 +32,7 @@ const GOOGLE_GEMINI_TEXT_MODEL_ROWS: ReadonlyArray<
   ["gemini-3.5-flash", "Gemini 3.5 Flash", true],
   ["gemini-3.6-flash", "Gemini 3.6 Flash", true],
   ["gemini-3.7-flash", "Gemini 3.7 Flash", true, { minimal: null }],
+  ["gemini-3.8-flash", "Gemini 3.8 Flash", true, { minimal: null }],
   ["gemini-3.5-flash-lite", "Gemini 3.5 Flash-Lite", true],
   ["gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview", true],
   ["gemini-3.1-flash-lite", "Gemini 3.1 Flash Lite", true],

--- a/extensions/google/provider-models.test.ts
+++ b/extensions/google/provider-models.test.ts
@@ -537,6 +537,7 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
 
   it.each([
     ["gemini-3.7-flash", "gemini-3-flash-preview"],
+    ["gemini-3.8-flash", "gemini-3-flash-preview"],
     ["gemini-3.5-flash-lite", "gemini-3.1-flash-lite"],
   ])("resolves future Gemini 3 text family %s from %s metadata", (modelId, templateId) => {
     const model = resolveGoogleGeminiForwardCompatModel({

--- a/extensions/google/thinking.test.ts
+++ b/extensions/google/thinking.test.ts
@@ -51,6 +51,11 @@ describe("google thinking policy", () => {
     ["gemini-3.7-flash", "low", "LOW"],
     ["gemini-3.7-flash", "medium", "MEDIUM"],
     ["gemini-3.7-flash", "high", "HIGH"],
+    ["gemini-3.8-flash", "off", "LOW"],
+    ["gemini-3.8-flash", "minimal", "LOW"],
+    ["gemini-3.8-flash", "low", "LOW"],
+    ["gemini-3.8-flash", "medium", "MEDIUM"],
+    ["gemini-3.8-flash", "high", "HIGH"],
   ] as const)("maps %s thinking level %s to %s", (modelId, thinkingLevel, expected) => {
     expect(
       resolveGoogleGemini3ThinkingLevel({
@@ -68,6 +73,7 @@ describe("google thinking policy", () => {
     ["gemini-3.1-flash-lite", 8193, "HIGH"],
     ["gemini-3.6-flash", 0, "MINIMAL"],
     ["gemini-3.7-flash", 0, "LOW"],
+    ["gemini-3.8-flash", 0, "LOW"],
   ] as const)("maps %s budget %s to %s", (modelId, thinkingBudget, expected) => {
     expect(
       resolveGoogleGemini3ThinkingLevel({

--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -48,6 +48,7 @@ describe("buildGoogleSimpleThinking", () => {
     { id: "gemini-flash-latest", expectedLevel: "MINIMAL" },
     { id: "gemini-3.6-flash", expectedLevel: "MINIMAL" },
     { id: "gemini-3.7-flash", expectedLevel: "LOW" },
+    { id: "gemini-3.8-flash", expectedLevel: "LOW" },
   ])("uses the supported thinking floor for $id", ({ id, expectedLevel }) => {
     const flashModel = { ...model, id };
 


### PR DESCRIPTION
Closes #138468

## What Problem This Solves

OpenClaw's static Google and Cerebras catalogs lag their providers' current model lineups. Gemini 3.8 Flash is missing from Google AI Studio and Vertex selection, while fresh Cerebras onboarding cannot select Qwen 3.8 27B and still defaults to the older Gemma model.

## Why This Change Was Made

Add Gemini 3.8 Flash to the manifest-owned Google catalogs with its published limits, preferred Code Mode metadata, and LOW minimum thinking level. Add Qwen 3.8 27B to Cerebras's offline catalog and make it the fresh-onboarding default while preserving existing model selections; use Cerebras's published developer token prices and document the public-feed discrepancy.

## User Impact

Operators can select Gemini 3.8 Flash through Google AI Studio or Vertex, including correct thinking-level behavior. New Cerebras setups default to the current multimodal agentic Qwen model; existing Cerebras primaries and aliases remain unchanged.

## Evidence

- 162 focused tests passed across Google provider catalog/model/thinking/shared transport and Cerebras onboarding/catalog suites.
- `pnpm check:changed`: all checks through core/extension typechecks, deprecation guards, dead-export scan, and other changed-surface gates passed; the full-tree type-aware core lint exceeded its 15-minute local timeout. Targeted core lint passed with 0 errors, and targeted extension lint passed after generating the repository's Plugin SDK boundary declarations.
- `git diff --check` passed.
- `docs:check-config-examples` validated 1,219 config examples across 746 files.
- Google live coverage now includes `gemini-3.8-flash`; not run locally because no Google API credential was available.
- Vendor evidence: https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash and https://inference-docs.cerebras.ai/models/qwen-3.8-27b
