### PR TITLE
fix(cli): share recorded gateway state path inspection

### DIFF
--- a/docs/cli/configure.md
+++ b/docs/cli/configure.md
@@ -19,6 +19,8 @@ Use `openclaw onboard` or `openclaw setup` for the full guided first-run journey
 
 Before `openclaw configure` changes local credentials or configuration, OpenClaw compares the selected CLI state/config paths with the local Gateway or its installed service. A proven mismatch stops before the write. A remote Gateway or an authenticated path that cannot be verified produces a warning instead.
 
+This comparison also applies when `OPENCLAW_HOME` relocates the CLI's default state directory. The installed service's recorded environment determines its paths, including while the Gateway is stopped; the CLI's path overrides do not replace them.
+
 `--section <section>`: repeatable section filter. Available sections:
 
 `workspace`, `model`, `web`, `gateway`, `daemon`, `channels`, `plugins`, `skills`, `health`

--- a/docs/cli/configure.md
+++ b/docs/cli/configure.md
@@ -19,7 +19,7 @@ Use `openclaw onboard` or `openclaw setup` for the full guided first-run journey
 
 Before `openclaw configure` changes local credentials or configuration, OpenClaw compares the selected CLI state/config paths with the local Gateway or its installed service. A proven mismatch stops before the write. A remote Gateway or an authenticated path that cannot be verified produces a warning instead.
 
-This comparison also applies when `OPENCLAW_HOME` relocates the CLI's default state directory. The installed service's recorded environment determines its paths, including while the Gateway is stopped; the CLI's path overrides do not replace them.
+This comparison also applies when `OPENCLAW_HOME` relocates the CLI's default state directory. The installed service's recorded environment determines its paths, including while the Gateway is stopped; the CLI's path overrides do not replace them. If the service definition or its recorded paths cannot be verified, OpenClaw warns and leaves configuration available. Inspect the service with `openclaw gateway status --deep` before relying on local changes to reach it.
 
 `--section <section>`: repeatable section filter. Available sections:
 

--- a/src/cli/program/preaction-state-store.test.ts
+++ b/src/cli/program/preaction-state-store.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   action: vi.fn(),
   check: vi.fn<() => Promise<CliGatewayStateDirOutcome>>(async () => ({ kind: "allow" })),
   debug: vi.fn(),
+  log: vi.fn(),
   ensureBootstrap: vi.fn(async () => {}),
 }));
 
