### PR TITLE
fix: local model setup leaves CPU chats waiting

### DIFF
--- a/docs/concepts/experimental-features.md
+++ b/docs/concepts/experimental-features.md
@@ -65,7 +65,7 @@ native `sessions_spawn` tool, while the low-level flow also requires
 
 `agents.defaults.experimental.localModelLean: true` drops heavyweight optional tools from the agent's direct surface every turn: `browser`, `cron`, `message`, `image_generate`, `music_generate`, `video_generate`, `tts`, and `pdf`. Explicitly allowed or delivery-required tools remain available, though Tool Search may catalog them instead of exposing them directly. Lean mode also defaults plugin/MCP/client catalogs to structured Tool Search (`tool_search`, `tool_describe`, `tool_call`) when `tools.toolSearch` is not already set. Use `agents.entries.*.experimental.localModelLean` to scope this to one agent.
 
-During onboarding, a verified `ollama` or `lmstudio` inference route automatically sets `agents.defaults.experimental.localModelLean: true` when that value is absent. OpenClaw records that the setting came from onboarding, so a later verified non-local route lifts only the automatic setting. An explicitly configured `true` or `false` is preserved. Other self-hosted and OpenAI-compatible providers are not inferred from model names or URLs.
+Selecting an `ollama`, `lmstudio`, or managed local-model route with `models.providers.<id>.localService` during onboarding automatically sets `agents.defaults.experimental.localModelLean: true` when that value is absent. Hosted Ollama models are excluded. When setup verifies a candidate, it uses the same setting that will be saved. OpenClaw records that the setting came from onboarding, so running setup for a non-local route lifts only the automatic setting. An explicitly configured `true` or `false` is preserved. Other self-hosted and OpenAI-compatible providers are not inferred from model names or URLs.
 
 If you already tune Tool Search globally, OpenClaw leaves that config alone. Set `tools.toolSearch: false` to opt out of the lean-mode Tool Search default.
 
@@ -91,7 +91,7 @@ Enable lean mode once you have proved the model can talk to the Gateway but full
 
 ### When to leave it off
 
-If your backend handles the full default runtime cleanly, leave this off. It is a workaround for local stacks that need a smaller tool surface, not a default for hosted models or well-resourced local rigs.
+If your backend handles the full default runtime cleanly, explicitly set `agents.defaults.experimental.localModelLean: false`. Setup preserves that choice. Lean mode is intended for local stacks that benefit from a smaller tool surface; hosted models do not enable it automatically.
 
 Lean mode does not replace `tools.profile`, `tools.allow`/`tools.deny`, or the model `compat.supportsTools: false` escape hatch. For a permanent narrower tool surface on a specific agent, prefer those stable knobs.
 

--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -43,8 +43,17 @@ Review the named host, execution backend, model, and download size, then confirm
 the download. Setup verifies pinned model files and the llama.cpp build,
 prepares a loopback endpoint, and checks inference before saving the new
 default. Guided activation also asks the model to read a temporary file through
