### PR TITLE
fix(compaction): stop cancelled queued preparation

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -3409,6 +3409,151 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     mockQueuedRouteAwareModel();
   });
 
+  it("reports target-only cancellation during prepared runtime lease admission", async () => {
+    const sourceController = new AbortController();
+    const admissionStarted = createDeferred<AbortSignal | undefined>();
+    acquireAgentRunPreparedModelRuntimeMock.mockImplementationOnce((async (
+      _input: Record<string, unknown>,
+      options?: { abortSignal?: AbortSignal },
+    ): Promise<never> => {
+      const signal = options?.abortSignal;
+      admissionStarted.resolve(signal);
+      if (!signal) {
+        throw new Error("prepared runtime lease admission did not receive the caller signal");
+      }
+      return await new Promise<never>((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => {
+            const error = new Error("Prepared model runtime lease admission aborted", {
+              cause: signal.reason,
+            });
+            error.name = "AbortError";
+            reject(error);
+          },
+          { once: true },
+        );
+      });
+    }) as never);
+
+    const pending = compactEmbeddedAgentSession(
+      wrappedCompactionArgs({ abortSignal: sourceController.signal, trigger: "manual" }),
+    );
+    const admittedSignal = expectDefined(
+      await admissionStarted.promise,
+      "prepared runtime lease admission signal",
+    );
+    expect(abortEmbeddedAgentRun(TEST_SESSION_ID)).toBe(true);
+
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      compacted: false,
+      reason: "compaction aborted",
+    });
+    expect(sourceController.signal.aborted).toBe(false);
+    expect(admittedSignal.aborted).toBe(true);
+    expect(isEmbeddedAgentRunHandleActive(TEST_SESSION_ID)).toBe(false);
+    expect(resolveContextEngineMock).not.toHaveBeenCalled();
+  });
+
+  it("releases the prepared runtime lease when host authority expires after admission", async () => {
+    const admissionStarted = createDeferred();
+    const releaseAdmission = createDeferred();
+    const releaseLease = vi.fn();
+    const defaultAcquire = expectDefined(
+      acquireAgentRunPreparedModelRuntimeMock.getMockImplementation(),
+      "default prepared runtime acquisition mock",
+    );
+    let hostActive = true;
+    acquireAgentRunPreparedModelRuntimeMock.mockImplementationOnce((async (
+      input: Record<string, unknown>,
+    ) => {
+      admissionStarted.resolve(undefined);
+      await releaseAdmission.promise;
+      const lease = await defaultAcquire(input);
+      return { ...lease, release: releaseLease };
+    }) as never);
+
+    const pending = compactEmbeddedAgentSession(wrappedCompactionArgs(), {
+      assertActive: () => {
+        if (!hostActive) {
+          throw new Error("queued compaction host authority expired");
+        }
+      },
+    });
+    await admissionStarted.promise;
+    hostActive = false;
+    releaseAdmission.resolve(undefined);
+
+    await expect(pending).rejects.toThrow("queued compaction host authority expired");
+    expect(releaseLease).toHaveBeenCalledTimes(1);
+    expect(resolveContextEngineMock).not.toHaveBeenCalled();
+  });
+
+  it("stops preparation when host authority expires during context-engine resolution", async () => {
+    const resolutionStarted = createDeferred();
+    const releaseResolution = createDeferred();
+    let hostActive = true;
+    resolveContextEngineMock.mockImplementationOnce(async () => {
+      resolutionStarted.resolve(undefined);
+      await releaseResolution.promise;
+      return {
+        info: { ownsCompaction: true },
+        compact: contextEngineCompactMock,
+      };
+    });
+
+    const pending = compactEmbeddedAgentSession(wrappedCompactionArgs(), {
+      assertActive: () => {
+        if (!hostActive) {
+          throw new Error("queued compaction host authority expired");
+        }
+      },
+    });
+    await resolutionStarted.promise;
+    hostActive = false;
+    releaseResolution.resolve(undefined);
+
+    await expect(pending).rejects.toThrow("queued compaction host authority expired");
+    expect(resolveModelAsyncMock).not.toHaveBeenCalled();
+    expect(selectAgentHarnessForPreparedModelProvidersMock).not.toHaveBeenCalled();
+    expect(contextEngineCompactMock).not.toHaveBeenCalled();
+  });
+
+  it("reports budget compaction cancellation during context-engine resolution", async () => {
+    const sourceController = new AbortController();
+    const resolutionStarted = createDeferred();
+    const releaseResolution = createDeferred();
+    resolveContextEngineMock.mockImplementationOnce(async () => {
+      resolutionStarted.resolve(undefined);
+      await releaseResolution.promise;
+      return {
+        info: { ownsCompaction: true },
+        compact: contextEngineCompactMock,
+      };
+    });
+
+    const pending = compactEmbeddedAgentSession(
+      wrappedCompactionArgs({
+        abortSignal: sourceController.signal,
+        trigger: "budget",
+      }),
+    );
+    await resolutionStarted.promise;
+    sourceController.abort(new Error("request timed out"));
+    releaseResolution.resolve(undefined);
+
+    await expect(pending).resolves.toEqual({
+      ok: false,
+      compacted: false,
+      reason: "compaction aborted",
+    });
+    expect(resolveModelAsyncMock).not.toHaveBeenCalled();
+    expect(selectAgentHarnessForPreparedModelProvidersMock).not.toHaveBeenCalled();
+    expect(contextEngineCompactMock).not.toHaveBeenCalled();
+    expect(enqueueCommandInLaneMock).not.toHaveBeenCalled();
+  });
+
   it("resolves the durable session key before invoking an owning context engine", async () => {
     const dir = await realpath(await mkdtemp(join(tmpdir(), "openclaw-compaction-session-key-")));
     const storePath = join(dir, "sessions.json");
@@ -3504,6 +3649,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     expect(result.ok).toBe(true);
     expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "marie-clawndo" }),
