### PR TITLE
perf(queues): avoid redundant mixed-route scans

### DIFF
--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -1520,12 +1520,8 @@ export function scheduleFollowupDrain(
           continue;
         }
         if (queue.mode === "collect") {
-          // Once the batch is mixed, never collect again within this drain.
-          // Prevents “collect after shift” collapsing different targets.
-          //
-          // Debug: `pnpm test src/auto-reply/reply/reply-flow.test.ts`
-          // Check if messages span multiple channels.
-          // If so, process individually to preserve per-message routing.
+          // Recheck remaining routes after each individual drain so a later
+          // compatible suffix can collect without mixing destinations.
           const isCrossChannel =
             hasCrossChannelItems(queue.items, resolveCrossChannelKey) ||
             queue.items.some(requiresIndividualCollectDrain);

--- a/src/utils/queue-helpers.ts
+++ b/src/utils/queue-helpers.ts
@@ -313,18 +313,15 @@ export function hasCrossChannelItems<T>(
   items: T[],
   resolveKey: (item: T) => { key?: string; cross?: boolean },
 ): boolean {
-  const keys = new Set<string>();
+  let firstKey: string | undefined;
 
   for (const item of items) {
     const resolved = resolveKey(item);
-    if (resolved.cross) {
+    if (resolved.cross || (resolved.key && firstKey && resolved.key !== firstKey)) {
       return true;
     }
-    if (!resolved.key) {
-      continue;
-    }
-    keys.add(resolved.key);
+    firstKey ||= resolved.key;
   }
 
-  return keys.size > 1;
+  return false;
 }


### PR DESCRIPTION
## What Problem This Solves

The follow-up queue kept resolving every route after it already knew the batch contained different destinations. Each individual drain repeated the scan, creating a temporary set and unnecessary route strings.

Production LOC: +6/-13 (net -7). Tests and docs: unchanged.

## Why This Change Was Made

The shared predicate now remembers the first nonempty key and returns at the first mismatch. Missing and empty keys remain ignored, and an explicit cross marker still forces individual delivery. The immediate caller's stale comment now describes its existing behavior: after each individual drain it rechecks whether the remaining compatible suffix can collect.

## User Impact

Mixed-route queues perform less route-discovery work while retaining the same destination boundaries, delivery order and collected prompts. The caller's executable behavior and all queue settings are unchanged.

## Evidence

Both versions passed 3,906 helper cases and four scenarios using the real exported enqueue/drain flow: one route, mixed routes followed by a compatible suffix, unresolved input followed by one route, and 20 distinct routes. Exact generated prompts and destination fields matched. The shrinking 20-route scan used 210 resolver calls before and 39 after; the same-route and unresolved-prefix controls stayed at 20 and 4. These are operation counts, not whole-Gateway memory or latency measurements.

Both versions passed 123 existing tests. The candidate's complete changed-file gate and independent managed Codex P0–P2 review passed with no actionable findings.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/utils/queue-helpers.test.ts \
  src/auto-reply/reply/queue.collect.test.ts
node scripts/check-changed.mjs -- \
  src/utils/queue-helpers.ts src/auto-reply/reply/queue/drain.ts
```

Existing tests cover route and collection behavior; no permanent call-count test or additional production seam was added.
