### PR TITLE
fix(claws): preserve active and shared agent data during removal

### DIFF
--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -431,6 +431,11 @@ still open, stop the command or restart the Gateway holding it before retrying.
 Removing scheduled jobs still requires a running Gateway. A database-lease
 refusal leaves the agent config, execution approvals, and creation history unchanged.
 
+If session cleanup or transcript archive export fails after the agent is removed
+from config, removal reports `partial` with `session_cleanup_failed` and retains
+its cleanup record. Correct the reported error, preview removal again, and retry
+to finish cleanup before recreating the agent.
+
 To remove unchanged Claw-introduced references that have no other current
 owner, include `--remove-unused` in both preview and apply. To select exact
 referenced resources instead, repeat `--remove-referenced`:

--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -425,6 +425,12 @@ released. Removal reports which retained requirements Claw add introduced; use
 the ordinary plugin lifecycle separately when you intend to uninstall a
 process-wide plugin.
 
+Directories containing another agent's registered database are retained, even
+when that database is closed. If removal reports that an agent database is
+still open, stop the command or restart the Gateway holding it before retrying.
+Removing scheduled jobs still requires a running Gateway. A database-lease
+refusal leaves the agent config, execution approvals, and creation history unchanged.
+
 To remove unchanged Claw-introduced references that have no other current
 owner, include `--remove-unused` in both preview and apply. To select exact
 referenced resources instead, repeat `--remove-referenced`:

--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -12,7 +12,10 @@ import { sessionChildCacheRetentionEntrypoint } from "../../src/gateway/session-
 import { sessionTitleRetentionEntrypoints } from "../../src/gateway/session-title-retention.test-support.ts";
 import { nodeHostConfigRuntimeEntrypoint } from "../../src/node-host/config-runtime.test-support.ts";
 import { persistenceRuntimeEntrypoint } from "../../src/skills/library/persistence-runtime.test-support.ts";
-import { stateLeaseProcessExitRuntimeEntrypoint } from "../../src/state/openclaw-state-lease-runtime.test-support.ts";
+import {
+  agentDatabaseHeldRuntimeEntrypoint,
+  stateLeaseProcessExitRuntimeEntrypoint,
+} from "../../src/state/openclaw-state-lease-runtime.test-support.ts";
 import { tuiPtyRuntimeEntrypoints } from "../../src/tui/tui-pty-runtime-test-support.ts";
 import { channelIngressGatewayRestartEntrypoint } from "../../test/fixtures/channel-ingress-gateway-restart-entrypoint.ts";
 import { runtimeProcessBuildEntries } from "./runtime-process-build-entries.mts";
@@ -36,6 +39,7 @@ export const vitestWorkerBuildEntries = {
       persistenceRuntimeEntrypoint,
       qaGatewayCleanupRuntimeEntrypoint,
       stateLeaseProcessExitRuntimeEntrypoint,
+      agentDatabaseHeldRuntimeEntrypoint,
     ].map((entry) => [
       entry.distWorkerPath.replace(/\.js$/u, ""),
       fileURLToPath(new URL(`./${entry.sourceWorkerName}.ts`, entry.currentModuleUrl)),

--- a/src/agents/agent-delete-databases.ts
+++ b/src/agents/agent-delete-databases.ts
@@ -1,0 +1,120 @@
+import path from "node:path";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isPathInside } from "../infra/path-guards.js";
+import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { assertNoOpenClawAgentDatabaseLeases } from "../state/openclaw-agent-db-lease.js";
+import { invalidateRegisteredAgentDatabasesMemo } from "../state/openclaw-agent-db-registry-listing.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  listOpenClawRegisteredAgentDatabases,
+  resolveOpenClawAgentSqlitePath,
+} from "../state/openclaw-agent-db.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
+import { findOverlappingWorkspaceAgentIds } from "./agent-delete-safety.js";
+import {
+  isPathOwnedByAnotherRegisteredAgent,
+  normalizeAgentDirRegistryPath,
+} from "./agent-dir-registry.js";
+
+export type AgentDeleteDatabasePlan = {
+  registrationPaths: string[];
+  fileGroups: string[][];
+  relocatedFileGroups: string[][];
+};
+
+/** Destructive planning includes every registered owner, regardless of runtime schema readiness. */
+export function readAgentDeleteDatabaseRegistry(options: OpenClawStateDatabaseOptions = {}) {
+  invalidateRegisteredAgentDatabasesMemo(options);
+  return listOpenClawRegisteredAgentDatabases({
+    ...options,
+    includeIncompatibleSchemaVersions: true,
+  });
+}
+
+export function resolveSurvivingDatabaseFilePaths(
+  registeredDatabases: ReturnType<typeof listOpenClawRegisteredAgentDatabases>,
+  agentId: string,
+  env?: NodeJS.ProcessEnv,
+): string[] {
+  return [
+    ...new Set(
+      registeredDatabases
+        .filter((entry) => normalizeAgentId(entry.agentId) !== agentId)
+        .flatMap((entry) => resolveSqliteDatabaseFilePaths(entry.path))
+        .map((pathname) => normalizeAgentDirRegistryPath(pathname, env)),
+    ),
+  ];
+}
+
+export function isPathOwnedBySurvivingAgent(
+  cfg: OpenClawConfig,
+  agentId: string,
+  pathname: string,
+  survivingDatabaseFilePaths: readonly string[] = [],
+  env?: NodeJS.ProcessEnv,
+): boolean {
+  const canonicalPath = normalizeAgentDirRegistryPath(pathname, env);
+  return (
+    isPathOwnedByAnotherRegisteredAgent({ agentId, pathname, env }) ||
+    findOverlappingWorkspaceAgentIds(cfg, agentId, pathname, env).length > 0 ||
+    survivingDatabaseFilePaths.some(
+      (databasePath) =>
+        databasePath === canonicalPath ||
+        isPathInside(databasePath, canonicalPath) ||
+        isPathInside(canonicalPath, databasePath),
+    )
+  );
+}
+
+export function prepareAgentDeleteDatabases(
+  cfg: OpenClawConfig,
+  agentId: string,
+  agentDir: string,
+  options: OpenClawStateDatabaseOptions = {},
+): AgentDeleteDatabasePlan {
+  const registeredDatabases = readAgentDeleteDatabaseRegistry(options);
+  const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
+    registeredDatabases,
+    agentId,
+    options.env,
+  );
+  const registeredDatabasePaths = new Set([
+    resolveOpenClawAgentSqlitePath({
+      agentId,
+      env: options.env,
+      path: path.join(agentDir, "openclaw-agent.sqlite"),
+    }),
+    ...registeredDatabases
+      .filter((entry) => normalizeAgentId(entry.agentId) === agentId)
+      .map((entry) => entry.path),
+  ]);
+  // A surviving directory retains files, not the deleted agent's connection. Check the
+  // actual cached owner so stale registration cannot close a surviving agent's handle.
+  for (const databasePath of registeredDatabasePaths) {
+    closeOpenClawAgentDatabaseByPath(databasePath, agentId);
+  }
+  const databasePaths = [...registeredDatabasePaths].filter((pathname) =>
+    resolveSqliteDatabaseFilePaths(pathname).every(
+      (filePath) =>
+        !isPathOwnedBySurvivingAgent(
+          cfg,
+          agentId,
+          filePath,
+          survivingDatabaseFilePaths,
+          options.env,
+        ),
+    ),
+  );
+  assertNoOpenClawAgentDatabaseLeases(agentId, options);
+  const fileGroups = databasePaths.map(resolveSqliteDatabaseFilePaths);
+  const relocatedFileGroups = fileGroups.filter((fileGroup) => {
+    const relative = path.relative(agentDir, fileGroup[0] ?? agentDir);
+    return relative.startsWith("..") || path.isAbsolute(relative);
+  });
+  return {
+    registrationPaths: [...registeredDatabasePaths],
+    fileGroups,
+    relocatedFileGroups,
+  };
+}

