### PR TITLE
feat(ui): render live dashboard gallery previews

### DIFF
--- a/ui/src/components/board/board-document.test.ts
+++ b/ui/src/components/board/board-document.test.ts
@@ -44,6 +44,13 @@ it("binds an acknowledged conversation only while the dashboard document is moun
   );
   await element.updateComplete;
   expect(element.querySelector("openclaw-board-view")).not.toBeNull();
+  element.gatewaySnapshot = {
+    client,
+    phase: "connected",
+    hello: { features: { methods: ["board.get"] } },
+  } as ApplicationGatewaySnapshot;
+  await element.updateComplete;
+  expect(request).toHaveBeenCalledTimes(2);
   element.remove();
   await element.updateComplete;
   expect(removeListener).toHaveBeenCalledOnce();
@@ -52,4 +59,34 @@ it("binds an acknowledged conversation only while the dashboard document is moun
   document.body.append(element);
   await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(4));
   expect(request).toHaveBeenLastCalledWith("board.get", { sessionKey: "global", agentId: "work" });
+});
+
+it("uses a prepared gallery session without describing it again", async () => {
+  const request = vi.fn(async (method: string) => {
+    if (method === "sessions.describe") {
+      throw new Error("prepared sessions must not be described");
+    }
+    return { sessionKey: "dashboard", revision: 1, tabs: [], widgets: [] };
+  });
+  const client = {
+    request,
+    addEventListener: vi.fn(() => vi.fn()),
+  } as unknown as GatewayBrowserClient;
+  const element = document.createElement("openclaw-board-document");
+  mounted.push(element);
+  element.preparedSession = { sessionKey: "dashboard", agentId: "main" };
+  element.gatewaySnapshot = {
+    client,
+    phase: "connected",
+    hello: { features: { methods: ["board.get"] } },
+  } as ApplicationGatewaySnapshot;
+  document.body.append(element);
+
+  await vi.waitFor(() =>
+    expect(request).toHaveBeenCalledWith("board.get", {
+      sessionKey: "dashboard",
+      agentId: "main",
+    }),
+  );
+  expect(request).toHaveBeenCalledOnce();
 });

--- a/ui/src/components/board/board-document.test.ts
+++ b/ui/src/components/board/board-document.test.ts
@@ -90,3 +90,63 @@ it("uses a prepared gallery session without describing it again", async () => {
   );
   expect(request).toHaveBeenCalledOnce();
 });
+
+it("keeps passive documents live while exposing only capability-free HTML", async () => {
+  const request = vi.fn(async () => ({
+    sessionKey: "dashboard",
+    revision: 1,
+    tabs: [{ tabId: "main", title: "Main", position: 0 }],
+    widgets: [
+      {
+        name: "status",
+        tabId: "main",
+        contentKind: "html",
+        sizeW: 12,
+        sizeH: 6,
+        position: 0,
+        grantState: "granted",
+        revision: 1,
+        frameUrl: "data:text/html,status",
+      },
+      {
+        name: "tools",
+        tabId: "main",
+        contentKind: "mcp-app",
+        sizeW: 12,
+        sizeH: 6,
+        position: 1,
+        grantState: "granted",
+        revision: 1,
+      },
+    ],
+  }));
+  const client = {
+    request,
+    addEventListener: vi.fn(() => vi.fn()),
+  } as unknown as GatewayBrowserClient;
+  const element = document.createElement("openclaw-board-document");
+  mounted.push(element);
+  element.passive = true;
+  element.preparedSession = { sessionKey: "dashboard", agentId: "main" };
+  element.gatewaySnapshot = {
+    client,
+    phase: "connected",
+    hello: {
+      auth: { role: "operator", scopes: ["operator.admin"] },
+      features: { methods: ["board.get", "board.widget.appView"] },
+    },
+  } as ApplicationGatewaySnapshot;
+  document.body.append(element);
+
+  const view = await vi.waitFor(() => {
+    const current = element.querySelector("openclaw-board-view");
+    expect(current).not.toBeNull();
+    return current!;
+  });
+  expect(view.active).toBe(true);
+  expect(view.bridgeEnabled).toBe(false);
+  expect(view.canMutate).toBe(false);
+  expect(view.canGrant).toBe(false);
+  expect(view.snapshot?.widgets.map((widget) => widget.name)).toEqual(["status"]);
+  expect(request).toHaveBeenCalledOnce();
+});

