### PR TITLE
improve(gateway): reduce allocations for Canvas-heavy chat history

### DIFF
--- a/src/gateway/chat-display-projection.canvas.test.ts
+++ b/src/gateway/chat-display-projection.canvas.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { augmentChatHistoryWithCanvasBlocks } from "./chat-display-projection.canvas.js";
+
+describe("augmentChatHistoryWithCanvasBlocks batches", () => {
+  it.each(["next-renderable", "last-renderable", "last-assistant"] as const)(
+    "preserves first-accepted previews and original messages on the %s target",
+    (placement) => {
+      const baseContent = [
+        { type: "text", text: "Canvas results" },
+        { type: "canvas", preview: { viewId: "existing", url: "/existing" } },
+        { type: "canvas", preview: { viewId: "", url: "" } },
+        ...(placement === "last-assistant" ? [{ type: "toolCall", name: "canvas" }] : []),
+      ];
+      Object.freeze(baseContent);
+      const target = Object.freeze({ role: "assistant", content: baseContent, timestamp: 42 });
+      const toolAssistant = { role: "assistant", content: [{ type: "toolCall", name: "canvas" }] };
+      const tools = [
+        ["existing", "/rejected-id-url"],
+        ["first", "/rejected-id-url"],
+        ["first", "/later-url"],
+        ["second", "/later-url"],
+        ["url-duplicate", "/existing"],
+        [undefined, "/url-only"],
+        [undefined, "/url-only"],
+      ].map(([id, url]) => ({
+        role: "toolResult",
+        toolName: "canvas",
+        content: JSON.stringify({ kind: "canvas", view: { ...(id ? { id } : {}), url } }),
+      }));
+      const detailTool = {
+        role: "toolResult",
+        toolName: "demo__show",
+        content: "Keep the original tool result",
+        details: {
+          mcpAppPreview: {
+            kind: "canvas",
+            view: { id: "app" },
+            mcpApp: { viewId: "app" },
+          },
+        },
+      };
+      const pending = [...tools, detailTool];
+      const messages =
+        placement === "next-renderable"
+          ? [...pending, toolAssistant, target]
+          : placement === "last-renderable"
+            ? [target, toolAssistant, ...pending]
+            : [target, ...pending];
+      Object.freeze(messages);
+      const original = JSON.stringify(messages);
+      const targetIndex = placement === "next-renderable" ? messages.length - 1 : 0;
+      const accepted = [
+        { index: 1, viewId: "first", url: "/rejected-id-url" },
+        { index: 3, viewId: "second", url: "/later-url" },
+        { index: 5, url: "/url-only" },
+      ].map(({ index, ...preview }) => ({
+        type: "canvas",
+        preview: { kind: "canvas", surface: "assistant_message", render: "url", ...preview },
+        rawText: tools[index]?.content,
+      }));
+      const expectedContent = [
+        ...baseContent,
+        ...accepted,
+        {
+          type: "canvas",
+          preview: {
+            kind: "canvas",
+            surface: "assistant_message",
+            render: "url",
+            viewId: "app",
+            mcpApp: { viewId: "app" },
+          },
+          rawText: null,
+        },
+      ];
+
+      const augmented = augmentChatHistoryWithCanvasBlocks(messages);
+
+      expect(augmented).toEqual(
+        messages.map((message, index) =>
+          index === targetIndex ? { ...target, content: expectedContent } : message,
+        ),
+      );
+      expect(augmented[targetIndex]).not.toBe(target);
+      for (const [index, message] of messages.entries()) {
+        if (index !== targetIndex) {
+          expect(augmented[index]).toBe(message);
+        }
+      }
+      expect(JSON.stringify(messages)).toBe(original);
+    },
+  );
+});

--- a/src/gateway/chat-display-projection.canvas.ts
+++ b/src/gateway/chat-display-projection.canvas.ts
@@ -223,16 +223,19 @@ function extractChatHistoryCanvasPreview(message: Record<string, unknown>) {
   return undefined;
 }
 
