### PR TITLE
perf(media): bound directive prefix casing

### DIFF
--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -444,8 +444,8 @@ export function splitMediaFromOutput(
       continue;
     }
 
-    const trimmedStart = line.trimStart();
-    if (!extractMediaDirectives || !trimmedStart.toUpperCase().startsWith("MEDIA:")) {
+    const linePrefix = line.trimStart().slice(0, "MEDIA:".length);
+    if (!extractMediaDirectives || !linePrefix.toUpperCase().startsWith("MEDIA:")) {
       const markdownImageResult = extractMarkdownImages
         ? collectMarkdownImageSegments({
             line,


### PR DESCRIPTION
## What Problem This Solves

Once media parsing is active, the directive classifier uppercased each complete line merely to recognize its six-character `MEDIA:` prefix. Long prose or attachment lines therefore created unnecessary uppercase strings.

Production LOC: +2/-2 (net 0). Tests and docs: unchanged.

## Why This Change Was Made

Inspect only the first six UTF-16 units after leading whitespace. Keep the existing uppercase comparison, including its Unicode casing behavior, and pass the original line to media extraction. This changes the classifier at its owner without adding a cache or another parsing path.

## User Impact

Replies containing media syntax do less casing work on long lines. Extracted attachments, visible text, Markdown images, fenced code, and audio directives retain their existing behavior.

## Evidence

A before/after diagnostic exercised the actual parser and matched complete outputs for 114 cases. With a 1 MiB ASCII line plus a directive, uppercase input fell from 1,048,611 to 12 UTF-16 units; each individual classification now examines at most six. Unicode, whitespace, paths, Markdown, audio, and option combinations were included. These are measured operation counts, not Gateway RSS or latency estimates.

257 existing tests passed across `src/media/parse.test.ts`, `src/auto-reply/reply/reply-utils.test.ts`, and `src/gateway/chat-display-projection.media.test.ts`. The complete changed-file gate passed. Independent managed Codex review through P2 found no actionable issues. Existing behavior coverage was reused; no allocation-count test or test seam was added.
