### PR TITLE
fix: full-access tasks lose tools after Gateway restart

### DIFF
--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -254,11 +254,15 @@ restriction for the continuation. An aborted turn is the interruption itself,
 so it resumes on a best-effort basis whatever abort detail the provider or worker recorded with it:
 partial streamed text stays in the transcript and the continuation picks up from
 the message beneath it, while a tool call left dangling is dropped from the next
-provider payload and restricted to restart-safe tools unless it is audited
-replay-safe. Provider failures, completed assistant tails, empty transcripts,
+provider payload. Provider failures, completed assistant tails, empty transcripts,
 and stale pending approvals also continue from the existing transcript. States
-with ambiguous side effects use restart-safe tools; otherwise the model decides
-what completed and what remains and can report any uncertainty to the user.
+with ambiguous side effects normally use restart-safe tools. A session with
+effective **Full Access**, including an inherited Full Access default, keeps its
+ordinary tools so it can inspect the outcome and finish the task. Recovery does
+not replay the interrupted call automatically or treat its missing result as
+success. Existing tool restrictions and current permissions still apply.
+Pending reply delivery, ambiguous reply-hook outcomes, and explicitly replay-safe
+Code Mode reconstruction retain their narrower recovery restrictions.
 
 OpenClaw can also reconstruct interrupted read-only [Code Mode](/tools/code-mode)
 work. Code Mode marks these runs as restart-safe and rejects side-effecting
@@ -267,9 +271,11 @@ the `wait` control, the new gateway reconstructs the turn from its transcript
 and forces the reconstructed execution to remain restart-safe even if the
 model omits or clears that flag. The host filters the entire reconstructed
 turn to audited read-only core tools and explicitly replay-safe plugin tools,
-including when Code Mode is disabled after the restart. A non-replay-safe or
-unmatched Code Mode checkpoint still resumes for model reconciliation, but
-without Code Mode controls and with the restart-safe tool restriction.
+including when Code Mode is disabled after the restart. Other interrupted
+Code Mode work resumes for model reconciliation: Full Access keeps its configured
+tool surface unless the current turn has an explicitly replay-safe checkpoint;
+other sessions retain the restart-safe restriction. Old process-local runs and
+approval handles are not revived.
 
 ### Subagents
 

