### PR TITLE
fix(qa): honor required command failures in progress scenarios

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.progress.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.progress.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { buildMatrixToolProgressMentionSafetyPrompt } from "../../live-transports/matrix/scenarios/scenario-runtime-prompts.js";
 import { startQaMockOpenAiServer } from "./server.js";
 
 const READ_PROMPT =
@@ -106,6 +107,35 @@ async function requestProgress(route: string, prompt: string, results: ProgressR
 }
 
 describe.each(["responses", "messages"])("%s background command progress", (route) => {
+  it.each([
+    { exitCode: 1, expected: "PROGRESS_OK" },
+    { exitCode: 0, expected: "BUG-TOOL-DID-NOT-FAIL" },
+  ])("honors the Matrix required failure after exit $exitCode", async ({ exitCode, expected }) => {
+    const prompt = buildMatrixToolProgressMentionSafetyPrompt(
+      "@qa-sut:matrix-qa.test",
+      "PROGRESS_OK",
+    );
+    const plan = await requestProgress(route, prompt, []);
+    const call = (route === "responses" ? plan.output : plan.content)[0];
+    expect(call.name).toBe("exec");
+    const args = route === "responses" ? JSON.parse(call.arguments) : call.input;
+    const results: ProgressResult[] = [{ tool: "exec", args, output: RUNNING_OUTPUT }];
+    const pending = await requestProgress(route, prompt, results);
+    expect(route === "responses" ? pending.output : pending.content).toMatchObject([
+      { name: "process" },
+    ]);
+    results.push({
+      tool: "process",
+      args: { action: "poll", sessionId: "lucky-slug" },
+      output: `\n\nProcess exited with code ${exitCode}.`,
+    });
+    expect(await requestProgress(route, prompt, results)).toMatchObject(
+      route === "responses"
+        ? { output: [{ content: [{ text: expected }] }] }
+        : { content: [{ text: expected }] },
+    );
+  });
+
   it.each([
     { label: "plain text", output: RUNNING_OUTPUT },
     { label: "warning-prefixed text", output: `Task warning\n\n${RUNNING_OUTPUT}` },

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -992,7 +992,7 @@ async function buildResponsesPayload(
   const pendingCommandProgress = (
     progressInput: ResponsesInputItem[],
     command: string,
-    allowsFailure = false,
+    expectedOutcome: "success" | "failure" | "either" = "success",
   ) => {
     const progress = readProgressCommand(progressInput, command);
     if (progress.error) {
@@ -1005,7 +1005,12 @@ async function buildResponsesPayload(
         timeout: 30_000,
       });
     }
-    return progress.failed && !allowsFailure ? buildAssistantEvents("BUG-TOOL-FAILED") : null;
+    if (expectedOutcome === "failure" && !progress.failed) {
+      return buildAssistantEvents("BUG-TOOL-DID-NOT-FAIL");
+    }
+    return progress.failed && expectedOutcome === "success"
+      ? buildAssistantEvents("BUG-TOOL-FAILED")
+      : null;
   };
   const allInputText = extractAllRequestTexts(input, body);
   const hasCompactionRetryDurableContext = allInputText.includes(
@@ -1819,7 +1824,11 @@ async function buildResponsesPayload(
       const pending = pendingCommandProgress(
         progressInput,
         command,
-        /completes or fails/iu.test(scenarioFamilyPrompt),
+        /command fails/iu.test(scenarioFamilyPrompt)
+          ? "failure"
+          : /completes or fails/iu.test(scenarioFamilyPrompt)
+            ? "either"
+            : "success",
       );
       if (pending) {
         return pending;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Full Release Validation fails Matrix tool-progress mention-safety after the intentionally failing command completes. The real Matrix flow delivered `BUG-TOOL-FAILED` instead of the expected completion marker.

## Why This Change Was Made

The scenario deliberately runs a missing-file command containing Matrix mention syntax and asks for the final marker after that command fails. The command-progress owner previously supported success or either outcome, but recognized only the phrase “completes or fails” for the latter. It now distinguishes success, required failure, and either terminal outcome. Pending processes still require a matching terminal poll, and unexpected zero exits fail required-failure scenarios.

## User Impact

This repairs release QA coverage. Matrix transport behavior, mention sanitization, runtime settings, and public APIs are unchanged.

## Evidence

- Before: Full Release Validation [33936309800](https://github.com/openclaw/openclaw/actions/runs/33936309800), Matrix live job [101226205425](https://github.com/openclaw/openclaw/actions/runs/33936472739/job/101226205425), failed mention-safety with `BUG-TOOL-FAILED`.
- The exact scenario prompt reproduced that wrong result against the actual mock HTTP server.
- New boundary regression invokes the actual Matrix prompt through both Responses and Messages endpoints, waits for process completion, and distinguishes required failure from an unexpected zero exit. All four cases fail before the fix for the expected reasons.
- After: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/qa-lab/src/providers/mock-openai/server.progress.test.ts` — 133 tests passed, including existing Slack, read-error, pending/unknown, approval, call-identity, and foreground/background cases.
- Sibling streaming/history dispatch proof: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/qa-lab/src/providers/mock-openai/server.test.ts -t 'tool.progress|Matrix|Slack.*progress|Slack commentary'` — 20 passed, 264 unrelated cases skipped.
- QA provider implementation: +9 lines. Tests: +30 lines. The added private terminal-outcome distinction is required to preserve failure-only coverage rather than broadly allowing errors.

Exact-head [CI run 33942268883](https://github.com/openclaw/openclaw/actions/runs/33942268883) completed successfully: 35 jobs passed, 16 skipped. Independent Codex review is scoped-clean through P2 (no findings). All checks prescribed by the changed-file plan passed, including implementation/test typechecks, plugin boundaries, all three unused-export scans, targeted lint, and final static guards. Two initial attempts found omitted owner dependency links in the reused checkout; after linking the existing dependencies read-only, the failed checks and remaining commands passed. No installation or dependency change was needed.

The rebuilt exact candidate `d2b40cc8fb3707840c76d25a3d14c020e32ebb85` also passed the complete selected [Matrix catalog run 33943520733](https://github.com/openclaw/openclaw/actions/runs/33943520733/job/101245993821): **93 passed, 0 failed, 0 skipped**. All 93 evidence entries bind this exact source SHA, Linux Node 24.19, real Matrix transport and the existing mock provider. The repaired mention-safety scenario recorded an inert command preview (`mentions: {}`) and the expected final marker. The [artifact](https://github.com/openclaw/openclaw/actions/runs/33943520733/artifacts/9962837790) contains the summary and exact execution metadata.
