### PR TITLE
fix(ci): retain failure diagnostics and shard provenance

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -155,6 +155,20 @@ lease ID, and reuse it with `run --id <tbx_id>`. Stop the owned lease with
   `--script*`, `--env-helper`, capture/download flags, and `--stop-after` are not
   a substitute for the delegated Testbox workflow.
 
+When remote sync uses a temporary checkout, the wrapper preserves native
+`.crabbox/runs` and `.crabbox/captures` outputs together beneath a fresh
+`.crabbox/wrapper-artifacts/run-*` directory before removing that checkout.
+Repeated runs retain separate evidence even when native filenames match. The
+wrapper prints the old-to-new root mapping; native logs and generated proof may
+still reference the old paths. A preservation error fails the wrapper and retains
+the temporary checkout at the reported path for manual recovery.
+
+These are local artifacts, not published or fully sanitized proof. Blacksmith's
+native failure bundle contains captured stdout/stderr and diagnostic metadata;
+it does not automatically include remote UI screenshots or reports. Retrieve
+those separately before stopping the owned Testbox, and inspect all artifacts
+for secrets and private data before sharing.
+
 The native Windows Testbox idle monitor uses the running `sshd` service's local
 listener ports, not Blacksmith's externally forwarded SSH port. Established SSH
 connections keep the job alive; the `~/.testbox-last-activity` modification time
@@ -511,7 +525,12 @@ do not describe a replay as recovery of lost files.
 
 Timeout diagnostics allocate fresh children beneath the existing
 `OPENCLAW_UI_E2E_DIAGNOSTIC_DIR` or default timeout directory, keeping each PNG and
-JSON report together. Mantis allocates an invocation directory for setup logs,
+JSON report together. Their `ci.shardIndex` and `ci.vitestShardCount` fields record
+`VITEST_SHARD_INDEX` and `VITEST_SHARD_COUNT`, respectively, as supplied by normal
+CI. Missing values remain `null`; manual and separate release E2E invocations do
+not infer this metadata from Vitest's `--shard` argument.
+
+Mantis allocates an invocation directory for setup logs,
 capture attempts, and its report; the builder preserves each attempt's relative
 paths and refuses to overwrite an existing report.
 

--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -1381,31 +1381,30 @@ function observeBlacksmithTimingJSONLine(line: string) {
   }
 }
 
