### PR TITLE
fix(ui): preserve rich preview metadata beside shortcodes

### DIFF
--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -145,8 +145,15 @@ export function isStandaloneToolMessageForDisplay(message: unknown): boolean {
   return role === "tool" || hasToolMessageEnvelope(m);
 }
 
-function coerceCanvasPreview(preview: Record<string, unknown>): CanvasPreview | null {
-  if (preview.kind !== "canvas" || preview.surface === "tool_card" || preview.render !== "url") {
+export function readCanvasContentPreview(content: unknown): CanvasPreview | null {
+  const item = asOptionalRecord(content);
+  const preview = item?.type === "canvas" ? asOptionalRecord(item.preview) : undefined;
+  if (
+    !preview ||
+    preview.kind !== "canvas" ||
+    preview.surface === "tool_card" ||
+    preview.render !== "url"
+  ) {
     return null;
   }
   const result: CanvasPreview = { kind: "canvas", surface: "assistant_message", render: "url" };
@@ -440,9 +447,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   // History's structured blocks retain sandbox and dashboard metadata that
   // an assistant shortcode cannot carry. Keep that representation when both exist.
   const projectedCanvasPreviews = (contentItems ?? []).flatMap((value) => {
-    const item = asOptionalRecord(value);
-    const rawPreview = item?.type === "canvas" ? asOptionalRecord(item.preview) : undefined;
-    const preview = rawPreview ? coerceCanvasPreview(rawPreview) : null;
+    const preview = readCanvasContentPreview(value);
     return preview ? [preview] : [];
   });
 
@@ -491,9 +496,8 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
       if (type === "attachment" || type === "attachment_error") {
         return normalizeAttachmentContentBlock(item) ?? [];
       }
-      const rawPreview = type === "canvas" ? asOptionalRecord(item.preview) : undefined;
-      if (rawPreview) {
-        const preview = coerceCanvasPreview(rawPreview);
+      if (type === "canvas") {
+        const preview = readCanvasContentPreview(item);
         if (!preview) {
           return [];
         }

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -140,13 +140,18 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   const searchFiltering = props.searchOpen === true && Boolean(props.searchQuery?.trim());
   const persistedCanvasIdentities = new Set<string>();
   const normalizedHistory = history.map(safeNormalizeMessage);
-  let canvasTurn: { previews: CanvasToolPreview[]; lastMatchingAssistantIndex: number } = {
+  const historyItems = buildMessageItems(history);
+  let canvasTurn: {
+    previews: { preview: CanvasToolPreview; item: (typeof historyItems)[number] }[];
+    lastMatchingAssistantIndex: number;
+  } = {
     previews: [],
     lastMatchingAssistantIndex: -1,
   };
   // Rows in one turn share these facts so a tool result can see the assistant
   // projection that follows it, without consuming a view from another turn.
-  const canvasTurns = normalizedHistory.map((message, index) => {
+  const canvasTurns = historyItems.map((item, index) => {
+    const message = normalizedHistory[index];
     const role = message && normalizeRoleForGrouping(message.role);
     if (role === "user" || role === "system") {
       canvasTurn = { previews: [], lastMatchingAssistantIndex: -1 };
@@ -158,7 +163,9 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     ) {
       canvasTurn.lastMatchingAssistantIndex = index;
       canvasTurn.previews.push(
-        ...message.content.flatMap((block) => (block.type === "canvas" ? [block.preview] : [])),
+        ...message.content.flatMap((block) =>
+          block.type === "canvas" ? [{ preview: block.preview, item }] : [],
+        ),
       );
     }
     return canvasTurn;
@@ -168,7 +175,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     ? `divider:compaction:live:${compaction.runId}:${compaction.itemId ?? "manual"}`
     : undefined;
   let hasPersistedCompaction = false;
-  for (const [i, item] of buildMessageItems(history).entries()) {
+  for (const [i, item] of historyItems.entries()) {
     const msg = item.message;
     const itemKey = item.key;
     const raw = asRecord(msg) ?? {};
@@ -214,11 +221,23 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
         persistedCanvasIdentities.add(identity);
       }
     }
+    const matchingCanvas =
+      persistedCanvasSource &&
+      canvasTurns[i]!.previews.find(({ preview }) =>
+        canvasPreviewsMatch(preview, persistedCanvasSource.preview),
+      );
+    if (persistedCanvasSource && matchingCanvas) {
+      // Enrich the owned display row, including a later assistant shortcode,
+      // without changing transcript input or introducing a second widget card.
+      matchingCanvas.item.message = appendCanvasBlockToAssistantMessage(
+        matchingCanvas.item.message,
+        persistedCanvasSource.preview,
+        persistedCanvasSource.text,
+      );
+    }
     const renderPersistedPreview =
       persistedCanvasSource != null &&
-      !canvasTurns[i]!.previews.some((preview) =>
-        canvasPreviewsMatch(preview, persistedCanvasSource.preview),
-      ) &&
+      !matchingCanvas &&
       (!searchFiltering || canvasTurns[i]!.lastMatchingAssistantIndex > i);
     if (persistedCanvasSource && renderPersistedPreview) {
       items.push({

--- a/ui/src/pages/chat/chat-thread-items.ts
+++ b/ui/src/pages/chat/chat-thread-items.ts
@@ -8,7 +8,7 @@ import type { ChatItem, ChatQueueItem, ToolCard } from "../../lib/chat/chat-type
 import { extractTextCached, readTranscriptMediaEntries } from "../../lib/chat/message-extract.ts";
 import {
   canvasPreviewsMatch,
-  normalizeMessage,
+  readCanvasContentPreview,
   stripMessageDisplayMetadataText,
   normalizeRoleForGrouping,
 } from "../../lib/chat/message-normalizer.ts";
@@ -22,13 +22,6 @@ export function appendCanvasBlockToAssistantMessage(
   preview: Extract<NonNullable<ToolCard["preview"]>, { kind: "canvas" }>,
   rawText: string | null,
 ) {
-  if (
-    normalizeMessage(message).content.some(
-      (block) => block.type === "canvas" && canvasPreviewsMatch(block.preview, preview),
-    )
-  ) {
-    return message;
-  }
   const raw = message as Record<string, unknown>;
   const existingContent = Array.isArray(raw.content)
     ? [...raw.content]
@@ -37,6 +30,16 @@ export function appendCanvasBlockToAssistantMessage(
       : typeof raw.text === "string"
         ? [{ type: "text", text: raw.text }]
         : [];
+  // A shortcode carries identity, not the tool's sandbox or App descriptor.
+  // Only an existing structured block can replace the canonical projection.
+  if (
+    existingContent.some((block) => {
+      const existing = readCanvasContentPreview(block);
+      return existing && canvasPreviewsMatch(existing, preview);
+    })
+  ) {
+    return message;
+  }
   return {
     ...raw,
     content: [

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -4566,6 +4566,62 @@ describe("buildCachedChatItems", () => {
     },
   );
 
+  it.each(
+    ["live", "history-before", "history-after"].flatMap((source) =>
+      ["mcp", "board"].map((kind) => ({ source, kind })),
+    ),
+  )("preserves rich $kind metadata over a shortcode from $source", ({ source, kind }) => {
+    const viewId = "cv_rich_shortcode";
+    const callId = "call-rich-shortcode";
+    const url = `/__openclaw__/canvas/documents/${viewId}/index.html`;
+    const boardOutput = JSON.stringify({
+      kind: "canvas",
+      view: { id: viewId, url, title: "Widget", boardWidgetName: "saved-widget" },
+      presentation: { target: "assistant_message", sandbox: "strict" },
+    });
+    const result =
+      kind === "mcp"
+        ? mcpAppResult(viewId, callId, 1_002)
+        : toolResultMessage(callId, "show_widget", boardOutput, 1_002);
+    const assistant = assistantMessage(
+      [{ type: "text", text: `[embed ref="${viewId}" title="Widget" /]\n\nReady.` }],
+      source === "history-after" ? 1_001 : 1_003,
+    );
+    const original = structuredClone(assistant);
+    const history =
+      source === "live"
+        ? [assistant]
+        : source === "history-before"
+          ? [result, assistant]
+          : [assistant, result];
+    const groups = messageGroups({
+      messages: [userMessage("Show a widget", 1_000), ...history],
+      toolMessages:
+        source !== "live"
+          ? []
+          : kind === "mcp"
+            ? [mcpAppLiveResult(viewId, callId, 1_002)]
+            : [toolMessage(callId, "show_widget", boardOutput, 1_002)],
+      showToolCalls: false,
+    });
+
+    const previews = groups.flatMap(canvasBlocksAcross);
+    expect(previews).toHaveLength(1);
+    expect(previews[0]).toMatchObject({
+      type: "canvas",
+      preview:
+        kind === "mcp"
+          ? { viewId, sandbox: "scripts", mcpApp: mcpAppCanvasBlock(viewId, callId).preview.mcpApp }
+          : { viewId, url, sandbox: "strict", boardWidgetName: "saved-widget" },
+    });
+    expect(
+      groups.flatMap((group) =>
+        group.messages.flatMap(({ message }) => normalizeMessage(message).content),
+      ),
+    ).toContainEqual({ type: "text", text: "Ready." });
+    expect(assistant).toEqual(original);
+  });
+
   it("deduplicates a Gateway Canvas copy that matches only by URL", () => {
     const viewId = "cv_url_match";
     const result = toolResultMessage(


### PR DESCRIPTION
## What this fixes

An assistant reply containing only an `[embed]` shortcode could discard the matching tool result’s rich preview metadata. An MCP App then rendered as a Canvas document instead of an interactive App; dashboard widget identity and the tool’s sandbox ceiling could also be lost. The regression affected live results and persisted history in either ordering.

The projection now deduplicates against actual structured Canvas blocks, not the lightweight preview synthesized from a shortcode. History enrichment updates the existing owned display row, so it preserves one card, stable row identity and transcript immutability. The existing canonical Canvas parser is reused by both paths. Raw structured-block deduplication, turn boundaries and search filtering remain unchanged.

## Validation

- Refreshed on pinned main `b1164348d55ca3bc221544daa86a908b70c100c6`. All four repair files remain byte-identical to the previously reviewed candidate; current renderer and test/build context are retained.
- Before the production repair: all six metadata regressions fail and all 248 existing chat-thread controls pass. After: **410/410 tests pass, zero skipped**, across chat-thread, message normalization and tool-card rendering.
- Actual Chromium against freshly built Control UI, with synthetic Gateway data and the real sandbox HTTP owner: before, one Canvas-document card/request and no App request; after, one interactive MCP App/request and no Canvas-document request. Reload keeps exactly one App. The same scenario and exact final source bytes were used; all owned browser/context/server resources closed.
- All **20 canonical staged changed-file checks passed** (261.085s), including core-test/UI types, format, UI i18n, line/assertion ratchets, export scans and lint. Fresh current-base independent P0–P3 review was **scoped-clean** (93.589s). No hosted CI result is claimed yet.

## Before / after

Both captures are synthetic-only and have been inspected for unrelated or sensitive content. The before error is an intentional mocked missing-document response, not a claim about provider availability.

![Before: the App descriptor is lost and the Canvas-document renderer is selected](https://github.com/user-attachments/assets/c5c7c8d0-6604-4a64-bfc6-a1d4630bce3b)

![After: the canonical interactive MCP App renders once](https://github.com/user-attachments/assets/4676ac60-6138-4685-a51b-bc930a68f1dc)

## Scope and release-note context

Restore rich Canvas/MCP App previews when an assistant emits a matching shortcode, including dashboard widget identity and sandbox metadata. No new protocol, configuration, database, dependency or compatibility surface. Production is +49/-23 lines (net +26), needed to retain the owning history row across both result orderings while avoiding duplicate cards; tests add 56 lines in the existing suite. No changelog edit is included under the repository’s release-time convention.

## Final review disposition

Reviewed the latest ClawSweeper disposition. The +26 production lines retain the existing display-row owner so rich tool metadata can enrich either persisted ordering without another card; the canonical parser is shared rather than duplicated. All six metadata/order regressions, 410 owner tests, source-bound before/after Chromium proof and 20 local changed checks pass. Exact-head CI 33917323341 is now successful. No config, storage, protocol or sandbox policy change is introduced; proceed through the normal prepare/merge gates.
