### PR TITLE
refactor(sqlite): infer delivery queue query rows

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3023,9 +3023,8 @@ src/infra/channels-status-issues.ts	2
 src/infra/clawhub-client.ts	2
 src/infra/clawhub-install-trust.ts	2
 src/infra/control-ui-assets.ts	1
-src/infra/delivery-queue-sqlite-bound.ts	3
-src/infra/delivery-queue-sqlite-namespace.ts	3
-src/infra/delivery-queue-sqlite.ts	4
+src/infra/delivery-queue-sqlite-bound.ts	2
+src/infra/delivery-queue-sqlite.ts	2
 src/infra/delivery-queue-sqlite.types.ts	1
 src/infra/delivery-recovery.shared.ts	4
 src/infra/device-pairing-store.ts	6

--- a/src/infra/delivery-queue-sqlite-bound.ts
+++ b/src/infra/delivery-queue-sqlite-bound.ts
@@ -1,6 +1,6 @@
 // Database-bound delivery queue serialization and mutations used by shared transactions.
 import type { DatabaseSync } from "node:sqlite";
-import type { Insertable } from "kysely";
+import type { Insertable, Selectable } from "kysely";
 import type { OpenClawStateDatabase } from "../state/openclaw-state-db-contract.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import type { DeliveryQueueEntryState } from "./delivery-queue-sqlite.types.js";
@@ -42,16 +42,10 @@ const deliveryQueueRowColumns = [
   "recovery_state",
 ] as const;
 
