### PR TITLE
fix: emit store:false for ChatGPT Codex responses transport

### DIFF
--- a/packages/ai/src/transports/openai-responses-payload-policy.test.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveOpenAIResponsesServerCompactionPlan } from "./openai-responses-payload-policy.js";
+import {
+  applyOpenAIResponsesPayloadPolicy,
+  resolveOpenAIResponsesPayloadPolicy,
+  resolveOpenAIResponsesServerCompactionPlan,
+} from "./openai-responses-payload-policy.js";
 
 describe("OpenAI Responses compact threshold", () => {
   it.each([
@@ -41,5 +45,29 @@ describe("OpenAI Responses compact threshold", () => {
         extraParams,
       ).threshold,
     ).toBe(expected);
+  });
+});
+
+describe("chatgpt responses store policy", () => {
+  it("chatgpt responses requires explicit store false on the transport path", () => {
+    const policy = resolveOpenAIResponsesPayloadPolicy({
+      api: "openai-chatgpt-responses",
+      provider: "openai",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+    });
+    expect(policy.explicitStore).toBe(false);
+
+    const payload: Record<string, unknown> = { model: "gpt-5.6-luna" };
+    applyOpenAIResponsesPayloadPolicy(payload, policy);
+    expect(payload.store).toBe(false);
+  });
+
+  it("openclaw chatgpt responses transport also emits store false", () => {
+    const policy = resolveOpenAIResponsesPayloadPolicy({
+      api: "openclaw-openai-chatgpt-responses-transport",
+      provider: "openai",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+    });
+    expect(policy.explicitStore).toBe(false);
   });
 });

--- a/packages/ai/src/transports/openai-responses-payload-policy.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.ts
@@ -393,6 +393,12 @@ export function resolveOpenAIResponsesPayloadPolicy(
 ): OpenAIResponsesPayloadPolicy {
   const capabilities = resolveOpenAIResponsesPayloadCapabilities(model);
   const storeMode = options.storeMode ?? "provider-policy";
+  const api = normalizeOptionalLowercaseString(model.api);
+  // ChatGPT Codex Responses rejects omitted `store` and requires an explicit
+  // `store: false` (native codex path already does this; transport path must too).
+  const requiresExplicitStoreFalse =
+    api === "openai-chatgpt-responses" ||
+    api === "openclaw-openai-chatgpt-responses-transport";
   const explicitStore =
     storeMode === "preserve"
       ? undefined
@@ -402,7 +408,9 @@ export function resolveOpenAIResponsesPayloadPolicy(
           : undefined
         : capabilities.allowsResponsesStore
           ? true
-          : undefined;
+          : requiresExplicitStoreFalse && capabilities.supportsResponsesStoreField
+            ? false
+            : undefined;
   const isResponsesApi = isOpenAIResponsesApi(normalizeOptionalLowercaseString(model.api));
   const shouldStripDisabledReasoningPayload =
     isResponsesApi &&

--- a/packages/ai/src/transports/openai-responses-payload-policy.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.ts
@@ -397,8 +397,7 @@ export function resolveOpenAIResponsesPayloadPolicy(
   // ChatGPT Codex Responses rejects omitted `store` and requires an explicit
   // `store: false` (native codex path already does this; transport path must too).
   const requiresExplicitStoreFalse =
-    api === "openai-chatgpt-responses" ||
-    api === "openclaw-openai-chatgpt-responses-transport";
+    api === "openai-chatgpt-responses" || api === "openclaw-openai-chatgpt-responses-transport";
   const explicitStore =
     storeMode === "preserve"
       ? undefined


### PR DESCRIPTION
## Summary
- Transport-aware OpenAI Responses requests to the ChatGPT Codex backend omitted `store`, while the native Codex path already sends `store: false`.
- That backend now requires an explicit `store: false` and returns `400 Store must be set to false` when the field is missing.
- For `openai-chatgpt-responses` / `openclaw-openai-chatgpt-responses-transport`, provider policy now emits `store: false`.

Fixes #138395

## What Problem This Solves
ChatGPT Codex Responses API calls made through the OpenAI Responses transport omitted `store`. The Codex backend now rejects that with `400 Store must be set to false`, so those requests fail even though the native Codex path already sends `store: false`.

## Evidence
- Added unit coverage in `packages/ai/src/transports/openai-responses-payload-policy.test.ts` asserting `resolveOpenAIResponsesPayloadPolicy` sets `explicitStore: false` for both `openai-chatgpt-responses` and `openclaw-openai-chatgpt-responses-transport`, and that `applyOpenAIResponsesPayloadPolicy` writes `store: false` onto the payload.
- Native Codex path already emitted `store: false`; this aligns the transport path with that behavior.

## Test plan
- [x] Unit coverage in `openai-responses-payload-policy.test.ts` for both ChatGPT Responses API ids