### PR TITLE
fix(logbook): drain accepted work before closing SQLite

### DIFF
--- a/extensions/logbook/index.test.ts
+++ b/extensions/logbook/index.test.ts
@@ -11,6 +11,7 @@ function registerLogbookPolicies(): OpenClawPluginNodeInvokePolicy[] {
   const policies: OpenClawPluginNodeInvokePolicy[] = [];
   plugin.register({
     pluginConfig: {},
+    lifecycle: { registerRuntimeLifecycle() {} },
     session: { controls: { registerControlUiDescriptor: () => {} } },
     registerNodeInvokePolicy: (policy: OpenClawPluginNodeInvokePolicy) => policies.push(policy),
     registerService: () => {},
@@ -24,6 +25,7 @@ describe("logbook gateway methods", () => {
     const registrations: Array<{ method: string; options: unknown }> = [];
     plugin.register({
       pluginConfig: {},
+      lifecycle: { registerRuntimeLifecycle() {} },
       session: { controls: { registerControlUiDescriptor: () => {} } },
       registerNodeInvokePolicy: () => {},
       registerService: () => {},

--- a/extensions/logbook/index.ts
+++ b/extensions/logbook/index.ts
@@ -70,6 +70,13 @@ export default definePluginEntry({
   register(api: OpenClawPluginApi) {
     const config = logbookConfigSchema.parse(api.pluginConfig);
     let service: LogbookService | null = null;
+    let stopping: Promise<void> | undefined;
+    let retired = false;
+    const stopService = () => {
+      const current = service;
+      service = null;
+      return (stopping ??= current?.stop());
+    };
 
     const requireService = () => {
       if (!service) {
@@ -129,6 +136,10 @@ export default definePluginEntry({
     api.registerService({
       id: "logbook",
       start: (ctx) => {
+        if (retired) {
+          throw new Error("Logbook plugin runtime has been retired");
+        }
+        stopping = undefined;
         service = new LogbookService(config, {
           runtime: api.runtime,
           fullConfig: ctx.config,
@@ -137,9 +148,21 @@ export default definePluginEntry({
         });
         service.start();
       },
-      stop: () => {
-        service?.stop();
-        service = null;
+      stop: stopService,
+    });
+    api.lifecycle.registerRuntimeLifecycle({
+      id: "logbook-service",
+      cleanup: ({ reason, sessionKey, runId }) => {
+        // Registry-only retirement does not run service.stop; scoped session cleanup stays local.
+        if (
+          sessionKey === undefined &&
+          runId === undefined &&
+          (reason === "restart" || reason === "disable")
+        ) {
+          retired = true;
+          return stopService();
+        }
+        return undefined;
       },
     });
 

--- a/extensions/logbook/src/card-reads.test.ts
+++ b/extensions/logbook/src/card-reads.test.ts
@@ -81,6 +81,7 @@ it("hydrates a timeline once and counts status without reading card payloads", a
 
   plugin.register({
     pluginConfig: { captureEnabled: false },
+    lifecycle: { registerRuntimeLifecycle() {} },
     runtime: {},
     session: { controls: { registerControlUiDescriptor() {} } },
     registerNodeInvokePolicy() {},

--- a/extensions/logbook/src/service-lifecycle.test.ts
+++ b/extensions/logbook/src/service-lifecycle.test.ts
@@ -1,0 +1,273 @@
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { setImmediate } from "node:timers/promises";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { OpenClawPluginApi, OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  createCapturedPluginRegistration,
+  createPluginRuntimeMock,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it, vi } from "vitest";
+import plugin from "../index.js";
+import { resolveLogbookConfig } from "./config.js";
+import { LogbookService } from "./service.js";
+import { dayKeyFor, LogbookStore } from "./store.js";
+
+const quietLogger = { info() {}, warn() {}, error() {}, debug() {} };
+const snapshot = { payload: { base64: Buffer.from("synthetic image").toString("base64") } };
+
+function completion(
+  text: string,
+): Awaited<ReturnType<OpenClawPluginApi["runtime"]["llm"]["complete"]>> {
+  return {
+    text,
+    provider: "synthetic",
+    model: "synthetic",
+    agentId: "main",
+    usage: {},
+    execution: { mode: "direct-provider", owner: { kind: "provider", id: "synthetic" } },
+    audit: { caller: { kind: "plugin", id: "logbook" } },
+  };
+}
+
+describe("Logbook service disposal", () => {
+  it.each(["capture-list", "capture-invoke", "vision-success", "vision-error", "standup"])(
+    "drains %s before closing SQLite",
+    async (kind) => {
+      const dataDir = realpathSync(mkdtempSync(path.join(tmpdir(), "logbook-service-drain-")));
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      const runtime = createPluginRuntimeMock();
+      const day = dayKeyFor(Date.now());
+      const startMs = new Date(`${day}T10:00:00`).getTime();
+      const logger = { ...quietLogger, error: vi.fn(), warn: vi.fn() };
+      const nodes = { nodes: [{ nodeId: "synthetic-node", commands: ["screen.snapshot"] }] };
+      runtime.nodes.list = vi.fn(async () => {
+        if (kind === "capture-list") {
+          entered.resolve();
+          await release.promise;
+        }
+        return nodes;
+      });
+      runtime.nodes.invoke = vi.fn(async () => {
+        if (kind === "capture-invoke") {
+          entered.resolve();
+          await release.promise;
+        }
+        return snapshot;
+      });
+      runtime.mediaUnderstanding.extractStructuredWithModel = vi.fn(async () => {
+        entered.resolve();
+        await release.promise;
+        if (kind === "vision-error") {
+          throw new Error("synthetic vision failure");
+        }
+        return {
+          text: JSON.stringify([
+            { start: "10:00:00", end: "10:01:00", description: "Synthetic activity" },
+          ]),
+        };
+      });
+      runtime.llm.complete = vi.fn(async () => {
+        if (kind === "standup") {
+          entered.resolve();
+          await release.promise;
+          return completion("Synthetic standup");
+        }
+        return completion(
+          JSON.stringify([
+            {
+              startTime: "10:00:00",
+              endTime: "10:01:00",
+              title: "Synthetic activity",
+              summary: "Completed before shutdown",
+              category: "coding",
+            },
+          ]),
+        );
+      });
+      if (kind.startsWith("vision")) {
+        const seed = new LogbookStore(dataDir);
+        try {
+          for (let index = 0; index < 2; index++) {
+            const time = startMs + index * 120_000;
+            const framePath = seed.frameFilePath(day, time);
+            mkdirSync(path.dirname(framePath), { recursive: true });
+            writeFileSync(framePath, "synthetic image");
+            const frameId = seed.insertFrame({
+              capturedAtMs: time,
+              day,
+              path: framePath,
+              screenIndex: 0,
+              byteSize: 15,
+              contentHash: `synthetic-${index}`,
+              idle: false,
+            });
+            seed.createBatch({ day, startMs: time, endMs: time + 60_000, frameIds: [frameId] });
+          }
+        } finally {
+          seed.close();
+        }
+      }
+      const service = new LogbookService(
+        resolveLogbookConfig({
+          captureEnabled: true,
+          captureIntervalSeconds: 600,
+          visionModel: "synthetic/vision",
+        }),
+        { runtime, fullConfig: {}, logger, dataDir },
+      );
+      service.start();
+      const ticks = service as unknown as {
+        captureTick(): Promise<void>;
+        analysisTick(): Promise<void>;
+      };
+      const active = kind.startsWith("capture")
+        ? ticks.captureTick()
+        : kind.startsWith("vision")
+          ? ticks.analysisTick()
+          : service.standup(day, true);
+      void active.catch(() => {});
+      await entered.promise;
+      const stopped = vi.fn();
+      const stopping = service.stop();
+      const settled = Promise.resolve(stopping).then(stopped);
+      try {
+        expect(service.stop()).toBe(stopping);
+        await setImmediate();
+        expect.soft(stopped).not.toHaveBeenCalled();
+        await expect(service.standup(day, true)).rejects.toThrow("not running");
+        await expect(service.analyzeNow()).rejects.toThrow("not running");
+        release.resolve();
+        await active;
+        await settled;
+        expect(logger.error).not.toHaveBeenCalled();
+        const reopened = new LogbookStore(dataDir);
+        try {
+          if (kind.startsWith("capture")) {
+            expect(reopened.countUnbatchedActiveFrames()).toBe(1);
+            expect(runtime.nodes.invoke).toHaveBeenCalledTimes(1);
+          } else if (kind === "standup") {
+            expect(reopened.getStandup(day)?.text).toBe("Synthetic standup");
+          } else {
+            const db = new DatabaseSync(path.join(dataDir, "logbook.sqlite"), { readOnly: true });
+            try {
+              expect(db.prepare("SELECT status, error FROM batches ORDER BY id").all()).toEqual([
+                {
+                  status: kind === "vision-success" ? "done" : "error",
+                  error: kind === "vision-success" ? null : "synthetic vision failure",
+                },
+                { status: "pending", error: null },
+              ]);
+              expect(runtime.mediaUnderstanding.extractStructuredWithModel).toHaveBeenCalledTimes(
+                1,
+              );
+            } finally {
+              db.close();
+            }
+          }
+        } finally {
+          reopened.close();
+        }
+      } finally {
+        release.resolve();
+        await active.catch(() => {});
+        await settled;
+        await service.stop();
+        rmSync(dataDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each(["restart", "disable"] as const)(
+    "joins service stop and whole-plugin %s cleanup without stopping sessions",
+    async (reason) => {
+      const stateDir = realpathSync(mkdtempSync(path.join(tmpdir(), "logbook-runtime-drain-")));
+      const captured = createCapturedPluginRegistration({ id: "logbook" });
+      captured.api.pluginConfig = { captureEnabled: false };
+      const services: OpenClawPluginService[] = [];
+      captured.api.registerService = (service) => services.push(service);
+      const handlers = new Map<string, Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]>();
+      captured.api.registerGatewayMethod = (name, handler) => handlers.set(name, handler);
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      captured.api.runtime.llm.complete = async () => {
+        entered.resolve();
+        await release.promise;
+        return completion("Accepted standup");
+      };
+      plugin.register(captured.api);
+      const service = services[0]!;
+      const context = { config: {}, stateDir, logger: quietLogger };
+      await service.start(context);
+      const call = async (name: string, params = {}) => {
+        const respond = vi.fn();
+        await handlers.get(name)!({ params, respond } as never);
+        return respond.mock.calls[0];
+      };
+      const cleanup = async (scope: {
+        reason: typeof reason | "reset" | "delete";
+        sessionKey?: string;
+        runId?: string;
+      }) => {
+        for (const lifecycle of captured.runtimeLifecycles) {
+          await lifecycle.cleanup?.(scope);
+        }
+      };
+      try {
+        for (const scope of [
+          { reason: "reset" as const },
+          { reason: "delete" as const },
+          { reason, sessionKey: "" },
+          { reason, runId: "" },
+        ]) {
+          await cleanup(scope);
+          expect((await call("logbook.status"))?.[0]).toBe(true);
+        }
+        const standup = call("logbook.standup");
+        await entered.promise;
+        const retired = vi.fn();
+        const retiring = cleanup({ reason }).then(retired);
+        await setImmediate();
+        expect.soft(retired).not.toHaveBeenCalled();
+        expect.soft((await call("logbook.status"))?.[0]).toBe(false);
+        const stopping = Promise.resolve(service.stop?.(context));
+        release.resolve();
+        expect((await standup)?.[0]).toBe(true);
+        await Promise.all([retiring, stopping, cleanup({ reason })]);
+        const reopened = new LogbookStore(path.join(stateDir, "logbook"));
+        try {
+          expect(reopened.getStandup(dayKeyFor(Date.now()))?.text).toBe("Accepted standup");
+        } finally {
+          reopened.close();
+        }
+      } finally {
+        release.resolve();
+        await service.stop?.(context);
+        rmSync(stateDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("does not start a service after its registered runtime has retired", async () => {
+    const stateDir = realpathSync(mkdtempSync(path.join(tmpdir(), "logbook-retired-start-")));
+    const captured = createCapturedPluginRegistration({ id: "logbook" });
+    captured.api.pluginConfig = { captureEnabled: false };
+    const services: OpenClawPluginService[] = [];
+    captured.api.registerService = (service) => services.push(service);
+    plugin.register(captured.api);
+    const context = { config: {}, stateDir, logger: quietLogger };
+    try {
+      for (const lifecycle of captured.runtimeLifecycles) {
+        await lifecycle.cleanup?.({ reason: "restart" });
+      }
+      expect(() => services[0]!.start(context)).toThrow("runtime has been retired");
+      expect(existsSync(path.join(stateDir, "logbook", "logbook.sqlite"))).toBe(false);
+    } finally {
+      await services[0]!.stop?.(context);
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/logbook/src/service.test.ts
+++ b/extensions/logbook/src/service.test.ts
@@ -51,10 +51,10 @@ const framePayload = {
 };
 
 describe("LogbookService capture node selection", () => {
-  const cleanups: Array<() => void> = [];
-  afterEach(() => {
+  const cleanups: Array<() => Promise<void>> = [];
+  afterEach(async () => {
     for (const cleanup of cleanups.splice(0)) {
-      cleanup();
+      await cleanup();
     }
   });
 
@@ -66,8 +66,8 @@ describe("LogbookService capture node selection", () => {
       ],
       invoke: async () => framePayload,
     });
-    cleanups.push(() => {
-      service.stop();
+    cleanups.push(async () => {
+      await service.stop();
       rmSync(dataDir, { recursive: true, force: true });
     });
 
@@ -89,8 +89,8 @@ describe("LogbookService capture node selection", () => {
         return framePayload;
       },
     });
-    cleanups.push(() => {
-      service.stop();
+    cleanups.push(async () => {
+      await service.stop();
       rmSync(dataDir, { recursive: true, force: true });
     });
 
@@ -109,8 +109,8 @@ describe("LogbookService capture node selection", () => {
       nodes: [{ nodeId: "capture-node", commands: ["logbook.snapshot"] }],
       invoke: async () => ({ payload: { format: "jpeg", base64 } }),
     });
-    cleanups.push(() => {
-      service.stop();
+    cleanups.push(async () => {
+      await service.stop();
       rmSync(dataDir, { recursive: true, force: true });
     });
 
@@ -124,10 +124,10 @@ describe("LogbookService capture node selection", () => {
 });
 
 describe("LogbookService vision model selection", () => {
-  const cleanups: Array<() => void> = [];
-  afterEach(() => {
+  const cleanups: Array<() => Promise<void>> = [];
+  afterEach(async () => {
     for (const cleanup of cleanups.splice(0)) {
-      cleanup();
+      await cleanup();
     }
   });
 
@@ -146,8 +146,8 @@ describe("LogbookService vision model selection", () => {
         },
       },
     });
-    cleanups.push(() => {
-      service.stop();
+    cleanups.push(async () => {
+      await service.stop();
       rmSync(dataDir, { recursive: true, force: true });
     });
 
@@ -169,8 +169,8 @@ describe("LogbookService vision model selection", () => {
         },
       },
     });
-    cleanups.push(() => {
-      service.stop();
+    cleanups.push(async () => {
+      await service.stop();
       rmSync(dataDir, { recursive: true, force: true });
     });
 
@@ -182,7 +182,7 @@ describe("LogbookService vision model selection", () => {
 });
 
 describe("LogbookService status", () => {
-  it("returns the capture-host timezone without exposing the state path", () => {
+  it("returns the capture-host timezone without exposing the state path", async () => {
     const { service, dataDir } = makeService({
       nodes: [],
       invoke: async () => framePayload,
@@ -194,7 +194,7 @@ describe("LogbookService status", () => {
       });
       expect(service.status()).not.toHaveProperty("dataDir");
     } finally {
-      service.stop();
+      await service.stop();
       rmSync(dataDir, { recursive: true, force: true });
     }
   });

--- a/extensions/logbook/src/service.ts
+++ b/extensions/logbook/src/service.ts
@@ -29,7 +29,7 @@ import {
   OBSERVATION_JSON_SCHEMA,
 } from "./prompts.js";
 import { dayKeyFor, LogbookStore } from "./store.js";
-import type { LogbookBatch } from "./types.js";
+import type { LogbookBatch, LogbookStatus } from "./types.js";
 
 const ANALYSIS_TICK_MS = 60 * 1000;
 const PRUNE_TICK_MS = 60 * 60 * 1000;
@@ -73,28 +73,10 @@ function unwrapInvokePayload(raw: unknown): SnapshotPayload | null {
 /** Capture commands in preference order: app nodes first, headless node hosts second. */
 const CAPTURE_COMMANDS = ["screen.snapshot", "logbook.snapshot"] as const;
 
-type LogbookStatus = {
-  captureEnabled: boolean;
-  capturePaused: boolean;
-  captureIntervalSeconds: number;
-  analysisIntervalMinutes: number;
-  retentionDays: number;
-  nodeId?: string;
-  nodeName?: string;
-  lastCaptureAtMs?: number;
-  lastCaptureError?: string;
-  pendingFrames: number;
-  analysisRunning: boolean;
-  lastBatch?: Pick<LogbookBatch, "id" | "day" | "status" | "endMs" | "error">;
-  visionModel?: string;
-  visionModelSource: "config" | "media-defaults" | "missing";
-  today: string;
-  todayCards: number;
-  timeZone: string;
-};
-
 export class LogbookService {
   private store: LogbookStore | null = null;
+  private readonly operations = new Set<Promise<unknown>>();
+  private stopping: Promise<void> | undefined;
   private captureTimer: NodeJS.Timeout | null = null;
   private analysisTimer: NodeJS.Timeout | null = null;
   private pruneTimer: NodeJS.Timeout | null = null;
@@ -122,6 +104,7 @@ export class LogbookService {
   ) {}
 
   start(): void {
+    this.stopping = undefined;
     this.store = new LogbookStore(this.deps.dataDir);
     // Batches interrupted by a gateway restart go back to pending.
     this.store.resetRunningBatches();
@@ -143,7 +126,10 @@ export class LogbookService {
     );
   }
 
-  stop(): void {
+  stop(): Promise<void> {
+    if (this.stopping) {
+      return this.stopping;
+    }
     for (const timer of [this.captureTimer, this.analysisTimer, this.pruneTimer]) {
       if (timer) {
         clearInterval(timer);
@@ -152,18 +138,30 @@ export class LogbookService {
     this.captureTimer = null;
     this.analysisTimer = null;
     this.pruneTimer = null;
-    this.store?.close();
-    this.store = null;
+    const store = this.store;
+    // Admitted work retains its connection through its final writes and error recording.
+    this.stopping = Promise.allSettled(this.operations).then(() => {
+      store?.close();
+      this.store = null;
+    });
+    return this.stopping;
+  }
+
+  private trackOperation<T>(run: () => Promise<T>): Promise<T> {
+    // Register ownership before runtime hooks can reenter shutdown.
+    const operation = Promise.resolve().then(run);
+    this.operations.add(operation);
+    const settled = () => this.operations.delete(operation);
+    void operation.then(settled, settled);
+    return operation;
   }
 
   private requireStore(): LogbookStore {
-    if (!this.store) {
+    if (this.stopping || !this.store) {
       throw new Error("Logbook service is not running");
     }
     return this.store;
   }
-
-  // ── Capture ────────────────────────────────────────────────────────
 
   setCapturePaused(paused: boolean): void {
     this.capturePaused = paused;
@@ -222,7 +220,14 @@ export class LogbookService {
   }
 
   private async captureTick(): Promise<void> {
-    if (!this.config.captureEnabled || this.capturePaused || this.captureInFlight || !this.store) {
+    const store = this.store;
+    if (
+      this.stopping ||
+      !this.config.captureEnabled ||
+      this.capturePaused ||
+      this.captureInFlight ||
+      !store
+    ) {
       return;
     }
     if (this.captureBackoffTicks > 0) {
@@ -230,87 +235,87 @@ export class LogbookService {
       return;
     }
     this.captureInFlight = true;
-    try {
-      const resolved = await this.resolveNode();
-      if ("reason" in resolved) {
-        if (this.lastCaptureError !== resolved.reason) {
-          this.deps.logger.warn(`logbook: ${resolved.reason}`);
+    return this.trackOperation(async () => {
+      try {
+        const resolved = await this.resolveNode();
+        if ("reason" in resolved) {
+          if (this.lastCaptureError !== resolved.reason) {
+            this.deps.logger.warn(`logbook: ${resolved.reason}`);
+          }
+          this.lastCaptureError = resolved.reason;
+          return;
         }
-        this.lastCaptureError = resolved.reason;
-        return;
-      }
-      const node = resolved.node;
-      const invoked = await this.deps.runtime.nodes.invoke({
-        nodeId: node.nodeId,
-        command: node.command,
-        params: {
+        const node = resolved.node;
+        const invoked = await this.deps.runtime.nodes.invoke({
+          nodeId: node.nodeId,
+          command: node.command,
+          params: {
+            screenIndex: this.config.screenIndex,
+            maxWidth: this.config.maxWidth,
+            quality: JPEG_QUALITY,
+            format: "jpeg",
+          },
+          timeoutMs: 30_000,
+        });
+        const raw = unwrapInvokePayload(invoked);
+        if (raw?.error) {
+          throw new Error(raw.error);
+        }
+        const rawBase64 = raw?.base64;
+        if (rawBase64 === undefined || rawBase64 === "") {
+          throw new Error(`${node.command} returned no image payload`);
+        }
+        if (typeof rawBase64 !== "string") {
+          throw new Error(`${node.command} returned invalid image payload`);
+        }
+        const base64 = canonicalizeBase64(rawBase64);
+        if (!base64) {
+          throw new Error(`${node.command} returned invalid image payload`);
+        }
+        const buffer = Buffer.from(base64, "base64");
+        const capturedAtMs = Date.now();
+        const day = dayKeyFor(capturedAtMs);
+        const contentHash = createHash("sha256").update(buffer).digest("hex");
+        // Unchanged consecutive frames mean the user is idle (or away); they are
+        // stored for the filmstrip but excluded from analysis batches.
+        const idle = store.lastFrame()?.contentHash === contentHash;
+        const filePath = store.frameFilePath(day, capturedAtMs);
+        // Screen captures can contain secrets; keep them owner-only.
+        mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+        writeFileSync(filePath, buffer, { mode: 0o600 });
+        store.insertFrame({
+          capturedAtMs,
+          day,
+          path: filePath,
           screenIndex: this.config.screenIndex,
-          maxWidth: this.config.maxWidth,
-          quality: JPEG_QUALITY,
-          format: "jpeg",
-        },
-        timeoutMs: 30_000,
-      });
-      const raw = unwrapInvokePayload(invoked);
-      if (raw?.error) {
-        throw new Error(raw.error);
+          width: raw?.width,
+          height: raw?.height,
+          byteSize: buffer.byteLength,
+          contentHash,
+          idle,
+        });
+        this.lastCaptureAtMs = capturedAtMs;
+        this.lastCaptureError = undefined;
+        this.captureFailures = 0;
+        this.failedNodeIds.clear();
+      } catch (err) {
+        this.captureFailures += 1;
+        if (this.cachedNode) {
+          this.failedNodeIds.add(this.cachedNode.nodeId);
+        }
+        this.cachedNode = null;
+        this.lastCaptureError = err instanceof Error ? err.message : String(err);
+        if (this.captureFailures >= CAPTURE_FAILURE_THRESHOLD) {
+          this.captureBackoffTicks = CAPTURE_FAILURE_PAUSE_TICKS;
+          this.deps.logger.warn(
+            `logbook: capture failing (${this.lastCaptureError}); backing off for ${CAPTURE_FAILURE_PAUSE_TICKS} ticks`,
+          );
+        }
+      } finally {
+        this.captureInFlight = false;
       }
-      const rawBase64 = raw?.base64;
-      if (rawBase64 === undefined || rawBase64 === "") {
-        throw new Error(`${node.command} returned no image payload`);
-      }
-      if (typeof rawBase64 !== "string") {
-        throw new Error(`${node.command} returned invalid image payload`);
-      }
-      const base64 = canonicalizeBase64(rawBase64);
-      if (!base64) {
-        throw new Error(`${node.command} returned invalid image payload`);
-      }
-      const buffer = Buffer.from(base64, "base64");
-      const capturedAtMs = Date.now();
-      const day = dayKeyFor(capturedAtMs);
-      const contentHash = createHash("sha256").update(buffer).digest("hex");
-      // Unchanged consecutive frames mean the user is idle (or away); they are
-      // stored for the filmstrip but excluded from analysis batches.
-      const idle = this.store.lastFrame()?.contentHash === contentHash;
-      const filePath = this.store.frameFilePath(day, capturedAtMs);
-      // Screen captures can contain secrets; keep them owner-only.
-      mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
-      writeFileSync(filePath, buffer, { mode: 0o600 });
-      this.store.insertFrame({
-        capturedAtMs,
-        day,
-        path: filePath,
-        screenIndex: this.config.screenIndex,
-        width: raw?.width,
-        height: raw?.height,
-        byteSize: buffer.byteLength,
-        contentHash,
-        idle,
-      });
-      this.lastCaptureAtMs = capturedAtMs;
-      this.lastCaptureError = undefined;
-      this.captureFailures = 0;
-      this.failedNodeIds.clear();
-    } catch (err) {
-      this.captureFailures += 1;
-      if (this.cachedNode) {
-        this.failedNodeIds.add(this.cachedNode.nodeId);
-      }
-      this.cachedNode = null;
-      this.lastCaptureError = err instanceof Error ? err.message : String(err);
-      if (this.captureFailures >= CAPTURE_FAILURE_THRESHOLD) {
-        this.captureBackoffTicks = CAPTURE_FAILURE_PAUSE_TICKS;
-        this.deps.logger.warn(
-          `logbook: capture failing (${this.lastCaptureError}); backing off for ${CAPTURE_FAILURE_PAUSE_TICKS} ticks`,
-        );
-      }
-    } finally {
-      this.captureInFlight = false;
-    }
+    });
   }
-
-  // ── Analysis ───────────────────────────────────────────────────────
 
   private resolveVisionModel(): {
     ref?: { provider: string; model: string; profile?: string; preferredProfile?: string };
@@ -363,7 +368,7 @@ export class LogbookService {
     store.resetErrorBatches();
     if (!store.nextPendingBatch()) {
       // Force-close the current window so "analyze now" needs no elapsed time.
-      if (!this.enqueueNextBatch(true)) {
+      if (!this.enqueueNextBatch(store, true)) {
         return { started: false, reason: "no unanalyzed activity captured yet" };
       }
     }
@@ -372,7 +377,8 @@ export class LogbookService {
   }
 
   private async analysisTick(): Promise<void> {
-    if (this.analysisInFlight || !this.store) {
+    const store = this.store;
+    if (this.stopping || this.analysisInFlight || !store) {
       return;
     }
     // Without a vision model, leave frames unbatched and batches pending so
@@ -387,24 +393,28 @@ export class LogbookService {
       return;
     }
     this.analysisInFlight = true;
-    try {
-      this.enqueueElapsedWindow();
-      for (let i = 0; i < 4; i += 1) {
-        const batch = this.store.nextPendingBatch();
-        if (!batch) {
+    return this.trackOperation(async () => {
+      try {
+        if (this.stopping) {
           return;
         }
-        await this.runBatch(batch);
+        this.enqueueElapsedWindow(store);
+        for (let i = 0; i < 4 && !this.stopping; i += 1) {
+          const batch = store.nextPendingBatch();
+          if (!batch) {
+            return;
+          }
+          await this.runBatch(store, batch);
+        }
+      } catch (err) {
+        this.deps.logger.error(`logbook: analysis tick failed: ${String(err)}`);
+      } finally {
+        this.analysisInFlight = false;
       }
-    } catch (err) {
-      this.deps.logger.error(`logbook: analysis tick failed: ${String(err)}`);
-    } finally {
-      this.analysisInFlight = false;
-    }
+    });
   }
 
-  private enqueueNextBatch(force = false): boolean {
-    const store = this.requireStore();
+  private enqueueNextBatch(store: LogbookStore, force = false): boolean {
     const selection = selectBatchFrames({
       frames: store.unbatchedActiveFrames(2000),
       windowMs: this.config.analysisIntervalMinutes * 60_000,
@@ -423,16 +433,15 @@ export class LogbookService {
     return true;
   }
 
-  private enqueueElapsedWindow(): void {
+  private enqueueElapsedWindow(store: LogbookStore): void {
     // Windows close on elapsed wall-clock or on a capture gap; both cases are
     // resolved by selectBatchFrames against the oldest unbatched frame.
-    while (this.enqueueNextBatch()) {
+    while (this.enqueueNextBatch(store)) {
       // Continue until all elapsed windows are queued.
     }
   }
 
-  private async runBatch(batch: LogbookBatch): Promise<void> {
-    const store = this.requireStore();
+  private async runBatch(store: LogbookStore, batch: LogbookBatch): Promise<void> {
     const vision = this.resolveVisionModel();
     if (!vision.ref) {
       // Stay pending: the analysis tick pauses until a model is configured.
@@ -481,7 +490,7 @@ export class LogbookService {
         return;
       }
       store.replaceObservations(batch.id, batch.day, segments);
-      await this.reviseCards(batch);
+      await this.reviseCards(store, batch);
       store.setBatchStatus(batch.id, "done");
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -490,8 +499,7 @@ export class LogbookService {
     }
   }
 
-  private async reviseCards(batch: LogbookBatch): Promise<void> {
-    const store = this.requireStore();
+  private async reviseCards(store: LogbookStore, batch: LogbookBatch): Promise<void> {
     const lookbackStart = batch.startMs - CARD_LOOKBACK_MS;
     const previousCards = store.cardsForDay(batch.day, {
       startMs: lookbackStart,
@@ -568,40 +576,40 @@ export class LogbookService {
     store.replaceCardsInWindow(batch.day, window.startMs, window.endMs, drafts);
   }
 
-  // ── Q&A / standup ──────────────────────────────────────────────────
-
   async standup(
     day: string,
     refresh: boolean,
   ): Promise<{ day: string; text: string; updatedMs: number }> {
     const store = this.requireStore();
-    if (!refresh) {
-      const cached = store.getStandup(day);
-      if (cached) {
-        return cached;
+    return this.trackOperation(async () => {
+      if (!refresh) {
+        const cached = store.getStandup(day);
+        if (cached) {
+          return cached;
+        }
       }
-    }
-    const previousDay = dayKeyFor(new Date(`${day}T12:00:00`).getTime() - 24 * 60 * 60 * 1000);
-    const result = await this.deps.runtime.llm.complete({
-      messages: [
-        {
-          role: "user",
-          content: buildStandupPrompt({
-            day,
-            cards: store.cardsForDay(day),
-            previousDayCards: store.cardsForDay(previousDay),
-          }),
-        },
-      ],
-      purpose: "logbook.standup",
-      maxTokens: 800,
+      const previousDay = dayKeyFor(new Date(`${day}T12:00:00`).getTime() - 24 * 60 * 60 * 1000);
+      const result = await this.deps.runtime.llm.complete({
+        messages: [
+          {
+            role: "user",
+            content: buildStandupPrompt({
+              day,
+              cards: store.cardsForDay(day),
+              previousDayCards: store.cardsForDay(previousDay),
+            }),
+          },
+        ],
+        purpose: "logbook.standup",
+        maxTokens: 800,
+      });
+      store.saveStandup(day, result.text.trim());
+      const saved = store.getStandup(day);
+      if (!saved) {
+        throw new Error("standup save failed");
+      }
+      return saved;
     });
-    store.saveStandup(day, result.text.trim());
-    const saved = store.getStandup(day);
-    if (!saved) {
-      throw new Error("standup save failed");
-    }
-    return saved;
   }
 
   async ask(day: string, question: string): Promise<string> {
@@ -624,8 +632,6 @@ export class LogbookService {
     });
     return result.text.trim();
   }
-
-  // ── Introspection ──────────────────────────────────────────────────
 
   timelineForDay(day: string): ReturnType<LogbookStore["timelineForDay"]> {
     return this.requireStore().timelineForDay(day);

--- a/extensions/logbook/src/types.ts
+++ b/extensions/logbook/src/types.ts
@@ -63,3 +63,23 @@ export type LogbookDayStats = {
   categories: Array<{ category: string; ms: number }>;
   apps: Array<{ domain: string; ms: number }>;
 };
+
+export type LogbookStatus = {
+  captureEnabled: boolean;
+  capturePaused: boolean;
+  captureIntervalSeconds: number;
+  analysisIntervalMinutes: number;
+  retentionDays: number;
+  nodeId?: string;
+  nodeName?: string;
+  lastCaptureAtMs?: number;
+  lastCaptureError?: string;
+  pendingFrames: number;
+  analysisRunning: boolean;
+  lastBatch?: Pick<LogbookBatch, "id" | "day" | "status" | "endMs" | "error">;
+  visionModel?: string;
+  visionModelSource: "config" | "media-defaults" | "missing";
+  today: string;
+  todayCards: number;
+  timeZone: string;
+};


### PR DESCRIPTION
Related: #127526, #127608.

## What Problem This Solves

Fixes an issue where stopping or replacing Logbook could lose an accepted capture, analysis result, or generated standup because SQLite closed while the operation awaited a runtime response. Recording an analysis failure could also replace the original error with a closed-database error. Registry retirement could leave the service's database and timers alive when ordinary service shutdown was skipped.

## Why This Change Was Made

The service now owns admitted database-using operations through their final writes and error recording. Stop prevents new work and clears timers immediately, then waits for accepted work before closing the connection once. Capture, analysis, and standup retain their admitted store; analysis finishes its current batch without starting another after shutdown begins. Day questions remain independent because they finish all database reads before awaiting the answer.

Ordinary service stop and whole-plugin restart/disable cleanup share that drain. Retirement revokes the published service and prevents a retired registration from opening a database later. Session/run cleanup does not dispose the global store. Existing host shutdown deadlines, model/capture deadlines, write queries, schemas, retention, and configuration are unchanged.

## User Impact

Accepted activity and standup results can finish saving during shutdown, and actual model failures retain their original error. Shutdown may wait for already accepted work under the existing host deadline; no new timeout or cancellation policy is introduced.

## Evidence

- Seven held-operation regressions failed on the original implementation. The final complete Logbook suite passes 75 tests in seven files, including retirement before service startup.
- The required changed-file gate passes production/test types, lint, formatting, dead-export scans, database/storage guards, and import cycles. Fresh independent Codex review found no actionable P0–P2 findings.
- Native SQLite probes cover capture held at node discovery or invocation, successful and rejected analysis, a pending second batch, standup persistence, independent day questions, fresh reopen/integrity, and exactly-once close. Successful and rejected standup hooks also request stop synchronously to exercise reentrant shutdown.
- An actual plugin-registration/registry-retirement probe holds a synthetic standup response. Before the fix, retirement completes with four database descriptors open. Afterward it waits for the accepted result, saves it, and releases all four descriptors. Retired-before-start registration remains unopened. These probes use synthetic runtime boundaries and real SQLite; they do not call a real model or capture personal screens.
- Independent proof on commit `db1f25125721` passed all five phases on the first attempt: the held-operation matrix, actual registry retirement, reentrant shutdown, nine fresh-process table-hash/integrity checks, and real Gateway status/days/timeline payloads before and after restart. The exact-head runtime build passed. All synthetic state and processes were removed; the complete synthetic trace is posted below.

Production delta is +49 lines, including a net-neutral move of the existing status type. The added code supplies the previously missing service-operation lifetime owner and retirement binding; placing a drain only in the database store would miss the asynchronous work between queries. Tests add 276 lines net. The old immediate-close path and duplicate stop ownership are removed.

The related reports also propose forwarding cancellation through structured media extraction. This PR repairs database lifetime by draining accepted work and preserves current cancellation contracts; it does not claim that separate interruption work is implemented or automatically close those broader reports.