--- a/qa/scenarios/runtime/gateway-restart-full-access-live.yaml
+++ b/qa/scenarios/runtime/gateway-restart-full-access-live.yaml
@@ -1,0 +1,188 @@
+title: Full-access tools survive an interrupted Gateway turn
+
+scenario:
+  id: gateway-restart-full-access-live
+  surface: runtime
+  coverage:
+    primary:
+      - session-memory.recovery-restart-recovery
+    secondary:
+      - gateway.restart-and-stop-gateway-restart
+      - session-memory.recovery-delivery
+  gatewayRuntime:
+    preserveDebugArtifacts: true
+  gatewayConfigPatch:
+    tools:
+      exec:
+        mode: full
+      alsoAllow:
+        - qa_restart_wait
+      codeMode:
+        enabled: true
+        timeoutMs: 60000
+  objective: Verify ordinary full-access task continuation retains shell and delegation after an ambiguous interrupted Code Mode call, without replaying its side effect.
+  successCriteria:
+    - An ordinary non-replay-safe Code Mode call records one shell side effect and remains pending during Gateway replacement.
+    - Recovery preserves the session's shell and session-spawn tools and executes fresh work.
+    - The prior shell side effect occurs exactly once and recovery delivers one final response without another user turn.
+  docsRefs:
+    - docs/tools/code-mode.md
+    - docs/channels/qa-channel.md
+  codeRefs:
+    - src/agents/main-session-recovery/main-session-restart-recovery.ts
+    - extensions/qa-lab/src/suite-runtime-gateway.ts
+  execution:
+    kind: flow
+    runtime: openclaw
+    retryCount: 0
+    summary: Run a live OpenAI full-access task across one real Gateway replacement, verify fresh shell and delegation capabilities, and reject duplicate prior effects.
+    suiteIsolation: isolated
+    isolationReason: Replaces its private Gateway while an ordinary Code Mode call is pending.
+    config:
+      requiredProviderMode: live-frontier
+      requiredProvider: openai
+      requiredModel: gpt-5.6-luna
+      finalMarker: FULL-ACCESS-RESTART-OK
+      failureMarker: FULL-ACCESS-RESTART-BLOCKED
+      prompt: |-
+        Complete this restart-resilience task in this one user turn. A Gateway replacement is expected halfway through. Do not ask me to send another message.
+
+        In the initial lifecycle, make one ordinary Code Mode exec without restartSafe, using this exact JavaScript (yield_control is already a built-in function; never search for or shadow it):
+        const shell = (await catalog.search("exec")).find(tool => tool.toolName === "exec");
+        await shell({command: "echo original-effect >> restart-original.txt"});
+        const target = (await catalog.search("qa_restart_wait")).find(tool => tool.toolName === "qa_restart_wait");
+        await Promise.all([target({}), yield_control("FULL-ACCESS-CHECKPOINT")]);
+        return "FULL-ACCESS-CHECKPOINT";
+        When exec reports waiting, call wait exactly once. Do not issue any further actions until the Gateway recovery system message arrives. Do not send assistant text before that recovery message.
+
+        After the Gateway recovery message, the interrupted execution has an unknown outcome. Do not replay that original exec or append to restart-original.txt again. Discover the shell execution and sessions_spawn tools afresh. If either is absent, reply exactly FULL-ACCESS-RESTART-BLOCKED and name the absent capability. Otherwise use the shell tool to read restart-original.txt and verify it contains one line original-effect, then execute `echo fresh-effect > restart-fresh.txt`. Use sessions_spawn with label restart-proof-child and agentId qa to ask a child to reply exactly CHILD-RESTART-OK, and wait for its completion using the available session tools or completion notification. Do not claim success before the child completes.
+
+        Finish with exactly FULL-ACCESS-RESTART-OK only after verifying the original single side effect, successful fresh shell work, and the child's CHILD-RESTART-OK reply. Do not perform unrelated work.
+
+flow:
+  steps:
+    - name: verifies the live full-access lane
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: scenario requires live-frontier provider mode
+        - set: selected
+          value:
+            expr: splitModelRef(env.primaryModel)
+        - assert:
+            expr: "selected?.provider === config.requiredProvider && selected?.model === config.requiredModel"
+            message: scenario requires its declared OpenAI model
+        - assert:
+            expr: "env.cfg.tools?.exec?.mode === 'full'"
+            message: scenario requires full access
+    - name: preserves full access through an ambiguous interrupted call
+      actions:
+        - call: waitForGatewayHealthy
+          args: [{ ref: env }, 180000]
+        - call: waitForQaChannelReady
+          args: [{ ref: env }, 180000]
+        - call: reset
+        - set: startIndex
+          value:
+            expr: state.getSnapshot().messages.length
+        - set: conversationId
+          value:
+            expr: "`restart-full-access-${randomUUID().slice(0, 8)}`"
+        - set: sessionKey
+          value:
+            expr: "buildAgentSessionKey({ agentId: 'qa', channel: 'qa-channel', accountId: transport.accountId, peer: { kind: 'direct', id: `dm:${conversationId}` }, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
+        - sendInbound:
+            accountId: default
+            conversation: { id: { ref: conversationId }, kind: direct }
+            senderId: { ref: conversationId }
+            senderName: QA Restart Operator
+            text: { expr: config.prompt }
+          saveAs: inbound
+        - call: waitForCondition
+          saveAs: checkpoint
+          args:
+            - lambda:
+                async: true
+                expr: "readSessionTranscriptSummary(env, sessionKey, { pendingCodeModeExecNeedle: 'FULL-ACCESS-CHECKPOINT' }).then((summary) => summary.hasPendingCodeModeWait ? summary : undefined).catch(() => undefined)"
+            - expr: liveTurnTimeoutMs(env, 180000)
+            - 50
+        - call: fs.readFile
+          saveAs: originalBefore
+          args:
+            - expr: "path.join(env.gateway.workspaceDir, 'restart-original.txt')"
+            - utf8
+        - assert:
+            expr: "originalBefore === 'original-effect' + String.fromCharCode(10)"
+            message: initial side effect did not occur exactly once
+        - call: restartGatewayWithConfigPatch
+          args:
+            - env: { ref: env }
+              patch:
+                gateway:
+                  controlUi:
+                    allowedOrigins: ["http://127.0.0.1:64221"]
+        - call: waitForGatewayHealthy
+          args: [{ ref: env }, 180000]
+        - call: waitForQaChannelReady
+          args: [{ ref: env }, 180000]
+        - call: waitForOutboundMessage
+          saveAs: outbound
+          args:
+            - ref: state
+            - lambda:
+                params: [candidate]
+                expr: "candidate.conversation.id === conversationId && (candidate.text.includes(config.finalMarker) || candidate.text.includes(config.failureMarker))"
+            - expr: liveTurnTimeoutMs(env, 300000)
+            - sinceIndex: { ref: startIndex }
+        - assert:
+            expr: "outbound.text.includes(config.finalMarker) && !outbound.text.includes(config.failureMarker)"
+            message:
+              expr: "`full-access recovery lost capabilities: ${outbound.text}`"
+        - call: fs.readFile
+          saveAs: originalAfter
+          args:
+            - expr: "path.join(env.gateway.workspaceDir, 'restart-original.txt')"
+            - utf8
+        - call: fs.readFile
+          saveAs: freshAfter
+          args:
+            - expr: "path.join(env.gateway.workspaceDir, 'restart-fresh.txt')"
+            - utf8
+        - assert:
+            expr: "originalAfter === 'original-effect' + String.fromCharCode(10) && freshAfter === 'fresh-effect' + String.fromCharCode(10)"
+            message: recovered work either repeated the prior side effect or failed to execute fresh shell work
+        - call: waitForCondition
+          saveAs: childTask
+          args:
+            - lambda:
+                async: true
+                expr: "(await env.gateway.call('tasks.list', { agentId: 'qa', limit: 100 })).tasks?.find(task => task.title === 'restart-proof-child' && task.sessionKey === sessionKey && task.status === 'completed')"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 50
+        - call: readSessionTranscriptSummary
+          saveAs: childTranscript
+          args:
+            - ref: env
+            - expr: childTask.childSessionKey
+        - assert:
+            expr: "childTranscript.finalText.trim() === 'CHILD-RESTART-OK'"
+            message: no successful child response was recorded
+        - set: outboundCountAfterDelivery
+          value:
+            expr: "state.getSnapshot().messages.filter(message => message.direction === 'outbound').length"
+        - waitForNoOutbound:
+            quietMs: 3000
+            sinceIndex: { ref: outboundCountAfterDelivery }
+        - set: finalMatches
+          value:
+            expr: "state.getSnapshot().messages.slice(startIndex).filter(message => message.direction === 'outbound' && message.conversation.id === conversationId && message.text.includes(config.finalMarker))"
+        - assert:
+            expr: "finalMatches.length === 1 && state.getSnapshot().messages.slice(startIndex).filter(message => message.direction === 'inbound' && message.conversation.id === conversationId).every(message => message.id === inbound.id)"
+            message: recovery required another user turn or delivered the final response more than once
+        - call: readSessionTranscriptSummary
+          saveAs: finalTranscript
+          args: [{ ref: env }, { ref: sessionKey }]
+        - assert:
+            expr: "finalTranscript.lastAssistantStopReason !== 'error' && finalTranscript.lastAssistantStopReason !== 'aborted'"
+            message: task did not automatically finish as a single original user turn
+      detailsExpr: "`session=${sessionKey} originalEffects=1 freshShellEffect=1 childCompleted=true final=${outbound.text}`"

