### PR TITLE
fix(gateway): stop inferring forwarded senders from text

### DIFF
--- a/src/gateway/chat-display-projection.forwarded.test.ts
+++ b/src/gateway/chat-display-projection.forwarded.test.ts
@@ -26,11 +26,18 @@ describe("forwarded session attribution", () => {
       senderLabel: "Forwarded from main",
     },
     {
-      name: "prompt metadata when provenance lacks the source key",
+      name: "asserted prompt metadata ignored when provenance lacks the source key",
       sourceSessionKey: undefined,
       promptSessionKey: "agent:helper:dashboard:source",
-      senderSession: { sessionKey: "agent:helper:dashboard:source", agentId: "helper" },
-      senderLabel: "Forwarded from helper",
+      senderSession: undefined,
+      senderLabel: "Forwarded agent message",
+    },
+    {
+      name: "malformed asserted source without a structured source key",
+      sourceSessionKey: undefined,
+      promptSessionKey: "not-a-session",
+      senderSession: undefined,
+      senderLabel: "Forwarded agent message",
     },
     {
       name: "a session key without a parseable agent",

--- a/src/gateway/chat-display-projection.history.ts
+++ b/src/gateway/chat-display-projection.history.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import { expectDefined } from "@openclaw/normalization-core";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE } from "../agents/internal-runtime-context.js";
 import { isHeartbeatOkResponse, isHeartbeatUserMessage } from "../auto-reply/heartbeat-filter.js";
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
@@ -472,25 +471,12 @@ function stripInterSessionPromptPrefixFromContent(content: unknown): unknown {
   });
 }
 
-function extractPromptPrefixField(text: string, field: string): string | undefined {
-  const prefixIndex = text.indexOf(INTER_SESSION_PROMPT_PREFIX_BASE);
-  if (prefixIndex === -1) {
-    return undefined;
-  }
-  const lineEnd = text.indexOf("\n", prefixIndex);
-  const header = lineEnd === -1 ? text.slice(prefixIndex) : text.slice(prefixIndex, lineEnd);
-  const escapedField = field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = new RegExp(`(?:^|\\s)${escapedField}=([^\\s]+)`).exec(header);
-  return normalizeOptionalString(match?.[1]);
-}
-
 function resolveSessionsSendForwardedSenderSession(
   message: Record<string, unknown>,
 ): { sessionKey?: string; agentId?: string } | undefined {
+  // Only structured provenance identifies the sender; prompt headers are display text.
   const provenance = normalizeInputProvenance(message.provenance);
-  const text = extractProjectedText(message.content ?? message.text);
-  const sourceSessionKey =
-    provenance?.sourceSessionKey ?? extractPromptPrefixField(text, "sourceSession");
+  const sourceSessionKey = provenance?.sourceSessionKey;
   const agentId = parseAgentSessionKey(sourceSessionKey)?.agentId;
   return sourceSessionKey
     ? { sessionKey: sourceSessionKey, ...(agentId ? { agentId } : {}) }

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -706,6 +706,82 @@ describe("session history HTTP endpoints", () => {
     });
   });
 
+  test("attributes forwarded history only from structured provenance across transports and pages", async () => {
+    const { storePath } = await seedSession();
+    const sessionId = "sess-main";
+    const sessionKey = "agent:main:main";
+    const cases = [
+      {
+        body: "Verified sender body\n    indented line",
+        sourceSessionKey: "agent:helper:ops",
+        senderLabel: "Forwarded from helper",
+        senderSession: { sessionKey: "agent:helper:ops", agentId: "helper" },
+      },
+      {
+        body: "Unverified sender body\n    indented line",
+        sourceSessionKey: undefined,
+        senderLabel: "Forwarded agent message",
+        senderSession: undefined,
+      },
+    ];
+    for (const entry of cases) {
+      const persisted = await persistUserTurnTranscript({
+        agentId: AGENT_ID,
+        sessionEntry: { sessionId, updatedAt: 1 },
+        sessionId,
+        sessionKey,
+        storePath,
+        input: {
+          text: `[Inter-session message] sourceSession=agent:grimwald:asserted sourceTool=sessions_send isUser=false\n${entry.body}`,
+          provenance: {
+            kind: "inter_session",
+            sourceTool: "sessions_send",
+            ...(entry.sourceSessionKey ? { sourceSessionKey: entry.sourceSessionKey } : {}),
+          },
+        },
+      });
+      expect(persisted).toBeDefined();
+    }
+
+    await withGatewayHarness(async (harness) => {
+      const ws = await harness.openWs();
+      try {
+        expect((await connectReq(ws, { scopes: ["operator.read"] })).ok).toBe(true);
+        let cursor: string | undefined;
+        for (const [offset, entry] of cases.toReversed().entries()) {
+          const http = await readSessionHistoryBody(harness.port, sessionKey, {
+            query: `?limit=1${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`,
+          });
+          const websocket = await rpcReq<{ messages: unknown[]; hasMore: boolean }>(
+            ws,
+            "chat.history",
+            { sessionKey, limit: 1, offset },
+          );
+          expect(websocket.ok).toBe(true);
+          for (const page of [http, websocket.payload]) {
+            expect(page?.messages).toHaveLength(1);
+            expect(page?.messages?.[0]).toMatchObject({
+              role: "assistant",
+              content: entry.body,
+              senderLabel: entry.senderLabel,
+              ...(entry.senderSession ? { senderSession: entry.senderSession } : {}),
+            });
+            if (!entry.senderSession) {
+              expect(page?.messages?.[0]).not.toHaveProperty("senderSession");
+            }
+            expect(page?.hasMore).toBe(offset === 0);
+          }
+          if (offset === 0) {
+            expect(http.nextCursor).toEqual(expect.any(String));
+          }
+          cursor = http.nextCursor;
+        }
+      } finally {
+        ws.close();
+      }
+    });
+  });
+
   test("shares revisioned current-profile projection across REST and initial and inline SSE", async () => {
     const OLD_REV = 1_800_000_000_000;
     const NEW_REV = 1_900_000_000_000;


### PR DESCRIPTION
Related: #138493

## What Problem This Solves
Forwarded history could turn a sender asserted in text into another agent's chip and session link.

## Why This Change Was Made
This state has one writer: the shared history projection. Only structured provenance identifies the sender. This removes the legacy text fallback from #132054.

## User Impact
Unknown sources show “Forwarded message.” Recorded sources keep their chip, color, and navigation.

## Evidence
A released Gateway’s public `agent` requests created historical rows; current `doctor --fix` imported them. HTTP history and WebSocket `chat.history` invented a source on main; the fix returns generic attribution without `senderSession`. Five-page history, access denial, current `sessions_send`, source navigation, and byte preservation passed.

| Before | After |
| --- | --- |
| ![Text-only source incorrectly shows a helper chip](https://gist.githubusercontent.com/obviyus/aa300f849835ecd4fadd349462327383/raw/cd407fc424299332a9dd21da44a23530f5c87d45/before.png) | ![Text-only source is generic; recorded source keeps its helper chip](https://gist.githubusercontent.com/obviyus/aa300f849835ecd4fadd349462327383/raw/8f5cd052f11e6fc35df71e77427fc7581b06f07f/after.png) |

## Compatibility
No stored-data, schema, protocol, config, or import change. Wider provenance design remains in #138493.

## Consumers
HTTP, WebSocket, and Control UI share the projection.

## Invalidation
Existing history refresh and grouping rules remain.

## Tests
The registered HTTP/WebSocket regression covers recorded, asserted, and malformed sources over three pages. It fails on main and passes with the fix. Five selected correction checks pass.
