### PR TITLE
refactor(plugins): remove obsolete interactive registration alias

### DIFF
--- a/src/plugins/interactive-registry.ts
+++ b/src/plugins/interactive-registry.ts
@@ -131,20 +131,6 @@ export function registerPluginInteractiveHandlerInRegistry(
   );
 }
 
-/** Registers one compatibility handler in the currently selected channel registry. */
-export function registerRegistryPluginInteractiveHandler(
-  pluginId: string,
-  registration: PluginInteractiveHandlerRegistration,
-  opts?: { pluginName?: string; pluginRoot?: string },
-): InteractiveRegistrationResult {
-  return registerPluginInteractiveHandlerWithOptions(
-    requireInteractiveRegistrationRegistry().interactiveHandlers,
-    resolveDirectPluginRegistrationOwner(pluginId) ?? pluginId,
-    registration,
-    opts,
-  );
-}
-
 /** Clears all active plugin interactive handlers. */
 export function clearPluginInteractiveHandlers(): void {
   requireActivePluginChannelRegistry().interactiveHandlers.length = 0;

--- a/src/plugins/interactive.test.ts
+++ b/src/plugins/interactive.test.ts
@@ -6,7 +6,6 @@ import type {
   SlackInteractiveHandlerContext,
   TelegramInteractiveHandlerContext,
 } from "./interactive-contract.test-helpers.js";
-import { registerRegistryPluginInteractiveHandler } from "./interactive-registry.js";
 import {
   clearPluginInteractiveHandlers,
   createChannelInteractiveDispatcher,
@@ -579,7 +578,7 @@ describe("plugin interactive handlers", () => {
       },
     ];
     expect(
-      registerRegistryPluginInteractiveHandler(
+      registerPluginInteractiveHandler(
         "openclaw-code-agent",
         {
           channel: "telegram",


### PR DESCRIPTION
## What Problem This Solves

Removes an obsolete private compatibility registration path that duplicated the canonical plugin interactive-handler registration flow.

## Why This Change Was Made

The compatibility helper and `registerPluginInteractiveHandler` had identical ownership resolution and registry behavior. The sole internal test caller now uses the canonical helper, while explicit registry-scoped registration and public Plugin SDK exports remain unchanged.

## User Impact

No user-visible behavior changes. Plugin interactive handlers keep the same registration, ownership, dispatch, and retirement behavior with one fewer internal alias.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/interactive.test.ts src/plugins/registry.diagnostics.test.ts` - 53 tests passed.
- `node scripts/check-changed.mjs -- src/plugins/interactive-registry.ts src/plugins/interactive.test.ts` - passed on the exact base and candidate file hashes.
- Targeted `oxfmt --check` - passed.
- `git diff --check` - passed.
- Autoreview P0-P2 - no actionable findings.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/33928709892
