### PR TITLE
feat: tune inbound batching without reconnecting channels

### DIFF
--- a/docs/concepts/messages.md
+++ b/docs/concepts/messages.md
@@ -54,6 +54,13 @@ Rapid consecutive text messages from the same sender can be batched into one age
 - Disabled by default: `messages.inbound.debounceMs` has no built-in default, so debouncing only activates once you set it (globally or per channel).
 - iMessage follows the same generic debounce policy. `imsg` 0.13.1 and newer coalesces Apple URL-preview split-sends before OpenClaw receives them, so no iMessage-specific debounce setting is needed.
 
+Changes to `messages.inbound.debounceMs` and `messages.inbound.byChannel` apply without
+reconnecting Discord, Feishu, iMessage, Mattermost, Microsoft Teams, Signal, Slack,
+Telegram, or WhatsApp. Newly admitted inbound work uses the committed delay. A config change alone does not reschedule a pending batch;
+later messages can update its idle delay within the original maximum deadline.
+Explicit transport timing overrides remain fixed. Telegram's forwarded-message
+collection window remains separate.
+
 ## Sessions and devices
 
 Sessions are owned by the gateway, not by clients.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -603,14 +603,17 @@ back to OpenClaw.
 | Gateway server            | Other `gateway.*` settings (port, bind, auth mode, roles, tailscale, TLS)                                                                                                                                                                                          | **Yes**                                |
 | Infrastructure            | Other `discovery` and `browser` settings, MCP Apps listener settings, `secrets.egressProxy`, `plugins.load`, `plugins.installs`                                                                                                                                    | **Yes**                                |
 
-Changes to `channels.defaults`, `channels.modelByChannel`, `messages.inbound`,
-`commands`, `accessGroups`, `tts`, `surfaces`,
-`acp.stream`, and `diagnostics.flags` restart loaded channel runtimes to refresh shared policy. Manually stopped accounts stay
-stopped, and the Gateway keeps running.
+Changes to `channels.defaults`, `channels.modelByChannel`, `commands`,
+`accessGroups`, `tts`, `surfaces`, `acp.stream`, and `diagnostics.flags` refresh
+loaded channel runtimes that capture those policies. Manually stopped accounts
+stay stopped, and the Gateway keeps running.
 
