### PR TITLE
fix(subagents): prevent stale completion after requester delivery

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -242,11 +242,7 @@ const finalizeSubagentCleanup = async (
     const delivery = ensureDeliveryState(entry);
     const terminalNonDelivery =
       announceOutcome === "intentional_non_delivery" && delivery.status === "failed";
-    const shouldCreditDelivery =
-      announceOutcome === "delivered" &&
-      (!options?.skipAnnounce ||
-        delivery.status === "delivered" ||
-        typeof delivery.announcedAt === "number");
+    const shouldCreditDelivery = announceOutcome === "delivered";
     if (shouldCreditDelivery) {
       const deliveredAt = delivery.deliveredAt ?? delivery.announcedAt ?? Date.now();
       delivery.status = "delivered";
@@ -256,9 +252,8 @@ const finalizeSubagentCleanup = async (
         delivery.announcedAt = deliveredAt;
         params.persist(runId);
       }
-    }
-    if (announceOutcome === "delivered") {
       clearSubagentPendingDelivery(entry);
+      delivery.lastDropReason = undefined;
     } else {
       // A handoff stays pending for requester-settle; explicit suppression is
       // terminal and must not start another turn that overrides the decision.
@@ -269,7 +264,6 @@ const finalizeSubagentCleanup = async (
       delivery.attemptCount = undefined;
       delivery.nextAttemptAt = undefined;
     }
-    const finalDelivery = ensureDeliveryState(entry);
     if (shouldCreditDelivery && !options?.skipDeliveryStatus) {
       safeSetSubagentTaskDeliveryStatus(params, {
         entry,
@@ -281,10 +275,6 @@ const finalizeSubagentCleanup = async (
         deliveryStatus: terminalNonDelivery ? "failed" : "pending",
         deliveryError: terminalNonDelivery ? getDeliveryLastError(entry) : undefined,
       });
-    }
-    if (announceOutcome === "delivered") {
-      finalDelivery.lastError = undefined;
-      finalDelivery.lastDropReason = undefined;
     }
     entry.wakeOnDescendantSettle = undefined;
     const completion = ensureCompletionState(entry);
@@ -519,6 +509,7 @@ export const startSubagentAnnounceCleanupFlow = (
   const pendingPayload = loadPendingFinalDeliveryPayload(entry);
   const requesterOrigin = normalizeDeliveryContext(pendingPayload.requesterOrigin);
   let latestDeliveryError = getDeliveryLastError(entry);
+  let committedDelivery: SubagentRunRecord["delivery"];
   const finalizeAnnounceCleanup = async (announceOutcome: SubagentAnnounceFlowOutcome) => {
     if (!context.isCleanupAttemptCurrent(runId, entry, cleanupGeneration)) {
       await retireSupersededCleanupIfNeeded(context, runId, entry, cleanupGeneration);
@@ -573,7 +564,7 @@ export const startSubagentAnnounceCleanupFlow = (
     isChildSessionEffectsAllowed: childSessionEffectsAllowed,
     isCompletionDeliveryAllowed: () =>
       entry.suppressCompletionDelivery !== true &&
-      entry.delivery?.status !== "delivered" &&
+      (entry.delivery?.status !== "delivered" || entry.delivery === committedDelivery) &&
       context.isCleanupAttemptCurrent(runId, entry, cleanupGeneration),
     isCompletionOwnedByRequesterYield: () =>
       entry.requesterTurnYielded === true ||
@@ -625,11 +616,11 @@ export const startSubagentAnnounceCleanupFlow = (
       recordAnnounceDeliveryResult(entry, delivery, params.runs);
       if (delivery.delivered) {
         const deliveryState = ensureDeliveryState(entry);
+        // Later chunks retain this receipt owner; requester settlement replaces it.
+        committedDelivery = deliveryState;
         deliveryState.status = "delivered";
         deliveryState.announcedAt = deliveryState.deliveredAt ?? Date.now();
-        deliveryState.lastError = undefined;
-        deliveryState.suspendedAt = undefined;
-        deliveryState.suspendedReason = undefined;
+        clearSubagentPendingDelivery(entry);
         // Identified platform delivery precedes best-effort transcript
         // mirroring; task ownership must become durable at that same edge.
         params.persist(runId);

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -270,11 +270,6 @@ const finalizeSubagentCleanup = async (
       delivery.nextAttemptAt = undefined;
     }
     const finalDelivery = ensureDeliveryState(entry);
-    if (shouldCreditDelivery) {
-      finalDelivery.status = "delivered";
-      finalDelivery.suspendedAt = undefined;
-      finalDelivery.suspendedReason = undefined;
-    }
     if (shouldCreditDelivery && !options?.skipDeliveryStatus) {
       safeSetSubagentTaskDeliveryStatus(params, {
         entry,
@@ -412,11 +407,11 @@ export const startSubagentAnnounceCleanupFlow = (
     return true;
   }
   let suppressSessionEffects = shouldSuppressSubagentRecoverySessionEffects(entry);
+  const cleanupGeneration = beginSubagentCleanup(context, runId);
+  if (cleanupGeneration === undefined) {
+    return false;
+  }
   if (typeof entry.delivery?.announcedAt === "number" || entry.delivery?.status === "delivered") {
-    const cleanupGeneration = beginSubagentCleanup(context, runId);
-    if (cleanupGeneration === undefined) {
-      return false;
-    }
     runDetachedCleanupAttempt(context, {
       runId,
       entry,
@@ -428,10 +423,6 @@ export const startSubagentAnnounceCleanupFlow = (
       },
     });
     return true;
-  }
-  const cleanupGeneration = beginSubagentCleanup(context, runId);
-  if (cleanupGeneration === undefined) {
-    return false;
   }
   const cleanupSessionEntry = suppressSessionEffects
     ? undefined
@@ -533,12 +524,16 @@ export const startSubagentAnnounceCleanupFlow = (
       await retireSupersededCleanupIfNeeded(context, runId, entry, cleanupGeneration);
       return;
     }
-    const shouldCreditPriorDelivery =
-      announceOutcome !== "delivered" && (await hasPriorRequesterDeliveryMirror(params, entry));
+    const hasDeliveryMirror =
+      announceOutcome !== "delivered" &&
+      entry.delivery?.status !== "delivered" &&
+      (await hasPriorRequesterDeliveryMirror(params, entry));
     if (!context.isCleanupAttemptCurrent(runId, entry, cleanupGeneration)) {
       await retireSupersededCleanupIfNeeded(context, runId, entry, cleanupGeneration);
       return;
     }
+    // Requester-settle can commit delivery while the mirror lookup is pending.
+    const shouldCreditPriorDelivery = entry.delivery?.status === "delivered" || hasDeliveryMirror;
     if (shouldCreditPriorDelivery) {
       latestDeliveryError = undefined;
     }
@@ -578,6 +573,7 @@ export const startSubagentAnnounceCleanupFlow = (
     isChildSessionEffectsAllowed: childSessionEffectsAllowed,
     isCompletionDeliveryAllowed: () =>
       entry.suppressCompletionDelivery !== true &&
+      entry.delivery?.status !== "delivered" &&
       context.isCleanupAttemptCurrent(runId, entry, cleanupGeneration),
     isCompletionOwnedByRequesterYield: () =>
       entry.requesterTurnYielded === true ||
@@ -620,6 +616,10 @@ export const startSubagentAnnounceCleanupFlow = (
       const previousDropReason = entry.delivery?.lastDropReason;
       if (!context.isCleanupAttemptCurrent(runId, entry, cleanupGeneration)) {
         retireSupersededCleanupInBackground(context, runId, entry, cleanupGeneration);
+        return;
+      }
+      // A stale announce cannot replace a delivery already committed by requester-settle.
+      if (entry.delivery?.status === "delivered") {
         return;
       }
       recordAnnounceDeliveryResult(entry, delivery, params.runs);

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
@@ -209,7 +209,8 @@ export const hasPriorRequesterDeliveryMirror = async (
         text === expectedText
       );
     });
-    if (mirror) {
+    // A late history result must not replace the newer requester delivery timestamp.
+    if (mirror && entry.delivery?.status !== "delivered") {
       ensureDeliveryState(entry).deliveredAt = (mirror as { timestamp: number }).timestamp;
     }
     return Boolean(mirror);
@@ -474,6 +475,7 @@ export const clearSubagentPendingDelivery = (entry: SubagentRunRecord) => {
   delivery.payload = undefined;
   delivery.createdAt = undefined;
   delivery.lastAttemptAt = undefined;
+  delivery.nextAttemptAt = undefined;
   delivery.attemptCount = undefined;
   delivery.lastError = undefined;
   delivery.suspendedAt = undefined;

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
@@ -21,6 +21,7 @@ import type {
 } from "./subagent-registry-lifecycle-context.js";
 import {
   buildSafeLifecycleErrorMeta,
+  clearSubagentPendingDelivery,
   markRequesterSettleWakePending,
   maskLifecycleIdentifier,
   safeSetSubagentTaskDeliveryStatus,
@@ -106,7 +107,7 @@ const completeRequesterSettleWakeBatch = (
   }
   const requesterSessionKeys = new Set(entries.map((entry) => entry.requesterSessionKey));
   const previousStates = entries.map((entry) => ({
-    delivery: structuredClone(entry.delivery),
+    delivery: outcome?.delivered ? entry.delivery : structuredClone(entry.delivery),
     requesterSettleWake: structuredClone(entry.requesterSettleWake),
     retireAfterRequesterTurn: entry.retireAfterRequesterTurn,
     suppressCompletionDelivery: entry.suppressCompletionDelivery,
@@ -114,6 +115,11 @@ const completeRequesterSettleWakeBatch = (
   const settledDeliveries: SubagentRunRecord[] = [];
   for (const entry of entries) {
     const { runId } = entry;
+    if (outcome?.delivered && entry.expectsCompletionMessage === true) {
+      // Replace the receipt owner even if an older multipart send already committed a chunk.
+      // Its retained guard must stay closed after this wake is cleared.
+      entry.delivery = { ...ensureDeliveryState(entry) };
+    }
     if (
       outcome &&
       entry.expectsCompletionMessage === true &&
@@ -126,7 +132,7 @@ const completeRequesterSettleWakeBatch = (
         delivery.disposition = "delivered";
         delivery.deliveredAt = deliveredAt;
         delivery.announcedAt = deliveredAt;
-        delivery.lastError = undefined;
+        clearSubagentPendingDelivery(entry);
         delivery.lastDropReason = undefined;
       } else {
         const error = outcome.error ?? outcome.reason ?? "requester settle wake failed";

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -4295,6 +4295,108 @@ describe("subagent registry lifecycle hardening", () => {
     expect(persist).toHaveBeenCalled();
   });
 
+  it.each([
+    { waitingOn: "announce", outcome: "intentional_non_delivery" },
+    { waitingOn: "announce", outcome: "retryable" },
+    { waitingOn: "mirror", outcome: "intentional_non_delivery" },
+    { waitingOn: "mirror", outcome: "retryable" },
+  ] as const)(
+    "preserves requester-settle delivery while $outcome cleanup awaits $waitingOn",
+    async ({ waitingOn, outcome }) => {
+      const entry = createRunEntry({
+        endedAt: Date.now(),
+        outcome: { status: "timeout" },
+        requesterTurnRunId: "run-requester",
+        expectsCompletionMessage: true,
+        retainAttachmentsOnKeep: true,
+        completion: { required: true, resultText: "child timed out" },
+        delivery: { status: "pending", attemptCount: 1 },
+      });
+      entry.delivery!.payload = loadPendingFinalDeliveryPayload(entry);
+      const announce = createDeferredCore<void>();
+      const mirror = createDeferredCore<{ messages: unknown[] }>();
+      const runSubagentAnnounceFlow = vi.fn<LifecycleControllerParams["runSubagentAnnounceFlow"]>(
+        async (params) => {
+          await announce.promise;
+          params.onDeliveryResult?.({
+            delivered: false,
+            path: "direct",
+            error: "completion agent did not produce a visible reply",
+            disposition: outcome,
+          });
+          return outcome;
+        },
+      );
+      gatewayMocks.callGateway.mockImplementation(() => mirror.promise);
+      const controller = createLifecycleController({
+        entry,
+        runSubagentAnnounceFlow,
+        maybeWakeRequesterAfterAllChildrenSettled: async (params) => {
+          params.completeBatch([entry], entry.requesterSettleWake?.rearmGeneration, {
+            delivered: true,
+            path: "direct",
+            deliveredAt: 12_345,
+            requesterVisibleFinalDelivered: true,
+          });
+          return true;
+        },
+      });
+
+      try {
+        expect(controller.startSubagentAnnounceCleanupFlow(entry.runId, entry)).toBe(true);
+        await waitForLifecycleState(() => expect(runSubagentAnnounceFlow).toHaveBeenCalledOnce());
+        if (waitingOn === "mirror") {
+          announce.resolve();
+          await waitForLifecycleState(() =>
+            expect(gatewayMocks.callGateway).toHaveBeenCalledWith(
+              expect.objectContaining({ method: "chat.history" }),
+            ),
+          );
+        }
+        const announceParams = runSubagentAnnounceFlow.mock.calls[0]![0];
+        expect(announceParams.isCompletionDeliveryAllowed?.()).toBe(true);
+        entry.requesterTurnYielded = true;
+        expect(
+          controller.settleRequesterTurnAfterSessionSpawns({
+            requesterSessionKey: entry.requesterSessionKey,
+            requesterTurnRunId: "run-requester",
+            requesterYielded: true,
+            acceptedSessionSpawns: [{ runId: entry.runId, childSessionKey: entry.childSessionKey }],
+          }),
+        ).toBe(true);
+        await waitForLifecycleState(() => expect(entry.delivery?.status).toBe("delivered"));
+        expect(entry.requesterSettleWake).toBeUndefined();
+        expect(announceParams.isCompletionOwnedByRequesterYield?.()).toBe(false);
+        expect.soft(announceParams.isCompletionDeliveryAllowed?.()).toBe(false);
+
+        announce.resolve();
+        mirror.resolve({ messages: [] });
+        await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
+        expect(entry.delivery).toMatchObject({
+          status: "delivered",
+          disposition: "delivered",
+          deliveredAt: 12_345,
+          announcedAt: 12_345,
+          payload: undefined,
+          lastError: undefined,
+          attemptCount: undefined,
+        });
+        expect(taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId).toHaveBeenLastCalledWith({
+          runId: entry.runId,
+          runtime: "subagent",
+          sessionKey: entry.childSessionKey,
+          deliveryStatus: "delivered",
+          error: undefined,
+        });
+      } finally {
+        announce.resolve();
+        mirror.resolve({ messages: [] });
+        await waitForLifecycleState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+        controller.clearScheduledResumeTimers();
+      }
+    },
+  );
+
   it("credits only current-run requester delivery mirrors before retrying NO_REPLY", async () => {
     const entry = await runNoReplyMirrorScenario({ timestamp: 12_345 });
 

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -3316,7 +3316,7 @@ describe("subagent registry lifecycle hardening", () => {
     await waitForLifecycleState(() => expect(entry.delivery?.status).toBe("suspended"));
   });
 
-  it("persists identified completion delivery before stalled announce bookkeeping settles", async () => {
+  it("persists identified completion delivery while completing the active multipart send", async () => {
     const persist = vi.fn();
     const entry = createRunEntry({
       expectsCompletionMessage: true,
@@ -3324,19 +3324,28 @@ describe("subagent registry lifecycle hardening", () => {
         status: "pending",
         lastError: "earlier delivery failed",
         lastDropReason: "sink_unavailable",
+        nextAttemptAt: 13_000,
       },
     });
     let releaseAnnounce!: () => void;
     const announcePending = new Promise<void>((resolve) => {
       releaseAnnounce = resolve;
     });
+    const sentChunks: number[] = [];
     const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
       async (announceParams) => {
-        announceParams.onDeliveryResult?.({
-          delivered: true,
-          path: "direct",
-          deliveredAt: 12_300,
-        });
+        for (const chunk of [1, 2, 3]) {
+          if (announceParams.isCompletionDeliveryAllowed?.() === false) {
+            break;
+          }
+          sentChunks.push(chunk);
+          announceParams.onDeliveryResult?.({
+            delivered: true,
+            path: "direct",
+            deliveredAt: 12_300,
+          });
+          await Promise.resolve();
+        }
         await announcePending;
         return "delivered" as const;
       },
@@ -3366,9 +3375,11 @@ describe("subagent registry lifecycle hardening", () => {
     expect(entry.delivery?.lastDropReason).toBeUndefined();
     expect(entry.cleanupCompletedAt).toBeUndefined();
     expect(persist).toHaveBeenCalledWith(entry.runId);
+    expect.soft(sentChunks).toEqual([1, 2, 3]);
 
     releaseAnnounce();
     await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
+    expect(entry.delivery?.nextAttemptAt).toBeUndefined();
   });
 
   it("keeps a late superseded-delivery retirement root-admitted", async () => {
@@ -4300,6 +4311,8 @@ describe("subagent registry lifecycle hardening", () => {
     { waitingOn: "announce", outcome: "retryable" },
     { waitingOn: "mirror", outcome: "intentional_non_delivery" },
     { waitingOn: "mirror", outcome: "retryable" },
+    { waitingOn: "active-send", outcome: "delivered" },
+    { waitingOn: "delivered-mirror", outcome: "retryable" },
   ] as const)(
     "preserves requester-settle delivery while $outcome cleanup awaits $waitingOn",
     async ({ waitingOn, outcome }) => {
@@ -4313,11 +4326,17 @@ describe("subagent registry lifecycle hardening", () => {
         delivery: { status: "pending", attemptCount: 1 },
       });
       entry.delivery!.payload = loadPendingFinalDeliveryPayload(entry);
-      const announce = createDeferredCore<void>();
+      const announce = createDeferredCore();
       const mirror = createDeferredCore<{ messages: unknown[] }>();
       const runSubagentAnnounceFlow = vi.fn<LifecycleControllerParams["runSubagentAnnounceFlow"]>(
         async (params) => {
+          if (waitingOn === "active-send") {
+            params.onDeliveryResult?.({ delivered: true, path: "direct", deliveredAt: 12_345 });
+          }
           await announce.promise;
+          if (waitingOn === "active-send") {
+            return outcome;
+          }
           params.onDeliveryResult?.({
             delivered: false,
             path: "direct",
@@ -4345,7 +4364,7 @@ describe("subagent registry lifecycle hardening", () => {
       try {
         expect(controller.startSubagentAnnounceCleanupFlow(entry.runId, entry)).toBe(true);
         await waitForLifecycleState(() => expect(runSubagentAnnounceFlow).toHaveBeenCalledOnce());
-        if (waitingOn === "mirror") {
+        if (waitingOn === "mirror" || waitingOn === "delivered-mirror") {
           announce.resolve();
           await waitForLifecycleState(() =>
             expect(gatewayMocks.callGateway).toHaveBeenCalledWith(
@@ -4365,12 +4384,27 @@ describe("subagent registry lifecycle hardening", () => {
           }),
         ).toBe(true);
         await waitForLifecycleState(() => expect(entry.delivery?.status).toBe("delivered"));
+        expect.soft(entry.delivery).toMatchObject({ payload: undefined, attemptCount: undefined });
         expect(entry.requesterSettleWake).toBeUndefined();
         expect(announceParams.isCompletionOwnedByRequesterYield?.()).toBe(false);
         expect.soft(announceParams.isCompletionDeliveryAllowed?.()).toBe(false);
 
         announce.resolve();
-        mirror.resolve({ messages: [] });
+        mirror.resolve({
+          messages:
+            waitingOn === "delivered-mirror"
+              ? [
+                  {
+                    role: "assistant",
+                    provider: "openclaw",
+                    model: "delivery-mirror",
+                    timestamp: 12_300,
+                    idempotencyKey: buildExpectedAnnounceIdempotencyKey(entry),
+                    content: "child timed out",
+                  },
+                ]
+              : [],
+        });
         await waitForLifecycleState(() => expect(entry.cleanupCompletedAt).toBeTypeOf("number"));
         expect(entry.delivery).toMatchObject({
           status: "delivered",

--- a/src/agents/subagents/registry/subagent-registry.requester-wake.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.requester-wake.e2e.test.ts
@@ -52,6 +52,17 @@ let releaseAgentCallGate: (() => void) | undefined;
 let chatHistoryBySessionKey = new Map<string, Array<Record<string, unknown>>>();
 let sessionStore: Record<string, SessionStoreEntry> = {};
 let rejectNextRequesterWake = false;
+let emptyGatedAgentReply = false;
+
+const sendMessageMock = vi.fn<typeof import("../../../infra/outbound/message.js").sendMessage>(
+  async () => ({
+    channel: "discord",
+    to: "user-1",
+    via: "direct",
+    mediaUrl: null,
+    result: { messageId: "unexpected-fallback" },
+  }),
+);
 
 const callGatewayMock = vi.fn(async (request: GatewayRequest) => {
   if (request.method === "agent.wait") {
@@ -65,6 +76,9 @@ const callGatewayMock = vi.fn(async (request: GatewayRequest) => {
     const gate = sourceSessionKey ? agentCallGates.get(sourceSessionKey) : undefined;
     if (gate) {
       await gate;
+      if (emptyGatedAgentReply) {
+        return { result: { payloads: [] } };
+      }
     }
     return {
       result: {
@@ -134,6 +148,8 @@ describe("requester settle wake product flow", () => {
     agentCallGates = new Map();
     chatHistoryBySessionKey = new Map();
     rejectNextRequesterWake = false;
+    emptyGatedAgentReply = false;
+    sendMessageMock.mockClear();
     sessionStore = {
       [MAIN_REQUESTER_SESSION_KEY]: {
         sessionId: "sess-main",
@@ -173,6 +189,7 @@ describe("requester settle wake product flow", () => {
       loadSubagentRegistryRuntime: loadSubagentRegistryRuntimeForTest,
     });
     subagentAnnounceDeliveryTesting.setDepsForTest({
+      sendMessage: sendMessageMock,
       callGateway: callGatewayMock as typeof import("../../../gateway/call.js").callGateway,
       getRuntimeConfig:
         loadConfigMock as typeof import("../../../config/config.js").getRuntimeConfig,
@@ -449,9 +466,19 @@ describe("requester settle wake product flow", () => {
   );
 
   it.each([
-    { name: "delivers the visible requester final", rejectRequesterWake: false },
-    { name: "settles the rejected delivered-row wake", rejectRequesterWake: true },
-  ])("$name", async ({ rejectRequesterWake }) => {
+    { name: "delivers the visible requester final", rejectRequesterWake: false, emptyReply: false },
+    {
+      name: "settles the rejected delivered-row wake",
+      rejectRequesterWake: true,
+      emptyReply: false,
+    },
+    {
+      name: "retires a stale empty announce after requester delivery",
+      rejectRequesterWake: false,
+      emptyReply: true,
+    },
+  ])("$name", async ({ rejectRequesterWake, emptyReply }) => {
+    emptyGatedAgentReply = emptyReply;
     const requesterTurnRunId = "run-requester-yield";
     const alpha = {
       runId: "run-alpha",
@@ -548,6 +575,14 @@ describe("requester settle wake product flow", () => {
     await waitForDeliveredCleanup(beta.runId);
     await registry.testing.sweepOnceForTests();
     expect(getRequesterWakeCalls()).toHaveLength(rejectRequesterWake ? 0 : 1);
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(registry.getSubagentRunByRunId(beta.runId)?.delivery).toMatchObject({
+      status: "delivered",
+      disposition: "delivered",
+      payload: undefined,
+      lastError: undefined,
+      lastDropReason: undefined,
+    });
   });
 
   it("caps a stale requester batch despite foreign active work in a global session", async () => {


### PR DESCRIPTION
Closes #138802

## What Problem This Solves

- An older subagent announce can resume after requester settlement has delivered the parent final.
- Its late callback can restore pending delivery, an old error, and retry state.
- A matching history result can also replace the newer delivery timestamps.

## Why This Change Was Made

- Keep terminal delivery in the existing subagent lifecycle owner.
- Preserve row, generation, and suppression checks.
- Let an active multipart send retain its own delivery record, but replace that ownership when requester settlement succeeds.
- Recheck delivered state after awaited history work and keep newer timestamps.
- Reuse the existing retry-state clearer in both receipt producers and cleanup.

Production LOC: +32/-33, net -1. Tests: +180/-9, net +171.

## User Impact

- One delivered parent final stays delivered.
- Late child callbacks cannot reopen its delivery or restore stale retries.
- An active multipart fallback still sends every chunk.
- The timeout outcome and Task status stay timed out; the parent notification stays delivered.
- No configuration, schema, dependency, or public protocol changes.

## Evidence

| Real product flow | Current main | Repaired candidate |
| --- | --- | --- |
| Completed child, older announce held across requester settlement | Delivered child state changes to pending and regains retry data | One parent final; child and Task remain delivered; cleanup completes |
| Actual history response held across requester settlement | Child and Task delivery both change from delivered to pending | Delivery and original timestamps stay terminal |
| Timed-out child, older announce resumes after the timeout notification | Child delivery changes to pending | One truthful timeout notification; delivery stays delivered |
| Telegram direct fallback split into three messages | Full report arrives | Full report still arrives, including every numbered line and the end marker |

- Discord proof uses real mention ingress, Gateway tools, channel sends, and read-only observation of real SQLite state.
- Timing-only instrumentation pauses existing calls; it does not substitute results or edit rows.
- Telegram proof uses a leased Test Server user and bot, with no timing instrumentation or mocked Telegram responses.
- Baseline main: `b6a2e5b4eff71070a02e755d55aea0dd53904a20`, using [CI run 33962732030](https://github.com/openclaw/openclaw/actions/runs/33962732030).
- Candidate: `eddad23d881f90105cfae7542f3f868c2f8ff3a0`. All 37,933 tracked source files and symlink targets match the tested archive. Its build metadata was not rewritten.
- 519 focused tests pass: 507 unit and 12 registry/announce integration tests.
- New regressions failed before their fixes: multipart truncation, stale retry state, active-send takeover, and late history timestamps.
- Focused lint, pinned formatting, runtime build, and independent review pass. Exact-head CI is checked before landing.
- Both ClawSweeper rank-up requests are addressed: active-send ownership and real Gateway/transport evidence.

Separate follow-ups, not claimed fixed here:

- An already-admitted generated-media queue racing requester settlement.
- Continuation after a partial transport failure following an identified first send; this repair preserves the existing no-replay contract.
- Visible-session spawning from a Telegram direct chat returned an unknown-parent-session error during setup; multipart proof uses the normal hidden-spawn path.
- The timeout run returns the separate registry execution-status field to `running` on both main and the candidate. This repair preserves delivery, the timeout outcome, and Task status; it does not repair that pre-existing projection.

Original implementation by @NianJiuZst. Reported by @josephbergvinson in #138802.

<!-- agent-transcript:start -->
## Agent Transcript

This existing contributor excerpt describes the initial patch.

<details>
<summary>Redacted session excerpt</summary>

Only the task request and relevant visible decisions are retained. Tool outputs, instructions, local paths, credentials, and unrelated discussion are omitted.

**User:** https://github.com/openclaw/openclaw/issues/138802 — 完成新pr修复这个issue

**Assistant:** 复现成功：4 个阻塞时序都出现了问题。父回复已记为“已交付”后，旧回调仍允许发送；晚到清理还会把状态改回 pending 或 failed，并留下旧错误。修复会让现有生命周期明确保留“已交付”这一终态。

**Assistant:** 修复后，4 个竞态回归用例已通过，生产代码净增为 0。另一个检查发现晚到的结果回调也会覆盖交付记录，已一并修复。接下来会补充经过真实 announce 流程的边界测试，再运行相关测试和独立审查。

**Assistant:** 相关测试全部通过：478 个单元测试和 12 个集成测试，包括新增的竞态场景。独立审查经公开性核验后已完成，未发现 P0 阻塞问题；现在进行最后的静态检查并整理 PR 说明。

</details>
<!-- agent-transcript:end -->
