### PR TITLE
fix: allow older source on newer Testbox checkouts

### DIFF
--- a/scripts/crabbox-source-receiver.mts
+++ b/scripts/crabbox-source-receiver.mts
@@ -78,8 +78,9 @@ try {
     ["refs/heads/openclaw-source^{tree}", expected.tree],
     ["refs/heads/openclaw-source^", expected.baseSha],
   ]) if (git(["rev-parse", ref]).trim() !== value) fail("source capsule identity mismatch");
-  function entries(tree) {
-    const output = git(["ls-tree", "-r", "-z", tree], { encoding: "buffer" });
+  function entries(tree, directory = gitDir) {
+    const output = git(["ls-tree", "-r", "-z", tree], { encoding: "buffer",
+      env: { ...env, GIT_DIR: directory, GIT_INDEX_FILE: path.join(directory, "index") } });
     if (!isUtf8(output)) fail("unsupported non-UTF-8 source paths");
     return output.subarray(0, -1).toString("utf8")
       .split("\0").filter(Boolean).map(row => {
@@ -88,6 +89,10 @@ try {
         return { mode: match[1], oid: match[2], file: safePath(match[3]) };
       });
   }
+  // The prepared workspace can contain newer workflow source. Its committed tree
+  // owns only cleanup candidates; the capsule alone selects the executed source.
+  const previous = new Map((process.argv[2] ? entries("HEAD", path.join(cwd, ".git")) : [])
+    .map(entry => [entry.file, entry]));
   const files = entries(expected.tree);
   const metadata = JSON.parse(git(["show", "-s", "--format=%B", expected.carrier]));
   if (!Array.isArray(metadata.deleted) || metadata.deleted.some(file => typeof file !== "string"))
@@ -112,8 +117,8 @@ try {
     safePath(file);
     if (reachable(file)) fs.rmSync(file, { recursive: true, force: true });
   }
-  // Only the producer can declare source deletions: old indexes may have lost
-  // ignored entries. A directory with unknown contents is not ours to erase.
+  // The producer owns privacy-filtered deletions, including ignored entries lost
+  // from old indexes. A directory with unknown contents is not ours to erase.
   for (const file of [...deleted].sort((a, b) => b.split("/").length - a.split("/").length)) {
     if (selected.has(file) || directories.has(file)) fail("conflicting source deletion");
     if (reachable(file)) {
@@ -174,14 +179,32 @@ try {
   } finally { fs.closeSync(input); }
   git(["read-tree", expected.tree]);
   fs.rmSync(capsule);
-  for (const file of git(["ls-files", "--others", "--exclude-standard", "-z"]).split("\0").filter(Boolean)) {
-    if (!file.startsWith(path.basename(temporary) + "/")) fail("unexpected source entry: " + file);
+  for (;;) {
+    const extras = git(["ls-files", "--others", "--exclude-standard", "-z"]).split("\0")
+      .filter(file => file && !file.startsWith(path.basename(temporary) + "/"));
+    if (extras.length === 0) break;
+    // Settle ancestor ignore rules first: removing a negated rule can protect
+    // descendant rules already listed, while removing an exclusion can reveal more.
+    const ignore = extras.filter(file => path.posix.basename(file) === ".gitignore")
+      .sort((a, b) => a.split("/").length - b.split("/").length)[0];
+    for (const file of ignore ? [ignore] : extras) {
+      const entry = previous.get(file);
+      if (!entry) fail("unexpected source entry: " + file);
+      // Preserve untracked, ignored, and modified runtime state. Only unchanged
+      // committed extras may be retired after the new source's ignore rules apply.
+      verify(entry);
+      fs.unlinkSync(file);
+      deleted.add(file);
+    }
+    // Each pass removes committed files. Retiring their .gitignore rules can
+    // expose more entries, so verification ends only with an empty inventory.
   }
   for (const file of deleted) {
     if (reachable(file) && stat(file)) fail("source deletion mismatch: " + file);
   }
-  // Verify filesystem bytes, kind, and executable bit independently of the index.
-  for (const { file, mode, oid } of files) {
+  // Verify filesystem bytes, kind, and executable bit independently of either index.
+  function verify({ file, mode, oid }) {
+    if (!reachable(file)) fail("source parent mismatch: " + file);
     const info = stat(file);
     let actual;
     if (mode === "120000") {
@@ -195,6 +218,7 @@ try {
     }
     if (actual !== oid) fail("source bytes mismatch: " + file);
   }
+  for (const entry of files) verify(entry);
   if (expected.alias) git(["update-ref", expected.alias, expected.baseSha]);
   git(["symbolic-ref", "HEAD", "refs/heads/openclaw-source"]);
   fs.rmSync(".git", { recursive: true, force: true });

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -3973,6 +3973,7 @@ describe("scripts/crabbox-wrapper", () => {
         source = origin,
         extraEnv: NodeJS.ProcessEnv = {},
         nativeSeed = true,
+        prepareReceiver?: (receiver: string) => void,
       ) => {
         const receiver = path.join(root, name);
         if (source === origin && nativeSeed) {
@@ -4020,6 +4021,7 @@ describe("scripts/crabbox-wrapper", () => {
         } else {
           mkdirSync(receiver);
         }
+        prepareReceiver?.(receiver);
         const transport =
           provider === "blacksmith-testbox" ? path.join(root, `${name}-transport`) : receiver;
         if (transport !== receiver) {
@@ -4181,9 +4183,80 @@ describe("scripts/crabbox-wrapper", () => {
           : existsSync(path.join(producer, ".git", "shallow")),
       ).toEqual(shallowBefore ?? false);
 
-      const imported = receive("candidate", candidate.remoteCommand, candidate.bundle);
+      const newerFiles = [
+        "newer-source.txt",
+        "newer-source-link",
+        "newer-directory/owned.txt",
+        "newer-directory/.gitignore",
+        "newer-directory/hidden/.gitignore",
+        "newer-directory/hidden/generated.js",
+      ];
+      const newerCaches = [
+        "newer-directory/cache.ignored",
+        "newer-directory/changed-cache.ignored",
+        "newer-directory/.cache.ignored/.gitignore",
+        "newer-directory/.changed-cache.ignored/.gitignore",
+        "newer-directory/.untracked-cache.ignored/.gitignore",
+      ];
+      const prepareNewerReceiver = (receiver: string) => {
+        writeFileSync(path.join(receiver, newerFiles[0]!), "newer workflow source\n");
+        symlinkSync("newer-source.txt", path.join(receiver, newerFiles[1]!));
+        mkdirSync(path.join(receiver, "newer-directory"));
+        writeFileSync(path.join(receiver, newerFiles[2]!), "newer nested source\n");
+        mkdirSync(path.join(receiver, "newer-directory/hidden"));
+        writeFileSync(path.join(receiver, newerFiles[3]!), "hidden/\n!*.ignored\n");
+        writeFileSync(path.join(receiver, newerFiles[4]!), "generated.js\n");
+        writeFileSync(path.join(receiver, newerFiles[5]!), "newer hidden source\n");
+        writeFileSync(path.join(receiver, "newer-private.ignored"), "retained private bytes\n");
+        for (const file of newerCaches) {
+          mkdirSync(path.dirname(path.join(receiver, file)), { recursive: true });
+          writeFileSync(path.join(receiver, file), "retained cache bytes\n");
+        }
+        git(receiver, [
+          "add",
+          "-f",
+          ...newerFiles,
+          ...newerCaches.slice(0, -1),
+          "newer-private.ignored",
+        ]);
+        git(receiver, ["commit", "-qm", "newer workflow source"]);
+        // A stale execution index cannot erase ownership recorded by its commit.
+        git(receiver, ["update-index", "--force-remove", ...newerFiles]);
+        writeFileSync(path.join(receiver, "newer-private.ignored"), "changed private bytes\n");
+        writeFileSync(path.join(receiver, newerCaches[1]!), "changed cache bytes\n");
+        writeFileSync(path.join(receiver, newerCaches[3]!), "changed cache bytes\n");
+      };
+      const imported = receive(
+        "candidate",
+        candidate.remoteCommand,
+        candidate.bundle,
+        origin,
+        {
+          GIT_DIR: path.join(root, "unrelated-git"),
+          GIT_WORK_TREE: root,
+          GIT_INDEX_FILE: path.join(root, "unrelated-index"),
+          GIT_COMMON_DIR: path.join(root, "unrelated-common"),
+          GIT_OBJECT_DIRECTORY: path.join(root, "unrelated-objects"),
+          GIT_ALTERNATE_OBJECT_DIRECTORIES: path.join(root, "unrelated-alternates"),
+        },
+        true,
+        provider === "blacksmith-testbox" ? prepareNewerReceiver : undefined,
+      );
       expect(imported.result.status, failureDetail(imported.result)).toBe(0);
       expect(imported.result.stdout).toBe("transport fixture reached\n");
+      if (provider === "blacksmith-testbox") {
+        for (const file of newerFiles) {
+          expect(() => lstatSync(path.join(imported.receiver, file))).toThrow();
+        }
+        for (const [index, file] of newerCaches.entries()) {
+          expect(readFileSync(path.join(imported.receiver, file), "utf8")).toBe(
+            index === 1 || index === 3 ? "changed cache bytes\n" : "retained cache bytes\n",
+          );
+        }
+        expect(readFileSync(path.join(imported.receiver, "newer-private.ignored"), "utf8")).toBe(
+          "changed private bytes\n",
+        );
+      }
       expect(git(imported.receiver, ["rev-parse", "HEAD^"])).toBe(base);
       expect(git(imported.receiver, ["rev-list", "--count", "HEAD"])).toBe("3");
       if (alias) {
@@ -4302,6 +4375,62 @@ describe("scripts/crabbox-wrapper", () => {
       // Shared receiver failure paths need one full real-Git fixture; provider/history
       // variants above retain independent successful source identity checks.
       if (provider === "blacksmith-testbox" && !shallow) {
+        for (const [fault, file, message] of [
+          ["bytes", "newer-source.txt", "source bytes mismatch"],
+          ["mode", "newer-source.txt", "source mode mismatch"],
+          ["kind", "newer-source.txt", "source mode mismatch"],
+          ["link", "newer-source-link", "source bytes mismatch"],
+          ["parent", "newer-directory", "unexpected source entry"],
+          ["untracked", "unowned.txt", "unexpected source entry"],
+          ["index", "unowned.txt", "unexpected source entry"],
+          ["hidden-untracked", "newer-directory/hidden/unknown.js", "unexpected source entry"],
+          ["hidden-bytes", "newer-directory/hidden/generated.js", "source bytes mismatch"],
+        ] as const) {
+          let retained: ReturnType<typeof sourceManifest> = [];
+          let priorHead = "";
+          const rejected = receive(
+            `newer-${fault}`,
+            candidate.remoteCommand,
+            candidate.bundle,
+            origin,
+            {},
+            true,
+            (receiver) => {
+              prepareNewerReceiver(receiver);
+              priorHead = git(receiver, ["rev-parse", "HEAD"]);
+              const fullPath = path.join(receiver, file);
+              if (fault === "mode") {
+                chmodSync(fullPath, 0o755);
+              } else if (fault === "kind" || fault === "link" || fault === "parent") {
+                rmSync(fullPath, { recursive: true });
+                symlinkSync(
+                  fault === "parent" ? deletionReferent : path.join(deletionReferent, "canary.txt"),
+                  fullPath,
+                );
+              } else {
+                writeFileSync(fullPath, "retained changed bytes\n");
+              }
+              if (fault === "index") {
+                git(receiver, ["add", file]);
+              }
+              retained = sourceManifest(receiver, [file]);
+            },
+          );
+          expect(rejected.result.status, failureDetail(rejected.result)).toBe(2);
+          expect(rejected.result.stderr, fault).toContain(message);
+          expect(rejected.result.stdout, fault).not.toContain("transport fixture reached");
+          expect(
+            sourceManifest(
+              rejected.receiver,
+              retained.map(([retainedFile]) => retainedFile),
+            ),
+            fault,
+          ).toEqual(retained);
+          expect(git(rejected.receiver, ["rev-parse", "HEAD"]), fault).toBe(priorHead);
+          expect(readFileSync(path.join(deletionReferent, "canary.txt"), "utf8")).toBe(
+            "private referent\n",
+          );
+        }
         const corrupt = Buffer.from(candidate.bundle);
         const lastIndex = corrupt.length - 1;
         corrupt.writeUInt8(corrupt.readUInt8(lastIndex) ^ 1, lastIndex);


### PR DESCRIPTION
Related: #138612.

## What Problem This Solves

Fixes an issue where developers testing an older source revision on a newer hydrated Testbox would fail source verification before their command ran. Files added by the newer workflow checkout survived in the execution workspace although they were absent from the selected source.

## Why This Change Was Made

The receiver uses the prepared checkout's committed tree solely to prove cleanup ownership. An obsolete, nonignored file is removed only when its bytes, kind and executable mode match that committed entry. The frozen capsule remains the sole authority for the source that executes.

Ancestor ignore rules are retired before their descendants, and Git recomputes eligibility after each removal. This preserves newly protected caches and rejects newly exposed unknown or modified files. Cleanup and final source validation share the existing raw-file verifier.

## User Impact

Older revisions can run against newer Testbox hydration while unrelated untracked, ignored and modified extra data remains intact. Unexpected or modified nonignored source still stops the command. No configuration, dependency or protocol change.

## Evidence

Configured Blacksmith Testbox run [33937838286](https://github.com/openclaw/openclaw/actions/runs/33937838286), lease `tbx_01m1qmqrsh3dwrkhwb08cbt4aa`, Node 24.19.0 / pnpm 12.1.0:

- Real staging passed from workflow `578cb8b9` to selected source `6c63f671` plus this repair. Both previously reported obsolete files were removed; hydrated runtime remained present.
- The original receiver failed both Testbox history cases in the extended regression (2 failed, 2 direct-provider cases passed). The final candidate passed all **307 tests** across `crabbox-wrapper.test.ts` and `testbox-lease-freshness.test.ts`.
- The full `scripts/check-changed.mjs --base 06759eabcbdd33b24ad131627d354e95fbf6cd93` gate passed for both changed files, including script/root-test types, lint and source guards. The normal frozen install and module resolution used a private candidate `node_modules`.
- Final independent Codex review was scoped clean through P2. Tests cover stale indexes, inherited Git routing, raw bytes/mode/kind, symlink parents, unknown/index-only extras, and nested ignore transitions preserving unchanged, modified and untracked cache rules.

The wrapper and proof controller exited 0. The complete 17,204-byte archive and all nine log hashes were verified locally before stop/status confirmed lease completion. Artifact SHA-256: `3e121327c67450bff827df18d1db333c8ad98a21b41b36c841dc231b39e43821`.

Limits and retained failures: two local attempts hit existing deadlines on the loaded macOS host. The first Linux run passed staging/owner tests but failed test lint and relative artifact retrieval; both were corrected for the final run. Its immutable manifest retains an outdated descriptive patch checksum, explicitly qualified by the final asserted source-file hashes and selected Git tree. Linux proof is pinned to `06759eab`; current-main qualification separately covers the incoming artifact-preservation sibling changes and dependency update, with hosted integration CI still required.

Tooling: +32/-8 (net +24); tests: +130/-1. Growth represents the missing prior-source ownership boundary and reuses the existing verifier and Git ignore policy.
