### PR TITLE
feat: navigate long chats with a previewable position rail

### DIFF
--- a/ui/src/e2e/chat-position-rail.e2e.test.ts
+++ b/ui/src/e2e/chat-position-rail.e2e.test.ts
@@ -1,0 +1,154 @@
+import { expect, it } from "vitest";
+import {
+  captureUiProof,
+  captureUiProofEnabled,
+  createChatFlowE2eSuite,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+
+suite.define(() => {
+  it("tracks reader position with a restrained, keyboard-navigable rail", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+        ...(captureUiProofEnabled
+          ? { recordVideo: { dir: suite.artifactDir, size: { height: 900, width: 1440 } } }
+          : {}),
+      },
+      async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => pageErrors.push(error.message));
+        const messages = Array.from({ length: 72 }, (_, index) => ({
+          __openclaw: { id: `position-rail-${index}`, seq: index + 1 },
+          content: [{ text: `Transcript checkpoint ${index}`, type: "text" }],
+          role: index % 2 === 0 ? "user" : "assistant",
+          timestamp: Date.UTC(2026, 8, 4, 12, index),
+        }));
+        await installMockGateway(page, { historyMessages: messages });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const transcript = page.locator(".chat-thread");
+        await transcript
+          .locator(".chat-virtual-row")
+          .getByText("Transcript checkpoint 71", { exact: true })
+          .waitFor();
+
+        const rail = page.locator(".chat-position-rail");
+        const markers = rail.locator(".chat-position-rail__marker");
+        const preview = rail.locator(".chat-position-rail__preview-copy");
+        await markers.first().waitFor();
+        await expect.poll(() => markers.count()).toBe(10);
+        expect(await preview.count()).toBe(0);
+        expect(await rail.locator('[role="status"]').count()).toBe(0);
+        await captureUiProof(suite, page, "chat-position-rail", "idle.png");
+
+        const currentMarkerIndex = () =>
+          markers.evaluateAll((items) =>
+            items.findIndex((item) => item.getAttribute("aria-current") === "true"),
+          );
+        await transcript.evaluate((element) => {
+          element.scrollTop = element.scrollHeight;
+        });
+        await expect.poll(currentMarkerIndex).toBe(9);
+        await transcript.evaluate((element) => {
+          element.scrollTop = Math.round((element.scrollHeight - element.clientHeight) / 2);
+        });
+        await expect.poll(currentMarkerIndex).toBeGreaterThan(0);
+        await expect.poll(currentMarkerIndex).toBeLessThan(9);
+        await transcript.evaluate((element) => {
+          element.scrollTop = 0;
+        });
+        await expect.poll(currentMarkerIndex).toBe(0);
+
+        await markers.nth(4).hover();
+        await expect.poll(() => preview.textContent()).toContain("Transcript checkpoint 32");
+        await expect
+          .poll(() =>
+            markers
+              .nth(4)
+              .evaluate((marker) =>
+                Number.parseFloat(
+                  getComputedStyle(marker.querySelector(".chat-position-rail__tick")!).width,
+                ),
+              ),
+          )
+          .toBeGreaterThan(8);
+        const hoveredAppearance = await markers.nth(4).evaluate((marker) => {
+          const markerStyle = getComputedStyle(marker.querySelector(".chat-position-rail__dot")!);
+          const tickStyle = getComputedStyle(marker.querySelector(".chat-position-rail__tick")!);
+          return {
+            background: markerStyle.backgroundColor,
+            opacity: markerStyle.opacity,
+            ring: markerStyle.boxShadow,
+            tickWidth: Number.parseFloat(tickStyle.width),
+            targetWidth: marker.getBoundingClientRect().width,
+            targetHeight: marker.getBoundingClientRect().height,
+          };
+        });
+        expect(hoveredAppearance.opacity).toBe("1");
+        expect(hoveredAppearance.background).not.toBe("rgba(0, 0, 0, 0)");
+        expect(hoveredAppearance.ring).not.toBe("none");
+        expect(hoveredAppearance.tickWidth).toBeGreaterThan(8);
+        expect(hoveredAppearance.targetWidth).toBeGreaterThanOrEqual(24);
+        expect(hoveredAppearance.targetHeight).toBeGreaterThanOrEqual(24);
+        await captureUiProof(suite, page, "chat-position-rail", "scroll-follow-hover.png");
+
+        await page.mouse.move(600, 100);
+        await expect.poll(() => preview.count()).toBe(0);
+        await markers.nth(5).focus();
+        await expect.poll(() => preview.textContent()).toContain("Transcript checkpoint 39");
+        await markers.nth(5).press("ArrowDown");
+        await expect
+          .poll(() =>
+            page.evaluate(
+              () => document.activeElement?.getAttribute("data-position-marker-id") ?? null,
+            ),
+          )
+          .toBe("position-rail-47");
+        await expect.poll(() => preview.textContent()).toContain("Transcript checkpoint 47");
+        await markers.nth(6).press("Enter");
+        const revealed = transcript.locator('.chat-bubble[data-entry-id="position-rail-47"]');
+        await expect
+          .poll(() =>
+            revealed.evaluate((element) => {
+              const viewport = element.closest(".chat-thread")!.getBoundingClientRect();
+              const bubble = element.getBoundingClientRect();
+              return bubble.top >= viewport.top && bubble.bottom <= viewport.bottom;
+            }),
+          )
+          .toBe(true);
+        await captureUiProof(suite, page, "chat-position-rail", "keyboard-jump.png");
+        await markers.nth(6).press("Escape");
+        await expect.poll(() => preview.count()).toBe(0);
+        await markers.nth(6).press("Home");
+        await expect
+          .poll(() => markers.first().evaluate((element) => element === document.activeElement))
+          .toBe(true);
+        await markers.first().press(" ");
+        await expect.poll(currentMarkerIndex).toBe(0);
+        await markers.first().press("End");
+        await markers.last().press("Enter");
+        await expect.poll(currentMarkerIndex).toBe(9);
+
+        // Pane-local width matters even inside an otherwise wide desktop.
+        await transcript.evaluate((element) => {
+          element.style.width = "800px";
+        });
+        await markers.first().waitFor({ state: "hidden" });
+        await transcript.evaluate((element) => {
+          element.style.removeProperty("width");
+        });
+        await markers.first().waitFor({ state: "visible" });
+
+        await page.setViewportSize({ height: 900, width: 1100 });
+        await markers.first().waitFor({ state: "hidden" });
+        await captureUiProof(suite, page, "chat-position-rail", "narrow-pane.png");
+        expect(pageErrors).toEqual([]);
+      },
+    );
+  });
+});

--- a/ui/src/e2e/chat-position-rail.e2e.test.ts
+++ b/ui/src/e2e/chat-position-rail.e2e.test.ts
@@ -1,4 +1,6 @@
 import { expect, it } from "vitest";
+import { SIDEBAR_GEOMETRY_COMMIT_EVENT } from "../pages/chat/sidebar-layout.ts";
+import { controlUiBundledSettingsStorageKey } from "../test-helpers/control-ui-e2e.ts";
 import {
   captureUiProof,
   captureUiProofEnabled,
@@ -180,6 +182,63 @@ suite.define(() => {
                 Number.parseFloat(getComputedStyle(element).transitionDuration),
               ),
           ).toBeLessThanOrEqual(0.00001); // Global reduced-motion policy uses 0.01ms.
+
+          // Saved widths can consume the gutter even in a wide desktop pane.
+          for (const width of ["100%", "none", "95%", "48rem"]) {
+            await page.goto(`${suite.server.baseUrl}settings/appearance#settings-appearance-chat`);
+            const widthInput = page.locator("[data-settings-chat-message-width]");
+            await widthInput.fill(width);
+            await widthInput.press("Tab");
+            await expect
+              .poll(() =>
+                page.evaluate(
+                  (key) => JSON.parse(localStorage.getItem(key) ?? "{}").chatMessageMaxWidth,
+                  controlUiBundledSettingsStorageKey(suite.server.baseUrl),
+                ),
+              )
+              .toBe(width);
+            await page.goto(`${suite.server.baseUrl}chat`);
+            await transcript.locator(".chat-virtual-row").first().waitFor();
+            await expect
+              .poll(() =>
+                transcript.evaluate((element) =>
+                  getComputedStyle(element).getPropertyValue("--chat-thread-max-width").trim(),
+                ),
+              )
+              .toBe(width);
+            await markers.first().waitFor({ state: width === "48rem" ? "visible" : "hidden" });
+            if (width === "48rem") {
+              const inner = await transcript.locator(".chat-thread-inner").boundingBox();
+              const marker = await markers.first().boundingBox();
+              expect(marker!.x - (inner!.x + inner!.width)).toBeGreaterThanOrEqual(8);
+            }
+            await captureUiProof(
+              suite,
+              page,
+              "chat-position-rail",
+              `saved-width-${width.replace("%", "percent")}.png`,
+            );
+          }
+          // A foreign-host commit can change the inner column while the pane's
+          // own dimensions stay fixed. Exercise that existing event boundary.
+          for (const width of ["95%", "48rem"]) {
+            await transcript.evaluate(
+              (element, { columnWidth, eventName }) => {
+                element.style.setProperty("--chat-thread-max-width", columnWidth);
+                element.dispatchEvent(
+                  new CustomEvent(eventName, {
+                    bubbles: true,
+                    detail: { widthChanged: false },
+                  }),
+                );
+              },
+              { columnWidth: width, eventName: SIDEBAR_GEOMETRY_COMMIT_EVENT },
+            );
+            await markers.first().waitFor({ state: width === "48rem" ? "visible" : "hidden" });
+          }
+          await transcript.evaluate((element) =>
+            element.style.removeProperty("--chat-thread-max-width"),
+          );
           expect(pageErrors).toEqual([]);
         },
       );

--- a/ui/src/e2e/chat-position-rail.e2e.test.ts
+++ b/ui/src/e2e/chat-position-rail.e2e.test.ts
@@ -66,6 +66,8 @@ suite.define(() => {
           });
           await expect.poll(currentMarkerIndex).toBe(0);
 
+          const composer = page.locator(".agent-chat__composer-combobox textarea");
+          await composer.focus();
           await markers.nth(4).hover();
           await expect.poll(() => preview.textContent()).toContain("Transcript checkpoint 32");
           await expect
