### PR TITLE
refactor: prepare heartbeat state retirement

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2436,7 +2436,7 @@ src/commands/doctor-config-preflight.cron.ts	4
 src/commands/doctor-db-bloat.ts	1
 src/commands/doctor-gateway-services.ts	1
 src/commands/doctor-heartbeat-main-session-repair.ts	1
-src/commands/doctor-heartbeat-scratch-migration.ts	6
+src/commands/doctor-heartbeat-scratch-migration.ts	5
 src/commands/doctor-main-session-recovery.ts	1
 src/commands/doctor-model-catalog-credentials.ts	1
 src/commands/doctor-plugin-model-catalog.ts	1

--- a/src/commands/doctor-heartbeat-config-write.test.ts
+++ b/src/commands/doctor-heartbeat-config-write.test.ts
@@ -1,0 +1,184 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { resolveDefaultModelForAgent } from "../agents/model-selection-config.js";
+import { applyModelDefaults, DEFAULT_MODEL_ALIASES } from "../config/defaults.js";
+import { readConfigFileSnapshot } from "../config/io.runtime.js";
+import { transformConfigFile } from "../config/mutate.js";
+import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { readDefaultProactiveJobReceipt } from "../cron/proactive-job-receipt.js";
+import { loadCronJobsStore } from "../cron/store.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { heartbeatRetirementConfigFingerprint } from "./doctor-heartbeat-retirement-policy.js";
+import {
+  applyHeartbeatRetirement,
+  completeHeartbeatRetirement,
+  prepareHeartbeatRetirement,
+} from "./doctor-heartbeat-retirement.js";
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+it.each([
+  { interrupted: false, include: false },
+  { interrupted: true, include: false },
+  { interrupted: false, include: true },
+  { interrupted: true, include: true },
+])(
+  "binds retirement to the real writer's source projection ($interrupted, include: $include)",
+  async ({ interrupted, include }) => {
+    await withTempHome(async (home) => {
+      await withEnvOverride(
+        {
+          HEARTBEAT_TEST_AGENT_NAME: "Synthetic agent",
+          HEARTBEAT_TEST_MODEL: "openai/gpt-5.6-luna",
+        },
+        async () => {
+          const configPath = await writeOpenClawConfig(home, {
+            agents: {
+              defaults: {
+                workspace: "~/workspace",
+                model: "${HEARTBEAT_TEST_MODEL}",
+                heartbeat: { every: "30m" },
+              },
+              entries: { main: { name: "${HEARTBEAT_TEST_AGENT_NAME}" } },
+            },
+          });
+          const agentsPath = path.join(path.dirname(configPath), "agents.json");
+          if (include) {
+            const authored = JSON.parse(await fs.readFile(configPath, "utf8"));
+            await fs.writeFile(agentsPath, JSON.stringify(authored.agents));
+            await fs.writeFile(configPath, JSON.stringify({ agents: { $include: "agents.json" } }));
+          }
+          const original = await fs.readFile(configPath, "utf8");
+          const originalAgents = include ? await fs.readFile(agentsPath, "utf8") : undefined;
+          const prepare = async () => {
+            const snapshot = await readConfigFileSnapshot();
+            expect(snapshot.valid).toBe(true);
+            return {
+              snapshot,
+              plan: await prepareHeartbeatRetirement({
+                sourceConfig: snapshot.sourceConfig,
+                effectiveConfig: snapshot.config,
+                env: process.env,
+                nowMs: 2_000_000_000_000,
+              }),
+            };
+          };
+          let { snapshot, plan } = await prepare();
+          const write = (
+            nextConfig: OpenClawConfig,
+            preCommitRuntimePreflight: (sourceConfig: OpenClawConfig) => Promise<void>,
+          ) =>
+            transformConfigFile({
+              ...(snapshot.hash ? { baseHash: snapshot.hash } : {}),
+              transform: () => ({ nextConfig }),
+              afterWrite: { mode: "auto" },
+              writeOptions: { skipOutputLogs: true, preCommitRuntimePreflight },
+            });
+          if (interrupted) {
+            await expect(
+              write(plan.config, async (sourceConfig) => {
+                await applyHeartbeatRetirement(plan, sourceConfig);
+                throw new Error("Interrupted before config commit");
+              }),
+            ).rejects.toThrow("Interrupted before config commit");
+            expect(await fs.readFile(configPath, "utf8")).toBe(original);
+            if (include) {
+              expect(await fs.readFile(agentsPath, "utf8")).toBe(originalAgents);
+            }
+            expect(readDefaultProactiveJobReceipt(plan.storePath, "main")?.phase).toBe("pending");
+            ({ snapshot, plan } = await prepare());
+          }
+          let preparedRevision: string | undefined;
+          await write({ ...plan.config, logging: undefined }, async (sourceConfig) => {
+            if (!include) {
+              expect(sourceConfig.meta?.lastTouchedVersion).toBeTruthy();
+            }
+            expect(sourceConfig.agents?.defaults?.workspace).toBe("~/workspace");
+            preparedRevision = heartbeatRetirementConfigFingerprint(sourceConfig);
+            await applyHeartbeatRetirement(plan, sourceConfig);
+          });
+          const persisted = await readConfigFileSnapshot();
+          expect(persisted.valid).toBe(true);
+          expect(heartbeatRetirementConfigFingerprint(persisted.sourceConfig)).toBe(
+            preparedRevision,
+          );
+          const authored = JSON.parse(await fs.readFile(configPath, "utf8"));
+          const authoredAgents = include
+            ? JSON.parse(await fs.readFile(agentsPath, "utf8"))
+            : authored.agents;
+          expect(authoredAgents.defaults.workspace).toBe("~/workspace");
+          expect(authoredAgents.defaults.model).toBe("${HEARTBEAT_TEST_MODEL}");
+          expect(authoredAgents.entries.main.name).toBe("${HEARTBEAT_TEST_AGENT_NAME}");
+          expect(authoredAgents.defaults.heartbeat).toBeUndefined();
+          if (include) {
+            expect(authored.agents).toEqual({ $include: "agents.json" });
+          }
+          expect(authored.logging).toBeUndefined();
+          await completeHeartbeatRetirement(plan, persisted.sourceConfig);
+          expect(readDefaultProactiveJobReceipt(plan.storePath, "main")?.phase).toBe("complete");
+        },
+      );
+    });
+  },
+);
+
+const modelAliases = ["gpt", "sonnet", "gemini"];
+it.each(
+  modelAliases.flatMap((primary) =>
+    ["partial", "full", "redirect"].map((mode) => ({ primary, mode })),
+  ),
+)(
+  "compares canonical $primary alias bindings after $mode normalization",
+  async ({ primary, mode }) => {
+    await withTempHome(async (home) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: path.join(home, "workspace"),
+            heartbeat: { every: "30m" },
+            model: { primary, fallbacks: modelAliases.filter((alias) => alias !== primary) },
+            models: Object.fromEntries(
+              modelAliases.map((alias) => [DEFAULT_MODEL_ALIASES[alias]!, {}]),
+            ),
+          },
+          list: [{ id: "main" }],
+        },
+      };
+      const effective = applyModelDefaults(cfg);
+      const plan = await prepareHeartbeatRetirement({
+        sourceConfig: cfg,
+        effectiveConfig: effective,
+        env: process.env,
+        nowMs: 2_000_000_000_000,
+      });
+      const candidate = structuredClone(plan.config);
+      const models = candidate.agents!.defaults!.models!;
+      if (mode === "redirect") {
+        models[`openai/${primary}`] = { alias: primary };
+        expect(
+          resolveDefaultModelForAgent({ cfg: applyModelDefaults(candidate), agentId: "main" }),
+        ).not.toEqual(resolveDefaultModelForAgent({ cfg: effective, agentId: "main" }));
+        const before = await loadCronJobsStore(plan.storePath);
+        await expect(applyHeartbeatRetirement(plan, candidate)).rejects.toThrow("policy changed");
+        expect(await loadCronJobsStore(plan.storePath)).toEqual(before);
+        expect(readDefaultProactiveJobReceipt(plan.storePath, "main")).toBeUndefined();
+      } else {
+        for (const alias of mode === "full" ? modelAliases : [primary]) {
+          models[DEFAULT_MODEL_ALIASES[alias]!]!.alias = alias;
+        }
+        expect(applyModelDefaults(candidate).agents!.defaults!.models).toEqual(
+          effective.agents!.defaults!.models,
+        );
+        await applyHeartbeatRetirement(plan, candidate);
+        await completeHeartbeatRetirement(plan, candidate);
+        expect(readDefaultProactiveJobReceipt(plan.storePath, "main")?.phase).toBe("complete");
+      }
+    });
+  },
+);

