### PR TITLE
perf(sqlite): reuse compiled plugin state point reads

### DIFF
--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -7,6 +7,7 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
+  prepareSqliteQuerySync,
 } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { isTerminalSqliteIntegrityError } from "../infra/sqlite-integrity.js";
@@ -215,20 +216,35 @@ function insertPluginStateEntryIfAbsent(
   return Number(result.numAffectedRows ?? 0) > 0;
 }
 
+type PluginStateEntryLookup = { pluginId: string; namespace: string; key: string; now: number };
+const pluginStateEntryQueries = new WeakMap<
+  DatabaseSync,
+  ReturnType<typeof prepareSqliteQuerySync<PluginStateEntryLookup, PluginStateRow>>
+>();
+
 function selectPluginStateEntry(
   db: DatabaseSync,
-  params: { pluginId: string; namespace: string; key: string; now: number },
+  params: PluginStateEntryLookup,
 ): PluginStateRow | undefined {
-  return executeSqliteQueryTakeFirstSync(
-    db,
-    getPluginStateKysely(db)
-      .selectFrom("plugin_state_entries")
-      .select(["plugin_id", "namespace", "entry_key", "value_json", "created_at", "expires_at"])
-      .where("plugin_id", "=", params.pluginId)
-      .where("namespace", "=", params.namespace)
-      .where("entry_key", "=", params.key)
-      .where((eb) => eb.or([eb("expires_at", "is", null), eb("expires_at", ">", params.now)])),
-  );
+  let query = pluginStateEntryQueries.get(db);
+  if (!query) {
+    // Retain compilation with the physical connection; keys and expiry stay invocation-local.
+    query = prepareSqliteQuerySync<PluginStateEntryLookup, PluginStateRow>(db, (parameter) => {
+      const pluginId = parameter((value) => value.pluginId);
+      const namespace = parameter((value) => value.namespace);
+      const key = parameter((value) => value.key);
+      const now = parameter((value) => value.now);
+      return getPluginStateKysely(db)
+        .selectFrom("plugin_state_entries")
+        .select(["plugin_id", "namespace", "entry_key", "value_json", "created_at", "expires_at"])
+        .where("plugin_id", "=", pluginId)
+        .where("namespace", "=", namespace)
+        .where("entry_key", "=", key)
+        .where((eb) => eb.or([eb("expires_at", "is", null), eb("expires_at", ">", now)]));
+    });
+    pluginStateEntryQueries.set(db, query);
+  }
+  return query(params).rows[0];
 }
 
 function selectPluginStateEntries(

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { trackSqliteStatementExecutions } from "../../test/helpers/sqlite-statement-execution-counter.js";
+import { getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import {
   closeOpenClawStateDatabaseByPath,
   isOpenClawStateDatabaseOpen,
@@ -109,6 +110,52 @@ describe("plugin state keyed store", () => {
       expect(store.consume("interaction:1")).toEqual({ count: 1 });
       expect(store.lookup("interaction:1")).toBeUndefined();
     });
+  });
+
+  it("compiles exact reads once per connection with fresh scope and expiry bindings", () => {
+    const now = Date.now();
+    seedPluginStateEntriesForTests([
+      { pluginId: "discord", namespace: "prepared", key: "first", value: 1, expiresAt: now + 100 },
+      { pluginId: "discord", namespace: "prepared", key: "second", value: 2 },
+      { pluginId: "telegram", namespace: "prepared", key: "first", value: 3 },
+      { pluginId: "discord", namespace: "sibling", key: "first", value: 4 },
+    ]);
+    const store = createPluginStateSyncKeyedStore<number>("discord", {
+      namespace: "prepared",
+      maxEntries: 10,
+    });
+    const pluginSibling = createPluginStateSyncKeyedStore<number>("telegram", {
+      namespace: "prepared",
+      maxEntries: 10,
+    });
+    const namespaceSibling = createPluginStateSyncKeyedStore<number>("discord", {
+      namespace: "sibling",
+      maxEntries: 10,
+    });
+    const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      for (let connection = 0; connection < 2; connection++) {
+        closePluginStateDatabase();
+        const { db } = openOpenClawStateDatabase();
+        const compile = vi.spyOn(getNodeSqliteKysely(db).getExecutor(), "compileQuery");
+        try {
+          clock.mockReturnValue(now);
+          expect(store.lookup("first")).toBe(1);
+          expect(store.lookup("second")).toBe(2);
+          expect(pluginSibling.lookup("first")).toBe(3);
+          expect(namespaceSibling.lookup("first")).toBe(4);
+          expect(store.lookup("missing")).toBeUndefined();
+          clock.mockReturnValue(now + 100);
+          expect(store.lookup("first")).toBeUndefined();
+          expect(store.lookup("second")).toBe(2);
+          expect(compile).toHaveBeenCalledOnce();
+        } finally {
+          compile.mockRestore();
+        }
+      }
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   it("shares sync and async state while preserving their error contracts", async () => {


### PR DESCRIPTION
## What Problem This Solves

Plugin state point reads rebuild and compile the same Kysely query for every lookup. Reconstructing a large Reef audit chain or Buzz reconnect cursor set repeats that JavaScript work thousands of times even though the physical connection and query shape are unchanged.

## Why This Change Was Made

Reuse the existing `prepareSqliteQuerySync` helper once per physical SQLite connection at the shared point-read owner. Every invocation still binds its current plugin, namespace, key, and expiry time and executes the same fresh read. Native statement invalidation remains owned by the existing helper, and the compiled runner has weak connection ownership.

This preserves exact point-read timing. Replacing these callers with namespace snapshots would change concurrent reconnect observations or expose unrelated malformed audit rows. No result rows, authorization decisions, or expiry facts are cached.

## User Impact

Existing plugin-state consumers perform less repeated query-building work without changing their results or setup. Schema, stored rows, transactions, error handling, quotas, and public APIs are unchanged.

## Evidence

- The regression fails before the change with seven compilations instead of one. It passes across two independently opened native connections with different plugins, namespaces, keys, absent rows, and exact expiry boundaries.
- All 190 tests in 12 owner/helper/Buzz/Reef files pass, as does the full changed-file gate. Fresh independent Codex review found no actionable P0–P2 findings.
- Five native phases exercise the actual candidate source with synthetic state: a 30,000-entry committed Reef chain, 1,020 Buzz reconnect rooms, malformed uncommitted overflow, an interleaved reconnect update, and physical close/reopen. Complete result hashes and all persisted row bytes/timestamps match baseline. The committed chain still performs 30,001 fresh SELECTs but no per-read Kysely compilations after its prepared reader is initialized; Buzz retains 1,021 SELECTs and only its separate list-query compilation.
- The retained public store reads correctly after its old physical handle closes and a new connection opens. The native proof verifies candidate source hashes before and after. These are structural compilation/query measurements, not a latency benchmark or external channel test.

Production delta is +16 lines for one connection-owned compiled reader; tests add 47. There is no new cache framework, dependency, configuration, or test-only production hook.
