### PR TITLE
fix(doctor): preserve enabled skills during automatic updates

### DIFF
--- a/src/commands/doctor-skills.test.ts
+++ b/src/commands/doctor-skills.test.ts
@@ -1,9 +1,9 @@
 // Doctor skills tests cover skill install checks, status summaries, and repair guidance.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEmptyInstallChecks } from "../cli/requirements-test-fixtures.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SkillStatusEntry, SkillStatusReport } from "../skills/discovery/status.js";
-import type { DoctorPrompter } from "./doctor-prompter.js";
+import { createDoctorPrompter, type DoctorPrompter } from "./doctor-prompter.js";
 import {
   collectUnavailableAgentSkills,
   disableUnavailableSkillsInConfig,
@@ -77,6 +77,13 @@ function createPrompter(): DoctorPrompter {
   };
 }
 
+function createRepairPrompter() {
+  return createDoctorPrompter({
+    runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    options: { repair: true, nonInteractive: true },
+  });
+}
+
 async function runSkillDoctor(skills: SkillStatusEntry[]) {
   mocks.note.mockClear();
   mocks.buildWorkspaceSkillStatus.mockReturnValue(createReport(skills));
@@ -88,6 +95,49 @@ async function runSkillDoctor(skills: SkillStatusEntry[]) {
 }
 
 describe("doctor skills", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    { mode: "update", update: true, available: false, expectedEnabled: true },
+    { mode: "standalone repair", update: false, available: false, expectedEnabled: false },
+    {
+      mode: "update with an available skill",
+      update: true,
+      available: true,
+      expectedEnabled: true,
+    },
+  ])("honors skill-repair authority for $mode", async ({ update, available, expectedEnabled }) => {
+    vi.stubEnv("OPENCLAW_UPDATE_IN_PROGRESS", update ? "1" : undefined);
+    mocks.buildWorkspaceSkillStatus.mockReturnValue(
+      createReport([
+        createSkill({
+          name: "optional-tool",
+          eligible: available,
+          missing: {
+            bins: available ? [] : ["missing-tool"],
+            anyBins: [],
+            env: [],
+            config: [],
+            os: [],
+          },
+        }),
+      ]),
+    );
+    const cfg: OpenClawConfig = {
+      skills: { entries: { "optional-tool": { enabled: true, env: { EXISTING: "1" } } } },
+    };
+
+    const next = await maybeRepairSkillReadiness({ cfg, prompter: createRepairPrompter() });
+
+    expect(next.skills?.entries?.["optional-tool"]).toEqual({
+      enabled: expectedEnabled,
+      env: { EXISTING: "1" },
+    });
+    expect(cfg.skills?.entries?.["optional-tool"]?.enabled).toBe(true);
+  });
+
   it("collects only unavailable skills that this agent is allowed to use", () => {
     const unavailable = createSkill({
       name: "missing-bin",
@@ -190,6 +240,7 @@ describe("doctor skills", () => {
   });
 
   it("does not offer a global disable when another agent can use the skill", async () => {
+    vi.stubEnv("OPENCLAW_UPDATE_IN_PROGRESS", undefined);
     mocks.note.mockClear();
     mocks.buildWorkspaceSkillStatus.mockClear();
     const healthy = createSkill({ name: "shared", skillKey: "shared" });
@@ -202,8 +253,6 @@ describe("doctor skills", () => {
     mocks.buildWorkspaceSkillStatus.mockImplementation((_workspaceDir, { agentId }) =>
       createReport(agentId === "secondary" ? [missing] : [healthy], agentId),
     );
-    const confirmAutoFix = vi.fn(async () => true);
-    const prompter = { ...createPrompter(), confirmAutoFix };
     const cfg: OpenClawConfig = {
       agents: {
         list: [
@@ -211,12 +260,13 @@ describe("doctor skills", () => {
           { id: "secondary", workspace: "/tmp/secondary" },
         ],
       },
+      skills: { entries: { shared: { enabled: true } } },
     };
 
-    const next = await maybeRepairSkillReadiness({ cfg, prompter });
+    const next = await maybeRepairSkillReadiness({ cfg, prompter: createRepairPrompter() });
 
-    expect(next).toBe(cfg);
-    expect(confirmAutoFix).not.toHaveBeenCalled();
+    expect(next).toEqual(cfg);
+    expect(next.skills?.entries?.shared?.enabled).toBe(true);
     expect(mocks.buildWorkspaceSkillStatus).toHaveBeenCalledTimes(2);
     expect(
       String(mocks.note.mock.calls.find(([, title]) => title === "Skills")?.[0] ?? ""),

--- a/src/commands/doctor-skills.ts
+++ b/src/commands/doctor-skills.ts
@@ -147,7 +147,8 @@ export async function maybeRepairSkillReadiness(params: {
     return params.cfg;
   }
 
-  const shouldDisable = await params.prompter.confirmAutoFix({
+  // Updating may migrate required state, but must not disable optional skills for this environment.
+  const shouldDisable = await params.prompter.confirmRuntimeRepair({
     message:
       agentIds.length === 1
         ? `Disable ${fleetUnavailable.length} unavailable skill${fleetUnavailable.length === 1 ? "" : "s"} in config?`


### PR DESCRIPTION
Related: #124396

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users running an automatic update would have an explicitly enabled skill persistently disabled when an optional binary was missing in the update environment.

This is a separate two-file Doctor approval-policy repair. It does not include the migration-planner feature in #136529.

## Why This Change Was Made

Use Doctor's existing runtime-repair approval for optional skill disabling. That approval preserves preferences during noninteractive updates while allowing explicit standalone repair. Keep updater `--fix`, required migrations, skill discovery and the healthy-other-agent guard unchanged.

Production +2/-1, net +1 for the caller-invariant comment. Tests +57/-7. No new configuration, environment option, schema, dependency or storage owner.

## User Impact

Automatic updates retain enabled skills even when the current environment cannot use them. Explicit standalone Doctor repair can still disable unavailable skills. Required configuration migrations still run and persist independently.

## Evidence

The disposable source/caller fixture exercises actual skill discovery, update policy, Doctor approval and the real config writer. Its approved scope is not full CLI, packaged, service or containment proof.

Unmodified canonical `66fa0bd2be4f811a6c6dbee8bd5dd102dae8e544` reproduced the unwanted persisted disable. Standalone repair, an available skill and a required legacy migration supplied the controls. The regression also failed before the fix. The healthy-other-agent test verifies actual availability on another agent, rather than an empty candidate set.

Final local candidate `1d9c71210c293d8fab30dae576de2775f2b2865c`, tree `860e399fc966ef8825dad554962a8a907052c658`, descends directly from fetched canonical `51202a46f7b2d1a501b2194c63b0ca1bb915b339`. The nineteen-commit range was inspected. Doctor approval/callers, migration writer and dependency inputs are unchanged. The shared SQLite coordinator changed, so the real-writer proof was refreshed on this final tree. No source repair or proof-contract change was needed.

One independent source-blind invocation passed all five clauses. All four children exited 0 with no signal or error. The parent rehashed all 28 manifest artifacts and their retained original files, checked individual versus aggregate process receipts, and reopened each final config. No mismatch.

| Case | Config writes | Persisted result |
| --- | ---: | --- |
| Automatic update, missing optional binary | 0 | Skill stays enabled; exact bytes preserved |
| Explicit standalone repair, missing binary | 1 final write | Skill becomes disabled |
| Automatic update, available binary | 0 | Skill stays enabled; exact bytes preserved |
| Automatic update, required legacy migration | 1 initial write | Retired field becomes `mode=off`; optional skill stays enabled |

Source-blind report SHA-256: `3c2e1aa566c8d266465823ffc61cc48dc4bb0a8c28f43fbaaee311bc42e41aaf`. Evidence manifest SHA-256: `60b13c1f05c261a8e2028ec998009e54dc369a56518091ac0803ae283f906fb5`. Native handle 76407, Darwin, Node 24.20.0. This does not attribute unrelated historical config changes.

Retained focused proof: 92 tests passed on the prior integrated candidate across Doctor skills/prompter, required legacy skill-config migration, skill-path containment and config paths. Those tested files and their approval/discovery inputs remain unchanged.

```text
node scripts/run-vitest.mjs src/commands/doctor-skills.test.ts src/commands/doctor-prompter.test.ts src/commands/doctor/shared/legacy-config-migrations.runtime.skills.test.ts src/skills/loading/skill-path-containment.test.ts src/config/paths.test.ts
```

The final selected native changed gate passed on this exact local candidate, native handle 81994 exit 0. Core/core-test types, all three dead-export scans, lint and all selected guards passed without skips. Log SHA-256: `d74a5460a6e5a521442a99b3627ead43b5297db2b1374335f783d2b2e1768c1d`.

```text
node scripts/check-changed.mjs --base 51202a46f7b2d1a501b2194c63b0ca1bb915b339 -- src/commands/doctor-skills.ts src/commands/doctor-skills.test.ts
```

Max-P2 Autoreview was scoped-clean at `59e1a197`. The patch and all eight reviewed approval/caller/writer context files are byte-identical on this candidate; that review is retained, not relabeled as a new invocation. Relevant integration behavior was revalidated by the independent caller/writer run.

The native production dependency audit completed exit 0 with no matching high-or-higher advisories from npm bulk. Its dependency, lockfile, policy and audit implementation inputs are unchanged. It does not check upstream repository advisories. Exact published-head security and required CI remain separate gates.

Native GraphQL publication produced `78b484ae609982e34c3ff342e68e1b344bd02fd7`. GitHub reports its signature verified with reason `valid`; its sole parent is the pinned canonical base. The full tree and both file modes/blob IDs exactly match the tested local candidate. This signature-only publication does not relabel the local proof as a run on the returned commit SHA.

No remote runtime, packaged, video, native-service or final-head hosted-CI result is claimed by this local evidence.
