### PR TITLE
fix(tasks): keep session lists available during unrelated activity

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3713,7 +3713,7 @@ src/tasks/task-flow-registry.store.ts	1
 src/tasks/task-flow-registry.ts	1
 src/tasks/task-flow-registry.types.ts	2
 src/tasks/task-registry-query.ts	4
-src/tasks/task-registry-state.ts	4
+src/tasks/task-registry-state.ts	3
 src/tasks/task-registry.process-state.ts	1
 src/tasks/task-registry.sqlite.shared.ts	1
 src/tasks/task-registry.store.sqlite.ts	1

--- a/src/gateway/server.tasks-list-performance.test.ts
+++ b/src/gateway/server.tasks-list-performance.test.ts
@@ -481,6 +481,51 @@ describe("tasks.list Gateway performance", () => {
             },
           });
 
+          const scopedTasks = new Map(
+            [...createTaskSnapshot()].slice(0, 65).map(([taskId, task], index) => {
+              const requesterSessionKey = index === 0 ? OWNED_SESSION_KEY : FOREIGN_SESSION_KEY;
+              return [taskId, { ...task, requesterSessionKey, ownerKey: requesterSessionKey }];
+            }),
+          );
+          let scopedRevision = 0;
+          let scopedChurn: ReturnType<typeof setImmediate> | undefined;
+          const mutateUnrelatedTask = () => {
+            scopedRevision += 1;
+            markTaskTerminalById({
+              taskId: "task-00064",
+              status: "succeeded",
+              endedAt: TASK_COUNT + scopedRevision,
+            });
+            scopedChurn = setImmediate(mutateUnrelatedTask);
+          };
+          resetTaskRegistryForTests({ persist: false });
+          configureTaskRegistryRuntime({
+            store: {
+              loadSnapshot: () => {
+                scopedChurn = setImmediate(mutateUnrelatedTask);
+                return { tasks: scopedTasks, deliveryStates: new Map() };
+              },
+              saveSnapshot: () => {},
+            },
+          });
+          try {
+            const scopedPage = await sendRpc<TasksListResult>(
+              viewer,
+              "tasks-scoped",
+              "tasks.list",
+              {
+                sessionKey: OWNED_SESSION_KEY,
+                agentId: "main",
+                limit: 1,
+              },
+            );
+            expect(scopedPage.ok, JSON.stringify(scopedPage.error)).toBe(true);
+            expect(scopedPage.payload?.tasks.map((task) => task.id)).toEqual(["task-00000"]);
+            expect(scopedPage.payload?.nextCursor).toBeUndefined();
+          } finally {
+            clearImmediate(scopedChurn);
+          }
+
           const accessTasks = new Map([...createTaskSnapshot()].slice(0, 1_000));
           resetTaskRegistryForTests({ persist: false });
           configureTaskRegistryRuntime({

--- a/src/tasks/task-backing-authority.ts
+++ b/src/tasks/task-backing-authority.ts
@@ -1,4 +1,5 @@
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { getTaskFlowById } from "./task-flow-runtime-internal.js";
 import {
   ensureTaskRegistryReady,
@@ -116,7 +117,14 @@ export function createNextAcpTaskBackingDetail(params: {
   for (const taskId of taskIdsByRelatedSessionKey.get(params.childSessionKey) ?? []) {
     const task = tasks.get(taskId);
     const instance = task ? readTaskBackingInstance(task.detail) : undefined;
-    if (task && instance?.runtime === "acp" && isCanonicalBackingTask(task)) {
+    // Requester candidates serve list queries; generation history keeps its owner/child scope.
+    if (
+      task &&
+      (normalizeOptionalString(task.ownerKey) === params.childSessionKey ||
+        normalizeOptionalString(task.childSessionKey) === params.childSessionKey) &&
+      instance?.runtime === "acp" &&
+      isCanonicalBackingTask(task)
+    ) {
       generation = Math.max(generation, instance.generation);
     }
   }

--- a/src/tasks/task-registry-mutation.ts
+++ b/src/tasks/task-registry-mutation.ts
@@ -179,6 +179,8 @@ export function updateTask(taskId: string, patch: Partial<TaskRecord>): TaskReco
     next.cleanupAfter = resolveTaskCleanupAfter({ ...next, createdAt });
   }
   const sessionIndexChanged =
+    normalizeOptionalString(current.requesterSessionKey) !==
+      normalizeOptionalString(next.requesterSessionKey) ||
     normalizeOptionalString(current.ownerKey) !== normalizeOptionalString(next.ownerKey) ||
     normalizeOptionalString(current.childSessionKey) !==
       normalizeOptionalString(next.childSessionKey);

--- a/src/tasks/task-registry-query.test.ts
+++ b/src/tasks/task-registry-query.test.ts
@@ -34,6 +34,54 @@ async function readTaskPage(params: Parameters<typeof listTaskRecordPage>[0]) {
 
 describe("listTaskRecordPage", () => {
   it.each([
+    { scope: "sparse", matching: 1 },
+    { scope: "dense", matching: 65 },
+  ])("keeps $scope session pages independent of unrelated task activity", async ({ matching }) => {
+    configureTaskSnapshot(
+      Array.from({ length: 65 }, (_, index): TaskRecord => ({
+        taskId: `task-${index}`,
+        runtime: "cli",
+        requesterSessionKey: index < matching ? "agent:main:requested" : "agent:main:unrelated",
+        ownerKey: index < matching ? "agent:main:requested" : "agent:main:unrelated",
+        scopeKind: "session",
+        task: "Scoped task page",
+        status: "running",
+        deliveryStatus: "pending",
+        notifyPolicy: "done_only",
+        createdAt: 1,
+        lastEventAt: 1,
+      })),
+    );
+    expect(getTaskById("task-0")).toBeDefined();
+    let mutations = 0;
+    const update = () => {
+      mutations += 1;
+      markTaskTerminalById({ taskId: "task-64", status: "succeeded", endedAt: mutations + 1 });
+      pending = setImmediate(update);
+    };
+    let pending = setImmediate(update);
+    try {
+      const page = await listTaskRecordPage({
+        offset: 0,
+        limit: 1,
+        sessionKey: "agent:main:requested",
+      });
+      if (matching === 1) {
+        expect(page.ok).toBe(true);
+        if (page.ok) {
+          expect(page.value.tasks.map((task) => task.taskId)).toEqual(["task-0"]);
+          expect(page.value.hasMore).toBe(false);
+        }
+      } else {
+        expect(page).toEqual({ ok: false, error: "registry_changed" });
+        expect(mutations).toBeGreaterThanOrEqual(3);
+      }
+    } finally {
+      clearImmediate(pending);
+    }
+  });
+
+  it.each([
     { count: 32, mutationTurn: 1, completes: true },
     { count: 64, mutationTurn: 2, completes: true },
     { count: 33, mutationTurn: 1, completes: false },

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -183,12 +183,14 @@ export async function listTaskRecordPage(params: {
     if (params.expectedRevision !== undefined && params.expectedRevision !== revision) {
       return err("cursor_stale");
     }
-    const scanLimit = tasks.size;
+    // Session pages scan only related candidates; exact owner/agent checks still run below.
+    const source = sessionKey ? taskIdsByRelatedSessionKey.get(sessionKey) : tasks;
+    const scanLimit = source?.size ?? 0;
     const window: TaskRecord[] = [];
     let matchingCount = 0;
     let heapReady = false;
     let scannedCount = 0;
-    const iterator = tasks.values();
+    const iterator = source?.keys() ?? [].values();
     let current = iterator.next();
     while (!current.done && scannedCount < scanLimit) {
       // Yield only when another batch exists; completed pages keep their revision.
@@ -197,7 +199,10 @@ export async function listTaskRecordPage(params: {
       }
       const batch: TaskRecord[] = [];
       while (!current.done && batch.length < 32 && scannedCount < scanLimit) {
-        batch.push(current.value);
+        const task = tasks.get(current.value);
+        if (task) {
+          batch.push(task);
+        }
         scannedCount += 1;
         current = iterator.next();
       }

--- a/src/tasks/task-registry-session-index.test.ts
+++ b/src/tasks/task-registry-session-index.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createNextAcpTaskBackingDetail } from "./task-backing-authority.js";
+import { createAcpTaskBackingDetailForTest } from "./task-backing-authority.test-support.js";
+import { createTaskFlowForTask } from "./task-flow-registry.js";
+import { publishTaskRecordAfterAtomicStore, updateTask } from "./task-registry-mutation.js";
+import {
+  deleteTaskRecordById,
+  hasActiveTaskForChildSessionKey,
+  listTaskRecordPage,
+  listTasksForRelatedSessionKey,
+} from "./task-registry-query.js";
+import { createTaskRecord, linkTaskToFlowById } from "./task-registry-record-api.js";
+import { reloadTaskRegistryFromStore } from "./task-registry-state.js";
+import { configureTaskRegistryRuntime, getTaskRegistryStore } from "./task-registry.store.js";
+import { upsertTaskRegistryRecordToSqlite } from "./task-registry.store.sqlite.js";
+import {
+  resetTaskFlowRegistryForTests,
+  resetTaskRegistryForTests,
+} from "./task-runtime.test-helpers.js";
+
+let state: Awaited<ReturnType<typeof createOpenClawTestState>>;
+beforeEach(async () => {
+  state = await createOpenClawTestState({ scenario: "minimal" });
+  resetTaskRegistryForTests({ persist: false });
+  resetTaskFlowRegistryForTests({ persist: false });
+});
+afterEach(async () => {
+  resetTaskRegistryForTests({ persist: false });
+  resetTaskFlowRegistryForTests({ persist: false });
+  await state.cleanup();
+});
+
+function createTask(params: Partial<Parameters<typeof createTaskRecord>[0]>) {
+  const task = createTaskRecord({
+    runtime: "cli",
+    scopeKind: "session",
+    ownerKey: "agent:main:owner",
+    requesterSessionKey: "agent:main:requester",
+    childSessionKey: "agent:main:child",
+    status: "running",
+    deliveryStatus: "not_applicable",
+    task: "Indexed session task",
+    ...params,
+  });
+  if (!task) {
+    throw new Error("task creation failed");
+  }
+  return task;
+}
+
+async function taskIds(params: Omit<Parameters<typeof listTaskRecordPage>[0], "offset" | "limit">) {
+  const result = await listTaskRecordPage({ ...params, offset: 0, limit: 100 });
+  if (!result.ok) {
+    throw new Error(result.error);
+  }
+  return result.value.tasks.map((task) => task.taskId);
+}
+
+it("publishes requester membership through create, update, restore, atomic publication and delete", async () => {
+  const task = createTask({});
+  const originalKey = task.requesterSessionKey;
+  expect(await taskIds({ sessionKey: originalKey })).toEqual([task.taskId]);
+  expect(hasActiveTaskForChildSessionKey({ sessionKey: originalKey })).toBe(false);
+  expect(hasActiveTaskForChildSessionKey({ sessionKey: task.childSessionKey! })).toBe(true);
+
+  const store = getTaskRegistryStore();
+  configureTaskRegistryRuntime({
+    store: {
+      ...store,
+      upsertTaskWithDeliveryState: () => {
+        throw new Error("fixture write rejected");
+      },
+    },
+  });
+  try {
+    expect(updateTask(task.taskId, { requesterSessionKey: "agent:main:rejected" })).toBeNull();
+    expect(await taskIds({ sessionKey: originalKey })).toEqual([task.taskId]);
+    expect(await taskIds({ sessionKey: "agent:main:rejected" })).toEqual([]);
+  } finally {
+    configureTaskRegistryRuntime({ store });
+  }
+
+  const updated = updateTask(task.taskId, { requesterSessionKey: task.ownerKey });
+  expect(updated).not.toBeNull();
+  expect(await taskIds({ sessionKey: originalKey })).toEqual([]);
+  expect(await taskIds({ sessionKey: task.ownerKey })).toEqual([task.taskId]);
+  reloadTaskRegistryFromStore();
+  expect(listTasksForRelatedSessionKey(task.ownerKey).map((row) => row.taskId)).toEqual([
+    task.taskId,
+  ]);
+
+  const published = { ...task, requesterSessionKey: "agent:main:published" };
+  upsertTaskRegistryRecordToSqlite(published);
+  publishTaskRecordAfterAtomicStore(published);
+  expect(await taskIds({ sessionKey: published.requesterSessionKey })).toEqual([task.taskId]);
+  expect(await taskIds({ sessionKey: task.ownerKey })).toEqual([task.taskId]);
+  expect(deleteTaskRecordById(task.taskId)).toBe(true);
+  reloadTaskRegistryFromStore();
+  for (const sessionKey of [
+    originalKey,
+    published.requesterSessionKey,
+    task.ownerKey,
+    task.childSessionKey!,
+  ]) {
+    expect(await taskIds({ sessionKey })).toEqual([]);
+  }
+});
+
+it("keeps requester-only bare keys bound to their agent", async () => {
+  const cfg = {
+    session: { scope: "global" },
+    agents: { ownership: "explicit", entries: { ops: {}, research: {} } },
+  } satisfies OpenClawConfig;
+  const tasks = ["ops", "research"].map((requesterAgentId) =>
+    createTask({ requesterSessionKey: "global", requesterAgentId }),
+  );
+  for (const [index, sessionAgentId] of ["ops", "research"].entries()) {
+    expect(await taskIds({ cfg, sessionKey: "global", sessionAgentId })).toEqual([
+      tasks[index]?.taskId,
+    ]);
+  }
+  expect(
+    await taskIds({ cfg, sessionKey: "global", sessionAgentId: "ops", agentId: "research" }),
+  ).toEqual([]);
+});
+
+it("preserves owner-or-child ACP generation history when requester candidates are added", async () => {
+  const key = "agent:main:watched";
+  const records = [
+    { childSessionKey: key, generation: 2 },
+    { ownerKey: key, generation: 8 },
+    { requesterSessionKey: key, generation: 100 },
+    { generation: 200 },
+  ].map(({ generation, ...keys }) => {
+    const task = createTask({
+      ...keys,
+      runtime: "acp",
+      runId: `run-${generation}`,
+      detail: createAcpTaskBackingDetailForTest(`instance-${generation}`, generation),
+    });
+    const flow = createTaskFlowForTask({ task });
+    if (!flow) {
+      throw new Error("task flow creation failed");
+    }
+    expect(linkTaskToFlowById({ taskId: task.taskId, flowId: flow.flowId })).not.toBeNull();
+    return task;
+  });
+  expect(new Set(await taskIds({ sessionKey: key }))).toEqual(
+    new Set(records.slice(0, 3).map((task) => task.taskId)),
+  );
+  expect(
+    createNextAcpTaskBackingDetail({ childSessionKey: key, instanceId: "next" }),
+  ).toMatchObject({ generation: 9 });
+  reloadTaskRegistryFromStore();
+  expect(
+    createNextAcpTaskBackingDetail({ childSessionKey: key, instanceId: "after-restore" }),
+  ).toMatchObject({ generation: 9 });
+  expect(deleteTaskRecordById(records[0]!.taskId)).toBe(true);
+  expect(hasActiveTaskForChildSessionKey({ sessionKey: key })).toBe(false);
+});

--- a/src/tasks/task-registry-state.ts
+++ b/src/tasks/task-registry-state.ts
@@ -341,11 +341,13 @@ function deleteIndexedKey(index: Map<string, Set<string>>, key: string, taskId: 
   }
 }
 
-function getTaskRelatedSessionIndexKeys(task: Pick<TaskRecord, "ownerKey" | "childSessionKey">) {
+type TaskSessionKeys = Pick<TaskRecord, "requesterSessionKey" | "ownerKey" | "childSessionKey">;
+
+function getTaskRelatedSessionIndexKeys(task: TaskSessionKeys) {
   return uniqueStrings(
-    [normalizeOptionalString(task.ownerKey), normalizeOptionalString(task.childSessionKey)].filter(
-      Boolean,
-    ) as string[],
+    [task.requesterSessionKey, task.ownerKey, task.childSessionKey]
+      .map(normalizeOptionalString)
+      .filter((key): key is string => Boolean(key)),
   );
 }
 
@@ -381,19 +383,13 @@ export function deleteParentFlowIdIndex(taskId: string, task: Pick<TaskRecord, "
   deleteIndexedKey(taskIdsByParentFlowId, key, taskId);
 }
 
-export function addRelatedSessionKeyIndex(
-  taskId: string,
-  task: Pick<TaskRecord, "ownerKey" | "childSessionKey">,
-) {
+export function addRelatedSessionKeyIndex(taskId: string, task: TaskSessionKeys) {
   for (const sessionKey of getTaskRelatedSessionIndexKeys(task)) {
     addIndexedKey(taskIdsByRelatedSessionKey, sessionKey, taskId);
   }
 }
 
-export function deleteRelatedSessionKeyIndex(
-  taskId: string,
-  task: Pick<TaskRecord, "ownerKey" | "childSessionKey">,
-) {
+export function deleteRelatedSessionKeyIndex(taskId: string, task: TaskSessionKeys) {
   for (const sessionKey of getTaskRelatedSessionIndexKeys(task)) {
     deleteIndexedKey(taskIdsByRelatedSessionKey, sessionKey, taskId);
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a session’s background-task list can receive “Task activity did not stabilize” while unrelated tasks are active, even when the session has only one related task.

## Why This Change Was Made

Session pages scanned the whole registry and yielded between batches, allowing unrelated activity to invalidate every attempt. They now select candidates from the existing in-memory related-session index, completed for requester, owner and child keys. Exact agent/session predicates, global cursor revisions and fresh authorization remain authoritative.

ACP generation discovery explicitly keeps its previous owner-or-child candidate set. Create, update, restore, atomic publication and deletion use the same index owner, with persistence succeeding before publication. No stored representation, SQLite schema/index, configuration or RPC contract changes.

Production changes are +27/−16 lines (net +11), including the ownership check needed to preserve ACP generation semantics. Tests add 255 lines; the assertion baseline shrinks by one after removing an unnecessary cast.

## User Impact

Session task lists avoid scanning unrelated registry entries. Large candidate sets and global lists retain cooperative yielding and revision checks.

## Evidence

- Original-source reproduction: the sparse-session case failed; its dense fairness control and eight existing selector cases passed.
- Linux: 98 tests passed across nine files, including real authenticated WebSocket Gateway requests, profile-merge/stale-cursor checks, requester-only colliding agent keys, failed-write publication, lifecycle restoration/deletion and ACP generation history.
- All 30 canonical changed checks passed. The first gate correctly rejected the stale assertion allowance; lowering it from four to three resolved that failure without changing runtime or test source.
- Independent Codex review found no actionable P0–P2 issues in the final eight-file diff.

The Gateway proof uses isolated synthetic task fixtures and real authorization/session storage. This is a deterministic correctness and scan-work reduction proof, not a production latency benchmark. Regression introduction is not attributed. Hosted exact-head CI remains a separate landing gate.
