### PR TITLE
test: avoid real sleeps in PR metadata retry tests

### DIFF
--- a/test/scripts/pr-metadata.test.ts
+++ b/test/scripts/pr-metadata.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,6 +10,8 @@ function createFakeGh(): string {
   const dir = mkdtempSync(join(tmpdir(), "openclaw-pr-metadata-"));
   const gh = join(dir, "gh");
   tempDirs.push(dir);
+  writeFileSync(join(dir, "pr-view-count"), "0\n");
+  writeFileSync(join(dir, "pr-view-count.sleeps"), "");
   writeFileSync(
     gh,
     `#!/usr/bin/env bash
@@ -121,11 +123,19 @@ function readPrMetadata(
     restFileCount?: string;
   } = {},
 ) {
-  return spawnSync(
+  const result = spawnSync(
     "bash",
     [
       "-c",
-      "set -euo pipefail; source scripts/lib/plain-gh.sh; source scripts/pr-lib/worktree.sh; source scripts/pr-lib/common.sh; pr_meta_json 42",
+      [
+        "set -euo pipefail",
+        "source scripts/lib/plain-gh.sh",
+        "source scripts/pr-lib/worktree.sh",
+        "source scripts/pr-lib/common.sh",
+        // Keep the real retry loop, but record its delays in this child shell only.
+        'sleep() { printf "%s\\n" "$*" >> "$FAKE_PR_VIEW_COUNT_FILE.sleeps"; }',
+        "pr_meta_json 42",
+      ].join("; "),
     ],
     {
       cwd: process.cwd(),
@@ -149,6 +159,15 @@ function readPrMetadata(
       encoding: "utf8",
     },
   );
+  return {
+    ...result,
+    prViewAttempts: Number(readFileSync(join(fakeGhDir, "pr-view-count"), "utf8")),
+    retryDelays: readFileSync(join(fakeGhDir, "pr-view-count.sleeps"), "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map(Number),
+  };
 }
 
 afterEach(() => {
@@ -167,6 +186,8 @@ describe("PR metadata", () => {
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
+    expect(result.prViewAttempts).toBe(2);
+    expect(result.retryDelays).toEqual([]);
   });
 
   it("uses cacheable GraphQL file metadata when the complete list fits", () => {
@@ -296,8 +317,11 @@ describe("PR metadata", () => {
     const result = readPrMetadata(createFakeGh(), { prViewFailureMode });
 
     expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.prViewAttempts).toBe(3);
+    expect(result.retryDelays).toEqual([1, 2]);
     expect(result.stderr).toContain(
-      `GitHub API failure while reading PR #42: gh pr view ${detail}`,
+      `GitHub API failure while reading PR #42: gh pr view ${detail} after 3 attempts.`,
     );
     expect(result.stderr).toContain("HTTP 503: No server is currently available");
     expect(result.stderr).not.toContain("integer expected");
@@ -313,8 +337,11 @@ describe("PR metadata", () => {
     });
 
     expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.prViewAttempts).toBe(4);
+    expect(result.retryDelays).toEqual([1, 2]);
     expect(result.stderr).toContain(
-      "GitHub API failure while reading PR #42: gh pr view returned empty stdout",
+      "GitHub API failure while reading PR #42: gh pr view returned empty stdout after 3 attempts.",
     );
     expect(result.stderr).not.toContain("PR head changed");
   });
@@ -329,6 +356,8 @@ describe("PR metadata", () => {
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
+    expect(result.prViewAttempts).toBe(3);
+    expect(result.retryDelays).toEqual([1]);
     expect(JSON.parse(result.stdout)).toMatchObject({ headRefOid: "head-a", changedFiles: 2 });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The PR metadata tests spend real seconds backing off between deterministic fake GitHub responses. Five exhaustion cases sleep for one then two seconds; the successful recovery case sleeps once. Those waits do not advance fixture state.

## Why This Change Was Made

Record requested sleeps inside the existing child Bash fixture while continuing to execute the real retry and metadata owners. Preserve all 15 cases and existing assertions, and check actual request counts, requested delays, clean failure stdout, and the three-attempt diagnostic. The recorder uses the same child-shell override pattern already used by PR merge-outcome tests.

## User Impact

No production behavior changes. In one same-host comparison, summed case bodies fell from 20.54s to 6.70s; command wall time fell from 27.32s to 14.41s. Machine/startup variation remains, and this is not a native CI timing guarantee.

## Evidence

- Original and candidate: all 15 cases passed, with identical case names/order and no skips.
- Node 24.19.0, one worker, separate empty module caches; canonical `scripts/run-vitest.mjs` with `test/vitest/vitest.tooling.config.ts` and the exact metadata test file.
- All 15 selected canonical changed checks passed against pinned base `7b0bc9c9d88f5e9db966fc376cbc253d7fc1a9ea`, including root typecheck, script lint, edited-file type-aware lint, and boundary guards.
- Independent Codex P0–P2 review: scoped clean, one pass, no actionable findings.
- Single test file, +34/−5; production source and retry policy unchanged.
