### PR TITLE
fix(openai): preserve GPT-6 reasoning without catalog metadata

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1473,7 +1473,7 @@ packages/ai/src/providers/openai-chatgpt-responses.ts	27
 packages/ai/src/providers/openai-completions-tool-calls.ts	5
 packages/ai/src/providers/openai-completions.ts	10
 packages/ai/src/providers/openai-reasoning-effort.ts	6
-packages/ai/src/providers/openai-responses-shared.ts	7
+packages/ai/src/providers/openai-responses-shared.ts	6
 packages/ai/src/providers/openai-responses-tools.ts	2
 packages/ai/src/providers/openai-responses.ts	1
 packages/ai/src/providers/openai-tool-schema-compat.ts	6

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -79,6 +79,7 @@ An existing `minimal` setting maps to `low`. Astra cannot disable reasoning;
 Temperature and `top_p` are not sent.
 These defaults also apply to configured Astra model entries without explicit
 reasoning or temperature compatibility metadata.
+Azure Responses deployments continue to use their configured capabilities.
 
 Standard pricing per million tokens is $10 input, $1 cache reads, $12.50 cache
 writes, and $50 output. Requests above 272K input tokens have higher rates.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -77,6 +77,8 @@ The supported reasoning efforts are `low`, `medium`, `high`, `xhigh`, and `max`.
 An existing `minimal` setting maps to `low`. Astra cannot disable reasoning;
 `off` never sends the unsupported `none` effort.
 Temperature and `top_p` are not sent.
+These defaults also apply to configured Astra model entries without explicit
+reasoning or temperature compatibility metadata.
 
 Standard pricing per million tokens is $10 input, $1 cache reads, $12.50 cache
 writes, and $50 output. Requests above 272K input tokens have higher rates.

--- a/packages/ai/src/providers/azure-openai-responses.test.ts
+++ b/packages/ai/src/providers/azure-openai-responses.test.ts
@@ -164,6 +164,49 @@ describe("azure-openai-responses", () => {
     }
   });
 
+  it.each<{
+    reasoning: "minimal" | "xhigh" | "max" | undefined;
+    compat: Model<"azure-openai-responses">["compat"];
+    effort: string;
+    temperature: number | undefined;
+  }>([
+    { reasoning: undefined, compat: undefined, effort: "none", temperature: 0.5 },
+    { reasoning: "minimal", compat: undefined, effort: "minimal", temperature: 0.5 },
+    { reasoning: "xhigh", compat: undefined, effort: "high", temperature: 0.5 },
+    { reasoning: "max", compat: undefined, effort: "high", temperature: 0.5 },
+    {
+      reasoning: "xhigh",
+      compat: {
+        supportedReasoningEfforts: ["low", "medium", "high", "xhigh"],
+        supportsTemperature: false,
+      },
+      effort: "xhigh",
+      temperature: undefined,
+    },
+  ])(
+    "preserves Azure deployment capabilities for $reasoning with compat=$compat",
+    async ({ reasoning, compat, effort, temperature }) => {
+      let sentParams: { reasoning?: { effort?: unknown }; temperature?: unknown } | undefined;
+      configureAiTransportHost({
+        buildModelFetch: () => async (input, init) => {
+          sentParams = (await new Request(input, init).json()) as typeof sentParams;
+          return Response.json({ error: { message: "captured" } }, { status: 400 });
+        },
+      });
+      try {
+        await streamSimpleAzureOpenAIResponses(
+          { ...azureResponsesModel, id: "gpt-6-astra", compat },
+          context,
+          { apiKey: "test-api-key", reasoning, temperature: 0.5 },
+        ).result();
+        expect(sentParams?.reasoning?.effort).toBe(effort);
+        expect(sentParams?.temperature).toBe(temperature);
+      } finally {
+        configureAiTransportHost({});
+      }
+    },
+  );
+
   it("fences compaction replay by the resolved Azure endpoint", async () => {
     const routeA = "https://route-a.openai.azure.com/openai/v1";
     const routeB = "https://route-b.openai.azure.com/openai/v1";

--- a/packages/ai/src/providers/openai-chatgpt-responses.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.test.ts
@@ -371,37 +371,80 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(connections).toBe(2);
   });
 
