### PR TITLE
perf(terminal): reuse line width facts when wrapping notes

### DIFF
--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -100,6 +100,8 @@ function wrapLine(line: string, maxWidth: number): string[] {
   const firstWidth = Math.max(10, maxWidth - visibleWidth(firstPrefix));
   const nextWidth = Math.max(10, maxWidth - visibleWidth(nextPrefix));
 
+  // Printable ASCII width equals length; reuse that fact for every word and candidate.
+  const isPrintableAscii = /^[\u0020-\u007E]*$/.test(content);
   const words = content.split(/\s+/).filter(Boolean);
   const lines: string[] = [];
   let current = "";
@@ -107,50 +109,31 @@ function wrapLine(line: string, maxWidth: number): string[] {
   let available = firstWidth;
 
   for (const word of words) {
-    if (!current) {
-      if (visibleWidth(word) > available) {
-        if (isCopySensitiveToken(word)) {
-          current = word;
-          continue;
-        }
-        pushWrappedWordSegments({
-          word,
-          available,
-          firstPrefix: prefix,
-          continuationPrefix: nextPrefix,
-          lines,
-        });
-        prefix = nextPrefix;
-        available = nextWidth;
+    if (current) {
+      const candidate = `${current} ${word}`;
+      if ((isPrintableAscii ? candidate.length : visibleWidth(candidate)) <= available) {
+        current = candidate;
         continue;
       }
-      current = word;
-      continue;
+      lines.push(prefix + current);
+      current = "";
+      prefix = nextPrefix;
+      available = nextWidth;
     }
 
-    const candidate = `${current} ${word}`;
-    if (visibleWidth(candidate) <= available) {
-      current = candidate;
-      continue;
-    }
-
-    lines.push(prefix + current);
-    prefix = nextPrefix;
-    available = nextWidth;
-
-    if (visibleWidth(word) > available) {
-      if (isCopySensitiveToken(word)) {
-        current = word;
-        continue;
-      }
+    if (
+      (isPrintableAscii ? word.length : visibleWidth(word)) > available &&
+      !isCopySensitiveToken(word)
+    ) {
       pushWrappedWordSegments({
         word,
         available,
         firstPrefix: prefix,
-        continuationPrefix: prefix,
+        continuationPrefix: nextPrefix,
         lines,
       });
-      current = "";
+      prefix = nextPrefix;
+      available = nextWidth;
       continue;
     }
     current = word;


### PR DESCRIPTION
## What Problem This Solves

Terminal notes repeatedly measure growing strings while placing words, even when an entire line contains printable ASCII. The first-word and overflow branches also repeat the same placement decisions.

## Why This Change Was Made

The existing note wrapper now recognizes printable ASCII once per line and reuses the fact that its cell width equals its length. All other text still uses the existing whole-string width calculation. One placement flow handles both the first word and overflow; the old duplicate branch is removed.

This distinction matters for ANSI sequences spanning whitespace: adding separately measured word widths would change existing behavior. Indentation and bullet prefixes still get their own visible-width calculation. Long words retain grapheme-aware splitting, and paths, URLs and other copyable tokens remain intact. Suppression, output routing, coercion, and final Clack rendering are unchanged.

Production is **+17/−34, net −17 lines**. No new tests, dependency, configuration, cache, public API, or output format is introduced.

## Measurements and Tradeoffs

The retained experiment measured the complete public note renderer, including Clack rendering, across 10,800 steady-state calls and 48 cold calls. Ordinary paragraph and security-note medians improved roughly **17–25% in both orders**. The measured candidate is byte-identical to this patch; current source/dependency correspondence and new functional proof are recorded separately. These remain historical measurements, not a new benchmark of this entire checkout.

**The original numeric verdict remains failed.** Four preset gates failed, and all 30 adverse summary/resource comparisons remain retained. The control-heavy N11 median increased 5.125/9.732 µs; its tail and the empty-output tail also regressed. Cold N03 parent acknowledgment increased 27.058 ms. No samples or thresholds were changed, and the experiment was not rerun for a passing result.

This is an explicit engineering acceptance of the simpler wrapping flow and ordinary-note improvement with those limited regressions. It does not establish a universal speedup, lower memory use, faster Gateway startup, or lower model-turn latency.

## Verification

The same **274 cases across five complete files** passed on both variants, with identical per-file case order. Coverage preserves Unicode and ANSI handling, copyable tokens, wrapping, suppression, stream selection and real-PTY prompt cancellation. All **27 normal changed-file checks** passed. Independent managed Codex P0–P2 review returned scoped-clean with no findings, confidence 0.86 across two assigned context partitions; each partition's limitations remain recorded.

A normal mapped build passed. The emitted CLI route reaches the actual note chunk, and 20 maps with 52 complete source contents match the validated source, including the exact candidate. Existing worker source-map, dependency-eval and browser-externalization warnings remain retained; they were not suppressed.

The additional real built CLI smoke uses supported `onboard --classic` with wholly synthetic HOME/config/state. It displays the complete first security note at 100 columns, then receives Ctrl-D once at the confirmation. The complete message, framing, wrapping, intact command/URL lines, visible cancellation, unchanged config and absence of an onboarding lock all passed. Underlying CLI exit 1 is intentional cancellation; the proof fixture passed. This is one real ASCII render/cancel flow, not a replacement for the broader paired tests or a timing comparison.

All observed build and CLI processes closed. Normal preflight created only task-local SQLite state; its complete census was checked before the temporary state was removed. The raw transcript and closure evidence remain retained.

Hosted CI run 33937185665 passed on the exact published head, including `openclaw/ci-gate` (101 successful checks, 29 skipped and one neutral). No changelog is edited for this PR.

## ClawSweeper Review Follow-up

The latest review (comment 5548576980, exact head `1bd7a4841ace5f1a547a782f6eeac474d2871ee6`) found no correctness defect. Both before-merge items and its Rank-up move concern the reviewer's inability to retrieve the exact dependency sources. That inspection is now complete in the dependency-equipped checkout; no extra contributor runtime run or source change was needed.

I personally checked installed `string-width` **8.2.2**, its manifest/export, and its complete `index.js`: lines 171–173 explicitly return string length for printable ASCII. OpenClaw's `ansi.ts` still owns ANSI parsing and invokes whole-string width with upstream escape parsing disabled; its non-ASCII and tab handling are unchanged. I also checked installed `@clack/prompts` **1.7.0** `dist/index.mjs` lines 843–873: note formatting wraps against the selected output's columns, computes frame widths, and writes the complete frame to that output. The `@clack/core` **1.4.3** column helper at line 159 honors the adapted stream's numeric columns. The exact package and implementation hashes are retained with the existing mapped-build and real-CLI evidence.

This resolves the dependency-inspection gap and optional Rank-up move. The original numeric failures and all measurement qualifications above remain unchanged.
