### PR TITLE
perf(browser): reduce cold bridge startup and cleanup stalls

### DIFF
--- a/extensions/browser/bridge-api.ts
+++ b/extensions/browser/bridge-api.ts
@@ -1,0 +1,6 @@
+/** Keep bridge lifecycle and auth state in the same owner as the full runtime. */
+export {
+  type BrowserBridge,
+  startBrowserBridgeServer,
+  stopBrowserBridgeServer,
+} from "./src/browser/bridge-server.js";

--- a/extensions/browser/src/browser/bridge-server.ts
+++ b/extensions/browser/src/browser/bridge-server.ts
@@ -7,8 +7,8 @@
 import type { Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import express from "express";
+import { isLoopbackHost } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { isLoopbackHost } from "../gateway/net.js";
 import { deleteBridgeAuthForPort, setBridgeAuthForPort } from "./bridge-auth-registry.js";
 import type { ResolvedBrowserConfig } from "./config.js";
 import { listenBrowserHttpServer } from "./http-listen.js";

--- a/extensions/browser/src/browser/cdp-proxy-bypass.ts
+++ b/extensions/browser/src/browser/cdp-proxy-bypass.ts
@@ -9,8 +9,8 @@
  */
 import http from "node:http";
 import https from "node:https";
+import { isLoopbackHost } from "openclaw/plugin-sdk/ssrf-runtime";
 import { registerManagedProxyBrowserCdpBypass } from "openclaw/plugin-sdk/ssrf-runtime-internal";
-import { isLoopbackHost } from "../gateway/net.js";
 import { hasProxyEnvConfigured } from "../infra/net/proxy-env.js";
 
 /** HTTP agent that never uses a proxy — for localhost CDP connections. */

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -7,8 +7,7 @@
 import { createHash } from "node:crypto";
 import { redactCdpUrl } from "openclaw/plugin-sdk/browser-cdp";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
-import { isLoopbackHost } from "../gateway/net.js";
+import { fetchWithSsrFGuard, isLoopbackHost } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   SsrFBlockedError,
   type SsrFPolicy,

--- a/extensions/browser/src/browser/client-fetch.timeout.test.ts
+++ b/extensions/browser/src/browser/client-fetch.timeout.test.ts
@@ -20,9 +20,13 @@ vi.mock("./control-auth.js", () => ({
 vi.mock("./bridge-auth-registry.js", () => ({
   getBridgeAuthForPort: authMocks.getBridgeAuthForPort,
 }));
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
-  fetchWithSsrFGuard: (...args: unknown[]) => fetchWithSsrFGuardMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: (...args: unknown[]) => fetchWithSsrFGuardMock(...args),
+  };
+});
 
 const { fetchBrowserJson } = await import("./client-fetch.js");
 

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -13,13 +13,12 @@ import {
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { formatCliCommand } from "openclaw/plugin-sdk/setup-tools";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard, isLoopbackHost } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeOptionalString,
   normalizeLowercaseStringOrEmpty,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getRuntimeConfig } from "../config/config.js";
-import { isLoopbackHost } from "../gateway/net.js";
 import { getBridgeAuthForPort } from "./bridge-auth-registry.js";
 import { resolveBrowserConfig, resolveProfile } from "./config.js";
 import { resolveBrowserControlAuth } from "./control-auth.js";

--- a/extensions/browser/src/browser/csrf.ts
+++ b/extensions/browser/src/browser/csrf.ts
@@ -5,8 +5,8 @@
  * contexts while allowing CLI, Gateway, and local service clients.
  */
 import type { NextFunction, Request, Response } from "express";
