### PR TITLE
fix(lmstudio): budget against the loaded instance context

### DIFF
--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -370,6 +370,25 @@ describe("lmstudio-models", () => {
     });
   });
 
+  it("keeps a loaded context above the default load length", () => {
+    const model = mapLmstudioWireEntry({
+      type: "llm",
+      key: "large-loaded-context",
+      max_context_length: 262_144,
+      loaded_instances: [{ id: "loaded", config: { context_length: 98_304 } }],
+    });
+
+    // The default load length only governs the JIT load request for unloaded
+    // models; a running instance decides its own serving context.
+    expect(model).toMatchObject({
+      id: "large-loaded-context",
+      contextWindow: 262_144,
+      contextTokens: 98_304,
+      maxTokens: SELF_HOSTED_DEFAULT_MAX_TOKENS,
+      loaded: true,
+    });
+  });
+
   it("resolves reasoning capability for supported and unsupported options", () => {
     expect(resolveLmstudioReasoningCapability({ capabilities: undefined })).toBe(false);
     expect(

--- a/extensions/lmstudio/src/models.ts
+++ b/extensions/lmstudio/src/models.ts
@@ -543,9 +543,13 @@ export function mapLmstudioWireEntry(entry: LmstudioModelWire): LmstudioModelBas
   const advertisedContextWindow = asPositiveSafeInteger(entry.max_context_length) ?? null;
   const contextWindow = advertisedContextWindow ?? SELF_HOSTED_DEFAULT_CONTEXT_WINDOW;
   // ModelDefinitionConfig keeps the native maximum in contextWindow. Runtime
-  // budgeting and preload prefer contextTokens, so cap that to the loaded instance.
+  // budgeting reads contextTokens, so it must reflect what the server actually
+  // serves: a loaded instance is authoritative for its own context, while an
+  // unloaded model is budgeted at the length JIT loading will request — the
+  // same clamp ensureLmstudioModelLoaded applies when it triggers the load.
   const effectiveContextWindow = loadedContextWindow ?? contextWindow;
-  const contextTokens = Math.min(effectiveContextWindow, LMSTUDIO_DEFAULT_LOAD_CONTEXT_LENGTH);
+  const contextTokens =
+    loadedContextWindow ?? Math.min(contextWindow, LMSTUDIO_DEFAULT_LOAD_CONTEXT_LENGTH);
   const rawDisplayName = entry.display_name?.trim();
   const reasoningCompat = resolveLmstudioReasoningCompat(entry);
   const trainedForToolUse = entry.capabilities?.trained_for_tool_use;


### PR DESCRIPTION
Fixes #138589.

## What Problem This Solves

Fixes an issue where LM Studio users who loaded a model above 64,000 context still received a 64,000-token OpenClaw budget, causing premature compaction despite allocating a larger serving context.

## Why This Change Was Made

Use a valid loaded instance context as the runtime budget. Keep the existing default-load cap for unloaded models. The retained budget also feeds the existing preload path, so an evicted model reloads to the capacity the runtime already expects, subject to the model's advertised maximum.

## User Impact

A model serving 98,304 tokens is budgeted at 98,304. Automatic reload preserves that target after eviction. This requires no new configuration option.

## Evidence

- All 55 mapper tests pass at PR head `405da2856e06e395fec33e5bdef5f4c5b7885db0`; the live baseline contrast below reproduces the faulty cap. Independent P2 review is clean, and exact-head CI run [33933064781](https://github.com/openclaw/openclaw/actions/runs/33933064781) passed.
- Real headless LM Studio (`llmster` 0.0.23-1) on isolated Linux, using pinned `Qwen3.5-0.8B-Q4_K_M`. This model exercises context metadata and reload behavior; this is not a model-quality or throughput comparison.
- The canonical baseline mapper and PR mapper consumed the same real server response:

| Server state | Baseline budget | PR budget |
| --- | ---: | ---: |
| One instance loaded at 98,304 | 64,000 | 98,304 |
| Model unloaded | 64,000 | 64,000 |

Real OpenClaw discovery returned 98,304. A production preload-wrapper request completed with `OK`. The test then unloaded that owned instance, confirmed no loaded instance remained, and separately confirmed unloaded discovery still returned 64,000. It retained the original discovered model object and reused the same wrapper for the second request.

That wrapper sent the actual reload request:

```json
{"model":"qwen3.5-0.8b","context_length":98304}
```

The native load endpoint returned HTTP 200, the server again reported a single 98,304-context instance, and the second completion returned `OK`. No manual reload or budget patch was applied after eviction. Both completions used 16 input and 2 output tokens.

Candidate and canonical-baseline source remained tracked-clean before and after the run. Models were unloaded and all 26 observed task processes were cleaned up, with zero survivors. Earlier attempts stopped during lab provisioning or transport; their failure evidence is retained separately. The behavior probe, source, model pins, and context assertions stayed fixed.
