### PR TITLE
fix(active-memory): name the reason when recall is skipped

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -515,6 +515,10 @@ describe("active-memory plugin", () => {
     vi
       .mocked(api.logger.warn)
       .mock.calls.some((call: unknown[]) => String(call[0]).includes(needle));
+  const hasInfoLine = (needle: string) =>
+    vi
+      .mocked(api.logger.info)
+      .mock.calls.some((call: unknown[]) => String(call[0]).includes(needle));
   const expectPrependContextResult = (result: unknown) => {
     expect(typeof (result as { prependContext?: unknown } | undefined)?.prependContext).toBe(
       "string",
@@ -815,6 +819,22 @@ describe("active-memory plugin", () => {
     expect(assertActive).toHaveBeenCalled();
     expect(hoisted.getActiveMemorySearchManager).not.toHaveBeenCalled();
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
+  });
+
+  it("names the skip reason at info level when the turn authority denies recall tools", async () => {
+    const result = await runPromptBuild(
+      { prompt: "what wings should i order?" },
+      {
+        toolAuthority: {
+          fingerprint: "denied-memory-authority",
+          allows: () => false,
+          assertActive: () => undefined,
+        },
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(hasInfoLine("active-memory: recall skipped reason=policy-disabled")).toBe(true);
   });
 
   it("does not inject recall that completes after the turn authority closes", async () => {
@@ -1738,6 +1758,7 @@ describe("active-memory plugin", () => {
     expectPrependContextContains(result, skippedRecallContext);
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
     expect(hasDebugLine("active-memory: recall skipped reason=no-recall-intent")).toBe(true);
+    expect(hasInfoLine("active-memory: recall skipped reason=no-recall-intent")).toBe(false);
   });
 
   it("does not run deep recall when the live active-memory plugin entry is removed", async () => {

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -819,21 +819,6 @@ describe("active-memory plugin", () => {
     expect(assertActive).toHaveBeenCalled();
     expect(hoisted.getActiveMemorySearchManager).not.toHaveBeenCalled();
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
-  });
-
-  it("names the skip reason at info level when the turn authority denies recall tools", async () => {
-    const result = await runPromptBuild(
-      { prompt: "what wings should i order?" },
-      {
-        toolAuthority: {
-          fingerprint: "denied-memory-authority",
-          allows: () => false,
-          assertActive: () => undefined,
-        },
-      },
-    );
-
-    expect(result).toBeUndefined();
     expect(hasInfoLine("active-memory: recall skipped reason=policy-disabled")).toBe(true);
   });
 

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -203,11 +203,22 @@ export default definePluginEntry({
     // both maxima so preflight latency cannot consume recall settlement time.
     const beforePromptBuildTimeoutMs =
       MAX_TIMEOUT_MS + MAX_SETUP_GRACE_TIMEOUT_MS + HOOK_TIMEOUT_RECOVERY_GRACE_MS * 2;
+    // Names the exit taken when recall is configured off for this session, so
+    // "no relevant memory found" and "recall never ran" stop being
+    // indistinguishable at info level. Reserved for states an operator can act
+    // on; the routine escalation decision stays at debug. Deliberately not
+    // gated on config.logging, which defaults to false and would reproduce the
+    // invisibility this reports.
+    const logRecallSkipped = (reason: string) => {
+      api.logger.info?.(`active-memory: recall skipped reason=${reason}`);
+    };
     api.on(
       "before_prompt_build",
       async (event, ctx) => {
         const toolAuthority = ctx.toolAuthority;
         if (!toolAuthority) {
+          // Defensive only: the host filters authority-required registrations
+          // out of the unauthorized pass, so this never runs in production.
           api.logger.debug?.(
             "active-memory: recall skipped because this prompt has no turn tool authority",
           );
@@ -288,6 +299,7 @@ export default definePluginEntry({
                 sessionKey: resolvedSessionKey,
                 statusLine: `${ACTIVE_MEMORY_STATUS_PREFIX} status=policy-disabled`,
               });
+              logRecallSkipped("policy-disabled");
               toolAuthority.assertActive();
               return undefined;
             }
@@ -298,6 +310,7 @@ export default definePluginEntry({
                 sessionKey: resolvedSessionKey,
               })
             ) {
+              logRecallSkipped("harness-session");
               return undefined;
             }
             const sessionDisabled = await isSessionActiveMemoryDisabled({
@@ -307,6 +320,7 @@ export default definePluginEntry({
             deadlineController.signal.throwIfAborted();
             toolAuthority.assertActive();
             if (sessionDisabled) {
+              logRecallSkipped("session-disabled");
               await persistPluginStatusLines({
                 api,
                 agentId: effectiveAgentId,
@@ -319,6 +333,7 @@ export default definePluginEntry({
               sessionKey: resolvedSessionKey ?? ctx.sessionKey,
             };
             if (!isEligibleInteractiveSession(sessionContext)) {
+              logRecallSkipped("session-ineligible");
               await persistPluginStatusLines({
                 api,
                 agentId: effectiveAgentId,
@@ -416,6 +431,7 @@ export default definePluginEntry({
               );
             }
             if (!activeMemoryAllowed && !productRecallAllowed) {
+              logRecallSkipped("destination-not-allowed");
               await persistPluginStatusLines({
                 api,
                 agentId: effectiveAgentId,
@@ -429,6 +445,9 @@ export default definePluginEntry({
               hasStrongLaneOneHit: laneOne.hasStrongHit,
             });
             if (escalationDecision !== "recall") {
+              // Stays at debug: escalate is the default mode and ordinary
+              // prompts resolve to no-recall-intent, so this is the healthy
+              // path rather than an actionable skip.
               api.logger.debug?.(`active-memory: recall skipped reason=${escalationDecision}`);
               const outcomeContext =
                 escalationDecision === "no-recall-intent"


### PR DESCRIPTION
Related: #138561

## What Problem This Solves

Active Memory can skip recall because of tool policy, a locked harness session, a disabled session, session eligibility, or destination policy. Default Gateway logs do not name those decisions, so operators cannot distinguish them from recall that ran without a useful result.

## Why This Change Was Made

Each of the five existing exits emits a fixed info-level reason. The branch conditions, return values, recall policy, and optional detailed logging remain unchanged. The existing strict authority boundary remains intact.

Reasons apply per prompt build. Successful recall can also emit `session-ineligible` for its separate manual helper build, which deliberately avoids recursive automatic recall. That line does not mean the outer user turn performed no memory work. Existing structured trace relationships identify the nested build; the message adds no private identifiers.

The healthy `no-recall-intent` outcome and defensive missing-authority guard stay at debug level. No new setting, schema, or hook API is added.

## User Impact

Default logs expose `policy-disabled`, `harness-session`, `session-disabled`, `session-ineligible`, and `destination-not-allowed` without including prompt, memory, session, destination, or credential data in the reason message. This is diagnostic logging only. It does not fix or diagnose the broader recall regression in #138561; that issue remains open.

## Evidence

Pinned-main and candidate proof use the same compiled-source Gateway, task-owned Memory Core state, deterministic loopback provider, and real authenticated Gateway requests. The catalog fixture creates a locked session through the supported creation owner; session disabling uses the public `/active-memory off` command. No direct callback or database-write fixture substitutes for those routes.

- Baseline: the five skipped prompt builds complete without the corresponding info line.
- The focused regression fails on baseline because the info logger has zero calls.
- 426 focused Active Memory tests pass on the candidate, with the duplicate policy-denial setup consolidated into the existing stronger case.
- Eligible recall reads an actual synthetic memory file and places its result in the main prompt. Default no-intent and debug logging controls retain their behavior.
- Fresh source-blind acceptance exercised nine additional cases with changed prompts, memory facts and paths, and off/on recovery. Observable checks passed; source-only obligations were separately reviewed.
- Source review through P2, formatting, scoped lint and source ratchets passed. Exact-head CI and final landing review remain required.

AI-assisted verification and test consolidation. Original implementation by @DasX.

Captured default-log messages from separate real Gateway prompt builds:

```text
INFO active-memory: recall skipped reason=policy-disabled
INFO active-memory: recall skipped reason=harness-session
INFO active-memory: recall skipped reason=session-disabled
INFO active-memory: recall skipped reason=session-ineligible
INFO active-memory: recall skipped reason=destination-not-allowed
```

Each shown skip build completed its turn. The eligible outer build performed real memory retrieval and supplied context; its separate manual helper produced its own session-ineligible record. The ordinary default no-intent control produced no info skip line. Complete source, fixture, logs, provider requests and acceptance evidence are retained privately with hashes. Public extracts omit prompts, memory contents, session/destination identities and infrastructure metadata.

One exploratory phrasing did not trigger the existing recall-intent heuristic; it is preserved as a separate observation and not counted as automatic-recall proof. This repair does not change that heuristic. Source-history changes also make the two complete requests differ; the introduced patch changes only the logging owner and regression assertions, so this is not a claim of whole-repository byte-equivalence.
