### PR TITLE
fix(voice-call): truncate realtime audio at played duration, not call clock

### DIFF
--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
@@ -257,3 +257,138 @@ describe("RealtimeAudioPacer", () => {
     expect(pacer.hasPendingAudio()).toBe(false);
   });
 });
+
+describe("RealtimeAudioPacer playout state", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function createPlaybackPacer() {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance", "Date"] });
+    const sent: string[] = [];
+    const pacer = new RealtimeAudioPacer({
+      serializer: createCompactSerializer(),
+      send: (message) => {
+        sent.push(message);
+        return true;
+      },
+    });
+    return { pacer, sent };
+  }
+
+  it("reports retained items with consumed playout duration in playback order", async () => {
+    const { pacer } = createPlaybackPacer();
+
+    pacer.sendAudio(createSequencedAudio(30), { itemId: "item-a" });
+    pacer.sendAudio(createSequencedAudio(20), { itemId: "item-b" });
+
+    // Lead-window audio has not played out yet; queued items report zero.
+    expect(pacer.getPlaybackState()).toEqual([
+      { itemId: "item-a", audioEndMs: 0 },
+      { itemId: "item-b", audioEndMs: 0 },
+    ]);
+
+    // 600 ms later the pace has sent 760 ms; only 600 ms can have played out.
+    await vi.advanceTimersByTimeAsync(600);
+    expect(pacer.getPlaybackState()).toEqual([
+      { itemId: "item-a", audioEndMs: 600 },
+      { itemId: "item-b", audioEndMs: 0 },
+    ]);
+
+    await vi.advanceTimersByTimeAsync(20 * 20 + 500);
+    expect(pacer.hasPendingAudio()).toBe(false);
+    expect(pacer.getPlaybackState()).toEqual([
+      { itemId: "item-a", audioEndMs: 600 },
+      { itemId: "item-b", audioEndMs: 400 },
+    ]);
+  });
+
+  it("merges consecutive chunks of the same provider item", async () => {
+    const { pacer } = createPlaybackPacer();
+
+    pacer.sendAudio(createSequencedAudio(4), { itemId: "item-a" });
+    pacer.sendAudio(createSequencedAudio(6), { itemId: "item-a" });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 200 }]);
+  });
+
+  it("consumes playout time for untracked audio without reporting it", async () => {
+    const { pacer } = createPlaybackPacer();
+
+    pacer.sendAudio(createSequencedAudio(10));
+    pacer.sendAudio(createSequencedAudio(20), { itemId: "item-a" });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 400 }]);
+  });
+
+  it("drops playout state when queued audio is cleared or closed", async () => {
+    const { pacer } = createPlaybackPacer();
+
+    pacer.sendAudio(createSequencedAudio(20), { itemId: "item-a" });
+    await vi.advanceTimersByTimeAsync(400);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 400 }]);
+
+    pacer.clearAudio();
+    expect(pacer.getPlaybackState()).toEqual([]);
+
+    pacer.sendAudio(createSequencedAudio(20), { itemId: "item-b" });
+    pacer.close();
+    expect(pacer.getPlaybackState()).toEqual([]);
+  });
+
+  it("keeps the drained carrier lead unplayed until the playout frontier passes it", async () => {
+    const { pacer } = createPlaybackPacer();
+
+    // One lead window drains synchronously; the carrier edge still buffers it.
+    pacer.sendAudio(createSequencedAudio(8), { itemId: "item-a" });
+    expect(pacer.hasPendingAudio()).toBe(false);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 0 }]);
+
+    await vi.advanceTimersByTimeAsync(80);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 80 }]);
+
+    await vi.advanceTimersByTimeAsync(80);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 160 }]);
+  });
+
+  it("retires carrier-acknowledged playback before the next interruption", async () => {
+    const { pacer } = createPlaybackPacer();
+
+    pacer.sendAudio(createSequencedAudio(20), { itemId: "item-a" });
+    pacer.sendMark("item-a-done");
+    pacer.sendAudio(createSequencedAudio(10), { itemId: "item-b" });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(pacer.getPlaybackState()).toEqual([
+      { itemId: "item-a", audioEndMs: 400 },
+      { itemId: "item-b", audioEndMs: 200 },
+    ]);
+
+    // Carrier confirms playout reached the mark: item-a leaves the snapshot so a
+    // later interruption of item-b cannot truncate it again.
+    pacer.acknowledgeMark("item-a-done");
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-b", audioEndMs: 200 }]);
+  });
+
+  it("treats a carrier mark acknowledgement as playout confirmation", async () => {
+    const { pacer } = createPlaybackPacer();
+
+    pacer.sendAudio(createSequencedAudio(8), { itemId: "item-a" });
+    pacer.sendMark("item-a-done");
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 0 }]);
+
+    pacer.acknowledgeMark("item-a-done");
+    expect(pacer.getPlaybackState()).toEqual([]);
+  });
+
+  it("ignores acknowledgements for unknown marks", async () => {
+    const { pacer } = createPlaybackPacer();
+
+    pacer.sendAudio(createSequencedAudio(8), { itemId: "item-a" });
+    pacer.sendMark("item-a-done");
+
+    pacer.acknowledgeMark("never-sent");
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 0 }]);
+  });
+});

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
@@ -41,6 +41,29 @@ function inspectQueue(pacer: RealtimeAudioPacer): { length: number; head: number
   return { length: state.queue.length, head: state.queueHead };
 }
 
+function readSentMarks(sent: string[]): { name: string; audioEndMs: number }[] {
+  let audioEndMs = 0;
+  const marks: { name: string; audioEndMs: number }[] = [];
+  for (const message of sent) {
+    if (message.startsWith("mark:")) {
+      marks.push({ name: message.slice("mark:".length), audioEndMs });
+    } else if (message === "clear") {
+      audioEndMs = 0;
+    } else {
+      audioEndMs += Buffer.from(message, "base64").length / 8;
+    }
+  }
+  return marks;
+}
+
+function sentMarkAt(sent: string[], audioEndMs: number): string {
+  const mark = readSentMarks(sent).find((entry) => entry.audioEndMs === audioEndMs);
+  if (!mark) {
+    throw new Error(`No sent carrier mark follows ${audioEndMs} ms of audio`);
+  }
+  return mark.name;
+}
+
 describe("RealtimeAudioPacer", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -276,8 +299,8 @@ describe("RealtimeAudioPacer playout state", () => {
     return { pacer, sent };
   }
 
-  it("reports retained items with consumed playout duration in playback order", async () => {
-    const { pacer } = createPlaybackPacer();
+  it("reports zero until carrier receipts confirm a retained item's played prefix", async () => {
+    const { pacer, sent } = createPlaybackPacer();
 
     pacer.sendAudio(createSequencedAudio(30), { itemId: "item-a" });
     pacer.sendAudio(createSequencedAudio(20), { itemId: "item-b" });
@@ -288,39 +311,73 @@ describe("RealtimeAudioPacer playout state", () => {
       { itemId: "item-b", audioEndMs: 0 },
     ]);
 
-    // 600 ms later the pace has sent 760 ms; only 600 ms can have played out.
     await vi.advanceTimersByTimeAsync(600);
     expect(pacer.getPlaybackState()).toEqual([
-      { itemId: "item-a", audioEndMs: 600 },
+      { itemId: "item-a", audioEndMs: 0 },
       { itemId: "item-b", audioEndMs: 0 },
     ]);
 
-    await vi.advanceTimersByTimeAsync(20 * 20 + 500);
+    pacer.acknowledgeMark(sentMarkAt(sent, 480));
+    expect(pacer.getPlaybackState()).toEqual([
+      { itemId: "item-a", audioEndMs: 480 },
+      { itemId: "item-b", audioEndMs: 0 },
+    ]);
+
+    await vi.advanceTimersByTimeAsync(1_000);
     expect(pacer.hasPendingAudio()).toBe(false);
     expect(pacer.getPlaybackState()).toEqual([
-      { itemId: "item-a", audioEndMs: 600 },
-      { itemId: "item-b", audioEndMs: 400 },
+      { itemId: "item-a", audioEndMs: 480 },
+      { itemId: "item-b", audioEndMs: 0 },
     ]);
+    pacer.acknowledgeMark(sentMarkAt(sent, 960));
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-b", audioEndMs: 360 }]);
   });
 
   it("merges consecutive chunks of the same provider item", async () => {
-    const { pacer } = createPlaybackPacer();
+    const { pacer, sent } = createPlaybackPacer();
 
     pacer.sendAudio(createSequencedAudio(4), { itemId: "item-a" });
     pacer.sendAudio(createSequencedAudio(6), { itemId: "item-a" });
     await vi.advanceTimersByTimeAsync(1_000);
 
-    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 200 }]);
+    pacer.acknowledgeMark(sentMarkAt(sent, 160));
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 160 }]);
+  });
+
+  it("reports one cumulative offset when an item resumes after another item", async () => {
+    const { pacer, sent } = createPlaybackPacer();
+
+    pacer.sendAudio(createSequencedAudio(30), { itemId: "item-a" });
+    pacer.sendAudio(createSequencedAudio(20), { itemId: "item-b" });
+    pacer.sendAudio(createSequencedAudio(10), { itemId: "item-a" });
+    await vi.advanceTimersByTimeAsync(300);
+    pacer.acknowledgeMark(sentMarkAt(sent, 160));
+
+    expect(pacer.getPlaybackState()).toEqual([
+      { itemId: "item-a", audioEndMs: 160 },
+      { itemId: "item-b", audioEndMs: 0 },
+    ]);
+
+    await vi.advanceTimersByTimeAsync(860);
+    pacer.acknowledgeMark(sentMarkAt(sent, 1120));
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 720 }]);
   });
 
   it("consumes playout time for untracked audio without reporting it", async () => {
-    const { pacer } = createPlaybackPacer();
+    const { pacer, sent } = createPlaybackPacer();
 
     pacer.sendAudio(createSequencedAudio(10));
     pacer.sendAudio(createSequencedAudio(20), { itemId: "item-a" });
     await vi.advanceTimersByTimeAsync(1_000);
 
-    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 400 }]);
+    const mark = readSentMarks(sent).find((entry) => entry.audioEndMs > 200);
+    if (!mark) {
+      throw new Error("No progress mark follows the anonymous audio prefix");
+    }
+    pacer.acknowledgeMark(mark.name);
+    expect(pacer.getPlaybackState()).toEqual([
+      { itemId: "item-a", audioEndMs: mark.audioEndMs - 200 },
+    ]);
   });
 
   it("drops playout state when queued audio is cleared or closed", async () => {
@@ -328,7 +385,7 @@ describe("RealtimeAudioPacer playout state", () => {
 
     pacer.sendAudio(createSequencedAudio(20), { itemId: "item-a" });
     await vi.advanceTimersByTimeAsync(400);
-    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 400 }]);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 0 }]);
 
     pacer.clearAudio();
     expect(pacer.getPlaybackState()).toEqual([]);
