### PR TITLE
fix(ui): align task toolbar with side-panel tabs

### DIFF
--- a/docs/web/dashboard-architecture.md
+++ b/docs/web/dashboard-architecture.md
@@ -76,6 +76,8 @@ Principles:
   Ordinary revisits restore it. Gallery links with `?dashboard=expanded` explicitly
   make Dashboard main and focus it. Placement changes reuse the mounted content
   so widget frames, browser views, terminals, and chat drafts survive a swap.
+  The task toolbar and side-panel tab header align above their respective panes
+  in left/right layouts; stacked layouts keep each header above its own pane.
 - **Drag:** user drags widgets; grid auto-compacts (widgets float up, neighbors
   reflow). Resize by handle snaps to size steps. No pixel placement — for
   anyone.

--- a/docs/web/dashboards.md
+++ b/docs/web/dashboards.md
@@ -59,8 +59,10 @@ and widget interactions. Closing the whole side panel hides its tabs and leaves
 the main view in place. Closing the Dashboard tab removes that view from the
 layout; it does not delete the board. Reopen it from the panel's **+** menu.
 An empty dashboard stays open so you can add its first widget without changing
-your chosen layout. Task controls share the existing toolbar; side-panel tabs
-appear only when there are views to switch between.
+your chosen layout. The task toolbar sits above the main pane, aligned with the
+side-panel tabs when the panes are side by side. In a stacked layout, each
+header stays above its own pane. Side-panel tabs appear only when there are
+views to switch between.
 
 ## Build a dashboard by asking
 

--- a/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
@@ -13,6 +13,7 @@ import {
   sidebarSessionOrder,
   waitForChatScrollIdle,
 } from "./chat-flow.test-support.ts";
