### PR TITLE
improve(acp): avoid reloading history when recording updates

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1594,7 +1594,7 @@ src/acp/control-plane/manager.runtime-resume-state.ts	2
 src/acp/control-plane/manager.ts	1
 src/acp/control-plane/manager.utils.ts	1
 src/acp/control-plane/runtime-options.ts	2
-src/acp/event-ledger.ts	8
+src/acp/event-ledger.ts	5
 src/acp/event-ledger.types.ts	1
 src/acp/event-mapper.ts	1
 src/acp/permission-relay.ts	1

--- a/src/acp/event-ledger.test.ts
+++ b/src/acp/event-ledger.test.ts
@@ -1,8 +1,12 @@
 /** Tests ACP event ledger recording, replay, retention, and SQLite persistence. */
 import path from "node:path";
+import { constants } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { createInMemoryAcpEventLedger, createSqliteAcpEventLedger } from "./event-ledger.js";
 
@@ -112,7 +116,7 @@ describe("ACP event ledger", () => {
     });
   });
 
-  it("persists SQLite-backed replay state across ledger instances", async () => {
+  it("persists replay without reading old payloads during session writes or rejected replays", async () => {
     await withTestDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
       const databasePath = path.join(dir, "openclaw.sqlite");
       const first = createSqliteAcpEventLedger({ path: databasePath, now: () => 1000 });
@@ -131,19 +135,66 @@ describe("ACP event ledger", () => {
           content: { type: "text", text: "Thinking" },
         },
       });
+      await expect(
+        first.readReplay({ sessionId: "session-1", sessionKey: "agent:main:work" }),
+      ).resolves.toMatchObject({ complete: true });
+
+      const session = {
+        sessionId: "session-1",
+        sessionKey: "agent:main:canonical-work",
+        cwd: "/new-work",
+        complete: false,
+      };
+      const { db } = openOpenClawStateDatabase({ path: databasePath });
+      // Payload access is unnecessary for append/metadata work and rejected
+      // replay; making it fail exposes accidental full-history hydration.
+      db.setAuthorizer((action, table, column) =>
+        action === constants.SQLITE_READ &&
+        table === "acp_replay_events" &&
+        column === "update_json"
+          ? constants.SQLITE_DENY
+          : constants.SQLITE_OK,
+      );
+      try {
+        await first.recordUpdate({
+          ...session,
+          runId: "run-1",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "Answer" },
+          },
+        });
+        await first.startSession(session);
+        await expect(
+          first.readReplay({ ...session, sessionKey: "agent:main:work" }),
+        ).resolves.toEqual({ complete: false, events: [] });
+        await first.markIncomplete(session);
+        await expect(first.readReplay(session)).resolves.toEqual({ complete: false, events: [] });
+        await expect(first.readReplayBySessionId(session)).resolves.toEqual({
+          complete: false,
+          events: [],
+        });
+        await first.startSession({ ...session, complete: true });
+      } finally {
+        db.setAuthorizer(null);
+      }
 
       closeOpenClawStateDatabaseForTest();
       const second = createSqliteAcpEventLedger({ path: databasePath });
-      const replay = await second.readReplay({
-        sessionId: "session-1",
-        sessionKey: "agent:main:work",
-      });
+      const replay = await second.readReplay(session);
 
       expect(replay.complete).toBe(true);
-      expect(replay.events).toHaveLength(1);
+      expect(replay.events.map((event) => [event.seq, event.sessionKey])).toEqual([
+        [1, "agent:main:work"],
+        [2, "agent:main:canonical-work"],
+      ]);
       expect(replay.events[0]?.update).toEqual({
         sessionUpdate: "agent_thought_chunk",
         content: { type: "text", text: "Thinking" },
+      });
+      expect(replay.events[1]?.update).toEqual({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Answer" },
       });
     });
   });

--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -1,7 +1,13 @@
 /** Persistent SQLite-backed ACP event ledger for session rehydration. */
 import type { DatabaseSync } from "node:sqlite";
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
 import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
   type OpenClawStateDatabaseOptions,
