### PR TITLE
refactor(sqlite): reduce redundant store query work

### DIFF
--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -1,17 +1,22 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
 // Cron store tests cover persisted scheduled job state and run metadata.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { trackSqliteStatementExecutions } from "../../test/helpers/sqlite-statement-execution-counter.js";
 import { loadLegacyCronQuarantineForMigration } from "../commands/doctor/cron/legacy-quarantine-migration.js";
 import {
   archiveLegacyCronStoreForMigration,
   loadLegacyCronStoreForMigration,
 } from "../commands/doctor/cron/legacy-store-migration.js";
 import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   assertCronJobsStoreUnchanged,
   CronJobsStoreChangedError,
@@ -25,6 +30,7 @@ import {
   saveCronQuarantinedJobs,
   saveCronStore,
 } from "./store.js";
+import { cronStoreKey } from "./store/key.js";
 import type { CronStoreFile } from "./types.js";
 
 let fixtureRoot = "";
@@ -1782,6 +1788,75 @@ describe("saveCronStore", () => {
   });
 });
 describe("cron jobs fingerprint guard", () => {
+  it.each(["UTF-8", "UTF-16le", "UTF-16be"])(
+    "fingerprints one raw definition snapshot independently of %s storage",
+    async (encoding) => {
+      await withOpenClawTestState({ label: "cron-fingerprint" }, async (state) => {
+        const databasePath = resolveOpenClawStateSqlitePath(state.env);
+        await fs.mkdir(path.dirname(databasePath), { recursive: true });
+        const initial = new DatabaseSync(databasePath);
+        try {
+          // SQLite fixes file encoding at the first schema write, even after that table is removed.
+          initial.exec(
+            `PRAGMA encoding = '${encoding}'; CREATE TABLE fixture(id); DROP TABLE fixture;`,
+          );
+        } finally {
+          initial.close();
+        }
+        const storePath = state.statePath("cron", "jobs.json");
+        const jobs = ["z", "\u{10000}", "\ue000", "malformed"].map((id) =>
+          expectDefined(makeStore(id, true).jobs[0], "fingerprint fixture"),
+        );
+        await saveCronStore(storePath, { version: 1, jobs });
+        const db = openOpenClawStateDatabase().db;
+        expect(db.prepare("PRAGMA encoding").get()).toEqual({ encoding });
+        const storeKey = cronStoreKey(storePath);
+        db.prepare(
+          "UPDATE cron_jobs SET job_json = '{malformed' WHERE store_key = ? AND job_id = ?",
+        ).run(storeKey, "malformed");
+        const raw = db
+          .prepare(
+            "SELECT job_id, job_json, sort_order FROM cron_jobs WHERE store_key = ? ORDER BY job_id",
+          )
+          .all(storeKey);
+        const expectedOrder = ["malformed", "z", "\ue000", "\u{10000}"].map((id) =>
+          expectDefined(
+            raw.find((row) => row.job_id === id),
+            "raw fingerprint row",
+          ),
+        );
+        const fingerprint = createHash("sha256")
+          .update(JSON.stringify(expectedOrder))
+          .digest("hex");
+        const reads = trackSqliteStatementExecutions(db, ["jobs"], (sql) =>
+          sql.startsWith("select ") && sql.includes('from "cron_jobs"') ? "jobs" : null,
+        );
+        try {
+          const loaded = await loadCronJobsStoreWithConfigJobs(storePath);
+          expect(loaded.jobsFingerprint).toBe(fingerprint);
+          expect(loaded.store.jobs.map((job) => job.id)).toEqual(["z", "\u{10000}", "\ue000"]);
+          expect(loaded.invalidConfigRows).toHaveLength(1);
+          expect(reads.rowCounts.jobs).toBe(4);
+          expect(reads.counts.jobs).toBe(1);
+        } finally {
+          reads.restore();
+        }
+        db.prepare("UPDATE cron_jobs SET state_json = ? WHERE store_key = ? AND job_id = ?").run(
+          '{"lastRunAtMs":42}',
+          storeKey,
+          "z",
+        );
+        expect(() => assertCronJobsStoreUnchanged(db, storePath, fingerprint)).not.toThrow();
+        db.prepare(
+          "UPDATE cron_jobs SET sort_order = sort_order + 1 WHERE store_key = ? AND job_id = ?",
+        ).run(storeKey, "z");
+        expect(() => assertCronJobsStoreUnchanged(db, storePath, fingerprint)).toThrow(
+          CronJobsStoreChangedError,
+        );
+      });
+    },
+  );
+
   it("refuses a replace after a concurrent order change and accepts a fresh snapshot", async () => {
     const { storePath } = await makeStorePath();
     const jobA = expectDefined(makeStore("job-a", true).jobs[0], "job-a fixture");

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -6,6 +6,7 @@ import { isDeepStrictEqual } from "node:util";
 import { expandHomePrefix } from "../infra/home-dir.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -23,6 +24,7 @@ import {
   assertCronStoreCanPersist,
   deleteCronJobRowInDatabase,
   deleteStaleCronJobFamilyRows,
+  fingerprintCronJobRows,
   loadedCronStoreFromRows,
   loadCronRows,
   readCronJobsFingerprint,
@@ -103,8 +105,8 @@ export async function loadCronJobsStoreWithConfigJobs(storePath: string): Promis
   const resolvedStorePath = path.resolve(storePath);
   const storeKey = cronStoreKey(resolvedStorePath);
   const database = openOpenClawStateDatabase().db;
-  const jobsFingerprint = readCronJobsFingerprint(database, storeKey);
   const rows = loadCronRows(database, storeKey);
+  const jobsFingerprint = fingerprintCronJobRows(rows);
   if (rows.length > 0) {
     const loaded = loadedCronStoreFromRows(rows);
     const authority = loadCronRuntimeAuthorities({
@@ -196,14 +198,6 @@ function emptyLoadedCronStore(): LoadedCronStore {
     configJobRuntimeEntries: [],
     invalidConfigRows: [],
   };
-}
-
-function tableExists(db: DatabaseSync, tableName: string): boolean {
-  return (
-    db
-      .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = ?")
-      .get(tableName) !== undefined
-  );
 }
 
 /** Loads cron jobs from an existing SQLite store without creating or migrating state. */

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -212,17 +212,31 @@ export function loadCronRows(
   return jobIds ? rows.filter((row) => jobIds.has(row.job_id)) : rows;
 }
 
-/** Fingerprints definition JSON and order while excluding runtime-owned state. */
+/** Fingerprints raw definition rows without mutating their config order. */
+export function fingerprintCronJobRows(
+  rows: readonly Pick<CronJobRow, "job_id" | "job_json" | "sort_order">[],
+): string {
+  // This internal, transient Doctor token uses one encoding-independent ID order.
+  // Keep raw fields so every definition edit invalidates the snapshot.
+  const ordered = rows
+    .map(({ job_id, job_json, sort_order }) => ({
+      idBytes: Buffer.from(job_id),
+      definition: { job_id, job_json, sort_order },
+    }))
+    .toSorted((left, right) => Buffer.compare(left.idBytes, right.idBytes));
+  return sha256Hex(JSON.stringify(ordered.map(({ definition }) => definition)));
+}
+
+/** Reads only definition JSON and order while excluding runtime-owned state. */
 export function readCronJobsFingerprint(db: DatabaseSync, storeKey: string): string {
   const rows = executeSqliteQuerySync(
     db,
     getCronStoreKysely(db)
       .selectFrom("cron_jobs")
       .select(["job_id", "job_json", "sort_order"])
-      .where("store_key", "=", storeKey)
-      .orderBy("job_id", "asc"),
+      .where("store_key", "=", storeKey),
   ).rows;
-  return sha256Hex(JSON.stringify(rows));
+  return fingerprintCronJobRows(rows);
 }
 
 /** Materializes retired ownership within the caller's write transaction. */

--- a/src/infra/delivery-queue-sqlite.test.ts
+++ b/src/infra/delivery-queue-sqlite.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { trackSqliteStatementExecutions } from "../../test/helpers/sqlite-statement-execution-counter.js";
 import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import {
   claimDeliveryQueueEntryPlatformSend,
@@ -15,6 +16,7 @@ import {
   countPendingDeliveryQueueEntries,
   deleteDeliveryQueueEntry,
   getDeliveryQueueEntryStatus,
+  getDeliveryQueueEntryOwners,
   loadDeliveryQueueEntries,
   loadDeliveryQueueEntry,
   moveDeliveryQueueEntryToFailed,
@@ -127,6 +129,38 @@ describe("delivery-queue-sqlite corrupt JSON resilience", () => {
 
     expect(countPendingDeliveryQueueEntries([QUEUE, "other-q"], stateDir)).toBe(1);
     expect(countPendingDeliveryQueueEntries([], stateDir)).toBe(0);
+  });
+
+  it("reads ownership without materializing unrelated queue payloads", () => {
+    const id = "large-pending-payload";
+    for (const status of ["pending", "failed"] as const) {
+      const entry = {
+        id,
+        enqueuedAt: Date.now(),
+        retryCount: 0,
+        payload: "x".repeat(16_384),
+        ...(status === "failed" ? { recoveryState: "settlement_pending" } : {}),
+      };
+      upsertDeliveryQueueEntry({ queueName: status, entry, status, stateDir });
+    }
+    const { db } = openOpenClawStateDatabase({
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    const reads = trackSqliteStatementExecutions(db, ["owners"], (sql) =>
+      sql.startsWith("select ") && sql.includes('from "delivery_queue_entries"') ? "owners" : null,
+    );
+    try {
+      expect(getDeliveryQueueEntryOwners(["pending", "failed"], id, stateDir)).toEqual(
+        new Map([
+          ["failed", { status: "failed", settlementPending: true }],
+          ["pending", { status: "pending" }],
+        ]),
+      );
+      expect(reads.rowCounts.owners).toBe(2);
+      expect(reads.textBytes.owners).toBeLessThan(1024);
+    } finally {
+      reads.restore();
+    }
   });
 
   describe("updateDeliveryQueueEntry with corrupt row", () => {

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -40,7 +40,7 @@ type QueueStatus = "pending" | "failed" | "completed";
 type DeliveryQueueStatusRow = {
   queue_name: string;
   status?: QueueStatus;
-  entry_json: string;
+  entry_json: string | null;
   recovery_state: string | null;
 };
 
@@ -92,13 +92,14 @@ export function expireStagingAndLoadDeliveryQueueEntries(params: {
   const snapshot = runSqliteImmediateTransactionSync(
     database.db,
     () => {
-      // sqlite-allow-raw: Expiry must share the write snapshot with both ownership reads.
-      database.db
-        .prepare(
-          `DELETE FROM delivery_queue_entries
-            WHERE queue_name = ? AND status = 'pending' AND enqueued_at <= ?`,
-        )
-        .run(params.stagingQueueName, params.expireBeforeMs);
+      executeSqliteQuerySync(
+        database.db,
+        getNodeSqliteKysely<DeliveryQueueDatabase>(database.db)
+          .deleteFrom("delivery_queue_entries")
+          .where("queue_name", "=", params.stagingQueueName)
+          .where("status", "=", "pending")
+          .where("enqueued_at", "<=", params.expireBeforeMs),
+      );
       const read = (queueNames: readonly string[]) =>
         executeSqliteQuerySync(
           database.db,
@@ -175,14 +176,23 @@ export function getDeliveryQueueEntryOwnersInDatabase(
           database.db,
           queueDb
             .selectFrom("delivery_queue_entries")
-            .select(["queue_name", "status", "entry_json", "recovery_state"])
+            .select(["queue_name", "status", "recovery_state"])
+            .select((eb) =>
+              eb
+                .case("recovery_state")
+                .when("completed_bounded")
+                .then(eb.ref("entry_json"))
+                .else(null)
+                .end()
+                .as("entry_json"),
+            )
             .where("queue_name", "in", queueNames)
             .where("id", "=", id),
         ).rows as DeliveryQueueStatusRow[];
       let rows = readExact();
       let pruned = false;
       for (const row of rows) {
-        if (row.recovery_state !== "completed_bounded") {
+        if (row.entry_json === null) {
           continue;
         }
         const entry = safeParseJsonRecord(row.entry_json);

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -380,27 +380,26 @@ function deleteOldestPluginStateNamespaceEntries(
   db: DatabaseSync,
   params: { pluginId: string; namespace: string; protectedKey: string; now: number; limit: number },
 ): number {
-  const keys = executeSqliteQuerySync(
+  const kysely = getPluginStateKysely(db);
+  const keys = kysely
+    .selectFrom("plugin_state_entries")
+    .select("entry_key")
+    .where("plugin_id", "=", params.pluginId)
+    .where("namespace", "=", params.namespace)
+    .where("entry_key", "!=", params.protectedKey)
+    .where((eb) => eb.or([eb("expires_at", "is", null), eb("expires_at", ">", params.now)]))
+    .orderBy("created_at", "asc")
+    .orderBy("entry_key", "asc")
+    .limit(params.limit);
+  const result = executeSqliteQuerySync(
     db,
-    getPluginStateKysely(db)
-      .selectFrom("plugin_state_entries")
-      .select(["entry_key"])
+    kysely
+      .deleteFrom("plugin_state_entries")
       .where("plugin_id", "=", params.pluginId)
       .where("namespace", "=", params.namespace)
-      .where("entry_key", "!=", params.protectedKey)
-      .where((eb) => eb.or([eb("expires_at", "is", null), eb("expires_at", ">", params.now)]))
-      .orderBy("created_at", "asc")
-      .orderBy("entry_key", "asc")
-      .limit(params.limit),
-  ).rows;
-  for (const row of keys) {
-    deletePluginStateEntry(db, {
-      pluginId: params.pluginId,
-      namespace: params.namespace,
-      key: row.entry_key,
-    });
-  }
-  return keys.length;
+      .where("entry_key", "in", keys),
+  );
+  return Number(result.numAffectedRows ?? 0);
 }
 
 function openPluginStateDatabase(

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -3,6 +3,7 @@ import { chmodSync, existsSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { trackSqliteStatementExecutions } from "../../test/helpers/sqlite-statement-execution-counter.js";
 import {
   closeOpenClawStateDatabaseByPath,
   isOpenClawStateDatabaseOpen,
@@ -505,18 +506,38 @@ describe("plugin state keyed store", () => {
     });
   });
 
-  it("evicts oldest live entries over maxEntries", async () => {
+  it("evicts oldest live entries over maxEntries with bounded database calls", async () => {
     await withPluginStateTestState(async () => {
       vi.useFakeTimers();
-      const store = createPluginStateKeyedStore("discord", { namespace: "evict", maxEntries: 2 });
       vi.setSystemTime(1000);
-      await store.register("a", 1);
-      vi.setSystemTime(2000);
-      await store.register("b", 2);
-      vi.setSystemTime(3000);
-      await store.register("c", 3);
+      seedPluginStateEntriesForTests(
+        Array.from({ length: 64 }, (_, index) => ({
+          pluginId: "discord",
+          namespace: "evict",
+          key: `key-${String(index).padStart(2, "0")}`,
+          value: index,
+          createdAt: Math.floor(index / 2),
+        })),
+      );
+      const store = createPluginStateKeyedStore("discord", { namespace: "evict", maxEntries: 3 });
+      const statements = trackSqliteStatementExecutions(
+        openOpenClawStateDatabase().db,
+        ["delete"],
+        (sql) => (sql.startsWith('delete from "plugin_state_entries"') ? "delete" : null),
+      );
+      try {
+        await store.register("a-protected", 64);
+      } finally {
+        statements.restore();
+      }
 
-      expect((await store.entries()).map((entry) => entry.key)).toEqual(["b", "c"]);
+      // One bounded expiry sweep plus eviction must not scale with the victim count.
+      expect(statements.counts.delete).toBeLessThanOrEqual(2);
+      expect(await store.entries()).toEqual([
+        { key: "key-62", value: 62, createdAt: 31 },
+        { key: "key-63", value: 63, createdAt: 31 },
+        { key: "a-protected", value: 64, createdAt: 1000 },
+      ]);
     });
   });
 

--- a/test/helpers/sqlite-statement-execution-counter.ts
+++ b/test/helpers/sqlite-statement-execution-counter.ts
@@ -13,10 +13,16 @@ export function trackSqliteStatementExecutions<Key extends string>(
   db: DatabaseSync,
   keys: readonly Key[],
   classify: (sql: string) => Key | null,
-): { counts: Record<Key, number>; rowCounts: Record<Key, number>; restore: () => void } {
+): {
+  counts: Record<Key, number>;
+  rowCounts: Record<Key, number>;
+  textBytes: Record<Key, number>;
+  restore: () => void;
+} {
   clearNodeSqliteKyselyCacheForDatabase(db);
   const counts = Object.fromEntries(keys.map((key) => [key, 0])) as Record<Key, number>;
   const rowCounts = Object.fromEntries(keys.map((key) => [key, 0])) as Record<Key, number>;
+  const textBytes = Object.fromEntries(keys.map((key) => [key, 0])) as Record<Key, number>;
   const originalPrepare = db.prepare.bind(db);
   const prepareSpy = vi.spyOn(db, "prepare").mockImplementation((sqlText: string) => {
     const statement = originalPrepare(sqlText);
@@ -39,6 +45,11 @@ export function trackSqliteStatementExecutions<Key extends string>(
         return (function* () {
           for (const row of rows) {
             rowCounts[key] += 1;
+            for (const value of Object.values(row)) {
+              if (typeof value === "string") {
+                textBytes[key] += Buffer.byteLength(value);
+              }
+            }
             yield row;
           }
         })();
@@ -46,5 +57,13 @@ export function trackSqliteStatementExecutions<Key extends string>(
     }
     return statement;
   });
-  return { counts, rowCounts, restore: () => prepareSpy.mockRestore() };
+  return {
+    counts,
+    rowCounts,
+    textBytes,
+    restore: () => {
+      clearNodeSqliteKyselyCacheForDatabase(db);
+      prepareSpy.mockRestore();
+    },
+  };
 }


### PR DESCRIPTION
## What Problem This Solves

Large plugin-state evictions perform one DELETE per victim, delivery ownership checks load payloads they do not use, and Cron's configuration loader reads every definition twice. These operations add synchronous database work to ordinary state, delivery, and automation flows.

## Why This Change Was Made

Use the existing ordered victim selection inside one scoped Kysely DELETE; project delivery JSON only when bounded receipt expiry needs it; and fingerprint the raw Cron rows already loaded. Both Cron fingerprint producers share the same raw-field serialization and UTF-8 identifier ordering, including malformed rows. The fingerprint is a private, transient Doctor comparison token: existing UTF-8 bytes stay identical, and UTF-16 stores retain the same concurrent-change protection.

The same owner pass replaces staging expiry's ordinary raw DELETE with typed Kysely and removes Cron's duplicate table-existence probe in favor of the shared schema helper. Transaction boundaries, persisted values, eviction policy, receipt expiry, schemas, and public APIs remain unchanged.

## User Impact

Existing SQLite flows do less query and row-materialization work. No setup, migration, or configuration change is required. This continues database cleanup while retaining SQLite as the runtime backend.

## Evidence

- Regressions failed before the change for the intended reasons: 63 eviction DELETEs versus a bound of two, 33,019 projected text bytes versus a bound of 1,024, and eight Cron definition rows returned instead of four.
- Focused owner and sibling coverage passed 204 tests in nine files. After the final adjacent simplifications, 135 affected tests in five files passed. The final changed-file gate passed types, lint, formatting, dead-export, storage/schema, and import-cycle checks.
- Native baseline/candidate comparisons preserve complete retained/victim rows and durable hashes. A large eviction falls from 2,044 DELETEs to one; a two-quota case falls from six to two. Delivery ownership reads avoid projecting 16,777,405 bytes of unused JSON, while bounded expiry, malformed receipts, and settlement ownership retain their behavior. Cron definition reads fall from two to one.
- Native UTF-8, UTF-16le, and UTF-16be probes cover raw malformed rows, identifier ordering, runtime-only updates, stale definition rejection, integrity, and fresh reopen. Staging probes cover inclusive expiry, failed/sibling preservation, late-producer refusal, recent commit, and read-only missing-store noncreation.
- Fresh independent Codex review found no actionable P0–P2 findings. Independent proof on commit `08701cc6b5cb` passed all eight phases: actual Doctor repair preserves concurrent runtime updates, rejects stale definition changes without partial quarantine, and succeeds on fresh retry; real Cron CLI execution records a local command receipt and preserves complete list/get payloads and receipts across Gateway restart. A fresh process confirms durable rows and integrity. All synthetic state and processes were removed. The complete synthetic trace is posted below.

The initial changed gate exposed a nullable projection type and an array-sort lint issue; both were fixed and the full gate rerun successfully. Statement and projected-byte counts are direct native observations, not latency or disk-I/O benchmarks.

Production delta is +58/−41 (net +17): one shared raw-row fingerprint owner and typed query projections replace duplicate reads and per-row deletion. Tests add 130 lines net; shared measurement support adds 19. No dependency, schema, retention, or configuration surface is added.
