### PR TITLE
fix(testbox): preserve hydrated runtime across native sync

### DIFF
--- a/.github/actions/prepare-testbox-shell/action.yml
+++ b/.github/actions/prepare-testbox-shell/action.yml
@@ -74,3 +74,27 @@ runs:
         for tool in go gofmt; do
           sudo ln -sf "$go_root/bin/$tool" "/usr/local/bin/$tool"
         done
+
+    - name: Isolate Testbox sync workspace
+      shell: bash
+      run: |
+        set -euo pipefail
+        state=/tmp/.testbox/working_directory
+        if [ ! -f "$state" ]; then
+          exit 0
+        fi
+
+        workspace="$(cd "$GITHUB_WORKSPACE" && pwd -P)"
+        sync_root="$(mktemp -d "$RUNNER_TEMP/openclaw-testbox-sync.XXXXXX")"
+        sync_root="$(cd "$sync_root" && pwd -P)"
+        case "$sync_root/" in
+          "$workspace/"*) echo "Testbox sync must stay outside the execution workspace" >&2; exit 1 ;;
+        esac
+        # Native preparation resets/cleans its checkout before rsync. Keep hydrated
+        # runtime at its original paths; only the verified source receiver updates it.
+        # Do not share Git objects: the receiver replaces execution-side Git metadata.
+        git clone --quiet --local --no-hardlinks "$workspace" "$sync_root"
+        git -C "$sync_root" remote set-url origin "$(git -C "$workspace" remote get-url origin)"
+        ln -s "$workspace" "$sync_root/.git/crabbox-artifact-root"
+        # run-testbox publishes this documented handoff field in its ready registration.
+        printf '%s\n' "$sync_root" > "$state"

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -33,6 +33,26 @@ fresh lease. Every run still syncs the current checkout.
 `OPENCLAW_TESTBOX_ALLOW_STALE=1` is only for intentional diagnostics, not
 release proof.
 
+Testbox sync requires **GNU rsync on the caller's `PATH`**. Apple `openrsync`
+reports rsync 2.6.9 compatibility but drops the receiver-side ignore rules used
+by native full sync; ignored runtime directories, including hydrated dependencies,
+can be deleted before source verification. The wrapper checks the implementation
+before acquiring or syncing a Testbox and rejects unavailable or incompatible
+rsync. It does not install tools or change `PATH`; help, warmup, status, and stop
+remain available. Other providers are unaffected.
+
+On macOS, install GNU rsync with Homebrew (`brew install rsync`), then select it
+for the wrapper invocation:
+
+```bash
+env PATH="$(brew --prefix rsync)/bin:$PATH" node scripts/crabbox-wrapper.mjs run --timing-json -- node --version
+```
+
+Replace `node --version` with the proof command. If an earlier native sync already
+deleted the prepared runtime, stop that lease and warm a fresh one; source recovery
+cannot reconstruct ignored runtime data. This prerequisite does not repair upstream
+`openrsync` or make direct native Blacksmith invocations safe with it.
+
 Testbox runs and POSIX remote changed gates freeze source into a Git bundle
 against the pinned base. These runs require Crabbox 0.37.0 or later for
 `sync-plan --json`; upgrade Crabbox before retrying an older binary. This API floor

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -33,25 +33,26 @@ fresh lease. Every run still syncs the current checkout.
 `OPENCLAW_TESTBOX_ALLOW_STALE=1` is only for intentional diagnostics, not
 release proof.
 
-Testbox sync requires **GNU rsync on the caller's `PATH`**. Apple `openrsync`
-reports rsync 2.6.9 compatibility but drops the receiver-side ignore rules used
-by native full sync; ignored runtime directories, including hydrated dependencies,
-can be deleted before source verification. The wrapper checks the implementation
-before acquiring or syncing a Testbox and rejects unavailable or incompatible
-rsync. It does not install tools or change `PATH`; help, warmup, status, and stop
-remain available. Other providers are unaffected.
+The Testbox workflow registers a separate disposable checkout for native sync.
+The hydrated execution workspace stays at its original absolute path, so native
+Git cleanup and rsync cannot delete dependencies, build output, or ignored runtime
+there. The wrapper verifies and applies the source bundle in that execution
+workspace, then runs the payload there. It never restores runtime from the caller
+or changes the selected rsync binary.
 
-On macOS, install GNU rsync with Homebrew (`brew install rsync`), then select it
-for the wrapper invocation:
+Workspace preparation changes require a fresh lease. A missing or overlapping
+execution-workspace binding stops the payload; stop that lease and warm a new one.
+Use the OpenClaw wrapper for proof: direct native Blacksmith commands target the
+transport checkout, which deliberately has no hydrated runtime.
 
-```bash
-env PATH="$(brew --prefix rsync)/bin:$PATH" node scripts/crabbox-wrapper.mjs run --timing-json -- node --version
-```
-
-Replace `node --version` with the proof command. If an earlier native sync already
-deleted the prepared runtime, stop that lease and warm a fresh one; source recovery
-cannot reconstruct ignored runtime data. This prerequisite does not repair upstream
-`openrsync` or make direct native Blacksmith invocations safe with it.
+Testbox requests with `--artifact-glob` or `--require-artifact` also require the
+`prepared-artifact-workspace` feature in the selected Crabbox binary's
+`providers describe blacksmith-testbox --json` response. The wrapper checks this
+before sync or lease work, rather than collecting missing or stale transport files.
+Update Crabbox if that capability is absent. Collection stays anchored in the
+prepared workspace across payload directory changes and normal failure exits;
+existing cancellation and signal-related artifact withholding remains unchanged.
+Ordinary runs without artifact requests do not require this additional capability.
 
 Testbox runs and POSIX remote changed gates freeze source into a Git bundle
 against the pinned base. These runs require Crabbox 0.37.0 or later for