--- a/ui/src/components/board/board-document.ts
+++ b/ui/src/components/board/board-document.ts
@@ -43,6 +43,7 @@ type ProviderBinding = {
 export class OpenClawBoardDocument extends OpenClawLightDomElement {
   @property({ attribute: false }) gatewaySnapshot?: ApplicationGatewaySnapshot;
   @property({ attribute: false }) sessionKey: string | null = null;
+  @property({ attribute: false }) preparedSession: BoardGetParams | null = null;
   @property({ attribute: false }) onDocumentClose: (() => void) | null = null;
 
   @state() private documentState: DashboardDocumentState = "loading";
@@ -70,7 +71,11 @@ export class OpenClawBoardDocument extends OpenClawLightDomElement {
   }
 
   override updated(changed: PropertyValues<this>): void {
-    if (changed.has("sessionKey") || changed.has("gatewaySnapshot")) {
+    if (
+      changed.has("sessionKey") ||
+      changed.has("preparedSession") ||
+      changed.has("gatewaySnapshot")
+    ) {
       this.synchronizeProvider();
     }
   }
@@ -100,7 +105,7 @@ export class OpenClawBoardDocument extends OpenClawLightDomElement {
     if (!this.isConnected) {
       return;
     }
-    const sessionKey = this.sessionKey?.trim() ?? "";
+    const sessionKey = (this.preparedSession?.sessionKey ?? this.sessionKey)?.trim() ?? "";
     if (!sessionKey) {
       this.releaseProvider();
       this.documentState = "missing-session";
@@ -123,6 +128,7 @@ export class OpenClawBoardDocument extends OpenClawLightDomElement {
     if (
       this.binding?.client === client &&
       this.binding.sessionKey === sessionKey &&
+      (!this.preparedSession || this.binding.session.agentId === this.preparedSession.agentId) &&
       this.binding.capabilityKey === capabilityKey
     ) {
       this.providerLease?.update(client, snapshot.phase === "connected", capabilities);
@@ -131,23 +137,31 @@ export class OpenClawBoardDocument extends OpenClawLightDomElement {
     this.releaseProvider();
     this.documentState = "loading";
     const generation = this.bindingGeneration;
-    void this.bindProvider({ client, sessionKey, capabilityKey }, capabilities, generation);
+    void this.bindProvider(
+      { client, sessionKey, capabilityKey },
+      capabilities,
+      generation,
+      this.preparedSession,
+    );
   }
 
   private async bindProvider(
     binding: ProviderBinding,
     capabilities: ReturnType<OpenClawBoardDocument["providerCapabilities"]>,
     generation: number,
+    preparedSession: BoardGetParams | null,
   ): Promise<void> {
     try {
-      const described = await binding.client.request<{ session?: GatewaySessionRow | null }>(
-        "sessions.describe",
-        { key: binding.sessionKey },
-      );
+      const described = preparedSession
+        ? null
+        : await binding.client.request<{ session?: GatewaySessionRow | null }>(
+            "sessions.describe",
+            { key: binding.sessionKey },
+          );
       if (generation !== this.bindingGeneration) {
         return;
       }
-      if (!described.session) {
+      if (!preparedSession && !described?.session) {
         this.documentState = "not-found";
         return;
       }
@@ -155,7 +169,10 @@ export class OpenClawBoardDocument extends OpenClawLightDomElement {
       if (!current || current.client !== binding.client) {
         return;
       }
-      const session = { sessionKey: described.session.key, agentId: described.session.agentId };
+      const session = preparedSession ?? {
+        sessionKey: described!.session!.key,
+        agentId: described!.session!.agentId,
+      };
       const lease = acquireBoardProviderForSession(
         session,
         binding.client,

--- a/ui/src/components/board/board-document.ts
+++ b/ui/src/components/board/board-document.ts
@@ -45,6 +45,7 @@ export class OpenClawBoardDocument extends OpenClawLightDomElement {
   @property({ attribute: false }) sessionKey: string | null = null;
   @property({ attribute: false }) preparedSession: BoardGetParams | null = null;
   @property({ attribute: false }) onDocumentClose: (() => void) | null = null;
+  @property({ type: Boolean }) passive = false;
 
   @state() private documentState: DashboardDocumentState = "loading";
   @state() private snapshot?: BoardSnapshot;
@@ -298,19 +299,29 @@ export class OpenClawBoardDocument extends OpenClawLightDomElement {
         this.activeTabId = tabId;
       },
       frameLoadFailed: (name) => provider.refreshWidgetFrame(name),
-      widgetAppView: (name, revision) => provider.widgetAppView(name, revision),
-      refreshWidgetAppView: (name, revision) => provider.refreshWidgetAppView(name, revision),
+      ...(!this.passive
+        ? {
+            widgetAppView: (name, revision) => provider.widgetAppView(name, revision),
+            refreshWidgetAppView: (name, revision) => provider.refreshWidgetAppView(name, revision),
+          }
+        : {}),
     } satisfies BoardViewCallbacks;
+    // A gallery thumbnail may render saved HTML, but it must not bootstrap
+    // executable plugin surfaces or MCP App leases merely by entering view.
+    const renderSnapshot = this.passive
+      ? { ...snapshot, widgets: snapshot.widgets.filter((widget) => widget.contentKind === "html") }
+      : snapshot;
     return html`<openclaw-board-view
       .active=${true}
+      .bridgeEnabled=${!this.passive}
       .fitAutoContent=${true}
       .session=${session}
-      .snapshot=${snapshot}
+      .snapshot=${renderSnapshot}
       .activeTabId=${this.activeTabId}
       .widgetFrameUrl=${(name: string, revision: number) => provider.widgetFrameUrl(name, revision)}
       .callbacks=${callbacks}
-      .canMutate=${provider.canMutate}
-      .canGrant=${provider.canGrant}
+      .canMutate=${!this.passive && provider.canMutate}
+      .canGrant=${!this.passive && provider.canGrant}
     ></openclaw-board-view>`;
   }
 

--- a/ui/src/components/board/board-mcp-app-lifecycle.ts
+++ b/ui/src/components/board/board-mcp-app-lifecycle.ts
@@ -1,6 +1,7 @@
 import type { BoardWidget } from "../../lib/board/types.ts";
 import type { BoardWidgetAppViewState } from "../../lib/board/view-types.ts";
 import { formatUiError } from "../../lib/format-error.ts";
+import { NearViewportObserver } from "../near-viewport-observer.ts";
 
 const REFRESH_LEAD_MS = 5_000;
 type AppViewMode = "cached" | "refresh" | "expired";
@@ -14,59 +15,6 @@ function clearTimer(timer: number | undefined): undefined {
     window.clearTimeout(timer);
   }
   return undefined;
-}
-
-class NearViewportObserver {
-  private observer?: IntersectionObserver;
-  nearVisible = false;
-  target?: Element;
-
-  constructor(
-    private readonly marginPx: number,
-    private readonly visibilityChanged: () => void,
-  ) {}
-
-  observe(target: Element): void {
-    if (target === this.target) {
-      return;
-    }
-    this.disconnect();
-    this.target = target;
-    this.setNearVisible(this.isNearViewport(target));
-    if (typeof IntersectionObserver === "undefined") {
-      return;
-    }
-    this.observer = new IntersectionObserver(
-      (entries) => {
-        const entry = entries.at(-1);
-        if (!entry || entry.target !== this.target) {
-          return;
-        }
-        this.setNearVisible(entry.isIntersecting || this.isNearViewport(entry.target));
-      },
-      { rootMargin: `${this.marginPx}px 0px` },
-    );
-    this.observer.observe(target);
-  }
-
-  disconnect(): void {
-    this.observer?.disconnect();
-    this.observer = undefined;
-    this.target = undefined;
-    this.setNearVisible(false);
-  }
-
-  private setNearVisible(nearVisible: boolean): void {
-    if (nearVisible !== this.nearVisible) {
-      this.nearVisible = nearVisible;
-      this.visibilityChanged();
-    }
-  }
-
-  private isNearViewport(target: Element): boolean {
-    const bounds = target.getBoundingClientRect();
-    return bounds.bottom >= -this.marginPx && bounds.top <= window.innerHeight + this.marginPx;
-  }
 }
 
 type AppViewCallbacks = {

--- a/ui/src/components/board/board-view.ts
+++ b/ui/src/components/board/board-view.ts
@@ -86,6 +86,7 @@ class OpenClawBoardView extends OpenClawLightDomElement {
   @property({ attribute: false }) widgetFrameUrl?: BoardWidgetFrameUrl;
   @property({ attribute: false }) callbacks?: BoardViewCallbacks;
   @property({ type: Boolean }) active = true;
+  @property({ type: Boolean }) bridgeEnabled = true;
   @property({ type: Boolean }) canMutate = true;
   @property({ type: Boolean }) canGrant = true;
   @property({ type: Boolean }) fitAutoContent = false;
@@ -605,6 +606,7 @@ class OpenClawBoardView extends OpenClawLightDomElement {
                 .widgetFrameUrl=${this.widgetFrameUrl}
                 .callbacks=${this.cellCallbacks}
                 .active=${this.active}
+                .bridgeEnabled=${this.bridgeEnabled}
                 .dragging=${widget.name === this.gestureName}
                 .focusTabIndex=${widget.name === focusName ? 0 : -1}
                 .positionInSet=${(logicalPosition.get(widget.name) ?? 0) + 1}

--- a/ui/src/components/board/board-widget-cell.ts
+++ b/ui/src/components/board/board-widget-cell.ts
@@ -78,6 +78,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
   @property({ attribute: false }) widgetFrameUrl?: BoardWidgetFrameUrl;
   @property({ attribute: false }) callbacks?: BoardWidgetCellCallbacks;
   @property({ type: Boolean }) active = true;
+  @property({ type: Boolean }) bridgeEnabled = true;
   @property({ type: Boolean }) dragging = false;
   @property({ type: Number }) focusTabIndex = -1;
   @property({ type: Number }) positionInSet = 1;
@@ -106,6 +107,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
   });
   private readonly frame = new BoardWidgetFrameLifecycle({
     active: () => this.active,
+    bridgeEnabled: () => this.bridgeEnabled,
     connected: () => this.isConnected,
     context: () => this.context,
     refreshFrame: () => this.callbacks?.frameLoadFailed,

--- a/ui/src/components/board/board-widget-frame.ts
+++ b/ui/src/components/board/board-widget-frame.ts
@@ -52,6 +52,7 @@ type FrameRefresh = (name: string) => Promise<void>;
 
 type BoardWidgetFrameLifecycleHost = {
   active: () => boolean;
+  bridgeEnabled?: () => boolean;
   connected: () => boolean;
   context: () => ApplicationContext | undefined;
   refreshFrame: () => FrameRefresh | undefined;
@@ -412,6 +413,7 @@ export class BoardWidgetFrameLifecycle {
     return {
       frame,
       widget,
+      bridgeEnabled: this.host.bridgeEnabled?.() ?? true,
       sandboxOrigin: this.sandboxOrigin,
       sandboxUrl: frame.src,
       sourceOrigin: resolveGatewayHttpOrigin(

--- a/ui/src/components/near-viewport-observer.ts
+++ b/ui/src/components/near-viewport-observer.ts
@@ -1,0 +1,52 @@
+export class NearViewportObserver {
+  private observer?: IntersectionObserver;
+  nearVisible = false;
+  target?: Element;
+
+  constructor(
+    private readonly marginPx: number,
+    private readonly visibilityChanged: () => void,
+  ) {}
+
+  observe(target: Element): void {
+    if (target === this.target) {
+      return;
+    }
+    this.disconnect();
+    this.target = target;
+    this.setNearVisible(this.isNearViewport(target));
+    if (typeof IntersectionObserver === "undefined") {
+      return;
+    }
+    this.observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries.at(-1);
+        if (!entry || entry.target !== this.target) {
+          return;
+        }
+        this.setNearVisible(entry.isIntersecting || this.isNearViewport(entry.target));
+      },
+      { rootMargin: `${this.marginPx}px 0px` },
+    );
+    this.observer.observe(target);
+  }
+
+  disconnect(): void {
+    this.observer?.disconnect();
+    this.observer = undefined;
+    this.target = undefined;
+    this.setNearVisible(false);
+  }
+
+  private setNearVisible(nearVisible: boolean): void {
+    if (nearVisible !== this.nearVisible) {
+      this.nearVisible = nearVisible;
+      this.visibilityChanged();
+    }
+  }
+
+  private isNearViewport(target: Element): boolean {
+    const bounds = target.getBoundingClientRect();
+    return bounds.bottom >= -this.marginPx && bounds.top <= window.innerHeight + this.marginPx;
+  }
+}

--- a/ui/src/e2e/dashboard-gallery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-gallery.e2e.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -118,7 +119,7 @@ suite.define(() => {
       const capacityKey = "agent:main:dashboard:capacity";
       const capacityRequested = async () =>
         (await gateway.getRequests("board.get")).some(
-          (request) => request.params.sessionKey === capacityKey,
+          (request) => isRecord(request.params) && request.params.sessionKey === capacityKey,
         );
       expect(await capacityRequested()).toBe(false);
       const capacityCard = gallery.locator(`[data-dashboard-session="${capacityKey}"]`);

--- a/ui/src/e2e/dashboard-gallery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-gallery.e2e.test.ts
@@ -17,6 +17,12 @@ const dashboardRows = [
   ["agent:main:dashboard:ci-signal", "CI signal", "peter", "Peter", 42_000, "done"],
   ["agent:main:dashboard:community-pulse", "Community pulse", "mira", "Mira", 75_000, "done"],
   ["agent:main:dashboard:gateway-fleet", "Gateway fleet", "peter", "Peter", 130_000, "done"],
+  ["agent:main:dashboard:deployments", "Deployments", "mira", "Mira", 160_000, "done"],
+  ["agent:main:dashboard:incidents", "Incidents", "peter", "Peter", 190_000, "done"],
+  ["agent:main:dashboard:traffic", "Traffic", "mira", "Mira", 220_000, "done"],
+  ["agent:main:dashboard:queues", "Queues", "peter", "Peter", 250_000, "done"],
+  ["agent:main:dashboard:workers", "Workers", "mira", "Mira", 280_000, "done"],
+  ["agent:main:dashboard:capacity", "Capacity", "peter", "Peter", 310_000, "done"],
 ].map(([key, displayName, actorId, actorLabel, age, status]) => ({
   key: String(key),
   kind: "direct",
@@ -104,12 +110,26 @@ suite.define(() => {
         hasText: "Release health",
       });
       await releaseCard.waitFor();
-      expect(await gallery.locator("[data-dashboard-session]").count()).toBe(6);
-      expect(await gallery.getByText("By Mira", { exact: true }).count()).toBe(3);
-      await releaseCard.locator('iframe[title="Live Gateway Pulse"]').waitFor();
-      await expect
-        .poll(() => gateway.getRequests("board.get"))
-        .toSatisfy((requests) => requests.length >= dashboardRows.length);
+      expect(await gallery.locator("[data-dashboard-session]").count()).toBe(12);
+      expect(await gallery.getByText("By Mira", { exact: true }).count()).toBe(6);
+      const previewFrame = releaseCard.locator('iframe[title="Live Gateway Pulse"]');
+      await previewFrame.waitFor();
+      await previewFrame.contentFrame().getByText("All systems nominal", { exact: true }).waitFor();
+      const capacityKey = "agent:main:dashboard:capacity";
+      const capacityRequested = async () =>
+        (await gateway.getRequests("board.get")).some(
+          (request) => request.params.sessionKey === capacityKey,
+        );
+      expect(await capacityRequested()).toBe(false);
+      const capacityCard = gallery.locator(`[data-dashboard-session="${capacityKey}"]`);
+      await capacityCard.scrollIntoViewIfNeeded();
+      await expect.poll(capacityRequested).toBe(true);
+      const capacityFrame = capacityCard.locator('iframe[title="Live Gateway Pulse"]');
+      await capacityFrame.waitFor();
+      await capacityFrame
+        .contentFrame()
+        .getByText("All systems nominal", { exact: true })
+        .waitFor();
       expect(await releaseCard.locator("a").getAttribute("href")).toBe(
         "/chat/main/release-health-12345678?dashboard=expanded",
       );

--- a/ui/src/e2e/dashboard-gallery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-gallery.e2e.test.ts
@@ -27,13 +27,28 @@ const dashboardRows = [
   createdActor: { type: "human", id: String(actorId), label: String(actorLabel) },
 }));
 
-const boardSnapshot = {
-  sessionKey: selectedSessionKey,
+const previewMarkup = encodeURIComponent(
+  `<!doctype html><html><body style="margin:0;background:#111827;color:#f8fafc;font:16px sans-serif"><main style="padding:24px"><h1>Live Gateway Pulse</h1><strong>All systems nominal</strong></main></body></html>`,
+);
+const boardSnapshots = dashboardRows.map((row) => ({
+  sessionKey: row.key,
   revision: 1,
   tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
-  widgets: [],
-};
-
+  widgets: [
+    {
+      name: "gateway-pulse",
+      tabId: "main",
+      title: "Live Gateway Pulse",
+      contentKind: "html",
+      sizeW: 12,
+      sizeH: 6,
+      position: 0,
+      grantState: "granted",
+      revision: 1,
+      frameUrl: `data:text/html,${previewMarkup}`,
+    },
+  ],
+}));
 suite.define(() => {
   it("opens a responsive gallery card in its owning chat with the dashboard expanded", async () => {
     const proofDir = process.env.OPENCLAW_UI_E2E_RECORD === "1" ? suite.artifactDir : null;
@@ -43,11 +58,22 @@ suite.define(() => {
     });
     const page = await context.newPage();
     try {
-      await installMockGateway(page, {
+      const gateway = await installMockGateway(page, {
         sessionKey: selectedSessionKey,
         featureMethods: ["board.get", "chat.metadata", "chat.startup", "sessions.resolve"],
         methodResponses: {
-          "board.get": boardSnapshot,
+          "sessions.describe": {
+            cases: dashboardRows.map((row) => ({
+              match: { key: row.key },
+              response: { session: row },
+            })),
+          },
+          "board.get": {
+            cases: boardSnapshots.map((snapshot) => ({
+              match: { sessionKey: snapshot.sessionKey },
+              response: snapshot,
+            })),
+          },
           "sessions.resolve": {
             ok: true,
             key: selectedSessionKey,
@@ -80,6 +106,10 @@ suite.define(() => {
       await releaseCard.waitFor();
       expect(await gallery.locator("[data-dashboard-session]").count()).toBe(6);
       expect(await gallery.getByText("By Mira", { exact: true }).count()).toBe(3);
+      await releaseCard.locator('iframe[title="Live Gateway Pulse"]').waitFor();
+      await expect
+        .poll(() => gateway.getRequests("board.get"))
+        .toSatisfy((requests) => requests.length >= dashboardRows.length);
       expect(await releaseCard.locator("a").getAttribute("href")).toBe(
         "/chat/main/release-health-12345678?dashboard=expanded",
       );

--- a/ui/src/e2e/dashboard-gallery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-gallery.e2e.test.ts
@@ -54,6 +54,21 @@ const boardSnapshots = dashboardRows.map((row) => ({
       revision: 1,
       frameUrl: `data:text/html,${previewMarkup}`,
     },
+    ...(row.key === selectedSessionKey
+      ? [
+          {
+            name: "release-tools",
+            tabId: "main",
+            title: "Release tools",
+            contentKind: "mcp-app",
+            sizeW: 12,
+            sizeH: 6,
+            position: 1,
+            grantState: "granted",
+            revision: 1,
+          },
+        ]
+      : []),
   ],
 }));
 suite.define(() => {
@@ -67,7 +82,13 @@ suite.define(() => {
     try {
       const gateway = await installMockGateway(page, {
         sessionKey: selectedSessionKey,
-        featureMethods: ["board.get", "chat.metadata", "chat.startup", "sessions.resolve"],
+        featureMethods: [
+          "board.get",
+          "board.widget.appView",
+          "chat.metadata",
+          "chat.startup",
+          "sessions.resolve",
+        ],
         methodResponses: {
           "sessions.describe": {
             cases: dashboardRows.map((row) => ({
@@ -80,6 +101,11 @@ suite.define(() => {
               match: { sessionKey: snapshot.sessionKey },
               response: snapshot,
             })),
+          },
+          "board.widget.appView": {
+            status: "ready",
+            viewId: "release-tools-view",
+            expiresAtMs: now + 60_000,
           },
           "sessions.resolve": {
             ok: true,
@@ -116,6 +142,8 @@ suite.define(() => {
       const previewFrame = releaseCard.locator('iframe[title="Live Gateway Pulse"]');
       await previewFrame.waitFor();
       await previewFrame.contentFrame().getByText("All systems nominal", { exact: true }).waitFor();
+      expect(await releaseCard.locator('[data-widget-name="release-tools"]').count()).toBe(0);
+      expect(await gateway.getRequests("board.widget.appView")).toHaveLength(0);
       const capacityKey = "agent:main:dashboard:capacity";
       const capacityRequested = async () =>
         (await gateway.getRequests("board.get")).some(

--- a/ui/src/lib/board/widget-sandbox-host.test.ts
+++ b/ui/src/lib/board/widget-sandbox-host.test.ts
@@ -141,6 +141,50 @@ describe("BoardWidgetSandboxHost", () => {
     );
   });
 
+  it("delivers passive preview HTML without accepting its capability bridge", async () => {
+    const frame = document.createElement("iframe");
+    document.body.append(frame);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("<!doctype html><p>weather</p>")),
+    );
+    const client = { request: vi.fn(async () => ({ ok: true })) };
+    const onLoaded = vi.fn();
+    const host = new BoardWidgetSandboxHost({
+      frame,
+      widget: widget(),
+      sandboxOrigin: "https://sandbox.example",
+      sandboxUrl: SANDBOX_URL,
+      sourceOrigin: "https://gateway.example",
+      client,
+      bridgeEnabled: false,
+      resolveFrameUrl: () => "/__openclaw__/board/weather?bt=ticket",
+      confirmPrompt: () => true,
+      onFrameUrl: vi.fn(),
+      onLoadFailed: vi.fn(),
+      onUnauthorized: vi.fn(),
+      onReadyTimeout: vi.fn(),
+      onLoaded,
+      onError: vi.fn(),
+    });
+
+    notifyProxyReady(host, frame);
+    await vi.waitFor(() => expect(onLoaded).toHaveBeenCalledOnce());
+    const channel = new MessageChannel();
+    const close = vi.spyOn(channel.port1, "close");
+    host.handleMessage(
+      new MessageEvent("message", {
+        source: frame.contentWindow,
+        origin: "https://sandbox.example",
+        data: { type: "openclaw:widget-bridge-port-offer" },
+        ports: [channel.port1],
+      }),
+    );
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
   it("routes transient document fetch failures through the refresh budget", async () => {
     const frame = document.createElement("iframe");
     document.body.append(frame);

--- a/ui/src/lib/board/widget-sandbox-host.ts
+++ b/ui/src/lib/board/widget-sandbox-host.ts
@@ -11,6 +11,7 @@ import {
 type BoardWidgetSandboxHostOptions = {
   frame: HTMLIFrameElement;
   widget: BoardWidget;
+  bridgeEnabled?: boolean;
   sandboxOrigin: string;
   sandboxUrl: string;
   sourceOrigin: string;
@@ -154,7 +155,7 @@ export class BoardWidgetSandboxHost {
     }
     if (event.data?.type === "openclaw:widget-bridge-port-offer") {
       const port = event.ports[0];
-      if (!port || this.bridgePort) {
+      if (this.options.bridgeEnabled === false || !port || this.bridgePort) {
         port?.close();
         return;
       }
@@ -174,6 +175,9 @@ export class BoardWidgetSandboxHost {
   }
 
   private handleBridgeMessage(data: unknown): void {
+    if (this.options.bridgeEnabled === false) {
+      return;
+    }
     if (
       data &&
       typeof data === "object" &&
@@ -277,12 +281,16 @@ export class BoardWidgetSandboxHost {
     // Ticket renewal keeps the same generation, while delete/recreate gets a
     // new one even if the name, source path, bytes, and revision are reused.
     const generation = this.options.widget.viewGeneration ?? this.options.widget.viewTicket ?? "";
-    return `${sourceIdentity}\0${this.options.widget.revision}\0${generation}`;
+    // Switching between an interactive board and a passive preview must replace
+    // the wrapper document so no previously adopted bridge port crosses modes.
+    const bridgeMode = this.options.bridgeEnabled === false ? "passive" : "interactive";
+    return `${sourceIdentity}\0${this.options.widget.revision}\0${generation}\0${bridgeMode}`;
   }
 
   private postHostInit(): void {
     const ticket = this.options.widget.viewTicket;
     if (
+      this.options.bridgeEnabled === false ||
       !this.documentHost.ready ||
       !this.active ||
       !this.bridgePort ||

--- a/ui/src/pages/dashboards/dashboard-preview.test.ts
+++ b/ui/src/pages/dashboards/dashboard-preview.test.ts
@@ -1,0 +1,39 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, expect, it, vi } from "vitest";
+import "./dashboard-preview.ts";
+
+type DashboardPreviewElement = HTMLElement & {
+  error: string | null;
+  updateComplete: Promise<boolean>;
+};
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+it("resumes near-viewport rendering after being detached and reattached", async () => {
+  const frames: FrameRequestCallback[] = [];
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    frames.push(callback);
+    return frames.length;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
+  const element = document.createElement("openclaw-dashboard-preview") as DashboardPreviewElement;
+  element.error = "Preview unavailable";
+
+  document.body.append(element);
+  frames.shift()?.(0);
+  await element.updateComplete;
+  expect(element.textContent).toContain("Preview unavailable");
+
+  element.remove();
+  await element.updateComplete;
+  expect(element.textContent).not.toContain("Preview unavailable");
+
+  document.body.append(element);
+  frames.shift()?.(0);
+  await element.updateComplete;
+  expect(element.textContent).toContain("Preview unavailable");
+});

--- a/ui/src/pages/dashboards/dashboard-preview.ts
+++ b/ui/src/pages/dashboards/dashboard-preview.ts
@@ -1,0 +1,48 @@
+import { html, nothing } from "lit";
+import { property } from "lit/decorators.js";
+import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { NearViewportObserver } from "../../components/near-viewport-observer.ts";
+import { t } from "../../i18n/index.ts";
+import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
+
+class OpenClawDashboardPreview extends OpenClawLightDomElement {
+  @property({ attribute: false }) gatewaySnapshot?: ApplicationGatewaySnapshot;
+  @property({ attribute: false }) sessionKey = "";
+  @property({ attribute: false }) agentId?: string;
+  @property({ attribute: false }) error: string | null = null;
+
+  private readonly visibility = new NearViewportObserver(200, () => this.requestUpdate());
+  private observationFrame = 0;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    window.cancelAnimationFrame(this.observationFrame);
+    // Measure after the first paint; connected elements report zero-sized bounds
+    // before layout and would otherwise activate every gallery preview at once.
+    this.observationFrame = window.requestAnimationFrame(() => this.visibility.observe(this));
+  }
+
+  override disconnectedCallback(): void {
+    window.cancelAnimationFrame(this.observationFrame);
+    this.visibility.disconnect();
+    super.disconnectedCallback();
+  }
+
+  override render() {
+    if (!this.visibility.nearVisible) {
+      return nothing;
+    }
+    return this.error
+      ? html`<div class="dashboard-preview__error">
+          ${t("dashboardDocument.loadFailed", { error: this.error })}
+        </div>`
+      : html`<openclaw-board-document
+          .gatewaySnapshot=${this.gatewaySnapshot}
+          .preparedSession=${{ sessionKey: this.sessionKey, agentId: this.agentId }}
+        ></openclaw-board-document>`;
+  }
+}
+
+if (!customElements.get("openclaw-dashboard-preview")) {
+  customElements.define("openclaw-dashboard-preview", OpenClawDashboardPreview);
+}

--- a/ui/src/pages/dashboards/dashboard-preview.ts
+++ b/ui/src/pages/dashboards/dashboard-preview.ts
@@ -37,6 +37,7 @@ class OpenClawDashboardPreview extends OpenClawLightDomElement {
           ${t("dashboardDocument.loadFailed", { error: this.error })}
         </div>`
       : html`<openclaw-board-document
+          .passive=${true}
           .gatewaySnapshot=${this.gatewaySnapshot}
           .preparedSession=${{ sessionKey: this.sessionKey, agentId: this.agentId }}
         ></openclaw-board-document>`;

--- a/ui/src/pages/dashboards/dashboards-page.test.ts
+++ b/ui/src/pages/dashboards/dashboards-page.test.ts
@@ -84,7 +84,10 @@ describe("DashboardsPage", () => {
     const selectionState = { selectedId: "main", scopeId: null as string | null };
     const context = {
       basePath: "",
-      gateway: { snapshot: { client: {}, phase: "connected", hello: null } },
+      gateway: {
+        snapshot: { client: {}, phase: "connected", hello: null },
+        subscribe: () => () => undefined,
+      },
       sessions: {
         listSnapshot(query: SessionListOptions) {
           return snapshots.get(queryKey(query))!;
@@ -194,7 +197,10 @@ describe("DashboardsPage", () => {
     const list = vi.fn(async () => second);
     const context = {
       basePath: "",
-      gateway: { snapshot: { client: {}, phase: "connected", hello: null } },
+      gateway: {
+        snapshot: { client: {}, phase: "connected", hello: null },
+        subscribe: () => () => undefined,
+      },
       sessions: {
         list,
         listSnapshot: () => snapshot,

--- a/ui/src/pages/dashboards/dashboards-page.test.ts
+++ b/ui/src/pages/dashboards/dashboards-page.test.ts
@@ -272,6 +272,7 @@ describe("DashboardsPage", () => {
     await element.updateComplete;
 
     expect(element.querySelectorAll("[data-dashboard-session]")).toHaveLength(3);
+    expect(element.querySelector(".dashboard-preview")?.hasAttribute("inert")).toBe(true);
 
     const search = element.querySelector<HTMLInputElement>('input[type="search"]');
     expect(search).not.toBeNull();

--- a/ui/src/pages/dashboards/dashboards-page.ts
+++ b/ui/src/pages/dashboards/dashboards-page.ts
@@ -2,6 +2,10 @@ import { consume } from "@lit/context";
 import type { PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
+import {
+  DASHBOARD_DOCUMENT_ELEMENT,
+  ensureCustomElementDefined,
+} from "../../app/lazy-custom-element.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { fetchPagedSessionRows } from "../../lib/sessions/paged-session-rows.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -24,19 +28,37 @@ class DashboardsPage extends OpenClawLightDomElement {
     ownerId: "",
     sort: "updated",
   };
+  @state() private previewError: string | null = null;
 
   private observedSessions?: ApplicationContext["sessions"];
   private observedScopeId?: string | null;
   private unsubscribeList?: () => void;
   private data?: DashboardsRouteData;
   private listGeneration = 0;
-  private readonly subscriptions = new SubscriptionsController(this).effect(
-    () => this.context?.agentSelection,
-    (agentSelection) => {
-      this.bindList();
-      return agentSelection.subscribe(() => this.bindList());
-    },
-  );
+  private readonly subscriptions = new SubscriptionsController(this)
+    .effect(
+      () => this.context?.agentSelection,
+      (agentSelection) => {
+        this.bindList();
+        return agentSelection.subscribe(() => this.bindList());
+      },
+    )
+    .watch(
+      () => this.context?.gateway,
+      (gateway, notify) => gateway.subscribe(notify),
+    );
+
+  override connectedCallback() {
+    super.connectedCallback();
+    void ensureCustomElementDefined(
+      DASHBOARD_DOCUMENT_ELEMENT.tagName,
+      DASHBOARD_DOCUMENT_ELEMENT.loadModule,
+    )
+      .then(() => this.requestUpdate())
+      .catch((error: unknown) => {
+        this.previewError = formatUiError(error);
+      });
+  }
 
   override disconnectedCallback() {
     this.listGeneration += 1;
@@ -161,6 +183,8 @@ class DashboardsPage extends OpenClawLightDomElement {
           this.filters = { ...this.filters, sort };
         },
       },
+      this.context?.gateway.snapshot,
+      this.previewError,
     );
   }
 }

--- a/ui/src/pages/dashboards/view.ts
+++ b/ui/src/pages/dashboards/view.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import type { SessionsListResult } from "../../api/types.ts";
 import { titleForRoute } from "../../app-navigation.ts";
+import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { icons } from "../../components/icons.ts";
 import { renderPanelRefreshStatus } from "../../components/panel-refresh-status.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
@@ -46,27 +47,22 @@ function dashboardAuthor(row: DashboardRow, fallbackAgentId: string) {
   return { id, label: actor?.label?.trim() || id };
 }
 
-function dashboardPreviewVariant(key: string): number {
-  let hash = 0;
-  for (const character of key) {
-    hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
-  }
-  return hash % 3;
-}
-
-function renderDashboardPreview(row: DashboardRow) {
-  return html`<div
-    class="dashboard-preview dashboard-preview--${dashboardPreviewVariant(row.key)}"
-    aria-hidden="true"
-  >
-    <div class="dashboard-preview__topbar"><span></span><span></span><span></span><i></i></div>
-    <div class="dashboard-preview__canvas">
-      <div class="dashboard-preview__metric"><span></span><strong></strong><i></i></div>
-      <div class="dashboard-preview__chart">
-        <span></span><span></span><span></span><span></span><span></span><span></span>
-      </div>
-      <div class="dashboard-preview__feed"><span></span><span></span><span></span></div>
-    </div>
+function renderDashboardPreview(
+  row: DashboardRow,
+  gatewaySnapshot: ApplicationGatewaySnapshot | undefined,
+  error: string | null,
+) {
+  return html`<div class="dashboard-preview" aria-hidden="true">
+    ${
+      error
+        ? html`<div class="dashboard-preview__error">
+            ${t("dashboardDocument.loadFailed", { error })}
+          </div>`
+        : html`<openclaw-board-document
+            .gatewaySnapshot=${gatewaySnapshot}
+            .sessionKey=${row.key}
+          ></openclaw-board-document>`
+    }
   </div>`;
 }
 
@@ -94,7 +90,12 @@ function visibleDashboardRows(data: DashboardsRouteData, filters: DashboardGalle
     );
 }
 
-function renderDashboardCard(data: DashboardsRouteData, row: DashboardRow) {
+function renderDashboardCard(
+  data: DashboardsRouteData,
+  row: DashboardRow,
+  gatewaySnapshot: ApplicationGatewaySnapshot | undefined,
+  previewError: string | null,
+) {
   const target = sessionNavigationTarget({
     face: "chat",
     sessionKey: row.key,
@@ -109,7 +110,7 @@ function renderDashboardCard(data: DashboardsRouteData, row: DashboardRow) {
   const initial = author.label.trim().charAt(0).toLocaleUpperCase() || "?";
   return html`<article class="dashboard-card" data-dashboard-session=${row.key}>
     <a class="dashboard-card__main" href=${target.href} aria-label=${title}>
-      ${renderDashboardPreview(row)}
+      ${renderDashboardPreview(row, gatewaySnapshot, previewError)}
       <div class="dashboard-card__body">
         <div class="dashboard-card__heading">
           <h2>${title}</h2>
@@ -142,6 +143,8 @@ function renderDashboardList(
   data: DashboardsRouteData,
   filters: DashboardGalleryFilters,
   handlers: DashboardGalleryHandlers,
+  gatewaySnapshot: ApplicationGatewaySnapshot | undefined,
+  previewError: string | null,
 ) {
   const rows = data.result?.sessions ?? [];
   if (data.error && !data.result) {
@@ -224,7 +227,7 @@ function renderDashboardList(
             ${repeat(
               visibleRows,
               (row) => row.key,
-              (row) => renderDashboardCard(data, row),
+              (row) => renderDashboardCard(data, row, gatewaySnapshot, previewError),
             )}
           </div>`
     }
@@ -236,6 +239,8 @@ export function renderDashboards(
   onRetry: () => void,
   filters: DashboardGalleryFilters = DEFAULT_FILTERS,
   handlers: DashboardGalleryHandlers = NOOP_HANDLERS,
+  gatewaySnapshot?: ApplicationGatewaySnapshot,
+  previewError: string | null = null,
 ) {
   const body = data
     ? html`
@@ -250,7 +255,7 @@ export function renderDashboards(
             : undefined,
           onRetry,
         })}
-        ${renderDashboardList(data, filters, handlers)}
+        ${renderDashboardList(data, filters, handlers, gatewaySnapshot, previewError)}
       `
     : html`<section class="card" aria-busy="true">${t("common.loading")}</section>`;
   return html`

--- a/ui/src/pages/dashboards/view.ts
+++ b/ui/src/pages/dashboards/view.ts
@@ -11,6 +11,7 @@ import { formatRelativeTimestamp } from "../../lib/format.ts";
 import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import { sessionNavigationTarget } from "../../lib/sessions/route-navigation.ts";
 import "../../styles/dashboards.css";
+import "./dashboard-preview.ts";
 
 export type DashboardsRouteData = {
   result: SessionsListResult | null;
@@ -52,17 +53,13 @@ function renderDashboardPreview(
   gatewaySnapshot: ApplicationGatewaySnapshot | undefined,
   error: string | null,
 ) {
-  return html`<div class="dashboard-preview" aria-hidden="true">
-    ${
-      error
-        ? html`<div class="dashboard-preview__error">
-            ${t("dashboardDocument.loadFailed", { error })}
-          </div>`
-        : html`<openclaw-board-document
-            .gatewaySnapshot=${gatewaySnapshot}
-            .sessionKey=${row.key}
-          ></openclaw-board-document>`
-    }
+  return html`<div class="dashboard-preview" aria-hidden="true" inert>
+    <openclaw-dashboard-preview
+      .gatewaySnapshot=${gatewaySnapshot}
+      .sessionKey=${row.key}
+      .agentId=${row.agentId}
+      .error=${error}
+    ></openclaw-dashboard-preview>
   </div>`;
 }
 

--- a/ui/src/styles/dashboards.css
+++ b/ui/src/styles/dashboards.css
@@ -147,178 +147,43 @@
   aspect-ratio: 16 / 9;
   overflow: hidden;
   border-bottom: 1px solid var(--border);
-  background:
-    radial-gradient(circle at 88% 12%, var(--accent-glow), transparent 30%),
-    color-mix(in srgb, var(--bg) 88%, var(--accent) 12%);
+  background: var(--bg);
+  pointer-events: none;
 }
 
-.dashboard-preview::after {
+.dashboard-preview > openclaw-board-document {
   position: absolute;
   inset: 0;
-  background-image:
-    linear-gradient(var(--card-highlight) 1px, transparent 1px),
-    linear-gradient(90deg, var(--card-highlight) 1px, transparent 1px);
-  background-size: 24px 24px;
-  content: "";
-  mask-image: linear-gradient(to bottom, transparent, var(--media-bg));
-}
-
-.dashboard-preview__topbar {
-  position: relative;
-  z-index: 2;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  height: 22px;
-  padding: 0 9px;
-  border-bottom: 1px solid var(--border);
-  background: color-mix(in srgb, var(--bg-elevated) 90%, transparent);
-}
-
-.dashboard-preview__topbar span {
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
-  background: var(--muted);
-  opacity: 0.55;
-}
-
-.dashboard-preview__topbar i {
-  width: 34%;
-  height: 4px;
-  margin-left: 7px;
-  border-radius: var(--radius-full);
-  background: var(--border-strong);
-}
-
-.dashboard-preview__canvas {
-  position: absolute;
-  inset: 31px 9px 9px;
-  z-index: 1;
-  display: grid;
-  grid-template-columns: 0.85fr 1.45fr;
-  grid-template-rows: 1fr 0.7fr;
-  gap: 7px;
-}
-
-.dashboard-preview__metric,
-.dashboard-preview__chart,
-.dashboard-preview__feed {
-  min-width: 0;
-  border: 1px solid color-mix(in srgb, var(--border-strong) 84%, transparent);
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--card) 90%, transparent);
-}
-
-.dashboard-preview__metric {
-  display: grid;
-  align-content: center;
-  gap: 6px;
-  padding: 9px;
-}
-
-.dashboard-preview__metric span,
-.dashboard-preview__metric strong,
-.dashboard-preview__metric i,
-.dashboard-preview__feed span {
   display: block;
-  border-radius: var(--radius-full);
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg);
 }
 
-.dashboard-preview__metric span {
-  width: 44%;
-  height: 3px;
-  background: var(--muted);
-  opacity: 0.55;
+.dashboard-preview .board-document__content > openclaw-board-view {
+  padding: 0;
+  overflow: hidden;
 }
 
-.dashboard-preview__metric strong {
-  width: 68%;
-  height: 11px;
-  background: var(--text-strong);
-  opacity: 0.82;
+.dashboard-preview .board-document__content .board-view {
+  min-height: 100%;
+  padding: 8px;
 }
 
-.dashboard-preview__metric i {
-  width: 38%;
-  height: 3px;
-  background: var(--accent);
+.dashboard-preview .board-tabs {
+  display: none;
 }
 
-.dashboard-preview__chart {
-  display: flex;
-  align-items: end;
-  gap: 5px;
-  padding: 9px;
-}
-
-.dashboard-preview__chart span {
-  flex: 1;
-  min-height: 16%;
-  border-radius: 3px 3px 1px 1px;
-  background: color-mix(in srgb, var(--accent) 72%, var(--text));
-  opacity: 0.8;
-}
-
-.dashboard-preview__chart span:nth-child(1) {
-  height: 36%;
-}
-.dashboard-preview__chart span:nth-child(2) {
-  height: 54%;
-}
-.dashboard-preview__chart span:nth-child(3) {
-  height: 43%;
-}
-.dashboard-preview__chart span:nth-child(4) {
-  height: 76%;
-}
-.dashboard-preview__chart span:nth-child(5) {
-  height: 62%;
-}
-.dashboard-preview__chart span:nth-child(6) {
-  height: 88%;
-}
-
-.dashboard-preview__feed {
-  grid-column: 1 / -1;
+.dashboard-preview__error {
+  position: absolute;
+  inset: 0;
   display: grid;
-  align-content: center;
-  gap: 5px;
-  padding: 8px 10px;
-}
-
-.dashboard-preview__feed span {
-  height: 3px;
-  background: var(--border-hover);
-}
-
-.dashboard-preview__feed span:nth-child(1) {
-  width: 83%;
-}
-.dashboard-preview__feed span:nth-child(2) {
-  width: 61%;
-}
-.dashboard-preview__feed span:nth-child(3) {
-  width: 74%;
-}
-
-.dashboard-preview--1 {
-  background:
-    radial-gradient(circle at 16% 10%, var(--accent-2-subtle), transparent 34%),
-    color-mix(in srgb, var(--bg) 90%, var(--accent-2) 10%);
-}
-
-.dashboard-preview--1 .dashboard-preview__canvas {
-  grid-template-columns: 1.3fr 0.7fr;
-}
-.dashboard-preview--1 .dashboard-preview__chart span {
-  background: color-mix(in srgb, var(--accent-2) 72%, var(--text));
-}
-.dashboard-preview--2 .dashboard-preview__canvas {
-  grid-template-columns: 1fr 1fr;
-}
-.dashboard-preview--2 .dashboard-preview__chart {
-  order: -1;
+  place-items: center;
+  padding: var(--space-4);
+  color: var(--danger);
+  font-size: var(--control-ui-text-xs);
+  text-align: center;
 }
 
 .dashboard-card__body {

--- a/ui/src/styles/dashboards.css
+++ b/ui/src/styles/dashboards.css
@@ -151,7 +151,8 @@
   pointer-events: none;
 }
 
-.dashboard-preview > openclaw-board-document {
+.dashboard-preview > openclaw-dashboard-preview,
+.dashboard-preview openclaw-board-document {
   position: absolute;
   inset: 0;
   display: block;


### PR DESCRIPTION
## Summary

- replace the hardcoded dashboard-card scaffold with the saved dashboard HTML rendered through the canonical board document
- lazy-load previews near the viewport and pass the gallery session identity through without a redundant session lookup
- make gallery rendering explicitly passive: render saved HTML, omit MCP Apps/plugins, disable the HTML capability bridge, and expose no mutation or grant controls
- keep decorative iframe content inert inside the card link and preserve preview lifecycle across detach/reattach

## Before / after

Before: dashboard cards used a fixed placeholder scaffold regardless of their saved content.

![Hardcoded dashboard gallery preview](https://github.com/user-attachments/assets/586af679-48e4-4534-9067-6703932ee596)

After: a real dashboard created on the disposable OCM gateway renders its actual saved HTML in the gallery.

![Live OCM dashboard gallery preview](https://github.com/user-attachments/assets/bda0e271-d6e0-41d4-a517-deef981f41ec)

## Validation

- `node scripts/run-vitest.mjs run ui/src/components/board/board-document.test.ts ui/src/components/board/board-view.test.ts ui/src/components/board/board-widget-cell-mcp-app.test.ts ui/src/components/board/board-widget-frame.test.ts ui/src/lib/board/widget-sandbox-host.test.ts ui/src/pages/dashboards/dashboard-preview.test.ts ui/src/pages/dashboards/dashboards-page.test.ts` — 87 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/dashboard-gallery.e2e.test.ts` — passed
- `pnpm tsgo:ui`
- `pnpm lint:ui:styles`
- `pnpm ui:build`
- real OCM gateway at port 18951 with Gateway-created `dashboard-gallery-live-sample`

The browser regression includes visible saved HTML and a granted MCP App in the same dashboard. It verifies the HTML iframe body, confirms the MCP App is omitted, and records zero `board.widget.appView` requests while the gallery card is visible. The sandbox-host regression separately proves passive HTML is fetched and delivered while its capability port is closed and no Gateway bridge request occurs.

## Review notes

- Production delta: +242 / -259 (net -17); tests: +278 / -12.
- The passive repair closes the ClawSweeper P1 at the board document owner boundary instead of disabling HTML loading: preview HTML stays live, but executable plugin/MCP surfaces and the private dashboard bridge never initialize.
- Independent review findings around reconnect lifecycle, focus containment, redundant lookup, bounded loading, and passive authority were addressed.
- Codex runtime is not part of this Control UI / Gateway board rendering path.