### PR TITLE
perf(agents): size only the final output line

### DIFF
--- a/src/agents/sessions/tools/output-accumulator.test.ts
+++ b/src/agents/sessions/tools/output-accumulator.test.ts
@@ -88,6 +88,8 @@ describe("OutputAccumulator", () => {
       ["xy\n", 2, 2],
       ["\n", 0, 3],
       ["z", 1, 4],
+      ["longer\n界\n🙂\n", 4, 6],
+      ["one\n\n", 0, 8],
     ] as const) {
       accumulator.append(Buffer.from(text), "stdout");
       expect(accumulator.getLastLineBytes()).toBe(lastLineBytes);

--- a/src/agents/sessions/tools/output-accumulator.ts
+++ b/src/agents/sessions/tools/output-accumulator.ts
@@ -39,10 +39,6 @@ interface OutputSnapshot {
   fullOutputPath?: string;
 }
 
-function byteLength(text: string): number {
-  return Buffer.byteLength(text, "utf-8");
-}
-
 /**
  * Incrementally tracks streaming output with bounded memory.
  *
@@ -192,27 +188,28 @@ export class OutputAccumulator {
       return;
     }
 
-    const bytes = byteLength(text);
+    const bytes = Buffer.byteLength(text);
     this.totalDecodedBytes += bytes;
     this.tailText += text;
     this.tailBytes += bytes;
     if (this.tailBytes > this.maxRollingBytes * 2) {
       this.tailText = truncateUtf8Suffix(this.tailText, this.maxRollingBytes);
-      this.tailBytes = byteLength(this.tailText);
+      this.tailBytes = Buffer.byteLength(this.tailText);
     }
 
     // A terminator closes the last real line; its size still belongs in the footer.
-    for (let start = 0; start < text.length;) {
-      const newline = text.indexOf("\n", start);
-      const end = newline === -1 ? text.length : newline;
-      this.lastLineBytes =
-        (this.hasOpenLine ? this.lastLineBytes : 0) + byteLength(text.slice(start, end));
-      this.hasOpenLine = newline === -1;
-      if (!this.hasOpenLine) {
-        this.completedLines++;
+    const end = text.endsWith("\n") ? text.length - 1 : text.length;
+    let start = 0;
+    for (let index = text.indexOf("\n"); index !== -1; index = text.indexOf("\n", index + 1)) {
+      this.completedLines++;
+      if (index < end) {
+        start = index + 1;
       }
-      start = end + 1;
     }
+    this.lastLineBytes =
+      (start === 0 && this.hasOpenLine ? this.lastLineBytes : 0) +
+      (start === 0 && end === text.length ? bytes : Buffer.byteLength(text.slice(start, end)));
+    this.hasOpenLine = end === text.length;
     this.totalLines = this.completedLines + (this.hasOpenLine ? 1 : 0);
   }
 


### PR DESCRIPTION
## What Problem This Solves

The output accumulator measured UTF-8 bytes for every completed line even though only the final line's size survives each appended chunk. Large multiline tool output repeated this discarded work.

Production LOC: +12/-15 (net -3). Tests: +2/-0 (net +2). Docs: unchanged.

## Why This Change Was Made

Count every newline while measuring only the final real-line fragment. Carry the prior byte count only when continuing the same open line, preserve the size of a newline-terminated final line, and reuse the whole-chunk size when no newline exists. Remove the trivial UTF-8 sizing wrapper.

## User Impact

Multiline tool output performs fewer byte-length calculations. Decoding, output tails, truncation footers, full-output spill files, and cleanup retain their existing behavior.

## Evidence

A before/after diagnostic matched 28 actual-accumulator controls and a real local Bash run, including per-append counts, final-line sizes, retained tails, and full spill hashes. The Bash footer still reported 5,001 lines and the final 50.0 KB of a 244.2 KB line. For 12,000 ASCII lines in one chunk, byte-length calls fell from 12,001 to 2; across 40 chunks they fell from 12,040 to 80. Unicode and open-line cases also matched. These are work counts, not retained-memory or Gateway latency claims.

44 tests passed across `src/agents/sessions/tools/output-accumulator.test.ts`, `src/agents/sessions/tools/bash.test.ts`, and `src/agents/sessions/bash-executor.test.ts`. Two rows extend the existing line-lifetime table. The complete changed-file gate passed, and independent managed Codex review through P2 found no actionable issues.
