### PR TITLE
fix(release): emit v2 ClawHub recovery approval bound to the authorized child

### DIFF
--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -48,6 +48,16 @@ on:
         required: false
         default: ""
         type: string
+      recovered_clawhub_run_id:
+        description: Human recovery only - original Plugin ClawHub Release run id bound by the parent authorization receipt (discovered from the parent run when omitted)
+        required: false
+        default: ""
+        type: string
+      recovered_clawhub_run_attempt:
+        description: Human recovery only - original Plugin ClawHub Release run attempt bound by the parent authorization receipt (discovered from the parent run when omitted)
+        required: false
+        default: ""
+        type: string
       dry_run:
         description: Validate the full ClawHub artifact handoff without publishing.
         required: false
@@ -612,6 +622,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: clawhub-plugin-release
     permissions:
+      actions: read
       contents: read
     steps:
       - name: Approve Plugin ClawHub release publish
@@ -619,7 +630,8 @@ jobs:
           echo "Approved CLAW-277 03 - Split OpenClaw plugin ClawHub publishing into OIDC release and token bootstrap workflows release publish gate."
 
       # The automated bot-dispatched route is unchanged; direct human dispatch binds this approval
-      # to the exact child run for explicit-recovery finalization (openclaw/clawhub
+      # to the exact child run and to the original child attempt whose parent receipt ClawHub
+      # resolves for explicit-recovery finalization (openclaw/clawhub
       # convex/lib/openClawPublishAuthorization.ts validateRecoveryReceipt).
       - name: Checkout trusted release tooling
         if: needs.validate_release_publish_approval.outputs.direct_recovery == 'true'
@@ -635,8 +647,11 @@ jobs:
       - name: Write recovery environment approval receipt
         if: needs.validate_release_publish_approval.outputs.direct_recovery == 'true'
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
           RELEASE_PUBLISH_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
+          RECOVERED_CLAWHUB_RUN_ID: ${{ inputs.recovered_clawhub_run_id }}
+          RECOVERED_CLAWHUB_RUN_ATTEMPT: ${{ inputs.recovered_clawhub_run_attempt }}
         run: |
           node scripts/clawhub-parent-authorization.mjs recovery-approval --output "$RUNNER_TEMP/openclaw-clawhub-recovery-approval/approval.json"
       - name: Upload recovery environment approval receipt

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -768,7 +768,24 @@ at the exact release SHA. Each verifier still independently checks that manifest
 against the artifact's recorded source hash, together with the tarball hashes
 and producer identity.
 
-ClawHub OIDC publication requires the executing release parent to authorize the exact child run, attempt, and package inventories. A direct `Plugin ClawHub Release` dry run can prepare packages without publication authority, but a standalone publish cannot replace the parent. A direct human `Plugin ClawHub Release` dispatch with `release_publish_run_id` now uploads the `openclaw-clawhub-recovery-approval-<run-id>-<run-attempt>` receipt from the `approve_plugins_clawhub_release` environment job, supplying the child-side evidence ClawHub's explicit-recovery route requires; bot-dispatched children never upload it. ClawHub still also requires a parent authorization receipt bound to that exact recovery child, which a completed parent cannot issue, so failed-parent recovery remains blocked on that parent-side contract. Do not retry publication with copied receipts or treat staging as completed publication.
+ClawHub OIDC publication requires the executing release parent to authorize the exact child run, attempt, and package inventories. A direct `Plugin ClawHub Release` dry run can prepare packages without publication authority, but a standalone publish cannot replace the parent. Bot-dispatched children stay on the automated route and are terminal once their exact parent attempt completes without success.
+
+A direct human `Plugin ClawHub Release` dispatch with `release_publish_run_id` always takes ClawHub's explicit-recovery route. The `approve_plugins_clawhub_release` environment job uploads the version 2 `openclaw-clawhub-recovery-approval-<run-id>-<run-attempt>` receipt, which names the original child attempt (`authorizedChildRunId`/`authorizedChildRunAttempt`) whose parent receipt `openclaw-clawhub-parent-authorization-v2-<parent-run-id>-<parent-run-attempt>-<child-run-id>-<child-run-attempt>` the completed parent already uploaded; a completed parent cannot mint a new one. ClawHub resolves that parent receipt through the authorized child and requires the recovery child to run the same workflow ref and SHA, candidate SHA, tooling, parent attempt, and exact package inventory, so dispatch recovery from the parent's tooling ref with the parent's inputs. Pass `recovered_clawhub_run_id` and `recovered_clawhub_run_attempt` to name the original child explicitly; when omitted, the approval job discovers it from the parent run's single matching receipt and fails with the candidate list when zero or several exist. Version 1 recovery receipts are rejected. Do not retry publication with copied receipts or treat staging as completed publication.
+
+```bash
+gh workflow run plugin-clawhub-release.yml \
+  --ref <parent-tooling-ref> \
+  -f publish_scope=all-publishable \
+  -f ref=<full-40-character-release-sha> \
+  -f release_tag=vYYYY.M.PATCH \
+  -f release_publish_run_id=<parent-run-id> \
+  -f release_publish_run_attempt=<parent-run-attempt> \
+  -f release_publish_branch=<parent-tooling-ref> \
+  -f release_publish_full_ref=<parent-tooling-full-ref> \
+  -f release_publish_workflow_sha=<parent-tooling-sha> \
+  -f recovered_clawhub_run_id=<original-child-run-id> \
+  -f recovered_clawhub_run_attempt=<original-child-run-attempt>
+```
 
 Before dispatching a ClawHub publisher, the parent refuses dispatch if a run for
 the same tooling ref is waiting, pending, queued, or in progress. Follow the