@@ -99,6 +101,24 @@ suite.define(() => {
           expect(hoveredAppearance.targetHeight).toBeGreaterThanOrEqual(24);
           await captureUiProof(suite, page, "chat-position-rail", "scroll-follow-hover.png");
 
+          const previewBounds = await preview.boundingBox();
+          expect(previewBounds).not.toBeNull();
+          await page.mouse.move(
+            previewBounds!.x + previewBounds!.width / 2,
+            previewBounds!.y + previewBounds!.height / 2,
+            { steps: 20 },
+          );
+          expect(await preview.textContent()).toContain("Transcript checkpoint 32");
+          await captureUiProof(suite, page, "chat-position-rail", "hover-reading.png");
+          await page.keyboard.press("Escape");
+          await expect.poll(() => preview.count()).toBe(0);
+          expect(await composer.evaluate((element) => element === document.activeElement)).toBe(
+            true,
+          );
+
+          await page.mouse.move(600, 100);
+          await markers.nth(4).hover();
+          await expect.poll(() => preview.textContent()).toContain("Transcript checkpoint 32");
           await page.mouse.move(600, 100);
           await expect.poll(() => preview.count()).toBe(0);
           await markers.nth(5).focus();

--- a/ui/src/e2e/chat-position-rail.e2e.test.ts
+++ b/ui/src/e2e/chat-position-rail.e2e.test.ts
@@ -9,146 +9,160 @@ import {
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
-  it("tracks reader position with a restrained, keyboard-navigable rail", async () => {
-    await suite.withPage(
-      {
-        colorScheme: "dark",
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1440 },
-        ...(captureUiProofEnabled
-          ? { recordVideo: { dir: suite.artifactDir, size: { height: 900, width: 1440 } } }
-          : {}),
-      },
-      async ({ page }) => {
-        const pageErrors: string[] = [];
-        page.on("pageerror", (error) => pageErrors.push(error.message));
-        const messages = Array.from({ length: 72 }, (_, index) => ({
-          __openclaw: { id: `position-rail-${index}`, seq: index + 1 },
-          content: [{ text: `Transcript checkpoint ${index}`, type: "text" }],
-          role: index % 2 === 0 ? "user" : "assistant",
-          timestamp: Date.UTC(2026, 8, 4, 12, index),
-        }));
-        await installMockGateway(page, { historyMessages: messages });
-        await page.goto(`${suite.server.baseUrl}chat`);
-        const transcript = page.locator(".chat-thread");
-        await transcript
-          .locator(".chat-virtual-row")
-          .getByText("Transcript checkpoint 71", { exact: true })
-          .waitFor();
+  it.each(["dark", "light"] as const)(
+    "tracks reader position and keyboard jumps in %s mode",
+    async (colorScheme) => {
+      await suite.withPage(
+        {
+          colorScheme,
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 900, width: 1440 },
+          ...(captureUiProofEnabled
+            ? { recordVideo: { dir: suite.artifactDir, size: { height: 900, width: 1440 } } }
+            : {}),
+        },
+        async ({ page }) => {
+          const pageErrors: string[] = [];
+          page.on("pageerror", (error) => pageErrors.push(error.message));
+          const messages = Array.from({ length: 72 }, (_, index) => ({
+            __openclaw: { id: `position-rail-${index}`, seq: index + 1 },
+            content: [{ text: `Transcript checkpoint ${index}`, type: "text" }],
+            role: index % 2 === 0 ? "user" : "assistant",
+            timestamp: Date.UTC(2026, 8, 4, 12, index),
+          }));
+          await installMockGateway(page, { historyMessages: messages });
+          await page.goto(`${suite.server.baseUrl}chat`);
+          const transcript = page.locator(".chat-thread");
+          await transcript
+            .locator(".chat-virtual-row")
+            .getByText("Transcript checkpoint 71", { exact: true })
+            .waitFor();
 
-        const rail = page.locator(".chat-position-rail");
-        const markers = rail.locator(".chat-position-rail__marker");
-        const preview = rail.locator(".chat-position-rail__preview-copy");
-        await markers.first().waitFor();
-        await expect.poll(() => markers.count()).toBe(10);
-        expect(await preview.count()).toBe(0);
-        expect(await rail.locator('[role="status"]').count()).toBe(0);
-        await captureUiProof(suite, page, "chat-position-rail", "idle.png");
+          const rail = page.locator(".chat-position-rail");
+          const markers = rail.locator(".chat-position-rail__marker");
+          const preview = rail.locator(".chat-position-rail__preview-copy");
+          await markers.first().waitFor();
+          await expect.poll(() => markers.count()).toBe(10);
+          expect(await preview.count()).toBe(0);
+          expect(await rail.locator('[role="status"]').count()).toBe(0);
+          await captureUiProof(suite, page, "chat-position-rail", "idle.png");
 
-        const currentMarkerIndex = () =>
-          markers.evaluateAll((items) =>
-            items.findIndex((item) => item.getAttribute("aria-current") === "true"),
-          );
-        await transcript.evaluate((element) => {
-          element.scrollTop = element.scrollHeight;
-        });
-        await expect.poll(currentMarkerIndex).toBe(9);
-        await transcript.evaluate((element) => {
-          element.scrollTop = Math.round((element.scrollHeight - element.clientHeight) / 2);
-        });
-        await expect.poll(currentMarkerIndex).toBeGreaterThan(0);
-        await expect.poll(currentMarkerIndex).toBeLessThan(9);
-        await transcript.evaluate((element) => {
-          element.scrollTop = 0;
-        });
-        await expect.poll(currentMarkerIndex).toBe(0);
+          const currentMarkerIndex = () =>
+            markers.evaluateAll((items) =>
+              items.findIndex((item) => item.getAttribute("aria-current") === "true"),
+            );
+          await transcript.evaluate((element) => {
+            element.scrollTop = element.scrollHeight;
+          });
+          await expect.poll(currentMarkerIndex).toBe(9);
+          await transcript.evaluate((element) => {
+            element.scrollTop = Math.round((element.scrollHeight - element.clientHeight) / 2);
+          });
+          await expect.poll(currentMarkerIndex).toBeGreaterThan(0);
+          await expect.poll(currentMarkerIndex).toBeLessThan(9);
+          await transcript.evaluate((element) => {
+            element.scrollTop = 0;
+          });
+          await expect.poll(currentMarkerIndex).toBe(0);
 
-        await markers.nth(4).hover();
-        await expect.poll(() => preview.textContent()).toContain("Transcript checkpoint 32");
-        await expect
-          .poll(() =>
-            markers
-              .nth(4)
-              .evaluate((marker) =>
-                Number.parseFloat(
-                  getComputedStyle(marker.querySelector(".chat-position-rail__tick")!).width,
+          await markers.nth(4).hover();
+          await expect.poll(() => preview.textContent()).toContain("Transcript checkpoint 32");
+          await expect
+            .poll(() =>
+              markers
+                .nth(4)
+                .evaluate((marker) =>
+                  Number.parseFloat(
+                    getComputedStyle(marker.querySelector(".chat-position-rail__tick")!).width,
+                  ),
                 ),
+            )
+            .toBeGreaterThan(8);
+          const hoveredAppearance = await markers.nth(4).evaluate((marker) => {
+            const markerStyle = getComputedStyle(marker.querySelector(".chat-position-rail__dot")!);
+            const tickStyle = getComputedStyle(marker.querySelector(".chat-position-rail__tick")!);
+            return {
+              background: markerStyle.backgroundColor,
+              opacity: markerStyle.opacity,
+              ring: markerStyle.boxShadow,
+              tickWidth: Number.parseFloat(tickStyle.width),
+              targetWidth: marker.getBoundingClientRect().width,
+              targetHeight: marker.getBoundingClientRect().height,
+            };
+          });
+          expect(hoveredAppearance.opacity).toBe("1");
+          expect(hoveredAppearance.background).not.toBe("rgba(0, 0, 0, 0)");
+          expect(hoveredAppearance.ring).not.toBe("none");
+          expect(hoveredAppearance.tickWidth).toBeGreaterThan(8);
+          expect(hoveredAppearance.targetWidth).toBeGreaterThanOrEqual(24);
+          expect(hoveredAppearance.targetHeight).toBeGreaterThanOrEqual(24);
+          await captureUiProof(suite, page, "chat-position-rail", "scroll-follow-hover.png");
+
+          await page.mouse.move(600, 100);
+          await expect.poll(() => preview.count()).toBe(0);
+          await markers.nth(5).focus();
+          await expect.poll(() => preview.textContent()).toContain("Transcript checkpoint 39");
+          await markers.nth(5).press("ArrowDown");
+          await expect
+            .poll(() =>
+              page.evaluate(
+                () => document.activeElement?.getAttribute("data-position-marker-id") ?? null,
               ),
-          )
-          .toBeGreaterThan(8);
-        const hoveredAppearance = await markers.nth(4).evaluate((marker) => {
-          const markerStyle = getComputedStyle(marker.querySelector(".chat-position-rail__dot")!);
-          const tickStyle = getComputedStyle(marker.querySelector(".chat-position-rail__tick")!);
-          return {
-            background: markerStyle.backgroundColor,
-            opacity: markerStyle.opacity,
-            ring: markerStyle.boxShadow,
-            tickWidth: Number.parseFloat(tickStyle.width),
-            targetWidth: marker.getBoundingClientRect().width,
-            targetHeight: marker.getBoundingClientRect().height,
-          };
-        });
-        expect(hoveredAppearance.opacity).toBe("1");
-        expect(hoveredAppearance.background).not.toBe("rgba(0, 0, 0, 0)");
-        expect(hoveredAppearance.ring).not.toBe("none");
-        expect(hoveredAppearance.tickWidth).toBeGreaterThan(8);
-        expect(hoveredAppearance.targetWidth).toBeGreaterThanOrEqual(24);
-        expect(hoveredAppearance.targetHeight).toBeGreaterThanOrEqual(24);
-        await captureUiProof(suite, page, "chat-position-rail", "scroll-follow-hover.png");
+            )
+            .toBe("position-rail-47");
+          await expect.poll(() => preview.textContent()).toContain("Transcript checkpoint 47");
+          await markers.nth(6).press("Enter");
+          const revealed = transcript.locator('.chat-bubble[data-entry-id="position-rail-47"]');
+          await expect
+            .poll(() =>
+              revealed.evaluate((element) => {
+                const viewport = element.closest(".chat-thread")!.getBoundingClientRect();
+                const bubble = element.getBoundingClientRect();
+                return bubble.top >= viewport.top && bubble.bottom <= viewport.bottom;
+              }),
+            )
+            .toBe(true);
+          await captureUiProof(suite, page, "chat-position-rail", "keyboard-jump.png");
+          await markers.nth(6).press("Escape");
+          await expect.poll(() => preview.count()).toBe(0);
+          await markers.nth(6).press("Home");
+          await expect
+            .poll(() => markers.first().evaluate((element) => element === document.activeElement))
+            .toBe(true);
+          await markers.first().press(" ");
+          await expect.poll(currentMarkerIndex).toBe(0);
+          await markers.first().press("End");
+          await markers.last().press("Enter");
+          await expect.poll(currentMarkerIndex).toBe(9);
 
-        await page.mouse.move(600, 100);
-        await expect.poll(() => preview.count()).toBe(0);
-        await markers.nth(5).focus();
-        await expect.poll(() => preview.textContent()).toContain("Transcript checkpoint 39");
-        await markers.nth(5).press("ArrowDown");
-        await expect
-          .poll(() =>
-            page.evaluate(
-              () => document.activeElement?.getAttribute("data-position-marker-id") ?? null,
-            ),
-          )
-          .toBe("position-rail-47");
-        await expect.poll(() => preview.textContent()).toContain("Transcript checkpoint 47");
-        await markers.nth(6).press("Enter");
-        const revealed = transcript.locator('.chat-bubble[data-entry-id="position-rail-47"]');
-        await expect
-          .poll(() =>
-            revealed.evaluate((element) => {
-              const viewport = element.closest(".chat-thread")!.getBoundingClientRect();
-              const bubble = element.getBoundingClientRect();
-              return bubble.top >= viewport.top && bubble.bottom <= viewport.bottom;
-            }),
-          )
-          .toBe(true);
-        await captureUiProof(suite, page, "chat-position-rail", "keyboard-jump.png");
-        await markers.nth(6).press("Escape");
-        await expect.poll(() => preview.count()).toBe(0);
-        await markers.nth(6).press("Home");
-        await expect
-          .poll(() => markers.first().evaluate((element) => element === document.activeElement))
-          .toBe(true);
-        await markers.first().press(" ");
-        await expect.poll(currentMarkerIndex).toBe(0);
-        await markers.first().press("End");
-        await markers.last().press("Enter");
-        await expect.poll(currentMarkerIndex).toBe(9);
+          // Pane-local width matters even inside an otherwise wide desktop.
+          await transcript.evaluate((element) => {
+            element.style.width = "800px";
+          });
+          await markers.first().waitFor({ state: "hidden" });
+          await transcript.evaluate((element) => {
+            element.style.removeProperty("width");
+          });
+          await markers.first().waitFor({ state: "visible" });
 
-        // Pane-local width matters even inside an otherwise wide desktop.
-        await transcript.evaluate((element) => {
-          element.style.width = "800px";
-        });
-        await markers.first().waitFor({ state: "hidden" });
-        await transcript.evaluate((element) => {
-          element.style.removeProperty("width");
-        });
-        await markers.first().waitFor({ state: "visible" });
-
-        await page.setViewportSize({ height: 900, width: 1100 });
-        await markers.first().waitFor({ state: "hidden" });
-        await captureUiProof(suite, page, "chat-position-rail", "narrow-pane.png");
-        expect(pageErrors).toEqual([]);
-      },
-    );
-  });
+          await page.setViewportSize({ height: 900, width: 900 });
+          await markers.first().waitFor({ state: "hidden" });
+          await captureUiProof(suite, page, "chat-position-rail", "narrow-pane.png");
+          await page.setViewportSize({ height: 900, width: 1440 });
+          await markers.first().waitFor({ state: "visible" });
+          await page.emulateMedia({ reducedMotion: "reduce" });
+          expect(
+            await markers
+              .first()
+              .locator(".chat-position-rail__dot")
+              .evaluate((element) =>
+                Number.parseFloat(getComputedStyle(element).transitionDuration),
+              ),
+          ).toBeLessThanOrEqual(0.00001); // Global reduced-motion policy uses 0.01ms.
+          expect(pageErrors).toEqual([]);
+        },
+      );
+    },
+  );
 });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5431,6 +5431,12 @@ export const en: TranslationMap & {
       showEarlier: "Show earlier",
       loadingEarlier: "Loading earlier history…",
       noMatches: "No matching messages",
+      positionRail: "Conversation position",
+      positionMarker: "{label}, marker {position} of {count}",
+      positionUserMessage: "User message",
+      positionAssistantMessage: "Assistant message",
+      positionMarkerHint:
+        "Use arrow keys to choose a marker, Enter or Space to jump, and Escape to dismiss the preview.",
     },
     pendingInputs: {
       cancelled:

--- a/ui/src/pages/chat/components/chat-position-rail.test.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.test.ts
@@ -1,0 +1,196 @@
+/* @vitest-environment jsdom */
+
+import { html, nothing, render } from "lit";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestTranscript } from "../chat-view.test-helpers.ts";
+import { getTranscriptState } from "./chat-thread-interactions.ts";
+import { renderChatThread } from "./chat-thread.ts";
+import { projectChatTranscript } from "./chat-transcript-projection.ts";
+import {
+  installTranscriptDomMocks,
+  mountTestTranscript,
+  resetTranscriptTestDom,
+  resizeObservers,
+  threadProps,
+  transcriptDomState,
+  type TestContentRow,
+} from "./chat-transcript.test-support.ts";
+
+function message(id: string, role: string, content: unknown, seq: number, runId?: string) {
+  return {
+    role,
+    content,
+    timestamp: seq * 1_000,
+    __openclaw: { id, seq, ...(runId ? { runId } : {}) },
+  };
+}
+
+describe("conversation position rail", () => {
+  beforeEach(installTranscriptDomMocks);
+  afterEach(resetTranscriptTestDom);
+
+  it("resolves distant reader positions before scroll notification and counts the header once", async () => {
+    transcriptDomState.measuredRowHeight = 120;
+    const rows: TestContentRow[] = Array.from({ length: 40 }, (_, index) => ({
+      kind: "content",
+      key: `row-${index}`,
+      content: html`<div>${index}</div>`,
+    }));
+    const { container, transcript, session } = await mountTestTranscript("rail-offset", rows);
+    try {
+      Object.defineProperties(container, {
+        clientHeight: { configurable: true, value: 600 },
+        scrollHeight: { configurable: true, value: 4880 },
+      });
+      container.style.paddingTop = "80px";
+      for (const observer of resizeObservers) {
+        observer.emitTarget(container, 800, 600);
+      }
+      const ids = rows.map((row) => row.key);
+      session.syncMessageRows(new Map(ids.map((id) => [id, id])));
+      // No scroll event or render between these queries: mounted rows are stale.
+      container.scrollTop = 100;
+      expect(session.activeMessageId(ids)).toBe("row-2");
+      container.scrollTop = 3000;
+      expect(session.activeMessageId(ids)).toBe("row-26");
+      Object.defineProperty(container, "clientHeight", { configurable: true, value: 300 });
+      expect(session.activeMessageId(ids)).toBe("row-25");
+      container.scrollTop = 4580;
+      expect(session.activeMessageId(ids)).toBe("row-39");
+      expect(session.activeMessageId(["missing"])).toBeNull();
+    } finally {
+      transcript.hostDisconnected();
+    }
+  });
+
+  it("keeps focused previews after pointer exit and resets interaction when the session changes", () => {
+    const messages = Array.from({ length: 12 }, (_, index) =>
+      message(
+        `message-${index}`,
+        index % 2 ? "assistant" : "user",
+        `Checkpoint ${index}`,
+        index + 1,
+      ),
+    );
+    const props = threadProps("rail-interaction", "agent:main:first", messages);
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const rerender = () => {
+      render(renderChatThread(props, transcript), container);
+      transcript.hostUpdated();
+    };
+    props.onRequestUpdate = rerender;
+    const markers = () => [
+      ...container.querySelectorAll<HTMLButtonElement>(".chat-position-rail__marker"),
+    ];
+    const preview = () => container.querySelector(".chat-position-rail__preview-copy")?.textContent;
+    try {
+      rerender();
+      transcript.hostConnected();
+      expect(markers()).toHaveLength(10);
+      expect(preview()).toBeUndefined();
+      markers()[4]!.focus();
+      expect(preview()).toContain("Checkpoint 5");
+      markers()[2]!.dispatchEvent(new Event("pointerenter"));
+      expect(preview()).toContain("Checkpoint 2");
+      markers()[2]!.dispatchEvent(new Event("pointerleave"));
+      expect(preview()).toContain("Checkpoint 5");
+      markers()[4]!.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }),
+      );
+      expect(document.activeElement).toBe(markers()[5]);
+      expect(preview()).toContain("Checkpoint 6");
+      const focused = document.activeElement;
+      props.messages = [...messages, message("message-12", "user", "Checkpoint 12", 13)];
+      rerender();
+      expect(markers()).toHaveLength(10);
+      expect(document.activeElement).toBe(focused);
+      expect(preview()).toContain("Checkpoint 6");
+      focused!.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+      );
+      expect(preview()).toBeUndefined();
+      markers()[0]!.focus();
+      expect(preview()).toBeDefined();
+      render(nothing, container);
+      rerender();
+      expect(preview()).toBeUndefined();
+      props.sessionKey = "agent:main:second";
+      rerender();
+      expect(preview()).toBeUndefined();
+      const state = getTranscriptState(props.paneId);
+      state.searchOpen = true;
+      state.searchQuery = "Checkpoint 5";
+      rerender();
+      expect(markers()).toHaveLength(0);
+      state.searchQuery = "not present";
+      rerender();
+      expect(markers()).toHaveLength(0);
+    } finally {
+      transcript.hostDisconnected();
+    }
+  });
+
+  it("uses the visible completed answer and keeps attachment-only user landmarks", () => {
+    const messages = [
+      message("question", "user", "Inspect the design", 1),
+      message("commentary", "assistant", "Checking the files", 2, "run-1"),
+      {
+        ...message("tool", "toolResult", "File contents", 3, "run-1"),
+        toolName: "read",
+        toolCallId: "read-1",
+      },
+      message("answer", "assistant", "The design is ready", 4, "run-1"),
+      message(
+        "attachment",
+        "user",
+        [{ type: "image", source: { type: "base64", media_type: "image/png", data: "AA==" } }],
+        5,
+      ),
+    ];
+    const props = threadProps("rail-projection", "agent:main:projection", messages);
+    const transcript = createTestTranscript();
+    let landmarks: readonly unknown[] = [];
+    transcript.renderSession(props.paneId, props.sessionKey, (session) => {
+      landmarks = projectChatTranscript(props, session).positionMessages;
+      return html``;
+    });
+    expect(landmarks).toEqual([messages[0], messages[3], messages[4]]);
+    transcript.hostDisconnected();
+  });
+
+  it("does not target a final-answer action owner folded behind dashboard work", () => {
+    const messages = [
+      message("question", "user", "Inspect the design", 1),
+      { ...message("final", "assistant", "Design ready", 2, "run-1"), phase: "final_answer" },
+      {
+        ...message("tool-1", "toolResult", "File contents", 3, "run-1"),
+        toolName: "read",
+        toolCallId: "read-1",
+      },
+      {
+        ...message("tail", "assistant", "Checking the saved result", 4, "run-1"),
+        phase: "commentary",
+      },
+      {
+        ...message("tool-2", "toolResult", "Saved", 5, "run-1"),
+        toolName: "read",
+        toolCallId: "read-2",
+      },
+    ];
+    const props = {
+      ...threadProps("rail-folded", "agent:main:dashboard:audit", messages),
+      showToolCalls: true,
+      persistCommentary: true,
+      runWorking: false,
+    };
+    const transcript = createTestTranscript();
+    let landmarks: readonly unknown[] = [];
+    transcript.renderSession(props.paneId, props.sessionKey, (session) => {
+      landmarks = projectChatTranscript(props, session).positionMessages;
+      return html``;
+    });
+    expect(landmarks).toEqual([messages[0], messages[3]]);
+    transcript.hostDisconnected();
+  });
+});