--- a/qa/scenarios/runtime/gateway-restart-multi-live.yaml
+++ b/qa/scenarios/runtime/gateway-restart-multi-live.yaml
@@ -54,7 +54,7 @@ scenario:
         - After the second Gateway-recovery system message, perform only checkpoint 3.
         - After the third Gateway-recovery system message, perform the audit and final report.
 
-        For each checkpoint phase, make exactly one `exec` call with `restartSafe: true`. Its JavaScript must search for `qa_restart_wait`, call the single match with `{}`, and return only that phase's literal (`CHECKPOINT-1`, `CHECKPOINT-2`, or `CHECKPOINT-3`). Once `exec` reports waiting, call `wait` exactly once with its run id. Do not issue another `exec` until a new Gateway-recovery system message arrives. Do not read audit files, search for the unsafe probe, or write the final report during a checkpoint phase.
+        For each checkpoint phase, make exactly one `exec` call with `restartSafe: true`. Its JavaScript must search for `qa_restart_wait`, bind the single match as `target`, explicitly suspend with `await Promise.all([target({}), yield_control("restart checkpoint")])`, and then return only that phase's literal (`CHECKPOINT-1`, `CHECKPOINT-2`, or `CHECKPOINT-3`). `yield_control` is a built-in function; never search for or redeclare it. Once `exec` reports waiting, call `wait` exactly once with its run id. Do not issue another `exec` until a new Gateway-recovery system message arrives. Do not read audit files, search for the unsafe probe, or write the final report during a checkpoint phase.
 
         A Gateway restart will interrupt each checkpoint wait. A failed, unavailable, expired, or aborted `wait` result after restart is expected checkpoint evidence, not an audit failure; do not retry the old wait. Checkpoint literals are internal tool output. Never echo them or send assistant text during a checkpoint phase.
 

