### PR TITLE
refactor(tencent): share ordered provider registration

### DIFF
--- a/extensions/tencent/index.test.ts
+++ b/extensions/tencent/index.test.ts
@@ -2,12 +2,13 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { Context, Model } from "openclaw/plugin-sdk/llm";
 import {
+  createRuntimeEnv,
   registerProviderPlugin,
   requireRegisteredProvider,
   resolveProviderPluginChoice,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
 import tencentPlugin from "./index.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
@@ -93,43 +94,125 @@ function captureTencentPayload(params: {
 }
 
 describe("tencent provider plugin", () => {
-  it("registers Tencent TokenHub api-key auth metadata", async () => {
+  it.each([
+    ["tencent-tokenhub", "Tencent TokenHub", "TOKENHUB_API_KEY", "tokenhub-api-key"],
+    ["tencent-tokenplan", "Tencent TokenPlan", "TOKENPLAN_API_KEY", "tokenplan-api-key"],
+  ])("registers %s api-key auth metadata", async (providerId, label, envVar, choiceId) => {
     const { providers } = await registerTencentPlugin();
-    const provider = requireRegisteredProvider(providers, "tencent-tokenhub");
-    const resolved = resolveProviderPluginChoice({
-      providers,
-      choice: "tokenhub-api-key",
-    });
+    const provider = requireRegisteredProvider(providers, providerId);
+    const resolved = resolveProviderPluginChoice({ providers, choice: choiceId });
 
-    expect(provider.id).toBe("tencent-tokenhub");
-    expect(provider.label).toBe("Tencent TokenHub");
-    expect(provider.envVars).toEqual(["TOKENHUB_API_KEY"]);
+    expect(providers.map((entry) => entry.id)).toEqual(["tencent-tokenhub", "tencent-tokenplan"]);
+    expect(provider).toMatchObject({
+      id: providerId,
+      label,
+      docsPath: "/providers/tencent",
+      envVars: [envVar],
+      catalog: { order: "simple" },
+      staticCatalog: { order: "simple" },
+    });
     expect(provider.auth).toHaveLength(1);
-    if (!resolved) {
-      throw new Error("expected Tencent TokenHub api-key auth choice");
-    }
-    expect(resolved.provider.id).toBe("tencent-tokenhub");
-    expect(resolved.method.id).toBe("api-key");
+    expect(resolved?.provider.id).toBe(providerId);
+    expect(resolved?.method).toMatchObject({
+      id: "api-key",
+      label,
+      hint: `Hy via ${label} Gateway`,
+      kind: "api_key",
+      starterModel: `${providerId}/hy3`,
+      wizard: {
+        choiceId,
+        choiceLabel: label,
+        groupId: "tencent",
+        groupLabel: "Tencent Cloud",
+        groupHint: label,
+      },
+    });
   });
 
-  it("registers Tencent TokenPlan api-key auth metadata", async () => {
-    const { providers } = await registerTencentPlugin();
-    const provider = requireRegisteredProvider(providers, "tencent-tokenplan");
-    const resolved = resolveProviderPluginChoice({
-      providers,
-      choice: "tokenplan-api-key",
-    });
+  it.each([
+    {
+      providerId: "tencent-tokenhub",
+      choiceId: "tokenhub-api-key",
+      flagValue: "tokenhub-test-key",
+      envVar: "TOKENHUB_API_KEY",
+      aliases: {
+        "tencent-tokenhub/hy3": { alias: "Hy3 (TokenHub)" },
+        "tencent-tokenhub/hy3-preview": { alias: "Hy3 preview (TokenHub)" },
+      },
+    },
+    {
+      providerId: "tencent-tokenplan",
+      choiceId: "tokenplan-api-key",
+      flagValue: "tokenplan-test-key",
+      envVar: "TOKENPLAN_API_KEY",
+      aliases: { "tencent-tokenplan/hy3": { alias: "Hy3 (TokenPlan)" } },
+    },
+  ] as const)(
+    "configures only $providerId through its registered auth method",
+    async ({ providerId, choiceId, flagValue, envVar, aliases }) => {
+      const { providers } = await registerTencentPlugin();
+      const provider = requireRegisteredProvider(providers, providerId);
+      const resolveApiKey = vi.fn(async () => ({
+        key: "stored-test-key",
+        source: "profile" as const,
+      }));
+      const toApiKeyCredential = vi.fn(() => null);
+      const method = provider.auth[0];
+      if (!method?.runNonInteractive) {
+        throw new Error("expected Tencent noninteractive auth method");
+      }
+      const config = await method.runNonInteractive({
+        authChoice: choiceId,
+        config: {},
+        baseConfig: {},
+        opts: { tokenhubApiKey: "tokenhub-test-key", tokenplanApiKey: "tokenplan-test-key" },
+        runtime: createRuntimeEnv(),
+        resolveApiKey,
+        toApiKeyCredential,
+      });
 
-    expect(provider.id).toBe("tencent-tokenplan");
-    expect(provider.label).toBe("Tencent TokenPlan");
-    expect(provider.envVars).toEqual(["TOKENPLAN_API_KEY"]);
-    expect(provider.auth).toHaveLength(1);
-    if (!resolved) {
-      throw new Error("expected Tencent TokenPlan api-key auth choice");
-    }
-    expect(resolved.provider.id).toBe("tencent-tokenplan");
-    expect(resolved.method.id).toBe("api-key");
-  });
+      expect(resolveApiKey).toHaveBeenCalledExactlyOnceWith({
+        provider: providerId,
+        flagValue,
+        flagName: `--${choiceId}`,
+        envVar,
+      });
+      expect(toApiKeyCredential).not.toHaveBeenCalled();
+      expect(Object.keys(config?.models?.providers ?? {})).toEqual([providerId]);
+      expect(config?.models?.providers?.[providerId]?.models.map((model) => model.id)).toEqual(
+        manifest.modelCatalog.providers[providerId].models.map((model) => model.id),
+      );
+      expect(config?.agents?.defaults?.model).toEqual({ primary: `${providerId}/hy3` });
+      expect(config?.agents?.defaults?.models).toEqual(aliases);
+    },
+  );
+
+  it.each(["tencent-tokenhub", "tencent-tokenplan"])(
+    "isolates %s static and augmented catalog results",
+    async (providerId) => {
+      const { providers } = await registerTencentPlugin();
+      const provider = requireRegisteredProvider(providers, providerId);
+      const first = await runSingleProviderCatalog({ catalog: provider.staticCatalog });
+      const expected = structuredClone(first);
+      const model = first.models[0];
+      if (!model) {
+        throw new Error("expected Tencent static model");
+      }
+      model.input.push("image");
+      model.cost.input = 999;
+      expect(await runSingleProviderCatalog({ catalog: provider.staticCatalog })).toEqual(expected);
+
+      const context = { env: {}, entries: [] };
+      const augmented = await provider.augmentModelCatalog?.(context);
+      expect(augmented?.map((entry) => entry.id)).toEqual(expected.models.map((entry) => entry.id));
+      if (!augmented?.[0]?.input) {
+        throw new Error("expected Tencent model input modalities");
+      }
+      const expectedAugmented = structuredClone(augmented);
+      augmented[0].input.push("image");
+      expect(await provider.augmentModelCatalog?.(context)).toEqual(expectedAugmented);
+    },
+  );
 
   it("builds the static Tencent TokenHub model catalog with reasoning flags", async () => {
     const provider = await getTokenHubProvider();

--- a/extensions/tencent/index.ts
+++ b/extensions/tencent/index.ts
@@ -17,112 +17,90 @@ import {
 import { buildTokenHubProvider, buildTokenPlanProvider } from "./provider-catalog.js";
 import { wrapTencentProviderStream } from "./stream.js";
 
-function buildStaticCatalogEntries(providerId: string, catalog: typeof TOKENHUB_MODEL_CATALOG) {
-  return catalog.map((entry) => ({
-    provider: providerId,
-    id: entry.id,
-    name: entry.name,
-    reasoning: entry.reasoning,
-    input: [...entry.input],
-    contextWindow: entry.contextWindow,
-  }));
-}
-
-function createTokenHubApiKeyAuthMethod() {
-  return createProviderApiKeyAuthMethod({
+const TENCENT_PROVIDERS = [
+  {
     providerId: TOKENHUB_PROVIDER_ID,
-    methodId: "api-key",
     label: "Tencent TokenHub",
-    hint: "Hy via Tencent TokenHub Gateway",
     optionKey: "tokenhubApiKey",
     flagName: "--tokenhub-api-key",
     envVar: "TOKENHUB_API_KEY",
-    promptMessage: "Enter Tencent TokenHub API key",
     defaultModel: TOKENHUB_DEFAULT_MODEL_REF,
-    expectedProviders: [TOKENHUB_PROVIDER_ID],
     applyConfig: applyTokenHubConfig,
-    wizard: {
-      choiceId: "tokenhub-api-key",
-      choiceLabel: "Tencent TokenHub",
-      groupId: "tencent",
-      groupLabel: "Tencent Cloud",
-      groupHint: "Tencent TokenHub",
-    },
-  });
-}
+    choiceId: "tokenhub-api-key",
+    buildProvider: buildTokenHubProvider,
+    modelCatalog: TOKENHUB_MODEL_CATALOG,
+  },
+  {
+    providerId: TOKENPLAN_PROVIDER_ID,
+    label: "Tencent TokenPlan",
+    optionKey: "tokenplanApiKey",
+    flagName: "--tokenplan-api-key",
+    envVar: "TOKENPLAN_API_KEY",
+    defaultModel: TOKENPLAN_DEFAULT_MODEL_REF,
+    applyConfig: applyTokenPlanConfig,
+    choiceId: "tokenplan-api-key",
+    buildProvider: buildTokenPlanProvider,
+    modelCatalog: TOKENPLAN_MODEL_CATALOG,
+  },
+] as const;
 
 export default definePluginEntry({
   id: "tencent",
   name: "Tencent Cloud Provider",
   description: "Bundled Tencent Cloud provider plugin (TokenHub, TokenPlan)",
   register(api) {
-    api.registerProvider({
-      id: TOKENHUB_PROVIDER_ID,
-      label: "Tencent TokenHub",
-      docsPath: "/providers/tencent",
-      envVars: ["TOKENHUB_API_KEY"],
-      auth: [createTokenHubApiKeyAuthMethod()],
-      catalog: {
-        order: "simple",
-        run: (ctx) =>
-          buildOpenAICompatibleProviderCatalog({
-            ctx,
-            providerId: TOKENHUB_PROVIDER_ID,
-            buildProvider: buildTokenHubProvider,
+    for (const provider of TENCENT_PROVIDERS) {
+      api.registerProvider({
+        id: provider.providerId,
+        label: provider.label,
+        docsPath: "/providers/tencent",
+        envVars: [provider.envVar],
+        auth: [
+          createProviderApiKeyAuthMethod({
+            providerId: provider.providerId,
+            methodId: "api-key",
+            label: provider.label,
+            hint: `Hy via ${provider.label} Gateway`,
+            optionKey: provider.optionKey,
+            flagName: provider.flagName,
+            envVar: provider.envVar,
+            promptMessage: `Enter ${provider.label} API key`,
+            defaultModel: provider.defaultModel,
+            expectedProviders: [provider.providerId],
+            applyConfig: provider.applyConfig,
+            wizard: {
+              choiceId: provider.choiceId,
+              choiceLabel: provider.label,
+              groupId: "tencent",
+              groupLabel: "Tencent Cloud",
+              groupHint: provider.label,
+            },
           }),
-      },
-      staticCatalog: {
-        order: "simple",
-        run: async () => ({ provider: buildTokenHubProvider() }),
-      },
-      augmentModelCatalog: () =>
-        buildStaticCatalogEntries(TOKENHUB_PROVIDER_ID, TOKENHUB_MODEL_CATALOG),
-      wrapStreamFn: wrapTencentProviderStream,
-    });
-
-    api.registerProvider({
-      id: TOKENPLAN_PROVIDER_ID,
-      label: "Tencent TokenPlan",
-      docsPath: "/providers/tencent",
-      envVars: ["TOKENPLAN_API_KEY"],
-      auth: [
-        createProviderApiKeyAuthMethod({
-          providerId: TOKENPLAN_PROVIDER_ID,
-          methodId: "api-key",
-          label: "Tencent TokenPlan",
-          hint: "Hy via Tencent TokenPlan Gateway",
-          optionKey: "tokenplanApiKey",
-          flagName: "--tokenplan-api-key",
-          envVar: "TOKENPLAN_API_KEY",
-          promptMessage: "Enter Tencent TokenPlan API key",
-          defaultModel: TOKENPLAN_DEFAULT_MODEL_REF,
-          expectedProviders: [TOKENPLAN_PROVIDER_ID],
-          applyConfig: applyTokenPlanConfig,
-          wizard: {
-            choiceId: "tokenplan-api-key",
-            choiceLabel: "Tencent TokenPlan",
-            groupId: "tencent",
-            groupLabel: "Tencent Cloud",
-            groupHint: "Tencent TokenPlan",
-          },
-        }),
-      ],
-      catalog: {
-        order: "simple",
-        run: (ctx) =>
-          buildOpenAICompatibleProviderCatalog({
-            ctx,
-            providerId: TOKENPLAN_PROVIDER_ID,
-            buildProvider: buildTokenPlanProvider,
-          }),
-      },
-      staticCatalog: {
-        order: "simple",
-        run: async () => ({ provider: buildTokenPlanProvider() }),
-      },
-      augmentModelCatalog: () =>
-        buildStaticCatalogEntries(TOKENPLAN_PROVIDER_ID, TOKENPLAN_MODEL_CATALOG),
-      wrapStreamFn: wrapTencentProviderStream,
-    });
+        ],
+        catalog: {
+          order: "simple",
+          run: (ctx) =>
+            buildOpenAICompatibleProviderCatalog({
+              ctx,
+              providerId: provider.providerId,
+              buildProvider: provider.buildProvider,
+            }),
+        },
+        staticCatalog: {
+          order: "simple",
+          run: async () => ({ provider: provider.buildProvider() }),
+        },
+        augmentModelCatalog: () =>
+          provider.modelCatalog.map((entry) => ({
+            provider: provider.providerId,
+            id: entry.id,
+            name: entry.name,
+            reasoning: entry.reasoning,
+            input: [...entry.input],
+            contextWindow: entry.contextWindow,
+          })),
+        wrapStreamFn: wrapTencentProviderStream,
+      });
+    }
   },
 });


### PR DESCRIPTION
## What Problem This Solves

Tencent TokenHub and TokenPlan duplicate the same authentication and catalog registration wiring. Maintaining separate copies makes it easier for the two provider registrations to drift. This is a maintainer-requested, behavior-neutral cleanup of that duplication.

## Why This Change Was Made

Use one private, ordered provider table and registration loop inside the Tencent plugin. Keep TokenHub before TokenPlan, separate credentials and config appliers, all existing auth and onboarding metadata, fresh catalog results, and the existing stream hook.

Lightweight discovery stays independent. No shared SDK abstraction or new public surface is introduced.

## User Impact

No user-visible behavior change. Provider IDs, CLI flags, environment variables, wizard choices, model defaults, aliases, catalogs, and streaming behavior stay unchanged. There are no config, manifest, dependency, or external API changes.

## Evidence

- [Final Testbox command run](https://github.com/openclaw/openclaw/actions/runs/33931255329) exited 0: all 16 tests in `extensions/tencent/index.test.ts`, extension-test typechecking, and the eight previously unreached checks passed. Those checks cover coercion declarations, deprecated APIs, dead exports, targeted lint, legacy stores, media-download helpers, sidecar loaders, and runtime import cycles.
- Before execution, the final run verified base `894e9f4d28781858204bda4e6bcebef8c85c7651`, snapshot tree `602d4977e0ca4156706fddb65a5313ff9e5a5c5d`, the exact two-file diff, and both candidate file hashes.
- [Earlier focused Testbox command run](https://github.com/openclaw/openclaw/actions/runs/33928489866) passed all 22 tests across `extensions/tencent/index.test.ts`, `extensions/tencent/onboard.test.ts`, and `extensions/tencent/config-compat.test.ts`. That run verified the candidate file hashes. The subsequent edit only narrowed indexed test values; all 16 index tests were rerun on the final candidate above. Onboarding and config-compat tests are unchanged.
- The [initial changed-gate run](https://github.com/openclaw/openclaw/actions/runs/33929274244) passed production typechecking, formatting, five doctor-contract tests, plugin-boundary checks, and the preceding guards. It exposed three test-only strict-null errors, which were corrected. The final run passed the failed typecheck and every remaining check without replaying already-passed production gates.
- Tests exercise both providers' registered noninteractive auth methods, distinct CLI inputs and credential resolution, provider-specific config and aliases, registration order, metadata, and fresh catalog/input-array isolation. Existing stream-payload tests remain green.
- Independent autoreview of the final two-file candidate: no P0-P2 findings. Targeted formatting and `git diff --check` pass.

| Scope | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 71 | 93 | -22 |
| Tests | 115 | 32 | +83 |

These are Testbox command receipts, not published PR-head CI. No live Tencent API request was made: this refactor changes registration construction, not external request/response behavior. Exact-head CI and the repository's review/landing gates still apply before merge.
