### PR TITLE
fix(mcp): keep healthy tools connected during hot reload

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1611,12 +1611,12 @@ src/acp/translator.session-lifecycle.ts	1
 src/acp/translator.session-list.ts	1
 src/acp/translator.session-state.ts	1
 src/agents/agent-bundle-lsp-runtime.ts	4
-src/agents/agent-bundle-mcp-combined.ts	2
+src/agents/agent-bundle-mcp-combined.ts	1
 src/agents/agent-bundle-mcp-manager-api.ts	2
 src/agents/agent-bundle-mcp-manager-lifecycle.ts	1
 src/agents/agent-bundle-mcp-materialize.ts	3
 src/agents/agent-bundle-mcp-runtime-shared.ts	2
-src/agents/agent-bundle-mcp-runtime.ts	9
+src/agents/agent-bundle-mcp-runtime.ts	7
 src/agents/agent-command-restart-recovery.ts	3
 src/agents/agent-command.ts	1
 src/agents/agent-hooks/compaction-safeguard.ts	14

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -197,11 +197,13 @@ target server during config edits.
   default MCP approval behavior.
 - Session-scoped bundled MCP runtimes use a built-in 10-minute idle TTL.
   One-shot embedded runs request run-end cleanup; the TTL is the backstop for long-lived sessions and future callers.
-- Changes under `mcp.*` hot-apply by disposing cached session MCP runtimes.
-  The next tool discovery/use recreates them from the new config, so removed
-  `mcp.servers` entries are reaped immediately instead of waiting for idle TTL.
+- MCP config changes retire only changed or removed server connections. Unchanged
+  servers keep their transports and tool catalogs; active runs can continue calling
+  their tools and resources. The next turn's discovery creates changed servers from the new config. Plugin
+  reloads also retire connections owned by the replaced plugins or their resolvers.
+  Requester sign-in tools refresh on the next message after runtime replacement.
 - Runtime discovery also honors MCP tool-list change notifications by dropping
-  the cached catalog for that session. Servers that advertise resources or
+  the affected server's cached catalog. Servers that advertise resources or
   prompts get utility tools for listing/reading resources and listing/fetching
   prompts. Repeated tool-call failures pause the affected server briefly before
   another call is attempted.