-an OpenClaw tool and return its contents. A plain text reply alone does not pass
-that check.
+an OpenClaw tool and return its contents. The tool check uses an isolated
+workspace without your agent's bootstrap instructions. A plain text reply alone
+does not pass that check. Each verification check has a 90-second deadline;
+changing `agents.defaults.timeoutSeconds` does not extend setup verification.
+Failures identify whether the response check or tool-use check timed out.
+
+Managed setup also enables [local model lean mode](/concepts/experimental-features#local-model-lean-mode)
+unless you have explicitly configured it. By default, large tool catalogs use Tool Search,
+reducing the input the model must process before replying. Normal chats still
+include your agent's instructions. On CPU-only hosts, the first reply can take
+several minutes even after setup verification succeeds.
 
 ### Model recommendations
 

--- a/src/config/local-model-lean-auto.test.ts
+++ b/src/config/local-model-lean-auto.test.ts
@@ -1,7 +1,61 @@
 import { describe, expect, it } from "vitest";
 import { applyAutoLocalModelLean } from "./local-model-lean-auto.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
 
 describe("local model lean onboarding defaults", () => {
+  it.each([
+    { providerKey: "managed-local", providerId: "managed-local", managed: true, expected: true },
+    { providerKey: "Managed-Local", providerId: "MANAGED-LOCAL", managed: true, expected: true },
+    { providerKey: "managed-local", providerId: "managed-local", managed: false, expected: false },
+  ])(
+    "classifies $providerKey by its configured process ownership ($managed)",
+    ({ providerKey, providerId, managed, expected }) => {
+      const config: OpenClawConfig = {
+        models: {
+          providers: {
+            [providerKey]: {
+              baseUrl: "http://127.0.0.1:8080/v1",
+              models: [],
+              ...(managed ? { localService: { command: "/usr/bin/model-server" } } : {}),
+            },
+          },
+        },
+      };
+      const modelRef = `${providerId}/test-model`;
+      const result = applyAutoLocalModelLean({ config, providerId, modelRef });
+
+      expect(result.enabled).toBe(expected);
+      expect(result.config.agents?.defaults?.experimental?.localModelLean).toBe(
+        expected ? true : undefined,
+      );
+      expect(result.config.wizard?.localModelLeanAutoModel).toBe(expected ? modelRef : undefined);
+    },
+  );
+
+  it("does not mistake an Ollama cloud model for local inference when its daemon is managed", () => {
+    const config: OpenClawConfig = {
+      models: {
+        providers: {
+          ollama: {
+            models: [],
+            localService: { command: "/usr/bin/ollama" },
+          },
+        },
+      },
+    };
+    expect(
+      applyAutoLocalModelLean({
+        config,
+        providerId: "ollama",
+        modelRef: "ollama/test-model:cloud",
+      }),
+    ).toEqual({
+      config,
+      changed: false,
+      enabled: false,
+    });
+  });
+
   it.each([
     ["ollama", true],
     ["OLLAMA", true],
@@ -45,15 +99,42 @@ describe("local model lean onboarding defaults", () => {
   });
 
   it.each([false, true])("preserves an explicit localModelLean=%s", (localModelLean) => {
-    const config = { agents: { defaults: { experimental: { localModelLean } } } };
+    const config: OpenClawConfig = {
+      agents: { defaults: { experimental: { localModelLean } } },
+      models: {
+        providers: {
+          "managed-local": { models: [], localService: { command: "/usr/bin/model-server" } },
+        },
+      },
+    };
 
     expect(
-      applyAutoLocalModelLean({ config, providerId: "ollama", modelRef: "ollama/test-model" }),
+      applyAutoLocalModelLean({
+        config,
+        providerId: "managed-local",
+        modelRef: "managed-local/test-model",
+      }),
     ).toEqual({
       config,
       changed: false,
       enabled: false,
     });
+  });
+
+  it("lifts the automatic default when the same provider switches to an external server", () => {
+    const modelRef = "managed-local/test-model";
+    const config: OpenClawConfig = {
+      wizard: { localModelLeanAutoModel: modelRef },
+      agents: { defaults: { model: modelRef, experimental: { localModelLean: true } } },
+      models: {
+        providers: { "managed-local": { models: [], baseUrl: "http://127.0.0.1:8080/v1" } },
+      },
+    };
+
+    const result = applyAutoLocalModelLean({ config, providerId: "managed-local", modelRef });
+
+    expect(result.config.agents?.defaults?.experimental?.localModelLean).toBeUndefined();
+    expect(result.config.wizard?.localModelLeanAutoModel).toBeUndefined();
   });
 
   it("lifts only an onboarding-owned lean setting for a later non-local route", () => {

--- a/src/config/local-model-lean-auto.test.ts
+++ b/src/config/local-model-lean-auto.test.ts
@@ -37,6 +37,7 @@ describe("local model lean onboarding defaults", () => {
       models: {
         providers: {
           ollama: {
+            baseUrl: "http://127.0.0.1:11434",
             models: [],
             localService: { command: "/usr/bin/ollama" },
           },
@@ -103,7 +104,11 @@ describe("local model lean onboarding defaults", () => {
       agents: { defaults: { experimental: { localModelLean } } },
       models: {
         providers: {
-          "managed-local": { models: [], localService: { command: "/usr/bin/model-server" } },
+          "managed-local": {
+            baseUrl: "http://127.0.0.1:8080/v1",
+            models: [],
+            localService: { command: "/usr/bin/model-server" },
+          },
         },
       },
     };

--- a/src/config/local-model-lean-auto.ts
+++ b/src/config/local-model-lean-auto.ts
@@ -1,20 +1,29 @@
 import { isCloudModelRef } from "@openclaw/model-catalog-core/model-catalog-refs";
-import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import {
+  findNormalizedProviderValue,
+  normalizeProviderId,
+} from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
 const AUTO_LOCAL_MODEL_LEAN_PROVIDER_IDS = new Set(["lmstudio", "ollama"]);
 
 /** Returns true only for local runtimes that onboarding can identify without model-name guesses. */
-function shouldAutoEnableLocalModelLean(providerId: string, modelRef: string): boolean {
+function shouldAutoEnableLocalModelLean(
+  config: OpenClawConfig,
+  providerId: string,
+  modelRef: string,
+): boolean {
   const normalizedProviderId = normalizeProviderId(providerId);
-  if (!AUTO_LOCAL_MODEL_LEAN_PROVIDER_IDS.has(normalizedProviderId)) {
+  // A managed daemon can still serve a hosted model; source ownership wins.
+  if (normalizedProviderId === "ollama" && isCloudModelRef(modelRef)) {
     return false;
   }
-  if (normalizedProviderId !== "ollama") {
-    return true;
-  }
-  // Hosted source-tagged models can be routed through the same local daemon.
-  return !isCloudModelRef(modelRef);
+  return (
+    AUTO_LOCAL_MODEL_LEAN_PROVIDER_IDS.has(normalizedProviderId) ||
+    Boolean(
+      findNormalizedProviderValue(config.models?.providers, normalizedProviderId)?.localService,
+    )
+  );
 }
 
 function resolveDefaultModelRef(config: OpenClawConfig): string | undefined {
@@ -44,7 +53,7 @@ export function applyAutoLocalModelLean(params: {
   const onboardingOwnsSetting =
     autoModel !== undefined &&
     (params.previousModelRef ?? resolveDefaultModelRef(params.config)) === autoModel;
-  if (!shouldAutoEnableLocalModelLean(params.providerId, params.modelRef)) {
+  if (!shouldAutoEnableLocalModelLean(params.config, params.providerId, params.modelRef)) {
     if (!autoModel) {
       return { config: params.config, changed: false, enabled: false };
     }

--- a/src/system-agent/setup-inference-activate-persist.ts
+++ b/src/system-agent/setup-inference-activate-persist.ts
@@ -2,6 +2,7 @@ import { isDeepStrictEqual } from "node:util";
 import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
 import { applyAutoLocalModelLean } from "../config/local-model-lean-auto.js";
 import { applyMergePatch } from "../config/merge-patch.js";
+import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import {
   attachRuntimeConfigWriteApplication,
   createRuntimeConfigWriteApplication,
@@ -126,7 +127,7 @@ export async function persistActivatedSetupInference(input: {
   const stageCandidate = (
     current: OpenClawConfig,
     configKind: "runtime" | "source",
-  ): OpenClawConfig => {
+  ): { config: OpenClawConfig; autoLocalModelLeanApplied: boolean } => {
     let next = codexPluginPatch === undefined ? current : stripPendingPluginInstallRecords(current);
     if (plan.manualAuth) {
       next = applyManualAuthConfig(
@@ -149,21 +150,18 @@ export async function persistActivatedSetupInference(input: {
       }
       next = enabledCodex.config;
     }
-    next = applyAutoLocalModelLean({
+    const autoLocalModelLean = applyAutoLocalModelLean({
       config: next,
       providerId: testPlan.provider,
       modelRef: plan.modelRef,
-    }).config;
-    next = selectModel ? selectModel(next) : next;
-    if (!pendingCodexInstall) {
-      return next;
-    }
+      previousModelRef: resolveAgentModelPrimaryValue(current.agents?.defaults?.model),
+    });
+    next = selectModel ? selectModel(autoLocalModelLean.config) : autoLocalModelLean.config;
     return {
-      ...next,
-      plugins: {
-        ...next.plugins,
-        installs: { codex: pendingCodexInstall },
-      },
+      config: pendingCodexInstall
+        ? { ...next, plugins: { ...next.plugins, installs: { codex: pendingCodexInstall } } }
+        : next,
+      autoLocalModelLeanApplied: autoLocalModelLean.enabled,
     };
   };
   // Pending install records are probe-only discovery input. The config
@@ -171,12 +169,14 @@ export async function persistActivatedSetupInference(input: {
   // so post-write reconciliation must compare against the stripped route
   // and verify the exact index record separately below.
   const persistedRoute = pendingCodexInstall
-    ? await projectRoute(stripPendingPluginInstallRecords(stageCandidate(cfg, "runtime")))
+    ? await projectRoute(stripPendingPluginInstallRecords(stageCandidate(cfg, "runtime").config))
     : verifiedRoute;
   // Runtime config may materialize provider defaults that are intentionally
   // absent from authored config. Compare source writes against the candidate
   // produced from the original source shape, without ignoring concurrent rows.
-  const expectedSourceCandidateRoute = await projectRoute(stageCandidate(sourceCfg, "source"));
+  const expectedSourceCandidateRoute = await projectRoute(
+    stageCandidate(sourceCfg, "source").config,
+  );
   // Resolve every fallible config-commit dependency before writing a
   // credential into the real agent store. From this point onward, any
   // failure is inside the rollback boundary below.
@@ -188,7 +188,7 @@ export async function persistActivatedSetupInference(input: {
     throwIfSetupInferenceCancelled(params);
     await params.beforePersistentEffect?.();
     throwIfSetupInferenceCancelled(params);
-    const initialCandidate = stageCandidate(cfg, "runtime");
+    const initialCandidate = stageCandidate(cfg, "runtime").config;
     const initialRoute = await projectRoute(initialCandidate);
     const resolvedRoute = await resolveRoute(initialCandidate);
     if (
@@ -252,7 +252,7 @@ export async function persistActivatedSetupInference(input: {
         const latestRuntime = context.snapshot.runtimeConfig ?? context.snapshot.config;
         // Validate that the candidate is still admissible before reporting
         // broader route drift, so policy revocations retain their actionable error.
-        const stagedRuntime = stageCandidate(latestRuntime, "runtime");
+        const stagedRuntime = stageCandidate(latestRuntime, "runtime").config;
         const latestBaseline = await projectRoute(latestRuntime);
         if (!sameDefaultInferenceRoute(latestBaseline, baselineRoute)) {
           throw new Error(
@@ -299,12 +299,7 @@ export async function persistActivatedSetupInference(input: {
             "The authored target model metadata changed during its live inference test, so the verified candidate was not saved. Review the current model settings and retry.",
           );
         }
-        const autoLocalModelLean = applyAutoLocalModelLean({
-          config: current,
-          providerId: testPlan.provider,
-          modelRef: plan.modelRef,
-        });
-        const nextConfig = stageCandidate(current, "source");
+        const { config: nextConfig, autoLocalModelLeanApplied } = stageCandidate(current, "source");
         const nextRouteProjection = await projectRoute(nextConfig);
         const nextResolvedRoute = await resolveRoute(nextConfig);
         if (
@@ -328,7 +323,7 @@ export async function persistActivatedSetupInference(input: {
         throwIfSetupInferenceCancelled(params);
         params.onCommitStarted?.(current);
         commitMayHaveStarted = true;
-        state.autoLocalModelLeanApplied = autoLocalModelLean.enabled;
+        state.autoLocalModelLeanApplied = autoLocalModelLeanApplied;
         return { nextConfig };
       },
     });

--- a/src/system-agent/setup-inference-activate.ts
+++ b/src/system-agent/setup-inference-activate.ts
@@ -8,6 +8,7 @@ import {
 } from "../agents/cli-credentials.js";
 import { applyAutoLocalModelLean } from "../config/local-model-lean-auto.js";
 import { createMergePatch } from "../config/merge-patch.js";
+import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -198,11 +199,19 @@ async function activateSetupInferenceUnredacted(
     }
 
     const hasPreparedAuthProfiles = (plan.manualAuth?.profiles.length ?? 0) > 0;
-    let testPlan = plan;
+    // Verify the same automatic tool surface that activation will persist. Provider
+    // preparation may already have selected the candidate; retain the prior owner.
+    const autoLocalModelLeanUpdate = applyAutoLocalModelLean({
+      config: plan.config,
+      providerId: plan.provider,
+      modelRef: plan.modelRef,
+      previousModelRef: resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model),
+    });
+    let testPlan = { ...plan, config: autoLocalModelLeanUpdate.config };
     if (plan.persistModelRef) {
       const agentRuntimeId = resolveSetupAgentRuntimeId(params.kind);
       const stagedConfig = await applySystemAgentModelSelection({
-        config: plan.config,
+        config: testPlan.config,
         model: plan.persistModelRef,
         ...(params.agentId ? { targetAgentId: testPlan.routeAgentId } : {}),
         ...(agentRuntimeId ? { agentRuntimeId } : {}),
@@ -485,11 +494,6 @@ async function activateSetupInferenceUnredacted(
       };
     }
 
-    const autoLocalModelLeanUpdate = applyAutoLocalModelLean({
-      config: sourceCfg,
-      providerId: testPlan.provider,
-      modelRef: plan.modelRef,
-    });
     const needsPersistence =
       plan.persistModelRef !== undefined ||
       plan.manualAuth !== undefined ||

--- a/src/system-agent/setup-inference-core.ts
+++ b/src/system-agent/setup-inference-core.ts
@@ -54,7 +54,7 @@ export const SETUP_INFERENCE_TEST_PROMPT = "Reply with the single word OK. Do no
 const PROVIDER_AUTO_SETUP_KIND_PREFIX = "provider-auto:";
 
 export const AUTO_LOCAL_MODEL_LEAN_ANNOUNCEMENT =
-  "This model is small, so I set up the lean surface — switching to a bigger model later lifts it.";
+  "I enabled the lean tool surface for this local runtime.";
 
 export type ProviderAutoSetupInferenceKind = `provider-auto:${string}`;
 

--- a/src/system-agent/setup-inference-test.test.ts
+++ b/src/system-agent/setup-inference-test.test.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
+import { prepareEmbeddedAttemptBootstrap } from "../agents/embedded-agent-runner/run/attempt-bootstrap-prepare.js";
+import type { EmbeddedRunAttemptParams } from "../agents/embedded-agent-runner/run/types.js";
 import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import type { ActivateSetupInferenceDeps } from "./setup-inference-core.js";
@@ -78,10 +81,11 @@ async function probe(
     verifyAgentTools?: boolean;
     prompt?: string;
     signal?: AbortSignal;
+    plan?: SetupInferenceTestPlan;
   },
 ) {
   const tempDir = await tempRoots.make("case");
-  const selectedPlan = plan(input?.managed, input?.supportsTools);
+  const selectedPlan = input?.plan ?? plan(input?.managed, input?.supportsTools);
   selectedPlan.agentDir = path.join(tempDir, "agent");
   return await runSetupInferenceTest({
     plan: selectedPlan,
@@ -97,7 +101,29 @@ async function probe(
 
 describe("managed local model setup verification", () => {
   it("requires a real read result and final answer on the selected isolated runtime", async () => {
+    const ambientWorkspace = await tempRoots.make("ambient-workspace");
+    await fs.writeFile(path.join(ambientWorkspace, "AGENTS.md"), "Ambient agent instructions");
+    const selectedPlan = plan();
+    selectedPlan.config.agents = {
+      defaults: { contextInjection: "never" },
+      entries: {
+        other: { workspace: "/other/workspace" },
+        main: {
+          workspace: ambientWorkspace,
+          contextInjection: "always",
+          model: selectedPlan.modelRef,
+          params: { temperature: 0.2 },
+          tools: { profile: "coding" },
+          experimental: { localModelLean: false },
+        },
+      },
+    };
+    selectedPlan.executionConfig = { ...selectedPlan.config, tools: { allow: ["read"] } };
+    const originalConfig = structuredClone(selectedPlan.executionConfig);
     let workspace: string | undefined;
+    let bootstrapWorkspace: string | undefined;
+    let bootstrap: Awaited<ReturnType<typeof prepareEmbeddedAttemptBootstrap>> | undefined;
+    let toolRunConfig: RunParams["config"];
     const run = vi.fn<RunEmbeddedAgent>(async (input) => {
       input.onSuccessfulAuthBinding?.(auth);
       if (input.disableTools) {
@@ -113,6 +139,25 @@ describe("managed local model setup verification", () => {
       expect(input.permissionMode).toBe("read-only");
       expect(input.sessionRoot).toBe(workspace);
       expect(input.agentDir?.startsWith(`${workspace}${path.sep}`)).toBe(false);
+      toolRunConfig = input.config;
+      bootstrapWorkspace = resolveAgentWorkspaceDir(input.config!, input.agentId!);
+      bootstrap = await prepareEmbeddedAttemptBootstrap({
+        attempt: {
+          sessionId: input.sessionId,
+          sessionKey: input.sessionKey,
+          trigger: "manual",
+          isCanonicalWorkspace: bootstrapWorkspace === workspace,
+          config: input.config,
+        } as EmbeddedRunAttemptParams,
+        bootstrapWorkspaceDir: bootstrapWorkspace,
+        effectiveWorkspace: workspace,
+        hasReadTool: true,
+        isRawModelRun: false,
+        markStage: () => undefined,
+        resolvedWorkspace: workspace,
+        sessionAgentId: input.agentId!,
+        sessionLabel: input.sessionKey!,
+      });
       const nonce = await readFixture(input);
       input.onAgentToolResult?.({
         toolName: "read",
@@ -121,7 +166,24 @@ describe("managed local model setup verification", () => {
       });
       return reply(`The file contains: ${nonce}`);
     });
-    expect(await probe(run)).toMatchObject({ ok: true, auth });
+    expect(await probe(run, { plan: selectedPlan })).toMatchObject({ ok: true, auth });
+    expect(bootstrap?.contextFiles).toEqual([]);
+    expect(bootstrapWorkspace).toBe(workspace);
+    expect(toolRunConfig).toEqual({
+      ...originalConfig,
+      agents: {
+        ...originalConfig.agents,
+        entries: {
+          ...originalConfig.agents?.entries,
+          main: {
+            ...originalConfig.agents?.entries?.main,
+            workspace,
+            contextInjection: "never",
+          },
+        },
+      },
+    });
+    expect(selectedPlan.executionConfig).toEqual(originalConfig);
     expect(run).toHaveBeenCalledTimes(2);
     await expect(fs.stat(workspace!)).rejects.toMatchObject({ code: "ENOENT" });
   });
@@ -155,6 +217,35 @@ describe("managed local model setup verification", () => {
         status: failure === "changed owner" ? "auth" : "format",
       });
       await expect(fs.stat(workspace!)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it.each([
+    { phase: "response", failConnection: true },
+    { phase: "tool-use", failConnection: false },
+  ])(
+    "reports the failed $phase check without suggesting an unrelated timeout setting",
+    async ({ phase, failConnection }) => {
+      const run = vi.fn<RunEmbeddedAgent>(async (input) => {
+        input.onSuccessfulAuthBinding?.(auth);
+        if (input.disableTools && !failConnection) {
+          return reply("OK");
+        }
+        return {
+          payloads: [
+            {
+              text: "Request timed out before a response was generated. Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
+              isError: true,
+            },
+          ],
+          meta: { durationMs: 90_000 },
+        };
+      });
+      expect(await probe(run)).toEqual({
+        ok: false,
+        status: "timeout",
+        error: `The setup ${phase} check timed out. Retry setup, or choose another model or runtime. No default model was changed.`,
+      });
     },
   );
 

--- a/src/system-agent/setup-inference-test.ts
+++ b/src/system-agent/setup-inference-test.ts
@@ -157,17 +157,28 @@ async function runSetupInferenceProbe(
   const sessionKey = `agent:${effectiveAgentId}:setup-inference:incognito-${runId}`;
   const timeoutMs = deps.timeoutMs ?? SETUP_INFERENCE_TEST_TIMEOUT_MS;
   const started = Date.now();
+  const phase = agentProbe ? "tool-use" : "response";
   const failed = (status: SetupInferenceFailureStatus, error: string) => {
     setupInferenceLog.warn("Inference setup probe failed.", {
       event: "setup_inference_probe_failed",
       provider: plan.provider,
       model: plan.model,
       runner: plan.runner,
+      runId,
+      phase,
       status,
       timeoutMs,
       durationMs: Date.now() - started,
     });
-    return { ok: false as const, status, error };
+    // Setup owns this deadline; changing the ordinary agent timeout cannot extend it.
+    return {
+      ok: false as const,
+      status,
+      error:
+        status === "timeout"
+          ? `The setup ${phase} check timed out. Retry setup, or choose another model or runtime. No default model was changed.`
+          : error,
+    };
   };
   const preparedRunAdmission = prepareSystemAgentRunAdmission(
     plan.config,
@@ -225,6 +236,7 @@ async function runSetupInferenceProbe(
     } else {
       const runEmbedded =
         deps.runEmbeddedAgent ?? (await import("../agents/embedded-agent.js")).runEmbeddedAgent;
+      const executionConfig = plan.executionConfig ?? plan.config;
       result = await runEmbedded({
         preparedRunAdmission,
         sessionId,
@@ -237,7 +249,24 @@ async function runSetupInferenceProbe(
         sessionFile,
         workspaceDir: tempDir,
         ...(plan.agentDir ? { agentDir: plan.agentDir } : {}),
-        config: plan.executionConfig ?? plan.config,
+        // Bootstrap follows the configured agent workspace, independently of workspaceDir.
+        // Keep this private check from importing the selected agent's ambient instructions.
+        config: agentProbe
+          ? {
+              ...executionConfig,
+              agents: {
+                ...executionConfig.agents,
+                entries: {
+                  ...executionConfig.agents?.entries,
+                  [effectiveAgentId]: {
+                    ...executionConfig.agents?.entries?.[effectiveAgentId],
+                    workspace: tempDir,
+                    contextInjection: "never",
+                  },
+                },
+              },
+            }
+          : executionConfig,
         prompt: params.prompt ?? SETUP_INFERENCE_TEST_PROMPT,
         provider: plan.provider,
         model: plan.model,

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -515,6 +515,7 @@ function successfulRun(provider: string, model: string, params?: SuccessfulRunPa
   );
   return {
     meta: {
+      durationMs: 1,
       finalAssistantVisibleText: "OK",
       executionTrace: { winnerProvider: provider, winnerModel: params?.reportedModel ?? model },
     },

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -60,7 +60,7 @@ import { WizardCancelledError, WizardNavigationError } from "../wizard/prompts.j
 import { cleanupSystemAgentSession, createSystemAgentSession } from "./agent-turn.js";
 import { runSystemAgentTurnWithDeps } from "./agent-turn.test-support.js";
 import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
-import { setupInferenceLog } from "./setup-inference-core.js";
+import { setupInferenceLog, type ActivateSetupInferenceDeps } from "./setup-inference-core.js";
 import { resolveSetupInferenceProbeStreamParams } from "./setup-inference-probe.js";
 import { runSetupInferenceTest } from "./setup-inference-test.js";
 import {
@@ -2119,20 +2119,39 @@ describe("activateSetupInference", () => {
   it.each([
     {
       name: "auto-enables the lean surface for a verified local model",
+      providerId: "lmstudio",
       initialConfig: {} satisfies OpenClawConfig,
       expectedLean: true,
       expectedAnnouncement: true,
     },
     {
       name: "preserves an explicit localModelLean=false",
+      providerId: "lmstudio",
       initialConfig: {
         agents: { defaults: { experimental: { localModelLean: false } } },
       } satisfies OpenClawConfig,
       expectedLean: false,
       expectedAnnouncement: false,
     },
-  ])("$name", async ({ initialConfig, expectedLean, expectedAnnouncement }) => {
-    const modelRef = "lmstudio/qwen-local";
+    {
+      name: "stages and announces lean tools for a newly configured managed provider",
+      providerId: "llama-cpp",
+      initialConfig: {} satisfies OpenClawConfig,
+      expectedLean: true,
+      expectedAnnouncement: true,
+    },
+    ...[false, true].map((localModelLean) => ({
+      name: `preserves explicit lean=${localModelLean} for a managed provider`,
+      providerId: "llama-cpp",
+      initialConfig: {
+        agents: { defaults: { experimental: { localModelLean } } },
+      } satisfies OpenClawConfig,
+      expectedLean: localModelLean,
+      expectedAnnouncement: false,
+    })),
+  ])("$name", async ({ providerId, initialConfig, expectedLean, expectedAnnouncement }) => {
+    const modelRef = `${providerId}/qwen-local`;
+    const managed = providerId === "llama-cpp";
     const detect = vi.fn(async () => ({ modelRef, detail: "qwen-local at localhost" }));
     const prepare = vi.fn(async () => ({
       profiles: [],
@@ -2141,9 +2160,10 @@ describe("activateSetupInference", () => {
         models: {
           mode: "merge" as const,
           providers: {
-            lmstudio: {
+            [providerId]: {
               baseUrl: "http://127.0.0.1:1234/v1",
               api: "openai-completions" as const,
+              ...(managed ? { localService: { command: "/usr/bin/model-server" } } : {}),
               models: [
                 {
                   id: "qwen-local",
@@ -2161,9 +2181,9 @@ describe("activateSetupInference", () => {
       },
     }));
     const provider: ProviderPlugin = {
-      id: "lmstudio",
+      id: providerId,
       label: "LM Studio",
-      pluginId: "lmstudio",
+      pluginId: providerId,
       auth: [
         {
           id: "custom",
@@ -2176,18 +2196,36 @@ describe("activateSetupInference", () => {
     };
     const configHarness = createConfigTransformHarness(initialConfig);
     const updateAuthStore = vi.fn();
-    const runEmbeddedAgent = vi.fn(successfulRunner("lmstudio", "qwen-local"));
+    const runEmbeddedAgent = vi.fn<NonNullable<ActivateSetupInferenceDeps["runEmbeddedAgent"]>>(
+      async (input) => {
+        expect(input.config?.agents?.defaults?.experimental?.localModelLean).toBe(expectedLean);
+        const result = await successfulRunner(providerId, "qwen-local")(input);
+        if (input.onAgentToolResult) {
+          const contents = await fs.readFile(
+            path.join(input.workspaceDir, "verification.txt"),
+            "utf8",
+          );
+          input.onAgentToolResult({
+            toolName: "read",
+            result: { content: [{ type: "text", text: contents }] },
+            isError: false,
+          });
+          result.meta.finalAssistantVisibleText = contents;
+        }
+        return result;
+      },
+    );
 
     const result = await activateSetupInference({
-      kind: "provider-auto:lmstudio",
+      kind: `provider-auto:${providerId}`,
       modelRef,
       deps: {
         readConfigFileSnapshot: mockConfigSnapshot(initialConfig, { includeMetadata: true }),
         resolveManifestProviderAuthChoice: () => ({
-          pluginId: "lmstudio",
-          providerId: "lmstudio",
+          pluginId: providerId,
+          providerId,
           methodId: "custom",
-          choiceId: "lmstudio",
+          choiceId: providerId,
           choiceLabel: "LM Studio",
           appGuidedDiscovery: true,
         }),
@@ -2204,15 +2242,11 @@ describe("activateSetupInference", () => {
     }
     expect(result.lines).toEqual([
       `Inference verified: ${modelRef}`,
-      ...(expectedAnnouncement
-        ? [
-            "This model is small, so I set up the lean surface — switching to a bigger model later lifts it.",
-          ]
-        : []),
+      ...(expectedAnnouncement ? ["I enabled the lean tool surface for this local runtime."] : []),
     ]);
     expect(runEmbeddedAgent).toHaveBeenCalledWith(
       expect.objectContaining({
-        provider: "lmstudio",
+        provider: providerId,
         model: "qwen-local",
         streamParams: { maxTokens: 256 },
       }),
@@ -2225,13 +2259,13 @@ describe("activateSetupInference", () => {
       agents: { defaults: { model: modelRef, experimental: { localModelLean: expectedLean } } },
       models: {
         providers: {
-          lmstudio: {
+          [providerId]: {
             baseUrl: "http://127.0.0.1:1234/v1",
             models: [expect.objectContaining({ id: "qwen-local" })],
           },
         },
       },
-      plugins: { entries: { lmstudio: { enabled: true } } },
+      plugins: { entries: { [providerId]: { enabled: true } } },
     });
   });
 
@@ -6496,6 +6530,8 @@ describe("verifySetupInference", () => {
       provider: "openai",
       model: "gpt-5.5",
       runner: "embedded",
+      runId: expect.stringMatching(/^probe-setup-inference-/u),
+      phase: "response",
       status: "timeout",
       timeoutMs: 90_000,
       durationMs: expect.any(Number),

--- a/src/wizard/setup.model-auth.test.ts
+++ b/src/wizard/setup.model-auth.test.ts
@@ -458,7 +458,11 @@ describe("runSetupModelAuthStep", () => {
         agents: { defaults: { ...config.agents?.defaults, model: "managed-local/prepared" } },
         models: {
           providers: {
-            "managed-local": { models: [], localService: { command: "/fixture/server" } },
+            "managed-local": {
+              baseUrl: "http://127.0.0.1:8080/v1",
+              models: [],
+              localService: { command: "/fixture/server" },
+            },
           },
         },
       };
@@ -492,7 +496,11 @@ describe("runSetupModelAuthStep", () => {
         agents: { defaults: { model: "managed-local/model" } },
         models: {
           providers: {
-            "managed-local": { models: [], localService: { command: "/fixture/server" } },
+            "managed-local": {
+              baseUrl: "http://127.0.0.1:8080/v1",
+              models: [],
+              localService: { command: "/fixture/server" },
+            },
           },
         },
       };

--- a/src/wizard/setup.model-auth.test.ts
+++ b/src/wizard/setup.model-auth.test.ts
@@ -439,6 +439,77 @@ describe("runSetupModelAuthStep", () => {
     expect(result.config.agents?.defaults?.model).toBe("openai/global-model");
   });
 
+  it.each([
+    { selectedModel: "managed-local/selected", previousAuto: false, expectedLean: true },
+    { selectedModel: "openai/selected", previousAuto: false, expectedLean: undefined },
+    { selectedModel: "openai/selected", previousAuto: true, expectedLean: undefined },
+  ])(
+    "applies lean to the final model $selectedModel (prior automatic=$previousAuto)",
+    async ({ selectedModel, previousAuto, expectedLean }) => {
+      const previousModel = "managed-local/previous";
+      const config: OpenClawConfig = previousAuto
+        ? {
+            wizard: { localModelLeanAutoModel: previousModel },
+            agents: { defaults: { model: previousModel, experimental: { localModelLean: true } } },
+          }
+        : {};
+      const preparedConfig: OpenClawConfig = {
+        ...config,
+        agents: { defaults: { ...config.agents?.defaults, model: "managed-local/prepared" } },
+        models: {
+          providers: {
+            "managed-local": { models: [], localService: { command: "/fixture/server" } },
+          },
+        },
+      };
+      promptAuthChoiceGrouped.mockResolvedValueOnce("anthropic-cli");
+      applyAuthChoice.mockResolvedValueOnce({
+        config: preparedConfig,
+        authProfiles: [],
+        persistAuthProfiles: async () => {},
+      });
+      promptDefaultModel.mockResolvedValueOnce({ model: selectedModel });
+
+      const result = await runSetupModelAuthStep({
+        config,
+        opts: {},
+        prompter: createPrompter(),
+        runtime: createRuntime(),
+      });
+
+      expect(result.config.agents?.defaults?.experimental?.localModelLean).toBe(expectedLean);
+      expect(result.config.wizard?.localModelLeanAutoModel).toBe(
+        expectedLean ? selectedModel : undefined,
+      );
+      expect(config.agents?.defaults?.model).toBe(previousAuto ? previousModel : undefined);
+    },
+  );
+
+  it.each(["skip", "__keep-current"])(
+    "keeps %s free of automatic lean changes",
+    async (authChoice) => {
+      const config: OpenClawConfig = {
+        agents: { defaults: { model: "managed-local/model" } },
+        models: {
+          providers: {
+            "managed-local": { models: [], localService: { command: "/fixture/server" } },
+          },
+        },
+      };
+      promptAuthChoiceGrouped.mockResolvedValueOnce(authChoice);
+
+      const result = await runSetupModelAuthStep({
+        config,
+        opts: {},
+        prompter: createPrompter(),
+        runtime: createRuntime(),
+      });
+
+      expect(result.config).toBe(config);
+      expect(applyAuthChoice).not.toHaveBeenCalled();
+    },
+  );
+
   it("re-prompts after a provider setup error instead of aborting", async () => {
     promptAuthChoiceGrouped.mockResolvedValueOnce("anthropic-cli").mockResolvedValueOnce("skip");
     applyAuthChoice.mockRejectedValueOnce(

--- a/src/wizard/setup.model-auth.ts
+++ b/src/wizard/setup.model-auth.ts
@@ -7,6 +7,8 @@ import {
   resolveOnboardingSetupTarget,
 } from "../commands/onboard-agent-target.js";
 import type { AuthChoice, OnboardOptions } from "../commands/onboard-types.js";
+import { applyAutoLocalModelLean } from "../config/local-model-lean-auto.js";
+import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -340,6 +342,20 @@ export async function runSetupModelAuthStep(params: {
       validateCatalog: false,
     });
     break;
+  }
+  if (authChoice !== "skip" && !isKeepCurrentAuthChoice?.(authChoice)) {
+    const { resolveDefaultModelForAgent } = await import("../agents/model-selection-config.js");
+    const selected = resolveDefaultModelForAgent({ cfg: nextConfig, agentId: target.agentId });
+    // The picker can replace the auth provider's model. Stage its final tool surface
+    // before verification, preserving ownership from the unreplaced source config.
+    nextConfig = applyAutoLocalModelLean({
+      config: nextConfig,
+      providerId: selected.provider,
+      modelRef: `${selected.provider}/${selected.model}`,
+      previousModelRef: resolveAgentModelPrimaryValue(
+        prepareAgentModelDefaults(params.config, target).agents?.defaults?.model,
+      ),
+    }).config;
   }
   return { config: nextConfig, authProfiles, persistAuthProfiles };
 }

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -2995,7 +2995,11 @@ describe("runSetupWizard", () => {
             ? {
                 models: {
                   providers: {
-                    [provider]: { models: [], localService: { command: "/fixture/server" } },
+                    [provider]: {
+                      baseUrl: "http://127.0.0.1:8080/v1",
+                      models: [],
+                      localService: { command: "/fixture/server" },
+                    },
                   },
                 },
               }

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -2962,29 +2962,74 @@ describe("runSetupWizard", () => {
     );
   });
 
-  it("offers a live AI check after classic model setup", async () => {
-    applyAuthChoice.mockImplementationOnce(async (args) => ({
-      config: {
-        ...args.config,
-        agents: {
-          ...args.config.agents,
-          defaults: {
-            ...args.config.agents?.defaults,
-            model: { primary: "openai/gpt-5.5" },
+  it.each([
+    { provider: "openai", explicitLean: undefined, expectedLean: undefined },
+    { provider: "managed-local", explicitLean: undefined, expectedLean: true },
+    { provider: "managed-local", explicitLean: false, expectedLean: false },
+    { provider: "managed-local", explicitLean: true, expectedLean: true },
+  ])(
+    "verifies and persists classic $provider setup with lean=$explicitLean",
+    async ({ provider, explicitLean, expectedLean }) => {
+      const managed = provider === "managed-local";
+      const modelRef = `${provider}/test-model`;
+      readConfigFileSnapshot.mockResolvedValue(
+        configSnapshot({
+          agents: { defaults: { experimental: { localModelLean: explicitLean } } },
+        }),
+      );
+      replaceConfigFile.mockImplementation(async ({ nextConfig }) => {
+        readConfigFileSnapshot.mockResolvedValue(configSnapshot(nextConfig));
+        return { config: nextConfig };
+      });
+      applyAuthChoice.mockImplementationOnce(async (args) => ({
+        config: {
+          ...args.config,
+          agents: {
+            ...args.config.agents,
+            defaults: {
+              ...args.config.agents?.defaults,
+              model: { primary: modelRef },
+            },
           },
+          ...(managed
+            ? {
+                models: {
+                  providers: {
+                    [provider]: { models: [], localService: { command: "/fixture/server" } },
+                  },
+                },
+              }
+            : {}),
         },
-      },
-    }));
-    const confirm = vi.fn(async () => true) as unknown as WizardPrompter["confirm"];
-    const prompter = buildWizardPrompter({ confirm });
+      }));
+      verifySetupInferenceConfig.mockImplementationOnce(async ({ config, verifyAgentTools }) => {
+        expect(config.agents?.defaults?.experimental?.localModelLean).toBe(expectedLean);
+        expect(verifyAgentTools).toBe(true);
+        expect(replaceConfigFile).not.toHaveBeenCalled();
+        return { ok: true, modelRef, latencyMs: 1 };
+      });
+      const confirm = vi.fn(async () => true) as unknown as WizardPrompter["confirm"];
+      const prompter = buildWizardPrompter({ confirm });
 
-    await runWizard({ authChoice: "demo-provider" }, createRuntime(), prompter);
+      await runWizard({ authChoice: "demo-provider" }, createRuntime(), prompter);
 
-    expect(confirm).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Test AI access now with a live completion?" }),
-    );
-    expect(verifySetupInferenceConfig).toHaveBeenCalledOnce();
-  });
+      const optionalCheck = expect.objectContaining({
+        message: "Test AI access now with a live completion?",
+      });
+      if (managed) {
+        expect(confirm).not.toHaveBeenCalledWith(optionalCheck);
+      } else {
+        expect(confirm).toHaveBeenCalledWith(optionalCheck);
+      }
+      expect(verifySetupInferenceConfig).toHaveBeenCalledOnce();
+      expect(persistedWizardConfigs().at(-1)?.agents?.defaults?.experimental?.localModelLean).toBe(
+        expectedLean,
+      );
+      expect(persistedWizardConfigs().at(-1)?.wizard?.localModelLeanAutoModel).toBe(
+        managed && explicitLean === undefined ? modelRef : undefined,
+      );
+    },
+  );
 
   it("continues classic setup when live AI verification fails", async () => {
     applyAuthChoice.mockImplementationOnce(async (args) => ({


### PR DESCRIPTION
Closes #138705. Follow-up to #138464.

Post-landing follow-up: the two-agent scope finding is confirmed and tracked in #138753. The CPU repair is landed; target-only setup must still be corrected to preserve unrelated agents' lean/tool settings.

## What Problem This Solves

Fixes an issue where users completing managed local-model setup could pass activation but then wait until the ordinary chat deadline on a CPU-only host. Classic CLI onboarding also gave its setup tool check ambient agent instructions that native activation did not yet have.

## Why This Change Was Made

Setup now uses the existing lean tool surface for providers that declare a managed `localService`. Both classic CLI and app activation stage that decision before verification and preserve it when saving. The CLI applies it after the final model picker; persistence reuses the canonical classifier instead of separately classifying an unstaged configuration. Explicit true/false values and existing onboarding ownership rules are preserved; hosted Ollama routes remain excluded.

The private tool probe now owns an isolated bootstrap workspace. Ordinary chats retain their agent instructions. Setup timeout errors name the failed response/tool-use phase and no longer suggest changing an unrelated agent deadline. No new config keys, dependencies, model choices, reasoning defaults, or timeouts were added.

## User Impact

Fresh managed local-model onboarding automatically reduces large direct tool catalogs through the existing lean/Tool Search behavior. CPU first replies can still take several minutes; the change makes the tested ordinary file-read task complete with the default model and deadline. An explicit `localModelLean: false` remains an opt-out. This does not retroactively change existing installations outside setup.

## Evidence

Fresh Blacksmith Testbox proof on exact head `1bc6e800c358bde642af54257d2e11bfc9806a90`: four usable CPUs, 15.42 GiB RAM, Qwen3.5 4B Q4_K_M, llama.cpp b10534. Both flows installed the packaged plugin and used independent clean profiles/workspaces, the recommended model, default reasoning, and unchanged deadlines. [Live workflow](https://github.com/openclaw/openclaw/actions/runs/33932218295).

| Real user flow | Observed result |
| --- | --- |
| Classic CLI onboarding, then ordinary agent chat | Setup saved lean mode and its ownership marker automatically; a real `read` returned fresh file contents in 223.956 seconds. Requested/effective model matched, no rerouting, normal stop. |
| Actual Linux Tauri app setup, then ordinary visible chat | Activation saved the same automatic settings; a real `read` and its fresh contents appeared in chat. UI reported 4 minutes, 3 seconds with default Medium reasoning. |
| Three further fresh CLI onboarding checks | All passed with actual read/final-content proof and automatic settings. Existing diagnostic tracing only; no behavior overrides. |

The first CLI attempt rejected its file/tool check before saving any model. Four subsequent fresh CLI setups passed; the original reply was not retained, so its exact mismatch is unknown. This limitation is tracked in #138736. The first combined command consequently exited nonzero; the separate full CLI rerun succeeded. A later diagnostic archive heredoc failed after all three successful setup checks; artifact collection was corrected without rerunning model tests.

The original native baseline activated successfully but waited at the 600-second ordinary-chat deadline. Runtime logs showed approximately 34K prompt tokens and CPU prefill without swap or OOM. A controlled lean-only comparison reduced that to 12,639 tokens and completed in 249.63 seconds with unchanged model/reasoning/deadline. This supports applying the existing lean policy at setup, rather than changing timeout or thinking policy.

317 focused tests passed across setup activation/probes, classic wizard/model selection, lean ownership, and ordinary bootstrap siblings. Regression failures were captured before the corresponding fixes. Test typechecking caught incomplete duration/base-URL fixtures; those were corrected and the affected 156 + 137 cases rerun successfully. The final isolated-clone type/lint/architecture gate passed. Independent Codex P0–P2 reviews found no actionable defects. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33932049399) completed successfully across all 125 jobs, including `openclaw/ci-gate`.

Production LOC: +95/-42 (net +53); tests: +384/-42; docs: +13/-4. Growth implements the private probe boundary, phase diagnostics, and missing final CLI candidate staging. Duplicate persistence classification is removed. The separate router inventory lifecycle issue remains tracked in #138452.

Before: synthetic native chat still waiting at ten minutes.

![Before: local-model chat waiting at ten minutes](https://github.com/user-attachments/assets/9410e158-5416-477c-a1f2-8cb2df5ac412)

After: actual native file read and completed reply on the candidate. The nonce was absent from the prompt.

![After: local-model file read completed](https://github.com/user-attachments/assets/f4ab4564-0629-4abd-99a0-8702ee4a4bed)

Final 30 seconds of the actual native chat, recorded at 1 fps. Every frame was inspected; only the isolated synthetic session is visible.

https://github.com/user-attachments/assets/959e29d4-1afa-4118-be81-18518c13084b
