### PR TITLE
fix(ui): prevent Talk E2E audio capture stalls

### DIFF
--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -7,9 +7,9 @@ import {
   captureVideoTalkProof,
   dispatchOpenAiTalkEvent,
   installBlockedMicrophoneFixture,
-  installBlockedVideoTalkFixture,
-  installTalkBrowserFixtures,
   installOpenAiTalkFixture,
+  installTalkBrowserFixtures,
+  installVideoTalkMediaFixture,
   videoTalkCatalog,
 } from "./browser-talk-start-stop.fixtures.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -529,25 +529,7 @@ suite.define(() => {
           }
         });
       });
-      await page.addInitScript(() => {
-        const getUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
-        Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
-          configurable: true,
-          value: async (constraints: MediaStreamConstraints) => {
-            const stream = await getUserMedia(constraints);
-            (
-              window as Window & {
-                openclawGeminiVideoTalkTracks?: MediaStreamTrack[];
-              }
-            ).openclawGeminiVideoTalkTracks = [
-              ...((window as Window & { openclawGeminiVideoTalkTracks?: MediaStreamTrack[] })
-                .openclawGeminiVideoTalkTracks ?? []),
-              ...stream.getTracks(),
-            ];
-            return stream;
-          },
-        });
-      });
+      await installVideoTalkMediaFixture(page, { camera: "native" });
 
       await page.setViewportSize({ width: 1366, height: 900 });
       await page.goto(`${suite.server.baseUrl}chat`);
@@ -614,9 +596,9 @@ suite.define(() => {
       const trackStates = await page.evaluate(() =>
         (
           window as Window & {
-            openclawGeminiVideoTalkTracks?: MediaStreamTrack[];
+            openclawVideoTalkTracks?: MediaStreamTrack[];
           }
-        ).openclawGeminiVideoTalkTracks?.map((track) => track.readyState),
+        ).openclawVideoTalkTracks?.map((track) => track.readyState),
       );
       expect(trackStates).toHaveLength(2);
       expect(trackStates?.every((state) => state === "ended")).toBe(true);
@@ -657,7 +639,7 @@ suite.define(() => {
           }
         });
       });
-      await installBlockedVideoTalkFixture(page);
+      await installVideoTalkMediaFixture(page, { camera: "blocked" });
 
       await page.setViewportSize({ width: 1366, height: 900 });
       await page.goto(`${suite.server.baseUrl}chat`);
@@ -674,7 +656,16 @@ suite.define(() => {
         .poll(() => page.getByRole("button", { name: "Turn camera on" }).isVisible())
         .toBe(true);
       await captureVideoTalkProof(suite, page, "03-camera-permission-blocked.png");
-      console.info("[video-talk-e2e] camera_denial=actionable,no-audio-fallback");
+      await page.getByRole("button", { name: "Stop voice input" }).click();
+      const trackStates = await page.evaluate(() =>
+        (
+          window as Window & {
+            openclawVideoTalkTracks?: MediaStreamTrack[];
+          }
+        ).openclawVideoTalkTracks?.map((track) => track.readyState),
+      );
+      expect(trackStates).toEqual(["ended"]);
+      console.info("[video-talk-e2e] camera_denial=actionable,audio_track:ended");
     });
   });
 

--- a/ui/src/e2e/browser-talk-start-stop.fixtures.ts
+++ b/ui/src/e2e/browser-talk-start-stop.fixtures.ts
@@ -13,49 +13,147 @@ export async function dispatchOpenAiTalkEvent(page: Page, event: unknown) {
   }, event);
 }
 
