### PR TITLE
fix(skills): keep node skill metadata and instructions in sync

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -54,6 +54,9 @@ Skill roots support grouped layouts. OpenClaw discovers a skill whenever
 <workspace>/skills/personal/research/SKILL.md ✓ also found as "research"
 ```
 
+During grouped discovery, finding `SKILL.md` ends traversal below that directory.
+Invalid skill files are reported and skipped; valid siblings can still load.
+
 The folder path is for organization only. The skill's name and slash command
 come from the `name` frontmatter field (or the directory name when `name` is
 missing). Agent allowlists (below) also match on this `name`.
@@ -76,7 +79,8 @@ apply). They appear in the normal agent skill list while the node is connected
 and disappear when it disconnects. A local or Gateway skill keeps its name on
 collision; the node skill receives a deterministic node-prefixed name.
 Node-hosted v1 requires the directory name to match the skill's `name`
-frontmatter field.
+frontmatter field. The published name, description, and instructions come from
+the same captured file content.
 
 The skill entry includes the node locator. Its files, relative references, and
 binaries live on the node, so load and execute it with

--- a/src/node-host/skills.test.ts
+++ b/src/node-host/skills.test.ts
@@ -77,13 +77,34 @@ describe("scanNodeHostedSkills", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
-  it("loads descriptors and preserves the full SKILL.md content", () => {
+  it("loads complete descriptors in skill-name order", () => {
     const root = createRoot();
     const content = writeSkill(root, "release-helper", "Prepare a release", "# Release\nDo it.");
+    const prefixContent = writeSkill(root, "release", "Release", "# Prefix skill");
 
     expect(scanNodeHostedSkills({ skillsDir: root })).toEqual([
+      { name: "release", description: "Release", content: prefixContent },
       { name: "release-helper", description: "Prepare a release", content },
     ]);
+  });
+
+  it("publishes the same bounded content that supplied the skill metadata", () => {
+    const root = createRoot();
+    const original = writeSkill(root, "a-stable", "Original description", "# Original");
+    const invalidDir = path.join(root, "b-invalid");
+    fs.mkdirSync(invalidDir);
+    const invalidFile = path.join(invalidDir, "SKILL.md");
+    fs.writeFileSync(invalidFile, "# Missing frontmatter\n");
+    const warn = vi.fn((message: string) => {
+      if (message.includes(invalidFile)) {
+        writeSkill(root, "a-stable", "Replacement description", "# Replacement");
+      }
+    });
+
+    expect(scanNodeHostedSkills({ skillsDir: root, warn })).toEqual([
+      { name: "a-stable", description: "Original description", content: original },
+    ]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(invalidFile));
   });
 
   it("loads JSON5-style metadata frontmatter", () => {
@@ -144,7 +165,7 @@ metadata:
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("directory, name, and frontmatter"));
   });
 
-  it("keeps nested diagnostics separate from the current candidate", () => {
+  it("does not inspect nested skills after rejecting the named candidate", () => {
     const root = createRoot();
     const candidateDir = path.join(root, "candidate");
     fs.mkdirSync(path.join(candidateDir, "nested"), { recursive: true });
@@ -155,7 +176,7 @@ metadata:
     const warn = vi.fn();
 
     expect(scanNodeHostedSkills({ skillsDir: root, warn })).toEqual([]);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining(nestedFile));
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining(nestedFile));
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining(`${candidateFile}): description is required`),
     );

--- a/src/node-host/skills.ts
+++ b/src/node-host/skills.ts
@@ -9,7 +9,8 @@ import {
   NODE_SKILL_MAX_TOTAL_BYTES,
   NODE_SKILL_NAME_RE,
 } from "../shared/node-skill-constraints.js";
-import { loadSkillsFromDirSafe, type LoadedLocalSkill } from "../skills/loading/local-loader.js";
+import { loadSingleSkillDirectory } from "../skills/loading/local-loader.js";
+import { tryRealpath } from "../skills/loading/symlink-targets.js";
 import { resolveConfigDir } from "../utils.js";
 
 type ScanNodeHostedSkillsOptions = {
@@ -42,7 +43,10 @@ export function resolveNodeHostedSkillDirectory(locator: string, nodeId: string)
   }
 }
 
-function listCandidateSkillFiles(skillsDir: string, warn: (message: string) => void): string[] {
+function listCandidateSkills(
+  skillsDir: string,
+  warn: (message: string) => void,
+): Array<{ name: string; filePath: string }> {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(skillsDir, { withFileTypes: true });
@@ -52,7 +56,7 @@ function listCandidateSkillFiles(skillsDir: string, warn: (message: string) => v
     }
     return [];
   }
-  const candidates: string[] = [];
+  const candidates: Array<{ name: string; filePath: string }> = [];
   for (const entry of entries) {
     if (!entry.isDirectory() || entry.name.startsWith(".")) {
       continue;
@@ -60,13 +64,14 @@ function listCandidateSkillFiles(skillsDir: string, warn: (message: string) => v
     const filePath = path.join(skillsDir, entry.name, "SKILL.md");
     try {
       if (fs.statSync(filePath, { throwIfNoEntry: false })?.isFile()) {
-        candidates.push(filePath);
+        candidates.push({ name: entry.name, filePath });
       }
     } catch (error) {
       warn(`node host skill skipped (${filePath}): ${String(error)}`);
     }
   }
-  return candidates.toSorted((left, right) => left.localeCompare(right, "en"));
+  // Accepted names must match their unique child directories, so this is descriptor order.
+  return candidates.toSorted((left, right) => left.name.localeCompare(right.name, "en"));
 }
 
 export function scanNodeHostedSkills(
@@ -82,71 +87,40 @@ export function scanNodeHostedSkills(
   } catch (error) {
     warn(`node host skill scan skipped (${rootSkillFile}): ${String(error)}`);
   }
-  const candidates = listCandidateSkillFiles(skillsDir, warn);
-  if (candidates.length === 0) {
-    return [];
-  }
-
-  const loadedSkills: LoadedLocalSkill[] = [];
-  for (const candidate of candidates) {
-    let invalidFrontmatter = false;
-    const candidatePath = path.resolve(candidate);
-    const loaded = loadSkillsFromDirSafe({
-      dir: path.dirname(candidate),
-      source: "openclaw-node",
-      maxBytes: NODE_SKILL_MAX_CONTENT_BYTES,
-      onDiagnostic: (diagnostic) => {
-        if (path.resolve(diagnostic.path) === candidatePath) {
-          invalidFrontmatter = true;
-        }
-        warn(`node host skill skipped (${diagnostic.path}): ${diagnostic.message}`);
-      },
-    });
-    const loadedSkill = loaded.find(
-      (entry) => path.resolve(entry.skill.filePath) === candidatePath,
-    );
-    if (loadedSkill) {
-      loadedSkills.push(loadedSkill);
-      continue;
-    }
-    let size: number | undefined;
-    try {
-      size = fs.statSync(candidate, { throwIfNoEntry: false })?.size;
-    } catch (error) {
-      warn(`node host skill skipped (${candidate}): ${String(error)}`);
-      continue;
-    }
-    const reason = invalidFrontmatter
-      ? null
-      : typeof size === "number" && size > NODE_SKILL_MAX_CONTENT_BYTES
-        ? `exceeds ${NODE_SKILL_MAX_CONTENT_BYTES} bytes`
-        : "has invalid or missing frontmatter";
-    if (reason) {
-      warn(`node host skill skipped (${candidate}): ${reason}`);
-    }
-  }
-
   const descriptors: NodeSkillDescriptor[] = [];
-  const seenNames = new Set<string>();
   let totalBytes = 0;
-  for (const { skill, frontmatter } of loadedSkills.toSorted((left, right) =>
-    left.skill.name.localeCompare(right.skill.name, "en"),
-  )) {
+  for (const candidate of listCandidateSkills(skillsDir, warn)) {
+    const skillDir = path.dirname(candidate.filePath);
+    const rootRealPath = tryRealpath(skillDir);
+    let diagnosed = false;
+    const loaded = rootRealPath
+      ? loadSingleSkillDirectory({
+          skillDir,
+          rootRealPath,
+          source: "openclaw-node",
+          maxBytes: NODE_SKILL_MAX_CONTENT_BYTES,
+          onDiagnostic: (diagnostic) => {
+            diagnosed = true;
+            warn(`node host skill skipped (${diagnostic.path}): ${diagnostic.message}`);
+          },
+        })
+      : null;
+    if (!loaded) {
+      if (!diagnosed) {
+        warn(`node host skill skipped (${candidate.filePath}): has invalid or missing frontmatter`);
+      }
+      continue;
+    }
+    // Metadata and advertised instructions must come from the same bounded descriptor read.
+    const { skill, frontmatter, content } = loaded;
     if (
-      frontmatter?.name?.trim() !== skill.name ||
+      frontmatter.name?.trim() !== skill.name ||
       frontmatter.description?.trim() !== skill.description ||
-      path.basename(skill.baseDir) !== skill.name
+      candidate.name !== skill.name
     ) {
       warn(
         `node host skill skipped (${skill.filePath}): directory, name, and frontmatter must match`,
       );
-      continue;
-    }
-    let content: string;
-    try {
-      content = fs.readFileSync(skill.filePath, "utf8");
-    } catch (error) {
-      warn(`node host skill skipped (${skill.filePath}): ${String(error)}`);
       continue;
     }
     const contentBytes = Buffer.byteLength(content, "utf8");
@@ -159,10 +133,6 @@ export function scanNodeHostedSkills(
       warn(`node host skill skipped (${skill.filePath}): invalid name, description, or size`);
       continue;
     }
-    if (seenNames.has(skill.name)) {
-      warn(`node host skill skipped (${skill.filePath}): duplicate name ${skill.name}`);
-      continue;
-    }
     if (descriptors.length >= NODE_SKILL_MAX_COUNT) {
       warn(`node host skill skipped (${skill.filePath}): exceeds ${NODE_SKILL_MAX_COUNT} skills`);
       continue;
@@ -173,7 +143,6 @@ export function scanNodeHostedSkills(
       );
       continue;
     }
-    seenNames.add(skill.name);
     totalBytes += contentBytes;
     descriptors.push({ name: skill.name, description: skill.description, content });
   }

--- a/src/skills/lifecycle/install.test.ts
+++ b/src/skills/lifecycle/install.test.ts
@@ -10,11 +10,7 @@ import { createMockPluginRegistry } from "../../plugins/hooks.test-fixtures.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import { buildWorkspaceSkillStatus } from "../discovery/status.js";
-import {
-  resolveSkillInvocationPolicy,
-  resolveSkillManifestMetadata,
-} from "../loading/frontmatter.js";
-import { loadSkillsFromDirSafe } from "../loading/local-loader.js";
+import { loadWorkspaceSkills } from "../loading/workspace-skill-loader.js";
 import { runCommandWithTimeoutMock } from "../test-support/install-test-mocks.js";
 import type { SkillEntry, SkillInstallSpec } from "../types.js";
 import { installSkill } from "./install.js";
@@ -66,24 +62,7 @@ async function writeDangerousInstallableSkill(workspaceDir: string, name: string
 }
 
 function loadTestWorkspaceSkillEntries(workspaceDir: string): SkillEntry[] {
-  const skills = loadSkillsFromDirSafe({
-    dir: path.join(workspaceDir, "skills"),
-    source: "openclaw-workspace",
-  });
-  return skills.map(({ skill, frontmatter }) => {
-    const invocation = resolveSkillInvocationPolicy(frontmatter);
-    return {
-      skill,
-      frontmatter,
-      metadata: resolveSkillManifestMetadata(frontmatter),
-      invocation,
-      exposure: {
-        includeInRuntimeRegistry: true,
-        includeInAvailableSkillsPrompt: !invocation.disableModelInvocation,
-        userInvocable: invocation.userInvocable,
-      },
-    };
-  });
+  return loadWorkspaceSkills(workspaceDir, { workspaceOnly: true });
 }
 
 function lastRunCommandCall(): unknown[] | undefined {

--- a/src/skills/loading/local-loader.ts
+++ b/src/skills/loading/local-loader.ts
@@ -17,6 +17,7 @@ import {
 export type LoadedLocalSkill = {
   skill: Skill;
   frontmatter: ParsedSkillFrontmatter;
+  content: string;
 };
 
 export type LocalSkillLoadDiagnostic = {
@@ -125,62 +126,6 @@ export function loadSingleSkillDirectory(params: {
       disableModelInvocation: invocation.disableModelInvocation,
     },
     frontmatter,
+    content: raw,
   };
-}
-
-function listCandidateSkillDirs(dir: string): string[] {
-  try {
-    return fs
-      .readdirSync(dir, { withFileTypes: true })
-      .filter(
-        (entry) =>
-          entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules",
-      )
-      .map((entry) => path.join(dir, entry.name))
-      .toSorted((left, right) => left.localeCompare(right));
-  } catch {
-    return [];
-  }
-}
-
-/** Loads skills from a local directory while turning read/parse failures into diagnostics. */
-export function loadSkillsFromDirSafe(params: {
-  dir: string;
-  source: string;
-  maxBytes?: number;
-  rejectHardlinks?: boolean;
-  onDiagnostic?: (diagnostic: LocalSkillLoadDiagnostic) => void;
-}): LoadedLocalSkill[] {
-  const rootDir = path.resolve(params.dir);
-  let rootRealPath: string;
-  try {
-    rootRealPath = fs.realpathSync(rootDir);
-  } catch {
-    return [];
-  }
-
-  const rootSkill = loadSingleSkillDirectory({
-    skillDir: rootDir,
-    source: params.source,
-    rootRealPath,
-    maxBytes: params.maxBytes,
-    rejectHardlinks: params.rejectHardlinks,
-    onDiagnostic: params.onDiagnostic,
-  });
-  if (rootSkill) {
-    return [rootSkill];
-  }
-
-  return listCandidateSkillDirs(rootDir)
-    .map((skillDir) =>
-      loadSingleSkillDirectory({
-        skillDir,
-        source: params.source,
-        rootRealPath,
-        maxBytes: params.maxBytes,
-        rejectHardlinks: params.rejectHardlinks,
-        onDiagnostic: params.onDiagnostic,
-      }),
-    )
-    .filter((skill): skill is LoadedLocalSkill => skill !== null);
 }

--- a/src/skills/loading/skill-root-discovery.test.ts
+++ b/src/skills/loading/skill-root-discovery.test.ts
@@ -536,7 +536,7 @@ describe("discoverSkillCandidates", () => {
     expect(names).not.toContain("too-deep");
   });
 
-  it("does not fall through to child skills when an immediate SKILL.md is invalid", async () => {
+  it("does not inspect child skills when an immediate SKILL.md is invalid", async () => {
     const workspaceDir = await createTempWorkspaceDir();
     const parentDir = path.join(workspaceDir, "skills", "group", "parent");
     await fs.mkdir(parentDir, { recursive: true });
@@ -546,9 +546,20 @@ describe("discoverSkillCandidates", () => {
       name: "too-deep",
       description: "Should not be discovered through invalid parent fallback",
     });
+    const nestedFile = path.join(parentDir, "malformed-child", "SKILL.md");
+    await fs.mkdir(path.dirname(nestedFile));
+    await fs.writeFile(
+      nestedFile,
+      "---\nname: [malformed\ndescription: Ignored child\n---\n",
+      "utf-8",
+    );
+    const warn = captureWarningLogger();
 
     const names = loadTestWorkspaceSkills(workspaceDir).map((entry) => entry.skill.name);
     expect(names).not.toContain("too-deep");
+    const warningText = warn.mock.calls.flat().map(String).join("\n");
+    expect(warningText).toContain(path.join(parentDir, "SKILL.md"));
+    expect(warningText).not.toContain(nestedFile);
   });
 
   it("treats an immediate SKILL.md as terminal and does not descend", async () => {

--- a/src/skills/loading/skill-root-discovery.ts
+++ b/src/skills/loading/skill-root-discovery.ts
@@ -31,7 +31,6 @@ export type CandidateSkillDir = {
   skillDir: string;
   skillDirRealPath: string;
   name: string;
-  skillMdRealPath: string;
 };
 
 type PluginSkillCandidate = {
@@ -476,7 +475,6 @@ export function discoverSkillCandidates(params: {
               skillDir: baseDir,
               skillDirRealPath: baseDirRealPath,
               name: path.basename(baseDir),
-              skillMdRealPath: rootSkillRealPath,
             },
           ]
         : [],
@@ -538,7 +536,6 @@ export function discoverSkillCandidates(params: {
         skillDir: rootDir,
         skillDirRealPath: rootRealPath,
         name: path.basename(rootDir),
-        skillMdRealPath: configuredRootSkillRealPath,
       };
     }
   }
@@ -579,7 +576,6 @@ export function discoverSkillCandidates(params: {
           skillDir: candidate.skillDir,
           skillDirRealPath,
           name: candidate.name,
-          skillMdRealPath,
         });
       }
       continue;

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -27,7 +27,6 @@ import { resolveBundledAllowlist, shouldIncludeSkill } from "./config.js";
 import { resolveSkillInvocationPolicy, resolveSkillKey } from "./frontmatter.js";
 import {
   loadSingleSkillDirectory,
-  loadSkillsFromDirSafe,
   type LoadedLocalSkill,
   type LocalSkillLoadDiagnostic,
 } from "./local-loader.js";
@@ -56,7 +55,7 @@ const MAX_SKILL_ENTRY_CACHE_SIZE = 64;
 const skillEntryCache = new Map<string, SkillEntry[]>();
 const reportedSkillCollisions = new Map<string, true>();
 
-type LoadedSkillRecord = LoadedLocalSkill & {
+type LoadedSkillRecord = Pick<LoadedLocalSkill, "skill" | "frontmatter"> & {
   syncSourceDir?: string;
   syncDirName?: string;
 };
@@ -175,26 +174,29 @@ function filterSkillEntries(
   return filtered;
 }
 
-function loadContainedSkillRecords(params: {
+function loadContainedSkillRecord(params: {
   skillDir: string;
+  skillDirRealPath: string;
   source: string;
   maxSkillFileBytes: number;
   canonicalSkillDir?: string;
   rejectHardlinks: boolean;
-}): LoadedSkillRecord[] {
-  const expectedBaseDir = path.resolve(params.skillDir);
-  const loaded = loadSkillsFromDirSafe({
-    dir: params.skillDir,
+}): LoadedSkillRecord | null {
+  const loaded = loadSingleSkillDirectory({
+    skillDir: params.skillDir,
+    rootRealPath: params.skillDirRealPath,
     source: params.source,
     maxBytes: params.maxSkillFileBytes,
     rejectHardlinks: params.rejectHardlinks,
     onDiagnostic: (diagnostic) => warnInvalidSkill(params.source, diagnostic),
   });
-  const records = loaded.filter((record) => path.resolve(record.skill.baseDir) === expectedBaseDir);
+  if (!loaded) {
+    return null;
+  }
+  // Discovery selected one terminal SKILL.md; keep its parsed facts, not its content, in the cache.
+  const record: LoadedSkillRecord = { skill: loaded.skill, frontmatter: loaded.frontmatter };
   const canonicalSkillDir = params.canonicalSkillDir;
-  return canonicalSkillDir
-    ? records.map((record) => canonicalizeLoadedSkillRecord(record, canonicalSkillDir))
-    : records;
+  return canonicalSkillDir ? canonicalizeLoadedSkillRecord(record, canonicalSkillDir) : record;
 }
 
 function canonicalizeLoadedSkillRecord(
@@ -246,17 +248,18 @@ function loadDiscoveredSkillRecords(params: {
   const discovered = discoverSkillCandidates(params);
   const maxSkillsLoadedPerSource = Math.max(0, params.limits.maxSkillsLoadedPerSource);
   const loadCandidate = (candidate: CandidateSkillDir) =>
-    loadContainedSkillRecords({
+    loadContainedSkillRecord({
       skillDir: candidate.skillDir,
+      skillDirRealPath: candidate.skillDirRealPath,
       source: params.source,
       maxSkillFileBytes: params.limits.maxSkillFileBytes,
       canonicalSkillDir: canonicalSkillDirForSource(params.source, candidate.skillDirRealPath),
       rejectHardlinks: params.rejectHardlinks,
     });
   if (discovered.configuredRootCandidate) {
-    const rootRecords = loadCandidate(discovered.configuredRootCandidate);
-    if (rootRecords.length > 0) {
-      return rootRecords;
+    const rootRecord = loadCandidate(discovered.configuredRootCandidate);
+    if (rootRecord) {
+      return [rootRecord];
     }
   }
 
@@ -265,12 +268,10 @@ function loadDiscoveredSkillRecords(params: {
     if (!discovered.rootIsSkill && loadedSkills.length >= maxSkillsLoadedPerSource) {
       break;
     }
-    loadedSkills.push(...loadCandidate(candidate));
-  }
-  if (loadedSkills.length > maxSkillsLoadedPerSource && !discovered.rootIsSkill) {
-    return loadedSkills
-      .toSorted((a, b) => a.skill.name.localeCompare(b.skill.name, "en"))
-      .slice(0, maxSkillsLoadedPerSource);
+    const record = loadCandidate(candidate);
+    if (record) {
+      loadedSkills.push(record);
+    }
   }
   return loadedSkills;
 }
@@ -285,25 +286,19 @@ function loadGeneratedPluginSkillRecords(params: {
   const maxSkillsLoadedPerSource = Math.max(0, params.limits.maxSkillsLoadedPerSource);
   const loadedSkills: LoadedSkillRecord[] = [];
   for (const candidate of candidates) {
-    const loadedRecords = loadContainedSkillRecords({
+    const record = loadContainedSkillRecord({
       skillDir: candidate.skillDir,
+      skillDirRealPath: candidate.skillDirRealPath,
       source: params.source,
       maxSkillFileBytes: params.limits.maxSkillFileBytes,
       rejectHardlinks: candidate.rejectHardlinks,
     });
-    loadedSkills.push(
-      ...loadedRecords.map((record) =>
-        setSyncSourceForPluginSkill(record, candidate.skillDirRealPath),
-      ),
-    );
+    if (record) {
+      loadedSkills.push(setSyncSourceForPluginSkill(record, candidate.skillDirRealPath));
+    }
     if (loadedSkills.length >= maxSkillsLoadedPerSource) {
       break;
     }
-  }
-  if (loadedSkills.length > maxSkillsLoadedPerSource) {
-    return loadedSkills
-      .toSorted((a, b) => a.skill.name.localeCompare(b.skill.name, "en"))
-      .slice(0, maxSkillsLoadedPerSource);
   }
   return loadedSkills;
 }


### PR DESCRIPTION
Related: #138582

## What Problem This Solves

Fixes an issue where a node could publish skill metadata from one version of `SKILL.md` with instructions from a later version if the file changed during discovery. The Gateway could then reject the skill because its metadata and content disagreed. Discovery also loaded nested skills beneath an invalid selected parent, producing diagnostics for children that could never be admitted.

## Why This Change Was Made

The selected-directory loader now supplies metadata and complete content from one bounded read. Both node and workspace discovery use that owner directly; the node no longer rereads accepted files or sorts and deduplicates already ordered directory identities. Workspace caches retain parsed facts without retaining the raw instruction body.

This builds on #138582 and preserves its containment checks. Existing file/count/aggregate limits and source-specific hardlink policies remain intact. Net change: **−95 production lines, +11 test lines, +4 documentation lines**.

## User Impact

Node skills retain their complete original instruction bytes, including Unicode, BOMs and CRLF line endings. Metadata and instructions stay consistent, and invalid selected parents produce their own diagnostic without inspecting nested children. Local, disabled and bundled skill inventory behavior remains unchanged.

## Evidence

- Captured **three failing regressions before the production edit**: mixed metadata/content during a synchronous file replacement, nested node discovery after an invalid parent, and nested workspace discovery after an invalid immediate `SKILL.md`.
- **97 tests passed across seven suites**, covering node discovery, root discovery, workspace loading, path containment, installation, remote skills and resources. The complete **29-stage changed-file gate** passed for all eight changed files, including core/test types, dead exports, lint, formatting, assertion safety and architecture guards.
- Fresh independent Codex review found no actionable P0–P2 issues. A normal frozen pnpm 12.1.0 install and full `pnpm build` passed in a separate physical checkout.
- The real built Gateway and foreground node flow passed on commit `6cf1a29d75573ec4f7bebfd6a27889ba4b7ee76b`: exact device and command-surface approvals, one accepted `node.skills.update`, and real `skills list --json --agent main` / `gateway call skills.status` inventories. All three request and response descriptors matched the original fixture bytes, including BOM/CRLF content. The inventory grew **57 → 60**, preserving all 57 existing records.
- The built flow retained five correlated, successfully forwarded RPC pairs and 30 complete command captures. Both node starts diagnosed the same 70,060-byte oversized fixture at the existing 65,536-byte limit; invalid parent diagnostics appeared without nested-child diagnostics. All owned processes joined, both loopback ports were released, and the private runtime was removed. No provider/model turn or external channel was used.

The built flow proves publication and operator visibility. The deterministic mid-read replacement is covered by the failing-before/passing-after regression; these results are not a memory or latency benchmark.
