### PR TITLE
fix(cli): preserve foreground Gateway argument handling

### DIFF
--- a/src/cli/gateway-run-argv.ts
+++ b/src/cli/gateway-run-argv.ts
@@ -1,5 +1,9 @@
 // Fast-path argv parser for `openclaw gateway ...` without full Commander registration.
-import { consumeRootOptionToken, isValueToken } from "../infra/cli-root-options.js";
+import {
+  consumeRootOptionToken,
+  getCommandPositionalsWithRootOptions,
+  isValueToken,
+} from "../infra/cli-root-options.js";
 
 const GATEWAY_RUN_VALUE_FLAGS = new Set([
   "--port",
@@ -18,6 +22,8 @@ const GATEWAY_RUN_BOOLEAN_FLAGS = new Set([
   "--tailscale-reset-on-exit",
   "--allow-unconfigured",
   "--dev",
+  "--ambient-channels",
+  "--dev-ambient-channels",
   "--reset",
   "--force",
   "--verbose",
@@ -26,6 +32,20 @@ const GATEWAY_RUN_BOOLEAN_FLAGS = new Set([
   "--compact",
   "--raw-stream",
 ]);
+
+export function isForegroundGatewayRunArgv(argv: string[]): boolean {
+  const positionals = getCommandPositionalsWithRootOptions(argv, {
+    commandPath: ["gateway"],
+    booleanFlags: [...GATEWAY_RUN_BOOLEAN_FLAGS],
+    valueFlags: [...GATEWAY_RUN_VALUE_FLAGS],
+  });
+  if (!positionals) {
+    return false;
+  }
+  // Foreground gateway owns the terminal/process environment itself; respawning would
+  // add an extra parent process around the long-lived server.
+  return positionals.length === 0 || (positionals.length === 1 && positionals[0] === "run");
+}
 
 /** Return how many argv tokens a gateway-run option consumes, or 0 when not recognized. */
 export function consumeGatewayRunOptionToken(args: ReadonlyArray<string>, index: number): number {

--- a/src/cli/respawn-policy.ts
+++ b/src/cli/respawn-policy.ts
@@ -1,31 +1,7 @@
 // CLI respawn skip policy for help, interactive TTY commands, and foreground Gateway runs.
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
-import { getCommandPathWithRootOptions, getCommandPositionalsWithRootOptions } from "./argv.js";
-
-const GATEWAY_RUN_BOOLEAN_FLAGS = [
-  "--allow-unconfigured",
-  "--claude-cli-logs",
-  "--cli-backend-logs",
-  "--compact",
-  "--dev",
-  "--force",
-  "--raw-stream",
-  "--reset",
-  "--tailscale-reset-on-exit",
-  "--verbose",
-] as const;
-
-const GATEWAY_RUN_VALUE_FLAGS = [
-  "--auth",
-  "--bind",
-  "--password",
-  "--password-file",
-  "--port",
-  "--raw-stream-path",
-  "--tailscale",
-  "--token",
-  "--ws-log",
-] as const;
+import { getCommandPathWithRootOptions } from "./argv.js";
+import { isForegroundGatewayRunArgv } from "./gateway-run-argv.js";
 
 const INTERACTIVE_TTY_COMMANDS = new Set(["tui", "terminal", "chat"]);
 
@@ -57,20 +33,6 @@ export function isTerminalInteractiveRespawnArgv(argv: string[]): boolean {
     return false;
   }
   return invocation.primary === null || INTERACTIVE_TTY_COMMANDS.has(invocation.primary);
-}
-
-function isForegroundGatewayRunArgv(argv: string[]): boolean {
-  const positionals = getCommandPositionalsWithRootOptions(argv, {
-    commandPath: ["gateway"],
-    booleanFlags: GATEWAY_RUN_BOOLEAN_FLAGS,
-    valueFlags: GATEWAY_RUN_VALUE_FLAGS,
-  });
-  if (!positionals) {
-    return false;
-  }
-  // Foreground gateway owns the terminal/process environment itself; respawning would
-  // add an extra parent process around the long-lived server.
-  return positionals.length === 0 || (positionals.length === 1 && positionals[0] === "run");
 }
 
 /** Returns whether CLI startup should avoid the general respawn wrapper for this argv. */

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -1,5 +1,5 @@
 // Run main tests cover CLI main entrypoint behavior and process error handling.
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginManifestCommandAliasRegistry } from "../plugins/manifest-command-aliases.js";
 import {
   resolveGatewayCatalogCommandPath,
@@ -14,7 +14,55 @@ import {
   shouldUseRootHelpFastPath,
   shouldUseSetupOnboardConfigureHelpFastPath,
 } from "./run-main-policy.js";
-import { isGatewayRunFastPathArgv } from "./run-main.js";
+import { isGatewayRunFastPathArgv, runCli } from "./run-main.js";
+
+const runGatewayCommand = vi.hoisted(() => vi.fn());
+
+vi.mock("./gateway-cli/run.js", () => ({ runGatewayCommand }));
+vi.mock("./gateway-cli/pre-bootstrap.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./gateway-cli/pre-bootstrap.js")>()),
+  selectGatewayRunEnvironment: async () => true,
+  prepareGatewayRunBootstrap: async () => false,
+}));
+vi.mock("../logging.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../logging.js")>()),
+  enableConsoleCapture: vi.fn(),
+}));
+
+describe("Gateway fast-path Commander parsing", () => {
+  const previousExitCode = process.exitCode;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    runGatewayCommand.mockClear();
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.exitCode = previousExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    { flag: "--ambient-channels", key: "ambientChannels" },
+    { flag: "--dev-ambient-channels", key: "devAmbientChannels" },
+    { flag: "--verbose", key: "verbose" },
+  ])("accepts root no-color after $flag on parent and child", async ({ flag, key }) => {
+    for (const args of [
+      [flag, "--no-color", "run"],
+      ["run", flag, "--no-color"],
+    ]) {
+      runGatewayCommand.mockClear();
+      await runCli(["node", "openclaw", "gateway", ...args, "--token=--no-color"]);
+
+      expect(process.exitCode).toBeUndefined();
+      expect(runGatewayCommand).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ [key]: true, token: "--no-color" }),
+        expect.any(Object),
+      );
+    }
+  });
+});
 
 const memoryWikiCommandAliasRegistry: PluginManifestCommandAliasRegistry = {
   plugins: [
@@ -75,10 +123,10 @@ describe("isGatewayRunFastPathArgv", () => {
     expect(isGatewayRunFastPathArgv(["node", "openclaw", "gateway", "run"])).toBe(true);
     expect(
       isGatewayRunFastPathArgv(["node", "openclaw", "gateway", "--log-level", "debug", "run"]),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isGatewayRunFastPathArgv(["node", "openclaw", "gateway", "--log-level=debug", "run"]),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isGatewayRunFastPathArgv(["node", "openclaw", "gateway", "run", "--raw-stream-path", "x"]),
     ).toBe(true);

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -14,11 +14,7 @@ import { resolveGatewayPort, resolveStateDir } from "../config/paths.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import { isLoopbackAddress, isSecureWebSocketUrl } from "../gateway/net.js";
 import { normalizeWebSocketProtocol } from "../gateway/websocket-protocol.js";
-import {
-  consumeRootOptionToken,
-  FLAG_TERMINATOR,
-  isValueToken,
-} from "../infra/cli-root-options.js";
+import { FLAG_TERMINATOR, isValueToken } from "../infra/cli-root-options.js";
 import { isTruthyEnvValue, normalizeEnv } from "../infra/env.js";
 import type { ProxyHandle } from "../infra/net/proxy/proxy-lifecycle.js";
 import { tryProcessCwd } from "../infra/safe-cwd.js";
@@ -138,7 +134,7 @@ export function isGatewayRunFastPathArgv(argv: string[]): boolean {
       continue;
     }
 
-    const rootConsumed = consumeRootOptionToken(args, index);
+    const rootConsumed = consumeGatewayFastPathRootOptionToken(args, index);
     if (rootConsumed > 0) {
       index += rootConsumed - 1;
       continue;
@@ -256,8 +252,9 @@ async function tryRunGatewayRunFastPath(
     gateway.command("run").description("Run the WebSocket Gateway (foreground)"),
     { beforeRun },
   );
+  const parseArgv = normalizeRootNoColorArgvForProgram(argv, program);
   try {
-    await startupTrace.measure("gateway-run-parse", () => program.parseAsync(argv), {
+    await startupTrace.measure("gateway-run-parse", () => program.parseAsync(parseArgv), {
       timeline: false,
     });
   } catch (error) {

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -30,6 +30,24 @@ describe("buildCliRespawnPlan", () => {
     ).toBeNull();
   });
 
+  it.each([
+    ["gateway", "run", "--ambient-channels"],
+    ["gateway", "--ambient-channels", "run"],
+    ["gateway", "run", "--dev-ambient-channels"],
+  ])("keeps foreground Gateway ambient channel options in process: %j", (...args) => {
+    for (const platform of ["darwin", "linux", "win32"] as const) {
+      expect(
+        buildCliRespawnPlan({
+          argv: ["node", "openclaw", ...args],
+          env: {},
+          execArgv: [],
+          autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+          platform,
+        }),
+      ).toBeNull();
+    }
+  });
+
   it("does not detach native hook relays through a startup respawn", () => {
     expect(
       buildCliRespawnPlan({


### PR DESCRIPTION
Closes #138762

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is to remain enabled when this PR is created.

</details>

## What Problem This Solves

Fixes an issue where users running a foreground Gateway with `--ambient-channels` or its deprecated alias would get an unnecessary respawn parent. It also fixes existing argument failures where `--verbose --no-color` or trailing `--log-level` were rejected before Gateway startup validation.

The first local candidate exposed the reduced parser's existing no-color defect for ambient flags. Managed review caught that P2 before publication; this version fixes the shared owner rather than excluding the new cases from the fast path.

## Why This Change Was Made

Foreground detection now uses the canonical Gateway flag table instead of duplicate lists. The reduced parser reuses existing metadata-aware no-color normalization, and fast-path root-option admission is consistent before and after `gateway`. Log-level validation and logging preactions remain with the full parser that owns them.

Production 27 additions/48 deletions: **net -21**. Tests 70 additions/4 deletions: **net +66**. No new CLI options, config/environment surfaces, persistence changes, timeout changes or compatibility paths. Windows containment and the separate managed-service handoff lifecycle repair are not included.

## User Impact

The two documented ambient-channel flags preserve foreground process ownership. Global no-color and log-level options work with the applicable Gateway arguments, without weakening invalid-option or invalid-log-level validation. Required flag-looking token values remain intact.

## Evidence

Fresh Node 24.20.0/pnpm 12.1.0 installs and supported dist-backed runtime builds were compared against `d329e6144965561c88cad197380def7b12eb6beb` on macOS 27.0.

| Actual check | Baseline / first candidate | Final candidate |
| --- | --- | --- |
| Ambient primary and alias | Two process starts: launcher+respawn child | One process start each |
| Ambient flag followed by no-color | Baseline reaches port validation; first candidate rejects no-color | Reaches port validation |
| Existing verbose followed by no-color | Unknown no-color option | Reaches port validation |
| Trailing valid log-level | Unknown log-level option | Reaches port validation, as the prefix form does |
| Invalid log-level | Existing validator retained | Specific invalid-log-level error |
| Required token value `--no-color` | Existing value contract retained | Reaches port validation |

Supported build/CLI commands included:

```sh
node scripts/run-node.mjs gateway run --ambient-channels --no-color --port 0
node openclaw.mjs gateway run --ambient-channels --port 0
node openclaw.mjs gateway run --dev-ambient-channels --port 0
node openclaw.mjs gateway run --dev-ambient-channels --no-color --port 0
node openclaw.mjs gateway run --verbose --no-color --port 0
node openclaw.mjs gateway run --log-level debug --port 0
node openclaw.mjs --log-level debug gateway run --port 0
node openclaw.mjs gateway run --log-level=loud --port 0
node openclaw.mjs gateway run --token --no-color --port 0
```

A passive main-thread process-start observer supplied with Node `--require` captured the process comparisons; it did not mock spawning. Every command used private HOME/state/config/TMP. Valid argument cases intentionally ended with:

```text
Invalid --port. Use a port number from 1 to 65535, for example 18789.
```

Invalid log-level retained its dedicated validation error:

```text
OpenClaw could not parse this command: option '--log-level <level>' argument 'loud' is invalid. Invalid --log-level (use silent|fatal|error|warn|info|debug|trace)
Try: openclaw --help
```

These are normal expected exit 1 outcomes, not Gateway-start success; no operator Gateway/listener or Windows VM was launched.

The entry regression failed 3 intended cases before repair. The real runCli+Commander+Gateway-registration regression failed 3 intended parse-exit cases before normalization repair and passed afterward. 696 tests passed across 10 focused files, with no skips. Existing value/terminator, option-collision, exit/profile and log-level coverage remained intact. The canonical 29-check changed gate passed in 397.25s (25 printed subprocess commands plus 4 internally run check stages), including formatting, core/test types, lint and required guards. Final managed P0–P2 review passed both partitions with no actionable findings; complete integration context was retained in both.

The first review's P2 and all red receipts remain retained. A baseline setup attempt initially failed because a root-only dependency symlink missed plugin-local workspace dependencies; a fresh authorized frozen install resolved that setup issue. Earlier source-entry observations are not used as the supported dist-backed proof. No successful Gateway boot, Windows execution or native containment proof is claimed.
