### PR TITLE
fix(wizard): preserve typed enum values in plugin config

### DIFF
--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -1,9 +1,11 @@
 // Setup plugin config tests cover plugin choices and generated config.
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { validatePluginSchemaValue } from "../plugins/schema-validator.js";
 import type { PluginConfigUiHint } from "../plugins/types.js";
 import type { WizardPrompter } from "./prompts.js";
 import {
+  configurePluginConfig,
   discoverConfigurablePlugins,
   discoverUnconfiguredPlugins,
   setupPluginConfig,
@@ -342,7 +344,7 @@ describe("setupPluginConfig", () => {
         outro: vi.fn(async () => {}),
         note: vi.fn(async () => {}),
         // enum ["web", "llm-context"]; select the member at index 1
-        select: vi.fn(async () => "__enum_1__") as unknown as WizardPrompter["select"],
+        select: vi.fn(async () => "1") as unknown as WizardPrompter["select"],
         multiselect: vi.fn(async () => ["brave"]) as unknown as WizardPrompter["multiselect"],
         text: vi.fn(async () => ""),
         confirm: vi.fn(async () => true),
@@ -552,31 +554,31 @@ describe("setupPluginConfig", () => {
     {
       name: "an integer enum member as a number",
       schemaProp: { type: "integer", enum: [1, 2] },
-      selectedToken: "__enum_0__",
+      selectedToken: "0",
       expected: 1,
     },
     {
       name: "a boolean enum member as a boolean",
       schemaProp: { type: "boolean", enum: [true, false] },
-      selectedToken: "__enum_0__",
+      selectedToken: "0",
       expected: true,
     },
     {
       name: "a later integer enum member selected by index",
       schemaProp: { type: "integer", enum: [10, 20, 30] },
-      selectedToken: "__enum_2__",
+      selectedToken: "2",
       expected: 30,
     },
     {
       name: "distinct members sharing a string label keep distinct types",
       schemaProp: { type: ["string", "integer"], enum: ["1", 1] },
-      selectedToken: "__enum_1__",
+      selectedToken: "1",
       expected: 1,
     },
     {
       name: "an object enum member by index",
       schemaProp: { type: "object", enum: [{ mode: "auto" }, { mode: "manual" }] },
-      selectedToken: "__enum_1__",
+      selectedToken: "1",
       expected: { mode: "manual" },
     },
   ])(
@@ -617,4 +619,76 @@ describe("setupPluginConfig", () => {
       expect(typeof result.plugins?.entries?.[pluginId]?.config?.["mode"]).toBe(typeof expected);
     },
   );
+
+  it("produces config that passes canonical schema validation", async () => {
+    const pluginId = "typed-enum-plugin";
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      properties: { mode: { type: "integer", enum: [1, 2] } },
+    };
+    loadPluginManifestRegistryCore.mockReturnValue({
+      plugins: [makeManifestPlugin(pluginId, { mode: { label: "Mode" } }, schema)],
+    });
+
+    const result = await setupPluginConfig({
+      config: { plugins: { entries: { [pluginId]: { enabled: true } } } },
+      prompter: {
+        intro: vi.fn(async () => {}),
+        outro: vi.fn(async () => {}),
+        note: vi.fn(async () => {}),
+        select: vi.fn(async () => "0") as unknown as WizardPrompter["select"],
+        multiselect: vi.fn(async () => [pluginId]) as unknown as WizardPrompter["multiselect"],
+        text: vi.fn(async () => ""),
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+    });
+
+    const saved = result.plugins?.entries?.[pluginId]?.config;
+    expect(saved).toEqual({ mode: 1 });
+
+    const validation = validatePluginSchemaValue({
+      origin: "global",
+      cacheKey: "typed-enum.canonical",
+      schema,
+      value: saved,
+    });
+    expect(validation.ok).toBe(true);
+  });
+
+  it("preserves the existing value when the keep-current option is selected", async () => {
+    const pluginId = "typed-enum-plugin";
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      properties: { mode: { type: "integer", enum: [1, 2, 3] } },
+    };
+    loadPluginManifestRegistryCore.mockReturnValue({
+      plugins: [makeManifestPlugin(pluginId, { mode: { label: "Mode" } }, schema)],
+    });
+
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce(pluginId) // configurePluginConfig plugin selection
+      .mockResolvedValueOnce("__keep__"); // keep the current enum value
+
+    const result = await configurePluginConfig({
+      config: { plugins: { entries: { [pluginId]: { enabled: true, config: { mode: 2 } } } } },
+      prompter: {
+        intro: vi.fn(async () => {}),
+        outro: vi.fn(async () => {}),
+        note: vi.fn(async () => {}),
+        select: select as unknown as WizardPrompter["select"],
+        multiselect: vi.fn(async () => [pluginId]) as unknown as WizardPrompter["multiselect"],
+        text: vi.fn(async () => ""),
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+    });
+
+    const saved = result.plugins?.entries?.[pluginId]?.config;
+    expect(saved).toEqual({ mode: 2 });
+    expect(typeof saved?.mode).toBe("number");
+  });
 });

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -608,7 +608,7 @@ describe("setupPluginConfig", () => {
         const options = params.options as Array<{ value: string; label: string }>;
         expect(options.map((o) => o.value)).toEqual(enumMembers.map((_, i) => String(i)));
         expect(options.map((o) => o.label)).toEqual(enumMembers.map((v) => String(v)));
-        return options[Number(selectedToken)].value;
+        return options[Number(selectedToken)]!.value;
       });
 
       const result = await setupPluginConfig({

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -579,39 +579,42 @@ describe("setupPluginConfig", () => {
       selectedToken: "__enum_1__",
       expected: { mode: "manual" },
     },
-  ])("preserves the typed enum value for $name", async ({ schemaProp, selectedToken, expected }) => {
-    const pluginId = "typed-enum-plugin";
-    loadPluginManifestRegistryCore.mockReturnValue({
-      plugins: [
-        makeManifestPlugin(
-          pluginId,
-          { mode: { label: "Mode" } },
-          {
-            type: "object",
-            additionalProperties: false,
-            properties: { mode: schemaProp },
-          },
-        ),
-      ],
-    });
+  ])(
+    "preserves the typed enum value for $name",
+    async ({ schemaProp, selectedToken, expected }) => {
+      const pluginId = "typed-enum-plugin";
+      loadPluginManifestRegistryCore.mockReturnValue({
+        plugins: [
+          makeManifestPlugin(
+            pluginId,
+            { mode: { label: "Mode" } },
+            {
+              type: "object",
+              additionalProperties: false,
+              properties: { mode: schemaProp },
+            },
+          ),
+        ],
+      });
 
-    const result = await setupPluginConfig({
-      config: {
-        plugins: { entries: { [pluginId]: { enabled: true } } },
-      },
-      prompter: {
-        intro: vi.fn(async () => {}),
-        outro: vi.fn(async () => {}),
-        note: vi.fn(async () => {}),
-        select: vi.fn(async () => selectedToken) as unknown as WizardPrompter["select"],
-        multiselect: vi.fn(async () => [pluginId]) as unknown as WizardPrompter["multiselect"],
-        text: vi.fn(async () => ""),
-        confirm: vi.fn(async () => true),
-        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
-      },
-    });
+      const result = await setupPluginConfig({
+        config: {
+          plugins: { entries: { [pluginId]: { enabled: true } } },
+        },
+        prompter: {
+          intro: vi.fn(async () => {}),
+          outro: vi.fn(async () => {}),
+          note: vi.fn(async () => {}),
+          select: vi.fn(async () => selectedToken) as unknown as WizardPrompter["select"],
+          multiselect: vi.fn(async () => [pluginId]) as unknown as WizardPrompter["multiselect"],
+          text: vi.fn(async () => ""),
+          confirm: vi.fn(async () => true),
+          progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+        },
+      });
 
-    expect(result.plugins?.entries?.[pluginId]?.config).toEqual({ mode: expected });
-    expect(typeof result.plugins?.entries?.[pluginId]?.config?.["mode"]).toBe(typeof expected);
-  });
+      expect(result.plugins?.entries?.[pluginId]?.config).toEqual({ mode: expected });
+      expect(typeof result.plugins?.entries?.[pluginId]?.config?.["mode"]).toBe(typeof expected);
+    },
+  );
 });

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -341,7 +341,8 @@ describe("setupPluginConfig", () => {
         intro: vi.fn(async () => {}),
         outro: vi.fn(async () => {}),
         note: vi.fn(async () => {}),
-        select: vi.fn(async () => "llm-context") as unknown as WizardPrompter["select"],
+        // enum ["web", "llm-context"]; select the member at index 1
+        select: vi.fn(async () => "__enum_1__") as unknown as WizardPrompter["select"],
         multiselect: vi.fn(async () => ["brave"]) as unknown as WizardPrompter["multiselect"],
         text: vi.fn(async () => ""),
         confirm: vi.fn(async () => true),
@@ -541,5 +542,81 @@ describe("setupPluginConfig", () => {
       scientific: 100,
       retries: 3,
     });
+  });
+
+  // Regression coverage for #127577: enum selections must preserve the JSON
+  // type of the chosen member instead of being stringified. Enum option values
+  // are opaque tokens; the wizard maps the selected token back to the original
+  // (typed) enum member.
+  it.each([
+    {
+      name: "an integer enum member as a number",
+      enumMembers: [1, 2],
+      schemaProp: { type: "integer", enum: [1, 2] },
+      selectedToken: "__enum_0__",
+      expected: 1,
+    },
+    {
+      name: "a boolean enum member as a boolean",
+      enumMembers: [true, false],
+      schemaProp: { type: "boolean", enum: [true, false] },
+      selectedToken: "__enum_0__",
+      expected: true,
+    },
+    {
+      name: "a later integer enum member selected by index",
+      enumMembers: [10, 20, 30],
+      schemaProp: { type: "integer", enum: [10, 20, 30] },
+      selectedToken: "__enum_2__",
+      expected: 30,
+    },
+    {
+      name: "distinct members sharing a string label keep distinct types",
+      enumMembers: ["1", 1],
+      schemaProp: { type: ["string", "integer"], enum: ["1", 1] },
+      selectedToken: "__enum_1__",
+      expected: 1,
+    },
+    {
+      name: "an object enum member by index",
+      enumMembers: [{ mode: "auto" }, { mode: "manual" }],
+      schemaProp: { type: "object", enum: [{ mode: "auto" }, { mode: "manual" }] },
+      selectedToken: "__enum_1__",
+      expected: { mode: "manual" },
+    },
+  ])("preserves the typed enum value for $name", async ({ enumMembers, schemaProp, selectedToken, expected }) => {
+    const pluginId = "typed-enum-plugin";
+    loadPluginManifestRegistryCore.mockReturnValue({
+      plugins: [
+        makeManifestPlugin(
+          pluginId,
+          { mode: { label: "Mode" } },
+          {
+            type: "object",
+            additionalProperties: false,
+            properties: { mode: schemaProp },
+          },
+        ),
+      ],
+    });
+
+    const result = await setupPluginConfig({
+      config: {
+        plugins: { entries: { [pluginId]: { enabled: true } } },
+      },
+      prompter: {
+        intro: vi.fn(async () => {}),
+        outro: vi.fn(async () => {}),
+        note: vi.fn(async () => {}),
+        select: vi.fn(async () => selectedToken) as unknown as WizardPrompter["select"],
+        multiselect: vi.fn(async () => [pluginId]) as unknown as WizardPrompter["multiselect"],
+        text: vi.fn(async () => ""),
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+    });
+
+    expect(result.plugins?.entries?.[pluginId]?.config).toEqual({ mode: expected });
+    expect(typeof result.plugins?.entries?.[pluginId]?.config?.["mode"]).toBe(typeof expected);
   });
 });

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -548,7 +548,7 @@ describe("setupPluginConfig", () => {
 
   // Regression coverage for #127577: enum selections must preserve the JSON
   // type of the chosen member instead of being stringified. Enum option values
-  // are opaque tokens; the wizard maps the selected token back to the original
+  // are numeric indices; the wizard maps the selected index back to the original
   // (typed) enum member.
   it.each([
     {
@@ -585,6 +585,7 @@ describe("setupPluginConfig", () => {
     "preserves the typed enum value for $name",
     async ({ schemaProp, selectedToken, expected }) => {
       const pluginId = "typed-enum-plugin";
+      const enumMembers = schemaProp.enum as unknown[];
       loadPluginManifestRegistryCore.mockReturnValue({
         plugins: [
           makeManifestPlugin(
@@ -599,6 +600,17 @@ describe("setupPluginConfig", () => {
         ],
       });
 
+      // Select from the options actually offered: assert each option's value is
+      // its numeric index and its label is the stringified member, then return
+      // the offered option at the chosen index. This proves the saved value is
+      // the same member the wizard displayed, not an independent hardcoded token.
+      const select = vi.fn(async (params) => {
+        const options = params.options as Array<{ value: string; label: string }>;
+        expect(options.map((o) => o.value)).toEqual(enumMembers.map((_, i) => String(i)));
+        expect(options.map((o) => o.label)).toEqual(enumMembers.map((v) => String(v)));
+        return options[Number(selectedToken)].value;
+      });
+
       const result = await setupPluginConfig({
         config: {
           plugins: { entries: { [pluginId]: { enabled: true } } },
@@ -607,7 +619,7 @@ describe("setupPluginConfig", () => {
           intro: vi.fn(async () => {}),
           outro: vi.fn(async () => {}),
           note: vi.fn(async () => {}),
-          select: vi.fn(async () => selectedToken) as unknown as WizardPrompter["select"],
+          select: select as unknown as WizardPrompter["select"],
           multiselect: vi.fn(async () => [pluginId]) as unknown as WizardPrompter["multiselect"],
           text: vi.fn(async () => ""),
           confirm: vi.fn(async () => true),

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -551,40 +551,35 @@ describe("setupPluginConfig", () => {
   it.each([
     {
       name: "an integer enum member as a number",
-      enumMembers: [1, 2],
       schemaProp: { type: "integer", enum: [1, 2] },
       selectedToken: "__enum_0__",
       expected: 1,
     },
     {
       name: "a boolean enum member as a boolean",
-      enumMembers: [true, false],
       schemaProp: { type: "boolean", enum: [true, false] },
       selectedToken: "__enum_0__",
       expected: true,
     },
     {
       name: "a later integer enum member selected by index",
-      enumMembers: [10, 20, 30],
       schemaProp: { type: "integer", enum: [10, 20, 30] },
       selectedToken: "__enum_2__",
       expected: 30,
     },
     {
       name: "distinct members sharing a string label keep distinct types",
-      enumMembers: ["1", 1],
       schemaProp: { type: ["string", "integer"], enum: ["1", 1] },
       selectedToken: "__enum_1__",
       expected: 1,
     },
     {
       name: "an object enum member by index",
-      enumMembers: [{ mode: "auto" }, { mode: "manual" }],
       schemaProp: { type: "object", enum: [{ mode: "auto" }, { mode: "manual" }] },
       selectedToken: "__enum_1__",
       expected: { mode: "manual" },
     },
-  ])("preserves the typed enum value for $name", async ({ enumMembers, schemaProp, selectedToken, expected }) => {
+  ])("preserves the typed enum value for $name", async ({ schemaProp, selectedToken, expected }) => {
     const pluginId = "typed-enum-plugin";
     loadPluginManifestRegistryCore.mockReturnValue({
       plugins: [

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -239,14 +239,14 @@ async function promptPluginFields(params: {
       continue;
     }
 
-    // Handle enum fields with select. Option values are opaque per-index tokens
-    // (never the raw stringified member) so that typed enum members — numbers,
-    // booleans, objects — survive the round-trip without being coerced to
-    // strings. The selected token is mapped back to the original member, which is
-    // stored as a structured clone to preserve its JSON type.
+    // Handle enum fields with select. Option values are the member's numeric
+    // index (never the raw stringified member) so that typed enum members —
+    // numbers, booleans, objects — survive the round-trip without being coerced
+    // to strings. The selected index is mapped back to the original member, which
+    // is stored as a structured clone to preserve its JSON type.
     if (schemaProp?.enum && Array.isArray(schemaProp.enum)) {
       const options = schemaProp.enum.map((v, i) => ({
-        value: `__enum_${i}__`,
+        value: String(i),
         label: String(v),
       }));
       if (hasValue) {
@@ -261,11 +261,9 @@ async function promptPluginFields(params: {
         initialValue: hasValue ? "__keep__" : undefined,
       });
       if (selected !== "__keep__") {
-        const tokenMatch = /^__enum_(\d+)__$/.exec(selected);
-        const index = tokenMatch ? Number(tokenMatch[1]) : undefined;
-        const member = index !== undefined ? schemaProp.enum[index] : undefined;
-        if (index !== undefined && index < schemaProp.enum.length) {
-          setPathCreateStrict(updatedConfig, pathSegments, structuredClone(member));
+        const index = Number(selected);
+        if (Number.isInteger(index) && index >= 0 && index < schemaProp.enum.length) {
+          setPathCreateStrict(updatedConfig, pathSegments, structuredClone(schemaProp.enum[index]));
           changed = true;
         }
       }

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -240,10 +240,7 @@ async function promptPluginFields(params: {
     }
 
     // Handle enum fields with select. Option values are the member's numeric
-    // index (never the raw stringified member) so that typed enum members —
-    // numbers, booleans, objects — survive the round-trip without being coerced
-    // to strings. The selected index is mapped back to the original member, which
-    // is stored as a structured clone to preserve its JSON type.
+    // index, mapped back to a structured clone of the original member to preserve its JSON type.
     if (schemaProp?.enum && Array.isArray(schemaProp.enum)) {
       const options = schemaProp.enum.map((v, i) => ({
         value: String(i),

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -239,10 +239,14 @@ async function promptPluginFields(params: {
       continue;
     }
 
-    // Handle enum fields with select
+    // Handle enum fields with select. Option values are opaque per-index tokens
+    // (never the raw stringified member) so that typed enum members — numbers,
+    // booleans, objects — survive the round-trip without being coerced to
+    // strings. The selected token is mapped back to the original member, which is
+    // stored as a structured clone to preserve its JSON type.
     if (schemaProp?.enum && Array.isArray(schemaProp.enum)) {
-      const options = schemaProp.enum.map((v) => ({
-        value: String(v),
+      const options = schemaProp.enum.map((v, i) => ({
+        value: `__enum_${i}__`,
         label: String(v),
       }));
       if (hasValue) {
@@ -257,8 +261,13 @@ async function promptPluginFields(params: {
         initialValue: hasValue ? "__keep__" : undefined,
       });
       if (selected !== "__keep__") {
-        setPathCreateStrict(updatedConfig, pathSegments, selected);
-        changed = true;
+        const tokenMatch = /^__enum_(\d+)__$/.exec(selected);
+        const index = tokenMatch ? Number(tokenMatch[1]) : undefined;
+        const member = index !== undefined ? schemaProp.enum[index] : undefined;
+        if (index !== undefined && index < schemaProp.enum.length) {
+          setPathCreateStrict(updatedConfig, pathSegments, structuredClone(member));
+          changed = true;
+        }
       }
       continue;
     }


### PR DESCRIPTION
Closes #127577

## What Problem This Solves

Fixes an issue where users configuring a plugin through the wizard would get an
invalid config when the plugin schema declares a numeric or boolean enum field.
The wizard stringified every enum member as the select option's value, so
selecting `1` stored `"1"` and `true` stored `"true"`, which then failed the
plugin's JSON-schema validation.

## Why This Change Was Made

The enum select previously mapped each `schema.enum` member to
`{ value: String(v) }` and wrote the selected string back verbatim, losing the
member's JSON type. It now maps each member to its numeric index as the select
value and restores the original member via `structuredClone` on selection,
preserving its type. This mirrors the index-to-value mapping already used by the
Control UI's enum scalar renderer, and keeps the `__keep__` sentinel a separate
string so the "keep current value" path is untouched.

## User Impact

Users can now select numeric, boolean, and object enum values in the plugin
wizard and get a valid, correctly-typed config entry instead of a string that
fails schema validation. Existing values are preserved unchanged when the
keep-current option is chosen.

## Evidence

Regression tests in `src/wizard/setup.plugin-config.test.ts` cover both the
onboard (`setupPluginConfig`) and reconfigure (`configurePluginConfig`) flows:

- an integer enum member stays a JSON `number`
- a boolean enum member stays a JSON `boolean`
- a later member selected by index works
- `["1", 1]` (same label, different types) stays distinguishable and preserves both types
- an object enum member is restored by index
- **offered-option connection**: the select mock reads the options actually
  offered to the user, asserts each option's `value` is its index and `label` is
  the stringified member, then returns the offered option at the chosen index —
  so the saved value is the same member the wizard displayed, not an independent
  hardcoded token
- **canonical validation**: the wizard output is fed through the real
  `validatePluginSchemaValue` (the same validator used at config read/write
  boundaries) and returns `{ ok: true }` for an integer enum
- **keep-current**: reconfiguring a plugin whose enum field already holds `2`
  and choosing the keep-current option leaves `{ mode: 2 }` (a `number`),
  untouched

```text
✓ src/wizard/setup.plugin-config.test.ts (27 tests) — all pass
```

`pnpm tsgo:prod` passes (EXIT=0) for core/ui/extensions tsconfigs. `oxlint` and
`oxfmt --check` pass on the changed files. CI check runs are green
(mergeable_state: clean).

### Real runtime proof (interactive wizard via PTY)

Driven the actual wizard end-to-end through a pseudo-terminal against a
self-contained mock manifest with an integer enum `mode` (`[1,2,3]`) and a
boolean enum `ratio` (`[true,false]`). Navigated the selects with real arrow /
space / enter keystrokes (moved down once on each select, i.e. picked `2` and
`false`):

```text
◆  Mode
│  ● 1
│  ○ 2
│  ○ 3
└
◇  Mode
│  2

◆  Ratio
│  ● true
│  ○ false
└
◇  Ratio
│  false

SAVED_CONFIG={"mode":2,"ratio":false}
MODE_TYPE=number
RATIO_TYPE=boolean
VALIDATION_OK=true
```

The saved config serializes `mode` as `2` (JSON `number`, not `"2"`) and `ratio`
as `false` (JSON `boolean`, not `"false"`), and the resulting config passes the
plugin's canonical JSON-schema validation (`validatePluginSchemaValue` returns
`{ ok: true }`).
