### PR TITLE
fix(gateway): stop repeated teardown after WebSocket failures

### DIFF
--- a/src/gateway/server-broadcast.live-text.test.ts
+++ b/src/gateway/server-broadcast.live-text.test.ts
@@ -258,7 +258,7 @@ describe("connection live-text delivery", () => {
       } else {
         peer.complete(release === "send error" ? new Error("connection closed") : undefined);
       }
-      expect(getBufferedAmount(peer.client.connId)).toBe(0);
+      expect(getBufferedAmount(peer.client.connId)).toBe(release === "send error" ? undefined : 0);
       expect(getEventListeners(owner.signal, "abort")).toHaveLength(0);
       owner.abort();
       peer.complete();

--- a/src/gateway/server-broadcast.transport.test.ts
+++ b/src/gateway/server-broadcast.transport.test.ts
@@ -1,0 +1,226 @@
+import { getEventListeners, once } from "node:events";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import { createGatewayBroadcaster } from "./server-broadcast.js";
+import { WS_COMPRESSION_THRESHOLD_BYTES } from "./server-constants.js";
+import { GatewayClientRegistry } from "./server/client-registry.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
+import { TerminalOutputController } from "./terminal/output-flow-control.js";
+
+const sendError = vi.hoisted(() => vi.fn());
+vi.mock("../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "gateway/broadcast" ? { ...logger, error: sendError } : logger;
+    },
+  };
+});
+
+function clientFor(connId: string, socket: WebSocket): GatewayWsClient {
+  return {
+    connId,
+    socket,
+    connect: { role: "operator", scopes: ["operator.read"] } as GatewayWsClient["connect"],
+    usesSharedGatewayAuth: false,
+  };
+}
+
+function controlledPeer(connId: string) {
+  const callbacks: Array<(error?: Error) => void> = [];
+  const frames: Array<{ seq: number; payload: unknown }> = [];
+  const socket = {
+    readyState: WebSocket.OPEN,
+    bufferedAmount: 0,
+    close: vi.fn(),
+    terminate: vi.fn(),
+    send: vi.fn((wire: string, callback: (error?: Error) => void) => {
+      frames.push(JSON.parse(wire));
+      callbacks.push(callback);
+    }),
+  };
+  return { client: clientFor(connId, socket as unknown as WebSocket), socket, callbacks, frames };
+}
+
+const liveText = (group: AbortSignal) => ({
+  group,
+  coalesce: { key: "text", merge: (_previous: unknown, next: unknown) => next },
+});
+
+describe("broadcast transport retirement", () => {
+  it("settles a compressed queue failure once while healthy peers keep ordered delivery", async () => {
+    const server = new WebSocketServer({
+      host: "127.0.0.1",
+      port: 0,
+      perMessageDeflate: {
+        serverNoContextTakeover: true,
+        clientNoContextTakeover: true,
+        threshold: WS_COMPRESSION_THRESHOLD_BYTES,
+      },
+    });
+    await once(server, "listening");
+    const peers: WebSocket[] = [];
+    try {
+      const connect = async () => {
+        const accepted = once(server, "connection");
+        const peer = new WebSocket(`ws://127.0.0.1:${(server.address() as AddressInfo).port}`);
+        peers.push(peer);
+        await once(peer, "open");
+        const [socket] = (await accepted) as [WebSocket];
+        expect(socket.extensions).toBe("permessage-deflate");
+        return { peer, socket };
+      };
+      const broken = await connect();
+      const healthy = await connect();
+      const clients = new GatewayClientRegistry([
+        clientFor("compressed-broken", broken.socket),
+        clientFor("compressed-healthy", healthy.socket),
+      ]);
+      const { broadcast, getBufferedAmount } = createGatewayBroadcaster({ clients });
+      const received: Array<{ seq: number; payload: { index: number } }> = [];
+      healthy.peer.on("message", (data) => received.push(JSON.parse(data.toString())));
+      const owner = new AbortController();
+      sendError.mockClear();
+      const terminate = vi.spyOn(broken.socket, "terminate");
+      const payload = "x".repeat(WS_COMPRESSION_THRESHOLD_BYTES * 2);
+      for (let index = 0; index < 165; index += 1) {
+        broadcast("skills.changed", { index, payload });
+      }
+      broadcast("chat", { text: "pending" }, { liveText: liveText(owner.signal) });
+      expect(getEventListeners(owner.signal, "abort")).toHaveLength(2);
+      const closed = once(broken.peer, "close");
+      broken.socket.terminate();
+      await closed;
+      await vi.waitFor(() => expect(received).toHaveLength(166));
+      expect(received.map(({ seq }) => seq)).toEqual(
+        Array.from({ length: 166 }, (_, index) => index + 1),
+      );
+      expect(received.slice(0, 165).map(({ payload: value }) => value.index)).toEqual(
+        Array.from({ length: 165 }, (_, index) => index),
+      );
+      expect(sendError).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining("The socket was closed while data was being compressed"),
+        { event: "skills.changed" },
+      );
+      expect(terminate).toHaveBeenCalledTimes(2); // External close and one delivery retirement.
+      expect(getEventListeners(owner.signal, "abort")).toHaveLength(0);
+      expect(broken.socket.bufferedAmount).toBeGreaterThan(0);
+      expect(getBufferedAmount("compressed-broken")).toBeUndefined();
+    } finally {
+      peers.forEach((peer) => peer.terminate());
+      for (const socket of server.clients) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("keeps failed delivery terminal through late callbacks and permits a replacement socket", () => {
+    const retired = controlledPeer("replacement");
+    const replacement = controlledPeer("replacement");
+    const { broadcast, getBufferedAmount } = createGatewayBroadcaster({
+      clients: new GatewayClientRegistry([retired.client]),
+    });
+    const owner = new AbortController();
+    sendError.mockClear();
+    broadcast("tick", {});
+    broadcast("tick", {});
+    broadcast("tick", {});
+    broadcast("chat", { text: "old pending" }, { liveText: liveText(owner.signal) });
+    retired.callbacks[0]!(new Error("transport failed"));
+    // A transport may invoke callbacks synchronously before changing readyState.
+    broadcast("chat", { text: "after failure" }, { liveText: liveText(owner.signal) });
+    retired.callbacks[1]!();
+    retired.callbacks[0]!(new Error("duplicate callback"));
+    expect(retired.frames).toHaveLength(3);
+    expect(retired.socket.terminate).toHaveBeenCalledOnce();
+    expect(getBufferedAmount("replacement")).toBeUndefined();
+    expect(getEventListeners(owner.signal, "abort")).toHaveLength(0);
+    expect(sendError).toHaveBeenCalledOnce();
+
+    retired.client.socket = replacement.client.socket;
+    broadcast("chat", { text: "new socket" });
+    broadcast("chat", { text: "new pending" }, { liveText: liveText(owner.signal) });
+    retired.callbacks[2]!(new Error("late old failure"));
+    replacement.callbacks[0]!();
+    expect(replacement.frames).toEqual([
+      { type: "event", event: "chat", seq: 4, payload: { text: "new socket" } },
+      { type: "event", event: "chat", seq: 5, payload: { text: "new pending" } },
+    ]);
+    expect(replacement.socket.terminate).not.toHaveBeenCalled();
+    replacement.callbacks[1]!();
+    expect(getEventListeners(owner.signal, "abort")).toHaveLength(0);
+  });
+
+  it.each(["failed", "closing", "invalidated"] as const)(
+    "does not hold healthy terminal viewers paused for a %s peer's stale bytes",
+    (retirement) => {
+      const stale = controlledPeer("stale-pressure");
+      const healthy = controlledPeer("healthy-pressure");
+      const clients = new GatewayClientRegistry([stale.client, healthy.client]);
+      const { broadcast, getBufferedAmount } = createGatewayBroadcaster({ clients });
+      broadcast("tick", {});
+      stale.socket.bufferedAmount = 4 * 1024 * 1024;
+      const backend = { pause: vi.fn(), resume: vi.fn() };
+      const output = new TerminalOutputController({
+        backend,
+        getConnIds: () => [stale.client.connId, healthy.client.connId],
+        getBufferedAmount,
+        record: vi.fn(),
+        emit: vi.fn(),
+      });
+      try {
+        output.reconcileRecipients();
+        expect(backend.pause).toHaveBeenCalledOnce();
+        if (retirement === "failed") {
+          stale.callbacks[0]!(new Error("compression lost socket"));
+        } else if (retirement === "closing") {
+          stale.socket.readyState = WebSocket.CLOSING;
+        } else {
+          stale.client.invalidated = true;
+        }
+        expect(clients.has(stale.client)).toBe(true);
+        output.reconcileRecipients();
+        expect(backend.resume).toHaveBeenCalledOnce();
+        expect(getBufferedAmount(stale.client.connId)).toBeUndefined();
+      } finally {
+        output.dispose();
+      }
+    },
+  );
+
+  it.each(["callback", "throw"])(
+    "stops a terminal barrier when its pending flush fails by synchronous %s",
+    (failure) => {
+      const peer = controlledPeer("barrier");
+      const { broadcast } = createGatewayBroadcaster({
+        clients: new GatewayClientRegistry([peer.client]),
+      });
+      const owner = new AbortController();
+      broadcast("tick", {});
+      broadcast("chat", { text: "pending" }, { liveText: liveText(owner.signal) });
+      sendError.mockClear();
+      peer.socket.send.mockImplementationOnce((_wire, callback) => {
+        const error = new Error("flush failed");
+        if (failure === "throw") {
+          throw error;
+        }
+        callback(error);
+      });
+
+      broadcast("chat", { text: "terminal" }, { liveText: { group: owner.signal } });
+      peer.callbacks[0]!();
+
+      expect(peer.socket.send).toHaveBeenCalledTimes(2);
+      expect(peer.frames).toHaveLength(1);
+      expect(peer.socket.terminate).toHaveBeenCalledOnce();
+      expect(sendError).toHaveBeenCalledOnce();
+      expect(getEventListeners(owner.signal, "abort")).toHaveLength(0);
+    },
+  );
+});

--- a/src/gateway/server-broadcast.transport.test.ts
+++ b/src/gateway/server-broadcast.transport.test.ts
@@ -1,5 +1,6 @@
 import { getEventListeners, once } from "node:events";
 import type { AddressInfo } from "node:net";
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
@@ -32,7 +33,13 @@ function clientFor(connId: string, socket: WebSocket): GatewayWsClient {
 function controlledPeer(connId: string) {
   const callbacks: Array<(error?: Error) => void> = [];
   const frames: Array<{ seq: number; payload: unknown }> = [];
-  const socket = {
+  const socket: {
+    readyState: WebSocket["readyState"];
+    bufferedAmount: number;
+    close: ReturnType<typeof vi.fn>;
+    terminate: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn<(wire: string, callback: (error?: Error) => void) => void>>;
+  } = {
     readyState: WebSocket.OPEN,
     bufferedAmount: 0,
     close: vi.fn(),
@@ -81,7 +88,7 @@ describe("broadcast transport retirement", () => {
       ]);
       const { broadcast, getBufferedAmount } = createGatewayBroadcaster({ clients });
       const received: Array<{ seq: number; payload: { index: number } }> = [];
-      healthy.peer.on("message", (data) => received.push(JSON.parse(data.toString())));
+      healthy.peer.on("message", (data) => received.push(JSON.parse(rawDataToString(data))));
       const owner = new AbortController();
       sendError.mockClear();
       const terminate = vi.spyOn(broken.socket, "terminate");

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -233,6 +233,7 @@ type PendingLiveText = {
 };
 type ClientDelivery = {
   socket: GatewayWsClient["socket"];
+  retired: boolean;
   inFlight: number;
   draining: boolean;
   bytes: number;
@@ -266,6 +267,7 @@ export function createGatewayBroadcaster(params: {
       }
       state = {
         socket: client.socket,
+        retired: false,
         inFlight: 0,
         draining: false,
         bytes: 0,
@@ -301,7 +303,7 @@ export function createGatewayBroadcaster(params: {
     }
   };
   const drain = (state: ClientDelivery, group?: AbortSignal) => {
-    if (state.draining) {
+    if (state.retired || state.draining) {
       return;
     }
     state.draining = true;
@@ -462,6 +464,9 @@ export function createGatewayBroadcaster(params: {
       if (live && !live.coalesce) {
         drain(state, live.group);
       }
+      if (state.retired) {
+        continue;
+      }
       const nextSeq = (clientSeq.get(c) ?? 0) + 1;
       const bufferedAmount = bufferedBytes(state);
       const slow = bufferedAmount > MAX_BUFFERED_BYTES;
@@ -483,6 +488,8 @@ export function createGatewayBroadcaster(params: {
         continue;
       }
       if (slow) {
+        state.retired = true;
+        clearPending(state);
         try {
           c.socket.close(1008, "slow consumer");
         } catch {
@@ -593,11 +600,17 @@ export function createGatewayBroadcaster(params: {
         }
         finished = true;
         state.inFlight -= 1;
+        // ws fails every queued write when compression loses its socket. Settle
+        // each callback, but retire this delivery generation only once.
+        if (state.retired) {
+          return;
+        }
         if (err) {
+          state.retired = true;
+          clearPending(state);
           log.error(`broadcast send failed conn=${c.connId}: ${formatErrorMessage(err)}`, {
             event,
           });
-          clearPending(state);
           state.socket.terminate();
         } else {
           drain(state);
@@ -622,7 +635,12 @@ export function createGatewayBroadcaster(params: {
 
   const getBufferedAmount: GatewayBufferedAmountFn = (connId) => {
     const client = params.clients.getByConnectionId(connId);
-    return client ? bufferedBytes(deliveryFor(client)) : undefined;
+    if (!client || client.invalidated || client.socket.readyState !== WEBSOCKET_OPEN_READY_STATE) {
+      return undefined;
+    }
+    const state = deliveryFor(client);
+    // Failed compression retains ws's queued byte count after transport retirement.
+    return state.retired ? undefined : bufferedBytes(state);
   };
 
   const broadcastPluginEvent: GatewayPluginEventBroadcastFn = (event, payload, scope) => {

--- a/src/gateway/server-connection-state.test.ts
+++ b/src/gateway/server-connection-state.test.ts
@@ -114,6 +114,7 @@ describe("gateway connection state", () => {
     state.broadcastToConnIds("tick", { ts: 1 }, new Set(["target"]));
 
     expect(target.send).toHaveBeenCalledTimes(1);
+    expect(state.getBufferedAmount("target")).toBe(0);
     expect(reads.count).toBe(0);
 
     target.socket.readyState = WebSocket.CLOSING;
@@ -122,7 +123,7 @@ describe("gateway connection state", () => {
     expect(target.send).toHaveBeenCalledTimes(1);
 
     reads.count = 0;
-    expect(state.getBufferedAmount("target")).toBe(0);
+    expect(state.getBufferedAmount("target")).toBeUndefined();
     expect(state.isConnectionActive("target")).toBe(true);
     expect(reads.count).toBe(0);
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a WebSocket disconnect during compressed broadcasts repeatedly tears down the same failed connection and emits one error for every queued frame. The failed socket can also keep reporting stale send-buffer pressure to terminal co-viewers.

## Why This Change Was Made

The broadcaster owned per-send completion but lacked a terminal state for the connection's delivery generation. It now retires that generation once, releases pending text and listeners, and prevents further sends or drains after failure—including failure during a synchronous terminal-barrier flush. Each callback still settles its own in-flight write, and a replacement socket gets independent state.

The existing optional pressure getter reports unavailable for retired, closing, or invalidated connections. It preserves actual buffered-byte counts for live connections. Compression, recipient authorization, sequence accounting, byte limits, and coalescing policy remain unchanged.

## User Impact

A disconnected peer produces one failure diagnostic and cannot keep healthy terminal viewers paused through stale buffer counts. This fixes teardown amplification; it does not claim to explain every disconnect or remove all event-loop stalls.

## Evidence

- Real loopback WebSocket test with the pinned `ws@8.21.3`: 165 queued compressed broadcasts reproduce 165 error callbacks from one closed socket. The fixed broadcaster retires once, frees pending listeners, and preserves every healthy peer frame in order.
- Regression cases cover late successful and duplicate callbacks, an unfinished old-socket callback after replacement, synchronous callback/throw failures during a terminal barrier, and the actual terminal flow controller resuming healthy viewers when a failed/closing/invalidated peer still remains registered.
- Baseline failures were captured before each owning change. All 153 tests across seven broadcaster, connection-state, and terminal suites pass.
- Canonical `sourcePerformance` runtime build passes, including post-build and CLI bootstrap validation.
- [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33942585727) on `d313656ceccd069764c28542821c82a64b592057`; targeted lint and the canonical Gateway test type graph also pass.
- Independent P2 autoreview: no actionable findings. The latest ClawSweeper dependency-inspection gap is [resolved with exact upstream source and byte matches](https://github.com/openclaw/openclaw/pull/138818#issuecomment-5549185617).

Production LOC: +21/-3 (net +18), for the missing terminal delivery state and unavailable pressure projection. Test changes are separate. No schema, configuration, dependency, or protocol change.
