### PR TITLE
perf(http): avoid copying rejected response bodies

### DIFF
--- a/src/infra/http-response-body.ts
+++ b/src/infra/http-response-body.ts
@@ -15,7 +15,7 @@ export async function cancelUnreadResponseBody(response: Response | undefined): 
 }
 
 type ReadResponsePrefixResult = {
-  buffer: Buffer;
+  materializeBuffer: () => Buffer;
   size: number;
   truncated: boolean;
 };
@@ -77,8 +77,9 @@ async function readResponsePrefixFromReader(
   }
 
   return {
+    // Full-body readers reject overflow before allocating a contiguous copy.
     // MiB limits can yield fractional bytes; retained slices contain only whole bytes.
-    buffer: Buffer.concat(chunks, Math.floor(Math.min(size, maxBytes))),
+    materializeBuffer: () => Buffer.concat(chunks, Math.floor(Math.min(size, maxBytes))),
     size,
     truncated,
   };
@@ -107,14 +108,12 @@ async function readResponsePrefix(
       cancel: async (error) => await body?.cancel(error),
       read: async () => {
         const fallback = Buffer.from(await response.arrayBuffer());
-        if (fallback.length > maxBytes) {
-          return {
-            buffer: fallback.subarray(0, maxBytes),
-            size: fallback.length,
-            truncated: true,
-          };
-        }
-        return { buffer: fallback, size: fallback.length, truncated: false };
+        const truncated = fallback.length > maxBytes;
+        return {
+          materializeBuffer: () => (truncated ? fallback.subarray(0, maxBytes) : fallback),
+          size: fallback.length,
+          truncated,
+        };
       },
     });
   }
@@ -145,7 +144,7 @@ export async function readResponseTextPrefix(
     stopAtLimit: true,
   });
   return {
-    text: decodeTextPrefix(prefix.buffer, { truncated: prefix.truncated }),
+    text: decodeTextPrefix(prefix.materializeBuffer(), { truncated: prefix.truncated }),
     size: prefix.size,
     truncated: prefix.truncated,
   };
@@ -171,7 +170,7 @@ export async function readResponseWithLimit(
       ? onOverflow({ size: prefix.size, maxBytes, res: response })
       : new Error(`Content too large: ${prefix.size} bytes (limit: ${maxBytes} bytes)`);
   }
-  return prefix.buffer;
+  return prefix.materializeBuffer();
 }
 
 /** Reads a small collapsed text prefix from a response body for diagnostics/errors. */


### PR DESCRIPTION
## What Problem This Solves

Full-body HTTP readers copied the retained response prefix before rejecting an oversized download. With a 20 MiB limit, rejection therefore allocated an extra 20 MiB buffer that the caller could never use.

Production LOC: +11/-12 (net -1). Tests and docs: unchanged.

## Why This Change Was Made

The private prefix reader now defers contiguous-buffer materialization until its consumer needs the bytes. Full-body readers reject overflow first; text-prefix readers still materialize and decode the bounded prefix. The fallback continues to share the original ArrayBuffer. Public option snapshots, cancellation, deadlines, fractional byte limits, and error callbacks retain their existing behavior.

## User Impact

Oversized streamed downloads avoid a discarded buffer allocation. Successful downloads, diagnostic snippets, configured limits, and the plugin SDK response-reader API remain unchanged.

## Evidence

A before/after probe exercised the actual reader with a stream exceeding a 20 MiB cap. The rejected path concatenated 20,971,520 bytes before the change and zero afterward. The probe also verified the custom error and response identities, cancellation and reader release, successful multichunk reads, UTF-8 and fractional prefixes, fallback backing identity, and collapsed snippets. Corresponding behavior hashes matched. The probe imported the public response-reader API and checked that its exports were the same functions as the current extracted response-body owner. This measures the avoided concatenation; it is not a whole-Gateway RSS claim.

66 existing tests passed across these suites:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/infra/http-body.response.test.ts \
  src/infra/http-body.test.ts \
  src/infra/http-error-body.test.ts
node scripts/check-changed.mjs -- src/infra/http-response-body.ts
```

The complete changed-file gate passed. Independent managed Codex review through P2 found no actionable issues. Existing behavior tests cover both response readers and timeout/error siblings; no permanent allocation-count test or test seam was added.
