### PR TITLE
fix: restore Gateway restarts after Git updates

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -546,7 +546,8 @@ vi.mock("./daemon-cli.js", () => ({
   runDaemonInstall: mockedRunDaemonInstall,
   runDaemonRestart: vi.fn(),
 }));
-vi.mock("./daemon-cli/install.runtime.js", () => ({
+vi.mock("./daemon-cli/install.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./daemon-cli/install.js")>()),
   runDaemonInstall: mockedRunDaemonInstall,
 }));
 

--- a/src/cli/update-cli/update-command-service-command.process.test.ts
+++ b/src/cli/update-cli/update-command-service-command.process.test.ts
@@ -1,0 +1,102 @@
+import { expect, it } from "vitest";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { formatCliProcessFailure, runCliProcessChild } from "../cli-process-child.test-helpers.js";
+
+it.each(["restart", "install", "missing candidate"] as const)(
+  "handles %s after replacing the updater's module files",
+  async (scenario) => {
+    await withOpenClawTestState(
+      { prefix: "openclaw-update-command-replacement-", scenario: "minimal", applyEnv: false },
+      async (state) => {
+        const script = String.raw`
+          import assert from "node:assert/strict";
+          import fs from "node:fs/promises";
+          import { registerHooks } from "node:module";
+          import path from "node:path";
+          import { pathToFileURL } from "node:url";
+
+          const scenario = ${JSON.stringify(scenario)};
+          const root = ${JSON.stringify(state.path("installation"))};
+          const dist = path.join(root, "dist");
+          const receipt = path.join(root, "candidate.json");
+          const owner = ${JSON.stringify(new URL("./update-command-service-command.ts", import.meta.url).href)};
+          await fs.mkdir(dist, { recursive: true });
+
+          // A split build can emit a separate namespace facade even when other
+          // imports have already loaded the underlying implementation. Keep the
+          // actual helpers cached, then replace only the owner's facade files.
+          const facades = new Map();
+          for (const specifier of [
+            "./shared.js",
+            "./update-command-service-recovery.js",
+            "../daemon-cli/install.runtime.js",
+            "../daemon-cli/install.js",
+          ]) {
+            const source = new URL(specifier.replace(/\.js$/, ".ts"), owner).href;
+            await import(source);
+            const facade = path.join(dist, "old-" + facades.size + ".mjs");
+            await fs.writeFile(facade, "export * from " + JSON.stringify(source) + ";\n");
+            facades.set(specifier, pathToFileURL(facade).href);
+          }
+          registerHooks({
+            resolve(specifier, context, nextResolve) {
+              const facade = context.parentURL === owner && facades.get(specifier);
+              return facade ? { url: facade, shortCircuit: true } : nextResolve(specifier, context);
+            },
+          });
+          const { runUpdatedInstallGatewayCommand } = await import(owner);
+
+          await fs.rm(dist, { recursive: true });
+          await fs.mkdir(dist);
+          const params = {
+            result: { root, mode: "npm" },
+            opts: { json: true },
+            invocationEnv: process.env,
+            timeoutMs: 10_000,
+          };
+          if (scenario === "missing candidate") {
+            await assert.rejects(runUpdatedInstallGatewayCommand(params, "install"), {
+              message: "updated install entrypoint not found under " + root,
+            });
+          } else {
+            await fs.writeFile(path.join(dist, "index.mjs"), [
+              'import fs from "node:fs";',
+              'fs.writeFileSync(' + JSON.stringify(receipt) + ', JSON.stringify({',
+              '  args: process.argv.slice(2),',
+              '  node: process.execPath,',
+              '  config: process.env.OPENCLAW_CONFIG_PATH,',
+              '  compileCacheDisabled: process.env.NODE_DISABLE_COMPILE_CACHE,',
+              '}));',
+            ].join("\n"));
+            assert.equal(await runUpdatedInstallGatewayCommand(params, scenario, true), true);
+            const observed = JSON.parse(await fs.readFile(receipt, "utf8"));
+            assert.deepEqual(observed, {
+              args: ["gateway", scenario, scenario === "install" ? "--force" : "--preserve-definition", "--json"],
+              node: process.execPath,
+              config: process.env.OPENCLAW_CONFIG_PATH,
+              compileCacheDisabled: "1",
+            });
+          }
+          console.log("UPDATE_COMMAND_AFTER_REPLACEMENT_OK");
+        `;
+        const result = await runCliProcessChild({
+          nodeArgs: ["--import", "./scripts/tsx.mjs", "--input-type=module", "--eval", script],
+          env: {
+            PATH: process.env.PATH,
+            ...state.envVars,
+            TMPDIR: state.root,
+            TMP: state.root,
+            TEMP: state.root,
+          },
+        });
+        const failure = formatCliProcessFailure({
+          reason: "Update command child failed",
+          ...result,
+        });
+        expect(result.signal, failure).toBeNull();
+        expect(result.code, failure).toBe(0);
+        expect(result.stdout, failure).toContain("UPDATE_COMMAND_AFTER_REPLACEMENT_OK");
+      },
+    );
+  },
+);