--- a/scripts/clawhub-parent-authorization.mjs
+++ b/scripts/clawhub-parent-authorization.mjs
@@ -279,9 +279,66 @@ export function createClawHubParentAuthorization(transactions, authorizationRout
   return receipt;
 }
 
+function listRunArtifactNames(runId, runGhJson) {
+  const names = [];
+  for (let page = 1; page <= 20; page++) {
+    const response = runGhJson(`actions/runs/${runId}/artifacts?per_page=100&page=${page}`);
+    if (
+      !Array.isArray(response.artifacts) ||
+      !Number.isSafeInteger(response.total_count) ||
+      response.total_count > 2000
+    ) {
+      throw new Error("Invalid release parent artifact inventory.");
+    }
+    names.push(...response.artifacts.map((artifact) => String(artifact.name)));
+    if (names.length >= response.total_count) {
+      if (names.length !== response.total_count) {
+        throw new Error("Inconsistent release parent artifact inventory.");
+      }
+      return names;
+    }
+    if (response.artifacts.length === 0) {
+      break;
+    }
+  }
+  throw new Error("Incomplete release parent artifact inventory.");
+}
+
+// A completed parent cannot mint another receipt, so recovery names the original
+// child attempt its parent receipt is bound to. Explicit dispatch inputs win;
+// otherwise the parent attempt must own exactly one v2 receipt naming that child.
+function resolveAuthorizedClawHubChild(env, parentRunId, parentRunAttempt, runGhJson) {
+  const explicitRunId = env.RECOVERED_CLAWHUB_RUN_ID?.trim() ?? "";
+  const explicitRunAttempt = env.RECOVERED_CLAWHUB_RUN_ATTEMPT?.trim() ?? "";
+  if (explicitRunId || explicitRunAttempt) {
+    return {
+      authorizedChildRunId: pattern(explicitRunId, ID, "Recovered ClawHub run id"),
+      authorizedChildRunAttempt: pattern(explicitRunAttempt, ID, "Recovered ClawHub run attempt"),
+    };
+  }
+  const prefix = `openclaw-clawhub-parent-authorization-v2-${parentRunId}-${parentRunAttempt}-`;
+  const candidates = listRunArtifactNames(parentRunId, runGhJson).filter((name) =>
+    name.startsWith(prefix),
+  );
+  const remedy = "pass recovered_clawhub_run_id and recovered_clawhub_run_attempt explicitly";
+  if (candidates.length !== 1) {
+    throw new Error(
+      candidates.length === 0
+        ? `Release parent attempt ${parentRunId}/${parentRunAttempt} has no ${prefix}* receipt; ${remedy}.`
+        : `Release parent attempt ${parentRunId}/${parentRunAttempt} has ambiguous receipts (${candidates.join(", ")}); ${remedy}.`,
+    );
+  }
+  const child = /^([1-9][0-9]*)-([1-9][0-9]*)$/u.exec(candidates[0].slice(prefix.length));
+  if (!child) {
+    throw new Error(`Malformed parent authorization receipt name ${candidates[0]}.`);
+  }
+  return { authorizedChildRunId: child[1], authorizedChildRunAttempt: child[2] };
+}
+
 // Mirrors openclaw/clawhub convex/lib/openClawPublishAuthorization.ts RECOVERY_RECEIPT_KEYS /