--- a/scripts/crabbox-source-receiver.mts
+++ b/scripts/crabbox-source-receiver.mts
@@ -9,7 +9,8 @@ const { createHash } = require("node:crypto");
 const { isUtf8 } = require("node:buffer");
 const { spawnSync } = require("node:child_process");
 const expected = JSON.parse(process.argv[1]);
-const cwd = process.cwd();
+const syncRoot = process.cwd();
+const cwd = process.argv[2] ?? syncRoot;
 let temporary;
 function fail(message) { throw new Error(message); }
 function stat(file) {
@@ -37,9 +38,14 @@ function hashFile(file, algorithm, blob = false) {
   } finally { fs.closeSync(fd); }
 }
 try {
-  const capsule = ".openclaw-crabbox-changed-gate.bundle";
+  if (process.argv[2] && (cwd === syncRoot || cwd.startsWith(syncRoot + path.sep) || syncRoot.startsWith(cwd + path.sep)))
+    fail("Testbox execution and sync workspaces overlap; stop this lease and warm a fresh one");
+  const capsule = path.join(syncRoot, ".openclaw-crabbox-changed-gate.bundle");
   if (!stat(capsule)?.isFile() || hashFile(capsule, "sha256") !== expected.digest)
     fail("missing or mismatched source capsule; rerun from the local candidate");
+  // Native cleanup owns only syncRoot. Source application and the payload share
+  // the prepared workspace, so ignored runtime never enters the native delete walk.
+  process.chdir(cwd);
   temporary = fs.mkdtempSync(path.join(cwd, ".openclaw-source-"));
   const bundle = path.join(temporary, "source.bundle");
   fs.copyFileSync(capsule, bundle);
@@ -167,7 +173,7 @@ try {
     }
   } finally { fs.closeSync(input); }
   git(["read-tree", expected.tree]);
-  remove(capsule);
+  fs.rmSync(capsule);
   for (const file of git(["ls-files", "--others", "--exclude-standard", "-z"]).split("\0").filter(Boolean)) {
     if (!file.startsWith(path.basename(temporary) + "/")) fail("unexpected source entry: " + file);
   }