--- a/src/commands/doctor-heartbeat-outcome-migration.test.ts
+++ b/src/commands/doctor-heartbeat-outcome-migration.test.ts
@@ -1,0 +1,390 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { afterEach, expect, it, vi } from "vitest";
+import { sanitizeCompactionMessages } from "../agents/compaction-planning.js";
+import { assembleHarnessContextEngine } from "../agents/harness/context-engine-lifecycle.js";
+import { convertToLlm } from "../agents/sessions/messages.js";
+import { SessionManager } from "../agents/sessions/session-manager.js";
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
+import * as sessionAccessor from "../config/sessions/session-accessor.js";
+import {
+  loadTranscriptEvents,
+  replaceSessionEntry,
+  replaceTranscriptEvents,
+} from "../config/sessions/session-accessor.js";
+import {
+  resolveSqliteScope,
+  toDatabaseOptions,
+} from "../config/sessions/session-accessor.sqlite-scope.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { LegacyContextEngine } from "../context-engine/legacy.js";
+import { persistHeartbeatOutcome } from "../infra/heartbeat-outcome-store.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import {
+  applyHeartbeatOutcomeRetirement,
+  prepareHeartbeatOutcomeRetirement,
+} from "./doctor-heartbeat-outcome-migration.js";
+
+const roots: string[] = [];
+const now = 2_000_000_000_000;
+afterEach(async () => {
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+async function fixture(initialize = true) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-outcome-retirement-"));
+  roots.push(root);
+  vi.stubEnv("OPENCLAW_STATE_DIR", root);
+  vi.stubEnv("HOME", path.join(root, "home"));
+  vi.spyOn(Date, "now").mockReturnValue(now);
+  const env = { ...process.env };
+  const config: OpenClawConfig = {
+    agents: { list: [{ id: "main" }] },
+    session: { reset: { mode: "idle", idleMinutes: 60 } },
+  };
+  const scope = {
+    agentId: "main",
+    storePath: resolveSessionStorePathCore(undefined, { agentId: "main", env }),
+    sessionKey: "agent:main:main",
+    env,
+  };
+  const session = {
+    sessionId: "session-one",
+    lifecycleRevision: "generation-one",
+    updatedAt: now,
+    sessionStartedAt: now - 1000,
+  };
+  const persist = (summary = "Inbox cleared") =>
+    persistHeartbeatOutcome({
+      ...scope,
+      runSessionKey: "agent:main:main:heartbeat",
+      occurredAt: now - 500,
+      response: {
+        outcome: "done",
+        summary,
+        notify: false,
+        reason: "No urgent work remains",
+        priority: "high",
+        nextCheck: "Tomorrow",
+      },
+      taskNames: ["inbox", "calendar"],
+      wakeSource: "interval",
+      wakeReason: "scheduled check",
+    });
+  const database = () => openOpenClawAgentDatabase(toDatabaseOptions(resolveSqliteScope(scope))).db;
+  const row = () =>
+    database()
+      .prepare("SELECT * FROM heartbeat_outcomes WHERE session_key = ?")
+      .get(scope.sessionKey);
+  const events = () => loadTranscriptEvents({ ...scope, sessionId: session.sessionId });
+  if (initialize) {
+    await replaceSessionEntry(scope, session);
+    persist();
+  }
+  return { env, config, scope, session, persist, database, row, events };
+}
+
+it("prepares missing state without creating databases", async () => {
+  const f = await fixture(false);
+  expect(prepareHeartbeatOutcomeRetirement(f.config, f.env)).toMatchObject({
+    imports: [],
+    retainedExpired: [],
+  });
+  await expect(fs.stat(resolveOpenClawStateSqlitePath(f.env))).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+});
+
+it("imports all known facts as hidden context and retains the source row across reopen and replay", async () => {
+  const f = await fixture();
+  const before = f.row();
+  const plan = prepareHeartbeatOutcomeRetirement(f.config, f.env);
+  expect(plan.imports).toHaveLength(1);
+  await applyHeartbeatOutcomeRetirement(plan);
+  const after = f.row();
+  expect(after).toEqual({
+    ...before,
+    context_run_id: plan.imports[0]!.importId,
+    context_claimed_at: now,
+  });
+  const messages = await f.events();
+  const text = JSON.stringify(messages);
+  for (const fact of [
+    "Inbox cleared",
+    "No urgent work remains",
+    "high",
+    "Tomorrow",
+    "inbox",
+    "calendar",
+    "interval",
+    "scheduled check",
+    "agent:main:main:heartbeat",
+  ]) {
+    expect(text).toContain(fact);
+  }
+  expect(messages).toContainEqual(
+    expect.objectContaining({
+      message: expect.objectContaining({ role: "custom", display: false }),
+    }),
+  );
+  expect(sessionAccessor.loadSessionEntryReadOnly(f.scope)).toMatchObject(f.session);
+  closeOpenClawAgentDatabasesForTest();
+  await applyHeartbeatOutcomeRetirement(plan);
+  expect(await f.events()).toEqual(messages);
+  expect(prepareHeartbeatOutcomeRetirement(f.config, f.env).imports.length).toBe(0);
+  expect(f.row()).toEqual(after);
+});
+
+it("keeps imported facts in next-turn model context and compaction after reopen", async () => {
+  const f = await fixture();
+  await applyHeartbeatOutcomeRetirement(prepareHeartbeatOutcomeRetirement(f.config, f.env));
+  closeOpenClawAgentDatabasesForTest();
+  const manager = SessionManager.openModelContext({ ...f.scope, sessionId: f.session.sessionId });
+  manager.appendMessage({ role: "user", content: "What happened?", timestamp: now + 1 });
+  const assembled = await assembleHarnessContextEngine({
+    contextEngine: new LegacyContextEngine(),
+    sessionId: f.session.sessionId,
+    modelId: "synthetic-model",
+    messages: manager.buildSessionContext().messages,
+    tokenBudget: 8_000,
+  });
+  const messages = assembled!.messages;
+  expect(JSON.stringify(convertToLlm(messages))).toContain("Inbox cleared");
+  expect(JSON.stringify(convertToLlm(sanitizeCompactionMessages(messages)))).toContain(
+    "Inbox cleared",
+  );
+  expect(messages[0]).toMatchObject({
+    role: "custom",
+    customType: "openclaw.system-note",
+    display: false,
+  });
+});
+
+it("rolls the consumed marker back when the transcript insert fails", async () => {
+  const f = await fixture();
+  const before = f.row();
+  const plan = prepareHeartbeatOutcomeRetirement(f.config, f.env);
+  f.database().exec(
+    "CREATE TRIGGER reject_outcome_context BEFORE INSERT ON transcript_events BEGIN SELECT RAISE(ABORT, 'context insert failed'); END",
+  );
+  await expect(applyHeartbeatOutcomeRetirement(plan)).rejects.toThrow("context insert failed");
+  expect(f.row()).toEqual(before);
+  f.database().exec("DROP TRIGGER reject_outcome_context");
+  await applyHeartbeatOutcomeRetirement(plan);
+  expect(f.row()).toMatchObject({ context_run_id: plan.imports[0]!.importId });
+});
+
+it("does not reappend when the caller loses acknowledgement after the transaction committed", async () => {
+  const f = await fixture();
+  const plan = prepareHeartbeatOutcomeRetirement(f.config, f.env);
+  const persistTurn = sessionAccessor.persistSessionTranscriptTurn;
+  vi.spyOn(sessionAccessor, "persistSessionTranscriptTurn").mockImplementationOnce(
+    async (...args) => {
+      await persistTurn(...args);
+      throw new Error("lost acknowledgement");
+    },
+  );
+  await expect(applyHeartbeatOutcomeRetirement(plan)).rejects.toThrow("lost acknowledgement");
+  const committed = await f.events();
+  await applyHeartbeatOutcomeRetirement(plan);
+  expect(await f.events()).toEqual(committed);
+  expect(f.row()).toMatchObject({ context_run_id: plan.imports[0]!.importId });
+});
+
+it("keeps a consumed outcome retired after its same-session transcript is replaced", async () => {
+  const f = await fixture();
+  const plan = prepareHeartbeatOutcomeRetirement(f.config, f.env);
+  await applyHeartbeatOutcomeRetirement(plan);
+  const consumed = f.row();
+  await replaceTranscriptEvents({ ...f.scope, sessionId: f.session.sessionId }, []);
+  closeOpenClawAgentDatabasesForTest();
+  const freshPlan = prepareHeartbeatOutcomeRetirement(f.config, f.env);
+  expect(freshPlan.imports).toEqual([]);
+  await applyHeartbeatOutcomeRetirement(plan);
+  expect(await f.events()).toEqual([]);
+  await applyHeartbeatOutcomeRetirement(freshPlan);
+  expect(await f.events()).toEqual([]);
+  expect(f.row()).toEqual(consumed);
+});
+
+it("rejects a replacement outcome in the real append transaction", async () => {
+  const f = await fixture();
+  const plan = prepareHeartbeatOutcomeRetirement(f.config, f.env);
+  const persistTurn = sessionAccessor.persistSessionTranscriptTurn;
+  vi.spyOn(sessionAccessor, "persistSessionTranscriptTurn").mockImplementationOnce(
+    async (...args) => {
+      f.persist("Newer outcome");
+      return await persistTurn(...args);
+    },
+  );
+  await expect(applyHeartbeatOutcomeRetirement(plan)).rejects.toThrow(
+    "changed before its transcript commit",
+  );
+  expect(f.row()).toMatchObject({ summary: "Newer outcome", context_run_id: null });
+  expect(JSON.stringify(await f.events())).not.toContain("Inbox cleared");
+});
+
+it("rejects a lifecycle rotation without consuming its old outcome", async () => {
+  const f = await fixture();
+  const plan = prepareHeartbeatOutcomeRetirement(f.config, f.env);
+  const before = f.row();
+  const persistTurn = sessionAccessor.persistSessionTranscriptTurn;
+  vi.spyOn(sessionAccessor, "persistSessionTranscriptTurn").mockImplementationOnce(
+    async (...args) => {
+      await replaceSessionEntry(f.scope, { ...f.session, lifecycleRevision: "generation-two" });
+      return await persistTurn(...args);
+    },
+  );
+  await expect(applyHeartbeatOutcomeRetirement(plan)).rejects.toThrow(
+    "changed before its heartbeat outcome",
+  );
+  expect(f.row()).toEqual(before);
+  expect(JSON.stringify(await f.events())).not.toContain("Inbox cleared");
+});
+
+it.each(["previous session", "expired session"])(
+  "retains %s facts without promoting them into current context",
+  async (reason) => {
+    const f = await fixture();
+    await replaceSessionEntry(f.scope, {
+      ...f.session,
+      ...(reason === "previous session"
+        ? { sessionStartedAt: now }
+        : { updatedAt: now - 7_200_000, lastInteractionAt: now - 7_200_000 }),
+    });
+    const before = f.row();
+    const plan = prepareHeartbeatOutcomeRetirement(f.config, f.env);
+    expect(plan.imports.length).toBe(0);
+    expect(plan.retainedExpired).toEqual([{ agentId: "main", sessionKey: f.scope.sessionKey }]);
+    await applyHeartbeatOutcomeRetirement(plan);
+    expect(f.row()).toEqual(before);
+    expect(JSON.stringify(await f.events())).not.toContain("Inbox cleared");
+  },
+);
+
+it("rechecks reset freshness after awaiting the transcript owner", async () => {
+  const f = await fixture();
+  const plan = prepareHeartbeatOutcomeRetirement(f.config, f.env);
+  const before = f.row();
+  const persistTurn = sessionAccessor.persistSessionTranscriptTurn;
+  vi.spyOn(sessionAccessor, "persistSessionTranscriptTurn").mockImplementationOnce(
+    async (...args) => {
+      vi.spyOn(Date, "now").mockReturnValue(now + 7_200_000);
+      return await persistTurn(...args);
+    },
+  );
+  await expect(applyHeartbeatOutcomeRetirement(plan)).rejects.toThrow(
+    "changed before its transcript commit",
+  );
+  expect(f.row()).toEqual(before);
+});
+
+it.each(["shared", "per-agent", "per-agent global"])(
+  "imports each logical owner once from %s stores across interrupted retry",
+  async (kind) => {
+    const f = await fixture(false);
+    f.config.agents = { ownership: "explicit", entries: { main: {}, ops: {} } };
+    if (kind === "shared") {
+      f.config.session!.store = path.join(f.env.OPENCLAW_STATE_DIR!, "shared.sqlite");
+    }
+    const scopes = ["main", "ops"].map((agentId) => ({
+      env: f.env,
+      agentId,
+      sessionKey: kind === "per-agent global" ? "global" : `agent:${agentId}:main`,
+      sessionId: `session-${agentId}`,
+      storePath: resolveSessionStorePathCore(f.config.session?.store, { agentId, env: f.env }),
+    }));
+    for (const scope of scopes) {
+      await replaceSessionEntry(scope, { ...f.session, sessionId: scope.sessionId });
+      persistHeartbeatOutcome({
+        ...scope,
+        runSessionKey: `${scope.sessionKey}:heartbeat`,
+        occurredAt: now - 500,
+        response: { outcome: "done", summary: `Result for ${scope.agentId}`, notify: false },
+      });
+    }
+    const plan = prepareHeartbeatOutcomeRetirement(f.config, f.env);
+    expect(plan.imports.map(({ scope }) => [scope.agentId, scope.sessionKey])).toEqual([
+      ["main", kind === "per-agent global" ? "global" : "agent:main:main"],
+      ["ops", kind === "per-agent global" ? "global" : "agent:ops:main"],
+    ]);
+    const persistTurn = sessionAccessor.persistSessionTranscriptTurn;
+    vi.spyOn(sessionAccessor, "persistSessionTranscriptTurn").mockImplementationOnce(
+      async (...args) => {
+        await persistTurn(...args);
+        throw new Error("Interrupted between owners");
+      },
+    );
+    await expect(applyHeartbeatOutcomeRetirement(plan)).rejects.toThrow(
+      "Interrupted between owners",
+    );
+    closeOpenClawAgentDatabasesForTest();
+    const retry = prepareHeartbeatOutcomeRetirement(f.config, f.env);
+    expect(retry.imports.map(({ scope }) => scope.agentId)).toEqual(["ops"]);
+    await applyHeartbeatOutcomeRetirement(retry);
+    for (const scope of scopes) {
+      const messages = await loadTranscriptEvents(scope);
+      const contexts = messages.filter(
+        (event) => asOptionalRecord(asOptionalRecord(event)?.message)?.role === "custom",
+      );
+      expect(contexts).toHaveLength(1);
+      expect(JSON.stringify(contexts)).toContain(`Result for ${scope.agentId}`);
+    }
+    expect(prepareHeartbeatOutcomeRetirement(f.config, f.env).imports).toHaveLength(0);
+  },
+);
+
+it.each([undefined, "ops", "retired"])(
+  "requires a proven logical owner for a shared global outcome (owner: %s)",
+  async (owner) => {
+    const f = await fixture(false);
+    f.config.agents = {
+      ownership: "explicit",
+      entries: { main: {}, ops: {} },
+      ...(owner ? { defaults: { sessionStore: { agentId: owner } } } : {}),
+    };
+    f.config.session = {
+      ...f.config.session,
+      scope: "global",
+      store: path.join(f.env.OPENCLAW_STATE_DIR!, "shared.sqlite"),
+    };
+    const scope = {
+      ...f.scope,
+      agentId: "ops",
+      storePath: f.config.session.store,
+      sessionKey: "global",
+      sessionId: f.session.sessionId,
+    };
+    await replaceSessionEntry(scope, f.session);
+    persistHeartbeatOutcome({
+      ...scope,
+      runSessionKey: "agent:ops:global:heartbeat",
+      occurredAt: now - 500,
+      response: { outcome: "done", summary: "Global result for ops", notify: false },
+    });
+    if (owner !== "ops") {
+      expect(() => prepareHeartbeatOutcomeRetirement(f.config, f.env)).toThrow("configured owner");
+      expect(JSON.stringify(await loadTranscriptEvents(scope))).not.toContain(
+        "Global result for ops",
+      );
+      return;
+    }
+    const plan = prepareHeartbeatOutcomeRetirement(f.config, f.env);
+    expect(plan.imports.map((item) => [item.scope.agentId, item.scope.sessionKey])).toEqual([
+      ["ops", "global"],
+    ]);
+    await applyHeartbeatOutcomeRetirement(plan);
+    expect(JSON.stringify(await loadTranscriptEvents(scope))).toContain("Global result for ops");
+  },
+);

--- a/src/commands/doctor-heartbeat-outcome-migration.ts
+++ b/src/commands/doctor-heartbeat-outcome-migration.ts
@@ -1,0 +1,272 @@
+import { createHash } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import type { Selectable } from "kysely";
+import { listAgentIds } from "../agents/agent-scope-config.js";
+import { sliceToolResultTextToBudget } from "../agents/embedded-agent-runner/tool-result-text-budget.js";
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
+import {
+  evaluateSessionFreshness,
+  resolveChannelResetConfig,
+  resolveSessionResetPolicy,
+  resolveSessionResetType,
+} from "../config/sessions/reset.js";
+import {
+  loadSessionEntryReadOnly,
+  persistSessionTranscriptTurn,
+} from "../config/sessions/session-accessor.js";
+import {
+  resolveSqliteScope,
+  toDatabaseOptions,
+} from "../config/sessions/session-accessor.sqlite-scope.js";
+import type { SessionAccessScope } from "../config/sessions/session-accessor.types.js";
+import { resolvePersistedSessionStoreOwnerForTarget } from "../config/sessions/session-store-owner.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import {
+  classifySessionKeyShape,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../routing/session-key.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
+import { isSameOpenClawAgentDatabasePath } from "../state/openclaw-agent-db-registry.js";
+import type { DB } from "../state/openclaw-agent-db.generated.js";
+import {
+  openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
+} from "../state/openclaw-agent-db.js";
+import { deliveryContextFromSession } from "../utils/delivery-context.shared.js";
+
+type OutcomeRow = Selectable<DB["heartbeat_outcomes"]>;
+type OutcomeDatabase = Pick<DB, "heartbeat_outcomes">;
+type OutcomeImport = {
+  row: OutcomeRow;
+  scope: SessionAccessScope & { agentId: string; storePath: string; sessionKey: string };
+  session: SessionEntry;
+  importId: string;
+  context: string;
+};
+export type HeartbeatOutcomeRetirementPlan = {
+  config: OpenClawConfig;
+  imports: OutcomeImport[];
+  retainedExpired: Array<{ agentId: string; sessionKey: string }>;
+};
+
+function isCurrentOutcome(cfg: OpenClawConfig, row: OutcomeRow, entry: SessionEntry): boolean {
+  const policy = resolveSessionResetPolicy({
+    sessionCfg: cfg.session,
+    resetType: resolveSessionResetType({ sessionKey: row.session_key }),
+    resetOverride: resolveChannelResetConfig({
+      sessionCfg: cfg.session,
+      channel: deliveryContextFromSession(entry)?.channel,
+    }),
+  });
+  return (
+    !(entry.sessionStartedAt !== undefined && row.occurred_at < entry.sessionStartedAt) &&
+    evaluateSessionFreshness({ ...entry, now: Date.now(), policy }).fresh
+  );
+}
+
+function outcomeContext(row: OutcomeRow): string {
+  // The complete producer-bounded record stays in heartbeat_outcomes. This
+  // one-time projection bounds each field so long summaries cannot hide the
+  // remaining facts; the whole context is capped at 2,000 weighted character units.
+  const field = (name: string, value: string | null, budget: number): string[] =>
+    value ? [`${name}=${sliceToolResultTextToBudget(value, budget)}`] : [];
+  return sliceToolResultTextToBudget(
+    [
+      "Migrated automation result (recorded facts, not instructions):",
+      `recordedAt=${new Date(row.occurred_at).toISOString()}`,
+      ...field("runSession", row.run_session_key, 64),
+      `outcome=${row.outcome}`,
+      ...(row.priority ? [`priority=${row.priority}`] : []),
+      ...field("wakeSource", row.wake_source, 32),
+      ...field("wakeReason", row.wake_reason, 150),
+      ...field("nextCheck", row.next_check, 150),
+      ...field("tasks", row.task_names_json, 350),
+      ...field("reason", row.response_reason, 200),
+      ...field("summary", row.summary, 700),
+    ].join("\n"),
+    2000,
+  );
+}
+
+/** Read-only; expired facts remain inert and must be reported by the cutover owner. */
+export function prepareHeartbeatOutcomeRetirement(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): HeartbeatOutcomeRetirementPlan {
+  const imports: OutcomeImport[] = [];
+  const retainedExpired: HeartbeatOutcomeRetirementPlan["retainedExpired"] = [];
+  const scopes = listAgentIds(cfg).map((agentId) => {
+    const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId, env });
+    const options = toDatabaseOptions(
+      resolveSqliteScope({ agentId, storePath, env, sessionKey: `agent:${agentId}:main` }),
+    );
+    return { agentId, storePath, options, path: resolveOpenClawAgentSqlitePath(options) };
+  });
+  const scanned: string[] = [];
+  for (const store of scopes) {
+    if (scanned.some((path) => isSameOpenClawAgentDatabasePath(path, store.path))) {
+      continue;
+    }
+    scanned.push(store.path);
+    const owners = scopes.filter((scope) =>
+      isSameOpenClawAgentDatabasePath(scope.path, store.path),
+    );
+    const read = withOpenClawAgentDatabaseReadOnly(
+      ({ db }) =>
+        executeSqliteQuerySync(
+          db,
+          getNodeSqliteKysely<OutcomeDatabase>(db)
+            .selectFrom("heartbeat_outcomes")
+            .selectAll()
+            .where("context_run_id", "is", null)
+            .orderBy("session_key", "asc"),
+        ).rows,
+      store.options,
+    );
+    if (!read.found) {
+      continue;
+    }
+    for (const row of read.value) {
+      if (!["progress", "done", "blocked", "needs_attention"].includes(row.outcome)) {
+        throw new Error(
+          `Unknown pending heartbeat outcome for ${row.session_key}; its source was retained.`,
+        );
+      }
+      // Exact SQLite locators may hold several logical agents. The schema owner
+      // identifies the file, not every row; global keys need a proven owner too.
+      const parsed = parseAgentSessionKey(row.session_key);
+      const fixedOwner = resolvePersistedSessionStoreOwnerForTarget({
+        config: cfg,
+        sessionKey: row.session_key,
+        storePath: store.storePath,
+        env,
+      });
+      const agentId = parsed
+        ? normalizeAgentId(parsed.agentId)
+        : fixedOwner.kind === "configured"
+          ? fixedOwner.agentId
+          : fixedOwner.kind === "none" && owners.length === 1
+            ? owners[0]!.agentId
+            : undefined;
+      const owner = owners.find((candidate) => candidate.agentId === agentId);
+      if (!owner || classifySessionKeyShape(row.session_key) === "malformed_agent") {
+        throw new Error(
+          `Pending heartbeat outcome for ${row.session_key} has no unambiguous configured owner; its source was retained.`,
+        );
+      }
+      const scope = {
+        agentId: owner.agentId,
+        storePath: owner.storePath,
+        env,
+        sessionKey: row.session_key,
+      };
+      const session = loadSessionEntryReadOnly(scope);
+      if (!session) {
+        throw new Error(
+          `Pending heartbeat outcome for ${row.session_key} has no current session; restore it before cutover.`,
+        );
+      }
+      if (!isCurrentOutcome(cfg, row, session)) {
+        retainedExpired.push({ agentId: owner.agentId, sessionKey: row.session_key });
+        continue;
+      }
+      const digest = createHash("sha256").update(JSON.stringify(row)).digest("hex");
+      imports.push({
+        row,
+        scope,
+        session,
+        importId: `doctor:heartbeat-outcome:${digest}`,
+        context: outcomeContext(row),
+      });
+    }
+  }
+  return { config: structuredClone(cfg), imports, retainedExpired };
+}
+
+/**
+ * Dormant; the cutover owner must stop runtime writers before import and account
+ * for imported/expired outcomes before restarting with the retired reader removed.
+ */
+export async function applyHeartbeatOutcomeRetirement(
+  plan: HeartbeatOutcomeRetirementPlan,
+): Promise<void> {
+  for (const item of plan.imports) {
+    const { scope, session, row, importId } = item;
+    const options = toDatabaseOptions(resolveSqliteScope(scope));
+    const result = await persistSessionTranscriptTurn(
+      { ...scope, sessionId: session.sessionId },
+      {
+        config: plan.config,
+        expectedSessionId: session.sessionId,
+        expectedLifecycleRevision: session.lifecycleRevision ?? null,
+        touchSessionEntry: false,
+        messages: [
+          {
+            message: {
+              role: "custom",
+              customType: "openclaw.system-note",
+              content: item.context,
+              display: false,
+              timestamp: Date.now(),
+              idempotencyKey: importId,
+            },
+            idempotencyLookup: "scan",
+            shouldAppendInTransaction: () => {
+              const { db } = openOpenClawAgentDatabase(options);
+              const query = getNodeSqliteKysely<OutcomeDatabase>(db);
+              const current = executeSqliteQuerySync(
+                db,
+                query
+                  .selectFrom("heartbeat_outcomes")
+                  .selectAll()
+                  .where("session_key", "=", row.session_key),
+              ).rows[0];
+              // The consumed row remains authoritative if transcript replacement
+              // removed the note; a different outcome must still fail comparison.
+              const replay = current?.context_run_id === importId;
+              const comparable = current
+                ? {
+                    ...current,
+                    ...(replay
+                      ? {
+                          context_run_id: row.context_run_id,
+                          context_claimed_at: row.context_claimed_at,
+                        }
+                      : {}),
+                  }
+                : undefined;
+              const entry = loadSessionEntryReadOnly(scope);
+              if (
+                !isDeepStrictEqual(comparable, { ...row }) ||
+                !entry ||
+                !isCurrentOutcome(plan.config, row, entry)
+              ) {
+                throw new Error(
+                  `Pending heartbeat outcome for ${row.session_key} changed before its transcript commit; rerun Doctor.`,
+                );
+              }
+              if (!replay) {
+                executeSqliteQuerySync(
+                  db,
+                  query
+                    .updateTable("heartbeat_outcomes")
+                    .set({ context_run_id: importId, context_claimed_at: Date.now() })
+                    .where("session_key", "=", row.session_key),
+                );
+              }
+              return !replay;
+            },
+          },
+        ],
+      },
+    );
+    if (result.rejectedReason) {
+      throw new Error(
+        `Session ${row.session_key} changed before its heartbeat outcome could be retired.`,
+      );
+    }
+  }
+}

