### PR TITLE
fix(update): report cancellation errors before the initiating CLI exits

### DIFF
--- a/src/cli/update-cli/update-command-handoff.test.ts
+++ b/src/cli/update-cli/update-command-handoff.test.ts
@@ -1,8 +1,152 @@
-import { describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
+import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 import {
   formatUpdateAncestryBlockMessage,
   gatewayAncestryBlockMessage,
 } from "./update-command-handoff.js";
+
+const tempDirs = createTrackedTempDirs();
+afterEach(() => tempDirs.cleanup());
+
+it.runIf(process.platform === "darwin").each(["cancel", "cancel-output-first", "transfer"])(
+  "settles the initiating CLI's owned handoff lifetime: %s",
+  async (mode) => {
+    const root = await fs.realpath(await tempDirs.make("openclaw-cli-handoff-lifetime-"));
+    const callerPath = path.join(root, "caller.mjs");
+    const preloadPath = path.join(root, "handoff-order.cjs");
+    const tracePath = path.join(root, "trace.jsonl");
+    const resultPath = path.join(root, "result.json");
+    const managerPath = path.join(root, "manager-calls");
+    const leasePath = path.join(resolvePreferredOpenClawTmpDir(), "managed-update-handoffs.sqlite");
+    await fs.mkdir(path.join(root, "dist"));
+    await fs.writeFile(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "1.0.0", type: "module" }),
+    );
+    await fs.writeFile(path.join(root, "dist/index.mjs"), "throw new Error('unexpected updater');");
+    // The task-owned manager rejects every service command; host launchd is never invoked.
+    await fs.writeFile(
+      path.join(root, "launchctl"),
+      `#!${process.execPath}\nimport fs from 'node:fs';fs.appendFileSync(${JSON.stringify(managerPath)}, 'called\\n');process.exit(61);`,
+      { mode: 0o755 },
+    );
+    await fs.writeFile(
+      preloadPath,
+      `
+const fs=require('node:fs');
+const record=(event,data={})=>fs.appendFileSync(${JSON.stringify(tracePath)},JSON.stringify({event,...data})+'\\n');
+if(process.argv[1]===${JSON.stringify(callerPath)} && ${mode !== "transfer"}) {
+  const sqlite=require('node:sqlite'), Original=sqlite.DatabaseSync;
+  sqlite.DatabaseSync=new Proxy(Original,{construct(target,args,newTarget) {
+    if(String(args[0])===${JSON.stringify(path.join(root, "state/openclaw.sqlite"))}) {
+      const db=new Original(${JSON.stringify(leasePath)},{readOnly:true});
+      const lease=db.prepare('SELECT owner FROM managed_update_handoffs WHERE install_root=?').get(${JSON.stringify(root)});
+      db.close();record('publication-denied',{ready:!!lease});
+      throw Object.assign(new Error('fixture publication denied'),{code:'SQLITE_CANTOPEN'});
+    }
+    return Reflect.construct(target,args,newTarget);
+  }});
+  require('node:module').syncBuiltinESMExports();
+} else if(process.argv[1]?.endsWith('/handoff.cjs')) {
+  const params=JSON.parse(fs.readFileSync(process.argv[2],'utf8'));
+  if(params.updateLeaseKey===${JSON.stringify(root)}) {
+    if(${mode === "cancel-output-first"}) {
+      // Close only helper output before native exit; the initiating CLI has no keepalive.
+      process.once('beforeExit',()=>{record('helper-output-closed');process.stdout.end();setTimeout(()=>{},100);});
+    }
+    process.once('exit',()=>record('helper-exit'));
+  }
+}`,
+    );
+    await fs.writeFile(
+      callerPath,
+      `
+import fs from 'node:fs';
+import {handoffUpdateFromGateway} from ${JSON.stringify(new URL("./update-command-handoff.ts", import.meta.url).href)};
+try {
+  const transferred=await handoffUpdateFromGateway({state:{env:process.env,runtime:{status:'running',pid:process.ppid}},root:${JSON.stringify(root)},mode:'npm',opts:{json:true},timeoutMs:10000,nodeRunner:process.execPath,stopProgress:()=>{}});
+  fs.appendFileSync(${JSON.stringify(tracePath)},JSON.stringify({event:'caller-transferred',transferred})+'\\n');
+} catch(error) {
+  fs.appendFileSync(${JSON.stringify(tracePath)},JSON.stringify({event:'caller-error'})+'\\n');
+  process.stdout.write(JSON.stringify({code:error.code})+'\\n');process.exitCode=23;
+}`,
+    );
+    const gatewayPath = path.join(root, "gateway.cjs");
+    await fs.writeFile(
+      gatewayPath,
+      `
+const fs=require('node:fs'),{spawn}=require('node:child_process');process.stdin.resume();
+const child=spawn(process.execPath,['--import',${JSON.stringify(pathToFileURL(createRequire(import.meta.url).resolve("tsx/esm")).href)},${JSON.stringify(callerPath)}],{env:process.env,stdio:['pipe','pipe','pipe']});
+let stdout='',stderr='';child.stdout.on('data',chunk=>stdout+=chunk);child.stderr.on('data',chunk=>stderr+=chunk);
+child.once('close',(code,signal)=>{fs.writeFileSync(${JSON.stringify(resultPath)},JSON.stringify({code,signal,stdout,stderr}));child.stdin.destroy();});
+process.stdin.once('end',()=>{if(child.exitCode===null&&child.signalCode===null)child.kill('SIGKILL');process.stdin.destroy();});`,
+    );
+    const gateway = spawn(process.execPath, [gatewayPath], {
+      env: {
+        ...process.env,
+        OPENCLAW_STATE_DIR: root,
+        OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
+        OPENCLAW_LAUNCHD_LABEL: `ai.openclaw.handoff-test.${process.pid}`,
+        OPENCLAW_UPDATE_RUN_HANDOFF: undefined,
+        OPENCLAW_SUPERVISOR_MODE: undefined,
+        PATH: `${root}${path.delimiter}${process.env.PATH ?? ""}`,
+        NODE_OPTIONS: `--require=${JSON.stringify(preloadPath)}`,
+      },
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+    const closed = new Promise<void>((resolve) => {
+      gateway.once("close", () => resolve());
+    });
+    const readLease = () => {
+      const db = new DatabaseSync(leasePath, { readOnly: true });
+      try {
+        return db
+          .prepare("SELECT owner FROM managed_update_handoffs WHERE install_root=?")
+          .get(root);
+      } finally {
+        db.close();
+      }
+    };
+    try {
+      await expect.poll(() => fs.readFile(resultPath, "utf8"), { timeout: 20_000 }).toBeDefined();
+      const result = JSON.parse(await fs.readFile(resultPath, "utf8"));
+      await expect.poll(readLease).toBeUndefined();
+      expect(gateway.exitCode).toBeNull();
+      expect(result.code, result.stderr).toBe(mode === "transfer" ? 0 : 23);
+      const trace = (await fs.readFile(tracePath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      if (mode === "transfer") {
+        expect(trace[0]).toEqual({ event: "caller-transferred", transferred: true });
+      } else {
+        expect(JSON.parse(result.stdout)).toEqual({ code: "SQLITE_CANTOPEN" });
+        expect(await fs.readFile(managerPath, "utf8").catch(() => "")).toBe("");
+        expect(trace[0]).toEqual({ event: "publication-denied", ready: true });
+        if (mode === "cancel-output-first") {
+          expect(trace.map((row) => row.event)).toEqual([
+            "publication-denied",
+            "helper-output-closed",
+            "helper-exit",
+            "caller-error",
+          ]);
+        }
+      }
+    } finally {
+      gateway.stdin.end();
+      await closed;
+      await expect.poll(readLease).toBeUndefined();
+      await expect.poll(() => fs.readFile(tracePath, "utf8")).toContain('"event":"helper-exit"');
+    }
+  },
+);
 
 describe("gatewayAncestryBlockMessage", () => {
   it("never advises stopping the gateway service or running update from the caller", () => {

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -1719,8 +1719,6 @@ async function spawnManagedServiceUpdateHandoff(
     await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
     throw err;
   }
-  child.unref();
-
   const result = { command: commandLabel, logPath };
   const handoffId = readiness.slice(HANDOFF_BUSY_MARKER.length).trim();
   return `${readiness}\n` === HANDOFF_READY_MARKER
@@ -1938,8 +1936,9 @@ export async function transferManagedServiceUpdateHandoff(
   ) {
     return false;
   }
-  // Node's spawn pipe streams are net.Socket instances. Unref keeps the control
-  // channel open until CLI exit, so its result is printed before service stop.
+  // Readiness still owns cancellation; only acknowledged transfer may detach
+  // the child and its Socket pipes so the CLI can print its result before exit.
+  child.unref();
   child.stdin.unref();
   child.stdout.unref();
   return true;


### PR DESCRIPTION
Closes #138797.

## What Problem This Solves

Fixes an issue where users initiating a managed update could lose the original failure diagnostic when cancellation closed helper output before the helper process exited. The initiating CLI could exit with an unsettled top-level await while still waiting for cleanup.

## Why This Change Was Made

Readiness still leaves cancellation with the initiating caller. Keep the native child-process reference until the helper acknowledges transfer, then release it alongside the existing pipe references after the final ownership check. This moves the existing release into the lifecycle boundary that already owns detachment, without adding a timer, state, fallback, or configuration surface. Gateway-owned restart continues to use explicit process exit.

Production is +3/−4 lines, raw net −1; the statement relocation itself is net-neutral and the one-line reduction is a blank separator. Tests are +145/−1, net +144. No storage schema, persistence policy, protocol, or public API changes.

## User Impact

Failed handoffs can finish owned cancellation and report the original error. Successfully acknowledged handoffs still let the initiating CLI return and exit while the helper continues independently.

## Evidence

The regression exercises the actual handoff caller and generated helper in native subprocesses on macOS with Node 24.20.0. On unchanged production, the output-first cancellation case exited 13 instead of reaching the fixture's original-error handler (exit 23). Ordinary cancellation, acknowledged transfer, and the three existing guidance cases passed in that same run. With the repair, all six caller cases pass; the output-first trace records helper exit before the caller's original-error handler, and successful transfer returns true and exits naturally with code 0.

Five existing helper suites pass 181 cases with two existing Windows-only skips, for **187 passing cases and two skips** in total. The canonical changed-path checks pass, and independent managed Codex review found no actionable P0–P2 findings on the frozen candidate.

```sh
node scripts/run-vitest.mjs src/cli/update-cli/update-command-handoff.test.ts --reporter=verbose
node scripts/run-vitest.mjs src/infra/update-managed-service-handoff-command.test.ts src/infra/update-managed-service-handoff-cross-process.test.ts src/infra/update-managed-service-handoff-lifecycle.test.ts src/infra/update-managed-service-handoff-ownership.test.ts src/infra/update-managed-service-handoff-single-flight.test.ts --reporter=verbose
node scripts/check-changed.mjs --base d329e6144965561c88cad197380def7b12eb6beb -- src/infra/update-managed-service-handoff.ts src/cli/update-cli/update-command-handoff.test.ts
```

The real-process fixture uses a task-owned `launchctl` that rejects service commands. It does not activate an operator service or exercise full packaged CLI bootstrap or Windows. The canonical temporary lease database may be shared; each fixture owns a unique installation-root row and checks that it is absent afterward. The transfer control proves caller return and natural exit, not rendered JSON under the inherited test-mode output gating. Source and index hashes remained unchanged throughout the completed tests, checks, and review.

The executed baseline is `d329e6144965561c88cad197380def7b12eb6beb`. Source comparison against local main `3c9da5dd0e3519696befe50e059d3a34f989921b` found the changed owner/caller unchanged and no conflicting lifetime changes in the immediate update and Gateway restart neighbors. CI and final landing validation remain pending.