+      { abortSignal: undefined },
     );
   });
 
@@ -3557,6 +3703,66 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
         .preparedModelRuntime,
     ).toBe(snapshot);
     expect(dispose).toHaveBeenCalledTimes(1);
+    expect(enqueueCommandInLaneMock).not.toHaveBeenCalled();
+  });
+
+  it("stops preparation when host authority expires during model resolution before route rematerialization", async () => {
+    const modelResolutionStarted = createDeferred();
+    const releaseModelResolution = createDeferred();
+    const authStorage = { setRuntimeApiKey: vi.fn() };
+    let hostActive = true;
+    resolveModelAsyncMock.mockImplementationOnce(async () => {
+      modelResolutionStarted.resolve(undefined);
+      await releaseModelResolution.promise;
+      return {
+        model: {
+          provider: "openai",
+          id: "fake",
+          api: "openai-chatgpt-responses",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          input: [],
+        },
+        error: null,
+        authStorage,
+        modelRegistry: {},
+      };
+    });
+
+    const pending = compactEmbeddedAgentSession(
+      wrappedCompactionArgs({
+        provider: "openai",
+        model: "fake",
+        runtimeAuthPlan: {
+          providerForAuth: "openai",
+          authProfileProviderForAuth: "openai",
+          selectedAuthMode: "api-key",
+          modelRoute: {
+            provider: "openai",
+            modelId: "fake",
+            api: "openai-responses",
+            baseUrl: "https://api.openai.com/v1",
+            authRequirement: "api-key",
+            requestTransportOverrides: "none",
+          },
+        },
+      }),
+      {
+        assertActive: () => {
+          if (!hostActive) {
+            throw new Error("queued compaction host authority expired");
+          }
+        },
+      },
+    );
+    await modelResolutionStarted.promise;
+    hostActive = false;
+    releaseModelResolution.resolve(undefined);
+
+    await expect(pending).rejects.toThrow("queued compaction host authority expired");
+    expect(resolveModelAsyncMock).toHaveBeenCalledTimes(1);
+    expect(selectAgentHarnessForPreparedModelProvidersMock).not.toHaveBeenCalled();
+    expect(contextEngineCompactMock).not.toHaveBeenCalled();
+    expect(maybeCompactAgentHarnessSessionMock).not.toHaveBeenCalled();
     expect(enqueueCommandInLaneMock).not.toHaveBeenCalled();
   });
 

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -4682,6 +4682,76 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     }
   });
 
