### PR TITLE
fix(macos): hide the dashboard titlebar toolbar in native fullscreen

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -15,6 +15,8 @@ private final class DashboardWindowContentView: NSView {
 /// Toolbar` (and ⌥⌘T) would collapse the titlebar while the web inset stays
 /// pinned at `--openclaw-native-titlebar-height`, resurrecting the traffic-light
 /// misalignment. Refusing the toggle keeps the two heights in lockstep.
+/// Native fullscreen removes the traffic lights, so delegate callbacks hide the toolbar; init
+/// reconciles reused fullscreen windows while the web row keeps hosting `.macos-titlebar-controls`.
 private final class DashboardWindow: NSWindow {
     /// User intent belongs to the native window, not the privileged document it hosts.
     var userIntentGeneration: UInt64 = 0
@@ -255,6 +257,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             self?.persistLinkBrowserWidth()
         }
         self.window?.delegate = self
+        self.applyFullScreenChrome(isFullScreen: window.styleMask.contains(.fullScreen))
         self.installHistoryStateBridge()
         if restoreKeyboardFocus {
             window.makeFirstResponder(self.webView)
@@ -1210,6 +1213,8 @@ extension DashboardWindowController {
         self.currentURL
     }
 
+    // MARK: - NSWindowDelegate
+
     func windowWillClose(_: Notification) {
         (self.window as? DashboardWindow)?.lifetimeRevision &+= 1
         self.advanceWindowIntent()
@@ -1222,6 +1227,18 @@ extension DashboardWindowController {
         self.webView.stopLoading()
         self.closeLinkBrowser(focusDashboard: false)
         self.onClosed?()
+    }
+
+    func windowDidEnterFullScreen(_: Notification) {
+        self.applyFullScreenChrome(isFullScreen: true)
+    }
+
+    func windowDidExitFullScreen(_: Notification) {
+        self.applyFullScreenChrome(isFullScreen: false)
+    }
+
+    private func applyFullScreenChrome(isFullScreen: Bool) {
+        self.window?.toolbar?.isVisible = !isFullScreen
     }
 
     func webView(

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -114,8 +114,19 @@ struct DashboardWindowSmokeTests {
         // The empty unified toolbar is what grows the titlebar to 52pt so the
         // traffic lights center against the web titlebar row; without it they
         // hug the top edge and misalign with the hosted web buttons.
-        #expect(controller.window?.toolbar != nil)
+        let toolbar = try #require(controller.window?.toolbar)
         #expect(controller.window?.toolbarStyle == .unified)
+        #expect(controller.window?.toolbar?.isVisible == true)
+        NotificationCenter.default.post(
+            name: NSWindow.didEnterFullScreenNotification,
+            object: controller.window)
+        #expect(controller.window?.toolbar?.isVisible == false)
+        #expect(controller.window?.toolbar === toolbar)
+        NotificationCenter.default.post(
+            name: NSWindow.didExitFullScreenNotification,
+            object: controller.window)
+        #expect(controller.window?.toolbar?.isVisible == true)
+        #expect(controller.window?.toolbar === toolbar)
         // The toolbar only exists to size the titlebar, so View > Hide Toolbar
         // (⌥⌘T) must be refused; otherwise hiding it desyncs the 52pt web inset.
         controller.window?.toggleToolbarShown(nil)
@@ -124,6 +135,84 @@ struct DashboardWindowSmokeTests {
         #expect((controller.window?.frame.height ?? 0) >= DashboardWindowLayout.windowMinSize.height)
         #expect(controller.window?.frameAutosaveName == windowAutosaveName)
         controller.closeDashboard()
+    }
+
+    @Test func `dashboard reused window reconciles toolbar visibility in init`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let url = server.url("/control/#token=device-token")
+        let controller = DashboardWindowController(
+            url: url,
+            auth: DashboardWindowAuth(
+                gatewayUrl: server.websocketURL("/control/").absoluteString,
+                token: "device-token",
+                password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
+        controller.show()
+        let originalWindow = try #require(controller.window)
+        let originalToolbar = try #require(originalWindow.toolbar)
+        #expect(originalToolbar.isVisible == true)
+        NotificationCenter.default.post(
+            name: NSWindow.didEnterFullScreenNotification,
+            object: originalWindow)
+        #expect(originalToolbar.isVisible == false)
+
+        let transferredWindow = try #require(controller.detachWindowForReplacement())
+        let replacement = DashboardWindowController(
+            url: url,
+            auth: controller.auth,
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            reusingWindow: transferredWindow,
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { replacement.closeDashboard() }
+
+        #expect(replacement.window === originalWindow)
+        #expect(replacement.window?.toolbar !== originalToolbar)
+        // New toolbar inherits hidden state; .fullScreen off-transition throws NSGenericException.
+        #expect(replacement.window?.toolbar?.isVisible == true)
+    }
+
+    @Test func `dashboard fullscreen toolbar state is per window`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let url = server.url("/control/#token=device-token")
+        let firstController = DashboardWindowController(
+            url: url,
+            auth: DashboardWindowAuth(
+                gatewayUrl: server.websocketURL("/control/").absoluteString,
+                token: "device-token",
+                password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { firstController.closeDashboard() }
+        let secondController = DashboardWindowController(
+            url: url,
+            auth: firstController.auth,
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { secondController.closeDashboard() }
+        firstController.show()
+        secondController.show()
+        #expect(firstController.window?.toolbar?.isVisible == true)
+        #expect(secondController.window?.toolbar?.isVisible == true)
+
+        NotificationCenter.default.post(
+            name: NSWindow.didEnterFullScreenNotification,
+            object: firstController.window)
+        #expect(firstController.window?.toolbar?.isVisible == false)
+        #expect(secondController.window?.toolbar?.isVisible == true)
+
+        NotificationCenter.default.post(
+            name: NSWindow.didExitFullScreenNotification,
+            object: firstController.window)
+        #expect(firstController.window?.toolbar?.isVisible == true)
+        #expect(secondController.window?.toolbar?.isVisible == true)
     }
 
     @Test func `dashboard context menu removes browser items and collapses separators`() {


### PR DESCRIPTION
Fixes #136131

## What Problem This Solves

The native macOS dashboard window installs an empty unified `NSToolbar` whose only job is to grow the transparent titlebar to 52pt so the traffic lights line up with the hosted web titlebar row. In native fullscreen (green button / ⌃⌘F) AppKit removes the traffic lights but keeps that empty toolbar attached to the top of the screen, so a blank ~52pt band spans the whole top edge and the dashboard starts below it. Leaving fullscreen restores the normal layout. `DashboardWindowController` is the window delegate but had no fullscreen callbacks, so nothing reconciled the toolbar with the fullscreen state.

## Why This Change Was Made

Following the fix shape in the ClawSweeper advisory on the issue (one fullscreen-aware chrome owner in `DashboardWindowController`), with one deliberate deviation explained below.

Change (`apps/macos/Sources/OpenClaw/DashboardWindowController.swift`, +17 lines, no other production file):

- `windowDidEnterFullScreen` / `windowDidExitFullScreen` call a single private owner, `applyFullScreenChrome(isFullScreen:)`, which only toggles `window.toolbar?.isVisible`. Using the `Did*` callbacks (no stored flag, no `Will*` pre-emption) means a cancelled transition never leaves stale chrome, and exit restores the exact 52pt titlebar contract.
- `init` applies the same state once from the window's real style mask, because `makeWindow(reusing:)` re-installs a fresh (visible) toolbar on a reused window. This matters for `DashboardManager.replaceWindowController`, which transfers the live window to a new controller for background gateway/route/document-isolation changes and does not call `show()` when the window is already open; a fullscreen window replaced that way would otherwise get the band back. (Three independent pre-submission reviews converged on this path; it was fixed before submission.)
- The toolbar object is kept (`isVisible`, never `toolbar = nil`) so its identifier and the 52pt sizing survive the round trip. The existing refusal of `View > Hide Toolbar` (⌥⌘T) is untouched.
- One sentence added to the header comment that documents the toolbar contract.

Deviation from the advisory: the web-side clearance (`--openclaw-native-titlebar-height: 52px`, injected by the `WKUserScript`) is intentionally **not** collapsed to 0 in fullscreen. That variable is not only padding: `ui/src/styles/layout.css` sizes `.macos-titlebar-controls` (the hosted back/forward, search and new-session buttons) with it, `sidebar-attention-floating.css` positions the floating attention badge from it, and `chat/split-view.css` / `sidebar-update-card.css` size against it. A 0px value clips those buttons at the top edge and pushes the badge off-screen. In fullscreen the top row is therefore the web app's own titlebar row (as Safari keeps its toolbar row in fullscreen), and only the blank native band goes away. A first pass of this PR did push 0px; it was reverted for that reason before submission.

Production LOC closeout: `DashboardWindowController.swift` +17/−0, tests +90/−1, no other files; no test-only seam in production. Net-neutral alternative considered and rejected: `window(_:willUseFullScreenPresentationOptions:)` returning `.autoHideToolbar` (~4 lines). It hides the toolbar together with the menu bar, but the empty 52pt band comes back as an overlay every time the pointer reaches the top edge, and its behavior with an empty unified toolbar cannot be reasoned about statically; the explicit `isVisible` toggle is deterministic and keeps the band gone for the whole fullscreen session. There is no existing owner that can absorb the state change: `toggleToolbarShown` is a deliberate no-op, and no fullscreen callback existed. The remaining growth is the two delegate callbacks, the one-line owner, and the `init` reconciliation.

AppKit contracts relied on (Apple Developer Documentation): [`NSWindowDelegate.windowDidEnterFullScreen(_:)`](https://developer.apple.com/documentation/appkit/nswindowdelegate/windowdidenterfullscreen(_:)) and [`windowDidExitFullScreen(_:)`](https://developer.apple.com/documentation/appkit/nswindowdelegate/windowdidexitfullscreen(_:)) are sent after the transition completes; [`NSWindow.StyleMask.fullScreen`](https://developer.apple.com/documentation/appkit/nswindow/stylemask/fullscreen) is set while the window is in fullscreen; [`NSToolbar.isVisible`](https://developer.apple.com/documentation/appkit/nstoolbar/isvisible) shows or hides the toolbar without detaching it from the window (so the identifier and configuration survive); [`NSWindow.toggleToolbarShown(_:)`](https://developer.apple.com/documentation/appkit/nswindow/toggletoolbarshown(_:)) is the user-facing toggle this window deliberately refuses.

Not in scope: shrinking the left inset of `.macos-titlebar-controls` while the traffic lights are absent (web-side polish, no functional impact).

## User Impact

Entering native fullscreen no longer leaves a blank white strip across the top of the screen; the dashboard extends to the top edge with its own titlebar row. Leaving fullscreen restores the previous titlebar and traffic-light alignment exactly. No config, no behavior change outside fullscreen transitions.

## Evidence

Build and tests on macOS 26 / Xcode 26.5 / Swift 6.3.2, run through the repo's isolating launcher `scripts/test-macos-native.mts` (private HOME/config/state/TMPDIR, disposable Keychain — the same launcher the `macos-swift` CI job uses):

- `swift build --package-path apps/macos --product OpenClaw` — OK (also after rebasing on `main` d2d79f940e)
- `swift build --package-path apps/macos --build-system native --build-tests` — OK
- `DashboardWindowSmokeTests` — base 36/36 passed; fix 38/38 passed. Assertions in `dashboard window controller shows and closes` (windowed default visible → `didEnterFullScreenNotification` hides → same toolbar instance → `didExitFullScreenNotification` restores → existing ⌥⌘T refusal check), `dashboard reused window reconciles toolbar visibility in init` (hidden via the delegate path, `detachWindowForReplacement()`, replacement controller with `reusingWindow:` and no `show()` → same window, new toolbar instance, visible again) and `dashboard fullscreen toolbar state is per window` (two dashboards; enter/exit posted for one leaves the other untouched)
- Pre-fix red: with `DashboardWindowController.swift` at base and the test file kept, the target compiles and the new expectations fail by assertion (toolbar stays visible after `didEnterFullScreenNotification` in all three tests; 3 issues, 38 tests)
- `swiftformat --lint` on `apps/macos/Sources` and the test file (0.63.0, CI pin) — 0/359 files require formatting
- `git diff --check` — clean
- Mutation check requested by reviewers: deleting only the `init` reconciliation line and re-running the suite makes `dashboard reused window reconciles toolbar visibility in init` fail (`DashboardWindowSmokeTests.swift:168: Expectation failed: (replacement.window?.toolbar?.isVisible → false) == true`), so the test pins the reuse path; line restored afterwards

Test shape: the real fullscreen transition is not driven in tests (no interactive session guarantee on CI runners). The tests reach the real delegate entry points by posting `NSWindow.didEnterFullScreenNotification` / `didExitFullScreenNotification` for the window on the default notification center, which AppKit routes to the window delegate exactly as a real transition does; there is no test-only seam in production. The reuse test hides the toolbar through that path, transfers the window with `detachWindowForReplacement()`, builds a replacement controller without `show()`, and asserts a fresh toolbar that is visible again (the window is not really fullscreen, so `init` must reconcile it back). AppKit does not allow setting the fullscreen style-mask bit outside a transition (`NSGenericException: NSWindowStyleMaskFullScreen set on a window outside of a full screen transition`), so the fullscreen direction of that same line is covered by the live proof rather than a unit test. A third test posts enter/exit for one of two open dashboard windows and checks the other window's toolbar is unaffected. On base production code the test file compiles and these expectations fail by assertion.

Live proof on a real macOS 26 host (MacBook Pro, 2048×1280 pt display), packaged app (`scripts/package-mac-app.sh`, ad-hoc signed, debug configuration), launched under an isolated app profile (`OPENCLAW_PROFILE=proof136131 … --attach-only --dashboard`, no Gateway configured so the dashboard shows its native "Dashboard unavailable" page; the band is native chrome, so the page content does not matter). Fullscreen entered/exited through the window's accessibility `AXFullScreen` attribute (same code path as the green button / ⌃⌘F); window frame confirmed `0,0 2048×1280` in fullscreen and `1240×860` again after exit.

| capture | rows 0–52pt avg luma | rows 52–104pt | page body | result |
|---|---|---|---|---|
| main d2d79f940e (before) | **255.0** (white band, ends at ~65pt) | 248.4 | 246.0 | band present, matches the reporter's `YAVG=234.97` limited-range white |
| this PR (after) | 246.0 | 246.0 | 246.0 | content reaches the top edge from row 0 |

After exiting fullscreen the traffic lights sit centered in the 52pt titlebar again on both builds (exit restore verified on the fix build).

Top-left 900×140pt strip of both fullscreen captures (before above, after below):

![before/after top strip](https://raw.githubusercontent.com/shojikumaru/pr-proof-assets/master/openclaw/136131/compare-topstrip.png)

<details><summary>Full fullscreen captures and the exit-restore capture (sanitized: isolated profile, no Gateway, no user content)</summary>

Before (main), fullscreen:

![before fullscreen](https://raw.githubusercontent.com/shojikumaru/pr-proof-assets/master/openclaw/136131/base-2-fullscreen.png)

After (this PR), fullscreen:

![after fullscreen](https://raw.githubusercontent.com/shojikumaru/pr-proof-assets/master/openclaw/136131/fix-2-fullscreen.png)

After (this PR), back in windowed mode — traffic lights centered in the 52pt titlebar again:

![after exit](https://raw.githubusercontent.com/shojikumaru/pr-proof-assets/master/openclaw/136131/fix-3-exited.png)

</details>

CI's `macos-swift` job runs the suite on a disposable runner.

Pre-submission reviews (three independent read-only model reviews, blind to each other: GLM 5.3, Opus 5, Grok 4.6): round 1 all GO-WITH-CHANGES, converging on the reuse-path gap described above (fixed); round 2 cumulative GO from all three. Remaining notes are folded into this body: LOC closeout with the rejected `.autoHideToolbar` alternative, the traffic-light gutter left in the hosted controls row, and the fact that the two delegate callbacks themselves are not driven by tests (the hook exercises the same owner method).

Human + AI disclosure: written by Sho (human) directing Alpha (Claude-based agent); implementation by Codex; three independent model reviews before submission. Maintainer edits welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