@@ -338,8 +395,8 @@ describe("RealtimeAudioPacer playout state", () => {
     expect(pacer.getPlaybackState()).toEqual([]);
   });
 
-  it("keeps the drained carrier lead unplayed until the playout frontier passes it", async () => {
-    const { pacer } = createPlaybackPacer();
+  it("keeps the drained carrier lead unconfirmed until its played mark arrives", async () => {
+    const { pacer, sent } = createPlaybackPacer();
 
     // One lead window drains synchronously; the carrier edge still buffers it.
     pacer.sendAudio(createSequencedAudio(8), { itemId: "item-a" });
@@ -347,10 +404,12 @@ describe("RealtimeAudioPacer playout state", () => {
     expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 0 }]);
 
     await vi.advanceTimersByTimeAsync(80);
-    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 80 }]);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 0 }]);
 
     await vi.advanceTimersByTimeAsync(80);
-    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 160 }]);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 0 }]);
+    pacer.acknowledgeMark(sentMarkAt(sent, 160));
+    expect(pacer.getPlaybackState()).toEqual([]);
   });
 
   it("retires carrier-acknowledged playback before the next interruption", async () => {
@@ -361,14 +420,14 @@ describe("RealtimeAudioPacer playout state", () => {
     pacer.sendAudio(createSequencedAudio(10), { itemId: "item-b" });
     await vi.advanceTimersByTimeAsync(1_000);
     expect(pacer.getPlaybackState()).toEqual([
-      { itemId: "item-a", audioEndMs: 400 },
-      { itemId: "item-b", audioEndMs: 200 },
+      { itemId: "item-a", audioEndMs: 0 },
+      { itemId: "item-b", audioEndMs: 0 },
     ]);
 
     // Carrier confirms playout reached the mark: item-a leaves the snapshot so a
     // later interruption of item-b cannot truncate it again.
     pacer.acknowledgeMark("item-a-done");
-    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-b", audioEndMs: 200 }]);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-b", audioEndMs: 0 }]);
   });
 
   it("treats a carrier mark acknowledgement as playout confirmation", async () => {
@@ -378,6 +437,7 @@ describe("RealtimeAudioPacer playout state", () => {
     pacer.sendMark("item-a-done");
     expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 0 }]);
 
+    await vi.advanceTimersByTimeAsync(160);
     pacer.acknowledgeMark("item-a-done");
     expect(pacer.getPlaybackState()).toEqual([]);
   });
@@ -411,7 +471,7 @@ describe("RealtimeAudioPacer playout state", () => {
     // acknowledged offset instead of restarting at zero.
     pacer.sendAudio(createSequencedAudio(3), { itemId: "item-a" });
     await vi.advanceTimersByTimeAsync(1_000);
-    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 260 }]);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 200 }]);
   });
 
   it("retires every retained prefix confirmed by one mark", async () => {
@@ -422,42 +482,80 @@ describe("RealtimeAudioPacer playout state", () => {
     pacer.sendMark("both-played");
     await vi.advanceTimersByTimeAsync(1_000);
     expect(pacer.getPlaybackState()).toEqual([
-      { itemId: "item-a", audioEndMs: 100 },
-      { itemId: "item-b", audioEndMs: 100 },
+      { itemId: "item-a", audioEndMs: 0 },
+      { itemId: "item-b", audioEndMs: 0 },
     ]);
 
     pacer.acknowledgeMark("both-played");
     expect(pacer.getPlaybackState()).toEqual([]);
   });
 
-  it("carries the buffered lead forward when another short burst drains", async () => {
-    const { pacer } = createPlaybackPacer();
+  it("confirms only the first short burst when a later burst is still unacknowledged", async () => {
+    const { pacer, sent } = createPlaybackPacer();
 
     pacer.sendAudio(createSequencedAudio(8), { itemId: "item-a" });
     await vi.advanceTimersByTimeAsync(80);
     pacer.sendAudio(createSequencedAudio(8), { itemId: "item-a" });
 
-    // Only 80 ms of wall time has passed, so only 80 ms can have played even
-    // though both bursts drained synchronously.
-    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 80 }]);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 0 }]);
 
     await vi.advanceTimersByTimeAsync(240);
-    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 320 }]);
+    pacer.acknowledgeMark(sentMarkAt(sent, 160));
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 160 }]);
+    pacer.acknowledgeMark(sentMarkAt(sent, 320));
+    expect(pacer.getPlaybackState()).toEqual([]);
   });
 
-  it("carries outstanding playback through a resumed paced burst", async () => {
-    const { pacer } = createPlaybackPacer();
+  it("keeps queued frames attached to their item after a partial progress receipt", async () => {
+    const { pacer, sent } = createPlaybackPacer();
 
     pacer.sendAudio(createSequencedAudio(8), { itemId: "item-a" });
     await vi.advanceTimersByTimeAsync(80);
-    // A larger burst resumes pacing instead of draining synchronously; the
-    // frontier must still only claim the 80 ms that could have played.
     pacer.sendAudio(createSequencedAudio(20), { itemId: "item-a" });
     expect(pacer.hasPendingAudio()).toBe(true);
-    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 80 }]);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 0 }]);
+
+    await vi.advanceTimersByTimeAsync(80);
+    pacer.acknowledgeMark(sentMarkAt(sent, 160));
+    expect(pacer.hasPendingAudio()).toBe(true);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 160 }]);
 
     await vi.advanceTimersByTimeAsync(400);
+    pacer.acknowledgeMark(sentMarkAt(sent, 480));
     expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 480 }]);
