### PR TITLE
fix(channels): apply acknowledgement settings without reconnecting

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1150,7 +1150,7 @@ extensions/slack/src/monitor/message-handler/dispatch-streaming.ts	6
 extensions/slack/src/monitor/message-handler/dispatch.ts	1
 extensions/slack/src/monitor/message-handler/prepare-dm-history.ts	1
 extensions/slack/src/monitor/message-handler/prepare-thread-context.ts	1
-extensions/slack/src/monitor/message-handler/prepare.ts	2
+extensions/slack/src/monitor/message-handler/prepare.ts	1
 extensions/slack/src/monitor/message-handler/preview-finalize.ts	3
 extensions/slack/src/monitor/message-handler/subteam-mentions.ts	1
 extensions/slack/src/monitor/provider-support.ts	3

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1539,7 +1539,7 @@ Values:
 - `"off"` / `"none"`: never react.
 
 <Note>
-The default scope (`"group-mentions"`) does not fire ack reactions in direct messages or ambient room events. To see the configured `ackReaction` (for example `"eyes"`) on inbound Slack DMs and quiet room events, set `messages.ackReactionScope` to `"all"`. `messages.ackReactionScope` is read at Slack provider startup, so a gateway restart is needed for the change to take effect.
+The default scope (`"group-mentions"`) does not fire ack reactions in direct messages or ambient room events. To see the configured `ackReaction` (for example `"eyes"`) on inbound Slack DMs and quiet room events, set `messages.ackReactionScope` to `"all"`. Scope changes apply to the next message without reconnecting Slack.
 </Note>
 
 ```json5

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -604,9 +604,13 @@ back to OpenClaw.
 | Infrastructure            | Other `discovery` and `browser` settings, MCP Apps listener settings, `secrets.egressProxy`, `plugins.load`, `plugins.installs`                                                                                                                                    | **Yes**                                |
 
 Changes to `channels.defaults`, `channels.modelByChannel`, `messages.inbound`,
-`messages.ackReactionScope`, `commands`, `accessGroups`, `tts`, `surfaces`,
+`commands`, `accessGroups`, `tts`, `surfaces`,
 `acp.stream`, and `diagnostics.flags` restart loaded channel runtimes to refresh shared policy. Manually stopped accounts stay
 stopped, and the Gateway keeps running.
+
+`messages.ackReactionScope` applies to subsequent channel turns without reconnecting
+channels. Per-channel and per-account overrides still take precedence; turns
+already being processed retain their captured policy.
 
 Operation settings apply at their next use; they do not restart in-flight runs
 or recreate provisioned workers. Approval expiry changes affect newly issued

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -53,6 +53,13 @@ Internal OpenClaw runtime code follows the same direction: load config once at t
 
 Provider and channel execution paths must use the active runtime config snapshot, not a file snapshot returned for config readback or editing. File snapshots preserve source values such as SecretRef markers for UI and writes; provider callbacks need the resolved runtime view. When a helper may be called with either the active source snapshot or the active runtime snapshot, route through `selectApplicableRuntimeConfig()` before reading credentials.
 
+Retained channel monitors can bind `createRuntimeConfigReader(cfg)` from
+`openclaw/plugin-sdk/runtime-config-snapshot` once at startup. The reader follows
+runtime updates when the supplied config belongs to the active runtime, and
+preserves an explicitly scoped config otherwise, including when no runtime has
+been published yet. Read once per turn and carry that snapshot through admission
+and replies.
+
 ## Reusable runtime utilities
 
 Native command probes should use `runCommandWithTimeout` from

--- a/extensions/discord/src/monitor/message-dispatcher.ts
+++ b/extensions/discord/src/monitor/message-dispatcher.ts
@@ -5,6 +5,7 @@ import {
 } from "openclaw/plugin-sdk/channel-inbound";
 import { fanInChannelIngressLifecycles } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { createRuntimeConfigReader } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import type { Client } from "../internal/discord.js";
@@ -73,10 +74,7 @@ export function createDiscordMessageDispatcher(
     groupPolicy: params.discordConfig?.groupPolicy,
     defaultGroupPolicy: params.cfg.channels?.defaults?.groupPolicy,
   });
-  const ackReactionScope =
-    params.discordConfig?.ackReactionScope ??
-    params.cfg.messages?.ackReactionScope ??
-    "group-mentions";
+  const readConfig = createRuntimeConfigReader(params.cfg);
   const preflightDiscordMessageImpl = params.testing?.preflightDiscordMessage;
   const messageRunQueue = createDiscordMessageRunQueue({
     runtime: params.runtime,
@@ -150,72 +148,56 @@ export function createDiscordMessageDispatcher(
             return;
           }
           try {
-            if (entries.length === 1) {
-              const preflight =
-                preflightDiscordMessageImpl ??
-                (await loadMessagePreflightRuntime()).preflightDiscordMessage;
-              const ctx = await preflight({
-                ...params,
-                avatarResolver,
-                ackReactionScope,
-                groupPolicy,
-                abortSignal,
-                data: last.data,
-                client: last.client,
-                turnAdoptionLifecycle: admissionLifecycle,
-              });
-              if (abortSignal?.aborted) {
-                await ingress.cancel();
-                return;
-              }
-              if (!ctx) {
-                await ingress.settle();
-                return;
-              }
-              applyImplicitReplyBatchGate(ctx, params.replyToMode, false);
-              messageRunQueue.enqueue(buildDiscordInboundJob(ctx, { ingressSettlement: ingress }));
-              return;
+            const cfg = readConfig();
+            let data = last.data;
+            if (entries.length > 1) {
+              const combinedBaseText = entries
+                .map((entry) =>
+                  resolveDiscordMessageText(entry.data.message, { includeForwarded: false }),
+                )
+                .filter(Boolean)
+                .join("\n");
+              const syntheticMessage = Object.create(Object.getPrototypeOf(last.data.message), {
+                ...Object.getOwnPropertyDescriptors(last.data.message),
+                content: { value: combinedBaseText, enumerable: true, configurable: true },
+                attachments: { value: [], enumerable: true, configurable: true },
+                message_snapshots: {
+                  value: (last.data.message as { message_snapshots?: unknown }).message_snapshots,
+                  enumerable: true,
+                  configurable: true,
+                },
+                messageSnapshots: {
+                  value: (last.data.message as { messageSnapshots?: unknown }).messageSnapshots,
+                  enumerable: true,
+                  configurable: true,
+                },
+                rawData: {
+                  value: {
+                    ...(last.data.message as { rawData?: Record<string, unknown> }).rawData,
+                  },
+                  enumerable: true,
+                  configurable: true,
+                },
+              }) as DiscordMessageEvent["message"];
+              data = {
+                ...last.data,
+                message: syntheticMessage,
+              };
             }
-            const combinedBaseText = entries
-              .map((entry) =>
-                resolveDiscordMessageText(entry.data.message, { includeForwarded: false }),
-              )
-              .filter(Boolean)
-              .join("\n");
-            const syntheticMessage = Object.create(Object.getPrototypeOf(last.data.message), {
-              ...Object.getOwnPropertyDescriptors(last.data.message),
-              content: { value: combinedBaseText, enumerable: true, configurable: true },
-              attachments: { value: [], enumerable: true, configurable: true },
-              message_snapshots: {
-                value: (last.data.message as { message_snapshots?: unknown }).message_snapshots,
-                enumerable: true,
-                configurable: true,
-              },
-              messageSnapshots: {
-                value: (last.data.message as { messageSnapshots?: unknown }).messageSnapshots,
-                enumerable: true,
-                configurable: true,
-              },
-              rawData: {
-                value: { ...(last.data.message as { rawData?: Record<string, unknown> }).rawData },
-                enumerable: true,
-                configurable: true,
-              },
-            }) as DiscordMessageEvent["message"];
-            const syntheticData: DiscordMessageEvent = {
-              ...last.data,
-              message: syntheticMessage,
-            };
             const preflight =
               preflightDiscordMessageImpl ??
               (await loadMessagePreflightRuntime()).preflightDiscordMessage;
             const ctx = await preflight({
               ...params,
+              cfg,
               avatarResolver,
-              ackReactionScope,
+              ackReactionScope:
+                params.discordConfig?.ackReactionScope ??
+                cfg.messages?.ackReactionScope ??
+                "group-mentions",
               groupPolicy,
               abortSignal,
-              data: syntheticData,
+              data,
               client: last.client,
               turnAdoptionLifecycle: admissionLifecycle,
             });
@@ -227,9 +209,9 @@ export function createDiscordMessageDispatcher(
               await ingress.settle();
               return;
             }
-            applyImplicitReplyBatchGate(ctx, params.replyToMode, true);
+            applyImplicitReplyBatchGate(ctx, params.replyToMode, entries.length > 1);
             const ids = entries.map((entry) => entry.data.message?.id).filter(isNonEmptyString);
-            if (ids.length > 0) {
+            if (entries.length > 1 && ids.length > 0) {
               const ctxBatch = ctx as typeof ctx & {
                 MessageSids?: string[];
                 MessageSidFirst?: string;

--- a/extensions/discord/src/monitor/message-handler.ack-policy.test.ts
+++ b/extensions/discord/src/monitor/message-handler.ack-policy.test.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { describe, expect, it } from "vitest";
+import {
+  createDiscordMessageHandler,
+  preflightDiscordMessageMock,
+  processDiscordMessageMock,
+} from "./message-handler.module-test-helpers.js";
+import { createBaseDiscordMessageContext } from "./message-handler.test-harness.js";
+import { createDiscordHandlerParams } from "./message-handler.test-helpers.js";
+
+describe("Discord acknowledgement policy", () => {
+  it.each([undefined, "off"] as const)(
+    "captures current acknowledgement policy for each turn (account override: %s)",
+    async (accountScope) => {
+      preflightDiscordMessageMock.mockReset().mockResolvedValue(null);
+      processDiscordMessageMock.mockReset();
+      const params = createDiscordHandlerParams();
+      params.cfg.messages = { inbound: { debounceMs: 0 }, ackReactionScope: "off" };
+      params.discordConfig = { ...params.discordConfig, ackReactionScope: accountScope };
+      params.cfg.channels = { discord: params.discordConfig };
+      setRuntimeConfigSnapshot(params.cfg, params.cfg);
+      const context = await createBaseDiscordMessageContext();
+      const handler = createDiscordMessageHandler(params);
+      try {
+        for (const scope of ["off", "all", "off"] as const) {
+          const cfg = {
+            ...params.cfg,
+            messages: { ...params.cfg.messages, ackReactionScope: scope },
+          };
+          setRuntimeConfigSnapshot(cfg, cfg);
+          await handler({ ...context.data, message: context.message }, context.client);
+          expect(preflightDiscordMessageMock).toHaveBeenLastCalledWith(
+            expect.objectContaining({ cfg, ackReactionScope: accountScope ?? scope }),
+          );
+        }
+        expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(3);
+      } finally {
+        await handler.deactivate();
+        clearRuntimeConfigSnapshot();
+        await fs.rm(path.dirname(context.cfg.session!.store!), { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/extensions/matrix/src/matrix/monitor/handler-ingress-access.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-ingress-access.ts
@@ -3,6 +3,7 @@ import { mergePairLoopGuardConfig } from "openclaw/plugin-sdk/pair-loop-guard-ru
 import { resolveMatrixMonitorAccessState } from "./access-state.js";
 import { resolveMatrixAllowBotsMode } from "./handler-helpers.js";
 import { loadMatrixReactionEvents, loadMatrixSendModule } from "./handler-runtime.js";
+import type { createMatrixHandlerState } from "./handler-state.js";
 import type { MatrixHandlerRuntimeConfig } from "./handler-types.js";
 import type { MatrixLocationPayload } from "./location.js";
 import type { ReservedHistorySlot } from "./room-history.js";
@@ -30,10 +31,9 @@ export async function resolveMatrixIngressAccess(config: {
   isReactionEvent: boolean;
   readStoreAllowFrom: () => Promise<string[]>;
   shouldSendPairingReply: (senderId: string, created: boolean) => boolean;
-  resolveLiveAccountAllowlists: () => Promise<{
-    liveDmAllowFrom: string[];
-    liveGroupAllowFrom: string[];
-  }>;
+  resolveLiveAccountAllowlists: ReturnType<
+    typeof createMatrixHandlerState
+  >["resolveLiveAccountAllowlists"];
   roomHistoryTracker: ReturnType<typeof createRoomHistoryTracker>;
   commitInboundEventIfClaimed: () => Promise<void>;
 }) {
@@ -179,7 +179,7 @@ export async function resolveMatrixIngressAccess(config: {
       ? await readStoreAllowFrom()
       : [];
   const roomUsers = roomConfig?.users ?? [];
-  const { liveDmAllowFrom, liveGroupAllowFrom } = await resolveLiveAccountAllowlists();
+  const { liveCfg, liveDmAllowFrom, liveGroupAllowFrom } = await resolveLiveAccountAllowlists();
   const accessState = await resolveMatrixMonitorAccessState({
     allowFrom: liveDmAllowFrom,
     storeAllowFrom,
@@ -288,6 +288,8 @@ export async function resolveMatrixIngressAccess(config: {
   }
 
   return {
+    cfg: liveCfg,
+    liveDmAllowFrom,
     content,
     messageId,
     audioPreflightMode,

--- a/extensions/matrix/src/matrix/monitor/handler-ingress-content.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-ingress-content.ts
@@ -60,7 +60,6 @@ export async function resolveMatrixIngressContent(config: {
   const {
     client,
     core,
-    cfg,
     accountId,
     accountConfig,
     logger,
@@ -72,6 +71,8 @@ export async function resolveMatrixIngressContent(config: {
   } = handler;
 
   const {
+    cfg,
+    liveDmAllowFrom,
     content: accessContent,
     messageId,
     audioPreflightMode,
@@ -497,6 +498,8 @@ export async function resolveMatrixIngressContent(config: {
   const triggerSnapshot = preparedTrigger;
 
   return {
+    cfg,
+    liveDmAllowFrom,
     messageIngress,
     resolveMessageIngress,
     route: _route,

--- a/extensions/matrix/src/matrix/monitor/handler.reply-presentation.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.reply-presentation.test.ts
@@ -1,8 +1,10 @@
+import { shouldAckReaction } from "openclaw/plugin-sdk/channel-feedback";
 // Matrix tests cover the handler's reply presentation wiring.
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { prepareMatrixReplyPayload } from "../../outbound.js";
 import { installMatrixMonitorTestRuntime } from "../../test-runtime.js";
+import type { CoreConfig } from "../../types.js";
 import type { MatrixClient } from "../sdk.js";
 import { createMatrixDraftController } from "./handler-draft-controller.js";
 import { createMatrixReplyDispatcher } from "./handler-reply-dispatcher.js";
@@ -19,6 +21,7 @@ const editMessageMatrixMock = vi.hoisted(() => vi.fn(async () => "$edited"));
 const sendSingleTextMessageMatrixMock = vi.hoisted(() =>
   vi.fn(async () => ({ messageId: "$draft1", roomId: "!room" })),
 );
+const reactMatrixMessageMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
 
 vi.mock("../send.js", () => ({
   editMessageMatrix: editMessageMatrixMock,
@@ -28,7 +31,7 @@ vi.mock("../send.js", () => ({
     singleEventLimit: 4000,
     fitsInSingleEvent: true,
   })),
-  reactMatrixMessage: vi.fn(async () => {}),
+  reactMatrixMessage: reactMatrixMessageMock,
   resolveMatrixMentionsForBody: vi.fn(async () => ({})),
   sendMessageMatrix: sendMessageMatrixMock,
   sendSingleTextMessageMatrix: sendSingleTextMessageMatrixMock,
@@ -54,6 +57,7 @@ describe("matrix monitor handler reply presentation", () => {
     sendMessageMatrixMock.mockClear();
     editMessageMatrixMock.mockClear();
     sendSingleTextMessageMatrixMock.mockClear();
+    reactMatrixMessageMock.mockClear();
     deliverMatrixRepliesMock.mockReset().mockResolvedValue({
       messageIds: ["$reply1"],
       receipt: {
@@ -66,6 +70,45 @@ describe("matrix monitor handler reply presentation", () => {
       content: "delivered",
     });
   });
+
+  it.each([undefined, "off"] as const)(
+    "applies current acknowledgement scope while preserving account override %s",
+    async (accountScope) => {
+      const cfg: CoreConfig = {
+        messages: { ackReaction: "👀", ackReactionScope: "off" },
+        channels: {
+          matrix: {
+            dm: { allowFrom: ["*"] },
+            accounts: { ops: { ackReactionScope: accountScope } },
+          },
+        },
+      };
+      let currentConfig = cfg;
+      const dispatchInboundMessage = vi.fn(async () => ({
+        queuedFinal: false,
+        counts: { final: 0, block: 0, tool: 0 },
+      }));
+      const { handler } = createMatrixHandlerTestHarness({
+        cfg,
+        currentConfig: () => currentConfig,
+        shouldAckReaction,
+        dispatchInboundMessage,
+      });
+      for (const [index, scope] of (["off", "all", "off"] as const).entries()) {
+        currentConfig = { ...cfg, messages: { ...cfg.messages, ackReactionScope: scope } };
+        const eventId = `$reload-${index}`;
+        await handler(
+          "!room:example.org",
+          createMatrixTextMessageEvent({ eventId, body: "hello" }),
+        );
+        const reactions = reactMatrixMessageMock.mock.calls.filter((call) => call[1] === eventId);
+        expect(reactions.some((call) => call[2] === "👀")).toBe(
+          accountScope === undefined && scope === "all",
+        );
+      }
+      expect(dispatchInboundMessage).toHaveBeenCalledTimes(3);
+    },
+  );
 
   it("resolves a reply's presentation before the room delivery reads it", async () => {
     const runGate = createDeferred<void>();

--- a/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
@@ -109,7 +109,7 @@ type MatrixHandlerTestHarnessOptions = {
   runChannelInboundEvent?: MatrixMonitorHandlerParams["core"]["channel"]["inbound"]["run"];
   runPrepared?: MatrixRunPreparedMock;
   inboundDeduper?: MatrixMonitorHandlerParams["inboundDeduper"];
-  shouldAckReaction?: () => boolean;
+  shouldAckReaction?: MatrixMonitorHandlerParams["core"]["channel"]["reactions"]["shouldAckReaction"];
   enqueueSystemEvent?: (...args: unknown[]) => void;
   getRoomInfo?: MatrixMonitorHandlerParams["getRoomInfo"];
   getMemberDisplayName?: MatrixMonitorHandlerParams["getMemberDisplayName"];

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -52,7 +52,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
   const {
     client,
     core,
-    cfg,
+    cfg: startupConfig,
     accountId,
     runtime,
     logger,
@@ -91,11 +91,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     createChannelInboundEnvelopeBuilder: createChannelInboundEnvelopeBuilderImpl,
     resolveHumanDelayConfig: resolveHumanDelayConfigImpl,
   };
-  const contextVisibilityMode = resolveChannelContextVisibilityMode({
-    cfg,
-    channel: "matrix",
-    accountId,
-  });
   const handlerState = createMatrixHandlerState({
     core,
     accountId,
@@ -244,7 +239,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
                 ...prefix,
                 audioPreflightMode: shouldDeferMatrixAudioPreflightForRoomIngress({
                   content: prefix.content,
-                  cfg,
+                  cfg: startupConfig,
                 })
                   ? "defer"
                   : "run",
@@ -274,6 +269,8 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       }
 
       const {
+        cfg,
+        liveDmAllowFrom,
         route: _route,
         hasExplicitSessionBinding,
         roomConfig,
@@ -301,6 +298,11 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         effectiveRoomUsers,
         resolveMessageIngress,
       } = resolvedIngressResult;
+      const contextVisibilityMode = resolveChannelContextVisibilityMode({
+        cfg,
+        channel: "matrix",
+        accountId,
+      });
 
       // Keep the per-room ingress gate focused on ordering-sensitive state updates.
       // Prompt/session enrichment below can run concurrently after the history snapshot is fixed.
@@ -439,14 +441,11 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       });
       const { deliverReply, onReplyError, turnDispatcherOptions } = replyDispatcher;
       const pinnedMainDmOwner = isDirectMessage
-        ? await (async () => {
-            const { liveCfg, liveDmAllowFrom } = await handlerState.resolveLiveAccountAllowlists();
-            return resolvePinnedMainDmOwnerFromAllowlist({
-              dmScope: liveCfg.session?.dmScope,
-              allowFrom: liveDmAllowFrom,
-              normalizeEntry: normalizeMatrixUserId,
-            });
-          })()
+        ? resolvePinnedMainDmOwnerFromAllowlist({
+            dmScope: cfg.session?.dmScope,
+            allowFrom: liveDmAllowFrom,
+            normalizeEntry: normalizeMatrixUserId,
+          })
         : null;
 
       const inboundLastRouteSessionKey = resolveInboundLastRouteSessionKey({

--- a/extensions/signal/src/monitor/event-handler.control-lane.test.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.test.ts
@@ -268,6 +268,7 @@ describe("Signal active-run control lane", () => {
 
   it("does not promote or cancel an unauthorized abort", () => {
     const entry = {
+      cfg: {},
       senderName: "Alice",
       senderDisplay: "+15550001111",
       senderRecipient: "+15550001111",
@@ -291,6 +292,7 @@ describe("Signal active-run control lane", () => {
 
   it("shares one group control lane without merging normal sender batches", () => {
     const entry = {
+      cfg: {},
       senderName: "Alice",
       senderDisplay: "+15550001111",
       senderRecipient: "+15550001111",

--- a/extensions/signal/src/monitor/event-handler.control-lane.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.ts
@@ -10,9 +10,12 @@ import {
   normalizeCommandBody,
 } from "openclaw/plugin-sdk/command-auth-native";
 import { isAbortRequestText } from "openclaw/plugin-sdk/command-primitives-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { SignalIngressLifecycle } from "../signal-ingress.js";
 
 export type SignalInboundEntry = {
+  /** Admission, buffered dispatch, and retries share this receipt-time snapshot. */
+  cfg: OpenClawConfig;
   senderName: string;
   senderDisplay: string;
   senderRecipient: string;

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -2,6 +2,10 @@
 import { expectChannelInboundContextContract as expectInboundContextContract } from "openclaw/plugin-sdk/channel-contract-testing";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveSignalReplyContextWithPersistence } from "../reply-authors.js";
 import { resetSignalReplyAuthorsForTests } from "../reply-authors.test-helpers.js";
@@ -34,7 +38,6 @@ type DispatchInboundMessageMockParams = {
   };
 };
 
-type SendReactionSignalMockCall = [string, number, string, unknown];
 type TestDispatchResult = {
   queuedFinal: boolean;
   counts: Record<"tool" | "block" | "final", number>;
@@ -70,7 +73,9 @@ const {
   return {
     sendTypingMock: vi.fn(),
     sendReadReceiptMock: vi.fn(),
-    sendReactionSignalMock: vi.fn(async () => ({ ok: true })),
+    sendReactionSignalMock: vi.fn<typeof import("../send-reactions.js").sendReactionSignal>(
+      async () => ({ ok: true }),
+    ),
     enqueueSystemEventMock: vi.fn(),
     recordInboundSessionMock: vi.fn(),
     dispatchInboundMessageMock: vi.fn(
@@ -427,9 +432,7 @@ function receiveGroupMessage(
 }
 
 function sentReactionEmojis(): string[] {
-  return (sendReactionSignalMock.mock.calls as unknown as SendReactionSignalMockCall[]).map(
-    (call) => call[2],
-  );
+  return sendReactionSignalMock.mock.calls.map((call) => call[2]);
 }
 
 describe("signal createSignalEventHandler inbound context", () => {
@@ -945,18 +948,26 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(sendReactionSignalMock).not.toHaveBeenCalled();
   });
 
-  it("does not send Signal status reactions when ackReactionScope is off", async () => {
-    const handler = createTestHandler({
-      cfg: createStatusReactionConfig({
-        messages: { ackReactionScope: "off", statusReactions: { enabled: true } },
-      }),
-    });
-
-    await receiveDirectMessage(handler);
-    await nextTimerTick();
-
-    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
-    expect(sendReactionSignalMock).not.toHaveBeenCalled();
+  it("applies acknowledgement scope changes to the next Signal message", async () => {
+    const cfg = createStatusReactionConfig({ messages: { ackReactionScope: "off" } });
+    setRuntimeConfigSnapshot(cfg, cfg);
+    try {
+      const handler = createTestHandler({ cfg });
+      for (const [index, scope] of (["off", "direct", "off"] as const).entries()) {
+        const next = { ...cfg, messages: { ...cfg.messages, ackReactionScope: scope } };
+        setRuntimeConfigSnapshot(next, next);
+        const timestamp = 1700000000001 + index;
+        await receiveDirectMessage(handler, { timestamp });
+        for (let tick = 0; tick < 5; tick += 1) {
+          await nextTimerTick();
+        }
+        const reactions = sendReactionSignalMock.mock.calls.filter((call) => call[1] === timestamp);
+        expect(reactions.some((call) => call[2] === "👀")).toBe(scope === "direct");
+      }
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(3);
+    } finally {
+      clearRuntimeConfigSnapshot();
+    }
   });
 
   it("treats message-tool-only Signal replies as successful status outcomes", async () => {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -59,6 +59,7 @@ import { kindFromMime } from "openclaw/plugin-sdk/media-runtime";
 import { createChannelHistoryWindow } from "openclaw/plugin-sdk/reply-history";
 import { resolveBatchedReplyThreadingPolicy } from "openclaw/plugin-sdk/reply-reference";
 import { resolveAgentRoute, resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
+import { createRuntimeConfigReader } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
@@ -189,6 +190,7 @@ async function finalizeSignalStatusReaction(params: {
 }
 
 export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
+  const readConfig = createRuntimeConfigReader(deps.cfg);
   const groupsConfigPath = resolveChannelGroupsConfigPath({
     cfg: deps.cfg,
     channel: "signal",
@@ -199,6 +201,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   const activeEnqueueEntries = new WeakSet<SignalInboundEntry>();
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
+    const { cfg } = entry;
     const fromLabel = formatInboundFromLabel({
       isGroup: entry.isGroup,
       groupLabel: entry.groupName ?? undefined,
@@ -208,16 +211,16 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       directId: entry.senderDisplay,
     });
     const route = resolveSignalInboundRoute({
-      cfg: deps.cfg,
+      cfg,
       accountId: deps.accountId,
       isGroup: entry.isGroup,
       groupId: entry.groupId,
       senderPeerId: entry.senderPeerId,
     });
-    const storePath = resolveStorePath(deps.cfg.session?.store, {
+    const storePath = resolveStorePath(cfg.session?.store, {
       agentId: route.agentId,
     });
-    const envelopeOptions = resolveEnvelopeFormatOptions(deps.cfg);
+    const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
     const previousTimestamp = readSessionUpdatedAt({
       storePath,
       sessionKey: route.sessionKey,
@@ -266,7 +269,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           })
         : undefined;
     const replyToMode = resolveSignalReplyToMode({
-      cfg: deps.cfg,
+      cfg,
       accountId: deps.accountId,
       chatType: entry.isGroup ? "group" : "direct",
     });
@@ -347,19 +350,19 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     }
 
     const statusReactionTimestamp = resolveSignalStatusReactionTimestamp(entry);
-    const statusReactionsConfig = deps.cfg.messages?.statusReactions;
+    const statusReactionsConfig = cfg.messages?.statusReactions;
     const signalReactionLevel = resolveSignalReactionLevel({
-      cfg: deps.cfg,
+      cfg,
       accountId: route.accountId,
     });
-    const ackReaction = resolveAckReaction(deps.cfg, route.agentId, {
+    const ackReaction = resolveAckReaction(cfg, route.agentId, {
       channel: "signal",
       accountId: route.accountId,
     });
     const shouldSendStatusReaction = Boolean(
       ackReaction &&
       shouldAckReaction({
-        scope: deps.cfg.messages?.ackReactionScope,
+        scope: cfg.messages?.ackReactionScope,
         isDirect: !entry.isGroup,
         isGroup: entry.isGroup,
         isMentionableGroup: entry.isGroup,
@@ -371,7 +374,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       statusReactionTimestamp ?? "unknown"
     }`;
     const signalReactionOpts: SignalReactionOpts = {
-      cfg: deps.cfg,
+      cfg,
       ...(deps.baseUrl ? { baseUrl: deps.baseUrl } : {}),
       ...(deps.account ? { account: deps.account } : {}),
       ...(deps.accountId ? { accountId: deps.accountId } : {}),
@@ -419,7 +422,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
 
     const { onModelSelected, typingCallbacks, ...replyPipeline } =
       createChannelMessageReplyPipeline({
-        cfg: deps.cfg,
+        cfg,
         agentId: route.agentId,
         channel: "signal",
         accountId: route.accountId,
@@ -429,7 +432,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
               return;
             }
             await sendTypingSignal(ctxPayload.To, {
-              cfg: deps.cfg,
+              cfg,
               baseUrl: deps.baseUrl,
               account: deps.account,
               accountId: deps.accountId,
@@ -457,13 +460,13 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const dispatcherOptions: NonNullable<ChannelInboundTurnPlan["dispatcherOptions"]> = {
       ...replyPipeline,
       propagateRetryableNoSendFailure: true,
-      humanDelay: resolveHumanDelayConfig(deps.cfg, route.agentId),
+      humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
       typingCallbacks,
     };
     const delivery: ChannelInboundTurnPlan["delivery"] = {
       deliver: async (payload, _info) => {
         await deps.deliverReplies({
-          cfg: deps.cfg,
+          cfg,
           replies: [payload],
           target: ctxPayload.To,
           baseUrl: deps.baseUrl,
@@ -526,7 +529,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           raw: entry,
         }),
         resolveTurn: () => ({
-          cfg: deps.cfg,
+          cfg,
           channel: "signal",
           accountId: route.accountId,
           route: { agentId: route.agentId, sessionKey: route.sessionKey },
@@ -545,7 +548,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
                       return undefined;
                     }
                     const pinnedOwner = resolvePinnedMainDmOwnerFromAllowlist({
-                      dmScope: deps.cfg.session?.dmScope,
+                      dmScope: cfg.session?.dmScope,
                       allowFrom: deps.allowFrom,
                       normalizeEntry: normalizeSignalAllowRecipient,
                     });
@@ -694,7 +697,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       return last.boundChannelIngress;
     }
     const route = resolveSignalInboundRoute({
-      cfg: deps.cfg,
+      cfg: last.cfg,
       accountId: deps.accountId,
       isGroup: last.isGroup,
       groupId: last.groupId,
@@ -841,6 +844,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   });
 
   async function handleReactionOnlyInbound(params: {
+    cfg: SignalEventHandlerDeps["cfg"];
     envelope: SignalEnvelope;
     sender: SignalSender;
     senderDisplay: string;
@@ -869,7 +873,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     if (
       conversationKey &&
       (await maybeResolveSignalApprovalReaction({
-        cfg: deps.cfg,
+        cfg: params.cfg,
         accountId: deps.accountId,
         conversationKey,
         messageId,
@@ -891,7 +895,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     if (
       conversationKey &&
       (await maybeResolveSignalQuestionReaction({
-        cfg: deps.cfg,
+        cfg: params.cfg,
         accountId: deps.accountId,
         conversationKey,
         messageId,
@@ -920,7 +924,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
 
     const senderPeerId = resolveSignalPeerId(params.sender);
     const route = resolveSignalInboundRoute({
-      cfg: deps.cfg,
+      cfg: params.cfg,
       accountId: deps.accountId,
       isGroup,
       groupId,
@@ -962,6 +966,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       return;
     }
 
+    const cfg = readConfig();
     let payload: SignalReceivePayload | null = preparedPayload ?? null;
     if (!preparedPayload) {
       try {
@@ -1018,7 +1023,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const messageText = normalizedMessage.trim();
     const groupId = dataMessage?.groupInfo?.groupId ?? reaction?.groupInfo?.groupId ?? undefined;
     const isGroup = Boolean(groupId);
-    const hasControlCommandInMessage = isControlCommandMessage(messageText, deps.cfg);
+    const hasControlCommandInMessage = isControlCommandMessage(messageText, cfg);
 
     const senderDisplay = formatSignalSenderDisplay(sender);
     const resolveChannelIngress = async (contextBinding?: ChannelIngressContextBinding) =>
@@ -1031,7 +1036,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         sender,
         groupId,
         isGroup,
-        cfg: deps.cfg,
+        cfg,
         hasControlCommand: hasControlCommandInMessage,
         contextBinding,
       });
@@ -1040,7 +1045,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const quoteText = normalizeOptionalString(dataMessage?.quote?.text) ?? "";
     const { contextVisibilityMode, quoteSenderAllowed, visibleQuoteText, visibleQuoteSender } =
       resolveSignalQuoteContext({
-        cfg: deps.cfg,
+        cfg,
         accountId: deps.accountId,
         isGroup,
         dataMessage,
@@ -1058,6 +1063,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     if (
       reaction &&
       (await handleReactionOnlyInbound({
+        cfg,
         envelope,
         sender,
         senderDisplay,
@@ -1092,7 +1098,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         accountId: deps.accountId,
         sendPairingReply: async (text) => {
           await sendMessageSignal(`signal:${senderRecipient}`, text, {
-            cfg: deps.cfg,
+            cfg,
             baseUrl: deps.baseUrl,
             account: deps.account,
             maxBytes: deps.mediaMaxBytes,
@@ -1130,7 +1136,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     }
 
     const route = resolveSignalInboundRoute({
-      cfg: deps.cfg,
+      cfg,
       accountId: deps.accountId,
       isGroup,
       groupId,
@@ -1153,14 +1159,14 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         : undefined;
     const signalToRaw = isGroup ? `group:${groupId}` : `signal:${senderRecipient}`;
     const signalTo = normalizeSignalMessagingTarget(signalToRaw) ?? signalToRaw;
-    const mentionRegexes = buildMentionRegexes(deps.cfg, route.agentId);
+    const mentionRegexes = buildMentionRegexes(cfg, route.agentId);
     const textWasMentioned = isGroup && matchesMentionPatterns(messageText, mentionRegexes);
     const nativeMentionFacts = resolveSignalMentionFacts(deps, rawMessage, dataMessage?.mentions);
     const wasMentioned = isGroup && (textWasMentioned || nativeMentionFacts.mentionsBot);
     const requireMention =
       isGroup &&
       resolveChannelGroupRequireMention({
-        cfg: deps.cfg,
+        cfg,
         channel: "signal",
         groupId,
         accountId: deps.accountId,
@@ -1223,7 +1229,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         sourceTimestamp: inboundTimestamp,
       });
       const signalGroupPolicy = resolveChannelGroupPolicy({
-        cfg: deps.cfg,
+        cfg,
         channel: "signal",
         groupId,
         accountId: deps.accountId,
@@ -1319,7 +1325,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     if (deps.sendReadReceipts && !deps.readReceiptsViaDaemon && !isGroup && inboundTimestamp) {
       try {
         await sendReadReceiptSignal(`signal:${senderRecipient}`, inboundTimestamp, {
-          cfg: deps.cfg,
+          cfg,
           baseUrl: deps.baseUrl,
           account: deps.account,
           accountId: deps.accountId,
@@ -1347,6 +1353,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       sourceTimestamp: inboundTimestamp,
     });
     const entry: SignalInboundEntry = {
+      cfg,
       senderName,
       senderDisplay,
       senderRecipient,

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -1,8 +1,13 @@
 // Slack tests cover monitor.tool result plugin behavior.
 import { CURRENT_MESSAGE_MARKER } from "openclaw/plugin-sdk/channel-mention-gating";
 import { expectPairingReplyText } from "openclaw/plugin-sdk/channel-test-helpers";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { HISTORY_CONTEXT_MARKER } from "openclaw/plugin-sdk/reply-history";
 import { resetInboundDedupe } from "openclaw/plugin-sdk/reply-runtime";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   defaultSlackTestConfig,
@@ -12,6 +17,7 @@ import {
   getSlackHandlers,
   flush,
   resetSlackTestState,
+  runSlackHandlerWithDispatch,
   runSlackMessageOnce,
   startSlackMonitor,
   stopSlackMonitor,
@@ -721,6 +727,44 @@ describe("monitorSlackProvider tool results", () => {
         }),
       { timeout: 5_000 },
     );
+  });
+
+  it("applies acknowledgement scope changes without reconnecting the running monitor", async () => {
+    const config: OpenClawConfig = {
+      messages: { ackReaction: "eyes", ackReactionScope: "off" },
+      channels: { slack: { dmPolicy: "open", allowFrom: ["*"] } },
+    };
+    slackTestState.config = config;
+    setRuntimeConfigSnapshot(config, config);
+    replyMock.mockResolvedValue({ text: "reply" });
+    const monitor = startSlackMonitor(monitorSlackProvider);
+    try {
+      const handler = await getSlackHandlerOrThrow("message");
+      for (const [index, scope] of (["off", "all", "off"] as const).entries()) {
+        const nextConfig: OpenClawConfig = {
+          ...config,
+          messages: { ...config.messages, ackReactionScope: scope },
+        };
+        setRuntimeConfigSnapshot(nextConfig, nextConfig);
+        await runSlackHandlerWithDispatch(handler, {
+          event: makeSlackMessageEvent({ ts: `200.${index}` }),
+        });
+        await vi.waitFor(() => expect(reactionAddMock).toHaveBeenCalledTimes(index === 0 ? 0 : 1));
+        expect(slackTestState.appStartMock).toHaveBeenCalledTimes(1);
+        expect(slackTestState.appStopMock).not.toHaveBeenCalled();
+      }
+      expect(reactionAddMock).toHaveBeenCalledWith({
+        channel: "C1",
+        timestamp: "200.1",
+        name: "eyes",
+      });
+    } finally {
+      try {
+        await stopSlackMonitor(monitor);
+      } finally {
+        clearRuntimeConfigSnapshot();
+      }
+    }
   });
 
   it("keeps ack reaction after sending the missing-reply fallback when status reactions are disabled", async () => {

--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -76,7 +76,6 @@ function createTestContext(params?: {
     },
     textLimit: 4000,
     typingReaction: "",
-    ackReactionScope: "group-mentions",
     mediaMaxBytes: 20 * 1024 * 1024,
   });
 }

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -118,7 +118,6 @@ export type SlackMonitorContext = {
   threadInheritParent: boolean;
   slashCommand: Required<import("openclaw/plugin-sdk/config-contracts").SlackSlashCommandConfig>;
   textLimit: number;
-  ackReactionScope: string;
   typingReaction: string;
   mediaMaxBytes: number;
 
@@ -222,7 +221,6 @@ export function createSlackMonitorContext(params: {
   threadInheritParent: SlackMonitorContext["threadInheritParent"];
   slashCommand: SlackMonitorContext["slashCommand"];
   textLimit: number;
-  ackReactionScope: string;
   typingReaction: string;
   mediaMaxBytes: number;
 }): SlackMonitorContext {
@@ -632,7 +630,6 @@ export function createSlackMonitorContext(params: {
     threadInheritParent: params.threadInheritParent,
     slashCommand: params.slashCommand,
     textLimit: params.textLimit,
-    ackReactionScope: params.ackReactionScope,
     typingReaction: params.typingReaction,
     mediaMaxBytes: params.mediaMaxBytes,
     logger,

--- a/extensions/slack/src/monitor/ingress.test.ts
+++ b/extensions/slack/src/monitor/ingress.test.ts
@@ -197,7 +197,6 @@ function attachBoltMemberIngress(params: {
       ephemeral: true,
     },
     textLimit: 4000,
-    ackReactionScope: "group-mentions",
     typingReaction: "",
     mediaMaxBytes: 1,
     threadHistoryScope: "thread",

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -9,6 +9,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type InboundDebounceFlush = { admission: Promise<void>; completion: Promise<void> };
 
+let useRealDebouncer = false;
+const realDebouncers: Array<{ drain: () => Promise<void> }> = [];
 const enqueueMock = vi.fn(async (_entry: unknown) => {});
 const flushKeyMock = vi.fn(async (_key: string) => {});
 const onFlushCallbacks: Array<
@@ -38,13 +40,15 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
   );
   return {
     ...actual,
-    createChannelInboundDebouncer: (params: {
-      onFlush: (
-        entries: Array<Record<string, unknown>>,
-        createFlush: typeof createTestInboundDebounceFlush,
-      ) => InboundDebounceFlush;
-    }) => {
+    createChannelInboundDebouncer: (
+      params: Parameters<typeof actual.createChannelInboundDebouncer<Record<string, unknown>>>[0],
+    ) => {
       onFlushCallbacks.push(params.onFlush);
+      if (useRealDebouncer) {
+        const result = actual.createChannelInboundDebouncer(params);
+        realDebouncers.push(result.debouncer);
+        return result;
+      }
       return {
         debounceMs: 10,
         debouncer: {
@@ -100,18 +104,22 @@ function createContext(overrides?: {
 }
 
 function createHandlerWithTracker(overrides?: {
+  cfg?: OpenClawConfig;
+  abortSignal?: AbortSignal;
   rememberSlackChannelType?: (
     channel: string | null | undefined,
     channelType: string | null | undefined,
   ) => void;
 }) {
   const trackEvent = vi.fn();
+  const ctx = createContext(overrides);
   const handler = createSlackMessageHandler({
-    ctx: createContext(overrides),
+    ctx,
+    abortSignal: overrides?.abortSignal,
     account: { accountId: "default" } as Parameters<typeof createSlackMessageHandler>[0]["account"],
     trackEvent,
   });
-  return { handler, trackEvent };
+  return { handler, trackEvent, ctx };
 }
 
 async function handleDirectMessage(
@@ -130,6 +138,8 @@ async function handleDirectMessage(
 
 describe("createSlackMessageHandler", () => {
   beforeEach(() => {
+    useRealDebouncer = false;
+    realDebouncers.length = 0;
     clearRuntimeConfigSnapshot();
     enqueueMock.mockClear();
     flushKeyMock.mockClear();
@@ -148,6 +158,7 @@ describe("createSlackMessageHandler", () => {
     const updatedConfig: OpenClawConfig = {
       agents: { defaults: { thinkingDefault: "ultra", fastModeDefault: true } },
     };
+    setRuntimeConfigSnapshot(startupConfig, startupConfig);
     const context = createContext({ cfg: startupConfig });
     const handler = createSlackMessageHandler({
       ctx: context,
@@ -183,6 +194,7 @@ describe("createSlackMessageHandler", () => {
     const runtimeConfig: OpenClawConfig = { agents: { defaults: { thinkingDefault: "ultra" } } };
     const initialChannels = { C_OLD: { enabled: true } };
     const resolvedChannels = { C_RESOLVED: { enabled: true } };
+    setRuntimeConfigSnapshot(startupConfig, startupConfig);
     const context = createContext({ cfg: startupConfig });
     context.botUserId = "U_STALE";
     context.channelsConfig = initialChannels;
@@ -325,6 +337,7 @@ describe("createSlackMessageHandler", () => {
     const startupConfig: OpenClawConfig = { agents: { defaults: { thinkingDefault: "max" } } };
     const firstConfig: OpenClawConfig = { agents: { defaults: { thinkingDefault: "high" } } };
     const secondConfig: OpenClawConfig = { agents: { defaults: { thinkingDefault: "ultra" } } };
+    setRuntimeConfigSnapshot(startupConfig, startupConfig);
     const context = createContext({ cfg: startupConfig });
     const handler = createSlackMessageHandler({
       ctx: context,
@@ -911,7 +924,7 @@ describe("createSlackMessageHandler", () => {
     await Promise.all([handledFailure, flushFailure]);
   });
 
-  it("retries native session initialization conflicts", async () => {
+  it("retains the admitted batch config across native session conflict retries", async () => {
     dispatchPreparedSlackMessageMock.mockRejectedValueOnce(
       new Error("Slack dispatch failed", {
         cause: new Error(
@@ -919,7 +932,9 @@ describe("createSlackMessageHandler", () => {
         ),
       }),
     );
-    const { handler } = createHandlerWithTracker();
+    const cfg: OpenClawConfig = { messages: { ackReactionScope: "off" } };
+    setRuntimeConfigSnapshot(cfg, cfg);
+    const { handler } = createHandlerWithTracker({ cfg });
     await handler(
       {
         type: "message",
@@ -932,19 +947,105 @@ describe("createSlackMessageHandler", () => {
     );
 
     const entry = enqueueMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    enqueueMock.mockImplementation(async (retry) => runOnFlush([retry as Record<string, unknown>]));
     vi.useFakeTimers();
     try {
-      await expect(runOnFlush([entry])).rejects.toThrow("Slack dispatch failed");
+      const flush = runOnFlush([entry]).then(
+        () => "completed",
+        () => "failed",
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      const next: OpenClawConfig = { messages: { ackReactionScope: "all" } };
+      setRuntimeConfigSnapshot(next, next);
       await vi.advanceTimersByTimeAsync(1000);
-
-      expect(enqueueMock).toHaveBeenCalledTimes(2);
-      expect(enqueueMock.mock.calls[1]?.[0]).toMatchObject({
-        opts: {
-          retryAttempt: 1,
-        },
-      });
-      expect(enqueueMock.mock.calls[1]?.[0]).not.toHaveProperty("opts.dispatchCompletion");
+      expect(
+        prepareSlackMessageMock.mock.calls.map(
+          ([params]) => params?.ctx.cfg.messages?.ackReactionScope,
+        ),
+      ).toEqual(["off", "off"]);
+      expect(await flush).toBe("completed");
+      expect(enqueueMock).toHaveBeenCalledTimes(1);
     } finally {
+      vi.useRealTimers();
+      enqueueMock.mockImplementation(async () => {});
+    }
+  });
+
+  it("keeps later same-key messages behind a retry with the original policy", async () => {
+    useRealDebouncer = true;
+    const cfg: OpenClawConfig = { messages: { ackReactionScope: "off" } };
+    setRuntimeConfigSnapshot(cfg, cfg);
+    const abort = new AbortController();
+    const { handler } = createHandlerWithTracker({ cfg, abortSignal: abort.signal });
+    dispatchPreparedSlackMessageMock.mockRejectedValueOnce(
+      new Error("reply session initialization conflicted for agent:main:main"),
+    );
+    const message: Parameters<typeof handler>[0] = {
+      type: "message",
+      channel: "D1",
+      user: "U1",
+      ts: "123.001",
+      text: "first",
+    };
+    vi.useFakeTimers();
+    try {
+      const first = handler(message, { source: "message" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(prepareSlackMessageMock).toHaveBeenCalledTimes(1);
+      const next: OpenClawConfig = { messages: { ackReactionScope: "all" } };
+      setRuntimeConfigSnapshot(next, next);
+      const second = handler({ ...message, ts: "123.002", text: "second" }, { source: "message" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(prepareSlackMessageMock).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1000);
+      await Promise.all([first, second]);
+      expect(
+        prepareSlackMessageMock.mock.calls.map(
+          ([params]) => params?.ctx.cfg.messages?.ackReactionScope,
+        ),
+      ).toEqual(["off", "off", "all"]);
+    } finally {
+      abort.abort();
+      await Promise.all(realDebouncers.map((debouncer) => debouncer.drain()));
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["stop", "exhaust"] as const)("settles native retry ownership on %s", async (outcome) => {
+    useRealDebouncer = true;
+    const abort = new AbortController();
+    const { handler, ctx } = createHandlerWithTracker({ abortSignal: abort.signal });
+    const onError = vi.fn();
+    ctx.runtime.error = onError;
+    for (let attempt = 0; attempt < (outcome === "stop" ? 1 : 4); attempt += 1) {
+      dispatchPreparedSlackMessageMock.mockRejectedValueOnce(
+        new Error("reply session initialization conflicted for agent:main:main"),
+      );
+    }
+    vi.useFakeTimers();
+    try {
+      const handled = handler(
+        { type: "message", channel: "D1", user: "U1", ts: "123.003", text: "retry" },
+        { source: "message" },
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(prepareSlackMessageMock).toHaveBeenCalledTimes(1);
+      if (outcome === "stop") {
+        abort.abort(new Error("monitor stopped"));
+      }
+      await vi.advanceTimersByTimeAsync(3000);
+      await handled;
+      await Promise.all(realDebouncers.map((debouncer) => debouncer.drain()));
+      expect(prepareSlackMessageMock).toHaveBeenCalledTimes(outcome === "stop" ? 1 : 4);
+      expect(onError).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining(
+          outcome === "stop" ? "aborted" : "reply session initialization conflicted",
+        ),
+      );
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      abort.abort();
+      await Promise.all(realDebouncers.map((debouncer) => debouncer.drain()));
       vi.useRealTimers();
     }
   });

--- a/extensions/slack/src/monitor/message-handler.thread-resolution.test.ts
+++ b/extensions/slack/src/monitor/message-handler.thread-resolution.test.ts
@@ -99,7 +99,6 @@ describe("Slack message handler thread resolution", () => {
         },
         textLimit: 4000,
         typingReaction: "",
-        ackReactionScope: "group-mentions",
         mediaMaxBytes: 20 * 1024 * 1024,
       }),
       account: resolveSlackAccount({ cfg: {}, accountId: "thread-test" }),

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -6,11 +6,8 @@ import {
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
-import {
-  getRuntimeConfigSnapshot,
-  getRuntimeConfigSourceSnapshot,
-  selectApplicableRuntimeConfig,
-} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { createRuntimeConfigReader } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackSendIdentity } from "../send.js";
 import type { SlackMessageEvent } from "../types.js";
@@ -54,11 +51,7 @@ export type SlackMessageHandler = (
 
 type SlackDispatchCompletion = ReturnType<typeof createDeferred<void>>;
 
-type IngressSlackMessageOptions = Parameters<SlackMessageHandler>[1] & {
-  retryAttempt?: number;
-};
-
-type QueuedSlackMessageOptions = IngressSlackMessageOptions & {
+type QueuedSlackMessageOptions = Parameters<SlackMessageHandler>[1] & {
   dispatchCompletion?: Omit<SlackDispatchCompletion, "promise">;
 };
 
@@ -86,6 +79,7 @@ function shouldDebounceSlackMessage(message: SlackMessageEvent, cfg: SlackMonito
 export function createSlackMessageHandler(params: {
   ctx: SlackMonitorContext;
   account: ResolvedSlackAccount;
+  abortSignal?: AbortSignal;
   /** Called on each inbound event to update liveness tracking. */
   trackEvent?: () => void;
   /** Called after access/routing preparation accepts a human message. */
@@ -93,26 +87,15 @@ export function createSlackMessageHandler(params: {
   dispatchReplayGuard?: SlackMessageDispatchReplayGuard;
 }): SlackMessageHandler {
   const { ctx, account, trackEvent, onPrepared } = params;
-  const startupRuntimeConfig = getRuntimeConfigSnapshot();
-  const startupRuntimeSourceConfig = getRuntimeConfigSourceSnapshot();
-  // Bind snapshot ownership once so unrelated process-global config cannot replace scoped monitors.
-  const followsRuntimeConfig =
-    !startupRuntimeConfig ||
-    startupRuntimeConfig === ctx.cfg ||
-    (startupRuntimeSourceConfig !== null &&
-      selectApplicableRuntimeConfig({
-        inputConfig: ctx.cfg,
-        runtimeConfig: startupRuntimeConfig,
-        runtimeSourceConfig: startupRuntimeSourceConfig,
-      }) === startupRuntimeConfig);
+  const readConfig = createRuntimeConfigReader(ctx.cfg);
   const runtimeContexts = new WeakMap<
     NonNullable<SlackMonitorContext["cfg"]>,
     SlackMonitorContext
   >();
   const resolveRuntimeContext = (): SlackMonitorContext => {
     // Channel monitors outlive config reloads; pin one live snapshot per turn without reconnecting.
-    const runtimeConfig = getRuntimeConfigSnapshot();
-    if (!followsRuntimeConfig || !runtimeConfig || runtimeConfig === ctx.cfg) {
+    const runtimeConfig = readConfig();
+    if (runtimeConfig === ctx.cfg) {
       return ctx;
     }
     const cached = runtimeContexts.get(runtimeConfig);
@@ -139,264 +122,247 @@ export function createSlackMessageHandler(params: {
   }>({
     cfg: ctx.cfg,
     channel: "slack",
+    serializeImmediate: true,
     buildKey: (entry) =>
       buildSlackDebounceKey(entry.message, ctx.accountId, entry.opts.eventScope?.teamId),
     shouldDebounce: (entry) =>
       !entry.opts.eventScope && shouldDebounceSlackMessage(entry.message, ctx.cfg),
     onFlush: (entries, createFlush) =>
       createFlush({
+        lifecycle: {
+          abortSignal: AbortSignal.any(
+            [
+              params.abortSignal,
+              ...entries.map((entry) => entry.opts.turnAdoptionLifecycle?.abortSignal),
+            ].filter((signal) => signal !== undefined),
+          ),
+        },
         dispatch: async (admissionLifecycle) => {
-          const retryEntries = (sourceError: unknown): boolean => {
-            if (
-              !isRetryableSlackInboundError(sourceError) ||
-              entries.some((entry) => entry.opts.eventScope)
-            ) {
-              return false;
-            }
-            const nextEntries = entries
-              .map((entry) => {
-                // Relay delivery owns retry until its dispatch completion is acknowledged.
-                // Scheduling here as well can race the router redelivery and duplicate a reply.
-                if (entry.opts.dispatchCompletion) {
-                  return null;
-                }
-                const retryAttempt = entry.opts.retryAttempt ?? 0;
-                if (retryAttempt >= RETRYABLE_FLUSH_MAX_ATTEMPTS) {
-                  return null;
-                }
-                const { dispatchCompletion: _dispatchCompletion, ...retryOpts } = entry.opts;
-                return {
-                  ...entry,
-                  opts: {
-                    ...retryOpts,
-                    retryAttempt: retryAttempt + 1,
-                  },
-                };
-              })
-              .filter((entry) => entry !== null);
-            if (nextEntries.length === 0) {
-              return false;
-            }
-            const retryTimer = setTimeout(() => {
-              for (const entry of nextEntries) {
-                // Re-enter the normal inbound path so retry ordering and debouncing stay consistent.
-                void enqueueSlackMessage(entry.message, entry.opts).catch((err: unknown) => {
-                  ctx.runtime.error?.(
-                    `slack inbound retry enqueue failed: ${formatErrorMessage(err)}`,
-                  );
-                });
-              }
-            }, RETRYABLE_FLUSH_RETRY_DELAY_MS);
-            retryTimer.unref?.();
-            return true;
-          };
           const completions = entries
             .map((entry) => entry.opts.dispatchCompletion)
             .filter((completion) => completion !== undefined);
-          try {
-            await (async () => {
-              const flushedEntry = entries.at(-1);
-              if (flushedEntry) {
-                const teamId = flushedEntry.opts.eventScope?.teamId;
-                const flushedKey = buildSlackDebounceKey(
-                  flushedEntry.message,
-                  ctx.accountId,
-                  teamId,
-                );
-                const topLevelConversationKey = buildTopLevelSlackConversationKey(
-                  flushedEntry.message,
-                  ctx.accountId,
-                  teamId,
-                );
-                if (flushedKey && topLevelConversationKey) {
-                  const pendingKeys = pendingTopLevelDebounceKeys.get(topLevelConversationKey);
-                  if (pendingKeys) {
-                    pendingKeys.delete(flushedKey);
-                    if (pendingKeys.size === 0) {
-                      pendingTopLevelDebounceKeys.delete(topLevelConversationKey);
+          const runtimeContext = resolveRuntimeContext();
+          for (let retryAttempt = 0; ; retryAttempt += 1) {
+            try {
+              admissionLifecycle.abortSignal.throwIfAborted();
+              await (async () => {
+                const flushedEntry = entries.at(-1);
+                if (flushedEntry) {
+                  const teamId = flushedEntry.opts.eventScope?.teamId;
+                  const flushedKey = buildSlackDebounceKey(
+                    flushedEntry.message,
+                    ctx.accountId,
+                    teamId,
+                  );
+                  const topLevelConversationKey = buildTopLevelSlackConversationKey(
+                    flushedEntry.message,
+                    ctx.accountId,
+                    teamId,
+                  );
+                  if (flushedKey && topLevelConversationKey) {
+                    const pendingKeys = pendingTopLevelDebounceKeys.get(topLevelConversationKey);
+                    if (pendingKeys) {
+                      pendingKeys.delete(flushedKey);
+                      if (pendingKeys.size === 0) {
+                        pendingTopLevelDebounceKeys.delete(topLevelConversationKey);
+                      }
                     }
                   }
                 }
-              }
-              // Logical-identity claims: Slack sends message + app_mention twins with
-              // distinct event_ids for one post, so the durable queue cannot dedupe
-              // them. Same-flush twins share one claim and one logical message while
-              // retaining the latest event's routing and any earlier mention.
-              const claims: SlackMessageDispatchReplayClaim[] = [];
-              const claimedKeys = new Map<string, number>();
-              const surviving: typeof entries = [];
-              let latestSurviving: (typeof entries)[number] | undefined;
-              for (const entry of entries) {
-                const replayKey = buildSlackMessageDispatchReplayKey({
-                  accountId: ctx.accountId,
-                  channelId: entry.message.channel,
-                  ts: entry.message.ts,
-                  teamId: entry.opts.eventScope?.teamId,
-                });
-                if (!replayKey) {
-                  surviving.push(entry);
-                  latestSurviving = entry;
-                  continue;
-                }
-                const existingIndex = claimedKeys.get(replayKey);
-                if (existingIndex !== undefined) {
-                  const existing = surviving[existingIndex];
-                  const merged = {
-                    ...entry,
-                    opts: {
-                      ...entry.opts,
-                      ...(existing?.opts.source === "app_mention"
-                        ? { source: "app_mention" as const }
-                        : {}),
-                      ...(existing?.opts.wasMentioned ? { wasMentioned: true } : {}),
-                    },
-                  };
-                  surviving[existingIndex] = merged;
-                  latestSurviving = merged;
-                  continue;
-                }
-                const claim = await claimSlackMessageDispatchReplay({
-                  guard: dispatchReplayGuard,
-                  key: replayKey,
-                });
-                if (claim.kind === "claimed") {
-                  claims.push(claim.handle);
-                  claimedKeys.set(replayKey, surviving.length);
-                  surviving.push(entry);
-                  latestSurviving = entry;
-                }
-              }
-              const releaseClaims = (error?: unknown) => {
-                for (const handle of claims) {
-                  handle.release(error === undefined ? {} : { error });
-                }
-              };
-              const commitClaims = async () => {
-                for (const handle of claims) {
-                  await handle.commit();
-                }
-              };
-              const last = latestSurviving;
-              if (!last) {
-                releaseClaims();
-                return;
-              }
-              const combinedText =
-                surviving.length === 1
-                  ? (last.message.text ?? "")
-                  : surviving
-                      .map((entry) => entry.message.text ?? "")
-                      .filter(Boolean)
-                      .join("\n");
-              const combinedMentioned = surviving.some((entry) => Boolean(entry.opts.wasMentioned));
-              const syntheticMessage: SlackMessageEvent = {
-                ...last.message,
-                text: combinedText,
-              };
-              const { prepareSlackMessage, dispatchPreparedSlackMessage } =
-                await loadSlackMessagePipeline();
-              const {
-                dispatchCompletion: _completion,
-                awaitDispatch: _awaitDispatch,
-                turnAdoptionLifecycle,
-                ...lastOpts
-              } = last.opts;
-              let prepared: Awaited<ReturnType<typeof prepareSlackMessage>>;
-              let visibleDrop = false;
-              let settlementHandedOff = false;
-              try {
-                const runtimeContext = resolveRuntimeContext();
-                prepared = await prepareSlackMessage({
-                  ctx: runtimeContext,
-                  account,
-                  message: syntheticMessage,
-                  opts: {
-                    ...lastOpts,
-                    wasMentioned: combinedMentioned || last.opts.wasMentioned,
-                    onVisibleDrop: () => {
-                      visibleDrop = true;
-                    },
-                  },
-                });
-                if (!prepared) {
-                  if (visibleDrop) {
-                    // The gate already produced a sender-visible notice. Commit the
-                    // logical claim so a later message/app_mention twin cannot repeat it.
-                    await commitClaims();
-                    return;
+                // Logical-identity claims: Slack sends message + app_mention twins with
+                // distinct event_ids for one post, so the durable queue cannot dedupe
+                // them. Same-flush twins share one claim and one logical message while
+                // retaining the latest event's routing and any earlier mention.
+                const claims: SlackMessageDispatchReplayClaim[] = [];
+                const claimedKeys = new Map<string, number>();
+                const surviving: typeof entries = [];
+                let latestSurviving: (typeof entries)[number] | undefined;
+                for (const entry of entries) {
+                  const replayKey = buildSlackMessageDispatchReplayKey({
+                    accountId: ctx.accountId,
+                    channelId: entry.message.channel,
+                    ts: entry.message.ts,
+                    teamId: entry.opts.eventScope?.teamId,
+                  });
+                  if (!replayKey) {
+                    surviving.push(entry);
+                    latestSurviving = entry;
+                    continue;
                   }
-                  // Gated before dispatch: release so the surviving twin can run the
-                  // same gate; nothing visible was produced, so no duplicate risk.
+                  const existingIndex = claimedKeys.get(replayKey);
+                  if (existingIndex !== undefined) {
+                    const existing = surviving[existingIndex];
+                    const merged = {
+                      ...entry,
+                      opts: {
+                        ...entry.opts,
+                        ...(existing?.opts.source === "app_mention"
+                          ? { source: "app_mention" as const }
+                          : {}),
+                        ...(existing?.opts.wasMentioned ? { wasMentioned: true } : {}),
+                      },
+                    };
+                    surviving[existingIndex] = merged;
+                    latestSurviving = merged;
+                    continue;
+                  }
+                  const claim = await claimSlackMessageDispatchReplay({
+                    guard: dispatchReplayGuard,
+                    key: replayKey,
+                  });
+                  if (claim.kind === "claimed") {
+                    claims.push(claim.handle);
+                    claimedKeys.set(replayKey, surviving.length);
+                    surviving.push(entry);
+                    latestSurviving = entry;
+                  }
+                }
+                const releaseClaims = (error?: unknown) => {
+                  for (const handle of claims) {
+                    handle.release(error === undefined ? {} : { error });
+                  }
+                };
+                const commitClaims = async () => {
+                  for (const handle of claims) {
+                    await handle.commit();
+                  }
+                };
+                const last = latestSurviving;
+                if (!last) {
                   releaseClaims();
                   return;
                 }
-                await turnAdoptionLifecycle?.onSessionRouted?.(prepared.route.sessionKey);
-                // Commit at adoption (durable turn ownership), release on abandonment;
-                // deferred turns hand settlement to the reply lane with the claim held.
-                prepared.turnAdoptionLifecycle = {
-                  ...turnAdoptionLifecycle,
-                  admission: turnAdoptionLifecycle?.admission ?? "exclusive",
-                  abortSignal: turnAdoptionLifecycle?.abortSignal ?? admissionLifecycle.abortSignal,
-                  onAdopted: async () => {
-                    settlementHandedOff = true;
-                    await commitClaims();
-                    await turnAdoptionLifecycle?.onAdopted();
-                    await admissionLifecycle.onAdopted();
-                  },
-                  onDeferred: () => {
-                    turnAdoptionLifecycle?.onDeferred();
-                    const admissionAccepted = admissionLifecycle.onDeferred();
-                    if (admissionAccepted === false) {
-                      return false;
-                    }
-                    settlementHandedOff = true;
-                    return undefined;
-                  },
-                  onDeferredHeartbeat: () => {
-                    turnAdoptionLifecycle?.onDeferredHeartbeat?.();
-                    admissionLifecycle.onDeferredHeartbeat?.();
-                  },
-                  onAbandoned: () => {
-                    settlementHandedOff = true;
-                    releaseClaims();
-                    // Slack has no owner-local teardown gated on core claim release.
-                    void turnAdoptionLifecycle?.onAbandoned();
-                    void admissionLifecycle.onAbandoned();
-                  },
+                const combinedText =
+                  surviving.length === 1
+                    ? (last.message.text ?? "")
+                    : surviving
+                        .map((entry) => entry.message.text ?? "")
+                        .filter(Boolean)
+                        .join("\n");
+                const combinedMentioned = surviving.some((entry) =>
+                  Boolean(entry.opts.wasMentioned),
+                );
+                const syntheticMessage: SlackMessageEvent = {
+                  ...last.message,
+                  text: combinedText,
                 };
-                onPrepared?.(prepared);
-                if (surviving.length > 1) {
-                  const ids = surviving
-                    .map((entry) => entry.message.ts)
-                    .filter(Boolean) as string[];
-                  if (ids.length > 0) {
-                    prepared.ctxPayload.MessageSids = ids;
-                    prepared.ctxPayload.MessageSidFirst = ids[0];
-                    prepared.ctxPayload.MessageSidLast = ids[ids.length - 1];
+                const { prepareSlackMessage, dispatchPreparedSlackMessage } =
+                  await loadSlackMessagePipeline();
+                const {
+                  dispatchCompletion: _completion,
+                  awaitDispatch: _awaitDispatch,
+                  turnAdoptionLifecycle,
+                  ...lastOpts
+                } = last.opts;
+                let prepared: Awaited<ReturnType<typeof prepareSlackMessage>>;
+                let visibleDrop = false;
+                let settlementHandedOff = false;
+                try {
+                  prepared = await prepareSlackMessage({
+                    ctx: runtimeContext,
+                    account,
+                    message: syntheticMessage,
+                    opts: {
+                      ...lastOpts,
+                      wasMentioned: combinedMentioned || last.opts.wasMentioned,
+                      onVisibleDrop: () => {
+                        visibleDrop = true;
+                      },
+                    },
+                  });
+                  if (!prepared) {
+                    if (visibleDrop) {
+                      // The gate already produced a sender-visible notice. Commit the
+                      // logical claim so a later message/app_mention twin cannot repeat it.
+                      await commitClaims();
+                      return;
+                    }
+                    // Gated before dispatch: release so the surviving twin can run the
+                    // same gate; nothing visible was produced, so no duplicate risk.
+                    releaseClaims();
+                    return;
                   }
+                  await turnAdoptionLifecycle?.onSessionRouted?.(prepared.route.sessionKey);
+                  // Commit at adoption (durable turn ownership), release on abandonment;
+                  // deferred turns hand settlement to the reply lane with the claim held.
+                  prepared.turnAdoptionLifecycle = {
+                    ...turnAdoptionLifecycle,
+                    admission: turnAdoptionLifecycle?.admission ?? "exclusive",
+                    abortSignal:
+                      turnAdoptionLifecycle?.abortSignal ?? admissionLifecycle.abortSignal,
+                    onAdopted: async () => {
+                      settlementHandedOff = true;
+                      await commitClaims();
+                      await turnAdoptionLifecycle?.onAdopted();
+                      await admissionLifecycle.onAdopted();
+                    },
+                    onDeferred: () => {
+                      turnAdoptionLifecycle?.onDeferred();
+                      const admissionAccepted = admissionLifecycle.onDeferred();
+                      if (admissionAccepted === false) {
+                        return false;
+                      }
+                      settlementHandedOff = true;
+                      return undefined;
+                    },
+                    onDeferredHeartbeat: () => {
+                      turnAdoptionLifecycle?.onDeferredHeartbeat?.();
+                      admissionLifecycle.onDeferredHeartbeat?.();
+                    },
+                    onAbandoned: () => {
+                      settlementHandedOff = true;
+                      releaseClaims();
+                      // Slack has no owner-local teardown gated on core claim release.
+                      void turnAdoptionLifecycle?.onAbandoned();
+                      void admissionLifecycle.onAbandoned();
+                    },
+                  };
+                  onPrepared?.(prepared);
+                  if (surviving.length > 1) {
+                    const ids = surviving
+                      .map((entry) => entry.message.ts)
+                      .filter(Boolean) as string[];
+                    if (ids.length > 0) {
+                      prepared.ctxPayload.MessageSids = ids;
+                      prepared.ctxPayload.MessageSidFirst = ids[0];
+                      prepared.ctxPayload.MessageSidLast = ids[ids.length - 1];
+                    }
+                  }
+                  await dispatchPreparedSlackMessage(prepared);
+                  if (!turnAdoptionLifecycle && !settlementHandedOff) {
+                    await commitClaims();
+                  } else if (!settlementHandedOff) {
+                    // Dispatch finished without adoption or deferral (skip/no-reply):
+                    // deliberate terminal handling, release for gate-idempotent twins.
+                    releaseClaims();
+                  }
+                } catch (error) {
+                  releaseClaims(error);
+                  throw error;
                 }
-                await dispatchPreparedSlackMessage(prepared);
-                if (!turnAdoptionLifecycle && !settlementHandedOff) {
-                  await commitClaims();
-                } else if (!settlementHandedOff) {
-                  // Dispatch finished without adoption or deferral (skip/no-reply):
-                  // deliberate terminal handling, release for gate-idempotent twins.
-                  releaseClaims();
-                }
-              } catch (error) {
-                releaseClaims(error);
-                throw error;
+              })();
+              for (const completion of completions) {
+                completion.resolve();
               }
-            })();
-            for (const completion of completions) {
-              completion.resolve();
+              break;
+            } catch (error) {
+              if (
+                retryAttempt < RETRYABLE_FLUSH_MAX_ATTEMPTS &&
+                isRetryableSlackInboundError(error) &&
+                !entries.some((entry) => entry.opts.eventScope || entry.opts.dispatchCompletion)
+              ) {
+                // Keep batch/config ownership while retrying; shutdown must cancel its backoff.
+                await sleepWithAbort(
+                  RETRYABLE_FLUSH_RETRY_DELAY_MS,
+                  admissionLifecycle.abortSignal,
+                );
+                continue;
+              }
+              for (const completion of completions) {
+                completion.reject(error);
+              }
+              throw error;
             }
-          } catch (error) {
-            retryEntries(error);
-            for (const completion of completions) {
-              completion.reject(error);
-            }
-            throw error;
           }
         },
       }),
@@ -413,7 +379,7 @@ export function createSlackMessageHandler(params: {
 
   async function enqueueSlackMessage(
     message: SlackMessageEvent,
-    opts: IngressSlackMessageOptions,
+    opts: Parameters<SlackMessageHandler>[1],
   ): Promise<SlackDispatchCompletion | undefined> {
     if (opts.source === "message" && message.type !== "message") {
       return undefined;

--- a/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
@@ -67,7 +67,6 @@ export function createInboundSlackTestContext(params: {
       ephemeral: true,
     },
     textLimit: 4000,
-    ackReactionScope: "group-mentions",
     typingReaction: "",
     mediaMaxBytes: 1024,
   });

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1842,7 +1842,6 @@ describe("slack prepareSlackMessage inbound contract", () => {
     });
     slackCtx.resolveUserName = async () => ({ name: "Alice" });
     slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
-    slackCtx.ackReactionScope = "group-all";
 
     const prepared = await prepareMessageWith(slackCtx, defaultAccount, {
       channel: "C123",
@@ -1883,7 +1882,6 @@ describe("slack prepareSlackMessage inbound contract", () => {
     });
     slackCtx.resolveUserName = async () => ({ name: "Alice" });
     slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
-    slackCtx.ackReactionScope = "all";
 
     const prepared = await prepareMessageWith(slackCtx, defaultAccount, {
       channel: "C123",
@@ -5067,6 +5065,7 @@ describe("prepareSlackMessage sender prefix", () => {
       cfg: {
         agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
         channels: { slack: params.channels },
+        messages: { ackReactionScope: "off" },
       },
       accountId: "default",
       botToken: "xoxb",
@@ -5101,7 +5100,6 @@ describe("prepareSlackMessage sender prefix", () => {
       threadInheritParent: false,
       slashCommand: params.slashCommand,
       textLimit: 2000,
-      ackReactionScope: "off",
       mediaMaxBytes: 1000,
       logger: { info: vi.fn(), warn: vi.fn() },
       shouldDropMismatchedSlackEvent: () => false,

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -2,7 +2,6 @@
 import {
   resolveAckReaction,
   shouldAckReaction as shouldAckReactionGate,
-  type AckReactionScope,
 } from "openclaw/plugin-sdk/channel-feedback";
 import {
   buildChannelInboundEventContext,
@@ -1416,7 +1415,7 @@ export async function prepareSlackMessage(params: {
     Boolean(
       ackReaction &&
       shouldAckReactionGate({
-        scope: ctx.ackReactionScope as AckReactionScope | undefined,
+        scope: cfg.messages?.ackReactionScope,
         inboundEventKind,
         isDirect: isDirectMessage,
         isGroup: isRoomish,

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -309,7 +309,6 @@ const baseParams = () => ({
     ephemeral: true,
   },
   textLimit: 4000,
-  ackReactionScope: "group-mentions",
   typingReaction: "",
   mediaMaxBytes: 1,
   threadHistoryScope: "thread" as const,

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -397,7 +397,6 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const textLimit = resolveTextChunkLimit(cfg, "slack", account.accountId, {
     fallbackLimit: SLACK_TEXT_LIMIT,
   });
-  const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
   const typingReaction = slackCfg.typingReaction?.trim() ?? "";
   const mediaMaxBytes = (opts.mediaMaxMb ?? slackCfg.mediaMaxMb ?? 20) * 1024 * 1024;
   const slackDispatcher = resolveSlackProxyDispatcher();
@@ -638,7 +637,6 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     threadInheritParent,
     slashCommand,
     textLimit,
-    ackReactionScope,
     typingReaction,
     mediaMaxBytes,
   });
@@ -706,6 +704,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const handleSlackMessage = createSlackMessageHandler({
     ctx,
     account,
+    abortSignal: opts.abortSignal,
     trackEvent,
     onPrepared: (prepared) => presenceMonitor?.observe(prepared),
   });

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -351,7 +351,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: browser-safe Date timestamp validation and UTF-16 truncation primitives.
       // +3: capability catalog descriptors, entry factories, and native host context.
       // +2: canonical paragraph grouping and UTF-16 boundaries for channel-owned chunking.
-      4433,
+      // +1: retained runtime config reader preserves channel owner and scoped config identity.
+      4434,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -473,7 +474,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +4: defineFeatureContract, createFeatureClient, defineFeaturePlugin, defineControlUiPlugin.
       // +2: browser-safe Date timestamp validation and UTF-16 truncation primitives.
       // +2: canonical paragraph grouping and UTF-16 boundaries for channel-owned chunking.
-      2618,
+      // +1: retained runtime config reader preserves channel owner and scoped config identity.
+      2619,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/config/runtime-snapshot.test.ts
+++ b/src/config/runtime-snapshot.test.ts
@@ -8,6 +8,7 @@ import {
   setConfigResolutionFacts,
 } from "./resolution-facts.js";
 import {
+  createRuntimeConfigReader,
   finalizeRuntimeSnapshotWrite,
   getRuntimeConfigAppliedHash,
   hashRuntimeConfigValue,
@@ -141,7 +142,7 @@ describe("runtime snapshot state", () => {
   });
 
   it.each([false, true])(
-    "selects only matching runtime sources (resolution facts: %s)",
+    "selects and retains only matching runtime sources (resolution facts: %s)",
     (withFacts) => {
       const sourceConfig = createProviderConfigFixture();
       if (withFacts) {
@@ -154,6 +155,8 @@ describe("runtime snapshot state", () => {
           updatePlan: true,
         },
       };
+
+      const readUnbound = createRuntimeConfigReader(scopedResolvedConfig);
 
       expect(
         selectApplicableRuntimeConfig({
@@ -184,6 +187,16 @@ describe("runtime snapshot state", () => {
           runtimeSourceConfig: sourceConfig,
         }),
       ).toBe(foreignConfig);
+      setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+      const readRuntime = createRuntimeConfigReader(cloneConfigWithResolutionFacts(sourceConfig));
+      const readScoped = createRuntimeConfigReader(scopedResolvedConfig);
+      const readForeign = createRuntimeConfigReader(foreignConfig);
+      const nextConfig = { ...runtimeConfig, messages: { ackReactionScope: "all" as const } };
+      setRuntimeConfigSnapshot(nextConfig, nextConfig);
+      expect(readRuntime()).toBe(nextConfig);
+      expect(readScoped()).toBe(scopedResolvedConfig);
+      expect(readForeign()).toBe(foreignConfig);
+      expect(readUnbound()).toBe(scopedResolvedConfig);
     },
   );
 

--- a/src/config/runtime-snapshot.ts
+++ b/src/config/runtime-snapshot.ts
@@ -325,6 +325,15 @@ export function selectApplicableRuntimeConfig(params: {
   return inputConfig;
 }
 
+/** Bind a retained consumer to its current runtime owner while preserving scoped configs. */
+export function createRuntimeConfigReader(inputConfig: OpenClawConfig): () => OpenClawConfig {
+  const followsRuntimeConfig =
+    runtimeConfigSnapshot === inputConfig ||
+    (runtimeConfigSourceSnapshot !== null &&
+      configSnapshotsMatch(inputConfig, runtimeConfigSourceSnapshot));
+  return () => (followsRuntimeConfig ? runtimeConfigSnapshot : null) ?? inputConfig;
+}
+
 export function setRuntimeConfigSnapshotRefreshHandler(
   refreshHandler: RuntimeConfigSnapshotRefreshHandler | null,
 ): void {

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -283,7 +283,6 @@ function getReloadPolicyCatalog() {
         "channels.defaults",
         "channels.modelByChannel",
         "messages.inbound",
-        "messages.ackReactionScope",
         "commands",
         "accessGroups",
         "tts",

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -770,6 +770,21 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartChannels).toEqual(new Set(["telegram"]));
   });
 
+  it.each<[OpenClawConfig, OpenClawConfig]>([
+    [{}, { messages: { ackReactionScope: "all" } }],
+    [{ messages: { ackReactionScope: "all" } }, {}],
+    [{ messages: { ackReactionScope: "off" } }, { messages: { ackReactionScope: "all" } }],
+  ])(
+    "keeps running channels connected when acknowledgement scope changes: %j → %j",
+    (prev, next) => {
+      const paths = diffGatewayReloadPaths(prev, next, listConfigReloadRefinementPrefixes());
+      const plan = buildGatewayReloadPlan(paths);
+      expect(isNoopGatewayReloadPlan(plan)).toBe(true);
+      expect(plan.restartChannels).toEqual(new Set());
+      expect(plan.restartChannelAccounts).toEqual(new Map());
+    },
+  );
+
   const sharedChannelSettings = [
     {
       path: "tts",
@@ -817,12 +832,6 @@ describe("buildGatewayReloadPlan", () => {
       path: "messages.inbound",
       before: { messages: { inbound: { debounceMs: 100 } } },
       after: { messages: { inbound: { debounceMs: 500 } } },
-      empty: { messages: {} },
-    },
-    {
-      path: "messages.ackReactionScope",
-      before: { messages: { ackReactionScope: "group-mentions" } },
-      after: { messages: { ackReactionScope: "all" } },
       empty: { messages: {} },
     },
     {

--- a/src/plugin-sdk/runtime-config-snapshot.ts
+++ b/src/plugin-sdk/runtime-config-snapshot.ts
@@ -3,6 +3,7 @@
  */
 export {
   clearRuntimeConfigSnapshot,
+  createRuntimeConfigReader,
   getRuntimeConfigSnapshot,
   selectApplicableRuntimeConfig,
   setRuntimeConfigSnapshot,


### PR DESCRIPTION
## What Problem This Solves

Changing `messages.ackReactionScope` no longer reconnects loaded channel monitors. Subsequent turns use the new acknowledgement policy while admitted turns and retries retain their original configuration.

## Why This Change Was Made

One retained config reader follows the Gateway runtime only when its input belongs to that owner; explicitly scoped configs stay scoped. Slack keeps conflict retries inside its existing per-key queue, removing detached timer/re-enqueue state. Discord shares single/batch preflight, Matrix carries its existing live ingress facts, and Signal carries its receipt-time snapshot. Telegram and WhatsApp already read current turn config.

## User Impact

Global acknowledgement changes apply live across Slack, Discord, Signal, Matrix, Telegram and WhatsApp. Account overrides retain precedence; later messages cannot change the config of an admitted retry. No added config keys, defaults, storage or protocol. Only this existing prefix leaves the shared channel restart list.

Production **−34 LOC**, tests/support **+265**, docs **+11**, tooling **+2**. The shared reader uses an existing SDK subpath; #138556 uses the identical helper.

## Evidence

- Failed-before regressions cover stale policy in the affected adapters, planner classification and Slack retry ordering. **1,125 focused tests** passed on final production sources, **53** after fixture-only cleanup, and **471** after the actual-conflict rebase. Canonical types, lint, SDK/structural guards, dead-code and cycle checks passed. Final independent review is clean; exact-head CI is green.
- [Linux Crabbox run33923383886](https://github.com/openclaw/openclaw/actions/runs/33923383886) built commit `5d40d84b69de46e3029a5d990c7a837b7eaab59f` and passed **18 observations** across all six real plugins: off → all → off produced accepted acknowledgement counts **0 → 1 → 0**, with final replies and unchanged Gateway PID, boot, operator connection and channel start time in every fixture.
- The source receiver verified tree `0ab2dbdd50082d268302984e8f8ca67f7ce0c4a6`; build attribution uses the existing pre-build `GIT_COMMIT` input. Candidate and transport carrier are recorded separately. The **35,463-byte** archive matches SHA-256 `dfd455fda1cd15cbd45d69b03ae314f2c390f22b93fc71c086d4b802a752294c`. Command exit0; owned lease stopped/completed. An initial guard-only failure before build is retained in the archive.

Proof uses synthetic platform/model APIs with the real Gateway and plugins, not vendor accounts. WhatsApp counts accepted encrypted reaction stanzas, not decoded emoji. Its Crabline0.1.20 provider required three standard Baileys dictionary tokens; the proof uses a task-owned copy, hash-checked against the original, with the exact patch and four encoder/decoder checks archived. Installed dependencies remain unchanged; the owner-repository repair is being landed separately. Six nonfatal first-turn metadata snapshot warnings occurred; replies and acknowledgement transitions passed, and metadata was not probed.

ClawSweeper disposition: no introduced code findings. The requested combined exact-head proof is attached above, and the description now states the final behavior, validation and limits. Config compatibility is preserved as described above; no extra operator action is introduced.

### Main integration

Current head `5113fcd74ec38d9330f31de78fcfccaa8a8e5690` rebases the live-tested `5d40d84b69de46e3029a5d990c7a837b7eaab59f` onto current main. Range-diff shows only the SDK budget conflict resolution for two newly landed paragraph helpers; production changes are identical. Independent four-pass integration review, SDK surface check, and planner/runtime-snapshot suites passed. The Linux receipt above remains tied to its actual tested commit.

### Compatibility review disposition

The latest review flags external plugins that capture acknowledgement scope. Verified stable `v2026.9.1`: `messages` was a no-restart policy; the generic acknowledgement restart fallback was introduced on main by #138112. Removing that unreleased fallback does not regress the stable reload contract. Explicit plugin reload declarations remain honored. The documented live-reader contract is accepted for this change; the companion debounce work will additionally preserve conservative fallback per undeclared owner through existing reload metadata. The reported merge conflict is resolved and independently reviewed at5113. The proof archive was independently hash-verified locally; reviewer download limitations do not replace or invalidate the recorded real-Gateway evidence.
