### PR TITLE
refactor(logbook): avoid repeated card reads

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -623,7 +623,7 @@ extensions/logbook/src/analyze.ts	8
 extensions/logbook/src/config.ts	1
 extensions/logbook/src/node-host.ts	1
 extensions/logbook/src/service.ts	6
-extensions/logbook/src/store.ts	19
+extensions/logbook/src/store.ts	17
 extensions/matrix/src/actions.ts	3
 extensions/matrix/src/approval-auth.ts	1
 extensions/matrix/src/approval-handler.runtime.ts	8

--- a/extensions/logbook/index.ts
+++ b/extensions/logbook/index.ts
@@ -164,11 +164,9 @@ export default definePluginEntry({
     // so they require write scope while derived text stays readable.
     registerRead("logbook.days", () => ({ days: requireService().listDays() }));
 
-    registerRead("logbook.timeline", (params) => {
-      const day = readDayParam(params);
-      const svc = requireService();
-      return { day, cards: svc.cardsForDay(day), stats: svc.dayStats(day) };
-    });
+    registerRead("logbook.timeline", (params) =>
+      requireService().timelineForDay(readDayParam(params)),
+    );
 
     registerWrite("logbook.frames", (params) => {
       const startMs = readNumberParam(params, "startMs");

--- a/extensions/logbook/src/card-reads.test.ts
+++ b/extensions/logbook/src/card-reads.test.ts
@@ -1,0 +1,125 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { GatewayRequestHandlerOptions } from "openclaw/plugin-sdk/gateway-runtime";
+import type { OpenClawPluginApi, OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
+import { afterEach, expect, it, vi } from "vitest";
+import plugin from "../index.js";
+import { LogbookStore } from "./store.js";
+
+const cardReads = vi.hoisted(() => ({ queries: 0, payloadRows: 0 }));
+
+vi.mock("openclaw/plugin-sdk/sqlite-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/sqlite-runtime")>();
+  return {
+    ...actual,
+    openNodeSqliteDatabase: (...args: Parameters<typeof actual.openNodeSqliteDatabase>) => {
+      const db = actual.openNodeSqliteDatabase(...args);
+      const prepare = db.prepare.bind(db);
+      vi.spyOn(db, "prepare").mockImplementation((sql) => {
+        const statement = prepare(sql);
+        if (!/\bfrom\s+"?cards\b/i.test(sql)) {
+          return statement;
+        }
+        const all = statement.all.bind(statement);
+        vi.spyOn(statement, "all").mockImplementation((...bindings) => {
+          cardReads.queries++;
+          const rows = all(...bindings);
+          cardReads.payloadRows += rows.filter((row) => "distractions" in row).length;
+          return rows;
+        });
+        const iterate = statement.iterate.bind(statement);
+        vi.spyOn(statement, "iterate").mockImplementation(function* (...bindings) {
+          cardReads.queries++;
+          for (const row of iterate(...bindings)) {
+            if ("distractions" in row) {
+              cardReads.payloadRows++;
+            }
+            yield row;
+          }
+          return undefined;
+        });
+        return statement;
+      });
+      return db;
+    },
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+it("hydrates a timeline once and counts status without reading card payloads", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-07-03T12:00:00"));
+  const stateDir = realpathSync(mkdtempSync(path.join(tmpdir(), "logbook-card-reads-")));
+  const services: OpenClawPluginService[] = [];
+  const methods = new Map<string, Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]>();
+  const context = {
+    stateDir,
+    config: {},
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+  };
+  const store = new LogbookStore(path.join(stateDir, "logbook"));
+  const day = "2026-07-03";
+  const startMs = new Date(`${day}T09:00:00`).getTime();
+  const drafts = Array.from({ length: 8 }, (_, index) => ({
+    day,
+    startMs: startMs + index * 60_000,
+    endMs: startMs + (index + 1) * 60_000,
+    title: `Card ${index} 🦞`,
+    summary: "Summary",
+    detail: "Detailed activity",
+    category: "coding",
+    distractions: [{ startMs: startMs + 1, endMs: startMs + 11, title: "Break" }],
+  }));
+  store.replaceCardsInWindow(day, 0, Number.MAX_SAFE_INTEGER, drafts);
+  const cards = store.cardsForDay(day);
+  store.close();
+
+  plugin.register({
+    pluginConfig: { captureEnabled: false },
+    runtime: {},
+    session: { controls: { registerControlUiDescriptor() {} } },
+    registerNodeInvokePolicy() {},
+    registerService: (service: OpenClawPluginService) => services.push(service),
+    registerGatewayMethod: (
+      method: string,
+      handler: Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1],
+    ) => methods.set(method, handler),
+  } as unknown as OpenClawPluginApi);
+  const service = services[0]!;
+  try {
+    await service.start(context);
+    const call = async (method: string, params = {}) => {
+      const respond = vi.fn();
+      await methods.get(method)!({ params, respond } as unknown as GatewayRequestHandlerOptions);
+      expect(respond.mock.calls[0]?.[0]).toBe(true);
+      return respond.mock.calls[0]?.[1];
+    };
+    cardReads.queries = 0;
+    cardReads.payloadRows = 0;
+    expect(await call("logbook.timeline", { day })).toEqual({
+      day,
+      cards,
+      stats: {
+        trackedMs: 8 * 60_000,
+        distractionMs: 80,
+        categories: [{ category: "coding", ms: 8 * 60_000 }],
+        apps: [],
+      },
+    });
+    expect.soft(cardReads.queries).toBe(1);
+    expect.soft(cardReads.payloadRows).toBe(cards.length);
+
+    cardReads.queries = 0;
+    cardReads.payloadRows = 0;
+    expect(await call("logbook.status")).toMatchObject({ today: day, todayCards: 8 });
+    expect.soft(cardReads.payloadRows).toBe(0);
+  } finally {
+    await service.stop?.(context);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});

--- a/extensions/logbook/src/service.ts
+++ b/extensions/logbook/src/service.ts
@@ -29,7 +29,7 @@ import {
   OBSERVATION_JSON_SCHEMA,
 } from "./prompts.js";
 import { dayKeyFor, LogbookStore } from "./store.js";
-import type { LogbookBatch, LogbookCard } from "./types.js";
+import type { LogbookBatch } from "./types.js";
 
 const ANALYSIS_TICK_MS = 60 * 1000;
 const PRUNE_TICK_MS = 60 * 60 * 1000;
@@ -493,9 +493,10 @@ export class LogbookService {
   private async reviseCards(batch: LogbookBatch): Promise<void> {
     const store = this.requireStore();
     const lookbackStart = batch.startMs - CARD_LOOKBACK_MS;
-    const previousCards = store
-      .cardsForDay(batch.day)
-      .filter((card) => card.endMs > lookbackStart && card.startMs < batch.endMs);
+    const previousCards = store.cardsForDay(batch.day, {
+      startMs: lookbackStart,
+      endMs: batch.endMs,
+    });
     const observations = store.observationsInRange(
       batch.day,
       Math.min(lookbackStart, batch.startMs),
@@ -626,16 +627,12 @@ export class LogbookService {
 
   // ── Introspection ──────────────────────────────────────────────────
 
-  cardsForDay(day: string): LogbookCard[] {
-    return this.requireStore().cardsForDay(day);
+  timelineForDay(day: string): ReturnType<LogbookStore["timelineForDay"]> {
+    return this.requireStore().timelineForDay(day);
   }
 
   listDays(): ReturnType<LogbookStore["listDays"]> {
     return this.requireStore().listDays();
-  }
-
-  dayStats(day: string): ReturnType<LogbookStore["dayStats"]> {
-    return this.requireStore().dayStats(day);
   }
 
   frameById(id: number): ReturnType<LogbookStore["frameById"]> {
@@ -675,7 +672,7 @@ export class LogbookService {
       visionModel: vision.ref ? `${vision.ref.provider}/${vision.ref.model}` : undefined,
       visionModelSource: vision.source,
       today,
-      todayCards: store.cardsForDay(today).length,
+      todayCards: store.countCardsForDay(today),
       timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     };
   }

--- a/extensions/logbook/src/store.test.ts
+++ b/extensions/logbook/src/store.test.ts
@@ -307,6 +307,14 @@ describe("LogbookStore", () => {
       draft({ startMs: base, endMs: base + 30 * 60_000, title: "Early" }),
       draft({ startMs: base + 60 * 60_000, endMs: base + 90 * 60_000, title: "Mid" }),
     ]);
+    expect(
+      store.cardsForDay(DAY, { startMs: base + 30 * 60_000, endMs: base + 60 * 60_000 }),
+    ).toEqual([]);
+    expect(
+      store
+        .cardsForDay(DAY, { startMs: base + 50 * 60_000, endMs: base + 2 * 60 * 60_000 })
+        .map((card) => card.title),
+    ).toEqual(["Mid"]);
     // Revise only the window covering "Mid"; "Early" must survive untouched.
     store.replaceCardsInWindow(DAY, base + 50 * 60_000, base + 2 * 60 * 60_000, [
       draft({ startMs: base + 55 * 60_000, endMs: base + 95 * 60_000, title: "Mid revised" }),
@@ -321,16 +329,40 @@ describe("LogbookStore", () => {
       draft({
         distractions: [{ startMs: base + 5 * 60_000, endMs: base + 10 * 60_000, title: "Twitter" }],
       }),
+      draft({ title: "Review", category: "review", appPrimary: undefined, appSecondary: "" }),
     ]);
+    const database = new DatabaseSync(path.join(dir, "logbook.sqlite"));
+    try {
+      database.prepare("UPDATE cards SET distractions = ? WHERE title = ?").run("{", "Review");
+    } finally {
+      database.close();
+    }
     const cards = store.cardsForDay(DAY);
+    expect(cards.map((card) => card.title)).toEqual(["Card", "Review"]);
+    expect(cards[1]).toMatchObject({
+      appPrimary: undefined,
+      appSecondary: "",
+      keyframeId: undefined,
+      distractions: [],
+    });
     expect(expectDefined(cards[0], "stored logbook card").distractions).toEqual([
       { startMs: base + 5 * 60_000, endMs: base + 10 * 60_000, title: "Twitter" },
     ]);
-    const stats = store.dayStats(DAY);
-    expect(stats.trackedMs).toBe(30 * 60_000);
+    const stats = store.timelineForDay(DAY).stats;
+    expect(stats.trackedMs).toBe(60 * 60_000);
     expect(stats.distractionMs).toBe(5 * 60_000);
-    expect(stats.categories[0]).toEqual({ category: "coding", ms: 30 * 60_000 });
+    expect(stats.categories).toEqual([
+      { category: "coding", ms: 30 * 60_000 },
+      { category: "review", ms: 30 * 60_000 },
+    ]);
     expect(expectDefined(stats.apps[0], "logbook app statistic").domain).toBe("github.com");
+    expect(store.countCardsForDay(DAY)).toBe(cards.length);
+    expect(store.countCardsForDay("2026-07-04")).toBe(0);
+    expect(store.timelineForDay("2026-07-04")).toEqual({
+      day: "2026-07-04",
+      cards: [],
+      stats: { trackedMs: 0, distractionMs: 0, categories: [], apps: [] },
+    });
   });
 
   it("prunes old frame rows and files but keeps recent ones", () => {

--- a/extensions/logbook/src/store.ts
+++ b/extensions/logbook/src/store.ts
@@ -1,13 +1,15 @@
 // Logbook SQLite store: frames on disk, everything else in one plugin-owned DB.
-// Uses node:sqlite prepared statements directly (extension-local store, same
-// pattern as memory-core/imessage); the shared Kysely helpers are core-only.
 import { chmodSync, mkdirSync, rmdirSync, rmSync } from "node:fs";
 import path from "node:path";
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import {
   configureSqliteConnectionPragmas,
   migrateSqliteSchemaToStrict,
 } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
   openNodeSqliteDatabase,
   runSqliteImmediateTransactionSync,
 } from "openclaw/plugin-sdk/sqlite-runtime";
@@ -127,6 +129,7 @@ type CardRow = {
   app_secondary: string | null;
   distractions: string;
   keyframe_id: number | null;
+  updated_ms: number;
 };
 
 function toFrame(row: FrameRow): LogbookFrame {
@@ -202,6 +205,7 @@ export function dayKeyFor(ms: number): string {
 
 export class LogbookStore {
   private readonly db: Database;
+  private readonly cardsQuery;
   private readonly walMaintenance: ReturnType<typeof configureSqliteConnectionPragmas>;
   readonly framesDir: string;
 
@@ -251,6 +255,7 @@ export class LogbookStore {
     }
     this.db = db;
     this.walMaintenance = walMaintenance;
+    this.cardsQuery = getNodeSqliteKysely<{ cards: CardRow }>(db).selectFrom("cards");
   }
 
   close(): void {
@@ -494,24 +499,20 @@ export class LogbookStore {
     }));
   }
 
-  cardsForDay(day: string): LogbookCard[] {
-    const rows = this.db
-      .prepare(
-        `SELECT id, day, start_ms, end_ms, title, summary, detail, category, app_primary, app_secondary, distractions, keyframe_id
-         FROM cards WHERE day = ? ORDER BY start_ms ASC`,
-      )
-      .all(day) as CardRow[];
-    return rows.map(toCard);
+  cardsForDay(day: string, window?: { startMs: number; endMs: number }): LogbookCard[] {
+    let query = this.cardsQuery.selectAll().where("day", "=", day).orderBy("start_ms", "asc");
+    if (window) {
+      query = query.where("end_ms", ">", window.startMs).where("start_ms", "<", window.endMs);
+    }
+    return executeSqliteQuerySync(this.db, query).rows.map(toCard);
   }
 
-  cardById(id: number): LogbookCard | null {
-    const row = this.db
-      .prepare(
-        `SELECT id, day, start_ms, end_ms, title, summary, detail, category, app_primary, app_secondary, distractions, keyframe_id
-         FROM cards WHERE id = ?`,
-      )
-      .get(id) as CardRow | undefined;
-    return row ? toCard(row) : null;
+  countCardsForDay(day: string): number {
+    const row = executeSqliteQueryTakeFirstSync(
+      this.db,
+      this.cardsQuery.select((eb) => eb.fn.countAll<number>().as("count")).where("day", "=", day),
+    );
+    return expectDefined(row, "Logbook card count").count;
   }
 
   /**
@@ -577,7 +578,7 @@ export class LogbookStore {
     }));
   }
 
-  dayStats(day: string): LogbookDayStats {
+  timelineForDay(day: string): { day: string; cards: LogbookCard[]; stats: LogbookDayStats } {
     const cards = this.cardsForDay(day);
     const categories = new Map<string, number>();
     const apps = new Map<string, number>();
@@ -596,12 +597,16 @@ export class LogbookStore {
     }
     const byMsDesc = (a: { ms: number }, b: { ms: number }) => b.ms - a.ms;
     return {
-      trackedMs,
-      distractionMs,
-      categories: [...categories.entries()]
-        .map(([category, ms]) => ({ category, ms }))
-        .toSorted(byMsDesc),
-      apps: [...apps.entries()].map(([domain, ms]) => ({ domain, ms })).toSorted(byMsDesc),
+      day,
+      cards,
+      stats: {
+        trackedMs,
+        distractionMs,
+        categories: [...categories.entries()]
+          .map(([category, ms]) => ({ category, ms }))
+          .toSorted(byMsDesc),
+        apps: [...apps.entries()].map(([domain, ms]) => ({ domain, ms })).toSorted(byMsDesc),
+      },
     };
   }
 


### PR DESCRIPTION
## What Problem This Solves

A normal Logbook dashboard refresh decoded every card three times: twice for the timeline and its statistics, then again just to count today's cards. Card revision also loaded the entire day before selecting the overlapping window.

## Why This Change Was Made

The store now returns the timeline and its statistics from one card snapshot, counts today's cards directly, and applies the existing revision overlap predicates in the typed Kysely query. The unused private card lookup and redundant service wrappers are removed.

Card decoding, ordering, timeline response fields, schema, writes, retention, and authorization remain unchanged. This is a bounded read cleanup; it introduces no new database or adapter surface.

## User Impact

Dashboard refreshes and card revision read less intermediate data. Production code remains the same size (+41/-41); tests grow by 157 lines and the assertion baseline shrinks for the removed casts.

## Evidence

All 67 tests across six Logbook suites passed, together with the required changed checks, production/test typechecks, lint and boundaries. The registered Gateway RPC regression failed on the original implementation because timeline read 16 payload rows for 8 cards and status read 8 payload rows; it passes with one timeline read and no status payloads.

A real SQLite before/after probe with 64 synthetic cards produced identical complete timeline, status and revision payloads. Timeline changed from 2 queries/128 payload rows to 1 query/64 rows; status from 64 payload rows to one 12-byte count row; revision from 64 rows to the same 3 overlapping rows. Native close/reopen and integrity checks passed. All nine write methods and the complete schema are byte-identical to the base. These are query/materialization observations, not latency benchmarks.

Independent Codex review of the frozen patch and full owner/caller/dependency context was scoped-clean through P2. The [real Gateway and restart proof](https://github.com/openclaw/openclaw/pull/138709#issuecomment-5547832078) passed with 64 synthetic cards across two days, default/explicit/empty timeline calls, identical wire payloads after restart, capture disabled and no frames or batches.

Follow-ups in the ongoing SQLite audit: ordinary noncard queries and bounded observation reads, plus service shutdown draining for already-accepted asynchronous capture/analysis. They do not change the read semantics covered here.
