### PR TITLE
fix(codex): keep unavailable apps from blocking conversations

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -358,12 +358,13 @@ allowed app can be installed and authenticated before it becomes callable.
 OpenClaw provisionally admits only ownership-proven, policy-approved apps,
 creates the thread with `_default.enabled = false` and explicit app overrides,
 then calls `app/installed` once with that thread's ID and `forceRefresh: false`.
-It exposes an app only when Codex confirms the app is enabled and callable for
-the actual thread. Managed restrictions, workspace policy, missing metadata,
-revoked auth, and unavailable tools still fail closed.
+If that snapshot reports missing, disabled, or non-callable apps, OpenClaw logs
+one warning and continues with the remaining tools. Codex still enforces
+managed restrictions, workspace policy, and app/tool permissions; unavailable
+apps gain no access.
 
-Attestation completes before OpenClaw injects history, starts a turn, or
-persists the native thread binding. On failure, OpenClaw deletes a persistent
+The check completes before OpenClaw injects history, starts a turn, or
+persists the native thread binding. If the snapshot request fails, OpenClaw deletes a persistent
 provisional thread with `thread/delete` or unsubscribes an ephemeral thread
 with `thread/unsubscribe`. If safe cleanup cannot be confirmed, it retires the
 owning app-server connection. Supervised branches also clean up their temporary

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -23,12 +23,13 @@ policy. OpenClaw caches a runtime-and-workspace-scoped `plugin/installed`
 snapshot, reads exact configured plugin details, provisionally admits only
 explicitly allowed, ownership-proven apps, and creates a deny-by-default
 native thread. One `app/installed` request verifies the actual thread ID
-without forcing an inventory refresh. Native app execution begins only after
-Codex confirms the app is enabled and callable for that thread.
+without forcing an inventory refresh. Missing, disabled, or non-callable apps
+produce one warning; the conversation continues with the remaining tools.
+Codex still enforces app and tool permissions for the actual thread.
 
 This check finishes before OpenClaw injects history, starts a turn, or commits a
-thread binding. Failed persistent provisional threads are deleted; ephemeral
-threads are unsubscribed. OpenClaw retires the app-server connection when safe
+thread binding. If the snapshot request fails, persistent provisional threads
+are deleted and ephemeral threads are unsubscribed. OpenClaw retires the app-server connection when safe
 cleanup cannot be confirmed. Supervised branches also clean up their temporary
 probe and preserve recovery state if cleanup fails.
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -1166,14 +1166,14 @@ An authorized app can initially appear disabled or non-callable because Codex
 has not yet applied the target thread's restrictive app configuration.
 OpenClaw provisionally admits only explicitly allowed, ownership-proven apps,
 starts the thread with `_default.enabled = false`, and reads `app/installed`
-once with that thread's ID and `forceRefresh: false`. An app is exposed only
-after Codex confirms it is enabled and callable for the actual thread. Missing
-metadata, revoked auth, managed restrictions, workspace policy, and unavailable
-tools remain fail-closed.
+once with that thread's ID and `forceRefresh: false`. Missing, disabled, or
+non-callable apps produce one warning without blocking unrelated chat or
+heartbeat runs. Codex still enforces app/tool permissions, managed restrictions,
+and workspace policy; continuing the conversation does not enable an unavailable app.
 
-The check runs before OpenClaw starts a turn or commits a thread binding. A
-failed persistent provisional thread is deleted; an ephemeral thread is
-unsubscribed. If cleanup cannot be confirmed, OpenClaw retires the app-server
+The check runs before OpenClaw starts a turn or commits a thread binding. If the
+snapshot request fails, a persistent provisional thread is deleted and an
+ephemeral thread is unsubscribed. If cleanup cannot be confirmed, OpenClaw retires the app-server
 connection instead of reusing an unsafe thread.
 
 Account-wide app access never overrides an explicitly disabled configured

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -401,12 +401,16 @@ An app can be installed and authenticated but non-callable in the account-wide
 snapshot while `_default` is disabled. OpenClaw provisionally admits only
 ownership-proven, policy-allowed apps, creates the restrictive thread, and then
 rereads `app/installed` once with the resulting thread ID and