@@ -202,8 +208,19 @@ try {
 }
 `;
 
-export function remoteSourceBootstrap(capsule: CrabboxSourceCapsule, alias: string) {
+export function remoteSourceBootstrap(
+  capsule: CrabboxSourceCapsule,
+  alias: string,
+  testboxWorkspace: boolean,
+) {
   const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
   const { sourceSha, baseSha, tree, carrier, digest } = capsule;
-  return `node -e ${quote(receiver)} ${quote(JSON.stringify({ sourceSha, baseSha, tree, carrier, digest, alias }))}`;
+  const command = `node -e ${quote(receiver)} ${quote(JSON.stringify({ sourceSha, baseSha, tree, carrier, digest, alias }))}`;
+  if (!testboxWorkspace) {
+    return command;
+  }
+  return [
+    'openclaw_source_root="$(cd ./.git/crabbox-artifact-root && pwd -P)" || { echo "[crabbox] missing prepared Testbox execution workspace; stop this lease and warm a fresh one" >&2; exit 2; };',
+    `${command} "$openclaw_source_root" && cd "$openclaw_source_root"`,
+  ].join(" ");
 }

--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -488,6 +488,33 @@ function probeCrabboxMetadata(command: string, commandArgs: string[]) {
   return checkedOutput(command, commandArgs, CRABBOX_METADATA_PROBE_RETRY_TIMEOUT_MS);
 }
 
+function supportsPreparedTestboxArtifacts() {
+  const metadata = checkedOutput(binary, ["providers", "describe", "blacksmith-testbox", "--json"]);
+  if (metadata.status !== 0) {
+    return false;
+  }
+  try {
+    const description: unknown = JSON.parse(metadata.stdout);
+    if (
+      !isRecord(description) ||
+      description.schemaVersion !== 2 ||
+      !isRecord(description.provider) ||
+      description.provider.canonical !== "blacksmith-testbox" ||
+      !isRecord(description.capabilities)
+    ) {
+      return false;
+    }
+    const features = description.capabilities.features;
+    return (
+      Array.isArray(features) &&
+      features.every((feature) => typeof feature === "string") &&
+      features.includes("prepared-artifact-workspace")
+    );
+  } catch {
+    return false;
+  }
+}
+
 function parseCrabboxVersion(value: string) {
   const match = value.match(/\bv?(\d+)\.(\d+)\.(\d+)(?:-([^\s+]+))?(?:\+[^\s]+)?\b/u);
   if (!match) {
@@ -3655,8 +3682,9 @@ function applyRunTransforms(
     provider: string;
   },
 ) {
+  const testboxWorkspace = canonicalProviderName(options.provider) === "blacksmith-testbox";
   const sourceBootstrap = options.capsule
-    ? remoteSourceBootstrap(options.capsule, options.changedGateAlias)
+    ? remoteSourceBootstrap(options.capsule, options.changedGateAlias, testboxWorkspace)
     : "";
   const markedArgs = injectRemoteChangedGateEnvironment(initialInvocation, initialFacts);
   const localArgs =
@@ -3863,22 +3891,6 @@ if (canonicalProvider === "blacksmith-testbox") {
     process.exit(2);
   }
 
-  if (normalizedArgs[0] === "run") {
-    // Native full sync relies on receiver-side dir-merge rules. Apple openrsync
-    // drops them and deletes ignored runtime data before our source receiver runs.
-    const rsyncBinary = resolvePathBinary("rsync", process.env, process.platform) ?? "rsync";
-    const rsync = checkedOutput(rsyncBinary, ["--version"]);
-    const gnuRsync = /^rsync\s+version\s+\d+\.\d+\.\d+\s+protocol version\s+\d+\b/u.test(
-      rsync.stdout,
-    );
-    if (rsync.status !== 0 || !gnuRsync) {
-      console.error(
-        "[crabbox] Testbox sync requires GNU rsync on PATH; Apple openrsync can delete ignored runtime directories, including hydrated dependencies. Select GNU rsync on PATH and rerun. No Testbox was acquired or synced.",
-      );
-      process.exit(2);
-    }
-  }
-
   if (isWindowsRemoteTarget(normalizedArgs)) {
     console.error(
       [
@@ -3896,6 +3908,16 @@ if (canonicalProvider === "blacksmith-testbox") {
         `[crabbox] selected binary reported version=${version.text || "unknown"}.`,
         "[crabbox] if using ../crabbox, rebuild it: version=$(git -C ../crabbox describe --tags --always --dirty | sed 's/^v//') && go build -C ../crabbox -trimpath -ldflags \"-s -w -X github.com/openclaw/crabbox/internal/cli.version=${version}\" -o bin/crabbox ./cmd/crabbox",
       ].join("\n"),
+    );
+    process.exit(2);
+  }
+  const artifactRun =
+    normalizedArgs[0] === "run" &&
+    (hasOption(normalizedArgs, "--artifact-glob") ||
+      hasOption(normalizedArgs, "--require-artifact"));
+  if (artifactRun && !supportsPreparedTestboxArtifacts()) {
+    console.error(
+      "[crabbox] Testbox artifact collection requires Crabbox's prepared-artifact-workspace capability. Update Crabbox and retry; refusing to collect from the disposable sync checkout.",
     );
     process.exit(2);
   }

--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -3866,7 +3866,8 @@ if (canonicalProvider === "blacksmith-testbox") {
   if (normalizedArgs[0] === "run") {
     // Native full sync relies on receiver-side dir-merge rules. Apple openrsync
     // drops them and deletes ignored runtime data before our source receiver runs.
-    const rsync = checkedOutput("rsync", ["--version"]);
+    const rsyncBinary = resolvePathBinary("rsync", process.env, process.platform) ?? "rsync";
+    const rsync = checkedOutput(rsyncBinary, ["--version"]);
     const gnuRsync = /^rsync\s+version\s+\d+\.\d+\.\d+\s+protocol version\s+\d+\b/u.test(
       rsync.stdout,
     );

--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -3863,6 +3863,21 @@ if (canonicalProvider === "blacksmith-testbox") {
     process.exit(2);
   }
 
+  if (normalizedArgs[0] === "run") {
+    // Native full sync relies on receiver-side dir-merge rules. Apple openrsync
+    // drops them and deletes ignored runtime data before our source receiver runs.
+    const rsync = checkedOutput("rsync", ["--version"]);
+    const gnuRsync = /^rsync\s+version\s+\d+\.\d+\.\d+\s+protocol version\s+\d+\b/u.test(
+      rsync.stdout,
+    );
+    if (rsync.status !== 0 || !gnuRsync) {
+      console.error(
+        "[crabbox] Testbox sync requires GNU rsync on PATH; Apple openrsync can delete ignored runtime directories, including hydrated dependencies. Select GNU rsync on PATH and rerun. No Testbox was acquired or synced.",
+      );
+      process.exit(2);
+    }
+  }
+
   if (isWindowsRemoteTarget(normalizedArgs)) {
     console.error(
       [

--- a/scripts/testbox-lease-freshness.mts
+++ b/scripts/testbox-lease-freshness.mts
@@ -16,7 +16,7 @@ const STATE_VERSION = 1;
 const DEPENDENCY_INPUTS = ["package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", ".npmrc"];
 const ENVIRONMENT_INPUTS = [
   ".crabbox.yaml",
-  ".github/workflows/ci-check-testbox.yml",
+  ".github/actions/prepare-testbox-shell",
   ".node-version",
   "scripts/crabbox-wrapper.mjs",
   "scripts/crabbox-wrapper.mts",
@@ -70,6 +70,11 @@ function digestInputs(repoRoot: string, inputs: readonly string[]) {
 }
 
 function buildTestboxLeaseFingerprint(repoRoot: string, args: readonly string[]) {
+  const workflow = optionValue(
+    args,
+    "--blacksmith-workflow",
+    ".github/workflows/ci-check-testbox.yml",
+  );
   let baseSha;
   try {
     baseSha = git(repoRoot, ["merge-base", "HEAD", "refs/remotes/origin/main"]);
@@ -81,8 +86,8 @@ function buildTestboxLeaseFingerprint(repoRoot: string, args: readonly string[])
     baseSha,
     headSha: git(repoRoot, ["rev-parse", "HEAD"]),
     dependencyDigest: digestInputs(repoRoot, [...DEPENDENCY_INPUTS, "patches"]),
-    environmentDigest: digestInputs(repoRoot, ENVIRONMENT_INPUTS),
-    workflow: optionValue(args, "--blacksmith-workflow", ".github/workflows/ci-check-testbox.yml"),
+    environmentDigest: digestInputs(repoRoot, [...ENVIRONMENT_INPUTS, workflow]),
+    workflow,
     job: optionValue(args, "--blacksmith-job", "check"),
     ref: optionValue(args, "--blacksmith-ref", "main"),
   };

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -61,6 +61,7 @@ const fakeRunValueOptionHelp = [
   "label string",
   "market string",
   "provider string",
+  "require-artifact value",
   "script string",
   "target string",
   "ttl duration",
@@ -91,13 +92,6 @@ function makeFakeCrabbox(helpText: string): string {
 function writeFakeCrabbox(binDir: string, helpText: string): string {
   mkdirSync(binDir, { recursive: true });
   const crabboxPath = path.join(binDir, "crabbox");
-  writeNodeCommand(
-    path.join(binDir, "rsync"),
-    `const fs = require("node:fs");
-if (process.env.OPENCLAW_FAKE_RSYNC_LOG) fs.appendFileSync(process.env.OPENCLAW_FAKE_RSYNC_LOG, JSON.stringify(process.argv.slice(2)) + "\\n");
-process.stdout.write(process.env.OPENCLAW_FAKE_RSYNC_VERSION ?? "rsync  version 3.5.0  protocol version 32\\n");
-process.exit(Number(process.env.OPENCLAW_FAKE_RSYNC_STATUS || "0"));`,
-  );
   const stampClaimScript = [
     "const claimPaths = [process.env.OPENCLAW_FAKE_CRABBOX_CLAIM_PATH, process.env.OPENCLAW_FAKE_CRABBOX_EXTRA_CLAIM_PATH].filter(Boolean);",
     "for (const claimPath of claimPaths) { const claim = fs.existsSync(claimPath) ? JSON.parse(fs.readFileSync(claimPath, 'utf8')) : { leaseID: process.env.OPENCLAW_FAKE_CRABBOX_TIMING_LEASE_ID }; claim.repoRoot = process.env.OPENCLAW_FAKE_CRABBOX_CLAIM_REPO_ROOT || process.cwd(); fs.mkdirSync(path.dirname(claimPath), { recursive: true }); fs.writeFileSync(claimPath, JSON.stringify(claim) + '\\n', 'utf8'); }",
@@ -125,6 +119,10 @@ async function main() {
     const topFiles = [...new Set(candidates)].filter((file) => !excluded.has(file) && fs.existsSync(path.dirname(file)) && (() => { try { return !fs.lstatSync(file).isDirectory(); } catch { return false; } })()).map((file) => ({ path: file }));
     if (process.env.OPENCLAW_FAKE_CRABBOX_SELECTION_UNKNOWN_PATH) topFiles.push({ path: "not-a-source-candidate.txt" });
     process.stdout.write(JSON.stringify({ candidate: { files: topFiles.length + Number(process.env.OPENCLAW_FAKE_CRABBOX_SELECTION_COUNT_DELTA || "0") }, topFiles })); return;
+  }
+  if (args[0] === "providers" && args[1] === "describe") {
+    process.stdout.write(process.env.OPENCLAW_FAKE_CRABBOX_DESCRIPTION ?? JSON.stringify({ schemaVersion: 2, provider: { canonical: "blacksmith-testbox" }, capabilities: { features: ["prepared-artifact-workspace"] } }));
+    process.exit(Number(process.env.OPENCLAW_FAKE_CRABBOX_DESCRIPTION_STATUS || "0"));
   }
   if (args[0] === "--version") { console.log(process.env.OPENCLAW_FAKE_CRABBOX_VERSION || "crabbox 0.37.0"); return; }
   if (args[0] === "run" && args[1] === "--help") { process.stdout.write(helpText); return; }
@@ -1644,62 +1642,127 @@ describe("scripts/crabbox-wrapper", () => {
     },
   );
 
-  it.each([
-    ["blacksmith-testbox", "openrsync: protocol version 29\nrsync version 2.6.9 compatible\n", "0"],
-    ["blacksmith", "openrsync: protocol version 29\nrsync version 2.6.9 compatible\n", "0"],
-    ["blacksmith-testbox", "", "0"],
-    ["blacksmith-testbox", "rsync  version 3.5.0  protocol version 32\n", "7"],
-  ])(
-    "rejects unusable Testbox rsync before sync or lease work: %s %j %s",
-    (provider, version, status) => {
-      const log = makeInvocationLog();
-      const result = runDefaultWrapper(["run", "--provider", provider, "--", "echo", "ok"], {
-        env: {
-          OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG: log,
-          OPENCLAW_FAKE_RSYNC_VERSION: version,
-          OPENCLAW_FAKE_RSYNC_STATUS: status,
-        },
-      });
-      expect(result.status, result.stderr).toBe(2);
-      expect(result.stderr).toContain("Testbox sync requires GNU rsync on PATH");
-      expect(result.stderr).not.toContain("syncing from temporary full checkout");
-      expect(
-        readInvocations(log).filter(
-          ([name]) => name === "sync-plan" || name === "run" || name === "warmup",
-        ),
-      ).toEqual([]);
+  it.skipIf(process.platform === "win32").each(["missing", "overlapping"])(
+    "rejects a %s Testbox workspace binding before running the payload",
+    (binding) => {
+      const { remoteCommand } = runSuccessfulDefaultWrapper([
+        "run",
+        "--provider",
+        "blacksmith-testbox",
+        "--",
+        "echo",
+        "payload-ran",
+      ]);
+      const cwd = realpathSync(invocationLogTempDirs.make("openclaw-unprepared-testbox-"));
+      if (binding === "overlapping") {
+        mkdirSync(path.join(cwd, ".git"));
+        symlinkSync(cwd, path.join(cwd, ".git", "crabbox-artifact-root"), "dir");
+      }
+      const result = spawnSync("bash", ["-c", remoteCommand], { cwd, encoding: "utf8" });
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain(
+        binding === "missing"
+          ? "missing prepared Testbox execution workspace"
+          : "workspaces overlap",
+      );
+      expect(result.stdout).not.toContain("payload-ran");
+      expect(readdirSync(cwd)).toEqual(binding === "missing" ? [] : [".git"]);
     },
   );
 
   it.each([
-    ["run", "--provider", "blacksmith-testbox", "--help"],
-    ["warmup", "--provider", "blacksmith-testbox"],
-    ["status", "--provider", "blacksmith-testbox"],
-    ["stop", "--provider", "blacksmith-testbox"],
-    ["run", "--provider", "aws", "--", "echo", "ok"],
-  ])("does not probe rsync without native Testbox sync: %j", (...args) => {
-    const log = makeInvocationLog();
-    const result = runDefaultWrapper(args, {
-      env: { OPENCLAW_FAKE_RSYNC_VERSION: "openrsync\n", OPENCLAW_FAKE_RSYNC_LOG: log },
-    });
-    expect(result.status, result.stderr).toBe(0);
-    expect(existsSync(log)).toBe(false);
-  });
+    [
+      "--artifact-glob",
+      '{"schemaVersion":2,"provider":{"canonical":"blacksmith-testbox"},"capabilities":{"features":["run-artifacts"]}}',
+      "0",
+    ],
+    [
+      "--require-artifact",
+      '{"schemaVersion":2,"provider":{"canonical":"blacksmith-testbox"},"capabilities":{"features":[]}}',
+      "0",
+    ],
+    ["--artifact-glob", "not-json", "0"],
+    [
+      "--artifact-glob",
+      '{"schemaVersion":2,"provider":{"canonical":"aws"},"capabilities":{"features":["prepared-artifact-workspace"]}}',
+      "0",
+    ],
+    ["--artifact-glob", "{}", "7"],
+  ])(
+    "requires prepared artifact-workspace support before Testbox sync: %s %s",
+    (flag, description, status) => {
+      const log = makeInvocationLog();
+      writeFileSync(log, "");
+      const result = runDefaultWrapper(
+        [
+          "run",
+          "--provider",
+          "blacksmith-testbox",
+          flag,
+          "reports/result.json",
+          "--",
+          "echo",
+          "ok",
+        ],
+        {
+          env: {
+            OPENCLAW_FAKE_CRABBOX_DESCRIPTION: description,
+            OPENCLAW_FAKE_CRABBOX_DESCRIPTION_STATUS: status,
+            OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG: log,
+          },
+        },
+      );
+      expect(result.status, result.stderr).toBe(2);
+      expect(result.stderr).toContain("prepared-artifact-workspace");
+      expect(result.stderr).not.toContain("syncing from temporary full checkout");
+      expect(readInvocations(log).some(([name]) => name === "run" || name === "sync-plan")).toBe(
+        false,
+      );
+    },
+  );
 
-  it.each(["2.6.9", "3.5.0"])("accepts GNU rsync %s for Testbox sync", (version) => {
+  it("accepts advertised prepared artifact-workspace support", () => {
     const log = makeInvocationLog();
     const result = runDefaultWrapper(
-      ["run", "--provider", "blacksmith-testbox", "--", "echo", "ok"],
+      [
+        "run",
+        "--provider",
+        "blacksmith-testbox",
+        "--require-artifact",
+        "reports/result.json",
+        "--",
+        "echo",
+        "ok",
+      ],
       {
-        env: {
-          OPENCLAW_FAKE_RSYNC_VERSION: `rsync  version ${version}  protocol version 29\n`,
-          OPENCLAW_FAKE_RSYNC_LOG: log,
-        },
+        env: { OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG: log },
       },
     );
     expect(result.status, result.stderr).toBe(0);
-    expect(readInvocations(log)).toEqual([["--version"]]);
+    expect(readInvocations(log)).toContainEqual([
+      "providers",
+      "describe",
+      "blacksmith-testbox",
+      "--json",
+    ]);
   });
+
+  it.each([
+    ["run", "--provider", "blacksmith-testbox", "--", "echo", "--artifact-glob"],
+    ["run", "--provider", "blacksmith-testbox", "--label", "--artifact-glob", "--", "echo", "ok"],
+    ["run", "--provider", "aws", "--artifact-glob", "reports/result.json", "--", "echo", "ok"],
+  ])(
+    "does not require prepared artifact-workspace support outside Testbox artifact options: %j",
+    (...args) => {
+      const log = makeInvocationLog();
+      writeFileSync(log, "");
+      const result = runDefaultWrapper(args, {
+        env: { OPENCLAW_FAKE_CRABBOX_DESCRIPTION: "{}", OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG: log },
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(readInvocations(log).some(([name]) => name === "providers")).toBe(false);
+    },
+  );
 
   it("requires a current Crabbox binary for Blacksmith Testbox runs", () => {
     const result = runDefaultWrapper(["run", "--provider", "blacksmith-testbox", "--", "echo ok"], {
@@ -3956,11 +4019,21 @@ describe("scripts/crabbox-wrapper", () => {
         } else {
           mkdirSync(receiver);
         }
+        const transport =
+          provider === "blacksmith-testbox" ? path.join(root, `${name}-transport`) : receiver;
+        if (transport !== receiver) {
+          mkdirSync(path.join(transport, ".git"), { recursive: true });
+          symlinkSync(
+            realpathSync(receiver),
+            path.join(transport, ".git", "crabbox-artifact-root"),
+            "dir",
+          );
+        }
         if (bundle) {
-          writeFileSync(path.join(receiver, ".openclaw-crabbox-changed-gate.bundle"), bundle);
+          writeFileSync(path.join(transport, ".openclaw-crabbox-changed-gate.bundle"), bundle);
         }
         const result = runCommand("bash", ["-c", remoteCommand], {
-          cwd: receiver,
+          cwd: transport,
           encoding: "utf8",
           timeout: 10_000,
           env: {
@@ -3974,6 +4047,12 @@ describe("scripts/crabbox-wrapper", () => {
           },
         });
         expect(result.error, failureDetail(result)).toBeUndefined();
+        if (transport !== receiver && result.status === 0) {
+          expect(readlinkSync(path.join(transport, ".git", "crabbox-artifact-root"))).toBe(
+            realpathSync(receiver),
+          );
+          expect(existsSync(path.join(transport, "owner.txt"))).toBe(false);
+        }
         return { receiver, result };
       };
       const empty = runSender();

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -91,6 +91,13 @@ function makeFakeCrabbox(helpText: string): string {
 function writeFakeCrabbox(binDir: string, helpText: string): string {
   mkdirSync(binDir, { recursive: true });
   const crabboxPath = path.join(binDir, "crabbox");
+  writeNodeCommand(
+    path.join(binDir, "rsync"),
+    `const fs = require("node:fs");
+if (process.env.OPENCLAW_FAKE_RSYNC_LOG) fs.appendFileSync(process.env.OPENCLAW_FAKE_RSYNC_LOG, JSON.stringify(process.argv.slice(2)) + "\\n");
+process.stdout.write(process.env.OPENCLAW_FAKE_RSYNC_VERSION ?? "rsync  version 3.5.0  protocol version 32\\n");
+process.exit(Number(process.env.OPENCLAW_FAKE_RSYNC_STATUS || "0"));`,
+  );
   const stampClaimScript = [
     "const claimPaths = [process.env.OPENCLAW_FAKE_CRABBOX_CLAIM_PATH, process.env.OPENCLAW_FAKE_CRABBOX_EXTRA_CLAIM_PATH].filter(Boolean);",
     "for (const claimPath of claimPaths) { const claim = fs.existsSync(claimPath) ? JSON.parse(fs.readFileSync(claimPath, 'utf8')) : { leaseID: process.env.OPENCLAW_FAKE_CRABBOX_TIMING_LEASE_ID }; claim.repoRoot = process.env.OPENCLAW_FAKE_CRABBOX_CLAIM_REPO_ROOT || process.cwd(); fs.mkdirSync(path.dirname(claimPath), { recursive: true }); fs.writeFileSync(claimPath, JSON.stringify(claim) + '\\n', 'utf8'); }",
@@ -1636,6 +1643,63 @@ describe("scripts/crabbox-wrapper", () => {
       }
     },
   );
+
+  it.each([
+    ["blacksmith-testbox", "openrsync: protocol version 29\nrsync version 2.6.9 compatible\n", "0"],
+    ["blacksmith", "openrsync: protocol version 29\nrsync version 2.6.9 compatible\n", "0"],
+    ["blacksmith-testbox", "", "0"],
+    ["blacksmith-testbox", "rsync  version 3.5.0  protocol version 32\n", "7"],
+  ])(
+    "rejects unusable Testbox rsync before sync or lease work: %s %j %s",
+    (provider, version, status) => {
+      const log = makeInvocationLog();
+      const result = runDefaultWrapper(["run", "--provider", provider, "--", "echo", "ok"], {
+        env: {
+          OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG: log,
+          OPENCLAW_FAKE_RSYNC_VERSION: version,
+          OPENCLAW_FAKE_RSYNC_STATUS: status,
+        },
+      });
+      expect(result.status, result.stderr).toBe(2);
+      expect(result.stderr).toContain("Testbox sync requires GNU rsync on PATH");
+      expect(result.stderr).not.toContain("syncing from temporary full checkout");
+      expect(
+        readInvocations(log).filter(
+          ([name]) => name === "sync-plan" || name === "run" || name === "warmup",
+        ),
+      ).toEqual([]);
+    },
+  );
+
+  it.each([
+    ["run", "--provider", "blacksmith-testbox", "--help"],
+    ["warmup", "--provider", "blacksmith-testbox"],
+    ["status", "--provider", "blacksmith-testbox"],
+    ["stop", "--provider", "blacksmith-testbox"],
+    ["run", "--provider", "aws", "--", "echo", "ok"],
+  ])("does not probe rsync without native Testbox sync: %j", (...args) => {
+    const log = makeInvocationLog();
+    const result = runDefaultWrapper(args, {
+      env: { OPENCLAW_FAKE_RSYNC_VERSION: "openrsync\n", OPENCLAW_FAKE_RSYNC_LOG: log },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(existsSync(log)).toBe(false);
+  });
+
+  it.each(["2.6.9", "3.5.0"])("accepts GNU rsync %s for Testbox sync", (version) => {
+    const log = makeInvocationLog();
+    const result = runDefaultWrapper(
+      ["run", "--provider", "blacksmith-testbox", "--", "echo", "ok"],
+      {
+        env: {
+          OPENCLAW_FAKE_RSYNC_VERSION: `rsync  version ${version}  protocol version 29\n`,
+          OPENCLAW_FAKE_RSYNC_LOG: log,
+        },
+      },
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(readInvocations(log)).toEqual([["--version"]]);
+  });
 
   it("requires a current Crabbox binary for Blacksmith Testbox runs", () => {
     const result = runDefaultWrapper(["run", "--provider", "blacksmith-testbox", "--", "echo ok"], {

--- a/test/scripts/testbox-lease-freshness.test.ts
+++ b/test/scripts/testbox-lease-freshness.test.ts
@@ -10,7 +10,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, expect, it, onTestFinished } from "vitest";
 import {
   prepareTestboxLeaseFreshness,
@@ -67,27 +67,32 @@ describe("Testbox lease freshness", () => {
     expect(fixture.prepare()).toEqual(prepared);
   });
 
-  it("invalidates saved proof when executable source-sync owners change", () => {
+  it("invalidates saved proof when source-sync or workspace preparation owners change", () => {
     const fixture = createLeaseFixture();
-    mkdirSync(join(fixture.root, "scripts"));
+    const workflow = ".github/workflows/custom-testbox.yml";
     const owners = [
-      "crabbox-wrapper.mjs",
-      "crabbox-wrapper.mts",
-      "crabbox-source-capsule.mts",
-      "crabbox-source-receiver.mts",
+      "scripts/crabbox-wrapper.mjs",
+      "scripts/crabbox-wrapper.mts",
+      "scripts/crabbox-source-capsule.mts",
+      "scripts/crabbox-source-receiver.mts",
+      ".github/actions/prepare-testbox-shell/action.yml",
+      workflow,
     ];
     for (const owner of owners) {
-      writeFileSync(join(fixture.root, "scripts", owner), "original\n");
+      const file = join(fixture.root, owner);
+      mkdirSync(dirname(file), { recursive: true });
+      writeFileSync(file, "original\n");
     }
-    fixture.git(["add", "scripts"]);
+    fixture.git(["add", "."]);
     fixture.advanceBase();
-    recordTestboxLeaseFreshness(fixture.prepare());
+    const prepare = () => fixture.prepare(["--blacksmith-workflow", workflow]);
+    recordTestboxLeaseFreshness(prepare());
     writeFileSync(join(fixture.root, "unrelated-source.ts"), "source change\n");
-    expect(() => fixture.prepare()).not.toThrow();
+    expect(() => prepare()).not.toThrow();
     for (const owner of owners) {
-      const file = join(fixture.root, "scripts", owner);
+      const file = join(fixture.root, owner);
       writeFileSync(file, "changed executable owner\n");
-      expect(() => fixture.prepare(), owner).toThrow("environmentDigest");
+      expect(() => prepare(), owner).toThrow("environmentDigest");
       writeFileSync(file, "original\n");
     }
   });


### PR DESCRIPTION
Related: [complete source-snapshot repair](https://github.com/openclaw/openclaw/pull/138404) and [original Testbox sync omission report](https://github.com/openclaw/openclaw/issues/138153).

Companion: [Crabbox prepared artifact-workspace ownership](https://github.com/openclaw/crabbox/pull/1840).

<details>
<summary>Additional instructions</summary>

Same-repository maintainer-owned branch; maintainers can push updates directly.

</details>

## What Problem This Solves

Fixes an issue where maintainers reusing a Blacksmith Testbox could lose hydrated dependencies, build output, or ignored runtime during native source synchronization, even when the complete source snapshot was restored and verified afterward.

There are two deleting owners: Apple `openrsync` drops receiver-side ignore rules, and native preparation can remove newly ignored runtime **before rsync starts**. A live GNU rsync control preserved root caches but still lost a runtime directory protected by a newly added nested `.gitignore`. A GNU-only prerequisite was therefore discarded rather than presented as a complete fix.

## Why This Change Was Made

Keep native synchronization in a disposable source-only checkout and leave the hydrated execution workspace at its original absolute path. The shared Testbox setup action registers the transport checkout through the pinned actions' existing workspace handoff; the existing raw source-bundle receiver applies and verifies source in the prepared workspace before the payload runs there. Git objects are copied independently because the receiver replaces execution-side Git metadata.

The same prepared-root binding is used by the [companion Crabbox artifact supervisor](https://github.com/openclaw/crabbox/pull/1840), which captures its directory before workload execution. Artifact requests require the advertised `prepared-artifact-workspace` feature through Crabbox's existing static provider-description API; missing, malformed, failed, or mismatched capability responses stop before source/lease work. No unpublished version floor is guessed and no post-command artifact-copy workaround is introduced.

Lease freshness now includes workspace preparation and the explicitly selected workflow file. The default, ARM, and prebuilt-artifact Testbox workflows share this preparation owner.

## User Impact

Ordinary runs preserve the prepared runtime with the existing installed Crabbox and native Blacksmith CLI, including stock macOS `openrsync`. No provider switch, global tool replacement, new user configuration option, dependency override, SQLite change, or product retention change is introduced. Raw source bytes, Git executable modes, symlink targets, privacy exclusions, and producer-owned deletions retain their existing verification contract.

Stop and rewarm existing leases when adopting the changed wrapper/workflow. Missing or overlapping execution-workspace bindings stop the payload instead of falling back to the unsafe transport checkout. Direct native Blacksmith commands target the deliberately unhydrated transport checkout; OpenClaw proof uses the wrapper.

Artifact flags need a Crabbox build advertising the companion capability. The older installed CLI remains usable for ordinary runs, but its artifact requests fail clearly before synchronization rather than returning stale transport evidence. The new binding is trusted CI metadata, not authentication or a same-user sandbox. Signal/cancellation artifact withholding remains unchanged.

Production/tooling: **net +84 lines**, providing the workspace ownership boundary, prepared artifact capability admission, and preparation/workflow freshness. Tests: **net +148**. Docs: **net +21**. The companion removes **123 production lines** by deleting the obsolete second collector, for **net −39 production lines across the repair**.

## Evidence

### Native failure and repaired stock-tool flow

The failed control used native Blacksmith 0.4.58 with GNU rsync 3.5.0. Immediately before the unchanged native rsync invocation, remote HEAD had already returned to the source base and both the new nested ignore file and runtime sentinel were absent. This proves why swapping rsync alone is insufficient. [Control environment](https://github.com/openclaw/openclaw/actions/runs/33909605925).

The repaired flow used the **stock installed Crabbox 0.48.2 development build, native Blacksmith 0.4.58, and macOS `/usr/bin/rsync` (Apple openrsync)** on a fresh task-owned **Blacksmith Testbox**, `tbx_01m1q1nw95yxnxq8kekg5n6pfc`: [Actions run 33916325719](https://github.com/openclaw/openclaw/actions/runs/33916325719), pinned to the live-tested pre-refresh head **d316a80c955acf93fb8c7c23b408fad73fb6cc7a**.

| Proof | Observed result |
| --- | --- |
| Initial large source sync | Native `parallel-manifest`, 217 changed files. Actual command entry matched the registered transport directory; source application and payload ran in the disjoint original execution directory. |
| Repeated native `checksum-full` | **104,924 runtime files/symlinks across 171 roots** remained byte/mode/link-identical, including root cache and newly ignored nested runtime. Runtime inventory SHA-256 stayed `41f3073ceac8c4848cb5e514b311fe3db6a54a158c4d57710485f9c6431cb97b`. |
| Source mutation replay | Explicit deletion, executable-bit change, and symlink-target change were reflected exactly. **37,858 source records** matched hash `3d5cf0543d204111978cebc23c3da981a455d6d9a0dede402070e1b0aa0194ac`; the declared deleted path was absent. Private canaries stayed absent. |
| Second `checksum-full` plus Linux owner suite | Runtime inventory still matched; **295/295 tests passed**; complete source hash was unchanged before and after the suite. |

The live fixture used the reviewed code plus staged synthetic source paths to force the large-sync paths. No original retention worktree, operator gateway, or unrelated lease was touched. The stock-tool lease was stopped and confirmed completed. Its hosting Actions run can show cancelled after explicit cleanup; CLI receipts and independent manifests establish the command outcomes.

### Local and sibling proof

Pre-fix regressions demonstrated the wrong execution/transport owner, missing selected-workflow freshness, and old-CLI artifact admission. The repaired full local owner suite passed **295/295**; shared workflow/base tests and changed-scope formatting, typecheck, lint, and guards passed. Fresh Codex autoreview was scoped-clean at the repository's default P0 threshold.

```bash
node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts test/scripts/testbox-lease-freshness.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/testbox-base.test.ts test/scripts/ci-workflow-guards.test.ts
```

```bash
node scripts/check-changed.mjs -- .github/actions/prepare-testbox-shell/action.yml scripts/crabbox-source-receiver.mts scripts/crabbox-wrapper.mts scripts/testbox-lease-freshness.mts test/scripts/crabbox-wrapper.test.ts test/scripts/testbox-lease-freshness.test.ts docs/reference/test.md
```

Early Mac runs hit existing Git-fixture timeouts while a large checkout was being created; those unchanged cases passed on rerun, followed by a fully passing local suite. No timeout was increased. The first diagnostic module probe incorrectly attempted a source alias through bare Node; it was corrected to use the repository's existing TypeScript preload, without restoring dependencies or changing source expectations.

### Artifact integration

A separate fresh **Blacksmith Testbox**, `tbx_01m1q35gazmqn2r6gwwy2nk4x9`, uses the same OpenClaw head and the task-local companion CLI built from **31029eb80288b48e93aabb9a38226f711aa8b27a**: [Actions run 33918475684](https://github.com/openclaw/openclaw/actions/runs/33918475684). The live success case placed conflicting reports at the same relative path in transport and execution; the collected archive contained only the fresh execution report with its per-invocation receipt and full-source hash.

All live artifact cases passed: success collected the execution report instead of the conflicting transport report; a normal failure after `cd /tmp` preserved exit 23 and collected the correct report; actual SIGTERM produced exit 143 with no new artifact publication; retargeting the binding during the workload did not redirect collection. Every collected report matched a fresh per-invocation receipt and the independently checked full-source hash. The artifact lease was stopped and confirmed completed. Neither PR has been merged, and no CLI release or global installation was performed.

### Current-main refresh

Current PR head: **1ef66ff0ffb1d34b0535e7e6db9d846a7e4b101f**, rebased once onto **65417dfc01deb9109cf373a4f83d7aa4d3412791** to resolve a freshness-test conflict. The resolution retains [the upstream large-dirty-checkout fix and stronger freshness tests](https://github.com/openclaw/openclaw/pull/138317).

The live-tested action, source capsule, receiver, wrapper, docs, and wrapper-test blobs are byte-identical to the pre-refresh head. The only production difference is the upstream deletion of the unused full `git status` call from freshness calculation. All **10 refreshed freshness tests**, the full changed-scope checks above, and fresh post-resolution Codex autoreview passed. Live evidence is explicitly attributed to the pre-refresh head rather than relabeled as a new run.