@@ -16,7 +22,6 @@ import {
   type AcpEventLedgerEntry,
   type AcpEventLedgerReplay,
   type AcpLedgerOptions,
-  type AcpLedgerSession,
   type AcpMutableLedgerState,
 } from "./event-ledger.types.js";
 
@@ -27,49 +32,14 @@ function normalizeSqliteInteger(value: number | bigint | null): number {
   return value === null ? 0 : sqliteNumber(value);
 }
 
-type AcpReplaySessionRow = {
-  session_id: string;
-  session_key: string;
-  cwd: string;
-  complete: number | bigint;
-  created_at: number | bigint;
-  updated_at: number | bigint;
-  next_seq: number | bigint;
-};
-
-type AcpReplayEventRow = {
-  session_id: string;
-  seq: number | bigint;
-  at: number | bigint;
-  session_key: string;
-  run_id: string | null;
-  update_json: string;
-};
-
-function sqliteRowToLedgerSession(db: DatabaseSync, row: AcpReplaySessionRow): AcpLedgerSession {
-  const events = db
-    .prepare(
-      `SELECT session_id, seq, at, session_key, run_id, update_json
-         FROM acp_replay_events
-        WHERE session_id = ?
-        ORDER BY seq ASC`,
-    )
-    .all(row.session_id)
-    .flatMap((eventRow) => {
-      const normalized = sqliteRowToLedgerEvent(eventRow as AcpReplayEventRow);
-      return normalized ? [normalized] : [];
-    });
-  return {
-    sessionId: row.session_id,
-    sessionKey: row.session_key,
-    cwd: row.cwd,
-    complete: normalizeSqliteInteger(row.complete) === 1,
-    createdAt: normalizeSqliteInteger(row.created_at),
-    updatedAt: normalizeSqliteInteger(row.updated_at),
-    nextSeq: normalizeSqliteInteger(row.next_seq),
-    events,
-  };
-}
+type AcpLedgerDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "acp_replay_sessions" | "acp_replay_events"
+>;
+type AcpReplayEventRow = Pick<
+  AcpLedgerDatabase["acp_replay_events"],
+  "session_id" | "seq" | "at" | "session_key" | "run_id" | "update_json"
+>;
 
 function sqliteRowToLedgerEvent(row: AcpReplayEventRow): AcpEventLedgerEntry | undefined {
   let update: unknown;
@@ -88,31 +58,29 @@ function sqliteRowToLedgerEvent(row: AcpReplayEventRow): AcpEventLedgerEntry | u
   });
 }
 
