### PR TITLE
fix(signal): keep prototype-named container styles unstyled

### DIFF
--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -894,6 +894,30 @@ describe("containerSendMessage", () => {
     expect(body.message).toBe("**Bold** C:\\Temp\\file and /foo\\bar/");
   });
 
+  it.each(["custom", "constructor", "__proto__", "toString"])(
+    "keeps inherited %s style names from wrapping Signal container text",
+    async (style) => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        ...bodyStream(JSON.stringify({})),
+      });
+
+      await containerSendMessage({
+        baseUrl: "http://localhost:8080",
+        account: "+14259798283",
+        recipients: ["+15550001111"],
+        message: "Bold text",
+        textStyles: [{ start: 0, length: 4, style }],
+      });
+
+      const body = parseFetchBody();
+      expect(typeof body.message).toBe("string");
+      expect(typeof body.message).not.toBe("function");
+      expect(body.message).toBe("Bold text");
+    },
+  );
+
   it("includes attachments as base64 data URIs", async () => {
     const fs = await import("node:fs/promises");
     const os = await import("node:os");

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -591,7 +591,12 @@ function renderContainerStyledText(
 ): string {
   const spans = styles
     .map((style) => {
-      const marker = CONTAINER_TEXT_STYLE_MARKERS[style.style];
+      // Style names come from text-style ranges; an unguarded index returns
+      // inherited Object.prototype values (`constructor`) that stringify into
+      // the container payload as Function source instead of leaving text plain.
+      const marker = Object.hasOwn(CONTAINER_TEXT_STYLE_MARKERS, style.style)
+        ? CONTAINER_TEXT_STYLE_MARKERS[style.style]
+        : undefined;
       if (!marker) {
         return null;
       }


### PR DESCRIPTION
## What Problem This Solves

`renderContainerStyledText` indexed `CONTAINER_TEXT_STYLE_MARKERS` with the caller-supplied style name, so a range named `constructor` resolved to `Object.prototype.constructor`. That is truthy, so the Signal container payload wrapped the text in native Function source instead of leaving it plain. Reachable from `containerRpcRequest` send via text-style ranges.

The lookup goes through `Object.hasOwn` now. Own keys (`BOLD`, `ITALIC`) still wrap; prototype names and unknown styles stay plain.

## Evidence

`node scripts/run-vitest.mjs run --config test/vitest/vitest.config.ts extensions/signal/src/client-container.test.ts` at this head:

```text
 Test Files  1 passed (1)
      Tests  87 passed (87)
```

Same test file with only `extensions/signal/src/client-container.ts` reverted to the parent commit:

```text
 × keeps inherited constructor style names from wrapping Signal container text
   → expected 'function Object() { [native code] }Bo…' to be 'Bold text'
 × keeps inherited __proto__ style names from wrapping Signal container text
   → expected '[object Object]Bold[object Object] te…' to be 'Bold text'
 × keeps inherited toString style names from wrapping Signal container text
   → expected 'function toString() { [native code] }…' to be 'Bold text'

 Test Files  1 failed (1)
      Tests  3 failed | 84 passed (87)
```

`custom` passes either way; an unknown non-prototype key already resolved to undefined. The existing marker cases, including `**Bold** C:\Temp\file and /foo\bar/`, are in the 84 that stay green.
