### PR TITLE
fix(discord): remove stale Working previews after repeated delete failures

### DIFF
--- a/extensions/discord/src/draft-delete-custody.test-support.ts
+++ b/extensions/discord/src/draft-delete-custody.test-support.ts
@@ -1,0 +1,26 @@
+// Discord test support resets the intentionally cross-loader draft-delete
+// custody registry, mirroring the thread-bindings test-support pattern.
+type CustodyTestAccountState = {
+  pending: unknown[];
+  retryTimer: ReturnType<typeof setTimeout> | undefined;
+};
+
+type CustodyTestState = {
+  byAccount: Map<string, CustodyTestAccountState>;
+};
+
+const CUSTODY_STATE_KEY = Symbol.for("openclaw.discordDraftDeleteCustodyState");
+
+export function resetDiscordDraftDeleteCustodyForTest(): void {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const state = globalStore[CUSTODY_STATE_KEY] as CustodyTestState | undefined;
+  if (!state) {
+    return;
+  }
+  for (const custody of state.byAccount.values()) {
+    if (custody.retryTimer) {
+      clearTimeout(custody.retryTimer);
+    }
+  }
+  state.byAccount.clear();
+}

--- a/extensions/discord/src/draft-delete-custody.test.ts
+++ b/extensions/discord/src/draft-delete-custody.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  adoptDiscordDraftDeleteCustody,
+  drainDiscordDraftDeleteCustody,
+} from "./draft-delete-custody.js";
+import { resetDiscordDraftDeleteCustodyForTest } from "./draft-delete-custody.test-support.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetDiscordDraftDeleteCustodyForTest();
+});
+
+describe("Discord draft delete custody", () => {
+  it("drains adopted deletes on the next lifecycle boundary", async () => {
+    const removed: string[] = [];
+    adoptDiscordDraftDeleteCustody({
+      accountId: "default",
+      messages: [
+        {
+          channelId: "c1",
+          messageId: "preview-1",
+          remove: async () => {
+            removed.push("preview-1");
+          },
+        },
+      ],
+    });
+
+    await drainDiscordDraftDeleteCustody("default");
+
+    expect(removed).toEqual(["preview-1"]);
+  });
+
+  it("keeps custody scoped to the owning account", async () => {
+    const removed: string[] = [];
+    adoptDiscordDraftDeleteCustody({
+      accountId: "work",
+      messages: [
+        {
+          channelId: "c1",
+          messageId: "preview-1",
+          remove: async () => {
+            removed.push("preview-1");
+          },
+        },
+      ],
+    });
+
+    await drainDiscordDraftDeleteCustody("default");
+    expect(removed).toEqual([]);
+
+    await drainDiscordDraftDeleteCustody("work");
+    expect(removed).toEqual(["preview-1"]);
+  });
+
+  it("retries failed deletes with a bounded attempt budget", async () => {
+    const warnings: string[] = [];
+    let calls = 0;
+    adoptDiscordDraftDeleteCustody({
+      accountId: "default",
+      messages: [
+        {
+          channelId: "c1",
+          messageId: "preview-1",
+          remove: async () => {
+            calls += 1;
+            throw new Error("still unavailable");
+          },
+        },
+      ],
+    });
+
+    await drainDiscordDraftDeleteCustody("default", (message) => warnings.push(message));
+    await drainDiscordDraftDeleteCustody("default", (message) => warnings.push(message));
+    await drainDiscordDraftDeleteCustody("default", (message) => warnings.push(message));
+    await drainDiscordDraftDeleteCustody("default", (message) => warnings.push(message));
+
+    expect(calls).toBe(3);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("preview-1");
+  });
+
+  it("retries adopted deletes after a bounded delay", async () => {
+    vi.useFakeTimers();
+    const removed: string[] = [];
+    adoptDiscordDraftDeleteCustody({
+      accountId: "default",
+      messages: [
+        {
+          channelId: "c1",
+          messageId: "preview-1",
+          remove: async () => {
+            removed.push("preview-1");
+          },
+        },
+      ],
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(removed).toEqual(["preview-1"]);
+  });
+
+  it("serializes overlapping drains and keeps custody ownership until work settles", async () => {
+    let unblockFirst: (() => void) | undefined;
+    const firstBlocked = new Promise<void>((resolve) => {
+      unblockFirst = resolve;
+    });
+    const removed: string[] = [];
+    let firstAttempts = 0;
+    let secondAttempts = 0;
+    adoptDiscordDraftDeleteCustody({
+      accountId: "default",
+      messages: [
+        {
+          channelId: "c1",
+          messageId: "preview-1",
+          remove: async () => {
+            firstAttempts += 1;
+            await firstBlocked;
+            removed.push("preview-1");
+          },
+        },
+      ],
+    });
+
+    const firstDrain = drainDiscordDraftDeleteCustody("default");
+    // While the first sweep is still deleting, a later turn adopts another
+    // failed delete and its cleanup kicks off a second drain.
+    adoptDiscordDraftDeleteCustody({
+      accountId: "default",
+      messages: [
+        {
+          channelId: "c2",
+          messageId: "preview-2",
+          remove: async () => {
+            secondAttempts += 1;
+            throw new Error("still unavailable");
+          },
+        },
+      ],
+    });
+    const secondDrain = drainDiscordDraftDeleteCustody("default");
+
+    unblockFirst?.();
+    await Promise.all([firstDrain, secondDrain]);
+
+    expect(removed).toEqual(["preview-1"]);
+    expect(firstAttempts).toBe(1);
+    expect(secondAttempts).toBe(0);
+    // Ownership is retained for the requeued failure: a later boundary can
+    // still drain it instead of finding a detached registry entry.
+    await drainDiscordDraftDeleteCustody("default");
+    expect(secondAttempts).toBe(1);
+  });
+
+  it("reports exhaustion for timer-driven retries using the retained warn sink", async () => {
+    vi.useFakeTimers();
+    const warnings: string[] = [];
+    adoptDiscordDraftDeleteCustody({
+      accountId: "default",
+      messages: [
+        {
+          channelId: "c1",
+          messageId: "preview-1",
+          remove: async () => {
+            throw new Error("still unavailable");
+          },
+        },
+      ],
+      warn: (message) => warnings.push(message),
+    });
+
+    // No later turn drains this account; only the bounded delayed retries run.
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(warnings).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("custody exhausted");
+    expect(warnings[0]).toContain("preview-1");
+  });
+
+  it("caps the custody queue per account", async () => {
+    const warnings: string[] = [];
+    const removed: string[] = [];
+    adoptDiscordDraftDeleteCustody({
+      accountId: "default",
+      messages: Array.from({ length: 60 }, (_, index) => ({
+        channelId: "c1",
+        messageId: `preview-${index + 1}`,
+        remove: async () => {
+          removed.push(`preview-${index + 1}`);
+        },
+      })),
+      warn: (message) => warnings.push(message),
+    });
+
+    await drainDiscordDraftDeleteCustody("default");
+
+    expect(removed).toHaveLength(50);
+    expect(removed).not.toContain("preview-1");
+    expect(removed).toContain("preview-11");
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+});

--- a/extensions/discord/src/draft-delete-custody.ts
+++ b/extensions/discord/src/draft-delete-custody.ts
@@ -1,0 +1,186 @@
+// Discord plugin module implementing failed draft-delete custody.
+//
+// A draft preview whose DELETE fails repeatedly outlives the per-turn
+// controller that owned it: once the controller's final cleanup sweep
+// finishes, nothing in the turn lifecycle retries the delete. This registry
+// keeps custody of those failed deletes per account and drains them at later
+// lifecycle boundaries plus a bounded delayed retry, so previews are removed
+// after transient REST failures instead of being orphaned.
+// The registry state lives on a global symbol (thread-bindings pattern) so it
+// survives loader re-instantiation and test support can reset it.
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+
+/** A failed draft-preview delete awaiting a later retry. */
+export type DiscordDraftDeleteCustodyEntry = {
+  channelId: string;
+  messageId: string;
+  /** Delete the Discord message. Must throw when the delete fails. */
+  remove: () => Promise<void>;
+};
+
+const RETRY_DELAY_MS = 30_000;
+const MAX_CUSTODY_DELETE_ATTEMPTS = 3;
+const MAX_CUSTODY_ENTRIES_PER_ACCOUNT = 50;
+// Sentinel key for an empty account id. Uses a prefix that cannot collide
+// with user-configured account IDs.
+const DEFAULT_ACCOUNT_KEY = "\0__default__";
+
+type CustodyRecord = {
+  entry: DiscordDraftDeleteCustodyEntry;
+  attempts: number;
+};
+
+type AccountCustody = {
+  pending: CustodyRecord[];
+  retryTimer: ReturnType<typeof setTimeout> | undefined;
+  /** Warn sink retained from adoption so timer-driven retries keep diagnostics. */
+  warn: ((message: string) => void) | undefined;
+  /** Active drain promise; concurrent drains await it instead of overlapping. */
+  drainInFlight: Promise<void> | undefined;
+};
+
+// The registry lives on a global symbol so test support can reset it across
+// loader instances, mirroring the thread-bindings registry pattern.
+const CUSTODY_STATE_KEY = Symbol.for("openclaw.discordDraftDeleteCustodyState");
+
+type CustodyState = {
+  byAccount: Map<string, AccountCustody>;
+};
+
+function getCustodyState(): CustodyState {
+  // SAFETY: globalThis is indexed as a plain record to stash the registry.
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  // SAFETY: this module exclusively owns the custody state under this symbol.
+  let state = globalStore[CUSTODY_STATE_KEY] as CustodyState | undefined;
+  if (!state) {
+    state = { byAccount: new Map() };
+    globalStore[CUSTODY_STATE_KEY] = state;
+  }
+  return state;
+}
+
+function getCustodyByAccount(): Map<string, AccountCustody> {
+  return getCustodyState().byAccount;
+}
+
+function resolveAccountKey(accountId: string): string {
+  return accountId || DEFAULT_ACCOUNT_KEY;
+}
+
+function scheduleCustodyRetry(key: string, custody: AccountCustody): void {
+  if (custody.retryTimer || !custody.pending.length) {
+    return;
+  }
+  custody.retryTimer = setTimeout(() => {
+    custody.retryTimer = undefined;
+    void drainDiscordDraftDeleteCustodyByKey(key, custody.warn);
+  }, RETRY_DELAY_MS);
+  custody.retryTimer.unref?.();
+}
+
+/** Stop and clear a custody record's pending retry timer. */
+function clearCustodyRetryTimer(custody: AccountCustody): void {
+  if (custody.retryTimer) {
+    clearTimeout(custody.retryTimer);
+    custody.retryTimer = undefined;
+  }
+}
+
+/** Take ownership of failed deletes so later retries can remove them. */
+export function adoptDiscordDraftDeleteCustody(params: {
+  accountId: string;
+  messages: DiscordDraftDeleteCustodyEntry[];
+  warn?: (message: string) => void;
+}): void {
+  if (!params.messages.length) {
+    return;
+  }
+  const key = resolveAccountKey(params.accountId);
+  const custodyByAccount = getCustodyByAccount();
+  let custody = custodyByAccount.get(key);
+  if (!custody) {
+    custody = { pending: [], retryTimer: undefined, warn: undefined, drainInFlight: undefined };
+    custodyByAccount.set(key, custody);
+  }
+  // Retain the latest warn sink so timer-driven retries can still report
+  // exhaustion even when no later turn drains this account.
+  custody.warn = params.warn ?? custody.warn;
+  for (const entry of params.messages) {
+    custody.pending.push({ entry, attempts: 0 });
+  }
+  if (custody.pending.length > MAX_CUSTODY_ENTRIES_PER_ACCOUNT) {
+    const dropped = custody.pending.splice(
+      0,
+      custody.pending.length - MAX_CUSTODY_ENTRIES_PER_ACCOUNT,
+    );
+    for (const record of dropped) {
+      params.warn?.(
+        `discord draft delete custody dropped (queue full): ` +
+          `channel=${record.entry.channelId} message=${record.entry.messageId}`,
+      );
+    }
+  }
+  scheduleCustodyRetry(key, custody);
+}
+
+async function drainDiscordDraftDeleteCustodyByKey(
+  key: string,
+  warn?: (message: string) => void,
+): Promise<void> {
+  const custody = getCustodyByAccount().get(key);
+  if (!custody) {
+    return;
+  }
+  if (custody.drainInFlight) {
+    // Drains are serialized per account: await the in-flight sweep so callers
+    // observe its deletions instead of racing a second overlapping drain.
+    await custody.drainInFlight;
+    return;
+  }
+  if (!custody.pending.length) {
+    return;
+  }
+  const effectiveWarn = warn ?? custody.warn;
+  const inFlight = (async () => {
+    const due = custody.pending;
+    custody.pending = [];
+    for (const record of due) {
+      record.attempts += 1;
+      try {
+        await record.entry.remove();
+      } catch (err) {
+        if (record.attempts >= MAX_CUSTODY_DELETE_ATTEMPTS) {
+          effectiveWarn?.(
+            `discord draft delete custody exhausted: ` +
+              `channel=${record.entry.channelId} message=${record.entry.messageId} ` +
+              `(${formatErrorMessage(err)})`,
+          );
+          continue;
+        }
+        custody.pending.push(record);
+      }
+    }
+  })();
+  custody.drainInFlight = inFlight;
+  try {
+    await inFlight;
+  } finally {
+    custody.drainInFlight = undefined;
+  }
+  // Registry ownership is retained until every claimed record settles, so a
+  // requeued failure still has its account entry and retry timer.
+  if (!custody.pending.length) {
+    clearCustodyRetryTimer(custody);
+    getCustodyByAccount().delete(key);
+    return;
+  }
+  scheduleCustodyRetry(key, custody);
+}
+
+/** Retry failed deletes adopted for this account. Safe to call at any boundary. */
+export async function drainDiscordDraftDeleteCustody(
+  accountId: string,
+  warn?: (message: string) => void,
+): Promise<void> {
+  await drainDiscordDraftDeleteCustodyByKey(resolveAccountKey(accountId), warn);
+}

--- a/extensions/discord/src/draft-stream.test.ts
+++ b/extensions/discord/src/draft-stream.test.ts
@@ -73,6 +73,37 @@ describe("createDiscordDraftStream", () => {
     expect(rest.delete).toHaveBeenNthCalledWith(2, "/channels/parent/messages/parent-draft");
   });
 
+  it("detaches failed deletes so a lifecycle owner can retry them", async () => {
+    const rest = {
+      post: vi.fn().mockResolvedValueOnce({ id: "parent-draft" }),
+      patch: vi.fn(async () => undefined),
+      delete: vi.fn().mockRejectedValueOnce(new Error("transient")),
+    };
+    const stream = createDiscordDraftStream({
+      rest: rest as never,
+      channelId: "parent",
+      throttleMs: 250,
+    });
+
+    stream.update("working");
+    await stream.flush();
+    await stream.clear();
+
+    const detached = stream.detachPendingCleanup();
+    expect(detached).toHaveLength(1);
+    const [firstDetached] = detached;
+    expect(firstDetached).toMatchObject({ channelId: "parent", messageId: "parent-draft" });
+
+    // The failed delete is no longer owned by the stream after detachment.
+    expect(stream.detachPendingCleanup()).toEqual([]);
+    await stream.cleanupPendingMessages();
+    expect(rest.delete).toHaveBeenCalledTimes(1);
+
+    rest.delete.mockResolvedValueOnce(undefined);
+    await firstDetached?.remove();
+    expect(rest.delete).toHaveBeenNthCalledWith(2, "/channels/parent/messages/parent-draft");
+  });
+
   it("keeps the parent draft when the thread replacement cannot be created", async () => {
     const rest = {
       post: vi

--- a/extensions/discord/src/draft-stream.ts
+++ b/extensions/discord/src/draft-stream.ts
@@ -1,6 +1,7 @@
 // Discord plugin module implements draft stream behavior.
 import { createFinalizableDraftStreamControlsForState } from "openclaw/plugin-sdk/channel-outbound";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import type { DiscordDraftDeleteCustodyEntry } from "./draft-delete-custody.js";
 import {
   createChannelMessage,
   deleteChannelMessage,
@@ -27,6 +28,8 @@ type DiscordDraftStream = {
   retarget: (channelId: string) => Promise<void>;
   /** Retry failed preview deletes at the owning turn's cleanup boundary. */
   cleanupPendingMessages: () => Promise<void>;
+  /** Release failed preview deletes so a lifecycle owner can retry them. */
+  detachPendingCleanup: () => DiscordDraftDeleteCustodyEntry[];
   /** Reset internal state so the next update creates a new message instead of editing. */
   forceNewMessage: (mode?: "preserve" | "discard") => void;
 };
@@ -193,6 +196,17 @@ export function createDiscordDraftStream(params: {
       await deleteCleanupMessage(message);
     }
   };
+  const detachPendingCleanup = (): DiscordDraftDeleteCustodyEntry[] => {
+    const pending = pendingCleanupMessages;
+    pendingCleanupMessages = [];
+    return pending.map((message) => ({
+      channelId: message.channelId,
+      messageId: message.messageId,
+      remove: async () => {
+        await deleteChannelMessage(rest, message.channelId, message.messageId);
+      },
+    }));
+  };
   const retarget = async (nextChannelId: string) => {
     const normalized = nextChannelId.trim();
     if (!normalized || normalized === channelId) {
@@ -264,6 +278,7 @@ export function createDiscordDraftStream(params: {
     stop,
     retarget,
     cleanupPendingMessages,
+    detachPendingCleanup,
     forceNewMessage,
   };
 }

--- a/extensions/discord/src/monitor/message-handler.draft-preview.rest.test.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.rest.test.ts
@@ -1,5 +1,7 @@
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { drainDiscordDraftDeleteCustody } from "../draft-delete-custody.js";
+import { resetDiscordDraftDeleteCustodyForTest } from "../draft-delete-custody.test-support.js";
 import { RequestClient } from "../internal/discord.js";
 import { createDiscordDraftPreviewController } from "./message-handler.draft-preview.js";
 
@@ -21,6 +23,10 @@ function createPreviewController(rest: RequestClient) {
 }
 
 describe("Discord draft preview REST lifecycle", () => {
+  beforeEach(() => {
+    resetDiscordDraftDeleteCustodyForTest();
+  });
+
   it("retains the progress draft after an error final is delivered", async () => {
     const requests: string[] = [];
     const rest = new RequestClient("test-token", {
@@ -119,4 +125,76 @@ describe("Discord draft preview REST lifecycle", () => {
       expect(deletedIds.filter((id) => id === "preview-1")).toHaveLength(deleteFailures + 1);
     },
   );
+
+  it("hands repeated delete failures to account custody and removes them on the next turn", async () => {
+    let deleteFailures = 2;
+    const visibleMessages = new Map<string, string>();
+    let createdCount = 0;
+    const rest = new RequestClient("test-token", {
+      fetch: async (input, init) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        if (init?.method === "POST") {
+          const id = `preview-${++createdCount}`;
+          visibleMessages.set(id, "orphaned progress");
+          return Response.json({ id });
+        }
+        if (init?.method === "DELETE") {
+          const id = url.pathname.split("/").at(-1)!;
+          if (deleteFailures > 0) {
+            deleteFailures -= 1;
+            return Response.json({ message: "temporarily unavailable" }, { status: 503 });
+          }
+          visibleMessages.delete(id);
+          return new Response(null, { status: 204 });
+        }
+        throw new Error(`Unexpected Discord request: ${init?.method} ${url.pathname}`);
+      },
+    });
+    const firstTurn = createPreviewController(rest);
+
+    firstTurn.draftStream?.update("orphaned progress");
+    await firstTurn.flush();
+    firstTurn.markFinalReplyStarted();
+    firstTurn.markFinalReplyDelivered(false);
+    // Two transient DELETE failures exhaust the per-turn retry; the preview
+    // stays visible while the controller terminates.
+    await firstTurn.cleanup();
+
+    expect([...visibleMessages]).toEqual([["preview-1", "orphaned progress"]]);
+
+    const nextTurn = createPreviewController(rest);
+    await nextTurn.cleanup();
+    // Turn completion schedules account recovery without awaiting it; settle
+    // the serialized drain to observe the deletion.
+    await drainDiscordDraftDeleteCustody("default");
+
+    expect([...visibleMessages]).toEqual([]);
+  });
+
+  it("keeps intentional error-final retention out of custody", async () => {
+    const requests: string[] = [];
+    const rest = new RequestClient("test-token", {
+      queueRequests: false,
+      fetch: async (input, init) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        requests.push(`${init?.method ?? "GET"} ${url.pathname.replace("/api/v10", "")}`);
+        if (init?.method === "POST") {
+          return Response.json({ id: "preview-error" });
+        }
+        return new Response(null, { status: 204 });
+      },
+    });
+    const firstTurn = createPreviewController(rest);
+
+    firstTurn.draftStream?.update("retained progress");
+    await firstTurn.flush();
+    firstTurn.markFinalReplyStarted();
+    firstTurn.markFinalReplyDelivered(true);
+    await firstTurn.cleanup();
+
+    const nextTurn = createPreviewController(rest);
+    await nextTurn.cleanup();
+
+    expect(requests).not.toContain("DELETE /channels/c1/messages/preview-error");
+  });
 });

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -16,6 +16,10 @@ import {
 } from "openclaw/plugin-sdk/text-chunking";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import { resolveDiscordDraftStreamingChunking } from "../draft-chunking.js";
+import {
+  adoptDiscordDraftDeleteCustody,
+  drainDiscordDraftDeleteCustody,
+} from "../draft-delete-custody.js";
 import { createDiscordDraftStream } from "../draft-stream.js";
 import type { RequestClient } from "../internal/discord.js";
 import { resolveDiscordPreviewStreamMode } from "../preview-streaming.js";
@@ -377,6 +381,20 @@ export function createDiscordDraftPreviewController(params: {
           await draftStream.clear();
         }
         await draftStream?.cleanupPendingMessages();
+        // Kick off custody recovery adopted by earlier turns without blocking
+        // turn completion: the account-wide sweep can span many sequential
+        // deletes bounded by the REST timeout, and a finished turn must not wait
+        // for unrelated previews. Drains are serialized per account, so this
+        // sweep adopts its leftovers after the in-flight drain snapshot.
+        void drainDiscordDraftDeleteCustody(params.accountId, params.log);
+        // Deletes that still fail after the final sweep outlive this per-turn
+        // controller; hand custody to the account-level owner so later turns
+        // and bounded retries remove them.
+        adoptDiscordDraftDeleteCustody({
+          accountId: params.accountId,
+          messages: draftStream?.detachPendingCleanup() ?? [],
+          warn: params.log,
+        });
       } catch (err) {
         params.log(`discord: draft cleanup failed: ${String(err)}`);
       }

--- a/extensions/discord/src/monitor/message-handler.draft-preview.visibility.test.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.visibility.test.ts
@@ -11,6 +11,7 @@ const draftStream = vi.hoisted(() => ({
   stop: vi.fn(async () => {}),
   retarget: vi.fn(async () => {}),
   cleanupPendingMessages: vi.fn(async () => {}),
+  detachPendingCleanup: vi.fn(() => []),
   forceNewMessage: vi.fn(),
 }));
 

--- a/extensions/discord/src/monitor/message-handler.process.test-harness.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test-harness.ts
@@ -58,6 +58,7 @@ export function createMockDraftStream() {
     stop: vi.fn(async () => {}),
     retarget: vi.fn(async () => {}),
     cleanupPendingMessages: vi.fn(async () => {}),
+    detachPendingCleanup: vi.fn(() => []),
     forceNewMessage: vi.fn(() => {
       messageId = undefined;
     }),


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #138630

## What Problem This Solves

- Fixes an issue where Discord users see a stale `Working` progress preview left beside a normal reply after the reply already delivered. The preview's DELETE can fail transiently (e.g. during Discord REST flakiness around gateway heartbeat timeouts); when it fails twice, nothing ever retries it, so the preview stays visible indefinitely next to completed conversations.
- **Related:** #130006 (failed-delete custody, one retry) and #130392 (late preview cleanup after transient delete failures) are the merged predecessors; this closes the remaining repeated-failure hole they left, as identified by the ClawSweeper source-repro review on this issue.

## Why This Change Was Made

- **Intended outcome:** Failed preview deletes that outlive the per-turn controller are handed to an account-level custody owner, which drains them at later turn cleanup boundaries and via a bounded delayed retry (30s, up to 3 custody attempts, queue capped at 50 per account). A preview is removed once Discord accepts the delete after recovery, while intentional error-final retention stays untouched.
- **Out of scope:** The heartbeat/reconnect correlation itself (the gateway supervisor treats heartbeat ACK timeouts as non-stopping, so reconnect is not the deletion cause); no persistence across process restarts (matching the in-memory custody of #130006/#130392).
- **Highest-risk area:** The controller `cleanup()` ordering (drain older custody before adopting this sweep's leftovers).
- **How is that risk mitigated?** The existing REST lifecycle test matrix (0/1/2 delete failures across queued admission and teardown boundaries) passes unchanged, and new lifecycle tests pin the handoff behavior, including that error finals never enter custody.
- **Review follow-up (ClawSweeper findings addressed):** Account drains are now serialized per account and registry ownership is retained until every claimed record settles, so overlapping drains cannot orphan records before their retry budget is exhausted. Account-wide custody recovery no longer blocks turn completion (it is scheduled without awaiting, so a finished turn does not wait for unrelated previews bounded by the REST timeout). Adoption retains the warn sink so timer-driven retries that exhaust their budget still emit a terminal custody diagnostic. The test reset seam moved to `draft-delete-custody.test-support.ts` (thread-bindings pattern) so production knip scans no longer flag it.

## User Impact

- **Success criteria:** A draft created around transport/liveness turbulence is deleted after the successful final delivery — at the latest by the next turn's cleanup or the bounded retry — instead of lingering as `Working` beside the answer. Error finals still retain the draft as the visible failure record.
- **What should reviewers focus on?** `extensions/discord/src/draft-delete-custody.ts` (new registry, follows the gateway-registry module pattern), the custody handoff in `message-handler.draft-preview.ts` `cleanup()`, and the regression tests in `message-handler.draft-preview.rest.test.ts` ("hands repeated delete failures to account custody and removes them on the next turn").

## Evidence

- **Real environment tested:** `/home/0668000710/code/PR/aispace/worktrees/issue-138630` (worktree off `origin/main` @ 8918e743cdf); zero-mock lifecycle proof running the real `createDiscordDraftPreviewController` and `RequestClient` against a real local HTTP server acting as Discord REST (no mocks in the request path), plus the repo's REST lifecycle tests.
- **Exact steps or commands run after this patch:**
  ```bash
  pnpm install --prefer-offline
  # Zero-mock proof: real controller + real HTTP server, first two DELETEs return 503
  node --import ./scripts/tsx.mjs <evidence>/live-proof.mts        # with this patch
  PROOF_WORKTREE=<origin/main worktree> node --import <loader>/tsx.mjs <evidence>/live-proof.mts  # before
  # Regression tests
  node scripts/run-vitest.mjs run extensions/discord/src/draft-delete-custody.test.ts \
    extensions/discord/src/draft-stream.test.ts \
    extensions/discord/src/monitor/message-handler.draft-preview.rest.test.ts
  node scripts/run-vitest.mjs run extensions/discord/src/monitor/message-handler.process.draft-recovery.test.ts \
    extensions/discord/src/monitor/message-handler.process.draft-final.test.ts \
    extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts \
    extensions/discord/src/monitor/message-handler.process.draft-reasoning.test.ts
  ```
- **Evidence after fix:**
  ```json
  {
    "phase": "after turn 1 cleanup (2 transient DELETE failures)",
    "visibleMessages": [["preview-1", "Working on your request"]],
    "deleteLog": ["DELETE preview-1 -> 503 (transient failure 1)", "DELETE preview-1 -> 503 (transient failure 2)"]
  }
  {
    "phase": "after turn 2 cleanup (custody drain)",
    "visibleMessages": [],
    "deleteLog": ["DELETE preview-1 -> 503 (transient failure 1)", "DELETE preview-1 -> 503 (transient failure 2)", "DELETE preview-1 -> 204"]
  }
  ```
  Same scenario on `origin/main` (before): after turn 2 cleanup `visibleMessages` still contains `[["preview-1", "Working on your request"]]` with no third DELETE — the preview is orphaned. Vitest: 33/33 passed across the four touched/new lifecycle files; 108/108 passed across the process draft suites; `tsgo:core` clean.
- **Observed result after fix:** The orphaned preview is removed by the next lifecycle boundary (or the bounded delayed retry) once Discord accepts the delete; single-failure and success paths behave exactly as before.
- **Before evidence (optional, visual changes encouraged):** On `origin/main`, the controller's final cleanup sweep drains the failed-delete queue once; a second DELETE failure re-queues into controller-local state that terminates with the turn, so the `Working` preview survives next to the delivered reply (reproduced above with two 503s).
- **What was not tested:** No live Discord account session was exercised (no credentials); the heartbeat-timeout correlation is not reproduced end-to-end since it is not the deletion cause. CI lanes (`test-projects --changed`, full `check:test-types`) pending on Actions.
- **Proof tier:** L2
- **Proof limitations:** none
- **Review state:** Awaiting CI + maintainer review
- **Follow-up verification:** 160/160 tests pass across the custody, draft-stream, REST lifecycle, visibility, and process draft suites after the review fixes; `pnpm deadcode:full`, `tsgo:extensions`, and `tsgo:extensions:test` clean locally.