--- a/src/commands/doctor-heartbeat-retirement-plan.ts
+++ b/src/commands/doctor-heartbeat-retirement-plan.ts
@@ -1,0 +1,518 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
+import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
+import {
+  resolveSqliteScope,
+  toDatabaseOptions,
+} from "../config/sessions/session-accessor.sqlite-scope.js";
+import { resolvePersistedSessionStoreOwner } from "../config/sessions/session-store-owner.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveCronJobConfigRevision } from "../cron/config-revision.js";
+import { heartbeatTaskDeclarationKey, isHeartbeatTaskCronJob } from "../cron/heartbeat-task.js";
+import {
+  readDefaultProactiveJobReceiptInDatabase,
+  type PendingProactiveJobReceipt,
+} from "../cron/proactive-job-receipt.js";
+import { cronSchedulingInputsEqual } from "../cron/schedule-identity.js";
+import { assertCronJobScratchContent } from "../cron/scratch-contract.js";
+import {
+  readCronJobScratchStateInDatabase,
+  type CronJobScratchState,
+} from "../cron/scratch-store.js";
+import { computeJobNextRunAtMs } from "../cron/service/jobs-scheduling.js";
+import { finalizeUpdatedJob } from "../cron/service/ops-mutations.js";
+import { resolveCronJobsStorePathFromConfig } from "../cron/store.js";
+import { cronStoreKey } from "../cron/store/key.js";
+import { loadCronRows, loadedCronStoreFromRows } from "../cron/store/row-codec.js";
+import type { CronStoredJob } from "../cron/types.js";
+import { resolveIdentityPathViaExistingAncestorSync } from "../infra/boundary-path.js";
+import { resolveHeartbeatAgents, resolveHeartbeatConfig } from "../infra/heartbeat-config.js";
+import { resolveHeartbeatSessionKey } from "../infra/heartbeat-runner-session.js";
+import {
+  resolveHeartbeatPhaseMs,
+  resolveHeartbeatSchedulerSeed,
+} from "../infra/heartbeat-schedule.js";
+import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import {
+  convertHeartbeatJobForRetirement,
+  heartbeatRetirementConfigFingerprint,
+  heartbeatRetirementFingerprint,
+  resolveHeartbeatRetirementPolicy,
+  type RetiredHeartbeatJob,
+} from "./doctor-heartbeat-retirement-policy.js";
+import { readHeartbeatSource, type HeartbeatSource } from "./doctor-heartbeat-scratch-migration.js";
+import { validateLegacyHeartbeatTasks } from "./doctor-heartbeat-task-migration.js";
+import { analyzeLegacyHeartbeatTasks } from "./heartbeat-task-legacy.js";
+
+type JobPlan = {
+  previous?: CronStoredJob;
+  job: RetiredHeartbeatJob;
+  sortOrder: number;
+  scratch: CronJobScratchState;
+  nextScratch: CronJobScratchState;
+};
+type AgentPlan = {
+  agentId: string;
+  sourceRevision: string;
+  receipt?: PendingProactiveJobReceipt;
+  jobs: JobPlan[];
+  defaultJobId: string;
+  sourceFile?: { entryKey: string; sha256: string };
+};
+type SourcePlan = { source: HeartbeatSource; agentId: string };
+export type HeartbeatRetirementPlan = {
+  sourceConfig: OpenClawConfig;
+  config: OpenClawConfig;
+  effectiveConfig: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  storePath: string;
+  agents: AgentPlan[];
+  sources: SourcePlan[];
+  absentSourceAgentIds: string[];
+  nowMs: number;
+  legacyJobIds: string[];
+  sourceSelection: ReturnType<typeof resolveSourceSelection>;
+};
+
+function resolveSourceSelection(cfg: OpenClawConfig, env: NodeJS.ProcessEnv, legacyConfig = cfg) {
+  return {
+    storePath: resolveCronJobsStorePathFromConfig(cfg, env),
+    sessionStoreOwner: resolvePersistedSessionStoreOwner(cfg),
+    agents: listAgentIds(cfg)
+      .toSorted()
+      .map((agentId) => {
+        const session = resolveHeartbeatSessionKey(
+          cfg,
+          agentId,
+          resolveHeartbeatConfig(legacyConfig, agentId),
+          undefined,
+          env,
+        );
+        const scope = resolveSqliteScope({ agentId, env, ...session });
+        return {
+          agentId,
+          workspace: resolveIdentityPathViaExistingAncestorSync(
+            resolveAgentWorkspaceDir(cfg, agentId, env),
+          ),
+          sessionKey: scope.sessionKey,
+          databasePath: resolveOpenClawAgentSqlitePath(toDatabaseOptions(scope)),
+        };
+      }),
+  };
+}
+
+/** Writer normalization may change spelling, but cannot move the prepared sources. */
+export function assertHeartbeatRetirementSourceSelection(
+  plan: HeartbeatRetirementPlan,
+  cfg: OpenClawConfig,
+): void {
+  if (
+    !isDeepStrictEqual(
+      resolveSourceSelection(cfg, plan.env, plan.effectiveConfig),
+      plan.sourceSelection,
+    )
+  ) {
+    throw new Error(
+      "Heartbeat source selection changed after preparation; configuration was retained.",
+    );
+  }
+}
+
+export function withoutHeartbeatConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const next = structuredClone(cfg);
+  if (next.agents?.defaults) {
+    delete next.agents.defaults.heartbeat;
+  }
+  for (const agent of Object.values(next.agents?.entries ?? {})) {
+    delete agent.heartbeat;
+  }
+  for (const agent of next.agents?.list ?? []) {
+    delete agent.heartbeat;
+  }
+  for (const channel of Object.values(next.channels ?? {})) {
+    if (!isRecord(channel)) {
+      continue;
+    }
+    delete channel.heartbeatVisibility;
+    if (!isRecord(channel.accounts)) {
+      continue;
+    }
+    for (const account of Object.values(channel.accounts)) {
+      if (isRecord(account)) {
+        delete account.heartbeatVisibility;
+      }
+    }
+  }
+  return next;
+}
+
+export function isLegacyJob(job: CronStoredJob): boolean {
+  return job.payload.kind === "heartbeat" || isHeartbeatTaskCronJob(job);
+}
+
+export function assertPendingDestination(
+  receipt: PendingProactiveJobReceipt,
+  jobs: readonly CronStoredJob[],
+  scratch: (jobId: string) => CronJobScratchState,
+): void {
+  for (const binding of receipt.jobs) {
+    const job = jobs.find((candidate) => candidate.id === binding.jobId);
+    if (
+      !job ||
+      job.state.runningAtMs !== undefined ||
+      job.state.queuedAtMs !== undefined ||
+      resolveCronJobConfigRevision(job) !== binding.configRevision ||
+      scratch(job.id).currentRevision !== binding.scratchRevision
+    ) {
+      throw new Error(
+        `Automation ${binding.jobId} changed during pending cutover; configuration was retained.`,
+      );
+    }
+  }
+}
+
+/** Read-only preparation pins effective defaults separately from authored configuration. */
+export async function prepareHeartbeatRetirement(params: {
+  sourceConfig: OpenClawConfig;
+  effectiveConfig: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  nowMs?: number;
+}): Promise<HeartbeatRetirementPlan> {
+  const env = params.env ?? process.env;
+  const nowMs = params.nowMs ?? Date.now();
+  const cfg = params.effectiveConfig;
+  const sourceSelection = resolveSourceSelection(cfg, env);
+  const storePath = sourceSelection.storePath;
+  const storeKey = cronStoreKey(storePath);
+  const snapshot = withExistingOpenClawStateDatabaseReadOnly(
+    ({ db }) => {
+      const rows = loadCronRows(db, storeKey);
+      const loaded = loadedCronStoreFromRows(rows);
+      if (loaded.invalidConfigRows.length) {
+        throw new Error("Cron contains unreadable rows; repair them before heartbeat cutover.");
+      }
+      const jobs = loaded.store.jobs;
+      return {
+        jobs,
+        sortOrder: new Map(rows.map((row) => [row.job_id, row.sort_order])),
+        scratch: new Map(
+          jobs.map((job) => [job.id, readCronJobScratchStateInDatabase(db, storeKey, job.id)]),
+        ),
+        receipts: new Map(
+          listAgentIds(cfg).map((agentId) => [
+            agentId,
+            readDefaultProactiveJobReceiptInDatabase(db, storePath, agentId),
+          ]),
+        ),
+      };
+    },
+    { env },
+  ) ?? { jobs: [], sortOrder: new Map(), scratch: new Map(), receipts: new Map() };
+  const agentIds = new Set(resolveHeartbeatAgents(cfg).map((agent) => agent.agentId));
+  const configured = new Set(listAgentIds(cfg));
+  const sourceFiles = new Map<string, HeartbeatSource>();
+  const sources = new Map<string, SourcePlan>();
+  for (const agentId of configured) {
+    const source = await readHeartbeatSource(cfg, agentId, { env });
+    if (source) {
+      sourceFiles.set(agentId, source);
+      sources.set(source.entryKey, { source, agentId });
+    }
+    if (source || resolveHeartbeatConfig(cfg, agentId)) {
+      agentIds.add(agentId);
+    }
+  }
+  // Absence is part of the snapshot: a file appearing between shared owners'
+  // reads must not be archived after only the later owner received its tasks.
+  for (const agentId of configured) {
+    if (
+      !isDeepStrictEqual(await readHeartbeatSource(cfg, agentId, { env }), sourceFiles.get(agentId))
+    ) {
+      throw new Error("A heartbeat source changed during preparation; configuration was retained.");
+    }
+  }
+  for (const job of snapshot.jobs.filter(isLegacyJob)) {
+    if (!job.agentId || !configured.has(job.agentId)) {
+      throw new Error(
+        `Legacy automation ${job.id} has no configured owner; configuration was retained.`,
+      );
+    }
+    agentIds.add(job.agentId);
+  }
+  for (const [agentId, receipt] of snapshot.receipts) {
+    if (receipt) {
+      agentIds.add(agentId);
+    }
+  }
+  const agents: AgentPlan[] = [];
+  let sortOrder = Math.max(-1, ...snapshot.sortOrder.values()) + 1;
+  const seed = resolveHeartbeatSchedulerSeed(undefined, { env, readOnly: true });
+  for (const agentId of [...agentIds].toSorted()) {
+    const policy = resolveHeartbeatRetirementPolicy({ effectiveConfig: cfg, agentId, env });
+    const sourceRevision = heartbeatRetirementFingerprint(policy);
+    const receipt = snapshot.receipts.get(agentId);
+    if (receipt?.phase === "complete") {
+      if (
+        sourceFiles.has(agentId) ||
+        resolveHeartbeatConfig(params.sourceConfig, agentId) ||
+        heartbeatRetirementConfigFingerprint({ channels: params.sourceConfig.channels }) !==
+          heartbeatRetirementConfigFingerprint({
+            channels: withoutHeartbeatConfig(params.sourceConfig).channels,
+          })
+      ) {
+        throw new Error(
+          `Agent ${agentId} acquired legacy heartbeat intent after completed cutover; configuration and files were retained.`,
+        );
+      }
+      if (snapshot.jobs.some((job) => job.agentId === agentId && isLegacyJob(job))) {
+        throw new Error(
+          `Agent ${agentId} acquired legacy jobs after completed cutover; configuration was retained.`,
+        );
+      }
+      continue;
+    }
+    if (receipt?.phase === "pending") {
+      if (snapshot.jobs.some((job) => job.agentId === agentId && isLegacyJob(job))) {
+        throw new Error(
+          "Legacy automation appeared during pending cutover; configuration was retained.",
+        );
+      }
+      if (
+        receipt.sourceRevision !== sourceRevision &&
+        receipt.retiredConfigRevision !== heartbeatRetirementConfigFingerprint(params.sourceConfig)
+      ) {
+        throw new Error(
+          `Agent ${agentId} heartbeat policy changed during pending cutover; restore the original policy or a verified backup before retrying. Configuration was retained.`,
+        );
+      }
+      assertPendingDestination(
+        receipt,
+        snapshot.jobs,
+        (id) => snapshot.scratch.get(id) ?? { currentRevision: 0 },
+      );
+      const source = sourceFiles.get(agentId);
+      const recorded = receipt.sourceFile;
+      const workspace = sourceSelection.agents.find(
+        (agent) => agent.agentId === agentId,
+      )!.workspace;
+      if (
+        (recorded &&
+          recorded.entryKey !== path.join(workspace, path.basename(recorded.entryKey))) ||
+        (source && (recorded?.entryKey !== source.entryKey || recorded.sha256 !== source.sha256))
+      ) {
+        throw new Error(
+          `Agent ${agentId} heartbeat file changed during pending cutover; configuration was retained.`,
+        );
+      }
+      agents.push({
+        agentId,
+        sourceRevision: receipt.sourceRevision,
+        receipt,
+        defaultJobId: receipt.jobId,
+        jobs: [],
+      });
+      continue;
+    }
+    const previousJobs = snapshot.jobs.filter((job) => job.agentId === agentId && isLegacyJob(job));
+    const generated = previousJobs
+      .filter(
+        (job) => job.payload.kind === "heartbeat" && job.declarationKey === `heartbeat:${agentId}`,
+      )
+      .toSorted((left, right) => right.updatedAtMs - left.updatedAtMs);
+    const everyMs = policy.everyMs ?? 30 * 60_000;
+    const original = generated[0] ?? {
+      id: randomUUID(),
+      agentId,
+      name: `Proactive check (${agentId})`,
+      enabled: policy.eligible,
+      createdAtMs: nowMs,
+      updatedAtMs: nowMs,
+      schedule: {
+        kind: "every" as const,
+        everyMs,
+        anchorMs: resolveHeartbeatPhaseMs({ schedulerSeed: seed, agentId, intervalMs: everyMs }),
+      },
+      payload: { kind: "heartbeat" as const },
+      sessionTarget: "main" as const,
+      wakeMode: "next-heartbeat" as const,
+      state: {},
+    };
+    const monitor = convertHeartbeatJobForRetirement(original, policy, nowMs);
+    // Config owns the canonical monitor; a stopped Gateway may not have applied
+    // a cadence re-enable yet. Editable tasks retain their stored enabled flag.
+    monitor.enabled = policy.eligible;
+    if (
+      generated[0] &&
+      policy.everyMs !== null &&
+      (monitor.schedule.kind !== "every" || monitor.schedule.everyMs !== policy.everyMs)
+    ) {
+      monitor.schedule = {
+        kind: "every",
+        everyMs: policy.everyMs,
+        anchorMs: resolveHeartbeatPhaseMs({
+          schedulerSeed: seed,
+          agentId,
+          intervalMs: policy.everyMs,
+        }),
+      };
+    }
+    if (!generated[0]) {
+      monitor.state.nextRunAtMs = computeJobNextRunAtMs(monitor, nowMs);
+    } else if (!cronSchedulingInputsEqual(original, monitor)) {
+      finalizeUpdatedJob({
+        job: original,
+        nextJob: monitor,
+        now: nowMs,
+        schedulingInputsRequested: true,
+        scheduleChanged: !isDeepStrictEqual(original.schedule, monitor.schedule),
+      });
+    }
+    const scratch = snapshot.scratch.get(monitor.id) ?? { currentRevision: 0 };
+    const source = sourceFiles.get(agentId);
+    let content = scratch.scratch?.content;
+    if (source) {
+      // SQLite is already authoritative after the first scratch mutation. A
+      // leftover file is archived, but cannot revive an unset checklist or
+      // overwrite an operator edit.
+      if (scratch.currentRevision === 0) {
+        content = source.content;
+      }
+    }
+    const document = analyzeLegacyHeartbeatTasks(content ?? "");
+    const tasks = document.hasTasksBlock
+      ? validateLegacyHeartbeatTasks(document.tasks, document.taskEntryCount)
+      : [];
+    const jobs: JobPlan[] = [
+      {
+        previous: generated[0],
+        job: monitor,
+        sortOrder: snapshot.sortOrder.get(monitor.id) ?? sortOrder++,
+        scratch,
+        nextScratch: scratch,
+      },
+    ];
+    if (content !== undefined) {
+      assertCronJobScratchContent(document.strippedContent);
+      const sourceSha256 =
+        scratch.currentRevision === 0 ? source?.sha256 : scratch.scratch?.sourceSha256;
+      if (
+        scratch.scratch?.content !== document.strippedContent ||
+        scratch.scratch?.sourceSha256 !== sourceSha256
+      ) {
+        const revision = scratch.currentRevision + 1;
+        jobs[0]!.nextScratch = {
+          currentRevision: revision,
+          scratch: {
+            content: document.strippedContent,
+            revision,
+            updatedAtMs: nowMs,
+            ...(sourceSha256 ? { sourceSha256 } : {}),
+          },
+        };
+      }
+    }
+    for (const previous of previousJobs.filter((job) => job !== generated[0])) {
+      if (
+        previous.payload.kind === "heartbeat" &&
+        previous.declarationKey?.startsWith("heartbeat:") &&
+        !generated.includes(previous)
+      ) {
+        throw new Error(
+          `Legacy monitor ${previous.id} has a conflicting declaration; configuration was retained.`,
+        );
+      }
+      const state = snapshot.scratch.get(previous.id) ?? { currentRevision: 0 };
+      const job = convertHeartbeatJobForRetirement(previous, policy, nowMs);
+      // Match the monitor reconciler's newest-row winner while retaining the
+      // retired duplicates' IDs, scratch, and history for inspection.
+      if (generated.includes(previous)) {
+        job.enabled = false;
+      }
+      jobs.push({
+        previous,
+        job,
+        sortOrder: snapshot.sortOrder.get(previous.id)!,
+        scratch: state,
+        nextScratch: state,
+      });
+    }
+    const session = loadSessionEntryReadOnly({
+      agentId,
+      storePath: policy.sessionStorePath,
+      sessionKey: policy.sessionKey,
+      env,
+    });
+    for (const { task, intervalMs, occurrenceIndex } of tasks) {
+      const declaration = heartbeatTaskDeclarationKey(agentId, task.name, occurrenceIndex);
+      const matches = snapshot.jobs.filter((job) => job.declarationKey === declaration);
+      if (
+        matches.length > 1 ||
+        (matches[0] && (!isHeartbeatTaskCronJob(matches[0]) || matches[0].agentId !== agentId))
+      ) {
+        throw new Error(
+          `Heartbeat task ${task.name} collides with another automation; configuration was retained.`,
+        );
+      }
+      if (matches[0]) {
+        continue;
+      }
+      const lastRunAtMs = session?.heartbeatTaskState?.[task.name];
+      const anchorMs =
+        typeof lastRunAtMs === "number" && Number.isFinite(lastRunAtMs)
+          ? Math.max(nowMs + 1, lastRunAtMs + intervalMs)
+          : nowMs + 1;
+      const job: RetiredHeartbeatJob = {
+        id: randomUUID(),
+        agentId,
+        name: task.name,
+        createdAtMs: nowMs,
+        updatedAtMs: nowMs,
+        enabled: policy.eligible,
+        sessionKey: policy.sessionKey,
+        sessionTarget: policy.sessionTarget,
+        wakeMode: "now",
+        activeHours: policy.activeHours,
+        idleOnly: true,
+        delivery: policy.delivery,
+        schedule: { kind: "every", everyMs: intervalMs, anchorMs },
+        payload: { kind: "agentTurn", message: task.prompt, ...policy.payload },
+        state:
+          typeof lastRunAtMs === "number" && Number.isFinite(lastRunAtMs) ? { lastRunAtMs } : {},
+      };
+      job.state.nextRunAtMs = computeJobNextRunAtMs(job, nowMs);
+      jobs.push({
+        job,
+        sortOrder: sortOrder++,
+        scratch: { currentRevision: 0 },
+        nextScratch: { currentRevision: 0 },
+      });
+    }
+    agents.push({
+      agentId,
+      sourceRevision,
+      jobs,
+      defaultJobId: monitor.id,
+      ...(source ? { sourceFile: { entryKey: source.entryKey, sha256: source.sha256 } } : {}),
+    });
+  }
+  return {
+    sourceConfig: structuredClone(params.sourceConfig),
+    effectiveConfig: structuredClone(cfg),
+    config: withoutHeartbeatConfig(params.sourceConfig),
+    storePath,
+    env,
+    nowMs,
+    sourceSelection,
+    agents,
+    sources: [...sources.values()],
+    absentSourceAgentIds: [...configured].filter((agentId) => !sourceFiles.has(agentId)),
+    legacyJobIds: snapshot.jobs
+      .filter(isLegacyJob)
+      .map((job) => job.id)
+      .toSorted(),
+  };
+}

