### PR TITLE
fix: retain numeric ranges in Code Mode tool hints

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -66,7 +66,10 @@ before the call settles.
   compact input hints, and compact declared output hints when a
   trusted tool provides an output schema. It omits descriptions, full schemas,
   MCP entries, and overflow entries; callable `catalog.search(...)` results are
-  the fallback.
+  the fallback. Input hints retain integer and numeric bounds as comments, such
+  as `offset?: number /* integer, >= 1 */`. Other validation details remain in
+  the full schema available through `describe()`; these hints do not change
+  tool validation or output contracts.
 - Guest code calls globals directly or searches the hidden catalog for callable
   handles. A handle exposes bounded metadata and `describe()`, but never the
   exact internal catalog id. Calls use the same execution path as normal agent

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -19,6 +19,7 @@ import {
   mcpTool,
   createCodeModeHarness,
 } from "./code-mode.test-support.js";
+import { readToolInputSchema } from "./sessions/tools/read-tool-contract.js";
 import { ToolSearchRuntime } from "./tool-search-runtime.js";
 import {
   createToolSearchCatalogRef,
@@ -375,11 +376,12 @@ describe("Code Mode catalog and model-visible surface", () => {
   it("primes the exec schema with callable names and compact contracts", () => {
     const { config, catalogRef, tools } = createCodeModeHarness();
     const alpha = pluginTool("alpha_tool", "Another deferred description.");
+    const read = { ...fakeTool("read", "Read file"), parameters: readToolInputSchema };
     alpha.outputSchema = Type.Array(
       Type.Object({ id: Type.String(), score: Type.Number() }, { additionalProperties: false }),
     );
     const compacted = applyCodeModeCatalog({
-      tools: [...tools, pluginTool("zeta_tool", "Description stays deferred."), alpha],
+      tools: [...tools, pluginTool("zeta_tool", "Description stays deferred."), alpha, read],
       config,
       sessionId: "session-code-mode",
       sessionKey: "agent:main:main",
@@ -393,6 +395,9 @@ describe("Code Mode catalog and model-visible surface", () => {
       "- alpha_tool { value?: string } -> Array<{ id: string; score: number }>",
     );
     expect(description).toContain("- zeta_tool { value?: string } -> ?");
+    expect(description).toContain(
+      "- read { path: string; cursor?: number /* integer, >= 0 */; limit?: number; offset?: number /* integer, >= 1 */; optional?: true } -> ?",
+    );
     expect(description).not.toContain("openclaw:fake-code-mode");
     expect(description.indexOf("alpha_tool")).toBeLessThan(description.indexOf("zeta_tool"));
     expect(description).not.toContain("Description stays deferred.");

--- a/src/agents/tool-schema-hints.test.ts
+++ b/src/agents/tool-schema-hints.test.ts
@@ -4,6 +4,80 @@ import { describe, expect, it } from "vitest";
 import { compactToolInputHint, compactToolOutputHint } from "./tool-schema-hints.js";
 
 describe("tool schema hints", () => {
+  it.each([
+    { schema: { type: "number" }, input: "number" },
+    { schema: { type: "integer" }, input: "number /* integer */" },
+    {
+      schema: { type: "number", minimum: -1.5, maximum: 0 },
+      input: "number /* >= -1.5, <= 0 */",
+    },
+    {
+      schema: { type: "number", exclusiveMinimum: -0.5, exclusiveMaximum: 3.5 },
+      input: "number /* > -0.5, < 3.5 */",
+    },
+    {
+      schema: {
+        type: "integer",
+        minimum: 0,
+        maximum: 10,
+        exclusiveMinimum: 1,
+        exclusiveMaximum: 9,
+      },
+      input: "number /* integer, >= 0, <= 10, > 1, < 9 */",
+    },
+  ])(
+    "preserves numeric input constraints without changing output hints: $input",
+    ({ schema, input }) => {
+      expect(compactToolInputHint(schema)).toBe(input);
+      expect(compactToolOutputHint(schema)).toBe("number");
+    },
+  );
+
+  it.each([
+    { exclusiveMinimum: true },
+    { exclusiveMaximum: false },
+    { minimum: "1" },
+    { maximum: Number.POSITIVE_INFINITY },
+    { minimum: Number.NEGATIVE_INFINITY },
+    { exclusiveMinimum: Number.NaN },
+  ])("defers malformed numeric bounds instead of inventing constraints: %j", (bounds) => {
+    expect(compactToolInputHint({ type: "number", ...bounds })).toBe("unknown");
+  });
+
+  it("keeps nested nullable numeric constraints scoped to input hints", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        values: { type: "array", items: { type: "number", minimum: 0, nullable: true } },
+      },
+      required: ["values"],
+      additionalProperties: false,
+    };
+
+    expect(compactToolInputHint(schema)).toBe("{ values: Array<number /* >= 0 */ | null> }");
+    expect(compactToolOutputHint(schema)).toBe("{ values: Array<number | null> }");
+  });
+
+  it("charges complete numeric annotations to the existing input budget", () => {
+    const schema = Type.Object(
+      Object.fromEntries(
+        Array.from({ length: 12 }, (_, index) => [
+          `field_${String(index).padStart(2, "0")}`,
+          Type.Integer({ minimum: 0, maximum: 100, description: "Description stays deferred." }),
+        ]),
+      ),
+      { additionalProperties: false },
+    );
+    const input = compactToolInputHint(schema);
+
+    expect(input).toContain("field_00: number /* integer, >= 0, <= 100 */");
+    expect(input).toContain("...");
+    expect(input).not.toContain("Description stays deferred.");
+    expect(input.length).toBeLessThanOrEqual(300);
+    expect(compactToolOutputHint(schema)).toContain("field_11: number");
+    expect(compactToolOutputHint(schema)).not.toContain("/*");
+  });
+
   it("renders nested declared outputs as compact TypeScript shapes", () => {
     const outputSchema = Type.Array(
       Type.Object(

--- a/src/agents/tool-schema-hints.ts
+++ b/src/agents/tool-schema-hints.ts
@@ -16,6 +16,12 @@ const MAX_COMPACT_UNION_TYPES = 5;
 const MAX_COMPACT_ENUM_VALUES = 8;
 const MAX_COMPACT_ENUM_CHARS = 96;
 const IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/u;
+const NUMERIC_INPUT_BOUNDS = [
+  ["minimum", ">="],
+  ["maximum", "<="],
+  ["exclusiveMinimum", ">"],
+  ["exclusiveMaximum", "<"],
+] as const;
 const UNSUPPORTED_SHAPE_KEYWORDS = [
   "$ref",
   "$dynamicRef",
@@ -41,17 +47,20 @@ type CompactSchemaLimits = {
   maxChars: number;
   maxDepth: number;
   maxProperties: number;
+  numericInputConstraints: boolean;
 };
 
 const INPUT_LIMITS: CompactSchemaLimits = {
   maxChars: MAX_COMPACT_INPUT_HINT_CHARS,
   maxDepth: MAX_COMPACT_INPUT_DEPTH,
   maxProperties: MAX_COMPACT_INPUT_SCHEMA_PROPERTIES,
+  numericInputConstraints: true,
 };
 const OUTPUT_LIMITS: CompactSchemaLimits = {
   maxChars: MAX_COMPACT_OUTPUT_HINT_CHARS,
   maxDepth: MAX_COMPACT_OUTPUT_DEPTH,
   maxProperties: MAX_COMPACT_OUTPUT_SCHEMA_PROPERTIES,
+  numericInputConstraints: false,
 };
 
 const UNKNOWN_HINT: SchemaHint = { text: "unknown", complete: false };
@@ -353,7 +362,24 @@ function compactSchemaType(
     return finish(completeHint([...new Set(rendered.map((hint) => hint.text))].join(" | ")));
   }
   if (type === "integer" || type === "number") {
-    return finish(completeHint("number"));
+    if (!limits.numericInputConstraints) {
+      return finish(completeHint("number"));
+    }
+    // Inputs need valid argument ranges; output hints retain their existing shapes.
+    const constraints = type === "integer" ? ["integer"] : [];
+    for (const [key, operator] of NUMERIC_INPUT_BOUNDS) {
+      const bound = schema[key];
+      if (bound === undefined) {
+        continue;
+      }
+      if (typeof bound !== "number" || !Number.isFinite(bound)) {
+        return UNKNOWN_HINT;
+      }
+      constraints.push(`${operator} ${bound}`);
+    }
+    return finish(
+      completeHint(`number${constraints.length > 0 ? ` /* ${constraints.join(", ")} */` : ""}`),
+    );
   }
   if (type === "array") {
     const itemHint = compactSchemaType(schema.items, depth + 1, limits);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Code Mode's compact tool index discarded existing integer and numeric-bound constraints. For example, the read tool's one-based offset appeared as an unrestricted number. A retained live run attempted three reads with offset zero and received validation errors before correcting them.

## Why This Change Was Made

The shared compact input renderer now retains integer, minimum, maximum and exclusive numeric bounds as TypeScript-style comments. It uses the existing schema facts for every tool rather than special-casing read. Invalid/nonfinite bounds remain unknown; validation, output hints, trust rules and ordering stay unchanged.

Production is **+27/−1, net +26** for the missing model-visible constraint capability. Tests are **+80/−1, net +79** (including nine layout lines); docs are **+4/−1**. No configuration, dependency, storage or protocol change is introduced.

## User Impact

The quick index can show `offset?: number /* integer, >= 1 */` and equivalent generic constraints. Hints remain guidance, not validators. The existing 300-character input, 800-character output and 8,000-character index limits remain; longer annotations can displace later fields or entries. Full schemas remain available through `describe()`.

## Evidence

All 122 candidate cases passed across six complete suites. The baseline passed 109 and failed the 13 expected new assertions; unstarted projects were continued after the first failing project, with no completed file retried. Per-file case order matches. Coverage includes numeric and malformed bounds, nullable/nested schemas, unchanged output hints, bounded rendering, the actual read schema in the quick index, dispatch and filesystem siblings. The normal mapped build and all 29 changed-file checks passed on base 94ae415c565088667b594c16edc77791b516ed21.

Independent Codex P0–P2 review returned scoped-clean with no findings across two context partitions; their context limitations remain recorded. This is a source verdict, not a performance or hosted-CI result.

A real OpenAI development-Gateway run exercised catalog discovery/status and Code Mode file work. The complete capture matched all six visible assistant outputs and all 15 tool description/schema pairs to the same-run summaries. Numeric read hints were present, and all three file reads completed once with path-only arguments.

**The full Code Mode task still failed:** its second exec wrote and returned 19 instead of the expected 16. The original audit correctly exited 1. A separate offline audit verified only the capture correspondence; it did not change the task oracle or retry the provider. Status took 5,638.538 ms and the incorrect file task 6,411.712 ms. Neither duration establishes a speedup. The earlier offset-zero failure, later arithmetic failure and existing dreaming/scheduler startup messages remain retained. There is no claim of causality, reduced error rate, successful arithmetic, final provider-wire capture or improved whole-turn latency.

All task-owned Gateway, receiver and review processes closed. Exact published head `8f625075f96ec31fc3945c413f0f7ced824bb596` passed [CI run 33934589743](https://github.com/openclaw/openclaw/actions/runs/33934589743), including `openclaw/ci-gate`: 133 successful checks, 50 expected skips and one neutral result; no failures or pending checks. Selected source paths were unchanged in the later main c26e46b2 check; the live build remains explicitly tied to the validated base and candidate.
