### PR TITLE
improve(memory): avoid redundant cache reads during reindexing

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-cache.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-cache.test.ts
@@ -69,9 +69,27 @@ describe("memory embedding cache", () => {
       upsertMemoryEmbeddingCache({
         db,
         enabled: true,
+        provider: { id: "local", model: "hf:owner/default.gguf" },
+        providerKey: "provider-key-current",
+        entries: [
+          { hash: "overlap", embedding: [1, 2] },
+          { hash: "empty", embedding: [] },
+          { hash: "invalid", embedding: [] },
+        ],
+      });
+      db.prepare("UPDATE memory_embedding_cache SET embedding = ? WHERE hash = ?").run(
+        "invalid JSON",
+        "invalid",
+      );
+      upsertMemoryEmbeddingCache({
+        db,
+        enabled: true,
         provider: { id: "local", model: "/cache/default.gguf" },
         providerKey: "provider-key-alias",
-        entries: [{ hash: "alias", embedding: [0.1, 0.2] }],
+        entries: ["alias", "overlap", "empty", "invalid"].map((hash) => ({
+          hash,
+          embedding: [0.1, 0.2],
+        })),
       });
       upsertMemoryEmbeddingCache({
         db,
@@ -96,14 +114,81 @@ describe("memory embedding cache", () => {
             providerKey: "provider-key-alias",
           },
         ],
-        hashes: ["alias", "arbitrary"],
+        hashes: ["alias", "arbitrary", "overlap", "empty", "invalid", "overlap", ""],
       });
 
-      expect(cached).toEqual(new Map([["alias", [0.1, 0.2]]]));
+      expect(cached).toEqual(
+        new Map([
+          ["overlap", [1, 2]],
+          ["empty", []],
+          ["invalid", []],
+          ["alias", [0.1, 0.2]],
+        ]),
+      );
+      const { missing } = collectMemoryCachedEmbeddings({
+        chunks: ["overlap", "empty", "invalid", "alias", "arbitrary"].map((hash) => ({ hash })),
+        cached,
+      });
+      expect(missing.map(({ chunk }) => chunk.hash)).toEqual(["empty", "invalid", "arbitrary"]);
     } finally {
       db.close();
     }
   });
