### PR TITLE
fix(crabbox): retain diagnostics safely across capsule cleanup

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -182,7 +182,12 @@ When remote sync uses a temporary checkout, the wrapper preserves native
 Repeated runs retain separate evidence even when native filenames match. The
 wrapper prints the old-to-new root mapping; native logs and generated proof may
 still reference the old paths. A preservation error fails the wrapper and retains
-the temporary checkout at the reported path for manual recovery.
+the temporary checkout at the reported path for manual recovery, preserving the
+child's nonzero exit code. The wrapper rejects symlinks in artifact trees
+and destination parents, and copies only regular files and real directories.
+Retained files use mode `0600` and new directories use `0700` on POSIX systems.
+If preservation fails, recover the outputs from the reported checkout before
+removing it; incomplete destination copies are removed.
 
 These are local artifacts, not published or fully sanitized proof. Blacksmith's
 native failure bundle contains captured stdout/stderr and diagnostic metadata;

--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -5,7 +5,8 @@ import {
   accessSync,
   chmodSync,
   constants,
-  cpSync,
+  copyFileSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -1413,9 +1414,12 @@ function preserveTemporaryCrabboxArtifacts() {
     return;
   }
   const sourceRoot = resolve(childCwd, ".crabbox");
+  if (!crabboxArtifactDirectoryExists(sourceRoot)) {
+    return;
+  }
   const directories = ["runs", "captures"].filter((name) => {
     const source = resolve(sourceRoot, name);
-    return statSync(source, { throwIfNoEntry: false }) && readdirSync(source).length > 0;
+    return crabboxArtifactDirectoryExists(source) && readdirSync(source).length > 0;
   });
   if (directories.length === 0) {
     return;
@@ -1424,14 +1428,48 @@ function preserveTemporaryCrabboxArtifacts() {
   // Native artifacts reuse lease names. Keep each invocation together without
   // overwriting earlier evidence, and copy only outputs, never other Crabbox state.
   const retainedRoot = resolve(repoRoot, ".crabbox", "wrapper-artifacts");
-  mkdirSync(retainedRoot, { recursive: true });
+  for (const directory of [dirname(retainedRoot), retainedRoot]) {
+    if (!crabboxArtifactDirectoryExists(directory)) {
+      mkdirSync(directory, { mode: 0o700 });
+    }
+  }
   const destination = mkdtempSync(resolve(retainedRoot, "run-"));
-  for (const name of directories) {
-    cpSync(resolve(sourceRoot, name), resolve(destination, name), { recursive: true });
+  try {
+    for (const name of directories) {
+      copyCrabboxArtifact(resolve(sourceRoot, name), resolve(destination, name));
+    }
+  } catch (error) {
+    rmSync(destination, { recursive: true, force: true });
+    throw error;
   }
   console.error(
     `[crabbox] preserved temporary artifacts: ${sourceRoot} -> ${relative(repoRoot, destination)}`,
   );
+}
+
+function crabboxArtifactDirectoryExists(directory: string) {
+  const info = lstatSync(directory, { throwIfNoEntry: false });
+  if (info && !info.isDirectory()) {
+    throw new Error(`artifact path must be a real directory: ${directory}`);
+  }
+  return Boolean(info);
+}
+
+function copyCrabboxArtifact(source: string, destination: string) {
+  // Links can escape the output allowlist or point back into the deleted capsule.
+  // Copy only regular files and real directories; diagnostics remain private bytes.
+  const info = lstatSync(source);
+  if (info.isDirectory()) {
+    mkdirSync(destination, { mode: 0o700 });
+    for (const entry of readdirSync(source)) {
+      copyCrabboxArtifact(resolve(source, entry), resolve(destination, entry));
+    }
+  } else if (info.isFile()) {
+    copyFileSync(source, destination, constants.COPYFILE_EXCL);
+    chmodSync(destination, 0o600);
+  } else {
+    throw new Error(`artifact must be a regular file or directory: ${source}`);
+  }
 }
 
 function shellQuote(value: string) {
@@ -3969,7 +4007,7 @@ let childCwd = repoRoot;
 let cleanupChildCwd = () => {};
 let fullCheckout = null;
 let stopFullCheckoutKeepalive = () => {};
-let cleanupDone = false;
+let cleanupSucceeded: boolean | undefined;
 let sourceCapsule: CrabboxSourceCapsule | null = null;
 let remoteChangedGateAlias = "";
 let capturedBlacksmithLeaseId = "";
@@ -4031,10 +4069,10 @@ try {
 }
 
 function cleanupOnce() {
-  if (cleanupDone) {
-    return;
+  if (cleanupSucceeded !== undefined) {
+    return cleanupSucceeded;
   }
-  cleanupDone = true;
+  cleanupSucceeded = false;
   stopFullCheckoutKeepalive();
   wsl2ScriptBootstrap.cleanup();
   scriptBootstrap.cleanup();
@@ -4047,11 +4085,14 @@ function cleanupOnce() {
     preserveTemporaryCrabboxArtifacts();
   } catch (error) {
     console.error(
-      `[crabbox] artifact preservation failed; temporary checkout retained at ${childCwd}`,
+      `[crabbox] artifact preservation failed: ${error instanceof Error ? error.message : String(error)}; temporary checkout retained at ${childCwd}. Recover .crabbox/runs and .crabbox/captures from this checkout before removing it.`,
     );
-    throw error;
+    process.exitCode ||= 1;
+    return false;
   }
   cleanupChildCwd();
+  cleanupSucceeded = true;
+  return true;
 }
 
 const invocation = parseCommandInvocation(help.text, normalizedArgs);
@@ -4247,12 +4288,12 @@ child.on("exit", (code, signal) => {
       exitCode = 2;
     }
   }
-  cleanupOnce();
+  const artifactsPreserved = cleanupOnce();
   if (signal) {
     process.exit(signalExitCodes.get(signal) ?? 1);
     return;
   }
-  const finalExitCode = fullCheckoutAvailable ? (exitCode ?? 1) : 1;
+  const finalExitCode = (exitCode ?? 1) || (fullCheckoutAvailable && artifactsPreserved ? 0 : 1);
   if (
     finalExitCode !== 0 &&
     reusedRunLeaseId &&

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -31,6 +31,7 @@ import { makeTempDir, useAutoCleanupTempDirTracker } from "../helpers/temp-dir.j
 
 const tempDirs: string[] = [];
 const invocationLogTempDirs = useAutoCleanupTempDirTracker(afterEach);
+const artifactTempDirs = useAutoCleanupTempDirTracker(afterEach);
 const repoRoot = process.cwd();
 const bundledWrapperPath = path.join(repoRoot, ".tmp", `crabbox-wrapper-test-${process.pid}.mjs`);
 const realBundledWrapperPath = bundledWrapperPath.replace(".mjs", "-real.mjs");
@@ -157,9 +158,13 @@ async function main() {
     process.exit(ready ? 0 : 1);
   }
   if (args[0] === "run" || args[0] === "warmup") { ${stampClaimScript} }
+  if (args[0] === "run" && process.env.OPENCLAW_FAKE_CRABBOX_ARTIFACT_LINKS) {
+    for (const [file, target] of Object.entries(JSON.parse(process.env.OPENCLAW_FAKE_CRABBOX_ARTIFACT_LINKS))) { fs.mkdirSync(path.dirname(file), { recursive: true }); fs.symlinkSync(target, file); }
+  }
   if (args[0] === "run" && process.env.OPENCLAW_FAKE_CRABBOX_ARTIFACTS) {
     for (const [file, bytes] of Object.entries(JSON.parse(process.env.OPENCLAW_FAKE_CRABBOX_ARTIFACTS))) { fs.mkdirSync(path.dirname(file), { recursive: true }); fs.writeFileSync(file, Buffer.from(bytes, "base64")); }
   }
+  if (args[0] === "run" && process.env.OPENCLAW_FAKE_CRABBOX_ARTIFACT_FIFO) execFileSync("mkfifo", [process.env.OPENCLAW_FAKE_CRABBOX_ARTIFACT_FIFO]);
   const runStatus = Number.parseInt(process.env.OPENCLAW_FAKE_CRABBOX_RUN_STATUS || "0", 10); if (args[0] === "run" && runStatus !== 0) { process.stdout.write(JSON.stringify({ args, cwd: process.cwd() }) + "\n"); process.stderr.write("fake run failure\n"); process.exit(runStatus); }
   if (args[0] === "config" && args[1] === "show" && args.includes("--json")) {
     const status = Number.parseInt(process.env.OPENCLAW_FAKE_CRABBOX_CONFIG_STATUS || "0", 10);
@@ -4977,25 +4982,50 @@ describe("scripts/crabbox-wrapper", () => {
   });
 
   it.each([
-    { mode: "capsule", artifacts: "captures", exitCode: 23 },
-    { mode: "capsule", artifacts: "both", exitCode: 23 },
-    { mode: "sparse", artifacts: "both", exitCode: 23 },
-    { mode: "capsule", artifacts: "runs", exitCode: 0 },
-    { mode: "capsule", artifacts: "none", exitCode: 0 },
-    { mode: "direct", artifacts: "captures", exitCode: 23 },
-    { mode: "capsule", artifacts: "both", exitCode: 0, blocked: true },
+    { mode: "capsule", artifacts: "captures", exitCode: 23, fault: undefined },
+    { mode: "capsule", artifacts: "both", exitCode: 23, fault: undefined },
+    { mode: "sparse", artifacts: "both", exitCode: 23, fault: undefined },
+    { mode: "capsule", artifacts: "runs", exitCode: 0, fault: undefined },
+    { mode: "capsule", artifacts: "none", exitCode: 0, fault: undefined },
+    { mode: "direct", artifacts: "captures", exitCode: 23, fault: undefined },
+    ...[0, 23].map((exitCode) => ({
+      mode: "capsule",
+      artifacts: "both",
+      exitCode,
+      fault: "destination file",
+    })),
+    ...(process.platform === "win32"
+      ? []
+      : [
+          "source root link",
+          "source root dangling link",
+          "source runs link",
+          "source captures link",
+          "source captures dangling link",
+          "nested file link",
+          "nested directory link",
+          "nested internal link",
+          "nested dangling link",
+          "destination root link",
+          "destination root dangling link",
+          "destination parent link",
+          "destination parent dangling link",
+          "nested fifo",
+        ]
+    ).map((fault) => ({ mode: "capsule", artifacts: "both", exitCode: 0, fault })),
   ])(
-    "retains native artifacts through the wrapper ($mode, $artifacts, exit=$exitCode, blocked=$blocked)",
-    ({ mode, artifacts, exitCode, blocked }) => {
-      const root = realpathSync(makeTempDir(tempDirs, "openclaw-wrapper-artifacts-"));
+    "retains native artifacts through the wrapper ($mode, $artifacts, exit=$exitCode, fault=$fault)",
+    ({ mode, artifacts, exitCode, fault }) => {
+      const root = realpathSync(artifactTempDirs.make("openclaw-wrapper-artifacts-"));
       const producer = path.join(root, "repo");
       const syncRoot = path.join(root, "sync");
       const fixtureWrapper = path.join(producer, ".tmp", "crabbox-wrapper.mjs");
       mkdirSync(path.dirname(fixtureWrapper), { recursive: true });
       copyFileSync(realBundledWrapperPath, fixtureWrapper);
       const env = {
-        ...process.env,
         ...testHomeEnv(path.join(root, "home")),
+        XDG_STATE_HOME: path.join(root, "home", ".local", "state"),
+        ...(process.platform === "win32" ? { SystemRoot: process.env.SystemRoot } : {}),
         PATH: [makeFakeCrabbox(defaultProviderHelp), process.env.PATH ?? ""].join(path.delimiter),
         GIT_CONFIG_GLOBAL: "/dev/null",
         GIT_CONFIG_NOSYSTEM: "1",
@@ -5018,7 +5048,7 @@ describe("scripts/crabbox-wrapper", () => {
         return result.stdout.trim();
       };
       git("init", "-q", "-b", "main");
-      writeFileSync(path.join(producer, ".gitignore"), ".tmp/\n.crabbox/\n");
+      writeFileSync(path.join(producer, ".gitignore"), ".tmp/\n.crabbox\n");
       writeFileSync(path.join(producer, "fixture.txt"), "source fixture\n");
       git("add", ".gitignore", "fixture.txt");
       git("commit", "-qm", "fixture");
@@ -5029,7 +5059,14 @@ describe("scripts/crabbox-wrapper", () => {
       }
       const capturePath = ".crabbox/captures/tbx_fixture-20260904T190427Z.tar.gz";
       const runPath = ".crabbox/runs/run_fixture/proof/nested.json";
-      const bytes = Buffer.from([0x1f, 0x8b, 0, 255, 13, 10, 128]);
+      const bundleInput = path.join(root, "bundle-input");
+      mkdirSync(bundleInput);
+      const logBytes = Buffer.from("synthetic failure\r\n\u001b[31mraw diagnostic\u001b[0m\n");
+      writeFileSync(path.join(bundleInput, "stdout.log"), logBytes);
+      const bundle = path.join(root, "failure.tar.gz");
+      const packed = spawnSync("tar", ["-czf", bundle, "-C", bundleInput, "stdout.log"], { env });
+      expect(packed.status).toBe(0);
+      const bytes = readFileSync(bundle);
       const files = [
         ...(artifacts === "captures" || artifacts === "both" ? [capturePath] : []),
         ...(artifacts === "runs" || artifacts === "both" ? [runPath] : []),
@@ -5041,11 +5078,44 @@ describe("scripts/crabbox-wrapper", () => {
       mkdirSync(path.dirname(previousFile), { recursive: true });
       writeFileSync(previousFile, "prior evidence\n");
       const retainedRoot = path.join(producer, ".crabbox", "wrapper-artifacts");
-      if (blocked) {
+      const outside = path.join(root, "outside");
+      mkdirSync(outside);
+      const sentinel = "synthetic-private-data-must-not-be-printed";
+      const sentinelPath = path.join(outside, "private.txt");
+      writeFileSync(sentinelPath, sentinel);
+      const artifactLinks: Record<string, string> = {};
+      const missing = path.join(root, "missing");
+      if (fault === "destination file") {
         writeFileSync(retainedRoot, "not a directory\n");
+      } else if (fault?.startsWith("destination")) {
+        const target = fault.includes("dangling") ? missing : outside;
+        if (fault.includes("root")) {
+          renameSync(path.join(producer, ".crabbox"), path.join(root, "prior-crabbox"));
+          symlinkSync(target, path.join(producer, ".crabbox"), "dir");
+        } else {
+          symlinkSync(target, retainedRoot, "dir");
+        }
+      } else if (fault?.startsWith("source")) {
+        const file = fault.includes("root")
+          ? ".crabbox"
+          : fault.includes("runs")
+            ? ".crabbox/runs"
+            : ".crabbox/captures";
+        artifactLinks[file] = fault.includes("dangling") ? missing : outside;
+      } else if (fault?.startsWith("nested") && fault !== "nested fifo") {
+        const target = fault.includes("dangling")
+          ? missing
+          : fault.includes("internal")
+            ? path.basename(capturePath)
+            : fault.includes("directory")
+              ? outside
+              : sentinelPath;
+        artifactLinks[".crabbox/captures/linked-artifact"] = target;
       }
       const retainedDirectories: string[] = [];
-      const attempts = mode === "capsule" && artifacts === "both" && !blocked ? 2 : 1;
+      const attempts = mode === "capsule" && artifacts === "both" && !fault ? 2 : 1;
+      const emittedFiles = fault?.startsWith("source") && fault.includes("dangling") ? [] : files;
+      const ignoredFiles = [".crabbox/credentials/token", ".crabbox/state/claim", ".crabbox/env"];
       for (let attempt = 0; attempt < attempts; attempt += 1) {
         const result = spawnSync(
           process.execPath,
@@ -5061,8 +5131,17 @@ describe("scripts/crabbox-wrapper", () => {
             cwd: producer,
             env: {
               ...env,
+              OPENCLAW_FAKE_CRABBOX_ARTIFACT_LINKS: JSON.stringify(artifactLinks),
+              ...(fault === "nested fifo"
+                ? { OPENCLAW_FAKE_CRABBOX_ARTIFACT_FIFO: ".crabbox/captures/pipe" }
+                : {}),
               OPENCLAW_FAKE_CRABBOX_ARTIFACTS: JSON.stringify(
-                Object.fromEntries(files.map((file) => [file, bytes.toString("base64")])),
+                Object.fromEntries([
+                  ...emittedFiles.map((file) => [file, bytes.toString("base64")]),
+                  ...(fault?.includes("dangling") && fault.startsWith("source")
+                    ? []
+                    : ignoredFiles.map((file) => [file, Buffer.from(sentinel).toString("base64")])),
+                ]),
               ),
             },
             encoding: "utf8",
@@ -5070,16 +5149,31 @@ describe("scripts/crabbox-wrapper", () => {
           },
         );
         expect(result.error, result.stderr).toBeUndefined();
+        expect(result.stdout, result.stderr).not.toBe("");
         const output = parseFakeCrabboxOutput(result);
-        expect(readFileSync(previousFile, "utf8")).toBe("prior evidence\n");
-        if (blocked) {
-          expect(result.status).not.toBe(0);
+        const previousPath = fault?.startsWith("destination root")
+          ? path.join(root, "prior-crabbox", path.relative(".crabbox", capturePath))
+          : previousFile;
+        expect(readFileSync(previousPath, "utf8")).toBe("prior evidence\n");
+        expect(readFileSync(sentinelPath, "utf8")).toBe(sentinel);
+        expect(result.stdout + result.stderr).not.toContain(sentinel);
+        if (fault) {
+          expect(result.status, result.stderr).toBe(exitCode || 1);
           expect(result.stderr).toContain("temporary checkout retained");
           expect(result.stderr).toContain(output.cwd);
-          for (const file of files) {
+          expect(result.stderr).not.toContain("preserved temporary artifacts:");
+          expect(existsSync(output.cwd)).toBe(true);
+          for (const file of emittedFiles) {
             expect(readFileSync(path.join(output.cwd, file))).toEqual(bytes);
           }
-          expect(readFileSync(retainedRoot, "utf8")).toBe("not a directory\n");
+          if (fault === "destination file") {
+            expect(readFileSync(retainedRoot, "utf8")).toBe("not a directory\n");
+          } else if (fault.startsWith("destination")) {
+            expect(readdirSync(outside)).toEqual(["private.txt"]);
+            expect(existsSync(missing)).toBe(false);
+          } else {
+            expect(existsSync(retainedRoot) ? readdirSync(retainedRoot) : []).toEqual([]);
+          }
           continue;
         }
         expect(result.status, result.stderr).toBe(exitCode);
@@ -5102,10 +5196,26 @@ describe("scripts/crabbox-wrapper", () => {
             expect(retainedDirectories).not.toContain(retained);
             retainedDirectories.push(retained);
             for (const directory of retainedDirectories) {
+              if (process.platform !== "win32") {
+                expect(lstatSync(directory).mode & 0o777).toBe(0o700);
+              }
+              expect(new Set(readdirSync(directory))).toEqual(
+                new Set(files.map((file) => file.split("/")[1])),
+              );
               for (const file of files) {
-                expect(readFileSync(path.join(directory, path.relative(".crabbox", file)))).toEqual(
-                  bytes,
-                );
+                const retainedFile = path.join(directory, path.relative(".crabbox", file));
+                expect(readFileSync(retainedFile)).toEqual(bytes);
+                expect(lstatSync(retainedFile).isFile()).toBe(true);
+                if (file === capturePath) {
+                  const unpacked = spawnSync("tar", ["-xOf", retainedFile, "stdout.log"], { env });
+                  expect(unpacked.status).toBe(0);
+                  expect(unpacked.stdout).toEqual(logBytes);
+                }
+                if (process.platform !== "win32") {
+                  expect(lstatSync(retainedFile).mode & 0o777).toBe(0o600);
+                  expect(lstatSync(path.dirname(retainedFile)).mode & 0o777).toBe(0o700);
+                  expect(lstatSync(retainedFile).uid).toBe(process.getuid?.());
+                }
               }
             }
           }


### PR DESCRIPTION
Related: #138650 — failure captures lost during temporary sync cleanup.
Follow-up to #138651 — initial per-invocation retention of native run and capture artifacts.

<details>
<summary>Additional instructions</summary>

This is a same-repository branch, writable by repository maintainers. GitHub's fork-only maintainer-edit flag does not govern this branch.

</details>

## What Problem This Solves

Resolves a problem where maintainers inspecting diagnostics from temporary Crabbox source checkouts could receive a successful retention message for symlinked artifacts that become unusable after cleanup, or have copied output redirected through a symlinked destination. A preservation failure could also replace the original command failure code with a generic process crash.

The basic runs-only omission was already fixed by #138651. This PR completes the same local artifact-lifetime boundary; it does not claim to recover the originally deleted failure bundle.

## Why This Change Was Made

The temporary-checkout owner retains only native `runs` and `captures`, rejects filesystem symlinks and non-file/non-directory entries, and copies regular files into its existing invocation-owned directory with private POSIX modes. Failed preservation removes incomplete destination copies, retains the source checkout with actionable recovery instructions, and keeps an already-failed child's exit code; a successful child still becomes a wrapper failure when preservation fails.

This replaces unrestricted recursive copying rather than adding another retention path. Copying all of `.crabbox` would also copy environment/credential/state material; preserving filesystem links would keep references outside the output boundary or back into the removed capsule. Archive and log bytes are not rewritten. Lease claims, provider selection, source synchronization, and native metadata redaction remain with their existing owners.

## User Impact

Maintainers can use the printed relocation mapping to inspect regular diagnostic artifacts after capsule cleanup. Repeated invocations retain independent evidence. Unsafe paths and copy failures end visibly and retain the original source for manual recovery instead of silently discarding it. New POSIX directories use `0700`; retained files use `0600`.

The testing guide documents the retention/error behavior and its limits. Native logs and proof metadata may still contain their original paths. Failure bundles are local-only and are not guaranteed fully redacted; screenshots and remote reports still need their separate collection flow. No product UI, channel behavior, configuration, schema, dependency, or release change is included.

## Evidence

### Owner-boundary regression

The corrected 22-case matrix produced **17 failures against the initial implementation and 22 passes after the repair**. It executes the real wrapper, real Git source preparation, and filesystem cleanup; only the external provider executable is synthetic. Cases cover captures-only, runs-only, no artifacts, sparse and direct paths, repeated native filenames, source/destination/nested symlinks (including dangling links), FIFO rejection, blocked destinations, private modes, and excluded credential/state/environment sentinels.

A separate real-process replay from synthetic linked caller checkouts reproduced the historical runs-only loss and verified that the repaired wrapper's reported mapping leads to byte-identical, extractable tar.gz contents and run metadata after the source capsule is removed. Both command exits remained 23. The fixture's archive and extracted stream bytes were compared directly. This is local host-side cleanup proof, not a new live Linux/browser or remote-provider run. No existing lease or live operator state was accessed, and no raw bundle is attached.

### Local validation

After rebasing onto `7baae61fa1fb72cb25e21e88f66eeeb08da2ba63`, **329 tests passed across the wrapper, lease-freshness, and routing suites**, including the upstream prepared-workspace cases:

```bash
node scripts/run-vitest.mjs test/scripts/crabbox-wrapper.test.ts test/scripts/testbox-lease-freshness.test.ts test/scripts/crabbox-routing-policy.test.ts
```

```bash
node scripts/check-changed.mjs -- scripts/crabbox-wrapper.mts test/scripts/crabbox-wrapper.test.ts docs/reference/test.md
```

The classified gate passed script/root-test typechecks, targeted lint, formatting, and selected guards. An earlier capsule-preparation timeout passed on an isolated rerun and the full rerun with its original timeout unchanged. New-test type/lint issues were corrected before the final green checks. Fresh isolated Codex autoreview was scoped-clean at P0 with no findings. The clean rebase preserved the reviewed patch exactly (`git range-diff`); the [exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33932065166) completed successfully and the native watcher ended GREEN with no pending checks. Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 138715` then completed successfully at `6471ac631b4e5497a846163366f485d619df602d`; hosted CI/Testbox gates were accepted and the remote branch already matched, so no further push or rebase occurred. A fresh isolated commit autoreview of `6471ac631b4e5497a846163366f485d619df602d` is also scoped-clean at P0 with no findings.

### Dependency contract

The [native Crabbox capture producer](https://github.com/openclaw/crabbox/blob/c766cde9e877ade7cb13d241d106d5694b842deb/internal/cli/run_observability.go#L942) writes `.crabbox/captures/<name>.tar.gz` relative to its current directory and reports that path. Its [failure-output owner](https://github.com/openclaw/crabbox/blob/c766cde9e877ade7cb13d241d106d5694b842deb/internal/cli/run_failure_output_unix.go#L16) rejects symlinked managed destinations, writes private regular files, and treats raw streams as potentially secret-bearing. This wrapper preserves that output contract without extracting bundles or reclassifying their contents as sanitized.

### Maintainer disposition

The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/138715#issuecomment-5548214889) found no patch defect or security finding. We accept its recommended documented rejection policy: symlinked artifact entries or managed retention parents intentionally fail preservation, including after child success, because those links can misrepresent discarded or outside data as retained output. This bounded operator tradeoff is accepted for this repair. The source remains intact at the reported recovery path; regular layouts retain unchanged bytes, private modes, and the original nonzero child status. The policy is documented in [the testing guide](https://github.com/openclaw/openclaw/blob/6471ac631b4e5497a846163366f485d619df602d/docs/reference/test.md) and implemented by [the cleanup owner](https://github.com/openclaw/openclaw/blob/6471ac631b4e5497a846163366f485d619df602d/scripts/crabbox-wrapper.mts#L1412). No configuration or compatibility fallback is added.

The reviewer's upstream source-access concern is resolved: the lead fetched both complete files through the authenticated GitHub Contents API at Crabbox `c766cde9e877ade7cb13d241d106d5694b842deb`, byte-compared them with the pinned Git objects, and personally read the [capture producer and metadata rules](https://github.com/openclaw/crabbox/blob/c766cde9e877ade7cb13d241d106d5694b842deb/internal/cli/run_observability.go#L942) and [safe-output implementation](https://github.com/openclaw/crabbox/blob/c766cde9e877ade7cb13d241d106d5694b842deb/internal/cli/run_failure_output_unix.go#L16). The delivery worker also directly inspected the pinned implementation. Both before-merge items are dispositioned; there is no separate Rank-up moves list. Fresh isolated commit autoreview is scoped-clean at P0, and the lead grants native merge admission for the unchanged reviewed head without bypass.

### Scope and LOC

Tooling: **+54/-13 (net +41)**. Tests/support: **+134/-24 (net +110)**. Docs: **+6/-1 (net +5)**. Product runtime: **0**. The tooling increase provides the validated directory/file traversal and explicit preservation-failure outcome that unrestricted recursive copying could not express.
