### PR TITLE
fix(sqlite): avoid writes when reacquiring data-free coordinators

### DIFF
--- a/src/infra/node-sqlite.ts
+++ b/src/infra/node-sqlite.ts
@@ -122,7 +122,11 @@ export function tryAcquireExclusiveSqliteCoordinator(
   const database = openNodeSqliteDatabase(location);
   try {
     // Kysely transaction callbacks cannot own a lock beyond their synchronous commit section.
-    database.exec(`PRAGMA busy_timeout = ${busyTimeoutMs}; BEGIN EXCLUSIVE;`);
+    // This handle never writes or commits data. Keep the empty database's initial
+    // journal in memory so acquiring a lock does not create filesystem artifacts.
+    database.exec(
+      `PRAGMA busy_timeout = ${busyTimeoutMs}; PRAGMA journal_mode = MEMORY; BEGIN EXCLUSIVE;`,
+    );
   } catch (error) {
     database.close();
     if (isSqliteLockError(error)) {

--- a/src/infra/sqlite-coordinator.test.ts
+++ b/src/infra/sqlite-coordinator.test.ts
@@ -1,0 +1,180 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { openNodeSqliteDatabase, tryAcquireExclusiveSqliteCoordinator } from "./node-sqlite.js";
+import { ensurePrivateSqliteCoordinatorDirectory } from "./sqlite-coordinator.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const loader = new URL("../../scripts/tsx.mjs", import.meta.url).href;
+const moduleUrl = new URL("./node-sqlite.ts", import.meta.url).href;
+
+function observeDirectory(directory: string) {
+  // Stat only: opening and closing the coordinator in this process could drop
+  // the holder's POSIX locks and invalidate the contender observation.
+  return [".", ...fs.readdirSync(directory).toSorted()].map((name) => {
+    const stat = fs.lstatSync(path.join(directory, name), { bigint: true });
+    return {
+      name,
+      dev: stat.dev,
+      ino: stat.ino,
+      mode: stat.mode,
+      size: stat.size,
+      mtimeNs: stat.mtimeNs,
+      ctimeNs: stat.ctimeNs,
+    };
+  });
+}
+
+function runPeer(script: string, pathname: string) {
+  return execFileSync(
+    process.execPath,
+    ["--import", loader, "--input-type=module", "-e", script, pathname],
+    { encoding: "utf8", timeout: 15_000, stdio: ["ignore", "pipe", "pipe"] },
+  ).trim();
+}
+
+const acquirePeer = `
+  import { tryAcquireExclusiveSqliteCoordinator } from ${JSON.stringify(moduleUrl)};
+  const coordinator = tryAcquireExclusiveSqliteCoordinator(process.argv[1]);
+  process.stdout.write(coordinator ? "held" : "blocked");
+  coordinator?.release();
+`;
+
+describe("data-free SQLite coordinator", () => {
+  it("leaves an existing coordinator unchanged while excluding current and default-journal peers", () => {
+    const directory = tempDirs.make("openclaw-sqlite-coordinator-");
+    const pathname = path.join(directory, "coordinator.sqlite");
+    const initialize = openNodeSqliteDatabase(pathname);
+    initialize.exec("BEGIN EXCLUSIVE; ROLLBACK;");
+    initialize.close();
+    const before = observeDirectory(directory);
+    const bytes = fs.readFileSync(pathname);
+    const coordinator = tryAcquireExclusiveSqliteCoordinator(pathname);
+    expect(coordinator).not.toBeNull();
+    try {
+      expect(observeDirectory(directory)).toEqual(before);
+      expect(runPeer(acquirePeer, pathname)).toBe("blocked");
+      // Swift and older Node peers use the default rollback journal mode.
+      expect(
+        runPeer(
+          `import { DatabaseSync } from "node:sqlite";
+          const database = new DatabaseSync(process.argv[1]);
+          try {
+            database.exec("PRAGMA busy_timeout=0; BEGIN EXCLUSIVE;");
+            process.stdout.write("held");
+            database.exec("ROLLBACK;");
+          } catch (error) {
+            if (error.errcode !== 5) throw error;
+            process.stdout.write("blocked");
+          } finally { database.close(); }`,
+          pathname,
+        ),
+      ).toBe("blocked");
+      expect(observeDirectory(directory)).toEqual(before);
+    } finally {
+      coordinator?.release();
+    }
+    expect(runPeer(acquirePeer, pathname)).toBe("held");
+    expect(observeDirectory(directory)).toEqual(before);
+    expect(fs.readFileSync(pathname)).toEqual(bytes);
+  });
+
+  it("creates a missing coordinator without a journal and permits retry after owner exit", () => {
+    const directory = tempDirs.make("openclaw-sqlite-coordinator-exit-");
+    const pathname = path.join(directory, "coordinator.sqlite");
+    const coordinator = tryAcquireExclusiveSqliteCoordinator(pathname);
+    expect(coordinator).not.toBeNull();
+    try {
+      expect(fs.readdirSync(directory)).toEqual(["coordinator.sqlite"]);
+    } finally {
+      coordinator?.release();
+    }
+    const before = observeDirectory(directory);
+    expect(
+      runPeer(
+        `import { tryAcquireExclusiveSqliteCoordinator } from ${JSON.stringify(moduleUrl)};
+        if (!tryAcquireExclusiveSqliteCoordinator(process.argv[1])) process.exit(1);
+        process.stdout.write("held");
+        process.exit(0);`,
+        pathname,
+      ),
+    ).toBe("held");
+    expect(runPeer(acquirePeer, pathname)).toBe("held");
+    expect(observeDirectory(directory)).toEqual(before);
+    expect(fs.readFileSync(pathname)).toHaveLength(0);
+  });
+
+  it("does not change ordinary state connection durability", () => {
+    const directory = tempDirs.make("openclaw-sqlite-state-durability-");
+    const pathname = path.join(directory, "state.sqlite");
+    const database = openNodeSqliteDatabase(pathname);
+    try {
+      database.exec("PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL; CREATE TABLE probe(id);");
+      const coordinator = tryAcquireExclusiveSqliteCoordinator(path.join(directory, "lock.sqlite"));
+      expect(coordinator).not.toBeNull();
+      try {
+        expect(database.prepare("PRAGMA journal_mode").get()).toEqual({ journal_mode: "wal" });
+        expect(database.prepare("PRAGMA synchronous").get()).toEqual({ synchronous: 2 });
+        database.exec("INSERT INTO probe VALUES(1);");
+      } finally {
+        coordinator?.release();
+      }
+    } finally {
+      database.close();
+    }
+    const reopened = openNodeSqliteDatabase(pathname);
+    try {
+      expect(reopened.prepare("SELECT id FROM probe").all()).toEqual([{ id: 1 }]);
+      expect(reopened.prepare("PRAGMA journal_mode").get()).toEqual({ journal_mode: "wal" });
+    } finally {
+      reopened.close();
+    }
+  });
+});
+
+describe.skipIf(process.platform === "win32")("private coordinator directory", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("does not mutate an already-private directory", () => {
+    const directory = tempDirs.make("openclaw-private-coordinator-");
+    fs.chmodSync(directory, 0o700);
+    const before = observeDirectory(directory);
+    const chmod = vi.spyOn(fs, "chmodSync");
+    ensurePrivateSqliteCoordinatorDirectory(directory, "test");
+    expect(chmod).not.toHaveBeenCalled();
+    expect(observeDirectory(directory)).toEqual(before);
+  });
+
+  it.each([0o755, 0o500, 0o1700])("still hardens mode %s", (mode) => {
+    const directory = tempDirs.make("openclaw-private-coordinator-mode-");
+    fs.chmodSync(directory, mode);
+    ensurePrivateSqliteCoordinatorDirectory(directory, "test");
+    expect(fs.lstatSync(directory).mode & 0o7777).toBe(0o700);
+  });
+
+  it("rejects a symlink without changing its target", () => {
+    const directory = tempDirs.make("openclaw-private-coordinator-link-");
+    const target = path.join(directory, "target");
+    const alias = path.join(directory, "alias");
+    fs.mkdirSync(target, { mode: 0o755 });
+    fs.symlinkSync(target, alias);
+    const before = observeDirectory(directory);
+    expect(() => ensurePrivateSqliteCoordinatorDirectory(alias, "test")).toThrow("real directory");
+    expect(observeDirectory(directory)).toEqual(before);
+  });
+
+  it("refuses foreign ownership before chmod", () => {
+    const directory = tempDirs.make("openclaw-private-coordinator-owner-");
+    fs.chmodSync(directory, 0o755);
+    const before = observeDirectory(directory);
+    vi.spyOn(process, "getuid").mockReturnValue(fs.lstatSync(directory).uid + 1);
+    const chmod = vi.spyOn(fs, "chmodSync");
+    expect(() => ensurePrivateSqliteCoordinatorDirectory(directory, "test")).toThrow(
+      "belongs to another user",
+    );
+    expect(chmod).not.toHaveBeenCalled();
+    expect(observeDirectory(directory)).toEqual(before);
+  });
+});

--- a/src/infra/sqlite-coordinator.ts
+++ b/src/infra/sqlite-coordinator.ts
@@ -79,7 +79,9 @@ export function ensurePrivateSqliteCoordinatorDirectory(
     throw new SqliteCoordinatorError(`${coordinatorLabel} directory belongs to another user`);
   }
   if (process.platform !== "win32") {
-    applyPrivateModeSync(directoryPath, 0o700);
+    if ((stats.mode & 0o7777) !== 0o700) {
+      applyPrivateModeSync(directoryPath, 0o700);
+    }
     const secured = fs.lstatSync(directoryPath);
     if (secured.isSymbolicLink() || !secured.isDirectory() || (secured.mode & 0o077) !== 0) {
       throw new SqliteCoordinatorError(`${coordinatorLabel} directory permissions are not private`);

--- a/src/infra/state-database-coordinator.test.ts
+++ b/src/infra/state-database-coordinator.test.ts
@@ -11,6 +11,38 @@ import {
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("state database coordinator", () => {
+  it.each([
+    ["state", acquireStateDatabaseCoordinator],
+    ["Gateway", acquireGatewayLifecycleCoordinator],
+  ] as const)(
+    "reacquires an existing %s coordinator without filesystem changes",
+    async (_, acquire) => {
+      const root = tempDirs.make("openclaw-lifecycle-coordinator-noop-");
+      const params = {
+        databasePath: path.join(root, "state", "openclaw.sqlite"),
+        runtimeDirectory: root,
+      };
+      const first = acquire(params);
+      const coordinatorPath = first.path;
+      first.release();
+      const directory = path.dirname(coordinatorPath);
+      const beforeDirectory = await fs.stat(directory, { bigint: true });
+      const beforeFile = await fs.stat(coordinatorPath, { bigint: true });
+      const next = acquire(params);
+      try {
+        expect(await fs.readdir(directory)).toEqual([path.basename(coordinatorPath)]);
+        const afterDirectory = await fs.stat(directory, { bigint: true });
+        const afterFile = await fs.stat(coordinatorPath, { bigint: true });
+        for (const key of ["ino", "mode", "size", "mtimeNs", "ctimeNs"] as const) {
+          expect(afterDirectory[key]).toBe(beforeDirectory[key]);
+          expect(afterFile[key]).toBe(beforeFile[key]);
+        }
+      } finally {
+        next.release();
+      }
+    },
+  );
+
   it("reference-counts same-process owners", async () => {
     const root = tempDirs.make("openclaw-state-database-coordinator-");
     const databasePath = path.join(root, "selected-state", "state", "openclaw.sqlite");


### PR DESCRIPTION
Related: #124396, atomic update recovery.

<details>
<summary>Additional instructions</summary>

Keep Allow edits from maintainers enabled for this PR.

</details>

## What Problem This Solves

Resolves a problem where acquiring an existing coordination lock creates a temporary SQLite journal and changes directory metadata even when no state update is admitted. Reusing an already-private coordination directory also changes its ctime. Those writes prevent a rejected cold recovery request from leaving existing files unchanged.

## Why This Change Was Made

Use a connection-local memory journal only for the existing data-free, exclusive lock handle. Skip chmod when the verified owner directory already has exact 0700 permissions. The handle exposes only release and never commits data; ordinary state database durability and the existing ownership checks remain unchanged.

This repairs helpers already used by Gateway, device identity and state lifecycle coordination. It adds no database, schema, persisted format or updater API. The install-bound transaction record, retained bootstrap and recovery command are separate work.

## User Impact

Acquiring, refusing a contender and releasing an existing lock no longer creates a journal or changes the private directory's metadata. Cross-process exclusion, retry after owner exit and permission hardening still work. This prerequisite does not yet recover an interrupted package activation or restart a stopped service.

## Evidence

The unchanged actual-helper probes fail on canonical base `54ef5b3f5f1509dab6c0717d6b466e3db4583ad5` and pass with private patch SHA-256 `e8dbbd861d5dda58c860fc2e0eca45c0f62e42683fbbede2b61cec6583851ad0`. The base creates a 512-byte journal while held and changes an already-private directory's ctime. The patched observations preserve bytes, entries and the protected metadata through acquisition, refusal and release.

- [Isolated AWS/Linux red and green run](https://crabbox.openclaw.ai/portal/runs/run_ca458ee25c47): both base probes fail for the intended mutations, both patched probes pass, and all 14 focused tests pass. Linux x64, Node 24.19.0, SQLite 3.53.3. The task lease was released.
- Original macOS arm64 proof on the frozen patch: the same probes pass, 14 focused tests pass, and 86 existing sibling tests pass. Source-blind validation passes five observation clauses on fresh fixtures.
- Fresh integration on pinned base `0be4cd7512582b66cda1da6e2ee095103bc78a9a` with the unchanged patch: all 66 tests pass across the two coordinator files and three Gateway lock files. The full four-file `check:changed` gate passes with its base pinned to that SHA and no skip flags. Node 24.20.0, SQLite 3.53.4, task-owned frozen dependencies.
- Publication base `66fa0bd2be4f811a6c6dbee8bd5dd102dae8e544`: the helper sources and patch are unchanged. After inspecting the intervening range, reran the three Gateway lock files because their config-path dependency changed; all 52 tests pass. The earlier 66-test and static results remain evidence on their recorded base, not new-head results.
- Final PR base `06759eabcbdd33b24ad131627d354e95fbf6cd93`: inspected all four commits since `66fa0bd2`. The coordinator owners, direct callers, config-path selection, proof fixtures, dependencies and native workflow are unchanged. The exact four-file patch and file modes are preserved. Earlier results retain their original SHA labels; exact-head CI is required before landing.
- Focused command: `node scripts/run-vitest.mjs src/infra/sqlite-coordinator.test.ts src/infra/state-database-coordinator.test.ts --maxWorkers=1`.
- P0-scoped Autoreview found no actionable findings; the subsequent test-only `sort()` to `toSorted()` lint correction changed no production code, assertions or fixtures.

Controls cover default-journal peers, a concurrent contender, owner process exit and successful retry, separate WAL/FULL state durability, directory mode hardening, symlink refusal and foreign-owner refusal with a mocked process UID. Raw API and filesystem observations are the evidence for this invisible behavior. Native Windows, persistent-disk power loss and complete cold admission remain unproven.
