### PR TITLE
chore(codex): update managed runtime to 0.153.4

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -277,7 +277,7 @@ reconciliation so OpenClaw does not override that selection.
 ## Remote marketplaces
 
 Remote marketplace support was introduced in Codex 0.146.1 and remains
-available in OpenClaw's pinned Codex 0.153.0. OpenClaw passes the opaque remote
+available in OpenClaw's pinned Codex 0.153.4. OpenClaw passes the opaque remote
 plugin ID returned by Codex to `plugin/read` and `plugin/install`; a
 human-readable plugin name is not a valid substitute.
 

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -177,7 +177,7 @@ flags, and plugin allow/deny references into this block. Explicit canonical
 ## App-server transport
 
 For ordinary harness turns, OpenClaw starts the managed Codex binary shipped
-with the official plugin (currently `@openai/codex` `0.153.0`):
+with the official plugin (currently `@openai/codex` `0.153.4`):
 
 ```bash
 codex app-server --listen stdio://
@@ -323,7 +323,7 @@ If the normal app-server runtime would be `danger-full-access`, enabling
 permission profile instead. Codex-managed network enforcement is sandboxed
 networking, so a full-access profile would not protect outbound traffic.
 
-The plugin manages stable Codex app-server `0.153.0`. Explicit custom
+The plugin manages stable Codex app-server `0.153.4`. Explicit custom
 executables, remote app-servers, and macOS desktop binaries must report a
 parseable semantic version of `0.149.0` or newer. Older, malformed, and
 unversioned handshakes are rejected. Newer versions log a compatibility warning
@@ -452,7 +452,7 @@ The stable default is fail-closed: active OpenClaw sandboxing disables native
 Codex execution surfaces that would otherwise run from the Codex app-server
 host. Use `appServer.experimental.sandboxExecServer: true` only when you want
 to try Codex's remote environment support with OpenClaw's sandbox backend.
-This preview path uses the pinned Codex `0.153.0` app-server.
+This preview path uses the pinned Codex `0.153.4` app-server.
 
 ```json5
 {
@@ -868,8 +868,8 @@ response remains authoritative even if it contains no visible models; HTTP
 `401` and `403` return an empty catalog rather than exposing fallback models.
 
 <Note>
-The current bundled harness is `@openai/codex` `0.153.0`. A live `model/list`
-probe against the official `0.153.0` app-server, using an isolated,
+The current bundled harness is `@openai/codex` `0.153.4`. A live `model/list`
+probe against the official `0.153.4` app-server, using an isolated,
 unauthenticated Codex home and `includeHidden: true`, returned this public
 subset of catalog metadata:
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -103,8 +103,8 @@ channel is the communication surface.
 
 - The official `@openclaw/codex` plugin installed. Include `codex` in
   `plugins.allow` if your config uses an allowlist.
-- Managed Codex app-server `0.153.0`. The plugin ships and manages
-  `@openai/codex` `0.153.0` by default, so a `codex` command on `PATH` does not
+- Managed Codex app-server `0.153.4`. The plugin ships and manages
+  `@openai/codex` `0.153.4` by default, so a `codex` command on `PATH` does not
   affect normal startup. Explicit custom, remote, and macOS desktop-owned
   app-servers must report a parseable semantic version of `0.149.0` or newer.
   Newer versions continue with a compatibility warning and normal runtime

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -23,7 +23,7 @@ working.
 - `plugins.entries.codex.enabled` is `true`.
 - `plugins.entries.codex.config.codexPlugins.enabled` is `true`.
 - Codex app-server reports `0.149.0` or newer. The official plugin ships
-  `@openai/codex` `0.153.0`; newer custom, remote, and macOS desktop-owned
+  `@openai/codex` `0.153.4`; newer custom, remote, and macOS desktop-owned
   binaries continue with a compatibility warning and normal runtime validation.
 - The target Codex app-server can see the expected marketplace, plugin, and
   app inventory.

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@openai/codex": "0.153.0",
+    "@openai/codex": "0.153.4",
     "semver": "7.8.5",
     "smol-toml": "1.8.0",
     "typebox": "1.3.18",

--- a/extensions/codex/src/app-server/plugin-thread-config-deadline.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config-deadline.ts
@@ -108,15 +108,20 @@ async function buildCodexPluginThreadConfigWithinDeadline(
   // One deadline owns the whole config build; every RPC gets only the remaining
   // budget so discovery cannot consume one full request timeout per call.
   const deadlineMs = Date.now() + timeoutMs;
-  const boundedRequest: CodexPluginRuntimeRequest = (method, requestParams) => {
+  let requestTimedOut = false;
+  const boundedRequest: CodexPluginRuntimeRequest = async (method, requestParams) => {
     const remainingTimeoutMs = deadlineMs - Date.now();
-    if (remainingTimeoutMs <= 0) {
+    if (requestTimedOut || remainingTimeoutMs <= 0) {
       throw new CodexPluginThreadConfigDeadlineError();
     }
-    return request(method, requestParams, {
-      timeoutMs: remainingTimeoutMs,
-      signal,
-    });
+    try {
+      return await request(method, requestParams, { timeoutMs: remainingTimeoutMs, signal });
+    } catch (error) {
+      // Inventory readers absorb failures. Preserve timeout evidence before they
+      // turn it into missing apps, even if the wall clock trails the request timer.
+      requestTimedOut ||= isCodexPluginThreadConfigTimeoutError(error);
+      throw error;
+    }
   };
   try {
     return await withAbortableTimeout({
@@ -129,7 +134,7 @@ async function buildCodexPluginThreadConfigWithinDeadline(
         });
         const result = transform ? await transform(config, boundedRequest) : config;
         // Inventory readers can absorb an RPC timeout into an unavailable result.
-        if (Date.now() >= deadlineMs) {
+        if (requestTimedOut || Date.now() >= deadlineMs) {
           throw new CodexPluginThreadConfigDeadlineError();
         }
         return result;
@@ -140,7 +145,7 @@ async function buildCodexPluginThreadConfigWithinDeadline(
   } catch (error) {
     if (
       signal.aborted ||
-      (!isCodexPluginThreadConfigTimeoutError(error) && Date.now() < deadlineMs)
+      (!requestTimedOut && !isCodexPluginThreadConfigTimeoutError(error) && Date.now() < deadlineMs)
     ) {
       throw error;
     }

--- a/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
@@ -651,6 +651,9 @@ describe("Codex app inventory across physical process restart", () => {
       const release = createDeferred<void>();
       f.process.faults.beforeInventory = () => release.promise;
       f.appServer.requestTimeoutMs = 400;
+      // Real request timers can win before the wall clock reaches the shared
+      // deadline. Keep that ordering deterministic without replacing the timers.
+      vi.spyOn(Date, "now").mockReturnValue(Date.now());
       const boundary = f.calls.length;
       try {
         if (scheduled) {

--- a/extensions/codex/src/app-server/version.ts
+++ b/extensions/codex/src/app-server/version.ts
@@ -2,7 +2,7 @@
  * Version and package pins for the managed Codex app-server runtime.
  */
 /** Exact Codex app-server version shipped by the OpenClaw Codex bridge. */
-export const CODEX_APP_SERVER_VERSION = "0.153.0";
+export const CODEX_APP_SERVER_VERSION = "0.153.4";
 /** Inclusive runtime compatibility floor for external app-server binaries. */
 export const MIN_SUPPORTED_CODEX_APP_SERVER_VERSION = "0.149.0";
 /** npm package name for the managed Codex app-server binary. */

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -93,7 +93,7 @@ function classifyOpenAiFailoverCode(code: string | undefined) {
 const OPENAI_MODELS_ENDPOINT = "https://api.openai.com/v1/models";
 // Keep synchronized with extensions/codex's exact @openai/codex dependency;
 // the provider contract test fails when that managed-runtime pin changes.
-const OPENAI_CODEX_CLIENT_VERSION = "0.153.0";
+const OPENAI_CODEX_CLIENT_VERSION = "0.153.4";
 const OPENAI_CODEX_MODELS_ENDPOINT = `${OPENAI_CODEX_RESPONSES_BASE_URL}/models?client_version=${OPENAI_CODEX_CLIENT_VERSION}`;
 const OPENAI_MODELS_CACHE_TTL_MS = 60_000;
 const OPENAI_CODEX_MODELS_CACHE_TTL_MS = 60_000;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,7 +108,7 @@ settings:
 overrides:
   '@lancedb/lancedb>@huggingface/transformers': '-'
   baileys>sharp: '-'
-  '@agentclientprotocol/codex-acp@1.6.2>@openai/codex': 0.153.0
+  '@agentclientprotocol/codex-acp@1.6.2>@openai/codex': 0.153.4
   '@codemirror/commands@6.11.0>@codemirror/view': 6.43.9
   '@anthropic-ai/sdk': 0.120.0
   '@opentelemetry/core': 2.10.0
@@ -827,8 +827,8 @@ importers:
   extensions/codex:
     dependencies:
       '@openai/codex':
-        specifier: 0.153.0
-        version: 0.153.0
+        specifier: 0.153.4
+        version: 0.153.4
       semver:
         specifier: 7.8.5
         version: 7.8.5
@@ -4142,43 +4142,43 @@ packages:
     resolution: {integrity: sha512-3zcN5Q3yEmeyxXBzqB6fXPQFzYa2ROsGFSr69W0ArXIAGJqxl/aFECOVPD2kbkYPm0U/EHxFKgclK3UA9WQg5A==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
-  '@openai/codex@0.153.0':
-    resolution: {integrity: sha512-k55kUZaclNi5ceUStSVuyW834ruA6AEdzTK7Xi3M1mOyXokUmq1sJLXm1RJ3XD2S7bRPeF1EXNsYB5Qxwus0mw==}
+  '@openai/codex@0.153.4':
+    resolution: {integrity: sha512-wbHDmit7S/YvBGVX1DQmk13xtWblZ2cApeJ/pB7xDZ10Cna+DZc5ij7f0F4OxdsXN4FW1oLT48OpogUI1+8Y2w==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.153.0-darwin-arm64':
-    resolution: {integrity: sha512-C9F3HVEYekVJC3WhiGSztcxItWBwd7Y6hTWoDqa9Z9aLWsYywzqChABB59n7G5F5jCil9wxW3+u2L6uiVUydmw==}
+  '@openai/codex@0.153.4-darwin-arm64':
+    resolution: {integrity: sha512-B1qhN3fa1ay0R0wGziXqgwSkB5icpYChNKHhtBHff/0UtSTC7z+l8aTtvMlGjH3E8HEvY3+njIJelM9CAAoVWg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.153.0-darwin-x64':
-    resolution: {integrity: sha512-DO5u+X/eL8pObrV0WDErOjS9DeuDvVuOL5oHR5y5Yklp0NGoGj3oOHsmaSXjGesiIiu3IX8l4pzS6dbeQXJAvQ==}
+  '@openai/codex@0.153.4-darwin-x64':
+    resolution: {integrity: sha512-vnSbbPzfoDZmmyzsxswsDDXQ06IVFBzkQU7/hroB3ji93Ok2utcsq8Psfk2tjF5r9mEx8RWFJhzuTGHG26/NDA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.153.0-linux-arm64':
-    resolution: {integrity: sha512-N2zLgmuslhMoC2RFC2aDkcCWk3iapZmBlSiESpjXFF+UMNxIpNxWJ5qQtQrCp5Md7kYbF4/EFy8RqJ8tL8UTeA==}
+  '@openai/codex@0.153.4-linux-arm64':
+    resolution: {integrity: sha512-QKdjYLYV4hXIuUQDP3P6F4NXuWFoKo9WUoV4nAREIx55kiUyi8UsYdsVobkeXir5n/maEQgYMCKLHVma4rNPiw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.153.0-linux-x64':
-    resolution: {integrity: sha512-sFF+g7p1o6sZVL6PHd9JTYrP2j3xao3Qeu5AngcrD5brWrCc+w9ifBJCJuRSM728WfgjXML9PQPdHPaZSeHAEA==}
+  '@openai/codex@0.153.4-linux-x64':
+    resolution: {integrity: sha512-x1EcwBlY3AObM1VTUHNM2AzAJQsyreGdagpF+qFiYi/Oa30VBktvvG0C6tLtCzqW6hjZNWkGZQWmeVk7MuJKWg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.153.0-win32-arm64':
-    resolution: {integrity: sha512-Ro+/2oAQnOObxuw3hpr+anv+j9hFmql/2iDxd7v0m46ctZy8x6ygW/Ud4f9CB1UXlRRsDhW+Tu9UAd5X9vTL1g==}
+  '@openai/codex@0.153.4-win32-arm64':
+    resolution: {integrity: sha512-/FBh42976ltF1kxDoPQBg1Q6+hwChRU5/sm5dfeC8kFVQMvOCGoGeY5d8rRZGVJE8XojlXo74VQb0sHowcfgBw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.153.0-win32-x64':
-    resolution: {integrity: sha512-eXvmitT1Hmr6d8n9r5HVjTuSgdHtxFSyXh0c3rRnaTcJA0ef8JnI5LY0TJci/QHYLNJGaEMBZ5R4dEdB2d87Lw==}
+  '@openai/codex@0.153.4-win32-x64':
+    resolution: {integrity: sha512-lMkB43kJZH0VFr+hoXc11qqR7QtQIbkr07ALgj4urKL1osNyUyuy1iXd3Vzz2iCYvBUCSw7I0l/W1cEPGx9euQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -9752,7 +9752,7 @@ snapshots:
   '@agentclientprotocol/codex-acp@1.6.2':
     dependencies:
       '@agentclientprotocol/sdk': 1.4.0(zod@4.4.3)
-      '@openai/codex': 0.153.0
+      '@openai/codex': 0.153.4
       diff: 9.0.0
       open: 11.0.1
       vscode-jsonrpc: 9.0.1
@@ -11484,31 +11484,31 @@ snapshots:
 
   '@npmcli/redact@5.0.0': {}
 
-  '@openai/codex@0.153.0':
+  '@openai/codex@0.153.4':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.153.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.153.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.153.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.153.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.153.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.153.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.153.4-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.153.4-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.153.4-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.153.4-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.153.4-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.153.4-win32-x64'
 
-  '@openai/codex@0.153.0-darwin-arm64':
+  '@openai/codex@0.153.4-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.153.0-darwin-x64':
+  '@openai/codex@0.153.4-darwin-x64':
     optional: true
 
-  '@openai/codex@0.153.0-linux-arm64':
+  '@openai/codex@0.153.4-linux-arm64':
     optional: true
 
-  '@openai/codex@0.153.0-linux-x64':
+  '@openai/codex@0.153.4-linux-x64':
     optional: true
 
-  '@openai/codex@0.153.0-win32-arm64':
+  '@openai/codex@0.153.4-win32-arm64':
     optional: true
 
-  '@openai/codex@0.153.0-win32-x64':
+  '@openai/codex@0.153.4-win32-x64':
     optional: true
 
   '@openclaw/crabline@0.1.20':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,7 +42,7 @@ overrides:
   # Memory LanceDB supplies vectors; WhatsApp prepares thumbnails with Rastermill.
   "@lancedb/lancedb>@huggingface/transformers": "-"
   "baileys>sharp": "-"
-  "@agentclientprotocol/codex-acp@1.6.2>@openai/codex": 0.153.0
+  "@agentclientprotocol/codex-acp@1.6.2>@openai/codex": 0.153.4
   "@codemirror/commands@6.11.0>@codemirror/view": 6.43.9
   "@anthropic-ai/sdk": 0.120.0
   "@opentelemetry/core": 2.10.0

--- a/scripts/e2e/lib/codex-media-path/fake-codex-app-server.mjs
+++ b/scripts/e2e/lib/codex-media-path/fake-codex-app-server.mjs
@@ -5,7 +5,7 @@ import {
   runFakeCodexAppServer,
 } from "../codex-app-server-fixture.mjs";
 
-const version = "0.153.0";
+const version = "0.153.4";
 const requestLog =
   process.env.OPENCLAW_CODEX_MEDIA_PATH_APP_SERVER_LOG ??
   "/tmp/openclaw-codex-media-path-app-server.jsonl";


### PR DESCRIPTION
## What Problem This Solves

Updates the managed Codex harness from 0.153.0 to the latest stable npm release, 0.153.4, so installs receive the upstream patch fixes and refreshed runtime model metadata. Also repairs an existing startup timeout race exposed by CI: scheduled Codex runs could mistake a timed-out app inventory request for revoked app access and tell operators to reauthorize.

## Why This Change Was Made

Keeps the Codex plugin dependency, managed runtime version, OpenAI discovery client version, and existing ACP dependency override on the same exact release. Regenerates the lockfile for all six platform packages and refreshes the harness documentation from a real 0.153.4 model-list probe. The custom app-server compatibility floor remains 0.149.0. The media E2E fake server advertises the same current pin. The startup deadline owner now records observed request timeouts before inventory readers can absorb them, preserving timeout classification and abort precedence without changing any budgets or adding retries.

## User Impact

Managed Codex turns and ACP installs use 0.153.4. No new configuration, migration, or protocol change is introduced. The six public models documented in the isolated catalog snapshot retain the same modalities, reasoning efforts, and hidden status. Slow app inventory produces the existing timeout/retry outcome; ordinary turns retain the existing app-disabled fallback and scheduled turns preserve their binding without running tools.

## Evidence

- Registry: `npm view @openai/codex@latest version dist.tarball dist.integrity --json` resolved 0.153.4; installed binary reports `codex-cli 0.153.4`.
- 404 focused tests passed across managed binary resolution, configuration, model discovery, JSON-RPC client, real-binary stdio configuration, WebSocket transport, OpenAI provider discovery, and install assertions.
- Generated the experimental schemas with the installed 0.153.4 binary and compared all nine compact schema artifacts with the checked-in protocol mirror: identical.
- Real isolated unauthenticated `initialize`, `account/read`, and `model/list` (`includeHidden: true`) succeeded; documented public catalog metadata is unchanged.
- Full `pnpm build` passed before and after the timeout repair (runtime, plugins, SDK declarations, and Control UI).
- CI run [33932889278](https://github.com/openclaw/openclaw/actions/runs/33932889278) exposed the missed media fixture pin and pre-existing inventory-timeout race. The repaired media fixture suite passes all 12 tests.
- The existing lifecycle test now retains real timers while fixing wall-clock ordering: both warm/cold scheduled cases fail on pre-fix source with the incorrect reauthorization error, then pass with the owner fix. All 169 tests across lifecycle, plugin configuration, and scheduled-authority siblings pass.
- Authenticated [live Codex harness run 33932937376](https://github.com/openclaw/openclaw/actions/runs/33932937376) passed with GPT-5.6 Luna at max effort (2 passed, 1 skipped) on the dependency-upgrade commit.
- Final exact-head [CI33935118426](https://github.com/openclaw/openclaw/actions/runs/33935118426) and [authenticated live harness33935201848](https://github.com/openclaw/openclaw/actions/runs/33935201848) passed on `78f3ecbaa098276eb13e756bbd9a055d99d95f1f`.
- Full changed-surface checks passed, including extension/test type checks, lint, dependency/boundary guards, and import cycles.
- ClawSweeper current-version documentation finding and rank-up move are addressed in both native-plugin and Computer Use guides.
- Scoped docs MDX and formatting checks passed; `git diff --check` passed.
- Independent Codex review: no actionable P0–P2 findings.

Upstream source personally inspected at [rust-v0.153.4](https://github.com/openai/codex/tree/rust-v0.153.4): `codex-cli/bin/codex.js:15-115` (platform package selection), `codex-rs/app-server/src/request_processors/catalog_processor.rs:169-280` and `codex-rs/app-server/src/models.rs:13-77` (model listing), and `codex-rs/ext/guardian-v2/src/async_scorer/extension.rs:260-300,495-530` (patch behavior). The app-server protocol source and schema trees are unchanged from rust-v0.153.0. No protocol regeneration is needed.

Production TypeScript delta: +15/-10 (net +5), retaining one observed timeout fact at its owner instead of inferring it from a later wall-clock sample. Manifest/workspace pins: +2/-2. Lockfile: +31/-31. Docs: +9/-9. Tests: +3/-0; test fixture: +1/-1. The timeout bug predates this upgrade (present in d2829f348d8); no new configuration, protocol, storage, or fallback path is added.