--- a/src/commands/doctor-heartbeat-retirement-policy.ts
+++ b/src/commands/doctor-heartbeat-retirement-policy.ts
@@ -1,0 +1,313 @@
+import { isDeepStrictEqual } from "node:util";
+import { stableStringify } from "@openclaw/normalization-core";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveAgentConfig } from "../agents/agent-scope-config.js";
+import { resolveUserTimezone } from "../agents/date-time.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection-config.js";
+import {
+  buildModelAliasIndex,
+  resolveConfiguredModelFallbacks,
+  resolveModelRefFromString,
+} from "../agents/model-selection-resolve.js";
+import { applyModelDefaults } from "../config/defaults.js";
+import { normalizeAgentModelRefForConfig, toAgentModelListLike } from "../config/model-input.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { CronDelivery, CronStoredJob } from "../cron/types.js";
+import { sha256Hex } from "../infra/crypto-digest.js";
+import {
+  resolveHeartbeatAgents,
+  resolveHeartbeatConfig,
+  resolveHeartbeatIntervalMs,
+} from "../infra/heartbeat-config.js";
+import { resolveHeartbeatSessionKey } from "../infra/heartbeat-runner-session.js";
+import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
+
+type RetiredHeartbeatWindow = { start: string; end: string; timezone?: string };
+type RetiredHeartbeatDelivery = CronDelivery & {
+  target?: "owner";
+  directPolicy?: "allow" | "block";
+};
+
+function alertsEnabled(cfg: OpenClawConfig, target: string, accountId?: string): boolean {
+  const channels =
+    target === "owner" || target === "last"
+      ? Object.keys(cfg.channels ?? {}).filter(
+          (key) => key !== "defaults" && key !== "modelByChannel",
+        )
+      : [target];
+  const values = new Set(
+    (channels.length ? channels : ["webchat"]).flatMap((channel) => {
+      const accounts = Object.keys(
+        asOptionalRecord(asOptionalRecord(cfg.channels?.[channel])?.accounts) ?? {},
+      );
+      return (accountId ? [accountId] : accounts.length ? accounts : [undefined]).map(
+        (id) => resolveHeartbeatVisibility({ cfg, channel, accountId: id }).showAlerts,
+      );
+    }),
+  );
+  if (values.size !== 1) {
+    throw new Error(
+      "Mixed heartbeat alert visibility cannot be represented by one automation delivery policy; configuration was retained.",
+    );
+  }
+  return values.has(true);
+}
+
+/** Prepared destination shape; runtime policy ownership lands with the complete cutover. */
+export type RetiredHeartbeatJob = CronStoredJob & {
+  activeHours?: RetiredHeartbeatWindow;
+  idleOnly: true;
+  delivery: RetiredHeartbeatDelivery;
+  payload: Extract<CronStoredJob["payload"], { kind: "agentTurn" }> & {
+    skipIfScratchEmpty?: boolean;
+  };
+};
+
+export function resolveHeartbeatRetirementPolicy(params: {
+  effectiveConfig: OpenClawConfig;
+  agentId: string;
+  env: NodeJS.ProcessEnv;
+}) {
+  const { effectiveConfig: cfg, agentId, env } = params;
+  for (const channel of Object.values(cfg.channels ?? {})) {
+    const entry = asOptionalRecord(channel);
+    const records = [
+      entry,
+      ...Object.values(asOptionalRecord(entry?.accounts) ?? {}).map(asOptionalRecord),
+    ];
+    if (
+      records.some((record) => {
+        const visibility = asOptionalRecord(record?.heartbeatVisibility);
+        return visibility?.showOk !== undefined || visibility?.useIndicator !== undefined;
+      })
+    ) {
+      throw new Error(
+        "Explicit heartbeat showOk/useIndicator settings have no ordinary cron equivalent; configuration was retained.",
+      );
+    }
+  }
+  const heartbeat = resolveHeartbeatConfig(cfg, agentId);
+  const everyMs = resolveHeartbeatIntervalMs(cfg, undefined, heartbeat);
+  const enrolled = resolveHeartbeatAgents(cfg).some((agent) => agent.agentId === agentId);
+  const session = resolveHeartbeatSessionKey(cfg, agentId, heartbeat, undefined, env);
+  const active = heartbeat?.activeHours;
+  let activeHours: RetiredHeartbeatWindow | undefined;
+  // Legacy windows with either endpoint absent were unrestricted. Filling the
+  // missing endpoint would silently introduce a new execution restriction.
+  if (
+    active?.start &&
+    active.end &&
+    /^([01]\d|2[0-3]):[0-5]\d$/.test(active.start) &&
+    /^(([01]\d|2[0-3]):[0-5]\d|24:00)$/.test(active.end)
+  ) {
+    const timezone = active.timezone?.trim();
+    let normalizedTimezone = timezone;
+    if (timezone && timezone !== "user" && timezone !== "local") {
+      try {
+        new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(0);
+      } catch {
+        normalizedTimezone = "user";
+      }
+    }
+    activeHours = {
+      start: active.start,
+      end: active.end,
+      ...(normalizedTimezone ? { timezone: normalizedTimezone } : {}),
+    };
+  }
+  const globalTimeout = cfg.agents?.defaults?.timeoutSeconds;
+  const timeoutSeconds =
+    heartbeat?.timeoutSeconds ??
+    (typeof globalTimeout === "number" && Number.isFinite(globalTimeout)
+      ? globalTimeout === 0
+        ? 0
+        : Math.max(1, Math.floor(globalTimeout))
+      : Math.max(1, Math.min(600, Math.ceil((everyMs ?? 600_000) / 1000))));
+  const target = normalizeOptionalString(heartbeat?.target) ?? "owner";
+  const delivery: RetiredHeartbeatDelivery = {
+    mode:
+      target === "none" || !alertsEnabled(cfg, target, heartbeat?.accountId) ? "none" : "announce",
+    ...(target === "owner" ? { target } : target !== "none" ? { channel: target } : {}),
+    ...(target !== "owner" && target !== "none" && heartbeat?.to ? { to: heartbeat.to } : {}),
+    ...(heartbeat?.accountId ? { accountId: heartbeat.accountId } : {}),
+    ...(heartbeat?.directPolicy ? { directPolicy: heartbeat.directPolicy } : {}),
+  };
+  const model = normalizeOptionalString(heartbeat?.model);
+  return {
+    eligible: enrolled && everyMs !== null,
+    everyMs,
+    sessionKey: session.sessionKey,
+    sessionStorePath: session.storePath,
+    sessionTarget: heartbeat?.isolatedSession
+      ? ("isolated" as const)
+      : (`session:${session.sessionKey}` as const),
+    activeHours,
+    idleOnly: true as const,
+    delivery,
+    payload: {
+      ...(model ? { model } : {}),
+      timeoutSeconds,
+      ...(heartbeat?.lightContext !== undefined ? { lightContext: heartbeat.lightContext } : {}),
+    },
+    prompt: normalizeOptionalString(heartbeat?.prompt),
+    // Preserve the distinction between inherited fallback policy and an
+    // explicit empty override while a prepared cutover is pending.
+    agentModel: resolveAgentConfig(cfg, agentId)?.model,
+    defaultModel: cfg.agents?.defaults?.model,
+    // A user-timezone edit changes the effective window even when its authored
+    // token stays "user"; pin that fact in the migration source fingerprint.
+    userTimezone: resolveUserTimezone(cfg.agents?.defaults?.userTimezone),
+  };
+}
+
+export function heartbeatRetirementFingerprint(value: unknown): string {
+  return sha256Hex(stableStringify(value));
+}
+
+/** Match the writer-owned source projection after JSON removes own-undefined fields. */
+export function heartbeatRetirementConfigFingerprint(config: OpenClawConfig): string {
+  // oxlint-disable-next-line unicorn/prefer-structured-clone -- Match persisted JSON omission semantics, not an in-memory clone.
+  return heartbeatRetirementFingerprint(JSON.parse(JSON.stringify(config)));
+}
+
+function inheritedPolicyInputs(cfg: OpenClawConfig, agentId: string) {
+  const defaults = cfg.agents?.defaults;
+  const agentModel = toAgentModelListLike(resolveAgentConfig(cfg, agentId)?.model);
+  const defaultModel = toAgentModelListLike(defaults?.model);
+  return {
+    timeoutSeconds: defaults?.timeoutSeconds,
+    userTimezone: defaults?.userTimezone,
+    agentPrimary: agentModel?.primary && normalizeAgentModelRefForConfig(agentModel.primary),
+    agentFallbacks: agentModel?.fallbacks?.map(normalizeAgentModelRefForConfig),
+    defaultPrimary: defaultModel?.primary && normalizeAgentModelRefForConfig(defaultModel.primary),
+    defaultFallbacks: defaultModel?.fallbacks?.map(normalizeAgentModelRefForConfig),
+  };
+}
+
+function modelBindings(config: OpenClawConfig, agentId: string, refs: readonly string[]) {
+  const cfg = applyModelDefaults(config);
+  const primary = resolveDefaultModelForAgent({ cfg, agentId });
+  const aliasIndex = buildModelAliasIndex({ cfg, agentId, defaultProvider: primary.provider });
+  return [
+    primary,
+    ...refs.map((raw) => {
+      const resolved = resolveModelRefFromString({
+        cfg,
+        agentId,
+        raw,
+        defaultProvider: primary.provider,
+        aliasIndex,
+      });
+      return resolved ? { ref: resolved.ref, aliased: resolved.alias !== undefined } : null;
+    }),
+  ];
+}
+
+export function assertHeartbeatRetirementInheritedPolicy(
+  plan: {
+    sourceConfig: OpenClawConfig;
+    effectiveConfig: OpenClawConfig;
+    agents: ReadonlyArray<{ agentId: string }>;
+  },
+  candidate: OpenClawConfig,
+): void {
+  for (const { agentId } of plan.agents) {
+    const authored = inheritedPolicyInputs(plan.sourceConfig, agentId);
+    const effective = inheritedPolicyInputs(plan.effectiveConfig, agentId);
+    const final = inheritedPolicyInputs(candidate, agentId);
+    if (resolveHeartbeatConfig(plan.effectiveConfig, agentId)?.timeoutSeconds !== undefined) {
+      authored.timeoutSeconds = undefined;
+      effective.timeoutSeconds = undefined;
+      final.timeoutSeconds = undefined;
+    }
+    // Doctor may materialize an omitted effective default. An authored value
+    // disappearing is a policy edit, and an explicit empty fallback stays one.
+    const fields = [
+      "timeoutSeconds",
+      "userTimezone",
+      "agentPrimary",
+      "agentFallbacks",
+      "defaultPrimary",
+      "defaultFallbacks",
+    ] as const;
+    const project = (inputs: typeof authored) =>
+      fields.map((key) =>
+        inputs[key] === undefined && authored[key] === undefined ? effective[key] : inputs[key],
+      );
+    const refs = [
+      resolveHeartbeatConfig(plan.effectiveConfig, agentId)?.model,
+      ...resolveConfiguredModelFallbacks({ cfg: plan.effectiveConfig, agentId }),
+    ].flatMap((ref) => (ref ? [ref] : []));
+    const authoredBindings = modelBindings(plan.sourceConfig, agentId, refs);
+    const effectiveBindings = modelBindings(plan.effectiveConfig, agentId, refs);
+    const sameBindings = modelBindings(candidate, agentId, refs).every(
+      (binding, index) =>
+        isDeepStrictEqual(binding, authoredBindings[index]) ||
+        isDeepStrictEqual(binding, effectiveBindings[index]),
+    );
+    if (!isDeepStrictEqual(project(authored), project(final)) || !sameBindings) {
+      throw new Error(
+        `Agent ${agentId} inherited heartbeat policy changed after preparation; configuration was retained.`,
+      );
+    }
+  }
+}
+
+const DEFAULT_PROMPT =
+  "Review your automation scratch checklist and relevant session context. Do not infer or repeat old tasks from prior conversations. Take useful action only when needed. Use NO_REPLY when there is nothing to tell the user.";
+
+export function convertHeartbeatJobForRetirement(
+  previous: CronStoredJob,
+  policy: ReturnType<typeof resolveHeartbeatRetirementPolicy>,
+  nowMs: number,
+): RetiredHeartbeatJob {
+  const payload = previous.payload;
+  const message = payload.kind === "systemEvent" ? payload.text : (policy.prompt ?? DEFAULT_PROMPT);
+  const storedDelivery = previous.delivery;
+  if (
+    storedDelivery?.mode === "webhook" ||
+    (["channel", "to", "threadId", "accountId", "completionDestination"] as const).some(
+      (key) =>
+        storedDelivery?.[key] !== undefined &&
+        !isDeepStrictEqual(storedDelivery[key], policy.delivery[key]),
+    )
+  ) {
+    throw new Error(
+      `Legacy automation ${previous.id} has an explicit delivery destination that heartbeat never executed; resolve it before cutover. Configuration was retained.`,
+    );
+  }
+  const tools = {
+    ...(payload.toolsAllow ? { toolsAllow: payload.toolsAllow } : {}),
+    ...(payload.toolsAllowIsDefault !== undefined
+      ? { toolsAllowIsDefault: payload.toolsAllowIsDefault }
+      : {}),
+  };
+  const job: RetiredHeartbeatJob = {
+    ...structuredClone(previous),
+    enabled: previous.enabled && policy.eligible,
+    sessionKey: policy.sessionKey,
+    sessionTarget: policy.sessionTarget,
+    activeHours: policy.activeHours,
+    idleOnly: true,
+    // The heartbeat wake bus ignored task completion routes. Preserve its
+    // effective delivery and cron's independently active failure destination.
+    delivery: {
+      ...policy.delivery,
+      ...(storedDelivery?.failureDestination
+        ? { failureDestination: storedDelivery.failureDestination }
+        : {}),
+    },
+    wakeMode: "now",
+    payload: {
+      kind: "agentTurn",
+      message,
+      ...policy.payload,
+      ...tools,
+      ...(payload.kind === "heartbeat" ? { skipIfScratchEmpty: true } : {}),
+    },
+    updatedAtMs: nowMs,
+  };
+  delete job.declarationKey;
+  return job;
+}