-`forceRefresh: false`. Codex must confirm each admitted app is enabled and
-callable under the thread's effective app, managed, workspace, and tool
-policies before the turn proceeds. If that attestation fails, the provisional
-thread is never bound or used. OpenClaw deletes a failed persistent provisional
-thread, unsubscribes a failed ephemeral thread, and retires the app-server
-connection if safe cleanup cannot be confirmed.
+`forceRefresh: false`. If the snapshot reports an app missing, disabled, or
+non-callable, OpenClaw logs one warning listing the unavailable apps and
+continues with the remaining tools. Codex still enforces the thread's effective
+app, managed, workspace, and tool policies. An unavailable optional app does
+not block unrelated chat or heartbeat runs.
+
+If the snapshot request itself fails, the provisional thread is never bound
+or used. OpenClaw deletes a failed persistent provisional thread, unsubscribes
+a failed ephemeral thread, and retires the app-server connection if safe
+cleanup cannot be confirmed.
 
 `destructive_enabled` on each app comes from the effective global or
 per-plugin `allow_destructive_actions` policy; `true`, `"auto"`, and `"ask"`

--- a/extensions/codex/src/app-server/canonical-session-fork.ts
+++ b/extensions/codex/src/app-server/canonical-session-fork.ts
@@ -16,7 +16,7 @@ import {
   type CodexAppServerLiveThreadOwnership,
 } from "./client-runtime.js";
 import { parseCodexNativeToolCatalog } from "./native-tool-catalog.js";
-import { attestCodexPluginThreadApps } from "./plugin-thread-attestation.js";
+import { checkCodexThreadAppAvailability } from "./plugin-thread-attestation.js";
 import { assertCodexThreadForkResponse } from "./protocol-validators.js";
 import { flattenCodexDynamicToolFunctions } from "./protocol.js";
 import { CodexAppServerScopedRequestRejectedError } from "./request.js";