@@ -13,7 +14,7 @@ vi.mock("../state-dir-gateway-check.js", () => ({ checkCliGatewayStateDir: mocks
 vi.mock("../../logger.js", () => ({ logDebug: mocks.debug }));
 vi.mock("../../runtime.js", () => ({
   defaultRuntime: {
-    log: vi.fn(),
+    log: mocks.log,
     error: vi.fn(),
     writeStdout: vi.fn(),
     writeJson: vi.fn(),
@@ -66,6 +67,18 @@ describe("state-store preAction guard", () => {
     await expect(program.parseAsync(process.argv)).resolves.toBe(program);
 
     expect(mocks.debug).toHaveBeenCalledWith("state-store guard unavailable: inspection failed");
+    expect(mocks.action).toHaveBeenCalledOnce();
+  });
+
+  it("shows an unknown-path warning while allowing the action", async () => {
+    mocks.check.mockResolvedValueOnce({
+      kind: "warn",
+      message: "Service paths could not be verified.",
+    });
+
+    await expect(program.parseAsync(process.argv)).resolves.toBe(program);
+
+    expect(mocks.log).toHaveBeenCalledWith("Service paths could not be verified.");
     expect(mocks.action).toHaveBeenCalledOnce();
   });
 });

--- a/src/cli/state-dir-gateway-check.test.ts
+++ b/src/cli/state-dir-gateway-check.test.ts
@@ -116,6 +116,40 @@ describe("state-dir-gateway-check", () => {
     expect(mocks.probeGateway).not.toHaveBeenCalled();
   });
 
+  it.each([false, true])(
+    "refuses an offline home mismatch when the service sets OPENCLAW_HOME: %s",
+    async (serviceSetsHome) => {
+      const canonicalRoot = await fs.realpath(root);
+      const serviceHome = path.join(canonicalRoot, "service-home");
+      const cliHome = path.join(canonicalRoot, "cli-home");
+      const serviceRuntimeHome = serviceSetsHome ? path.join(serviceHome, "runtime") : serviceHome;
+      await fs.mkdir(serviceHome);
+      await fs.mkdir(cliHome);
+      vi.stubEnv("HOME", serviceHome);
+      vi.stubEnv("OPENCLAW_HOME", cliHome);
+      vi.stubEnv("OPENCLAW_STATE_DIR", undefined);
+      vi.stubEnv("OPENCLAW_CONFIG_PATH", undefined);
+      mocks.readGatewayServiceState.mockImplementation(
+        async (_service: unknown, options: { env: NodeJS.ProcessEnv }) => ({
+          installed: true,
+          running: false,
+          env: {
+            ...options.env,
+            HOME: serviceHome,
+            ...(serviceSetsHome ? { OPENCLAW_HOME: serviceRuntimeHome } : {}),
+          },
+        }),
+      );
+
+      await expect(
+        checkCliGatewayStateDir({ command: "openclaw configure", config: {} }),
+      ).resolves.toMatchObject({
+        kind: "refuse",
+        message: expect.stringContaining(path.join(serviceRuntimeHome, ".openclaw")),
+      });
+    },
+  );
+
   it("refuses paths from an authenticated hello without service fallback", async () => {
     const gatewayStateDir = path.join(root, "gateway");
     const gatewayConfigPath = path.join(gatewayStateDir, "openclaw.json");

--- a/src/cli/state-dir-gateway-check.test.ts
+++ b/src/cli/state-dir-gateway-check.test.ts
@@ -6,8 +6,8 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 const mocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
   probeGateway: vi.fn(),
-  readGatewayServiceState: vi.fn(),
-  resolveGatewayService: vi.fn(() => ({})),
+  readServiceCommand: vi.fn(),
+  resolveGatewayService: vi.fn(),
 }));
 
 vi.mock("../gateway/call.js", async (importOriginal) => ({
@@ -19,7 +19,6 @@ vi.mock("../gateway/probe.js", async (importOriginal) => ({
   probeGateway: mocks.probeGateway,
 }));
 vi.mock("../daemon/service.js", () => ({
-  readGatewayServiceState: mocks.readGatewayServiceState,
   resolveGatewayService: mocks.resolveGatewayService,
 }));
 
@@ -42,11 +41,10 @@ describe("state-dir-gateway-check", () => {
     vi.stubEnv("OPENCLAW_CONFIG_PATH", cliConfigPath);
     mocks.callGateway.mockReset().mockRejectedValue(new Error("ECONNREFUSED"));
     mocks.probeGateway.mockReset().mockResolvedValue({ ok: false });
-    mocks.readGatewayServiceState.mockReset().mockResolvedValue({
-      installed: false,
-      env: {},
-    });
-    mocks.resolveGatewayService.mockClear();
+    mocks.resolveGatewayService
+      .mockReset()
+      .mockReturnValue({ readCommand: mocks.readServiceCommand });
+    mocks.readServiceCommand.mockReset().mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -73,38 +71,31 @@ describe("state-dir-gateway-check", () => {
     ).toEqual({ kind: "allow" });
   });
 
-  it.each([true, false, undefined])(
-    "refuses an installed service mismatch when running is %s",
-    async (running) => {
-      const gatewayStateDir = path.join(root, "service");
-      const gatewayConfigPath = path.join(gatewayStateDir, "openclaw.json");
-      await fs.mkdir(gatewayStateDir);
-      mocks.readGatewayServiceState.mockImplementation(
-        async (_service: unknown, options: { env: NodeJS.ProcessEnv }) => ({
-          installed: true,
-          running,
-          env: {
-            ...options.env,
-            OPENCLAW_STATE_DIR: gatewayStateDir,
-            OPENCLAW_CONFIG_PATH: gatewayConfigPath,
-          },
-        }),
-      );
+  it("refuses an installed service mismatch from its recorded environment", async () => {
+    const gatewayStateDir = path.join(root, "service");
+    const gatewayConfigPath = path.join(gatewayStateDir, "openclaw.json");
+    await fs.mkdir(gatewayStateDir);
+    mocks.readServiceCommand.mockResolvedValue({
+      programArguments: ["node", "gateway.js"],
+      environment: {
+        OPENCLAW_STATE_DIR: gatewayStateDir,
+        OPENCLAW_CONFIG_PATH: gatewayConfigPath,
+      },
+    });
 
-      await expect(
-        checkCliGatewayStateDir({ command: "openclaw channels add", config: {} }),
-      ).resolves.toMatchObject({ kind: "refuse" });
-      const inspectedEnv = mocks.readGatewayServiceState.mock.calls[0]?.[1]?.env;
-      expect(inspectedEnv).not.toHaveProperty("OPENCLAW_STATE_DIR");
-      expect(inspectedEnv).not.toHaveProperty("OPENCLAW_CONFIG_PATH");
-    },
-  );
+    await expect(
+      checkCliGatewayStateDir({ command: "openclaw channels add", config: {} }),
+    ).resolves.toMatchObject({ kind: "refuse" });
+    const inspectedEnv = mocks.readServiceCommand.mock.calls[0]?.[0];
+    expect(inspectedEnv).not.toHaveProperty("OPENCLAW_STATE_DIR");
+    expect(inspectedEnv).not.toHaveProperty("OPENCLAW_CONFIG_PATH");
+    expect(mocks.readServiceCommand.mock.calls[0]?.[1]).toMatchObject({ requireEffective: true });
+  });
 
   it("allows a matching installed service without probing", async () => {
-    mocks.readGatewayServiceState.mockResolvedValue({
-      installed: true,
-      running: false,
-      env: {
+    mocks.readServiceCommand.mockResolvedValue({
+      programArguments: ["node", "gateway.js"],
+      environment: {
         OPENCLAW_STATE_DIR: cliStateDir,
         OPENCLAW_CONFIG_PATH: cliConfigPath,
       },
@@ -129,17 +120,13 @@ describe("state-dir-gateway-check", () => {
       vi.stubEnv("OPENCLAW_HOME", cliHome);
       vi.stubEnv("OPENCLAW_STATE_DIR", undefined);
       vi.stubEnv("OPENCLAW_CONFIG_PATH", undefined);
-      mocks.readGatewayServiceState.mockImplementation(
-        async (_service: unknown, options: { env: NodeJS.ProcessEnv }) => ({
-          installed: true,
-          running: false,
-          env: {
-            ...options.env,
-            HOME: serviceHome,
-            ...(serviceSetsHome ? { OPENCLAW_HOME: serviceRuntimeHome } : {}),
-          },
-        }),
-      );
+      mocks.readServiceCommand.mockResolvedValue({
+        programArguments: ["node", "gateway.js"],
+        environment: {
+          HOME: serviceHome,
+          ...(serviceSetsHome ? { OPENCLAW_HOME: serviceRuntimeHome } : {}),
+        },
+      });
 
       await expect(
         checkCliGatewayStateDir({ command: "openclaw configure", config: {} }),
@@ -168,7 +155,7 @@ describe("state-dir-gateway-check", () => {
     await expect(
       checkCliGatewayStateDir({ command: "openclaw channels add", config: {} }),
     ).resolves.toMatchObject({ kind: "refuse" });
-    expect(mocks.readGatewayServiceState).not.toHaveBeenCalled();
+    expect(mocks.readServiceCommand).not.toHaveBeenCalled();
   });
 
   it("warns only when a credential-blocked protocol probe reaches an unowned Gateway", async () => {
@@ -207,6 +194,45 @@ describe("state-dir-gateway-check", () => {
       }),
     ).resolves.toMatchObject({ kind: "warn" });
     expect(mocks.callGateway).not.toHaveBeenCalled();
-    expect(mocks.readGatewayServiceState).not.toHaveBeenCalled();
+    expect(mocks.readServiceCommand).not.toHaveBeenCalled();
+  });
+
+  it("warns when service inspection is unavailable without exposing its error", async () => {
+    const error = new Error("private-service-inspection-canary");
+    mocks.readServiceCommand.mockRejectedValue(error);
+
+    const result = await checkCliGatewayStateDir({ command: "openclaw configure", config: {} });
+    expect(result).toMatchObject({
+      kind: "warn",
+      message: expect.stringContaining("could not be verified"),
+    });
+    expect(JSON.stringify(result)).not.toContain("private-service-inspection-canary");
+  });
+
+  it("does not infer service paths from the CLI environment", async () => {
+    mocks.readServiceCommand.mockResolvedValue({
+      programArguments: ["node", "gateway.js"],
+      environment: { PATH: "/synthetic/bin" },
+    });
+
+    await expect(
+      checkCliGatewayStateDir({ command: "openclaw configure", config: {} }),
+    ).resolves.toMatchObject({ kind: "warn" });
+  });
+
+  it("redacts credentials in remote target warnings", async () => {
+    const result = await checkCliGatewayStateDir({
+      command: "openclaw configure",
+      config: {
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "wss://private-url-user:private-url-password@gateway.example?token=private-url-token",
+          },
+        },
+      },
+    });
+    expect(result.kind).toBe("warn");
+    expect(JSON.stringify(result)).not.toContain("private-url-");
   });
 });

--- a/src/cli/state-dir-gateway-check.ts
+++ b/src/cli/state-dir-gateway-check.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveServiceInspectionEnv } from "../daemon/service-env-merge.js";
 import { readGatewayServiceState, resolveGatewayService } from "../daemon/service.js";
 import {
   buildGatewayConnectionDetails,
@@ -108,12 +109,8 @@ export async function checkCliGatewayStateDir(params: {
     });
   }
 
-  const serviceEnv = { ...process.env };
-  // Caller path overrides select the write target, not the installed service definition.
-  delete serviceEnv.OPENCLAW_STATE_DIR;
-  delete serviceEnv.OPENCLAW_CONFIG_PATH;
   const serviceState = await readGatewayServiceState(resolveGatewayService(), {
-    env: serviceEnv,
+    env: resolveServiceInspectionEnv(),
     timeoutMs: STATE_DIR_CHECK_TIMEOUT_MS,
   });
   if (serviceState.installed) {

--- a/src/cli/state-dir-gateway-check.ts
+++ b/src/cli/state-dir-gateway-check.ts
@@ -1,14 +1,14 @@
 import path from "node:path";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveServiceInspectionEnv } from "../daemon/service-env-merge.js";
-import { readGatewayServiceState, resolveGatewayService } from "../daemon/service.js";
+import { resolveGatewayService } from "../daemon/service.js";
 import {
   buildGatewayConnectionDetails,
   callGateway,
   isGatewayCredentialsRequiredError,
 } from "../gateway/call.js";
 import type { GatewayClientOptions } from "../gateway/client.js";
+import { projectGatewayUrlForDiagnostics } from "../gateway/connection-details.js";
 import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
 import { isLoopbackGatewayUrl } from "../gateway/net.js";
 import { probeGateway } from "../gateway/probe.js";
@@ -22,6 +22,46 @@ export type CliGatewayStateDirOutcome =
   | { kind: "allow" }
   | { kind: "warn"; message: string }
   | { kind: "refuse"; message: string };
+
+export const GATEWAY_SERVICE_PATHS_UNVERIFIED =
+  "Installed Gateway service state and config paths could not be verified. Inspect the service environment with `openclaw gateway status --deep` before repairing plugin state.";
+
+export async function inspectInstalledGatewayStatePaths(
+  timeoutMs = STATE_DIR_CHECK_TIMEOUT_MS,
+): Promise<
+  { kind: "known"; stateDir: string; configPath: string } | { kind: "absent" | "unknown" }
+> {
+  try {
+    const serviceEnv = { ...process.env };
+    // CLI overrides select its store; only recorded service values describe the other store.
+    delete serviceEnv.OPENCLAW_STATE_DIR;
+    delete serviceEnv.OPENCLAW_CONFIG_PATH;
+    delete serviceEnv.OPENCLAW_HOME;
+    const command = await resolveGatewayService().readCommand(serviceEnv, {
+      timeoutMs,
+      requireEffective: true,
+    });
+    if (!command) {
+      return { kind: "absent" };
+    }
+    const environment = command.environment;
+    if (
+      !environment ||
+      !["OPENCLAW_STATE_DIR", "OPENCLAW_HOME", "HOME", "USERPROFILE"].some((key) =>
+        environment[key]?.trim(),
+      )
+    ) {
+      return { kind: "unknown" };
+    }
+    return {
+      kind: "known",
+      stateDir: resolveStateDir(environment),
+      configPath: resolveConfigPath(environment),
+    };
+  } catch {
+    return { kind: "unknown" };
+  }
+}
 
 export function compareCliGatewayStateDirs(params: {
   cliStateDir: string;
@@ -76,7 +116,7 @@ export async function checkCliGatewayStateDir(params: {
   if (!isLoopbackGatewayUrl(details.url)) {
     return {
       kind: "warn",
-      message: `Gateway target ${details.url} is remote. Local credentials and configuration do not reach that Gateway.`,
+      message: `Gateway target ${projectGatewayUrlForDiagnostics(details.url)} is remote. Local credentials and configuration do not reach that Gateway.`,
     };
   }
 
@@ -109,16 +149,16 @@ export async function checkCliGatewayStateDir(params: {
     });
   }
 
-  const serviceState = await readGatewayServiceState(resolveGatewayService(), {
-    env: resolveServiceInspectionEnv(),
-    timeoutMs: STATE_DIR_CHECK_TIMEOUT_MS,
-  });
-  if (serviceState.installed) {
+  const servicePaths = await inspectInstalledGatewayStatePaths();
+  if (servicePaths.kind === "unknown") {
+    return { kind: "warn", message: GATEWAY_SERVICE_PATHS_UNVERIFIED };
+  }
+  if (servicePaths.kind === "known") {
     return compareCliGatewayStateDirs({
       cliStateDir,
       cliConfigPath,
-      gatewayStateDir: resolveStateDir(serviceState.env),
-      gatewayConfigPath: resolveConfigPath(serviceState.env),
+      gatewayStateDir: servicePaths.stateDir,
+      gatewayConfigPath: servicePaths.configPath,
       source: "installed Gateway service",
       mode: "refuse",
       command: params.command,

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -6,6 +6,7 @@ import { probeGatewayStatus } from "../cli/daemon-cli/probe.js";
 import { compareCliGatewayStateDirs, type GatewayHello } from "../cli/state-dir-gateway-check.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveServiceInspectionEnv } from "../daemon/service-env-merge.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import {
   buildGatewayConnectionDetails,
@@ -107,12 +108,7 @@ async function noteInstalledGatewayStateDirectory(cfg: OpenClawConfig, timeoutMs
     if (!isLoopbackGatewayUrl(buildGatewayConnectionDetails({ config: cfg }).url)) {
       return;
     }
-    const serviceEnv = { ...process.env };
-    // CLI path overrides select its store, not the installed service's environment.
-    delete serviceEnv.OPENCLAW_STATE_DIR;
-    delete serviceEnv.OPENCLAW_CONFIG_PATH;
-    delete serviceEnv.OPENCLAW_HOME;
-    const command = await resolveGatewayService().readCommand(serviceEnv, {
+    const command = await resolveGatewayService().readCommand(resolveServiceInspectionEnv(), {
       timeoutMs: Math.min(timeoutMs, 3_000),
       requireEffective: true,
     });

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -3,11 +3,14 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { probeGatewayStatus } from "../cli/daemon-cli/probe.js";
-import { compareCliGatewayStateDirs, type GatewayHello } from "../cli/state-dir-gateway-check.js";
+import {
+  compareCliGatewayStateDirs,
+  GATEWAY_SERVICE_PATHS_UNVERIFIED,
+  inspectInstalledGatewayStatePaths,
+  type GatewayHello,
+} from "../cli/state-dir-gateway-check.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveServiceInspectionEnv } from "../daemon/service-env-merge.js";
-import { resolveGatewayService } from "../daemon/service.js";
 import {
   buildGatewayConnectionDetails,
   buildGatewayProbeConnectionDetails,
@@ -108,31 +111,14 @@ async function noteInstalledGatewayStateDirectory(cfg: OpenClawConfig, timeoutMs
     if (!isLoopbackGatewayUrl(buildGatewayConnectionDetails({ config: cfg }).url)) {
       return;
     }
-    const command = await resolveGatewayService().readCommand(resolveServiceInspectionEnv(), {
-      timeoutMs: Math.min(timeoutMs, 3_000),
-      requireEffective: true,
-    });
-    if (!command) {
-      return;
+    const paths = await inspectInstalledGatewayStatePaths(Math.min(timeoutMs, 3_000));
+    if (paths.kind === "known") {
+      noteGatewayStateDirectory(paths, "installed Gateway service");
+    } else if (paths.kind === "unknown") {
+      note(GATEWAY_SERVICE_PATHS_UNVERIFIED, "Gateway state directory");
     }
-    const environment = command.environment;
-    if (
-      !environment ||
-      !["OPENCLAW_STATE_DIR", "OPENCLAW_HOME", "HOME", "USERPROFILE"].some((key) =>
-        environment[key]?.trim(),
-      )
-    ) {
-      throw new Error("Service state paths are unavailable");
-    }
-    noteGatewayStateDirectory(
-      { stateDir: resolveStateDir(environment), configPath: resolveConfigPath(environment) },
-      "installed Gateway service",
-    );
   } catch {
-    note(
-      "Installed Gateway service state and config paths could not be verified. Inspect the service environment with `openclaw gateway status --deep` before repairing plugin state.",
-      "Gateway state directory",
-    );
+    note(GATEWAY_SERVICE_PATHS_UNVERIFIED, "Gateway state directory");
   }
 }
 

--- a/src/daemon/service-env-merge.ts
+++ b/src/daemon/service-env-merge.ts
@@ -1,14 +1,5 @@
 import type { GatewayServiceCommandConfig, GatewayServiceEnv } from "./service-types.js";
 
-export function resolveServiceInspectionEnv(): GatewayServiceEnv {
-  // Runtime path overrides select the CLI store, not the installed service definition.
-  const serviceEnv = { ...process.env };
-  delete serviceEnv.OPENCLAW_STATE_DIR;
-  delete serviceEnv.OPENCLAW_CONFIG_PATH;
-  delete serviceEnv.OPENCLAW_HOME;
-  return serviceEnv;
-}
-
 export function mergeGatewayServiceEnv(
   baseEnv: GatewayServiceEnv,
   command: GatewayServiceCommandConfig | null,

--- a/src/daemon/service-env-merge.ts
+++ b/src/daemon/service-env-merge.ts
@@ -1,5 +1,14 @@
 import type { GatewayServiceCommandConfig, GatewayServiceEnv } from "./service-types.js";
 
+export function resolveServiceInspectionEnv(): GatewayServiceEnv {
+  // Runtime path overrides select the CLI store, not the installed service definition.
+  const serviceEnv = { ...process.env };
+  delete serviceEnv.OPENCLAW_STATE_DIR;
+  delete serviceEnv.OPENCLAW_CONFIG_PATH;
+  delete serviceEnv.OPENCLAW_HOME;
+  return serviceEnv;
+}
+
 export function mergeGatewayServiceEnv(
   baseEnv: GatewayServiceEnv,
   command: GatewayServiceCommandConfig | null,


### PR DESCRIPTION
Related: #138342. Mandatory follow-up to landed #138746 (`bd8b3c806d4da76d0b21cbc3a8b5264eff3b1a2b`). Reported by @maxpcuser.

## What Problem This Solves

A CLI using `OPENCLAW_HOME` could falsely conclude that its state directory matched an offline installed Gateway. The write guard inherited the CLI's home override while reconstructing the service environment, allowing configuration against a different store. Failed service inspection could also disappear into a best-effort catch without an operator-visible warning.

## Why This Change Was Made

Doctor and the CLI write guard now share one strict installed-service path inspector. It excludes CLI state/config/home overrides from service selection and resolves paths from the service's recorded environment. The result distinguishes known paths, confirmed absence and unknown inspection. This removes duplicate projection and the guard's unnecessary runtime/status reads.

The existing policy remains: proven local mismatches refuse writes; unknown inspection warns and permits the action. Doctor retains its remote-mode and best-effort health boundaries. The nearby remote-target warning uses the existing diagnostic URL projection so credentials are not echoed.

## User Impact

A relocated CLI detects a stopped service's different store and refuses configuration before opening the wizard. If service paths cannot be verified, the command visibly advises `openclaw gateway status --deep` and leaves configuration available. Native inspection details are not leaked.

No config options, environment variables, database/schema changes, protocol changes, dependencies or authorization policies were added. The configure docs explain both outcomes.

## Evidence

The pre-fix regressions returned allow for a known home mismatch, rejected with a raw service error for unknown inspection, inferred service paths from ambient CLI values, and exposed credentials in a remote URL warning. Tests now cover the repaired owner boundary, an authoritative service-recorded `OPENCLAW_HOME`, and the visible warning before a still-permitted action.

On head `4c1a3ab8b47f569698e1764ccc4d23c5c7fe35c0`, CLI, Doctor, ordered recovery and pre-action suites passed **111 tests** through `node scripts/run-vitest.mjs`. Branch autoreview is scoped-clean at P0–P2. Full `node scripts/check-changed.mjs --base bd8b3c806d4da76d0b21cbc3a8b5264eff3b1a2b` passed. [Exact-head CI33942153615](https://github.com/openclaw/openclaw/actions/runs/33942153615) is green.

The [Crabbox/Testbox environment](https://github.com/openclaw/openclaw/actions/runs/33938626682) ran the actual public configuration flow against a stopped systemd user service in isolated Ubuntu 26.04. Its unit records `HOME=/home/proof`; the CLI uses `OPENCLAW_HOME=/home/proof/relocated`; the synthetic Gateway port is 56797. No operator state or real credentials were used.

The parent runtime `7d0bc2b41f8c09fdfb9c769536260188413df0d5` reproduced both failures. The final candidate package was built through the canonical repository pipeline from exact head `4c1a3ab8b47f569698e1764ccc4d23c5c7fe35c0`, tree `9f6d1ba2984d9c8edab8d9254cba13cdbc1aaaac`. Installed build-info confirms that commit and version 2026.9.1; tarball SHA256: `da27379376d1da69ff1ee4602b517ead50cdf8a30eedd4e51e00ab4cc101b879`. The canonical build/package/live command returned exit0 in 4m49s. Both short public probes also passed with the inherited development-version switches removed; **the final proof uses no version or trust overrides**.

```json
{"case":"known-home-mismatch-before","wizardOpened":true,"refused":false,"configUnchanged":true}
{"case":"known-home-mismatch-after","wizardOpened":false,"refused":true,"configUnchanged":true}
{"case":"unknown-required-env-file-before","wizardOpened":true,"warningObserved":false,"configUnchanged":true}
{"case":"unknown-required-env-file-after","wizardOpened":true,"warningObserved":true,"configUnchanged":true}
```

The known mismatch names both state/config paths and the command needed to select the Gateway's store. The unknown case prints the complete sanitized remedy before the first wizard prompt:

```text
Installed Gateway service state and config paths could not be verified. Inspect the service environment with `openclaw gateway status --deep` before repairing plugin state.
```

Every configuration hash remained unchanged; the harness stopped before submitting wizard input. The required-file fixture was restored and the service remained inactive. These are real native service/CLI observations, not mocked Gateway verdicts.

## LOC and Follow-up

`git diff --numstat bd8b3c806d4da76d0b21cbc3a8b5264eff3b1a2b..HEAD`: production **+62/-43 = +19**; tests **+113/-40 = +73**; docs **+2/-0 = +2**, across five files. Growth implements the missing visible unknown-state outcome and credential-safe warning after removing duplicate projection and indirect status inference. It adds no new policy choice or configuration surface.

Named remaining follow-up: the CLI guard still classifies target locality from URL loopback status. A configured remote Gateway reached through a loopback SSH tunnel needs a separate target-ownership repair aligned with prepared connection configuration. Doctor already skips configured remote mode; this PR preserves the CLI target-selection contract.

The reporter's original npm Discord upgrade refusal remains unreproduced; #138342 stays open.

## Final Review Disposition

The completed exact-head ClawSweeper review found no actionable code or security defect and accepted the native before/after proof. Its remaining “Add data-model compatibility proof” checklist item is a filename/content classification false positive for `src/commands/doctor-gateway-health.ts`: this follow-up changes no stored representation, schema, migration, retention, database access, or persistence writes. The complete production delta is the shared read-only service inspector and its two diagnostic consumers. The existing configuration and authorization policies are unchanged; before/after public configure probes preserve every config hash, and the 111 focused tests include Doctor and ordered recovery behavior. No data migration is applicable to this PR. The distinct provenance migration belongs to already-landed #138746 and has original-database/fresh-process proof there.

That checklist item is therefore resolved as not applicable; no source change or new review request is needed. The named remote-tunnel locality follow-up remains explicitly recorded above.