--- a/src/commands/doctor-heartbeat-retirement.test.ts
+++ b/src/commands/doctor-heartbeat-retirement.test.ts
@@ -1,0 +1,966 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  buildModelAliasIndex,
+  resolveModelRefFromString,
+} from "../agents/model-selection-shared.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { heartbeatTaskDeclarationKey } from "../cron/heartbeat-task.js";
+import { readDefaultProactiveJobReceipt } from "../cron/proactive-job-receipt.js";
+import { readCronJobScratchState, writeCronJobScratch } from "../cron/scratch-store.js";
+import {
+  loadCronJobsStore,
+  resolveCronJobsStorePathFromConfig,
+  saveCronJobsStore,
+} from "../cron/store.js";
+import type { CronStoredJob } from "../cron/types.js";
+import { writeConfigMachineState } from "../state/config-machine-state.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { resolveHeartbeatRetirementPolicy } from "./doctor-heartbeat-retirement-policy.js";
+import {
+  applyHeartbeatRetirement,
+  completeHeartbeatRetirement,
+  prepareHeartbeatRetirement,
+} from "./doctor-heartbeat-retirement.js";
+import {
+  archiveHeartbeatSource,
+  archivePathForSource,
+  claimHeartbeatSource,
+  readHeartbeatSource,
+} from "./doctor-heartbeat-scratch-migration.js";
+
+const roots: string[] = [];
+const nowMs = 2_000_000_000_000;
+const tasks =
+  "# Checklist\n\ntasks:\n  - name: inbox\n    interval: 1h\n    prompt: Check urgent inbox items\n\n# Keep alerts concise\n";
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+function monitor(id = "monitor"): CronStoredJob {
+  return {
+    id,
+    agentId: "main",
+    name: "Existing heartbeat",
+    declarationKey: "heartbeat:main",
+    createdAtMs: nowMs - 20_000,
+    updatedAtMs: nowMs - 10_000,
+    enabled: true,
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    schedule: { kind: "every", everyMs: 1_800_000, anchorMs: 1234 },
+    payload: { kind: "heartbeat" },
+    state: { nextRunAtMs: nowMs - 1, lastRunAtMs: nowMs - 60_000, lastRunStatus: "ok" },
+  };
+}
+
+async function fixture(jobs: CronStoredJob[] = [monitor()]) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-retirement-"));
+  roots.push(root);
+  const workspace = path.join(root, "workspace");
+  await fs.mkdir(workspace);
+  vi.stubEnv("HOME", path.join(root, "home"));
+  vi.stubEnv("OPENCLAW_STATE_DIR", root);
+  const env = { ...process.env };
+  const cfg: OpenClawConfig = {
+    agents: { defaults: { workspace, heartbeat: { every: "30m" } }, list: [{ id: "main" }] },
+  };
+  const storePath = resolveCronJobsStorePathFromConfig(cfg, env);
+  if (jobs.length) {
+    await saveCronJobsStore(storePath, { version: 1, jobs });
+  }
+  const prepare = (sourceConfig = cfg, effectiveConfig = sourceConfig) =>
+    prepareHeartbeatRetirement({ sourceConfig, effectiveConfig, env, nowMs });
+  const scratch = () => readCronJobScratchState(storePath, "monitor", { env });
+  const receipt = () => readDefaultProactiveJobReceipt(storePath, "main", { env });
+  return {
+    root,
+    env,
+    cfg,
+    storePath,
+    prepare,
+    scratch,
+    receipt,
+    heartbeatPath: path.join(workspace, "HEARTBEAT.md"),
+  };
+}
+
+it("prepares a provider-resolved default without creating state or modifying authored config", async () => {
+  const f = await fixture([]);
+  delete f.cfg.agents!.defaults!.heartbeat;
+  const effective = structuredClone(f.cfg);
+  effective.agents!.defaults!.heartbeat = { every: "1h" };
+  const plan = await f.prepare(f.cfg, effective);
+  expect(plan.agents[0]?.jobs[0]?.job.schedule).toMatchObject({
+    kind: "every",
+    everyMs: 3_600_000,
+  });
+  expect(f.cfg.agents!.defaults!.heartbeat).toBeUndefined();
+  await expect(fs.stat(resolveOpenClawStateSqlitePath(f.env))).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+});
+
+it.each([{ start: "09:00" }, { end: "17:00" }])(
+  "keeps partial active-hours windows unrestricted: %j",
+  async (activeHours) => {
+    const f = await fixture([]);
+    f.cfg.agents!.defaults!.heartbeat!.activeHours = activeHours;
+    expect(
+      resolveHeartbeatRetirementPolicy({ effectiveConfig: f.cfg, agentId: "main", env: f.env })
+        .activeHours,
+    ).toBeUndefined();
+  },
+);
+
+it("preserves uniform alert suppression and rejects mixed dynamic owner visibility", async () => {
+  const f = await fixture([]);
+  f.cfg.channels = { defaults: { heartbeatVisibility: { showAlerts: false } } };
+  expect(
+    resolveHeartbeatRetirementPolicy({ effectiveConfig: f.cfg, agentId: "main", env: f.env })
+      .delivery.mode,
+  ).toBe("none");
+  f.cfg.channels = {
+    telegram: { heartbeatVisibility: { showAlerts: false } },
+    discord: { heartbeatVisibility: { showAlerts: true } },
+  };
+  await expect(f.prepare()).rejects.toThrow("Mixed heartbeat alert visibility");
+  await expect(fs.stat(resolveOpenClawStateSqlitePath(f.env))).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+});
+
+it("converts unenrolled owners' old tasks and files without enabling their jobs", async () => {
+  const f = await fixture();
+  delete f.cfg.agents!.defaults!.heartbeat;
+  f.cfg.agents!.list = [
+    { id: "main", workspace: path.dirname(f.heartbeatPath) },
+    { id: "other", heartbeat: { every: "1h" } },
+    { id: "untouched" },
+  ];
+  await fs.writeFile(f.heartbeatPath, tasks);
+  const plan = await f.prepare();
+  const main = plan.agents.find((agent) => agent.agentId === "main")!;
+  expect(main.jobs).toHaveLength(2);
+  expect(main.jobs.every(({ job }) => !job.enabled)).toBe(true);
+  expect(plan.agents.some((agent) => agent.agentId === "untouched")).toBe(false);
+  await applyHeartbeatRetirement(plan, plan.config);
+  expect(
+    (await loadCronJobsStore(f.storePath)).jobs
+      .filter((job) => job.agentId === "main")
+      .every((job) => !job.enabled),
+  ).toBe(true);
+});
+
+it.each(["showOk", "useIndicator"] as const)(
+  "retains explicit unsupported %s settings before preparation",
+  async (setting) => {
+    const f = await fixture([]);
+    f.cfg.channels = { defaults: { heartbeatVisibility: { [setting]: true } } };
+    await expect(f.prepare()).rejects.toThrow("no ordinary cron equivalent");
+    await expect(fs.stat(resolveOpenClawStateSqlitePath(f.env))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  },
+);
+
+it("retains the claimed inode when archiving across filesystems fails", async () => {
+  const f = await fixture([]);
+  await fs.writeFile(f.heartbeatPath, "Original instructions");
+  const source = (await readHeartbeatSource(f.cfg, "main", { env: f.env }))!;
+  await archiveHeartbeatSource({ source, agentId: "main", env: f.env });
+  const writer = await fs.open(f.heartbeatPath, "r+");
+  try {
+    const claim = await claimHeartbeatSource(source);
+    vi.spyOn(fs, "rename").mockRejectedValueOnce(
+      Object.assign(new Error("different filesystem"), { code: "EXDEV" }),
+    );
+    await expect(
+      claim.release({ archivePath: archivePathForSource("main", source.sha256, f.env) }),
+    ).rejects.toMatchObject({ code: "EXDEV" });
+    await writer.truncate(0);
+    await writer.writeFile("Late operator instructions");
+    await claim.restore(undefined);
+    expect(await fs.readFile(f.heartbeatPath, "utf8")).toBe("Late operator instructions");
+  } finally {
+    await writer.close();
+  }
+});
+
+it.each(["runningAtMs", "queuedAtMs"] as const)(
+  "refuses cutover while a job has %s ownership",
+  async (marker) => {
+    const job = monitor();
+    job.state[marker] = nowMs;
+    const f = await fixture([job]);
+    const before = await loadCronJobsStore(f.storePath);
+    const plan = await f.prepare();
+    await expect(applyHeartbeatRetirement(plan, plan.config)).rejects.toThrow(
+      "changed during preparation",
+    );
+    expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+    expect(f.receipt()).toBeUndefined();
+  },
+);
+
+it("preserves disabled enrollment, task overrides, tool policy, scratch and execution history", async () => {
+  const task: CronStoredJob = {
+    ...monitor("task"),
+    name: "inbox",
+    declarationKey: heartbeatTaskDeclarationKey("main", "inbox"),
+    payload: { kind: "systemEvent", text: "Operator-edited prompt", toolsAllow: ["read"] },
+    schedule: { kind: "every", everyMs: 9_000_000, anchorMs: 500 },
+  };
+  const original = monitor();
+  original.enabled = false;
+  const f = await fixture([original, task]);
+  f.cfg.agents!.defaults!.heartbeat = {
+    every: "0m",
+    model: "openai/gpt-5.6-sol",
+    lightContext: false,
+  };
+  f.cfg.agents!.defaults!.timeoutSeconds = 0;
+  writeCronJobScratch({
+    storePath: f.storePath,
+    jobId: original.id,
+    content: tasks,
+    expectedRevision: 0,
+  });
+  const plan = await f.prepare();
+  await applyHeartbeatRetirement(plan, plan.config);
+  const converted = (await loadCronJobsStore(f.storePath)).jobs;
+  expect(converted.map((job) => job.id)).toEqual(["monitor", "task"]);
+  expect(converted.every((job) => !job.enabled && job.payload.kind === "agentTurn")).toBe(true);
+  expect(converted[0]?.schedule).toEqual(original.schedule);
+  expect(converted[0]?.state).toEqual(original.state);
+  expect(converted[1]).toMatchObject({
+    schedule: task.schedule,
+    state: task.state,
+    payload: {
+      kind: "agentTurn",
+      message: "Operator-edited prompt",
+      toolsAllow: ["read"],
+      model: "openai/gpt-5.6-sol",
+      lightContext: false,
+      timeoutSeconds: 0,
+    },
+  });
+  expect(f.scratch().scratch?.content).not.toContain("tasks:");
+  await expect(completeHeartbeatRetirement(plan, f.cfg)).rejects.toThrow("still present");
+  expect(f.receipt()?.phase).toBe("pending");
+  await completeHeartbeatRetirement(plan, plan.config);
+  expect(f.receipt()?.phase).toBe("complete");
+});
+
+it("rejects invalid tasks before committing any job, scratch, or receipt", async () => {
+  const f = await fixture();
+  const invalid = tasks.replace("interval: 1h", "interval: nonsense");
+  writeCronJobScratch({
+    storePath: f.storePath,
+    jobId: "monitor",
+    content: invalid,
+    expectedRevision: 0,
+  });
+  const before = await loadCronJobsStore(f.storePath);
+  const beforeScratch = f.scratch();
+  await expect(f.prepare()).rejects.toThrow();
+  expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+  expect(f.scratch()).toEqual(beforeScratch);
+  expect(f.receipt()).toBeUndefined();
+});
+
+it.each(["default", "explicit"])(
+  "uses heartbeat delivery without activating a stored %s task route",
+  async (kind) => {
+    const task: CronStoredJob = {
+      ...monitor("task"),
+      declarationKey: heartbeatTaskDeclarationKey("main", "inbox"),
+      payload: { kind: "systemEvent", text: "Check inbox" },
+      delivery:
+        kind === "default"
+          ? { mode: "none", failureDestination: { channel: "last" } }
+          : { mode: "announce", channel: "telegram", to: "operator-target" },
+    };
+    const f = await fixture([monitor(), task]);
+    const before = await loadCronJobsStore(f.storePath);
+    if (kind === "explicit") {
+      await expect(f.prepare()).rejects.toThrow("heartbeat never executed");
+      expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+      expect(f.receipt()).toBeUndefined();
+      return;
+    }
+    const plan = await f.prepare();
+    const converted = plan.agents[0]!.jobs.find(({ job }) => job.id === "task")!;
+    expect(converted.previous).toMatchObject({ delivery: task.delivery });
+    expect(converted.job.delivery).toMatchObject({
+      mode: "announce",
+      target: "owner",
+      failureDestination: task.delivery!.failureDestination,
+    });
+  },
+);
+
+it.each(["cadence", "window", "delivery", "empty fallbacks"])(
+  "retains pending migration when repaired source changes %s",
+  async (change) => {
+    const f = await fixture();
+    const plan = await f.prepare();
+    await applyHeartbeatRetirement(plan, plan.config);
+    const before = await loadCronJobsStore(f.storePath);
+    const heartbeat = f.cfg.agents!.defaults!.heartbeat!;
+    if (change === "cadence") {
+      heartbeat.every = "2h";
+    }
+    if (change === "window") {
+      heartbeat.activeHours = { start: "10:00", end: "12:00" };
+    }
+    if (change === "delivery") {
+      heartbeat.directPolicy = "block";
+    }
+    if (change === "empty fallbacks") {
+      f.cfg.agents!.list![0]!.model = { fallbacks: [] };
+    }
+    await expect(f.prepare()).rejects.toThrow("policy changed");
+    expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+    expect(f.receipt()?.phase).toBe("pending");
+  },
+);
+
+it.each(["config", "file"])(
+  "retains newly introduced legacy %s after completed cutover",
+  async (change) => {
+    const f = await fixture();
+    const plan = await f.prepare();
+    await applyHeartbeatRetirement(plan, plan.config);
+    await completeHeartbeatRetirement(plan, plan.config);
+    const source = structuredClone(plan.config);
+    if (change === "config") {
+      source.agents!.defaults!.heartbeat = { every: "2h" };
+    } else {
+      await fs.writeFile(f.heartbeatPath, "New instructions");
+    }
+    const before = await loadCronJobsStore(f.storePath);
+    await expect(f.prepare(source)).rejects.toThrow("legacy heartbeat intent");
+    expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+    if (change === "file") {
+      expect(await fs.readFile(f.heartbeatPath, "utf8")).toBe("New instructions");
+    }
+  },
+);
+
+it.each(["job", "scratch"])(
+  "preserves an intervening destination %s edit on retry",
+  async (change) => {
+    const f = await fixture();
+    const plan = await f.prepare();
+    await applyHeartbeatRetirement(plan, plan.config);
+    if (change === "job") {
+      const store = await loadCronJobsStore(f.storePath);
+      store.jobs[0]!.name = "Operator edit";
+      await saveCronJobsStore(f.storePath, store);
+    } else {
+      writeCronJobScratch({
+        storePath: f.storePath,
+        jobId: "monitor",
+        content: "Operator edit",
+        expectedRevision: 0,
+      });
+    }
+    await expect(f.prepare()).rejects.toThrow("changed during pending");
+    await expect(completeHeartbeatRetirement(plan, plan.config)).rejects.toThrow(
+      "changed during pending",
+    );
+    expect(f.receipt()?.phase).toBe("pending");
+  },
+);
+
+it("archives a leftover file without reviving an explicit scratch tombstone", async () => {
+  const f = await fixture();
+  writeCronJobScratch({
+    storePath: f.storePath,
+    jobId: "monitor",
+    content: "Removed checklist",
+    expectedRevision: 0,
+  });
+  writeCronJobScratch({
+    storePath: f.storePath,
+    jobId: "monitor",
+    content: null,
+    expectedRevision: 1,
+  });
+  await fs.writeFile(f.heartbeatPath, tasks);
+  const plan = await f.prepare();
+  await applyHeartbeatRetirement(plan, plan.config);
+  expect(f.scratch()).toEqual({ currentRevision: 2 });
+  expect((await loadCronJobsStore(f.storePath)).jobs).toHaveLength(1);
+  await expect(fs.stat(f.heartbeatPath)).rejects.toMatchObject({ code: "ENOENT" });
+  const archiveDir = path.join(f.root, "backups", "heartbeat-migration");
+  const archives = await fs.readdir(archiveDir, { withFileTypes: true });
+  expect(
+    await fs.readFile(
+      path.join(archiveDir, archives.find((entry) => entry.isFile())!.name),
+      "utf8",
+    ),
+  ).toBe(tasks);
+  await completeHeartbeatRetirement(plan, plan.config);
+});
+
+it("preserves source bytes and all database rows when the file changes after preparation", async () => {
+  const f = await fixture();
+  await fs.writeFile(f.heartbeatPath, tasks);
+  const plan = await f.prepare();
+  const before = await loadCronJobsStore(f.storePath);
+  await fs.writeFile(f.heartbeatPath, "New operator instructions");
+  await expect(applyHeartbeatRetirement(plan, plan.config)).rejects.toThrow(
+    "changed during preparation",
+  );
+  expect(await fs.readFile(f.heartbeatPath, "utf8")).toBe("New operator instructions");
+  expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+  expect(f.receipt()).toBeUndefined();
+});
+
+it("resumes after the exact final Doctor config was written, then remembers permanent deletion", async () => {
+  const f = await fixture();
+  const plan = await f.prepare();
+  const finalConfig = { ...plan.config, logging: { level: "warn" as const } };
+  await applyHeartbeatRetirement(plan, finalConfig);
+  await expect(completeHeartbeatRetirement(plan, plan.config)).rejects.toThrow(
+    "differs from the final",
+  );
+  const retry = await f.prepare(finalConfig);
+  await applyHeartbeatRetirement(retry, finalConfig);
+  await completeHeartbeatRetirement(retry, finalConfig);
+  await saveCronJobsStore(f.storePath, { version: 1, jobs: [] });
+  const afterDeletion = await f.prepare(finalConfig);
+  expect(afterDeletion.agents).toEqual([]);
+  expect(f.receipt()?.jobId).toBe("monitor");
+});
+
+it("matches the persisted JSON projection when a candidate contains undefined properties", async () => {
+  const f = await fixture();
+  const plan = await f.prepare();
+  const finalConfig = { ...plan.config, logging: undefined };
+  await applyHeartbeatRetirement(plan, finalConfig);
+  // oxlint-disable-next-line unicorn/prefer-structured-clone -- Exercise the persisted JSON shape, which omits undefined fields.
+  const persisted = JSON.parse(JSON.stringify(finalConfig)) as OpenClawConfig;
+  await expect(completeHeartbeatRetirement(plan, persisted)).resolves.toBeUndefined();
+  expect(f.receipt()?.phase).toBe("complete");
+});
+
+it("keeps duplicate monitor IDs and scratch while enabling only the current reconciler winner", async () => {
+  const older = monitor("older");
+  const newer = monitor();
+  newer.updatedAtMs++;
+  const f = await fixture([older, newer]);
+  writeCronJobScratch({
+    storePath: f.storePath,
+    jobId: "older",
+    content: "Earlier checklist",
+    expectedRevision: 0,
+  });
+  const plan = await f.prepare();
+  await applyHeartbeatRetirement(plan, plan.config);
+  const store = await loadCronJobsStore(f.storePath);
+  expect(store.jobs.find((job) => job.id === "older")).toMatchObject({
+    enabled: false,
+    state: older.state,
+  });
+  expect(store.jobs.find((job) => job.id === "monitor")).toMatchObject({
+    enabled: true,
+    state: newer.state,
+  });
+  expect(readCronJobScratchState(f.storePath, "older").scratch?.content).toBe("Earlier checklist");
+  expect(f.receipt()?.jobId).toBe("monitor");
+});
+
+it("uses current enrollment for a stale disabled monitor without enabling a disabled task", async () => {
+  const stale = { ...monitor(), enabled: false };
+  const task: CronStoredJob = {
+    ...monitor("disabled-task"),
+    enabled: false,
+    declarationKey: heartbeatTaskDeclarationKey("main", "inbox"),
+    payload: { kind: "systemEvent", text: "Check inbox" },
+  };
+  const f = await fixture([stale, task]);
+  const plan = await f.prepare();
+  await applyHeartbeatRetirement(plan, plan.config);
+  const { jobs } = await loadCronJobsStore(f.storePath);
+  expect(jobs.find((job) => job.id === stale.id)?.enabled).toBe(true);
+  expect(jobs.find((job) => job.id === task.id)?.enabled).toBe(false);
+});
+
+it.each(["present", "absent"])(
+  "rejects differing reads of an initially %s shared heartbeat source",
+  async (initial) => {
+    const f = await fixture();
+    const workspace = path.dirname(f.heartbeatPath);
+    f.cfg.agents!.list = [
+      { id: "main", workspace },
+      { id: "ops", workspace },
+    ];
+    if (initial === "present") {
+      await fs.writeFile(f.heartbeatPath, tasks);
+    }
+    const before = await loadCronJobsStore(f.storePath);
+    let read = false;
+    const readSource = readHeartbeatSource;
+    vi.spyOn(
+      await import("./doctor-heartbeat-scratch-migration.js"),
+      "readHeartbeatSource",
+    ).mockImplementation(async (...args) => {
+      const source = await readSource(...args);
+      if (!read) {
+        read = true;
+        await fs.writeFile(f.heartbeatPath, "New operator checklist");
+      }
+      return source;
+    });
+    await expect(f.prepare().then(() => undefined)).rejects.toThrow("heartbeat source changed");
+    expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+    expect(f.receipt()).toBeUndefined();
+    expect(await fs.readFile(f.heartbeatPath, "utf8")).toBe("New operator checklist");
+  },
+);
+
+it("retains a newly created source for an untouched owner at completion", async () => {
+  const f = await fixture();
+  delete f.cfg.agents!.defaults!.heartbeat;
+  const untouchedWorkspace = path.join(f.root, "untouched");
+  await fs.mkdir(untouchedWorkspace);
+  f.cfg.agents!.list = [
+    { id: "main", heartbeat: { every: "30m" } },
+    { id: "untouched", workspace: untouchedWorkspace },
+  ];
+  const plan = await f.prepare();
+  expect(plan.agents.map(({ agentId }) => agentId)).toEqual(["main"]);
+  await applyHeartbeatRetirement(plan, plan.config);
+  const sourcePath = path.join(untouchedWorkspace, "HEARTBEAT.md");
+  await fs.writeFile(sourcePath, "New untouched-owner instructions");
+  const before = await loadCronJobsStore(f.storePath);
+  await expect(completeHeartbeatRetirement(plan, plan.config)).rejects.toThrow(
+    "heartbeat source remains",
+  );
+  expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+  expect(f.receipt()?.phase).toBe("pending");
+  expect(await fs.readFile(sourcePath, "utf8")).toBe("New untouched-owner instructions");
+});
+
+it.each(["apply", "complete"])(
+  "rejects canonical partition drift across %s filesystem awaits",
+  async (operation) => {
+    const f = await fixture();
+    await fs.writeFile(f.heartbeatPath, tasks);
+    const plan = await f.prepare();
+    if (operation === "complete") {
+      await applyHeartbeatRetirement(plan, plan.config);
+    }
+    const before = await loadCronJobsStore(f.storePath);
+    const changePartition = () =>
+      writeConfigMachineState("cron.store", path.join(f.root, "new-jobs.json"), { env: f.env });
+    const sourceModule = await import("./doctor-heartbeat-scratch-migration.js");
+    if (operation === "apply") {
+      const archiveSource = archiveHeartbeatSource;
+      vi.spyOn(sourceModule, "archiveHeartbeatSource").mockImplementation(async (...args) => {
+        await archiveSource(...args);
+        changePartition();
+      });
+    } else {
+      const readSource = readHeartbeatSource;
+      vi.spyOn(sourceModule, "readHeartbeatSource").mockImplementation(async (...args) => {
+        const source = await readSource(...args);
+        changePartition();
+        return source;
+      });
+    }
+    await expect(
+      operation === "apply"
+        ? applyHeartbeatRetirement(plan, plan.config)
+        : completeHeartbeatRetirement(plan, plan.config),
+    ).rejects.toThrow("source selection changed");
+    expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+    if (operation === "apply") {
+      expect(f.receipt()).toBeUndefined();
+      expect(await fs.readFile(f.heartbeatPath, "utf8")).toBe(tasks);
+    } else {
+      expect(f.receipt()?.phase).toBe("pending");
+    }
+  },
+);
+
+it.each([
+  { operation: "prepare", kind: "monitor" },
+  { operation: "prepare", kind: "task" },
+  { operation: "complete", kind: "monitor" },
+  { operation: "complete", kind: "task" },
+])("rejects a new legacy $kind during pending $operation", async ({ operation, kind }) => {
+  const f = await fixture();
+  const plan = await f.prepare();
+  await applyHeartbeatRetirement(plan, plan.config);
+  const store = await loadCronJobsStore(f.storePath);
+  const added = monitor("new-legacy-job");
+  if (kind === "task") {
+    added.declarationKey = heartbeatTaskDeclarationKey("main", "inbox");
+    added.payload = { kind: "systemEvent", text: "New instructions" };
+  }
+  store.jobs.push(added);
+  await saveCronJobsStore(f.storePath, store);
+  const before = await loadCronJobsStore(f.storePath);
+  await expect(
+    operation === "prepare"
+      ? f.prepare().then(() => undefined)
+      : completeHeartbeatRetirement(plan, plan.config),
+  ).rejects.toThrow("Legacy automation");
+  expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+  expect(f.receipt()?.phase).toBe("pending");
+});
+
+it.each(["before", "after"])(
+  "rejects canonical partition drift %s source release without approving the config write",
+  async (stage) => {
+    const f = await fixture();
+    await fs.writeFile(f.heartbeatPath, tasks);
+    const plan = await f.prepare();
+    const claimSource = claimHeartbeatSource;
+    const changePartition = () =>
+      writeConfigMachineState("cron.store", path.join(f.root, "new-jobs.json"), { env: f.env });
+    vi.spyOn(
+      await import("./doctor-heartbeat-scratch-migration.js"),
+      "claimHeartbeatSource",
+    ).mockImplementation(async (...args) => {
+      const claim = await claimSource(...args);
+      return {
+        ...claim,
+        release: async (params) => {
+          if (stage === "before") {
+            changePartition();
+          }
+          await claim.release(params);
+          if (stage === "after") {
+            changePartition();
+          }
+        },
+      };
+    });
+    await expect(applyHeartbeatRetirement(plan, plan.config)).rejects.toThrow(
+      "source selection changed",
+    );
+    expect(f.receipt()?.phase).toBe("pending");
+    expect((await loadCronJobsStore(f.storePath)).jobs[0]?.payload.kind).toBe("agentTurn");
+    expect(
+      (await loadCronJobsStore(resolveCronJobsStorePathFromConfig(f.cfg, f.env))).jobs,
+    ).toEqual([]);
+    if (stage === "before") {
+      expect(await fs.readFile(f.heartbeatPath, "utf8")).toBe(tasks);
+    } else {
+      await expect(fs.stat(f.heartbeatPath)).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  },
+);
+
+it.each(["workspace", "session store", "cron partition", "agent roster"])(
+  "rejects changed %s selection before retiring the prepared source",
+  async (selection) => {
+    const f = await fixture();
+    await fs.writeFile(f.heartbeatPath, tasks);
+    const plan = await f.prepare();
+    const candidate = structuredClone(plan.config);
+    if (selection === "workspace") {
+      const workspace = path.join(f.root, "new-workspace");
+      await fs.mkdir(workspace);
+      await fs.writeFile(path.join(workspace, "HEARTBEAT.md"), "Unimported instructions");
+      candidate.agents!.defaults!.workspace = workspace;
+    } else if (selection === "session store") {
+      candidate.session = { store: path.join(f.root, "new-sessions.sqlite") };
+    } else if (selection === "cron partition") {
+      writeConfigMachineState("cron.store", path.join(f.root, "new-jobs.json"), { env: f.env });
+    } else {
+      candidate.agents!.list = [{ id: "other" }];
+    }
+    const before = await loadCronJobsStore(f.storePath);
+    await expect(applyHeartbeatRetirement(plan, candidate)).rejects.toThrow(
+      "source selection changed",
+    );
+    expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+    expect(f.receipt()).toBeUndefined();
+    expect(await fs.readFile(f.heartbeatPath, "utf8")).toBe(tasks);
+  },
+);
+
+it.each(["before apply", "during claims"])(
+  "rejects a previously absent source appearing %s without committing a pending cutover",
+  async (phase) => {
+    const f = await fixture();
+    const otherWorkspace = path.join(f.root, "other-workspace");
+    await fs.mkdir(otherWorkspace);
+    f.cfg.agents!.list = [
+      { id: "main", workspace: path.dirname(f.heartbeatPath) },
+      { id: "other", workspace: otherWorkspace },
+    ];
+    const otherSourcePath = path.join(otherWorkspace, "HEARTBEAT.md");
+    await fs.writeFile(otherSourcePath, "Other instructions");
+    const plan = await f.prepare();
+    const before = await loadCronJobsStore(f.storePath);
+    if (phase === "before apply") {
+      await fs.writeFile(f.heartbeatPath, "New instructions");
+    } else {
+      const archiveSource = archiveHeartbeatSource;
+      vi.spyOn(
+        await import("./doctor-heartbeat-scratch-migration.js"),
+        "archiveHeartbeatSource",
+      ).mockImplementation(async (...args) => {
+        await archiveSource(...args);
+        await fs.writeFile(f.heartbeatPath, "New instructions");
+      });
+    }
+    await expect(applyHeartbeatRetirement(plan, plan.config)).rejects.toThrow(
+      "heartbeat source remains",
+    );
+    expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+    expect(f.receipt()).toBeUndefined();
+    expect(await fs.readFile(f.heartbeatPath, "utf8")).toBe("New instructions");
+    expect(await fs.readFile(otherSourcePath, "utf8")).toBe("Other instructions");
+  },
+);
+
+it("rejects a retargeted shared owner's alias even when another owner holds the source claim", async () => {
+  const f = await fixture();
+  const original = path.dirname(f.heartbeatPath);
+  const replacement = path.join(f.root, "replacement");
+  const alias = path.join(f.root, "alias");
+  await fs.mkdir(replacement);
+  await fs.symlink(original, alias, "dir");
+  await fs.writeFile(f.heartbeatPath, tasks);
+  await fs.writeFile(path.join(replacement, "HEARTBEAT.md"), tasks);
+  f.cfg.agents!.list = [
+    { id: "main", workspace: alias },
+    { id: "other", workspace: original },
+  ];
+  const plan = await f.prepare();
+  expect(plan.sources).toHaveLength(1);
+  expect(plan.sources[0]?.agentId).toBe("other");
+  const before = await loadCronJobsStore(f.storePath);
+  await fs.unlink(alias);
+  await fs.symlink(replacement, alias, "dir");
+  await expect(applyHeartbeatRetirement(plan, plan.config)).rejects.toThrow(
+    "source selection changed",
+  );
+  expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+  expect(f.receipt()).toBeUndefined();
+  expect(await fs.readFile(f.heartbeatPath, "utf8")).toBe(tasks);
+  expect(await fs.readFile(path.join(replacement, "HEARTBEAT.md"), "utf8")).toBe(tasks);
+});
+
+it.each([
+  "timeout",
+  "removed timeout",
+  "default model",
+  "agent model",
+  "empty fallbacks",
+  "timezone",
+])("rejects inherited %s drift in the final Doctor candidate", async (field) => {
+  const f = await fixture();
+  f.cfg.agents!.defaults!.timeoutSeconds = 60;
+  f.cfg.agents!.defaults!.model = {
+    primary: "openai/gpt-5.6-luna",
+    fallbacks: ["openai/gpt-5.6-sol"],
+  };
+  f.cfg.agents!.defaults!.userTimezone = "UTC";
+  await fs.writeFile(f.heartbeatPath, tasks);
+  const plan = await f.prepare();
+  const candidate = structuredClone(plan.config);
+  const defaults = candidate.agents!.defaults!;
+  if (field === "timeout") {
+    defaults.timeoutSeconds = 300;
+  } else if (field === "removed timeout") {
+    delete defaults.timeoutSeconds;
+  } else if (field === "default model") {
+    defaults.model = "openai/gpt-5.6-sol";
+  } else if (field === "agent model") {
+    candidate.agents!.list![0]!.model = "openai/gpt-5.6-sol";
+  } else if (field === "empty fallbacks") {
+    candidate.agents!.list![0]!.model = { fallbacks: [] };
+  } else {
+    defaults.userTimezone = "America/New_York";
+  }
+  const before = await loadCronJobsStore(f.storePath);
+  await expect(applyHeartbeatRetirement(plan, candidate)).rejects.toThrow("policy changed");
+  expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+  expect(f.receipt()).toBeUndefined();
+  expect(await fs.readFile(f.heartbeatPath, "utf8")).toBe(tasks);
+});
+
+it.each([false, true])(
+  "accepts unchanged effective defaults (materialized: %s)",
+  async (materialized) => {
+    const f = await fixture();
+    const effective = structuredClone(f.cfg);
+    effective.agents!.defaults!.timeoutSeconds = 60;
+    effective.agents!.defaults!.model = {
+      primary: "openai/gpt-5.6-luna",
+      fallbacks: ["openai/gpt-5.6-sol"],
+    };
+    effective.agents!.defaults!.userTimezone = "UTC";
+    effective.agents!.list![0]!.model = { fallbacks: [] };
+    const plan = await f.prepare(f.cfg, effective);
+    const candidate = structuredClone(plan.config);
+    if (materialized) {
+      candidate.agents!.defaults = { ...effective.agents!.defaults, heartbeat: undefined };
+      candidate.agents!.list = effective.agents!.list;
+    }
+    candidate.logging = { level: "warn" };
+    await applyHeartbeatRetirement(plan, candidate);
+    await completeHeartbeatRetirement(plan, candidate);
+    expect(f.receipt()?.phase).toBe("complete");
+    expect((await loadCronJobsStore(f.storePath)).jobs[0]?.payload).toMatchObject({
+      timeoutSeconds: 60,
+    });
+  },
+);
+
+it("allows a global timeout edit when heartbeat has an explicit timeout", async () => {
+  const f = await fixture();
+  f.cfg.agents!.defaults!.timeoutSeconds = 60;
+  f.cfg.agents!.defaults!.heartbeat!.timeoutSeconds = 120;
+  const plan = await f.prepare();
+  const candidate = structuredClone(plan.config);
+  candidate.agents!.defaults!.timeoutSeconds = 300;
+  await applyHeartbeatRetirement(plan, candidate);
+  await completeHeartbeatRetirement(plan, candidate);
+  expect((await loadCronJobsStore(f.storePath)).jobs[0]?.payload).toMatchObject({
+    timeoutSeconds: 120,
+  });
+});
+
+it.each(["omitted", "retired"])(
+  "rejects a %s source created during final archive release",
+  async (phase) => {
+    const f = await fixture();
+    const other = path.join(f.root, "other");
+    await fs.mkdir(other);
+    if (phase === "retired") {
+      await fs.writeFile(f.heartbeatPath, "Original instructions");
+    }
+    await fs.writeFile(path.join(other, "HEARTBEAT.md"), "Other instructions");
+    f.cfg.agents!.list = [
+      { id: "main", workspace: path.dirname(f.heartbeatPath) },
+      { id: "other", workspace: other },
+    ];
+    const entry = path.join(await fs.realpath(path.dirname(f.heartbeatPath)), "HEARTBEAT.md");
+    const plan = await f.prepare();
+    const rename = fs.rename.bind(fs);
+    vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+      await rename(from, to);
+      if (
+        String(to).includes("heartbeat-migration") &&
+        path.basename(String(to)) === "HEARTBEAT.md" &&
+        (phase === "omitted" || String(from).startsWith(entry))
+      ) {
+        await fs.writeFile(f.heartbeatPath, "New instructions");
+      }
+    });
+    const result = await applyHeartbeatRetirement(plan, plan.config).catch(
+      (error: unknown) => error,
+    );
+    expect(await fs.readFile(f.heartbeatPath, "utf8")).toBe("New instructions");
+    expect(result).toMatchObject({ message: expect.stringContaining("heartbeat source remains") });
+    expect(f.receipt()?.phase).toBe("pending");
+  },
+);
+
+it("retains the recorded source location across an interrupted retry and empty alias retarget", async () => {
+  const f = await fixture();
+  const original = path.dirname(f.heartbeatPath);
+  const empty = path.join(f.root, "empty");
+  const alias = path.join(f.root, "alias");
+  await fs.mkdir(empty);
+  await fs.symlink(original, alias, "dir");
+  f.cfg.agents!.list = [{ id: "main", workspace: alias }];
+  await fs.writeFile(f.heartbeatPath, tasks);
+  const plan = await f.prepare();
+  const rename = fs.rename.bind(fs);
+  const fault = vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+    if (
+      String(to).includes("heartbeat-migration") &&
+      path.basename(String(to)) === "HEARTBEAT.md"
+    ) {
+      throw Object.assign(new Error("Different filesystem"), { code: "EXDEV" });
+    }
+    await rename(from, to);
+  });
+  await expect(applyHeartbeatRetirement(plan, plan.config)).rejects.toMatchObject({
+    code: "EXDEV",
+  });
+  fault.mockRestore();
+  const pending = f.receipt();
+  expect(pending?.phase).toBe("pending");
+  const before = await loadCronJobsStore(f.storePath);
+  await fs.unlink(alias);
+  await fs.symlink(empty, alias, "dir");
+  await expect(f.prepare()).rejects.toThrow("heartbeat file changed");
+  expect(f.receipt()).toEqual(pending);
+  expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+  expect(await fs.readFile(f.heartbeatPath, "utf8")).toBe(tasks);
+  await fs.unlink(alias);
+  await fs.symlink(original, alias, "dir");
+  const retry = await f.prepare();
+  await applyHeartbeatRetirement(retry, retry.config);
+  await completeHeartbeatRetirement(retry, retry.config);
+  expect(f.receipt()?.phase).toBe("complete");
+});
+
+it.each(["inherited", "heartbeat", "agent override", "unused", "empty fallback override"])(
+  "pins consumed model alias bindings while allowing %s controls",
+  async (kind) => {
+    const f = await fixture();
+    f.cfg.agents!.defaults!.model = kind === "heartbeat" ? "openai/gpt-5.6-luna" : "fast";
+    f.cfg.agents!.defaults!.models = { "openai/gpt-5.6-luna": { alias: "fast" } };
+    if (kind === "heartbeat") {
+      f.cfg.agents!.defaults!.heartbeat!.model = "fast";
+    }
+    if (kind === "agent override") {
+      f.cfg.agents!.list![0]!.models = { "openai/gpt-5.6-luna": { alias: "fast" } };
+    }
+    if (kind === "empty fallback override") {
+      f.cfg.agents!.defaults!.model = { primary: "fast", fallbacks: ["fast"] };
+      f.cfg.agents!.list![0]!.model = { primary: "openai/gpt-5.6-luna", fallbacks: [] };
+    }
+    const route = (cfg: OpenClawConfig) =>
+      resolveModelRefFromString({
+        cfg,
+        agentId: "main",
+        raw: "fast",
+        defaultProvider: "openai",
+        aliasIndex: buildModelAliasIndex({ cfg, agentId: "main", defaultProvider: "openai" }),
+      })?.ref;
+    const plan = await f.prepare();
+    const candidate = structuredClone(plan.config);
+    candidate.agents!.defaults!.models =
+      kind === "unused"
+        ? { ...candidate.agents!.defaults!.models, "openai/gpt-5.6-sol": { alias: "unused" } }
+        : { "openai/gpt-5.6-sol": { alias: "fast" } };
+    const changed = kind === "inherited" || kind === "heartbeat";
+    if (changed) {
+      expect(route(f.cfg)).not.toEqual(route(candidate));
+      const before = await loadCronJobsStore(f.storePath);
+      await expect(applyHeartbeatRetirement(plan, candidate)).rejects.toThrow("policy changed");
+      expect(await loadCronJobsStore(f.storePath)).toEqual(before);
+      expect(f.receipt()).toBeUndefined();
+    } else {
+      if (kind !== "empty fallback override") {
+        expect(route(f.cfg)).toEqual(route(candidate));
+      }
+      await applyHeartbeatRetirement(plan, candidate);
+      await completeHeartbeatRetirement(plan, candidate);
+      expect(f.receipt()?.phase).toBe("complete");
+    }
+  },
+);

