### PR TITLE
refactor(skills): keep loaded skills paired with their frontmatter

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3629,7 +3629,6 @@ src/skills/lifecycle/workspace-skill-write.ts	1
 src/skills/loading/config.ts	1
 src/skills/loading/frontmatter.ts	1
 src/skills/loading/source.ts	1
-src/skills/loading/workspace-skill-loader.ts	1
 src/skills/loading/workspace-skill-sync.runtime.ts	1
 src/skills/runtime/refresh.ts	3
 src/skills/runtime/remote-probe-utils.ts	2

--- a/src/node-host/skills.ts
+++ b/src/node-host/skills.ts
@@ -9,7 +9,7 @@ import {
   NODE_SKILL_MAX_TOTAL_BYTES,
   NODE_SKILL_NAME_RE,
 } from "../shared/node-skill-constraints.js";
-import { loadSkillsFromDirSafe } from "../skills/loading/local-loader.js";
+import { loadSkillsFromDirSafe, type LoadedLocalSkill } from "../skills/loading/local-loader.js";
 import { resolveConfigDir } from "../utils.js";
 
 type ScanNodeHostedSkillsOptions = {
@@ -87,8 +87,7 @@ export function scanNodeHostedSkills(
     return [];
   }
 
-  const loadedSkills: ReturnType<typeof loadSkillsFromDirSafe>["skills"] = [];
-  const frontmatterByFilePath = new Map<string, Record<string, string>>();
+  const loadedSkills: LoadedLocalSkill[] = [];
   for (const candidate of candidates) {
     let invalidFrontmatter = false;
     const candidatePath = path.resolve(candidate);
@@ -103,13 +102,11 @@ export function scanNodeHostedSkills(
         warn(`node host skill skipped (${diagnostic.path}): ${diagnostic.message}`);
       },
     });
