### PR TITLE
fix(gateway): keep webhook ingress retryable during hot reload

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -708,6 +708,12 @@ Gateway restart; `hybrid` schedules that restart, while `off` leaves it to you.
 Changing an agent's workspace also does not discover plugins in the new
 directory until restart. See [Plugin metadata snapshots](/plugins/architecture#plugin-metadata-snapshot-and-lookup-table).
 
+During channel or plugin hot reload, Gateway-hosted channel webhook routes return
+`503` with `Retry-After: 1` until replacement ingress registers. Senders must honor
+retry responses; this does not acknowledge delivery. Disabled or removed accounts,
+manual stops, and cancelled replacement lifetimes release those temporary routes.
+When replacement ingress reports ready, old paths it did not reclaim are removed.
+
 ### Reload planning
 
 When you edit a source file that is referenced through `$include`, OpenClaw plans

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -290,6 +290,12 @@ The Gateway retains the admitted account's `cfg`, resolved `account`, and owning
 use that context even when the published config removes the account or a new
 plugin registration replaces it.
 
+Finish status updates inside `stopAccount` before its promise settles. The Gateway ignores
+writes through a retained stop callback after that attempt finishes or times out.
+Terminal startup status retires previous webhook handoffs even when the account
+promise stays pending until abort; it does not revoke the current task's ability
+to register ingress and explicitly report ready after recovery.
+
 Account-count-dependent policy needs whole-channel reloads. For example, Telegram
 changes how an empty account `groups` map inherits defaults between single- and
 multi-account configurations. Synology Chat also validates inherited and duplicate

--- a/src/agents/mcp-connection-resolver.test.ts
+++ b/src/agents/mcp-connection-resolver.test.ts
@@ -363,6 +363,7 @@ describe("mcp connection resolver helpers", () => {
           return new Map();
         },
         async stopChannel() {},
+        releaseChannelRouteHandoffs() {},
         pruneInactiveChannelAccountState() {},
         async reloadPlugins({ beforeReplace, commitRuntime }) {
           await beforeReplace(new Set());

--- a/src/gateway/channel-health-monitor.clock-rollback.test.ts
+++ b/src/gateway/channel-health-monitor.clock-rollback.test.ts
@@ -24,6 +24,7 @@ function createChannelManager(running: boolean) {
     startChannels: vi.fn(async () => {}),
     startChannel: vi.fn(async () => new Map()),
     stopChannel: vi.fn(async () => {}),
+    releaseChannelRouteHandoffs: vi.fn(),
     setAutostartSuppression: vi.fn(),
     getAutostartSuppression: vi.fn(() => null),
     recoverAutostartSuppression: vi.fn(async () => false),

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -15,6 +15,7 @@ function createMockChannelManager(overrides?: Partial<ChannelManager>): ChannelM
     startChannels: vi.fn(async () => {}),
     startChannel: vi.fn(async () => new Map()),
     stopChannel: vi.fn(async () => {}),
+    releaseChannelRouteHandoffs: vi.fn(),
     setAutostartSuppression: vi.fn(),
     getAutostartSuppression: vi.fn(() => null),
     recoverAutostartSuppression: vi.fn(async () => false),

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -49,7 +49,11 @@ import {
 } from "../secrets/runtime-degraded-state.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
 import { evaluateChannelHealth } from "./channel-health-policy.js";
-import { channelReadyPatch, createTransportActivityStatusPatch } from "./channel-status-patches.js";
+import {
+  channelBlockedPatch,
+  channelReadyPatch,
+  createTransportActivityStatusPatch,
+} from "./channel-status-patches.js";
 import { restartRunningChannelAccounts } from "./channel-thaw-restart.js";
 import { createChannelManager, type ChannelManager } from "./server-channels.js";
 import { AUTH_NONE, createTestGatewayServer } from "./server-http.test-harness.js";
@@ -2095,16 +2099,22 @@ describe("server-channels auto restart", () => {
       const registry = installTestRegistry(
         createTestPlugin({
           startAccount: async ({ abortSignal, setStatus }) => {
+            const stopped = new Promise<void>((resolve) => {
+              abortSignal.addEventListener("abort", () => resolve(), { once: true });
+            });
             const generation = ++starts;
             if (generation === 2) {
               if (terminal) {
-                setStatus({
-                  accountId: DEFAULT_ACCOUNT_ID,
-                  terminalDisconnect: true,
-                  lifecycle: "blocked",
-                });
+                setStatus(
+                  channelBlockedPatch("startup blocked", { accountId: DEFAULT_ACCOUNT_ID }),
+                );
+                await Promise.race([stopped, replacement.promise]);
+                if (abortSignal.aborted) {
+                  return;
+                }
+              } else {
+                throw new Error("startup failed");
               }
-              throw new Error("startup failed");
             }
             if (generation === 3) {
               await replacement.promise;
@@ -2117,9 +2127,7 @@ describe("server-channels auto restart", () => {
               throwOnFailure: true,
             });
             setStatus(channelReadyPatch({ accountId: DEFAULT_ACCOUNT_ID }));
-            await new Promise<void>((resolve) => {
-              abortSignal.addEventListener("abort", () => resolve(), { once: true });
-            });
+            await stopped;
           },
         }),
       );
@@ -2132,6 +2140,12 @@ describe("server-channels auto restart", () => {
         if (terminal) {
           expect(registry.httpRoutes).toEqual([]);
           expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+          replacement.resolve();
+          await flushMicrotasks(30);
+          expect(registry.httpRoutes.map((route) => route.handoff)).toEqual([undefined]);
+          expect(
+            manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID],
+          ).toMatchObject({ lifecycle: "ready", terminalDisconnect: undefined });
           return;
         }
         expect(registry.httpRoutes.map((route) => route.handoff)).toEqual([true]);
@@ -2149,6 +2163,78 @@ describe("server-channels auto restart", () => {
         expect(registry.httpRoutes.map((route) => route.handoff)).toEqual([undefined]);
       } finally {
         replacement.resolve();
+        await manager.stopChannel("discord");
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "terminal pending startup retires only its handoff (sibling pending=%s)",
+    async (siblingPending) => {
+      const siblingReady = createDeferred();
+      const starts = new Map<string, number>();
+      const sharedHandler = vi.fn();
+      const registry = installTestRegistry(
+        createTestPlugin({
+          listAccountIds: () => ["blocked", "healthy"],
+          startAccount: async ({ accountId, abortSignal, setStatus }) => {
+            const stopped = new Promise<void>((resolve) => {
+              abortSignal.addEventListener("abort", () => resolve(), { once: true });
+            });
+            const generation = (starts.get(accountId) ?? 0) + 1;
+            starts.set(accountId, generation);
+            if (generation === 2 && accountId === "blocked") {
+              setStatus(channelBlockedPatch("startup validation failed", { accountId }));
+              await stopped;
+              return;
+            }
+            if (generation === 2 && accountId === "healthy") {
+              await siblingReady.promise;
+            }
+            for (const key of [accountId, "shared"]) {
+              registerPluginHttpRoute({
+                path: `/plugins/terminal/${key}`,
+                auth: "plugin",
+                pluginId: "discord",
+                source: key,
+                handler: sharedHandler,
+                reuseExistingSameOwner: true,
+                throwOnFailure: true,
+              });
+            }
+            setStatus(channelReadyPatch({ accountId }));
+            await stopped;
+          },
+        }),
+      );
+      const manager = createManager({ getPluginRegistry: () => registry });
+      const route = (key: string) =>
+        registry.httpRoutes.find(({ path: routePath }) => routePath === `/plugins/terminal/${key}`);
+      try {
+        await manager.startChannels();
+        await manager.stopChannel("discord", "blocked", { manual: false, routeHandoff: true });
+        if (siblingPending) {
+          await manager.stopChannel("discord", "healthy", { manual: false, routeHandoff: true });
+          await manager.startChannel("discord", "healthy");
+        }
+        await manager.startChannel("discord", "blocked");
+        await flushMicrotasks(30);
+        expect(route("blocked")).toBeUndefined();
+        expect(route("shared")?.handoff).toBe(siblingPending ? true : undefined);
+        expect(route("healthy")?.handoff).toBe(siblingPending ? true : undefined);
+        expect(manager.getRuntimeSnapshot().channelAccounts.discord?.blocked).toMatchObject({
+          running: true,
+          lifecycle: "blocked",
+          terminalDisconnect: true,
+        });
+        expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+        siblingReady.resolve();
+        await flushMicrotasks(30);
+        expect(route("shared")?.handler).toBe(sharedHandler);
+        expect(route("shared")?.handoff).toBeUndefined();
+        expect(starts.get("healthy")).toBe(siblingPending ? 2 : 1);
+      } finally {
+        siblingReady.resolve();
         await manager.stopChannel("discord");
       }
     },
@@ -2216,55 +2302,93 @@ describe("server-channels auto restart", () => {
     }
   });
 
-  it("retires unclaimed webhook paths only when replacement ingress reports ready", async () => {
-    const firstRegistered = createDeferred();
-    const completeIngress = createDeferred();
-    let starts = 0;
-    const registry = installTestRegistry(
-      createTestPlugin({
-        startAccount: async ({ abortSignal, setStatus }) => {
-          const generation = ++starts;
-          const register = (suffix: string) =>
-            registerPluginHttpRoute({
-              path: `/plugins/reload/${generation}/${suffix}`,
-              auth: "plugin",
-              pluginId: "discord",
-              handler: vi.fn(),
-              throwOnFailure: true,
+  it.each([
+    { phase: "starting", retiredStop: "none" },
+    { phase: "blocked", retiredStop: "none" },
+    { phase: "recovering", retiredStop: "none" },
+    { phase: "starting", retiredStop: "returned" },
+    { phase: "starting", retiredStop: "timed-out" },
+  ] as const)(
+    "retires unclaimed webhook paths on readiness (phase=$phase, retired stop=$retiredStop)",
+    async ({ phase, retiredStop }) => {
+      const firstRegistered = createDeferred<(next: ChannelAccountSnapshot) => void>();
+      const stoppedStatus = createDeferred<(next: ChannelAccountSnapshot) => void>();
+      const finishStop = createDeferred();
+      const completeIngress = createDeferred();
+      let starts = 0;
+      const registry = installTestRegistry(
+        createTestPlugin({
+          startAccount: async ({ abortSignal, setStatus }) => {
+            const generation = ++starts;
+            const register = (suffix: string) =>
+              registerPluginHttpRoute({
+                path: `/plugins/reload/${generation}/${suffix}`,
+                auth: "plugin",
+                pluginId: "discord",
+                handler: vi.fn(),
+                throwOnFailure: true,
+              });
+            register("first");
+            if (generation === 2) {
+              setStatus({ accountId: DEFAULT_ACCOUNT_ID, lifecycle: phase });
+              firstRegistered.resolve(setStatus);
+              await completeIngress.promise;
+            }
+            register("second");
+            setStatus(channelReadyPatch({ accountId: DEFAULT_ACCOUNT_ID }));
+            await new Promise<void>((resolve) => {
+              abortSignal.addEventListener("abort", () => resolve(), { once: true });
             });
-          register("first");
-          if (generation === 2) {
-            firstRegistered.resolve();
-            await completeIngress.promise;
-          }
-          register("second");
-          setStatus({ accountId: DEFAULT_ACCOUNT_ID, lifecycle: "ready" });
-          await new Promise<void>((resolve) => {
-            abortSignal.addEventListener("abort", () => resolve(), { once: true });
-          });
-        },
-      }),
-    );
-    const manager = createManager({ getPluginRegistry: () => registry });
-    try {
-      await manager.startChannels();
-      await manager.stopChannel("discord", undefined, { manual: false, routeHandoff: true });
-      await manager.startChannels();
-      await firstRegistered.promise;
-      expect(
-        registry.httpRoutes.filter((route) => route.handoff).map((route) => route.path),
-      ).toEqual(["/plugins/reload/1/first", "/plugins/reload/1/second"]);
-      completeIngress.resolve();
-      await flushMicrotasks();
-      expect(registry.httpRoutes.map((route) => route.path)).toEqual([
-        "/plugins/reload/2/first",
-        "/plugins/reload/2/second",
-      ]);
-    } finally {
-      completeIngress.resolve();
-      await manager.stopChannel("discord");
-    }
-  });
+          },
+          stopAccount: async ({ setStatus }) => {
+            if (retiredStop !== "none" && starts === 1) {
+              stoppedStatus.resolve(setStatus);
+              if (retiredStop === "timed-out") {
+                await finishStop.promise;
+              }
+            }
+          },
+        }),
+      );
+      const manager = createManager({ getPluginRegistry: () => registry });
+      try {
+        await manager.startChannels();
+        const stop = manager.stopChannel("discord", undefined, {
+          manual: false,
+          routeHandoff: true,
+        });
+        if (retiredStop === "timed-out") {
+          await vi.advanceTimersByTimeAsync(5_000);
+        }
+        await stop;
+        await manager.startChannels();
+        const setReplacementStatus = await firstRegistered.promise;
+        if (retiredStop !== "none") {
+          (await stoppedStatus.promise)(
+            channelBlockedPatch("late stop diagnosis", { accountId: DEFAULT_ACCOUNT_ID }),
+          );
+          expect(
+            manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]
+              ?.terminalDisconnect,
+          ).toBeUndefined();
+        }
+        setReplacementStatus({ accountId: DEFAULT_ACCOUNT_ID, lifecycle: phase });
+        expect(
+          registry.httpRoutes.filter((route) => route.handoff).map((route) => route.path),
+        ).toEqual(["/plugins/reload/1/first", "/plugins/reload/1/second"]);
+        completeIngress.resolve();
+        await flushMicrotasks();
+        expect(registry.httpRoutes.map((route) => route.path)).toEqual([
+          "/plugins/reload/2/first",
+          "/plugins/reload/2/second",
+        ]);
+      } finally {
+        completeIngress.resolve();
+        finishStop.resolve();
+        await manager.stopChannel("discord");
+      }
+    },
+  );
 
   it("keeps stopped webhook routes retryable until replacement ingress is ready", async () => {
     const route = { path: "/plugins/reload", auth: "plugin" as const, pluginId: "discord" };

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -2086,6 +2086,424 @@ describe("server-channels auto restart", () => {
     expect(account?.lastError).toContain("channel stop timed out");
   });
 
+  it.each(["retry", "superseded", "terminal"] as const)(
+    "ends retry ingress with the recovery lifetime (%s)",
+    async (mode) => {
+      const terminal = mode === "terminal";
+      const replacement = createDeferred();
+      let starts = 0;
+      const registry = installTestRegistry(
+        createTestPlugin({
+          startAccount: async ({ abortSignal, setStatus }) => {
+            const generation = ++starts;
+            if (generation === 2) {
+              if (terminal) {
+                setStatus({
+                  accountId: DEFAULT_ACCOUNT_ID,
+                  terminalDisconnect: true,
+                  lifecycle: "blocked",
+                });
+              }
+              throw new Error("startup failed");
+            }
+            if (generation === 3) {
+              await replacement.promise;
+            }
+            registerPluginHttpRoute({
+              path: "/plugins/reload/retry",
+              auth: "plugin",
+              pluginId: "discord",
+              handler: vi.fn(),
+              throwOnFailure: true,
+            });
+            setStatus(channelReadyPatch({ accountId: DEFAULT_ACCOUNT_ID }));
+            await new Promise<void>((resolve) => {
+              abortSignal.addEventListener("abort", () => resolve(), { once: true });
+            });
+          },
+        }),
+      );
+      const manager = createManager({ getPluginRegistry: () => registry });
+      try {
+        await manager.startChannels();
+        await manager.stopChannel("discord", undefined, { manual: false, routeHandoff: true });
+        await manager.startChannels();
+        await flushMicrotasks(30);
+        if (terminal) {
+          expect(registry.httpRoutes).toEqual([]);
+          expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+          return;
+        }
+        expect(registry.httpRoutes.map((route) => route.handoff)).toEqual([true]);
+        if (mode === "superseded") {
+          await manager.stopChannel("discord", undefined, { manual: false, routeHandoff: true });
+          expect(registry.httpRoutes.map((route) => route.handoff)).toEqual([true]);
+          await manager.startChannels();
+        } else {
+          await vi.advanceTimersByTimeAsync(6_000);
+        }
+        expect(starts).toBe(3);
+        expect(registry.httpRoutes.map((route) => route.handoff)).toEqual([true]);
+        replacement.resolve();
+        await flushMicrotasks();
+        expect(registry.httpRoutes.map((route) => route.handoff)).toEqual([undefined]);
+      } finally {
+        replacement.resolve();
+        await manager.stopChannel("discord");
+      }
+    },
+  );
+
+  it("preserves admitted sibling ingress when partial rollback releases failed handoffs", async () => {
+    const replacement = createDeferred();
+    const starts = new Map<string, number>();
+    let failStop = true;
+    const registry = installTestRegistry(
+      createTestPlugin({
+        listAccountIds: () => ["failed", "started"],
+        startAccount: async ({ accountId, abortSignal, setStatus }) => {
+          const generation = (starts.get(accountId) ?? 0) + 1;
+          starts.set(accountId, generation);
+          if (generation > 1) {
+            await replacement.promise;
+          }
+          registerPluginHttpRoute({
+            path: `/plugins/reload/${accountId}`,
+            auth: "plugin",
+            pluginId: "discord",
+            handler: vi.fn(),
+            throwOnFailure: true,
+          });
+          setStatus(channelReadyPatch({ accountId }));
+          await new Promise<void>((resolve) => {
+            abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        },
+        stopAccount: async ({ accountId }) => {
+          if (accountId === "failed" && failStop) {
+            failStop = false;
+            throw new Error("teardown failed");
+          }
+        },
+      }),
+    );
+    const manager = createManager({ getPluginRegistry: () => registry });
+    try {
+      await manager.startChannels();
+      await expect(
+        manager.stopChannel("discord", undefined, { manual: false, routeHandoff: true }),
+      ).rejects.toThrow("teardown failed");
+      expect(
+        await manager.startChannel("discord", undefined, { preserveManualStop: true }),
+      ).toEqual(
+        new Map([
+          ["failed", { status: "retry", reason: "stop-in-flight" }],
+          ["started", { status: "handed-off" }],
+        ]),
+      );
+      manager.releaseChannelRouteHandoffs("discord");
+      expect(
+        registry.httpRoutes.map((route) => ({ path: route.path, handoff: route.handoff })),
+      ).toEqual([{ path: "/plugins/reload/started", handoff: true }]);
+      replacement.resolve();
+      await flushMicrotasks();
+      expect(
+        registry.httpRoutes.map((route) => ({ path: route.path, handoff: route.handoff })),
+      ).toEqual([{ path: "/plugins/reload/started", handoff: undefined }]);
+    } finally {
+      replacement.resolve();
+      await manager.stopChannel("discord");
+    }
+  });
+
+  it("retires unclaimed webhook paths only when replacement ingress reports ready", async () => {
+    const firstRegistered = createDeferred();
+    const completeIngress = createDeferred();
+    let starts = 0;
+    const registry = installTestRegistry(
+      createTestPlugin({
+        startAccount: async ({ abortSignal, setStatus }) => {
+          const generation = ++starts;
+          const register = (suffix: string) =>
+            registerPluginHttpRoute({
+              path: `/plugins/reload/${generation}/${suffix}`,
+              auth: "plugin",
+              pluginId: "discord",
+              handler: vi.fn(),
+              throwOnFailure: true,
+            });
+          register("first");
+          if (generation === 2) {
+            firstRegistered.resolve();
+            await completeIngress.promise;
+          }
+          register("second");
+          setStatus({ accountId: DEFAULT_ACCOUNT_ID, lifecycle: "ready" });
+          await new Promise<void>((resolve) => {
+            abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        },
+      }),
+    );
+    const manager = createManager({ getPluginRegistry: () => registry });
+    try {
+      await manager.startChannels();
+      await manager.stopChannel("discord", undefined, { manual: false, routeHandoff: true });
+      await manager.startChannels();
+      await firstRegistered.promise;
+      expect(
+        registry.httpRoutes.filter((route) => route.handoff).map((route) => route.path),
+      ).toEqual(["/plugins/reload/1/first", "/plugins/reload/1/second"]);
+      completeIngress.resolve();
+      await flushMicrotasks();
+      expect(registry.httpRoutes.map((route) => route.path)).toEqual([
+        "/plugins/reload/2/first",
+        "/plugins/reload/2/second",
+      ]);
+    } finally {
+      completeIngress.resolve();
+      await manager.stopChannel("discord");
+    }
+  });
+
+  it("keeps stopped webhook routes retryable until replacement ingress is ready", async () => {
+    const route = { path: "/plugins/reload", auth: "plugin" as const, pluginId: "discord" };
+    const replacement = createDeferred();
+    let starts = 0;
+    const registry = installTestRegistry(
+      createTestPlugin({
+        startAccount: async ({ abortSignal }) => {
+          const generation = ++starts;
+          if (generation > 1) {
+            await replacement.promise;
+          }
+          if (abortSignal.aborted) {
+            return;
+          }
+          const unregister = registerPluginHttpRoute({
+            ...route,
+            throwOnFailure: true,
+            handler: (_req, res) => {
+              res.end(String(generation));
+              return true;
+            },
+          });
+          await new Promise<void>((resolve) => {
+            abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          });
+          unregister();
+        },
+      }),
+    );
+    const manager = createManager({ getPluginRegistry: () => registry });
+    const server = createTestGatewayServer({
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        handlePluginRequest: createGatewayPluginRequestHandler({
+          registry,
+          log: createSubsystemLogger("gateway/webhook-reload-test"),
+        }),
+      },
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected a TCP listener");
+    }
+    const read = async () => {
+      const response = await fetch(`http://127.0.0.1:${address.port}${route.path}`);
+      return {
+        status: response.status,
+        retryAfter: response.headers.get("retry-after"),
+        body: await response.text(),
+      };
+    };
+    try {
+      await manager.startChannels();
+      expect(await read()).toMatchObject({ status: 200, body: "1" });
+      await manager.stopChannel("discord", undefined, { manual: false, routeHandoff: true });
+      expect(await read()).toMatchObject({ status: 503, retryAfter: "1" });
+      await manager.startChannels();
+      expect(await read()).toMatchObject({ status: 503, retryAfter: "1" });
+      const repeatedStop = manager.stopChannel("discord", undefined, {
+        manual: false,
+        routeHandoff: true,
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+      await repeatedStop;
+      expect(await read()).toMatchObject({ status: 503, retryAfter: "1" });
+      // Timed-out preparation is retired by the existing two-attempt recovery owner.
+      await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+      await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+      expect(await read()).toMatchObject({ status: 503, retryAfter: "1" });
+      replacement.resolve();
+      await flushMicrotasks();
+      expect(await read()).toMatchObject({ status: 200, body: "3" });
+      await manager.stopChannel("discord");
+      expect(await read()).toMatchObject({ status: 404 });
+      await manager.startChannels();
+      expect(await read()).toMatchObject({ status: 200, body: "4" });
+      await manager.stopChannel("discord", undefined, { manual: false, routeHandoff: true });
+      expect(await read()).toMatchObject({ status: 503, retryAfter: "1" });
+      manager.pruneInactiveChannelAccountState(new Set());
+      expect(await read()).toMatchObject({ status: 404 });
+    } finally {
+      replacement.resolve();
+      await manager.stopChannel("discord");
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("rejects late startup registration while the next ingress handoff remains parked", async () => {
+    const pending = createDeferred();
+    const lateAttempt = createDeferred<string>();
+    let starts = 0;
+    const registry = installTestRegistry(
+      createTestPlugin({
+        startAccount: async ({ abortSignal }) => {
+          const generation = ++starts;
+          if (generation === 2) {
+            await pending.promise;
+          }
+          try {
+            registerPluginHttpRoute({
+              path: "/plugins/late-reload",
+              auth: "plugin",
+              pluginId: "discord",
+              handler: vi.fn(),
+              throwOnFailure: true,
+            });
+            if (generation === 2) {
+              lateAttempt.resolve("registered after retirement");
+              return;
+            }
+            await new Promise<void>((resolve) => {
+              abortSignal.addEventListener("abort", () => resolve(), { once: true });
+            });
+          } catch (error) {
+            lateAttempt.resolve(String(error));
+          }
+        },
+      }),
+    );
+    const manager = createManager({ getPluginRegistry: () => registry });
+    await manager.startChannels();
+    await manager.stopChannel("discord", undefined, { manual: false, routeHandoff: true });
+    await manager.startChannels();
+    const stop = manager.stopChannel("discord", undefined, { manual: false, routeHandoff: true });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await stop;
+    pending.resolve();
+    expect(await lateAttempt.promise).toContain("lease is no longer active");
+    await flushMicrotasks();
+    expect(registry.httpRoutes.map((route) => route.handoff)).toEqual([true]);
+  });
+
+  it.each(["removed", "disabled", "resolved-disabled", "manual"] as const)(
+    "removes %s ingress while its timed-out predecessor still needs cleanup",
+    async (action) => {
+      const pending = createDeferred();
+      let disabled = false;
+      const registry = installTestRegistry(
+        createTestPlugin({
+          resolveAccount: () => ({ enabled: action !== "resolved-disabled" || !disabled }),
+          startAccount: async () => {
+            registerPluginHttpRoute({
+              path: "/plugins/removed-reload",
+              auth: "plugin",
+              pluginId: "discord",
+              handler: vi.fn(),
+              throwOnFailure: true,
+            });
+            await pending.promise;
+          },
+        }),
+      );
+      const manager = createManager({
+        getPluginRegistry: () => registry,
+        getRuntimeConfig: () => ({
+          channels: { discord: { enabled: action === "resolved-disabled" || !disabled } },
+        }),
+      });
+      try {
+        await manager.startChannels();
+        if (action === "manual") {
+          const stop = manager.stopChannel("discord");
+          await vi.advanceTimersByTimeAsync(5_000);
+          await stop;
+        }
+        const stop = manager.stopChannel("discord", undefined, {
+          manual: false,
+          routeHandoff: true,
+        });
+        await vi.advanceTimersByTimeAsync(5_000);
+        await stop;
+        if (action !== "manual") {
+          expect(registry.httpRoutes.map((route) => route.handoff)).toEqual([true]);
+        }
+        if (action === "manual") {
+          await manager.startChannel("discord", undefined, { preserveManualStop: true });
+        } else if (action === "resolved-disabled") {
+          disabled = true;
+          pending.resolve();
+          await flushMicrotasks(30);
+          expect(await manager.startChannel("discord")).toEqual(
+            new Map([[DEFAULT_ACCOUNT_ID, { status: "skipped", reason: "disabled" }]]),
+          );
+        } else if (action === "disabled") {
+          disabled = true;
+          await manager.startChannels();
+        } else {
+          manager.pruneInactiveChannelAccountState(new Set());
+        }
+        expect(registry.httpRoutes).toEqual([]);
+      } finally {
+        pending.resolve();
+        await flushMicrotasks();
+      }
+    },
+  );
+
+  it("retires removed ingress even when account teardown rejects", async () => {
+    let removed = false;
+    const stopAccount = vi.fn().mockRejectedValueOnce(new Error("teardown failed"));
+    const registry = installTestRegistry(
+      createTestPlugin({
+        listAccountIds: () => (removed ? [] : [DEFAULT_ACCOUNT_ID]),
+        resolveAccount: () => {
+          if (removed) {
+            throw new Error("account is no longer configured");
+          }
+          return { enabled: true };
+        },
+        startAccount: async ({ abortSignal }) => {
+          registerPluginHttpRoute({
+            path: "/plugins/removed",
+            auth: "plugin",
+            pluginId: "discord",
+            handler: vi.fn(),
+          });
+          await new Promise<void>((resolve) => {
+            abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        },
+        stopAccount,
+      }),
+    );
+    const manager = createManager({ getPluginRegistry: () => registry });
+    await manager.startChannels();
+    removed = true;
+    await expect(
+      manager.stopChannel("discord", undefined, { manual: false, routeHandoff: true }),
+    ).rejects.toThrow("teardown failed");
+    expect(registry.httpRoutes).toEqual([]);
+    removed = false;
+  });
+
   it.each([false, true])(
     "scopes stop routes to their Gateway and releases them when teardown settles (rejects=%s)",
     async (rejects) => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -43,7 +43,11 @@ import {
   createPluginRuntimeCapabilityLease,
   type PluginRuntimeCapabilityLease,
 } from "../plugins/capability-lease.js";
-import { withPluginHttpRouteRegistry } from "../plugins/http-registry.js";
+import {
+  createPluginHttpRouteHandoff,
+  withPluginHttpRouteRegistry,
+  type PluginHttpRouteHandoff,
+} from "../plugins/http-registry.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginRuntimeChannel } from "../plugins/runtime/types-channel.js";
@@ -96,6 +100,10 @@ type ChannelAccountLifetime = {
 
 type ChannelRuntimeStore = {
   lifetimes: Map<string, ChannelAccountLifetime>;
+  routeHandoffs: Map<
+    string,
+    { handoff: PluginHttpRouteHandoff; parkedBy: AbortController; admittedSignal?: AbortSignal }
+  >;
   starting: Map<string, Promise<void>>;
   stops: Map<string, ChannelAccountStopState>;
   tasks: Map<string, Promise<unknown>>;
@@ -156,6 +164,7 @@ type GatewayStartupTrace = {
 function createRuntimeStore(): ChannelRuntimeStore {
   return {
     lifetimes: new Map(),
+    routeHandoffs: new Map(),
     starting: new Map(),
     stops: new Map(),
     tasks: new Map(),
@@ -243,6 +252,7 @@ type ChannelManagerOptions = {
 
 type StopChannelOptions = {
   manual?: boolean;
+  routeHandoff?: boolean;
 };
 
 type ChannelAccountStopOutcome = { status: "fulfilled" } | { status: "rejected"; error: unknown };
@@ -276,6 +286,7 @@ export type ChannelManager = {
     opts?: StartChannelOptions,
   ) => Promise<ReadonlyMap<string, ChannelAccountStartOutcome>>;
   stopChannel: (channel: ChannelId, accountId?: string, opts?: StopChannelOptions) => Promise<void>;
+  releaseChannelRouteHandoffs: (channel: ChannelId, accountId?: string) => void;
   setAutostartSuppression: (suppression: ChannelAutostartSuppression | null) => void;
   getAutostartSuppression: () => ChannelAutostartSuppression | null;
   recoverAutostartSuppression: () => Promise<boolean>;
@@ -337,6 +348,26 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   );
 
   const restartKey = (channelId: ChannelId, accountId: string) => `${channelId}:${accountId}`;
+  const releaseRouteHandoff = (
+    store: ChannelRuntimeStore,
+    accountId: string,
+    expected = store.routeHandoffs.get(accountId),
+  ): void => {
+    if (expected && store.routeHandoffs.get(accountId) === expected) {
+      expected.handoff.release();
+      store.routeHandoffs.delete(accountId);
+    }
+  };
+  const releaseChannelRouteHandoffs = (channelId: ChannelId, accountId?: string): void => {
+    const store = getStore(channelId);
+    for (const id of accountId ? [accountId] : store.routeHandoffs.keys()) {
+      const admittedSignal = store.routeHandoffs.get(id)?.admittedSignal;
+      // Partial rollback must preserve ingress owned by an admitted sibling.
+      if (!admittedSignal || admittedSignal.aborted) {
+        releaseRouteHandoff(store, id);
+      }
+    }
+  };
   const ensureChannelLog = (channelId: ChannelId): SubsystemLogger => {
     channelLogs[channelId] ??= createSubsystemLogger("channels").child(channelId);
     return channelLogs[channelId];
@@ -440,12 +471,18 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     channelId: ChannelId,
     accountId: string,
     patch: ChannelAccountSnapshot,
-    abortSignal?: AbortSignal,
+    abortSignal: AbortSignal,
   ): ChannelAccountSnapshot => {
-    const safePatch = abortSignal?.aborted
+    const safePatch = abortSignal.aborted
       ? sanitizeAbortedTaskStatusPatch(patch, getRuntime(channelId, accountId))
       : patch;
-    return setRuntime(channelId, accountId, safePatch);
+    const next = setRuntime(channelId, accountId, safePatch);
+    // Readiness belongs to the current task, after all ingress registrations.
+    // Retire old paths it did not reclaim; first registration alone is too early.
+    if (!abortSignal.aborted && next.lifecycle === "ready") {
+      releaseRouteHandoff(getStore(channelId), accountId);
+    }
+    return next;
   };
 
   const setStoppedRuntime = (
@@ -494,6 +531,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     accountIds: readonly string[],
   ) => {
     const activeAccountIds = new Set(accountIds);
+    for (const id of store.routeHandoffs.keys()) {
+      if (!activeAccountIds.has(id)) {
+        releaseRouteHandoff(store, id);
+      }
+    }
     for (const id of store.runtimes.keys()) {
       if (
         activeAccountIds.has(id) ||
@@ -536,6 +578,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     const plugin = registration?.plugin;
     const startAccount = plugin?.gateway?.startAccount;
     if (!startAccount) {
+      const store = getStore(channelId);
+      for (const id of accountId ? [accountId] : store.routeHandoffs.keys()) {
+        releaseRouteHandoff(store, id);
+      }
       return accountId
         ? new Map([[accountId, { status: "skipped", reason: "unsupported" }]])
         : new Map();
@@ -564,6 +610,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         `channel autostart suppressed by crash-loop breaker; refusing automatic start for ${channelId}${suffix}. ${formatGatewayCrashLoopManualChannelStartHint({ channelId, ...(accountId ? { accountId } : {}) })}`,
       );
       for (const id of accountIds) {
+        releaseRouteHandoff(store, id);
         setStoppedRuntime(channelId, id, {
           restartPending: false,
           lastError: autostartSuppression.message,
@@ -578,6 +625,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     }
     if (ambientAutostartSuppressedChannelIds.has(channelId) && optsValue.manual !== true) {
       for (const id of accountIds) {
+        releaseRouteHandoff(store, id);
         setStoppedRuntime(channelId, id, {
           restartPending: false,
           lastError:
@@ -595,6 +643,16 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       tasks: accountIds.map((id) => async () => {
         assertStartCurrent();
         const rKey = restartKey(channelId, id);
+        const explicitlyDisabled = isChannelAccountExplicitlyDisabled({
+          cfg,
+          channel: channelId,
+          accountId: id,
+        });
+        // An operator disable ends ingress even when an aborted predecessor
+        // still owns its task slot. Keep that slot for its separate cleanup.
+        if (explicitlyDisabled) {
+          releaseRouteHandoff(store, id);
+        }
         // Record start intent before waiting; a later stop must survive cancelled preparation.
         if (!preserveManualStop && !store.stops.has(id)) {
           manuallyStopped.delete(rKey);
@@ -656,6 +714,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
 
         // Reserve the account before the first await so overlapping start calls
         // cannot race into duplicate provider boots for the same account.
+        const routeHandoff = store.routeHandoffs.get(id);
         const abort = new AbortController();
         const capabilityLease = createPluginRuntimeCapabilityLease("channel account");
         const lifetime: ChannelAccountLifetime = { abort, capabilityLease };
@@ -701,7 +760,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           // Explicitly disabled accounts need no credentials. Unlisted requests still go
           // through the plugin resolver so a disable cannot hide account-selection errors.
           if (
-            isChannelAccountExplicitlyDisabled({ cfg, channel: channelId, accountId: id }) &&
+            explicitlyDisabled &&
             plugin.config
               .listAccountIds(cfg)
               .some((listed) => normalizeAccountId(listed) === normalizeAccountId(id))
@@ -1080,7 +1139,14 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 pendingAutoRestarts.delete(rKey);
               }
             })
-            .finally(releaseTask);
+            .finally(() => {
+              releaseTask();
+              // Retry ingress spans backoff and preparation. A successful retry
+              // transfers admission to its signal before this predecessor ends.
+              if (routeHandoff?.admittedSignal === abort.signal) {
+                releaseRouteHandoff(store, id, routeHandoff);
+              }
+            });
           function releaseTask() {
             if (store.tasks.get(id) === trackedPromise) {
               store.tasks.delete(id);
@@ -1097,6 +1163,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           }
           handedOffTask = true;
           store.tasks.set(id, trackedPromise);
+          if (routeHandoff) {
+            routeHandoff.admittedSignal = abort.signal;
+          }
           startOutcomes.set(id, { status: "handed-off" });
         } catch (error) {
           if (!handedOffTask) {
@@ -1109,6 +1178,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         } finally {
           if (!handedOffTask) {
             capabilityLease.revoke();
+            if (routeHandoff) {
+              releaseRouteHandoff(store, id, routeHandoff);
+            }
             await cleanupTaskScopedApprovalRuntime("channel startup cleanup failed");
           }
           if (!handedOffTask && store.lifetimes.get(id) === lifetime && !store.stops.has(id)) {
@@ -1143,6 +1215,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     const manual = optsLocal.manual ?? true;
     const plugin = getLoadedChannelPluginEntryById(channelId, registry)?.plugin;
     const store = getStore(channelId);
+    if (manual || !optsLocal.routeHandoff) {
+      releaseChannelRouteHandoffs(channelId, accountId);
+    }
     const lifecycleIds = new Set<string>([
       ...store.lifetimes.keys(),
       ...store.starting.keys(),
@@ -1155,10 +1230,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       return;
     }
     const cfg = getRuntimeConfig();
+    const configuredAccountIds =
+      !accountId || optsLocal.routeHandoff ? (plugin?.config.listAccountIds(cfg) ?? []) : [];
     const knownIds = new Set<string>(
-      accountId
-        ? [accountId]
-        : [...lifecycleIds, ...(plugin ? plugin.config.listAccountIds(cfg) : [])],
+      accountId ? [accountId] : [...lifecycleIds, ...configuredAccountIds],
     );
 
     // Gate replacement starts before teardown begins. Failures still reject only
@@ -1175,9 +1250,28 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         ): Promise<ChannelAccountStopOutcome> => {
           const lifetime = store.lifetimes.get(id);
           const abort = lifetime?.abort;
+          const canHandoff =
+            optsLocal.routeHandoff &&
+            configuredAccountIds.includes(id) &&
+            !isChannelAccountExplicitlyDisabled({ cfg, channel: channelId, accountId: id }) &&
+            !manuallyStopped.has(rKey);
+          if (!canHandoff) {
+            releaseRouteHandoff(store, id);
+          }
           const task = store.tasks.get(id);
           if (!abort && !task && !plugin?.gateway?.stopAccount) {
             return previousOutcome;
+          }
+          const lease = lifetime?.capabilityLease;
+          if (canHandoff && abort && lease && store.routeHandoffs.get(id)?.parkedBy !== abort) {
+            const handoff = store.routeHandoffs.get(id)?.handoff ?? createPluginHttpRouteHandoff();
+            handoff.park(lease);
+            store.routeHandoffs.set(id, { handoff, parkedBy: abort });
+          }
+          // Parking transfers ingress ownership before cancellation. Retired
+          // startup work must never reclaim it while its promise is settling.
+          if (optsLocal.routeHandoff) {
+            lease?.revoke();
           }
           abort?.abort();
           const log = ensureChannelLog(channelId);
@@ -1510,6 +1604,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     startChannels,
     startChannel: startChannelInternal,
     stopChannel,
+    releaseChannelRouteHandoffs,
     pruneInactiveChannelAccountState,
     setAutostartSuppression: (suppression) => {
       autostartSuppression = suppression;

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -477,9 +477,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       ? sanitizeAbortedTaskStatusPatch(patch, getRuntime(channelId, accountId))
       : patch;
     const next = setRuntime(channelId, accountId, safePatch);
-    // Readiness belongs to the current task, after all ingress registrations.
-    // Retire old paths it did not reclaim; first registration alone is too early.
-    if (!abortSignal.aborted && next.lifecycle === "ready") {
+    // Ready follows all ingress registrations; terminal startup may wait for abort.
+    // Retire on this task's terminal report, never an inherited diagnosis.
+    if (!abortSignal.aborted && (next.lifecycle === "ready" || patch.terminalDisconnect === true)) {
       releaseRouteHandoff(getStore(channelId), accountId);
     }
     return next;
@@ -1295,9 +1295,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             }
             if (teardown) {
               const { context, run } = teardown;
-              // The start task can settle before stopAccount. Shutdown routes need
-              // their own lease, bounded by this stop attempt rather than that task.
-              capabilityLease = createPluginRuntimeCapabilityLease("channel account stop");
+              // Teardown can outlive the start task. Its own lease permits route and status
+              // writes only until this stop attempt completes or times out.
+              const stopLease = createPluginRuntimeCapabilityLease("channel account stop");
+              capabilityLease = stopLease;
               // A plugin stopAccount that never settles must not wedge every
               // stop-driven flow (health monitor sweeps, thaw recovery, reload).
               // Bound it like the task teardown below; the timed-out path flows
@@ -1306,22 +1307,15 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               const runStopAccount = () =>
                 run({
                   ...context,
-                  setStatus: (next) => {
-                    // A stop we abandoned may settle after a replacement started;
-                    // its late writes must not repaint or tear down that account.
-                    setRuntime(
-                      channelId,
-                      id,
-                      stopAttemptAbandoned
-                        ? sanitizeAbortedTaskStatusPatch(next, getRuntime(channelId, id))
-                        : next,
-                    );
-                  },
+                  setStatus: (next) =>
+                    stopLease.isActive()
+                      ? setRuntime(channelId, id, next)
+                      : getRuntime(channelId, id),
                 });
               const stopAccountAttempt = withPluginHttpRouteRegistry(
                 registry,
                 runStopAccount,
-                capabilityLease,
+                stopLease,
               ).catch((error: unknown) => {
                 if (stopAttemptAbandoned) {
                   log.warn?.(

--- a/src/gateway/server-core-runtime.ts
+++ b/src/gateway/server-core-runtime.ts
@@ -5,6 +5,7 @@ import { listLoadedChannelPluginsForRegistry } from "../channels/plugins/registr
 import type { ChannelId } from "../channels/plugins/types.public.js";
 import { getRuntimeConfig } from "../config/io.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
+import { adoptPluginHttpRouteHandoffs } from "../plugins/http-registry.js";
 import { isGatewayWorkAdmissionClosed } from "../process/gateway-work-admission.js";
 import { createAgentRuntimeApprovalAuthorityValidator } from "./agent-runtime-identity-token.js";
 import { restartRunningChannelAccounts, type ThawRestartTarget } from "./channel-thaw-restart.js";
@@ -437,6 +438,7 @@ export async function startGatewayCoreRuntime(input: {
     gatewayMethods: string[];
     retireGatewayRuntimeBindings?: () => void;
   }) => {
+    adoptPluginHttpRouteHandoffs(pluginRuntime.registry, loaded.pluginRegistry);
     const retirePreviousBindings = retireAttachedPluginRuntimeBindings;
     retireAttachedPluginRuntimeBindings = loaded.retireGatewayRuntimeBindings ?? (() => {});
     retirePreviousBindings();

--- a/src/gateway/server-plugins.lifecycle.test.ts
+++ b/src/gateway/server-plugins.lifecycle.test.ts
@@ -999,6 +999,17 @@ describe("Gateway plugin replacement channel ownership", () => {
       expect(restarted.ok).toBe(false);
       expect(restarted.error?.message).toContain("plugins are reloading; retry");
       expect(starts.get("active")).toBe(1);
+      expect(await probe("active")).toEqual({
+        status: 503,
+        body: "plugin route is restarting; retry",
+        registry: null,
+      });
+      expect((await probe("parked")).status).toBe(404);
+      const stoppedAfterFailure = await rpcReq(socket, "channels.stop", {
+        channel: channelId,
+        accountId: "active",
+      });
+      expect(stoppedAfterFailure.ok, stoppedAfterFailure.error?.message).toBe(true);
       expect((await probe("active")).status).toBe(404);
       return;
     }

--- a/src/gateway/server-reload-channel-restart.test.ts
+++ b/src/gateway/server-reload-channel-restart.test.ts
@@ -20,6 +20,52 @@ afterEach(async () => {
   resetGatewayWorkAdmission();
 });
 
+it("retains a failed teardown target when rollback cannot admit its replacement", async () => {
+  const stopAccount = vi
+    .fn()
+    .mockResolvedValue(undefined)
+    .mockRejectedValueOnce(new Error("teardown failed"));
+  const plugin: ChannelPlugin = {
+    ...createChannelTestPluginBase({
+      id: "discord",
+      config: {
+        listAccountIds: () => ["running"],
+        resolveAccount: (_cfg, accountId) => ({ accountId }),
+      },
+    }),
+    gateway: {
+      startAccount: async ({ abortSignal }) =>
+        new Promise<void>((resolve) => {
+          abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        }),
+      stopAccount,
+    },
+  };
+  setActivePluginRegistry(createTestRegistry([{ pluginId: "discord", plugin, source: "test" }]));
+  manager = createChannelManager({
+    getRuntimeConfig: () => ({}),
+    getPluginRegistry: requireActivePluginChannelRegistry,
+    channelLogs: {},
+    channelRuntimeEnvs: {},
+  });
+  await manager.startChannel("discord");
+  await expect(manager.stopChannel("discord", undefined, { manual: false })).rejects.toThrow(
+    "teardown failed",
+  );
+
+  const channels = new Set<ChannelKind>(["discord"]);
+  const logChannels = { info: vi.fn(), error: vi.fn() };
+  expect(
+    await rollbackStoppedGatewayChannels(
+      { startChannel: manager.startChannel, logChannels },
+      channels,
+      "failed plugin runtime publication",
+    ),
+  ).toEqual(["discord"]);
+  expect([...channels]).toEqual(["discord"]);
+  expect(logChannels.error).toHaveBeenCalledWith(expect.stringContaining("stop-in-flight"));
+});
+
 it.each(["idle", "stopped", "racing"] as const)(
   "channel rollback preserves %s manual stops while explicit starts resume",
   async (state) => {

--- a/src/gateway/server-reload-channel-restart.ts
+++ b/src/gateway/server-reload-channel-restart.ts
@@ -2,8 +2,27 @@ import { getLoadedChannelPluginEntryById } from "../channels/plugins/registry-lo
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { ChannelKind, GatewayReloadPlan } from "./config-reload-plan.js";
+import type { StartChannelOptions } from "./server-channel-runtime.types.js";
 import type { GatewayReloadHandlerParams } from "./server-reload-contracts.js";
 import { collectChannelOperationFailures } from "./server-reload-utils.js";
+
+async function startGatewayChannelForReload(
+  params: Pick<GatewayReloadHandlerParams, "startChannel">,
+  channel: ChannelKind,
+  accountId?: string,
+  options: Pick<StartChannelOptions, "skipUnavailableAccounts"> = {},
+): Promise<void> {
+  // Registry selection and admission detachment belong to the channel manager.
+  const outcomes = await params.startChannel(channel, accountId, {
+    preserveManualStop: true,
+    ...options,
+  });
+  for (const [id, outcome] of outcomes) {
+    if (outcome.status === "retry") {
+      throw new Error(`${channel}[${id}] replacement not admitted: ${outcome.reason}`);
+    }
+  }
+}
 
 export async function rollbackStoppedGatewayChannels(
   params: Pick<GatewayReloadHandlerParams, "startChannel" | "logChannels">,
@@ -14,8 +33,7 @@ export async function rollbackStoppedGatewayChannels(
     channels: [...channels],
     run: async (channel) => {
       params.logChannels.info(`restarting ${channel} channel after ${reason}`);
-      // Registry selection and admission detachment belong to the channel manager.
-      await params.startChannel(channel, undefined, { preserveManualStop: true });
+      await startGatewayChannelForReload(params, channel);
       channels.delete(channel);
     },
     onFailure: (channel, err) => {
@@ -110,21 +128,33 @@ export async function restartGatewayChannels(options: {
   const operation = suppressed ? "stop" : "restart";
   const phase = suppressed ? "suppressed hot reload" : "hot reload";
   const accountTargets = collectChannelAccountTargets();
+  const restartTarget = async (channel: ChannelKind, accountId?: string) => {
+    const target =
+      accountId === undefined ? `${channel} channel` : `${channel} account ${accountId}`;
+    const canRestart = () => !suppressed && !isLifecycleReloadAborted();
+    params.logChannels.info(
+      suppressed ? `stopping ${target} before suppressed hot reload` : `restarting ${target}`,
+    );
+    if (accountId !== undefined || !channelsStoppedBeforePluginReload.has(channel)) {
+      await params.stopChannel(channel, accountId, {
+        manual: false,
+        ...(canRestart() ? { routeHandoff: true } : {}),
+      });
+    }
+    if (canRestart()) {
+      await startGatewayChannelForReload(params, channel, accountId, {
+        skipUnavailableAccounts: true,
+      });
+    } else {
+      // Cancellation ends the promise of replacement ingress; do not leave
+      // senders retrying an account whose reload will never start it.
+      params.releaseChannelRouteHandoffs(channel, accountId);
+    }
+  };
   const accountFailures: string[] = [];
   for (const [channel, accountId] of accountTargets) {
     try {
-      params.logChannels.info(
-        suppressed
-          ? `stopping ${channel} account ${accountId} before suppressed hot reload`
-          : `restarting ${channel} account ${accountId}`,
-      );
-      await params.stopChannel(channel, accountId, { manual: false });
-      if (!suppressed && !isLifecycleReloadAborted()) {
-        await params.startChannel(channel, accountId, {
-          preserveManualStop: true,
-          skipUnavailableAccounts: true,
-        });
-      }
+      await restartTarget(channel, accountId);
     } catch (err) {
       accountFailures.push(`${channel}[${accountId}]`);
       params.logChannels.error(
@@ -138,20 +168,7 @@ export async function restartGatewayChannels(options: {
       if (plan.reloadPlugins && activePluginChannelsAfterReload?.has(channel) === false) {
         return;
       }
-      params.logChannels.info(
-        suppressed
-          ? `stopping ${channel} channel before suppressed hot reload`
-          : `restarting ${channel} channel`,
-      );
-      if (!channelsStoppedBeforePluginReload.has(channel)) {
-        await params.stopChannel(channel, undefined, { manual: false });
-      }
-      if (!suppressed && !isLifecycleReloadAborted()) {
-        await params.startChannel(channel, undefined, {
-          preserveManualStop: true,
-          skipUnavailableAccounts: true,
-        });
-      }
+      await restartTarget(channel);
     },
     onFailure: (channel, err) => {
       params.logChannels.error(

--- a/src/gateway/server-reload-contracts.ts
+++ b/src/gateway/server-reload-contracts.ts
@@ -144,6 +144,7 @@ export type GatewayReloadHandlerParams = {
   getPluginRegistry: () => PluginRegistry;
   startChannel: GatewayChannelManager["startChannel"];
   stopChannel: GatewayChannelManager["stopChannel"];
+  releaseChannelRouteHandoffs: GatewayChannelManager["releaseChannelRouteHandoffs"];
   pruneInactiveChannelAccountState: (activeChannelIds: ReadonlySet<ChannelKind>) => void;
   getChannelAutostartSuppression?: GatewayChannelManager["getAutostartSuppression"];
   stopPostReadySidecars?: () => Promise<void> | void;
@@ -177,7 +178,10 @@ export type GatewayReloadHandlerParams = {
 
 export type ManagedGatewayConfigReloaderParams = Omit<
   GatewayReloadHandlerParams,
-  "assertRestartReady" | "logReload" | "pruneInactiveChannelAccountState"
+  | "assertRestartReady"
+  | "logReload"
+  | "pruneInactiveChannelAccountState"
+  | "releaseChannelRouteHandoffs"
 > & {
   configRevisionProjector: import("./config-revision-token.js").GatewayConfigRevisionProjector;
   minimalTestGateway: boolean;

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -44,11 +44,18 @@ import {
   setGatewaySigusr1RestartPolicy,
   setPreRestartDeferralCheck,
 } from "../infra/restart.js";
+import { createPluginRuntimeCapabilityLease } from "../plugins/capability-lease.js";
 import { registerPluginCommandInRegistry } from "../plugins/command-registration.js";
+import {
+  createPluginHttpRouteHandoff,
+  registerPluginHttpRoute,
+  withPluginHttpRouteRegistry,
+} from "../plugins/http-registry.js";
 import {
   createPluginCommandRuntime,
   type PluginCommandCatalogDecision,
 } from "../plugins/plugin-command-runtime.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   captureActivePluginRegistrySnapshot,
   requireActivePluginChannelRegistry,
@@ -168,6 +175,7 @@ function createGatewayReloadHandlers(
     setState: vi.fn(),
     startChannel: vi.fn(async () => new Map()),
     stopChannel: vi.fn(async () => {}),
+    releaseChannelRouteHandoffs: vi.fn(),
     pruneInactiveChannelAccountState: vi.fn(),
     stopPostReadySidecars: vi.fn(),
     reloadPlugins: vi.fn(async () => makePluginReloadResult()),
@@ -230,7 +238,10 @@ function startManagedGatewayConfigReloader(params: ManagedReloaderTestParams) {
     logChannels: { info: vi.fn(), error: vi.fn() },
     logCron: { error: vi.fn() },
     logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-    channelManager: { pruneInactiveChannelAccountState: vi.fn() } as never,
+    channelManager: {
+      pruneInactiveChannelAccountState: vi.fn(),
+      releaseChannelRouteHandoffs: vi.fn(),
+    } as never,
     activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) =>
       makePreparedSecretsSnapshot(config),
     ) as never,
@@ -3162,7 +3173,10 @@ describe("gateway hot reload superseded tail recovery", () => {
     releaseStop.resolve();
     await reloadA;
 
-    expect(stopChannel).toHaveBeenCalledWith("discord", undefined, { manual: false });
+    expect(stopChannel).toHaveBeenCalledWith("discord", undefined, {
+      manual: false,
+      routeHandoff: true,
+    });
     expect(startChannel).toHaveBeenCalledWith("discord", undefined, {
       preserveManualStop: true,
       skipUnavailableAccounts: true,
@@ -4018,7 +4032,10 @@ describe("gateway restart deferral preflight", () => {
       restoreChannelReloadEnv();
     }
 
-    expect(stopChannel).toHaveBeenCalledWith("discord", undefined, { manual: false });
+    expect(stopChannel).toHaveBeenCalledWith("discord", undefined, {
+      manual: false,
+      routeHandoff: true,
+    });
     expect(startChannel).toHaveBeenCalledWith("discord", undefined, {
       preserveManualStop: true,
       skipUnavailableAccounts: true,
@@ -4065,7 +4082,10 @@ describe("gateway restart deferral preflight", () => {
       restoreChannelReloadEnv();
     }
 
-    expect(stopChannel).toHaveBeenCalledWith("telegram", undefined, { manual: false });
+    expect(stopChannel).toHaveBeenCalledWith("telegram", undefined, {
+      manual: false,
+      routeHandoff: true,
+    });
     expect(startChannel).toHaveBeenCalledWith("telegram", undefined, {
       preserveManualStop: true,
       skipUnavailableAccounts: true,
@@ -6304,7 +6324,10 @@ describe("gateway plugin hot reload handlers", () => {
 
     expect(runtimeEnv.env[envKey]).toBeUndefined();
     expect(targetEnv[envKey]).toBeUndefined();
-    expect(stopChannel).toHaveBeenCalledWith("discord", undefined, { manual: false });
+    expect(stopChannel).toHaveBeenCalledWith("discord", undefined, {
+      manual: false,
+      routeHandoff: true,
+    });
     expect(startChannel).toHaveBeenCalledWith("discord", undefined, {
       preserveManualStop: true,
       skipUnavailableAccounts: true,
@@ -6904,6 +6927,7 @@ describe("gateway plugin hot reload handlers", () => {
       }
       expect(channels.stop).toHaveBeenCalledExactlyOnceWith("discord", undefined, {
         manual: false,
+        routeHandoff: true,
       });
       expect(channels.start).toHaveBeenCalledExactlyOnceWith("discord", undefined, {
         preserveManualStop: true,
@@ -7215,7 +7239,7 @@ describe("gateway plugin hot reload handlers", () => {
             await root?.run(async () => {
               await expect(
                 applyHotReload(createPluginReloadPlan(), { plugins: { enabled: false } }),
-              ).rejects.toThrow("failed to stop channels before plugin reload: discord");
+              ).rejects.toThrow("plugin reload cancellation rollback failed for: discord");
               await waitForFast(() => expect(monitorStarts).toEqual(["telegram"]));
             });
           } finally {
@@ -7231,6 +7255,9 @@ describe("gateway plugin hot reload handlers", () => {
           ]);
           expect(logChannels.error).toHaveBeenCalledWith(
             "failed to stop discord channel before plugin reload: stop failed",
+          );
+          expect(logChannels.error).toHaveBeenCalledWith(
+            expect.stringContaining("replacement not admitted: stop-in-flight"),
           );
           expect(startChannel).toHaveBeenCalledWith("telegram", undefined, {
             preserveManualStop: true,
@@ -7324,8 +7351,8 @@ describe("gateway plugin hot reload handlers", () => {
     });
     expect(reloadParamsRecord?.sourceConfig).toBe(sourceConfig);
     expect(stopChannel.mock.calls).toEqual([
-      ["discord", undefined, { manual: false }],
-      ["slack", undefined, { manual: false }],
+      ["discord", undefined, { manual: false, routeHandoff: true }],
+      ["slack", undefined, { manual: false, routeHandoff: true }],
     ]);
     expect(startChannel).toHaveBeenCalledExactlyOnceWith("slack", undefined, {
       preserveManualStop: true,
@@ -7347,6 +7374,7 @@ describe("gateway plugin hot reload handlers", () => {
     const restoreChannelReloadEnv = enableChannelReloadsForTest();
     const gatewayState = createDefaultGatewayReloadState();
     const setState = vi.fn();
+    const releaseChannelRouteHandoffs = vi.fn();
     const logChannels = { info: vi.fn(), error: vi.fn() };
     const events: string[] = [];
     const startChannel = vi.fn(async (channel: ChannelKind) => {
@@ -7373,6 +7401,7 @@ describe("gateway plugin hot reload handlers", () => {
       setState,
       startChannel,
       stopChannel,
+      releaseChannelRouteHandoffs,
       reloadPlugins,
       getChannelAutostartSuppression: () => ({
         reason: "crash-loop-breaker",
@@ -7391,8 +7420,13 @@ describe("gateway plugin hot reload handlers", () => {
       restoreChannelReloadEnv();
     }
 
-    expect(stopChannel).toHaveBeenCalledWith("discord", undefined, { manual: false });
+    expect(stopChannel).toHaveBeenCalledWith("discord", undefined, {
+      manual: false,
+      routeHandoff: true,
+    });
     expect(startChannel).not.toHaveBeenCalled();
+    expect(stopChannel).toHaveBeenCalledTimes(1);
+    expect(releaseChannelRouteHandoffs).toHaveBeenCalledExactlyOnceWith("discord", undefined);
     expect(events).toEqual(["reload:start", "stop:discord", "registry:replace"]);
     expect(logChannels.info).toHaveBeenCalledWith(
       "channel restart during hot reload suppressed by crash-loop breaker for channels: discord",
@@ -7418,16 +7452,15 @@ describe("deferred channel reload abort generation", () => {
   const createTestHandlers = (
     logChannels: any,
     channels: any,
-    options?: {
-      reloadPlugins?: ReloadHandlerParams["reloadPlugins"];
-      requestRecoveryRestart?: ReloadHandlerParams["requestRecoveryRestart"];
-    },
+    options?: Pick<
+      Partial<ReloadHandlerParams>,
+      "reloadPlugins" | "requestRecoveryRestart" | "releaseChannelRouteHandoffs"
+    >,
   ) =>
     createGatewayReloadHandlers({
       startChannel: channels.start,
       stopChannel: channels.stop,
-      ...(options?.reloadPlugins ? { reloadPlugins: options.reloadPlugins } : {}),
-      requestRecoveryRestart: options?.requestRecoveryRestart,
+      ...options,
       logChannels,
     });
 
@@ -7463,6 +7496,7 @@ describe("deferred channel reload abort generation", () => {
       expect(oldChannels.start).not.toHaveBeenCalled();
       expect(nextChannels.stop).toHaveBeenCalledExactlyOnceWith("whatsapp", undefined, {
         manual: false,
+        routeHandoff: true,
       });
       expect(nextChannels.start).toHaveBeenCalledExactlyOnceWith("whatsapp", undefined, {
         preserveManualStop: true,
@@ -7523,7 +7557,10 @@ describe("deferred channel reload abort generation", () => {
       "config hot reload cancelled by config supersession or in-process restart",
     );
 
-    expect(channels.stop).toHaveBeenCalledWith("whatsapp", undefined, { manual: false });
+    expect(channels.stop).toHaveBeenCalledWith("whatsapp", undefined, {
+      manual: false,
+      routeHandoff: true,
+    });
     expect(channels.start).not.toHaveBeenCalled();
   });
 
@@ -7552,18 +7589,39 @@ describe("deferred channel reload abort generation", () => {
       "config hot reload cancelled by config supersession or in-process restart",
     );
 
-    expect(channels.stop).toHaveBeenCalledWith("whatsapp", undefined, { manual: false });
+    expect(channels.stop).toHaveBeenCalledWith("whatsapp", undefined, {
+      manual: false,
+      routeHandoff: true,
+    });
     expect(channels.start).not.toHaveBeenCalled();
     expect(requestRecoveryRestart).not.toHaveBeenCalled();
   });
 
   it("schedules recovery when plugin cancellation rollback cannot restart a channel", async () => {
     const logChannels = { info: vi.fn(), error: vi.fn() };
+    const registry = createEmptyPluginRegistry();
+    const lease = createPluginRuntimeCapabilityLease("rollback channel test");
+    const handoff = createPluginHttpRouteHandoff();
+    withPluginHttpRouteRegistry(
+      registry,
+      () =>
+        registerPluginHttpRoute({
+          path: "/rollback-webhook",
+          auth: "plugin",
+          pluginId: "whatsapp",
+          handler: vi.fn(),
+        }),
+      lease,
+    );
     const channels = {
       start: vi.fn(async () => {
         throw new Error("channel restart failed");
       }),
-      stop: vi.fn(async () => {}),
+      stop: vi.fn(async () => {
+        handoff.park(lease);
+        lease.revoke();
+        expect(registry.httpRoutes[0]?.handoff).toBe(true);
+      }),
     };
     const reloadPlugins: NonNullable<ReloadHandlerParams["reloadPlugins"]> = async (params) => {
       await params.beforeReplace(new Set(["whatsapp"]));
@@ -7575,11 +7633,13 @@ describe("deferred channel reload abort generation", () => {
     const { applyHotReload } = createTestHandlers(logChannels, channels, {
       reloadPlugins,
       requestRecoveryRestart,
+      releaseChannelRouteHandoffs: () => handoff.release(),
     });
 
     await expect(applyHotReload(createPluginReloadPlan(), {})).rejects.toThrow(
       "plugin reload cancellation rollback failed for: whatsapp",
     );
+    expect(registry.httpRoutes).toEqual([]);
 
     expect(requestRecoveryRestart).toHaveBeenCalledWith(
       expect.stringContaining("hot reload recovery: plugin channel rollback"),
@@ -8012,7 +8072,10 @@ describe("deferred channel reload abort generation", () => {
       await vi.advanceTimersByTimeAsync(500); // wake up, see active=0, drain complete
       await expect(reloadPromise).resolves.toBe("applied");
 
-      expect(channels.stop).toHaveBeenCalledWith("whatsapp", undefined, { manual: false });
+      expect(channels.stop).toHaveBeenCalledWith("whatsapp", undefined, {
+        manual: false,
+        routeHandoff: true,
+      });
       expect(channels.start).toHaveBeenCalledWith("whatsapp", undefined, {
         preserveManualStop: true,
         skipUnavailableAccounts: true,

--- a/src/gateway/server-reload-hot.ts
+++ b/src/gateway/server-reload-hot.ts
@@ -381,6 +381,9 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       const rollbackStoppedPluginTargets = (reason: string) =>
         rollbackStoppedGatewayChannels(params, channelsStoppedBeforePluginReload, reason);
       const failPluginChannelRollback = (reason: string, failures: string[]): never => {
+        for (const channel of channelsStoppedBeforePluginReload) {
+          params.releaseChannelRouteHandoffs(channel);
+        }
         const error = new Error(
           `plugin reload cancellation rollback failed for: ${failures.join(", ")}`,
         );
@@ -414,7 +417,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
             }
             params.logChannels.info(`stopping ${channel} channel before plugin reload`);
             channelsStoppedBeforePluginReload.add(channel);
-            await params.stopChannel(channel, undefined, { manual: false });
+            await params.stopChannel(channel, undefined, { manual: false, routeHandoff: true });
             pluginReloadAborted = isPluginReloadAborted();
           },
           onFailure: (channel, err) => {
@@ -510,6 +513,9 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         (!runtimeCommitted || isRestartRetryStopped() || isLifecycleReloadAborted());
     }
     if (pluginReloadAborted) {
+      for (const channel of channelsStoppedBeforePluginReload) {
+        params.releaseChannelRouteHandoffs(channel);
+      }
       // Only an uncommitted reload can transfer its receipt to the watcher. After
       // commit, same-content replay may be a no-op and cannot finish the interrupted tail.
       const error = createReloadCancellationError(

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -150,6 +150,7 @@ export function startManagedGatewayConfigReloader(
     stopRestartRetries,
   } = createGatewayReloadHandlers({
     ...params,
+    releaseChannelRouteHandoffs: params.channelManager.releaseChannelRouteHandoffs,
     pruneInactiveChannelAccountState: params.channelManager.pruneInactiveChannelAccountState,
     createGmailRestartAbortController,
     clearGmailRestartAbortController: (abortController) => {

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -34,6 +34,7 @@ function createManager(snapshot: ChannelRuntimeSnapshot): ChannelManager {
     startChannels: vi.fn(),
     startChannel: vi.fn(),
     stopChannel: vi.fn(),
+    releaseChannelRouteHandoffs: vi.fn(),
     setAutostartSuppression: vi.fn(),
     getAutostartSuppression: vi.fn(() => null),
     recoverAutostartSuppression: vi.fn(async () => false),

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -1,7 +1,12 @@
 /** Verifies plugin HTTP route registration, collision detection, and metadata capture. */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { registerPluginHttpRoute, withPluginHttpRouteRegistry } from "./http-registry.js";
+import {
+  adoptPluginHttpRouteHandoffs,
+  createPluginHttpRouteHandoff,
+  registerPluginHttpRoute,
+  withPluginHttpRouteRegistry,
+} from "./http-registry.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { createPluginRegistry } from "./registry.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
@@ -112,6 +117,149 @@ describe("registerPluginHttpRoute", () => {
   afterEach(() => {
     resetPluginRuntimeStateForTest();
   });
+
+  it("transfers retry ingress while retired holders release their leases", () => {
+    const previous = createEmptyPluginRegistry();
+    const next = createEmptyPluginRegistry();
+    const retired = createTrackedRouteLease();
+    const current = createTrackedRouteLease();
+    const route = {
+      path: "/plugins/handoff",
+      auth: "plugin" as const,
+      pluginId: "demo",
+      source: "account",
+    };
+    const unregisterOld = withPluginHttpRouteRegistry(
+      previous,
+      () => registerPluginHttpRoute({ ...route, handler: vi.fn(), throwOnFailure: true }),
+      retired.lease,
+    );
+    const handoff = createPluginHttpRouteHandoff();
+    handoff.park(retired.lease);
+    retired.revoke();
+    expect(retired.cleanups.size).toBe(0);
+    adoptPluginHttpRouteHandoffs(previous, next);
+    expect(previous.httpRoutes).toHaveLength(0);
+    expect(next.httpRoutes).toHaveLength(1);
+    const handler = vi.fn();
+    withPluginHttpRouteRegistry(
+      next,
+      () => registerPluginHttpRoute({ ...route, handler, throwOnFailure: true }),
+      current.lease,
+    );
+    unregisterOld();
+    handoff.release();
+    expect(next.httpRoutes.map((entry) => entry.handler)).toEqual([handler]);
+    current.revoke();
+    expect(next.httpRoutes).toHaveLength(0);
+    expect(current.cleanups.size).toBe(0);
+  });
+
+  it.each([{ pluginId: "other" }, { source: "other-account" }, { auth: "gateway" as const }])(
+    "preserves retry ingress when a successor changes ownership: %j",
+    (changed) => {
+      const registry = createEmptyPluginRegistry();
+      const retired = createTrackedRouteLease();
+      const route = {
+        path: "/plugins/handoff",
+        auth: "plugin" as const,
+        pluginId: "demo",
+        source: "account",
+      };
+      withPluginHttpRouteRegistry(
+        registry,
+        () => registerPluginHttpRoute({ ...route, handler: vi.fn(), throwOnFailure: true }),
+        retired.lease,
+      );
+      const handoff = createPluginHttpRouteHandoff();
+      handoff.park(retired.lease);
+      retired.revoke();
+      const placeholder = registry.httpRoutes[0];
+      expect(() =>
+        registerPluginHttpRoute({
+          ...route,
+          ...changed,
+          registry,
+          handler: vi.fn(),
+          throwOnFailure: true,
+        }),
+      ).toThrow();
+      expect(registry.httpRoutes).toEqual([placeholder]);
+      const next = createEmptyPluginRegistry();
+      registerPluginHttpRoute({
+        ...route,
+        ...changed,
+        registry: next,
+        handler: vi.fn(),
+        throwOnFailure: true,
+      });
+      expect(() => adoptPluginHttpRouteHandoffs(registry, next)).toThrow();
+      expect(registry.httpRoutes).toEqual([placeholder]);
+      handoff.release();
+      expect(registry.httpRoutes).toHaveLength(0);
+    },
+  );
+
+  it.each([false, true])(
+    "keeps sibling handoffs across successor claims (registry swap: %s)",
+    (swapRegistry) => {
+      const registry = createEmptyPluginRegistry();
+      const first = createTrackedRouteLease();
+      const second = createTrackedRouteLease();
+      const firstHandoff = createPluginHttpRouteHandoff();
+      const secondHandoff = createPluginHttpRouteHandoff();
+      const route = {
+        path: "/plugins/shared",
+        auth: "plugin" as const,
+        pluginId: "demo",
+        source: "shared",
+      };
+      for (const owner of [first, second]) {
+        withPluginHttpRouteRegistry(
+          registry,
+          () =>
+            registerPluginHttpRoute({
+              ...route,
+              handler: vi.fn(),
+              reuseExistingSameOwner: true,
+              throwOnFailure: true,
+            }),
+          owner.lease,
+        );
+      }
+      firstHandoff.park(first.lease);
+      first.revoke();
+      secondHandoff.park(second.lease);
+      second.revoke();
+      expect(registry.httpRoutes.map((entry) => entry.handoff)).toEqual([true]);
+      const next = swapRegistry ? createEmptyPluginRegistry() : registry;
+      const handler = vi.fn();
+      const unregister = registerPluginHttpRoute({
+        ...route,
+        registry: next,
+        handler,
+        throwOnFailure: true,
+      });
+      if (swapRegistry) {
+        adoptPluginHttpRouteHandoffs(registry, next);
+      }
+      firstHandoff.release();
+      expect(next.httpRoutes.map((entry) => entry.handler)).toEqual([handler]);
+      unregister();
+      expect(next.httpRoutes.map((entry) => entry.handoff)).toEqual([true]);
+      const secondHandler = vi.fn();
+      const unregisterSecond = registerPluginHttpRoute({
+        ...route,
+        registry: next,
+        handler: secondHandler,
+        throwOnFailure: true,
+      });
+      secondHandoff.release();
+      expect(next.httpRoutes.map((entry) => entry.handler)).toEqual([secondHandler]);
+      unregisterSecond();
+      expect(next.httpRoutes).toHaveLength(0);
+    },
+  );
 
   it("registers route and unregisters it", () => {
     const registry = createEmptyPluginRegistry();
@@ -303,8 +451,12 @@ describe("registerPluginHttpRoute", () => {
     expect(registry.httpRoutes[0]?.handler).toBe(firstHandler);
     expect(logs.at(-1)).toContain("reusing existing webhook path");
 
+    const handoff = createPluginHttpRouteHandoff();
+    handoff.park(firstOwner.lease);
     firstOwner.revoke();
+    handoff.release();
     expect(registry.httpRoutes).toHaveLength(1);
+    expect(registry.httpRoutes[0]?.handler).toBe(firstHandler);
     expect(secondOwner.cleanups).toHaveLength(1);
 
     unregisterSecond();

--- a/src/plugins/http-registry.ts
+++ b/src/plugins/http-registry.ts
@@ -13,45 +13,168 @@ type PluginHttpRouteHandler = (
 ) => Promise<boolean | void> | boolean | void;
 
 type PluginHttpRouteRegistrationLease = Pick<PluginRuntimeCapabilityLease, "isActive" | "retain">;
+type RouteOwner = {
+  entry: PluginHttpRouteRegistration;
+  routes: PluginHttpRouteRegistration[];
+  holders: Set<() => void>;
+  handoffs: Set<Set<RouteOwner>>;
+};
+type RouteRetention = { owner: RouteOwner };
+export type PluginHttpRouteHandoff = {
+  park: (lease: PluginHttpRouteRegistrationLease) => void;
+  release: () => void;
+};
 
 const pluginHttpRouteRegistryScope = new AsyncLocalStorage<{
   registry: PluginRegistry;
   leases: readonly PluginHttpRouteRegistrationLease[];
 }>();
-const pluginHttpRouteHolders = new WeakMap<PluginHttpRouteRegistration, Set<() => void>>();
+const routeOwners = new WeakMap<PluginHttpRouteRegistration, RouteOwner>();
+const leasedRoutes = new WeakMap<PluginHttpRouteRegistrationLease, Set<RouteRetention>>();
 const noopUnregister = () => {};
 
+function removeOwnedRoute(owner: RouteOwner, successor?: RouteOwner): void {
+  const index = owner.routes.indexOf(owner.entry);
+  if (index >= 0) {
+    owner.routes.splice(index, 1);
+  }
+  for (const handoff of owner.handoffs) {
+    handoff.delete(owner);
+    if (successor) {
+      handoff.add(successor);
+      successor.handoffs.add(handoff);
+    }
+  }
+  owner.handoffs.clear();
+  routeOwners.delete(owner.entry);
+}
+
+function retireUnheldRoute(owner: RouteOwner): void {
+  if (owner.holders.size > 0) {
+    return;
+  }
+  const index = owner.routes.indexOf(owner.entry);
+  if (owner.handoffs.size === 0 || index < 0) {
+    removeOwnedRoute(owner);
+  } else if (!owner.entry.handoff) {
+    // Shared ingress serves live holders, then stays retryable while any
+    // replacement still owns it. Late unregisters retain this same owner.
+    const previous = owner.entry;
+    owner.entry = {
+      ...previous,
+      handoff: true,
+      handleUpgrade: undefined,
+      handler: (_req, res) => {
+        res.statusCode = 503;
+        res.setHeader("Retry-After", "1");
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        res.end("plugin route is restarting; retry");
+        return true;
+      },
+    };
+    owner.routes.splice(index, 1, owner.entry);
+    routeOwners.delete(previous);
+    routeOwners.set(owner.entry, owner);
+  }
+}
+
+/** Keep retired ingress retryable until a successor claims it or every replacement ends. */
+export function createPluginHttpRouteHandoff(): PluginHttpRouteHandoff {
+  const routes = new Set<RouteOwner>();
+  return {
+    park(lease) {
+      for (const { owner } of leasedRoutes.get(lease) ?? []) {
+        if (owner.routes.includes(owner.entry)) {
+          routes.add(owner);
+          owner.handoffs.add(routes);
+        }
+      }
+    },
+    release() {
+      for (const owner of routes) {
+        owner.handoffs.delete(routes);
+        retireUnheldRoute(owner);
+      }
+      routes.clear();
+    },
+  };
+}
+
+function hasSameRouteOwner(
+  left: Pick<PluginHttpRouteRegistration, "pluginId" | "source" | "auth">,
+  right: Pick<PluginHttpRouteRegistration, "pluginId" | "source" | "auth">,
+): boolean {
+  return (
+    left.auth === right.auth &&
+    normalizeOptionalString(left.pluginId) === normalizeOptionalString(right.pluginId) &&
+    normalizeOptionalString(left.source) === normalizeOptionalString(right.source)
+  );
+}
+
+export function adoptPluginHttpRouteHandoffs(previous: PluginRegistry, next: PluginRegistry): void {
+  if (previous === next) {
+    return;
+  }
+  const transfers = previous.httpRoutes.flatMap((entry) => {
+    const owner = routeOwners.get(entry);
+    if (!owner || !entry.handoff) {
+      return [];
+    }
+    const conflicts = findPluginHttpRouteRegistrationConflicts(next.httpRoutes, entry);
+    if (
+      conflicts.authOverlap ||
+      conflicts.canonicalMatches.some((route) => !hasSameRouteOwner(route, entry))
+    ) {
+      throw new Error(`plugin reload cannot replace HTTP route ownership at ${entry.path}`);
+    }
+    return [{ owner, replacement: conflicts.canonicalMatches[0] }];
+  });
+  // Validate the complete incoming registry before changing either serving array.
+  for (const { owner, replacement } of transfers) {
+    if (replacement) {
+      removeOwnedRoute(owner, routeOwners.get(replacement));
+    } else {
+      previous.httpRoutes.splice(previous.httpRoutes.indexOf(owner.entry), 1);
+      next.httpRoutes.push(owner.entry);
+      owner.routes = next.httpRoutes;
+    }
+  }
+}
+
 // Same-owner reuse creates independent holders so one task cannot evict a route
-// while another task still owns the shared registration.
+// while another live task or pending replacement still owns its ingress.
 function retainPluginHttpRoute(params: {
   entry: PluginHttpRouteRegistration;
-  routes: PluginHttpRouteRegistration[];
   leases: readonly PluginHttpRouteRegistrationLease[];
 }): () => void {
-  const holders = pluginHttpRouteHolders.get(params.entry);
+  const owner = routeOwners.get(params.entry);
   // Static API routes belong to the registry; borrowing one cannot give a
   // dynamic caller authority to remove it on unregister or lease expiry.
-  if (!holders) {
+  if (!owner) {
     return noopUnregister;
   }
+  const retention = { owner };
   const leaseReleases: Array<() => void> = [];
   const release = () => {
-    if (!holders.delete(release)) {
+    if (!owner.holders.delete(release)) {
       return;
+    }
+    for (const lease of params.leases) {
+      leasedRoutes.get(lease)?.delete(retention);
     }
     for (const releaseLease of leaseReleases.splice(0)) {
       releaseLease();
     }
-    if (holders.size > 0) {
-      return;
-    }
-    const index = params.routes.indexOf(params.entry);
-    if (index >= 0) {
-      params.routes.splice(index, 1);
-    }
+    retireUnheldRoute(owner);
   };
-  holders.add(release);
+  owner.holders.add(release);
   for (const lease of params.leases) {
+    let retentions = leasedRoutes.get(lease);
+    if (!retentions) {
+      retentions = new Set();
+      leasedRoutes.set(lease, retentions);
+    }
+    retentions.add(retention);
     leaseReleases.push(lease.retain(release));
   }
   return release;
@@ -126,6 +249,18 @@ export function registerPluginHttpRoute(params: {
         `owned by ${authOverlap.pluginId ?? "unknown-plugin"} (${authOverlap.source ?? "unknown-source"})`,
     );
   }
+  const entry: PluginHttpRouteRegistration = {
+    path: normalizedPath,
+    handler: params.handler,
+    auth: params.auth,
+    match: routeMatch,
+    ...(params.gatewayRuntimeScopeSurface
+      ? { gatewayRuntimeScopeSurface: params.gatewayRuntimeScopeSurface }
+      : {}),
+    pluginId: params.pluginId,
+    source: params.source,
+  };
+  const successor: RouteOwner = { entry, routes, holders: new Set(), handoffs: new Set() };
   // Canonical aliases occupy one Gateway route even when their configured
   // bytes differ. Nested same-auth prefix chains remain separate routes.
   const existingIndex = canonicalMatches[0] ? routes.indexOf(canonicalMatches[0]) : -1;
@@ -138,19 +273,17 @@ export function registerPluginHttpRoute(params: {
     }
     const requestedOwner = normalizeOptionalString(params.pluginId);
     const requestedSource = normalizeOptionalString(params.source);
-    const mismatchedOwner = canonicalMatches.find(
-      (route) =>
-        normalizeOptionalString(route.pluginId) !== requestedOwner ||
-        normalizeOptionalString(route.source) !== requestedSource,
-    );
-    if (!params.replaceExisting && params.reuseExistingSameOwner) {
+    const mismatchedOwner = canonicalMatches.find((route) => !hasSameRouteOwner(route, params));
+    const replaceExisting =
+      params.replaceExisting ||
+      (!mismatchedOwner && canonicalMatches.every((route) => route.handoff));
+    if (!replaceExisting && params.reuseExistingSameOwner) {
       if (requestedOwner !== undefined && requestedSource !== undefined && !mismatchedOwner) {
         params.log?.(
           `plugin: reusing existing webhook path ${normalizedPath} (${routeMatch}) (${requestedOwner}/${requestedSource})`,
         );
         return retainPluginHttpRoute({
           entry: existing,
-          routes,
           leases: scope?.leases ?? [],
         });
       }
@@ -159,7 +292,7 @@ export function registerPluginHttpRoute(params: {
         `plugin: route reuse denied for ${normalizedPath} (${routeMatch})${suffix}; owned by ${conflictingOwner.pluginId ?? "unknown-plugin"} (${conflictingOwner.source ?? "unknown-source"})`,
       );
     }
-    if (!params.replaceExisting) {
+    if (!replaceExisting) {
       return rejectRegistration(
         `plugin: route conflict at ${normalizedPath} (${routeMatch})${suffix}; owned by ${existing.pluginId ?? "unknown-plugin"} (${existing.source ?? "unknown-source"})`,
       );
@@ -181,6 +314,12 @@ export function registerPluginHttpRoute(params: {
       `plugin: replacing stale webhook path ${normalizedPath} (${routeMatch})${suffix}${pluginHint}`,
     );
     for (const route of canonicalMatches.toReversed()) {
+      const owner = routeOwners.get(route);
+      if (owner) {
+        // The first replacement may stop while a shared sibling is still
+        // starting. Transfer its pending handoffs, not its retired live holders.
+        removeOwnedRoute(owner, successor);
+      }
       const index = routes.indexOf(route);
       if (index >= 0) {
         routes.splice(index, 1);
@@ -188,22 +327,10 @@ export function registerPluginHttpRoute(params: {
     }
   }
 
-  const entry: PluginHttpRouteRegistration = {
-    path: normalizedPath,
-    handler: params.handler,
-    auth: params.auth,
-    match: routeMatch,
-    ...(params.gatewayRuntimeScopeSurface
-      ? { gatewayRuntimeScopeSurface: params.gatewayRuntimeScopeSurface }
-      : {}),
-    pluginId: params.pluginId,
-    source: params.source,
-  };
-  pluginHttpRouteHolders.set(entry, new Set());
+  routeOwners.set(entry, successor);
   routes.push(entry);
   return retainPluginHttpRoute({
     entry,
-    routes,
     leases: scope?.leases ?? [],
   });
 }

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -126,6 +126,8 @@ type PluginCliRegistration = {
 
 /** Gateway HTTP route registered by a plugin runtime. */
 export type PluginHttpRouteRegistration = {
+  /** Retired ingress awaiting a lifecycle replacement; responds with Retry-After. */
+  handoff?: true;
   pluginId?: string;
   path: string;
   handler: OpenClawPluginHttpRouteHandler;


### PR DESCRIPTION
## What Problem This Solves

During channel hot reload, Gateway-hosted webhook routes disappear between teardown and replacement startup. Senders receive 404 even though the channel is coming back. Preserve known ingress as HTTP 503 with `Retry-After: 1` until its replacement is ready or its lifecycle ends.

## Why This Change Was Made

The route registry owns live holders and reload handoffs together. Shared live holders keep serving, while a retired last holder becomes retry-only. Replacement routes must match plugin, source and authentication ownership. Expired callbacks cannot register ingress.

The channel manager records the admitted account lifetime. Readiness retires unreclaimed paths; automatic recovery retains them through startup backoff. Manual stop, disable, removal, abandoned replacement and terminal startup retire the handoff. Terminal status also retires it when startup remains pending until abort. Partial rollback preserves admitted siblings. Stop callbacks use the existing stop-attempt capability lease, so returned or timed-out hooks cannot overwrite a successor's status.

This replaces single-holder route removal and duplicated restart dispatch. There is no expiration timer or second HTTP dispatcher. The final terminal/status repair removes six production lines by reusing the existing lease owner.

## User Impact

Webhook senders can retry through reload without a Gateway restart. A retry response does not acknowledge delivery. Shared accounts, manual stops and recoverable startup retain their distinct lifetimes. No public configuration keys, defaults, SDK fields, storage schema or wire protocol are added.

Maintainer-owned replacement for #137706, preserving contributor credit for @ylcn91 (Yalçın Doksanbir), whose proposal identified the ingress gap.

## Evidence

- Original-order regression coverage spans failed/cancelled rollback, partial-account rollback, retry outcomes, changed paths, shared-route retirement and reload during startup backoff. Prior focused runs passed 453 owner/integration tests and 263 final-main integration tests at their recorded revisions.
- Final repair `5003e2835666567d81b569b1665a5545b136daa0`: terminal-pending reproductions failed three cases before the fix; returned/timed-out stop writers failed two. All 146 channel-manager tests now pass, including shared live/pending siblings, recoverable waits, same-task ready recovery and valid active-stop diagnostics. Canonical core types, Gateway test types, typed lint and independent review pass.
- Exact final commit `5003e2835666567d81b569b1665a5545b136daa0` passed [CI run 33943694738](https://github.com/openclaw/openclaw/actions/runs/33943694738) and all **13 built-Gateway Linux groups** in [Testbox run 33943879771](https://github.com/openclaw/openclaw/actions/runs/33943879771). The clean build took 186.7 seconds; live proof took 43.7 seconds. Reload, aborted startup, independent/shared readiness, manual stop/resume, account removal, moved paths, automatic recovery, terminal-pending siblings, returned/timed-out stop writers and disable all passed. Gateway PID 9728 and boot ID `2182d871-d205-413c-9efc-2e8707384c29` stayed unchanged, with one operator hello and zero connection closes. No model calls occurred.
- Source/build commit matched the candidate; Git tree `e71ffdeddabef17b546edf615df7759cd87d2de9` matched before and after execution. The source carrier was `c39f910b43e6336ffb36da8eb584e6951b8f605c`. Both command and wrapper exited 0. Receipt archive: **23,603 bytes**, SHA-256 `6d3007bc15c9a9c3d8476386a3279cd2bceeed804659b5c3deb5dda8922ee27f`. Gateway, control server and temporary state cleanup passed. Provider: blacksmith-testbox; lease `tbx_01m1qw6xxhh0zpx6f98mv9b986`, stopped/completed. The external runner portal sync timed out after successful execution; the local archive was captured and independently verified.
- The preceding `056a714213cb154e19eccb50294b55f3cf03667e` passed nine real Gateway HTTP/WebSocket groups in [Testbox run 33940391216](https://github.com/openclaw/openclaw/actions/runs/33940391216) and its CI. The final run adds terminal-pending/shared-sibling and stale-stop-writer cases.

Production **+248 LOC**; tests/support **+818**; docs **+12**. Production growth represents explicit shared-route and replacement ownership; the former single-holder path and duplicated dispatch are removed. The proof uses a built Gateway and real HTTP/WebSocket with synthetic channels and traffic; external vendor-account delivery is not claimed.

## Review Disposition and Follow-up

ClawSweeper's rollback P1 is resolved at the rollback owner: abandoned handoffs retire before failure propagates, admitted siblings remain live, and unsuccessful starts remain in recovery. Its terminal-pending P2 is fixed by retiring on the current task's terminal report, preserving nonterminal waits and sibling holders. The connected stale-stop status bug is fixed at the stop-attempt lease. Red-to-green regressions and independent review cover both owners.

Named upstream follow-up: Matrix crypto 0.6.6's installer catches `ex` but references undefined `err`, masking a binary-download `ECONNRESET`. Direct installed-source inspection confirmed this unrelated setup failure; its one exact-job retry passed without product changes. No changelog edit: OpenClaw generates release notes from landed PR context.
