### PR TITLE
docs(diagnostics): clarify whole-process CPU metrics

### DIFF
--- a/docs/gateway/diagnostics.md
+++ b/docs/gateway/diagnostics.md
@@ -110,7 +110,13 @@ delay; otherwise they log at `debug`. Idle liveness samples are still recorded
 as diagnostic events but never escalate to a warning by themselves.
 
 Startup phases emit `diagnostic.phase.completed` events with wall-clock and
-CPU timing. Stalled embedded-run diagnostics mark `terminalProgressStale=true`
+whole-process CPU timing, including worker and native threads. Phase CPU can
+include concurrent work outside that phase; it is not exclusive attribution.
+The `cpuCoreRatio` in phase and liveness events is measured in core equivalents
+and can exceed `1`. See
+[CPU pressure and event-loop delay](/gateway/health#cpu-pressure-and-event-loop-delay).
+
+Stalled embedded-run diagnostics mark `terminalProgressStale=true`
 when the last bridge progress looked terminal (for example a raw response
 item or response-completion event) but the Gateway still considers the
 embedded run active.

--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -72,6 +72,21 @@ The Gateway exposes three unauthenticated `GET`/`HEAD` probe pairs:
 
 Remote unauthenticated startup responses contain only `ok` and `status`. Local-direct and authenticated callers also receive `version`, `uptimeMs`, and `pendingReason` while startup is pending. Readiness details follow the same local-or-authenticated gate because they can name failing subsystems.
 
+### CPU pressure and event-loop delay
+
+Detailed readiness can include an `eventLoop` diagnostic snapshot. Its
+`cpuCoreRatio` measures user and system CPU time across the whole Gateway process,
+including worker and native threads, divided by elapsed wall time. The unit is
+core equivalents: `1` means one CPU core fully occupied over the interval, and
+parallel work can produce values above `1`. It is not a percentage of the host's
+total CPU capacity.
+
+Event-loop delay and utilization describe the main thread separately. A `cpu`
+degradation reason reports process CPU pressure with delay co-evidence; it does
+not identify the thread consuming CPU or prove a main-thread hang. Inspect the
+delay measurements alongside CPU pressure. The `eventLoop` diagnostic does not
+change the readiness result by itself.
+
 ## Uptime monitoring
 
 External uptime monitoring services should use the dedicated `/health` endpoint, not `/v1/chat/completions`.

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -559,6 +559,11 @@ Liveness warnings also emit:
 - `openclaw.liveness.event_loop_utilization` (histogram, attrs: `openclaw.liveness.reason`)
 - `openclaw.liveness.cpu_core_ratio` (histogram, attrs: `openclaw.liveness.reason`)
 
+The CPU ratio measures whole-process CPU usage in core equivalents, including
+worker and native threads, and can exceed `1`. Event-loop delay and utilization
+measure the main thread separately. See
+[CPU pressure and event-loop delay](/gateway/health#cpu-pressure-and-event-loop-delay).
+
 ### Gateway event-loop observation windows
 
 - `openclaw.gateway.event_loop.delay_max_ms` (histogram, no attrs; maximum delay per completed health-monitor window)

--- a/docs/gateway/prometheus.md
+++ b/docs/gateway/prometheus.md
@@ -184,6 +184,11 @@ also drop observations, reported by `openclaw_diagnostic_async_queue_dropped_tot
 
 ### Event-loop observation windows
 
+`openclaw_liveness_cpu_core_ratio` measures whole-process CPU usage in core
+equivalents, including worker and native threads, and can exceed `1`. Interpret
+it alongside main-thread delay and utilization; see
+[CPU pressure and event-loop delay](/gateway/health#cpu-pressure-and-event-loop-delay).
+
 The event-loop histogram records the maximum delay from each completed Gateway
 health-monitor window. The counter sums the seconds represented by those
 windows. Both are cumulative: a readiness or status read can complete a window

--- a/extensions/diagnostics-otel/src/service-metrics.ts
+++ b/extensions/diagnostics-otel/src/service-metrics.ts
@@ -308,7 +308,8 @@ export function createDiagnosticsMetrics(
     ),
     livenessCpuCoreRatioHistogram: createHistogram("openclaw.liveness.cpu_core_ratio", {
       unit: "1",
-      description: "CPU core ratio reported by diagnostic liveness warnings",
+      description:
+        "Whole-process CPU usage in core equivalents, including worker and native threads; can exceed 1.",
     }),
     telemetryExporterCounter: createCounter("openclaw.telemetry.exporter.events", {
       unit: "1",

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -964,7 +964,7 @@ function recordDiagnosticEvent(
       );
       store.histogram(
         "openclaw_liveness_cpu_core_ratio",
-        "CPU core ratio reported by diagnostic liveness warnings.",
+        "Whole-process CPU usage in core equivalents, including worker and native threads; can exceed 1.",
         livenessLabels(evt),
         numericValue(evt.cpuCoreRatio),
         RATIO_BUCKETS,


### PR DESCRIPTION
## What Problem This Solves

Operators can mistake the diagnostic CPU core ratio for main-thread utilization or a percentage capped at 100%. The existing metric measures CPU time across the whole process, including worker and native threads.

## Why This Change Was Made

Clarify the Prometheus HELP text and OpenTelemetry description, with a shared health-guide explanation of core equivalents and values above one. Phase diagnostics also explain that concurrent work contributes to their process CPU totals.

Node's [CPU usage contract](https://nodejs.org/api/process.html#processcpuusagepreviousvalue) and the existing diagnostic producers establish these semantics. Metric names, fields, measurements, thresholds, readiness behavior, and configuration stay unchanged. The production diff is description text only (+3/-2 lines, including formatting); documentation is +32/-1.

## User Impact

Operators can distinguish whole-process CPU pressure from measured main-thread delay when reading metrics and health snapshots. A CPU degradation reason alone does not attribute CPU to a thread or prove a main-thread hang.

## Evidence

- Existing Prometheus and OpenTelemetry liveness-warning tests passed (2 selected tests), including export of a CPU ratio of 1.4.
- MDX validation passed all 752 files; formatting and `git diff --check` passed.
- Independent Codex review found no actionable P0–P2 issues.
- The full anchor audit reported 12 existing broken links in ClawHub's `plugin-validation-fixes.md`, targeting unchanged manifest/SDK pages; no changed-page link failed.
- The first remote changed-check attempt refused an unexpected source file before running checks and closed its Testbox lease. The supported local changed-file gate then passed all selected checks, including plugin production/test types, lint, owner tests, and static guards.

No runtime behavior changed, so the existing exporter tests and source contract review cover this wording repair; no additional production CPU workload was run.
