### PR TITLE
improve(codex): reduce startup CPU for large rollouts

### DIFF
--- a/extensions/codex/src/app-server/startup-binding.test.ts
+++ b/extensions/codex/src/app-server/startup-binding.test.ts
@@ -483,36 +483,37 @@ describe("Codex app-server startup binding", () => {
     expect(fileReads).toBeGreaterThan(1);
   });
 
-  it("combines the latest usage with an older context window across rollout tail chunks", async () => {
+  it.each([
+    { boundary: 0, eol: "\n", suffix: "" },
+    { boundary: 1, eol: "\n", suffix: "\n" },
+    { boundary: 65_535, eol: "\r\n", suffix: "\r\n" },
+  ])("reads older windows across byte $boundary", async ({ boundary, eol, suffix }) => {
     const sessionFile = path.join(tempDir, "session.jsonl");
-    const workspaceDir = path.join(tempDir, "workspace");
     const agentDir = path.join(tempDir, "agent");
     const rolloutDir = path.join(agentDir, "codex-home", "sessions");
     const rolloutPath = path.join(rolloutDir, "rollout-thread-existing.jsonl");
     await fs.mkdir(rolloutDir, { recursive: true });
-    await fs.writeFile(
-      rolloutPath,
-      [
-        JSON.stringify({
-          payload: {
-            type: "token_count",
-            info: {
-              last_token_usage: { total_tokens: 1_000 },
-              model_context_window: 128_000,
-            },
+    const tokenRecord = (totalTokens: number, modelContextWindow?: number, text?: string) =>
+      JSON.stringify({
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: { total_tokens: totalTokens },
+            model_context_window: modelContextWindow,
           },
-        }),
-        JSON.stringify({ payload: { type: "agent_message", text: "x".repeat(80_000) } }),
-        JSON.stringify({
-          payload: {
-            type: "token_count",
-            info: { last_token_usage: { total_tokens: 120_000 } },
-          },
-        }),
-        "",
-      ].join("\n"),
-    );
-    await writeExistingBinding(sessionFile, workspaceDir, { rolloutPath });
+          text,
+        },
+      });
+    const latest = tokenRecord(120_000, undefined, "🦞€".repeat(12_000));
+    const afterBoundary = `{malformed${eol}${latest}${suffix}`;
+    const padding =
+      (2 * 65_536 - boundary - 1 - (Buffer.byteLength(afterBoundary) % 65_536)) % 65_536;
+    const older = tokenRecord(1_000, 128_000);
+    const contents = Buffer.from(older + eol + "x".repeat(padding) + afterBoundary);
+    const newlineOffset = Buffer.byteLength(older) + eol.length - 1;
+    expect((newlineOffset - (contents.length % 65_536) + 65_536) % 65_536).toBe(boundary);
+    await fs.writeFile(rolloutPath, contents);
+    await writeExistingBinding(sessionFile, tempDir, { rolloutPath });
 
     const binding = await rotateOversizedCodexAppServerStartupBinding({
       binding: await readCodexAppServerBinding(sessionFile),

--- a/extensions/codex/src/app-server/startup-binding.ts
+++ b/extensions/codex/src/app-server/startup-binding.ts
@@ -274,9 +274,11 @@ async function readCodexAppServerRolloutTokenSnapshot(
         bytesRead += result.bytesRead;
       }
       let lineEnd = bytesRead;
-      for (let index = bytesRead - 1; index >= 0; index -= 1) {
-        if (chunk[index] !== 0x0a) {
-          continue;
+      // Negative Buffer offsets wrap from the end, so stop when byte zero is consumed.
+      while (lineEnd > 0) {
+        const index = chunk.lastIndexOf(0x0a, lineEnd - 1);
+        if (index < 0) {
+          break;
         }
         const lineFragment = chunk.subarray(index + 1, lineEnd);
         const line =


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary startup CPU when a Codex conversation's token snapshot sits behind a large rollout record, or its latest usage needs a context window from an older record.

## Why This Change Was Made

Use native Buffer reverse newline search inside the existing 64 KiB reader. It reconstructs and parses the same complete records, preserving latest usage, older windows, short reads, descriptor cleanup, and the current generation checks before binding clears. The loop stops when its prefix is empty because negative Buffer offsets wrap around.

Production is +5/-3 (net +2) for the native-search loop and its termination comment. The existing older-window test becomes three boundary cases, +25/-24 (net +1).

## User Impact

Large or sparse-token rollouts require less scan CPU when resuming a Codex conversation. Large-record JSON decoding and parsing remain synchronous, so this is a bounded startup improvement.

## Evidence

- Integrated on `f325f4f58d44f9ef1326743c664c603432894b71`, retaining #138473's generation fences. All **140 tests across three files** passed: startup binding, connection preparation, and binding-store ownership. Coverage includes byte 0/1/65,535, split UTF-8, CRLF, malformed/unterminated records, short reads, path/symlink rejection, revoked authority, predecessor-generation lease races, and cancellation cleanup.
- Production and test extension types, scoped typed lint, and formatting pass. Independent Codex P2 review of this integrated diff is clean. The original-base required static checks also passed; unchanged broad checks were not repeated during this integration.
- Paired real-filesystem owner probe on original `05a236c7` versus this exact scan change: four variants, three samples each, Node 26.8.1 on a contended macOS host. With a 32 MiB unrelated record, median process CPU was **405→270 ms** for an older window, **354→290 ms** for a large trailing record, and **403→293 ms** with discovery. All twelve results, read counts/bytes, and JSON parse counts/characters matched; the complete-tail control retained one 64 KiB read. The reader/parser prefix is byte-identical on the integration base.
- The probe uses the existing in-memory binding adapter and excludes SQLite/lease contention. It is not a full Gateway/native startup measurement. Host contention prevents portable wall-time claims; candidate heartbeat gaps still reached 626 ms. Codex 0.153.0's actual token/window and JSONL producer contracts were inspected directly, including legal absent context windows. Native main `c57e3632` now pins 0.153.4; direct inspection of that exact upstream release confirms the six token/rollout producer files remain byte-identical. This qualifies these contracts, not the entire runtime.

Earlier fixture-padding, lint/type, and local command-selection failures are retained in the proof record and corrected; no test deadline or assertion outcome was relaxed. Separate follow-ups cover large-record parsing, the preexisting legacy session-file reader, and opt-in compressed rollouts.

Exact-head CI run **33938705423** completed successfully on `f8b33a290f24d2e950455f61ae7e10c4a0d2ec4b` (36 successful jobs, 17 skipped).