-function readSqliteSessionById(db: DatabaseSync, sessionId: string): AcpLedgerSession | undefined {
-  const row = db
-    .prepare(
-      `SELECT session_id, session_key, cwd, complete, created_at, updated_at, next_seq
-         FROM acp_replay_sessions
-        WHERE session_id = ?`,
-    )
-    .get(sessionId) as AcpReplaySessionRow | undefined;
-  return row ? sqliteRowToLedgerSession(db, row) : undefined;
+function sqliteSessionMetadataQuery(db: DatabaseSync) {
+  return getNodeSqliteKysely<AcpLedgerDatabase>(db)
+    .selectFrom("acp_replay_sessions")
+    .select(["session_id", "session_key", "cwd", "complete", "next_seq"]);
 }
 
-function readLatestCompleteSqliteSessionByKey(
-  db: DatabaseSync,
-  sessionKey: string,
-): AcpLedgerSession | undefined {
-  const row = db
-    .prepare(
-      `SELECT session_id, session_key, cwd, complete, created_at, updated_at, next_seq
-         FROM acp_replay_sessions
-        WHERE session_key = ? AND complete = 1
-        ORDER BY updated_at DESC, session_id ASC
-        LIMIT 1`,
-    )
-    .get(sessionKey) as AcpReplaySessionRow | undefined;
-  return row ? sqliteRowToLedgerSession(db, row) : undefined;
+function readSqliteSessionById(db: DatabaseSync, sessionId: string) {
+  return executeSqliteQueryTakeFirstSync(
+    db,
+    sqliteSessionMetadataQuery(db).where("session_id", "=", sessionId),
+  );
+}
+
+function readLatestCompleteSqliteSessionByKey(db: DatabaseSync, sessionKey: string) {
+  return executeSqliteQueryTakeFirstSync(
+    db,
+    sqliteSessionMetadataQuery(db)
+      .where("session_key", "=", sessionKey)
+      .where("complete", "=", 1)
+      .orderBy("updated_at", "desc")
+      .orderBy("session_id", "asc")
+      .limit(1),
+  );
 }
 
 function upsertSqliteSession(
@@ -125,12 +93,12 @@ function upsertSqliteSession(
     complete: boolean;
     reset?: boolean;
   },
-): AcpLedgerSession {
+): number {
   const now = state.now();
-  const existing = readSqliteSessionById(db, params.sessionId);
-  if (!params.reset && existing) {
+  const existing = params.reset ? undefined : readSqliteSessionById(db, params.sessionId);
+  if (existing) {
     const cwd = params.cwd || existing.cwd;
-    const complete = existing.complete || params.complete ? 1 : 0;
+    const complete = normalizeSqliteInteger(existing.complete) === 1 || params.complete ? 1 : 0;
     // SET expressions read the pre-update row, so the aggregate sheds the old
     // key/cwd lengths and gains the new ones; drift here would silently
     // unbound the byte budget.
@@ -147,13 +115,7 @@ function upsertSqliteSession(
       now,
       params.sessionId,
     );
-    return {
-      ...existing,
-      sessionKey: params.sessionKey,
-      cwd,
-      complete: complete === 1,
-      updatedAt: now,
-    };
+    return normalizeSqliteInteger(existing.next_seq);
   }
 
   if (params.reset) {
@@ -190,16 +152,7 @@ function upsertSqliteSession(
     now,
     rowBytes,
   );
-  return {
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-    cwd: params.cwd,
-    complete: params.complete,
-    createdAt: existing?.createdAt ?? now,
-    updatedAt: now,
-    nextSeq: 1,
-    events: [],
-  };
+  return 1;
 }
 
 // Session rows carry a running footprint aggregate (row overhead plus their
@@ -338,7 +291,7 @@ function appendSqliteUpdate(
     update: SessionUpdate;
   },
 ): void {
-  const session = upsertSqliteSession(db, state, {
+  const nextSeq = upsertSqliteSession(db, state, {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     cwd: "",
@@ -357,7 +310,7 @@ function appendSqliteUpdate(
      VALUES (?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     params.sessionId,
-    session.nextSeq,
+    nextSeq,
     now,
     params.sessionKey,
     params.runId ?? null,
@@ -375,21 +328,37 @@ function appendSqliteUpdate(
     params.sessionKey.length + eventBytes,
     params.sessionKey,
     now,
-    session.nextSeq + 1,
+    nextSeq + 1,
     params.sessionId,
   );
   trimSqliteLedger(db, state);
 }
 
-function buildSqliteReplay(session: AcpLedgerSession | undefined): AcpEventLedgerReplay {
-  if (!session?.complete) {
+function buildSqliteReplay(
+  db: DatabaseSync,
+  session: ReturnType<typeof readSqliteSessionById>,
+): AcpEventLedgerReplay {
+  if (!session || normalizeSqliteInteger(session.complete) !== 1) {
     return { complete: false, events: [] };
   }
+  // Only eligible replays load history; appends and session metadata changes
+  // must not decode all prior payloads while holding the write transaction.
+  const events = executeSqliteQuerySync(
+    db,
+    getNodeSqliteKysely<AcpLedgerDatabase>(db)
+      .selectFrom("acp_replay_events")
+      .select(["session_id", "seq", "at", "session_key", "run_id", "update_json"])
+      .where("session_id", "=", session.session_id)
+      .orderBy("seq", "asc"),
+  ).rows.flatMap((row) => {
+    const event = sqliteRowToLedgerEvent(row);
+    return event ? [event] : [];
+  });
   return {
     complete: true,
-    sessionId: session.sessionId,
-    sessionKey: session.sessionKey,
-    events: session.events.map((event) => cloneAcpLedgerValue(event)),
+    sessionId: session.session_id,
+    sessionKey: session.session_key,
+    events,
   };
 }
 
@@ -446,20 +415,20 @@ export function createSqliteAcpEventLedger(
     async readReplay(replayParams) {
       return read((db) => {
         const session = readSqliteSessionById(db, replayParams.sessionId);
-        if (session?.sessionKey !== replayParams.sessionKey) {
+        if (session?.session_key !== replayParams.sessionKey) {
           return { complete: false, events: [] };
         }
-        return buildSqliteReplay(session);
+        return buildSqliteReplay(db, session);
       });
     },
 
     async readReplayBySessionId(replayParams) {
-      return read((db) => buildSqliteReplay(readSqliteSessionById(db, replayParams.sessionId)));
+      return read((db) => buildSqliteReplay(db, readSqliteSessionById(db, replayParams.sessionId)));
     },
 
     async readReplayBySessionKey(replayParams) {
       return read((db) =>
-        buildSqliteReplay(readLatestCompleteSqliteSessionByKey(db, replayParams.sessionKey)),
+        buildSqliteReplay(db, readLatestCompleteSqliteSessionByKey(db, replayParams.sessionKey)),
       );
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where recording ACP session updates repeatedly loaded and decoded the session's entire earlier history. Recording 1,000 small updates materialized 499,500 old event rows, and even a rejected replay loaded payloads it would discard.

## Why This Change Was Made

The SQLite ledger now reads session metadata separately and loads event payloads only for an eligible replay. Session writes return only the next sequence they need; typed Kysely reads share one metadata projection and remove the unused full-session reconstruction and extra replay clone. Existing mutation, retention, schema, stored JSON, and transaction behavior stay unchanged.

## User Impact

Long ACP sessions perform less work while recording updates. Replay content, event ordering, key rebinding, incomplete-session fallback, and retention remain the same. The existing retention count scan still runs; this change does not make append constant-time.

## Evidence

The extended native persistence test fails on the original code because an authorizer denies unnecessary reads of old event payloads. It passes after the change, including session metadata updates, rejected replays, canonical-key rebinding, and database reopen. All 19 focused ledger and translator tests pass:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/acp/event-ledger.test.ts src/acp/translator.event-ledger.test.ts src/acp/translator.session-updates.test.ts
```

A separate native SQLite probe measured prior payload rows loaded during 500/1,000 appends: 124,750/499,500 before, zero/zero after. Full replay remained intact, and modifying one returned replay did not affect the reopened result. Production code decreases by 31 lines; the existing persistence test grows by 51 lines.

Changed checks passed for all three changed files; focused checks passed again after the final test-only assertion. Independent Codex review found no actionable P0–P2 findings. Live ACP stdio proof passed against a real isolated Gateway: /status, /help and /commands settled with visible replies. Fourteen persisted updates replayed exactly by ACP session ID and Gateway session key before and after restart, with unchanged raw bytes and next sequence. Native access-denial, retention/reset/rebinding and 500/1,000-append query-budget controls also passed.

Related: #124476 addresses separate Unicode byte accounting. This PR preserves all mutation SQL and retention formulas; the accounting change should remain independently reviewed.

The isolated combined checkout contained the four reviewed database-cleanup PRs; all affected source/test/docs files matched their PR commits exactly. The qaRuntime build and all ten process/native proof phases passed on Node 24.20.0. All synthetic state and listeners were removed. Initial harness-only fixture corrections are retained in the local proof record; production source stayed unchanged.
