### PR TITLE
refactor(logbook): type reads and bound observation queries

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -622,7 +622,7 @@ extensions/logbook/src/analyze.ts	8
 extensions/logbook/src/config.ts	1
 extensions/logbook/src/node-host.ts	1
 extensions/logbook/src/service.ts	6
-extensions/logbook/src/store.ts	17
+extensions/logbook/src/store.ts	6
 extensions/matrix/src/actions.ts	3
 extensions/matrix/src/approval-auth.ts	1
 extensions/matrix/src/approval-handler.runtime.ts	8

--- a/extensions/logbook/src/observation-reads.test.ts
+++ b/extensions/logbook/src/observation-reads.test.ts
@@ -1,0 +1,137 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, expect, it, vi } from "vitest";
+import { resolveLogbookConfig } from "./config.js";
+import { buildAskPrompt } from "./prompts.js";
+import { LogbookService } from "./service.js";
+import { LogbookStore } from "./store.js";
+
+const reads = vi.hoisted(() => ({ rows: 0 }));
+
+vi.mock("openclaw/plugin-sdk/sqlite-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/sqlite-runtime")>();
+  return {
+    ...actual,
+    openNodeSqliteDatabase: (...args: Parameters<typeof actual.openNodeSqliteDatabase>) => {
+      const db = actual.openNodeSqliteDatabase(...args);
+      const prepare = db.prepare.bind(db);
+      vi.spyOn(db, "prepare").mockImplementation((sql) => {
+        const statement = prepare(sql);
+        if (!/\bfrom\s+"?observations\b/i.test(sql)) {
+          return statement;
+        }
+        const all = statement.all.bind(statement);
+        vi.spyOn(statement, "all").mockImplementation((...bindings) => {
+          const rows = all(...bindings);
+          reads.rows += rows.length;
+          return rows;
+        });
+        const iterate = statement.iterate.bind(statement);
+        vi.spyOn(statement, "iterate").mockImplementation(function* (...bindings) {
+          for (const row of iterate(...bindings)) {
+            reads.rows++;
+            yield row;
+          }
+          return undefined;
+        });
+        return statement;
+      });
+      return db;
+    },
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+it.each([0, 199, 200, 201])(
+  "asks with the same latest observations while reading at most 200 of %i rows",
+  async (count) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-03T12:00:00"));
+    const dataDir = mkdtempSync(path.join(tmpdir(), "logbook-observation-reads-"));
+    const day = "2026-07-03";
+    const store = new LogbookStore(dataDir);
+    const segments = Array.from({ length: count }, (_, index) => ({
+      startMs: 1 + Math.floor(index / 3) * 1000,
+      endMs: 1001 + Math.floor(index / 3) * 1000,
+      text: `Observation ${index} 🦞`,
+    }));
+    const seedBatch = (batchDay: string) => {
+      const frameId = store.insertFrame({
+        capturedAtMs: Date.now(),
+        day: batchDay,
+        path: path.join(dataDir, "synthetic.jpg"),
+        screenIndex: 0,
+        byteSize: 0,
+        contentHash: "synthetic",
+        idle: false,
+      });
+      return store.createBatch({
+        day: batchDay,
+        startMs: 1,
+        endMs: Number.MAX_SAFE_INTEGER,
+        frameIds: [frameId],
+      });
+    };
+    const batchId = seedBatch(day);
+    store.replaceObservations(batchId, day, [
+      ...segments,
+      { startMs: -10, endMs: 0, text: "Excluded end boundary" },
+      {
+        startMs: Number.MAX_SAFE_INTEGER,
+        endMs: Number.MAX_SAFE_INTEGER,
+        text: "Excluded start boundary",
+      },
+    ]);
+    store.replaceObservations(seedBatch("2026-07-04"), "2026-07-04", [
+      { startMs: 1, endMs: 2, text: "Excluded day" },
+    ]);
+    store.close();
+    const runtime = createPluginRuntimeMock();
+    const complete = vi.fn<OpenClawPluginApi["runtime"]["llm"]["complete"]>(async () => ({
+      text: "Synthetic answer",
+      provider: "synthetic",
+      model: "synthetic",
+      agentId: "main",
+      usage: {},
+      execution: { mode: "direct-provider", owner: { kind: "provider", id: "synthetic" } },
+      audit: { caller: { kind: "plugin", id: "logbook" } },
+    }));
+    runtime.llm.complete = complete;
+    const service = new LogbookService(resolveLogbookConfig({ captureEnabled: false }), {
+      dataDir,
+      runtime,
+      fullConfig: {},
+      logger: { info() {}, warn() {}, error() {}, debug() {} },
+    });
+    service.start();
+    try {
+      reads.rows = 0;
+      expect(await service.ask(day, "What happened?")).toBe("Synthetic answer");
+      expect(complete).toHaveBeenCalledTimes(1);
+      expect(complete.mock.calls[0]?.[0].messages).toEqual([
+        {
+          role: "user",
+          content: buildAskPrompt({
+            day,
+            cards: [],
+            observations: segments
+              .map((segment, index) => Object.assign({ id: index + 1, batchId, day }, segment))
+              .slice(-200),
+            question: "What happened?",
+          }),
+        },
+      ]);
+      expect(reads.rows).toBe(Math.min(count, 200));
+    } finally {
+      await Promise.resolve(service.stop());
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  },
+);

--- a/extensions/logbook/src/service.ts
+++ b/extensions/logbook/src/service.ts
@@ -614,7 +614,7 @@ export class LogbookService {
 
   async ask(day: string, question: string): Promise<string> {
     const store = this.requireStore();
-    const observations = store.observationsInRange(day, 0, Number.MAX_SAFE_INTEGER).slice(-200);
+    const observations = store.observationsInRange(day, 0, Number.MAX_SAFE_INTEGER, 200);
     const result = await this.deps.runtime.llm.complete({
       messages: [
         {

--- a/extensions/logbook/src/store.ts
+++ b/extensions/logbook/src/store.ts
@@ -18,6 +18,7 @@ import type {
   LogbookBatchStatus,
   LogbookCard,
   LogbookCardDraft,
+  LogbookDatabase,
   LogbookDayStats,
   LogbookDistraction,
   LogbookFrame,
@@ -93,44 +94,8 @@ CREATE TABLE IF NOT EXISTS standups (
 ) STRICT;
 `;
 
-type FrameRow = {
-  id: number;
-  captured_at_ms: number;
-  day: string;
-  path: string;
-  screen_index: number;
-  width: number | null;
-  height: number | null;
-  byte_size: number;
-  idle: number;
-};
-
-type BatchRow = {
-  id: number;
-  day: string;
-  start_ms: number;
-  end_ms: number;
-  status: LogbookBatchStatus;
-  error: string | null;
-  frame_count: number;
-  model: string | null;
-};
-
-type CardRow = {
-  id: number;
-  day: string;
-  start_ms: number;
-  end_ms: number;
-  title: string;
-  summary: string;
-  detail: string;
-  category: string;
-  app_primary: string | null;
-  app_secondary: string | null;
-  distractions: string;
-  keyframe_id: number | null;
-  updated_ms: number;
-};
+type FrameRow = Omit<LogbookDatabase["frames"], "content_hash" | "batch_id">;
+type BatchRow = Omit<LogbookDatabase["batches"], "created_ms" | "updated_ms">;
 
 function toFrame(row: FrameRow): LogbookFrame {
   return {
@@ -178,7 +143,7 @@ function parseDistractions(raw: string): LogbookDistraction[] {
   }
 }
 
-function toCard(row: CardRow): LogbookCard {
+function toCard(row: LogbookDatabase["cards"]): LogbookCard {
   return {
     id: row.id,
     day: row.day,
@@ -205,6 +170,9 @@ export function dayKeyFor(ms: number): string {
 
 export class LogbookStore {
   private readonly db: Database;
+  private readonly query;
+  private readonly framesQuery;
+  private readonly batchesQuery;
   private readonly cardsQuery;
   private readonly walMaintenance: ReturnType<typeof configureSqliteConnectionPragmas>;
   readonly framesDir: string;
@@ -255,7 +223,27 @@ export class LogbookStore {
     }
     this.db = db;
     this.walMaintenance = walMaintenance;
-    this.cardsQuery = getNodeSqliteKysely<{ cards: CardRow }>(db).selectFrom("cards");
+    this.query = getNodeSqliteKysely<LogbookDatabase>(db);
+    // Timestamp ties follow insertion ids, matching existing SQLite reads.
+    this.framesQuery = this.query
+      .selectFrom("frames")
+      .select([
+        "id",
+        "captured_at_ms",
+        "day",
+        "path",
+        "screen_index",
+        "width",
+        "height",
+        "byte_size",
+        "idle",
+      ])
+      .orderBy("captured_at_ms", "asc")
+      .orderBy("id", "asc");
+    this.batchesQuery = this.query
+      .selectFrom("batches")
+      .select(["id", "day", "start_ms", "end_ms", "status", "error", "frame_count", "model"]);
+    this.cardsQuery = this.query.selectFrom("cards");
   }
 
   close(): void {
@@ -298,51 +286,47 @@ export class LogbookStore {
   }
 
   lastFrame(): { capturedAtMs: number; contentHash: string } | null {
-    const row = this.db
-      .prepare(
-        `SELECT captured_at_ms, content_hash FROM frames ORDER BY captured_at_ms DESC LIMIT 1`,
-      )
-      .get() as { captured_at_ms: number; content_hash: string } | undefined;
+    const row = executeSqliteQueryTakeFirstSync(
+      this.db,
+      this.query
+        .selectFrom("frames")
+        .select(["captured_at_ms", "content_hash"])
+        .orderBy("captured_at_ms", "desc")
+        .orderBy("id", "desc")
+        .limit(1),
+    );
     return row ? { capturedAtMs: row.captured_at_ms, contentHash: row.content_hash } : null;
   }
 
   unbatchedActiveFrames(limit: number): LogbookFrame[] {
-    const rows = this.db
-      .prepare(
-        `SELECT id, captured_at_ms, day, path, screen_index, width, height, byte_size, idle
-         FROM frames WHERE batch_id IS NULL AND idle = 0
-         ORDER BY captured_at_ms ASC LIMIT ?`,
-      )
-      .all(limit) as FrameRow[];
-    return rows.map(toFrame);
+    return executeSqliteQuerySync(
+      this.db,
+      this.framesQuery.where("batch_id", "is", null).where("idle", "=", 0).limit(limit),
+    ).rows.map(toFrame);
   }
 
   countUnbatchedActiveFrames(): number {
-    const row = this.db
-      .prepare(`SELECT COUNT(*) AS n FROM frames WHERE batch_id IS NULL AND idle = 0`)
-      .get() as { n: number };
-    return row.n;
+    const row = executeSqliteQueryTakeFirstSync(
+      this.db,
+      this.query
+        .selectFrom("frames")
+        .select((eb) => eb.fn.countAll<number>().as("n"))
+        .where("batch_id", "is", null)
+        .where("idle", "=", 0),
+    );
+    return expectDefined(row, "Logbook unbatched frame count").n;
   }
 
   frameById(id: number): LogbookFrame | null {
-    const row = this.db
-      .prepare(
-        `SELECT id, captured_at_ms, day, path, screen_index, width, height, byte_size, idle
-         FROM frames WHERE id = ?`,
-      )
-      .get(id) as FrameRow | undefined;
+    const row = executeSqliteQueryTakeFirstSync(this.db, this.framesQuery.where("id", "=", id));
     return row ? toFrame(row) : null;
   }
 
   framesInRange(startMs: number, endMs: number): LogbookFrame[] {
-    const rows = this.db
-      .prepare(
-        `SELECT id, captured_at_ms, day, path, screen_index, width, height, byte_size, idle
-         FROM frames WHERE captured_at_ms >= ? AND captured_at_ms < ?
-         ORDER BY captured_at_ms ASC`,
-      )
-      .all(startMs, endMs) as FrameRow[];
-    return rows.map(toFrame);
+    return executeSqliteQuerySync(
+      this.db,
+      this.framesQuery.where("captured_at_ms", ">=", startMs).where("captured_at_ms", "<", endMs),
+    ).rows.map(toFrame);
   }
 
   createBatch(params: { day: string; startMs: number; endMs: number; frameIds: number[] }): number {
@@ -399,12 +383,10 @@ export class LogbookStore {
   }
 
   latestBatch(): LogbookBatch | null {
-    const row = this.db
-      .prepare(
-        `SELECT id, day, start_ms, end_ms, status, error, frame_count, model
-         FROM batches ORDER BY id DESC LIMIT 1`,
-      )
-      .get() as BatchRow | undefined;
+    const row = executeSqliteQueryTakeFirstSync(
+      this.db,
+      this.batchesQuery.orderBy("id", "desc").limit(1),
+    );
     return row ? toBatch(row) : null;
   }
 
@@ -426,23 +408,22 @@ export class LogbookStore {
   }
 
   nextPendingBatch(): LogbookBatch | null {
-    const row = this.db
-      .prepare(
-        `SELECT id, day, start_ms, end_ms, status, error, frame_count, model
-         FROM batches WHERE status = 'pending' ORDER BY start_ms ASC LIMIT 1`,
-      )
-      .get() as BatchRow | undefined;
+    const row = executeSqliteQueryTakeFirstSync(
+      this.db,
+      this.batchesQuery
+        .where("status", "=", "pending")
+        .orderBy("start_ms", "asc")
+        .orderBy("id", "asc")
+        .limit(1),
+    );
     return row ? toBatch(row) : null;
   }
 
   batchFrames(batchId: number): LogbookFrame[] {
-    const rows = this.db
-      .prepare(
-        `SELECT id, captured_at_ms, day, path, screen_index, width, height, byte_size, idle
-         FROM frames WHERE batch_id = ? ORDER BY captured_at_ms ASC`,
-      )
-      .all(batchId) as FrameRow[];
-    return rows.map(toFrame);
+    return executeSqliteQuerySync(
+      this.db,
+      this.framesQuery.where("batch_id", "=", batchId),
+    ).rows.map(toFrame);
   }
 
   /**
@@ -475,20 +456,29 @@ export class LogbookStore {
     );
   }
 
-  observationsInRange(day: string, startMs: number, endMs: number): LogbookObservation[] {
-    const rows = this.db
-      .prepare(
-        `SELECT id, batch_id, day, start_ms, end_ms, text FROM observations
-         WHERE day = ? AND end_ms > ? AND start_ms < ? ORDER BY start_ms ASC`,
-      )
-      .all(day, startMs, endMs) as Array<{
-      id: number;
-      batch_id: number;
-      day: string;
-      start_ms: number;
-      end_ms: number;
-      text: string;
-    }>;
+  observationsInRange(
+    day: string,
+    startMs: number,
+    endMs: number,
+    tailLimit?: number,
+  ): LogbookObservation[] {
+    const direction = tailLimit === undefined ? "asc" : "desc";
+    let query = this.query
+      .selectFrom("observations")
+      .selectAll()
+      .where("day", "=", day)
+      .where("end_ms", ">", startMs)
+      .where("start_ms", "<", endMs)
+      .orderBy("start_ms", direction)
+      .orderBy("id", direction);
+    if (tailLimit !== undefined) {
+      query = query.limit(tailLimit);
+    }
+    const rows = executeSqliteQuerySync(this.db, query).rows;
+    // Reverse the stable timestamp/id tail so prompts keep their original chronology.
+    if (tailLimit !== undefined) {
+      rows.reverse();
+    }
     return rows.map((row) => ({
       id: row.id,
       batchId: row.batch_id,
@@ -500,7 +490,11 @@ export class LogbookStore {
   }
 
   cardsForDay(day: string, window?: { startMs: number; endMs: number }): LogbookCard[] {
-    let query = this.cardsQuery.selectAll().where("day", "=", day).orderBy("start_ms", "asc");
+    let query = this.cardsQuery
+      .selectAll()
+      .where("day", "=", day)
+      .orderBy("start_ms", "asc")
+      .orderBy("id", "asc");
     if (window) {
       query = query.where("end_ms", ">", window.startMs).where("start_ms", "<", window.endMs);
     }
@@ -564,13 +558,18 @@ export class LogbookStore {
   }
 
   listDays(): Array<{ day: string; cards: number; firstMs: number; lastMs: number }> {
-    const rows = this.db
-      .prepare(
-        `SELECT day, COUNT(*) AS cards, MIN(start_ms) AS first_ms, MAX(end_ms) AS last_ms
-         FROM cards GROUP BY day ORDER BY day DESC`,
-      )
-      .all() as Array<{ day: string; cards: number; first_ms: number; last_ms: number }>;
-    return rows.map((row) => ({
+    return executeSqliteQuerySync(
+      this.db,
+      this.cardsQuery
+        .select((eb) => [
+          "day",
+          eb.fn.countAll<number>().as("cards"),
+          eb.fn.min<number>("start_ms").as("first_ms"),
+          eb.fn.max<number>("end_ms").as("last_ms"),
+        ])
+        .groupBy("day")
+        .orderBy("day", "desc"),
+    ).rows.map((row) => ({
       day: row.day,
       cards: row.cards,
       firstMs: row.first_ms,
@@ -611,9 +610,10 @@ export class LogbookStore {
   }
 
   getStandup(day: string): { day: string; text: string; updatedMs: number } | null {
-    const row = this.db
-      .prepare(`SELECT day, text, updated_ms FROM standups WHERE day = ?`)
-      .get(day) as { day: string; text: string; updated_ms: number } | undefined;
+    const row = executeSqliteQueryTakeFirstSync(
+      this.db,
+      this.query.selectFrom("standups").selectAll().where("day", "=", day),
+    );
     return row ? { day: row.day, text: row.text, updatedMs: row.updated_ms } : null;
   }
 

--- a/extensions/logbook/src/types.ts
+++ b/extensions/logbook/src/types.ts
@@ -83,3 +83,55 @@ export type LogbookStatus = {
   todayCards: number;
   timeZone: string;
 };
+
+export type LogbookDatabase = {
+  frames: {
+    id: number;
+    captured_at_ms: number;
+    day: string;
+    path: string;
+    screen_index: number;
+    width: number | null;
+    height: number | null;
+    byte_size: number;
+    content_hash: string;
+    idle: number;
+    batch_id: number | null;
+  };
+  batches: {
+    id: number;
+    day: string;
+    start_ms: number;
+    end_ms: number;
+    status: LogbookBatchStatus;
+    error: string | null;
+    frame_count: number;
+    model: string | null;
+    created_ms: number;
+    updated_ms: number;
+  };
+  observations: {
+    id: number;
+    batch_id: number;
+    day: string;
+    start_ms: number;
+    end_ms: number;
+    text: string;
+  };
+  cards: {
+    id: number;
+    day: string;
+    start_ms: number;
+    end_ms: number;
+    title: string;
+    summary: string;
+    detail: string;
+    category: string;
+    app_primary: string | null;
+    app_secondary: string | null;
+    distractions: string;
+    keyframe_id: number | null;
+    updated_ms: number;
+  };
+  standups: { day: string; text: string; updated_ms: number };
+};


### PR DESCRIPTION
## What Problem This Solves

Logbook questions read every eligible observation, then retain only the latest 200 in JavaScript. Other ordinary reads repeat handwritten SQL and row assertions despite the existing Kysely boundary.

## Why This Change Was Made

Apply the existing 200-observation limit inside the store, selecting the same timestamp/id tail and restoring chronological prompt order. Move ordinary frame, batch, observation, standup and aggregate reads to the typed synchronous query helpers, with one Logbook table model and the original projections. Remove the service-side slice and redundant row assertions.

## User Impact

Questions about a busy day load only the observations already selected for the prompt. Timeline, status, capture, analysis and saved standup results remain unchanged. Explicit secondary ordering preserves the observed tie behavior. SQLite schemas, nine write/retention methods, stored formats, configuration and lifecycle are unchanged.

## Evidence

All 79 tests across eight Logbook files, the full changed-file gate and a fresh six-part independent Codex P0–P2 review passed on `3e5cbb5a03894f4341edbea536fd7d84047452ea`, after integration with the orderly drain merged in #138754. The 201-row regression fails on the original implementation because it reads 201 rows; both versions produce the same full prompt.

One runtime build and eight native phases passed. All 32 read cases and six full-prompt hashes match baseline, including tied timestamps, range boundaries, missing/NULL/zero values and negative frame limits. At 10,000 observations, reads fall to 200 rows / 23,001 serialized bytes from 10,000 rows / 1,141,124 bytes. The actual registered ask handler receives the exact full prompt and returns its answer. These are row/byte counts, not RSS or latency measurements.

Batch reassignment and observation/card replacement rollback, retry, six held operations, registry retirement and two reentrant stop cases pass, with ten independent fresh-process integrity/FK readbacks. The real Gateway serves 64 synthetic cards over two days with identical status, days, timeline and raw rows after restart. Capture is disabled; completion boundaries are synthetic. Full Gateway payload hash: `1b833355758a329768b48fc2411227ddc9d17513e52a92ad34d0dcd2cf2ccc75`. All owned state, processes and listeners were removed.

Production +52 lines supplies the canonical table types; the store itself is net neutral. Tests +137; assertion allowances shrink 17 to 6. Prepare-once writers remain separate because a mechanical conversion through the generic executor would increase native preparations. This PR preserves orderly drain and does not implement cancellation. The changed gate reported one warning-only existing test temporary-directory style advisory; cleanup was verified.