--- a/src/commands/doctor-heartbeat-retirement.ts
+++ b/src/commands/doctor-heartbeat-retirement.ts
@@ -1,0 +1,356 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveCronJobConfigRevision } from "../cron/config-revision.js";
+import {
+  completeProactiveJobInDatabase,
+  readDefaultProactiveJobReceiptInDatabase,
+  recordPendingProactiveJobInDatabase,
+  type PendingProactiveJobReceipt,
+} from "../cron/proactive-job-receipt.js";
+import { readCronJobScratchStateInDatabase } from "../cron/scratch-store.js";
+import { noteCronJobsStoreCommit } from "../cron/store.js";
+import { cronStoreKey } from "../cron/store/key.js";
+import {
+  loadCronRows,
+  loadedCronStoreFromRows,
+  upsertCronJobRow,
+} from "../cron/store/row-codec.js";
+import { listActiveCronRunReceiptJobIdsInDatabase } from "../cron/store/run-receipt-store.js";
+import { getCronStoreKysely } from "../cron/store/schema.js";
+import { executeSqliteQuerySync } from "../infra/kysely-sync.js";
+import { sameFsObject } from "../infra/path-case.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
+import {
+  assertHeartbeatRetirementSourceSelection,
+  assertPendingDestination,
+  isLegacyJob,
+  withoutHeartbeatConfig,
+  type HeartbeatRetirementPlan,
+} from "./doctor-heartbeat-retirement-plan.js";
+import {
+  assertHeartbeatRetirementInheritedPolicy,
+  heartbeatRetirementConfigFingerprint,
+} from "./doctor-heartbeat-retirement-policy.js";
+import {
+  archiveHeartbeatSource,
+  archivePathForSource,
+  claimHeartbeatSource,
+  readHeartbeatSource,
+} from "./doctor-heartbeat-scratch-migration.js";
+export {
+  prepareHeartbeatRetirement,
+  type HeartbeatRetirementPlan,
+} from "./doctor-heartbeat-retirement-plan.js";
+
+async function assertAbsentHeartbeatSources(
+  plan: HeartbeatRetirementPlan,
+  agentIds = plan.sourceSelection.agents.map(({ agentId }) => agentId),
+): Promise<void> {
+  for (const agentId of agentIds) {
+    if (await readHeartbeatSource(plan.effectiveConfig, agentId, { env: plan.env })) {
+      throw new Error("A heartbeat source remains; configuration was retained.");
+    }
+  }
+}
+
+// A contained link may leave its workspace and return through another source.
+// Resolve removable-entry dependencies before publishing pending destinations.
+async function orderHeartbeatSources(sources: HeartbeatRetirementPlan["sources"]) {
+  const pending = new Map(
+    sources
+      .toSorted((a, b) => a.source.entryKey.localeCompare(b.source.entryKey))
+      .map((item) => [item.source.entryKey, { item, dependencies: new Set<string>() }]),
+  );
+  for (const [entry, { dependencies }] of pending) {
+    let current = entry;
+    const visited = new Set<string>();
+    while ((await fs.lstat(current)).isSymbolicLink()) {
+      if (visited.has(current)) {
+        throw new Error("Heartbeat source links changed into a cycle; configuration was retained.");
+      }
+      visited.add(current);
+      const link = await fs.readlink(current);
+      // Resolve symlink parents before collapsing '..'; lexical normalization
+      // can otherwise select a different file or invent a cycle.
+      const target = path.isAbsolute(link) ? link : `${path.dirname(current)}${path.sep}${link}`;
+      const parent = await fs.realpath(path.dirname(target));
+      current = path.join(parent, path.basename(target));
+      const dependency = [...pending.keys()].find(
+        (candidate) =>
+          path.dirname(candidate) === parent &&
+          path.basename(candidate).toLowerCase() === path.basename(current).toLowerCase(),
+      );
+      // Case variants are aliases only when the filesystem proves they name
+      // the same entry; never collapse distinct files on case-sensitive stores.
+      if (
+        dependency &&
+        (dependency === current ||
+          sameFsObject(await fs.lstat(dependency), await fs.lstat(current)))
+      ) {
+        dependencies.add(dependency);
+      }
+    }
+  }
+  const ordered: typeof sources = [];
+  while (pending.size) {
+    const ready = [...pending].find(
+      ([entry]) => ![...pending.values()].some(({ dependencies }) => dependencies.has(entry)),
+    );
+    if (!ready) {
+      throw new Error(
+        "Heartbeat source dependencies changed into a cycle; configuration was retained.",
+      );
+    }
+    ordered.push(ready[1].item);
+    pending.delete(ready[0]);
+  }
+  return ordered;
+}
+
+/** Dormant until the integration owner installs ordinary policy execution and its schema fence. */
+export async function applyHeartbeatRetirement(
+  plan: HeartbeatRetirementPlan,
+  finalConfig: OpenClawConfig,
+): Promise<void> {
+  if (
+    heartbeatRetirementConfigFingerprint(finalConfig) !==
+    heartbeatRetirementConfigFingerprint(withoutHeartbeatConfig(finalConfig))
+  ) {
+    throw new Error("The final Doctor candidate still contains heartbeat configuration.");
+  }
+  assertHeartbeatRetirementSourceSelection(plan, finalConfig);
+  assertHeartbeatRetirementInheritedPolicy(plan, finalConfig);
+  const retiredConfigRevision = heartbeatRetirementConfigFingerprint(finalConfig);
+  let claim: Awaited<ReturnType<typeof claimHeartbeatSource>> | undefined;
+  try {
+    const sources = await orderHeartbeatSources(plan.sources);
+    for (const source of sources) {
+      await archiveHeartbeatSource({ ...source, env: plan.env });
+    }
+    for (const { source, agentId } of plan.sources) {
+      if (
+        !isDeepStrictEqual(
+          await readHeartbeatSource(plan.effectiveConfig, agentId, { env: plan.env }),
+          source,
+        )
+      ) {
+        throw new Error(
+          "A heartbeat source changed during preparation; configuration was retained.",
+        );
+      }
+    }
+    await assertAbsentHeartbeatSources(plan, plan.absentSourceAgentIds);
+    assertHeartbeatRetirementSourceSelection(plan, finalConfig);
+    assertHeartbeatRetirementInheritedPolicy(plan, finalConfig);
+    runOpenClawStateWriteTransaction(
+      ({ db }) => {
+        const storeKey = cronStoreKey(plan.storePath);
+        const rows = loadCronRows(db, storeKey);
+        const currentJobs = loadedCronStoreFromRows(rows).store.jobs;
+        const activeIds = listActiveCronRunReceiptJobIdsInDatabase(db, plan.storePath);
+        if (
+          plan.agents.some((agent) =>
+            (agent.receipt?.jobs ?? agent.jobs.map(({ job }) => ({ jobId: job.id }))).some(
+              ({ jobId }) => activeIds.has(jobId),
+            ),
+          )
+        ) {
+          throw new Error(
+            "An automation still has an active run receipt; finish recovery before heartbeat cutover.",
+          );
+        }
+        if (
+          !isDeepStrictEqual(
+            currentJobs
+              .filter(isLegacyJob)
+              .map((job) => job.id)
+              .toSorted(),
+            plan.legacyJobIds,
+          )
+        ) {
+          throw new Error("Legacy automation inventory changed during preparation.");
+        }
+        const scratch = (id: string) => readCronJobScratchStateInDatabase(db, storeKey, id);
+        for (const agent of plan.agents) {
+          const receipt = readDefaultProactiveJobReceiptInDatabase(
+            db,
+            plan.storePath,
+            agent.agentId,
+          );
+          if (agent.receipt) {
+            if (agent.receipt.retiredConfigRevision !== retiredConfigRevision) {
+              throw new Error(
+                "The final Doctor candidate changed during pending cutover; configuration was retained.",
+              );
+            }
+            if (!isDeepStrictEqual(receipt, agent.receipt)) {
+              throw new Error("Cutover receipt changed during preparation.");
+            }
+            assertPendingDestination(agent.receipt, currentJobs, scratch);
+            continue;
+          }
+          if (receipt) {
+            throw new Error("Cutover receipt appeared during preparation.");
+          }
+          for (const item of agent.jobs) {
+            const current = currentJobs.find((job) => job.id === item.job.id);
+            if (
+              !isDeepStrictEqual(current, item.previous) ||
+              current?.state.runningAtMs !== undefined ||
+              current?.state.queuedAtMs !== undefined ||
+              !isDeepStrictEqual(scratch(item.job.id), item.scratch)
+            ) {
+              throw new Error(
+                `Automation ${item.job.id} changed during preparation; no cutover was committed.`,
+              );
+            }
+          }
+        }
+        for (const agent of plan.agents) {
+          if (agent.receipt) {
+            continue;
+          }
+          const bindings: PendingProactiveJobReceipt["jobs"] = [];
+          for (const item of agent.jobs) {
+            const job = upsertCronJobRow(db, storeKey, item.job, item.sortOrder);
+            if (!isDeepStrictEqual(item.scratch, item.nextScratch)) {
+              const next = item.nextScratch;
+              const values = {
+                store_key: storeKey,
+                job_id: job.id,
+                revision: next.currentRevision,
+                content: next.scratch?.content ?? null,
+                source_sha256: next.scratch?.sourceSha256 ?? null,
+                updated_at_ms: plan.nowMs,
+              };
+              executeSqliteQuerySync(
+                db,
+                getCronStoreKysely(db)
+                  .insertInto("cron_job_scratch")
+                  .values(values)
+                  .onConflict((conflict) =>
+                    conflict.columns(["store_key", "job_id"]).doUpdateSet(values),
+                  ),
+              );
+            }
+            bindings.push({
+              jobId: job.id,
+              configRevision: resolveCronJobConfigRevision(job),
+              scratchRevision: item.nextScratch.currentRevision,
+            });
+          }
+          recordPendingProactiveJobInDatabase(db, plan.storePath, agent.agentId, {
+            phase: "pending",
+            jobId: agent.defaultJobId,
+            provisionedAtMs: plan.nowMs,
+            sourceRevision: agent.sourceRevision,
+            jobs: bindings,
+            retiredConfigRevision,
+            ...(agent.sourceFile ? { sourceFile: agent.sourceFile } : {}),
+          });
+        }
+      },
+      { env: plan.env },
+      { operationLabel: "doctor.heartbeat-retirement.prepare" },
+    );
+    noteCronJobsStoreCommit(cronStoreKey(plan.storePath));
+    for (const { source, agentId } of sources) {
+      claim = await claimHeartbeatSource(source);
+      await claim.release({
+        archivePath: archivePathForSource(agentId, source.sha256, plan.env),
+        verifyDestination: () => verifyPreparedDestinations(plan, finalConfig),
+      });
+      claim = undefined;
+    }
+    await assertAbsentHeartbeatSources(plan);
+    assertHeartbeatRetirementSourceSelection(plan, finalConfig);
+  } catch (error) {
+    if (claim) {
+      await claim.restore(error).catch((restoreError: unknown) => {
+        throw new AggregateError(
+          [error, restoreError],
+          "Heartbeat cutover failed; preserve the migration claims and backups before retrying.",
+          { cause: error },
+        );
+      });
+    }
+    throw error;
+  }
+}
+
+/** Complete job receipts after the full owner verifies Claw/outcomes and rereads canonical sourceConfig. */
+export async function completeHeartbeatRetirement(
+  plan: HeartbeatRetirementPlan,
+  persistedConfig: OpenClawConfig,
+): Promise<void> {
+  if (
+    heartbeatRetirementConfigFingerprint(persistedConfig) !==
+    heartbeatRetirementConfigFingerprint(withoutHeartbeatConfig(persistedConfig))
+  ) {
+    throw new Error("Heartbeat configuration is still present; cutover remains pending.");
+  }
+  await assertAbsentHeartbeatSources(plan);
+  assertHeartbeatRetirementSourceSelection(plan, persistedConfig);
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const storeKey = cronStoreKey(plan.storePath);
+      const jobs = loadedCronStoreFromRows(loadCronRows(db, storeKey)).store.jobs;
+      if (jobs.some(isLegacyJob)) {
+        throw new Error("Legacy automation remains unconverted; cutover stays pending.");
+      }
+      for (const agent of plan.agents) {
+        const receipt = readDefaultProactiveJobReceiptInDatabase(db, plan.storePath, agent.agentId);
+        if (receipt?.phase === "complete") {
+          continue;
+        }
+        if (!receipt || receipt.sourceRevision !== agent.sourceRevision) {
+          throw new Error("Cutover receipt changed before completion.");
+        }
+        if (
+          receipt.retiredConfigRevision !== heartbeatRetirementConfigFingerprint(persistedConfig)
+        ) {
+          throw new Error(
+            "Persisted configuration differs from the final Doctor candidate; cutover remains pending.",
+          );
+        }
+        assertPendingDestination(receipt, jobs, (id) =>
+          readCronJobScratchStateInDatabase(db, storeKey, id),
+        );
+        completeProactiveJobInDatabase(db, plan.storePath, agent.agentId, receipt);
+      }
+    },
+    { env: plan.env },
+    { operationLabel: "doctor.heartbeat-retirement.complete" },
+  );
+  noteCronJobsStoreCommit(cronStoreKey(plan.storePath));
+}
+
+function verifyPreparedDestinations(
+  plan: HeartbeatRetirementPlan,
+  finalConfig: OpenClawConfig,
+): void {
+  assertHeartbeatRetirementSourceSelection(plan, finalConfig);
+  const found = withExistingOpenClawStateDatabaseReadOnly(
+    ({ db }) => {
+      const storeKey = cronStoreKey(plan.storePath);
+      const jobs = loadedCronStoreFromRows(loadCronRows(db, storeKey)).store.jobs;
+      for (const agent of plan.agents) {
+        const receipt = readDefaultProactiveJobReceiptInDatabase(db, plan.storePath, agent.agentId);
+        if (receipt?.phase !== "pending" || receipt.sourceRevision !== agent.sourceRevision) {
+          throw new Error("Cutover receipt changed before source retirement.");
+        }
+        assertPendingDestination(receipt, jobs, (id) =>
+          readCronJobScratchStateInDatabase(db, storeKey, id),
+        );
+      }
+      return true;
+    },
+    { env: plan.env },
+  );
+  if (!found) {
+    throw new Error("Cutover state disappeared before source retirement.");
+  }
+}