--- a/ui/src/pages/chat/components/chat-position-rail.test.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.test.ts
@@ -172,7 +172,7 @@ describe("conversation position rail", () => {
       expect(preview()).toContain("Checkpoint 5");
       markers()[2]!.dispatchEvent(new Event("pointerenter"));
       expect(preview()).toContain("Checkpoint 2");
-      markers()[2]!.dispatchEvent(new Event("pointerleave"));
+      container.querySelector(".chat-position-rail")!.dispatchEvent(new Event("pointerleave"));
       expect(preview()).toContain("Checkpoint 5");
       markers()[4]!.dispatchEvent(
         new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }),
@@ -192,6 +192,13 @@ describe("conversation position rail", () => {
       markers()[0]!.focus();
       expect(preview()).toBeDefined();
       render(nothing, container);
+      const escapeAfterRemoval = new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+        cancelable: true,
+      });
+      document.dispatchEvent(escapeAfterRemoval);
+      expect(escapeAfterRemoval.defaultPrevented).toBe(false);
       rerender();
       expect(preview()).toBeUndefined();
       props.sessionKey = "agent:main:second";

--- a/ui/src/pages/chat/components/chat-position-rail.test.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.test.ts
@@ -1,10 +1,12 @@
 /* @vitest-environment jsdom */
 
 import { html, nothing, render } from "lit";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestTranscript } from "../chat-view.test-helpers.ts";
