### PR TITLE
improve(trajectory): keep capture trimming bounded

### DIFF
--- a/src/trajectory/runtime-store.sqlite.test.ts
+++ b/src/trajectory/runtime-store.sqlite.test.ts
@@ -121,6 +121,68 @@ describe("SQLite trajectory runtime store", () => {
     expect(events.map((event) => event.type)).toEqual(["event-3", "event-4"]);
   });
 
+  it("stops reading old event bodies once the retained byte window is full", async () => {
+    const history = Array.from({ length: 64 }, (_, index) =>
+      createTrajectoryEvent({ type: `old-${index}`, payloadSize: 64 * 1024 }),
+    );
+    appendSqliteTrajectoryRuntimeEvents({ sessionId: "session-1", storePath }, history);
+    const newest = createTrajectoryEvent({ type: "newest" });
+    const retained = [...history.slice(-2), newest];
+    const maxRuntimeBytes = retained.reduce(
+      (bytes, event) => bytes + Buffer.byteLength(JSON.stringify(event), "utf8") + 1,
+      0,
+    );
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: sqlitePath() });
+    const prepare = database.db.prepare.bind(database.db);
+    let materializedEvents = 0;
+    const prepareSpy = vi.spyOn(database.db, "prepare").mockImplementation((sql) => {
+      const statement = prepare(sql);
+      const iterate = statement.iterate.bind(statement);
+      vi.spyOn(statement, "iterate").mockImplementation(function* (...args) {
+        for (const row of iterate(...args)) {
+          if (typeof row.event_json === "string") {
+            materializedEvents += 1;
+          }
+          yield row;
+        }
+        return undefined;
+      });
+      return statement;
+    });
+    try {
+      appendSqliteTrajectoryRuntimeEvents({ maxRuntimeBytes, sessionId: "session-1", storePath }, [
+        newest,
+      ]);
+      expect(materializedEvents).toBeLessThanOrEqual(retained.length + 1);
+    } finally {
+      prepareSpy.mockRestore();
+    }
+    await expect(
+      loadSqliteTrajectoryRuntimeEvents({ sessionId: "session-1", storePath }),
+    ).resolves.toEqual(retained);
+  });
+
+  it.each([0, -1])("keeps the exact UTF-8 byte window with a %i-byte adjustment", async (delta) => {
+    const events = ["old", "middle", "newest"].map((type) => {
+      const event = createTrajectoryEvent({ type });
+      event.data = { payload: "日本語🦞".repeat(20) };
+      return event;
+    });
+    const maxRuntimeBytes = events
+      .slice(-2)
+      .reduce(
+        (bytes, event) => bytes + Buffer.byteLength(JSON.stringify(event), "utf8") + 1,
+        delta,
+      );
+    appendSqliteTrajectoryRuntimeEvents(
+      { maxRuntimeBytes, sessionId: "session-1", storePath },
+      events,
+    );
+    await expect(
+      loadSqliteTrajectoryRuntimeEvents({ sessionId: "session-1", storePath }),
+    ).resolves.toEqual(events.slice(delta === 0 ? -2 : -1));
+  });
+
   it("loads a bounded trailing window in storage order", () => {
     appendSqliteTrajectoryRuntimeEvents({ sessionId: "session-1", storePath }, [
       createTrajectoryEvent({ type: "event-1" }),

--- a/src/trajectory/runtime-store.sqlite.ts
+++ b/src/trajectory/runtime-store.sqlite.ts
@@ -9,6 +9,7 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
+  iterateSqliteQuerySync,
 } from "../infra/kysely-sync.js";
 import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
@@ -46,11 +47,6 @@ type SqliteTrajectoryRuntimeReadScope = Omit<
 
 type SqliteTrajectoryRuntimeEventRow = {
   event: TrajectoryEvent;
-  seq: number;
-};
-
-type TrajectoryRuntimeRow = {
-  event_json: string;
   seq: number;
 };
 
@@ -299,16 +295,26 @@ function trimSqliteTrajectoryRuntimeWindow(
   maxRuntimeBytes: number,
 ): void {
   const db = getTrajectoryKysely(database.db);
-  const rows = executeSqliteQuerySync(
+  const rows = iterateSqliteQuerySync(
     database.db,
     db
       .selectFrom("trajectory_runtime_events")
       .select(["seq", "event_json"])
       .where("session_id", "=", sessionId)
-      .orderBy("seq", "asc"),
-  ).rows;
-  const removableSeqs = oldestTrajectorySeqsPastByteWindow(rows, maxRuntimeBytes);
-  if (removableSeqs.length === 0) {
+      .orderBy("seq", "desc"),
+  );
+  let retainedBytes = 0;
+  let removeThroughSeq: number | undefined;
+  // Retention removes an oldest prefix. Stop once the newest suffix fills the
+  // UTF-8 byte budget, then close the iterator before deleting that prefix.
+  for (const row of rows) {
+    retainedBytes += Buffer.byteLength(row.event_json, "utf8") + 1;
+    if (!(retainedBytes <= maxRuntimeBytes)) {
+      removeThroughSeq = row.seq;
+      break;
+    }
+  }
+  if (removeThroughSeq === undefined) {
     return;
   }
   executeSqliteQuerySync(
@@ -316,28 +322,8 @@ function trimSqliteTrajectoryRuntimeWindow(
     db
       .deleteFrom("trajectory_runtime_events")
       .where("session_id", "=", sessionId)
-      .where("seq", "in", removableSeqs),
+      .where("seq", "<=", removeThroughSeq),
   );
-}
-
-function oldestTrajectorySeqsPastByteWindow(
-  rows: readonly TrajectoryRuntimeRow[],
-  maxRuntimeBytes: number,
-): number[] {
-  let totalBytes = rows.reduce((total, row) => total + trajectoryJsonlRowBytes(row.event_json), 0);
-  const removableSeqs: number[] = [];
-  for (const row of rows) {
-    if (totalBytes <= maxRuntimeBytes) {
-      break;
-    }
-    removableSeqs.push(row.seq);
-    totalBytes -= trajectoryJsonlRowBytes(row.event_json);
-  }
-  return removableSeqs;
-}
-
-function trajectoryJsonlRowBytes(eventJson: string): number {
-  return Buffer.byteLength(eventJson, "utf8") + 1;
 }
 
 function readTrajectoryEventTimestamp(event: TrajectoryEvent): number | undefined {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where flushing trajectory capture reloads every retained event body and builds a deletion parameter for every expired row. A sufficiently large backlog can exceed SQLite's bind limit and roll back the append instead of trimming the capture.

## Why This Change Was Made

The store now streams events newest first until it has identified the retained byte window, closes the iterator, and deletes the oldest prefix using one sequence cutoff. This removes the full result array, the deletion-ID array, and two helper functions while preserving the existing UTF-8 byte accounting, session scope, transaction, and retention policy.

## User Impact

Capture trimming reads fewer obsolete event bodies and its deletion query stays the same size as the backlog grows. Retained events and trajectory exports remain unchanged, including the case where the newest event alone exceeds the budget and nothing is retained.

## Evidence

The new materialization regression fails on the original implementation: 65 event bodies are read for a three-event retained suffix. The change reads four and preserves the same events. Exact and one-byte-below UTF-8 boundaries pass alongside the runtime recorder and export suites: 87 tests across three files. The final test-only lint correction was followed by a 16-test rerun and a successful complete changed gate.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/trajectory/runtime-store.sqlite.test.ts src/trajectory/runtime.test.ts src/trajectory/export.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs
```

A separate native Node 24.20.0 / SQLite 3.53.4 process probe verified the host's 250,000-variable limit at the accepted/rejected prepare boundary. With 250,000 synthetic old rows, the original append materialized 250,001 bodies, attempted 250,001 delete bindings, and rolled back with `too many SQL variables`. The candidate read two bodies, used two bindings, and retained the new event. This deliberately oversized fixture is not a claim that the default 10 MiB window normally reaches the host limit, and these counts are not a timing comparison.

Native controls also passed for sequence gaps, exact/oversized events, another session's isolation, deletion failure with rollback and retry, fresh-process reopen, and recorder flush through trajectory export. Instrumentation observed the native iterator return before DELETE. The composite session/sequence index serves both the reverse scan and range delete.

Independent Codex review found no actionable P0–P2 findings. Production LOC: +17/−31 (net −14); tests: +62/−0. Public CLI export proof passed on the combined candidate: 65 input rows required four payload visits to retain the same three events, and export contained those three runtime events plus the transcript event. Exact/one-byte-overflow budgets, sequence gaps, other-session isolation, injected rollback, retry and fresh-process reopen passed.

Related: #130877 changes export reader limits independently; this change stays in the capture retention owner.

The isolated combined checkout contained the four reviewed database-cleanup PRs; all affected source/test/docs files matched their PR commits exactly. The qaRuntime build and all ten process/native proof phases passed on Node 24.20.0. All synthetic state and listeners were removed. Initial harness-only fixture corrections are retained in the local proof record; production source stayed unchanged.

## Review follow-through

Maintainer disposition: accept this focused retention repair under the maintainer-authorized autonomous database cleanup and landing scope. The acting reviewer inspected the storage owner, recorder/export callers, sibling retention behavior and the native iterator contract, completed an independent Codex review, and verified the regression, live process proof and exact-head hosted CI before native landing. The protected maintainer label routes this decision to the maintainer workflow; no schema, retention-policy or configuration change is proposed.
