### PR TITLE
fix(gateway): prevent shutdown hangs during suspension

### DIFF
--- a/docs/gateway/external-apps.md
+++ b/docs/gateway/external-apps.md
@@ -84,6 +84,9 @@ call resume. The
 that cannot speak WebSocket at all. If every control path is lost, the
 two-minute lease expiry reopens admission automatically.
 
+Closing the Gateway cancels background work queued by operator reconnects without
+waiting for suspension expiry. Shutdown still waits for work already running to finish.
+
 The hello snapshot includes `suspension: { phase }`, and `gateway.suspension`
 events publish admission changes immediately. The phase is `accepting`,
 `preparing`, `draining`, or `prepared`; neither surface exposes suspension IDs.

--- a/extensions/browser/src/browser/chrome-mcp-connect.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp-connect.test.ts
@@ -96,7 +96,10 @@ for await (const line of readline.createInterface({ input: process.stdin })) {
     expect(pid).toBeGreaterThan(0);
     expect(pid).not.toBe(process.pid);
     await vi.waitFor(async () => {
-      expect(await fs.readFile(state.statePath("stdin-ended"), "utf8")).toBe("closed");
+      // Windows terminates the process tree before the transport can close stdin.
+      if (process.platform !== "win32") {
+        expect(await fs.readFile(state.statePath("stdin-ended"), "utf8")).toBe("closed");
+      }
       expect(() => process.kill(pid, 0)).toThrow(expect.objectContaining({ code: "ESRCH" }));
     });
     expect(getChromeMcpPid(profileName)).toBeNull();

--- a/src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts
+++ b/src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts
@@ -5,21 +5,42 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { withTestTimeout } from "../../../test/helpers/promise.js";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 
 const CHILD_READY_TIMEOUT_MS = 45_000;
 const TEST_TIMEOUT_MS = 60_000;
+const CHILD_CLOSE_TIMEOUT_MS = 5_000;
 const RELEASE_DELAY_MS = 400;
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-const children = new Set<ChildProcess>();
+const tempDirs = createTempDirTracker();
+const children = new Map<ChildProcess, Promise<unknown[]>>();
 
-afterEach(() => {
-  for (const child of children) {
+function ownChild(child: ChildProcess): Promise<unknown[]> {
+  const closed = once(child, "close");
+  children.set(child, closed);
+  void closed.catch(() => {});
+  return closed;
+}
+
+async function cleanupFixtures() {
+  for (const child of children.keys()) {
     child.kill("SIGKILL");
   }
+  const results = await withTestTimeout(
+    Promise.allSettled(children.values()),
+    CHILD_CLOSE_TIMEOUT_MS,
+    "direct-stop fixture children did not close; retaining their temporary directories",
+  );
+  const errors = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+  if (errors.length) {
+    throw new AggregateError(errors, "direct-stop fixture cleanup failed; retaining state");
+  }
   children.clear();
-});
+  tempDirs.cleanup();
+}
+
+afterEach(cleanupFixtures);
 
 const moduleUrl = (relativePath: string) => pathToFileURL(path.resolve(relativePath)).href;
 
@@ -130,6 +151,31 @@ function readTrace(tracePath: string): string[] {
 describe("runGatewayLoop direct-stop active work", () => {
   const posixIt = process.platform === "win32" ? it.skip : it;
 
+  posixIt("joins forced child cleanup before deleting its fixture directory", async () => {
+    const fixtureDir = tempDirs.make("openclaw-direct-stop-failure-");
+    const child = spawn(
+      process.execPath,
+      ["-e", 'process.stdout.write("ready"); setInterval(() => {}, 1_000)'],
+      { stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const closed = ownChild(child);
+    let rootExistsAtClose = false;
+    child.once("close", () => {
+      rootExistsAtClose = fs.existsSync(fixtureDir);
+    });
+    await withTestTimeout(
+      once(child.stdout!, "data"),
+      CHILD_READY_TIMEOUT_MS,
+      "forced cleanup fixture did not start",
+    );
+
+    await cleanupFixtures();
+
+    expect(await closed).toEqual([null, "SIGKILL"]);
+    expect(rootExistsAtClose).toBe(true);
+    expect(fs.existsSync(fixtureDir)).toBe(false);
+  });
+
   posixIt.each([false, true])(
     "reports and drains a rootless adopted channel run after OS SIGTERM (trace=%s)",
     async (traceEnabled) => {
@@ -158,7 +204,8 @@ describe("runGatewayLoop direct-stop active work", () => {
           stdio: ["ignore", "pipe", "pipe"],
         },
       );
-      children.add(child);
+      // Register close before readiness: failed startup still owns both output streams.
+      const exited = ownChild(child);
       const stdout: Buffer[] = [];
       const stderr: Buffer[] = [];
       child.stdout?.on("data", (chunk: Buffer) => stdout.push(chunk));
@@ -173,9 +220,6 @@ describe("runGatewayLoop direct-stop active work", () => {
         { timeout: CHILD_READY_TIMEOUT_MS, interval: 25 },
       );
       // The exit event can precede the final stdout data; close joins both streams.
-      const exited = once(child, "close") as Promise<
-        [code: number | null, signal: NodeJS.Signals | null]
-      >;
       expect(child.kill("SIGTERM")).toBe(true);
 
       const exit = await exited;

--- a/src/gateway/server-methods/usage.cost-usage-cache.test.ts
+++ b/src/gateway/server-methods/usage.cost-usage-cache.test.ts
@@ -67,7 +67,7 @@ describe("costUsageCache bounded growth", () => {
     try {
       const stale = await owner.track(() => testApi.loadCostUsageSummaryCached(params));
       expect(stale).toEqual(first);
-      // Keep the original producer joinable even against the broken owner on red.
+      // Retain the original refresh for cleanup if scope tracking regresses.
       refresh = Array.from(testApi.costUsageCache.values())[0]?.inFlight;
       expect(refresh).toBeDefined();
       await replacementOwner.track(() =>

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -228,9 +228,9 @@ export async function finishGatewayStartup(params: {
     () => import("./server-active-work.js"),
   );
   const activeWorkInspectors = createGatewayServerActiveWorkInspectors(gatewayRequestContext);
-  const trackStartupWork = <T>(run: () => Promise<T>): Promise<T> => {
+  const trackStartupWork = <T>(run: (signal: AbortSignal) => Promise<T>): Promise<T> => {
     // Register before starting, without lending the connection scope to long-lived services.
-    const operation = Promise.resolve().then(run);
+    const operation = Promise.resolve().then(() => run(runtime.connectionWork.signal));
     return runtime.connectionWork.track(() => operation);
   };
   const postAttachHandles = await trackStartupWork(() =>

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -19,6 +19,7 @@ import {
   markGatewayRestartDraining,
   resetGatewayWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
+  tryBeginGatewaySuspendAdmission,
 } from "../process/gateway-work-admission.js";
 import { AsyncWorkScope, getAsyncWorkSignal } from "../shared/async-work-scope.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
@@ -965,7 +966,7 @@ describe("startGatewayPostAttachRuntime", () => {
       });
       const lifetime = new AsyncWorkScope();
       const trackStartupWork: PostAttachParams["trackStartupWork"] = (run) => {
-        const operation = Promise.resolve().then(run);
+        const operation = Promise.resolve().then(() => run(lifetime.signal));
         return lifetime.track(() => operation);
       };
       const release = () => {
@@ -4259,7 +4260,7 @@ describe("startGatewayPostAttachRuntime", () => {
       return null;
     });
     const trackStartupWork: PostAttachParams["trackStartupWork"] = (run) => {
-      const operation = Promise.resolve().then(run);
+      const operation = Promise.resolve().then(() => run(connectionWork.signal));
       return connectionWork.track(() => operation);
     };
     const runtime = await trackStartupWork(() =>
@@ -4308,6 +4309,91 @@ describe("startGatewayPostAttachRuntime", () => {
     }
   });
 
+  it.each(["sentinel", "gateway_start"] as const)(
+    "retires startup %s admission parked behind suspension when the Gateway closes",
+    async (stage) => {
+      const { createHookRunner } = await import("../plugins/hooks.js");
+      const gatewayStart = vi.fn<PluginHookHandlerMap["gateway_start"]>(async () => {});
+      const pluginRegistry = createEmptyPluginRegistry();
+      pluginRegistry.typedHooks.push({
+        pluginId: "startup-suspension-test",
+        hookName: "gateway_start",
+        handler: gatewayStart,
+        source: "startup-suspension-test",
+      });
+      const hookRunner = createHookRunner(pluginRegistry);
+      const postReadyWork = createDeferred();
+      const hookLoadStarted = createDeferred();
+      const releaseHookLoad = createDeferred();
+      const connectionWork = new GatewayConnectionWork();
+      const refresh = vi.fn(async () => null);
+      const sidecarsReady = vi.fn();
+      const trackStartupWork: PostAttachParams["trackStartupWork"] = (run) => {
+        const operation = Promise.resolve().then(() => run(connectionWork.signal));
+        return connectionWork.track(() => operation);
+      };
+      const runtime = await trackStartupWork(() =>
+        startGatewayPostAttachRuntime(
+          createPostAttachParams({
+            pluginRegistry,
+            isClosing: () => connectionWork.isClosing,
+            trackStartupWork,
+            onSidecarsReady: sidecarsReady,
+            waitForPostReadyWork: () => postReadyWork.promise,
+          }),
+          createPostAttachRuntimeDeps({
+            refreshLatestUpdateRestartSentinel: refresh,
+            getGlobalHookRunner: async () => {
+              hookLoadStarted.resolve();
+              if (stage === "gateway_start") {
+                await releaseHookLoad.promise;
+                return hookRunner;
+              }
+              return null;
+            },
+          }),
+        ),
+      );
+      let suspension: ReturnType<typeof tryBeginGatewaySuspendAdmission> = null;
+      let closing: Promise<void> | undefined;
+      try {
+        expect(sidecarsReady).toHaveBeenCalledOnce();
+        if (stage === "gateway_start") {
+          postReadyWork.resolve();
+          await hookLoadStarted.promise;
+        }
+        suspension = tryBeginGatewaySuspendAdmission(() => {});
+        expect(suspension?.commit()).toBe(true);
+        postReadyWork.resolve();
+        await hookLoadStarted.promise;
+        releaseHookLoad.resolve();
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        let drained = false;
+        connectionWork.beginClose();
+        closing = connectionWork.drain().then(() => {
+          drained = true;
+        });
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect.soft(drained, "startup admission retires without reopening suspension").toBe(true);
+        suspension?.release();
+        await closing;
+        expect(gatewayStart).not.toHaveBeenCalled();
+        expect(refresh).toHaveBeenCalledTimes(stage === "sentinel" ? 0 : 1);
+      } finally {
+        suspension?.release();
+        postReadyWork.resolve();
+        releaseHookLoad.resolve();
+        await runtime.startupSettled;
+        await connectionWork.drain();
+        await closing;
+      }
+    },
+  );
+
   it("retains gateway_start loading until close can retire plugin metadata", async () => {
     const { createHookRunner } = await import("../plugins/hooks.js");
     const gatewayStart = vi.fn<PluginHookHandlerMap["gateway_start"]>(async () => {});
@@ -4324,7 +4410,7 @@ describe("startGatewayPostAttachRuntime", () => {
     const connectionWork = new GatewayConnectionWork();
     const retirePluginMetadata = vi.fn();
     const trackStartupWork: PostAttachParams["trackStartupWork"] = (run) => {
-      const operation = Promise.resolve().then(run);
+      const operation = Promise.resolve().then(() => run(connectionWork.signal));
       return connectionWork.track(() => operation);
     };
     const runtime = await trackStartupWork(() =>
@@ -4521,6 +4607,7 @@ function createPostAttachRuntimeDeps(
 }
 
 function createPostAttachParams(overrides: Partial<PostAttachParams> = {}): PostAttachParams {
+  const startupSignal = new AbortController().signal;
   return {
     minimalTestGateway: false,
     cfgAtStart: { hooks: { internal: { enabled: false } } } as never,
@@ -4568,7 +4655,7 @@ function createPostAttachParams(overrides: Partial<PostAttachParams> = {}): Post
     unlockStartupMethods: vi.fn(),
     providerAuthPrewarm: { enabled: false },
     unregisterConnectionDependentSidecar: vi.fn(),
-    trackStartupWork: (run) => run(),
+    trackStartupWork: (run) => run(startupSignal),
     ...overrides,
   };
 }

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1205,7 +1205,7 @@ export async function startGatewayPostAttachRuntime(
     onPostReadySidecars?: (postReadySidecars: GatewayPostReadySidecarHandle[]) => void;
     onGatewayLifetimeSidecars?: (sidecars: GatewayPostReadySidecarHandle[]) => void;
     unregisterConnectionDependentSidecar: (sidecar: GatewayPostReadySidecarHandle) => void;
-    trackStartupWork: <T>(run: () => Promise<T>) => Promise<T>;
+    trackStartupWork: <T>(run: (signal: AbortSignal) => Promise<T>) => Promise<T>;
     startWorkerEnvironmentRuntime?: () => Awaitable<GatewayPostReadySidecarHandle | null>;
     onSidecarsReady?: () => void;
     isClosing?: () => boolean;
@@ -1582,7 +1582,7 @@ export async function startGatewayPostAttachRuntime(
   // retains dependency loads and hooks even when readiness has already settled.
   const sidecarsPromise = params.trackStartupWork(startSidecars);
   void params
-    .trackStartupWork(async () => {
+    .trackStartupWork(async (signal) => {
       const sidecarsResult = await sidecarsPromise;
       if (params.minimalTestGateway) {
         return;
@@ -1597,13 +1597,17 @@ export async function startGatewayPostAttachRuntime(
       if (params.isClosing?.()) {
         return;
       }
-      const sentinelRefresh = runWithGatewayIndependentRootWorkAdmission(async () => {
-        await measureStartup(params.startupTrace, "post-attach.update-sentinel", async () => {
-          if (!params.isClosing?.()) {
-            await runtimeDeps.refreshLatestUpdateRestartSentinel();
-          }
-        });
-      }, "startup:update-sentinel").catch((err: unknown) => {
+      const sentinelRefresh = runWithGatewayIndependentRootWorkAdmission(
+        async () => {
+          await measureStartup(params.startupTrace, "post-attach.update-sentinel", async () => {
+            if (!params.isClosing?.()) {
+              await runtimeDeps.refreshLatestUpdateRestartSentinel();
+            }
+          });
+        },
+        "startup:update-sentinel",
+        signal,
+      ).catch((err: unknown) => {
         params.log.warn(`restart sentinel refresh failed: ${String(err)}`);
       });
       try {
@@ -1619,25 +1623,29 @@ export async function startGatewayPostAttachRuntime(
         if (params.isClosing?.()) {
           return;
         }
-        await runWithGatewayIndependentRootWorkAdmission(async () => {
-          if (params.isClosing?.()) {
-            return;
-          }
-          await withPluginHttpRouteRegistry(sidecarsResult.pluginRegistry, () =>
-            hookRunner.runGatewayStart(
-              { port: params.port },
-              {
-                port: params.port,
-                config: params.gatewayPluginConfigAtStart,
-                workspaceDir: params.defaultWorkspaceDir,
-                getCron: () =>
-                  (params.getCronService?.() ?? params.deps.cron) as
-                    | PluginHookGatewayCronService
-                    | undefined,
-              },
-            ),
-          );
-        }, "hooks:gateway-start").catch((err: unknown) => {
+        await runWithGatewayIndependentRootWorkAdmission(
+          async () => {
+            if (params.isClosing?.()) {
+              return;
+            }
+            await withPluginHttpRouteRegistry(sidecarsResult.pluginRegistry, () =>
+              hookRunner.runGatewayStart(
+                { port: params.port },
+                {
+                  port: params.port,
+                  config: params.gatewayPluginConfigAtStart,
+                  workspaceDir: params.defaultWorkspaceDir,
+                  getCron: () =>
+                    (params.getCronService?.() ?? params.deps.cron) as
+                      | PluginHookGatewayCronService
+                      | undefined,
+                },
+              ),
+            );
+          },
+          "hooks:gateway-start",
+          signal,
+        ).catch((err: unknown) => {
           params.log.warn(`gateway_start hook failed: ${String(err)}`);
         });
       } finally {

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -1,5 +1,6 @@
 // WebSocket message-handler health tests cover post-connect startup-unavailable and health-gated dispatch.
 import type { IncomingMessage } from "node:http";
+import { setImmediate as nextTurn } from "node:timers/promises";
 import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import type { WebSocket } from "ws";
 import { ConnectErrorDetailCodes } from "../../../../packages/gateway-protocol/src/connect-error-details.js";
@@ -15,6 +16,7 @@ import {
   getActiveDiagnosticTraceContext,
   type DiagnosticTraceContext,
 } from "../../../infra/diagnostic-trace-context.js";
+import { tryBeginGatewaySuspendAdmission } from "../../../process/gateway-work-admission.js";
 import {
   ensureProfileForEmail,
   setDisplayName,
@@ -1307,6 +1309,67 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
             expect.objectContaining({ id: canonical.id }),
           );
         });
+      });
+    },
+  );
+
+  it.each(["resume", "close"] as const)(
+    "settles identity sync parked by suspension when the Gateway handles %s",
+    async (action) => {
+      await withGatewayTestState({ label: "gateway-suspended-identity" }, async () => {
+        const canonical = ensureProfileForEmail("canonical@example.test");
+        const sync = vi.fn(async () => ({
+          profileId: canonical.id,
+          updatedAt: canonical.updatedAt,
+        }));
+        createAuthenticatedGitHubIdentitySyncMock.mockReturnValueOnce(sync);
+        resolveConnectAuthStateMock.mockResolvedValueOnce({
+          authResult: {
+            ok: true,
+            method: "tailscale",
+            user: "ada@github",
+            tailscaleIdentity: { login: "ada@github", name: "Ada Lovelace" },
+          },
+          authOk: true,
+          authMethod: "tailscale",
+          sharedAuthOk: true,
+        });
+        const suspension = tryBeginGatewaySuspendAdmission(() => {});
+        expect(suspension?.commit()).toBe(true);
+        let closing: Promise<void> | undefined;
+        try {
+          const harness = attachGatewayHarness({
+            connId: "conn-suspended-identity",
+            connectNonce: "nonce-suspended-identity",
+          });
+          harness.sendConnect("connect-suspended-identity", {
+            minProtocol: PROTOCOL_VERSION,
+            maxProtocol: PROTOCOL_VERSION,
+            client: { id: "test", version: "dev", platform: "test", mode: "test" },
+            role: "operator",
+            caps: [],
+          });
+          await waitForFast(() => expect(harness.socketSend).toHaveBeenCalled());
+          await nextTurn();
+          expect(sync).not.toHaveBeenCalled();
+          if (action === "resume") {
+            suspension?.release();
+            await waitForFast(() => expect(sync).toHaveBeenCalledOnce());
+            return;
+          }
+          let drained = false;
+          closing = cleanupGatewayHarnesses().then(() => {
+            drained = true;
+          });
+          await nextTurn();
+          expect.soft(drained, "closing does not wait for suspension expiry").toBe(true);
+          suspension?.release();
+          await closing;
+          expect(sync).not.toHaveBeenCalled();
+        } finally {
+          suspension?.release();
+          await closing;
+        }
       });
     },
   );

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -168,7 +168,9 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     // Connect-triggered mutations outlive hello-ok. Give each tail its own
     // root lease so suspension cannot report ready while one is still active.
     void params.connectionWork
-      .track(() => runWithGatewayIndependentRootWorkAdmission(run, "ws:preauth"))
+      .track(() =>
+        runWithGatewayIndependentRootWorkAdmission(run, "ws:preauth", params.connectionWork.signal),
+      )
       .catch(onError);
   };
 

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -1,4 +1,5 @@
 // Covers root work counting and reversible suspension admission transitions.
+import { setImmediate as nextTurn } from "node:timers/promises";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { createDeferredCore } from "../shared/deferred.js";
 import {
@@ -18,6 +19,7 @@ import {
   retainGatewayRootWorkAdmissionContinuation,
   resetGatewayWorkAdmission,
   rollbackGatewayRestartSignalFence,
+  runWithGatewayIndependentRootWorkAdmission,
   runWithGatewayIndependentRootWorkContinuation,
   runWithRetainedGatewayRootWork,
   runOutsideGatewayRootWorkAdmission,
@@ -584,6 +586,84 @@ it("defers required internal root work until suspension reopens", async () => {
   await pending;
 
   expect(entered).toHaveBeenCalledOnce();
+  expect(getActiveGatewayRootWorkCount()).toBe(0);
+});
+
+it.each(["before admission", "while suspended", "during resume"] as const)(
+  "retires independent work cancelled %s without running it after resume",
+  async (timing) => {
+    const controller = new AbortController();
+    const suspension =
+      timing === "before admission" ? null : tryBeginGatewaySuspendAdmission(() => {});
+    if (suspension) {
+      expect(suspension.commit()).toBe(true);
+    }
+    if (timing === "before admission") {
+      controller.abort();
+    }
+    const run = vi.fn(async () => {});
+    let outcome: "resolved" | "rejected" | undefined;
+    let rejection: unknown;
+    const completion = runWithGatewayIndependentRootWorkAdmission(
+      run,
+      "test:cancellable",
+      controller.signal,
+    ).then(
+      () => {
+        outcome = "resolved";
+      },
+      (error: unknown) => {
+        outcome = "rejected";
+        rejection = error;
+      },
+    );
+    try {
+      if (timing === "during resume") {
+        suspension?.release();
+      }
+      controller.abort();
+      await nextTurn();
+      expect.soft(outcome, "cancellation does not wait for suspension release").toBe("rejected");
+    } finally {
+      suspension?.release();
+      await completion;
+    }
+    expect(rejection).toMatchObject({ name: "AbortError" });
+    expect(run).not.toHaveBeenCalled();
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  },
+);
+
+it("retains resumed independent work until its original completion after admission cancellation", async () => {
+  const controller = new AbortController();
+  const suspension = tryBeginGatewaySuspendAdmission(() => {});
+  expect(suspension?.commit()).toBe(true);
+  const started = createDeferredCore();
+  const release = createDeferredCore();
+  let settled = false;
+  const execution = runWithGatewayIndependentRootWorkAdmission(
+    async () => {
+      started.resolve();
+      await release.promise;
+    },
+    "test:cancellable",
+    controller.signal,
+  ).then(() => {
+    settled = true;
+  });
+  try {
+    suspension?.release();
+    await started.promise;
+    controller.abort();
+    await nextTurn();
+    expect(settled).toBe(false);
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+  } finally {
+    suspension?.release();
+    release.resolve();
+    await execution;
+  }
+  expect(settled).toBe(true);
   expect(getActiveGatewayRootWorkCount()).toBe(0);
 });
 

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -1,7 +1,9 @@
 // Coordinates process-wide root work admission with reversible host suspension.
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { GatewaySuspension } from "../../packages/gateway-protocol/src/schema/gateway-suspend.js";
+import { racePromiseWithAbortSignal } from "../infra/abort-signal.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 
 type GatewaySuspendAdmissionPhase = GatewaySuspension["phase"];
@@ -374,6 +376,16 @@ export function tryBeginGatewayIndependentRootWorkAdmission(
   return createGatewayRootWorkAdmission(origin);
 }
 
+async function waitForGatewayWorkAdmissionChange(signal?: AbortSignal): Promise<void> {
+  const wake = createDeferredCore();
+  GATEWAY_WORK_ADMISSION_STATE.suspendOpenWaiters.add(wake.resolve);
+  try {
+    await racePromiseWithAbortSignal(wake.promise, signal);
+  } finally {
+    GATEWAY_WORK_ADMISSION_STATE.suspendOpenWaiters.delete(wake.resolve);
+  }
+}
+
 /** Waits through a prepared lease, then joins the root-work set atomically. */
 export async function beginGatewayRootWorkAdmissionWhenOpen(
   origin = "gateway",
@@ -386,17 +398,18 @@ export async function beginGatewayRootWorkAdmissionWhenOpen(
     if (admission) {
       return admission;
     }
-    await new Promise<void>((resolve) => {
-      GATEWAY_WORK_ADMISSION_STATE.suspendOpenWaiters.add(resolve);
-    });
+    await waitForGatewayWorkAdmissionChange();
   }
 }
 
 export async function runWithGatewayIndependentRootWorkAdmission<T>(
   run: () => Promise<T>,
   origin?: string,
+  signal?: AbortSignal,
 ): Promise<T> {
   while (true) {
+    // Cancellation retires admission only; an admitted operation still owns its full completion.
+    signal?.throwIfAborted();
     if (GATEWAY_WORK_ADMISSION_STATE.restartDraining) {
       throw new GatewayDrainingError("gateway is draining for restart");
     }
@@ -408,9 +421,7 @@ export async function runWithGatewayIndependentRootWorkAdmission<T>(
         admission.release();
       }
     }
-    await new Promise<void>((resolve) => {
-      GATEWAY_WORK_ADMISSION_STATE.suspendOpenWaiters.add(resolve);
-    });
+    await waitForGatewayWorkAdmissionChange(signal);
   }
 }
 

--- a/test/gateway-restored-requester-settle.e2e.test.ts
+++ b/test/gateway-restored-requester-settle.e2e.test.ts
@@ -108,7 +108,7 @@ describe("Gateway restored requester settlement", () => {
         }
       } finally {
         closeOpenClawStateDatabaseForTest();
-        instance.state.restoreEnv();
+        await instance.state.restoreEnv();
       }
 
       await instance.startGateway();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators closing a suspended Gateway could wait until suspension expiry because background work queued by a reconnect or startup hook still held the connection lifetime open.

Related: #136146.

## Why This Change Was Made

Pending independent admission now observes the owning connection scope's abort signal and removes its waiter on cancellation. The admission owner rechecks cancellation after resume; callbacks already admitted remain tracked until their original completion. Reconnect identity synchronization, restart-sentinel refresh, and `gateway_start` use the same cancellation boundary. Startup work still avoids lending its connection scope to long-lived services.

The follow-up also waits for child-process close before removing fixture directories, awaits asynchronous environment restoration, and limits the browser stdin-EOF assertion to platforms where graceful stdin closure precedes process termination. Process-death assertions remain cross-platform.

## User Impact

Gateway shutdown no longer waits for a suspension lease to expire merely to retire queued background work. Work already running still drains normally. The suspension documentation records that behavior. No configuration, schema, protocol, or dependency changes.

## Evidence

- Reproduced pending-admission, reconnect, and both startup-tail failures before the runtime fix. The forced child-cleanup test also fails with the original kill-then-remove ordering.
- Passed 223 affected tests across admission, WebSocket connect/suspension, startup, and real child-process shutdown; reran all 106 startup cases after the final lint correction.
- Passed seven native Gateway startup/request lifetime cases and eight actual browser MCP subprocess cases on macOS. Earlier broader lifecycle verification passed 112 tests plus 25 focused scope/approval/question/cache cases.
- Selected core, core-test, plugin-test, and root-test typechecks passed. Formatting, lint, dead-export scans, dependency/boundary guards, state-schema/store guards, sidecar loading, import cycles, and pairing/webhook checks passed. The initial lint run caught two promise-executor expressions in new tests; both were corrected and lint rerun successfully.
- Fresh independent Codex autoreview: no actionable P0–P2 findings.

Production: +58/-37 (net +21); tests: +294/-17 (net +277); docs: +3. The production growth carries cancellation through the existing admission owner while sharing and replacing duplicated waiter registration; racing whole callbacks would incorrectly abandon admitted work.

Windows execution was not performed locally. This follow-up does not claim acceptance of #136146's separate protected-metadata audit gap.
