### PR TITLE
fix: recover stale Windows owners when exited PIDs return EPERM

### DIFF
--- a/src/infra/windows-process-start.test.ts
+++ b/src/infra/windows-process-start.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getWindowsPowerShellExePath, getWindowsWmicExePath } from "./windows-install-roots.js";
-import { readWindowsProcessStartTimeSync } from "./windows-process-start.js";
+import {
+  isWindowsProcessDefinitelyAbsentSync,
+  readWindowsProcessStartTimeSync,
+} from "./windows-process-start.js";
 
 const spawnSyncMock = vi.hoisted(() => vi.fn());
 
@@ -135,5 +138,77 @@ describe("readWindowsProcessStartTimeSync", () => {
 
     expect(readWindowsProcessStartTimeSync(789, 1000)).toBeNull();
     expect(readWindowsProcessStartTimeSync(0, 1000)).toBeNull();
+  });
+});
+
+describe("isWindowsProcessDefinitelyAbsentSync", () => {
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+  });
+
+  it("returns true only for an exact successful zero-row result", () => {
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: "COUNT=0" } as never);
+    expect(isWindowsProcessDefinitelyAbsentSync(123)).toBe(true);
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      getWindowsPowerShellExePath(),
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        expect.stringMatching(
+          /\$rows = @\(Get-CimInstance Win32_Process -Filter "ProcessId = 123" -ErrorAction Stop\); \[Console\]::Out\.Write\("COUNT=\$\(\$rows\.Count\)"\)/,
+        ),
+      ],
+      expect.objectContaining({
+        encoding: "utf8",
+        timeout: 2000,
+        windowsHide: true,
+      }),
+    );
+  });
+
+  it("projects the supplied native context into the enumeration query", () => {
+    const env = {
+      SYSTEMROOT: "D:\\Native",
+      SystemRoot: "E:\\Ignored",
+      NODE_OPTIONS: "--synthetic-injection-must-not-be-inherited",
+    };
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: "COUNT=0" });
+
+    expect(isWindowsProcessDefinitelyAbsentSync(123, 2000, env)).toBe(true);
+    expect(spawnSyncMock.mock.calls[0]?.[0]).toBe(
+      "D:\\Native\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+    expect(spawnSyncMock.mock.calls[0]?.[2]).toMatchObject({
+      env: { SYSTEMROOT: "D:\\Native" },
+      timeout: 2000,
+    });
+    expect(spawnSyncMock.mock.calls[0]?.[2].env.SystemRoot).toBeUndefined();
+    expect(spawnSyncMock.mock.calls[0]?.[2].env.NODE_OPTIONS).toBeUndefined();
+    expect(env.SystemRoot).toBe("E:\\Ignored");
+    expect(env.NODE_OPTIONS).toBe("--synthetic-injection-must-not-be-inherited");
+  });
+
+  it.each([
+    { label: "provider failure", result: { status: 1, stdout: "" } },
+    { label: "spawn failure", result: { error: new Error("spawn failed"), status: null } },
+    { label: "active process", result: { status: 0, stdout: "COUNT=1" } },
+    { label: "malformed output", result: { status: 0, stdout: "not-count" } },
+    { label: "multiple rows", result: { status: 0, stdout: "COUNT=2" } },
+    { label: "extra output", result: { status: 0, stdout: "COUNT=0\nwarning" } },
+    { label: "whitespace stderr", result: { status: 0, stdout: "COUNT=0", stderr: "\n" } },
+    { label: "trailing newline stdout", result: { status: 0, stdout: "COUNT=0\n" } },
+    { label: "leading whitespace stdout", result: { status: 0, stdout: " COUNT=0" } },
+    { label: "stderr only", result: { status: 0, stdout: "", stderr: "warning" } },
+    { label: "stderr with zero rows", result: { status: 0, stdout: "COUNT=0", stderr: "warning" } },
+  ])("stays fail-closed for $label", ({ result }) => {
+    spawnSyncMock.mockReturnValue(result as never);
+    expect(isWindowsProcessDefinitelyAbsentSync(123)).toBe(false);
+  });
+
+  it("rejects invalid PIDs without spawning PowerShell", () => {
+    expect(isWindowsProcessDefinitelyAbsentSync(0)).toBe(false);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
   });
 });