-function preserveTemporaryCrabboxRuns() {
+function preserveTemporaryCrabboxArtifacts() {
   if (childCwd === repoRoot) {
     return;
   }
-
-  const sourceRuns = resolve(childCwd, ".crabbox", "runs");
-  if (!pathExists(sourceRuns)) {
+  const sourceRoot = resolve(childCwd, ".crabbox");
+  const directories = ["runs", "captures"].filter((name) => {
+    const source = resolve(sourceRoot, name);
+    return statSync(source, { throwIfNoEntry: false }) && readdirSync(source).length > 0;
+  });
+  if (directories.length === 0) {
     return;
   }
 
-  const targetRuns = resolve(repoRoot, ".crabbox", "runs");
-  mkdirSync(targetRuns, { recursive: true });
-  let preserved = 0;
-  for (const entry of readdirSync(sourceRuns)) {
-    cpSync(resolve(sourceRuns, entry), resolve(targetRuns, entry), {
-      recursive: true,
-      force: true,
-    });
-    preserved += 1;
+  // Native artifacts reuse lease names. Keep each invocation together without
+  // overwriting earlier evidence, and copy only outputs, never other Crabbox state.
+  const retainedRoot = resolve(repoRoot, ".crabbox", "wrapper-artifacts");
+  mkdirSync(retainedRoot, { recursive: true });
+  const destination = mkdtempSync(resolve(retainedRoot, "run-"));
+  for (const name of directories) {
+    cpSync(resolve(sourceRoot, name), resolve(destination, name), { recursive: true });
   }
-  if (preserved > 0) {
-    console.error(
-      `[crabbox] preserved ${preserved} temporary run artifact ${preserved === 1 ? "directory" : "directories"} under ${relative(repoRoot, targetRuns)}`,
-    );
-  }
+  console.error(
+    `[crabbox] preserved temporary artifacts: ${sourceRoot} -> ${relative(repoRoot, destination)}`,
+  );
 }
 
 function shellQuote(value: string) {
@@ -4006,7 +4005,14 @@ function cleanupOnce() {
     // so restore the real repo or every later reuse needs --reclaim.
     restoreTemporaryBlacksmithTestboxClaim(normalizedArgs, capturedBlacksmithLeaseId);
   }
-  preserveTemporaryCrabboxRuns();
+  try {
+    preserveTemporaryCrabboxArtifacts();
+  } catch (error) {
+    console.error(
+      `[crabbox] artifact preservation failed; temporary checkout retained at ${childCwd}`,
+    );
+    throw error;
+  }
   cleanupChildCwd();
 }
 

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -14,7 +14,6 @@ import {
   realpathSync,
   renameSync,
   rmSync,
-  statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -153,7 +152,10 @@ async function main() {
     process.exit(ready ? 0 : 1);
   }
   if (args[0] === "run" || args[0] === "warmup") { ${stampClaimScript} }
-  const runStatus = Number.parseInt(process.env.OPENCLAW_FAKE_CRABBOX_RUN_STATUS || "0", 10); if (args[0] === "run" && runStatus !== 0) { process.stderr.write("fake run failure\n"); process.exit(runStatus); }
+  if (args[0] === "run" && process.env.OPENCLAW_FAKE_CRABBOX_ARTIFACTS) {
+    for (const [file, bytes] of Object.entries(JSON.parse(process.env.OPENCLAW_FAKE_CRABBOX_ARTIFACTS))) { fs.mkdirSync(path.dirname(file), { recursive: true }); fs.writeFileSync(file, Buffer.from(bytes, "base64")); }
+  }
+  const runStatus = Number.parseInt(process.env.OPENCLAW_FAKE_CRABBOX_RUN_STATUS || "0", 10); if (args[0] === "run" && runStatus !== 0) { process.stdout.write(JSON.stringify({ args, cwd: process.cwd() }) + "\n"); process.stderr.write("fake run failure\n"); process.exit(runStatus); }
   if (args[0] === "config" && args[1] === "show" && args.includes("--json")) {
     const status = Number.parseInt(process.env.OPENCLAW_FAKE_CRABBOX_CONFIG_STATUS || "0", 10);
     if (status !== 0) { process.stderr.write("config unavailable\n"); process.exit(status); }
@@ -166,7 +168,6 @@ async function main() {
     if (status !== 0) { process.stderr.write('coordinator GET /v1/whoami: http 401: {"error":"unauthorized"}\n'); process.exit(status); }
     process.stdout.write("fake-crabbox-user\n"); return;
   }
-  if (args.includes("--artifact-glob") || args.includes("-artifact-glob")) { fs.mkdirSync(".crabbox/runs/run_fake", { recursive: true }); fs.writeFileSync(".crabbox/runs/run_fake/fake-artifacts.tgz", "fake artifact\n"); }
   const scriptIndex = args.findIndex((arg) => arg === "--script" || arg === "-script"); const scriptPath = scriptIndex >= 0 ? args[scriptIndex + 1] : "";
   const scriptContent = scriptPath ? fs.readFileSync(scriptPath, "utf8") : "";
   if (process.env.OPENCLAW_FAKE_CRABBOX_DELETE_CWD_AND_EXIT === "1") {
@@ -4832,31 +4833,144 @@ describe("scripts/crabbox-wrapper", () => {
     expect(output.args).toContain(`/tmp/proof=${path.join(repoRoot, ".artifacts/proof")}`);
   });
 
-  it("preserves artifact-glob downloads from temporary sparse-sync checkouts", () => {
-    const preservedDir = path.join(repoRoot, ".crabbox", "runs", "run_fake");
-    rmSync(preservedDir, { recursive: true, force: true });
-
-    const { output, result } = runSuccessfulDefaultWrapper(
-      [
-        "run",
-        "--provider",
-        "blacksmith-testbox",
-        "--blacksmith-ref",
-        "main",
-        "--artifact-glob",
-        ".artifacts/proof/**",
-        "--",
-        "echo ok",
-      ],
-      cleanSparseSyncOptions,
-    );
-
-    expect(output.cwd).toContain("openclaw-crabbox-sync-");
-    expect(result.stderr).toContain("syncing from temporary full checkout");
-    expect(result.stderr).toContain("preserved");
-    expect(statSync(path.join(preservedDir, "fake-artifacts.tgz")).isFile()).toBe(true);
-    rmSync(preservedDir, { recursive: true, force: true });
-  });
+  it.each([
+    { mode: "capsule", artifacts: "captures", exitCode: 23 },
+    { mode: "capsule", artifacts: "both", exitCode: 23 },
+    { mode: "sparse", artifacts: "both", exitCode: 23 },
+    { mode: "capsule", artifacts: "runs", exitCode: 0 },
+    { mode: "capsule", artifacts: "none", exitCode: 0 },
+    { mode: "direct", artifacts: "captures", exitCode: 23 },
+    { mode: "capsule", artifacts: "both", exitCode: 0, blocked: true },
+  ])(
+    "retains native artifacts through the wrapper ($mode, $artifacts, exit=$exitCode, blocked=$blocked)",
+    ({ mode, artifacts, exitCode, blocked }) => {
+      const root = realpathSync(makeTempDir(tempDirs, "openclaw-wrapper-artifacts-"));
+      const producer = path.join(root, "repo");
+      const syncRoot = path.join(root, "sync");
+      const fixtureWrapper = path.join(producer, ".tmp", "crabbox-wrapper.mjs");
+      mkdirSync(path.dirname(fixtureWrapper), { recursive: true });
+      copyFileSync(realBundledWrapperPath, fixtureWrapper);
+      const env = {
+        ...process.env,
+        ...testHomeEnv(path.join(root, "home")),
+        PATH: [makeFakeCrabbox(defaultProviderHelp), process.env.PATH ?? ""].join(path.delimiter),
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_NOSYSTEM: "1",
+        GIT_AUTHOR_NAME: "Artifact fixture",
+        GIT_AUTHOR_EMAIL: "fixture@example.invalid",
+        GIT_COMMITTER_NAME: "Artifact fixture",
+        GIT_COMMITTER_EMAIL: "fixture@example.invalid",
+        CRABBOX_PROVIDER: "",
+        CRABBOX_TARGET: "",
+        CRABBOX_TARGET_OS: "",
+        CRABBOX_WINDOWS_MODE: "",
+        OPENCLAW_CRABBOX_WRAPPER_IGNORE_REPO_BINARY: "1",
+        OPENCLAW_CRABBOX_SYNC_TMPDIR: syncRoot,
+        OPENCLAW_CRABBOX_SYNC_MIN_FREE_BYTES: "0",
+        OPENCLAW_FAKE_CRABBOX_RUN_STATUS: String(exitCode),
+      };
+      const git = (...args: string[]) => {
+        const result = spawnSync("git", args, { cwd: producer, env, encoding: "utf8" });
+        expect(result.status, result.stderr).toBe(0);
+        return result.stdout.trim();
+      };
+      git("init", "-q", "-b", "main");
+      writeFileSync(path.join(producer, ".gitignore"), ".tmp/\n.crabbox/\n");
+      writeFileSync(path.join(producer, "fixture.txt"), "source fixture\n");
+      git("add", ".gitignore", "fixture.txt");
+      git("commit", "-qm", "fixture");
+      git("remote", "add", "origin", producer);
+      git("update-ref", "refs/remotes/origin/main", "HEAD");
+      if (mode === "sparse") {
+        git("sparse-checkout", "set", "--no-cone", "/fixture.txt");
+      }
+      const capturePath = ".crabbox/captures/tbx_fixture-20260904T190427Z.tar.gz";
+      const runPath = ".crabbox/runs/run_fixture/proof/nested.json";
+      const bytes = Buffer.from([0x1f, 0x8b, 0, 255, 13, 10, 128]);
+      const files = [
+        ...(artifacts === "captures" || artifacts === "both" ? [capturePath] : []),
+        ...(artifacts === "runs" || artifacts === "both" ? [runPath] : []),
+      ];
+      const previousFile = path.join(
+        producer,
+        mode === "direct" ? ".crabbox/captures/older.tgz" : capturePath,
+      );
+      mkdirSync(path.dirname(previousFile), { recursive: true });
+      writeFileSync(previousFile, "prior evidence\n");
+      const retainedRoot = path.join(producer, ".crabbox", "wrapper-artifacts");
+      if (blocked) {
+        writeFileSync(retainedRoot, "not a directory\n");
+      }
+      const retainedDirectories: string[] = [];
+      const attempts = mode === "capsule" && artifacts === "both" && !blocked ? 2 : 1;
+      for (let attempt = 0; attempt < attempts; attempt += 1) {
+        const result = spawnSync(
+          process.execPath,
+          [
+            fixtureWrapper,
+            "run",
+            "--provider",
+            mode === "capsule" ? "blacksmith-testbox" : "local-container",
+            "--",
+            "false",
+          ],
+          {
+            cwd: producer,
+            env: {
+              ...env,
+              OPENCLAW_FAKE_CRABBOX_ARTIFACTS: JSON.stringify(
+                Object.fromEntries(files.map((file) => [file, bytes.toString("base64")])),
+              ),
+            },
+            encoding: "utf8",
+            timeout: 10_000,
+          },
+        );
+        expect(result.error, result.stderr).toBeUndefined();
+        const output = parseFakeCrabboxOutput(result);
+        expect(readFileSync(previousFile, "utf8")).toBe("prior evidence\n");
+        if (blocked) {
+          expect(result.status).not.toBe(0);
+          expect(result.stderr).toContain("temporary checkout retained");
+          expect(result.stderr).toContain(output.cwd);
+          for (const file of files) {
+            expect(readFileSync(path.join(output.cwd, file))).toEqual(bytes);
+          }
+          expect(readFileSync(retainedRoot, "utf8")).toBe("not a directory\n");
+          continue;
+        }
+        expect(result.status, result.stderr).toBe(exitCode);
+        if (mode === "direct") {
+          expect(output.cwd).toBe(producer);
+          expect(existsSync(retainedRoot)).toBe(false);
+          for (const file of files) {
+            expect(readFileSync(path.join(producer, file))).toEqual(bytes);
+          }
+        } else {
+          expect(output.cwd).not.toBe(producer);
+          expect(existsSync(output.cwd)).toBe(false);
+          expect(readdirSync(syncRoot)).toEqual([]);
+          if (files.length === 0) {
+            expect(existsSync(retainedRoot)).toBe(false);
+          } else {
+            const relocated = result.stderr.match(/preserved temporary artifacts: (.+) -> (.+)/u);
+            expect(relocated?.[1]).toBe(path.join(output.cwd, ".crabbox"));
+            const retained = path.resolve(producer, relocated![2]!);
+            expect(retainedDirectories).not.toContain(retained);
+            retainedDirectories.push(retained);
+            for (const directory of retainedDirectories) {
+              for (const file of files) {
+                expect(readFileSync(path.join(directory, path.relative(".crabbox", file)))).toEqual(
+                  bytes,
+                );
+              }
+            }
+          }
+        }
+      }
+      expect(git("status", "--porcelain")).toBe("");
+    },
+  );
 
   it("uses the temporary full checkout for sparse sync-only runs", () => {
     const { output, result } = runSuccessfulDefaultWrapper(

--- a/ui/src/test-helpers/control-ui-e2e.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.test.ts
@@ -17,43 +17,65 @@ describe("shared proof capture", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   afterEach(() => vi.unstubAllEnvs());
 
-  it("keeps each failure screenshot and report in its own retained directory", async () => {
-    const parent = tempDirs.make("control-ui-failure-proof-");
-    vi.stubEnv("OPENCLAW_UI_E2E_DIAGNOSTIC_DIR", parent);
-    writeFileSync(path.join(parent, "prior.png"), "prior-proof");
-    // SAFETY: this fixture implements the Page boundary used by failure diagnostics.
-    const page = {
-      evaluate: async () => ({ marker: "failed-page" }),
-      isClosed: () => false,
-      url: () => "http://127.0.0.1/chat",
-      screenshot: async (options: { path: string }) => {
-        writeFileSync(options.path, "failure-proof");
-        return Buffer.from("failure-proof");
-      },
-    } as unknown as Page;
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      await captureControlUiE2eFailureDiagnostics(page, {
-        error: new Error("Synthetic request timeout"),
-        label: "chat.send",
-      });
-    }
-    const directories = readdirSync(parent, { withFileTypes: true }).filter((entry) =>
-      entry.isDirectory(),
-    );
-    expect(directories).toHaveLength(2);
-    for (const directory of directories) {
-      const root = path.join(parent, directory.name);
-      const files = readdirSync(root);
-      expect(files).toHaveLength(2);
-      const reportFile = files.find((file) => file.endsWith(".json"));
-      expect(reportFile).toBeDefined();
-      const report = JSON.parse(readFileSync(path.join(root, reportFile!), "utf8"));
-      expect(report).toMatchObject({ label: "chat.send", captureErrors: [] });
-      expect(files).toContain(report.screenshot);
-      expect(readFileSync(path.join(root, report.screenshot), "utf8")).toBe("failure-proof");
-    }
-    expect(readFileSync(path.join(parent, "prior.png"), "utf8")).toBe("prior-proof");
-  });
+  it.each([
+    { shardIndex: "5", shardCount: "6" },
+    { shardIndex: undefined, shardCount: undefined },
+  ])(
+    "retains each failure capture with its shard provenance ($shardIndex/$shardCount)",
+    async ({ shardIndex, shardCount }) => {
+      const parent = tempDirs.make("control-ui-failure-proof-");
+      vi.stubEnv("OPENCLAW_UI_E2E_DIAGNOSTIC_DIR", parent);
+      vi.stubEnv("VITEST_SHARD_INDEX", shardIndex);
+      vi.stubEnv("VITEST_SHARD_COUNT", shardCount);
+      vi.stubEnv("SHARD_INDEX", shardIndex ? undefined : "unrelated-shard");
+      vi.stubEnv("GITHUB_JOB", "checks-ui-e2e");
+      vi.stubEnv("GITHUB_RUN_ID", "123456");
+      vi.stubEnv("GITHUB_RUN_ATTEMPT", "2");
+      writeFileSync(path.join(parent, "prior.png"), "prior-proof");
+      // SAFETY: this fixture implements the Page boundary used by failure diagnostics.
+      const page = {
+        evaluate: async () => ({ marker: "failed-page" }),
+        isClosed: () => false,
+        url: () => "http://127.0.0.1/chat",
+        screenshot: async (options: { path: string }) => {
+          writeFileSync(options.path, "failure-proof");
+          return Buffer.from("failure-proof");
+        },
+      } as unknown as Page;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        await captureControlUiE2eFailureDiagnostics(page, {
+          error: new Error("Synthetic request timeout"),
+          label: "chat.send",
+        });
+      }
+      const directories = readdirSync(parent, { withFileTypes: true }).filter((entry) =>
+        entry.isDirectory(),
+      );
+      expect(directories).toHaveLength(2);
+      for (const directory of directories) {
+        const root = path.join(parent, directory.name);
+        const files = readdirSync(root);
+        expect(files).toHaveLength(2);
+        const reportFile = files.find((file) => file.endsWith(".json"));
+        expect(reportFile).toBeDefined();
+        const report = JSON.parse(readFileSync(path.join(root, reportFile!), "utf8"));
+        expect(report).toMatchObject({
+          label: "chat.send",
+          captureErrors: [],
+          ci: {
+            githubJob: "checks-ui-e2e",
+            runAttempt: "2",
+            runId: "123456",
+            shardIndex: shardIndex ?? null,
+            vitestShardCount: shardCount ?? null,
+          },
+        });
+        expect(files).toContain(report.screenshot);
+        expect(readFileSync(path.join(root, report.screenshot), "utf8")).toBe("failure-proof");
+      }
+      expect(readFileSync(path.join(parent, "prior.png"), "utf8")).toBe("prior-proof");
+    },
+  );
 
   it("keeps shared capture disabled until its gate is enabled and uses the supplied owner", async () => {
     const parent = tempDirs.make("control-ui-proof-capture-");

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -3257,7 +3257,7 @@ async function captureControlUiE2eFailureDiagnosticsUnsafe(
       githubJob: process.env.GITHUB_JOB ?? null,
       runAttempt: process.env.GITHUB_RUN_ATTEMPT ?? null,
       runId: process.env.GITHUB_RUN_ID ?? null,
-      shardIndex: process.env.SHARD_INDEX ?? null,
+      shardIndex: process.env.VITEST_SHARD_INDEX ?? null,
       vitestShardCount: process.env.VITEST_SHARD_COUNT ?? null,
     },
     pageEvents: [...pageEvents],


### PR DESCRIPTION
Closes #138650 — failure captures lost during temporary CI sync checkout cleanup.
Related: #138482 — keep ready PR checks alive after delayed draft events; this diagnostic follow-up is independent of that admission fix.

<details>
<summary>Additional instructions</summary>

This is a same-repository branch, writable by repository maintainers. GitHub's fork-only maintainer-edit flag does not govern this branch.

</details>

## What Problem This Solves

Resolves a problem where maintainers diagnosing failed remote validation received a local failure-bundle path that disappeared when the wrapper cleaned up its temporary sync checkout. Repeated native artifact filenames could also overwrite earlier retained evidence.

The same investigation found Control UI E2E reports losing their shard index even though CI correctly executed the requested native shard. This PR repairs diagnostic retention and attribution only; it does not change the underlying browser behavior or CI admission/concurrency.

## Why This Change Was Made

The temporary-checkout cleanup owner now preserves both native `runs` and `captures` outputs together beneath a fresh `.crabbox/wrapper-artifacts/run-*` directory, prints the old-to-new root mapping, and retains the temporary checkout if preservation fails. This replaces the runs-only copy path instead of adding a separate cleanup mechanism.

The diagnostic writer reads the existing `VITEST_SHARD_INDEX` exported by CI, preserving the `ci.shardIndex` JSON field and schema. No alias, new configuration, workflow change, backend selection, cache, budget, permission, or product-runtime change is added.

## User Impact

Maintainers can inspect retained failure bundles after temporary sync cleanup and distinguish repeated invocations without losing earlier artifacts. Normal CI UI diagnostics retain their actual shard index. There is no change to the product UI or channel behavior.

Local documentation explains the retention location and its limits. Native proof strings still reference their original paths; use the printed relocation mapping. Native Blacksmith failure bundles contain streams and diagnostic metadata, not remote screenshots, which must be retrieved separately before stopping a Testbox. Missing shard environment metadata remains `null`, including separate release/manual invocations that only pass a CLI shard.

## Evidence

### Before/after owner proof

- The wrapper is byte-identical at incident merge `da817a8aaca3a63b0edbe2133fc8098d6326935c` and the reproduced base `93450a667d2ab1e747db303de86ab02737c18dda`. Initial boundary tests failed with missing-capture `ENOENT` and demonstrated overwritten prior run bytes.
- The replacement regression executes the full wrapper, real Git/source-capsule preparation, and filesystem cleanup; only the external provider executable is a fixture. It covers capture-only failures, combined/nested outputs, sparse checkouts, successful runs, no artifacts, direct execution, repeated native names, and a blocked retention destination.
- The existing UI capture/filesystem test now checks populated 5/6 metadata and absent canonical metadata without falling back to an unrelated old-name variable. Its independent two-attempt screenshot/report retention assertions remain.
- Full focused validation passed: **286 wrapper tests + 7 UI-helper tests**. A final nine-test regression selection also passed after removing an obsolete test import.

```bash
node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts ui/src/test-helpers/control-ui-e2e.test.ts
```

```bash
node scripts/check-changed.mjs -- scripts/crabbox-wrapper.mts test/scripts/crabbox-wrapper.test.ts ui/src/test-helpers/control-ui-e2e.ts ui/src/test-helpers/control-ui-e2e.test.ts docs/reference/test.md
```

The complete classified gate passed, including core-test/UI/scripts/root-test typechecks, focused lint, dead-export scans, formatting, and applicable guards. Fresh isolated Codex autoreview through P2 found no accepted/actionable findings.

### Real browser diagnostic capture

A synthetic missing-element timeout in real Chromium **151.0.7922.34**, with `VITEST_SHARD_INDEX=5` and `VITEST_SHARD_COUNT=6`, produced:

```json
{"before":{"shardIndex":null,"vitestShardCount":"6"},"after":{"shardIndex":"5","vitestShardCount":"6"},"captureErrors":[]}
```

Both PNGs were inspected and contain only synthetic content; their visible page is unchanged because this is a JSON provenance repair, not a visual UI change. This is diagnostic-boundary browser proof, not a full native CI shard or new remote Testbox replay. Raw logs, local paths, credentials, and agent transcripts are not attached.

### Dependency contract and remaining limits

Crabbox **0.48.1**, clean revision [`c766cde9e877ade7cb13d241d106d5694b842deb`](https://github.com/openclaw/crabbox/commit/c766cde9e877ade7cb13d241d106d5694b842deb), was inspected directly: [failure-bundle producer](https://github.com/openclaw/crabbox/blob/c766cde9e877ade7cb13d241d106d5694b842deb/internal/providers/blacksmith/backend.go#L336), [cwd-relative capture destination](https://github.com/openclaw/crabbox/blob/c766cde9e877ade7cb13d241d106d5694b842deb/internal/cli/run_observability.go#L886), and [per-lease run artifact names](https://github.com/openclaw/crabbox/blob/c766cde9e877ade7cb13d241d106d5694b842deb/internal/cli/run_artifacts.go#L82). Native capture names use second-level timestamps and run proof filenames repeat, so wrapper retention needs an invocation-owned namespace. Native history/logs/results use the coordinator rather than discovering these local paths.

The shard consumer mismatch is verified in the parent-relative patch of [`90d5fbbd314c09abca616bab683f9027c0bbfac7`](https://github.com/openclaw/openclaw/commit/90d5fbbd314c09abca616bab683f9027c0bbfac7), which renamed the CI producer without migrating this diagnostic read.

No Blacksmith directory-download fix is claimed: original argv and upstream source were unavailable, and no guessed recursive flag was added. This change cannot recover already deleted evidence.

### Maintainer follow-through

[CI run 33923535421](https://github.com/openclaw/openclaw/actions/runs/33923535421) passed on attempt 1 for exact head `1f3d5f1b9bcc9901b7e8233ecd829781e6a5a480`; required `openclaw/ci-gate` is green. [The pinned-source verification and pre-merge proof](https://github.com/openclaw/openclaw/pull/138651#issuecomment-5547073088) address both ClawSweeper before-merge entries and its rank-up move: the three Crabbox producer files were independently fetched at the pinned public commit and byte-compared with the inspected copy. The live 0.48.1 tag and installed binary's clean VCS revision match that commit. No code change was needed; the automated review's gap was upstream source access.

### Scope and LOC

| Category | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Product runtime | 0 | 0 | 0 |
| Wrapper tooling | 25 | 19 | +6 |
| UI test-support owner | 1 | 1 | 0 |
| Tests | 201 | 65 | +136 |
| Docs | 20 | 1 | +19 |

The six-line tooling increase preserves the second native artifact category, prevents cross-invocation overwrite, and reports the retained source on preservation failure. The old shared-root artifact fixture is removed.
