### PR TITLE
improve: avoid redundant work when rendering subagent status

### DIFF
--- a/src/auto-reply/reply/commands-status-subagents.ts
+++ b/src/auto-reply/reply/commands-status-subagents.ts
@@ -1,63 +1,54 @@
 // Formats subagent status rows for the status command response.
-import type { SubagentRunRecord } from "../../agents/subagents/registry/subagent-registry.types.js";
+import type { buildControlledSubagentRunsReadContext } from "../../agents/subagents/registry/subagent-control-scope.js";
 import {
   hasSubagentRunEnded,
   isLiveUnendedSubagentRun,
 } from "../../agents/subagents/registry/subagent-run-liveness.js";
-import { sortSubagentRuns } from "../../agents/subagents/registry/subagent-run-view.js";
 import { formatDurationCompact } from "../../infra/format-time/format-duration.ts";
 import { formatRunLabel } from "./subagents-utils.js";
 
-function formatActiveSubagentDetail(params: {
-  entry: SubagentRunRecord;
-  now: number;
-  pendingDescendants: number;
-}): string {
-  const { entry, now, pendingDescendants } = params;
-  const startedAt = entry.execution.startedAt ?? entry.sessionStartedAt ?? entry.createdAt;
-  const durationMs = Math.max(
-    0,
-    (entry.execution.endedAt && pendingDescendants === 0 ? entry.execution.endedAt : now) -
-      startedAt,
-  );
-  const duration = formatDurationCompact(durationMs, { spaced: true }) ?? "0s";
-  const label = formatRunLabel(entry, { maxLength: 56 });
-  const descendantText =
-    pendingDescendants > 0
-      ? ` · ${pendingDescendants} child${pendingDescendants === 1 ? "" : "ren"} active`
-      : "";
-  return `  • ${label} · ${duration}${descendantText}`;
-}
-
-/** Builds the compact status line for active and completed subagents. */
+/** Builds the compact status line from the controller's ordered snapshot and descendant index. */
 export function buildSubagentsStatusLine(params: {
-  runs: SubagentRunRecord[];
+  context: ReturnType<typeof buildControlledSubagentRunsReadContext>;
   verboseEnabled: boolean;
-  pendingDescendantsForRun: (entry: SubagentRunRecord) => number;
   now?: number;
 }): string | undefined {
-  const { runs, pendingDescendantsForRun, verboseEnabled } = params;
-  if (runs.length === 0) {
+  const { context, verboseEnabled } = params;
+  if (context.runs.length === 0) {
     return undefined;
   }
   const now = params.now ?? Date.now();
-  const details = sortSubagentRuns(runs).map((entry) => ({
-    entry,
-    pendingDescendants: pendingDescendantsForRun(entry),
-    now,
-  }));
-  const active = details.filter(
-    ({ entry, pendingDescendants }) =>
-      isLiveUnendedSubagentRun(entry, now) || pendingDescendants > 0,
-  );
-  const done = details.filter(
-    ({ entry, pendingDescendants }) => hasSubagentRunEnded(entry) && pendingDescendants === 0,
-  ).length;
-  if (active.length === 0) {
+  let active = 0;
+  let done = 0;
+  const detailLines: string[] = [];
+  for (const entry of context.runs) {
+    const pendingDescendants = context.countPendingDescendantRuns(entry.childSessionKey);
+    if (isLiveUnendedSubagentRun(entry, now) || pendingDescendants > 0) {
+      active += 1;
+      if (detailLines.length >= 3) {
+        continue;
+      }
+      const startedAt = entry.execution.startedAt ?? entry.sessionStartedAt ?? entry.createdAt;
+      const durationMs = Math.max(
+        0,
+        (entry.execution.endedAt && pendingDescendants === 0 ? entry.execution.endedAt : now) -
+          startedAt,
+      );
+      const duration = formatDurationCompact(durationMs, { spaced: true }) ?? "0s";
+      const label = formatRunLabel(entry, { maxLength: 56 });
+      const descendantText =
+        pendingDescendants > 0
+          ? ` · ${pendingDescendants} child${pendingDescendants === 1 ? "" : "ren"} active`
+          : "";
+      detailLines.push(`  • ${label} · ${duration}${descendantText}`);
+    } else if (hasSubagentRunEnded(entry) && pendingDescendants === 0) {
+      done += 1;
+    }
+  }
+  if (active === 0) {
     return verboseEnabled && done > 0 ? `🤖 Subagents: 0 active · ${done} done` : undefined;
   }
 
-  const summary = `🤖 Subagents: ${active.length} active${done > 0 ? ` · ${done} done` : ""}`;
-  const detailLines = active.slice(0, 3).map(formatActiveSubagentDetail);
+  const summary = `🤖 Subagents: ${active} active${done > 0 ? ` · ${done} done` : ""}`;
   return [summary, ...detailLines].join("\n");
 }

--- a/src/auto-reply/reply/commands-subagents.test.ts
+++ b/src/auto-reply/reply/commands-subagents.test.ts
@@ -7,11 +7,8 @@
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildControlledSubagentRunsReadContext } from "../../agents/subagents/registry/subagent-control-scope.js";
 import { SUBAGENT_ENDED_REASON_KILLED } from "../../agents/subagents/registry/subagent-lifecycle-events.js";
-import {
-  countPendingDescendantRuns,
-  listSubagentRunsForController,
-} from "../../agents/subagents/registry/subagent-registry-read.js";
 import {
   addSubagentRunForTests,
   releaseSubagentRun,
@@ -74,9 +71,8 @@ describe("subagents status", () => {
     }
 
     const text = buildSubagentsStatusLine({
-      runs: listSubagentRunsForController("agent:main:main"),
+      context: buildControlledSubagentRunsReadContext("agent:main:main"),
       verboseEnabled: true,
-      pendingDescendantsForRun: (entry) => countPendingDescendantRuns(entry.childSessionKey),
       now,
     });
 
@@ -163,12 +159,10 @@ describe("subagents status", () => {
     },
   ])("$name", ({ seedRuns, verboseLevel, expectedText, unexpectedText }) => {
     seedRuns();
-    const runs = listSubagentRunsForController("agent:main:main");
     const text =
       buildSubagentsStatusLine({
-        runs,
+        context: buildControlledSubagentRunsReadContext("agent:main:main"),
         verboseEnabled: verboseLevel === "on",
-        pendingDescendantsForRun: (entry) => countPendingDescendantRuns(entry.childSessionKey),
         now: 5000,
       }) ?? "";
     for (const expected of expectedText) {
@@ -177,6 +171,86 @@ describe("subagents status", () => {
     for (const blocked of unexpectedText) {
       expect(text).not.toContain(blocked);
     }
+  });
+
+  it.each([1, 2])(
+    "keeps the newest three details and %i pending children in the full counts",
+    (children) => {
+      const now = Date.now();
+      const parentKey = "agent:main:subagent:tie-a";
+      for (const [name, ageMs, ended] of [
+        ["tie-b", 2_000, false],
+        ["done", 3_000, true],
+        ["oldest", 4_000, false],
+        ["first", 1_000, false],
+        ["tie-a", 2_000, true],
+        ["stale", 3 * 60 * 60_000, false],
+      ] as const) {
+        addSubagentRunForTests({
+          runId: name,
+          childSessionKey: `agent:main:subagent:${name}`,
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: `${name} worker`,
+          cleanup: "keep",
+          createdAt: now - ageMs,
+          startedAt: now - ageMs,
+          endedAt: ended ? now - 500 : undefined,
+        });
+      }
+      for (let index = 0; index < children; index++) {
+        addSubagentRunForTests({
+          runId: `child-${index}`,
+          childSessionKey: `${parentKey}:subagent:${index}`,
+          requesterSessionKey: parentKey,
+          requesterDisplayKey: "tie-a",
+          task: "pending child",
+          cleanup: "keep",
+          createdAt: now - 1_000,
+          startedAt: now - 1_000,
+          endedAt: index > 0 ? now - 500 : undefined,
+        });
+      }
+
+      expect(
+        buildSubagentsStatusLine({
+          context: buildControlledSubagentRunsReadContext("agent:main:main"),
+          verboseEnabled: true,
+          now,
+        }),
+      ).toBe(
+        [
+          "🤖 Subagents: 4 active · 1 done",
+          "  • first worker · 1s",
+          "  • tie-b worker · 2s",
+          `  • tie-a worker · 2s · ${children} child${children === 1 ? "" : "ren"} active`,
+        ].join("\n"),
+      );
+    },
+  );
+
+  it.each([
+    { endedAt: Number.NaN, duration: "4s" },
+    { endedAt: Infinity, duration: "0s" },
+    { endedAt: -Infinity, duration: "0s" },
+  ])("preserves active duration for non-finite end $endedAt", ({ endedAt, duration }) => {
+    const run: SubagentRunRecord = {
+      runId: "non-finite-end",
+      childSessionKey: "agent:main:subagent:non-finite-end",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "active worker",
+      cleanup: "keep",
+      createdAt: 1_000,
+      execution: { status: "running", startedAt: 1_000, endedAt },
+    };
+    expect(
+      buildSubagentsStatusLine({
+        context: { runs: [run], countPendingDescendantRuns: () => 0 },
+        verboseEnabled: false,
+        now: 5_000,
+      }),
+    ).toBe(`🤖 Subagents: 1 active\n  • active worker · ${duration}`);
   });
 });
 

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -540,13 +540,10 @@ export async function buildStatusReplyParts(
       statusAgentId,
       cfg,
     );
-    const runs = subagentReadContext.runs;
     const verboseEnabled = resolvedVerboseLevel && resolvedVerboseLevel !== "off";
     subagentsLine = buildSubagentsStatusLine({
-      runs,
+      context: subagentReadContext,
       verboseEnabled,
-      pendingDescendantsForRun: (entry) =>
-        subagentReadContext.countPendingDescendantRuns(entry.childSessionKey),
     });
   }
   const groupActivation = isGroup


### PR DESCRIPTION
## What Problem This Solves

Requesting status for a session with many controlled subagents performs redundant list work before returning the compact summary.

## Why This Change Was Made

Pass the status caller's already prepared, ordered run context and descendant index into the formatter. Count active and completed runs in one traversal, removing the second sort, per-run wrapper array, and two filtered arrays.

## User Impact

Status output remains unchanged: visibility, stable ordering, complete active/done counts, pending descendants, duration precedence, labels, and the existing three-detail limit are preserved. Production LOC: +35/-47 (net -12). Tests: +83/-9 (net +74). Docs are unchanged.

## Evidence

A 500-run diagnostic removes one redundant sort, one large map, and two large filters. Descendant lookups remain exactly 500, and output is identical. The previous implementation already formatted at most three labels; this change preserves that limit.

Across 2,016 baseline/candidate cases, output and descendant-callback order match exactly, while input values, references, and ordering remain unchanged. The combined output SHA-256 is `3e772112f56ec5317fe11d3338f37a3152c41d0a93e84e75046408a0d4ae972d`.

All 110 tests across the subagent, status-command, and status-text suites passed, followed by all 29 stages of the changed-file gate and independent managed Codex review through P2. Initial lint findings were corrected while retaining the context method receiver; the final diagnostic, parity proof, tests, and gate were rerun.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/commands-subagents.test.ts \
  src/auto-reply/reply/commands-status.test.ts src/status/status-text.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/check-changed.mjs -- src/auto-reply/reply/commands-status-subagents.ts \
  src/status/status-text.ts src/auto-reply/reply/commands-subagents.test.ts
```

The built-Gateway status integration is complete on combined candidate `15216423e92c`, which contains this exact patch and the other 19 changes. Synthetic records were seeded through the canonical SQLite registry owner; no real subagent admissions or model turns were performed. Status showed `2 active · 1 done` with two pending children, then `0 active · 3 done` after settlement. Turning verbose off hid the settled summary, turning it on restored the summary, and clearing the registry removed it. All 44 recorded capture streams were verified; shutdown, process cleanup, port release and removal of the isolated runtime were confirmed. This verifies the candidate's built status path; the 2,016-case comparison above remains the before/after parity evidence. Normal native landing gates still apply. These operation counts do not establish CPU, latency, RSS, or overall sorting-complexity improvements.