--- a/docs/tools/mcp.md
+++ b/docs/tools/mcp.md
@@ -29,7 +29,7 @@ Once the server is saved, verify it actually answers:
 openclaw mcp doctor <name> --probe
 ```
 
-Saving a definition proves nothing about reachability — the probe does. Note that already-running Gateway or agent processes may need a restart or runtime reload before they pick up the new definition.
+Saving a definition proves nothing about reachability — the probe does. With Gateway hot reload enabled, changed or removed servers retire immediately and the next turn's discovery uses the new definition. Unchanged servers keep their connections and cached tools, including for runs already in progress. Requester sign-in tools refresh on the next message after runtime replacement.
 
 ## Add a server from the composer
 

--- a/src/agents/agent-bundle-mcp-acquisition.test.ts
+++ b/src/agents/agent-bundle-mcp-acquisition.test.ts
@@ -1,0 +1,144 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { cleanupTempDirs } from "../../test/helpers/temp-dir.js";
+import { materializeRequesterScopedMcpToolsForHarnessRunCore } from "./agent-bundle-mcp-harness.js";
+import {
+  acquireRequesterScopedMcpRuntime,
+  acquireSessionMcpRuntime,
+  disposeAllSessionMcpRuntimes,
+  getSessionMcpRuntimeManagerForTesting,
+} from "./agent-bundle-mcp-manager-api.js";
+import { materializeBundleMcpToolsForRun } from "./agent-bundle-mcp-materialize.js";
+import { createMcpProbeFixture, probeMcpServer } from "./agent-bundle-mcp-probe.test-support.js";
+import { SESSION_MCP_RUNTIME_MANAGER_KEY } from "./agent-bundle-mcp-runtime-shared.js";
+
+const readAuthorization = vi.hoisted(() => vi.fn(async () => ({ state: "unauthenticated" })));
+vi.mock("./mcp-oauth.js", () => ({
+  readMcpOAuthCredentialsStatus: readAuthorization,
+  startMcpOAuthAuthorization: async () => ({ status: "authorized" }),
+}));
+
+const tempDirs: string[] = [];
+const releases: Array<() => void> = [];
+beforeEach(async () => {
+  await disposeAllSessionMcpRuntimes();
+  // The process singleton's lazy factory must not retain another test file's OAuth mock.
+  Reflect.deleteProperty(globalThis, SESSION_MCP_RUNTIME_MANAGER_KEY);
+});
+afterEach(async () => {
+  for (const release of releases.splice(0)) {
+    release();
+  }
+  await disposeAllSessionMcpRuntimes();
+  Reflect.deleteProperty(globalThis, SESSION_MCP_RUNTIME_MANAGER_KEY);
+  cleanupTempDirs(tempDirs);
+  readAuthorization.mockReset().mockResolvedValue({ state: "unauthenticated" });
+});
+
+it.each(["exported acquisition", "harness materialization"])(
+  "admits requester leases through %s",
+  async (surface) => {
+    const { params, config } = await createMcpProbeFixture(tempDirs);
+    const cfg = config();
+    cfg.gateway = { publicOrigin: "https://gateway.example.test" };
+    cfg.mcp!.servers!.calendar = {
+      transport: "streamable-http",
+      url: "https://mcp.example.test",
+      auth: "oauth",
+      oauth: { identity: "per-requester" },
+    };
+    const input = { ...params, cfg, requesterSenderId: "alice" };
+    const acquired = await acquireSessionMcpRuntime(input);
+    const original = await materializeBundleMcpToolsForRun(acquired);
+    const healthy = await probeMcpServer(acquired.runtime, "healthy");
+    const manager = getSessionMcpRuntimeManagerForTesting();
+    const started = createDeferred();
+    const released = createDeferred();
+    releases.push(() => released.resolve());
+    readAuthorization.mockImplementationOnce(async () => {
+      started.resolve();
+      await released.promise;
+      return { state: "unauthenticated" };
+    });
+    const pending =
+      surface === "exported acquisition"
+        ? acquireRequesterScopedMcpRuntime(input)
+        : materializeRequesterScopedMcpToolsForHarnessRunCore(input);
+    void pending.catch(() => undefined);
+    await started.promise;
+    manager.deferRetirement(params.sessionId, { retainAcrossReuse: true });
+    const retiring = original.dispose();
+    await expect.poll(() => manager.totalActiveLeasesForSession(params.sessionId)).toBe(0);
+    released.resolve();
+    const nextAcquired = expectDefined(await pending, "requester acquisition");
+    await retiring;
+    expect(manager.totalActiveLeasesForSession(params.sessionId)).toBeGreaterThan(0);
+    const next =
+      "runtime" in nextAcquired
+        ? await materializeBundleMcpToolsForRun(nextAcquired)
+        : nextAcquired;
+    try {
+      expect(next.tools.map((tool) => tool.name)).toEqual(["calendar__connect"]);
+      expect(await probeMcpServer(acquired.runtime, "healthy")).toEqual(healthy);
+    } finally {
+      await next.dispose();
+    }
+    expect(manager.listRuntimeKeys()).toEqual([]);
+    expect(() => process.kill(healthy.pid, 0)).toThrow();
+  },
+);
+
+it("releases static admission when requester resolution fails during required retirement", async () => {
+  const { params, config } = await createMcpProbeFixture(tempDirs);
+  const cfg = config();
+  cfg.mcp!.servers!.calendar = {
+    transport: "streamable-http",
+    url: "https://mcp.example.test",
+    auth: "oauth",
+    oauth: { identity: "per-requester" },
+  };
+  const input = { ...params, cfg, requesterSenderId: "alice" };
+  const original = await acquireSessionMcpRuntime(input);
+  const healthy = await probeMcpServer(original.runtime, "healthy");
+  original.releaseLease();
+  const manager = getSessionMcpRuntimeManagerForTesting();
+  readAuthorization.mockImplementationOnce(async () => {
+    manager.deferRetirement(params.sessionId, { retainAcrossReuse: true });
+    throw new Error("requester authorization unavailable");
+  });
+  await expect(acquireSessionMcpRuntime(input)).rejects.toThrow(
+    "requester authorization unavailable",
+  );
+  expect(manager.listRuntimeKeys()).toEqual([]);
+  expect(() => process.kill(healthy.pid, 0)).toThrow();
+});
+
+it.each(["empty", "catalog failure"])(
+  "releases admission on %s materialization",
+  async (result) => {
+    const { params } = await createMcpProbeFixture(tempDirs);
+    const acquired = await acquireSessionMcpRuntime({
+      ...params,
+      cfg: { plugins: { enabled: false } },
+    });
+    const manager = getSessionMcpRuntimeManagerForTesting();
+    expect(acquired.runtime.activeLeases).toBe(1);
+    manager.deferRetirement(params.sessionId, { retainAcrossReuse: true });
+    if (result === "catalog failure") {
+      vi.spyOn(acquired.runtime, "getCatalog").mockRejectedValueOnce(
+        new Error("catalog unavailable"),
+      );
+      await expect(materializeBundleMcpToolsForRun(acquired)).rejects.toThrow(
+        "catalog unavailable",
+      );
+    } else {
+      const materialized = await materializeBundleMcpToolsForRun(acquired);
+      expect(materialized.tools).toEqual([]);
+      expect(acquired.runtime.activeLeases).toBe(1);
+      await materialized.dispose();
+    }
+    expect(acquired.runtime.activeLeases).toBe(0);
+    expect(manager.listRuntimeKeys()).toEqual([]);
+  },
+);

--- a/src/agents/agent-bundle-mcp-combined.ts
+++ b/src/agents/agent-bundle-mcp-combined.ts
@@ -1,5 +1,6 @@
-/** Combined session MCP runtime facade for static + requester partitions. */
+/** Combined session MCP runtime facade for server and requester partitions. */
 import { racePromiseWithAbortSignal } from "../infra/abort-signal.js";
+import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { getSessionMcpRequestSignal } from "./agent-bundle-mcp-request-context.js";
 import type {
   McpCatalogTool,
@@ -9,13 +10,6 @@ import type {
   SessionMcpRuntime,
 } from "./agent-bundle-mcp-types.js";
 
-const COMBINED_SESSION_MCP_RUNTIME = Symbol.for("openclaw.combinedSessionMcpRuntime");
-
-type CombinedSessionMcpRuntime = SessionMcpRuntime & {
-  [COMBINED_SESSION_MCP_RUNTIME]: true;
-  managedParts: readonly SessionMcpRuntime[];
-};
-
 function compareCatalogTools(left: McpCatalogTool, right: McpCatalogTool): number {
   return (
     left.safeServerName.localeCompare(right.safeServerName) ||
@@ -24,10 +18,21 @@ function compareCatalogTools(left: McpCatalogTool, right: McpCatalogTool): numbe
   );
 }
 
-export function isCombinedSessionMcpRuntime(
-  runtime: SessionMcpRuntime,
-): runtime is CombinedSessionMcpRuntime {
-  return (runtime as CombinedSessionMcpRuntime)[COMBINED_SESSION_MCP_RUNTIME] !== undefined;
+async function loadCurrentCatalog(part: SessionMcpRuntime): Promise<McpToolCatalog> {
+  if (part.retiredCatalog) {
+    return part.retiredCatalog;
+  }
+  try {
+    const catalog = await part.getCatalog();
+    return part.retiredCatalog ?? catalog;
+  } catch (error) {
+    // Revocation can close a transport while discovery awaits it. Preserve the
+    // owner's recorded outcome without suppressing failures from live siblings.
+    if (part.retiredCatalog) {
+      return part.retiredCatalog;
+    }
+    throw error;
+  }
 }
 
 /**
@@ -78,16 +83,19 @@ export function createCombinedSessionMcpRuntime(params: {
   workspaceDir: string;
   agentDir?: string;
   parts: readonly SessionMcpRuntime[];
+  serverOwners?: Map<string, SessionMcpRuntime>;
 }): SessionMcpRuntime {
-  if (params.parts.length === 1) {
+  if (params.parts.length === 1 && !params.serverOwners) {
     return params.parts[0]!;
   }
   const parts = params.parts;
-  let lastUsedAt = Math.max(...parts.map((part) => part.lastUsedAt));
+  // Empty partitions still own run/view leases; populated ones carry reused server leases.
+  let activeLeases = 0;
+  let lastUsedAt = Math.max(Date.now(), ...parts.map((part) => part.lastUsedAt));
   let cachedCatalog: McpToolCatalog | null = null;
   let mergedSourceCatalogs: ReadonlyArray<McpToolCatalog> | null = null;
   let catalogInFlight: Promise<McpToolCatalog> | undefined;
-  const serverOwner = new Map<string, SessionMcpRuntime>();
+  const serverOwner = params.serverOwners ?? new Map<string, SessionMcpRuntime>();
   const requesterConnect = parts.find((part) => part.requesterConnect)?.requesterConnect;
 
   const rememberServerOwners = (catalog: McpToolCatalog, owner: SessionMcpRuntime) => {
@@ -102,7 +110,10 @@ export function createCombinedSessionMcpRuntime(params: {
   const cachedCatalogIsCurrent = (): boolean =>
     cachedCatalog !== null &&
     mergedSourceCatalogs !== null &&
-    parts.every((part, index) => part.peekCatalog() === mergedSourceCatalogs?.[index]);
+    parts.every(
+      (part, index) =>
+        (part.retiredCatalog ?? part.peekCatalog()) === mergedSourceCatalogs?.[index],
+    );
 
   const loadCatalog = async (): Promise<McpToolCatalog> => {
     if (cachedCatalog && !cachedCatalog.diagnostics?.length && cachedCatalogIsCurrent()) {
@@ -112,16 +123,42 @@ export function createCombinedSessionMcpRuntime(params: {
       return catalogInFlight;
     }
     const inFlight = (async () => {
-      const catalogs = await Promise.all(parts.map((part) => part.getCatalog()));
+      let loaded: Array<{ catalog: McpToolCatalog; cached: boolean } | undefined> = [];
+      // Replay once when a completed catalog invalidates while siblings await I/O.
+      // A child returning an uncached result already exhausted its own replay budget.
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const { results, firstError, hasError } = await runTasksWithConcurrency({
+          tasks: parts.map((part, index) => async () => {
+            const previous = loaded[index];
+            if (previous && (!previous.cached || part.retiredCatalog || part.peekCatalog())) {
+              return previous;
+            }
+            const catalog = await loadCurrentCatalog(part);
+            return { catalog, cached: part.peekCatalog() !== null };
+          }),
+          limit: 6,
+          errorMode: "continue",
+        });
+        if (hasError) {
+          throw firstError;
+        }
+        loaded = results;
+      }
+      // An owner can retire after its discovery finishes while a sibling still awaits I/O.
+      const catalogs = parts.map(
+        (part, index) => part.retiredCatalog ?? part.peekCatalog() ?? loaded[index]!.catalog,
+      );
       if (
         cachedCatalog &&
         mergedSourceCatalogs?.every((source, index) => source === catalogs[index])
       ) {
         return cachedCatalog;
       }
-      serverOwner.clear();
-      for (let index = 0; index < parts.length; index += 1) {
-        rememberServerOwners(catalogs[index]!, parts[index]!);
+      if (!params.serverOwners) {
+        serverOwner.clear();
+        for (let index = 0; index < parts.length; index += 1) {
+          rememberServerOwners(catalogs[index]!, parts[index]!);
+        }
       }
       mergedSourceCatalogs = catalogs;
       cachedCatalog = mergeMcpToolCatalogs(catalogs);
@@ -152,9 +189,7 @@ export function createCombinedSessionMcpRuntime(params: {
     throw new Error(`bundle-mcp server "${serverName}" is not connected`);
   };
 
-  const combined: CombinedSessionMcpRuntime = {
-    [COMBINED_SESSION_MCP_RUNTIME]: true,
-    managedParts: parts,
+  return {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     workspaceDir: params.workspaceDir,
@@ -166,14 +201,18 @@ export function createCombinedSessionMcpRuntime(params: {
       return serverOwner.get(serverName)?.requesterScope !== undefined;
     },
     mcpAppsEnabled: parts.some((part) => part.mcpAppsEnabled === true),
-    createdAt: Math.min(...parts.map((part) => part.createdAt)),
+    createdAt: Math.min(Date.now(), ...parts.map((part) => part.createdAt)),
     get lastUsedAt() {
       return lastUsedAt;
     },
     get activeLeases() {
-      return parts.reduce((sum, part) => sum + (part.activeLeases ?? 0), 0);
+      return Math.max(
+        activeLeases,
+        parts.reduce((sum, part) => sum + (part.activeLeases ?? 0), 0),
+      );
     },
     acquireLease() {
+      activeLeases += 1;
       const releases = parts.map((part) => part.acquireLease?.());
       let released = false;
       return () => {
@@ -181,6 +220,7 @@ export function createCombinedSessionMcpRuntime(params: {
           return;
         }
         released = true;
+        activeLeases -= 1;
         for (const release of releases) {
           release?.();
         }
@@ -191,7 +231,7 @@ export function createCombinedSessionMcpRuntime(params: {
       if (cachedCatalog && cachedCatalogIsCurrent()) {
         return cachedCatalog;
       }
-      const peeked = parts.map((part) => part.peekCatalog());
+      const peeked = parts.map((part) => part.retiredCatalog ?? part.peekCatalog());
       if (peeked.some((catalog) => catalog === null)) {
         return null;
       }
@@ -255,5 +295,4 @@ export function createCombinedSessionMcpRuntime(params: {
       await Promise.allSettled(parts.map((part) => part.dispose()));
     },
   };
-  return combined;
 }

--- a/src/agents/agent-bundle-mcp-harness.test.ts
+++ b/src/agents/agent-bundle-mcp-harness.test.ts
@@ -41,18 +41,22 @@ const mocks = vi.hoisted(() => {
     setResolveImpl(impl?: typeof resolveImpl) {
       resolveImpl = impl;
     },
-    getOrCreateRequesterScopedMcpRuntime: vi.fn(
+    acquireRequesterScopedMcpRuntime: vi.fn(
       async (params: { sessionId: string; requesterSenderId?: string | null }) => {
         if (resolveImpl) {
           const runtime = await resolveImpl(params);
           return runtime
-            ? { runtime, advertisedCatalogConfigFingerprint: runtime.configFingerprint }
+            ? {
+                runtime,
+                releaseLease: runtime.acquireLease?.() ?? (() => {}),
+                advertisedCatalogConfigFingerprint: runtime.configFingerprint,
+              }
             : undefined;
         }
         return undefined;
       },
     ),
-    getOrCreateSessionMcpRuntime: vi.fn(),
+    acquireSessionMcpRuntime: vi.fn(),
     rememberAdvertisedScopedMcpCatalog: vi.fn(
       (
         handle: { runtime: Runtime },
@@ -74,8 +78,8 @@ vi.mock("./agent-bundle-mcp-manager-api.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./agent-bundle-mcp-manager-api.js")>();
   return {
     ...actual,
-    getOrCreateRequesterScopedMcpRuntime: mocks.getOrCreateRequesterScopedMcpRuntime,
-    getOrCreateSessionMcpRuntime: mocks.getOrCreateSessionMcpRuntime,
+    acquireRequesterScopedMcpRuntime: mocks.acquireRequesterScopedMcpRuntime,
+    acquireSessionMcpRuntime: mocks.acquireSessionMcpRuntime,
     rememberAdvertisedScopedMcpCatalog: mocks.rememberAdvertisedScopedMcpCatalog,
     getAdvertisedScopedMcpCatalog: mocks.getAdvertisedScopedMcpCatalog,
   };
@@ -194,8 +198,8 @@ async function makeConnectRuntime(params: {
 
 beforeEach(() => {
   mocks.reset();
-  mocks.getOrCreateRequesterScopedMcpRuntime.mockClear();
-  mocks.getOrCreateSessionMcpRuntime.mockReset();
+  mocks.acquireRequesterScopedMcpRuntime.mockClear();
+  mocks.acquireSessionMcpRuntime.mockReset();
   mocks.rememberAdvertisedScopedMcpCatalog.mockClear();
   mocks.getAdvertisedScopedMcpCatalog.mockClear();
   readCredentialsStatus.mockReset().mockResolvedValue({ state: "unauthenticated" });
@@ -207,7 +211,10 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
     const runtime = makeRuntime({ sessionId: "scheduled", requesterSenderId: "unused" });
     delete runtime.requesterScope;
     runtime.peekCatalog()!.servers["user-mail"]!.codexApprovalMode = "approve";
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
 
     const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled",
@@ -215,7 +222,7 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
       toolsAllow: ["user-mail__inbox"],
     });
 
-    expect(mocks.getOrCreateSessionMcpRuntime).toHaveBeenCalledWith(
+    expect(mocks.acquireSessionMcpRuntime).toHaveBeenCalledWith(
       expect.not.objectContaining({
         requesterSenderId: expect.anything(),
         agentAccountId: expect.anything(),
@@ -229,7 +236,10 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
   it("never widens a finite scheduled cap", async () => {
     const runtime = makeRuntime({ sessionId: "scheduled-denied", requesterSenderId: "unused" });
     delete runtime.requesterScope;
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
 
     const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-denied",
@@ -245,7 +255,10 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
     const runtime = makeRuntime({ sessionId: "interactive", requesterSenderId: "unused" });
     delete runtime.requesterScope;
     const callTool = vi.spyOn(runtime, "callTool");
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
     let active: (() => boolean) | undefined;
     const requestInteractiveCodexApproval = vi.fn(async (request) => {
       active = request.isActive;
@@ -289,7 +302,10 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
     const runtime = makeRuntime({ sessionId: "interactive-policy", requesterSenderId: "unused" });
     delete runtime.requesterScope;
     runtime.peekCatalog()!.servers["user-mail"]!.codexApprovalMode = mode;
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
     const requestInteractiveCodexApproval = vi.fn(async () => undefined);
 
     const result = await materializeStaticMcpToolsForHarnessRunCore({
@@ -343,7 +359,10 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
       ],
     });
     const callTool = vi.spyOn(runtime, "callTool");
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
 
     const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-app",
@@ -417,7 +436,10 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
       ],
     });
     const callTool = vi.spyOn(runtime, "callTool");
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
     const requestInteractiveCodexApproval = vi.fn(async () => undefined);
 
     const result = await materializeStaticMcpToolsForHarnessRunCore({
@@ -486,7 +508,10 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
         },
       ],
     });
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
 
     const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-app-yolo",
@@ -511,7 +536,10 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
     const emptyCatalog = { version: 1, generatedAt: 0, servers: {}, tools: [] };
     runtime.peekCatalog = () => emptyCatalog;
     runtime.getCatalog = async () => emptyCatalog;
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
 
     const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-empty",
@@ -542,7 +570,10 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
     };
     runtime.peekCatalog = () => failedCatalog;
     runtime.getCatalog = async () => failedCatalog;
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
 
     const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-diagnostic",
@@ -560,7 +591,10 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
     delete runtime.requesterScope;
     const catalog = runtime.peekCatalog()!;
     catalog.servers["user-mail"]!.codexApprovalMode = "prompt";
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
     const callTool = vi.spyOn(runtime, "callTool");
 
     const result = await materializeStaticMcpToolsForHarnessRunCore({
@@ -587,7 +621,10 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
     const runtime = makeRuntime({ sessionId: "scheduled-yolo", requesterSenderId: "unused" });
     delete runtime.requesterScope;
     runtime.peekCatalog()!.servers["user-mail"]!.codexApprovalMode = mode;
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
     const callTool = vi.spyOn(runtime, "callTool");
 
     const result = await materializeStaticMcpToolsForHarnessRunCore({
@@ -619,7 +656,10 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
     if (annotations) {
       catalog.tools[0]!.codexAnnotations = annotations;
     }
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
     const callTool = vi.spyOn(runtime, "callTool");
 
     const result = await materializeStaticMcpToolsForHarnessRunCore({
@@ -636,7 +676,10 @@ describe("materializeStaticMcpToolsForHarnessRunCore", () => {
   it("omits MCP tools when scheduled approval metadata is absent", async () => {
     const runtime = makeRuntime({ sessionId: "scheduled-unknown", requesterSenderId: "unused" });
     delete runtime.requesterScope;
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({
+      runtime,
+      releaseLease: runtime.acquireLease?.() ?? (() => {}),
+    });
     const callTool = vi.spyOn(runtime, "callTool");
 
     const result = await materializeStaticMcpToolsForHarnessRunCore({

--- a/src/agents/agent-bundle-mcp-harness.ts
+++ b/src/agents/agent-bundle-mcp-harness.ts
@@ -5,8 +5,8 @@ import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tool-metadata.js";
 import {
   getAdvertisedScopedMcpCatalog,
-  getOrCreateRequesterScopedMcpRuntime,
-  getOrCreateSessionMcpRuntime,
+  acquireRequesterScopedMcpRuntime,
+  acquireSessionMcpRuntime,
   rememberAdvertisedScopedMcpCatalog,
   retireSessionMcpRuntime,
 } from "./agent-bundle-mcp-manager-api.js";
@@ -251,7 +251,7 @@ export async function materializeStaticMcpToolsForHarnessRunCore(
     retireSessionRuntimeAfterDispose?: boolean;
   },
 ): Promise<StaticHarnessMcpTools> {
-  const runtime = await getOrCreateSessionMcpRuntime({
+  const acquisition = await acquireSessionMcpRuntime({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     workspaceDir: params.workspaceDir,
@@ -271,7 +271,7 @@ export async function materializeStaticMcpToolsForHarnessRunCore(
   let liveRuntime: Awaited<ReturnType<typeof materializeBundleMcpToolsForRun>>;
   try {
     liveRuntime = await materializeBundleMcpToolsForRun({
-      runtime,
+      ...acquisition,
       agentId: params.agentId,
       reservedToolNames: params.reservedToolNames,
       ...(retireSnapshotRuntime ? { disposeRuntime: retireSnapshotRuntime } : {}),
@@ -351,7 +351,7 @@ export async function materializeStaticMcpToolsForHarnessRunCore(
 export async function materializeRequesterScopedMcpToolsForHarnessRunCore(
   params: MaterializeRequesterScopedMcpToolsForHarnessRunParams,
 ): Promise<RequesterScopedHarnessMcpTools | undefined> {
-  const scopedRuntimeHandle = await getOrCreateRequesterScopedMcpRuntime({
+  const scopedRuntimeHandle = await acquireRequesterScopedMcpRuntime({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     workspaceDir: params.workspaceDir,
@@ -371,6 +371,7 @@ export async function materializeRequesterScopedMcpToolsForHarnessRunCore(
     if (scopedRuntime) {
       liveRuntime = await materializeBundleMcpToolsForRun({
         runtime: scopedRuntime,
+        releaseLease: scopedRuntimeHandle?.releaseLease,
         agentId: params.agentId,
         reservedToolNames: params.reservedToolNames,
       });

--- a/src/agents/agent-bundle-mcp-manager-api.ts
+++ b/src/agents/agent-bundle-mcp-manager-api.ts
@@ -2,14 +2,17 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { SessionToolOverrides } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { logWarn } from "../logger.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.js";
+import type { SessionMcpConfigReload } from "./agent-bundle-mcp-runtime-owner.js";
 import { SESSION_MCP_RUNTIME_MANAGER_KEY } from "./agent-bundle-mcp-runtime-shared.js";
 import type {
   McpToolCatalog,
   RequesterScopedMcpRuntimeHandle,
   SessionMcpRuntime,
+  SessionMcpRuntimeLease,
   SessionMcpRuntimeManager,
 } from "./agent-bundle-mcp-types.js";
 
@@ -24,7 +27,7 @@ function peekSessionMcpRuntimeManager(): SessionMcpRuntimeManager | undefined {
     : undefined;
 }
 
-export async function getOrCreateSessionMcpRuntime(params: {
+export async function acquireSessionMcpRuntime(params: {
   sessionId: string;
   sessionKey?: string;
   workspaceDir: string;
@@ -35,15 +38,15 @@ export async function getOrCreateSessionMcpRuntime(params: {
   agentAccountId?: string | null;
   messageChannel?: string | null;
   toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
-}): Promise<SessionMcpRuntime> {
-  return await getSessionMcpRuntimeManager().getOrCreate(params);
+}): Promise<SessionMcpRuntimeLease> {
+  return await getSessionMcpRuntimeManager().acquire(params);
 }
 
 /**
  * Requester-scoped MCP runtime only (no static partition).
  * Shared-thread harnesses use this so static MCP stays harness-native.
  */
-export async function getOrCreateRequesterScopedMcpRuntime(params: {
+export async function acquireRequesterScopedMcpRuntime(params: {
   sessionId: string;
   sessionKey?: string;
   workspaceDir: string;
@@ -55,7 +58,7 @@ export async function getOrCreateRequesterScopedMcpRuntime(params: {
   messageChannel?: string | null;
   toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
 }): Promise<RequesterScopedMcpRuntimeHandle | undefined> {
-  return await getSessionMcpRuntimeManager().getOrCreateRequesterScoped(params);
+  return await getSessionMcpRuntimeManager().acquireRequesterScoped(params);
 }
 
 export function rememberAdvertisedScopedMcpCatalog(
@@ -123,6 +126,17 @@ export async function retireSessionMcpRuntime(params: {
   }
 }
 
+/** Releases an acquisition after its consumer has taken ownership, or after failure. */
+export async function releaseSessionMcpRuntime(lease: {
+  runtime: SessionMcpRuntime;
+  releaseLease?: () => void;
+}): Promise<void> {
+  lease.releaseLease?.();
+  await completeDeferredSessionMcpRuntimeRetirement(lease.runtime).catch((error: unknown) => {
+    logWarn(`bundle-mcp: deferred runtime cleanup failed: ${String(error)}`);
+  });
+}
+
 /** Completes a one-shot retirement after its final run, view, or request lease releases. */
 export async function completeDeferredSessionMcpRuntimeRetirement(
   runtime: SessionMcpRuntime,
@@ -147,6 +161,10 @@ export async function retireSessionMcpRuntimeForSessionKey(params: {
     preserveActiveLeases: params.preserveActiveLeases,
     onError: params.onError,
   });
+}
+
+export async function reloadSessionMcpRuntimes(params: SessionMcpConfigReload): Promise<void> {
+  await peekSessionMcpRuntimeManager()?.reloadConfig(params);
 }
 
 export async function disposeAllSessionMcpRuntimes(): Promise<void> {

--- a/src/agents/agent-bundle-mcp-manager-api.ts
+++ b/src/agents/agent-bundle-mcp-manager-api.ts
@@ -6,11 +6,11 @@ import { logWarn } from "../logger.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.js";
-import type { SessionMcpConfigReload } from "./agent-bundle-mcp-runtime-owner.js";
 import { SESSION_MCP_RUNTIME_MANAGER_KEY } from "./agent-bundle-mcp-runtime-shared.js";
 import type {
   McpToolCatalog,
   RequesterScopedMcpRuntimeHandle,
+  SessionMcpConfigReload,
   SessionMcpRuntime,
   SessionMcpRuntimeLease,
   SessionMcpRuntimeManager,

--- a/src/agents/agent-bundle-mcp-manager-install.ts
+++ b/src/agents/agent-bundle-mcp-manager-install.ts
@@ -1,11 +1,13 @@
-import type { SessionToolOverrides } from "../config/sessions/types.js";
 /** Session MCP runtime manager install path: static get-or-create + requester resolve/install. */
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { BundleMcpServerConfig } from "../plugins/bundle-mcp.js";
-import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
-import type { SessionMcpRuntimeManagerLifecycle } from "./agent-bundle-mcp-manager-lifecycle.js";
+import type {
+  SessionMcpConfigPublication,
+  SessionMcpRuntimeManagerLifecycle,
+} from "./agent-bundle-mcp-manager-lifecycle.js";
 import { createRequesterMcpConnect } from "./agent-bundle-mcp-requester-connect.js";
 import { loadSessionMcpConfig } from "./agent-bundle-mcp-runtime-config.js";
+import { sessionMcpRuntimeOwners } from "./agent-bundle-mcp-runtime-owner.js";
+import type { CreateSessionMcpRuntime } from "./agent-bundle-mcp-runtime-shared.js";
 import type {
   RequesterMcpConnect,
   SessionMcpRequesterScope,
@@ -19,57 +21,32 @@ import {
   type McpServerConnectionResolved,
 } from "./mcp-connection-resolver.js";
 
-type RuntimeEntryParams = {
+type RuntimeEntryParams = Parameters<CreateSessionMcpRuntime>[0] & {
+  configReloadAtAdmission?: SessionMcpConfigPublication;
   runtimeKey: string;
-  sessionId: string;
-  sessionKey?: string;
-  workspaceDir: string;
-  agentDir?: string;
-  cfg?: OpenClawConfig;
-  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
-  includeServerNames?: ReadonlySet<string>;
-  excludeServerNames?: ReadonlySet<string>;
-  safeServerNamesByServer?: ReadonlyMap<string, string>;
-  connectionOverrides?: ReadonlyMap<string, McpServerConnectionResolved>;
-  redactConnectionServerNames?: ReadonlySet<string>;
-  requesterScope?: SessionMcpRequesterScope;
-  requesterConnect?: RequesterMcpConnect;
-  configFingerprint?: string;
-  toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
 };
 
-type SessionMcpRuntimeManagerInstall = {
-  getOrCreateRuntimeEntry: (params: RuntimeEntryParams) => Promise<SessionMcpRuntime>;
-  resolveAndInstallRequesterRuntime: (params: {
-    runtimeKey: string;
-    sessionId: string;
-    sessionKey?: string;
-    workspaceDir: string;
-    agentDir?: string;
-    cfg?: OpenClawConfig;
-    manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
-    oauthRequesterNameSet: ReadonlySet<string>;
-    mcpServers: Record<string, BundleMcpServerConfig>;
-    resolverRequesterServerNames: readonly string[];
-    safeServerNamesByServer: ReadonlyMap<string, string>;
-    fullScopedFingerprint: string;
-    requesterSenderId: string;
-    agentAccountId?: string | null;
-    messageChannel?: string | null;
-    requesterScope: SessionMcpRequesterScope;
-    toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
-  }) => Promise<SessionMcpRuntime | undefined>;
+type RequesterRuntimeParams = RuntimeEntryParams & {
+  oauthRequesterNameSet: ReadonlySet<string>;
+  mcpServers: Record<string, BundleMcpServerConfig>;
+  resolverRequesterServerNames: readonly string[];
+  safeServerNamesByServer: ReadonlyMap<string, string>;
+  fullScopedFingerprint: string;
+  requesterSenderId: string;
+  agentAccountId?: string | null;
+  messageChannel?: string | null;
+  requesterScope: SessionMcpRequesterScope;
 };
 
-const matchesStaticReuse = (params: {
-  workspaceDir: string;
-  agentDir?: string;
-  configFingerprint: string;
-  candidate: { workspaceDir: string; agentDir?: string; configFingerprint: string };
-}): boolean =>
-  params.candidate.workspaceDir === params.workspaceDir &&
-  params.candidate.agentDir === params.agentDir &&
-  params.candidate.configFingerprint === params.configFingerprint;
+const matchesRuntime = (
+  runtime: SessionMcpRuntime,
+  params: Pick<RuntimeEntryParams, "workspaceDir" | "agentDir">,
+  fingerprint: string,
+): boolean =>
+  sessionMcpRuntimeOwners.get(runtime)?.isCurrent() !== false &&
+  runtime.workspaceDir === params.workspaceDir &&
+  runtime.agentDir === params.agentDir &&
+  runtime.configFingerprint === fingerprint;
 
 function requesterRuntimeFingerprint(
   configFingerprint: string,
@@ -82,7 +59,7 @@ function requesterRuntimeFingerprint(
 
 export function createSessionMcpRuntimeManagerInstall(
   lifecycle: SessionMcpRuntimeManagerLifecycle,
-): SessionMcpRuntimeManagerInstall {
+) {
   const { store } = lifecycle;
   const reconcileReusableRetirement = (sessionId: string, runtime: SessionMcpRuntime) => {
     if (store.requiredRetirementSessionIds.has(sessionId)) {
@@ -96,148 +73,83 @@ export function createSessionMcpRuntimeManagerInstall(
     allowMcpAppModelContext(runtime);
   };
 
-  /** Static/session runtime get-or-create (createInFlight dedup for bare keys only). */
+  /** Install under the runtime-key queue shared by acquisition and disposal. */
   const getOrCreateRuntimeEntry = async (
     params: RuntimeEntryParams,
   ): Promise<SessionMcpRuntime> => {
     const nextFingerprint =
       params.configFingerprint ??
-      loadSessionMcpConfig({
-        workspaceDir: params.workspaceDir,
-        cfg: params.cfg,
-        logDiagnostics: false,
-        manifestRegistry: params.manifestRegistry,
-        includeServerNames: params.includeServerNames,
-        excludeServerNames: params.excludeServerNames,
-        redactConnectionServerNames: params.redactConnectionServerNames,
-        safeServerNamesByServer: params.safeServerNamesByServer,
-        toolOverrides: params.toolOverrides,
-      }).fingerprint;
-    const { runtimeKey, ...runtimeParams } = params;
-    const identity = {
-      workspaceDir: params.workspaceDir,
-      agentDir: params.agentDir,
-      configFingerprint: nextFingerprint,
-    };
-    const inFlight = store.createInFlight.get(runtimeKey);
-    if (inFlight && matchesStaticReuse({ ...identity, candidate: inFlight })) {
-      return inFlight.promise;
-    }
+      loadSessionMcpConfig({ ...params, logDiagnostics: false }).fingerprint;
+    const { runtimeKey, configReloadAtAdmission, ...runtimeParams } = params;
     const existing = store.runtimesBySessionId.get(runtimeKey);
-    if (!inFlight && existing && matchesStaticReuse({ ...identity, candidate: existing })) {
+    const connectionMatches =
+      !params.connectionOverrides ||
+      store.connectionMetaByRuntimeKey.get(runtimeKey)?.connectionHash ===
+        hashMcpResolvedConnections(params.connectionOverrides);
+    if (existing && connectionMatches && matchesRuntime(existing, params, nextFingerprint)) {
       reconcileReusableRetirement(params.sessionId, existing);
       existing.markUsed();
       return existing;
     }
-    store.runtimesBySessionId.delete(runtimeKey);
     store.connectionMetaByRuntimeKey.delete(runtimeKey);
-    const isCurrent = (): boolean => store.createInFlight.get(runtimeKey)?.promise === created;
-    const superseded = () =>
-      new Error(`MCP runtime creation superseded for session ${params.sessionId}`);
-    // Claim replacement before awaiting cleanup or imports. Its producer owns late
-    // disposal; an obsolete producer must never publish or clear its successor.
-    const created: Promise<SessionMcpRuntime> = Promise.resolve().then(async () => {
-      await existing?.dispose();
-      await inFlight?.promise.catch(() => undefined);
-      if (!isCurrent()) {
-        throw superseded();
-      }
-      const runtime = await store.createRuntime({
+    let runtime =
+      existing &&
+      sessionMcpRuntimeOwners.get(existing)?.replace({
         ...runtimeParams,
         configFingerprint: nextFingerprint,
       });
-      if (!isCurrent()) {
-        await runtime.dispose();
-        throw superseded();
+    try {
+      // Transfer ownership before cleanup yields so publication can immediately
+      // revoke changed servers, including calls still using the previous facade.
+      store.runtimesBySessionId.delete(runtimeKey);
+      if (runtime) {
+        store.runtimesBySessionId.set(runtimeKey, runtime);
+      }
+      await existing?.dispose();
+      runtime ??= await store.createRuntime({
+        ...runtimeParams,
+        configFingerprint: nextFingerprint,
+      });
+      store.runtimesBySessionId.set(runtimeKey, runtime);
+      let publication = configReloadAtAdmission;
+      // Keep explicit run snapshots, but fence any publish crossed by acquisition.
+      // Plugin epochs survive subsequent ordinary config publishes.
+      while (store.configReload && store.configReload !== publication) {
+        const next = store.configReload;
+        await sessionMcpRuntimeOwners.get(runtime)?.reload({
+          ...next,
+          reloadPlugins: next.pluginGeneration !== (publication?.pluginGeneration ?? 0),
+        });
+        publication = next;
       }
       reconcileReusableRetirement(params.sessionId, runtime);
       runtime.markUsed();
-      store.runtimesBySessionId.set(runtimeKey, runtime);
       return runtime;
-    });
-    store.createInFlight.set(runtimeKey, { ...identity, promise: created });
-    try {
-      return await created;
-    } finally {
-      if (isCurrent()) {
-        store.createInFlight.delete(runtimeKey);
-      }
+    } catch (error) {
+      store.runtimesBySessionId.delete(runtimeKey);
+      await runtime?.dispose();
+      throw error;
     }
   };
 
   /** Install or reuse one requester runtime. Must run under its runtime-key lock. */
-  const installRequesterRuntime = async (params: {
-    runtimeKey: string;
-    sessionId: string;
-    sessionKey?: string;
-    workspaceDir: string;
-    agentDir?: string;
-    cfg?: OpenClawConfig;
-    manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
-    safeServerNamesByServer: ReadonlyMap<string, string>;
-    includeServerNames: ReadonlySet<string>;
-    requesterConnect?: RequesterMcpConnect;
-    connectionOverrides: Map<string, McpServerConnectionResolved>;
-    redactConnectionServerNames: ReadonlySet<string>;
-    requesterScope: SessionMcpRequesterScope;
-    toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
-  }): Promise<SessionMcpRuntime> => {
+  const installRequesterRuntime = async (
+    params: RuntimeEntryParams & {
+      connectionOverrides: Map<string, McpServerConnectionResolved>;
+    },
+  ): Promise<SessionMcpRuntime> => {
     const { fingerprint: resolvedFingerprint } = loadSessionMcpConfig({
-      workspaceDir: params.workspaceDir,
-      cfg: params.cfg,
+      ...params,
       logDiagnostics: false,
-      manifestRegistry: params.manifestRegistry,
-      includeServerNames: params.includeServerNames,
-      redactConnectionServerNames: params.redactConnectionServerNames,
-      safeServerNamesByServer: params.safeServerNamesByServer,
-      toolOverrides: params.toolOverrides,
     });
     const runtimeFingerprint = requesterRuntimeFingerprint(
       resolvedFingerprint,
       params.requesterConnect,
     );
     const connectionHash = hashMcpResolvedConnections(params.connectionOverrides);
-    const existing = store.runtimesBySessionId.get(params.runtimeKey);
-    const meta = store.connectionMetaByRuntimeKey.get(params.runtimeKey);
-    if (
-      existing &&
-      meta?.connectionHash === connectionHash &&
-      matchesStaticReuse({
-        workspaceDir: params.workspaceDir,
-        agentDir: params.agentDir,
-        configFingerprint: runtimeFingerprint,
-        candidate: existing,
-      })
-    ) {
-      reconcileReusableRetirement(params.sessionId, existing);
-      existing.markUsed();
-      store.connectionMetaByRuntimeKey.set(params.runtimeKey, {
-        connectionHash,
-        resolvedAt: store.now(),
-      });
-      return existing;
-    }
-    if (existing) {
-      store.runtimesBySessionId.delete(params.runtimeKey);
-      store.connectionMetaByRuntimeKey.delete(params.runtimeKey);
-      await existing.dispose();
-    }
     const runtime = await getOrCreateRuntimeEntry({
-      runtimeKey: params.runtimeKey,
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      workspaceDir: params.workspaceDir,
-      agentDir: params.agentDir,
-      cfg: params.cfg,
-      manifestRegistry: params.manifestRegistry,
-      includeServerNames: params.includeServerNames,
-      safeServerNamesByServer: params.safeServerNamesByServer,
-      connectionOverrides: params.connectionOverrides,
-      redactConnectionServerNames: params.redactConnectionServerNames,
-      requesterScope: params.requesterScope,
-      requesterConnect: params.requesterConnect,
+      ...params,
       configFingerprint: runtimeFingerprint,
-      toolOverrides: params.toolOverrides,
     });
     store.connectionMetaByRuntimeKey.set(params.runtimeKey, {
       connectionHash,
@@ -246,34 +158,13 @@ export function createSessionMcpRuntimeManagerInstall(
     return runtime;
   };
 
-  /** Revoke cached scoped runtime (empty re-resolution). Auth boundary: leases do not block. */
-  const revokeRequesterRuntime = async (runtimeKey: string): Promise<void> => {
-    await lifecycle.disposeRuntimeKeyNow(runtimeKey);
-  };
-
   /**
    * Full requester section for one runtimeKey: reuse / resolve / install / revoke.
    * Always invoked under runExclusiveOnRuntimeKey.
    */
-  const resolveAndInstallRequesterRuntime = async (params: {
-    runtimeKey: string;
-    sessionId: string;
-    sessionKey?: string;
-    workspaceDir: string;
-    agentDir?: string;
-    cfg?: OpenClawConfig;
-    manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
-    oauthRequesterNameSet: ReadonlySet<string>;
-    mcpServers: Record<string, BundleMcpServerConfig>;
-    resolverRequesterServerNames: readonly string[];
-    safeServerNamesByServer: ReadonlyMap<string, string>;
-    fullScopedFingerprint: string;
-    requesterSenderId: string;
-    agentAccountId?: string | null;
-    messageChannel?: string | null;
-    requesterScope: SessionMcpRequesterScope;
-    toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
-  }): Promise<SessionMcpRuntime | undefined> => {
+  const resolveAndInstallRequesterRuntime = async (
+    params: RequesterRuntimeParams,
+  ): Promise<SessionMcpRuntime | undefined> => {
     const requesterConnect = await createRequesterMcpConnect({
       serverNames: params.oauthRequesterNameSet,
       mcpServers: params.mcpServers,
@@ -287,14 +178,10 @@ export function createSessionMcpRuntimeManagerInstall(
       ...params.resolverRequesterServerNames,
     ]);
     const { fingerprint: expectedLiveFingerprint } = loadSessionMcpConfig({
-      workspaceDir: params.workspaceDir,
-      cfg: params.cfg,
+      ...params,
       logDiagnostics: false,
-      manifestRegistry: params.manifestRegistry,
       includeServerNames: expectedLiveNameSet,
       redactConnectionServerNames: new Set(params.resolverRequesterServerNames),
-      safeServerNamesByServer: params.safeServerNamesByServer,
-      toolOverrides: params.toolOverrides,
     });
     const scopedFingerprint = requesterRuntimeFingerprint(
       expectedLiveFingerprint,
@@ -308,16 +195,7 @@ export function createSessionMcpRuntimeManagerInstall(
     // continuously active requesters (markUsed does not extend this clock alone).
     const withinRevalidateWindow =
       meta !== undefined && store.now() - meta.resolvedAt < revalidateMs;
-    if (
-      withinRevalidateWindow &&
-      existing &&
-      matchesStaticReuse({
-        workspaceDir: params.workspaceDir,
-        agentDir: params.agentDir,
-        configFingerprint: scopedFingerprint,
-        candidate: existing,
-      })
-    ) {
+    if (withinRevalidateWindow && existing && matchesRuntime(existing, params, scopedFingerprint)) {
       reconcileReusableRetirement(params.sessionId, existing);
       existing.markUsed();
       return existing;
@@ -336,16 +214,14 @@ export function createSessionMcpRuntimeManagerInstall(
     if (activeNameSet.size === 0 && !requesterConnect) {
       // Empty re-resolution revokes cached scoped credentials.
       // Leases do not block: this is an authorization boundary.
-      if (
-        store.runtimesBySessionId.has(params.runtimeKey) ||
-        store.createInFlight.has(params.runtimeKey)
-      ) {
-        await revokeRequesterRuntime(params.runtimeKey);
+      if (store.runtimesBySessionId.has(params.runtimeKey)) {
+        await lifecycle.disposeRuntimeKeyNow(params.runtimeKey);
       }
       return undefined;
     }
     return await installRequesterRuntime({
       runtimeKey: params.runtimeKey,
+      configReloadAtAdmission: params.configReloadAtAdmission,
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
       workspaceDir: params.workspaceDir,

--- a/src/agents/agent-bundle-mcp-manager-lifecycle.ts
+++ b/src/agents/agent-bundle-mcp-manager-lifecycle.ts
@@ -2,6 +2,10 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { logWarn } from "../logger.js";
 import {
+  sessionMcpRuntimeOwners,
+  type SessionMcpConfigReload,
+} from "./agent-bundle-mcp-runtime-owner.js";
+import {
   DEFAULT_SESSION_MCP_RUNTIME_IDLE_TTL_MS,
   SESSION_MCP_MAX_IDLE_REQUESTER_RUNTIMES,
   SESSION_MCP_RUNTIME_SWEEP_INTERVAL_MS,
@@ -19,12 +23,7 @@ import type {
 // The process-owned sweep must not retain its first requesting turn.
 const runInMcpManagerContext = AsyncLocalStorage.snapshot();
 
-type ManagerCreateInFlight = {
-  promise: Promise<SessionMcpRuntime>;
-  workspaceDir: string;
-  agentDir?: string;
-  configFingerprint: string;
-};
+export type SessionMcpConfigPublication = SessionMcpConfigReload & { pluginGeneration: number };
 
 type AdvertisedScopedCatalogEntry = {
   configFingerprint: string;
@@ -34,6 +33,7 @@ type AdvertisedScopedCatalogEntry = {
 };
 
 type SessionMcpRuntimeManagerStore = {
+  configReload?: SessionMcpConfigPublication;
   runtimesBySessionId: Map<string, SessionMcpRuntime>;
   sessionIdBySessionKey: Map<string, string>;
   deferredRetirementSessionIds: Set<string>;
@@ -41,8 +41,8 @@ type SessionMcpRuntimeManagerStore = {
   requiredRetirementSessionIds: Set<string>;
   connectionMetaByRuntimeKey: Map<string, { connectionHash: string; resolvedAt: number }>;
   advertisedScopedCatalogBySessionId: Map<string, AdvertisedScopedCatalogEntry>;
-  requesterWorkChains: Map<string, Promise<unknown>>;
-  createInFlight: Map<string, ManagerCreateInFlight>;
+  runtimeWorkChains: Map<string, Promise<unknown>>;
+  disposalInFlight?: Promise<void>;
   createRuntime: CreateSessionMcpRuntime;
   now: () => number;
   idleSweepIntervalMs: number;
@@ -91,15 +91,13 @@ export function createSessionMcpRuntimeManagerStore(
      */
     advertisedScopedCatalogBySessionId: new Map(),
     /**
-     * Per-runtimeKey serialization for requester resolve+install and dispose.
+     * Per-runtimeKey serialization for acquisition and dispose.
      * Sections never overlap for one key, so a slow resolve cannot clobber a newer install.
      * Entries are removed when their chain drains.
      */
-    requesterWorkChains: new Map(),
+    runtimeWorkChains: new Map(),
     createRuntime: opts.createRuntime ?? createSessionMcpRuntime,
     now: opts.now ?? Date.now,
-    // Static bare-sessionId create dedup only. Requester keys use requesterWorkChains exclusively.
-    createInFlight: new Map(),
     idleSweepIntervalMs: opts.idleSweepIntervalMs ?? SESSION_MCP_RUNTIME_SWEEP_INTERVAL_MS,
     maxIdleRequesterRuntimes:
       opts.maxIdleRequesterRuntimesPerSession ?? SESSION_MCP_MAX_IDLE_REQUESTER_RUNTIMES,
@@ -109,33 +107,9 @@ export function createSessionMcpRuntimeManagerStore(
   };
 }
 
-export type SessionMcpRuntimeManagerLifecycle = {
-  store: SessionMcpRuntimeManagerStore;
-  forgetSessionKeysForSessionId: (sessionId: string) => void;
-  runtimeKeysForSessionId: (sessionId: string) => string[];
-  totalActiveLeasesForSessionId: (sessionId: string) => number;
-  runExclusiveOnRuntimeKey: <T>(runtimeKey: string, work: () => Promise<T>) => Promise<T>;
-  sweepIdleRuntimes: () => Promise<number>;
-  enforceRequesterRuntimeCap: (sessionId: string, keepRuntimeKey: string) => Promise<void>;
-  ensureIdleSweepTimer: () => void;
-  clearIdleSweepTimer: () => void;
-  disposeRuntimeKeyNow: (runtimeKey: string) => Promise<void>;
-  disposeRuntimeKeys: (runtimeKeys: Iterable<string>) => Promise<void>;
-  disposeManagedSession: (
-    sessionId: string,
-    opts?: { preserveRequiredRetirement?: boolean },
-  ) => Promise<void>;
-  rememberAdvertisedScopedCatalog: (
-    handle: RequesterScopedMcpRuntimeHandle,
-    catalog: McpToolCatalog,
-  ) => void;
-  getAdvertisedScopedCatalog: (sessionId: string) => McpToolCatalog | null;
-  reconcileAdvertisedScopedCatalogConfig: (
-    sessionId: string,
-    fingerprint: string,
-    preparePublication: boolean,
-  ) => void;
-};
+export type SessionMcpRuntimeManagerLifecycle = ReturnType<
+  typeof createSessionMcpRuntimeManagerLifecycle
+>;
 
 function scopedCatalogToolsSignature(tools: readonly McpCatalogTool[]): string {
   return JSON.stringify(
@@ -153,9 +127,7 @@ function scopedCatalogToolsSignature(tools: readonly McpCatalogTool[]): string {
   );
 }
 
-export function createSessionMcpRuntimeManagerLifecycle(
-  store: SessionMcpRuntimeManagerStore,
-): SessionMcpRuntimeManagerLifecycle {
+export function createSessionMcpRuntimeManagerLifecycle(store: SessionMcpRuntimeManagerStore) {
   const forgetSessionKeysForSessionId = (sessionId: string) => {
     for (const [sessionKey, mappedSessionId] of store.sessionIdBySessionKey.entries()) {
       if (mappedSessionId === sessionId) {
@@ -165,13 +137,18 @@ export function createSessionMcpRuntimeManagerLifecycle(
   };
 
   const runtimeKeysForSessionId = (sessionId: string): string[] => {
-    const keys: string[] = [];
+    const keys = new Set<string>();
     for (const [runtimeKey, runtime] of store.runtimesBySessionId.entries()) {
       if (runtime.sessionId === sessionId) {
-        keys.push(runtimeKey);
+        keys.add(runtimeKey);
       }
     }
-    return keys;
+    for (const runtimeKey of store.runtimeWorkChains.keys()) {
+      if (parseRuntimeCacheSessionId(runtimeKey) === sessionId) {
+        keys.add(runtimeKey);
+      }
+    }
+    return [...keys];
   };
 
   const totalActiveLeasesForSessionId = (sessionId: string): number => {
@@ -182,17 +159,26 @@ export function createSessionMcpRuntimeManagerLifecycle(
     return total;
   };
 
-  const runExclusiveOnRuntimeKey = <T>(runtimeKey: string, work: () => Promise<T>): Promise<T> => {
-    const previous = store.requesterWorkChains.get(runtimeKey) ?? Promise.resolve();
-    const run = previous.catch(() => undefined).then(() => work());
+  const runExclusiveOnRuntimeKeys = <T>(
+    runtimeKeys: string[],
+    work: () => Promise<T>,
+  ): Promise<T> => {
+    const previous = runtimeKeys
+      .map((key) => store.runtimeWorkChains.get(key))
+      .filter((pending) => pending !== undefined);
+    const run = Promise.allSettled(previous).then(work);
     const settled: Promise<unknown> = run.then(
       () => undefined,
       () => undefined,
     );
-    store.requesterWorkChains.set(runtimeKey, settled);
+    for (const key of runtimeKeys) {
+      store.runtimeWorkChains.set(key, settled);
+    }
     void settled.finally(() => {
-      if (store.requesterWorkChains.get(runtimeKey) === settled) {
-        store.requesterWorkChains.delete(runtimeKey);
+      for (const key of runtimeKeys) {
+        if (store.runtimeWorkChains.get(key) === settled) {
+          store.runtimeWorkChains.delete(key);
+        }
       }
     });
     return run;
@@ -208,9 +194,9 @@ export function createSessionMcpRuntimeManagerLifecycle(
       if (nowMs - runtime.lastUsedAt < DEFAULT_SESSION_MCP_RUNTIME_IDLE_TTL_MS) {
         continue;
       }
-      // Requester work runs outside the runtime lease. Keep its current
+      // Acquisition runs outside the runtime lease. Keep its current
       // transport until the chain records the refreshed runtime.
-      if (store.requesterWorkChains.has(runtimeKey)) {
+      if (store.runtimeWorkChains.has(runtimeKey)) {
         continue;
       }
       store.runtimesBySessionId.delete(runtimeKey);
@@ -259,11 +245,11 @@ export function createSessionMcpRuntimeManagerLifecycle(
     for (const { runtimeKey, runtime } of evictable) {
       // Do not queue opportunistic eviction behind active requester work: that
       // would dispose the runtime the work just refreshed.
-      if (store.requesterWorkChains.has(runtimeKey)) {
+      if (store.runtimeWorkChains.has(runtimeKey)) {
         continue;
       }
       // Claim the idle key before yielding so later requester work follows disposal.
-      await runExclusiveOnRuntimeKey(runtimeKey, async () => {
+      await runExclusiveOnRuntimeKeys([runtimeKey], async () => {
         const current = store.runtimesBySessionId.get(runtimeKey);
         if (current !== runtime || (current.activeLeases ?? 0) > 0) {
           return;
@@ -308,54 +294,53 @@ export function createSessionMcpRuntimeManagerLifecycle(
   };
 
   const disposeRuntimeKeyNow = async (runtimeKey: string): Promise<void> => {
-    const inFlight = store.createInFlight.get(runtimeKey);
     const runtime = store.runtimesBySessionId.get(runtimeKey);
-    // Revoke publication before yielding. The captured producer disposes its own
-    // late result, while a newly admitted replacement keeps its maps and claim.
-    store.createInFlight.delete(runtimeKey);
     store.runtimesBySessionId.delete(runtimeKey);
     store.connectionMetaByRuntimeKey.delete(runtimeKey);
-    try {
-      await runtime?.dispose();
-    } finally {
-      await inFlight?.promise.catch(() => undefined);
-    }
+    await runtime?.dispose();
   };
 
-  const disposeRuntimeKeys = async (runtimeKeys: Iterable<string>): Promise<void> => {
-    // Keep requester chains owned until teardown runs; clearing them early lets
-    // replacement installs overlap the resolve/install work being drained.
-    await Promise.allSettled(
-      [...runtimeKeys].map((runtimeKey) =>
-        runtimeKey.startsWith("{")
-          ? runExclusiveOnRuntimeKey(runtimeKey, () => disposeRuntimeKeyNow(runtimeKey))
-          : disposeRuntimeKeyNow(runtimeKey),
-      ),
-    );
-  };
-
-  const disposeManagedSession = async (
-    sessionId: string,
+  const disposeManagedRuntimes = (
+    sessionId?: string,
     opts?: { preserveRequiredRetirement?: boolean },
   ): Promise<void> => {
-    store.deferredRetirementSessionIds.delete(sessionId);
-    if (opts?.preserveRequiredRetirement !== true) {
-      store.requiredRetirementSessionIds.delete(sessionId);
-    }
-    store.advertisedScopedCatalogBySessionId.delete(sessionId);
-    const runtimeKeys = new Set(runtimeKeysForSessionId(sessionId));
-    for (const runtimeKey of store.createInFlight.keys()) {
-      if (parseRuntimeCacheSessionId(runtimeKey) === sessionId) {
-        runtimeKeys.add(runtimeKey);
+    const runtimeKeys = [
+      ...new Set(
+        sessionId === undefined
+          ? [...store.runtimesBySessionId.keys(), ...store.runtimeWorkChains.keys()]
+          : [sessionId, ...runtimeKeysForSessionId(sessionId)],
+      ),
+    ];
+    const priorDisposal = store.disposalInFlight;
+    const disposal = runExclusiveOnRuntimeKeys(runtimeKeys, async () => {
+      await priorDisposal;
+      // Clear bookkeeping after admitted acquisitions finish, before successors run.
+      if (sessionId === undefined) {
+        clearIdleSweepTimer();
+        store.configReload = undefined;
+        store.sessionIdBySessionKey.clear();
+        store.deferredRetirementSessionIds.clear();
+        store.requiredRetirementSessionIds.clear();
+        store.advertisedScopedCatalogBySessionId.clear();
+      } else {
+        store.deferredRetirementSessionIds.delete(sessionId);
+        if (opts?.preserveRequiredRetirement !== true) {
+          store.requiredRetirementSessionIds.delete(sessionId);
+        }
+        store.advertisedScopedCatalogBySessionId.delete(sessionId);
+        forgetSessionKeysForSessionId(sessionId);
       }
+      await Promise.allSettled(runtimeKeys.map(disposeRuntimeKeyNow));
+    });
+    if (sessionId === undefined) {
+      // New session keys also wait for a global teardown already in progress.
+      store.disposalInFlight = disposal;
     }
-    for (const runtimeKey of store.requesterWorkChains.keys()) {
-      if (parseRuntimeCacheSessionId(runtimeKey) === sessionId) {
-        runtimeKeys.add(runtimeKey);
+    return disposal.finally(() => {
+      if (store.disposalInFlight === disposal) {
+        store.disposalInFlight = undefined;
       }
-    }
-    forgetSessionKeysForSessionId(sessionId);
-    await disposeRuntimeKeys(runtimeKeys);
+    });
   };
 
   const rememberAdvertisedScopedCatalog = (
@@ -366,7 +351,11 @@ export function createSessionMcpRuntimeManagerLifecycle(
     // An older requester may finish after reconciliation; reject its catalog
     // instead of allowing stale tools to repopulate the session cache.
     const entry = store.advertisedScopedCatalogBySessionId.get(runtime.sessionId);
-    if (entry?.configFingerprint !== advertisedCatalogConfigFingerprint) {
+    if (
+      entry?.configFingerprint !== advertisedCatalogConfigFingerprint ||
+      sessionMcpRuntimeOwners.get(runtime)?.isCurrent() === false ||
+      ![...store.runtimesBySessionId.values()].includes(runtime)
+    ) {
       return;
     }
     const toolsByServerName = new Map<string, McpCatalogTool[]>();
@@ -435,17 +424,14 @@ export function createSessionMcpRuntimeManagerLifecycle(
 
   return {
     store,
-    forgetSessionKeysForSessionId,
     runtimeKeysForSessionId,
     totalActiveLeasesForSessionId,
-    runExclusiveOnRuntimeKey,
+    runExclusiveOnRuntimeKeys,
     sweepIdleRuntimes,
     enforceRequesterRuntimeCap,
     ensureIdleSweepTimer,
-    clearIdleSweepTimer,
     disposeRuntimeKeyNow,
-    disposeRuntimeKeys,
-    disposeManagedSession,
+    disposeManagedRuntimes,
     rememberAdvertisedScopedCatalog,
     getAdvertisedScopedCatalog,
     reconcileAdvertisedScopedCatalogConfig,

--- a/src/agents/agent-bundle-mcp-manager-lifecycle.ts
+++ b/src/agents/agent-bundle-mcp-manager-lifecycle.ts
@@ -1,10 +1,7 @@
 /** Session MCP runtime manager lifecycle: maps, idle sweep, dispose, advertised catalog. */
 import { AsyncLocalStorage } from "node:async_hooks";
 import { logWarn } from "../logger.js";
-import {
-  sessionMcpRuntimeOwners,
-  type SessionMcpConfigReload,
-} from "./agent-bundle-mcp-runtime-owner.js";
+import { sessionMcpRuntimeOwners } from "./agent-bundle-mcp-runtime-owner.js";
 import {
   DEFAULT_SESSION_MCP_RUNTIME_IDLE_TTL_MS,
   SESSION_MCP_MAX_IDLE_REQUESTER_RUNTIMES,
@@ -16,6 +13,7 @@ import type {
   McpServerCatalog,
   McpToolCatalog,
   RequesterScopedMcpRuntimeHandle,
+  SessionMcpConfigReload,
   SessionMcpRuntime,
 } from "./agent-bundle-mcp-types.js";
 

--- a/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
+++ b/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
@@ -2,12 +2,13 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
-import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.js";
+import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.test-support.js";
+import type { SessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.test-support.js";
 import {
   SESSION_MCP_RUNTIME_SWEEP_INTERVAL_MS,
   type CreateSessionMcpRuntime,
 } from "./agent-bundle-mcp-runtime-shared.js";
-import type { SessionMcpRuntime, SessionMcpRuntimeManager } from "./agent-bundle-mcp-types.js";
+import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { testing as resolverTesting } from "./mcp-connection-resolver.js";
 
 vi.mock("./agent-bundle-mcp-runtime.js", () => {
@@ -180,7 +181,7 @@ describe("MCP manager creation ownership", () => {
   );
 
   it.each(["session", "all"] as const)(
-    "drains late creation during %s disposal without publishing or clearing a successor",
+    "drains late creation during %s disposal before admitting a successor",
     async (scope) => {
       const first = holdFactory();
       const next = holdFactory();
@@ -190,7 +191,6 @@ describe("MCP manager creation ownership", () => {
         .mockImplementationOnce(next.createRuntime);
       const manager = createManager(createRuntime);
       const oldRequest = manager.getOrCreate(params);
-      const oldOutcome = oldRequest.catch((error: unknown) => error);
       const oldRuntime = await first.started;
       const closing = holdDisposal(oldRuntime);
       let drained = false;
@@ -201,17 +201,17 @@ describe("MCP manager creation ownership", () => {
       });
 
       const nextRequest = manager.getOrCreate(params);
-      const nextRuntime = await next.started;
       first.release();
       await closing.started;
       expect(drained).toBe(false);
+      expect(createRuntime).toHaveBeenCalledOnce();
       expect(manager.peekSession({ sessionId: params.sessionId })).toBeUndefined();
       closing.release();
       await disposal;
-      expect(await oldOutcome).toMatchObject({ message: expect.stringContaining("superseded") });
+      expect(await oldRequest).toBe(oldRuntime);
       expect(oldRuntime.dispose).toHaveBeenCalledOnce();
 
-      // The old producer's finally and teardown both ran while this claim was pending.
+      const nextRuntime = await next.started;
       const concurrentRequest = manager.getOrCreate(params);
       next.release();
       const [created, concurrent] = await Promise.all([nextRequest, concurrentRequest]);
@@ -260,7 +260,93 @@ describe("MCP manager creation ownership", () => {
     expect(oldRuntime.dispose).toHaveBeenCalledOnce();
   });
 
-  it("supersedes a pending factory without duplicating its replacement", async () => {
+  it.each(["session", "all"] as const)(
+    "drains the requester partition of a pending full acquisition during %s disposal",
+    async (scope) => {
+      const first = holdFactory();
+      const resolutionStarted = createDeferred();
+      const releaseResolution = createDeferred();
+      releaseHeldWork.push(() => releaseResolution.resolve());
+      resolverTesting.setMcpServerConnectionResolversForTest([
+        {
+          serverName: "scoped",
+          resolve: async () => {
+            resolutionStarted.resolve();
+            await releaseResolution.promise;
+            return { url: "https://mcp.example.test/scoped" };
+          },
+        },
+      ]);
+      const created: SessionMcpRuntime[] = [];
+      const manager = createManager(async (input) => {
+        const runtime = created.length
+          ? createRuntimeFixture(input)
+          : await first.createRuntime(input);
+        created.push(runtime);
+        return runtime;
+      });
+      const pending = manager.acquire(requesterParams("sender"));
+      await first.started;
+      let drained = false;
+      const disposal = (
+        scope === "session" ? manager.disposeSession(params.sessionId) : manager.disposeAll()
+      ).then(() => {
+        drained = true;
+      });
+      first.release();
+      await resolutionStarted.promise;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(drained).toBe(false);
+      releaseResolution.resolve();
+      const acquired = await pending;
+      acquired.releaseLease();
+      await disposal;
+      expect(created).toHaveLength(2);
+      for (const runtime of created) {
+        expect(runtime.dispose).toHaveBeenCalledOnce();
+      }
+      expect(manager.listRuntimeKeys()).toEqual([]);
+      expect(manager.resolveSessionId(params.sessionKey)).toBeUndefined();
+    },
+  );
+
+  it.each(["session", "all"] as const)(
+    "queues a new requester key behind %s teardown",
+    async (scope) => {
+      resolverTesting.setMcpServerConnectionResolversForTest([
+        { serverName: "scoped", resolve: async () => ({ url: "https://mcp.example.test/scoped" }) },
+      ]);
+      const createRuntime = vi.fn<CreateSessionMcpRuntime>(createRuntimeFixture);
+      const manager = createManager(createRuntime);
+      const old = expectDefined(
+        await manager.acquireRequesterScoped(requesterParams("first")),
+        "first requester",
+      );
+      old.releaseLease();
+      const closing = holdDisposal(old.runtime);
+      const disposal =
+        scope === "session" ? manager.disposeSession(params.sessionId) : manager.disposeAll();
+      await closing.started;
+      const next = manager.acquireRequesterScoped({
+        ...requesterParams("next"),
+        ...(scope === "all" ? { sessionId: "another-session", sessionKey: "another-key" } : {}),
+      });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(createRuntime).toHaveBeenCalledOnce();
+      closing.release();
+      await disposal;
+      const acquired = expectDefined(await next, "next requester");
+      acquired.releaseLease();
+      expect(acquired.runtime.dispose).not.toHaveBeenCalled();
+      expect(manager.listSessionIds()).toEqual([acquired.runtime.sessionId]);
+    },
+  );
+
+  it("serializes a pending factory and reuses its queued replacement", async () => {
     const first = holdFactory();
     const next = holdFactory();
     const createRuntime = vi
@@ -268,7 +354,7 @@ describe("MCP manager creation ownership", () => {
       .mockImplementationOnce(first.createRuntime)
       .mockImplementationOnce(next.createRuntime);
     const manager = createManager(createRuntime);
-    const oldRequest = manager.getOrCreate(params).catch((error: unknown) => error);
+    const oldRequest = manager.getOrCreate(params);
     const oldRuntime = await first.started;
     const changed = { ...params, workspaceDir: "/replacement-workspace" };
     const replacement = manager.getOrCreate(changed);
@@ -277,7 +363,7 @@ describe("MCP manager creation ownership", () => {
     first.release();
 
     const nextRuntime = await next.started;
-    expect(await oldRequest).toMatchObject({ message: expect.stringContaining("superseded") });
+    expect(await oldRequest).toBe(oldRuntime);
     expect(oldRuntime.dispose).toHaveBeenCalledOnce();
     expect(manager.peekSession({ sessionId: params.sessionId })).toBeUndefined();
     next.release();

--- a/src/agents/agent-bundle-mcp-manager.requester-connect.test.ts
+++ b/src/agents/agent-bundle-mcp-manager.requester-connect.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.js";
+import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.test-support.js";
 import { materializeBundleMcpToolsForRun } from "./agent-bundle-mcp-materialize.js";
 import type { CreateSessionMcpRuntime } from "./agent-bundle-mcp-runtime-shared.js";
 import type { McpToolCatalog, SessionMcpRuntime } from "./agent-bundle-mcp-types.js";

--- a/src/agents/agent-bundle-mcp-manager.test-support.ts
+++ b/src/agents/agent-bundle-mcp-manager.test-support.ts
@@ -1,0 +1,33 @@
+import { acquireSessionMcpRuntime } from "./agent-bundle-mcp-manager-api.js";
+import { createSessionMcpRuntimeManager as createManager } from "./agent-bundle-mcp-manager.js";
+import type { SessionMcpRuntimeManager as RuntimeManager } from "./agent-bundle-mcp-types.js";
+
+// Passive cache/TTL tests deliberately relinquish admission before inspecting the
+// raw runtime. Production callers transfer the acquired lease to their consumer.
+export async function getOrCreateSessionMcpRuntime(
+  params: Parameters<typeof acquireSessionMcpRuntime>[0],
+) {
+  const lease = await acquireSessionMcpRuntime(params);
+  lease.releaseLease();
+  return lease.runtime;
+}
+
+export function createSessionMcpRuntimeManager(...args: Parameters<typeof createManager>) {
+  const manager = createManager(...args);
+  return Object.assign(manager, {
+    async getOrCreate(params: Parameters<RuntimeManager["acquire"]>[0]) {
+      const lease = await manager.acquire(params);
+      lease.releaseLease();
+      return lease.runtime;
+    },
+    async getOrCreateRequesterScoped(
+      params: Parameters<RuntimeManager["acquireRequesterScoped"]>[0],
+    ) {
+      const lease = await manager.acquireRequesterScoped(params);
+      lease?.releaseLease();
+      return lease;
+    },
+  });
+}
+
+export type SessionMcpRuntimeManager = ReturnType<typeof createSessionMcpRuntimeManager>;

--- a/src/agents/agent-bundle-mcp-manager.ts
+++ b/src/agents/agent-bundle-mcp-manager.ts
@@ -1,26 +1,34 @@
-/** Session MCP runtime manager: get-or-create and requester-scoped install orchestration. */
+/** Session MCP runtime manager: acquisition and requester-scoped install orchestration. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { BundleMcpServerConfig } from "../plugins/bundle-mcp.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
-import {
-  createCombinedSessionMcpRuntime,
-  isCombinedSessionMcpRuntime,
-} from "./agent-bundle-mcp-combined.js";
+import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
 import { createSessionMcpRuntimeManagerInstall } from "./agent-bundle-mcp-manager-install.js";
 import {
   createSessionMcpRuntimeManagerLifecycle,
   createSessionMcpRuntimeManagerStore,
   type SessionMcpRuntimeManagerOpts,
+  type SessionMcpConfigPublication,
 } from "./agent-bundle-mcp-manager-lifecycle.js";
 import { assignSafeServerNames } from "./agent-bundle-mcp-names.js";
 import { loadSessionMcpConfig } from "./agent-bundle-mcp-runtime-config.js";
+import { sessionMcpRuntimeOwners } from "./agent-bundle-mcp-runtime-owner.js";
 import type { CreateSessionMcpRuntime } from "./agent-bundle-mcp-runtime-shared.js";
-import type { SessionMcpRuntime, SessionMcpRuntimeManager } from "./agent-bundle-mcp-types.js";
+import type {
+  SessionMcpRuntime,
+  SessionMcpRuntimeLease,
+  SessionMcpRuntimeManager,
+} from "./agent-bundle-mcp-types.js";
 import { revokeMcpAppModelContext } from "./mcp-app-model-context.js";
 import {
   buildMcpRequesterRuntimeCacheKey,
   partitionMcpServersByConnectionScope,
 } from "./mcp-connection-resolver.js";
+
+type RuntimeAcquisitionParams = Parameters<SessionMcpRuntimeManager["acquire"]>[0];
+type PreparedAcquisitionParams = RuntimeAcquisitionParams & {
+  requester?: { runtimeKey: string; senderId: string };
+};
 
 const sessionMcpRuntimeLoader = createLazyImportLoader(
   () => import("./agent-bundle-mcp-runtime.js"),
@@ -38,215 +46,216 @@ export function createSessionMcpRuntimeManager(
   const store = createSessionMcpRuntimeManagerStore(opts, createSessionMcpRuntimeLazy);
   const lifecycle = createSessionMcpRuntimeManagerLifecycle(store);
   const install = createSessionMcpRuntimeManagerInstall(lifecycle);
+  const leaseRuntime = (runtime: SessionMcpRuntime): SessionMcpRuntimeLease => ({
+    runtime,
+    releaseLease: runtime.acquireLease?.() ?? (() => {}),
+  });
+  const acquireCurrent = <T extends SessionMcpRuntimeLease | undefined>(
+    scope: "full" | "requester",
+    acquire: (params: PreparedAcquisitionParams) => Promise<T>,
+  ) =>
+    async function current(params: RuntimeAcquisitionParams): Promise<T> {
+      const senderId = normalizeOptionalString(params.requesterSenderId);
+      const requester = senderId
+        ? {
+            senderId,
+            runtimeKey: buildMcpRequesterRuntimeCacheKey({
+              ...params,
+              requesterSenderId: senderId,
+            }),
+          }
+        : undefined;
+      const runtimeKeys = requester ? [requester.runtimeKey] : [];
+      if (scope === "full" || !requester) {
+        runtimeKeys.push(params.sessionId);
+      }
+      const priorDisposal = store.disposalInFlight;
+      const priorSessionWork = store.runtimeWorkChains.get(params.sessionId);
+      const input: PreparedAcquisitionParams = { ...params, requester };
+      let publication = store.configReload;
+      let acquired: T | undefined;
+      try {
+        // Reserve every possible partition before yielding, including requester
+        // keys a crossed publication may add. Teardown drains this entire admission.
+        return await lifecycle.runExclusiveOnRuntimeKeys(runtimeKeys, async () => {
+          await Promise.all([priorDisposal, priorSessionWork].filter((work) => work !== undefined));
+          for (;;) {
+            const next = store.configReload;
+            // A publication can cross queued admission before a producer starts.
+            if (next && next !== publication) {
+              Object.assign(input, { cfg: next.cfg, manifestRegistry: next.manifestRegistry });
+            }
+            publication = next;
+            const previous = acquired;
+            acquired = await acquire(input);
+            // Keep one hidden lease until its successor owns unchanged transports.
+            previous?.releaseLease();
+            if (!store.configReload || store.configReload === publication) {
+              return acquired;
+            }
+          }
+        });
+      } catch (error) {
+        acquired?.releaseLease();
+        acquired = undefined;
+        throw error;
+      } finally {
+        // Retirement may wait for this queue; complete it only after leaving it.
+        if (!acquired) {
+          await manager.completeDeferredRetirement(params.sessionId);
+        }
+      }
+    };
+  const prepareAcquisition = (params: PreparedAcquisitionParams) => {
+    const fullConfig = loadSessionMcpConfig({ ...params, logDiagnostics: false });
+    const partition = partitionMcpServersByConnectionScope(fullConfig.loaded.mcpServers);
+    // Full-set names stay stable when only some requester connections resolve.
+    const safeServerNamesByServer = assignSafeServerNames(
+      Object.keys(fullConfig.loaded.mcpServers),
+    );
+    const advertisedCatalogConfigFingerprint = loadSessionMcpConfig({
+      ...params,
+      loaded: fullConfig.loaded,
+      logDiagnostics: false,
+      redactConnectionServerNames: new Set(partition.requesterScopedServerNames),
+      safeServerNamesByServer,
+    }).fingerprint;
+    lifecycle.reconcileAdvertisedScopedCatalogConfig(
+      params.sessionId,
+      advertisedCatalogConfigFingerprint,
+      params.requester !== undefined && partition.requesterScopedServerNames.length > 0,
+    );
+    return {
+      fullConfig,
+      ...partition,
+      safeServerNamesByServer,
+      requester: params.requester,
+      advertisedCatalogConfigFingerprint,
+    };
+  };
   const materializeRequesterScopedRuntime = async (
-    params: Parameters<SessionMcpRuntimeManager["getOrCreate"]>[0] & {
+    params: RuntimeAcquisitionParams & {
+      configReloadAtAdmission?: SessionMcpConfigPublication;
       mcpServers: Record<string, BundleMcpServerConfig>;
       oauthRequesterServerNames: readonly string[];
       resolverRequesterServerNames: readonly string[];
       scopedNameSet: ReadonlySet<string>;
       safeServerNamesByServer: ReadonlyMap<string, string>;
       requesterSenderId: string;
+      runtimeKey: string;
     },
   ) => {
     const oauthRequesterNameSet = new Set(params.oauthRequesterServerNames);
     const resolverRequesterNameSet = new Set(params.resolverRequesterServerNames);
     const agentAccountId = normalizeOptionalString(params.agentAccountId);
     const messageChannel = normalizeOptionalString(params.messageChannel);
-    const runtimeKey = buildMcpRequesterRuntimeCacheKey({
-      sessionId: params.sessionId,
-      messageChannel,
-      agentAccountId,
-      requesterSenderId: params.requesterSenderId,
-    });
     const fullScopedFingerprint = loadSessionMcpConfig({
-      workspaceDir: params.workspaceDir,
-      cfg: params.cfg,
+      ...params,
       logDiagnostics: false,
-      manifestRegistry: params.manifestRegistry,
       includeServerNames: params.scopedNameSet,
       redactConnectionServerNames: resolverRequesterNameSet,
-      safeServerNamesByServer: params.safeServerNamesByServer,
-      toolOverrides: params.toolOverrides,
     }).fingerprint;
-    const runtime = await lifecycle.runExclusiveOnRuntimeKey(runtimeKey, () =>
-      install.resolveAndInstallRequesterRuntime({
-        ...params,
-        runtimeKey,
-        fullScopedFingerprint,
-        oauthRequesterNameSet,
-        agentAccountId,
-        messageChannel,
-        requesterScope: {
-          requesterSenderId: params.requesterSenderId,
-          ...(agentAccountId ? { agentAccountId } : {}),
-          ...(messageChannel ? { messageChannel } : {}),
-        },
-      }),
-    );
-    return { runtimeKey, runtime };
+    const runtime = await install.resolveAndInstallRequesterRuntime({
+      ...params,
+      fullScopedFingerprint,
+      oauthRequesterNameSet,
+      agentAccountId,
+      messageChannel,
+      requesterScope: {
+        requesterSenderId: params.requesterSenderId,
+        ...(agentAccountId ? { agentAccountId } : {}),
+        ...(messageChannel ? { messageChannel } : {}),
+      },
+    });
+    return runtime ? leaseRuntime(runtime) : undefined;
   };
 
   const manager: SessionMcpRuntimeManager = {
-    async getOrCreate(params) {
+    acquire: acquireCurrent("full", async (params) => {
+      const configReloadAtAdmission = store.configReload;
       await lifecycle.sweepIdleRuntimes();
       lifecycle.ensureIdleSweepTimer();
       if (params.sessionKey) {
         store.sessionIdBySessionKey.set(params.sessionKey, params.sessionId);
       }
 
-      const configParams = {
-        workspaceDir: params.workspaceDir,
-        cfg: params.cfg,
-        logDiagnostics: false,
-        manifestRegistry: params.manifestRegistry,
-        toolOverrides: params.toolOverrides,
-      };
-      const fullConfig = loadSessionMcpConfig(configParams);
-      // Safe names from the FULL declared set so partial resolution never changes tool names.
-      const safeServerNamesByServer = assignSafeServerNames(
-        Object.keys(fullConfig.loaded.mcpServers),
-      );
       const {
+        fullConfig,
         staticServers,
         requesterScopedServerNames,
         oauthRequesterServerNames,
         resolverRequesterServerNames,
-      } = partitionMcpServersByConnectionScope(fullConfig.loaded.mcpServers);
-      const hasRequesterScoped = requesterScopedServerNames.length > 0;
-      const requesterSenderId = normalizeOptionalString(params.requesterSenderId);
-      lifecycle.reconcileAdvertisedScopedCatalogConfig(
-        params.sessionId,
-        loadSessionMcpConfig({
-          ...configParams,
-          loaded: fullConfig.loaded,
-          redactConnectionServerNames: new Set(requesterScopedServerNames),
-          safeServerNamesByServer,
-        }).fingerprint,
-        hasRequesterScoped && requesterSenderId !== undefined,
-      );
+        safeServerNamesByServer,
+        requester,
+      } = prepareAcquisition(params);
 
-      if (!hasRequesterScoped) {
-        return await install.getOrCreateRuntimeEntry({
-          runtimeKey: params.sessionId,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          workspaceDir: params.workspaceDir,
-          agentDir: params.agentDir,
-          cfg: params.cfg,
-          manifestRegistry: params.manifestRegistry,
-          safeServerNamesByServer,
-          toolOverrides: params.toolOverrides,
-        });
-      }
-
-      const parts: SessionMcpRuntime[] = [];
-      const scopedNameSet = new Set(requesterScopedServerNames);
-      let emptyStaticRuntime: SessionMcpRuntime | undefined;
-      if (Object.keys(staticServers).length > 0) {
-        parts.push(
+      const leases: SessionMcpRuntimeLease[] = [];
+      try {
+        const staticLease = leaseRuntime(
           await install.getOrCreateRuntimeEntry({
+            ...params,
             runtimeKey: params.sessionId,
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            workspaceDir: params.workspaceDir,
-            agentDir: params.agentDir,
-            cfg: params.cfg,
-            manifestRegistry: params.manifestRegistry,
-            excludeServerNames: scopedNameSet,
+            configReloadAtAdmission,
+            excludeServerNames: new Set(requesterScopedServerNames),
             safeServerNamesByServer,
-            toolOverrides: params.toolOverrides,
           }),
         );
-      } else {
-        // Reconcile bare key when every server is requester-scoped.
-        emptyStaticRuntime = await install.getOrCreateRuntimeEntry({
-          runtimeKey: params.sessionId,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          workspaceDir: params.workspaceDir,
-          agentDir: params.agentDir,
-          cfg: params.cfg,
-          manifestRegistry: params.manifestRegistry,
-          includeServerNames: new Set(),
-          safeServerNamesByServer,
-          toolOverrides: params.toolOverrides,
-        });
-      }
-
-      if (requesterSenderId) {
-        const { runtimeKey, runtime: scopedRuntime } = await materializeRequesterScopedRuntime({
-          ...params,
-          mcpServers: fullConfig.loaded.mcpServers,
-          oauthRequesterServerNames,
-          resolverRequesterServerNames,
-          scopedNameSet,
-          safeServerNamesByServer,
-          requesterSenderId,
-        });
-        if (scopedRuntime) {
-          parts.push(scopedRuntime);
+        leases.push(staticLease);
+        if (requesterScopedServerNames.length === 0) {
+          return staticLease;
         }
-        await lifecycle.enforceRequesterRuntimeCap(params.sessionId, runtimeKey);
-      }
-
-      if (parts.length === 0) {
-        return (
-          emptyStaticRuntime ??
-          (await install.getOrCreateRuntimeEntry({
-            runtimeKey: params.sessionId,
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            workspaceDir: params.workspaceDir,
-            agentDir: params.agentDir,
-            cfg: params.cfg,
-            manifestRegistry: params.manifestRegistry,
-            includeServerNames: new Set(),
+        const parts = Object.keys(staticServers).length > 0 ? [staticLease.runtime] : [];
+        const scopedNameSet = new Set(requesterScopedServerNames);
+        if (requester) {
+          const lease = await materializeRequesterScopedRuntime({
+            ...params,
+            configReloadAtAdmission,
+            mcpServers: fullConfig.loaded.mcpServers,
+            oauthRequesterServerNames,
+            resolverRequesterServerNames,
+            scopedNameSet,
             safeServerNamesByServer,
-            toolOverrides: params.toolOverrides,
-          }))
-        );
+            requesterSenderId: requester.senderId,
+            runtimeKey: requester.runtimeKey,
+          });
+          if (lease) {
+            leases.push(lease);
+            parts.push(lease.runtime);
+            await lifecycle.enforceRequesterRuntimeCap(params.sessionId, requester.runtimeKey);
+          }
+        }
+        return {
+          runtime:
+            parts.length === 0
+              ? staticLease.runtime
+              : createCombinedSessionMcpRuntime({
+                  sessionId: params.sessionId,
+                  sessionKey: params.sessionKey,
+                  workspaceDir: params.workspaceDir,
+                  agentDir: params.agentDir,
+                  parts,
+                }),
+          releaseLease: () => leases.forEach((lease) => lease.releaseLease()),
+        };
+      } catch (error) {
+        leases.forEach((lease) => lease.releaseLease());
+        throw error;
       }
-
-      return createCombinedSessionMcpRuntime({
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        workspaceDir: params.workspaceDir,
-        agentDir: params.agentDir,
-        parts,
-      });
-    },
-    async getOrCreateRequesterScoped(params) {
+    }),
+    acquireRequesterScoped: acquireCurrent("requester", async (params) => {
+      const configReloadAtAdmission = store.configReload;
       // Anonymous turns own no requester runtime; reconcile first so a cached
       // catalog cannot survive a senderless harness turn.
-      const requesterSenderId = normalizeOptionalString(params.requesterSenderId);
-      const configParams = {
-        workspaceDir: params.workspaceDir,
-        cfg: params.cfg,
-        logDiagnostics: false,
-        manifestRegistry: params.manifestRegistry,
-        toolOverrides: params.toolOverrides,
-      };
-      const fullConfig = loadSessionMcpConfig(configParams);
       const {
+        fullConfig,
         requesterScopedServerNames,
         oauthRequesterServerNames,
         resolverRequesterServerNames,
-      } = partitionMcpServersByConnectionScope(fullConfig.loaded.mcpServers);
-      const safeServerNamesByServer = assignSafeServerNames(
-        Object.keys(fullConfig.loaded.mcpServers),
-      );
-      const advertisedCatalogConfigFingerprint = loadSessionMcpConfig({
-        ...configParams,
-        loaded: fullConfig.loaded,
-        redactConnectionServerNames: new Set(requesterScopedServerNames),
         safeServerNamesByServer,
-      }).fingerprint;
-      lifecycle.reconcileAdvertisedScopedCatalogConfig(
-        params.sessionId,
+        requester,
         advertisedCatalogConfigFingerprint,
-        requesterSenderId !== undefined && requesterScopedServerNames.length > 0,
-      );
-      if (!requesterSenderId) {
+      } = prepareAcquisition(params);
+      if (!requester) {
         return undefined;
       }
       await lifecycle.sweepIdleRuntimes();
@@ -258,21 +267,28 @@ export function createSessionMcpRuntimeManager(
         return undefined;
       }
       const scopedNameSet = new Set(requesterScopedServerNames);
-      const { runtimeKey, runtime } = await materializeRequesterScopedRuntime({
+      const lease = await materializeRequesterScopedRuntime({
         ...params,
+        configReloadAtAdmission,
         mcpServers: fullConfig.loaded.mcpServers,
         oauthRequesterServerNames,
         resolverRequesterServerNames,
         scopedNameSet,
         safeServerNamesByServer,
-        requesterSenderId,
+        requesterSenderId: requester.senderId,
+        runtimeKey: requester.runtimeKey,
       });
-      if (!runtime) {
+      if (!lease) {
         return undefined;
       }
-      await lifecycle.enforceRequesterRuntimeCap(params.sessionId, runtimeKey);
-      return { runtime, advertisedCatalogConfigFingerprint };
-    },
+      try {
+        await lifecycle.enforceRequesterRuntimeCap(params.sessionId, requester.runtimeKey);
+        return { ...lease, advertisedCatalogConfigFingerprint };
+      } catch (error) {
+        lease.releaseLease();
+        throw error;
+      }
+    }),
     rememberAdvertisedScopedCatalog: lifecycle.rememberAdvertisedScopedCatalog,
     getAdvertisedScopedCatalog: lifecycle.getAdvertisedScopedCatalog,
     bindSessionKey(sessionKey, sessionId) {
@@ -287,9 +303,7 @@ export function createSessionMcpRuntimeManager(
         (params.sessionKey ? store.sessionIdBySessionKey.get(params.sessionKey) : undefined);
       return sessionId ? store.runtimesBySessionId.get(sessionId) : undefined;
     },
-    async disposeSession(sessionId) {
-      await lifecycle.disposeManagedSession(sessionId);
-    },
+    disposeSession: lifecycle.disposeManagedRuntimes,
     deferRetirement(sessionId, retirementOpts) {
       if (retirementOpts?.retainAcrossReuse === true) {
         for (const runtimeKey of lifecycle.runtimeKeysForSessionId(sessionId)) {
@@ -298,8 +312,6 @@ export function createSessionMcpRuntimeManager(
             revokeMcpAppModelContext(runtime);
           }
         }
-      }
-      if (retirementOpts?.retainAcrossReuse === true) {
         store.requiredRetirementSessionIds.add(sessionId);
       } else {
         store.requiredRetirementSessionIds.delete(sessionId);
@@ -326,41 +338,41 @@ export function createSessionMcpRuntimeManager(
       ) {
         return false;
       }
-      const managed = lifecycle
-        .runtimeKeysForSessionId(sessionId)
-        .map((runtimeKey) => store.runtimesBySessionId.get(runtimeKey))
-        .filter((entry): entry is SessionMcpRuntime => Boolean(entry));
-      if (managed.length === 0) {
+      const runtimeKeys = lifecycle.runtimeKeysForSessionId(sessionId);
+      if (runtimeKeys.length === 0) {
         return false;
       }
-      const managedSet = new Set(managed);
-      if (runtime !== undefined) {
-        if (isCombinedSessionMcpRuntime(runtime)) {
-          if (!runtime.managedParts.every((part) => managedSet.has(part))) {
-            return false;
-          }
-        } else if (!managedSet.has(runtime)) {
-          return false;
-        }
+      const pendingWork = runtimeKeys
+        .map((runtimeKey) => store.runtimeWorkChains.get(runtimeKey))
+        .filter((work) => work !== undefined);
+      if (pendingWork.length > 0) {
+        // Acquisition can clear ordinary intent or take a replacement lease.
+        // Recheck after success or failure; neither may strand required retirement.
+        await Promise.allSettled(pendingWork);
+        return await manager.completeDeferredRetirement(sessionId, runtime);
       }
-      await lifecycle.disposeManagedSession(sessionId, {
+      // Retirement belongs to the session. Reuse clears ordinary intent; required
+      // intent survives replacement and completes when its last transferred lease releases.
+      await lifecycle.disposeManagedRuntimes(sessionId, {
         preserveRequiredRetirement: store.requiredRetirementSessionIds.has(sessionId),
       });
       return true;
     },
-    async disposeAll() {
-      lifecycle.clearIdleSweepTimer();
-      const runtimeKeys = new Set([
-        ...store.runtimesBySessionId.keys(),
-        ...store.createInFlight.keys(),
-        ...store.requesterWorkChains.keys(),
-      ]);
-      store.sessionIdBySessionKey.clear();
-      store.deferredRetirementSessionIds.clear();
-      store.requiredRetirementSessionIds.clear();
+    async reloadConfig(reload) {
+      store.configReload = {
+        ...reload,
+        pluginGeneration:
+          (store.configReload?.pluginGeneration ?? 0) + (reload.reloadPlugins ? 1 : 0),
+      };
       store.advertisedScopedCatalogBySessionId.clear();
-      await lifecycle.disposeRuntimeKeys(runtimeKeys);
+      // In-flight creation checks this publication before it can expose its runtime.
+      await Promise.all(
+        [...store.runtimesBySessionId.values()].map(async (runtime) =>
+          sessionMcpRuntimeOwners.get(runtime)?.reload(reload),
+        ),
+      );
     },
+    disposeAll: () => lifecycle.disposeManagedRuntimes(),
     sweepIdleRuntimes: lifecycle.sweepIdleRuntimes,
     listSessionIds() {
       return [
@@ -379,8 +391,7 @@ export function createSessionMcpRuntimeManager(
     bookkeepingSizesForTest: () => ({
       runtimes: store.runtimesBySessionId.size,
       connectionMeta: store.connectionMetaByRuntimeKey.size,
-      createInFlight: store.createInFlight.size,
-      requesterWorkChains: store.requesterWorkChains.size,
+      runtimeWorkChains: store.runtimeWorkChains.size,
       sessionKeys: store.sessionIdBySessionKey.size,
       deferredRetirement: store.deferredRetirementSessionIds.size,
       advertisedScopedCatalogs: store.advertisedScopedCatalogBySessionId.size,

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -42,14 +42,9 @@ async function releaseRuntimeLease(params: {
   runtime: SessionMcpRuntime;
   releaseLease?: () => void;
 }): Promise<void> {
-  params.releaseLease?.();
-  // Lease retirement is a lifecycle-only edge. Keep the manager graph out of
-  // read-only CLI startup paths that load tool materialization metadata.
-  const { completeDeferredSessionMcpRuntimeRetirement } =
-    await import("./agent-bundle-mcp-manager-api.js");
-  await completeDeferredSessionMcpRuntimeRetirement(params.runtime).catch((error: unknown) => {
-    logWarn(`bundle-mcp: deferred runtime cleanup failed: ${String(error)}`);
-  });
+  // Keep lifecycle imports out of read-only tool metadata loading.
+  const { releaseSessionMcpRuntime } = await import("./agent-bundle-mcp-manager-api.js");
+  await releaseSessionMcpRuntime(params);
 }
 
 function buildAppToolPolicyProjections(params: {
@@ -448,12 +443,14 @@ export async function materializeBundleMcpToolsForRun(params: {
   runtime: SessionMcpRuntime;
   agentId?: string;
   reservedToolNames?: Iterable<string>;
+  /** Transfer the lease admitted by the manager before returning this runtime. */
+  releaseLease?: () => void;
   disposeRuntime?: () => Promise<void>;
 }): Promise<BundleMcpToolRuntime> {
   const runtime = params.runtime;
   let disposed = false;
   let allowedAppToolsByServer: Map<string, Set<string>> | undefined;
-  const releaseLease = runtime.acquireLease?.();
+  const releaseLease = params.releaseLease ?? runtime.acquireLease?.();
   runtime.markUsed();
   let catalog;
   try {

--- a/src/agents/agent-bundle-mcp-probe.test-support.ts
+++ b/src/agents/agent-bundle-mcp-probe.test-support.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { makeTempDir } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
+
+export async function probeMcpServer(runtime: SessionMcpRuntime, serverName: string, input = {}) {
+  const result = await runtime.callTool(serverName, "probe", input);
+  const text = result.content.find((item) => item.type === "text")?.text;
+  return JSON.parse(String(text)) as { pid: number; label: string; lists: number };
+}
+
+export async function createMcpProbeFixture(tempDirs: string[]) {
+  const workspaceDir = makeTempDir(tempDirs, "mcp-reload-");
+  const serverPath = path.join(workspaceDir, "server.mjs");
+  await fs.writeFile(
+    serverPath,
+    `
+import readline from "node:readline";
+import fs from "node:fs/promises";
+import { setTimeout } from "node:timers/promises";
+let lists = 0;
+let toolName = "probe";
+async function handle(message) {
+  let result;
+  if (message.method === "initialize") result = { protocolVersion: message.params.protocolVersion, capabilities: { tools: { listChanged: true } }, serverInfo: { name: "reload-probe", version: "1" } };
+  if (message.method === "tools/list") { lists++; result = { tools: [{ name: toolName, inputSchema: { type: "object" } }] }; }
+  if (message.method === "tools/call") {
+    if (message.params.arguments?.changeTools) {
+      toolName = "updated_probe";
+      process.stdout.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/tools/list_changed" }) + "\\n");
+    }
+    if (message.params.arguments?.hold) {
+      const marker = message.params.arguments.hold;
+      await fs.writeFile(marker + ".started", "started");
+      while (!(await fs.stat(marker).catch(() => undefined))) await setTimeout(10);
+    }
+    result = { content: [{ type: "text", text: JSON.stringify({ pid: process.pid, label: process.argv[2], lists }) }] };
+  }
+  if (result) process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result }) + "\\n");
+}
+for await (const line of readline.createInterface({ input: process.stdin })) void handle(JSON.parse(line));
+`,
+  );
+  const config = (label = "old"): OpenClawConfig => ({
+    plugins: { enabled: false },
+    mcp: {
+      servers: {
+        healthy: { command: process.execPath, args: [serverPath, "healthy"] },
+        changed: { command: process.execPath, args: [serverPath, label] },
+      },
+    },
+  });
+  return {
+    config,
+    params: { sessionId: "reload-test", workspaceDir, manifestRegistry: { plugins: [] } },
+  };
+}

--- a/src/agents/agent-bundle-mcp-reload.test.ts
+++ b/src/agents/agent-bundle-mcp-reload.test.ts
@@ -1,0 +1,851 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import { setImmediate } from "node:timers/promises";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { cleanupTempDirs } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginManifestRecordFixture } from "../plugins/plugin-metadata.test-support.js";
+import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
+import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.test-support.js";
+import { materializeBundleMcpToolsForRun } from "./agent-bundle-mcp-materialize.js";
+import {
+  createMcpProbeFixture,
+  probeMcpServer as probe,
+} from "./agent-bundle-mcp-probe.test-support.js";
+import { createSessionMcpRuntime } from "./agent-bundle-mcp-runtime.js";
+import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
+import { testing as resolverTesting } from "./mcp-connection-resolver.js";
+
+const startAuthorization = vi.hoisted(() => vi.fn(async () => ({ status: "authorized" })));
+const readAuthorization = vi.hoisted(() => vi.fn(async () => ({ state: "unauthenticated" })));
+vi.mock("./mcp-oauth.js", () => ({
+  readMcpOAuthCredentialsStatus: readAuthorization,
+  startMcpOAuthAuthorization: startAuthorization,
+}));
+
+const tempDirs: string[] = [];
+const managers: ReturnType<typeof createSessionMcpRuntimeManager>[] = [];
+const cleanups: Array<() => Promise<unknown>> = [];
+const releaseHeld: Array<() => void> = [];
+
+afterEach(async () => {
+  for (const release of releaseHeld.splice(0)) {
+    release();
+  }
+  await Promise.all(managers.splice(0).map((manager) => manager.disposeAll()));
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+  cleanupTempDirs(tempDirs);
+  startAuthorization.mockClear();
+  readAuthorization.mockReset().mockResolvedValue({ state: "unauthenticated" });
+  resolverTesting.setMcpServerConnectionResolversForTest();
+  resolverTesting.setMcpConnectionRevalidateMsForTest();
+});
+
+async function fixture() {
+  const source = await createMcpProbeFixture(tempDirs);
+  const manager = createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
+  managers.push(manager);
+  return { ...source, manager };
+}
+
+it("keeps unchanged server transports and catalogs when another server changes", async () => {
+  const { manager, config, params } = await fixture();
+  const original = await manager.getOrCreate({ ...params, cfg: config() });
+  const originalCatalog = await original.getCatalog();
+  const first = await probe(original, "healthy");
+  const old = await probe(original, "changed");
+  const refreshed = await manager.getOrCreate({ ...params, cfg: config("new") });
+
+  expect(await probe(refreshed, "healthy")).toEqual(first);
+  expect(await probe(original, "healthy")).toEqual(first);
+  expect((await refreshed.getCatalog()).servers.healthy).toBe(originalCatalog.servers.healthy);
+  expect(await probe(refreshed, "changed")).toMatchObject({ label: "new" });
+  expect((await probe(refreshed, "changed")).pid).not.toBe(old.pid);
+  await expect(probe(original, "changed")).rejects.toThrow(/disposed|retir/);
+});
+
+it.each(["change", "disable", "remove", "collision"] as const)(
+  "revokes only the changed owner immediately on %s publication",
+  async (change) => {
+    const { manager, config, params } = await fixture();
+    const acquisition = await manager.acquire({ ...params, cfg: config() });
+    const original = acquisition.runtime;
+    const healthy = await probe(original, "healthy");
+    await probe(original, "changed");
+    const next = config("new");
+    if (change === "disable") {
+      expectDefined(next.mcp!.servers!.changed, "configured changed server").enabled = false;
+    }
+    if (change === "remove") {
+      delete next.mcp!.servers!.changed;
+    }
+    if (change === "collision") {
+      next.mcp!.servers = {
+        CHANGED: expectDefined(config().mcp!.servers!.changed, "collision source server"),
+        ...config().mcp!.servers,
+      };
+    }
+    await manager.reloadConfig({ cfg: next, manifestRegistry: params.manifestRegistry });
+    await expect(probe(original, "changed")).rejects.toThrow();
+    expect(await probe(original, "healthy")).toEqual(healthy);
+    const materialized = await materializeBundleMcpToolsForRun(acquisition);
+    try {
+      expect(materialized.tools.map((tool) => tool.name)).toEqual(["healthy__probe"]);
+      expect(materialized.diagnostics).toEqual([
+        expect.objectContaining({
+          serverName: "changed",
+          message: expect.stringMatching(/retired/),
+        }),
+      ]);
+    } finally {
+      await materialized.dispose();
+    }
+    const refreshed = await manager.getOrCreate({ ...params, cfg: next });
+    expect(await probe(refreshed, "healthy")).toEqual(healthy);
+    const catalog = await refreshed.getCatalog();
+    if (change === "disable" || change === "remove") {
+      expect(catalog.servers.changed).toBeUndefined();
+    } else {
+      expect(catalog.servers.changed?.safeServerName).toBe(
+        change === "collision" ? "changed-2" : "changed",
+      );
+    }
+  },
+);
+
+it("allows an unchanged server call to finish across config publication", async () => {
+  const { manager, config, params } = await fixture();
+  const original = await manager.getOrCreate({ ...params, cfg: config() });
+  const healthy = await probe(original, "healthy");
+  const held = path.join(params.workspaceDir, "held-call");
+  const result = probe(original, "healthy", { hold: held });
+  const observed = result.catch(() => undefined);
+  try {
+    await expect
+      .poll(async () => Boolean(await fs.stat(`${held}.started`).catch(() => undefined)))
+      .toBe(true);
+    await manager.reloadConfig({ cfg: config("new"), manifestRegistry: params.manifestRegistry });
+    const refreshed = await manager.getOrCreate({ ...params, cfg: config("new") });
+    await fs.writeFile(held, "release");
+    expect(await result).toEqual(healthy);
+    expect(await probe(refreshed, "healthy")).toEqual(healthy);
+  } finally {
+    await fs.writeFile(held, "release");
+    await observed;
+  }
+});
+
+it.each(["creating", "queued"])(
+  "fences a %s acquisition against a crossed publication",
+  async (phase) => {
+    const { config, params } = await fixture();
+    const started = createDeferred();
+    const released = createDeferred();
+    releaseHeld.push(() => released.resolve());
+    const manager = createSessionMcpRuntimeManager({
+      enableIdleSweepTimer: false,
+      async createRuntime(input) {
+        started.resolve();
+        await released.promise;
+        return createSessionMcpRuntime(input);
+      },
+    });
+    managers.push(manager);
+    const first = manager.acquire({ ...params, cfg: config() });
+    await started.promise;
+    const pending = phase === "queued" ? manager.acquire({ ...params, cfg: config() }) : first;
+    const next = config();
+    delete next.mcp!.servers!.changed;
+    await manager.reloadConfig({ cfg: next, manifestRegistry: params.manifestRegistry });
+    released.resolve();
+    if (phase === "queued") {
+      (await first).releaseLease();
+    }
+    const acquisition = await pending;
+    const old = acquisition.runtime;
+    await expect(probe(old, "changed")).rejects.toThrow();
+    expect(await probe(old, "healthy")).toMatchObject({ label: "healthy" });
+    const materialized = await materializeBundleMcpToolsForRun(acquisition);
+    try {
+      expect(materialized.tools.map((tool) => tool.name)).toEqual(["healthy__probe"]);
+    } finally {
+      await materialized.dispose();
+    }
+    const current = await manager.getOrCreate({ ...params, cfg: next });
+    expect((await current.getCatalog()).servers.changed).toBeUndefined();
+  },
+);
+
+async function httpProbe(onDelete?: () => Promise<void>, onList?: () => Promise<void>) {
+  let initialized = 0;
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      if (req.method === "DELETE") {
+        await onDelete?.();
+        res.writeHead(200).end();
+        return;
+      }
+      if (req.method !== "POST") {
+        res.writeHead(405).end();
+        return;
+      }
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(Buffer.from(chunk));
+      }
+      const message = JSON.parse(Buffer.concat(chunks).toString()) as {
+        id?: number;
+        method: string;
+        params?: { protocolVersion?: string };
+      };
+      let result;
+      if (message.method === "initialize") {
+        res.setHeader("mcp-session-id", String(++initialized));
+        result = {
+          protocolVersion: message.params?.protocolVersion,
+          capabilities: { tools: {} },
+          serverInfo: { name: "requester-probe", version: "1" },
+        };
+      } else if (message.method === "tools/list") {
+        await onList?.();
+        result = { tools: [{ name: "probe", inputSchema: { type: "object" } }] };
+      } else if (message.method === "tools/call") {
+        result = {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                pid: Number(req.headers["mcp-session-id"]),
+                label: "requester",
+              }),
+            },
+          ],
+        };
+      }
+      if (!result) {
+        res.writeHead(202).end();
+        return;
+      }
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ jsonrpc: "2.0", id: message.id, result }));
+    })().catch(() => {
+      res.writeHead(500).end();
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  cleanups.push(async () => {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("MCP probe did not bind");
+  }
+  return `http://127.0.0.1:${address.port}/mcp`;
+}
+
+it.each(["changed", "healthy"])(
+  "materializes healthy siblings when %s discovery spans revocation",
+  async (heldServer) => {
+    const started = createDeferred();
+    const released = createDeferred();
+    releaseHeld.push(() => released.resolve());
+    const url = await httpProbe(undefined, async () => {
+      started.resolve();
+      await released.promise;
+    });
+    const { manager, config, params } = await fixture();
+    const cfg = config();
+    cfg.mcp!.servers![heldServer] = { transport: "streamable-http", url };
+    const acquisition = await manager.acquire({ ...params, cfg });
+    const pending = materializeBundleMcpToolsForRun(acquisition);
+    void pending.catch(() => undefined);
+    await started.promise;
+    await probe(acquisition.runtime, heldServer === "changed" ? "healthy" : "changed");
+    const next = structuredClone(cfg);
+    delete next.mcp!.servers!.changed;
+    await manager.reloadConfig({ cfg: next, manifestRegistry: params.manifestRegistry });
+    released.resolve();
+    const materialized = await pending;
+    try {
+      expect(materialized.tools.map((tool) => tool.name)).toEqual(["healthy__probe"]);
+      expect(materialized.diagnostics).toEqual([
+        expect.objectContaining({
+          serverName: "changed",
+          message: expect.stringMatching(/retired/),
+        }),
+      ]);
+    } finally {
+      await materialized.dispose();
+    }
+  },
+);
+
+it("refreshes a catalog invalidated while a sibling is still discovering", async () => {
+  const started = createDeferred();
+  const released = createDeferred();
+  releaseHeld.push(() => released.resolve());
+  const url = await httpProbe(undefined, async () => {
+    started.resolve();
+    await released.promise;
+  });
+  const { manager, config, params } = await fixture();
+  const cfg = config();
+  delete cfg.mcp!.servers!.changed;
+  const first = await manager.getOrCreate({ ...params, cfg });
+  await first.getCatalog();
+  const second = await manager.getOrCreate({
+    ...params,
+    sessionId: "discovering-sibling",
+    cfg: { mcp: { servers: { sibling: { transport: "streamable-http", url } } } },
+  });
+  const combined = createCombinedSessionMcpRuntime({ ...params, parts: [first, second] });
+  const pending = combined.getCatalog();
+  await started.promise;
+  await probe(first, "healthy", { changeTools: true });
+  await expect.poll(() => first.peekCatalog()).toBeNull();
+  released.resolve();
+  expect((await pending).tools.map((tool) => tool.toolName)).toEqual(["updated_probe", "probe"]);
+  expect(combined.peekCatalog()?.tools.map((tool) => tool.toolName)).toEqual([
+    "updated_probe",
+    "probe",
+  ]);
+});
+
+it.each(["remove", "disable", "public origin"])(
+  "does not publish revoked sign-in tools when %s crosses sibling discovery",
+  async (change) => {
+    const started = createDeferred();
+    const released = createDeferred();
+    releaseHeld.push(() => released.resolve());
+    const url = await httpProbe(undefined, async () => {
+      started.resolve();
+      await released.promise;
+    });
+    const { manager, config, params } = await fixture();
+    const cfg = config();
+    cfg.gateway = { publicOrigin: "https://gateway.example.test" };
+    cfg.mcp!.servers!.healthy = { transport: "streamable-http", url };
+    for (const serverName of ["calendar", "contacts"]) {
+      cfg.mcp!.servers![serverName] = {
+        transport: "streamable-http",
+        url: `https://mcp.example.test/${serverName}`,
+        auth: "oauth",
+        oauth: { identity: "per-requester" },
+      };
+    }
+    const acquisition = await manager.acquire({ ...params, cfg, requesterSenderId: "alice" });
+    const pending = materializeBundleMcpToolsForRun(acquisition);
+    await started.promise;
+    const next = structuredClone(cfg);
+    if (change === "remove") {
+      delete next.mcp!.servers!.calendar;
+    } else if (change === "disable") {
+      next.mcp!.servers!.calendar!.enabled = false;
+    } else {
+      next.gateway!.publicOrigin = "https://replacement.example.test";
+    }
+    await manager.reloadConfig({ cfg: next, manifestRegistry: params.manifestRegistry });
+    released.resolve();
+    const materialized = await pending;
+    try {
+      expect(materialized.tools.map((tool) => tool.name)).toEqual(
+        change === "public origin"
+          ? ["changed__probe", "healthy__probe"]
+          : ["changed__probe", "contacts__connect", "healthy__probe"],
+      );
+    } finally {
+      await materialized.dispose();
+    }
+  },
+);
+
+it("rotates one requester's changed server while retaining sibling connections and requesters", async () => {
+  const url = await httpProbe();
+  let generation = 0;
+  resolverTesting.setMcpConnectionRevalidateMsForTest(1);
+  resolverTesting.setMcpServerConnectionResolversForTest(
+    ["first", "second"].map((serverName) => ({
+      serverName,
+      resolve: async ({ requesterSenderId }) => ({
+        url,
+        headers: {
+          Authorization: `proof-${requesterSenderId}-${serverName === "first" && requesterSenderId === "alice" ? generation : 0}`,
+        },
+      }),
+    })),
+  );
+  const { manager, params } = await fixture();
+  const cfg: OpenClawConfig = {
+    plugins: { enabled: false },
+    mcp: {
+      servers: {
+        first: { transport: "streamable-http" },
+        second: { transport: "streamable-http" },
+      },
+    },
+  };
+  const aliceParams = { ...params, cfg, requesterSenderId: "alice" };
+  const bobParams = { ...params, cfg, requesterSenderId: "bob" };
+  const alice = await manager.getOrCreate(aliceParams);
+  const bob = await manager.getOrCreate(bobParams);
+  const before = await Promise.all([
+    probe(alice, "first"),
+    probe(alice, "second"),
+    probe(bob, "first"),
+    probe(bob, "second"),
+  ]);
+  generation++;
+  const nextAlice = await manager.getOrCreate(aliceParams);
+  const nextBob = await manager.getOrCreate(bobParams);
+  const after = await Promise.all([
+    probe(nextAlice, "first"),
+    probe(nextAlice, "second"),
+    probe(nextBob, "first"),
+    probe(nextBob, "second"),
+  ]);
+  expect(after[0]).not.toEqual(before[0]);
+  expect(after.slice(1)).toEqual(before.slice(1));
+  const oldHandle = await manager.getOrCreateRequesterScoped(aliceParams);
+  expect(oldHandle).toBeDefined();
+  await manager.reloadConfig({
+    cfg,
+    manifestRegistry: params.manifestRegistry,
+    reloadPlugins: true,
+  });
+  await expect(probe(nextAlice, "first")).rejects.toThrow();
+  const currentHandle = await manager.getOrCreateRequesterScoped(bobParams);
+  expect(currentHandle).toBeDefined();
+  const currentCatalog = await currentHandle!.runtime.getCatalog();
+  manager.rememberAdvertisedScopedCatalog(currentHandle!, currentCatalog);
+  manager.rememberAdvertisedScopedCatalog(oldHandle!, {
+    ...currentCatalog,
+    servers: { retired: { serverName: "retired", launchSummary: "retired plugin", toolCount: 0 } },
+    tools: [],
+  });
+  expect(manager.getAdvertisedScopedCatalog(params.sessionId)?.servers.retired).toBeUndefined();
+  const successor = await manager.getOrCreate(aliceParams);
+  expect(await probe(successor, "first")).not.toEqual(after[0]);
+});
+
+it.each(["removal", "public origin change", "plugin replacement with explicit shadow"])(
+  "revokes a retained connect callback on %s",
+  async (change) => {
+    const { manager, params } = await fixture();
+    const cfg: OpenClawConfig = {
+      plugins: { enabled: false },
+      gateway: { publicOrigin: "https://gateway.example.test" },
+      mcp: {
+        servers: {
+          calendar: {
+            transport: "streamable-http",
+            url: "https://mcp.example.test",
+            auth: "oauth",
+            oauth: { identity: "per-requester" },
+            cwd: params.workspaceDir,
+          },
+        },
+      },
+    };
+    const calendar = expectDefined(cfg.mcp!.servers!.calendar, "calendar server");
+    const reloadPlugins = change === "plugin replacement with explicit shadow";
+    const manifestRegistry = reloadPlugins
+      ? {
+          plugins: [
+            createPluginManifestRecordFixture({
+              id: "reload-probe",
+              rootDir: params.workspaceDir,
+              mcpServers: { calendar },
+            }),
+          ],
+        }
+      : params.manifestRegistry;
+    if (reloadPlugins) {
+      cfg.plugins = { entries: { "reload-probe": { enabled: true } } };
+      cfg.mcp!.servers = {};
+    }
+    const runtime = await manager.getOrCreate({
+      ...params,
+      manifestRegistry,
+      cfg,
+      requesterSenderId: "alice",
+    });
+    const connect = runtime.requesterConnect?.createExecute("calendar");
+    expect(connect).toBeDefined();
+    await connect!("before", {});
+    expect(startAuthorization).toHaveBeenCalledOnce();
+    await manager.reloadConfig({
+      cfg:
+        change === "removal"
+          ? { ...cfg, mcp: { servers: {} } }
+          : reloadPlugins
+            ? { ...cfg, mcp: { servers: { calendar } } }
+            : {
+                ...cfg,
+                gateway: { publicOrigin: "https://replacement.example.test" },
+              },
+      manifestRegistry,
+      reloadPlugins,
+    });
+    await expect(connect!("after", {})).rejects.toThrow("disposed");
+    expect(startAuthorization).toHaveBeenCalledOnce();
+  },
+);
+
+it("preserves transferred servers across queued replacements", async () => {
+  const { manager, config, params } = await fixture();
+  const original = await manager.getOrCreate({ ...params, cfg: config() });
+  const healthy = await probe(original, "healthy");
+  await probe(original, "changed");
+  const closing = createDeferred();
+  const released = createDeferred();
+  releaseHeld.push(() => released.resolve());
+  const dispose = original.dispose;
+  original.dispose = async () => {
+    closing.resolve();
+    await released.promise;
+    await dispose();
+  };
+  const first = manager.getOrCreate({ ...params, cfg: config("intermediate") });
+  await closing.promise;
+  const second = manager.getOrCreate({ ...params, cfg: config("winner") });
+  released.resolve();
+  await first;
+  const winner = await second;
+  expect(await probe(winner, "healthy")).toEqual(healthy);
+  expect(await probe(winner, "changed")).toMatchObject({ label: "winner" });
+});
+
+it("retains plugin retirement across a later config-only publication during creation", async () => {
+  const url = await httpProbe();
+  const { params } = await fixture();
+  const cfg: OpenClawConfig = {
+    plugins: { enabled: false },
+    mcp: { servers: { scoped: { transport: "streamable-http" } } },
+  };
+  resolverTesting.setMcpServerConnectionResolversForTest([
+    { serverName: "scoped", resolve: async () => ({ url }) },
+  ]);
+  const started = createDeferred();
+  const released = createDeferred();
+  let retired: SessionMcpRuntime | undefined;
+  let firstConnection: Awaited<ReturnType<typeof probe>> | undefined;
+  releaseHeld.push(() => released.resolve());
+  const manager = createSessionMcpRuntimeManager({
+    enableIdleSweepTimer: false,
+    async createRuntime(input) {
+      const runtime = createSessionMcpRuntime(input);
+      if (input.requesterScope && !retired) {
+        retired = runtime;
+        firstConnection = await probe(runtime, "scoped");
+        started.resolve();
+        await released.promise;
+      }
+      return runtime;
+    },
+  });
+  managers.push(manager);
+  const pending = manager.getOrCreate({ ...params, cfg, requesterSenderId: "alice" });
+  await started.promise;
+  resolverTesting.setMcpServerConnectionResolversForTest([
+    {
+      serverName: "scoped",
+      resolve: async () => ({ url, headers: { Authorization: "replacement" } }),
+    },
+  ]);
+  await manager.reloadConfig({
+    cfg,
+    manifestRegistry: params.manifestRegistry,
+    reloadPlugins: true,
+  });
+  await manager.reloadConfig({
+    cfg: structuredClone(cfg),
+    manifestRegistry: params.manifestRegistry,
+  });
+  released.resolve();
+  expect(await probe(await pending, "scoped")).not.toEqual(firstConnection);
+  await expect(probe(expectDefined(retired, "retired plugin owner"), "scoped")).rejects.toThrow();
+});
+
+it.each(["no shadow", "shadow at publication", "shadow before transfer"])(
+  "retires a transferred plugin with %s before the next queued acquisition",
+  async (shadow) => {
+    const { manager, config, params } = await fixture();
+    const bundledServer = {
+      command: process.execPath,
+      args: [path.join(params.workspaceDir, "server.mjs"), "plugin"],
+      cwd: params.workspaceDir,
+    };
+    const manifestRegistry = {
+      plugins: [
+        createPluginManifestRecordFixture({
+          id: "reload-probe",
+          rootDir: params.workspaceDir,
+          mcpServers: {
+            bundled: bundledServer,
+          },
+        }),
+      ],
+    };
+    const cfg = (label: string): OpenClawConfig => {
+      const next = {
+        ...config(label),
+        plugins: { entries: { "reload-probe": { enabled: true } } },
+      };
+      if (
+        (label === "winner" && shadow !== "no shadow") ||
+        (label === "intermediate" && shadow === "shadow before transfer")
+      ) {
+        next.mcp!.servers!.bundled = bundledServer;
+      }
+      return next;
+    };
+    const acquire = (label: string) =>
+      manager.getOrCreate({ ...params, manifestRegistry, cfg: cfg(label) });
+    const original = await acquire("old");
+    const healthy = await probe(original, "healthy");
+    const bundled = await probe(original, "bundled");
+    const closing = createDeferred();
+    const released = createDeferred();
+    releaseHeld.push(() => released.resolve());
+    const dispose = original.dispose;
+    original.dispose = async () => {
+      closing.resolve();
+      await released.promise;
+      await dispose();
+    };
+    const first = acquire("intermediate");
+    await closing.promise;
+    await manager.reloadConfig({ cfg: cfg("winner"), manifestRegistry, reloadPlugins: true });
+    const second = acquire("winner");
+    released.resolve();
+    await first;
+    const winner = await second;
+    expect(await probe(winner, "healthy")).toEqual(healthy);
+    expect((await probe(winner, "bundled")).pid).not.toBe(bundled.pid);
+  },
+);
+
+it("reconciles a second publication arriving while a pending owner is retiring a server", async () => {
+  const closing = createDeferred();
+  const releaseClose = createDeferred();
+  releaseHeld.push(() => releaseClose.resolve());
+  let held = false;
+  const url = await httpProbe(async () => {
+    if (!held) {
+      held = true;
+      closing.resolve();
+      await releaseClose.promise;
+    }
+  });
+  const { params } = await fixture();
+  const server = { transport: "streamable-http" as const, url };
+  const cfg: OpenClawConfig = {
+    plugins: { enabled: false },
+    mcp: { servers: { first: server, second: server } },
+  };
+  const created = createDeferred();
+  const releaseCreate = createDeferred();
+  releaseHeld.push(() => releaseCreate.resolve());
+  const manager = createSessionMcpRuntimeManager({
+    enableIdleSweepTimer: false,
+    async createRuntime(input) {
+      const runtime = createSessionMcpRuntime(input);
+      await runtime.getCatalog();
+      created.resolve();
+      await releaseCreate.promise;
+      return runtime;
+    },
+  });
+  managers.push(manager);
+  const pending = manager.getOrCreate({ ...params, cfg });
+  await created.promise;
+  await manager.reloadConfig({
+    cfg: { ...cfg, mcp: { servers: { second: server } } },
+    manifestRegistry: params.manifestRegistry,
+  });
+  releaseCreate.resolve();
+  await closing.promise;
+  await manager.reloadConfig({
+    cfg: { ...cfg, mcp: { servers: {} } },
+    manifestRegistry: params.manifestRegistry,
+  });
+  releaseClose.resolve();
+  await expect(probe(await pending, "second")).rejects.toThrow();
+});
+
+it("preserves an explicit config snapshot acquired after an unrelated global publication", async () => {
+  const { manager, config, params } = await fixture();
+  await manager.reloadConfig({
+    cfg: { mcp: { servers: {} } },
+    manifestRegistry: params.manifestRegistry,
+  });
+  const explicit = await manager.getOrCreate({ ...params, cfg: config() });
+  expect(await probe(explicit, "healthy")).toMatchObject({ label: "healthy" });
+});
+
+it("joins config retirement cleanup before installing a replacement transport", async () => {
+  const closing = createDeferred();
+  const releaseClose = createDeferred();
+  releaseHeld.push(() => releaseClose.resolve());
+  const url = await httpProbe(async () => {
+    closing.resolve();
+    await releaseClose.promise;
+  });
+  const { manager, params } = await fixture();
+  const server = { transport: "streamable-http" as const, url };
+  const cfg: OpenClawConfig = {
+    plugins: { enabled: false },
+    mcp: { servers: { first: server, second: server } },
+  };
+  const original = await manager.getOrCreate({ ...params, cfg });
+  await probe(original, "first");
+  const healthy = await probe(original, "second");
+  const next = {
+    ...cfg,
+    mcp: { servers: { first: { ...server, headers: { "X-Generation": "new" } }, second: server } },
+  };
+  const reload = manager.reloadConfig({ cfg: next, manifestRegistry: params.manifestRegistry });
+  await closing.promise;
+  let installed = false;
+  const replacement = manager.getOrCreate({ ...params, cfg: next }).then((runtime) => {
+    installed = true;
+    return runtime;
+  });
+  // Let ready producers drain while the server deliberately holds DELETE open.
+  await setImmediate();
+  expect(installed).toBe(false);
+  releaseClose.resolve();
+  await reload;
+  expect(await probe(await replacement, "second")).toEqual(healthy);
+  expect(await probe(await replacement, "first")).not.toEqual(healthy);
+});
+
+it("revokes transferred active work while unrelated transport cleanup is pending", async () => {
+  const closing = createDeferred();
+  const releaseClose = createDeferred();
+  releaseHeld.push(() => releaseClose.resolve());
+  const url = await httpProbe(async () => {
+    closing.resolve();
+    await releaseClose.promise;
+  });
+  const { manager, config, params } = await fixture();
+  const cfg = config();
+  cfg.mcp!.servers!.changed = { transport: "streamable-http", url };
+  const original = await manager.getOrCreate({ ...params, cfg });
+  await probe(original, "changed");
+  const marker = path.join(params.workspaceDir, "revoked-call");
+  let revoked = false;
+  const held = probe(original, "healthy", { hold: marker }).catch(() => {
+    revoked = true;
+  });
+  await expect
+    .poll(async () => Boolean(await fs.stat(`${marker}.started`).catch(() => undefined)))
+    .toBe(true);
+  const next = structuredClone(cfg);
+  next.mcp!.servers!.changed = { transport: "streamable-http", url, headers: { generation: "2" } };
+  const pending = manager.getOrCreate({ ...params, cfg: next });
+  void pending.catch(() => undefined);
+  await closing.promise;
+  const removed = structuredClone(next);
+  delete removed.mcp!.servers!.healthy;
+  await manager.reloadConfig({ cfg: removed, manifestRegistry: params.manifestRegistry });
+  await setImmediate();
+  expect(revoked).toBe(true);
+  releaseClose.resolve();
+  await pending;
+  await held;
+});
+
+it("completes required retirement when the old run releases the final transferred lease", async () => {
+  const { manager, config, params } = await fixture();
+  const original = await manager.getOrCreate({ ...params, cfg: config() });
+  const releaseOriginal = expectDefined(original.acquireLease, "original run lease")();
+  const healthy = await probe(original, "healthy");
+  manager.deferRetirement(params.sessionId, { retainAcrossReuse: true });
+  const replacement = await manager.getOrCreate({ ...params, cfg: config("new") });
+  const releaseReplacement = expectDefined(replacement.acquireLease, "replacement run lease")();
+  releaseReplacement();
+  await expect(manager.completeDeferredRetirement(params.sessionId, replacement)).resolves.toBe(
+    false,
+  );
+  releaseOriginal();
+  await expect(manager.completeDeferredRetirement(params.sessionId, original)).resolves.toBe(true);
+  expect(manager.listRuntimeKeys()).toEqual([]);
+  expect(() => process.kill(healthy.pid, 0)).toThrow();
+});
+
+it.each([false, true])(
+  "defers retirement behind acquisition (required: %s)",
+  async (retainAcrossReuse) => {
+    const { manager, config, params } = await fixture();
+    const original = await manager.getOrCreate({ ...params, cfg: config() });
+    const releaseOriginal = expectDefined(original.acquireLease, "original run lease")();
+    const healthy = await probe(original, "healthy");
+    const closing = createDeferred();
+    const releaseClose = createDeferred();
+    releaseHeld.push(() => releaseClose.resolve());
+    const dispose = original.dispose;
+    original.dispose = async () => {
+      closing.resolve();
+      await releaseClose.promise;
+      await dispose();
+    };
+    const pending = manager.acquire({ ...params, cfg: config("new") }).then((lease) => ({
+      runtime: lease.runtime,
+      release: lease.releaseLease,
+    }));
+    await closing.promise;
+    manager.deferRetirement(params.sessionId, { retainAcrossReuse });
+    releaseOriginal();
+    const retiring = manager.completeDeferredRetirement(params.sessionId, original);
+    releaseClose.resolve();
+    const next = await pending;
+    await expect(retiring).resolves.toBe(false);
+    expect(await probe(next.runtime, "healthy")).toEqual(healthy);
+    next.release();
+    await expect(manager.completeDeferredRetirement(params.sessionId, next.runtime)).resolves.toBe(
+      retainAcrossReuse,
+    );
+  },
+);
+
+it("completes required retirement after pending requester acquisition fails without a lease", async () => {
+  const { manager, config, params } = await fixture();
+  const cfg = config();
+  cfg.mcp!.servers!.calendar = {
+    transport: "streamable-http",
+    url: "https://mcp.example.test",
+    auth: "oauth",
+    oauth: { identity: "per-requester" },
+  };
+  const input = { ...params, cfg, requesterSenderId: "alice" };
+  const original = await manager.getOrCreate(input);
+  const releaseOriginal = expectDefined(original.acquireLease, "original run lease")();
+  const healthy = await probe(original, "healthy");
+  const started = createDeferred();
+  const released = createDeferred();
+  releaseHeld.push(() => released.resolve());
+  readAuthorization.mockImplementationOnce(async () => {
+    started.resolve();
+    await released.promise;
+    throw new Error("requester authorization unavailable");
+  });
+  const pending = manager.getOrCreateRequesterScoped(input).catch((error: unknown) => error);
+  await started.promise;
+  manager.deferRetirement(params.sessionId, { retainAcrossReuse: true });
+  releaseOriginal();
+  const retiring = manager.completeDeferredRetirement(params.sessionId, original);
+  released.resolve();
+  expect(await pending).toMatchObject({ message: "requester authorization unavailable" });
+  await expect(retiring).resolves.toBe(true);
+  expect(manager.listRuntimeKeys()).toEqual([]);
+  expect(() => process.kill(healthy.pid, 0)).toThrow();
+});

