### PR TITLE
refactor(cua): simplify desktop session ownership and dispatch

### DIFF
--- a/apps/macos/Sources/OpenClaw/CuaDriverHostLifecycle.swift
+++ b/apps/macos/Sources/OpenClaw/CuaDriverHostLifecycle.swift
@@ -36,20 +36,8 @@ extension CuaDriverHostCoordinator {
                       expectedExecutableURL: expectedExecutableURL)
             else { continue }
 
-            if let hostPID = self.processEnvironmentValue(
-                processIdentifier,
-                key: "CUA_DRIVER_EMBEDDED_HOST_PID").flatMap(pid_t.init),
-                !self.processIsAlive(hostPID)
-            {
-                logger.error(
-                    """
-                    reaping orphaned embedded CUA daemon \(processIdentifier, privacy: .public) \
-                    whose host \(hostPID, privacy: .public) is gone
-                    """)
-            } else {
-                logger.error(
-                    "reaping owned embedded CUA daemon \(processIdentifier, privacy: .public) during lifecycle cleanup")
-            }
+            logger.error(
+                "reaping owned embedded CUA daemon \(processIdentifier, privacy: .public) during lifecycle cleanup")
             if await self.terminateProcess(
                 processIdentifier,
                 directory: directory,
@@ -210,79 +198,6 @@ extension CuaDriverHostCoordinator {
         let actualPath = actualExecutableURL.resolvingSymlinksInPath().standardizedFileURL.path
         let expectedPath = expectedExecutableURL.resolvingSymlinksInPath().standardizedFileURL.path
         return actualPath == expectedPath
-    }
-
-    private static func processEnvironmentValue(
-        _ processIdentifier: pid_t,
-        key: String) -> String?
-    {
-        var argumentMaximum: Int32 = 0
-        var argumentMaximumSize = MemoryLayout<Int32>.size
-        var argumentMaximumMIB: [Int32] = [CTL_KERN, KERN_ARGMAX]
-        guard sysctl(
-            &argumentMaximumMIB,
-            u_int(argumentMaximumMIB.count),
-            &argumentMaximum,
-            &argumentMaximumSize,
-            nil,
-            0) == 0,
-            argumentMaximum > 0,
-            argumentMaximum <= 4 * 1024 * 1024
-        else { return nil }
-
-        var buffer = [UInt8](repeating: 0, count: Int(argumentMaximum))
-        var bufferSize = buffer.count
-        var processMIB: [Int32] = [CTL_KERN, KERN_PROCARGS2, processIdentifier]
-        let readSucceeded = buffer.withUnsafeMutableBytes { bytes in
-            sysctl(
-                &processMIB,
-                u_int(processMIB.count),
-                bytes.baseAddress,
-                &bufferSize,
-                nil,
-                0) == 0
-        }
-        guard readSucceeded, bufferSize >= MemoryLayout<Int32>.size else { return nil }
-
-        var argumentCount: Int32 = 0
-        withUnsafeMutableBytes(of: &argumentCount) { destination in
-            destination.copyBytes(from: buffer.prefix(destination.count))
-        }
-        guard argumentCount > 0 else { return nil }
-
-        var offset = MemoryLayout<Int32>.size
-        func skipString() -> Bool {
-            guard offset < bufferSize else { return false }
-            while offset < bufferSize, buffer[offset] != 0 {
-                offset += 1
-            }
-            guard offset < bufferSize else { return false }
-            offset += 1
-            return true
-        }
-
-        guard skipString() else { return nil }
-        while offset < bufferSize, buffer[offset] == 0 {
-            offset += 1
-        }
-        for _ in 0..<argumentCount where offset < bufferSize {
-            guard skipString() else { return nil }
-        }
-
-        let prefix = Data("\(key)=".utf8)
-        while offset < bufferSize {
-            while offset < bufferSize, buffer[offset] == 0 {
-                offset += 1
-            }
-            guard offset < bufferSize else { break }
-            let start = offset
-            guard skipString() else { break }
-            let entry = Data(buffer[start..<(offset - 1)])
-            if entry.starts(with: prefix) {
-                return String(bytes: entry.dropFirst(prefix.count), encoding: .utf8)
-            }
-        }
-        return nil
     }
 
     private static func terminateProcess(

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -275,11 +275,11 @@ extensions/copilot/src/tool-bridge.ts	6
 extensions/copilot/src/workspace-bootstrap.ts	1
 extensions/crabbox/src/crabbox-worker-inspect.ts	3
 extensions/crabbox/src/crabbox-worker-provider.ts	1
-extensions/cua-computer/src/commands.ts	3
+extensions/cua-computer/src/commands.ts	2
 extensions/cua-computer/src/driver-artifact-verification.ts	2
 extensions/cua-computer/src/driver-artifacts.ts	1
 extensions/cua-computer/src/driver-client.ts	15
-extensions/cua-computer/src/driver-result.ts	10
+extensions/cua-computer/src/driver-result.ts	9
 extensions/cua-computer/src/mcp-driver-client.ts	5
 extensions/cua-computer/src/window-actions.ts	3
 extensions/deepinfra/provider-models.ts	3
@@ -2024,7 +2024,7 @@ src/agents/tools/automations-tool-name.ts	1
 src/agents/tools/chat-history-text.ts	3
 src/agents/tools/common.ts	2
 src/agents/tools/computer-tool-node.ts	2
-src/agents/tools/computer-tool-request.ts	5
+src/agents/tools/computer-tool-request.ts	3
 src/agents/tools/computer-tool.ts	2
 src/agents/tools/conversation-tools.ts	3
 src/agents/tools/cron-tool-context.ts	1

--- a/extensions/cua-computer/src/browser-actions.test.ts
+++ b/extensions/cua-computer/src/browser-actions.test.ts
@@ -12,17 +12,33 @@ describe("cua-computer browser actions", () => {
   it("maps every browser action to the pinned driver tool contract", async () => {
     const { session, callTool } = driver();
     let downloadedFile = "";
+    const binding = {
+      ...CUA_DRIVER_CONTRACT_FIXTURES.browserBinding,
+      tabs: CUA_DRIVER_CONTRACT_FIXTURES.browserBinding.tabs.map((tab) => ({
+        ...tab,
+        title: "",
+        active: false,
+        nativeSession: "private-native-browser-session",
+      })),
+    };
+    const snapshot = {
+      ...CUA_DRIVER_CONTRACT_FIXTURES.browserSnapshot,
+      refs: CUA_DRIVER_CONTRACT_FIXTURES.browserSnapshot.refs.map((ref) => ({
+        ...ref,
+        value: "",
+        states: [],
+        nativeSession: "private-native-browser-session",
+      })),
+      content_refs: [{ ref: "p7:0", label: "duplicate action reference" }],
+    };
     callTool.mockImplementation(async (name, args) => {
       switch (name) {
         case "list_windows":
           return cuaToolResult(CUA_DRIVER_CONTRACT_FIXTURES.listWindows);
         case "get_browser_state":
-          return cuaToolResult(
-            "target_id" in args
-              ? CUA_DRIVER_CONTRACT_FIXTURES.browserSnapshot
-              : CUA_DRIVER_CONTRACT_FIXTURES.browserBinding,
-            { image: "target_id" in args },
-          );
+          return cuaToolResult("target_id" in args ? snapshot : binding, {
+            image: "target_id" in args,
+          });
         case "browser_prepare":
           return cuaToolResult(CUA_DRIVER_CONTRACT_FIXTURES.browserPrepare);
         case "browser_navigate":
@@ -68,11 +84,15 @@ describe("cua-computer browser actions", () => {
     );
     expect(boundJson).not.toContain("native-browser-target-1");
     expect(boundJson).not.toContain("native-page-1");
+    expect(boundJson).not.toContain("private-native-browser-session");
     const bound = JSON.parse(boundJson) as {
       details: { browserRef: string; pages: Array<{ pageRef: string }> };
     };
     expect(bound.details.browserRef).toMatch(/^cua:v2:browser:/);
     expect(bound.details.pages[0]!.pageRef).toMatch(/^cua:v2:page:/);
+    expect(bound.details.pages).toEqual([
+      { pageRef: expect.any(String), title: "", url: "https://example.com/", active: false },
+    ]);
     const browserRef = bound.details.browserRef;
     const pageRef = bound.details.pages[0]!.pageRef;
 
@@ -80,11 +100,32 @@ describe("cua-computer browser actions", () => {
       JSON.stringify({ action: "get_browser_state", browserRef, pageRef }),
     );
     expect(observedJson).not.toContain("p7:0");
+    expect(observedJson).not.toContain("private-native-browser-session");
     const observed = JSON.parse(observedJson) as {
       observation: { kind: string; observationId: string };
       details: { elements: Array<{ elementRef: string }> };
     };
     expect(observed.observation.kind).toBe("browser");
+    expect(observed.details.elements).toEqual([
+      {
+        elementRef: expect.any(String),
+        kind: "action",
+        node: "BUTTON",
+        label: "Continue",
+        value: "",
+        states: [],
+        frame: "main",
+      },
+      {
+        elementRef: expect.any(String),
+        kind: "action",
+        node: "INPUT",
+        label: "Name",
+        value: "",
+        states: [],
+        frame: "main",
+      },
+    ]);
     const observationId = observed.observation.observationId;
     const [firstElement, secondElement] = observed.details.elements.map(
       (element) => element.elementRef,

--- a/extensions/cua-computer/src/commands.ts
+++ b/extensions/cua-computer/src/commands.ts
@@ -19,7 +19,7 @@ import {
   type CuaDriverSession,
   type CuaToolResult,
 } from "./driver-client.js";
-import { platformActions } from "./driver-result.js";
+import { platformActions, projectedToolDetails } from "./driver-result.js";
 import { createLazyCuaExecutionResources } from "./execution-resources.js";
 import {
   adoptGeneration,
@@ -151,17 +151,7 @@ function assertToolSuccess(result: CuaToolResult, tool: string): CuaToolResult {
 }
 
 function structuredContent(result: CuaToolResult, tool: string): Record<string, unknown> {
-  assertToolSuccess(result, tool);
-  if (!result.structuredJson) {
-    throw new Error(`COMPUTER_DRIVER_ERROR: ${tool} returned no structuredContent`);
-  }
-  try {
-    const value: unknown = JSON.parse(result.structuredJson);
-    if (value && typeof value === "object" && !Array.isArray(value)) {
-      return value as Record<string, unknown>;
-    }
-  } catch {}
-  throw new Error(`COMPUTER_DRIVER_ERROR: ${tool} returned invalid structuredContent`);
+  return projectedToolDetails(assertToolSuccess(result, tool), tool);
 }
 
 function desktopGeometry(result: CuaToolResult): CuaDesktopGeometry {
@@ -497,18 +487,18 @@ export function createCuaComputerProvider(
         if (closing) {
           throw new Error("COMPUTER_DRIVER_UNAVAILABLE: provider execution is closing");
         }
+        if (!isSupportedPlatform) {
+          throw new Error(
+            platform === "darwin"
+              ? `COMPUTER_DRIVER_UNAVAILABLE: cua-computer requires app-provided ${CUA_DRIVER_ENDPOINT_ENV}`
+              : "COMPUTER_DRIVER_UNAVAILABLE: cua-computer supports macOS, Windows, and Linux",
+          );
+        }
       };
       return {
         snapshot: async (paramsJSON, signal) =>
           await queue.run(async () => {
             assertOpen();
-            if (!isSupportedPlatform) {
-              throw new Error(
-                platform === "darwin"
-                  ? `COMPUTER_DRIVER_UNAVAILABLE: cua-computer requires app-provided ${CUA_DRIVER_ENDPOINT_ENV}`
-                  : "COMPUTER_DRIVER_UNAVAILABLE: cua-computer supports macOS, Windows, and Linux",
-              );
-            }
             const params = parseScreenSnapshotParamsJSON(paramsJSON);
             assertPrimaryDisplay(params.screenIndex);
             const format = params.format ?? "jpeg";
@@ -561,13 +551,6 @@ export function createCuaComputerProvider(
         act: async (paramsJSON, signal) =>
           await queue.run(async () => {
             assertOpen();
-            if (!isSupportedPlatform) {
-              throw new Error(
-                platform === "darwin"
-                  ? `COMPUTER_DRIVER_UNAVAILABLE: cua-computer requires app-provided ${CUA_DRIVER_ENDPOINT_ENV}`
-                  : "COMPUTER_DRIVER_UNAVAILABLE: cua-computer supports macOS, Windows, and Linux",
-              );
-            }
             return await handleWindowAct(
               platform,
               executionDriver,

--- a/extensions/cua-computer/src/driver-result.ts
+++ b/extensions/cua-computer/src/driver-result.ts
@@ -121,7 +121,7 @@ export function platformActions(platform: NodeJS.Platform): ComputerUseV2ActionN
   return CUA_COMMON_ACTION_NAMES.filter(
     (action) =>
       platform === "linux" || (action !== "left_mouse_down" && action !== "left_mouse_up"),
-  ) as ComputerUseV2ActionName[];
+  );
 }
 
 function boundedItems<T>(items: T[]): { items: T[]; truncated: number } {
@@ -468,14 +468,8 @@ export function browserBinding(
     if (!parsed.success) {
       return [];
     }
-    return [
-      {
-        pageRef: issuePageRef(state, browserRef, parsed.data.tab_id),
-        ...(parsed.data.title !== undefined ? { title: parsed.data.title } : {}),
-        ...(parsed.data.url !== undefined ? { url: parsed.data.url } : {}),
-        ...(parsed.data.active !== undefined ? { active: parsed.data.active } : {}),
-      },
-    ];
+    const { tab_id: tabId, ...details } = parsed.data;
+    return [{ pageRef: issuePageRef(state, browserRef, tabId), ...details }];
   });
   const bounded = boundedItems(pages);
   return {
@@ -519,37 +513,25 @@ export function browserObservation(
     throw new Error("COMPUTER_DRIVER_ERROR: invalid browser snapshot result");
   }
   const observation = issueBrowserObservation(state, target.browserRef, target.pageRef);
-  const rawRefs = [
-    ...(Array.isArray(structured.refs)
-      ? structured.refs.map((value) => ({ value, kind: "action" }))
-      : []),
-    ...(Array.isArray(structured.content_refs)
-      ? structured.content_refs.map((value) => ({ value, kind: "content" }))
-      : []),
-  ];
+  const elements = [];
   const seen = new Set<string>();
-  const elements = rawRefs.flatMap(({ value, kind }) => {
-    const parsed = NativeBrowserRefSchema.safeParse(value);
-    if (!parsed.success || seen.has(parsed.data.ref)) {
-      return [];
+  for (const [kind, values] of [
+    ["action", structured.refs],
+    ["content", structured.content_refs],
+  ] as const) {
+    if (!Array.isArray(values)) {
+      continue;
     }
-    seen.add(parsed.data.ref);
-    return [
-      {
-        elementRef: issueBrowserElementRef(observation, parsed.data.ref),
-        kind,
-        ...(parsed.data.node !== undefined ? { node: parsed.data.node } : {}),
-        ...(parsed.data.role !== undefined ? { role: parsed.data.role } : {}),
-        ...(parsed.data.label !== undefined ? { label: parsed.data.label } : {}),
-        ...(parsed.data.name !== undefined ? { name: parsed.data.name } : {}),
-        ...(parsed.data.value !== undefined ? { value: parsed.data.value } : {}),
-        ...(parsed.data.states !== undefined ? { states: parsed.data.states } : {}),
-        ...(parsed.data.actions !== undefined ? { actions: parsed.data.actions } : {}),
-        ...(parsed.data.frame !== undefined ? { frame: parsed.data.frame } : {}),
-        ...(parsed.data.visibility !== undefined ? { visibility: parsed.data.visibility } : {}),
-      },
-    ];
-  });
+    for (const value of values) {
+      const parsed = NativeBrowserRefSchema.safeParse(value);
+      if (!parsed.success || seen.has(parsed.data.ref)) {
+        continue;
+      }
+      const { ref, ...details } = parsed.data;
+      seen.add(ref);
+      elements.push({ elementRef: issueBrowserElementRef(observation, ref), kind, ...details });
+    }
+  }
   const boundedElements = elements.slice(0, MAX_BROWSER_ELEMENTS);
   const page =
     structured.page && typeof structured.page === "object" && !Array.isArray(structured.page)

--- a/src/agents/tools/computer-tool-request.ts
+++ b/src/agents/tools/computer-tool-request.ts
@@ -19,22 +19,18 @@ const INPUT_ACTIONS = new Set<ComputerUseV2ActionName>(
   COMPUTER_USE_V2_ACTION_NAMES.filter((action) => !LOCAL_ACTIONS.has(action)),
 );
 
-const COORDINATE_REQUIRED_ACTIONS = new Set<ComputerToolAction>([
-  "left_click",
-  "right_click",
-  "middle_click",
-  "double_click",
-  "triple_click",
-  "mouse_move",
-  "left_click_drag",
-]);
-
 const ELEMENT_TARGETABLE_CLICK_ACTIONS = new Set<ComputerToolAction>([
   "left_click",
   "right_click",
   "middle_click",
   "double_click",
   "triple_click",
+]);
+
+const COORDINATE_REQUIRED_ACTIONS = new Set<ComputerToolAction>([
+  ...ELEMENT_TARGETABLE_CLICK_ACTIONS,
+  "mouse_move",
+  "left_click_drag",
 ]);
 
 const COORDINATE_OPTIONAL_ACTIONS = new Set<ComputerToolAction>([
@@ -44,11 +40,7 @@ const COORDINATE_OPTIONAL_ACTIONS = new Set<ComputerToolAction>([
 ]);
 
 const MODIFIER_TEXT_ACTIONS = new Set<ComputerToolAction>([
-  "left_click",
-  "right_click",
-  "middle_click",
-  "double_click",
-  "triple_click",
+  ...ELEMENT_TARGETABLE_CLICK_ACTIONS,
   "left_mouse_down",
   "left_mouse_up",
   "scroll",
@@ -113,7 +105,7 @@ function requireCoordinate(params: Record<string, unknown>, action: string): [nu
   if (!coordinate) {
     throw new Error(`coordinate [x, y] required for ${action}`);
   }
-  return [coordinate[0], coordinate[1]];
+  return coordinate;
 }
 
 function readModifiers(params: Record<string, unknown>, action: ComputerToolAction) {
@@ -193,7 +185,7 @@ export function buildComputerActParams(params: {
 }): ComputerActParams {
   const { action, input } = params;
   const wire: Record<string, unknown> = { action, executionId: params.executionId };
-  if ((COMPUTER_ACT_V1_ACTION_NAMES as readonly string[]).includes(action)) {
+  if (POINTER_OR_KEYBOARD_ACTIONS.has(action)) {
     wire.screenIndex = params.screenIndex;
     wire.refWidth = params.refWidth ?? COMPUTER_REF_WIDTH;
   }
@@ -263,15 +255,14 @@ export function buildComputerActParams(params: {
       }
       break;
     }
-    case "get_accessibility_tree": {
-      copyOptionalStringParam(wire, input, "windowRef");
-      copyOptionalStringParam(wire, input, "query");
-      copyOptionalIntegerParam(wire, input, "depth", { min: 0, max: 64 });
-      copyOptionalIntegerParam(wire, input, "maxElements", { min: 1, max: 2_000 });
-      break;
-    }
+    case "get_accessibility_tree":
     case "get_window_state": {
-      wire.windowRef = readToolStringParam(input, "windowRef", { required: true });
+      const windowRef = readToolStringParam(input, "windowRef", {
+        required: action === "get_window_state",
+      });
+      if (windowRef !== undefined) {
+        wire.windowRef = windowRef;
+      }
       copyOptionalStringParam(wire, input, "query");
       copyOptionalIntegerParam(wire, input, "depth", { min: 0, max: 64 });
       copyOptionalIntegerParam(wire, input, "maxElements", { min: 1, max: 2_000 });
@@ -492,7 +483,7 @@ export function validateCapabilityBoundInput(params: {
   if ((browserRef || pageRef) && !capabilities?.targets.includes("browser")) {
     throw new Error(`${COMPUTER_CONTRACT_MISMATCH}: selected node has no browser target support`);
   }
-  if (deliveryMode && !capabilities?.deliveryModes.includes(deliveryMode as never)) {
+  if (deliveryMode && !capabilities?.deliveryModes.some((mode) => mode === deliveryMode)) {
     throw new Error(
       `${COMPUTER_CONTRACT_MISMATCH}: selected node does not advertise ${deliveryMode} delivery`,
     );

--- a/src/agents/tools/computer-tool.ts
+++ b/src/agents/tools/computer-tool.ts
@@ -1,11 +1,3 @@
-/**
- * computer built-in tool.
- *
- * Drives a paired desktop node with computer_20251124-style actions: reads
- * reuse the screen.snapshot node command as the reference frame and input is
- * routed through the dangerous computer.act node command. The tool cannot
- * tell how a node fulfills computer.act; macOS nodes are the first fulfiller.
- */
 import crypto from "node:crypto";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -32,7 +24,6 @@ import type {
   ComputerToolAction,
   ComputerToolTransport,
   ResolvedComputerTarget,
-  ScreenshotCapture,
 } from "./computer-tool-shared.js";
 import {
   AFTER_ACTION_SCREENSHOT_DELAY_MS,
@@ -108,15 +99,16 @@ export function createComputerTool(options?: {
     getOperationQueue: () => opQueue,
   });
 
-  const deliverScreenshot = async (params: {
-    capture: ScreenshotCapture;
+  const captureAndDeliverScreenshot = async (params: {
     noteLines: string[];
     resolved: ResolvedComputerTarget;
     action: ComputerToolAction;
     toolCallId: string;
+    signal?: AbortSignal;
   }) => {
+    const capture = await session.captureScreenshot(params.resolved, referenceWidth, params.signal);
     const projected = await projectScreenshotResult({
-      capture: params.capture,
+      capture,
       noteLines: params.noteLines,
       target: params.resolved.target,
       action: params.action,
@@ -125,7 +117,7 @@ export function createComputerTool(options?: {
     });
     const previousFrame = session.refreshUnchangedFrame({
       target: params.resolved.target,
-      capture: params.capture,
+      capture,
       imageIdentity: projected.imageIdentity,
       modelHasVision: options?.modelHasVision,
     });
@@ -147,7 +139,7 @@ export function createComputerTool(options?: {
     }
     session.bindDeliveredFrame({
       resolved: params.resolved,
-      capture: params.capture,
+      capture,
       frameId: projected.frameId,
       toolCallId: params.toolCallId,
       imageIdentity: projected.imageIdentity,
@@ -180,18 +172,9 @@ export function createComputerTool(options?: {
           signal,
         });
 
-        switch (action) {
-          case "screenshot": {
-            const capture = await session.captureScreenshot(resolved, referenceWidth, signal);
-            return await deliverScreenshot({
-              capture,
-              noteLines: [],
-              resolved,
-              action,
-              toolCallId,
-            });
-          }
-          case "wait": {
+        if (action === "screenshot" || action === "wait") {
+          const noteLines: string[] = [];
+          if (action === "wait") {
             const seconds =
               readFiniteNumberParam(params, "duration", {
                 min: 0,
@@ -199,17 +182,15 @@ export function createComputerTool(options?: {
                 message: `duration must be 0-${MAX_WAIT_SECONDS} seconds for wait`,
               }) ?? 1;
             await sleep(Math.round(seconds * 1000), signal);
-            const capture = await session.captureScreenshot(resolved, referenceWidth, signal);
-            return await deliverScreenshot({
-              capture,
-              noteLines: [`waited ${seconds}s`],
-              resolved,
-              action,
-              toolCallId,
-            });
+            noteLines.push(`waited ${seconds}s`);
           }
-          default:
-            break;
+          return await captureAndDeliverScreenshot({
+            noteLines,
+            resolved,
+            action,
+            toolCallId,
+            signal,
+          });
         }
 
         if (!isComputerActAction(action)) {
@@ -243,13 +224,12 @@ export function createComputerTool(options?: {
         }
         try {
           await sleep(AFTER_ACTION_SCREENSHOT_DELAY_MS, signal);
-          const capture = await session.captureScreenshot(resolved, referenceWidth, signal);
-          return await deliverScreenshot({
-            capture,
+          return await captureAndDeliverScreenshot({
             noteLines: [computerActResultText(action, actResult)],
             resolved,
             action,
             toolCallId,
+            signal,
           });
         } catch (err) {
           session.setTarget(resolved.target);

--- a/src/gateway/desktop/attachment.test.ts
+++ b/src/gateway/desktop/attachment.test.ts
@@ -51,7 +51,7 @@ describe("RFB attachments", () => {
     await expect(accepted).resolves.toBeUndefined();
   });
 
-  it("does not claim a stream that closed before observer redemption", async () => {
+  it.each([false, true])("claims only its source's live stream (closed: %s)", async (closed) => {
     const registry = createDesktopSessionRegistry();
     await registry.acquire({
       sourceKey: "node:one",
@@ -60,6 +60,7 @@ describe("RFB attachments", () => {
         attachment: { kind: "tcp", host: "127.0.0.1", port: 5900 },
       }),
     });
+    await registry.activate({ sourceKey: "node:two", ownerEpoch: 1 });
     const stream = new PassThrough();
     const reservation = registry.reserveObserver("node:one", 1);
     if (!reservation) {
@@ -74,14 +75,28 @@ describe("RFB attachments", () => {
     if (!attachment) {
       throw new Error("expected stream attachment");
     }
-    const closed = new Promise<void>((resolve) => {
-      stream.once("close", () => resolve());
-    });
-    stream.destroy();
-    await closed;
+    try {
+      expect(registry.hasPendingStream("node:one", attachment)).toBe(true);
+      expect(registry.hasPendingStream("node:two", attachment)).toBe(false);
+      expect(registry.claimStream("node:two", attachment)).toBeUndefined();
+      expect(stream.destroyed).toBe(false);
+      expect(registry.hasPendingStream("node:one", attachment)).toBe(true);
 
-    expect(registry.claimStream(attachment)).toBeUndefined();
-    await registry.stopAll();
+      if (closed) {
+        const streamClosed = new Promise<void>((resolve) => {
+          stream.once("close", () => resolve());
+        });
+        stream.destroy();
+        await streamClosed;
+      }
+
+      expect(registry.claimStream("node:one", attachment)).toBe(closed ? undefined : stream);
+      expect(registry.hasPendingStream("node:one", attachment)).toBe(false);
+      expect(registry.claimStream("node:one", attachment)).toBeUndefined();
+    } finally {
+      stream.destroy();
+      await registry.stopAll();
+    }
   });
 
   it.each(["acquire", "activate"] as const)("refreshes idle cleanup after %s", async (method) => {

--- a/src/gateway/desktop/node-source.ts
+++ b/src/gateway/desktop/node-source.ts
@@ -6,6 +6,7 @@ import type { NodeRegistry, NodeSession } from "../node-registry.js";
 import { DesktopCredentialsRequiredError } from "./host-source-errors.js";
 import type { NodeDesktopStreamBroker } from "./node-stream-broker.js";
 import { mintDesktopObserverToken } from "./observe-bridge.js";
+import type { RfbPreauthDescriptor } from "./rfb-preauth.js";
 import type { DesktopSessionRegistry } from "./session-registry.js";
 
 type NodeDesktopObserveResult = {
@@ -224,9 +225,9 @@ export function createNodeDesktopService(params: {
         active.stream = attached.stream;
         assertAuthorized();
 
-        let password: string | undefined;
+        let preauth: RfbPreauthDescriptor;
         if (attached.auth === "vnc-password") {
-          password = attached.vncPassword ?? request.credentials?.password;
+          const password = attached.vncPassword ?? request.credentials?.password;
           if (!password) {
             throw new DesktopCredentialsRequiredError(
               "vnc-password",
@@ -234,16 +235,18 @@ export function createNodeDesktopService(params: {
             );
           }
           registerSecretValueForRedaction(password);
+          preauth = { auth: attached.auth, credentials: { password } };
         } else {
           const username = request.credentials?.username?.trim() ?? "";
-          const ardPassword = request.credentials?.password ?? "";
-          if (!username || !ardPassword) {
+          const password = request.credentials?.password ?? "";
+          if (!username || !password) {
             throw new DesktopCredentialsRequiredError(
               "ard-account",
               "macOS account credentials are required to observe this node",
             );
           }
-          registerSecretValueForRedaction(ardPassword);
+          registerSecretValueForRedaction(password);
+          preauth = { auth: attached.auth, credentials: { username, password } };
         }
 
         const attachment = params.desktopRegistry.publishStream({
@@ -256,20 +259,6 @@ export function createNodeDesktopService(params: {
           throw new Error("node desktop session was superseded before publication");
         }
         active.reservationTransferred = true;
-        const credentials = request.credentials;
-        const preauth =
-          attached.auth === "ard-account"
-            ? {
-                auth: attached.auth,
-                credentials: {
-                  username: credentials?.username?.trim() ?? "",
-                  password: credentials?.password ?? "",
-                },
-              }
-            : {
-                auth: attached.auth,
-                credentials: { password: password ?? credentials?.password ?? "" },
-              };
         const minted = mintDesktopObserverToken({
           sourceKey,
           ownerEpoch: session.ownerEpoch,
@@ -279,7 +268,7 @@ export function createNodeDesktopService(params: {
         });
         active.unclaimedTimer = setTimeout(
           () => {
-            if (params.desktopRegistry.hasPendingStream(attachment)) {
+            if (params.desktopRegistry.hasPendingStream(sourceKey, attachment)) {
               void stopActiveStream(active).then(() => session.active.delete(active));
             }
           },

--- a/src/gateway/desktop/node-stream-broker.ts
+++ b/src/gateway/desktop/node-stream-broker.ts
@@ -40,7 +40,6 @@ type TicketEntry = {
   reject: (error: Error) => void;
   timer: ReturnType<typeof setTimeout>;
   redeemed: boolean;
-  settled: boolean;
   socket?: Duplex;
   ws?: WebSocket;
   stopKeepalive?: () => void;
@@ -172,10 +171,9 @@ export function createNodeDesktopStreamBroker(deps: { ttlMs?: number; now?: () =
 
   const rejectTicket = (ticket: string, error: Error): void => {
     const entry = remove(ticket);
-    if (!entry || entry.settled) {
+    if (!entry) {
       return;
     }
-    entry.settled = true;
     entry.reject(error);
     entry.stopKeepalive?.();
     entry.closeTrigger ??= "attach-rejected";
@@ -189,11 +187,10 @@ export function createNodeDesktopStreamBroker(deps: { ttlMs?: number; now?: () =
     metadata: NodeDesktopStreamMetadata | undefined,
   ): void => {
     const entry = remove(ticket);
-    if (!entry || entry.settled) {
+    if (!entry) {
       stream.destroy();
       return;
     }
-    entry.settled = true;
     entry.resolve(stream, metadata);
   };
 
@@ -230,7 +227,6 @@ export function createNodeDesktopStreamBroker(deps: { ttlMs?: number; now?: () =
       reject,
       timer,
       redeemed: false,
-      settled: false,
     });
     return {
       ticket,
@@ -314,20 +310,17 @@ export function createNodeDesktopStreamBroker(deps: { ttlMs?: number; now?: () =
     } catch {
       current = false;
     }
-    if (entry.settled) {
-      return true;
-    }
-    if (!current) {
-      socket.off("error", onSocketError);
-      socket.off("end", onSocketClose);
-      socket.off("close", onSocketClose);
-      writeUnauthorized(socket);
-      rejectTicket(ticket, new Error(`node ${kind} stream ticket binding is stale`));
+    if (tickets.get(ticket) !== entry) {
       return true;
     }
     socket.off("error", onSocketError);
     socket.off("end", onSocketClose);
     socket.off("close", onSocketClose);
+    if (!current) {
+      writeUnauthorized(socket);
+      rejectTicket(ticket, new Error(`node ${kind} stream ticket binding is stale`));
+      return true;
+    }
     try {
       wss.handleUpgrade(req, socket, head, (ws) => {
         entry.socket = undefined;

--- a/src/gateway/desktop/observe-bridge.ts
+++ b/src/gateway/desktop/observe-bridge.ts
@@ -188,7 +188,9 @@ export function handleDesktopObserveUpgrade(
   }
   desktopObserverWss.handleUpgrade(req, socket, head, (ws) => {
     const claimedStream =
-      entry.attachment.kind === "stream" ? deps.registry.claimStream(entry.attachment) : undefined;
+      entry.attachment.kind === "stream"
+        ? deps.registry.claimStream(entry.sourceKey, entry.attachment)
+        : undefined;
     if (entry.attachment.kind === "stream" && !claimedStream) {
       ws.close(1013, "desktop stream unavailable");
       return;

--- a/src/gateway/desktop/session-registry.ts
+++ b/src/gateway/desktop/session-registry.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { createDeferredCore } from "../../shared/deferred.js";
+import { createDeferredCore, type Deferred } from "../../shared/deferred.js";
 import type { ConnectedRfbStream, DesktopRfbAttachment } from "./attachment.js";
 
 const DEFAULT_LINGER_MS = 60_000;
@@ -48,9 +48,7 @@ type DesktopSessionEntry = {
   ownerEpoch: number;
   initialization?: Promise<void>;
   stopPromise?: Promise<void>;
-  ready: Promise<DesktopSessionStartResult>;
-  resolveReady: (result: DesktopSessionStartResult) => void;
-  rejectReady: (error: Error) => void;
+  ready: Deferred<DesktopSessionStartResult>;
   readySettled: boolean;
   observers: Set<ObserverEntry>;
   observerReservations: Set<symbol>;
@@ -120,7 +118,7 @@ export function createDesktopSessionRegistry(
       entry.observerReservations.clear();
       if (!entry.readySettled) {
         entry.readySettled = true;
-        entry.rejectReady(new DesktopSessionStoppedError());
+        entry.ready.reject(new DesktopSessionStoppedError());
       }
       // Teardown brackets initialization so a source can stop the currently published
       // transport, then dispose anything initialization publishes before it settles.
@@ -148,7 +146,7 @@ export function createDesktopSessionRegistry(
   };
 
   const waitForReady = async (entry: DesktopSessionEntry): Promise<DesktopSessionStartResult> => {
-    const result = await entry.ready;
+    const result = await entry.ready.promise;
     // Every observation gets an idle attachment window, including same-epoch reuse.
     scheduleLinger(entry);
     return result;
@@ -170,19 +168,12 @@ export function createDesktopSessionRegistry(
       }
     }
 
-    let resolveReady!: (result: DesktopSessionStartResult) => void;
-    let rejectReady!: (error: Error) => void;
-    const ready = new Promise<DesktopSessionStartResult>((resolve, reject) => {
-      resolveReady = resolve;
-      rejectReady = reject;
-    });
-    void ready.catch(() => undefined);
+    const ready = createDeferredCore<DesktopSessionStartResult>();
+    void ready.promise.catch(() => undefined);
     const entry: DesktopSessionEntry = {
       sourceKey: request.sourceKey,
       ownerEpoch: request.ownerEpoch,
       ready,
-      resolveReady,
-      rejectReady,
       readySettled: false,
       observers: new Set(),
       observerReservations: new Set(),
@@ -204,12 +195,12 @@ export function createDesktopSessionRegistry(
         return;
       }
       entry.readySettled = true;
-      entry.resolveReady(result);
+      entry.ready.resolve(result);
     })();
     void entry.initialization.catch((error: unknown) => {
       if (!entry.readySettled) {
         entry.readySettled = true;
-        entry.rejectReady(error instanceof Error ? error : new Error("Desktop session failed"));
+        entry.ready.reject(error instanceof Error ? error : new Error("Desktop session failed"));
       }
       void stopEntry(entry);
     });
@@ -315,13 +306,11 @@ export function createDesktopSessionRegistry(
       entry.stopped ||
       entry.ownerEpoch !== params.ownerEpoch ||
       params.reservation.sourceKey !== params.sourceKey ||
-      params.reservation.ownerEpoch !== params.ownerEpoch
+      params.reservation.ownerEpoch !== params.ownerEpoch ||
+      params.stream.destroyed ||
+      params.stream.readableEnded ||
+      params.stream.writableEnded
     ) {
-      params.reservation.release();
-      params.stream.destroy();
-      return undefined;
-    }
-    if (params.stream.destroyed || params.stream.readableEnded || params.stream.writableEnded) {
       params.reservation.release();
       params.stream.destroy();
       return undefined;
@@ -338,31 +327,24 @@ export function createDesktopSessionRegistry(
     return { kind: "stream", streamId } as const;
   }
 
-  function claimStream(attachment: { kind: "stream"; streamId: string }) {
-    for (const entry of entries.values()) {
-      const pending = entry.pendingStreams.get(attachment.streamId);
-      if (!pending) {
-        continue;
-      }
-      entry.pendingStreams.delete(attachment.streamId);
-      pending.reservation.release();
-      const stream = pending.stream;
-      if (stream.destroyed || stream.readableEnded || stream.writableEnded) {
-        stream.destroy();
-        return undefined;
-      }
-      return stream;
+  function claimStream(sourceKey: string, attachment: { kind: "stream"; streamId: string }) {
+    const entry = entries.get(sourceKey);
+    const pending = entry?.pendingStreams.get(attachment.streamId);
+    if (!entry || !pending) {
+      return undefined;
     }
-    return undefined;
+    entry.pendingStreams.delete(attachment.streamId);
+    pending.reservation.release();
+    const stream = pending.stream;
+    if (stream.destroyed || stream.readableEnded || stream.writableEnded) {
+      stream.destroy();
+      return undefined;
+    }
+    return stream;
   }
 
-  function hasPendingStream(attachment: { kind: "stream"; streamId: string }): boolean {
-    for (const entry of entries.values()) {
-      if (entry.pendingStreams.has(attachment.streamId)) {
-        return true;
-      }
-    }
-    return false;
+  function hasPendingStream(sourceKey: string, attachment: { kind: "stream"; streamId: string }) {
+    return entries.get(sourceKey)?.pendingStreams.has(attachment.streamId) ?? false;
   }
 
   async function stop(sourceKey: string, ownerEpoch?: number): Promise<void> {

--- a/src/gateway/worker-environments/node-desktop-carrier.ts
+++ b/src/gateway/worker-environments/node-desktop-carrier.ts
@@ -46,9 +46,7 @@ type ActiveNodeDesktopStream = {
 type ActiveNodeDesktopLaunch = {
   binding: NodeDesktopBinding;
   app: WorkerDesktopApp;
-  token: object;
   controller: AbortController;
-  invocation?: ReturnType<NodeWorkerSupervisorTransport["invoke"]>;
   operation: Promise<void>;
 };
 
@@ -361,7 +359,7 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
       });
       active.unclaimedTimer = setTimeout(
         () => {
-          if (options.desktopRegistry.hasPendingStream(attachment)) {
+          if (options.desktopRegistry.hasPendingStream(binding.environmentId, attachment)) {
             void stopStream(active);
           }
         },
@@ -394,19 +392,15 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
     }
     const app = structuredClone(advertisedApp);
     const key = launchKey(binding, app);
-    const current = activeLaunches.get(key);
-    if (current?.binding.ownerEpoch === binding.ownerEpoch && isDeepStrictEqual(current.app, app)) {
-      return current.operation;
+    const previous = activeLaunches.get(key);
+    if (
+      previous?.binding.ownerEpoch === binding.ownerEpoch &&
+      isDeepStrictEqual(previous.app, app)
+    ) {
+      return previous.operation;
     }
-    const previous = current;
-    const token = {};
     const controller = new AbortController();
-    let start!: () => void;
-    const startGate = new Promise<void>((resolve) => {
-      start = resolve;
-    });
-    const operation = (async () => {
-      await startGate;
+    const operation = Promise.resolve().then(async () => {
       await claimOwner(binding);
       if (previous) {
         previous.controller.abort(
@@ -420,11 +414,10 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
         throw new Error("Worker environment node desktop runtime is unavailable");
       }
       const node = await findCurrentNode(binding, capturedRuntime, controller.signal);
-      const active = activeLaunches.get(key);
-      if (active?.token !== token) {
+      if (activeLaunches.get(key) !== entry) {
         throw new Error("Worker environment node desktop launch owner was replaced");
       }
-      active.invocation = capturedRuntime.transport.invoke({
+      const result = await capturedRuntime.transport.invoke({
         node,
         command: NODE_WORKER_DESKTOP_LAUNCH_COMMAND,
         params: app,
@@ -432,22 +425,19 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
         signal: controller.signal,
         isDispatchAuthorized: () => bindingIsCurrent(binding, capturedRuntime, node),
       });
-      const result = await active.invocation;
       requireLaunchReady(result);
       if (!bindingIsCurrent(binding, capturedRuntime, node)) {
         throw new Error("Worker environment node desktop launch owner changed");
       }
-    })();
+    });
     const entry: ActiveNodeDesktopLaunch = {
       binding,
       app,
-      token,
       controller,
       operation,
     };
     // Stateful launch is visible to teardown before node discovery or dispatch begins.
     activeLaunches.set(key, entry);
-    start();
     void operation
       .finally(() => {
         if (activeLaunches.get(key) === entry) {

--- a/ui/src/components/desktop/desktop-client.test.ts
+++ b/ui/src/components/desktop/desktop-client.test.ts
@@ -130,13 +130,13 @@ describe("DesktopClient", () => {
       credentials: { username: "operator", password: "secret" },
     });
 
-    handle.setScaleViewport?.(true);
+    handle.setScaleViewport(true);
     expect(instances[0]?.scaleViewport).toBe(true);
-    handle.sendKeyboardEvent?.(new KeyboardEvent("keydown", { key: "k", code: "KeyK" }));
+    handle.sendKeyboardEvent(new KeyboardEvent("keydown", { key: "k", code: "KeyK" }));
     expect(onKeyDown).toHaveBeenCalledOnce();
     expect((onKeyDown.mock.calls[0]?.[0] as KeyboardEvent | undefined)?.key).toBe("k");
-    handle.sendText?.("m");
-    handle.sendBackspace?.();
+    handle.sendText("m");
+    handle.sendBackspace();
     expect(onKeyDown.mock.calls.map((call) => (call[0] as KeyboardEvent | undefined)?.key)).toEqual(
       ["k", "m", "Backspace"],
     );
@@ -206,7 +206,7 @@ describe("DesktopClient", () => {
       target,
     });
 
-    handle.sendText?.(text);
+    handle.sendText(text);
 
     expect(events.map(({ type, key, code }) => ({ type, key, code }))).toEqual(
       keys.map((key) => ({ type: "keydown", key, code: "Unidentified" })),

--- a/ui/src/components/desktop/desktop-client.ts
+++ b/ui/src/components/desktop/desktop-client.ts
@@ -26,10 +26,10 @@ type DesktopConnectOptions = {
 export type DesktopConnectionHandle = {
   disconnect(): void;
   disableInput(): void;
-  sendBackspace?(): void;
-  sendKeyboardEvent?(event: KeyboardEvent): void;
-  sendText?(text: string): void;
-  setScaleViewport?(enabled: boolean): void;
+  sendBackspace(): void;
+  sendKeyboardEvent(event: KeyboardEvent): void;
+  sendText(text: string): void;
+  setScaleViewport(enabled: boolean): void;
 };
 
 type RfbClient = EventTarget & {

--- a/ui/src/components/desktop/desktop-mobile-keyboard.ts
+++ b/ui/src/components/desktop/desktop-mobile-keyboard.ts
@@ -1,3 +1,5 @@
+import type { DesktopConnectionHandle } from "./desktop-client.ts";
+
 /**
  * Mobile browsers only report composed text through an input's value, so the desktop document
  * keeps a padded sentinel in the field and derives key events from how that value changed.
@@ -5,12 +7,7 @@
 const MOBILE_KEYBOARD_SENTINEL = "________________";
 
 type MobileKeyboardOptions = {
-  /** Live RFB handle, or null while disconnected; absent senders mean a view-only transport. */
-  connection: () => {
-    sendBackspace?: () => void;
-    sendKeyboardEvent?: (event: KeyboardEvent) => void;
-    sendText?: (text: string) => void;
-  } | null;
+  connection: () => DesktopConnectionHandle | null;
   controlling: () => boolean;
   input: () => HTMLTextAreaElement | null | undefined;
 };
@@ -38,7 +35,7 @@ export class DesktopMobileKeyboard {
 
   handleKeyboardEvent(event: KeyboardEvent): void {
     const connection = this.options.connection();
-    if (!this.options.controlling() || !connection?.sendKeyboardEvent) {
+    if (!this.options.controlling() || !connection) {
       return;
     }
     connection.sendKeyboardEvent(event);
@@ -62,9 +59,9 @@ export class DesktopMobileKeyboard {
       prefixLength += 1;
     }
     for (let index = this.value.length - prefixLength; index > 0; index -= 1) {
-      connection?.sendBackspace?.();
+      connection?.sendBackspace();
     }
-    connection?.sendText?.(nextValue.slice(prefixLength));
+    connection?.sendText(nextValue.slice(prefixLength));
     // Refill once the field drifts outside the range that keeps further deletes reportable.
     if (nextValue.length < 1 || nextValue.length > MOBILE_KEYBOARD_SENTINEL.length * 2) {
       this.reset(input);

--- a/ui/src/components/desktop/desktop-panel.test.ts
+++ b/ui/src/components/desktop/desktop-panel.test.ts
@@ -33,6 +33,18 @@ function createPanel() {
   return document.createElement("openclaw-desktop-panel");
 }
 
+function createConnectionHandle(overrides: Partial<DesktopConnectionHandle> = {}) {
+  return {
+    disconnect: vi.fn(),
+    disableInput: vi.fn(),
+    sendBackspace: vi.fn(),
+    sendKeyboardEvent: vi.fn(),
+    sendText: vi.fn(),
+    setScaleViewport: vi.fn(),
+    ...overrides,
+  } satisfies DesktopConnectionHandle;
+}
+
 function clickPanelButton(
   panel: DesktopPanelElement,
   selector = ".desktop-environment button",
@@ -102,7 +114,7 @@ describe("embedded desktop panel presentation", () => {
     const disconnect = vi.fn();
     const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
       options.onConnect?.();
-      return { disconnect, disableInput: vi.fn() };
+      return createConnectionHandle({ disconnect });
     });
     const panel = createPanel();
     panel.client = createGatewayClient(request).client;
@@ -196,7 +208,7 @@ describe("embedded desktop panel presentation", () => {
       const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
         expect(options.credentials).toBeUndefined();
         options.onConnect?.();
-        return { disconnect, disableInput: vi.fn() };
+        return createConnectionHandle({ disconnect });
       });
       const panel = createPanel();
       panel.client = gateway.client;
@@ -295,7 +307,7 @@ describe("embedded desktop panel presentation", () => {
     const disconnect = vi.fn();
     const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
       options.onConnect?.();
-      return { disconnect, disableInput: vi.fn() };
+      return createConnectionHandle({ disconnect });
     });
     const panel = createPanel();
     panel.client = gateway.client;
@@ -348,7 +360,7 @@ describe("embedded desktop panel presentation", () => {
       const disconnect = vi.fn();
       const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
         options.onConnect?.();
-        return { disconnect, disableInput: vi.fn() };
+        return createConnectionHandle({ disconnect });
       });
       const panel = createPanel();
       panel.client = gateway.client;
@@ -458,7 +470,7 @@ describe("embedded desktop panel presentation", () => {
     const disconnect = vi.fn();
     const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
       options.onConnect?.();
-      return { disconnect, disableInput: vi.fn() };
+      return createConnectionHandle({ disconnect });
     });
     const panel = createPanel();
     panel.client = gateway.client;
@@ -547,7 +559,7 @@ describe("embedded desktop panel presentation", () => {
       const disconnect = vi.fn();
       const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
         options.onConnect?.();
-        return { disconnect, disableInput: vi.fn() };
+        return createConnectionHandle({ disconnect });
       });
       const gateway = createGatewayClient(request);
       const panel = createPanel();
@@ -661,8 +673,8 @@ describe("embedded desktop panel presentation", () => {
     async ({ initialControl, handleTiming }) => {
       const observe = createDeferred<unknown>();
       const replacement = createDeferred<DesktopConnectionHandle>();
-      const previous = { disconnect: vi.fn(), disableInput: vi.fn(), sendKeyboardEvent: vi.fn() };
-      const next = { disconnect: vi.fn(), disableInput: vi.fn(), sendKeyboardEvent: vi.fn() };
+      const previous = createConnectionHandle();
+      const next = createConnectionHandle();
       let pending: Parameters<DesktopClient["connect"]>[0] | undefined;
       const request = vi.fn(async (method: string, params?: { control?: boolean }) => {
         if (method === "environments.list") {
@@ -774,8 +786,8 @@ describe("embedded desktop panel presentation", () => {
     "unmount",
   ] as const)("releases the retained viewer and pending replacement on %s", async (outcome) => {
     const observe = createDeferred<unknown>();
-    const previous = { disconnect: vi.fn(), disableInput: vi.fn() };
-    const next = { disconnect: vi.fn(), disableInput: vi.fn() };
+    const previous = createConnectionHandle();
+    const next = createConnectionHandle();
     let pending: Parameters<DesktopClient["connect"]>[0] | undefined;
     const request = vi.fn(async (method: string, params?: { control?: boolean }) => {
       if (method === "environments.list") {
@@ -914,7 +926,7 @@ describe("embedded desktop panel presentation", () => {
     const disconnect = vi.fn();
     const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
       options.onConnect?.();
-      return { disconnect, disableInput: vi.fn() };
+      return createConnectionHandle({ disconnect });
     });
     const panel = createPanel();
     panel.client = createGatewayClient(request).client;
@@ -963,7 +975,7 @@ describe("embedded desktop panel presentation", () => {
       }
       return observe;
     });
-    const connect = vi.fn(async () => ({ disconnect: vi.fn(), disableInput: vi.fn() }));
+    const connect = vi.fn(async () => createConnectionHandle());
     const panel = createPanel();
     panel.client = createGatewayClient(request).client;
     panel.available = true;

--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -612,7 +612,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
   }
 
   override render() {
-    if (!this.available) {
+    if (!this.available || (!this.documentMode && !this.embedded && !this.dockLayout.open)) {
       return nothing;
     }
     const notice = renderDesktopNotice(
@@ -652,17 +652,6 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
         void this.connectEnvironment(this.environmentId, this.controlling);
       },
     });
-    const connection = renderDesktopConnection({
-      state: this.state,
-      controlling: this.controlling,
-      desktopApps: this.desktopApps,
-      environmentSelected: this.environmentId !== null,
-      launchingApp: this.launchingApp,
-      showApps: this.source?.kind === "environment",
-      onLaunch: (app) => void this.launchApp(app),
-      onTakeControl: () => void this.connectEnvironment(this.environmentId, true),
-      onDisconnect: () => this.returnToPicker(),
-    });
     if (this.documentMode) {
       return renderDesktopDocumentView({
         state: this.state,
@@ -679,14 +668,22 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
         onKeyboardInput: (event) => this.mobileKeyboard.handleInput(event),
         onScaleToggle: () => {
           this.scaleViewport = !this.scaleViewport;
-          this.connection.handle?.setScaleViewport?.(this.scaleViewport);
+          this.connection.handle?.setScaleViewport(this.scaleViewport);
         },
         onClose: () => this.onDocumentClose?.(),
       });
     }
-    if (!this.embedded && !this.dockLayout.open) {
-      return nothing;
-    }
+    const connection = renderDesktopConnection({
+      state: this.state,
+      controlling: this.controlling,
+      desktopApps: this.desktopApps,
+      environmentSelected: this.environmentId !== null,
+      launchingApp: this.launchingApp,
+      showApps: this.source?.kind === "environment",
+      onLaunch: (app) => void this.launchApp(app),
+      onTakeControl: () => void this.connectEnvironment(this.environmentId, true),
+      onDisconnect: () => this.returnToPicker(),
+    });
     const dock = this.dockLayout.dock;
     const style =
       this.embedded || this.fullscreenMode.active

--- a/ui/src/e2e/desktop-document-mode.e2e.test.ts
+++ b/ui/src/e2e/desktop-document-mode.e2e.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "../../../src/gateway/control-ui-bootstrap-contract.js";
+import type { DesktopClient } from "../components/desktop/desktop-client.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import {
@@ -35,27 +36,11 @@ const gatewayEnvironment = {
   desktop: true,
 };
 
-type FakeDesktopConnectOptions = {
-  onConnect?: () => void;
-  scaleViewport?: boolean;
-  target: HTMLElement;
-  viewOnly: boolean;
-};
-
 async function installDesktopClientFake(panel: import("playwright").Locator) {
   await panel.evaluate((element) => {
     (
       element as HTMLElement & {
-        desktopClientFactory: () => {
-          connect(options: FakeDesktopConnectOptions): Promise<{
-            disconnect(): void;
-            disableInput(): void;
-            sendBackspace(): void;
-            sendKeyboardEvent(event: KeyboardEvent): void;
-            sendText(text: string): void;
-            setScaleViewport(enabled: boolean): void;
-          }>;
-        };
+        desktopClientFactory: () => Pick<DesktopClient, "connect">;
       }
     ).desktopClientFactory = () => ({
       async connect(options) {

--- a/ui/src/e2e/desktop-rfb-test-support.ts
+++ b/ui/src/e2e/desktop-rfb-test-support.ts
@@ -1,5 +1,6 @@
 import { deflateSync } from "node:zlib";
 import type { Locator, Page } from "playwright";
+import type { DesktopClient } from "../components/desktop/desktop-client.ts";
 
 export function createRfbClipboardProvide(format: 1 | 2): number[] {
   const text = Buffer.from("Clipboard continuity: Café Ω\0");
@@ -34,12 +35,7 @@ export async function installDesktopClientFake(panel: Locator): Promise<void> {
   await panel.evaluate((element) => {
     (
       element as HTMLElement & {
-        desktopClientFactory: () => {
-          connect(options: { credentials?: { username?: string; password?: string } }): Promise<{
-            disconnect(): void;
-            disableInput(): void;
-          }>;
-        };
+        desktopClientFactory: () => Pick<DesktopClient, "connect">;
       }
     ).desktopClientFactory = () => ({
       async connect(options) {
@@ -47,6 +43,10 @@ export async function installDesktopClientFake(panel: Locator): Promise<void> {
         element.dataset.usedCredentials = options.credentials?.password ? "true" : "false";
         return {
           disableInput() {},
+          sendBackspace() {},
+          sendKeyboardEvent() {},
+          sendText() {},
+          setScaleViewport() {},
           disconnect() {
             element.dataset.disconnectCount = String(
               Number(element.dataset.disconnectCount ?? "0") + 1,


### PR DESCRIPTION
Related: #138142, #138173, #138230, #138271, #138209

## What Problem This Solves

Maintainer-requested cleanup of the cloud desktop / CUA integration after the recent launch, flow-control, coordinate and native lifecycle repairs. The same ownership and projection facts were represented repeatedly: observer lookups scanned unrelated desktops, browser output repeated its schema allowlist, launch entries had a second identity token, and native cleanup parsed an entire process environment only to choose a log message.

## Why This Change Was Made

Keep each decision with its existing owner and remove the duplicate path:

- Pass the already-known source key into pending-stream lookup and redemption; preserve single use, owner epochs, cancellation, backpressure and control takeover.
- Use ticket-map and launch-entry identity directly, use the existing deferred helper for readiness, and normalize validated VNC/ARD credentials once. Publish launch ownership synchronously before its deferred operation begins.
- Reuse CUA result parsing and schema-projected browser metadata, preserving opaque references, ordered deduplication, bounds, unknown-field exclusion, and empty/false values.
- Share screenshot capture/delivery and pointer action families in the computer tool. Keep frame binding, capability validation, cancellation and post-action screenshot failure behavior intact.
- Share the actual desktop connection contract with mobile input; skip construction of discarded hidden/docked templates. Preserve noVNC's UTF-16 keyboard contract.
- Delete the native process-environment parser and redundant diagnostic branch. All directory ownership, inode/PID/executable checks and signal ordering remain; the daemon launch environment is unchanged.

Net **199 production lines removed**, **53 test/support lines added**, plus three shrink-only assertion-baseline counts for four removed assertions. Existing cancellation queues and timing guards were deliberately retained. No new configuration, environment variables, persistence, protocol, dependencies or permission surfaces.

## User Impact

No intentional visual or command behavior change. The desktop integration has fewer competing representations to maintain, and stream lookup work no longer grows with unrelated desktop sessions. Native cleanup no longer reads process environments for a diagnostic message.

## Evidence

- 420 focused tool, CUA plugin, desktop transport and worker-carrier tests passed across 33 files. These include real WebSocket/RFB owner-boundary tests, stale/replayed ticket and cancellation cases, and portal transport siblings.
- 58 desktop unit tests and 43 Chromium desktop E2E flows passed, including real noVNC takeover, launch completion across source changes, mobile input, document mode and fullscreen.
- The final launch scheduling simplification passed all 14 carrier tests again. No behavioral cases or assertions were deleted.
- Independent Codex review of the complete staged candidate and owner/caller/test context found no actionable P0–P2 findings.
- Changed-code type checks (core, core tests, UI, plugins and plugin tests), lint, formatting, dead-code and boundary checks passed. The local gate required the expected assertion-baseline shrink, then caught an IIFE definite-assignment error; the final code removes the manual start gate instead of adding a cast.
- The broad local macOS tooling gate remains recorded as failed: its 152-case elevation-host suite passed, then 564 of 566 packaging/tooling cases passed, with two unchanged foreign PE/COFF artifact fixtures exceeding their 20-second deadline. One timed-out process group could not be verified closed at teardown; a subsequent process inspection found no survivors, and its evidence/claim was retained. No timeout or guard was weakened. Eleven relevant fixture/managed-process inputs are byte-identical across the cleanup and main refresh. One complete replay in the original eight-file order passed all 566 tests; PE/COFF completed in 2.411s/1.962s with unchanged source, deadlines, concurrency and environment. The original delay was before native classification, but its exact phase/cause remains unproven; no repair is claimed. All eight remaining post-macOS guards passed separately.
- [Required PR CI](https://github.com/openclaw/openclaw/actions/runs/33933257713/attempts/2) completed successfully: 126 successful jobs, 10 skipped; 124 successes carry forward from attempt 1. The native retry passed 1,629 shared Swift tests across 124 suites, 2,109 app Swift tests across 220 suites, the existing CUA lifecycle suite including all six stale-startup variants, and both separately isolated AppState tests. Shared XCTest had 60 cases with two skips and no failures; app XCTest passed four cases, and the separate health render passed. Actual native source/workflow was merge `843c947819e62e34d67e4927bda5767c8c37eef2`, with parents `09aeb635e75863525e002138d1611b101df05af9` and the exact reviewed head `93adf446607b9ffff9586eaa452dbb2f921a0c1e`; all 19 changed code/test blobs match. Required gate `101222299141` succeeded under GitHub Actions app `15368` on that PR head.
- Hosted attempt 1 failed in one unchanged shared Swift listener-startup fixture, before authentication/CUA, so app tests were skipped then. The existing workflow selects serial shared-package execution on retry; the same case passed in 0.664s. No timeout, source or workflow was changed. This recovery is not a repair of the original parallel fixture failure. Native CUA coordinator tests use injected lifecycle probes; these are not a live bundled-daemon deployment claim.
- The separate [Shared OpenClawKit Periphery workflow](https://github.com/openclaw/openclaw/actions/runs/33933257703) still has its two advisory scans queued; these are not included in the successful CI counts. Live main rules require only `openclaw/ci-gate` from GitHub Actions, and the normal pinned merge does not bypass that gate.
- The initial main refresh was conflict-free. Every changed code/test file remained byte-identical; only unrelated assertion-baseline entries advanced with main.

A bounded synthetic benchmark used the exact pre-refactor and candidate registry sources, seven measured rounds plus warmup, and the last registered source. At 1 / 100 / 1,000 sources, median pending lookup was **9.9 / 385.1 / 5,390.2 ns before** and **15.3 / 16.6 / 16.6 ns after**. Stream claims were **276.3 / 759.5 / 7,826.9 ns before** and **201.5 / 194.0 / 280.4 ns after**. All 98,352 streams were destroyed and all 48 registries stopped. Setup/cleanup are excluded; the single-source pending lookup has a small overhead. This is a synthetic complexity check, not production or end-to-end WebVNC latency.

Existing launch failure and recovery behavior after the refactor (both captures are from the candidate's synthetic browser flow; these are not before/after source-revision comparisons):

| Launch failure remains visible | Successful retry clears the error |
| --- | --- |
| ![Launch failure](https://github.com/user-attachments/assets/3a24ece0-b606-43c4-aaa3-39a3628cdef1) | ![Launch recovery](https://github.com/user-attachments/assets/23471efd-c6cc-4da9-a995-348ea364b5be) |

Unchanged mobile control toolbar:

![Mobile desktop controls](https://github.com/user-attachments/assets/16c80fda-9ffe-4aa9-a790-10cfd46cee1c)

The AWS Mac and its WebVNC rig are retained without redeploying its signed app or Gateway during this cleanup. Native verification belongs to the exact candidate's hosted macOS suite; no new live Windows/native-coordinate or deployment claim is made. This PR does not claim to repair the earlier translation failures, unexplained HTTP-fixture timeout, or historical WebVNC 1006 disconnect.

## Review Disposition

Addressing [ClawSweeper’s reviewed-head comment](https://github.com/openclaw/openclaw/pull/138728#issuecomment-5548178212), including its Rank-up move:

- **Dependency verification completed.** I directly inspected the installed, pinned sources and verified byte-for-byte equality with upstream. [Zod 4.4.3 object parsing](https://github.com/colinhacks/zod/blob/v4.4.3/packages/zod/src/v4/core/schemas.ts#L1938) constructs a fresh result from declared keys and returns without copying unknown keys when there is no catchall; the JIT path preserves the same declared-key projection/order. Both browser schemas are ordinary `z.object` shapes without catchalls. Existing browser-action boundary coverage was extended for unknown fields, opaque references, empty strings, false values and ordered deduplication.
- **Keyboard contract verified and preserved.** [noVNC 1.7.0 keyboard handling](https://github.com/novnc/noVNC/blob/v1.7.0/core/input/keyboard.js#L125) translates `Unidentified` input to balanced press/release events; [its keysym conversion](https://github.com/novnc/noVNC/blob/v1.7.0/core/input/util.js#L178) rejects non-special keys whose JavaScript length is not one. The existing UTF-16 code-unit loop remains unchanged. The repository patch affects clipboard framing only; both inspected input modules match upstream exactly.
- **No stored-data change.** The `commands.ts` hunk delegates parsing of the same driver `structuredJson` response to the existing helper and consolidates the same platform checks. It does not change a database, schema, migration, stored representation or serialized request/response contract. The review’s persistent-model flag is therefore not applicable; no migration or new storage design is needed.
- **Confidence disposition.** No actionable code finding was reported. The concrete reviewer dependency-access gap is closed by the direct checks above; the independent full-context Codex review is clean. The generated requirement that ClawSweeper itself reach high confidence is not an enforced repository approval rule. The required CI gate is now green on the reviewed head; no admin/review bypass is being used. A later automatic ClawSweeper review is in progress; the completed review is less than 12 hours old and its concrete items are addressed here.

Named follow-up: investigate parallel `NativeGatewayWebSocketFixture` listener-readiness timeout. The unchanged fixture checks its deadline before sampling listener state; the original log cannot distinguish delayed readiness from late MainActor resumption. Candidate and actual tested-merge fixture/test blobs are identical. Retain that failure and diagnostic ordering; do not change token logic, increase timeouts, or claim this cleanup repaired it.
