### PR TITLE
fix: preserve global board ownership from pinning to notifications

### DIFF
--- a/src/canvas/widget-tool.test.ts
+++ b/src/canvas/widget-tool.test.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { InProcessGatewayCaller } from "../agents/tools/in-process-gateway.js";
 import { createTestBoardStore } from "../boards/board-store.test-support.js";
+import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
+import type { OpenClawConfig } from "../config/types.js";
 import { createBoardHandlers } from "../gateway/server-methods/board.js";
 import type { GatewayRequestContext, RespondFn } from "../gateway/server-methods/types.js";
 import { createPluginBoardWidgetContentKindRegistrar } from "../plugins/board-widget-content-kinds.js";
@@ -67,11 +69,12 @@ function registerDiagramContentKind(): void {
 
 function createLiveBoardTestContext(
   broadcast: ReturnType<typeof vi.fn> = vi.fn(),
+  cfg: OpenClawConfig = { agents: { entries: { main: {} } } },
 ): GatewayRequestContext {
   const context = {
     broadcast,
     getSessionEventSubscriberConnIds: () => new Set<string>(),
-    getRuntimeConfig: () => ({ agents: { list: [{ id: "main" }] } }),
+    getRuntimeConfig: () => cfg,
   } as unknown as GatewayRequestContext;
   context.resolveGatewayContext = () => context;
   return context;
@@ -86,6 +89,7 @@ async function executeWidget(params: {
   sessionId?: string;
   title?: string;
   widgetCode: string;
+  agentId?: string;
   agentSessionKey?: string;
   callGateway?: InProcessGatewayCaller;
   pin?: boolean;
@@ -104,7 +108,7 @@ async function executeWidget(params: {
   const tool = createShowWidgetTool({
     stateDir: params.stateDir,
     sessionId: params.sessionId ?? "widget-session",
-    agentId: "main",
+    agentId: params.agentId ?? "main",
     agentSessionKey: params.agentSessionKey,
     callGateway: params.callGateway,
     presenters: params.presenters,
@@ -670,101 +674,112 @@ describe("show_widget", () => {
     expect(callGateway).not.toHaveBeenCalled();
   });
 
-  it("lets the board domain create and refresh explicitly named pinned HTML", async () => {
-    const stateDir = await createStateDir();
-    const store = createTestBoardStore({ stateDir });
-    const broadcast = vi.fn();
-    const handlers = createBoardHandlers(store);
-    const title = "Release Status ".repeat(8).trim();
-    const callGateway: InProcessGatewayCaller = async <T>(
-      method: string,
-      params: Record<string, unknown>,
-    ): Promise<T> => {
-      let result: unknown;
-      let failure: Error | undefined;
-      const respond: RespondFn = (ok, payload, error) => {
-        if (ok) {
-          result = payload;
-        } else {
-          failure = new Error(error?.message ?? "board request failed");
-        }
+  it.each([
+    ["qualified Main", "agent:main:pinned", "main", false],
+    ["explicit Research global", "global", "research", false],
+    ["Research global with retained Main", "global", "research", true],
+  ] as const)(
+    "creates and refreshes pinned HTML in %s",
+    async (_label, sessionKey, agentId, retainedMain) => {
+      const stateDir = await createStateDir();
+      const store = createTestBoardStore({ stateDir });
+      const broadcast = vi.fn();
+      const target = { sessionKey, agentId };
+      const sibling = { sessionKey: "global", agentId: agentId === "main" ? "research" : "main" };
+      const siblingBefore = store.getSnapshot(sibling);
+      const boardBroadcastScope = { sessionKeys: [sessionKey], agentId };
+      const eventSessionKey = sessionKey === "global" ? `agent:${agentId}:global` : sessionKey;
+      const cfg: OpenClawConfig = {
+        agents: { ownership: "explicit", entries: { main: {}, research: {} } },
+        session: { scope: "global" },
       };
-      await handlers[method]!({
-        req: { type: "req", id: "show-widget-pin", method, params },
-        params,
-        client: null,
-        isWebchatConnect: () => false,
-        respond,
-        context: createLiveBoardTestContext(broadcast),
-      });
-      if (failure) {
-        throw failure;
+      if (retainedMain) {
+        retainLegacyDefaultAgentId(cfg, "main");
       }
-      return result as T;
-    };
+      const handlers = createBoardHandlers(store);
+      const title = "Release Status ".repeat(8).trim();
+      const callGateway: InProcessGatewayCaller = async <T>(
+        method: string,
+        params: Record<string, unknown>,
+      ): Promise<T> => {
+        let result: unknown;
+        let failure: Error | undefined;
+        const respond: RespondFn = (ok, payload, error) => {
+          if (ok) {
+            result = payload;
+          } else {
+            failure = new Error(error?.message ?? "board request failed");
+          }
+        };
+        await handlers[method]!({
+          req: { type: "req", id: "show-widget-pin", method, params },
+          params,
+          client: null,
+          isWebchatConnect: () => false,
+          respond,
+          context: createLiveBoardTestContext(broadcast, cfg),
+        });
+        if (failure) {
+          throw failure;
+        }
+        return result as T;
+      };
 
-    const pinWidget = (widgetCode: string, withPlacement = false) =>
-      executeWidget({
-        stateDir,
-        agentSessionKey: "agent:main:pinned",
-        title,
-        widgetCode,
-        pin: true,
-        name: "release-status",
-        ...(withPlacement
-          ? { tab: "main", size: "lg" as const, presentation: { frame: "frameless" as const } }
-          : {}),
-        callGateway,
+      const pinWidget = (widgetCode: string, withPlacement = false) =>
+        executeWidget({
+          stateDir,
+          agentId,
+          agentSessionKey: sessionKey,
+          title,
+          widgetCode,
+          pin: true,
+          name: "release-status",
+          ...(withPlacement
+            ? { tab: "main", size: "lg" as const, presentation: { frame: "frameless" as const } }
+            : {}),
+          callGateway,
+        });
+      const result = await pinWidget("<p>ready</p>", true);
+      const pinnedTitle = Array.from(title).slice(0, 80).join("");
+
+      expect(store.readWidgetHtml(target, "release-status")).toMatchObject({
+        html: buildWidgetDocument(pinnedTitle, "<p>ready</p>"),
+        revision: 1,
       });
-    const result = await pinWidget("<p>ready</p>", true);
-    const pinnedTitle = Array.from(title).slice(0, 80).join("");
+      expect(store.getSnapshot(target).widgets[0]?.title).toBe(pinnedTitle);
+      expect(store.getSnapshot(target).widgets[0]?.presentation).toBe("frameless");
+      expect(result.resultText).toContain("pinned to dashboard tab main as release-status (lg)");
+      expect(result.boardWidgetName).toBe("release-status");
+      expect(broadcast).toHaveBeenCalledWith(
+        "board.changed",
+        { sessionKey: eventSessionKey, revision: 1, widget: "release-status" },
+        boardBroadcastScope,
+      );
 
-    expect(
-      store.readWidgetHtml({ sessionKey: "agent:main:pinned" }, "release-status"),
-    ).toMatchObject({
-      html: buildWidgetDocument(pinnedTitle, "<p>ready</p>"),
-      revision: 1,
-    });
-    expect(store.getSnapshot({ sessionKey: "agent:main:pinned" }).widgets[0]?.title).toBe(
-      pinnedTitle,
-    );
-    expect(store.getSnapshot({ sessionKey: "agent:main:pinned" }).widgets[0]?.presentation).toBe(
-      "frameless",
-    );
-    expect(result.resultText).toContain("pinned to dashboard tab main as release-status (lg)");
-    expect(result.boardWidgetName).toBe("release-status");
-    expect(broadcast).toHaveBeenCalledWith("board.changed", {
-      sessionKey: "agent:main:pinned",
-      revision: 1,
-      widget: "release-status",
-    });
+      await expect(
+        callGateway("board.widget.put", {
+          ...target,
+          name: "release-status",
+          content: { kind: "plugin", pluginKind: "workboard:card" },
+        }),
+      ).rejects.toThrow(/same content kind.*remove/i);
+      expect(store.readWidgetHtml(target, "release-status")?.revision).toBe(1);
 
-    await expect(
-      callGateway("board.widget.put", {
-        sessionKey: "agent:main:pinned",
-        name: "release-status",
-        content: { kind: "plugin", pluginKind: "workboard:card" },
-      }),
-    ).rejects.toThrow(/same content kind.*remove/i);
-    expect(
-      store.readWidgetHtml({ sessionKey: "agent:main:pinned" }, "release-status")?.revision,
-    ).toBe(1);
+      const refreshed = await pinWidget("<p>refreshed</p>");
 
-    const refreshed = await pinWidget("<p>refreshed</p>");
-
-    expect(
-      store.readWidgetHtml({ sessionKey: "agent:main:pinned" }, "release-status"),
-    ).toMatchObject({
-      html: buildWidgetDocument(pinnedTitle, "<p>refreshed</p>"),
-      revision: 2,
-    });
-    expect(refreshed.boardWidgetName).toBe("release-status");
-    expect(broadcast).toHaveBeenCalledWith("board.changed", {
-      sessionKey: "agent:main:pinned",
-      revision: 2,
-      widget: "release-status",
-    });
-  });
+      expect(store.readWidgetHtml(target, "release-status")).toMatchObject({
+        html: buildWidgetDocument(pinnedTitle, "<p>refreshed</p>"),
+        revision: 2,
+      });
+      expect(refreshed.boardWidgetName).toBe("release-status");
+      expect(broadcast).toHaveBeenCalledWith(
+        "board.changed",
+        { sessionKey: eventSessionKey, revision: 2, widget: "release-status" },
+        boardBroadcastScope,
+      );
+      expect(store.getSnapshot(sibling)).toEqual(siblingBefore);
+    },
+  );
 
   it("pins a granted-CSP document and declaration without networking in the inline preview", async () => {
     const stateDir = await createStateDir();

--- a/src/canvas/widget-tool.ts
+++ b/src/canvas/widget-tool.ts
@@ -401,7 +401,6 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
       let pinnedWidgetName: string | undefined;
       let capabilityState: BoardWidgetPutResult["widgets"][number]["grantState"] | undefined;
       if (pinSessionKey) {
-        const sessionKey = pinSessionKey;
         const explicitName = readToolStringParam(params, "name");
         const name = explicitName ?? slugWidgetName(title);
         const tab = readToolStringParam(params, "tab");
@@ -417,7 +416,8 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
           );
         }
         const snapshot = await gatewayCall<BoardWidgetPutResult>("board.widget.put", {
-          sessionKey,
+          sessionKey: pinSessionKey,
+          agentId: options.agentId,
           name,
           ...(pinnedTitle ? { title: pinnedTitle } : {}),
           // The Gateway owns the board document shell so agent-authored bytes

--- a/src/gateway/server-broadcast.board.test.ts
+++ b/src/gateway/server-broadcast.board.test.ts
@@ -4,17 +4,22 @@ import {
   GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_IDS,
 } from "../../packages/gateway-protocol/src/client-info.js";
+import { setRuntimeConfigSnapshot } from "../config/io.js";
 import {
   deleteSessionEntryLifecycle,
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { boardStore } from "./board-store.js";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
 import {
   createSessionEventSubscriberRegistry,
   createSessionMessageSubscriberRegistry,
 } from "./server-chat-state.js";
+import { createBoardHandlers } from "./server-methods/board.js";
+import { flushPendingSessionsChangedEvents } from "./server-methods/session-change-event.js";
+import type { GatewayRequestContext, RespondFn } from "./server-methods/types.js";
 import { GatewayClientRegistry } from "./server/client-registry.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { createSessionObserverAudience } from "./session-observer-audience.js";
@@ -23,6 +28,7 @@ import {
   invalidateSessionSharingSnapshot,
   resolveSessionSharingTarget,
 } from "./session-sharing.js";
+import { roleClient, rolePolicyConfig } from "./session-sharing.test-utils.js";
 import { resolveSessionSubscriptionKeys } from "./session-subscription-keys.js";
 
 type RecordingSocket = {
@@ -163,6 +169,155 @@ describe("board event scope guards", () => {
     expect(visible.socket.events).toEqual(["board.changed"]);
     expect(canReceiveSessionEvent).toHaveBeenCalledTimes(2);
   });
+});
+
+describe("board event session ownership", () => {
+  it.each(["global", "per-sender"] as const)(
+    "delivers board events only to the canonical draft owner in %s mode",
+    async (scope) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const cfg: OpenClawConfig = {
+          ...rolePolicyConfig(),
+          agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+          session: { scope },
+          tools: { exec: { mode: "ask" } },
+        };
+        setRuntimeConfigSnapshot(cfg, cfg);
+        const targets = [
+          { sessionKey: "global", agentId: "work", label: "raw-owner" },
+          { sessionKey: "agent:work:global", agentId: "work", label: "ordinary-owner" },
+          { sessionKey: "global", agentId: "main", label: "other-agent-owner" },
+        ];
+        const peers = targets.map(({ label }) => {
+          const peer = makeClient(label, "operator", ["operator.read"]);
+          Object.assign(peer.client, roleClient("view", label));
+          return peer;
+        });
+        for (const [index, target] of targets.entries()) {
+          await upsertSessionEntryCore(target, {
+            sessionId: target.label,
+            label: target.label,
+            updatedAt: 1,
+            visibility: "draft",
+            createdActor: {
+              type: "human",
+              source: "profile",
+              id: peers[index]!.client.authenticatedUserProfile!.profileId,
+            },
+          });
+        }
+        invalidateSessionSharingSnapshot();
+        const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({
+          clients: new GatewayClientRegistry(peers.map(({ client }) => client)),
+          canReceiveSessionEvent: (client, sessionKeys, agentId, event, payload) =>
+            canReceiveSessionEventForClient({ cfg, client, sessionKeys, agentId, event, payload }),
+        });
+        const handlers = createBoardHandlers(boardStore);
+        const context = {
+          broadcast,
+          broadcastToConnIds,
+          getRuntimeConfig: () => cfg,
+          getSessionEventSubscriberConnIds: () => new Set(peers.map(({ client }) => client.connId)),
+          chatAbortControllers: new Map(),
+          resolveGatewayContext: (): GatewayRequestContext => context,
+        } as unknown as GatewayRequestContext;
+        const invoke = async (method: string, params: Record<string, unknown>) => {
+          const respond = vi.fn<RespondFn>();
+          await handlers[method]!({
+            req: { type: "req", id: "event-owner", method, params },
+            params,
+            client: peers[0]!.client,
+            isWebchatConnect: () => false,
+            respond,
+            context,
+          });
+          flushPendingSessionsChangedEvents(context);
+          expect(respond.mock.calls[0]?.[0]).toBe(true);
+          return peers.map(({ socket }) => {
+            const frames = socket.send.mock.calls.map(([frame]) => JSON.parse(String(frame)));
+            socket.send.mockClear();
+            return frames.map(({ event, payload }) => ({ event, payload }));
+          });
+        };
+        const target = { sessionKey: "global", agentId: "work" };
+        const rawUpdate = await invoke("board.update", {
+          ...target,
+          ops: [{ kind: "tab_create", tabId: "notes", title: "Notes" }],
+        });
+        const rawPut = await invoke("board.widget.put", {
+          ...target,
+          name: "status",
+          content: { kind: "html", html: "<p>Working</p>" },
+          declared: { tools: ["status.refresh"] },
+        });
+        const widget = boardStore.getSnapshot(target).widgets[0]!;
+        const rawGrant = await invoke("board.widget.grant", {
+          ...target,
+          name: "status",
+          decision: "granted",
+          revision: widget.revision,
+          instanceId: widget.instanceId,
+        });
+        const emptyUpdate = await invoke("board.update", { ...target, ops: [] });
+        const ordinaryUpdate = await invoke("board.update", {
+          sessionKey: "agent:work:global",
+          ops: [{ kind: "tab_create", tabId: "ordinary", title: "Ordinary" }],
+        });
+        const otherAgentUpdate = await invoke("board.update", {
+          sessionKey: "global",
+          agentId: "main",
+          ops: [{ kind: "tab_create", tabId: "main-notes", title: "Main notes" }],
+        });
+        expect(boardStore.getSnapshot(target)).toMatchObject({
+          sessionKey: "global",
+          revision: 3,
+          widgets: [{ name: "status", grantState: "granted" }],
+        });
+        const changed = (agentId: string, revision: number, widgetName?: string) => ({
+          event: "board.changed",
+          payload: {
+            sessionKey: `agent:${agentId}:global`,
+            revision,
+            ...(widgetName ? { widget: widgetName } : {}),
+          },
+        });
+        const sessionChanged = (sessionKey: string, agentId: string, label: string) => ({
+          event: "sessions.changed",
+          payload: expect.objectContaining({
+            sessionKey,
+            agentId,
+            sessionId: label,
+            label,
+            reason: "board",
+          }),
+        });
+        const rawSession = sessionChanged("global", "work", "raw-owner");
+        expect({
+          rawUpdate,
+          rawPut,
+          rawGrant,
+          emptyUpdate,
+          ordinaryUpdate,
+          otherAgentUpdate,
+        }).toEqual({
+          rawUpdate: [[rawSession, changed("work", 1)], [], []],
+          rawPut: [[rawSession, changed("work", 2, "status")], [], []],
+          rawGrant: [[changed("work", 3)], [], []],
+          emptyUpdate: [[], [], []],
+          ordinaryUpdate: [
+            [],
+            [sessionChanged("agent:work:global", "work", "ordinary-owner"), changed("work", 1)],
+            [],
+          ],
+          otherAgentUpdate: [
+            [],
+            [],
+            [sessionChanged("global", "main", "other-agent-owner"), changed("main", 1)],
+          ],
+        });
+      });
+    },
+  );
 });
 
 describe("collaboration event scope guards", () => {

--- a/src/gateway/server-methods/board.test.ts
+++ b/src/gateway/server-methods/board.test.ts
@@ -12,6 +12,8 @@ import { readSessionsMutationVersion } from "./session-change-event.js";
 
 const reviewWidgetApproval = vi.hoisted(() => vi.fn());
 const readSessionEntry = vi.hoisted(() => vi.fn());
+const sessionKey = "agent:main:session";
+const boardBroadcastScope = { sessionKeys: [sessionKey], agentId: "main" };
 
 vi.mock("../../agents/exec-auto-reviewer.js", () => ({
   createModelExecAutoReviewer: vi.fn(() => reviewWidgetApproval),
@@ -261,10 +263,11 @@ describe("board gateway methods", () => {
       true,
       expect.objectContaining({ sessionKey: "agent:main:session", revision: 1 }),
     );
-    expect(broadcast).toHaveBeenCalledWith("board.changed", {
-      sessionKey: "agent:main:session",
-      revision: 1,
-    });
+    expect(broadcast).toHaveBeenCalledWith(
+      "board.changed",
+      { sessionKey, revision: 1 },
+      boardBroadcastScope,
+    );
     expect(readSessionsMutationVersion(context)).toBe(before + 1);
   });
 
@@ -288,11 +291,11 @@ describe("board gateway methods", () => {
         widgets: [expect.objectContaining({ declaredSummary: ["Tool access: weather.refresh"] })],
       }),
     );
-    expect(broadcast).toHaveBeenCalledWith("board.changed", {
-      sessionKey: "agent:main:session",
-      revision: 1,
-      widget: "weather",
-    });
+    expect(broadcast).toHaveBeenCalledWith(
+      "board.changed",
+      { sessionKey, revision: 1, widget: "weather" },
+      boardBroadcastScope,
+    );
 
     const snapshot = put.mock.calls[0]?.[1] as BoardSnapshot;
     const grant = await invoke("board.widget.grant", {
@@ -309,10 +312,11 @@ describe("board gateway methods", () => {
         widgets: [expect.objectContaining({ grantState: "granted" })],
       }),
     );
-    expect(broadcast).toHaveBeenLastCalledWith("board.changed", {
-      sessionKey: "agent:main:session",
-      revision: 2,
-    });
+    expect(broadcast).toHaveBeenLastCalledWith(
+      "board.changed",
+      { sessionKey, revision: 2 },
+      boardBroadcastScope,
+    );
   });
 
   it.each(boardWidgetContentPermissionCases)(
@@ -395,11 +399,11 @@ describe("board gateway methods", () => {
         );
       }
       expect(broadcast).toHaveBeenCalledOnce();
-      expect(broadcast).toHaveBeenCalledWith("board.changed", {
-        sessionKey: "agent:main:session",
-        revision: grantState === "pending" ? 1 : 2,
-        widget: "weather",
-      });
+      expect(broadcast).toHaveBeenCalledWith(
+        "board.changed",
+        { sessionKey, revision: grantState === "pending" ? 1 : 2, widget: "weather" },
+        boardBroadcastScope,
+      );
     },
   );
 
@@ -843,11 +847,11 @@ describe("board gateway methods", () => {
       true,
       expect.objectContaining({ widgets: [expect.objectContaining({ name: "canvas-widget" })] }),
     );
-    expect(broadcast).toHaveBeenCalledWith("board.changed", {
-      sessionKey: "agent:main:session",
-      revision: 1,
-      widget: "canvas-widget",
-    });
+    expect(broadcast).toHaveBeenCalledWith(
+      "board.changed",
+      { sessionKey, revision: 1, widget: "canvas-widget" },
+      boardBroadcastScope,
+    );
   });
 
   it("installs the trusted bridge before arbitrary complete HTML", async () => {

--- a/src/gateway/server-methods/board.ts
+++ b/src/gateway/server-methods/board.ts
@@ -253,14 +253,18 @@ export function createBoardHandlers(
           );
           if (boardParams.ops.length > 0) {
             emitSessionsChanged(context, {
-              sessionKey: snapshot.sessionKey,
+              sessionKey: boardSession.sessionKey,
               agentId: boardSession.agentId,
               reason: "board",
             });
-            context.broadcast("board.changed", {
-              sessionKey: snapshot.sessionKey,
-              revision: snapshot.revision,
-            });
+            context.broadcast(
+              "board.changed",
+              {
+                sessionKey: snapshot.sessionKey,
+                revision: snapshot.revision,
+              },
+              { sessionKeys: [boardSession.sessionKey], agentId: boardSession.agentId },
+            );
           }
           respond(true, snapshot);
         } catch (error) {
@@ -452,15 +456,19 @@ export function createBoardHandlers(
           }
           snapshot = projectBoardSnapshot(snapshot, boardSession.agentId);
           emitSessionsChanged(context, {
-            sessionKey: snapshot.sessionKey,
+            sessionKey: boardSession.sessionKey,
             agentId: boardSession.agentId,
             reason: "board",
           });
-          context.broadcast("board.changed", {
-            sessionKey: snapshot.sessionKey,
-            revision: snapshot.revision,
-            widget: snapshot.resolvedWidgetName,
-          });
+          context.broadcast(
+            "board.changed",
+            {
+              sessionKey: snapshot.sessionKey,
+              revision: snapshot.revision,
+              widget: snapshot.resolvedWidgetName,
+            },
+            { sessionKeys: [boardSession.sessionKey], agentId: boardSession.agentId },
+          );
           respond(true, snapshot);
         } catch (error) {
           respondBoardError(error, respond);
@@ -489,10 +497,14 @@ export function createBoardHandlers(
             ),
             boardSession.agentId,
           );
-          context.broadcast("board.changed", {
-            sessionKey: snapshot.sessionKey,
-            revision: snapshot.revision,
-          });
+          context.broadcast(
+            "board.changed",
+            {
+              sessionKey: snapshot.sessionKey,
+              revision: snapshot.revision,
+            },
+            { sessionKeys: [boardSession.sessionKey], agentId: boardSession.agentId },
+          );
           respond(true, snapshot);
         } catch (error) {
           respondBoardError(error, respond);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a maintainer-owned branch in the same repository.

</details>

## What Problem This Solves

An agent pinning a widget from its global session could report success while writing it to Main's board. With explicit ownership and no retained default owner, the same action failed as ownerless. Board viewers could also miss updates or receive another session's gallery metadata when a global board and an ordinary session shared an outward-facing event key.

## Why This Change Was Made

The prepared session owner was lost at two boundaries. `show_widget` kept its agent identity in the constructor but omitted it from the existing board request. The board handlers correctly resolved the storage owner, then used the projected event key for recipient filtering and gallery notifications.

The tool now forwards its existing host-prepared agent. Board notifications carry the resolved canonical key and agent into the existing private broadcast and session-change contracts. The public event payload stays unchanged. This keeps one resolution path and avoids trying to recover ownership from an ambiguous display key.

## User Impact

Pinned widgets stay on the selected agent's board. Live board updates and gallery refreshes reach that board's viewers, including when another session shares its projected key. Existing ordinary sessions, content-kind checks, widget approvals, and no-op behavior remain covered.

## Current validation

Rebased onto `c57e36320e0cd19f1026ff6b36659b6976168d46` after main migrated broadcaster clients to `GatewayClientRegistry`. Both original board ownership cases and all upstream fixture changes are preserved. The board and widget production files are byte-identical to the earlier reviewed head. Current PR head: `bc3cdc2e873bfc5a173cdc8459098c1840b06ba7`.

The refreshed candidate passed 204 tests across 13 files, both targeted actual-source typechecks, type-aware lint, formatting, and two independent review passes with no actionable findings. A new isolated Gateway WebSocket run passed all 38 authenticated requests across four peers; all six ownership and no-op controls matched, and sockets, listener, and the owned process group closed. The first attempt stopped before application startup because an isolated home changed Git diff formatting; deterministic proof metadata resolved that fixture issue without changing application code or weakening assertions.

The earlier UI captures and their stated limits remain evidence for their recorded source. The new WebSocket run covers integration with the updated broadcaster. [CI on the current head](https://github.com/openclaw/openclaw/actions/runs/33940663587) passed, including the required `openclaw/ci-gate`. This completes the latest ClawSweeper requests to preserve the canonical client registry during conflict resolution and validate the refreshed ownership regressions. The prior green CI remains attributed to `91519785d603ddfc9e5164b871dbb4ef166514a4`.

## Earlier reproduction and UI evidence

The board regressions fail on the unchanged base and pass in both global and per-sender modes. They exercise real handlers, SQLite, profile authorization, and the broadcaster with recording sockets. All 131 focused handler, broadcaster, store, sharing, session-change, and UI board-provider tests passed on the original three-file board change.

The expanded widget regression independently failed for both Research/global cases while qualified Main passed. With the producer repair, all 34 tests across the five widget suites passed, covering creation, refresh, grants, scheduled authoring, presenters, and prompt contracts. Actual-source types (10,781 inputs), type-aware lint, formatting, and a fresh independent P0–P2 review of the complete five-file diff passed. The first type-check attempt used an external config and could not locate Node types; the existing in-repo configuration passed without source or dependency changes.

A separate real default-tool → in-process Gateway router → canonical SQLite replay passed under explicit ownership and retained-Main compatibility. Research/global received the pin, Main/global remained empty at revision zero, and all six owner-aware board, ordinary-session pinning, and dashboard controls passed. This used a synthetic system actor; it is not human-profile WebSocket evidence.

Authenticated WebSocket acceptance passed on `5fdd5e0fa4630ef9bb92e370f3b6c33f80153b7d`, whose three board files are unchanged in the expanded candidate. Three signed, paired read-only profiles and a separate admin writer completed 38 RPCs through an isolated real Gateway. Update, replacement, and approval events reached only the intended reader; gallery IDs/labels stayed with the owner; empty updates emitted nothing. Canonical SQLite revisions were 3/1/1, and all sockets, the listener, and the Gateway process closed. This live run used global mode; per-sender behavior has failing/passing broadcaster coverage.

The initial public CI failure was an existing widget test expecting only two broadcast arguments. Both assertions now check the canonical owner scope in the expanded create/refresh regression. Production is +29/−17 lines (net +12 for the existing broadcast scope arguments); tests are +287/−113 (net +174, including reindentation of the table-driven widget case). The producer fix itself is net zero. No schema, configuration, dependency, public RPC, or storage representation changes.

Previously tested head: `91519785d603ddfc9e5164b871dbb4ef166514a4`. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33932989753) passed: 108 successful jobs, 17 skipped, and the required `openclaw/ci-gate` succeeded.

The [isolated Testbox browser run](https://github.com/openclaw/openclaw/actions/runs/33937272998) completed the board flow on this exact source: select Research/global, invoke the actual default `show_widget` tool, reload the selected dashboard, refresh the same widget through the tool, reload again, and return to Main. Research's board advanced from revision 1 to 2 to 3, its single widget advanced from revision 1 to 2, and Main's complete stored board remained unchanged. All five browser `board.get` requests carried the selected owner and succeeded; the captures show the rendered iframe before pinning, after pinning, and after refresh. The tool was invoked through the real in-process Gateway router without model inference; browser readback used the actual listener Gateway and source Control UI. This proves durable readback; the separate authenticated WebSocket run proves event recipients.

The broader browser runner exited 1 after those board assertions because one sidebar `sessions.describe({key:"global"})` response was outside its error allowlist. Its caller and handler are unchanged from the PR base: the sidebar lineage lookup omits the owner, and the handler rejects the ambiguous global key. **Global-session sidebar lineage owner resolution** remains a separate follow-up; this PR does not claim that path fixed. The retained raw report stays failed. All 243 requests received responses; the 19 non-board errors were two progress-card requests, eleven GitHub-options requests, five unconfigured Talk-catalog requests, and that one lineage request. Progress/GitHub ownership is separate ongoing repair work; Talk was intentionally unconfigured in this synthetic two-agent fixture. No board RPC failed, no browser page error or external request was recorded, and all processes, ports, and the owned lease were closed. The scoped board result does not claim the whole UI is healthy.

ClawSweeper's latest rank-up request for actual selected-board pin/refresh evidence is addressed by the captures below. The Control UI gallery itself was not exercised; gallery row identity and notification delivery are covered by the separate 38-RPC authenticated WebSocket proof above. The earlier local setup/loading failures and the first Testbox source-context failure remain retained as failed attempts.

<details>
<summary>Authenticated WebSocket recipient trace</summary>

Synthetic fixture only. Readers authenticated as three distinct operator.read profiles; a fourth operator.admin profile issued the writes. Session IDs below are the fixture rows verified after delivery. This trace projects the recorded socket frames; empty arrays mean no board or session-change frame reached that reader during the completed operation.

```jsonl
{"stage":"raw-global-update","received":{"raw-owner":[{"event":"sessions.changed","sessionKey":"global","agentId":"work","sessionId":"0e98f1ff-6726-4e6d-b7fe-5b1613c5727d","label":"raw-owner"},{"event":"board.changed","sessionKey":"agent:work:global","revision":1}],"ordinary-owner":[],"other-agent-owner":[]}}
{"stage":"raw-global-put","received":{"raw-owner":[{"event":"board.changed","sessionKey":"agent:work:global","revision":2,"widget":"status"},{"event":"sessions.changed","sessionKey":"global","agentId":"work","sessionId":"0e98f1ff-6726-4e6d-b7fe-5b1613c5727d","label":"raw-owner"}],"ordinary-owner":[],"other-agent-owner":[]}}
{"stage":"raw-global-grant","received":{"raw-owner":[{"event":"board.changed","sessionKey":"agent:work:global","revision":3}],"ordinary-owner":[],"other-agent-owner":[]}}
{"stage":"empty-update","received":{"raw-owner":[],"ordinary-owner":[],"other-agent-owner":[]}}
{"stage":"ordinary-qualified-control","received":{"raw-owner":[],"ordinary-owner":[{"event":"sessions.changed","sessionKey":"agent:work:global","agentId":"work","sessionId":"8ab1c614-13d0-4271-91d9-2dd44f53fafa","label":"ordinary-owner"},{"event":"board.changed","sessionKey":"agent:work:global","revision":1}],"other-agent-owner":[]}}
{"stage":"other-agent-control","received":{"raw-owner":[],"ordinary-owner":[],"other-agent-owner":[{"event":"sessions.changed","sessionKey":"global","agentId":"main","sessionId":"5b67880e-d67a-49ff-98b6-3891755cdb33","label":"other-agent-owner"},{"event":"board.changed","sessionKey":"agent:main:global","revision":1}]}}
```

Recorded runner SHA256: `d92c06f77969e0e75477eda7bf41aa4c913f3274dd674f2f05921e8137c50b17`; complete local report SHA256: `52201e8d84d8de8ea7cd352a69e0c2612b72ea171f5c8c263b1628cff6f5e5fd`.
</details>


<details>
<summary>Actual selected-board captures</summary>

These are before/after actions on the same fixed source, not before/after code screenshots. The selected agent and rendered dashboard are visible in each full capture.

**Main before the Research pin**

![Main before the Research pin](https://github.com/user-attachments/assets/1dfe8591-9d45-466c-9f46-29e479fd052c)

**Research before pinning**

![Research before pinning](https://github.com/user-attachments/assets/2e3fdbbb-d433-4ba0-b762-d6f6491e5833)

**Research after pinning**

![Research after pinning](https://github.com/user-attachments/assets/4d445246-0ca6-41b1-81db-4e30a6f0e49f)

**Research after refreshing the same widget**

![Research after refreshing the same widget](https://github.com/user-attachments/assets/dfafec19-9ca8-45d3-b3fb-91bd97f537b9)

**Main after both Research actions**

![Main after both Research actions](https://github.com/user-attachments/assets/e8366ce7-2b71-4867-9e05-6c63a61602e8)

</details>

Closes #138616.
