### PR TITLE
refactor(plugins): centralize admission preparation

### DIFF
--- a/src/channels/plugins/read-only.test.ts
+++ b/src/channels/plugins/read-only.test.ts
@@ -1311,41 +1311,47 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
     expect(fs.existsSync(fullMarker)).toBe(false);
   });
 
-  it("discovers trusted external channel plugins from the default agent workspace", () => {
-    const workspaceDir = makePluginLoaderTempDir();
-    const pluginDir = path.join(workspaceDir, ".openclaw", "extensions", "external-chat-plugin");
-    fs.mkdirSync(pluginDir, { recursive: true });
-    const { fullMarker, setupMarker } = writeExternalSetupChannelPlugin({
-      pluginDir,
-      pluginId: "external-chat-plugin",
-      channelId: "external-chat",
-    });
-    const plugins = listReadOnlyChannelPluginsForConfig(
-      {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
+  it.each(["trusted", "untrusted", "denied", "unconfigured"] as const)(
+    "scopes external workspace setup imports by current policy (%s)",
+    (policy) => {
+      vi.stubEnv("EXTERNAL_CHAT_TOKEN", undefined);
+      const workspaceDir = makePluginLoaderTempDir();
+      const pluginDir = path.join(workspaceDir, ".openclaw", "extensions", "external-chat-plugin");
+      fs.mkdirSync(pluginDir, { recursive: true });
+      const { fullMarker, setupMarker } = writeExternalSetupChannelPlugin({
+        pluginDir,
+        pluginId: "external-chat-plugin",
+        channelId: "external-chat",
+      });
+      const plugins = listReadOnlyChannelPluginsForConfig(
+        {
+          agents: {
+            defaults: {
+              workspace: workspaceDir,
+            },
           },
+          ...(policy === "unconfigured"
+            ? {}
+            : { channels: { "external-chat": { token: "configured" } } }),
+          plugins: {
+            allow: policy === "untrusted" ? [] : ["external-chat-plugin"],
+            deny: policy === "denied" ? ["external-chat-plugin"] : [],
+          },
+        } as never,
+        {
+          env: { ...process.env },
+          includePersistedAuthState: false,
+          includeSetupFallbackPlugins: true,
         },
-        channels: {
-          "external-chat": { token: "configured" },
-        },
-        plugins: {
-          allow: ["external-chat-plugin"],
-        },
-      } as never,
-      {
-        env: { ...process.env },
-        includePersistedAuthState: false,
-        includeSetupFallbackPlugins: true,
-      },
-    );
+      );
 
-    const plugin = plugins.find((entry) => entry.id === "external-chat");
-    expect(plugin?.meta.blurb).toBe("setup entry");
-    expect(fs.existsSync(setupMarker)).toBe(true);
-    expect(fs.existsSync(fullMarker)).toBe(false);
-  });
+      const plugin = plugins.find((entry) => entry.id === "external-chat");
+      const accepted = policy === "trusted";
+      expect(plugin?.meta.blurb).toBe(accepted ? "setup entry" : undefined);
+      expect(fs.existsSync(setupMarker)).toBe(accepted);
+      expect(fs.existsSync(fullMarker)).toBe(false);
+    },
+  );
 
   it("ignores external setup plugins that export an unrequested channel id", () => {
     const { pluginDir, fullMarker, setupMarker } = writeExternalSetupChannelPlugin({

--- a/src/plugins/loader-cli-registry.ts
+++ b/src/plugins/loader-cli-registry.ts
@@ -4,12 +4,7 @@ import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { describeRootFileOpenFailure, openRootFileSync } from "../infra/boundary-file-read.js";
 import { resolveUserPath } from "../utils.js";
 import { buildPluginApi, createUnavailableRuntime } from "./api-builder.js";
-import {
-  resolveEffectiveEnableState,
-  resolveEffectivePluginActivationState,
-  resolveMemorySlotDecision,
-} from "./config-state.js";
-import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
+import { resolveMemorySlotDecision } from "./config-state.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import { isPluginRegistryCacheEnabled } from "./loader-cache.js";
 import { resolvePluginLoadDiscovery } from "./loader-discovery.js";
@@ -21,17 +16,13 @@ import {
   runPluginRegisterSyncInRegistry,
 } from "./loader-module-runtime.js";
 import {
-  formatAutoEnabledActivationReason,
   formatMissingPluginRegisterError,
   markPluginActivationDisabled,
   recordPluginError,
 } from "./loader-records.js";
 import {
-  applyPluginManifestRecordDetails,
-  createManifestPluginRecord,
   createPluginLoaderLogger,
-  isAuthorizedDreamingSidecarPlugin,
-  matchesScopedPluginOrDreamingSidecar,
+  preparePluginLoadRecord,
   resolveAuthorizedDreamingSidecar,
   safeRealpathOrResolve,
   validatePluginConfig,
@@ -39,7 +30,6 @@ import {
 import type { PluginLoadOptions } from "./loader-types.js";
 import { resolveExternalPluginRuntimeDependencyRepairHint } from "./official-external-plugin-repair-hints.js";
 import { withProfile } from "./plugin-load-profile.js";
-import { normalizePluginPolicyId } from "./plugin-policy-id.js";
 import { createPluginIdScopeSet } from "./plugin-scope.js";
 import { pluginLoaderCacheState } from "./registry-lifecycle.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
@@ -103,74 +93,19 @@ export async function loadOpenClawPluginCliRegistry(
     if (!manifestRecord) {
       continue;
     }
-    const pluginId = manifestRecord.id;
-    const policyId = normalizePluginPolicyId(pluginId);
-    if (
-      !matchesScopedPluginOrDreamingSidecar({
-        onlyPluginIdSet,
-        pluginId,
-        sidecar: dreamingSidecar,
-      })
-    ) {
-      continue;
-    }
-    const isDreamingSidecar = isAuthorizedDreamingSidecarPlugin({
-      sidecar: dreamingSidecar,
-      pluginId,
-    });
-    const activationState = isDreamingSidecar
-      ? {
-          enabled: true,
-          activated: true,
-          explicitlyEnabled: false,
-          source: "auto" as const,
-          reason: `dreaming sidecar for selected memory slot "${dreamingSidecar?.selectedMemoryPluginId ?? ""}"`,
-        }
-      : resolveEffectivePluginActivationState({
-          id: pluginId,
-          origin: candidate.origin,
-          config: context.normalized,
-          rootConfig: context.cfg,
-          enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
-          channelIds: manifestRecord.channels,
-          activationSource: context.activationSource,
-          autoEnabledReason: formatAutoEnabledActivationReason(
-            context.autoEnabledReasons[pluginId],
-          ),
-        });
-    const existingOrigin = seenIds.get(pluginId);
-    if (existingOrigin) {
-      const duplicate = createManifestPluginRecord({
-        candidate,
-        manifestRecord,
-        enabled: false,
-        activationState,
-      });
-      duplicate.status = "disabled";
-      duplicate.error = `overridden by ${existingOrigin} plugin`;
-      markPluginActivationDisabled(duplicate, duplicate.error);
-      registry.plugins.push(duplicate);
-      continue;
-    }
-    const enableState = isDreamingSidecar
-      ? { enabled: true }
-      : resolveEffectiveEnableState({
-          id: pluginId,
-          origin: candidate.origin,
-          config: context.normalized,
-          rootConfig: context.cfg,
-          enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
-          channelIds: manifestRecord.channels,
-          activationSource: context.activationSource,
-        });
-    const entry = context.normalized.entries[policyId];
-    const record = createManifestPluginRecord({
+    const prepared = preparePluginLoadRecord({
       candidate,
       manifestRecord,
-      enabled: enableState.enabled,
-      activationState,
+      context,
+      onlyPluginIdSet,
+      dreamingSidecar,
+      registry,
+      seenIds,
     });
-    applyPluginManifestRecordDetails(record, manifestRecord);
+    if (!prepared) {
+      continue;
+    }
+    const { pluginId, policyId, isDreamingSidecar, enableState, entry, record } = prepared;
     const pushPluginLoadError = (message: string) =>
       recordPluginError({
         registry,

--- a/src/plugins/loader-load-context.ts
+++ b/src/plugins/loader-load-context.ts
@@ -181,7 +181,6 @@ function buildCacheKey(params: {
   onlyPluginIds?: string[];
   includeSetupOnlyChannelPlugins?: boolean;
   forceSetupOnlyChannelPlugins?: boolean;
-  requireSetupEntryForSetupOnlyChannelPlugins?: boolean;
   channelPluginLoadIntent: ChannelPluginLoadIntent;
   artifactPreference: PluginRuntimeArtifactPreference;
   resolveRawConfigEnvVars?: boolean;
@@ -221,10 +220,6 @@ function buildCacheKey(params: {
   const setupOnlyKey = params.includeSetupOnlyChannelPlugins === true ? "setup-only" : "runtime";
   const setupOnlyModeKey =
     params.forceSetupOnlyChannelPlugins === true ? "force-setup" : "normal-setup";
-  const setupOnlyRequirementKey =
-    params.requireSetupEntryForSetupOnlyChannelPlugins === true
-      ? "require-setup-entry"
-      : "allow-full-fallback";
   const rawConfigEnvMode =
     params.resolveRawConfigEnvVars === true ? "resolve-raw-env" : "runtime-config";
   const moduleLoadMode = params.loadModules === false ? "manifest-only" : "load-modules";
@@ -242,7 +237,7 @@ function buildCacheKey(params: {
       capabilityCatalogIdentity: params.capabilityCatalogIdentity,
       allowProcessHomeSessionCatalogs: params.allowProcessHomeSessionCatalogs !== false,
     },
-  )}::${serializePluginIdScope(params.onlyPluginIds)}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${params.channelPluginLoadIntent}::${params.artifactPreference}::${rawConfigEnvMode}::${moduleLoadMode}::${discoveryMode}::${params.runtimeSubagentMode ?? "default"}::${params.runtimeBindingIdentity ?? "{}"}::${params.pluginSdkResolution ?? "auto"}::${JSON.stringify(params.coreGatewayMethodNames ?? [])}::${activationMode}`;
+  )}::${serializePluginIdScope(params.onlyPluginIds)}::${setupOnlyKey}::${setupOnlyModeKey}::${params.channelPluginLoadIntent}::${params.artifactPreference}::${rawConfigEnvMode}::${moduleLoadMode}::${discoveryMode}::${params.runtimeSubagentMode ?? "default"}::${params.runtimeBindingIdentity ?? "{}"}::${params.pluginSdkResolution ?? "auto"}::${JSON.stringify(params.coreGatewayMethodNames ?? [])}::${activationMode}`;
   return createHash("sha256").update(cacheIdentity).digest("hex");
 }
 
@@ -332,8 +327,6 @@ export function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const onlyPluginIds = normalizePluginIdScope(options.onlyPluginIds);
   const includeSetupOnlyChannelPlugins = options.includeSetupOnlyChannelPlugins === true;
   const forceSetupOnlyChannelPlugins = options.forceSetupOnlyChannelPlugins === true;
-  const requireSetupEntryForSetupOnlyChannelPlugins =
-    options.requireSetupEntryForSetupOnlyChannelPlugins === true;
   const channelPluginLoadIntent = options.channelPluginLoadIntent ?? "full";
   const artifactPreference = resolvePluginRuntimeArtifactPreference(
     options.preferBuiltPluginArtifacts,
@@ -388,7 +381,6 @@ export function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     onlyPluginIds,
     includeSetupOnlyChannelPlugins,
     forceSetupOnlyChannelPlugins,
-    requireSetupEntryForSetupOnlyChannelPlugins,
     channelPluginLoadIntent,
     artifactPreference,
     resolveRawConfigEnvVars: options.resolveRawConfigEnvVars,
@@ -420,7 +412,6 @@ export function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     onlyPluginIds,
     includeSetupOnlyChannelPlugins,
     forceSetupOnlyChannelPlugins,
-    requireSetupEntryForSetupOnlyChannelPlugins,
     channelPluginLoadIntent,
     artifactPreference,
     shouldActivate: options.activate !== false,

--- a/src/plugins/loader-registration-plan.ts
+++ b/src/plugins/loader-registration-plan.ts
@@ -20,8 +20,6 @@ export type PluginRegistrationPlan = {
 /** Converts loader intent into explicit entrypoint and activation behavior. */
 export function resolvePluginRegistrationPlan(params: {
   canLoadScopedSetupOnlyChannelPlugin: boolean;
-  scopedSetupOnlyChannelPluginRequested: boolean;
-  requireSetupEntryForSetupOnlyChannelPlugins: boolean;
   enableStateEnabled: boolean;
   shouldLoadModules: boolean;
   validateOnly: boolean;
@@ -40,12 +38,6 @@ export function resolvePluginRegistrationPlan(params: {
       runRuntimeCapabilityPolicy: false,
       runFullActivationOnlyRegistrations: false,
     };
-  }
-  if (
-    params.scopedSetupOnlyChannelPluginRequested &&
-    params.requireSetupEntryForSetupOnlyChannelPlugins
-  ) {
-    return null;
   }
   if (!params.enableStateEnabled) {
     return null;

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -3,16 +3,11 @@ import { describeRootFileOpenFailure, openRootFileSync } from "../infra/boundary
 import { isBundleCapabilitySupported } from "./bundle-capability-support.js";
 import { inspectBundleMcpRuntimeSupport } from "./bundle-mcp.js";
 import { capabilityCatalogFamilies, resolvePluginCapabilityCatalog } from "./capability-catalog.js";
-import {
-  resolveEffectiveEnableState,
-  resolveEffectivePluginActivationState,
-  resolveMemorySlotDecision,
-} from "./config-state.js";
+import { resolveMemorySlotDecision } from "./config-state.js";
 import {
   PluginDashboardDeclarationError,
   registerPluginDashboardCapabilities,
 } from "./dashboard-capabilities.js";
-import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import type { PluginCandidate } from "./discovery.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import { loadSetupRuntimeChannelCandidate } from "./loader-channel-runtime.js";
@@ -24,7 +19,6 @@ import {
   runPluginRegisterSyncInRegistry,
 } from "./loader-module-runtime.js";
 import {
-  formatAutoEnabledActivationReason,
   formatMissingPluginRegisterError,
   markPluginActivationDisabled,
   recordPluginConfiguredUnavailable,
@@ -33,12 +27,9 @@ import {
 import { resolvePluginRegistrationPlan } from "./loader-registration-plan.js";
 import {
   applyManifestSnapshotMetadata,
-  applyPluginManifestRecordDetails,
   type AuthorizedDreamingSidecar,
-  createManifestPluginRecord,
   detailPluginStartupTrace,
-  isAuthorizedDreamingSidecarPlugin,
-  matchesScopedPluginOrDreamingSidecar,
+  preparePluginLoadRecord,
   safeRealpathOrResolve,
   validatePluginConfig,
 } from "./loader-shared.js";
@@ -51,7 +42,6 @@ import type { PluginManifestRecord } from "./manifest-registry.js";
 import { resolveExternalPluginRuntimeDependencyRepairHint } from "./official-external-plugin-repair-hints.js";
 import { withProfile } from "./plugin-load-profile.js";
 import { preparePluginModule } from "./plugin-module-loader-cache.js";
-import { normalizePluginPolicyId } from "./plugin-policy-id.js";
 import {
   resolveCanonicalDistRuntimeSource,
   resolvePluginRuntimeArtifact,
@@ -91,75 +81,20 @@ export function loadRuntimePluginCandidate(params: {
 }): void {
   const { candidate, manifestRecord, context, state } = params;
   const { registry } = params.registryBuilder;
-  const pluginId = manifestRecord.id;
-  const policyId = normalizePluginPolicyId(pluginId);
-  // Manifest filtering scopes diagnostics; this final guard also blocks imports
-  // and registration outside the requested snapshot.
-  if (
-    !matchesScopedPluginOrDreamingSidecar({
-      onlyPluginIdSet: params.onlyPluginIdSet,
-      pluginId,
-      sidecar: params.dreamingSidecar,
-    })
-  ) {
-    return;
-  }
-  const isDreamingSidecar = isAuthorizedDreamingSidecarPlugin({
-    sidecar: params.dreamingSidecar,
-    pluginId,
-  });
-  const activationState = isDreamingSidecar
-    ? {
-        enabled: true,
-        activated: true,
-        explicitlyEnabled: false,
-        source: "auto" as const,
-        reason: `dreaming sidecar for selected memory slot "${params.dreamingSidecar?.selectedMemoryPluginId ?? ""}"`,
-      }
-    : resolveEffectivePluginActivationState({
-        id: pluginId,
-        origin: candidate.origin,
-        config: context.normalized,
-        rootConfig: context.cfg,
-        enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
-        channelIds: manifestRecord.channels,
-        activationSource: context.activationSource,
-        autoEnabledReason: formatAutoEnabledActivationReason(context.autoEnabledReasons[pluginId]),
-      });
-  const existingOrigin = state.seenIds.get(pluginId);
-  if (existingOrigin) {
-    const duplicate = createManifestPluginRecord({
-      candidate,
-      manifestRecord,
-      enabled: false,
-      activationState,
-    });
-    duplicate.status = "disabled";
-    duplicate.error = `overridden by ${existingOrigin} plugin`;
-    markPluginActivationDisabled(duplicate, duplicate.error);
-    registry.plugins.push(duplicate);
-    return;
-  }
-
-  const enableState = isDreamingSidecar
-    ? { enabled: true }
-    : resolveEffectiveEnableState({
-        id: pluginId,
-        origin: candidate.origin,
-        config: context.normalized,
-        rootConfig: context.cfg,
-        enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
-        channelIds: manifestRecord.channels,
-        activationSource: context.activationSource,
-      });
-  const entry = context.normalized.entries[policyId];
-  const record = createManifestPluginRecord({
+  const prepared = preparePluginLoadRecord({
     candidate,
     manifestRecord,
-    enabled: enableState.enabled,
-    activationState,
+    context,
+    onlyPluginIdSet: params.onlyPluginIdSet,
+    dreamingSidecar: params.dreamingSidecar,
+    registry,
+    seenIds: state.seenIds,
   });
-  applyPluginManifestRecordDetails(record, manifestRecord);
+  if (!prepared) {
+    return;
+  }
+  const { pluginId, policyId, isDreamingSidecar, activationState, enableState, entry, record } =
+    prepared;
   const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
   const degradedPluginForId = findActiveDegradedPlugin(pluginId);
   const degradedPlugin =
@@ -260,13 +195,9 @@ export function loadRuntimePluginCandidate(params: {
     (!enableState.enabled || context.forceSetupOnlyChannelPlugins);
   const canLoadScopedSetupOnlyChannelPlugin =
     scopedSetupOnlyChannelPluginRequested &&
-    (candidate.origin !== "workspace" || enableState.enabled) &&
-    (!context.requireSetupEntryForSetupOnlyChannelPlugins || Boolean(manifestRecord.setupSource));
+    (candidate.origin !== "workspace" || enableState.enabled);
   const registrationPlan = resolvePluginRegistrationPlan({
     canLoadScopedSetupOnlyChannelPlugin,
-    scopedSetupOnlyChannelPluginRequested,
-    requireSetupEntryForSetupOnlyChannelPlugins:
-      context.requireSetupEntryForSetupOnlyChannelPlugins,
     enableStateEnabled: enableState.enabled,
     shouldLoadModules: context.shouldLoadModules,
     validateOnly: params.validateOnly,

--- a/src/plugins/loader-shared.test.ts
+++ b/src/plugins/loader-shared.test.ts
@@ -5,10 +5,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { resolvePluginCandidateInstallOwner } from "./candidate-install-owner.js";
 import { getPluginCliCommandDescriptors } from "./cli-root-descriptors.js";
+import { createPluginActivationSource } from "./config-state.js";
 import type { PluginCandidate } from "./discovery.js";
 import {
-  createManifestPluginRecord,
   createPluginCandidatesFromManifestRegistry,
+  preparePluginLoadRecord,
   validatePluginConfig as validatePluginConfigByOrigin,
 } from "./loader-shared.js";
 import { loadOpenClawPluginCliRegistry, loadOpenClawPlugins } from "./loader.js";
@@ -59,23 +60,31 @@ function createRecordWithBuildVersion(openclawVersion: unknown) {
     } as unknown as NonNullable<PluginCandidate["packageManifest"]>,
   } satisfies PluginCandidate;
 
-  return createManifestPluginRecord({
+  const cfg = { plugins: { entries: { example: { enabled: true } } } };
+  const activationSource = createPluginActivationSource({ config: cfg });
+  return preparePluginLoadRecord({
     candidate,
     manifestRecord,
-    enabled: true,
-    activationState: {
-      enabled: true,
-      activated: true,
-      explicitlyEnabled: true,
-      source: "explicit",
+    context: {
+      cfg,
+      normalized: activationSource.plugins,
+      activationSource,
+      autoEnabledReasons: {},
     },
-  });
+    onlyPluginIdSet: null,
+    dreamingSidecar: null,
+    registry: { plugins: [] },
+    seenIds: new Map(),
+  })?.record;
 }
 
-describe("createManifestPluginRecord", () => {
+describe("preparePluginLoadRecord", () => {
   it("ignores malformed package build version metadata", () => {
-    expect(createRecordWithBuildVersion(" 2026.7.2 ").builtWithOpenClawVersion).toBe("2026.7.2");
-    expect(createRecordWithBuildVersion(42).builtWithOpenClawVersion).toBeUndefined();
+    expect(createRecordWithBuildVersion(" 2026.7.2 ")).toHaveProperty(
+      "builtWithOpenClawVersion",
+      "2026.7.2",
+    );
+    expect(createRecordWithBuildVersion(42)).toHaveProperty("builtWithOpenClawVersion", undefined);
   });
 });
 

--- a/src/plugins/loader-shared.ts
+++ b/src/plugins/loader-shared.ts
@@ -15,6 +15,7 @@ import {
 import { recordPluginCandidateInstallOwner } from "./candidate-install-owner.js";
 import {
   resolveEffectiveEnableState,
+  resolveEffectivePluginActivationState,
   type NormalizedPluginsConfig,
   type PluginActivationConfigSource,
   type PluginActivationState,
@@ -27,7 +28,12 @@ import {
   resetGlobalHookRunner,
 } from "./hook-runner-global.js";
 import { collectPluginManifestCompatCodes } from "./installed-plugin-index-record-builder.js";
-import { createPluginRecord } from "./loader-records.js";
+import type { PluginLoadCacheContext } from "./loader-load-context.js";
+import {
+  createPluginRecord,
+  formatAutoEnabledActivationReason,
+  markPluginActivationDisabled,
+} from "./loader-records.js";
 import type { PluginLoadOptions, PluginRuntimeSubagentMode } from "./loader-types.js";
 import {
   isPluginManifestInstallOwnerAmbiguous,
@@ -35,6 +41,7 @@ import {
 } from "./manifest-install-owner.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
+import { normalizePluginPolicyId } from "./plugin-policy-id.js";
 import type { PluginRecord, PluginRegistry } from "./registry.js";
 import {
   captureActivePluginRegistrySnapshot,
@@ -135,14 +142,14 @@ export function resolveAuthorizedDreamingSidecar(params: {
   return selectedEnableState.enabled ? { engineId, selectedMemoryPluginId } : null;
 }
 
-export function isAuthorizedDreamingSidecarPlugin(params: {
+function isAuthorizedDreamingSidecarPlugin(params: {
   sidecar: AuthorizedDreamingSidecar | null;
   pluginId: string;
 }): boolean {
   return params.sidecar?.engineId === params.pluginId;
 }
 
-export function matchesScopedPluginOrDreamingSidecar(params: {
+function matchesScopedPluginOrDreamingSidecar(params: {
   onlyPluginIdSet: ReadonlySet<string> | null;
   pluginId: string;
   sidecar: AuthorizedDreamingSidecar | null;
@@ -273,7 +280,7 @@ function isEmptyPluginConfigJsonSchema(schema: Record<string, unknown>): boolean
 }
 
 /** Builds the common manifest-backed record shape used by runtime and CLI loaders. */
-export function createManifestPluginRecord(params: {
+function createManifestPluginRecord(params: {
   candidate: PluginCandidate;
   manifestRecord: PluginManifestRecord;
   enabled: boolean;
@@ -313,15 +320,95 @@ export function createManifestPluginRecord(params: {
   });
 }
 
-export function applyPluginManifestRecordDetails(
-  record: PluginRecord,
-  manifestRecord: PluginManifestRecord,
-): void {
+/** Prepares one candidate; import and registration policy stays with each loader. */
+export function preparePluginLoadRecord(params: {
+  candidate: PluginCandidate;
+  manifestRecord: PluginManifestRecord;
+  context: Pick<
+    PluginLoadCacheContext,
+    "cfg" | "normalized" | "activationSource" | "autoEnabledReasons"
+  >;
+  onlyPluginIdSet: ReadonlySet<string> | null;
+  dreamingSidecar: AuthorizedDreamingSidecar | null;
+  registry: Pick<PluginRegistry, "plugins">;
+  seenIds: ReadonlyMap<string, PluginRecord["origin"]>;
+}) {
+  const { candidate, manifestRecord, context, dreamingSidecar } = params;
+  const pluginId = manifestRecord.id;
+  const policyId = normalizePluginPolicyId(pluginId);
+  // Manifest filtering scopes diagnostics; this final guard also blocks imports
+  // and registration outside the requested snapshot.
+  if (
+    !matchesScopedPluginOrDreamingSidecar({
+      onlyPluginIdSet: params.onlyPluginIdSet,
+      pluginId,
+      sidecar: dreamingSidecar,
+    })
+  ) {
+    return null;
+  }
+  const isDreamingSidecar = isAuthorizedDreamingSidecarPlugin({
+    sidecar: dreamingSidecar,
+    pluginId,
+  });
+  const activationState = isDreamingSidecar
+    ? {
+        enabled: true,
+        activated: true,
+        explicitlyEnabled: false,
+        source: "auto" as const,
+        reason: `dreaming sidecar for selected memory slot "${dreamingSidecar?.selectedMemoryPluginId ?? ""}"`,
+      }
+    : resolveEffectivePluginActivationState({
+        id: pluginId,
+        origin: candidate.origin,
+        config: context.normalized,
+        rootConfig: context.cfg,
+        enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
+        channelIds: manifestRecord.channels,
+        activationSource: context.activationSource,
+        autoEnabledReason: formatAutoEnabledActivationReason(context.autoEnabledReasons[pluginId]),
+      });
+  const existingOrigin = params.seenIds.get(pluginId);
+  if (existingOrigin) {
+    const duplicate = createManifestPluginRecord({
+      candidate,
+      manifestRecord,
+      enabled: false,
+      activationState,
+    });
+    duplicate.status = "disabled";
+    duplicate.error = `overridden by ${existingOrigin} plugin`;
+    markPluginActivationDisabled(duplicate, duplicate.error);
+    params.registry.plugins.push(duplicate);
+    return null;
+  }
+  // Activation carries auto-enable provenance; enablement independently controls loading.
+  // An auto-enabled reason can activate a record without enabling its module load.
+  const enableState = isDreamingSidecar
+    ? { enabled: true }
+    : resolveEffectiveEnableState({
+        id: pluginId,
+        origin: candidate.origin,
+        config: context.normalized,
+        rootConfig: context.cfg,
+        enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
+        channelIds: manifestRecord.channels,
+        activationSource: context.activationSource,
+      });
+  const entry = context.normalized.entries[policyId];
+  const record = createManifestPluginRecord({
+    candidate,
+    manifestRecord,
+    enabled: enableState.enabled,
+    activationState,
+  });
   record.kind = manifestRecord.kind;
   record.configUiHints = manifestRecord.configUiHints;
   record.configJsonSchema = manifestRecord.configSchema;
   // Manifest ownership survives rollback of executable registrations.
   record.commandAliases = manifestRecord.commandAliases;
+  return { pluginId, policyId, isDreamingSidecar, activationState, enableState, entry, record };
 }
 
 export function applyManifestSnapshotMetadata(

--- a/src/plugins/loader-types.ts
+++ b/src/plugins/loader-types.ts
@@ -40,7 +40,6 @@ export type PluginLoadOptions = {
   onlyPluginIds?: string[];
   includeSetupOnlyChannelPlugins?: boolean;
   forceSetupOnlyChannelPlugins?: boolean;
-  requireSetupEntryForSetupOnlyChannelPlugins?: boolean;
   /** Select full runtime registration or the lightweight unconfigured-channel setup path. */
   channelPluginLoadIntent?: ChannelPluginLoadIntent;
   /** Built hosts prefer canonical checkout artifacts by default; false retains source execution. */

--- a/src/plugins/loader.admission-contracts.test.ts
+++ b/src/plugins/loader.admission-contracts.test.ts
@@ -1,0 +1,135 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadOpenClawPluginCliRegistry, loadOpenClawPlugins } from "./loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  EMPTY_PLUGIN_SCHEMA,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+  writePluginMetadata,
+} from "./loader.test-fixtures.js";
+
+afterEach(resetPluginLoaderTestStateForTest);
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+it.each(["runtime", "cli"] as const)(
+  "keeps effective enablement separate from reason-only activation (%s)",
+  async (surface) => {
+    const imported = path.join(makePluginLoaderTempDir(), "imported");
+    const plugin = writePlugin({
+      id: "admission-contract",
+      filename: "index.cjs",
+      body: `require("node:fs").writeFileSync(${JSON.stringify(imported)}, "imported");
+module.exports = { id: "admission-contract", register() {} };`,
+    });
+    const config: OpenClawConfig = {
+      plugins: { enabled: true, slots: { memory: "none" } },
+    };
+    const options = {
+      config,
+      manifestRegistry: {
+        plugins: [
+          {
+            id: plugin.id,
+            origin: "bundled" as const,
+            rootDir: plugin.dir,
+            source: plugin.file,
+            manifestPath: path.join(plugin.dir, "openclaw.plugin.json"),
+            channels: [],
+            providers: [],
+            cliBackends: [],
+            skills: [],
+            hooks: [],
+            configSchema: EMPTY_PLUGIN_SCHEMA,
+          },
+        ],
+        diagnostics: [],
+      },
+      installRecords: {},
+      onlyPluginIds: [plugin.id],
+      activate: false,
+      cache: false,
+      autoEnabledReasons: { [plugin.id]: ["reason without effective enablement"] },
+    };
+    const registry =
+      surface === "runtime"
+        ? loadOpenClawPlugins(options)
+        : await loadOpenClawPluginCliRegistry(options);
+    expect(registry.plugins).toHaveLength(1);
+    expect(registry.plugins[0]).toMatchObject({
+      id: plugin.id,
+      enabled: false,
+      activated: false,
+      status: "disabled",
+      activationSource: "disabled",
+      activationReason: "bundled (disabled by default)",
+      error: "bundled (disabled by default)",
+    });
+    expect(registry.cliRegistrars).toHaveLength(0);
+    expect(fs.existsSync(imported)).toBe(false);
+  },
+);
+
+it.each([false, true])("keeps scoped forced setup selection with setupEntry=%s", (setupEntry) => {
+  useNoBundledPlugins();
+  const markers = makePluginLoaderTempDir();
+  const fullMarker = path.join(markers, "full-imported");
+  const setupMarker = path.join(markers, "setup-imported");
+  const channelSource = `const channel = {
+  id: "admission-channel",
+  meta: { id: "admission-channel", label: "Admission Channel" },
+  capabilities: { chatTypes: ["direct"] },
+  config: { listAccountIds: () => ["default"], resolveAccount: () => ({}) },
+};`;
+  const plugin = writePlugin({
+    id: "admission-setup",
+    filename: "index.cjs",
+    body: `require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "imported");
+${channelSource}
+module.exports = { id: "admission-setup", register(api) { api.registerChannel({ plugin: channel }); } };`,
+  });
+  if (setupEntry) {
+    writePlugin({
+      id: plugin.id,
+      dir: plugin.dir,
+      filename: "setup.cjs",
+      body: `require("node:fs").writeFileSync(${JSON.stringify(setupMarker)}, "imported");
+${channelSource}
+module.exports = { plugin: channel };`,
+    });
+  }
+  writePluginMetadata({
+    dir: plugin.dir,
+    id: plugin.id,
+    channels: ["admission-channel"],
+    packageJson: {
+      name: "@example/admission-setup",
+      version: "1.0.0",
+      openclaw: {
+        extensions: ["./index.cjs"],
+        ...(setupEntry ? { setupEntry: "./setup.cjs" } : {}),
+      },
+    },
+  });
+  const registry = loadOpenClawPlugins({
+    config: { plugins: { allow: [plugin.id], load: { paths: [plugin.dir] } } },
+    onlyPluginIds: [plugin.id],
+    includeSetupOnlyChannelPlugins: true,
+    forceSetupOnlyChannelPlugins: true,
+    activate: false,
+    cache: false,
+  });
+  expect(registry.plugins.map(({ id, status }) => ({ id, status }))).toEqual([
+    { id: plugin.id, status: "loaded" },
+  ]);
+  expect(registry.channelSetups.map(({ plugin: channel }) => channel.id)).toEqual([
+    "admission-channel",
+  ]);
+  expect(registry.channels).toHaveLength(0);
+  expect(fs.existsSync(setupMarker)).toBe(setupEntry);
+  expect(fs.existsSync(fullMarker)).toBe(!setupEntry);
+});

--- a/src/plugins/loader.cli-metadata.test.ts
+++ b/src/plugins/loader.cli-metadata.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { Command } from "commander";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
 import {
   defineBundledChannelEntry,
@@ -28,6 +29,104 @@ afterAll(() => {
 });
 
 describe("plugin loader CLI metadata", () => {
+  it.each(
+    (["runtime", "cli"] as const).flatMap((surface) =>
+      (["explicit", "auto", "denied", "disabled"] as const).map((policy) => ({
+        surface,
+        policy,
+      })),
+    ),
+  )(
+    "preserves admission before parser registration ($surface, $policy)",
+    async ({ surface, policy }) => {
+      useNoBundledPlugins();
+      const markers = makePluginLoaderTempDir();
+      const targetId = "Admission-Fixture";
+      const command = "admission-fixture";
+      const imported = path.join(markers, "target-imported");
+      const unrelatedImported = path.join(markers, "unrelated-imported");
+      const invoked = path.join(markers, "invoked");
+      const target = writePlugin({
+        id: targetId,
+        filename: "index.cjs",
+        body: `const fs = require("node:fs");
+  fs.writeFileSync(${JSON.stringify(imported)}, "imported");
+  module.exports = { id: ${JSON.stringify(targetId)}, register(api) {
+    api.registerCli(({ program }) => program.command("${command}").action(() => {
+      fs.writeFileSync(${JSON.stringify(invoked)}, api.registrationMode);
+    }), { commands: ["${command}"] });
+  } };`,
+      });
+      const unrelated = writePlugin({
+        id: "unrelated-fixture",
+        filename: "index.cjs",
+        body: `require("node:fs").writeFileSync(${JSON.stringify(unrelatedImported)}, "imported");
+  module.exports = { id: "unrelated-fixture", register() {} };`,
+      });
+      const config = {
+        plugins: {
+          enabled: true,
+          allow: [command, unrelated.id],
+          deny: policy === "denied" ? [command] : [],
+          load: { paths: [target.file, unrelated.file] },
+          entries: { [command]: { enabled: policy !== "disabled" } },
+        },
+      };
+      const options = {
+        config,
+        activate: false,
+        cache: false,
+        onlyPluginIds: [targetId],
+        ...(policy === "auto"
+          ? {
+              activationSourceConfig: { plugins: { enabled: true } },
+              autoEnabledReasons: { [targetId]: ["configured fixture", "selected fixture"] },
+            }
+          : {}),
+      };
+      const registry =
+        surface === "runtime"
+          ? loadOpenClawPlugins(options)
+          : await loadOpenClawPluginCliRegistry(options);
+      const enabled = policy === "explicit" || policy === "auto";
+      const reason =
+        policy === "auto"
+          ? "configured fixture; selected fixture"
+          : policy === "denied"
+            ? "blocked by denylist"
+            : policy === "disabled"
+              ? "disabled in config"
+              : "enabled in config";
+      expect(registry.plugins.map((entry) => entry.id)).toEqual([targetId]);
+      expect(registry.plugins[0]).toMatchObject({
+        enabled,
+        activated: enabled,
+        status: enabled ? "loaded" : "disabled",
+        activationSource: enabled ? policy : "disabled",
+        activationReason: reason,
+      });
+      expect(fs.existsSync(imported)).toBe(enabled);
+      expect(fs.existsSync(unrelatedImported)).toBe(false);
+      expect(registry.cliRegistrars).toHaveLength(enabled ? 1 : 0);
+      if (enabled) {
+        const program = new Command();
+        await registry.cliRegistrars[0]!.register({
+          program,
+          parentPath: [],
+          config,
+          workspaceDir: undefined,
+          logger: { info() {}, warn() {}, error() {} },
+        });
+        await program.parseAsync([command], { from: "user" });
+        expect(fs.readFileSync(invoked, "utf8")).toBe(
+          surface === "runtime" ? "discovery" : "cli-metadata",
+        );
+      } else {
+        expect(fs.existsSync(invoked)).toBe(false);
+      }
+    },
+  );
+
   it("keeps an explicit empty CLI metadata registry authoritative", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({


### PR DESCRIPTION
## What Problem This Solves

Runtime plugin loading and CLI metadata loading separately prepared the same admission facts, leaving two places to keep activation, enablement, duplicate diagnostics and manifest details aligned. This continues the maintainer-requested cleanup already proposed in this PR, not a newly reproduced user defect or a new feature request.

## Why This Change Was Made

Centralize scoped admission preparation in the shared loader while keeping runtime and CLI import/registration policy distinct. Remove the dormant private required-setup option now that read-only channel discovery owns direct setup loading. Preserve independent activation provenance and enablement, manifest trust and control UI metadata, capability catalog behavior, and source-root channel policy during normalized config reuse.

The refreshed candidate also preserves main's consolidated `recordPluginError` owner: validation errors retain their existing classification, while load errors can carry SDK seam/version/build diagnostics. The two actual rebase conflicts were import blocks; obsolete validation helpers were not restored.

Production code decreases by 65 lines (+122/-187); tests change by +293/-44 across four files. No configuration, dependency, persistence, public CLI or plugin SDK contract change is intended by this refactor.

## User Impact

No intentional user-visible behavior change. Plugin loading and inspection retain their policy boundaries, with one shared owner for common preparation. No upgrade or operator action is required.

## Current Candidate Evidence

Candidate `1e15198412e4cb25e473624c1a7a77e6270307ef` has raw parent `5650fe2abc1ae54143aad2e41735396ae1f55331` and tree `4bd3dd5fdd13c08879a354bb559d217a25bbc670`. The normal frozen dependency installation completed against that parent graph. One normal six-file focused run passed 123 tests, including the four changed tests and current error-recording/SDK-diagnostic sibling cases. The normal configured Linux changed-file gate passed all 30 checks with source/receiver identity and lease cleanup verified.

The normal full build on the clean signed candidate completed all 16 phases: 15 ran and CLI startup metadata was restored through its normal cache path and refreshed. Build information and both stamps identify `1e15198412e4`.

Three serial built CLI observations passed in a new isolated profile: snapshot inspection remained metadata-only, runtime inspection imported and registered memory-core without diagnostics, and memory help printed the current build and command tree. Snapshot and runtime schema, UI hints, contracts, trust and activation metadata matched. Registration is not execution: no Gateway, provider or memory operation was invoked. Real profile initialization was recorded and retained, rather than described as having no filesystem effects.

The resolved composition and the separate exact signed commit each received canonical P2 static review with no actionable findings in two partitioned passes. The exact-commit passes returned confidence 0.82 and 0.86, with aggregate scoped-clean confidence 0.82. The first pass explicitly limits its assessment to its supplied batch; this is not a claim that either pass saw the entire packet together. Reviewers treated the tests/builds as author evidence and did not independently execute project code.

## Historical Evidence and Review Context

The earlier `04ea328f900` candidate on the older base passed 200 nonoverlapping tests, a full build, three operator observations, changed checks, and precommit/exact-commit P2 reviews. Those executions remain historical; the current 123-test run is not presented as a replay of all 200. The original `b8a208ede254` candidate's comparison/replay evidence also remains historical. The original loader timeout's cause remains unknown; recovered runs used different canonical cache routes.

The earlier review's data-model compatibility item concerned the removed setup-option cache-key dimension in `loader-load-context.ts`. Its owner is the process-local `PluginLoaderCacheState` LRU and in-flight sets, not a persisted schema. The option had no remaining caller. Removing its constant default key component changes transient cache identities, not a database, stored record, migration or upgrade reader; no data migration is applicable.

ClawSweeper's September 6 review of `04ea328f900` withdrew the migration concern and reported no patch findings. Its remaining integration item is addressed by the pinned rebase composition, current validation and separate exact-commit review described above. The ready transition still requires a fresh positive GitHub mergeability check. Hosted exact-head CI and repo-native landing remain separate gates; neither is claimed complete by the local proof.