@@ -259,7 +259,7 @@ export async function forkCanonicalCodexSession(params: {
           }
           await snapshot.assertUnchanged();
           assertCurrent();
-          await attestCodexPluginThreadApps({
+          await checkCodexThreadAppAvailability({
             client: context.client,
             threadId: freshThreadId,
             appIds: prepared.provisionalAppIds,

--- a/extensions/codex/src/app-server/plugin-thread-attestation.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-attestation.test.ts
@@ -1,119 +1,104 @@
-import { describe, expect, it, vi } from "vitest";
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  attestCodexPluginThreadApps,
+  checkCodexThreadAppAvailability,
   discardUnattestedCodexPluginThread,
 } from "./plugin-thread-attestation.js";
 import type { v2 } from "./protocol.js";
 
-describe("Codex plugin thread app attestation", () => {
-  it("reads the committed snapshot with the started thread's effective policy", async () => {
-    const request = vi.fn(async () => installedApps(["linear-app"]));
+describe("Codex thread app availability", () => {
+  afterEach(() => vi.restoreAllMocks());
 
-    await attestCodexPluginThreadApps({
-      client: { request } as never,
-      threadId: "thread-linear",
-      appIds: ["linear-app", "linear-app"],
-    });
-
-    expect(request).toHaveBeenCalledExactlyOnceWith(
-      "app/installed",
-      { threadId: "thread-linear", forceRefresh: false },
-      { signal: undefined },
-    );
-  });
-
-  it("attests configured plugin and account apps against one thread snapshot", async () => {
+  it("checks configured and account apps once using the thread policy", async () => {
     const request = vi.fn(async () => installedApps(["plugin-app", "account-app"]));
-
-    await attestCodexPluginThreadApps({
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+    await checkCodexThreadAppAvailability({
       client: { request } as never,
-      threadId: "thread-mixed-apps",
+      threadId: "thread-mixed",
       appIds: ["plugin-app", "account-app", "plugin-app"],
     });
-
     expect(request).toHaveBeenCalledExactlyOnceWith(
       "app/installed",
-      { threadId: "thread-mixed-apps", forceRefresh: false },
+      { threadId: "thread-mixed", forceRefresh: false },
       { signal: undefined },
     );
+    expect(warn).not.toHaveBeenCalled();
   });
 
-  it("rejects a mixed snapshot when the thread denies its account-wide app", async () => {
-    const request = vi.fn(async () => installedApps(["plugin-app"]));
-
-    await expect(
-      attestCodexPluginThreadApps({
-        client: { request } as never,
-        threadId: "thread-mixed-apps",
-        appIds: ["plugin-app", "account-app"],
-      }),
-    ).rejects.toMatchObject({
-      name: "CodexPluginThreadAppAttestationError",
-      message: expect.stringContaining("account-app:missing"),
+  it("records unavailable apps without blocking the remaining tools", async () => {
+    const request = vi.fn(async () => ({
+      apps: [
+        ...installedApps(["working"]).apps,
+        ...installedApps(["disabled"], { enabled: false, callable: false }).apps,
+        ...installedApps(["readonly"], { callable: false }).apps,
+      ],
+    }));
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+    await checkCodexThreadAppAvailability({
+      client: { request } as never,
+      threadId: "thread-mixed",
+      appIds: ["working", "readonly", "missing", "disabled", "missing"],
     });
-
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      "codex apps unavailable; continuing with remaining tools",
+      {
+        threadId: "thread-mixed",
+        failures: ["disabled:disabled", "missing:missing", "readonly:not-callable"],
+      },
+    );
     expect(request).toHaveBeenCalledOnce();
   });
 
-  it("does not read the app snapshot when no apps need attestation", async () => {
+  it("does not read the app snapshot when no apps are configured", async () => {
     const request = vi.fn();
-
-    await attestCodexPluginThreadApps({
+    await checkCodexThreadAppAvailability({
       client: { request } as never,
-      threadId: "thread-linear",
+      threadId: "thread-empty",
       appIds: [],
     });
-
     expect(request).not.toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      state: "missing",
-      response: installedApps([]),
-      failure: "linear-app:missing",
-    },
-    {
-      state: "disabled",
-      response: installedApps(["linear-app"], { enabled: false, callable: false }),
-      failure: "linear-app:disabled",
-    },
-    {
-      state: "not callable",
-      response: installedApps(["linear-app"], { callable: false }),
-      failure: "linear-app:not-callable",
-    },
-  ])("fails closed when an admitted app is $state", async ({ response, failure }) => {
-    await expect(
-      attestCodexPluginThreadApps({
-        client: { request: vi.fn(async () => response) } as never,
-        threadId: "thread-linear",
-        appIds: ["linear-app"],
-      }),
-    ).rejects.toMatchObject({
-      name: "CodexPluginThreadAppAttestationError",
-      message: expect.stringContaining(failure),
+  it("preserves snapshot request failures and their cause", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+    const cause = new Error("app inventory offline");
+    const request = vi.fn(async () => {
+      throw cause;
     });
+    await expect(
+      checkCodexThreadAppAvailability({
+        client: { request } as never,
+        threadId: "thread-unavailable",
+        appIds: ["plugin-app"],
+      }),
+    ).rejects.toMatchObject({ name: "CodexPluginThreadAppAttestationError", cause });
+    expect(warn).not.toHaveBeenCalled();
   });
 
-  it("preserves the original cause when thread-scoped discovery fails", async () => {
-    const cause = new Error("committed app snapshot unavailable");
-
-    await expect(
-      attestCodexPluginThreadApps({
-        client: {
-          request: vi.fn(async () => {
-            throw cause;
-          }),
-        } as never,
-        threadId: "thread-linear",
-        appIds: ["linear-app"],
-      }),
-    ).rejects.toMatchObject({
-      name: "CodexPluginThreadAppAttestationError",
-      cause,
-    });
-  });
+  it.each(["resolve", "reject"])(
+    "preserves cancellation when discovery will %s",
+    async (outcome) => {
+      const abort = new AbortController();
+      const cause = new Error("turn cancelled");
+      const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+      const request = vi.fn(async () => {
+        abort.abort(cause);
+        if (outcome === "reject") {
+          throw cause;
+        }
+        return installedApps([]);
+      });
+      await expect(
+        checkCodexThreadAppAvailability({
+          client: { request } as never,
+          threadId: "thread-cancelled",
+          appIds: ["plugin-app"],
+          signal: abort.signal,
+        }),
+      ).rejects.toBe(cause);
+      expect(warn).not.toHaveBeenCalled();
+    },
+  );
 });
 
 describe("unattested Codex plugin thread cleanup", () => {

--- a/extensions/codex/src/app-server/plugin-thread-attestation.ts
+++ b/extensions/codex/src/app-server/plugin-thread-attestation.ts
@@ -1,6 +1,5 @@
 /**
- * Confirms admitted plugin and account apps against their actual Codex thread before
- * OpenClaw commits a binding or starts a turn.
+ * Checks app availability and enforces restricted MCP surfaces before a turn.
  */
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
@@ -14,7 +13,7 @@ import { attestCodexRestrictedToolSurfaceMcpServersDisabled } from "./thread-mcp
 
 /** Every admission path checks the same surface; its lifecycle owner keeps the claim fenced. */
 export async function attestCodexThreadToolSurface(
-  params: Parameters<typeof attestCodexPluginThreadApps>[0] & {
+  params: Parameters<typeof checkCodexThreadAppAvailability>[0] & {
     threadConfig?: JsonObject;
     restrictedToolSurface: boolean;
     lifecycleTiming: CodexThreadLifecycleTimingTracker;
@@ -24,7 +23,7 @@ export async function attestCodexThreadToolSurface(
   params.assertCurrent();
   if (params.appIds.length > 0) {
     await params.lifecycleTiming.measure("plugin-app-attestation", () =>
-      attestCodexPluginThreadApps(params),
+      checkCodexThreadAppAvailability(params),
     );
     params.assertCurrent();
   }
@@ -51,7 +50,7 @@ class CodexPluginThreadAppAttestationError extends Error {
 }
 
 /** Reads the existing runtime snapshot with the started thread's effective app policy. */
-export async function attestCodexPluginThreadApps(params: {
+export async function checkCodexThreadAppAvailability(params: {
   client: CodexAppServerClient;
   threadId: string;
   appIds: readonly string[];
@@ -70,11 +69,13 @@ export async function attestCodexPluginThreadApps(params: {
       { signal: params.signal },
     );
   } catch (error) {
+    params.signal?.throwIfAborted();
     throw new CodexPluginThreadAppAttestationError(
       `Codex could not confirm admitted apps for thread ${params.threadId}`,
       { cause: error },
     );
   }
+  params.signal?.throwIfAborted();
 
   const installedById = new Map(response.apps.map((app) => [app.id, app] as const));
   const failures = appIds.flatMap((appId): string[] => {
@@ -88,9 +89,12 @@ export async function attestCodexPluginThreadApps(params: {
     return app.callable ? [] : [`${appId}:not-callable`];
   });
   if (failures.length > 0) {
-    throw new CodexPluginThreadAppAttestationError(
-      `Codex thread ${params.threadId} did not expose admitted apps: ${failures.join(", ")}`,
-    );
+    // Availability is not authorization: Codex still filters and checks each tool.
+    // An optional app with no allowed tools must not prevent unrelated chat or heartbeats.
+    embeddedAgentLog.warn("codex apps unavailable; continuing with remaining tools", {
+      threadId: params.threadId,
+      failures,
+    });
   }
 }
 

--- a/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
@@ -792,15 +792,15 @@ describe("Codex app inventory across physical process restart", () => {
   });
 
   it.each(["cold", "warm"])(
-    "attests provisional apps on the %s loaded thread",
+    "keeps the %s loaded thread when an optional app is disabled",
     async (lifecycle) => {
       const f = await continuation(false, lifecycle);
       const previousBinding = f.readBinding();
       f.process.disabledThreadApps.add(f.first.threadId);
       const boundary = f.calls.length;
-      await expect(f.process.run()).rejects.toThrow("did not expose admitted apps");
-      expect(f.readBinding()).toEqual(previousBinding);
-      expect(f.process.subscribedThreads.has(f.first.threadId)).toBe(false);
+      await expect(f.process.run()).resolves.toMatchObject({ threadId: f.first.threadId });
+      expect(f.readBinding()).toMatchObject({ threadId: previousBinding!.threadId });
+      expect(f.process.subscribedThreads.has(f.first.threadId)).toBe(true);
       expect(f.calls.slice(boundary).some((call) => call.method === "thread/start")).toBe(false);
     },
   );

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -3375,28 +3375,27 @@ describe("Codex thread-effective app attestation", () => {
     },
   );
 
-  it.each([
-    {
-      state: "missing",
-      apps: [],
-      failure: "linear-app:missing",
-    },
-    {
-      state: "disabled by managed or workspace policy",
-      apps: [{ id: "linear-app", runtimeName: "Linear", enabled: false, callable: false }],
-      failure: "linear-app:disabled",
-    },
-    {
-      state: "not callable under thread policy",
-      apps: [{ id: "linear-app", runtimeName: "Linear", enabled: true, callable: false }],
-      failure: "linear-app:not-callable",
-    },
-  ])("deletes the unbound persistent thread when its app is $state", async ({ apps, failure }) => {
+  it.each(
+    ["chat", "heartbeat", "incognito"].flatMap((source) =>
+      ["missing", "disabled", "not-callable"].map((state) => ({
+        source,
+        state,
+      })),
+    ),
+  )("keeps the $source binding when its optional app is $state", async ({ source, state }) => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
-    const abandonClient = vi.fn(async () => undefined);
-    const request = vi.fn(
-      async (method: string, _requestParams?: unknown, _requestOptions?: unknown) => {
+    params.sessionKey =
+      source === "heartbeat"
+        ? "agent:main:main"
+        : source === "incognito"
+          ? "agent:main:internal-session-effects:incognito-app-unavailable"
+          : "agent:main:dashboard:app-unavailable";
+    const provider = createProvisionalPluginThreadConfigProvider("linear-app");
+    const expectedConfig = (await provider.build()).configPatch;
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond: (method, requestParams) => {
         if (method === "config/read") {
           return { config: {}, origins: {}, layers: [] };
         }
@@ -3404,40 +3403,39 @@ describe("Codex thread-effective app attestation", () => {
           return { requirements: null };
         }
         if (method === "thread/start") {
-          return threadStartResult("thread-linear-blocked");
+          expect(requestParams).toMatchObject({ config: expectedConfig });
+          return threadStartResult("thread-app-unavailable");
         }
         if (method === "app/installed") {
-          return { apps };
-        }
-        if (method === "thread/delete") {
-          return {};
+          return {
+            apps:
+              state === "missing"
+                ? []
+                : [
+                    {
+                      id: "linear-app",
+                      runtimeName: "Linear",
+                      enabled: state !== "disabled",
+                      callable: false,
+                    },
+                  ],
+          };
         }
         throw new Error(`unexpected method: ${method}`);
       },
-    );
-
-    await expect(
-      startOrResumeThread({
-        client: { request } as never,
-        abandonClient,
-        params,
-        cwd: workspaceDir,
-        dynamicTools: [],
-        appServer: createThreadLifecycleAppServerOptions(),
-        pluginThreadConfig: createProvisionalPluginThreadConfigProvider("linear-app"),
-      }),
-    ).rejects.toThrow(failure);
-
-    expect(request.mock.calls.map(([method]) => method)).toEqual([
-      "config/read",
-      "configRequirements/read",
-      "thread/start",
-      "app/installed",
-      "thread/delete",
-    ]);
-    expect(request.mock.calls[4]?.[1]).toEqual({ threadId: "thread-linear-blocked" });
-    expect(request.mock.calls[4]?.[2]).toEqual({ timeoutMs: 5_000 });
-    expect(abandonClient).not.toHaveBeenCalled();
+    });
+    const abandonClient = vi.fn(async () => {});
+    const result = await startOrResumeThread({
+      client: fixture.client,
+      abandonClient,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createThreadLifecycleAppServerOptions(),
+      pluginThreadConfig: provider,
+      signal: new AbortController().signal,
+    });
+    expect(result.threadId).toBe("thread-app-unavailable");
     expect(
       testCodexAppServerBindingStore.read(
         sessionBindingIdentity({
@@ -3447,103 +3445,14 @@ describe("Codex thread-effective app attestation", () => {
           config: params.config,
         }),
       ),
-    ).toBeUndefined();
+    ).toMatchObject({ threadId: result.threadId });
+    expect(
+      fixture.request.mock.calls.some(
+        ([method]) => method === "thread/delete" || method === "thread/unsubscribe",
+      ),
+    ).toBe(false);
+    expect(abandonClient).not.toHaveBeenCalled();
   });
-
-  it.each([
-    {
-      source: "globally ready configured plugin",
-      createProvider: createProvisionalPluginThreadConfigProvider,
-      state: "disabled by thread policy",
-      enabled: false,
-      callable: false,
-      failure: "global-ready-app:disabled",
-    },
-    {
-      source: "globally ready account-wide app",
-      createProvider: createAttestedAccountAppThreadConfigProvider,
-      state: "disabled by thread policy",
-      enabled: false,
-      callable: false,
-      failure: "global-ready-app:disabled",
-    },
-    {
-      source: "globally ready configured plugin",
-      createProvider: createProvisionalPluginThreadConfigProvider,
-      state: "not callable under thread policy",
-      enabled: true,
-      callable: false,
-      failure: "global-ready-app:not-callable",
-    },
-    {
-      source: "globally ready account-wide app",
-      createProvider: createAttestedAccountAppThreadConfigProvider,
-      state: "not callable under thread policy",
-      enabled: true,
-      callable: false,
-      failure: "global-ready-app:not-callable",
-    },
-  ])(
-    "rejects a $source when it is $state in the actual thread",
-    async ({ createProvider, enabled, callable, failure }) => {
-      const workspaceDir = path.join(tempDir, "workspace");
-      const params = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
-      const abandonClient = vi.fn(async () => undefined);
-      const request = vi.fn(async (method: string, requestParams?: unknown) => {
-        if (method === "config/read") {
-          return { config: {}, origins: {}, layers: [] };
-        }
-        if (method === "configRequirements/read") {
-          return { requirements: null };
-        }
-        if (method === "thread/start") {
-          return threadStartResult("thread-global-ready");
-        }
-        if (method === "app/installed") {
-          expect(requestParams).toEqual({ threadId: "thread-global-ready", forceRefresh: false });
-          return {
-            apps: [{ id: "global-ready-app", runtimeName: "Global App", enabled, callable }],
-          };
-        }
-        if (method === "thread/delete") {
-          return {};
-        }
-        throw new Error(`unexpected method: ${method}`);
-      });
-
-      await expect(
-        startOrResumeThread({
-          client: { request } as never,
-          abandonClient,
-          params,
-          cwd: workspaceDir,
-          dynamicTools: [],
-          appServer: createThreadLifecycleAppServerOptions(),
-          pluginThreadConfig: createProvider("global-ready-app"),
-        }),
-      ).rejects.toThrow(failure);
-
-      expect(request.mock.calls.map(([method]) => method)).toEqual([
-        "config/read",
-        "configRequirements/read",
-        "thread/start",
-        "app/installed",
-        "thread/delete",
-      ]);
-      expect(abandonClient).not.toHaveBeenCalled();
-      expect(
-        testCodexAppServerBindingStore.read(
-          sessionBindingIdentity({
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            agentId: params.agentId,
-            config: params.config,
-          }),
-        ),
-      ).toBeUndefined();
-    },
-  );
-
   it("retires the client when a persistent unattested thread cannot be deleted", async () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
@@ -3559,7 +3468,7 @@ describe("Codex thread-effective app attestation", () => {
         return threadStartResult("thread-linear-unsafe");
       }
       if (method === "app/installed") {
-        return { apps: [] };
+        throw new Error("app inventory offline");
       }
       if (method === "thread/delete") {
         throw new Error("delete unavailable");
@@ -3641,7 +3550,7 @@ describe("Codex thread-effective app attestation", () => {
     expect(abandonClient).not.toHaveBeenCalled();
   });
 
-  it("unsubscribes an ephemeral thread when its app cannot be attested", async () => {
+  it("unsubscribes an ephemeral thread when its app snapshot request fails", async () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.sessionKey = "agent:main:internal-session-effects:incognito-plugin-attestation";
@@ -3658,7 +3567,7 @@ describe("Codex thread-effective app attestation", () => {
         return threadStartResult("thread-linear-ephemeral");
       }
       if (method === "app/installed") {
-        return { apps: [] };
+        throw new Error("app inventory offline");
       }
       if (method === "thread/unsubscribe") {
         return {};
@@ -3676,7 +3585,7 @@ describe("Codex thread-effective app attestation", () => {
         appServer: createThreadLifecycleAppServerOptions(),
         pluginThreadConfig: createProvisionalPluginThreadConfigProvider("linear-app"),
       }),
-    ).rejects.toThrow("linear-app:missing");
+    ).rejects.toThrow("Codex could not confirm admitted apps");
 
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "config/read",
@@ -3704,7 +3613,7 @@ describe("Codex thread-effective app attestation", () => {
         return threadStartResult("thread-linear-ephemeral-unsafe");
       }
       if (method === "app/installed") {
-        return { apps: [] };
+        throw new Error("app inventory offline");
       }
       if (method === "thread/unsubscribe") {
         throw new Error("unsubscribe unavailable");
@@ -4721,46 +4630,40 @@ describe("Codex app-server supervised branch lifecycle", () => {
       createProvider: createProvisionalPluginThreadConfigProvider,
       state: "missing from the effective thread",
       apps: [],
-      failure: "linear-app:missing",
     },
     {
       source: "account-wide policy",
       createProvider: createAttestedAccountAppThreadConfigProvider,
       state: "missing from the effective thread",
       apps: [],
-      failure: "linear-app:missing",
     },
     {
       source: "configured plugin",
       createProvider: createProvisionalPluginThreadConfigProvider,
       state: "disabled by managed or workspace policy",
       apps: [{ id: "linear-app", runtimeName: "Linear", enabled: false, callable: false }],
-      failure: "linear-app:disabled",
     },
     {
       source: "account-wide policy",
       createProvider: createAttestedAccountAppThreadConfigProvider,
       state: "disabled by managed or workspace policy",
       apps: [{ id: "linear-app", runtimeName: "Linear", enabled: false, callable: false }],
-      failure: "linear-app:disabled",
     },
     {
       source: "configured plugin",
       createProvider: createProvisionalPluginThreadConfigProvider,
       state: "not callable under thread policy",
       apps: [{ id: "linear-app", runtimeName: "Linear", enabled: true, callable: false }],
-      failure: "linear-app:not-callable",
     },
     {
       source: "account-wide policy",
       createProvider: createAttestedAccountAppThreadConfigProvider,
       state: "not callable under thread policy",
       apps: [{ id: "linear-app", runtimeName: "Linear", enabled: true, callable: false }],
-      failure: "linear-app:not-callable",
     },
   ])(
-    "cleans both supervised branches when a $source app is $state",
-    async ({ createProvider, apps, failure }) => {
+    "keeps the supervised branch when a $source app is $state",
+    async ({ createProvider, apps }) => {
       const sourceThreadId = "thread-source";
       const probeThreadId = "thread-probe";
       const finalThreadId = "thread-final";
@@ -4811,7 +4714,7 @@ describe("Codex app-server supervised branch lifecycle", () => {
           appServer: createThreadLifecycleAppServerOptions(),
           pluginThreadConfig: createProvider("linear-app"),
         }),
-      ).rejects.toThrow(failure);
+      ).resolves.toMatchObject({ threadId: finalThreadId, lifecycle: { action: "forked" } });
 
       expect(request.mock.calls.map(([method]) => method)).toEqual([
         "config/read",
@@ -4821,18 +4724,15 @@ describe("Codex app-server supervised branch lifecycle", () => {
         "thread/unsubscribe",
         "thread/start",
         "app/installed",
-        "thread/delete",
       ]);
       expect(request.mock.calls[4]?.[1]).toEqual({ threadId: probeThreadId });
-      expect(request.mock.calls[7]?.[1]).toEqual({ threadId: finalThreadId });
       expect(abandonClient).not.toHaveBeenCalled();
       expect(testCodexAppServerBindingStore.read(identity)).toMatchObject({
-        pendingSupervisionBranch: { sourceThreadId },
+        threadId: finalThreadId,
       });
       expect(
-        testCodexAppServerBindingStore.read(identity)?.pendingSupervisionBranch?.cleanupThreadIds ??
-          [],
-      ).toEqual([]);
+        testCodexAppServerBindingStore.read(identity)?.pendingSupervisionBranch,
+      ).toBeUndefined();
     },
   );
 
@@ -4865,7 +4765,7 @@ describe("Codex app-server supervised branch lifecycle", () => {
         return nativeThreadResult(finalThreadId, "native-effective", "native-provider");
       }
       if (method === "app/installed") {
-        return { apps: [] };
+        throw new Error("app inventory offline");
       }
       if (method === "thread/delete") {
         throw new Error("delete unavailable");

--- a/extensions/codex/src/app-server/thread-supervision.ts
+++ b/extensions/codex/src/app-server/thread-supervision.ts
@@ -16,7 +16,7 @@ import { CodexAppServerRpcError, type CodexAppServerClient } from "./client.js";
 import type { CodexAppServerRuntimeOptions } from "./config.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
 import {
-  attestCodexPluginThreadApps,
+  checkCodexThreadAppAvailability,
   discardUnattestedCodexPluginThread,
 } from "./plugin-thread-attestation.js";
 import {
@@ -299,7 +299,7 @@ export async function materializePendingSupervisionBranch(
     if (params.provisionalAppIds?.length) {
       try {
         await params.lifecycleTiming.measure("plugin-app-attestation", () =>
-          attestCodexPluginThreadApps({
+          checkCodexThreadAppAvailability({
             client: params.client,
             threadId: finalThreadId,
             appIds: params.provisionalAppIds ?? [],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ordinary Codex conversations and heartbeat runs fail before the model can respond when a configured plugin app is missing, disabled, or has no callable tools in the thread's `app/installed` snapshot. An unavailable optional app currently aborts the entire turn, even when the request does not need that app.

## Why This Change Was Made

Treat a successful snapshot reporting unavailable apps as an availability diagnostic: log one warning containing the affected app IDs and reasons, then continue with the remaining tools. The shared check covers new threads, warm/cold continuations, and forks; it is renamed to reflect that responsibility.

The restrictive thread configuration and Codex's per-tool enforcement remain in place. RPC failures, cancellation, ownership fencing, restricted MCP validation, and scheduled app-authority checks retain their failure behavior. This adds no configuration, retry, notification, model prompt, or persistent warning state.

## User Impact

An unavailable optional app no longer blocks unrelated conversations or heartbeats. Operators get a warning through the existing logger. Continuing a turn neither enables the unavailable app nor claims it was successfully invoked; tool discovery and invocation results remain the model's evidence for its response.

## Evidence

- Regression proof: restoring the original fatal unavailable-app branch makes `records unavailable apps without blocking the remaining tools` fail with `CodexPluginThreadAppAttestationError`; the candidate passes.
- Five focused test files pass: **255 tests**, including chat/heartbeat/incognito admission, warm/cold continuity, supervised and upstream forks, snapshot RPC cleanup, cancellation/ownership fences, restricted MCP checks, and revoked scheduled authority.
- Command: `node scripts/run-vitest.mjs extensions/codex/src/app-server/plugin-thread-attestation.test.ts extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/upstream-session-fork.test.ts extensions/codex/src/app-server/upstream-session-fork-continuation.test.ts`.
- Formatting, diff whitespace, conflict-marker, plugin-boundary, dependency-pin, and applicable guard checks passed. `check:changed` stops at extension typecheck: candidate and unmodified base both report the same **72** diagnostics (missing/stale shared dependencies, no candidate-only diagnostic). The checkout uses a shared `node_modules`; changing it would affect other active worktrees. Extension-test typecheck is likewise blocked by shared dependencies (no diagnostics in the changed files). The focused lint wrapper is also blocked while generating SDK declarations from those dependencies. These checks remain incomplete; no suppressions or dependency changes are included.
- Repository-required autoreview completed with no actionable P0 findings (the workflow default scope).
- Dependency contract inspected directly in Codex: `codex-rs/connectors/src/runtime_projection.rs` computes app callability from visible, policy-allowed tools; `codex-rs/core/src/mcp_tool_call.rs` independently enforces app policy before dispatch.
- Live model/chat verification is not included: the affected deployment is restricted to read-only investigation, and the local test flow uses the repository's synthetic native server over its real JSON-RPC client and lease machinery. This remains a draft pending live acceptance; no deployment is included.

Production change: net +4 lines, for the aggregate warning and explicit abort checks; removes the fatal unavailable-app branch. Obsolete app-unavailability cleanup assertions are replaced with continuation assertions; RPC-error cleanup coverage remains.
