### PR TITLE
test: clarify live CLI announcement completion intent

### DIFF
--- a/src/gateway/gateway-cli-backend.live-cache.test-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-cache.test-helpers.ts
@@ -288,6 +288,8 @@ export async function verifyCliBackendAnnounceOrdering({
         `Call sessions_spawn exactly once with taskName=cli_announce_${announceNonce.toLowerCase()} and task=${JSON.stringify(`Reply exactly ${announceChildToken} and nothing else.`)}.`,
         `After sessions_spawn returns status=accepted, call ${CLI_ANNOUNCE_BARRIER_TOOL_NAME} exactly once with no arguments.`,
         `After that tool returns, reply exactly ${announceParentToken}.`,
+        "That first reply is only an acknowledgment. My request remains open until I receive the child result.",
+        `When the completion event arrives afterward, reply exactly ${announceChildToken}; I have not received that result yet.`,
       ].join("\n"),
     },
     { expectFinal: true, timeoutMs: requestTimeoutMs },


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full release verification stopped in the Claude CLI announcement check even though the model completed the parent and child turns. The fixture asked for an acknowledgment, then expected a later child-result reply that its user request had never required.

## Why This Change Was Made

Clarify that the first marker is only an acknowledgment and that the request remains open until the child result arrives. The existing barrier, delivery receipts, committed-history ordering, cache-hit thresholds, and process-generation checks remain unchanged. Production code is unchanged.

## User Impact

No product behavior changes. Release verification can exercise the intended busy-parent announcement flow and continue into the Claude cache and thinking-level checks.

## Evidence

- Original failure: [Full Release Validation live CLI cache job](https://github.com/openclaw/openclaw/actions/runs/33936472739/job/101227227277), waiting for the delivered announcement at `gateway-cli-backend.live-cache.test-helpers.ts:328` after a `NO_REPLY` completion.
- Reproduced on frozen source `d3ebbd01d60ed316f2cefd7734f911039969ceb6` with Claude CLI 2.1.261, Linux Node 24.19.0, and the existing API-key auth path in [Testbox run 33939504345](https://github.com/openclaw/openclaw/actions/runs/33939504345). The unchanged fixture failed in 517.18 seconds. A temporary prompt capture confirmed the resumed history contained only the completed acknowledgment request; the capture was removed before candidate proof.
- The two-line fixture change passed the same full live test in 102.46 seconds: child completion was delivered after the parent reply and appeared at history index 1 after parent index 0. Both steady cache checks reached 99.65%; thinking changes rotated the native process and the next steady turn reused its new cache prefix.
- Command: `pnpm test:live -- src/gateway/gateway-cli-backend.live.test.ts`, with the existing Claude cache-probe, API-key, model, and MCP settings used by the live Docker lane. No timeout or assertion limits changed. Frozen install and full `pnpm build` passed before both runs.
- The native Testbox command wrapper returned a shell-postlude syntax error after the candidate test passed; evidence/check commands trim the trailing command newline. This wrapper result is separate from the completed live test.

- Fresh isolated Codex review: no actionable P0–P2 findings. Targeted formatting and `git diff --check` passed.
- Static checks are pending: the remote changed gate passed guards and formatting, then lost SSH with exit255 during core-test typechecking; no successful result is claimed for that attempt. The full changed gate is running locally, and required PR CI must pass before merge.

Production delta: 0. Test support: +2 lines.

Follow-up: reconcile general late-completion silence guidance in `subagent-system-prompt.ts` and the sub-agent docs with the announcement owner's result-delivery rule. That spawn receipt was absent from the captured CLI wake, so changing it would not repair this fixture's missing request.