--- a/src/commands/doctor-heartbeat-scratch-migration.test.ts
+++ b/src/commands/doctor-heartbeat-scratch-migration.test.ts
@@ -115,9 +115,13 @@ describe("HEARTBEAT.md cron scratch migration", () => {
       expect.objectContaining({ content, revision: 1, sourceSha256: expect.any(String) }),
     );
     const archiveDir = path.join(fixture.stateDir, "backups", "heartbeat-migration");
-    const archives = await fs.readdir(archiveDir);
-    expect(archives).toHaveLength(1);
-    await expect(fs.readFile(path.join(archiveDir, archives[0]!), "utf8")).resolves.toBe(content);
+    const archives = await fs.readdir(archiveDir, { withFileTypes: true });
+    const snapshot = archives.find((entry) => entry.isFile())!;
+    const original = archives.find((entry) => entry.isDirectory())!;
+    await expect(fs.readFile(path.join(archiveDir, snapshot.name), "utf8")).resolves.toBe(content);
+    await expect(
+      fs.readFile(path.join(archiveDir, original.name, "HEARTBEAT.md"), "utf8"),
+    ).resolves.toBe(content);
 
     const rerun = await maybeMigrateHeartbeatFilesToScratch({
       cfg: fixture.cfg,

--- a/src/commands/doctor-heartbeat-scratch-migration.ts
+++ b/src/commands/doctor-heartbeat-scratch-migration.ts
@@ -17,7 +17,7 @@ import {
 import { resolveCronJobsStorePathFromConfig } from "../cron/store.js";
 import type { CronJob } from "../cron/types.js";
 import type { HealthFinding } from "../flows/health-checks.js";
-import { formatErrorMessage as errorMessage } from "../infra/errors.js";
+import { formatErrorMessage as errorMessage, hasErrnoCode } from "../infra/errors.js";
 import { resolveHeartbeatAgents, resolveHeartbeatIntervalMs } from "../infra/heartbeat-config.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { readRegularFile } from "../infra/regular-file.js";
@@ -34,7 +34,7 @@ type HeartbeatScratchMigrationResult = {
   warnings: string[];
 };
 
-type HeartbeatSource = {
+export type HeartbeatSource = {
   path: string;
   /** Canonical parent directory + basename: the identity of the removable entry. */
   entryKey: string;
@@ -59,12 +59,12 @@ async function resolveHeartbeatScratchMigrationOwners(cfg: OpenClawConfig) {
   return { migrationAgents, disabledEntryKeys };
 }
 
-async function readHeartbeatSource(
+export async function readHeartbeatSource(
   cfg: OpenClawConfig,
   agentId: string,
-  options?: { recoverClaims?: boolean },
+  options?: { recoverClaims?: boolean; env?: NodeJS.ProcessEnv },
 ): Promise<HeartbeatSource | undefined> {
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId, options?.env);
   const heartbeatPath = path.join(workspaceDir, LEGACY_HEARTBEAT_FILENAME);
   let sourceStat;
   try {
@@ -128,7 +128,11 @@ async function readHeartbeatSource(
   };
 }
 
-function archivePathForSource(agentId: string, sha256: string, env: NodeJS.ProcessEnv): string {
+export function archivePathForSource(
+  agentId: string,
+  sha256: string,
+  env: NodeJS.ProcessEnv,
+): string {
   const safeAgentId = agentId.replace(/[^A-Za-z0-9._-]+/g, "-");
   return path.join(
     resolveStateDir(env),
@@ -142,7 +146,7 @@ type HeartbeatSourceClaim = {
   claimPath: string;
   restore(cause: unknown): Promise<void>;
   retain(): Promise<void>;
-  release(params: { archivePath: string }): Promise<void>;
+  release(params: { archivePath: string; verifyDestination?: () => void }): Promise<void>;
 };
 
 const HEARTBEAT_CLAIM_INFIX = ".doctor-importing-";
@@ -159,8 +163,11 @@ async function findStaleHeartbeatClaim(heartbeatPath: string): Promise<string | 
   let entries: string[];
   try {
     entries = await fs.readdir(dir);
-  } catch {
-    return undefined;
+  } catch (error) {
+    if (hasErrnoCode(error, "ENOENT")) {
+      return undefined;
+    }
+    throw error;
   }
   const claims = entries.filter((entry) => claimPattern.test(entry));
   if (claims.length > 1) {
@@ -221,14 +228,23 @@ async function restoreClaimNoClobber(claimPath: string, destinationPath: string)
 
 /**
  * Move the source aside and prove the claimed bytes still match what was read.
- * The claim happens before any scratch write so a concurrent edit can never
- * leave stale content committed while the replacement file is restored.
+ * Legacy scratch migration claims before copying; retirement records pending
+ * destinations first and keeps runtime writers stopped until completion.
  */
-async function claimHeartbeatSource(source: HeartbeatSource): Promise<HeartbeatSourceClaim> {
-  const claimPath = `${source.path}${HEARTBEAT_CLAIM_INFIX}${process.pid}-${source.sha256.slice(0, 12)}`;
-  await fs.rename(source.path, claimPath);
+export async function claimHeartbeatSource(source: HeartbeatSource): Promise<HeartbeatSourceClaim> {
+  const workspaceRealPath = path.dirname(source.entryKey);
+  const assertWorkspaceUnchanged = async () => {
+    if ((await fs.realpath(path.dirname(source.path))) !== workspaceRealPath) {
+      throw new Error("HEARTBEAT.md workspace changed after the source was read");
+    }
+  };
+  await assertWorkspaceUnchanged();
+  // Mutate the captured entry, so an alias retarget cannot redirect a claim or
+  // its restoration into another workspace while filesystem calls are pending.
+  const claimPath = `${source.entryKey}${HEARTBEAT_CLAIM_INFIX}${process.pid}-${source.sha256.slice(0, 12)}`;
+  await fs.rename(source.entryKey, claimPath);
   const restore = async (cause: unknown) => {
-    await restoreClaimNoClobber(claimPath, source.path).catch((restoreError: unknown) => {
+    await restoreClaimNoClobber(claimPath, source.entryKey).catch((restoreError: unknown) => {
       throw restoreError instanceof Error && restoreError.message.includes("preserved at")
         ? restoreError
         : new Error(`HEARTBEAT.md migration claim could not be restored from ${claimPath}`, {
@@ -237,7 +253,7 @@ async function claimHeartbeatSource(source: HeartbeatSource): Promise<HeartbeatS
     });
   };
   try {
-    const workspaceRealPath = await fs.realpath(path.dirname(source.path));
+    await assertWorkspaceUnchanged();
     const claimRealPath = await fs.realpath(claimPath);
     if (claimRealPath !== workspaceRealPath && !isPathInside(workspaceRealPath, claimRealPath)) {
       throw new Error("claimed HEARTBEAT.md target escapes the agent workspace");
@@ -267,7 +283,7 @@ async function claimHeartbeatSource(source: HeartbeatSource): Promise<HeartbeatS
     throw error;
   };
   const readFinalContent = async (filePath: string) => {
-    const workspaceRealPath = await fs.realpath(path.dirname(source.path));
+    await assertWorkspaceUnchanged();
     const fileRealPath = await fs.realpath(filePath);
     if (fileRealPath !== workspaceRealPath && !isPathInside(workspaceRealPath, fileRealPath)) {
       throw new Error("HEARTBEAT.md target escapes the agent workspace");
@@ -294,7 +310,7 @@ async function claimHeartbeatSource(source: HeartbeatSource): Promise<HeartbeatS
     // changed claim so the import rolls back instead of shadowing it.
     let recreated: boolean;
     try {
-      await fs.lstat(source.path);
+      await fs.lstat(source.entryKey);
       recreated = true;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -309,7 +325,7 @@ async function claimHeartbeatSource(source: HeartbeatSource): Promise<HeartbeatS
   const verifyRestoredUnchanged = async () => {
     let finalContent: string;
     try {
-      finalContent = await readFinalContent(source.path);
+      finalContent = await readFinalContent(source.entryKey);
     } catch (error) {
       throw changedError("restored HEARTBEAT.md could not be re-verified", error);
     }
@@ -324,36 +340,34 @@ async function claimHeartbeatSource(source: HeartbeatSource): Promise<HeartbeatS
       await restore(undefined);
       await verifyRestoredUnchanged();
     },
-    release: async ({ archivePath }) => {
+    release: async ({ archivePath, verifyDestination }) => {
       await verifyUnchanged();
-      // Retire the claim by moving the inode into the archive instead of
-      // unlinking it: a writer holding an open descriptor that lands a write
-      // after the hash check above still writes into the preserved archive
-      // file, never into a deleted inode.
       const claimStat = await fs.lstat(claimPath);
       if (claimStat.isSymbolicLink()) {
         // The removable entry is the symlink itself; its target file stays in
         // the workspace, so no open-descriptor write can be lost here.
+        verifyDestination?.();
         await fs.unlink(claimPath);
         return;
       }
+      // Equal bytes can come from distinct inodes still held by editors. Keep
+      // each original in a new private backup directory; never replace an older
+      // archive or the immutable snapshot written before claiming the source.
+      const archiveDir = await fs.mkdtemp(`${archivePath}.`);
       try {
-        await fs.rename(claimPath, archivePath);
+        verifyDestination?.();
+        await fs.rename(claimPath, path.join(archiveDir, LEGACY_HEARTBEAT_FILENAME));
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "EXDEV") {
-          throw error;
-        }
-        // Cross-device archive: the pre-written archive copy already holds the
-        // verified bytes. Accepted tradeoff: the unlink below reopens the
-        // microsecond open-descriptor window only when workspace and state dir
-        // sit on different filesystems.
-        await fs.unlink(claimPath);
+        // EXDEV leaves the recoverable claim intact. A completed rename with a
+        // lost acknowledgement leaves a nonempty backup, which rmdir preserves.
+        await fs.rmdir(archiveDir).catch(() => undefined);
+        throw error;
       }
     },
   };
 }
 
-async function archiveSource(params: {
+export async function archiveHeartbeatSource(params: {
   agentId: string;
   source: HeartbeatSource;
   env: NodeJS.ProcessEnv;
@@ -558,7 +572,7 @@ export async function maybeMigrateHeartbeatFilesToScratch(params: {
       // already durable under the state backups instead of only at a hidden
       // .doctor-importing-* path nothing rescans.
       try {
-        await archiveSource({ agentId: importAgents[0]![0], source, env });
+        await archiveHeartbeatSource({ agentId: importAgents[0]![0], source, env });
       } catch (error) {
         warnings.push(
           `${shortenHomePath(source.path)} was not migrated: ${errorMessage(error)}. Rerun doctor to retry safely.`,

--- a/src/commands/doctor-heartbeat-source-archive.test.ts
+++ b/src/commands/doctor-heartbeat-source-archive.test.ts
@@ -1,0 +1,277 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { readDefaultProactiveJobReceipt } from "../cron/proactive-job-receipt.js";
+import { readCronJobScratchState } from "../cron/scratch-store.js";
+import { loadCronJobsStore, resolveCronJobsStorePathFromConfig } from "../cron/store.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  applyHeartbeatRetirement,
+  completeHeartbeatRetirement,
+  prepareHeartbeatRetirement,
+} from "./doctor-heartbeat-retirement.js";
+import {
+  archiveHeartbeatSource,
+  archivePathForSource,
+  claimHeartbeatSource,
+  readHeartbeatSource,
+} from "./doctor-heartbeat-scratch-migration.js";
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(() => {
+    vi.restoreAllMocks();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    vi.unstubAllEnvs();
+    cleanup();
+  }),
+);
+
+async function fixture() {
+  const root = tempDirs.make("openclaw-heartbeat-archive-");
+  const workspace = path.join(root, "workspace");
+  await fs.mkdir(workspace);
+  const sourcePath = path.join(workspace, "HEARTBEAT.md");
+  vi.stubEnv("OPENCLAW_STATE_DIR", root);
+  const env = { ...process.env };
+  const cfg: OpenClawConfig = {
+    agents: {
+      defaults: { workspace, heartbeat: { every: "30m" } },
+      list: [{ id: "main", workspace }],
+    },
+  };
+  const storePath = resolveCronJobsStorePathFromConfig(cfg, env);
+  const prepare = () =>
+    prepareHeartbeatRetirement({
+      sourceConfig: cfg,
+      effectiveConfig: cfg,
+      env,
+      nowMs: 2_000_000_000_000,
+    });
+  const read = async (recoverClaims = false) =>
+    await readHeartbeatSource(cfg, "main", { env, recoverClaims });
+  const claim = async () => {
+    const source = (await read())!;
+    await archiveHeartbeatSource({ source, agentId: "main", env });
+    return {
+      claim: await claimHeartbeatSource(source),
+      archivePath: archivePathForSource("main", source.sha256, env),
+    };
+  };
+  const archivedContents = async () => {
+    const entries = await fs.readdir(path.join(root, "backups", "heartbeat-migration"), {
+      recursive: true,
+      withFileTypes: true,
+    });
+    return Promise.all(
+      entries
+        .filter((entry) => entry.isFile())
+        .map((entry) => fs.readFile(path.join(entry.parentPath, entry.name), "utf8")),
+    );
+  };
+  return { root, env, cfg, storePath, prepare, sourcePath, read, claim, archivedContents };
+}
+
+it("treats a missing workspace as having no heartbeat source", async () => {
+  const f = await fixture();
+  await fs.rmdir(path.dirname(f.sourcePath));
+  await expect(f.read()).resolves.toBeUndefined();
+});
+
+// Windows and root do not enforce these POSIX directory-listing permissions.
+it.runIf(process.platform !== "win32" && process.getuid?.() !== 0)(
+  "surfaces an unreadable claim inventory while preserving the interrupted source",
+  async () => {
+    const f = await fixture();
+    const workspace = path.dirname(f.sourcePath);
+    const claimPath = `${f.sourcePath}.doctor-importing-${process.pid}-0123456789ab`;
+    await fs.writeFile(claimPath, "Interrupted instructions");
+    await expect(f.read()).rejects.toThrow("interrupted migration claim");
+    await fs.chmod(workspace, 0o111);
+    try {
+      await expect(fs.lstat(f.sourcePath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.readdir(workspace)).rejects.toMatchObject({ code: "EACCES" });
+      await expect(f.read()).rejects.toMatchObject({ code: "EACCES" });
+    } finally {
+      await fs.chmod(workspace, 0o700);
+    }
+    expect(await fs.readFile(claimPath, "utf8")).toBe("Interrupted instructions");
+  },
+);
+
+it("preserves every original inode when the same heartbeat bytes are imported again", async () => {
+  const f = await fixture();
+  const writers: Awaited<ReturnType<typeof fs.open>>[] = [];
+  try {
+    for (let occurrence = 0; occurrence < 2; occurrence++) {
+      await fs.writeFile(f.sourcePath, "Same checklist");
+      writers.push(await fs.open(f.sourcePath, "r+"));
+      const { claim, archivePath } = await f.claim();
+      await claim.release({ archivePath });
+      await expect(fs.access(f.sourcePath)).rejects.toMatchObject({ code: "ENOENT" });
+    }
+    for (const [index, writer] of writers.entries()) {
+      expect((await writer.stat()).nlink).toBeGreaterThan(0);
+      await writer.truncate(0);
+      await writer.writeFile(`Late edit ${index}`);
+      await writer.sync();
+    }
+    expect(await f.archivedContents()).toEqual(
+      expect.arrayContaining(["Late edit 0", "Late edit 1"]),
+    );
+  } finally {
+    await Promise.all(writers.map((writer) => writer.close()));
+  }
+});
+
+it.each(["before claiming", "while claimed"])(
+  "preserves both entries when a workspace alias is retargeted %s",
+  async (phase) => {
+    const root = tempDirs.make("openclaw-heartbeat-alias-");
+    const original = path.join(root, "original");
+    const replacement = path.join(root, "replacement");
+    const alias = path.join(root, "workspace");
+    for (const workspace of [original, replacement]) {
+      await fs.mkdir(workspace);
+      await fs.writeFile(path.join(workspace, "HEARTBEAT.md"), "Same instructions");
+    }
+    await fs.symlink(original, alias, "dir");
+    const cfg = { agents: { list: [{ id: "main", workspace: alias }] } };
+    const env = { OPENCLAW_STATE_DIR: root };
+    const source = (await readHeartbeatSource(cfg, "main", { env }))!;
+    await archiveHeartbeatSource({ source, agentId: "main", env });
+    const claim = phase === "while claimed" ? await claimHeartbeatSource(source) : undefined;
+    await fs.unlink(alias);
+    await fs.symlink(replacement, alias, "dir");
+    if (claim) {
+      await expect(
+        claim.release({ archivePath: archivePathForSource("main", source.sha256, env) }),
+      ).rejects.toThrow();
+    } else {
+      await expect(claimHeartbeatSource(source)).rejects.toThrow();
+    }
+    for (const workspace of [original, replacement]) {
+      expect(await fs.readFile(path.join(workspace, "HEARTBEAT.md"), "utf8")).toBe(
+        "Same instructions",
+      );
+    }
+  },
+);
+
+it.each(["before", "after"])("recovers an interruption %s the archive rename", async (phase) => {
+  const f = await fixture();
+  await fs.writeFile(f.sourcePath, "Original checklist");
+  const writer = await fs.open(f.sourcePath, "r+");
+  try {
+    const { claim, archivePath } = await f.claim();
+    const rename = fs.rename.bind(fs);
+    vi.spyOn(fs, "rename").mockImplementationOnce(async (from, to) => {
+      if (phase === "after") {
+        await rename(from, to);
+      }
+      throw new Error("Interrupted archive rename");
+    });
+    await expect(claim.release({ archivePath })).rejects.toThrow("Interrupted archive rename");
+    const recovered = await f.read(true);
+    expect(Boolean(recovered)).toBe(phase === "before");
+    await writer.truncate(0);
+    await writer.writeFile("Late edit after interruption");
+    await writer.sync();
+    if (phase === "before") {
+      expect(await fs.readFile(f.sourcePath, "utf8")).toBe("Late edit after interruption");
+    } else {
+      expect(await f.archivedContents()).toContain("Late edit after interruption");
+    }
+  } finally {
+    await writer.close();
+  }
+});
+
+it.each(
+  ["forward", "reverse", "indirect", "directory parent"].flatMap((direction) =>
+    ["parent first", "child first"].map((order) => ({ direction, order })),
+  ),
+)(
+  "retires $direction contained links and shared aliases with $order insertion",
+  async ({ direction, order }) => {
+    const f = await fixture();
+    const outer = path.dirname(f.sourcePath);
+    const inner = path.join(
+      outer,
+      ...(direction === "directory parent" ? ["0", "nested"] : ["child"]),
+    );
+    const alias = path.join(f.root, "outer-alias");
+    await fs.mkdir(inner, { recursive: true });
+    await fs.symlink(outer, alias, "dir");
+    const linked = direction === "reverse" || direction === "indirect";
+    const target = linked ? "checklist.md" : "HEARTBEAT.md";
+    await fs.writeFile(path.join(inner, target), "Shared nested instructions");
+    if (direction === "directory parent") {
+      await fs.mkdir(path.join(outer, "0", "deep"));
+      await fs.mkdir(path.join(outer, "nested"));
+      await fs.writeFile(path.join(outer, "nested", "HEARTBEAT.md"), "Untouched decoy");
+      await fs.symlink("0/deep", path.join(outer, "bridge"));
+      await fs.symlink("bridge/../nested/HEARTBEAT.md", f.sourcePath);
+    } else {
+      await fs.symlink(`child/${target}`, f.sourcePath);
+    }
+    if (linked) {
+      const link = direction === "reverse" ? "../HEARTBEAT.md" : "alias.md";
+      if (direction === "indirect") {
+        await fs.symlink("../HEARTBEAT.md", path.join(inner, "alias.md"));
+      }
+      await fs.symlink(link, path.join(inner, "HEARTBEAT.md"));
+    }
+    const entries = [
+      { id: "main", workspace: outer },
+      { id: "child", workspace: inner },
+    ];
+    f.cfg.agents!.list = [
+      ...(order === "parent first" ? entries : entries.toReversed()),
+      { id: "shared", workspace: alias },
+    ];
+    let plan = await f.prepare();
+    expect(plan.sources).toHaveLength(2);
+    if (direction === "forward" && order === "child first") {
+      const rename = fs.rename.bind(fs);
+      const fault = vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+        if (
+          String(to).includes("heartbeat-migration") &&
+          path.basename(String(to)) === "HEARTBEAT.md"
+        ) {
+          throw Object.assign(new Error("Different filesystem"), { code: "EXDEV" });
+        }
+        await rename(from, to);
+      });
+      await expect(applyHeartbeatRetirement(plan, plan.config)).rejects.toMatchObject({
+        code: "EXDEV",
+      });
+      fault.mockRestore();
+      plan = await f.prepare();
+    }
+    await applyHeartbeatRetirement(plan, plan.config);
+    await completeHeartbeatRetirement(plan, plan.config);
+    const jobs = (await loadCronJobsStore(f.storePath)).jobs;
+    expect(jobs).toHaveLength(3);
+    for (const job of jobs) {
+      expect(readCronJobScratchState(f.storePath, job.id, { env: f.env }).scratch?.content).toBe(
+        "Shared nested instructions",
+      );
+      expect(readDefaultProactiveJobReceipt(f.storePath, job.agentId!, { env: f.env })?.phase).toBe(
+        "complete",
+      );
+    }
+    if (direction === "directory parent") {
+      expect(await fs.readFile(path.join(outer, "nested", "HEARTBEAT.md"), "utf8")).toBe(
+        "Untouched decoy",
+      );
+    }
+    await expect(fs.lstat(f.sourcePath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.lstat(path.join(inner, "HEARTBEAT.md"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  },
+);

--- a/src/commands/doctor-heartbeat-task-migration.ts
+++ b/src/commands/doctor-heartbeat-task-migration.ts
@@ -54,7 +54,7 @@ type ValidatedHeartbeatTask = {
   occurrenceIndex: number;
 };
 
-function validateTasks(
+export function validateLegacyHeartbeatTasks(
   tasks: readonly LegacyHeartbeatTask[],
   declaredEntryCount: number,
 ): ValidatedHeartbeatTask[] {
@@ -128,7 +128,7 @@ export async function collectHeartbeatTaskMigrationFindings(
       continue;
     }
     try {
-      validateTasks(document.tasks, document.taskEntryCount);
+      validateLegacyHeartbeatTasks(document.tasks, document.taskEntryCount);
       findings.push(
         migrationFinding({
           storePath,
@@ -450,7 +450,7 @@ export async function maybeMigrateHeartbeatTasksToCron(params: {
     const tasks = document.tasks;
     let validatedTasks: ValidatedHeartbeatTask[];
     try {
-      validatedTasks = validateTasks(tasks, document.taskEntryCount);
+      validatedTasks = validateLegacyHeartbeatTasks(tasks, document.taskEntryCount);
     } catch (error) {
       warnings.push(
         `Agent "${agent.agentId}" heartbeat tasks were not migrated: ${errorMessage(error)}.`,

--- a/src/cron/proactive-job-receipt.ts
+++ b/src/cron/proactive-job-receipt.ts
@@ -1,0 +1,142 @@
+import type { DatabaseSync } from "node:sqlite";
+import { isDeepStrictEqual } from "node:util";
+import { z } from "zod";
+import { normalizeAgentId } from "../routing/session-key.js";
+import {
+  readConfigMachineStateWithMetadataInDatabase,
+  writeConfigMachineStateInDatabase,
+} from "../state/config-machine-state.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import { cronStoreKey } from "./store/key.js";
+
+const JobBindingSchema = z
+  .object({
+    jobId: z.string().min(1),
+    configRevision: z.string().min(1),
+    scratchRevision: z.number().int().nonnegative(),
+  })
+  .strict();
+const ReceiptIdentity = {
+  jobId: z.string().min(1),
+  provisionedAtMs: z.number().int().nonnegative(),
+};
+const ProactiveReceiptSchema = z.discriminatedUnion("phase", [
+  z
+    .object({
+      ...ReceiptIdentity,
+      phase: z.literal("pending"),
+      sourceRevision: z.string().min(1),
+      retiredConfigRevision: z.string().min(1),
+      sourceFile: z
+        .object({ entryKey: z.string().min(1), sha256: z.string().min(1) })
+        .strict()
+        .optional(),
+      jobs: z.array(JobBindingSchema).min(1),
+    })
+    .strict(),
+  z
+    .object({
+      ...ReceiptIdentity,
+      phase: z.literal("complete"),
+      convertedJobIds: z.array(z.string().min(1)),
+    })
+    .strict(),
+]);
+
+export type ProactiveJobReceipt = z.infer<typeof ProactiveReceiptSchema>;
+export type PendingProactiveJobReceipt = Extract<ProactiveJobReceipt, { phase: "pending" }>;
+
+function receiptKey(storePath: string, agentId: string): string {
+  return `automation-default:${cronStoreKey(storePath)}:${normalizeAgentId(agentId)}`;
+}
+
+export function readDefaultProactiveJobReceiptInDatabase(
+  db: DatabaseSync,
+  storePath: string,
+  agentId: string,
+): ProactiveJobReceipt | undefined {
+  const value = readConfigMachineStateWithMetadataInDatabase(
+    db,
+    receiptKey(storePath, agentId),
+  )?.value;
+  if (value === undefined) {
+    return undefined;
+  }
+  const decoded = ProactiveReceiptSchema.safeParse(value);
+  if (!decoded.success) {
+    throw new Error(
+      `Invalid automation cutover receipt for ${agentId}; preserve the state and restore a verified backup before retrying.`,
+    );
+  }
+  return decoded.data;
+}
+
+export function readDefaultProactiveJobReceipt(
+  storePath: string,
+  agentId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): ProactiveJobReceipt | undefined {
+  return withExistingOpenClawStateDatabaseReadOnly(
+    ({ db }) => readDefaultProactiveJobReceiptInDatabase(db, storePath, agentId),
+    options,
+  );
+}
+
+/** Called in the same transaction that publishes the exact converted jobs and scratch. */
+export function recordPendingProactiveJobInDatabase(
+  db: DatabaseSync,
+  storePath: string,
+  agentId: string,
+  receipt: PendingProactiveJobReceipt,
+): void {
+  const previous = readDefaultProactiveJobReceiptInDatabase(db, storePath, agentId);
+  if (previous) {
+    throw new Error(`Agent ${agentId} already has an automation cutover receipt.`);
+  }
+  writeConfigMachineStateInDatabase(
+    db,
+    receiptKey(storePath, agentId),
+    JSON.stringify(receipt),
+    Date.now(),
+  );
+}
+
+/** Completion retains identity after operator edits or permanent job deletion. */
+export function completeProactiveJobInDatabase(
+  db: DatabaseSync,
+  storePath: string,
+  agentId: string,
+  expected: PendingProactiveJobReceipt,
+): void {
+  const previous = readDefaultProactiveJobReceiptInDatabase(db, storePath, agentId);
+  if (!previous || previous.phase !== "pending" || !isDeepStrictEqual(previous, expected)) {
+    throw new Error(`Agent ${agentId} cutover receipt changed before completion.`);
+  }
+  const complete: ProactiveJobReceipt = {
+    phase: "complete",
+    jobId: previous.jobId,
+    provisionedAtMs: previous.provisionedAtMs,
+    convertedJobIds: previous.jobs.map((job) => job.jobId).filter((id) => id !== previous.jobId),
+  };
+  writeConfigMachineStateInDatabase(
+    db,
+    receiptKey(storePath, agentId),
+    JSON.stringify(complete),
+    Date.now(),
+  );
+}
+
+export function isProactiveJobCutoverPending(
+  storePath: string,
+  job: { id: string; agentId?: string },
+  db?: DatabaseSync,
+): boolean {
+  if (!job.agentId) {
+    return false;
+  }
+  const receipt = db
+    ? readDefaultProactiveJobReceiptInDatabase(db, storePath, job.agentId)
+    : readDefaultProactiveJobReceipt(storePath, job.agentId);
+  return receipt?.phase === "pending" && receipt.jobs.some((binding) => binding.jobId === job.id);
+}

--- a/src/cron/scratch-store.ts
+++ b/src/cron/scratch-store.ts
@@ -53,7 +53,7 @@ function rowToState(row: {
   };
 }
 
-function readScratchStateFromDatabase(
+export function readCronJobScratchStateInDatabase(
   db: DatabaseSync,
   storeKey: string,
   jobId: string,
@@ -77,7 +77,7 @@ export function readCronJobScratchState(
   options: OpenClawStateDatabaseOptions = {},
 ): CronJobScratchState {
   const { db } = openOpenClawStateDatabase(options);
-  return readScratchStateFromDatabase(db, cronStoreKey(storePath), jobId);
+  return readCronJobScratchStateInDatabase(db, cronStoreKey(storePath), jobId);
 }
 
 function readHeartbeatMonitorScratchFromDatabase(
@@ -164,7 +164,7 @@ export function writeCronJobScratch(params: {
   return runOpenClawStateWriteTransaction(
     ({ db }) => {
       const cronDb = getCronStoreKysely(db);
-      const { currentRevision } = readScratchStateFromDatabase(db, storeKey, params.jobId);
+      const { currentRevision } = readCronJobScratchStateInDatabase(db, storeKey, params.jobId);
       const owningJob = executeSqliteQuerySync(
         db,
         cronDb
@@ -242,7 +242,7 @@ export function deleteCronJobScratch(
     ({ db }) => {
       const storeKey = cronStoreKey(storePath);
       if (guard) {
-        const { currentRevision } = readScratchStateFromDatabase(db, storeKey, jobId);
+        const { currentRevision } = readCronJobScratchStateInDatabase(db, storeKey, jobId);
         if (currentRevision !== guard.expectedRevision) {
           return false;
         }

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -102,7 +102,7 @@ function reconcileStreamSourceIdentity(job: CronJob, nextJob: CronJob): void {
     sourceChanged || !currentIdentity ? createCronStreamSourceIdentity() : currentIdentity;
 }
 
-function finalizeUpdatedJob(params: {
+export function finalizeUpdatedJob(params: {
   job: CronJob;
   nextJob: CronJob;
   now: number;

--- a/src/state/config-machine-state.ts
+++ b/src/state/config-machine-state.ts
@@ -1,4 +1,5 @@
 // Machine-owned values retired from openclaw.json live in the shared state database.
+import type { DatabaseSync } from "node:sqlite";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -35,22 +36,50 @@ export function readConfigMachineStateWithMetadata<T>(
   key: string,
   options: OpenClawStateDatabaseOptions = {},
 ): { value: T; updatedAtMs: number } | undefined {
-  return withExistingOpenClawStateDatabaseReadOnly(({ db: database }) => {
-    if (!tableExists(database, "config_machine_state")) {
-      return undefined;
-    }
-    const db = getNodeSqliteKysely<ConfigMachineStateDatabase>(database);
-    const row = executeSqliteQueryTakeFirstSync(
-      database,
-      db
-        .selectFrom("config_machine_state")
-        .select(["value_json", "updated_at_ms"])
-        .where("state_key", "=", normalizeStateKey(key)),
-    );
-    return row
-      ? { value: JSON.parse(row.value_json) as T, updatedAtMs: row.updated_at_ms }
-      : undefined;
-  }, options);
+  return withExistingOpenClawStateDatabaseReadOnly(
+    ({ db }) => readConfigMachineStateWithMetadataInDatabase<T>(db, key),
+    options,
+  );
+}
+
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Callers own the JSON shape for open-ended state keys.
+export function readConfigMachineStateWithMetadataInDatabase<T>(
+  database: DatabaseSync,
+  key: string,
+): { value: T; updatedAtMs: number } | undefined {
+  if (!tableExists(database, "config_machine_state")) {
+    return undefined;
+  }
+  const db = getNodeSqliteKysely<ConfigMachineStateDatabase>(database);
+  const row = executeSqliteQueryTakeFirstSync(
+    database,
+    db
+      .selectFrom("config_machine_state")
+      .select(["value_json", "updated_at_ms"])
+      .where("state_key", "=", normalizeStateKey(key)),
+  );
+  return row
+    ? { value: JSON.parse(row.value_json) as T, updatedAtMs: row.updated_at_ms }
+    : undefined;
+}
+
+/** Join the caller's synchronous commit with an already serialized value. */
+export function writeConfigMachineStateInDatabase(
+  database: DatabaseSync,
+  stateKey: string,
+  valueJson: string,
+  now: number,
+): void {
+  const db = getNodeSqliteKysely<ConfigMachineStateDatabase>(database);
+  executeSqliteQuerySync(
+    database,
+    db
+      .insertInto("config_machine_state")
+      .values({ state_key: stateKey, value_json: valueJson, updated_at_ms: now })
+      .onConflict((conflict) =>
+        conflict.column("state_key").doUpdateSet({ value_json: valueJson, updated_at_ms: now }),
+      ),
+  );
 }
 
 // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Callers own the JSON shape for open-ended state keys.
@@ -71,16 +100,7 @@ export function writeConfigMachineState(
   const now = Date.now();
   runOpenClawStateWriteTransaction(
     (database) => {
-      const db = getNodeSqliteKysely<ConfigMachineStateDatabase>(database.db);
-      executeSqliteQuerySync(
-        database.db,
-        db
-          .insertInto("config_machine_state")
-          .values({ state_key: stateKey, value_json: valueJson, updated_at_ms: now })
-          .onConflict((conflict) =>
-            conflict.column("state_key").doUpdateSet({ value_json: valueJson, updated_at_ms: now }),
-          ),
-      );
+      writeConfigMachineStateInDatabase(database.db, stateKey, valueJson, now);
     },
     options,
     { operationLabel: "config-machine-state.write" },
@@ -127,15 +147,7 @@ export function updateConfigMachineState<T>(
         return undefined;
       }
       const valueJson = serializeStateValue(value);
-      executeSqliteQuerySync(
-        database.db,
-        db
-          .insertInto("config_machine_state")
-          .values({ state_key: stateKey, value_json: valueJson, updated_at_ms: now })
-          .onConflict((conflict) =>
-            conflict.column("state_key").doUpdateSet({ value_json: valueJson, updated_at_ms: now }),
-          ),
-      );
+      writeConfigMachineStateInDatabase(database.db, stateKey, valueJson, now);
       return value;
     },
     options,


### PR DESCRIPTION
Related: #135933. Stacked on #138566.

## What Problem This Solves

Retiring heartbeat execution must preserve saved outcomes, scheduled tasks, scratch state, and the original instruction files. An interrupted Doctor run must resume its own conversion without overwriting later edits or reviving deleted destinations.

## Why This Change Was Made

Prepare conversion against the canonical stores. Outcome imports append hidden session notes and consume the source marker in the same agent transaction. Job and scratch conversion uses pending receipts and exact revisions; completion verifies the final persisted configuration and destination state.

Capture the original source entry and inherited policy during preparation. Retry checks preserve that entry even when a workspace alias now points to an empty directory. Model checks apply the canonical defaults before resolving aliases and fallbacks, accepting equivalent partial or complete Doctor defaults while rejecting explicit changes to consumed bindings. Validate the source set and resolve actual symlink dependencies before publishing pending destinations. Retire dependent entries before their targets, holding one file claim at a time; case variants are matched only after exact filesystem identity checks, and parent-directory symlinks resolve before `..` normalization. Recheck every source entry before approving the configuration write. Every original regular-file inode is retained in a private backup directory.

## User Impact

The retirement coordinator remains dormant. This draft changes no SQLite schema/version or Gateway wire field, adds no configuration option, and leaves heartbeat scheduling in place. The existing Doctor archive helper gains the source-preservation repairs: cross-device archive failure retains recoverable data, and unreadable claim inventory is reported instead of treated as absence.

Activation still requires the shared-database version fence, stopped runtime writers, canonical cron policy fields, Claw ownership/serialization, and the complete config-writer coordinator. That coordinator must rediscover the original cron partition across interrupted retries: these per-store receipt APIs cannot locate an earlier conversion after store selection changes before fresh preparation. The canonical cron executor must also preserve the existing distinction between absent scratch (run the generic/custom monitor prompt), present empty scratch (skip the monitor), and independently due tasks (run). The existing heartbeat outcome table remains intact. No atomic filesystem snapshot or safe mixed-version writer operation is claimed.

This draft must be folded with the consuming legacy-engine deletion before landing. Production is +1,705/-78 (**+1,627**), tests are +1,824/-3 (**+1,821**), and the assertion baseline changes one line for one line. It is not an independently landable unit under the negative-production-LOC requirement.

## Evidence

- The final component suites pass all 126 cases: real config-writer projection, per-agent/shared/global outcome ownership, transaction rollback, interrupted retry, edited/deleted destinations, source alias changes, contained link dependencies, original inode preservation, and consumed model-alias policy. The exact staged source on the published ownership parent also passes all 126 cases across five files, followed by worker-generation verification; core types pass on that same tree.
- Reproductions precede the repairs, including source drift on pending retry, source recreation during archive release, reverse link dependencies, directory symlinks followed by `..`, and model aliases changing behind unchanged authored strings. Native filesystem and canonical-owner probes pass after repair; the failing evidence is preserved.
- Production and full core-test typechecks, formatting, type-aware lint, and the remaining native-selected contract checks pass. The unchanged native gate remains failed on fifteen production unused exports (ten migration, five inherited ownership) and one full-tree migration export awaiting real consumers. No suppression or artificial caller was added.
- Independent Codex review of the final sixteen-path slice on the published ownership parent completed both evidence partitions with no actionable P0–P2 findings, followed by source/index verification. The focused final repair review retains the earlier owner review and failure evidence; it is not a new exhaustive review of unchanged dependencies.
- Earlier isolated live-model outcome-import proof covered OpenClaw and Codex in per-agent and shared stores: four cells and 114 assertions. It exercised the importer with heartbeat execution disabled, not the final retirement coordinator or this complete cutover.

The existing standalone legacy scratch-migration loop remains separate. Its eventual removal or dependency-order proof belongs to the full cutover; the new source-chain tests establish the dormant retirement owner's behavior.

Next draft: #138700 (ordinary background execution and delivery).