--- a/src/cli/update-cli/update-command-service-command.ts
+++ b/src/cli/update-cli/update-command-service-command.ts
@@ -2,8 +2,10 @@ import { safeParseJsonRecord } from "@openclaw/normalization-core/json-coercion"
 import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
-import type { UpdateCommandOptions } from "./shared.js";
+import { runDaemonInstall } from "../daemon-cli/install.js";
+import { resolveNodeRunner, type UpdateCommandOptions } from "./shared.js";
 import { resolveUpdatedInstallCommandEnv } from "./update-command-service-env.js";
+import { isPackageManagerUpdateMode } from "./update-command-service-recovery.js";
 
 const SERVICE_REFRESH_TIMEOUT_MS = 60_000;
 export const DEFINITION_DENIAL = /\bSERVICE_DEFINITION_(?:SEALED|UNKNOWN):[^\n]*/;
@@ -17,8 +19,8 @@ function formatCommandFailure(stdout: string, stderr: string): string {
   return detail ? detail.split("\n").slice(-3).join("\n") : "command returned a non-zero exit code";
 }
 
-// Use the candidate's version guards for both refresh and activation. The parsed
-// preservation option makes older targets reject before repair, without a retry.
+// Loaded before package replacement: activation dependencies must stay eager.
+// Candidate version/preservation guards reject older targets before repair, without retry.
 export async function runUpdatedInstallGatewayCommand(
   params: {
     result: { root?: string; mode?: UpdateRunResult["mode"] };
@@ -37,9 +39,7 @@ export async function runUpdatedInstallGatewayCommand(
   const entrypoint = await resolveGatewayInstallEntrypoint(params.result.root);
   if (!entrypoint) {
     if (installing) {
-      const { isPackageManagerUpdateMode } = await import("./update-command-service-recovery.js");
       if (!isPackageManagerUpdateMode(params.result.mode ?? "unknown")) {
-        const { runDaemonInstall } = await import("../daemon-cli/install.runtime.js");
         await runDaemonInstall({ force: true, json: params.opts.json || undefined });
         return true;
       }
@@ -57,7 +57,7 @@ export async function runUpdatedInstallGatewayCommand(
   if (params.opts.json) {
     args.push("--json");
   }
-  const nodeRunner = params.nodeRunner ?? (await import("./shared.js")).resolveNodeRunner();
+  const nodeRunner = params.nodeRunner ?? resolveNodeRunner();
   const res = await runCommandWithTimeout([nodeRunner, entrypoint, ...args], {
     // The complete owned env must not regain selectors removed during capture.
     baseEnv: {},


### PR DESCRIPTION
Closes #138760 — Git updates can leave the Gateway stopped after loading a removed restart bundle.

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Fixes an issue where users updating a Git installation would be left with a stopped Gateway even though the new version built successfully and passed Doctor. Finalization failed before it could launch the new version's restart command, reporting `restart-unhealthy` / `runtime-verification-failed`.

## Why This Change Was Made

The activation command still dynamically imported dependencies after the updater had replaced its own generated files. This change makes those dependencies eager within the existing preload-before-replacement boundary, covering the Node resolver, update-mode check, and legacy service-install helper without changing restart, ownership, environment, version, or health policy.

## User Impact

Git updates can proceed to restart and verify the newly installed Gateway instead of failing on a removed bundle. No new settings, migrations, retries, version rollback, or database changes are introduced; supplied Node runners, service-definition preservation, and safe missing-candidate rejection remain intact.

## Evidence

The completed proof below used this patch applied to base `dcdbd055c7b4d2c96b7ca96adf6b9ab6fd9ef617`; that source tree is recorded by published commit `99aa2f15e2749fd9a9d4657097be22e1f42f3a3d`. These local results are separate from subsequent merge-ref CI.

### Observed failure

The documented Linux/Node 24.19.0 update went from 2026.8.1 (`c6f6055a527e91c5d17b166b81d0023581318526`) to 2026.9.1 (`0229a108fee749327b2cc60c4d228299dfe2f889`). Sanitized local output:

```text
Stopping managed gateway service before git update...
✓ Running doctor checks (244.67s)
✓ Verifying update (8ms)
Gateway service definition left unchanged
Restarting service...
Gateway: restart failed: Error: ENOENT: no such file or directory,
open '<install>/dist/shared-VSNmp8jC.js'
Update Result: ERROR
Reason: restart-unhealthy
```

The exception occurs in `runUpdatedInstallGatewayCommand()` while resolving Node, before spawning the candidate. The old implementation can already be cached while its separately emitted namespace facade is not. Fresh-process validation and starting the verified candidate restored Gateway health/RPC without rollback or database repair; that recovery is incident evidence, not a deployment of this patch.

### Regression and sibling coverage

The new native-Node process test loads real helper implementations, maps the owner's imports to physical namespace facade files, loads the actual activation owner, deletes/recreates the fixture build directory, then invokes it without an injected Node runner. Restart and install spawn real candidate Node processes and assert their argv, executable, configuration selector, and compile-cache isolation. A missing package-manager candidate must still be rejected safely.

Before the production change, all three new cases failed with `ENOENT` for removed facade files. Afterward:

```text
node scripts/run-vitest.mjs \
  src/cli/update-cli/update-command-service-command.process.test.ts \
  src/cli/update-cli/update-command-service.test.ts \
  src/cli/update-cli/update-command-service.integration.test.ts \
  src/cli/update-cli/update-command-post-update-recovery.test.ts

Test Files  4 passed (4)
Tests       141 passed (141)
```

Sibling coverage includes preserved service definitions, candidate version guards, expected Git build identity, stale-launcher recovery, failed-update recovery safety, and macOS/Windows decision paths. These tests do not claim native macOS/Windows service-manager execution.

<!-- pr-behavior-proof:start -->
## Real behavior proof

- **Claim:** After a Git update replaces the running installation's generated files, the emitted Gateway activation owner can launch the updated candidate's restart and install commands without importing a removed bundle; a missing package-manager candidate still rejects safely.
- **Exercised surface:** Production `runUpdatedInstallGatewayCommand()` from the actual emitted `pnpm build` output for patch commit `99aa2f15e2749fd9a9d4657097be22e1f42f3a3d`. The exact reviewed PR head is `2dc5b10ec533ed70245a03a3f05fb61a8e0c2fc8`; its only later change is the test mock correction described below, with no production change to this owner.
- **Scenario / fixture:** A disposable copy of the built package used isolated HOME, state, config, workspace, and temporary directories with native ESM imports and no loader hooks or dependency mocks. The proof loaded the emitted activation owner, deleted the fixture's entire `dist`, installed a recording candidate entrypoint, and invoked restart, install, and missing-candidate paths through real Node subprocesses.
- **Command / environment:** Linux with Node 24.19.0, after `pnpm build`: `node /tmp/openclaw-update-restart-built-proof.mjs`. The script ran from the checkout root and removed its temporary fixture on exit.
- **Observable result:** Restart and install both launched after the fixture build directory was deleted. The candidate processes received the expected Node executable, `gateway restart --preserve-definition --json` and `gateway install --force --json`, the isolated config selector, and disabled compile cache. The missing-candidate case rejected as expected.
- **Artifact / trace:** Sanitized copied terminal output:

```text
node /tmp/openclaw-update-restart-built-proof.mjs
BUILT_DIST_REPLACEMENT_RESTART_OK
BUILT_DIST_REPLACEMENT_INSTALL_OK
BUILT_DIST_REPLACEMENT_MISSING_CANDIDATE_OK
```

- **Limits:** This proof exercises the emitted production module-loader and subprocess boundary with an isolated fixture. It does not perform a real Git update against an operator installation, invoke native systemd/launchd service management, or restart a live Gateway. Native cross-platform service-manager E2E remains untested. The final head's test-only follow-up was validated separately below.
<!-- pr-behavior-proof:end -->

<details>
<summary>Reproduce the emitted-code check on Linux after pnpm build</summary>

Save this as `/tmp/openclaw-update-restart-built-proof.mjs`, then run it with Node from the checkout root. It creates and removes only a temporary fixture.

```js
import assert from "node:assert/strict";
import { execFile } from "node:child_process";
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { fileURLToPath, pathToFileURL } from "node:url";
import { promisify } from "node:util";

const execFileAsync = promisify(execFile);
const checkout = process.cwd();

if (process.argv[2] !== "--child") {
  const fixture = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-built-proof-"));
  try {
    await fs.mkdir(path.join(fixture, "home"));
    await fs.mkdir(path.join(fixture, "state"));
    await fs.mkdir(path.join(fixture, "workspace"));
    // Disposable copy: deletion never touches the source build or live installation.
    await execFileAsync("cp", ["-a", path.join(checkout, "dist"), path.join(fixture, "dist")]);
    await fs.copyFile(path.join(checkout, "package.json"), path.join(fixture, "package.json"));
    await fs.symlink(path.join(checkout, "node_modules"), path.join(fixture, "node_modules"));
    const result = await execFileAsync(process.execPath, [fileURLToPath(import.meta.url), "--child", fixture], {
      cwd: fixture,
      env: {
        PATH: process.env.PATH,
        HOME: path.join(fixture, "home"),
        OPENCLAW_STATE_DIR: path.join(fixture, "state"),
        OPENCLAW_CONFIG_PATH: path.join(fixture, "state", "openclaw.json"),
        OPENCLAW_WORKSPACE_DIR: path.join(fixture, "workspace"),
        NODE_DISABLE_COMPILE_CACHE: "1",
        TMPDIR: fixture,
        TMP: fixture,
        TEMP: fixture,
      },
      timeout: 120_000,
    });
    process.stdout.write(result.stdout);
    process.stderr.write(result.stderr);
  } finally {
    await fs.rm(fixture, { recursive: true, force: true });
  }
} else {
  const root = process.argv[3];
  const dist = path.join(root, "dist");
  const owners = [];
  for (const file of await fs.readdir(dist)) {
    if (file.endsWith(".js")) {
      const contents = await fs.readFile(path.join(dist, file), "utf8");
      if (contents.includes("async function runUpdatedInstallGatewayCommand(")) owners.push(file);
    }
  }
  assert.equal(owners.length, 1);
  const module = await import(pathToFileURL(path.join(dist, owners[0])).href);
  const commands = Object.values(module).filter(
    (value) => typeof value === "function" && value.name === "runUpdatedInstallGatewayCommand",
  );
  assert.equal(commands.length, 1);
  const runCommand = commands[0];
  await fs.rm(dist, { recursive: true });
  await fs.mkdir(dist);
  const receipt = path.join(root, "candidate.json");
  await fs.writeFile(path.join(dist, "index.mjs"), [
    'import fs from "node:fs";',
    `fs.writeFileSync(${JSON.stringify(receipt)}, JSON.stringify({`,
    'args: process.argv.slice(2), node: process.execPath,',
    'config: process.env.OPENCLAW_CONFIG_PATH, cache: process.env.NODE_DISABLE_COMPILE_CACHE,',
    '}));',
  ].join("\n"));
  const params = {
    result: { root, mode: "git" },
    opts: { json: true },
    invocationEnv: process.env,
    timeoutMs: 10_000,
  };
  for (const action of ["restart", "install"]) {
    assert.equal(await runCommand(params, action, true), true);
    const observed = JSON.parse(await fs.readFile(receipt, "utf8"));
    assert.deepEqual(observed, {
      args: ["gateway", action, action === "restart" ? "--preserve-definition" : "--force", "--json"],
      node: process.execPath,
      config: process.env.OPENCLAW_CONFIG_PATH,
      cache: "1",
    });
    console.log(`BUILT_DIST_REPLACEMENT_${action.toUpperCase()}_OK`);
  }
  await fs.unlink(path.join(dist, "index.mjs"));
  await assert.rejects(runCommand({ ...params, result: { root, mode: "npm" } }, "install"), {
    message: "updated install entrypoint not found under " + root,
  });
  console.log("BUILT_DIST_REPLACEMENT_MISSING_CANDIDATE_OK");
}
```

</details>

### Build and review

Fresh independent `autoreview` of the full patch against `dcdbd055c7b4d2c96b7ca96adf6b9ab6fd9ef617`: scoped-clean through P2, no findings. Review included the unchanged preload boundary and dependency implementations, not just the diff.

`pnpm build` passed, including native built plugin control-plane loading, CLI bootstrap import guards, plugin SDK export validation, and the Control UI build. No `INEFFECTIVE_DYNAMIC_IMPORT` warnings were emitted.

Production typechecking, formatting, dependency guards, plugin boundaries, and deprecation checks passed. The full test-typecheck and remaining canonical changed-plan guards have now passed as well. The interrupted serial test-typecheck was resumed using `pnpm tsgo:core:test --stripe 1/1 --concurrency 4`, which selects all 16 graphs; subsequent guards ran in their canonical order. This is combined local validation evidence, not a claim that the original interrupted wrapper completed.

Production delta: +6/-6 lines (net zero). Test delta: +104/-1 lines; no new production test seam.

### CI follow-up

The first merge-ref run for head `99aa2f15e2749fd9a9d4657097be22e1f42f3a3d` failed only in [`checks-node-compact-small-51`](https://github.com/openclaw/openclaw/actions/runs/33938334535/job/101230674284): three existing service-refresh tests in `src/cli/update-cli.test.ts` expected installer-stub calls but observed none. The suite still mocked `daemon-cli/install.runtime.js`, while the repaired activation owner now imports `daemon-cli/install.js` eagerly.

The same three assertion failures reproduced locally with `node scripts/run-vitest.mjs src/cli/update-cli.test.ts -t 'updateCommand service refresh behavior'` (3 failed, 2 passed). The follow-up targets the implementation owner with a partial mock: only `runDaemonInstall` is replaced, while real exports such as `mergeInstallInvocationEnv` remain available to the existing explicit-wrapper test. Retargeting a whole-module mock initially exposed that sibling dependency; the partial mock preserves it. No assertions, production behavior, or restart safety policy change.

After the final partial-mock correction in `2dc5b10ec533ed70245a03a3f05fb61a8e0c2fc8`:

```text
node scripts/run-vitest.mjs src/cli/update-cli.test.ts \
  -t 'updateCommand service refresh behavior|uses an explicit service wrapper when openclaw is absent from PATH'

Test Files  1 passed (1)
Tests       6 passed | 351 skipped (357)
```

The complete owner and restart/recovery run also passed on the same final source tree:

```text
node scripts/run-vitest.mjs \
  src/cli/update-cli.test.ts \
  src/cli/update-cli/update-command-service-command.process.test.ts \
  src/cli/update-cli/update-command-service.test.ts \
  src/cli/update-cli/update-command-service.integration.test.ts \
  src/cli/update-cli/update-command-post-update-recovery.test.ts

Test Files  5 passed (5)
Tests       498 passed (498)
```

Targeted formatting and lint pass. Fresh independent review of the final combined fixture correction is scoped-clean through P2 with no findings. [CI run 33939582103](https://github.com/openclaw/openclaw/actions/runs/33939582103) passed for head `2dc5b10ec533ed70245a03a3f05fb61a8e0c2fc8`, including the [previously failing shard](https://github.com/openclaw/openclaw/actions/runs/33939582103/job/101234323710) and [aggregate CI gate](https://github.com/openclaw/openclaw/actions/runs/33939582103/job/101235205813). The final observed rollup had no pending or failed checks.

Proof boundary: both the source regression and emitted-code check exercise the native module loader and subprocess boundary, not a real systemd/launchd update end to end. Repeating the operator's real update would replace their installation and disrupt their running Gateway; PR validation deliberately used disposable fixtures instead. The operator's running Gateway, configuration, session history, and databases were not changed for this validation. Native cross-platform service-manager E2E remains untested by this PR.
