### PR TITLE
fix(terminal): stream wrapped table rows without argument limits

### DIFF
--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -142,42 +142,52 @@ describe("renderTable", () => {
     expect(lines.at(-1)).toBe(lines[0]);
   });
 
-  it("renders large tables with the CLI process stack rather than the worker stack", () => {
-    // Worker threads have a larger stack than the CLI process; spreading every
-    // row into Math.max can pass in Vitest but crash a normal sessions --limit all.
-    const result = spawnSync(
-      process.execPath,
-      [
-        "--import",
-        fileURLToPath(new URL("../../../scripts/tsx.mjs", import.meta.url)),
-        "--input-type=module",
-        "-e",
-        `import { renderTable } from ${JSON.stringify(new URL("./table.ts", import.meta.url).href)};
+  it.each(["rows", "wrapped lines", "soft-wrap suffix"])(
+    "renders large %s with the CLI process stack",
+    (shape) => {
+      // Worker threads have a larger stack than the CLI process. Neither many
+      // rows nor one heavily wrapped cell may depend on V8's argument-count limit.
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--import",
+          fileURLToPath(new URL("../../../scripts/tsx.mjs", import.meta.url)),
+          "--input-type=module",
+          "-e",
+          `import { renderTable } from ${JSON.stringify(new URL("./table.ts", import.meta.url).href)};
+const shape = ${JSON.stringify(shape)};
 const output = renderTable({
   border: "ascii",
-  columns: [{ key: "Key", header: "Key" }],
-  rows: Array.from({ length: 150_000 }, () => ({ Key: "session" })),
+  columns: [{ key: "Key", header: "Key", maxWidth: 5 }],
+  rows: shape === "rows"
+    ? Array.from({ length: 150_000 }, () => ({ Key: "row" }))
+    : [{ Key: shape === "wrapped lines" ? "row".repeat(150_000) : "a  " + "\\u200b".repeat(150_000) + "b" }],
 });
 const lines = output.trimEnd().split("\\n");
 console.log(JSON.stringify({
   lineCount: lines.length,
-  rows: lines.filter(line => line === "| session |").length,
+  rows: lines.filter(line => line === "| row |").length,
   header: lines[1],
   firstLine: lines[0],
   lastLine: lines.at(-1),
+  softWrapRowsMatch: lines[3] === "| a   |" && lines[4] === "| " + "\\u200b".repeat(150_000) + "b   |",
 }));`,
-      ],
-      { encoding: "utf8", timeout: 30_000 },
-    );
+        ],
+        { encoding: "utf8", timeout: 30_000 },
+      );
 
-    expect(result.error).toBeUndefined();
-    expect(result.status, result.stderr).toBe(0);
-    const rendered = JSON.parse(result.stdout);
-    expect(rendered.lineCount).toBe(150_004);
-    expect(rendered.rows).toBe(150_000);
-    expect(rendered.header).toMatch(/^\| Key +\|$/u);
-    expect(rendered.lastLine).toBe(rendered.firstLine);
-  });
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+      const rendered = JSON.parse(result.stdout);
+      expect(rendered.lineCount).toBe(shape === "soft-wrap suffix" ? 6 : 150_004);
+      expect(rendered.rows).toBe(shape === "soft-wrap suffix" ? 0 : 150_000);
+      if (shape === "soft-wrap suffix") {
+        expect(rendered.softWrapRowsMatch).toBe(true);
+      }
+      expect(rendered.header).toMatch(/^\| Key +\|$/u);
+      expect(rendered.lastLine).toBe(rendered.firstLine);
+    },
+  );
 
   it("prefers shrinking flex columns to avoid wrapping non-flex labels", () => {
     const out = renderTable({

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -276,44 +276,11 @@ function wrapLine(text: string, width: number): string[] {
     return [text];
   }
 
-  // ANSI-aware wrapping: never split inside ANSI SGR/OSC-8 sequences.
-  // Table cells are padded and bordered per physical line, so wrapped lines
-  // must not leak styling into padding while the next continuation keeps it.
-  const tokens: AnsiToken[] = [];
-  for (const segment of iterateAnsiSegments(text)) {
-    let value = segment.value;
-    if (segment.kind === "ansi") {
-      if (segment.controls.includes("\t")) {
-        // Reset with the CSI introducer before printable controls can enter pending escape parsing.
-        tokens.push({
-          kind: "ansi",
-          value: value.slice(0, value[0] === ESC ? 2 : 1) + "\x18",
-          width: 0,
-        });
-        const controls = new Set(segment.controls);
-        for (const control of segment.controls) {
-          tokens.push({ kind: control === "\t" ? "char" : "ansi", value: control, width: 0 });
-        }
-        value = Array.from(value)
-          .filter((character) => !controls.has(character))
-          .join("");
-      }
-      tokens.push({ kind: "ansi", value, width: 0 });
-      continue;
-    }
-    for (const grapheme of splitGraphemes(value)) {
-      tokens.push({ kind: "char", value: grapheme, width: 0 });
-    }
-  }
-
-  if (!tokens.some((token) => token.kind === "char")) {
-    return [text];
-  }
-
   const lines: string[] = [];
   const isBreakChar = (ch: string) =>
     ch === " " || ch === "/" || ch === "-" || ch === "_" || ch === ".";
   let skipNextLf = false;
+  let hasChar = false;
 
   const buf: AnsiToken[] = [];
   let bufVisible = 0;
@@ -333,7 +300,9 @@ function wrapLine(text: string, width: number): string[] {
     if (buf.length === 0) {
       return;
     }
-    const left = breakAt == null || breakAt <= 0 ? buf : buf.slice(0, breakAt);
+    // Keep the suffix in its buffer: long zero-width runs can exceed the argument
+    // limit of a spread-based copy even when their visible width is small.
+    const left = breakAt == null || breakAt <= 0 ? buf : buf.splice(0, breakAt);
     const activeSgr = activeSgrAfter(left);
     const activeOsc8 = activeOsc8After(left);
     const closeOsc8 = activeOsc8 ? `${ESC}]8;;${BEL}` : "";
@@ -354,15 +323,12 @@ function wrapLine(text: string, width: number): string[] {
       return;
     }
 
-    // breakAt follows the latest break character, or is buf.length.
-    // The retained suffix therefore has no leading space tokens to trim.
-    const rest = buf.slice(breakAt);
     pushLine(`${bufToString(left)}${closeOsc8}${closeSgr}`);
     if (openOsc8) {
-      rest.unshift({ kind: "ansi", value: openOsc8, width: 0 });
+      buf.unshift({ kind: "ansi", value: openOsc8, width: 0 });
     }
     if (activeSgr.length > 0) {
-      rest.unshift(
+      buf.unshift(
         ...activeSgr.map((state) => ({
           kind: "ansi" as const,
           value: state.open,
@@ -371,26 +337,25 @@ function wrapLine(text: string, width: number): string[] {
       );
     }
 
-    buf.length = 0;
-    buf.push(...rest);
     bufVisible = buf.reduce((acc, token) => acc + token.width, 0);
     lastBreakIndex = null;
   };
 
-  for (const token of tokens) {
+  const acceptToken = (token: AnsiToken) => {
     if (token.kind === "char") {
+      hasChar = true;
       // Emit the one-cell space used by layout instead of following terminal tab stops.
       token.value = token.value.replaceAll("\t", " ");
       const ch = token.value;
       if (skipNextLf && ch === "\n") {
         skipNextLf = false;
-        continue;
+        return;
       }
       // CRLF is one grapheme; separated CR/LF may retain intervening ANSI controls.
       skipNextLf = ch === "\r";
       if (ch === "\n" || ch === "\r" || ch === "\r\n") {
         flushAt(buf.length);
-        continue;
+        return;
       }
       // Soft-wrap remainders reuse the width measured when each token entered the buffer.
       token.width = visibleWidth(ch);
@@ -402,7 +367,7 @@ function wrapLine(text: string, width: number): string[] {
       }
     }
     if (token.kind === "char" && bufVisible === 0 && token.value === " ") {
-      continue;
+      return;
     }
 
     buf.push(token);
@@ -410,6 +375,38 @@ function wrapLine(text: string, width: number): string[] {
     if (token.kind === "char" && isBreakChar(token.value)) {
       lastBreakIndex = buf.length;
     }
+  };
+
+  // Consume tokens as they arrive; only the current wrap buffer owns them.
+  // SGR/OSC-8 remain atomic and close before padding, then reopen on continuation.
+  for (const segment of iterateAnsiSegments(text)) {
+    let value = segment.value;
+    if (segment.kind === "ansi") {
+      if (segment.controls.includes("\t")) {
+        // Reset with the CSI introducer before printable controls can enter pending escape parsing.
+        acceptToken({
+          kind: "ansi",
+          value: value.slice(0, value[0] === ESC ? 2 : 1) + "\x18",
+          width: 0,
+        });
+        const controls = new Set(segment.controls);
+        for (const control of segment.controls) {
+          acceptToken({ kind: control === "\t" ? "char" : "ansi", value: control, width: 0 });
+        }
+        value = Array.from(value)
+          .filter((character) => !controls.has(character))
+          .join("");
+      }
+      acceptToken({ kind: "ansi", value, width: 0 });
+      continue;
+    }
+    for (const grapheme of splitGraphemes(value)) {
+      acceptToken({ kind: "char", value: grapheme, width: 0 });
+    }
+  }
+
+  if (!hasChar) {
+    return [text];
   }
 
   flushAt(buf.length);
@@ -612,28 +609,26 @@ export function renderTable(opts: RenderTableOptions): string {
   };
   const padStr = repeat(" ", padding);
 
+  const lines: string[] = [];
   const renderRow = (record: Record<string, string>, isHeader = false) => {
     const cells = columns.map((c) => (isHeader ? c.header : (record[c.key] ?? "")));
     const wrapped = cells.map((cell, i) => wrapLine(cell, contentWidthFor(i)));
     const height = Math.max(...wrapped.map((w) => w.length));
-    const out: string[] = [];
     for (let li = 0; li < height; li += 1) {
-      const parts = wrapped.map((lines, i) => {
-        const raw = lines[li] ?? "";
+      const parts = wrapped.map((cellLines, i) => {
+        const raw = cellLines[li] ?? "";
         const aligned = padCell(raw, contentWidthFor(i), columns[i]?.align ?? "left");
         return `${padStr}${aligned}${padStr}`;
       });
-      out.push(`${box.v}${parts.join(box.v)}${box.v}`);
+      lines.push(`${box.v}${parts.join(box.v)}${box.v}`);
     }
-    return out;
   };
 
-  const lines: string[] = [];
   lines.push(hLine(box.tl, box.t, box.tr));
-  lines.push(...renderRow({}, true));
+  renderRow({}, true);
   lines.push(hLine(box.ml, box.m, box.mr));
   for (const row of rows) {
-    lines.push(...renderRow(row, false));
+    renderRow(row, false);
   }
   lines.push(hLine(box.bl, box.b, box.br));
   return `${lines.join("\n")}\n`;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where CLI tables can crash with `RangeError: Maximum call stack size exceeded` when one cell wraps into many physical rows or retains a long zero-width suffix at a word break.

## Why This Change Was Made

Consume the existing ANSI iterator directly into the active wrap buffer, retain the unconsumed suffix in that buffer, and append physical rows directly to the table output. This removes the whole-cell token collection, suffix copy, temporary per-row output, and both unbounded argument spreads.

## User Impact

Very long wrapped cells render without depending on the JavaScript argument-count limit. Grapheme widths, ANSI styles and links, line breaks, padding, and borders retain their behavior. Production LOC: +49/-54 (net -5); tests: +36/-26 (net +10).

## Evidence

Both failures were reproduced before the fix in normal Node processes: a 450,000-character cell at width 3 and a 150,000-character zero-width suffix. The final owner passes both; the long cell emits all 150,000 data rows. The regression tests also fail on the original code.

All 174 focused table, ANSI, and hooks tests passed. Exact output parity passed for 375 cases across Unicode/control fixtures, three borders, and five widths. The registered source CLI ran `openclaw hooks list --agent proof` against synthetic filesystem-discovered hooks in an isolated workspace; both arms exited successfully with all 698,248 stdout bytes identical.

The complete 28-stage changed-file gate passed on the final source. Independent managed Codex review through P2 found no actionable issues. The removed storage and copies are source-level improvements; shared-load timing and RSS observations are not claimed as controlled performance results.

The integrated built `openclaw.mjs hooks list --agent proof` comparison now passes. The candidate build contains this PR’s exact table postimage; it is an integrated build, not an isolated build of the PR branch. A synthetic hook with a long styled description produced byte-identical 377,781-byte outputs, SHA-256 `4d80f5705d3e0dc020afa1133391ddd6c78754de9d3295156cc35b42db5860a5`. Both outputs retained all 2,000 description repetitions, CJK, emoji and combining text, ANSI styling, and three 120-character borders across 2,505 lines. Complete source, build, dependency, and Node identities matched before and after each arm. Captures were untruncated, every owned command exited successfully, and observed processes and temporary runtimes closed. This verifies built-entry functional parity; it is not a timing or memory measurement.
