### PR TITLE
fix: keep pairing for bootstrap-token when auth.mode is none

### DIFF
--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -153,6 +153,21 @@ describe("ws connect policy", () => {
   test("auth.mode=none skips pairing for operator control-ui only", () => {
     // Control UI + operator + auth.mode=none: skip pairing (the fix for #42931)
     expectSkipPairing({ isControlUi: true, role: "operator", authMode: "none" }, "auth-none");
+    // Explicit none method (credential-free connect) still skips
+    expectSkipPairing(
+      { isControlUi: true, role: "operator", authMode: "none", authMethod: "none" },
+      "auth-none",
+    );
+    // Bootstrap / token handoff must still enroll + pair even when mode is none
+    expectSkipPairing(
+      {
+        isControlUi: true,
+        role: "operator",
+        authMode: "none",
+        authMethod: "bootstrap-token",
+      },
+      null,
+    );
     // Control UI + node role + auth.mode=none: still require pairing
     expectSkipPairing({ isControlUi: true, role: "node", authMode: "none" }, null);
     // Non-Control-UI + operator + auth.mode=none: still require pairing

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -27,7 +27,15 @@ export function shouldSkipControlUiPairing(params: {
   // called for ALL clients (not just Control UI) at the call site.
   // Scope to operator role so node-role sessions still need device identity
   // (#43478 was reverted for skipping ALL clients).
-  if (params.isControlUi && params.role === "operator" && params.authMode === "none") {
+  // If a concrete auth method already authenticated this connect (for example
+  // a dashboard bootstrap-token handoff while mode is still "none"), keep
+  // pairing so consumeSetupHandoff can match the paired public key.
+  if (
+    params.isControlUi &&
+    params.role === "operator" &&
+    params.authMode === "none" &&
+    (params.authMethod == null || params.authMethod === "none")
+  ) {
     return "auth-none";
   }
   return null;


### PR DESCRIPTION
## Summary
- `shouldSkipControlUiPairing` treated `auth.mode === "none"` alone as a pairing bypass.
- Dashboard bootstrap-token handoffs still authenticate with a concrete method while mode is `none`, so pairing was skipped and `consumeSetupHandoff` then closed without hello.
- Only skip pairing for credential-free none-mode connects (`authMethod` unset or `"none"`).

Fixes #138432

## What Problem This Solves
With `auth.mode` set to `none`, dashboard bootstrap-token handoffs still present a real `authMethod`. Treating mode alone as a pairing bypass skipped pairing, so `consumeSetupHandoff` closed without a hello and the control UI never finished connecting.

## Evidence
- Extended `connect-policy.test.ts` so a bootstrap-token connect under `auth.mode=none` still requires pairing, while a credential-free none-mode connect continues to skip it.

## Test plan
- [x] Extended `connect-policy.test.ts` for bootstrap-token under `auth.mode=none`

Remaining validation: no after-fix dashboard enrollment run is available. Fresh enrollment, same-key repair, credential-free access, and replay/revocation boundaries remain unverified; this PR is not ready to merge.

GitHub CI gate passed for the current submitted revision: https://github.com/openclaw/openclaw/actions/runs/33928836492/job/101204727825. This is automated CI evidence, not a live dashboard/provider validation.
