### PR TITLE
fix(ui): hide broken Customize UI control

### DIFF
--- a/ui/src/e2e/native-plugin-ui.e2e.test.ts
+++ b/ui/src/e2e/native-plugin-ui.e2e.test.ts
@@ -702,12 +702,13 @@ suite.define(() => {
         });
         await selectView(page, "Workspace", "ui-fixture/workspace");
         await page.getByRole("heading", { name: "Custom workspace" }).waitFor();
-        expect(await page.locator("button.plugin-ui-recovery").isVisible()).toBe(false);
         await page.screenshot({
           path: path.join(suite.artifactDir, "custom-workspace.png"),
           fullPage: true,
         });
-        await page.getByRole("button", { name: "Show built-in workspace" }).click();
+        await page.getByRole("button", { name: "Customize UI", exact: true }).click();
+        await page.getByRole("combobox", { name: "Workspace", exact: true }).selectOption("");
+        await page.getByRole("button", { name: "Close", exact: true }).last().click();
         await page.getByRole("link", { name: "UI fixture", exact: true }).waitFor();
         await page.getByRole("link", { name: "UI fixture", exact: true }).click();
         await page.getByRole("heading", { name: "Fixture revision one" }).waitFor();

--- a/ui/src/e2e/native-plugin-ui.e2e.test.ts
+++ b/ui/src/e2e/native-plugin-ui.e2e.test.ts
@@ -161,9 +161,15 @@ const actionPluginModule = `export default { id:"ui-fixture", activate(host) {
 } };`;
 
 async function selectView(page: Page, label: string, value: string) {
-  await page.getByRole("button", { name: "Customize UI", exact: true }).click();
+  await openCustomizeUi(page);
   await page.getByRole("combobox", { name: label, exact: true }).selectOption(value);
   await page.getByRole("button", { name: "Close", exact: true }).last().click();
+}
+
+async function openCustomizeUi(page: Page) {
+  await page.locator("button.plugin-ui-recovery").evaluate((button) => {
+    (button as HTMLButtonElement).click();
+  });
 }
 
 suite.define(() => {
@@ -604,6 +610,7 @@ suite.define(() => {
         await expect.poll(() => page.locator(".board-session-surface").isVisible()).toBe(false);
         await expectOneAccessory();
         await page.screenshot({ path: path.join(suite.artifactDir, "before.png"), fullPage: true });
+        expect(await page.locator("button.plugin-ui-recovery").isVisible()).toBe(false);
         for (const replacement of [
           "",
           "ui-fixture/delegated-composer",
@@ -654,7 +661,7 @@ suite.define(() => {
         await page
           .getByLabel("Fixture draft", { exact: true })
           .fill("Send through the canonical composer");
-        await page.getByRole("button", { name: "Customize UI", exact: true }).click();
+        await openCustomizeUi(page);
         const composerSelect = page.getByRole("combobox", { name: "Composer", exact: true });
         expect(await composerSelect.inputValue()).toBe("ui-fixture/composer");
         await composerSelect.selectOption("");
@@ -695,7 +702,7 @@ suite.define(() => {
         });
         await selectView(page, "Workspace", "ui-fixture/workspace");
         await page.getByRole("heading", { name: "Custom workspace" }).waitFor();
-        await page.getByRole("button", { name: "Customize UI", exact: true }).waitFor();
+        expect(await page.locator("button.plugin-ui-recovery").isVisible()).toBe(false);
         await page.screenshot({
           path: path.join(suite.artifactDir, "custom-workspace.png"),
           fullPage: true,
@@ -775,7 +782,7 @@ suite.define(() => {
           await gateway.emitGatewayEvent("plugins.controlUi.changed", { revision });
         };
         const readComposerSelection = async () => {
-          await page.getByRole("button", { name: "Customize UI", exact: true }).click();
+          await openCustomizeUi(page);
           const selected = await page
             .getByRole("combobox", { name: "Composer", exact: true })
             .inputValue();
@@ -783,7 +790,7 @@ suite.define(() => {
           return selected;
         };
         await gateway.setMethodResponse("plugins.controlUi.list", catalog("two"));
-        await page.getByRole("button", { name: "Customize UI", exact: true }).click();
+        await openCustomizeUi(page);
         await page.getByRole("button", { name: "Reload plugin UI", exact: true }).click();
         await gateway.waitForRequest("plugins.controlUi.reload");
         await page.getByRole("button", { name: "Close", exact: true }).last().click();
@@ -796,7 +803,7 @@ suite.define(() => {
         expect(await gateway.getRequests("fixture.stale")).toHaveLength(0);
         await selectView(page, "Composer", "ui-fixture/composer");
         const sameRevisionListed = (await gateway.getRequests("plugins.controlUi.list")).length;
-        await page.getByRole("button", { name: "Customize UI", exact: true }).click();
+        await openCustomizeUi(page);
         const reloadButton = page.getByRole("button", { name: "Reload plugin UI", exact: true });
         await reloadButton.click();
         await gateway.waitForRequest("plugins.controlUi.list", { after: sameRevisionListed });
@@ -836,7 +843,7 @@ suite.define(() => {
           await expect
             .poll(() => page.getByLabel("Fixture outcome").textContent())
             .toBe("completed");
-          await page.getByRole("button", { name: "Customize UI", exact: true }).click();
+          await openCustomizeUi(page);
           for (const surface of ["Composer", "Workspace"]) {
             expect(
               await page.getByRole("combobox", { name: surface, exact: true }).inputValue(),
@@ -982,7 +989,7 @@ suite.define(() => {
         });
         await gateway.setMethodResponse("plugins.controlUi.list", next);
         await gateway.setMethodResponse("plugins.controlUi.reload", next);
-        await page.getByRole("button", { name: "Customize UI", exact: true }).click();
+        await openCustomizeUi(page);
         const reload = page.getByRole("button", { name: "Reload plugin UI", exact: true });
         await reload.click();
         await gateway.waitForRequest("fixture.peerStarted");

--- a/ui/src/plugins/control-ui-view.runtime.ts
+++ b/ui/src/plugins/control-ui-view.runtime.ts
@@ -137,9 +137,11 @@ class ControlUiPluginView extends OpenClawLightDomContentsElement {
               throw new Error("This plugin UI view has ended.");
             }
             this.defaultContainers.add(target);
+            this.toggleAttribute("data-plugin-default-mounted", true);
             render(this.defaultView, target, { host: this.defaultHost ?? this });
             return () => {
               this.defaultContainers.delete(target);
+              this.toggleAttribute("data-plugin-default-mounted", this.defaultContainers.size > 0);
               render(nothing, target);
             };
           },
@@ -228,6 +230,7 @@ class ControlUiPluginView extends OpenClawLightDomContentsElement {
       render(nothing, container);
     }
     this.defaultContainers.clear();
+    this.removeAttribute("data-plugin-default-mounted");
     this.viewContext = undefined;
   }
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5698,11 +5698,7 @@ td.data-table-key-col {
   line-height: 0;
 }
 
-/* Recovery stays outside a plugin-owned workspace so the built-in UI remains reachable. */
+/* Keep the recovery control mounted, but hide it until the customization flow is ready. */
 .plugin-ui-recovery {
-  position: fixed;
-  right: max(12px, env(safe-area-inset-right));
-  bottom: max(12px, env(safe-area-inset-bottom));
-  z-index: 110;
-  box-shadow: var(--shadow-md);
+  display: none;
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5698,7 +5698,18 @@ td.data-table-key-col {
   line-height: 0;
 }
 
-/* Keep the recovery control mounted, but hide it until the customization flow is ready. */
+/* Hide the idle manager; full workspace replacements retain a host-owned escape. */
 .plugin-ui-recovery {
   display: none;
+  position: fixed;
+  right: max(12px, env(safe-area-inset-right));
+  bottom: max(12px, env(safe-area-inset-bottom));
+  z-index: 110;
+  box-shadow: var(--shadow-md);
+}
+
+openclaw-plugin-view:not([data-plugin-default-mounted])
+  + openclaw-plugin-manager
+  .plugin-ui-recovery {
+  display: block;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users saw a non-working **Customize UI** control floating over the Control UI whenever native plugin UI was available.

## Why This Change Was Made

Hides the control while a replacement retains the built-in workspace. A full workspace replacement still exposes the host-owned recovery control until the operator restores Built-in, while the plugin UI runtime and replacement lifecycle remain intact.

## User Impact

Users no longer see or accidentally invoke the broken floating control during normal/default-backed layouts. A full plugin workspace retains the visible recovery path needed to return to Built-in. Plugin pages, actions, widgets, and backend behavior are unchanged.

## Evidence

Deterministic mocked-Gateway Control UI flow on `origin/main` (`7697286a566f`) and candidate `7f3844af3e4f`, using identical fixture data and routes.

| Viewport | Before | After |
| --- | --- | --- |
| Desktop (`1440×900`) | ![Desktop before](https://github.com/user-attachments/assets/6056dffc-cad6-4a2d-9f10-13b3c0ee350b) | ![Desktop after](https://github.com/user-attachments/assets/ef2f2128-e7cc-46c4-8352-6061624f6a45) |
| Mobile (`390×844`) | ![Mobile before](https://github.com/user-attachments/assets/970c2fc9-c06b-4d44-8657-3e894ab1fd11) | ![Mobile after](https://github.com/user-attachments/assets/58469c27-ea15-4ec6-9aaf-f2981d47e409) |

Full-workspace recovery remains visible and restores the host UI through ordinary browser interaction:

| Active replacement | Restored built-in UI |
| --- | --- |
| ![Full workspace recovery](https://github.com/user-attachments/assets/93f1350a-edcf-4129-bb3b-8d823c2685e3) | ![Built-in restored](https://github.com/user-attachments/assets/ff043f39-47f0-49b5-9080-df27ea2b6c6f) |

Validation:

- `native-plugin-ui.e2e.test.ts`: 6/6 scenarios passed.
- `control-ui-contributions.test.ts`: 12/12 tests passed.
- Changed-file validation passed formatting, typecheck, i18n, lint, dependency, architecture, assertion, and dead-export gates.
- Autoreview rerun after recovery refinement: scoped clean, no accepted/actionable findings.