-// validateRecoveryReceipt: a human actor and an exact receipt within the verifier's 8 KiB file bound.
-export function createClawHubRecoveryApproval(env) {
+// parseRecoveryReceipt / validateRecoveryReceipt: version 2, a human actor, the authorized
+// original child attempt, and an exact receipt within the verifier's 8 KiB file bound.
+export function createClawHubRecoveryApproval(env, runGhJson = api) {
   if (env.GITHUB_REPOSITORY !== REPOSITORY) {
     throw new Error("ClawHub recovery approval repository mismatch.");
   }
@@ -289,8 +346,14 @@ export function createClawHubRecoveryApproval(env) {
   if (typeof actor !== "string" || !actor.trim() || /\[bot\]$/iu.test(actor)) {
     throw new Error("ClawHub recovery approval actor must be a human login.");
   }
+  const parentRunId = pattern(env.RELEASE_PUBLISH_RUN_ID, ID, "Recovery parent run id");
+  const parentRunAttempt = pattern(
+    env.RELEASE_PUBLISH_RUN_ATTEMPT,
+    ID,
+    "Recovery parent run attempt",
+  );
   const receipt = {
-    version: 1,
+    version: 2,
     kind: "openclaw-clawhub-recovery-approval",
     repository: env.GITHUB_REPOSITORY,
     workflow: CLAWHUB_CHILD_WORKFLOW,
@@ -300,8 +363,9 @@ export function createClawHubRecoveryApproval(env) {
     environment: "clawhub-plugin-release",
     approvalJob: "approve_plugins_clawhub_release",
     authorizationRoute: "explicit-recovery",
-    parentRunId: pattern(env.RELEASE_PUBLISH_RUN_ID, ID, "Recovery parent run id"),
-    parentRunAttempt: pattern(env.RELEASE_PUBLISH_RUN_ATTEMPT, ID, "Recovery parent run attempt"),
+    parentRunId,
+    parentRunAttempt,
+    ...resolveAuthorizedClawHubChild(env, parentRunId, parentRunAttempt, runGhJson),
   };
   if (Buffer.byteLength(JSON.stringify(receipt)) + 1 > 8 * 1024) {
     throw new Error("ClawHub recovery approval exceeds 8 KiB.");

--- a/test/scripts/clawhub-parent-authorization.test.ts
+++ b/test/scripts/clawhub-parent-authorization.test.ts
@@ -19,12 +19,27 @@ const sha = "a".repeat(40);
 const ref = `release-publish/${sha.slice(0, 12)}-1`;
 const recoveryEnv = {
   GITHUB_REPOSITORY: "openclaw/openclaw",
-  GITHUB_RUN_ID: "20",
+  GITHUB_RUN_ID: "30",
   GITHUB_RUN_ATTEMPT: "1",
   GITHUB_ACTOR: "octocat",
   RELEASE_PUBLISH_RUN_ID: "10",
   RELEASE_PUBLISH_RUN_ATTEMPT: "2",
+  RECOVERED_CLAWHUB_RUN_ID: "20",
+  RECOVERED_CLAWHUB_RUN_ATTEMPT: "1",
 };
+const noGh = () => {
+  throw new Error("unexpected GitHub lookup");
+};
+function parentArtifacts(names: string[], total = names.length) {
+  return (path: string) => {
+    expect(path).toMatch(/^actions\/runs\/10\/artifacts\?per_page=100&page=[1-9]/u);
+    const page = Number(/page=(\d+)$/u.exec(path)?.[1]);
+    return {
+      total_count: total,
+      artifacts: names.slice((page - 1) * 100, page * 100).map((name) => ({ name })),
+    };
+  };
+}
 function transactions(count = 1) {
   return {
     schemaVersion: 1,
@@ -60,12 +75,14 @@ function transactions(count = 1) {
 
 describe("ClawHub parent publication authorization", () => {
   it("writes an exact human recovery receipt once for the child and parent attempts", () => {
-    const receipt = createClawHubRecoveryApproval(recoveryEnv);
+    const receipt = createClawHubRecoveryApproval(recoveryEnv, noGh);
     // Mirrors openclaw/clawhub convex/lib/openClawPublishAuthorization.ts RECOVERY_RECEIPT_KEYS.
     const recoveryReceiptKeys = [
       "actor",
       "approvalJob",
       "authorizationRoute",
+      "authorizedChildRunAttempt",
+      "authorizedChildRunId",
       "environment",
       "kind",
       "parentRunAttempt",
@@ -78,11 +95,11 @@ describe("ClawHub parent publication authorization", () => {
     ] as const;
     expect(Object.keys(receipt).toSorted()).toEqual(recoveryReceiptKeys);
     expect(receipt).toEqual({
-      version: 1,
+      version: 2,
       kind: "openclaw-clawhub-recovery-approval",
       repository: "openclaw/openclaw",
       workflow: ".github/workflows/plugin-clawhub-release.yml",
-      runId: "20",
+      runId: "30",
       runAttempt: "1",
       actor: "octocat",
       environment: "clawhub-plugin-release",
@@ -90,12 +107,14 @@ describe("ClawHub parent publication authorization", () => {
       authorizationRoute: "explicit-recovery",
       parentRunId: "10",
       parentRunAttempt: "2",
+      authorizedChildRunId: "20",
+      authorizedChildRunAttempt: "1",
     });
     expect(Buffer.byteLength(JSON.stringify(receipt))).toBeLessThanOrEqual(8 * 1024);
     for (const actor of ["github-actions[bot]", "Something[Bot]", ""]) {
-      expect(() => createClawHubRecoveryApproval({ ...recoveryEnv, GITHUB_ACTOR: actor })).toThrow(
-        /human login/u,
-      );
+      expect(() =>
+        createClawHubRecoveryApproval({ ...recoveryEnv, GITHUB_ACTOR: actor }, noGh),
+      ).toThrow(/human login/u);
     }
     for (const key of [
       "GITHUB_RUN_ID",
@@ -104,16 +123,27 @@ describe("ClawHub parent publication authorization", () => {
       "RELEASE_PUBLISH_RUN_ATTEMPT",
     ]) {
       for (const value of ["invalid", "0", "01", ""]) {
-        expect(() => createClawHubRecoveryApproval({ ...recoveryEnv, [key]: value })).toThrow(
+        expect(() => createClawHubRecoveryApproval({ ...recoveryEnv, [key]: value }, noGh)).toThrow(
           /invalid/u,
         );
       }
     }
+    // Explicit recovered-child inputs are validated as a pair; one half never falls back to discovery.
+    for (const key of ["RECOVERED_CLAWHUB_RUN_ID", "RECOVERED_CLAWHUB_RUN_ATTEMPT"]) {
+      for (const value of ["invalid", "0", "01", " ", "", "1.5"]) {
+        expect(() => createClawHubRecoveryApproval({ ...recoveryEnv, [key]: value }, noGh)).toThrow(
+          /Recovered ClawHub run (id|attempt) is invalid/u,
+        );
+      }
+    }
     expect(() =>
-      createClawHubRecoveryApproval({ ...recoveryEnv, GITHUB_REPOSITORY: "other/repository" }),
+      createClawHubRecoveryApproval(
+        { ...recoveryEnv, GITHUB_REPOSITORY: "other/repository" },
+        noGh,
+      ),
     ).toThrow(/repository/u);
     expect(() =>
-      createClawHubRecoveryApproval({ ...recoveryEnv, GITHUB_RUN_ID: "1".repeat(8 * 1024) }),
+      createClawHubRecoveryApproval({ ...recoveryEnv, GITHUB_RUN_ID: "1".repeat(8 * 1024) }, noGh),
     ).toThrow(/8 KiB/u);
 
     const directory = mkdtempSync(join(tmpdir(), "clawhub-recovery-approval-"));
@@ -139,10 +169,58 @@ describe("ClawHub parent publication authorization", () => {
     }
   });
 
+  it("discovers the authorized child from the parent attempt's single v2 receipt", () => {
+    const env = { ...recoveryEnv, RECOVERED_CLAWHUB_RUN_ID: "", RECOVERED_CLAWHUB_RUN_ATTEMPT: "" };
+    const receiptName = "openclaw-clawhub-parent-authorization-v2-10-2-21-3";
+    const unrelated = [
+      "openclaw-release-children-10-2",
+      "openclaw-clawhub-parent-authorization-v2-10-1-20-1",
+      "openclaw-clawhub-parent-authorization-v2-11-2-22-1",
+      "openclaw-clawhub-transactions-21-3",
+    ];
+    const discovered = createClawHubRecoveryApproval(
+      env,
+      parentArtifacts([...unrelated, receiptName]),
+    );
+    expect(discovered).toMatchObject({
+      authorizedChildRunId: "21",
+      authorizedChildRunAttempt: "3",
+      parentRunId: "10",
+      parentRunAttempt: "2",
+    });
+    // Receipts land on later pages of a full release inventory.
+    const padded = Array.from({ length: 150 }, (_, index) => `clawhub-package-${index}`);
+    expect(
+      createClawHubRecoveryApproval(env, parentArtifacts([...padded, receiptName])),
+    ).toMatchObject({ authorizedChildRunId: "21", authorizedChildRunAttempt: "3" });
+    expect(() => createClawHubRecoveryApproval(env, parentArtifacts(unrelated))).toThrow(
+      /has no openclaw-clawhub-parent-authorization-v2-10-2-\* receipt; pass recovered_clawhub_run_id and recovered_clawhub_run_attempt/u,
+    );
+    const rival = "openclaw-clawhub-parent-authorization-v2-10-2-25-1";
+    expect(() => createClawHubRecoveryApproval(env, parentArtifacts([receiptName, rival]))).toThrow(
+      new RegExp(`ambiguous receipts \\(${receiptName}, ${rival}\\)`, "u"),
+    );
+    expect(() =>
+      createClawHubRecoveryApproval(
+        env,
+        parentArtifacts(["openclaw-clawhub-parent-authorization-v2-10-2-021-3"]),
+      ),
+    ).toThrow(/Malformed parent authorization receipt name/u);
+    expect(() => createClawHubRecoveryApproval(env, parentArtifacts([receiptName], 2))).toThrow(
+      /Incomplete release parent artifact inventory/u,
+    );
+    // Explicit inputs win without any parent lookup.
+    expect(createClawHubRecoveryApproval(recoveryEnv, noGh)).toMatchObject({
+      authorizedChildRunId: "20",
+      authorizedChildRunAttempt: "1",
+    });
+  });
+
   it("uploads recovery approval only for direct human dispatches from trusted tooling", () => {
     const workflow = parse(
       readFileSync(".github/workflows/plugin-clawhub-release.yml", "utf8"),
     ) as {
+      on: { workflow_dispatch: { inputs: Record<string, Record<string, unknown>> } };
       jobs: Record<
         "approve_plugins_clawhub_release" | "validate_release_publish_approval",
         {
@@ -150,11 +228,13 @@ describe("ClawHub parent publication authorization", () => {
           if?: string;
           needs: string[];
           outputs?: Record<string, string>;
+          permissions?: Record<string, string>;
           steps: {
             id?: string;
             uses?: string;
             run?: string;
             if?: string;
+            env?: Record<string, string>;
             with?: Record<string, string>;
           }[];
         }
@@ -189,6 +269,22 @@ describe("ClawHub parent publication authorization", () => {
     expect(write?.run).toContain(
       'recovery-approval --output "$RUNNER_TEMP/openclaw-clawhub-recovery-approval/approval.json"',
     );
+    // Discovery lists the parent run's receipts, so the job needs a token and actions:read.
+    expect(approval.permissions).toEqual({ actions: "read", contents: "read" });
+    expect(write?.env).toEqual({
+      GH_TOKEN: "${{ github.token }}",
+      RELEASE_PUBLISH_RUN_ID: "${{ inputs.release_publish_run_id }}",
+      RELEASE_PUBLISH_RUN_ATTEMPT: "${{ inputs.release_publish_run_attempt }}",
+      RECOVERED_CLAWHUB_RUN_ID: "${{ inputs.recovered_clawhub_run_id }}",
+      RECOVERED_CLAWHUB_RUN_ATTEMPT: "${{ inputs.recovered_clawhub_run_attempt }}",
+    });
+    for (const input of ["recovered_clawhub_run_id", "recovered_clawhub_run_attempt"]) {
+      expect(workflow.on.workflow_dispatch.inputs[input]).toMatchObject({
+        required: false,
+        default: "",
+        type: "string",
+      });
+    }
     const upload = approval.steps.find((step) => step.uses?.startsWith("actions/upload-artifact@"));
     const artifactName =
       "openclaw-clawhub-recovery-approval-${{ github.run_id }}-${{ github.run_attempt }}";


### PR DESCRIPTION
## What Problem This Solves

ClawHub is changing its OpenClaw publish authorization contract (openclaw/clawhub `fix/recovery-contract-and-attempt-discard`, spec `specs/package-publish-tooling-identity.md` "Recovery Approval Receipt"). The verifier now selects the route from the live child actor: a bot-dispatched `Plugin ClawHub Release` child stays on the automated route, while a human-dispatched child ALWAYS needs a version 2 environment-approved recovery receipt that names the original child attempt whose parent authorization receipt the completed parent already uploaded. The version 1 receipt this repo emitted today is rejected outright, and it carried no way to point ClawHub at that original child, so human failed-parent recovery could not work end to end.

## Why This Change Was Made

- `scripts/clawhub-parent-authorization.mjs` `createClawHubRecoveryApproval` now emits version 2 with `authorizedChildRunId` / `authorizedChildRunAttempt` (positive-integer strings), keeping the human-actor check and the verifier's 8 KiB bound. The exact key set mirrors ClawHub's `RECOVERY_RECEIPT_KEYS`.
- The authorized child comes from the new optional `workflow_dispatch` inputs `recovered_clawhub_run_id` / `recovered_clawhub_run_attempt` when given (validated as a pair). When omitted, the approval job lists the parent run's artifacts and requires exactly one `openclaw-clawhub-parent-authorization-v2-<parentRunId>-<parentRunAttempt>-*` receipt, failing with the candidate list and the explicit-input remedy when zero or several exist.
- `.github/workflows/plugin-clawhub-release.yml`: `approve_plugins_clawhub_release` gains `actions: read` and passes `GH_TOKEN` plus the two new inputs into the receipt step. Bot-dispatched children never run those steps, so the automated route is unchanged.
- Docs: `docs/reference/RELEASING.md` describes the v2 receipt, the discovery/explicit precedence, the same-ref/same-inputs requirement, and a recovery dispatch command.

The parent's `openclaw-release-children-<parentRunId>-<parentRunAttempt>` dispatch record was left as an optional cross-check and is not downloaded here: ClawHub already resolves the parent receipt through the authorized child and rejects any mismatch in workflow ref/SHA, candidate SHA, tooling, parent attempt, and package inventory, so an incorrect discovery fails closed at the verifier.

## User Impact

Cross-repo ordering: the ClawHub verifier change is merged on openclaw/clawhub `main` (d5a3688) but production is still on d07a821 (two commits behind) at the time of landing. Maintainer decision: land now. This is behavior-neutral for existing users: bot-dispatched children never run the changed steps, and human recovery was never end-to-end functional with the version 1 receipt, so nothing that works today stops working. Human recovery becomes usable once ClawHub production deploys d5a3688 or later. Release operators recovering a failed parent by hand dispatch `Plugin ClawHub Release` from the parent's tooling ref with the parent's inputs and optionally the original child run id/attempt.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/clawhub-parent-authorization.test.ts` — 16 passed. The two touched/added tests fail on the pre-fix script (v1 shape, no discovery) and pass after.
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts test/scripts/ci-workflow-guards.test.ts test/scripts/clawhub-postpublish.test.ts test/scripts/plugin-clawhub-new-workflow.test.ts test/scripts/validate-release-publish-approval.test.ts` — 5 files, 919 passed, 2 skipped.
- `pnpm check:changed` — exit 0 (format, package patch guard, tsgo test root, coercion guard, scripts lint, test lint).
- Production LOC delta: script +64, workflow +15 (two optional inputs, one permission, three env lines); tests +96; docs +17. Growth is the new capability (authorized-child resolution) the ClawHub contract requires.
- Final-effect proof against the real ClawHub verifier (authority chain): a throwaway Vitest file in the openclaw/clawhub checkout at `main` d5a3688 imports this PR's `createClawHubRecoveryApproval` and runs its output through ClawHub's `verifyOpenClawPublishAuthorization` (`convex/lib/openClawPublishAuthorization.ts`) using that suite's own fake-GitHub harness (parent run completed/failure, human child actor, parent receipt bound to the original child). Results:
  - producer v2 receipt with explicit authorized child inputs: accepted, `authorizationRoute: "explicit-recovery"`, parent receipt artifact 101 resolved
  - producer v2 receipt with the authorized child discovered from the parent run's single matching receipt name: accepted, same route
  - nearest mismatched authorized child (different original run id; same run id but a different attempt): rejected before any publication with `authorization artifact ... is missing or ambiguous`, no publish step reached
  - pre-PR version 1 receipt shape: rejected with `recovery environment approval receipt version must be 2`
  Command: `node_modules/.bin/vitest run convex/lib/openClawPublishAuthorization.openclaw-producer.test.ts` in openclaw/clawhub, 4 passed. The file was not committed to ClawHub; its cases mirror that repo's existing `openClawPublishAuthorization.test.ts` recovery suite, which landed with openclaw/clawhub PR #3599.
- Live proof against production ClawHub: not possible until production deploys the verifier (see User Impact); the offline run above exercises the exact verifier code that will be deployed.
- Production LOC (+79 net): the ClawHub contract requires the producer to name the authorized original child, which a human operator recovering a failed parent generally does not know. The discovery path (about 55 of those lines: bounded artifact listing plus exact-prefix matching) is what makes the documented recovery dispatch usable without hunting through parent artifacts by hand; the remainder is the contract-required receipt fields and pair validation. No net-neutral absorbing refactor exists because the previous receipt carried no child binding to reshape.

## ClawSweeper review response (reviewed head 5ab9581, 21:47 UTC)

Maintainer decision (release owner, Peter Steinberger): land now and accept the predeployment ordering. Per-item status:

- Add real behavior proof / merge risk (deployed final-effect trace): **skipped with reason.** A deployed ClawHub verifier trace cannot exist before ClawHub production deploys d5a3688; that deploy is a separate manual operator action outside this repository. The substitute is the offline run of the exact verifier code (ClawHub `main` d5a3688, real `verifyOpenClawPublishAuthorization`, fake GitHub transport only) recorded in Evidence, covering accepted authorized child, discovered child, nearest mismatched child rejected before publication, and version 1 rejected.
- Merge risk (verifier source not inspectable by the reviewer): **addressed by evidence.** The verifier source is public at openclaw/clawhub `convex/lib/openClawPublishAuthorization.ts` (RECOVERY_RECEIPT_KEYS, parseRecoveryReceipt, validateRecoveryReceipt) and was inspected directly while writing this PR.
- Next step (attach deployed proof or have the release owner accept the risk): **release owner accepts the predeployment risk.** The change is behavior-neutral for shipped flows: bot-dispatched children never run the changed steps, and human recovery was non-functional before this PR as well. Follow-up: after ClawHub production deploys, the first real human recovery is the live trace.
- Review confidence / maintainer decision: **resolved by this section.**
