### PR TITLE
fix(ci): stabilize Control UI stream and recovery tests

### DIFF
--- a/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
+++ b/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
@@ -26,17 +26,14 @@ const suite = createChatFlowE2eSuite();
 type ChatFlowSuite = ReturnType<typeof createChatFlowE2eSuite>;
 type ChatFlowPage = Parameters<Parameters<ChatFlowSuite["withPage"]>[1]>[0]["page"];
 
-// Burst size for the render-scheduling gate. Each delta lands in its own
-// macrotask, so every event forces an invalidation; the animation-frame queue
-// is what keeps those invalidations executing inside frame callbacks instead
-// of on message/timer tasks.
+// Each delta lands in its own message task. The animation-frame queue must
+// coalesce those invalidations and keep them off message tasks.
 const BURST_DELTA_COUNT = 240;
 // Sanity floor: the burst must invalidate the chat page host at least twice,
 // proving the probe observed the streaming path at all.
 const MIN_BURST_HOST_UPDATES = 2;
-// Valid frame-queued runs commit 115-144 host updates for this burst. A direct
-// update per delta produces 241, so this ceiling catches lost coalescing while
-// retaining headroom for runner cadence.
+// A direct update per delta produces at least 240 host invalidations. Keep the
+// burst below that count so frame scheduling alone cannot hide lost coalescing.
 const MAX_BURST_HOST_UPDATES = 180;
 // Minimum share of host invalidations that must execute inside an animation
 // frame callback. The queue guarantees this for every stream-driven update;
