### PR TITLE
fix(agents): preserve recovered task progress and lifecycle ownership

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -722,11 +722,23 @@ whichever is longer) stop counting as active/pending in `/subagents list`,
 status summaries, descendant completion gating, and per-session
 concurrency checks.
 
-After a gateway restart, stale unended restored runs are pruned unless
-their child session is marked `abortedLastRun: true`. Restart-aborted
-runs remain registered for the sub-agent orphan recovery flow: stale
-runs are finalized without a resume, while fresh child sessions receive
-a synthetic resume message before the aborted marker is cleared.
+After a Gateway restart, fresh interrupted sub-agents resume automatically
+from their existing child transcript. Recovery handles both sessions marked
+`abortedLastRun: true` and hard kills that prevented the shutdown marker from
+being written. For a hard kill, the child session must still identify the exact
+running sub-agent from the retired Gateway process, with no newer run or admitted
+work owning that session. Stale interrupted runs are finalized without a resume;
+other stale unended restored runs are pruned.
+
+An accepted recovery keeps the original task, Task Flow, requester, and child
+session identities. The task returns to `running` as the replacement execution
+continues, and the aborted marker is cleared after acceptance. You do not need
+to send another prompt to restart the work.
+
+For sub-agents that announce completion, OpenClaw also attempts a notice to the
+original requester: “Resumed your interrupted task after the Gateway restart.”
+Failed or suppressed notices are retried without launching another recovery
+turn; completion continues through the normal delivery path.
 
 Automatic restart recovery is bounded per child session. If the same
 sub-agent child is accepted for orphan recovery repeatedly inside the

--- a/src/agents/subagents/registry/subagent-registry-replacement-store.ts
+++ b/src/agents/subagents/registry/subagent-registry-replacement-store.ts
@@ -17,7 +17,6 @@ import {
   readTaskRecord,
   upsertTaskRunRowInDatabase,
 } from "../../../tasks/task-registry.store.sqlite.js";
