### PR TITLE
fix(read): accept cursor 0 on an empty first line instead of rejecting it as past EOF

### DIFF
--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -549,44 +549,82 @@ describe("read tool", () => {
     ).rejects.toThrow(/cursor.*surrogate.*(?:1|3)/i);
   });
 
-  it.each([4, 5])("explains an intra-line cursor at or past EOF (%s)", async (cursor) => {
-    const tool = createReadToolDefinition("/workspace", {
-      operations: {
-        access: async () => {},
-        readFile: async () => Buffer.from("done"),
-      },
+  it.each([
+    { cursor: 4, contents: "done", length: 4 },
+    { cursor: 5, contents: "done", length: 4 },
+    { cursor: 1, contents: "\n", length: 0 },
+  ])(
+    "explains an intra-line cursor at or past EOF ($cursor)",
+    async ({ cursor, contents, length }) => {
+      const tool = createReadToolDefinition("/workspace", {
+        operations: {
+          access: async () => {},
+          readFile: async () => Buffer.from(contents),
+        },
+      });
+
+      const result = await tool.execute(
+        "call-cursor-eof",
+        { path: "done.txt", cursor },
+        undefined,
+        undefined,
+        {} as never,
+      );
+
+      expect(textContent(result)).toBe(
+        `Cursor ${cursor} is at or beyond the end of line 1 (${length} characters).`,
+      );
+    },
+  );
+
+  it.each([
+    {
+      name: "an empty first line",
+      contents: "\nsecond line\n",
+      offset: 1,
+      limit: 2000,
+      expected: "\nsecond line\n",
+    },
+    {
+      name: "a later empty line",
+      contents: "first line\n\nsecond line\n",
+      offset: 2,
+      limit: 2000,
+      expected: "\nsecond line\n",
+    },
+    {
+      name: "a nonempty line",
+      contents: "\nsecond line\n",
+      offset: 2,
+      limit: 2000,
+      expected: "second line\n",
+    },
+    {
+      name: "a blank-only file",
+      contents: "\n\n",
+      offset: 1,
+      limit: 2000,
+      expected: "File contains 2 blank lines.",
+    },
+    {
+      name: "a blank-only range",
+      contents: "\n\n",
+      offset: 1,
+      limit: 1,
+      expected:
+        "Selected range contains 1 blank line.\n\n[1 more line in file. Use offset=2 to continue.]",
+    },
+  ])("accepts cursor 0 on $name", async ({ contents, offset, limit, expected }) => {
+    const tempDir = tempDirs.make("openclaw-read-cursor-zero-");
+    await fs.writeFile(path.join(tempDir, "synthetic.txt"), contents);
+    const result = await createReadTool(tempDir).execute("read-zero", {
+      path: "synthetic.txt",
+      offset,
+      limit,
+      cursor: 0,
     });
 
-    const result = await tool.execute(
-      "call-cursor-eof",
-      { path: "done.txt", cursor },
-      undefined,
-      undefined,
-      {} as never,
-    );
-
-    expect(textContent(result)).toMatch(/cursor.*(?:end|beyond).*line 1/i);
-  });
-
-  it("accepts cursor 0 on an empty first line instead of rejecting it as past EOF", async () => {
-    const tool = createReadToolDefinition("/workspace", {
-      operations: {
-        access: async () => {},
-        readFile: async () => Buffer.from("\nsecond line\n"),
-      },
-    });
-
-    const result = await tool.execute(
-      "call-cursor-zero-empty-line",
-      { path: "synthetic.txt", offset: 1, limit: 2000, cursor: 0 },
-      undefined,
-      undefined,
-      {} as never,
-    );
-
-    const output = textContent(result);
-    expect(output).not.toMatch(/cursor.*(?:end|beyond).*line/i);
-    expect(output).toContain("second line");
+    expect(textContent(result)).toBe(expected);
   });
 
   it("finishes an oversized selected line before continuing at the next line", async () => {

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -568,6 +568,27 @@ describe("read tool", () => {
     expect(textContent(result)).toMatch(/cursor.*(?:end|beyond).*line 1/i);
   });
 
+  it("accepts cursor 0 on an empty first line instead of rejecting it as past EOF", async () => {
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        readFile: async () => Buffer.from("\nsecond line\n"),
+      },
+    });
+
+    const result = await tool.execute(
+      "call-cursor-zero-empty-line",
+      { path: "synthetic.txt", offset: 1, limit: 2000, cursor: 0 },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    const output = textContent(result);
+    expect(output).not.toMatch(/cursor.*(?:end|beyond).*line/i);
+    expect(output).toContain("second line");
+  });
+
   it("finishes an oversized selected line before continuing at the next line", async () => {
     const longLine = "x".repeat(DEFAULT_MAX_BYTES + 100);
     const tool = createReadToolDefinition("/workspace", {

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -535,7 +535,11 @@ export function createReadToolDefinition(
                     : `File contains no readable text (${buffer.length} bytes).`;
               } else if (startLine >= totalFileLines) {
                 outputText = `Offset ${offset} is beyond end of file (${totalFileLines} lines total). Retry with offset <= ${totalFileLines}.`;
-              } else if (cursor !== undefined && cursor >= allLines[startLine]!.length) {
+              } else if (
+                cursor !== undefined &&
+                cursor > 0 &&
+                cursor >= allLines[startLine]!.length
+              ) {
                 const nextLine =
                   startLine + 1 < totalFileLines
                     ? ` Use offset=${startLineDisplay + 1} to continue.`

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -392,7 +392,7 @@ export function createReadToolDefinition(
         path,
         offset,
         limit,
-        cursor,
+        cursor = 0,
         optional,
       }: { path: string; offset?: number; limit?: number; cursor?: number; optional?: true },
       signal?: AbortSignal,
@@ -404,7 +404,7 @@ export function createReadToolDefinition(
       if (offset !== undefined && (!Number.isSafeInteger(offset) || offset < 1)) {
         throw new Error("Offset must be an integer at least 1");
       }
-      if (cursor !== undefined && (!Number.isSafeInteger(cursor) || cursor < 0)) {
+      if (!Number.isSafeInteger(cursor) || cursor < 0) {
         throw new Error("Cursor must be an integer at least 0");
       }
       return new Promise<{
@@ -535,11 +535,7 @@ export function createReadToolDefinition(
                     : `File contains no readable text (${buffer.length} bytes).`;
               } else if (startLine >= totalFileLines) {
                 outputText = `Offset ${offset} is beyond end of file (${totalFileLines} lines total). Retry with offset <= ${totalFileLines}.`;
-              } else if (
-                cursor !== undefined &&
-                cursor > 0 &&
-                cursor >= allLines[startLine]!.length
-              ) {
+              } else if (cursor > 0 && cursor >= allLines[startLine]!.length) {
                 const nextLine =
                   startLine + 1 < totalFileLines
                     ? ` Use offset=${startLineDisplay + 1} to continue.`
@@ -547,11 +543,7 @@ export function createReadToolDefinition(
                 outputText = `Cursor ${cursor} is at or beyond the end of line ${startLineDisplay} (${allLines[startLine]!.length} characters).${nextLine}`;
               } else {
                 const firstLine = allLines[startLine]!;
-                if (
-                  cursor !== undefined &&
-                  cursor > 0 &&
-                  firstLine.codePointAt(cursor - 1)! > 0xffff
-                ) {
+                if (cursor > 0 && firstLine.codePointAt(cursor - 1)! > 0xffff) {
                   throw new Error(
                     `Cursor ${cursor} splits a UTF-16 surrogate pair; retry with cursor=${cursor - 1} or cursor=${cursor + 1}.`,
                   );
@@ -564,9 +556,7 @@ export function createReadToolDefinition(
                         totalFileLines,
                       );
                 const selectedLines = allLines.slice(startLine, endLine);
-                if (cursor !== undefined) {
-                  selectedLines[0] = firstLine.slice(cursor);
-                }
+                selectedLines[0] = firstLine.slice(cursor);
                 const userLimitedLines = limit === undefined ? undefined : endLine - startLine;
                 if (selectedLines.every((line) => line.length === 0)) {
                   const selectedLineCount = selectedLines.length;


### PR DESCRIPTION
> AI-assisted: yes

Closes #138610

## What Problem This Solves

The built-in `read` tool accepted cursor zero in its schema but rejected it when the selected line was empty. A valid file beginning with a newline could therefore return a false end-of-line diagnostic instead of its content.

## Why This Change Was Made

Normalize an omitted cursor to zero at the shared read owner. Zero then follows the normal selection path, including on empty lines. Keep positive end-of-line diagnostics and surrogate-pair validation.

This removes redundant optional-cursor branches. Production changes are +5/-11, net **-6 lines**. No writer, loop-detection, schema, permission, configuration or resource-limit changes.

## User Impact

Reading an empty selected line followed by text preserves the leading blank line and following text. Blank-only files and ranges retain their existing explanations. Nonempty lines, positive cursors and oversized-line continuation keep their established behavior.

Thanks to @LiuwqGit for the original repair and @benmillerat for the report and exact-output assertion suggestion. Contributor ancestry is preserved.

## Evidence

Real Gateway agent turns used the actual coding `read` tool and a real local model, with all 42 tools and a full 32,768-token context. Every provider request reported zero truncation. No mock provider, forced transcript, direct source invocation or HTTP `tools/invoke` shortcut was used.

Baseline: `c56fcc8d4d06e38f6564c61875e284afaf34b331`.
Candidate: `8de17827742085b3e85cc9e822d0ae1f1ecdca63`.

For a file containing exactly `"\nsecond line\n"`, the actual call was:

```json
{"path":"synthetic.txt","offset":1,"limit":2000,"cursor":0}
```

| Actual tool result before | Actual tool result after |
| --- | --- |
| `Cursor 0 is at or beyond the end of line 1 (0 characters). Use offset=2 to continue.` | `"\nsecond line\n"` |

The later-line probe read `first line\n\nsecond line\n` at offset 2 and cursor 0. It also returned exactly `"\nsecond line\n"`, proving the repair is not specific to the first line.

The baseline model made additional reads after the false diagnostic and returned partial content. Each candidate scenario completed with one read. The final model replies summarized the text rather than reproducing whitespace, so byte-level assertions use the captured actual tool results.

Validation:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/agents/sessions/tools/read.test.ts \
  src/agents/filesystem-tools-output-contract.test.ts \
  src/agents/agent-tools.create-openclaw-coding-tools.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
  src/agents/sessions/tools/read.test.ts src/agents/sessions/tools/read.ts
pnpm check:coercion-helpers
pnpm build
git diff --check
```

- The strengthened tests fail on unpatched production code in four empty-line cases.
- All 193 candidate tests pass, including existing oversized-line and surrogate-boundary coverage.
- Focused lint, coercion guard, pinned formatting and both isolated builds pass.
- Exact-output assertions replace the weaker substring checks.
- The prior production-growth review concern is resolved by the net-negative owner simplification.
- Fresh canonical exact-head review passed with no P0 findings; [exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33952230111).
- The guarded merge dry run passed; the earlier review-invocation incompatibility is resolved.

This proves the shared coding read-tool contract through real Gateway turns. It does not claim a native Codex live run or deterministic reproduction of a particular model's prolonged retry count.
