### PR TITLE
fix(workers): replacement turns stall after transcript commit

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -525,10 +525,11 @@ export async function withTranscriptWriteLock<T>(
 export async function withTranscriptWriteTransaction<T>(
   scope: SessionTranscriptWriteScope,
   run: (context: SessionTranscriptWriteTransactionContext) => T,
+  onCommitted?: (result: T) => void,
 ): Promise<T> {
   const resolved = resolveSqliteTranscriptScope(scope);
-  return await runExclusiveSqliteSessionWrite(resolved, async () =>
-    runOpenClawAgentWriteTransaction(
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    const result = runOpenClawAgentWriteTransaction(
       () =>
         run({
           agentId: resolved.agentId,
@@ -541,8 +542,11 @@ export async function withTranscriptWriteTransaction<T>(
         }),
       toDatabaseOptions(resolved),
       { operationLabel: "session.transcript.batch" },
-    ),
-  );
+    );
+    // Record committed progress before publication or teardown can close the caller.
+    onCommitted?.(result);
+    return result;
+  });
 }
 
 function isSqliteTranscriptSnapshotUnchanged(

--- a/src/gateway/worker-environments/service.test-support.ts
+++ b/src/gateway/worker-environments/service.test-support.ts
@@ -501,10 +501,14 @@ export function terminalEvent(identity: WorkerConnectionIdentity, overrides: Liv
 }
 
 export function successfulTranscriptCommit(entryId: string, beforeCommit?: () => Promise<unknown>) {
-  return vi.fn(async () => {
-    await beforeCommit?.();
-    return { ok: true as const, result: { entryIds: [entryId], newLeafId: entryId } };
-  });
+  return vi.fn<NonNullable<WorkerEnvironmentServiceOptions["applyTranscriptCommit"]>>(
+    async (params) => {
+      await beforeCommit?.();
+      const outcome = { ok: true as const, result: { entryIds: [entryId], newLeafId: entryId } };
+      params.onCommitted?.(outcome);
+      return outcome;
+    },
+  );
 }
 
 export function sequencedLiveEvents(ackedSeq = (seq: number) => seq) {

--- a/src/gateway/worker-environments/transcript-commit.test.ts
+++ b/src/gateway/worker-environments/transcript-commit.test.ts
@@ -548,6 +548,8 @@ describe("worker transcript commit application", () => {
   });
 
   it("recovers an interrupted terminal write after later transcript activity", async () => {
+    const updates: Parameters<Parameters<typeof onSessionTranscriptUpdate>[0]>[0][] = [];
+    unsubscribe = onSessionTranscriptUpdate((update) => updates.push(update));
     let interruptCompletion = true;
     const interruptedStore: WorkerTranscriptCommitStore = {
       ...ledgerStore,
@@ -571,6 +573,7 @@ describe("worker transcript commit application", () => {
     const afterInterruption = SessionManager.open(sessionTarget);
     const committedEntryIds = afterInterruption.getEntries().map((entry) => entry.id);
     expect(committedEntryIds).toHaveLength(request.messages.length);
+    expect(updates.map((update) => update.messageId)).toEqual(committedEntryIds);
     const laterLeafId = afterInterruption.appendMessage({
       role: "user",
       content: [{ type: "text", text: "Later local activity" }],
@@ -589,6 +592,7 @@ describe("worker transcript commit application", () => {
     const reopened = SessionManager.open(sessionTarget);
     expect(reopened.getEntries()).toHaveLength(request.messages.length + 1);
     expect(reopened.getLeafId()).toBe(laterLeafId);
+    expect(updates.map((update) => update.messageId)).toEqual(committedEntryIds);
   });
 
   it("replays an interrupted terminal write after its branch is abandoned", async () => {

--- a/src/gateway/worker-environments/transcript-commit.ts
+++ b/src/gateway/worker-environments/transcript-commit.ts
@@ -33,6 +33,7 @@ export type WorkerTranscriptCommitApplication = (params: {
   identity: WorkerConnectionIdentity;
   request: WorkerTranscriptCommitParams;
   assertCurrent: () => undefined;
+  onCommitted?: (outcome: WorkerTranscriptCommitOutcome) => void;
 }) => Promise<WorkerTranscriptCommitOutcome>;
 
 type WorkerTranscriptCommitterOptions = {
@@ -324,6 +325,7 @@ function resolvePersistedCommitAcrossDag(params: {
 
 async function applyWorkerTranscriptCommit(params: {
   assertCurrent: () => undefined;
+  complete: (applied: ApplyTranscriptCommitResult) => WorkerTranscriptCommitOutcome;
   config: OpenClawConfig;
   identity: WorkerConnectionIdentity;
   messages: readonly CommittedAgentMessage[];
@@ -332,7 +334,7 @@ async function applyWorkerTranscriptCommit(params: {
   runId: string | null;
   sessionId: string;
   target: ResolvedWorkerSessionTarget;
-}): Promise<ApplyTranscriptCommitResult> {
+}): Promise<WorkerTranscriptCommitOutcome> {
   const redactedMessages = params.messages.map((message) =>
     attachSessionTranscriptRunId(
       redactTranscriptMessage(message, params.config) as CommittedAgentMessage,
@@ -343,107 +345,115 @@ async function applyWorkerTranscriptCommit(params: {
     sessionId: params.sessionId,
     lifecycleRevision: params.target.sessionEntry.lifecycleRevision,
   };
-  let applied: ApplyTranscriptCommitResult;
+  let applied: ApplyTranscriptCommitResult | undefined;
+  let outcome!: WorkerTranscriptCommitOutcome;
   try {
-    applied = await withTranscriptWriteTransaction(params.target, (transcriptTarget) => {
-      params.assertCurrent();
-      const currentEntry = loadSessionEntry(params.target);
-      if (!currentEntry || currentEntry.sessionId !== expectedState.sessionId) {
-        return { ok: false as const, reason: "session-not-attached" as const };
-      }
-      if (currentEntry.lifecycleRevision !== expectedState.lifecycleRevision) {
-        return { ok: false as const, reason: "invalid-batch" as const };
-      }
+    await withTranscriptWriteTransaction(
+      params.target,
+      (transcriptTarget) => {
+        params.assertCurrent();
+        const currentEntry = loadSessionEntry(params.target);
+        if (!currentEntry || currentEntry.sessionId !== expectedState.sessionId) {
+          return { ok: false as const, reason: "session-not-attached" as const };
+        }
+        if (currentEntry.lifecycleRevision !== expectedState.lifecycleRevision) {
+          return { ok: false as const, reason: "invalid-batch" as const };
+        }
 
-      const manager = SessionManager.open(transcriptTarget);
-      if (params.recoverPersistedBatch) {
-        // Only a pending ledger row may prove an off-branch batch: the agent DB
-        // can commit before the shared replay ledger records its terminal result.
-        const recovered = resolvePersistedCommitAcrossDag({
+        const manager = SessionManager.open(transcriptTarget);
+        if (params.recoverPersistedBatch) {
+          // Only a pending ledger row may prove an off-branch batch: the agent DB
+          // can commit before the shared replay ledger records its terminal result.
+          const recovered = resolvePersistedCommitAcrossDag({
+            baseLeafId: params.requestedBaseLeafId,
+            manager,
+            messages: redactedMessages,
+          });
+          if (recovered.kind === "found") {
+            return { ok: true as const, messages: recovered.messages };
+          }
+          if (recovered.kind === "ambiguous") {
+            return { ok: false as const, reason: "invalid-batch" as const };
+          }
+        }
+        const prefix = resolveActiveCommitPrefix({
           baseLeafId: params.requestedBaseLeafId,
           manager,
           messages: redactedMessages,
         });
-        if (recovered.kind === "found") {
-          return { ok: true as const, messages: recovered.messages };
+        if (!prefix.ok) {
+          return { ok: false as const, reason: "stale-base-leaf" as const };
         }
-        if (recovered.kind === "ambiguous") {
-          return { ok: false as const, reason: "invalid-batch" as const };
-        }
-      }
-      const prefix = resolveActiveCommitPrefix({
-        baseLeafId: params.requestedBaseLeafId,
-        manager,
-        messages: redactedMessages,
-      });
-      if (!prefix.ok) {
-        return { ok: false as const, reason: "stale-base-leaf" as const };
-      }
 
-      const messages = [...prefix.recoveredMessages];
-      let nextMessageSeq = prefix.activeVisibleEntryCount;
-      for (const message of redactedMessages.slice(prefix.recoveredMessages.length)) {
-        if (message.role === "assistant") {
-          Object.assign(message, prepareWorkerTurnTranscriptMessage(params.identity, message));
+        const messages = [...prefix.recoveredMessages];
+        let nextMessageSeq = prefix.activeVisibleEntryCount;
+        for (const message of redactedMessages.slice(prefix.recoveredMessages.length)) {
+          if (message.role === "assistant") {
+            Object.assign(message, prepareWorkerTurnTranscriptMessage(params.identity, message));
+          }
+          const messageId = manager.appendMessage(message, {
+            config: params.config,
+            // Active-path recovery owns dedupe. A global key scan could reuse an
+            // id from an abandoned branch while SessionManager advances another id.
+            idempotencyLookup: "caller-checked",
+          });
+          nextMessageSeq += 1;
+          messages.push({
+            appended: true,
+            message,
+            messageId,
+            messageSeq: nextMessageSeq,
+          });
         }
-        const messageId = manager.appendMessage(message, {
-          config: params.config,
-          // Active-path recovery owns dedupe. A global key scan could reuse an
-          // id from an abandoned branch while SessionManager advances another id.
-          idempotencyLookup: "caller-checked",
-        });
-        nextMessageSeq += 1;
-        messages.push({
-          appended: true,
-          message,
-          messageId,
-          messageSeq: nextMessageSeq,
-        });
-      }
 
-      const freshEntry = loadSessionEntry(params.target);
-      if (
-        !freshEntry ||
-        freshEntry.sessionId !== expectedState.sessionId ||
-        freshEntry.lifecycleRevision !== expectedState.lifecycleRevision
-      ) {
-        throw WORKER_TRANSCRIPT_SESSION_CONFLICT;
-      }
-      const appendedCount = messages.filter((message) => message.appended).length;
-      const nextEntry = {
-        ...freshEntry,
-        ...(appendedCount > 0
-          ? { updatedAt: Math.max(freshEntry.updatedAt ?? 0, Date.now()) }
-          : {}),
-      };
-      replaceSessionEntrySync(params.target, nextEntry);
-      // Synchronous assistant preparation can close the owner after earlier rows were appended.
-      params.assertCurrent();
-      return { ok: true as const, messages };
-    });
+        const freshEntry = loadSessionEntry(params.target);
+        if (
+          !freshEntry ||
+          freshEntry.sessionId !== expectedState.sessionId ||
+          freshEntry.lifecycleRevision !== expectedState.lifecycleRevision
+        ) {
+          throw WORKER_TRANSCRIPT_SESSION_CONFLICT;
+        }
+        const appendedCount = messages.filter((message) => message.appended).length;
+        const nextEntry = {
+          ...freshEntry,
+          ...(appendedCount > 0
+            ? { updatedAt: Math.max(freshEntry.updatedAt ?? 0, Date.now()) }
+            : {}),
+        };
+        replaceSessionEntrySync(params.target, nextEntry);
+        // Synchronous assistant preparation can close the owner after earlier rows were appended.
+        params.assertCurrent();
+        return { ok: true as const, messages };
+      },
+      (committed) => {
+        applied = committed;
+        outcome = params.complete(committed);
+      },
+    );
   } catch (error) {
     if (error === WORKER_TRANSCRIPT_SESSION_CONFLICT) {
-      return { ok: false, reason: "invalid-batch" };
+      return params.complete({ ok: false, reason: "invalid-batch" });
     }
     throw error;
-  }
-  if (!applied.ok) {
-    return applied;
-  }
-
-  for (const message of applied.messages) {
-    if (!message.appended) {
-      continue;
+  } finally {
+    // Committed messages still need publication when replay bookkeeping fails.
+    if (applied?.ok) {
+      for (const message of applied.messages) {
+        if (!message.appended) {
+          continue;
+        }
+        const runId = resolveTerminalAssistantTranscriptRunId(message.message, params.runId);
+        await publishTranscriptUpdate(params.target, {
+          message: message.message,
+          messageId: message.messageId,
+          messageSeq: message.messageSeq,
+          ...(runId ? { runId } : {}),
+        });
+      }
     }
-    const runId = resolveTerminalAssistantTranscriptRunId(message.message, params.runId);
-    await publishTranscriptUpdate(params.target, {
-      message: message.message,
-      messageId: message.messageId,
-      messageSeq: message.messageSeq,
-      ...(runId ? { runId } : {}),
-    });
   }
-  return applied;
+  return outcome;
 }
 
 /** Applies ordered, idempotent semantic worker turns to the canonical session transcript. */
@@ -470,19 +480,22 @@ export function createWorkerTranscriptCommitter(options: WorkerTranscriptCommitt
       params.assertCurrent();
       const started = store.begin(input);
       if (started.kind === "replay") {
+        params.onCommitted?.(started.outcome);
         return started.outcome;
       }
       if (started.kind === "rejected") {
         return { ok: false, reason: "invalid-batch" };
       }
 
+      const complete = (outcome: WorkerTranscriptCommitOutcome) => {
+        const committed = store.complete({ ...input, outcome });
+        params.onCommitted?.(committed);
+        return committed;
+      };
       const config = options.getConfig();
       const target = resolveWorkerSessionTarget(config, sessionId);
       if (!target) {
-        return store.complete({
-          ...input,
-          outcome: { ok: false, reason: "session-not-attached" },
-        });
+        return complete({ ok: false, reason: "session-not-attached" });
       }
       const messages = params.request.messages.map((message, index) =>
         buildCommittedMessage(
@@ -496,9 +509,20 @@ export function createWorkerTranscriptCommitter(options: WorkerTranscriptCommitt
         ),
       );
       let authorityFailure: { error: unknown } | undefined;
-      let applied: ApplyTranscriptCommitResult;
       try {
-        applied = await applyWorkerTranscriptCommit({
+        return await applyWorkerTranscriptCommit({
+          complete: (applied) => {
+            if (!applied.ok) {
+              return complete({ ok: false, reason: applied.reason });
+            }
+            const entryIds = applied.messages.map((message) => message.messageId);
+            const newLeafId = entryIds.at(-1);
+            return complete(
+              entryIds.length === params.request.messages.length && newLeafId
+                ? { ok: true, result: { entryIds, newLeafId } }
+                : { ok: false, reason: "invalid-batch" },
+            );
+          },
           assertCurrent: () => {
             try {
               params.assertCurrent();
@@ -524,21 +548,6 @@ export function createWorkerTranscriptCommitter(options: WorkerTranscriptCommitt
         }
         throw error;
       }
-      if (!applied.ok) {
-        return store.complete({ ...input, outcome: { ok: false, reason: applied.reason } });
-      }
-      const entryIds = applied.messages.map((message) => message.messageId);
-      const newLeafId = entryIds.at(-1);
-      if (entryIds.length !== params.request.messages.length || !newLeafId) {
-        return store.complete({
-          ...input,
-          outcome: { ok: false, reason: "invalid-batch" },
-        });
-      }
-      return store.complete({
-        ...input,
-        outcome: { ok: true, result: { entryIds, newLeafId } },
-      });
     });
   };
 

--- a/src/gateway/worker-environments/worker-turn-rpc.test.ts
+++ b/src/gateway/worker-environments/worker-turn-rpc.test.ts
@@ -635,7 +635,11 @@ describe("worker environment service", () => {
   it("advances the transcript cursor when a stale-base commit consumes its sequence", async () => {
     const applyTranscriptCommit = vi
       .fn<NonNullable<WorkerEnvironmentServiceOptions["applyTranscriptCommit"]>>()
-      .mockResolvedValueOnce({ ok: false, reason: "stale-base-leaf" })
+      .mockImplementationOnce(async (params) => {
+        const outcome = { ok: false as const, reason: "stale-base-leaf" as const };
+        params.onCommitted?.(outcome);
+        return outcome;
+      })
       .mockResolvedValueOnce({ ok: false, reason: "invalid-batch" });
     const { identity, placementStore, workerService } = support.placementHarness(
       "worker-placement-stale",

--- a/src/gateway/worker-environments/worker-turn-rpc.transcript.test.ts
+++ b/src/gateway/worker-environments/worker-turn-rpc.transcript.test.ts
@@ -165,4 +165,109 @@ describe("worker transcript claim fences", () => {
       }
     },
   );
+
+  it.each(["released", "replaced"] as const)(
+    "preserves committed progress when the claim is fenced during publication: %s",
+    async (scenario) => {
+      const identity = support.seedAttachedIdentity(
+        "worker-publication-race",
+        "session-publication-race",
+      );
+      const { claim, store } = claimWorkerPlacement({
+        environmentId: identity.environmentId,
+        ownerEpoch: identity.ownerEpoch,
+        sessionId: "session-publication-race",
+      });
+      identity.turnClaim = claim;
+      const target = {
+        agentId: "main",
+        sessionId: claim.sessionId,
+        sessionKey: `agent:main:${claim.sessionId}`,
+        storePath: path.join(support.testState.root, "openclaw-agent.sqlite"),
+      };
+      await upsertSessionEntryCore(target, {
+        sessionId: claim.sessionId,
+        lifecycleRevision: "publication-race-lifecycle",
+        updatedAt: 1,
+      });
+      const committer = createWorkerTranscriptCommitter({
+        getConfig: () => ({ session: { store: target.storePath } }),
+        store: createWorkerTranscriptCommitStore({ database: support.testState.stateDb }),
+      });
+      const workerService = support.createService(support.createProvider(), {
+        placementStore: createWorkerSessionPlacementGate(store),
+        applyTranscriptCommit: committer.commit,
+      });
+      const published = createDeferredCore();
+      const updates: unknown[] = [];
+      const unsubscribe = onSessionTranscriptUpdate((update) => {
+        if (update.sessionId === claim.sessionId) {
+          updates.push(update);
+          published.resolve();
+        }
+      });
+      let replacement: WorkerSessionTurnClaim | undefined;
+      const replace = () =>
+        store.claimTurn({
+          ...target,
+          claimId: "replacement-publication-claim",
+          runId: "replacement-publication-run",
+          owner: claim.owner,
+        });
+      try {
+        const firstRequest = support.transcriptRequest(identity, "committed before closure");
+        const committing = workerService.commitTranscript(identity, firstRequest);
+        await published.promise;
+        expect(SessionManager.open(target).getEntries()).toHaveLength(1);
+        store.releaseTurn(claim);
+        if (scenario === "replaced") {
+          replacement = replace();
+        }
+        await expect(committing).resolves.toEqual({ ok: false, closeReason: "placement-mismatch" });
+        const cursorAfterCommit = store.get(claim.sessionId)?.lastTranscriptAckCursor;
+        replacement ??= replace();
+        const credential = await workerService.acquireTurnCredential(replacement);
+        expect(credential.ownerEpoch).toBe(identity.ownerEpoch);
+        expect(workerService.acknowledgeCredentialDelivery(credential)).toBe(true);
+        const admitted = await workerService.admitWorker({
+          environmentId: identity.environmentId,
+          credential: credential.credential,
+          sessionId: claim.sessionId,
+          runId: replacement.runId,
+          ownerEpoch: credential.ownerEpoch,
+          rpcSetVersion: 1,
+          handshake: support.BOOTSTRAP_RECEIPT,
+        });
+        if (!admitted.ok) {
+          throw new Error("replacement worker was not admitted");
+        }
+        const nextSeq = (store.get(claim.sessionId)?.lastTranscriptAckCursor ?? 0) + 1;
+        const replacementResult = await workerService.commitTranscript(
+          admitted.identity,
+          support.transcriptRequest(admitted.identity, "replacement progresses", {
+            seq: nextSeq,
+            baseLeafId: SessionManager.open(target).getLeafId(),
+          }),
+        );
+        expect({
+          cursorAfterCommit,
+          nextSeq,
+          replacementResult,
+          entryCount: SessionManager.open(target).getEntries().length,
+          updateCount: updates.length,
+        }).toMatchObject({
+          cursorAfterCommit: firstRequest.seq,
+          nextSeq: firstRequest.seq + 1,
+          replacementResult: { ok: true },
+          entryCount: 2,
+          updateCount: 2,
+        });
+      } finally {
+        unsubscribe();
+        if (store.validateTurnClaim(replacement ?? claim)) {
+          store.releaseTurn(replacement ?? claim);
+        }
+      }
+    },
+  );
 });

--- a/src/gateway/worker-environments/worker-turn-rpc.ts
+++ b/src/gateway/worker-environments/worker-turn-rpc.ts
@@ -387,23 +387,32 @@ export function createWorkerTurnRpc(options: WorkerTurnRpcOptions) {
         if (!options.applyTranscriptCommit) {
           return { ok: false, closeReason: "gateway-unavailable" };
         }
-        const result = await options.applyTranscriptCommit({ identity, request, assertCurrent });
-        // Persistence checks this owner after its queues and before commit; ACKs
-        // also require the claim to remain live after post-commit publication.
+        const result = await options.applyTranscriptCommit({
+          identity,
+          request,
+          assertCurrent,
+          onCommitted: (committed) => {
+            assertCurrent();
+            // Record consumed progress before publication can close this claim.
+            if (committed.ok || committed.reason === "stale-base-leaf") {
+              const placement = placementClaim(identity);
+              const processTurn = processTurnBinding(identity);
+              if (!placement || !processTurn) {
+                throw new WorkerTranscriptAuthorityError({
+                  ok: false,
+                  closeReason: "placement-mismatch",
+                });
+              }
+              options.placementStore?.updateAckCursors({
+                claim: placement,
+                transcriptSeq: request.seq,
+              });
+              recordAckCursor(processTurn, { transcriptSeq: request.seq });
+            }
+          },
+        });
+        // Committed progress survives closure; the revoked claim still receives no ACK.
         assertCurrent();
-        // Stale base consumes a sequence just like success, including on replay.
-        if (result.ok || result.reason === "stale-base-leaf") {
-          const placement = placementClaim(identity);
-          const processTurn = processTurnBinding(identity);
-          if (!placement || !processTurn) {
-            return { ok: false, closeReason: "placement-mismatch" };
-          }
-          options.placementStore?.updateAckCursors({
-            claim: placement,
-            transcriptSeq: request.seq,
-          });
-          recordAckCursor(processTurn, { transcriptSeq: request.seq });
-        }
         return result;
       } catch (error) {
         if (error instanceof WorkerTranscriptAuthorityError) {


### PR DESCRIPTION
Related: #135868 (found during review; separate existing worker bug).

## What Problem This Solves

Fixes an issue where a remote worker session could get stuck after its active turn was released or replaced while a committed transcript update was being published. The replacement could reuse a consumed transcript sequence and repeatedly fail with `invalid-batch`.

## Why This Change Was Made

The transcript writer now records the existing replay outcome and placement cursor immediately after its synchronous database commit, before publication yields. The old post-publication bookkeeping path is removed. Publication of committed messages is still attempted if replay bookkeeping fails; the bookkeeping error reaches the caller when publication succeeds. Publisher failures continue to propagate.

Exact live-claim checks still protect writes and cursor updates. A claim closed during publication receives no acknowledgement. The repair preserves existing schemas, stored representation, protocol, and recovery rules; it does not make the separate agent and shared databases atomic across a process crash.

## User Impact

A replacement turn in the same owner epoch starts with the next unconsumed transcript sequence and can continue the session. Revoked workers remain fenced.

## Evidence

Two real-owner regressions release or immediately replace the claim from the actual transcript publisher. Both failed before the repair: the first message was durable but its placement cursor remained null, so the replacement reused sequence 1 and failed. Both pass with the repair: the cursor is 1, the replacement uses sequence 2, and both messages remain in the transcript. The revoked request is rejected in both versions.

An existing interrupted-ledger recovery test now also verifies publication of all committed rows and no duplicate notifications on replay. That assertion passed on the original baseline, exposed a regression in the first repair draft, and passes with the final owner-level repair.

Validation on the final candidate:

- 54 passing tests across transcript RPC, transcript commit, replay ledger, and placement claim closure suites, including the existing pre-commit closure and transaction rollback cases.
- Four passing real WebSocket fault-injection cases covering repeated partitions, Gateway restart, worker replacement, and an in-flight base change. These use the real dispatcher, SQLite stores, and claim owners with synthetic worker provisioning and inference; 11 unrelated cases were filtered out.
- `check:changed --staged` passed against the pinned main baseline, including core and core-test typechecks, changed-file formatting/lint, dead-code scans, and selected repository guards.
- Canonical independent Codex review completed both evidence passes with no actionable P0–P2 findings.

These are local owner and WebSocket proofs, not an authenticated provider or full installed-Gateway run. No stable-release affectedness or backport claim is made.

Production LOC: +149/-127 (net +22); tests/support: +122/-5 (net +117). The production growth supplies a synchronous post-commit callback at the existing transaction owner and carries completion to the cursor owner. Moving the response check alone cannot repair this because the cursor gate itself requires the exact live claim.