-function appendCanvasBlockToAssistantHistoryMessage(params: {
-  message: unknown;
-  preview: ReturnType<typeof extractCanvasFromText>;
+type HistoryCanvasPreview = {
+  preview: NonNullable<ReturnType<typeof extractCanvasFromText>>;
   rawText: string | null;
-}): unknown {
-  const preview = params.preview;
-  if (!preview || !params.message || typeof params.message !== "object") {
-    return params.message;
+};
+
+function appendCanvasBlocksToAssistantHistoryMessage(
+  message: unknown,
+  previews: HistoryCanvasPreview[],
+): unknown {
+  if (!message || typeof message !== "object") {
+    return message;
   }
-  const entry = params.message as Record<string, unknown>;
+  const entry = message as Record<string, unknown>;
   const baseContent = Array.isArray(entry.content)
     ? [...entry.content]
     : typeof entry.content === "string"
@@ -240,27 +243,27 @@ function appendCanvasBlockToAssistantHistoryMessage(params: {
       : typeof entry.text === "string"
         ? [{ type: "text", text: entry.text }]
         : [];
-  const alreadyPresent = baseContent.some((block) => {
-    if (!block || typeof block !== "object") {
-      return false;
-    }
-    const typed = block as { type?: unknown; preview?: unknown };
-    return (
-      typed.type === "canvas" &&
-      typed.preview &&
-      typeof typed.preview === "object" &&
-      (((typed.preview as { viewId?: unknown }).viewId &&
-        (typed.preview as { viewId?: unknown }).viewId === preview.viewId) ||
-        ((typed.preview as { url?: unknown }).url &&
-          (typed.preview as { url?: unknown }).url === preview.url))
-    );
-  });
-  if (!alreadyPresent) {
-    baseContent.push({
-      type: "canvas",
-      preview,
-      rawText: params.rawText,
+  for (const { preview, rawText } of previews) {
+    // Only retained blocks participate: rejecting an id collision must not
+    // reserve that preview's different URL for subsequent previews.
+    const alreadyPresent = baseContent.some((block) => {
+      if (!block || typeof block !== "object") {
+        return false;
+      }
+      const typed = block as { type?: unknown; preview?: unknown };
+      return (
+        typed.type === "canvas" &&
+        typed.preview &&
+        typeof typed.preview === "object" &&
+        (((typed.preview as { viewId?: unknown }).viewId &&
+          (typed.preview as { viewId?: unknown }).viewId === preview.viewId) ||
+          ((typed.preview as { url?: unknown }).url &&
+            (typed.preview as { url?: unknown }).url === preview.url))
+      );
     });
+    if (!alreadyPresent) {
+      baseContent.push({ type: "canvas", preview, rawText });
+    }
   }
   return {
     ...entry,
@@ -300,10 +303,7 @@ export function augmentChatHistoryWithCanvasBlocks(messages: unknown[]): unknown
   let changed = false;
   let lastAssistantIndex = -1;
   let lastRenderableAssistantIndex = -1;
-  const pending: Array<{
-    preview: NonNullable<ReturnType<typeof extractCanvasFromText>>;
-    rawText: string | null;
-  }> = [];
+  const pending: HistoryCanvasPreview[] = [];
   for (let index = 0; index < next.length; index++) {
     const message = next[index];
     if (!message || typeof message !== "object") {
@@ -316,15 +316,7 @@ export function augmentChatHistoryWithCanvasBlocks(messages: unknown[]): unknown
       if (!messageContainsToolHistoryContent(entry)) {
         lastRenderableAssistantIndex = index;
         if (pending.length > 0) {
-          let target = next[index];
-          for (const item of pending) {
-            target = appendCanvasBlockToAssistantHistoryMessage({
-              message: target,
-              preview: item.preview,
-              rawText: item.rawText,
-            });
-          }
-          next[index] = target;
+          next[index] = appendCanvasBlocksToAssistantHistoryMessage(next[index], pending);
           pending.length = 0;
           changed = true;
         }
@@ -355,15 +347,7 @@ export function augmentChatHistoryWithCanvasBlocks(messages: unknown[]): unknown
     const targetIndex =
       lastRenderableAssistantIndex >= 0 ? lastRenderableAssistantIndex : lastAssistantIndex;
     if (targetIndex >= 0) {
-      let target = next[targetIndex];
-      for (const item of pending) {
-        target = appendCanvasBlockToAssistantHistoryMessage({
-          message: target,
-          preview: item.preview,
-          rawText: item.rawText,
-        });
-      }
-      next[targetIndex] = target;
+      next[targetIndex] = appendCanvasBlocksToAssistantHistoryMessage(next[targetIndex], pending);
       changed = true;
     }
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Chat histories containing several Canvas previews repeatedly copied the growing assistant-message content while attaching each preview. This created avoidable temporary allocations when loading preview-heavy conversations.

## Why This Change Was Made

Append each complete pending preview batch after copying its target content once. Both flush sites use the same batch owner, removing their duplicate per-preview loops and repeated message copies.

Preview order, target selection, input immutability, existing block identity and first-accepted deduplication remain unchanged. Only retained previews reserve a truthy view ID or URL; rejecting one collision must not suppress a later distinct preview. The existing deduplication scan remains, so this does not claim linear time for the whole algorithm.

Production: **+34/−50 (net −16)**. Tests: **+93/−0**. No UI source, public API, protocol, configuration or persistence changes.

## User Impact

Preview-heavy chat history needs fewer temporary allocations while preserving the same displayed Canvas data and placement.

## Evidence

- All **12 relevant tests pass before and after**: three batch-placement cases, two existing history augmentation cases and seven parser cases. The batch cases protect mixed ID/URL collisions, URL-only previews, MCP detail metadata, frozen inputs and untouched-message identity.
- The same actual-owner workload produced identical serialized output. Across 3,000 calls with 64 previews, median sampled allocations attributed to the owner fell from **257,034,992 to 35,159,144 bytes** for the next-assistant flush and **257,371,856 to 34,798,264 bytes** for the trailing flush. Each bulk case had three observations; single-preview controls varied roughly ±6%.
- These are cumulative sampled allocations in a synthetic owner workload, including collected objects. They are not retained heap, Gateway RSS or a speed measurement.
- The full canonical changed-file gate and managed Codex review through P2 pass.
- A real isolated built baseline Gateway completed one OpenAI turn with two sequential native reads and two exact JSON results. Public history attached both ordered Canvas previews to the final assistant message; fresh-connection and settled rereads were byte-stable with no duplicate previews. Capture hashes, shutdown, process cleanup and port release were verified. This exercises distinct preview IDs and URLs through the real history path; it does not establish the collision branches or browser rendering.
- **Candidate live proof completed:** the isolated built candidate `15216423e92c` contains this exact patch alongside the other 19 changes in the comparison. One OpenAI turn made two sequential native `read` calls with exact JSON results. Public `chat.history` attached both ordered Canvas previews once to the final assistant message; fresh-connection and settled rereads were byte-identical with no duplicate previews. Capture hashes, shutdown, process cleanup and port release were verified. This covers distinct IDs/URLs and stable re-projection; collision branches remain covered by the focused tests, and browser rendering was not measured.
- **Pending before landing:** normal native landing gates.