+  });
+
+  it("does not retire an unfinished item when the carrier catches up to a delayed pump", async () => {
+    const { pacer, sent } = createPlaybackPacer();
+    const stalledClock = vi.spyOn(performance, "now").mockReturnValue(0);
+    try {
+      pacer.sendAudio(createSequencedAudio(30), { itemId: "item-a" });
+      const mark = sentMarkAt(sent, 160);
+
+      // The carrier plays the sent lead while the pump has no new clock tick.
+      await vi.advanceTimersByTimeAsync(160);
+      expect(sent.filter((message) => !message.startsWith("mark:"))).toHaveLength(8);
+      pacer.acknowledgeMark(mark);
+
+      expect(pacer.hasPendingAudio()).toBe(true);
+      expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 160 }]);
+    } finally {
+      pacer.close();
+      stalledClock.mockRestore();
+    }
+  });
+
+  it("ignores a delayed progress receipt after clear when the same item resumes", async () => {
+    const { pacer, sent } = createPlaybackPacer();
+
+    pacer.sendAudio(createSequencedAudio(30), { itemId: "item-a" });
+    await vi.advanceTimersByTimeAsync(160);
+    const oldMark = sentMarkAt(sent, 160);
+    pacer.clearAudio();
+    pacer.sendAudio(createSequencedAudio(30), { itemId: "item-a" });
+    pacer.acknowledgeMark(oldMark);
+
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 0 }]);
   });
 
   it("fires the playback reset hook on every clear and close", async () => {
@@ -539,24 +637,45 @@ describe("RealtimeAudioPacer playback retention", () => {
     expect(onBackpressure).toHaveBeenCalledOnce();
   });
 
-  it("drops fully played segments at the retention limit without backpressure", async () => {
+  it("does not evict fully sent segments without receipts after elapsed playout time", async () => {
     const { pacer, onBackpressure } = createRetentionPolicyPacer();
 
-    // 128 distinct items whose audio is fully sent and played out.
     for (let index = 1; index <= 128; index += 1) {
       pacer.sendAudio(createSequencedAudio(1), { itemId: `item-${index}` });
     }
     await vi.advanceTimersByTimeAsync(128 * 20 + 500);
     expect(pacer.hasPendingAudio()).toBe(false);
+    expect(pacer.getPlaybackState()).toEqual(
+      Array.from({ length: 128 }, (_, index) => ({
+        itemId: `item-${index + 1}`,
+        audioEndMs: 0,
+      })),
+    );
 
-    // The head segment has been fully consumed, so the retention bound can
-    // release it and admit the 129th item without tearing the call down.
     pacer.sendAudio(createSequencedAudio(1), { itemId: "item-129" });
-    expect(onBackpressure).not.toHaveBeenCalled();
+    expect(onBackpressure).toHaveBeenCalledOnce();
+    expect(pacer.hasPendingAudio()).toBe(false);
+  });
 
-    const state = pacer.getPlaybackState();
-    expect(state).toHaveLength(128);
-    expect(state.at(0)).toEqual({ itemId: "item-2", audioEndMs: 20 });
-    expect(state.at(-1)).toEqual({ itemId: "item-129", audioEndMs: 0 });
+  it("reuses retention capacity only after receipts confirm completed prefixes", async () => {
+    const { pacer, sent, onBackpressure } = createRetentionPolicyPacer();
+
+    for (let index = 1; index <= 128; index += 1) {
+      pacer.sendAudio(createSequencedAudio(1), { itemId: `item-${index}` });
+    }
+    await vi.advanceTimersByTimeAsync(128 * 20 + 500);
+    pacer.acknowledgeMark(sentMarkAt(sent, 160));
+
+    expect(pacer.getPlaybackState()).toHaveLength(120);
+    expect(pacer.getPlaybackState().at(0)).toEqual({ itemId: "item-9", audioEndMs: 0 });
+    for (let index = 129; index <= 136; index += 1) {
+      pacer.sendAudio(createSequencedAudio(1), { itemId: `item-${index}` });
+    }
+    expect(onBackpressure).not.toHaveBeenCalled();
+    expect(pacer.getPlaybackState()).toHaveLength(128);
+    expect(pacer.getPlaybackState().at(-1)).toEqual({ itemId: "item-136", audioEndMs: 0 });
+
+    pacer.sendAudio(createSequencedAudio(1), { itemId: "item-137" });
+    expect(onBackpressure).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
@@ -391,4 +391,172 @@ describe("RealtimeAudioPacer playout state", () => {
     pacer.acknowledgeMark("never-sent");
     expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 0 }]);
   });
+
+  it("preserves cumulative item progress across chunk acknowledgements", async () => {
+    const { pacer } = createPlaybackPacer();
+
+    // Providers emit a mark after every audio delta, so an item can be
+    // acknowledged and then resume with more audio under the same item id.
+    pacer.sendAudio(createSequencedAudio(5), { itemId: "item-a" });
+    pacer.sendMark("chunk-1");
+    pacer.sendAudio(createSequencedAudio(5), { itemId: "item-a" });
+    pacer.sendMark("chunk-2");
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    pacer.acknowledgeMark("chunk-1");
+    pacer.acknowledgeMark("chunk-2");
+    expect(pacer.getPlaybackState()).toEqual([]);
+
+    // Generation resumes for the same item: the snapshot continues from the
+    // acknowledged offset instead of restarting at zero.
+    pacer.sendAudio(createSequencedAudio(3), { itemId: "item-a" });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 260 }]);
+  });
+
+  it("retires every retained prefix confirmed by one mark", async () => {
+    const { pacer } = createPlaybackPacer();
+
+    pacer.sendAudio(createSequencedAudio(5), { itemId: "item-a" });
+    pacer.sendAudio(createSequencedAudio(5), { itemId: "item-b" });
+    pacer.sendMark("both-played");
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(pacer.getPlaybackState()).toEqual([
+      { itemId: "item-a", audioEndMs: 100 },
+      { itemId: "item-b", audioEndMs: 100 },
+    ]);
+
+    pacer.acknowledgeMark("both-played");
+    expect(pacer.getPlaybackState()).toEqual([]);
+  });
+
+  it("carries the buffered lead forward when another short burst drains", async () => {
+    const { pacer } = createPlaybackPacer();
+
+    pacer.sendAudio(createSequencedAudio(8), { itemId: "item-a" });
+    await vi.advanceTimersByTimeAsync(80);
+    pacer.sendAudio(createSequencedAudio(8), { itemId: "item-a" });
+
+    // Only 80 ms of wall time has passed, so only 80 ms can have played even
+    // though both bursts drained synchronously.
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 80 }]);
+
+    await vi.advanceTimersByTimeAsync(240);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 320 }]);
+  });
+
+  it("carries outstanding playback through a resumed paced burst", async () => {
+    const { pacer } = createPlaybackPacer();
+
+    pacer.sendAudio(createSequencedAudio(8), { itemId: "item-a" });
+    await vi.advanceTimersByTimeAsync(80);
+    // A larger burst resumes pacing instead of draining synchronously; the
+    // frontier must still only claim the 80 ms that could have played.
+    pacer.sendAudio(createSequencedAudio(20), { itemId: "item-a" });
+    expect(pacer.hasPendingAudio()).toBe(true);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 80 }]);
+
+    await vi.advanceTimersByTimeAsync(400);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-a", audioEndMs: 480 }]);
+  });
+
+  it("fires the playback reset hook on every clear and close", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance", "Date"] });
+    const onPlaybackReset = vi.fn();
+    const pacer = new RealtimeAudioPacer({
+      serializer: createCompactSerializer(),
+      onPlaybackReset,
+      send: () => true,
+    });
+
+    pacer.sendAudio(createSequencedAudio(8), { itemId: "item-a" });
+    pacer.clearAudio();
+    expect(onPlaybackReset).toHaveBeenCalledTimes(1);
+
+    pacer.sendAudio(createSequencedAudio(8), { itemId: "item-b" });
+    pacer.close();
+    expect(onPlaybackReset).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("RealtimeAudioPacer playback retention", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function createRetentionPolicyPacer() {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance", "Date"] });
+    const sent: string[] = [];
+    const onBackpressure = vi.fn();
+    const pacer = new RealtimeAudioPacer({
+      serializer: createCompactSerializer(),
+      onBackpressure,
+      send: (message) => {
+        sent.push(message);
+        return true;
+      },
+    });
+    return { pacer, sent, onBackpressure };
+  }
+
+  it("tears down through backpressure instead of evicting a queued item at the retention limit", async () => {
+    const { pacer, onBackpressure } = createRetentionPolicyPacer();
+
+    // A 2,000 ms playing item followed by 127 distinct 20 ms items fills the
+    // 128-segment retention bound while staying far below the byte limit.
+    pacer.sendAudio(createSequencedAudio(100), { itemId: "item-1" });
+    for (let index = 2; index <= 128; index += 1) {
+      pacer.sendAudio(createSequencedAudio(1), { itemId: `item-${index}` });
+    }
+
+    // The playing item keeps its identity: the snapshot still reports it.
+    expect(onBackpressure).not.toHaveBeenCalled();
+    expect(pacer.getPlaybackState().at(0)).toEqual({ itemId: "item-1", audioEndMs: 0 });
+
+    // The 129th distinct item cannot be admitted because the oldest segment
+    // still has unsent queued frames, so the pacer must fail loudly through
+    // the existing backpressure path instead of silently dropping identity.
+    pacer.sendAudio(createSequencedAudio(1), { itemId: "item-129" });
+    expect(onBackpressure).toHaveBeenCalledOnce();
+    expect(pacer.hasPendingAudio()).toBe(false);
+    expect(pacer.getPlaybackState()).toEqual([]);
+  });
+
+  it("keeps a fully sent but unplayed lead item live at the retention limit", async () => {
+    const { pacer, onBackpressure } = createRetentionPolicyPacer();
+
+    // The first item drains synchronously into the carrier lead window: every
+    // frame is sent, but none of it can have played out yet.
+    pacer.sendAudio(createSequencedAudio(8), { itemId: "item-1" });
+    expect(pacer.hasPendingAudio()).toBe(false);
+    expect(pacer.getPlaybackState()).toEqual([{ itemId: "item-1", audioEndMs: 0 }]);
+
+    for (let index = 2; index <= 128; index += 1) {
+      pacer.sendAudio(createSequencedAudio(1), { itemId: `item-${index}` });
+    }
+
+    pacer.sendAudio(createSequencedAudio(1), { itemId: "item-129" });
+    expect(onBackpressure).toHaveBeenCalledOnce();
+  });
+
+  it("drops fully played segments at the retention limit without backpressure", async () => {
+    const { pacer, onBackpressure } = createRetentionPolicyPacer();
+
+    // 128 distinct items whose audio is fully sent and played out.
+    for (let index = 1; index <= 128; index += 1) {
+      pacer.sendAudio(createSequencedAudio(1), { itemId: `item-${index}` });
+    }
+    await vi.advanceTimersByTimeAsync(128 * 20 + 500);
+    expect(pacer.hasPendingAudio()).toBe(false);
+
+    // The head segment has been fully consumed, so the retention bound can
+    // release it and admit the 129th item without tearing the call down.
+    pacer.sendAudio(createSequencedAudio(1), { itemId: "item-129" });
+    expect(onBackpressure).not.toHaveBeenCalled();
+
+    const state = pacer.getPlaybackState();
+    expect(state).toHaveLength(128);
+    expect(state.at(0)).toEqual({ itemId: "item-2", audioEndMs: 20 });
+    expect(state.at(-1)).toEqual({ itemId: "item-129", audioEndMs: 0 });
+  });
 });

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
@@ -7,18 +7,42 @@ const TELEPHONY_CHUNK_BYTES = 160;
 const LEAD_MS = 160;
 const DEFAULT_MAX_QUEUED_AUDIO_BYTES = TELEPHONY_SAMPLE_RATE * 120;
 const QUEUE_COMPACT_HEAD_THRESHOLD = 256;