+import { isLoopbackHost } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { isLoopbackHost } from "../gateway/net.js";
 
 function firstHeader(value: string | string[] | undefined): string {
   return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");

--- a/extensions/browser/src/browser/extension-relay/relay-server.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import http, { type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
+import { isLoopbackHost } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   rawDataToString,
   readRequestBodyWithLimit,
@@ -10,7 +11,6 @@ import {
   WEBHOOK_BODY_READ_DEFAULTS,
 } from "openclaw/plugin-sdk/webhook-ingress";
 import { WebSocketServer, type WebSocket } from "ws";
-import { isLoopbackHost } from "../../gateway/net.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { randomRelayId } from "./auth-v2-crypto.js";
 import { authenticateExtensionWebSocket } from "./auth-v2-websocket.js";

--- a/extensions/browser/src/gateway/net.ts
+++ b/extensions/browser/src/gateway/net.ts
@@ -1,4 +1,0 @@
-/**
- * Gateway network helper re-export for loopback host checks.
- */
-export { isLoopbackHost } from "../sdk-node-runtime.js";

--- a/extensions/browser/src/sdk-node-runtime.ts
+++ b/extensions/browser/src/sdk-node-runtime.ts
@@ -8,7 +8,6 @@ export {
   ensureGatewayStartupAuth,
   ErrorCodes,
   errorShape,
-  isLoopbackHost,
   isNodeCommandAllowed,
   respondUnavailableOnNodeInvokeError,
   resolveGatewayAuth,

--- a/src/plugin-sdk/browser-bridge.test.ts
+++ b/src/plugin-sdk/browser-bridge.test.ts
@@ -1,4 +1,4 @@
-// Browser bridge tests protect async activation and lifecycle delegation.
+// Browser bridge tests protect narrow loading, async activation, and lifecycle delegation.
 import { createServer, type Server } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserBridge, startBrowserBridgeServer } from "./browser-bridge.js";
@@ -69,7 +69,7 @@ describe("browser bridge facade", () => {
   });
 
   for (const operation of ["startBrowserBridgeServer", "stopBrowserBridgeServer"] as const) {
-    it(`awaits activation before ${operation} and preserves argument and result identity`, async () => {
+    it(`awaits activation of the bridge-only artifact before ${operation} and preserves identity`, async () => {
       const surface = createSurface();
       let resolveActivation!: (value: typeof surface) => void;
       const activation = new Promise<typeof surface>((resolve) => {
@@ -96,7 +96,7 @@ describe("browser bridge facade", () => {
       );
       expect(loaders.async).toHaveBeenCalledWith({
         dirName: "browser",
-        artifactBasename: "runtime-api.js",
+        artifactBasename: "bridge-api.js",
       });
     });
 

--- a/src/plugin-sdk/browser-bridge.ts
+++ b/src/plugin-sdk/browser-bridge.ts
@@ -31,7 +31,7 @@ type BrowserBridgeFacadeModule = {
 function loadFacadeModule(): Promise<BrowserBridgeFacadeModule> {
   return loadActivatedBundledPluginPublicSurfaceModule<BrowserBridgeFacadeModule>({
     dirName: "browser",
-    artifactBasename: "runtime-api.js",
+    artifactBasename: "bridge-api.js",
   });
 }
 


### PR DESCRIPTION
Related: #138152 (merged repair that made browser bridge activation asynchronous; this addresses its remaining allowed-artifact cost).

## What Problem This Solves

Fixes an issue where starting or stopping a cold sandbox browser bridge blocked the event loop while loading the entire browser runtime, including tool, CLI, service, and gateway-handler exports unrelated to bridge lifecycle. Awaiting activation did not remove that synchronous artifact cost.

## Why This Change Was Made

The bridge facade now loads a small browser-owned `bridge-api` artifact that directly re-exports the existing bridge server owner. It does not copy the implementation or introduce another state/cache owner. All six browser-local loopback consumers now use the existing canonical `ssrf-runtime` export, allowing the obsolete wrapper and its unused private re-export to be deleted.

The full `runtime-api` remains for its existing worker and other consumers. Per-call activation checks, checked artifact resolution, original delegated errors, authentication, exact Server identity, and cleanup ownership remain unchanged. The internal bridge adapter is not an exported SDK subpath; no supported cross-version third-party implementation of it was found in source/tagged contracts. Generic installed-root resolution is unchanged, with no speculative fallback. A denied call now names the actual `bridge-api.js` artifact in its diagnostic while retaining the same throwing policy/reason.

Production: **+13/-14 (net -1)**. Tests: **+10/-6 (net +4)**. No dependency, configuration, schema, protocol, or security-policy change.

## User Impact

Cold bridge artifact loading and cleanup perform substantially less work. Bridge startup also improves, although it still loads much of the route/SDK graph and is not fully nonblocking. No operator configuration changes are required.

**Memory tradeoff:** in the final ordinary samples, whole startup-proof peak RSS increased about **5.1% source / 12.5% native**, even though artifact-only and cold-stop peak RSS decreased. A separate current-candidate full-versus-narrow diagnostic converged to approximately the same 143.1 MiB native retained heap after post-stop major GC; source narrow retained about 14.8 MiB less heap. RSS stayed higher after collection. Four lifecycle cycles did not demonstrate accumulating bridge retention, but this is not a memory-improvement or no-leak claim. There are no production GC calls or other workarounds.

## Evidence

Matched fresh-process measurements used **Node v26.8.1**, the same probe/isolation contract, and a contended macOS host. Two ordinary samples per cell; before and after source paths are separate from before and after native built JavaScript. No prewarm, timeout increases, or assertion weakening. Facade import and activation preparation are recorded separately; queued timers and interval gaps tracked the remaining synchronous work.

| Path / operation | Before seconds | Final after seconds | Mean operation process-CPU reduction |
| --- | ---: | ---: | ---: |
| Source artifact | 58.560 / 64.544 | 10.709 / 9.289 | 81.1% |
| Source start | 110.433 / 58.917 | 50.651 / 29.173 | 43.5% |
| Source cold stop | 73.442 / 82.022 | 17.418 / 12.447 | 76.6% |
| Native built artifact | 11.084 / 2.766 | 0.895 / 1.280 | 73.8% |
| Native built start | 14.386 / 13.643 | 10.453 / 11.180 | 16.5% |
| Native built cold stop | 27.505 / 6.548 | 2.760 / 3.771 | 66.8% |

These are observations, not latency guarantees or statistically controlled estimates. Complete start/auth/stop process walls also improved: source 122.8/64.4s to 64.7/45.2s; native 28.2/18.5s to 12.6/14.5s. The work was not merely shifted ahead of the measurement interval.

Instrumented artifact loads fell from **5,072 to 1,887 URLs in source** and **3,224 to 1,419 in native built code**. Final cold-operation graph checks exclude the full runtime artifact and unrelated browser tool/CLI/service/gateway-handler roots. Built probes recorded zero native misses or source-transform fallbacks. Canonical build discovery emits the new artifact in the unified core/plugin graph, includes it in package artifacts, and retains one shared bridge/auth/lifecycle owner. The final rebuild's full/narrow runtime closure hashes match the earlier candidate exactly after the unused-export cleanup. These are local built-artifact checks, not an installed npm tarball test.

The reused facade regression produced **two intended failures / five passes before the production edit**, then passed afterward. The failures were broad-artifact selection, not missing mock exports. **313 owner/sibling tests passed**, plus focused/private SDK tests. The timeout test's existing fetch mock was updated to retain the real canonical loopback export; its assertions and deadlines are unchanged.

Real isolated loopback proof covered:

- Both full/narrow loading orders in source/Jiti and native built code: identical lifecycle functions, shared auth, exact Server/config/result identity, concurrent owner stop Promise identity, original cleanup failure and successful retry, and retained-loader/fresh-generation behavior after cleanup.
- A separate **narrow-only startup order** that did not load the full API first: authenticated `POST /start` entered a deferred attach callback, then actual cached-stop → facade → owner invalidated it. At the cleanup barrier ingress was closed; after releasing attach, the request returned HTTP 409 with the expected lifecycle-changed error rather than a CDP-connect failure. Only afterward was the full API loaded and identity/auth checked.
- HTTP 401 without auth, authenticated routing, auth removal after stopping and rebinding the former ephemeral port, one exact close/cleanup, preservation of a replacement cached bridge and unrelated listener, and no owned listeners or process-group members left behind.

The final **full build passed in 10m53s**, complete changed-file checks and five import guards passed, and the final browser entrypoint memory profile passed. Initial changed checks identified the now-unused loopback re-export; it was deleted, checks passed, and the final build/proofs were refreshed. No compiler-input guard was weakened. No ineffective-dynamic-import warning appeared.

Fresh **Codex autoreview of the exact final code** was scoped-clean with no accepted/actionable findings at its configured P0 threshold. The broader execution proof is independent of that review.

<details>
<summary>Verification commands (Node v26.8.1)</summary>

```sh
node scripts/run-vitest.mjs \
  src/plugin-sdk/browser-bridge.test.ts \
  src/plugin-sdk/facade-runtime.activation.test.ts \
  src/plugin-sdk/facade-runtime.activation-failure.test.ts \
  src/plugin-sdk/facade-runtime.activation-cold.test.ts \
  src/plugin-sdk/facade-runtime.cold.test.ts \
  src/plugin-sdk/facade-runtime.test.ts \
  src/plugin-sdk/facade-loader.test.ts \
  src/plugins/plugin-module-loader-cache.test.ts \
  src/plugins/plugin-cache.test.ts \
  src/plugins/native-module-require.test.ts \
  src/plugin-sdk/browser-maintenance.test.ts \
  extensions/browser/src/browser/bridge-server.auth.test.ts \
  extensions/browser/src/browser/runtime-lifecycle.shutdown-race.test.ts \
  extensions/browser/src/browser/server-middleware.test.ts \
  extensions/browser/src/browser/client-fetch.loopback-auth.test.ts \
  extensions/browser/src/browser/cdp-proxy-bypass.test.ts \
  extensions/browser/src/browser/cdp.helpers.test.ts \
  extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts \
  extensions/browser/src/attached-browser-tool-runtime.test.ts \
  extensions/browser/browser-maintenance.cold.test.ts \
  extensions/browser/browser-maintenance.test.ts \
  src/agents/sandbox/browser.create.test.ts \
  src/agents/sandbox/manage.test.ts \
  src/agents/sandbox/prune.test.ts \
  src/worker/browser-runtime.test.ts \
  extensions/browser/src/browser/client-fetch.timeout.test.ts \
  --reporter=verbose --reporter=json \
  --outputFile=.artifacts/browser-bridge-refactor/owners.json
```

```sh
node scripts/check-changed.mjs -- \
  extensions/browser/bridge-api.ts \
  extensions/browser/src/browser/bridge-server.ts \
  extensions/browser/src/browser/cdp-proxy-bypass.ts \
  extensions/browser/src/browser/cdp.helpers.ts \
  extensions/browser/src/browser/client-fetch.timeout.test.ts \
  extensions/browser/src/browser/client-fetch.ts \
  extensions/browser/src/browser/csrf.ts \
  extensions/browser/src/browser/extension-relay/relay-server.ts \
  extensions/browser/src/gateway/net.ts \
  extensions/browser/src/sdk-node-runtime.ts \
  src/plugin-sdk/browser-bridge.test.ts \
  src/plugin-sdk/browser-bridge.ts
```

```sh
pnpm build
```

```sh
OPENCLAW_LOCAL_CHECK=0 node --import tsx scripts/profile-extension-memory.mts --extension browser --skip-combined --concurrency 1
```

```sh
git diff --check
```

</details>

Proof scope is real browser bridge HTTP/import/lifecycle behavior; no actual Chrome/CDP session, Docker sandbox, or operator Gateway was launched. This has no visual/UI change. Existing HTTP/auth/setup documentation and public SDK exports remain accurate, so no product documentation or changelog changes are included. Scripts, CPU profiles, module inventories, exact hashes, and all positive/negative measurements are retained locally; the historical investigation and raw artifacts are not committed.
