### PR TITLE
fix(gateway): keep task suggestions retryable after agent recovery

### DIFF
--- a/src/gateway/server-methods/task-suggestions.owner-recovery.test.ts
+++ b/src/gateway/server-methods/task-suggestions.owner-recovery.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { abandonTaskSuggestionAcceptance } from "../task-suggestion-registry.js";
+import { sessionCreateHandlers } from "./sessions-create.js";
+import { sessionDispatchHandlers } from "./sessions-dispatch.js";
+import {
+  call,
+  configuredCloudContext,
+  createSourceSuggestion,
+  dismissPendingTaskSuggestions,
+  SOURCE_SESSION_KEY,
+} from "./task-suggestions.test-support.js";
+import type { RespondFn } from "./types.js";
+
+const mocks = vi.hoisted(() => ({ handleChatSend: vi.fn() }));
+vi.mock("./chat-send-handler.js", () => ({ handleChatSend: mocks.handleChatSend }));
+
+beforeEach(async () => {
+  await dismissPendingTaskSuggestions();
+  mocks.handleChatSend.mockReset();
+  mocks.handleChatSend.mockImplementation(async ({ respond }: { respond: RespondFn }) => {
+    respond(true, { runId: "suggested-task-run", status: "started" }, undefined);
+  });
+});
+
+afterEach(async () => {
+  await dismissPendingTaskSuggestions();
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
+});
+
+describe("task suggestion owner recovery", () => {
+  it.each(["worktree", "local", "cloud", "session"] as const)(
+    "keeps %s suggestions retryable when their owner is temporarily unavailable",
+    async (mode) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey: SOURCE_SESSION_KEY },
+          { sessionId: "source-session", updatedAt: 1 },
+        );
+        const taskId = await createSourceSuggestion();
+        const config: OpenClawConfig = {
+          agents: { entries: { other: {} } },
+          cloudWorkers: { profiles: { primary: { provider: "test" } } },
+        };
+        const context = { ...configuredCloudContext(), getRuntimeConfig: () => config };
+        const acceptParams = {
+          taskId,
+          mode,
+          ...(mode === "cloud" ? { cloudProfileId: "primary" } : {}),
+        };
+        const createSession = vi
+          .spyOn(sessionCreateHandlers, "sessions.create")
+          .mockImplementation(async ({ params, respond }) => {
+            respond(true, { key: (params as { key: string }).key, runStarted: true }, undefined);
+          });
+        const dispatchSession = vi
+          .spyOn(sessionDispatchHandlers, "sessions.dispatch")
+          .mockImplementation(async ({ respond }) => respond(true, { ok: true }, undefined));
+        try {
+          const rejected = await call("taskSuggestions.accept", acceptParams, vi.fn(), { context });
+          expect(rejected.response?.[2]).toMatchObject({
+            code: "INVALID_REQUEST",
+            message: 'Unknown agent id "main"',
+          });
+          expect(createSession).not.toHaveBeenCalled();
+          expect(dispatchSession).not.toHaveBeenCalled();
+          expect(mocks.handleChatSend).not.toHaveBeenCalled();
+          const listed = await call("taskSuggestions.list", {});
+          expect(listed.response?.[1]).toMatchObject({ suggestions: [{ id: taskId }] });
+
+          config.agents = { entries: { main: {} } };
+          const accepted = await call("taskSuggestions.accept", acceptParams, vi.fn(), { context });
+          expect(accepted.response?.[0]).toBe(true);
+          config.agents = { entries: { other: {} } };
+          const replay = await call("taskSuggestions.accept", acceptParams, vi.fn(), { context });
+          expect(replay.response).toEqual(accepted.response);
+          expect(createSession).toHaveBeenCalledTimes(mode === "session" ? 0 : 1);
+          expect(dispatchSession).toHaveBeenCalledTimes(mode === "cloud" ? 1 : 0);
+          expect(mocks.handleChatSend).toHaveBeenCalledTimes(
+            mode === "session" || mode === "cloud" ? 1 : 0,
+          );
+        } finally {
+          abandonTaskSuggestionAcceptance(taskId);
+        }
+      });
+    },
+  );
+});