+import { renderChatPositionRail } from "./chat-position-rail.ts";
 import { getTranscriptState } from "./chat-thread-interactions.ts";
 import { renderChatThread } from "./chat-thread.ts";
+import { ChatTranscriptController } from "./chat-transcript-controller.ts";
 import { projectChatTranscript } from "./chat-transcript-projection.ts";
 import {
   installTranscriptDomMocks,
@@ -28,6 +30,83 @@ function message(id: string, role: string, content: unknown, seq: number, runId?
 describe("conversation position rail", () => {
   beforeEach(installTranscriptDomMocks);
   afterEach(resetTranscriptTestDom);
+
+  it("publishes consecutive reader offsets even when the virtual row range is unchanged", async () => {
+    transcriptDomState.measuredRowHeight = 120;
+    const requestUpdate = vi.fn();
+    const transcript = new ChatTranscriptController({
+      addController: () => undefined,
+      removeController: () => undefined,
+      requestUpdate,
+      updateComplete: Promise.resolve(true),
+    });
+    const rows: TestContentRow[] = Array.from({ length: 40 }, (_, index) => ({
+      kind: "content",
+      key: `row-${index}`,
+      content: html`<div>${index}</div>`,
+    }));
+    const { container, session } = await mountTestTranscript("rail-notification", rows, transcript);
+    try {
+      Object.defineProperties(container, {
+        clientHeight: { configurable: true, value: 600 },
+        scrollHeight: { configurable: true, value: 4800 },
+      });
+      for (const observer of resizeObservers) {
+        observer.emitTarget(container, 800, 600);
+      }
+      const ids = rows.map((row) => row.key);
+      session.syncMessageRows(new Map(ids.map((id) => [id, id])));
+      const rail = document.body.appendChild(document.createElement("div"));
+      const renderRail = () =>
+        render(
+          renderChatPositionRail({
+            messages: [
+              message("row-2", "user", "Second", 2),
+              message("row-3", "assistant", "Third", 3),
+            ],
+            transcript: session,
+            requestUpdate,
+          }),
+          rail,
+        );
+      requestUpdate.mockImplementation(renderRail);
+      const currentId = () =>
+        rail.querySelector('[aria-current="true"]')?.getAttribute("data-position-marker-id");
+      container.scrollTop = 50;
+      container.dispatchEvent(new Event("scroll"));
+      expect(currentId()).toBe("row-2");
+      requestUpdate.mockClear();
+
+      // Both viewports span rows 0–5, but their midpoints straddle row 3.
+      // TanStack's range/isScrolling notification alone cannot publish this.
+      container.scrollTop = 70;
+      container.dispatchEvent(new Event("scroll"));
+      expect(requestUpdate).toHaveBeenCalled();
+      expect(currentId()).toBe("row-3");
+      requestUpdate.mockClear();
+      container.scrollTop = 50;
+      container.dispatchEvent(new Event("scroll"));
+      expect(requestUpdate).toHaveBeenCalled();
+      expect(currentId()).toBe("row-2");
+
+      Object.defineProperty(container, "clientHeight", { configurable: true, value: 640 });
+      for (const observer of resizeObservers) {
+        observer.emitTarget(container, 800, 640);
+      }
+      expect(currentId()).toBe("row-3");
+      requestUpdate.mockClear();
+      container.dispatchEvent(new Event("scroll"));
+      expect(requestUpdate).not.toHaveBeenCalled();
+
+      transcript.hostDisconnected();
+      requestUpdate.mockClear();
+      container.scrollTop = 70;
+      container.dispatchEvent(new Event("scroll"));
+      expect(requestUpdate).not.toHaveBeenCalled();
+    } finally {
+      transcript.hostDisconnected();
+    }
+  });
 
   it("resolves distant reader positions before scroll notification and counts the header once", async () => {
     transcriptDomState.measuredRowHeight = 120;

--- a/ui/src/pages/chat/components/chat-position-rail.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.ts
@@ -5,6 +5,7 @@ import { directive } from "lit/directive.js";
 import { repeat } from "lit/directives/repeat.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { t } from "../../../i18n/index.ts";
+import { normalizeMessage } from "../../../lib/chat/message-normalizer.ts";
 import { persistedMessageEntryId } from "../chat-thread-items.ts";
 import { resolveMessageReplyText } from "./chat-message-markdown.ts";
 import type { ChatTranscriptSession } from "./chat-transcript-session.ts";
@@ -30,13 +31,13 @@ class ChatPositionRailDirective extends AsyncDirective {
   private interaction = initialInteraction();
   private requestUpdate: (() => void) | undefined;
 
-  protected disconnected() {
+  protected override disconnected() {
     this.interaction.hoveredId = null;
     this.interaction.focusedId = null;
     this.interaction.dismissed = false;
   }
 
-  protected reconnected() {
+  protected override reconnected() {
     this.requestUpdate?.();
   }
 
@@ -93,7 +94,7 @@ class ChatPositionRailDirective extends AsyncDirective {
     // Resolve previews only for the bounded set of visible landmarks.
     const markers = indexes.map((candidateIndex, index) => {
       const candidate = candidates[candidateIndex]!;
-      const role = (candidate.message as { role?: unknown }).role;
+      const role = normalizeMessage(candidate.message).role;
       return {
         id: candidate.id,
         label: t(
@@ -132,7 +133,10 @@ class ChatPositionRailDirective extends AsyncDirective {
       event.preventDefault();
       event.stopPropagation();
       // Focus existing buttons synchronously: currentTarget expires after dispatch.
-      (event.currentTarget as HTMLElement)
+      if (!(event.currentTarget instanceof HTMLButtonElement)) {
+        return;
+      }
+      event.currentTarget
         .closest(".chat-position-rail")
         ?.querySelectorAll<HTMLButtonElement>(".chat-position-rail__marker")
         .item(nextIndex)
@@ -160,7 +164,7 @@ class ChatPositionRailDirective extends AsyncDirective {
                   type="button"
                   data-position-marker-id=${marker.id}
                   tabindex=${marker.id === rovingMarker.id ? "0" : "-1"}
-                  aria-label=${t("chat.thread.positionMarker", { position: index + 1, count, label: marker.label })}
+                  aria-label=${t("chat.thread.positionMarker", { position: String(index + 1), count: String(count), label: marker.label })}
                   aria-description=${`${marker.preview}. ${t("chat.thread.positionMarkerHint")}`}
                   aria-current=${marker.id === activeMarker.id ? "true" : "false"}
                   @pointerenter=${() => {

--- a/ui/src/pages/chat/components/chat-position-rail.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.ts
@@ -1,0 +1,227 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { html, nothing } from "lit";
+import { AsyncDirective } from "lit/async-directive.js";
+import { directive } from "lit/directive.js";
+import { repeat } from "lit/directives/repeat.js";
+import { styleMap } from "lit/directives/style-map.js";
+import { t } from "../../../i18n/index.ts";
+import { persistedMessageEntryId } from "../chat-thread-items.ts";
+import { resolveMessageReplyText } from "./chat-message-markdown.ts";
+import type { ChatTranscriptSession } from "./chat-transcript-session.ts";
+
+const MAX_POSITION_MARKERS = 10;
+const PREVIEW_LENGTH = 140;
+const PROXIMITY_RADIUS = 3;
+
+type RailInteraction = {
+  hoveredId: string | null;
+  focusedId: string | null;
+  rovingId: string | null;
+  dismissed: boolean;
+};
+
+function initialInteraction(): RailInteraction {
+  return { hoveredId: null, focusedId: null, rovingId: null, dismissed: false };
+}
+
+// The directive owns transient DOM interaction; the session owns reader position.
+class ChatPositionRailDirective extends AsyncDirective {
+  private session: ChatTranscriptSession | null = null;
+  private interaction = initialInteraction();
+  private requestUpdate: (() => void) | undefined;
+
+  protected disconnected() {
+    this.interaction.hoveredId = null;
+    this.interaction.focusedId = null;
+    this.interaction.dismissed = false;
+  }
+
+  protected reconnected() {
+    this.requestUpdate?.();
+  }
+
+  render({
+    messages,
+    transcript,
+    requestUpdate,
+  }: {
+    messages: readonly unknown[];
+    transcript: ChatTranscriptSession;
+    requestUpdate: () => void;
+  }) {
+    this.requestUpdate = requestUpdate;
+    if (this.session !== transcript) {
+      this.session = transcript;
+      this.interaction = initialInteraction();
+    }
+    const candidates = messages.flatMap((message) => {
+      const id = persistedMessageEntryId(message);
+      return id ? [{ id, message }] : [];
+    });
+    const count = Math.min(candidates.length, MAX_POSITION_MARKERS);
+    if (count < 2) {
+      this.disconnected();
+      return nothing;
+    }
+    const interaction = this.interaction;
+    if (!candidates.some((candidate) => candidate.id === interaction.focusedId)) {
+      interaction.focusedId = null;
+    }
+    if (!candidates.some((candidate) => candidate.id === interaction.hoveredId)) {
+      interaction.hoveredId = null;
+    }
+    const indexes = Array.from({ length: count }, (_, index) =>
+      Math.round((index * (candidates.length - 1)) / (count - 1)),
+    );
+    const focusedIndex = candidates.findIndex(
+      (candidate) => candidate.id === interaction.focusedId,
+    );
+    if (focusedIndex >= 0 && !indexes.includes(focusedIndex)) {
+      // Appends/prepends can change the sample. Keep the focused DOM node while
+      // retaining both endpoints and the same bounded number of landmarks.
+      let replacement = 1;
+      for (let index = 2; index < count - 1; index++) {
+        if (
+          Math.abs(indexes[index]! - focusedIndex) < Math.abs(indexes[replacement]! - focusedIndex)
+        ) {
+          replacement = index;
+        }
+      }
+      indexes[replacement] = focusedIndex;
+      indexes.sort((left, right) => left - right);
+    }
+    // Resolve previews only for the bounded set of visible landmarks.
+    const markers = indexes.map((candidateIndex, index) => {
+      const candidate = candidates[candidateIndex]!;
+      const role = (candidate.message as { role?: unknown }).role;
+      return {
+        id: candidate.id,
+        label: t(
+          role === "user"
+            ? "chat.thread.positionUserMessage"
+            : "chat.thread.positionAssistantMessage",
+        ),
+        preview: truncateUtf16Safe(
+          resolveMessageReplyText(candidate.message).replace(/\s+/g, " ").trim(),
+          PREVIEW_LENGTH,
+        ),
+        position: `${((index + 0.5) / count) * 100}%`,
+      };
+    });
+    const activeId = transcript.activeMessageId(markers.map((marker) => marker.id));
+    const activeMarker = markers.find((marker) => marker.id === activeId) ?? markers.at(-1)!;
+    const previewMarker = interaction.dismissed
+      ? undefined
+      : markers.find((marker) => marker.id === (interaction.hoveredId ?? interaction.focusedId));
+    const rovingMarker =
+      markers.find((marker) => marker.id === interaction.rovingId) ?? activeMarker;
+    const previewIndex = previewMarker ? markers.indexOf(previewMarker) : -1;
+    const moveFocus = (event: KeyboardEvent, index: number) => {
+      const nextIndex =
+        event.key === "Home"
+          ? 0
+          : event.key === "End"
+            ? count - 1
+            : Math.max(
+                0,
+                Math.min(
+                  count - 1,
+                  index + (event.key === "ArrowUp" || event.key === "ArrowLeft" ? -1 : 1),
+                ),
+              );
+      event.preventDefault();
+      event.stopPropagation();
+      // Focus existing buttons synchronously: currentTarget expires after dispatch.
+      (event.currentTarget as HTMLElement)
+        .closest(".chat-position-rail")
+        ?.querySelectorAll<HTMLButtonElement>(".chat-position-rail__marker")
+        .item(nextIndex)
+        ?.focus({ preventScroll: true });
+    };
+    return html`
+      <aside class="chat-position-rail" aria-label=${t("chat.thread.positionRail")}>
+        <div class="chat-position-rail__track">
+          ${repeat(
+            markers,
+            (marker) => marker.id,
+            (marker, index) => {
+              const proximity =
+                previewIndex < 0
+                  ? 0
+                  : Math.max(0, 1 - Math.abs(index - previewIndex) / PROXIMITY_RADIUS);
+              return html`
+                <button
+                  class="chat-position-rail__marker ${marker.id === activeMarker.id ? "chat-position-rail__marker--current" : ""}"
+                  style=${styleMap({
+                    "--chat-position-marker": marker.position,
+                    "--chat-position-proximity-opacity": String(0.18 + 0.72 * proximity),
+                    "--chat-position-proximity-width": `${2 + Math.round(12 * proximity)}px`,
+                  })}
+                  type="button"
+                  data-position-marker-id=${marker.id}
+                  tabindex=${marker.id === rovingMarker.id ? "0" : "-1"}
+                  aria-label=${t("chat.thread.positionMarker", { position: index + 1, count, label: marker.label })}
+                  aria-description=${`${marker.preview}. ${t("chat.thread.positionMarkerHint")}`}
+                  aria-current=${marker.id === activeMarker.id ? "true" : "false"}
+                  @pointerenter=${() => {
+                    interaction.hoveredId = marker.id;
+                    interaction.dismissed = false;
+                    requestUpdate();
+                  }}
+                  @pointerleave=${() => {
+                    interaction.hoveredId = null;
+                    requestUpdate();
+                  }}
+                  @focus=${() => {
+                    interaction.focusedId = marker.id;
+                    interaction.rovingId = marker.id;
+                    interaction.dismissed = false;
+                    requestUpdate();
+                  }}
+                  @blur=${() => {
+                    interaction.focusedId = null;
+                    requestUpdate();
+                  }}
+                  @keydown=${(event: KeyboardEvent) => {
+                    if (
+                      ["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp", "End", "Home"].includes(
+                        event.key,
+                      )
+                    ) {
+                      moveFocus(event, index);
+                    } else if (event.key === "Escape") {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      interaction.dismissed = true;
+                      requestUpdate();
+                    }
+                  }}
+                  @click=${() => transcript.revealMessage(marker.id)}
+                >
+                  <span class="chat-position-rail__dot" aria-hidden="true"></span>
+                  <span class="chat-position-rail__tick" aria-hidden="true"></span>
+                </button>
+              `;
+            },
+          )}
+          ${
+            previewMarker
+              ? html`
+                  <div
+                    class="chat-position-rail__preview"
+                    aria-hidden="true"
+                    style=${styleMap({ "--chat-position-preview": previewMarker.position })}
+                  >
+                    <span class="chat-position-rail__preview-label">${previewMarker.label}</span>
+                    <span class="chat-position-rail__preview-copy">${previewMarker.preview}</span>
+                  </div>
+                `
+              : nothing
+          }
+        </div>
+      </aside>
+    `;
+  }
+}
+
+export const renderChatPositionRail = directive(ChatPositionRailDirective);

--- a/ui/src/pages/chat/components/chat-position-rail.ts
+++ b/ui/src/pages/chat/components/chat-position-rail.ts
@@ -2,6 +2,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
 import { AsyncDirective } from "lit/async-directive.js";
 import { directive } from "lit/directive.js";
+import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { t } from "../../../i18n/index.ts";
@@ -30,8 +31,38 @@ class ChatPositionRailDirective extends AsyncDirective {
   private session: ChatTranscriptSession | null = null;
   private interaction = initialInteraction();
   private requestUpdate: (() => void) | undefined;
+  private previewElement: Element | undefined;
+
+  private readonly dismissPreview = (event: KeyboardEvent) => {
+    const rail = this.previewElement?.closest(".chat-position-rail");
+    if (
+      event.key !== "Escape" ||
+      event.defaultPrevented ||
+      this.interaction.dismissed ||
+      !rail ||
+      rail.ownerDocument.defaultView?.getComputedStyle(rail).display === "none"
+    ) {
+      return;
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    this.interaction.hoveredId = null;
+    this.interaction.dismissed = true;
+    this.requestUpdate?.();
+  };
+
+  private readonly bindPreview = (element?: Element) => {
+    this.previewElement?.ownerDocument.defaultView?.removeEventListener(
+      "keydown",
+      this.dismissPreview,
+      true,
+    );
+    this.previewElement = element;
+    element?.ownerDocument.defaultView?.addEventListener("keydown", this.dismissPreview, true);
+  };
 
   protected override disconnected() {
+    this.bindPreview();
     this.interaction.hoveredId = null;
     this.interaction.focusedId = null;
     this.interaction.dismissed = false;
@@ -143,7 +174,14 @@ class ChatPositionRailDirective extends AsyncDirective {
         ?.focus({ preventScroll: true });
     };
     return html`
-      <aside class="chat-position-rail" aria-label=${t("chat.thread.positionRail")}>
+      <aside
+        class="chat-position-rail"
+        aria-label=${t("chat.thread.positionRail")}
+        @pointerleave=${() => {
+          interaction.hoveredId = null;
+          requestUpdate();
+        }}
+      >
         <div class="chat-position-rail__track">
           ${repeat(
             markers,
@@ -172,10 +210,6 @@ class ChatPositionRailDirective extends AsyncDirective {
                     interaction.dismissed = false;
                     requestUpdate();
                   }}
-                  @pointerleave=${() => {
-                    interaction.hoveredId = null;
-                    requestUpdate();
-                  }}
                   @focus=${() => {
                     interaction.focusedId = marker.id;
                     interaction.rovingId = marker.id;
@@ -193,11 +227,6 @@ class ChatPositionRailDirective extends AsyncDirective {
                       )
                     ) {
                       moveFocus(event, index);
-                    } else if (event.key === "Escape") {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      interaction.dismissed = true;
-                      requestUpdate();
                     }
                   }}
                   @click=${() => transcript.revealMessage(marker.id)}
@@ -212,6 +241,7 @@ class ChatPositionRailDirective extends AsyncDirective {
             previewMarker
               ? html`
                   <div
+                    ${ref(this.bindPreview)}
                     class="chat-position-rail__preview"
                     aria-hidden="true"
                     style=${styleMap({ "--chat-position-preview": previewMarker.position })}

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -22,6 +22,7 @@ import {
   CHAT_HISTORY_BOUNDARY_HEIGHT_PX,
   renderChatHistoryBoundary,
 } from "./chat-history-boundary.ts";
+import { renderChatPositionRail } from "./chat-position-rail.ts";
 import {
   handleTranscriptContextMenu,
   handleTranscriptPointerUp,
@@ -154,6 +155,11 @@ function renderTranscriptShell(
         aria-atomic="true"
         >${transcript.liveAnnouncementText}</span
       >
+      ${renderChatPositionRail({
+        messages: projection.positionMessages,
+        transcript,
+        requestUpdate: props.onRequestUpdate ?? (() => {}),
+      })}
       ${transcriptContents}
     </div>
   `;

--- a/ui/src/pages/chat/components/chat-transcript-geometry.ts
+++ b/ui/src/pages/chat/components/chat-transcript-geometry.ts
@@ -1,5 +1,5 @@
 import type { Virtualizer } from "@tanstack/virtual-core";
-import type { ReactiveControllerHost } from "lit";
+import type { ReactiveController, ReactiveControllerHost } from "lit";
 
 function transcriptScrollMargin(element: Element | null): number {
   if (!(element instanceof HTMLElement) || typeof getComputedStyle !== "function") {
@@ -65,16 +65,48 @@ export function maxTranscriptScrollOffset(element: HTMLElement | null): number |
   return element ? Math.max(0, element.scrollHeight - element.clientHeight) : null;
 }
 
-export function syncPositionRailGutter(
-  viewport: HTMLDivElement | null,
-  inner: HTMLDivElement | null,
-): void {
-  if (!viewport || !inner) {
-    return;
+export class PositionRailGutterController implements ReactiveController {
+  private frame: number | null = null;
+
+  constructor(
+    private readonly host: ReactiveControllerHost & {
+      readonly scrollElement: HTMLDivElement | null;
+    },
+    private readonly inner: () => HTMLDivElement | null,
+  ) {
+    host.addController(this);
   }
-  const right = viewport.getBoundingClientRect().left + viewport.clientLeft + viewport.clientWidth;
-  const gutter = right - inner.getBoundingClientRect().right;
-  // The rail's marker/tick footprint reaches 69px from the client edge;
-  // reserve 80px including breathing room (see message-layout.css).
-  viewport.toggleAttribute("data-position-rail-gutter", gutter >= 80);
+
+  hostUpdated(): void {
+    if (this.frame !== null) {
+      return;
+    }
+    // Nested Lit children can still be replacing footer content. A synchronous
+    // layout read here clamps scrolling against that intermediate viewport.
+    this.frame = requestAnimationFrame(() => {
+      this.frame = null;
+      this.sync();
+    });
+  }
+
+  hostDisconnected(): void {
+    if (this.frame !== null) {
+      cancelAnimationFrame(this.frame);
+      this.frame = null;
+    }
+  }
+
+  sync(): void {
+    const viewport = this.host.scrollElement;
+    const inner = this.inner();
+    if (!viewport?.isConnected || inner?.parentElement !== viewport) {
+      return;
+    }
+    const right =
+      viewport.getBoundingClientRect().left + viewport.clientLeft + viewport.clientWidth;
+    const gutter = right - inner.getBoundingClientRect().right;
+    // The rail's marker/tick footprint reaches 69px from the client edge;
+    // reserve 80px including breathing room (see message-layout.css).
+    viewport.toggleAttribute("data-position-rail-gutter", gutter >= 80);
+  }
 }

--- a/ui/src/pages/chat/components/chat-transcript-geometry.ts
+++ b/ui/src/pages/chat/components/chat-transcript-geometry.ts
@@ -64,3 +64,17 @@ export function measureConnectedTranscriptRows(
 export function maxTranscriptScrollOffset(element: HTMLElement | null): number | null {
   return element ? Math.max(0, element.scrollHeight - element.clientHeight) : null;
 }
+
+export function syncPositionRailGutter(
+  viewport: HTMLDivElement | null,
+  inner: HTMLDivElement | null,
+): void {
+  if (!viewport || !inner) {
+    return;
+  }
+  const right = viewport.getBoundingClientRect().left + viewport.clientLeft + viewport.clientWidth;
+  const gutter = right - inner.getBoundingClientRect().right;
+  // The rail's marker/tick footprint reaches 69px from the client edge;
+  // reserve 80px including breathing room (see message-layout.css).
+  viewport.toggleAttribute("data-position-rail-gutter", gutter >= 80);
+}

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -67,6 +67,7 @@ import { resolveAssistantDisplayAvatar } from "./chat-welcome.ts";
 import { renderTurnRecapRow } from "./chat-working-indicator.ts";
 
 type ChatTranscriptProjection = {
+  positionMessages: readonly unknown[];
   isDirectThread: boolean;
   isEmpty: boolean;
   showLoadingSkeleton: boolean;
@@ -525,7 +526,33 @@ export function projectChatTranscript(
     (tailStatusOwner.kind !== "group" || !tailStatusOwner.isStreaming)
       ? tailStatusOwner.key
       : null;
+  const positionMessages: unknown[] = [];
   for (const item of transcriptItems) {
+    // Completed runs also contain folded work that is not a visible landmark.
+    const frameActionOwner =
+      item.kind === "agent-run-frame" && item.outcome.kind === "completed"
+        ? item.outcome.actionOwner
+        : null;
+    const visibleFrameSources =
+      item.kind === "agent-run-frame"
+        ? item.parts.flatMap((part) =>
+            part.kind === "group" && part.role === "assistant" && part.visibleContent !== "none"
+              ? part.messages.filter((source) => persistedMessageEntryId(source.message))
+              : [],
+          )
+        : [];
+    const positionSource =
+      item.kind === "group" &&
+      (item.role === "user" || item.role === "assistant") &&
+      item.visibleContent !== "none"
+        ? item.messages.find((source) => persistedMessageEntryId(source.message))
+        : item.kind === "agent-run-frame" && item.outcome.kind === "completed"
+          ? (visibleFrameSources.find((source) => source === frameActionOwner) ??
+            visibleFrameSources.at(-1))
+          : null;
+    if (positionSource) {
+      positionMessages.push(positionSource.message);
+    }
     const groups =
       item.kind === "agent-run-frame"
         ? agentRunFrameGroups(item)
@@ -678,6 +705,7 @@ export function projectChatTranscript(
   };
   return {
     isDirectThread,
+    positionMessages: showLoadingSkeleton ? [] : positionMessages,
     isEmpty,
     showLoadingSkeleton,
     searchOpen: state.searchOpen,

--- a/ui/src/pages/chat/components/chat-transcript-session.ts
+++ b/ui/src/pages/chat/components/chat-transcript-session.ts
@@ -38,6 +38,8 @@ export type ChatTranscriptSession = {
     header?: TranscriptHeader | null,
   ): TemplateResult;
   syncMessageRows(messageRowKeysById: ReadonlyMap<string, string>): void;
+  /** Returns the loaded message nearest the reader's virtualized viewport anchor. */
+  activeMessageId(messageIds: readonly string[]): string | null;
   revealMessage(messageId: string): boolean;
   setContentReady(ready: boolean): void;
   handleFocusIn(event: FocusEvent): void;

--- a/ui/src/pages/chat/components/chat-transcript-session.ts
+++ b/ui/src/pages/chat/components/chat-transcript-session.ts
@@ -38,7 +38,7 @@ export type ChatTranscriptSession = {
     header?: TranscriptHeader | null,
   ): TemplateResult;
   syncMessageRows(messageRowKeysById: ReadonlyMap<string, string>): void;
-  /** Returns the loaded message nearest the reader's virtualized viewport anchor. */
+  /** Returns the sampled loaded message at or preceding the viewport midpoint. */
   activeMessageId(messageIds: readonly string[]): string | null;
   revealMessage(messageId: string): boolean;
   setContentReady(ready: boolean): void;

--- a/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
+++ b/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
@@ -31,7 +31,7 @@ import {
   maxTranscriptScrollOffset,
   measureConnectedTranscriptRows,
   resolveTranscriptScrollMargin,
-  syncPositionRailGutter,
+  PositionRailGutterController,
   syncScrollMargin,
 } from "./chat-transcript-geometry.ts";
 import {
@@ -58,6 +58,7 @@ import {
 export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscriptSession {
   expandedAssistantMessages = new Map<string, AssistantMessageExpansionState>();
   private readonly controllers = new Set<ReactiveController>();
+  private readonly positionRail: PositionRailGutterController;
   private readonly virtualizerController: VirtualizerController<HTMLDivElement, HTMLElement>;
   private threadInnerElement: HTMLDivElement | null = null;
   private connected = false;
@@ -132,7 +133,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
   }
   private readonly handleGeometryCommit = (event: Event) => {
     this.reconcileInteractionResize(event.target);
-    syncPositionRailGutter(this.scrollElement, this.threadInnerElement);
+    this.positionRail.sync();
     if (event instanceof CustomEvent && event.detail?.widthChanged === false) {
       return;
     }
@@ -212,6 +213,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     onInitialOffsetSettled?: (position: ChatSessionScrollPosition) => void,
     private readonly callbacks: TranscriptCallbacks = {},
   ) {
+    this.positionRail = new PositionRailGutterController(this, () => this.threadInnerElement);
     this.implicitEndAnchorPending = initialOffset === null;
     this.virtualizerController = new VirtualizerController(this, {
       count: 0,
@@ -234,7 +236,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
           const heightChanged = previousHeight !== null && previousHeight !== rect.height;
           this.observedWidth = rect.width;
           this.observedHeight = rect.height;
-          syncPositionRailGutter(this.scrollElement, this.threadInnerElement);
+          this.positionRail.sync();
           // appliedHeaderHeight, not headerHeight: only the render paths fold a
           // header toggle into the margin, because they own its compensation.
           syncScrollMargin(instance.scrollElement, instance, this.appliedHeaderHeight);
@@ -379,9 +381,6 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     for (const controller of this.controllers) {
       controller.hostUpdated?.();
     }
-    // Saved message widths can change the inner column without resizing the
-    // viewport. Read committed layout, including foreign-host geometry commits.
-    syncPositionRailGutter(this.scrollElement, this.threadInnerElement);
     this.reconcileInteractionResize();
     this.reconcileImplicitEndAnchor();
     this.applyPendingScrollOffset();

--- a/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
+++ b/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
@@ -31,6 +31,7 @@ import {
   maxTranscriptScrollOffset,
   measureConnectedTranscriptRows,
   resolveTranscriptScrollMargin,
+  syncPositionRailGutter,
   syncScrollMargin,
 } from "./chat-transcript-geometry.ts";
 import {
@@ -131,6 +132,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
   }
   private readonly handleGeometryCommit = (event: Event) => {
     this.reconcileInteractionResize(event.target);
+    syncPositionRailGutter(this.scrollElement, this.threadInnerElement);
     if (event instanceof CustomEvent && event.detail?.widthChanged === false) {
       return;
     }
@@ -232,6 +234,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
           const heightChanged = previousHeight !== null && previousHeight !== rect.height;
           this.observedWidth = rect.width;
           this.observedHeight = rect.height;
+          syncPositionRailGutter(this.scrollElement, this.threadInnerElement);
           // appliedHeaderHeight, not headerHeight: only the render paths fold a
           // header toggle into the margin, because they own its compensation.
           syncScrollMargin(instance.scrollElement, instance, this.appliedHeaderHeight);
@@ -376,6 +379,9 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     for (const controller of this.controllers) {
       controller.hostUpdated?.();
     }
+    // Saved message widths can change the inner column without resizing the
+    // viewport. Read committed layout, including foreign-host geometry commits.
+    syncPositionRailGutter(this.scrollElement, this.threadInnerElement);
     this.reconcileInteractionResize();
     this.reconcileImplicitEndAnchor();
     this.applyPendingScrollOffset();
@@ -536,11 +542,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     // The reader has reached the final section even though the normal midpoint
     // viewport anchor still points into the preceding row.
     if (maxOffset !== null && Math.abs(maxOffset - scrollElement.scrollTop) <= 1) {
-      for (const messageId of messageIds.toReversed()) {
-        if (this.messageRowKeysById.has(messageId)) {
-          return messageId;
-        }
-      }
+      return messageIds.findLast((messageId) => this.messageRowKeysById.has(messageId)) ?? null;
     }
     // Measurements already include scrollMargin. Query the complete row model,
     // not the rendered range, which can lag a jump or include a focused outlier.

--- a/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
+++ b/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
@@ -246,17 +246,28 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
           }
           if (widthChanged || heightChanged) {
             this.callbacks.onViewportResize?.();
+            this.host.requestUpdate();
           }
         }),
       observeElementOffset: (instance, callback) => {
         const element = this.scrollElement;
+        const publishOffset = (offset: number, scrolling: boolean) => {
+          const changed = offset !== instance.scrollOffset;
+          callback(offset, scrolling);
+          // Range notifications are memoized: the viewport midpoint can cross
+          // a rail landmark without changing the visible rows. Lit coalesces
+          // this request with the virtualizer's own update when both fire.
+          if (changed) {
+            this.host.requestUpdate();
+          }
+        };
         const syncOffset = () => {
           if (!element || element !== this.scrollElement || instance.scrollElement !== element) {
             return;
           }
           const offset = element.scrollTop;
           if (offset !== instance.scrollOffset) {
-            callback(offset, instance.isScrolling);
+            publishOffset(offset, instance.isScrolling);
           }
         };
         this.syncNativeOffset = syncOffset;
@@ -282,7 +293,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
           if (element !== this.scrollElement) {
             return;
           }
-          callback(offset, scrolling);
+          publishOffset(offset, scrolling);
           // Idle can arrive between smooth retargets. Completion needs the
           // restore path's 1px precision, not the 8px UI-follow boundary.
           // The input listeners above own reader takeover.
@@ -525,7 +536,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     // The reader has reached the final section even though the normal midpoint
     // viewport anchor still points into the preceding row.
     if (maxOffset !== null && Math.abs(maxOffset - scrollElement.scrollTop) <= 1) {
-      for (const messageId of [...messageIds].reverse()) {
+      for (const messageId of messageIds.toReversed()) {
         if (this.messageRowKeysById.has(messageId)) {
           return messageId;
         }

--- a/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
+++ b/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
@@ -515,6 +515,44 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     this.messageRowKeysById = messageRowKeysById;
   }
 
+  activeMessageId(messageIds: readonly string[]): string | null {
+    const scrollElement = this.scrollElement;
+    if (!scrollElement || messageIds.length === 0) {
+      return null;
+    }
+    const virtualizer = this.virtualizerController.getVirtualizer();
+    const maxOffset = maxTranscriptScrollOffset(scrollElement);
+    // The reader has reached the final section even though the normal midpoint
+    // viewport anchor still points into the preceding row.
+    if (maxOffset !== null && Math.abs(maxOffset - scrollElement.scrollTop) <= 1) {
+      for (const messageId of [...messageIds].reverse()) {
+        if (this.messageRowKeysById.has(messageId)) {
+          return messageId;
+        }
+      }
+    }
+    // Measurements already include scrollMargin. Query the complete row model,
+    // not the rendered range, which can lag a jump or include a focused outlier.
+    const viewportAnchor = scrollElement.scrollTop + scrollElement.clientHeight * 0.5;
+    const activeRow = virtualizer.getVirtualItemForOffset(viewportAnchor);
+    if (!activeRow) {
+      return null;
+    }
+    let precedingId: string | null = null;
+    for (const messageId of messageIds) {
+      const rowKey = this.messageRowKeysById.get(messageId);
+      const rowIndex = rowKey ? this.rowIndexesByKey.get(rowKey) : undefined;
+      if (rowIndex === undefined) {
+        continue;
+      }
+      if (rowIndex > activeRow.index) {
+        return precedingId ?? messageId;
+      }
+      precedingId = messageId;
+    }
+    return precedingId;
+  }
+
   revealMessage(messageId: string): boolean {
     const rowKey = this.messageRowKeysById.get(messageId);
     const rowIndex = rowKey ? this.rowIndexesByKey.get(rowKey) : undefined;

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -82,6 +82,7 @@
 
 .chat-position-rail__marker {
   position: absolute;
+  z-index: 1;
   top: var(--chat-position-marker);
   left: -13px;
   display: grid;
@@ -156,8 +157,18 @@
   box-shadow: var(--shadow-md);
   font-size: 12px;
   line-height: 1.35;
-  pointer-events: none;
   transform: translateY(-50%);
+}
+
+/* A contiguous hover path lets magnifier users move from the marker onto the
+   preview. Marker hit targets stay above this transparent bridge. */
+.chat-position-rail__preview::after {
+  position: absolute;
+  top: 0;
+  left: 100%;
+  width: 16px;
+  height: 100%;
+  content: "";
 }
 
 .chat-position-rail__preview-label {

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -29,6 +29,7 @@
 
 /* Chat thread - scrollable middle section, transparent */
 .chat-thread {
+  container: chat-transcript / size;
   flex: 1 1 0;
   /* Grow, shrink, and use 0 base for proper scrolling */
   overflow-y: auto;
@@ -57,6 +58,119 @@
    no focus box: a ring around the whole main content reads as a broken border. */
 .chat-thread:focus-visible {
   outline: none;
+}
+
+/* Desktop-only transcript landmarks. The rail lives in the existing gutter so it
+   complements the native scrollbar instead of impersonating it. */
+.chat-position-rail {
+  position: sticky;
+  z-index: 4;
+  top: clamp(20px, 3vh, 28px);
+  width: 0;
+  height: 0;
+  margin-inline-start: auto;
+}
+
+.chat-position-rail__track {
+  position: absolute;
+  top: 0;
+  right: calc(var(--chat-thread-gutter) + 4px);
+  width: 24px;
+  height: min(420px, calc(100cqh - 48px));
+  border-inline-start: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
+}
+
+.chat-position-rail__marker {
+  position: absolute;
+  top: var(--chat-position-marker);
+  left: -13px;
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  cursor: var(--cursor-action);
+  transform: translateY(-50%);
+}
+
+.chat-position-rail__dot {
+  width: 9px;
+  height: 9px;
+  border: 2px solid var(--panel);
+  border-radius: 50%;
+  background: var(--muted);
+  pointer-events: none;
+  transition:
+    background-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.chat-position-rail__tick {
+  position: absolute;
+  top: 50%;
+  right: calc(50% + 9px);
+  display: block;
+  width: var(--chat-position-proximity-width);
+  height: 2px;
+  border-radius: 1px;
+  background: color-mix(in srgb, var(--text) 58%, var(--muted));
+  opacity: var(--chat-position-proximity-opacity);
+  pointer-events: none;
+  transform: translateY(-50%);
+  transition:
+    width 120ms ease,
+    opacity 120ms ease;
+}
+
+.chat-position-rail__marker:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.chat-position-rail__marker:hover .chat-position-rail__dot,
+.chat-position-rail__marker:focus-visible .chat-position-rail__dot,
+.chat-position-rail__marker--current .chat-position-rail__dot {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
+.chat-position-rail__marker--current .chat-position-rail__dot {
+  background: var(--accent);
+}
+
+.chat-position-rail__preview {
+  position: absolute;
+  top: var(--chat-position-preview);
+  right: 52px;
+  display: grid;
+  width: 200px;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--focus-ring) 50%, var(--border));
+  border-radius: var(--radius-md);
+  color: var(--text);
+  background: color-mix(in srgb, var(--panel) 94%, var(--bg));
+  box-shadow: var(--shadow-md);
+  font-size: 12px;
+  line-height: 1.35;
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.chat-position-rail__preview-label {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.chat-position-rail__preview-copy {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .chat-thread-inner > :first-child {
@@ -629,6 +743,30 @@
     --chat-thread-gutter: 16px;
     --chat-thread-side-inset: 0px;
     --chat-mobile-edge-inset: 4px;
+  }
+}
+
+@container chat-transcript (max-width: 960px) or (max-height: 360px) {
+  .chat-position-rail {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-position-rail__dot,
+  .chat-position-rail__tick {
+    transition: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .chat-position-rail__dot {
+    background: ButtonText;
+  }
+
+  .chat-position-rail__marker--current .chat-position-rail__dot {
+    background: Highlight;
+    outline: 2px solid Highlight;
   }
 }
 

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -80,6 +80,12 @@
   border-inline-start: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
 }
 
+/* The transcript owner measures the actual saved-width gutter. Its 80px
+   threshold covers the marker/tick footprint plus space clear of messages. */
+.chat-thread:not([data-position-rail-gutter]) > .chat-position-rail {
+  display: none;
+}
+
 .chat-position-rail__marker {
   position: absolute;
   z-index: 1;
@@ -195,6 +201,9 @@
   width: calc(100% - 2 * var(--chat-thread-gutter) - 2 * var(--chat-thread-side-inset));
   max-width: var(--chat-thread-max-width);
   margin-inline: auto;
+  /* Commit width with the virtual rows, even under the global reduced-motion
+     duration; gutter and row measurements must not sample a transition. */
+  transition-property: none;
 }
 
 /* Message images (sent images displayed in chat) */


### PR DESCRIPTION
Closes #138587

## What Problem This Solves

Long conversations are difficult to navigate by scrolling alone: the scrollbar shows distance, but not the content at a destination.

## Why This Change Was Made

Adds a restrained, previewable conversation-position rail in the spare gutter of wide Control UI chat panes. Up to ten landmarks sample visible, loaded conversational rows. Hover or focus previews a destination; click or Enter/Space reveals its message through the existing transcript virtualizer.

- The current landmark follows the reader, including consecutive scrolls within an unchanged virtual row range and viewport resizing.
- Arrow keys and Home/End move marker focus; Escape dismisses the preview. Appending messages preserves a focused landmark.
- Hidden tool work is not a jump destination. Session changes and disconnected views clear transient previews.
- The rail hides in narrow or short panes, including split views, and respects reduced motion and forced colors.
- No new API, configuration, dependency, or history-pagination behavior. The native scrollbar remains available.

## User Impact

Readers can orient themselves and return to earlier exchanges without guessing from scrollbar position. This complements transcript search rather than replacing it.

**Author direction:** proceed with the desktop, loaded-history rail shown below. This implementation follows the author's approved interactive mockup. This is a proposed product addition, not a claim that project-wide design approval or merge approval has already been granted.

**Maintainer decision pending:** the author will share this PR on Discord once implementation and code review are complete, so a Control UI maintainer can evaluate the interaction, modify the editable branch, and decide whether to merge it. Product sponsorship is not yet established; this PR requests that review rather than claiming merge readiness.

## Review Follow-up

The first hosted ClawSweeper review identified missing reader-position invalidation. Reproduced the precise failure: with 120px rows and a 600px viewport, offsets 50 → 70 retain the same visible range while the midpoint moves from row 2 to row 3. TanStack memoizes notifications by scrolling state and range endpoints, so it did not request the second render.

The repair publishes distinct offset changes through the transcript's existing observer, including native-offset synchronization. Lit coalesces render requests; no second scroll listener or parallel scroll owner is added. Meaningful viewport changes invalidate the marker too. The regression asserts rendered `aria-current` through consecutive forward/backward scroll events, resize, duplicate-event suppression, and disconnection cleanup. It failed before the repair and passes afterward.

The broader end → middle → top browser scenario also passes in both themes. The review's prediction that this broad scenario fails was not reproduced; the same-range case above establishes the actual defect and repair.

The transcript owner is the appropriate repair boundary: a second rail-owned scroll subscription would duplicate lifecycle and offset synchronization, while invalidation through the existing new-message indicator misses unchanged indicator state. The directive retains only transient interaction state and delegates position and navigation to that owner.

Independent Codex review also identified that a mouse-only preview could not be hovered. Its browser regression failed before repair. The rail and preview now share a contiguous hover region; marker hit targets remain above the transparent bridge. Escape dismisses the preview even when focus stays in the composer, clears stale hover state, and leaves focus alone. The preview's Lit ref owns the single key listener and removes it on teardown. Browser coverage verifies stepped pointer movement onto the text, dismissal, re-entry, and subsequent keyboard navigation in both themes. This follows the hoverable/dismissible requirements described in [WCAG 1.4.13](https://www.w3.org/WAI/WCAG22/Understanding/content-on-hover-or-focus.html); assistive-technology user testing itself was not performed.

The next hosted ClawSweeper review accepted the scroll repair and marked the behavior proof sufficient, then identified overlap with saved full-width message settings. The new browser regression reproduced that failure in both themes before repair. The transcript geometry owner now measures the actual right-side gutter after committed layout, viewport changes, and sidebar commits (including unchanged outer width). It shows the rail only when 80px accommodates the marker/tick footprint and spacing. There is no new observer, settings parser, or width override. The browser changes the real Appearance setting through `100%`, `none`, `95%`, and `48rem`, verifies persistence and rendered width, and checks that the rail hides or returns accordingly. A fixed-pane foreign-host geometry event also verifies inner-only width changes in both directions.

The stronger unchanged-pane scenario also exposed a reduced-motion timing defect: the global 0.01ms transition duration let a synchronous geometry commit observe the old inner width. The transcript inner column now disables transitions, matching the existing virtual-row geometry policy. Both theme scenarios pass this regression without timers, additional observers, or changed motion preferences.

CI then caught an intermediate-layout regression in the gutter repair. On `341777c8900a41463c7a1e39afa7144bac148bbe`, the existing question-footer and disclosure-anchor suites failed together at 505px and 48px from the end. A/B runs passed all 24 tests on the preceding revision and when gutter reads were disabled; retaining the reads without changing the visibility attribute reproduced both failures. A browser state trace showed the question transition moving native scrollTop from 561 to 449 without reader input, then setting the existing follow lock. The parent-update gutter measurement forced layout after removal of the old composer but before nested Lit content finished, allowing the browser to clamp against a temporary viewport.

The geometry owner now registers a session-owned Lit controller that coalesces update-time measurements into one animation frame, after nested render work. Disconnect cancels pending work; execution-time getters and DOM ownership checks prevent stale measurements after remounts. Actual viewport-observer and sidebar-geometry commits remain synchronous. No scroll-policy change, additional row scan, observer, test timeout, or weakened assertion is needed. The previously failing suites plus both rail themes pass together: 26 browser tests. Existing tests provide the pre-fix regression evidence; no duplicate test or production-only testing hook was added.

Scope against the pinned base: production +560/-3 lines (net +557), tests +529/-0, ten files. The growth implements the new interaction and its styles; it adds no generic framework, dependency, configuration surface, or alternate navigation backend. The final repair replaces the unowned synchronous measurement with a cancellable, coalesced lifecycle owner, adding 31 net production lines. The lifecycle state is necessary to avoid intermediate layout and retire pending work on disconnect; sharing the row-measurement frame would add needless row scans during ordinary renders.

## Evidence

### Real Behavior Proof

**Checked head:** `decebd2a825b4e9da5050eb531f6fe039b7d3262`, based on `137698c76560b4b552e848533529c963ffed87fa`. Behavior proof, the full changed-check gate, and independent Codex local-candidate and committed-branch reviews passed. Both reviews were scoped-clean through P2; the committed review includes the final behavior-preserving constructor-wiring cleanup. Product and merge decisions remain with a Control UI maintainer.

- **Claim:** a reader can preview and navigate loaded conversation landmarks without losing virtualized transcript positioning or keyboard focus, and the current marker follows consecutive reader positions.
- **Exercised surface:** the real production-built Control UI `/chat` entrypoint, actual transcript renderer, rail directive, and TanStack virtualizer in Chromium.
- **Scenario/fixture:** the committed `chat-position-rail.e2e.test.ts` uses the repository's mocked Gateway with 72 synthetic persisted conversation messages. Covers idle state, end/middle/top scrolls, hover styling and preview, keyboard jump to checkpoint 47, Escape, Home/End, pane-local width 800px, viewport width 900px, dark/light themes, and reduced motion. The real Appearance screen saves `100%`, `none`, `95%`, and `48rem`; the test verifies persistence, rendered width, rail visibility, and clear spacing. Same-pane foreign geometry commits cover inner-only width changes under reduced motion. Adjacent agent-run and focused-row browser scenarios also ran.
- **Command/environment:** Docker-backed Crabbox `provider=local-container`, lease `cbx_80e1f4d11c47`, slug `swift-krill-d8be`, image `mcr.microsoft.com/playwright:v1.62.0-noble`, Node 24.18.0, pnpm 12.1.0, frozen lockfile, Playwright 1.62.1. Commands below executed inside the owned worker with `docker exec --user crabbox` after Crabbox provisioning.
- **Observed result:** 168 focused transcript tests passed across four files; 33 real-browser tests passed together across five files, including both rail themes, question flow, disclosure anchoring, focused-row placement, and agent-run transcripts. The previously failing end-follow assertions pass unchanged. The target message was asserted fully inside the viewport after keyboard activation. No page errors were observed in either rail scenario.
- **Artifact/trace:** inspected before/after screenshots and recordings below. The original 14-second overview predates the hover-persistence repair; the approximately five-second recording includes that repair. The feature baseline was built separately from base `137698c76560b4b552e848533529c963ffed87fa` with the same synthetic fixture, not simulated by hiding the rail. The saved-width baseline is from `9fb3c0982b4c65e81f20da027347fa36e994987e`; its after screenshots cover the gutter and reduced-motion fixes. The question-footer baseline uses exact product revision `341777c8900a41463c7a1e39afa7144bac148bbe`; its after capture includes the lifecycle repair, before a behavior-preserving constructor-wiring cleanup. The final 33-test browser run includes that cleanup. The proof worker's tracked source was compared against committed head `decebd2a825b4e9da5050eb531f6fe039b7d3262` with `git diff --exit-code` and matched exactly. Final Chromium run started at 00:42:06 UTC on September 5, 2026 and passed in 85.39 seconds; logs were retained as `position-rail-final-deferred-browser.log` and `position-rail-final-deferred-focused.log`. Question screenshots use `.artifacts/position-rail-deferred-proof`; earlier overview recordings use `.artifacts/position-rail-final`.
- **Limits:** mocked Gateway, synthetic messages, Chromium/Linux; no production account, external API, new history fetch, or live agent invocation. Native Safari/Firefox and assistive-technology user testing were not run. Screenshot/video evidence complements the DOM assertions; it does not replace them.

```sh
node scripts/run-vitest.mjs \
  ui/src/pages/chat/components/chat-position-rail.test.ts \
  ui/src/pages/chat/components/chat-transcript-render.test.ts \
  ui/src/pages/chat/components/chat-transcript-scroll-ownership.test.ts \
  ui/src/pages/chat/components/chat-transcript-controller.test.ts

node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/question-flow.e2e.test.ts \
  ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts \
  ui/src/e2e/chat-position-rail.e2e.test.ts \
  ui/src/e2e/chat-transcript-focus.e2e.test.ts \
  ui/src/e2e/chat-agent-run-transcript.e2e.test.ts

# Existing screenshot hook for the repaired question-footer scenario:
OPENCLAW_CAPTURE_UI_PROOF=1 \
OPENCLAW_UI_E2E_ARTIFACT_DIR=.artifacts/position-rail-deferred-proof \
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/question-flow.e2e.test.ts -t "settles a live-edge transcript"
```

### Before and after

Same loaded conversation at its end, before the feature:

![Baseline: native transcript without the rail](https://github.com/user-attachments/assets/6a9e686f-10c5-441c-8131-336bd54eace6)

After, idle with the last landmark current and no preview:

![After: restrained idle rail](https://github.com/user-attachments/assets/f524ee27-8d97-4518-9291-33a252390640)

Dark-mode hover preview:

![Preview an earlier checkpoint without moving the reader](https://github.com/user-attachments/assets/76585584-b750-451c-8259-612efd3ddde0)

Light-mode keyboard jump:

![Keyboard navigation reveals checkpoint 47](https://github.com/user-attachments/assets/d149fc18-2239-4c19-9944-68ad9c71c517)

Continuous browser proof: scrolling, hover, keyboard jumps, and narrow-pane hiding. The recorder pads the smaller viewport during the narrow-pane portion.

https://github.com/user-attachments/assets/7f9d17af-6eaa-4e7e-b579-9000c00f8a3c

Latest accessibility regression: the pointer is over the preview text while keyboard focus remains in the composer.

![Hover preview remains readable with composer focus preserved](https://github.com/user-attachments/assets/7d3ac3a9-770b-4940-8453-f1122aac20f4)

Continuous real-time recording of the updated scenario (approximately five seconds; includes hover-to-card, Escape, keyboard jumps, and narrow-pane hiding):

https://github.com/user-attachments/assets/7a054192-8b4b-4cc5-a6cb-6e9ea1de64cb

### Saved full-width regression

Before the gutter repair, `100%` message width lets the rail overlap the right-aligned message column:

![Before gutter repair: full-width messages overlap the rail](https://github.com/user-attachments/assets/15a75546-431b-461d-8c95-369b3d187316)

After the repair, the same setting and fixture retain their full-width layout and the rail hides:

![After gutter repair: full-width messages remain unobstructed](https://github.com/user-attachments/assets/bb172115-c94e-4411-a57c-1199eaf50864)

Restoring `48rem` brings back the rail with clear space beside the message column (light theme). Both after screenshots are from the successful nine-test gutter-repair run, before the behavior-preserving landmark-search simplification:

![Default-width messages retain the rail in their spare gutter](https://github.com/user-attachments/assets/d172decb-426f-4305-af1e-d31dee2d7b3d)

### Question-footer regression

The same synthetic question scenario before the lifecycle repair, built from `341777c8900a41463c7a1e39afa7144bac148bbe`: older messages remain visible and the latest-message arrow appears despite no reader input. The existing end-follow assertion fails at 505px.

![Before lifecycle repair: the question leaves the reader above the latest message](https://github.com/user-attachments/assets/4e986295-395e-4dfc-a9ca-db79fe974343)

After the repair, the latest assistant message stays above the question and the unnecessary arrow disappears. The unchanged test passes its end-position, question placement, and absent-arrow assertions.

![After lifecycle repair: the question preserves the latest transcript position](https://github.com/user-attachments/assets/06ecd069-653b-488d-81de-c518ff80f730)

The before capture uses a separate exact-product checkout with only diagnostic screenshot insertion in the test; the after capture is the test's existing screenshot hook. Both images were inspected before attaching.

### Additional verification

- Full `node scripts/check-changed.mjs --base 137698c76560b4b552e848533529c963ffed87fa --timed` gate passed: core-test and UI type checks, formatting, typed lint, UI style lint, keyless i18n verification, unused-export scans, and repository guards. Changed-file lint reported zero warnings and zero errors.
- Directly inspected installed `@tanstack/virtual-core` 3.17.8 source: `observeElementRect` (lines 99–144), the native offset observer (170–230), and memoized range notification (737–758), plus `@tanstack/lit-virtual/src/index.ts` (1–100) for Lit update/lifecycle delegation. Linked proof images and videos were also loaded and inspected locally; the previous hosted review's DNS failure was a reviewer access limitation, not an unverified dependency claim or absent contributor artifact.
- Independent Codex local-candidate review passed with `scoped-clean` and no accepted P0–P2 findings before the behavior-preserving constructor-wiring cleanup. Final committed-branch review also completed `scoped-clean` with no accepted P0–P2 findings for `137698c76560b4b552e848533529c963ffed87fa` → `decebd2a825b4e9da5050eb531f6fe039b7d3262`.
- [CI run 33934856311](https://github.com/openclaw/openclaw/actions/runs/33934856311) completed successfully on `decebd2a825b4e9da5050eb531f6fe039b7d3262`, including all thirteen UI browser shards and the real-Gateway browser lane. Both browser shards that failed on the preceding revision passed.
- No local ClawSweeper review was run. [Hosted ClawSweeper re-review](https://github.com/openclaw/openclaw/pull/138603#issuecomment-5546383138) reviewed this exact head at 01:10:40 UTC on September 5, 2026: no actionable findings, sufficient recording proof, and diamond-lobster ratings (5/6) for proof, patch quality, and overall readiness. Its remaining pre-merge items are the Control UI product decision and explicitly identified reviewer-access limitations, not contributor defects. The PR is ready for maintainer look, not approved for merge.

No production deployment or merge has been performed.