--- a/src/agents/agent-bundle-mcp-requester-connect.ts
+++ b/src/agents/agent-bundle-mcp-requester-connect.ts
@@ -154,11 +154,12 @@ export function mergeMcpConnectCatalog(
   liveCatalog: McpToolCatalog,
   requesterConnect?: RequesterMcpConnect,
 ): McpToolCatalog {
-  if (!requesterConnect) {
+  const connectCatalog = requesterConnect?.catalog;
+  if (!connectCatalog) {
     return liveCatalog;
   }
   const missingServerNames = new Set(
-    Object.keys(requesterConnect.catalog.servers).filter(
+    Object.keys(connectCatalog.servers).filter(
       (serverName) => !Object.hasOwn(liveCatalog.servers, serverName),
     ),
   );
@@ -167,18 +168,18 @@ export function mergeMcpConnectCatalog(
   }
   return {
     ...liveCatalog,
-    generatedAt: Math.max(liveCatalog.generatedAt, requesterConnect.catalog.generatedAt),
+    generatedAt: Math.max(liveCatalog.generatedAt, connectCatalog.generatedAt),
     servers: {
       ...liveCatalog.servers,
       ...Object.fromEntries(
-        Object.entries(requesterConnect.catalog.servers).filter(([serverName]) =>
+        Object.entries(connectCatalog.servers).filter(([serverName]) =>
           missingServerNames.has(serverName),
         ),
       ),
     },
     tools: [
       ...liveCatalog.tools,
-      ...requesterConnect.catalog.tools.filter((tool) => missingServerNames.has(tool.serverName)),
+      ...connectCatalog.tools.filter((tool) => missingServerNames.has(tool.serverName)),
     ].toSorted(
       (left, right) =>
         left.safeServerName.localeCompare(right.safeServerName) ||

--- a/src/agents/agent-bundle-mcp-runtime-owner.ts
+++ b/src/agents/agent-bundle-mcp-runtime-owner.ts
@@ -1,14 +1,6 @@
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import type { CreateSessionMcpRuntime } from "./agent-bundle-mcp-runtime-shared.js";
-import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
-
-export type SessionMcpConfigReload = {
-  cfg: OpenClawConfig;
-  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
-  reloadPlugins?: boolean;
-};
+import type { SessionMcpConfigReload, SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 
 type SessionMcpRuntimeOwner = {
   isCurrent: () => boolean;

--- a/src/agents/agent-bundle-mcp-runtime-owner.ts
+++ b/src/agents/agent-bundle-mcp-runtime-owner.ts
@@ -1,0 +1,23 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { CreateSessionMcpRuntime } from "./agent-bundle-mcp-runtime-shared.js";
+import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
+
+export type SessionMcpConfigReload = {
+  cfg: OpenClawConfig;
+  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
+  reloadPlugins?: boolean;
+};
+
+type SessionMcpRuntimeOwner = {
+  isCurrent: () => boolean;
+  replace: (params: Parameters<CreateSessionMcpRuntime>[0]) => SessionMcpRuntime;
+  reload: (params: SessionMcpConfigReload) => Promise<void>;
+};
+
+// SDK facades and the Gateway can load separate bundles of this module.
+export const sessionMcpRuntimeOwners = resolveGlobalSingleton(
+  Symbol.for("openclaw.sessionMcpRuntimeOwners"),
+  () => new WeakMap<SessionMcpRuntime, SessionMcpRuntimeOwner>(),
+);

--- a/src/agents/agent-bundle-mcp-runtime.agent-bundle.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.agent-bundle.test.ts
@@ -10,9 +10,9 @@ import { loadEnabledBundleMcpConfig } from "../plugins/bundle-mcp.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { getOrCreateSessionMcpRuntime } from "./agent-bundle-mcp-manager.test-support.js";
 import {
   disposeAllSessionMcpRuntimes,
-  getOrCreateSessionMcpRuntime,
   materializeBundleMcpToolsForRun,
 } from "./agent-bundle-mcp-tools.js";
 

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -19,6 +19,10 @@ import {
 } from "../../test/helpers/temp-dir.js";
 import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
 import { completeDeferredSessionMcpRuntimeRetirement } from "./agent-bundle-mcp-manager-api.js";
+import {
+  createSessionMcpRuntimeManager,
+  getOrCreateSessionMcpRuntime,
+} from "./agent-bundle-mcp-manager.test-support.js";
 import { runWithSessionMcpRequestSignal } from "./agent-bundle-mcp-request-context.js";
 import { SESSION_MCP_RUNTIME_MANAGER_KEY } from "./agent-bundle-mcp-runtime-shared.js";
 import {
@@ -27,7 +31,6 @@ import {
   testing,
 } from "./agent-bundle-mcp-runtime.js";
 import {
-  getOrCreateSessionMcpRuntime,
   materializeBundleMcpToolsForRun,
   peekSessionMcpRuntime,
   retireSessionMcpRuntime,
@@ -72,9 +75,7 @@ vi.mock("./mcp-auth-profile.js", () => ({
 const tempDirs: string[] = [];
 const tempDirTracker = useAutoCleanupTempDirTracker(afterEach);
 
-type RuntimeFactoryOptions = NonNullable<
-  Parameters<typeof testing.createSessionMcpRuntimeManager>[0]
->;
+type RuntimeFactoryOptions = NonNullable<Parameters<typeof createSessionMcpRuntimeManager>[0]>;
 type RuntimeFactory = NonNullable<RuntimeFactoryOptions["createRuntime"]>;
 type RuntimeParams = Parameters<typeof getOrCreateSessionMcpRuntime>[0];
 type ConfiguredMcpServer = NonNullable<
@@ -1882,6 +1883,7 @@ describe("session MCP runtime", () => {
     });
 
     try {
+      await runtime.getCatalog();
       await expect(runtime.callTool("child", "slow_tool", {})).resolves.toMatchObject({
         isError: false,
       });
@@ -2758,7 +2760,7 @@ process.on("SIGINT", shutdown);`,
         },
       };
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const manifestRegistry = { plugins: [] };
 
     const runtimeA = await manager.getOrCreate({
@@ -2831,7 +2833,7 @@ process.on("SIGINT", shutdown);`,
         },
       };
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
 
     const runtimeA = await manager.getOrCreate({
       sessionId: "session-agent-dir",
@@ -2881,7 +2883,7 @@ process.on("SIGINT", shutdown);`,
         },
       };
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
 
     expect(manager.peekSession({ sessionId: "session-peek" })).toBeUndefined();
 
@@ -2916,7 +2918,7 @@ process.on("SIGINT", shutdown);`,
         }),
       };
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
 
     const runtimeA = await manager.getOrCreate({
       sessionId: "session-c",
@@ -3006,7 +3008,7 @@ process.on("SIGINT", shutdown);`,
         rejectCatalog?.(new Error(`bundle-mcp runtime disposed for session ${params.sessionId}`));
       },
     });
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const runtime = await manager.getOrCreate({
       sessionId: "session-d",
       sessionKey: "agent:test:session-d",
@@ -3323,7 +3325,7 @@ process.on("SIGINT", shutdown);`,
   });
 
   it("cancels deferred retirement when a later run reuses the runtime", async () => {
-    const manager = testing.createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
+    const manager = createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
     const params = {
       sessionId: "session-reused-after-view",
       sessionKey: "agent:test:session-reused-after-view",
@@ -3345,7 +3347,7 @@ process.on("SIGINT", shutdown);`,
   });
 
   it("keeps required retirement armed across late runtime creation and reuse", async () => {
-    const manager = testing.createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
+    const manager = createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
     const params = {
       sessionId: "session-required-retirement",
       sessionKey: "agent:test:session-required-retirement",
@@ -3423,7 +3425,7 @@ process.on("SIGINT", shutdown);`,
     const singletonStore = globalThis as Record<PropertyKey, unknown>;
     const hadRuntimeManager = Object.hasOwn(singletonStore, SESSION_MCP_RUNTIME_MANAGER_KEY);
     const previousRuntimeManager = singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY];
-    const manager = testing.createSessionMcpRuntimeManager({
+    const manager = createSessionMcpRuntimeManager({
       now: () => nowMs,
       enableIdleSweepTimer: false,
     });
@@ -3547,7 +3549,7 @@ describe("requester-scoped MCP connection resolution", () => {
           resolve: async () => ({ url: "https://mcp.example.test/user" }),
         },
       ]);
-      const manager = testing.createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
+      const manager = createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
       const sessionKey = "agent:test:session-fixed-idle";
       const params: RuntimeParams = {
         sessionId: "session-fixed-idle",
@@ -3598,7 +3600,7 @@ describe("requester-scoped MCP connection resolution", () => {
     vi.useFakeTimers();
     vi.setSystemTime(100_000);
     const now = vi.fn(() => Date.now());
-    const manager = testing.createSessionMcpRuntimeManager({ now });
+    const manager = createSessionMcpRuntimeManager({ now });
     const params: RuntimeParams = {
       sessionId: "session-idle-timer",
       workspaceDir: "/workspace",
@@ -3651,7 +3653,7 @@ describe("requester-scoped MCP connection resolution", () => {
       });
       return makeManagedRuntime(params);
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
       mcp: {
         servers: {
@@ -3708,7 +3710,7 @@ describe("requester-scoped MCP connection resolution", () => {
   it("keeps the tools.effective config summary in fingerprint parity with the peeked runtime", async () => {
     const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
     const { resolveSessionMcpConfigSummary } = await import("./agent-bundle-mcp-tools.js");
-    const manager = testing.createSessionMcpRuntimeManager();
+    const manager = createSessionMcpRuntimeManager();
     const expectBareRuntimeParity = async (params: {
       sessionId: string;
       cfg: NonNullable<RuntimeParams["cfg"]>;
@@ -3822,7 +3824,7 @@ describe("requester-scoped MCP connection resolution", () => {
     ]);
 
     const createRuntime: RuntimeFactory = makeManagedRuntime;
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
       mcp: {
         servers: {
@@ -3859,7 +3861,7 @@ describe("requester-scoped MCP connection resolution", () => {
       });
       return makeManagedRuntime(params);
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
       mcp: {
         servers: {
@@ -3903,7 +3905,7 @@ describe("requester-scoped MCP connection resolution", () => {
       });
       return makeManagedRuntime(params);
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
       mcp: {
         servers: {
@@ -3955,7 +3957,7 @@ describe("requester-scoped MCP connection resolution", () => {
       fingerprints.push(params.configFingerprint ?? "missing");
       return makeManagedRuntime(params);
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
       mcp: {
         servers: {
@@ -4001,7 +4003,7 @@ describe("requester-scoped MCP connection resolution", () => {
       });
       return makeManagedRuntime(params);
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
       mcp: {
         servers: {
@@ -4045,7 +4047,7 @@ describe("requester-scoped MCP connection resolution", () => {
       }
       return makeManagedRuntime(params);
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
       mcp: {
         servers: {
@@ -4115,7 +4117,7 @@ describe("requester-scoped MCP connection resolution", () => {
         }),
       };
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const runtime = await manager.getOrCreate({
       sessionId: "session-combined-call",
       workspaceDir: "/workspace",
@@ -4174,7 +4176,7 @@ describe("requester-scoped MCP connection resolution", () => {
           },
         };
       };
-      const manager = testing.createSessionMcpRuntimeManager({
+      const manager = createSessionMcpRuntimeManager({
         createRuntime,
         // Pin the sweep clock near the synthetic lastUsedAt values so the idle
         // TTL sweep never fires; this test exercises only the cap eviction.
@@ -4249,7 +4251,7 @@ describe("requester-scoped MCP connection resolution", () => {
         getServerRequestTimeoutMs: () => (serverName === "user-mail" ? 90_000 : 60_000),
       };
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const runtime = await manager.getOrCreate({
       sessionId: "session-combined-refresh",
       workspaceDir: "/workspace",
@@ -4312,7 +4314,7 @@ describe("requester-scoped MCP connection resolution", () => {
         },
       };
     };
-    const manager = testing.createSessionMcpRuntimeManager({
+    const manager = createSessionMcpRuntimeManager({
       createRuntime,
       now: () => nowMs,
       enableIdleSweepTimer: false,
@@ -4361,7 +4363,7 @@ describe("requester-scoped MCP connection resolution", () => {
     ]);
 
     const createRuntime: RuntimeFactory = makeManagedRuntime;
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const pending = manager.getOrCreate({
       sessionId: "session-race-dispose",
       workspaceDir: "/workspace",
@@ -4386,7 +4388,7 @@ describe("requester-scoped MCP connection resolution", () => {
     await pending;
     await disposePromise;
     expect(manager.listRuntimeKeys()).toEqual([]);
-    expect(testing.getBookkeepingSizes(manager).requesterWorkChains).toBe(0);
+    expect(testing.getBookkeepingSizes(manager).runtimeWorkChains).toBe(0);
 
     await manager.disposeAll();
   });
@@ -4427,7 +4429,7 @@ describe("requester-scoped MCP connection resolution", () => {
       }
       return makeManagedRuntime(params);
     };
-    const manager = testing.createSessionMcpRuntimeManager({
+    const manager = createSessionMcpRuntimeManager({
       createRuntime,
       now: () => {
         clock += 10;
@@ -4476,7 +4478,7 @@ describe("requester-scoped MCP connection resolution", () => {
         resolve: async () => ({ url: "https://mcp.example.test/user" }),
       },
     ]);
-    const manager = testing.createSessionMcpRuntimeManager({
+    const manager = createSessionMcpRuntimeManager({
       createRuntime: makeManagedRuntime,
     });
     await manager.getOrCreate({
@@ -4493,8 +4495,7 @@ describe("requester-scoped MCP connection resolution", () => {
     expect(testing.getBookkeepingSizes(manager)).toEqual({
       runtimes: 0,
       connectionMeta: 0,
-      createInFlight: 0,
-      requesterWorkChains: 0,
+      runtimeWorkChains: 0,
       sessionKeys: 0,
       deferredRetirement: 0,
       advertisedScopedCatalogs: 0,
@@ -4525,7 +4526,7 @@ describe("requester-scoped MCP connection resolution", () => {
       createCount += 1;
       return makeManagedRuntime(params);
     };
-    const manager = testing.createSessionMcpRuntimeManager({
+    const manager = createSessionMcpRuntimeManager({
       createRuntime,
       now: () => nowMs,
       enableIdleSweepTimer: false,
@@ -4631,7 +4632,7 @@ describe("requester-scoped MCP connection resolution", () => {
         }),
       };
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
       mcp: {
         servers: {
@@ -4692,7 +4693,7 @@ describe("requester-scoped MCP connection resolution", () => {
         );
       },
     });
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
 
     // No resolver yet: bare session runtime owns the only server.
     await manager.getOrCreate({
@@ -4828,7 +4829,7 @@ describe("requester-scoped MCP connection resolution", () => {
       fingerprints.push(params.configFingerprint ?? "");
       return makeManagedRuntime(params);
     };
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
     resolverTesting.setMcpServerConnectionResolversForTest([
       {
@@ -4913,7 +4914,7 @@ describe("requester-scoped MCP connection resolution", () => {
       };
     };
     const now = vi.fn(() => nowMs);
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime, now });
+    const manager = createSessionMcpRuntimeManager({ createRuntime, now });
     const cfg = {
       mcp: {
         servers: {
@@ -4929,9 +4930,7 @@ describe("requester-scoped MCP connection resolution", () => {
       makeRequesterParams(sessionId, cfg as never, "sender-a", { sessionKey }),
     );
     expect(scoped?.runtime.requesterScope?.requesterSenderId).toBe("sender-a");
-    await vi.waitFor(() =>
-      expect(testing.getBookkeepingSizes(manager).requesterWorkChains).toBe(0),
-    );
+    await vi.waitFor(() => expect(testing.getBookkeepingSizes(manager).runtimeWorkChains).toBe(0));
     const runtimeKeys = manager.listRuntimeKeys();
     const bookkeeping = testing.getBookkeepingSizes(manager);
     expect(runtimeKeys).toHaveLength(1);
@@ -4941,7 +4940,7 @@ describe("requester-scoped MCP connection resolution", () => {
     expect(bookkeeping).toMatchObject({
       runtimes: 1,
       connectionMeta: 1,
-      requesterWorkChains: 0,
+      runtimeWorkChains: 0,
       sessionKeys: 1,
     });
 
@@ -4998,7 +4997,7 @@ describe("requester-scoped MCP connection resolution", () => {
     ]);
     const createRuntime: RuntimeFactory = (params) =>
       makeManagedRuntime(params, [{ toolName: "probe", description: "probe" }], "user-mail");
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
       mcp: {
         servers: {
@@ -5032,7 +5031,7 @@ describe("requester-scoped MCP connection resolution", () => {
     ]);
     const createRuntime: RuntimeFactory = (params) =>
       makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
       mcp: {
         servers: {
@@ -5081,7 +5080,7 @@ describe("requester-scoped MCP connection resolution", () => {
     ]);
     const createRuntime: RuntimeFactory = (params) =>
       makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const cfgA = {
       mcp: {
         servers: {
@@ -5119,7 +5118,7 @@ describe("requester-scoped MCP connection resolution", () => {
     ]);
     const createRuntime: RuntimeFactory = (params) =>
       makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const scopedConfig = {
       mcp: {
         servers: {
@@ -5159,7 +5158,7 @@ describe("requester-scoped MCP connection resolution", () => {
     ]);
     const createRuntime: RuntimeFactory = (params) =>
       makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const scopedConfig = {
       mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
     };
@@ -5208,7 +5207,7 @@ describe("requester-scoped MCP connection resolution", () => {
     ]);
     const createRuntime: RuntimeFactory = (params) =>
       makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
-    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const manager = createSessionMcpRuntimeManager({ createRuntime });
     const oldConfig = {
       mcp: {
         servers: {
@@ -6474,11 +6473,10 @@ process.on("SIGINT", shutdown);`,
           secondCatalogPromise,
         ]);
 
-        // The notification refresh is serialized after the timed-out first generation,
-        // so callers now receive the newest clean catalog rather than its stale diagnostic.
-        expect(firstCatalogResult.servers.slow).toBeDefined();
+        // A sibling notification cannot restart this failed server before its own retry.
+        expect(firstCatalogResult.diagnostics?.[0]?.serverName).toBe("slow");
         expect(secondCatalog.servers.trigger).toBeDefined();
-        expect(secondCatalog.servers.slow).toBeDefined();
+        expect(secondCatalog.servers.slow).toBeUndefined();
         await expect(runtime.callTool("trigger", "poke", {})).resolves.toMatchObject({
           content: [{ type: "text", text: "poked" }],
           isError: false,
@@ -6494,8 +6492,20 @@ process.on("SIGINT", shutdown);`,
           LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
         );
 
-        const retriedCatalog = await runtime.getCatalog();
-
+        const now = Date.now;
+        const clock = vi.spyOn(Date, "now").mockImplementation(() => now() + 5_001);
+        let retriedCatalog;
+        try {
+          await runtime.getCatalog();
+          await waitForPredicate(
+            () => runtime.peekCatalog()?.servers.slow !== undefined,
+            "the timed-out server's own catalog retry",
+            LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+          );
+          retriedCatalog = await runtime.getCatalog();
+        } finally {
+          clock.mockRestore();
+        }
         expect(retriedCatalog.diagnostics ?? []).toEqual([]);
         expect(retriedCatalog.servers.slow).toBeDefined();
         expect(retriedCatalog.tools.map((tool) => tool.toolName).toSorted()).toEqual([

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -1,5 +1,5 @@
 /** Session-scoped MCP runtime catalog loader and transport lifecycle. */
-import { Client, type ClientOptions } from "@modelcontextprotocol/sdk/client/index.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
   ErrorCode,
@@ -11,30 +11,27 @@ import {
   type Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import type { SessionToolOverrides } from "../config/sessions/types.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { racePromiseWithAbortSignal } from "../infra/abort-signal.js";
 import { logWarn } from "../logger.js";
-import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
-import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
-import { mergeMcpToolCatalogs } from "./agent-bundle-mcp-combined.js";
+import {
+  createCombinedSessionMcpRuntime,
+  mergeMcpToolCatalogs,
+} from "./agent-bundle-mcp-combined.js";
 import {
   disposeAllSessionMcpRuntimes,
   getSessionMcpRuntimeManagerForTesting,
 } from "./agent-bundle-mcp-manager-api.js";
-import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.js";
-import { assignSafeServerNames, sanitizeServerName } from "./agent-bundle-mcp-names.js";
+import { assignSafeServerNames } from "./agent-bundle-mcp-names.js";
 import { getSessionMcpRequestSignal } from "./agent-bundle-mcp-request-context.js";
 import { loadSessionMcpConfig } from "./agent-bundle-mcp-runtime-config.js";
+import { sessionMcpRuntimeOwners } from "./agent-bundle-mcp-runtime-owner.js";
+import type { CreateSessionMcpRuntime } from "./agent-bundle-mcp-runtime-shared.js";
 import type {
   McpCatalogTool,
   McpRequestOptions,
   McpServerCatalog,
   McpToolCatalog,
   McpToolCatalogDiagnostic,
-  RequesterMcpConnect,
-  SessionMcpRequesterScope,
   SessionMcpRuntime,
   SessionMcpRuntimeManager,
 } from "./agent-bundle-mcp-types.js";
@@ -50,7 +47,8 @@ import {
 } from "./mcp-codex-tool-approval.js";
 import {
   applyMcpConnectionOverride,
-  type McpServerConnectionResolved,
+  hashMcpResolvedConnections,
+  partitionMcpServersByConnectionScope,
 } from "./mcp-connection-resolver.js";
 import { redactMcpDiagnosticError } from "./mcp-error.js";
 import { createMcpJsonSchemaValidator } from "./mcp-json-schema-validator.js";
@@ -66,7 +64,6 @@ type BundleMcpSession = {
   transport: Transport;
   transportType: "stdio" | "sse" | "streamable-http";
   requestTimeoutMs: number;
-  supportsParallelToolCalls: boolean;
   connected: boolean;
   disconnectReason?: string;
   retiring: boolean;
@@ -75,7 +72,6 @@ type BundleMcpSession = {
   toolMetadata?: McpToolCatalogMetadata;
 };
 
-type ListedTool = Tool;
 const MCP_APPS_CLIENT_EXTENSION = "io.modelcontextprotocol/ui";
 const MCP_APP_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
 const BUNDLE_MCP_FAILURE_THRESHOLD = 3;
@@ -83,7 +79,6 @@ const BUNDLE_MCP_FAILURE_COOLDOWN_MS = 60_000;
 const BUNDLE_MCP_CATALOG_FAILURE_RETRY_MS = 5_000;
 const BUNDLE_MCP_CATALOG_LIST_TIMEOUT_MS = 1_500;
 const BUNDLE_MCP_DISPOSE_TIMEOUT_MS = 5_000;
-const BUNDLE_MCP_CATALOG_CONNECT_CONCURRENCY = 6;
 const BUNDLE_MCP_MAX_LIST_PAGES = 128;
 const BUNDLE_MCP_MAX_LIST_ITEMS = 16_384;
 const BUNDLE_MCP_MAX_LIST_BYTES = 10 * 1024 * 1024;
@@ -212,10 +207,6 @@ function buildMcpClientCapabilities(mcpAppsEnabled: boolean): ClientCapabilities
     : {};
 }
 
-function buildMcpClientOptions(mcpAppsEnabled: boolean): ClientOptions {
-  return { capabilities: buildMcpClientCapabilities(mcpAppsEnabled) };
-}
-
 function normalizeToolUiVisibility(value: unknown): Array<"app" | "model"> | undefined {
   if (!Array.isArray(value)) {
     return undefined;
@@ -243,45 +234,195 @@ function createDisposedError(sessionId: string): Error {
   return new Error(`bundle-mcp runtime disposed for session ${sessionId}`);
 }
 
-export function createSessionMcpRuntime(params: {
-  sessionId: string;
-  sessionKey?: string;
-  workspaceDir: string;
-  agentDir?: string;
-  cfg?: OpenClawConfig;
-  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
-  includeServerNames?: ReadonlySet<string>;
-  excludeServerNames?: ReadonlySet<string>;
-  /**
-   * Precomputed name→safeName for the full declared server set. Required for
-   * stable tool names when this runtime holds only a subset of servers.
-   */
-  safeServerNamesByServer?: ReadonlyMap<string, string>;
-  /** Resolved per-requester url/headers; never logged/persisted as credentials. */
-  connectionOverrides?: ReadonlyMap<string, McpServerConnectionResolved>;
-  redactConnectionServerNames?: ReadonlySet<string>;
-  requesterScope?: SessionMcpRequesterScope;
-  requesterConnect?: RequesterMcpConnect;
-  configFingerprint?: string;
-  toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
-}): SessionMcpRuntime {
-  const { loaded, fingerprint: computedFingerprint } = loadSessionMcpConfig({
-    workspaceDir: params.workspaceDir,
-    cfg: params.cfg,
+type ServerMcpRuntime = SessionMcpRuntime & { readonly pluginOwned: boolean };
+
+export function createSessionMcpRuntime(
+  params: Parameters<CreateSessionMcpRuntime>[0],
+  previous = new Map<string, ServerMcpRuntime>(),
+): SessionMcpRuntime {
+  const declared = loadSessionMcpConfig({
+    ...params,
+    includeServerNames: undefined,
+    excludeServerNames: undefined,
     logDiagnostics: true,
-    manifestRegistry: params.manifestRegistry,
-    includeServerNames: params.includeServerNames,
-    excludeServerNames: params.excludeServerNames,
-    redactConnectionServerNames: params.redactConnectionServerNames,
-    safeServerNamesByServer: params.safeServerNamesByServer,
-    toolOverrides: params.toolOverrides,
   });
+  const config = loadSessionMcpConfig({
+    ...params,
+    loaded: declared.loaded,
+    logDiagnostics: false,
+  });
+  const safeNames =
+    params.safeServerNamesByServer ??
+    assignSafeServerNames(Object.keys(declared.loaded.mcpServers));
+  const configForServer = (serverName: string, nextParams = params, loaded = config.loaded) => {
+    const connection = nextParams.connectionOverrides?.get(serverName);
+    const serverConfig = loadSessionMcpConfig({
+      ...nextParams,
+      loaded,
+      logDiagnostics: false,
+      includeServerNames: new Set([serverName]),
+      excludeServerNames: undefined,
+      safeServerNamesByServer: new Map([[serverName, safeNames.get(serverName)!]]),
+      toolOverrides: {
+        ...nextParams.toolOverrides,
+        mcpToolsDeny: Object.fromEntries(
+          Object.entries(nextParams.toolOverrides?.mcpToolsDeny ?? {}).filter(
+            ([name]) => name === serverName,
+          ),
+        ),
+      },
+    });
+    if (connection) {
+      serverConfig.fingerprint += `:${hashMcpResolvedConnections(new Map([[serverName, connection]]))}`;
+    }
+    return serverConfig;
+  };
+  const owned = new Map<string, ServerMcpRuntime>();
+  for (const serverName of Object.keys(config.loaded.mcpServers)) {
+    const serverConfig = configForServer(serverName);
+    const fingerprint = serverConfig.fingerprint;
+    const existing = previous.get(serverName);
+    if (
+      existing?.configFingerprint === fingerprint &&
+      existing.workspaceDir === params.workspaceDir &&
+      existing.agentDir === params.agentDir
+    ) {
+      owned.set(serverName, existing);
+      previous.delete(serverName);
+    } else {
+      owned.set(
+        serverName,
+        createServerMcpRuntime({
+          ...params,
+          serverName,
+          serverConfig,
+          safeServerNamesByServer: safeNames,
+          configFingerprint: fingerprint,
+        }),
+      );
+    }
+  }
+  const requesterConnect = params.requesterConnect;
+  const connectFingerprints = new Map(
+    Object.keys(requesterConnect?.catalog.servers ?? {}).map((name) => [
+      name,
+      configForServer(name, params, declared.loaded).fingerprint,
+    ]),
+  );
+  let invalidated = false;
+  let pendingDisposal = Promise.resolve();
+  const disposeParts = (parts: SessionMcpRuntime[]) => {
+    // Replacement must join cleanup already started by config publication.
+    pendingDisposal = Promise.allSettled([
+      pendingDisposal,
+      ...parts.map((part) => part.dispose()),
+    ]).then(() => undefined);
+    return pendingDisposal;
+  };
+  const runtime = createCombinedSessionMcpRuntime({
+    ...params,
+    parts: [...owned.values()],
+    // Admitted views keep routing to transferred servers; ownership alone moves.
+    serverOwners: new Map(owned),
+  });
+  runtime.configFingerprint = params.configFingerprint ?? config.fingerprint;
+  runtime.requesterScope = params.requesterScope;
+  runtime.requesterConnect = requesterConnect && {
+    ...requesterConnect,
+    get catalog() {
+      const catalog = requesterConnect.catalog;
+      return {
+        ...catalog,
+        servers: Object.fromEntries(
+          Object.entries(catalog.servers).filter(([name]) => connectFingerprints.has(name)),
+        ),
+        tools: catalog.tools.filter((tool) => connectFingerprints.has(tool.serverName)),
+      };
+    },
+    createExecute(serverName) {
+      const execute = requesterConnect.createExecute(serverName);
+      return (
+        execute &&
+        (async (...args) => {
+          if (!connectFingerprints.has(serverName)) {
+            throw createDisposedError(params.sessionId);
+          }
+          return await execute(...args);
+        })
+      );
+    },
+  };
+  runtime.mcpAppsEnabled = params.cfg?.mcp?.apps?.enabled === true;
+  runtime.dispose = async () => {
+    connectFingerprints.clear();
+    invalidated = true;
+    const retired = [...owned.values()];
+    owned.clear();
+    sessionMcpRuntimeOwners.delete(runtime);
+    await disposeParts(retired);
+  };
+  sessionMcpRuntimeOwners.set(runtime, {
+    isCurrent: () => !invalidated,
+    replace: (nextParams) => createSessionMcpRuntime(nextParams, owned),
+    async reload({ cfg, manifestRegistry, reloadPlugins }) {
+      const nextParams = { ...params, cfg, manifestRegistry };
+      const nextConfig = loadSessionMcpConfig({
+        ...nextParams,
+        includeServerNames: undefined,
+        excludeServerNames: undefined,
+        logDiagnostics: false,
+      });
+      const nextSafeNames = assignSafeServerNames(Object.keys(nextConfig.loaded.mcpServers));
+      const { requesterScopedServerNames } = partitionMcpServersByConnectionScope(
+        nextConfig.loaded.mcpServers,
+      );
+      for (const [name, fingerprint] of connectFingerprints) {
+        if (
+          (reloadPlugins && !Object.hasOwn(params.cfg?.mcp?.servers ?? {}, name)) ||
+          cfg.gateway?.publicOrigin !== params.cfg?.gateway?.publicOrigin ||
+          configForServer(name, nextParams, nextConfig.loaded).fingerprint !== fingerprint ||
+          nextSafeNames.get(name) !== safeNames.get(name)
+        ) {
+          invalidated = true;
+          connectFingerprints.delete(name);
+        }
+      }
+      const retired: SessionMcpRuntime[] = [];
+      for (const [serverName, part] of owned) {
+        if (
+          (reloadPlugins && part.pluginOwned) ||
+          !Object.hasOwn(nextConfig.loaded.mcpServers, serverName) ||
+          requesterScopedServerNames.includes(serverName) !== Boolean(params.requesterScope) ||
+          nextSafeNames.get(serverName) !== safeNames.get(serverName) ||
+          configForServer(serverName, nextParams, nextConfig.loaded).fingerprint !==
+            part.configFingerprint
+        ) {
+          invalidated = true;
+          owned.delete(serverName);
+          retired.push(part);
+        }
+      }
+      // Disposal revokes the changed owner synchronously, before transport cleanup yields.
+      await disposeParts(retired);
+    },
+  });
+  return runtime;
+}
+
+function createServerMcpRuntime(
+  params: Parameters<CreateSessionMcpRuntime>[0] & {
+    serverName: string;
+    serverConfig: ReturnType<typeof loadSessionMcpConfig>;
+  },
+): ServerMcpRuntime {
+  const { loaded, fingerprint: computedFingerprint } = params.serverConfig;
+  const serverName = params.serverName;
   const configFingerprint = params.configFingerprint ?? computedFingerprint;
   const mcpAppsEnabled = params.cfg?.mcp?.apps?.enabled === true;
   const createdAt = Date.now();
   let lastUsedAt = createdAt;
   let activeLeases = 0;
-  let disposed = false;
+  let retiredCatalog: McpToolCatalog | undefined;
   const lifecycleAbortController = new AbortController();
   let catalog: McpToolCatalog | null = null;
   let catalogRetryAfterMs: number | undefined;
@@ -292,12 +433,10 @@ export function createSessionMcpRuntime(params: {
     catalog = null;
     catalogRetryAfterMs = undefined;
   };
-  const scheduleCatalogServerRetry = (serverName: string, message: string) => {
+  const scheduleCatalogServerRetry = (message: string) => {
     const currentCatalog = catalog;
     const server = currentCatalog?.servers[serverName];
-    const existing = currentCatalog?.diagnostics?.find(
-      (diagnostic) => diagnostic.serverName === serverName,
-    );
+    const existing = currentCatalog?.diagnostics?.[0];
     if (!currentCatalog) {
       invalidateCatalog();
       return;
@@ -319,41 +458,34 @@ export function createSessionMcpRuntime(params: {
     catalogInvalidationGeneration += 1;
     catalog = {
       ...currentCatalog,
-      diagnostics: [
-        ...(currentCatalog.diagnostics?.filter((entry) => entry.serverName !== serverName) ?? []),
-        diagnostic,
-      ].toSorted((left, right) => left.serverName.localeCompare(right.serverName)),
+      diagnostics: [diagnostic],
     };
     catalogRetryAfterMs = Date.now();
   };
   const catalogRetryIsDue = (): boolean =>
     catalogRetryAfterMs !== undefined && Date.now() >= catalogRetryAfterMs;
-  const sessions = new Map<string, BundleMcpSession>();
-  const serverBackoff = new Map<string, McpServerBackoffState>();
-  const recordServerToolFailure = (
-    serverName: string,
-    session: BundleMcpSession,
-    nowMs: number,
-  ) => {
-    if (sessions.get(serverName) !== session || session.retiring) {
+  let currentSession: BundleMcpSession | undefined;
+  let serverBackoff: McpServerBackoffState | undefined;
+  const recordServerToolFailure = (session: BundleMcpSession, nowMs: number) => {
+    if (currentSession !== session || session.retiring) {
       return undefined;
     }
-    const previous = serverBackoff.get(serverName);
+    const previous = serverBackoff;
     const failures = (previous?.session === session ? previous.failures : 0) + 1;
     const nextBackoff: McpServerBackoffState = { session, failures };
     if (failures >= BUNDLE_MCP_FAILURE_THRESHOLD) {
       nextBackoff.retryAfterMs = nowMs + BUNDLE_MCP_FAILURE_COOLDOWN_MS;
     }
-    serverBackoff.set(serverName, nextBackoff);
+    serverBackoff = nextBackoff;
     return failures;
   };
   const failIfDisposed = () => {
-    if (disposed) {
+    if (retiredCatalog) {
       throw createDisposedError(params.sessionId);
     }
   };
-  const requireConnectedSession = (serverName: string): BundleMcpSession => {
-    const session = sessions.get(serverName);
+  const requireConnectedSession = (): BundleMcpSession => {
+    const session = currentSession;
     if (!session || !session.connected) {
       throw new Error(
         session?.disconnectReason
@@ -395,15 +527,12 @@ export function createSessionMcpRuntime(params: {
       });
     await session.connectPromise;
   };
-  const retireSessionIfCurrent = async (
-    serverName: string,
-    session: BundleMcpSession,
-  ): Promise<boolean> => {
-    if (sessions.get(serverName) !== session) {
+  const retireSessionIfCurrent = async (session: BundleMcpSession): Promise<boolean> => {
+    if (currentSession !== session) {
       return false;
     }
     session.retiring = true;
-    sessions.delete(serverName);
+    currentSession = undefined;
     await disposeBundleMcpSession(session);
     return true;
   };
@@ -444,7 +573,6 @@ export function createSessionMcpRuntime(params: {
     }
   };
   const runGuardedServerRequest = async <T>(
-    serverName: string,
     session: BundleMcpSession,
     request: () => Promise<T>,
     options?: McpRequestOptions,
@@ -452,7 +580,7 @@ export function createSessionMcpRuntime(params: {
     const requestSignal = getSessionMcpRequestSignal();
     const tracksFailureBackoff = options?.failureBackoff !== "ignore";
     const nowMs = Date.now();
-    const backoff = serverBackoff.get(serverName);
+    const backoff = serverBackoff;
     if (
       tracksFailureBackoff &&
       backoff?.session === session &&
@@ -464,12 +592,12 @@ export function createSessionMcpRuntime(params: {
       );
     }
     if (backoff && backoff.session !== session) {
-      serverBackoff.delete(serverName);
+      serverBackoff = undefined;
     }
     try {
       const result = await request();
-      if (tracksFailureBackoff && serverBackoff.get(serverName)?.session === session) {
-        serverBackoff.delete(serverName);
+      if (tracksFailureBackoff && serverBackoff?.session === session) {
+        serverBackoff = undefined;
       }
       return result;
     } catch (error) {
@@ -480,7 +608,7 @@ export function createSessionMcpRuntime(params: {
       if (sessionExpired && !requestSignal?.aborted) {
         recycleReason = "expired HTTP session";
       } else if (tracksFailureBackoff && !requestSignal?.aborted) {
-        const failures = recordServerToolFailure(serverName, session, nowMs);
+        const failures = recordServerToolFailure(session, nowMs);
         const requestTimedOut =
           error !== null && typeof error === "object" && localRequestTimeouts.has(error);
         if (requestTimedOut && failures && failures >= BUNDLE_MCP_FAILURE_THRESHOLD) {
@@ -488,13 +616,13 @@ export function createSessionMcpRuntime(params: {
         }
       }
       if (recycleReason) {
-        serverBackoff.delete(serverName);
-        scheduleCatalogServerRetry(serverName, recycleReason);
+        serverBackoff = undefined;
+        scheduleCatalogServerRetry(recycleReason);
         const timedOut = recycleReason === "repeated request timeouts";
         logWarn(
           `bundle-mcp: recycling server "${serverName}" after ${timedOut ? "repeated timeouts" : "an expired HTTP session"}`,
         );
-        void retireSessionIfCurrent(serverName, session).catch((retireError: unknown) => {
+        void retireSessionIfCurrent(session).catch((retireError: unknown) => {
           logWarn(
             `bundle-mcp: failed to retire ${timedOut ? "timed-out" : "expired-session"} server "${serverName}": ${redactMcpDiagnosticError(retireError)}`,
           );
@@ -504,11 +632,10 @@ export function createSessionMcpRuntime(params: {
     }
   };
   const runGuardedMcpRequest = <T>(
-    serverName: string,
     session: BundleMcpSession,
     request: (signal: AbortSignal) => Promise<T>,
     options?: McpRequestOptions,
-  ) => runGuardedServerRequest(serverName, session, () => runMcpRequest(session, request), options);
+  ) => runGuardedServerRequest(session, () => runMcpRequest(session, request), options);
   const collectServerItems = (session: BundleMcpSession, kind: "prompts" | "resources") => {
     const callerSignal = getSessionMcpRequestSignal();
     return collectMcpPaginatedItems({
@@ -539,399 +666,249 @@ export function createSessionMcpRuntime(params: {
     });
   };
 
-  const loadCatalog = async (retryBaseCatalog?: McpToolCatalog): Promise<McpToolCatalog> => {
+  const loadCatalog = async (): Promise<McpToolCatalog> => {
     failIfDisposed();
     if (catalogInFlight) {
       return catalogInFlight;
     }
-    const retryServerNames = retryBaseCatalog
-      ? new Set(retryBaseCatalog.diagnostics?.map((diagnostic) => diagnostic.serverName))
-      : undefined;
     const catalogGeneration = catalogInvalidationGeneration;
-    const inFlight = (async () => {
-      if (Object.keys(loaded.mcpServers).length === 0) {
-        return {
-          version: 1,
-          generatedAt: Date.now(),
-          servers: {},
-          tools: [],
+    const inFlight = (async (): Promise<McpToolCatalog> => {
+      const rawServer = loaded.mcpServers[serverName]!;
+      const override = params.connectionOverrides?.get(serverName);
+      const transportSource = override
+        ? applyMcpConnectionOverride(rawServer, override)
+        : rawServer;
+      const resolved = resolveMcpTransport(serverName, transportSource, {
+        cfg: params.cfg,
+        agentDir: params.agentDir,
+        prepareDataDir: loaded.prepareDataDirsByServer?.[serverName]?.dataDir,
+        requesterScope: params.requesterScope,
+      });
+      if (!resolved) {
+        return { version: 1, generatedAt: Date.now(), servers: {}, tools: [] };
+      }
+      const safeServerName = params.safeServerNamesByServer?.get(serverName) ?? serverName;
+      // Resolved requester URLs are credentials and never enter catalog text.
+      const launchDescription = override
+        ? `${serverName}: requester-scoped connection`
+        : resolved.description;
+      failIfDisposed();
+
+      let session = currentSession;
+      while (session && !session.retiring && !session.connected && !session.connectPromise) {
+        // A closed SDK client cannot reconnect cleanly on the same transport.
+        await retireSessionIfCurrent(session);
+        // Retirement yields while closing. Preserve any replacement that a
+        // newer catalog generation installed during that await.
+        session = currentSession;
+      }
+      if (session?.retiring) {
+        session = undefined;
+      }
+      const reusedSession = Boolean(session);
+      const schemaValidator = createMcpJsonSchemaValidator();
+      if (!session) {
+        const client = new Client(
+          {
+            name: "openclaw-bundle-mcp",
+            version: "0.0.0",
+          },
+          {
+            capabilities: buildMcpClientCapabilities(mcpAppsEnabled),
+            jsonSchemaValidator: schemaValidator,
+            listChanged: {
+              tools: {
+                autoRefresh: false,
+                debounceMs: 0,
+                onChanged: (error) => {
+                  if (error) {
+                    logWarn(
+                      `bundle-mcp: failed to refresh changed tool list for server "${serverName}": ${redactMcpDiagnosticError(error)}`,
+                    );
+                  }
+                  invalidateCatalog();
+                },
+              },
+            },
+          },
+        );
+        const createdSession: BundleMcpSession = {
+          serverName,
+          client,
+          transport: resolved.transport,
+          transportType: resolved.transportType,
+          requestTimeoutMs: resolved.requestTimeoutMs,
+          connected: false,
+          retiring: false,
+          detachStderr: resolved.detachStderr,
         };
+        // The SDK exposes lifecycle hooks as callback properties. A close is
+        // terminal for this client/transport pair.
+        // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Client is not an EventTarget.
+        client.onclose = () => {
+          const wasConnected = createdSession.connected;
+          createdSession.connected = false;
+          createdSession.disconnectReason = "mcp transport closed";
+          // Only established current sessions invalidate the catalog. Startup closes
+          // already belong to catalog loading, and retirement must not start a rebuild.
+          if (
+            wasConnected &&
+            !retiredCatalog &&
+            !createdSession.retiring &&
+            currentSession === createdSession
+          ) {
+            scheduleCatalogServerRetry("mcp transport closed");
+            logWarn(`bundle-mcp: server "${serverName}" closed; next request reconnects`);
+          }
+        };
+        session = createdSession;
+        currentSession = session;
       }
 
-      // A cooldown retry replaces only diagnostic-bearing servers. Healthy clients
-      // keep their SDK tool-metadata snapshot and remain callable during recovery.
-      const servers: Record<string, McpServerCatalog> = Object.fromEntries(
-        Object.entries(retryBaseCatalog?.servers ?? {}).filter(
-          ([serverName]) => !retryServerNames?.has(serverName),
-        ),
-      );
-      const tools: McpCatalogTool[] = (retryBaseCatalog?.tools ?? []).filter(
-        (tool) => !retryServerNames?.has(tool.serverName),
-      );
-      const policyTools: McpCatalogTool[] = (retryBaseCatalog?.policyTools ?? []).filter(
-        (tool) => !retryServerNames?.has(tool.serverName),
-      );
-      const sessionDeniedTools: McpCatalogTool[] = (
-        retryBaseCatalog?.sessionDeniedTools ?? []
-      ).filter((tool) => !retryServerNames?.has(tool.serverName));
-      const diagnostics: McpToolCatalogDiagnostic[] = [];
-      // Prefer session-wide precomputed assignments; fall back only for isolated runtimes.
-      const safeServerNamesByServer =
-        params.safeServerNamesByServer ?? assignSafeServerNames(Object.keys(loaded.mcpServers));
-      const usedServerNames = new Set<string>(
-        [...safeServerNamesByServer.values()].map((name) => normalizeLowercaseStringOrEmpty(name)),
-      );
-
       try {
-        // Safe names come from the full declared set (precomputed), not from who resolved.
-        const preparedEntries: Array<{
-          serverName: string;
-          rawServer: (typeof loaded.mcpServers)[string];
-          resolved: NonNullable<ReturnType<typeof resolveMcpTransport>>;
-          safeServerName: string;
-          launchDescription: string;
-        }> = [];
-        for (const [serverName, rawServer] of Object.entries(loaded.mcpServers)) {
-          failIfDisposed();
-          if (retryServerNames && !retryServerNames.has(serverName)) {
-            continue;
-          }
-          const override = params.connectionOverrides?.get(serverName);
-          // Overrides supply per-requester transport only; never write them back to config.
-          const transportSource = override
-            ? applyMcpConnectionOverride(rawServer, override)
-            : rawServer;
-          const dataDirOwnership = Object.hasOwn(loaded.prepareDataDirsByServer ?? {}, serverName)
-            ? loaded.prepareDataDirsByServer?.[serverName]
-            : undefined;
-          const resolved = resolveMcpTransport(serverName, transportSource, {
-            cfg: params.cfg,
-            agentDir: params.agentDir,
-            prepareDataDir: dataDirOwnership?.dataDir,
-            requesterScope: params.requesterScope,
-          });
-          if (!resolved) {
-            continue;
-          }
-          const safeServerName =
-            safeServerNamesByServer.get(serverName) ??
-            sanitizeServerName(serverName, usedServerNames);
-          if (safeServerName !== serverName) {
-            logWarn(
-              `bundle-mcp: server key "${serverName}" registered as "${safeServerName}" for provider-safe tool names.`,
-            );
-          }
-          // Never put per-user resolved URLs into catalog/diagnostics/model text.
-          const launchDescription = override
-            ? `${serverName}: requester-scoped connection`
-            : resolved.description;
-          preparedEntries.push({
-            serverName,
-            rawServer,
-            resolved,
-            safeServerName,
-            launchDescription,
-          });
-        }
-
-        // Bounded fan-out keeps common 4-5 server setups parallel without letting
-        // large configs spawn/connect every MCP transport at once.
-        type ServerResult = {
-          serverName: string;
-          serverEntry: McpServerCatalog | null;
-          toolEntries: McpCatalogTool[];
-          policyToolEntries: McpCatalogTool[];
-          diagnostics: McpToolCatalogDiagnostic[];
-        };
-
-        const tasks = preparedEntries.map(
-          ({ serverName, rawServer, resolved, safeServerName, launchDescription }) =>
-            async (): Promise<ServerResult> => {
-              failIfDisposed();
-
-              let session = sessions.get(serverName);
-              while (
-                session &&
-                !session.retiring &&
-                !session.connected &&
-                !session.connectPromise
-              ) {
-                // A closed SDK client cannot reconnect cleanly on the same transport.
-                await retireSessionIfCurrent(serverName, session);
-                // Retirement yields while closing. Preserve any replacement that a
-                // newer catalog generation installed during that await.
-                session = sessions.get(serverName);
-              }
-              if (session?.retiring) {
-                session = undefined;
-              }
-              const reusedSession = Boolean(session);
-              const schemaValidator = createMcpJsonSchemaValidator();
-              if (!session) {
-                const client = new Client(
-                  {
-                    name: "openclaw-bundle-mcp",
-                    version: "0.0.0",
-                  },
-                  {
-                    ...buildMcpClientOptions(mcpAppsEnabled),
-                    jsonSchemaValidator: schemaValidator,
-                    listChanged: {
-                      tools: {
-                        autoRefresh: false,
-                        debounceMs: 0,
-                        onChanged: (error) => {
-                          if (error) {
-                            logWarn(
-                              `bundle-mcp: failed to refresh changed tool list for server "${serverName}": ${redactMcpDiagnosticError(error)}`,
-                            );
-                          }
-                          invalidateCatalog();
-                        },
-                      },
-                    },
-                  },
-                );
-                const createdSession: BundleMcpSession = {
-                  serverName,
-                  client,
-                  transport: resolved.transport,
-                  transportType: resolved.transportType,
-                  requestTimeoutMs: resolved.requestTimeoutMs,
-                  supportsParallelToolCalls: resolved.supportsParallelToolCalls,
-                  connected: false,
-                  retiring: false,
-                  detachStderr: resolved.detachStderr,
-                };
-                // The SDK exposes lifecycle hooks as callback properties. A close is
-                // terminal for this client/transport pair.
-                // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Client is not an EventTarget.
-                client.onclose = () => {
-                  const wasConnected = createdSession.connected;
-                  createdSession.connected = false;
-                  createdSession.disconnectReason = "mcp transport closed";
-                  // Only established current sessions invalidate the catalog. Startup closes
-                  // already belong to catalog loading, and retirement must not start a rebuild.
-                  if (
-                    wasConnected &&
-                    !disposed &&
-                    !createdSession.retiring &&
-                    sessions.get(serverName) === createdSession
-                  ) {
-                    scheduleCatalogServerRetry(serverName, "mcp transport closed");
-                    logWarn(`bundle-mcp: server "${serverName}" closed; next request reconnects`);
-                  }
-                };
-                session = createdSession;
-                sessions.set(serverName, session);
-              }
-
-              try {
-                failIfDisposed();
-                await ensureSessionConnected(session, resolved.connectionTimeoutMs);
-                failIfDisposed();
-                const capabilities = summarizeServerCapabilities(
-                  session.client.getServerCapabilities(),
-                );
-                let listedTools: ListedTool[];
-                try {
-                  listedTools = await listAllTools(
-                    session.client,
-                    getCatalogListTimeoutMs(rawServer, resolved.requestTimeoutMs),
-                    lifecycleAbortController.signal,
-                  );
-                } catch (error) {
-                  if (
-                    !capabilities.tools &&
-                    (capabilities.resources || capabilities.prompts) &&
-                    isMcpMethodNotFoundError(error)
-                  ) {
-                    listedTools = [];
-                  } else {
-                    throw error;
-                  }
-                }
-                failIfDisposed();
-                const toolFilter = normalizeMcpToolFilter(
-                  isRecord(rawServer) ? rawServer.toolFilter : undefined,
-                );
-                const denialMap = params.toolOverrides?.mcpToolsDeny;
-                const deniedToolNames = new Set(
-                  denialMap && Object.hasOwn(denialMap, serverName) ? denialMap[serverName] : [],
-                );
-                const normalizedTools = normalizeMcpToolCatalog(
-                  listedTools,
-                  schemaValidator,
-                  (toolName) => {
-                    if (!isMcpToolAllowed(toolFilter, toolName)) {
-                      return "exclude";
-                    }
-                    return deniedToolNames.has(toolName) ? "denied" : "include";
-                  },
-                );
-                session.toolMetadata = normalizedTools.metadata;
-                const exposedTools = normalizedTools.tools;
-                const serverEntry: McpServerCatalog = {
-                  serverName,
-                  safeServerName,
-                  launchSummary: launchDescription,
-                  toolCount: exposedTools.length,
-                  requestTimeoutMs: resolved.requestTimeoutMs,
-                  supportsParallelToolCalls: resolved.supportsParallelToolCalls,
-                  ...(capabilities.resources ? { resources: capabilities.resources } : {}),
-                  ...(capabilities.prompts ? { prompts: capabilities.prompts } : {}),
-                  ...(capabilities.tools
-                    ? {
-                        tools: {
-                          ...capabilities.tools,
-                          ...(exposedTools.length !== listedTools.length
-                            ? { filteredCount: listedTools.length - exposedTools.length }
-                            : {}),
-                        },
-                      }
-                    : {}),
-                  ...(toolFilter ? { toolFilter } : {}),
-                  ...(deniedToolNames.size > 0
-                    ? { deniedToolNames: [...deniedToolNames].toSorted() }
-                    : {}),
-                  codexApprovalMode: resolveProjectedMcpCodexToolApprovalMode(
-                    serverName,
-                    rawServer,
-                  ),
-                };
-                const toolEntries: McpCatalogTool[] = [];
-                const policyToolEntries: McpCatalogTool[] = [];
-                for (const [tool, excludedFromOpenClawCatalog, deniedBySession] of [
-                  ...normalizedTools.tools.map((entry) => [entry, false, false] as const),
-                  ...normalizedTools.deniedTools.map((entry) => [entry, false, true] as const),
-                  ...normalizedTools.excludedTools.map(
-                    (entry) => [entry, true, deniedToolNames.has(entry.name)] as const,
-                  ),
-                ]) {
-                  const toolName = tool.name;
-                  const { _meta: metadata } = tool;
-                  const uiMeta =
-                    metadata?.ui && typeof metadata.ui === "object" && !Array.isArray(metadata.ui)
-                      ? (metadata.ui as { resourceUri?: unknown; visibility?: unknown })
-                      : undefined;
-                  const rawResourceUri = uiMeta?.resourceUri ?? metadata?.["ui/resourceUri"];
-                  const uiResourceUri =
-                    typeof rawResourceUri === "string" && rawResourceUri.startsWith("ui://")
-                      ? rawResourceUri
-                      : undefined;
-                  const uiVisibility = normalizeToolUiVisibility(uiMeta?.visibility);
-                  const entry: McpCatalogTool = {
-                    serverName,
-                    safeServerName,
-                    toolName,
-                    title: tool.title,
-                    description: sanitizeMcpMetadataText(tool.description),
-                    inputSchema: tool.inputSchema,
-                    fallbackDescription: `Provided by bundle MCP server "${serverName}" (${launchDescription}).`,
-                    ...(uiResourceUri ? { uiResourceUri } : {}),
-                    ...(uiVisibility ? { uiVisibility } : {}),
-                    ...(excludedFromOpenClawCatalog
-                      ? { excludedFromOpenClawCatalog: true as const }
-                      : {}),
-                    ...(deniedBySession ? { deniedBySession: true } : {}),
-                    codexAnnotations: normalizeMcpCodexToolAnnotations(tool.annotations),
-                  };
-                  policyToolEntries.push(entry);
-                  if (!entry.excludedFromOpenClawCatalog) {
-                    toolEntries.push(entry);
-                  }
-                }
-                return {
-                  serverName,
-                  serverEntry,
-                  toolEntries,
-                  policyToolEntries,
-                  diagnostics: [] as McpToolCatalogDiagnostic[],
-                };
-              } catch (error) {
-                const message = redactMcpDiagnosticError(error);
-                if (!disposed) {
-                  const action = reusedSession ? "refresh" : "start";
-                  logWarn(
-                    `bundle-mcp: failed to ${action} server "${serverName}" (${launchDescription}): ${message}`,
-                  );
-                }
-                const diags: McpToolCatalogDiagnostic[] = [
-                  {
-                    serverName,
-                    safeServerName,
-                    launchSummary: launchDescription,
-                    message,
-                  },
-                ];
-                if (!session.connected) {
-                  // A close is terminal for every catalog generation sharing this
-                  // session. The identity guard preserves any newer replacement.
-                  await retireSessionIfCurrent(serverName, session);
-                } else if (!reusedSession && catalogInvalidationGeneration === catalogGeneration) {
-                  // An isolated startup failure gets a fresh process on retry. When a
-                  // notification superseded this list, the queued generation reuses it.
-                  await retireSessionIfCurrent(serverName, session);
-                }
-                failIfDisposed();
-                return {
-                  serverName,
-                  serverEntry: null,
-                  toolEntries: [],
-                  policyToolEntries: [],
-                  diagnostics: diags,
-                } as ServerResult;
-              }
-            },
-        );
-        const { results, firstError, hasError } = await runTasksWithConcurrency({
-          tasks,
-          limit: BUNDLE_MCP_CATALOG_CONNECT_CONCURRENCY,
-          errorMode: "continue",
-        });
-        if (hasError) {
-          throw firstError;
-        }
-
-        for (const result of results) {
-          if (!result) {
-            continue;
-          }
-          const { serverEntry, toolEntries, policyToolEntries, diagnostics: serverDiags } = result;
-          if (serverEntry) {
-            servers[result.serverName] = serverEntry;
-          }
-          for (const tool of toolEntries) {
-            if (tool.deniedBySession) {
-              sessionDeniedTools.push(tool);
-            } else {
-              tools.push(tool);
-            }
-          }
-          policyTools.push(...policyToolEntries);
-          diagnostics.push(...serverDiags);
-        }
-
         failIfDisposed();
+        await ensureSessionConnected(session, resolved.connectionTimeoutMs);
+        failIfDisposed();
+        const capabilities = summarizeServerCapabilities(session.client.getServerCapabilities());
+        let listedTools: Tool[];
+        try {
+          listedTools = await listAllTools(
+            session.client,
+            getCatalogListTimeoutMs(rawServer, resolved.requestTimeoutMs),
+            lifecycleAbortController.signal,
+          );
+        } catch (error) {
+          if (
+            !capabilities.tools &&
+            (capabilities.resources || capabilities.prompts) &&
+            isMcpMethodNotFoundError(error)
+          ) {
+            listedTools = [];
+          } else {
+            throw error;
+          }
+        }
+        failIfDisposed();
+        const toolFilter = normalizeMcpToolFilter(
+          isRecord(rawServer) ? rawServer.toolFilter : undefined,
+        );
+        const denialMap = params.toolOverrides?.mcpToolsDeny;
+        const deniedToolNames = new Set(
+          denialMap && Object.hasOwn(denialMap, serverName) ? denialMap[serverName] : [],
+        );
+        const normalizedTools = normalizeMcpToolCatalog(
+          listedTools,
+          schemaValidator,
+          (toolName) => {
+            if (!isMcpToolAllowed(toolFilter, toolName)) {
+              return "exclude";
+            }
+            return deniedToolNames.has(toolName) ? "denied" : "include";
+          },
+        );
+        session.toolMetadata = normalizedTools.metadata;
+        const exposedTools = normalizedTools.tools;
+        const serverEntry: McpServerCatalog = {
+          serverName,
+          safeServerName,
+          launchSummary: launchDescription,
+          toolCount: exposedTools.length,
+          requestTimeoutMs: resolved.requestTimeoutMs,
+          supportsParallelToolCalls: resolved.supportsParallelToolCalls,
+          ...(capabilities.resources ? { resources: capabilities.resources } : {}),
+          ...(capabilities.prompts ? { prompts: capabilities.prompts } : {}),
+          ...(capabilities.tools
+            ? {
+                tools: {
+                  ...capabilities.tools,
+                  ...(exposedTools.length !== listedTools.length
+                    ? { filteredCount: listedTools.length - exposedTools.length }
+                    : {}),
+                },
+              }
+            : {}),
+          ...(toolFilter ? { toolFilter } : {}),
+          ...(deniedToolNames.size > 0 ? { deniedToolNames: [...deniedToolNames].toSorted() } : {}),
+          codexApprovalMode: resolveProjectedMcpCodexToolApprovalMode(serverName, rawServer),
+        };
+        const toolEntries: McpCatalogTool[] = [];
+        const policyToolEntries: McpCatalogTool[] = [];
+        for (const [tool, excludedFromOpenClawCatalog, deniedBySession] of [
+          ...normalizedTools.tools.map((entry) => [entry, false, false] as const),
+          ...normalizedTools.deniedTools.map((entry) => [entry, false, true] as const),
+          ...normalizedTools.excludedTools.map(
+            (entry) => [entry, true, deniedToolNames.has(entry.name)] as const,
+          ),
+        ]) {
+          const toolName = tool.name;
+          const { _meta: metadata } = tool;
+          const uiMeta =
+            metadata?.ui && typeof metadata.ui === "object" && !Array.isArray(metadata.ui)
+              ? (metadata.ui as { resourceUri?: unknown; visibility?: unknown })
+              : undefined;
+          const rawResourceUri = uiMeta?.resourceUri ?? metadata?.["ui/resourceUri"];
+          const uiResourceUri =
+            typeof rawResourceUri === "string" && rawResourceUri.startsWith("ui://")
+              ? rawResourceUri
+              : undefined;
+          const uiVisibility = normalizeToolUiVisibility(uiMeta?.visibility);
+          const entry: McpCatalogTool = {
+            serverName,
+            safeServerName,
+            toolName,
+            title: tool.title,
+            description: sanitizeMcpMetadataText(tool.description),
+            inputSchema: tool.inputSchema,
+            fallbackDescription: `Provided by bundle MCP server "${serverName}" (${launchDescription}).`,
+            ...(uiResourceUri ? { uiResourceUri } : {}),
+            ...(uiVisibility ? { uiVisibility } : {}),
+            ...(excludedFromOpenClawCatalog ? { excludedFromOpenClawCatalog: true as const } : {}),
+            ...(deniedBySession ? { deniedBySession: true } : {}),
+            codexAnnotations: normalizeMcpCodexToolAnnotations(tool.annotations),
+          };
+          policyToolEntries.push(entry);
+          if (!entry.excludedFromOpenClawCatalog) {
+            toolEntries.push(entry);
+          }
+        }
         return {
           version: 1,
           generatedAt: Date.now(),
-          servers,
-          tools,
-          ...(policyTools.length > 0 ? { policyTools } : {}),
-          ...(sessionDeniedTools.length > 0 ? { sessionDeniedTools } : {}),
-          ...(diagnostics.length > 0 ? { diagnostics } : {}),
+          servers: { [serverName]: serverEntry },
+          tools: toolEntries.filter((tool) => !tool.deniedBySession),
+          policyTools: policyToolEntries,
+          sessionDeniedTools: toolEntries.filter((tool) => tool.deniedBySession),
         };
       } catch (error) {
-        await Promise.allSettled(
-          Array.from(sessions.values(), (session) => disposeBundleMcpSession(session)),
-        );
-        sessions.clear();
-        throw error;
+        const message = redactMcpDiagnosticError(error);
+        if (!retiredCatalog) {
+          const action = reusedSession ? "refresh" : "start";
+          logWarn(
+            `bundle-mcp: failed to ${action} server "${serverName}" (${launchDescription}): ${message}`,
+          );
+        }
+        const diags: McpToolCatalogDiagnostic[] = [
+          {
+            serverName,
+            safeServerName,
+            launchSummary: launchDescription,
+            message,
+          },
+        ];
+        if (!session.connected) {
+          // A close is terminal for every catalog generation sharing this
+          // session. The identity guard preserves any newer replacement.
+          await retireSessionIfCurrent(session);
+        } else if (!reusedSession && catalogInvalidationGeneration === catalogGeneration) {
+          // An isolated startup failure gets a fresh process on retry. When a
+          // notification superseded this list, the queued generation reuses it.
+          await retireSessionIfCurrent(session);
+        }
+        failIfDisposed();
+        return { version: 1, generatedAt: Date.now(), servers: {}, tools: [], diagnostics: diags };
       }
     })();
     catalogInFlight = inFlight;
-
     try {
       const nextCatalog = await inFlight;
       failIfDisposed();
@@ -967,21 +944,28 @@ export function createSessionMcpRuntime(params: {
 
     const staleCatalog = catalog;
     catalogRetryAfterMs = undefined;
-    void loadCatalog(staleCatalog).catch(() => {
-      if (!disposed && catalog === staleCatalog && catalogRetryAfterMs === undefined) {
+    void loadCatalog().catch(() => {
+      if (!retiredCatalog && catalog === staleCatalog && catalogRetryAfterMs === undefined) {
         catalogRetryAfterMs = Date.now() + BUNDLE_MCP_CATALOG_FAILURE_RETRY_MS;
       }
     });
     return staleCatalog;
   };
-  const getActiveSession = async (serverName: string) => {
+  const getActiveSession = async (requestedServer: string) => {
+    if (requestedServer !== serverName) {
+      throw new Error(`bundle-mcp server "${requestedServer}" is not connected`);
+    }
     const signal = getSessionMcpRequestSignal();
     signal?.throwIfAborted();
     await racePromiseWithAbortSignal(getCatalog(), signal);
-    return requireConnectedSession(serverName);
+    return requireConnectedSession();
   };
 
-  const runtime: SessionMcpRuntime = {
+  const runtime: ServerMcpRuntime = {
+    // Provenance travels with the transport; a later explicit definition cannot relabel it.
+    pluginOwned:
+      !Object.hasOwn(params.cfg?.mcp?.servers ?? {}, serverName) ||
+      params.connectionOverrides?.has(serverName) === true,
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     workspaceDir: params.workspaceDir,
@@ -1012,21 +996,24 @@ export function createSessionMcpRuntime(params: {
       };
     },
     getCatalog,
+    get retiredCatalog() {
+      return retiredCatalog;
+    },
     /** Synchronous catalog snapshot only; must not connect transports or issue tools/list. */
     peekCatalog() {
       return catalog;
     },
     /** Session-owned timeout that survives catalog invalidation. */
-    getServerRequestTimeoutMs(serverName: string) {
-      return sessions.get(serverName)?.requestTimeoutMs;
+    getServerRequestTimeoutMs(requestedServer: string) {
+      return requestedServer === serverName ? currentSession?.requestTimeoutMs : undefined;
     },
     markUsed() {
       lastUsedAt = Date.now();
     },
-    async callTool(serverName, toolName, input) {
-      const session = await getActiveSession(serverName);
+    async callTool(requestedServer, toolName, input) {
+      const session = await getActiveSession(requestedServer);
       const validateResult = session.toolMetadata?.validatorForCall(toolName);
-      const result = (await runGuardedMcpRequest(serverName, session, (signal) =>
+      const result = (await runGuardedMcpRequest(session, (signal) =>
         session.client.callTool(
           { name: toolName, arguments: isRecord(input) ? input : {} },
           undefined,
@@ -1036,9 +1023,9 @@ export function createSessionMcpRuntime(params: {
       validateResult?.(result);
       return result;
     },
-    async listTools(serverName, requestParams) {
-      const session = await getActiveSession(serverName);
-      return await runGuardedMcpRequest(serverName, session, (signal) =>
+    async listTools(requestedServer, requestParams) {
+      const session = await getActiveSession(requestedServer);
+      return await runGuardedMcpRequest(session, (signal) =>
         session.client.request(
           { method: "tools/list", params: requestParams },
           ListToolsResultSchema,
@@ -1046,43 +1033,41 @@ export function createSessionMcpRuntime(params: {
         ),
       );
     },
-    async listResources(serverName, options) {
-      const session = await getActiveSession(serverName);
+    async listResources(requestedServer, options) {
+      const session = await getActiveSession(requestedServer);
       return await runGuardedServerRequest(
-        serverName,
         session,
         async () => collectServerItems(session, "resources"),
         options,
       );
     },
-    async readResource(serverName, uri, options) {
-      const session = await getActiveSession(serverName);
+    async readResource(requestedServer, uri, options) {
+      const session = await getActiveSession(requestedServer);
       return await runGuardedMcpRequest(
-        serverName,
         session,
         (signal) =>
           session.client.readResource({ uri }, { timeout: session.requestTimeoutMs, signal }),
         options,
       );
     },
-    async listResourceTemplates(serverName, requestParams) {
-      const session = await getActiveSession(serverName);
-      return await runGuardedMcpRequest(serverName, session, (signal) =>
+    async listResourceTemplates(requestedServer, requestParams) {
+      const session = await getActiveSession(requestedServer);
+      return await runGuardedMcpRequest(session, (signal) =>
         session.client.listResourceTemplates(requestParams, {
           timeout: session.requestTimeoutMs,
           signal,
         }),
       );
     },
-    async listPrompts(serverName) {
-      const session = await getActiveSession(serverName);
-      return await runGuardedServerRequest(serverName, session, async () =>
+    async listPrompts(requestedServer) {
+      const session = await getActiveSession(requestedServer);
+      return await runGuardedServerRequest(session, async () =>
         collectServerItems(session, "prompts"),
       );
     },
-    async getPrompt(serverName, name, args) {
-      const session = await getActiveSession(serverName);
-      return await runGuardedMcpRequest(serverName, session, (signal) =>
+    async getPrompt(requestedServer, name, args) {
+      const session = await getActiveSession(requestedServer);
+      return await runGuardedMcpRequest(session, (signal) =>
         session.client.getPrompt(
           { name, ...(args ? { arguments: args } : {}) },
           { timeout: session.requestTimeoutMs, signal },
@@ -1090,17 +1075,32 @@ export function createSessionMcpRuntime(params: {
       );
     },
     async dispose() {
-      if (disposed) {
+      if (retiredCatalog) {
         return;
       }
-      disposed = true;
+      retiredCatalog = {
+        version: 1,
+        generatedAt: Date.now(),
+        servers: {},
+        tools: [],
+        diagnostics: [
+          {
+            serverName,
+            safeServerName: params.safeServerNamesByServer?.get(serverName) ?? serverName,
+            launchSummary: serverName,
+            message: "MCP server runtime retired; retry discovery on the next turn.",
+          },
+        ],
+      };
       lifecycleAbortController.abort(createDisposedError(params.sessionId));
       catalog = null;
       catalogRetryAfterMs = undefined;
       catalogInFlight = undefined;
-      const sessionsToClose = Array.from(sessions.values());
-      sessions.clear();
-      await Promise.allSettled(sessionsToClose.map((session) => disposeBundleMcpSession(session)));
+      const session = currentSession;
+      currentSession = undefined;
+      if (session) {
+        await disposeBundleMcpSession(session);
+      }
     },
   };
   return runtime;
@@ -1108,7 +1108,6 @@ export function createSessionMcpRuntime(params: {
 
 export const testing = {
   buildMcpClientCapabilities,
-  createSessionMcpRuntimeManager,
   async resetSessionMcpRuntimeManager() {
     await disposeAllSessionMcpRuntimes();
     setBundleMcpCatalogListTimeoutMsForTest();

--- a/src/agents/agent-bundle-mcp-tools.ts
+++ b/src/agents/agent-bundle-mcp-tools.ts
@@ -1,7 +1,8 @@
 /** Public facade for bundle MCP tool materialization and session-scoped runtime management. */
 export {
   disposeAllSessionMcpRuntimes,
-  getOrCreateSessionMcpRuntime,
+  reloadSessionMcpRuntimes,
+  acquireSessionMcpRuntime,
   peekSessionMcpRuntime,
   retireSessionMcpRuntime,
   retireSessionMcpRuntimeForSessionKey,

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -9,9 +9,14 @@ import type { SessionToolOverrides } from "../config/sessions/types.js";
 import type { McpCodexToolApprovalMode, McpServerToolFilterConfig } from "../config/types.mcp.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
-import type { SessionMcpConfigReload } from "./agent-bundle-mcp-runtime-owner.js";
 import type { McpCodexToolAnnotations } from "./mcp-codex-tool-approval.js";
 import type { AnyAgentTool } from "./tools/common.js";
+
+export type SessionMcpConfigReload = {
+  cfg: OpenClawConfig;
+  manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
+  reloadPlugins?: boolean;
+};
 
 /** Materialized MCP tools plus diagnostics and cleanup handle for one run. */
 export type BundleMcpToolRuntime = {

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -9,6 +9,7 @@ import type { SessionToolOverrides } from "../config/sessions/types.js";
 import type { McpCodexToolApprovalMode, McpServerToolFilterConfig } from "../config/types.mcp.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import type { SessionMcpConfigReload } from "./agent-bundle-mcp-runtime-owner.js";
 import type { McpCodexToolAnnotations } from "./mcp-codex-tool-approval.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -138,6 +139,8 @@ export type SessionMcpRuntime = {
   lastUsedAt: number;
   activeLeases?: number;
   acquireLease?: () => () => void;
+  /** Terminal server outcome recorded at retirement, with no callable tools. */
+  readonly retiredCatalog?: McpToolCatalog;
   /** Lists tools if needed and may connect MCP transports. */
   getCatalog: () => Promise<McpToolCatalog>;
   /** Returns the cached catalog only; must not start runtimes, connect transports, or issue tools/list. */
@@ -158,15 +161,20 @@ export type SessionMcpRuntime = {
   dispose: () => Promise<void>;
 };
 
-/** One requester call's runtime and immutable catalog publication version. */
-export type RequesterScopedMcpRuntimeHandle = {
+/** Acquisition owns a lease before any caller can observe the runtime. */
+export type SessionMcpRuntimeLease = {
   runtime: SessionMcpRuntime;
+  releaseLease: () => void;
+};
+
+/** One requester call's lease and immutable catalog publication version. */
+export type RequesterScopedMcpRuntimeHandle = SessionMcpRuntimeLease & {
   advertisedCatalogConfigFingerprint: string;
 };
 
 /** Manager for session-scoped MCP runtimes and their idle lifecycle. */
 export type SessionMcpRuntimeManager = {
-  getOrCreate: (params: {
+  acquire: (params: {
     sessionId: string;
     sessionKey?: string;
     workspaceDir: string;
@@ -178,12 +186,12 @@ export type SessionMcpRuntimeManager = {
     agentAccountId?: string | null;
     messageChannel?: string | null;
     toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
-  }) => Promise<SessionMcpRuntime>;
+  }) => Promise<SessionMcpRuntimeLease>;
   /**
    * Requester-scoped partition only — never creates static transports.
    * Undefined when no scoped servers, no senderId, or nothing resolves.
    */
-  getOrCreateRequesterScoped: (params: {
+  acquireRequesterScoped: (params: {
     sessionId: string;
     sessionKey?: string;
     workspaceDir: string;
@@ -215,6 +223,7 @@ export type SessionMcpRuntimeManager = {
   /** Required retirement stays armed when a stopping run creates or reuses a runtime. */
   deferRetirement: (sessionId: string, opts?: { retainAcrossReuse?: boolean }) => boolean;
   completeDeferredRetirement: (sessionId: string, runtime?: SessionMcpRuntime) => Promise<boolean>;
+  reloadConfig: (params: SessionMcpConfigReload) => Promise<void>;
   disposeAll: () => Promise<void>;
   sweepIdleRuntimes: () => Promise<number>;
   listSessionIds: () => string[];

--- a/src/agents/cli-runner.before-agent-reply-cron.test.ts
+++ b/src/agents/cli-runner.before-agent-reply-cron.test.ts
@@ -1,6 +1,5 @@
-/** Tests cron before_agent_reply gating at the CLI runner entrypoint. */
-
 import { expectDefined } from "@openclaw/normalization-core";
+/** Tests cron before_agent_reply gating at the CLI runner entrypoint. */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import {
@@ -14,6 +13,7 @@ import {
 } from "../infra/diagnostic-events.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import { wrapRunWithTestPreparedAdmission } from "./admitted-run-context.test-support.js";
+import { getOrCreateSessionMcpRuntime } from "./agent-bundle-mcp-manager.test-support.js";
 import { testing as cliBackendsTesting } from "./cli-backends.test-support.js";
 import type { CliOutput } from "./cli-output-contracts.js";
 import { CliAuthProfilePreparationError } from "./cli-runner/auth-profile-preparation-error.js";
@@ -965,11 +965,11 @@ describe("runCliAgent before_agent_reply seam", () => {
     executePreparedCliRunMock.mockResolvedValue({ text: "real reply" });
 
     try {
-      await mcpTools.getOrCreateSessionMcpRuntime({
+      await getOrCreateSessionMcpRuntime({
         ...runtimeParams,
         sessionId: originalSessionId,
       });
-      const successorRuntime = await mcpTools.getOrCreateSessionMcpRuntime({
+      const successorRuntime = await getOrCreateSessionMcpRuntime({
         ...runtimeParams,
         sessionId: successorSessionId,
       });

--- a/src/agents/cli-runner/bundle-mcp-codex.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.ts
@@ -7,7 +7,10 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadMcpToolGrants } from "../../infra/exec-approvals-mcp.js";
 import type { BundleMcpConfig, BundleMcpServerConfig } from "../../plugins/bundle-mcp.js";
 import { isValidAgentId, normalizeAgentId } from "../../routing/session-key.js";
-import { getOrCreateSessionMcpRuntime } from "../agent-bundle-mcp-manager-api.js";
+import {
+  acquireSessionMcpRuntime,
+  releaseSessionMcpRuntime,
+} from "../agent-bundle-mcp-manager-api.js";
 import type { PreparedNativeMcpPolicy } from "../agent-bundle-mcp-types.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { isRecord } from "../bundle-mcp-adapter.js";
@@ -317,7 +320,7 @@ export async function buildCodexUserMcpServersThreadConfigPatchForRun(params: {
     ...run.config,
     mcp: { ...run.config?.mcp, servers: configuredMcpServers },
   };
-  const runtime = await getOrCreateSessionMcpRuntime({
+  const acquisition = await acquireSessionMcpRuntime({
     sessionId: run.sessionId,
     sessionKey: run.sessionKey,
     workspaceDir: run.workspaceDir,
@@ -328,14 +331,19 @@ export async function buildCodexUserMcpServersThreadConfigPatchForRun(params: {
     messageChannel: run.messageChannel,
     toolOverrides: scopedToolOverrides,
   });
-  const preparedNativeMcpPolicy = await prepareNativeMcpPolicy({
-    runtime,
-    config: run.config,
-    workspaceDir: run.workspaceDir,
-    capabilityProfile,
-    runtimeToolsAllow: run.toolsAllow,
-    warn: params.warn ?? (() => {}),
-  });
+  let preparedNativeMcpPolicy: PreparedNativeMcpPolicy;
+  try {
+    preparedNativeMcpPolicy = await prepareNativeMcpPolicy({
+      runtime: acquisition.runtime,
+      config: run.config,
+      workspaceDir: run.workspaceDir,
+      capabilityProfile,
+      runtimeToolsAllow: run.toolsAllow,
+      warn: params.warn ?? (() => {}),
+    });
+  } finally {
+    await releaseSessionMcpRuntime(acquisition);
+  }
   return await buildCodexUserMcpServersThreadConfigPatchForRuntime(projectionConfig, {
     agentId,
     agentDir: run.agentDir,

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -20,7 +20,10 @@ import {
 } from "../../plugins/bundle-mcp.js";
 import type { CliBackendConfig } from "../../plugins/cli-backend.types.js";
 import type { CliBundleMcpMode } from "../../plugins/types.js";
-import { getOrCreateSessionMcpRuntime } from "../agent-bundle-mcp-manager-api.js";
+import {
+  acquireSessionMcpRuntime,
+  releaseSessionMcpRuntime,
+} from "../agent-bundle-mcp-manager-api.js";
 import { isRecord } from "../bundle-mcp-adapter.js";
 import {
   loadMergedBundleMcpConfig,
@@ -460,7 +463,7 @@ export async function prepareCliBundleMcpConfig(params: {
       ...params.config,
       mcp: { ...params.config?.mcp, servers: nativePolicyConfig.mcpServers },
     };
-    const runtime = await getOrCreateSessionMcpRuntime({
+    const acquisition = await acquireSessionMcpRuntime({
       sessionId: params.nativeMcpPolicy.sessionId,
       sessionKey: params.nativeMcpPolicy.sessionKey,
       workspaceDir: params.workspaceDir,
@@ -468,14 +471,19 @@ export async function prepareCliBundleMcpConfig(params: {
       cfg: runtimeConfig,
       toolOverrides: params.toolOverrides,
     });
-    const policy = await prepareNativeMcpPolicy({
-      runtime,
-      config: params.config,
-      workspaceDir: params.workspaceDir,
-      capabilityProfile: params.nativeMcpPolicy.capabilityProfile,
-      runtimeToolsAllow: params.nativeMcpPolicy.runtimeToolsAllow,
-      warn: params.warn ?? (() => {}),
-    });
+    let policy: Awaited<ReturnType<typeof prepareNativeMcpPolicy>>;
+    try {
+      policy = await prepareNativeMcpPolicy({
+        runtime: acquisition.runtime,
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+        capabilityProfile: params.nativeMcpPolicy.capabilityProfile,
+        runtimeToolsAllow: params.nativeMcpPolicy.runtimeToolsAllow,
+        warn: params.warn ?? (() => {}),
+      });
+    } finally {
+      await releaseSessionMcpRuntime(acquisition);
+    }
     effectiveConfig = {
       mcpServers: {
         ...applyPreparedNativeMcpPolicy(policyConfig, policy).mcpServers,

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
@@ -8,7 +8,7 @@ import { attachToolAllowlistIntersection } from "../../tool-policy.js";
 
 const mocks = vi.hoisted(() => ({
   createBundleLspToolRuntime: vi.fn(),
-  getOrCreateSessionMcpRuntime: vi.fn(),
+  acquireSessionMcpRuntime: vi.fn(),
   materializeBundleMcpToolsForRun: vi.fn(),
   applyFinalEffectiveToolPolicy: vi.fn(),
   filterRuntimeCompatibleTools: vi.fn(),
@@ -19,7 +19,7 @@ vi.mock("../../agent-bundle-lsp-runtime.js", () => ({
 }));
 
 vi.mock("../../agent-bundle-mcp-tools.js", () => ({
-  getOrCreateSessionMcpRuntime: mocks.getOrCreateSessionMcpRuntime,
+  acquireSessionMcpRuntime: mocks.acquireSessionMcpRuntime,
   materializeBundleMcpToolsForRun: mocks.materializeBundleMcpToolsForRun,
 }));
 
@@ -45,7 +45,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.createBundleLspToolRuntime.mockReset().mockResolvedValue(undefined);
-    mocks.getOrCreateSessionMcpRuntime.mockReset().mockResolvedValue(undefined);
+    mocks.acquireSessionMcpRuntime.mockReset().mockResolvedValue(undefined);
     mocks.materializeBundleMcpToolsForRun.mockReset().mockResolvedValue(undefined);
     mocks.applyFinalEffectiveToolPolicy
       .mockReset()
@@ -102,14 +102,14 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
     };
     input.attempt.toolsAllow = testCase.allow;
     input.preparedToolBase.effectiveToolsAllow = testCase.allow;
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({ runtime: {}, releaseLease: () => {} });
     mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
       tools: [{ name: "chrome__click" }, { name: "other__click" }],
     });
 
     const result = await prepareEmbeddedAttemptBundleTools(input);
 
-    expect(mocks.getOrCreateSessionMcpRuntime).toHaveBeenCalledTimes(
+    expect(mocks.acquireSessionMcpRuntime).toHaveBeenCalledTimes(
       testCase.discover === false ? 0 : 1,
     );
     expect(result.uncompactedEffectiveTools.map((tool) => tool.name)).toEqual(testCase.expected);
@@ -133,7 +133,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
 
     await prepareEmbeddedAttemptBundleTools(input);
 
-    expect(mocks.getOrCreateSessionMcpRuntime).toHaveBeenCalledTimes(testCase.expected ? 1 : 0);
+    expect(mocks.acquireSessionMcpRuntime).toHaveBeenCalledTimes(testCase.expected ? 1 : 0);
   });
 
   it.each([
@@ -152,7 +152,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
 
     await prepareEmbeddedAttemptBundleTools(input);
 
-    expect(mocks.getOrCreateSessionMcpRuntime).toHaveBeenCalledOnce();
+    expect(mocks.acquireSessionMcpRuntime).toHaveBeenCalledOnce();
   });
 
   it.each(["disableTools", "raw", "restart", "model"])(
@@ -168,7 +168,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
 
       await prepareEmbeddedAttemptBundleTools(input);
 
-      expect(mocks.getOrCreateSessionMcpRuntime).not.toHaveBeenCalled();
+      expect(mocks.acquireSessionMcpRuntime).not.toHaveBeenCalled();
     },
   );
 
@@ -192,7 +192,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
       manifestRegistry: registry,
     });
     input.getCurrentAttemptPluginMetadataSnapshot = () => snapshot;
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({ runtime: {}, releaseLease: () => {} });
     mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
       tools: [{ name: "chrome-dev__click" }, { name: "chrome-dev-2__click" }],
     });
@@ -276,7 +276,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
       type: "function" as const,
       function: { name, parameters: { type: "object" as const } },
     }));
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({ runtime: {}, releaseLease: () => {} });
     mocks.materializeBundleMcpToolsForRun.mockResolvedValue({ tools: [] });
 
     const result = await prepareEmbeddedAttemptBundleTools(input);
@@ -303,14 +303,14 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
     const result = await prepareEmbeddedAttemptBundleTools(input);
 
     expect(result.clientTools).toBeUndefined();
-    expect(mocks.getOrCreateSessionMcpRuntime).not.toHaveBeenCalled();
+    expect(mocks.acquireSessionMcpRuntime).not.toHaveBeenCalled();
     expect(mocks.materializeBundleMcpToolsForRun).not.toHaveBeenCalled();
     expect(mocks.createBundleLspToolRuntime).not.toHaveBeenCalled();
   });
 
   it("refreshes spawned-child inheritance after authorized MCP tools materialize", async () => {
     const inheritedToolAllowlist = ["sessions_spawn"];
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({ runtime: {}, releaseLease: () => {} });
     mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
       tools: [{ name: "server__read" }],
     });
@@ -324,7 +324,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
 
   it("never adds policy-denied bundled tools to spawned-child inheritance", async () => {
     const inheritedToolAllowlist = ["sessions_spawn"];
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({ runtime: {}, releaseLease: () => {} });
     mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
       tools: [{ name: "server__read" }, { name: "server__delete" }],
     });
@@ -350,7 +350,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
       pluginId: "bundle-mcp",
       optional: false,
     });
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({ runtime: {}, releaseLease: () => {} });
     mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
       tools: [allowedMcpTool, quarantinedMcpTool],
     });
@@ -377,7 +377,7 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
   it("disposes prepared bundle runtimes when later policy setup fails", async () => {
     const disposeMcp = vi.fn(async () => {});
     const disposeLsp = vi.fn(async () => {});
-    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({ runtime: {}, releaseLease: () => {} });
     mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
       tools: [],
       dispose: disposeMcp,

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -3,7 +3,7 @@ import { createBundleLspToolRuntime } from "../../agent-bundle-lsp-runtime.js";
 import { assignSafeServerNames, TOOL_NAME_SEPARATOR } from "../../agent-bundle-mcp-names.js";
 import { loadSessionMcpConfig } from "../../agent-bundle-mcp-runtime-config.js";
 import {
-  getOrCreateSessionMcpRuntime,
+  acquireSessionMcpRuntime,
   materializeBundleMcpToolsForRun,
 } from "../../agent-bundle-mcp-tools.js";
 import { wrapToolWithAbortSignal } from "../../agent-tools.abort.js";
@@ -123,8 +123,8 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
         });
       },
     });
-  const bundleMcpSessionRuntime = bundleMcpEnabled
-    ? await getOrCreateSessionMcpRuntime({
+  const bundleMcpAcquisition = bundleMcpEnabled
+    ? await acquireSessionMcpRuntime({
         ...mcpConfig,
         sessionId: params.attempt.sessionId,
         sessionKey: params.attempt.sessionKey,
@@ -137,9 +137,9 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
         messageChannel: params.attempt.messageChannel ?? params.attempt.messageProvider,
       })
     : undefined;
-  const bundleMcpRuntime = bundleMcpSessionRuntime
+  const bundleMcpRuntime = bundleMcpAcquisition
     ? await materializeBundleMcpToolsForRun({
-        runtime: bundleMcpSessionRuntime,
+        ...bundleMcpAcquisition,
         agentId: params.sessionAgentId,
         reservedToolNames: [
           ...tools.map((tool) => tool.name),

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -726,7 +726,7 @@ vi.mock("../../agent-tools.js", () => ({
 
 vi.mock("../../agent-bundle-mcp-tools.js", () => ({
   createBundleMcpToolRuntime: async () => undefined,
-  getOrCreateSessionMcpRuntime: async () => undefined,
+  acquireSessionMcpRuntime: async () => undefined,
   materializeBundleMcpToolsForRun: async () => undefined,
   retireSessionMcpRuntime: async () => true,
 }));

--- a/src/agents/mcp-connection-resolver.test.ts
+++ b/src/agents/mcp-connection-resolver.test.ts
@@ -19,11 +19,8 @@ import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plug
 import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { createPluginRecord } from "../plugins/status.test-fixtures.js";
-import {
-  disposeAllSessionMcpRuntimes,
-  getOrCreateSessionMcpRuntime,
-  peekSessionMcpRuntime,
-} from "./agent-bundle-mcp-tools.js";
+import { getOrCreateSessionMcpRuntime } from "./agent-bundle-mcp-manager.test-support.js";
+import { disposeAllSessionMcpRuntimes, peekSessionMcpRuntime } from "./agent-bundle-mcp-tools.js";
 import {
   applyMcpConnectionOverride,
   buildMcpRequesterRuntimeCacheKey,
@@ -392,7 +389,7 @@ describe("mcp connection resolver helpers", () => {
       expect(refreshContextWindowCache).toHaveBeenCalledWith(nextConfig);
       expect(requestRecoveryRestart).not.toHaveBeenCalled();
       expect(isPluginRegistryRetired(previous.registry)).toBe(true);
-      expect(peekSessionMcpRuntime({ sessionId })).toBeUndefined();
+      expect(peekSessionMcpRuntime({ sessionId })?.peekCatalog()?.tools ?? []).toEqual([]);
 
       const legacyRequests = proof.mail.requests;
       await expect(previousRuntime.callTool("user-mail", "owner_probe", {})).rejects.toThrow(

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
@@ -2,8 +2,8 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentRouteBinding } from "../config/types.agents.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import { getOrCreateSessionMcpRuntime } from "./agent-bundle-mcp-manager.test-support.js";
 import { testing as bundleMcpRuntimeTesting } from "./agent-bundle-mcp-runtime.js";
-import { getOrCreateSessionMcpRuntime } from "./agent-bundle-mcp-tools.js";
 import {
   getCallGatewayMock,
   getSessionsSpawnTool,

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -5,8 +5,8 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { getOrCreateSessionMcpRuntime } from "../../agents/agent-bundle-mcp-manager.test-support.js";
 import { testing as sessionMcpTesting } from "../../agents/agent-bundle-mcp-runtime.js";
-import { getOrCreateSessionMcpRuntime } from "../../agents/agent-bundle-mcp-tools.js";
 import * as bootstrapCache from "../../agents/bootstrap-cache.js";
 import {
   clearEmbeddedSessionPromptStates,

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -268,14 +268,12 @@ function getReloadPolicyCatalog() {
       },
       { prefixes: plugin.reload?.noopPrefixes ?? [], kind: "none" },
     ]),
-    ...channelPlugins.map(
-      (plugin): ReloadPolicy => ({
-        prefixes: [`plugins.entries.${plugin.id}`],
-        kind: "hot",
-        actions: ["reloadPlugins", "disposeMcpRuntimes"],
-        channels: [plugin],
-      }),
-    ),
+    ...channelPlugins.map((plugin): ReloadPolicy => ({
+      prefixes: [`plugins.entries.${plugin.id}`],
+      kind: "hot",
+      actions: ["reloadPlugins", "disposeMcpRuntimes"],
+      channels: [plugin],
+    })),
     // Channel snapshots capture shared policy. Fan out by default while
     // preserving explicit plugin/channel policies above on equal-prefix ties.
     {

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -104,7 +104,6 @@ const CORE_RELOAD_POLICIES: ReloadPolicy[] = [
       "gateway.http.securityHeaders.strictTransportSecurity",
       "gateway.tools",
       "gateway.cliAgents",
-      "gateway.publicOrigin",
       "gateway.controlUi.enabled",
       "gateway.controlUi.environment",
       "gateway.controlUi.communityInvite",
@@ -170,7 +169,7 @@ const CORE_RELOAD_POLICIES: ReloadPolicy[] = [
     actions: ["reconcileSystemJobs"],
   },
   { prefixes: ["cron"], kind: "hot", actions: ["restartCron"] },
-  { prefixes: ["mcp"], kind: "hot", actions: ["disposeMcpRuntimes"] },
+  { prefixes: ["mcp", "gateway.publicOrigin"], kind: "hot", actions: ["disposeMcpRuntimes"] },
   // Capability ownership changes replace the plugin generation that owns its routes.
   {
     prefixes: ["talk.provider", "talk.realtime.provider"],
@@ -269,12 +268,14 @@ function getReloadPolicyCatalog() {
       },
       { prefixes: plugin.reload?.noopPrefixes ?? [], kind: "none" },
     ]),
-    ...channelPlugins.map((plugin): ReloadPolicy => ({
-      prefixes: [`plugins.entries.${plugin.id}`],
-      kind: "hot",
-      actions: ["reloadPlugins", "disposeMcpRuntimes"],
-      channels: [plugin],
-    })),
+    ...channelPlugins.map(
+      (plugin): ReloadPolicy => ({
+        prefixes: [`plugins.entries.${plugin.id}`],
+        kind: "hot",
+        actions: ["reloadPlugins", "disposeMcpRuntimes"],
+        channels: [plugin],
+      }),
+    ),
     // Channel snapshots capture shared policy. Fan out by default while
     // preserving explicit plugin/channel policies above on equal-prefix ties.
     {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -481,7 +481,6 @@ describe("buildGatewayReloadPlan", () => {
     "gateway.nodes.browser.mode",
     "gateway.nodes.browser.node",
     "gateway.push.apns.relay.baseUrl",
-    "gateway.publicOrigin",
     "mcp.apps.sandboxOrigin",
     "approvals.exec.enabled",
     "approvals.plugin.targets",
@@ -600,6 +599,10 @@ describe("buildGatewayReloadPlan", () => {
     },
     {
       path: "mcp.servers.context7.command",
+      expected: { disposeMcpRuntimes: true },
+    },
+    {
+      path: "gateway.publicOrigin",
       expected: { disposeMcpRuntimes: true },
     },
     {

--- a/src/gateway/mcp-app-reconstruction.test.ts
+++ b/src/gateway/mcp-app-reconstruction.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   fetchMcpAppView: vi.fn(),
   getMcpAppViewLease: vi.fn(),
-  getOrCreateSessionMcpRuntime: vi.fn(),
+  acquireSessionMcpRuntime: vi.fn(),
+  releaseLease: vi.fn(),
   loadSessionEntry: vi.fn(),
   resolveAgentDir: vi.fn(),
   resolveAgentIdFromSessionKey: vi.fn(),
@@ -12,7 +13,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../agents/agent-bundle-mcp-manager-api.js", () => ({
-  getOrCreateSessionMcpRuntime: mocks.getOrCreateSessionMcpRuntime,
+  acquireSessionMcpRuntime: mocks.acquireSessionMcpRuntime,
+  releaseSessionMcpRuntime: async (lease: { releaseLease: () => void }) => lease.releaseLease(),
 }));
 vi.mock("../agents/agent-scope.js", () => ({
   resolveAgentDir: mocks.resolveAgentDir,
@@ -50,7 +52,10 @@ beforeEach(() => {
     entry: { sessionId: "session-1" },
     storePath: "/tmp/sessions.json",
   });
-  mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+  mocks.acquireSessionMcpRuntime.mockResolvedValue({
+    runtime,
+    releaseLease: mocks.releaseLease,
+  });
   mocks.fetchMcpAppView.mockImplementation(async (params: { viewId?: string }) => ({
     viewId: params.viewId ?? "mcp-app-fresh",
   }));
@@ -114,6 +119,7 @@ describe("MCP App transcript reconstruction", () => {
     );
 
     expect(restored).toEqual({ runtime, view });
+    expect(mocks.releaseLease).toHaveBeenCalledOnce();
     expect(mocks.fetchMcpAppView).toHaveBeenCalledWith({
       runtime,
       agentId: "main",
@@ -191,6 +197,38 @@ describe("MCP App transcript reconstruction", () => {
       );
       expect(mocks.loadSessionEntry).toHaveBeenCalledWith(sessionKey, { agentId: expectedOwner });
       expect(mocks.fetchMcpAppView.mock.calls.at(-1)?.[0]).not.toHaveProperty("viewId");
+    },
+  );
+
+  it.each(["disabled", "no view", "aborted"])(
+    "releases runtime admission when reconstruction is %s",
+    async (outcome) => {
+      if (outcome === "disabled") {
+        mocks.acquireSessionMcpRuntime.mockResolvedValue({
+          runtime: { mcpAppsEnabled: false },
+          releaseLease: mocks.releaseLease,
+        });
+      } else if (outcome === "no view") {
+        mocks.fetchMcpAppView.mockResolvedValue(undefined);
+      } else {
+        mocks.fetchMcpAppView.mockRejectedValue(new DOMException("aborted", "AbortError"));
+      }
+      const restored = restoreFromMessages(
+        [
+          {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "call-1", name: "demo__show", args: {} }],
+          },
+          toolResult("mcp-app-abandoned", "call-1"),
+        ],
+        "mcp-app-abandoned",
+      );
+      if (outcome === "aborted") {
+        await expect(restored).rejects.toMatchObject({ name: "AbortError" });
+      } else {
+        await expect(restored).resolves.toBeUndefined();
+      }
+      expect(mocks.releaseLease).toHaveBeenCalledOnce();
     },
   );
 

--- a/src/gateway/mcp-app-reconstruction.ts
+++ b/src/gateway/mcp-app-reconstruction.ts
@@ -2,7 +2,10 @@ import { type CallToolResult, ContentBlockSchema } from "@modelcontextprotocol/s
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { BoardMcpAppDescriptor } from "../../packages/gateway-protocol/src/index.js";
-import { getOrCreateSessionMcpRuntime } from "../agents/agent-bundle-mcp-manager-api.js";
+import {
+  acquireSessionMcpRuntime,
+  releaseSessionMcpRuntime,
+} from "../agents/agent-bundle-mcp-manager-api.js";
 import type { SessionMcpRuntime } from "../agents/agent-bundle-mcp-types.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import {
@@ -271,34 +274,39 @@ async function reconstructMcpAppView(params: {
   if (!data) {
     return undefined;
   }
-  const runtime = await getOrCreateSessionMcpRuntime({
+  const acquisition = await acquireSessionMcpRuntime({
     sessionId,
     sessionKey: loaded.canonicalKey,
     workspaceDir: resolveAgentWorkspaceDir(params.cfg, agentId),
     agentDir: resolveAgentDir(params.cfg, agentId),
     cfg: params.cfg,
   });
-  if (runtime.mcpAppsEnabled !== true) {
-    return undefined;
+  const { runtime } = acquisition;
+  try {
+    if (runtime.mcpAppsEnabled !== true) {
+      return undefined;
+    }
+    const fetched = await fetchMcpAppView({
+      runtime,
+      agentId,
+      serverName: data.descriptor.serverName,
+      toolName: data.descriptor.toolName,
+      uiResourceUri: data.descriptor.uiResourceUri,
+      toolCallId: data.descriptor.toolCallId,
+      toolInput: data.toolInput,
+      toolResult: data.toolResult,
+      ...(params.viewId ? { viewId: params.viewId } : {}),
+      allowedAppToolNames: params.allowedAppToolNames,
+      ...(params.authorizeAppInteraction
+        ? { authorizeAppInteraction: params.authorizeAppInteraction }
+        : {}),
+      ...(params.readOnly ? { readOnly: true as const } : {}),
+    });
+    const view = fetched ? getMcpAppViewLease(fetched.viewId, runtime) : undefined;
+    return view ? { runtime, view } : undefined;
+  } finally {
+    await releaseSessionMcpRuntime(acquisition);
   }
-  const fetched = await fetchMcpAppView({
-    runtime,
-    agentId,
-    serverName: data.descriptor.serverName,
-    toolName: data.descriptor.toolName,
-    uiResourceUri: data.descriptor.uiResourceUri,
-    toolCallId: data.descriptor.toolCallId,
-    toolInput: data.toolInput,
-    toolResult: data.toolResult,
-    ...(params.viewId ? { viewId: params.viewId } : {}),
-    allowedAppToolNames: params.allowedAppToolNames,
-    ...(params.authorizeAppInteraction
-      ? { authorizeAppInteraction: params.authorizeAppInteraction }
-      : {}),
-    ...(params.readOnly ? { readOnly: true as const } : {}),
-  });
-  const view = fetched ? getMcpAppViewLease(fetched.viewId, runtime) : undefined;
-  return view ? { runtime, view } : undefined;
 }
 
 async function restoreMcpAppViewOnce(params: {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -2716,11 +2716,9 @@ describe("gateway hot reload superseded tail recovery", () => {
   it("rearms detached stale-tail recovery against an already accepted config", async () => {
     vi.useFakeTimers();
     const requestRecoveryRestart = vi.fn(() => ({ status: "emitted" as const }));
-    const prepareRuntimeConfig = vi.fn(
-      async (): Promise<OpenClawConfig> => ({
-        logging: { level: "debug" },
-      }),
-    );
+    const prepareRuntimeConfig = vi.fn(async (): Promise<OpenClawConfig> => ({
+      logging: { level: "debug" },
+    }));
     const handlers = createReloadHandlersForTest(
       undefined,
       undefined,

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -309,7 +309,7 @@ const hoisted = vi.hoisted(() => ({
   ),
   refreshContextWindowCache: vi.fn(async (_cfg: OpenClawConfig) => {}),
   clearCurrentProviderAuthState: vi.fn(() => {}),
-  disposeAllSessionMcpRuntimes: vi.fn(async () => {}),
+  reloadSessionMcpRuntimes: vi.fn(async () => {}),
   buildGatewayCronService: vi.fn((_params?: { env?: NodeJS.ProcessEnv }) => ({
     cron: { start: vi.fn(async () => {}), stop: vi.fn() },
     storePath: "/tmp/rebuilt-cron.json",
@@ -439,7 +439,7 @@ vi.mock("../agents/model-provider-auth.js", () => ({
 }));
 
 vi.mock("../agents/agent-bundle-mcp-tools.js", () => ({
-  disposeAllSessionMcpRuntimes: hoisted.disposeAllSessionMcpRuntimes,
+  reloadSessionMcpRuntimes: hoisted.reloadSessionMcpRuntimes,
 }));
 
 vi.mock("../plugins/installed-plugin-index-records.js", () => ({
@@ -963,8 +963,8 @@ afterEach(() => {
   hoisted.refreshPreparedModelRuntimeSnapshots.mockClear();
   hoisted.refreshContextWindowCache.mockClear();
   hoisted.clearCurrentProviderAuthState.mockClear();
-  hoisted.disposeAllSessionMcpRuntimes.mockClear();
-  hoisted.disposeAllSessionMcpRuntimes.mockResolvedValue(undefined);
+  hoisted.reloadSessionMcpRuntimes.mockClear();
+  hoisted.reloadSessionMcpRuntimes.mockResolvedValue(undefined);
   hoisted.buildGatewayCronService.mockClear();
   clearSecretsRuntimeSnapshot();
   clearRuntimeConfigSnapshot();
@@ -2131,7 +2131,7 @@ describe("gateway hot reload model state", () => {
     expect(cron.stop).not.toHaveBeenCalled();
     expect(channels.start).not.toHaveBeenCalled();
     expect(channels.stop).not.toHaveBeenCalled();
-    expect(hoisted.disposeAllSessionMcpRuntimes).not.toHaveBeenCalled();
+    expect(hoisted.reloadSessionMcpRuntimes).not.toHaveBeenCalled();
     expect(logReload.info).toHaveBeenCalledWith(`config hot reload applied (${changedPath})`);
   });
 
@@ -2521,9 +2521,9 @@ describe("gateway hot reload model state", () => {
     });
   });
 
-  it("disposes cached MCP runtimes on MCP config hot reloads", async () => {
+  it("reconciles cached MCP owners on MCP config hot reloads", async () => {
     const logReload = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-    hoisted.disposeAllSessionMcpRuntimes.mockRejectedValueOnce(new Error("dispose failed"));
+    hoisted.reloadSessionMcpRuntimes.mockRejectedValueOnce(new Error("dispose failed"));
     const { applyHotReload, setState } = createReloadHandlersForTest(
       logReload,
       undefined,
@@ -2541,7 +2541,7 @@ describe("gateway hot reload model state", () => {
       nextConfig,
     );
 
-    expect(hoisted.disposeAllSessionMcpRuntimes).toHaveBeenCalledTimes(1);
+    expect(hoisted.reloadSessionMcpRuntimes).toHaveBeenCalledTimes(1);
     expect(setState).toHaveBeenCalledOnce();
     expect(logReload.warn).toHaveBeenCalledWith(
       "bundle-mcp runtime disposal during config reload failed: Error: dispose failed",
@@ -2716,9 +2716,11 @@ describe("gateway hot reload superseded tail recovery", () => {
   it("rearms detached stale-tail recovery against an already accepted config", async () => {
     vi.useFakeTimers();
     const requestRecoveryRestart = vi.fn(() => ({ status: "emitted" as const }));
-    const prepareRuntimeConfig = vi.fn(async (): Promise<OpenClawConfig> => ({
-      logging: { level: "debug" },
-    }));
+    const prepareRuntimeConfig = vi.fn(
+      async (): Promise<OpenClawConfig> => ({
+        logging: { level: "debug" },
+      }),
+    );
     const handlers = createReloadHandlersForTest(
       undefined,
       undefined,
@@ -2880,7 +2882,7 @@ describe("gateway hot reload superseded tail recovery", () => {
         throw new Error("gmail tail failed");
       });
       if (surface === "mcp") {
-        hoisted.disposeAllSessionMcpRuntimes.mockImplementationOnce(async () => {
+        hoisted.reloadSessionMcpRuntimes.mockImplementationOnce(async () => {
           entered.resolve();
           await release.promise;
         });

--- a/src/gateway/server-reload-hot.ts
+++ b/src/gateway/server-reload-hot.ts
@@ -1,4 +1,4 @@
-import { disposeAllSessionMcpRuntimes } from "../agents/agent-bundle-mcp-tools.js";
+import { reloadSessionMcpRuntimes } from "../agents/agent-bundle-mcp-tools.js";
 import { tryResolveConfiguredAgentWorkspaceDir } from "../agents/agent-scope-config.js";
 import { refreshContextWindowCache } from "../agents/context.js";
 import {
@@ -543,7 +543,12 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
 
     if (plan.disposeMcpRuntimes) {
       await disposeMcpRuntimesWithTimeout({
-        dispose: disposeAllSessionMcpRuntimes,
+        dispose: () =>
+          reloadSessionMcpRuntimes({
+            cfg: nextConfig,
+            manifestRegistry: params.getPluginMetadataSnapshot?.()?.manifestRegistry,
+            reloadPlugins: plan.reloadPlugins,
+          }),
         timeoutMs: MCP_RUNTIME_RELOAD_DISPOSE_TIMEOUT_MS,
         onWarn: params.logReload.warn,
         label: "bundle-mcp runtime disposal during config reload",

--- a/src/gateway/server.mcp-request-shutdown.test.ts
+++ b/src/gateway/server.mcp-request-shutdown.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import type { WebSocket } from "ws";
-import { getOrCreateSessionMcpRuntime } from "../agents/agent-bundle-mcp-tools.js";
+import { getOrCreateSessionMcpRuntime } from "../agents/agent-bundle-mcp-manager.test-support.js";
 import type { SessionMcpRuntime } from "../agents/agent-bundle-mcp-types.js";
 import { fetchMcpAppView } from "../agents/mcp-ui-resource.js";
 import { resolveStateDir } from "../config/paths.js";

--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -7,10 +7,8 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import type { Frame } from "playwright";
 import { expect, inject, it } from "vitest";
-import {
-  disposeAllSessionMcpRuntimes,
-  getOrCreateSessionMcpRuntime,
-} from "../../../src/agents/agent-bundle-mcp-manager-api.js";
+import { disposeAllSessionMcpRuntimes } from "../../../src/agents/agent-bundle-mcp-manager-api.js";
+import { getOrCreateSessionMcpRuntime } from "../../../src/agents/agent-bundle-mcp-manager.test-support.js";
 import { materializeBundleMcpToolsForRun } from "../../../src/agents/agent-bundle-mcp-materialize.js";
 import { getMcpAppViewLease } from "../../../src/agents/mcp-ui-resource.js";
 import { readConfigFileSnapshotWithPluginMetadata } from "../../../src/config/config.js";


### PR DESCRIPTION
## What Problem This Solves

Changing one MCP server currently disconnects every session’s MCP servers, discarding healthy connections and cached catalogs. Operators can hot reload MCP settings, but unrelated running work still loses its tools.

## Why This Change Was Made

Move transport, catalog, and backoff ownership to individual servers. Configuration publication retires changed owners while unchanged servers survive across sessions and retained run views. One queue owns acquisition and teardown; every acquired runtime already holds its lease, closing the gap between asynchronous acquisition and tool materialization.

Explicit removal, disablement, credential changes, name reassignment, and plugin replacement still fence the affected owners immediately. Plugin provenance stays with its transport through ownership transfer, so an identical explicit definition cannot keep a retired plugin process alive. Requester sign-in callbacks retain their existing per-message lifetime; public-origin changes invalidate stale redirect callbacks and catalog entries.

## User Impact

An unchanged MCP tool can finish a call during reload and remain callable later in that same admitted run. Healthy sibling tools still materialize when another server is revoked. Changes take effect without restarting the Gateway or unrelated MCP processes.

No configuration keys, persistence schemas, dependencies, or protocol versions change. The internal unleased getter path is replaced throughout embedded, native CLI, and MCP App reconstruction callers. Production changes total **+1093 / −1109 (net −16 LOC)**; tests and support total **+1393 / −132**.

## Evidence

- Independent complete integration reviews against pinned parents `4b9954e37d7017e7921ff81dc2c9bd4f091d6064` and final rebase parent `66fa0bd2be4f811a6c6dbee8bd5dd102dae8e544`: scoped clean through P2. The formatter-only and final type/test integration follow-ups were independently reviewed as well.
- Thirteen focused owner, acquisition, requester, native CLI, embedded materialization, App reconstruction, and Gateway reload suites: **960 passed**.
- Fail-before reproductions cover healthy transport replacement, retained-run routing, atomic lease admission, requester/session teardown ordering, crossed publications, plugin provenance, and stale sign-in/catalog publication. The original execution orders are preserved in the regressions.
- Full changed-scope formatting/type/lint/ownership guards passed, including all core/test types and three dead-export scans. A fresh frozen dependency install and complete local build passed.
- Rebased onto `66fa0bd2be4f811a6c6dbee8bd5dd102dae8e544` after an actual conflict in test imports. All 18 changed production files are byte-identical to the fully checked and built `9223086c9d1748b13190b8b4e33d791185a93b2d`. After rebase, all **112 MCP runtime tests** and the real Chromium/Gateway MCP App conformance case passed; fixture teardown recorded no cleanup failures.
- Exact-source **Crabbox live proof passed** on `e779a98bf85360416732d17dbd6618cd9e708f80` in [the retained Testbox run](https://github.com/openclaw/openclaw/actions/runs/33930523828). Six scenarios used the built Gateway, real stdio MCP transports, authenticated `config.patch` and tool APIs, and two independent sessions: change one server, disable it, remove it, change public origin, and replace plugin-owned servers despite byte-identical explicit shadowing. Healthy server PIDs and cached catalog counts stayed fixed. A held call finished across reload, and the same admitted tool worked again afterward. Changed owners exited before rediscovery. Gateway PID/boot ID remained fixed with one operator hello and zero socket closes. All ten MCP subprocesses and the Gateway exited during cleanup; the lease was then stopped.
- The source receiver verified every file/mode/symlink against tree `b96a203777a1ffa4dafb316d83cef400ba3a3f67`; the supported initial `GIT_COMMIT` build stamp matched the candidate SHA. Source/carrier identity was checked again after the probe. Receipt, provenance, and sanitized Gateway logs were retained. Two probe-only retries corrected `config.patch` replacement paths and artifact destination handling; neither required a product change. The final command exited **0**.
- CI exposed a new upstream shutdown test still importing the removed getter and a type-only import cycle. The follow-up moves the unchanged type into its existing type module and migrates that test to the passive test adapter. Both failed type stripes, the real Gateway shutdown regression, typed lint, and the Madge check now pass locally; independent P0–P2 review is clean. All four affected production modules emit identical JavaScript ASTs to the live-tested parent (only erased types and import formatting differ). Exact-head [CI run 33933560752](https://github.com/openclaw/openclaw/actions/runs/33933560752) is **green** on `ae79ca3a9469ac5324e7b8655f5a0376705ee4d9`: 120 successful jobs and 13 intentional skips. One unrelated external-session author-link UI assertion failed on the first attempt, passed its focused two-viewer replay, and passed the single requested failed-job rerun without a source change.

The remote proof uses the real built Gateway, authenticated operator/config/tool APIs, and real local MCP server transports with synthetic data. It does not make a live model-provider request.

ClawSweeper follow-through: directly inspected `@modelcontextprotocol/sdk@1.30.0` cancellation and teardown in `dist/esm/shared/protocol.js:248–269,671–691`, `client/stdio.js:143–180`, and `client/streamableHttp.js:281–288,433–461`. Request cancellation rejects immediately; transport closure rejects remaining responses. HTTP session termination is separate from local transport closure. OpenClaw retains its existing bounded `disposeMcpClient` sequence (HTTP termination, transport/client close, forced stdio cleanup) while the server owner records retirement and aborts its request signal synchronously before awaiting cleanup. The live test independently verified process exit. Native Codex publication/reuse was also checked directly in `codex-rs/core/src/session/mcp_runtime.rs:299–333` and `codex-rs/codex-mcp/src/runtime.rs:260–328`.

Compatibility review: **zero keys/defaults/formats added or removed**. Existing MCP reloads now retire affected owners; `gateway.publicOrigin` uses the existing MCP reload action to revoke stale callback URLs. Established unchanged transports survive; per-message connection/authorization callbacks refresh on the next turn under their existing lease. No storage migration, protocol change, or new operator action is required.