-export type DeliveryQueueSqliteRow = {
-  id: string;
-  entry_json: string;
-  enqueued_at: number | bigint;
-  retry_count: number | bigint;
-  last_attempt_at: number | bigint | null;
-  last_error: string | null;
-  platform_send_started_at: number | bigint | null;
-  recovery_state: string | null;
-};
+type DeliveryQueueSqliteRow = Pick<
+  Selectable<DeliveryQueueTable>,
+  (typeof deliveryQueueRowColumns)[number]
+>;
 
 type DeliveryQueueRowMetadata = {
   entryKind?: string;
@@ -315,8 +309,6 @@ export function loadDeliveryQueueEntryInDatabase(
   mode: DeliveryQueueReadMode = "all",
 ): DeliveryQueueEntryState | null {
   const query = deliveryQueueEntriesQuery(database, [queueName], mode).where("id", "=", id);
-  const row = executeSqliteQueryTakeFirstSync(database.db, query) as
-    | DeliveryQueueSqliteRow
-    | undefined;
+  const row = executeSqliteQueryTakeFirstSync(database.db, query);
   return row ? inflateDeliveryQueueRow(row) : null;
 }

--- a/src/infra/delivery-queue-sqlite-namespace.ts
+++ b/src/infra/delivery-queue-sqlite-namespace.ts
@@ -1,6 +1,6 @@
 // Owns atomic delivery-queue ownership changes across namespace versions.
-import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
+import type { DeliveryQueueDatabase } from "./delivery-queue-sqlite-bound.js";
 import {
   completeDeliveryQueueEntryInDatabase,
   deleteDeliveryQueueEntryInDatabase,
@@ -13,9 +13,6 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
-
-type DeliveryQueueDatabase = Pick<OpenClawStateKyselyDatabase, "delivery_queue_entries">;
-type QueueStatus = "pending" | "failed" | "completed";
 
 /** Atomically publishes one staged owner only when retired namespaces do not own its id. */
 export function commitStagedDeliveryQueueEntryOnceAcrossNamespaces(params: {
@@ -153,7 +150,7 @@ export function replacePendingDeliveryQueueEntry(params: {
           .select(["entry_json", "status"])
           .where("queue_name", "=", params.queueName)
           .where("id", "=", params.expectedEntry.id),
-      ) as { entry_json: string; status: QueueStatus } | undefined;
+      );
       if (
         !source ||
         source.status !== "pending" ||
@@ -195,7 +192,7 @@ export function completePendingDeliveryQueueEntry(params: {
           .select(["entry_json", "status"])
           .where("queue_name", "=", params.queueName)
           .where("id", "=", params.expectedEntry.id),
-      ) as { entry_json: string; status: QueueStatus } | undefined;
+      );
       if (
         !source ||
         source.status !== "pending" ||
@@ -232,7 +229,7 @@ export function movePendingDeliveryQueueEntryNamespace(
           .select(["entry_json", "status"])
           .where("queue_name", "=", params.sourceQueueName)
           .where("id", "=", params.expectedSourceEntry.id),
-      ) as { entry_json: string; status: QueueStatus } | undefined;
+      );
       if (
         !source ||
         source.status !== "pending" ||

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -15,7 +15,6 @@ import {
   terminalizeBoundDeliveryQueueEntry,
   type DeliveryQueueDatabase,
   type DeliveryQueueReadMode,
-  type DeliveryQueueSqliteRow,
   type UpsertDeliveryQueueEntryParams,
   upsertBoundDeliveryQueueEntryInDatabase,
 } from "./delivery-queue-sqlite-bound.js";
@@ -36,13 +35,7 @@ export type {
 
 // Generic durable delivery queue storage shared by session and outbound queues.
 // Queue-specific wrappers own payload shape; this layer owns SQLite state.
-type QueueStatus = "pending" | "failed" | "completed";
-type DeliveryQueueStatusRow = {
-  queue_name: string;
-  status?: QueueStatus;
-  entry_json: string | null;
-  recovery_state: string | null;
-};
+type QueueStatus = NonNullable<UpsertDeliveryQueueEntryParams["status"]>;
 
 type TerminalizePendingDeliveryQueueEntryResult =
   | { status: "terminalized"; retained: boolean }
@@ -106,7 +99,7 @@ export function expireStagingAndLoadDeliveryQueueEntries(params: {
           deliveryQueueEntriesQuery(database, queueNames, "unfinished")
             .orderBy("enqueued_at", "asc")
             .orderBy("id", "asc"),
-        ).rows as DeliveryQueueSqliteRow[];
+        ).rows;
       return {
         entryRows: read(params.queueNames),
         stagingRows: read([params.stagingQueueName]),
@@ -188,7 +181,7 @@ export function getDeliveryQueueEntryOwnersInDatabase(
             )
             .where("queue_name", "in", queueNames)
             .where("id", "=", id),
-        ).rows as DeliveryQueueStatusRow[];
+        ).rows;
       let rows = readExact();
       let pruned = false;
       for (const row of rows) {
@@ -215,7 +208,8 @@ export function getDeliveryQueueEntryOwnersInDatabase(
                 [
                   row.queue_name,
                   {
-                    status: row.status,
+                    // Preserve the status API and ownership of unknown stored statuses.
+                    status: row.status as QueueStatus,
                     ...(row.status === "failed" && row.recovery_state === "settlement_pending"
                       ? { settlementPending: true as const }
                       : {}),
@@ -245,7 +239,7 @@ export function loadDeliveryQueueEntries(
     deliveryQueueEntriesQuery(database, [queueName], mode)
       .orderBy("enqueued_at", "asc")
       .orderBy("id", "asc"),
-  ).rows as DeliveryQueueSqliteRow[];
+  ).rows;
   return rows
     .map(inflateDeliveryQueueRow)
     .filter((entry): entry is DeliveryQueueEntryState => entry != null);


### PR DESCRIPTION
## What Problem This Solves

Delivery queue readers assert handwritten row shapes over Kysely results, duplicating the generated table contract and concealing changes to selected columns.

## Why This Change Was Made

Derive the reusable row projection from the canonical generated table and existing column tuple, let other query results retain inferred types, and reuse the database and status types already owned by delivery storage. Remove seven query-result assertions and the unused row/status declarations.

## User Impact

This is an internal type cleanup. SQL, parsed payloads, ownership decisions, filtering, ordering and stored rows remain unchanged. Unknown nonempty stored statuses still reserve ownership, empty statuses are still omitted, and malformed JSON does not erase a scalar ownership fence. The existing API status assertion remains explicit at its return boundary; generated SQLite status stays string because the table has no status CHECK constraint.

## Evidence

All 68 existing delivery/terminal/claim/namespace tests and the full changed-file gate passed. TypeScript emits byte-identical JavaScript from all three production modules with comments removed. Native SQLite comparisons preserve pending, failed, completed, unknown and empty statuses, malformed JSON, numeric/null values and the unchanged refusal of NULL status. Fresh independent Codex P0–P2 review found no actionable findings. After the parent query PR landed, a mechanical rebase preserved the exact patch ID and all three production files byte-for-byte.

No new tests were added for aliases or source structure. Production delta is −17 lines; the required assertion-safety allowance shrinks by one metadata line. No schema, migration, configuration or dependency change.
