### PR TITLE
fix(workboard): stop services before store retirement

### DIFF
--- a/extensions/workboard/index.lifecycle.test.ts
+++ b/extensions/workboard/index.lifecycle.test.ts
@@ -2,10 +2,60 @@ import { Command } from "commander";
 import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { withStateDirEnv } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi, OpenClawPluginService } from "./api.js";
 import plugin from "./index.js";
+import { registerWorkboardGatewayMethods } from "./runtime-api.js";
+import { WorkboardStore } from "./src/store.js";
 
-function registerGeneration() {
-  const captured = capturePluginRegistration(plugin);
+function registerGeneration(register: (api: OpenClawPluginApi) => void = plugin.register) {
+  const services: OpenClawPluginService[] = [];
+  const methods = new Map<string, Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]>();
+  let gatewayStart = () => {};
+  let gatewayStop = () => {};
+  const captured = capturePluginRegistration({
+    ...plugin,
+    register(api) {
+      api.registerService = (service) => {
+        services.push(service);
+      };
+      api.registerGatewayMethod = (method, handler) => {
+        methods.set(method, handler);
+      };
+      api.on = (name, handler) => {
+        if (name === "gateway_start") {
+          gatewayStart = () => {
+            void (handler as Parameters<typeof api.on<"gateway_start">>[1])({ port: 0 }, {});
+          };
+        } else if (name === "gateway_stop") {
+          gatewayStop = () => {
+            void (handler as Parameters<typeof api.on<"gateway_stop">>[1])({}, {});
+          };
+        }
+      };
+      register(api);
+    },
+  });
+  const warn = vi.fn();
+  const emit = vi.fn();
+  const serviceContext = {
+    config: {},
+    stateDir: process.env.OPENCLAW_STATE_DIR!,
+    logger: { ...captured.api.logger, warn },
+    gatewayEvents: { emit, onSessionsChanged: () => () => {} },
+  };
+  const start = async () => {
+    for (const service of services) {
+      await service.start(serviceContext);
+    }
+    gatewayStart();
+    await vi.advanceTimersByTimeAsync(0);
+  };
+  const stop = async () => {
+    gatewayStop();
+    for (const service of services) {
+      await service.stop?.(serviceContext);
+    }
+  };
   const cleanup = async (
     context: Parameters<NonNullable<(typeof captured.runtimeLifecycles)[number]["cleanup"]>>[0],
   ) => {
@@ -35,7 +85,17 @@ function registerGeneration() {
       write.mockRestore();
     }
   };
-  return { cleanup, run };
+  const call = async (method: string, params = {}) => {
+    const handler = methods.get(method);
+    if (!handler) {
+      throw new Error(`Missing Gateway method: ${method}`);
+    }
+    const respond = vi.fn<Parameters<typeof handler>[0]["respond"]>();
+    await handler({ params, respond } as unknown as Parameters<typeof handler>[0]);
+    const [ok, payload, error] = respond.mock.calls[0] ?? [];
+    return { ok, payload, error };
+  };
+  return { cleanup, run, start, stop, warn, emit, call };
 }
 
 describe("Workboard registration cleanup", () => {
@@ -43,9 +103,11 @@ describe("Workboard registration cleanup", () => {
     "closes only the retired generation on %s",
     async (reason) => {
       await withStateDirEnv("workboard-registration-lifecycle-", async () => {
+        vi.useFakeTimers();
         const first = registerGeneration();
         const second = registerGeneration();
         try {
+          await first.start();
           await first.run("create", "Retained card");
           for (const context of [
             { reason: "reset" as const },
@@ -59,8 +121,13 @@ describe("Workboard registration cleanup", () => {
             });
           }
 
+          expect(vi.getTimerCount()).toBeGreaterThan(0);
           await first.cleanup({ reason });
           await expect(first.run("list")).rejects.toThrow("workboard store is closed.");
+          await vi.advanceTimersByTimeAsync(60_000);
+          expect(first.warn).not.toHaveBeenCalled();
+          expect(vi.getTimerCount()).toBe(0);
+          await second.start();
           await expect(second.run("create", "Fresh card")).resolves.toMatchObject({
             card: { title: "Fresh card" },
           });
@@ -71,9 +138,58 @@ describe("Workboard registration cleanup", () => {
             ]),
           });
           await first.cleanup({ reason });
+          second.emit.mockClear();
+          await second.run("create", "After repeated retirement");
+          expect(second.emit).toHaveBeenCalled();
         } finally {
+          await first.stop();
+          await second.stop();
           await first.cleanup({ reason: "disable" });
           await second.cleanup({ reason: "disable" });
+          vi.useRealTimers();
+        }
+      });
+    },
+  );
+
+  it.each(["internal", "injected"] as const)(
+    "retains public Gateway store ownership for %s stores",
+    async (ownership) => {
+      await withStateDirEnv("workboard-gateway-lifecycle-", async () => {
+        const store = ownership === "injected" ? WorkboardStore.openSqlite() : undefined;
+        const generation = registerGeneration((api) =>
+          registerWorkboardGatewayMethods({ api, store }),
+        );
+        try {
+          expect(await generation.call("workboard.cards.list")).toMatchObject({
+            ok: true,
+            payload: { cards: [] },
+          });
+          expect(
+            await generation.call("workboard.boards.upsert", {
+              id: "retained",
+              name: "Retained board",
+            }),
+          ).toMatchObject({ ok: true });
+          await generation.cleanup({ reason: "disable", sessionKey: "agent:other:session" });
+          expect(await generation.call("workboard.cards.list")).toMatchObject({ ok: true });
+          await generation.cleanup({ reason: "disable" });
+          expect(await generation.call("workboard.cards.list")).toMatchObject({
+            ok: ownership === "injected",
+          });
+          const reopened = WorkboardStore.openSqlite();
+          try {
+            expect(await reopened.listBoards()).toMatchObject({
+              boards: expect.arrayContaining([
+                expect.objectContaining({ id: "retained", name: "Retained board" }),
+              ]),
+            });
+          } finally {
+            await reopened.close();
+          }
+        } finally {
+          await generation.cleanup({ reason: "disable" });
+          await store?.close();
         }
       });
     },

--- a/extensions/workboard/index.ts
+++ b/extensions/workboard/index.ts
@@ -10,6 +10,7 @@ import {
   syncWorkboardAgentEnded,
   syncWorkboardSubagentEnded,
 } from "./src/lifecycle-sync.js";
+import { registerWorkboardStoreLifecycle } from "./src/store-lifecycle.js";
 import { WorkboardStore } from "./src/store.js";
 import { createWorkboardTools } from "./src/tools.js";
 import {
@@ -23,20 +24,7 @@ export default definePluginEntry({
   description: "Dashboard workboard for agent-owned issues and sessions.",
   register(api) {
     const store = WorkboardStore.openSqlite();
-    api.lifecycle.registerRuntimeLifecycle({
-      id: "workboard-sqlite-store",
-      cleanup: ({ reason, sessionKey, runId }) => {
-        // Session cleanup shares this hook, but only registry retirement owns the whole store.
-        if (
-          sessionKey === undefined &&
-          runId === undefined &&
-          (reason === "disable" || reason === "restart")
-        ) {
-          return store.close();
-        }
-        return undefined;
-      },
-    });
+    const changeEvents = createWorkboardChangeEventService(store);
     const automationNudge = createWorkboardAutomationNudgeService({
       store,
       gateway: api.runtime.gateway,
@@ -46,6 +34,11 @@ export default definePluginEntry({
       worktrees: api.runtime.worktrees,
       readSessions: async (options) =>
         await readWorkboardLifecycleSessions(api.runtime.gateway, options),
+    });
+    registerWorkboardStoreLifecycle(api, store, () => {
+      changeEvents.stop();
+      automationNudge.stop();
+      lifecycleSync.stop();
     });
     api.session.controls.registerControlUiDescriptor({
       surface: "tab",
@@ -76,7 +69,7 @@ export default definePluginEntry({
     });
     registerWorkboardGatewayMethods({ api, store });
     registerWorkboardCommand({ api, store });
-    api.registerService(createWorkboardChangeEventService(store));
+    api.registerService(changeEvents);
     api.registerService(automationNudge);
     api.registerService(lifecycleSync);
     api.on("gateway_start", () => lifecycleSync.onGatewayStart());

--- a/extensions/workboard/src/automation-nudge.ts
+++ b/extensions/workboard/src/automation-nudge.ts
@@ -15,6 +15,7 @@ type WorkboardAutomationNudgeInput = {
 };
 
 type WorkboardAutomationNudgeService = OpenClawPluginService & {
+  stop: () => void;
   nudge: (input: WorkboardAutomationNudgeInput) => Promise<void>;
 };
 

--- a/extensions/workboard/src/change-events.ts
+++ b/extensions/workboard/src/change-events.ts
@@ -4,7 +4,9 @@ import type { WorkboardStore } from "./store.js";
 
 const WORKBOARD_EXTERNAL_CHANGE_CHECK_MS = 1000;
 
-export function createWorkboardChangeEventService(store: WorkboardStore): OpenClawPluginService {
+export function createWorkboardChangeEventService(
+  store: WorkboardStore,
+): OpenClawPluginService & { stop: () => void } {
   let unsubscribe: (() => void) | undefined;
   let timer: ReturnType<typeof setInterval> | undefined;
 

--- a/extensions/workboard/src/gateway.ts
+++ b/extensions/workboard/src/gateway.ts
@@ -16,7 +16,8 @@ import {
   registerWorkboardWorkspaceCardMethods,
   registerWorkboardWorkspaceWorkflowMethods,
 } from "./gateway-workspace-methods.js";
-import type { WorkboardStore } from "./store.js";
+import { registerWorkboardStoreLifecycle } from "./store-lifecycle.js";
+import { WorkboardStore } from "./store.js";
 
 const READ_SCOPE = "operator.read" as const;
 const WRITE_SCOPE = "operator.write" as const;
@@ -37,9 +38,13 @@ async function redactCardResult(card: Promise<WorkboardCard>) {
 
 export function registerWorkboardGatewayMethods(params: {
   api: OpenClawPluginApi;
-  store: WorkboardStore;
+  store?: WorkboardStore;
 }) {
-  const { api: hostApi, store } = params;
+  const { api: hostApi } = params;
+  const store = params.store ?? WorkboardStore.openSqlite();
+  if (!params.store) {
+    registerWorkboardStoreLifecycle(hostApi, store);
+  }
   const api: OpenClawPluginApi = {
     ...hostApi,
     registerGatewayMethod: (method, handler, options) =>

--- a/extensions/workboard/src/lifecycle-sync.ts
+++ b/extensions/workboard/src/lifecycle-sync.ts
@@ -78,6 +78,7 @@ type WorkboardLifecycleMatchHandler = (input: {
 }) => Promise<void>;
 
 type WorkboardLifecycleService = OpenClawPluginService & {
+  stop: () => void;
   onGatewayStart: () => void;
   onGatewayStop: () => void;
 };

--- a/extensions/workboard/src/store-lifecycle.ts
+++ b/extensions/workboard/src/store-lifecycle.ts
@@ -1,0 +1,25 @@
+import type { OpenClawPluginApi } from "../api.js";
+import type { WorkboardStore } from "./store.js";
+
+export function registerWorkboardStoreLifecycle(
+  api: OpenClawPluginApi,
+  store: WorkboardStore,
+  stopServices?: () => void,
+): void {
+  api.lifecycle.registerRuntimeLifecycle({
+    id: "workboard-sqlite-store",
+    cleanup: ({ reason, sessionKey, runId }) => {
+      // Session cleanup shares this hook, but only registry retirement owns the whole store.
+      if (
+        sessionKey === undefined &&
+        runId === undefined &&
+        (reason === "disable" || reason === "restart")
+      ) {
+        // Stop producers before the store drains admitted work and closes its connection.
+        stopServices?.();
+        return store.close();
+      }
+      return undefined;
+    },
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where retiring or replacing a Workboard plugin registration left background services polling a closed database and logging errors every second. Also restores the public Gateway registration helper's optional store argument, which otherwise registered handlers that failed on every request.

## Why This Change Was Made

Registry retirement now stops Workboard's existing service owners before the existing store operation drain closes SQLite. One Workboard lifecycle binding is shared by the plugin entry and the helper's internally opened store; injected stores remain caller-owned. The operation drain, dispatcher, schema, stored formats, configuration and retention are unchanged.

## User Impact

Workboard reload and disable finish without stale polling warnings. Public helper callers can continue omitting a store, and requests already accepted before retirement still finish their durable writes or cleanup.

## Evidence

The baseline reproduced two live timers after actual registry clear/replacement and repeated database-is-not-open warnings. The candidate leaves no native SQLite handles or service timers while retaining the old registry, and emits no post-retirement warnings. Real registered Gateway probes preserved accepted launch records, failure/workspace compensation, held lifecycle writes and fresh reopen data. The public helper passed list/write, scoped cleanup and reopen; injected ownership remains covered.

Nine focused test files passed (120 tests); the four changed registration cases passed again after a test fixture type correction. The corrected regression baseline had three intended failures and one injected-store control pass. The full changed-file gate passed, including production and test typechecks, lint, dead exports and cycles. Eight native probes passed, including a held automation request. Fresh independent Codex review of the complete owners, stable API and native evidence found no actionable P0–P2 findings.

Production delta: +27 lines; test delta: +116 lines. The growth binds missing lifecycle ownership and preserves the stable optional factory without adding another queue. Broader disposal of prepared registries that were never activated remains a separate host-lifecycle follow-up.

After rebasing onto the current plugin-service reload owner, all 54 focused tests and nine native probes passed on commit `706fa3ce56efac290bbbdcf38fb0f597b482203b`. The extra probe holds dispatch while all three real services reload, then retires the registry and verifies accepted work persists before closure. A fresh seven-part independent Codex review found no actionable P0–P2 finding. The patch is unchanged by the rebase.

A separate native overlap audit reproduced provider sign-in setup replacing the active Gateway registry before authentication begins. That happens on both main and this candidate; the candidate fixes Workboard's resulting closed-database polling. Named follow-up: **Provider-auth setup must not replace the active Gateway registry**. Its owner is provider discovery in `src/commands/models/auth.ts`, and the existing local setup resolver is being verified separately. The overlap proof used synthetic state and stopped before auth or network calls.