--- a/src/gateway/server-methods/task-suggestions.ts
+++ b/src/gateway/server-methods/task-suggestions.ts
@@ -206,13 +206,13 @@ function finishSuggestedTaskAcceptance(params: {
   return { ok: true, result: { taskId: params.taskId, key: params.sessionKey } };
 }
 
-function failSuggestedTaskDelivery(params: {
+function restoreSuggestedTaskClaim(params: {
   taskId: string;
   options: GatewayRequestHandlerOptions;
   error: NonNullable<Parameters<RespondFn>[2]>;
 }): TaskSuggestionAcceptanceResult {
-  // Session-mode delivery owns only the registry claim. Never roll back the
-  // operator-owned source session or its worktree when message delivery fails.
+  // Before session creation or after source-session delivery fails, only the
+  // suggestion claim can be rolled back; never delete the source session.
   const restored = cancelTaskSuggestionAcceptance(params.taskId);
   if (restored) {
     params.options.context.broadcast(
@@ -222,17 +222,6 @@ function failSuggestedTaskDelivery(params: {
     );
   }
   return { ok: false, error: params.error };
-}
-
-function resolveSuggestionOwner(
-  suggestion: TaskSuggestion,
-  options: GatewayRequestHandlerOptions,
-): ReturnType<typeof resolveRequestedSessionAgentId> {
-  return resolveRequestedSessionAgentId(
-    options.context.getRuntimeConfig(),
-    suggestion.sessionKey,
-    suggestion.agentId,
-  );
 }
 
 async function sendSuggestedTaskPrompt(params: {
@@ -267,15 +256,12 @@ async function createSuggestedTaskSession(params: {
   taskId: string;
   suggestion: TaskSuggestion;
   options: GatewayRequestHandlerOptions;
+  agentId: string;
   mode: Exclude<TaskSuggestionAcceptMode, "session">;
   cloudProfileId?: string;
 }): Promise<TaskSuggestionAcceptanceResult> {
   let sessionResponse: Parameters<RespondFn> | undefined;
-  const sourceOwner = resolveSuggestionOwner(params.suggestion, params.options);
-  if (!sourceOwner.ok) {
-    return { ok: false, error: sourceOwner.error };
-  }
-  const agentId = normalizeAgentId(sourceOwner.agentId);
+  const { agentId } = params;
   const sessionKey = buildDashboardSessionKey(agentId);
   const fail = (key: string, error: NonNullable<Parameters<RespondFn>[2]>) =>
     failSuggestedTaskSession({
@@ -403,14 +389,11 @@ async function deliverSuggestedTaskToSourceSession(params: {
   taskId: string;
   suggestion: TaskSuggestion;
   options: GatewayRequestHandlerOptions;
+  agentId: string;
 }): Promise<TaskSuggestionAcceptanceResult> {
-  const sourceOwner = resolveSuggestionOwner(params.suggestion, params.options);
-  if (!sourceOwner.ok) {
-    return { ok: false, error: sourceOwner.error };
-  }
-  const agentId = normalizeAgentId(sourceOwner.agentId);
+  const { agentId } = params;
   const fail = (error: NonNullable<Parameters<RespondFn>[2]>) =>
-    failSuggestedTaskDelivery({ taskId: params.taskId, options: params.options, error });
+    restoreSuggestedTaskClaim({ taskId: params.taskId, options: params.options, error });
   let source: ReturnType<typeof loadGatewaySessionEntryReadOnly>;
   try {
     source = loadGatewaySessionEntryReadOnly(params.suggestion.sessionKey, { agentId });
@@ -648,21 +631,36 @@ export const taskSuggestionsHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const pending = (
-      mode === "session"
+    const pending = (async () => {
+      const sourceOwner = resolveRequestedSessionAgentId(
+        config,
+        acceptance.suggestion.sessionKey,
+        acceptance.suggestion.agentId,
+      );
+      if (!sourceOwner.ok) {
+        return restoreSuggestedTaskClaim({
+          taskId: params.taskId,
+          options,
+          error: sourceOwner.error,
+        });
+      }
+      const agentId = normalizeAgentId(sourceOwner.agentId);
+      return mode === "session"
         ? deliverSuggestedTaskToSourceSession({
             taskId: params.taskId,
             suggestion: acceptance.suggestion,
             options,
+            agentId,
           })
         : createSuggestedTaskSession({
             taskId: params.taskId,
             suggestion: acceptance.suggestion,
             options,
+            agentId,
             mode,
             ...(cloudProfileId ? { cloudProfileId } : {}),
-          })
-    ).catch((error: unknown) => {
+          });
+    })().catch((error: unknown) => {
       abandonSuggestedTaskAcceptance(params.taskId, options);
       throw error;
     });


### PR DESCRIPTION
Related: #120940

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where users accepting a task suggestion would lose the pending suggestion when its source agent had been removed through a config-file hot reload. Restoring the agent still left the suggestion unavailable for retry.

## Why This Change Was Made

Resolve the source agent once at the common acceptance-claim boundary. If resolution fails before session work begins, restore the claim through the existing rollback and notification path, then carry the resolved identity into either execution mode.

This removes the duplicated branch-local owner checks and their one-use wrapper. Accepted-result replay, concurrent acceptance coalescing, exception cleanup and session ownership remain with their existing owners. The earlier exception cleanup in #120940 did not cover this ordinary error return.

Production: **+27/−29 (net −2)**. Tests: **+92/−0**. No config, protocol or storage contract changes.

## User Impact

An unavailable source agent produces the existing error while leaving the suggestion pending. Once the agent is restored, the operator can retry the same suggestion. Already accepted suggestions continue to return their original result.

## Evidence

- All four owner-recovery cases fail on the original source and pass after the fix, covering session, local, worktree and cloud acceptance. The real handler and registry are exercised; downstream create, dispatch and send operations are mocked.
- **56 tests across four suites**, the canonical changed-file gate and managed Codex review through P2 pass.
- A real isolated built baseline Gateway reproduced the defect through public RPCs and the documented external config-file hot-reload flow. The Gateway kept its process identity, the original source session stayed empty and inactive, and restoring the agent still returned `task suggestion cannot be accepted: accepting`. No model turn was dispatched. Capture hashes, shutdown, process cleanup and port release were verified.
- **Candidate live proof completed:** the isolated built candidate `15216423e92c` contains this exact patch alongside the other 19 changes in the comparison. Public RPCs and config-file hot reload kept the same Gateway process: accepting with the source agent removed returned the existing error while the suggestion remained pending. Restoring the agent and retrying completed one user turn with an OpenAI assistant response. Removing the agent again still allowed accepted-result replay; fresh and settled history showed no additional messages. Command capture hashes, process identity, shutdown, cleanup and port release were verified.
- **Pending before landing:** normal native landing gates.
