### PR TITLE
test(tts): wait for voice requests before measuring deadlines

### DIFF
--- a/extensions/azure-speech/voices-timeout.test.ts
+++ b/extensions/azure-speech/voices-timeout.test.ts
@@ -3,7 +3,6 @@
 // the real fetch abort path without depending on Azure latency.
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
-import { clearTimeout as clearRealTimeout, setTimeout as setRealTimeout } from "node:timers";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { listAzureSpeechVoices } from "./tts.js";
 
@@ -35,62 +34,56 @@ describe("listAzureSpeechVoices timeout", () => {
     vi.unstubAllGlobals();
   });
 
-  it(
-    "aborts a hanging voice list request within the configured timeout",
-    { timeout: 2_000 },
-    async () => {
-      let requestCount = 0;
-      let notifyRequest = () => {};
-      const requestReceived = new Promise<void>((resolve) => {
-        notifyRequest = resolve;
-      });
-      const server = createServer((_request, _response) => {
-        requestCount += 1;
-        notifyRequest();
-      });
+  it("aborts a hanging voice list request within the configured timeout", async () => {
+    let requestCount = 0;
+    let requestSignal: AbortSignal | undefined;
+    const cleanupController = new AbortController();
+    let notifyRequest = () => {};
+    const requestReceived = new Promise<void>((resolve) => {
+      notifyRequest = resolve;
+    });
+    const server = createServer((_request, _response) => {
+      requestCount += 1;
+      notifyRequest();
+    });
 
-      const port = await listenLocal(server);
+    const port = await listenLocal(server);
 
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-          return await originalFetch(
-            `http://127.0.0.1:${port}/cognitiveservices/voices/list`,
-            init,
-          );
-        }) as unknown as typeof globalThis.fetch,
-      );
-
-      const startedAt = Date.now();
-      let watchdog: ReturnType<typeof setRealTimeout> | undefined;
-
-      try {
-        vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
-        const watchdogPromise = new Promise<never>((_, reject) => {
-          watchdog = setRealTimeout(() => reject(new Error("voices list did not time out")), 1_000);
-        });
-        const request = Promise.race([
-          listAzureSpeechVoices({
-            apiKey: "not-a-real",
-            baseUrl: "https://custom.example.com",
-            timeoutMs: 100,
-          }),
-          watchdogPromise,
-        ]);
-        const rejection = expect(request).rejects.toThrow(/aborted|timeout|timed out/i);
-
-        await Promise.race([requestReceived, watchdogPromise]);
-        expect(requestCount).toBe(1);
-        await vi.advanceTimersByTimeAsync(100);
-        await rejection;
-        expect(Date.now() - startedAt).toBeLessThan(1_000);
-      } finally {
-        vi.useRealTimers();
-        if (watchdog) {
-          clearRealTimeout(watchdog);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        requestSignal = init?.signal ?? undefined;
+        if (!requestSignal) {
+          throw new Error("guarded fetch did not pass an abort signal");
         }
-        await closeServer(server);
-      }
-    },
-  );
+        return await originalFetch(`http://127.0.0.1:${port}/cognitiveservices/voices/list`, {
+          ...init,
+          signal: AbortSignal.any([requestSignal, cleanupController.signal]),
+        });
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const request = listAzureSpeechVoices({
+      apiKey: "not-a-real",
+      baseUrl: "https://custom.example.com",
+      timeoutMs: 100,
+    });
+    try {
+      // Measure the request deadline after cold SDK imports and socket setup finish.
+      await Promise.race([requestReceived, request]);
+      expect(requestCount).toBe(1);
+      await vi.advanceTimersByTimeAsync(99);
+      expect(requestSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(requestSignal?.aborted).toBe(true);
+      await expect(request).rejects.toThrow(/aborted|timeout|timed out/i);
+    } finally {
+      // Abort independently of the production deadline, then settle before global/socket cleanup.
+      cleanupController.abort();
+      await request.catch(() => undefined);
+      vi.useRealTimers();
+      await closeServer(server);
+    }
+  });
 });

