### PR TITLE
improve: reduce allocations while budgeting multilingual tool results

### DIFF
--- a/packages/normalization-core/src/cjk-chars.test.ts
+++ b/packages/normalization-core/src/cjk-chars.test.ts
@@ -85,4 +85,20 @@ describe("normalization-core/cjk-chars", () => {
   it("does not collapse non-CJK surrogate pairs", () => {
     expect(estimateStringChars("\uD83D\uDE00")).toBe(2);
   });
+
+  it.each([
+    ["\ud800", 1],
+    ["\udfff", 1],
+    ["\ud800a\udfff", 3],
+    ["\u{1D360}\u{20000}", 28],
+    ["\u{20000}\u{20000}", 32],
+  ])("keeps repeated estimates stable for %j", (text, expected) => {
+    expect([text, "ascii", text, "", text].map(estimateStringChars)).toEqual([
+      expected,
+      5,
+      expected,
+      0,
+      expected,
+    ]);
+  });
 });

--- a/packages/normalization-core/src/cjk-chars.ts
+++ b/packages/normalization-core/src/cjk-chars.ts
@@ -9,6 +9,9 @@
 
 export const CHARS_PER_TOKEN_ESTIMATE = 4;
 
+export type StringCharBudgetOptions = { minimumRawWeight?: number };
+const DEFAULT_BUDGET_OPTIONS: StringCharBudgetOptions = {};
+const ASCII_RUN_OR_NON_ASCII_CODE_POINT_RE = /[\p{ASCII}]+|[^\p{ASCII}]/gu;
 const NON_ASCII_RE = /[\u0080-\u{10FFFF}]/u;
 const COMMON_CJK_RE = /[\u00B7\u3000-\u319F\u4E00-\u9FA5\uAC00-\uD7AF\uFF01-\uFF60]/gu;
 const RARE_BMP_CJK_RE =
