### PR TITLE
fix(gateway): deliver session catalog updates from slow hosts

### DIFF
--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -174,6 +174,27 @@ export default definePluginEntry({
   `onHost(host)` callback as each host settles; the returned host array remains
   required as the final compatibility snapshot.
 
+  If a host can finish after `list` returns a fail-soft snapshot, register its
+  bounded completion with the optional `waitUntil(completion: Promise<void>)`
+  hook before `list` settles. Include host mapping and the `onHost` call in that
+  promise. Use `publishSessionCatalogHost({ onHost, waitUntil }, pendingHost)`
+  from the same SDK entry point to publish the host and register the complete
+  callback chain. Registration after `list` settles is rejected. Providers that
+  do not register completion work finish publishing when their `list` settles.
+
+  The optional `signal: AbortSignal` belongs to the catalog operation or provider
+  lifetime. Pass it to cancellable work, including the top-level `signal` field
+  of `api.runtime.nodes.invoke(...)`. A requesting client disconnect only removes
+  that client's subscription; it does not cancel shared discovery. Retaining
+  completion does not extend native invocation or fail-soft response deadlines,
+  grant new authority, or permit starting work after the owner retires. Providers
+  remain responsible for bounded work that settles after cancellation.
+
+  Keep `onHost`, `waitUntil`, and `signal` separate from validated catalog query
+  objects and node command payloads. The request-owned `sessionEntries` snapshot
+  and `listNodes` hook still must not be retained past `list`; prepare any facts
+  needed by late host mapping before returning.
+
   Transcript items may include a `sender` with a qualified `SessionParticipant`
   identity and optional display label or avatar. Supply only source-known
   attribution; the viewer and the session adopter are not transcript authors.

--- a/extensions/anthropic/session-catalog-listing.ts
+++ b/extensions/anthropic/session-catalog-listing.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs/promises";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { withTimeout } from "openclaw/plugin-sdk/security-runtime";
-import type { SessionCatalogProvider } from "openclaw/plugin-sdk/session-catalog";
+import {
+  publishSessionCatalogHost,
+  type SessionCatalogProvider,
+} from "openclaw/plugin-sdk/session-catalog";
 import {
   isRecord,
   normalizeBoundedOptionalString as readBoundedString,
@@ -209,6 +212,8 @@ export async function listClaudeSessionCatalog(params: {
   allowProcessHomeFallback?: boolean;
   listNodes?: Parameters<SessionCatalogProvider["list"]>[0]["listNodes"];
   onHost?: (host: ClaudeSessionCatalogHost) => void;
+  waitUntil?: (completion: Promise<void>) => void;
+  signal?: AbortSignal;
 }): Promise<ClaudeSessionCatalogResult> {
   const query = parseGatewayQuery(params.query);
   const requested = query.hostIds ? new Set(query.hostIds) : undefined;
@@ -253,9 +258,7 @@ export async function listClaudeSessionCatalog(params: {
         ]
       : [];
   for (const host of localHosts) {
-    if (params.onHost) {
-      void host.then(params.onHost).catch(() => undefined);
-    }
+    publishSessionCatalogHost(params, host);
   }
   const wantsNodes = !requested || query.hostIds?.some((hostId) => hostId.startsWith("node:"));
   if (!wantsNodes) {
@@ -279,6 +282,7 @@ export async function listClaudeSessionCatalog(params: {
       hosts: [...(await Promise.all(localHosts)), registryHost],
     };
   }
+  params.signal?.throwIfAborted();
   const eligible = nodes
     .filter(
       (node) =>
@@ -333,6 +337,7 @@ export async function listClaudeSessionCatalog(params: {
             },
             timeoutMs: NODE_INVOKE_TIMEOUT_MS,
             scopes: ["operator.write"],
+            signal: params.signal,
           });
           return Object.assign({}, common, parseCatalogPage(unwrapNodePayload(raw)));
         })
@@ -344,11 +349,8 @@ export async function listClaudeSessionCatalog(params: {
             },
           }),
         );
-      if (params.onHost) {
-        // The fail-soft response can finish first; the original node invoke still
-        // publishes its authoritative host page whenever cold discovery completes.
-        void eventualHost.then(params.onHost).catch(() => undefined);
-      }
+      // Retain publication through cold discovery without extending the fail-soft response.
+      publishSessionCatalogHost(params, eventualHost);
       try {
         return await withTimeout(eventualHost, NODE_CATALOG_LIST_RESPONSE_TIMEOUT_MS, {
           message: "paired node Claude session catalog timed out",

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type {
   OpenClawPluginApi,
   OpenClawPluginNodeHostCommand,
@@ -590,6 +591,37 @@ afterEach(async () => {
 });
 
 describe("Claude session catalog", () => {
+  it("does not start paired hosts when retired during node inventory", async () => {
+    const inventory = createDeferred<Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>>();
+    const inventoryStarted = createDeferred<void>();
+    const listNodes = vi.fn(() => {
+      inventoryStarted.resolve();
+      return inventory.promise;
+    });
+    const invoke = vi.fn<PluginRuntime["nodes"]["invoke"]>(async () => ({
+      payloadJSON: JSON.stringify({ sessions: [] }),
+    }));
+    const provider = captureCatalogProvider({
+      nodes: { list: listNodes, invoke },
+    } as unknown as PluginRuntime);
+    const controller = new AbortController();
+    const reason = new Error("catalog retired during inventory");
+    const listed = provider
+      .list({
+        hostIds: ["node:late"],
+        signal: controller.signal,
+      })
+      .catch((error: unknown) => error);
+    await inventoryStarted.promise;
+    controller.abort(reason);
+    inventory.resolve({
+      nodes: [{ nodeId: "late", connected: true, commands: [CLAUDE_SESSIONS_LIST_COMMAND] }],
+    });
+    const result = await listed;
+    expect(invoke).not.toHaveBeenCalled();
+    expect(result).toBe(reason);
+  });
+
   it.each([
     {
       label: "catalog marker",
@@ -3524,20 +3556,34 @@ describe("Claude session catalog", () => {
       name: "returns cold paired-node discovery before the fail-soft response",
       delayMs: 10_000,
       timedOut: false,
+      cancelled: false,
     },
     {
       name: "publishes a paired-node page that finishes after the fail-soft response",
       delayMs: 20_000,
       timedOut: true,
+      cancelled: false,
     },
-  ])("$name", async ({ delayMs, timedOut }) => {
+    {
+      name: "settles paired-node publication when its owner cancels after the fail-soft response",
+      delayMs: 20_000,
+      timedOut: true,
+      cancelled: true,
+    },
+  ])("$name", async ({ delayMs, timedOut, cancelled }) => {
     vi.useFakeTimers();
     try {
-      let resolveInvoke!: (value: unknown) => void;
-      const invokeResult = new Promise<unknown>((resolve) => {
-        resolveInvoke = resolve;
+      const invokeResult = createDeferred<unknown>();
+      const controller = new AbortController();
+      const invoke = vi.fn<PluginRuntime["nodes"]["invoke"]>(async ({ signal }) => {
+        const abort = () => invokeResult.reject(signal?.reason);
+        signal?.addEventListener("abort", abort, { once: true });
+        try {
+          return await invokeResult.promise;
+        } finally {
+          signal?.removeEventListener("abort", abort);
+        }
       });
-      const invoke = vi.fn<PluginRuntime["nodes"]["invoke"]>(async () => await invokeResult);
       const provider = captureCatalogProvider({
         nodes: {
           list: vi.fn().mockResolvedValue({
@@ -3553,8 +3599,23 @@ describe("Claude session catalog", () => {
           invoke,
         },
       } as unknown as PluginRuntime);
+      const completions: Promise<void>[] = [];
+      const completed = vi.fn();
       const onHost = vi.fn();
-      const pending = provider.list({ hostIds: ["node:slow-node"], onHost });
+      const pending = provider.list({
+        hostIds: ["node:slow-node"],
+        limitPerHost: 40,
+        signal: controller.signal,
+        waitUntil: (completion) => {
+          completions.push(
+            completion.then(() => {
+              expect(onHost).toHaveBeenCalledOnce();
+              completed();
+            }),
+          );
+        },
+        onHost,
+      });
 
       await vi.advanceTimersByTimeAsync(delayMs);
       if (timedOut) {
@@ -3564,22 +3625,36 @@ describe("Claude session catalog", () => {
           }),
         ]);
       }
+      expect(completions).toHaveLength(1);
+      expect(completed).not.toHaveBeenCalled();
       expect(onHost).not.toHaveBeenCalled();
-
-      resolveInvoke({
-        payloadJSON: JSON.stringify({
-          sessions: [
-            {
-              threadId: "late-thread",
-              status: "stored",
-              source: "claude-cli",
-              modelProvider: "anthropic",
-              archived: false,
-            },
-          ],
-        }),
+      expect(invoke).toHaveBeenCalledWith({
+        nodeId: "slow-node",
+        command: CLAUDE_SESSIONS_LIST_COMMAND,
+        params: { limit: 40 },
+        timeoutMs: 30_000,
+        scopes: ["operator.write"],
+        signal: controller.signal,
       });
-      await vi.advanceTimersByTimeAsync(0);
+
+      if (cancelled) {
+        controller.abort(new Error("catalog owner retired"));
+      } else {
+        invokeResult.resolve({
+          payloadJSON: JSON.stringify({
+            sessions: [
+              {
+                threadId: "late-thread",
+                status: "stored",
+                source: "claude-cli",
+                modelProvider: "anthropic",
+                archived: false,
+              },
+            ],
+          }),
+        });
+      }
+      await Promise.all(completions);
 
       if (!timedOut) {
         await expect(pending).resolves.toEqual([
@@ -3592,9 +3667,21 @@ describe("Claude session catalog", () => {
       expect(onHost).toHaveBeenCalledWith(
         expect.objectContaining({
           hostId: "node:slow-node",
-          sessions: [expect.objectContaining({ threadId: "late-thread" })],
+          ...(cancelled
+            ? { sessions: [], error: { code: "NODE_INVOKE_FAILED", message: expect.any(String) } }
+            : {
+                sessions: [
+                  expect.objectContaining({
+                    threadId: "late-thread",
+                    canContinue: false,
+                    canArchive: false,
+                    canOpenTerminal: false,
+                  }),
+                ],
+              }),
         }),
       );
+      expect(completed).toHaveBeenCalledOnce();
     } finally {
       vi.useRealTimers();
     }
@@ -3629,14 +3716,31 @@ describe("Claude session catalog", () => {
       nodes: { list: runtimeListNodes },
     } as unknown as PluginRuntime);
 
-    const listing = provider.list({ listNodes: requestListNodes });
+    const completions: Promise<void>[] = [];
+    const onHost = vi.fn();
+    const listing = provider.list({
+      listNodes: requestListNodes,
+      onHost,
+      waitUntil: (completion) => {
+        completions.push(completion);
+      },
+    });
     await opened;
+    expect(completions).toHaveLength(1);
+    expect(onHost).not.toHaveBeenCalled();
     expect(requestListNodes).toHaveBeenCalledOnce();
     expect(runtimeListNodes).not.toHaveBeenCalled();
     releaseOpen();
     await expect(listing).resolves.toMatchObject([
       { hostId: "gateway:local", sessions: [expect.objectContaining({ threadId: sessionId })] },
     ]);
+    await Promise.all(completions);
+    expect(onHost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostId: "gateway:local",
+        sessions: [expect.objectContaining({ threadId: sessionId, canArchive: false })],
+      }),
+    );
   });
 
   it("falls back to the plugin node runtime without a request snapshot", async () => {

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -169,6 +169,8 @@ export function createClaudeSessionCatalogRuntime(
         agentId: _agentId,
         listNodes,
         onHost,
+        waitUntil,
+        signal,
         sessionEntries: _sessionEntries,
         ...gatewayQuery
       } = query;
@@ -179,6 +181,8 @@ export function createClaudeSessionCatalogRuntime(
         query: gatewayQuery,
         allowProcessHomeFallback,
         listNodes,
+        waitUntil,
+        signal,
         ...(onHost ? { onHost: (host) => onHost(mapHost(host)) } : {}),
       });
       return result.hosts.map(mapHost);

--- a/extensions/codex/src/session-catalog-listing.test.ts
+++ b/extensions/codex/src/session-catalog-listing.test.ts
@@ -1,6 +1,8 @@
 // Codex supervision tests cover passive listing and safe local session takeover.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it, vi } from "vitest";
 import { MAX_HOST_COUNT } from "./session-catalog-parsing.js";
+import type { CodexSessionCatalogPage } from "./session-catalog-types.js";
 import {
   commandRpcMocks,
   pinnedConnectionMocks,
@@ -73,6 +75,85 @@ describe("Codex session catalog errors", () => {
 });
 
 describe("Codex supervision catalog", () => {
+  it("does not classify threads or request another page when retired during a local page", async () => {
+    const firstPage = createDeferred<CodexSessionCatalogPage>();
+    const pageStarted = createDeferred<void>();
+    const listPage = vi.fn(async ({ cursor }: { cursor?: string }) => {
+      if (cursor) {
+        return { sessions: [] };
+      }
+      pageStarted.resolve();
+      return firstPage.promise;
+    });
+    const mark = vi.fn(async () => undefined);
+    const bindingStore = Object.assign(createCodexTestBindingStore(), {
+      managedThreads: {
+        has: vi.fn(async () => false),
+        mark,
+        snapshot: vi.fn(async () => new Map<string, ReadonlySet<string>>()),
+      },
+    });
+    const home: CodexCatalogHome = {
+      sourceHomeId: "home-main",
+      hostId: CODEX_LOCAL_SESSION_HOST_ID,
+      label: "Main",
+      agentDir: "/agents/main",
+      appServer: {} as CodexCatalogHome["appServer"],
+      usesProcessHomeFallback: false,
+    };
+    const controller = new AbortController();
+    const listed = listCodexSessionCatalog({
+      bindingStore,
+      config,
+      runtime: createRuntime().runtime,
+      control: createControl({ listPage }),
+      localHomes: [home],
+      query: { hostIds: [CODEX_LOCAL_SESSION_HOST_ID] },
+      signal: controller.signal,
+    });
+    await pageStarted.promise;
+    controller.abort(new Error("catalog retired during page"));
+    firstPage.resolve({
+      sessions: [],
+      managedThreads: [{ threadId: "managed" }],
+      nextCursor: "next",
+    });
+    const result = await listed;
+    expect({ pages: listPage.mock.calls.length, marks: mark.mock.calls.length }).toEqual({
+      pages: 1,
+      marks: 0,
+    });
+    expect(result.hosts[0]?.error?.code).toBe("APP_SERVER_UNAVAILABLE");
+  });
+
+  it("does not start local hosts when retired during the managed-thread snapshot", async () => {
+    const snapshotResult = createDeferred<Map<string, ReadonlySet<string>>>();
+    const snapshot = vi.fn(() => snapshotResult.promise);
+    const bindingStore = Object.assign(createCodexTestBindingStore(), {
+      managedThreads: { has: vi.fn(async () => false), mark: vi.fn(), snapshot },
+    });
+    const listPage = vi.fn(async () => ({ sessions: [] }));
+    const controller = new AbortController();
+    const reason = new Error("catalog retired during snapshot");
+    const listed = listCodexSessionCatalog({
+      bindingStore,
+      config,
+      runtime: createRuntime().runtime,
+      control: createControl({ listPage }),
+      query: { hostIds: [CODEX_LOCAL_SESSION_HOST_ID] },
+      signal: controller.signal,
+      waitUntil: () => {
+        controller.signal.throwIfAborted();
+      },
+    }).catch((error: unknown) => error);
+    expect(snapshot).toHaveBeenCalledOnce();
+    controller.abort(reason);
+    snapshotResult.resolve(new Map());
+    const result = await listed;
+    expect(listPage).not.toHaveBeenCalled();
+    expect(result).toBe(reason);
+  });
+
   it("lists non-archived interactive threads without probing transcript previews", async () => {
     const pluginConfig = await normalizeCodexManifestConfig({
       supervision: { enabled: true },
@@ -435,12 +516,22 @@ describe("Codex supervision catalog", () => {
     });
 
     await withEnvAsync({ CODEX_HOME: processCodexHome }, async () => {
-      const hosts = await getProvider()?.list({
+      const onHost = vi.fn();
+      const completions: Promise<void>[] = [];
+      const hosts = await getProvider()!.list({
         agentId: "beta",
         listNodes: async () => ({ nodes: [] }),
+        onHost,
+        waitUntil: (completion) => {
+          completions.push(completion);
+        },
       });
 
       expect(hosts).toHaveLength(3);
+      expect(completions).toHaveLength(3);
+      await Promise.all(completions);
+      expect(onHost).toHaveBeenCalledTimes(3);
+      expect(onHost.mock.calls.map(([host]) => host)).toEqual(expect.arrayContaining(hosts));
       expect(hosts?.every((host) => host.hostId.startsWith("gateway:local"))).toBe(true);
       expect(
         hosts?.every(

--- a/extensions/codex/src/session-catalog-listing.ts
+++ b/extensions/codex/src/session-catalog-listing.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { OpenClawPluginNodeHostCommand } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import {
+  publishSessionCatalogHost,
   sessionCatalogAdoptedSourceKey,
   type SessionCatalogEntrySnapshot,
   type SessionCatalogProvider,
@@ -74,6 +75,7 @@ async function listVisiblePage(params: {
   limit: number;
   onExcludedThread?: (thread: { threadId: string; rolloutPath?: string }) => Promise<void>;
   searchTerm?: string;
+  signal?: AbortSignal;
 }): Promise<CodexSessionCatalogPage> {
   const excluded = params.excludedThreadIds;
   const sessions: ReturnType<typeof parseCatalogPage>["sessions"] = [];
@@ -81,7 +83,9 @@ async function listVisiblePage(params: {
   let nextCursor: string | undefined;
   let backwardsCursor: string | undefined;
   const seenCursors = new Set<string>();
+  // An issued page still settles; retirement stops its follow-up reads and classification.
   for (let pageIndex = 0; pageIndex < MAX_TITLE_SEARCH_CATALOG_PAGES; pageIndex += 1) {
+    params.signal?.throwIfAborted();
     let excludedFromPage = false;
     const rawPage = await params.control.listPage({
       limit: params.limit - sessions.length,
@@ -89,12 +93,14 @@ async function listVisiblePage(params: {
       ...(params.searchTerm ? { searchTerm: params.searchTerm } : {}),
       ...(params.cwd ? { cwd: params.cwd } : {}),
     });
+    params.signal?.throwIfAborted();
     const page = filterCatalogPageByTitle(parseCatalogPage(rawPage), params.searchTerm);
     if (pageIndex === 0) {
       backwardsCursor = page.backwardsCursor;
     }
     for (const managed of rawPage.managedThreads ?? []) {
       excludedFromPage = true;
+      params.signal?.throwIfAborted();
       await params.onExcludedThread?.(managed);
     }
     for (const session of page.sessions) {
@@ -103,6 +109,7 @@ async function listVisiblePage(params: {
         continue;
       }
       excludedFromPage = true;
+      params.signal?.throwIfAborted();
       await params.onExcludedThread?.({ threadId: session.threadId });
     }
     nextCursor = page.nextCursor;
@@ -130,6 +137,7 @@ async function listGatewayHost(params: {
   query: ReturnType<typeof readGatewayParams>;
   runtime: PluginRuntime;
   sessionEntries?: SessionCatalogEntrySnapshot;
+  signal?: AbortSignal;
   source?: CodexCatalogHome;
   excludedThreadIds?: ReadonlySet<string>;
   onExcludedThread?: (thread: { threadId: string; rolloutPath?: string }) => Promise<void>;
@@ -145,7 +153,9 @@ async function listGatewayHost(params: {
       limit: params.query.limitPerHost,
       onExcludedThread: params.onExcludedThread,
       searchTerm: params.query.search,
+      signal: params.signal,
     });
+    params.signal?.throwIfAborted();
     const adoptedSessions = await listAdoptedSessionEntries({
       agentId: params.agentId,
       bindingStore: params.bindingStore,
@@ -195,6 +205,8 @@ export async function listCodexSessionCatalog(params: {
   query?: CodexSessionCatalogParams;
   listNodes?: Parameters<SessionCatalogProvider["list"]>[0]["listNodes"];
   onHost?: (host: CodexSessionCatalogHost) => void;
+  waitUntil?: (completion: Promise<void>) => void;
+  signal?: AbortSignal;
   sessionEntries?: SessionCatalogEntrySnapshot;
   includeLocal?: boolean;
   localHomes?: CodexCatalogHome[];
@@ -215,6 +227,7 @@ export async function listCodexSessionCatalog(params: {
       ? [undefined]
       : []);
   const managedThreads = await params.bindingStore.managedThreads?.snapshot();
+  params.signal?.throwIfAborted();
   const fallbackSource = params.control.homesForAgent(agentId)[0];
   const localHosts = localSources.map((source) =>
     (() => {
@@ -230,6 +243,7 @@ export async function listCodexSessionCatalog(params: {
         query,
         runtime: params.runtime,
         sessionEntries: params.sessionEntries,
+        signal: params.signal,
         excludedThreadIds: managedThreadIds,
         ...(ownershipSource && params.bindingStore.managedThreads
           ? {
@@ -249,9 +263,7 @@ export async function listCodexSessionCatalog(params: {
     })(),
   );
   for (const host of localHosts) {
-    if (params.onHost) {
-      void host.then(params.onHost).catch(() => undefined);
-    }
+    publishSessionCatalogHost(params, host);
   }
   const wantsNodes =
     !requestedHostIds || query.hostIds?.some((hostId) => hostId.startsWith("node:"));
@@ -284,6 +296,7 @@ export async function listCodexSessionCatalog(params: {
       hosts: [...(await Promise.all(localHosts)), registryHost],
     };
   }
+  params.signal?.throwIfAborted();
   const adoptedNodeSessions = listNodeAdoptedSessionEntries({
     agentId,
     config: params.config,
@@ -298,6 +311,8 @@ export async function listCodexSessionCatalog(params: {
       query,
       adoptedSessions: adoptedNodeSessions,
       terminalCapabilities: codexNodeTerminalCapability(node),
+      waitUntil: params.waitUntil,
+      signal: params.signal,
       ...(params.onHost ? { onHost: params.onHost } : {}),
     }),
   );

--- a/extensions/codex/src/session-catalog-node-continue.ts
+++ b/extensions/codex/src/session-catalog-node-continue.ts
@@ -4,6 +4,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   createSessionCatalogAdoptionCoordinator,
+  publishSessionCatalogHost,
   sessionCatalogAdoptedSourceKey,
 } from "openclaw/plugin-sdk/session-catalog";
 import type { CodexThread } from "./app-server/protocol.js";
@@ -95,6 +96,8 @@ export async function listPairedNode(params: {
   adoptedSessions: ReadonlyMap<string, AdoptedSessionEntry>;
   terminalCapabilities: Pick<CodexSessionCatalogHost, "canOpenTerminalCodex" | "canStartTerminal">;
   onHost?: (host: CodexSessionCatalogHost) => void;
+  waitUntil?: (completion: Promise<void>) => void;
+  signal?: AbortSignal;
 }): Promise<CodexSessionCatalogHost> {
   const hostId = `node:${params.node.nodeId}`;
   const common = {
@@ -133,6 +136,7 @@ export async function listPairedNode(params: {
         },
         timeoutMs: NODE_INVOKE_TIMEOUT_MS,
         scopes: ["operator.write"],
+        signal: params.signal,
       });
       const page = filterCatalogPageByTitle(
         parseCatalogPage(unwrapNodeInvokePayload(raw)),
@@ -156,11 +160,8 @@ export async function listPairedNode(params: {
       sessions: [],
       error: catalogError("NODE_INVOKE_FAILED", error),
     }));
-  if (params.onHost) {
-    // Keep the 8s aggregate response while allowing cold app-server discovery
-    // to replace that fail-soft page as soon as the node invoke really settles.
-    void eventualHost.then(params.onHost).catch(() => undefined);
-  }
+  // Retain publication through cold discovery without extending the fail-soft response.
+  publishSessionCatalogHost(params, eventualHost);
   try {
     return await withTimeout(
       eventualHost,

--- a/extensions/codex/src/session-catalog-node-listing.test.ts
+++ b/extensions/codex/src/session-catalog-node-listing.test.ts
@@ -1,5 +1,6 @@
 // Codex supervision tests cover passive listing and safe local session takeover.
 /* oxlint-disable typescript/unbound-method -- assertions inspect vi.fn-backed object methods, not unbound class methods. */
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it, vi } from "vitest";
 import {
   nodeHostMocks,
@@ -31,6 +32,39 @@ import {
 } from "./session-catalog.test-helpers.js";
 
 describe("Codex supervision catalog", () => {
+  it("does not start paired hosts when retired during node inventory", async () => {
+    const inventory = createDeferred<Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>>();
+    const inventoryStarted = createDeferred<void>();
+    const listNodes = vi.fn(() => {
+      inventoryStarted.resolve();
+      return inventory.promise;
+    });
+    const invoke = vi.fn<PluginRuntime["nodes"]["invoke"]>(async () => ({
+      payloadJSON: JSON.stringify({ sessions: [] }),
+    }));
+    const controller = new AbortController();
+    const reason = new Error("catalog retired during inventory");
+    const listed = listCodexSessionCatalog({
+      bindingStore: createCodexTestBindingStore(),
+      config,
+      runtime: createRuntime({ invoke }).runtime,
+      control: createControl(),
+      query: { hostIds: ["node:late"] },
+      listNodes,
+      signal: controller.signal,
+    }).catch((error: unknown) => error);
+    await inventoryStarted.promise;
+    controller.abort(reason);
+    inventory.resolve({
+      nodes: [
+        { nodeId: "late", connected: true, commands: [CODEX_APP_SERVER_THREADS_LIST_COMMAND] },
+      ],
+    });
+    const result = await listed;
+    expect(invoke).not.toHaveBeenCalled();
+    expect(result).toBe(reason);
+  });
+
   it("filters managed threads and backfills paired-node catalog pages", async () => {
     const listPage = vi.fn(async ({ cursor }: { cursor?: string; limit: number }) =>
       cursor
@@ -411,56 +445,108 @@ describe("Codex supervision catalog", () => {
     }
   });
 
-  it("publishes a paired-node page that finishes after the fail-soft response", async () => {
-    vi.useFakeTimers();
-    try {
-      let resolveInvoke!: (value: unknown) => void;
-      const invokeResult = new Promise<unknown>((resolve) => {
-        resolveInvoke = resolve;
-      });
-      const invoke = vi.fn<PluginRuntime["nodes"]["invoke"]>(async () => await invokeResult);
-      const onHost = vi.fn();
-      const pending = listPairedNode({
-        agentId: "main",
-        runtime: { nodes: { invoke } } as unknown as PluginRuntime,
-        node: {
+  it.each(["completes", "is cancelled"] as const)(
+    "owns paired-node publication after the fail-soft response when discovery %s",
+    async (outcome) => {
+      vi.useFakeTimers();
+      try {
+        const invokeResult = createDeferred<unknown>();
+        const controller = new AbortController();
+        const invoke = vi.fn<PluginRuntime["nodes"]["invoke"]>(async ({ signal }) => {
+          const abort = () => invokeResult.reject(signal?.reason);
+          signal?.addEventListener("abort", abort, { once: true });
+          try {
+            return await invokeResult.promise;
+          } finally {
+            signal?.removeEventListener("abort", abort);
+          }
+        });
+        const { runtime } = createRuntime({
+          invoke,
+          nodes: [
+            {
+              nodeId: "slow-node",
+              displayName: "Slow node",
+              connected: true,
+              commands: [CODEX_APP_SERVER_THREADS_LIST_COMMAND],
+            },
+          ],
+        });
+        const { api, getProvider } = createGatewayApi(runtime);
+        registerCodexSessionCatalog({
+          api,
+          bindingStore: createCodexTestBindingStore(),
+          control: createControl(),
+          getRuntimeConfig: () => config,
+        });
+        const completions: Promise<void>[] = [];
+        const completed = vi.fn();
+        const onHost = vi.fn();
+        const pending = getProvider()!.list({
+          hostIds: ["node:slow-node"],
+          limitPerHost: 40,
+          signal: controller.signal,
+          waitUntil: (completion) => {
+            completions.push(
+              completion.then(() => {
+                expect(onHost).toHaveBeenCalledOnce();
+                completed();
+              }),
+            );
+          },
+          onHost,
+        });
+
+        await vi.advanceTimersByTimeAsync(8_000);
+        await expect(pending).resolves.toMatchObject([
+          { hostId: "node:slow-node", error: { code: "NODE_INVOKE_FAILED" } },
+        ]);
+        expect(completions).toHaveLength(1);
+        expect(completed).not.toHaveBeenCalled();
+        expect(onHost).not.toHaveBeenCalled();
+        expect(invoke).toHaveBeenCalledWith({
           nodeId: "slow-node",
-          displayName: "Slow node",
-          connected: true,
-          commands: [CODEX_APP_SERVER_THREADS_LIST_COMMAND],
-        },
-        query: { limitPerHost: 40 },
-        adoptedSessions: new Map(),
-        terminalCapabilities: { canStartTerminal: true, canOpenTerminalCodex: true },
-        onHost,
-      });
+          command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
+          params: { agentId: "main", cursor: undefined, limit: 40, searchTerm: undefined },
+          timeoutMs: 65_000,
+          scopes: ["operator.write"],
+          signal: controller.signal,
+        });
 
-      await vi.advanceTimersByTimeAsync(8_000);
-      await expect(pending).resolves.toMatchObject({
-        canStartTerminal: true,
-        error: { code: "NODE_INVOKE_FAILED" },
-      });
-      expect(onHost).not.toHaveBeenCalled();
+        if (outcome === "is cancelled") {
+          controller.abort(new Error("catalog owner retired"));
+        } else {
+          invokeResult.resolve({
+            payloadJSON: JSON.stringify({
+              sessions: [{ threadId: "late-thread", status: "idle", archived: false }],
+            }),
+          });
+        }
+        await Promise.all(completions);
 
-      resolveInvoke({
-        payloadJSON: JSON.stringify({
-          sessions: [{ threadId: "late-thread", status: "idle", archived: false }],
-        }),
-      });
-      await vi.advanceTimersByTimeAsync(0);
-
-      expect(onHost).toHaveBeenCalledWith(
-        expect.objectContaining({
-          hostId: "node:slow-node",
-          canStartTerminal: true,
-          canOpenTerminalCodex: true,
-          sessions: [expect.objectContaining({ threadId: "late-thread" })],
-        }),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+        expect(onHost).toHaveBeenCalledWith(
+          expect.objectContaining({
+            hostId: "node:slow-node",
+            ...(outcome === "is cancelled"
+              ? { sessions: [], error: { code: "NODE_INVOKE_FAILED", message: expect.any(String) } }
+              : {
+                  sessions: [
+                    expect.objectContaining({
+                      threadId: "late-thread",
+                      canContinue: false,
+                      canArchive: false,
+                      canOpenTerminal: false,
+                    }),
+                  ],
+                }),
+          }),
+        );
+        expect(completed).toHaveBeenCalledOnce();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it.each([
     { mode: "app-owned", execHost: "app", boundedReader: false },

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -210,6 +210,8 @@ function registerCodexSessionCatalog(params: {
         allowProcessHomeFallback,
         listNodes,
         onHost,
+        waitUntil,
+        signal,
         sessionEntries,
         ...gatewayQuery
       } = query;
@@ -234,6 +236,8 @@ function registerCodexSessionCatalog(params: {
           control: params.control,
           query: gatewayQuery,
           listNodes,
+          waitUntil,
+          signal,
           sessionEntries,
           localHomes,
           ...(onHost ? { onHost: (host) => onHost(mapHost(host)) } : {}),

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -352,7 +352,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +3: capability catalog descriptors, entry factories, and native host context.
       // +2: canonical paragraph grouping and UTF-16 boundaries for channel-owned chunking.
       // +1: retained runtime config reader preserves channel owner and scoped config identity.
-      4434,
+      // +1: shared session-catalog host publication with completion ownership.
+      4435,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -475,7 +476,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: browser-safe Date timestamp validation and UTF-16 truncation primitives.
       // +2: canonical paragraph grouping and UTF-16 boundaries for channel-owned chunking.
       // +1: retained runtime config reader preserves channel owner and scoped config identity.
-      2619,
+      // +1: shared session-catalog host publication with completion ownership.
+      2620,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/gateway/server-methods/client-types.ts
+++ b/src/gateway/server-methods/client-types.ts
@@ -32,6 +32,8 @@ export type GatewayClient = {
   connect: ConnectParams;
   /** Transport-owned revocation marker; retained callers have no authority after invalidation. */
   invalidated?: boolean;
+  /** Host-owned transport retirement notification; does not cancel ordinary admitted RPCs. */
+  connectionSignal?: AbortSignal;
   connId?: string;
   presenceKey?: string;
   clientIp?: string;

--- a/src/gateway/server-methods/session-catalog-entry-snapshot.test.ts
+++ b/src/gateway/server-methods/session-catalog-entry-snapshot.test.ts
@@ -5,6 +5,7 @@ import {
   type SessionCreatedActor,
 } from "../../config/sessions/session-entry-provenance.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { markPluginRegistryActive } from "../../plugins/registry-lifecycle.js";
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import { createPluginRuntime } from "../../plugins/runtime/index.js";
 import {
@@ -83,6 +84,7 @@ describe("session catalog entry snapshots", () => {
 
   beforeEach(() => {
     hoisted.activeRegistry = createEmptyPluginRegistry() as TestPluginRegistry;
+    markPluginRegistryActive(hoisted.activeRegistry as PluginRegistry);
     hoisted.listSessionEntriesReadOnly.mockReset();
   });
 

--- a/src/gateway/server-methods/session-catalog-list-admission.ts
+++ b/src/gateway/server-methods/session-catalog-list-admission.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 type QueuedProviderList = {
   start: () => void;
 };
@@ -34,10 +36,13 @@ export class SessionCatalogListAdmission {
     if (this.queue.length >= this.maxQueued) {
       return Promise.reject(new SessionCatalogListBusyError(this.maxConcurrent, this.maxQueued));
     }
+    // A released slot runs the next caller's plugin and root scope, never the
+    // preceding provider's context inherited by the queue drain.
+    const runInAsyncContext = AsyncLocalStorage.snapshot();
     return new Promise<T>((resolve, reject) => {
       this.queue.push({
         start: () => {
-          void this.start(task).then(resolve, reject);
+          void runInAsyncContext(() => this.start(task)).then(resolve, reject);
         },
       });
     });

--- a/src/gateway/server-methods/session-catalog-list-lifetime.test.ts
+++ b/src/gateway/server-methods/session-catalog-list-lifetime.test.ts
@@ -1,14 +1,18 @@
+import { EventEmitter } from "node:events";
+import { setImmediate as nextTurn } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
 import type { SessionCatalogHost } from "../../../packages/gateway-protocol/src/index.js";
 import type { SessionCatalogListProviderParams } from "../../plugins/session-catalog.js";
 import {
   getActiveGatewayRootWorkCount,
+  getActiveGatewayRootWorkHolders,
   getGatewayRestartDrainSignal,
   markGatewayRestartDraining,
   resetGatewayWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
 } from "../../process/gateway-work-admission.js";
 import { createDeferredCore } from "../../shared/deferred.js";
+import { GatewayConnectionWork } from "../server-connection-work.js";
 import { SessionCatalogListLifetime } from "./session-catalog-list-lifetime.js";
 
 const host: SessionCatalogHost = {
@@ -65,20 +69,119 @@ describe("catalog list completion ownership", () => {
     }
   });
 
-  it("closes zero-background callbacks and completion registration with the list", async () => {
-    const lifetime = new SessionCatalogListLifetime(() => true, []);
+  it.each([false, true])(
+    "closes zero-background callbacks, registration, and root ownership (throws=%s)",
+    async (throws) => {
+      const before = getActiveGatewayRootWorkHolders();
+      const root = tryBeginGatewayRootWorkAdmission("catalog-zero-background");
+      expect(root).not.toBeNull();
+      const lifetime = new SessionCatalogListLifetime(() => true, []);
+      const publish = vi.fn();
+      let retained: SessionCatalogListProviderParams | undefined;
+      try {
+        const listing = root!.run(() =>
+          lifetime.runProvider(publish, async (params) => {
+            retained = params;
+            params.onHost(host);
+            if (throws) {
+              throw new Error("catalog list failed");
+            }
+            return [];
+          }),
+        );
+        if (throws) {
+          await expect(listing).rejects.toThrow("catalog list failed");
+        } else {
+          await expect(listing).resolves.toEqual([]);
+        }
+        root!.release();
+        lifetime.finishListing();
+        retained?.onHost?.(host);
+        expect(publish).toHaveBeenCalledOnce();
+        expect(() => retained?.waitUntil?.(Promise.resolve())).toThrow(/registration is closed/);
+        expect(retained?.signal?.aborted).toBe(true);
+        expect(getActiveGatewayRootWorkHolders()).toEqual(before);
+      } finally {
+        lifetime.finishListing();
+        root!.release();
+      }
+    },
+  );
+
+  it("keeps completion on its admitted owner when an external callback registers it", async () => {
+    const before = getActiveGatewayRootWorkHolders();
+    const ownerOrigin = "catalog-original-owner";
+    const foreignOrigin = "catalog-foreign-callback";
+    const root = tryBeginGatewayRootWorkAdmission(ownerOrigin);
+    const foreignRoot = tryBeginGatewayRootWorkAdmission(foreignOrigin);
+    expect(root).not.toBeNull();
+    expect(foreignRoot).not.toBeNull();
+    const owner = new GatewayConnectionWork();
+    const foreign = new GatewayConnectionWork();
+    const lifetime = new SessionCatalogListLifetime(() => true, [owner.signal]);
+    lifetime.subscribe(
+      "active",
+      () => undefined,
+      () => true,
+    );
+    const callback = new EventEmitter();
+    const registered = createDeferredCore();
+    const release = createDeferredCore();
     const publish = vi.fn();
-    let retained: SessionCatalogListProviderParams | undefined;
-    await lifetime.runProvider(publish, async (params) => {
-      retained = params;
-      params.onHost(host);
-      return [];
-    });
-    lifetime.finishListing();
-    retained?.onHost?.(host);
-    expect(publish).toHaveBeenCalledOnce();
-    expect(() => retained?.waitUntil?.(Promise.resolve())).toThrow(/registration is closed/);
-    expect(retained?.signal?.aborted).toBe(true);
+    let publication: Promise<void> | undefined;
+    let closing: Promise<void> | undefined;
+    let ownerDrained = false;
+    let foreignDrained = false;
+    let rootsAtOwnerDrain: string[] | undefined;
+    const listing = owner.track(() =>
+      root!.run(() =>
+        lifetime.runProvider(publish, async (params) => {
+          publication = release.promise.then(() => params.onHost(host));
+          // EventEmitter invokes the callback in the emitter's current context.
+          callback.once("register", () => {
+            params.waitUntil(publication!);
+            registered.resolve();
+          });
+          await registered.promise;
+        }),
+      ),
+    );
+    try {
+      await foreign.track(() => foreignRoot!.run(async () => callback.emit("register")));
+      foreignRoot!.release();
+      await listing;
+      root!.release();
+      lifetime.finishListing();
+      const retained = getActiveGatewayRootWorkHolders();
+      closing = Promise.all([
+        owner.drain().then(() => {
+          rootsAtOwnerDrain = getActiveGatewayRootWorkHolders();
+          ownerDrained = true;
+        }),
+        foreign.drain().then(() => {
+          foreignDrained = true;
+        }),
+      ]).then(() => undefined);
+      await nextTurn();
+      const whileHeld = { ownerDrained, foreignDrained };
+      release.resolve();
+      await publication;
+      await closing;
+      expect(whileHeld).toEqual({ ownerDrained: false, foreignDrained: true });
+      expect(retained).toEqual([...before, ownerOrigin].toSorted((a, b) => a.localeCompare(b)));
+      expect(rootsAtOwnerDrain).toEqual(before);
+      expect(getActiveGatewayRootWorkHolders()).toEqual(before);
+      expect(publish).not.toHaveBeenCalled();
+    } finally {
+      registered.resolve();
+      release.resolve();
+      await Promise.allSettled([listing, publication, closing]);
+      lifetime.finishListing();
+      root!.release();
+      foreignRoot!.release();
+      callback.removeAllListeners();
+      await Promise.all([owner.drain(), foreign.drain()]);
+    }
   });
 
   it.each([false, true])(

--- a/src/gateway/server-methods/session-catalog-list-lifetime.test.ts
+++ b/src/gateway/server-methods/session-catalog-list-lifetime.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionCatalogHost } from "../../../packages/gateway-protocol/src/index.js";
+import type { SessionCatalogListProviderParams } from "../../plugins/session-catalog.js";
+import {
+  getActiveGatewayRootWorkCount,
+  getGatewayRestartDrainSignal,
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
+  tryBeginGatewayRootWorkAdmission,
+} from "../../process/gateway-work-admission.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { SessionCatalogListLifetime } from "./session-catalog-list-lifetime.js";
+
+const host: SessionCatalogHost = {
+  hostId: "node:late",
+  kind: "node",
+  label: "Late host",
+  connected: true,
+  sessions: [],
+};
+const catalog = {
+  id: "fixture",
+  label: "Fixture",
+  capabilities: { continueSession: false, archive: false },
+  hosts: [host],
+};
+
+describe("catalog list completion ownership", () => {
+  it("keeps work started before retirement owned when registration follows an await", async () => {
+    const before = getActiveGatewayRootWorkCount();
+    const root = tryBeginGatewayRootWorkAdmission("catalog-register-after-retirement");
+    expect(root).not.toBeNull();
+    const lifetime = new SessionCatalogListLifetime(() => true, []);
+    const releaseListing = createDeferredCore();
+    const releaseWork = createDeferredCore();
+    const publish = vi.fn();
+    let publication: Promise<void> | undefined;
+    let signal: AbortSignal | undefined;
+    const listing = root!.run(() =>
+      lifetime.runProvider(publish, async (params) => {
+        signal = params.signal;
+        publication = releaseWork.promise.then(() => params.onHost(host));
+        await releaseListing.promise;
+        params.waitUntil(publication);
+      }),
+    );
+    try {
+      lifetime.retire();
+      releaseListing.resolve();
+      await expect(listing).resolves.toBeUndefined();
+      root!.release();
+      lifetime.finishListing();
+      expect(signal?.aborted).toBe(true);
+      expect(getActiveGatewayRootWorkCount()).toBe(before + 1);
+      releaseWork.resolve();
+      await publication;
+      expect(publish).not.toHaveBeenCalled();
+      expect(getActiveGatewayRootWorkCount()).toBe(before);
+    } finally {
+      releaseListing.resolve();
+      releaseWork.resolve();
+      await Promise.allSettled([listing, publication]);
+      lifetime.finishListing();
+      root!.release();
+    }
+  });
+
+  it("closes zero-background callbacks and completion registration with the list", async () => {
+    const lifetime = new SessionCatalogListLifetime(() => true, []);
+    const publish = vi.fn();
+    let retained: SessionCatalogListProviderParams | undefined;
+    await lifetime.runProvider(publish, async (params) => {
+      retained = params;
+      params.onHost(host);
+      return [];
+    });
+    lifetime.finishListing();
+    retained?.onHost?.(host);
+    expect(publish).toHaveBeenCalledOnce();
+    expect(() => retained?.waitUntil?.(Promise.resolve())).toThrow(/registration is closed/);
+    expect(retained?.signal?.aborted).toBe(true);
+  });
+
+  it.each([false, true])(
+    "retains the admitted root through the full publication chain (throws=%s)",
+    async (throws) => {
+      const before = getActiveGatewayRootWorkCount();
+      const root = tryBeginGatewayRootWorkAdmission("catalog-test");
+      expect(root).not.toBeNull();
+      const lifetime = new SessionCatalogListLifetime(() => true, []);
+      lifetime.subscribe(
+        "active",
+        () => undefined,
+        () => true,
+      );
+      const release = createDeferredCore();
+      let publication: Promise<void> | undefined;
+      let retained: SessionCatalogListProviderParams | undefined;
+      const publish = vi.fn(() => {
+        expect(getActiveGatewayRootWorkCount()).toBe(before + 1);
+        if (throws) {
+          throw new Error("publication failed");
+        }
+      });
+      try {
+        await root!.run(() =>
+          lifetime.runProvider(publish, async (params) => {
+            retained = params;
+            publication = release.promise.then(() => params.onHost(host));
+            params.waitUntil(publication);
+            return [];
+          }),
+        );
+        root!.release();
+        lifetime.finishListing();
+        expect(getActiveGatewayRootWorkCount()).toBe(before + 1);
+        expect(retained?.signal?.aborted).toBe(false);
+        release.resolve();
+        await publication?.catch(() => undefined);
+        expect(publish).toHaveBeenCalledOnce();
+        expect(getActiveGatewayRootWorkCount()).toBe(before);
+        retained?.onHost?.(host);
+        expect(publish).toHaveBeenCalledOnce();
+      } finally {
+        release.resolve();
+        await publication?.catch(() => undefined);
+        lifetime.finishListing();
+        root!.release();
+      }
+    },
+  );
+
+  it("disconnects subscribers without cancelling the native discovery", async () => {
+    const lifetime = new SessionCatalogListLifetime(() => true, []);
+    const connection = new AbortController();
+    const disconnected = vi.fn();
+    const live = vi.fn();
+    lifetime.subscribe("old", disconnected, () => true, connection.signal);
+    lifetime.subscribe("live", live, () => true);
+    const release = createDeferredCore();
+    let publication: Promise<void> | undefined;
+    let producerSignal: AbortSignal | undefined;
+    try {
+      await lifetime.runProvider(
+        () => lifetime.publish(catalog, new Map()),
+        async (params) => {
+          producerSignal = params.signal;
+          publication = release.promise.then(() => params.onHost(host));
+          params.waitUntil(publication);
+        },
+      );
+      lifetime.finishListing();
+      connection.abort();
+      expect(producerSignal?.aborted).toBe(false);
+      release.resolve();
+      await publication;
+      expect(disconnected).not.toHaveBeenCalled();
+      expect(live).toHaveBeenCalledOnce();
+    } finally {
+      release.resolve();
+      await publication;
+      lifetime.finishListing();
+    }
+  });
+
+  it("joins native completion when the Gateway starts draining", async () => {
+    const root = tryBeginGatewayRootWorkAdmission("catalog-drain-test");
+    expect(root).not.toBeNull();
+    const lifetime = new SessionCatalogListLifetime(() => true, [getGatewayRestartDrainSignal()]);
+    lifetime.subscribe(
+      "active",
+      () => undefined,
+      () => true,
+    );
+    const publish = vi.fn();
+    let publication: Promise<void> | undefined;
+    try {
+      await root!.run(() =>
+        lifetime.runProvider(publish, async (params) => {
+          publication = new Promise<void>((resolve) => {
+            params.signal.addEventListener("abort", () => resolve(), { once: true });
+          }).then(() => params.onHost(host));
+          params.waitUntil(publication);
+        }),
+      );
+      root!.release();
+      lifetime.finishListing();
+      expect(getActiveGatewayRootWorkCount()).toBe(1);
+      markGatewayRestartDraining();
+      expect(tryBeginGatewayRootWorkAdmission("after-drain")).toBeNull();
+      await publication;
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+      expect(publish).not.toHaveBeenCalled();
+    } finally {
+      lifetime.retire();
+      await publication;
+      lifetime.finishListing();
+      root!.release();
+      resetGatewayWorkAdmission();
+    }
+  });
+
+  it("releases the final subscriber's publisher while keeping native completion owned", async () => {
+    const before = getActiveGatewayRootWorkCount();
+    const root = tryBeginGatewayRootWorkAdmission("catalog-last-subscriber");
+    expect(root).not.toBeNull();
+    const lifetime = new SessionCatalogListLifetime(() => true, []);
+    const connection = new AbortController();
+    const listener = vi.fn();
+    lifetime.subscribe("only", listener, () => true, connection.signal);
+    const publishSnapshot = vi.fn(() => lifetime.publish(catalog, new Map()));
+    const release = createDeferredCore();
+    let publication: Promise<void> | undefined;
+    let signal: AbortSignal | undefined;
+    try {
+      await root!.run(() =>
+        lifetime.runProvider(publishSnapshot, async (params) => {
+          signal = params.signal;
+          publication = release.promise.then(() => params.onHost(host));
+          params.waitUntil(publication);
+        }),
+      );
+      root!.release();
+      lifetime.finishListing();
+      connection.abort();
+      expect(signal?.aborted).toBe(false);
+      expect(getActiveGatewayRootWorkCount()).toBe(before + 1);
+      release.resolve();
+      await publication;
+      expect(publishSnapshot).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+      expect(getActiveGatewayRootWorkCount()).toBe(before);
+    } finally {
+      release.resolve();
+      await publication;
+      lifetime.finishListing();
+      root!.release();
+    }
+  });
+
+  it.each(["signal", "aggregate-failure", "provider-failure"] as const)(
+    "retires delivery on %s without declaring an ignoring producer finished",
+    async (retirement) => {
+      const before = getActiveGatewayRootWorkCount();
+      const root = tryBeginGatewayRootWorkAdmission("catalog-retirement-test");
+      expect(root).not.toBeNull();
+      const controller = new AbortController();
+      const lifetime = new SessionCatalogListLifetime(() => true, [controller.signal]);
+      lifetime.subscribe(
+        "active",
+        () => undefined,
+        () => true,
+      );
+      const publish = vi.fn();
+      const release = createDeferredCore();
+      let publication: Promise<void> | undefined;
+      let signal: AbortSignal | undefined;
+      try {
+        const listing = root!.run(() =>
+          lifetime.runProvider(publish, async (params) => {
+            signal = params.signal;
+            publication = release.promise.then(() => params.onHost(host));
+            params.waitUntil(publication);
+            if (retirement === "provider-failure") {
+              throw new Error("provider failed");
+            }
+          }),
+        );
+        if (retirement === "provider-failure") {
+          await expect(listing).rejects.toThrow("provider failed");
+        } else {
+          await listing;
+        }
+        root!.release();
+        lifetime.finishListing();
+        if (retirement === "signal") {
+          controller.abort();
+        } else if (retirement === "aggregate-failure") {
+          lifetime.retire(new Error("response failed"));
+        }
+        expect(signal?.aborted).toBe(true);
+        expect(getActiveGatewayRootWorkCount()).toBe(before + 1);
+        release.resolve();
+        await publication;
+        expect(publish).not.toHaveBeenCalled();
+        expect(getActiveGatewayRootWorkCount()).toBe(before);
+      } finally {
+        release.resolve();
+        await publication;
+        lifetime.finishListing();
+        root!.release();
+      }
+    },
+  );
+});

--- a/src/gateway/server-methods/session-catalog-list-lifetime.ts
+++ b/src/gateway/server-methods/session-catalog-list-lifetime.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { SessionCatalogListProviderParams } from "../../plugins/session-catalog.js";
 import { retainGatewayRootWorkAdmissionContinuation } from "../../process/gateway-work-admission.js";
+import { captureAsyncWorkTracker } from "../../shared/async-work-scope.js";
 import type { SessionCatalogInstances } from "./session-catalog-entry-snapshot.js";
 
 export type CatalogListProgressSubscriber = (
@@ -88,6 +89,7 @@ export class SessionCatalogListLifetime {
       params: Required<Pick<SessionCatalogListProviderParams, "onHost" | "waitUntil" | "signal">>,
     ) => Promise<T>,
   ): Promise<T> {
+    const trackWork = captureAsyncWorkTracker();
     let publish = onHost;
     const controller = new AbortController();
     const signal = AbortSignal.any([this.controller.signal, controller.signal]);
@@ -108,6 +110,9 @@ export class SessionCatalogListLifetime {
     };
     try {
       signal.throwIfAborted();
+      // Completion callbacks can arrive from a different async context; both owners
+      // belong to this listing, and finishListing releases zero-background lists.
+      this.releaseRoot ??= retainGatewayRootWorkAdmissionContinuation() ?? undefined;
       return await run({
         signal,
         onHost: (host) => {
@@ -120,11 +125,10 @@ export class SessionCatalogListLifetime {
             throw new Error("Session catalog completion registration is closed");
           }
           // Retirement closes delivery, not accounting for work already started.
-          // Retain the admitted root through the full publication chain before list returns.
-          this.releaseRoot ??= retainGatewayRootWorkAdmissionContinuation() ?? undefined;
+          // Join the publication finalizer before the Gateway releases its dependencies.
           pending += 1;
           this.pending += 1;
-          void completion.then(settle, settle);
+          void trackWork(() => completion.then(settle, settle));
         },
       });
     } catch (error) {

--- a/src/gateway/server-methods/session-catalog-list-lifetime.ts
+++ b/src/gateway/server-methods/session-catalog-list-lifetime.ts
@@ -1,0 +1,179 @@
+import type {
+  SessionCatalog,
+  SessionCatalogHost,
+} from "../../../packages/gateway-protocol/src/index.js";
+import type { SessionCatalogListProviderParams } from "../../plugins/session-catalog.js";
+import { retainGatewayRootWorkAdmissionContinuation } from "../../process/gateway-work-admission.js";
+import type { SessionCatalogInstances } from "./session-catalog-entry-snapshot.js";
+
+export type CatalogListProgressSubscriber = (
+  catalog: SessionCatalog,
+  instances: SessionCatalogInstances,
+) => void;
+
+/** The aggregate response can finish before the native host publications it owns. */
+export class SessionCatalogListLifetime {
+  private readonly controller = new AbortController();
+  private readonly subscribers = new Map<
+    string,
+    { publish: CatalogListProgressSubscriber; remove: () => void; isCurrent: () => boolean }
+  >();
+  private readonly publishers = new Set<() => void>();
+  private readonly removeAbortListeners: Array<() => void> = [];
+  private isCurrent: (() => boolean) | undefined;
+  private listing = true;
+  private pending = 0;
+  private releaseRoot: (() => void) | undefined;
+
+  constructor(isCurrent: () => boolean, signals: readonly AbortSignal[]) {
+    this.isCurrent = isCurrent;
+    for (const signal of signals) {
+      if (signal.aborted) {
+        this.retire(signal.reason);
+        break;
+      }
+      const retire = () => this.retire(signal.reason);
+      signal.addEventListener("abort", retire, { once: true });
+      this.removeAbortListeners.push(() => signal.removeEventListener("abort", retire));
+    }
+  }
+
+  private active(): boolean {
+    try {
+      if (this.isCurrent?.()) {
+        return true;
+      }
+    } catch {
+      // A lost context is retirement, never permission to use a successor.
+    }
+    this.retire();
+    return false;
+  }
+
+  subscribe(
+    key: string,
+    publish: CatalogListProgressSubscriber,
+    isCurrent: () => boolean,
+    signal?: AbortSignal,
+  ): void {
+    this.subscribers.get(key)?.remove();
+    if (!this.active() || signal?.aborted || !isCurrent()) {
+      return;
+    }
+    const remove = () => {
+      signal?.removeEventListener("abort", remove);
+      this.subscribers.delete(key);
+      this.releaseUnusedPublishers();
+    };
+    this.subscribers.set(key, { publish, remove, isCurrent });
+    signal?.addEventListener("abort", remove, { once: true });
+  }
+
+  publish(catalog: SessionCatalog, instances: SessionCatalogInstances): void {
+    if (!this.active()) {
+      return;
+    }
+    for (const subscriber of this.subscribers.values()) {
+      if (subscriber.isCurrent()) {
+        subscriber.publish(catalog, instances);
+      } else {
+        subscriber.remove();
+      }
+    }
+  }
+
+  async runProvider<T>(
+    onHost: ((host: SessionCatalogHost) => void) | undefined,
+    run: (
+      params: Required<Pick<SessionCatalogListProviderParams, "onHost" | "waitUntil" | "signal">>,
+    ) => Promise<T>,
+  ): Promise<T> {
+    let publish = onHost;
+    const controller = new AbortController();
+    const signal = AbortSignal.any([this.controller.signal, controller.signal]);
+    let listing = true;
+    let pending = 0;
+    const releasePublisher = () => {
+      publish = undefined;
+      this.publishers.delete(releasePublisher);
+    };
+    this.publishers.add(releasePublisher);
+    const settle = () => {
+      pending -= 1;
+      this.pending -= 1;
+      if (!listing && pending === 0) {
+        releasePublisher();
+      }
+      this.finish();
+    };
+    try {
+      signal.throwIfAborted();
+      return await run({
+        signal,
+        onHost: (host) => {
+          if (this.active()) {
+            publish?.(host);
+          }
+        },
+        waitUntil: (completion) => {
+          if (!listing) {
+            throw new Error("Session catalog completion registration is closed");
+          }
+          // Retirement closes delivery, not accounting for work already started.
+          // Retain the admitted root through the full publication chain before list returns.
+          this.releaseRoot ??= retainGatewayRootWorkAdmissionContinuation() ?? undefined;
+          pending += 1;
+          this.pending += 1;
+          void completion.then(settle, settle);
+        },
+      });
+    } catch (error) {
+      releasePublisher();
+      controller.abort(error);
+      throw error;
+    } finally {
+      listing = false;
+      if (pending === 0) {
+        releasePublisher();
+      }
+    }
+  }
+
+  finishListing(): void {
+    this.listing = false;
+    this.releaseUnusedPublishers();
+    this.finish();
+  }
+
+  private releaseUnusedPublishers(): void {
+    // Active lists can gain followers; settled lists cannot. Retirement clears every capture.
+    if (this.isCurrent && (this.listing || this.subscribers.size > 0)) {
+      return;
+    }
+    for (const release of this.publishers) {
+      release();
+    }
+  }
+
+  private finish(): void {
+    if (this.listing || this.pending > 0) {
+      return;
+    }
+    this.retire();
+    this.releaseRoot?.();
+    this.releaseRoot = undefined;
+  }
+
+  retire(reason?: unknown): void {
+    // Clear captured clients and snapshots immediately, even when a producer ignores abort.
+    this.isCurrent = undefined;
+    for (const subscriber of this.subscribers.values()) {
+      subscriber.remove();
+    }
+    this.releaseUnusedPublishers();
+    for (const remove of this.removeAbortListeners.splice(0)) {
+      remove();
+    }
+    this.controller.abort(reason);
+  }
+}

--- a/src/gateway/server-methods/session-catalog-privacy.test.ts
+++ b/src/gateway/server-methods/session-catalog-privacy.test.ts
@@ -256,14 +256,38 @@ describe("catalog delivery uses current canonical privacy", () => {
   it("does not transfer a cached native thread to a replacement session at the same key", async () => {
     await withCatalog(async ({ call, changeForeign, replaceForeign, list }) => {
       await changeForeign({ visibility: "draft" });
-      expect(rows(await call())).toEqual(["owned"]);
-      await replaceForeign();
-      expect.soft(rows(await call())).toEqual(["owned"]);
-      expect(list).toHaveBeenCalledOnce();
-      expect(rows(await call("sessions.catalog.list", { search: "cold-replacement" }))).toEqual([
-        "owned",
-      ]);
-      expect(list).toHaveBeenCalledTimes(2);
+      const now = Date.now();
+      const clock = vi.spyOn(Date, "now");
+      try {
+        // Cache observations use logical time; real deletion/recreation keeps native timers.
+        await clock.withImplementation(
+          () => now,
+          async () => {
+            expect(rows(await call())).toEqual(["owned"]);
+          },
+        );
+        await replaceForeign();
+        await clock.withImplementation(
+          () => now + 1,
+          async () => {
+            expect.soft(rows(await call())).toEqual(["owned"]);
+            expect(list).toHaveBeenCalledOnce();
+            expect(
+              rows(await call("sessions.catalog.list", { search: "cold-replacement" })),
+            ).toEqual(["owned"]);
+            expect(list).toHaveBeenCalledTimes(2);
+          },
+        );
+        await clock.withImplementation(
+          () => now + 3_001,
+          async () => {
+            expect(rows(await call())).toEqual(["owned"]);
+            expect(list).toHaveBeenCalledTimes(3);
+          },
+        );
+      } finally {
+        clock.mockRestore();
+      }
     });
   });
 
@@ -279,15 +303,28 @@ describe("catalog delivery uses current canonical privacy", () => {
     });
   });
 
-  it.each([true, false])(
-    "retains the original adoption across replacement before publication (prefetch=%s)",
-    async (prefetch) =>
+  it.each([
+    { prefetch: true, late: false },
+    { prefetch: false, late: false },
+    { prefetch: true, late: true },
+  ])(
+    "retains the original adoption across replacement (prefetch=$prefetch, late=$late)",
+    async ({ prefetch, late }) =>
       withCatalog(async ({ call, changeForeign, replaceForeign, enumerate, list, owner }) => {
         await changeForeign({ visibility: "draft" });
         const entered = createDeferredCore();
         const release = createDeferredCore();
         let observed: SessionCatalogHost | undefined;
-        list.mockImplementation(async ({ sessionEntries, onHost }) => {
+        let publication: Promise<void> | undefined;
+        list.mockImplementation(async ({ sessionEntries, onHost, waitUntil }) => {
+          if (late) {
+            const prepared = enumerate(sessionEntries);
+            observed = prepared;
+            publication = release.promise.then(() => onHost?.(prepared));
+            waitUntil?.(publication);
+            entered.resolve();
+            return [];
+          }
           if (prefetch) {
             observed = enumerate(sessionEntries);
           }
@@ -304,24 +341,36 @@ describe("catalog delivery uses current canonical privacy", () => {
           owner,
           broadcast,
         );
-        await entered.promise;
-        await replaceForeign();
-        release.resolve();
-        const result = await pending;
-        // The provider's request snapshot keeps the original adoption even when first read
-        // after its await; publication must reject that now-replaced instance independently.
-        expect
-          .soft(observed?.sessions.find((session) => session.threadId === "foreign")?.sessionKey)
-          .toBe("agent:main:foreign");
-        expect.soft(rows(result)).toEqual(["owned"]);
-        expect(broadcast).toHaveBeenCalledOnce();
-        expect
-          .soft(
-            broadcast.mock.calls[0]?.[1]?.catalog.hosts[0]?.sessions.map(
-              (session: { threadId: string }) => session.threadId,
-            ),
-          )
-          .toEqual(["owned"]);
+        try {
+          await entered.promise;
+          if (late) {
+            const initial = await pending;
+            expect(initial.mock.calls[0]?.[1]?.catalogs[0]?.hosts).toEqual([]);
+          }
+          await replaceForeign();
+          release.resolve();
+          const result = await pending;
+          await publication;
+          // The provider's request snapshot keeps the original adoption even when first read
+          // after its await; publication must reject that now-replaced instance independently.
+          expect
+            .soft(observed?.sessions.find((session) => session.threadId === "foreign")?.sessionKey)
+            .toBe("agent:main:foreign");
+          if (!late) {
+            expect.soft(rows(result)).toEqual(["owned"]);
+          }
+          expect(broadcast).toHaveBeenCalledOnce();
+          expect
+            .soft(
+              broadcast.mock.calls[0]?.[1]?.catalog.hosts[0]?.sessions.map(
+                (session: { threadId: string }) => session.threadId,
+              ),
+            )
+            .toEqual(["owned"]);
+        } finally {
+          release.resolve();
+          await Promise.allSettled([pending, publication]);
+        }
       }),
   );
 

--- a/src/gateway/server-methods/session-catalog-progress.test.ts
+++ b/src/gateway/server-methods/session-catalog-progress.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../../shared/deferred.js";
+import {
+  call,
+  hoisted,
+  markPluginRegistryActive,
+  provider,
+  resetSessionCatalogTestState,
+  startCall,
+  type PluginRegistry,
+  type SessionCatalogProvider,
+} from "./session-catalog.test-helpers.js";
+
+describe("session catalog progress ownership", () => {
+  beforeEach(resetSessionCatalogTestState);
+
+  it("streams completed hosts to only the requesting connection", async () => {
+    const broadcastToConnIds = vi.fn();
+    const host = {
+      hostId: "node:fast",
+      label: "Fast node",
+      kind: "node" as const,
+      connected: true,
+      nodeId: "fast",
+      sessions: [],
+    };
+    hoisted.activeRegistry.sessionCatalogs = [
+      {
+        provider: provider("codex", {
+          list: vi.fn(async ({ onHost }) => {
+            onHost?.(host);
+            return [host];
+          }),
+        }),
+      },
+    ];
+
+    const respond = await call(
+      "sessions.catalog.list",
+      { progressId: "progress-1" },
+      {},
+      { connId: "requester", connect: {} },
+      { broadcastToConnIds },
+    );
+
+    expect(broadcastToConnIds).toHaveBeenCalledWith(
+      "sessions.catalog.host",
+      {
+        progressId: "progress-1",
+        agentId: "main",
+        catalog: expect.objectContaining({ id: "codex", hosts: [host] }),
+      },
+      new Set(["requester"]),
+      { dropIfSlow: true },
+    );
+    expect(respond).toHaveBeenCalledWith(true, {
+      catalogs: [expect.objectContaining({ id: "codex", hosts: [host] })],
+    });
+  });
+
+  it("single-flights identical concurrent lists for one caller and fans progress to active followers", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const host = {
+      hostId: "gateway:local",
+      label: "Local",
+      kind: "gateway" as const,
+      connected: true,
+      sessions: [],
+    };
+    const late = createDeferredCore();
+    const publications: Promise<void>[] = [];
+    const list = vi.fn<SessionCatalogProvider["list"]>(async ({ onHost, waitUntil }) => {
+      const publication = late.promise.then(() => onHost?.(host));
+      publications.push(publication);
+      waitUntil?.(publication);
+      await gate;
+      onHost?.(host);
+      return [host];
+    });
+    hoisted.activeRegistry.sessionCatalogs = [{ provider: provider("codex", { list }) }];
+    const config = { agents: { list: [{ id: "main" }, { id: "research" }] } };
+    const leaderBroadcast = vi.fn();
+    const followerBroadcast = vi.fn();
+    const sharedClient = { connId: "requester" };
+    const leader = startCall(
+      "sessions.catalog.list",
+      { progressId: "leader-progress", agentId: "main" },
+      config,
+      sharedClient,
+      { broadcastToConnIds: leaderBroadcast },
+    );
+    const follower = startCall(
+      "sessions.catalog.list",
+      { progressId: "follower-progress", agentId: "main" },
+      config,
+      sharedClient,
+      { broadcastToConnIds: followerBroadcast },
+    );
+    const otherAgent = startCall("sessions.catalog.list", { agentId: "research" }, config);
+    const otherParams = startCall(
+      "sessions.catalog.list",
+      { search: "other", agentId: "main" },
+      config,
+    );
+
+    try {
+      await vi.waitFor(() => expect(list).toHaveBeenCalledTimes(3));
+      release();
+      await Promise.all([
+        leader.completion,
+        follower.completion,
+        otherAgent.completion,
+        otherParams.completion,
+      ]);
+
+      expect(leaderBroadcast).toHaveBeenCalledOnce();
+      expect(followerBroadcast).toHaveBeenCalledOnce();
+      for (const pending of [leader, follower, otherAgent, otherParams]) {
+        expect(pending.respond).toHaveBeenCalledWith(true, {
+          catalogs: [expect.objectContaining({ id: "codex", hosts: [host] })],
+        });
+      }
+      const settledBroadcast = vi.fn();
+      await call(
+        "sessions.catalog.list",
+        { progressId: "settled-progress", agentId: "main" },
+        config,
+        sharedClient,
+        { broadcastToConnIds: settledBroadcast },
+      );
+      late.resolve();
+      await Promise.all(publications);
+      expect(leaderBroadcast).toHaveBeenCalledTimes(2);
+      expect(followerBroadcast).toHaveBeenCalledTimes(2);
+      expect(settledBroadcast).not.toHaveBeenCalled();
+      expect(list).toHaveBeenCalledTimes(3);
+    } finally {
+      release();
+      late.resolve();
+      await Promise.allSettled([
+        leader.completion,
+        follower.completion,
+        otherAgent.completion,
+        otherParams.completion,
+        ...publications,
+      ]);
+    }
+  });
+
+  it("retires pending progress when aggregate projection fails", async () => {
+    const late = createDeferredCore();
+    const broadcastToConnIds = vi.fn();
+    let publication: Promise<void> | undefined;
+    let signal: AbortSignal | undefined;
+    hoisted.activeRegistry.sessionCatalogs = [
+      {
+        provider: provider("fixture", {
+          list: async (params) => {
+            signal = params.signal;
+            publication = late.promise.then(() =>
+              params.onHost?.({
+                hostId: "late",
+                label: "Late",
+                kind: "node",
+                connected: true,
+                sessions: [],
+              }),
+            );
+            params.waitUntil?.(publication);
+            return [];
+          },
+        }),
+      },
+    ];
+    const getRuntimeConfig = vi
+      .fn()
+      .mockReturnValueOnce({})
+      .mockImplementation(() => {
+        throw new Error("current config unavailable");
+      });
+    try {
+      await expect(
+        call(
+          "sessions.catalog.list",
+          { progressId: "failed" },
+          {},
+          { connId: "requester" },
+          {
+            getRuntimeConfig,
+            broadcastToConnIds,
+          },
+        ),
+      ).rejects.toThrow("current config unavailable");
+      expect(signal?.aborted).toBe(true);
+      late.resolve();
+      await publication;
+      expect(broadcastToConnIds).not.toHaveBeenCalled();
+    } finally {
+      late.resolve();
+      await publication;
+    }
+  });
+
+  it.each(["registry-reactivation", "gateway-close", "disconnect"] as const)(
+    "fences old publications after %s while a replacement request can publish",
+    async (retirement) => {
+      const releases = [createDeferredCore(), createDeferredCore()];
+      const publications: Promise<void>[] = [];
+      const connection = new AbortController();
+      const gateway = new AbortController();
+      const broadcastToConnIds = vi.fn();
+      const replacementBroadcast = vi.fn();
+      let producerSignal: AbortSignal | undefined;
+      const list = vi.fn<SessionCatalogProvider["list"]>(async (params) => {
+        producerSignal = params.signal;
+        const publication = releases[publications.length]!.promise.then(() =>
+          params.onHost?.({
+            hostId: "node:late",
+            label: "Late",
+            kind: "node",
+            connected: true,
+            sessions: [],
+          }),
+        );
+        publications.push(publication);
+        params.waitUntil?.(publication);
+        return [];
+      });
+      hoisted.activeRegistry.sessionCatalogs = [{ provider: provider("fixture", { list }) }];
+      const config = {};
+      try {
+        await call(
+          "sessions.catalog.list",
+          { progressId: "original" },
+          config,
+          { connId: "old", connectionSignal: connection.signal },
+          { broadcastToConnIds, requestEntryLifetime: { signal: gateway.signal } },
+        );
+        if (retirement === "registry-reactivation") {
+          markPluginRegistryActive(hoisted.activeRegistry as PluginRegistry);
+        } else if (retirement === "gateway-close") {
+          gateway.abort();
+        } else {
+          connection.abort();
+        }
+        expect(producerSignal?.aborted).toBe(retirement !== "disconnect");
+        await call(
+          "sessions.catalog.list",
+          { progressId: "replacement" },
+          config,
+          { connId: "new" },
+          { broadcastToConnIds: replacementBroadcast },
+        );
+        releases[0]!.resolve();
+        await publications[0];
+        expect(broadcastToConnIds).not.toHaveBeenCalled();
+        expect(replacementBroadcast).not.toHaveBeenCalled();
+        expect(list).toHaveBeenCalledTimes(2);
+        releases[1]!.resolve();
+        await publications[1];
+        expect(broadcastToConnIds).not.toHaveBeenCalled();
+        expect(replacementBroadcast).toHaveBeenCalledOnce();
+        expect(replacementBroadcast.mock.calls[0]?.[1]?.progressId).toBe("replacement");
+      } finally {
+        for (const release of releases) {
+          release.resolve();
+        }
+        await Promise.allSettled(publications);
+      }
+    },
+  );
+});

--- a/src/gateway/server-methods/session-catalog-provider-access.test.ts
+++ b/src/gateway/server-methods/session-catalog-provider-access.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionCatalogHost } from "../../../packages/gateway-protocol/src/index.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import {
+  getPluginRuntimeGatewayRequestScope,
+  withPluginRuntimeGatewayRequestScope,
+} from "../../plugins/runtime/gateway-request-scope.js";
+import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
+import {
+  getActiveGatewayRootWorkHolders,
+  resetGatewayWorkAdmission,
+  retainGatewayRootWorkAdmissionContinuation,
+  tryBeginGatewayRootWorkAdmission,
+} from "../../process/gateway-work-admission.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { listSessionCatalogProvider } from "./session-catalog-provider-access.js";
+
+describe("session catalog provider admission", () => {
+  it("preserves the queued caller's plugin scope and retained Gateway root", async () => {
+    resetGatewayWorkAdmission();
+    const predecessor = tryBeginGatewayRootWorkAdmission("catalog-predecessor")!;
+    const requester = tryBeginGatewayRootWorkAdmission("catalog-requester")!;
+    const firstRegistry = createEmptyPluginRegistry();
+    const queuedRegistry = createEmptyPluginRegistry();
+    const gate = createDeferredCore<SessionCatalogHost[]>();
+    const blocker: SessionCatalogProvider = {
+      id: "blocking-catalog",
+      label: "Blocking catalog",
+      list: vi.fn(() => gate.promise),
+      read: async ({ hostId, threadId }) => ({ hostId, threadId, items: [] }),
+    };
+    let observedScope: ReturnType<typeof getPluginRuntimeGatewayRequestScope>;
+    const retained: { release: (() => void) | null } = { release: null };
+    const queued: SessionCatalogProvider = {
+      ...blocker,
+      id: "queued-catalog",
+      list: vi.fn(async () => {
+        observedScope = getPluginRuntimeGatewayRequestScope();
+        retained.release = retainGatewayRootWorkAdmissionContinuation();
+        return [];
+      }),
+    };
+    const active = predecessor.run(async () =>
+      withPluginRuntimeGatewayRequestScope(
+        { pluginRegistry: firstRegistry, pluginId: "first-owner", isWebchatConnect: () => false },
+        () => Promise.all(Array.from({ length: 4 }, () => listSessionCatalogProvider(blocker, {}))),
+      ),
+    );
+    const pending = requester.run(async () =>
+      withPluginRuntimeGatewayRequestScope(
+        { pluginRegistry: queuedRegistry, pluginId: "queued-owner", isWebchatConnect: () => false },
+        () => listSessionCatalogProvider(queued, {}),
+      ),
+    );
+    try {
+      expect(blocker.list).toHaveBeenCalledTimes(4);
+      expect(queued.list).not.toHaveBeenCalled();
+      gate.resolve([]);
+      await Promise.all([active, pending]);
+
+      expect(queued.list).toHaveBeenCalledOnce();
+      expect.soft(observedScope?.pluginRegistry).toBe(queuedRegistry);
+      expect.soft(observedScope?.pluginId).toBe("queued-owner");
+      expect(retained.release).not.toBeNull();
+      predecessor.release();
+      requester.release();
+      expect(getActiveGatewayRootWorkHolders()).toEqual(["catalog-requester"]);
+    } finally {
+      gate.resolve([]);
+      await Promise.allSettled([active, pending]);
+      retained.release?.();
+      predecessor.release();
+      requester.release();
+      resetGatewayWorkAdmission();
+    }
+  });
+
+  it("skips a retired queued provider and continues with the next live request", async () => {
+    const gate = createDeferredCore<SessionCatalogHost[]>();
+    const blocker: SessionCatalogProvider = {
+      id: "blocking-catalog",
+      label: "Blocking catalog",
+      list: vi.fn(() => gate.promise),
+      read: async ({ hostId, threadId }) => ({ hostId, threadId, items: [] }),
+    };
+    const queued = { ...blocker, id: "retired-catalog", list: vi.fn(async () => []) };
+    const successor = { ...blocker, id: "live-catalog", list: vi.fn(async () => []) };
+    const active = Array.from({ length: 4 }, () => listSessionCatalogProvider(blocker, {}));
+    const owner = new AbortController();
+    const rejected = listSessionCatalogProvider(queued, { signal: owner.signal });
+    const observed = rejected.then(
+      (hosts) => ({ hosts }),
+      (error: unknown) => ({ error }),
+    );
+    const next = listSessionCatalogProvider(successor, {});
+    try {
+      expect(blocker.list).toHaveBeenCalledTimes(4);
+      expect(queued.list).not.toHaveBeenCalled();
+      expect(successor.list).not.toHaveBeenCalled();
+      const retirement = new Error("catalog owner retired");
+      owner.abort(retirement);
+
+      gate.resolve([]);
+
+      expect(await observed).toEqual({ error: retirement });
+      expect(queued.list).not.toHaveBeenCalled();
+      expect(await next).toEqual([]);
+      expect(successor.list).toHaveBeenCalledOnce();
+    } finally {
+      gate.resolve([]);
+      await Promise.allSettled([...active, rejected, next]);
+    }
+  });
+});

--- a/src/gateway/server-methods/session-catalog-provider-access.ts
+++ b/src/gateway/server-methods/session-catalog-provider-access.ts
@@ -43,7 +43,10 @@ export function listSessionCatalogProvider(
   provider: SessionCatalogProvider,
   params: SessionCatalogListProviderParams,
 ) {
-  return sessionCatalogListAdmission.run(() => provider.list(params));
+  return sessionCatalogListAdmission.run(() => {
+    params.signal?.throwIfAborted();
+    return provider.list(params);
+  });
 }
 
 function resolveSessionCatalogRegistry(): PluginRegistry | null {

--- a/src/gateway/server-methods/session-catalog-share-route.test.ts
+++ b/src/gateway/server-methods/session-catalog-share-route.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { markPluginRegistryActive } from "../../plugins/registry-lifecycle.js";
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
 
@@ -64,6 +65,7 @@ async function listCatalogs(params: unknown = {}) {
 describe("session catalog share routes", () => {
   beforeEach(() => {
     hoisted.activeRegistry = createEmptyPluginRegistry() as TestPluginRegistry;
+    markPluginRegistryActive(hoisted.activeRegistry as PluginRegistry);
     hoisted.hasMultipleSessionSharingIdentities.mockReset().mockReturnValue(false);
     hoisted.listSessionEntriesReadOnly.mockReset().mockReturnValue([]);
   });

--- a/src/gateway/server-methods/session-catalog-visibility.test.ts
+++ b/src/gateway/server-methods/session-catalog-visibility.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { GATEWAY_OWNER_PROFILE_ID } from "../../../packages/gateway-protocol/src/schema/users.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { markPluginRegistryActive } from "../../plugins/registry-lifecycle.js";
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
 
@@ -143,6 +144,7 @@ function roleConfig(others: "none" | "view" | "suggest" | "write", agents: "*" |
 describe("session catalog caller visibility", () => {
   beforeEach(() => {
     hoisted.activeRegistry = createEmptyPluginRegistry() as TestPluginRegistry;
+    markPluginRegistryActive(hoisted.activeRegistry as PluginRegistry);
     hoisted.hasMultipleSessionSharingIdentities.mockReset().mockReturnValue(false);
     hoisted.getUserProfileRole.mockReset().mockReturnValue(null);
     hoisted.listSessionEntriesReadOnly.mockReset().mockReturnValue([]);

--- a/src/gateway/server-methods/session-catalog.home-isolation.test.ts
+++ b/src/gateway/server-methods/session-catalog.home-isolation.test.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { markPluginRegistryActive } from "../../plugins/registry-lifecycle.js";
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
 import { withEnvAsync } from "../../test-utils/env.js";
@@ -79,6 +80,7 @@ function withProfile<T>(profile: string | undefined, run: () => Promise<T>): Pro
 describe("session catalog Gateway HOME isolation", () => {
   beforeEach(() => {
     hoisted.activeRegistry = createEmptyPluginRegistry() as TestPluginRegistry;
+    markPluginRegistryActive(hoisted.activeRegistry as PluginRegistry);
     hoisted.listSessionEntriesReadOnly.mockReset().mockReturnValue([]);
   });
 

--- a/src/gateway/server-methods/session-catalog.test-helpers.ts
+++ b/src/gateway/server-methods/session-catalog.test-helpers.ts
@@ -1,0 +1,129 @@
+import { vi } from "vitest";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import type { PluginRegistry } from "../../plugins/registry-types.js";
+import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
+
+type TestPluginRegistry = Omit<PluginRegistry, "sessionCatalogs"> & {
+  sessionCatalogs: Array<{
+    pluginId?: string;
+    pluginName?: string;
+    provider: SessionCatalogProvider;
+    rootDir?: string;
+    source?: string;
+  }>;
+};
+
+const hoisted = vi.hoisted(() => ({
+  activeRegistry: {} as TestPluginRegistry,
+  hasMultipleSessionSharingIdentities: vi.fn(() => false),
+  listSessionEntriesReadOnly: vi.fn<
+    (scope?: { agentId?: string; clone?: boolean; projection?: "full" | "list" }) => Array<{
+      sessionKey: string;
+      entry: {
+        createdActor?: { type: "human" | "agent" | "system"; id?: string };
+        updatedAt?: number;
+      };
+    }>
+  >(() => []),
+  recordSessionStateEvent: vi.fn(),
+  upsertSessionUpstreamLink: vi.fn(),
+}));
+const conversationBindingMocks = vi.hoisted(() => ({
+  bindPluginSessionConversation: vi.fn(async (params: { afterBind?: () => Promise<void> }) => {
+    await params.afterBind?.();
+    return {};
+  }),
+}));
+vi.mock("../../plugins/runtime.js", () => ({
+  getActivePluginRegistry: () => hoisted.activeRegistry,
+  requireActivePluginRegistry: () => hoisted.activeRegistry,
+}));
+
+vi.mock("../../sessions/session-state-events.js", () => ({
+  recordSessionStateEvent: hoisted.recordSessionStateEvent,
+}));
+
+vi.mock("../../sessions/session-upstream-links.js", () => ({
+  upsertSessionUpstreamLink: hoisted.upsertSessionUpstreamLink,
+}));
+vi.mock("../../plugins/session-conversation-binding.js", () => ({
+  bindPluginSessionConversation: conversationBindingMocks.bindPluginSessionConversation,
+}));
+vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions/session-accessor.js")>();
+  return { ...actual, listSessionEntriesReadOnly: hoisted.listSessionEntriesReadOnly };
+});
+vi.mock("../../state/user-profiles.js", () => ({
+  getUserProfileRole: vi.fn(() => null),
+  hasMultipleSessionSharingIdentities: hoisted.hasMultipleSessionSharingIdentities,
+}));
+const { markPluginRegistryActive } = await import("../../plugins/registry-lifecycle.js");
+const { bindPluginRegistryRuntime } = await import("../../plugins/registry-runtime-binding.js");
+const { createPluginRuntime } = await import("../../plugins/runtime/index.js");
+const { resolveRegisteredCatalogCreateTarget, sessionCatalogHandlers } =
+  await import("./session-catalog.js");
+
+export function provider(
+  id: string,
+  overrides: Partial<SessionCatalogProvider> = {},
+): SessionCatalogProvider {
+  return {
+    id,
+    label: id.toUpperCase(),
+    list: vi.fn(async () => []),
+    read: vi.fn(async ({ hostId, threadId }) => ({ hostId, threadId, items: [] })),
+    ...overrides,
+  };
+}
+
+export async function call(
+  method: keyof typeof sessionCatalogHandlers,
+  params: unknown,
+  config: Record<string, unknown> = {},
+  client?: { connect?: { scopes?: string[] }; connId?: string; connectionSignal?: AbortSignal },
+  contextOverrides: Record<string, unknown> = {},
+) {
+  const pending = startCall(method, params, config, client, contextOverrides);
+  await pending.completion;
+  return pending.respond;
+}
+
+export function startCall(
+  method: keyof typeof sessionCatalogHandlers,
+  params: unknown,
+  config: Record<string, unknown> = {},
+  client?: { connect?: { scopes?: string[] }; connId?: string; connectionSignal?: AbortSignal },
+  contextOverrides: Record<string, unknown> = {},
+) {
+  const respond = vi.fn();
+  const completion = Promise.resolve(
+    sessionCatalogHandlers[method]?.({
+      params,
+      respond,
+      client,
+      context: { getRuntimeConfig: () => config, ...contextOverrides },
+    } as never),
+  );
+  return { completion, respond };
+}
+
+export function resetSessionCatalogTestState() {
+  hoisted.activeRegistry = createEmptyPluginRegistry() as TestPluginRegistry;
+  markPluginRegistryActive(hoisted.activeRegistry as PluginRegistry);
+  hoisted.hasMultipleSessionSharingIdentities.mockReset().mockReturnValue(false);
+  hoisted.listSessionEntriesReadOnly.mockReset();
+  hoisted.listSessionEntriesReadOnly.mockReturnValue([]);
+  hoisted.recordSessionStateEvent.mockClear();
+  hoisted.upsertSessionUpstreamLink.mockClear();
+  conversationBindingMocks.bindPluginSessionConversation.mockClear();
+}
+
+export {
+  bindPluginRegistryRuntime,
+  conversationBindingMocks,
+  createPluginRuntime,
+  hoisted,
+  markPluginRegistryActive,
+  resolveRegisteredCatalogCreateTarget,
+};
+export type { PluginRegistry, SessionCatalogProvider };

--- a/src/gateway/server-methods/session-catalog.test.ts
+++ b/src/gateway/server-methods/session-catalog.test.ts
@@ -1,122 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
-import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
-import { bindPluginRegistryRuntime } from "../../plugins/registry-runtime-binding.js";
-import type { PluginRegistry } from "../../plugins/registry-types.js";
-import { createPluginRuntime } from "../../plugins/runtime/index.js";
-import type { SessionCatalogProvider } from "../../plugins/session-catalog.js";
-
-type TestPluginRegistry = Omit<PluginRegistry, "sessionCatalogs"> & {
-  sessionCatalogs: Array<{
-    pluginId?: string;
-    pluginName?: string;
-    provider: SessionCatalogProvider;
-    rootDir?: string;
-    source?: string;
-  }>;
-};
-
-const hoisted = vi.hoisted(() => ({
-  activeRegistry: {} as TestPluginRegistry,
-  hasMultipleSessionSharingIdentities: vi.fn(() => false),
-  listSessionEntriesReadOnly: vi.fn<
-    (scope?: { agentId?: string; clone?: boolean; projection?: "full" | "list" }) => Array<{
-      sessionKey: string;
-      entry: {
-        createdActor?: { type: "human" | "agent" | "system"; id?: string };
-        updatedAt?: number;
-      };
-    }>
-  >(() => []),
-  recordSessionStateEvent: vi.fn(),
-  upsertSessionUpstreamLink: vi.fn(),
-}));
-const conversationBindingMocks = vi.hoisted(() => ({
-  bindPluginSessionConversation: vi.fn(async (params: { afterBind?: () => Promise<void> }) => {
-    await params.afterBind?.();
-    return {};
-  }),
-}));
-vi.mock("../../plugins/runtime.js", () => ({
-  getActivePluginRegistry: () => hoisted.activeRegistry,
-  requireActivePluginRegistry: () => hoisted.activeRegistry,
-}));
-
-vi.mock("../../sessions/session-state-events.js", () => ({
-  recordSessionStateEvent: hoisted.recordSessionStateEvent,
-}));
-
-vi.mock("../../sessions/session-upstream-links.js", () => ({
-  upsertSessionUpstreamLink: hoisted.upsertSessionUpstreamLink,
-}));
-vi.mock("../../plugins/session-conversation-binding.js", () => ({
-  bindPluginSessionConversation: conversationBindingMocks.bindPluginSessionConversation,
-}));
-vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../config/sessions/session-accessor.js")>();
-  return { ...actual, listSessionEntriesReadOnly: hoisted.listSessionEntriesReadOnly };
-});
-vi.mock("../../state/user-profiles.js", () => ({
-  getUserProfileRole: vi.fn(() => null),
-  hasMultipleSessionSharingIdentities: hoisted.hasMultipleSessionSharingIdentities,
-}));
-const { resolveRegisteredCatalogCreateTarget, sessionCatalogHandlers } =
-  await import("./session-catalog.js");
-
-function provider(
-  id: string,
-  overrides: Partial<SessionCatalogProvider> = {},
-): SessionCatalogProvider {
-  return {
-    id,
-    label: id.toUpperCase(),
-    list: vi.fn(async () => []),
-    read: vi.fn(async ({ hostId, threadId }) => ({ hostId, threadId, items: [] })),
-    ...overrides,
-  };
-}
-
-async function call(
-  method: keyof typeof sessionCatalogHandlers,
-  params: unknown,
-  config: Record<string, unknown> = {},
-  client?: { connect?: { scopes?: string[] }; connId?: string },
-  contextOverrides: Record<string, unknown> = {},
-) {
-  const pending = startCall(method, params, config, client, contextOverrides);
-  await pending.completion;
-  return pending.respond;
-}
-
-function startCall(
-  method: keyof typeof sessionCatalogHandlers,
-  params: unknown,
-  config: Record<string, unknown> = {},
-  client?: { connect?: { scopes?: string[] }; connId?: string },
-  contextOverrides: Record<string, unknown> = {},
-) {
-  const respond = vi.fn();
-  const completion = Promise.resolve(
-    sessionCatalogHandlers[method]?.({
-      params,
-      respond,
-      client,
-      context: { getRuntimeConfig: () => config, ...contextOverrides },
-    } as never),
-  );
-  return { completion, respond };
-}
+import {
+  bindPluginRegistryRuntime,
+  call,
+  conversationBindingMocks,
+  createPluginRuntime,
+  hoisted,
+  provider,
+  resetSessionCatalogTestState,
+  resolveRegisteredCatalogCreateTarget,
+  type PluginRegistry,
+} from "./session-catalog.test-helpers.js";
 
 describe("session catalog Gateway methods", () => {
-  beforeEach(() => {
-    hoisted.activeRegistry = createEmptyPluginRegistry() as TestPluginRegistry;
-    hoisted.hasMultipleSessionSharingIdentities.mockReset().mockReturnValue(false);
-    hoisted.listSessionEntriesReadOnly.mockReset();
-    hoisted.listSessionEntriesReadOnly.mockReturnValue([]);
-    hoisted.recordSessionStateEvent.mockClear();
-    hoisted.upsertSessionUpstreamLink.mockClear();
-    conversationBindingMocks.bindPluginSessionConversation.mockClear();
-  });
+  beforeEach(resetSessionCatalogTestState);
 
   it("sorts catalogs and isolates provider failures", async () => {
     hoisted.activeRegistry.sessionCatalogs = [
@@ -140,111 +37,6 @@ describe("session catalog Gateway methods", () => {
         expect.objectContaining({ id: "zeta", hosts: [] }),
       ],
     });
-  });
-
-  it("streams completed hosts to only the requesting connection", async () => {
-    const broadcastToConnIds = vi.fn();
-    const host = {
-      hostId: "node:fast",
-      label: "Fast node",
-      kind: "node" as const,
-      connected: true,
-      nodeId: "fast",
-      sessions: [],
-    };
-    hoisted.activeRegistry.sessionCatalogs = [
-      {
-        provider: provider("codex", {
-          list: vi.fn(async ({ onHost }) => {
-            onHost?.(host);
-            return [host];
-          }),
-        }),
-      },
-    ];
-
-    const respond = await call(
-      "sessions.catalog.list",
-      { progressId: "progress-1" },
-      {},
-      { connId: "requester", connect: {} },
-      { broadcastToConnIds },
-    );
-
-    expect(broadcastToConnIds).toHaveBeenCalledWith(
-      "sessions.catalog.host",
-      {
-        progressId: "progress-1",
-        agentId: "main",
-        catalog: expect.objectContaining({ id: "codex", hosts: [host] }),
-      },
-      new Set(["requester"]),
-      { dropIfSlow: true },
-    );
-    expect(respond).toHaveBeenCalledWith(true, {
-      catalogs: [expect.objectContaining({ id: "codex", hosts: [host] })],
-    });
-  });
-
-  it("single-flights identical concurrent lists for one caller and fans progress to active followers", async () => {
-    let release!: () => void;
-    const gate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const host = {
-      hostId: "gateway:local",
-      label: "Local",
-      kind: "gateway" as const,
-      connected: true,
-      sessions: [],
-    };
-    const list = vi.fn(async ({ onHost }: { onHost?: (value: typeof host) => void }) => {
-      await gate;
-      onHost?.(host);
-      return [host];
-    });
-    hoisted.activeRegistry.sessionCatalogs = [{ provider: provider("codex", { list }) }];
-    const config = { agents: { list: [{ id: "main" }, { id: "research" }] } };
-    const leaderBroadcast = vi.fn();
-    const followerBroadcast = vi.fn();
-    const sharedClient = { connId: "requester" };
-    const leader = startCall(
-      "sessions.catalog.list",
-      { progressId: "leader-progress", agentId: "main" },
-      config,
-      sharedClient,
-      { broadcastToConnIds: leaderBroadcast },
-    );
-    const follower = startCall(
-      "sessions.catalog.list",
-      { progressId: "follower-progress", agentId: "main" },
-      config,
-      sharedClient,
-      { broadcastToConnIds: followerBroadcast },
-    );
-    const otherAgent = startCall("sessions.catalog.list", { agentId: "research" }, config);
-    const otherParams = startCall(
-      "sessions.catalog.list",
-      { search: "other", agentId: "main" },
-      config,
-    );
-
-    await vi.waitFor(() => expect(list).toHaveBeenCalledTimes(3));
-    release();
-    await Promise.all([
-      leader.completion,
-      follower.completion,
-      otherAgent.completion,
-      otherParams.completion,
-    ]);
-
-    expect(leaderBroadcast).toHaveBeenCalledOnce();
-    expect(followerBroadcast).toHaveBeenCalledOnce();
-    for (const pending of [leader, follower, otherAgent, otherParams]) {
-      expect(pending.respond).toHaveBeenCalledWith(true, {
-        catalogs: [expect.objectContaining({ id: "codex", hosts: [host] })],
-      });
-    }
   });
 
   it("forwards one explicit multi-agent owner through list, read, continue, and archive", async () => {

--- a/src/gateway/server-methods/session-catalog.ts
+++ b/src/gateway/server-methods/session-catalog.ts
@@ -17,10 +17,17 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
+import {
+  capturePluginLifecycleAuthority,
+  capturePluginRegistryLifecycleEpoch,
+  capturePluginRegistryLifecycleSignal,
+} from "../../plugins/registry-lifecycle.js";
+import { getPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import type {
   SessionCatalogCreateTarget,
   SessionCatalogProvider,
 } from "../../plugins/session-catalog.js";
+import { getGatewayRestartDrainSignal } from "../../process/gateway-work-admission.js";
 import { authorizeGatewaySessionCreation } from "../operator-role-policy.js";
 import { projectSessionParticipant } from "../session-identity-projection.js";
 import type { SessionActorProfileIdentity } from "../session-utils-contracts.js";
@@ -31,6 +38,10 @@ import {
   createSessionCatalogRequestEntrySnapshot,
   type SessionCatalogInstances,
 } from "./session-catalog-entry-snapshot.js";
+import {
+  SessionCatalogListLifetime,
+  type CatalogListProgressSubscriber,
+} from "./session-catalog-list-lifetime.js";
 import {
   allowProcessHomeFallback,
   createSessionCatalogRequestNodeSnapshot,
@@ -95,14 +106,9 @@ const providerCreateTargetsByConfig = new WeakMap<
 type CatalogListResult = { catalogs: SessionCatalog[] };
 type CatalogListEnumeration = CatalogListResult & { instances: SessionCatalogInstances };
 
-type CatalogListProgressSubscriber = (
-  catalog: SessionCatalog,
-  instances: SessionCatalogInstances,
-) => void;
-
 type CatalogListCacheEntry = {
   expiresAt?: number;
-  progressSubscribers: Map<string, CatalogListProgressSubscriber>;
+  progress: SessionCatalogListLifetime;
   result: Promise<CatalogListEnumeration>;
 };
 
@@ -317,7 +323,7 @@ function catalogResult(
 }
 
 export const sessionCatalogHandlers: GatewayRequestHandlers = {
-  "sessions.catalog.list": async ({ params, respond, context, client }) => {
+  "sessions.catalog.list": async ({ params, respond, context, client, signal }) => {
     if (
       !assertValidParams(
         params,
@@ -410,6 +416,22 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
               { dropIfSlow: true },
             )
         : undefined;
+    const subscribe = (progress: SessionCatalogListLifetime) => {
+      if (subscriber && progressConnId) {
+        progress.subscribe(
+          `${progressConnId}\0${progressId}`,
+          subscriber,
+          () =>
+            client?.invalidated !== true &&
+            context.isConnectionActive?.(progressConnId) !== false &&
+            (!client?.internal?.agentRuntimeIdentity ||
+              context.validateAgentRuntimeApprovalAuthority?.(
+                client.internal.agentRuntimeIdentity,
+              ) === true),
+          client?.connectionSignal ?? signal,
+        );
+      }
+    };
     const listKey = sessionCatalogListKey({
       agentId: resolvedAgent.agentId,
       client,
@@ -423,8 +445,8 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     if (cached && (cached.expiresAt === undefined || cached.expiresAt > Date.now())) {
       // progressId is connection-owned and excluded from the work key. Active followers register
       // for the remaining host frames; settled followers receive only the authoritative result.
-      if (cached.expiresAt === undefined && subscriber) {
-        cached.progressSubscribers.set(`${progressConnId}\0${progressId}`, subscriber);
+      if (cached.expiresAt === undefined) {
+        subscribe(cached.progress);
       }
       cache.delete(listKey);
       cache.set(listKey, cached);
@@ -434,10 +456,30 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
     if (cached) {
       cache.delete(listKey);
     }
-    const progressSubscribers = new Map<string, CatalogListProgressSubscriber>();
-    if (subscriber) {
-      progressSubscribers.set(`${progressConnId}\0${progressId}`, subscriber);
-    }
+    const registry = catalogRegistrations.registry;
+    const scopedRuntime = getPluginRuntimeGatewayRequestScope()?.pluginRegistry === registry;
+    const epoch = registry ? capturePluginRegistryLifecycleEpoch(registry) : undefined;
+    const registryAuthority = registry
+      ? capturePluginLifecycleAuthority(registry, undefined, { scopedRuntime })
+      : undefined;
+    const registrySignal = registry
+      ? capturePluginRegistryLifecycleSignal(registry, epoch, { scopedRuntime })
+      : undefined;
+    const resolveGatewayContext = context.resolveGatewayContext;
+    const progress = new SessionCatalogListLifetime(
+      () =>
+        (!resolveGatewayContext || resolveGatewayContext() === context) &&
+        (!registry ||
+          (registryAuthority?.() === true &&
+            registry.sessionCatalogs === catalogRegistrations.source)),
+      [
+        getGatewayRestartDrainSignal(),
+        context.requestEntryLifetime?.signal,
+        registrySignal,
+        signal,
+      ].filter((candidate): candidate is AbortSignal => candidate !== undefined),
+    );
+    subscribe(progress);
     const operation = (async () => {
       const requestEntries = createSessionCatalogRequestEntrySnapshot({
         cfg: config,
@@ -461,22 +503,22 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
             const catalog = catalogResult(provider, shareRoute, [host], undefined, createSession);
             // Progressive frames are an optimization. The final RPC response remains
             // authoritative when a slow client drops an intermediate host update.
-            for (const publish of progressSubscribers.values()) {
-              publish(catalog, instances);
-            }
+            progress.publish(catalog, instances);
           };
           try {
-            const hosts = await listSessionCatalogProvider(provider, {
-              agentId: resolvedAgent.agentId,
-              allowProcessHomeFallback: allowHomeFallback,
-              search,
-              limitPerHost: request.limitPerHost,
-              hostIds: request.hostIds,
-              ...(request.cursors !== undefined ? { cursors: request.cursors } : {}),
-              sessionEntries: requestEntries.sessionEntries,
-              listNodes,
-              onHost,
-            });
+            const hosts = await progress.runProvider(onHost, (lifetime) =>
+              listSessionCatalogProvider(provider, {
+                agentId: resolvedAgent.agentId,
+                allowProcessHomeFallback: allowHomeFallback,
+                search,
+                limitPerHost: request.limitPerHost,
+                hostIds: request.hostIds,
+                ...(request.cursors !== undefined ? { cursors: request.cursors } : {}),
+                sessionEntries: requestEntries.sessionEntries,
+                listNodes,
+                ...lifetime,
+              }),
+            );
             for (const host of hosts) {
               requestEntries.captureHostInstances(host, instances);
             }
@@ -488,7 +530,7 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
       );
       return { catalogs: catalogList, instances };
     })();
-    const entry: CatalogListCacheEntry = { progressSubscribers, result: operation };
+    const entry: CatalogListCacheEntry = { progress, result: operation };
     // Raw enumeration stays shareable for 3s within the caller's authority partition. Privacy
     // and creator projection are refreshed per delivery, independently of metadata expiry.
     cache.set(listKey, entry);
@@ -500,12 +542,13 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
       }
       respond(true, projectResult(result));
     } catch (error) {
+      progress.retire(error);
       if (cache.get(listKey) === entry) {
         cache.delete(listKey);
       }
       throw error;
     } finally {
-      progressSubscribers.clear();
+      progress.finishListing();
     }
   },
 

--- a/src/gateway/server.request-lifetime.test.ts
+++ b/src/gateway/server.request-lifetime.test.ts
@@ -228,6 +228,145 @@ describe("public Gateway close request lifetime", () => {
     }
   });
 
+  it("joins a returned catalog's held completion before zero-budget dependency retirement", async ({
+    signal,
+  }) => {
+    const release = createDeferredCore();
+    const connectionReleased = createDeferredCore();
+    const order: string[] = [];
+    const finishedAtClose: boolean[] = [];
+    let publication: Promise<void> | undefined;
+    let providerSignal: AbortSignal | undefined;
+    let completionSettled = false;
+    let drainFinished = false;
+    const registry = createEmptyPluginRegistry();
+    registry.sessionCatalogs.push({
+      pluginId: "catalog-lifetime-proof",
+      source: "test",
+      provider: {
+        id: "catalog-lifetime-proof",
+        label: "Catalog lifetime proof",
+        audience: "gateway-operators",
+        supportsProcessHomeIsolation: true,
+        list: async (params) => {
+          providerSignal = params.signal;
+          publication = release.promise
+            .then(() =>
+              params.onHost?.({
+                hostId: "node:held",
+                kind: "node",
+                label: "Held host",
+                connected: true,
+                sessions: [],
+              }),
+            )
+            .finally(() => {
+              completionSettled = true;
+              order.push("catalog completion settled");
+            });
+          params.waitUntil?.(publication);
+          return [];
+        },
+        read: async () => {
+          throw new Error("read is outside this catalog lifetime proof");
+        },
+      },
+    });
+    setTestPluginRegistry(registry);
+    const unblock = () => release.resolve();
+    signal.addEventListener("abort", unblock, { once: true });
+    let gateway: GatewayHarness | undefined;
+    let ws: WebSocket | undefined;
+    let closing: Promise<void> | undefined;
+    try {
+      // Observe the real owner after the fixture's mock registration has loaded.
+      const kernelModule = await import("./server-kernel.js");
+      const createKernel = kernelModule.createGatewayKernel;
+      vi.spyOn(kernelModule, "createGatewayKernel").mockImplementationOnce(async (...args) => {
+        const kernel = await createKernel(...args);
+        const register = kernel.connectionWork.registerConnection.bind(kernel.connectionWork);
+        vi.spyOn(kernel.connectionWork, "registerConnection").mockImplementation((close) => {
+          const releaseConnection = register(close);
+          return () => {
+            releaseConnection();
+            connectionReleased.resolve();
+          };
+        });
+        const drain = kernel.connectionWork.drain.bind(kernel.connectionWork);
+        vi.spyOn(kernel.connectionWork, "drain").mockImplementation(async () => {
+          await drain();
+          drainFinished = true;
+        });
+        kernel.registerGatewayLifetimeSidecars([
+          {
+            stop: () => {
+              order.push("dependencies stopped");
+            },
+          },
+        ]);
+        return kernel;
+      });
+      gateway = await createGatewaySuiteHarness({
+        serverOptions: { bind: "loopback", auth: { mode: "none" } },
+      });
+      await gateway.server.startupSettled;
+      ws = await gateway.openWs();
+      await connectOk(ws, { scopes: ["operator.admin"] });
+      const response = onceMessage<{
+        type: string;
+        id: string;
+        ok: boolean;
+        payload?: { catalogs: Array<{ id: string; hosts: unknown[] }> };
+      }>(ws, (frame) => frame.type === "res" && frame.id === "held-catalog");
+      ws.send(
+        JSON.stringify({
+          type: "req",
+          id: "held-catalog",
+          method: "sessions.catalog.list",
+          params: { catalogId: "catalog-lifetime-proof", progressId: "held-catalog" },
+        }),
+      );
+      expect(await response).toMatchObject({
+        ok: true,
+        payload: { catalogs: [{ id: "catalog-lifetime-proof", hosts: [] }] },
+      });
+      await nextTurn();
+      expect(completionSettled).toBe(false);
+      expect(providerSignal?.aborted).toBe(false);
+      const disconnected = once(ws, "close");
+      const firstClose = gateway.server.close({ drainTimeoutMs: 0 }).then(() => {
+        finishedAtClose.push(completionSettled);
+      });
+      const concurrentClose = gateway.server.close({ drainTimeoutMs: 0 }).then(() => {
+        finishedAtClose.push(completionSettled);
+      });
+      closing = Promise.all([firstClose, concurrentClose]).then(() => undefined);
+      await disconnected;
+      // The server-side release follows actual socket bookkeeping. Once its microtasks
+      // settle, the held catalog completion must be the remaining required work.
+      await connectionReleased.promise;
+      await nextTurn();
+      const whileHeld = { drainFinished, order: [...order], retired: providerSignal?.aborted };
+      unblock();
+      await publication;
+      await closing;
+      expect(whileHeld).toEqual({ drainFinished: false, order: [], retired: true });
+      expect(order).toEqual(["catalog completion settled", "dependencies stopped"]);
+      expect(finishedAtClose).toEqual([true, true]);
+    } finally {
+      unblock();
+      try {
+        await Promise.allSettled([publication]);
+        ws?.terminate();
+        await (closing ?? gateway?.server.close({ drainTimeoutMs: 0 }));
+        resetTestPluginRegistry();
+      } finally {
+        vi.restoreAllMocks();
+        signal.removeEventListener("abort", unblock);
+      }
+    }
+  });
+
   it("fences incoming RPCs while an asynchronous shutdown owner is still stopping", async ({
     signal,
   }) => {

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -339,11 +339,12 @@ describe("attachGatewayWsConnectionHandler", () => {
     expect(socket.ping).toHaveBeenCalledOnce();
   });
 
-  it("runs connection-owned Talk cleanup when a gateway connection closes", async () => {
+  it("ends delivery subscriptions before connection-owned Talk cleanup", async () => {
     const { passed, socket } = await connectTestWs();
     const handlerParams = passed as {
       connId: string;
       setClient: (client: unknown) => boolean;
+      getClient: () => GatewayWsClient | null;
     };
     expect(
       handlerParams.setClient({
@@ -351,11 +352,20 @@ describe("attachGatewayWsConnectionHandler", () => {
         connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
         connId: handlerParams.connId,
         usesSharedGatewayAuth: false,
+        connectionSignal: AbortSignal.abort(),
       }),
     ).toBe(true);
 
+    const signal = handlerParams.getClient()?.connectionSignal;
+    expect(signal?.aborted).toBe(false);
+    const closeOrder: string[] = [];
+    signal?.addEventListener("abort", () => closeOrder.push("subscription-ended"));
+    cleanupTalkConnectionMock.mockImplementation(() => closeOrder.push("talk-cleanup"));
+
     socket.emit("close", 1000, Buffer.from("done"));
 
+    expect(signal?.aborted).toBe(true);
+    expect(closeOrder).toEqual(["subscription-ended", "talk-cleanup"]);
     expect(cleanupTalkConnectionMock).toHaveBeenCalledOnce();
     expect(cleanupTalkConnectionMock).toHaveBeenCalledWith(
       handlerParams.connId,
@@ -480,6 +490,7 @@ describe("attachGatewayWsConnectionHandler", () => {
       const handlerParams = passed as {
         send: (frame: unknown) => { kind: string };
         setClient: (client: unknown) => boolean;
+        getClient: () => GatewayWsClient | null;
       };
       handlerParams.setClient({
         socket,
@@ -487,6 +498,8 @@ describe("attachGatewayWsConnectionHandler", () => {
         connId: "closing-client",
         usesSharedGatewayAuth: false,
       });
+      const signal = handlerParams.getClient()?.connectionSignal;
+      expect(signal?.aborted).toBe(false);
       socket.send.mockClear();
       socket.readyState = readyState;
 
@@ -495,6 +508,7 @@ describe("attachGatewayWsConnectionHandler", () => {
       });
       expect(socket.send).not.toHaveBeenCalled();
       expect(clients.size).toBe(0);
+      expect(signal?.aborted).toBe(true);
     },
   );
 
@@ -601,6 +615,9 @@ describe("attachGatewayWsConnectionHandler", () => {
       usesSharedGatewayAuth: false,
     };
     expect(handler.setClient(nodeClient)).toBe(true);
+    expect(nodeClient.connectionSignal?.aborted).toBe(false);
+    const subscriptionEnded = vi.fn();
+    nodeClient.connectionSignal?.addEventListener("abort", subscriptionEnded);
     const healthySocket = createGatewayWsTestSocket();
     clients.add({
       socket: healthySocket as unknown as GatewayWsClient["socket"],
@@ -620,6 +637,8 @@ describe("attachGatewayWsConnectionHandler", () => {
       kind: "unavailable",
     });
     expect(clients.has(nodeClient)).toBe(true);
+    expect(nodeClient.connectionSignal?.aborted).toBe(true);
+    expect(subscriptionEnded).toHaveBeenCalledOnce();
     const broadcaster = createGatewayBroadcaster({ clients });
     broadcaster.broadcast("tick", { source: "before-node-close" });
 
@@ -642,6 +661,7 @@ describe("attachGatewayWsConnectionHandler", () => {
     await dispatch;
     await vi.waitFor(() => expect(unregister).toHaveBeenCalledOnce());
     expect(clients.has(nodeClient)).toBe(false);
+    expect(subscriptionEnded).toHaveBeenCalledOnce();
   });
 
   it("distinguishes serialization failure from unavailable transports", async () => {

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -159,6 +159,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     let client: GatewayWsClient | null = null,
       closed = false;
     const [openedAt, connId] = [Date.now(), randomUUID()];
+    const connectionController = new AbortController();
     const ingressSocket = socket as GatewayIngressWebSocket;
     const connectionKind = ingressSocket[GATEWAY_WS_CONNECTION_KIND_PROPERTY] ?? "gateway";
     const publicWorkerIngress =
@@ -276,6 +277,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         return;
       }
       closed = true;
+      connectionController.abort();
       clearTimeout(handshakeTimer);
       stopKeepalive?.();
       cleanupWorkerConnection?.();
@@ -555,6 +557,8 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       close();
     };
     socket.once("close", (code, reason) => {
+      // Delivery subscriptions end before asynchronous node drain or history cleanup.
+      connectionController.abort();
       clearTimeout(shutdownTimer);
       // ws removes its client synchronously; the Gateway retains this connection
       // until asynchronous node history and other close cleanup have settled.
@@ -596,6 +600,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         }
       }
       releasePreauthBudget();
+      next.connectionSignal = connectionController.signal;
       client = next;
       clients.add(next);
       if (

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -32,6 +32,8 @@ export type GatewayWsClient = PluginNodeCapabilityClient & {
   socket: WebSocket;
   connect: ConnectParams;
   connId: string;
+  /** Host-owned transport retirement notification; never accepted from wire params. */
+  connectionSignal?: AbortSignal;
   connectionKind?: GatewayWsConnectionKind;
   worker?: WorkerConnectionIdentity;
   isDeviceTokenAuth?: boolean;

--- a/src/plugin-sdk/session-catalog.ts
+++ b/src/plugin-sdk/session-catalog.ts
@@ -64,6 +64,21 @@ export {
   type SessionCatalogNodeHostBindingsOptions,
 } from "../plugins/session-catalog-family.js";
 
+/** Keep a host's publication owned until its callback finishes, even after a fail-soft list. */
+export function publishSessionCatalogHost<T>(
+  params: {
+    onHost?: (host: T) => void;
+    waitUntil?: (completion: Promise<void>) => void;
+  },
+  pendingHost: Promise<T>,
+): void {
+  const { onHost, waitUntil } = params;
+  const published = pendingHost.then((host) => onHost?.(host));
+  // Observe rejection before registration: a closed owner may reject this handoff synchronously.
+  void published.catch(() => undefined);
+  waitUntil?.(published);
+}
+
 const DEFAULT_PAGE_LIMIT = 20;
 const MAX_PAGE_LIMIT = 100;
 const MAX_CURSOR_LENGTH = 128;

--- a/src/plugins/registry-lifecycle.test.ts
+++ b/src/plugins/registry-lifecycle.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { loadPluginRegistryHandle } from "./loader.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import {
+  activatePluginRecordLifecycleEpoch,
+  capturePluginLifecycleAuthority,
+  capturePluginRegistryLifecycleEpoch,
+  capturePluginRegistryLifecycleSignal,
+  isPluginRecordLifecycleEpochActive,
+  isPluginRegistryActivated,
+  isPluginRegistryLifecycleEpochActive,
+  markPluginRegistryActive,
+  markPluginRegistryRetired,
+  revokePluginRecordLifecycleEpoch,
+} from "./registry-lifecycle.js";
+import type { PluginRegistry } from "./registry-types.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  commitStagedPluginRegistry,
+  resetPluginRuntimeStateForTest,
+  rollbackStagedPluginRegistry,
+  setActivePluginRegistry,
+  stageActivePluginRegistry,
+} from "./runtime.js";
+import {
+  getPluginRuntimeGatewayRequestScope,
+  withPluginRuntimeRegistryScope,
+} from "./runtime/gateway-request-scope.js";
+import { createPluginRecord } from "./status.test-helpers.js";
+
+function captureActivation(registry: PluginRegistry) {
+  const epoch = capturePluginRegistryLifecycleEpoch(registry)!;
+  expect(epoch).toBeDefined();
+  const signal = capturePluginRegistryLifecycleSignal(registry, epoch)!;
+  expect(signal).toBeDefined();
+  return { epoch, signal };
+}
+
+afterEach(() => resetPluginRuntimeStateForTest());
+
+describe("plugin registry retirement notifications", () => {
+  it.each(["retire", "activate"] as const)(
+    "notifies a scoped loader handle on %s without inventing an activation epoch",
+    (action) => {
+      const registry = loadPluginRegistryHandle({ onlyPluginIds: [] });
+      const record = createPluginRecord({ id: "scoped-owner" });
+      registry.plugins.push(record);
+      expect(capturePluginRegistryLifecycleSignal(registry, undefined)).toBeUndefined();
+      const { signal, authority } = withPluginRuntimeRegistryScope(registry, () => {
+        const scopedRuntime = getPluginRuntimeGatewayRequestScope()?.pluginRegistry === registry;
+        const epoch = capturePluginRegistryLifecycleEpoch(registry);
+        const options = { scopedRuntime };
+        return {
+          signal: capturePluginRegistryLifecycleSignal(registry, epoch, options)!,
+          authority: capturePluginLifecycleAuthority(registry, record, options)!,
+        };
+      });
+      expect(signal?.aborted).toBe(false);
+      expect(authority()).toBe(true);
+      expect(capturePluginRegistryLifecycleEpoch(registry)).toBeUndefined();
+      expect(isPluginRegistryActivated(registry)).toBe(false);
+      expect(activatePluginRecordLifecycleEpoch(registry, record)).toBeUndefined();
+      expect(capturePluginRegistryLifecycleSignal(registry, undefined)).toBeUndefined();
+      expect(
+        capturePluginRegistryLifecycleSignal(registry, undefined, { scopedRuntime: true }),
+      ).toBe(signal);
+      const observations: boolean[] = [];
+      signal.addEventListener("abort", () => observations.push(authority()));
+
+      if (action === "retire") {
+        markPluginRegistryRetired(registry);
+      } else {
+        markPluginRegistryActive(registry);
+      }
+
+      expect(observations).toEqual([false]);
+      expect(signal.aborted).toBe(true);
+      expect(
+        capturePluginRegistryLifecycleSignal(registry, undefined, { scopedRuntime: true }),
+      ).toBeUndefined();
+      markPluginRegistryActive(registry);
+      expect(captureActivation(registry).signal.aborted).toBe(false);
+      expect(signal.aborted).toBe(true);
+      expect(authority()).toBe(false);
+      expect(observations).toHaveLength(1);
+    },
+  );
+
+  it("keeps epoch identity opaque and rejects missing or mismatched activation signals", () => {
+    const registry = createEmptyPluginRegistry();
+    const other = createEmptyPluginRegistry();
+    expect(capturePluginRegistryLifecycleSignal(registry, {})).toBeUndefined();
+    expect(capturePluginLifecycleAuthority(registry)).toBeUndefined();
+    const scopedAuthority = capturePluginLifecycleAuthority(registry, undefined, {
+      scopedRuntime: true,
+    });
+    expect(scopedAuthority?.()).toBe(true);
+
+    markPluginRegistryActive(registry);
+    const { epoch, signal } = captureActivation(registry);
+    expect(Object.isFrozen(epoch)).toBe(true);
+    for (const property of ["abort", "controller", "signal"]) {
+      expect(epoch).not.toHaveProperty(property);
+    }
+    expect(capturePluginRegistryLifecycleEpoch(registry)).toBe(epoch);
+    expect(capturePluginRegistryLifecycleSignal(registry, epoch)).toBe(signal);
+    expect(capturePluginRegistryLifecycleSignal(other, epoch)).toBeUndefined();
+    expect(capturePluginRegistryLifecycleSignal(registry, { ...epoch })).toBeUndefined();
+    expect(scopedAuthority?.()).toBe(false);
+  });
+
+  it.each(["retire", "reactivate"] as const)(
+    "revokes registry and record authority before %s listeners run",
+    (action) => {
+      const registry = createEmptyPluginRegistry();
+      const record = createPluginRecord({ id: "lifecycle-owner" });
+      registry.plugins.push(record);
+      markPluginRegistryActive(registry);
+      const { epoch, signal } = captureActivation(registry);
+      const recordEpoch = activatePluginRecordLifecycleEpoch(registry, record)!;
+      const authority = capturePluginLifecycleAuthority(registry, record)!;
+      expect(isPluginRecordLifecycleEpochActive(registry, record, recordEpoch)).toBe(true);
+      expect(authority()).toBe(true);
+      const observations: unknown[] = [];
+      signal.addEventListener("abort", () => {
+        const nextEpoch = capturePluginRegistryLifecycleEpoch(registry);
+        observations.push({
+          registryActive: isPluginRegistryLifecycleEpochActive(registry, epoch),
+          recordActive: isPluginRecordLifecycleEpochActive(registry, record, recordEpoch),
+          authorityActive: authority(),
+          oldSignal: capturePluginRegistryLifecycleSignal(registry, epoch),
+          nextActive: nextEpoch ? isPluginRegistryLifecycleEpochActive(registry, nextEpoch) : false,
+          nextSignalAborted: nextEpoch
+            ? capturePluginRegistryLifecycleSignal(registry, nextEpoch)?.aborted
+            : undefined,
+        });
+      });
+
+      if (action === "retire") {
+        markPluginRegistryRetired(registry);
+      } else {
+        markPluginRegistryActive(registry);
+      }
+
+      expect(signal.aborted).toBe(true);
+      expect(observations).toEqual([
+        {
+          registryActive: false,
+          recordActive: false,
+          authorityActive: false,
+          oldSignal: undefined,
+          nextActive: action === "reactivate",
+          nextSignalAborted: action === "reactivate" ? false : undefined,
+        },
+      ]);
+      markPluginRegistryActive(registry);
+      const next = captureActivation(registry);
+      expect(next.epoch).not.toBe(epoch);
+      expect(next.signal.aborted).toBe(false);
+      expect(signal.aborted).toBe(true);
+      expect(authority()).toBe(false);
+      expect(observations).toHaveLength(1);
+    },
+  );
+
+  it("does not retire a registry or sibling record when one record is revoked", () => {
+    const registry = createEmptyPluginRegistry();
+    const first = createPluginRecord({ id: "first-owner" });
+    const sibling = createPluginRecord({ id: "sibling-owner" });
+    registry.plugins.push(first, sibling);
+    markPluginRegistryActive(registry);
+    const { epoch, signal } = captureActivation(registry);
+    const firstEpoch = activatePluginRecordLifecycleEpoch(registry, first)!;
+    const siblingEpoch = activatePluginRecordLifecycleEpoch(registry, sibling)!;
+
+    revokePluginRecordLifecycleEpoch(registry, first);
+
+    expect(isPluginRecordLifecycleEpochActive(registry, first, firstEpoch)).toBe(false);
+    expect(isPluginRecordLifecycleEpochActive(registry, sibling, siblingEpoch)).toBe(true);
+    expect(isPluginRegistryLifecycleEpochActive(registry, epoch)).toBe(true);
+    expect(signal.aborted).toBe(false);
+  });
+
+  it.each(["commit", "rollback"] as const)(
+    "retires only the abandoned activation after staged %s",
+    (action) => {
+      const original = createEmptyPluginRegistry();
+      const candidate = createEmptyPluginRegistry();
+      setActivePluginRegistry(original);
+      const first = captureActivation(original);
+      const snapshot = captureActivePluginRegistrySnapshot();
+
+      stageActivePluginRegistry(candidate, "candidate", "default");
+      const second = captureActivation(candidate);
+      expect(first.signal.aborted).toBe(false);
+
+      if (action === "commit") {
+        commitStagedPluginRegistry(original, candidate);
+      } else {
+        rollbackStagedPluginRegistry(snapshot);
+      }
+
+      expect(first.signal.aborted).toBe(action === "commit");
+      expect(second.signal.aborted).toBe(action === "rollback");
+      const retained = action === "commit" ? second : first;
+      const current = captureActivation(action === "commit" ? candidate : original);
+      expect(current.epoch).toBe(retained.epoch);
+      expect(current.signal).toBe(retained.signal);
+    },
+  );
+});

--- a/src/plugins/registry-lifecycle.ts
+++ b/src/plugins/registry-lifecycle.ts
@@ -5,6 +5,13 @@ import type { PluginRecord, PluginRegistry } from "./registry-types.js";
 
 const MAX_PLUGIN_REGISTRY_CACHE_ENTRIES = 128;
 
+export type PluginRegistryLifecycleEpoch = object;
+type PluginRecordLifecycleEpoch = object;
+type PluginRegistryLifecycleState = {
+  epoch: PluginRegistryLifecycleEpoch | undefined;
+  controller: AbortController;
+};
+
 export const pluginLoaderCacheState = new PluginLoaderCacheState<PluginRegistry>(
   MAX_PLUGIN_REGISTRY_CACHE_ENTRIES,
 );
@@ -15,33 +22,35 @@ const { retiredRegistries, activatedRegistries, registryEpochs, recordEpochs, re
   resolveGlobalSingleton(Symbol.for("openclaw.pluginRegistryLifecycle"), () => ({
     retiredRegistries: new WeakSet<PluginRegistry>(),
     activatedRegistries: new WeakSet<PluginRegistry>(),
-    registryEpochs: new WeakMap<PluginRegistry, object>(),
+    registryEpochs: new WeakMap<PluginRegistry, PluginRegistryLifecycleState>(),
     recordEpochs: new WeakMap<PluginRegistry, WeakMap<PluginRecord, object>>(),
     revokedRecordEpoch: Object.freeze({}),
   }));
 
-export type PluginRegistryLifecycleEpoch = object;
-type PluginRecordLifecycleEpoch = object;
-
 /** Marks a registry retired so late runtime calls can reject stale plugin state. */
 export function markPluginRegistryRetired(registry: PluginRegistry | null | undefined): void {
   if (registry) {
+    const previous = registryEpochs.get(registry);
     retiredRegistries.add(registry);
     registryEpochs.delete(registry);
     // Retired registrations cannot be reused and retain their Gateway/cache generation.
     // Release every cache key now, including keys that will never be looked up again.
     pluginLoaderCacheState.deleteValue(registry);
+    // Reentrant abort listeners must observe revoked authority and released cache aliases.
+    previous?.controller.abort();
   }
 }
 
 /** Marks a registry active and clears any previous retired state. */
 export function markPluginRegistryActive(registry: PluginRegistry | null | undefined): void {
   if (registry) {
+    const previous = registryEpochs.get(registry);
     activatedRegistries.add(registry);
     retiredRegistries.delete(registry);
     // Every activation owns a fresh opaque generation. A retired closure cannot
     // regain authority merely because the same registry object becomes active.
-    registryEpochs.set(registry, Object.freeze({}));
+    registryEpochs.set(registry, { epoch: Object.freeze({}), controller: new AbortController() });
+    previous?.controller.abort();
   }
 }
 
@@ -49,7 +58,30 @@ export function markPluginRegistryActive(registry: PluginRegistry | null | undef
 export function capturePluginRegistryLifecycleEpoch(
   registry: PluginRegistry,
 ): PluginRegistryLifecycleEpoch | undefined {
-  return retiredRegistries.has(registry) ? undefined : registryEpochs.get(registry);
+  return retiredRegistries.has(registry) ? undefined : registryEpochs.get(registry)?.epoch;
+}
+
+/** Observe an exact active epoch or explicitly scoped handle without granting activation. */
+export function capturePluginRegistryLifecycleSignal(
+  registry: PluginRegistry,
+  epoch: PluginRegistryLifecycleEpoch | undefined,
+  options?: { scopedRuntime?: boolean },
+): AbortSignal | undefined {
+  let current = registryEpochs.get(registry);
+  if (
+    retiredRegistries.has(registry) ||
+    (epoch === undefined && options?.scopedRuntime !== true) ||
+    current?.epoch !== epoch
+  ) {
+    return undefined;
+  }
+  if (!current) {
+    // Scoped loader handles are live without root activation. Their existing undefined
+    // epoch remains unchanged until retirement or the first real activation.
+    current = { epoch: undefined, controller: new AbortController() };
+    registryEpochs.set(registry, current);
+  }
+  return current.controller.signal;
 }
 
 /** True only while the exact captured registry activation remains current. */
@@ -57,7 +89,7 @@ export function isPluginRegistryLifecycleEpochActive(
   registry: PluginRegistry,
   epoch: PluginRegistryLifecycleEpoch,
 ): boolean {
-  return !retiredRegistries.has(registry) && registryEpochs.get(registry) === epoch;
+  return !retiredRegistries.has(registry) && registryEpochs.get(registry)?.epoch === epoch;
 }
 
 /** Mint the exact record generation used by one registered native channel runtime. */
@@ -65,7 +97,7 @@ export function activatePluginRecordLifecycleEpoch(
   registry: PluginRegistry,
   record: PluginRecord,
 ): PluginRecordLifecycleEpoch | undefined {
-  const registryEpoch = registryEpochs.get(registry);
+  const registryEpoch = registryEpochs.get(registry)?.epoch;
   if (!registryEpoch || retiredRegistries.has(registry)) {
     return undefined;
   }
@@ -82,7 +114,7 @@ export function isPluginRecordLifecycleEpochActive(
   record: PluginRecord,
   epoch: PluginRecordLifecycleEpoch,
 ): boolean {
-  const registryEpoch = registryEpochs.get(registry);
+  const registryEpoch = registryEpochs.get(registry)?.epoch;
   const epochRegistry = Object.getOwnPropertyDescriptor(epoch, "registryEpoch");
   return (
     registryEpoch !== undefined &&
@@ -120,7 +152,7 @@ export function capturePluginLifecycleAuthority(
   record?: PluginRecord,
   options?: { scopedRuntime?: boolean },
 ): (() => boolean) | undefined {
-  const epoch = registryEpochs.get(registry);
+  const epoch = registryEpochs.get(registry)?.epoch;
   const recordEpoch = record && recordEpochs.get(registry)?.get(record);
   if (
     (!epoch && !options?.scopedRuntime) ||
@@ -130,7 +162,7 @@ export function capturePluginLifecycleAuthority(
     return undefined;
   }
   return () =>
-    registryEpochs.get(registry) === epoch &&
+    registryEpochs.get(registry)?.epoch === epoch &&
     !retiredRegistries.has(registry) &&
     (!record ||
       (registry.plugins.includes(record) &&

--- a/src/plugins/session-catalog.ts
+++ b/src/plugins/session-catalog.ts
@@ -28,6 +28,10 @@ export type SessionCatalogListProviderParams = {
   listNodes?: () => ReturnType<PluginRuntime["nodes"]["list"]>;
   /** Publishes completed hosts without waiting for slower machines in the same list. */
   onHost?: (host: SessionCatalogHost) => void;
+  /** Register bounded host publication work before `list` settles; includes the onHost callback. */
+  waitUntil?: (completion: Promise<void>) => void;
+  /** Catalog owner retirement, independent of the requesting connection's lifetime. */
+  signal?: AbortSignal;
 };
 export type SessionCatalogReadProviderParams = Omit<SessionsCatalogReadParams, "catalogId"> & {
   /** Gateway always supplies this; optional only for pre-existing external provider types. */


### PR DESCRIPTION
Closes #138668

## What Problem This Solves

Users browsing native sessions can miss slow-host results when a host finishes after the catalog’s partial response. The aggregate list previously discarded its subscribers at return, even though the provider still owned a publication that could finish later.

## Why This Change Was Made

One catalog lifetime now owns delivery and registered completion separately. Codex and Claude register their full publication promise with the admitted work; disconnect and registry retirement revoke delivery immediately while that work remains owned until it settles. Replacement connections inherit no subscription. Once the aggregate and its last subscriber finish, the owner releases delivery captures without losing completion accounting.

The optional SDK hooks preserve existing providers and document completion registration. The owner captures the original Gateway work tracker at provider admission, so an external callback cannot attach completion to an unrelated async context. Its finalizer joins before the Gateway releases dependencies. Codex also checks retirement before starting another page, classification or adopted read; already-issued requests remain owned until settlement.

## User Impact

Active subscribers receive slow-host updates after the initial response, with current session privacy filtering. Disconnects and plugin retirement suppress stale delivery. Shutdown joins work already started instead of releasing its dependencies early. This repairs progressive results and ownership; it does not claim whole-request latency or CPU improvement.

Result-cache timing, native deadlines, configuration, persistence and Gateway wire payloads are unchanged. A callback TTL or unconditional subscriber retention would leave lifecycle and privacy ownership unresolved.

## Evidence

Fresh Linux proof against main `66fa0bd2be4f811a6c6dbee8bd5dd102dae8e544` plus the complete candidate passed 277 tests: 146 Gateway, 113 native provider, 8 registry and 10 SDK cases. Two regressions failed on the original lifetime owner for the intended assertions, then passed on the repair. The full canonical changed-code gate passed in 1007.81s and `pnpm build sourcePerformance` passed in 31.94s. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33938767386).

The real built synthetic Gateway passed four wire scenarios: early/late follower delivery, disconnected-connection isolation, current privacy projection after session replacement, and shutdown with a held completion. The held completion remained accounted for after the partial response, rejected retired delivery, released its captures and settled before socket closure and Gateway exit. Gateway cleanup completed in 323ms with exit 0 and no escalation. Source, installed dependencies, tool binaries and proof outputs were sealed before/after; all 33 local candidate postimages matched the retained proof. The owned Testbox is stopped.

Canonical commands included `node scripts/run-vitest.mjs` over the four named owner suites, `node scripts/check-changed.mjs --base 66fa0bd2be4f811a6c6dbee8bd5dd102dae8e544 -- <33 changed paths>`, and `pnpm build sourcePerformance`. The real Gateway fixture used an isolated state directory and synthetic provider over authenticated WebSockets. This proves the Gateway lifecycle and delivery boundary; it is not an authenticated Codex/Claude service run, a browser recording or a Team performance measurement.

After rebasing onto `c748cd5714b8160f0ce0a895071f039877082f08`, all task-owned runtime production postimages stayed byte-identical. The only two changed postimages combine independently added SDK exports and preserve main's `GatewayClientRegistry` test fixture. Fresh `pnpm install --frozen-lockfile` and `pnpm plugin-sdk:surface:check` passed; the latter counts exactly 4435 public exports and 2620 callable exports. All 55 focused integration tests passed on the published head `3d1a09e6a5d2a2e7252d3e7a497f5ce26eb18409` (WebSocket lifecycle, returned catalog shutdown, completion owner, and SDK report). A fresh independent P2 review completed all four passes with no actionable findings. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33940680780) completed successfully on `3d1a09e6a5d2a2e7252d3e7a497f5ce26eb18409`.

Final staged-diff structured P2 review completed four partitions with no actionable findings. An earlier review caught the pre-integration staged owner, and the missing tracked completion was corrected before the clean final review. The earlier exact-head CI visibility failure exposed four test fixtures that supplied an active registry without activating its lifecycle; those fixtures now model the actual runtime setup and retain their privacy/streaming assertions.

Earlier proof-infrastructure failures and all raw outcomes are retained. No timeout or assertion was relaxed to make a run pass.

Production LOC: +379/-59 (net +320), providing the missing completion/delivery owner and private retirement notification while removing disposal at list return. Tests/support: +1737/-321 (net +1416, including moved fixtures/cases); documentation +21; SDK accounting net +2. No new timeout, configuration, schema, persistence or native protocol surface. The separately owned stale-page refresh path is outside this repair.

### ClawSweeper merge-risk disposition

Retain the documented optional bounded-completion contract. Registered work stays accounted for until it actually settles; existing native deadlines and shutdown policy remain unchanged. A broken provider that never settles can still prolong drain. The held-then-released proof establishes ordering and cleanup, not eventual settlement for such a provider. Releasing active work early or adding a detached timeout would hide the lifecycle defect.