--- a/extensions/inworld/voices-timeout.test.ts
+++ b/extensions/inworld/voices-timeout.test.ts
@@ -14,9 +14,15 @@ describe("listInworldVoices timeout", () => {
 
   it("aborts a hanging voice list request within the configured timeout", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    let notifyFetchStarted!: () => void;
+    const fetchStarted = new Promise<void>((resolve) => {
+      notifyFetchStarted = resolve;
+    });
+    let rejectFetch: ((error: Error) => void) | undefined;
     const fetchMock = vi.fn(
       (_input: RequestInfo | URL, init?: RequestInit) =>
         new Promise<Response>((_resolve, reject) => {
+          rejectFetch = reject;
           const signal = init?.signal;
           if (!signal) {
             reject(new Error("guarded fetch did not pass an abort signal"));
@@ -28,6 +34,7 @@ describe("listInworldVoices timeout", () => {
               reject(signal.reason instanceof Error ? signal.reason : new Error("request aborted")),
             { once: true },
           );
+          notifyFetchStarted();
         }),
     );
     vi.stubGlobal("fetch", fetchMock as unknown as typeof globalThis.fetch);
@@ -37,16 +44,21 @@ describe("listInworldVoices timeout", () => {
       baseUrl: "https://custom.inworld.example.com",
       timeoutMs: 250,
     });
-    const rejection = expect(request).rejects.toThrow(/aborted|timeout|timed out/i);
+    try {
+      // Cold SDK imports must finish before the guarded fetch deadline starts.
+      await Promise.race([fetchStarted, request]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
 
-    // Flush guard preflight microtasks so the request is in flight.
-    await vi.advanceTimersByTimeAsync(0);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(249);
+      expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(false);
 
-    await vi.advanceTimersByTimeAsync(249);
-    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(false);
-
-    await vi.advanceTimersByTimeAsync(1);
-    await rejection;
+      await vi.advanceTimersByTimeAsync(1);
+      expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+      await expect(request).rejects.toThrow(/aborted|timeout|timed out/i);
+    } finally {
+      // Cleanup must not depend on the production timeout working.
+      rejectFetch?.(new Error("test cleanup"));
+      await request.catch(() => undefined);
+    }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where voice catalog timeout tests fail during cold SDK initialization and leave requests running into later tests. CI can report an Inworld request that never reached its fetch mock, followed by a real DNS error attributed to a later Zoom test. Azure's startup watchdog can likewise leave a request that contaminates the following default-timeout assertion.

Observed in [CI run 33916473013](https://github.com/openclaw/openclaw/actions/runs/33916473013/job/101164894119), while validating #138473. This is a separate test-only repair.

## Why This Change Was Made

The lazy SDK imports added in #138483 make the existing guessed readiness boundaries unreliable: flushing zero fake milliseconds does not finish Inworld's cold imports, and Azure's one-second watchdog includes initialization before its configured request deadline begins.

Both tests now wait for actual request entry before advancing fake time. They retain the exact production-signal checks (Inworld: un-aborted at 249 ms, aborted at 250 ms; Azure: un-aborted at 99 ms, aborted at 100 ms). Test-owned cleanup settles each request before timers, globals, and sockets are restored. Azure still uses real fetch against a loopback HTTP server. The unrelated startup watchdog and startup-latency claim are removed; request deadlines are unchanged.

## User Impact

No runtime behavior changes. Developers get reliable cold-start timeout coverage without dangling requests causing misleading failures in neighboring tests. Azure's existing default 30,000 ms and explicit 5,000 ms forwarding assertions remain intact.

## Evidence

On main `4c8eff54b87738883171aab9c4e83f823abcb25a`, before the fix:

- Inworld's focused test failed: expected one fetch call, received zero.
- Azure's focused test failed at its startup watchdog and emitted an unhandled rejection.
- The neighboring group reproduced Azure's dangling-request contamination: expected the default 30,000 ms, observed the earlier request's 100 ms.

After the fix:

```text
node scripts/run-vitest.mjs extensions/inworld/voices-timeout.test.ts extensions/inworld/tts.test.ts extensions/azure-speech/voices-timeout.test.ts extensions/azure-speech/voices-timeout-default.test.ts extensions/zoom-meetings/src/cli.test.ts
5 files passed; 32 tests passed

node scripts/run-vitest.mjs extensions/inworld/voices-timeout.test.ts extensions/inworld/tts.test.ts extensions/inworld/speech-provider.test.ts extensions/azure-speech/voices-timeout.test.ts extensions/azure-speech/voices-timeout-default.test.ts extensions/azure-speech/tts.test.ts extensions/azure-speech/speech-provider.test.ts extensions/zoom-meetings/src/cli.test.ts
8 files passed; 65 tests passed
```

Fault injection temporarily set each test's request timeout to zero, disabling the production deadline: both tests failed at the positive abort assertion and exited without unhandled rejections or leaked DNS requests. The original 100/250 ms inputs were restored before the passing runs. Formatting checked with the repository's pinned oxfmt 0.65.0. Independent scoped review found no actionable P0–P2 findings.

The same eight-file suite also passed all 65 tests after applying this patch to main `d3adc01d75e2b189732bd4d86c6b3be3cfa7e03e`. `node scripts/check-changed.mjs` passed the preceding guards and formatting, then stopped at extension typechecking because the borrowed local dependency tree lacks newer Grammy/normalization-core types and yargs-parser/pako declarations. No diagnostic names either changed file; exact-head CI with the pinned install supplies the full typecheck gate.

Observed proof is local, with synthetic data and real loopback fetch for Azure; no authenticated provider or remote gateway was needed for this test-only repair.

`git diff --numstat` (production: +0/-0, net 0; tests: +69/-64, net +5):

```text
48 55 extensions/azure-speech/voices-timeout.test.ts
21  9 extensions/inworld/voices-timeout.test.ts
```

NO-FOLLOW-UP: both timeout-test owners now use observed request readiness and independent cleanup; no additional rent-paying change was found in the inspected neighboring tests.

Exact-head hosted [CI gate passed](https://github.com/openclaw/openclaw/actions/runs/33919813721/job/101176598875) for `2830111548b2869d84853f3159e16a19545b6a53`; native review artifacts and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 138611` validated that same commit without a source push.

ClawSweeper’s [completed exact-head review](https://github.com/openclaw/openclaw/pull/138611#issuecomment-5546780654) found no correctness or security findings and no before-merge actions or rank-up moves. Publication was delayed by a GitHub rate limit; the native merge was retried only after the trusted completion appeared.

Landed through the native review/prepare/merge flow as [b8ca3ca0e3fc86a650bf1c249ed3a79b6741ab02](https://github.com/openclaw/openclaw/commit/b8ca3ca0e3fc86a650bf1c249ed3a79b6741ab02), verified as an ancestor of fetched main. No source changes or CI reruns were needed after the green head.