+  it("reports cancellation while queued native CLI compaction is in flight", async () => {
+    const agentDir = await realpath(tempDirs.make("openclaw-native-compaction-queued-abort-"));
+    const controller = new AbortController();
+    const cliStarted = createDeferred<AbortSignal>();
+    try {
+      await upsertSessionEntryCore(
+        {
+          agentId: "main",
+          sessionKey: TEST_SESSION_KEY,
+          storePath: join(agentDir, "sessions.json"),
+        },
+        { sessionId: TEST_SESSION_ID, updatedAt: 1 },
+      );
+      resolveCliBackendConfigMock.mockReturnValue({
+        id: "claude-cli",
+        ownsNativeCompaction: true,
+        manualCompaction: {
+          buildPrompt: () => "/compact",
+          input: "arg",
+          validateOutput: () => ({ ok: true }),
+        },
+      });
+      runCliAgentMock.mockImplementationOnce((async (params: { abortSignal?: AbortSignal }) => {
+        const signal = expectDefined(params.abortSignal, "native CLI compaction abort signal");
+        cliStarted.resolve(signal);
+        return await new Promise<never>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              const reason = signal.reason;
+              reject(reason instanceof Error ? reason : new Error("native CLI compaction aborted"));
+            },
+            { once: true },
+          );
+        });
+      }) as never);
+
+      const pending = compactEmbeddedAgentSession(
+        wrappedCompactionArgs({
+          abortSignal: controller.signal,
+          agentDir,
+          sessionTarget: {
+            agentId: "main",
+            sessionId: TEST_SESSION_ID,
+            sessionKey: TEST_SESSION_KEY,
+            storePath: join(agentDir, "sessions.json"),
+          },
+          trigger: "manual",
+          provider: "anthropic",
+          model: "opus",
+          agentHarnessId: "claude-cli",
+          cliSessionId: "native-session",
+        }),
+      );
+      const nativeSignal = await cliStarted.promise;
+      controller.abort(new Error("request timed out"));
+
+      await expect(pending).resolves.toEqual({
+        ok: false,
+        compacted: false,
+        reason: "compaction aborted",
+      });
+      expect(nativeSignal.aborted).toBe(true);
+      expect(resolveContextEngineMock).not.toHaveBeenCalled();
+      expect(isEmbeddedAgentRunHandleActive(TEST_SESSION_ID)).toBe(false);
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
+    }
+  });
+
   it("rejects a replaced writer claim before queued native CLI compaction", async () => {
     const agentDir = await realpath(
       await mkdtemp(join(tmpdir(), "openclaw-native-compaction-queued-replaced-")),

--- a/src/agents/embedded-agent-runner/compact.queued-execution.ts
+++ b/src/agents/embedded-agent-runner/compact.queued-execution.ts
@@ -21,6 +21,7 @@ import {
   type ContextEngineSessionTarget,
 } from "../../context-engine/types.js";
 import type { CapturedCompactionCheckpointSnapshot } from "../../gateway/session-compaction-checkpoints.js";
+import { isAbortError } from "../../infra/abort-signal.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
@@ -51,6 +52,25 @@ export type QueuedCompactionHostOptions = {
   assertActive?: () => void;
   onCommitted?: (accepted: AcceptedCompactionSuccessor) => void;
 };
+
+export function createQueuedCompactionAbortedResult(): EmbeddedAgentCompactResult {
+  return { ok: false, compacted: false, reason: "compaction aborted" };
+}
+
+export async function withQueuedCompactionCancellationResult(
+  params: Pick<CompactEmbeddedAgentSessionParams, "abortSignal">,
+  run: () => Promise<EmbeddedAgentCompactResult>,
+): Promise<EmbeddedAgentCompactResult> {
+  try {
+    return await run();
+  } catch (error) {
+    const signal = params.abortSignal;
+    if (!signal?.aborted || (!isAbortError(error) && error !== signal.reason)) {
+      throw error;
+    }
+    return createQueuedCompactionAbortedResult();
+  }
+}
 
 export function projectQueuedCompactionSessionTarget(
   params: CompactEmbeddedAgentSessionParams,
@@ -186,7 +206,7 @@ export async function executeQueuedContextEngineCompaction(input: {
       let checkpointSnapshotRetained = false;
       try {
         if (params.abortSignal?.aborted) {
-          return { ok: false, compacted: false, reason: "compaction aborted" };
+          return createQueuedCompactionAbortedResult();
         }
         assertActive();
         // When the context engine owns compaction, its compact() implementation
@@ -239,7 +259,7 @@ export async function executeQueuedContextEngineCompaction(input: {
           }
         }
         if (params.abortSignal?.aborted) {
-          return { ok: false, compacted: false, reason: "compaction aborted" };
+          return createQueuedCompactionAbortedResult();
         }
         assertActive();
         // Preserve the delegate's progress-aware watchdog and bound other engines.

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -42,9 +42,11 @@ import { resolveSessionPlacementSandbox } from "../session-placement-admission.j
 import { DEFERRED_CONTEXT_ENGINE_COMPACTION_REASON } from "./compact-reasons.js";
 import { compactNativeCliSession } from "./compact.js";
 import {
+  createQueuedCompactionAbortedResult,
   projectQueuedCompactionSessionTarget,
   executeQueuedContextEngineCompaction,
   type QueuedCompactionHostOptions,
+  withQueuedCompactionCancellationResult,
 } from "./compact.queued-execution.js";
 import type { CompactEmbeddedAgentSessionParams } from "./compact.types.js";
 import {
@@ -91,14 +93,15 @@ const DEFERRED_CONTEXT_ENGINE_COMPACTION_SCHEDULE_FAILURE_REASON =
   "failed to schedule background context-engine maintenance";
 const MANUAL_COMPACTION_ACTIVE_RUN_REASON =
   "manual compaction unavailable while another embedded run is active";
-const COMPACTION_ABORTED_REASON = "compaction aborted";
 
-function createCompactionAbortedResult(): EmbeddedAgentCompactResult {
-  return {
-    ok: false,
-    compacted: false,
-    reason: COMPACTION_ABORTED_REASON,
-  };
+function assertQueuedCompactionPreparationActive(
+  params: CompactEmbeddedAgentSessionParams,
+  host: QueuedCompactionHostOptions,
+): void {
+  // Preparation runs outside the execution queue. Revalidate after each await
+  // so a cancelled or replaced owner cannot continue expensive setup.
+  params.abortSignal?.throwIfAborted();
+  host.assertActive?.();
 }
 
 function resolveManualCompactionActiveRunSessionId(
@@ -237,11 +240,8 @@ export async function compactEmbeddedAgentSession(
     contextEngineAgentId,
   };
   if (resolvedParams.trigger !== "manual") {
-    return await compactEmbeddedAgentSessionImpl(
-      resolvedParams,
-      expectedEntry,
-      host,
-      contextEngineSessionKey,
+    return await withQueuedCompactionCancellationResult(resolvedParams, () =>
+      compactEmbeddedAgentSessionImpl(resolvedParams, expectedEntry, host, contextEngineSessionKey),
     );
   }
   // Reply operations and embedded handles are separate lifecycle owners. A
@@ -268,6 +268,7 @@ export async function compactEmbeddedAgentSession(
     abort: (reason) => controller.abort(reason ?? "user_abort"),
     cancel: (reason) => controller.abort(reason ?? "user_abort"),
   };
+  const activeParams = { ...resolvedParams, abortSignal };
   setActiveEmbeddedRun(
     resolvedParams.sessionId,
     handle,
@@ -276,14 +277,8 @@ export async function compactEmbeddedAgentSession(
     resolvedParams.agentId,
   );
   try {
-    return await compactEmbeddedAgentSessionImpl(
-      {
-        ...resolvedParams,
-        abortSignal,
-      },
-      expectedEntry,
-      host,
-      contextEngineSessionKey,
+    return await withQueuedCompactionCancellationResult(activeParams, () =>
+      compactEmbeddedAgentSessionImpl(activeParams, expectedEntry, host, contextEngineSessionKey),
     );
   } finally {
     clearActiveEmbeddedRun(
@@ -332,7 +327,7 @@ async function compactEmbeddedAgentSessionImpl(
   contextEngineSessionKey?: string,
 ): Promise<EmbeddedAgentCompactResult> {
   if (params.abortSignal?.aborted) {
-    return createCompactionAbortedResult();
+    return createQueuedCompactionAbortedResult();
   }
   host.assertActive?.();
   const runtimeTarget = params.sessionTarget;
@@ -356,6 +351,7 @@ async function compactEmbeddedAgentSessionImpl(
           workspaceDir: resolvedWorkspaceDir,
         })
       : null;
+  assertQueuedCompactionPreparationActive(params, host);
   const preparedParams = placementSandbox ? { ...params, sandbox: placementSandbox } : params;
   const runtimeSelection = resolveCompactionRuntimeSelection({
     ...preparedParams,
@@ -364,10 +360,6 @@ async function compactEmbeddedAgentSessionImpl(
     preparedRuntimePlan: preparedParams.runtimePlan,
     selectedHarnessRuntime: resolveSessionPinnedHarnessId(preparedParams.sessionEntry),
   });
-  if (params.abortSignal?.aborted) {
-    return createCompactionAbortedResult();
-  }
-  host.assertActive?.();
   // Native control operations reuse the backend's existing authenticated session.
   // Run them before generic model preparation so subscription-only CLI sessions do
   // not incorrectly require an OpenClaw model API credential.
@@ -384,23 +376,27 @@ async function compactEmbeddedAgentSessionImpl(
   if (nativeCliResult) {
     return nativeCliResult;
   }
-  const lease = await acquireAgentRunPreparedModelRuntime({
-    config: params.config ?? {},
-    agentId: agentIds.sessionAgentId,
-    agentDir,
-    workspaceDir: resolvedWorkspaceDir,
-    ...(params.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
-    runtimePluginSelections: [
-      {
-        provider: runtimeSelection.provider,
-        modelId: runtimeSelection.modelId,
-        ...(runtimeSelection.selectedHarnessRuntime
-          ? { runtime: runtimeSelection.selectedHarnessRuntime }
-          : {}),
-        agentId: agentIds.sessionAgentId,
-      },
-    ],
-  });
+  assertQueuedCompactionPreparationActive(params, host);
+  const lease = await acquireAgentRunPreparedModelRuntime(
+    {
+      config: params.config ?? {},
+      agentId: agentIds.sessionAgentId,
+      agentDir,
+      workspaceDir: resolvedWorkspaceDir,
+      ...(params.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
+      runtimePluginSelections: [
+        {
+          provider: runtimeSelection.provider,
+          modelId: runtimeSelection.modelId,
+          ...(runtimeSelection.selectedHarnessRuntime
+            ? { runtime: runtimeSelection.selectedHarnessRuntime }
+            : {}),
+          agentId: agentIds.sessionAgentId,
+        },
+      ],
+    },
+    { abortSignal: params.abortSignal },
+  );
   const run = async () => {
     ensureContextEnginesInitialized();
     const contextEngine = await resolveContextEngine(params.config, {
@@ -409,6 +405,7 @@ async function compactEmbeddedAgentSessionImpl(
     });
     let disposeContextEngineOnExit = true;
     try {
+      assertQueuedCompactionPreparationActive(params, host);
       // Foreground disposal belongs to this finally. Only accepted background
       // maintenance transfers engine ownership away from this call.
       return await compactResolvedContextEngine(
@@ -431,6 +428,7 @@ async function compactEmbeddedAgentSessionImpl(
     }
   };
   try {
+    assertQueuedCompactionPreparationActive(params, host);
     return await withPluginRuntimeGenerationScope(lease.snapshot, run);
   } finally {
     lease.release();
@@ -486,6 +484,7 @@ async function compactResolvedContextEngine(
     workspaceDir: resolvedWorkspaceDir,
     pluginRegistry: requireActivePluginRegistry(),
   });
+  assertQueuedCompactionPreparationActive(params, host);
   const { resolution: modelResolution } = await resolveTieredModel({
     provider: ceRuntimeProvider,
     modelId: ceModelId,
@@ -495,6 +494,7 @@ async function compactResolvedContextEngine(
     ...initialModelAuth,
     preparedModelRuntime,
   });
+  assertQueuedCompactionPreparationActive(params, host);
   const { model: ceModel, authStorage, modelRegistry } = modelResolution;
   const ceRuntimeModel = ceModel as ProviderRuntimeModel | undefined;
   // Overrides stay unset when no bound/planned/explicit harness resolved so auth-aware
@@ -518,6 +518,7 @@ async function compactResolvedContextEngine(
     agentHarnessRuntimeOverride: selectedHarnessRuntime,
     convergenceErrorPrefix: "Prepared queued compaction",
   });
+  assertQueuedCompactionPreparationActive(params, host);
   const preparedHarnessRuntime = selectedPreparedHarness.id;
   const attemptNativeHarnessCompaction =
     selectedNativeHarnessCompaction && preparedHarnessRuntime !== "openclaw";
@@ -542,9 +543,11 @@ async function compactResolvedContextEngine(
         authProfileId,
         authProfileMode,
       });
+      assertQueuedCompactionPreparationActive(params, host);
       return { ...resolved, model: resolved.model as ProviderRuntimeModel | undefined };
     },
   });
+  assertQueuedCompactionPreparationActive(params, host);
   const preparedParams: QueuedCompactionParams = {
     ...params,
     provider: ceProvider,
@@ -593,17 +596,13 @@ async function compactResolvedContextEngine(
     contextEngineSelectionSource: contextEngine.info.id === "legacy" ? "default" : "configured",
     promptTokenBudget: contextTokenBudget,
   });
-  if (params.abortSignal?.aborted) {
-    return createCompactionAbortedResult();
-  }
-  host.assertActive?.();
   const contextEngineOwnsCompaction = contextEngine.info.ownsCompaction === true;
   let requiredPreflightNativeCapabilityUsed = false;
   const harnessResult =
     attemptNativeHarnessCompaction && (!contextEngineOwnsCompaction || lockedNativeHarness)
       ? await runPrimaryNativeCompactionInLanes(preparedParams, expectedEntry, host, async () => {
           if (params.abortSignal?.aborted) {
-            return createCompactionAbortedResult();
+            return createQueuedCompactionAbortedResult();
           }
           return await maybeCompactAgentHarnessSession(
             {
@@ -648,7 +647,7 @@ async function compactResolvedContextEngine(
     );
   }
   if (params.abortSignal?.aborted) {
-    return createCompactionAbortedResult();
+    return createQueuedCompactionAbortedResult();
   }
   host.assertActive?.();
   if (

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -4,6 +4,7 @@
 import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
 import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import { projectPublicSessionEntry } from "../../config/sessions/session-entry-projection.js";
+import { isAbortError } from "../../infra/abort-signal.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
@@ -165,6 +166,10 @@ export async function compactNativeCliSession(params: {
       await runControlOperation();
     }
   } catch (err) {
+    const signal = params.compactParams.abortSignal;
+    if (signal?.aborted && (isAbortError(err) || err === signal.reason)) {
+      throw err;
+    }
     return {
       ok: false,
       compacted: false,


### PR DESCRIPTION
Related: #138184

## What Problem This Solves

Fixes an issue where queued compaction could continue preparing a model after
the caller cancelled or the session host lost authority. That stale work could
retain a prepared-runtime lease, and native CLI cancellation could be reported
as an ordinary backend failure instead of a cancelled compaction.

## Why This Change Was Made

Queued execution now revalidates cancellation and host authority at the
preparation owner after each asynchronous boundary, and releases any acquired
prepared-runtime lease from one lifecycle-owned cleanup path. Native CLI
signal-owned aborts remain exceptions until the queued owner converts them to
the public cancellation result; ordinary CLI failures remain result-based and
completed work still wins over a late abort.

This is separate from #138473, which repairs Codex thread-binding continuity
after a committed compaction successor.

## User Impact

Stop and timeout requests now halt stale queued compaction before further model
or context-engine work. A cancelled native CLI compaction reports
`compaction aborted`, and replacement session owners do not inherit abandoned
preparation or leases.

## Evidence

Exact signed head: `dce2f6535e47cf1bc72d0c37aca278099c7d00c0`.

- Red proof: caller cancellation and host expiry previously allowed another
  model-resolution step.
- Red proof: native CLI cancellation previously surfaced a backend failure
  containing `request timed out` instead of `compaction aborted`.
- Exact-head owner/sibling suite: 227 tests passed across prepared-runtime
  cancellation, queued/native compaction, successor ownership, and overflow
  recovery.
- Exact-head `node scripts/check-changed.mjs`: passed with `core` and
  `coreTests`; no temp-directory warnings.
- Exact-head hosted CI: 130 successful checks, 52 intentionally skipped,
  0 failed or pending in
  https://github.com/openclaw/openclaw/actions/runs/33923172518.
- Native `scripts/pr prepare-run` accepted that hosted exact-head proof and
  recorded `gates_mode=hosted_exact_or_recent_parent`.
- Autoreview at P0-P2: scoped clean, no findings, confidence 0.98.
- Local ClawSweeper: no concrete bug, regression, or security issue; best-fix
  verdict was the queued lifecycle owner. Its sandbox could not start Vitest
  because artifact writes are read-only, so the executable proof is the
  separate exact-head run above.
- Current Codex source inspected at
  `3921a30d6b11218883e5bb81a48082095cf79b7c`: task cancellation is expected to
  terminate promptly, and `TurnAborted` owns aborted-turn lifecycle handling
  (`codex-rs/core/src/tasks/mod.rs:187`,
  `codex-rs/core/src/tasks/compact.rs:28`).
- Live `origin/main` was checked at
  `6e42083f34e74d122d9773d163e3604dfe9da629`; no intervening commit touched the
  four changed files, so the branch was not cosmetically rebased.

## Maintainer Decision

Approved for self-landing after exact-head gates. The +24 production-line delta
is accepted because the distinct post-await checks protect caller cancellation,
host authority, and one lease-release owner; collapsing them to one downstream
guard would leave stale preparation running. Native review artifacts record no
findings and recommend `READY FOR /prepare-pr`.

ClawSweeper's medium-confidence limitation was its read-only/partial-clone
environment, not a source finding. The missing evidence is supplied above by
the exact-head hosted matrix, the 227-test local owner/sibling run, and the live
main overlap check.

Production LOC: +74/-50 (net +24) | Tests: +276/-0.

The positive production delta carries cancellation and host-authority facts
through the existing queued owner and provides one lease-release boundary.
Moving the checks downstream would leave stale preparation active; swallowing
abort at the native backend boundary reproduces the original failure.

No config, schema, dependency, protocol, docs, or changelog surface changes.
