### PR TITLE
refactor(memory): simplify source-state queries

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -741,7 +741,6 @@ extensions/memory-core/src/memory/manager-embedding-ops.ts	2
 extensions/memory-core/src/memory/manager-keyword-retrieval.ts	1
 extensions/memory-core/src/memory/manager-search-orchestration.ts	2
 extensions/memory-core/src/memory/manager-search.ts	9
-extensions/memory-core/src/memory/manager-source-state.ts	2
 extensions/memory-core/src/memory/manager-sync-base.ts	5
 extensions/memory-core/src/memory/manager-vector-rebuild-state.ts	1
 extensions/memory-core/src/memory/manager-watch-ops.ts	4

--- a/extensions/memory-core/src/memory/manager-session-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-ops.ts
@@ -196,7 +196,7 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
     const existingRows = loadMemorySourceFileState({
       db: this.db,
       source: "sessions",
-    }).rows;
+    });
     const readOnly = this.database.readOnly;
     const sqliteCorpusEntries = readOnly
       ? corpusEntries.filter((entry) => entry.transcriptSource === "sqlite")

--- a/extensions/memory-core/src/memory/manager-source-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-source-state.test.ts
@@ -1,91 +1,67 @@
 // Memory Core tests cover manager source state plugin behavior.
-import { describe, expect, it } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { ensureMemoryIndexSchema } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   loadMemorySourceFileState,
   resolveMemorySourceExistingHash,
 } from "./manager-source-state.js";
 
 describe("memory source state", () => {
-  it("loads source hashes with one bulk query", () => {
-    const calls: Array<{ sql: string; args: unknown[] }> = [];
-    const state = loadMemorySourceFileState({
-      db: {
-        prepare: (sql) => ({
-          all: (...args) => {
-            calls.push({ sql, args });
-            return [
-              { path: "memory/one.md", hash: "hash-1", mtime: 100, size: 10 },
-              { path: "memory/two.md", hash: "hash-2", mtime: 200, size: 20 },
-            ];
-          },
-          get: () => undefined,
-        }),
-      },
-      source: "memory",
-    });
+  let db: DatabaseSync;
 
-    expect(calls).toEqual([
-      {
-        sql: "SELECT path, hash, mtime, size FROM memory_index_sources WHERE source = ?",
-        args: ["memory"],
-      },
-    ]);
-    expect(state.rows).toEqual([
-      { path: "memory/one.md", hash: "hash-1", mtime: 100, size: 10 },
-      { path: "memory/two.md", hash: "hash-2", mtime: 200, size: 20 },
-    ]);
-    expect(state.hashes).toEqual(
-      new Map([
-        ["memory/one.md", "hash-1"],
-        ["memory/two.md", "hash-2"],
-      ]),
+  beforeEach(() => {
+    db = new DatabaseSync(":memory:");
+    ensureMemoryIndexSchema({
+      db,
+      cacheEnabled: false,
+      ftsEnabled: false,
+      ftsTokenizer: "unicode61",
+    });
+    const insert = db.prepare(
+      "INSERT INTO memory_index_sources(path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)",
     );
+    insert.run("memory/one.md", "memory", "hash-1", 100.25, 10);
+    insert.run("memory/two.md", "memory", "hash-2", 200.5, 20);
+    insert.run("memory/one.md", "sessions", "session-hash", 300.75, 30);
   });
 
-  it("uses bulk snapshot hashes when present", () => {
-    const calls: Array<{ sql: string; args: unknown[] }> = [];
-    const hash = resolveMemorySourceExistingHash({
-      db: {
-        prepare: (sql) => ({
-          all: () => [],
-          get: (...args) => {
-            calls.push({ sql, args });
-            return { hash: "unexpected" };
-          },
-        }),
-      },
-      source: "sessions",
-      path: "sessions/thread.jsonl",
-      existingHashes: new Map([["sessions/thread.jsonl", "hash-from-snapshot"]]),
-    });
+  afterEach(() => db.close());
 
-    expect(hash).toBe("hash-from-snapshot");
-    expect(calls).toStrictEqual([]);
-  });
-
-  it("falls back to per-file lookups without a bulk snapshot", () => {
-    const calls: Array<{ sql: string; args: unknown[] }> = [];
-    const hash = resolveMemorySourceExistingHash({
-      db: {
-        prepare: (sql) => ({
-          all: () => [],
-          get: (...args) => {
-            calls.push({ sql, args });
-            return { hash: "hash-from-row" };
-          },
-        }),
-      },
-      source: "sessions",
-      path: "sessions/thread.jsonl",
-      existingHashes: null,
-    });
-
-    expect(hash).toBe("hash-from-row");
-    expect(calls).toEqual([
-      {
-        sql: "SELECT hash FROM memory_index_sources WHERE path = ? AND source = ?",
-        args: ["sessions/thread.jsonl", "sessions"],
-      },
+  it("loads complete indexed rows for the requested source", () => {
+    expect(loadMemorySourceFileState({ db, source: "memory" })).toEqual([
+      { path: "memory/one.md", hash: "hash-1", mtime: 100.25, size: 10 },
+      { path: "memory/two.md", hash: "hash-2", mtime: 200.5, size: 20 },
     ]);
+    db.prepare("DELETE FROM memory_index_sources WHERE source = ?").run("memory");
+    expect(loadMemorySourceFileState({ db, source: "memory" })).toEqual([]);
+  });
+
+  it.each([
+    {
+      existingHashes: new Map([["memory/one.md", "hash-from-snapshot"]]),
+      expected: "hash-from-snapshot",
+    },
+    { existingHashes: new Map<string, string>(), expected: undefined },
+  ])(
+    "uses the bulk snapshot without consulting newer rows: $expected",
+    ({ existingHashes, expected }) => {
+      expect(
+        resolveMemorySourceExistingHash({
+          db,
+          source: "memory",
+          path: "memory/one.md",
+          existingHashes,
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it.each([
+    { source: "memory" as const, path: "memory/one.md", expected: "hash-1" },
+    { source: "sessions" as const, path: "memory/one.md", expected: "session-hash" },
+    { source: "sessions" as const, path: "memory/missing.md", expected: undefined },
+  ])("reads the current $source row for $path without a snapshot", ({ source, path, expected }) => {
+    expect(resolveMemorySourceExistingHash({ db, source, path })).toBe(expected);
   });
 });

--- a/extensions/memory-core/src/memory/manager-source-state.ts
+++ b/extensions/memory-core/src/memory/manager-source-state.ts
@@ -1,5 +1,5 @@
 // Memory Core plugin module implements manager source state behavior.
-import type { SQLInputValue } from "node:sqlite";
+import type { DatabaseSync } from "node:sqlite";
 import type { ResolvedMemorySearchConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   buildFileEntry,
@@ -8,6 +8,11 @@ import {
   type MemoryFileEntry,
   type MemorySource,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "openclaw/plugin-sdk/sqlite-runtime";
 
 export type MemorySourceFileStateRow = {
   path: string;
@@ -16,15 +21,9 @@ export type MemorySourceFileStateRow = {
   size?: number;
 };
 
-type MemorySourceStateDb = {
-  prepare: (sql: string) => {
-    all: (...args: SQLInputValue[]) => unknown;
-    get: (...args: SQLInputValue[]) => unknown;
-  };
+type MemorySourceDatabase = {
+  memory_index_sources: MemorySourceFileStateRow & { source: MemorySource };
 };
-
-const MEMORY_SOURCE_FILE_STATE_SQL = `SELECT path, hash, mtime, size FROM memory_index_sources WHERE source = ?`;
-const MEMORY_SOURCE_FILE_HASH_SQL = `SELECT hash FROM memory_index_sources WHERE path = ? AND source = ?`;
 
 type MemorySourceInspection = {
   source: MemorySource;
@@ -68,13 +67,13 @@ function hasMemorySourceDrift(params: {
 }
 
 export async function inspectMemorySourceState(params: {
-  db: MemorySourceStateDb;
+  db: DatabaseSync;
   workspaceDir: string;
   settings: Pick<ResolvedMemorySearchConfig, "extraPaths" | "multimodal">;
   concurrency: number;
 }): Promise<MemorySourceInspection> {
   const entries = await resolveMemorySourceFileEntries(params);
-  const indexedRows = loadMemorySourceFileState({ db: params.db, source: "memory" }).rows;
+  const indexedRows = loadMemorySourceFileState({ db: params.db, source: "memory" });
   return {
     source: "memory",
     dirty: hasMemorySourceDrift({ entries, indexedRows }),
@@ -84,24 +83,20 @@ export async function inspectMemorySourceState(params: {
 }
 
 export function loadMemorySourceFileState(params: {
-  db: MemorySourceStateDb;
+  db: DatabaseSync;
   source: MemorySource;
-}): {
-  rows: MemorySourceFileStateRow[];
-  hashes: Map<string, string>;
-} {
-  const rows = params.db.prepare(MEMORY_SOURCE_FILE_STATE_SQL).all(params.source) as
-    | MemorySourceFileStateRow[]
-    | undefined;
-  const normalizedRows = rows ?? [];
-  return {
-    rows: normalizedRows,
-    hashes: new Map(normalizedRows.map((row) => [row.path, row.hash])),
-  };
+}): MemorySourceFileStateRow[] {
+  return executeSqliteQuerySync(
+    params.db,
+    getNodeSqliteKysely<MemorySourceDatabase>(params.db)
+      .selectFrom("memory_index_sources")
+      .select(["path", "hash", "mtime", "size"])
+      .where("source", "=", params.source),
+  ).rows;
 }
 
 export function resolveMemorySourceExistingHash(params: {
-  db: MemorySourceStateDb;
+  db: DatabaseSync;
   source: MemorySource;
   path: string;
   existingHashes?: Map<string, string> | null;
@@ -109,9 +104,12 @@ export function resolveMemorySourceExistingHash(params: {
   if (params.existingHashes) {
     return params.existingHashes.get(params.path);
   }
-  return (
-    params.db.prepare(MEMORY_SOURCE_FILE_HASH_SQL).get(params.path, params.source) as
-      | { hash: string }
-      | undefined
+  return executeSqliteQueryTakeFirstSync(
+    params.db,
+    getNodeSqliteKysely<MemorySourceDatabase>(params.db)
+      .selectFrom("memory_index_sources")
+      .select("hash")
+      .where("path", "=", params.path)
+      .where("source", "=", params.source),
   )?.hash;
 }

--- a/extensions/memory-core/src/memory/manager-source-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-source-sync-ops.ts
@@ -71,12 +71,11 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
       batch: this.batch.enabled,
       concurrency: this.getIndexConcurrency(),
     });
-    const existingState = loadMemorySourceFileState({
+    const existingRows = loadMemorySourceFileState({
       db: this.db,
       source: "memory",
     });
-    const existingRows = existingState.rows;
-    const existingHashes = existingState.hashes;
+    const existingHashes = new Map(existingRows.map((row) => [row.path, row.hash]));
     const activePaths = new Set(fileEntries.map((entry) => entry.path));
     if (params.progress) {
       params.progress.total += fileEntries.length;
@@ -204,7 +203,7 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
         : loadMemorySourceFileState({
             db: this.db,
             source: "sessions",
-          }).rows,
+          }),
       sessionPathForFile: (file) => this.sessionPathForCorpusEntry(corpusEntryForPath(file)),
     });
     const { activePaths, existingRows, existingHashes, indexAll } = sessionPlan;
@@ -267,7 +266,7 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
         loadMemorySourceFileState({
           db: this.db,
           source: "sessions",
-        }).rows.map((row) => row.path),
+        }).map((row) => row.path),
       );
       for (const file of targetArchiveFiles) {
         const corpusEntry = corpusEntryForPath(file);

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -88,14 +88,16 @@ type MemoryIndexEntry = {
   content?: string;
 };
 
-function createDbMock(): DatabaseSync {
-  return {
-    prepare: vi.fn(() => ({
-      all: vi.fn(() => []),
-      get: vi.fn(() => undefined),
-      run: vi.fn(),
-    })),
-  } as unknown as DatabaseSync;
+function createDb(): DatabaseSync {
+  const { DatabaseSync: NodeDatabaseSync } = requireNodeSqlite();
+  const db = new NodeDatabaseSync(":memory:");
+  ensureMemoryIndexSchema({
+    db,
+    cacheEnabled: true,
+    ftsEnabled: false,
+    ftsTokenizer: "unicode61",
+  });
+  return db;
 }
 
 class SessionSyncYieldHarness extends MemoryManagerSyncOps {
@@ -121,25 +123,22 @@ class SessionSyncYieldHarness extends MemoryManagerSyncOps {
   protected readonly cache = { enabled: false };
   protected providerUnavailableReason?: string;
   protected providerLifecycle = { mode: "active" as const, providerId: "test" };
-  protected publishedDatabase = new MemoryIndexDatabase(createDbMock());
+  protected publishedDatabase: MemoryIndexDatabase;
 
   readonly indexedPaths: string[] = [];
   private corpusFiles: string[] = [];
 
-  constructor(private readonly onIndexFile: (count: number) => void) {
+  constructor(
+    db: DatabaseSync,
+    private readonly onIndexFile: (count: number) => void,
+  ) {
     super();
+    this.publishedDatabase = new MemoryIndexDatabase(db);
   }
 
   async syncTargetArchiveFiles(files: string[]): Promise<void> {
     this.corpusFiles = files;
-    await (
-      this as unknown as {
-        syncArchiveFiles: (params: {
-          needsFullReindex: boolean;
-          targetArchiveFiles: string[];
-        }) => Promise<void>;
-      }
-    ).syncArchiveFiles({
+    await this.syncArchiveFiles({
       needsFullReindex: false,
       targetArchiveFiles: files,
     });
@@ -195,8 +194,7 @@ class EmbeddingCacheSeedHarness extends SessionSyncYieldHarness {
   protected override readonly cache = { enabled: true };
 
   constructor(db: DatabaseSync) {
-    super(() => {});
-    this.publishedDatabase = new MemoryIndexDatabase(db);
+    super(db, () => {});
   }
 
   async seedCache(sourceDb: DatabaseSync): Promise<void> {
@@ -238,34 +236,25 @@ describe("session sync responsiveness", () => {
       });
     });
     const observedBeforeLastFile: boolean[] = [];
-    const harness = new SessionSyncYieldHarness((count) => {
+    const db = createDb();
+    const harness = new SessionSyncYieldHarness(db, (count) => {
       if (count === 11) {
         observedBeforeLastFile.push(immediateRan);
       }
     });
 
-    await harness.syncTargetArchiveFiles(files);
-
-    expect(harness.indexedPaths).toHaveLength(files.length);
-    expect(observedBeforeLastFile).toEqual([true]);
-    await immediate;
+    try {
+      await harness.syncTargetArchiveFiles(files);
+      expect(harness.indexedPaths).toHaveLength(files.length);
+      expect(observedBeforeLastFile).toEqual([true]);
+      await immediate;
+    } finally {
+      db.close();
+    }
   });
 });
 
 describe("embedding cache seed responsiveness", () => {
-  const { DatabaseSync: NodeDatabaseSync } = requireNodeSqlite();
-
-  function createCacheDb(): DatabaseSync {
-    const db = new NodeDatabaseSync(":memory:");
-    ensureMemoryIndexSchema({
-      db,
-      cacheEnabled: true,
-      ftsEnabled: false,
-      ftsTokenizer: "unicode61",
-    });
-    return db;
-  }
-
   function countCacheRows(db: DatabaseSync): number {
     const row = db.prepare("SELECT count(*) AS count FROM memory_embedding_cache").get() as {
       count: number;
@@ -274,8 +263,8 @@ describe("embedding cache seed responsiveness", () => {
   }
 
   it("commits each materialized page before yielding", async () => {
-    const sourceDb = createCacheDb();
-    const targetDb = createCacheDb();
+    const sourceDb = createDb();
+    const targetDb = createDb();
     try {
       const insert = sourceDb.prepare(
         `INSERT INTO memory_embedding_cache


### PR DESCRIPTION
## What Problem This Solves

Memory source inspection and session reconciliation built a complete path-to-hash map even when their callers used only the source rows. Several callers immediately built the different lookup structure they actually needed, retaining unnecessary work for large indexed corpora.

## Why This Change Was Made

The source-state reader now returns its rows directly. Memory-file synchronization builds its required hash map at the original snapshot boundary; status inspection, startup catchup, session planning, and targeted cleanup stop constructing and discarding an extra map.

Both ordinary source-state queries now use the existing synchronous Kysely helpers. This removes the mock-shaped database interface, handwritten SQL, result casts, and impossible undefined-array fallback. The full row projection, source predicates, snapshot precedence, and query timing are preserved. No schema, configuration, retention, migration, or SDK surface changes are introduced.

## User Impact

Memory status and session reconciliation allocate less intermediate state while keeping the same dirty-state detection, indexing, and pruning behavior. Production code is three lines smaller, and the SQL-string mock tests are replaced with shorter real-SQLite coverage.

## Evidence

All required changed checks passed, including extension/test typechecks, lint, boundaries, and runtime import-cycle checks.

The focused source-state, session-planning, startup-catchup, and update/forget-race suites passed 66 tests. Three additional public manager cases passed for offline source edits, canonical session discovery, and pruning removed sessions without re-embedding survivors.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  extensions/memory-core/src/memory/manager-source-state.test.ts \
  extensions/memory-core/src/memory/manager-session-sync-state.test.ts \
  extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts \
  extensions/memory-core/src/memory/manager-session-update-race.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  extensions/memory-core/src/memory/index.test.ts \
  -t 'detects offline source edits|diagnostic status uses canonical session discovery|prunes removed sessions'
```

A native probe on Node 24.20.0 read 20,000 synthetic indexed source rows before and after the change. The complete row digest was identical. Both versions used one bulk query, zero queries for supplied snapshots, and three scoped point queries. The reader's unused hash map went from 20,000 entries to zero. Source separation, fractional modification times, an empty snapshot, fresh point reads, and a quoted missing path retained their behavior; SQLite integrity remained healthy. These are allocation-structure and query-count observations, not wall-clock or peak-RSS measurements.

Removing the two raw result casts also removes this file's grandfathered assertion-baseline entry. Targeted archive cleanup still reads the full source snapshot; narrowing that query is a separate follow-up requiring explicit large-target and snapshot semantics.

Independent Codex review of the complete frozen patch and owner/caller/dependency context was scoped-clean through P2. The [composed native CLI/Gateway proof](https://github.com/openclaw/openclaw/pull/138709#issuecomment-5547832078) passed all six phases, including offline edits, indexing, deletion, canonical-session pruning and fresh-process reopen.

CI caught an older responsiveness fixture whose fake database lacked native iteration. That fixture now uses the real SQLite schema already used by its cache-seeding sibling, with explicit connection ownership and unchanged yield assertions. The original failure reproduced locally; the repaired fixture and source-state suite passed all 8 tests, required changed checks passed, and a fresh full-patch independent review was scoped-clean through P2. The repair changes tests only; the production files exercised in the live proof are unchanged. Overall production net−3, tests net−35, assertion baseline−1. Exact-head hosted CI is rerunning.