+
+  it.each([0, 200, 401])(
+    "reads each requested cache row at most once with %i canonical hits",
+    (canonicalHits) => {
+      const db = createDb();
+      try {
+        const hashes = Array.from({ length: 401 }, (_, index) => `hash-${index}`);
+        const providerIdentities = Array.from({ length: 4 }, (_, index) => ({
+          provider: "local",
+          model: `model-${index}`,
+          providerKey: `provider-key-${index}`,
+        }));
+        for (const [index, identity] of providerIdentities.entries()) {
+          upsertMemoryEmbeddingCache({
+            db,
+            enabled: true,
+            provider: { id: identity.provider, model: identity.model },
+            providerKey: identity.providerKey,
+            entries: (index === 0 ? hashes.slice(0, canonicalHits) : hashes).map((hash) => ({
+              hash,
+              embedding: [index + 1],
+            })),
+          });
+        }
+        const reads: Array<{ bindings: number; rows: number }> = [];
+        const prepare = db.prepare.bind(db);
+        vi.spyOn(db, "prepare").mockImplementation((sql) => {
+          const statement = prepare(sql);
+          const all = statement.all.bind(statement);
+          vi.spyOn(statement, "all").mockImplementation((...bindings) => {
+            const rows = all(...bindings);
+            reads.push({ bindings: bindings.length, rows: rows.length });
+            return rows;
+          });
+          return statement;
+        });
+
+        const cached = loadMemoryEmbeddingCache({
+          db,
+          enabled: true,
+          providerIdentities,
+          hashes: [...hashes, ...hashes.slice(0, 1), ""],
+        });
+
+        expect(cached).toEqual(
+          new Map(hashes.map((hash, index) => [hash, [index < canonicalHits ? 1 : 2]])),
+        );
+        expect(reads.every(({ bindings }) => bindings <= 403)).toBe(true);
+        expect(reads.reduce((total, { rows }) => total + rows, 0)).toBe(hashes.length);
+        expect(reads.length).toBeLessThanOrEqual(2 + Math.ceil((401 - canonicalHits) / 400));
+      } finally {
+        db.close();
+      }
+    },
+  );
 
   it("reuses cached embeddings on forced reindex instead of scheduling new embeds", () => {
     const cached = new Map<string, number[]>([

--- a/extensions/memory-core/src/memory/manager-embedding-cache.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-cache.ts
@@ -23,16 +23,8 @@ export function loadMemoryEmbeddingCache(params: {
   if (!params.enabled || params.providerIdentities.length === 0 || params.hashes.length === 0) {
     return new Map();
   }
-  const unique: string[] = [];
-  const seen = new Set<string>();
-  for (const hash of params.hashes) {
-    if (!hash || seen.has(hash)) {
-      continue;
-    }
-    seen.add(hash);
-    unique.push(hash);
-  }
-  if (unique.length === 0) {
+  const unresolved = new Set(params.hashes.filter(Boolean));
+  if (unresolved.size === 0) {
     return new Map();
   }
 
@@ -40,9 +32,13 @@ export function loadMemoryEmbeddingCache(params: {
   const out = new Map<string, number[]>();
   const batchSize = 400;
   for (const identity of params.providerIdentities) {
+    if (unresolved.size === 0) {
+      break;
+    }
+    const hashes = [...unresolved];
     const baseParams: SQLInputValue[] = [identity.provider, identity.model, identity.providerKey];
-    for (let start = 0; start < unique.length; start += batchSize) {
-      const batch = unique.slice(start, start + batchSize);
+    for (let start = 0; start < hashes.length; start += batchSize) {
+      const batch = hashes.slice(start, start + batchSize);
       const placeholders = batch.map(() => "?").join(", ");
       const rows = params.db
         .prepare(
@@ -51,9 +47,9 @@ export function loadMemoryEmbeddingCache(params: {
         )
         .all(...baseParams, ...batch) as Array<{ hash: string; embedding: string }>;
       for (const row of rows) {
-        if (!out.has(row.hash)) {
-          out.set(row.hash, parseEmbedding(row.embedding));
-        }
+        // The first stored row wins even when its vector needs to be regenerated.
+        out.set(row.hash, parseEmbedding(row.embedding));
+        unresolved.delete(row.hash);
       }
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where memory indexing with a provider that declares equivalent model identities repeatedly loads embedding vectors already found in the cache. The default local embedding provider can declare several such aliases, so a complete cache hit still performs unnecessary database reads during reindexing.

## Why This Change Was Made

The existing embedding-cache reader now removes each resolved hash from the current lookup and asks subsequent identities only for missing rows. This replaces its separate deduplication structures with one operation-local set and preserves identity precedence, including empty or malformed canonical vectors that must be regenerated instead of replaced by an alias.

This changes only read selection. The cache writer, stored representation, schema, retention, provider identities, and SQLite index publication remain unchanged. Production code is four lines smaller; no new abstraction or configuration is added.

## User Impact

Memory indexing performs less SQLite work while retaining the same vectors, cache reuse, search results, and provider-alias migration behavior. Each statement retains the existing limit of 400 requested hashes.

## Evidence

The cache/identity suites passed 28 tests, the manager reopen suite passed both selected cases, and all required changed checks passed.

Real SQLite regression cases for zero, partial, and complete canonical hits all failed before the change because later aliases reread resolved rows. All now pass, together with the existing identity tests and the two public manager tests that close/reopen the index, search, and force reindex in both directions between canonical and cache-path identities.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  extensions/memory-core/src/memory/manager-embedding-cache.test.ts \
  extensions/memory-core/src/memory/manager-reindex-state.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  extensions/memory-core/src/memory/index.test.ts \
  -t 'indexes and embedding caches usable'
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- \
  extensions/memory-core/src/memory/manager-embedding-cache.ts \
  extensions/memory-core/src/memory/manager-embedding-cache.test.ts
```

A native `node:sqlite` probe used 401 requested hashes, four equivalent identities, and synthetic 512-coordinate vectors. It measured the actual owner before and after the change:

| Canonical hits | SELECTs before → after | Rows materialized before → after | Embedding bytes materialized before → after |
| --- | --- | --- | --- |
| 0 | 8 → 4 | 1,203 → 401 | 3,077,274 → 1,025,758 |
| 200 | 8 → 3 | 1,403 → 401 | 3,588,874 → 1,025,758 |
| 401 | 8 → 2 | 1,604 → 401 | 4,103,032 → 1,025,758 |

All cases returned the exact expected vectors; persisted cache rows were unchanged and SQLite integrity checks passed. These are query and payload counts, not a wall-clock latency claim. Tests also cover overlapping aliases, empty and malformed canonical vectors, undeclared identities, duplicate inputs, and the binding cap.

Independent Codex review found no actionable P0–P2 findings. Production LOC: +11/−15 (net −4); tests: +88/−3. Public CLI indexing/search proof passed with a normally registered deterministic local embedding plugin. Initial indexing embedded eight inputs; full cache hits, identity migration and partial alias reuse embedded zero; empty/invalid current vectors embedded exactly two. Gateway bootstrap then created USER.md: search indexed its ten new chunks while preserving all 32 original cache rows byte-for-byte. Subsequent fresh CLI searches embedded zero new inputs and preserved all 42 rows and search results.

The isolated combined checkout contained the four reviewed database-cleanup PRs; all affected source/test/docs files matched their PR commits exactly. The qaRuntime build and all ten process/native proof phases passed on Node 24.20.0. All synthetic state and listeners were removed. Initial harness-only fixture corrections are retained in the local proof record; production source stayed unchanged.

## Review follow-through

The requested isolated CLI reindex-and-search proof is complete: canonical cache reuse, equivalent-identity migration and missing-primary alias reuse each used zero new embeddings, with unchanged search ranking/snippets. Empty or malformed current vectors regenerated exactly two inputs. Fresh-process reopen preserved existing cache bytes; normal indexing of newly bootstrapped USER.md was verified separately. The PR is ready and its exact-head CI run passed.

The generated embedding-metadata flag does not represent a data-model change. The cache upsert and collector, schema, identity construction and embedding caller are byte-identical to the base; this diff only excludes already-resolved hashes from subsequent SELECTs. Existing SQLite rows and serialized vectors retain their representation.
