### PR TITLE
fix: keep session edits responsive during model catalog reloads

### DIFF
--- a/src/gateway/server-methods/sessions-mutations.catalog-queue.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.catalog-queue.test.ts
@@ -1,0 +1,469 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  markPreparedModelRuntimeSnapshotsStale,
+  rejectPendingPreparedModelRuntimeReplacement,
+} from "../../agents/prepared-model-runtime.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "../../agents/prepared-model-runtime.test-support.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import {
+  loadSessionEntry,
+  patchSessionEntryCore,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { handleGatewayRequest } from "../server-methods.js";
+import { loadGatewayModelCatalog as loadActualGatewayModelCatalog } from "../server-model-catalog.js";
+import { sessionMutationHandlers } from "./sessions-mutations.js";
+import type { GatewayRequestContext } from "./types.js";
+
+afterEach(() => {
+  resetPreparedModelRuntimeSnapshotsForTest();
+  closeOpenClawAgentDatabasesForTest();
+});
+
+function patchContext(
+  loadGatewayModelCatalog: GatewayRequestContext["loadGatewayModelCatalog"],
+  cfg: OpenClawConfig = {},
+) {
+  return {
+    getRuntimeConfig: () => cfg,
+    loadGatewayModelCatalog,
+    getSessionEventSubscriberConnIds: () => new Set(),
+    broadcastToConnIds: vi.fn(),
+    chatAbortControllers: new Map(),
+    chatQueuedTurns: new Map(),
+    dedupe: new Map(),
+  } as unknown as GatewayRequestContext;
+}
+
+function patchRequest(context: GatewayRequestContext) {
+  return (params: Record<string, unknown>, respond: ReturnType<typeof vi.fn>) =>
+    sessionMutationHandlers["sessions.patch"]!({
+      params,
+      respond,
+      context,
+      client: null,
+    } as never);
+}
+
+test("catalog reload releases the agent writer while preserving same-session ordering", async () => {
+  await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+    const catalogKey = "agent:main:catalog-dependent";
+    const metadataKey = "agent:main:independent-metadata";
+    for (const sessionKey of [catalogKey, metadataKey]) {
+      await upsertSessionEntryCore(
+        { agentId: "main", env: state.env, sessionKey },
+        { sessionId: sessionKey, updatedAt: 1 },
+      );
+    }
+    const entered = createDeferredCore();
+    const replacement = markPreparedModelRuntimeSnapshotsStale("catalog reload", {
+      waitForReplacement: true,
+    });
+    expect(replacement).toBeDefined();
+    const loadGatewayModelCatalog = vi.fn(async () => {
+      entered.resolve();
+      return await loadActualGatewayModelCatalog({ agentId: "main", getConfig: () => ({}) });
+    });
+    const context = patchContext(loadGatewayModelCatalog);
+    const catalogResponse = vi.fn();
+    const metadataResponse = vi.fn();
+    const successorResponse = vi.fn();
+    const patch = patchRequest(context);
+    const catalogPatch = patch({ key: catalogKey, contextWindow: "extended" }, catalogResponse);
+    let metadataPatch: ReturnType<typeof patch> | undefined;
+    let successorPatch: ReturnType<typeof patch> | undefined;
+    let blockedMetadata: Error | undefined;
+    try {
+      await Promise.race([entered.promise, catalogPatch]);
+      expect(loadGatewayModelCatalog).toHaveBeenCalledOnce();
+      expect(catalogResponse).not.toHaveBeenCalled();
+      successorPatch = patch({ key: catalogKey, pinned: true }, successorResponse);
+      metadataPatch = patch({ key: metadataKey, pinned: true }, metadataResponse);
+      await vi
+        .waitFor(() =>
+          expect(metadataResponse).toHaveBeenCalledWith(true, expect.any(Object), undefined),
+        )
+        .catch((error: unknown) => {
+          blockedMetadata = error instanceof Error ? error : new Error(String(error));
+        });
+      expect(catalogResponse).not.toHaveBeenCalled();
+      expect(successorResponse).not.toHaveBeenCalled();
+      expect(
+        loadSessionEntry({ agentId: "main", sessionKey: catalogKey })?.pinnedAt,
+      ).toBeUndefined();
+      expect(loadGatewayModelCatalog).toHaveBeenCalledOnce();
+    } finally {
+      rejectPendingPreparedModelRuntimeReplacement(
+        replacement,
+        new Error("Synthetic catalog reload failed"),
+      );
+      await Promise.allSettled([catalogPatch, metadataPatch, successorPatch]);
+    }
+    expect(catalogResponse).toHaveBeenCalledWith(false, undefined, {
+      code: "UNAVAILABLE",
+      message: "Session patch failed unexpectedly. Retry the request.",
+      retryable: true,
+    });
+    expect(
+      loadSessionEntry({ agentId: "main", sessionKey: catalogKey })?.contextWindow,
+    ).toBeUndefined();
+    expect(metadataResponse).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+    expect(successorResponse).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+    expect(loadSessionEntry({ agentId: "main", sessionKey: catalogKey })?.pinnedAt).toEqual(
+      expect.any(Number),
+    );
+    expect(loadSessionEntry({ agentId: "main", sessionKey: metadataKey })?.pinnedAt).toEqual(
+      expect.any(Number),
+    );
+    if (blockedMetadata) {
+      throw blockedMetadata;
+    }
+  });
+});
+
+test.each(["identity", "label", "alias", "cleared-selection"] as const)(
+  "catalog preparation revalidates fresh %s before using the prepared result",
+  async (change) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const key = change === "alias" ? "agent:main:main" : "agent:main:catalog-revalidation";
+      const storedKey = change === "alias" ? "agent:main:work" : key;
+      const otherKey = "agent:main:new-label-owner";
+      const existing: SessionEntry = {
+        sessionId: "before",
+        updatedAt: 1,
+        providerOverride: "anthropic",
+        modelOverride: "claude-sonnet-4-6",
+        ...(change === "cleared-selection"
+          ? { thinkingLevel: "high", contextWindow: "extended" }
+          : {}),
+      };
+      await upsertSessionEntryCore({ agentId: "main", sessionKey: storedKey }, existing);
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey: otherKey },
+        { sessionId: "other", updatedAt: 1 },
+      );
+      const entered = createDeferredCore();
+      const catalog =
+        createDeferredCore<Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalog"]>>>();
+      const loadGatewayModelCatalog = vi.fn(() => {
+        entered.resolve();
+        return catalog.promise;
+      });
+      const patch = patchRequest(
+        patchContext(
+          loadGatewayModelCatalog,
+          change === "alias"
+            ? {
+                session: { mainKey: "work" },
+                agents: { list: [{ id: "main", default: true }] },
+              }
+            : {},
+        ),
+      );
+      const response = vi.fn();
+      const pending = patch(
+        change === "cleared-selection"
+          ? { key, model: null }
+          : {
+              key,
+              expectedSessionId: "before",
+              contextWindow: "extended",
+              ...(change === "label" ? { label: "Claimed" } : {}),
+            },
+        response,
+      );
+      let mutation: Promise<unknown> | void = undefined;
+      const changed = vi.fn();
+      try {
+        await Promise.race([entered.promise, pending]);
+        expect(loadGatewayModelCatalog).toHaveBeenCalledOnce();
+        expect(response).not.toHaveBeenCalled();
+        mutation =
+          change === "label"
+            ? patch({ key: otherKey, label: "Claimed" }, changed)
+            : upsertSessionEntryCore(
+                { agentId: "main", sessionKey: key },
+                change === "identity" || change === "alias"
+                  ? { sessionId: "replacement", updatedAt: 2, label: "Replacement" }
+                  : {
+                      ...existing,
+                      updatedAt: 2,
+                      thinkingLevel: undefined,
+                      contextWindow: undefined,
+                    },
+              ).then(() => changed());
+        await vi.waitFor(() => expect(changed).toHaveBeenCalledOnce());
+      } finally {
+        if (change === "alias") {
+          catalog.resolve([]);
+        } else {
+          catalog.reject(new Error("Synthetic catalog preparation failed"));
+        }
+        await Promise.allSettled([pending, mutation]);
+      }
+      expect(loadGatewayModelCatalog).toHaveBeenCalledOnce();
+      const stored = loadSessionEntry({ agentId: "main", sessionKey: storedKey });
+      if (change === "cleared-selection") {
+        expect(response).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+        expect(stored).toMatchObject({ sessionId: "before" });
+        expect(stored?.modelOverride).toBeUndefined();
+        expect(stored?.providerOverride).toBeUndefined();
+        expect(stored?.thinkingLevel).toBeUndefined();
+        expect(stored?.contextWindow).toBeUndefined();
+      } else if (change === "identity") {
+        expect(response).toHaveBeenCalledWith(
+          false,
+          undefined,
+          expect.objectContaining({
+            code: "INVALID_REQUEST",
+            details: { reason: "session-changed" },
+          }),
+        );
+        expect(stored).toMatchObject({ sessionId: "replacement", label: "Replacement" });
+        expect(stored?.contextWindow).toBeUndefined();
+      } else if (change === "alias") {
+        expect(response).toHaveBeenCalledWith(false, undefined, {
+          code: "UNAVAILABLE",
+          message: "Session patch failed unexpectedly. Retry the request.",
+          retryable: true,
+        });
+        expect(stored).toMatchObject({ sessionId: "before" });
+        expect(stored?.contextWindow).toBeUndefined();
+        expect(loadSessionEntry({ agentId: "main", sessionKey: key })).toMatchObject({
+          sessionId: "replacement",
+          label: "Replacement",
+        });
+        expect(
+          loadSessionEntry({ agentId: "main", sessionKey: key })?.contextWindow,
+        ).toBeUndefined();
+      } else {
+        expect(changed).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+        expect(response).toHaveBeenCalledWith(false, undefined, {
+          code: "INVALID_REQUEST",
+          message: "label already in use: Claimed",
+        });
+        expect(stored?.label).toBeUndefined();
+        expect(stored?.contextWindow).toBeUndefined();
+        expect(loadSessionEntry({ agentId: "main", sessionKey: otherKey })?.label).toBe("Claimed");
+      }
+    });
+  },
+);
+
+test("patchMany prepares singleton agent groups without blocking another session", async () => {
+  await withOpenClawTestState({ scenario: "minimal" }, async () => {
+    const targets = ["main", "secondary"].map((agentId) => ({
+      key: `agent:${agentId}:catalog-batch`,
+    }));
+    for (const [index, { key }] of targets.entries()) {
+      await upsertSessionEntryCore(
+        { agentId: index === 0 ? "main" : "secondary", sessionKey: key },
+        { sessionId: key, updatedAt: 1 },
+      );
+    }
+    const metadataKey = "agent:main:batch-independent";
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey: metadataKey },
+      { sessionId: metadataKey, updatedAt: 1 },
+    );
+    const catalog =
+      createDeferredCore<Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalog"]>>>();
+    const loadGatewayModelCatalog = vi.fn(() => catalog.promise);
+    const context = patchContext(loadGatewayModelCatalog, {
+      agents: {
+        defaults: { model: "anthropic/claude-sonnet-4-6" },
+        list: [{ id: "main" }, { id: "secondary" }],
+      },
+    });
+    const respond = vi.fn();
+    const batch = sessionMutationHandlers["sessions.patchMany"]!({
+      params: { targets, patch: { contextWindow: "extended" } },
+      respond,
+      context,
+      client: null,
+    } as never);
+    const metadataResponse = vi.fn();
+    let metadataPatch: Promise<void> | void = undefined;
+    try {
+      await vi.waitFor(() => expect(loadGatewayModelCatalog).toHaveBeenCalledTimes(2));
+      metadataPatch = patchRequest(context)({ key: metadataKey, pinned: true }, metadataResponse);
+      await vi.waitFor(() =>
+        expect(metadataResponse).toHaveBeenCalledWith(true, expect.any(Object), undefined),
+      );
+      expect(respond).not.toHaveBeenCalled();
+    } finally {
+      catalog.resolve([
+        {
+          provider: "anthropic",
+          id: "claude-sonnet-4-6",
+          name: "Sonnet",
+          contextWindows: [{ id: "extended", label: "Extended", contextWindow: 200_000 }],
+        },
+      ]);
+      await Promise.allSettled([batch, metadataPatch]);
+    }
+    expect(loadGatewayModelCatalog).toHaveBeenCalledTimes(2);
+    expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ agentId: "main" });
+    expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ agentId: "secondary" });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      { outcomes: targets.map(({ key }) => ({ key, ok: true })) },
+      undefined,
+    );
+    for (const [index, { key }] of targets.entries()) {
+      expect(
+        loadSessionEntry({ agentId: index === 0 ? "main" : "secondary", sessionKey: key })
+          ?.contextWindow,
+      ).toBe("extended");
+    }
+    expect(loadSessionEntry({ agentId: "main", sessionKey: metadataKey })?.pinnedAt).toEqual(
+      expect.any(Number),
+    );
+  });
+});
+
+test("a multi-target agent group retains ordered label claims around catalog loading", async () => {
+  await withOpenClawTestState({ scenario: "minimal" }, async () => {
+    const targets = ["first", "second"].map((name) => ({ key: `agent:main:ordered-${name}` }));
+    for (const { key } of targets) {
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey: key },
+        { sessionId: key, updatedAt: 1 },
+      );
+    }
+    const loadGatewayModelCatalog = vi.fn(async () => []);
+    const respond = vi.fn();
+    await sessionMutationHandlers["sessions.patchMany"]!({
+      params: { targets, patch: { label: "Winner", thinkingLevel: "off" } },
+      respond,
+      context: patchContext(loadGatewayModelCatalog),
+      client: null,
+    } as never);
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        outcomes: [
+          { key: targets[0]!.key, ok: true },
+          {
+            key: targets[1]!.key,
+            ok: false,
+            error: { code: "INVALID_REQUEST", message: "label already in use: Winner" },
+          },
+        ],
+      },
+      undefined,
+    );
+    expect(loadGatewayModelCatalog).toHaveBeenCalledOnce();
+    expect(loadSessionEntry({ agentId: "main", sessionKey: targets[0]!.key })).toMatchObject({
+      label: "Winner",
+      thinkingLevel: "off",
+    });
+    expect(
+      loadSessionEntry({ agentId: "main", sessionKey: targets[1]!.key })?.label,
+    ).toBeUndefined();
+    expect(
+      loadSessionEntry({ agentId: "main", sessionKey: targets[1]!.key })?.thinkingLevel,
+    ).toBeUndefined();
+  });
+});
+
+test("dispatched authorization rejects an instance replaced during catalog preparation", async () => {
+  await withOpenClawTestState({ scenario: "minimal" }, async () => {
+    const sessionKey = "agent:main:commit-bound-authorization";
+    // A write-scoped model reset revalidates retained thinking. Admin scope would
+    // bypass the session-instance authorization this request must exercise.
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey },
+      { sessionId: "session-shared", updatedAt: 1, visibility: "shared", thinkingLevel: "off" },
+    );
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    const respond = vi.fn();
+    const request = handleGatewayRequest({
+      req: {
+        type: "req",
+        id: "catalog-authorization",
+        method: "sessions.patch",
+        params: { key: sessionKey, label: "stale mutation", model: null },
+      },
+      respond,
+      client: {
+        connId: "catalog-authorization",
+        authenticatedUserId: "member@example.com",
+        authenticatedUserProfile: {
+          profileId: "member",
+          displayName: "Member",
+          hasAvatar: false,
+          updatedAt: 1,
+        },
+        connect: {
+          role: "operator",
+          scopes: ["operator.write"],
+          client: { id: "test", version: "1", platform: "test", mode: "test" },
+          minProtocol: 1,
+          maxProtocol: 1,
+        },
+      } as Parameters<typeof handleGatewayRequest>[0]["client"],
+      isWebchatConnect: () => false,
+      context: {
+        ...patchContext(async () => {
+          entered.resolve();
+          await release.promise;
+          return [];
+        }),
+        logGateway: { warn: vi.fn() },
+        broadcast: vi.fn(),
+      } as unknown as GatewayRequestContext,
+      extraHandlers: { "sessions.patch": sessionMutationHandlers["sessions.patch"]! },
+    });
+    let replacement: Promise<void> | undefined;
+    const committed = vi.fn();
+    try {
+      await Promise.race([entered.promise, request]);
+      expect(respond).not.toHaveBeenCalled();
+      replacement = (async () => {
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey },
+          {
+            sessionId: "session-draft-replacement",
+            updatedAt: 2,
+            thinkingLevel: undefined,
+            visibility: "draft",
+            createdVia: "operator",
+            createdActor: { type: "human", source: "profile", id: "owner" },
+          },
+        );
+        await patchSessionEntryCore({ agentId: "main", sessionKey }, () => ({
+          visibility: "draft",
+        }));
+        committed();
+      })();
+      void replacement.catch(() => {});
+      await vi.waitFor(() => expect(committed).toHaveBeenCalledOnce());
+      await replacement;
+      release.resolve();
+      await request;
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          details: expect.objectContaining({ code: "SESSION_MUTATION_AUTHORIZATION_CHANGED" }),
+        }),
+      );
+      const current = loadSessionEntry({ agentId: "main", sessionKey });
+      expect(current).toMatchObject({
+        sessionId: "session-draft-replacement",
+        visibility: "draft",
+      });
+      expect(current).not.toHaveProperty("label");
+      expect(current).not.toHaveProperty("thinkingLevel");
+    } finally {
+      release.resolve();
+      await Promise.allSettled([request, replacement]);
+    }
+  });
+});