-import type { TaskRecord } from "../../../tasks/task-registry.types.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
 import { publishSubagentRunsAfterAtomicStore } from "./subagent-registry-state.js";
 import {
@@ -63,7 +62,7 @@ export function commitSubagentTaskReplacement(params: {
   source: SubagentRunRecord;
   successor: SubagentRunRecord;
   task: PreparedCanonicalTaskActivation;
-}): TaskRecord {
+}): void {
   assertReplacementCorrelation(params);
   const changedRows = params.changedRunIds.flatMap((runId) => {
     const entry = params.runs.get(runId);
@@ -112,7 +111,7 @@ export function commitSubagentTaskReplacement(params: {
   subagentRuns.commitOwnership(params.successor);
   const deferredObserverEvents: Array<() => void> = [];
   publishSubagentRunsAfterAtomicStore(params.runs, params.changedRunIds, deferredObserverEvents);
-  const task = publishTaskRecordAfterAtomicStore(params.task.next, {
+  publishTaskRecordAfterAtomicStore(params.task.next, {
     syncTaskFlow: false,
     deferredObserverEvents,
   });
@@ -125,5 +124,4 @@ export function commitSubagentTaskReplacement(params: {
       break;
     }
   }
-  return task;
 }

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery-notice.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery-notice.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import {
+  getAgentEventLifecycleGeneration,
+  rotateAgentEventLifecycleGeneration,
+} from "../../../infra/agent-events.js";
+import type { recoverInterruptedSubagentRow } from "./subagent-registry-restart-recovery.js";
+import { restartRecoveryTestHarness } from "./subagent-registry-restart-recovery.test-support.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+type RecoveryParams = Parameters<typeof recoverInterruptedSubagentRow>[0];
+type ReplaceRunParams = Parameters<RecoveryParams["replaceRun"]>[0];
+
+const {
+  mocks,
+  childSessionKey,
+  gatewayRuntime,
+  dispatchAgent,
+  replaceRun,
+  clearAcceptedRecovery,
+  clearPendingNotice,
+  resumeAcceptedRecovery,
+  warn,
+  run,
+  recover,
+} = restartRecoveryTestHarness;
+
+describe("subagent registry restart recovery notices", () => {
+  beforeEach(() => restartRecoveryTestHarness.reset());
+
+  it("attempts the resumption notice before releasing completion monitoring", async () => {
+    const delivery = createDeferred<{ suppressed: boolean }>();
+    vi.mocked(gatewayRuntime.sendRecoveryNotice).mockImplementationOnce(() => delivery.promise);
+    const entry = run();
+
+    const recovery = recover(entry);
+    await vi.waitFor(() => expect(gatewayRuntime.sendRecoveryNotice).toHaveBeenCalledOnce());
+    expect(entry.resumptionNotice).toEqual({
+      idempotencyKey: expect.stringMatching(/^subagent-recovery:/),
+    });
+    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(resumeAcceptedRecovery).not.toHaveBeenCalled();
+    expect(entry.execution.restartRecovery).toBeUndefined();
+
+    delivery.reject(new Error("delivery unavailable"));
+    await expect(recovery).resolves.toEqual({ status: "accepted" });
+
+    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(resumeAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(entry.execution.restartRecovery).toBeUndefined();
+    expect(entry.resumptionNotice).toEqual({
+      idempotencyKey: expect.stringMatching(/^subagent-recovery:/),
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("could not confirm resumption"),
+      expect.objectContaining({ error: expect.any(Error) }),
+    );
+
+    entry.execution = {
+      ...entry.execution,
+      status: "terminal",
+      endedAt: Date.now(),
+      outcome: { status: "ok" },
+    };
+
+    await expect(recover(entry)).resolves.toEqual({ status: "accepted" });
+
+    expect(gatewayRuntime.sendRecoveryNotice).toHaveBeenCalledTimes(2);
+    expect(clearPendingNotice).toHaveBeenCalledOnce();
+    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(resumeAcceptedRecovery).toHaveBeenCalledTimes(2);
+    expect(entry.execution.restartRecovery).toBeUndefined();
+    expect(entry.resumptionNotice).toBeUndefined();
+  });
+
+  it("keeps non-announcing recovery silent", async () => {
+    const entry = run({ expectsCompletionMessage: false });
+
+    await expect(recover(entry)).resolves.toEqual({ status: "accepted" });
+
+    expect(gatewayRuntime.sendRecoveryNotice).not.toHaveBeenCalled();
+    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(resumeAcceptedRecovery).toHaveBeenCalledOnce();
+  });
+
+  it("retains notice debt when outbound delivery is suppressed", async () => {
+    vi.mocked(gatewayRuntime.sendRecoveryNotice).mockResolvedValueOnce({ suppressed: true });
+    const entry = run();
+
+    await expect(recover(entry)).resolves.toEqual({ status: "accepted" });
+
+    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(resumeAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(clearPendingNotice).not.toHaveBeenCalled();
+    expect(entry.resumptionNotice).toEqual({
+      idempotencyKey: expect.stringMatching(/^subagent-recovery:/),
+    });
+  });
+
+  it("releases terminal cleanup after the resumption notice retry window", async () => {
+    vi.mocked(gatewayRuntime.sendRecoveryNotice).mockResolvedValueOnce({ suppressed: true });
+    const now = Date.now();
+    const entry = run({
+      resumptionNotice: { idempotencyKey: "subagent-recovery:notice-debt" },
+      execution: {
+        status: "terminal",
+        startedAt: now - 180_000,
+        endedAt: now - 120_000,
+        outcome: { status: "ok" },
+      },
+    });
+
+    await expect(recover(entry, { now })).resolves.toEqual({ status: "accepted" });
+
+    expect(clearPendingNotice).toHaveBeenCalledOnce();
+    expect(resumeAcceptedRecovery).toHaveBeenCalledOnce();
+    expect(entry.resumptionNotice).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("exhausted its resumption notice window"),
+      expect.objectContaining({ runId: entry.runId }),
+    );
+  });
+
+  it.each([
+    { label: "confirmed running notice", terminal: false, suppressed: false },
+    { label: "expired terminal notice debt", terminal: true, suppressed: true },
+  ])(
+    "preserves $label when its lifecycle retires during delivery",
+    async ({ terminal, suppressed }) => {
+      const now = Date.now();
+      const pendingNotice = { idempotencyKey: "subagent-recovery:notice-debt" };
+      const entry = run({
+        resumptionNotice: pendingNotice,
+        execution: terminal
+          ? {
+              status: "terminal",
+              startedAt: now - 180_000,
+              endedAt: now - 120_000,
+              outcome: { status: "ok" },
+            }
+          : {
+              status: "running",
+              startedAt: now - 60_000,
+              lifecycleGeneration: getAgentEventLifecycleGeneration(),
+            },
+      });
+      const delivery = createDeferred<{ suppressed: boolean }>();
+      vi.mocked(gatewayRuntime.sendRecoveryNotice).mockImplementationOnce(() => delivery.promise);
+
+      const recovery = recover(entry, { now });
+      await vi.waitFor(() => expect(gatewayRuntime.sendRecoveryNotice).toHaveBeenCalledOnce());
+      const notice = vi.mocked(gatewayRuntime.sendRecoveryNotice).mock.calls[0]![0];
+      expect(notice.isCurrent?.()).toBe(true);
+      rotateAgentEventLifecycleGeneration();
+      expect(notice.isCurrent?.()).toBe(false);
+      delivery.resolve({ suppressed });
+      await recovery;
+
+      expect(entry.resumptionNotice).toEqual(pendingNotice);
+      expect(clearPendingNotice).not.toHaveBeenCalled();
+      expect(resumeAcceptedRecovery).not.toHaveBeenCalled();
+      expect(dispatchAgent).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps notice debt from blocking a later restart recovery", async () => {
+    vi.mocked(gatewayRuntime.sendRecoveryNotice)
+      .mockRejectedValueOnce(new Error("delivery unavailable"))
+      .mockRejectedValueOnce(new Error("delivery still unavailable"));
+    const entry = run();
+    const replacements: SubagentRunRecord[] = [];
+    replaceRun.mockImplementation((params: ReplaceRunParams) => {
+      const replacement = structuredClone(params.expected ?? entry);
+      replacement.runId = params.nextRunId;
+      replacement.execution = {
+        status: "running",
+        startedAt: Date.now(),
+        restartRecovery: params.restartRecovery,
+      };
+      replacements.push(replacement);
+      return true;
+    });
+
+    const getRun = (runId: string) => replacements.find((candidate) => candidate.runId === runId);
+    await expect(recover(entry, { getRun })).resolves.toEqual({ status: "accepted" });
+    const firstSuccessor = replacements[0]!;
+    const firstRecoveryRunId = firstSuccessor.runId;
+    expect(firstSuccessor.execution.restartRecovery).toBeUndefined();
+    expect(firstSuccessor.resumptionNotice?.idempotencyKey).toBe(firstRecoveryRunId);
+    expect(replaceRun.mock.calls[0]?.[0].restartRecovery).toMatchObject({
+      phase: "accepted",
+    });
+
+    firstSuccessor.execution.lifecycleGeneration = getAgentEventLifecycleGeneration();
+    rotateAgentEventLifecycleGeneration();
+    mocks.entries[childSessionKey] = {
+      sessionId: "session-id-2",
+      updatedAt: Date.now() + 1_000,
+      abortedLastRun: true,
+    };
+    await expect(recover(firstSuccessor, { getRun })).resolves.toEqual({ status: "accepted" });
+
+    expect(dispatchAgent).toHaveBeenCalledTimes(2);
+    expect(replacements).toHaveLength(2);
+    expect(replacements[1]!.runId).not.toBe(firstRecoveryRunId);
+    expect(replacements[1]!.execution.restartRecovery).toBeUndefined();
+    expect(replacements[1]!.resumptionNotice).toBeUndefined();
+    expect(replaceRun.mock.calls[1]?.[0].restartRecovery).toMatchObject({
+      phase: "accepted",
+    });
+    expect(gatewayRuntime.sendRecoveryNotice).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { InternalSessionEntry as SessionEntry } from "../../../config/sessions/types.js";
 import {
   getAgentEventLifecycleGeneration,
@@ -13,7 +12,6 @@ import { beginSessionWorkAdmission } from "../../../sessions/session-lifecycle-a
 import { getLatestSubagentRunByChildSessionKeyFromRuns } from "./subagent-registry-queries.js";
 import type { recoverInterruptedSubagentRow } from "./subagent-registry-restart-recovery.js";
 import { restartRecoveryTestHarness } from "./subagent-registry-restart-recovery.test-support.js";
-import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 type RecoveryParams = Parameters<typeof recoverInterruptedSubagentRow>[0];
 type ReplaceRunParams = Parameters<RecoveryParams["replaceRun"]>[0];
@@ -26,7 +24,6 @@ const {
   dispatchAgent,
   replaceRun,
   clearAcceptedRecovery,
-  clearPendingNotice,
   resumeAcceptedRecovery,
   reserveLaunch,
   markLaunchAttempted,
@@ -643,99 +640,6 @@ describe("subagent registry restart recovery", () => {
     });
   });
 
-  it("attempts the resumption notice before releasing completion monitoring", async () => {
-    const delivery = createDeferred<{ suppressed: boolean }>();
-    vi.mocked(gatewayRuntime.sendRecoveryNotice).mockImplementationOnce(() => delivery.promise);
-    const entry = run();
-
-    const recovery = recover(entry);
-    await vi.waitFor(() => expect(gatewayRuntime.sendRecoveryNotice).toHaveBeenCalledOnce());
-    expect(entry.resumptionNotice).toEqual({
-      idempotencyKey: expect.stringMatching(/^subagent-recovery:/),
-    });
-    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
-    expect(resumeAcceptedRecovery).not.toHaveBeenCalled();
-    expect(entry.execution.restartRecovery).toBeUndefined();
-
-    delivery.reject(new Error("delivery unavailable"));
-    await expect(recovery).resolves.toEqual({ status: "accepted" });
-
-    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
-    expect(resumeAcceptedRecovery).toHaveBeenCalledOnce();
-    expect(entry.execution.restartRecovery).toBeUndefined();
-    expect(entry.resumptionNotice).toEqual({
-      idempotencyKey: expect.stringMatching(/^subagent-recovery:/),
-    });
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("could not confirm resumption"),
-      expect.objectContaining({ error: expect.any(Error) }),
-    );
-
-    entry.execution = {
-      ...entry.execution,
-      status: "terminal",
-      endedAt: Date.now(),
-      outcome: { status: "ok" },
-    };
-
-    await expect(recover(entry)).resolves.toEqual({ status: "accepted" });
-
-    expect(gatewayRuntime.sendRecoveryNotice).toHaveBeenCalledTimes(2);
-    expect(clearPendingNotice).toHaveBeenCalledOnce();
-    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
-    expect(resumeAcceptedRecovery).toHaveBeenCalledTimes(2);
-    expect(entry.execution.restartRecovery).toBeUndefined();
-    expect(entry.resumptionNotice).toBeUndefined();
-  });
-
-  it("keeps non-announcing recovery silent", async () => {
-    const entry = run({ expectsCompletionMessage: false });
-
-    await expect(recover(entry)).resolves.toEqual({ status: "accepted" });
-
-    expect(gatewayRuntime.sendRecoveryNotice).not.toHaveBeenCalled();
-    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
-    expect(resumeAcceptedRecovery).toHaveBeenCalledOnce();
-  });
-
-  it("retains notice debt when outbound delivery is suppressed", async () => {
-    vi.mocked(gatewayRuntime.sendRecoveryNotice).mockResolvedValueOnce({ suppressed: true });
-    const entry = run();
-
-    await expect(recover(entry)).resolves.toEqual({ status: "accepted" });
-
-    expect(clearAcceptedRecovery).toHaveBeenCalledOnce();
-    expect(resumeAcceptedRecovery).toHaveBeenCalledOnce();
-    expect(clearPendingNotice).not.toHaveBeenCalled();
-    expect(entry.resumptionNotice).toEqual({
-      idempotencyKey: expect.stringMatching(/^subagent-recovery:/),
-    });
-  });
-
-  it("releases terminal cleanup after the resumption notice retry window", async () => {
-    vi.mocked(gatewayRuntime.sendRecoveryNotice).mockResolvedValueOnce({ suppressed: true });
-    const now = Date.now();
-    const entry = run({
-      resumptionNotice: { idempotencyKey: "subagent-recovery:notice-debt" },
-      execution: {
-        status: "terminal",
-        startedAt: now - 180_000,
-        endedAt: now - 120_000,
-        outcome: { status: "ok" },
-      },
-    });
-
-    await expect(recover(entry, { now })).resolves.toEqual({ status: "accepted" });
-
-    expect(clearPendingNotice).toHaveBeenCalledOnce();
-    expect(resumeAcceptedRecovery).toHaveBeenCalledOnce();
-    expect(entry.resumptionNotice).toBeUndefined();
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("exhausted its resumption notice window"),
-      expect.objectContaining({ runId: entry.runId }),
-    );
-  });
-
   it("keeps a definitive accepted response when the consumed write fails", async () => {
     const entry = run();
     markLaunchConsumed.mockImplementationOnce((params) => {
@@ -1005,54 +909,6 @@ describe("subagent registry restart recovery", () => {
     expect(mocks.patchSessionEntryCore).not.toHaveBeenCalled();
     expect(clearAcceptedRecovery).not.toHaveBeenCalled();
     expect(successor.execution.restartRecovery).toMatchObject({ phase: "accepted" });
-  });
-
-  it("keeps notice debt from blocking a later restart recovery", async () => {
-    vi.mocked(gatewayRuntime.sendRecoveryNotice)
-      .mockRejectedValueOnce(new Error("delivery unavailable"))
-      .mockRejectedValueOnce(new Error("delivery still unavailable"));
-    const entry = run();
-    const replacements: SubagentRunRecord[] = [];
-    replaceRun.mockImplementation((params: ReplaceRunParams) => {
-      const replacement = structuredClone(params.expected ?? entry);
-      replacement.runId = params.nextRunId;
-      replacement.execution = {
-        status: "running",
-        startedAt: Date.now(),
-        restartRecovery: params.restartRecovery,
-      };
-      replacements.push(replacement);
-      return true;
-    });
-
-    const getRun = (runId: string) => replacements.find((candidate) => candidate.runId === runId);
-    await expect(recover(entry, { getRun })).resolves.toEqual({ status: "accepted" });
-    const firstSuccessor = replacements[0]!;
-    const firstRecoveryRunId = firstSuccessor.runId;
-    expect(firstSuccessor.execution.restartRecovery).toBeUndefined();
-    expect(firstSuccessor.resumptionNotice?.idempotencyKey).toBe(firstRecoveryRunId);
-    expect(replaceRun.mock.calls[0]?.[0].restartRecovery).toMatchObject({
-      phase: "accepted",
-    });
-
-    firstSuccessor.execution.lifecycleGeneration = getAgentEventLifecycleGeneration();
-    rotateAgentEventLifecycleGeneration();
-    mocks.entries[childSessionKey] = {
-      sessionId: "session-id-2",
-      updatedAt: Date.now() + 1_000,
-      abortedLastRun: true,
-    };
-    await expect(recover(firstSuccessor, { getRun })).resolves.toEqual({ status: "accepted" });
-
-    expect(dispatchAgent).toHaveBeenCalledTimes(2);
-    expect(replacements).toHaveLength(2);
-    expect(replacements[1]!.runId).not.toBe(firstRecoveryRunId);
-    expect(replacements[1]!.execution.restartRecovery).toBeUndefined();
-    expect(replacements[1]!.resumptionNotice).toBeUndefined();
-    expect(replaceRun.mock.calls[1]?.[0].restartRecovery).toMatchObject({
-      phase: "accepted",
-    });
-    expect(gatewayRuntime.sendRecoveryNotice).toHaveBeenCalledTimes(3);
   });
 
   it("tombstones a rapid third accepted recovery", async () => {

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery.ts
@@ -49,17 +49,21 @@ export async function recoverInterruptedSubagentRow(
   }
   const pendingNotice = params.entry.resumptionNotice;
   if (pendingNotice) {
+    const isNoticeOwnerCurrent = () =>
+      isRecoveryAttemptLifecycleCurrent() &&
+      params.isCurrent(params.runId, params.entry) &&
+      params.entry.resumptionNotice === pendingNotice;
     const confirmed = await confirmAcceptedRecoveryResumption({
       childSessionKey,
       gatewayRuntime: params.gatewayRuntime,
       idempotencyKey: pendingNotice.idempotencyKey,
-      isOwnerCurrent: () =>
-        isRecoveryAttemptLifecycleCurrent() &&
-        params.isCurrent(params.runId, params.entry) &&
-        params.entry.resumptionNotice === pendingNotice,
+      isOwnerCurrent: isNoticeOwnerCurrent,
       owner: params.entry,
       warn: params.warn,
     });
+    if (!isNoticeOwnerCurrent()) {
+      return { status: "handled" };
+    }
     const endedAt = params.entry.execution.endedAt;
     const terminalNoticeExpired =
       typeof endedAt === "number" &&

--- a/src/agents/subagents/registry/subagent-registry-state.ts
+++ b/src/agents/subagents/registry/subagent-registry-state.ts
@@ -145,15 +145,10 @@ function rememberPersistedSubagentRunsSnapshot(
 export function publishSubagentRunsAfterAtomicStore(
   runs: Map<string, SubagentRunRecord>,
   changedRunIds: readonly string[],
-  deferredObserverEvents?: Array<() => void>,
+  deferredObserverEvents: Array<() => void>,
 ): void {
   rememberPersistedSubagentRunsSnapshot(runs, changedRunIds);
-  const emit = () => emitSubagentRegistryPersisted();
-  if (deferredObserverEvents) {
-    deferredObserverEvents.push(emit);
-  } else {
-    emit();
-  }
+  deferredObserverEvents.push(() => emitSubagentRegistryPersisted());
 }
 
 function shouldReadPersistedSubagentRuns(): boolean {

--- a/src/agents/subagents/registry/subagent-registry-task-replacement.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-task-replacement.test.ts
@@ -12,7 +12,11 @@ import type { WorkerConnectionIdentity } from "../../../gateway/worker-environme
 import { createWorkerLiveEventReceiver } from "../../../gateway/worker-environments/live-events.js";
 import { createWorkerSessionPlacementStore } from "../../../gateway/worker-environments/placement-store.js";
 import { createWorkerSessionPlacementGate } from "../../../gateway/worker-environments/placement-worker-gate.js";
-import { getAgentEventLifecycleGeneration, onAgentEvent } from "../../../infra/agent-events.js";
+import {
+  emitAgentEvent,
+  getAgentEventLifecycleGeneration,
+  onAgentEvent,
+} from "../../../infra/agent-events.js";
 import {
   getAgentRunContext,
   getAgentRunContextOwnership,
@@ -432,9 +436,47 @@ it("rearms the canonical task and mirrored flow for an interrupted run's success
   expect(getTaskById(originalTask.taskId)).toEqual(task);
   expect(getTaskFlowById(flowId)).toEqual(flow);
 
+  const activityAt = task.lastEventAt! + 60_001;
+  const clock = vi.spyOn(Date, "now").mockReturnValue(activityAt);
+  try {
+    emitAgentEvent({
+      runId: successor.runId,
+      sessionKey: childSessionKey,
+      stream: "assistant",
+      data: { text: "Resumed work is progressing" },
+    });
+    expect
+      .soft(getTaskActivitySnapshot(task.taskId)?.lastActivity)
+      .toBe("Resumed work is progressing");
+    expect.soft(getTaskById(task.taskId)?.lastEventAt).toBe(activityAt);
+    emitAgentEvent({
+      runId: successor.runId,
+      sessionKey: childSessionKey,
+      stream: "tool",
+      data: { phase: "start", name: "read" },
+    });
+    expect.soft(getTaskById(task.taskId)).toMatchObject({
+      toolUseCount: 1,
+      lastToolName: "read",
+    });
+    const currentActivity = getTaskActivitySnapshot(task.taskId);
+    const currentTask = getTaskById(task.taskId);
+    for (const event of [
+      { stream: "assistant", data: { text: "Retired owner progress" } },
+      { stream: "tool", data: { phase: "start", name: "write" } },
+      { stream: "error", data: { error: "Retired owner error" } },
+    ]) {
+      emitAgentEvent({ runId: previous.runId, sessionKey: childSessionKey, ...event });
+    }
+    expect.soft(getTaskActivitySnapshot(task.taskId)).toEqual(currentActivity);
+    expect.soft(getTaskById(task.taskId)).toEqual(currentTask);
+  } finally {
+    clock.mockRestore();
+  }
+
   const staleFlow = failFlow({
     flowId,
-    expectedRevision: flow.revision,
+    expectedRevision: getTaskFlowById(flowId)!.revision,
     endedAt: Date.now(),
   });
   expect(staleFlow.applied).toBe(true);

--- a/src/agents/subagents/spawn/subagent-spawn-cleanup.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-cleanup.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { withPluginRuntimeGatewayRequestScope } from "../../../plugins/runtime/gateway-request-scope.js";
 import {
   cleanupProvisionalSession,
   terminateAcceptedCollectorRun,
@@ -110,6 +111,26 @@ describe("subagent spawn cleanup identity", () => {
       },
       timeoutMs: 60_000,
     });
+  });
+
+  it("stops accepted-run cleanup when its Gateway request owner is retired", async () => {
+    const callGateway = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Gateway request owner is retired"))
+      .mockResolvedValue({ aborted: false, runIds: [] });
+
+    await withPluginRuntimeGatewayRequestScope(
+      { resolveGatewayContext: () => undefined, isWebchatConnect: () => false },
+      () =>
+        terminateAcceptedCollectorRun({
+          childSessionKey: "agent:main:subagent:child",
+          gatewayRunId: "gateway-run",
+          sessionCleanup: "preserve",
+          callGateway,
+        }),
+    );
+
+    expect(callGateway).toHaveBeenCalledOnce();
   });
 
   it("stops cleanup when guarded deletion observes a successor lifecycle", async () => {

--- a/src/agents/subagents/spawn/subagent-spawn-cleanup.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-cleanup.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import type { callGateway } from "../../../gateway/call.js";
 import { isFastTestRuntimeEnv } from "../../../infra/env.js";
+import { getPluginRuntimeGatewayRequestScope } from "../../../plugins/runtime/gateway-request-scope.js";
 import { deleteSubagentSessionForCleanup } from "../registry/subagent-session-cleanup.js";
 import { callSubagentGateway } from "./subagent-spawn-gateway.js";
 
@@ -134,39 +135,47 @@ export async function terminateAcceptedCollectorRun(params: {
 }): Promise<void> {
   const call = params.callGateway ?? callSubagentGateway;
   const timeoutMs = params.timeoutMs ?? SUBAGENT_CONTROL_GATEWAY_TIMEOUT_MS;
-  await retrySubagentCleanup(async () => {
-    try {
-      const response = await call({
-        method: "chat.abort",
-        params: { sessionKey: params.childSessionKey, runId: params.gatewayRunId },
-        timeoutMs,
-      });
-      if (isMatchingAbortResponse(response, params.gatewayRunId)) {
-        return true;
+  const resolveGatewayContext = getPluginRuntimeGatewayRequestScope()?.resolveGatewayContext;
+  await retrySubagentCleanup(
+    async () => {
+      try {
+        const response = await call({
+          method: "chat.abort",
+          params: { sessionKey: params.childSessionKey, runId: params.gatewayRunId },
+          timeoutMs,
+        });
+        if (isMatchingAbortResponse(response, params.gatewayRunId)) {
+          return true;
+        }
+        if (
+          params.sessionCleanup === "preserve" &&
+          isDefinitiveAbortMiss(response, params.gatewayRunId)
+        ) {
+          return true;
+        }
+      } catch {
+        if (params.sessionCleanup === "preserve") {
+          return false;
+        }
+        // Fall through to exact-session deletion for provisional sessions only.
       }
-      if (
-        params.sessionCleanup === "preserve" &&
-        isDefinitiveAbortMiss(response, params.gatewayRunId)
-      ) {
-        return true;
-      }
-    } catch {
       if (params.sessionCleanup === "preserve") {
         return false;
       }
-      // Fall through to exact-session deletion for provisional sessions only.
-    }
-    if (params.sessionCleanup === "preserve") {
-      return false;
-    }
-    const cleanup = await requestProvisionalSessionCleanup(params.childSessionKey, {
-      deleteTranscript: true,
-      expectedSessionId: params.expectedSessionId,
-      expectedLifecycleRevision: params.expectedLifecycleRevision,
-      callGateway: call,
-      timeoutMs,
-    });
-    // A changed lifecycle proves the accepted run no longer owns this session.
-    return cleanup !== "failed";
-  });
+      const cleanup = await requestProvisionalSessionCleanup(params.childSessionKey, {
+        deleteTranscript: true,
+        expectedSessionId: params.expectedSessionId,
+        expectedLifecycleRevision: params.expectedLifecycleRevision,
+        callGateway: call,
+        timeoutMs,
+      });
+      // A changed lifecycle proves the accepted run no longer owns this session.
+      return cleanup !== "failed";
+    },
+    {
+      // A retired request scope can never dispatch again; retrying would retain
+      // its Gateway forever without terminating the accepted run.
+      shouldRetry: () => !resolveGatewayContext || Boolean(resolveGatewayContext()),
+    },
+  );
 }

--- a/src/tasks/task-backing-authority-write.ts
+++ b/src/tasks/task-backing-authority-write.ts
@@ -47,12 +47,10 @@ export function prepareCanonicalTaskActivation(
   ) {
     return { current, next };
   }
-  Object.assign(next, {
-    status: "running" as const,
-    startedAt: current.startedAt ?? params.startedAt,
-    lastEventAt: params.startedAt,
-    deliveryStatus: "pending" as const,
-  });
+  next.status = "running";
+  next.startedAt = current.startedAt ?? params.startedAt;
+  next.lastEventAt = params.startedAt;
+  next.deliveryStatus = "pending";
   delete next.endedAt;
   delete next.cleanupAfter;
   delete next.error;

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -775,22 +775,17 @@ export function prepareTaskMirroredFlowSync(
 /** Publishes a mirrored flow record already committed by a shared-state transaction. */
 export function publishTaskFlowAfterAtomicStore(
   prepared: PreparedTaskMirroredFlowSync,
-  deferredObserverEvents?: Array<() => void>,
-): TaskFlowRecord {
+  deferredObserverEvents: Array<() => void>,
+): void {
   const next = cloneFlowRecord(prepared.next);
   flows.set(next.flowId, next);
-  const emit = () =>
+  deferredObserverEvents.push(() =>
     emitFlowRegistryObserverEvent(() => ({
       kind: "upserted",
       flow: cloneFlowRecord(next),
       previous: cloneFlowRecord(prepared.current),
-    }));
-  if (deferredObserverEvents) {
-    deferredObserverEvents.push(emit);
-  } else {
-    emit();
-  }
-  return cloneFlowRecord(next);
+    })),
+  );
 }
 
 export function getTaskFlowById(flowId: string): TaskFlowRecord | undefined {

--- a/src/tasks/task-registry-lifecycle.ts
+++ b/src/tasks/task-registry-lifecycle.ts
@@ -1,4 +1,5 @@
 import { buildAgentRunTerminalOutcomeFromLifecycleEvent } from "../agents/agent-run-terminal-outcome.js";
+import { subagentRuns } from "../agents/subagents/registry/subagent-registry-memory.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { hasAuthoritativeTaskBacking, readTaskBackingInstance } from "./task-backing-authority.js";
 import { isTerminalTaskStatus } from "./task-executor-policy.js";
@@ -35,12 +36,34 @@ function ensureListener() {
       runId: evt.runId,
       sessionKey: evt.sessionKey,
     });
+    const subagent = subagentRuns.get(evt.runId);
+    const canonicalRunId = subagent?.taskRunId;
+    // Replacement runs retain the original task identity. Follow the live
+    // registry owner without changing event routing for other task runtimes.
+    if (canonicalRunId && canonicalRunId !== evt.runId) {
+      scopedTasks.push(
+        ...getTasksByRunScope({
+          runId: canonicalRunId,
+          runtime: "subagent",
+          sessionKey: evt.sessionKey,
+        }).filter((task) => readTaskBackingInstance(task.detail)?.runtime === "subagent"),
+      );
+    }
     if (scopedTasks.length === 0) {
       return;
     }
     const now = evt.ts || Date.now();
     for (const current of scopedTasks) {
-      if (isTerminalTaskStatus(current.status) || !hasAuthoritativeTaskBacking(current)) {
+      const backing = readTaskBackingInstance(current.detail);
+      const registryBackedSubagent =
+        current.runtime === "subagent" && backing?.runtime === "subagent";
+      if (
+        isTerminalTaskStatus(current.status) ||
+        !hasAuthoritativeTaskBacking(current) ||
+        (registryBackedSubagent &&
+          (subagent?.generation !== backing.generation ||
+            subagent?.childSessionKey !== current.childSessionKey))
+      ) {
         continue;
       }
       recordTaskActivityEvent(current, evt);
@@ -61,10 +84,7 @@ function ensureListener() {
         } else if (phase === "end" || phase === "error") {
           // Registry-backed subagents keep task.runId across replacement runs.
           // Their registry owns terminal projection; predecessor events do not.
-          if (
-            current.runtime === "subagent" &&
-            readTaskBackingInstance(current.detail)?.runtime === "subagent"
-          ) {
+          if (registryBackedSubagent) {
             continue;
           }
           const terminal = buildAgentRunTerminalOutcomeFromLifecycleEvent({

--- a/test/vitest/vitest.agents-paths.mjs
+++ b/test/vitest/vitest.agents-paths.mjs
@@ -19,6 +19,7 @@ const coreIsolatedFiles = [
   "src/agents/models-config.runtime-source-snapshot.test.ts",
   "src/agents/openai-transport-stream.streaming.test.ts",
   "src/agents/subagents/registry/subagent-registry.announce-loop-guard.test.ts",
+  "src/agents/subagents/registry/subagent-registry-restart-recovery-notice.test.ts",
   "src/agents/subagents/registry/subagent-registry-restart-recovery.test.ts",
 ];
 const incompleteTurnFiles = [


### PR DESCRIPTION
Related: #138394, #137991. Separate persistence follow-up: #138783.

## What Problem This Solves

Fixes an issue where automatically recovered subagent tasks stopped showing progress, while late events from their predecessor could overwrite activity or errors. It also fixes cleanup retrying after its Gateway retires and pending resumption notices settling state after lifecycle retirement.

## Why This Change Was Made

The registry remains the execution owner, and the task retains its logical identity across replacement runs. Task activity now follows the current registry generation and child session, preserving direct-run ACP/CLI routes. Cleanup uses its existing Gateway-scope liveness predicate; notice settlement revalidates the same owner immediately after awaited delivery.

Atomic publication helpers now require deferred observers where their sole caller already deferred them, discard unused return values, and avoid an unnecessary clone. The recovery notice tests share the existing isolated harness in a focused sibling suite. Recovery docs now describe hard kills and the requester notice.

Production LOC: +86/-67 (net +19). Tests/support: +279/-146 (net +133, including moved notice cases). Docs: +17/-5. The production growth provides current-owner event correlation and lifecycle fencing; unused publication branches were removed. No schema, configuration, dependency, protocol or transaction-validation change.

This follows the restart-recovery work by @fuller-stack-dev in #138394. The separately reproduced acceptance-write failure is tracked in #138783 and is not claimed fixed here.

## User Impact

Recovered tasks keep visible assistant/tool progress without accepting stale predecessor updates. Gateway retirement releases pending cleanup, and a notice that finishes after retirement cannot clear the retired owner's recovery state. Existing task, flow, requester and child-session identities remain stable.

## Evidence

Before the fixes, real event/registry tests lost successor activity and accepted predecessor activity; the cleanup regression issued a second abort after retirement; both held-send notice cases cleared debt after lifecycle rotation. Those regressions now pass.

- 216 focused tests passed: task registry (150), Gateway runtime (7), replacement/recovery/cleanup (59). After moving notice tests, all 59 focused tests passed again without exclusions.
- Full changed-scope checks passed: formatting, core/test type graphs, core/tooling lint, dead exports, plugin boundaries, schema v15, database-first storage, import cycles, and webhook/pairing guards.
- Fresh independent Codex P0–P2 review: scoped-clean. The unresolved #138783 is explicitly recorded as an unchanged base defect.

### Live OpenAI hard-restart proof

[Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/33936150641), through Crabbox, lease `tbx_01m1qjrh3zwpegkvpm39e1qfaf` (stopped). The wrapper verified source `1426e49d2b26c5f4a9e8db1c1ed96c15d701643a` with the candidate changes; all seven changed production modules were compared byte-for-byte with this PR's files. Proof used an ephemeral Gateway, a synthetic QA channel, and a real OpenAI key from the prepared test environment, confined to a loopback provider proxy.

```text
model: gpt-5.6-luna
OpenAI Responses requests: 5, all HTTP 200
SIGKILL -> automatic successor generation: 1 -> 2
canonical task/flow and requester/child identities: preserved
operator prompt required: false
resumption confirmations: 1
completion replies: 1
exec/wait calls before restart: 1/1
exec/wait calls after second restart + 65-second sweep: 1/1
task and flow after reopening: succeeded
```

The stopped-Gateway failure projection was explicit fault injection; it is not claimed to arise naturally from every SIGKILL. This is bounded recovery/replay evidence, not a general exactly-once guarantee for external effects. Initial remote attempts failed before tests due to missing prepared dependencies and a stale hydration/source mismatch; a matching fresh lease passed without weakening source verification.

Direct Codex dependency inspection at `07f18d5ff74bb361b46e1eacab0bddc28da26752` checked `codex-rs/app-server-protocol/src/protocol/common.rs:530-535,982-987` and `codex-rs/app-server/src/request_processors/thread_lifecycle.rs:568-760`: thread resume reports/attaches thread state; starting a turn is a separate request. This repair stays in OpenClaw lifecycle ownership.
