### PR TITLE
perf(agents): skip impossible tool image prefixes

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-char-estimator.ts
+++ b/src/agents/embedded-agent-runner/tool-result-char-estimator.ts
@@ -13,6 +13,7 @@ import { estimateToolResultTextChars } from "./tool-result-text-budget.js";
 
 export const TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE = 2;
 const IMAGE_CHAR_ESTIMATE = 8_000;
+export const TOOL_IMAGE_CHARS = IMAGE_CHAR_ESTIMATE * TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE;
 
 export type MessageCharEstimateCache = WeakMap<AgentMessage, number>;
 
@@ -85,7 +86,7 @@ function estimateToolResultContentChars(content: unknown[]): number {
         minimumRawWeight: TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE,
       });
     } else if (isImageBlock(block)) {
-      chars += IMAGE_CHAR_ESTIMATE * TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE;
+      chars += TOOL_IMAGE_CHARS;
     } else {
       chars += estimateUnknownChars(block) * TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE;
     }

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.image.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.image.test.ts
@@ -98,7 +98,7 @@ describe("native image tool result context projection", () => {
   it.each([
     { contextWindowTokens: 8_000, loadedImages: 1, visibleImages: 0 },
     { contextWindowTokens: 32_000, loadedImages: 3, visibleImages: 1 },
-    { contextWindowTokens: 128_000, loadedImages: 9, visibleImages: 7 },
+    { contextWindowTokens: 128_000, loadedImages: 20, visibleImages: 7 },
   ])(
     "preserves a fitting sanitized image prefix in a $contextWindowTokens-token window",
     async ({ contextWindowTokens, loadedImages, visibleImages }) => {

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -17,6 +17,7 @@ import {
   type CompactionReplayPressureContext,
 } from "./run/preemptive-compaction.js";
 import {
+  TOOL_IMAGE_CHARS,
   TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE,
   type MessageCharEstimateCache,
   createMessageCharEstimateCache,
@@ -205,9 +206,10 @@ function truncateToolResultToChars(
       ]);
     };
 
-    // Reserve non-text content first. The shared allocator keeps diagnostic tails
-    // and short text blocks within the same weighted cap, with or without images.
-    for (let retainedImages = imageCount; retainedImages >= 0; retainedImages -= 1) {
+    // Image cost alone rules out larger prefixes. The allocator still reserves
+    // other non-text content and preserves diagnostic tails and short text blocks.
+    const maxRetainedImages = Math.min(imageCount, Math.floor(maxChars / TOOL_IMAGE_CHARS));
+    for (let retainedImages = maxRetainedImages; retainedImages >= 0; retainedImages -= 1) {
       let seenImages = 0;
       const retainedContent = content.filter(
         (block) => !isImage(block) || ++seenImages <= retainedImages,


### PR DESCRIPTION
## What Problem This Solves

When an image tool result exceeded the context limit, its guard repeatedly built projections that could never fit. For a default 20-image result in a 128,000-token context, it tried keeping 20 images, then 19, and so on before reaching the same seven-image result.

## Why This Change Was Made

Reuse the estimator's existing 16,000-unit tool-image cost to rule out impossible counts before projection. The existing descending search still decides the exact fit, including text, other blocks, and omission notices, so it retains the same largest fitting image prefix.

## User Impact

Image-heavy tool results do less temporary projection work while preserving image order, visible text, omission notices, and private-detail handling. Production LOC: +7/-4 (net +3); tests: +1/-1 (net 0). The three added production lines name and reuse the estimator's existing invariant instead of introducing a second budget policy or projection path.

## Evidence

A before/after probe installed the actual context guard and called its transform boundary. In the default 20-image case, original-content filtering fell from 15 calls to 3, including the initial image count. Attempted image prefixes fell from 14 to 2. Both versions kept exactly seven images with the same result digest and estimated cost.

All 13 functional and stress cases preserved output digests and original input, covering 8k/32k/128k contexts, ASCII/CJK text, diagnostic tails, unknown blocks, fitting images, and larger image batches. These are observed operation counts, not exact heap or whole-Gateway savings; concurrent timing/RSS samples are diagnostic only.

91 tests passed, including an existing native-image case expanded to the actual default batch of 20. It creates real synthetic PNG images, calls the native image tool, sanitizes them to JPEG, and applies the context guard without an external provider.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/agents/embedded-agent-runner/tool-result-context-guard.image.test.ts \
  src/agents/embedded-agent-runner/tool-result-context-guard.test.ts \
  src/agents/embedded-agent-runner/tool-result-char-estimator.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/check-changed.mjs -- \
  src/agents/embedded-agent-runner/tool-result-char-estimator.ts \
  src/agents/embedded-agent-runner/tool-result-context-guard.ts \
  src/agents/embedded-agent-runner/tool-result-context-guard.image.test.ts
```

Formatting and the complete canonical changed-file gate passed. Independent managed Codex review through P2 returned no actionable findings. The existing image test was strengthened without adding a duplicate permanent counter test or production test seam.

## Measured 20-image transform benchmark

The additional measurements below supply the elapsed-time and RSS evidence requested in the [ClawSweeper review](https://github.com/openclaw/openclaw/pull/138601#issuecomment-5546355989), including its repeated merge-risk/next-step request and sole Rank-up move. The earlier concurrent observations remain diagnostic; this comparison ran separately with other task workloads paused.

Before source: `8f0facca5e0bc990b2949a73afea69e7cc2a19f4`. After source: the reviewed PR head, `046ece3247ab99c783cc7d22e6b9fcf1e217d745`. Runtime: Node 26.8.1 on macOS arm64. Both arms used the same frozen dependency installation.

Preparation called the actual native image tool independently in each arm with twenty distinct synthetic 64×64 PNGs, native vision enabled, and `imageMaxDimensionPx: 32`. It used the default 20-image limit without a `maxImages` override. The real sanitizer produced twenty 32×32 JPEGs in each arm. All PNG bytes, JPEG bytes, and complete native-result bytes matched across arms. Preparation was outside the timed processes.

Each fresh measurement process loaded the same frozen native-result JSON, installed the actual context guard with a 128,000-token context, warmed it for 100 calls, then awaited 10,000 actual `agent.transformContext([source], signal)` calls. Three serial pairs ran in AB/BA/AB order. Two explicit GCs occurred before timing and again after result validation; imports, warmup, image conversion, hashes, file access, counter instrumentation, and explicit GC were outside the timed loop. No provider request, model turn, or Gateway was involved.

The median elapsed time for 10,000 transforms fell from **0.655757916 s to 0.098204334 s (85.02%)**. Median process CPU for that loop fell from **0.770372 s to 0.138603 s (82.01%)**. Median lifetime process peak RSS was **516,336 KiB before and 515,152 KiB after**, a difference of −1,184 KiB (−1.15625 MiB): essentially stable, with the peak dominated by imports and warmup. The timing/CPU improvement is specific to this repeated owner-level workload; these three pairs do not establish statistical significance or natural model-turn latency. No retained-memory or whole-Gateway memory saving is inferred.

All six raw runs are shown in execution order. Elapsed seconds are rounded to nine decimal places; CPU values are seconds for the timed loop. Peak RSS is the Node process's lifetime high-water mark, including imports, warmup, validation, GC, and its threads; it excludes the separate fixture-preparation process and esbuild child.

| Run | Arm | Elapsed s / 10,000 | User CPU s | System CPU s | Total CPU s | Lifetime peak RSS KiB |
|---|---|---:|---:|---:|---:|---:|
| 1 | before | 0.655757916 | 0.759709 | 0.010663 | 0.770372 | 514,032 |
| 2 | after | 0.098204334 | 0.136611 | 0.001992 | 0.138603 | 515,952 |
| 3 | after | 0.096717833 | 0.135442 | 0.001911 | 0.137353 | 515,152 |
| 4 | before | 0.694858916 | 0.807441 | 0.014554 | 0.821995 | 517,264 |
| 5 | before | 0.646469166 | 0.751343 | 0.009667 | 0.761010 | 516,336 |
| 6 | after | 0.098815333 | 0.138250 | 0.001197 | 0.139447 | 514,496 |

<details>
<summary>Raw process RSS snapshots and high-water marks</summary>

RSS snapshots are process-wide bytes. High-water values are KiB. They are neither per-transform allocations nor retained-heap measurements. The nearly identical pre-loop and final high-water values show why this run does not support a material RSS-benefit claim.

| Run | Arm | RSS before loop B | RSS after loop B | RSS after validation + GC B | Peak before loop KiB | Peak through loop KiB | Final peak KiB |
|---|---|---:|---:|---:|---:|---:|---:|
| 1 | before | 524,779,520 | 526,155,776 | 526,286,848 | 513,600 | 513,824 | 514,032 |
| 2 | after | 527,466,496 | 527,630,336 | 527,679,488 | 515,952 | 515,952 | 515,952 |
| 3 | after | 526,450,688 | 526,483,456 | 526,516,224 | 515,152 | 515,152 | 515,152 |
| 4 | before | 529,104,896 | 529,645,568 | 529,678,336 | 517,200 | 517,232 | 517,264 |
| 5 | before | 527,532,032 | 528,662,528 | 528,728,064 | 515,840 | 516,272 | 516,336 |
| 6 | after | 525,975,552 | 526,073,856 | 526,319,616 | 514,496 | 514,496 | 514,496 |

</details>

Every measured run kept the exact first seven images, reported thirteen omissions, removed private details from the projection, left the source unchanged, and produced the same complete output bytes. The estimated result cost was 112,324 against the existing 128,000-unit cap. Source JSON file SHA-256: `35b55fbccab96dc1aa54686d4ee2f9d3a1c688eaf3cf3879cd45e9bd4755e3a4`. Projected JSON file SHA-256 in all six runs: `b7eb0b140e128acddd7b362549f7b2644f7dac1ed2b4c744d04b684540ee406c`. All eight preparation/measurement commands exited zero, were joined, and left no owned process groups. A separate artifact check verified all sixteen output captures, eighty PNG/JPEG files, and six projections.

The sealed local evidence pins 27,294 source/input entries and 1,011 dependency/artifact entries, including 406 shared compiled workspace files. This is a source-owner microbenchmark using shared frozen dependencies, rather than two independently built installations. Six generated plugin assets differed between the built baseline and author checkout: the canvas A2UI hash and two bundles, the two diffs viewer-runtime bundles, and the Discord embedded SDK bundle. Their identities were recorded per arm; they are outside the timed guard path. Source, dependency, and artifact identities were checked around the run. This scope does not assert whole-installation equivalence.

Retained report SHA-256: `a8800752e4dd5a5fde3b2967d4edef052d8645238be3c8e7c61981605fc9df18`. Sealed preparation SHA-256: `3aa0c09316d97260f554e0c849a6a6dd7baf32f09af7a8d70175f2ec3453a09f`. Source-manifest SHA-256: `28221d9196db13782ee1a5f1709914d756afcbf006285a5596fcc25db02e0948`. The benchmark adds evidence only; the source, 91-test result, canonical gate, and independent review described above remain unchanged.
