### PR TITLE
fix(codex): reject stale control commands after session rollover

### DIFF
--- a/extensions/codex/src/command-handler-actions.ts
+++ b/extensions/codex/src/command-handler-actions.ts
@@ -4,7 +4,7 @@ import {
   resolvePersistedSessionRuntimeId,
 } from "openclaw/plugin-sdk/model-session-runtime";
 import type { PluginCommandContext } from "openclaw/plugin-sdk/plugin-entry";
-import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveCodexBindingAppServerConnection } from "./app-server/binding-connection.js";
 import type { CodexComputerUseSetupParams } from "./app-server/computer-use.js";
@@ -17,7 +17,6 @@ import type {
   CodexAppServerBindingIdentity,
   CodexAppServerThreadBinding,
 } from "./app-server/session-binding.js";
-import { sessionBindingIdentity } from "./app-server/session-binding.js";
 import { isSameCodexAppServerThreadOwner } from "./app-server/thread-ownership.js";
 import { assertCodexSupervisionThreadLineage } from "./app-server/thread-policy.js";
 import {
@@ -36,7 +35,7 @@ import { isCurrentSessionModelSelectionLocked } from "./command-handler-bindings
 import { CODEX_CONTROL_METHODS, type CodexCommandDeps } from "./command-handler-deps.js";
 import {
   resolveCodexConversationControlScope,
-  resolveControlTarget,
+  resolvePreparedCodexCommandAuthority,
 } from "./command-handler-scope.js";
 import type { CodexControlRequestOptions } from "./command-rpc.js";
 import { parseCodexFastModeArg, parseCodexPermissionsModeArg } from "./conversation-control.js";
@@ -190,11 +189,11 @@ export async function handleNativeGoal(
 ): Promise<string> {
   const action = (args[0] ?? "status").toLowerCase();
   const objective = args.slice(1).join(" ").trim();
-  const target = await resolveControlTarget(ctx);
+  const authority = await resolvePreparedCodexCommandAuthority(deps, ctx);
+  const { target, binding } = authority;
   if (!target) {
     return "Cannot manage the Codex goal because this command has no stable binding identity.";
   }
-  const binding = deps.bindingStore.read(target.identity);
   if (!binding?.threadId) {
     return "No Codex thread is attached to this OpenClaw session yet.";
   }
@@ -207,6 +206,10 @@ export async function handleNativeGoal(
     agentDir: target.agentDir,
     authProfileId: connection.clientAuthProfileId,
     config: ctx.config,
+    sessionId: authority.sessionId,
+    sessionKey: authority.sessionKey,
+    storePath: authority.storePath,
+    assertCurrent: authority.assertCurrent,
     ...(connection.usesSupervisionConnection ? { startOptions: connection.appServer.start } : {}),
   };
   if (action === "status" || action === "get") {
@@ -296,17 +299,19 @@ export async function stopConversationTurn(
   ctx: PluginCommandContext,
   pluginConfig: unknown,
 ): Promise<string> {
-  const target = await resolveControlTarget(ctx);
+  const authority = await resolvePreparedCodexCommandAuthority(deps, ctx);
+  const { target, binding } = authority;
   if (!target) {
     return "Cannot stop Codex because this command did not include a stable binding identity.";
   }
   return (
     await deps.stopCodexConversationTurn({
       identity: target.identity,
-      bindingStore: deps.bindingStore,
+      binding,
       pluginConfig,
       agentDir: target.agentDir,
       config: ctx.config,
+      assertCurrent: authority.assertCurrent,
     })
   ).message;
 }
@@ -317,18 +322,20 @@ export async function steerConversationTurn(
   pluginConfig: unknown,
   message: string,
 ): Promise<string> {
-  const target = await resolveControlTarget(ctx);
+  const authority = await resolvePreparedCodexCommandAuthority(deps, ctx);
+  const { target, binding } = authority;
   if (!target) {
     return "Cannot steer Codex because this command did not include a stable binding identity.";
   }
   return (
     await deps.steerCodexConversationTurn({
       identity: target.identity,
-      bindingStore: deps.bindingStore,
+      binding,
       message,
       pluginConfig,
       agentDir: target.agentDir,
       config: ctx.config,
+      assertCurrent: authority.assertCurrent,
     })
   ).message;
 }
@@ -347,25 +354,26 @@ export async function setConversationModel(
   if (normalized && isCurrentSessionModelSelectionLocked(ctx)) {
     return MODEL_SELECTION_LOCKED_MESSAGE;
   }
-  const target = await resolveControlTarget(ctx);
+  const authority = await resolvePreparedCodexCommandAuthority(deps, ctx);
+  const { target, binding } = authority;
   if (!target) {
     return "Cannot set Codex model because this command did not include a stable binding identity.";
   }
   if (!normalized) {
     const currentSession =
-      ctx.sessionId && ctx.sessionKey
+      authority.sessionId && authority.sessionKey && authority.storePath
         ? getSessionEntry({
-            storePath: resolveStorePath(ctx.config.session?.store, { agentId: target.agentId }),
-            sessionKey: ctx.sessionKey,
+            storePath: authority.storePath,
+            sessionKey: authority.sessionKey,
             hydrateSkillPromptRefs: false,
             readConsistency: "latest",
           })
         : undefined;
     const selectedModel =
-      currentSession && currentSession.sessionId === ctx.sessionId
+      currentSession && currentSession.sessionId === authority.sessionId
         ? (currentSession.modelOverride ?? currentSession.model)
         : undefined;
-    const binding = deps.bindingStore.read(target.identity);
+    authority.assertCurrent();
     // Direct sessions report their desired selection; bound conversations
     // must never mistake an ambient outer-session model for native ownership.
     const activeModel =
@@ -381,6 +389,9 @@ export async function setConversationModel(
     model: normalized,
     agentDir: target.agentDir,
     config: ctx.config,
+    binding,
+    storePath: authority.storePath,
+    assertCurrent: authority.assertCurrent,
   });
 }
 
@@ -392,7 +403,8 @@ export async function setConversationFastMode(
   if (args.length > 1) {
     return "Usage: /codex fast [on|off|status]";
   }
-  const target = await resolveControlTarget(ctx);
+  const authority = await resolvePreparedCodexCommandAuthority(deps, ctx);
+  const { target, binding } = authority;
   if (!target) {
     return "Cannot set Codex fast mode because this command did not include a stable binding identity.";
   }
@@ -404,7 +416,9 @@ export async function setConversationFastMode(
   return await deps.setCodexConversationFastMode({
     identity: target.identity,
     bindingStore: deps.bindingStore,
+    binding,
     enabled: parsed,
+    assertCurrent: authority.assertCurrent,
   });
 }
 
@@ -416,7 +430,8 @@ export async function setConversationPermissions(
   if (args.length > 1) {
     return "Usage: /codex permissions [default|yolo|status]";
   }
-  const target = await resolveControlTarget(ctx);
+  const authority = await resolvePreparedCodexCommandAuthority(deps, ctx);
+  const { target } = authority;
   if (!target || !ctx.sessionId || !ctx.sessionKey) {
     return "Cannot set Codex permissions because this command did not include a complete session identity.";
   }
@@ -433,6 +448,8 @@ export async function setConversationPermissions(
   return await deps.setCodexConversationPermissions({
     mode: parsed,
     config: ctx.config,
+    storePath: authority.storePath,
+    assertCurrent: authority.assertHostCurrent,
     session: {
       agentId: target.agentId,
       sessionId: ctx.sessionId,
@@ -451,11 +468,11 @@ export async function startThreadAction(
   if (args.length > 0) {
     return `Usage: /codex ${kind}`;
   }
-  const target = await resolveControlTarget(ctx);
+  const authority = await resolvePreparedCodexCommandAuthority(deps, ctx);
+  const { target, binding } = authority;
   if (!target) {
     return `Cannot start Codex ${kind === "compact" ? "compaction" : "review"} because this command did not include a stable binding identity.`;
   }
-  const binding = deps.bindingStore.read(target.identity);
   if (!binding?.threadId) {
     return `No Codex thread is attached to this OpenClaw session yet.`;
   }
@@ -471,7 +488,7 @@ export async function startThreadAction(
       return "Codex compaction is unavailable because this command is not bound to a complete session identity.";
     }
     const currentSession = getSessionEntry({
-      storePath: sessionTarget.storePath,
+      storePath: authority.storePath ?? sessionTarget.storePath,
       sessionKey: ctx.sessionKey,
       hydrateSkillPromptRefs: false,
       readConsistency: "latest",
@@ -483,17 +500,7 @@ export async function startThreadAction(
       return "Codex compaction is unavailable because the current OpenClaw session is not using the Codex runtime.";
     }
     if (target.identity.kind === "conversation") {
-      const sessionBinding = ctx.sessionId
-        ? deps.bindingStore.read(
-            sessionBindingIdentity({
-              sessionId: ctx.sessionId,
-              sessionKey: ctx.sessionKey,
-              agentId: sessionTarget.agentId,
-              config: ctx.config,
-            }),
-          )
-        : undefined;
-      if (!isSameCodexAppServerThreadOwner(binding, sessionBinding)) {
+      if (!isSameCodexAppServerThreadOwner(binding, authority.currentSessionBinding)) {
         return "Codex compaction is unavailable because the conversation-bound thread differs from the current session binding. Resume that thread into the session first.";
       }
     }
@@ -501,6 +508,7 @@ export async function startThreadAction(
     if (!compactCurrent) {
       return "Codex compaction is unavailable because this command is not bound to a session.";
     }
+    authority.assertCurrent();
     const result = await compactCurrent();
     return result.compacted
       ? `Compacted Codex session (${result.tokensAfter ?? "unknown"} tokens after).`
@@ -520,6 +528,10 @@ export async function startThreadAction(
         agentDir: target.agentDir,
         authProfileId: connection.clientAuthProfileId,
         config: ctx.config,
+        sessionId: authority.sessionId,
+        sessionKey: authority.sessionKey,
+        storePath: authority.storePath,
+        assertCurrent: authority.assertCurrent,
         ...(connection.usesSupervisionConnection
           ? {
               startOptions: connection.appServer.start,

--- a/extensions/codex/src/command-handler-scope.ts
+++ b/extensions/codex/src/command-handler-scope.ts
@@ -1,11 +1,15 @@
+import { isDeepStrictEqual } from "node:util";
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import { resolveSessionAgentIdsStrict } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { PluginCommandContext } from "openclaw/plugin-sdk/plugin-entry";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveCodexAppServerAuthProfileIdForAgent } from "./app-server/auth-bridge.js";
 import { resolveCodexBindingAppServerConnection } from "./app-server/binding-connection.js";
 import {
+  resolveCodexSessionBinding,
   sessionBindingIdentity,
   type CodexAppServerBindingIdentity,
+  type CodexAppServerThreadBinding,
 } from "./app-server/session-binding.js";
 import type { CodexCommandDeps } from "./command-handler-deps.js";
 import type { CodexControlRequestOptions } from "./command-rpc.js";
@@ -48,18 +52,92 @@ export async function resolveControlTarget(
 
 type CommandAppServerScope = Pick<
   CodexControlRequestOptions,
-  "authProfileId" | "sessionId" | "sessionKey" | "startOptions"
+  "assertCurrent" | "authProfileId" | "sessionId" | "sessionKey" | "startOptions" | "storePath"
 > & { agentId: string; agentDir: string };
+
+export type PreparedCodexCommandAuthority = {
+  target: CodexConversationControlTarget | undefined;
+  binding: CodexAppServerThreadBinding | undefined;
+  currentSessionBinding: CodexAppServerThreadBinding | undefined;
+  sessionId: string | undefined;
+  sessionKey: string | undefined;
+  storePath: string | undefined;
+  assertHostCurrent: () => void;
+  assertCurrent: () => void;
+};
+
+export async function resolvePreparedCodexCommandAuthority(
+  deps: CodexCommandDeps,
+  ctx: PluginCommandContext,
+): Promise<PreparedCodexCommandAuthority> {
+  const target = await resolveControlTarget(ctx);
+  const fallback = resolveCodexConversationControlScope(ctx);
+  const sessionId = ctx.sessionId;
+  const sessionKey = ctx.sessionKey;
+  const sessionAgentId = ctx.sessionTarget?.agentId ?? fallback.agentId;
+  const storePath =
+    ctx.sessionTarget?.storePath ??
+    (sessionKey
+      ? resolveStorePath(ctx.config.session?.store, { agentId: sessionAgentId })
+      : undefined);
+  const sessionIdentity = sessionId
+    ? sessionBindingIdentity({
+        sessionId,
+        sessionKey,
+        agentId: sessionAgentId,
+        config: ctx.config,
+      })
+    : undefined;
+  const currentSession = sessionIdentity
+    ? await resolveCodexSessionBinding({
+        reclaimStale: true,
+        bindingStore: deps.bindingStore,
+        identity: sessionIdentity,
+        config: ctx.config,
+        storePath,
+      })
+    : undefined;
+  const assertHostCurrent = currentSession?.assertCurrent ?? (() => {});
+  const resolvedTarget =
+    target && (!sessionIdentity || !isDeepStrictEqual(target.identity, sessionIdentity))
+      ? await resolveCodexSessionBinding({
+          bindingStore: deps.bindingStore,
+          identity: target.identity,
+          config: ctx.config,
+          storePath,
+          assertCurrent: assertHostCurrent,
+        })
+      : currentSession;
+  const binding = resolvedTarget?.binding;
+  const assertCurrent = () => {
+    assertHostCurrent();
+    if (target && !isDeepStrictEqual(deps.bindingStore.read(target.identity), binding)) {
+      throw new Error("Codex command binding changed before dispatch");
+    }
+    assertHostCurrent();
+  };
+  assertCurrent();
+  return {
+    target,
+    binding,
+    currentSessionBinding: currentSession?.binding,
+    sessionId,
+    sessionKey,
+    storePath,
+    assertHostCurrent,
+    assertCurrent,
+  };
+}
 
 export async function resolveCommandAppServerScope(
   deps: CodexCommandDeps,
   ctx: PluginCommandContext,
   pluginConfig: unknown,
 ): Promise<CommandAppServerScope> {
-  const target = await resolveControlTarget(ctx);
+  const authority = await resolvePreparedCodexCommandAuthority(deps, ctx);
+  const { target, binding } = authority;
   const fallback = resolveCodexConversationControlScope(ctx);
   const agentDir = target?.agentDir ?? fallback.agentDir;
-  const binding = target ? deps.bindingStore.read(target.identity) : undefined;
   const authProfileId =
     binding?.connectionScope === "supervision"
       ? undefined
@@ -80,8 +158,10 @@ export async function resolveCommandAppServerScope(
       ? { authProfileId: connection.clientAuthProfileId }
       : {}),
     ...(connection.usesSupervisionConnection ? { startOptions: connection.appServer.start } : {}),
-    ...(ctx.sessionKey ? { sessionKey: ctx.sessionKey } : {}),
-    ...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}),
+    ...(authority.sessionKey ? { sessionKey: authority.sessionKey } : {}),
+    ...(authority.sessionId ? { sessionId: authority.sessionId } : {}),
+    ...(authority.storePath ? { storePath: authority.storePath } : {}),
+    assertCurrent: authority.assertCurrent,
   };
 }
 

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -8,6 +8,7 @@ import {
   type AuthProfileStore,
 } from "openclaw/plugin-sdk/agent-runtime";
 import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-binding-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { MODEL_SELECTION_LOCKED_MESSAGE } from "openclaw/plugin-sdk/model-session-runtime";
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/plugin-entry";
 import {
@@ -51,6 +52,11 @@ import type {
 } from "./command-plugins-management.js";
 import type { CodexControlRequestOptions } from "./command-rpc.js";
 import { codexConversationBindingRuntime } from "./conversation-binding.js";
+import {
+  steerCodexConversationTurn as steerCodexConversationTurnImpl,
+  stopCodexConversationTurn as stopCodexConversationTurnImpl,
+  trackCodexConversationActiveTurn,
+} from "./conversation-control.js";
 
 type CodexPluginConfigEntry = NonNullable<CodexPluginsConfigBlock["plugins"]>[string];
 
@@ -527,6 +533,13 @@ describe("codex command", () => {
 
   it("routes owner-only plugin discovery through the native command boundary with its workspace", async () => {
     const codexPluginsManagementIo = inMemoryCodexPluginsIO({}, { enabled: false });
+    const sessionKey = "agent:main:plugin-discovery";
+    const storePath = path.join(tempDir, "plugin-discovery-sessions.json");
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: { sessionId: "session-1", updatedAt: Date.now(), agentHarnessId: "codex" },
+    });
     const codexControlRequest = vi.fn(async () => ({
       marketplaces: [
         {
@@ -549,7 +562,10 @@ describe("codex command", () => {
     const result = await runCommand(
       "plugins available",
       { codexPluginsManagementIo, codexControlRequest },
-      {},
+      {
+        sessionKey,
+        sessionTarget: { agentId: "main", sessionId: "session-1", sessionKey, storePath },
+      },
       { pluginConfig: { appServer: { defaultWorkspaceDir: "/company" } } },
     );
 
@@ -558,7 +574,13 @@ describe("codex command", () => {
       { appServer: { defaultWorkspaceDir: "/company" } },
       "plugin/list",
       { cwds: ["/company"] },
-      expect.objectContaining({ config: {}, sessionId: "session-1" }),
+      expect.objectContaining({
+        config: {},
+        sessionId: "session-1",
+        sessionKey,
+        storePath,
+        assertCurrent: expect.any(Function),
+      }),
     );
 
     codexControlRequest.mockClear();
@@ -3387,6 +3409,72 @@ describe("codex command", () => {
     expect(codexControlRequest).not.toHaveBeenCalled();
   });
 
+  it("compacts a conversation binding after recovering its current session owner", async () => {
+    const runtime = await createCodexRuntimeContextOverrides(
+      "agent:main:test:conversation-compact-recovery",
+    );
+    await upsertSessionEntry({
+      storePath: runtime.sessionTarget.storePath,
+      sessionKey: runtime.sessionKey,
+      entry: {
+        sessionId: "session-1",
+        previousSessionId: "session-before-compact",
+        updatedAt: Date.now(),
+        agentHarnessId: "codex",
+      },
+    });
+    const owner = {
+      threadId: "thread-recovered-compact",
+      clientId: "client-recovered-compact",
+      cwd: "/repo",
+    };
+    await writeTestBinding(
+      {
+        kind: "session",
+        agentId: "main",
+        sessionId: "session-before-compact",
+        sessionKey: runtime.sessionKey,
+      },
+      owner,
+    );
+    await writeTestBinding({ kind: "conversation", bindingId: "binding-data-1" }, owner);
+    const compactCurrent = vi.fn(async () => ({ compacted: true, tokensAfter: 123 }));
+
+    await expect(
+      handleCodexCommand(
+        createContext("compact", undefined, {
+          ...runtime,
+          runtimeContext: { compactCurrent },
+          getCurrentConversationBinding: async () => ({
+            bindingId: "binding-1",
+            pluginId: "codex",
+            pluginRoot: "/plugin",
+            channel: "test",
+            accountId: "default",
+            conversationId: "conversation",
+            boundAt: 1,
+            data: {
+              kind: "codex-app-server-session",
+              version: 2,
+              bindingId: "binding-data-1",
+              workspaceDir: "/repo",
+            },
+          }),
+        }),
+        { deps: createDeps() },
+      ),
+    ).resolves.toEqual({ text: "Compacted Codex session (123 tokens after)." });
+    expect(compactCurrent).toHaveBeenCalledOnce();
+    expect(
+      testCodexAppServerBindingStore.read({
+        kind: "session",
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: runtime.sessionKey,
+      }),
+    ).toMatchObject(owner);
+  });
+
   it("rejects a Codex binding on a non-Codex session runtime", async () => {
     const sessionKey = "agent:main:test:mixed-runtime";
     const storePath = path.join(tempDir, "mixed-runtime-sessions.json");
@@ -5173,6 +5261,13 @@ describe("codex command", () => {
 
   it("scopes Codex read commands to the bound agent and auth profile", async () => {
     const agentDir = path.join(tempDir, "agents", "worker", "agent");
+    const storePath = path.join(tempDir, "worker", "sessions.json");
+    await upsertSessionEntry({
+      agentId: "worker",
+      storePath,
+      sessionKey: "agent:worker:session-1",
+      entry: { sessionId: "session-1", updatedAt: Date.now(), agentHarnessId: "codex" },
+    });
     const getCurrentConversationBinding = async () => ({
       bindingId: "binding-1",
       pluginId: "codex",
@@ -5201,9 +5296,16 @@ describe("codex command", () => {
     const context = (args: string) =>
       createContext(args, undefined, {
         sessionKey: "agent:worker:session-1",
+        sessionTarget: {
+          agentId: "worker",
+          sessionId: "session-1",
+          sessionKey: "agent:worker:session-1",
+          storePath,
+        },
         getCurrentConversationBinding,
       });
 
+    await handleCodexCommand(context("threads"), { deps });
     await handleCodexCommand(context("mcp"), { deps });
     await handleCodexCommand(context("skills"), { deps });
     await handleCodexCommand(context("account"), { deps });
@@ -5213,16 +5315,25 @@ describe("codex command", () => {
       authProfileId: "openai:work",
       sessionKey: "agent:worker:session-1",
       sessionId: "session-1",
+      storePath,
+      assertCurrent: expect.any(Function),
     });
     expect(codexControlRequest).toHaveBeenNthCalledWith(
       1,
+      undefined,
+      CODEX_CONTROL_METHODS.listThreads,
+      { limit: 10 },
+      expectedScope,
+    );
+    expect(codexControlRequest).toHaveBeenNthCalledWith(
+      2,
       undefined,
       CODEX_CONTROL_METHODS.listMcpServers,
       { limit: 100 },
       expectedScope,
     );
     expect(codexControlRequest).toHaveBeenNthCalledWith(
-      2,
+      3,
       undefined,
       CODEX_CONTROL_METHODS.listSkills,
       {},
@@ -5339,6 +5450,236 @@ describe("codex command", () => {
       expect.any(Object),
     );
   });
+
+  it.each(["goal", "review"] as const)(
+    "recovers the predecessor binding before the first /codex %s command",
+    async (command) => {
+      const sessionKey = `agent:main:test:first-${command}`;
+      const storePath = path.join(tempDir, "explicit", `${command}.json`);
+      const configuredStorePath = path.join(tempDir, "configured", `${command}.json`);
+      await upsertSessionEntry({
+        storePath,
+        sessionKey,
+        entry: {
+          sessionId: "session-successor",
+          previousSessionId: "session-predecessor",
+          updatedAt: Date.now(),
+          agentHarnessId: "codex",
+        },
+      });
+      await writeTestBinding(
+        {
+          kind: "session",
+          agentId: "main",
+          sessionId: "session-predecessor",
+          sessionKey,
+        },
+        { threadId: `thread-${command}`, cwd: "/repo" },
+      );
+      const codexControlRequest = vi.fn(async (): Promise<JsonValue | undefined> =>
+        command === "goal"
+          ? {
+              goal: {
+                threadId: "thread-goal",
+                objective: "recover authority",
+                status: "active",
+                tokenBudget: null,
+                tokensUsed: 0,
+                timeUsedSeconds: 0,
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            }
+          : undefined,
+      );
+
+      const result = await runCommand(
+        command,
+        { codexControlRequest },
+        {
+          sessionId: "session-successor",
+          sessionKey,
+          config: { session: { store: configuredStorePath } },
+          sessionTarget: {
+            agentId: "main",
+            sessionId: "session-successor",
+            sessionKey,
+            storePath,
+          },
+        },
+      );
+
+      expect(result.text).not.toContain("No Codex thread");
+      expect(codexControlRequest).toHaveBeenCalledWith(
+        undefined,
+        command === "goal" ? CODEX_CONTROL_METHODS.getThreadGoal : CODEX_CONTROL_METHODS.review,
+        expect.objectContaining({ threadId: `thread-${command}` }),
+        expect.objectContaining({
+          sessionId: "session-successor",
+          sessionKey,
+          storePath,
+          assertCurrent: expect.any(Function),
+        }),
+      );
+    },
+  );
+
+  it.each([
+    { command: "model gpt-5.5", expected: "Codex model set to gpt-5.5." },
+    { command: "fast on", expected: "Codex fast mode enabled." },
+  ])("recovers the predecessor binding before the first $command command", async (testCase) => {
+    const sessionKey = `agent:main:test:first-${testCase.command.split(" ")[0]}`;
+    const storePath = path.join(tempDir, "explicit", `${sessionKey}.json`);
+    await upsertSessionEntry({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "session-successor",
+        previousSessionId: "session-predecessor",
+        updatedAt: Date.now(),
+        agentHarnessId: "codex",
+      },
+    });
+    await writeTestBinding(
+      { kind: "session", agentId: "main", sessionId: "session-predecessor", sessionKey },
+      { threadId: "thread-first-control", cwd: "/repo", model: "gpt-5.4" },
+    );
+
+    await expect(
+      runCommand(
+        testCase.command,
+        {},
+        {
+          sessionId: "session-successor",
+          sessionKey,
+          sessionTarget: {
+            agentId: "main",
+            sessionId: "session-successor",
+            sessionKey,
+            storePath,
+          },
+        },
+      ),
+    ).resolves.toEqual({ text: testCase.expected });
+  });
+
+  it("rejects a queued goal before any app-server write when the host rolls over", async () => {
+    const runtime = await createCodexRuntimeContextOverrides("agent:main:test:queued-goal");
+    await writeTestBinding(
+      {
+        kind: "session",
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: runtime.sessionKey,
+      },
+      { threadId: "thread-queued-goal", cwd: "/repo" },
+    );
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    let appServerWrites = 0;
+    const codexControlRequest = vi.fn(
+      async (
+        _pluginConfig: unknown,
+        _method: string,
+        _params: unknown,
+        options?: CodexControlRequestOptions,
+      ): Promise<JsonValue> => {
+        entered.resolve();
+        await release.promise;
+        options?.assertCurrent?.();
+        appServerWrites += 1;
+        return { goal: null };
+      },
+    );
+
+    const command = runCommand("goal", { codexControlRequest }, runtime);
+    await entered.promise;
+    await upsertSessionEntry({
+      storePath: runtime.sessionTarget.storePath,
+      sessionKey: runtime.sessionKey,
+      entry: {
+        sessionId: "session-next",
+        previousSessionId: "session-1",
+        updatedAt: Date.now(),
+        agentHarnessId: "codex",
+      },
+    });
+    release.resolve();
+
+    expect((await command).text).toContain("Codex session generation is no longer current");
+    expect(appServerWrites).toBe(0);
+  });
+
+  it.each(["stop", "steer"] as const)(
+    "rejects a queued %s command before any app-server write when the host rolls over",
+    async (command) => {
+      const runtime = await createCodexRuntimeContextOverrides(`agent:main:test:queued-${command}`);
+      const identity = {
+        kind: "session" as const,
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: runtime.sessionKey,
+      };
+      await writeTestBinding(identity, {
+        threadId: `thread-queued-${command}`,
+        cwd: "/repo",
+      });
+      const harness = createClientHarness({
+        onWrite: (line, send) => {
+          const request = JSON.parse(line) as { id: number };
+          send({ id: request.id, result: {} });
+        },
+      });
+      const stopTracking = trackCodexConversationActiveTurn({
+        identity,
+        client: harness.client,
+        threadId: `thread-queued-${command}`,
+        turnId: "turn-1",
+      });
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      const stop = vi.fn(async (params: Parameters<typeof stopCodexConversationTurnImpl>[0]) => {
+        entered.resolve();
+        await release.promise;
+        return await stopCodexConversationTurnImpl(params);
+      });
+      const steer = vi.fn(async (params: Parameters<typeof steerCodexConversationTurnImpl>[0]) => {
+        entered.resolve();
+        await release.promise;
+        return await steerCodexConversationTurnImpl(params);
+      });
+
+      try {
+        const pending =
+          command === "stop"
+            ? runCommand("stop", { stopCodexConversationTurn: stop }, runtime)
+            : runCommand(
+                "steer keep the authority boundary",
+                { steerCodexConversationTurn: steer },
+                runtime,
+              );
+        await entered.promise;
+        await upsertSessionEntry({
+          storePath: runtime.sessionTarget.storePath,
+          sessionKey: runtime.sessionKey,
+          entry: {
+            sessionId: "session-next",
+            previousSessionId: "session-1",
+            updatedAt: Date.now(),
+            agentHarnessId: "codex",
+          },
+        });
+        release.resolve();
+
+        expect((await pending).text).toContain("Codex session generation is no longer current");
+        expect(harness.writes).toHaveLength(0);
+      } finally {
+        release.resolve();
+        stopTracking();
+        harness.client.close();
+      }
+    },
+  );
 
   it("rejects inherited object names as goal actions", async () => {
     await writeTestBinding(
@@ -6569,7 +6910,7 @@ describe("codex command", () => {
     );
   });
 
-  it("sets per-binding model, fast mode, and permissions", async () => {
+  it("sets per-binding model, fast mode, and permissions with prepared authority", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const setCodexConversationModel = vi.fn(async () => "Codex model set to gpt-5.4.");
     const setCodexConversationFastMode = vi.fn(async () => "Codex fast mode enabled.");
@@ -6598,28 +6939,121 @@ describe("codex command", () => {
       ),
     ).resolves.toEqual({ text: "Codex permissions set to full access." });
 
-    expect(setCodexConversationModel).toHaveBeenCalledWith({
-      identity: { kind: "session", agentId: "main", sessionId: "session-1" },
-      bindingStore: testCodexAppServerBindingStore,
-      pluginConfig: undefined,
-      model: "gpt-5.4",
-      agentDir: path.join(tempDir, "agents", "main", "agent"),
-      config: {},
+    expect(setCodexConversationModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identity: { kind: "session", agentId: "main", sessionId: "session-1" },
+        bindingStore: testCodexAppServerBindingStore,
+        pluginConfig: undefined,
+        model: "gpt-5.4",
+        agentDir: path.join(tempDir, "agents", "main", "agent"),
+        config: {},
+        assertCurrent: expect.any(Function),
+      }),
+    );
+    expect(setCodexConversationFastMode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identity: { kind: "session", agentId: "main", sessionId: "session-1" },
+        bindingStore: testCodexAppServerBindingStore,
+        enabled: true,
+        assertCurrent: expect.any(Function),
+      }),
+    );
+    expect(setCodexConversationPermissions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "yolo",
+        config: {},
+        session: {
+          agentId: "main",
+          sessionId: "session-1",
+          sessionKey: "agent:main:session-1",
+        },
+        assertCurrent: expect.any(Function),
+      }),
+    );
+  });
+
+  it("uses the admitted explicit store for model and permission reads and writes", async () => {
+    const sessionKey = "agent:main:test:explicit-control-store";
+    const storePath = path.join(tempDir, "explicit", "sessions.json");
+    const configuredStorePath = path.join(tempDir, "configured", "sessions.json");
+    for (const [targetStore, model, permissionMode] of [
+      [storePath, "gpt-5.4", "full"],
+      [configuredStorePath, "configured-model", "guarded"],
+    ] as const) {
+      await upsertSessionEntry({
+        storePath: targetStore,
+        sessionKey,
+        entry: {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+          model,
+          permissionMode,
+          agentHarnessId: "codex",
+        },
+      });
+    }
+    await writeTestBinding(
+      { kind: "session", agentId: "main", sessionId: "session-1", sessionKey },
+      { threadId: "thread-explicit-store", cwd: "/repo", model: "native-model" },
+    );
+    const context = {
+      config: { session: { store: configuredStorePath } },
+      sessionKey,
+      sessionTarget: { agentId: "main", sessionId: "session-1", sessionKey, storePath },
+    };
+
+    const modelStatus = await runCommand("model", {}, context);
+    const permissionStatus = await runCommand("permissions status", {}, context);
+    await runCommand("model gpt-5.5", {}, context);
+    await runCommand("permissions default", {}, context);
+
+    expect(modelStatus.text).toBe("Codex model: gpt-5.4");
+    expect(permissionStatus.text).toBe("Codex permissions: full access.");
+    expect(getSessionEntry({ storePath, sessionKey })).toMatchObject({
+      modelOverride: "gpt-5.5",
+      permissionMode: "guarded",
     });
-    expect(setCodexConversationFastMode).toHaveBeenCalledWith({
-      identity: { kind: "session", agentId: "main", sessionId: "session-1" },
-      bindingStore: testCodexAppServerBindingStore,
-      enabled: true,
+    const configuredEntry = getSessionEntry({ storePath: configuredStorePath, sessionKey });
+    expect(configuredEntry).toMatchObject({
+      model: "configured-model",
+      permissionMode: "guarded",
     });
-    expect(setCodexConversationPermissions).toHaveBeenCalledWith({
-      mode: "yolo",
-      config: {},
-      session: {
-        agentId: "main",
-        sessionId: "session-1",
-        sessionKey: "agent:main:session-1",
+    expect(configuredEntry?.modelOverride).toBeUndefined();
+  });
+
+  it("rejects a permission write after host rollover without requiring a native binding", async () => {
+    const runtime = await createCodexRuntimeContextOverrides(
+      "agent:main:test:permission-no-binding",
+    );
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    let writes = 0;
+    const setCodexConversationPermissions = vi.fn(
+      async (params: { assertCurrent?: () => void }) => {
+        entered.resolve();
+        await release.promise;
+        params.assertCurrent?.();
+        writes += 1;
+        return "Codex permissions set to guarded.";
+      },
+    );
+
+    const command = runCommand("permissions default", { setCodexConversationPermissions }, runtime);
+    await entered.promise;
+    await upsertSessionEntry({
+      storePath: runtime.sessionTarget.storePath,
+      sessionKey: runtime.sessionKey,
+      entry: {
+        sessionId: "session-next",
+        previousSessionId: "session-1",
+        updatedAt: Date.now(),
+        agentHarnessId: "codex",
       },
     });
+    release.resolve();
+
+    expect((await command).text).toContain("Codex session generation is no longer current");
+    expect(writes).toBe(0);
   });
 
   it("updates a bound conversation without changing its ambient outer session", async () => {
@@ -7092,11 +7526,15 @@ describe("codex command", () => {
       ),
     ).resolves.toEqual({ text: "Codex fast mode enabled." });
 
-    expect(setCodexConversationFastMode).toHaveBeenCalledWith({
-      identity: { kind: "conversation", bindingId: "binding-data-1" },
-      bindingStore: testCodexAppServerBindingStore,
-      enabled: true,
-    });
+    expect(setCodexConversationFastMode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identity: { kind: "conversation", bindingId: "binding-data-1" },
+        bindingStore: testCodexAppServerBindingStore,
+        binding: undefined,
+        enabled: true,
+        assertCurrent: expect.any(Function),
+      }),
+    );
   });
 
   it.each([false, true])(

--- a/extensions/codex/src/conversation-control.test.ts
+++ b/extensions/codex/src/conversation-control.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { clearRuntimeAuthProfileStoreSnapshots } from "openclaw/plugin-sdk/agent-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { MODEL_SELECTION_LOCKED_MESSAGE } from "openclaw/plugin-sdk/model-session-runtime";
 import { upsertAuthProfile } from "openclaw/plugin-sdk/provider-auth";
 import {
@@ -18,6 +19,7 @@ import {
   testCodexAppServerBindingStore,
   writeCodexAppServerBinding,
 } from "./app-server/session-binding.test-helpers.js";
+import { createClientHarness } from "./app-server/test-support.js";
 import {
   formatPermissionsMode,
   parseCodexPermissionsModeArg,
@@ -30,16 +32,28 @@ import {
 } from "./conversation-control.js";
 
 function controlTarget(sessionFile: string) {
+  const identity = { kind: "session" as const, agentId: "main", sessionId: sessionFile };
+  const binding = testCodexAppServerBindingStore.read(identity);
   return {
-    identity: { kind: "session" as const, agentId: "main", sessionId: sessionFile },
+    identity,
     bindingStore: testCodexAppServerBindingStore,
+    binding,
+    assertCurrent: () => {
+      expect(testCodexAppServerBindingStore.read(identity)).toEqual(binding);
+    },
   };
+}
+
+function mutateActiveTurn(command: "stop" | "steer", target: ReturnType<typeof controlTarget>) {
+  return command === "stop"
+    ? stopCodexConversationTurn(target)
+    : steerCodexConversationTurn({ ...target, message: "focus tests" });
 }
 
 function setCodexConversationFastMode(
   params: Omit<
     Parameters<typeof setCodexConversationFastModeImpl>[0],
-    "identity" | "bindingStore"
+    "identity" | "bindingStore" | "binding" | "assertCurrent"
   > & {
     sessionFile: string;
   },
@@ -49,7 +63,10 @@ function setCodexConversationFastMode(
 }
 
 function setCodexConversationModel(
-  params: Omit<Parameters<typeof setCodexConversationModelImpl>[0], "identity" | "bindingStore"> & {
+  params: Omit<
+    Parameters<typeof setCodexConversationModelImpl>[0],
+    "identity" | "bindingStore" | "binding" | "assertCurrent"
+  > & {
     sessionFile: string;
   },
 ) {
@@ -61,12 +78,14 @@ let tempDir: string;
 
 const sharedClientMocks = vi.hoisted(() => ({
   getSharedCodexAppServerClient: vi.fn(),
+  releaseLeasedSharedCodexAppServerClient: vi.fn(),
 }));
 
 vi.mock("./app-server/shared-client.js", () => ({
   ...sharedClientMocks,
   getLeasedSharedCodexAppServerClient: sharedClientMocks.getSharedCodexAppServerClient,
-  releaseLeasedSharedCodexAppServerClient: vi.fn(),
+  releaseLeasedSharedCodexAppServerClient:
+    sharedClientMocks.releaseLeasedSharedCodexAppServerClient,
   releaseCodexAppServerClientLease: vi.fn((lease: { client?: unknown }) => {
     lease.client = undefined;
   }),
@@ -90,6 +109,7 @@ describe("codex conversation controls", () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-control-"));
     vi.stubEnv("OPENCLAW_STATE_DIR", tempDir);
     sharedClientMocks.getSharedCodexAppServerClient.mockReset();
+    sharedClientMocks.releaseLeasedSharedCodexAppServerClient.mockReset();
   });
 
   afterEach(async () => {
@@ -130,7 +150,12 @@ describe("codex conversation controls", () => {
       "Codex fast mode enabled.",
     );
     await expect(
-      setCodexConversationPermissionsImpl({ session, mode: "default", config: {} }),
+      setCodexConversationPermissionsImpl({
+        session,
+        mode: "default",
+        config: {},
+        assertCurrent: () => {},
+      }),
     ).resolves.toBe("Codex permissions set to guarded.");
 
     const binding = await readCodexAppServerBinding(sessionFile);
@@ -148,7 +173,12 @@ describe("codex conversation controls", () => {
     ).toMatchObject({ permissionMode: "guarded", sessionRoot: tempDir });
 
     await expect(
-      setCodexConversationPermissionsImpl({ session, mode: "yolo", config: {} }),
+      setCodexConversationPermissionsImpl({
+        session,
+        mode: "yolo",
+        config: {},
+        assertCurrent: () => {},
+      }),
     ).resolves.toBe("Codex permissions set to full access.");
     expect(
       getSessionEntry({
@@ -158,6 +188,36 @@ describe("codex conversation controls", () => {
         readConsistency: "latest",
       })?.permissionMode,
     ).toBe("full");
+  });
+
+  it("rejects prepared binding mutations after the selected binding changes", async () => {
+    const sessionFile = path.join(tempDir, "prepared-binding.jsonl");
+    const identity = controlTarget(sessionFile).identity;
+    const prepared = {
+      threadId: "thread-prepared",
+      cwd: tempDir,
+      model: "gpt-5.4",
+      modelProvider: "openai",
+    };
+    await writeCodexAppServerBinding(sessionFile, prepared);
+    const assertCurrent = () => {
+      expect(testCodexAppServerBindingStore.read(identity)).toEqual(prepared);
+    };
+    await testCodexAppServerBindingStore.mutate(identity, {
+      kind: "set",
+      binding: { ...prepared, threadId: "thread-replacement" },
+    });
+
+    await expect(
+      setCodexConversationFastModeImpl({
+        identity,
+        bindingStore: testCodexAppServerBindingStore,
+        binding: prepared,
+        enabled: true,
+        assertCurrent,
+      }),
+    ).rejects.toThrow();
+    expect(testCodexAppServerBindingStore.read(identity)).not.toHaveProperty("serviceTier");
   });
 
   it.each([
@@ -191,7 +251,12 @@ describe("codex conversation controls", () => {
     });
 
     await expect(
-      setCodexConversationPermissionsImpl({ session, mode: "default", config: {} }),
+      setCodexConversationPermissionsImpl({
+        session,
+        mode: "default",
+        config: {},
+        assertCurrent: () => {},
+      }),
     ).resolves.toBe("Codex permissions set to guarded.");
     expect(
       getSessionEntry({ agentId: session.agentId, sessionKey: session.sessionKey, storePath }),
@@ -200,7 +265,6 @@ describe("codex conversation controls", () => {
 
   it("routes supervised stop and steer requests through the native user-home connection", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
-    const target = controlTarget(sessionFile);
     await writeCodexAppServerBinding(sessionFile, {
       threadId: "thread-supervised",
       connectionScope: "supervision",
@@ -212,6 +276,7 @@ describe("codex conversation controls", () => {
       preserveNativeModel: true,
       conversationSourceTransferComplete: true,
     });
+    const target = controlTarget(sessionFile);
     const request = vi.fn(async () => ({}));
     sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({ request });
     const stopTracking = trackCodexConversationActiveTurn({
@@ -244,7 +309,7 @@ describe("codex conversation controls", () => {
       1,
       "turn/interrupt",
       { threadId: "thread-supervised", turnId: "turn-1" },
-      { timeoutMs: 60_000 },
+      { timeoutMs: 60_000, assertCurrent: expect.any(Function) },
     );
     expect(request).toHaveBeenNthCalledWith(
       2,
@@ -254,17 +319,17 @@ describe("codex conversation controls", () => {
         expectedTurnId: "turn-1",
         input: [{ type: "text", text: "focus tests", text_elements: [] }],
       },
-      { timeoutMs: 60_000 },
+      { timeoutMs: 60_000, assertCurrent: expect.any(Function) },
     );
   });
 
   it("refuses to stop or steer when the active turn no longer matches the private binding", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
-    const target = controlTarget(sessionFile);
     await writeCodexAppServerBinding(sessionFile, {
       threadId: "replacement-thread",
       cwd: tempDir,
     });
+    const target = controlTarget(sessionFile);
     const stopTracking = trackCodexConversationActiveTurn({
       identity: target.identity,
       threadId: "stale-active-thread",
@@ -283,12 +348,13 @@ describe("codex conversation controls", () => {
         message: "The active Codex run no longer matches this session binding.",
       });
       await testCodexAppServerBindingStore.mutate(target.identity, { kind: "clear" });
-      await expect(stopCodexConversationTurn(target)).resolves.toEqual({
+      const clearedTarget = controlTarget(sessionFile);
+      await expect(stopCodexConversationTurn(clearedTarget)).resolves.toEqual({
         stopped: false,
         message: "The active Codex run no longer matches this session binding.",
       });
       await expect(
-        steerCodexConversationTurn({ ...target, message: "still do not send" }),
+        steerCodexConversationTurn({ ...clearedTarget, message: "still do not send" }),
       ).resolves.toEqual({
         steered: false,
         message: "The active Codex run no longer matches this session binding.",
@@ -299,6 +365,97 @@ describe("codex conversation controls", () => {
 
     expect(sharedClientMocks.getSharedCodexAppServerClient).not.toHaveBeenCalled();
   });
+
+  it.each(["stop", "steer"] as const)(
+    "rejects %s before a retained-client write after host rollover",
+    async (command) => {
+      const sessionFile = path.join(tempDir, `${command}-retained.jsonl`);
+      await writeCodexAppServerBinding(sessionFile, {
+        threadId: `thread-${command}-retained`,
+        cwd: tempDir,
+      });
+      const target = controlTarget(sessionFile);
+      const harness = createClientHarness({
+        onWrite: (line, send) => {
+          const request = JSON.parse(line) as { id: number };
+          send({ id: request.id, result: {} });
+        },
+      });
+      const stopTracking = trackCodexConversationActiveTurn({
+        identity: target.identity,
+        client: harness.client,
+        threadId: `thread-${command}-retained`,
+        turnId: "turn-1",
+      });
+
+      try {
+        await expect(
+          mutateActiveTurn(command, {
+            ...target,
+            assertCurrent: () => {
+              throw new Error("host session rolled over");
+            },
+          }),
+        ).rejects.toThrow("host session rolled over");
+        expect(harness.writes).toHaveLength(0);
+      } finally {
+        stopTracking();
+        harness.client.close();
+      }
+    },
+  );
+
+  it.each(["stop", "steer"] as const)(
+    "rejects %s before a leased-client write when host rollover occurs during acquisition",
+    async (command) => {
+      const sessionFile = path.join(tempDir, `${command}-leased.jsonl`);
+      await writeCodexAppServerBinding(sessionFile, {
+        threadId: `thread-${command}-leased`,
+        cwd: tempDir,
+      });
+      const target = controlTarget(sessionFile);
+      const harness = createClientHarness({
+        onWrite: (line, send) => {
+          const request = JSON.parse(line) as { id: number };
+          send({ id: request.id, result: {} });
+        },
+      });
+      const acquired = createDeferred<typeof harness.client>();
+      sharedClientMocks.getSharedCodexAppServerClient.mockReturnValue(acquired.promise);
+      const stopTracking = trackCodexConversationActiveTurn({
+        identity: target.identity,
+        threadId: `thread-${command}-leased`,
+        turnId: "turn-1",
+      });
+      let hostCurrent = true;
+
+      try {
+        const mutation = mutateActiveTurn(command, {
+          ...target,
+          assertCurrent: () => {
+            if (!hostCurrent) {
+              throw new Error("host session rolled over");
+            }
+          },
+        });
+        await vi.waitFor(() => {
+          expect(sharedClientMocks.getSharedCodexAppServerClient).toHaveBeenCalledOnce();
+        });
+        hostCurrent = false;
+        acquired.resolve(harness.client);
+
+        await expect(mutation).rejects.toThrow("host session rolled over");
+        expect(harness.writes).toHaveLength(0);
+        expect(sharedClientMocks.releaseLeasedSharedCodexAppServerClient).toHaveBeenCalledWith(
+          harness.client,
+        );
+      } finally {
+        acquired.resolve(harness.client);
+        stopTracking();
+        harness.client.close();
+      }
+    },
+  );
 
   it("rejects direct model changes for private supervised bindings", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
@@ -458,7 +615,10 @@ describe("codex conversation controls", () => {
       setCodexConversationModelImpl({
         identity,
         bindingStore: testCodexAppServerBindingStore,
+        binding: testCodexAppServerBindingStore.read(identity),
         model: "gpt-5.5",
+        storePath,
+        assertCurrent: () => {},
       }),
     ).resolves.toBe("Codex model set to gpt-5.5.");
 
@@ -506,7 +666,10 @@ describe("codex conversation controls", () => {
       setCodexConversationModelImpl({
         identity,
         bindingStore: testCodexAppServerBindingStore,
+        binding: testCodexAppServerBindingStore.read(identity),
         model: "openai/gpt-5.5",
+        storePath,
+        assertCurrent: () => {},
       }),
     ).resolves.toBe("Codex model set to gpt-5.5.");
 

--- a/extensions/codex/src/conversation-control.ts
+++ b/extensions/codex/src/conversation-control.ts
@@ -20,6 +20,7 @@ import {
   type CodexAppServerAuthProfileLookup,
   type CodexAppServerBindingIdentity,
   type CodexAppServerBindingStore,
+  type CodexAppServerThreadBinding,
 } from "./app-server/session-binding.js";
 import {
   getLeasedSharedCodexAppServerClient,
@@ -72,17 +73,18 @@ export function readCodexConversationActiveTurn(
 
 export async function stopCodexConversationTurn(params: {
   identity: CodexAppServerBindingIdentity;
-  bindingStore: CodexAppServerBindingStore;
+  binding: CodexAppServerThreadBinding | undefined;
   pluginConfig?: unknown;
   agentDir?: string;
   config?: CodexAppServerBindingLookup["config"];
+  assertCurrent: () => void;
 }): Promise<{ stopped: boolean; message: string }> {
   const active = readCodexConversationActiveTurn(params.identity);
   if (!active) {
     return { stopped: false, message: "No active Codex run to stop." };
   }
   const lookup = buildBindingLookup(params);
-  const binding = params.bindingStore.read(params.identity);
+  const binding = params.binding;
   if (binding?.threadId !== active.threadId) {
     return {
       stopped: false,
@@ -112,7 +114,7 @@ export async function stopCodexConversationTurn(params: {
         threadId: active.threadId,
         turnId: active.turnId,
       },
-      { timeoutMs: runtime.requestTimeoutMs },
+      { timeoutMs: runtime.requestTimeoutMs, assertCurrent: params.assertCurrent },
     );
   } finally {
     if (!active.client) {
@@ -124,11 +126,12 @@ export async function stopCodexConversationTurn(params: {
 
 export async function steerCodexConversationTurn(params: {
   identity: CodexAppServerBindingIdentity;
-  bindingStore: CodexAppServerBindingStore;
+  binding: CodexAppServerThreadBinding | undefined;
   message: string;
   pluginConfig?: unknown;
   agentDir?: string;
   config?: CodexAppServerBindingLookup["config"];
+  assertCurrent: () => void;
 }): Promise<{ steered: boolean; message: string }> {
   const active = readCodexConversationActiveTurn(params.identity);
   const text = params.message.trim();
@@ -139,7 +142,7 @@ export async function steerCodexConversationTurn(params: {
     return { steered: false, message: "No active Codex run to steer." };
   }
   const lookup = buildBindingLookup(params);
-  const binding = params.bindingStore.read(params.identity);
+  const binding = params.binding;
   if (binding?.threadId !== active.threadId) {
     return {
       steered: false,
@@ -170,7 +173,7 @@ export async function steerCodexConversationTurn(params: {
         expectedTurnId: active.turnId,
         input: [{ type: "text", text, text_elements: [] }],
       },
-      { timeoutMs: runtime.requestTimeoutMs },
+      { timeoutMs: runtime.requestTimeoutMs, assertCurrent: params.assertCurrent },
     );
   } finally {
     if (!active.client) {
@@ -183,17 +186,21 @@ export async function steerCodexConversationTurn(params: {
 export async function setCodexConversationModel(params: {
   identity: CodexAppServerBindingIdentity;
   bindingStore: CodexAppServerBindingStore;
+  binding: CodexAppServerThreadBinding | undefined;
   model: string;
   pluginConfig?: unknown;
   agentDir?: string;
   config?: CodexAppServerBindingLookup["config"];
+  storePath?: string;
+  assertCurrent: () => void;
 }): Promise<string> {
   const model = params.model.trim();
   if (!model) {
     return "Usage: /codex model <model>";
   }
   const lookup = buildBindingLookup(params);
-  const binding = requireThreadBinding(params.bindingStore, params.identity);
+  params.assertCurrent();
+  const binding = requirePreparedThreadBinding(params.binding);
   if (binding.connectionScope === "supervision") {
     throw new ModelSelectionLockedError();
   }
@@ -227,10 +234,13 @@ export async function setCodexConversationModel(params: {
     // lifecycle reconciliation can rotate its native generation safely.
     const updated = await patchSessionEntry({
       agentId: identity.agentId,
-      storePath: resolveStorePath(params.config?.session?.store, { agentId: identity.agentId }),
+      storePath:
+        params.storePath ??
+        resolveStorePath(params.config?.session?.store, { agentId: identity.agentId }),
       sessionKey: identity.sessionKey,
       requireWriteSuccess: true,
       replaceEntry: true,
+      assertCommitAllowed: params.assertCurrent,
       update: (entry) => {
         if (entry.sessionId !== identity.sessionId) {
           throw new Error("Codex session changed while applying the model selection.");
@@ -250,16 +260,28 @@ export async function setCodexConversationModel(params: {
       throw new Error("Codex session changed while applying the model selection.");
     }
     if (modelChanged && binding.contextEngine?.projection) {
-      await patchThreadBinding(params.bindingStore, identity, binding.threadId, projectionPatch);
+      await patchThreadBinding(
+        params.bindingStore,
+        identity,
+        binding.threadId,
+        projectionPatch,
+        params.assertCurrent,
+      );
     }
   } else {
     // Conversation bindings and ephemeral sessions own native selection;
     // ambient outer-session metadata must never redirect their runtime.
-    await patchThreadBinding(params.bindingStore, params.identity, binding.threadId, {
-      model: nextModel,
-      modelProvider: nextModelProvider,
-      ...projectionPatch,
-    });
+    await patchThreadBinding(
+      params.bindingStore,
+      params.identity,
+      binding.threadId,
+      {
+        model: nextModel,
+        modelProvider: nextModelProvider,
+        ...projectionPatch,
+      },
+      params.assertCurrent,
+    );
   }
   return `Codex model set to ${formatCodexDisplayText(nextModel)}.`;
 }
@@ -267,30 +289,44 @@ export async function setCodexConversationModel(params: {
 export async function setCodexConversationFastMode(params: {
   identity: CodexAppServerBindingIdentity;
   bindingStore: CodexAppServerBindingStore;
+  binding: CodexAppServerThreadBinding | undefined;
   enabled?: boolean;
   pluginConfig?: unknown;
   agentDir?: string;
   config?: CodexAppServerBindingLookup["config"];
+  assertCurrent: () => void;
 }): Promise<string> {
-  const binding = requireThreadBinding(params.bindingStore, params.identity);
+  params.assertCurrent();
+  const binding = requirePreparedThreadBinding(params.binding);
   if (params.enabled == null) {
     return `Codex fast mode: ${isCodexFastServiceTier(binding.serviceTier) ? "on" : "off"}.`;
   }
   const serviceTier: CodexServiceTier = params.enabled ? "priority" : "flex";
   // Fast mode is sent on each later turn; do not require Codex to accept an
   // immediate thread/resume control request just to persist the preference.
-  await patchThreadBinding(params.bindingStore, params.identity, binding.threadId, { serviceTier });
+  await patchThreadBinding(
+    params.bindingStore,
+    params.identity,
+    binding.threadId,
+    { serviceTier },
+    params.assertCurrent,
+  );
   return `Codex fast mode ${params.enabled ? "enabled" : "disabled"}.`;
 }
 
 export async function setCodexConversationPermissions(params: {
   mode?: PermissionsMode;
   config?: CodexAppServerBindingLookup["config"];
+  storePath?: string;
+  assertCurrent: () => void;
   session: { agentId: string; sessionId: string; sessionKey: string };
 }): Promise<string> {
-  const storePath = resolveStorePath(params.config?.session?.store, {
-    agentId: params.session.agentId,
-  });
+  params.assertCurrent();
+  const storePath =
+    params.storePath ??
+    resolveStorePath(params.config?.session?.store, {
+      agentId: params.session.agentId,
+    });
   if (!params.mode) {
     const entry = getSessionEntry({
       agentId: params.session.agentId,
@@ -299,6 +335,7 @@ export async function setCodexConversationPermissions(params: {
       sessionKey: params.session.sessionKey,
       storePath,
     });
+    params.assertCurrent();
     if (entry?.sessionId !== params.session.sessionId) {
       throw new Error("Codex session changed while reading the permission mode.");
     }
@@ -310,6 +347,7 @@ export async function setCodexConversationPermissions(params: {
     sessionKey: params.session.sessionKey,
     requireWriteSuccess: true,
     replaceEntry: true,
+    assertCommitAllowed: params.assertCurrent,
     update: (entry) => {
       if (entry.sessionId !== params.session.sessionId) {
         throw new Error("Codex session changed while applying the permission mode.");
@@ -358,11 +396,7 @@ export function formatPermissionsMode(
   return mode === "full" ? "full access" : (mode ?? "default");
 }
 
-function requireThreadBinding(
-  bindingStore: CodexAppServerBindingStore,
-  identity: CodexAppServerBindingIdentity,
-) {
-  const binding = bindingStore.read(identity);
+function requirePreparedThreadBinding(binding: CodexAppServerThreadBinding | undefined) {
   if (!binding?.threadId) {
     throw new Error("No Codex thread is attached to this OpenClaw session yet.");
   }
@@ -374,8 +408,9 @@ async function patchThreadBinding(
   identity: CodexAppServerBindingIdentity,
   threadId: string,
   patch: Extract<Parameters<CodexAppServerBindingStore["mutate"]>[1], { kind: "patch" }>["patch"],
+  assertCurrent: () => void,
 ): Promise<void> {
-  if (!(await bindingStore.mutate(identity, { kind: "patch", threadId, patch }))) {
+  if (!(await bindingStore.mutate(identity, { kind: "patch", threadId, patch }, assertCurrent))) {
     throw new Error("Codex thread binding changed while applying the control update.");
   }
 }


### PR DESCRIPTION
Related: #137914
Supersedes the remaining command-authority scope from #138184.

## What Problem This Solves

Fixes an issue where a queued `/codex` control command could continue after its
OpenClaw session rolled over and then read, mutate, or dispatch against a stale
native thread binding.

## Why This Change Was Made

The command path now prepares one authoritative host-session and selected-binding
snapshot, reclaims an eligible predecessor binding before dispatch, and carries
the resulting current-generation assertion through app-server requests and
session or binding commits. Permission changes remain owned by the host session;
model, fast-mode, goal, review, and compaction actions also fence the selected
native binding.

This is the residual command boundary after #138473 and #138767. It does not
change the app-server protocol or add compatibility paths.

## User Impact

Codex control commands now fail closed when a newer OpenClaw session or binding
has taken ownership. Current commands keep working, including predecessor
recovery and explicit session-store routing.

## Evidence

- Exact signed head: `b2abfc07617da32fe257d9c0177f8dea14b505e1`
- Focused command and conversation-control suite: `248/248` passed
- The accepted local ClawSweeper stop/steer finding reproduced as `6/6`
  deterministic pre-fix failures and passes after the repair for retained and
  leased app-server clients
- Local ClawSweeper rerun on the exact head found no actionable issue and judged
  the prepared authority plus synchronous pre-write revalidation the best fix;
  its read-only sandbox could not create Vitest temporary state
- Repo autoreview on the exact head: scoped clean at P0/P1, `0.90` confidence
- Regression coverage proves queued goal and permission writes stop before the
  first external or persistent write after host rollover
- Coverage also proves selected-binding replacement is rejected, predecessor
  bindings recover before first control, and explicit session stores remain
  authoritative
- `node scripts/check-changed.mjs --dry-run` classified the expected
  `extensions` and `extensionTests` lanes
- Production delta: `+188/-61` (net `+127`); tests: `+641/-40`
- Exact-head hosted CI is green, including `openclaw/ci-gate`
- Production-boundary final-effect proof on the exact head:
  - stale generation A goal rejected with zero physical `thread/goal/set`
    requests and zero native results
  - stale generation A permission update rejected with no permission persisted
  - current generation B preserved `thread-preserved`, completed one goal
    request/result with status `paused`, and persisted permission `guarded` in
    the explicitly admitted store
  - configured and ambient stores remained unchanged
- Proof command:
  `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/codex/src/pr138820-exact-final-effect.proof.test.ts --reporter=verbose --testTimeout=30000`
  (`1` passed, `0` failed)