@@ -22,28 +25,53 @@ const SPECIAL_CJK_RE =
   /[\u{02C7}\u{02C9}-\u{02CB}\u{02D9}\u{02EA}-\u{02EB}\u1100-\u11FF\u2E80-\u2FFF\u31A0-\u4DFF\u9FA6-\u9FFF\uA000-\uA4FF\uA700-\uA707\uA960-\uA97F\uD7B0-\uD7FF\uF900-\uFAFF\uFE10-\uFE4F\uFF61-\uFFDC\uFFE0-\uFFE6\u{16FE0}-\u{16FFF}\u{1AFF0}-\u{1AFFF}\u{1B000}-\u{1B16F}\u{1D360}-\u{1D371}\u{1F200}-\u{1F2FF}\u{20000}-\u{2FA1F}\u{30000}-\u{3347F}]|\u{0305}|\u{0323}/u;
 
 function countMatches(text: string, pattern: RegExp): number {
-  return (text.match(pattern) ?? []).length;
+  let count = 0;
+  // Every pattern consumes a code point; the final failed test resets its cursor.
+  while (pattern.test(text)) {
+    count += 1;
+  }
+  return count;
 }
 
 export function estimateStringChars(text: string): number {
-  if (!NON_ASCII_RE.test(text)) {
-    return text.length;
+  return estimateStringCharsWithMinimumRawWeight(text);
+}
+
+/** Apply a raw-text safety floor without multiplying CJK adjustments twice. */
+export function estimateStringCharsWithMinimumRawWeight(
+  text: string,
+  options: StringCharBudgetOptions = DEFAULT_BUDGET_OPTIONS,
+): number {
+  const minimumRawWeight = Math.max(1, options.minimumRawWeight ?? 1);
+  if (minimumRawWeight !== 1 && minimumRawWeight !== 2) {
+    let chars = 0;
+    // Other floors retain per-ASCII-run rounding and left-to-right numeric behavior.
+    for (const match of text.matchAll(ASCII_RUN_OR_NON_ASCII_CODE_POINT_RE)) {
+      const segment = match[0];
+      const minimumChars = Math.ceil(segment.length * minimumRawWeight);
+      chars +=
+        segment.charCodeAt(0) <= 0x7f
+          ? minimumChars
+          : Math.max(estimateStringChars(segment), minimumChars);
+    }
+    return chars;
   }
-  const commonCjkCount = countMatches(text, COMMON_CJK_RE);
-  const commonEstimate = text.length + commonCjkCount * (CHARS_PER_TOKEN_ESTIMATE - 1);
+  if (!NON_ASCII_RE.test(text)) {
+    return text.length * minimumRawWeight;
+  }
+  const commonEstimate =
+    text.length * minimumRawWeight +
+    countMatches(text, COMMON_CJK_RE) * (CHARS_PER_TOKEN_ESTIMATE - minimumRawWeight);
   if (!SPECIAL_CJK_RE.test(text)) {
     return commonEstimate;
   }
-  const rareBmpCjkCount = countMatches(text, RARE_BMP_CJK_RE);
-  const twoTokenCjkCount = countMatches(text, TWO_TOKEN_CJK_RE);
-  const threeTokenSupplementaryCjkCount = countMatches(text, THREE_TOKEN_SUPPLEMENTARY_CJK_RE);
-  const supplementaryCjkCount = countMatches(text, SUPPLEMENTARY_CJK_RE);
   return (
     commonEstimate +
-    rareBmpCjkCount * (CHARS_PER_TOKEN_ESTIMATE * 3 - 1) +
-    twoTokenCjkCount * (CHARS_PER_TOKEN_ESTIMATE * 2 - 1) +
-    threeTokenSupplementaryCjkCount * (CHARS_PER_TOKEN_ESTIMATE * 3 - 2) +
-    supplementaryCjkCount * (CHARS_PER_TOKEN_ESTIMATE * 4 - 2)
+    countMatches(text, RARE_BMP_CJK_RE) * (CHARS_PER_TOKEN_ESTIMATE * 3 - minimumRawWeight) +
+    countMatches(text, TWO_TOKEN_CJK_RE) * (CHARS_PER_TOKEN_ESTIMATE * 2 - minimumRawWeight) +
+    countMatches(text, THREE_TOKEN_SUPPLEMENTARY_CJK_RE) *
+      (CHARS_PER_TOKEN_ESTIMATE * 3 - 2 * minimumRawWeight) +
+    countMatches(text, SUPPLEMENTARY_CJK_RE) * (CHARS_PER_TOKEN_ESTIMATE * 4 - 2 * minimumRawWeight)
   );
 }
 

--- a/src/agents/embedded-agent-runner/tool-result-text-budget.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-text-budget.test.ts
@@ -20,6 +20,22 @@ describe("tool-result text budgets", () => {
   });
 
   it.each([
+    ["abc", 1.5, 5],
+    ["éé", 1.5, 4],
+    ["aéa", 1.5, 6],
+    ["🌍", 1.5, 3],
+    ["\ud800a\udfff", 2, 6],
+    ["\u1100\uFF61\u{1D360}\u{20000}", 2, 48],
+    ["你好", -Infinity, 8],
+    ["", Infinity, 0],
+    ["a", Infinity, Infinity],
+    ["", Number.NaN, 0],
+    ["a", Number.NaN, Number.NaN],
+  ])("retains the raw-floor accounting of %j at %s", (text, minimumRawWeight, expected) => {
+    expect(estimateToolResultTextChars(text, { minimumRawWeight })).toBe(expected);
+  });
+
+  it.each([
     ["abc", 3, 6],
     ["漢a", 5, 6],
     ["𠀀a", 17, 18],

--- a/src/agents/embedded-agent-runner/tool-result-text-budget.ts
+++ b/src/agents/embedded-agent-runner/tool-result-text-budget.ts
@@ -1,41 +1,15 @@
-import { estimateStringChars } from "@openclaw/normalization-core/cjk-chars";
+import {
+  estimateStringCharsWithMinimumRawWeight as estimateToolResultTextChars,
+  type StringCharBudgetOptions,
+} from "@openclaw/normalization-core/cjk-chars";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 
-type ToolResultTextBudgetOptions = {
-  minimumRawWeight?: number;
-};
-
-const ASCII_RUN_OR_NON_ASCII_CODE_POINT_RE = /[\p{ASCII}]+|[^\p{ASCII}]/gu;
-
-/**
- * Returns provider-independent character-budget units for tool-result text.
- * CJK weights match the shared token heuristic; callers may retain a larger
- * existing raw-text safety floor without multiplying the CJK adjustment twice.
- */
-export function estimateToolResultTextChars(
-  text: string,
-  options: ToolResultTextBudgetOptions = {},
-): number {
-  const minimumRawWeight = Math.max(1, options.minimumRawWeight ?? 1);
-  if (minimumRawWeight === 1) {
-    return estimateStringChars(text);
-  }
-  let chars = 0;
-  for (const match of text.matchAll(ASCII_RUN_OR_NON_ASCII_CODE_POINT_RE)) {
-    const segment = match[0];
-    const minimumChars = Math.ceil(segment.length * minimumRawWeight);
-    chars +=
-      segment.charCodeAt(0) <= 0x7f
-        ? minimumChars
-        : Math.max(estimateStringChars(segment), minimumChars);
-  }
-  return chars;
-}
+export { estimateToolResultTextChars };
 
 function sliceToolResultTextBudget(
   text: string,
   maxChars: number,
-  options: ToolResultTextBudgetOptions,
+  options: StringCharBudgetOptions,
   fromEnd: boolean,
 ): string {
   const budget = Math.max(0, Math.floor(maxChars));
@@ -64,7 +38,7 @@ function sliceToolResultTextBudget(
 export function sliceToolResultTextToBudget(
   text: string,
   maxChars: number,
-  options: ToolResultTextBudgetOptions = {},
+  options: StringCharBudgetOptions = {},
 ): string {
   return sliceToolResultTextBudget(text, maxChars, options, false);
 }
@@ -72,7 +46,7 @@ export function sliceToolResultTextToBudget(
 export function sliceToolResultTextTailToBudget(
   text: string,
   maxChars: number,
-  options: ToolResultTextBudgetOptions = {},
+  options: StringCharBudgetOptions = {},
 ): string {
   return sliceToolResultTextBudget(text, maxChars, options, true);
 }


### PR DESCRIPTION
## What Problem This Solves

Budgeting large multilingual tool results creates substantial temporary allocation as results are checked and trimmed for model context. The context guard's raw-weight floor makes this particularly expensive for dense CJK text.

## Why This Change Was Made

Move weighted counting into the shared CJK owner, count the existing character categories without materializing match arrays, and calculate the common raw-weight floors over the whole string. Preserve the one-argument public estimator, existing Unicode weights, UTF-16 boundaries, and the original rounding and nonfinite arithmetic for other floors.

## User Impact

Tool-result budgets and truncation output remain identical. Dense multilingual inputs use less temporary allocation in the measured counting path; some default-weight and sparse-input cases are slower, as detailed below.

Production LOC: +48/-46 (net +2). Tests: +32/-0. The small production increase retains the public callback contract while consolidating the weighted owner and removing the previous local weighted path.

## Evidence

Exact baseline/candidate output hashes match for all 1,114,112 Unicode code points, 4,352 mixed-weight cases, 34,816 prefix/tail boundary cases, and six real context-guard/read-page scenarios. Coverage includes unpaired surrogates, fractional and very large weights, NaN/Infinity, notices, continuations, and unchanged input messages.

In baseline/candidate/candidate/baseline microbenchmarks, the following means cover 32 estimates of 65,536 UTF-16 units at raw weight 2:

| Input | Before | After |
| --- | ---: | ---: |
| Common CJK | 166.97 ms | 27.59 ms |
| Rare/supplementary CJK | 219.32 ms | 24.00 ms |
| Emoji | 66.22 ms | 6.99 ms |
| Mixed multilingual | 104.40 ms | 16.11 ms |
| Sparse CJK in ASCII | 3.92 ms | 5.29 ms |

Default-weight rare/supplementary and multilingual cases were 15% and 11% slower. The sparse weight-2 difference is about 0.043 ms per 64K call. These are two observations per arm, not an end-to-end latency claim.

In a separate fixed six-fixture workload, allocation sampling estimated 2.12/2.14 GB of cumulative allocations in the baseline estimator stacks and recorded no samples there after the change. Sampling does not measure retained heap, and zero samples do not prove zero engine allocation.

All 443 focused tests across nine files passed. The full build, native imports of the built SDK, exhaustive packaged Unicode comparison, complete changed-file gate, and independent managed Codex review through P2 passed. The native check also verifies shared-owner identity and callback behavior. An initial gate rejected global `NaN` literals in the new test table; changing them to `Number.NaN`, rerunning the affected 19 tests, and rerunning the complete gate resolved it.

## Integrated Gateway comparison

The controlled built-Gateway comparison is complete: baseline/candidate/candidate/baseline, two observations per arm and ten model turns per run across Code Mode and ToolSearch. Candidate `15216423e92c` contains all 20 changes, including this exact patch. The independent audit verified the 40 turns, unchanged history prefixes, exact file output and Unicode truncation, and recomputed the recorded comparison values.

| Sampled allocation volume | Baseline mean | Combined candidate mean | Change |
| --- | ---: | ---: | ---: |
| All sampled stages | 1,088.02 MiB | 986.56 MiB | −9.33% |
| Code Mode | 757.17 MiB | 656.67 MiB | −13.27% |
| ToolSearch | 330.85 MiB | 329.89 MiB | −0.29% |

These are main-isolate sampled allocation estimates, including collected objects, for the combined candidate; they do not isolate this PR's contribution. ToolSearch's two paired differences have opposite signs. Post-GC idle memory did not decrease: Code Mode RSS was 484.88→485.78 MiB and main heap 268.43→268.45 MiB; ToolSearch RSS was 480.64→480.71 MiB and main heap 259.92→260.13 MiB. RSS includes Gateway workers, while heap and allocation sampling cover the main isolate.

Latency was mixed: instrumented stage totals changed by −1.75% for Code Mode and +0.95% for ToolSearch. Those intervals include fixed settling and sampling overhead, with live provider and cache variability. Two observations per arm establish neither statistical significance nor a uniform latency or retained-memory improvement. Normal native landing gates still apply.