--- a/src/infra/windows-process-start.ts
+++ b/src/infra/windows-process-start.ts
@@ -5,6 +5,7 @@ import { resolveDiagnosticProcessEnv, resolveEnvironmentValue } from "./process-
 
 const DEFAULT_TIMEOUT_MS = 5_000;
 const DEFAULT_PROCESS_START_TIMEOUT_MS = 10_000;
+const DEFAULT_PROCESS_ENUMERATION_TIMEOUT_MS = 2_000;
 const DEFAULT_WINDOWS_SYSTEM_ROOT = "C:\\Windows";
 
 function windowsSystemRoot(env: NodeJS.ProcessEnv): string {
@@ -75,6 +76,43 @@ function parseWindowsProcessStartTime(raw: Buffer | string): number | null {
   );
   const offsetMs = Number(offset) * 60_000 * (offsetSign === "+" ? 1 : -1);
   return localTimeMs - offsetMs;
+}
+
+/**
+ * Returns true only when a successful, diagnostic-free exact-PID CIM query
+ * proves the PID has no active process row. Query failures, timeouts, extra
+ * output, and live rows must all stay false: this predicate is the only
+ * Windows evidence allowed to revoke an EPERM lock owner, so it fails closed.
+ */
+export function isWindowsProcessDefinitelyAbsentSync(
+  pid: number,
+  timeoutMs = DEFAULT_PROCESS_ENUMERATION_TIMEOUT_MS,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  const powershell = spawnSync(
+    windowsPowerShellPath(env),
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `$rows = @(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction Stop); [Console]::Out.Write("COUNT=$($rows.Count)")`,
+    ],
+    {
+      env: resolveDiagnosticProcessEnv(env, "win32"),
+      encoding: "utf8",
+      timeout: Math.min(timeoutMs, DEFAULT_TIMEOUT_MS),
+      windowsHide: true,
+    },
+  );
+  return (
+    !powershell.error &&
+    powershell.status === 0 &&
+    decodeWindowsProcessOutput(powershell.stderr ?? "") === "" &&
+    decodeWindowsProcessOutput(powershell.stdout) === "COUNT=0"
+  );
 }
 
 /** Read a stable Windows process creation time for lock-owner identity checks. */

--- a/src/shared/pid-alive.test.ts
+++ b/src/shared/pid-alive.test.ts
@@ -13,15 +13,20 @@ import {
 const readWindowsProcessStartTimeSyncMock = vi.hoisted(() =>
   vi.fn<(pid: number) => number | null>(() => null),
 );
+const isWindowsProcessDefinitelyAbsentSyncMock = vi.hoisted(() =>
+  vi.fn<(pid: number, timeoutMs?: number) => boolean>(() => false),
+);
 
 vi.mock("../infra/windows-process-start.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../infra/windows-process-start.js")>()),
   readWindowsProcessStartTimeSync: readWindowsProcessStartTimeSyncMock,
