### PR TITLE
perf(auth): reuse ordered provider alias entries

### DIFF
--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -866,6 +866,47 @@ describe("provider env vars dynamic manifest metadata", () => {
     expect(pluginRegistryMocks.loadPluginMetadataSnapshot).not.toHaveBeenCalled();
   });
 
+  it("preserves alias-chain expansion order and ownership of lookup results", () => {
+    const evidence = {
+      type: "local-file-with-env" as const,
+      fileEnvVar: "BASE_CREDENTIALS",
+      credentialMarker: "base-local-credentials",
+    };
+    useInstalledPlugins(
+      setupPlugin("base-owner", "global", {
+        id: "base",
+        envVars: ["BASE_API_KEY"],
+        authEvidence: [evidence],
+      }),
+      { id: "first-alias", origin: "global", providerAuthAliases: { z: "base" } },
+      { id: "second-alias", origin: "global", providerAuthAliases: { a: "z" } },
+      { id: "third-alias", origin: "global", providerAuthAliases: { b: "a" } },
+    );
+
+    const first = resolveProviderAuthLookupMaps({ config: {} });
+    expect(Object.keys(first.aliasMap)).toEqual(["z", "a", "b"]);
+    expect(first.aliasMap).toEqual({ z: "base", a: "z", b: "a" });
+    expect(Object.getPrototypeOf(first.aliasMap)).toBeNull();
+    expect(first.envCandidateMap.base).toEqual(["BASE_API_KEY"]);
+    expect(first.envCandidateMap.z).toEqual(["BASE_API_KEY"]);
+    expect(first.envCandidateMap.a).toBeUndefined();
+    expect(first.envCandidateMap.b).toBeUndefined();
+    expect(first.authEvidenceMap).toEqual({ base: [evidence], z: [evidence] });
+    expect(first.authEvidenceMap.z?.[0]).toBe(evidence);
+    expect(first.setupProviderFallbackRefs).toEqual(["a", "b", "base", "z"]);
+
+    const second = resolveProviderAuthLookupMaps({ config: {} });
+    expect(second).toEqual(first);
+    expect(second.aliasMap).not.toBe(first.aliasMap);
+    expect(second.envCandidateMap).not.toBe(first.envCandidateMap);
+    expect(second.envCandidateMap.z).not.toBe(first.envCandidateMap.z);
+    expect(second.authEvidenceMap).not.toBe(first.authEvidenceMap);
+    expect(second.authEvidenceMap.z).not.toBe(first.authEvidenceMap.z);
+    expect(second.authEvidenceMap.z?.[0]).toBe(evidence);
+    expect(second.setupProviderFallbackRefs).not.toBe(first.setupProviderFallbackRefs);
+    expect(second.envCandidateMap.openai).toBe(first.envCandidateMap.openai);
+  });
+
   it("does not reuse a load-path current snapshot for default provider env lookups without parameters", () => {
     const staleSnapshot = metadataSnapshot(LOAD_PATH_PROVIDER_PLUGIN);
     pluginRegistryMocks.getCurrentPluginMetadataSnapshot.mockImplementation(

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -173,17 +173,6 @@ function resolveProviderMetadataSnapshot(
   });
 }
 
-function resolveManifestProviderAuthEnvVarCandidates(
-  params?: ProviderEnvVarLookupParams,
-): Record<string, string[]> {
-  const snapshot = resolveProviderMetadataSnapshot(params);
-  const aliases = resolveProviderAuthAliasMap({
-    ...params,
-    metadataSnapshot: snapshot,
-  });
-  return resolveManifestProviderAuthEnvVarCandidatesFromSnapshot(params, snapshot, aliases);
-}
-
 function resolveManifestProviderUsageAuthEnvVarNames(
   params?: ProviderEnvVarLookupParams,
 ): string[] {
@@ -195,10 +184,10 @@ function resolveManifestProviderUsageAuthEnvVarNames(
   );
 }
 
-function resolveManifestProviderAuthEnvVarCandidatesFromSnapshot(
+function resolveManifestProviderAuthEnvVarCandidates(
   params: ProviderEnvVarLookupParams | undefined,
   snapshot: PluginMetadataSnapshot,
-  aliases: Readonly<Record<string, string>>,
+  sortedAliases: readonly (readonly [string, string])[],
 ): Record<string, string[]> {
   const candidates: Record<string, string[]> = {};
   for (const plugin of snapshot.plugins) {
@@ -209,9 +198,7 @@ function resolveManifestProviderAuthEnvVarCandidatesFromSnapshot(
       appendUniqueEnvVarCandidates(candidates, provider.id, provider.envVars ?? []);
     }
   }
-  for (const [alias, target] of Object.entries(aliases).toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  )) {
+  for (const [alias, target] of sortedAliases) {
     const keys = candidates[target];
     if (keys) {
       appendUniqueEnvVarCandidates(candidates, alias, keys);
@@ -223,7 +210,8 @@ function resolveManifestProviderAuthEnvVarCandidatesFromSnapshot(
 function resolveManifestRuntimeAuthFacts(
   params: ProviderEnvVarLookupParams | undefined,
   snapshot: PluginMetadataSnapshot,
-  aliases: Readonly<Record<string, string>>,
+  aliasEntries: readonly (readonly [string, string])[],
+  sortedAliases: readonly (readonly [string, string])[],
 ) {
   const evidenceByProvider: Record<string, ProviderAuthEvidence[]> = {};
   const refs = new Set<string>();
@@ -253,15 +241,14 @@ function resolveManifestRuntimeAuthFacts(
       appendUniqueProviderRef(refs, providerId);
     }
   }
-  for (const [alias, target] of Object.entries(aliases).toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  )) {
+  for (const [alias, target] of sortedAliases) {
     const evidence = evidenceByProvider[target];
     if (evidence) {
       appendUniqueAuthEvidence(evidenceByProvider, alias, evidence);
     }
   }
-  for (const [alias, target] of Object.entries(aliases)) {
+  // Fallback refs keep insertion order; sorting would change one-pass alias-chain expansion.
+  for (const [alias, target] of aliasEntries) {
     if (refs.has(target)) {
       appendUniqueProviderRef(refs, alias);
     }
@@ -276,8 +263,13 @@ function resolveManifestRuntimeAuthFacts(
 export function resolveProviderAuthEnvVarCandidates(
   params?: ProviderEnvVarLookupParams,
 ): Record<string, readonly string[]> {
+  const snapshot = resolveProviderMetadataSnapshot(params);
+  const aliases = resolveProviderAuthAliasMap({ ...params, metadataSnapshot: snapshot });
+  const sortedAliases = Object.entries(aliases).toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  );
   return {
-    ...resolveManifestProviderAuthEnvVarCandidates(params),
+    ...resolveManifestProviderAuthEnvVarCandidates(params, snapshot, sortedAliases),
     ...CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES,
   };
 }
@@ -292,13 +284,15 @@ export function resolveProviderAuthLookupMaps(
     metadataSnapshot: snapshot,
   };
   const aliasMap = resolveProviderAuthAliasMap(lookupParams);
+  const aliasEntries = Object.entries(aliasMap);
+  const sortedAliases = aliasEntries.toSorted(([left], [right]) => left.localeCompare(right));
   return {
     aliasMap,
     envCandidateMap: {
-      ...resolveManifestProviderAuthEnvVarCandidatesFromSnapshot(params, snapshot, aliasMap),
+      ...resolveManifestProviderAuthEnvVarCandidates(params, snapshot, sortedAliases),
       ...CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES,
     },
-    ...resolveManifestRuntimeAuthFacts(params, snapshot, aliasMap),
+    ...resolveManifestRuntimeAuthFacts(params, snapshot, aliasEntries, sortedAliases),
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Provider auth lookup materializes and locale-sorts the same freshly selected alias map separately for env candidates and auth evidence, then enumerates it again for fallback references. This PR prepares the insertion-ordered entries once and derives one sorted array for the two sorted consumers. Fallback references keep their original insertion-order pass, which matters for one-pass alias-chain expansion.

## Why This Change Was Made

The owning flow remains `resolveProviderAuthLookupMaps` in `src/secrets/provider-env-vars.ts`. The env-only public export still computes only env candidates; its single-use wrapper is folded into that caller.

## User Impact

No process cache, config/schema option, trust/enablement change or credential-resolution fallback is introduced. Core env arrays keep their shared identity and override precedence; evidence elements keep their canonical references; non-core result containers stay fresh. Production changes are **+18/−24, net −6 lines**; one preservation test adds **41 lines**.

## Evidence

### Validation

The same four complete files passed before and after: **53/53 cases each**, with identical per-file case order and outcomes. The new alias-chain case passes on the original owner too; it protects existing propagation order, fresh containers, evidence identity and shared core arrays rather than claiming a bug reproduction. The files are `provider-env-vars.test.ts`, `provider-env-vars.dynamic.test.ts`, `provider-auth-aliases.test.ts` and `model-auth-env.provider-aliases.test.ts`.

The normal changed-file gate passed all **29 stages**. One managed Codex P0–P2 review completed two partitioned passes with no findings, aggregate scoped-clean confidence **0.94**; the per-pass scope limits remain retained. Normal shard/Vite warnings were preserved. No product/test retry was used to obtain these results.

### Measurement and tradeoffs

A fixed macOS/Node 26.8.1 cohort measured the complete synchronous public exports with canonically prepared metadata: B0/C0/C1/B1, **5,620 calls**, **1,536 batch means**, plus 26 separate correctness calls. Every full output, ordered key set and recorded ownership fact passed readback. The reducer retains **934 comparisons and all 286 adverse values**. No numerical threshold or aggregate numeric pass was defined.

Median latency in microseconds (negative change means lower latency):

| Complete operation / inventory | B0 → C0 | B1 → C1 |
| --- | ---: | ---: |
| Full lookup, 8 provider owners / 24 aliases | 42.375 → 37.198 (**−12.22%**) | 39.062 → 37.938 (**−2.88%**) |
| Full lookup, synthetic 32 owners / 128 aliases | 164.396 → 144.480 (**−12.11%**) | 159.230 → 149.625 (**−6.03%**) |
| Full lookup, empty/core-only | 1.096 → 1.096 (0.00%) | 1.115 → 0.966 (−13.31%) |
| Full lookup, mixed chain/origin/core override | 11.578 → 10.328 (−10.80%) | 11.219 → 10.391 (−7.38%) |
| Full lookup, live trust/enablement policy | 10.765 → 10.286 (−4.45%) | 10.417 → 10.739 (**+3.10%**) |
| Env-only sibling, same ordinary metadata | 8.792 → 8.521 (−3.08%) | 8.542 → 8.469 (−0.86%) |

The means and tails are mixed. Ordinary full-lookup mean is **+10.44%** forward and −17.31% reverse; the forward candidate retains a **1.188 ms** individual sample and **617.063 µs** maximum batch mean. Mixed-control mean is −15.05% forward but **+19.04%** reverse, with a retained **799.625 µs** sample. Policy mean is −25.07% / **+1.14%**, and reverse policy p95 is **+7.00%**. Empty-control p95 increases **17.60% / 13.99%**. Larger-inventory means improve 18.81% / 0.36%, but its reverse candidate still has an **852.667 µs** maximum sample. These values are retained without a causal explanation or dismissal as noise.

First calls are also mixed: the env-only sibling increases **42.79% / 10.44%**, empty lookup **1.43% / 2.14%**, forward policy **2.35%**, reverse mixed lookup **5.14%**, and reverse larger lookup **0.16%**. Sampled process-tree peak RSS changes **−1.40% / +2.94%**; kernel child maximum RSS changes **+0.79% / +4.15%**. This is not evidence of a memory reduction. Native wall decreases 6.16% / 4.98%, while forward user/system CPU increases 0.95% / 5.54%; these include setup/import/encoding and are separate from target latency.

Hosts ran in the fixed order but were not equally spaced: the first inter-host gap was **45.987 s**, then **175/179 ms**. Samples within each process are correlated, and “first” does not guarantee cold state. Metadata preparation is outside the target clock but inside the bounded native host. This measures lookup preparation from an available snapshot, not disk discovery, credential lookup, provider requests or Gateway latency. No Gateway speedup is claimed. Earlier R2/R3 harness setup failures occurred before target calls and remain retained; the fixed R4 numerical cohort was not rerun or tuned.

The engineering case is a smaller canonical preparation flow with both ordinary and larger-inventory medians lower in both orders. The adverse mean/tail, first-call and RSS results remain part of the decision; they do not support a universal performance claim.

### Named follow-up

The **prototype-key accumulation boundary** remains separate. Source inspection found a possible mismatch between accepted manifest target strings and ordinary-object env/evidence buckets. It has not been runtime-reproduced or established as a credential-disclosure/prototype-pollution exploit. This PR preserves the existing property access and error behavior; a normal-manifest reproduction must precede any dictionary or validation-policy repair.