+import { dockChatSidePanel, openChatSidePanelType } from "./chat-side-panel.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 const rosterMatch = { includeGlobal: true };
@@ -254,6 +255,13 @@ suite.define(() => {
       const splitEntry = page.getByRole("button", { name: "Open split view" });
       await expect.poll(() => splitEntry.isVisible()).toBe(true);
       await expect.poll(() => page.locator(".chat-pane__header").count()).toBe(1);
+      const taskHeader = page.locator(".chat-pane__header");
+      const regularHeaderPadding = await taskHeader.evaluate(
+        (header) => getComputedStyle(header).paddingLeft,
+      );
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill("Keep this draft while docking beside native controls");
+      const originalComposer = await composer.elementHandle();
       await page.evaluate(() => {
         document.documentElement.classList.add("openclaw-native-macos");
         document.querySelector(".shell")?.classList.add("shell--nav-collapsed");
@@ -265,6 +273,31 @@ suite.define(() => {
             .evaluate((header) => getComputedStyle(header).paddingLeft),
         )
         .toBe("90px");
+      await openChatSidePanelType(page, "Files");
+      await dockChatSidePanel(page, "left");
+      const sideHeader = page.locator('[data-region-header="side"]');
+      const filesTab = sideHeader.getByRole("tab", { name: "Files", exact: true });
+      await filesTab.waitFor();
+      await expect
+        .poll(() => taskHeader.evaluate((header) => getComputedStyle(header).paddingLeft))
+        .toBe(regularHeaderPadding);
+      await expect
+        .poll(() => filesTab.evaluate((tab) => tab.getBoundingClientRect().left))
+        .toBeGreaterThanOrEqual(90);
+      const taskHeaderBox = await taskHeader.boundingBox();
+      const sideHeaderBox = await sideHeader.boundingBox();
+      expect(taskHeaderBox?.y).toBeCloseTo(sideHeaderBox!.y, 0);
+      expect(taskHeaderBox!.x).toBeGreaterThan(sideHeaderBox!.x);
+      expect(
+        await composer.evaluate((element, original) => element === original, originalComposer),
+      ).toBe(true);
+      expect(await composer.inputValue()).toBe(
+        "Keep this draft while docking beside native controls",
+      );
+      await originalComposer?.dispose();
+      await sideHeader.getByRole("button", { name: "Close Files", exact: true }).click();
+      await filesTab.waitFor({ state: "detached" });
+      await composer.fill("");
       await page.evaluate(() => {
         document.documentElement.classList.remove("openclaw-native-macos");
         document.querySelector(".shell")?.classList.remove("shell--nav-collapsed");
@@ -369,17 +402,27 @@ suite.define(() => {
       await expect.poll(() => actionRows.first().isVisible()).toBe(false);
       await expect.poll(() => actionRows.last().isVisible()).toBe(true);
       const targetHeader = headers.first();
-      await expect
-        .poll(() =>
-          targetHeader.evaluate((header) => {
-            const owner = header.closest("openclaw-chat-pane");
-            return (
-              header.parentElement?.classList.contains("chat-pane-layout") === true &&
-              owner?.classList.contains("chat-split-view__pane") === true
-            );
-          }),
-        )
-        .toBe(true);
+      const headerGeometry = await headers.evaluateAll((nodes) =>
+        nodes.map((header) => {
+          const owner = header.closest("openclaw-chat-pane");
+          const main = owner?.querySelector('[data-region="main"]:not([hidden])');
+          if (!main) {
+            throw new Error("Each task toolbar must have visible main content");
+          }
+          const toolbar = header.getBoundingClientRect();
+          const content = main.getBoundingClientRect();
+          return {
+            height: toolbar.height,
+            left: Math.abs(toolbar.left - content.left),
+            right: Math.abs(toolbar.right - content.right),
+            gap: Math.abs(toolbar.bottom - content.top),
+          };
+        }),
+      );
+      for (const geometry of headerGeometry) {
+        expect(geometry.height).toBeGreaterThan(0);
+        expect(Math.max(geometry.left, geometry.right, geometry.gap)).toBeLessThanOrEqual(1);
+      }
 
       const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
       await dataTransfer.evaluate(

--- a/ui/src/e2e/chat-header-axis.e2e.test.ts
+++ b/ui/src/e2e/chat-header-axis.e2e.test.ts
@@ -59,6 +59,12 @@ suite.define(() => {
           await header.locator(".workspace-icon").waitFor();
 
           const geometry = await header.evaluate((root) => {
+            const main = root
+              .closest("openclaw-chat-pane")
+              ?.querySelector('[data-region="main"]:not([hidden])');
+            if (!main) {
+              throw new Error("Task header requires visible main content");
+            }
             const centerY = (selector: string) => {
               const node = root.querySelector(selector);
               if (!node) {
@@ -87,9 +93,7 @@ suite.define(() => {
                 ...root.querySelectorAll<HTMLElement>(".chat-pane__crumb-sep"),
               ].map((node) => getComputedStyle(node).display),
               headerBottom: root.getBoundingClientRect().bottom,
-              contentTop: root.parentElement
-                ?.querySelector(".sidebar-region")
-                ?.getBoundingClientRect().top,
+              contentTop: main.getBoundingClientRect().top,
             };
           });
 

--- a/ui/src/e2e/chat-rail-columns.e2e.test.ts
+++ b/ui/src/e2e/chat-rail-columns.e2e.test.ts
@@ -283,14 +283,16 @@ async function expectExpandedSidePanelFillsRegion(page: Page): Promise<void> {
       const panel = element.getBoundingClientRect();
       const shell = element.closest(".sidebar-region");
       const region = shell?.getBoundingClientRect();
-      if (!region) {
-        throw new Error("Expanded side panel has no sidebar region");
+      const header = shell?.querySelector(".chat-pane__header")?.getBoundingClientRect();
+      if (!region || !header) {
+        throw new Error("Focused panel requires its task toolbar and sidebar region");
       }
       return {
         bottom: Math.abs(panel.bottom - region.bottom),
         left: Math.abs(panel.left - region.left),
         right: Math.abs(panel.right - region.right),
-        top: Math.abs(panel.top - region.top),
+        top: Math.abs(header.top - region.top),
+        headerGap: Math.abs(panel.top - header.bottom),
       };
     });
   for (const delta of Object.values(geometry)) {

--- a/ui/src/e2e/dashboard-gallery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-gallery.e2e.test.ts
@@ -11,6 +11,12 @@ const suite = createControlUiE2eSuite({
 
 const now = Date.now();
 const selectedSessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
+const selectedSessionResolution = {
+  ok: true,
+  key: selectedSessionKey,
+  agentId: "main",
+  boardFace: "dashboard",
+};
 const dashboardRows = [
   [selectedSessionKey, "Release health", "mira", "Mira", 3_000, "running"],
   ["agent:main:dashboard:model-spend", "Model spend", "peter", "Peter", 8_000, "done"],
@@ -107,17 +113,13 @@ suite.define(() => {
             viewId: "release-tools-view",
             expiresAtMs: now + 60_000,
           },
+          "sessions.resolve": selectedSessionResolution,
           "chat.startup": {
             cases: [
               {
                 match: { shortId: "12345678", agentId: "main" },
                 response: {
-                  resolution: {
-                    ok: true,
-                    key: selectedSessionKey,
-                    agentId: "main",
-                    boardFace: "dashboard",
-                  },
+                  resolution: selectedSessionResolution,
                   messages: [],
                   sessionInfo: dashboardRows[0],
                 },

--- a/ui/src/e2e/task-panel-layout.e2e.test.ts
+++ b/ui/src/e2e/task-panel-layout.e2e.test.ts
@@ -45,7 +45,7 @@ async function expectPaneHeaderGeometry(page: Page, dock: "left" | "right" | "bo
   for (const [header, content] of [
     [boxes.toolbar, boxes.main],
     [boxes.tabs, boxes.side],
-  ]) {
+  ] as const) {
     expect(header.height).toBeGreaterThan(0);
     expect(content.height).toBeGreaterThan(80);
     expect(header.x).toBeCloseTo(content.x, 0);

--- a/ui/src/e2e/task-panel-layout.e2e.test.ts
+++ b/ui/src/e2e/task-panel-layout.e2e.test.ts
@@ -25,6 +25,42 @@ function widgetInput(page: Page): Locator {
   return page.frameLocator(".board-widget__frame").frameLocator("iframe").locator("#widget-note");
 }
 
+async function expectPaneHeaderGeometry(page: Page, dock: "left" | "right" | "bottom") {
+  const boxes = await page.evaluate(() => {
+    const bounds = (selector: string) => {
+      const element = document.querySelector(selector);
+      if (!element) {
+        throw new Error(`Missing visible pane surface: ${selector}`);
+      }
+      const { x, y, width, height, bottom, right } = element.getBoundingClientRect();
+      return { x, y, width, height, bottom, right };
+    };
+    return {
+      toolbar: bounds(".chat-pane__header"),
+      tabs: bounds('[data-region-header="side"]'),
+      main: bounds('.sidebar-region [data-region="main"]:not([hidden])'),
+      side: bounds('.sidebar-region [data-region="side"]:not([hidden])'),
+    };
+  });
+  for (const [header, content] of [
+    [boxes.toolbar, boxes.main],
+    [boxes.tabs, boxes.side],
+  ]) {
+    expect(header.height).toBeGreaterThan(0);
+    expect(content.height).toBeGreaterThan(80);
+    expect(header.x).toBeCloseTo(content.x, 0);
+    expect(header.right).toBeCloseTo(content.right, 0);
+    expect(header.bottom).toBeCloseTo(content.y, 0);
+  }
+  if (dock === "bottom") {
+    expect(boxes.tabs.y).toBeGreaterThanOrEqual(boxes.main.bottom);
+  } else {
+    expect(boxes.toolbar.y).toBeCloseTo(boxes.tabs.y, 0);
+    expect(boxes.main.y).toBeCloseTo(boxes.side.y, 0);
+    expect(boxes.side.x < boxes.main.x).toBe(dock === "left");
+  }
+}
+
 suite.define(() => {
   beforeAll(async () => {
     sandbox = createSandboxHostHttpServer();
@@ -130,11 +166,11 @@ suite.define(() => {
         };
 
         expect(await taskHeader.count()).toBe(1);
-        expect(await page.locator('[data-region-header="main"]').count()).toBe(0);
         expect(await swap.count()).toBe(1);
         expect(await layoutMenu.count()).toBe(1);
         expect(await page.getByRole("button", { name: "Layout", exact: true }).count()).toBe(1);
         await expectSwapLabel("Swap Chat and Dashboard");
+        await expectPaneHeaderGeometry(page, "right");
         await chat.evaluate((element) => {
           const initialWidth = element.getBoundingClientRect().width;
           element.parentElement!.addEventListener("openclaw-sidebar-geometry-commit", (event) => {
@@ -152,18 +188,21 @@ suite.define(() => {
         await expectSwapLabel("Swap Dashboard and Chat");
         await expect.poll(() => regionSize(chat)).toBeCloseTo(width, 0);
         expect(await chat.getAttribute("data-swap-width-invalidated")).toBe("true");
+        await expectPaneHeaderGeometry(page, "right");
         for (const dock of ["left", "bottom", "right"] as const) {
           await dockChatSidePanel(page, dock);
-          const chatBox = await chat.boundingBox();
-          const dashboardBox = await dashboard.boundingBox();
-          expect(chatBox).not.toBeNull();
-          expect(dashboardBox).not.toBeNull();
-          if (dock === "bottom") {
-            expect(chatBox!.y).toBeGreaterThan(dashboardBox!.y);
-          } else {
-            expect(chatBox!.x < dashboardBox!.x).toBe(dock === "left");
-            expect(chatBox!.width).toBeCloseTo(width, 0);
+          await expectPaneHeaderGeometry(page, dock);
+          if (dock !== "bottom") {
+            expect(await regionSize(chat)).toBeCloseTo(width, 0);
           }
+          await swap.click();
+          await expect.poll(() => chat.getAttribute("data-region")).toBe("main");
+          await expectPaneHeaderGeometry(page, dock);
+          await expectContinuity();
+          await swap.click();
+          await expect.poll(() => dashboard.getAttribute("data-region")).toBe("main");
+          await expectPaneHeaderGeometry(page, dock);
+          await expectContinuity();
           await taskHeader.getByRole("button", { name: "Focus", exact: true }).click();
           await chat.waitFor({ state: "hidden" });
           expect(await swap.isVisible()).toBe(false);
@@ -195,6 +234,7 @@ suite.define(() => {
           .waitFor();
         await expect.poll(() => regionSize(chat)).toBeCloseTo(resizedWidth, 0);
         await input.waitFor();
+        await expectPaneHeaderGeometry(page, "left");
         await sideHeader.getByRole("button", { name: "Add side panel tab", exact: true }).click();
         await sideHeader
           .locator(".side-panel-type-menu wa-dropdown-item")
@@ -223,6 +263,7 @@ suite.define(() => {
           .toBeGreaterThan(30);
         expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(400);
         expect(await layoutMenu.isVisible()).toBe(false);
+        await expectPaneHeaderGeometry(page, "bottom");
         for (const control of [
           taskHeader.getByRole("button", { name: "Focus", exact: true }),
           taskHeader.locator(".chat-side-panel-toggle"),
@@ -239,6 +280,7 @@ suite.define(() => {
         await expect
           .poll(() => swap.getAttribute("aria-label"))
           .toBe("Swap Dashboard and Terminal");
+        await expectPaneHeaderGeometry(page, "bottom");
         await taskHeader.getByRole("button", { name: "Focus", exact: true }).click();
         await taskHeader.getByRole("button", { name: "Restore split", exact: true }).click();
         await terminal.locator(".tp-host canvas").waitFor();

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -253,13 +253,14 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       panelActions,
       narrow: this.paneWidth < SIDEBAR_NARROW_BREAKPOINT_PX,
       panelTemplates,
+      header: html`${header}${recovery}`,
       primary,
       requestUpdate: state.requestUpdate!,
     });
-    return html`<div class="chat-pane-layout">${header}${recovery}${content}</div>
-      ${renderChatImageLightbox(
-        state.imageLightbox,
-        state.handleCloseImage,
-      )}${this.renderResetConfirmation()}`;
+    return html`${content}
+    ${renderChatImageLightbox(
+      state.imageLightbox,
+      state.handleCloseImage,
+    )}${this.renderResetConfirmation()}`;
   }
 }

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.ts
@@ -1,4 +1,4 @@
-import { html, type TemplateResult } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import { styleMap } from "lit/directives/style-map.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { ensureCustomElementDefined } from "../../app/lazy-custom-element.ts";
@@ -145,6 +145,7 @@ export function renderSidebarRegion(params: {
   panelDefinitions?: SidebarPanelDefinition[];
   panelActions: SidebarPanelTemplates;
   panelTemplates: SidebarPanelTemplates;
+  header?: TemplateResult | typeof nothing;
   primary: TemplateResult;
   requestUpdate: () => void;
 }): TemplateResult {
@@ -183,6 +184,7 @@ export function renderSidebarRegion(params: {
       "--side-panel-height": `${column?.height ?? 360}px`,
     })}
   >
+    <div class="sidebar-region__header">${params.header ?? nothing}</div>
     ${
       regionError !== undefined
         ? regionError === null

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1992,9 +1992,10 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         await page.setContent(`<!doctype html><html><head><style>${readUiCss()}</style></head><body style="margin:0;height:100vh;overflow:hidden">
           <div class="shell shell--chat ${label.startsWith("mobile") ? "shell--mobile-nav shell--merged-chat-chrome" : ""}">
             <main class="content content--chat" style="padding:0">
-              <div class="chat-pane-layout">
-                <header class="chat-pane__header">Session</header>
-                <div class="sidebar-region">
+              <div class="sidebar-region">
+                <div class="sidebar-region__header">
+                  <header class="chat-pane__header">Session</header>
+                </div>
                   <div class="sidebar-region__primary" data-region="main">
                     <section class="card chat">
                       <div class="chat-main">
@@ -2013,7 +2014,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
                       </div>
                     </section>
                   </div>
-                </div>
               </div>
             </main>
             <openclaw-toast-host data-toast-placement="shell">

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -5,7 +5,7 @@
     --chat-mobile-pane-header-height: 52px;
   }
 
-  .chat-pane-layout > .sidebar-region {
+  .sidebar-region [data-region] {
     --chat-mobile-pane-header-height: 0px;
   }
 
@@ -13,7 +13,7 @@
     padding-top: clamp(20px, 3vh, 28px);
   }
 
-  .chat-pane-layout > .chat-pane__header {
+  .sidebar-region__header > .chat-pane__header {
     position: relative;
     z-index: 3;
     isolation: isolate;
@@ -23,7 +23,7 @@
     overflow: visible;
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__nav-toggle {
+  .sidebar-region__header > .chat-pane__header .chat-pane__nav-toggle {
     position: relative;
     display: inline-flex;
     width: 40px;
@@ -44,18 +44,18 @@
     line-height: 1;
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__nav-toggle::after {
+  .sidebar-region__header > .chat-pane__header .chat-pane__nav-toggle::after {
     position: absolute;
     inset: -4px;
     content: "";
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__nav-toggle > svg {
+  .sidebar-region__header > .chat-pane__header .chat-pane__nav-toggle > svg {
     width: 20px;
     height: 20px;
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__crumbs {
+  .sidebar-region__header > .chat-pane__header .chat-pane__crumbs {
     flex: 1 1 auto;
     flex-direction: column;
     align-self: center;
@@ -65,62 +65,62 @@
     transform: none;
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__project-row,
-  .chat-pane-layout > .chat-pane__header .chat-pane__session-trail {
+  .sidebar-region__header > .chat-pane__header .chat-pane__project-row,
+  .sidebar-region__header > .chat-pane__header .chat-pane__session-trail {
     display: flex;
     min-width: 0;
     max-width: 100%;
     align-items: center;
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__session-trail {
+  .sidebar-region__header > .chat-pane__header .chat-pane__session-trail {
     gap: 6px;
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__workspace-chip,
-  .chat-pane-layout > .chat-pane__header .chat-pane__session-title,
-  .chat-pane-layout > .chat-pane__header .chat-pane__parent-session {
+  .sidebar-region__header > .chat-pane__header .chat-pane__workspace-chip,
+  .sidebar-region__header > .chat-pane__header .chat-pane__session-title,
+  .sidebar-region__header > .chat-pane__header .chat-pane__parent-session {
     line-height: 18px;
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__workspace-chip > svg {
+  .sidebar-region__header > .chat-pane__header .chat-pane__workspace-chip > svg {
     transform: translateY(1px);
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__workspace-chip--fallback-icon > svg,
-  .chat-pane-layout > .chat-pane__header .chat-pane__workspace-chip .workspace-icon-fallback {
+  .sidebar-region__header > .chat-pane__header .chat-pane__workspace-chip--fallback-icon > svg,
+  .sidebar-region__header > .chat-pane__header .chat-pane__workspace-chip .workspace-icon-fallback {
     display: none;
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__workspace-chip,
-  .chat-pane-layout > .chat-pane__header .chat-pane__workspace-chip:hover,
-  .chat-pane-layout > .chat-pane__header .chat-pane__workspace-chip:focus-visible {
+  .sidebar-region__header > .chat-pane__header .chat-pane__workspace-chip,
+  .sidebar-region__header > .chat-pane__header .chat-pane__workspace-chip:hover,
+  .sidebar-region__header > .chat-pane__header .chat-pane__workspace-chip:focus-visible {
     color: var(--muted);
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__session-title {
+  .sidebar-region__header > .chat-pane__header .chat-pane__session-title {
     font-size: 13px;
     font-weight: 500;
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__workspace-chip,
-  .chat-pane-layout > .chat-pane__header .chat-pane__session-title-button,
-  .chat-pane-layout > .chat-pane__header .chat-pane__parent-session {
+  .sidebar-region__header > .chat-pane__header .chat-pane__workspace-chip,
+  .sidebar-region__header > .chat-pane__header .chat-pane__session-title-button,
+  .sidebar-region__header > .chat-pane__header .chat-pane__parent-session {
     padding-block: 0;
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__crumb-sep {
+  .sidebar-region__header > .chat-pane__header .chat-pane__crumb-sep {
     display: none;
   }
 
-  .chat-pane-layout > .chat-pane__header .chat-pane__workspace-chip span {
+  .sidebar-region__header > .chat-pane__header .chat-pane__workspace-chip span {
     display: block;
   }
 }
 
 @media (display-mode: standalone) and (max-width: 768px),
   (display-mode: standalone) and (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
-  .chat-pane-layout > .chat-pane__header {
+  .sidebar-region__header > .chat-pane__header {
     padding-inline: var(--chat-mobile-edge-inset, 4px);
   }
 }

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -118,15 +118,6 @@
   }
 }
 
-.chat-pane-layout {
-  display: flex;
-  flex: 1 1 0;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  overflow: hidden;
-}
-
 openclaw-chat-sidebar-region,
 .sidebar-region__right-runtime {
   display: contents;
@@ -136,13 +127,18 @@ openclaw-chat-sidebar-region,
   position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  grid-template-rows: minmax(0, 1fr);
-  grid-template-areas: "main";
+  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-areas: "main-header" "main";
   flex: 1 1 0;
   width: 100%;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+}
+
+.sidebar-region__header {
+  grid-area: main-header;
+  min-width: 0;
 }
 
 .sidebar-region__primary {
@@ -156,26 +152,26 @@ openclaw-chat-sidebar-region,
 .sidebar-region--open:not(.sidebar-region--expanded) {
   grid-template-columns: minmax(0, 1fr) auto minmax(0, var(--side-panel-width));
   grid-template-rows: auto minmax(0, 1fr);
-  grid-template-areas: "main divider side-header" "main divider side";
+  grid-template-areas: "main-header divider side-header" "main divider side";
 }
 
 .sidebar-region--left.sidebar-region--open:not(.sidebar-region--expanded) {
   grid-template-columns: minmax(0, var(--side-panel-width)) auto minmax(0, 1fr);
-  grid-template-areas: "side-header divider main" "side divider main";
+  grid-template-areas: "side-header divider main-header" "side divider main";
 }
 
 .sidebar-region--bottom.sidebar-region--open:not(.sidebar-region--expanded),
 .sidebar-region--narrow.sidebar-region--open:not(.sidebar-region--expanded) {
   /* Fit saved heights to short task panes without consuming the main content row. */
   --side-panel-max-height: calc(
-    (100% - var(--rail-header-height) - var(--resize-handle-size, 6px)) * 0.6
+    (100% - 2 * var(--rail-header-height) - var(--resize-handle-size, 6px)) * 0.6
   );
   grid-template-columns: minmax(0, 1fr);
-  grid-template-rows: minmax(0, 1fr) auto auto minmax(
+  grid-template-rows: auto minmax(0, 1fr) auto auto minmax(
       0,
       min(var(--side-panel-height), var(--side-panel-max-height))
     );
-  grid-template-areas: "main" "divider" "side-header" "side";
+  grid-template-areas: "main-header" "main" "divider" "side-header" "side";
 }
 
 .sidebar-region [data-region="main"] {
@@ -188,6 +184,7 @@ openclaw-chat-sidebar-region,
 
 .sidebar-region [data-region-header="side"] {
   grid-area: side-header;
+  height: auto;
 }
 
 .sidebar-region__primary[hidden],
@@ -327,7 +324,7 @@ openclaw-chat-sidebar-region,
 }
 
 .sidebar-region--narrow.sidebar-region--open:not(.sidebar-region--expanded) {
-  grid-template-rows: minmax(0, 1fr) auto auto minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr) auto auto minmax(0, 1fr);
 }
 
 .chat-workspace-rail {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -966,13 +966,25 @@ html.openclaw-native-web-chrome .shell--nav-collapsed:not(.shell--mobile-nav) {
   );
 }
 
-/* The task header stays above both content regions; only the top-left task
-   needs window-control clearance. Mobile has a separate topbar row. */
+/* Only the physical top-left header needs window-control clearance. A left
+   dock puts the side tabs there; mobile has a separate topbar row. */
 .shell:not(.shell--mobile-nav)
   .chat-split-view__column:first-child
   > .chat-split-view__cell:first-child
-  .chat-pane-layout
-  > .chat-pane__header {
+  .sidebar-region:not(
+    .sidebar-region--left.sidebar-region--open:not(.sidebar-region--expanded):not(
+        .sidebar-region--narrow
+      )
+  )
+  > .sidebar-region__header
+  > .chat-pane__header,
+.shell:not(.shell--mobile-nav)
+  .chat-split-view__column:first-child
+  > .chat-split-view__cell:first-child
+  .sidebar-region--left.sidebar-region--open:not(.sidebar-region--expanded):not(
+    .sidebar-region--narrow
+  )
+  [data-region-header="side"] {
   padding-left: var(--shell-titlebar-inset);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening a task side panel puts its tabs a full row below the task toolbar. Restore the aligned header band: toolbar over the main pane, tabs over the side pane, and both content panes starting at the same height.

Related: #138077, #138713.

## Why This Change Was Made

The task header now occupies the main-header area of the existing panel grid. This removes the full-width wrapper that pushed the side tabs down, while retaining the same live chat, widget, browser, and terminal roots across swaps. Native window-control clearance follows whichever header is physically at the top left.

## User Impact

Left and right layouts have one aligned header band, including after swapping Dashboard and Chat. Bottom and mobile layouts keep each header above its own pane. Focus/Restore, saved layouts, drafts, widget input, and terminal sessions continue to work.

## Evidence

- The extended geometry regression fails on the immutable pre-fix source: the task toolbar extends to x=1440 while its main pane ends at x=954. It passes with this repair, checking both header bounds and content alignment before/after swapping, left/right docking, reload, and stacked layouts.
- The initial 11 bundled Chromium E2E cases pass, including native left-dock window-control clearance, retained composer identity, and split task headers. After CI follow-up, all 16 cases in the header-axis, tabbed-panel, task-layout, and dashboard-gallery suites pass. The 123 responsive cases pass again after the mobile repair; the 18 sidebar owner tests also passed.
- A fresh 12-stage synthetic browser recording verifies the views and retained widget document/input, chat draft, saved layout, and terminal session. The before/after images below were inspected in full. No private user screenshots are used.
- Independent Codex review is clean through P2. Formatting, lint, stylelint, i18n, dead-code, and selected static guards pass. Local typechecks hit the existing shared-install mismatch: `@openclaw/fs-safe` 0.7.0 lacks `assertBeforeRename`, while the repository pins 0.7.2. The first CI run passed production types and the UI owner shards; its test failures were resolved in the follow-up described below. [Final-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33938953720) on `6bed499fca7718e0e6db78ad1eaa8a2906fc4272`, including all UI browser shards, production/test typechecks, and the real-Gateway browser suite.

Production: +12 net lines, replacing the full-width wrapper with shared grid placement and physical-left native clearance. Tests: +93 net lines, chiefly measured regression coverage in existing flows. Docs: +4 net lines. No persistence format, configuration, database schema, or Gateway protocol changes.

| Before: toolbar above side tabs | After: aligned header band |
| --- | --- |
| ![Before alignment](https://github.com/user-attachments/assets/4e4a0527-f2e9-48fe-9afc-9c2b4569c65a) | ![After alignment](https://github.com/user-attachments/assets/48b56c35-ba50-439f-a856-1fd519e6a66c) |

<details>
<summary>Swapped dashboard with Chat docked left</summary>

![Aligned headers after swapping and docking left](https://github.com/user-attachments/assets/34f3b347-74dc-4621-b0fa-dc61116ffc7e)

</details>

## CI and review follow-up

The [first CI run](https://github.com/openclaw/openclaw/actions/runs/33937071768) found a tuple-inference error and geometry probes still tied to the former DOM hierarchy. The focused rerun then exposed the stale mobile CSS selectors. All are repaired, preserving the existing mobile breadcrumb, touch-target, safe-area, and content-offset assertions. The same run exposed an existing dashboard-gallery fixture mismatch introduced by #138635: startup resolved the session correctly, but the subsequent session-resolution request reported it missing. Both mock methods now share one resolution object; production routing is unchanged.

Both findings and rank-up moves in the [ClawSweeper review](https://github.com/openclaw/openclaw/pull/138769#issuecomment-5548598464) are addressed: mobile rules target the new header owner, the zero-height clearance override targets only content, and header-axis probes measure the visible main pane. Desktop/mobile, light/dark, short-landscape, native, and rearrangement coverage passes.

<details>
<summary>Mobile after restoring the header styles</summary>

<img src="https://github.com/user-attachments/assets/1d7d71e1-1507-4016-8aed-d8742c040696" alt="Mobile layout with restored breadcrumb and navigation styles" width="390" />

</details>
