### PR TITLE
perf(skills): reuse catalog rendering for optional remote notes

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -744,7 +744,7 @@ prompt. The cost is deterministic and scales linearly per skill:
 
 If the rendered block would exceed the configured prompt budget
 (`skills.limits.maxSkillsPromptChars`), OpenClaw first preserves as many skill
-identities (name, location, and version) as the description-free compact format
+identities (name and location) as the description-free compact format
 can fit. It then uses any remaining budget for shortened descriptions. If no
 description budget remains, descriptions are omitted. The prompt includes a
 note pointing at `openclaw skills check` whenever compact formatting or list

--- a/src/skills/loading/skill-prompt-limits.ts
+++ b/src/skills/loading/skill-prompt-limits.ts
@@ -34,7 +34,6 @@ function buildSkillsLimitNote(params: {
 }
 
 function buildRenderedSkillsPrompt(params: {
-  remoteNote?: string;
   skills: Skill[];
   total: number;
   format: SkillsPromptFormat;
@@ -58,7 +57,7 @@ function buildRenderedSkillsPrompt(params: {
           descriptionMaxChars: params.format.descriptionMaxChars,
         })
       : formatSkillsForPromptCore(params.skills);
-  return [params.remoteNote, limitNote, catalog].filter(Boolean).join("\n");
+  return [limitNote, catalog].filter(Boolean).join("\n");
 }
 
 type SkillsPromptParams = {
@@ -93,20 +92,15 @@ export function prepareSkillsForPrompt(params: SkillsPromptParams): {
     format: SkillsPromptFormat,
     includeLimitNote = true,
   ): string | undefined => {
-    const remoteNotes = params.remoteNote ? [params.remoteNote, undefined] : [undefined];
-    for (const remoteNote of remoteNotes) {
-      const prompt = buildRenderedSkillsPrompt({
-        remoteNote,
-        skills,
-        total,
-        format,
-        includeLimitNote,
-      });
-      if (prompt.length <= maxSkillsPromptChars) {
-        return prompt;
-      }
+    // Reuse the catalog and limit notice when the optional remote note does not fit.
+    const prompt = buildRenderedSkillsPrompt({ skills, total, format, includeLimitNote });
+    if (
+      params.remoteNote &&
+      params.remoteNote.length + prompt.length + (prompt ? 1 : 0) <= maxSkillsPromptChars
+    ) {
+      return prompt ? `${params.remoteNote}\n${prompt}` : params.remoteNote;
     }
-    return undefined;
+    return prompt.length <= maxSkillsPromptChars ? prompt : undefined;
   };
 
   const fitsCompact = (

--- a/src/skills/loading/workspace-skill-prompt.test.ts
+++ b/src/skills/loading/workspace-skill-prompt.test.ts
@@ -230,29 +230,52 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     expect(prompt).not.toContain("REMOTE_NOTE_");
   });
 
-  it("preserves the exact full-catalog bytes when a remote note fits", () => {
-    const skill = makeSkill("weather", "Get weather data");
-    const remoteNote = "Remote node skills are available.";
-    const catalog = formatSkillsForPromptCore([skill]);
-    const expected = [remoteNote, catalog].join("\n");
-    const prompt = buildWorkspaceSkillsPrompt("/fake", {
-      entries: [makeEntry(skill)],
-      config: {
-        skills: { limits: { maxSkillsPromptChars: expected.length } },
-      } satisfies OpenClawConfig,
-      eligibility: {
-        remote: {
-          platforms: ["linux"],
-          hasBin: () => false,
-          hasAnyBin: () => false,
-          note: remoteNote,
-        },
-      },
-    });
+  it.each(["full", "compact", "count-limited", "empty"])(
+    "preserves exact %s catalog bytes at the optional remote-note boundary",
+    (format) => {
+      const skill = makeSkill(
+        "weather",
+        format === "compact" ? "A".repeat(800) : "Get weather data",
+      );
+      const skills = format === "empty" ? [] : [skill];
+      const remoteNote = "Remote node skills are available.";
+      const notice =
+        format === "compact"
+          ? COMPACT_SHORTENED_NOTICE
+          : format === "count-limited"
+            ? "⚠️ Skills truncated: included 1 of 2. Run `openclaw skills check` to audit."
+            : "";
+      const catalog =
+        format === "compact" ? formatSkillsCompact(skills) : formatSkillsForPromptCore(skills);
+      const withoutNote = [notice, catalog].filter(Boolean).join("\n");
+      const withNote = [remoteNote, withoutNote].filter(Boolean).join("\n");
+      const entries = (format === "count-limited" ? [...skills, makeSkill("zoo")] : skills).map(
+        makeEntry,
+      );
 
-    expect(prompt).toBe(expected);
-    expect(prompt.length).toBeLessThanOrEqual(expected.length);
-  });
+      for (const delta of [-1, 0, 1]) {
+        const prompt = buildWorkspaceSkillsPrompt("/fake", {
+          entries,
+          config: {
+            skills: {
+              limits: { maxSkillsInPrompt: 1, maxSkillsPromptChars: withNote.length + delta },
+            },
+          } satisfies OpenClawConfig,
+          eligibility: {
+            remote: {
+              platforms: ["linux"],
+              hasBin: () => false,
+              hasAnyBin: () => false,
+              note: remoteNote,
+            },
+          },
+        });
+
+        expect(prompt).toBe(delta < 0 ? withoutNote : withNote);
+        expect(prompt.length).toBeLessThanOrEqual(withNote.length + delta);
+      }
+    },
+  );
 
   it("budgets the final rendered prompt including limit notices", () => {
     const skills = Array.from({ length: 24 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(160)));


### PR DESCRIPTION
## What Problem This Solves

When an optional remote-node note exceeded the skill prompt budget, the limit checker rendered the same catalog and notice twice in each trial. Compact-format searches repeated this work across multiple candidate budgets.

Production LOC: +9/-15 (net -6). Tests: +45/-22 (net +23). Docs: +1/-1 (net 0).

## Why This Change Was Made

Render the catalog and limit notice once, then admit the optional note using its exact combined length, including the conditional newline. Preserve catalog ordering, selected skill objects, formatting thresholds, and empty-catalog behavior. Extend the existing note-boundary test and correct the nearby documentation's obsolete claim that compact catalogs include a version field.

## User Impact

Skill prompt construction avoids duplicate rendering while producing the same prompt bytes and respecting the same limits.

## Evidence

A differential diagnostic matched exact prompt bytes and selected skill objects across 301,620 cases. With a normal 97-character remote note, measured skill-entry renders fell from 40 to 20 for the full-format workload and from 2,520 to 1,560 for the compact workload. These counts establish reduced rendering work, not Gateway latency or RSS savings.

65 tests passed across the workspace prompt, skill formatter, session, runtime resource, and Code Mode suites. The existing boundary test now checks full, compact, count-limited, and empty catalogs one character below, exactly at, and one character above note admission. The complete changed-file gate and docs listing passed. Independent managed Codex review through P2 found no actionable issues.
