### PR TITLE
refactor: type chat prefetch dependencies and clean loading tests

### DIFF
--- a/src/gateway/assistant-avatar-thumbnail.runtime.ts
+++ b/src/gateway/assistant-avatar-thumbnail.runtime.ts
@@ -71,10 +71,7 @@ export async function readGatewayAvatarThumbnail(
   source: GatewayAvatarImageSource,
 ): Promise<HttpImageRepresentation> {
   const revision = gatewayAvatarImageRevision(source);
-  let pending = thumbnailCache.get(revision);
-  if (!pending) {
-    pending = createAvatarThumbnail(source);
-  }
+  const pending = thumbnailCache.get(revision) ?? createAvatarThumbnail(source);
   thumbnailCache.delete(revision);
   thumbnailCache.set(revision, pending);
   // Original animation/vector bytes remain bounded by AVATAR_MAX_BYTES; limit

--- a/ui/src/components/identity-avatar-view.ts
+++ b/ui/src/components/identity-avatar-view.ts
@@ -47,10 +47,10 @@ function settleIdentityAvatarImage(event: Event, fallbackSelector: string, faile
   if (!(image instanceof HTMLImageElement)) {
     return;
   }
-  // Each rendered image owns its resource until replacement or disconnect.
   image.closest<HTMLElement>(fallbackSelector)?.classList.toggle("is-fallback", failed);
 }
 
+// Each rendered image owns its resource until replacement or disconnect.
 class IdentityAvatarImageDirective extends UntilDirective<unknown> {
   private part?: Part;
   private sourceUrl?: string;

--- a/ui/src/e2e/chat-loading-performance.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/chat-loading-performance.real-gateway.e2e.test.ts
@@ -1,4 +1,3 @@
-// Synthetic transcript and image bytes through the shipped UI and real Gateway.
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -623,7 +622,7 @@ suite.define(() => {
           ),
         );
 
-        // Capture baseline evidence before these repair assertions fail on the old bundle.
+        // Save measurements before asserting budgets so failures retain their evidence.
         const selectedStartup = startupMetrics.find(
           (metric) => metric.method === "chat.startup" && metric.resolvedKey === selectedKey,
         );

--- a/ui/src/e2e/dashboard-gallery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-gallery.e2e.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { expect, it } from "vitest";
+import type { SessionsResolveResult } from "../../../packages/gateway-protocol/src/index.js";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -11,14 +12,15 @@ const suite = createControlUiE2eSuite({
 
 const now = Date.now();
 const selectedSessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
-const selectedSessionResolution = {
+const selectedResolution = {
   ok: true,
   key: selectedSessionKey,
   agentId: "main",
+  displayName: "Release health",
   boardFace: "dashboard",
-};
+} satisfies SessionsResolveResult;
 const dashboardRows = [
-  [selectedSessionKey, "Release health", "mira", "Mira", 3_000, "running"],
+  [selectedSessionKey, selectedResolution.displayName, "mira", "Mira", 3_000, "running"],
   ["agent:main:dashboard:model-spend", "Model spend", "peter", "Peter", 8_000, "done"],
   ["agent:main:dashboard:support-radar", "Support radar", "mira", "Mira", 18_000, "done"],
   ["agent:main:dashboard:ci-signal", "CI signal", "peter", "Peter", 42_000, "done"],
@@ -80,155 +82,147 @@ const boardSnapshots = dashboardRows.map((row) => ({
 suite.define(() => {
   it("opens a responsive gallery card in its owning chat with the dashboard expanded", async () => {
     const proofDir = process.env.OPENCLAW_UI_E2E_RECORD === "1" ? suite.artifactDir : null;
-    const context = await suite.browser.newContext({
-      colorScheme: "dark",
-      viewport: { width: 1440, height: 900 },
-    });
-    const page = await context.newPage();
-    try {
-      const gateway = await installMockGateway(page, {
-        sessionKey: selectedSessionKey,
-        featureMethods: [
-          "board.get",
-          "board.widget.appView",
-          "chat.metadata",
-          "chat.startup",
-          "sessions.resolve",
-        ],
-        methodResponses: {
-          "sessions.describe": {
-            cases: dashboardRows.map((row) => ({
-              match: { key: row.key },
-              response: { session: row },
-            })),
-          },
-          "board.get": {
-            cases: boardSnapshots.map((snapshot) => ({
-              match: { sessionKey: snapshot.sessionKey },
-              response: snapshot,
-            })),
-          },
-          "board.widget.appView": {
-            status: "ready",
-            viewId: "release-tools-view",
-            expiresAtMs: now + 60_000,
-          },
-          "sessions.resolve": selectedSessionResolution,
-          "chat.startup": {
-            cases: [
-              {
-                match: { shortId: "12345678", agentId: "main" },
-                response: {
-                  resolution: selectedSessionResolution,
-                  messages: [],
-                  sessionInfo: dashboardRows[0],
+    await suite.withPage(
+      { colorScheme: "dark", viewport: { width: 1440, height: 900 } },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          sessionKey: selectedSessionKey,
+          sessions: dashboardRows,
+          featureMethods: [
+            "board.get",
+            "board.widget.appView",
+            "chat.metadata",
+            "chat.startup",
+            "sessions.resolve",
+          ],
+          methodResponses: {
+            "sessions.resolve": {
+              cases: [
+                {
+                  match: { shortId: "12345678", agentId: "main" },
+                  response: selectedResolution,
                 },
-              },
-            ],
-          },
-          "sessions.list": {
-            cases: [
-              {
-                match: { hasBoard: true },
-                response: {
-                  count: dashboardRows.length,
-                  defaults: { contextTokens: null, model: null, modelProvider: null },
-                  path: "",
-                  sessions: dashboardRows,
-                  ts: now,
+              ],
+            },
+            "board.get": {
+              cases: boardSnapshots.map((snapshot) => ({
+                match: { sessionKey: snapshot.sessionKey },
+                response: snapshot,
+              })),
+            },
+            "board.widget.appView": {
+              status: "ready",
+              viewId: "release-tools-view",
+              expiresAtMs: now + 60_000,
+            },
+            "chat.startup": {
+              cases: [
+                {
+                  match: { shortId: "12345678", agentId: "main" },
+                  response: {
+                    resolution: selectedResolution,
+                    messages: [],
+                    sessionInfo: dashboardRows[0],
+                  },
                 },
-              },
-            ],
+              ],
+            },
           },
-        },
-      });
+        });
 
-      await page.goto(suite.server.baseUrl);
-      await page.getByRole("link", { name: "Dashboards", exact: true }).click();
-      await page.waitForURL(`${suite.server.baseUrl}dashboards`);
-      const gallery = page.locator("openclaw-dashboards-page");
-      const releaseCard = gallery.locator("[data-dashboard-session]", {
-        hasText: "Release health",
-      });
-      await releaseCard.waitFor();
-      expect(await gallery.locator("[data-dashboard-session]").count()).toBe(12);
-      expect(await gallery.getByText("By Mira", { exact: true }).count()).toBe(6);
-      const previewFrame = releaseCard.locator('iframe[title="Live Gateway Pulse"]');
-      await previewFrame.waitFor();
-      await previewFrame.contentFrame().getByText("All systems nominal", { exact: true }).waitFor();
-      expect(await releaseCard.locator('[data-widget-name="release-tools"]').count()).toBe(0);
-      expect(await gateway.getRequests("board.widget.appView")).toHaveLength(0);
-      const capacityKey = "agent:main:dashboard:capacity";
-      const capacityRequested = async () =>
-        (await gateway.getRequests("board.get")).some(
-          (request) => isRecord(request.params) && request.params.sessionKey === capacityKey,
+        await page.goto(suite.server.baseUrl);
+        await page.getByRole("link", { name: "Dashboards", exact: true }).click();
+        await page.waitForURL(`${suite.server.baseUrl}dashboards`);
+        const gallery = page.locator("openclaw-dashboards-page");
+        const releaseCard = gallery.locator("[data-dashboard-session]", {
+          hasText: "Release health",
+        });
+        await releaseCard.waitFor();
+        expect(await gallery.locator("[data-dashboard-session]").count()).toBe(12);
+        expect(await gallery.getByText("By Mira", { exact: true }).count()).toBe(6);
+        const previewFrame = releaseCard.locator('iframe[title="Live Gateway Pulse"]');
+        await previewFrame.waitFor();
+        await previewFrame
+          .contentFrame()
+          .getByText("All systems nominal", { exact: true })
+          .waitFor();
+        expect(await releaseCard.locator('[data-widget-name="release-tools"]').count()).toBe(0);
+        expect(await gateway.getRequests("board.widget.appView")).toHaveLength(0);
+        const capacityKey = "agent:main:dashboard:capacity";
+        const capacityRequested = async () =>
+          (await gateway.getRequests("board.get")).some(
+            (request) => isRecord(request.params) && request.params.sessionKey === capacityKey,
+          );
+        expect(await capacityRequested()).toBe(false);
+        const capacityCard = gallery.locator(`[data-dashboard-session="${capacityKey}"]`);
+        await capacityCard.scrollIntoViewIfNeeded();
+        await expect.poll(capacityRequested).toBe(true);
+        const capacityFrame = capacityCard.locator('iframe[title="Live Gateway Pulse"]');
+        await capacityFrame.waitFor();
+        await capacityFrame
+          .contentFrame()
+          .getByText("All systems nominal", { exact: true })
+          .waitFor();
+        expect(await releaseCard.locator("a").getAttribute("href")).toBe(
+          "/chat/main/release-health-12345678?dashboard=expanded",
         );
-      expect(await capacityRequested()).toBe(false);
-      const capacityCard = gallery.locator(`[data-dashboard-session="${capacityKey}"]`);
-      await capacityCard.scrollIntoViewIfNeeded();
-      await expect.poll(capacityRequested).toBe(true);
-      const capacityFrame = capacityCard.locator('iframe[title="Live Gateway Pulse"]');
-      await capacityFrame.waitFor();
-      await capacityFrame
-        .contentFrame()
-        .getByText("All systems nominal", { exact: true })
-        .waitFor();
-      expect(await releaseCard.locator("a").getAttribute("href")).toBe(
-        "/chat/main/release-health-12345678?dashboard=expanded",
-      );
-      if (proofDir) {
-        await page.screenshot({ path: path.join(proofDir, "01-gallery.png") });
-      }
+        if (proofDir) {
+          await page.screenshot({ path: path.join(proofDir, "01-gallery.png") });
+        }
 
-      await releaseCard.locator("a").click();
-      await page.waitForURL(/\/chat\/main\/release-health-12345678\?dashboard=expanded$/u);
-      await page.locator(".board-session-surface").waitFor();
-      await expect.poll(() => page.locator(".sidebar-region--expanded").count()).toBe(1);
-      await expect.poll(() => page.locator(".chat-thread").isHidden()).toBe(true);
-      if (proofDir) {
-        await page.screenshot({ path: path.join(proofDir, "02-expanded-dashboard.png") });
-      }
+        await releaseCard.locator("a").click();
+        await page.waitForURL(/\/chat\/main\/release-health-12345678\?dashboard=expanded$/u);
+        await page.locator(".board-session-surface").waitFor();
+        await expect.poll(() => page.locator(".sidebar-region--expanded").count()).toBe(1);
+        await expect.poll(() => page.locator(".chat-thread").isHidden()).toBe(true);
+        // A cold route must resolve without the gallery's navigation handoff.
+        await page.reload();
+        await page.locator(".board-session-surface").waitFor();
+        await expect.poll(() => page.locator(".sidebar-region--expanded").count()).toBe(1);
+        await expect.poll(() => page.locator(".chat-thread").isHidden()).toBe(true);
+        if (proofDir) {
+          await page.screenshot({ path: path.join(proofDir, "02-expanded-dashboard.png") });
+        }
 
-      await page.getByRole("button", { name: "Restore split", exact: true }).click();
-      await expect.poll(() => page.locator(".sidebar-region--expanded").count()).toBe(0);
-      await page.locator(".chat-thread").waitFor();
-      if (proofDir) {
-        await page.screenshot({ path: path.join(proofDir, "03-split-dashboard.png") });
-      }
-      await page
-        .locator('[data-region-header="side"]')
-        .getByRole("button", { name: "Close", exact: true })
-        .click();
-      await page.locator(".board-session-surface").waitFor();
-      await page.locator(".chat-thread").waitFor({ state: "hidden" });
-      if (proofDir) {
-        await page.screenshot({ path: path.join(proofDir, "04-dashboard-only.png") });
-      }
+        await page.getByRole("button", { name: "Restore split", exact: true }).click();
+        await expect.poll(() => page.locator(".sidebar-region--expanded").count()).toBe(0);
+        await page.locator(".chat-thread").waitFor();
+        if (proofDir) {
+          await page.screenshot({ path: path.join(proofDir, "03-split-dashboard.png") });
+        }
+        await page
+          .locator('[data-region-header="side"]')
+          .getByRole("button", { name: "Close", exact: true })
+          .click();
+        await page.locator(".board-session-surface").waitFor();
+        await page.locator(".chat-thread").waitFor({ state: "hidden" });
+        if (proofDir) {
+          await page.screenshot({ path: path.join(proofDir, "04-dashboard-only.png") });
+        }
 
-      await page.setViewportSize({ width: 390, height: 844 });
-      await page.goto(`${suite.server.baseUrl}dashboards`);
-      await gallery.getByText("Release health", { exact: true }).waitFor();
-      await expect
-        .poll(() =>
-          page.evaluate(() => ({
-            documentWidth: document.documentElement.scrollWidth,
-            viewportWidth: window.innerWidth,
-          })),
-        )
-        .toEqual({ documentWidth: 390, viewportWidth: 390 });
-      expect(
-        await gallery
-          .locator(".dashboards-grid")
-          .evaluate(
-            (element) =>
-              getComputedStyle(element).gridTemplateColumns.split(" ").filter(Boolean).length,
-          ),
-      ).toBe(1);
-      if (proofDir) {
-        await page.screenshot({ path: path.join(proofDir, "05-gallery-mobile.png") });
-      }
-    } finally {
-      await context.close();
-    }
+        await page.setViewportSize({ width: 390, height: 844 });
+        await page.goto(`${suite.server.baseUrl}dashboards`);
+        await gallery.getByText("Release health", { exact: true }).waitFor();
+        await expect
+          .poll(() =>
+            page.evaluate(() => ({
+              documentWidth: document.documentElement.scrollWidth,
+              viewportWidth: window.innerWidth,
+            })),
+          )
+          .toEqual({ documentWidth: 390, viewportWidth: 390 });
+        expect(
+          await gallery
+            .locator(".dashboards-grid")
+            .evaluate(
+              (element) =>
+                getComputedStyle(element).gridTemplateColumns.split(" ").filter(Boolean).length,
+            ),
+        ).toBe(1);
+        if (proofDir) {
+          await page.screenshot({ path: path.join(proofDir, "05-gallery-mobile.png") });
+        }
+      },
+    );
   });
 });

--- a/ui/src/lib/agents/identity.test.ts
+++ b/ui/src/lib/agents/identity.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentIdentityResult } from "../../api/types.ts";
 import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import { createAgentIdentityCapability } from "./identity.ts";
 
 afterEach(() => {
@@ -111,7 +112,7 @@ it("shares identity requests between the sidebar and the selected chat", async (
   const { fetchAssistantIdentity } = await import("../../app/assistant-identity.ts");
   const result = { agentId: "main", name: "Main", avatar: "/avatar/main?v=1" };
   const request = vi.fn().mockResolvedValue(result);
-  const client = { request } as unknown as GatewayBrowserClient;
+  const client = createTestGatewayClient(request);
   const capability = createAgentIdentityCapability({
     snapshot: { client, phase: "connected" },
     subscribe: () => () => undefined,
@@ -135,7 +136,7 @@ it.each(["sidebar", "chat"])(
     const replacement = { ...oldIdentity, avatar: "/avatar/main?v=replaced" };
     const refresh = deferred<AgentIdentityResult>();
     const request = vi.fn().mockResolvedValueOnce(oldIdentity).mockReturnValueOnce(refresh.promise);
-    const client = { request } as unknown as GatewayBrowserClient;
+    const client = createTestGatewayClient(request);
     const capability = createAgentIdentityCapability({
       snapshot: { client, phase: "connected" },
       subscribe: () => () => undefined,

--- a/ui/src/pages/chat/chat-avatar.test.ts
+++ b/ui/src/pages/chat/chat-avatar.test.ts
@@ -219,12 +219,12 @@ describe("refreshChatAvatar", () => {
       settings: { token: "test-token" },
     });
     const second = makeChatHost({ client: first.client, settings: { token: "test-token" } });
-    const fetchAvatar = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-      return url.includes("meta=1")
-        ? new Response(JSON.stringify({ avatarUrl: "/avatar/main?v=1" }))
-        : new Response(new Uint8Array([1, 2, 3]), { headers: { "content-type": "image/png" } });
-    });
+    const fetchAvatar = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(
+        async () =>
+          new Response(new Uint8Array([1, 2, 3]), { headers: { "content-type": "image/png" } }),
+      );
     vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:shared-avatar");
     const revoke = vi.spyOn(URL, "revokeObjectURL");
 

--- a/ui/src/pages/chat/session-prefetch-lifecycle.test.ts
+++ b/ui/src/pages/chat/session-prefetch-lifecycle.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import { readChatSessionSnapshot, type ChatMessageCache } from "./session-message-cache.ts";
 import {
   createSessionPrefetchFixture,
@@ -30,7 +30,7 @@ describe("session prefetch pane and navigation ownership", () => {
         historyResult((params as { sessionKey: string }).sessionKey),
       );
       updatePrefetch({
-        client: { request } as unknown as GatewayBrowserClient,
+        client: createTestGatewayClient(request),
         listRevision: 1,
         openSessionKeys: [],
         rows: [row("agent:main:newest", NOW), row("agent:main:recent", NOW - 1), row(intended, 1)],
@@ -68,7 +68,7 @@ describe("session prefetch pane and navigation ownership", () => {
       historyResult((params as { sessionKey: string }).sessionKey),
     );
     updatePrefetch({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: ["agent:main:selected"],
       rows: [row(home.sessionKey, NOW), row("agent:main:recent", NOW - 1)],
@@ -92,7 +92,7 @@ describe("session prefetch pane and navigation ownership", () => {
         historyResult((params as { sessionKey: string }).sessionKey),
       );
       updatePrefetch({
-        client: { request } as unknown as GatewayBrowserClient,
+        client: createTestGatewayClient(request),
         listRevision: 1,
         openSessionKeys: ["agent:main:selected"],
         rows: [row(home.sessionKey, NOW), row("agent:main:recent", NOW - 1)],

--- a/ui/src/pages/chat/session-prefetch.test-support.ts
+++ b/ui/src/pages/chat/session-prefetch.test-support.ts
@@ -3,7 +3,6 @@ import type { ReactiveController } from "lit";
 import { vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
-import type { ApplicationContext } from "../../app/context.ts";
 import { createGatewayConnectionLifecycle } from "../../lib/gateway-connection-lifecycle.ts";
 import { observeChatCache, type ChatMessageCache } from "./session-message-cache.ts";
 import { installSessionPrefetch } from "./session-prefetch.ts";
@@ -57,13 +56,10 @@ export async function settleSessionPrefetch(): Promise<void> {
 }
 
 export function createSessionPrefetchFixture() {
-  let visibility: DocumentVisibilityState;
-  let current: SessionPrefetchUpdate;
-
   vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
   vi.setSystemTime(PREFETCH_TEST_NOW);
   vi.stubGlobal("indexedDB", new IDBFactory());
-  visibility = "visible";
+  let visibility: DocumentVisibilityState = "visible";
   const originalVisibility = Object.getOwnPropertyDescriptor(document, "visibilityState");
   Object.defineProperty(document, "visibilityState", {
     configurable: true,
@@ -89,20 +85,18 @@ export function createSessionPrefetchFixture() {
   const store = new SessionSnapshotStore(cache);
   store.connect();
   observeChatCache(cache, store);
-  current = { client: null, listRevision: 0, openSessionKeys: [], rows: null };
+  let current: SessionPrefetchUpdate = {
+    client: null,
+    listRevision: 0,
+    openSessionKeys: [],
+    rows: null,
+  };
   const connection = createGatewayConnectionLifecycle({ client: null, phase: "stopped" });
   const gatewayListeners = new Set<() => void>();
   const context = {
     agents: { state: { agentsList: null } },
     gateway: {
-      get snapshot() {
-        return {
-          assistantAgentId: "main",
-          client: current.client,
-          hello: null,
-          phase: current.client ? ("connected" as const) : ("stopped" as const),
-        };
-      },
+      snapshot: { assistantAgentId: "main", hello: null },
       subscribe: (listener: () => void) => {
         gatewayListeners.add(listener);
         return () => gatewayListeners.delete(listener);
@@ -120,7 +114,7 @@ export function createSessionPrefetchFixture() {
         return { result: current.rows ? { sessions: current.rows } : null };
       },
     },
-  } as unknown as ApplicationContext;
+  };
   const host = Object.assign(document.createElement("div"), {
     addController: (_controller: ReactiveController) => undefined,
     removeController: (_controller: ReactiveController) => undefined,

--- a/ui/src/pages/chat/session-prefetch.test.ts
+++ b/ui/src/pages/chat/session-prefetch.test.ts
@@ -3,8 +3,8 @@
 import type { ReactiveControllerHost } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import { MAX_CACHED_CHAT_SESSIONS } from "./session-cache.ts";
 import {
   appendChatMessageToCache,
@@ -72,7 +72,7 @@ describe("recent session prefetch", () => {
     const response = createDeferred<ReturnType<typeof historyResult>>();
     const request = vi.fn(() => response.promise);
     const snapshot = {
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: [],
       rows: [row(key, NOW - 1)],
@@ -99,7 +99,7 @@ describe("recent session prefetch", () => {
     const other = { ...row(otherKey, NOW), hasActiveRun: true };
     const queued = row(queuedKey, NOW - 2);
     const snapshot = {
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: [otherKey],
       rows: [unchanged, queued, other],
@@ -144,7 +144,7 @@ describe("recent session prefetch", () => {
     const request = vi.fn(() => response.promise);
     const original = { ...row(key, NOW - 1), sessionId: "original", activeLeafEntryId: "leaf" };
     const snapshot = {
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: [],
       rows: [original],
@@ -184,7 +184,7 @@ describe("recent session prefetch", () => {
       const request = vi.fn(() => response.promise);
       const original = { ...row(key, NOW - 1), sessionId: `id:${key}` };
       const snapshot = {
-        client: { request } as unknown as GatewayBrowserClient,
+        client: createTestGatewayClient(request),
         listRevision: 1,
         openSessionKeys: [],
         rows: [original],
@@ -224,7 +224,7 @@ describe("recent session prefetch", () => {
     const response = createDeferred<ReturnType<typeof historyResult>>();
     const request = vi.fn(() => response.promise);
     const snapshot = {
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: [],
       rows: [row(key, NOW - 1)],
@@ -236,7 +236,7 @@ describe("recent session prefetch", () => {
 
     let expected: ChatSessionSnapshot | null = null;
     if (change === "client replacement") {
-      updatePrefetch({ ...snapshot, client: { request } as unknown as GatewayBrowserClient });
+      updatePrefetch({ ...snapshot, client: createTestGatewayClient(request) });
     } else if (change === "same-client reconnect") {
       updatePrefetch({ ...snapshot, client: null });
       updatePrefetch(snapshot);
@@ -277,7 +277,7 @@ describe("recent session prefetch", () => {
           : page.promise,
       );
       updatePrefetch({
-        client: { request } as unknown as GatewayBrowserClient,
+        client: createTestGatewayClient(request),
         listRevision: 1,
         openSessionKeys: [],
         rows: [row(key, NOW + 1)],
@@ -337,7 +337,7 @@ describe("recent session prefetch", () => {
       row("agent:main:eligible-4", NOW - 6),
     ];
     const state: SessionPrefetchUpdate = {
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: ["main"],
       rows,
@@ -382,7 +382,7 @@ describe("recent session prefetch", () => {
       historyResult((params as { sessionKey: string }).sessionKey),
     );
     const state: SessionPrefetchUpdate = {
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: ["agent:main:main"],
       loadingSessionKeys: ["agent:main:main"],
@@ -415,7 +415,7 @@ describe("recent session prefetch", () => {
       });
     });
     const state: SessionPrefetchUpdate = {
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: ["agent:main:main"],
       rows: [
@@ -452,7 +452,7 @@ describe("recent session prefetch", () => {
       historyResult((params as { sessionKey: string }).sessionKey),
     );
     const state: SessionPrefetchUpdate = {
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: ["agent:main:main"],
       rows: [row("agent:main:main", NOW - 1), row("agent:main:recent", NOW - 2)],
@@ -490,7 +490,7 @@ describe("recent session prefetch", () => {
       historyResult((params as { sessionKey: string }).sessionKey),
     );
     const state: SessionPrefetchUpdate = {
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: ["agent:main:main"],
       rows: [row("agent:main:main", NOW - 1), row(sessionKey, NOW + 1)],
@@ -524,7 +524,7 @@ describe("recent session prefetch", () => {
     const request = vi.fn(async (_method: string, params: unknown) =>
       historyResult((params as { sessionKey: string }).sessionKey),
     );
-    const client = { request } as unknown as GatewayBrowserClient;
+    const client = createTestGatewayClient(request);
     const rows = Array.from({ length: 25 }, (_, index) =>
       row(`agent:main:recent-${index}`, NOW - index - 1),
     );
@@ -572,7 +572,7 @@ describe("recent session prefetch", () => {
     const request = vi.fn(async (_method: string, params: unknown) =>
       historyResult((params as { sessionKey: string }).sessionKey),
     );
-    const client = { request } as unknown as GatewayBrowserClient;
+    const client = createTestGatewayClient(request);
     const backgroundRows = Array.from({ length: 25 }, (_, index) =>
       row(`agent:main:background-${index}`, NOW - index - 1),
     );
@@ -598,7 +598,7 @@ describe("recent session prefetch", () => {
     const request = vi.fn(async (_method: string, params: unknown) =>
       historyResult((params as { sessionKey: string }).sessionKey),
     );
-    const client = { request } as unknown as GatewayBrowserClient;
+    const client = createTestGatewayClient(request);
     const base = {
       client,
       openSessionKeys: [],
@@ -685,7 +685,7 @@ describe("recent session prefetch", () => {
     }));
 
     updatePrefetch({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: [],
       rows: [row(sessionKey, NOW + 1)],
@@ -753,7 +753,7 @@ describe("recent session prefetch", () => {
     }));
 
     updatePrefetch({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: [],
       rows: [row(sessionKey, NOW + 1)],
@@ -771,7 +771,7 @@ describe("recent session prefetch", () => {
     const request = vi.fn();
 
     updatePrefetch({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: [],
       rows: [{ ...row(sessionKey, NOW + 1), hasActiveRun: true, status: "running" }],
@@ -796,7 +796,7 @@ describe("recent session prefetch", () => {
       value: { request: locksRequest },
     });
     updatePrefetch({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: [],
       rows: [row("agent:main:locked", NOW - 1)],
@@ -825,7 +825,7 @@ describe("recent session prefetch", () => {
       value: { request: locksRequest },
     });
     updatePrefetch({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: [],
       rows: [row("agent:main:hidden", NOW - 1)],
@@ -849,7 +849,7 @@ describe("recent session prefetch", () => {
       return historyResult(sessionKey);
     });
     updatePrefetch({
-      client: { request } as unknown as GatewayBrowserClient,
+      client: createTestGatewayClient(request),
       listRevision: 1,
       openSessionKeys: [],
       rows: [row("agent:main:failed", NOW - 1), row("agent:main:succeeded", NOW - 2)],

--- a/ui/src/pages/chat/session-prefetch.ts
+++ b/ui/src/pages/chat/session-prefetch.ts
@@ -2,8 +2,10 @@ import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
-import type { ApplicationContext } from "../../app/context.ts";
+import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
+import type { AgentCapability } from "../../lib/agents/index.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
+import type { SessionCapability } from "../../lib/sessions/session-capability.ts";
 import {
   CHAT_PANE_LIFECYCLE_CHANGED_EVENT,
   CHAT_TRANSCRIPT_LOADING_CHANGED_EVENT,
@@ -27,6 +29,21 @@ const SESSION_PREFETCH_COOLDOWN_MS = 30_000;
 const SESSION_PREFETCH_LOCK_NAME = "openclaw-chat-prefetch";
 
 type ChatSnapshotKeyHost = Parameters<typeof resolveChatSnapshotKey>[0];
+
+type SessionPrefetchContext = {
+  readonly gateway: {
+    readonly snapshot: Pick<ApplicationGatewaySnapshot, "assistantAgentId" | "hello">;
+    subscribe: (listener: () => void) => () => void;
+  };
+  readonly agents: { readonly state: Pick<AgentCapability["state"], "agentsList"> };
+  readonly sessions: Pick<
+    SessionCapability,
+    "captureConnectionScope" | "isConnectionScopeCurrent" | "canonicalListRevision"
+  > & {
+    readonly state: { readonly result: { readonly sessions: readonly GatewaySessionRow[] } | null };
+    subscribe: (listener: () => void) => () => void;
+  };
+};
 
 type SessionPrefetchSnapshot = {
   client: GatewayBrowserClient | null;
@@ -476,7 +493,7 @@ type SessionPrefetchHost = ReactiveControllerHost & HTMLElement;
 
 class SessionPrefetchController implements ReactiveController {
   private readonly prefetcher: SessionPrefetcher;
-  private context: ApplicationContext | undefined;
+  private context: SessionPrefetchContext | undefined;
   private subscriptions: Array<() => void> = [];
   private intentSessionKey: string | null = null;
   private paneRoot: Element;
@@ -485,7 +502,7 @@ class SessionPrefetchController implements ReactiveController {
     private readonly host: SessionPrefetchHost,
     cache: ChatMessageCache,
     snapshotStore: SessionSnapshotStore,
-    private readonly readContext: () => ApplicationContext | undefined,
+    private readonly readContext: () => SessionPrefetchContext | undefined,
   ) {
     this.paneRoot = host;
     this.prefetcher = new SessionPrefetcher(cache, snapshotStore);
@@ -590,7 +607,7 @@ export function installSessionPrefetch(
   host: SessionPrefetchHost,
   cache: ChatMessageCache,
   snapshotStore: SessionSnapshotStore,
-  readContext: () => ApplicationContext | undefined,
+  readContext: () => SessionPrefetchContext | undefined,
 ): ReactiveController {
   return new SessionPrefetchController(host, cache, snapshotStore, readContext);
 }


### PR DESCRIPTION
Related: #138635

## What Problem This Solves

The loading-performance tests hid a partial application context behind a double cast. Removing that cast required 27 unrelated application fields, so the fixture could not check the prefetch controller's actual dependencies.

CI also exposed a stale dashboard-gallery fixture: its missing resolver response and list-only metadata produced “Session not found.” #138769 landed the missing resolver fix on `main` during validation. This PR retains that fix and consolidates the fixture data, types, diagnostics, and cold-reload coverage.

## Why This Change Was Made

Prefetch now accepts only the snapshot fields, roster, session rows, notifications, and connection-scope methods it uses. Its caller keeps the same context object, preserving subscription identity and stale-connection fencing. The inferred fixture is checked directly; 26 partial-client casts use the existing typed helper.

The gallery now seeds one canonical set of session rows and shares a typed resolution between startup and dashboard navigation. Duplicate list/describe stubs are removed. The shared browser fixture captures failures before closing the page, and a cold reload verifies resolution without a warm navigation handoff. All previous gallery assertions remain.

The remaining cleanup simplifies private avatar-promise cache lookup, places the avatar lifetime explanation beside its owner, removes an unused metadata mock branch, and initializes fixture variables at their declaration.

## User Impact

No intended production behavior change. The prefetch refactor emits byte-identical JavaScript. Loading priority, cache ownership, avatar caching, and reconnect protections remain covered; the gallery test now exercises the current dashboard flow reliably.

## Evidence

- Removing the context cast before repair produces TS2740 for 27 unrelated fields. The inferred fixture and real ChatPage caller now pass the canonical typechecks.
- All 89 focused UI tests and all 33 configured changed-check steps passed for the nine-file cleanup. Its unchanged avatar implementation passed 19 HTTP tests. Independent Codex review through P2 found no actionable defects.
- The gallery failure reproduced twice in hosted CI and locally. Captured route/request evidence showed the unresolved dashboard navigation. The repaired browser case passes with a cold reload, preserving lazy preview loading, expanded/split/dashboard-only layouts, and mobile assertions. Its final canonical UI E2E typecheck, type-aware lint, formatting, and independent Codex review through P2 pass.
- [Fresh real-Gateway Chromium proof](https://github.com/openclaw/openclaw/actions/runs/33940976027/job/101238304825): the canonical paired Gateway/UI build and all 13 files / 24 tests passed on the final merge candidate `8a6cced8`, containing `b08185ff`. The loading case verifies the 80-message/256-KiB startup budget, selected-before-Home ordering, all 900 messages reachable, one 128px authenticated avatar resource, immutable caching with 304 revalidation, and AVIF/percent-encoded PNG decoding.
- That hosted job did not upload successful screenshots or measurement JSON; no fresh timing or byte measurements are claimed. The attached before/after images are local synthetic gallery proof.
- [Final-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33940976027) at `b08185ff`: 119 checks passed, 13 intentionally skipped, zero failures, including the corrected gallery and aggregate gate. The local gallery Chromium case also passed again after rebasing onto #138769. All ten touched files are byte-identical to the independently reviewed candidate before the rebase.

Production: +23/-9, net +14 lines. The private compile-time capability contract adds 17 lines; the avatar cache simplification removes three runtime lines. Tests/support: net -12 lines; most gallery churn is indentation under the shared fixture owner. No new public API, configuration, schema, or runtime adapter.

Follow-up: **Complete the gallery's expanded MCP app fixture.** The synthetic gallery includes an incomplete embedded-app placeholder to check that gallery previews exclude it; this placeholder remains visible in the expanded screenshot. Fully initialized MCP rendering is covered separately by the passing real-Gateway conformance test and would require a complete sandbox/SDK fixture here.

![Before: synthetic gallery navigation showed Session not found](https://github.com/user-attachments/assets/89c2ee80-3218-4eaf-8234-fa1e28bac1a7)

![After: dashboard opens after cold reload; embedded MCP placeholder remains a separate fixture gap](https://github.com/user-attachments/assets/e5852434-321a-4aec-a37b-816a57619f69)
