### PR TITLE
fix: reduce memory spikes during large batch scans

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1894,12 +1894,19 @@ describe("session MCP runtime", () => {
 
       await waitForPredicate(
         () =>
-          runtime.peekCatalog()?.diagnostics?.some((entry) => entry.serverName === "child") ===
-          true,
+          runtime
+            .peekCatalog()
+            ?.diagnostics?.some(
+              (entry) => entry.serverName === "child" && entry.message === "mcp transport closed",
+            ) === true,
         "closed transport to schedule a catalog retry",
         LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
       );
-      await expect(runtime.callTool("child", "slow_tool", {})).rejects.toThrow("is not connected");
+      // Background recovery may still hold the closed session or already have retired it.
+      // Both states must reject while the replacement catalog remains blocked.
+      await expect(runtime.callTool("child", "slow_tool", {})).rejects.toThrow(
+        /^bundle-mcp server "child" is (?:not connected|disconnected: mcp transport closed)$/,
+      );
       await waitForFileTextCount(logPath, "recv tools/list", 2, LIST_TOOLS_TEST_DEADLINE_MS);
       await expect(
         withTestTimeout(

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -2820,7 +2820,10 @@ describe("server-channels auto restart", () => {
     const firstStart = manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
     const secondStart = manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
 
-    await Promise.resolve();
+    await waitForMicrotaskCondition(
+      () => isConfigured.mock.calls.length === 1,
+      "expected the shared account startup preflight",
+    );
     expect(isConfigured).toHaveBeenCalledTimes(1);
     expect(startAccount).not.toHaveBeenCalled();
 
@@ -3582,7 +3585,10 @@ describe("server-channels auto restart", () => {
     const manager = createManager();
 
     const start = manager.startChannel("discord");
-    await flushMicrotasks();
+    await waitForMicrotaskCondition(
+      () => isConfigured.mock.calls.length === 4,
+      "expected first account startup wave",
+    );
 
     expect(isConfigured).toHaveBeenCalledTimes(4);
     expect(maxActive).toBe(4);
@@ -3632,7 +3638,10 @@ describe("server-channels auto restart", () => {
     const manager = createManager({ channelIds });
 
     const start = manager.startChannels();
-    await flushMicrotasks();
+    await waitForMicrotaskCondition(
+      () => releases.length === 4,
+      "expected first channel startup wave",
+    );
 
     expect(releases).toHaveLength(4);
     expect(maxActive).toBe(4);

--- a/src/utils/run-with-concurrency.test.ts
+++ b/src/utils/run-with-concurrency.test.ts
@@ -1,8 +1,143 @@
+import { AsyncLocalStorage, createHook } from "node:async_hooks";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import { runTasksWithConcurrency } from "./run-with-concurrency.js";
 
 describe("runTasksWithConcurrency", () => {
+  it("keeps pending promise allocation bounded when the task list grows", async () => {
+    async function countPendingPromises(taskCount: number): Promise<number> {
+      const limit = 8;
+      const started = createDeferred();
+      const release = createDeferred();
+      let startedCount = 0;
+      let promiseCount = 0;
+      const tasks = Array.from({ length: taskCount }, (_, index) => async () => {
+        if (++startedCount === limit) {
+          started.resolve();
+        }
+        await release.promise;
+        return index;
+      });
+      const scope = new AsyncLocalStorage<boolean>();
+      const hook = createHook({
+        init(_id, type) {
+          if (type === "PROMISE" && scope.getStore()) {
+            promiseCount += 1;
+          }
+        },
+      });
+      let run: ReturnType<typeof runTasksWithConcurrency<number>> | undefined;
+      hook.enable();
+      try {
+        run = scope.run(true, () => runTasksWithConcurrency({ tasks, limit }));
+        await withTestTimeout(started.promise, 1_000, "initial workers did not start");
+        return promiseCount;
+      } finally {
+        hook.disable();
+        scope.disable();
+        release.resolve();
+        const result = await run;
+        expect(result?.results).toEqual(Array.from({ length: taskCount }, (_, index) => index));
+      }
+    }
+
+    const smallQueue = await countPendingPromises(32);
+    const largeQueue = await countPendingPromises(4_096);
+    // Pending async resources follow concurrency, not the number of unstarted tasks.
+    expect(largeQueue).toBeLessThanOrEqual(smallQueue * 2);
+  });
+
+  it.each([false, true])(
+    "isolates task contexts when the error hook throws (throwOnError=%s)",
+    async (throwOnError) => {
+      const scope = new AsyncLocalStorage<string>();
+      async function runCaller(caller: string) {
+        const taskError = new Error("task failed");
+        const hookError = new Error("error hook failed");
+        const completed = createDeferred();
+        const starts: Array<string | undefined> = [];
+        const failures: Array<{ error: unknown; index: number; context: string | undefined }> = [];
+        let resumedContext: string | undefined;
+        const run = scope.run(caller, () =>
+          runTasksWithConcurrency({
+            tasks: [
+              async () => {
+                starts.push(scope.getStore());
+                scope.enterWith(`${caller}/task`);
+                await Promise.resolve();
+                resumedContext = scope.getStore();
+                throw taskError;
+              },
+              async () => {
+                starts.push(scope.getStore());
+                completed.resolve();
+                return 20;
+              },
+            ],
+            limit: 1,
+            throwOnError,
+            onTaskError: (error, index) => {
+              failures.push({ error, index, context: scope.getStore() });
+              scope.enterWith(`${caller}/hook`);
+              throw hookError;
+            },
+          }),
+        );
+        const observed = await scope.run(`${caller}/observer`, () =>
+          run.then(
+            (result) => ({ result, error: undefined, context: scope.getStore() }),
+            (error: unknown) => ({ result: undefined, error, context: scope.getStore() }),
+          ),
+        );
+        await withTestTimeout(completed.promise, 1_000, "queued task did not finish after error");
+        expect(starts).toEqual([caller, caller]);
+        expect(resumedContext).toBe(`${caller}/task`);
+        expect(failures).toEqual([{ error: taskError, index: 0, context: `${caller}/task` }]);
+        expect(observed.context).toBe(`${caller}/observer`);
+        if (throwOnError) {
+          expect(observed.error).toBe(hookError);
+          expect(observed.result).toBeUndefined();
+        } else {
+          expect(observed.error).toBeUndefined();
+          expect(observed.result).toEqual({
+            results: [undefined, 20],
+            firstError: taskError,
+            hasError: true,
+          });
+        }
+      }
+      try {
+        await Promise.all([runCaller("first"), runCaller("second")]);
+      } finally {
+        scope.disable();
+      }
+    },
+  );
+
+  it("retains the submitted factories when the caller changes its task array", async () => {
+    const started = createDeferred();
+    const release = createDeferred();
+    const tasks = [
+      async () => {
+        started.resolve();
+        await release.promise;
+        return 10;
+      },
+      async () => 20,
+    ];
+    const run = runTasksWithConcurrency({ tasks, limit: 1 });
+    try {
+      await withTestTimeout(started.promise, 1_000, "initial task did not start");
+      tasks[1] = async () => 30;
+      tasks.push(async () => 40);
+      release.resolve();
+      expect((await run).results).toEqual([10, 20]);
+    } finally {
+      release.resolve();
+      await run;
+    }
+  });
+
   it("preserves task order with bounded worker count", async () => {
     let running = 0;
     let peak = 0;

--- a/src/utils/run-with-concurrency.ts
+++ b/src/utils/run-with-concurrency.ts
@@ -1,4 +1,5 @@
-import pLimit from "p-limit";
+import { AsyncLocalStorage } from "node:async_hooks";
+import pMap from "p-map";
 
 /** Controls whether the worker pool keeps scheduling after a task failure. */
 export type ConcurrencyErrorMode = "continue" | "stop";
@@ -43,10 +44,10 @@ export async function runTasksWithConcurrency<T>(
   const results: T[] = Array.from({ length: tasks.length });
   let firstError: unknown = undefined;
   let hasError = false;
-  const limiter = pLimit(resolvedLimit);
-
-  const runs = tasks.map((task, index) =>
-    limiter(async () => {
+  // Admit tasks lazily instead of allocating a queued promise for every input.
+  // Caller rejection is separate from mapper completion so continue mode still drains.
+  return new Promise((resolve, reject) => {
+    const runOne = async (task: () => Promise<T>, index: number) => {
       if (errorMode === "stop" && hasError) {
         return;
       }
@@ -57,18 +58,24 @@ export async function runTasksWithConcurrency<T>(
           firstError = error;
           hasError = true;
         }
-        onTaskError?.(error, index);
+        try {
+          onTaskError?.(error, index);
+        } catch (callbackError) {
+          error = callbackError;
+        }
         if (throwOnError) {
-          throw error;
+          reject(error);
         }
       }
-    }),
-  );
-
-  if (throwOnError) {
-    await Promise.all(runs);
-  } else {
-    await Promise.allSettled(runs);
-  }
-  return { results, firstError, hasError };
+    };
+    // Capture the caller context, but run each task in a fresh continuation so
+    // enterWith cannot mutate the shared bound resource on Node 22.
+    const mapper = AsyncLocalStorage.bind((task: () => Promise<T>, index: number) =>
+      Promise.resolve().then(() => runOne(task, index)),
+    );
+    void pMap(tasks.slice(), mapper, { concurrency: resolvedLimit }).then(
+      () => resolve({ results, firstError, hasError }),
+      reject,
+    );
+  });
 }

--- a/src/utils/run-with-concurrency.ts
+++ b/src/utils/run-with-concurrency.ts
@@ -58,13 +58,15 @@ export async function runTasksWithConcurrency<T>(
           firstError = error;
           hasError = true;
         }
+        let rejectionError = error;
         try {
           onTaskError?.(error, index);
         } catch (callbackError) {
-          error = callbackError;
+          rejectionError = callbackError;
         }
         if (throwOnError) {
-          reject(error);
+          // oxlint-disable-next-line typescript/prefer-promise-reject-errors -- Preserve the public runner's original task or error-hook rejection value.
+          reject(rejectionError);
         }
       }
     };

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -259,6 +259,8 @@ describe("production lint suppressions", () => {
         "src/tasks/task-registry.sqlite.shared.ts|typescript/no-unnecessary-type-parameters|1",
         "src/test-utils/vitest-mock-fn.ts|typescript/no-explicit-any|1",
         "src/utils.ts|typescript/no-unnecessary-type-parameters|1",
+        // The public runner preserves task and error-hook rejection values, including non-Errors.
+        "src/utils/run-with-concurrency.ts|typescript/prefer-promise-reject-errors|1",
         // oxlint misreads CanvasRenderingContext2D.fill(path) as Array.fill.
         "ui/src/components/mascot-canvas.ts|unicorn/no-array-fill-with-reference-type|1",
       ]),

--- a/test/scripts/upstream-repository-advisories.test.ts
+++ b/test/scripts/upstream-repository-advisories.test.ts
@@ -27,7 +27,9 @@ function advisory(range: unknown = "< 2.0.0", fields: Record<string, unknown> = 
     vulnerabilities: [vulnerability(range)],
     ...fields,
   };
-  if (!publishedRows.has(row.ghsa_id)) publishedRows.set(row.ghsa_id, row);
+  if (!publishedRows.has(row.ghsa_id)) {
+    publishedRows.set(row.ghsa_id, row);
+  }
   return row;
 }
 
@@ -46,7 +48,7 @@ function createSourceFetch(
 ) {
   const calls: Array<{ url: URL; init: RequestInit | undefined }> = [];
   const fetchImpl: typeof fetch = async (input, init) => {
-    const url = new URL(String(input));
+    const url = new URL(input instanceof Request ? input.url : input);
     calls.push({ url, init });
     if (url.origin === REGISTRY) {
       return handlers.manifest ? handlers.manifest(url, init) : manifest(url);
@@ -55,7 +57,9 @@ function createSourceFetch(
       throw new Error(`Unexpected request origin: ${url.origin}`);
     }
     if (url.pathname.startsWith("/advisories/")) {
-      if (handlers.reviewed) return handlers.reviewed(url, init);
+      if (handlers.reviewed) {
+        return handlers.reviewed(url, init);
+      }
       const row = publishedRows.get(url.pathname.split("/").at(-1) ?? "");
       return Response.json({
         ...row,
@@ -730,7 +734,9 @@ describe("published upstream repository advisories", () => {
       );
       active += 1;
       peak = Math.max(peak, active);
-      if (active === 4) wave.started.resolve();
+      if (active === 4) {
+        wave.started.resolve();
+      }
       try {
         await wave.release.promise;
         return await source.fetchImpl(input, init);
@@ -762,7 +768,9 @@ describe("published upstream repository advisories", () => {
       expect(report.coverage.status).toBe("checked");
       expect(report.coverage.checkedRepositories).toBe(8);
     } finally {
-      for (const wave of waves) wave.release.resolve();
+      for (const wave of waves) {
+        wave.release.resolve();
+      }
       await scanning;
     }
   });

--- a/test/scripts/upstream-repository-advisories.test.ts
+++ b/test/scripts/upstream-repository-advisories.test.ts
@@ -1,6 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchPublishedRepositoryAdvisories } from "../../scripts/lib/upstream-repository-advisories.mts";
+import { createDeferred, withTestTimeout } from "../helpers/promise.js";
 
 const REGISTRY = "https://registry.npmjs.org";
 const REPOSITORY = "fixture/packages";
@@ -713,14 +714,25 @@ describe("published upstream repository advisories", () => {
   it("keeps metadata and repository requests within four concurrent operations", async () => {
     let active = 0;
     let peak = 0;
+    const waves = [REGISTRY, "https://api.github.com"].map((origin) => ({
+      origin,
+      started: createDeferred(),
+      release: createDeferred(),
+    }));
     const source = createSourceFetch({
       manifest: (url) => manifest(url, `https://github.com/fixture/${url.pathname.split("/")[1]}`),
     });
     const fetchImpl: typeof fetch = async (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      const wave = expectDefined(
+        waves.find(({ origin }) => origin === url.origin),
+        "request phase",
+      );
       active += 1;
       peak = Math.max(peak, active);
+      if (active === 4) wave.started.resolve();
       try {
-        await Promise.resolve();
+        await wave.release.promise;
         return await source.fetchImpl(input, init);
       } finally {
         active -= 1;
@@ -729,11 +741,30 @@ describe("published upstream repository advisories", () => {
     const payload = Object.fromEntries(
       Array.from({ length: 8 }, (_, index) => [`package-${index}`, ["1.0.0"]]),
     );
-    const report = await scan(fetchImpl, payload);
-    expect(peak).toBe(4);
-    expect(active).toBe(0);
-    expect(report.coverage.status).toBe("checked");
-    expect(report.coverage.checkedRepositories).toBe(8);
+    const scanning = scan(fetchImpl, payload);
+    try {
+      for (const wave of waves) {
+        await withTestTimeout(
+          wave.started.promise,
+          1_000,
+          `expected four requests to ${wave.origin}`,
+        );
+        // Let admission finish while requests stay blocked so excess fanout is observable.
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(active).toBe(4);
+        wave.release.resolve();
+      }
+      const report = await scanning;
+      expect(peak).toBe(4);
+      expect(active).toBe(0);
+      expect(report.coverage.status).toBe("checked");
+      expect(report.coverage.checkedRepositories).toBe(8);
+    } finally {
+      for (const wave of waves) wave.release.resolve();
+      await scanning;
+    }
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where large session inventories cause avoidable memory and CPU spikes during disk accounting. The concurrency limit bounded active filesystem work, but the shared task runner still allocated a queued promise graph for every file before processing began.

Related: #138485.

## Why This Change Was Made

Use the existing `p-map` dependency to admit work lazily at the shared concurrency owner. Preserve ordered results, the submitted factory list, stop/continue scheduling, immediate rejection, recorded error state, and synchronous error-hook behavior. Each admitted task retains the caller's async context; a fresh promise continuation also preserves this boundary on Node 22.

This removes the eager `p-limit` queue and its per-input promise graph. Production changes are +25/-16 lines (net +9); the additional context boundary and separate caller settlement preserve shipped SDK behavior. Tests are +207/-15 lines (net +192). No dependency, configuration, filesystem canonicalization, retention, schema, or protocol changes.

## User Impact

Large batches create fewer pending async resources and less initial heap pressure. Session accounting still reports the same physical byte totals, and callers retain their existing failure and cleanup behavior.

## Evidence

- The regression fails before the fix: 32 blocked tasks create 211 promises, while 4,096 create 16,467 at the same concurrency of eight. The corrected queue stays bounded.
- Nine focused contract tests pass on Node 22.22.3 and 26.8.1. An independent matrix covers 16 policy/concurrency/error-hook combinations under two parallel caller contexts on each runtime.
- A synthetic 176,873-task workload reduced initial blocked heap growth from 172.9 MB to 3.0 MB and synchronous admission from 150.1 ms to 4.7 ms. Both runs completed every task with a maximum of eight active tasks. These are isolated process measurements, not end-to-end Gateway latency.
- The real installed disk-accounting export was run against an unchanged directory containing 246,988 regular files, in two isolated Linux Node 26 processes. The candidate replaced only the frozen helper in its own process. All four byte counters and directory/prompt/database metadata matched. Immediate heap growth fell 377.1→187.7 MB; maximum 10 ms timer lateness fell 436.8→148.8 ms; process CPU fell 10.60→9.98 seconds. Total sampled allocation, including collected objects, fell only 1.6%. These are one-pass instrumented observations, not production Gateway recovery claims. No persistent database was opened or maintenance invoked; the live Gateway and installed modules were preserved.
- All 193 sibling tests pass across session disk budgets, archive eviction, worker artifact cleanup, model-runtime lifecycle, usage caching, and secret resolution. Scoped lint/format pass. The full local changed gate stopped on the shared dependency donor's existing `fs-safe` 0.7.0 versus the checkout's required 0.7.2; exact-head CI uses pinned dependencies.
- The first CI run exposed two helper lint errors and five tests coupled to promise-tick timing or one transient MCP disconnect state. The helper retains arbitrary rejection values through a documented lint exception. Tests now observe blocked startup/request waves and both source-defined MCP recovery states while retaining exact fanout, healthy-sibling, reconnect, PID, and disposal assertions. All 319 tests in those four complete suites pass; the final 75-test advisory rerun and focused type-aware lint pass as well.
- Direct inspection of the pinned `p-map` 7.0.6 source confirms why a separate caller promise is needed: its default error mode stops admission, while `stopOnError: false` waits for the batch and aggregates failures. Neither alone preserves this SDK’s immediate-rejection plus continued-drain contract. The fresh continuation also avoids mutable bound-context reuse on Node 22.
- A later CI run caught one failing test: the missing explicit registration for the intentional rejection-value lint exception. The exact file/rule/count is now documented in the suppression allowlist; its strict equality assertion remains unchanged. The original failure reproduces locally, and all four suppression-audit tests plus scoped type-aware lint pass after the two-line test fix.
- Independent Codex review through P2 found no actionable defects.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33926294879) passed for `949b6d142c58f00fb402931b81d850901059702c`: 108 successful jobs and 17 skips. Both ClawSweeper rank-up items are addressed: pinned dependency source inspection and green exact-head checks.

The eager queue was introduced in #106002 (113675717436a9aeaa905867adb19ca75c71c1bc). The immediate-rejection contract added in #126119 is retained. The live profile also contains substantial filesystem work, so this repair does not claim to eliminate every source of periodic CPU use.
