### PR TITLE
fix(codex): prevent stale compaction after session rollover

### DIFF
--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -269,6 +269,69 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(bindingStore.read(current)).toEqual(binding);
   });
 
+  it("rejects a queued compaction after admitted authority rotates before client acquisition", async () => {
+    const current = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionKey: "agent:main:queued-authority",
+      sessionId: "session-current",
+    };
+    const successor = { ...current, sessionId: "session-successor" };
+    const scope = {
+      agentId: current.agentId,
+      sessionKey: current.sessionKey,
+      storePath: path.join(tempDir, "admitted", "sessions.json"),
+    };
+    await upsertSessionEntry({
+      ...scope,
+      entry: { sessionId: current.sessionId, updatedAt: 1 },
+    });
+    const bindingStore = createCodexTestBindingStore();
+    const binding = { threadId: "thread-queued", cwd: tempDir };
+    await bindingStore.mutate(current, { kind: "set", binding });
+    const fake = createFakeCodexClient();
+    const clientFactory = vi.fn(async () => fake.client);
+    const queueEntered = createDeferred<void>();
+    const releaseQueue = createDeferred<void>();
+    const held = withCodexAppServerThreadMutation(binding.threadId, async () => {
+      queueEntered.resolve();
+      await releaseQueue.promise;
+    });
+    await queueEntered.promise;
+
+    const pending = maybeCompactCodexAppServerSessionImpl(
+      {
+        sessionId: current.sessionId,
+        sessionKey: current.sessionKey,
+        agentId: current.agentId,
+        sessionTarget: { ...scope, sessionId: current.sessionId },
+        sessionFile: path.join(tempDir, "queued-authority.jsonl"),
+        workspaceDir: tempDir,
+        trigger: "manual",
+      },
+      { bindingStore, clientFactory },
+    );
+    await flushAsyncTasks();
+    expect(clientFactory).not.toHaveBeenCalled();
+
+    await patchSessionEntry({ ...scope, update: () => ({ sessionId: successor.sessionId }) });
+    releaseQueue.resolve();
+    await held;
+
+    await expect(pending).rejects.toThrow("Codex session generation is no longer current");
+    expect(clientFactory).not.toHaveBeenCalled();
+    expect(fake.request).not.toHaveBeenCalled();
+    expect(bindingStore.read(current)).toEqual(binding);
+
+    const adopted = await resolveCodexSessionBinding({
+      bindingStore,
+      identity: successor,
+      storePath: scope.storePath,
+    });
+    expect(adopted.binding).toEqual(binding);
+    expect(bindingStore.read(successor)).toEqual(binding);
+  });
+
   it("waits for native app-server compaction completion", async () => {
     const fake = createFakeCodexClient();
     setCodexAppServerClientFactoryForTest(async () => fake.client);

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -462,17 +462,35 @@ async function compactCodexNativeThread(
     agentId: params.agentId,
     config: params.config,
   });
-  // Already-readable bindings keep compaction's own cancellation-result handling.
-  const readableBinding = options.bindingStore.read(bindingIdentity);
-  const { binding: initialBinding, assertCurrent } = readableBinding
-    ? { binding: readableBinding, assertCurrent: () => {} }
-    : await resolveCodexSessionBinding({
-        bindingStore: options.bindingStore,
-        identity: bindingIdentity,
-        config: params.config,
-        storePath: params.sessionTarget?.storePath,
-        signal: params.abortSignal,
-      });
+  const abortedResult = (expectedThreadId?: string, currentThreadId = expectedThreadId) =>
+    options.allowNonManualNativeRequest
+      ? skippedCodexNativeCompactionResult(params, {
+          reason: "codex app-server compaction aborted before native compaction",
+          code: "aborted_before_native_compaction",
+          request: options.nativeCompactionRequest ?? "after_context_engine",
+          ...(expectedThreadId ? { expectedThreadId, currentThreadId } : {}),
+        })
+      : {
+          ok: false as const,
+          compacted: false,
+          reason: "codex app-server compaction aborted while waiting to start",
+        };
+  let resolvedBinding: Awaited<ReturnType<typeof resolveCodexSessionBinding>>;
+  try {
+    resolvedBinding = await resolveCodexSessionBinding({
+      bindingStore: options.bindingStore,
+      identity: bindingIdentity,
+      config: params.config,
+      storePath: params.sessionTarget?.storePath,
+      signal: params.abortSignal,
+    });
+  } catch (error) {
+    if (!params.abortSignal?.aborted) {
+      throw error;
+    }
+    return abortedResult(options.bindingStore.read(bindingIdentity)?.threadId);
+  }
+  const { binding: initialBinding, assertCurrent } = resolvedBinding;
   if (!initialBinding?.threadId) {
     return failedCodexThreadBindingCompactionResult(params, {
       reason: "no codex app-server thread binding",
@@ -896,20 +914,7 @@ async function compactCodexNativeThread(
     );
   } catch (error) {
     if (params.abortSignal?.aborted) {
-      if (options.allowNonManualNativeRequest) {
-        return skippedCodexNativeCompactionResult(params, {
-          reason: "codex app-server compaction aborted before native compaction",
-          code: "aborted_before_native_compaction",
-          request: options.nativeCompactionRequest ?? "after_context_engine",
-          expectedThreadId: initialBinding.threadId,
-          currentThreadId: binding.threadId,
-        });
-      }
-      return {
-        ok: false,
-        compacted: false,
-        reason: "codex app-server compaction aborted while waiting to start",
-      };
+      return abortedResult(initialBinding.threadId, binding.threadId);
     }
     throw error;
   }

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -1025,6 +1025,116 @@ describe("Codex app-server binding store", () => {
     },
   );
 
+  it("fences an already-readable binding when its admitted session generation rotates", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-readable-authority-"));
+    const storePath = path.join(root, "sessions.json");
+    const { state } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const current = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "session-current",
+      sessionKey: "agent:main:readable",
+    };
+    const scope = { agentId: current.agentId, sessionKey: current.sessionKey, storePath };
+    const binding = { threadId: "thread-current", cwd: "/repo" };
+    try {
+      await upsertSessionEntry({
+        ...scope,
+        entry: { sessionId: current.sessionId, updatedAt: 1 },
+      });
+      await store.mutate(current, { kind: "set", binding });
+
+      const resolved = await resolveCodexSessionBinding({
+        bindingStore: store,
+        identity: current,
+        storePath,
+      });
+      expect(resolved.binding).toEqual(binding);
+
+      await patchSessionEntry({
+        ...scope,
+        update: () => ({ sessionId: "session-successor" }),
+      });
+      expect(resolved.assertCurrent).toThrow("Codex session generation is no longer current");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an already-readable binding owned by a stale admitted session", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-readable-stale-"));
+    const storePath = path.join(root, "sessions.json");
+    const { state } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const stale = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "session-stale",
+      sessionKey: "agent:main:readable",
+    };
+    try {
+      await upsertSessionEntry({
+        agentId: stale.agentId,
+        sessionKey: stale.sessionKey,
+        storePath,
+        entry: { sessionId: "session-current", updatedAt: 1 },
+      });
+      await store.mutate(stale, {
+        kind: "set",
+        binding: { threadId: "thread-stale", cwd: "/repo" },
+      });
+
+      await expect(
+        resolveCodexSessionBinding({ bindingStore: store, identity: stale, storePath }),
+      ).rejects.toThrow("Codex session generation is no longer current");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves caller authority for a scoped session with no durable row", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-readable-ephemeral-"));
+    const storePath = path.join(root, "sessions.json");
+    const { state } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const ephemeral = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "session-ephemeral",
+      sessionKey: "agent:main:ephemeral",
+    };
+    let active = true;
+    try {
+      await upsertSessionEntry({
+        agentId: ephemeral.agentId,
+        sessionKey: "agent:main:other",
+        storePath,
+        entry: { sessionId: "session-other", updatedAt: 1 },
+      });
+      const binding = { threadId: "thread-ephemeral", cwd: "/repo" };
+      await store.mutate(ephemeral, { kind: "set", binding });
+
+      const resolved = await resolveCodexSessionBinding({
+        bindingStore: store,
+        identity: ephemeral,
+        storePath,
+        assertCurrent: () => {
+          if (!active) {
+            throw new Error("caller authority closed");
+          }
+        },
+      });
+      expect(resolved.binding).toEqual(binding);
+      expect(resolved.assertCurrent).not.toThrow();
+
+      active = false;
+      expect(resolved.assertCurrent).toThrow("caller authority closed");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it.each(
     ["two generations behind", "different session key", "different agent"].flatMap((mismatch) =>
       [false, true].map((supervision) => ({ mismatch, supervision })),

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -87,15 +87,45 @@ export function resolveCodexRunSessionBindingAuthority(params: {
   config?: OpenClawConfig;
   storePath?: string;
 }): CodexRunSessionBindingAuthority {
-  try {
-    const entry = readCodexBindingSessionEntry(params);
-    if (!entry) {
-      return "ephemeral";
+  return captureCodexSessionGenerationAuthority(params)[0];
+}
+
+type CodexSessionGenerationAuthorityParams = Parameters<typeof readCodexBindingSessionEntry>[0];
+
+function captureCodexSessionGenerationAuthority(
+  params: CodexSessionGenerationAuthorityParams,
+  assertCallerCurrent: () => void = () => {},
+) {
+  const readEntry = () => {
+    try {
+      return readCodexBindingSessionEntry(params);
+    } catch {
+      return null;
     }
-    return entry.sessionId === params.identity.sessionId ? "current" : "superseded";
-  } catch {
-    return "superseded";
-  }
+  };
+  const entry = readEntry();
+  const current = entry?.sessionId === params.identity.sessionId;
+  const authority = entry === undefined ? "ephemeral" : current ? "current" : "superseded";
+  const previousSessionId = current ? entry.previousSessionId : undefined;
+  const assertHostCurrent = () => {
+    if (authority === "ephemeral") {
+      return;
+    }
+    const latest = readEntry();
+    if (
+      authority !== "current" ||
+      !latest ||
+      latest.sessionId !== params.identity.sessionId ||
+      latest.previousSessionId !== previousSessionId
+    ) {
+      throw createCodexSessionGenerationSupersededError(params.identity.sessionId);
+    }
+  };
+  const assertCurrent = () => {
+    assertCallerCurrent();
+    assertHostCurrent();
+  };
+  return [authority, previousSessionId, assertHostCurrent, assertCurrent] as const;
 }
 
 /** Builds the terminal coordination error used when a newer OpenClaw session owns the binding. */
@@ -375,55 +405,28 @@ export function scopeCodexRunBindingStore(params: {
   };
 }
 
-/** Lets the authoritative OpenClaw session generation claim a stale stable binding row. */
-export async function reclaimCurrentCodexSessionGeneration(params: {
+type CodexSessionGenerationReclaimParams = CodexSessionGenerationAuthorityParams & {
   assertCurrent?: () => void;
   onHostGenerationVerified?: (assertHostGeneration: () => void) => void;
   bindingStore: CodexAppServerBindingStore;
-  identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>;
-  config?: OpenClawConfig;
-  storePath?: string;
   reclaimStale?: boolean;
-}): Promise<boolean> {
-  params.assertCurrent?.();
-  const sessionKey = params.identity.sessionKey?.trim();
-  if (!sessionKey) {
-    return true;
-  }
+};
+
+async function reclaimPreparedCodexSessionGeneration(
+  params: CodexSessionGenerationReclaimParams,
+  authority: ReturnType<typeof captureCodexSessionGenerationAuthority>,
+  assertCurrent = authority[3],
+): Promise<boolean> {
   const plan = await params.bindingStore.prepareSessionGenerationReclaim(params.identity);
-  params.assertCurrent?.();
+  assertCurrent();
   if (plan.kind === "resolved") {
     return plan.result;
   }
-
-  let previousSessionId: string | undefined;
-  // Only a stale stable-key owner needs session-store authority. Resolve it before
-  // the second mutation so the session read never runs inside the binding write transaction.
-  try {
-    const entry = readCodexBindingSessionEntry(params);
-    if (entry?.sessionId !== params.identity.sessionId) {
-      return false;
-    }
-    previousSessionId = entry.previousSessionId;
-  } catch {
+  const [state, previousSessionId, assertHostCurrent] = authority;
+  if (state !== "current") {
     return false;
   }
-  // Lease waits may outlive host rotation without closing the run. Recheck the
-  // recorded pair immediately before each write, outside the binding transaction.
-  const assertHostGeneration = () => {
-    const entry = readCodexBindingSessionEntry(params);
-    if (
-      entry?.sessionId !== params.identity.sessionId ||
-      entry.previousSessionId !== previousSessionId
-    ) {
-      throw createCodexSessionGenerationSupersededError(params.identity.sessionId);
-    }
-  };
-  const assertCurrent = () => {
-    params.assertCurrent?.();
-    assertHostGeneration();
-  };
-  params.onHostGenerationVerified?.(assertHostGeneration);
+  params.onHostGenerationVerified?.(assertHostCurrent);
   if (previousSessionId === plan.expectedPreviousSessionId) {
     const adopted = await params.bindingStore.adoptSessionGeneration(
       params.identity,
@@ -437,7 +440,7 @@ export async function reclaimCurrentCodexSessionGeneration(params: {
   if (params.reclaimStale === false) {
     return false;
   }
-  return await params.bindingStore.mutate(
+  return params.bindingStore.mutate(
     params.identity,
     {
       kind: "reclaim-generation",
@@ -445,6 +448,21 @@ export async function reclaimCurrentCodexSessionGeneration(params: {
     },
     assertCurrent,
   );
+}
+
+/** Lets the authoritative OpenClaw session generation claim a stale stable binding row. */
+export async function reclaimCurrentCodexSessionGeneration(
+  params: CodexSessionGenerationReclaimParams,
+): Promise<boolean> {
+  params.assertCurrent?.();
+  if (!params.identity.sessionKey?.trim()) {
+    return true;
+  }
+  const authority = captureCodexSessionGenerationAuthority(params, params.assertCurrent);
+  if (authority[0] === "superseded") {
+    return false;
+  }
+  return reclaimPreparedCodexSessionGeneration(params, authority);
 }
 
 /** Resolve continuity before selecting native queues, catalogs, or connections. */
@@ -461,40 +479,36 @@ export async function resolveCodexSessionBinding(params: {
   binding: CodexAppServerThreadBinding | undefined;
   assertCurrent: () => void;
 }> {
-  let assertHostGeneration: (() => void) | undefined;
-  const assertCurrent = () => {
-    params.assertCurrent?.();
-    assertHostGeneration?.();
-  };
+  let assertCurrent = params.assertCurrent ?? (() => {});
   const assertAdmissionCurrent = () => {
     // Each caller retains its own cancellation error and cleanup behavior.
-    params.assertCurrent?.();
+    assertCurrent();
     params.signal?.throwIfAborted();
   };
   assertAdmissionCurrent();
-  if (params.assertBinding) {
-    params.assertBinding(readCodexSessionOwnershipBinding(params));
-  }
-  let binding = params.bindingStore.read(params.identity);
-  if (!binding && params.identity.kind === "session" && params.identity.sessionKey) {
+  params.assertBinding?.(readCodexSessionOwnershipBinding(params));
+  const identity = params.identity;
+  const authority =
+    identity.kind === "session" && identity.sessionKey?.trim()
+      ? captureCodexSessionGenerationAuthority({ ...params, identity }, assertCurrent)
+      : undefined;
+  assertCurrent = authority?.[3] ?? assertCurrent;
+  assertAdmissionCurrent();
+  let binding = params.bindingStore.read(identity);
+  if (!binding && authority && identity.kind === "session") {
     if (
-      !(await reclaimCurrentCodexSessionGeneration({
-        ...params,
-        identity: params.identity,
-        reclaimStale: params.reclaimStale === true,
-        assertCurrent: assertAdmissionCurrent,
-        onHostGenerationVerified: (assertHost) => {
-          assertHostGeneration = assertHost;
-        },
-      })) &&
+      !(await reclaimPreparedCodexSessionGeneration(
+        { ...params, identity, reclaimStale: params.reclaimStale === true },
+        authority,
+        assertAdmissionCurrent,
+      )) &&
       params.reclaimStale
     ) {
-      throw createCodexSessionGenerationSupersededError(params.identity.sessionId);
+      throw createCodexSessionGenerationSupersededError(identity.sessionId);
     }
-    binding = params.bindingStore.read(params.identity);
+    binding = params.bindingStore.read(identity);
   }
-  assertCurrent();
-  params.signal?.throwIfAborted();
+  assertAdmissionCurrent();
   params.assertBinding?.(binding);
   // Adoption can finish before a later host rollover. Carry its exact proof
   // through caller waits instead of treating the rewritten binding as authority.


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/138473

## What Problem This Solves

Fixes an issue where a queued Codex compaction admitted under one durable session generation could continue after the same session key rolled over to a successor generation. An already-readable native binding bypassed the durable-row generation fence, so stale work could acquire a client or write after ownership had moved.

## Why This Change Was Made

Codex binding resolution now captures tri-state authority from the canonical session row: a current durable row composes an exact `(sessionId, previousSessionId)` host assertion with the caller assertion, no row remains scoped ephemeral, and mismatched or unreadable authority fails closed. Reclaim and ordinary resolution share that prepared capture without persisting authority.

Compaction now resolves the binding once before client selection and narrowly converts only resolver-time cancellation into the existing compaction result. The merged pre-write rejection, ambiguous-write retirement, watcher, cleanup, and finalization paths remain unchanged.

## User Impact

Queued Codex compaction can no longer act through a stale native-thread binding after same-key session rollover. The successor generation can adopt the existing native thread without a stale client acquisition or write from its predecessor.

## Evidence

- Follow-up base: squash `c26e46b2f87ad50d2f655e44975eafc8d394527f` from #138473 is an ancestor. Its full tree differs from merged head `f4e1c96807f704cbe8de4276144b52001cbf4183` because the squash used a newer main base, while all four files changed here were byte-identical.
- Pre-fix exact-squash regression: https://crabbox.openclaw.ai/portal/runs/run_5470263bc90f — 123 passed, with the three intended failures: readable-current rollover, readable-stale admission, and queued compaction after row rotation. The no-row ephemeral case passed.
- Focused candidate proof: https://crabbox.openclaw.ai/portal/runs/run_44e231748b16 — 126/126 passed plus scoped oxlint.
- Current-base focused surface: https://crabbox.openclaw.ai/portal/runs/run_d0c3323378f8 — 716/716 passed. The registered attempt-extra project was 281/282; its sole `run-attempt.native-hook-relay.test.ts:466` failure reproduces unchanged on the untouched squash at https://crabbox.openclaw.ai/portal/runs/run_6ceeac0e7995.
- Topology and changed classifier: https://crabbox.openclaw.ai/portal/runs/run_8b2c014bd1cd — topology 24/24 and `node scripts/check-changed.mjs` passed, including extension production/test type checks, oxlint, formatting, boundary, cycle, and dead-export checks.
- Exact-head live final-effect proof: https://crabbox.openclaw.ai/portal/runs/run_84742ba57fbd — exact head `f44a3ffaa5831ccaf157f5fb9e751cab34a02298`, temporary harness SHA-256 `05332255d95da7adf8bc9b4906844a4fe36274d41ebed91446be53f6fb2d1fc6`, provider `hetzner`, and real Codex app-server `0.153.0` over stdio. The queued stale generation failed with `Codex session generation is no longer current`, zero client-factory calls, zero protocol methods, and its binding intact. The successor adopted the same native thread, acquired one client, sent `thread/resume` then `thread/compact/start`, observed matching compaction and turn completion, returned `ok=true`, `compacted=true`, `completed=true`, and became the binding owner. The live harness passed 1/1 and the task-owned lease was released.
- Direct upstream contract check: `openai/codex` commit `3921a30d6b11218883e5bb81a48082095cf79b7c`; inspected `codex-rs/app-server/src/request_processors/thread_processor.rs:762-770,2371-2383`, `codex-rs/core/src/tasks/compact.rs:19-85`, `codex-rs/core/src/compact.rs:185-245,290-320`, and `codex-rs/core/src/tasks/mod.rs:512-630,903-1005`.
- Production delta: +19 net (`session-binding.ts` +14, `compact.ts` +5), reduced from the earlier +26 shape. The remaining growth is the single canonical durable-row tri-state/exact-pair fence shared by resolution and reclaim, plus the deliberately narrow resolver-abort boundary. Further compression would duplicate authority policy, weaken the exact-pair fence or public rollback semantics, or broaden cancellation normalization.
- Test delta: +173 net across the two focused suites.
- Changelog: no edit. Repository contribution policy excludes normal PR changelog edits, and this is a correctness follow-up to the already merged compaction repair rather than a separate release surface.
- Duplicate check: no open PR covers this exact post-merge P1. The nearby older draft #138184 is a broad pre-merge lifecycle redesign, not this four-file canonical-row fence.

Local ClawSweeper completed on exact range `7b1795acc6783273c4218a511011bc1f7f13bd65..f44a3ffaa5831ccaf157f5fb9e751cab34a02298` after using an isolated authenticated reviewer home. It found no code defect, cleared security, judged the shared-owner fix correct, and requested the live final-effect proof recorded above. Hosted ClawSweeper then reviewed the same exact head with no findings and no before-merge actions: https://github.com/openclaw/openclaw/pull/138767#issuecomment-5548586736. Hosted CI is green at that SHA. Fresh generic autoreview also completed on exact commit `f44a3ffaa5831ccaf157f5fb9e751cab34a02298`: scoped clean, no P0/P1 findings, patch correct at 0.93 confidence.
<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript: fix(codex): fence current bindings against host rollover</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":5,"user":2,"assistant":2,"toolCalls":220,"toolOutputsDropped":219,"web":0,"redactions":1,"omittedUnsafe":0,"rawEntries":37}

[user]
Proceed as sole executor for a new follow-up PR from current main. Preserve both old dirty GWTs untouched. Read `CONTRIBUTING.md`, root/scoped AGENTS, relevant PR templates, `.agents/skills/test-audit/SKILL.md`, `.agents/skills/clawsweeper/SKILL.md`, and `.agents/skills/agent-transcript/SKILL.md` before contribution.

1. Fetch latest `origin/main`; verify squash `c26e46b2f87ad50d2f655e44975eafc8d394527f` is an ancestor. Compare its tree with merg
...[truncated 3150 chars]

[assistant]
hi. i’m re-anchoring on current `origin/main`, contribution policy, and the preserved patch evidence first. then i’ll build this in a fresh GWT and keep both old dirty worktrees untouched.

policy is clear: this is a new bug-fix PR, no changelog edit in a normal PR, and uncommitted autoreview is mandatory. i’m now verifying current main, squash ancestry/tree identity, the exact sibling Codex contract, and duplicate PR state before creating the fresh worktree.

current main is exactly the squash commit and contains it. its full tree is not identical to `f4e1c` because the squash was produced on a much newer main base; the four target files still need a focused comparison. GitHub GraphQL is rate-limited, so duplicate search will use REST/git-backed checks before any PR mutation.

the fresh GWT is clean at `c26e46b2`, with linked dependencies and the generation-finalization test already registered. the four target files are byte-identical between merged `f4e1c` and squash `c26e46b2`; i’m reading the owner and tests now to rebuild the fix with a smaller production shape.

i found the cleaner absorption point: prepare one authority capture, let the private reclaim worker consume it, and keep the host-only callback inside the verify path. that preserves the public boolean/rollback behavior while avoiding the earlier wrapper duplication; compact still needs a small resolver-abort adapter because merging it into the outer catch would broaden cancellation semantics.

the owner refactor is now **+19 production LOC** versus main, down from +26: `session-binding.ts` +14 and `compact.ts` +5. i found one more mechanical reduction in the capture return without changing the authority model; after that the remaining growth is the new durable-row fence plus the deliberately separate resolver-abort boundary.

local package links are incomplete, so i’m taking the allowed route: one fresh task-owned Hetzner lease. the first remote proof will apply only the four regression tests to exact `c26e46b2` and confirm the expected 3 failures before running the candidate.

one local tooling probe added `@pnpm/exe` metadata to the lockfile. that is outside scope and entirely task-created, so i’m removing it now; the branch remains four-file only.

fresh Hetzner lease acquired: `[LEASE_ID]` (`golden-crab`, `ccx33`). i’m using it for both exact-main pre-fix reproduction and candidate validation, then it will be released before handoff.

the remote checkout is still syncing/installing; no test output yet. the candidate remains four-file only at +19 production LOC, and the exact-main regression harness is staged to require precisely 3 failures and 123 passes.

exact-main pre-fix is proven on `[RUN_ID]`: **3 intended failures, 123 passes**. the failures are exactly current-binding rotation, stale readable binding admission, and queued compaction after row rotation; the no-row ephemeral case passes.

post-fix focused proof is clean: `[RUN_ID]`, **126/126**, plus scoped oxlint. next is the 716-test surface, registered attempt-extra project, its topology/config owner, both tsgo lanes, and the changed classifier on the same lease.

continuing from the active Hetzner validation. implementation is complete at four files; i’m waiting on the broad post-fix run, then i’ll handle review, signing, and the draft PR if it stays clean.

the broad surface is still green and working through the large lifecycle suite. no blocker yet; the pre-fix proof remains 3 deterministic failures, while the focused candidate proof is 126/126.

the exact reviewed 11-file surface is now confirmed at 716/716. attempt-extra is running next; after that come topology, type/lint/classifier, then the two independent reviews.

attempt-extra has one known unrelated failure at `run-attempt.native-hook-relay.test.ts:466`; the exact touched 716 surface and topology owner both pass. i’ll reproduce that assertion on untouched `c26` before classifying it, while the type/classifier lanes finish.

the remote validation is complete: 716/716, topology 24/24, both tsgo lanes, and `check:changed` all pass. attempt-extra is 281/282 with the same native-hook assertion outside this patch; i’m now proving that exact failure on untouched `c26` before treating it as baseline.

the attempt-extra miss is confirmed unchanged on untouched `c26`, so it is baseline, not branch-owned. i’m freezing edits now and running the required independent autoreview against the exact four-file diff.

autoreview itself failed before producing a verdict, not on a code finding. i’m checking the engine error and will rerun with an independent local reviewer rather than treating infrastructure failure as review evidence.

the first reviewer process failed, and Claude’s local auth is expired. i’m making one bounded retry with the configured Codex access fallback model; if that infrastructure also fails, i’ll record autoreview as unavailable rather than laundering it into a clean verdict.

autoreview is unavailable because both local reviewer credentials are expired/unauthorized; no verdict was produced. i’m recording that as a remaining draft gate, doing the final hands-on diff audit, and rechecking `origin/main` before I create the signed candidate for ClawSweeper.

`origin/main` advanced from `c26e46b2` to `7b1795acc6` during validation. i’m checking whether those commits touch the invariant; if they do not conflict, i’ll rebase the fresh dirty GWT onto the new main and rerun the affected proof before committing.

the main advance is non-conflicting: none of the four target files changed, though adjacent Codex app-server files did. i’m rebasing the fresh worktree onto `7b1795acc6`, then I’ll rerun the focused surface against that actual base.

the new-main rerun hit only a stale remote dependency tree after the package update (`tsx/esm` missing). this is the task-owned Hetzner box, so I’m reconciling dependencies there, then rerunning the same proof unchanged.

the rebased candidate is now on `7b1795acc6`; dependency refresh completed on the owned box. the duplicate scan found only unrelated Codex runtime and reply-execution PRs, so there is no exact open duplicate so far.

new-main validation remains green through the 716-test surface; attempt-extra is progressing normally. the production delta is still +19, down from +26: +14 centralizes one canonical durable-row fence shared by resolution/reclaim, and +5 isolates resolver-time abort normalization without widening the existing operation catch.

the rebased 716 surface still passes. two remaining failures are environmental/baseline: the same native-hook assertion, plus the fresh remote checkout lacks generated `ui/config/*.ts` files needed by topology and extension-test typecheck. i’m locating the repo-native generator and will rerun only those failed lanes.

the topology/type failure is a sparse-checkout omission, not generated code: `ui/config/*.ts` is tracked on main but excluded by this GWT’s sparse patterns. i’m adding that tracked directory to the fresh worktree’s sparse set, then rerunning only topology and the failed classifier lane.

[user]
The task-owned remote process has exited. Please report the exact validation statuses now, then finish the reviewed scope: reduce/justify production +19, run local ClawSweeper/autoreview as required, signed semantic commit, push, open draft PR with scrubbed temp-file body + ghx no-cache readback, release only your lease, and return exact head/signature/PR URL. Do not chase unrelated main movement or broaden scope.

[assistant]
status now: 716/716 passed on `7b1795acc6`; attempt-extra is 281/282 with the exact same base failure at `run-attempt.native-hook-relay.test.ts:466`; topology is 24/24 after restoring tracked sparse files. `check:changed` is in its final lanes now; no branch-owned failure or blocker.

validation is closed: `check:changed` passed after sparse restoration, including both tsgo lanes and oxlint. the +19 production lines are the compressed owner-level fix; further reduction would either duplicate authority policy, weaken the exact pair fence, or broaden abort handling, so I’m keeping it and creating the single signed candidate now.

the signed candidate is `f44a3ffaa5831ccaf157f5fb9e751cab34a02298` with a verified good SSH signature. local ClawSweeper completed; i’m reading its report now and will only amend if it found an actionable issue in this invariant.

both local review tools reached the exact committed range but failed before verdict on the same expired/unauthorized reviewer credentials; neither produced a finding. i’m keeping that explicit in the draft as a remaining gate, then pushing the signed commit and opening the draft with the completed runtime evidence.

status: pre-fix regression was 123/126 with the three intended failures; candidate is 716/716, topology 24/24, `check:changed` green, and attempt-extra is 281/282 with the same proven base failure. Production is +19 after reduction; I’m finishing transcript scrub, live-state checks, push, draft PR, then releasing only `[LEASE_ID]`.

the transcript helper picked an unrelated older session, so I’m discarding that artifact. `origin/main` moved after the commit; per your instruction I’m only checking whether the four owned files changed, not rebasing or chasing unrelated movement.

[tool summary]
46 read, 4 write, 170 execute; raw tool outputs dropped: 219
````

</details>
<!-- agent-transcript:end -->
