### PR TITLE
fix(exec): keep gateway exec open for legacy GitHub profile ids

### DIFF
--- a/src/agents/bash-tools.github-identity.test.ts
+++ b/src/agents/bash-tools.github-identity.test.ts
@@ -251,4 +251,86 @@ describe("exec GitHub identity", () => {
       }
     },
   );
+
+  it("does not fail-close gateway echo when a legacy PAT-shaped GitHub profile is configured", async () => {
+    storeMocks.readSecretStoreExecEnvironment.mockReturnValue({ env: {} });
+    const profileRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "exec-github-legacy-pat-")),
+    );
+    try {
+      const config = {
+        tools: {
+          github: {
+            profileId: `ghp_${"Z".repeat(36)}`,
+            kind: "oauth" as const,
+          },
+        },
+      };
+      const preparedRunEnvironment = prepareGitHubToolEnvironment({
+        config,
+        agentId: "main",
+        env: { OPENCLAW_STATE_DIR: profileRoot },
+      });
+      expect(preparedRunEnvironment.managedLocalIdentity).toBe(false);
+      expect(preparedRunEnvironment.localIdentityEnv).not.toHaveProperty("GH_CONFIG_DIR");
+      const tool = createExecTool({
+        host: "gateway",
+        security: "full",
+        ask: "off",
+        allowBackground: false,
+        config,
+        agentId: "main",
+        preparedRunEnvironment,
+      });
+
+      const result = await tool.execute("legacy-pat-echo", { command: "echo hello-legacy" });
+
+      expect(result.details.status).toBe("completed");
+      expect(result.details.exitCode).toBe(0);
+      expect(String(result.details.aggregated)).toContain("hello-legacy");
+      expect(String(result.details.aggregated)).not.toContain(
+        "GitHub Identity credential is unavailable or insecure",
+      );
+    } finally {
+      await fs.rm(profileRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("still fail-closes gateway exec when a managed GitHub identity is missing", async () => {
+    storeMocks.readSecretStoreExecEnvironment.mockReturnValue({ env: {} });
+    const profileRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "exec-github-missing-identity-")),
+    );
+    try {
+      const config = {
+        tools: { github: { profileId: "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } },
+      };
+      const preparedRunEnvironment = prepareGitHubToolEnvironment({
+        config,
+        agentId: "main",
+        env: { OPENCLAW_STATE_DIR: profileRoot },
+      });
+      expect(preparedRunEnvironment.managedLocalIdentity).toBe(true);
+      const tool = createExecTool({
+        host: "gateway",
+        security: "full",
+        ask: "off",
+        allowBackground: false,
+        config,
+        agentId: "main",
+        preparedRunEnvironment,
+      });
+
+      const result = await tool.execute("missing-identity-echo", { command: "echo hello-missing" });
+
+      expect(result.details.status).toBe("completed");
+      expect(result.details.exitCode).toBe(1);
+      expect(String(result.details.aggregated)).toContain(
+        "GitHub Identity credential is unavailable or insecure",
+      );
+      expect(String(result.details.aggregated)).not.toContain("hello-missing");
+    } finally {
+      await fs.rm(profileRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/agents/bash-tools.github-identity.test.ts
+++ b/src/agents/bash-tools.github-identity.test.ts
@@ -286,9 +286,12 @@ describe("exec GitHub identity", () => {
       const result = await tool.execute("legacy-pat-echo", { command: "echo hello-legacy" });
 
       expect(result.details.status).toBe("completed");
+      if (result.details.status !== "completed") {
+        throw new Error("expected completed exec result");
+      }
       expect(result.details.exitCode).toBe(0);
-      expect(String(result.details.aggregated)).toContain("hello-legacy");
-      expect(String(result.details.aggregated)).not.toContain(
+      expect(result.details.aggregated).toContain("hello-legacy");
+      expect(result.details.aggregated).not.toContain(
         "GitHub Identity credential is unavailable or insecure",
       );
     } finally {
@@ -324,11 +327,14 @@ describe("exec GitHub identity", () => {
       const result = await tool.execute("missing-identity-echo", { command: "echo hello-missing" });
 
       expect(result.details.status).toBe("completed");
+      if (result.details.status !== "completed") {
+        throw new Error("expected completed exec result");
+      }
       expect(result.details.exitCode).toBe(1);
-      expect(String(result.details.aggregated)).toContain(
+      expect(result.details.aggregated).toContain(
         "GitHub Identity credential is unavailable or insecure",
       );
-      expect(String(result.details.aggregated)).not.toContain("hello-missing");
+      expect(result.details.aggregated).not.toContain("hello-missing");
     } finally {
       await fs.rm(profileRoot, { recursive: true, force: true });
     }

--- a/src/agents/github-tool-identity.test.ts
+++ b/src/agents/github-tool-identity.test.ts
@@ -97,6 +97,18 @@ describe("GitHub tool identity", () => {
       managedLocalIdentity: false,
     });
 
+    expect(
+      prepareGitHubToolEnvironment({
+        config: {
+          tools: { github: { profileId: `ghp_${"Z".repeat(36)}`, kind: "oauth" } },
+        },
+        agentId: "main",
+      }),
+    ).toMatchObject({
+      localIdentityEnv: {},
+      managedLocalIdentity: false,
+    });
+
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const expectedProfileDir = resolveManagedGitHubProfileDir({
       agentId: "main",

--- a/src/agents/github-tool-identity.ts
+++ b/src/agents/github-tool-identity.ts
@@ -79,7 +79,7 @@ function resolveGitHubToolIdentity(params: {
 }) {
   const agentOverride = resolveAgentConfig(params.config, params.agentId)?.tools?.github;
   const config = agentOverride ?? params.config.tools?.github;
-  if (!config) {
+  if (!config || !isManagedGitHubProfileId(config.profileId)) {
     return { source: "system-detected" as const };
   }
   const source: "agent-override" | "system-configured" = agentOverride
@@ -104,7 +104,7 @@ function resolveScopedGitHubToolIdentity(params: {
   env?: NodeJS.ProcessEnv;
 }): ResolvedGitHubToolIdentity | undefined {
   const config = resolveConfiguredGitHubToolIdentity(params);
-  if (!config) {
+  if (!config || !isManagedGitHubProfileId(config.profileId)) {
     return params.scope === "system" ? { source: "system-detected" as const } : undefined;
   }
   const source = params.scope === "system" ? "system-configured" : "agent-override";


### PR DESCRIPTION
## What Problem This Solves

A leftover PAT-shaped `tools.github.profileId` after the 2026.9.1 upgrade fail-closed every gateway exec, including `echo`, with "GitHub Identity credential is unavailable or insecure". Managed identity is only the opaque `ghp_[a-f0-9]{32}` profile id, so a PAT-shaped id left behind in the config is not a managed identity and should never have bound a profile.

Closes #137836

## Why This Change Was Made

`resolveGitHubToolIdentity` and `resolveScopedGitHubToolIdentity` treated the presence of a `tools.github` block as a managed binding, and the managed-shape check further down then threw on the id. Both now fall through to native GitHub detection when `isManagedGitHubProfileId` rejects the id, which is the same path a config with no `tools.github` at all takes. Opaque managed profiles are untouched and still fail closed when the credential is missing or insecure.

## Evidence

A probe that drives the real `prepareGitHubToolEnvironment` and `createExecTool` against a throwaway `OPENCLAW_STATE_DIR`, with a classic PAT-shaped id (`ghp_` + 36 `A`) and an opaque managed one (`ghp_` + 32 `a`) that has no credential on disk. Script at the end of this section, saved as `probe-137836.mts` at the repo root.

Before, this head with `src/agents/github-tool-identity.ts` checked out from `HEAD~1`:

```text
$ npx tsx probe-137836.mts
isManaged legacy false
isManaged opaque true
schema legacy false
schema opaque true
prepare legacy THREW Managed GitHub profile id is invalid.
preparedRunEnvironment construction THREW Managed GitHub profile id is invalid.
echo legacy THREW Managed GitHub profile id is invalid.
prepare opaque missing {
  managed: true,
  ghConfigDir: '/tmp/oc-137836-probe-xWxfXd/credentials/github/system/ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
}
echo opaque missing {
  status: 'completed',
  exitCode: 1,
  aggregated: 'GitHub Identity credential is unavailable or insecure. Reconnect or change GitHub Identity, then retry.\n' +
    '\n' +
    '(Command exited with code 1)'
}
gh opaque missing {
  status: 'completed',
  exitCode: 1,
  aggregated: 'GitHub Identity credential is unavailable or insecure. Reconnect or change GitHub Identity, then retry.\n' +
    '\n' +
    '(Command exited with code 1)'
}
```

After, same probe on this head:

```text
$ npx tsx probe-137836.mts
isManaged legacy false
isManaged opaque true
schema legacy false
schema opaque true
prepare legacy { managed: false, ghConfigDir: undefined }
echo legacy { status: 'completed', exitCode: 0, aggregated: 'hello-legacy' }
prepare opaque missing {
  managed: true,
  ghConfigDir: '/tmp/oc-137836-probe-a2Cw94/credentials/github/system/ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
}
echo opaque missing {
  status: 'completed',
  exitCode: 1,
  aggregated: 'GitHub Identity credential is unavailable or insecure. Reconnect or change GitHub Identity, then retry.\n' +
    '\n' +
    '(Command exited with code 1)'
}
gh opaque missing {
  status: 'completed',
  exitCode: 1,
  aggregated: 'GitHub Identity credential is unavailable or insecure. Reconnect or change GitHub Identity, then retry.\n' +
    '\n' +
    '(Command exited with code 1)'
}
```

`echo hello-legacy` goes from a throw to exit 0. The opaque managed profile with no credential behaves identically in both runs, exit 1 for both `echo` and `gh api user`, so the fail-closed path is not widened.

Unit tests on this head:

```text
$ pnpm exec vitest run src/agents/bash-tools.github-identity.test.ts src/agents/github-tool-identity.test.ts src/agents/bash-tools.exec-github-credential.test.ts src/agents/github-exec-credential.test.ts

 Test Files  4 passed (4)
      Tests  73 passed (73)
   Duration   9.13s
```

The probe:

```ts
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { createExecTool } from "./src/agents/bash-tools.exec-run.ts";
import { prepareGitHubToolEnvironment } from "./src/agents/github-tool-identity.ts";
import { isManagedGitHubProfileId } from "./src/config/github-identity-profile-id.ts";
import { validateConfigObjectRaw } from "./src/config/validation.ts";

const LEGACY_PAT = "ghp_" + "A".repeat(36); // classic PAT shape, not opaque hex-32
const OPAQUE = "ghp_" + "a".repeat(32);

console.log("isManaged legacy", isManagedGitHubProfileId(LEGACY_PAT));
console.log("isManaged opaque", isManagedGitHubProfileId(OPAQUE));
console.log("schema legacy", validateConfigObjectRaw({ tools: { github: { profileId: LEGACY_PAT, kind: "oauth" } } }).ok);
console.log("schema opaque", validateConfigObjectRaw({ tools: { github: { profileId: OPAQUE, kind: "oauth" } } }).ok);

const root = await fs.mkdtemp(path.join(os.tmpdir(), "oc-137836-probe-"));
const env = { OPENCLAW_STATE_DIR: root };

function summarize(label: string, result: unknown) {
  const r = result as { details?: { status?: string; aggregated?: string; exitCode?: number }; content?: unknown };
  console.log(label, {
    status: r.details?.status,
    exitCode: r.details?.exitCode,
    aggregated: String(r.details?.aggregated ?? r.content ?? "").slice(0, 400),
  });
}

try {
  try {
    const prepared = prepareGitHubToolEnvironment({
      config: { tools: { github: { profileId: LEGACY_PAT, kind: "oauth" } } } as never,
      agentId: "main",
      env,
    });
    console.log("prepare legacy", {
      managed: prepared.managedLocalIdentity,
      ghConfigDir: prepared.localIdentityEnv.GH_CONFIG_DIR,
    });
  } catch (err) {
    console.log("prepare legacy THREW", (err as Error).message);
  }

  try {
    const prepared = (() => {
      try {
        return prepareGitHubToolEnvironment({
          config: { tools: { github: { profileId: LEGACY_PAT, kind: "oauth" } } } as never,
          agentId: "main",
          env,
        });
      } catch (err) {
        console.log("preparedRunEnvironment construction THREW", (err as Error).message);
        return undefined;
      }
    })();
    const tool2 = createExecTool({
      host: "gateway",
      security: "full",
      ask: "off",
      allowBackground: false,
      agentId: "main",
      config: { tools: { github: { profileId: LEGACY_PAT, kind: "oauth" } } } as never,
      preparedRunEnvironment: prepared,
    });
    const result = await tool2.execute("echo-legacy", { command: "echo hello-legacy" });
    summarize("echo legacy", result);
  } catch (err) {
    console.log("echo legacy THREW", (err as Error).message);
  }

  try {
    const prepared = prepareGitHubToolEnvironment({
      config: { tools: { github: { profileId: OPAQUE } } },
      agentId: "main",
      env,
    });
    console.log("prepare opaque missing", {
      managed: prepared.managedLocalIdentity,
      ghConfigDir: prepared.localIdentityEnv.GH_CONFIG_DIR,
    });
    const tool = createExecTool({
      host: "gateway",
      security: "full",
      ask: "off",
      allowBackground: false,
      agentId: "main",
      config: { tools: { github: { profileId: OPAQUE } } },
      preparedRunEnvironment: prepared,
    });
    const echo = await tool.execute("echo-opaque-missing", { command: "echo hello-opaque" });
    summarize("echo opaque missing", echo);
    const gh = await tool.execute("gh-opaque-missing", { command: "gh api user" });
    summarize("gh opaque missing", gh);
  } catch (err) {
    console.log("opaque missing THREW", (err as Error).message);
  }
} finally {
  await fs.rm(root, { recursive: true, force: true });
}
```
