### PR TITLE
feat(ios): send chat with hardware Return key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4948,6 +4948,7 @@ jobs:
             -only-testing:OpenClawTests/NotificationServingPreferenceTests \
             -only-testing:OpenClawTests/RootTabsSourceGuardTests \
             -only-testing:OpenClawTests/TraceHeadingVisualProofTests \
+            -only-testing:OpenClawTests/ChatComposerTextViewIOSTests \
             test
           xcodebuild \
             -project apps/ios/OpenClaw.xcodeproj \
@@ -4957,6 +4958,9 @@ jobs:
             -resultBundlePath apps/ios/build/LifecycleTestResults/OpenClawWatchDeliveryUITests.xcresult \
             -parallel-testing-enabled NO \
             -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testWatchMessageDeliveryIsReachableFromSettings \
+            -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testChatComposerReturnInsertsNewlineWithoutSending \
+            -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testChatComposerHardwareReturnSendsAndShiftReturnKeepsDraft \
+            -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testChatComposerHardwareReturnPreservesDraftDuringActiveRun \
             test
 
       - name: Run focused Apple Watch operation simulator tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4959,6 +4959,31 @@ jobs:
             -parallel-testing-enabled NO \
             -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testWatchMessageDeliveryIsReachableFromSettings \
             -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testChatComposerReturnInsertsNewlineWithoutSending \
+            test
+          # Apple's XCUIElement keyboard contract documents key events for macOS and iPadOS 15+;
+          # keep the hardware-keyboard coverage on an iPad while phone lifecycle coverage stays above.
+          ipad_simulator_id="$(
+            xcrun simctl list devices available --json | node --input-type=module -e '
+              const chunks = [];
+              for await (const chunk of process.stdin) chunks.push(chunk);
+              const runtimes = JSON.parse(Buffer.concat(chunks).toString("utf8")).devices;
+              const simulator = Object.values(runtimes)
+                .flat()
+                .find((device) => device.isAvailable && device.name.startsWith("iPad"));
+              if (!simulator) {
+                console.error("No available iPad simulator for hardware Return UI tests");
+                process.exit(1);
+              }
+              process.stdout.write(simulator.udid);
+            '
+          )"
+          xcodebuild \
+            -project apps/ios/OpenClaw.xcodeproj \
+            -scheme OpenClawUITests \
+            -configuration Debug \
+            -destination "platform=iOS Simulator,id=${ipad_simulator_id}" \
+            -resultBundlePath apps/ios/build/LifecycleTestResults/OpenClawHardwareReturnUITests.xcresult \
+            -parallel-testing-enabled NO \
             -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testChatComposerHardwareReturnSendsAndShiftReturnKeepsDraft \
             -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testChatComposerHardwareReturnPreservesDraftDuringActiveRun \
             test

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -703,22 +703,36 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertTrue(self.app?.keyboards.firstMatch.waitForNonExistence(timeout: 3) == true)
     }
 
-    func testChatComposerReturnInsertsNewlineWithoutSending() throws {
+    func testChatComposerHardwareReturnSendsAndShiftReturnKeepsDraft() throws {
         self.launchApp(for: ScreenshotTarget(
             initialTab: "chat",
             initialDestination: "chat",
-            name: "chat-composer-return"))
+            name: "chat-composer-hardware-return"))
 
         let app = try XCTUnwrap(self.app)
         let input = self.chatMessageInput(in: app)
         XCTAssertTrue(input.waitForExistence(timeout: 8))
         input.tap()
-        input.typeText("first line\nsecond line")
 
-        XCTAssertEqual(input.value as? String, "first line\nsecond line")
+        input.typeText("first message")
+        input.typeKey(.return, modifierFlags: [])
+        let firstMessageSent = expectation(
+            for: NSPredicate(format: "value == %@", ""),
+            evaluatedWith: input)
+        wait(for: [firstMessageSent], timeout: 3)
+
+        input.typeText("second message")
+        input.typeKey(.return, modifierFlags: [.command])
+        let secondMessageSent = expectation(
+            for: NSPredicate(format: "value == %@", ""),
+            evaluatedWith: input)
+        wait(for: [secondMessageSent], timeout: 3)
+
+        input.typeText("draft")
+        input.typeKey(.return, modifierFlags: [.shift])
+        XCTAssertEqual(input.value as? String, "draft\n")
         XCTAssertTrue(app.buttons["chat-send-message"].waitForExistence(timeout: 3))
