### PR TITLE
test(inworld): await the guarded fetch call before advancing the timeout

### DIFF
--- a/extensions/inworld/voices-timeout.test.ts
+++ b/extensions/inworld/voices-timeout.test.ts
@@ -14,9 +14,16 @@ describe("listInworldVoices timeout", () => {
 
   it("aborts a hanging voice list request within the configured timeout", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    let notifyFetchStarted = () => {};
+    // listInworldVoices reaches the guard through dynamic runtime imports, so the
+    // stub is only guaranteed to be in flight once it has actually been called.
+    const fetchStarted = new Promise<void>((resolve) => {
+      notifyFetchStarted = resolve;
+    });
     const fetchMock = vi.fn(
       (_input: RequestInfo | URL, init?: RequestInit) =>
         new Promise<Response>((_resolve, reject) => {
+          notifyFetchStarted();
           const signal = init?.signal;
           if (!signal) {
             reject(new Error("guarded fetch did not pass an abort signal"));
@@ -39,8 +46,7 @@ describe("listInworldVoices timeout", () => {
     });
     const rejection = expect(request).rejects.toThrow(/aborted|timeout|timed out/i);
 
-    // Flush guard preflight microtasks so the request is in flight.
-    await vi.advanceTimersByTimeAsync(0);
+    await fetchStarted;
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(249);


### PR DESCRIPTION
## What Problem This Solves

`extensions/inworld/voices-timeout.test.ts` fails intermittently on CI (shard `changed-extensions-config-1`, job `checks-node-changed-extensions-bundle-3`; runs 33918181076 and 33920439005 on #137594, twice in a row) with `expected "vi.fn()" to be called 1 times, but got 0 times`, plus an unhandled `getaddrinfo ENOTFOUND custom.inworld.example.com` rejection charged to `extensions/zoom-meetings/src/cli.test.ts`, the next file in the same non-isolated worker. A unit test that is meant to be hermetic makes a real DNS lookup and poisons an unrelated file.

## Why This Change Was Made

`listInworldVoices` awaits two dynamic runtime imports (`extensions/inworld/tts.ts:217` for `openclaw/plugin-sdk/media-runtime` and `:225` for `openclaw/plugin-sdk/ssrf-runtime`) before it enters `fetchWithSsrFGuard`, which captures `globalThis.fetch` at guard entry (`src/infra/net/fetch-guard.ts:473`). Module loading resolves on real event-loop turns; `vi.advanceTimersByTimeAsync(0)` only flushes microtasks and faked timers. On a cold or loaded worker the test body returned before the stub was called, `afterEach` ran `vi.unstubAllGlobals()`, the imports then settled, and the guard read the real `fetch`, took the pinned-DNS path, and failed with `ENOTFOUND`. #129024 introduced the `advanceTimersByTimeAsync(0)` synchronization; the azure-speech sibling (`extensions/azure-speech/voices-timeout.test.ts`) still awaits its handler notification and does not flake.

The test now resolves a promise from inside the fetch stub on its first call and awaits that before advancing the fake clock, so the stub is provably the function that ran regardless of how long the imports take. Test-only, +8/-2; no timeout, retry, or production change. Other provider timeout tests (`voices-timeout-default`, google-meet, brave, codex) have no dynamic import before `fetch` and keep their current shape.

## User Impact

None at runtime. Removes a CI-only failure that blocked `ci-gate` on unrelated PRs and made the extensions suite reach the network.

## Evidence

- Reproduction on a 16-core Linux box under CPU load (12 busy loops) with `OPENCLAW_VITEST_MAX_WORKERS=1`: `node scripts/run-vitest.mjs extensions/inworld/voices-timeout.test.ts extensions/zoom-meetings/src/cli.test.ts` on `origin/main` failed 5/5 runs with the exact CI signature (0 stub calls plus the `ENOTFOUND` unhandled rejection attributed to the zoom-meetings file); with this change 20/20 runs passed.
- `node scripts/check-changed.mjs -- extensions/inworld/voices-timeout.test.ts`: exit 0.
- CI evidence of the flake: https://github.com/openclaw/openclaw/actions/runs/33918181076 and https://github.com/openclaw/openclaw/actions/runs/33920439005 (same shard, same failure, on a PR that touches neither extension).