@@ -117,7 +114,7 @@ async function recordBudgetMetrics(
 // plain-text projection of the burst chunk emitted in-page
 // (`delta N with **boldN** and \`codeN\` tail`).
 function renderedChunkText(index: number): string {
-  return `delta ${index} with bold${index}`;
+  return `delta ${index} with bold${index} and code${index} tail`;
 }
 
 async function installRenderProbe(page: ChatFlowPage) {
@@ -194,9 +191,9 @@ async function readRenderProbe(page: ChatFlowPage): Promise<StreamPerfProbe> {
   return page.evaluate(() => (window as ScopedWindow).ocStreamPerf!);
 }
 
-// Emits each delta from its own macrotask so render work cannot hide inside
-// one task's microtask batching: the queue under test schedules commits per
-// animation frame, not per task.
+// Socket-like message tasks avoid nested timers' 4ms clamp, which can spread a
+// burst across enough frames to falsely exhaust the budget. Split at a real
+// frame so the sanity floor observes two streaming batches.
 async function emitDeltaBurstInPage(
   page: ChatFlowPage,
   runId: string,
@@ -211,6 +208,8 @@ async function emitDeltaBurstInPage(
       const scope = window as ScopedWindow;
       scope.ocBurstDone = false;
       let emitted = 0;
+      const channel = new MessageChannel();
+      const postNext = () => channel.port2.postMessage(null);
       const emitNext = () => {
         emitted += 1;
         const chunk = ` delta ${emitted} with **bold${emitted}** and \`code${emitted}\` tail`;
@@ -225,13 +224,19 @@ async function emitDeltaBurstInPage(
           sessionKey: "main",
           state: "delta",
         });
-        if (emitted < targetCount) {
-          setTimeout(emitNext, 0);
-        } else {
+        if (emitted === targetCount) {
+          channel.port1.close();
+          channel.port2.close();
           scope.ocBurstDone = true;
+        } else if (emitted === Math.floor(targetCount / 2)) {
+          requestAnimationFrame(postNext);
+        } else {
+          postNext();
         }
       };
-      setTimeout(emitNext, 0);
+      channel.port1.addEventListener("message", emitNext);
+      channel.port1.start();
+      postNext();
     },
     { runId, count },
   );

--- a/ui/src/e2e/new-session-page.cloud-startup.runtime-load.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.runtime-load.e2e.test.ts
@@ -221,13 +221,18 @@ suite.define(() => {
             }
           }
           await page.setViewportSize({ width: 390, height: 844 });
-          expect(
-            await alert.evaluate((element) => {
-              const text = element.querySelector(".chat-error__content")!.getBoundingClientRect();
-              const action = element.querySelector(".chat-error__discard")!.getBoundingClientRect();
-              return action.top >= text.bottom && action.right <= innerWidth && action.left >= 0;
-            }),
-          ).toBe(true);
+          // The resize event schedules the shell's mobile layout after the viewport RPC.
+          await expect
+            .poll(() =>
+              alert.evaluate((element) => {
+                const text = element.querySelector(".chat-error__content")!.getBoundingClientRect();
+                const action = element
+                  .querySelector(".chat-error__discard")!
+                  .getBoundingClientRect();
+                return action.top >= text.bottom && action.right <= innerWidth && action.left >= 0;
+              }),
+            )
+            .toBe(true);
           if (captureUiProofEnabled) {
             await page.screenshot({
               animations: "disabled",


### PR DESCRIPTION
## What Problem This Solves

Two Control UI browser fixtures failed during release verification. The stream budget fixture used nested zero-delay timers whose browser clamping could spread its supposed burst across too many frames. The startup recovery fixture inspected responsive geometry immediately after changing the viewport, before the application was required to have finished its resize update.

## Why This Change Was Made

Deliver each of the 240 stream snapshots in its own MessageChannel task, with one deliberate animation-frame boundary. Keep the 180-update ceiling, two-update floor, 90% frame-scheduling ratio, and complete final-text assertion. Both direct per-message updates and a separate rAF callback for every message still fail the gate.

Await the existing mobile recovery bounds with the suite's default `expect.poll` timeout. The bounds and recovery interactions are unchanged. CI observed the immediate assertion fail; local original and passive-diagnostic runs passed, so this change does not claim to have captured CI's exact bad geometry. It follows the asynchronous viewport/resize/render contract used by the responsive sibling tests.

## User Impact

Release verification checks browser behavior without these timer-cadence and immediate-layout assumptions. Production behavior and rendering policies are unchanged.

## Evidence

- The unchanged stream fixture failed with 225 host invalidations when the same 240 snapshots arrived 16 ms apart; every invalidation was inside rAF and the complete final snapshot was visible. The repaired five-test suite passed. Direct per-message invalidation still failed at `241 > 180`; removing pending-frame dedupe and its stale-callback fence failed at `240 > 180`.
- Startup recovery preserved the original saved/chat/toast order and passed all three cases with the polling change. The original and passive-diagnostic local runs also passed; CI is the observed failing reproduction for that immediate assertion.
- The separate dashboard gallery failure was repaired in #138769 (`6832f3b61ebce90d52921b592e9d23dd83802e06`). Validation includes its canonical fixture repair and exercises gallery navigation as sibling coverage.

Both complete scoped changed gates passed, including formatting, UI catalog verification, the UI E2E type graph, dead-export checks, and targeted lint. Both changed fixture files remain byte-identical after rebasing onto the canonical gallery-fix commit.

The final combined browser run passed all 9 cases across three files on head `958db6f3628da43176433647c843325296671f4f`, based on `6832f3b61ebce90d52921b592e9d23dd83802e06` (210.79 seconds). This includes the five streaming budget cases, three startup recovery paths, and canonical dashboard gallery scenario. CI must be green before merge.

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts ui/src/e2e/dashboard-gallery.e2e.test.ts ui/src/e2e/new-session-page.cloud-startup.runtime-load.e2e.test.ts
```

Independent Codex reviews of the stream and startup fixtures are scoped-clean through P2.

Production: +0/-0. Tests: +32/-22. No baseline, inventory, timeout, or performance budget was relaxed. Original coalescing coverage and negative-proof rationale come from #106353 and #128154; the generated locale PR #138680 exposed the stream-budget failure.
