### PR TITLE
test(qa): verify fallback receipts and visible acknowledgments

### DIFF
--- a/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
+++ b/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
@@ -53,6 +53,7 @@ scenario:
           expectedSendCount: 1
       restartMarker: QA-SUBAGENT-TERMINAL-RESTART-OK
       metadataSentinel: QA-SUBAGENT-TERMINAL-INTERNAL-MUST-NOT-LEAK
+      parentAcknowledgment: Worker started.
 
 flow:
   steps:
@@ -73,6 +74,9 @@ flow:
         - set: verdicts
           value:
             expr: "[]"
+        - set: directFallbackProofs
+          value:
+            expr: "[]"
         # The task ledger records terminal delivery after the subagent lifecycle
         # owner settles it. Use that fact instead of guessing with wall-clock sleeps.
         - set: readSettledTerminalTask
@@ -82,6 +86,15 @@ flow:
                 - caseName
               async: true
               expr: "(await env.gateway.call('tasks.list', { agentId: 'qa', limit: 100 }, { timeoutMs: 10000 })).tasks?.find((task) => task.title === `qa-terminal-${caseName}` && task.deliveryStatus === 'delivered')"
+        # The channel payload alone could also come from the completion model.
+        # Match the fallback owner's persisted mirror to this exact child run.
+        - set: readDirectFallbackReceipts
+          value:
+            lambda:
+              params:
+                - task
+              async: true
+              expr: "(await env.gateway.call('chat.history', { agentId: 'qa', sessionKey: task.sessionKey, limit: 100, maxChars: 20000 }, { timeoutMs: 10000 })).messages?.filter((message) => message.role === 'assistant' && message.provider === 'openclaw' && message.model === 'delivery-mirror' && message.__openclaw?.idempotencyKey === `announce:v1:${task.childSessionKey}:${task.runId}:text-direct`) ?? []"
         - forEach:
             items:
               expr: config.cases
@@ -112,7 +125,7 @@ flow:
                 args:
                   - lambda:
                       async: true
-                      expr: "(async () => { const task = await readSettledTerminalTask(terminalCase.name); if (!task) return undefined; const matchingCount = state.getSnapshot().messages.slice(startIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === conversationId && String(candidate.text ?? '').trim() === terminalCase.marker).length; return terminalCase.expectedSendCount === 0 || matchingCount >= terminalCase.expectedSendCount ? task : undefined; })().catch(() => undefined)"
+                      expr: "(async () => { const task = await readSettledTerminalTask(terminalCase.name); if (!task) return undefined; if (terminalCase.name !== 'silent' && (await readDirectFallbackReceipts(task)).length === 0) return undefined; const matchingCount = state.getSnapshot().messages.slice(startIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === conversationId && String(candidate.text ?? '').trim() === terminalCase.marker).length; return terminalCase.expectedSendCount === 0 || matchingCount >= terminalCase.expectedSendCount ? task : undefined; })().catch(() => undefined)"
                   - 60000
                   - 250
               - set: caseOutbound
@@ -124,6 +137,20 @@ flow:
               - set: caseRequests
                 value:
                   expr: "env.mock ? await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursor}`) : []"
+              - set: directFallbackReceipts
+                value:
+                  expr: "await readDirectFallbackReceipts(terminalTask)"
+              - assert:
+                  expr: "terminalCase.name === 'silent' || (directFallbackReceipts.length === 1 && directFallbackReceipts[0].content.filter((block) => block.type === 'text').map((block) => block.text).join('') === terminalCase.marker)"
+                  message:
+                    expr: "`terminal ${terminalCase.name}: missing or duplicate direct-fallback receipt: ${JSON.stringify(directFallbackReceipts)}`"
+              - assert:
+                  expr: "caseOutbound.filter((message) => !message.deleted && String(message.text ?? '').trim() === config.parentAcknowledgment).length === 1"
+                  message:
+                    expr: "`terminal ${terminalCase.name}: spawning parent did not acknowledge its completed turn`"
+              - set: appendDirectFallbackProof
+                value:
+                  expr: "directFallbackProofs.push({ case: terminalCase.name, taskId: terminalTask.taskId, receiptKeys: directFallbackReceipts.map((message) => message.__openclaw.idempotencyKey) })"
               - assert:
                   expr: "matchingOutbound.length === terminalCase.expectedSendCount"
                   message:
@@ -205,12 +232,22 @@ flow:
           args:
             - lambda:
                 async: true
-                expr: "(async () => { const task = await readSettledTerminalTask('restart'); if (!task) return undefined; const delivered = state.getSnapshot().messages.slice(restartStartIndex).some((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === restartConversationId && String(candidate.text ?? '').trim() === config.restartMarker); return delivered ? task : undefined; })().catch(() => undefined)"
+                expr: "(async () => { const task = await readSettledTerminalTask('restart'); if (!task || (await readDirectFallbackReceipts(task)).length === 0) return undefined; const delivered = state.getSnapshot().messages.slice(restartStartIndex).some((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === restartConversationId && String(candidate.text ?? '').trim() === config.restartMarker); return delivered ? task : undefined; })().catch(() => undefined)"
             - 60000
             - 250
         - set: restartMatches
           value:
             expr: "state.getSnapshot().messages.slice(restartStartIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === restartConversationId && String(candidate.text ?? '').trim() === config.restartMarker)"
