### PR TITLE
perf(sqlite): prune audit records with one scoped delete

### DIFF
--- a/src/infra/sqlite-audit-record-store.test.ts
+++ b/src/infra/sqlite-audit-record-store.test.ts
@@ -1,10 +1,17 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { DeleteQueryNode } from "kysely";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  closeOpenClawStateDatabase,
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
+import { getNodeSqliteKysely } from "./kysely-sync.js";
 import { createSqliteAuditRecordStore } from "./sqlite-audit-record-store.js";
 
 describe("SQLite audit record store", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     closeOpenClawStateDatabase();
   });
 
@@ -80,20 +87,114 @@ describe("SQLite audit record store", () => {
     });
   });
 
-  it("commits batch inserts with one retention pass", async () => {
+  it("prunes a legacy batch with one delete while preserving runtime rows and other scopes", async () => {
     await withTestDir({ prefix: "openclaw-audit-store-batch-" }, async (stateDir) => {
+      const options = { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
       const store = createSqliteAuditRecordStore<{ value: number }>({
+        ...options,
         scope: "batch-test",
-        maxEntries: 2,
-        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+        maxEntries: 3,
       });
+      const sibling = createSqliteAuditRecordStore<{ value: number }>({
+        ...options,
+        scope: "other-scope",
+        maxEntries: 3,
+      });
+      store.register("runtime", { value: 100 }, 0);
+      sibling.register("legacy-0", { value: 200 }, 1);
+      const { db } = openOpenClawStateDatabase(options);
+      const compile = vi.spyOn(getNodeSqliteKysely(db).getExecutor(), "compileQuery");
 
-      store.registerLegacyMany([
-        { key: "one", value: { value: 1 }, createdAt: 1 },
-        { key: "two", value: { value: 2 }, createdAt: 2 },
-        { key: "three", value: { value: 3 }, createdAt: 3 },
+      store.registerLegacyMany(
+        Array.from({ length: 50 }, (_, index) => ({
+          key: `legacy-${index}`,
+          value: { value: index },
+          createdAt: 100 - index,
+        })),
+      );
+
+      expect(store.entries().map((entry) => entry.key)).toEqual([
+        "legacy-48",
+        "legacy-49",
+        "runtime",
       ]);
+      expect(sibling.entries()).toEqual([{ key: "legacy-0", value: { value: 200 }, createdAt: 1 }]);
+      expect(
+        compile.mock.results.filter(
+          (result) => result.type === "return" && DeleteQueryNode.is(result.value.query),
+        ),
+      ).toHaveLength(1);
+    });
+  });
 
+  it.each(["register", "upsert", "compareAndSet"] as const)(
+    "protects the oldest key during %s without changing its insertion age",
+    async (operation) => {
+      await withTestDir({ prefix: "openclaw-audit-store-protected-" }, async (stateDir) => {
+        const options = {
+          scope: "protected-test",
+          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+        };
+        const seed = createSqliteAuditRecordStore<{ value: number }>({
+          ...options,
+          maxEntries: 4,
+        });
+        for (const [index, key] of ["old\0key", "second", "third", "newest"].entries()) {
+          seed.register(key, { value: index }, 1);
+        }
+        const store = createSqliteAuditRecordStore<{ value: number }>({
+          ...options,
+          maxEntries: 2,
+        });
+        if (operation === "compareAndSet") {
+          expect(store.compareAndSet("old\0key", { value: 0 }, { value: 9 }, 0)).toBe(true);
+        } else {
+          store[operation]("old\0key", { value: 9 }, 0);
+        }
+        expect(store.latest({ limit: 4 })).toEqual([
+          { key: "newest", value: { value: 3 }, createdAt: 1, sequence: 4 },
+          {
+            key: "old\0key",
+            value: { value: operation === "register" ? 0 : 9 },
+            createdAt: operation === "register" ? 1 : 0,
+            sequence: 1,
+          },
+        ]);
+      });
+    },
+  );
+
+  it("rolls back failed pruning and lets a caller-owned transaction continue", async () => {
+    await withTestDir({ prefix: "openclaw-audit-store-rollback-" }, async (stateDir) => {
+      const options = { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
+      const store = createSqliteAuditRecordStore<{ value: number }>({
+        ...options,
+        scope: "rollback-test",
+        maxEntries: 2,
+      });
+      store.register("one", { value: 1 }, 1);
+      store.register("two", { value: 2 }, 2);
+      const before = store.latest({ limit: 3 });
+      const { db } = openOpenClawStateDatabase(options);
+      db.exec(`
+        CREATE TEMP TRIGGER reject_audit_pruning BEFORE DELETE ON diagnostic_events
+        WHEN OLD.scope = 'rollback-test' AND OLD.event_key = 'one'
+        BEGIN SELECT RAISE(ABORT, 'audit pruning refused'); END;
+      `);
+      const append = () => store.register("three", { value: 3 }, 3);
+      expect(append).toThrow("audit pruning refused");
+      expect(store.latest({ limit: 3 })).toEqual(before);
+
+      runOpenClawStateWriteTransaction(() => {
+        expect(append).toThrow("audit pruning refused");
+        store.upsert("two", { value: 20 }, 20);
+      }, options);
+      expect(store.latest({ limit: 3 })).toEqual([
+        { key: "two", value: { value: 20 }, createdAt: 20, sequence: 2 },
+        before[1],
+      ]);
+      db.exec("DROP TRIGGER reject_audit_pruning");
+      append();
       expect(store.entries().map((entry) => entry.key)).toEqual(["two", "three"]);
     });
   });

--- a/src/infra/sqlite-audit-record-store.ts
+++ b/src/infra/sqlite-audit-record-store.ts
@@ -101,16 +101,13 @@ function pruneAuditRecords(params: {
   )
     .orderBy("sequence", "asc")
     .limit(overflow);
-  const rows = executeSqliteQuerySync(params.database, candidates).rows;
-  for (const row of rows) {
-    executeSqliteQuerySync(
-      params.database,
-      getAuditRecordKysely(params.database)
-        .deleteFrom("diagnostic_events")
-        .where("scope", "=", params.scope)
-        .where("event_key", "=", row.event_key),
-    );
-  }
+  executeSqliteQuerySync(
+    params.database,
+    getAuditRecordKysely(params.database)
+      .deleteFrom("diagnostic_events")
+      .where("scope", "=", params.scope)
+      .where("event_key", "in", candidates),
+  );
 }
 
 /** Opens one bounded audit-record scope in the shared state database. */


### PR DESCRIPTION
## What Problem This Solves

Audit-record retention currently loads every victim key into JavaScript, then compiles and executes one DELETE per key. Large legacy imports do thousands of redundant statements inside the existing write transaction.

## Why This Change Was Made

Feed the unchanged ordered victim query directly into one scoped Kysely DELETE. Keep the overflow count, protected key, scope, sequence order and limit at the existing owner; delete the materialized victim array and per-key loop.

## User Impact

Audit imports and pruning retain exactly the same records with less query work. Schemas, indexes, retention caps, stored values, sequence allocation, timestamps, public API and transaction boundaries are unchanged.

## Evidence

The original regression executes 48 DELETE compilations where the candidate executes one. All 148 tests across eight owner/sibling files and the complete changed-file gate passed. Fresh independent Codex P0–P2 review found no actionable findings.

Eight native baseline/candidate phases used real SQLite and the actual store. A 12,000-row legacy import with existing runtime records pruned the same 11,939 victims with one DELETE instead of 11,939, materializing zero victim keys. Stored rows and paginated outputs have identical hashes. Protected duplicate/upsert/CAS keys, Unicode/NUL keys, tied sequences, empty batches, ABORT rollback, caller-owned savepoint continuation, serialization failure and successful retry all match. Physical close/reopen and independent Node-process readback preserve the exact snapshot. Existing indexes serve both the candidate selection and outer deletion. Timing is observational; no general speedup ratio is claimed.

Production delta is −3 lines. Test delta is +101, including extension of the existing batch test rather than a parallel fixture.
