### PR TITLE
fix(channels): keep sibling IRC accounts connected during reloads

### DIFF
--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -65,6 +65,18 @@ IRC does not provide a replayable delivery ID or resend messages missed by a dis
 
 Named accounts inherit the channel-wide reply mode; override it with `channels.irc.accounts.<id>.replyToMode`.
 
+In the default `hybrid` reload mode, adding or editing a non-default named account
+restarts only that IRC account. Other account connections and the Gateway stay
+running, and manually stopped accounts stay stopped. Shared IRC settings,
+`accounts.default`, and account removal restart the whole IRC channel because
+they can affect inheritance or account selection.
+
+An account restart finishes accepted message admissions before closing its
+ingress queue; the replacement monitor recovers pending channel messages from
+that same queue. Messages missed while disconnected cannot be recovered, and
+pending DMs from an earlier connection are discarded because IRC nicknames can
+change owners.
+
 ## Outbound text
 
 IRC sends Markdown as plain text, preserving code contents and link destinations.

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -285,6 +285,16 @@ fields, `accounts.default`, removed or unresolvable accounts, and mixed changes
 that can affect inheritance are promoted to a whole-channel restart. Plugins
 that do not opt in always use the whole-channel path.
 
+The Gateway retains the admitted account's `cfg`, resolved `account`, and owning
+`stopAccount` hook through teardown, including failed-stop retries. Cleanup must
+use that context even when the published config removes the account or a new
+plugin registration replaces it.
+
+Account-count-dependent policy needs whole-channel reloads. For example, Telegram
+changes how an empty account `groups` map inherits defaults between single- and
+multi-account configurations. Synology Chat also validates inherited and duplicate
+webhook paths across accounts. These plugins do not opt into account-only reloads.
+
 For channels using the durable ingress drain, the account monitor's stop path
 must first settle all accepted transport admissions, then dispose and await its
 drain. Starting the account opens the same account-keyed queue, whose initial

--- a/extensions/irc/src/channel.test.ts
+++ b/extensions/irc/src/channel.test.ts
@@ -2,6 +2,39 @@
 import { describe, expect, it } from "vitest";
 import { ircPlugin } from "./channel.js";
 import { ircOutboundBaseAdapter } from "./outbound-base.js";
