### PR TITLE
feat(exec): show a plain-English purpose on approval prompts

### DIFF
--- a/extensions/whatsapp/src/approval-copy.ts
+++ b/extensions/whatsapp/src/approval-copy.ts
@@ -1,0 +1,21 @@
+// WhatsApp-specific approval copy helpers.
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
+
+const DEFAULT_EXEC_PURPOSE = "Runs the command shown below.";
+
+/** Adds a short purpose immediately below the approval heading. */
+export function addWhatsAppExecPurpose(params: {
+  text?: string;
+  approvalKind: ChannelApprovalKind;
+  purpose?: string | null;
+}): string | undefined {
+  if (!params.text || params.approvalKind !== "exec") {
+    return params.text;
+  }
+  const purpose = params.purpose?.trim() || DEFAULT_EXEC_PURPOSE;
+  const section = `**What this does:** ${purpose}`;
+  const firstSectionEnd = params.text.indexOf("\n\n");
+  return firstSectionEnd < 0
+    ? `${params.text}\n\n${section}`
+    : `${params.text.slice(0, firstSectionEnd)}\n\n${section}\n\n${params.text.slice(firstSectionEnd + 2)}`;
+}

--- a/extensions/whatsapp/src/approval-handler.runtime.test.ts
+++ b/extensions/whatsapp/src/approval-handler.runtime.test.ts
@@ -22,6 +22,7 @@ describe("whatsappApprovalNativeRuntime", () => {
         approvalKind: "exec",
         approvalId: "exec-1",
         commandText: "echo hi",
+        purpose: "Checks that command execution is working.",
         actions: [
           {
             decision: "allow-once",
@@ -39,12 +40,47 @@ describe("whatsappApprovalNativeRuntime", () => {
       } as never,
     });
 
+    expect(payload.reactionPayload.text).toContain(
+      "**What this does:** Checks that command execution is working.",
+    );
+    expect(payload.reactionPayload.text?.indexOf("**What this does:**")).toBeLessThan(
+      payload.reactionPayload.text?.indexOf("**Pending command:**") ?? -1,
+    );
+    expect(payload.manualFallbackPayload.text).toContain(
+      "**What this does:** Checks that command execution is working.",
+    );
     expect(payload.reactionPayload.text).toContain("👍 Allow Once");
     expect(payload.reactionPayload.text).toContain("👎 Deny");
     expect(payload.reactionPayload.text).not.toContain("1️⃣ Allow Once");
     expect(payload.reactionPayload.text).not.toContain("2️⃣ Allow Always");
     expect(payload.reactionPayload.text).not.toContain("3️⃣ Deny");
     expect(payload.reactionPayload.allowedDecisions).toEqual(["allow-once", "deny"]);
+  });
+
+  it("uses a short fallback explanation when an older exec request has no purpose", async () => {
+    const payload = await whatsappApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: { accountId: "default" },
+      request: {
+        id: "exec-legacy",
+        request: { command: "echo hi" },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      approvalKind: "exec",
+      nowMs: 0,
+      view: {
+        approvalKind: "exec",
+        approvalId: "exec-legacy",
+        commandText: "echo hi",
+        actions: [],
+      } as never,
+    });
+
+    expect(payload.reactionPayload.text).toContain(
+      "**What this does:** Runs the command shown below.",
+    );
   });
 
   it("renders allowed thumbs-only reactions in pending plugin approvals", async () => {

--- a/extensions/whatsapp/src/approval-handler.runtime.ts
+++ b/extensions/whatsapp/src/approval-handler.runtime.ts
@@ -19,6 +19,7 @@ import type {
 } from "openclaw/plugin-sdk/approval-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { resolveDefaultWhatsAppAccountId } from "./accounts.js";
+import { addWhatsAppExecPurpose } from "./approval-copy.js";
 import {
   registerWhatsAppApprovalReactionTarget,
   unregisterWhatsAppApprovalReactionTarget,
@@ -50,7 +51,26 @@ function buildPendingPayload(params: {
   view: PendingApprovalView;
   nowMs: number;
 }): WhatsAppPendingDelivery {
-  return buildApprovalReactionPendingContent(params);
+  const pending = buildApprovalReactionPendingContent(params);
+  return {
+    ...pending,
+    reactionPayload: {
+      ...pending.reactionPayload,
+      text: addWhatsAppExecPurpose({
+        text: pending.reactionPayload.text,
+        approvalKind: params.view.approvalKind,
+        purpose: params.view.approvalKind === "exec" ? params.view.purpose : null,
+      }),
+    },
+    manualFallbackPayload: {
+      ...pending.manualFallbackPayload,
+      text: addWhatsAppExecPurpose({
+        text: pending.manualFallbackPayload.text,
+        approvalKind: params.view.approvalKind,
+        purpose: params.view.approvalKind === "exec" ? params.view.purpose : null,
+      }),
+    },
+  };
 }
 
 export const whatsappApprovalNativeRuntime = createChannelApprovalNativeRuntimeAdapter<

--- a/extensions/whatsapp/src/approval-native.test.ts
+++ b/extensions/whatsapp/src/approval-native.test.ts
@@ -240,6 +240,7 @@ describe("whatsapp approval capability", () => {
       ask: "always",
       cwd: "/tmp/work",
       host: "gateway",
+      purpose: "Checks whether the project is ready to ship.",
     });
 
     const payload = whatsappApprovalCapability.render?.exec?.buildPendingPayload?.({
@@ -251,6 +252,7 @@ describe("whatsapp approval capability", () => {
     const text = payload?.text ?? "";
 
     expect(text).toContain("/approve exec-1 allow-once");
+    expect(text).toContain("**What this does:** Checks whether the project is ready to ship.");
     expect(text).toContain("React with:");
     expect(text).toContain("👍 Allow Once");
     expect(text).toContain("👎 Deny");

--- a/extensions/whatsapp/src/approval-native.ts
+++ b/extensions/whatsapp/src/approval-native.ts
@@ -19,6 +19,7 @@ import {
   resolveWhatsAppAccount,
 } from "./accounts.js";
 import { getWhatsAppApprovalApprovers, whatsappApprovalAuth } from "./approval-auth.js";
+import { addWhatsAppExecPurpose } from "./approval-copy.js";
 import { isWhatsAppGroupJid, normalizeWhatsAppMessagingTarget } from "./normalize.js";
 
 function isWhatsAppApprovalTransportEnabled(params: {
@@ -87,6 +88,14 @@ function buildWhatsAppPendingPayload(
   const payload = buildApprovalReactionPromptPayloadForRequest(params);
   return {
     ...payload,
+    text: addWhatsAppExecPurpose({
+      text: payload.text,
+      approvalKind,
+      purpose:
+        approvalKind === "exec" && "command" in params.request.request
+          ? params.request.request.purpose
+          : null,
+    }),
     presentation: buildTypedApprovalPresentation({
       approvalId: params.request.id,
       approvalKind,

--- a/packages/gateway-protocol/src/approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/approvals-validators.test.ts
@@ -14,6 +14,7 @@ import {
 const execPresentation = {
   kind: "exec",
   commandText: "git status --short",
+  purpose: "Checks which repository files have changed.",
   commandPreview: "git status",
   warningText: null,
   host: "gateway",
@@ -61,6 +62,9 @@ const pluginRecord = {
 describe("unified approval protocol validators", () => {
   it("accepts only reviewer-safe approval presentations", () => {
     expect(validateApprovalPresentation(execPresentation)).toBe(true);
+    expect(validateApprovalPresentation({ ...execPresentation, purpose: "x".repeat(241) })).toBe(
+      false,
+    );
     expect(validateApprovalPresentation(pluginPresentation)).toBe(true);
     expect(validateApprovalPresentation(systemAgentPresentation)).toBe(true);
     expect(

--- a/packages/gateway-protocol/src/schema/approvals.ts
+++ b/packages/gateway-protocol/src/schema/approvals.ts
@@ -150,6 +150,7 @@ export const ExecApprovalPresentationSchema = Type.Object(
   {
     kind: Type.Literal("exec"),
     commandText: NonEmptyString,
+    purpose: Type.Optional(Type.Union([Type.String({ maxLength: 240 }), Type.Null()])),
     commandPreview: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     warningText: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     host: Type.Optional(Type.Union([Type.String(), Type.Null()])),

--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -248,6 +248,7 @@ const ExecApprovalPolicySnapshotSchema = closedObject({
 export const ExecApprovalRequestParamsSchema = closedObject({
   id: Type.Optional(NonEmptyString),
   command: Type.Optional(NonEmptyString),
+  purpose: Type.Optional(Type.String({ minLength: 1, maxLength: 240 })),
   commandArgv: Type.Optional(Type.Array(Type.String())),
   systemRunPlan: Type.Optional(
     closedObject({

--- a/src/agents/agent-tools.deferred-followup-guidance.test.ts
+++ b/src/agents/agent-tools.deferred-followup-guidance.test.ts
@@ -105,7 +105,7 @@ describe("createOpenClawCodingTools availability guidance", () => {
 
       expect(exec.toolNames).toEqual(["exec", "process", schedulerToolName]);
       expect(exec.description).toBe(
-        "Run shell now; background continuation supported. Use yieldMs/background, then process for logs/status/input/intervention. Long run: automatic completion wake when enabled and output/failure occurs; otherwise process confirms completion. No sleep loops for reminders/follow-ups; use automations. TTY CLI/UI/coding agent: pty=true. Quote arguments containing shell metacharacters, including URL query strings with `?` or `&`.",
+        "Run shell now; background continuation supported. Use yieldMs/background, then process for logs/status/input/intervention. Long run: automatic completion wake when enabled and output/failure occurs; otherwise process confirms completion. No sleep loops for reminders/follow-ups; use automations. Always set purpose: one plain-English sentence on what the command achieves, shown to the human when approval is requested. TTY CLI/UI/coding agent: pty=true. Quote arguments containing shell metacharacters, including URL query strings with `?` or `&`.",
       );
       expect(process.description).toBe(
         "Control existing exec: list, poll, log, write, send-keys, submit, paste, kill. poll/log: status, output, quiet success, completion without auto-wake, input hints. Others: input/intervention. No polling as timer/reminder; scheduled follow-up uses automations.",
@@ -119,7 +119,7 @@ describe("createOpenClawCodingTools availability guidance", () => {
 
     expect(exec.toolNames).toEqual(["exec", "process"]);
     expect(exec.description).toBe(
-      "Run shell now; background continuation supported. Use yieldMs/background, then process for logs/status/input/intervention. Long run: automatic completion wake when enabled and output/failure occurs; otherwise process confirms completion. TTY CLI/UI/coding agent: pty=true. Quote arguments containing shell metacharacters, including URL query strings with `?` or `&`.",
+      "Run shell now; background continuation supported. Use yieldMs/background, then process for logs/status/input/intervention. Long run: automatic completion wake when enabled and output/failure occurs; otherwise process confirms completion. Always set purpose: one plain-English sentence on what the command achieves, shown to the human when approval is requested. TTY CLI/UI/coding agent: pty=true. Quote arguments containing shell metacharacters, including URL query strings with `?` or `&`.",
     );
     expect(process.description).toBe(
       "Control existing exec: list, poll, log, write, send-keys, submit, paste, kill. poll/log: status, output, quiet success, completion without auto-wake, input hints. Others: input/intervention.",
@@ -133,8 +133,8 @@ describe("createOpenClawCodingTools availability guidance", () => {
 
       expect(exec.description).toBe(
         schedulerToolName
-          ? "Run shell and wait for completion. No sleep loops for reminders/follow-ups; use automations. TTY CLI/UI/coding agent: pty=true. Quote arguments containing shell metacharacters, including URL query strings with `?` or `&`."
-          : "Run shell and wait for completion. TTY CLI/UI/coding agent: pty=true. Quote arguments containing shell metacharacters, including URL query strings with `?` or `&`.",
+          ? "Run shell and wait for completion. No sleep loops for reminders/follow-ups; use automations. Always set purpose: one plain-English sentence on what the command achieves, shown to the human when approval is requested. TTY CLI/UI/coding agent: pty=true. Quote arguments containing shell metacharacters, including URL query strings with `?` or `&`."
+          : "Run shell and wait for completion. Always set purpose: one plain-English sentence on what the command achieves, shown to the human when approval is requested. TTY CLI/UI/coding agent: pty=true. Quote arguments containing shell metacharacters, including URL query strings with `?` or `&`.",
       );
     },
   );

--- a/src/agents/bash-tools.descriptions.test.ts
+++ b/src/agents/bash-tools.descriptions.test.ts
@@ -30,6 +30,14 @@ describe("tool descriptions", () => {
     expect(processTool.description).toContain("write, send-keys, submit, paste, kill");
   });
 
+  it("asks for an approval-facing purpose regardless of scheduler availability", () => {
+    const nudge =
+      "Always set purpose: one plain-English sentence on what the command achieves, shown to the human when approval is requested.";
+    expect(execTool.description).toContain(nudge);
+    expect(createExecTool({ ...execDefaults, hasCronTool: true }).description).toContain(nudge);
+    expect(processTool.description).not.toContain(nudge);
+  });
+
   it.each(["darwin", "linux", "win32"] as const)(
     "limits shell-quoting guidance to Unix hosts: %s",
     (platform) => {

--- a/src/agents/bash-tools.descriptions.ts
+++ b/src/agents/bash-tools.descriptions.ts
@@ -35,6 +35,7 @@ export function describeExecTool(params?: {
   const base = [
     ...continuation,
     params?.hasCronTool ? "No sleep loops for reminders/follow-ups; use automations." : undefined,
+    "Always set purpose: one plain-English sentence on what the command achieves, shown to the human when approval is requested.",
     "TTY CLI/UI/coding agent: pty=true.",
   ]
     .filter(Boolean)

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -61,6 +61,7 @@ function restoreProcessPlatformForTest(): void {
 type ApprovalRequestPayload = {
   approvalReviewerDeviceIds?: string[];
   commandSpans?: Array<{ startIndex: number; endIndex: number }>;
+  purpose?: string;
   sessionId?: string;
   runId?: string;
   toolCallId?: string;
@@ -107,6 +108,7 @@ describe("exec approval requests", () => {
     await registerExecApprovalRequestForHostOrThrow({
       approvalId: "approval-id",
       command: "echo hi",
+      purpose: "Checks that the shell is responding.",
       workdir: "/tmp",
       host: "gateway",
       security: "allowlist",
@@ -117,6 +119,7 @@ describe("exec approval requests", () => {
     });
 
     expect(requireApprovalRequestPayload(0)).toMatchObject({
+      purpose: "Checks that the shell is responding.",
       sessionId: "session-1",
       runId: "run-1",
       toolCallId: "tool-1",

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -41,6 +41,7 @@ const loadExecApprovalCommandSpansRuntime = createLazyPromise(
 type RequestExecApprovalDecisionParams = {
   id: string;
   command?: string;
+  purpose?: string;
   commandArgv?: string[];
   systemRunPlan?: SystemRunApprovalPlan;
   env?: Record<string, string>;
@@ -79,6 +80,7 @@ function buildExecApprovalRequestToolParams(
   return {
     id: params.id,
     ...(params.command ? { command: params.command } : {}),
+    ...(params.purpose ? { purpose: params.purpose } : {}),
     ...(params.commandArgv ? { commandArgv: params.commandArgv } : {}),
     systemRunPlan: params.systemRunPlan,
     env: params.env,
@@ -209,6 +211,7 @@ export async function resolveRegisteredExecApprovalDecision(params: {
 type HostExecApprovalParams = {
   approvalId: string;
   command?: string;
+  purpose?: string;
   commandArgv?: string[];
   systemRunPlan?: SystemRunApprovalPlan;
   env?: Record<string, string>;
@@ -323,6 +326,7 @@ async function buildHostApprovalDecisionParams(
   return {
     id: params.approvalId,
     command: params.command,
+    purpose: params.purpose,
     commandArgv: params.commandArgv,
     systemRunPlan: params.systemRunPlan,
     env: params.env,

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -97,6 +97,7 @@ import type { AgentToolResult } from "./runtime/index.js";
 /** Full input bundle for gateway-host allowlist and approval processing. */
 type ProcessGatewayAllowlistParams = {
   command: string;
+  purpose?: string;
   workdir: string;
   env: Record<string, string>;
   githubProfileDir?: string;
@@ -1079,6 +1080,7 @@ export async function processGatewayAllowlist(
       await registerExecApprovalRequestForHostOrThrow({
         approvalId,
         command: params.command,
+        purpose: params.purpose,
         env: params.requestedEnv,
         workdir: params.workdir,
         host: "gateway",

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -209,6 +209,7 @@ export async function executeNodeHostCommand(
     await registerExecApprovalRequestForHostOrThrow({
       approvalId,
       systemRunPlan: prepared.plan,
+      purpose: params.purpose,
       env: target.env,
       workdir: prepared.cwd,
       host: "node",

--- a/src/agents/bash-tools.exec-host-node.types.ts
+++ b/src/agents/bash-tools.exec-host-node.types.ts
@@ -10,6 +10,7 @@ import type { ExecElevatedDefaults } from "./bash-tools.exec-types.js";
 /** Full parameter bundle for Node-hosted exec command execution. */
 export type ExecuteNodeHostCommandParams = {
   command: string;
+  purpose?: string;
   toolCallId?: string;
   workdir: string | undefined;
   env: Record<string, string>;

--- a/src/agents/bash-tools.exec-request-preparation.ts
+++ b/src/agents/bash-tools.exec-request-preparation.ts
@@ -35,6 +35,7 @@ import { ToolInputError } from "./tools/common.js";
 
 export type ExecToolArgs = Record<string, unknown> & {
   command: string;
+  purpose?: string;
   workdir?: string;
   env?: Record<string, string>;
   yieldMs?: number;
@@ -64,7 +65,14 @@ const resolvedExecWorkdirPreparedStates = new WeakMap<
   ExecToolArgs,
   ResolvedExecWorkdirPreparedState
 >();
-const XML_ARG_VALUE_EXEC_PARAM_KEYS = ["command", "workdir", "host", "ask", "node"] as const;
+const XML_ARG_VALUE_EXEC_PARAM_KEYS = [
+  "command",
+  "purpose",
+  "workdir",
+  "host",
+  "ask",
+  "node",
+] as const;
 
 export function assertSupportedExecParams(args: unknown): void {
   if (isRecord(args) && Object.hasOwn(args, "timeout")) {

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -450,6 +450,7 @@ export function createExecTool(
         if (host === "node") {
           return executeNodeHostCommand({
             command: params.command,
+            purpose: params.purpose,
             toolCallId,
             workdir,
             env,
@@ -501,6 +502,7 @@ export function createExecTool(
         if (host === "gateway" && !bypassApprovals) {
           const gatewayResult = await processGatewayAllowlist({
             command: params.command,
+            purpose: params.purpose,
             workdir,
             env,
             githubProfileDir,

--- a/src/agents/bash-tools.schemas.test.ts
+++ b/src/agents/bash-tools.schemas.test.ts
@@ -11,4 +11,13 @@ describe("exec environment guidance", () => {
       description: expect.stringMatching(/literal.*no expansion.*omit to inherit/i),
     });
   });
+
+  it("offers a bounded plain-English purpose for approval prompts", () => {
+    expect(execSchema.properties.purpose).toMatchObject({
+      maxLength: 240,
+      description: expect.stringMatching(/plain-English.*approval prompts/i),
+    });
+    expect(execCompletionSchema.properties.purpose).toBeDefined();
+    expect(nodeExecSchema.properties.purpose).toBeDefined();
+  });
 });

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -24,6 +24,13 @@ const PROCESS_TOOL_ACTIONS = [
 /** Parameters accepted by the exec tool. */
 export const execSchema = Type.Object({
   command: Type.String({ description: "Shell command." }),
+  purpose: Type.Optional(
+    Type.String({
+      description:
+        "Always set this. One short plain-English sentence naming what the command accomplishes, written for a non-technical reader who cannot read shell (e.g. 'Checks whether the project builds.'). Shown as 'What this does' on approval prompts. Describe the outcome, never restate the command text, and never include secrets.",
+      maxLength: 240,
+    }),
+  ),
   workdir: Type.Optional(
     Type.String({
       description: "Omit/empty string: default; whitespace-only invalid.",
@@ -77,6 +84,7 @@ export const execCompletionSchema = Type.Omit(execSchema, ["yieldMs", "backgroun
 /** Parameters exposed by node-only exec surfaces. */
 export const nodeExecSchema = Type.Object({
   command: execSchema.properties.command,
+  purpose: execSchema.properties.purpose,
   workdir: execSchema.properties.workdir,
   env: execSchema.properties.env,
   timeoutSeconds: execSchema.properties.timeoutSeconds,

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -1,6 +1,7 @@
 // Exec approval gateway methods create, list, inspect, and resolve command
 // approval requests, including iOS push delivery and requester visibility.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   ErrorCodes,
   errorShape,
@@ -170,6 +171,7 @@ export function createExecApprovalHandlers(
       const p = params as {
         id?: string;
         command: string;
+        purpose?: string;
         commandArgv?: string[];
         env?: Record<string, string>;
         cwd?: string;
@@ -285,6 +287,7 @@ export function createExecApprovalHandlers(
       }
       const envBinding = buildSystemRunApprovalEnvBinding(p.env);
       const warningText = normalizeOptionalString(p.warningText);
+      const purpose = normalizeOptionalString(p.purpose);
       const runtimeConfig =
         typeof context.getRuntimeConfig === "function" ? context.getRuntimeConfig() : {};
       const commandHighlighting = resolveExecCommandHighlighting({
@@ -369,6 +372,9 @@ export function createExecApprovalHandlers(
           : null;
       const request = {
         command: sanitizedCommandText,
+        purpose: purpose
+          ? truncateUtf16Safe(sanitizeExecApprovalDisplayText(purpose.replace(/\s+/g, " ")), 240)
+          : null,
         commandPreview:
           host === "node" || !approvalContext.commandPreview
             ? undefined

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -3949,6 +3949,15 @@ describe("exec approval handlers", () => {
     expect(request["warningText"]).not.toContain("\\u{A}");
   });
 
+  it("stores a short single-line purpose for approval cards", async (testContext) => {
+    const { request } = await requestExecApprovalForTest(testContext, {
+      timeoutMs: 10,
+      command: "printf safe",
+      purpose: "Inspect the project\nwithout changing files\u0000",
+    });
+    expect(request["purpose"]).toBe("Inspect the project without changing files\\u{0}");
+  });
+
   it("preserves command analysis and normalizes command spans", async (testContext) => {
     const { request } = await requestExecApprovalForTest(
       testContext,

--- a/src/infra/approval-presentation.test.ts
+++ b/src/infra/approval-presentation.test.ts
@@ -7,6 +7,7 @@ const allowedDecisions = ["allow-once", "deny"] as const;
 
 function buildExecPresentation(request: {
   command: string;
+  purpose?: string | null;
   host?: string | null;
   nodeId?: string | null;
   agentId?: string | null;
@@ -87,6 +88,20 @@ describe("buildApprovalPresentation", () => {
         agentId: "\t",
       }),
     ).toMatchObject({ kind: "exec", host: null, nodeId: null, agentId: null });
+  });
+
+  it("sanitizes the exec purpose before exposing it to reviewers", () => {
+    const githubToken = `ghp_${"a".repeat(100)}`;
+    const presentation = buildExecPresentation({
+      command: "printf safe",
+      purpose: `Check status\nwithout changing files ${githubToken}`,
+    });
+
+    expect(presentation).toMatchObject({
+      kind: "exec",
+      purpose: expect.stringMatching(/^Check status without changing files /),
+    });
+    expect(JSON.stringify(presentation)).not.toContain(githubToken);
   });
 
   it("escapes control and bidi spoofing while preserving description line breaks", () => {

--- a/src/infra/approval-presentation.ts
+++ b/src/infra/approval-presentation.ts
@@ -66,6 +66,13 @@ function normalizePluginExternalResolution(
   return { label, decisions: [...decisions] };
 }
 
+function sanitizeExecPurpose(value: unknown): string | null {
+  const normalized = normalizeOptionalString(value);
+  return normalized
+    ? truncateUtf16Safe(sanitizeExecApprovalDisplayText(normalized.replace(/\s+/g, " ")), 240)
+    : null;
+}
+
 function buildExecApprovalPresentation(params: {
   request: unknown;
   allowedDecisions: readonly ApprovalDecision[];
@@ -86,6 +93,7 @@ function buildExecApprovalPresentation(params: {
   return {
     kind: "exec",
     commandText,
+    purpose: sanitizeExecPurpose(request.purpose),
     commandPreview,
     warningText,
     host: sanitizeOptionalSingleLine(request.host),

--- a/src/infra/approval-view-model.test.ts
+++ b/src/infra/approval-view-model.test.ts
@@ -13,6 +13,7 @@ describe("buildPendingApprovalView", () => {
       expiresAtMs: 2,
       request: {
         command: 'ls | grep "stuff" | python -c \'print("hi")\'',
+        purpose: "Searches a file listing and prints the matching result.",
         host: "node",
         ask: "always",
         commandAnalysis: {
@@ -38,6 +39,7 @@ describe("buildPendingApprovalView", () => {
       throw new Error("expected exec approval view");
     }
     expect(view.commandAnalysis?.warningLines).toEqual(["Contains inline-eval: python -c"]);
+    expect(view.purpose).toBe("Searches a file listing and prints the matching result.");
     expect(view.scope).toEqual(request.request.scope);
     expect(view.metadata).toContainEqual({
       label: "Scope",

--- a/src/infra/approval-view-model.ts
+++ b/src/infra/approval-view-model.ts
@@ -85,6 +85,7 @@ function buildExecViewBase<TPhase extends ApprovalPhase>(
     warningText: request.request.warningText ?? null,
     commandAnalysis: request.request.commandAnalysis ?? null,
     commandText,
+    purpose: request.request.purpose ?? null,
     commandPreview,
     cwd: request.request.cwd ?? null,
     envKeys: request.request.envKeys ?? undefined,

--- a/src/infra/approval-view-model.types.ts
+++ b/src/infra/approval-view-model.types.ts
@@ -49,6 +49,7 @@ export type ExecApprovalViewBase = ApprovalViewBase & {
   warningText?: string | null;
   commandAnalysis?: CommandExplanationSummary | null;
   commandText: string;
+  purpose?: string | null;
   commandPreview?: string | null;
   cwd?: string | null;
   envKeys?: readonly string[];

--- a/src/infra/exec-approvals-core.ts
+++ b/src/infra/exec-approvals-core.ts
@@ -184,6 +184,8 @@ type ExecApprovalCronExecutionSource = {
 
 export type ExecApprovalRequestPayload = {
   command: string;
+  /** Brief reviewer-facing explanation of why the command is being run. */
+  purpose?: string | null;
   commandPreview?: string | null;
   commandArgv?: string[];
   // Optional UI-safe env key preview for approval prompts.


### PR DESCRIPTION
## Problem

An exec approval prompt shows the raw command and little else. On a phone that is often the entire decision surface, and a long shell one-liner is a poor basis for granting execution — the reviewer either squints at quoting and flags, or approves on trust.

## Change

Adds an optional `purpose` to the exec tool: one short sentence describing what the command accomplishes, written for a reader who cannot read shell. It is threaded through the exec hosts into the approval request and rendered by the WhatsApp channel as a `What this does:` line directly beneath the heading.

```
*Exec approval required*
*ID:* exec-1

*What this does:* Checks whether the project is ready to ship.

*Pending command:*
...
```

## Design notes

- **Optional, with a neutral fallback.** Requests without `purpose` — in-flight approvals, non-agent callers, older clients — fall back to `Runs the command shown below.`, so no card loses its heading or renders an empty section.
- **Treated as untrusted.** `purpose` is model-authored text landing on a security surface, so it goes through the same redaction and invisible/bidi-character escaping already applied to `commandText` and `warningText` before it is stored, plus whitespace collapsing and a 240-character cap.
- **Actually populated.** The exec tool description and the schema field description both ask for it, so real approvals carry a sentence rather than defaulting to the fallback.
- **Rendering is WhatsApp-only for now.** `PendingApprovalView` is shared across several channels; this change only adds the line to the WhatsApp renderer. The field is on the shared view model, so other channels can adopt it without further plumbing.

## Testing

- 9 focused test files, 113 tests, plus `server-methods.test.ts` (221 tests) — all passing.
- New coverage for the sanitizer (newlines and control characters), the fallback path, the rendered card, and the tool description.
- `oxlint` and `oxfmt --check` clean on the touched files.
- Production typecheck reports no errors in any file this branch touches.

## Notes

Written and run against a live gateway — the author has been using it on his own WhatsApp approvals.