+  isWindowsProcessDefinitelyAbsentSync: isWindowsProcessDefinitelyAbsentSyncMock,
 }));
 
 afterEach(() => {
   vi.restoreAllMocks();
   readWindowsProcessStartTimeSyncMock.mockReset();
+  isWindowsProcessDefinitelyAbsentSyncMock.mockReset();
 });
 
 function mockProcReads(entries: Record<string, string>) {
@@ -117,6 +122,42 @@ describe("isPidDefinitelyDead", () => {
 
     expect(isPidDefinitelyDead(42)).toBe(false);
     expect(process["kill"]).toHaveBeenCalledWith(42, 0);
+  });
+
+  it("returns true for Windows EPERM when active enumeration has zero rows", async () => {
+    const error = Object.assign(new Error("permission denied"), { code: "EPERM" });
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw error;
+    });
+    isWindowsProcessDefinitelyAbsentSyncMock.mockReturnValue(true);
+
+    await withMockedPlatform("win32", async () => {
+      expect(isPidDefinitelyDead(42)).toBe(true);
+    });
+    expect(isWindowsProcessDefinitelyAbsentSyncMock).toHaveBeenCalledWith(42, 2000);
+  });
+
+  it("keeps an unproven Windows EPERM state fail-closed", async () => {
+    const error = Object.assign(new Error("permission denied"), { code: "EPERM" });
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw error;
+    });
+    isWindowsProcessDefinitelyAbsentSyncMock.mockReturnValue(false);
+
+    await withMockedPlatform("win32", async () => {
+      expect(isPidDefinitelyDead(42)).toBe(false);
+    });
+  });
+
+  it("does not use Windows enumeration for non-Windows EPERM", async () => {
+    const error = Object.assign(new Error("permission denied"), { code: "EPERM" });
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw error;
+    });
+    await withMockedPlatform("linux", async () => {
+      expect(isPidDefinitelyDead(42)).toBe(false);
+    });
+    expect(isWindowsProcessDefinitelyAbsentSyncMock).not.toHaveBeenCalled();
   });
 
   it("returns false for live non-zombie processes", async () => {

--- a/src/shared/pid-alive.ts
+++ b/src/shared/pid-alive.ts
@@ -2,9 +2,13 @@
 import childProcess from "node:child_process";
 import fsSync from "node:fs";
 import { resolveDiagnosticProcessEnv } from "../infra/process-env.ts";
-import { readWindowsProcessStartTimeSync } from "../infra/windows-process-start.ts";
+import {
+  isWindowsProcessDefinitelyAbsentSync,
+  readWindowsProcessStartTimeSync,
+} from "../infra/windows-process-start.ts";
 
 const PROCESS_START_TIMEOUT_MS = 1000;
+const WINDOWS_DEFINITE_DEATH_TIMEOUT_MS = 2_000;
 // Cache only a successful self read: this identity lasts for the process.
 // Failed reads must retry, and foreign PIDs must stay fresh to detect PID reuse.
 let selfStartTime: number | null = null;
@@ -40,9 +44,8 @@ export function isPidAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
   } catch (err) {
-    // EPERM means the PID exists but we cannot signal it. Treat that as a
-    // successful existence probe, then still apply the Linux zombie check.
-    // Keep parity with isPidDefinitelyDead (EPERM is not "definitely dead").
+    // EPERM conservatively means the PID may still exist. This predicate stays
+    // fail-open; isPidDefinitelyDead may perform a Windows-specific second probe.
     if ((err as NodeJS.ErrnoException).code !== "EPERM") {
       return false;
     }
@@ -58,7 +61,17 @@ export function isPidDefinitelyDead(pid: number): boolean {
   try {
     process.kill(pid, 0);
   } catch (err) {
-    return (err as NodeJS.ErrnoException).code === "ESRCH";
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") {
+      return true;
+    }
+    // Exited Windows PIDs can keep answering EPERM until the PID is reclaimed;
+    // only a proven zero-row CIM query may revoke such an owner. Query
+    // failures, timeouts, and live rows all stay fail-closed here.
+    if (code === "EPERM" && process.platform === "win32") {
+      return isWindowsProcessDefinitelyAbsentSync(pid, WINDOWS_DEFINITE_DEATH_TIMEOUT_MS);
+    }
+    return false;
   }
   return isZombieProcess(pid);
 }


### PR DESCRIPTION
Closes #138686

## What Problem This Solves

Fixes an issue where Windows users cannot recover a stale lock or database lease after its owner has exited, because a signal-zero probe can still return `EPERM` for that PID.

I hit this during Gateway recovery: two terminated owners continued to look alive to OpenClaw even though `Win32_Process` had no row for either PID. A live elevated Gateway also returned `EPERM`, so treating that error alone as proof of death would be unsafe.

## Why This Change Was Made

Keep `isPidAlive` conservative. Only the stronger `isPidDefinitelyDead` predicate performs a second check after Windows `EPERM`: a bounded, exact-PID CIM query must succeed with empty stderr and exactly `COUNT=0` before the owner is considered gone. A live row, failed query, timeout, malformed result, or additional output retains the owner.

The check lives beside the existing Windows process-identity reader and uses its absolute PowerShell path plus the restricted diagnostic environment. The creation-time reader cannot prove absence because it returns `null` for both a missing process and a failed query, so this uses a separate fail-closed absence predicate. No persisted-state, dependency, schema, or public API change is included.

## User Impact

Windows recovery can release an owner that is confirmed absent without treating a live permission-restricted process as dead. Existing PID-reuse checks, conservative liveness callers, successful signal-zero probes, and non-Windows behavior remain unchanged.

## Evidence

Affected-machine incident observations from the original reproduction:

| Owner | Signal-zero result | CIM rows | Baseline definitely dead | Patched definitely dead |
| --- | --- | ---: | --- | --- |
| Terminated Gateway, PID 13888 | `EPERM` | 0 | false | true |
| Terminated Gateway, PID 49028 | `EPERM` | 0 | false | true |
| Live elevated Gateway, PID 70188 | `EPERM` | 1 | false | false |

Current refresh against frozen upstream commit `8dde3559a5516073694517043cc81efed41737bf`:

- Both focused files passed through the repository wrapper: **53/53 tests** in `src/shared/pid-alive.test.ts` and `src/infra/windows-process-start.test.ts`.
- The new positive regression test was copied onto the pre-fix source and failed for the intended assertion (`expected false to be true`); the same test passes with this patch.
- Targeted Oxfmt, OXLint, affected core TypeScript lanes, and `git diff --check` passed.
- A fresh native Windows probe observed `COUNT=0` for an exited child, `COUNT=1` for a live child, and `COUNT=1` for a protected SYSTEM PID whose signal-zero probe returned `EPERM`. A deliberately broken CIM query remained fail-closed.
- Repository `autoreview` completed `scoped-clean` for P0-P2 with no actionable findings. It specifically reviewed fail-closed parsing, process races, environment isolation, command construction, and timeout behavior.
- Upstream `main` advanced after the frozen base, but none of the four affected files changed and no equivalent absence helper was added, so the reviewed patch was not rebased solely for unrelated movement.

Broader local lanes had environment/setup limitations: one checkpoint suite hit an existing temp-path `EPERM` under a Chinese Windows user, the sparse checkout omitted app JSON needed by a full source type lane, and one handoff suite expects a sealed runtime. These are not reported as passes.

Hosted CI run [34155135961](https://github.com/openclaw/openclaw/actions/runs/34155135961) completed against exact head `005b3c43f42c67eba2b4e45d4a600d80fdba18ab`. Both Windows Node test shards, build artifacts, production/test type checks, and the relevant lint/type lanes passed. The run is red for two underlying failures outside this four-file patch:

- `check-lint-core-4` reports `ui/src/components/markdown.test.ts` over the 1,000-line limit. Current `main` run [34154404744](https://github.com/openclaw/openclaw/actions/runs/34154404744) has the identical file, line, count, and rule failure.
- `checks-node-compact-large-12` has one timing/cleanup assertion failure in untouched `src/agents/subagents/spawn/acp-spawn.authority.test.ts`; that shard otherwise reports 3,154 passed and 2 skipped tests.

The final `openclaw/ci-gate` failure is the aggregate result of those lanes, not a third underlying failure. I did not rerun the workflow or add unrelated fixes to this patch.

The exact OS-level reason an exited PID can continue returning `EPERM` is still unproven. Microsoft documents that `Win32_Process.ProcessId` values can be reused, so the successful zero-row query is bounded absence evidence rather than an atomic owner-identity guarantee; the existing identity checks remain necessary. Explicit provider errors are rejected, while silent omission of a live row remains the platform assumption a Windows maintainer should judge. The live elevated-owner control was visible to CIM.

Maintainer edits are enabled.