--- a/src/agents/agent-delete-safety.ts
+++ b/src/agents/agent-delete-safety.ts
@@ -48,6 +48,7 @@ export function findOverlappingWorkspaceAgentIds(
   cfg: OpenClawConfig,
   agentId: string,
   workspaceDir: string,
+  env?: NodeJS.ProcessEnv,
 ): string[] {
   const entries = listAgentEntries(cfg);
   const normalizedAgentId = normalizeAgentId(agentId);
@@ -57,7 +58,7 @@ export function findOverlappingWorkspaceAgentIds(
     if (otherAgentId === normalizedAgentId) {
       continue;
     }
-    const otherWorkspace = resolveAgentWorkspaceDir(cfg, otherAgentId);
+    const otherWorkspace = resolveAgentWorkspaceDir(cfg, otherAgentId, env);
     if (workspacePathsOverlap(workspaceDir, otherWorkspace)) {
       overlappingAgentIds.push(otherAgentId);
     }

--- a/src/agents/agent-lifecycle-registry.test.ts
+++ b/src/agents/agent-lifecycle-registry.test.ts
@@ -6,7 +6,7 @@ import {
   claimCompletedAgentDeletionJournal,
   readAgentDeletionJournal,
 } from "../state/agent-deletion-journal.js";
-import { recordAgentProvenance } from "../state/agent-provenance.js";
+import { readAgentProvenance, recordAgentProvenance } from "../state/agent-provenance.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   beginAgentDeletion,
@@ -68,12 +68,44 @@ describe("agent lifecycle registry", () => {
   it("refuses capture and matching while deletion owns the agent id", () => {
     const options = createOptions();
     const config = { agents: { entries: { main: {} } } };
+    recordAgentProvenance("main", { createdVia: "operator" }, options);
     const binding = captureAgentLifecycleBinding(config, "main", options);
     const deletion = beginAgentDeletion(createEntry("main"), options);
 
     expect(captureAgentLifecycleBinding(config, "main", options)).toBeUndefined();
     expect(binding && matchesAgentLifecycleBinding(config, binding, options)).toBe(false);
     deletion.rollback();
+    expect(binding && matchesAgentLifecycleBinding(config, binding, options)).toBe(true);
+  });
+
+  it("removes only the completing operation's provenance and keeps partial cleanup fenced", () => {
+    const options = createOptions();
+    const config = { agents: { entries: { main: {}, kept: {} } } };
+    recordAgentProvenance("main", { createdVia: "claw" }, { ...options, nowMs: 1 });
+    recordAgentProvenance("kept", { createdVia: "operator" }, options);
+    const before = readAgentProvenance("main", options);
+    const binding = captureAgentLifecycleBinding(config, "main", options);
+    const first = beginAgentDeletion(createEntry("main"), options);
+    first.commit();
+
+    expect(readAgentProvenance("main", options)).toEqual(before);
+    expect(isAgentDeletionBlocked("main", options)).toBe(true);
+    expect(binding && matchesAgentLifecycleBinding(config, binding, options)).toBe(false);
+    expect(captureAgentLifecycleBinding(config, "main", options)).toBeUndefined();
+
+    const recovery = beginAgentDeletion(createEntry("main"), options);
+    first.finish();
+    expect(readAgentProvenance("main", options)).toEqual(before);
+    recovery.finish();
+    expect(readAgentProvenance("main", options)).toBeUndefined();
+    expect(readAgentProvenance("kept", options)?.createdVia).toBe("operator");
+
+    expect(claimCompletedAgentDeletion("main", recovery.entry.operationId, options)).toBe(true);
+    recordAgentProvenance("main", { createdVia: "operator" }, { ...options, nowMs: 2 });
+    first.finish();
+    recovery.finish();
+    expect(readAgentProvenance("main", options)?.createdAtMs).toBe(2);
+    expect(binding && matchesAgentLifecycleBinding(config, binding, options)).toBe(false);
   });
 
   it("keeps a committed deletion fenced until recreation claims cleanup", () => {

--- a/src/agents/agent-lifecycle-registry.ts
+++ b/src/agents/agent-lifecycle-registry.ts
@@ -4,6 +4,7 @@ import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveGlobalMap } from "../shared/global-singleton.js";
+import { createAgentDeletionDatabaseCleanup } from "../state/agent-deletion-cleanup.js";
 import {
   beginAgentDeletionJournal,
   claimCompletedAgentDeletionJournal,
@@ -16,6 +17,7 @@ import {
   type AgentDeletionJournalEntry,
 } from "../state/agent-deletion-journal.js";
 import { readAgentProvenance, type AgentProvenance } from "../state/agent-provenance.js";
+import { assertNoOpenClawAgentDatabaseLeases } from "../state/openclaw-agent-db-lease.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
@@ -69,38 +71,80 @@ export function beginAgentDeletion(
   fenceCleanupPaths: (paths: readonly AgentDeletionJournalCleanupPath[]) => void;
   finish: () => void;
   rollback: () => void;
+  runDatabaseCleanup: ReturnType<typeof createAgentDeletionDatabaseCleanup>;
 } {
   const id = normalizeAgentId(entry.agentId);
-  const key = lifecycleKey(id, options);
+  const statePath = path.resolve(
+    options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env),
+  );
+  const stateOptions = { ...options, path: statePath, env: options.env && { ...options.env } };
+  const key = lifecycleKey(id, stateOptions);
   const operationId = crypto.randomUUID();
   const journal = beginAgentDeletionJournal(
     { ...entry, agentId: id, operationId, deleteFiles: entry.deleteFiles !== false },
-    options,
+    stateOptions,
   );
+  let active = true;
+  const assertJournal: Parameters<typeof createAgentDeletionDatabaseCleanup>[0]["assertJournal"] = (
+    currentStatePath,
+    entries,
+  ) => {
+    if (
+      !active ||
+      path.resolve(currentStatePath) !== statePath ||
+      !entries.some(
+        (current) =>
+          current.agentId === id &&
+          current.operationId === operationId &&
+          !current.cleanupCompleted,
+      )
+    ) {
+      throw new Error(`Agent ${id} deletion no longer owns database cleanup.`);
+    }
+    return id;
+  };
+  const runDatabaseCleanup = createAgentDeletionDatabaseCleanup({
+    statePath,
+    assertAdmission: () => assertNoOpenClawAgentDatabaseLeases(id, stateOptions),
+    assertJournal,
+    assertCurrent: () => {
+      const current = readAgentDeletionJournal(id, stateOptions);
+      assertJournal(statePath, current ? [current] : []);
+    },
+  });
   agentLifecycle.set(key, "deleting");
   return {
     entry: journal,
+    runDatabaseCleanup,
     commit: () => agentLifecycle.set(key, "deleted"),
     fenceDatabasePaths: (paths) => {
-      if (!updateAgentDeletionJournalDatabasePaths(id, operationId, paths, options)) {
+      if (!updateAgentDeletionJournalDatabasePaths(id, operationId, paths, stateOptions)) {
         throw new Error(`Failed to fence database cleanup paths for agent ${id}.`);
       }
       journal.databasePaths = [...new Set(paths.map((entryPath) => path.resolve(entryPath)))];
     },
     fenceCleanupPaths: (paths) => {
-      if (!updateAgentDeletionJournalCleanupPaths(id, operationId, paths, options)) {
+      if (!updateAgentDeletionJournalCleanupPaths(id, operationId, paths, stateOptions)) {
         throw new Error(`Failed to fence cleanup paths for agent ${id}.`);
       }
       journal.cleanupPaths = [...paths];
     },
     finish: () => {
-      if (completeAgentDeletionJournal(id, operationId, options)) {
-        agentLifecycle.set(key, "deleted");
+      try {
+        if (completeAgentDeletionJournal(id, operationId, stateOptions)) {
+          agentLifecycle.set(key, "deleted");
+        }
+      } finally {
+        active = false;
       }
     },
     rollback: () => {
-      if (removeAgentDeletionJournal(id, operationId, options)) {
-        agentLifecycle.delete(key);
+      try {
+        if (removeAgentDeletionJournal(id, operationId, stateOptions)) {
+          agentLifecycle.delete(key);
+        }
+      } finally {
+        active = false;
       }
     },
   };

--- a/src/claws/lifecycle-config-removal.ts
+++ b/src/claws/lifecycle-config-removal.ts
@@ -174,6 +174,7 @@ async function commitClawAgentConfigRemoval(
 
 type CommittedClawAgentRemoval = ClawAgentConfigRemovalResult & {
   completeDeletion: (database: OpenClawStateDatabase) => void;
+  runDatabaseCleanup: ReturnType<typeof beginAgentDeletion>["runDatabaseCleanup"];
 };
 
 export async function withClawAgentConfigRemoval<T>(
@@ -216,6 +217,7 @@ export async function withClawAgentConfigRemoval<T>(
       committed = true;
       return {
         ...result,
+        runDatabaseCleanup: deletion.runDatabaseCleanup,
         completeDeletion: (database: OpenClawStateDatabase) => {
           if (
             !completeAgentDeletionJournalInDatabase(

--- a/src/claws/lifecycle-config-removal.ts
+++ b/src/claws/lifecycle-config-removal.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { stableStringify } from "@openclaw/normalization-core";
+import { prepareAgentDeleteDatabases } from "../agents/agent-delete-databases.js";
 import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
 import { listAgentEntries } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/config.js";
@@ -68,7 +69,12 @@ async function commitClawAgentConfigRemoval(
   if (params.commitConfig) {
     let result: ClawAgentConfigRemovalResult | undefined;
     await params.commitConfig((config) => {
-      const effects = deletionEffects(config, params.agentId, params.fallbackWorkspace);
+      const effects = deletionEffects(
+        config,
+        params.agentId,
+        params.fallbackWorkspace,
+        params.stateDatabase?.env,
+      );
       const agent = listAgentEntries(config).find((candidate) => candidate.id === params.agentId);
       if (
         (agent && digestClawAgentConfig(agent) !== params.expectedDigest) ||
@@ -127,6 +133,7 @@ async function commitClawAgentConfigRemoval(
       configBeforeDelete,
       params.agentId,
       params.fallbackWorkspace,
+      params.stateDatabase?.env,
     );
     return {
       agentRemoved: Boolean(committed.result),
@@ -146,7 +153,12 @@ async function commitClawAgentConfigRemoval(
     if (listAgentEntries(latestConfig).some((agent) => agent.id === params.agentId)) {
       throw params.onModified();
     }
-    const effects = deletionEffects(latestConfig, params.agentId, params.fallbackWorkspace);
+    const effects = deletionEffects(
+      latestConfig,
+      params.agentId,
+      params.fallbackWorkspace,
+      params.stateDatabase?.env,
+    );
     return {
       agentRemoved: false,
       cleanupTargets: {
@@ -160,9 +172,21 @@ async function commitClawAgentConfigRemoval(
   }
 }
 
-export async function claimClawAgentConfigRemoval(params: ClawAgentConfigRemovalParams) {
+type CommittedClawAgentRemoval = ClawAgentConfigRemovalResult & {
+  completeDeletion: (database: OpenClawStateDatabase) => void;
+};
+
+export async function withClawAgentConfigRemoval<T>(
+  params: ClawAgentConfigRemovalParams,
+  apply: (commitRemoval: () => Promise<CommittedClawAgentRemoval>) => Promise<T>,
+): Promise<T> {
   const config = params.config ?? getRuntimeConfig();
-  const effects = deletionEffects(config, params.agentId, params.fallbackWorkspace);
+  const effects = deletionEffects(
+    config,
+    params.agentId,
+    params.fallbackWorkspace,
+    params.stateDatabase?.env,
+  );
   // beginAgentDeletion takes over an existing journal row instead of refusing it, so rolling back
   // a row this call did not open would erase another deletion's record.
   const existingJournal = readAgentDeletionJournal(params.agentId, params.stateDatabase);
@@ -178,31 +202,37 @@ export async function claimClawAgentConfigRemoval(params: ClawAgentConfigRemoval
     },
     params.stateDatabase,
   );
+  let committed = false;
   try {
-    const result = await withAgentExecApprovalsRemoved(
-      params.agentId,
-      async () => commitClawAgentConfigRemoval({ ...params, config }),
-      params.stateDatabase,
-    );
-    deletion.commit();
-    return {
-      ...result,
-      completeDeletion: (database: OpenClawStateDatabase) => {
-        if (
-          !completeAgentDeletionJournalInDatabase(
-            database,
-            params.agentId,
-            deletion.entry.operationId,
-          )
-        ) {
-          throw new Error(`Failed to complete deletion journal for agent ${params.agentId}.`);
-        }
-      },
-    };
-  } catch (error) {
-    if (!existingJournal) {
+    // Fence new claims and drain existing owners before any external or local removal effect.
+    prepareAgentDeleteDatabases(config, params.agentId, effects.agentDir, params.stateDatabase);
+    return await apply(async () => {
+      const result = await withAgentExecApprovalsRemoved(
+        params.agentId,
+        async () => commitClawAgentConfigRemoval({ ...params, config }),
+        params.stateDatabase,
+      );
+      deletion.commit();
+      committed = true;
+      return {
+        ...result,
+        completeDeletion: (database: OpenClawStateDatabase) => {
+          if (
+            !completeAgentDeletionJournalInDatabase(
+              database,
+              params.agentId,
+              deletion.entry.operationId,
+            )
+          ) {
+            throw new Error(`Failed to complete deletion journal for agent ${params.agentId}.`);
+          }
+        },
+      };
+    });
+  } finally {
+    // Pre-config partial results release only this attempt's fence; committed cleanup retains it.
+    if (!committed && !existingJournal) {
       deletion.rollback();
     }
-    throw error;
   }
 }

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -3,6 +3,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
+import {
+  isPathOwnedBySurvivingAgent,
+  readAgentDeleteDatabaseRegistry,
+  resolveSurvivingDatabaseFilePaths,
+} from "../agents/agent-delete-databases.js";
 import { findOverlappingWorkspaceAgentIds } from "../agents/agent-delete-safety.js";
 import { listAgentEntries, resolveAgentDir } from "../agents/agent-scope.js";
 import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../agents/workspace-bootstrap-read.js";
@@ -130,14 +135,19 @@ export function synthesizeOrphanInstall(params: {
   };
 }
 
-export function deletionEffects(config: OpenClawConfig, agentId: string, fallbackWorkspace = "") {
+export function deletionEffects(
+  config: OpenClawConfig,
+  agentId: string,
+  fallbackWorkspace = "",
+  env?: NodeJS.ProcessEnv,
+) {
   const agent = listAgentEntries(config).find((candidate) => candidate.id === agentId);
   const pruned = pruneAgentConfig(config, agentId);
   const workspace = agent?.workspace ?? fallbackWorkspace;
-  const agentDir = resolveAgentDir(config, agentId);
-  const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
+  const agentDir = resolveAgentDir(config, agentId, env);
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId, env);
   const workspaceSharedWith = workspace
-    ? findOverlappingWorkspaceAgentIds(config, agentId, workspace)
+    ? findOverlappingWorkspaceAgentIds(config, agentId, workspace, env)
     : [];
   return {
     pruned,
@@ -145,7 +155,6 @@ export function deletionEffects(config: OpenClawConfig, agentId: string, fallbac
     agentDir,
     sessionsDir,
     workspaceSharedWith,
-    workspaceRetained: workspaceSharedWith.length > 0,
   };
 }
 
@@ -251,17 +260,28 @@ export async function cleanupClawAgentFilesystem(params: {
   runtime: RuntimeEnv;
   trashPath?: ClawTrashPath;
   retainWorkspace?: boolean;
+  stateDatabase?: OpenClawStateDatabaseOptions;
 }): Promise<string[]> {
   const errors: string[] = [];
   const trashPath = params.trashPath ?? moveToTrash;
-  const workspaceSharedWith = params.targets.workspaceDir
-    ? findOverlappingWorkspaceAgentIds(
-        params.nextConfig,
-        params.agentId,
-        params.targets.workspaceDir,
-      )
-    : [];
-  if (params.targets.workspaceDir && !params.retainWorkspace && workspaceSharedWith.length === 0) {
+  const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
+    readAgentDeleteDatabaseRegistry(params.stateDatabase),
+    params.agentId,
+    params.stateDatabase?.env,
+  );
+  const sharedWithSurvivor = (pathname: string) =>
+    isPathOwnedBySurvivingAgent(
+      params.nextConfig,
+      params.agentId,
+      pathname,
+      survivingDatabaseFilePaths,
+      params.stateDatabase?.env,
+    );
+  if (
+    params.targets.workspaceDir &&
+    !params.retainWorkspace &&
+    !sharedWithSurvivor(params.targets.workspaceDir)
+  ) {
     const legacyPlan = prepareLegacyWorkspaceStateReset(params.targets.workspaceDir);
     const statePlan = prepareWorkspaceStateDeletion(params.targets.workspaceDir);
     const workspaceRemoved = await trashPath(params.targets.workspaceDir, params.runtime);
@@ -279,10 +299,16 @@ export async function cleanupClawAgentFilesystem(params: {
       errors.push(`Could not trash workspace ${params.targets.workspaceDir}.`);
     }
   }
-  if (!(await trashPath(params.targets.agentDir, params.runtime))) {
+  if (
+    !sharedWithSurvivor(params.targets.agentDir) &&
+    !(await trashPath(params.targets.agentDir, params.runtime))
+  ) {
     errors.push(`Could not trash agent state ${params.targets.agentDir}.`);
   }
-  if (!(await trashPath(params.targets.sessionsDir, params.runtime))) {
+  if (
+    !sharedWithSurvivor(params.targets.sessionsDir) &&
+    !(await trashPath(params.targets.sessionsDir, params.runtime))
+  ) {
     errors.push(`Could not trash session transcripts ${params.targets.sessionsDir}.`);
   }
   return errors;

--- a/src/claws/lifecycle-remove-approvals.test.ts
+++ b/src/claws/lifecycle-remove-approvals.test.ts
@@ -1,22 +1,31 @@
 import { spawn } from "node:child_process";
 import { once } from "node:events";
-import { stat } from "node:fs/promises";
-import { join } from "node:path";
+import { rmSync, writeFileSync } from "node:fs";
+import { rm, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { stopChildProcess } from "../../test/helpers/stop-child-process.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { createAgent } from "../agents/agent-create.js";
 import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
 import { listAgentEntries } from "../agents/agent-scope.js";
+import {
+  appendTranscriptMessage,
+  loadSessionEntryReadOnly,
+} from "../config/sessions/session-accessor.js";
+import { replaceSessionEntrySync } from "../config/sessions/session-accessor.sqlite-entry.js";
 import { withTempHomeConfig, writeOpenClawConfig } from "../config/test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadExecApprovals, saveExecApprovals } from "../infra/exec-approvals.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { onSessionIdentityMutation } from "../sessions/session-lifecycle-events.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import { readAgentProvenance } from "../state/agent-provenance.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
 import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
 import {
   closeOpenClawAgentDatabases,
+  closeOpenClawAgentDatabaseByPath,
   listOpenClawRegisteredAgentDatabases,
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
@@ -111,6 +120,129 @@ function startHeldDatabase(agentId = "worker", pathname = "") {
 }
 
 describe("Claw exec approvals removal", () => {
+  it.each([false, true])("purges a retained session database (cold: %s)", async (cold) => {
+    const addPlan = await buildApprovalFixture();
+    await withTempHomeConfig({}, async ({ home }) => {
+      setTestEnvValue("OPENCLAW_STATE_DIR", join(home, ".openclaw"));
+      let config: OpenClawConfig = {};
+      await applyClawAddPlan(addPlan, {
+        consentPlanIntegrity: addPlan.planIntegrity,
+        commitConfig: async (transform) => {
+          config = transform(config);
+        },
+      });
+      const target = openOpenClawAgentDatabase({ agentId: "worker" });
+      config = {
+        ...config,
+        agents: {
+          ...config.agents,
+          entries: { ...config.agents?.entries, kept: { workspace: dirname(target.path) } },
+        },
+      };
+      await writeOpenClawConfig(home, config);
+      const workerScope = { agentId: "worker", sessionKey: "agent:worker:main" };
+      const keptScope = { agentId: "kept", sessionKey: "agent:kept:main" };
+      replaceSessionEntrySync(workerScope, { sessionId: "worker-session", updatedAt: 1 });
+      replaceSessionEntrySync(keptScope, { sessionId: "kept-session", updatedAt: 1 });
+      if (cold) {
+        closeOpenClawAgentDatabaseByPath(target.path);
+      }
+      const plan = await buildClawRemovePlan("worker");
+      const trashPath = vi.fn(async () => true);
+      await expect(
+        applyClawRemovePlan(plan, {
+          consentPlanIntegrity: plan.planIntegrity,
+          trashPath,
+        }),
+      ).resolves.toMatchObject({ status: "complete", agentRemoved: true });
+      expect(loadSessionEntryReadOnly(workerScope)).toBeUndefined();
+      expect(loadSessionEntryReadOnly(keptScope)?.sessionId).toBe("kept-session");
+      expect(target.db.isOpen).toBe(false);
+      expect(trashPath).not.toHaveBeenCalledWith(dirname(target.path), expect.anything());
+      expect(readAgentDeletionJournal("worker")?.cleanupCompleted).toBe(true);
+    });
+  });
+
+  it("retains an archive publication failure and completes its real session cleanup on retry", async () => {
+    const addPlan = await buildApprovalFixture();
+    await withTempHomeConfig({}, async ({ home }) => {
+      setTestEnvValue("OPENCLAW_STATE_DIR", join(home, ".openclaw"));
+      let config: OpenClawConfig = {};
+      await applyClawAddPlan(addPlan, {
+        consentPlanIntegrity: addPlan.planIntegrity,
+        commitConfig: async (transform) => {
+          config = transform(config);
+        },
+      });
+      const target = openOpenClawAgentDatabase({ agentId: "worker" });
+      config = {
+        ...config,
+        agents: {
+          ...config.agents,
+          entries: { ...config.agents?.entries, kept: { workspace: dirname(target.path) } },
+        },
+      };
+      await writeOpenClawConfig(home, config);
+      const scope = {
+        agentId: "worker",
+        sessionKey: "agent:worker:main",
+        sessionId: "worker-session",
+      };
+      replaceSessionEntrySync(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      await appendTranscriptMessage(scope, {
+        message: { role: "user", content: "retained archive fixture" },
+      });
+      const sessionsDir = join(dirname(dirname(target.path)), "sessions");
+      let obstructed = false;
+      const unsubscribe = onSessionIdentityMutation((mutation) => {
+        if (mutation.kind === "delete" && mutation.previous.sessionId === scope.sessionId) {
+          // Obstruct file publication only after the real archive row and deletion commit.
+          rmSync(sessionsDir, { force: true, recursive: true });
+          writeFileSync(sessionsDir, "archive directory obstruction");
+          obstructed = true;
+        }
+      });
+      const plan = await buildClawRemovePlan("worker");
+      const trashPath = vi.fn(async () => true);
+      try {
+        await expect(
+          applyClawRemovePlan(plan, {
+            trashPath,
+            consentPlanIntegrity: plan.planIntegrity,
+          }),
+        ).resolves.toMatchObject({ status: "partial", error: { code: "session_cleanup_failed" } });
+      } finally {
+        unsubscribe();
+      }
+      expect(obstructed).toBe(true);
+      expect(trashPath).not.toHaveBeenCalled();
+      expect(readAgentDeletionJournal("worker")?.cleanupCompleted).toBe(false);
+      expect(readAgentProvenance("worker")).toBeDefined();
+      const readArchives = () =>
+        withOpenClawAgentDatabaseReadOnly(
+          (database) =>
+            database.db.prepare("SELECT published_at FROM session_transcript_archives").all(),
+          { agentId: "worker" },
+        );
+      expect(readArchives()).toMatchObject({ found: true, value: [{ published_at: null }] });
+      expect(loadSessionEntryReadOnly(scope)).toBeUndefined();
+      await rm(sessionsDir);
+      const retry = await buildClawRemovePlan("worker");
+      await expect(
+        applyClawRemovePlan(retry, {
+          trashPath,
+          consentPlanIntegrity: retry.planIntegrity,
+        }),
+      ).resolves.toMatchObject({ status: "complete" });
+      expect(readAgentDeletionJournal("worker")?.cleanupCompleted).toBe(true);
+      expect(readAgentProvenance("worker")).toBeUndefined();
+      expect(readArchives()).toMatchObject({
+        found: true,
+        value: [{ published_at: expect.any(Number) }],
+      });
+    });
+  });
+
   it("preserves config, approvals, and files until another process closes its database", async () => {
     const addPlan = await buildApprovalFixture(true);
     await withTempHomeConfig({}, async ({ home }) => {
@@ -172,6 +304,28 @@ describe("Claw exec approvals removal", () => {
         expect(unsetMcpServer).not.toHaveBeenCalled();
         expect(readClawMcpServerRefs("worker")).toHaveLength(1);
         expect(readAgentDeletionJournal("worker")).toBeUndefined();
+        const agentDir = join(home, ".openclaw", "agents", "worker", "agent");
+        const deletion = beginAgentDeletion({
+          agentId: "worker",
+          agentDir,
+          workspaceDir: join(home, "workspace-worker"),
+          sessionsDir: join(home, ".openclaw", "agents", "worker", "sessions"),
+        });
+        const cleanup = vi.fn(async () => undefined);
+        try {
+          await expect(
+            deletion.runDatabaseCleanup(
+              {
+                agentId: "worker",
+                path: join(agentDir, "openclaw-agent.sqlite"),
+              },
+              cleanup,
+            ),
+          ).rejects.toThrow("database is still open in another process");
+          expect(cleanup).not.toHaveBeenCalled();
+        } finally {
+          deletion.rollback();
+        }
         await child.close();
         const retry = await buildClawRemovePlan("worker", { config });
         await expect(
@@ -183,6 +337,35 @@ describe("Claw exec approvals removal", () => {
         expect(trashPath).toHaveBeenCalled();
         expect(unsetMcpServer).toHaveBeenCalledOnce();
         expect(readAgentProvenance("worker")).toBeUndefined();
+      } finally {
+        await child.dispose();
+      }
+    });
+  });
+
+  it("refuses a cleanup capability while a foreign process holds a database beneath its paths", async () => {
+    await withTempHomeConfig({}, async ({ home }) => {
+      setTestEnvValue("OPENCLAW_STATE_DIR", join(home, ".openclaw"));
+      const agentDir = join(home, ".openclaw", "agents", "worker", "agent");
+      const target = { agentId: "kept", path: join(agentDir, "shared.sqlite") };
+      const child = startHeldDatabase(target.agentId, target.path);
+      try {
+        await child.ready;
+        const deletion = beginAgentDeletion({
+          agentId: "worker",
+          agentDir,
+          workspaceDir: join(home, "workspace-worker"),
+          sessionsDir: join(home, ".openclaw", "agents", "worker", "sessions"),
+        });
+        const cleanup = vi.fn(async () => openOpenClawAgentDatabase(target));
+        await expect(deletion.runDatabaseCleanup(target, cleanup)).rejects.toThrow(
+          "agent worker deletion owns",
+        );
+        expect(cleanup).not.toHaveBeenCalled();
+        await child.close();
+        const database = await deletion.runDatabaseCleanup(target, cleanup);
+        expect(database.db.isOpen).toBe(false);
+        deletion.rollback();
       } finally {
         await child.dispose();
       }

--- a/src/claws/lifecycle-remove-approvals.test.ts
+++ b/src/claws/lifecycle-remove-approvals.test.ts
@@ -1,24 +1,40 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { stat } from "node:fs/promises";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { stopChildProcess } from "../../test/helpers/stop-child-process.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { createAgent } from "../agents/agent-create.js";
 import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
+import { listAgentEntries } from "../agents/agent-scope.js";
 import { withTempHomeConfig, writeOpenClawConfig } from "../config/test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadExecApprovals, saveExecApprovals } from "../infra/exec-approvals.js";
+import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
+import { readAgentProvenance } from "../state/agent-provenance.js";
+import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabases,
+  listOpenClawRegisteredAgentDatabases,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { agentDatabaseHeldRuntimeEntrypoint } from "../state/openclaw-state-lease-runtime.test-support.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { applyClawAddPlan } from "./add.js";
 import {
-  claimClawAgentConfigRemoval,
+  withClawAgentConfigRemoval,
+  digestClawAgentConfig,
   digestClawAgentRemovalSurface,
 } from "./lifecycle-config-removal.js";
 import { applyClawRemovePlan, buildClawRemovePlan, readClawStatus } from "./lifecycle-state.js";
 import { buildClawAddPlan } from "./lifecycle.js";
+import { installClawMcpServers, readClawMcpServerRefs } from "./mcp.js";
 import { parseClawManifest } from "./schema.js";
 import type { ClawSourceIdentity } from "./types.js";
 
@@ -26,15 +42,20 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
 
 afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabases();
   closeOpenClawStateDatabaseForTest();
   envSnapshot.restore();
 });
 
-async function buildApprovalFixture() {
+const sourceMcpServer = { command: "fixture-mcp" };
+
+async function buildApprovalFixture(withMcp = false) {
   const root = tempDirs.make("openclaw-claw-remove-approvals-");
   const parsed = parseClawManifest({
     schemaVersion: 1,
     agent: { id: "worker", name: "Worker" },
+    ...(withMcp ? { mcpServers: { docs: sourceMcpServer } } : {}),
   });
   if (!parsed.ok) {
     throw new Error(JSON.stringify(parsed.diagnostics));
@@ -56,7 +77,247 @@ async function buildApprovalFixture() {
   });
 }
 
+function startHeldDatabase(agentId = "worker", pathname = "") {
+  const childUrl = resolveRuntimeWorkerUrl(agentDatabaseHeldRuntimeEntrypoint);
+  const child = spawn(
+    process.execPath,
+    [...resolveRuntimeWorkerArgv(childUrl), agentId, pathname],
+    {
+      env: { ...process.env },
+      stdio: ["ignore", "ignore", "pipe", "ipc"],
+    },
+  );
+  let childError = "";
+  child.stderr?.on("data", (chunk: Buffer) => {
+    childError = (childError + chunk.toString()).slice(-8192);
+  });
+  const closed = once(child, "close");
+  return {
+    ready: Promise.race([
+      once(child, "message"),
+      closed.then(() => {
+        throw new Error(`Database opener exited: ${childError}`);
+      }),
+    ]),
+    close: async () => {
+      child.send("close");
+      expect(await closed).toEqual([0, null]);
+    },
+    dispose: async () => {
+      await stopChildProcess(child, 5000);
+      await closed;
+    },
+  };
+}
+
 describe("Claw exec approvals removal", () => {
+  it("preserves config, approvals, and files until another process closes its database", async () => {
+    const addPlan = await buildApprovalFixture(true);
+    await withTempHomeConfig({}, async ({ home }) => {
+      setTestEnvValue("OPENCLAW_STATE_DIR", join(home, ".openclaw"));
+      let config: OpenClawConfig = {};
+      await applyClawAddPlan(addPlan, {
+        consentPlanIntegrity: addPlan.planIntegrity,
+        commitConfig: async (transform) => {
+          config = transform(config);
+        },
+        installMcpServers: async () => [],
+      });
+      await installClawMcpServers(addPlan, {
+        setMcpServer: async () => ({
+          ok: true,
+          path: "fixture",
+          config: {},
+          mcpServers: { docs: sourceMcpServer },
+        }),
+        listMcpServers: async () => ({ ok: true, path: "fixture", config: {}, mcpServers: {} }),
+      });
+      config = { ...config, mcp: { servers: { docs: sourceMcpServer } } };
+      await writeOpenClawConfig(home, config);
+      saveExecApprovals({ version: 1, agents: { worker: { security: "deny" } } });
+      const configBefore = structuredClone(config);
+      const approvalsBefore = loadExecApprovals();
+      const provenanceBefore = readAgentProvenance("worker");
+      expect(provenanceBefore?.createdVia).toBe("claw");
+      const child = startHeldDatabase();
+      try {
+        await child.ready;
+        const plan = await buildClawRemovePlan("worker", { config });
+        const trashPath = vi.fn(async () => true);
+        const unsetMcpServer = vi.fn(async () => ({
+          ok: true as const,
+          path: "fixture",
+          config: {},
+          mcpServers: {},
+          removed: true,
+        }));
+        const removeOptions = {
+          config,
+          unsetMcpServer,
+          commitConfig: async (transform: (current: OpenClawConfig) => OpenClawConfig) => {
+            config = transform(config);
+          },
+          trashPath,
+        };
+        await expect(
+          applyClawRemovePlan(plan, {
+            ...removeOptions,
+            consentPlanIntegrity: plan.planIntegrity,
+          }),
+        ).rejects.toThrow("database is still open in another process");
+        expect(config).toEqual(configBefore);
+        expect(loadExecApprovals()).toEqual(approvalsBefore);
+        expect(readAgentProvenance("worker")).toEqual(provenanceBefore);
+        expect(trashPath).not.toHaveBeenCalled();
+        expect(unsetMcpServer).not.toHaveBeenCalled();
+        expect(readClawMcpServerRefs("worker")).toHaveLength(1);
+        expect(readAgentDeletionJournal("worker")).toBeUndefined();
+        await child.close();
+        const retry = await buildClawRemovePlan("worker", { config });
+        await expect(
+          applyClawRemovePlan(retry, {
+            ...removeOptions,
+            consentPlanIntegrity: retry.planIntegrity,
+          }),
+        ).resolves.toMatchObject({ status: "complete", agentRemoved: true });
+        expect(trashPath).toHaveBeenCalled();
+        expect(unsetMcpServer).toHaveBeenCalledOnce();
+        expect(readAgentProvenance("worker")).toBeUndefined();
+      } finally {
+        await child.dispose();
+      }
+    });
+  });
+
+  it.each([
+    { failClose: false, shared: false },
+    { failClose: true, shared: false },
+    { failClose: false, shared: true },
+  ])(
+    "closes configured and relocated databases in their state owner (failed close: $failClose, shared: $shared)",
+    async ({ failClose, shared }) => {
+      const root = tempDirs.make("claw-delete-lease-owner-");
+      const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+      const agentDir = join(root, "custom-agent");
+      const foreign = openOpenClawAgentDatabase({ agentId: "kept", env });
+      const owned = openOpenClawAgentDatabase({
+        agentId: "worker",
+        env,
+        path: join(agentDir, "openclaw-agent.sqlite"),
+      });
+      const relocated = openOpenClawAgentDatabase({
+        agentId: "worker",
+        env,
+        path: join(root, "relocated.sqlite"),
+      });
+      let config: OpenClawConfig = {
+        agents: {
+          entries: {
+            worker: { agentDir, workspace: join(root, "workspace") },
+            ...(shared ? { kept: { workspace: root } } : {}),
+          },
+        },
+      };
+      const originalConfig = structuredClone(config);
+      const agent = listAgentEntries(config)[0]!;
+      const remove = () =>
+        withClawAgentConfigRemoval(
+          {
+            agentId: "worker",
+            expectedDigest: digestClawAgentConfig(agent),
+            expectedRemovalSurfaceDigest: digestClawAgentRemovalSurface(config, "worker"),
+            expectedState: "present",
+            fallbackWorkspace: agent.workspace!,
+            config,
+            stateDatabase: { env },
+            commitConfig: async (transform) => {
+              config = transform(config);
+            },
+            onModified: () => new Error("agent modified"),
+          },
+          (commitRemoval) => commitRemoval(),
+        );
+      if (failClose) {
+        vi.spyOn(owned.walMaintenance, "close").mockImplementationOnce(() => {
+          throw new Error("retained close failure");
+        });
+        await expect(remove()).rejects.toThrow("retained close failure");
+        expect(config).toEqual(originalConfig);
+        expect(owned.db.isOpen).toBe(true);
+        expect(readAgentDeletionJournal("worker", { env })).toBeUndefined();
+      }
+      await expect(remove()).resolves.toMatchObject({ agentRemoved: true });
+      expect(owned.db.isOpen).toBe(false);
+      expect(relocated.db.isOpen).toBe(false);
+      expect(foreign.db.isOpen).toBe(true);
+    },
+  );
+
+  it.each([
+    { kind: "agentState", schemaVersion: undefined },
+    { kind: "sessionTranscripts", schemaVersion: 1 },
+    { kind: "workspace", schemaVersion: 999 },
+  ])(
+    "refreshes closed foreign ownership before cleaning $kind (schema: $schemaVersion)",
+    async ({ kind, schemaVersion }) => {
+      const addPlan = await buildApprovalFixture();
+      await withTempHomeConfig({}, async ({ home }) => {
+        setTestEnvValue("OPENCLAW_STATE_DIR", join(home, ".openclaw"));
+        let config: OpenClawConfig = {};
+        const commitConfig = async (transform: (current: OpenClawConfig) => OpenClawConfig) => {
+          config = transform(config);
+        };
+        await applyClawAddPlan(addPlan, {
+          consentPlanIntegrity: addPlan.planIntegrity,
+          commitConfig,
+        });
+        const sharedDir =
+          kind === "workspace"
+            ? addPlan.agent.workspace
+            : join(
+                home,
+                ".openclaw",
+                "agents",
+                "worker",
+                kind === "agentState" ? "agent" : "sessions",
+              );
+        const foreignPath = join(sharedDir, "kept.sqlite");
+        expect(listOpenClawRegisteredAgentDatabases()).toEqual([]);
+        const child = startHeldDatabase("kept", foreignPath);
+        try {
+          await child.ready;
+          await child.close();
+        } finally {
+          await child.dispose();
+        }
+        if (schemaVersion !== undefined) {
+          registerOpenClawAgentDatabase({ agentId: "kept", path: foreignPath, schemaVersion });
+        }
+        const before = await stat(foreignPath);
+        const plan = await buildClawRemovePlan("worker", { config });
+        expect(plan.actions).toContainEqual(
+          expect.objectContaining({
+            kind,
+            target: sharedDir,
+            action: "retain",
+            reason: expect.stringContaining("another agent"),
+          }),
+        );
+        const trashPath = vi.fn(async () => true);
+        await expect(
+          applyClawRemovePlan(plan, {
+            config,
+            commitConfig,
+            trashPath,
+            consentPlanIntegrity: plan.planIntegrity,
+          }),
+        ).resolves.toMatchObject({ status: "complete" });
+        expect(trashPath).not.toHaveBeenCalledWith(sharedDir, expect.anything());
+        expect((await stat(foreignPath)).ino).toBe(before.ino);
+      });
+    },
+  );
+
   it.each([
     { label: "config-file commit", commit: false, complete: true },
     { label: "commitConfig seam", commit: true, complete: true },
@@ -124,6 +385,7 @@ describe("Claw exec approvals removal", () => {
         cleanupCompleted: complete,
         deleteFiles: false,
       });
+      expect(readAgentProvenance("worker")?.createdVia).toBe(complete ? undefined : "claw");
     });
   });
 
@@ -232,18 +494,21 @@ describe("Claw exec approvals removal", () => {
     }
 
     await expect(
-      claimClawAgentConfigRemoval({
-        agentId: "worker",
-        expectedDigest: "sha256:unused",
-        expectedRemovalSurfaceDigest: digestClawAgentRemovalSurface({}, "worker"),
-        expectedState: "present",
-        fallbackWorkspace: join(root, "workspace"),
-        config: {},
-        commitConfig: async () => {
-          throw new Error("claw commit failed");
+      withClawAgentConfigRemoval(
+        {
+          agentId: "worker",
+          expectedDigest: "sha256:unused",
+          expectedRemovalSurfaceDigest: digestClawAgentRemovalSurface({}, "worker"),
+          expectedState: "present",
+          fallbackWorkspace: join(root, "workspace"),
+          config: {},
+          commitConfig: async () => {
+            throw new Error("claw commit failed");
+          },
+          onModified: () => new Error("claw agent modified"),
         },
-        onModified: () => new Error("claw agent modified"),
-      }),
+        (commitRemoval) => commitRemoval(),
+      ),
     ).rejects.toThrow("claw commit failed");
 
     expect(readAgentDeletionJournal("worker") === undefined).toBe(!seedJournal);

--- a/src/claws/lifecycle-remove-contract.ts
+++ b/src/claws/lifecycle-remove-contract.ts
@@ -1,3 +1,15 @@
+import type { unsetConfiguredMcpServer } from "../agents/mcp-config-mutation.js";
+import type { listConfiguredMcpServers } from "../config/mcp-config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import type { ClawCronGateway } from "./cron.js";
+import type { ConfigCommit } from "./lifecycle-config-removal.js";
+import type { ClawTrashPath, RemovedWorkspaceFile } from "./lifecycle-delete-support.js";
+import type {
+  ClawPackageRemovalResult,
+  ClawReferencedCleanup,
+  PackageRemovalDeps,
+} from "./package-remove.js";
 import { CLAW_OUTPUT_STABILITY } from "./types.js";
 
 export const CLAW_REMOVE_PLAN_SCHEMA_VERSION = "openclaw.clawRemovePlan.v1" as const;
@@ -49,4 +61,38 @@ export type RemovedMcpServer = {
   name: string;
   action: "removed" | "missing" | "released" | "error";
   message?: string;
+};
+
+export type ClawRemovePlanOptions = OpenClawStateDatabaseOptions & {
+  config?: OpenClawConfig;
+  sourceMcpServers?: Record<string, Record<string, unknown>>;
+  listMcpServers?: typeof listConfiguredMcpServers;
+  packageDeps?: PackageRemovalDeps;
+  referencedCleanup?: ClawReferencedCleanup;
+};
+
+export type ClawRemoveApplyOptions = ClawRemovePlanOptions & {
+  commitConfig?: ConfigCommit;
+  purgeSessions?: (config: OpenClawConfig, agentId: string) => Promise<void>;
+  trashPath?: ClawTrashPath;
+  consentPlanIntegrity?: string;
+  unsetMcpServer?: typeof unsetConfiguredMcpServer;
+  cronGateway?: Pick<ClawCronGateway, "get" | "remove">;
+};
+
+export const CLAW_REMOVE_RESULT_SCHEMA_VERSION = "openclaw.clawRemoveResult.v1" as const;
+export type ClawRemoveResult = {
+  schemaVersion: typeof CLAW_REMOVE_RESULT_SCHEMA_VERSION;
+  stability: typeof CLAW_OUTPUT_STABILITY;
+  dryRun: false;
+  status: "complete" | "partial";
+  agentId: string;
+  agentRemoved: boolean;
+  bootstrap?: RemovedWorkspaceFile;
+  workspaceFiles: RemovedWorkspaceFile[];
+  packages: ClawPackageRemovalResult[];
+  mcpServers: RemovedMcpServer[];
+  cronJobs: RemovedCronJob[];
+  packageRefsReleased: number;
+  error?: { code: string; message: string };
 };

--- a/src/claws/lifecycle-remove-contract.ts
+++ b/src/claws/lifecycle-remove-contract.ts
@@ -1,5 +1,6 @@
 import type { unsetConfiguredMcpServer } from "../agents/mcp-config-mutation.js";
 import type { listConfiguredMcpServers } from "../config/mcp-config.js";
+import type { purgeAgentSessionStoreEntries } from "../config/sessions/cleanup-service.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import type { ClawCronGateway } from "./cron.js";
@@ -50,7 +51,7 @@ export type ClawRemovePlan = {
   blockers: Array<{ code: string; message: string }>;
 };
 
-export type RemovedCronJob = {
+type RemovedCronJob = {
   manifestId: string;
   schedulerJobId?: string;
   action: "removed" | "error";
@@ -73,7 +74,9 @@ export type ClawRemovePlanOptions = OpenClawStateDatabaseOptions & {
 
 export type ClawRemoveApplyOptions = ClawRemovePlanOptions & {
   commitConfig?: ConfigCommit;
-  purgeSessions?: (config: OpenClawConfig, agentId: string) => Promise<void>;
+  purgeSessions?: (
+    ...args: Parameters<typeof purgeAgentSessionStoreEntries>
+  ) => Promise<boolean | void>;
   trashPath?: ClawTrashPath;
   consentPlanIntegrity?: string;
   unsetMcpServer?: typeof unsetConfiguredMcpServer;

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../state/openclaw-state-db.js";
 import { applyClawAddPlan } from "./add.js";
 import { markClawCronRefRemoved, readClawCronRefs } from "./cron.js";
-import { claimClawAgentConfigRemoval } from "./lifecycle-config-removal.js";
+import { withClawAgentConfigRemoval } from "./lifecycle-config-removal.js";
 import { applyClawRemovePlan, buildClawRemovePlan, readClawStatus } from "./lifecycle-state.js";
 import { buildClawAddPlan } from "./lifecycle.js";
 import {
@@ -176,15 +176,18 @@ async function addFixture(
 describe("Claw status and remove", () => {
   it("rejects cleanup when an expected-missing agent id was recreated", async () => {
     await expect(
-      claimClawAgentConfigRemoval({
-        agentId: "worker",
-        expectedDigest: "sha256:missing",
-        expectedRemovalSurfaceDigest: "sha256:unused",
-        expectedState: "missing",
-        fallbackWorkspace: "/tmp/old-worker",
-        config: { agents: { entries: { worker: { workspace: "/tmp/new-worker" } } } },
-        onModified: () => new Error("agent recreated"),
-      }),
+      withClawAgentConfigRemoval(
+        {
+          agentId: "worker",
+          expectedDigest: "sha256:missing",
+          expectedRemovalSurfaceDigest: "sha256:unused",
+          expectedState: "missing",
+          fallbackWorkspace: "/tmp/old-worker",
+          config: { agents: { entries: { worker: { workspace: "/tmp/new-worker" } } } },
+          onModified: () => new Error("agent recreated"),
+        },
+        (commitRemoval) => commitRemoval(),
+      ),
     ).rejects.toThrow("agent recreated");
   });
 

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -25,7 +25,6 @@ import {
   releaseClawRemoveRows,
   removeClawWorkspaceFile,
   workspaceContainsUntrackedEntries,
-  type RemovedWorkspaceFile,
 } from "./lifecycle-delete-support.js";
 import { removeClawMcpServers } from "./lifecycle-mcp-removal.js";
 import {
@@ -36,7 +35,6 @@ import {
   type ClawRemoveResult,
   type ClawRemovePlan,
   type ClawRemovePlanAction,
-  type RemovedCronJob,
 } from "./lifecycle-remove-contract.js";
 import { readClawStatus } from "./lifecycle-status.js";
 import { clawMcpRemovalSelector, planClawMcpServerRemoval } from "./mcp.js";
@@ -491,30 +489,33 @@ export async function applyClawRemovePlan(
         new ClawRemoveError("agent_modified", "Agent config changed during remove."),
     },
     async (commitRemoval) => {
+      const result: ClawRemoveResult = {
+        schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
+        stability: CLAW_OUTPUT_STABILITY,
+        dryRun: false,
+        status: "partial",
+        agentId,
+        agentRemoved: false,
+        workspaceFiles: [],
+        packages: [],
+        mcpServers: [],
+        cronJobs: [],
+        packageRefsReleased: 0,
+      };
+      const partial = (code: string, message: string): ClawRemoveResult => {
+        updateClawInstallRecordStatus(agentId, "partial", options);
+        return { ...result, error: { code, message } };
+      };
       const mcpRemoval = await removeClawMcpServers({
         agentId,
         servers: record.mcpServers,
         options,
       });
-      const mcpServers = mcpRemoval.mcpServers;
+      result.mcpServers = mcpRemoval.mcpServers;
       if (mcpRemoval.error) {
-        updateClawInstallRecordStatus(agentId, "partial", options);
-        return {
-          schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
-          stability: CLAW_OUTPUT_STABILITY,
-          dryRun: false,
-          status: "partial",
-          agentId,
-          agentRemoved: false,
-          workspaceFiles: [],
-          packages: [],
-          mcpServers,
-          cronJobs: [],
-          packageRefsReleased: 0,
-          error: { code: "mcp_cleanup_failed", message: mcpRemoval.error },
-        };
+        return partial("mcp_cleanup_failed", mcpRemoval.error);
       }
-      const cronJobs: RemovedCronJob[] = [];
+      const cronJobs = result.cronJobs;
       for (const cron of record.cronJobs) {
         if (cron.status !== "removed" && (!cron.schedulerJobId || cron.status !== "complete")) {
           throw new ClawRemoveError(
@@ -567,34 +568,30 @@ export async function applyClawRemovePlan(
             action: "error",
             message,
           });
-          updateClawInstallRecordStatus(agentId, "partial", options);
-          return {
-            schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
-            stability: CLAW_OUTPUT_STABILITY,
-            dryRun: false,
-            status: "partial",
-            agentId,
-            agentRemoved: false,
-            workspaceFiles: [],
-            packages: [],
-            mcpServers,
-            cronJobs,
-            packageRefsReleased: 0,
-            error: { code: "cron_cleanup_failed", message },
-          };
+          return partial("cron_cleanup_failed", message);
         }
       }
       const configRemoval = await commitRemoval();
-      const { agentRemoved, cleanupTargets, configBeforeDelete } = configRemoval;
+      const { cleanupTargets, configBeforeDelete } = configRemoval;
+      result.agentRemoved = configRemoval.agentRemoved;
       const committedNextConfig = configRemoval.nextConfig;
       const completeDeletion = configRemoval.completeDeletion;
       if (!options.commitConfig || options.purgeSessions) {
         const purgeSessions =
           options.purgeSessions ??
           (await import("../config/sessions/cleanup-service.js")).purgeAgentSessionStoreEntries;
-        await purgeSessions(configBeforeDelete, agentId);
+        const purgeFailed = await purgeSessions(configBeforeDelete, agentId, {
+          env: options.env,
+          runDatabaseCleanup: configRemoval.runDatabaseCleanup,
+        });
+        if (purgeFailed) {
+          return partial(
+            "session_cleanup_failed",
+            "Session cleanup failed; correct the reported error and retry Claw removal.",
+          );
+        }
       }
-      const packages = await applyClawPackageRemovals(
+      result.packages = await applyClawPackageRemovals(
         packageDecisions.toSorted(
           (left, right) =>
             Number(left.packageRef.relationship === "referenced") -
@@ -605,28 +602,11 @@ export async function applyClawRemovePlan(
           deps: options.packageDeps,
         },
       );
-      const packageErrors = packages.filter((pkg) => pkg.action === "error");
+      const packageErrors = result.packages.filter((pkg) => pkg.action === "error");
       if (packageErrors.length > 0) {
-        updateClawInstallRecordStatus(agentId, "partial", options);
-        return {
-          schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
-          stability: CLAW_OUTPUT_STABILITY,
-          dryRun: false,
-          status: "partial",
-          agentId,
-          agentRemoved,
-          workspaceFiles: [],
-          packages,
-          mcpServers,
-          cronJobs,
-          packageRefsReleased: 0,
-          error: {
-            code: "package_cleanup_failed",
-            message: packageErrors.map((pkg) => pkg.reason).join("; "),
-          },
-        };
+        return partial("package_cleanup_failed", packageErrors.map((pkg) => pkg.reason).join("; "));
       }
-      const workspaceFiles: RemovedWorkspaceFile[] = [];
+      const workspaceFiles = result.workspaceFiles;
       for (const file of record.workspaceFiles) {
         workspaceFiles.push(await removeClawWorkspaceFile(file));
       }
@@ -663,17 +643,9 @@ export async function applyClawRemovePlan(
       }
       releaseClawRemoveRows(agentId, workspaceFiles, complete, completeDeletion, options);
       return {
-        schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
-        stability: CLAW_OUTPUT_STABILITY,
-        dryRun: false,
+        ...result,
         status: complete ? "complete" : "partial",
-        agentId,
-        agentRemoved,
         ...(bootstrap ? { bootstrap } : {}),
-        workspaceFiles,
-        packages,
-        mcpServers,
-        cronJobs,
         packageRefsReleased: complete ? record.packages.length : 0,
         ...(complete
           ? {}

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -1,29 +1,20 @@
 import { createHash } from "node:crypto";
 import { coerceErrorMessage, stableStringify } from "@openclaw/normalization-core";
-import { unsetConfiguredMcpServer } from "../agents/mcp-config-mutation.js";
+import {
+  isPathOwnedBySurvivingAgent,
+  readAgentDeleteDatabaseRegistry,
+  resolveSurvivingDatabaseFilePaths,
+} from "../agents/agent-delete-databases.js";
 import { getRuntimeConfig } from "../config/config.js";
-import { listConfiguredMcpServers } from "../config/mcp-config.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  closeOpenClawAgentDatabaseByPath,
-  resolveOpenClawAgentSqlitePath,
-} from "../state/openclaw-agent-db.js";
-import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
-import {
-  clawCronGatewayJobMatchesRef,
-  deleteClawCronRef,
-  markClawCronRefRemoved,
-  type ClawCronGateway,
-} from "./cron.js";
+import { clawCronGatewayJobMatchesRef, deleteClawCronRef, markClawCronRefRemoved } from "./cron.js";
 import {
   clawBootstrapStateBlocksRemove,
   planClawBootstrapRemoval,
   removeClawBootstrap,
 } from "./lifecycle-bootstrap-removal.js";
 import {
-  claimClawAgentConfigRemoval,
+  withClawAgentConfigRemoval,
   digestClawAgentRemovalSurface,
-  type ConfigCommit,
 } from "./lifecycle-config-removal.js";
 import {
   clawRemoveQuietRuntime,
@@ -34,60 +25,36 @@ import {
   releaseClawRemoveRows,
   removeClawWorkspaceFile,
   workspaceContainsUntrackedEntries,
-  type ClawTrashPath,
   type RemovedWorkspaceFile,
 } from "./lifecycle-delete-support.js";
 import { removeClawMcpServers } from "./lifecycle-mcp-removal.js";
 import {
   CLAW_REMOVE_PLAN_SCHEMA_VERSION,
+  CLAW_REMOVE_RESULT_SCHEMA_VERSION,
+  type ClawRemoveApplyOptions,
+  type ClawRemovePlanOptions,
+  type ClawRemoveResult,
   type ClawRemovePlan,
   type ClawRemovePlanAction,
   type RemovedCronJob,
-  type RemovedMcpServer,
 } from "./lifecycle-remove-contract.js";
 import { readClawStatus } from "./lifecycle-status.js";
 import { clawMcpRemovalSelector, planClawMcpServerRemoval } from "./mcp.js";
 import { projectClawPackageRemovePlan } from "./package-remove-plan.js";
-import {
-  applyClawPackageRemovals,
-  planClawPackageRemovals,
-  type ClawPackageRemovalResult,
-  type ClawReferencedCleanup,
-  type PackageRemovalDeps,
-} from "./package-remove.js";
+import { applyClawPackageRemovals, planClawPackageRemovals } from "./package-remove.js";
 import { updateClawInstallRecordStatus } from "./provenance.js";
 import { CLAW_OUTPUT_STABILITY } from "./types.js";
 
 export { ClawRemoveError } from "./lifecycle-delete-support.js";
-export { CLAW_REMOVE_PLAN_SCHEMA_VERSION } from "./lifecycle-remove-contract.js";
+export {
+  CLAW_REMOVE_PLAN_SCHEMA_VERSION,
+  CLAW_REMOVE_RESULT_SCHEMA_VERSION,
+} from "./lifecycle-remove-contract.js";
 export { readClawStatus, type ClawStatusRecord } from "./lifecycle-status.js";
-
-export const CLAW_REMOVE_RESULT_SCHEMA_VERSION = "openclaw.clawRemoveResult.v1" as const;
-type ClawRemoveResult = {
-  schemaVersion: typeof CLAW_REMOVE_RESULT_SCHEMA_VERSION;
-  stability: typeof CLAW_OUTPUT_STABILITY;
-  dryRun: false;
-  status: "complete" | "partial";
-  agentId: string;
-  agentRemoved: boolean;
-  bootstrap?: RemovedWorkspaceFile;
-  workspaceFiles: RemovedWorkspaceFile[];
-  packages: ClawPackageRemovalResult[];
-  mcpServers: RemovedMcpServer[];
-  cronJobs: RemovedCronJob[];
-  packageRefsReleased: number;
-  error?: { code: string; message: string };
-};
 
 export async function buildClawRemovePlan(
   target: string,
-  options: OpenClawStateDatabaseOptions & {
-    config?: OpenClawConfig;
-    sourceMcpServers?: Record<string, Record<string, unknown>>;
-    listMcpServers?: typeof listConfiguredMcpServers;
-    packageDeps?: PackageRemovalDeps;
-    referencedCleanup?: ClawReferencedCleanup;
-  } = {},
+  options: ClawRemovePlanOptions = {},
 ): Promise<ClawRemovePlan> {
   const status = await readClawStatus(target, options);
   const blockers: ClawRemovePlan["blockers"] = [];
@@ -165,11 +132,29 @@ export async function buildClawRemovePlan(
       cleanup: packageCleanup,
     });
     blockers.push(...packagePlan.blockers);
+    const config = options.config ?? getRuntimeConfig();
     const effects = deletionEffects(
-      options.config ?? getRuntimeConfig(),
+      config,
       record.install.agentId,
       record.install.workspace,
+      options.env,
     );
+    const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
+      readAgentDeleteDatabaseRegistry(options),
+      record.install.agentId,
+      options.env,
+    );
+    const sharedWithSurvivor = (pathname: string) =>
+      isPathOwnedBySurvivingAgent(
+        config,
+        record.install.agentId,
+        pathname,
+        survivingDatabaseFilePaths,
+        options.env,
+      );
+    const sharedWorkspace = Boolean(effects.workspace) && sharedWithSurvivor(effects.workspace);
+    const sharedAgentDir = sharedWithSurvivor(effects.agentDir);
+    const sharedSessionsDir = sharedWithSurvivor(effects.sessionsDir);
     const workspaceHasModifiedFiles =
       record.workspaceFiles.some((file) => file.state === "modified") ||
       record.bootstrap.state === "modified";
@@ -237,18 +222,17 @@ export async function buildClawRemovePlan(
         kind: "workspace",
         id: record.install.agentId,
         action:
-          effects.workspaceRetained || workspaceHasModifiedFiles || workspaceHasUntrackedEntries
+          sharedWorkspace || workspaceHasModifiedFiles || workspaceHasUntrackedEntries
             ? "retain"
             : "trash",
         target: effects.workspace,
         blocked: record.agentState === "modified",
         details: {
-          retained:
-            effects.workspaceRetained || workspaceHasModifiedFiles || workspaceHasUntrackedEntries,
+          retained: sharedWorkspace || workspaceHasModifiedFiles || workspaceHasUntrackedEntries,
           sharedWith: effects.workspaceSharedWith,
         },
-        ...(effects.workspaceRetained
-          ? { reason: "Workspace overlaps another agent." }
+        ...(sharedWorkspace
+          ? { reason: "Workspace contains state owned by another agent." }
           : workspaceHasModifiedFiles
             ? { reason: "Workspace contains locally modified Claw-managed files." }
             : workspaceHasUntrackedEntries
@@ -260,9 +244,12 @@ export async function buildClawRemovePlan(
       actions.push({
         kind: "agentState",
         id: record.install.agentId,
-        action: "trash",
+        action: sharedAgentDir ? "retain" : "trash",
         target: effects.agentDir,
         blocked: record.agentState === "modified",
+        ...(sharedAgentDir
+          ? { reason: "Agent directory contains state owned by another agent." }
+          : {}),
       });
     }
     actions.push({
@@ -275,9 +262,12 @@ export async function buildClawRemovePlan(
     actions.push({
       kind: "sessionTranscripts",
       id: record.install.agentId,
-      action: "trash",
+      action: sharedSessionsDir ? "retain" : "trash",
       target: effects.sessionsDir,
       blocked: record.agentState === "modified",
+      ...(sharedSessionsDir
+        ? { reason: "Session directory contains state owned by another agent." }
+        : {}),
     });
     for (const job of attachedJobs) {
       actions.push({
@@ -415,22 +405,9 @@ export async function buildClawRemovePlan(
   };
 }
 
-type PurgeSessions = (config: OpenClawConfig, agentId: string) => Promise<void>;
 export async function applyClawRemovePlan(
   plan: ClawRemovePlan,
-  options: OpenClawStateDatabaseOptions & {
-    config?: OpenClawConfig;
-    sourceMcpServers?: Record<string, Record<string, unknown>>;
-    listMcpServers?: typeof listConfiguredMcpServers;
-    commitConfig?: ConfigCommit;
-    packageDeps?: PackageRemovalDeps;
-    referencedCleanup?: ClawReferencedCleanup;
-    purgeSessions?: PurgeSessions;
-    trashPath?: ClawTrashPath;
-    consentPlanIntegrity?: string;
-    unsetMcpServer?: typeof unsetConfiguredMcpServer;
-    cronGateway?: Pick<ClawCronGateway, "get" | "remove">;
-  } = {},
+  options: ClawRemoveApplyOptions = {},
 ): Promise<ClawRemoveResult> {
   if (options.consentPlanIntegrity !== plan.planIntegrity) {
     throw new ClawRemoveError(
@@ -499,205 +476,214 @@ export async function applyClawRemovePlan(
   if (JSON.stringify(plannedMcpServers) !== JSON.stringify(currentMcpServers)) {
     throw new ClawRemoveError("remove_changed", "MCP ownership changed after remove planning.");
   }
-  const mcpRemoval = await removeClawMcpServers({
-    agentId: plan.agentId,
-    servers: record.mcpServers,
-    options,
-  });
-  const mcpServers = mcpRemoval.mcpServers;
-  if (mcpRemoval.error) {
-    updateClawInstallRecordStatus(agentId, "partial", options);
-    return {
-      schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
-      stability: CLAW_OUTPUT_STABILITY,
-      dryRun: false,
-      status: "partial",
+  return await withClawAgentConfigRemoval<ClawRemoveResult>(
+    {
       agentId,
-      agentRemoved: false,
-      workspaceFiles: [],
-      packages: [],
-      mcpServers,
-      cronJobs: [],
-      packageRefsReleased: 0,
-      error: { code: "mcp_cleanup_failed", message: mcpRemoval.error },
-    };
-  }
-  const cronJobs: RemovedCronJob[] = [];
-  for (const cron of record.cronJobs) {
-    if (cron.status !== "removed" && (!cron.schedulerJobId || cron.status !== "complete")) {
-      throw new ClawRemoveError(
-        "cron_cleanup_uncertain",
-        `Cron declaration ${JSON.stringify(cron.manifestId)} is not safely removable.`,
-      );
-    }
-    if (cron.status !== "removed" && (!options.cronGateway?.get || !options.cronGateway.remove)) {
-      throw new ClawRemoveError(
-        "cron_gateway_required",
-        "Claw cron jobs require the gateway-owned cron.get and cron.remove APIs.",
-      );
-    }
-    try {
-      if (cron.status !== "removed") {
-        const live = await options.cronGateway!.get!(cron.schedulerJobId!);
-        if (live != null && !clawCronGatewayJobMatchesRef(plan.agentId, cron, live)) {
-          throw new Error(
-            `Cron declaration ${JSON.stringify(cron.manifestId)} changed after planning.`,
+      expectedDigest: record.install.agentConfigDigest,
+      expectedRemovalSurfaceDigest,
+      expectedState: record.agentState,
+      fallbackWorkspace: record.install.workspace,
+      config: options.config,
+      commitConfig: options.commitConfig,
+      stateDatabase: options,
+      trashPath: options.trashPath,
+      onModified: () =>
+        new ClawRemoveError("agent_modified", "Agent config changed during remove."),
+    },
+    async (commitRemoval) => {
+      const mcpRemoval = await removeClawMcpServers({
+        agentId,
+        servers: record.mcpServers,
+        options,
+      });
+      const mcpServers = mcpRemoval.mcpServers;
+      if (mcpRemoval.error) {
+        updateClawInstallRecordStatus(agentId, "partial", options);
+        return {
+          schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
+          stability: CLAW_OUTPUT_STABILITY,
+          dryRun: false,
+          status: "partial",
+          agentId,
+          agentRemoved: false,
+          workspaceFiles: [],
+          packages: [],
+          mcpServers,
+          cronJobs: [],
+          packageRefsReleased: 0,
+          error: { code: "mcp_cleanup_failed", message: mcpRemoval.error },
+        };
+      }
+      const cronJobs: RemovedCronJob[] = [];
+      for (const cron of record.cronJobs) {
+        if (cron.status !== "removed" && (!cron.schedulerJobId || cron.status !== "complete")) {
+          throw new ClawRemoveError(
+            "cron_cleanup_uncertain",
+            `Cron declaration ${JSON.stringify(cron.manifestId)} is not safely removable.`,
           );
         }
-        if (live != null) {
-          try {
-            await options.cronGateway!.remove(cron.schedulerJobId!);
-          } catch (removeError) {
-            // A transport failure can lose a successful cron.remove response. Re-read the
-            // gateway before preserving ownership so retries can converge on confirmed absence.
-            const afterRemove = await options.cronGateway!.get!(cron.schedulerJobId!);
-            if (afterRemove != null) {
-              throw removeError;
-            }
-          }
+        if (
+          cron.status !== "removed" &&
+          (!options.cronGateway?.get || !options.cronGateway.remove)
+        ) {
+          throw new ClawRemoveError(
+            "cron_gateway_required",
+            "Claw cron jobs require the gateway-owned cron.get and cron.remove APIs.",
+          );
         }
-        markClawCronRefRemoved(plan.agentId, cron.manifestId, options);
+        try {
+          if (cron.status !== "removed") {
+            const live = await options.cronGateway!.get!(cron.schedulerJobId!);
+            if (live != null && !clawCronGatewayJobMatchesRef(agentId, cron, live)) {
+              throw new Error(
+                `Cron declaration ${JSON.stringify(cron.manifestId)} changed after planning.`,
+              );
+            }
+            if (live != null) {
+              try {
+                await options.cronGateway!.remove(cron.schedulerJobId!);
+              } catch (removeError) {
+                // A transport failure can lose a successful cron.remove response. Re-read the
+                // gateway before preserving ownership so retries can converge on confirmed absence.
+                const afterRemove = await options.cronGateway!.get!(cron.schedulerJobId!);
+                if (afterRemove != null) {
+                  throw removeError;
+                }
+              }
+            }
+            markClawCronRefRemoved(agentId, cron.manifestId, options);
+          }
+          deleteClawCronRef(agentId, cron.manifestId, options);
+          cronJobs.push({
+            manifestId: cron.manifestId,
+            schedulerJobId: cron.schedulerJobId,
+            action: "removed",
+          });
+        } catch (error) {
+          const message = coerceErrorMessage(error);
+          cronJobs.push({
+            manifestId: cron.manifestId,
+            schedulerJobId: cron.schedulerJobId,
+            action: "error",
+            message,
+          });
+          updateClawInstallRecordStatus(agentId, "partial", options);
+          return {
+            schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
+            stability: CLAW_OUTPUT_STABILITY,
+            dryRun: false,
+            status: "partial",
+            agentId,
+            agentRemoved: false,
+            workspaceFiles: [],
+            packages: [],
+            mcpServers,
+            cronJobs,
+            packageRefsReleased: 0,
+            error: { code: "cron_cleanup_failed", message },
+          };
+        }
       }
-      deleteClawCronRef(plan.agentId, cron.manifestId, options);
-      cronJobs.push({
-        manifestId: cron.manifestId,
-        schedulerJobId: cron.schedulerJobId,
-        action: "removed",
-      });
-    } catch (error) {
-      const message = coerceErrorMessage(error);
-      cronJobs.push({
-        manifestId: cron.manifestId,
-        schedulerJobId: cron.schedulerJobId,
-        action: "error",
-        message,
-      });
-      updateClawInstallRecordStatus(agentId, "partial", options);
+      const configRemoval = await commitRemoval();
+      const { agentRemoved, cleanupTargets, configBeforeDelete } = configRemoval;
+      const committedNextConfig = configRemoval.nextConfig;
+      const completeDeletion = configRemoval.completeDeletion;
+      if (!options.commitConfig || options.purgeSessions) {
+        const purgeSessions =
+          options.purgeSessions ??
+          (await import("../config/sessions/cleanup-service.js")).purgeAgentSessionStoreEntries;
+        await purgeSessions(configBeforeDelete, agentId);
+      }
+      const packages = await applyClawPackageRemovals(
+        packageDecisions.toSorted(
+          (left, right) =>
+            Number(left.packageRef.relationship === "referenced") -
+            Number(right.packageRef.relationship === "referenced"),
+        ),
+        {
+          ...options,
+          deps: options.packageDeps,
+        },
+      );
+      const packageErrors = packages.filter((pkg) => pkg.action === "error");
+      if (packageErrors.length > 0) {
+        updateClawInstallRecordStatus(agentId, "partial", options);
+        return {
+          schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
+          stability: CLAW_OUTPUT_STABILITY,
+          dryRun: false,
+          status: "partial",
+          agentId,
+          agentRemoved,
+          workspaceFiles: [],
+          packages,
+          mcpServers,
+          cronJobs,
+          packageRefsReleased: 0,
+          error: {
+            code: "package_cleanup_failed",
+            message: packageErrors.map((pkg) => pkg.reason).join("; "),
+          },
+        };
+      }
+      const workspaceFiles: RemovedWorkspaceFile[] = [];
+      for (const file of record.workspaceFiles) {
+        workspaceFiles.push(await removeClawWorkspaceFile(file));
+      }
+      const bootstrap = await removeClawBootstrap(record);
+      const cleanupErrors = workspaceFiles
+        .filter((file) => file.action === "error")
+        .map((file) => file.message ?? `Could not remove ${file.path}.`);
+      if (bootstrap?.action === "error") {
+        cleanupErrors.push(bootstrap.message ?? `Could not remove ${bootstrap.path}.`);
+      }
+      if (cleanupErrors.length === 0 && cleanupTargets && committedNextConfig) {
+        const workspaceHasRemainingEntries = await workspaceContainsUntrackedEntries(
+          cleanupTargets.workspaceDir,
+          record.workspaceFiles.map((file) => file.path),
+        );
+        cleanupErrors.push(
+          ...(await cleanupClawAgentFilesystem({
+            agentId,
+            nextConfig: committedNextConfig,
+            targets: cleanupTargets,
+            runtime: clawRemoveQuietRuntime,
+            trashPath: options.trashPath,
+            stateDatabase: options,
+            retainWorkspace:
+              workspaceHasRemainingEntries ||
+              bootstrap?.action === "retainedModified" ||
+              workspaceFiles.some((file) => file.action === "retainedModified"),
+          })),
+        );
+      }
+      const complete = cleanupErrors.length === 0;
+      if (!complete) {
+        updateClawInstallRecordStatus(agentId, "partial", options);
+      }
+      releaseClawRemoveRows(agentId, workspaceFiles, complete, completeDeletion, options);
       return {
         schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
         stability: CLAW_OUTPUT_STABILITY,
         dryRun: false,
-        status: "partial",
-        agentId: plan.agentId,
-        agentRemoved: false,
-        workspaceFiles: [],
-        packages: [],
+        status: complete ? "complete" : "partial",
+        agentId,
+        agentRemoved,
+        ...(bootstrap ? { bootstrap } : {}),
+        workspaceFiles,
+        packages,
         mcpServers,
         cronJobs,
-        packageRefsReleased: 0,
-        error: { code: "cron_cleanup_failed", message },
+        packageRefsReleased: complete ? record.packages.length : 0,
+        ...(complete
+          ? {}
+          : {
+              error: {
+                code: "workspace_cleanup_failed",
+                message: cleanupErrors.join("; "),
+              },
+            }),
       };
-    }
-  }
-  const configRemoval = await claimClawAgentConfigRemoval({
-    agentId,
-    expectedDigest: record.install.agentConfigDigest,
-    expectedRemovalSurfaceDigest,
-    expectedState: record.agentState,
-    fallbackWorkspace: record.install.workspace,
-    config: options.config,
-    commitConfig: options.commitConfig,
-    stateDatabase: options,
-    trashPath: options.trashPath,
-    onModified: () => new ClawRemoveError("agent_modified", "Agent config changed during remove."),
-  });
-  const { agentRemoved, cleanupTargets, configBeforeDelete } = configRemoval;
-  const committedNextConfig = configRemoval.nextConfig;
-  const completeDeletion = configRemoval.completeDeletion;
-  if (!options.commitConfig || options.purgeSessions) {
-    const purgeSessions =
-      options.purgeSessions ??
-      (await import("../config/sessions/cleanup-service.js")).purgeAgentSessionStoreEntries;
-    await purgeSessions(configBeforeDelete, agentId);
-  }
-  closeOpenClawAgentDatabaseByPath(resolveOpenClawAgentSqlitePath({ agentId, env: options.env }));
-  const packages = await applyClawPackageRemovals(
-    packageDecisions.toSorted(
-      (left, right) =>
-        Number(left.packageRef.relationship === "referenced") -
-        Number(right.packageRef.relationship === "referenced"),
-    ),
-    {
-      ...options,
-      deps: options.packageDeps,
     },
   );
-  const packageErrors = packages.filter((pkg) => pkg.action === "error");
-  if (packageErrors.length > 0) {
-    updateClawInstallRecordStatus(agentId, "partial", options);
-    return {
-      schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
-      stability: CLAW_OUTPUT_STABILITY,
-      dryRun: false,
-      status: "partial",
-      agentId: plan.agentId,
-      agentRemoved,
-      workspaceFiles: [],
-      packages,
-      mcpServers,
-      cronJobs,
-      packageRefsReleased: 0,
-      error: {
-        code: "package_cleanup_failed",
-        message: packageErrors.map((pkg) => pkg.reason).join("; "),
-      },
-    };
-  }
-  const workspaceFiles: RemovedWorkspaceFile[] = [];
-  for (const file of record.workspaceFiles) {
-    workspaceFiles.push(await removeClawWorkspaceFile(file));
-  }
-  const bootstrap = await removeClawBootstrap(record);
-  const cleanupErrors = workspaceFiles
-    .filter((file) => file.action === "error")
-    .map((file) => file.message ?? `Could not remove ${file.path}.`);
-  if (bootstrap?.action === "error") {
-    cleanupErrors.push(bootstrap.message ?? `Could not remove ${bootstrap.path}.`);
-  }
-  if (cleanupErrors.length === 0 && cleanupTargets && committedNextConfig) {
-    const workspaceHasRemainingEntries = await workspaceContainsUntrackedEntries(
-      cleanupTargets.workspaceDir,
-      record.workspaceFiles.map((file) => file.path),
-    );
-    cleanupErrors.push(
-      ...(await cleanupClawAgentFilesystem({
-        agentId,
-        nextConfig: committedNextConfig,
-        targets: cleanupTargets,
-        runtime: clawRemoveQuietRuntime,
-        trashPath: options.trashPath,
-        retainWorkspace:
-          workspaceHasRemainingEntries ||
-          bootstrap?.action === "retainedModified" ||
-          workspaceFiles.some((file) => file.action === "retainedModified"),
-      })),
-    );
-  }
-  const complete = cleanupErrors.length === 0;
-  if (!complete) {
-    updateClawInstallRecordStatus(agentId, "partial", options);
-  }
-  releaseClawRemoveRows(plan.agentId, workspaceFiles, complete, completeDeletion, options);
-  return {
-    schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
-    stability: CLAW_OUTPUT_STABILITY,
-    dryRun: false,
-    status: complete ? "complete" : "partial",
-    agentId: plan.agentId,
-    agentRemoved,
-    ...(bootstrap ? { bootstrap } : {}),
-    workspaceFiles,
-    packages,
-    mcpServers,
-    cronJobs,
-    packageRefsReleased: complete ? record.packages.length : 0,
-    ...(complete
-      ? {}
-      : {
-          error: {
-            code: "workspace_cleanup_failed",
-            message: cleanupErrors.join("; "),
-          },
-        }),
-  };
 }

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -1,15 +1,18 @@
 // Implements agent deletion with gateway delegation and local cleanup fallback.
 import type { AgentsDeleteResult } from "../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import {
+  isPathOwnedBySurvivingAgent,
+  prepareAgentDeleteDatabases,
+  readAgentDeleteDatabaseRegistry,
+  resolveSurvivingDatabaseFilePaths,
+} from "../agents/agent-delete-databases.js";
+import {
   findOverlappingWorkspaceAgentIds,
   formatSharedAuthStoreOwnerDeleteError,
   isInheritedAuthStoreOwner,
   isSharedAuthStoreOwner,
 } from "../agents/agent-delete-safety.js";
-import {
-  isPathOwnedByAnotherRegisteredAgent,
-  normalizeAgentDirRegistryPath,
-} from "../agents/agent-dir-registry.js";
+import { normalizeAgentDirRegistryPath } from "../agents/agent-dir-registry.js";
 import {
   beginAgentDeletion,
   claimCompletedAgentDeletion,
@@ -50,14 +53,10 @@ import {
 } from "../gateway/call.js";
 import { withAgentExecApprovalsRemoved } from "../infra/exec-approvals.js";
 import { isPathInside } from "../infra/path-guards.js";
-import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
-import { normalizeAgentId, normalizeAgentIdStrict } from "../routing/session-key.js";
+import { normalizeAgentIdStrict } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
-import {
-  listOpenClawRegisteredAgentDatabases,
-  unregisterOpenClawAgentDatabases,
-} from "../state/openclaw-agent-db-registry.js";
+import { unregisterOpenClawAgentDatabases } from "../state/openclaw-agent-db-registry.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { createClackPrompter } from "../wizard/clack-prompter.js";
 import { createQuietRuntime } from "./agents.command-shared.js";
@@ -283,13 +282,13 @@ export async function agentsDeleteCommand(
   }
 
   const workspaceSharedWith = findOverlappingWorkspaceAgentIds(cfg, agentId, workspaceDir);
-  const workspaceRetained = workspaceSharedWith.length > 0;
 
   const deleteFiles = existingJournal?.deleteFiles ?? true;
   const deletion = beginAgentDeletion(
     existingJournal ?? { agentId, agentDir, workspaceDir, sessionsDir, deleteFiles },
   );
   try {
+    prepareAgentDeleteDatabases(cfg, agentId, agentDir);
     const commitRoster = async () =>
       await withAgentExecApprovalsRemoved(agentId, async () => {
         if (configured) {
@@ -321,7 +320,20 @@ export async function agentsDeleteCommand(
   }
 
   // Purge session store entries for this agent so orphaned sessions cannot be targeted (#65524).
-  const purgeFailed = await purgeAgentSessionStoreEntries(cfg, agentId);
+  const purgeFailed = await purgeAgentSessionStoreEntries(cfg, agentId, {
+    runDatabaseCleanup: deletion.runDatabaseCleanup,
+  });
+  // Directory ownership is process-local; resolve survivors before the destructive recheck.
+  for (const survivingAgentId of listAgentIds(result.config)) {
+    resolveAgentDir(result.config, survivingAgentId);
+  }
+  const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
+    readAgentDeleteDatabaseRegistry(),
+    agentId,
+  );
+  const sharedWithSurvivor = (pathname: string) =>
+    isPathOwnedBySurvivingAgent(result.config, agentId, pathname, survivingDatabaseFilePaths);
+  const workspaceRetained = sharedWithSurvivor(workspaceDir);
 
   const quietRuntime = opts.json ? createQuietRuntime(runtime) : runtime;
   // Only trash the workspace if no other agent can depend on that path (#70890).
@@ -337,11 +349,11 @@ export async function agentsDeleteCommand(
     }
     return outcome;
   };
-  if (deleteFiles && workspaceRetained) {
+  if (deleteFiles && !purgeFailed && workspaceRetained) {
     quietRuntime.log(
-      `Skipped workspace removal (shared with other agents: ${workspaceSharedWith.join(", ")}): ${workspaceDir}`,
+      `Skipped workspace removal (shared with other agents${workspaceSharedWith.length ? `: ${workspaceSharedWith.join(", ")}` : ""}): ${workspaceDir}`,
     );
-  } else if (deleteFiles) {
+  } else if (deleteFiles && !purgeFailed) {
     const legacyPlan = prepareLegacyWorkspaceStateReset(workspaceDir);
     const statePlan = prepareWorkspaceStateDeletion(workspaceDir);
     const workspaceResult = await removePath(workspaceDir);
@@ -357,30 +369,17 @@ export async function agentsDeleteCommand(
       }
     }
   }
-  if (deleteFiles) {
-    // Directory ownership is process-local; prepare every survivor before filtering journal paths,
-    // or a deleted agent's database nested beneath a survivor's agentDir could be trashed.
-    for (const survivingAgentId of listAgentIds(result.config)) {
-      resolveAgentDir(result.config, survivingAgentId);
-    }
+  if (deleteFiles && !purgeFailed) {
     const canonicalAgentDir = normalizeAgentDirRegistryPath(agentDir);
-    const survivingDatabasePaths = new Set(
-      listOpenClawRegisteredAgentDatabases()
-        .filter((entry) => normalizeAgentId(entry.agentId) !== agentId)
-        .flatMap((entry) => resolveSqliteDatabaseFilePaths(entry.path))
-        .map((pathname) => normalizeAgentDirRegistryPath(pathname)),
-    );
     const databasePaths = deletion.entry.databasePaths.filter((pathname) => {
       const canonicalPath = normalizeAgentDirRegistryPath(pathname);
-      return (
-        !isPathInside(canonicalAgentDir, canonicalPath) &&
-        !survivingDatabasePaths.has(canonicalPath) &&
-        !isPathOwnedByAnotherRegisteredAgent({ agentId, pathname }) &&
-        findOverlappingWorkspaceAgentIds(result.config, agentId, canonicalPath).length === 0
-      );
+      return !isPathInside(canonicalAgentDir, canonicalPath) && !sharedWithSurvivor(pathname);
     });
-    await removePath(agentDir);
-    await removePath(sessionsDir);
+    for (const directory of [agentDir, sessionsDir]) {
+      if (!sharedWithSurvivor(directory)) {
+        await removePath(directory);
+      }
+    }
     for (const databasePath of databasePaths) {
       await removePath(databasePath);
     }
@@ -388,7 +387,7 @@ export async function agentsDeleteCommand(
   if (workspaceCleanupError) {
     throw workspaceCleanupError;
   }
-  if (failed.length === 0) {
+  if (failed.length === 0 && !purgeFailed) {
     if (deleteFiles) {
       // Keep registry ownership until every cleanup target is terminal. A crash before journal
       // completion leaves this idempotent deregistration reachable on the next delete attempt.

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -18,7 +18,7 @@ import {
 import { resolveSessionStorePathCore } from "../config/sessions.js";
 import type { SessionEntry } from "../config/sessions.js";
 import {
-  listSessionEntriesCore,
+  listSessionEntriesReadOnly,
   replaceSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -34,6 +34,10 @@ import {
   listOpenClawRegisteredAgentDatabases,
   registerOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import {
   baseConfigSnapshot,
@@ -202,7 +206,7 @@ function expectSessionStore(
   expect(
     Object.fromEntries(
       [...agentIds].flatMap((storeAgentId) =>
-        listSessionEntriesCore({
+        listSessionEntriesReadOnly({
           agentId: storeAgentId,
           storePath: resolveSessionStorePathCore(cfg.session?.store, { agentId: storeAgentId }),
         }).map(({ entry, sessionKey }) => [sessionKey, entry]),
@@ -769,6 +773,44 @@ describe("agents delete command", () => {
       expect(readAgentProvenance("child")).toMatchObject({ creatorAgentId: "ops" });
     });
   });
+
+  it.each(["agent", "sessions"])(
+    "retains a deleted agent's %s directory containing a surviving database",
+    async (directory) => {
+      await withStateDirEnv("openclaw-agents-delete-foreign-directory-", async ({ stateDir }) => {
+        const retainedDirectory = path.join(stateDir, "agents", "ops", directory);
+        const cfg: OpenClawConfig = {
+          agents: {
+            entries: {
+              main: { default: true, workspace: path.join(stateDir, "workspace-main") },
+              ops: { workspace: path.join(stateDir, "workspace-ops") },
+            },
+          },
+        };
+        await arrangeAgentsDeleteTest({ stateDir, cfg, sessions: {} });
+        const foreign = openOpenClawAgentDatabase({
+          agentId: "main",
+          path: path.join(retainedDirectory, "kept.sqlite"),
+        });
+        closeOpenClawAgentDatabaseByPath(foreign.path);
+        fsSafeMocks.movePathToTrash.mockImplementation(async (targetPath) => {
+          const destination = `${targetPath}.trashed`;
+          await fs.rename(targetPath, destination);
+          return destination;
+        });
+
+        await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
+
+        expect(readJsonLogs()[0]).not.toHaveProperty("purgeFailed");
+        expect(fsSafeMocks.movePathToTrash).not.toHaveBeenCalledWith(
+          retainedDirectory,
+          expect.anything(),
+        );
+        expect((await fs.stat(foreign.path)).isFile()).toBe(true);
+        expect(readAgentDeletionJournal("ops")?.cleanupCompleted).toBe(true);
+      });
+    },
+  );
 
   it("resumes offline deletion after cleanup was interrupted", async () => {
     await withStateDirEnv("openclaw-agents-delete-recovery-", async ({ stateDir }) => {

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { getLogger } from "../../logging/logger.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import type { createAgentDeletionDatabaseCleanup } from "../../state/agent-deletion-cleanup.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import {
   createSessionsCleanupFailure,
@@ -665,26 +666,40 @@ export async function runSessionsCleanup(params: {
 export async function purgeAgentSessionStoreEntries(
   cfg: OpenClawConfig,
   agentId: string,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    runDatabaseCleanup?: ReturnType<typeof createAgentDeletionDatabaseCleanup>;
+  } = {},
 ): Promise<boolean> {
   const normalizedAgentId = normalizeAgentId(agentId);
   let storePath = typeof cfg.session?.store === "string" ? cfg.session.store : "<default>";
   try {
     storePath = resolveSessionStorePathCore(cfg.session?.store, {
       agentId: normalizedAgentId,
+      env: options.env,
     });
     const sqliteTarget = resolveSqliteTargetFromSessionStorePath(storePath, {
       agentId: normalizedAgentId,
       defaultAgentId: resolveSessionStoreCompatibilityAgentId(cfg),
+      env: options.env,
     });
     if (!fs.existsSync(sqliteTarget.path)) {
       return false;
     }
-    await purgeDeletedAgentSessionEntries({
-      cfg,
-      agentId: normalizedAgentId,
-      storeAgentId: sqliteTarget.agentId ?? normalizedAgentId,
-      storePath,
-    });
+    const storeAgentId = sqliteTarget.agentId ?? normalizedAgentId;
+    const purge = () =>
+      purgeDeletedAgentSessionEntries({
+        cfg,
+        agentId: normalizedAgentId,
+        storeAgentId,
+        storePath,
+        env: options.env,
+      });
+    if (options.runDatabaseCleanup) {
+      await options.runDatabaseCleanup({ agentId: storeAgentId, path: sqliteTarget.path }, purge);
+    } else {
+      await purge();
+    }
     return false;
   } catch (error) {
     getLogger().warn("session store purge failed during agent deletion", {

--- a/src/config/sessions/session-accessor.lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.lifecycle-types.ts
@@ -187,6 +187,7 @@ export type SessionEntryLifecycleMutationResult = {
 
 export type DeletedAgentSessionEntryPurgeParams = {
   cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
   agentId: string;
   storeAgentId: string;
   storePath: string;

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -76,7 +76,6 @@ import { applySessionEntryExactReplacements } from "./session-accessor.sqlite-re
 import {
   cloneSessionEntry,
   resolveSqliteScope,
-  resolveSqliteStoreScope,
   resolveSqliteTranscriptArchiveDirectory,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
@@ -552,7 +551,12 @@ export async function applySessionEntryLifecycleMutation(params: {
 export async function purgeDeletedAgentSessionEntries(
   params: DeletedAgentSessionEntryPurgeParams,
 ): Promise<void> {
-  const resolved = resolveSqliteStoreScope(params.storePath, { agentId: params.storeAgentId });
+  const resolved = resolveSqliteScope({
+    agentId: params.storeAgentId,
+    env: params.env,
+    sessionKey: "",
+    storePath: params.storePath,
+  });
   const prepared = await runExclusiveSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
     const store = readSessionEntryStore(database);

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -47,7 +47,7 @@ const mocks = vi.hoisted(() => ({
   resolveOpenClawAgentSqlitePath: vi.fn(
     (params?: { path?: string }) => params?.path ?? "/agents/test-agent/openclaw-agent.sqlite",
   ),
-  closeOpenClawAgentDatabaseByPath: vi.fn((_pathname?: string) => true),
+  closeOpenClawAgentDatabaseByPath: vi.fn((_pathname?: string, _expectedAgentId?: string) => true),
   listOpenClawRegisteredAgentDatabases: vi.fn(() => [] as Array<Record<string, unknown>>),
   unregisterOpenClawAgentDatabase: vi.fn(),
   assertNoOpenClawAgentDatabaseLeases: vi.fn(),
@@ -1428,6 +1428,7 @@ describe("agents.delete", () => {
     );
     expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/agents/test-agent/openclaw-agent.sqlite",
+      "test-agent",
     );
     expect(mocks.unregisterOpenClawAgentDatabase).toHaveBeenCalledWith({
       agentId: "test-agent",
@@ -1573,6 +1574,7 @@ describe("agents.delete", () => {
     expect(mocks.writeConfigFile).not.toHaveBeenCalled();
     expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/journal/agent/openclaw-agent.sqlite",
+      "test-agent",
     );
     expect(mocks.unregisterResolvedAgentDir).toHaveBeenCalledWith({
       agentId: "test-agent",
@@ -2344,6 +2346,7 @@ describe("agents.delete", () => {
     });
     expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/journal/agent/openclaw-agent.sqlite",
+      "test-agent",
     );
     expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/agent");
     expect(directoryOwners.has("/journal/agent")).toBe(false);
@@ -2400,8 +2403,11 @@ describe("agents.delete", () => {
 
     expectRespondOk(respond, { ok: true });
     expect(mocks.listOpenClawRegisteredAgentDatabases).toHaveBeenCalled();
-    expect(mocks.closeOpenClawAgentDatabaseByPath).not.toHaveBeenCalled();
-    expect(mocks.assertNoOpenClawAgentDatabaseLeases).toHaveBeenCalledWith("test-agent");
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
+      "/journal/agent/openclaw-agent.sqlite",
+      "test-agent",
+    );
+    expect(mocks.assertNoOpenClawAgentDatabaseLeases).toHaveBeenCalledWith("test-agent", {});
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal/agent");
     expect(mocks.unregisterOpenClawAgentDatabase).toHaveBeenCalledWith({
       agentId: "test-agent",
@@ -2480,9 +2486,10 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, { ok: true });
-    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledTimes(1);
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledTimes(2);
     expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/relocated/deleted.sqlite",
+      "test-agent",
     );
     expect(mocks.unregisterOpenClawAgentDatabase).toHaveBeenCalledWith({
       agentId: "test-agent",
@@ -2512,7 +2519,10 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, { ok: true, removed: [], failed: [] });
-    expect(mocks.closeOpenClawAgentDatabaseByPath).not.toHaveBeenCalled();
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
+      "/journal/agent/openclaw-agent.sqlite",
+      "test-agent",
+    );
     expect(mocks.movePathToTrash).not.toHaveBeenCalled();
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
@@ -2543,12 +2553,14 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, { ok: true });
-    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledTimes(1);
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledTimes(2);
     expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/agents/test-agent/openclaw-agent.sqlite",
+      "test-agent",
     );
-    expect(mocks.closeOpenClawAgentDatabaseByPath).not.toHaveBeenCalledWith(
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/linked/shared/agent.sqlite",
+      "test-agent",
     );
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/linked/shared/agent.sqlite");
     expect(databaseRows).toEqual([{ agentId: "other-agent", path: "/real/shared/agent.sqlite" }]);
@@ -2566,13 +2578,14 @@ describe("agents.delete", () => {
     expectRespondOk(respond, { ok: true });
     expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/agents/test-agent/openclaw-agent.sqlite",
+      "test-agent",
     );
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/agents/test-agent");
     expect(mocks.movePathToTrash).toHaveBeenCalledWith("/agents/test-agent/openclaw-agent.sqlite");
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
-  it("does not close a database whose companion file is registered to another agent", async () => {
+  it("retains database files whose companion file is registered to another agent", async () => {
     mocks.listOpenClawRegisteredAgentDatabases.mockReturnValue([
       { agentId: "test-agent", path: "/shared/deleted.sqlite" },
       { agentId: "other-agent", path: "/shared/deleted.sqlite-wal" },
@@ -2582,8 +2595,9 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, { ok: true });
-    expect(mocks.closeOpenClawAgentDatabaseByPath).not.toHaveBeenCalledWith(
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/shared/deleted.sqlite",
+      "test-agent",
     );
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/shared/deleted.sqlite-wal");
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
@@ -2628,6 +2642,7 @@ describe("agents.delete", () => {
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal/agent");
     expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/journal/agent/openclaw-agent.sqlite",
+      "test-agent",
     );
     expect(mocks.unregisterOpenClawAgentDatabase).toHaveBeenCalledWith({
       agentId: "test-agent",
@@ -2779,12 +2794,15 @@ describe("agents.delete", () => {
 
     expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/agents/test-agent/openclaw-agent.sqlite",
+      "test-agent",
     );
     expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/relocated/test-agent.sqlite",
+      "test-agent",
     );
     expect(mocks.closeOpenClawAgentDatabaseByPath).not.toHaveBeenCalledWith(
       "/relocated/other-agent.sqlite",
+      "test-agent",
     );
     expect(mocks.movePathToTrash).toHaveBeenCalledWith("/relocated/test-agent.sqlite");
     expect(mocks.unregisterOpenClawAgentDatabase).toHaveBeenCalledWith({

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -42,6 +42,9 @@ const mocks = vi.hoisted(() => ({
   beginAgentDeletionCommit: vi.fn(),
   beginAgentDeletionRollback: vi.fn(),
   beginAgentDeletionFinish: vi.fn(),
+  runAgentDatabaseCleanup: vi.fn(
+    async (_target: unknown, run: () => Promise<unknown>) => await run(),
+  ),
   claimCompletedAgentDeletion: vi.fn(() => true),
   readAgentDeletionJournal: vi.fn(() => undefined as Record<string, unknown> | undefined),
   resolveOpenClawAgentSqlitePath: vi.fn(
@@ -245,6 +248,7 @@ vi.mock("../../agents/agent-lifecycle-registry.js", () => ({
     },
     finish: mocks.beginAgentDeletionFinish,
     rollback: mocks.beginAgentDeletionRollback,
+    runDatabaseCleanup: mocks.runAgentDatabaseCleanup,
   }),
   claimCompletedAgentDeletion: mocks.claimCompletedAgentDeletion,
   isAgentDeletionBlocked: () => false,
@@ -2856,13 +2860,20 @@ describe("agents.delete", () => {
     expect(mocks.movePathToTrash).toHaveBeenCalled();
   });
 
-  it("reports a session purge failure without failing committed deletion", async () => {
+  it("reports failed session cleanup and retains its journal and files for retry", async () => {
     mocks.purgeAgentSessionStoreEntries.mockResolvedValueOnce(true);
     const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
 
     await promise;
 
     expectRespondOk(respond, { ok: true, purgeFailed: true });
+    expect(mocks.purgeAgentSessionStoreEntries).toHaveBeenCalledWith(
+      expect.anything(),
+      "test-agent",
+      { runDatabaseCleanup: mocks.runAgentDatabaseCleanup },
+    );
+    expect(mocks.movePathToTrash).not.toHaveBeenCalled();
+    expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
   });
 
   it("sweeps WAL sidecars recreated between deletion preparation and cleanup", async () => {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -22,13 +22,18 @@ import {
 import type { AgentsDeleteResult } from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import { createAgent } from "../../agents/agent-create.js";
 import {
-  findOverlappingWorkspaceAgentIds,
+  isPathOwnedBySurvivingAgent,
+  prepareAgentDeleteDatabases,
+  readAgentDeleteDatabaseRegistry,
+  resolveSurvivingDatabaseFilePaths,
+  type AgentDeleteDatabasePlan,
+} from "../../agents/agent-delete-databases.js";
+import {
   formatSharedAuthStoreOwnerDeleteError,
   isInheritedAuthStoreOwner,
   isSharedAuthStoreOwner,
 } from "../../agents/agent-delete-safety.js";
 import {
-  isPathOwnedByAnotherRegisteredAgent,
   normalizeAgentDirRegistryPath,
   registerResolvedAgentDir,
   resolveRegisteredAgentIdForDir,
@@ -87,20 +92,13 @@ import { isMissingPathError } from "../../infra/errors.js";
 import { withAgentExecApprovalsRemoved } from "../../infra/exec-approvals.js";
 import { root, FsSafeError, type ReadResult } from "../../infra/fs-safe.js";
 import { isPathInside } from "../../infra/path-guards.js";
-import { resolveSqliteDatabaseFilePaths } from "../../infra/sqlite-files.js";
 import { movePathToTrash } from "../../plugin-sdk/browser-maintenance.js";
-import { normalizeAgentId, normalizeAgentIdStrict } from "../../routing/session-key.js";
+import { normalizeAgentIdStrict } from "../../routing/session-key.js";
 import {
   readAgentDeletionJournal,
   type AgentDeletionJournalCleanupPath,
 } from "../../state/agent-deletion-journal.js";
-import { assertNoOpenClawAgentDatabaseLeases } from "../../state/openclaw-agent-db-lease.js";
 import { unregisterOpenClawAgentDatabase } from "../../state/openclaw-agent-db-registry.js";
-import {
-  closeOpenClawAgentDatabaseByPath,
-  listOpenClawRegisteredAgentDatabases,
-  resolveOpenClawAgentSqlitePath,
-} from "../../state/openclaw-agent-db.js";
 import { resolveUserPath } from "../../utils.js";
 import { listAgentsForGateway } from "../session-utils.js";
 import {
@@ -660,88 +658,6 @@ function cleanupPathCovers(
   );
 }
 
-type AgentDeleteDatabasePlan = {
-  paths: string[];
-  registrationPaths: string[];
-  fileGroups: string[][];
-  relocatedFileGroups: string[][];
-};
-
-function resolveSurvivingDatabaseFilePaths(
-  registeredDatabases: ReturnType<typeof listOpenClawRegisteredAgentDatabases>,
-  agentId: string,
-): string[] {
-  return [
-    ...new Set(
-      registeredDatabases
-        .filter((entry) => normalizeAgentId(entry.agentId) !== agentId)
-        .flatMap((entry) => resolveSqliteDatabaseFilePaths(entry.path))
-        .map((pathname) => normalizeAgentDirRegistryPath(pathname)),
-    ),
-  ];
-}
-
-function isPathOwnedBySurvivingAgent(
-  cfg: OpenClawConfig,
-  agentId: string,
-  pathname: string,
-  survivingDatabaseFilePaths: readonly string[] = [],
-): boolean {
-  const canonicalPath = normalizeAgentDirRegistryPath(pathname);
-  return (
-    isPathOwnedByAnotherRegisteredAgent({ agentId, pathname }) ||
-    findOverlappingWorkspaceAgentIds(cfg, agentId, pathname).length > 0 ||
-    survivingDatabaseFilePaths.some(
-      (databasePath) =>
-        databasePath === canonicalPath ||
-        isPathInside(databasePath, canonicalPath) ||
-        isPathInside(canonicalPath, databasePath),
-    )
-  );
-}
-
-function prepareAgentDeleteDatabases(
-  cfg: OpenClawConfig,
-  agentId: string,
-  agentDir: string,
-): AgentDeleteDatabasePlan {
-  const registeredDatabases = listOpenClawRegisteredAgentDatabases();
-  const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
-    registeredDatabases,
-    agentId,
-  );
-  const registeredDatabasePaths = new Set([
-    resolveOpenClawAgentSqlitePath({
-      agentId,
-      path: path.join(agentDir, "openclaw-agent.sqlite"),
-    }),
-    ...registeredDatabases
-      .filter((entry) => normalizeAgentId(entry.agentId) === agentId)
-      .map((entry) => entry.path),
-  ]);
-  const databasePaths = [...registeredDatabasePaths].filter((pathname) =>
-    resolveSqliteDatabaseFilePaths(pathname).every(
-      (filePath) =>
-        !isPathOwnedBySurvivingAgent(cfg, agentId, filePath, survivingDatabaseFilePaths),
-    ),
-  );
-  for (const databasePath of databasePaths) {
-    closeOpenClawAgentDatabaseByPath(databasePath);
-  }
-  assertNoOpenClawAgentDatabaseLeases(agentId);
-  const fileGroups = databasePaths.map(resolveSqliteDatabaseFilePaths);
-  const relocatedFileGroups = fileGroups.filter((fileGroup) => {
-    const relative = path.relative(agentDir, fileGroup[0] ?? agentDir);
-    return relative.startsWith("..") || path.isAbsolute(relative);
-  });
-  return {
-    paths: databasePaths,
-    registrationPaths: [...registeredDatabasePaths],
-    fileGroups,
-    relocatedFileGroups,
-  };
-}
-
 function unregisterAgentDeleteDatabases(agentId: string, databasePaths: string[]): void {
   for (const databasePath of databasePaths) {
     unregisterOpenClawAgentDatabase({ agentId, path: databasePath });
@@ -1275,7 +1191,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
 
         if (deleteFiles) {
           const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
-            listOpenClawRegisteredAgentDatabases(),
+            readAgentDeleteDatabaseRegistry(),
             agentId,
           );
           const workspaceTrashEligible = !isPathOwnedBySurvivingAgent(
@@ -1403,7 +1319,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
               continue;
             }
             const refreshedDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
-              listOpenClawRegisteredAgentDatabases(),
+              readAgentDeleteDatabaseRegistry(),
               agentId,
             );
             const blockingProtection = protectedCleanupPaths.find(

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -1184,12 +1184,14 @@ export const agentsHandlers: GatewayRequestHandlers = {
         // A journaled path is trash-eligible only while registry ownership still points at the
         // deleted agent; recovery must not consume a path claimed by a surviving agent.
         const agentDirRegistryPath = normalizeAgentDirRegistryPath(deleteResult.agentDir);
-        const purgeFailed = await purgeAgentSessionStoreEntries(lockedConfig, agentId);
+        const purgeFailed = await purgeAgentSessionStoreEntries(lockedConfig, agentId, {
+          runDatabaseCleanup: deletion.runDatabaseCleanup,
+        });
 
         const removed: AgentDeleteRemovedPath[] = [];
         const failed: AgentDeleteFailedPath[] = [];
 
-        if (deleteFiles) {
+        if (deleteFiles && !purgeFailed) {
           const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
             readAgentDeleteDatabaseRegistry(),
             agentId,
@@ -1416,7 +1418,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
             unregisterResolvedAgentDir({ agentId, agentDir: agentDirRegistryPath });
           }
         }
-        if (failed.length === 0) {
+        if (failed.length === 0 && !purgeFailed) {
           unregisterResolvedAgentDir({ agentId, agentDir: agentDirRegistryPath });
           if (deleteFiles) {
             unregisterAgentDeleteDatabases(agentId, databasePlan?.registrationPaths ?? []);

--- a/src/state/agent-deletion-cleanup.test.ts
+++ b/src/state/agent-deletion-cleanup.test.ts
@@ -1,0 +1,236 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
+import { purgeAgentSessionStoreEntries } from "../config/sessions/cleanup-service.js";
+import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
+import { replaceSessionEntrySync } from "../config/sessions/session-accessor.sqlite-entry.js";
+import { assertNoOpenClawAgentDatabaseLeases } from "./openclaw-agent-db-lease.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  closeOpenClawAgentDatabasesForTest,
+  getOpenClawAgentDatabaseIfOpen,
+  openOpenClawAgentDatabase,
+} from "./openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "./openclaw-state-db.js";
+
+const roots: string[] = [];
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function fixture() {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "agent-delete-cleanup-")));
+  roots.push(root);
+  const options = { agentId: "worker", env: { OPENCLAW_STATE_DIR: root } };
+  const database = openOpenClawAgentDatabase(options);
+  const scope = { ...options, sessionKey: "agent:worker:main" };
+  const write = (sessionId: string) => replaceSessionEntrySync(scope, { sessionId, updatedAt: 1 });
+  write("before");
+  closeOpenClawAgentDatabaseByPath(database.path);
+  const entry = {
+    agentId: options.agentId,
+    agentDir: path.dirname(database.path),
+    workspaceDir: path.join(root, "workspace"),
+    sessionsDir: path.join(root, "agents", options.agentId, "sessions"),
+  };
+  return {
+    root,
+    options,
+    target: { agentId: options.agentId, path: database.path },
+    entry,
+    write,
+    read: () => loadSessionEntryReadOnly(scope)?.sessionId,
+    begin: () => beginAgentDeletion(entry, { env: options.env }),
+  };
+}
+
+describe("agent deletion database cleanup authority", () => {
+  it("keeps a cold cleanup handle private through awaits and closes it before settlement", async () => {
+    const f = fixture();
+    const deletion = f.begin();
+    const opened = createDeferred();
+    const release = createDeferred();
+    const late = createDeferred();
+    let lateWrite: Promise<unknown> | undefined;
+    const running = deletion.runDatabaseCleanup(f.target, async () => {
+      const database = openOpenClawAgentDatabase(f.options);
+      lateWrite = (async () => {
+        await late.promise;
+        expect(() => f.write("late")).toThrow("no longer active");
+      })();
+      opened.resolve();
+      await release.promise;
+      f.write("owned");
+      return database;
+    });
+    try {
+      await opened.promise;
+      expect(() => openOpenClawAgentDatabase(f.options)).toThrow("active deletion cleanup");
+      expect(() => getOpenClawAgentDatabaseIfOpen(f.options)).toThrow("active deletion cleanup");
+      expect(() => f.write("ordinary")).toThrow("active deletion cleanup");
+      const alias = path.join(f.root, "alias");
+      fs.symlinkSync(
+        path.dirname(f.target.path),
+        alias,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      expect(() =>
+        openOpenClawAgentDatabase({
+          ...f.options,
+          path: path.join(alias, path.basename(f.target.path)),
+        }),
+      ).toThrow("active deletion cleanup");
+      expect(f.read()).toBe("before");
+    } finally {
+      release.resolve();
+      try {
+        expect((await running).db.isOpen).toBe(false);
+      } finally {
+        late.resolve();
+        await lateWrite;
+      }
+    }
+    expect(f.read()).toBe("owned");
+    expect(() =>
+      assertNoOpenClawAgentDatabaseLeases("worker", { env: f.options.env }),
+    ).not.toThrow();
+  });
+
+  it.each(["replace", "rollback", "finish"] as const)(
+    "rejects cleanup writes after its journal owner is retired by %s",
+    async (retire) => {
+      const f = fixture();
+      const deletion = f.begin();
+      const opened = createDeferred();
+      const release = createDeferred();
+      const running = deletion.runDatabaseCleanup(f.target, async () => {
+        const database = openOpenClawAgentDatabase(f.options);
+        opened.resolve();
+        await release.promise;
+        expect(() => f.write("stale")).toThrow("no longer owns database cleanup");
+        return database;
+      });
+      try {
+        await opened.promise;
+        if (retire === "replace") {
+          f.begin();
+        } else {
+          deletion[retire]();
+        }
+      } finally {
+        release.resolve();
+        expect((await running).db.isOpen).toBe(false);
+      }
+      expect(f.read()).toBe("before");
+    },
+  );
+
+  it("binds the cleanup target to its state database, identity, and physical locator", async () => {
+    const f = fixture();
+    const other = fixture();
+    const deletion = f.begin();
+    await deletion.runDatabaseCleanup(f.target, async () => {
+      const database = openOpenClawAgentDatabase(f.options);
+      expect(() =>
+        openOpenClawAgentDatabase({ ...f.options, env: other.options.env, path: f.target.path }),
+      ).toThrow("another state database");
+      expect(() =>
+        openOpenClawAgentDatabase({ ...f.options, agentId: "kept", path: f.target.path }),
+      ).toThrow("already open for agent worker");
+      expect(() =>
+        openOpenClawAgentDatabase({ ...f.options, path: path.join(f.root, "unowned.sqlite") }),
+      ).toThrow("unavailable while agent worker is deleted");
+      expect(database.db.isOpen).toBe(true);
+    });
+    expect(f.read()).toBe("before");
+    expect(other.read()).toBe("before");
+  });
+
+  it.each([false, true])(
+    "retains failed cleanup close ownership (operation also failed: %s)",
+    async (failRun) => {
+      const f = fixture();
+      const deletion = f.begin();
+      let retained: ReturnType<typeof openOpenClawAgentDatabase> | undefined;
+      const closeError = new Error("held native close");
+      const runError = new Error("cleanup operation failed");
+      const running = deletion.runDatabaseCleanup(f.target, async () => {
+        retained = openOpenClawAgentDatabase(f.options);
+        vi.spyOn(retained.db, "close").mockImplementationOnce(() => {
+          throw closeError;
+        });
+        if (failRun) {
+          throw runError;
+        }
+      });
+      if (failRun) {
+        await expect(running).rejects.toMatchObject({ errors: [runError, closeError] });
+      } else {
+        await expect(running).rejects.toBe(closeError);
+      }
+      expect(retained?.db.isOpen).toBe(true);
+      expect(() => openOpenClawAgentDatabase(f.options)).toThrow("active deletion cleanup");
+      expect(() => assertNoOpenClawAgentDatabaseLeases("worker", { env: f.options.env })).toThrow(
+        "database is still open",
+      );
+      expect(closeOpenClawAgentDatabaseByPath(f.target.path, "worker")).toBe(true);
+      await deletion.runDatabaseCleanup(f.target, async () => f.write("retried"));
+      expect(f.read()).toBe("retried");
+      expect(() =>
+        assertNoOpenClawAgentDatabaseLeases("worker", { env: f.options.env }),
+      ).not.toThrow();
+    },
+  );
+
+  it("never exempts a foreign deletion journal's overlapping path", async () => {
+    const f = fixture();
+    const foreign = beginAgentDeletion({ ...f.entry, agentId: "kept" }, { env: f.options.env });
+    const deletion = f.begin();
+    await expect(
+      deletion.runDatabaseCleanup(f.target, async () => f.write("blocked")),
+    ).rejects.toThrow("agent kept deletion owns");
+    expect(f.read()).toBe("before");
+    foreign.rollback();
+    await deletion.runDatabaseCleanup(f.target, async () => f.write("retried"));
+    expect(f.read()).toBe("retried");
+  });
+
+  it.each([false, true])(
+    "purges only target rows in a surviving shared store (cold: %s)",
+    async (cold) => {
+      const f = fixture();
+      const storePath = path.join(f.root, "shared.sqlite");
+      const sharedOptions = { ...f.options, agentId: "kept", path: storePath };
+      const shared = openOpenClawAgentDatabase(sharedOptions);
+      const workerScope = { ...f.options, storePath, sessionKey: "agent:worker:shared" };
+      const keptScope = { ...workerScope, agentId: "kept", sessionKey: "agent:kept:shared" };
+      replaceSessionEntrySync(workerScope, { sessionId: "remove", updatedAt: Date.now() });
+      replaceSessionEntrySync(keptScope, { sessionId: "keep", updatedAt: Date.now() });
+      if (cold) {
+        closeOpenClawAgentDatabaseByPath(storePath);
+      }
+      const deletion = f.begin();
+      await expect(
+        purgeAgentSessionStoreEntries(
+          { agents: { entries: { worker: {}, kept: {} } }, session: { store: storePath } },
+          "worker",
+          { env: f.options.env, runDatabaseCleanup: deletion.runDatabaseCleanup },
+        ),
+      ).resolves.toBe(false);
+      expect(loadSessionEntryReadOnly(workerScope)).toBeUndefined();
+      expect(loadSessionEntryReadOnly(keptScope)?.sessionId).toBe("keep");
+      expect(shared.db.isOpen).toBe(!cold);
+      if (cold) {
+        expect(getOpenClawAgentDatabaseIfOpen(sharedOptions)).toBeUndefined();
+      }
+    },
+  );
+});

--- a/src/state/agent-deletion-cleanup.ts
+++ b/src/state/agent-deletion-cleanup.ts
@@ -7,7 +7,6 @@ import type {
   OpenClawAgentDatabase,
   OpenClawAgentDatabaseOptions,
 } from "./openclaw-agent-db-contract.js";
-import type { isSameOpenClawAgentDatabasePath } from "./openclaw-agent-db-registry.js";
 import { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
@@ -142,7 +141,7 @@ export function assertAgentDeletionDatabaseCleanupAccess(
 
 export function assertAgentDeletionCleanupAliases(
   options: OpenClawAgentDatabaseOptions,
-  isSamePath: typeof isSameOpenClawAgentDatabasePath,
+  isSamePath: (left: string, right: string) => boolean,
 ): void {
   // Only cleanup-held files need this rare physical alias check on a cache miss.
   const pathname = resolveOpenClawAgentSqlitePath(options);

--- a/src/state/agent-deletion-cleanup.ts
+++ b/src/state/agent-deletion-cleanup.ts
@@ -1,0 +1,171 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import path from "node:path";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type {
+  OpenClawAgentDatabase,
+  OpenClawAgentDatabaseOptions,
+} from "./openclaw-agent-db-contract.js";
+import type { isSameOpenClawAgentDatabasePath } from "./openclaw-agent-db-registry.js";
+import { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
+import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
+
+type AgentDeletionCleanupRow = {
+  agentId: string;
+  operationId: string;
+  cleanupCompleted: boolean;
+};
+
+type AgentDeletionDatabaseCleanupScope = {
+  agentId: string;
+  path: string;
+  statePath: string;
+  assertCurrent: () => void;
+  assertJournal: (statePath: string, entries: readonly AgentDeletionCleanupRow[]) => string;
+  registerClose: (close: () => void) => void;
+};
+
+const databaseCleanup = resolveGlobalSingleton(
+  Symbol.for("openclaw.agentDeletionDatabaseCleanup"),
+  () => new AsyncLocalStorage<AgentDeletionDatabaseCleanupScope>(),
+);
+const cleanupHandles = resolveGlobalSingleton(
+  Symbol.for("openclaw.agentDeletionDatabaseCleanupHandles"),
+  () => new Map<OpenClawAgentDatabase, AgentDeletionDatabaseCleanupScope>(),
+);
+
+/** The lifecycle owner supplies live closures, never a transferable operation id. */
+export function createAgentDeletionDatabaseCleanup(owner: {
+  statePath: string;
+  assertAdmission: () => void;
+  assertCurrent: () => void;
+  assertJournal: (statePath: string, entries: readonly AgentDeletionCleanupRow[]) => string;
+}) {
+  return async <T>(
+    target: { agentId: string; path: string },
+    run: () => Promise<T>,
+  ): Promise<T> => {
+    let active = true;
+    const closers: Array<() => void> = [];
+    const assertActive = () => {
+      if (!active) {
+        throw new Error("Agent deletion database cleanup is no longer active.");
+      }
+    };
+    const scope: AgentDeletionDatabaseCleanupScope = {
+      agentId: normalizeAgentId(target.agentId),
+      path: path.resolve(target.path),
+      statePath: path.resolve(owner.statePath),
+      assertCurrent: () => {
+        assertActive();
+        owner.assertCurrent();
+      },
+      assertJournal: (statePath, entries) => {
+        assertActive();
+        return owner.assertJournal(statePath, entries);
+      },
+      registerClose: (close) => {
+        assertActive();
+        closers.push(close);
+      },
+    };
+    return await databaseCleanup.run(scope, async () => {
+      let outcome: Result<T, unknown>;
+      const closeErrors: unknown[] = [];
+      try {
+        scope.assertCurrent();
+        owner.assertAdmission();
+        outcome = ok(await run());
+      } catch (error) {
+        outcome = err(error);
+      } finally {
+        for (const close of closers.toReversed()) {
+          try {
+            close();
+          } catch (error) {
+            closeErrors.push(error);
+          }
+        }
+        // Retained async callbacks keep this same object and must fail after settlement.
+        // A failed native close remains tagged and leased for the existing close retry.
+        active = false;
+        closers.length = 0;
+      }
+      if (!outcome.ok) {
+        throw closeErrors.length > 0
+          ? new AggregateError(
+              [outcome.error, ...closeErrors],
+              "Agent deletion database cleanup failed.",
+            )
+          : outcome.error;
+      }
+      if (closeErrors.length > 0) {
+        throw closeErrors.length === 1
+          ? closeErrors[0]
+          : new AggregateError(closeErrors, "Agent deletion database cleanup failed.");
+      }
+      return outcome.value;
+    });
+  };
+}
+
+export function getAgentDeletionDatabaseCleanup(
+  params: OpenClawAgentDatabaseOptions & { statePath?: string },
+): AgentDeletionDatabaseCleanupScope | undefined {
+  const scope = databaseCleanup.getStore();
+  if (
+    !scope ||
+    scope.agentId !== normalizeAgentId(params.agentId) ||
+    scope.path !== resolveOpenClawAgentSqlitePath(params)
+  ) {
+    return undefined;
+  }
+  const statePath = params.statePath ?? resolveOpenClawStateSqlitePath(params.env ?? process.env);
+  if (scope.statePath !== path.resolve(statePath)) {
+    throw new Error("Agent deletion database cleanup belongs to another state database.");
+  }
+  return scope;
+}
+
+export function assertAgentDeletionDatabaseCleanupAccess(
+  database: OpenClawAgentDatabase,
+  options: OpenClawAgentDatabaseOptions,
+): void {
+  const scope = getAgentDeletionDatabaseCleanup(options);
+  const owner = cleanupHandles.get(database);
+  if (owner && owner !== scope) {
+    throw new Error("Agent database belongs to an active deletion cleanup.");
+  }
+  scope?.assertCurrent();
+}
+
+export function assertAgentDeletionCleanupAliases(
+  options: OpenClawAgentDatabaseOptions,
+  isSamePath: typeof isSameOpenClawAgentDatabasePath,
+): void {
+  // Only cleanup-held files need this rare physical alias check on a cache miss.
+  const pathname = resolveOpenClawAgentSqlitePath(options);
+  for (const owned of cleanupHandles.keys()) {
+    if (isSamePath(owned.path, pathname)) {
+      assertAgentDeletionDatabaseCleanupAccess(owned, options);
+    }
+  }
+}
+
+export function registerAgentDeletionDatabaseCleanup(
+  database: OpenClawAgentDatabase,
+  options: OpenClawAgentDatabaseOptions,
+): AgentDeletionDatabaseCleanupScope | undefined {
+  const scope = getAgentDeletionDatabaseCleanup(options);
+  scope?.assertCurrent();
+  if (scope) {
+    cleanupHandles.set(database, scope);
+  }
+  return scope;
+}
+
+/** Release the tag only after the native owner has closed and released its lease. */
+export function releaseAgentDeletionDatabaseCleanup(database: OpenClawAgentDatabase): void {
+  cleanupHandles.delete(database);
+}

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -421,7 +421,6 @@ export function beginAgentDeletionJournal(
         cleanupCompleted: false,
         deleteFiles: normalized.deleteFiles,
       };
-      deleteAgentProvenanceForAgent(database.db, normalized.agentId);
       return;
     }
     const createdAt = Date.now();
@@ -441,7 +440,6 @@ export function beginAgentDeletionJournal(
       }),
     );
     persisted = { ...normalized, databasePaths, cleanupPaths, createdAt, cleanupCompleted: false };
-    deleteAgentProvenanceForAgent(database.db, normalized.agentId);
   }, options);
   if (!persisted) {
     throw new Error(`Failed to record deletion journal for agent ${normalized.agentId}.`);
@@ -528,7 +526,13 @@ export function completeAgentDeletionJournalInDatabase(
       .where("agent_id", "=", id)
       .where("operation_id", "=", operationId),
   );
-  return Number(result.numAffectedRows ?? 0) > 0;
+  const completed = Number(result.numAffectedRows ?? 0) > 0;
+  // The journal already fences authority. Keep creation history through refusals and
+  // partial cleanup, and remove it only when this exact deletion owner completes.
+  if (completed) {
+    deleteAgentProvenanceForAgent(database.db, id);
+  }
+  return completed;
 }
 
 export function removeAgentDeletionJournal(

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -9,6 +9,7 @@ import {
 import { isPathInside } from "../infra/path-guards.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
 import { normalizeAgentId } from "../routing/session-key.js";
+import { getAgentDeletionDatabaseCleanup } from "./agent-deletion-cleanup.js";
 import { deleteAgentProvenanceForAgent, ensureAgentProvenanceSchema } from "./agent-provenance.js";
 import type {
   OpenClawStateDatabase,
@@ -29,6 +30,7 @@ type AgentDeletionDatabase = Pick<
 
 type AgentDeletionPathFenceSnapshot = {
   claimAgentId: string;
+  claimPath: string;
   fenceAgentId?: string;
   targetPaths: string[];
   entries: Array<{
@@ -57,7 +59,7 @@ export type AgentDeletionJournalCleanupPath = {
   note?: string;
 };
 
-export function assertAgentDeletionIdentityClaimAllowed(
+function assertAgentDeletionIdentityClaimAllowed(
   claimAgentId: string,
   deletedAgentId: string | undefined,
 ): void {
@@ -117,6 +119,7 @@ export function prepareAgentDeletionPathFence(
   const env = options.env ?? process.env;
   return {
     claimAgentId: normalizeAgentId(claim.agentId),
+    claimPath: path.resolve(claim.path),
     ...(claim.fenceAgentId ? { fenceAgentId: normalizeAgentId(claim.fenceAgentId) } : {}),
     // targetPaths is a pre-open realpath snapshot. A co-equal same-user
     // process could retarget a symlink between snapshot and open; that actor
@@ -150,9 +153,10 @@ export function prepareAgentDeletionPathFence(
 
 /** Refuse database claims beneath paths still owned by an unfinished deletion. */
 export function assertAgentDeletionPathFence(
-  database: OpenClawStateDatabase["db"],
+  state: OpenClawStateDatabase,
   snapshot: AgentDeletionPathFenceSnapshot,
 ): void {
+  const database = state.db;
   ensureAgentDeletionJournalSchema(database);
   const db = getNodeSqliteKysely<AgentDeletionDatabase>(database);
   const journalRows = executeSqliteQuerySync(
@@ -205,8 +209,27 @@ export function assertAgentDeletionPathFence(
   if (snapshotJournal.join("\n") !== currentJournal.join("\n")) {
     throw new Error("Agent deletion journal changed while preparing a database claim.");
   }
+  // Existing foreign leases remain blockers even inside the deletion's cleanup scope.
+  const cleanup = snapshot.fenceAgentId
+    ? undefined
+    : getAgentDeletionDatabaseCleanup({
+        agentId: snapshot.claimAgentId,
+        path: snapshot.claimPath,
+        statePath: state.path,
+      });
+  const cleanupAgentId = cleanup?.assertJournal(
+    state.path,
+    journalRows.map((row) => ({
+      agentId: row.agent_id,
+      operationId: row.operation_id,
+      cleanupCompleted: row.cleanup_completed === 1,
+    })),
+  );
   for (const row of journalRows) {
     if (snapshot.fenceAgentId && snapshot.fenceAgentId !== row.agent_id) {
+      continue;
+    }
+    if (row.agent_id === cleanupAgentId) {
       continue;
     }
     assertAgentDeletionIdentityClaimAllowed(snapshot.claimAgentId, row.agent_id);

--- a/src/state/openclaw-agent-db-held-child.test-support.ts
+++ b/src/state/openclaw-agent-db-held-child.test-support.ts
@@ -1,0 +1,13 @@
+import { closeOpenClawAgentDatabases, openOpenClawAgentDatabase } from "./openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "./openclaw-state-db.js";
+
+openOpenClawAgentDatabase({
+  agentId: process.argv[2] ?? "worker",
+  path: process.argv[3] || undefined,
+});
+process.send?.("ready");
+process.once("message", () => {
+  closeOpenClawAgentDatabases();
+  closeOpenClawStateDatabaseForTest();
+  process.disconnect?.();
+});

--- a/src/state/openclaw-agent-db-lease.ts
+++ b/src/state/openclaw-agent-db-lease.ts
@@ -8,7 +8,6 @@ import {
 import { normalizeAgentId } from "../routing/session-key.js";
 import { getFileLockProcessStartTime, isPidDefinitelyDead } from "../shared/pid-alive.js";
 import {
-  assertAgentDeletionIdentityClaimAllowed,
   assertAgentDeletionPathFence,
   prepareAgentDeletionPathFence,
 } from "./agent-deletion-journal.js";
@@ -102,12 +101,7 @@ export function claimOpenClawAgentDatabaseLease(params: {
           "Agent database maintenance is in progress; retry after openclaw doctor --fix completes.",
         );
       }
-      const deletion = executeSqliteQueryTakeFirstSync(
-        database.db,
-        db.selectFrom("agent_deletion_journal").select("agent_id").where("agent_id", "=", agentId),
-      );
-      assertAgentDeletionIdentityClaimAllowed(agentId, deletion?.agent_id);
-      assertAgentDeletionPathFence(database.db, deletionFence);
+      assertAgentDeletionPathFence(database, deletionFence);
       executeSqliteQuerySync(
         database.db,
         db.insertInto("agent_database_leases").values({
@@ -206,7 +200,7 @@ export function assertNoOpenClawAgentDatabaseLeases(
             .where("lease_id", "=", row.lease_id),
         ) !== undefined;
       if (leaseStillExists && row.agent_id !== agentId && deletionFence) {
-        assertAgentDeletionPathFence(database.db, deletionFence);
+        assertAgentDeletionPathFence(database, deletionFence);
       }
     }, options);
     if (leaseStillExists && (!agentId || row.agent_id === agentId)) {

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -620,7 +620,7 @@ export function registerOpenClawAgentDatabase(params: {
   const lastSeenAt = Date.now();
   runOpenClawStateWriteTransaction(
     (database) => {
-      assertAgentDeletionPathFence(database.db, deletionFence);
+      assertAgentDeletionPathFence(database, deletionFence);
       const storedPath = resolveOpenClawAgentDatabaseStoredPath(database.path, params.path);
       const db = getNodeSqliteKysely<OpenClawAgentRegistryDatabase>(database.db);
       executeSqliteQuerySync(

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -996,7 +996,7 @@ describe("openclaw agent database", () => {
 
     expect(() =>
       runOpenClawStateWriteTransaction(
-        (database) => assertAgentDeletionPathFence(database.db, fence),
+        (database) => assertAgentDeletionPathFence(database, fence),
         { env },
       ),
     ).toThrow("deletion journal changed");

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3015,12 +3015,14 @@ describe("openclaw agent database", () => {
     const second = openOpenClawAgentDatabase({ agentId: "worker-2", env, path: secondPath });
 
     expect(closeOpenClawAgentDatabaseByPath(path.join(stateDir, "missing.sqlite"))).toBe(false);
+    expect(closeOpenClawAgentDatabaseByPath(firstPath, "worker-2")).toBe(false);
     expect(first.db.isOpen).toBe(true);
     expect(second.db.isOpen).toBe(true);
 
     expect(
       closeOpenClawAgentDatabaseByPath(
         path.join(stateDir, "relocated", "nested", "..", "first.sqlite"),
+        "worker-1",
       ),
     ).toBe(true);
     expect(first.db.isOpen).toBe(false);

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -33,6 +33,13 @@ import {
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import {
+  assertAgentDeletionCleanupAliases,
+  assertAgentDeletionDatabaseCleanupAccess,
+  getAgentDeletionDatabaseCleanup,
+  registerAgentDeletionDatabaseCleanup,
+  releaseAgentDeletionDatabaseCleanup,
+} from "./agent-deletion-cleanup.js";
 import type {
   OpenClawAgentDatabase,
   OpenClawAgentDatabaseOptions,
@@ -248,6 +255,7 @@ export function openOpenClawAgentDatabase(
   const agentId = normalizeAgentId(options.agentId);
   const databaseOptions = { ...options, agentId };
   const pathname = resolveOpenClawAgentSqlitePath(databaseOptions);
+  getAgentDeletionDatabaseCleanup(databaseOptions)?.assertCurrent();
   const incognito = isIncognitoOpenClawAgentSqlitePath(pathname, databaseOptions);
   // A live successful cache entry is authoritative; failed entries remain only for disposal.
   const opened = getOpenClawAgentDatabaseIfOpen(databaseOptions);
@@ -401,6 +409,19 @@ export function openOpenClawAgentDatabase(
     ensureOpenClawAgentDatabasePermissions(pathname, databaseOptions);
     const database = { agentId, db, path: pathname, walMaintenance };
     openedDatabase = database;
+    const cleanup = registerAgentDeletionDatabaseCleanup(database, databaseOptions);
+    if (cleanup) {
+      const release = retainAgentDatabase(db);
+      cleanup.registerClose(() => {
+        release();
+        // The scope owns this connection, not a later cache entry at the same pathname.
+        if (cache.databases.get(database.path) === database) {
+          closeOpenClawAgentDatabaseByPath(database.path, database.agentId);
+        } else if (database.db.isOpen) {
+          throw new Error("Agent deletion cleanup lost its database close owner.");
+        }
+      });
+    }
     if (!isValidatedReopen) {
       registerOpenClawAgentDatabase({ agentId, path: pathname, env: options.env });
       cache.validatedPaths.set(pathname, agentId);
@@ -473,6 +494,7 @@ export function runOpenClawAgentWriteTransaction<T>(
     runSqliteImmediateTransactionSync(
       database.db,
       () => {
+        assertAgentDeletionDatabaseCleanupAccess(database, options);
         const operationResult = operation(database);
         if (!enteredNestedTransaction) {
           // Permission failure must roll back with the write. Repairing after
@@ -499,15 +521,16 @@ export function borrowOpenClawAgentDatabase(options: OpenClawAgentDatabaseOption
   release: () => void;
 } {
   const { db } = openOpenClawAgentDatabase(options);
+  return { db, release: retainAgentDatabase(db) };
+}
+
+function retainAgentDatabase(db: DatabaseSync): () => void {
   const borrowers = cache.borrowers.get(db) ?? new Set<object>();
   const borrower = {};
   borrowers.add(borrower);
   cache.borrowers.set(db, borrowers);
-  return {
-    db,
-    release: () => {
-      borrowers.delete(borrower);
-    },
+  return () => {
+    borrowers.delete(borrower);
   };
 }
 
@@ -526,6 +549,7 @@ function closeCachedOpenClawAgentDatabase(
     releaseOpenClawAgentDatabaseLease(lease.leaseId, { env: lease.env });
     cache.leases.delete(database.path);
   }
+  releaseAgentDeletionDatabaseCleanup(database);
 }
 
 function evictLruAgentDatabaseHandles(): void {
@@ -587,6 +611,7 @@ export function getOpenClawAgentDatabaseIfOpen(
   const pathname = resolveOpenClawAgentSqlitePath({ ...options, agentId });
   const database = cache.databases.get(pathname);
   if (!database?.db.isOpen) {
+    assertAgentDeletionCleanupAliases(options, isSameOpenClawAgentDatabasePath);
     return undefined;
   }
   if (cache.failures.has(pathname)) {
@@ -597,6 +622,7 @@ export function getOpenClawAgentDatabaseIfOpen(
       `OpenClaw agent database ${pathname} is already open for agent ${database.agentId}; requested agent ${agentId}.`,
     );
   }
+  assertAgentDeletionDatabaseCleanupAccess(database, options);
   return database;
 }
 

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -633,12 +633,15 @@ export function listOpenClawAgentDatabasesForTest(): Array<{ agentId: string; pa
 }
 
 /** Close one cached agent database identified by its exact resolved pathname. */
-export function closeOpenClawAgentDatabaseByPath(pathname: string): boolean {
+export function closeOpenClawAgentDatabaseByPath(
+  pathname: string,
+  expectedAgentId?: string,
+): boolean {
   // Cache keys are lexical resolved paths. Do not realpath aliases here: a
   // symlink swap must never redirect cleanup onto a different cached database.
   const resolvedPath = path.resolve(pathname);
   const database = cache.databases.get(resolvedPath);
-  if (!database) {
+  if (!database || (expectedAgentId !== undefined && database.agentId !== expectedAgentId)) {
     return false;
   }
   const incognito = cache.incognito.has(database);

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -200,22 +200,6 @@ export function clearOpenClawAgentDatabaseOpenFailure(
   return cleared;
 }
 
-function logSlowAgentDatabaseOpen(params: {
-  agentId: string;
-  elapsedMs: number;
-  path: string;
-}): void {
-  if (params.elapsedMs < OPENCLAW_AGENT_DB_SLOW_OPEN_MS) {
-    return;
-  }
-  agentDbLog.warn("slow OpenClaw agent database open", {
-    agentId: params.agentId,
-    elapsedMs: params.elapsedMs,
-    path: params.path,
-    thresholdMs: OPENCLAW_AGENT_DB_SLOW_OPEN_MS,
-  });
-}
-
 /** Read a database's durable role and agent owner without mutating it. */
 export function inspectOpenClawAgentDatabaseOwner(
   pathname: string,
@@ -430,11 +414,15 @@ export function openOpenClawAgentDatabase(
     // Safety net for processes that end without an orderly close: agent DBs have
     // no shutdown owner like the ACP/gateway state DB closes. Closing unregisters.
     cache.unregisterExitClose ??= registerSqliteCacheExitClose(closeOpenClawAgentDatabases);
-    logSlowAgentDatabaseOpen({
-      agentId,
-      elapsedMs: Date.now() - openStartedAt,
-      path: pathname,
-    });
+    const elapsedMs = Date.now() - openStartedAt;
+    if (elapsedMs >= OPENCLAW_AGENT_DB_SLOW_OPEN_MS) {
+      agentDbLog.warn("slow OpenClaw agent database open", {
+        agentId,
+        elapsedMs,
+        path: pathname,
+        thresholdMs: OPENCLAW_AGENT_DB_SLOW_OPEN_MS,
+      });
+    }
     cache.leases.set(pathname, { leaseId, env: leaseEnvironment });
     cache.databases.set(pathname, database);
     return database;

--- a/src/state/openclaw-state-lease-runtime.test-support.ts
+++ b/src/state/openclaw-state-lease-runtime.test-support.ts
@@ -4,3 +4,9 @@ export const stateLeaseProcessExitRuntimeEntrypoint = {
   sourceWorkerName: "openclaw-state-lease-process-exit-child.test-support",
   distWorkerPath: "state/openclaw-state-lease-process-exit-child.test-support.js",
 } as const;
+
+export const agentDatabaseHeldRuntimeEntrypoint = {
+  currentModuleUrl: import.meta.url,
+  sourceWorkerName: "openclaw-agent-db-held-child.test-support",
+  distWorkerPath: "state/openclaw-agent-db-held-child.test-support.js",
+} as const;


### PR DESCRIPTION
## What Problem This Solves

Claw removal could commit config and remove directories while another process still held an agent database. It also used incomplete ownership information for retained directories. Share the existing Gateway deletion preparation with Claw and offline CLI removal: fence new claims, close only the deleted agent's actual registered handles, and reject active leases before config, approvals, MCP, cron, or filesystem effects. Retain directories containing surviving database owners, including closed databases with older or newer schemas.

## Why This Change Was Made

Session cleanup needs the same deletion owner across its awaited purge and transcript archive work. An ordinary reopen after claiming the deletion journal correctly refuses access, which previously left retained databases unpurged while removal reported completion. The deletion owner now provides a scoped cleanup operation bound to its live closure, exact unfinished journal, state database, and physical store owner/path. Connections opened by that scope stay private to it, remain borrowed across awaits, and close before the operation settles. Ordinary callers, stale callbacks, foreign journal rows, and overlapping foreign leases retain their existing fences. Preexisting surviving shared-store connections retain their ordinary ownership, and cleanup removes only the deleted agent's rows.

## User Impact

Failed session cleanup or archive export now keeps the deletion journal unfinished. Claw reports a partial result and supports preview/retry; Gateway and offline CLI retain `purgeFailed` and defer filesystem cleanup and completion. Creation provenance is removed only when the exact deletion operation successfully completes. The canonical shared directory check replaces the CLI's duplicate retention rules, and Claw's repeated partial-result construction is consolidated.

## Evidence

Validation: original config-file and two-process reproductions are preserved; the final owner suite passes 325 tests with six existing platform skips across nine files. Coverage includes real postcommit archive publication failure and retry, active foreign child leases, relocated paths, closed foreign databases, stale registry/schema information, warm/cold shared stores, replacement/rollback/completion retirement, retained callbacks and aliases, and exact failed-close retry with the original operation error preserved. A fresh built standalone CLI run removed the target agent/session while preserving a foreign database and its surviving session. Final source hashes are checked before and after remote execution. The final extracted source passed the fresh standalone CLI build and all nine suites with identical hashes before, after CLI execution, and after the suites. The full changed-code gate passed on Linux (Node 24.19.0, pnpm 12.1.0) in 863.851 seconds on Testbox run https://github.com/openclaw/openclaw/actions/runs/33939598362. Fresh independent P2 review found no actionable findings. An earlier gate failed with corepack ENOENT while its runner was being cancelled; the cause of the missing binary was not established. The unchanged gate passed on a newly acquired matching lease. The final command succeeded before a runner-portal synchronization warning.

The review's retained-session purge finding and associated coverage requests are addressed by the scoped owner and real archive retry proof. The contract type move does not change a database schema or stored representation. No schema version, migration, configuration, dependency, or public RPC change; no changelog edit.
Production changes are +873/-498 (net +375); tests and test support are +855/-40 (net +815); docs are +11. Planner/type moves add no capability. The remaining production growth supplies the missing exact cleanup lifetime and handle isolation across awaited archive work. It reuses the journal, existing native borrower/close owner, existing path matcher, and lease fence; the duplicated Gateway/CLI retention rules and repeated Claw partial-result branches were removed. No global maintenance bypass or second deletion registry was introduced.

Hosted CI on the preceding head exposed two additional structural issues: the merged database owner exceeded the 700-line lint limit, and Madge counted a type-only registry cycle that the runtime-value check excludes. The repair removes the type dependency by taking the existing matcher signature and absorbs the one-use slow-open logger at its original call site. The actual merged-source lint now passes (the same pre-fix merge reproduces the failure), both cycle guards pass, scoped typed lint passes, and a fresh independent P2 review found no actionable findings. Cleanup and native-close behavior are unchanged by this follow-up.

Final head `24f56c0341ba039c58ef9a773b58c73a38586690` passed [CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33940991539/attempts/2), including `openclaw/ci-gate`. Attempt 1 failed only while downloading the Matrix crypto native dependency (ECONNRESET before the boundary check); the normal targeted retry passed.

The latest ClawSweeper review confirms the retained-session finding and both rank-up requests are addressed. Its remaining compatibility reminder is accepted: active database owners must release their handles, and callers must retry an unfinished deletion rather than recreate over it. This is documented and covered by refusal/retry tests. The flagged lifecycle and cleanup additions are process-local closures, AsyncLocalStorage, and handle maps; no serialized field, schema version, migration, or stored representation changes, so a data migration is not applicable.