-  it("preserves max for GPT-5.6 simple Codex Responses requests", async () => {
+  it.each([
+    { id: "gpt-5.6-sol", withCatalog: true },
+    { id: "gpt-5.6-sol", withCatalog: false },
+    { id: "gpt-6-astra", withCatalog: true },
+    { id: "gpt-6-astra", withCatalog: false },
+  ])(
+    "preserves max for $id simple requests with catalog=$withCatalog",
+    async ({ id, withCatalog }) => {
+      let capturedPayload: Record<string, unknown> | undefined;
+      const stream = streamSimpleOpenAICodexResponses(
+        {
+          ...model,
+          id,
+          name: id,
+          contextWindow: 372_000,
+          ...(withCatalog ? { thinkingLevelMap: { xhigh: "xhigh", max: "max" } as const } : {}),
+        },
+        context,
+        {
+          apiKey: createJwt({
+            "https://api.openai.com/auth": {
+              chatgpt_account_id: "acct-1",
+            },
+          }),
+          reasoning: "max",
+          transport: "sse",
+          onPayload: (payload) => {
+            capturedPayload = payload as Record<string, unknown>;
+            throw new Error("stop after payload");
+          },
+        },
+      );
+
+      await stream.result();
+
+      expect(capturedPayload).toMatchObject({
+        reasoning: { effort: "max", summary: "auto" },
+      });
+    },
+  );
+
+  it.each([
+    { id: "gpt-6-astra", effort: "none", map: undefined, expected: undefined },
+    { id: "gpt-6-astra", effort: "none", map: { off: null }, expected: undefined },
+    { id: "gpt-6-astra", effort: "minimal", map: undefined, expected: "low" },
+    { id: "custom-reasoning", effort: "xhigh", map: undefined, expected: "xhigh" },
+    { id: "custom-reasoning", effort: "high", map: { high: "HIGH" }, expected: "HIGH" },
+  ] as const)("normalizes raw $id $effort with map=$map", async ({ id, effort, map, expected }) => {
     let capturedPayload: Record<string, unknown> | undefined;
-    const stream = streamSimpleOpenAICodexResponses(
+    const result = await streamOpenAICodexResponses(
       {
         ...model,
-        id: "gpt-5.6-sol",
-        name: "GPT-5.6 Sol",
-        contextWindow: 372_000,
-        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+        id,
+        name: id,
+        thinkingLevelMap: map,
       },
       context,
       {
         apiKey: createJwt({
-          "https://api.openai.com/auth": {
-            chatgpt_account_id: "acct-1",
-          },
+          "https://api.openai.com/auth": { chatgpt_account_id: "acct-1" },
         }),
-        reasoning: "max",
+        reasoningEffort: effort,
         transport: "sse",
         onPayload: (payload) => {
           capturedPayload = payload as Record<string, unknown>;
           throw new Error("stop after payload");
         },
       },
+    ).result();
+
+    expect(result.errorMessage).toBe("stop after payload");
+    expect(capturedPayload?.reasoning).toEqual(
+      expected ? { effort: expected, summary: "auto" } : undefined,
     );
-
-    await stream.result();
-
-    expect(capturedPayload).toMatchObject({
-      reasoning: { effort: "max", summary: "auto" },
-    });
   });
 
   it("does not fall back to SSE when websocket transport is explicit", async () => {

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -76,6 +76,7 @@ import {
   convertResponsesToolPayload,
   createResponsesAssistantOutput,
   resolveResponsesReasoningEffort,
+  resolveResponsesRequestReasoningEffort,
 } from "./openai-responses-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
 
@@ -667,17 +668,15 @@ function buildRequestBody(
     }
   }
 
-  if (options?.reasoningEffort !== undefined) {
-    const effort =
-      options.reasoningEffort === "none"
-        ? (model.thinkingLevelMap?.off ?? "none")
-        : (model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort);
-    if (effort !== null) {
-      body.reasoning = {
-        effort,
-        summary: options.reasoningSummary ?? "auto",
-      };
-    }
+  const effort =
+    options?.reasoningEffort === undefined
+      ? undefined
+      : resolveResponsesRequestReasoningEffort(model, options.reasoningEffort);
+  if (effort !== undefined) {
+    body.reasoning = {
+      effort,
+      summary: options?.reasoningSummary ?? "auto",
+    };
   }
 
   return body;

--- a/packages/ai/src/providers/openai-reasoning-effort.test.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.test.ts
@@ -236,10 +236,14 @@ describe("OpenAI temperature support", () => {
     expect(supportsOpenAITemperature({ id: "gpt-5.5" })).toBe(true);
     expect(supportsOpenAITemperature({ id: "gpt-5.4-mini" })).toBe(true);
     expect(supportsOpenAITemperature({ id: "gpt-5.60" })).toBe(true);
+    expect(supportsOpenAITemperature({ id: "gpt-6-astra-custom" })).toBe(true);
     expect(supportsOpenAITemperature({ id: "llama-4-70b" })).toBe(true);
   });
 
   it("honors catalog compat overrides in both directions", () => {
+    expect(
+      supportsOpenAITemperature({ id: "gpt-6-astra", compat: { supportsTemperature: true } }),
+    ).toBe(true);
     expect(
       supportsOpenAITemperature({ id: "gpt-5.6-luna", compat: { supportsTemperature: true } }),
     ).toBe(true);

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -121,7 +121,8 @@ export function resolveOpenAIModelReasoningEfforts(
   }
 
   const id = normalizeModelId(typeof model.id === "string" ? model.id : undefined);
-  if (id === "gpt-6-astra") {
+  // Azure deployment capabilities must be declared until its Astra contract is verified.
+  if (id === "gpt-6-astra" && model.api !== "azure-openai-responses") {
     return GPT_6_ASTRA_REASONING_EFFORTS;
   }
   if (/^gpt-5\.6(?:-|$)/u.test(id)) {
@@ -167,7 +168,10 @@ export function supportsOpenAITemperature(model: OpenAIReasoningModel): boolean 
     }
   }
   const id = normalizeModelId(typeof model.id === "string" ? model.id : undefined);
-  return id !== "gpt-6-astra" && !/^gpt-5\.6(?:-|$)/u.test(id);
+  return (
+    (id !== "gpt-6-astra" || model.api === "azure-openai-responses") &&
+    !/^gpt-5\.6(?:-|$)/u.test(id)
+  );
 }
 
 /** Return whether a model accepts a requested reasoning effort. */

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -33,6 +33,7 @@ const GPT_5_REASONING_EFFORTS = ["minimal", "low", "medium", "high"] as const;
 const GPT_51_REASONING_EFFORTS = ["none", "low", "medium", "high"] as const;
 const GPT_52_REASONING_EFFORTS = ["none", "low", "medium", "high", "xhigh"] as const;
 const GPT_56_REASONING_EFFORTS = ["none", "low", "medium", "high", "xhigh", "max"] as const;
+const GPT_6_ASTRA_REASONING_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
 const GPT_CODEX_REASONING_EFFORTS = ["low", "medium", "high", "xhigh"] as const;
 const GPT_PRO_REASONING_EFFORTS = ["medium", "high", "xhigh"] as const;
 const GPT_5_PRO_REASONING_EFFORTS = ["high"] as const;
@@ -107,12 +108,22 @@ function isDisabledReasoningEffort(effort: string): boolean {
 export function resolveOpenAISupportedReasoningEfforts(
   model: OpenAIReasoningModel,
 ): readonly OpenAIApiReasoningEffort[] {
+  return resolveOpenAIModelReasoningEfforts(model) ?? GENERIC_REASONING_EFFORTS;
+}
+
+/** Read a declared or known model contract, leaving unknown compatible models unspecified. */
+export function resolveOpenAIModelReasoningEfforts(
+  model: OpenAIReasoningModel,
+): readonly OpenAIApiReasoningEffort[] | undefined {
   const compatEfforts = readCompatReasoningEfforts(model.compat);
   if (compatEfforts) {
     return compatEfforts;
   }
 
   const id = normalizeModelId(typeof model.id === "string" ? model.id : undefined);
+  if (id === "gpt-6-astra") {
+    return GPT_6_ASTRA_REASONING_EFFORTS;
+  }
   if (/^gpt-5\.6(?:-|$)/u.test(id)) {
     return GPT_56_REASONING_EFFORTS;
   }
@@ -140,12 +151,12 @@ export function resolveOpenAISupportedReasoningEfforts(
   if (/^gpt-5(?:-|$)/u.test(id)) {
     return GPT_5_REASONING_EFFORTS;
   }
-  return GENERIC_REASONING_EFFORTS;
+  return undefined;
 }
 
 /**
- * Return whether a model accepts the temperature parameter. The GPT-5.6
- * family rejects it with a 400; catalog compat can override per model.
+ * Return whether a model accepts temperature. GPT-5.6 and GPT-6 Astra
+ * reject it with a 400; catalog compat can override per model.
  */
 export function supportsOpenAITemperature(model: OpenAIReasoningModel): boolean {
   const compat = model.compat;
@@ -156,7 +167,7 @@ export function supportsOpenAITemperature(model: OpenAIReasoningModel): boolean 
     }
   }
   const id = normalizeModelId(typeof model.id === "string" ? model.id : undefined);
-  return !/^gpt-5\.6(?:-|$)/u.test(id);
+  return id !== "gpt-6-astra" && !/^gpt-5\.6(?:-|$)/u.test(id);
 }
 
 /** Return whether a model accepts a requested reasoning effort. */

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -347,9 +347,32 @@ describe("Responses reasoning effort", () => {
     expect(params).toMatchObject({ reasoning: { effort: "max", summary: "auto" } });
   });
 
-  it("raises unsupported minimal reasoning to low for GPT-5.6 Sol", () => {
-    expect(resolveResponsesReasoningEffort(gpt56SolModel, "minimal")).toBe("low");
-  });
+  it.each<{
+    model: Model<"openai-responses">;
+    reasoning: "minimal" | "high";
+    expected: string;
+  }>([
+    { model: gpt56SolModel, reasoning: "minimal", expected: "low" },
+    {
+      model: { ...proxyOpenAIModel, compat: { supportedReasoningEfforts: ["ProviderHigh"] } },
+      reasoning: "high",
+      expected: "ProviderHigh",
+    },
+  ])(
+    "normalizes $reasoning to $expected at the request boundary",
+    ({ model, reasoning, expected }) => {
+      const params = {} as ResponseCreateParamsStreaming;
+      applyCommonResponsesParams(
+        params,
+        model,
+        { messages: [] },
+        {
+          reasoningEffort: resolveResponsesReasoningEffort(model, reasoning),
+        },
+      );
+      expect(params.reasoning).toEqual({ effort: expected, summary: "auto" });
+    },
+  );
 
   it("keeps max clamped to xhigh for earlier models", () => {
     const gpt55WithXHigh = {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -41,8 +41,8 @@ import {
   type FirstStreamEventInternalOptions,
 } from "../utils/stream-first-event-timeout.js";
 import {
+  resolveOpenAIModelReasoningEfforts,
   resolveOpenAIReasoningEffortForModel,
-  supportsOpenAIReasoningEffort,
   supportsOpenAITemperature,
 } from "./openai-reasoning-effort.js";
 import { convertResponsesToolPayload } from "./openai-responses-tools.js";
@@ -102,18 +102,6 @@ type OpenAIResponsesProcessStreamOptions = OpenAIResponsesStreamOptions &
 
 type ResponsesReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
-function isResponsesReasoningEffort(
-  effort: string | undefined,
-): effort is ResponsesReasoningEffort {
-  return (
-    effort === "minimal" ||
-    effort === "low" ||
-    effort === "medium" ||
-    effort === "high" ||
-    effort === "xhigh" ||
-    effort === "max"
-  );
-}
 type ResponsesReasoningSummary = "auto" | "detailed" | "concise" | null;
 
 type ResponsesCommonParamsOptions = Pick<StreamOptions, "maxTokens" | "temperature"> & {
@@ -168,22 +156,32 @@ export function resolveResponsesReasoningEffort<TApi extends Api>(
   model: Model<TApi>,
   reasoning: SimpleStreamOptions["reasoning"] | undefined,
 ): ResponsesReasoningEffort | undefined {
-  const clampedReasoning = reasoning ? clampThinkingLevel(model, reasoning) : undefined;
-  if (!clampedReasoning || clampedReasoning === "off") {
+  if (!reasoning) {
     return undefined;
   }
-  if (clampedReasoning === "max") {
-    return supportsOpenAIReasoningEffort(model, "max") ? "max" : "xhigh";
+  const supportsRequestedEffort =
+    model.reasoning &&
+    model.thinkingLevelMap?.[reasoning] === undefined &&
+    resolveOpenAIModelReasoningEfforts(model)?.includes(reasoning);
+  const clampedReasoning = supportsRequestedEffort
+    ? reasoning
+    : clampThinkingLevel(model, reasoning);
+  return clampedReasoning === "off" ? undefined : clampedReasoning;
+}
+
+export function resolveResponsesRequestReasoningEffort<TApi extends Api>(
+  model: Model<TApi>,
+  reasoning: ResponsesReasoningEffort | "none" | "off",
+): string | undefined {
+  const mapped = model.thinkingLevelMap?.[reasoning === "none" ? "off" : reasoning];
+  if (mapped !== undefined) {
+    return mapped ?? undefined;
   }
-  if (
-    clampedReasoning === "minimal" &&
-    model.provider === "openai" &&
-    supportsOpenAIReasoningEffort(model, "max")
-  ) {
-    const effort = resolveOpenAIReasoningEffortForModel({ model, effort: "minimal" });
-    return isResponsesReasoningEffort(effort) ? effort : undefined;
-  }
-  return clampedReasoning;
+  return resolveOpenAIModelReasoningEfforts(model) === undefined
+    ? reasoning === "off"
+      ? "none"
+      : reasoning
+    : resolveOpenAIReasoningEffortForModel({ model, effort: reasoning });
 }
 
 export function applyCommonResponsesParams<TApi extends Api>(
@@ -212,21 +210,24 @@ export function applyCommonResponsesParams<TApi extends Api>(
     return;
   }
 
+  const requestedEffort =
+    options?.reasoningEffort ??
+    (options?.reasoningSummary
+      ? "medium"
+      : (config?.setDefaultReasoningOff ?? true)
+        ? "off"
+        : undefined);
+  const effort =
+    requestedEffort === undefined
+      ? undefined
+      : resolveResponsesRequestReasoningEffort(model, requestedEffort);
+  if (effort === undefined) {
+    return;
+  }
+  params.reasoning = { effort: effort as NonNullable<typeof params.reasoning>["effort"] };
   if (options?.reasoningEffort || options?.reasoningSummary) {
-    const effort = options?.reasoningEffort
-      ? (model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort)
-      : "medium";
-    params.reasoning = {
-      effort: effort as NonNullable<typeof params.reasoning>["effort"],
-      summary: options?.reasoningSummary || "auto",
-    };
+    params.reasoning.summary = options?.reasoningSummary || "auto";
     params.include = ["reasoning.encrypted_content"];
-  } else if ((config?.setDefaultReasoningOff ?? true) && model.thinkingLevelMap?.off !== null) {
-    params.reasoning = {
-      effort: (model.thinkingLevelMap?.off ?? "none") as NonNullable<
-        typeof params.reasoning
-      >["effort"],
-    };
   }
 }
 

--- a/packages/ai/src/providers/openai-responses.live.test.ts
+++ b/packages/ai/src/providers/openai-responses.live.test.ts
@@ -42,6 +42,7 @@ describeLive("OpenAI Responses live", () => {
       const result = await streamOpenAIResponses(liveModel(), context, {
         apiKey: OPENAI_KEY,
         maxTokens: 256,
+        temperature: 0.5,
       }).result();
 
       expect(result.errorMessage).toBeUndefined();

--- a/packages/ai/src/providers/openai-responses.test.ts
+++ b/packages/ai/src/providers/openai-responses.test.ts
@@ -187,18 +187,12 @@ describe("OpenAI Responses provider", () => {
   it.each([
     { reasoningEffort: undefined, expectedEffort: undefined },
     { reasoningEffort: "minimal", expectedEffort: "low" },
+    { reasoningEffort: "xhigh", expectedEffort: "xhigh" },
     { reasoningEffort: "max", expectedEffort: "max" },
   ] as const)(
-    "honors Astra reasoning and sampling capabilities for $reasoningEffort",
+    "honors Astra reasoning and sampling without catalog metadata for $reasoningEffort",
     async ({ reasoningEffort, expectedEffort }) => {
-      const requestModel = {
-        ...model({ id: "gpt-6-astra" }),
-        thinkingLevelMap: { off: null, minimal: "low", xhigh: "xhigh", max: "max" } as const,
-        compat: {
-          supportsTemperature: false,
-          supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
-        },
-      };
+      const requestModel = model({ id: "gpt-6-astra" });
       const options = { apiKey: "sentinel-key", reasoningEffort, temperature: 0.5, topP: 0.8 };
       const transportParams = buildOpenAIResponsesParams(requestModel, context, options);
       await streamOpenAIResponses(requestModel, context, options).result();

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -723,7 +723,7 @@ export interface Model<TApi extends Api = Api> {
   /** Compatibility overrides for OpenAI-compatible APIs. If not set, auto-detected from baseUrl. */
   compat?: TApi extends "openai-completions"
     ? OpenAICompletionsCompat
-    : TApi extends "openai-responses"
+    : TApi extends "openai-responses" | "azure-openai-responses" | "openai-codex-responses"
       ? OpenAIResponsesCompat
       : TApi extends "anthropic-messages"
         ? AnthropicMessagesCompat

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -560,6 +560,10 @@ export interface OpenAICompletionsCompat {
 export interface OpenAIResponsesCompat {
   /** Whether the provider supports the `developer` role (vs `system`). Default: true. */
   supportsDeveloperRole?: boolean;
+  /** Whether to send reasoning effort settings. Defaults to the model's known capabilities. */
+  supportsReasoningEffort?: boolean;
+  /** Provider-native reasoning efforts accepted by the model. Overrides known model defaults. */
+  supportedReasoningEfforts?: string[];
   /** Whether the model accepts the `temperature` parameter. Default: true. */
   supportsTemperature?: boolean;
   /** Whether to send the OpenAI `session_id` cache-affinity header from `options.sessionId` when caching is enabled. Default: true. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting GPT-6 Astra through configured model entries without catalog metadata could receive an unsupported-parameter error or silently run with less reasoning than requested. Standalone Responses requests could send `reasoning.effort: "none"` or `temperature`, and `xhigh`/`max` could be downgraded. The ChatGPT-backed provider also lost explicit disabled-reasoning overrides and prematurely clamped `max`.

Related: #137550 (initial GPT-6 Astra support).

## Why This Change Was Made

The shared OpenAI capability resolver now recognizes Astra even without a catalog row. Responses adapters select a logical thinking level and normalize it once at the request boundary, preserving explicit string/null mappings and unknown compatible-provider labels. The Responses compatibility type now declares reasoning fields already supported by the catalog and runtime, and is available to the Azure and ChatGPT Responses model types that consume it.

This removes the duplicate adapter mapping rather than adding retries or changing model selection. Production LOC is +74/-55 (net +19); growth records the known-model capability distinction, Astra's contract, the Azure deployment boundary, and existing-field type declarations. Tests are +136/-28 (net +108).

## User Impact

Configured and standalone Astra requests omit unsupported disabled reasoning and sampling parameters, map `minimal` to `low`, and preserve supported `xhigh`/`max`. Custom provider mappings remain authoritative. Azure Responses retains its prior metadata-free deployment behavior; explicit Azure capability metadata remains honored. Existing catalog metadata, model defaults, configuration, persistence, and dependencies are unchanged.

## Evidence

- Before: four payload regressions and five ChatGPT regressions failed. A real Astra request returned HTTP 400: `Unsupported value: 'none' is not supported with the 'gpt-6-astra' model`.
- After: 225 tests passed across nine suites covering provider builders, ChatGPT, Azure, continuation, configuration updates, steering, and custom mappings. The affected shared suite also passed all 100 tests after type alignment.
- Azure scope regression: four new payload cases failed against the first PR version. The repaired boundary passes default/minimal/xhigh/max and temperature cases, plus explicit capability overrides. No Azure API acceptance is assumed.
- Real `openai/gpt-6-astra` Responses checks passed for streamed text and usage, function calls, and two-turn `previous_response_id` continuation. Repeated with an isolated frozen-lockfile install.
- The complete `check:changed` gate passed with the exact lockfile, including production/test typechecks, lint, dead exports, and architecture guards. Independent Codex review was clean through P2.
- After rebasing onto current main: `pnpm build` passed, including bundled/plugin declarations and the Control UI build; the 220-test focused suite passed again.
- Directly inspected upstream Codex at `83b62a02fab5c0fc797cbc9896c332148f1fd9d0`: [model metadata](https://github.com/openai/codex/blob/83b62a02fab5c0fc797cbc9896c332148f1fd9d0/codex-rs/models-manager/models.json#L4), [reasoning/request construction](https://github.com/openai/codex/blob/83b62a02fab5c0fc797cbc9896c332148f1fd9d0/codex-rs/core/src/client.rs#L906), and [configuration updates](https://github.com/openai/codex/blob/83b62a02fab5c0fc797cbc9896c332148f1fd9d0/codex-rs/protocol/src/models/configuration_update.rs). Ordinary public Responses passed live; no separate Responses Lite mode is needed for these flows.
- Public contracts: [Astra model](https://developers.openai.com/api/docs/models/gpt-6-astra), [migration guide](https://developers.openai.com/api/docs/guides/latest-model), [OpenClaw OpenAI provider](https://docs.openclaw.ai/providers/openai).

Focused proof:

```sh
node scripts/run-vitest.mjs \
  packages/ai/src/providers/openai-reasoning-effort.test.ts \
  packages/ai/src/providers/openai-responses.test.ts \
  packages/ai/src/providers/openai-responses-shared.test.ts \
  packages/ai/src/providers/openai-chatgpt-responses.test.ts \
  packages/ai/src/providers/azure-openai-responses.test.ts \
  packages/ai/src/transports/openai-responses-params-internal.test.ts \
  packages/ai/src/transports/openai-responses-client.continuation.test.ts \
  packages/ai/src/transports/openai-responses-reasoning-update.test.ts \
  packages/ai/src/transports/openai-responses-steering.integration.test.ts

# With an OpenAI API key supplied through the normal secret workflow:
OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_RESPONSES_MODEL=gpt-6-astra \
  node scripts/run-vitest.mjs run --config test/vitest/vitest.live.config.ts \
  packages/ai/src/providers/openai-responses.live.test.ts \
  -t 'streams a reply|keeps reasoning'
OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_RESPONSES_MODEL=gpt-6-astra \
  node scripts/run-vitest.mjs run --config test/vitest/vitest.live.config.ts \
  packages/ai/src/transports/openai-responses-payload-policy.instructions.live.test.ts
```

Follow-up: Azure's separate simple adapter still caps `max` at `xhigh`; verify the relevant Azure deployment contract before enabling automatic Astra defaults or changing that behavior. No Astra-on-Azure availability claim is made here.