+import type { CoreConfig } from "./types.js";
+
+describe("IRC named-account reload contract", () => {
+  it("keeps sibling account resolution unchanged across named-account additions and edits", () => {
+    const cfg: CoreConfig = {
+      channels: {
+        irc: {
+          host: "irc.example.com",
+          nick: "default-bot",
+          channels: ["#shared"],
+          nickserv: { service: "NickServ", enabled: false },
+          accounts: { alpha: { nick: "alpha-bot", channels: ["#alpha"] } },
+        },
+      },
+    };
+    const original = ["default", "alpha"].map((id) => ircPlugin.config.resolveAccount(cfg, id));
+    for (const beta of [
+      { nick: "beta-bot", channels: ["#beta"] },
+      { nick: "beta-next", channels: ["#next"], nickserv: { enabled: true } },
+    ]) {
+      const next: CoreConfig = {
+        channels: {
+          irc: { ...cfg.channels?.irc, accounts: { ...cfg.channels?.irc?.accounts, beta } },
+        },
+      };
+      expect(["default", "alpha"].map((id) => ircPlugin.config.resolveAccount(next, id))).toEqual(
+        original,
+      );
+      expect(ircPlugin.config.resolveAccount(next, "beta").nick).toBe(beta.nick);
+    }
+    expect(ircPlugin.reload).toMatchObject({ accountScopedRestart: true });
+  });
+});
 
 describe("irc outbound chunking", () => {
   it("chunks outbound text without requiring IRC runtime initialization", () => {

--- a/extensions/irc/src/channel.ts
+++ b/extensions/irc/src/channel.ts
@@ -183,7 +183,7 @@ export const ircPlugin: ChannelPlugin<ResolvedIrcAccount, IrcProbe> = createChat
       media: true,
       blockStreaming: true,
     },
-    reload: { configPrefixes: ["channels.irc"] },
+    reload: { configPrefixes: ["channels.irc"], accountScopedRestart: true },
     configSchema: IrcChannelConfigSchema,
     config: {
       ...ircConfigAdapter,

--- a/extensions/irc/src/monitor.test.ts
+++ b/extensions/irc/src/monitor.test.ts
@@ -42,18 +42,22 @@ type ReconnectingReplyIrcServer = {
 
 type IrcIngressQueue = NonNullable<Parameters<typeof createIrcIngressMonitor>[0]["queue"]>;
 type IrcIngressPayload = Parameters<IrcIngressQueue["enqueue"]>[1];
+type IrcMonitorMessageHandler = NonNullable<Parameters<typeof monitorIrcProvider>[0]["onMessage"]>;
 
-async function withIngressQueue<T>(fn: (queue: IrcIngressQueue) => Promise<T>): Promise<T> {
+async function withIngressQueue<T>(
+  fn: (queue: IrcIngressQueue, stateDir: string) => Promise<T>,
+  accountId = "default",
+): Promise<T> {
   const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-irc-monitor-"));
   const stateDir = await fs.realpath(created);
   const queue = createChannelIngressQueueForTests<IrcIngressPayload>({
     channelId: "irc",
-    accountId: "default",
+    accountId,
     stateDir,
   });
   const complete = queue.complete.bind(queue);
   try {
-    return await fn(queue);
+    return await fn(queue, stateDir);
   } finally {
     queue.complete = complete;
     closeOpenClawStateDatabaseForTest();
@@ -255,6 +259,105 @@ describe("IRC configured-unavailable credential connection boundaries", () => {
 });
 
 describe("irc monitor reconnect", () => {
+  it("settles only the stopped account's admission and recovers its durable message on a fresh socket", async () => {
+    installMonitorRuntime();
+    await withIngressQueue(async (alphaQueue, stateDir) => {
+      const betaQueue = createChannelIngressQueueForTests<IrcIngressPayload>({
+        channelId: "irc",
+        accountId: "beta",
+        stateDir,
+      });
+      const sockets = new Map<string, net.Socket>();
+      let connections = 0;
+      const server = await startIrcTestServer((socket) => {
+        connections += 1;
+        let nick = "";
+        onIrcTestLine(socket, (line) => {
+          if (line.startsWith("NICK ")) {
+            nick = line.slice(5);
+            sockets.set(nick, socket);
+          }
+          if (line.startsWith("USER ")) {
+            socket.write(`:server 001 ${nick} :welcome\r\n`);
+          }
+        });
+      });
+      const config: CoreConfig = {
+        channels: {
+          irc: {
+            host: "127.0.0.1",
+            port: server.port,
+            tls: false,
+            accounts: { alpha: { nick: "qa-alpha" }, beta: { nick: "qa-beta" } },
+          },
+        },
+      };
+      const alphaDispatch = vi.fn<IrcMonitorMessageHandler>();
+      const betaDispatch = vi.fn<IrcMonitorMessageHandler>();
+      const freshDispatch = vi.fn<IrcMonitorMessageHandler>();
+      const stored = createDeferred<void>();
+      const releaseAdmission = createDeferred<void>();
+      const enqueue = alphaQueue.enqueue.bind(alphaQueue);
+      alphaQueue.enqueue = async (...args) => {
+        const result = await enqueue(...args);
+        stored.resolve();
+        await releaseAdmission.promise;
+        return result;
+      };
+      const monitors: Array<{ stop: () => Promise<void> }> = [];
+      const start = async (
+        accountId: string,
+        ingressQueue: IrcIngressQueue,
+        onMessage: IrcMonitorMessageHandler,
+      ) => {
+        const monitor = await monitorIrcProvider({ accountId, config, ingressQueue, onMessage });
+        monitors.push(monitor);
+        return monitor;
+      };
+      try {
+        const alpha = await start("alpha", alphaQueue, alphaDispatch);
+        await start("beta", betaQueue, betaDispatch);
+        const betaSocket = sockets.get("qa-beta");
+        expect(betaSocket).toBeDefined();
+        sockets.get("qa-alpha")?.write(":alice!ident@example.org PRIVMSG #alpha :recover me\r\n");
+        await withTimeout(stored.promise, 3_000, "alpha durable admission");
+        let stopSettled = false;
+        const stopping = alpha.stop().then(() => {
+          stopSettled = true;
+        });
+        const betaCompleted = observeIngressCompletion(betaQueue);
+        betaSocket?.write(":bob!ident@example.org PRIVMSG #beta :sibling stays live\r\n");
+        await withTimeout(betaCompleted, 3_000, "beta delivery during alpha stop");
+        expect(stopSettled).toBe(false);
+        expect(betaDispatch).toHaveBeenCalledOnce();
+        expect(alphaDispatch).not.toHaveBeenCalled();
+
+        releaseAdmission.resolve();
+        await stopping;
+        alphaQueue.enqueue = enqueue;
+        const pending = await alphaQueue.listPending({ limit: "all" });
+        expect(pending).toHaveLength(1);
+        const recovered = observeIngressCompletion(alphaQueue);
+        await start("alpha", alphaQueue, freshDispatch);
+        expect(await withTimeout(recovered, 3_000, "alpha replay completion")).toBe(pending[0]?.id);
+        expect(freshDispatch).toHaveBeenCalledOnce();
+        expect(freshDispatch.mock.calls[0]?.[0]).toMatchObject({
+          text: "recover me",
+          target: "#alpha",
+        });
+        expect(await alphaQueue.listPending({ limit: "all" })).toEqual([]);
+        expect(sockets.get("qa-beta")).toBe(betaSocket);
+        expect(betaSocket?.destroyed).toBe(false);
+        expect(connections).toBe(3);
+      } finally {
+        releaseAdmission.resolve();
+        alphaQueue.enqueue = enqueue;
+        await Promise.all(monitors.map((monitor) => monitor.stop()));
+        await server.close();
+      }
+    }, "alpha");
+  });
+
   it("reconnects when an established IRC socket closes", async () => {
     await withIngressQueue(async (ingressQueue) => {
       installMonitorRuntime();

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -1022,6 +1022,114 @@ describe("server-channels auto restart", () => {
     });
   });
 
+  it.each(["changed", "removed", "plugin-replaced"] as const)(
+    "stops the admitted account after its configuration is %s without stopping a sibling",
+    async (change) => {
+      const originalConfig: OpenClawConfig = {
+        channels: { discord: { accounts: { alpha: { enabled: true }, beta: { enabled: true } } } },
+      };
+      let config = originalConfig;
+      const admitted = new Map<string, ChannelGatewayContext<TestAccount>>();
+      const stopAccount = vi.fn(async (_context: ChannelGatewayContext<TestAccount>) => {});
+      const replacementStop = vi.fn(async (_context: ChannelGatewayContext<TestAccount>) => {});
+      const plugin = createTestPlugin({
+        listAccountIds: (cfg) => Object.keys(cfg.channels?.discord?.accounts ?? {}),
+        resolveAccount: (cfg, id) => {
+          const account = cfg.channels?.discord?.accounts?.[id ?? DEFAULT_ACCOUNT_ID];
+          if (!account) {
+            throw new Error(`Account ${id} no longer exists`);
+          }
+          return account;
+        },
+        startAccount: async (context) => {
+          admitted.set(context.accountId, context);
+          await new Promise<void>((resolve) => {
+            context.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        },
+        stopAccount,
+      });
+      installTestRegistry(plugin);
+      const manager = createManager({ getRuntimeConfig: () => config });
+      await manager.startChannels();
+      await flushMicrotasks();
+      expect(admitted.size).toBe(2);
+
+      config = {
+        channels: {
+          discord: {
+            accounts: {
+              ...(change === "removed" ? {} : { alpha: { enabled: false } }),
+              beta: { enabled: true },
+            },
+          },
+        },
+      };
+      if (change === "plugin-replaced") {
+        installTestRegistry({
+          ...plugin,
+          gateway: { ...plugin.gateway, stopAccount: replacementStop },
+        });
+      }
+      await expect(
+        manager.stopChannel("discord", "alpha", { manual: false }),
+      ).resolves.toBeUndefined();
+      expect(stopAccount).toHaveBeenCalledOnce();
+      expect(stopAccount.mock.calls[0]?.[0].cfg).toBe(originalConfig);
+      expect(stopAccount.mock.calls[0]?.[0].account).toBe(admitted.get("alpha")?.account);
+      expect(replacementStop).not.toHaveBeenCalled();
+      expect(admitted.get("alpha")?.abortSignal.aborted).toBe(true);
+      expect(admitted.get("beta")?.abortSignal.aborted).toBe(false);
+      expect(manager.getRuntimeSnapshot().channelAccounts.discord?.beta?.running).toBe(true);
+    },
+  );
+
+  it("retains the admitted teardown owner for a failed stop retry after account removal", async () => {
+    const originalConfig: OpenClawConfig = {
+      channels: { discord: { accounts: { alpha: { enabled: true } } } },
+    };
+    let config = originalConfig;
+    let stopFails = true;
+    const stopAccount = vi.fn(async (_context: ChannelGatewayContext<TestAccount>) => {
+      if (stopFails) {
+        throw new Error("first stop failed");
+      }
+    });
+    installTestRegistry(
+      createTestPlugin({
+        listAccountIds: (cfg) => Object.keys(cfg.channels?.discord?.accounts ?? {}),
+        resolveAccount: (cfg, id) => {
+          const account = cfg.channels?.discord?.accounts?.[id ?? DEFAULT_ACCOUNT_ID];
+          if (!account) {
+            throw new Error(`Account ${id} no longer exists`);
+          }
+          return account;
+        },
+        startAccount: async ({ abortSignal }) =>
+          await new Promise<void>((resolve) => {
+            abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          }),
+        stopAccount,
+      }),
+    );
+    const manager = createManager({ getRuntimeConfig: () => config });
+    await manager.startChannels();
+    await flushMicrotasks();
+    await expect(manager.stopChannel("discord", "alpha", { manual: false })).rejects.toThrow(
+      "first stop failed",
+    );
+    config = { channels: { discord: { accounts: {} } } };
+    stopFails = false;
+    await expect(
+      manager.stopChannel("discord", "alpha", { manual: false }),
+    ).resolves.toBeUndefined();
+    expect(stopAccount).toHaveBeenCalledTimes(2);
+    expect(stopAccount.mock.calls[1]?.[0].cfg).toBe(originalConfig);
+    expect(stopAccount.mock.calls[1]?.[0].account).toBe(
+      originalConfig.channels?.discord?.accounts?.alpha,
+    );
+  });
+
   it("serializes overlapping stops until the last teardown settles", async () => {
     const releaseTask = createDeferred();
     const stopHooks = [createDeferred(), createDeferred()];

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -10,7 +10,12 @@ import {
   getLoadedChannelPluginEntryById,
   listLoadedChannelPluginsForRegistry,
 } from "../channels/plugins/registry-loaded.js";
-import type { ChannelAccountSnapshot, ChannelId } from "../channels/plugins/types.public.js";
+import type { ChannelGatewayContext } from "../channels/plugins/types.adapters.js";
+import type {
+  ChannelAccountSnapshot,
+  ChannelId,
+  ChannelPlugin,
+} from "../channels/plugins/types.public.js";
 import {
   applyChannelAccountState,
   resolveChannelAccountState,
@@ -80,9 +85,17 @@ function waitForChannelStartupHandoff(): Promise<void> {
   });
 }
 
+type ChannelAccountLifetime = {
+  abort: AbortController;
+  capabilityLease: PluginRuntimeCapabilityLease;
+  teardown?: {
+    context: Omit<ChannelGatewayContext, "setStatus">;
+    run: NonNullable<NonNullable<ChannelPlugin["gateway"]>["stopAccount"]>;
+  };
+};
+
 type ChannelRuntimeStore = {
-  aborts: Map<string, AbortController>;
-  capabilityLeases: Map<string, PluginRuntimeCapabilityLease>;
+  lifetimes: Map<string, ChannelAccountLifetime>;
   starting: Map<string, Promise<void>>;
   stops: Map<string, ChannelAccountStopState>;
   tasks: Map<string, Promise<unknown>>;
@@ -142,8 +155,7 @@ type GatewayStartupTrace = {
 
 function createRuntimeStore(): ChannelRuntimeStore {
   return {
-    aborts: new Map(),
-    capabilityLeases: new Map(),
+    lifetimes: new Map(),
     starting: new Map(),
     stops: new Map(),
     tasks: new Map(),
@@ -457,6 +469,21 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     }
     return await resolveChannelRuntime?.();
   };
+  const createAccountContext = (
+    channelId: ChannelId,
+    accountId: string,
+    cfg: OpenClawConfig,
+    account: unknown,
+    abortSignal: AbortSignal,
+  ): Omit<ChannelGatewayContext, "setStatus"> => ({
+    cfg,
+    accountId,
+    account,
+    abortSignal,
+    runtime: ensureChannelRuntime(channelId),
+    log: ensureChannelLog(channelId),
+    getStatus: () => getRuntime(channelId, accountId),
+  });
   const measureStartup = async <T>(name: string, run: () => T | Promise<T>): Promise<T> => {
     return startupTrace ? startupTrace.measure(name, run) : await run();
   };
@@ -470,7 +497,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     for (const id of store.runtimes.keys()) {
       if (
         activeAccountIds.has(id) ||
-        store.aborts.has(id) ||
+        store.lifetimes.has(id) ||
         store.starting.has(id) ||
         store.stops.has(id) ||
         store.tasks.has(id)
@@ -595,9 +622,8 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 recoveryStopTimedOut.delete(rKey);
                 recoveryStartRequested.delete(rKey);
                 restarts.delete(rKey);
-                store.capabilityLeases.get(id)?.revoke();
-                store.capabilityLeases.delete(id);
-                store.aborts.delete(id);
+                store.lifetimes.get(id)?.capabilityLease.revoke();
+                store.lifetimes.delete(id);
                 store.tasks.delete(id);
                 clearedTimedOutRecoveryTask = true;
                 setRuntime(channelId, id, {
@@ -632,11 +658,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         // cannot race into duplicate provider boots for the same account.
         const abort = new AbortController();
         const capabilityLease = createPluginRuntimeCapabilityLease("channel account");
-        store.aborts.set(id, abort);
-        store.capabilityLeases.set(id, capabilityLease);
+        const lifetime: ChannelAccountLifetime = { abort, capabilityLease };
+        store.lifetimes.set(id, lifetime);
         let handedOffTask = false;
         const log = ensureChannelLog(channelId);
-        const runtime = ensureChannelRuntime(channelId);
         let scopedChannelRuntime: {
           channelRuntime?: PluginRuntimeChannel;
           dispose: () => void;
@@ -700,6 +725,13 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             return;
           }
           const account = plugin.config.resolveAccount(cfg, id);
+          const accountContext = createAccountContext(channelId, id, cfg, account, abort.signal);
+          if (plugin.gateway?.stopAccount) {
+            lifetime.teardown = {
+              context: accountContext,
+              run: plugin.gateway.stopAccount.bind(plugin.gateway),
+            };
+          }
           const described = plugin.config.describeAccount?.(account, cfg);
           const enabled = plugin.config.isEnabled
             ? plugin.config.isEnabled(account, cfg)
@@ -877,13 +909,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 try {
                   return withGatewayNativeApprovalRuntime(opts.getNativeApprovalRuntime?.(), () =>
                     startAccount({
-                      cfg,
-                      accountId: id,
-                      account,
-                      runtime,
-                      abortSignal: abort.signal,
-                      log,
-                      getStatus: () => getRuntime(channelId, id),
+                      ...accountContext,
                       setStatus: (next) =>
                         isCurrentTask()
                           ? setRuntimeFromTaskStatus(channelId, id, next, abort.signal)
@@ -909,15 +935,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             }
             await startAccountTask;
           });
-          const taskWithCapabilityCleanup = task.finally(() => {
-            capabilityLease.revoke();
-            if (store.capabilityLeases.get(id) === capabilityLease) {
-              store.capabilityLeases.delete(id);
-            }
-          });
           // Recovery can replace a timed-out task before the old promise settles.
           // Only the task that still owns the store slot may write lifecycle state.
-          const trackedPromise = taskWithCapabilityCleanup
+          const trackedPromise = task
+            .finally(() => capabilityLease.revoke())
             .then(() => {
               if (
                 abort.signal.aborted ||
@@ -993,12 +1014,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                     restartPending: false,
                     reconnectAttempts: 0,
                   });
-                  if (store.tasks.get(id) === trackedPromise) {
-                    store.tasks.delete(id);
-                  }
-                  if (store.aborts.get(id) === abort) {
-                    store.aborts.delete(id);
-                  }
+                  releaseTask();
                   return;
                 }
                 restarts.delete(rKey);
@@ -1008,16 +1024,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                   restartPending: true,
                   reconnectAttempts: 0,
                 });
-                if (store.tasks.get(id) === trackedPromise) {
-                  store.tasks.delete(id);
-                }
-                if (store.aborts.get(id) === abort) {
-                  store.aborts.delete(id);
-                }
-                // The settled task may have left background work racing on this
-                // signal. Abort before the replacement starts so two account
-                // instances can never share a live lifetime.
-                abort.abort();
+                releaseTask();
                 try {
                   await startChannelInternal(channelId, id, {
                     preserveManualStop: true,
@@ -1062,15 +1069,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 if (manuallyStopped.has(rKey) || opts.isClosing?.()) {
                   return;
                 }
-                if (store.tasks.get(id) === trackedPromise) {
-                  store.tasks.delete(id);
-                }
-                if (store.aborts.get(id) === abort) {
-                  store.aborts.delete(id);
-                }
-                // See the timed-out-stop restart above: never start the crash
-                // replacement while the predecessor's signal is unaborted.
-                abort.abort();
+                releaseTask();
                 await startChannelInternal(channelId, id, {
                   preserveRestartAttempts: true,
                   preserveManualStop: true,
@@ -1081,17 +1080,18 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 pendingAutoRestarts.delete(rKey);
               }
             })
-            .finally(() => {
-              if (store.tasks.get(id) === trackedPromise) {
-                store.tasks.delete(id);
-              }
-              if (store.aborts.get(id) === abort) {
-                store.aborts.delete(id);
-              }
-              // Terminal paths (give-up, terminal disconnect, manual stop) end
-              // here without a restart; leave no unaborted lifetime behind.
-              abort.abort();
-            });
+            .finally(releaseTask);
+          function releaseTask() {
+            if (store.tasks.get(id) === trackedPromise) {
+              store.tasks.delete(id);
+            }
+            // Failed or queued teardown retains the admitted context. Every terminal
+            // task still aborts before replacement so no predecessor keeps authority.
+            if (store.lifetimes.get(id) === lifetime && !store.stops.has(id)) {
+              store.lifetimes.delete(id);
+            }
+            abort.abort();
+          }
           function isCurrentTask() {
             return store.tasks.get(id) === trackedPromise;
           }
@@ -1109,13 +1109,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         } finally {
           if (!handedOffTask) {
             capabilityLease.revoke();
-            if (store.capabilityLeases.get(id) === capabilityLease) {
-              store.capabilityLeases.delete(id);
-            }
             await cleanupTaskScopedApprovalRuntime("channel startup cleanup failed");
           }
-          if (!handedOffTask && store.aborts.get(id) === abort) {
-            store.aborts.delete(id);
+          if (!handedOffTask && store.lifetimes.get(id) === lifetime && !store.stops.has(id)) {
+            store.lifetimes.delete(id);
           }
           if (store.starting.get(id) === startGate.promise) {
             store.starting.delete(id);
@@ -1147,7 +1144,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     const plugin = getLoadedChannelPluginEntryById(channelId, registry)?.plugin;
     const store = getStore(channelId);
     const lifecycleIds = new Set<string>([
-      ...store.aborts.keys(),
+      ...store.lifetimes.keys(),
       ...store.starting.keys(),
       ...store.stops.keys(),
       ...store.tasks.keys(),
@@ -1176,46 +1173,57 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         const runStopAttempt = async (
           previousOutcome: ChannelAccountStopOutcome,
         ): Promise<ChannelAccountStopOutcome> => {
-          const abort = store.aborts.get(id);
+          const lifetime = store.lifetimes.get(id);
+          const abort = lifetime?.abort;
           const task = store.tasks.get(id);
           if (!abort && !task && !plugin?.gateway?.stopAccount) {
             return previousOutcome;
           }
           abort?.abort();
           const log = ensureChannelLog(channelId);
-          const runtime = ensureChannelRuntime(channelId);
           let outcome: ChannelAccountStopOutcome = { status: "fulfilled" };
-          if (plugin?.gateway?.stopAccount) {
-            // The start task can settle before stopAccount. Shutdown routes need
-            // their own lease, bounded by this stop attempt rather than that task.
-            const capabilityLease = createPluginRuntimeCapabilityLease("channel account stop");
-            try {
-              const account = plugin.config.resolveAccount(cfg, id);
+          let capabilityLease: PluginRuntimeCapabilityLease | undefined;
+          try {
+            // Running and failed-stop accounts belong to their admitted plugin and config,
+            // even after publication removes the account or replaces its registration.
+            let teardown = lifetime?.teardown;
+            if (!lifetime && plugin?.gateway?.stopAccount) {
+              teardown = {
+                context: createAccountContext(
+                  channelId,
+                  id,
+                  cfg,
+                  plugin.config.resolveAccount(cfg, id),
+                  new AbortController().signal,
+                ),
+                run: plugin.gateway.stopAccount.bind(plugin.gateway),
+              };
+            }
+            if (teardown) {
+              const { context, run } = teardown;
+              // The start task can settle before stopAccount. Shutdown routes need
+              // their own lease, bounded by this stop attempt rather than that task.
+              capabilityLease = createPluginRuntimeCapabilityLease("channel account stop");
               // A plugin stopAccount that never settles must not wedge every
               // stop-driven flow (health monitor sweeps, thaw recovery, reload).
               // Bound it like the task teardown below; the timed-out path flows
               // into the existing recoveryStopTimedOut two-call restart contract.
               let stopAttemptAbandoned = false;
-              const runStopAccount = plugin.gateway.stopAccount.bind(plugin.gateway, {
-                cfg,
-                accountId: id,
-                account,
-                runtime,
-                abortSignal: abort?.signal ?? new AbortController().signal,
-                log,
-                getStatus: () => getRuntime(channelId, id),
-                setStatus: (next) => {
-                  // A stop we abandoned may settle after a replacement started;
-                  // its late writes must not repaint or tear down that account.
-                  setRuntime(
-                    channelId,
-                    id,
-                    stopAttemptAbandoned
-                      ? sanitizeAbortedTaskStatusPatch(next, getRuntime(channelId, id))
-                      : next,
-                  );
-                },
-              });
+              const runStopAccount = () =>
+                run({
+                  ...context,
+                  setStatus: (next) => {
+                    // A stop we abandoned may settle after a replacement started;
+                    // its late writes must not repaint or tear down that account.
+                    setRuntime(
+                      channelId,
+                      id,
+                      stopAttemptAbandoned
+                        ? sanitizeAbortedTaskStatusPatch(next, getRuntime(channelId, id))
+                        : next,
+                    );
+                  },
+                });
               const stopAccountAttempt = withPluginHttpRouteRegistry(
                 registry,
                 runStopAccount,
@@ -1240,12 +1248,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                   `[${id}] stopAccount exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms; continuing stop`,
                 );
               }
-            } catch (error) {
-              outcome = { status: "rejected", error };
-              log.warn?.(`[${id}] stopAccount failed: ${formatErrorMessage(error)}`);
-            } finally {
-              capabilityLease.revoke();
             }
+          } catch (error) {
+            outcome = { status: "rejected", error };
+            log.warn?.(`[${id}] stopAccount failed: ${formatErrorMessage(error)}`);
+          } finally {
+            capabilityLease?.revoke();
           }
           const stoppedCleanly = await waitForChannelStopGracefully(
             task,
@@ -1259,13 +1267,8 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           if (outcome.status === "rejected") {
             recoveryStopTimedOut.delete(rKey);
             recoveryStartRequested.delete(rKey);
-            if (stoppedCleanly) {
-              if (store.aborts.get(id) === abort) {
-                store.aborts.delete(id);
-              }
-              if (store.tasks.get(id) === task) {
-                store.tasks.delete(id);
-              }
+            if (stoppedCleanly && store.tasks.get(id) === task) {
+              store.tasks.delete(id);
             }
             setRuntime(channelId, id, {
               accountId: id,
@@ -1294,9 +1297,6 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           }
           recoveryStopTimedOut.delete(rKey);
           recoveryStartRequested.delete(rKey);
-          if (store.aborts.get(id) === abort) {
-            store.aborts.delete(id);
-          }
           if (store.tasks.get(id) === task) {
             store.tasks.delete(id);
           }
@@ -1321,6 +1321,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             store.stops.set(id, outcome);
           } else {
             store.stops.delete(id);
+            if (!store.tasks.has(id) && !store.starting.has(id)) {
+              store.lifetimes.delete(id);
+            }
           }
         }
         return outcome;

--- a/test/e2e/qa-lab/runtime/gateway-config-hot-reload-channels.ts
+++ b/test/e2e/qa-lab/runtime/gateway-config-hot-reload-channels.ts
@@ -19,6 +19,7 @@ import {
   waitForHotReloadFact,
   type HotReloadConnection,
 } from "./gateway-config-hot-reload-fixtures.js";
+import { proveHotReloadIrcAccounts } from "./gateway-config-hot-reload-irc.js";
 import { proveHotReloadChannelPolicy } from "./gateway-config-hot-reload-policy.js";
 
 const CHANNEL = "qa-channel";
@@ -328,6 +329,10 @@ export async function proveHotReloadChannels({
         );
         observations.push({ manuallyResumed: { inboundId: parkedMessage.id, reply: resumed } });
       }
+      const irc = await proveHotReloadIrcAccounts({ repoRoot, outputDir, appendLog });
+      evidence.push(...irc.evidence);
+      failures.push(...irc.failures);
+      observations.push(...irc.observations);
     },
     () => connection?.client.stopAndWait(),
     () => stopQaGatewayFixture(owner, { preserveToDir: path.join(outputDir, "channels-gateway") }),

--- a/test/e2e/qa-lab/runtime/gateway-config-hot-reload-irc.ts
+++ b/test/e2e/qa-lab/runtime/gateway-config-hot-reload-irc.ts
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import { createServer, type Socket } from "node:net";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { createQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
+import type { ChannelAccountSnapshot } from "../../../../src/channels/plugins/types.core.js";
+import { GatewayClientRequestError } from "../../../../src/gateway/client.js";
+import { runQaGatewayFixture, stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+import {
+  connectHotReloadClient,
+  waitForHotReloadFact,
+  type HotReloadConnection,
+} from "./gateway-config-hot-reload-fixtures.js";
+
+type Peer = { socket: Socket; nick: string; lines: string[]; sequence: number };
+
+export async function proveHotReloadIrcAccounts({
+  repoRoot,
+  outputDir,
+  appendLog,
+}: {
+  repoRoot: string;
+  outputDir: string;
+  appendLog: (text: string) => void;
+}) {
+  const owner = createQaGatewayChild();
+  const peers: Peer[] = [];
+  const evidence: Array<{ prefix: string; observation: string; bootId: string; pid: number }> = [];
+  const failures: Array<{ prefix: string; message: string }> = [];
+  const observations: Array<Record<string, unknown>> = [];
+  let connection: HotReloadConnection | undefined;
+  const server = createServer((socket) => {
+    const peer: Peer = { socket, nick: "", lines: [], sequence: peers.length + 1 };
+    peers.push(peer);
+    socket.setEncoding("utf8");
+    let buffer = "";
+    socket.on("data", (chunk: string) => {
+      buffer += chunk;
+      for (let end = buffer.indexOf("\n"); end !== -1; end = buffer.indexOf("\n")) {
+        const line = buffer.slice(0, end).replace(/\r$/, "");
+        buffer = buffer.slice(end + 1);
+        peer.lines.push(line);
+        if (line.startsWith("NICK ")) {
+          peer.nick = line.slice(5);
+        }
+        if (line.startsWith("USER ")) {
+          socket.write(`:qa-server 001 ${peer.nick} :welcome\r\n`);
+        }
+      }
+    });
+  });
+  await runQaGatewayFixture(
+    async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      assert(address && typeof address !== "string");
+      const gateway = await owner.start({
+        repoRoot,
+        useRepoCli: true,
+        command: {
+          executablePath: process.execPath,
+          argsPrefix: [path.join(repoRoot, "dist/index.js")],
+          cwd: repoRoot,
+          usePackagedPlugins: true,
+        },
+        enabledPluginIds: ["irc"],
+        providerMode: "mock-openai",
+        forcedRuntime: "openclaw",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        providerBaseUrl: "http://127.0.0.1:1/v1",
+        transportBaseUrl: "http://127.0.0.1:1",
+        controlUiEnabled: false,
+        mutateConfig: (cfg) => ({
+          ...cfg,
+          channels: {
+            ...cfg.channels,
+            irc: {
+              host: "127.0.0.1",
+              port: address.port,
+              tls: false,
+              accounts: {
+                alpha: { nick: "qa-alpha", channels: ["#alpha"] },
+                beta: { nick: "qa-beta", channels: ["#beta"] },
+                parked: { nick: "qa-parked" },
+              },
+            },
+          },
+        }),
+      });
+      connection = await connectHotReloadClient(gateway);
+      const primary = connection;
+      const { pid } = gateway;
+      const { bootId } = primary;
+      assert(pid && bootId);
+      const rpc = async <T>(method: string, params: unknown = {}): Promise<T> => {
+        const request = () => primary.client.request<T>(method, params, { timeoutMs: 40_000 });
+        try {
+          return await request();
+        } catch (error) {
+          if (
+            !(error instanceof GatewayClientRequestError) ||
+            !error.retryable ||
+            typeof error.retryAfterMs !== "number" ||
+            !error.message.startsWith(`rate limit exceeded for ${method}`)
+          ) {
+            throw error;
+          }
+          await delay(error.retryAfterMs);
+          return await request();
+        }
+      };
+      const accounts = async () =>
+        (
+          await rpc<{ channelAccounts: Record<string, ChannelAccountSnapshot[]> }>(
+            "channels.status",
+            { probe: false },
+          )
+        ).channelAccounts.irc ?? [];
+      const ready = async (id: string, nick: string, after = 0) =>
+        await waitForHotReloadFact(`IRC ${id} ready as ${nick}`, async () => {
+          const account = (await accounts()).find(
+            (row) =>
+              row.accountId === id &&
+              row.running &&
+              row.lifecycle === "ready" &&
+              !row.restartPending,
+          );
+          const peer = peers.findLast(
+            (row) => row.nick === nick && row.sequence > after && !row.socket.destroyed,
+          );
+          return account && peer ? peer : undefined;
+        });
+      const patch = async (change: unknown, replacePaths?: string[]) => {
+        const { hash } = await rpc<{ hash: string }>("config.get");
+        const result = await rpc<{
+          sentinel: { payload: { stats: { requiresRestart: boolean } } };
+        }>("config.patch", { baseHash: hash, raw: JSON.stringify(change), replacePaths });
+        assert.equal(result.sentinel.payload.stats.requiresRestart, false);
+      };
+      let ping = 0;
+      const witness = async (peer: Peer) => {
+        assert.equal(peer.socket.destroyed, false);
+        const marker = `qa-continuity-${++ping}`;
+        peer.socket.write(`PING :${marker}\r\n`);
+        await waitForHotReloadFact("same IRC socket PONG", () =>
+          peer.lines.includes(`PONG :${marker}`) ? true : undefined,
+        );
+      };
+      const record = async (prefix: string, observation: string) => {
+        assert.equal((await rpc<{ pid: number }>("system.info")).pid, pid);
+        assert.equal(primary.hellos, 1);
+        assert.equal(primary.closes, 0);
+        const fresh = await connectHotReloadClient(gateway);
+        try {
+          assert.equal(fresh.bootId, bootId);
+        } finally {
+          await fresh.client.stopAndWait();
+        }
+        const parked = (await accounts()).find((row) => row.accountId === "parked");
+        assert(parked && parked.running === false && parked.lifecycle === "stopped");
+        assert.equal(peers.filter((peer) => peer.nick === "qa-parked").length, 1);
+        observations.push({
+          prefix,
+          parked,
+          peers: peers.map(({ nick, sequence, lines, socket }) => ({
+            nick,
+            sequence,
+            lines: [...lines],
+            closed: socket.destroyed,
+          })),
+        });
+        evidence.push({ prefix, observation, bootId, pid });
+        appendLog(`PASS ${prefix}: ${observation}\n`);
+      };
+      try {
+        let alpha = await ready("alpha", "qa-alpha");
+        const beta = await ready("beta", "qa-beta");
+        const parked = await ready("parked", "qa-parked");
+        await rpc("channels.stop", { channel: "irc", accountId: "parked" });
+        await waitForHotReloadFact("parked IRC socket closed", () =>
+          parked.socket.destroyed ? true : undefined,
+        );
+        for (const [nick, channel] of [
+          ["qa-alpha-next", "#next"],
+          ["qa-alpha", "#alpha"],
+        ] as const) {
+          await patch(
+            { channels: { irc: { accounts: { alpha: { nick, channels: [channel] } } } } },
+            ["channels.irc.accounts.alpha.channels"],
+          );
+          const previous = alpha;
+          alpha = await ready("alpha", nick, previous.sequence);
+          await waitForHotReloadFact("old IRC socket retired", () =>
+            previous.socket.destroyed ? true : undefined,
+          );
+          assert(alpha.lines.includes(`JOIN ${channel}`));
+          await witness(beta);
+        }
+        await record(
+          "channels.irc.accounts.edit",
+          "Named account nick and JOIN settings changed A→B→A on new TCP connections; the sibling socket kept answering PING and the manually stopped account stayed stopped",
+        );
+        await patch({
+          channels: { irc: { accounts: { gamma: { nick: "qa-gamma", channels: ["#gamma"] } } } },
+        });
+        const gamma = await ready("gamma", "qa-gamma");
+        await witness(alpha);
+        await witness(beta);
+        await record(
+          "channels.irc.accounts.add",
+          "Adding a named account opened one new IRC socket while both existing account sockets and the Gateway connection remained live",
+        );
+        await patch({ channels: { irc: { accounts: { gamma: null } } } }, [
+          "channels.irc.accounts.gamma.channels",
+        ]);
+        await ready("alpha", "qa-alpha", alpha.sequence);
+        await ready("beta", "qa-beta", beta.sequence);
+        await waitForHotReloadFact("removed IRC account disconnected", () =>
+          gamma.socket.destroyed ? true : undefined,
+        );
+        assert(!(await accounts()).some((row) => row.accountId === "gamma"));
+        await record(
+          "channels.irc.accounts.remove",
+          "Removing an account used the whole-channel restart boundary, disconnected the removed account, preserved the manual stop, and kept the Gateway boot and operator socket",
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        failures.push({ prefix: "channels.irc.accounts", message });
+        appendLog(`FAIL channels.irc.accounts: ${message}\n`);
+      }
+    },
+    () => connection?.client.stopAndWait(),
+    () => stopQaGatewayFixture(owner, { preserveToDir: path.join(outputDir, "irc-gateway") }),
+    async () => {
+      for (const peer of peers) {
+        peer.socket.destroy();
+      }
+      if (server.listening) {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
+  return { evidence, failures, observations };
+}


### PR DESCRIPTION
## What Problem This Solves

Editing a named IRC account reconnects unaffected accounts. More broadly, channel teardown currently resolves an account and stop hook from newly published configuration, so a removed account can fail cleanup or a replacement plugin can receive another instance’s teardown.

## Why This Change Was Made

One account lifetime now retains its admitted configuration, resolved account, and bound stop hook through teardown and failed-stop retries. It replaces separate abort and capability maps and consolidates task retirement. The existing idle-stop cleanup contract remains available when no lifetime exists.

IRC opts into the existing account-scoped restart capability. Named-account edits and additions restart only that account; shared/default changes and removals keep the whole-channel boundary. Manual stops remain stopped. Telegram’s account-count-dependent group inheritance and Synology Chat’s cross-account webhook validation remain whole-channel. Twitch’s separate client/ingress ownership needs a dedicated audit before opting in.

## User Impact

Unchanged IRC connections stay live during eligible account changes. All channels use the original instance’s teardown context after configuration or plugin replacement. No new configuration keys, defaults, SDK fields, storage schema, or protocol. Production **+3 physical LOC** (−1 excluding four import-format lines); tests/support **+498**; docs **+22**.

## Evidence

- Four real channel-manager regressions failed before the repair: changed configuration, removed account, replaced plugin stop hook, and failed-stop retry. IRC socket/SQLite tests cover admitted-message recovery and continuing sibling delivery.
- 181 focused tests passed, followed by 256 integration tests after a patch-identical rebase. Full build, canonical changed guards/types/dead-export scans, typed lint and import-cycle checks passed. A final fixture lint correction was independently reviewed and its exact failed step rerun. Independent source and integration reviews are clean.
- Linux Crabbox [run 33932361338](https://github.com/openclaw/openclaw/actions/runs/33932361338) built and tested **`52e5b6298ec40c8117f64ac864fcb10847e05864`**. All three real-Gateway/TCP groups passed: nick/JOIN A→B→A, account addition, and conservative whole-channel removal. Actual sibling sockets answered PING throughout edit/add; the parked account never reconnected. Gateway PID **9649**, boot `ff700de7-3dd5-46c3-ac44-365da3d5d49a`, and operator connection remained unchanged.
- Build and source identity match the candidate; source tree `3fd8dbef1a904fbbf5ba282672acecc60b6c9ef3`. Command exited 0 (build 233.52s, live 31.57s). The independently verified **17,868-byte** receipt archive has SHA-256 `c83bddc258bd3568b80d2e00d708cfbbb861a58dc5b363ddd66512ed74e0a780`. The owned lease is stopped/completed.

The live server is a loopback IRC protocol fixture using the real bundled IRC plugin; no external IRC service, provider calls, or credentials are claimed. Initial local probes omitted required array `replacePaths`; the corrected public RPC requests passed. Tooling-only remote attempts ended before execution; the successful run above used the current Crabbox artifact capability without bypassing the source guard.

Final head `3fb10d3218059c29df4c3051d0e70545293ef15c` integrates newer main’s Gateway-owned registry selection. Teardown retains its admitted hook/config and executes in that Gateway registry scope. The verified range diff has no IRC or live harness changes; 246 integration tests, core/core-test types, typed lint and a fresh independent review passed. The Linux receipt above remains attributed to its actual tested commit.

The latest ClawSweeper review has no code findings and asks only for real-behavior evidence. The exact-head Linux receipt above addresses that request; Final-head [CI run33935769380](https://github.com/openclaw/openclaw/actions/runs/33935769380) is green. Release-note context is preserved here; OpenClaw generates its changelog at release.
