### PR TITLE
fix(gateway): reconcile removed device workers after caller retirement

### DIFF
--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -19,6 +19,7 @@ import {
   getNodeWakeStateSnapshot,
   resetNodeWakeStateForTest,
 } from "../node-wake-state.test-support.js";
+import { registerGatewayPolicyResponse } from "../server/ws-policy-close.js";
 import { bindDeviceWorkerReconciliation } from "../worker-environments/device-provider.js";
 import { deviceHandlers } from "./devices.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
@@ -322,34 +323,70 @@ describe("deviceHandlers", () => {
     expect(disconnect).toHaveBeenCalledWith("device-1");
   });
 
-  it("reconciles device worker authority before reporting pairing removal", async () => {
-    removePairedDeviceMock.mockResolvedValue({ deviceId: "device-1" });
-    const opts = createOptions("device.pair.remove", { deviceId: "device-1" });
-    const order: string[] = [];
-    const workerEnvironmentService = {};
-    bindDeviceWorkerReconciliation(workerEnvironmentService, async () => {
-      order.push("environment");
-      return ["environment-1"];
-    });
-    const reconcileActive = vi.fn(async () => {
-      order.push("placement");
-    });
-    Object.assign(opts.context, {
-      workerEnvironmentService,
-      workerPlacementDispatchService: { reconcileActive },
-    });
-    vi.mocked(opts.respond).mockImplementation(() => {
-      order.push("respond");
-    });
+  it.each([false, true])(
+    "reconciles removed device workers even if the caller retires during removal: %s",
+    async (callerRetired) => {
+      const opts = createOptions(
+        "device.pair.remove",
+        { deviceId: "device-1" },
+        { client: createClient(["operator.admin"], "admin-device", { isDeviceTokenAuth: true }) },
+      );
+      const client = Object.assign(expectDefined(opts.client, "device removal caller"), {
+        invalidated: false,
+        socket: { close: vi.fn() },
+      });
+      removePairedDeviceMock.mockImplementationOnce(async () => {
+        client.invalidated = callerRetired;
+        return { deviceId: "device-1" };
+      });
+      const policyResponse = registerGatewayPolicyResponse(
+        "device.pair.remove",
+        client,
+        opts.respond,
+      );
+      const order: string[] = [];
+      const workerEnvironmentService = {};
+      bindDeviceWorkerReconciliation(workerEnvironmentService, async () => {
+        order.push("environment");
+        return ["environment-1"];
+      });
+      const reconcileActive = vi.fn(async () => {
+        order.push("placement");
+      });
+      Object.assign(opts.context, {
+        workerEnvironmentService,
+        workerPlacementDispatchService: { reconcileActive },
+        invalidateClientsForDevice: vi.fn(() => order.push("invalidate")),
+        disconnectClientsForDevice: vi.fn(() => order.push("disconnect")),
+      });
+      vi.mocked(opts.respond).mockImplementation(() => {
+        order.push("respond");
+      });
 
-    await expectDefined(
-      deviceHandlers["device.pair.remove"],
-      'deviceHandlers["device.pair.remove"] test invariant',
-    )(opts);
-
-    expect(reconcileActive).toHaveBeenCalledWith("environment-1");
-    expect(order).toEqual(["environment", "placement", "respond"]);
-  });
+      try {
+        const removal = expectDefined(
+          deviceHandlers["device.pair.remove"],
+          'deviceHandlers["device.pair.remove"] test invariant',
+        )(opts);
+        if (callerRetired) {
+          await expect(removal).rejects.toThrow("client authorization is no longer active");
+          expect(opts.respond).not.toHaveBeenCalled();
+        } else {
+          await removal;
+        }
+        expect(reconcileActive).toHaveBeenCalledWith("environment-1");
+        expect(order).toEqual([
+          "invalidate",
+          "environment",
+          "placement",
+          ...(callerRetired ? [] : ["respond"]),
+          "disconnect",
+        ]);
+      } finally {
+        policyResponse?.finish();
+      }
+    },
+  );
 
   it("does not disconnect clients when device removal fails", async () => {
     removePairedDeviceMock.mockResolvedValue(null);

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -481,8 +481,8 @@ export const deviceHandlers: GatewayRequestHandlers = {
         context.invalidateClientsForDevice?.(removed.deviceId, {
           reason: "device-pair-removed",
         });
+        await reconcileRevokedDeviceWorker(context, removed.deviceId);
       }
-      await reconcileRevokedDeviceWorker(context, removed.deviceId);
       context.logGateway.info(`device pairing removed device=${removed.deviceId}`);
       emitDevicePairingLifecycleSecurityEvent({
         action: "device.pairing.removed",


### PR DESCRIPTION
## Summary

Keep worker reconciliation in the guaranteed cleanup block after a committed device pairing removal. If the requester loses authority while the removal is awaiting storage, its real policy-response claim correctly rejects—but the old handler then skipped worker credential/environment/placement reconciliation.

This moves one existing await into the inner finally block. Immediate client invalidation, no stale response, successful response ordering and the outer queued disconnect are preserved. It fixes the lifecycle owner instead of adding retries or downstream guards.

## Scope and provenance

Production: +1/-1 (net zero). Existing tests: +64/-27. No configuration, schema, migration, stored representation, dependency or protocol change.

The response-claim ordering entered main in #138492, commit c9ec2774c472b30210c5101c48c7bcbd52062569. Its raw parent is 10a86ffb58e196105d709dbefb7fc8b129d3afeb; the parent-to-commit diff adds the rejecting claim before reconciliation. That is source provenance, not an attribution of intent or a claim about an older stable release. This repair was found while integrating the independent Watch voice work in #135808 and remains a separate PR.

## Verification

- Before the production edit, the real registered policy-response regression had one passing live-caller control and one failing retired-caller case: the claim rejected and the placement reconciler was called zero times (16.656 seconds).
- Identical regression after the one-line move: 2/2 passed (12.033 seconds). The final formatted test also passed 2/2 (27.900 seconds); the only test-layout change wraps one call and adds its trailing comma.
- Complete device-handler, policy-dispatch and real Gateway token-authorization suites: 80/80 passed, zero skipped (96.616 seconds). The full-suite result precedes that formatting-only change, not the production change.
- Fresh managed P0–P3 review: no findings, scoped-clean (52.594 seconds). Independent source challenge traced the startup binding that revokes matching environment credentials before asynchronous reconciliation, then the existing placement cleanup owner.
- The focused race is deterministic owner-boundary fault injection using the actual policy-response registration. The sibling Gateway suite exercises authenticated WebSocket flows; this is not a physical-device or external-provider test.
- All 29 canonical changed-check stages passed (478.554 seconds). Exact published-head CI and native prepare/merge remain landing gates.

Commands exercised the existing test runner with the three owner suites:

    node scripts/run-vitest.mjs src/gateway/server-methods/devices.test.ts src/gateway/server/ws-connection/authenticated-request-dispatch.policy-close.test.ts src/gateway/server.device-token-rotate-authz.test.ts

## Limits and follow-up

This guarantees that response-claim rejection does not skip the existing reconciliation owner. It does not promise physical worker termination when the underlying provider cleanup fails; existing warning/failure handling remains.

Named P3 follow-up: a committed removal on this race still omits the later device.pairing.removed success diagnostic, although the dispatcher records the rejected request. Recording the committed mutation independently of reply authorization is not changed here.

Release-note context: finish removed-device worker reconciliation even when the requesting connection retires during the removal.

