### PR TITLE
perf(agents): skip serializing unchanged recovery messages

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -1385,8 +1385,8 @@ function buildRecoveryToolResultReplacementPlan(params: {
     if (
       entry.type !== "message" ||
       !entry.message ||
-      finalEntry?.type !== "message" ||
-      !finalEntry.message ||
+      !finalEntry?.message ||
+      entry.message === finalEntry.message ||
       JSON.stringify(entry.message) === JSON.stringify(finalEntry.message)
     ) {
       return [];


### PR DESCRIPTION
## What Problem This Solves

Tool-result recovery serialized every original and final message while deciding whether the transcript needed rewriting, even when both were the same object. Large unchanged user messages, images, assistant messages, and tool outputs therefore incurred unnecessary whole-message serialization during overflow recovery and mid-turn preflight.

## Why This Change Was Made

The recovery planner now accepts reference equality before comparing JSON. Projection and replacement preserve branch order, entry types, and unchanged message objects, so a duplicate final-entry type check can be removed. Distinct objects still receive the existing JSON comparison, preserving equal frozen projections and avoiding unnecessary transcript rewrites.

## User Impact

Recovery keeps the same decisions and transcript contents while avoiding serialization of unchanged messages. Production LOC: +2/-2 (net 0). Tests and docs: unchanged. No configuration or persistence contract changes.

## Evidence

A before/after probe used the real public in-memory SessionManager and recovery owner. A fitting eight-turn history contained 24 unchanged messages. Before the change it produced 48 message serializations totaling 531,990 UTF-8 bytes; afterward it produced zero. This measures serialized string volume, not exact V8 allocation or whole-Gateway memory savings. Concurrent timing/RSS samples are not used as performance claims.

The same probe verified ordinary recovery, frozen projection recovery, retention of original messages, and repeat-recovery idempotence. Corresponding message hashes and repair outcomes matched before and after.

95 existing tests passed across the owner and transcript-rewrite suites:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/agents/embedded-agent-runner/tool-result-truncation.test.ts \
  src/agents/embedded-agent-runner/tool-result-truncation.cache-ttl.test.ts \
  src/agents/embedded-agent-runner/transcript-rewrite.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/check-changed.mjs -- \
  src/agents/embedded-agent-runner/tool-result-truncation.ts
```

The complete canonical changed-file gate passed. Independent managed Codex review through P2 returned no actionable findings. Existing tests cover active-leaf selection, frozen/aggregate recovery, cache-TTL behavior, original transcript retention, and append-only rewriting. No implementation-coupled permanent serialization-count test or production seam was added.
