### PR TITLE
refactor(agents): centralize admitted cleanup ownership checks

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
@@ -411,17 +411,6 @@ export function completeCleanupBookkeeping(
 ): void {
   const params = context.options;
   const suppressSessionEffects = shouldSuppressSubagentRecoverySessionEffects(cleanupParams.entry);
-  const runCleanupTail = (label: string, run: () => Promise<unknown>) => {
-    // These best-effort tails can outlive the durable registry transition,
-    // but they still mutate session-owned resources and must block snapshots.
-    void runWithGatewayIndependentRootWorkAdmission(run, "subagents:lifecycle-cleanup").catch(
-      (error: unknown) => {
-        defaultRuntime.log(
-          `[warn] subagent ${label} failed (${cleanupParams.runId}): ${String(error)}`,
-        );
-      },
-    );
-  };
   const scheduleCleanupTails = (options: {
     allowRetiredRow: boolean;
     isDeleteCleanup: boolean;
@@ -439,20 +428,27 @@ export function completeCleanupBookkeeping(
         !shouldSuppressSubagentRecoverySessionEffects(cleanupParams.entry)
       );
     };
-    if (postBookkeepingEffectsAllowed() && !cleanupParams.preserveTranscript) {
-      runCleanupTail("session cleanup", async () => {
-        if (!postBookkeepingEffectsAllowed()) {
-          return;
+    const runCleanupTail = (label: string, run: () => Promise<unknown>) => {
+      // Admission can wait beyond retirement or replacement. Recheck ownership
+      // inside the independent root; surviving tails must still block snapshots.
+      void runWithGatewayIndependentRootWorkAdmission(async () => {
+        if (postBookkeepingEffectsAllowed()) {
+          await run();
         }
-        await removeInternalSessionEffectsSession(cleanupParams.entry.execution.transcriptTarget);
+      }, "subagents:lifecycle-cleanup").catch((error: unknown) => {
+        defaultRuntime.log(
+          `[warn] subagent ${label} failed (${cleanupParams.runId}): ${String(error)}`,
+        );
       });
+    };
+    if (postBookkeepingEffectsAllowed() && !cleanupParams.preserveTranscript) {
+      runCleanupTail("session cleanup", () =>
+        removeInternalSessionEffectsSession(cleanupParams.entry.execution.transcriptTarget),
+      );
     }
     if (postBookkeepingEffectsAllowed() && cleanupParams.entry.spawnMode !== "session") {
-      runCleanupTail("bundle MCP cleanup", async () => {
-        if (!postBookkeepingEffectsAllowed()) {
-          return;
-        }
-        await retireSessionMcpRuntimeForSessionKey({
+      runCleanupTail("bundle MCP cleanup", () =>
+        retireSessionMcpRuntimeForSessionKey({
           sessionKey: cleanupParams.entry.childSessionKey,
           reason: "subagent-run-cleanup",
           preserveActiveLeases: true,
@@ -467,19 +463,16 @@ export function completeCleanupBookkeeping(
               ),
             });
           },
-        });
-      });
+        }),
+      );
     }
     if (
       !cleanupParams.provisionalKill &&
       postBookkeepingEffectsAllowed() &&
       (options.isDeleteCleanup || !cleanupParams.entry.collect)
     ) {
-      runCleanupTail("context-engine cleanup", async () => {
-        if (!postBookkeepingEffectsAllowed()) {
-          return;
-        }
-        await params.notifyContextEngineSubagentEnded(
+      runCleanupTail("context-engine cleanup", () =>
+        params.notifyContextEngineSubagentEnded(
           {
             childSessionKey: cleanupParams.entry.childSessionKey,
             reason: options.isDeleteCleanup ? "deleted" : "completed",
@@ -487,8 +480,8 @@ export function completeCleanupBookkeeping(
             workspaceDir: cleanupParams.entry.workspaceDir,
           },
           { isCurrent: postBookkeepingEffectsAllowed },
-        );
-      });
+        ),
+      );
     }
   };
   if (cleanupParams.provisionalKill) {


### PR DESCRIPTION
Related: #137606

## What Problem This Solves

This is a maintainer-requested cleanup of subagent completion ownership checks, not a new user-facing behavior change. Three best-effort cleanup tails independently repeated the same post-admission ownership check, making it easier for a future tail to omit the fence.

## Why This Change Was Made

The existing cleanup-tail owner now performs that check once inside each independently admitted root. Session cleanup, bundle MCP retirement, and context-engine cleanup still have separate admissions, preserve their scheduling order and error handling, and block snapshots until they finish. The context-engine callback retains its additional check after asynchronous engine loading.

The durable completion bookkeeping, requester wake logic, rollback behavior, transcript retention, and allowed-retirement rules are unchanged. No database, protocol, configuration, or public API changes.

## User Impact

No intentional behavior change. This removes duplicate policy from the lifecycle owner while preserving stale-generation and restart/suspension protections.

Production LOC: **+23 / -30, net -7**. Tests, generated code, and documentation: **0**. Existing behavioral coverage already exercises this boundary; no redundant test file was added.

## Evidence

- 209 existing tests passed across lifecycle, context-engine cleanup, and Gateway work admission. These exercise the real in-process owners with controlled dependencies; they are not authenticated provider or channel proof.
- All 28 applicable repository changed-file checks passed, including core/core-test types, lint, formatting, dependency boundaries, and schema guards.
- Independent managed Codex review at P0–P2 found no actionable findings after reading the complete changed owner plus callers, callees, sibling ownership paths, and existing tests. The reviewed source remained unchanged throughout review.
- Manual review verified that each tail retains its own independent root lease, both pre- and post-admission ownership checks, and existing failure logging. Folding the three tails into a shared admission was rejected because that would change lifecycle ownership.

No live provider/channel call was made: this is behavior-preserving internal ownership consolidation, not a provider or transport change. Exact-head hosted CI remains the landing gate.
