### PR TITLE
fix(codex): avoid worker heap exhaustion in release tests

### DIFF
--- a/extensions/codex/src/app-server/remote-workspace-media.test.ts
+++ b/extensions/codex/src/app-server/remote-workspace-media.test.ts
@@ -113,7 +113,7 @@ describe("readBoundedCodexRemoteWorkspaceFile", () => {
       maxBytes: expected.byteLength,
     });
 
-    expect(Buffer.from(result.dataBase64, "base64")).toEqual(expected);
+    expect(Buffer.from(result.dataBase64, "base64").equals(expected)).toBe(true);
     expect(client.request).toHaveBeenCalledTimes(2);
     expect(client.request.mock.calls[0]?.[1].command).toEqual([
       "node",

--- a/extensions/codex/src/session-rollout-snapshot.test.ts
+++ b/extensions/codex/src/session-rollout-snapshot.test.ts
@@ -47,7 +47,8 @@ describe("bounded native rollout snapshot", () => {
       const snapshot = await f.read();
       expect(snapshot.metadata).toEqual(meta().payload);
       await snapshot.assertUnchanged();
-      expect(await fs.readFile(f.selectedPath)).toEqual(before);
+      // Deep equality expands every byte into entries; compare the full buffers natively.
+      expect((await fs.readFile(f.selectedPath)).equals(before)).toBe(true);
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Codex plugin batch in full release verification exhausts its worker heap before completing the rollout snapshot tests. The original-order batch reproduced on Linux with Node 24.20.0 and an 8 GiB worker heap; passive diagnostics identified `ERR_WORKER_OUT_OF_MEMORY` after 158 files.

## Why This Change Was Made

Vitest's deep equality matcher enumerates every index of the 9 MiB rollout buffer into entry arrays. Compare the complete buffers with `Buffer.equals` instead, preserving the exact length-and-byte invariant without those allocations. The existing 9 MiB fixture and both plain/zstd cases remain intact.

Apply the same byte-comparison cleanup to the nearby 512 KiB-plus-17-byte remote-media fixture. That assertion is a bounded sibling cleanup, not a separate reproduced cause of the full-batch crash. Runtime behavior, limits, worker configuration, ordering, and retries are unchanged. Production LOC: +0/-0; tests: +3/-2.

## User Impact

Maintainers can run the Codex release verification batch with its existing memory budget. There is no product behavior or public API change.

## Evidence

- Original full-batch reproduction: frozen source `2329399cf6a9a2ca0c19d6c620b713a2768f9125`, Linux x86_64, Node 24.20.0, one worker, 8 GiB heap. Exit 1 after 158 files and 4,702 passing results. A diagnostic replay reported `ERR_WORKER_OUT_OF_MEMORY` at the same point.
- Same-order repaired full batch: exit 0, 215 files passed and 1 skipped; 4,990 tests passed and 10 skipped. Vitest duration 763.05 seconds; whole command 12m44.26s. The unchanged configuration excludes four live-test files from the 220 enumerated targets. Snapshot plain/zstd cases completed in 15/8 ms. The wrapper reported success; its subsequent external portal sync timed out after the successful command.
- Isolated rollout snapshot file, before/after on macOS Node 26.8.1: 20/20 passed in both versions; peak RSS fell from 4.28 GiB to 1.83 GiB, and the plain-file case fell from 12.0 seconds to 293 ms. This is supplemental allocation evidence; the Linux batch owns the release reproduction.
- Remote-media sibling file, before/after: 23/23 passed in both versions; the chunk-reassembly case fell from 1,295 ms to 144 ms.
- Whole-batch peak RSS remained about 10.9 GiB (11,434,156 KiB after, 11,392,808 KiB before). The proof is completion within the existing worker heap limit and reduced isolated assertion allocation; it is not a claim of lower peak RSS for the whole suite.
- Focused lint against frozen dependencies, formatting, diff checks, and independent review passed. No new tests were needed: the existing large fixtures reproduce the expensive assertions and retain their original coverage.

```sh
NODE_OPTIONS=--max-old-space-size=8192 \
OPENCLAW_EXTENSION_BATCH_PARALLEL=2 \
OPENCLAW_VITEST_MAX_WORKERS=1 \
pnpm test:extensions:batch codex -- --retry=1 \
  --exclude extensions/codex/src/app-server/run-attempt.test.ts
```

The large snapshot assertion was added in #137167 (`d15d0fa6c253431d5a30b101773d3cc175ea2b7d`); its raw parent diff confirms the 9 MiB fixture and deep equality assertion were introduced together. Source inspection covered the rollout reader, remote-media producer and callers, Vitest 4.1.11's equality implementation, Node's native byte comparator, and Codex's plain/zstd rollout storage contract.