-export async function installOpenAiTalkFixture(page: Page) {
-  await page.addInitScript(() => {
-    const getUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
-    Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
-      configurable: true,
-      value: async (constraints: MediaStreamConstraints) => {
-        let stream: MediaStream;
-        // Chromium's fake capture can stall audio-only Talk startup; keep native video
-        // capture so camera dimensions and lifecycle assertions remain meaningful.
-        if (Boolean(constraints.audio) && !constraints.video) {
-          const context = new AudioContext();
-          stream = context.createMediaStreamDestination().stream;
-          const tracks = stream.getAudioTracks();
-          const [track] = tracks;
-          if (tracks.length !== 1 || !track) {
-            void context.close().catch(() => undefined);
-            throw new Error(`Expected one synthetic audio track, received ${tracks.length}`);
-          }
-          const stop = track.stop.bind(track);
-          let stopped = false;
-          track.stop = () => {
-            if (stopped) {
-              return;
-            }
-            stopped = true;
-            stop();
-            void context.close().catch(() => undefined);
-          };
-        } else {
-          stream = await getUserMedia(constraints);
+type TalkMediaFixtureProfile = "talk" | "video-native" | "video-blocked";
+
+function installTalkMediaBrowserFixture(profile: TalkMediaFixtureProfile) {
+  type InputProcessor = {
+    onaudioprocess:
+      | ((event: { inputBuffer: { getChannelData: () => Float32Array } }) => void)
+      | null;
+  };
+  const state = {
+    audioContextsClosed: 0,
+    tracksStopped: 0,
+    constraints: [] as unknown[],
+    inputProcessor: null as InputProcessor | null,
+    meterLevel: 0,
+  };
+  const nativeGetUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+  const trackWindow = window as Window & { openclawVideoTalkTracks?: MediaStreamTrack[] };
+  const recordTracks = (stream: MediaStream) => {
+    trackWindow.openclawVideoTalkTracks = [
+      ...(trackWindow.openclawVideoTalkTracks ?? []),
+      ...stream.getTracks(),
+    ];
+  };
+
+  class FakeAudioTrack extends EventTarget {
+    readonly kind = "audio";
+    enabled = true;
+    readonly muted = false;
+    readyState: MediaStreamTrackState = "live";
+
+    stop() {
+      if (this.readyState === "ended") {
+        return;
+      }
+      this.readyState = "ended";
+      state.tracksStopped += 1;
+    }
+  }
+
+  const createAudioStream = () => {
+    const track = new FakeAudioTrack() as MediaStreamTrack;
+    return {
+      getTracks: () => [track],
+      getAudioTracks: () => [track],
+      getVideoTracks: () => [],
+    } as unknown as MediaStream;
+  };
+
+  Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
+    configurable: true,
+    value: async (constraints: MediaStreamConstraints) => {
+      state.constraints.push(constraints);
+      if (constraints.video) {
+        if (profile === "video-blocked") {
+          throw new DOMException("Permission denied", "NotAllowedError");
         }
-        (
-          window as Window & {
-            openclawVideoTalkTracks?: MediaStreamTrack[];
-          }
-        ).openclawVideoTalkTracks = [
-          ...((window as Window & { openclawVideoTalkTracks?: MediaStreamTrack[] })
-            .openclawVideoTalkTracks ?? []),
-          ...stream.getTracks(),
-        ];
+        const stream = await nativeGetUserMedia(constraints);
+        recordTracks(stream);
         return stream;
-      },
+      }
+      if (constraints.audio) {
+        const stream = createAudioStream();
+        recordTracks(stream);
+        return stream;
+      }
+      return nativeGetUserMedia(constraints);
+    },
+  });
+  if (profile === "talk") {
+    Object.defineProperty(navigator.mediaDevices, "enumerateDevices", {
+      configurable: true,
+      value: async () => [
+        { kind: "audioinput", deviceId: "built-in", label: "Built-in Microphone" },
+        { kind: "audioinput", deviceId: "usb", label: "USB Audio Interface" },
+        { kind: "videoinput", deviceId: "camera", label: "Camera" },
+      ],
     });
+  }
+
+  class MockAudioContext {
+    readonly currentTime = 0;
+    readonly destination = {};
+    readonly sampleRate: number;
+
+    constructor(options?: { sampleRate?: number }) {
+      this.sampleRate = options?.sampleRate ?? 24_000;
+    }
+
+    createMediaStreamSource() {
+      return { connect() {}, disconnect() {} };
+    }
+
+    createAnalyser() {
+      return {
+        fftSize: 0,
+        smoothingTimeConstant: 0,
+        disconnect() {},
+        getFloatTimeDomainData(samples: Float32Array) {
+          samples.fill(state.meterLevel);
+        },
+      };
+    }
+
+    createScriptProcessor() {
+      const processor = { connect() {}, disconnect() {}, onaudioprocess: null };
+      state.inputProcessor = processor;
+      return processor;
+    }
+
+    createGain() {
+      return { gain: { value: 1 }, connect() {}, disconnect() {} };
+    }
+
+    async close() {
+      state.audioContextsClosed += 1;
+    }
+  }
+
+  Object.defineProperty(window, "AudioContext", {
+    configurable: true,
+    value: MockAudioContext,
+  });
+  Object.defineProperty(window, "openclawTalkE2eState", {
+    configurable: true,
+    value: state,
+  });
+}
+
+export async function installVideoTalkMediaFixture(
+  page: Page,
+  options: { camera: "native" | "blocked" },
+) {
+  await page.addInitScript<TalkMediaFixtureProfile>(
+    installTalkMediaBrowserFixture,
+    `video-${options.camera}` satisfies TalkMediaFixtureProfile,
+  );
+}
+
+export async function installOpenAiTalkFixture(page: Page) {
+  await installVideoTalkMediaFixture(page, { camera: "native" });
+  await page.addInitScript(() => {
     class FakeDataChannel extends EventTarget {
       readyState = "open";
       sent: unknown[] = [];
@@ -256,86 +354,7 @@ export function videoTalkCatalog(activeProvider: "google" | "openai") {
 }
 
 export async function installTalkBrowserFixtures(page: Page) {
-  await page.addInitScript(() => {
-    type InputProcessor = {
-      onaudioprocess:
-        | ((event: { inputBuffer: { getChannelData: () => Float32Array } }) => void)
-        | null;
-    };
-    const state = {
-      audioContextsClosed: 0,
-      tracksStopped: 0,
-      constraints: [] as unknown[],
-      inputProcessor: null as InputProcessor | null,
-      meterLevel: 0,
-    };
-    const track = Object.assign(new EventTarget(), { stop: () => (state.tracksStopped += 1) });
-    Object.defineProperty(navigator, "mediaDevices", {
-      configurable: true,
-      value: {
-        enumerateDevices: async () => [
-          { kind: "audioinput", deviceId: "built-in", label: "Built-in Microphone" },
-          { kind: "audioinput", deviceId: "usb", label: "USB Audio Interface" },
-          { kind: "videoinput", deviceId: "camera", label: "Camera" },
-        ],
-        getUserMedia: async (constraints: unknown) => {
-          state.constraints.push(constraints);
-          return {
-            getAudioTracks: () => [track],
-            getTracks: () => [track],
-          };
-        },
-      },
-    });
-
-    class MockAudioContext {
-      readonly currentTime = 0;
-      readonly destination = {};
-      readonly sampleRate: number;
-
-      constructor(options?: { sampleRate?: number }) {
-        this.sampleRate = options?.sampleRate ?? 24_000;
-      }
-
-      createMediaStreamSource() {
-        return { connect() {}, disconnect() {} };
-      }
-
-      createGain() {
-        return { connect() {}, disconnect() {}, gain: { value: 1 } };
-      }
-
-      createScriptProcessor() {
-        const processor = { connect() {}, disconnect() {}, onaudioprocess: null };
-        state.inputProcessor = processor;
-        return processor;
-      }
-
-      createAnalyser() {
-        return {
-          fftSize: 0,
-          smoothingTimeConstant: 0,
-          disconnect() {},
-          getFloatTimeDomainData(samples: Float32Array) {
-            samples.fill(state.meterLevel);
-          },
-        };
-      }
-
-      async close() {
-        state.audioContextsClosed += 1;
-      }
-    }
-
-    Object.defineProperty(window, "AudioContext", {
-      configurable: true,
-      value: MockAudioContext,
-    });
-    Object.defineProperty(window, "openclawTalkE2eState", {
-      configurable: true,
-      value: state,
-    });
-  });
+  await page.addInitScript<TalkMediaFixtureProfile>(installTalkMediaBrowserFixture, "talk");
 }
 
 async function installWebRtcSdpResponseFixture(page: Page, fixture: WebRtcSdpResponseFixture) {
@@ -495,33 +514,6 @@ export async function installBlockedMicrophoneFixture(page: Page) {
           throw new DOMException("Permission denied", "NotAllowedError");
         },
       },
-    });
-  });
-}
-
-export async function installBlockedVideoTalkFixture(page: Page) {
-  await page.addInitScript(() => {
-    const getUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
-    Object.defineProperty(navigator, "mediaDevices", {
-      configurable: true,
-      value: {
-        getUserMedia: async (constraints: MediaStreamConstraints) => {
-          if (constraints.video) {
-            throw new DOMException("Permission denied", "NotAllowedError");
-          }
-          return getUserMedia(constraints);
-        },
-      },
-    });
-    class FakePeerConnection extends EventTarget {
-      connectionState = "new";
-      close() {
-        this.connectionState = "closed";
-      }
-    }
-    Object.defineProperty(window, "RTCPeerConnection", {
-      configurable: true,
-      value: FakePeerConnection,
     });
   });
 }

--- a/ui/src/e2e/browser-talk-start-stop.fixtures.ts
+++ b/ui/src/e2e/browser-talk-start-stop.fixtures.ts
@@ -19,7 +19,31 @@ export async function installOpenAiTalkFixture(page: Page) {
     Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
       configurable: true,
       value: async (constraints: MediaStreamConstraints) => {
-        const stream = await getUserMedia(constraints);
+        let stream: MediaStream;
+        // Chromium's fake capture can stall audio-only Talk startup; keep native video
+        // capture so camera dimensions and lifecycle assertions remain meaningful.
+        if (Boolean(constraints.audio) && !constraints.video) {
+          const context = new AudioContext();
+          stream = context.createMediaStreamDestination().stream;
+          const tracks = stream.getAudioTracks();
+          const [track] = tracks;
+          if (tracks.length !== 1 || !track) {
+            void context.close().catch(() => undefined);
+            throw new Error(`Expected one synthetic audio track, received ${tracks.length}`);
+          }
+          const stop = track.stop.bind(track);
+          let stopped = false;
+          track.stop = () => {
+            if (stopped) {
+              return;
+            }
+            stopped = true;
+            stop();
+            void context.close().catch(() => undefined);
+          };
+        } else {
+          stream = await getUserMedia(constraints);
+        }
         (
           window as Window & {
             openclawVideoTalkTracks?: MediaStreamTrack[];


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI Talk E2E cases could stall in a warm Chromium process after an earlier fixture used the browser's native audio stack. This left later Gemini and blocked-camera cases stuck connecting even though `talk.client.create` succeeded.

## Why This Change Was Made

One serializable, profile-driven browser initializer now owns media behavior for ordinary Talk, native-camera Video Talk, and blocked-camera Video Talk fixtures. Audio-only requests receive a fresh deterministic fake stream and idempotent track, fixture pages use only the minimal mocked `AudioContext` surface, native video capture remains real, and blocked video requests fail before recording a track.

## User Impact

No production behavior changes. Talk browser coverage now remains deterministic when the full file shares one warm browser process, while still proving native camera dimensions, permission guidance, and resource cleanup.

## Evidence

- Pre-fix proof: the complete warm-process file passed 8/10; Gemini and blocked-camera cases remained `connecting` after `talk.client.create`, while each passed alone.
- Required warm sequence: OpenAI, Gemini, and blocked-camera passed back-to-back; track states were `ended+ended`, `ended+ended`, and `ended`.
- Full browser Talk start/stop E2E: 10/10 passed.
- Browser Talk ordering E2E: 1/1 passed.
- Talk audio, input, OpenAI WebRTC, and Gemini Live units: 108/108 passed.
- Native camera proof: OpenAI preview measured 640x480; Gemini streamed a native video frame; previews were removed after stop. Blocked-camera guidance remained actionable with no video track recorded.
- Formatting, direct oxlint, and `git diff --check`: passed.
- `tsgo:ui`: fixture errors are gone; only four unrelated stale-install `assertBeforeRename` errors remain in `src/infra/install-package-dir.ts`.
- Changed gate: every check through Control UI i18n passed; core test typecheck then reached the same four unrelated errors.
- Scoped P0-P2 autoreview: clean, no findings.
- LOC versus `122017f5`: production +0/-0; test support +155/-172 (net -17).
- Signed head: `90fcebcb876714020ee9aa15c2d476b47f1c8147`.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
source: local Codex session
redaction: local paths, credentials, environment details, and unrelated work omitted

[user]
Implement the approved isolated Control UI Talk audio fixture repair from current main. Keep production LOC at zero, prove the current failure, run focused browser and product tests, inspect retained artifacts, review the diff, sign the commit, and open a draft PR.

[assistant]
Created a fresh shared worktree from current main and captured the pre-fix failure: the affected Talk cases stalled before talk.client.create.

[assistant]
Updated the OpenAI Talk fixture so audio-only requests use one AudioContext destination track. Native getUserMedia remains responsible for video and all other requests. Track stop is idempotent and closes the context.

[assistant]
The two affected E2Es passed together. Native camera proof remained 640x480, the preview disappeared after stop, and both tracks ended. The current product surface passed 34/34 tests.

[assistant]
Formatting, direct lint, and diff checks passed. The changed gate reached only the known unrelated stale-install assertBeforeRename type errors. Scoped autoreview reported no P0-P2 findings.

[assistant]
Created signed commit 122017f5c55128b42ce79b56d13cc5de3d0d1658 with production +0/-0 and test-support +25/-1.
```

</details>
<!-- agent-transcript:end -->
