### PR TITLE
ci: run full-access restart recovery in nightly QA

### DIFF
--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -429,6 +429,24 @@ jobs:
             --fast \
             --output-dir "${{ steps.run_lane.outputs.output_dir }}/gateway-restart-gpt-5.4-runtime-pair"
 
+      - name: Run full-access gateway restart recovery
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENCLAW_LIVE_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          pnpm openclaw qa suite \
+            --repo-root . \
+            --provider-mode live-frontier \
+            --scenario gateway-restart-full-access-live \
+            --concurrency 1 \
+            --model openai/gpt-5.6-luna \
+            --alt-model openai/gpt-5.6-luna \
+            --fast \
+            --output-dir "${{ steps.run_lane.outputs.output_dir }}/gateway-restart-full-access"
+
       - name: Generate live runtime token-efficiency report
         if: steps.run_lane.outcome == 'success'
         shell: bash

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -34,6 +34,13 @@ plugin coverage lives in the separate
 [`Full Release Validation`](#full-release-validation) or an explicit manual
 dispatch.
 
+Scheduled QA runs nightly at 04:41 UTC. Its live runtime job runs the
+`gateway-restart-full-access-live` scenario with `openai/gpt-5.6-luna` alongside
+the three-restart replay-safety scenario. The Full Access check must preserve
+shell access and delegation without repeating the interrupted side effect;
+failure fails the job. Both scenarios run serially and retain their reports in
+the job's uploaded artifacts.
+
 ## Pipeline overview
 
 | Job                              | Purpose                                                                                                                                                                                                                                                                                                  | When it runs                                           |

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2059,6 +2059,29 @@ describe("ci workflow guards", () => {
     expect(releaseWorkflow.jobs.qa_live_buzz_release_checks.with.lock_scope).toBe("buzz");
   });
 
+  it("runs full-access restart proof as a failing nightly gate", () => {
+    const workflow = readWorkflow(".github/workflows/qa-live-transports-convex.yml");
+    const job = workflow.jobs.run_live_runtime_token_efficiency;
+    const step = job.steps.find((candidate: WorkflowStep) =>
+      candidate.run?.includes("--scenario gateway-restart-full-access-live"),
+    );
+
+    expect(workflow.on.schedule.length).toBeGreaterThan(0);
+    expect(job.if).toBe("github.event_name == 'schedule'");
+    expect(step).toBeDefined();
+    expect(step?.env?.OPENAI_API_KEY).toBe("${{ secrets.OPENAI_API_KEY }}");
+    expect(step?.["continue-on-error"]).toBeUndefined();
+    expect(step?.if).toBeUndefined();
+    expect(step?.run).toContain("--provider-mode live-frontier");
+    expect(step?.run).toContain("--model openai/gpt-5.6-luna");
+    expect(step?.run).toContain("--alt-model openai/gpt-5.6-luna");
+    expect(step?.run).toContain("--concurrency 1");
+    expect(step?.run).not.toContain("--allow-failures");
+    expect(step?.run).toContain(
+      '--output-dir "${{ steps.run_lane.outputs.output_dir }}/gateway-restart-full-access"',
+    );
+  });
+
   it("preserves module heredocs and cleans child temporary artifacts", () => {
     const parentTempDir = tmpdir();
     const run = runWorkflowShellScript(


### PR DESCRIPTION
Related: #138701

## What Problem This Solves

The Full Access restart regression introduced in #138701 had deterministic coverage and successful live proof, but no dedicated recurring live invocation. The scheduled QA job ran the restricted three-restart scenario while omitting ordinary Full Access continuation.

## Why This Change Was Made

Add the existing `gateway-restart-full-access-live` scenario as a serial step in the existing nightly live runtime job, using its declared `openai/gpt-5.6-luna` model. A scenario failure fails the job, and its report is retained under the existing artifact upload directory. This adds zero jobs, runner registrations, concurrency changes, credentials, or product runtime code.

A workflow guard protects the scheduled invocation, model and provider selection, failure policy, serial execution, and artifact path. The CI documentation now describes the recurring coverage.

## User Impact

The nightly run at 04:41 UTC checks that a Gateway restart preserves Full Access shell execution and delegation without duplicating the interrupted side effect. This complements the existing three-restart replay-safety check.

## Evidence

- New workflow guard failed on the unwired workflow and passes with the new step.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts --reporter=dot`: 432 passed, 2 existing skipped.
- Executed the exact added shell command with a stubbed `pnpm`: verified scenario/model arguments and propagation of both exit 0 and exit 23. No swallowed failure.
- Formatting and `git diff --check` pass. Independent Codex review is scoped-clean through P1.
- The unchanged live scenario was already exercised in #138701: fresh shell work and a completed child, one original side effect, one final delivery, and no extra user turn. This change wires that tested command into the schedule; it does not claim a scheduled execution has occurred before landing.
- Local aggregate workflow lint could not bootstrap its pinned `pre-commit==4.6.2` from the available package index. Hosted workflow syntax/security checks remain required before merge; the pin and validation policy are unchanged.

Diff: product runtime +0, workflow +18, tests +23, documentation +7. Existing runner, timeout, authorization, secret, and upload ownership are preserved.