+        - set: restartFallbackReceipts
+          value:
+            expr: "await readDirectFallbackReceipts(restartTask)"
+        - assert:
+            expr: "restartFallbackReceipts.length === 1 && restartFallbackReceipts[0].content.filter((block) => block.type === 'text').map((block) => block.text).join('') === config.restartMarker"
+            message:
+              expr: "`restart completion did not use its exact direct-fallback owner: ${JSON.stringify(restartFallbackReceipts)}`"
+        - set: appendRestartFallbackProof
+          value:
+            expr: "directFallbackProofs.push({ case: 'restart', taskId: restartTask.taskId, receiptKeys: restartFallbackReceipts.map((message) => message.__openclaw.idempotencyKey) })"
         - assert:
             expr: "restartMatches.length === 1"
             message:
@@ -249,4 +286,4 @@ flow:
             expr: "verdicts.length === 4 && verdicts.every((verdict) => verdict.pass === true)"
             message:
               expr: "`terminal reply verdict matrix incomplete: ${JSON.stringify(verdicts)}`"
-      detailsExpr: "JSON.stringify({ harness: 'qa-channel + qa-lab bus + ephemeral Gateway child + mock-openai', verdicts }, null, 2)"
+      detailsExpr: "JSON.stringify({ harness: 'qa-channel + qa-lab bus + ephemeral Gateway child + mock-openai', verdicts, directFallbackProofs }, null, 2)"

--- a/qa/scenarios/agents/subagent-empty-completion-non-delivery.yaml
+++ b/qa/scenarios/agents/subagent-empty-completion-non-delivery.yaml
@@ -98,7 +98,7 @@ flow:
           saveAs: requesterAcknowledgements
           args:
             - lambda:
-                expr: "(() => { const messages = state.getSnapshot().messages.slice(startIndex).filter((message) => message.direction === 'outbound' && message.conversation.id === conversationId && String(message.text ?? '').trim() === 'QA-SUBAGENT-EMPTY-PARENT-ACK'); return messages.length > 0 ? messages : undefined; })()"
+                expr: "(() => { const messages = state.getSnapshot().messages.slice(startIndex).filter((message) => message.direction === 'outbound' && !message.deleted && message.conversation.id === conversationId && String(message.text ?? '').trim() === 'QA-SUBAGENT-EMPTY-PARENT-ACK'); return messages.length > 0 ? messages : undefined; })()"
             - 60000
             - 250
         - set: emptyOutboundHistory


### PR DESCRIPTION
## What this fixes

The empty-completion QA scenario counted a deleted preview and its durable final as two acknowledgments. The QA channel correctly records both historical rows, but only one remains visible. This scenario now counts live rows while preserving the history-wide silence and metadata checks.

The direct-fallback scenario also verifies the actual delivery owner: its public chat history must contain exactly one matching child/run `:text-direct` mirror with the expected terminal text, including after restart. Matching channel text alone could have come from the completion model instead.

This builds on #137342’s already-landed parent acknowledgment fix by Ayaan Zaidi. That canonical mock behavior stays byte-identical; it is not reimplemented here. Only two YAML files change (+41/−4); no production, configuration, schema, storage, dependency or timeout changes.

## Verification

On pinned main b1164348d55ca3bc221544daa86a908b70c100c6, the original unmodified four-case scenario first passed with the canonical acknowledgment. With this patch, both the Telegram-profile and QA-channel four-case flows pass, each with three exact direct-fallback receipts. The empty-completion/restart flow has one live acknowledgment, no terminal send and no post-restart completion request. The original empty scenario failure was independently reproduced; its observed state contained one deleted preview and one live final.

These are real ephemeral Gateway flows with mocked provider and channel transports. The Telegram profile uses Crabline, not credentialed Telegram Test Server traffic. **718/718 owner/catalog tests pass**, with zero failures/skips. Formatting, scoped diff checks and fresh independent P0–P3 review pass. All source/dependency originals remain unchanged after testing, and all owned processes ended.

The generic YAML classifier selects a 25-stage all-lanes fallback. This bounded test-only change instead ran the owning real mock-Gateway flows, six complete owner/catalog test files, formatting and independent review. Those focused results are not represented as the full fallback or hosted CI; exact-head CI remains required for landing. Initial setup failures and historical proof are retained rather than relabeled as passes.

## Release-note context

QA-only repair. Preserve terminal delivery owner evidence and count the visible acknowledgment rather than deleted preview history. No user-facing runtime change or release-time changelog edit.

## Final review disposition

The latest ClawSweeper review has no code/security findings. Exact-head CI 33917943092 is now successful. The data-model flag is a false positive on QA YAML: only two test scenarios change; they read the existing public task/transcript receipt and count non-deleted acknowledgment rows. No production schema, storage, serialized runtime state, migration, config or dependency changes are introduced. The retained proof includes both four-case mock-channel flows, empty/restart coverage and 718 owner/catalog tests. Proceed through the normal prepare/merge gates.