+const MAX_PLAYBACK_SEGMENTS = 128;
+const MAX_PENDING_MARK_BOUNDARIES = 64;
 
 /** Queue item sent over the realtime provider media stream. */
 type RealtimeAudioQueueItem =
   | {
       chunk: Buffer;
       durationMs: number;
+      segment: RealtimePlaybackSegment;
       type: "audio";
     }
   | {
       name: string;
       type: "mark";
     };
+
+/** Retained playout accounting for one run of same-item provider audio. */
+type RealtimePlaybackSegment = {
+  itemId?: string;
+  totalMs: number;
+  sentMs: number;
+  /** Cumulative send position of the segment's last sent frame. */
+  lastSentEndMs?: number;
+};
+
+/** Send-time snapshot binding a carrier mark to the playback prefix before it. */
+type RealtimeMarkBoundary = {
+  name: string;
+  sentMs: number;
+};
+
+/** Carrier edge buffer still ahead of playout when the paced queue drained. */
+type RealtimeDrainedLead = {
+  atMs: number;
+  bufferedMs: number;
+};
 
 /** WebSocket send callback for realtime audio frames. */
 type RealtimeAudioSend = (message: string) => boolean;
@@ -38,6 +62,12 @@ export class RealtimeAudioPacer {
   private queuedAudioBytes = 0;
   private closed = false;
   private streamClockMs: number | null = null;
+  private playbackSegments: RealtimePlaybackSegment[] = [];
+  private sentAudioMs = 0;
+  private evictedSentMs = 0;
+  private confirmedPlayedMs = 0;
+  private drainedLead: RealtimeDrainedLead | null = null;
+  private markBoundaries: RealtimeMarkBoundary[] = [];
 
   constructor(
     private readonly params: {
@@ -49,7 +79,7 @@ export class RealtimeAudioPacer {
   ) {}
 
   /** Queue mulaw audio and split it into 20ms-ish telephony chunks. */
-  sendAudio(muLaw: Buffer): void {
+  sendAudio(muLaw: Buffer, metadata?: { itemId?: string }): void {
     if (this.closed || muLaw.length === 0) {
       return;
     }
@@ -60,14 +90,34 @@ export class RealtimeAudioPacer {
         this.failBackpressure();
         return;
       }
+      const durationMs = chunk.length / 8;
+      const segment = this.extendPlaybackSegment(metadata?.itemId, durationMs);
       this.queue.push({
         type: "audio",
         chunk,
-        durationMs: chunk.length / 8,
+        durationMs,
+        segment,
       });
       this.queuedAudioBytes += chunk.length;
     }
     this.ensurePump();
+  }
+
+  /**
+   * Retained provider items in playback order with consumed playout duration.
+   * Queued audio has not reached the telephony line, so unplayed items report zero.
+   */
+  getPlaybackState(): { itemId: string; audioEndMs: number }[] {
+    let remaining = Math.max(0, this.consumedPlayoutMs() - this.evictedSentMs);
+    const items: { itemId: string; audioEndMs: number }[] = [];
+    for (const segment of this.playbackSegments) {
+      const consumed = Math.min(remaining, segment.sentMs);
+      remaining -= consumed;
+      if (segment.itemId !== undefined) {
+        items.push({ itemId: segment.itemId, audioEndMs: Math.floor(consumed) });
+      }
+    }
+    return items;
   }
 
   /** Queue a provider mark frame after prior audio frames. */
@@ -79,6 +129,38 @@ export class RealtimeAudioPacer {
     this.ensurePump();
   }
 
+  /** Retire the playback prefix once the carrier confirms playout reached the mark. */
+  acknowledgeMark(name?: string): void {
+    if (this.closed || !name) {
+      return;
+    }
+    const boundaryIndex = this.markBoundaries.findIndex((boundary) => boundary.name === name);
+    if (boundaryIndex < 0) {
+      return;
+    }
+    // Carrier marks fire in send order, so every earlier boundary retires too.
+    const boundary = this.markBoundaries[boundaryIndex];
+    this.markBoundaries.splice(0, boundaryIndex + 1);
+    if (!boundary) {
+      return;
+    }
+    // Retire every segment whose sent frames all landed before the mark; the
+    // FIFO send order guarantees no retired segment receives more frames later.
+    for (const head of this.playbackSegments) {
+      if (head.lastSentEndMs === undefined || head.lastSentEndMs > boundary.sentMs) {
+        break;
+      }
+      const retired = this.playbackSegments.shift();
+      if (retired) {
+        this.evictedSentMs += retired.sentMs;
+      }
+    }
+    this.confirmedPlayedMs = Math.max(
+      this.confirmedPlayedMs,
+      Math.min(boundary.sentMs, this.sentAudioMs),
+    );
+  }
+
   /** Clear queued audio and notify the provider stream. */
   clearAudio(): number {
     if (this.closed) {
@@ -87,8 +169,7 @@ export class RealtimeAudioPacer {
     const clearedAudioBytes = this.queuedAudioBytes;
     this.clearTimer();
     this.resetQueue();
-    this.queuedAudioBytes = 0;
-    this.streamClockMs = null;
+    this.resetPlaybackState();
     this.params.send(this.params.serializer.clear());
     return clearedAudioBytes;
   }
@@ -103,7 +184,52 @@ export class RealtimeAudioPacer {
     this.closed = true;
     this.clearTimer();
     this.resetQueue();
+    this.resetPlaybackState();
+  }
+
+  /** Milliseconds of sent audio the telephony edge can already have played. */
+  private consumedPlayoutMs(): number {
+    let consumedMs: number;
+    if (this.hasPendingAudio()) {
+      // While pacing, the lead window is still buffered in the telephony edge.
+      consumedMs = Math.max(0, this.sentAudioMs - LEAD_MS);
+    } else if (this.drainedLead) {
+      // The queue drained, but the final lead can still sit in the carrier buffer
+      // until the playout frontier passes it.
+      const elapsedMs = Math.max(0, performance.now() - this.drainedLead.atMs);
+      const bufferedMs = Math.max(0, this.drainedLead.bufferedMs - elapsedMs);
+      consumedMs = Math.max(0, this.sentAudioMs - bufferedMs);
+    } else {
+      consumedMs = 0;
+    }
+    // Carrier mark acknowledgements confirm playout regardless of the lead estimate.
+    return Math.min(this.sentAudioMs, Math.max(consumedMs, this.confirmedPlayedMs));
+  }
+
+  private extendPlaybackSegment(itemId: string | undefined, durationMs: number) {
+    let segment = this.playbackSegments.at(-1);
+    if (!segment || segment.itemId !== itemId) {
+      segment = { itemId, totalMs: 0, sentMs: 0 };
+      this.playbackSegments.push(segment);
+      while (this.playbackSegments.length > MAX_PLAYBACK_SEGMENTS) {
+        const dropped = this.playbackSegments.shift();
+        if (dropped) {
+          this.evictedSentMs += dropped.sentMs;
+        }
+      }
+    }
+    segment.totalMs += durationMs;
+    return segment;
+  }
+
+  private resetPlaybackState(): void {
+    this.playbackSegments = [];
     this.queuedAudioBytes = 0;
+    this.sentAudioMs = 0;
+    this.evictedSentMs = 0;
+    this.confirmedPlayedMs = 0;
+    this.drainedLead = null;
+    this.markBoundaries = [];
     this.streamClockMs = null;
   }
 
@@ -167,17 +293,24 @@ export class RealtimeAudioPacer {
     const now = performance.now();
     this.streamClockMs ??= now;
 
+    let sentAudio = false;
     while (this.pendingQueueSize > 0 && this.streamClockMs < now + LEAD_MS) {
       const item = this.takeNextItem();
       if (!item) {
         break;
       }
 
-      const sent =
-        item.type === "audio"
-          ? this.sendAudioItem(item)
-          : this.params.send(this.params.serializer.mark(item.name));
-      if (!sent) {
+      if (item.type === "audio") {
+        sentAudio = true;
+        // Fresh audio replaces any previous drain frontier.
+        this.drainedLead = null;
+        if (!this.sendAudioItem(item)) {
+          this.resetQueue();
+          this.queuedAudioBytes = 0;
+          this.streamClockMs = null;
+          return;
+        }
+      } else if (!this.sendMarkItem(item)) {
         this.resetQueue();
         this.queuedAudioBytes = 0;
         this.streamClockMs = null;
@@ -186,7 +319,7 @@ export class RealtimeAudioPacer {
     }
 
     if (this.pendingQueueSize === 0) {
-      this.streamClockMs = null;
+      this.finishDrain(now, sentAudio);
       return;
     }
     const delayMs = Math.max(1, this.streamClockMs - LEAD_MS - performance.now());
@@ -196,7 +329,44 @@ export class RealtimeAudioPacer {
   private sendAudioItem(item: Extract<RealtimeAudioQueueItem, { type: "audio" }>): boolean {
     this.queuedAudioBytes = Math.max(0, this.queuedAudioBytes - item.chunk.length);
     const sent = this.params.send(this.params.serializer.media(item.chunk.toString("base64")));
+    if (sent) {
+      item.segment.sentMs += item.durationMs;
+      this.sentAudioMs += item.durationMs;
+      item.segment.lastSentEndMs = this.sentAudioMs;
+    }
     this.streamClockMs = (this.streamClockMs ?? performance.now()) + item.durationMs;
     return sent;
+  }
+
+  /** Send a queued mark frame and bind it to the playback prefix before it. */
+  private sendMarkItem(item: Extract<RealtimeAudioQueueItem, { type: "mark" }>): boolean {
+    const sent = this.params.send(this.params.serializer.mark(item.name));
+    if (sent) {
+      this.markBoundaries.push({
+        name: item.name,
+        sentMs: this.sentAudioMs,
+      });
+      if (this.markBoundaries.length > MAX_PENDING_MARK_BOUNDARIES) {
+        this.markBoundaries.shift();
+      }
+    }
+    return sent;
+  }
+
+  /** Record how much of the lead window the carrier edge may still hold. */
+  private finishDrain(now: number, sentAudio: boolean): void {
+    if (sentAudio) {
+      const bufferedMs =
+        this.streamClockMs === null ? 0 : Math.min(LEAD_MS, Math.max(0, this.streamClockMs - now));
+      this.drainedLead = { atMs: now, bufferedMs };
+    } else if (this.drainedLead) {
+      // A mark-only pump keeps the frontier moving while the lead plays out.
+      const elapsedMs = Math.max(0, now - this.drainedLead.atMs);
+      this.drainedLead = {
+        atMs: now,
+        bufferedMs: Math.max(0, this.drainedLead.bufferedMs - elapsedMs),
+      };
+    }
+    this.streamClockMs = null;
   }
 }

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
@@ -1,4 +1,5 @@
 // Realtime telephony audio pacing for mulaw streams.
+import { randomUUID } from "node:crypto";
 
 const TELEPHONY_SAMPLE_RATE = 8_000;
 const TELEPHONY_CHUNK_BYTES = 160;
@@ -58,10 +59,11 @@ export class RealtimeAudioPacer {
   private streamClockMs: number | null = null;
   private playbackSegments: RealtimePlaybackSegment[] = [];
   private sentAudioMs = 0;
-  private evictedSentMs = 0;
+  private retiredAudioMs = 0;
   private confirmedPlayedMs = 0;
-  private playedFrontierMs = 0;
-  private frontierAtMs: number | null = null;
+  private readonly playbackMarkPrefix = `openclaw-playout-${randomUUID()}`;
+  private playbackMarkSequence = 0;
+  private lastPlaybackMarkMs = 0;
   private markBoundaries: RealtimeMarkBoundary[] = [];
   private retiredItemOffsets = new Map<string, number>();
 
@@ -113,17 +115,21 @@ export class RealtimeAudioPacer {
    * Queued audio has not reached the telephony line, so unplayed items report zero.
    */
   getPlaybackState(): { itemId: string; audioEndMs: number }[] {
-    let remaining = Math.max(0, this.consumedPlayoutMs() - this.evictedSentMs);
-    const items: { itemId: string; audioEndMs: number }[] = [];
+    let remaining = Math.max(0, this.confirmedPlayedMs - this.retiredAudioMs);
+    const playedByItem = new Map<string, number>();
     for (const segment of this.playbackSegments) {
       const consumed = Math.min(remaining, segment.sentMs);
       remaining -= consumed;
       if (segment.itemId !== undefined) {
-        const retiredOffsetMs = this.retiredItemOffsets.get(segment.itemId) ?? 0;
-        items.push({ itemId: segment.itemId, audioEndMs: Math.floor(consumed + retiredOffsetMs) });
+        const previousMs =
+          playedByItem.get(segment.itemId) ?? this.retiredItemOffsets.get(segment.itemId) ?? 0;
+        playedByItem.set(segment.itemId, previousMs + consumed);
       }
     }
-    return items;
+    return Array.from(playedByItem, ([itemId, audioEndMs]) => ({
+      itemId,
+      audioEndMs: Math.floor(audioEndMs),
+    }));
   }
 
   /** Queue a provider mark frame after prior audio frames. */
@@ -150,16 +156,20 @@ export class RealtimeAudioPacer {
     if (!boundary) {
       return;
     }
-    // Retire every segment whose sent frames all landed before the mark; the
-    // FIFO send order guarantees no retired segment receives more frames later.
+    // Progress marks can confirm a prefix while the same item still has queued audio.
     while (this.playbackSegments.length > 0) {
       const head = this.playbackSegments[0];
-      if (!head || head.lastSentEndMs === undefined || head.lastSentEndMs > boundary.sentMs) {
+      if (
+        !head ||
+        head.sentMs < head.totalMs ||
+        head.lastSentEndMs === undefined ||
+        head.lastSentEndMs > boundary.sentMs
+      ) {
         break;
       }
       const retired = this.playbackSegments.shift();
       if (retired) {
-        this.evictedSentMs += retired.sentMs;
+        this.retiredAudioMs += retired.sentMs;
         // Providers may resume the same item after a chunk acknowledgement;
         // keep its cumulative played offset so later snapshots do not restart
         // at zero.
@@ -203,28 +213,6 @@ export class RealtimeAudioPacer {
     this.resetPlaybackState();
   }
 
-  /** Milliseconds of sent audio the telephony edge can already have played. */
-  private consumedPlayoutMs(): number {
-    // One continuous playout frontier: played duration advances with wall
-    // clock while sent audio exists, so lead windows, stacked bursts, drained
-    // tails, and resumed pacing all share the same conservative estimate.
-    this.advancePlayedFrontier(performance.now());
-    return Math.min(this.sentAudioMs, Math.max(this.playedFrontierMs, this.confirmedPlayedMs));
-  }
-
-  /** Advance the played frontier to `now`, capped at what was actually sent. */
-  private advancePlayedFrontier(now: number): void {
-    if (this.frontierAtMs === null) {
-      this.frontierAtMs = now;
-      return;
-    }
-    this.playedFrontierMs = Math.min(
-      this.sentAudioMs,
-      this.playedFrontierMs + Math.max(0, now - this.frontierAtMs),
-    );
-    this.frontierAtMs = now;
-  }
-
   private extendPlaybackSegment(
     itemId: string | undefined,
     durationMs: number,
@@ -232,12 +220,7 @@ export class RealtimeAudioPacer {
     let segment = this.playbackSegments.at(-1);
     if (!segment || segment.itemId !== itemId) {
       if (this.playbackSegments.length >= MAX_PLAYBACK_SEGMENTS) {
-        // Admission control: the retention bound may only release segments
-        // that fully reached the line and were fully played out. Live
-        // segments stay authoritative for provider truncation accounting.
-        if (!this.retireFullyPlayedHeadSegment()) {
-          return null;
-        }
+        return null;
       }
       segment = { itemId, totalMs: 0, sentMs: 0 };
       this.playbackSegments.push(segment);
@@ -246,47 +229,13 @@ export class RealtimeAudioPacer {
     return segment;
   }
 
-  /**
-   * Drop the head playback segment when every frame has been sent and its
-   * playout is fully consumed. Returns false while queued or unplayed frames
-   * keep the segment live, so the caller tears down through the backpressure
-   * path instead of silently evicting a live item's playback identity.
-   */
-  private retireFullyPlayedHeadSegment(): boolean {
-    const head = this.playbackSegments[0];
-    if (!head) {
-      return true;
-    }
-    if (head.sentMs < head.totalMs) {
-      return false;
-    }
-    const playoutBudgetMs = Math.max(0, this.consumedPlayoutMs() - this.evictedSentMs);
-    if (playoutBudgetMs < head.sentMs) {
-      return false;
-    }
-    const retired = this.playbackSegments.shift();
-    if (retired) {
-      this.evictedSentMs += retired.sentMs;
-      // Keep the cumulative offset like mark retirement so a later generation
-      // of the same item does not restart its snapshot at zero.
-      if (retired.itemId !== undefined) {
-        this.retiredItemOffsets.set(
-          retired.itemId,
-          (this.retiredItemOffsets.get(retired.itemId) ?? 0) + retired.sentMs,
-        );
-      }
-    }
-    return true;
-  }
-
   private resetPlaybackState(): void {
     this.playbackSegments = [];
     this.queuedAudioBytes = 0;
     this.sentAudioMs = 0;
-    this.evictedSentMs = 0;
+    this.retiredAudioMs = 0;
     this.confirmedPlayedMs = 0;
-    this.playedFrontierMs = 0;
-    this.frontierAtMs = null;
+    this.lastPlaybackMarkMs = 0;
     this.markBoundaries = [];
     this.retiredItemOffsets.clear();
     this.streamClockMs = null;
@@ -380,14 +329,25 @@ export class RealtimeAudioPacer {
     this.queuedAudioBytes = Math.max(0, this.queuedAudioBytes - item.chunk.length);
     const sent = this.params.send(this.params.serializer.media(item.chunk.toString("base64")));
     if (sent) {
-      // Advance the frontier before the new frames count as sent.
-      this.advancePlayedFrontier(performance.now());
       item.segment.sentMs += item.durationMs;
       this.sentAudioMs += item.durationMs;
       item.segment.lastSentEndMs = this.sentAudioMs;
     }
     this.streamClockMs = (this.streamClockMs ?? performance.now()) + item.durationMs;
-    return sent;
+    if (
+      !sent ||
+      item.segment.itemId === undefined ||
+      this.sentAudioMs - this.lastPlaybackMarkMs < LEAD_MS
+    ) {
+      return sent;
+    }
+    // Confirm playout during long provider chunks, before their final provider mark.
+    this.lastPlaybackMarkMs = this.sentAudioMs;
+    this.playbackMarkSequence += 1;
+    return this.sendMarkItem({
+      type: "mark",
+      name: `${this.playbackMarkPrefix}-${this.playbackMarkSequence}`,
+    });
   }
 
   /** Send a queued mark frame and bind it to the playback prefix before it. */

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
@@ -38,12 +38,6 @@ type RealtimeMarkBoundary = {
   sentMs: number;
 };
 
-/** Carrier edge buffer still ahead of playout when the paced queue drained. */
-type RealtimeDrainedLead = {
-  atMs: number;
-  bufferedMs: number;
-};
-
 /** WebSocket send callback for realtime audio frames. */
 type RealtimeAudioSend = (message: string) => boolean;
 
@@ -66,13 +60,17 @@ export class RealtimeAudioPacer {
   private sentAudioMs = 0;
   private evictedSentMs = 0;
   private confirmedPlayedMs = 0;
-  private drainedLead: RealtimeDrainedLead | null = null;
+  private playedFrontierMs = 0;
+  private frontierAtMs: number | null = null;
   private markBoundaries: RealtimeMarkBoundary[] = [];
+  private retiredItemOffsets = new Map<string, number>();
 
   constructor(
     private readonly params: {
       maxQueuedAudioBytes?: number;
       onBackpressure?: () => void;
+      /** Fires whenever queued audio and playback state are discarded. */
+      onPlaybackReset?: () => void;
       send: RealtimeAudioSend;
       serializer: RealtimeAudioSerializer;
     },
@@ -92,6 +90,13 @@ export class RealtimeAudioPacer {
       }
       const durationMs = chunk.length / 8;
       const segment = this.extendPlaybackSegment(metadata?.itemId, durationMs);
+      if (!segment) {
+        // Retention is at capacity with live segments. Losing a queued item's
+        // playback identity would corrupt interruption accounting, so tear
+        // down through the existing backpressure path instead of admitting it.
+        this.failBackpressure();
+        return;
+      }
       this.queue.push({
         type: "audio",
         chunk,
@@ -114,7 +119,8 @@ export class RealtimeAudioPacer {
       const consumed = Math.min(remaining, segment.sentMs);
       remaining -= consumed;
       if (segment.itemId !== undefined) {
-        items.push({ itemId: segment.itemId, audioEndMs: Math.floor(consumed) });
+        const retiredOffsetMs = this.retiredItemOffsets.get(segment.itemId) ?? 0;
+        items.push({ itemId: segment.itemId, audioEndMs: Math.floor(consumed + retiredOffsetMs) });
       }
     }
     return items;
@@ -146,13 +152,23 @@ export class RealtimeAudioPacer {
     }
     // Retire every segment whose sent frames all landed before the mark; the
     // FIFO send order guarantees no retired segment receives more frames later.
-    for (const head of this.playbackSegments) {
-      if (head.lastSentEndMs === undefined || head.lastSentEndMs > boundary.sentMs) {
+    while (this.playbackSegments.length > 0) {
+      const head = this.playbackSegments[0];
+      if (!head || head.lastSentEndMs === undefined || head.lastSentEndMs > boundary.sentMs) {
         break;
       }
       const retired = this.playbackSegments.shift();
       if (retired) {
         this.evictedSentMs += retired.sentMs;
+        // Providers may resume the same item after a chunk acknowledgement;
+        // keep its cumulative played offset so later snapshots do not restart
+        // at zero.
+        if (retired.itemId !== undefined) {
+          this.retiredItemOffsets.set(
+            retired.itemId,
+            (this.retiredItemOffsets.get(retired.itemId) ?? 0) + retired.sentMs,
+          );
+        }
       }
     }
     this.confirmedPlayedMs = Math.max(
@@ -189,37 +205,78 @@ export class RealtimeAudioPacer {
 
   /** Milliseconds of sent audio the telephony edge can already have played. */
   private consumedPlayoutMs(): number {
-    let consumedMs: number;
-    if (this.hasPendingAudio()) {
-      // While pacing, the lead window is still buffered in the telephony edge.
-      consumedMs = Math.max(0, this.sentAudioMs - LEAD_MS);
-    } else if (this.drainedLead) {
-      // The queue drained, but the final lead can still sit in the carrier buffer
-      // until the playout frontier passes it.
-      const elapsedMs = Math.max(0, performance.now() - this.drainedLead.atMs);
-      const bufferedMs = Math.max(0, this.drainedLead.bufferedMs - elapsedMs);
-      consumedMs = Math.max(0, this.sentAudioMs - bufferedMs);
-    } else {
-      consumedMs = 0;
-    }
-    // Carrier mark acknowledgements confirm playout regardless of the lead estimate.
-    return Math.min(this.sentAudioMs, Math.max(consumedMs, this.confirmedPlayedMs));
+    // One continuous playout frontier: played duration advances with wall
+    // clock while sent audio exists, so lead windows, stacked bursts, drained
+    // tails, and resumed pacing all share the same conservative estimate.
+    this.advancePlayedFrontier(performance.now());
+    return Math.min(this.sentAudioMs, Math.max(this.playedFrontierMs, this.confirmedPlayedMs));
   }
 
-  private extendPlaybackSegment(itemId: string | undefined, durationMs: number) {
+  /** Advance the played frontier to `now`, capped at what was actually sent. */
+  private advancePlayedFrontier(now: number): void {
+    if (this.frontierAtMs === null) {
+      this.frontierAtMs = now;
+      return;
+    }
+    this.playedFrontierMs = Math.min(
+      this.sentAudioMs,
+      this.playedFrontierMs + Math.max(0, now - this.frontierAtMs),
+    );
+    this.frontierAtMs = now;
+  }
+
+  private extendPlaybackSegment(
+    itemId: string | undefined,
+    durationMs: number,
+  ): RealtimePlaybackSegment | null {
     let segment = this.playbackSegments.at(-1);
     if (!segment || segment.itemId !== itemId) {
-      segment = { itemId, totalMs: 0, sentMs: 0 };
-      this.playbackSegments.push(segment);
-      while (this.playbackSegments.length > MAX_PLAYBACK_SEGMENTS) {
-        const dropped = this.playbackSegments.shift();
-        if (dropped) {
-          this.evictedSentMs += dropped.sentMs;
+      if (this.playbackSegments.length >= MAX_PLAYBACK_SEGMENTS) {
+        // Admission control: the retention bound may only release segments
+        // that fully reached the line and were fully played out. Live
+        // segments stay authoritative for provider truncation accounting.
+        if (!this.retireFullyPlayedHeadSegment()) {
+          return null;
         }
       }
+      segment = { itemId, totalMs: 0, sentMs: 0 };
+      this.playbackSegments.push(segment);
     }
     segment.totalMs += durationMs;
     return segment;
+  }
+
+  /**
+   * Drop the head playback segment when every frame has been sent and its
+   * playout is fully consumed. Returns false while queued or unplayed frames
+   * keep the segment live, so the caller tears down through the backpressure
+   * path instead of silently evicting a live item's playback identity.
+   */
+  private retireFullyPlayedHeadSegment(): boolean {
+    const head = this.playbackSegments[0];
+    if (!head) {
+      return true;
+    }
+    if (head.sentMs < head.totalMs) {
+      return false;
+    }
+    const playoutBudgetMs = Math.max(0, this.consumedPlayoutMs() - this.evictedSentMs);
+    if (playoutBudgetMs < head.sentMs) {
+      return false;
+    }
+    const retired = this.playbackSegments.shift();
+    if (retired) {
+      this.evictedSentMs += retired.sentMs;
+      // Keep the cumulative offset like mark retirement so a later generation
+      // of the same item does not restart its snapshot at zero.
+      if (retired.itemId !== undefined) {
+        this.retiredItemOffsets.set(
+          retired.itemId,
+          (this.retiredItemOffsets.get(retired.itemId) ?? 0) + retired.sentMs,
+        );
+      }
+    }
+    return true;
   }
 
   private resetPlaybackState(): void {
@@ -228,9 +285,12 @@ export class RealtimeAudioPacer {
     this.sentAudioMs = 0;
     this.evictedSentMs = 0;
     this.confirmedPlayedMs = 0;
-    this.drainedLead = null;
+    this.playedFrontierMs = 0;
+    this.frontierAtMs = null;
     this.markBoundaries = [];
+    this.retiredItemOffsets.clear();
     this.streamClockMs = null;
+    this.params.onPlaybackReset?.();
   }
 
   /** Clear the scheduled pump timer. */
@@ -293,24 +353,14 @@ export class RealtimeAudioPacer {
     const now = performance.now();
     this.streamClockMs ??= now;
 
-    let sentAudio = false;
     while (this.pendingQueueSize > 0 && this.streamClockMs < now + LEAD_MS) {
       const item = this.takeNextItem();
       if (!item) {
         break;
       }
 
-      if (item.type === "audio") {
-        sentAudio = true;
-        // Fresh audio replaces any previous drain frontier.
-        this.drainedLead = null;
-        if (!this.sendAudioItem(item)) {
-          this.resetQueue();
-          this.queuedAudioBytes = 0;
-          this.streamClockMs = null;
-          return;
-        }
-      } else if (!this.sendMarkItem(item)) {
+      const sent = item.type === "audio" ? this.sendAudioItem(item) : this.sendMarkItem(item);
+      if (!sent) {
         this.resetQueue();
         this.queuedAudioBytes = 0;
         this.streamClockMs = null;
@@ -319,7 +369,7 @@ export class RealtimeAudioPacer {
     }
 
     if (this.pendingQueueSize === 0) {
-      this.finishDrain(now, sentAudio);
+      this.streamClockMs = null;
       return;
     }
     const delayMs = Math.max(1, this.streamClockMs - LEAD_MS - performance.now());
@@ -330,6 +380,8 @@ export class RealtimeAudioPacer {
     this.queuedAudioBytes = Math.max(0, this.queuedAudioBytes - item.chunk.length);
     const sent = this.params.send(this.params.serializer.media(item.chunk.toString("base64")));
     if (sent) {
+      // Advance the frontier before the new frames count as sent.
+      this.advancePlayedFrontier(performance.now());
       item.segment.sentMs += item.durationMs;
       this.sentAudioMs += item.durationMs;
       item.segment.lastSentEndMs = this.sentAudioMs;
@@ -351,22 +403,5 @@ export class RealtimeAudioPacer {
       }
     }
     return sent;
-  }
-
-  /** Record how much of the lead window the carrier edge may still hold. */
-  private finishDrain(now: number, sentAudio: boolean): void {
-    if (sentAudio) {
-      const bufferedMs =
-        this.streamClockMs === null ? 0 : Math.min(LEAD_MS, Math.max(0, this.streamClockMs - now));
-      this.drainedLead = { atMs: now, bufferedMs };
-    } else if (this.drainedLead) {
-      // A mark-only pump keeps the frontier moving while the lead plays out.
-      const elapsedMs = Math.max(0, now - this.drainedLead.atMs);
-      this.drainedLead = {
-        atMs: now,
-        bufferedMs: Math.max(0, this.drainedLead.bufferedMs - elapsedMs),
-      };
-    }
-    this.streamClockMs = null;
   }
 }

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1275,6 +1275,64 @@ describe("RealtimeCallHandler path routing", () => {
     );
   });
 
+  it("drops unsent mark acknowledgements when barge-in clears the pacing queue", async () => {
+    await withBargeInHarness(
+      { providerCallId: "CA-mark-clear", handlesProviderBargeIn: true },
+      async ({ callbacks, outboundMessages, ws }) => {
+        callbacks?.onAudio?.(Buffer.alloc(8 * 160, 0xff), { itemId: "item-1" });
+        await waitForRealtimeTest(() => {
+          expect(outboundMessages.some((message) => message.event === "media")).toBe(true);
+        });
+
+        // The mark sits behind audio that barge-in clears, so it never reaches
+        // the carrier and its acknowledgement must not survive the clear.
+        let markAcknowledged = false;
+        callbacks?.onMark?.("mark-1", () => {
+          markAcknowledged = true;
+        });
+
+        callbacks?.onClearAudio("barge-in");
+        await waitForRealtimeTest(() => {
+          expect(outboundMessages.some((message) => message.event === "clear")).toBe(true);
+        });
+
+        ws.send(JSON.stringify({ event: "mark", mark: { name: "mark-1" } }));
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 60);
+        });
+        expect(markAcknowledged).toBe(false);
+      },
+    );
+  });
+
+  it("drops pending mark acknowledgements on a session continuity reset", async () => {
+    await withBargeInHarness(
+      { providerCallId: "CA-mark-continuity-reset", handlesProviderBargeIn: true },
+      async ({ callbacks, outboundMessages, ws }) => {
+        callbacks?.onAudio?.(Buffer.alloc(8 * 160, 0xff), { itemId: "item-1" });
+        await waitForRealtimeTest(() => {
+          expect(outboundMessages.some((message) => message.event === "media")).toBe(true);
+        });
+
+        let markAcknowledged = false;
+        callbacks?.onMark?.("mark-1", () => {
+          markAcknowledged = true;
+        });
+
+        callbacks?.onEvent?.({ direction: "client", type: "session.continuity.reset" });
+        await waitForRealtimeTest(() => {
+          expect(outboundMessages.some((message) => message.event === "clear")).toBe(true);
+        });
+
+        ws.send(JSON.stringify({ event: "mark", mark: { name: "mark-1" } }));
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 60);
+        });
+        expect(markAcknowledged).toBe(false);
+      },
+    );
+  });
+
   it("keeps local barge-in fallback for providers without speech-started events", async () => {
     await withBargeInHarness(
       { providerCallId: "CA-local-barge-in" },

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1232,6 +1232,49 @@ describe("RealtimeCallHandler path routing", () => {
     );
   });
 
+  it("supplies item-relative telephony playout state to the provider bridge", async () => {
+    await withBargeInHarness(
+      { providerCallId: "CA-playback-state", handlesProviderBargeIn: true },
+      async ({ callbacks, outboundMessages, ws }) => {
+        expect(callbacks.getPlaybackState).toBeTypeOf("function");
+        expect(callbacks.getPlaybackState?.()).toEqual([]);
+
+        callbacks?.onAudio?.(Buffer.alloc(8 * 160, 0xff), { itemId: "item-1" });
+        await waitForRealtimeTest(() => {
+          expect(outboundMessages.some((message) => message.event === "media")).toBe(true);
+        });
+        // One lead window was sent synchronously but still buffers at the carrier
+        // edge, so playout has consumed almost none of it yet.
+        const drainedPlayback = callbacks.getPlaybackState?.();
+        expect(drainedPlayback).toHaveLength(1);
+        expect(drainedPlayback?.[0]?.itemId).toBe("item-1");
+        expect(drainedPlayback?.[0]?.audioEndMs ?? 160).toBeLessThan(40);
+
+        // A provider mark travels through the pacing queue to the carrier.
+        let markAcknowledged = false;
+        callbacks?.onMark?.("mark-1", () => {
+          markAcknowledged = true;
+        });
+        await waitForRealtimeTest(() => {
+          expect(outboundMessages.some((message) => message.event === "mark")).toBe(true);
+        });
+
+        // The carrier acknowledgement retires the played prefix and confirms playout.
+        ws.send(JSON.stringify({ event: "mark", mark: { name: "mark-1" } }));
+        await waitForRealtimeTest(() => {
+          expect(markAcknowledged).toBe(true);
+        });
+        expect(callbacks.getPlaybackState?.()).toEqual([]);
+
+        callbacks?.onClearAudio("barge-in");
+        await waitForRealtimeTest(() => {
+          expect(outboundMessages.some((message) => message.event === "clear")).toBe(true);
+        });
+        expect(callbacks.getPlaybackState?.()).toEqual([]);
+      },
+    );
+  });
+
   it("keeps local barge-in fallback for providers without speech-started events", async () => {
     await withBargeInHarness(
       { providerCallId: "CA-local-barge-in" },

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -321,6 +321,7 @@ type RealtimeCallEndCause = "completed" | "disconnect" | "shutdown" | "inactivit
 // record termination. Replacement can retire old audio without a late close killing its successor.
 type RealtimeTelephonyBinding = {
   bridge: ActiveRealtimeVoiceBridge;
+  acknowledgeCarrierMark: (markName?: string) => void;
   close: (cause: RealtimeCallEndCause) => Promise<void>;
   endCall: () => void;
   noteMediaActivity: () => void;
@@ -519,7 +520,8 @@ export class RealtimeCallHandler {
             return;
           }
           if (frame.kind === "mark") {
-            telephonyBinding.bridge.acknowledgeMark();
+            telephonyBinding.acknowledgeCarrierMark(frame.name);
+            telephonyBinding.bridge.acknowledgeMark(frame.name);
             return;
           }
           if (frame.kind === "error") {
@@ -819,6 +821,7 @@ export class RealtimeCallHandler {
       }
       return true;
     };
+    const pendingMarkAcks = new Map<string, () => void>();
     const audioPacer = new RealtimeAudioPacer({
       send: sendString,
       serializer: {
@@ -865,10 +868,13 @@ export class RealtimeCallHandler {
       triggerGreetingOnReady: Boolean(initialGreetingInstructions),
       audioSink: {
         isOpen: () => ws.readyState === WebSocket.OPEN,
-        sendAudio: (muLaw) => {
+        sendAudio: (muLaw, metadata) => {
           harness.recordOutputAudio(muLaw);
-          audioPacer.sendAudio(muLaw);
+          audioPacer.sendAudio(muLaw, metadata);
         },
+        // Telephony pacing knows what actually reached the line; the provider's
+        // inbound media clock can run far ahead of playout.
+        getPlaybackState: () => audioPacer.getPlaybackState(),
         clearAudio: (reason) => {
           harness.flushOutput(() => {
             const clearedBytes = audioPacer.clearAudio();
@@ -882,8 +888,11 @@ export class RealtimeCallHandler {
             harness.finishOutputAudio("clear");
           });
         },
-        sendMark: (markName) => {
+        sendMark: (markName, acknowledge) => {
           audioPacer.sendMark(markName);
+          if (markName && acknowledge) {
+            pendingMarkAcks.set(markName, acknowledge);
+          }
         },
       },
       onTranscript: (role, text, isFinal) => {
@@ -1216,6 +1225,19 @@ export class RealtimeCallHandler {
     };
     const telephonyBinding: RealtimeTelephonyBinding = {
       bridge: session,
+      acknowledgeCarrierMark: (markName) => {
+        // Retire the played prefix before provider acknowledgement so any
+        // truncation snapshot no longer carries carrier-confirmed items.
+        audioPacer.acknowledgeMark(markName);
+        if (!markName) {
+          return;
+        }
+        const acknowledge = pendingMarkAcks.get(markName);
+        if (acknowledge) {
+          pendingMarkAcks.delete(markName);
+          acknowledge();
+        }
+      },
       close: (cause) => closeBinding(telephonyBinding, cause),
       endCall: () => {
         // Close the provider session before the carrier socket so no pending

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -823,6 +823,9 @@ export class RealtimeCallHandler {
     };
     const pendingMarkAcks = new Map<string, () => void>();
     const audioPacer = new RealtimeAudioPacer({
+      // Every pacer reset discards queued marks, so their stored provider
+      // acknowledgements can never fire and must be retired with them.
+      onPlaybackReset: () => pendingMarkAcks.clear(),
       send: sendString,
       serializer: {
         media: (payload) => adapter.serializeMedia(payload),


### PR DESCRIPTION
Fixes #138592.

## What Problem This Solves

Voice-call interruptions could use the incoming call clock as a playback offset. With one assistant item partly played and another queued, this omitted the first item's truncate and claimed playback for audio the caller had not heard.

## Why This Change Was Made

The telephony pacer now retains item identity and uses carrier-confirmed progress through the existing playback-state callback. It sends progress marks during long chunks, retires fully played prefixes, and combines resumed A/B/A chunks into one cumulative offset per item. Clear, continuity reset, close, and retention backpressure preserve that accounting.

## User Impact

Callers can interrupt replies without leaving queued speech marked as heard by the provider.

## Evidence

- Started the built Gateway with the Voice Call and OpenAI plugins. Signed synthetic Twilio webhooks admitted calls through the production call manager and webhook server. Baseline truncated the queued item at 400 ms with 0 ms played and omitted the first item. The repair sends accepted item-relative truncates, and a subsequent caller audio turn triggers a provider reply that plays on the same connection.
- The supported call path also passes with 128 retained items and with carrier receipts delayed by 100 ms. All 127 queued items truncate at zero; delayed receipts do not corrupt recovery.
- Protocol scenarios cover queued items, resumed and interleaved chunks, final carrier lead, marks, interruption at 128 retained items, backpressure, byte limits, reconnect, and close.
- 135 focused pacer, handler, lifecycle, and carrier-adapter tests pass, plus OpenAI, xAI, and shared-session sibling tests. Regressions fail on the previous implementations and pass after repair. Targeted formatting and syntax lint pass; full checks run in hosted CI.

The peers are task-owned protocol simulators. No real carrier calls or provider credentials were used. Playback offsets include confirmed audio only; progress marks use the existing 160 ms pacing interval. Real carrier behavior was not measured.
