### PR TITLE
fix(sessions): preserve signal exit status in tail follow

### DIFF
--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -370,6 +370,8 @@ describe("sessionsTailCommand", () => {
   ])("continues following until $signal and exits with $exitCode", async ({ signal, exitCode }) => {
     vi.useFakeTimers();
     const runtime = makeRuntime();
+    const sigintListeners = process.listenerCount("SIGINT");
+    const sigtermListeners = process.listenerCount("SIGTERM");
     await writeSessionEntry();
     appendSqliteTrajectoryRuntimeEvents({ agentId: "main", sessionId: "session-one", storePath }, [
       makeEvent({
@@ -411,11 +413,15 @@ describe("sessionsTailCommand", () => {
     expect(output).toContain("sqlite ok");
     expect(runtime.exit).toHaveBeenCalledOnce();
     expect(runtime.exit).toHaveBeenCalledWith(exitCode);
+    expect(process.listenerCount("SIGINT")).toBe(sigintListeners);
+    expect(process.listenerCount("SIGTERM")).toBe(sigtermListeners);
   });
 
   it("exits unsuccessfully when the followed trajectory store becomes unreadable", async () => {
     vi.useFakeTimers();
     const runtime = makeRuntime();
+    const sigintListeners = process.listenerCount("SIGINT");
+    const sigtermListeners = process.listenerCount("SIGTERM");
     await writeSessionEntry();
     await appendEvents([makeEvent({ type: "session.started", ts: "2026-05-18T12:04:17.000Z" })]);
 
@@ -435,7 +441,9 @@ describe("sessionsTailCommand", () => {
     expect(runtime.error).toHaveBeenCalledWith(
       expect.stringContaining(`Failed to read trajectory progress for ${sessionKey}`),
     );
-    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(vi.mocked(runtime.exit).mock.calls).toEqual([[1]]);
+    expect(process.listenerCount("SIGINT")).toBe(sigintListeners);
+    expect(process.listenerCount("SIGTERM")).toBe(sigtermListeners);
   });
 
   it.each([

--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -364,7 +364,10 @@ describe("sessionsTailCommand", () => {
     expect(output).not.toContain("stale ok");
   });
 
-  it("continues following when SQLite trajectory rows are appended", async () => {
+  it.each([
+    { signal: "SIGINT" as const, exitCode: 130 },
+    { signal: "SIGTERM" as const, exitCode: 143 },
+  ])("continues following until $signal and exits with $exitCode", async ({ signal, exitCode }) => {
     vi.useFakeTimers();
     const runtime = makeRuntime();
     await writeSessionEntry();
@@ -399,13 +402,15 @@ describe("sessionsTailCommand", () => {
     try {
       await vi.advanceTimersByTimeAsync(1_000);
     } finally {
-      process.emit("SIGTERM", "SIGTERM");
+      process.emit(signal, signal);
       await run;
     }
 
     const output = runtimeOutput(runtime);
     expect(output).toContain("tool.result");
     expect(output).toContain("sqlite ok");
+    expect(runtime.exit).toHaveBeenCalledOnce();
+    expect(runtime.exit).toHaveBeenCalledWith(exitCode);
   });
 
   it("exits unsuccessfully when the followed trajectory store becomes unreadable", async () => {

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -217,11 +217,11 @@ function readNewSqliteFollowEvents(state: SqliteFollowState): TrajectoryEvent[] 
   return rows.map((row) => row.event);
 }
 
-async function followSelections(
+function followSelections(
   selections: TailSelection[],
   runtime: RuntimeEnv,
   initialSnapshots: Map<TailSelection, TrajectorySnapshot>,
-): Promise<void> {
+): Promise<"SIGINT" | "SIGTERM"> {
   const states = selections.map((selection): SqliteFollowState => {
     const snapshot = initialSnapshots.get(selection);
     return {
@@ -230,7 +230,7 @@ async function followSelections(
     };
   });
 
-  await new Promise<void>((resolve) => {
+  return new Promise((resolve) => {
     const interval = setInterval(() => {
       for (const state of states) {
         try {
@@ -246,14 +246,16 @@ async function followSelections(
       }
     }, FOLLOW_INTERVAL_MS);
 
-    const stop = () => {
+    const stop = (signal: "SIGINT" | "SIGTERM") => {
       clearInterval(interval);
-      process.off("SIGINT", stop);
-      process.off("SIGTERM", stop);
-      resolve();
+      process.off("SIGINT", stopSigint);
+      process.off("SIGTERM", stopSigterm);
+      resolve(signal);
     };
-    process.once("SIGINT", stop);
-    process.once("SIGTERM", stop);
+    const stopSigint = () => stop("SIGINT");
+    const stopSigterm = () => stop("SIGTERM");
+    process.once("SIGINT", stopSigint);
+    process.once("SIGTERM", stopSigterm);
   });
 }
 
@@ -319,6 +321,7 @@ export async function sessionsTailCommand(
   }
 
   if (opts.follow) {
-    await followSelections(selected, runtime, followSnapshots);
+    const signal = await followSelections(selected, runtime, followSnapshots);
+    runtime.exit(signal === "SIGINT" ? 130 : 143);
   }
 }

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -44,6 +44,7 @@ type TrajectorySnapshot = {
   events: TrajectoryEvent[];
   maxStorageSeq: number;
 };
+type FollowOutcome = "ERROR" | "SIGINT" | "SIGTERM";
 
 const DEFAULT_TAIL_COUNT = 80;
 const SESSION_KEY_PAD = 30;
@@ -221,7 +222,7 @@ function followSelections(
   selections: TailSelection[],
   runtime: RuntimeEnv,
   initialSnapshots: Map<TailSelection, TrajectorySnapshot>,
-): Promise<"SIGINT" | "SIGTERM"> {
+): Promise<FollowOutcome> {
   const states = selections.map((selection): SqliteFollowState => {
     const snapshot = initialSnapshots.get(selection);
     return {
@@ -231,6 +232,7 @@ function followSelections(
   });
 
   return new Promise((resolve) => {
+    let finished = false;
     const interval = setInterval(() => {
       for (const state of states) {
         try {
@@ -241,19 +243,22 @@ function followSelections(
               error,
             )}`,
           );
-          runtime.exit(1);
+          return finish("ERROR");
         }
       }
     }, FOLLOW_INTERVAL_MS);
 
-    const stop = (signal: "SIGINT" | "SIGTERM") => {
-      clearInterval(interval);
-      process.off("SIGINT", stopSigint);
-      process.off("SIGTERM", stopSigterm);
-      resolve(signal);
+    const finish = (outcome: FollowOutcome) => {
+      if (!finished) {
+        finished = true;
+        clearInterval(interval);
+        process.off("SIGINT", stopSigint);
+        process.off("SIGTERM", stopSigterm);
+        resolve(outcome);
+      }
     };
-    const stopSigint = () => stop("SIGINT");
-    const stopSigterm = () => stop("SIGTERM");
+    const stopSigint = () => finish("SIGINT");
+    const stopSigterm = () => finish("SIGTERM");
     process.once("SIGINT", stopSigint);
     process.once("SIGTERM", stopSigterm);
   });
@@ -321,7 +326,7 @@ export async function sessionsTailCommand(
   }
 
   if (opts.follow) {
-    const signal = await followSelections(selected, runtime, followSnapshots);
-    runtime.exit(signal === "SIGINT" ? 130 : 143);
+    const outcome = await followSelections(selected, runtime, followSnapshots);
+    runtime.exit(outcome === "ERROR" ? 1 : outcome === "SIGINT" ? 130 : 143);
   }
 }


### PR DESCRIPTION
Closes #127348

## What Problem This Solves

`openclaw sessions tail --follow` handled `SIGINT` and `SIGTERM` by cleaning up its polling interval and returning normally. The real CLI therefore exited 0, so scripts and supervisors could not distinguish an operator interrupt or termination request from a successful completed tail.

## Why This Change Was Made

The follow owner now returns the exact signal after removing both listeners and clearing the polling interval. The command boundary maps that closed outcome to the conventional CLI statuses: 130 for `SIGINT` and 143 for `SIGTERM`.

This keeps cleanup in the follow lifecycle while keeping process-exit policy at the command boundary.

## User Impact

Operators, shells, and supervisors now receive a truthful nonzero status when a followed session tail is interrupted or terminated. Normal non-following tails and existing error exits are unchanged.

## Evidence

Current-main reproduction at `47dff2de27113271f91782f23a5ae5841eecce1a`:

```json
{"requestedSignal":"SIGINT","sentAfterEvent":true,"exitCode":0,"exitSignal":null}
{"requestedSignal":"SIGTERM","sentAfterEvent":true,"exitCode":0,"exitSignal":null}
```

Exact-head proof at `16f6ad0c0f977626669ea22a27aca451a7ce8a92` used the built CLI from a frozen isolated install, a real SQLite session/trajectory store, and real process actions only after the CLI rendered `session.started`:

```json
{"head":"16f6ad0c0f977626669ea22a27aca451a7ce8a92","case":"signal","requestedSignal":"SIGINT","sentAfterEvent":true,"exitCode":130,"exitSignal":null}
{"head":"16f6ad0c0f977626669ea22a27aca451a7ce8a92","case":"signal","requestedSignal":"SIGTERM","sentAfterEvent":true,"exitCode":143,"exitSignal":null}
{"head":"16f6ad0c0f977626669ea22a27aca451a7ce8a92","case":"read-error","corruptedAfterEvent":true,"errorObserved":true,"exitCode":1,"exitSignal":null}
```

Additional exact-head verification:

- `node scripts/run-vitest.mjs src/commands/sessions-tail.test.ts` - 33 passed.
- `pnpm build` - passed.
- `openclaw sessions tail --help` - passed.
- Formal P1 autoreview - clean, correctness 0.98.
- Duplicate search by issue number and signal behavior - no open fixing PR found.

## Risk

- Scope is limited to the already-installed `SIGINT` and `SIGTERM` handlers in follow mode.
- Both listeners and the polling interval are released before requesting process exit.
- No config, schema, persistence format, default, environment variable, migration, or public API changed.
- Compatibility acceptance: interrupted follow mode intentionally changes from exit 0 to conventional statuses 130/143; all non-following behavior and existing error status 1 remain unchanged.
- Production delta: +8 net lines; test delta: +13 net lines. The growth gives the follow lifecycle one named closed outcome and one idempotent cleanup owner.

## Changelog

n/a - repository policy derives release notes from the PR user-impact and evidence sections.