--- a/src/gateway/server-methods/sessions-mutations.owner.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.owner.test.ts
@@ -147,65 +147,106 @@ describe("sessions.patch", () => {
     });
   });
 
-  it("serializes permission changes through live-runtime acknowledgement", async () => {
-    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
-      const sessionKey = "agent:main:permission-update";
-      const sessionId = "session-permission-update";
-      const cfg: OpenClawConfig = {};
-      const requestContext = context(cfg);
-      const requestClient = client();
-      requestClient.connect.scopes = ["operator.admin"];
-      await upsertSessionEntryCore(
-        { agentId: "main", env: state.env, sessionKey },
-        { sessionId, updatedAt: 1, permissionMode: "guarded" },
-      );
-      const entered = createDeferredCore();
-      const release = createDeferredCore();
-      const applyPermissionMode = vi.fn(async (_mode: string | null, revoke: () => void) => {
-        revoke();
-        entered.resolve();
-        await release.promise;
-        return true;
+  it.each([false, true])(
+    "serializes permission changes through live-runtime acknowledgement (catalog preparation=%s)",
+    async (prepareCatalog) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+        const sessionKey = "agent:main:permission-update";
+        const sessionId = "session-permission-update";
+        const cfg: OpenClawConfig = {};
+        const requestContext = context(cfg);
+        const requestClient = client();
+        requestClient.connect.scopes = ["operator.admin"];
+        await upsertSessionEntryCore(
+          { agentId: "main", env: state.env, sessionKey },
+          { sessionId, updatedAt: 1, permissionMode: "guarded" },
+        );
+        const entered = createDeferredCore();
+        const release = createDeferredCore();
+        const catalogEntered = createDeferredCore();
+        const catalogRelease = createDeferredCore();
+        const loadGatewayModelCatalog = vi.fn(async () => {
+          catalogEntered.resolve();
+          await catalogRelease.promise;
+          return [];
+        });
+        requestContext.loadGatewayModelCatalog = loadGatewayModelCatalog;
+        const applyPermissionMode = vi.fn(async (_mode: string | null, revoke: () => void) => {
+          revoke();
+          entered.resolve();
+          await release.promise;
+          return true;
+        });
+        const handle = { ...createEmbeddedRunHandle(), applyPermissionMode };
+        const patched = vi.fn(async () => {});
+        registerInternalHook("session:patch", patched);
+        setActiveEmbeddedRun(sessionId, handle, sessionKey);
+        const responses = [vi.fn(), vi.fn()];
+        const patch = (permissionMode: "full" | "read-only", index: number) =>
+          sessionMutationHandlers["sessions.patch"]!({
+            params: {
+              key: sessionKey,
+              permissionMode,
+              ...(prepareCatalog && index === 0 ? { thinkingLevel: "off" } : {}),
+            },
+            client: requestClient,
+            context: requestContext,
+            respond: responses[index]!,
+          } as never);
+        const first = patch("full", 0);
+        let second: ReturnType<typeof patch> | undefined;
+        try {
+          if (prepareCatalog) {
+            await Promise.race([catalogEntered.promise, first]);
+            expect(loadGatewayModelCatalog).toHaveBeenCalledOnce();
+            expect(applyPermissionMode).not.toHaveBeenCalled();
+            expect(patched).not.toHaveBeenCalled();
+            expect(isSessionPermissionChangePending(sessionId)).toBe(false);
+            expect(responses[0]).not.toHaveBeenCalled();
+            expect(
+              loadSessionEntry({ agentId: "main", env: state.env, sessionKey })?.permissionMode,
+            ).toBe("guarded");
+          }
+          catalogRelease.resolve();
+          await Promise.race([entered.promise, first]);
+          expect(applyPermissionMode).toHaveBeenCalledTimes(1);
+          expect(responses[0]).not.toHaveBeenCalled();
+          expect(isSessionPermissionChangePending(sessionId)).toBe(true);
+          expect(
+            loadSessionEntry({ agentId: "main", env: state.env, sessionKey })?.permissionMode,
+          ).toBe("full");
+          second = patch("read-only", 1);
+          await Promise.resolve();
+          expect(applyPermissionMode).toHaveBeenCalledTimes(1);
+          release.resolve();
+          await Promise.all([first, second]);
+          expect(applyPermissionMode.mock.calls.map(([mode]) => mode)).toEqual([
+            "full",
+            "read-only",
+          ]);
+          expect(responses[0]).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+          expect(responses[1]).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+          expect(patched).toHaveBeenCalledTimes(2);
+          expect(loadGatewayModelCatalog).toHaveBeenCalledTimes(prepareCatalog ? 1 : 0);
+          expect(isSessionPermissionChangePending(sessionId)).toBe(false);
+          expect(
+            loadSessionEntry({ agentId: "main", env: state.env, sessionKey })?.permissionMode,
+          ).toBe("read-only");
+          if (prepareCatalog) {
+            expect(
+              loadSessionEntry({ agentId: "main", env: state.env, sessionKey })?.thinkingLevel,
+            ).toBe("off");
+          }
+        } finally {
+          catalogRelease.resolve();
+          release.resolve();
+          await Promise.allSettled([first, second]);
+          unregisterInternalHook("session:patch", patched);
+          clearActiveEmbeddedRun(sessionId, handle, sessionKey);
+        }
       });
-      const handle = { ...createEmbeddedRunHandle(), applyPermissionMode };
-      setActiveEmbeddedRun(sessionId, handle, sessionKey);
-      const responses = [vi.fn(), vi.fn()];
-      const patch = (permissionMode: "full" | "read-only", index: number) =>
-        sessionMutationHandlers["sessions.patch"]!({
-          params: { key: sessionKey, permissionMode },
-          client: requestClient,
-          context: requestContext,
-          respond: responses[index]!,
-        } as never);
-      const first = patch("full", 0);
-      let second: ReturnType<typeof patch> | undefined;
-      try {
-        await Promise.race([entered.promise, first]);
-        expect(applyPermissionMode).toHaveBeenCalledTimes(1);
-        expect(responses[0]).not.toHaveBeenCalled();
-        expect(isSessionPermissionChangePending(sessionId)).toBe(true);
-        expect(
-          loadSessionEntry({ agentId: "main", env: state.env, sessionKey })?.permissionMode,
-        ).toBe("full");
-        second = patch("read-only", 1);
-        await Promise.resolve();
-        expect(applyPermissionMode).toHaveBeenCalledTimes(1);
-        release.resolve();
-        await Promise.all([first, second]);
-        expect(applyPermissionMode.mock.calls.map(([mode]) => mode)).toEqual(["full", "read-only"]);
-        expect(responses[0]).toHaveBeenCalledWith(true, expect.any(Object), undefined);
-        expect(responses[1]).toHaveBeenCalledWith(true, expect.any(Object), undefined);
-        expect(isSessionPermissionChangePending(sessionId)).toBe(false);
-        expect(
-          loadSessionEntry({ agentId: "main", env: state.env, sessionKey })?.permissionMode,
-        ).toBe("read-only");
-      } finally {
-        release.resolve();
-        await Promise.allSettled([first, second]);
-        clearActiveEmbeddedRun(sessionId, handle, sessionKey);
-      }
-    });
-  });
+    },
+  );
 
   it("refuses unsupported live permission changes before saving a misleading mode", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async (state) => {

--- a/src/gateway/server-methods/sessions-patch-catalog-preparation.ts
+++ b/src/gateway/server-methods/sessions-patch-catalog-preparation.ts
@@ -1,0 +1,73 @@
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
+import { prepareSessionsPatchEntry, projectSessionsPatchEntry } from "../sessions-patch.js";
+
+export type SessionPatchCatalogResult = Result<ModelCatalogEntry[], unknown>;
+
+export function createSessionPatchCatalogPreparation(
+  loadCatalog: (agentId: string) => Promise<ModelCatalogEntry[]>,
+) {
+  const preparations = new Map<string, Promise<SessionPatchCatalogResult>>();
+  const prepare = (agentId: string) => {
+    let promise = preparations.get(agentId);
+    if (!promise) {
+      promise = (async () => {
+        try {
+          const catalog = await loadCatalog(agentId);
+          return ok(Array.isArray(catalog) ? catalog : []);
+        } catch (error) {
+          return err(error);
+        }
+      })();
+      preparations.set(agentId, promise);
+    }
+    return promise;
+  };
+  const load = async (agentId: string) => {
+    const catalog = await prepare(agentId);
+    if (!catalog.ok) {
+      throw catalog.error;
+    }
+    return catalog.value;
+  };
+  return {
+    prepare,
+    load,
+    available: async (agentId: string) => {
+      const catalog = await preparations.get(agentId);
+      // A fresh row may no longer need a failed preparation. Required failures
+      // belong at projection use; a committed response consumes available facts.
+      return catalog?.ok ? catalog.value : undefined;
+    },
+    project: async (params: {
+      agentId: string;
+      mode: "prepare" | "ordered";
+      catalog?: SessionPatchCatalogResult;
+      projection: Parameters<typeof prepareSessionsPatchEntry>[0];
+    }): Promise<
+      | { kind: "model-catalog" }
+      | { kind: "complete"; result: Awaited<ReturnType<typeof projectSessionsPatchEntry>> }
+    > => {
+      if (params.mode === "ordered") {
+        return {
+          kind: "complete",
+          result: await projectSessionsPatchEntry({
+            ...params.projection,
+            loadGatewayModelCatalog: () => load(params.agentId),
+          }),
+        };
+      }
+      const projection = prepareSessionsPatchEntry(params.projection);
+      if (projection.kind === "complete") {
+        return projection;
+      }
+      if (!params.catalog) {
+        return { kind: "model-catalog" };
+      }
+      if (!params.catalog.ok) {
+        throw params.catalog.error;
+      }
+      return { kind: "complete", result: projection.finish(params.catalog.value) };
+    },
+  };
+}

--- a/src/gateway/server-methods/sessions-patch-engine.ts
+++ b/src/gateway/server-methods/sessions-patch-engine.ts
@@ -1,9 +1,7 @@
-import {
-  ErrorCodes,
-  errorShape,
-  type ErrorShape,
-  type SessionsPatchManyResult,
-  type SessionsPatchParams,
+import type {
+  ErrorShape,
+  SessionsPatchManyResult,
+  SessionsPatchParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { isInternalSessionEffectsKey } from "../../config/sessions/internal-session-key.js";
@@ -27,7 +25,6 @@ import {
   resolveGatewaySessionStoreTargetWithStore,
   type SessionsPatchResult,
 } from "../session-utils.js";
-import { projectSessionsPatchEntry } from "../sessions-patch.js";
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
 import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
 import * as sessionUnreadAck from "./session-unread-ack.js";
@@ -39,6 +36,10 @@ import {
   type SessionPatchArchiveTarget,
   validateSessionPatchArchiveProjection,
 } from "./sessions-patch-archive.js";
+import {
+  createSessionPatchCatalogPreparation,
+  type SessionPatchCatalogResult,
+} from "./sessions-patch-catalog-preparation.js";
 import { publishSessionPatchEffects } from "./sessions-patch-effects.js";
 import {
   createCommitGuard,
@@ -74,7 +75,9 @@ type MutationOutcome =
   | { ok: true; applied: boolean; entry: SessionEntry; cleanupError?: ErrorShape }
   | { ok: false; error: ErrorShape };
 
-type ModelCatalog = Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalog"]>>;
+type GroupMutationResult =
+  | { kind: "model-catalog" }
+  | { kind: "complete"; outcomes: MutationOutcome[] };
 
 type MutationCoreResult =
   | { ok: false; error: ErrorShape }
@@ -83,7 +86,7 @@ type MutationCoreResult =
       cfg: ReturnType<GatewayRequestContext["getRuntimeConfig"]>;
       outcomes: MutationOutcome[];
       preparedByIndex: Array<PreparedPatchTarget | undefined>;
-      modelCatalogByAgent: Map<string, Promise<ModelCatalog>>;
+      catalogs: ReturnType<typeof createSessionPatchCatalogPreparation>;
     };
 
 async function executeSessionPatchMutations(params: {
@@ -137,7 +140,7 @@ async function executeSessionPatchMutations(params: {
     }
     const logicalId = `${resolved.storePath}\0${resolved.canonicalKey ?? key}`;
     if (logicalTargets.has(logicalId)) {
-      return { ok: false, error: errorShape(ErrorCodes.INVALID_REQUEST, "Duplicate target.") };
+      return invalidSessionPatchOutcome("Duplicate target.");
     }
     logicalTargets.add(logicalId);
   }
@@ -151,10 +154,7 @@ async function executeSessionPatchMutations(params: {
   for (const [index, { input, key, requestedAgent, resolved }] of preflightTargets.entries()) {
     const unreadAckError = validateSessionUnreadAck(params.patch, input);
     if (unreadAckError) {
-      outcomes[index] = {
-        ok: false,
-        error: errorShape(ErrorCodes.INVALID_REQUEST, unreadAckError),
-      };
+      outcomes[index] = invalidSessionPatchOutcome(unreadAckError);
       continue;
     }
     if (!requestedAgent.ok) {
@@ -162,10 +162,7 @@ async function executeSessionPatchMutations(params: {
       continue;
     }
     if (!resolved) {
-      outcomes[index] = {
-        ok: false,
-        error: errorShape(ErrorCodes.INVALID_REQUEST, "Session target could not be resolved."),
-      };
+      outcomes[index] = invalidSessionPatchOutcome("Session target could not be resolved.");
       continue;
     }
     const requestedAgentId = requestedAgent.agentId;
@@ -199,10 +196,7 @@ async function executeSessionPatchMutations(params: {
       initialEntry,
     );
     if (missingHarnessSessionError) {
-      outcomes[index] = {
-        ok: false,
-        error: errorShape(ErrorCodes.INVALID_REQUEST, missingHarnessSessionError),
-      };
+      outcomes[index] = invalidSessionPatchOutcome(missingHarnessSessionError);
       continue;
     }
     // Commit guards are core control state; construct the protocol patch from
@@ -232,10 +226,7 @@ async function executeSessionPatchMutations(params: {
       continue;
     }
     if (initialPlacementPatchError) {
-      outcomes[index] = {
-        ok: false,
-        error: errorShape(ErrorCodes.INVALID_REQUEST, initialPlacementPatchError),
-      };
+      outcomes[index] = invalidSessionPatchOutcome(initialPlacementPatchError);
       continue;
     }
     const lifecycleIdentities = Array.from(
@@ -258,15 +249,9 @@ async function executeSessionPatchMutations(params: {
     preparedByIndex[index] = preparedTarget;
   }
 
-  const modelCatalogByAgent = new Map<string, Promise<ModelCatalog>>();
-  const loadModelCatalog = (agentId: string) => {
-    let promise = modelCatalogByAgent.get(agentId);
-    if (!promise) {
-      promise = params.context.loadGatewayModelCatalog({ agentId });
-      modelCatalogByAgent.set(agentId, promise);
-    }
-    return promise;
-  };
+  const catalogs = createSessionPatchCatalogPreparation((agentId) =>
+    params.context.loadGatewayModelCatalog({ agentId }),
+  );
 
   if (prepared.length > 0) {
     const releaseArchiveDrains = async () =>
@@ -282,7 +267,7 @@ async function executeSessionPatchMutations(params: {
                 cfg,
                 commitGuard: params.targets[target.index]!.commitGuard,
                 context: params.context,
-                loadGatewayModelCatalog: () => loadModelCatalog(target.targetAgentId),
+                loadGatewayModelCatalog: () => catalogs.load(target.targetAgentId),
                 personalModelSelection,
                 ...(pluginOwnerId ? { pluginOwnerId } : {}),
                 target,
@@ -338,238 +323,260 @@ async function executeSessionPatchMutations(params: {
                   number,
                   Awaited<ReturnType<typeof prepareSessionPatchWorktreeTransition>>
                 >();
-                const groupOutcomes = await applySessionEntryCanonicalReplacements({
-                  assertCommitAllowed: () => {
-                    // Fresh selections remain human-owned through the final commit;
-                    // existing session pins are intentionally not rebound to the caller.
-                    personalModelSelection?.assertCurrent();
-                    for (const transition of worktreeTransitions.values()) {
-                      transition.assertCommitAllowed();
-                    }
-                  },
-                  agentId: first.targetAgentId,
-                  sessionKeys: selectedSessionKeys,
-                  ...(requestedLabel.ok ? { includeLabelOwners: requestedLabel.label } : {}),
-                  storePath: first.storePath,
-                  skipMaintenance: true,
-                  update: async (entries) => {
-                    const workingStore = Object.fromEntries(
-                      entries.flatMap(({ entry, sessionKey }) =>
-                        isInternalSessionEffectsKey(sessionKey)
-                          ? []
-                          : [[sessionKey, entry] as const],
-                      ),
-                    );
-                    const labelOwners = new SessionLabelOwnerIndex(workingStore);
-                    const replacements: SessionEntryCanonicalReplacement[] = [];
-                    const projectedOutcomes: MutationOutcome[] = [];
-                    for (const target of group) {
-                      try {
-                        // Preflight facts can stale behind the writer queue; resolve this snapshot
-                        // again so a new legacy alias is rejected rather than promoted or deleted.
-                        const {
-                          entry: existingEntry,
-                          primaryKey,
-                          target: currentTarget,
-                        } = resolveCanonicalGatewaySessionStoreKey({
-                          cfg,
-                          key: target.key,
-                          store: workingStore,
-                          ...(target.requestedAgentId ? { agentId: target.requestedAgentId } : {}),
-                        });
-                        const creationError =
-                          !existingEntry &&
-                          authorizeGatewaySessionCreation({
-                            cfg,
-                            client,
-                            agentId: target.targetAgentId,
-                          });
-                        if (creationError) {
-                          projectedOutcomes.push({ ok: false, error: creationError });
-                          continue;
-                        }
-                        const candidateKeys = currentTarget.storeKeys;
-                        const ownershipError = resolvePluginSessionOwnershipError({
-                          action: "patch",
-                          entry: existingEntry,
-                          key: primaryKey,
-                          pluginOwnerId,
-                        });
-                        if (ownershipError) {
-                          projectedOutcomes.push({ ok: false, error: ownershipError });
-                          continue;
-                        }
-                        // Compare tool policy only inside the serialized writer snapshot. A
-                        // preflight comparison can stale behind another queued restriction.
-                        const expectedSessionChanged =
-                          (target.fullPatch.expectedSessionId !== undefined &&
-                            existingEntry?.sessionId !== target.fullPatch.expectedSessionId) ||
-                          (target.fullPatch.expectedLifecycleRevision !== undefined &&
-                            existingEntry?.lifecycleRevision !==
-                              target.fullPatch.expectedLifecycleRevision) ||
-                          sessionPatchExpectations.sessionPatchExpectationsChanged(
-                            existingEntry,
-                            target.fullPatch,
-                          );
-                        const lifecycleEntryRemoved =
-                          target.initialEntry !== undefined && existingEntry === undefined;
-                        const archiveTargetChanged =
-                          target.fullPatch.archived === true &&
-                          (target.initialEntry === undefined
-                            ? existingEntry !== undefined
-                            : existingEntry !== undefined &&
-                              (existingEntry.sessionId !== target.initialEntry.sessionId ||
-                                existingEntry.lifecycleRevision !==
-                                  target.initialEntry.lifecycleRevision));
-                        if (
-                          expectedSessionChanged ||
-                          lifecycleEntryRemoved ||
-                          archiveTargetChanged
-                        ) {
-                          projectedOutcomes.push({
-                            ok: false,
-                            error: sessionChangedError(target.key),
-                          });
-                          continue;
-                        }
-                        if (target.fullPatch.archived === true) {
-                          const archiveError = validateSessionPatchArchiveProjection({
-                            cfg,
-                            existingEntry,
-                            fullPatch: target.fullPatch,
-                            key: target.key,
-                            ...(pluginOwnerId ? { pluginOwnerId } : {}),
-                            preparation: target.archivePreparation!,
+                const applyGroup = (catalogPreparation?: SessionPatchCatalogResult) =>
+                  applySessionEntryCanonicalReplacements<GroupMutationResult>({
+                    assertCommitAllowed: () => {
+                      // Fresh selections remain human-owned through the final commit;
+                      // existing session pins are intentionally not rebound to the caller.
+                      personalModelSelection?.assertCurrent();
+                      for (const transition of worktreeTransitions.values()) {
+                        transition.assertCommitAllowed();
+                      }
+                    },
+                    agentId: first.targetAgentId,
+                    sessionKeys: selectedSessionKeys,
+                    ...(requestedLabel.ok ? { includeLabelOwners: requestedLabel.label } : {}),
+                    storePath: first.storePath,
+                    skipMaintenance: true,
+                    update: async (entries) => {
+                      const workingStore = Object.fromEntries(
+                        entries.flatMap(({ entry, sessionKey }) =>
+                          isInternalSessionEffectsKey(sessionKey)
+                            ? []
+                            : [[sessionKey, entry] as const],
+                        ),
+                      );
+                      const labelOwners = new SessionLabelOwnerIndex(workingStore);
+                      const replacements: SessionEntryCanonicalReplacement[] = [];
+                      const projectedOutcomes: MutationOutcome[] = [];
+                      for (const target of group) {
+                        try {
+                          // Preflight facts can stale behind the writer queue; resolve this snapshot
+                          // again so a new legacy alias is rejected rather than promoted or deleted.
+                          const {
+                            entry: existingEntry,
                             primaryKey,
+                            target: currentTarget,
+                          } = resolveCanonicalGatewaySessionStoreKey({
+                            cfg,
+                            key: target.key,
+                            store: workingStore,
+                            ...(target.requestedAgentId
+                              ? { agentId: target.requestedAgentId }
+                              : {}),
                           });
-                          if (archiveError) {
+                          const creationError =
+                            !existingEntry &&
+                            authorizeGatewaySessionCreation({
+                              cfg,
+                              client,
+                              agentId: target.targetAgentId,
+                            });
+                          if (creationError) {
+                            projectedOutcomes.push({ ok: false, error: creationError });
+                            continue;
+                          }
+                          const candidateKeys = currentTarget.storeKeys;
+                          const ownershipError = resolvePluginSessionOwnershipError({
+                            action: "patch",
+                            entry: existingEntry,
+                            key: primaryKey,
+                            pluginOwnerId,
+                          });
+                          if (ownershipError) {
+                            projectedOutcomes.push({ ok: false, error: ownershipError });
+                            continue;
+                          }
+                          // Compare tool policy only inside the serialized writer snapshot. A
+                          // preflight comparison can stale behind another queued restriction.
+                          const expectedSessionChanged =
+                            (target.fullPatch.expectedSessionId !== undefined &&
+                              existingEntry?.sessionId !== target.fullPatch.expectedSessionId) ||
+                            (target.fullPatch.expectedLifecycleRevision !== undefined &&
+                              existingEntry?.lifecycleRevision !==
+                                target.fullPatch.expectedLifecycleRevision) ||
+                            sessionPatchExpectations.sessionPatchExpectationsChanged(
+                              existingEntry,
+                              target.fullPatch,
+                            );
+                          const lifecycleEntryRemoved =
+                            target.initialEntry !== undefined && existingEntry === undefined;
+                          const archiveTargetChanged =
+                            target.fullPatch.archived === true &&
+                            (target.initialEntry === undefined
+                              ? existingEntry !== undefined
+                              : existingEntry !== undefined &&
+                                (existingEntry.sessionId !== target.initialEntry.sessionId ||
+                                  existingEntry.lifecycleRevision !==
+                                    target.initialEntry.lifecycleRevision));
+                          if (
+                            expectedSessionChanged ||
+                            lifecycleEntryRemoved ||
+                            archiveTargetChanged
+                          ) {
                             projectedOutcomes.push({
                               ok: false,
-                              error: archiveError,
+                              error: sessionChangedError(target.key),
                             });
                             continue;
                           }
-                        }
-                        const unreadAck = resolveSessionUnreadAck(existingEntry, target.fullPatch);
-                        if (unreadAck.kind === "missing") {
-                          projectedOutcomes.push({
-                            ok: false,
-                            error: sessionChangedError(target.key),
+                          if (target.fullPatch.archived === true) {
+                            const archiveError = validateSessionPatchArchiveProjection({
+                              cfg,
+                              existingEntry,
+                              fullPatch: target.fullPatch,
+                              key: target.key,
+                              ...(pluginOwnerId ? { pluginOwnerId } : {}),
+                              preparation: target.archivePreparation!,
+                              primaryKey,
+                            });
+                            if (archiveError) {
+                              projectedOutcomes.push({ ok: false, error: archiveError });
+                              continue;
+                            }
+                          }
+                          const unreadAck = resolveSessionUnreadAck(
+                            existingEntry,
+                            target.fullPatch,
+                          );
+                          if (unreadAck.kind === "missing") {
+                            projectedOutcomes.push({
+                              ok: false,
+                              error: sessionChangedError(target.key),
+                            });
+                            continue;
+                          }
+                          if (unreadAck.kind === "stale") {
+                            const authorizationFailure =
+                              params.targets[target.index]!.commitGuard();
+                            if (authorizationFailure) {
+                              projectedOutcomes.push({ ok: false, error: authorizationFailure });
+                              continue;
+                            }
+                            // A newer explicit marker owns the session until a later activation.
+                            projectedOutcomes.push({
+                              ok: true,
+                              applied: false,
+                              entry: unreadAck.entry,
+                            });
+                            continue;
+                          }
+                          const projection = await catalogs.project({
+                            agentId: target.targetAgentId,
+                            // Multi-target groups retain ordered effects and label claims.
+                            mode: group.length === 1 ? "prepare" : "ordered",
+                            catalog: catalogPreparation,
+                            projection: {
+                              cfg,
+                              creation,
+                              existingEntry,
+                              isLabelInUse: (label) =>
+                                labelOwners.isLabelInUse(label, candidateKeys),
+                              storeKey: primaryKey,
+                              agentId: target.requestedAgentId,
+                              patch: target.fullPatch,
+                              archivedBy: archiveActor,
+                              personalModelSelection,
+                            },
                           });
-                          continue;
-                        }
-                        if (unreadAck.kind === "stale") {
+                          if (projection.kind === "model-catalog") {
+                            // No replacements or runtime effects exist yet. Release this
+                            // writer snapshot; completed preparation must use fresh rows.
+                            return { result: projection };
+                          }
+                          const projected = projection.result;
+                          if (!projected.ok) {
+                            projectedOutcomes.push(projected);
+                            continue;
+                          }
+                          const placementPatchError = resolveSessionWorkerPlacementPatchError({
+                            agentId: target.targetAgentId,
+                            cfg,
+                            context: params.context,
+                            entry: projected.entry,
+                            key: target.key,
+                            patch: target.fullPatch,
+                            sessionKey: primaryKey,
+                            validateModelRuntime: true,
+                          });
+                          if (placementPatchError) {
+                            projectedOutcomes.push(invalidSessionPatchOutcome(placementPatchError));
+                            continue;
+                          }
                           const authorizationFailure = params.targets[target.index]!.commitGuard();
                           if (authorizationFailure) {
                             projectedOutcomes.push({ ok: false, error: authorizationFailure });
                             continue;
                           }
-                          // A newer explicit marker owns the session until a later activation.
-                          projectedOutcomes.push({
-                            ok: true,
-                            applied: false,
-                            entry: unreadAck.entry,
+                          if (
+                            existingEntry?.worktree &&
+                            typeof target.fullPatch.archived === "boolean"
+                          ) {
+                            const transition = await prepareSessionPatchWorktreeTransition({
+                              archived: target.fullPatch.archived,
+                              entry: existingEntry,
+                              context: params.context,
+                              scope: {
+                                agentId: target.targetAgentId,
+                                sessionKey: primaryKey,
+                                storePath: target.storePath,
+                              },
+                              authorize: params.targets[target.index]!.commitGuard,
+                              preparation: target.archivePreparation,
+                            });
+                            worktreeTransitions.set(target.index, transition);
+                          }
+                          if (permissionRuntime && existingEntry?.sessionId) {
+                            const permission =
+                              permissionRuntime.prepareSessionPatchPermissionChange({
+                                context: params.context,
+                                sessionId: existingEntry.sessionId,
+                                sessionKey: target.canonicalKey,
+                                agentId: target.targetAgentId,
+                                assertCurrent: params.targets[target.index]!.commitGuard,
+                              });
+                            if (!permission.ok) {
+                              projectedOutcomes.push(permission);
+                              continue;
+                            }
+                            target.permissionChange = permission.change;
+                          }
+                          const previousSessionKeys = candidateKeys.filter(
+                            (sessionKey) => sessionKey !== primaryKey && workingStore[sessionKey],
+                          );
+                          replacements.push({
+                            entry: projected.entry,
+                            previousSessionKeys,
+                            sessionKey: primaryKey,
                           });
-                          continue;
-                        }
-                        const projected = await projectSessionsPatchEntry({
-                          cfg,
-                          creation,
-                          existingEntry,
-                          isLabelInUse: (label) => labelOwners.isLabelInUse(label, candidateKeys),
-                          storeKey: primaryKey,
-                          agentId: target.requestedAgentId,
-                          patch: target.fullPatch,
-                          archivedBy: archiveActor,
-                          loadGatewayModelCatalog: () => loadModelCatalog(target.targetAgentId),
-                          personalModelSelection,
-                        });
-                        if (!projected.ok) {
-                          projectedOutcomes.push(projected);
-                          continue;
-                        }
-                        const placementPatchError = resolveSessionWorkerPlacementPatchError({
-                          agentId: target.targetAgentId,
-                          cfg,
-                          context: params.context,
-                          entry: projected.entry,
-                          key: target.key,
-                          patch: target.fullPatch,
-                          sessionKey: primaryKey,
-                          validateModelRuntime: true,
-                        });
-                        if (placementPatchError) {
+                          const cloned = labelOwners.replaceEntry(
+                            candidateKeys,
+                            primaryKey,
+                            projected.entry,
+                          );
+                          projectedOutcomes.push({ ok: true, applied: true, entry: cloned });
+                        } catch (error) {
                           projectedOutcomes.push({
                             ok: false,
-                            error: errorShape(ErrorCodes.INVALID_REQUEST, placementPatchError),
+                            error: unexpectedPatchError(target.key, error),
                           });
-                          continue;
                         }
-                        const authorizationFailure = params.targets[target.index]!.commitGuard();
-                        if (authorizationFailure) {
-                          projectedOutcomes.push({ ok: false, error: authorizationFailure });
-                          continue;
-                        }
-                        if (
-                          existingEntry?.worktree &&
-                          typeof target.fullPatch.archived === "boolean"
-                        ) {
-                          const transition = await prepareSessionPatchWorktreeTransition({
-                            archived: target.fullPatch.archived,
-                            entry: existingEntry,
-                            context: params.context,
-                            scope: {
-                              agentId: target.targetAgentId,
-                              sessionKey: primaryKey,
-                              storePath: target.storePath,
-                            },
-                            authorize: params.targets[target.index]!.commitGuard,
-                            preparation: target.archivePreparation,
-                          });
-                          worktreeTransitions.set(target.index, transition);
-                        }
-                        if (permissionRuntime && existingEntry?.sessionId) {
-                          const permission = permissionRuntime.prepareSessionPatchPermissionChange({
-                            context: params.context,
-                            sessionId: existingEntry.sessionId,
-                            sessionKey: target.canonicalKey,
-                            agentId: target.targetAgentId,
-                            assertCurrent: params.targets[target.index]!.commitGuard,
-                          });
-                          if (!permission.ok) {
-                            projectedOutcomes.push(permission);
-                            continue;
-                          }
-                          target.permissionChange = permission.change;
-                        }
-                        const previousSessionKeys = candidateKeys.filter(
-                          (sessionKey) => sessionKey !== primaryKey && workingStore[sessionKey],
-                        );
-                        replacements.push({
-                          entry: projected.entry,
-                          previousSessionKeys,
-                          sessionKey: primaryKey,
-                        });
-                        const cloned = labelOwners.replaceEntry(
-                          candidateKeys,
-                          primaryKey,
-                          projected.entry,
-                        );
-                        projectedOutcomes.push({
-                          ok: true,
-                          applied: true,
-                          entry: cloned,
-                        });
-                      } catch (error) {
-                        projectedOutcomes.push({
-                          ok: false,
-                          error: unexpectedPatchError(target.key, error),
-                        });
                       }
-                    }
-                    return { replacements, result: projectedOutcomes };
-                  },
-                });
+                      return {
+                        replacements,
+                        result: { kind: "complete", outcomes: projectedOutcomes },
+                      };
+                    },
+                  });
+                let groupResult = await applyGroup();
+                if (groupResult.kind === "model-catalog") {
+                  const catalog = await catalogs.prepare(first.targetAgentId);
+                  groupResult = await applyGroup(catalog);
+                }
+                if (groupResult.kind !== "complete") {
+                  throw new Error("Session patch catalog preparation did not complete");
+                }
+                const groupOutcomes = groupResult.outcomes;
                 for (const [groupIndex, target] of group.entries()) {
                   const outcome = groupOutcomes[groupIndex]!;
                   outcomes[target.index] = outcome;
@@ -635,7 +642,7 @@ async function executeSessionPatchMutations(params: {
       outcome?.ok && outcome.cleanupError ? { ok: false, error: outcome.cleanupError } : outcome,
     ) as MutationOutcome[],
     preparedByIndex,
-    modelCatalogByAgent,
+    catalogs,
   };
 }
 
@@ -716,11 +723,11 @@ export async function executeSessionPatch(params: {
   const prepared = executed.preparedByIndex[0]!;
   return {
     ok: true,
-    result: await projectSessionPatchResult({
+    result: projectSessionPatchResult({
       ...prepared,
       cfg: executed.cfg,
       entry: outcome.entry,
-      modelCatalogByAgent: executed.modelCatalogByAgent,
+      modelCatalog: await executed.catalogs.available(prepared.targetAgentId),
     }),
   };
 }

--- a/src/gateway/server.sessions.archive-worktree-lifecycle.test.ts
+++ b/src/gateway/server.sessions.archive-worktree-lifecycle.test.ts
@@ -18,6 +18,7 @@ import {
   patchSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import { flushPendingSessionsChangedEvents } from "./server-methods/session-change-event.js";
 import {
@@ -31,12 +32,13 @@ const { createArchiveWorktreeFixture } = setupGatewaySessionsWorktreeTestHarness
 const execFileAsync = promisify(execFile);
 
 test.each([
-  ["sessions.patch", false],
-  ["sessions.patchMany", false],
-  ["sessions.patch", true],
+  ["sessions.patch", false, false],
+  ["sessions.patchMany", false, false],
+  ["sessions.patch", true, false],
+  ["sessions.patch", false, true],
 ] as const)(
-  "%s archives the checkout and restores dirty work without deleting the conversation (already archived=%s)",
-  async (method, alreadyArchived) => {
+  "%s archives the checkout and restores dirty work without deleting the conversation (already archived=%s, catalog preparation=%s)",
+  async (method, alreadyArchived, prepareCatalog) => {
     const fixture = await createArchiveWorktreeFixture();
     const { key, sessionId, storePath, worktree, workspace } = fixture;
     await fs.writeFile(path.join(worktree.path, "committed.txt"), "unpushed work\n");
@@ -52,12 +54,25 @@ test.each([
         skipMaintenance: true,
       });
     }
+    const catalogEntered = createDeferredCore();
+    const catalogRelease = createDeferredCore();
+    const loadGatewayModelCatalog = vi.fn(async () => {
+      catalogEntered.resolve();
+      await catalogRelease.promise;
+      return [];
+    });
     const patch = (archived: boolean) =>
       directSessionReq(
         method,
         method === "sessions.patch"
-          ? { key, expectedSessionId: sessionId, archived }
+          ? {
+              key,
+              expectedSessionId: sessionId,
+              archived,
+              ...(!archived && prepareCatalog ? { thinkingLevel: "off" } : {}),
+            }
           : { targets: [{ key, expectedSessionId: sessionId }], patch: { archived } },
+        !archived && prepareCatalog ? { context: { loadGatewayModelCatalog } } : undefined,
       );
 
     expect(await patch(true)).toMatchObject({ ok: true });
@@ -76,7 +91,30 @@ test.each([
     ).not.toContain(worktree.path);
     await expect(loadSeededTranscriptEvents(fixture.transcriptScope)).resolves.toEqual(transcript);
 
-    expect(await patch(false)).toMatchObject({ ok: true });
+    const restore = prepareCatalog ? vi.spyOn(managedWorktrees, "restore") : undefined;
+    const restored = patch(false);
+    try {
+      if (prepareCatalog) {
+        await Promise.race([catalogEntered.promise, restored]);
+        expect(loadGatewayModelCatalog).toHaveBeenCalledOnce();
+        expect(restore).not.toHaveBeenCalled();
+        expect(loadSessionEntry({ storePath, sessionKey: key })?.archivedAt).toEqual(
+          expect.any(Number),
+        );
+        await expect(fs.access(worktree.path)).rejects.toThrow();
+      }
+      catalogRelease.resolve();
+      expect(await restored).toMatchObject({ ok: true });
+      if (prepareCatalog) {
+        expect(restore).toHaveBeenCalledOnce();
+        expect(loadGatewayModelCatalog).toHaveBeenCalledOnce();
+        expect(loadSessionEntry({ storePath, sessionKey: key })?.thinkingLevel).toBe("off");
+      }
+    } finally {
+      catalogRelease.resolve();
+      await Promise.allSettled([restored]);
+      restore?.mockRestore();
+    }
     expect(loadSessionEntry({ storePath, sessionKey: key })?.archivedAt).toBeUndefined();
     expect(getRegistryWorktree(process.env, worktree.id)?.removedAt).toBeUndefined();
     await expect(fs.readFile(path.join(worktree.path, "README.md"), "utf8")).resolves.toBe(

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -670,14 +670,14 @@ function resolveSessionDisplayModelIdentityRef(params: {
   };
 }
 
-export async function projectSessionPatchResult(params: {
+export function projectSessionPatchResult(params: {
   canonicalKey: string;
   cfg: OpenClawConfig;
   entry: SessionEntry;
-  modelCatalogByAgent: ReadonlyMap<string, Promise<ModelCatalogEntry[]>>;
+  modelCatalog?: ModelCatalogEntry[];
   storePath: string;
   targetAgentId: string;
-}): Promise<SessionsPatchResult> {
+}): SessionsPatchResult {
   const agentId = resolveSessionAgentId({
     config: params.cfg,
     sessionKey: params.canonicalKey,
@@ -690,7 +690,7 @@ export async function projectSessionPatchResult(params: {
     provider: resolved.provider,
     model: resolved.model,
   });
-  const modelCatalog = await params.modelCatalogByAgent.get(params.targetAgentId);
+  const modelCatalog = params.modelCatalog;
   const thinking = resolveGatewaySessionThinkingProjectionInternal({
     cfg: params.cfg,
     agentId,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1464,7 +1464,7 @@ describe("gateway session utils", () => {
     expect(nativeUltra.thinkingLevels).toContainEqual({ id: "ultra", label: "ultra" });
   });
 
-  test("strips retired thinking provenance from Gateway patch results", async () => {
+  test("strips retired thinking provenance from Gateway patch results", () => {
     const entry = {
       sessionId: "private-fallback",
       updatedAt: 1,
@@ -1477,25 +1477,20 @@ describe("gateway session utils", () => {
         ts: 1,
       },
     } as unknown as InternalSessionEntry;
-    const result = await projectSessionPatchResult({
+    const result = projectSessionPatchResult({
       canonicalKey: "agent:main:main",
       cfg: {
         agents: { defaults: { model: { primary: "openai/gpt-5.6-sol" } } },
       } as OpenClawConfig,
       entry,
-      modelCatalogByAgent: new Map([
-        [
-          "main",
-          Promise.resolve([
-            {
-              provider: "openai",
-              id: "gpt-5.6-sol",
-              name: "GPT 5.6 Sol",
-              reasoning: true,
-            },
-          ]),
-        ],
-      ]),
+      modelCatalog: [
+        {
+          provider: "openai",
+          id: "gpt-5.6-sol",
+          name: "GPT 5.6 Sol",
+          reasoning: true,
+        },
+      ],
       storePath: "/tmp/openclaw-sessions.json",
       targetAgentId: "main",
     });

--- a/src/gateway/sessions-patch-catalog-queue.e2e.test.ts
+++ b/src/gateway/sessions-patch-catalog-queue.e2e.test.ts
@@ -1,0 +1,135 @@
+import { expect, test, vi } from "vitest";
+import {
+  markPreparedModelRuntimeSnapshotsStale,
+  rejectPendingPreparedModelRuntimeReplacement,
+} from "../agents/prepared-model-runtime.js";
+import { loadSessionEntry, upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { captureEnv } from "../test-utils/env.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { ADMIN_SCOPE } from "./method-scopes.js";
+import * as modelCatalog from "./server-model-catalog.js";
+import { startGatewayServer } from "./server.js";
+import {
+  connectGatewayClient,
+  disconnectGatewayClient,
+  getGatewayE2ePortBlock,
+} from "./test-helpers.e2e.js";
+import {
+  configureManualGatewayBackgroundEnv,
+  MANUAL_GATEWAY_ENV_KEYS,
+} from "./test-helpers.manual-gateway-env.js";
+
+test("an authenticated metadata patch completes while another session awaits catalog reload", async () => {
+  await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+    const backgroundEnv = captureEnv([...MANUAL_GATEWAY_ENV_KEYS]);
+    configureManualGatewayBackgroundEnv(state.home);
+    let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
+    let client: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+    try {
+      await state.writeConfig({ agents: { defaults: { workspace: state.workspaceDir } } });
+      const port = await getGatewayE2ePortBlock();
+      const token = "catalog-queue-synthetic-token";
+      server = await startGatewayServer(port, {
+        bind: "loopback",
+        auth: { mode: "token", token },
+        controlUiEnabled: false,
+        sidecarStartup: "defer",
+      });
+      client = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token,
+        scopes: [ADMIN_SCOPE],
+        clientDisplayName: "catalog queue proof",
+        timeoutMs: 60_000,
+      });
+      await server.startupSettled;
+      const catalogKey = "agent:main:catalog-dependent";
+      const metadataKey = "agent:main:independent-metadata";
+      for (const sessionKey of [catalogKey, metadataKey]) {
+        await upsertSessionEntryCore(
+          { agentId: "main", env: state.env, sessionKey },
+          { sessionId: sessionKey, updatedAt: 1 },
+        );
+      }
+      // The overlap measures a loaded method graph, not its first lazy import.
+      await client.request("sessions.patch", { key: metadataKey, pinned: false });
+      const entered = createDeferredCore();
+      const originalLoader = modelCatalog.loadGatewayModelCatalog;
+      const loader = vi
+        .spyOn(modelCatalog, "loadGatewayModelCatalog")
+        .mockImplementation((params) => {
+          entered.resolve();
+          return originalLoader(params);
+        });
+      const replacement = markPreparedModelRuntimeSnapshotsStale("catalog reload", {
+        waitForReplacement: true,
+      });
+      expect(replacement).toBeDefined();
+      const catalogPatch = client
+        .request("sessions.patch", {
+          key: catalogKey,
+          contextWindow: "extended",
+        })
+        .then(
+          (value) => ({ ok: true as const, value }),
+          (error: unknown) => ({ ok: false as const, error }),
+        );
+      let metadataPatch: Promise<unknown> | undefined;
+      let metadataResult: unknown;
+      let blockedMetadata: Error | undefined;
+      try {
+        await Promise.race([entered.promise, catalogPatch]);
+        expect(loader).toHaveBeenCalledOnce();
+        metadataPatch = client
+          .request("sessions.patch", { key: metadataKey, pinned: true })
+          .then((value) => {
+            metadataResult = value;
+            return value;
+          });
+        // Retain a timeout/rejection until after both original requests settle.
+        void metadataPatch.catch(() => {});
+        await vi
+          .waitFor(() =>
+            expect(metadataResult).toMatchObject({
+              entry: { pinnedAt: expect.any(Number) },
+            }),
+          )
+          .catch((error: unknown) => {
+            blockedMetadata = error instanceof Error ? error : new Error(String(error));
+          });
+        expect(loader).toHaveBeenCalledOnce();
+      } finally {
+        rejectPendingPreparedModelRuntimeReplacement(
+          replacement,
+          new Error("Synthetic catalog reload failed"),
+        );
+        await Promise.allSettled([catalogPatch, metadataPatch]);
+        loader.mockRestore();
+      }
+      expect(await catalogPatch).toMatchObject({
+        ok: false,
+        error: { gatewayCode: "UNAVAILABLE" },
+      });
+      expect(
+        loadSessionEntry({ agentId: "main", sessionKey: catalogKey })?.contextWindow,
+      ).toBeUndefined();
+      expect(await metadataPatch).toMatchObject({ entry: { pinnedAt: expect.any(Number) } });
+      expect(loadSessionEntry({ agentId: "main", sessionKey: metadataKey })?.pinnedAt).toEqual(
+        expect.any(Number),
+      );
+      if (blockedMetadata) {
+        throw blockedMetadata;
+      }
+    } finally {
+      try {
+        if (client) {
+          await disconnectGatewayClient(client);
+        }
+      } finally {
+        await server?.close();
+        backgroundEnv.restore();
+      }
+    }
+  });
+}, 120_000);

--- a/src/gateway/sessions-patch-context-window.ts
+++ b/src/gateway/sessions-patch-context-window.ts
@@ -3,13 +3,17 @@ import type { SessionsPatchParams } from "../../packages/gateway-protocol/src/in
 import { findModelCatalogEntry, type ModelCatalogEntry } from "../agents/model-catalog.js";
 import type { InternalSessionEntry as SessionEntry } from "../config/sessions.js";
 
-export async function applySessionContextWindowPatch(params: {
+export function* applySessionContextWindowPatch(params: {
   defaultModel: string;
   defaultProvider: string;
-  loadModelCatalog: () => Promise<ModelCatalogEntry[] | undefined>;
+  loadModelCatalog: () => Generator<
+    void,
+    ModelCatalogEntry[] | undefined,
+    ModelCatalogEntry[] | undefined
+  >;
   next: SessionEntry;
   patch: SessionsPatchParams;
-}): Promise<{ ok: true } | { ok: false; error: string }> {
+}): Generator<void, { ok: true } | { ok: false; error: string }, ModelCatalogEntry[] | undefined> {
   if ("contextWindow" in params.patch) {
     const previous = params.next.contextWindow;
     const raw = params.patch.contextWindow;
@@ -32,7 +36,7 @@ export async function applySessionContextWindowPatch(params: {
   }
   const provider = params.next.providerOverride ?? params.defaultProvider;
   const model = params.next.modelOverride ?? params.defaultModel;
-  const catalog = await params.loadModelCatalog();
+  const catalog = yield* params.loadModelCatalog();
   const catalogEntry = catalog
     ? findModelCatalogEntry(catalog, { provider, modelId: model })
     : undefined;

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -531,18 +531,24 @@ describe("gateway sessions patch", () => {
     expect(entry.thinkingLevel).toBe("off");
   });
 
-  test("clears thinkingLevel when patch sets null", async () => {
-    const store: Record<string, SessionEntry> = {
-      [MAIN_SESSION_KEY]: { thinkingLevel: "low" } as SessionEntry,
-    };
-    const entry = expectPatchOk(
-      await runPatch({
-        store,
-        patch: { key: MAIN_SESSION_KEY, thinkingLevel: null },
-      }),
-    );
-    expect(entry.thinkingLevel).toBeUndefined();
-  });
+  test.each(["thinkingLevel", "contextWindow"] as const)(
+    "clears %s without loading the catalog",
+    async (field) => {
+      const store = mainStoreEntry({ thinkingLevel: "low", contextWindow: "extended" });
+      const loadGatewayModelCatalog = vi.fn(async () => {
+        throw new Error("Catalog must not be needed for a clear");
+      });
+      const entry = expectPatchOk(
+        await runPatch({
+          store,
+          patch: { key: MAIN_SESSION_KEY, [field]: null },
+          loadGatewayModelCatalog,
+        }),
+      );
+      expect(entry[field]).toBeUndefined();
+      expect(loadGatewayModelCatalog).not.toHaveBeenCalled();
+    },
+  );
 
   test("persists responseUsage=off (does not clear)", async () => {
     const entry = expectPatchOk(
@@ -1146,16 +1152,108 @@ describe("gateway sessions patch", () => {
       modelOverrideSource: "user",
       liveModelSwitchPending: true,
     });
-    const entry = await applyMainModelPatch({
-      store,
-      cfg: createAllowlistedAnthropicModelCfg(),
-      model: null,
+    const loadGatewayModelCatalog = vi.fn(async () => {
+      throw new Error("Catalog must not be needed for an unqualified reset");
     });
+    const entry = expectPatchOk(
+      await runPatch({
+        store,
+        cfg: createAllowlistedAnthropicModelCfg(),
+        patch: { key: MAIN_SESSION_KEY, model: null },
+        loadGatewayModelCatalog,
+      }),
+    );
 
     expectModelSelection(entry, undefined, undefined);
     expect(entry.modelOverrideSource).toBeUndefined();
     expect(entry.liveModelSwitchPending).toBeUndefined();
+    expect(loadGatewayModelCatalog).not.toHaveBeenCalled();
   });
+
+  test.each([true, false])(
+    "model reset revalidates retained selections once (context supported: %s)",
+    async (supported) => {
+      const loadGatewayModelCatalog = vi.fn(async () => [
+        {
+          ...catalogEntry(ANTHROPIC_SONNET_MODEL),
+          reasoning: true,
+          contextWindows: supported
+            ? [{ id: "extended", label: "Extended", contextWindow: 200_000 }]
+            : [],
+        },
+      ]);
+      const entry = expectPatchOk(
+        await runPatch({
+          cfg: { agents: { defaults: { model: ANTHROPIC_SONNET_MODEL } } },
+          store: mainStoreEntry({
+            providerOverride: "anthropic",
+            modelOverride: ANTHROPIC_OPUS_ID,
+            thinkingLevel: "high",
+            contextWindow: "extended",
+          }),
+          patch: { key: MAIN_SESSION_KEY, model: null },
+          loadGatewayModelCatalog,
+        }),
+      );
+      expectModelSelection(entry, undefined, undefined);
+      expect(entry.thinkingLevel).toBe("high");
+      expect(entry.contextWindow).toBe(supported ? "extended" : undefined);
+      expect(loadGatewayModelCatalog).toHaveBeenCalledOnce();
+    },
+  );
+
+  test("one catalog prepares a combined model, thinking, and context-window patch", async () => {
+    const loadGatewayModelCatalog = vi.fn(async () => [
+      {
+        ...catalogEntry(ANTHROPIC_SONNET_MODEL),
+        reasoning: true,
+        contextWindows: [{ id: "extended", label: "Extended", contextWindow: 200_000 }],
+      },
+    ]);
+    const entry = expectPatchOk(
+      await runPatch({
+        cfg: createAllowlistedAnthropicModelCfg(),
+        store: mainStoreEntry({}),
+        patch: {
+          key: MAIN_SESSION_KEY,
+          model: ANTHROPIC_SONNET_MODEL,
+          thinkingLevel: "high",
+          contextWindow: "extended",
+        },
+        loadGatewayModelCatalog,
+      }),
+    );
+    expectModelSelection(entry, "anthropic", ANTHROPIC_SONNET_ID);
+    expect(entry).toMatchObject({ thinkingLevel: "high", contextWindow: "extended" });
+    expect(loadGatewayModelCatalog).toHaveBeenCalledOnce();
+  });
+
+  test.each([
+    { patch: { category: "" }, message: "invalid category" },
+    { patch: { model: "" }, message: "invalid model: empty" },
+  ])(
+    "preserves early validation before catalog preparation: $message",
+    async ({ patch, message }) => {
+      const loadGatewayModelCatalog = vi.fn(async () => {
+        throw new Error("Catalog failure must not replace early validation");
+      });
+      const store = mainStoreEntry({ label: "Original" });
+      expectPatchError(
+        await runPatch({
+          store,
+          patch: { key: MAIN_SESSION_KEY, contextWindow: "extended", ...patch },
+          loadGatewayModelCatalog,
+        }),
+        message,
+      );
+      expect(loadGatewayModelCatalog).not.toHaveBeenCalled();
+      expect(store[MAIN_SESSION_KEY]).toEqual({
+        sessionId: "sess",
+        updatedAt: 1,
+        label: "Original",
+      });
+    },
+  );
 
   test.each([
     {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -122,8 +122,7 @@ export function resolveSessionPatchModelSelection(params: {
   };
 }
 
-/** Project a validated gateway session patch for one session entry. */
-export async function projectSessionsPatchEntry(params: {
+type SessionPatchProjectionParams = {
   cfg: OpenClawConfig;
   creation?: { via: SessionCreatedVia; actor?: SessionEntry["createdActor"] };
   existingEntry?: SessionEntry;
@@ -136,12 +135,64 @@ export async function projectSessionsPatchEntry(params: {
   /** Trusted catalog runtime must own selection checks before the new row is persisted. */
   preparedAgentRuntime?: string;
   archivedBy?: SessionEntry["archivedBy"];
-  loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
   providerAuthMetadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins">;
   /** Exact harness owner authorized to project its new reserved session row. */
   authorizedAgentHarnessId?: string;
   personalModelSelection?: UserModelAccountSelection;
-}): Promise<{ ok: true; entry: SessionEntry } | { ok: false; error: ErrorShape }> {
+};
+
+type SessionPatchProjectionResult =
+  | { ok: true; entry: SessionEntry }
+  | { ok: false; error: ErrorShape };
+
+type SessionPatchPreparation =
+  | { kind: "complete"; result: SessionPatchProjectionResult }
+  | {
+      kind: "model-catalog";
+      finish: (catalog: ModelCatalogEntry[] | undefined) => SessionPatchProjectionResult;
+    };
+
+/** Stop at the first actual catalog use without committing or acquiring runtime effects. */
+export function prepareSessionsPatchEntry(
+  params: SessionPatchProjectionParams,
+): SessionPatchPreparation {
+  const projection = projectSessionPatchSteps(params);
+  const first = projection.next();
+  if (first.done) {
+    return { kind: "complete", result: first.value };
+  }
+  return {
+    kind: "model-catalog",
+    finish: (catalog) => {
+      const completed = projection.next(catalog);
+      if (!completed.done) {
+        throw new Error("Session patch preparation requested the catalog more than once");
+      }
+      return completed.value;
+    },
+  };
+}
+
+/** Project a validated gateway session patch for one session entry. */
+export async function projectSessionsPatchEntry(
+  params: SessionPatchProjectionParams & {
+    loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
+  },
+): Promise<SessionPatchProjectionResult> {
+  const preparation = prepareSessionsPatchEntry(params);
+  if (preparation.kind === "complete") {
+    return preparation.result;
+  }
+  if (!params.loadGatewayModelCatalog) {
+    return preparation.finish(undefined);
+  }
+  const catalog = await params.loadGatewayModelCatalog();
+  return preparation.finish(Array.isArray(catalog) ? catalog : []);
+}
+
+function* projectSessionPatchSteps(
+  params: SessionPatchProjectionParams,
+): Generator<void, SessionPatchProjectionResult, ModelCatalogEntry[] | undefined> {
   const { cfg, storeKey, patch, creation } = params;
   if ("execSecurity" in patch || "execAsk" in patch) {
     return invalid(
@@ -203,13 +254,18 @@ export async function projectSessionsPatchEntry(params: {
     );
   };
   let loadedModelCatalog: ModelCatalogEntry[] | undefined;
-  const loadPreparedModelCatalogForPatch = async () => {
-    if (!loadedModelCatalog && params.loadGatewayModelCatalog) {
-      const catalog = await params.loadGatewayModelCatalog();
-      loadedModelCatalog = Array.isArray(catalog) ? catalog : [];
+  let catalogPrepared = false;
+  function* loadPreparedModelCatalogForPatch(): Generator<
+    void,
+    ModelCatalogEntry[] | undefined,
+    ModelCatalogEntry[] | undefined
+  > {
+    if (!catalogPrepared) {
+      loadedModelCatalog = yield;
+      catalogPrepared = true;
     }
     return loadedModelCatalog;
-  };
+  }
 
   const existing =
     params.existingEntry && projectCanonicalSessionEntryShape({ ...params.existingEntry });
@@ -341,7 +397,7 @@ export async function projectSessionsPatchEntry(params: {
         const hintProvider =
           normalizeOptionalString(existing?.providerOverride) || resolvedDefault.provider;
         const hintModel = normalizeOptionalString(existing?.modelOverride) || resolvedDefault.model;
-        const thinkingCatalog = await loadPreparedModelCatalogForPatch();
+        const thinkingCatalog = yield* loadPreparedModelCatalogForPatch();
         const thinkingRuntime = resolveThinkingRuntime(hintProvider, hintModel, existing);
         return invalid(
           `invalid thinkingLevel (use ${formatThinkingLevels(hintProvider, hintModel, "|", thinkingCatalog, thinkingRuntime)})`,
@@ -496,7 +552,7 @@ export async function projectSessionsPatchEntry(params: {
       if (!trimmed) {
         return invalid("invalid model: empty");
       }
-      const catalog = await loadPreparedModelCatalogForPatch();
+      const catalog = yield* loadPreparedModelCatalogForPatch();
       if (!catalog) {
         return {
           ok: false,
@@ -587,7 +643,7 @@ export async function projectSessionsPatchEntry(params: {
     if (!thinkingLevel) {
       delete next.thinkingLevel;
     } else {
-      const thinkingCatalog = await loadPreparedModelCatalogForPatch();
+      const thinkingCatalog = yield* loadPreparedModelCatalogForPatch();
       thinkingRuntime = resolveThinkingRuntime(effectiveProvider, effectiveModel, next);
       if (
         !isThinkingLevelSupported({
@@ -614,7 +670,7 @@ export async function projectSessionsPatchEntry(params: {
     }
   }
 
-  const contextWindowPatch = await applySessionContextWindowPatch({
+  const contextWindowPatch = yield* applySessionContextWindowPatch({
     defaultModel: resolvedDefault.model,
     defaultProvider: resolvedDefault.provider,
     loadModelCatalog: loadPreparedModelCatalogForPatch,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users pinning or renaming one session would wait behind another session's model settings while its model catalog was reloading.

## Why This Change Was Made

Catalog preparation now releases the agent's physical session writer while retaining the target session's logical mutation owner. A fresh writer snapshot revalidates identity, aliases, labels and authority before committing or starting runtime effects. One generator owns projection policy for this path and existing asynchronous callers; catalog failures are consumed only if the fresh projection still needs them.

This adds 140 production lines for the explicit preparation boundary and removes the old inline promise cache. It does not change schemas, configuration, RPC shapes or the shared writer's serialization policy.

## User Impact

Unrelated session edits can finish during a catalog reload, while edits to the same session remain ordered. This covers one target per agent/store group, including cross-agent batches. Multi-target groups within one agent and the embedded TUI retain their existing asynchronous path and remain follow-ups.

## Evidence

The real token-authenticated Gateway/SQLite regression was RED on the base: an unrelated pin response was absent at the existing one-second observation deadline. On the candidate it was GREEN before catalog release. The original rejected catalog request, persisted pin, unchanged context choice and joined client/server cleanup are asserted. This is an in-process Gateway proof with the actual catalog replacement gate, not a production CPU attribution or latency benchmark.

Linux focused and sibling tests: 486 passed. They cover same-session ordering, fresh identity/alias/label/authorization checks, null/reset and error order, a now-unneeded failed catalog, cross-agent singleton groups, ordered same-agent batches, and once-only worktree/permission effects. The authenticated Gateway E2E passed separately.

The full `node scripts/check-changed.mjs --base HEAD` gate passed on the final source, including all core/test typechecks, changed-file lint, dead-code and runtime-boundary guards. The canonical Linux `sourcePerformance` build also passed, including emitted catalog/projector chunks, the CLI bootstrap import guard, and native built-plugin closure checks. Final independent Codex review found no actionable findings through P2. The final E2E has two disclosed mechanical changes from the original RED input: saved errors normalize to Error, and the readonly environment-key tuple is copied for captureEnv's mutable-array parameter; requests, keys, assertions, deadlines and cleanup semantics are preserved.

## Control UI Before / After

The same synthetic browser flow runs against the real in-process Gateway and Control UI on each side. Session A holds the actual catalog replacement gate; the user renames session B. The baseline misses the original one-second response assertion and keeps B's old name until the gate is released. The candidate receives B's successful WebSocket response, verifies its persisted label and displays the new name while A is still waiting. Both sides settle their requests and close the Gateway. This isolated UI fixture uses loopback authentication disabled; the separate backend regression above verifies token authentication. Clip durations are not latency measurements.

Before, while the catalog is held:

![Baseline: old session name remains while the catalog is held](https://github.com/user-attachments/assets/14680221-eeb8-465a-b1fd-04fd23748fd6)

https://github.com/user-attachments/assets/e295e08b-7beb-44a5-8bb0-7b7129b70b52

After, while the same catalog gate is held:

![Candidate: renamed session is persisted and visible before catalog release](https://github.com/user-attachments/assets/c7384ee9-6ce3-459c-9d92-3880c1bc71b1)

https://github.com/user-attachments/assets/78bcf462-e515-470e-9de3-32b1efa3b688