-        XCTAssertFalse(app.staticTexts["first line\nsecond line"].exists)
-        self.attachScreenshot(named: "chat-composer-return")
+        self.attachScreenshot(named: "chat-composer-hardware-return")
     }
 
     func testVoiceNoteDraftKeepsStopAvailableDuringActiveResponse() throws {

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -703,6 +703,24 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertTrue(self.app?.keyboards.firstMatch.waitForNonExistence(timeout: 3) == true)
     }
 
+    func testChatComposerReturnInsertsNewlineWithoutSending() throws {
+        self.launchApp(for: ScreenshotTarget(
+            initialTab: "chat",
+            initialDestination: "chat",
+            name: "chat-composer-return"))
+
+        let app = try XCTUnwrap(self.app)
+        let input = self.chatMessageInput(in: app)
+        XCTAssertTrue(input.waitForExistence(timeout: 8))
+        input.tap()
+        input.typeText("first line\nsecond line")
+
+        XCTAssertEqual(input.value as? String, "first line\nsecond line")
+        XCTAssertTrue(app.buttons["chat-send-message"].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.staticTexts["first line\nsecond line"].exists)
+        self.attachScreenshot(named: "chat-composer-return")
+    }
+
     func testChatComposerHardwareReturnSendsAndShiftReturnKeepsDraft() throws {
         self.launchApp(for: ScreenshotTarget(
             initialTab: "chat",
@@ -720,19 +738,54 @@ final class OpenClawSnapshotUITests: XCTestCase {
             for: NSPredicate(format: "value == %@", ""),
             evaluatedWith: input)
         wait(for: [firstMessageSent], timeout: 3)
+        XCTAssertTrue(app.staticTexts["first message"].waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", "I can help with"))
+                .firstMatch.waitForExistence(timeout: 5))
 
         input.typeText("second message")
+        self.waitForEnabled(app.buttons["chat-send-message"])
         input.typeKey(.return, modifierFlags: [.command])
         let secondMessageSent = expectation(
             for: NSPredicate(format: "value == %@", ""),
             evaluatedWith: input)
         wait(for: [secondMessageSent], timeout: 3)
+        XCTAssertTrue(app.staticTexts["second message"].waitForExistence(timeout: 5))
 
         input.typeText("draft")
         input.typeKey(.return, modifierFlags: [.shift])
         XCTAssertEqual(input.value as? String, "draft\n")
         XCTAssertTrue(app.buttons["chat-send-message"].waitForExistence(timeout: 3))
         self.attachScreenshot(named: "chat-composer-hardware-return")
+    }
+
+    func testChatComposerHardwareReturnPreservesDraftDuringActiveRun() throws {
+        self.launchApp(
+            for: ScreenshotTarget(
+                initialTab: "chat",
+                initialDestination: "chat",
+                name: "chat-composer-hardware-return-blocked"),
+            additionalArguments: ["--openclaw-hold-initial-chat-run"])
+
+        let app = try XCTUnwrap(self.app)
+        let input = self.chatMessageInput(in: app)
+        XCTAssertTrue(input.waitForExistence(timeout: 8))
+        input.tap()
+        input.typeText("Keep the first run active.")
+        input.typeKey(.return, modifierFlags: [])
+        XCTAssertTrue(app.buttons["Stop response"].waitForExistence(timeout: 8))
+
+        input.typeText("Keep this draft.")
+        let send = app.buttons["chat-send-message"]
+        XCTAssertTrue(send.waitForExistence(timeout: 3))
+        XCTAssertFalse(send.isEnabled)
+        let sendModifiers: [XCUIElement.KeyModifierFlags] = [[], .command]
+        for modifiers in sendModifiers {
+            input.typeKey(.return, modifierFlags: modifiers)
+            XCTAssertEqual(input.value as? String, "Keep this draft.")
+            XCTAssertFalse(app.staticTexts["Keep this draft."].exists)
+        }
+        self.attachScreenshot(named: "chat-composer-hardware-return-blocked")
     }
 
     func testVoiceNoteDraftKeepsStopAvailableDuringActiveResponse() throws {

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -407,6 +407,8 @@ targets:
         group: Tests
       - path: ../shared/OpenClawKit/Tests/OpenClawKitTests/ChatPasteboardTests.swift
         group: Tests
+      - path: ../shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewIOSTests.swift
+        group: Tests
       - path: WatchApp/Sources/WatchDeferredPayloadOrdering.swift
         group: WatchApp/Sources
     dependencies:

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -733,6 +733,9 @@ struct OpenClawChatComposer: View {
                 onFocusChange: { focused in
                     self.isFocused = focused
                 },
+                onSend: {
+                    self.sendDraftIfEnabled()
+                },
                 onHistoryUp: {
                     !self.isSlashPopoverPresented && self.viewModel.recallPreviousInput(caretOnFirstLine: $0)
                 },

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposerTextViewIOS.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposerTextViewIOS.swift
@@ -110,6 +110,19 @@ final class ChatComposerUITextView: UITextView {
     var onHistoryUp: ((Bool) -> Bool)?
     var onHistoryDown: (() -> Bool)?
 
+    override var keyCommands: [UIKeyCommand]? {
+        let inheritedCommands = super.keyCommands ?? []
+        guard self.markedTextRange == nil else { return inheritedCommands }
+        // Priority keeps hardware Return from being consumed as text input; omitting these
+        // commands during IME composition lets UIKit confirm marked text normally.
+        return inheritedCommands + [
+            self.makeSendKeyCommand(modifierFlags: []),
+            self.makeSendKeyCommand(modifierFlags: .command),
+            self.makeSendKeyCommand(modifierFlags: .numericPad),
+            self.makeSendKeyCommand(modifierFlags: [.command, .numericPad]),
+        ]
+    }
+
     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
         var unhandledPresses = presses
         for press in presses {
@@ -129,15 +142,6 @@ final class ChatComposerUITextView: UITextView {
     {
         let commandModifiers: UIKeyModifierFlags = [.shift, .control, .alternate, .command]
         let activeModifiers = modifierFlags.intersection(commandModifiers)
-        if keyCode == .keyboardReturnOrEnter,
-           activeModifiers.isEmpty || activeModifiers == .command
-        {
-            // Return confirms provisional IME text before it can submit a draft.
-            guard self.markedTextRange == nil else { return false }
-            self.onSend?()
-            return true
-        }
-
         guard activeModifiers.isEmpty else { return false }
         switch keyCode {
         case .keyboardUpArrow:
@@ -147,6 +151,28 @@ final class ChatComposerUITextView: UITextView {
         default:
             return false
         }
+    }
+
+    @objc
+    func handleSendKeyCommand(_: UIKeyCommand) {
+        guard self.markedTextRange == nil else { return }
+        self.onSend?()
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(self.handleSendKeyCommand(_:)) {
+            return self.markedTextRange == nil
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    private func makeSendKeyCommand(modifierFlags: UIKeyModifierFlags) -> UIKeyCommand {
+        let command = UIKeyCommand(
+            input: "\r",
+            modifierFlags: modifierFlags,
+            action: #selector(self.handleSendKeyCommand(_:)))
+        command.wantsPriorityOverSystemBehavior = true
+        return command
     }
 
     private var caretOnFirstLine: Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposerTextViewIOS.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposerTextViewIOS.swift
@@ -127,15 +127,18 @@ final class ChatComposerUITextView: UITextView {
         _ keyCode: UIKeyboardHIDUsage,
         modifierFlags: UIKeyModifierFlags) -> Bool
     {
+        let commandModifiers: UIKeyModifierFlags = [.shift, .control, .alternate, .command]
+        let activeModifiers = modifierFlags.intersection(commandModifiers)
         if keyCode == .keyboardReturnOrEnter,
-           modifierFlags.isEmpty || modifierFlags == [.command]
+           activeModifiers.isEmpty || activeModifiers == .command
         {
+            // Return confirms provisional IME text before it can submit a draft.
+            guard self.markedTextRange == nil else { return false }
             self.onSend?()
             return true
         }
 
-        let commandModifiers: UIKeyModifierFlags = [.shift, .control, .alternate, .command]
-        guard modifierFlags.isDisjoint(with: commandModifiers) else { return false }
+        guard activeModifiers.isEmpty else { return false }
         switch keyCode {
         case .keyboardUpArrow:
             return self.onHistoryUp?(self.caretOnFirstLine) == true

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposerTextViewIOS.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposerTextViewIOS.swift
@@ -10,6 +10,7 @@ struct ChatComposerTextViewIOS: UIViewRepresentable {
     var minHeight: CGFloat
     var maxHeight: CGFloat
     var onFocusChange: (Bool) -> Void
+    var onSend: () -> Void
     var onHistoryUp: (Bool) -> Bool
     var onHistoryDown: () -> Bool
 
@@ -21,6 +22,7 @@ struct ChatComposerTextViewIOS: UIViewRepresentable {
         let textView = ChatComposerTextViewIOSFactory.makeConfiguredTextView()
         textView.delegate = context.coordinator
         textView.text = self.text
+        textView.onSend = self.onSend
         self.configureHistoryHandlers(textView)
         return textView
     }
@@ -29,6 +31,7 @@ struct ChatComposerTextViewIOS: UIViewRepresentable {
         context.coordinator.parent = self
         textView.isEditable = self.isEnabled
         textView.isSelectable = self.isEnabled
+        textView.onSend = self.onSend
         self.configureHistoryHandlers(textView)
 
         // UIKit owns user-initiated focus. A false focus request is not a blur request;
@@ -103,6 +106,7 @@ struct ChatComposerTextViewIOS: UIViewRepresentable {
 
 @MainActor
 final class ChatComposerUITextView: UITextView {
+    var onSend: (() -> Void)?
     var onHistoryUp: ((Bool) -> Bool)?
     var onHistoryDown: (() -> Bool)?
 
@@ -123,6 +127,13 @@ final class ChatComposerUITextView: UITextView {
         _ keyCode: UIKeyboardHIDUsage,
         modifierFlags: UIKeyModifierFlags) -> Bool
     {
+        if keyCode == .keyboardReturnOrEnter,
+           modifierFlags.isEmpty || modifierFlags == [.command]
+        {
+            self.onSend?()
+            return true
+        }
+
         let commandModifiers: UIKeyModifierFlags = [.shift, .control, .alternate, .command]
         guard modifierFlags.isDisjoint(with: commandModifiers) else { return false }
         switch keyCode {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewIOSTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewIOSTests.swift
@@ -69,13 +69,32 @@ struct ChatComposerTextViewIOSTests {
 
         #expect(textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: []))
         #expect(textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: [.command]))
-        #expect(sendCalls == 2)
+        #expect(textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: .alphaShift))
+        #expect(textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: [.command, .alphaShift]))
+        #expect(sendCalls == 4)
 
         #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: .shift))
         #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: .control))
         #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: .alternate))
         #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: [.command, .shift]))
-        #expect(sendCalls == 2)
+        #expect(sendCalls == 4)
+    }
+
+    @Test func physicalReturnPreservesMarkedTextUntilCompositionCompletes() {
+        let textView = ChatComposerTextViewIOSFactory.makeConfiguredTextView()
+        var sendCalls = 0
+        textView.onSend = { sendCalls += 1 }
+        textView.setMarkedText("draft", selectedRange: NSRange(location: 5, length: 0))
+
+        #expect(textView.markedTextRange != nil)
+        #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: []))
+        #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: .command))
+        #expect(sendCalls == 0)
+        #expect(textView.text == "draft")
+
+        textView.unmarkText()
+        #expect(textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: []))
+        #expect(sendCalls == 1)
     }
 }
 #endif

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewIOSTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewIOSTests.swift
@@ -60,7 +60,22 @@ struct ChatComposerTextViewIOSTests {
         #expect(downCalls == 1)
         #expect(!textView.handleHardwareKey(.keyboardUpArrow, modifierFlags: .shift))
         #expect(textView.handleHardwareKey(.keyboardUpArrow, modifierFlags: .alphaShift))
-        #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: []))
+    }
+
+    @Test func physicalReturnKeysSendOnlyForBareAndCommandModifiers() {
+        let textView = ChatComposerTextViewIOSFactory.makeConfiguredTextView()
+        var sendCalls = 0
+        textView.onSend = { sendCalls += 1 }
+
+        #expect(textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: []))
+        #expect(textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: [.command]))
+        #expect(sendCalls == 2)
+
+        #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: .shift))
+        #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: .control))
+        #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: .alternate))
+        #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: [.command, .shift]))
+        #expect(sendCalls == 2)
     }
 }
 #endif

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewIOSTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewIOSTests.swift
@@ -62,38 +62,58 @@ struct ChatComposerTextViewIOSTests {
         #expect(textView.handleHardwareKey(.keyboardUpArrow, modifierFlags: .alphaShift))
     }
 
-    @Test func physicalReturnKeysSendOnlyForBareAndCommandModifiers() {
+    @Test func registeredReturnCommandsSendOnlyForBareAndCommandModifiers() throws {
         let textView = ChatComposerTextViewIOSFactory.makeConfiguredTextView()
         var sendCalls = 0
         textView.onSend = { sendCalls += 1 }
 
-        #expect(textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: []))
-        #expect(textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: [.command]))
-        #expect(textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: .alphaShift))
-        #expect(textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: [.command, .alphaShift]))
-        #expect(sendCalls == 4)
+        let sendAction = #selector(ChatComposerUITextView.handleSendKeyCommand(_:))
+        let commands = try #require(textView.keyCommands)
+        let sendCommands = commands.filter { $0.action == sendAction }
+        #expect(sendCommands.count == 4)
+        #expect(sendCommands.compactMap(\.input) == ["\r", "\r", "\r", "\r"])
+        #expect(
+            sendCommands.map(\.modifierFlags) == [
+                [],
+                .command,
+                .numericPad,
+                [.command, .numericPad],
+            ])
+        #expect(sendCommands.allSatisfy(\.wantsPriorityOverSystemBehavior))
 
-        #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: .shift))
-        #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: .control))
-        #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: .alternate))
-        #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: [.command, .shift]))
+        for command in sendCommands {
+            textView.handleSendKeyCommand(command)
+        }
         #expect(sendCalls == 4)
     }
 
-    @Test func physicalReturnPreservesMarkedTextUntilCompositionCompletes() {
+    @Test func physicalReturnPreservesMarkedTextUntilCompositionCompletes() throws {
         let textView = ChatComposerTextViewIOSFactory.makeConfiguredTextView()
         var sendCalls = 0
         textView.onSend = { sendCalls += 1 }
         textView.setMarkedText("draft", selectedRange: NSRange(location: 5, length: 0))
 
         #expect(textView.markedTextRange != nil)
-        #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: []))
-        #expect(!textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: .command))
+        let sendAction = #selector(ChatComposerUITextView.handleSendKeyCommand(_:))
+        #expect(textView.keyCommands?.contains { $0.action == sendAction } == false)
+        #expect(
+            !textView.canPerformAction(
+                sendAction,
+                withSender: nil))
+        textView.handleSendKeyCommand(
+            UIKeyCommand(
+                input: "\r",
+                modifierFlags: [],
+                action: #selector(ChatComposerUITextView.handleSendKeyCommand(_:))))
         #expect(sendCalls == 0)
         #expect(textView.text == "draft")
 
         textView.unmarkText()
-        #expect(textView.handleHardwareKey(.keyboardReturnOrEnter, modifierFlags: []))
+        let commands = try #require(textView.keyCommands)
+        let sendCommand = try #require(commands.first { $0.action == sendAction })
+        #expect(commands.filter { $0.action == sendAction }.count == 4)
+        #expect(textView.canPerformAction(sendAction, withSender: nil))
+        textView.handleSendKeyCommand(sendCommand)
         #expect(sendCalls == 1)
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewIOSTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewIOSTests.swift
@@ -79,9 +79,8 @@ struct ChatComposerTextViewIOSTests {
                 .numericPad,
                 [.command, .numericPad],
             ])
-        #expect(sendCommands.allSatisfy(\.wantsPriorityOverSystemBehavior))
-
         for command in sendCommands {
+            #expect(command.wantsPriorityOverSystemBehavior)
             textView.handleSendKeyCommand(command)
         }
         #expect(sendCalls == 4)


### PR DESCRIPTION
Closes #138614

## What Problem This Solves

iPad users with a Bluetooth or hardware keyboard cannot submit a chat draft with Return or Cmd-Return. The iOS composer currently leaves those hardware key presses to UIKit, so users must reach for the on-screen send button even when the draft is ready.

## Why This Change Was Made

Route bare Return and Cmd-Return through the existing iOS composer responder and call the same `sendDraftIfEnabled()` guard used by the send button. Priority UIKeyCommands handle bare, Command, numeric-keypad, and Command+numeric-keypad Return while preserving inherited commands. Return during marked IME composition stays with UIKit so it can confirm provisional text without submitting the draft. Other modified Return combinations remain unhandled so UIKit preserves multiline editing, including Shift-Return.

## User Impact

Hardware-keyboard users can send an iOS chat draft with Return or Cmd-Return. Shift-Return, Control-Return, Option-Return, and other modified Return combinations continue to edit the draft instead of sending it. Existing send eligibility checks remain authoritative.

## Evidence

- Issue acceptance: #138614 requests Return/Cmd-Return submission and preservation of modified Return behavior for hardware-keyboard users.
- Source inspection at base `6e82d8aa095e2daf1eaa20415c89e90aa976bc2a`: the responder has no Return dispatch branch, and the existing test expects that key to be unhandled. This is source evidence, not an executed acceptance-red run.
- Current proposed coverage: responder tests inspect the registered Return command variants, priority, and marked-composition guards. UI tests read back the sent message/fixture response, preserve Shift-Return editing, and retain a draft during an active run. The original software-newline UI test remains selected. Current-head acceptance-green remains unverified; parent-head execution is reported below.
- Existing-solutions preflight: UIKit's existing `UITextView` responder and OpenClaw's existing `sendDraftIfEnabled()` path are the canonical seams; no new dependency, plugin, protocol, or configuration is needed.
- Exact candidate: `4032f8370d7f353c9e6efc04de59b76a0d34a606` against base `6e82d8aa095e2daf1eaa20415c89e90aa976bc2a`.
- Historical full-candidate review: parent `dc635046c17de7deb9ea027cd7b17e4885b2ee6a` passed autoreview against base `6e82d8aa095e2daf1eaa20415c89e90aa976bc2a` with `--max-priority P3`. That review did not establish native acceptance, and its two subsequent UI failures motivated the current repair. The fresh repair-scope review is reported below.
- Local checks: `git diff --check` passed. Structured YAML parsing verified the iOS test source registration and the four focused CI test selections.
- Xcode proof: not run locally because the available Mac has only Command Line Tools and no Xcode/simulator runtime. The earlier head's CI is not proof for this correction. The existing iOS CI lane now explicitly selects the responder tests and all three composer UI scenarios; successful execution and artifact inspection on the exact candidate are still required. No production OpenClaw instance was changed.

### Current-Head Native Verification Status

- Current source head: `4032f8370d7f353c9e6efc04de59b76a0d34a606`. Production dispatch remains the two-file repair at `409ea90c4e2cf158a826464eb79608ad703c748f`. Parent `6c6ca70e4b152e3fd777b573db0ff39907be293d` repaired the responder-test macro; the current commit changes only the CI test device selection.
- Executed acceptance-red on parent `dc635046c17de7deb9ea027cd7b17e4885b2ee6a`: [iOS CI run 33942336125](https://github.com/openclaw/openclaw/actions/runs/33942336125), test job 101242401978. The two newly selected hardware-keyboard UI tests failed to submit the draft/start the held run. The responder unit suite and the existing software-newline UI test passed; those passes did not prove the hardware user flow.
- Correction: use UIKit priority key commands instead of relying on Return reaching `pressesBegan`. Keep inherited commands, omit send commands during marked composition, guard both action validation and execution, and retain the existing `sendDraftIfEnabled()` owner. Arrow-key handling remains unchanged. [Apple priority-key-command contract](https://developer.apple.com/documentation/uikit/uikeycommand/wantspriorityoversystembehavior).
- Pre-commit repair review: fresh `--mode local --base dc635046c17de7deb9ea027cd7b17e4885b2ee6a --max-priority P3`, scoped-clean, no accepted/actionable findings. `git diff --cached --check` passed. This is a repair-scope review, not a new claim of native acceptance-green.
- Both previously failing UI assertions remain selected in CI. Native execution on this new head and physical-keyboard behavior are not yet verified. No Xcode/simulator is installed on the available Mac; no production instance or channel was modified.

- Native CI follow-up: [run 33944978261](https://github.com/openclaw/openclaw/actions/runs/33944978261) on parent `409ea90c4e2cf158a826464eb79608ad703c748f` passed Release compilation but failed test compilation before any new UI acceptance ran. Xcode 26.6's Swift Testing macro expansion of the key-path `allSatisfy` assertion produced an unhandled `rethrows` diagnostic at responder-test line 82. Current head checks the identical priority property for each of the four commands in the existing dispatch loop. No production change or removed assertion.
- Fresh P0-P3 autoreview of this one-file test repair: scoped-clean, no accepted/actionable findings; `git diff --cached --check` passed. New-head native CI remains required; neither the parent Release build nor this review is acceptance-green.
- Independent platform-contract check succeeded on September 5, 2026: [Apple's machine-readable priority-key-command documentation](https://developer.apple.com/documentation/uikit/uikeycommand/wantspriorityoversystembehavior.md) documents text/focus-first physical-keyboard dispatch on iOS 15+, and reverses the priority when this property is true. This resolves the source-contract lookup gap, not the native-execution gap.

### iPad Automation Follow-up

- Executed [CI run 33945928525](https://github.com/openclaw/openclaw/actions/runs/33945928525), head `6c6ca70e4b152e3fd777b573db0ff39907be293d`: Debug and Release builds passed. Native test job `101252219329` compiled and passed responder/IME coverage, but both hardware Return UI scenarios still failed on the selected iPhone simulator. The software-newline UI scenario passed. Artifact `9963706499` contains the native test results; this run is not acceptance-green.
- The [Apple XCUIElement documentation](https://developer.apple.com/documentation/xcuiautomation/xcuielement) describes keyboard/mouse automation for macOS and iPadOS 15+. The issue is an iPad hardware-keyboard flow, but the original CI selection used an iPhone. This establishes a test-device mismatch to investigate, not proof that the production behavior works on iPad.
- Current workflow keeps the existing iPhone lifecycle, Watch UI, and software-newline selections. Only the two hardware-key scenarios move to a separate, serial iPad invocation inside the same existing job/step. No test assertion, production code, runner count, concurrency, permission, or test skip is changed. Missing iPad availability fails explicitly; the new xcresult is covered by the existing artifact upload glob.
- Validation: full workflow YAML parse; unchanged job keys, runner, and matrix assertions; `bash -n` on the complete lifecycle step; test-partition and result-upload assertions; no-iPad failure-path probe; `oxfmt --check .github/workflows/ci.yml`; `git diff --check`. All passed. Fresh P0-P3 autoreview of this workflow-only repair was scoped-clean, no findings. Full actionlint and native simulator execution were not available locally.
- Follow-up size: one existing workflow file, +25/-0; production and test assertion LOC unchanged. Exact-head [native job 101257373682](https://github.com/openclaw/openclaw/actions/runs/33947941144/job/101257373682) completed on September 5, 2026 with failure. Both hardware Return scenarios executed on iPad Pro 13-inch (M5), iOS 26.4, and still failed: the first draft did not clear after Return, and the active-run scenario did not reach Stop response after its first Return. The software-newline UI case and marked-text/IME unit coverage passed. [Artifact 9964261687](https://github.com/openclaw/openclaw/actions/runs/33947941144/artifacts/9964261687) includes `OpenClawHardwareReturnUITests.xcresult`. The device change therefore did not establish acceptance-green. The two failing acceptance tests have not been weakened or removed. Further input-event diagnosis needs an interactive Xcode/simulator environment; no additional speculative production change is claimed.

## Scope And Compatibility

- Changed files: 6. The additional project/CI files register and actually select the changed-surface tests; no new runner or job is introduced.
- Production LOC: +44/-1; test/UI-test LOC: +121/-1; project/CI LOC: +31/-0; total: +196/-2. The production growth connects the existing send owner to native key dispatch and protects marked composition, without a second send path.
- No config, storage, protocol, dependency, migration, or security surface changes.
- Existing composer send guards and UIKit handling for non-send Return modifiers remain unchanged.

## Known Limitations

This submission does not include a physical Magic Keyboard trace or an executed before/after iOS acceptance run. The new tests are proposed coverage, not proof of a passing user flow. Verification remains the contributor's responsibility.

## AI Disclosure

Implementation and validation were prepared with OpenAI Codex. No raw or secret-bearing session transcript is included.
