### PR TITLE
fix(openai): honor disabled reasoning effort for mapped models

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.test.ts
@@ -412,40 +412,65 @@ describe("streamOpenAICodexResponses transport", () => {
     },
   );
 
-  it.each([
+  it.each<{
+    id: string;
+    effort: "none" | "minimal" | "high" | "xhigh";
+    map?: Model["thinkingLevelMap"];
+    compat?: Model<"openai-responses">["compat"];
+    expected?: string;
+  }>([
     { id: "gpt-6-astra", effort: "none", map: undefined, expected: undefined },
     { id: "gpt-6-astra", effort: "none", map: { off: null }, expected: undefined },
     { id: "gpt-6-astra", effort: "minimal", map: undefined, expected: "low" },
     { id: "custom-reasoning", effort: "xhigh", map: undefined, expected: "xhigh" },
     { id: "custom-reasoning", effort: "high", map: { high: "HIGH" }, expected: "HIGH" },
-  ] as const)("normalizes raw $id $effort with map=$map", async ({ id, effort, map, expected }) => {
-    let capturedPayload: Record<string, unknown> | undefined;
-    const result = await streamOpenAICodexResponses(
-      {
-        ...model,
-        id,
-        name: id,
-        thinkingLevelMap: map,
-      },
-      context,
-      {
-        apiKey: createJwt({
-          "https://api.openai.com/auth": { chatgpt_account_id: "acct-1" },
-        }),
-        reasoningEffort: effort,
-        transport: "sse",
-        onPayload: (payload) => {
-          capturedPayload = payload as Record<string, unknown>;
-          throw new Error("stop after payload");
+    { id: "custom-reasoning", effort: "high", map: { high: null }, expected: undefined },
+    {
+      id: "custom-reasoning",
+      effort: "high",
+      map: { high: "HIGH" },
+      compat: { supportsReasoningEffort: false },
+      expected: undefined,
+    },
+    {
+      id: "custom-reasoning",
+      effort: "high",
+      map: { high: "HIGH" },
+      compat: { supportsReasoningEffort: true },
+      expected: "HIGH",
+    },
+  ])(
+    "normalizes raw $id $effort with map=$map and compat=$compat",
+    async ({ id, effort, map, compat, expected }) => {
+      let capturedPayload: Record<string, unknown> | undefined;
+      const result = await streamOpenAICodexResponses(
+        {
+          ...model,
+          id,
+          name: id,
+          thinkingLevelMap: map,
+          compat,
         },
-      },
-    ).result();
+        context,
+        {
+          apiKey: createJwt({
+            "https://api.openai.com/auth": { chatgpt_account_id: "acct-1" },
+          }),
+          reasoningEffort: effort,
+          transport: "sse",
+          onPayload: (payload) => {
+            capturedPayload = payload as Record<string, unknown>;
+            throw new Error("stop after payload");
+          },
+        },
+      ).result();
 
-    expect(result.errorMessage).toBe("stop after payload");
-    expect(capturedPayload?.reasoning).toEqual(
-      expected ? { effort: expected, summary: "auto" } : undefined,
-    );
-  });
+      expect(result.errorMessage).toBe("stop after payload");
+      expect(capturedPayload?.reasoning).toEqual(
+        expected ? { effort: expected, summary: "auto" } : undefined,
+      );
+    },
+  );
 
   it("does not fall back to SSE when websocket transport is explicit", async () => {
     const fetchMock = vi.fn(async () => {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -173,11 +173,16 @@ export function resolveResponsesRequestReasoningEffort<TApi extends Api>(
   model: Model<TApi>,
   reasoning: ResponsesReasoningEffort | "none" | "off",
 ): string | undefined {
+  const supported = resolveOpenAIModelReasoningEfforts(model);
+  // Catalog mappings cannot re-enable explicitly disabled reasoning effort.
+  if (supported?.length === 0) {
+    return undefined;
+  }
   const mapped = model.thinkingLevelMap?.[reasoning === "none" ? "off" : reasoning];
   if (mapped !== undefined) {
     return mapped ?? undefined;
   }
-  return resolveOpenAIModelReasoningEfforts(model) === undefined
+  return supported === undefined
     ? reasoning === "off"
       ? "none"
       : reasoning

--- a/packages/ai/src/providers/openai-responses.test.ts
+++ b/packages/ai/src/providers/openai-responses.test.ts
@@ -139,6 +139,27 @@ describe("OpenAI Responses provider", () => {
     expect(openAiMockState.requestOptions[0]).toMatchObject({ maxRetries: 0 });
   });
 
+  it.each([false, true])(
+    "honors supportsReasoningEffort=%s over mapped efforts in both Responses builders",
+    async (supportsReasoningEffort) => {
+      const requestModel = model({
+        thinkingLevelMap: { high: "high" },
+        compat: { supportsReasoningEffort },
+      });
+      const options = { apiKey: "sentinel-key", reasoningEffort: "high" as const };
+      const transportParams = buildOpenAIResponsesParams(requestModel, context, options);
+      await streamOpenAIResponses(requestModel, context, options).result();
+
+      for (const params of [transportParams, openAiMockState.params[0]]) {
+        if (supportsReasoningEffort) {
+          expect(params).toMatchObject({ reasoning: { effort: "high", summary: "auto" } });
+        } else {
+          expect(params).not.toHaveProperty("reasoning");
+        }
+      }
+    },
+  );
+
   it.each([
     { id: "gpt-6-astra", cacheRetention: "short", ttl: "30m", retention: undefined },
     { id: "gpt-6-astra", cacheRetention: "long", ttl: "30m", retention: undefined },

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -723,7 +723,7 @@ export interface Model<TApi extends Api = Api> {
   /** Compatibility overrides for OpenAI-compatible APIs. If not set, auto-detected from baseUrl. */
   compat?: TApi extends "openai-completions"
     ? OpenAICompletionsCompat
-    : TApi extends "openai-responses" | "azure-openai-responses" | "openai-codex-responses"
+    : TApi extends "openai-responses" | "azure-openai-responses" | "openai-chatgpt-responses"
       ? OpenAIResponsesCompat
       : TApi extends "anthropic-messages"
         ? AnthropicMessagesCompat


### PR DESCRIPTION
Related: #135868. These separate issues were found in incoming main while reviewing that PR.

## What Problem This Solves

Fixes an issue where operators disabling reasoning-effort parameters for a compatible Responses endpoint would still send them when the model had a thinking-level mapping. Developers also could not assign the existing Responses compatibility settings to a model using the current ChatGPT Responses API identifier.

## Why This Change Was Made

The shared request-effort resolver now checks the canonical capability result before applying catalog mappings. Provider-native labels, null opt-outs, and existing model defaults retain their behavior. The shared model type uses the current ChatGPT API identifier, with no legacy alias or new configuration.

## User Impact

Responses and ChatGPT requests honor explicit reasoning-effort disablement even with catalog mappings. Typed ChatGPT model definitions accept the existing compatibility settings. The native embedded transport already honored the opt-out and is covered as a passing sibling.

## Evidence

The new provider regressions failed before the repair (2 failures, 48 passing controls). Afterward, all 268 tests across nine provider, native transport, Azure, completions, and type-contract suites passed. A separate strict compiler probe changed from rejecting the current ChatGPT override and accepting the retired identifier to accepting the current API and rejecting the retired one.

A real loopback HTTP/SSE run completed four synthetic requests across Responses and ChatGPT, with disabled/enabled controls, actual request serialization, and exactly one request per case. Independent review through P2 found no actionable findings. Authenticated remote-provider validation remains pending; the loopback run is not a substitute for that evidence.

Required changed checks passed, including production/test type checking, formatting, lint and structural guards. Production change: +7/-2 lines (net +5); tests: +73/-27. The added owner check preserves explicit disablement without changing mapped label or null semantics.
