### PR TITLE
improve: reduce repeated plugin package ownership work

### DIFF
--- a/src/auto-reply/reply/commands-plugins.ts
+++ b/src/auto-reply/reply/commands-plugins.ts
@@ -9,8 +9,7 @@ import {
   selectInstallMutationWriteOptions,
   type ConfigSnapshotForInstallPersist,
 } from "../../plugins/install-persistence.js";
-import type { InstalledPluginIndex } from "../../plugins/installed-plugin-index.js";
-import { resolveInstalledPluginPackageOwnership } from "../../plugins/installed-plugin-package-ownership.js";
+import { createInstalledPluginOwnershipResolver } from "../../plugins/installed-plugin-package-ownership.js";
 import { withPluginLifecycleLease } from "../../plugins/plugin-lifecycle-lease.js";
 import { loadPluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import { refreshPluginRegistryAfterConfigMutation } from "../../plugins/registry-refresh.js";
@@ -44,9 +43,9 @@ function renderJsonBlock(label: string, value: unknown): string {
 
 function buildPluginInspectJson(
   inspect: ReturnType<typeof buildAllPluginInspectReports>[number],
-  index: InstalledPluginIndex,
+  ownershipResolver: ReturnType<typeof createInstalledPluginOwnershipResolver>,
 ) {
-  const ownership = resolveInstalledPluginPackageOwnership(index, inspect.plugin.id);
+  const ownership = ownershipResolver.resolvePackage(inspect.plugin.id);
   return {
     inspect,
     compatibilityWarnings: inspect.compatibility.map((warning) => ({
@@ -230,8 +229,9 @@ export const handlePluginsCommand: CommandHandler = defineAuthorizedTextCommand(
           return commandReply(formatPluginsList(report));
         }
         if (normalizeOptionalLowercaseString(pluginsCommand.name) === "all") {
+          const ownershipResolver = createInstalledPluginOwnershipResolver(metadataSnapshot.index);
           const reports = buildAllPluginInspectReports({ config, report }).map((inspect) =>
-            buildPluginInspectJson(inspect, metadataSnapshot.index),
+            buildPluginInspectJson(inspect, ownershipResolver),
           );
           return commandReply(renderJsonBlock("🔌 Plugins", reports));
         }
@@ -243,7 +243,10 @@ export const handlePluginsCommand: CommandHandler = defineAuthorizedTextCommand(
         if (!inspect) {
           return commandReply(`🔌 No plugin named "${pluginsCommand.name}" found.`);
         }
-        const payload = buildPluginInspectJson(inspect, metadataSnapshot.index);
+        const payload = buildPluginInspectJson(
+          inspect,
+          createInstalledPluginOwnershipResolver(metadataSnapshot.index),
+        );
         return commandReply(
           renderJsonBlock(`🔌 Plugin "${inspect.plugin.id}"`, {
             ...inspect,

--- a/src/cli/plugins-inspect-command.ts
+++ b/src/cli/plugins-inspect-command.ts
@@ -6,7 +6,7 @@ import { getRuntimeConfig } from "../config/config.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { formatConsoleDiagnosticLine } from "../logging/json-console-line.js";
 import { resolvePluginControlPlaneWorkspace } from "../plugins/control-plane-workspace.js";
-import { resolveInstalledPluginPackageOwnership } from "../plugins/installed-plugin-package-ownership.js";
+import { createInstalledPluginOwnershipResolver } from "../plugins/installed-plugin-package-ownership.js";
 import type { PluginDiagnostic } from "../plugins/manifest-types.js";
 import { tracePluginLifecyclePhase } from "../plugins/plugin-lifecycle-trace.js";
 import { defaultRuntime } from "../runtime.js";
@@ -152,10 +152,11 @@ export async function runPluginsInspectCommand(
     () => loadPluginMetadataSnapshot({ config: cfg, workspaceDir }),
     { command: "inspect" },
   );
+  const ownershipResolver = createInstalledPluginOwnershipResolver(metadataSnapshot.index);
   const resolveInstallRecord = (pluginId: string) => {
     // Runtime child ids need the package owner's record; ambiguous ownership
     // must not borrow provenance from an unrelated same-id install.
-    const ownership = resolveInstalledPluginPackageOwnership(metadataSnapshot.index, pluginId);
+    const ownership = ownershipResolver.resolvePackage(pluginId);
     return ownership.ok ? ownership.value.installRecord : undefined;
   };
   const loggerParams = opts.json ? { logger: quietPluginJsonLogger } : {};

--- a/src/cli/plugins-uninstall-command.ts
+++ b/src/cli/plugins-uninstall-command.ts
@@ -69,7 +69,7 @@ async function runPluginUninstallCommandUnlocked(
   const { loadInstalledPluginIndex } = await import("../plugins/installed-plugin-index.js");
   const { createInstalledPluginIndexScopeLookup } =
     await import("../plugins/installed-plugin-index-scope-lookup.js");
-  const { resolveInstalledPluginLifecycleOwnership } =
+  const { createInstalledPluginOwnershipResolver } =
     await import("../plugins/installed-plugin-package-ownership.js");
   const {
     loadInstalledPluginIndexInstallRecords,
@@ -135,7 +135,8 @@ async function runPluginUninstallCommandUnlocked(
   }
   const { plugin } = selection.value;
   const requestedPluginId = selection.value.pluginId;
-  const ownership = resolveInstalledPluginLifecycleOwnership(installedIndex, requestedPluginId);
+  const ownership =
+    createInstalledPluginOwnershipResolver(installedIndex).resolveLifecycle(requestedPluginId);
   if (!ownership.ok) {
     runtime.error(ownership.error);
     runtime.exit(1);

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -41,7 +41,7 @@ import {
   withPluginInstallRecords,
 } from "../plugins/installed-plugin-index-records.js";
 import { loadInstalledPluginIndex } from "../plugins/installed-plugin-index.js";
-import { resolveInstalledPluginLifecycleOwnership } from "../plugins/installed-plugin-package-ownership.js";
+import { createInstalledPluginOwnershipResolver } from "../plugins/installed-plugin-package-ownership.js";
 import { configReferencesNpmInstallPath } from "../plugins/installs.js";
 import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
 import {
@@ -254,11 +254,12 @@ async function runPluginUpdateCommandUnlocked(
   });
   const installOwnerByPluginId = new Map<string, string>();
   const rejectedPluginIds = new Map<string, string>();
+  const ownershipResolver = createInstalledPluginOwnershipResolver(installedPluginIndex);
   for (const pluginId of new Set([
     ...installedPluginIndex.plugins.map((plugin) => plugin.pluginId),
     ...Object.keys(pluginInstallRecords),
   ])) {
-    const ownership = resolveInstalledPluginLifecycleOwnership(installedPluginIndex, pluginId);
+    const ownership = ownershipResolver.resolveLifecycle(pluginId);
     if (!ownership.ok) {
       rejectedPluginIds.set(pluginId, ownership.error);
       continue;
@@ -299,10 +300,10 @@ async function runPluginUpdateCommandUnlocked(
   }
   const packageUpdateSnapshot = packageUpdateSnapshotResult.value;
   const packagePluginIds = Object.fromEntries(
-    pluginSelection.pluginIds.flatMap((pluginId) => {
-      const ownership = resolveInstalledPluginLifecycleOwnership(installedPluginIndex, pluginId);
-      return ownership.ok ? [[ownership.value.installOwner, ownership.value.pluginIds]] : [];
-    }),
+    [...packageUpdateSnapshot.values()].map((ownership) => [
+      ownership.installOwner,
+      [...ownership.pluginIds],
+    ]),
   );
   const selectedHooks = readHookInstalls();
   const hookSelection = resolveHookPackUpdateSelection({

--- a/src/plugins/capability-consent.ts
+++ b/src/plugins/capability-consent.ts
@@ -32,7 +32,7 @@ import {
   loadInstalledPluginIndexInstallRecords,
   writePersistedInstalledPluginIndexInstallRecordsWithLease,
 } from "./installed-plugin-index-records.js";
-import { resolveInstalledPluginPackageOwnership } from "./installed-plugin-package-ownership.js";
+import { createInstalledPluginOwnershipResolver } from "./installed-plugin-package-ownership.js";
 import { ManagedPluginLifecycleError } from "./management-lifecycle-error.js";
 import { isTrustedOfficialPluginInstallRecord } from "./official-external-install-records.js";
 import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
@@ -160,7 +160,9 @@ export async function resolvePluginCapabilityConsent(params: {
     ) {
       return;
     }
-    const ownership = resolveInstalledPluginPackageOwnership(metadata.index, pluginId, env);
+    const ownership = createInstalledPluginOwnershipResolver(metadata.index, env).resolvePackage(
+      pluginId,
+    );
     if (!ownership.ok) {
       throw new ManagedPluginLifecycleError(ownership.error);
     }

--- a/src/plugins/installed-plugin-package-ownership.ts
+++ b/src/plugins/installed-plugin-package-ownership.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import type { Result } from "@openclaw/normalization-core/result";
 import { isPathInside } from "../infra/path-guards.js";
 import { resolveUserPath } from "../utils.js";
 import {
@@ -14,10 +15,10 @@ import { safeRealpathSync } from "./path-safety.js";
 function collectDuplicateInstallRecordOwners(
   index: InstalledPluginIndex,
   env: NodeJS.ProcessEnv,
+  realpathCache: Map<string, string>,
 ): Set<string> {
   const ownersByPath = new Map<string, string>();
   const duplicateOwners = new Set<string>();
-  const realpathCache = new Map<string, string>();
   for (const [installOwner, record] of Object.entries(index.installRecords)) {
     const rawPath = record.installPath?.trim() || record.sourcePath?.trim();
     if (!rawPath) {
@@ -50,13 +51,9 @@ export type InstalledPluginLifecycleOwnership =
       pluginIds: [];
     };
 
-type InstalledPluginPackageOwnershipResult =
-  | { ok: true; value: InstalledPluginPackageOwnership }
-  | { ok: false; error: string };
+type InstalledPluginPackageOwnershipResult = Result<InstalledPluginPackageOwnership, string>;
 
-type InstalledPluginLifecycleOwnershipResult =
-  | { ok: true; value: InstalledPluginLifecycleOwnership }
-  | { ok: false; error: string };
+type InstalledPluginLifecycleOwnershipResult = Result<InstalledPluginLifecycleOwnership, string>;
 
 function ownershipError(pluginId: string, detail: string): InstalledPluginPackageOwnershipResult {
   return {
@@ -67,107 +64,117 @@ function ownershipError(pluginId: string, detail: string): InstalledPluginPackag
   };
 }
 
-export function resolveInstalledPluginPackageOwnership(
+// Reuse only while the index and package paths are unchanged in one synchronous
+// phase. After yielding or replacing paths, create a fresh resolver.
+export function createInstalledPluginOwnershipResolver(
   index: InstalledPluginIndex,
-  pluginId: string,
   env: NodeJS.ProcessEnv = process.env,
-): InstalledPluginPackageOwnershipResult {
-  const target = index.plugins.find((entry) => entry.pluginId === pluginId);
-  if (target && isInstalledPluginIndexInstallOwnerAmbiguous(target)) {
-    return ownershipError(pluginId, "has ambiguous package ownership");
+) {
+  const targets = new Map<string, InstalledPluginIndex["plugins"][number]>();
+  const childrenByOwner = new Map<string, string[]>();
+  for (const entry of index.plugins) {
+    if (!targets.has(entry.pluginId)) {
+      targets.set(entry.pluginId, entry);
+    }
+    const installOwner = resolveInstalledPluginIndexInstallOwner(entry);
+    if (installOwner) {
+      const children = childrenByOwner.get(installOwner) ?? [];
+      children.push(entry.pluginId);
+      childrenByOwner.set(installOwner, children);
+    }
   }
-  const ownerFromTarget = target ? resolveInstalledPluginIndexInstallOwner(target) : undefined;
-  if (target && !ownerFromTarget) {
-    return ownershipError(pluginId, "has no authoritative package-owner metadata");
+  for (const children of childrenByOwner.values()) {
+    children.sort();
+  }
+  const realpathCache = new Map<string, string>();
+  let duplicateOwners: Set<string> | undefined;
+  const duplicates = () =>
+    (duplicateOwners ??= collectDuplicateInstallRecordOwners(index, env, realpathCache));
+  const unsafeOwners = new Map<string, boolean>();
+
+  function resolvePackage(pluginId: string): InstalledPluginPackageOwnershipResult {
+    const target = targets.get(pluginId);
+    if (target && isInstalledPluginIndexInstallOwnerAmbiguous(target)) {
+      return ownershipError(pluginId, "has ambiguous package ownership");
+    }
+    const ownerFromTarget = target ? resolveInstalledPluginIndexInstallOwner(target) : undefined;
+    if (target && !ownerFromTarget) {
+      return ownershipError(pluginId, "has no authoritative package-owner metadata");
+    }
+
+    const ownerFromRecord = Object.hasOwn(index.installRecords, pluginId) ? pluginId : undefined;
+    const installOwner = ownerFromTarget ?? ownerFromRecord;
+    if (!installOwner) {
+      return ownershipError(pluginId, "is not associated with a tracked package install");
+    }
+    if (ownerFromTarget && ownerFromRecord && ownerFromTarget !== ownerFromRecord) {
+      return ownershipError(pluginId, "matches conflicting package owners");
+    }
+    const installRecord = index.installRecords[installOwner];
+    if (!installRecord) {
+      return ownershipError(pluginId, `references missing package owner "${installOwner}"`);
+    }
+    if (duplicates().has(installOwner)) {
+      return ownershipError(pluginId, `shares package path ownership with "${installOwner}"`);
+    }
+
+    const [firstPluginId, ...remainingPluginIds] = childrenByOwner.get(installOwner) ?? [];
+    if (!firstPluginId) {
+      return ownershipError(
+        pluginId,
+        `package owner "${installOwner}" has no authoritative runtime child list`,
+      );
+    }
+    // Each result owns its child list; callers cannot mutate the prepared order.
+    const pluginIds: [string, ...string[]] = [firstPluginId, ...remainingPluginIds];
+    const hasUnsafePackageEntry =
+      unsafeOwners.get(installOwner) ??
+      index.plugins.some(
+        (entry) =>
+          installRecordPathMatchesPluginRoot(installRecord, entry.rootDir, env, realpathCache) &&
+          resolveInstalledPluginIndexInstallOwner(entry) !== installOwner,
+      );
+    unsafeOwners.set(installOwner, hasUnsafePackageEntry);
+    if (hasUnsafePackageEntry) {
+      return ownershipError(pluginId, `package owner "${installOwner}" has conflicting child rows`);
+    }
+    return {
+      ok: true,
+      value: { installOwner, installRecord, pluginIds },
+    };
   }
 
-  const ownerFromRecord = Object.hasOwn(index.installRecords, pluginId) ? pluginId : undefined;
-  const installOwner = ownerFromTarget ?? ownerFromRecord;
-  if (!installOwner) {
-    return ownershipError(pluginId, "is not associated with a tracked package install");
-  }
-  if (ownerFromTarget && ownerFromRecord && ownerFromTarget !== ownerFromRecord) {
-    return ownershipError(pluginId, "matches conflicting package owners");
-  }
-  const installRecord = index.installRecords[installOwner];
-  if (!installRecord) {
-    return ownershipError(pluginId, `references missing package owner "${installOwner}"`);
-  }
-  if (collectDuplicateInstallRecordOwners(index, env).has(installOwner)) {
-    return ownershipError(pluginId, `shares package path ownership with "${installOwner}"`);
-  }
-
-  const [firstPluginId, ...remainingPluginIds] = index.plugins
-    .filter(
+  function resolveLifecycle(pluginId: string): InstalledPluginLifecycleOwnershipResult {
+    const ownership = resolvePackage(pluginId);
+    if (ownership.ok) {
+      return { ok: true, value: { kind: "package", ...ownership.value } };
+    }
+    const installRecord = index.installRecords[pluginId];
+    if (
+      !Object.hasOwn(index.installRecords, pluginId) ||
+      !installRecord ||
+      duplicates().has(pluginId)
+    ) {
+      return ownership;
+    }
+    const hasConflictingEntry = index.plugins.some(
       (entry) =>
-        resolveInstalledPluginIndexInstallOwner(entry) === installOwner &&
-        !isInstalledPluginIndexInstallOwnerAmbiguous(entry),
-    )
-    .map((entry) => entry.pluginId)
-    .toSorted();
-  if (!firstPluginId) {
-    return ownershipError(
-      pluginId,
-      `package owner "${installOwner}" has no authoritative runtime child list`,
+        entry.pluginId === pluginId ||
+        installRecordPathMatchesPluginRoot(installRecord, entry.rootDir, env, realpathCache),
     );
+    if (hasConflictingEntry) {
+      return ownership;
+    }
+    // Cleanup and pre-update planning may act on an exact durable tombstone.
+    // Replacement reconciliation keeps using the strict package resolver.
+    return {
+      ok: true,
+      value: { kind: "orphan", installOwner: pluginId, installRecord, pluginIds: [] },
+    };
   }
-  const pluginIds: [string, ...string[]] = [firstPluginId, ...remainingPluginIds];
-  if (target && !pluginIds.includes(target.pluginId)) {
-    return ownershipError(pluginId, `does not belong to package owner "${installOwner}"`);
-  }
-
-  const realpathCache = new Map<string, string>();
-  const hasUnsafePackageEntry = index.plugins.some(
-    (entry) =>
-      installRecordPathMatchesPluginRoot(installRecord, entry.rootDir, env, realpathCache) &&
-      (isInstalledPluginIndexInstallOwnerAmbiguous(entry) ||
-        resolveInstalledPluginIndexInstallOwner(entry) !== installOwner),
-  );
-  if (hasUnsafePackageEntry) {
-    return ownershipError(pluginId, `package owner "${installOwner}" has conflicting child rows`);
-  }
-  return {
-    ok: true,
-    value: { installOwner, installRecord, pluginIds },
-  };
+  return { resolvePackage, resolveLifecycle };
 }
 
-export function resolveInstalledPluginLifecycleOwnership(
-  index: InstalledPluginIndex,
-  pluginId: string,
-  env: NodeJS.ProcessEnv = process.env,
-): InstalledPluginLifecycleOwnershipResult {
-  const ownership = resolveInstalledPluginPackageOwnership(index, pluginId, env);
-  if (ownership.ok) {
-    return { ok: true, value: { kind: "package", ...ownership.value } };
-  }
-  const installRecord = index.installRecords[pluginId];
-  if (
-    !Object.hasOwn(index.installRecords, pluginId) ||
-    !installRecord ||
-    collectDuplicateInstallRecordOwners(index, env).has(pluginId)
-  ) {
-    return ownership;
-  }
-  const realpathCache = new Map<string, string>();
-  const hasConflictingEntry = index.plugins.some(
-    (entry) =>
-      entry.pluginId === pluginId ||
-      installRecordPathMatchesPluginRoot(installRecord, entry.rootDir, env, realpathCache),
-  );
-  if (hasConflictingEntry) {
-    return ownership;
-  }
-  // Cleanup and pre-update planning may act on an exact durable tombstone.
-  // Replacement reconciliation keeps using the strict package resolver.
-  return {
-    ok: true,
-    value: { kind: "orphan", installOwner: pluginId, installRecord, pluginIds: [] },
-  };
-}
-
-// Share physical path facts only within one synchronous scan. A later lifecycle
-// check gets a fresh map so replaced package paths are observed again.
 function installRecordPathMatchesPluginRoot(
   record: InstalledPluginInstallRecordInfo,
   rootDir: string,
@@ -190,11 +197,11 @@ export function hasMissingInstalledPluginOwnerMetadata(
   index: InstalledPluginIndex,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  if (collectDuplicateInstallRecordOwners(index, env).size > 0) {
+  const realpathCache = new Map<string, string>();
+  if (collectDuplicateInstallRecordOwners(index, env, realpathCache).size > 0) {
     return true;
   }
   const installRecords = Object.entries(index.installRecords);
-  const realpathCache = new Map<string, string>();
   // An orphaned owner record (for example, package code removed out of band) is
   // already closed by the lifecycle resolver. It must not make every unrelated
   // config read attempt an impossible registry migration with no discoverable rows.

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -100,10 +100,7 @@ import {
   createInstalledPluginEnabledPredicate,
   isInstalledPluginEnabled,
 } from "./installed-plugin-index.js";
-import {
-  resolveInstalledPluginLifecycleOwnership,
-  resolveInstalledPluginPackageOwnership,
-} from "./installed-plugin-package-ownership.js";
+import { createInstalledPluginOwnershipResolver } from "./installed-plugin-package-ownership.js";
 import { ManagedPluginLifecycleError } from "./management-lifecycle-error.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
@@ -877,11 +874,12 @@ export const listManagedPlugins = withManagedPluginCache(
       params.config,
       env,
     );
+    const ownershipResolver = createInstalledPluginOwnershipResolver(metadata.index);
     const plugins = metadata.index.plugins.map((record): ManagedPluginCatalogEntry => {
       const enabled = isEnabled(record.pluginId);
       const manifest = metadata.byPluginId.get(record.pluginId);
       const localCatalog = normalizeCatalogMetadata(manifest?.catalog);
-      const ownership = resolveInstalledPluginPackageOwnership(metadata.index, record.pluginId);
+      const ownership = ownershipResolver.resolvePackage(record.pluginId);
       const installOwner = ownership.ok ? ownership.value.installOwner : undefined;
       const installRecord = installOwner ? metadata.index.installRecords[installOwner] : undefined;
       if (
@@ -1109,7 +1107,9 @@ export const inspectManagedPlugin = withManagedPluginCache(
 
     if (record) {
       const manifest = metadata.byPluginId.get(pluginId);
-      const ownership = resolveInstalledPluginPackageOwnership(metadata.index, pluginId, env);
+      const ownership = createInstalledPluginOwnershipResolver(metadata.index, env).resolvePackage(
+        pluginId,
+      );
       const installOwner = ownership.ok ? ownership.value.installOwner : undefined;
       const installRecord = installOwner ? metadata.index.installRecords[installOwner] : undefined;
       const { entry: officialEntry, clawhubPackage } = resolveInstalledHostedOfficialEntry({
@@ -1959,11 +1959,10 @@ export async function installManagedPlugin(params: {
       officialCatalog,
       metadata: installedMetadata,
     });
-    const installedOwnership = resolveInstalledPluginPackageOwnership(
+    const installedOwnership = createInstalledPluginOwnershipResolver(
       installedMetadata.index,
-      installed.pluginId,
       env,
-    );
+    ).resolvePackage(installed.pluginId);
     if (!installedOwnership.ok) {
       throw new ManagedPluginLifecycleError(installedOwnership.error);
     }
@@ -2101,7 +2100,9 @@ export async function uninstallManagedPlugin(params: {
     if (!record && !Object.hasOwn(installRecords, pluginId)) {
       throw new ManagedPluginLifecycleError(`Plugin not found: ${pluginId}`);
     }
-    const ownership = resolveInstalledPluginLifecycleOwnership(metadata.index, pluginId, env);
+    const ownership = createInstalledPluginOwnershipResolver(metadata.index, env).resolveLifecycle(
+      pluginId,
+    );
     if (!ownership.ok) {
       throw new ManagedPluginLifecycleError(ownership.error);
     }

--- a/src/plugins/manifest-registry-installed.ownership.test.ts
+++ b/src/plugins/manifest-registry-installed.ownership.test.ts
@@ -1,0 +1,271 @@
+// Covers persisted installed package ownership and phase-local path validation.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  recordInstalledPluginIndexInstallOwner,
+  resolveInstalledPluginIndexInstallOwner,
+} from "./installed-plugin-index-install-owner.js";
+import { writePersistedInstalledPluginIndex } from "./installed-plugin-index-store-write.js";
+import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
+import { loadInstalledPluginIndex } from "./installed-plugin-index.js";
+import {
+  hasMissingInstalledPluginOwnerMetadata,
+  createInstalledPluginOwnershipResolver,
+} from "./installed-plugin-package-ownership.js";
+import { resolvePluginManifestInstallOwner } from "./manifest-install-owner.js";
+import { loadPluginManifestRegistryForInstalledIndex } from "./manifest-registry-installed.js";
+import { createIndex } from "./manifest-registry-installed.test-helpers.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+function makeTempDir() {
+  return makeTrackedTempDir("openclaw-installed-manifest-registry", tempDirs);
+}
+
+describe("loadPluginManifestRegistryForInstalledIndex", () => {
+  it("preserves package entry identities through a persisted cold reload", async () => {
+    const stateDir = makeTempDir();
+    const packageDir = path.join(stateDir, "extensions", "pack");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "pack",
+        version: "1.0.0",
+        openclaw: { extensions: ["./one.cjs", "./two.cjs"] },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(packageDir, "openclaw.plugin.json"),
+      JSON.stringify({ id: "pack", configSchema: { type: "object" } }),
+      "utf8",
+    );
+    for (const entry of ["one", "two"]) {
+      fs.writeFileSync(
+        path.join(packageDir, `${entry}.cjs`),
+        `module.exports = { id: "pack/${entry}", register() {} };\n`,
+        "utf8",
+      );
+    }
+    const config = {
+      plugins: {
+        entries: {
+          "pack/one": { enabled: true },
+          "pack/two": { enabled: false },
+        },
+      },
+    };
+    const env = {
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_VERSION: "2026.4.25",
+      VITEST: "true",
+    };
+    const installRecords = {
+      pack: {
+        source: "path" as const,
+        sourcePath: packageDir,
+        installPath: packageDir,
+      },
+    };
+    const index = loadInstalledPluginIndex({ config, env, installRecords, stateDir });
+
+    expect(
+      index.plugins.map((plugin) => ({
+        pluginId: plugin.pluginId,
+        installOwner: resolveInstalledPluginIndexInstallOwner(plugin),
+        enabled: plugin.enabled,
+      })),
+    ).toEqual([
+      { pluginId: "pack/one", installOwner: "pack", enabled: true },
+      { pluginId: "pack/two", installOwner: "pack", enabled: false },
+    ]);
+    await writePersistedInstalledPluginIndex(index, { stateDir });
+    clearPluginMetadataLifecycleCaches();
+    const persisted = await readPersistedInstalledPluginIndex({ stateDir });
+    if (!persisted) {
+      throw new Error("expected persisted package plugin index");
+    }
+    const persistedOwnership = createInstalledPluginOwnershipResolver(persisted);
+    const firstOwnership = persistedOwnership.resolvePackage("pack/one");
+    expect(firstOwnership).toMatchObject({
+      ok: true,
+      value: { installOwner: "pack", pluginIds: ["pack/one", "pack/two"] },
+    });
+    if (!firstOwnership.ok) {
+      throw new Error(firstOwnership.error);
+    }
+    firstOwnership.value.pluginIds.reverse();
+    expect(persistedOwnership.resolvePackage("pack/two")).toMatchObject({
+      ok: true,
+      value: { installOwner: "pack", pluginIds: ["pack/one", "pack/two"] },
+    });
+
+    const allEntries = loadPluginManifestRegistryForInstalledIndex({
+      index: persisted,
+      config,
+      env,
+      includeDisabled: true,
+    });
+    expect(
+      allEntries.plugins.map(({ id, source }) => ({ id, source: path.basename(source) })),
+    ).toEqual([
+      { id: "pack/one", source: "one.cjs" },
+      { id: "pack/two", source: "two.cjs" },
+    ]);
+    expect(allEntries.plugins.map(resolvePluginManifestInstallOwner)).toEqual(["pack", "pack"]);
+
+    const enabledEntries = loadPluginManifestRegistryForInstalledIndex({
+      index: persisted,
+      config,
+      env,
+    });
+    expect(enabledEntries.plugins.map(({ id }) => id)).toEqual(["pack/one"]);
+
+    const ownerless = {
+      ...persisted,
+      plugins: persisted.plugins.map((plugin) => {
+        const {
+          installOwner: _installOwner,
+          installOwnerAmbiguous: _installOwnerAmbiguous,
+          ...ownerlessPlugin
+        } = plugin as typeof plugin & {
+          installOwner?: string;
+          installOwnerAmbiguous?: true;
+        };
+        return ownerlessPlugin;
+      }),
+    };
+    expect(createInstalledPluginOwnershipResolver(ownerless).resolvePackage("pack/one").ok).toBe(
+      false,
+    );
+
+    const orphanedOwner = {
+      ...persisted,
+      installRecords: {
+        ...persisted.installRecords,
+        orphaned: {
+          source: "path" as const,
+          sourcePath: path.join(stateDir, "removed-orphan"),
+          installPath: path.join(stateDir, "removed-orphan"),
+        },
+      },
+    };
+    const orphanOwnership = createInstalledPluginOwnershipResolver(orphanedOwner);
+    expect(orphanOwnership.resolvePackage("orphaned").ok).toBe(false);
+    expect(orphanOwnership.resolveLifecycle("orphaned")).toMatchObject({
+      ok: true,
+      value: { kind: "orphan", installOwner: "orphaned", pluginIds: [] },
+    });
+    expect(hasMissingInstalledPluginOwnerMetadata(orphanedOwner, env)).toBe(false);
+
+    const legacyAmbiguous = {
+      ...ownerless,
+      installRecords: {
+        "pack/one": installRecords.pack,
+        "pack/two": installRecords.pack,
+      },
+    };
+    const legacyOwnership = createInstalledPluginOwnershipResolver(legacyAmbiguous);
+    expect(legacyOwnership.resolvePackage("pack/one").ok).toBe(false);
+    expect(legacyOwnership.resolveLifecycle("pack/one").ok).toBe(false);
+    expect(hasMissingInstalledPluginOwnerMetadata(legacyAmbiguous, env)).toBe(true);
+
+    const packageAlias = path.join(stateDir, "pack-alias");
+    fs.symlinkSync(packageDir, packageAlias, process.platform === "win32" ? "junction" : "dir");
+    const aliasedAmbiguous = {
+      ...ownerless,
+      installRecords: {
+        "pack/one": installRecords.pack,
+        "pack/two": {
+          ...installRecords.pack,
+          sourcePath: packageAlias,
+          installPath: packageAlias,
+        },
+      },
+    };
+    const aliasedOwnership = createInstalledPluginOwnershipResolver(aliasedAmbiguous);
+    expect(aliasedOwnership.resolvePackage("pack/one").ok).toBe(false);
+    expect(aliasedOwnership.resolveLifecycle("pack/one").ok).toBe(false);
+    expect(hasMissingInstalledPluginOwnerMetadata(aliasedAmbiguous, env)).toBe(true);
+
+    const unrelatedOwner = "unrelated";
+    const relationScoped = {
+      ...aliasedAmbiguous,
+      plugins: [
+        ...aliasedAmbiguous.plugins,
+        recordInstalledPluginIndexInstallOwner(
+          {
+            ...aliasedAmbiguous.plugins[0]!,
+            pluginId: unrelatedOwner,
+            rootDir: path.join(stateDir, unrelatedOwner),
+          },
+          unrelatedOwner,
+        ),
+      ],
+      installRecords: {
+        ...aliasedAmbiguous.installRecords,
+        [unrelatedOwner]: {
+          source: "path" as const,
+          sourcePath: path.join(stateDir, unrelatedOwner),
+          installPath: path.join(stateDir, unrelatedOwner),
+        },
+      },
+    };
+    expect(
+      createInstalledPluginOwnershipResolver(relationScoped).resolvePackage(unrelatedOwner),
+    ).toMatchObject({
+      ok: true,
+      value: { installOwner: unrelatedOwner, pluginIds: [unrelatedOwner] },
+    });
+
+    const ambiguous = {
+      ...legacyAmbiguous,
+      plugins: ownerless.plugins.map((plugin) =>
+        recordInstalledPluginIndexInstallOwner(plugin, undefined, true),
+      ),
+    };
+    expect(createInstalledPluginOwnershipResolver(ambiguous).resolvePackage("pack/one").ok).toBe(
+      false,
+    );
+    expect(hasMissingInstalledPluginOwnerMetadata(ambiguous, env)).toBe(true);
+  });
+
+  it("rechecks replaced package paths in the next ownership phase", () => {
+    const rootDir = makeTempDir();
+    const otherDir = makeTempDir();
+    const alias = path.join(makeTempDir(), "package");
+    const linkType = process.platform === "win32" ? "junction" : "dir";
+    fs.symlinkSync(otherDir, alias, linkType);
+    const index = createIndex(rootDir);
+    recordInstalledPluginIndexInstallOwner(index.plugins[0]!, "installed");
+    index.installRecords = {
+      installed: { source: "path", installPath: rootDir },
+      orphan: { source: "path", installPath: alias },
+    };
+    const initial = createInstalledPluginOwnershipResolver(index);
+    expect(initial.resolvePackage("installed").ok).toBe(true);
+    expect(initial.resolveLifecycle("orphan")).toMatchObject({
+      ok: true,
+      value: { kind: "orphan", installOwner: "orphan" },
+    });
+
+    fs.unlinkSync(alias);
+    fs.symlinkSync(rootDir, alias, linkType);
+    const replaced = createInstalledPluginOwnershipResolver(index);
+    expect(replaced.resolvePackage("installed")).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("shares package path ownership"),
+    });
+    expect(replaced.resolveLifecycle("orphan").ok).toBe(false);
+  });
+});

--- a/src/plugins/manifest-registry-installed.test-helpers.ts
+++ b/src/plugins/manifest-registry-installed.test-helpers.ts
@@ -1,0 +1,32 @@
+import path from "node:path";
+import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+
+export function createIndex(rootDir: string): InstalledPluginIndex {
+  return {
+    version: 1,
+    hostContractVersion: "2026.4.25",
+    compatRegistryVersion: "compat-v1",
+    migrationVersion: 1,
+    policyHash: "policy-v1",
+    generatedAtMs: 1777118400000,
+    installRecords: {},
+    plugins: [
+      {
+        pluginId: "installed",
+        manifestPath: path.join(rootDir, "openclaw.plugin.json"),
+        manifestHash: "manifest-hash",
+        source: path.join(rootDir, "index.ts"),
+        rootDir,
+        origin: "global",
+        enabled: true,
+        startup: {
+          sidecar: false,
+          memory: false,
+          agentHarnesses: [],
+        },
+        compat: [],
+      },
+    ],
+    diagnostics: [],
+  };
+}

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -3,23 +3,14 @@ import fs from "node:fs";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  recordInstalledPluginIndexInstallOwner,
-  resolveInstalledPluginIndexInstallOwner,
-} from "./installed-plugin-index-install-owner.js";
 import { writePersistedInstalledPluginIndex } from "./installed-plugin-index-store-write.js";
 import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
-import { loadInstalledPluginIndex, type InstalledPluginIndex } from "./installed-plugin-index.js";
-import {
-  hasMissingInstalledPluginOwnerMetadata,
-  resolveInstalledPluginLifecycleOwnership,
-  resolveInstalledPluginPackageOwnership,
-} from "./installed-plugin-package-ownership.js";
-import { resolvePluginManifestInstallOwner } from "./manifest-install-owner.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import {
   loadPluginManifestRegistryForInstalledIndex,
   resolveInstalledManifestRegistryIndexFingerprint,
 } from "./manifest-registry-installed.js";
+import { createIndex } from "./manifest-registry-installed.test-helpers.js";
 import { createPluginCache, withPluginCache } from "./plugin-cache.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
@@ -53,36 +44,6 @@ function writePlugin(rootDir: string, pluginId: string, modelPrefix: string) {
     }),
     "utf8",
   );
-}
-
-function createIndex(rootDir: string): InstalledPluginIndex {
-  return {
-    version: 1,
-    hostContractVersion: "2026.4.25",
-    compatRegistryVersion: "compat-v1",
-    migrationVersion: 1,
-    policyHash: "policy-v1",
-    generatedAtMs: 1777118400000,
-    installRecords: {},
-    plugins: [
-      {
-        pluginId: "installed",
-        manifestPath: path.join(rootDir, "openclaw.plugin.json"),
-        manifestHash: "manifest-hash",
-        source: path.join(rootDir, "index.ts"),
-        rootDir,
-        origin: "global",
-        enabled: true,
-        startup: {
-          sidecar: false,
-          memory: false,
-          agentHarnesses: [],
-        },
-        compat: [],
-      },
-    ],
-    diagnostics: [],
-  };
 }
 
 function fileSignature(filePath: string) {
@@ -430,196 +391,6 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
     expect(registry.plugins[0]?.modelSupport).toEqual({
       modelPrefixes: ["installed-"],
     });
-  });
-
-  it("preserves package entry identities through a persisted cold reload", async () => {
-    const stateDir = makeTempDir();
-    const packageDir = path.join(stateDir, "extensions", "pack");
-    fs.mkdirSync(packageDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(packageDir, "package.json"),
-      JSON.stringify({
-        name: "pack",
-        version: "1.0.0",
-        openclaw: { extensions: ["./one.cjs", "./two.cjs"] },
-      }),
-      "utf8",
-    );
-    fs.writeFileSync(
-      path.join(packageDir, "openclaw.plugin.json"),
-      JSON.stringify({ id: "pack", configSchema: { type: "object" } }),
-      "utf8",
-    );
-    for (const entry of ["one", "two"]) {
-      fs.writeFileSync(
-        path.join(packageDir, `${entry}.cjs`),
-        `module.exports = { id: "pack/${entry}", register() {} };\n`,
-        "utf8",
-      );
-    }
-    const config = {
-      plugins: {
-        entries: {
-          "pack/one": { enabled: true },
-          "pack/two": { enabled: false },
-        },
-      },
-    };
-    const env = {
-      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-      OPENCLAW_STATE_DIR: stateDir,
-      OPENCLAW_VERSION: "2026.4.25",
-      VITEST: "true",
-    };
-    const installRecords = {
-      pack: {
-        source: "path" as const,
-        sourcePath: packageDir,
-        installPath: packageDir,
-      },
-    };
-    const index = loadInstalledPluginIndex({ config, env, installRecords, stateDir });
-
-    expect(
-      index.plugins.map((plugin) => ({
-        pluginId: plugin.pluginId,
-        installOwner: resolveInstalledPluginIndexInstallOwner(plugin),
-        enabled: plugin.enabled,
-      })),
-    ).toEqual([
-      { pluginId: "pack/one", installOwner: "pack", enabled: true },
-      { pluginId: "pack/two", installOwner: "pack", enabled: false },
-    ]);
-    await writePersistedInstalledPluginIndex(index, { stateDir });
-    clearPluginMetadataLifecycleCaches();
-    const persisted = await readPersistedInstalledPluginIndex({ stateDir });
-    if (!persisted) {
-      throw new Error("expected persisted package plugin index");
-    }
-    expect(resolveInstalledPluginPackageOwnership(persisted, "pack/one")).toMatchObject({
-      ok: true,
-      value: { installOwner: "pack", pluginIds: ["pack/one", "pack/two"] },
-    });
-
-    const allEntries = loadPluginManifestRegistryForInstalledIndex({
-      index: persisted,
-      config,
-      env,
-      includeDisabled: true,
-    });
-    expect(
-      allEntries.plugins.map(({ id, source }) => ({ id, source: path.basename(source) })),
-    ).toEqual([
-      { id: "pack/one", source: "one.cjs" },
-      { id: "pack/two", source: "two.cjs" },
-    ]);
-    expect(allEntries.plugins.map(resolvePluginManifestInstallOwner)).toEqual(["pack", "pack"]);
-
-    const enabledEntries = loadPluginManifestRegistryForInstalledIndex({
-      index: persisted,
-      config,
-      env,
-    });
-    expect(enabledEntries.plugins.map(({ id }) => id)).toEqual(["pack/one"]);
-
-    const ownerless = {
-      ...persisted,
-      plugins: persisted.plugins.map((plugin) => {
-        const {
-          installOwner: _installOwner,
-          installOwnerAmbiguous: _installOwnerAmbiguous,
-          ...ownerlessPlugin
-        } = plugin as typeof plugin & {
-          installOwner?: string;
-          installOwnerAmbiguous?: true;
-        };
-        return ownerlessPlugin;
-      }),
-    };
-    expect(resolveInstalledPluginPackageOwnership(ownerless, "pack/one").ok).toBe(false);
-
-    const orphanedOwner = {
-      ...persisted,
-      installRecords: {
-        ...persisted.installRecords,
-        orphaned: {
-          source: "path" as const,
-          sourcePath: path.join(stateDir, "removed-orphan"),
-          installPath: path.join(stateDir, "removed-orphan"),
-        },
-      },
-    };
-    expect(resolveInstalledPluginPackageOwnership(orphanedOwner, "orphaned").ok).toBe(false);
-    expect(resolveInstalledPluginLifecycleOwnership(orphanedOwner, "orphaned")).toMatchObject({
-      ok: true,
-      value: { kind: "orphan", installOwner: "orphaned", pluginIds: [] },
-    });
-    expect(hasMissingInstalledPluginOwnerMetadata(orphanedOwner, env)).toBe(false);
-
-    const legacyAmbiguous = {
-      ...ownerless,
-      installRecords: {
-        "pack/one": installRecords.pack,
-        "pack/two": installRecords.pack,
-      },
-    };
-    expect(resolveInstalledPluginPackageOwnership(legacyAmbiguous, "pack/one").ok).toBe(false);
-    expect(resolveInstalledPluginLifecycleOwnership(legacyAmbiguous, "pack/one").ok).toBe(false);
-    expect(hasMissingInstalledPluginOwnerMetadata(legacyAmbiguous, env)).toBe(true);
-
-    const packageAlias = path.join(stateDir, "pack-alias");
-    fs.symlinkSync(packageDir, packageAlias, process.platform === "win32" ? "junction" : "dir");
-    const aliasedAmbiguous = {
-      ...ownerless,
-      installRecords: {
-        "pack/one": installRecords.pack,
-        "pack/two": {
-          ...installRecords.pack,
-          sourcePath: packageAlias,
-          installPath: packageAlias,
-        },
-      },
-    };
-    expect(resolveInstalledPluginPackageOwnership(aliasedAmbiguous, "pack/one").ok).toBe(false);
-    expect(resolveInstalledPluginLifecycleOwnership(aliasedAmbiguous, "pack/one").ok).toBe(false);
-    expect(hasMissingInstalledPluginOwnerMetadata(aliasedAmbiguous, env)).toBe(true);
-
-    const unrelatedOwner = "unrelated";
-    const relationScoped = {
-      ...aliasedAmbiguous,
-      plugins: [
-        ...aliasedAmbiguous.plugins,
-        recordInstalledPluginIndexInstallOwner(
-          {
-            ...aliasedAmbiguous.plugins[0]!,
-            pluginId: unrelatedOwner,
-            rootDir: path.join(stateDir, unrelatedOwner),
-          },
-          unrelatedOwner,
-        ),
-      ],
-      installRecords: {
-        ...aliasedAmbiguous.installRecords,
-        [unrelatedOwner]: {
-          source: "path" as const,
-          sourcePath: path.join(stateDir, unrelatedOwner),
-          installPath: path.join(stateDir, unrelatedOwner),
-        },
-      },
-    };
-    expect(resolveInstalledPluginPackageOwnership(relationScoped, unrelatedOwner)).toMatchObject({
-      ok: true,
-      value: { installOwner: unrelatedOwner, pluginIds: [unrelatedOwner] },
-    });
-
-    const ambiguous = {
-      ...legacyAmbiguous,
-      plugins: ownerless.plugins.map((plugin) =>
-        recordInstalledPluginIndexInstallOwner(plugin, undefined, true),
-      ),
-    };
-    expect(resolveInstalledPluginPackageOwnership(ambiguous, "pack/one").ok).toBe(false);
-    expect(hasMissingInstalledPluginOwnerMetadata(ambiguous, env)).toBe(true);
   });
 
   it("reuses a prepared manifest graph without reopening plugin manifests", () => {

--- a/src/plugins/plugin-package-update.ts
+++ b/src/plugins/plugin-package-update.ts
@@ -2,8 +2,7 @@ import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import {
-  resolveInstalledPluginLifecycleOwnership,
-  resolveInstalledPluginPackageOwnership,
+  createInstalledPluginOwnershipResolver,
   type InstalledPluginLifecycleOwnership,
 } from "./installed-plugin-package-ownership.js";
 import {
@@ -20,12 +19,9 @@ export function capturePluginPackageUpdateSnapshot(params: {
   env?: NodeJS.ProcessEnv;
 }): { ok: true; value: PluginPackageUpdateSnapshot } | { ok: false; error: string } {
   const snapshot = new Map<string, InstalledPluginLifecycleOwnership>();
+  const resolver = createInstalledPluginOwnershipResolver(params.index, params.env);
   for (const installOwner of new Set(params.installOwners)) {
-    const ownership = resolveInstalledPluginLifecycleOwnership(
-      params.index,
-      installOwner,
-      params.env,
-    );
+    const ownership = resolver.resolveLifecycle(installOwner);
     if (!ownership.ok) {
       return ownership;
     }
@@ -63,19 +59,12 @@ export function reconcilePluginPackageUpdateConfig(params: {
   env?: NodeJS.ProcessEnv;
 }): { ok: true; config: OpenClawConfig } | { ok: false; error: string } {
   let config = params.config;
+  const resolver = createInstalledPluginOwnershipResolver(params.afterIndex, params.env);
   for (const [installOwner, before] of params.snapshot) {
     const nextInstallOwner = params.installOwnerMigrations?.[installOwner] ?? installOwner;
-    const after = resolveInstalledPluginPackageOwnership(
-      params.afterIndex,
-      nextInstallOwner,
-      params.env,
-    );
+    const after = resolver.resolvePackage(nextInstallOwner);
     if (before.kind === "orphan") {
-      const lifecycleAfter = resolveInstalledPluginLifecycleOwnership(
-        params.afterIndex,
-        nextInstallOwner,
-        params.env,
-      );
+      const lifecycleAfter = resolver.resolveLifecycle(nextInstallOwner);
       const unchangedOrphan =
         nextInstallOwner === installOwner &&
         isDeepStrictEqual(

--- a/test/scripts/plugin-update-unchanged-docker.test.ts
+++ b/test/scripts/plugin-update-unchanged-docker.test.ts
@@ -8,7 +8,7 @@ import { pathToFileURL } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import { loadInstalledPluginIndex } from "../../src/plugins/installed-plugin-index.js";
-import { resolveInstalledPluginPackageOwnership } from "../../src/plugins/installed-plugin-package-ownership.js";
+import { createInstalledPluginOwnershipResolver } from "../../src/plugins/installed-plugin-package-ownership.js";
 import {
   closeOpenClawStateDatabaseByPath,
   openOpenClawStateDatabase,
@@ -206,7 +206,7 @@ describe("plugin update unchanged Docker E2E", () => {
           stateDir,
         });
         expect(
-          resolveInstalledPluginPackageOwnership(liveIndex, "lossless-claw", env),
+          createInstalledPluginOwnershipResolver(liveIndex, env).resolvePackage("lossless-claw"),
         ).toMatchObject({
           ok: true,
           value: {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Plugin package update planning and reconciliation repeat ownership work as they walk packages and runtime children. That repeated work grows with installed package inventories.

## Why This Change Was Made

One resolver now prepares ownership facts for each synchronous phase, replacing the two standalone package/lifecycle resolution paths and repeated scans at internal callers. Capture and replacement reconciliation create separate resolvers; yielding or replacing paths requires a fresh resolver. First-match identity, duplicate-preserving child order, physical-path conflicts, orphan cleanup rules, and fresh returned child arrays stay intact.

Production is **+148/−143, net +5 lines**. The added factory lifetime replaces repeated preparation across eight internal callers/owners; it introduces no process cache, configuration, SDK, or storage contract. Tests and support are **+307/−233, net +74**, including a shared typed fixture and ownership-suite extraction.

## User Impact

No intended behavior change. The complete capture/reconciliation component is faster on the populated fixtures below, with explicit construction costs on empty and early-error paths. This is not a whole-CLI, management-inventory, Gateway, cold-start, or memory improvement claim.

## Evidence

Before/candidate whole-file proof passed the same **333 cases across 18 files**, including consent, inventory, owner routing, install/uninstall/update, lifecycle and chat paths. After the test-only extraction, both complete resulting suites passed all **22 moved/retained cases**, with byte-identical moved bodies and preserved case names and within-file order. The first normal changed gate failed the registry test's 1,000-line lint limit; its failure is retained. Extracting the two complete ownership cases and sharing the existing typed fixture fixed it without changing ratchets, limits, or production. The successor normal pinned-base gate passed all **30 stages**.

Managed Codex P0–P2 review returned **scoped-clean**, no accepted findings, across three passes (aggregate confidence 0.80). Each pass saw its assigned evidence; the full report retains its per-pass unchanged-caller/dependency context limitations. No reviewer executed product code.

The fixed B0/C0/C1/B1 study times the actual exported capture operation and reconciliation on capture success, including resolver construction on every invocation. It retained **4,694 complete output envelopes, 8,210 exported calls, 512 measured batch means, 372 comparisons, and all 187 adverse comparisons**. Full outputs, own-undefined fields and public identity/array-preservation assertions passed. Raw-first arithmetic exactly matched the retained report. That arithmetic auditor also authored the harness; separate source reviewers inspected it.

| Complete capture/reconciliation row | Median delta, forward / reverse | Absolute delta, forward / reverse |
| --- | --- | --- |
| Empty inventory | +532.67% / +524.85% | +1.318 / +1.326 µs |
| 32 packages, zero selection | +6762.79% / +6538.54% | +19.198 / +20.094 µs |
| Single package | -37.33% / -36.98% | -28.380 / -28.276 µs |
| Missing owner, early error | +215.83% / +239.06% | +6.464 / +6.599 µs |
| Ownerless bundled entry, early error | +539.58% / +600.78% | +2.164 / +2.221 µs |
| Eight packages | -57.43% / -55.54% | -3585.612 / -3456.125 µs |
| 32 packages | -57.66% / -59.54% | -59030.435 / -61760.190 µs |
| Eight changed packages plus orphan/migration | -46.44% / -46.12% | -4918.812 / -4835.948 µs |

Sampled tree RSS increased **+2.064% / +2.322%**; kernel child peaks increased **+1.658% / +2.020%**. Both include setup, validation and retained evidence, and sampling can miss peaks. The zero-selection row's maximum batch mean regressed **+69.521 / +31.182 µs** and its first observations **+97.792 / +107.792 µs**. Empty, missing-owner and bundled-error tails also remain adverse. Every first, warm, matched batch, tail and RSS comparison is retained; none was rerun or removed. Here p95 of 16 batch means equals their maximum, not individual-call p95. There is no aggregate numerical pass threshold.

All six native hosts and the functional/gate processes closed; sources were restored and checked. First observations follow imports/fixture setup and earlier rows, so they are not independently cold filesystem or process samples. Source/dependency binding is selected, not an exhaustive loaded-image inventory. The immutable report digest is `870c605939e952ed887de10edd1d1622dc5df79eb153381d147c4d281f0d9d69`.

A separate follow-up remains: management inventory historically omits its supplied custom environment when resolving ownership. This patch preserves that behavior; it does not claim to fix it. All nine existing touched files are unchanged between the measured base and inspected main 06759eab. Fresh hosted CI remains required before landing.

CI correction: the first published head exposed a missed test caller of the removed scalar ownership resolver. The existing Docker-probe test now constructs the same canonical phase resolver with its loaded index and fixture environment. Before the correction, the complete file reproduced exactly two failures; after it, all 18 cases pass in the same order. The normal incremental 15-stage gate (including root test typechecking) and independent Codex P0–P2 review passed. This adds no production lines and changes two test lines. All eight production owners and the original measurements remain unchanged. Fresh hosted CI is still required; this local macOS proof is not a claim that the whole prior Linux shard passed.

Current landing evidence: exact-head CI run [33933305230](https://github.com/openclaw/openclaw/actions/runs/33933305230) passed, including the aggregate gate. The pinned fs-safe dependency source and its phase-local cache contract were directly inspected; [the review disposition](https://github.com/openclaw/openclaw/pull/138716#issuecomment-5548230982) addresses the remaining ClawSweeper dependency gap and rank-up move. No production or numerical result changed.
