### PR TITLE
perf(agents): bound streamed paragraph separator checks

### DIFF
--- a/src/agents/cli-output-records.ts
+++ b/src/agents/cli-output-records.ts
@@ -606,8 +606,8 @@ export function missingMessageBoundarySeparator(previousText: string, nextDelta:
   if (!previousText) {
     return "";
   }
-  const trailing = previousText.match(/\n*$/u)?.[0].length ?? 0;
-  const leading = nextDelta.match(/^\n*/u)?.[0].length ?? 0;
+  const trailing = previousText.slice(-2).match(/\n*$/u)?.[0].length ?? 0;
+  const leading = nextDelta.slice(0, 2).match(/^\n*/u)?.[0].length ?? 0;
   return "\n".repeat(Math.max(0, 2 - trailing - leading));
 }
 
@@ -681,6 +681,3 @@ export function readGeminiCliStreamJsonError(parsed: Record<string, unknown>): s
   }
   return undefined;
 }
-
-// A possible leading block stays buffered until visible prose or the message
-// boundary proves where private reasoning ends. Later tags remain literal.


### PR DESCRIPTION
## What Problem This Solves

Claude CLI message-boundary handling supplied the entire accumulated reply and incoming delta to newline-counting regexes. The separator decision only needs to know whether each boundary already has zero, one, or at least two newlines.

Production LOC: +2/-5 (net -3). Tests and docs: unchanged.

## Why This Change Was Made

Apply the existing regexes to the final two characters of the previous text and first two characters of the next delta. Preserve the separator formula and empty-text handling. Remove an orphaned comment left behind when its function moved to another module.

## User Impact

Long Claude CLI replies require bounded separator inspection while retaining identical streamed text, paragraph breaks, and terminal output. Codex and Gemini parsing do not call this helper.

## Evidence

Before/after diagnostics matched 2,025 direct boundary cases, 50 streaming/snapshot cases, and large streamed outputs. For the 512-message workload, 1,022 regex calls received 1,076,091,394 total characters before the change and 2,044 afterward, with a two-character maximum per call. This measures regex input size, not exact CPU time, allocation, or Gateway RSS.

86 existing tests passed across the CLI stream, snapshot, framing, and JSONL suites. The complete changed-file gate passed on the functional change; the subsequent orphan-comment removal passed formatting and fresh independent managed Codex review through P2 with no actionable issues. Official Codex JSONL event production and OpenClaw's separate Codex parser path were inspected.

Related work: #121567 proposes a broader Claude commentary behavior change that removes this helper. This PR preserves current behavior and would become unnecessary if that change lands first.
