### PR TITLE
fix(sessions): preserve full parsing for malformed metadata

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-excluded-rows.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-excluded-rows.test.ts
@@ -8,6 +8,12 @@ import {
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  iterateSessionEntryKeys,
+  readExactSessionEntryRow,
+  readSessionEntryCount,
+  readSessionEntryStore,
+} from "./session-accessor.sqlite-entry-store.js";
 import { readReferencedSessionIds } from "./session-accessor.sqlite-lifecycle-state.js";
 import { readSessionMaintenanceCapCandidates } from "./session-accessor.sqlite-maintenance-candidates.js";
 
@@ -156,6 +162,50 @@ describe.each(readers)("SQLite $name exclusions", ({ read }) => {
 });
 
 describe("SQLite exclusion survivor semantics", () => {
+  describe.each(["UTF-8", "UTF-16le", "UTF-16be"] as const)("%s JSON boundaries", (encoding) => {
+    it.each([
+      ["literal NUL", "\u0000"],
+      ["literal NUL and suffix", "\u0000garbage"],
+      ["valid escaped NUL", ""],
+    ])("keeps %s metadata reads consistent with full rows", (_name, suffix) => {
+      const database = openDatabase(encoding);
+      const key = "agent:main:survivor";
+      const json =
+        JSON.stringify({
+          sessionId: "raw",
+          updatedAt: 1,
+          previousSessionId: "historical",
+          label: "escaped\u0000日本語🦞",
+        }) + suffix;
+      insertEntry(database, key, "raw", json);
+      // Compare the actual full-reader contract, including older Node TEXT bindings.
+      const full = readSessionEntryStore(database, { allowCanonicalRepair: true });
+      const fullEntry = full[key];
+      expect(readSessionMaintenanceCapCandidates({ database, excludedKeys: new Set() })).toEqual(
+        full,
+      );
+      expect([...readReferencedSessionIds(database)].toSorted()).toEqual(
+        fullEntry ? ["historical", "raw"] : ["raw"],
+      );
+      expect(readSessionEntryCount(database)).toBe(Object.keys(full).length);
+      expect([...iterateSessionEntryKeys(database)]).toEqual(Object.keys(full));
+      if (fullEntry) {
+        expect(readExactSessionEntryRow(database, key, "list")?.entry).toEqual(fullEntry);
+      } else {
+        expect(() => readExactSessionEntryRow(database, key)).toThrow(
+          "invalid persisted session row",
+        );
+        expect(() => readExactSessionEntryRow(database, key, "list")).toThrow(
+          "invalid persisted session row",
+        );
+      }
+      expect(
+        readSessionMaintenanceCapCandidates({ database, excludedKeys: new Set([key]) }),
+      ).toEqual({});
+      expect([...readReferencedSessionIds(database, new Set([key]))]).toEqual([]);
+    });
+  });
+
   it.each([
     ["malformed", "{", false],
     ["retained placeholder", "{}", false],

--- a/src/config/sessions/session-accessor.sqlite-status.ts
+++ b/src/config/sessions/session-accessor.sqlite-status.ts
@@ -27,9 +27,10 @@ type SessionStatusDatabase = Pick<OpenClawAgentKyselyDatabase, "session_nodes">;
 // Metadata readers do not own prompt snapshots. Strip those bytes before JS allocation;
 // Malformed/overdepth JSON reaches the parser unchanged. Requiring an identity keeps
 // corrupt prompt-only objects distinct from the retained-window "{}" sentinel.
+// SQLite treats literal NUL as EOF; defer those rows to the full parser.
 export const sessionEntryMetadataJson =
   /* kysely-allow-raw: preserve raw-row parsing while omitting unused prompt payloads. */ sql<string>`CASE WHEN json_valid(entry_json)
-  THEN CASE WHEN json_type(entry_json, '$.sessionId') = 'text'
+  THEN CASE WHEN json_type(entry_json, '$.sessionId') = 'text' AND instr(entry_json, char(0)) = 0
     THEN json_remove(entry_json, '$.skillsSnapshot', '$.systemPromptReport')
     ELSE entry_json END
   ELSE entry_json END`.as("entry_json");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the main repository and remains writable by maintainers.

</details>

## What Problem This Solves

Resolves a problem where session metadata reads could accept a malformed stored row that a full session read rejected. A valid JSON identity followed by a literal NUL and trailing text could appear in session lists, maintenance candidates, and historical-reference collection.

Related: #134554 introduced metadata projection; #136391 added its identity fence; #138470 pushed exclusions before projection. This malformed-input behavior predates the exclusion optimization.

## Why This Change Was Made

SQLite treats a literal NUL as the end of JSON input. The shared metadata projection now leaves those rows to the existing full parser instead of removing prompt fields and accidentally discarding the invalid suffix. UTF-8 and both UTF-16 database encodings use the same condition. There is no schema, migration, stored representation, retention, configuration, or dependency change.

## User Impact

Metadata reads retain the same rejection, skip, and raw-current-ID protection outcomes as full reads. Valid escaped NULs, Unicode, duplicate fields, overdepth JSON, and excluded-row selection retain their existing behavior. This preserves the older Node binding behavior that truncates raw TEXT at a NUL. Inventory rows already marked valid retain their existing stored-validity contract; this repair covers rows that reach metadata parsing.

The correctness check adds a scan of surviving metadata text. In a bounded 16-row, 1 MiB prompt-per-row experiment, actual reference/cap reader CPU medians increased from about 11.1 ms to 32.5–32.7 ms with no exclusions, and about 5.5–5.7 ms to 16.2–16.6 ms with half excluded. All-excluded reads remained below 0.3 ms. These are synthetic CPU measurements, not production latency or stall attribution. The existing SQL exclusions still run before projection.

## Evidence

- Before the repair: six failing literal-NUL cases across UTF-8, UTF-16LE, and UTF-16BE; three escaped-NUL controls passed. After: 67 owner/cache tests passed using `node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-excluded-rows.test.ts src/config/sessions/session-accessor.sqlite-data-version.test.ts`.
- Actual owner probes cover full/exact/list/cache reads, cap/age candidates, pending inventory counts/keys, historical references, and exclusions on Node 26.8.1/SQLite 3.53.4, Node 24.20.0/SQLite 3.53.4, and Node 24.15.0/SQLite 3.51.3. They agree with each runtime's full-reader behavior; the older Node's existing truncated-prefix acceptance remains unchanged.
- Direct dependency inspection covered the [SQLite JSON trailing-input check](https://github.com/nodejs/node/blob/v24.20.0/deps/sqlite/sqlite3.c#L214793-L214834), its explicit-length `instr` implementation, and the older Node TEXT conversion.
- The source expression also passed 18 encoding/boundary cases against an independently built SQLite 3.44.6 C runner. That is minimum-SQLite proof, not a Node binary linked against SQLite 3.44.6.
- These probes execute the actual storage owners with isolated databases. They do not exercise authenticated Gateway routing or the Control UI; the corrupted-row parsing boundary is directly covered.
- Independent P0–P2 review: scoped-clean. Required changed-code checks completed cumulatively: the local run passed 19 phases, including core types and all 16 test-type graphs, before two Knip scans hit their 600-second limit. The same three-config export check passed with zero findings in 53 seconds on [Linux Testbox](https://github.com/openclaw/openclaw/actions/runs/33931735414), followed by all nine unrun guards and the 67 owner tests. Final wrapper exit 0; Node 24.19.0, pnpm 12.1.0, four CPUs. All 37,752 tracked source files matched before validation and after dependency installation.
- The original local wrapper failure and subsequent sequential scan timeout are retained. Earlier remote attempts stopped on proof-harness metadata checks or missing dependencies before substantive validation; the final run repaired those setup issues. This is cumulative coverage, not a green result for the original full wrapper.

Production: +2/-1 lines, including the necessary dependency-boundary comment. Tests: +50 lines. The additional field scan was chosen over a depth-changing wrapped-JSON check or trusting a validity fact produced under a different Node decoding contract.
