### PR TITLE
test(qa): preload the Slack action graph before scenario deadlines

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -1,6 +1,6 @@
 // Qa Lab tests cover slack live plugin behavior.
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { readQaScenarioById } from "../../scenario-catalog.js";
 import { requireFlowScenario } from "../../scenario-catalog.test-utils.js";
 import { resolveLiveTransportQaScenarioIds } from "../shared/scenario-selection.js";
@@ -32,6 +32,7 @@ import {
   runSlackTableInvalidBlocksFallbackScenario,
 } from "./slack-live.observations.js";
 import * as slackScenarioImplementations from "./slack-live.scenario-implementations.js";
+import { loadSlackQaRuntime } from "./slack-plugin.runtime.js";
 
 // Keep real Slack operations in Vitest's graph instead of recompiling them through Jiti.
 // The separate facade tests own plugin loading; this suite owns delivery behavior.
@@ -114,6 +115,13 @@ function renderExpectedSlackTableAccessibleText(summaryText: string) {
 }
 
 describe("Slack live QA runtime helpers", () => {
+  beforeAll(async () => {
+    // Load the real Slack action graph as suite preparation, outside scenario
+    // deadlines: the first send otherwise pays that cold import inside its
+    // 120s test budget and times out on contended CI shards.
+    await loadSlackQaRuntime().preloadSlackActions();
+  });
+
   it("converts Slack rate-limit retry seconds for the observer backoff", () => {
     expect(testing.resolveSlackRateLimitDelayMs({ retryAfter: 10 })).toBe(10_000);
     expect(testing.resolveSlackRateLimitDelayMs({ retryAfter: 0 })).toBeUndefined();

--- a/extensions/slack/test-api.test.ts
+++ b/extensions/slack/test-api.test.ts
@@ -8,6 +8,7 @@ describe("Slack test API", () => {
       "createSlackWebClient",
       "createSlackWriteClient",
       "listSlackReactions",
+      "preloadSlackActions",
       "resolveSlackWebClientOptions",
       "sendSlackMessage",
     ]);

--- a/extensions/slack/test-api.ts
+++ b/extensions/slack/test-api.ts
@@ -12,6 +12,14 @@ type SlackActions = typeof import("./src/actions.js");
 // Async imports keep Jiti from resolving the action graph on one deep synchronous stack.
 const loadSlackActions = createLazyRuntimeModule(() => import("./src/actions.js"));
 
+/**
+ * Warm the lazily imported action graph as suite preparation. The first
+ * action call otherwise pays the cold import inside a Vitest test deadline.
+ */
+export const preloadSlackActions = async (): Promise<void> => {
+  await loadSlackActions();
+};
+
 export const listSlackReactions: SlackActions["listSlackReactions"] = async (...args) =>
   (await loadSlackActions()).listSlackReactions(...args);
 export const sendSlackMessage: SlackActions["sendSlackMessage"] = async (...args) =>


### PR DESCRIPTION
## What Problem This Solves

The 2026.9.1 closeout PR #137506 could not land: CI run 33824494970 failed the same two shards on every one of its 14 attempts while both suites passed locally and on the full `agentic-gateway-core-3` dispatch shard. Root causes, one per shard:

1. **`checks-node-compact-large-1` — `local-request-context.session-tools.test.ts` "visible-spawn rollback protects the admitted child generation (unchanged)" timed out at 120s, then "(active)" failed its authority assertion.** This is the cold-shard first-fixture overrun that #137743 already fixed on `main` (merged 2026-09-04T01:34Z, test-only: preload the mutation runtime in `beforeAll`, join a timed-out fixture before globals reset). The closeout run never saw that fix: every `gh run rerun --failed` attempt re-checks out the run's original merge commit `b2e231b1` = closeout head merged into `main@3d30b3ac`, which predates #137743 by 40 minutes. A diagnostic dispatch of the same shard on current `main` (run 33924064570, breadcrumb-instrumented throwaway branch, 2 workers / 4 cores like the PR job) completes every `sessions.create`/`sessions.delete`/drain phase in under 2.5s. The fix for this half is a fresh merge ref: #137506 is rebased onto current `main` (new CI run 33927294485). No code change is needed here.

2. **`checks-node-changed-extensions-config-48` — `extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts` "proves the public Slack send path stores complete ordered fallback chunks" timed out at 120s (attempts 12 and 13; passed on 14).** That test is the first in its file to call `sendSlackMessage` from `@openclaw/slack/test-api.js`, which is a `createLazyRuntimeModule(() => import("./src/actions.js"))` loader: the first call performs the cold dynamic import of the entire Slack actions/send graph *inside* the test's own 120s deadline. Locally that import costs ~3.9s (breadcrumb: `sendSlackMessage start` → `sendMessageSlack enter` = 3898ms); on the contended 82-file extension shard (`import 129.55s` total, a sibling WhatsApp qa-suite spawning gateway processes at the same time) it is unbounded. This PR fixes that half at the owner.

## Why This Change Was Made

The Slack test API keeps its action graph lazy on purpose (Jiti must not resolve it on one deep synchronous stack in the QA runner). The suite, not the loader, owns the deadline problem: it must pay the cold import as suite preparation. `preloadSlackActions` exposes exactly that warm-up on the test API, and the qa-lab suite awaits it in `beforeAll` (hook timeout 180s, outside scenario deadlines), mirroring the #137743 pattern for the session-tools fixture. No production or runtime behavior changes.

## User Impact

None at runtime. Maintainers: the closeout PR and any PR whose changed-extension plan includes the qa-lab Slack suite stop failing on a cold-import timeout.

## Evidence

- Root-cause attribution: run 33824494970 attempts 12–14 job logs (compact shard: `Test timed out in 120000ms` at `session-tools.test.ts:78` then `:173`; extension shard: `slack-live.runtime.test.ts` fallback test at 120000ms), merge commit `b2e231b1` = `d22f1e43` into `3d30b3ac`; `git merge-base --is-ancestor 3d30b3ac <current main>` and `git log 3d30b3ac..main -- src/gateway/local-request-context.session-tools.test.ts` → `38565c8baea test(gateway): drain session tool fixture cleanup (#137743)`.
- Diagnostic dispatch on current `main` with timing breadcrumbs (throwaway branch, run 33924064570): `agentic-gateway-core-3` passes with 2 workers; per-phase timings for the first fixture: `sessions.create` 35ms, `sessions.delete` 2398ms, all drain phases < 2ms. The same shard also passes locally with `OPENCLAW_VITEST_MAX_WORKERS=2` (176/176).
- Slack cold import measured locally on the instrumented branch: 3898ms between the scenario's `sendSlackMessage` call and `sendMessageSlack` entering.
- After this change: `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts extensions/qa-lab/src/live-transports/slack/slack-plugin.runtime.test.ts` → 63/63; the fallback test now reports 13ms (was ~3.9s) because the graph is already warm.
- `oxfmt` and `scripts/run-oxlint.mjs` clean on both files.
- Codex autoreview (`--mode branch --base origin/main --max-priority P1`): one P1, "give the preload hook a timeout that covers the cold import", verified incorrect against the resolved project config: `test/vitest/vitest.extension-qa.config.ts` derives from the shared config, and the resolved values are `hookTimeout = 180000`, `testTimeout = 120000` (printed from the loaded config), so the `beforeAll` warm-up runs under the 180s hook budget that the shared config documents for cold 4-core runners, not Vitest's 10s default. No code change made for it.
- First CI run (33927499535) failed only `extensions/slack/test-api.test.ts`, the exact-export contract for the test API surface; the follow-up commit admits `preloadSlackActions` there (1/1 locally).
- Production LOC: +8 (one test-API export, test-support surface only); tests +9/−1.

Related: #137506 (closeout, rebased onto current `main`), #137743 (session-tools half, already on `main`).