-`messages.ackReactionScope` applies to subsequent channel turns without reconnecting
-channels. Per-channel and per-account overrides still take precedence; turns
-already being processed retain their captured policy.
+[Inbound debounce settings](/concepts/messages#inbound-debouncing) apply at the
+next inbound admission without reconnecting supported channels.
+`messages.ackReactionScope` applies to subsequent turns without reconnecting
+Discord, Matrix, Signal, Slack, Telegram, or WhatsApp. Other channel plugins
+refresh unless they declare that they read the policy live. Per-channel and
+per-account overrides still take precedence; admitted turns retain their policy.
 
 `diagnostics.enabled` updates diagnostic dispatch and heartbeat ownership live.
 With `diagnostics-otel` loaded, `diagnostics.otel` restarts only its exporter service,

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -61,6 +61,18 @@ been published yet. Read once per turn and carry that snapshot through admission
 and replies. Process-wide controls such as diagnostics should read at the point
 of emission.
 
+`createChannelInboundDebouncer` keeps its returned numeric `debounceMs` and default
+queue timing as startup snapshots. For live timing, pass its existing
+`resolveDebounceMs(entry)` callback and resolve with the bound config reader.
+If pending-key or shutdown bookkeeping also depends on the delay, capture one
+value on the entry and use it for both bookkeeping and the callback.
+
+A channel's `reload.noopPrefixes` opts only that channel out of shared-policy
+refresh. Declare a prefix only after every retained consumer reads it live or
+does not consume it. Undeclared channels still refresh; one channel's declaration
+cannot suppress a sibling's reload. A narrower `reload.configPrefixes` entry can
+retain restart behavior under a broader no-op prefix.
+
 ## Reusable runtime utilities
 
 Native command probes should use `runCommandWithTimeout` from

--- a/extensions/discord/src/monitor/message-dispatcher.ts
+++ b/extensions/discord/src/monitor/message-dispatcher.ts
@@ -1,6 +1,7 @@
 // Discord plugin module dispatches inbound messages into the processing queue.
 import {
   createChannelInboundDebouncer,
+  resolveInboundDebounceMs,
   shouldDebounceTextInbound,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { fanInChannelIngressLifecycles } from "openclaw/plugin-sdk/channel-ingress-runtime";
@@ -113,6 +114,7 @@ export function createDiscordMessageDispatcher(
   const { debouncer } = createChannelInboundDebouncer<DiscordDebounceEntry>({
     cfg: params.cfg,
     channel: "discord",
+    resolveDebounceMs: () => resolveInboundDebounceMs({ cfg: readConfig(), channel: "discord" }),
     buildKey: resolveDebounceKey,
     shouldDebounce: (entry) => {
       const message = entry.data.message;

--- a/extensions/discord/src/monitor/message-handler.debounce-policy.test.ts
+++ b/extensions/discord/src/monitor/message-handler.debounce-policy.test.ts
@@ -1,0 +1,88 @@
+import { MessageType } from "discord-api-types/v10";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { expect, it, vi } from "vitest";
+import { Message } from "../internal/discord.js";
+import { createInternalTestClient } from "../internal/test-builders.test-support.js";
+import { createDiscordMessageDispatcher } from "./message-dispatcher.js";
+import { createDiscordHandlerParams } from "./message-handler.test-helpers.js";
+
+it("applies current inbound timing without losing queued Discord messages", async () => {
+  const client = createInternalTestClient();
+  const params = createDiscordHandlerParams();
+  const dispatched: string[] = [];
+  setRuntimeConfigSnapshot(params.cfg, params.cfg);
+  const handler = createDiscordMessageDispatcher({
+    ...params,
+    testing: {
+      preflightDiscordMessage: async ({ data }) => {
+        dispatched.push(data.message.content ?? "");
+        return null;
+      },
+    },
+  });
+  const publish = (inbound: NonNullable<OpenClawConfig["messages"]>["inbound"]) => {
+    const cfg = { ...params.cfg, messages: { inbound } };
+    setRuntimeConfigSnapshot(cfg, cfg);
+  };
+  const enqueue = (text: string) => {
+    const message = new Message(client, {
+      id: text,
+      channel_id: "c1",
+      content: text,
+      author: {
+        id: "U1",
+        username: "alice",
+        global_name: null,
+        discriminator: "0",
+        avatar: null,
+      },
+      attachments: [],
+      embeds: [],
+      mentions: [],
+      mention_roles: [],
+      mention_everyone: false,
+      timestamp: "2026-09-04T00:00:00.000Z",
+      edited_timestamp: null,
+      type: MessageType.Default,
+      tts: false,
+      pinned: false,
+    });
+    return handler({ message, author: message.author, channel_id: message.channelId }, client);
+  };
+  vi.useFakeTimers();
+  try {
+    await enqueue("immediate");
+    expect(dispatched).toEqual(["immediate"]);
+
+    publish({ debounceMs: 50 });
+    await enqueue("first");
+    await vi.advanceTimersByTimeAsync(25);
+    expect(dispatched).toEqual(["immediate"]);
+    publish({ debounceMs: 50, byChannel: { discord: 10 } });
+    await enqueue("second");
+    await vi.advanceTimersByTimeAsync(9);
+    expect(dispatched).toEqual(["immediate"]);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(dispatched).toEqual(["immediate", "first\nsecond"]);
+
+    publish({ debounceMs: 50 });
+    await enqueue("pending");
+    publish({ debounceMs: 0 });
+    await enqueue("after disable");
+    expect(dispatched).toEqual(["immediate", "first\nsecond", "pending", "after disable"]);
+
+    publish({ debounceMs: 50 });
+    await enqueue("cancel on shutdown");
+    await handler.deactivate();
+    await vi.advanceTimersByTimeAsync(50);
+    expect(dispatched).toHaveLength(4);
+  } finally {
+    await handler.deactivate();
+    vi.useRealTimers();
+    clearRuntimeConfigSnapshot();
+  }
+});

--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -1,4 +1,3 @@
-// Discord plugin module implements shared behavior.
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
@@ -143,7 +142,10 @@ export function createDiscordPluginBase(params: {
     streaming: {
       blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
     },
-    reload: { configPrefixes: ["channels.discord"] },
+    reload: {
+      configPrefixes: ["channels.discord"],
+      noopPrefixes: ["messages.inbound", "messages.ackReactionScope"],
+    },
     configSchema: DiscordChannelConfigSchema,
     config: {
       ...discordConfigAdapter,

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1,4 +1,3 @@
-// Feishu plugin module implements channel behavior.
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-resolution";
 import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
@@ -1121,7 +1120,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
       mentions: {
         stripPatterns: () => ['<at user_id="[^"]*">[^<]*</at>'],
       },
-      reload: { configPrefixes: ["channels.feishu"] },
+      reload: { configPrefixes: ["channels.feishu"], noopPrefixes: ["messages.inbound"] },
       doctor: feishuDoctor,
       configSchema: FeishuChannelConfigSchema,
       config: {

--- a/extensions/feishu/src/monitor.message-handler.debounce-policy.test.ts
+++ b/extensions/feishu/src/monitor.message-handler.debounce-policy.test.ts
@@ -1,0 +1,96 @@
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "openclaw/plugin-sdk/channel-inbound-debounce";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { expect, it, vi } from "vitest";
+import * as dedup from "./dedup.js";
+import { createFeishuMessageReceiveHandler } from "./monitor.message-handler.js";
+
+it("changes Feishu batching timing on the running receive handler", async () => {
+  const cfg: OpenClawConfig = { messages: { inbound: { debounceMs: 0 } } };
+  setRuntimeConfigSnapshot(cfg, cfg);
+  const claim = vi
+    .spyOn(dedup, "claimUnprocessedFeishuMessage")
+    .mockImplementation(async ({ messageId }) =>
+      messageId
+        ? {
+            kind: "claimed",
+            handle: { keys: [messageId], commit: async () => true, release: () => {} },
+          }
+        : { kind: "invalid" },
+    );
+  const dispatched: string[] = [];
+  const debouncers: Array<{ drain: () => Promise<void> }> = [];
+  const createDebouncer: typeof createInboundDebouncer = (options) => {
+    const debouncer = createInboundDebouncer(options);
+    debouncers.push(debouncer);
+    return debouncer;
+  };
+  const handler = createFeishuMessageReceiveHandler({
+    cfg,
+    channelRuntime: createPluginRuntimeMock({
+      channel: { debounce: { createInboundDebouncer: createDebouncer, resolveInboundDebounceMs } },
+    }).channel,
+    accountId: "default",
+    chatHistories: new Map(),
+    handleMessage: async ({ event }) => {
+      dispatched.push(event.message.content);
+    },
+    resolveDebounceText: ({ event }) => event.message.content,
+    hasProcessedMessage: async () => false,
+  });
+  const enqueue = (text: string) =>
+    handler({
+      sender: { sender_id: { open_id: "sender" }, sender_type: "user" },
+      message: {
+        message_id: text,
+        chat_id: "conversation",
+        chat_type: "p2p",
+        message_type: "text",
+        content: text,
+      },
+    });
+  const publish = (debounceMs: number) => {
+    const current = { messages: { inbound: { byChannel: { feishu: debounceMs } } } };
+    setRuntimeConfigSnapshot(current, current);
+  };
+  try {
+    await enqueue("immediate");
+    expect(dispatched).toEqual(["immediate"]);
+    publish(250);
+    const started = performance.now();
+    await enqueue("first");
+    await enqueue("second");
+    expect(dispatched).toEqual(["immediate"]);
+    await vi.waitFor(() =>
+      expect(dispatched).toEqual(["immediate", JSON.stringify({ text: "first\nsecond" })]),
+    );
+    const delayedElapsedMs = performance.now() - started;
+    publish(0);
+    await enqueue("after disable");
+    expect(dispatched.at(-1)).toBe("after disable");
+    expect(dispatched).toHaveLength(3);
+    console.log(
+      "MONITOR_DEBOUNCE_PROOF " +
+        JSON.stringify({
+          channel: "feishu",
+          pid: process.pid,
+          clock: "real",
+          delaysMs: [0, 250, 0],
+          delayedElapsedMs,
+          bodies: dispatched,
+          debouncersCreated: debouncers.length,
+        }),
+    );
+  } finally {
+    await Promise.all(debouncers.map((debouncer) => debouncer.drain()));
+    clearRuntimeConfigSnapshot();
+    claim.mockRestore();
+  }
+});

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -1,4 +1,4 @@
-// Feishu plugin module implements monitor.message handler behavior.
+import { createRuntimeConfigReader } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { isRecord, readStringValue as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ClawdbotConfig, HistoryEntry, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
 import { claimUnprocessedFeishuMessage, type FeishuMessageProcessingClaim } from "./dedup.js";
@@ -186,10 +186,9 @@ export function createFeishuMessageReceiveHandler({
 }: FeishuMessageReceiveHandlerContext): (
   data: unknown,
 ) => Promise<{ kind: "deferred" } | { kind: "failed-retryable"; error: unknown } | void> {
-  const inboundDebounceMs = channelRuntime.debounce.resolveInboundDebounceMs({
-    cfg,
-    channel: "feishu",
-  });
+  const readConfig = createRuntimeConfigReader(cfg);
+  const resolveDebounceMs = () =>
+    channelRuntime.debounce.resolveInboundDebounceMs({ cfg: readConfig(), channel: "feishu" });
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
   const enqueue = createSequentialQueue({
@@ -274,7 +273,8 @@ export function createFeishuMessageReceiveHandler({
 
   const inboundDebouncer =
     channelRuntime.debounce.createInboundDebouncer<FeishuMessageDebounceEntry>({
-      debounceMs: inboundDebounceMs,
+      debounceMs: resolveDebounceMs(),
+      resolveDebounceMs,
       buildKey: ({ event }) => {
         const chatId = event.message.chat_id?.trim();
         const senderId = resolveSenderDebounceId(event);

--- a/extensions/imessage/src/monitor.debounce-policy.test.ts
+++ b/extensions/imessage/src/monitor.debounce-policy.test.ts
@@ -1,0 +1,130 @@
+import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { closeOpenClawStateDatabaseForTest } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import type { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
+import { expect, it, vi } from "vitest";
+import { IMessageRpcClient, createIMessageRpcClient } from "./client.js";
+import { monitorIMessageProvider } from "./monitor.js";
+import { resolveIMessageInboundDecision } from "./monitor/inbound-processing.js";
+import { getIMessageRuntime } from "./runtime.js";
+import { installIMessageStateRuntimeForTest } from "./test-support/runtime.js";
+
+vi.mock("openclaw/plugin-sdk/transport-ready-runtime", () => ({
+  waitForTransportReady: vi.fn<typeof waitForTransportReady>(async () => {}),
+}));
+vi.mock("./client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./client.js")>()),
+  createIMessageRpcClient: vi.fn<typeof createIMessageRpcClient>(),
+}));
+vi.mock("./monitor/inbound-processing.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./monitor/inbound-processing.js")>()),
+  resolveIMessageInboundDecision: vi.fn<typeof resolveIMessageInboundDecision>(async () => ({
+    kind: "drop",
+    reason: "dmPolicy disabled",
+  })),
+}));
+
+it("changes iMessage batching delay without replacing the attached RPC client", async () => {
+  installIMessageStateRuntimeForTest();
+  const cfg: OpenClawConfig = {
+    channels: {
+      imessage: {
+        dbPath: path.join(getIMessageRuntime().state.resolveStateDir(), "absent-chat.db"),
+        dmPolicy: "disabled",
+      },
+    },
+    messages: { inbound: { debounceMs: 0 } },
+  };
+  setRuntimeConfigSnapshot(cfg, cfg);
+  const ready = createDeferred<void>();
+  const closed = createDeferred<void>();
+  const client = new IMessageRpcClient();
+  vi.spyOn(client, "request").mockResolvedValue({ subscription: 1 });
+  vi.spyOn(client, "waitForClose").mockImplementation(() => closed.promise);
+  vi.spyOn(client, "stop").mockImplementation(async () => closed.resolve());
+  let notify: NonNullable<Parameters<typeof createIMessageRpcClient>[0]>["onNotification"];
+  vi.mocked(createIMessageRpcClient).mockImplementation(async (options) => {
+    notify = options?.onNotification;
+    return client;
+  });
+  const abort = new AbortController();
+  const monitor = monitorIMessageProvider({
+    config: cfg,
+    abortSignal: abort.signal,
+    runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    statusSink: (patch) => {
+      if (patch.connected) {
+        ready.resolve();
+      }
+    },
+  });
+  let sequence = 0;
+  const enqueue = (text: string) => {
+    sequence += 1;
+    notify?.({
+      method: "message",
+      params: {
+        message: {
+          id: sequence,
+          guid: `debounce-${sequence}`,
+          chat_id: 123,
+          sender: "+15555550101",
+          text,
+          created_at: new Date().toISOString(),
+          is_from_me: false,
+          is_group: false,
+        },
+      },
+    });
+  };
+  const bodies = () =>
+    vi.mocked(resolveIMessageInboundDecision).mock.calls.map(([params]) => params.message.text);
+  const publish = (debounceMs: number) => {
+    const current = { ...cfg, messages: { inbound: { byChannel: { imessage: debounceMs } } } };
+    setRuntimeConfigSnapshot(current, current);
+  };
+  try {
+    await Promise.race([ready.promise, monitor]);
+    enqueue("immediate");
+    await vi.waitFor(() => expect(bodies()).toEqual(["immediate"]));
+    publish(500);
+    const started = performance.now();
+    enqueue("first");
+    enqueue("second");
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    expect(bodies()).toEqual(["immediate"]);
+    await vi.waitFor(() => expect(bodies()).toEqual(["immediate", "first second"]));
+    const delayedElapsedMs = performance.now() - started;
+    publish(0);
+    enqueue("after disable");
+    await vi.waitFor(() =>
+      expect(bodies()).toEqual(["immediate", "first second", "after disable"]),
+    );
+    console.log(
+      "MONITOR_DEBOUNCE_PROOF " +
+        JSON.stringify({
+          channel: "imessage",
+          pid: process.pid,
+          clock: "real",
+          delaysMs: [0, 500, 0],
+          delayedElapsedMs,
+          bodies: bodies(),
+          clientsCreated: vi.mocked(createIMessageRpcClient).mock.calls.length,
+        }),
+    );
+    expect(createIMessageRpcClient).toHaveBeenCalledTimes(1);
+  } finally {
+    abort.abort();
+    await monitor;
+    clearRuntimeConfigSnapshot();
+    closeOpenClawStateDatabaseForTest();
+    vi.restoreAllMocks();
+  }
+});

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -5,6 +5,7 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 import { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
 import {
   createChannelInboundDebouncer,
+  resolveInboundDebounceMs,
   formatInboundMediaUnavailableText,
   resolveEnvelopeFormatOptions,
   runChannelInboundEvent,
@@ -36,7 +37,11 @@ import { isInboundPathAllowed, kindFromMime } from "openclaw/plugin-sdk/media-ru
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { resolveTextChunkLimit, type GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
-import { getRuntimeConfig, type OpenClawConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import {
+  createRuntimeConfigReader,
+  getRuntimeConfig,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose, shouldLogVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
 import {
   resolveOpenProviderRuntimeGroupPolicy,
@@ -358,6 +363,7 @@ async function waitForWatchSubscribeRetryDelay(params: {
 export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): Promise<void> {
   const runtime = resolveRuntime(opts);
   const cfg = opts.config ?? getRuntimeConfig();
+  const readConfig = createRuntimeConfigReader(cfg);
   const accountInfo = resolveIMessageAccount({
     cfg,
     accountId: opts.accountId,
@@ -534,6 +540,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   }>({
     cfg,
     channel: "imessage",
+    resolveDebounceMs: () => resolveInboundDebounceMs({ cfg: readConfig(), channel: "imessage" }),
     buildKey: (entry) => {
       const msg = entry.message;
       const sender = msg.sender?.trim();

--- a/extensions/imessage/src/shared.ts
+++ b/extensions/imessage/src/shared.ts
@@ -1,4 +1,3 @@
-// Imessage plugin module implements shared behavior.
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import {
   adaptScopedAccountAccessor,
@@ -101,7 +100,7 @@ export function createIMessagePluginBase(params: {
       effects: true,
       groupManagement: true,
     },
-    reload: { configPrefixes: ["channels.imessage"] },
+    reload: { configPrefixes: ["channels.imessage"], noopPrefixes: ["messages.inbound"] },
     configSchema: IMessageChannelConfigSchema,
     config: {
       ...imessageConfigAdapter,

--- a/extensions/matrix/src/channel.setup.ts
+++ b/extensions/matrix/src/channel.setup.ts
@@ -1,4 +1,3 @@
-// Matrix plugin module implements channel.setup behavior.
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { matrixConfigAdapter } from "./config-adapter.js";
@@ -31,7 +30,7 @@ export const matrixPluginBase = {
     threads: true,
     media: true,
   },
-  reload: { configPrefixes: ["channels.matrix"] },
+  reload: { configPrefixes: ["channels.matrix"], noopPrefixes: ["messages.ackReactionScope"] },
   configSchema: MatrixChannelConfigSchema,
   config: {
     ...matrixConfigAdapter,

--- a/extensions/mattermost/src/channel.setup.ts
+++ b/extensions/mattermost/src/channel.setup.ts
@@ -1,4 +1,3 @@
-// Mattermost plugin module implements channel.setup behavior.
 import type { ChannelPlugin } from "./channel-api.js";
 import {
   describeMattermostAccount,
@@ -25,6 +24,7 @@ export const mattermostSetupPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
   },
   reload: {
     configPrefixes: ["channels.mattermost"],
+    noopPrefixes: ["messages.inbound"],
     /**
      * accounts.default is promoted; named resolution merges only channel-wide fields
      * plus the selected account. Runtime monitor, debounce, and ingress use accountId.

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -1,4 +1,3 @@
-// Mattermost plugin module implements channel behavior.
 import {
   jsonResult,
   readPositiveIntegerParam,
@@ -746,6 +745,7 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
     },
     reload: {
       configPrefixes: ["channels.mattermost"],
+      noopPrefixes: ["messages.inbound"],
       /**
        * accounts.default is promoted; named resolution merges only channel-wide fields
        * plus the selected account. Monitor debounce and durable ingress use accountId.

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -5,7 +5,10 @@ import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
-import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "openclaw/plugin-sdk/channel-inbound-debounce";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
@@ -15,6 +18,10 @@ import {
   DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import type { MattermostPost } from "./client.js";
@@ -276,6 +283,7 @@ function createRuntimeCore(
   },
   overrides: {
     inboundDebounceMs?: number;
+    resolveInboundDebounceMs?: typeof resolveInboundDebounceMs;
     isControlCommandMessage?: (text?: string) => boolean;
     shouldComputeCommandAuthorized?: (text?: string) => boolean;
     shouldHandleTextCommands?: () => boolean;
@@ -427,7 +435,8 @@ function createRuntimeCore(
         shouldHandleTextCommands: overrides.shouldHandleTextCommands ?? (() => false),
       },
       debounce: {
-        resolveInboundDebounceMs: () => overrides.inboundDebounceMs ?? 0,
+        resolveInboundDebounceMs:
+          overrides.resolveInboundDebounceMs ?? (() => overrides.inboundDebounceMs ?? 0),
         createInboundDebouncer:
           overrides.createInboundDebouncer ??
           (<T>(params: {
@@ -595,6 +604,66 @@ describe("mattermost inbound user posts", () => {
     mockState.dispatchInboundMessage.mockImplementation(async () => {
       mockState.abortController?.abort();
     });
+  });
+
+  it("changes Mattermost delay at collector admission without replacing the socket", async () => {
+    const cfg = { ...testConfig, messages: { inbound: { debounceMs: 0 } } };
+    setRuntimeConfigSnapshot(cfg, cfg);
+    mockState.dispatchInboundMessage.mockResolvedValue(undefined);
+    mockState.runtimeCore = createRuntimeCore(cfg, undefined, {
+      createInboundDebouncer,
+      resolveInboundDebounceMs,
+    });
+    const socket = new FakeWebSocket();
+    const abort = new AbortController();
+    const socketFactory = vi.fn(() => socket);
+    const monitor = monitorMattermostProvider({
+      config: cfg,
+      runtime: testRuntime(),
+      abortSignal: abort.signal,
+      webSocketFactory: socketFactory,
+    });
+    await vi.waitFor(() => expect(socket.openListenerCount).toBeGreaterThan(0));
+    socket.emitOpen();
+    const bodies = () =>
+      mockState.dispatchInboundMessage.mock.calls.map(([params]) => params.ctx.BodyForAgent);
+    const publish = (debounceMs: number) => {
+      const current = { ...cfg, messages: { inbound: { byChannel: { mattermost: debounceMs } } } };
+      setRuntimeConfigSnapshot(current, current);
+    };
+    try {
+      await emitMattermostChannelPost(socket, { id: "debounce-1", message: "immediate" });
+      await vi.waitFor(() => expect(bodies()).toEqual(["immediate"]));
+      publish(500);
+      const started = performance.now();
+      await emitMattermostChannelPost(socket, { id: "debounce-2", message: "buffered" });
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      expect(bodies()).toEqual(["immediate"]);
+      publish(0);
+      await vi.waitFor(() => expect(bodies()).toEqual(["immediate", "buffered"]));
+      const delayedElapsedMs = performance.now() - started;
+      await emitMattermostChannelPost(socket, { id: "debounce-3", message: "after disable" });
+      await vi.waitFor(() => expect(bodies()).toEqual(["immediate", "buffered", "after disable"]));
+      console.log(
+        "MONITOR_DEBOUNCE_PROOF " +
+          JSON.stringify({
+            channel: "mattermost",
+            pid: process.pid,
+            clock: "real",
+            delaysMs: [0, 500, 0],
+            delayedElapsedMs,
+            bodies: bodies(),
+            socketsCreated: socketFactory.mock.calls.length,
+          }),
+      );
+    } finally {
+      abort.abort();
+      socket.emitClose(1000);
+      await monitor;
+      clearRuntimeConfigSnapshot();
+    }
   });
 
   it("preserves abandon retry accounting, backoff, threshold, and restart behavior", async () => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1,6 +1,6 @@
-// Mattermost plugin module orchestrates monitor setup, ingress, and teardown.
 import { fanInChannelIngressLifecycles } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { isLoopbackHost } from "openclaw/plugin-sdk/gateway-runtime";
+import { createRuntimeConfigReader } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeOptionalString,
@@ -84,6 +84,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       },
     } satisfies RuntimeEnv);
   const cfg = (opts.config ?? core.config.current()) as OpenClawConfig;
+  const readConfig = createRuntimeConfigReader(cfg);
+  const resolveDebounceMs = () =>
+    core.channel.debounce.resolveInboundDebounceMs({
+      cfg: readConfig(),
+      channel: "mattermost",
+    });
   const account = resolveMattermostAccount({ cfg, accountId: opts.accountId });
   const pairing = createChannelPairingController({
     core,
@@ -245,10 +251,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     payload: MattermostEventPayload;
     turnAdoptionLifecycle: MattermostIngressLifecycle;
   }>({
-    debounceMs: core.channel.debounce.resolveInboundDebounceMs({
-      cfg,
-      channel: "mattermost",
-    }),
+    debounceMs: resolveDebounceMs(),
+    resolveDebounceMs,
     buildKey: (entry) => {
       const channelId =
         entry.post.channel_id ??

--- a/extensions/msteams/src/channel.setup.ts
+++ b/extensions/msteams/src/channel.setup.ts
@@ -1,4 +1,3 @@
-// Msteams plugin module implements channel.setup behavior.
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import {
@@ -23,7 +22,7 @@ export const msteamsSetupPlugin: ChannelPlugin<ResolvedMSTeamsAccount> = {
     media: true,
     reactions: true,
   },
-  reload: { configPrefixes: ["channels.msteams"] },
+  reload: { configPrefixes: ["channels.msteams"], noopPrefixes: ["messages.inbound"] },
   configSchema: MSTeamsChannelConfigSchema,
   config: {
     ...msteamsConfigAdapter,

--- a/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ingress-lifecycle.test.ts
@@ -2,12 +2,19 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "openclaw/plugin-sdk/channel-inbound-debounce";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/channel-ingress-test-runtime";
 import { DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../runtime-api.js";
 import { createMSTeamsIngress } from "../msteams-ingress.js";
@@ -75,6 +82,66 @@ function createHandler(cfg: OpenClawConfig) {
 describe("Microsoft Teams drain claim ownership", () => {
   beforeEach(() => {
     runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher.mockClear();
+  });
+
+  it("changes batching timing without replacing the Microsoft Teams handler", async () => {
+    const cfg: OpenClawConfig = {
+      messages: { inbound: { debounceMs: 0 } },
+      channels: { msteams: { dmPolicy: "open", allowFrom: ["*"] } },
+    };
+    setRuntimeConfigSnapshot(cfg, cfg);
+    const debouncers: Array<{ drain: () => Promise<void> }> = [];
+    const createDebouncer: typeof createInboundDebouncer = (options) => {
+      const debouncer = createInboundDebouncer(options);
+      debouncers.push(debouncer);
+      return debouncer;
+    };
+    const { deps } = createMessageHandlerDeps(cfg, {
+      createInboundDebouncer: createDebouncer,
+      resolveInboundDebounceMs,
+    });
+    const handler = createMSTeamsMessageHandler(deps);
+    const dispatch = runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher;
+    const publish = (debounceMs: number) => {
+      const current = { ...cfg, messages: { inbound: { debounceMs } } };
+      setRuntimeConfigSnapshot(current, current);
+    };
+    try {
+      await handler(context(directActivity("initial", "immediate")), createLifecycle());
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      publish(250);
+      const started = performance.now();
+      await handler(context(directActivity("first", "part one")), createLifecycle());
+      await handler(context(directActivity("second", "part two")), createLifecycle());
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(2));
+      const delayedElapsedMs = performance.now() - started;
+      expect(dispatch).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          ctx: expect.objectContaining({
+            BodyForAgent: expect.stringContaining("part one\npart two"),
+          }),
+        }),
+      );
+      publish(0);
+      await handler(context(directActivity("last", "after disable")), createLifecycle());
+      expect(dispatch).toHaveBeenCalledTimes(3);
+      console.log(
+        "MONITOR_DEBOUNCE_PROOF " +
+          JSON.stringify({
+            channel: "msteams",
+            pid: process.pid,
+            clock: "real",
+            delaysMs: [0, 250, 0],
+            delayedElapsedMs,
+            dispatches: dispatch.mock.calls.length,
+            debouncersCreated: debouncers.length,
+          }),
+      );
+    } finally {
+      await Promise.all(debouncers.map((debouncer) => debouncer.drain()));
+      clearRuntimeConfigSnapshot();
+    }
   });
 
   it("defers a claimed activity and binds completion to reply adoption", async () => {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -1,4 +1,3 @@
-// Msteams plugin module implements message handler behavior.
 import {
   formatMediaPlaceholderText,
   resolveInboundMentionDecision,
@@ -10,6 +9,7 @@ import {
   createChannelHistoryWindow,
   type HistoryEntry,
 } from "openclaw/plugin-sdk/reply-history";
+import { createRuntimeConfigReader } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatUnknownError } from "../errors.js";
 import { normalizeMSTeamsConversationId, parseMSTeamsActivityTimestamp } from "../inbound.js";
@@ -60,10 +60,9 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       DEFAULT_GROUP_HISTORY_LIMIT,
   );
   const conversationHistories = new Map<string, HistoryEntry[]>();
-  const inboundDebounceMs = core.channel.debounce.resolveInboundDebounceMs({
-    cfg,
-    channel: "msteams",
-  });
+  const readConfig = createRuntimeConfigReader(cfg);
+  const resolveDebounceMs = () =>
+    core.channel.debounce.resolveInboundDebounceMs({ cfg: readConfig(), channel: "msteams" });
 
   const handleTeamsMessageNow = async (params: MSTeamsDebounceEntry) => {
     const facts = assembleMSTeamsInboundFacts({ entry: params, mediaMaxBytes });
@@ -296,7 +295,8 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
   };
 
   const inboundDebouncer = core.channel.debounce.createInboundDebouncer<MSTeamsDebounceEntry>({
-    debounceMs: inboundDebounceMs,
+    debounceMs: resolveDebounceMs(),
+    resolveDebounceMs,
     buildKey: (entry) => {
       const conversationId = normalizeMSTeamsConversationId(
         entry.context.activity.conversation?.id ?? "",

--- a/extensions/signal/src/monitor/event-handler.control-lane.test.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.test.ts
@@ -1,6 +1,10 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -125,16 +129,18 @@ function holdNextDispatch() {
   return gate.resolve;
 }
 
-function createHandler(debounceMs: number) {
+function createHandler(debounceMs: number, config?: OpenClawConfig) {
   pendingDebounceMs = Math.max(pendingDebounceMs, debounceMs);
   const dmPolicy = "allowlist";
   const allowFrom = ["+15550001111"];
   return createSignalEventHandler(
     createBaseSignalEventHandlerDeps({
-      cfg: {
-        messages: { inbound: { debounceMs } },
-        channels: { signal: { dmPolicy, allowFrom } },
-      } as OpenClawConfig,
+      cfg:
+        config ??
+        ({
+          messages: { inbound: { debounceMs } },
+          channels: { signal: { dmPolicy, allowFrom } },
+        } as OpenClawConfig),
       dmPolicy,
       allowFrom,
       historyLimit: 0,
@@ -193,6 +199,7 @@ describe("Signal active-run control lane", () => {
       await Promise.all(pendingTasks.splice(0));
     } finally {
       pendingDebounceMs = 0;
+      clearRuntimeConfigSnapshot();
       vi.useRealTimers();
     }
   });
@@ -204,6 +211,37 @@ describe("Signal active-run control lane", () => {
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
 
     expect(dispatchedCommandBody(0)).toBe("first\nsecond");
+  });
+
+  it("updates Signal batching while keeping stop on the immediate control lane", async () => {
+    const cfg: OpenClawConfig = {
+      messages: { inbound: { debounceMs: 0 } },
+      channels: { signal: { dmPolicy: "allowlist", allowFrom: ["+15550001111"] } },
+    };
+    setRuntimeConfigSnapshot(cfg, cfg);
+    const handler = createHandler(25, cfg);
+    const publish = (debounceMs: number) => {
+      const current = { ...cfg, messages: { inbound: { byChannel: { signal: debounceMs } } } };
+      setRuntimeConfigSnapshot(current, current);
+    };
+    await handler(signalText("immediate", 1));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    publish(25);
+    await handler(signalText("first", 2));
+    await handler(signalText("second", 3));
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(25);
+    expect(dispatchedCommandBody(1)).toBe("first\nsecond");
+    publish(0);
+    await handler(signalText("after disable", 4));
+    expect(dispatchedCommandBody(2)).toBe("after disable");
+    publish(25);
+    await handler(signalText("pending", 5));
+    await handler(signalText("stop", 6));
+    expect(dispatchedCommandBody(3)).toBe("stop");
+    await vi.advanceTimersByTimeAsync(25);
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(4);
   });
 
   it.each([

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -16,6 +16,7 @@ import {
   buildMentionRegexes,
   buildChannelInboundEventContext,
   createChannelInboundDebouncer,
+  resolveInboundDebounceMs,
   formatInboundMediaUnavailableText,
   formatInboundEnvelope,
   formatInboundFromLabel,
@@ -820,6 +821,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   const { debouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
     cfg: deps.cfg,
     channel: "signal",
+    resolveDebounceMs: (entry) => resolveInboundDebounceMs({ cfg: entry.cfg, channel: "signal" }),
     buildKey: (entry) => resolveSignalInboundDebounceKey(deps.accountId, entry),
     shouldDebounce: (entry) =>
       shouldDebounceTextInbound({

--- a/extensions/signal/src/shared.ts
+++ b/extensions/signal/src/shared.ts
@@ -1,4 +1,3 @@
-// Signal plugin module implements shared behavior.
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import {
   adaptScopedAccountAccessor,
@@ -112,7 +111,10 @@ export function createSignalPluginBase(params: {
     streaming: {
       blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
     },
-    reload: { configPrefixes: ["channels.signal"] },
+    reload: {
+      configPrefixes: ["channels.signal"],
+      noopPrefixes: ["messages.inbound", "messages.ackReactionScope"],
+    },
     configSchema: SignalChannelConfigSchema,
     doctor: signalDoctor,
     config: {

--- a/extensions/slack/src/channel.setup.ts
+++ b/extensions/slack/src/channel.setup.ts
@@ -1,4 +1,3 @@
-// Slack plugin module implements channel.setup behavior.
 import { isSlackSetupAccountConfigured } from "./account-configured.js";
 import type { ResolvedSlackAccount } from "./accounts.js";
 import type { ChannelPlugin } from "./channel-api.js";
@@ -42,7 +41,10 @@ export const slackSetupPlugin: ChannelPlugin<ResolvedSlackAccount> = {
   streaming: {
     blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
   },
-  reload: { configPrefixes: ["channels.slack"] },
+  reload: {
+    configPrefixes: ["channels.slack"],
+    noopPrefixes: ["messages.inbound", "messages.ackReactionScope"],
+  },
   configSchema: SlackChannelConfigSchema,
   config: {
     ...slackBaseConfigAdapter,

--- a/extensions/slack/src/monitor/message-handler.debounce-policy.test.ts
+++ b/extensions/slack/src/monitor/message-handler.debounce-policy.test.ts
@@ -1,0 +1,100 @@
+import { App } from "@slack/bolt";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { expect, it, vi } from "vitest";
+import { resolveSlackAccount } from "../accounts.js";
+import type { SlackMessageEvent } from "../types.js";
+import { createSlackMonitorContext } from "./context.js";
+import { createSlackMessageHandler } from "./message-handler.js";
+
+const prepare = vi.hoisted(() => vi.fn(async (_params: { message: SlackMessageEvent }) => null));
+vi.mock("./message-handler/pipeline.runtime.js", () => ({
+  prepareSlackMessage: prepare,
+  dispatchPreparedSlackMessage: vi.fn(),
+}));
+
+it("updates Slack delay and flushes newly buffered top-level keys before immediate work", async () => {
+  const cfg: OpenClawConfig = { messages: { inbound: { debounceMs: 0 } } };
+  setRuntimeConfigSnapshot(cfg, cfg);
+  prepare.mockClear();
+  const app = new App({
+    token: "synthetic-token",
+    signingSecret: "synthetic-signing-secret",
+    tokenVerificationEnabled: false,
+  });
+  const abort = new AbortController();
+  const handler = createSlackMessageHandler({
+    ctx: createSlackMonitorContext({
+      cfg,
+      accountId: "default",
+      app,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      botToken: "synthetic-token",
+      botUserId: "BOT",
+      identityHealth: { lifecycle: "ready", lastError: null },
+      teamId: "TEAM",
+      apiAppId: "APP",
+      historyLimit: 0,
+      sessionScope: "per-sender",
+      mainKey: "main",
+      dmEnabled: true,
+      dmPolicy: "open",
+      allowFrom: [],
+      allowNameMatching: false,
+      groupDmEnabled: false,
+      groupDmChannels: [],
+      groupPolicy: "open",
+      useAccessGroups: true,
+      reactionMode: "off",
+      reactionAllowlist: [],
+      replyToMode: "off",
+      threadHistoryScope: "thread",
+      threadInheritParent: false,
+      slashCommand: {
+        enabled: false,
+        name: "openclaw",
+        ephemeral: true,
+        sessionPrefix: "slack:slash",
+      },
+      textLimit: 4000,
+      typingReaction: "",
+      mediaMaxBytes: 1024,
+    }),
+    account: resolveSlackAccount({ cfg, accountId: "default" }),
+    abortSignal: abort.signal,
+  });
+  let sequence = 0;
+  const enqueue = (text: string, channel = "D1") =>
+    handler(
+      { type: "message", channel, user: "USER", ts: `123.${++sequence}`, text },
+      { source: "message" },
+    );
+  const publish = (debounceMs: number) => {
+    const current = { messages: { inbound: { debounceMs } } };
+    setRuntimeConfigSnapshot(current, current);
+  };
+  const bodies = () => prepare.mock.calls.map(([params]) => params.message.text);
+  vi.useFakeTimers();
+  try {
+    await enqueue("immediate");
+    expect(bodies()).toEqual(["immediate"]);
+    publish(25);
+    await enqueue("first");
+    await enqueue("second");
+    expect(bodies()).toEqual(["immediate"]);
+    await vi.advanceTimersByTimeAsync(25);
+    expect(bodies()).toEqual(["immediate", "first\nsecond"]);
+    await enqueue("pending top level", "C1");
+    publish(0);
+    await enqueue("after disable", "C1");
+    expect(bodies()).toEqual(["immediate", "first\nsecond", "pending top level", "after disable"]);
+  } finally {
+    abort.abort();
+    await vi.runOnlyPendingTimersAsync();
+    vi.useRealTimers();
+    clearRuntimeConfigSnapshot();
+  }
+});

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -505,7 +505,7 @@ describe("createSlackMessageHandler", () => {
 
   it("flushes pending top-level buffered keys before immediate non-debounce follow-ups", async () => {
     const handler = createSlackMessageHandler({
-      ctx: createContext(),
+      ctx: createContext({ cfg: { messages: { inbound: { debounceMs: 10 } } } }),
       account: { accountId: "default" } as Parameters<
         typeof createSlackMessageHandler
       >[0]["account"],
@@ -539,7 +539,7 @@ describe("createSlackMessageHandler", () => {
 
   it("flushes buffered text before a table-bearing message", async () => {
     const handler = createSlackMessageHandler({
-      ctx: createContext(),
+      ctx: createContext({ cfg: { messages: { inbound: { debounceMs: 10 } } } }),
       account: { accountId: "default" } as Parameters<
         typeof createSlackMessageHandler
       >[0]["account"],
@@ -581,7 +581,7 @@ describe("createSlackMessageHandler", () => {
 
   it("retires a buffered key when replay filtering drops every entry", async () => {
     const handler = createSlackMessageHandler({
-      ctx: createContext(),
+      ctx: createContext({ cfg: { messages: { inbound: { debounceMs: 10 } } } }),
       account: { accountId: "default" } as Parameters<
         typeof createSlackMessageHandler
       >[0]["account"],

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -1,6 +1,6 @@
-// Slack plugin module implements message handler behavior.
 import {
   createChannelInboundDebouncer,
+  resolveInboundDebounceMs,
   shouldDebounceTextInbound,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -116,13 +116,15 @@ export function createSlackMessageHandler(params: {
           `slack message dispatch dedupe persistence failed: ${formatErrorMessage(error)}`,
         ),
     });
-  const { debounceMs, debouncer } = createChannelInboundDebouncer<{
+  const { debouncer } = createChannelInboundDebouncer<{
     message: SlackMessageEvent;
     opts: QueuedSlackMessageOptions;
+    debounceMs: number;
   }>({
     cfg: ctx.cfg,
     channel: "slack",
     serializeImmediate: true,
+    resolveDebounceMs: (entry) => entry.debounceMs,
     buildKey: (entry) =>
       buildSlackDebounceKey(entry.message, ctx.accountId, entry.opts.eventScope?.teamId),
     shouldDebounce: (entry) =>
@@ -415,6 +417,8 @@ export function createSlackMessageHandler(params: {
       ctx.accountId,
       teamId,
     );
+    // Pending-key tracking and enqueue must agree even if flushing another key awaits.
+    const debounceMs = resolveInboundDebounceMs({ cfg: readConfig(), channel: "slack" });
     const canDebounce =
       !opts.eventScope && debounceMs > 0 && shouldDebounceSlackMessage(resolvedMessage, ctx.cfg);
     if (!canDebounce && conversationKey) {
@@ -433,6 +437,7 @@ export function createSlackMessageHandler(params: {
     }
     const dispatchCompletion = opts.awaitDispatch ? createDeferred<void>() : undefined;
     await debouncer.enqueue({
+      debounceMs,
       message: resolvedMessage,
       opts: {
         ...opts,

--- a/extensions/telegram/src/bot-handlers.inbound-buffer.provenance.test.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-buffer.provenance.test.ts
@@ -1,88 +1,104 @@
 import type { Message } from "grammy/types";
-import { describe, expect, it, vi } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTelegramInboundBuffers } from "./bot-handlers.inbound-buffer.js";
 import type { TelegramMessagePipeline } from "./bot-handlers.message-pipeline.js";
 import type { TelegramContext } from "./bot/types.js";
 import { createTelegramIngressResolver, createTelegramIngressSubject } from "./ingress.js";
 
 describe("Telegram inbound provenance buffering", () => {
-  it("preserves every exact authorization resolver through debounce collection", async () => {
-    const processMessageWithReplyChain = vi.fn<
-      TelegramMessagePipeline["processMessageWithReplyChain"]
-    >(async () => ({ kind: "completed" as const }));
-    const message = {
-      promptContextBoundaryOptions: () => ({}),
-      latestPromptContextMinTimestampMs: () => undefined,
-      latestPromptContextAmbientWatermark: () => undefined,
-      mergeDispatchDedupeClaims: () => [],
-      releaseDispatchDedupeClaims: () => undefined,
-      buildFailedProcessingResult: (error: unknown) => ({ kind: "failed-retryable", error }),
-      settleSpooledReplayParticipants: () => undefined,
-      createSpooledReplayParticipantForBufferedWork: () => undefined,
-      spooledReplayOptions: () => ({}),
-      buildSyntheticTextMessage: ({ base, text }: { base: Message; text: string }) => ({
-        ...base,
-        text,
-      }),
-      buildSyntheticContext: (ctx: TelegramContext, syntheticMessage: Message) => ({
-        ...ctx,
-        message: syntheticMessage,
-      }),
-      formatTelegramAmbientTranscriptBody: () => undefined,
-      processMessageWithReplyChain,
-    } as unknown as TelegramMessagePipeline;
-    const { inboundDebouncer } = createTelegramInboundBuffers({
-      params: {
-        cfg: { messages: { inbound: { debounceMs: 50 } } },
-        bot: { api: { sendMessage: vi.fn() } } as never,
-        runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
-        opts: { token: "test-token" },
-      },
-      message,
-    });
-    const resolver = createTelegramIngressResolver({ accountId: "default" });
-    const ingress = await Promise.all([
-      resolver.message({
-        subject: createTelegramIngressSubject("42"),
-        conversation: { kind: "direct", id: "42" },
-        dmPolicy: "open",
-      }),
-      resolver.message({
-        subject: createTelegramIngressSubject("42"),
-        conversation: { kind: "direct", id: "42" },
-        dmPolicy: "open",
-      }),
-    ]);
-    const ingressResolvers = ingress.map((result) => async () => await Promise.resolve(result));
-    const baseMessage = {
-      message_id: 1,
-      date: 1,
-      chat: { id: 42, type: "private", first_name: "Alice" },
-      from: { id: 42, is_bot: false, first_name: "Alice" },
-      text: "hello",
-    } as Message;
-    const ctx = { message: baseMessage } as TelegramContext;
+  afterEach(() => clearRuntimeConfigSnapshot());
 
-    for (const [index, channelIngressResolver] of ingressResolvers.entries()) {
-      await inboundDebouncer.enqueue({
-        ctx,
-        msg: { ...baseMessage, message_id: index + 1, text: `message ${index + 1}` },
-        allMedia: [],
-        storeAllowFrom: [],
-        receivedAtMs: index + 1,
-        debounceKey: "telegram:default:42:42:default",
-        debounceLane: "default",
-        threadSpec: { scope: "none" },
-        dispatchDedupeClaims: [],
-        channelIngressResolvers: [channelIngressResolver],
+  it.each([false, true])(
+    "preserves every authorization resolver through collection (hot reload: %s)",
+    async (reload) => {
+      const cfg = { messages: { inbound: { debounceMs: reload ? 0 : 50 } } };
+      setRuntimeConfigSnapshot(cfg, cfg);
+      const processMessageWithReplyChain = vi.fn<
+        TelegramMessagePipeline["processMessageWithReplyChain"]
+      >(async () => ({ kind: "completed" as const }));
+      const message = {
+        promptContextBoundaryOptions: () => ({}),
+        latestPromptContextMinTimestampMs: () => undefined,
+        latestPromptContextAmbientWatermark: () => undefined,
+        mergeDispatchDedupeClaims: () => [],
+        releaseDispatchDedupeClaims: () => undefined,
+        buildFailedProcessingResult: (error: unknown) => ({ kind: "failed-retryable", error }),
+        settleSpooledReplayParticipants: () => undefined,
+        createSpooledReplayParticipantForBufferedWork: () => undefined,
+        spooledReplayOptions: () => ({}),
+        buildSyntheticTextMessage: ({ base, text }: { base: Message; text: string }) => ({
+          ...base,
+          text,
+        }),
+        buildSyntheticContext: (ctx: TelegramContext, syntheticMessage: Message) => ({
+          ...ctx,
+          message: syntheticMessage,
+        }),
+        formatTelegramAmbientTranscriptBody: () => undefined,
+        processMessageWithReplyChain,
+      } as unknown as TelegramMessagePipeline;
+      const { inboundDebouncer } = createTelegramInboundBuffers({
+        params: {
+          cfg,
+          bot: { api: { sendMessage: vi.fn() } } as never,
+          runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+          opts: { token: "test-token" },
+        },
+        message,
       });
-    }
-    await inboundDebouncer.drain();
+      if (reload) {
+        const current = { messages: { inbound: { byChannel: { telegram: 50 } } } };
+        setRuntimeConfigSnapshot(current, current);
+      }
+      const resolver = createTelegramIngressResolver({ accountId: "default" });
+      const ingress = await Promise.all([
+        resolver.message({
+          subject: createTelegramIngressSubject("42"),
+          conversation: { kind: "direct", id: "42" },
+          dmPolicy: "open",
+        }),
+        resolver.message({
+          subject: createTelegramIngressSubject("42"),
+          conversation: { kind: "direct", id: "42" },
+          dmPolicy: "open",
+        }),
+      ]);
+      const ingressResolvers = ingress.map((result) => async () => await Promise.resolve(result));
+      const baseMessage = {
+        message_id: 1,
+        date: 1,
+        chat: { id: 42, type: "private", first_name: "Alice" },
+        from: { id: 42, is_bot: false, first_name: "Alice" },
+        text: "hello",
+      } as Message;
+      const ctx = { message: baseMessage } as TelegramContext;
 
-    const carried =
-      processMessageWithReplyChain.mock.calls[0]?.[0]?.options?.channelIngressResolvers;
-    expect(carried).toEqual(ingressResolvers);
-    expect(carried?.[0]).toBe(ingressResolvers[0]);
-    expect(carried?.[1]).toBe(ingressResolvers[1]);
-  });
+      for (const [index, channelIngressResolver] of ingressResolvers.entries()) {
+        await inboundDebouncer.enqueue({
+          ctx,
+          msg: { ...baseMessage, message_id: index + 1, text: `message ${index + 1}` },
+          allMedia: [],
+          storeAllowFrom: [],
+          receivedAtMs: index + 1,
+          debounceKey: "telegram:default:42:42:default",
+          debounceLane: "default",
+          threadSpec: { scope: "none" },
+          dispatchDedupeClaims: [],
+          channelIngressResolvers: [channelIngressResolver],
+        });
+      }
+      await inboundDebouncer.drain();
+
+      expect(processMessageWithReplyChain).toHaveBeenCalledTimes(1);
+      const carried =
+        processMessageWithReplyChain.mock.calls[0]?.[0]?.options?.channelIngressResolvers;
+      expect(carried).toEqual(ingressResolvers);
+      expect(carried?.[0]).toBe(ingressResolvers[0]);
+      expect(carried?.[1]).toBe(ingressResolvers[1]);
+    },
+  );
 });

--- a/extensions/telegram/src/bot-handlers.inbound-buffer.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-buffer.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { createRuntimeConfigReader } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { TelegramMessagePipeline } from "./bot-handlers.message-pipeline.js";
 import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
@@ -105,10 +106,12 @@ export function createTelegramInboundBuffers({
     formatTelegramAmbientTranscriptBody,
     processMessageWithReplyChain,
   } = message;
-  const debounceMs = resolveInboundDebounceMs({ cfg, channel: "telegram" });
+  const readConfig = createRuntimeConfigReader(cfg);
+  const resolveDebounceMs = () =>
+    resolveInboundDebounceMs({ cfg: readConfig(), channel: "telegram" });
   const FORWARD_BURST_DEBOUNCE_MS = 80;
   const resolveTelegramDebounceEntryMs = (entry: TelegramDebounceEntry): number =>
-    entry.debounceLane === "forward" ? FORWARD_BURST_DEBOUNCE_MS : debounceMs;
+    entry.debounceLane === "forward" ? FORWARD_BURST_DEBOUNCE_MS : resolveDebounceMs();
   const shouldDebounceTelegramEntry = (entry: TelegramDebounceEntry): boolean => {
     const hasDebounceableText = shouldDebounceTextInbound({
       text: getTelegramTextParts(entry.msg).text,
@@ -137,7 +140,7 @@ export function createTelegramInboundBuffers({
       : "default";
   };
   const inboundDebouncer = createInboundDebouncer<TelegramDebounceEntry>({
-    debounceMs,
+    debounceMs: resolveDebounceMs(),
     serializeImmediate: true,
     resolveDebounceMs: resolveTelegramDebounceEntryMs,
     buildKey: (entry) => entry.debounceKey,

--- a/extensions/telegram/src/setup-plugin.ts
+++ b/extensions/telegram/src/setup-plugin.ts
@@ -1,4 +1,3 @@
-// Telegram plugin module composes the setup-safe channel surface.
 import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { getChatChannelMeta } from "openclaw/plugin-sdk/channel-plugin-common";
 import type { ResolvedTelegramAccount } from "./accounts.js";
@@ -46,7 +45,10 @@ export function createTelegramSetupPluginBase(params: {
       nativeCommands: true,
       blockStreaming: true,
     },
-    reload: { configPrefixes: ["channels.telegram"] },
+    reload: {
+      configPrefixes: ["channels.telegram"],
+      noopPrefixes: ["messages.inbound", "messages.ackReactionScope"],
+    },
     configSchema: TelegramChannelConfigSchema,
     config: createTelegramPluginConfig(),
     secrets: {

--- a/extensions/whatsapp/index.test.ts
+++ b/extensions/whatsapp/index.test.ts
@@ -10,7 +10,7 @@ describe("whatsapp bundled entries", () => {
         "channels.whatsapp.accounts",
         "channels.whatsapp.selfChatMode",
       ],
-      noopPrefixes: ["channels.whatsapp"],
+      noopPrefixes: ["channels.whatsapp", "messages.inbound", "messages.ackReactionScope"],
     });
   });
 });

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -825,40 +825,46 @@ describe("web auto-reply connection", () => {
     scenario.assertAfterRun?.(context);
   });
 
-  it("passes the global inbound debounce into the live listener", async () => {
-    const capture = createWebListenerFactoryCapture();
+  it.each([undefined, 75])(
+    "keeps live debounce config and explicit transport override (%s)",
+    async (debounceMs) => {
+      const capture = createWebListenerFactoryCapture();
 
-    setLoadConfigMock({
-      messages: {
-        inbound: {
-          debounceMs: 250,
+      setLoadConfigMock({
+        messages: {
+          inbound: {
+            debounceMs: 250,
+          },
         },
-      },
-      channels: {
-        whatsapp: {
-          accounts: {
-            work: {
-              authDir: "/tmp/work",
+        channels: {
+          whatsapp: {
+            accounts: {
+              work: {
+                authDir: "/tmp/work",
+              },
             },
           },
         },
-      },
-    } as OpenClawConfig);
-    await monitorWebChannel(
-      false,
-      capture.listenerFactory as never,
-      false,
-      async () => ({ text: "ok" }),
-      undefined,
-      undefined,
-      {
-        accountId: "work",
-      },
-    );
+      } as OpenClawConfig);
+      await monitorWebChannel(
+        false,
+        capture.listenerFactory as never,
+        false,
+        async () => ({ text: "ok" }),
+        undefined,
+        undefined,
+        {
+          accountId: "work",
+          debounceMs,
+        },
+      );
 
-    resetLoadConfigMock();
-    expect(capture.getLastOptions()?.debounceMs).toBe(250);
-  });
+      resetLoadConfigMock();
+      expect(capture.getLastOptions()?.debounceMs).toBe(debounceMs);
+      expect(capture.getLastOptions()?.cfg.messages?.inbound?.debounceMs).toBe(250);
+      expect(capture.getLastOptions()?.loadConfig).toEqual(expect.any(Function));
+    },
+  );
 
   it("raises the process listener budget before opening the web listener", async () => {
     const originalMax = process.getMaxListeners();

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -3,7 +3,6 @@ import type { WAMessageKey } from "baileys";
 import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 import { shouldDebounceTextInbound } from "openclaw/plugin-sdk/channel-inbound";
-import { resolveInboundDebounceMs } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
@@ -223,10 +222,6 @@ export async function monitorWebChannel(
       }
 
       const connectionId = newConnectionId();
-      const inboundDebounceMs = resolveInboundDebounceMs({
-        cfg,
-        channel: "whatsapp",
-      });
       const shouldDebounce = (msg: WebInboundCallbackMessage) =>
         shouldDebounceTextInbound({
           text: msg.payload.commandBody ?? msg.payload.body,
@@ -280,7 +275,7 @@ export async function monitorWebChannel(
               selfChatMode: account.selfChatMode,
               sendReadReceipts: account.sendReadReceipts,
               socketTiming,
-              debounceMs: inboundDebounceMs,
+              debounceMs: tuning.debounceMs,
               appendReplyWindow: connectionLocal.openedAfterRecentInbound
                 ? {
                     afterMs: connectionLocal.startedAt - reconnectCatchUpWindowMs,

--- a/extensions/whatsapp/src/inbound/message-debounce.ts
+++ b/extensions/whatsapp/src/inbound/message-debounce.ts
@@ -1,4 +1,3 @@
-// Whatsapp plugin module owns inbound debounce batching and flush lifecycle.
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { fanInChannelIngressLifecycles } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { getPrimaryIdentityId } from "../identity.js";
@@ -16,14 +15,13 @@ export type WhatsAppQueuedInboundMessage = AdmittedWebInboundCallbackMessage & {
 };
 
 export function createWhatsAppInboundMessageDebouncer(options: {
-  debounceMs?: number;
+  resolveDebounceMs: () => number;
   onMessage: (msg: AdmittedWebInboundCallbackMessage) => Promise<void>;
   shouldDebounce?: (msg: AdmittedWebInboundCallbackMessage) => boolean;
   markRead: (target: WhatsAppReadReceiptTarget | undefined) => Promise<void>;
   onPendingWorkChanged: () => void;
   onError: (error: unknown) => void;
 }) {
-  const debounceMs = Math.max(0, Math.trunc(options.debounceMs ?? 0));
   const pendingKeys = new Map<string, number>();
   const activeFlushes = new Set<Promise<void>>();
   // Close waits wake as soon as a queued key becomes flushable, avoiding
@@ -71,8 +69,9 @@ export function createWhatsAppInboundMessageDebouncer(options: {
       return timestampDiff !== 0 ? timestampDiff : (a.receiveOrder ?? 0) - (b.receiveOrder ?? 0);
     });
 
-  const debouncer = createInboundDebouncer<WhatsAppQueuedInboundMessage>({
-    debounceMs,
+  const debouncer = createInboundDebouncer<WhatsAppQueuedInboundMessage & { debounceMs: number }>({
+    debounceMs: options.resolveDebounceMs(),
+    resolveDebounceMs: (entry) => entry.debounceMs,
     buildKey: (msg) => msg.debounceKey ?? buildKey(msg),
     shouldDebounce,
     onFlush: (entries, createFlush) => {
@@ -155,11 +154,13 @@ export function createWhatsAppInboundMessageDebouncer(options: {
     onError: options.onError,
   });
 
-  const enqueue = async (message: WhatsAppQueuedInboundMessage) => {
+  const enqueue = async (input: WhatsAppQueuedInboundMessage) => {
+    // Use one timing fact for both queue admission and shutdown tracking.
+    const message = { ...input, debounceMs: options.resolveDebounceMs() };
     const key = buildKey(message);
     if (key) {
       message.debounceKey = key;
-      if (debounceMs > 0 && shouldDebounce(message)) {
+      if (message.debounceMs > 0 && shouldDebounce(message)) {
         message.debounceKeyTracked = true;
         trackKey(key);
         options.onPendingWorkChanged();

--- a/extensions/whatsapp/src/inbound/message-delivery.ts
+++ b/extensions/whatsapp/src/inbound/message-delivery.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import type { AnyMessageContent, MiscMessageGenerationOptions, WAMessage, WASocket } from "baileys";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
+import { resolveInboundDebounceMs } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { getChildLogger } from "openclaw/plugin-sdk/logging-core";
 import { parseStrictFiniteNumber } from "openclaw/plugin-sdk/number-runtime";
@@ -185,7 +186,12 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
     await maybeMarkInboundAsRead(target);
   };
   const messageDebouncer = createWhatsAppInboundMessageDebouncer({
-    debounceMs: options.debounceMs,
+    resolveDebounceMs: () =>
+      resolveInboundDebounceMs({
+        cfg: options.loadConfig?.() ?? options.cfg,
+        channel: "whatsapp",
+        overrideMs: options.debounceMs,
+      }),
     onMessage: options.onMessage,
     shouldDebounce: options.shouldDebounce,
     markRead: maybeMarkInboundAsRead,

--- a/extensions/whatsapp/src/monitor-inbox.debounce-policy.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.debounce-policy.test.ts
@@ -1,0 +1,66 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { expect, it, vi } from "vitest";
+import {
+  buildNotifyMessageUpsert,
+  installWebMonitorInboxUnitTestHooks,
+  settleInboundWork,
+  startInboxMonitor,
+  waitForMessageCalls,
+  type InboxOnMessage,
+} from "./monitor-inbox.test-harness.js";
+
+installWebMonitorInboxUnitTestHooks();
+
+it("updates WhatsApp timing and drains batches enabled after socket attachment", async () => {
+  let cfg: OpenClawConfig = {
+    channels: { whatsapp: { allowFrom: ["*"] } },
+    messages: { inbound: { debounceMs: 0 } },
+  };
+  const onMessage = vi.fn<InboxOnMessage>(async () => {});
+  const { listener, sock } = await startInboxMonitor(onMessage, { cfg, loadConfig: () => cfg });
+  let sequence = 0;
+  const enqueue = (text: string) => {
+    sequence += 1;
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: `hot-debounce-${sequence}`,
+        remoteJid: "999@s.whatsapp.net",
+        text,
+        timestamp: 1_700_000_000 + sequence,
+      }),
+    );
+  };
+  const publish = (debounceMs: number) => {
+    cfg = { ...cfg, messages: { inbound: { byChannel: { whatsapp: debounceMs } } } };
+  };
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date", "performance"] });
+  try {
+    enqueue("immediate");
+    await waitForMessageCalls(onMessage, 1);
+    publish(60_000);
+    enqueue("first");
+    await settleInboundWork();
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    publish(0);
+    await vi.advanceTimersByTimeAsync(60_000);
+    await waitForMessageCalls(onMessage, 2);
+    enqueue("after disable");
+    await waitForMessageCalls(onMessage, 3);
+    expect(onMessage.mock.calls.map(([message]) => message.payload.body)).toEqual([
+      "immediate",
+      "first",
+      "after disable",
+    ]);
+    publish(60_000);
+    enqueue("pending at close");
+    await settleInboundWork();
+    expect(onMessage).toHaveBeenCalledTimes(3);
+  } finally {
+    await listener.close();
+    vi.useRealTimers();
+  }
+  expect(onMessage).toHaveBeenCalledTimes(4);
+  expect(onMessage.mock.calls.at(-1)?.[0].payload.body).toBe("pending at close");
+  expect(sock.end).toHaveBeenCalledTimes(1);
+});

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -1,4 +1,3 @@
-// Whatsapp plugin module implements shared behavior.
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import { normalizeE164 } from "openclaw/plugin-sdk/account-resolution";
 import {
@@ -190,7 +189,7 @@ export function createWhatsAppPluginBase(params: {
         "channels.whatsapp.accounts",
         "channels.whatsapp.selfChatMode",
       ],
-      noopPrefixes: ["channels.whatsapp"],
+      noopPrefixes: ["channels.whatsapp", "messages.inbound", "messages.ackReactionScope"],
     },
     gatewayMethodDescriptors: [{ name: "web.login.start" }, { name: "web.login.wait" }],
     configSchema: WhatsAppChannelConfigSchema,

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -3,22 +3,8 @@ import {
   resolveNonNegativeIntegerOption,
   resolveOptionalIntegerOption,
 } from "@openclaw/normalization-core/number-coercion";
-import type { InboundDebounceByProvider } from "../config/types.messages.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { toErrorObject } from "../infra/errors.js";
-
-const resolveMs = (value: unknown): number | undefined =>
-  resolveOptionalIntegerOption(value, { min: 0 });
-
-const resolveChannelOverride = (params: {
-  byChannel?: InboundDebounceByProvider;
-  channel: string;
-}): number | undefined => {
-  if (!params.byChannel) {
-    return undefined;
-  }
-  return resolveMs(params.byChannel[params.channel]);
-};
 
 /** Resolve effective inbound debounce milliseconds from explicit, channel, and global config. */
 export function resolveInboundDebounceMs(params: {
@@ -27,13 +13,17 @@ export function resolveInboundDebounceMs(params: {
   overrideMs?: number;
 }): number {
   const inbound = params.cfg.messages?.inbound;
-  const override = resolveMs(params.overrideMs);
-  const byChannel = resolveChannelOverride({
-    byChannel: inbound?.byChannel,
-    channel: params.channel,
-  });
-  const base = resolveMs(inbound?.debounceMs);
-  return override ?? byChannel ?? base ?? 0;
+  for (const value of [
+    params.overrideMs,
+    inbound?.byChannel?.[params.channel],
+    inbound?.debounceMs,
+  ]) {
+    const resolved = resolveOptionalIntegerOption(value, { min: 0 });
+    if (resolved !== undefined) {
+      return resolved;
+    }
+  }
+  return 0;
 }
 
 type DebounceBuffer<T> = {

--- a/src/channels/inbound-debounce-policy.test.ts
+++ b/src/channels/inbound-debounce-policy.test.ts
@@ -1,5 +1,7 @@
 // Inbound debounce policy tests cover channel message coalescing and delay decisions.
 import { describe, expect, it, vi } from "vitest";
+import { resolveInboundDebounceMs } from "../auto-reply/inbound-debounce.js";
+import type { OpenClawConfig } from "../config/types.js";
 import {
   createChannelInboundDebouncer,
   shouldDebounceTextInbound,
@@ -28,41 +30,55 @@ describe("shouldDebounceTextInbound", () => {
 });
 
 describe("createChannelInboundDebouncer", () => {
-  it("resolves per-channel debounce and forwards callbacks", async () => {
-    vi.useFakeTimers();
-    try {
-      const flushed: string[][] = [];
-      const cfg = {
-        messages: {
-          inbound: {
-            debounceMs: 10,
-            byChannel: {
-              "demo-channel": 25,
+  it.each([false, true])(
+    "preserves snapshot timing unless an explicit reader is supplied (live: %s)",
+    async (live) => {
+      vi.useFakeTimers();
+      try {
+        const flushed: string[][] = [];
+        let cfg: OpenClawConfig = {
+          messages: {
+            inbound: {
+              debounceMs: 10,
+              byChannel: {
+                "demo-channel": 25,
+              },
             },
           },
-        },
-      } as Parameters<typeof createChannelInboundDebouncer<{ id: string }>>[0]["cfg"];
+        };
 
-      const { debounceMs, debouncer } = createChannelInboundDebouncer<{ id: string }>({
-        cfg,
-        channel: "demo-channel",
-        buildKey: (item) => item.id,
-        onFlush: (items) => {
-          flushed.push(items.map((entry) => entry.id));
-          const completion = Promise.resolve();
-          return { admission: completion, completion };
-        },
-      });
+        const { debounceMs, debouncer } = createChannelInboundDebouncer<{ id: string }>({
+          cfg,
+          channel: "demo-channel",
+          buildKey: (item) => item.id,
+          ...(live
+            ? {
+                resolveDebounceMs: () => resolveInboundDebounceMs({ cfg, channel: "demo-channel" }),
+              }
+            : {}),
+          onFlush: (items) => {
+            flushed.push(items.map((entry) => entry.id));
+            const completion = Promise.resolve();
+            return { admission: completion, completion };
+          },
+        });
 
-      expect(debounceMs).toBe(25);
+        expect(debounceMs).toBe(25);
 
-      await debouncer.enqueue({ id: "a" });
-      await debouncer.enqueue({ id: "a" });
-      await vi.advanceTimersByTimeAsync(30);
+        await debouncer.enqueue({ id: "a" });
+        await debouncer.enqueue({ id: "a" });
+        await vi.advanceTimersByTimeAsync(30);
 
-      expect(flushed).toEqual([["a", "a"]]);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+        expect(flushed).toEqual([["a", "a"]]);
+        cfg = { messages: { inbound: { debounceMs: 0 } } };
+        await debouncer.enqueue({ id: "b" });
+        expect(debounceMs).toBe(25);
+        expect(flushed).toEqual(live ? [["a", "a"], ["b"]] : [["a", "a"]]);
+        await vi.advanceTimersByTimeAsync(25);
+        expect(flushed).toEqual([["a", "a"], ["b"]]);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 });

--- a/src/channels/inbound-debounce-policy.ts
+++ b/src/channels/inbound-debounce-policy.ts
@@ -1,8 +1,4 @@
-/**
- * Channel inbound debounce policy.
- *
- * Decides when text events can be delayed/merged before agent dispatch.
- */
+// Channel policy for delaying and merging text before agent dispatch.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { isControlCommandMessage } from "../auto-reply/command-detection.js";
 import type { CommandNormalizeOptions } from "../auto-reply/commands-registry.js";
@@ -38,7 +34,7 @@ export function shouldDebounceTextInbound(params: {
   return !isControlCommandMessage(text, params.cfg, params.commandOptions);
 }
 
-/** Creates a channel-scoped inbound debouncer using config/default debounce timing. */
+/** Snapshot timing by default; resolveDebounceMs opts into per-entry timing. */
 export function createChannelInboundDebouncer<T>(
   params: Omit<InboundDebounceCreateParams<T>, "debounceMs"> & {
     cfg: OpenClawConfig;

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -86,6 +86,29 @@ type GatewayReloadPlanOptions = {
 
 const PLUGIN_INSTALL_TIMESTAMP_KEYS = ["installedAt", "resolvedAt"] as const;
 const AUTH_CREDENTIAL_PATHS = ["gateway.auth.token", "gateway.auth.password"];
+const SHARED_CHANNEL_PREFIXES = [
+  "agents.defaults.mediaMaxMb",
+  "channels.defaults",
+  "channels.modelByChannel",
+  "messages.inbound",
+  "messages.ackReactionScope",
+  "commands",
+  "accessGroups",
+  "tts",
+  "surfaces",
+  "acp.stream",
+  "diagnostics.flags",
+];
+
+function matchesReloadPrefix(path: string, prefix: string): boolean {
+  return path === prefix || path.startsWith(`${prefix}.`);
+}
+
+function expandReloadPolicies(policies: ReloadPolicy[]): ReloadRule[] {
+  return policies
+    .flatMap(({ prefixes, ...policy }) => prefixes.map((prefix) => ({ ...policy, prefix })))
+    .toSorted((a, b) => b.prefix.length - a.prefix.length);
+}
 
 const CORE_RELOAD_POLICIES: ReloadPolicy[] = [
   { prefixes: ["gateway.remote", "gateway.reload"], kind: "none" },
@@ -255,6 +278,24 @@ function getReloadPolicyCatalog() {
     prefixes: service.reload?.configPrefixes ?? [],
     services: [service.id],
   }));
+  const channelPolicies = channelPlugins.flatMap((plugin): ReloadPolicy[] => [
+    {
+      prefixes: plugin.reload?.configPrefixes ?? [],
+      kind: "hot",
+      channels: [plugin],
+      accountScoped: plugin.reload?.accountScopedRestart,
+    },
+    { prefixes: plugin.reload?.noopPrefixes ?? [], kind: "none", channels: [plugin] },
+  ]);
+  const channelRules = expandReloadPolicies(channelPolicies);
+  const sharedPrefixes = new Set([
+    ...SHARED_CHANNEL_PREFIXES,
+    ...channelRules
+      .filter(({ prefix }) =>
+        SHARED_CHANNEL_PREFIXES.some((root) => matchesReloadPrefix(prefix, root)),
+      )
+      .map(({ prefix }) => prefix),
+  ]);
   const policies: ReloadPolicy[] = [
     ...CORE_RELOAD_POLICIES,
     ...(registry?.reloads ?? []).flatMap(({ registration }) =>
@@ -266,53 +307,38 @@ function getReloadPolicyCatalog() {
         ] as const
       ).map(([kind, prefixes]) => ({ kind, prefixes: prefixes ?? [] })),
     ),
-    ...channelPlugins.flatMap((plugin): ReloadPolicy[] => [
-      {
-        prefixes: plugin.reload?.configPrefixes ?? [],
-        kind: "hot",
-        channels: [plugin],
-        accountScoped: plugin.reload?.accountScopedRestart,
-      },
-      { prefixes: plugin.reload?.noopPrefixes ?? [], kind: "none" },
-    ]),
+    // Shared policy belongs to every loaded channel. One owner's opt-out must
+    // not suppress sibling refreshes; undeclared owners remain restart-bound.
+    ...Array.from(sharedPrefixes, (prefix): ReloadPolicy => {
+      const channels = channelPlugins.filter(
+        (plugin) =>
+          channelRules.find(
+            (rule) => rule.channels?.includes(plugin) && matchesReloadPrefix(prefix, rule.prefix),
+          )?.kind !== "none",
+      );
+      const hasService = servicePolicies.some(({ prefixes }) =>
+        prefixes.some((owner) => matchesReloadPrefix(prefix, owner)),
+      );
+      return { prefixes: [prefix], kind: channels.length || hasService ? "hot" : "none", channels };
+    }),
+    ...channelPolicies,
     ...channelPlugins.map((plugin): ReloadPolicy => ({
       prefixes: [`plugins.entries.${plugin.id}`],
       kind: "hot",
       actions: ["reloadPlugins", "disposeMcpRuntimes"],
       channels: [plugin],
     })),
-    // Channel snapshots capture shared policy. Fan out by default while
-    // preserving explicit plugin/channel policies above on equal-prefix ties.
-    {
-      prefixes: [
-        "agents.defaults.mediaMaxMb",
-        "channels.defaults",
-        "channels.modelByChannel",
-        "messages.inbound",
-        "commands",
-        "accessGroups",
-        "tts",
-        "surfaces",
-        "acp.stream",
-        "diagnostics.flags",
-      ],
-      kind: "hot",
-      channels: channelPlugins,
-    },
     { prefixes: ["session.scope", "session.store"], kind: "hot", actions: ["refreshHooksPolicy"] },
+    ...DEFAULT_RELOAD_POLICIES,
   ];
-  const expand = (items: ReloadPolicy[]): ReloadRule[] =>
-    items.flatMap(({ prefixes, ...policy }) => prefixes.map((prefix) => ({ ...policy, prefix })));
-  const ownedRules = expand([...policies, ...DEFAULT_RELOAD_POLICIES]).toSorted(
-    (a, b) => b.prefix.length - a.prefix.length,
-  );
+  const ownedRules = expandReloadPolicies(policies);
   const rules = [
     ...ownedRules,
     // Narrow service declarations retain existing owner actions, including
     // channel account targeting, while supplying their own hot classification.
     ...servicePolicies.flatMap(({ prefixes }) =>
       prefixes.map((prefix): ReloadRule => ({
-        ...ownedRules.find((owner) => matchesPrefix(prefix, owner.prefix)),
+        ...ownedRules.find((owner) => matchesReloadPrefix(prefix, owner.prefix)),
         kind: "hot",
         prefix,
       })),
@@ -320,7 +346,9 @@ function getReloadPolicyCatalog() {
   ];
   for (const rule of rules) {
     rule.services = servicePolicies
-      .filter((service) => service.prefixes.some((owner) => matchesPrefix(rule.prefix, owner)))
+      .filter((service) =>
+        service.prefixes.some((owner) => matchesReloadPrefix(rule.prefix, owner)),
+      )
       .flatMap((service) => service.services);
   }
   // Narrow config contracts must override broad owner fallbacks. Sort once per
@@ -339,12 +367,8 @@ export function listConfigReloadRefinementPrefixes(): string[] {
   return getReloadPolicyCatalog().refinementPrefixes;
 }
 
-function matchesPrefix(path: string, prefix: string): boolean {
-  return path === prefix || path.startsWith(`${prefix}.`);
-}
-
 function matchRule(path: string): ReloadRule | undefined {
-  return getReloadPolicyCatalog().rules.find(({ prefix }) => matchesPrefix(path, prefix));
+  return getReloadPolicyCatalog().rules.find(({ prefix }) => matchesReloadPrefix(path, prefix));
 }
 
 export function resolveConfigReloadMetadata(path: string): ConfigReloadMetadata {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -429,6 +429,53 @@ describe("buildGatewayReloadPlan", () => {
     }
     setActivePluginRegistry(emptyRegistry);
   });
+  it.each(
+    ["messages", "messages.inbound", "messages.inbound.debounceMs"].flatMap((prefix) =>
+      [false, true].flatMap((allChannelsLive) =>
+        [false, true].map((globalNoop) => ({ prefix, allChannelsLive, globalNoop })),
+      ),
+    ),
+  )(
+    "composes service $prefix with shared policy: all live=$allChannelsLive global noop=$globalNoop",
+    ({ prefix, allChannelsLive, globalNoop }) => {
+      const serviceRegistry = createTestRegistry([
+        {
+          pluginId: "telegram",
+          plugin: { ...telegramPlugin, reload: { noopPrefixes: ["messages.inbound"] } },
+          source: "test",
+        },
+        {
+          pluginId: "whatsapp",
+          plugin: allChannelsLive
+            ? { ...whatsappPlugin, reload: { noopPrefixes: ["messages.inbound"] } }
+            : whatsappPlugin,
+          source: "test",
+        },
+      ]);
+      serviceRegistry.services.push({
+        pluginId: "exporter",
+        source: "test",
+        origin: "workspace",
+        service: { id: "exporter", reload: { configPrefixes: [prefix] }, start() {} },
+      });
+      if (globalNoop) {
+        serviceRegistry.reloads.push({
+          pluginId: "policy-owner",
+          pluginName: "Policy owner",
+          source: "test",
+          registration: { noopPrefixes: ["messages.inbound.debounceMs"] },
+        });
+      }
+      setActivePluginRegistry(serviceRegistry);
+      const plan = buildGatewayReloadPlan(["messages.inbound.debounceMs"]);
+      expect(plan.restartGateway).toBe(false);
+      expect(plan.restartServices).toEqual(new Set(globalNoop ? [] : ["exporter"]));
+      expect(plan.restartChannels).toEqual(
+        new Set(allChannelsLive || globalNoop ? [] : ["whatsapp"]),
+      );
+      setActivePluginRegistry(emptyRegistry);
+    },
+  );
   it.each(["channels.mattermost", "channels.mattermost.accounts.work"])(
     "preserves channel account ownership when a service reloads %s",
     (prefix) => {
@@ -881,14 +928,40 @@ describe("buildGatewayReloadPlan", () => {
     [{}, { messages: { ackReactionScope: "all" } }],
     [{ messages: { ackReactionScope: "all" } }, {}],
     [{ messages: { ackReactionScope: "off" } }, { messages: { ackReactionScope: "all" } }],
-  ])(
-    "keeps running channels connected when acknowledgement scope changes: %j → %j",
-    (prev, next) => {
-      const paths = diffGatewayReloadPaths(prev, next, listConfigReloadRefinementPrefixes());
-      const plan = buildGatewayReloadPlan(paths);
-      expect(isNoopGatewayReloadPlan(plan)).toBe(true);
-      expect(plan.restartChannels).toEqual(new Set());
-      expect(plan.restartChannelAccounts).toEqual(new Map());
+  ])("refreshes undeclared owners when acknowledgement scope changes: %j → %j", (prev, next) => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        ...[telegramPlugin, whatsappPlugin].map((plugin) => ({
+          pluginId: plugin.id,
+          plugin: {
+            ...plugin,
+            reload: { ...plugin.reload, noopPrefixes: ["messages.ackReactionScope"] },
+          },
+          source: "test",
+        })),
+        { pluginId: "mattermost", plugin: mattermostPlugin, source: "test" },
+      ]),
+    );
+    const paths = diffGatewayReloadPaths(prev, next, listConfigReloadRefinementPrefixes());
+    const plan = buildGatewayReloadPlan(paths);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartChannels).toEqual(new Set(["mattermost"]));
+    expect(plan.restartChannelAccounts).toEqual(new Map());
+  });
+
+  it.each(["messages.inbound", "messages.ackReactionScope"])(
+    "keeps channels connected only when every loaded owner opts out of %s",
+    (prefix) => {
+      setActivePluginRegistry(
+        createTestRegistry(
+          [telegramPlugin, whatsappPlugin].map((plugin) => ({
+            pluginId: plugin.id,
+            plugin: { ...plugin, reload: { ...plugin.reload, noopPrefixes: [prefix] } },
+            source: "test",
+          })),
+        ),
+      );
+      expect(isNoopGatewayReloadPlan(buildGatewayReloadPlan([prefix]))).toBe(true);
     },
   );
 
@@ -1021,20 +1094,61 @@ describe("buildGatewayReloadPlan", () => {
 
   it.each(
     sharedChannelSettings.flatMap(({ path }) => [
-      { path, reload: { configPrefixes: [path] }, kind: "hot", channels: ["telegram"] },
-      { path, reload: { configPrefixes: [], noopPrefixes: [path] }, kind: "none", channels: [] },
+      { path, reload: { configPrefixes: [path] }, channels: ["telegram", "whatsapp"] },
+      { path, reload: { configPrefixes: [], noopPrefixes: [path] }, channels: ["whatsapp"] },
     ]),
-  )("preserves explicit channel $kind policy for $path", ({ path, reload, kind, channels }) => {
+  )("preserves sibling reloads with channel policy for $path", ({ path, reload, channels }) => {
     setActivePluginRegistry(
       createTestRegistry([
         { pluginId: "telegram", plugin: { ...telegramPlugin, reload }, source: "test" },
         { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
       ]),
     );
-    expect(resolveConfigReloadMetadata(path).kind).toBe(kind);
+    expect(resolveConfigReloadMetadata(path).kind).toBe("hot");
     const plan = buildGatewayReloadPlan([path]);
     expect(plan.restartGateway).toBe(false);
     expect(plan.restartChannels).toEqual(new Set(channels));
+  });
+
+  it("applies each channel's narrowest shared policy independently", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          plugin: {
+            ...telegramPlugin,
+            reload: {
+              configPrefixes: ["messages.inbound.byChannel.telegram"],
+              noopPrefixes: ["messages.inbound"],
+            },
+          },
+          source: "test",
+        },
+        {
+          pluginId: "whatsapp",
+          plugin: {
+            ...whatsappPlugin,
+            reload: { configPrefixes: [], noopPrefixes: ["messages"] },
+          },
+          source: "test",
+        },
+        { pluginId: "mattermost", plugin: mattermostPlugin, source: "test" },
+      ]),
+    );
+    expect(buildGatewayReloadPlan(["messages.inbound.debounceMs"]).restartChannels).toEqual(
+      new Set(["mattermost"]),
+    );
+    expect(buildGatewayReloadPlan(["messages.inbound.byChannel.telegram"]).restartChannels).toEqual(
+      new Set(["telegram", "mattermost"]),
+    );
+    const paths = diffGatewayReloadPaths(
+      {},
+      { messages: { inbound: { debounceMs: 20, byChannel: { telegram: 10 } } } },
+      listConfigReloadRefinementPrefixes(),
+    );
+    expect(buildGatewayReloadPlan(paths).restartChannels).toEqual(
+      new Set(["telegram", "mattermost"]),
+    );
   });
 
   const mattermostAccountConfig = {


### PR DESCRIPTION
Related: #138638, #138556

## What Problem This Solves

Changing inbound batching currently reconnects channels to replace a captured delay. This lets Discord, Feishu, iMessage, Mattermost, Microsoft Teams, Signal, Slack, Telegram, and WhatsApp adopt committed `messages.inbound` timing while keeping their channel runtimes.

Shared-policy planning also stops treating one plugin's no-op declaration as permission to skip another owner's refresh.

## Why This Change Was Made

The nine adapters use the existing per-entry `resolveDebounceMs` callback and bound runtime-config reader. The public `createChannelInboundDebouncer` retains its numeric startup snapshot and snapshot timing by default. Explicit transport overrides remain fixed, and independently scoped configurations stay isolated from unrelated Gateway snapshots.

The canonical policy catalog aggregates each channel's narrowest declaration independently. Undeclared channels retain conservative refresh behavior; narrower owner restart declarations and explicit global policies keep precedence. A synthesized no-channel-restart rule also preserves independently registered service interests. The service composition regression failed two cases before the fix; all 12 broad/equal/narrow, mixed/all-live, and explicit-global-noop cases now pass. The six previously verified acknowledgement consumers declare their live-read behavior through the same policy contract.

Redundant timing resolver wrappers and startup snapshots are removed. Production is **+161/−123, net +38 lines**; tests/support are +966/−160, net +806; docs are +30/−8, net +22. The production growth implements per-owner aggregation and explicit live-read opt-ins while preserving the shipped helper contract. No configuration keys, SDK fields, protocol fields, or persistent-store changes are added.

## User Impact

Newly admitted work uses committed timing. A setting change alone does not reschedule an existing batch; later admitted messages can adjust its idle deadline within the original maximum deadline. Slack and WhatsApp carry one timing value into both pending-work bookkeeping and queue admission. Telegram's separate forwarded-message window, control-message bypass, shutdown, and explicitly deferred reply ownership keep their existing behavior.

## Evidence

| Evidence | Observed result |
| --- | --- |
| Before-fix owner regressions | Stale timing reproduced for all nine consumers; original shared-owner cases also failed before aggregation was repaired |
| Local checks | Full build and selected canonical checks passed; final integration passed core/core-test types and focused typed lint; independent P0–P2 reviews are clean |
| Linux build and owner coverage | Frozen `f18961af5c23` built successfully in 223s; 614 distinct tests across 14 files/12 shards passed, including all 456 planner cases |
| Five real Gateway flows | Slack, Discord, Signal, Telegram, and WhatsApp each passed 0 → 10000 → 0 ms; enabled admission took 10.16–10.20s and returned to 169–206ms after disable. Each retained its PID, boot ID, channel start time, and one unclosed operator connection |
| Four retained-monitor processes | Feishu, iMessage, Mattermost, and Microsoft Teams passed real-clock 0 → delay → 0 transitions with one retained debouncer/client/socket per owner |
| Test-only CI follow-up | `ec335f132184` updates one stale exact WhatsApp metadata assertion; its focused test and independent review passed. Every other file is byte-identical to the tested `f18961af5c23` |
| Required CI | [CI run 33943196524](https://github.com/openclaw/openclaw/actions/runs/33943196524) passed on `ec335f132184`; the corrected metadata assertion passed and the earlier tooling watchdog did not recur |

[Linux Testbox run](https://github.com/openclaw/openclaw/actions/runs/33940640543): provider `blacksmith-testbox`, lease `tbx_01m1qr50btf2xy785k0rf6hxq8`, final command exit **0**. Candidate/build commit is `f18961af5c2337ccebc248d8d79ff9334e001e41`; verified source tree is `587c9496f05ab7eb8e35b72e83b66c22775520d4`; final source carrier is `2374b9ac5b7a9228fc56007ef92702645b286653`. The driver supplies `GIT_COMMIT` before building and verifies the existing build when resuming; it never restamps an artifact.

The first command passed its build and suites, then its external receipt parser missed ANSI-prefixed monitor records. The corrected continuation preserved that initial receipt, verified the same tree/build, and completed the remaining Gateway flows. Final `channel-debounce-receipt.tgz`: **46,722 bytes**, SHA-256 `902795e5de90734fd2bbc09843c0fd246db7e4e0d338830dcd87a1e531494da8`.

## Compatibility Decision

Retain conservative per-owner refresh for undeclared plugins, as requested for this reload redesign. An individual plugin's live-read declaration must not leave another plugin running with a stale policy snapshot. Existing configuration remains valid and the public helper defaults remain unchanged. An undeclared plugin may refresh its own channel runtime on a shared-policy edit; the Gateway keeps running and manually stopped accounts stay stopped. This is the disposition for ClawSweeper's two compatibility before-merge items. No behavior is assumed for untested external-plugin combinations.

## Known Follow-up and Proof Limits

**Durable collector coalescing versus deferred reply ownership:** WhatsApp's durable ingress uses the same retained-lane phase for collector buffering and an explicitly deferred reply, which can prevent another same-conversation message from reaching a pending collector. Mattermost has an analogous source-level risk. A captured original-order reproduction and an unconditional-release trial showed why that lifecycle needs its own repair: releasing the lane fixed batching but broke deferred-reply ordering. This PR preserves that contract and proves timing when work reaches the collector.

Linux proof uses synthetic providers and data. The five Gateway lanes run the real plugins and public config RPC; the other four exercise actual retained monitor/receive owners with real clocks and existing synthetic transport or reply-policy boundaries. They are distinct from full Gateway or authenticated vendor-account coverage.

The source-hash-checked, task-local Crabline 0.1.20 decoder fixture incorporates the four standard tokens already merged in [crabline#294](https://github.com/openclaw/crabline/pull/294). Its exact patch and real Baileys encoder/decoder checks are captured in the artifact. Installed dependencies remain unchanged; no npm publication or real vendor-account coverage is claimed.
