### PR TITLE
fix(update): preserve external service policy in fresh doctor

### DIFF
--- a/src/cli/update-cli/update-command-fresh-doctor.test.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "../../test-utils/env.js";
 import type { PostCorePluginUpdateResult } from "./update-command-plugins.js";
 
 const mocks = vi.hoisted(() => ({
@@ -29,7 +30,10 @@ vi.mock("./shared.js", async (importOriginal) => ({
   resolveNodeRunner: vi.fn(() => "/usr/bin/node"),
 }));
 
-import { completePostCorePluginUpdate } from "./update-command-fresh-doctor.js";
+import {
+  completePostCorePluginUpdate,
+  runUpdateFinalizationDoctorInFreshProcess,
+} from "./update-command-fresh-doctor.js";
 
 const pluginUpdate: PostCorePluginUpdateResult = {
   status: "ok",
@@ -93,6 +97,47 @@ describe("post-plugin update readiness", () => {
     ]);
     expect(mocks.runExec.mock.calls[2]?.[2]).toMatchObject({
       env: { OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" },
+    });
+  });
+
+  it.each(["pre-plugin", "post-plugin"] as const)(
+    "forwards an established external service-repair policy to the %s fresh Doctor child",
+    async (phase) => {
+      await withEnvAsync({ OPENCLAW_SERVICE_REPAIR_POLICY: "external" }, async () => {
+        await runUpdateFinalizationDoctorInFreshProcess({
+          phase,
+          root: "/opt/openclaw",
+          entryPath: "/opt/openclaw/dist/index.js",
+          yes: true,
+          json: true,
+          timeoutMs: 5_000,
+        });
+      });
+
+      expect(mocks.runExec.mock.calls[0]?.[2]).toMatchObject({
+        env: expect.objectContaining({
+          OPENCLAW_SERVICE_REPAIR_POLICY: "external",
+        }),
+      });
+    },
+  );
+
+  it("does not invent an external service-repair policy for an unknown owner", async () => {
+    await withEnvAsync({ OPENCLAW_SERVICE_REPAIR_POLICY: "unknown" }, async () => {
+      await runUpdateFinalizationDoctorInFreshProcess({
+        phase: "post-plugin",
+        root: "/opt/openclaw",
+        entryPath: "/opt/openclaw/dist/index.js",
+        yes: true,
+        json: true,
+        timeoutMs: 5_000,
+      });
+    });
+
+    expect(mocks.runExec.mock.calls[0]?.[2]).toMatchObject({
+      env: expect.objectContaining({
+        OPENCLAW_SERVICE_REPAIR_POLICY: undefined,
+      }),
     });
   });
 

--- a/src/cli/update-cli/update-command-fresh-doctor.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.ts
@@ -140,6 +140,10 @@ export async function runUpdateFinalizationDoctorInFreshProcess(params: {
           allowGatewayServiceRepair: false,
           allowGatewayActivation: false,
           deferConfiguredPluginInstallRepair: true,
+          serviceRepairPolicy:
+            process.env.OPENCLAW_SERVICE_REPAIR_POLICY?.trim().toLowerCase() === "external"
+              ? "external"
+              : undefined,
         }),
         ...(params.phase === "post-plugin" ? { [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1" } : {}),
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using an external supervisor could run an update that caused a fresh Doctor child to forget the external service policy and attempt managed-service repair during update finalization.

Fixes #138620

## Why This Change Was Made

The fresh Doctor spawn now forwards only the parent process's normalized, already-established `OPENCLAW_SERVICE_REPAIR_POLICY=external` value through the existing `buildUpdateDoctorEnv` contract. Unknown or absent policy values remain unset, and both pre-plugin and post-plugin phases use the same boundary.

## User Impact

Externally supervised gateway services keep their ownership policy across update finalization, so `openclaw update repair` can converge without reinstalling or activating the service unexpectedly.

## Evidence

- Production-module boundary proof: the real `runUpdateFinalizationDoctorInFreshProcess` entrypoint launched a child through `runExec` using a local fixture only at the process boundary. The external policy is preserved in both fresh-Doctor phases, while the unknown policy remains unset.
- Focused tests: `node scripts/run-vitest.mjs src/cli/update-cli/update-command-fresh-doctor.test.ts` and `node scripts/run-vitest.mjs src/infra/update-runner.test.ts -t 'passes the selected Doctor policy'`.

```text
$ pnpm exec tsx proof-live.ts
entrypoint: runUpdateFinalizationDoctorInFreshProcess
base: 64afb5a6a3891bf5b7c126a129919bf2d42c2d05 => external-pre: {"serviceRepairPolicy":null,"postCoreConvergence":null}
base: 64afb5a6a3891bf5b7c126a129919bf2d42c2d05 => external-post: {"serviceRepairPolicy":null,"postCoreConvergence":"1"}
base: 64afb5a6a3891bf5b7c126a129919bf2d42c2d05 => unknown-post: {"serviceRepairPolicy":null,"postCoreConvergence":"1"}
head: 118091d502e93c5379b2561853c978f561444d0c => external-pre: {"serviceRepairPolicy":"external","postCoreConvergence":null}
head: 118091d502e93c5379b2561853c978f561444d0c => external-post: {"serviceRepairPolicy":"external","postCoreConvergence":"1"}
head: 118091d502e93c5379b2561853c978f561444d0c => unknown-post: {"serviceRepairPolicy":null,"postCoreConvergence":"1"}
negative-control: unknown policy remains unset on the exact head
```

Canonical precedent: `buildUpdateDoctorEnv({ serviceRepairPolicy })` in `src/infra/update-runner-doctor.ts` already defines the update-to-Doctor policy handoff contract.

<details>
<summary>proof-live.ts</summary>

```ts
import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { pathToFileURL } from "node:url";

const repoRoot = path.resolve(process.argv[2] ?? process.cwd());

async function main(): Promise<void> {
  const { runUpdateFinalizationDoctorInFreshProcess } = await import(
    pathToFileURL(path.join(repoRoot, "src/cli/update-cli/update-command-fresh-doctor.ts")).href,
  );

  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "openclaw-138620-"));
  const outputPath = path.join(tempRoot, "child-output.json");
  const fixturePath = path.join(tempRoot, "fresh-doctor-child.mjs");
  await writeFile(
    fixturePath,
    [
      `const output = {`,
      `  serviceRepairPolicy: process.env.OPENCLAW_SERVICE_REPAIR_POLICY ?? null,`,
      `  postCoreConvergence: process.env.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE ?? null,`,
      `};`,
      `await import("node:fs/promises").then(({ writeFile }) => writeFile(${JSON.stringify(outputPath)}, JSON.stringify(output)));`,
    ].join("\n"),
  );

  const originalPolicy = process.env.OPENCLAW_SERVICE_REPAIR_POLICY;
  try {
    for (const [label, phase, policy] of [
      ["external-pre", "pre-plugin", "external"],
      ["external-post", "post-plugin", "external"],
      ["unknown-post", "post-plugin", "unknown"],
    ] as const) {
      process.env.OPENCLAW_SERVICE_REPAIR_POLICY = policy;
      await runUpdateFinalizationDoctorInFreshProcess({
        phase,
        root: repoRoot,
        entryPath: fixturePath,
        yes: false,
        json: false,
        timeoutMs: 5_000,
        nodeRunner: process.execPath,
      });
      console.log(`${label}: ${await readFile(outputPath, "utf8")}`);
    }
  } finally {
    if (originalPolicy === undefined) {
      delete process.env.OPENCLAW_SERVICE_REPAIR_POLICY;
    } else {
      process.env.OPENCLAW_SERVICE_REPAIR_POLICY = originalPolicy;
    }
    await rm(tempRoot, { recursive: true, force: true });
  }
}

void main().catch((error: unknown) => {
  console.error(error);
  process.exitCode = 1;
});
```
</details>

AI-assisted: built with Codex