-    const skill = loaded.skills.find((entry) => path.resolve(entry.filePath) === candidatePath);
-    if (skill) {
-      loadedSkills.push(skill);
-      const frontmatter = loaded.frontmatterByFilePath.get(skill.filePath);
-      if (frontmatter) {
-        frontmatterByFilePath.set(skill.filePath, frontmatter);
-      }
+    const loadedSkill = loaded.find(
+      (entry) => path.resolve(entry.skill.filePath) === candidatePath,
+    );
+    if (loadedSkill) {
+      loadedSkills.push(loadedSkill);
       continue;
     }
     let size: number | undefined;
@@ -132,10 +129,9 @@ export function scanNodeHostedSkills(
   const descriptors: NodeSkillDescriptor[] = [];
   const seenNames = new Set<string>();
   let totalBytes = 0;
-  for (const skill of loadedSkills.toSorted((left, right) =>
-    left.name.localeCompare(right.name, "en"),
+  for (const { skill, frontmatter } of loadedSkills.toSorted((left, right) =>
+    left.skill.name.localeCompare(right.skill.name, "en"),
   )) {
-    const frontmatter = frontmatterByFilePath.get(skill.filePath);
     if (
       frontmatter?.name?.trim() !== skill.name ||
       frontmatter.description?.trim() !== skill.description ||

--- a/src/skills/lifecycle/install.test.ts
+++ b/src/skills/lifecycle/install.test.ts
@@ -14,7 +14,7 @@ import {
   resolveSkillInvocationPolicy,
   resolveSkillManifestMetadata,
 } from "../loading/frontmatter.js";
-import { loadSkillsFromDirSafe, readSkillFrontmatterSafe } from "../loading/local-loader.js";
+import { loadSkillsFromDirSafe } from "../loading/local-loader.js";
 import { runCommandWithTimeoutMock } from "../test-support/install-test-mocks.js";
 import type { SkillEntry, SkillInstallSpec } from "../types.js";
 import { installSkill } from "./install.js";
@@ -69,13 +69,8 @@ function loadTestWorkspaceSkillEntries(workspaceDir: string): SkillEntry[] {
   const skills = loadSkillsFromDirSafe({
     dir: path.join(workspaceDir, "skills"),
     source: "openclaw-workspace",
-  }).skills;
-  return skills.map((skill) => {
-    const frontmatter =
-      readSkillFrontmatterSafe({
-        rootDir: skill.baseDir,
-        filePath: skill.filePath,
-      }) ?? {};
+  });
+  return skills.map(({ skill, frontmatter }) => {
     const invocation = resolveSkillInvocationPolicy(frontmatter);
     return {
       skill,

--- a/src/skills/loading/local-loader.ts
+++ b/src/skills/loading/local-loader.ts
@@ -150,16 +150,13 @@ export function loadSkillsFromDirSafe(params: {
   maxBytes?: number;
   rejectHardlinks?: boolean;
   onDiagnostic?: (diagnostic: LocalSkillLoadDiagnostic) => void;
-}): {
-  skills: Skill[];
-  frontmatterByFilePath: ReadonlyMap<string, ParsedSkillFrontmatter>;
-} {
+}): LoadedLocalSkill[] {
   const rootDir = path.resolve(params.dir);
   let rootRealPath: string;
   try {
     rootRealPath = fs.realpathSync(rootDir);
   } catch {
-    return { skills: [], frontmatterByFilePath: new Map() };
+    return [];
   }
 
   const rootSkill = loadSingleSkillDirectory({
@@ -171,13 +168,10 @@ export function loadSkillsFromDirSafe(params: {
     onDiagnostic: params.onDiagnostic,
   });
   if (rootSkill) {
-    return {
-      skills: [rootSkill.skill],
-      frontmatterByFilePath: new Map([[rootSkill.skill.filePath, rootSkill.frontmatter]]),
-    };
+    return [rootSkill];
   }
 
-  const loadedSkills = listCandidateSkillDirs(rootDir)
+  return listCandidateSkillDirs(rootDir)
     .map((skillDir) =>
       loadSingleSkillDirectory({
         skillDir,
@@ -189,41 +183,4 @@ export function loadSkillsFromDirSafe(params: {
       }),
     )
     .filter((skill): skill is LoadedLocalSkill => skill !== null);
-  const frontmatterByFilePath = new Map<string, ParsedSkillFrontmatter>();
-  for (const loaded of loadedSkills) {
-    frontmatterByFilePath.set(loaded.skill.filePath, loaded.frontmatter);
-  }
-
-  return {
-    skills: loadedSkills.map((loaded) => loaded.skill),
-    frontmatterByFilePath,
-  };
-}
-
-export function readSkillFrontmatterSafe(params: {
-  rootDir: string;
-  filePath: string;
-  maxBytes?: number;
-  rejectHardlinks?: boolean;
-}): Record<string, string> | null {
-  let rootRealPath: string;
-  try {
-    rootRealPath = fs.realpathSync(path.resolve(params.rootDir));
-  } catch {
-    return null;
-  }
-  const raw = readSkillFileSync({
-    rootRealPath,
-    filePath: path.resolve(params.filePath),
-    maxBytes: params.maxBytes,
-    rejectHardlinks: params.rejectHardlinks,
-  });
-  if (raw === null) {
-    return null;
-  }
-  try {
-    return parseSkillFrontmatter(raw);
-  } catch {
-    return null;
-  }
 }

--- a/src/skills/loading/skill-path-containment.test.ts
+++ b/src/skills/loading/skill-path-containment.test.ts
@@ -11,7 +11,7 @@ import {
   setMockSkillsHomeEnv,
   type SkillsHomeEnvSnapshot,
 } from "../test-support/home-env.test-support.js";
-import { readSkillFrontmatterSafe } from "./local-loader.js";
+import { loadSingleSkillDirectory } from "./local-loader.js";
 import { loadWorkspaceSkills } from "./workspace-skill-loader.js";
 
 vi.mock("./plugin-skills.js", () => ({
@@ -389,10 +389,11 @@ describe("skill path containment", () => {
         description: "Readable from filesystem root",
       });
 
-      const frontmatter = readSkillFrontmatterSafe({
-        rootDir: path.parse(skillDir).root,
-        filePath: path.join(skillDir, "SKILL.md"),
-      });
+      const frontmatter = loadSingleSkillDirectory({
+        skillDir,
+        source: "openclaw-workspace",
+        rootRealPath: path.parse(skillDir).root,
+      })?.frontmatter;
 
       expect(frontmatter?.name).toBe("root-allowed");
       expect(frontmatter?.description).toBe("Readable from filesystem root");

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -21,19 +21,14 @@ import { loadSkillLibrarySelection } from "../library/selection.js";
 import { getSkillsSnapshotVersion } from "../runtime/refresh-state.js";
 import { mergeRemoteNodeSkillEntries } from "../runtime/remote-skills.js";
 import { fingerprintSkillSnapshotConfig } from "../runtime/snapshot-config-fingerprint.js";
-import type {
-  ParsedSkillFrontmatter,
-  SkillEligibilityContext,
-  SkillEntry,
-  SkillSnapshot,
-} from "../types.js";
+import type { SkillEligibilityContext, SkillEntry, SkillSnapshot } from "../types.js";
 import { resolveBundledSkillsDir } from "./bundled-dir.js";
 import { resolveBundledAllowlist, shouldIncludeSkill } from "./config.js";
 import { resolveSkillInvocationPolicy, resolveSkillKey } from "./frontmatter.js";
 import {
   loadSingleSkillDirectory,
   loadSkillsFromDirSafe,
-  readSkillFrontmatterSafe,
+  type LoadedLocalSkill,
   type LocalSkillLoadDiagnostic,
 } from "./local-loader.js";
 import {
@@ -61,10 +56,7 @@ const MAX_SKILL_ENTRY_CACHE_SIZE = 64;
 const skillEntryCache = new Map<string, SkillEntry[]>();
 const reportedSkillCollisions = new Map<string, true>();
 
-type LoadedSkillRecord = {
-  skill: Skill;
-  frontmatter?: ParsedSkillFrontmatter;
-  rejectHardlinks: boolean;
+type LoadedSkillRecord = LoadedLocalSkill & {
   syncSourceDir?: string;
   syncDirName?: string;
 };
@@ -198,13 +190,7 @@ function loadContainedSkillRecords(params: {
     rejectHardlinks: params.rejectHardlinks,
     onDiagnostic: (diagnostic) => warnInvalidSkill(params.source, diagnostic),
   });
-  const records = loaded.skills
-    .map((skill) => ({
-      skill,
-      frontmatter: loaded.frontmatterByFilePath.get(skill.filePath),
-      rejectHardlinks: params.rejectHardlinks,
-    }))
-    .filter((record) => path.resolve(record.skill.baseDir) === expectedBaseDir);
+  const records = loaded.filter((record) => path.resolve(record.skill.baseDir) === expectedBaseDir);
   const canonicalSkillDir = params.canonicalSkillDir;
   return canonicalSkillDir
     ? records.map((record) => canonicalizeLoadedSkillRecord(record, canonicalSkillDir))
@@ -485,16 +471,7 @@ function loadSkillEntries(
   const entries = Array.from(merged.values())
     .toSorted((a, b) => a.skill.name.localeCompare(b.skill.name, "en"))
     .map((record) => {
-      const skill = record.skill;
-      const frontmatter =
-        record.frontmatter ??
-        readSkillFrontmatterSafe({
-          rootDir: skill.baseDir,
-          filePath: skill.filePath,
-          maxBytes: limits.maxSkillFileBytes,
-          rejectHardlinks: record.rejectHardlinks,
-        }) ??
-        ({} as ParsedSkillFrontmatter);
+      const { skill, frontmatter } = record;
       const invocation = resolveSkillInvocationPolicy(frontmatter);
       const entry: SkillEntry = {
         skill,


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of skill discovery ownership. The loader already reads and parses each skill together, but collection loading separates those results into a skill array and a path-keyed frontmatter map. Workspace and node-host consumers then reconstruct a relationship that was already known.

This is a behavior-preserving internal simplification, not a newly demonstrated user-facing bug or a measured performance improvement.

## Why This Change Was Made

Carry the existing required skill/frontmatter record from the canonical loader through both consumers. Remove the parallel map, optional-frontmatter reconstruction, redundant workspace reread path, and the now-unused standalone frontmatter reader.

Protected reads, hardlink policy, diagnostics, selection, ordering, and caps remain in their existing owners. Existing tests use the canonical loaders without removing any test case or assertion. The assertion-safety baseline shrinks by the one removed workspace assertion.

Production: **+18/-88 (net -70)**. Tests: **+9/-13 (net -4)**. Baseline: **-1**. No public CLI, RPC, plugin SDK, config, schema, or dependency change.

## User Impact

No intended user-visible change. Skill discovery and listing retain the same behavior, with one required record carrying the already-parsed frontmatter across the loader boundary.

The node host's later content read is unchanged; this does not claim to fix its existing read-after-validation race.

## Evidence

- The same five existing suites passed **73 tests before and after**: workspace loading, root discovery, path containment, node-host skills, and installation. A temporary pair-association fault made the existing node-host cap case fail with 1 instead of 64; its exact inverse was applied before the final passing run. Nine names were filtered in that control run. This is a discriminating synthetic control, not an original-product-bug claim.
- Targeted formatting, diff checking, and the canonical assertion-safety ratchet passed. The ordinary full **16-phase `pnpm build`** passed.
- A real isolated built Gateway → `skills list` CLI flow preserved two distinct frontmatter-only fields from two synthetic workspace skills. It used the normal 1500 ms CLI timeout and an explicit loopback target with no local fallback. This does not claim live node-host, provider, or skill-execution coverage.
- The normal six-path changed gate completed all **30 checks**, including production/test typechecks, dead-export scans, lint, and ratchets. [Backing runner record](https://github.com/openclaw/openclaw/actions/runs/33898896207). The native runner reported success and lease cleanup; portal synchronization emitted a nonfatal timeout. The backing Actions state is not used as a substitute for the recorded check outcomes.
- Precommit and exact-commit Codex reviews were both **scoped-clean through P2**, with all original provider reports retained. The exact-commit review used six automatic full-input partitions; no fallback or retry was used.

Signed commit `8b38acf019e6a7c5b9df840017dbaaef8900a171` preserves the exact reviewed six-file candidate and tree `c46ebbf3ab0a2dc04b68f6c929a067ea4dc82717`. Build and gate proof preceded the signed save and used those identical source bytes; the built metadata still identifies its actual base `78f1cf1eab9472bab69288e0c91b77771d099f5d`. No build was relabeled or replayed to claim a different source revision.

Proof limits: remote evidence binds the exact native sender tree and successful transport/execution, not an independent receiver-tree attestation. Dependency custody covers physical isolation and selected byte pins, not every dependency byte. All 14,997 inventoried generated artifacts remained unchanged. Earlier metadata-observer refusals were preserved and qualified without restoring Git state; unknown prior index/cache writers and unsampled transient children/temp leaves remain unknown. No screenshots are claimed for this nonvisual change.