--- a/src/agents/main-session-recovery/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-recovery/main-session-restart-dispatch.ts
@@ -490,9 +490,7 @@ export async function resumeMainSession(params: {
           return { result: false };
         }
         entry.restartRecoveryDeliveryRunId = recoveryRunId;
-        if (params.forceRestartSafeTools) {
-          entry.restartRecoveryForceSafeTools = true;
-        }
+        entry.restartRecoveryForceSafeTools = params.forceRestartSafeTools ? true : undefined;
         entry.updatedAt = Date.now();
         return {
           result: true,

--- a/src/agents/main-session-recovery/main-session-restart-recovery-replay-safety.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-replay-safety.ts
@@ -1,0 +1,29 @@
+import {
+  visitSessionMessagesAsync,
+  type SessionTranscriptReadScope,
+} from "../../gateway/session-transcript-readers.js";
+import { isMainSessionRestartRecoveryInputProvenance } from "../../sessions/input-provenance.js";
+import { getTranscriptMessageRole } from "../embedded-agent-runner/message-visibility.js";
+import { hasReplaySafeCodeModeCheckpointInCurrentTurn } from "./main-session-restart-recovery-resume-policy.js";
+
+export async function readMainSessionReplaySafeCheckpoint(
+  scope: SessionTranscriptReadScope,
+): Promise<boolean> {
+  let replaySafe = false;
+  // The display tail can evict a checkpoint. Scan the active history snapshot
+  // with constant memory; recovery inputs continue the original user turn.
+  await visitSessionMessagesAsync(scope, (message) => {
+    if (getTranscriptMessageRole(message) === "user") {
+      if (
+        !isMainSessionRestartRecoveryInputProvenance(
+          (message as { provenance?: unknown }).provenance,
+        )
+      ) {
+        replaySafe = false;
+      }
+    } else if (hasReplaySafeCodeModeCheckpointInCurrentTurn([message])) {
+      replaySafe = true;
+    }
+  });
+  return replaySafe;
+}

--- a/src/agents/main-session-recovery/main-session-restart-recovery-replay-safety.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-replay-safety.ts
@@ -1,3 +1,4 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   visitSessionMessagesAsync,
   type SessionTranscriptReadScope,
@@ -14,11 +15,7 @@ export async function readMainSessionReplaySafeCheckpoint(
   // with constant memory; recovery inputs continue the original user turn.
   await visitSessionMessagesAsync(scope, (message) => {
     if (getTranscriptMessageRole(message) === "user") {
-      if (
-        !isMainSessionRestartRecoveryInputProvenance(
-          (message as { provenance?: unknown }).provenance,
-        )
-      ) {
+      if (!isMainSessionRestartRecoveryInputProvenance(asOptionalRecord(message)?.provenance)) {
         replaySafe = false;
       }
     } else if (hasReplaySafeCodeModeCheckpointInCurrentTurn([message])) {

--- a/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.test.ts
@@ -40,6 +40,7 @@ function asyncDeliveryMessage(text: string, itemId: string): Record<string, unkn
 
 function resolvePolicy(params: {
   messages?: unknown[];
+  fullAccess?: boolean;
   beforeAgentReplyState?:
     | "admitted"
     | "pending"
@@ -57,6 +58,7 @@ function resolvePolicy(params: {
     params.beforeAgentReplyState,
     params.deliveryReceiptState,
     params.deliveryToolCallId,
+    params.fullAccess,
   );
 }
 
@@ -90,6 +92,18 @@ function codeModeWait(runId = "code-run") {
 }
 
 describe("resolveMainSessionResumePolicy former terminal states", () => {
+  it.each([
+    { deliveryReceiptState: "terminal-pending" as const },
+    { beforeAgentReplyState: "pending" as const },
+    { beforeAgentReplyState: "handled-reply" as const },
+    { beforeAgentReplyState: "handled-unrecoverable" as const },
+    { messages: [codeModeCheckpoint({ replaySafe: true, runId: "code-run" }), codeModeWait()] },
+  ])("retains reconciliation restrictions under full access: %j", (params) => {
+    expect(resolvePolicy({ ...params, fullAccess: true })).toMatchObject({
+      action: "resume",
+      forceRestartSafeTools: true,
+    });
+  });
   it.each([
     {
       label: "terminal delivery whose outcome is unknown",

--- a/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions.js";
+import { isMainSessionRestartRecoveryInputProvenance } from "../../sessions/input-provenance.js";
 import { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME } from "../code-mode-control-tools.js";
 import {
   getTranscriptMessageRole as getMessageRole,
@@ -224,7 +225,10 @@ export function hasReplaySafeCodeModeCheckpointInCurrentTurn(
 ): boolean {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
-    if (getMessageRole(message) === "user") {
+    if (
+      getMessageRole(message) === "user" &&
+      !isMainSessionRestartRecoveryInputProvenance((message as { provenance?: unknown }).provenance)
+    ) {
       return false;
     }
     if (readCodeModeCheckpoint(message)?.replaySafe === true) {

--- a/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
@@ -1,3 +1,4 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions.js";
 import { isMainSessionRestartRecoveryInputProvenance } from "../../sessions/input-provenance.js";
@@ -227,7 +228,7 @@ export function hasReplaySafeCodeModeCheckpointInCurrentTurn(
     const message = messages[index];
     if (
       getMessageRole(message) === "user" &&
-      !isMainSessionRestartRecoveryInputProvenance((message as { provenance?: unknown }).provenance)
+      !isMainSessionRestartRecoveryInputProvenance(asOptionalRecord(message)?.provenance)
     ) {
       return false;
     }

--- a/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
@@ -371,6 +371,7 @@ export function resolveMainSessionResumePolicy(
   beforeAgentReplyState?: SessionEntry["restartRecoveryBeforeAgentReplyState"],
   deliveryReceiptState?: SessionEntry["restartRecoveryDeliveryReceiptState"],
   deliveryToolCallId?: string,
+  fullAccess = false,
 ): MainSessionResumePolicy {
   const mirroredToolCallId = readDeliveredTerminalSourceReplyToolCallId(
     messages,
@@ -402,6 +403,12 @@ export function resolveMainSessionResumePolicy(
   }
   if (beforeAgentReplyState === "handled-unrecoverable") {
     return { action: "resume", forceRestartSafeTools: true };
+  }
+  // A fresh continuation must be able to inspect an interrupted side effect.
+  // Full access keeps ordinary tools; explicit replay-safe reconstruction and
+  // delivery reconciliation above retain their narrower execution contract.
+  if (fullAccess && !hasReplaySafeCodeModeCheckpointInCurrentTurn(messages)) {
+    return { action: "resume", forceRestartSafeTools: false };
   }
   // Progress can commit after the recovery mark while the old run is winding
   // down. It is not a terminal turn boundary; preserve it in the transcript

--- a/src/agents/main-session-recovery/main-session-restart-recovery-store.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-store.ts
@@ -44,6 +44,7 @@ import {
   reconcileInterruptedCompletionReport,
 } from "./main-session-restart-recovery-checkpoint.js";
 import { tombstoneMainRestartRecoveryWithNotice } from "./main-session-restart-recovery-failure.js";
+import { readMainSessionReplaySafeCheckpoint } from "./main-session-restart-recovery-replay-safety.js";
 import {
   hasReplaySafeCodeModeCheckpointInCurrentTurn,
   resolveMainSessionResumePolicy,
@@ -531,22 +532,37 @@ export async function recoverStore(params: {
       continue;
     }
 
+    const execPolicy = resolveExecDefaults({
+      cfg: params.cfg,
+      agentId,
+      sessionKey: dispatchSessionKey,
+      sessionEntry: entry,
+    });
+    const fullAccess =
+      execPolicy.mode === "full" &&
+      execPolicy.security === "full" &&
+      execPolicy.ask === "off" &&
+      entry.restartRecoveryDeliveryMediaUrls === undefined &&
+      entry.restartRecoveryDisableMessageTool !== true &&
+      entry.restartRecoverySuppressTextDelivery !== true;
+    let replaySafeCheckpoint = false;
     let messages: unknown[];
     try {
-      messages = await readSessionMessagesAsync(
-        {
-          agentId,
-          sessionEntry: entry,
-          sessionId: entry.sessionId,
-          sessionKey,
-          storePath: params.storePath,
-        },
-        {
-          mode: "recent",
-          maxMessages: 20,
-          maxBytes: 256 * 1024,
-        },
-      );
+      const transcriptScope = {
+        agentId,
+        sessionEntry: entry,
+        sessionId: entry.sessionId,
+        sessionKey,
+        storePath: params.storePath,
+      };
+      messages = await readSessionMessagesAsync(transcriptScope, {
+        mode: "recent",
+        maxMessages: 20,
+        maxBytes: 256 * 1024,
+      });
+      if (fullAccess && !entry.pendingFinalDelivery) {
+        replaySafeCheckpoint = await readMainSessionReplaySafeCheckpoint(transcriptScope);
+      }
     } catch (err) {
       if (stopped()) {
         return result;
@@ -609,22 +625,8 @@ export async function recoverStore(params: {
       continue;
     }
 
-    const execPolicy = resolveExecDefaults({
-      cfg: params.cfg,
-      agentId,
-      sessionKey: dispatchSessionKey,
-      sessionEntry: entry,
-    });
-    const fullAccess =
-      execPolicy.mode === "full" &&
-      execPolicy.security === "full" &&
-      execPolicy.ask === "off" &&
-      entry.restartRecoveryDeliveryMediaUrls === undefined &&
-      entry.restartRecoveryDisableMessageTool !== true &&
-      entry.restartRecoverySuppressTextDelivery !== true;
     const retainedSafeTools =
-      entry.restartRecoveryForceSafeTools === true &&
-      (!fullAccess || hasReplaySafeCodeModeCheckpointInCurrentTurn(messages));
+      replaySafeCheckpoint || (entry.restartRecoveryForceSafeTools === true && !fullAccess);
     const resumePolicy = resolveMainSessionResumePolicy(
       messages,
       retainedSafeTools,
@@ -632,7 +634,7 @@ export async function recoverStore(params: {
       entry.restartRecoveryBeforeAgentReplyState,
       entry.restartRecoveryDeliveryReceiptState,
       entry.restartRecoveryDeliveryToolCallId,
-      fullAccess,
+      fullAccess && !retainedSafeTools,
     );
     if (resumePolicy.action === "complete") {
       if (stopped()) {

--- a/src/agents/main-session-recovery/main-session-restart-recovery-store.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-store.ts
@@ -25,6 +25,7 @@ import {
   listActiveEmbeddedRunSessionIds,
   listActiveEmbeddedRunSessionKeys,
 } from "../embedded-agent-runner/active-run-projections.js";
+import { resolveExecDefaults } from "../exec-defaults.js";
 import {
   getMainSessionRecoveryRetryCount,
   isMainRestartRecoveryAggregateTerminalOnly,
@@ -608,13 +609,30 @@ export async function recoverStore(params: {
       continue;
     }
 
+    const execPolicy = resolveExecDefaults({
+      cfg: params.cfg,
+      agentId,
+      sessionKey: dispatchSessionKey,
+      sessionEntry: entry,
+    });
+    const fullAccess =
+      execPolicy.mode === "full" &&
+      execPolicy.security === "full" &&
+      execPolicy.ask === "off" &&
+      entry.restartRecoveryDeliveryMediaUrls === undefined &&
+      entry.restartRecoveryDisableMessageTool !== true &&
+      entry.restartRecoverySuppressTextDelivery !== true;
+    const retainedSafeTools =
+      entry.restartRecoveryForceSafeTools === true &&
+      (!fullAccess || hasReplaySafeCodeModeCheckpointInCurrentTurn(messages));
     const resumePolicy = resolveMainSessionResumePolicy(
       messages,
-      entry.restartRecoveryForceSafeTools === true,
+      retainedSafeTools,
       expectedRecoverySourceRunId,
       entry.restartRecoveryBeforeAgentReplyState,
       entry.restartRecoveryDeliveryReceiptState,
       entry.restartRecoveryDeliveryToolCallId,
+      fullAccess,
     );
     if (resumePolicy.action === "complete") {
       if (stopped()) {
@@ -646,8 +664,7 @@ export async function recoverStore(params: {
     }
 
     await resumeCurrent({
-      forceRestartSafeTools:
-        entry.restartRecoveryForceSafeTools === true || resumePolicy.forceRestartSafeTools,
+      forceRestartSafeTools: retainedSafeTools || resumePolicy.forceRestartSafeTools,
       forceCodeModeTools: resumePolicy.forceCodeModeTools === true,
     });
   }

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -238,6 +238,7 @@ async function writeStore(
 function mainSessionEntry(overrides: SessionEntryFixture = {}): SessionEntry {
   return createSessionEntry({
     sessionId: "main-session",
+    permissionMode: "guarded",
     updatedAt: Date.now() - 10_000,
     status: "running",
     abortedLastRun: true,
@@ -5465,19 +5466,27 @@ describe("main-session-restart-recovery", () => {
     expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
   });
 
-  it("resumes completed assistant output under the retained restart-safe guard", async () => {
-    await writeMainSessionTranscript(
-      [
-        { role: "user", content: "do the thing" },
-        { role: "assistant", content: [{ type: "text", text: "Done already." }] },
-      ],
-      { restartRecoveryForceSafeTools: true },
-    );
+  it.each(["guarded", "full"] as const)(
+    "retains explicit replay safety after a provider error with %s access",
+    async (permissionMode) => {
+      await writeMainSessionTranscript(
+        [
+          { role: "user", content: "do the thing" },
+          codeModeCheckpointMessage(),
+          {
+            role: "assistant",
+            stopReason: "error",
+            content: [{ type: "text", text: "Provider failed." }],
+          },
+        ],
+        { permissionMode, restartRecoveryForceSafeTools: true },
+      );
 
-    await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
-    expect(callGateway).toHaveBeenCalledOnce();
-    expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
-  });
+      await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
+      expect(callGateway).toHaveBeenCalledOnce();
+      expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
+    },
+  );
 
   it("resumes after a completed historical recovery prompt", async () => {
     await writeMainSessionTranscript([
@@ -5581,19 +5590,46 @@ describe("main-session-restart-recovery", () => {
     expect(callGateway).toHaveBeenCalledTimes(1);
   });
 
-  it("resumes a side-effecting tool call restricted to restart-safe tools", async () => {
-    await writeMainSessionTranscript([
-      { role: "user", content: "do the thing" },
-      createAssistantToolCallMessage([
-        { type: "text", text: "Running the check now." },
-        { type: "toolCall", id: "call-bash-1", name: "bash", arguments: { command: "true" } },
-      ]),
-    ]);
+  it.each([
+    { label: "inherited full access", mode: "full", permissionMode: undefined, restricted: false },
+    { label: "explicit full access", mode: "ask", permissionMode: "full", restricted: false },
+    { label: "inherited approvals", mode: "ask", permissionMode: undefined, restricted: true },
+    { label: "explicit guarded access", mode: "full", permissionMode: "guarded", restricted: true },
+  ] as const)(
+    "continues interrupted work with $label",
+    async ({ mode, permissionMode, restricted }) => {
+      const sessionsDir = await writeMainSessionTranscript(
+        [
+          { role: "user", content: "do the thing" },
+          createAssistantToolCallMessage([
+            { type: "text", text: "Running the check now." },
+            {
+              type: "toolCall",
+              id: "call-exec-1",
+              name: "exec",
+              arguments: { code: "await shell({command: 'true'})" },
+            },
+          ]),
+        ],
+        { permissionMode, restartRecoveryForceSafeTools: true },
+      );
 
-    await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
-    expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
-  });
+      await expectRecovery(
+        { started: 1, settled: 0, failed: 0, skipped: 0 },
+        { tools: { exec: { mode } } },
+      );
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(gatewayParams().forceRestartSafeTools === true).toBe(restricted);
+      expect(gatewayParams()).not.toHaveProperty("forceCodeModeTools");
+      expect(gatewayParams().message).toContain("unknown outcome");
+      expect(
+        loadSessionEntry({
+          storePath: path.join(sessionsDir, "sessions.json"),
+          sessionKey: "agent:main:main",
+        })?.restartRecoveryForceSafeTools === true,
+      ).toBe(restricted);
+    },
+  );
 
   it("reports an interrupted native tool outcome as unknown", async () => {
     await writeMainSessionTranscript([

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -5433,22 +5433,31 @@ describe("main-session-restart-recovery", () => {
     expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
   });
 
-  it("keeps restart safety after the recovery prompt leaves the recent transcript window", async () => {
-    await writeMainSessionTranscript(
-      [
-        { role: "user", content: "do the thing" },
-        ...Array.from({ length: 24 }, (_, index) => ({
-          role: "toolResult",
-          toolName: "read",
-          content: [{ type: "text", text: `read result ${index}` }],
-        })),
-      ],
-      { restartRecoveryForceSafeTools: true },
-    );
+  it.each(["guarded", "full"] as const)(
+    "keeps replay safety outside the recent transcript window with %s access",
+    async (permissionMode) => {
+      await writeMainSessionTranscript(
+        [
+          { role: "user", content: "do the thing" },
+          codeModeCheckpointMessage(),
+          {
+            role: "user",
+            content: "Continue after restart",
+            provenance: { kind: "internal_system", sourceTool: "main_session_restart_recovery" },
+          },
+          ...Array.from({ length: 24 }, (_, index) => ({
+            role: "toolResult",
+            toolName: "read",
+            content: [{ type: "text", text: `read result ${index}` }],
+          })),
+        ],
+        { permissionMode, restartRecoveryForceSafeTools: true },
+      );
 
-    await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
-    expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
-  });
+      await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
+      expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
+    },
+  );
 
   it("resumes an in-flight safe tool call across a repeated restart", async () => {
     await writeMainSessionTranscript(
@@ -5488,17 +5497,23 @@ describe("main-session-restart-recovery", () => {
     },
   );
 
-  it("resumes after a completed historical recovery prompt", async () => {
-    await writeMainSessionTranscript([
-      {
-        role: "user",
-        content:
-          "[System] Your previous turn was interrupted by a gateway restart while OpenClaw was waiting on tool/model work. Continue from the existing transcript and finish the interrupted response.",
-      },
-      { role: "assistant", content: [{ type: "text", text: "Finished that recovery." }] },
-      { role: "user", content: "a later request" },
-      { role: "assistant", content: [{ type: "text", text: "Finished the later request." }] },
-    ]);
+  it("ends prior replay restrictions at a new full-access user turn", async () => {
+    await writeMainSessionTranscript(
+      [
+        { role: "user", content: "the earlier request" },
+        codeModeCheckpointMessage(),
+        {
+          role: "user",
+          provenance: { kind: "internal_system", sourceTool: "main_session_restart_recovery" },
+          content:
+            "[System] Your previous turn was interrupted by a gateway restart while OpenClaw was waiting on tool/model work. Continue from the existing transcript and finish the interrupted response.",
+        },
+        { role: "assistant", content: [{ type: "text", text: "Finished that recovery." }] },
+        { role: "user", content: "a later request" },
+        { role: "assistant", content: [{ type: "text", text: "Finished the later request." }] },
+      ],
+      { permissionMode: "full", restartRecoveryForceSafeTools: true },
+    );
 
     await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
     expect(callGateway).toHaveBeenCalledOnce();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a task with Full Access lost shell, delegation, and other tools after a Gateway restart interrupted a Code Mode call. The permission picker still showed Full Access, but recovery filtered the new turn down to restart-safe tools and left it unable to inspect the interrupted operation or finish the task.

## Why This Change Was Made

Recovery uses the canonical effective exec policy, including inherited defaults and explicit session overrides, when admitting ordinary continuation work. It replaces the prior recovery restriction with the selected continuation policy. Unknown tool results stay unknown; old calls, process-local runs, and approval handles are not automatically replayed.

Explicit replay-safe checkpoints are read through the existing canonical transcript visitor with constant memory, independently of the recent 20-message/256-KiB display tail. Synthetic restart inputs preserve the original turn; a genuine new user input ends its replay restriction. Pending delivery, reply-hook ambiguity, constrained delivery media, and explicit replay-safe reconstruction retain their narrower restrictions. Fresh tool construction still applies current permissions, tool allowlists, and lifecycle authority. No configuration or database schema surface is added.

The existing repeated-restart live fixture also now explicitly suspends at its checkpoint. Its previous wait could complete inline before the harness could request a restart; timeouts and safety assertions remain unchanged.

## User Impact

Full Access sessions can inspect interrupted operations and continue authorized work without asking the user to resend the task. Guarded sessions and deliberately replay-safe reconstruction retain their existing protections.

## Evidence

Latest tested head: `1d3b8d92efb752971e77063b539f7d500490fc81`.

**Real Gateway + live OpenAI before/after:** the original build (`af54ce545a7174cb818e17b9d2d11281dbd6ac63`) restarted, reduced its model catalog from 30 to 9, and returned `FULL-ACCESS-RESTART-BLOCKED: shell execution and sessions_spawn absent`. On the tested head, the same Full Access scenario passed with real fresh shell work, a completed child, exactly one original side effect, and one final response without another user input.

**Replay-safe sibling:** the live task survived three Gateway replacements, retained its restricted tool policy on all three recoveries, completed its audit, and delivered one final response. `unsafeVisible=false`; no unsafe probe executed. These use a real disposable Gateway and live model API with the synthetic QA channel, not a production chat account.

```json
{
  "head": "1d3b8d92efb752971e77063b539f7d500490fc81",
  "gateway-restart-full-access-live": {
    "provider": "openai/gpt-5.6-luna", "passed": true,
    "durationMs": 42051, "originalEffects": 1,
    "freshShellEffects": 1, "childCompleted": true,
    "finalDeliveries": 1, "extraUserInputs": 0
  },
  "gateway-restart-multi-live": {
    "provider": "openai/gpt-5.4", "passed": true,
    "durationMs": 55260, "restarts": 3,
    "recoveryDispatches": 3, "retainedPolicies": 3,
    "unsafeVisible": false, "unsafeProbeExecutions": 0,
    "finalDeliveries": 1, "resendNotices": 0
  }
}
```

Reproduce with an approved `OPENAI_API_KEY` in the environment:

```sh
OPENCLAW_QA_SUITE_PROGRESS=1 OPENCLAW_BUILD_PRIVATE_QA=1 OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 \
  node openclaw.mjs qa suite --provider-mode live-frontier \
  --model openai/gpt-5.6-luna --alt-model openai/gpt-5.6-luna \
  --scenario gateway-restart-full-access-live --concurrency 1 \
  --output-dir .artifacts/restart-full-access-proof
```

For the three-restart sibling, use `gateway-restart-multi-live` with both model flags set to `openai/gpt-5.4` and a separate output directory.

211 recovery tests pass, including inherited/explicit Full Access, guarded policy, an evicted checkpoint across another recovery, a provider-error tail, and a genuine new-user boundary. The Full Access cases and checkpoint-eviction case were each observed failing before their corresponding repair. Focused exec-defaults/session-permissions/tool-surface tests and concrete Code Mode replay tests also pass; the latter reject side-effecting calls before their target executes even when the model clears `restartSafe`.

```sh
node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-restart-recovery.test.ts src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.test.ts
node scripts/run-vitest.mjs src/agents/exec-defaults.test.ts src/agents/embedded-agent-runner/run.session-permissions.test.ts src/agents/tool-surface-plan.test.ts
node scripts/run-vitest.mjs src/agents/code-mode.replay.test.ts src/agents/tool-replay-safety.test.ts
```

Independent Codex reviews are scoped-clean through P1 after addressing the accepted findings. Upstream Codex resume handling was inspected directly at `codex-rs/app-server/src/request_processors/thread_processor.rs:3673–3915`; the restrictive filter is OpenClaw-owned. [Current-head CI](https://github.com/openclaw/openclaw/actions/runs/33933490763) supplies the hosted checks. An earlier CI assertion-style failure was corrected with the existing record-coercion helper; no baseline was relaxed.

ClawSweeper's checkpoint-window finding and rank-up moves are addressed by the canonical scan, failing/passing eviction regression, and both live outcomes above. Production delta is +55 lines, for effective policy selection and the bounded-memory checkpoint read; test/scenario delta is separate. The old sticky restriction assignment is replaced. Owned test Gateways and credential-handling resources are cleaned up; no production Gateway or live database was modified.
