### PR TITLE
perf(plugins): skip route preparation when no hook exists

### DIFF
--- a/src/plugins/provider-model-routes.test.ts
+++ b/src/plugins/provider-model-routes.test.ts
@@ -543,9 +543,44 @@ describe("provider model route adapter", () => {
     });
   });
 
-  it("returns null when the provider artifact has no route hook", () => {
+  it.each([
+    ["missing", undefined],
+    ["null", null],
+    ["without a route hook", {}],
+  ] as const)("returns null for a %s route surface despite configured facts", (_label, surface) => {
+    const config = {
+      models: {
+        providers: {
+          "fixture:routes": {
+            api: "openai-completions",
+            baseUrl: "https://provider.example.test/v1",
+            models: [{ id: "demo", api: "openai-responses" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
     expect(
-      resolveProviderModelRoutes({ provider: "fixture", modelId: "demo", surface: {} }),
+      resolveProviderModelRoutes({
+        provider: "fixture:routes",
+        modelId: "demo",
+        api: "openai-responses",
+        baseUrl: "https://observed.example.test/v1",
+        config,
+        env: {},
+        surface,
+      }),
     ).toBeNull();
+  });
+
+  it("keeps a missing route hook captured while fresh resolvers see a later hook", () => {
+    const surface: { resolveModelRoutes?: () => { kind: "indeterminate" } } = {};
+    const resolveRoutes = createProviderModelRoutesResolver({ provider: "fixture", surface });
+    surface.resolveModelRoutes = () => ({ kind: "indeterminate" });
+
+    expect(resolveRoutes({ modelId: "demo" })).toBeNull();
+    expect(resolveProviderModelRoutes({ provider: "fixture", modelId: "demo", surface })).toEqual({
+      kind: "indeterminate",
+    });
   });
 });

--- a/src/plugins/provider-model-routes.ts
+++ b/src/plugins/provider-model-routes.ts
@@ -84,6 +84,9 @@ export function createProviderModelRoutesResolver(params: {
       ? resolveDirectBundledProviderPolicySurface(provider)
       : params.surface;
   const resolveModelRoutes = surface?.resolveModelRoutes;
+  if (!resolveModelRoutes) {
+    return () => null;
+  }
   const providerConfig = resolveMergedModelProviderConfig(params.config, provider);
   // Runtime defaults copy catalog capabilities into configured model rows. Route
   // eligibility must read the authored view or metadata looks like request behavior.
@@ -122,9 +125,6 @@ export function createProviderModelRoutesResolver(params: {
   const env = params.env ?? process.env;
 
   return (observed) => {
-    if (!resolveModelRoutes) {
-      return null;
-    }
     const modelId = normalizeModelId(provider, observed?.modelId, surface);
     const configuredModel = modelId ? configuredModels.get(modelId) : undefined;
     const requestTransportOverrides = modelId


### PR DESCRIPTION
## What Problem This Solves

Provider route checks prepared configured-model maps and transport-override facts even when the selected provider exposed no route hook. That work could only end in a null route result, adding avoidable work to model selection.

## Why This Change Was Made

Move the existing missing-hook guard to the resolver factory, immediately after capturing the provider hook. Hook-present routing, authored-versus-runtime config, model precedence, aliases, environment references and captured-hook lifetime are unchanged. This follows the prepared routing work in #138423 without adding a cache, compatibility path or configuration option.

Production LOC: +3/-3 (net 0). Tests: +37/-2 (net +35). This is a performance cleanup, not a newly identified correctness regression.

## User Impact

Providers without a route hook avoid unnecessary preparation. Existing route decisions and callback behavior stay the same. There is no claimed full-turn, Gateway startup or memory improvement.

## Evidence

Before and candidate each passed the same 185 cases in four complete files, including the route adapter, provider config, runtime-source projection and harness selection. The normal 29-stage changed gate passed. Independent managed Codex review found no actionable P0–P2 findings.

Fixed before/candidate/candidate/before measurements used the actual exported synchronous route operation and ordinary provider-policy loading, with complete outcome/descriptor/order checks. The clock also includes the fixed output-array push and call counters; the approximately 0.1 µs custom-provider results approach that harness overhead. Two behavioral hosts plus four timing hosts performed 21,932 calls and retained 384 measured batch means, first calls and warmups.

| Whole operation | Forward median | Reverse median |
| --- | ---: | ---: |
| Configured no-hook, 8 models | 3.709 → 0.110 µs | 3.680 → 0.120 µs |
| Configured no-hook, 48 models | 13.296 → 0.094 µs | 12.339 → 0.094 µs |
| Real Anthropic policy, no hook | 6.121 → 3.514 µs | 6.197 → 3.486 µs |
| OpenAI model-precedence control | 11.973 → 13.051 µs | 12.283 → 12.232 µs |
| OpenAI alias/header control | 7.686 → 7.469 µs | 7.908 → 7.698 µs |

**The preset numeric verdict is false:** the OpenAI model-precedence control regressed 9.005% / 1.078 µs in forward order, crossing the original 3% plus 1 µs gate. Reverse order improved 0.413% / 0.051 µs. All 12 adverse comparisons remain recorded, including first-call/tail values and sampled-tree RSS increases of 1.62%/1.10% (kernel-child peaks +1.09%/+2.04%). No retries or threshold changes were used.

The engineering tradeoff is explicit: a single existing guard moves earlier, avoids demonstrably unused work and adds no production lines; the small order-sensitive OpenAI cost is disclosed rather than classified as a universal speedup. The code review and output proofs support unchanged hook-present behavior, but do not establish the cause of the timing difference.

This is real in-process public-boundary proof, including bundled policy modules, not an authenticated provider turn or packaged Gateway measurement. The broader campaign's live development-Gateway task suite is separate evidence and is not attributed to this patch. All timing hosts and descendants closed; original setup/readback mistakes and compiler warnings remain in local evidence.

Source proof ran at `c6447291964c1024d1d41e077ff2bcc58d3d2558`; the selected route/config/policy owners and route tests remain unchanged on inspected main `ff925d0a838db7539589f416fe39740857683a89`. Hosted CI and final native landing checks remain pending.

Local evidence: `.artifacts/perf50prs-20260904/route-no-hook/verification-r1` and `native-root-r4` in the task-owned route checkout. Numerical result SHA-256: `14b17c6b78eafb43c1e08d736bbd67eaf929bd58afdb406389cbf642800f632b`. Separately recomputed arithmetic matches all 76 comparisons and 12 adverse entries; that auditor authored the antecedent benchmark, so it is not a nonauthor source review. Independent managed source review is separate. The percentile method uses 16 measured means, making p95 equal to the maximum.
