### PR TITLE
fix: normalize small Responses output budgets

### DIFF
--- a/packages/ai/src/providers/openai-responses.test.ts
+++ b/packages/ai/src/providers/openai-responses.test.ts
@@ -129,13 +129,18 @@ describe("OpenAI Responses provider", () => {
   });
 
   it("clamps small output limits and disables implicit SDK retries", async () => {
-    const result = await streamOpenAIResponses(model(), context, {
+    const requestModel = model();
+    const options = {
       apiKey: String(1),
       maxTokens: 1,
-    }).result();
+    };
+    const transportParams = buildOpenAIResponsesParams(requestModel, context, options);
+    const result = await streamOpenAIResponses(requestModel, context, options).result();
 
     expect(result.stopReason).toBe("error");
-    expect(openAiMockState.params[0]).toMatchObject({ max_output_tokens: 16, store: false });
+    for (const params of [transportParams, openAiMockState.params[0]]) {
+      expect(params).toMatchObject({ max_output_tokens: 16, store: false });
+    }
     expect(openAiMockState.requestOptions[0]).toMatchObject({ maxRetries: 0 });
   });
 

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -319,7 +319,8 @@ export function buildOpenAIResponsesParams(
   };
   const effectiveMaxTokens = options?.maxTokens || model.maxTokens;
   if (effectiveMaxTokens) {
-    params.max_output_tokens = effectiveMaxTokens;
+    // Responses rejects output budgets below 16 tokens.
+    params.max_output_tokens = Math.max(effectiveMaxTokens, 16);
   }
   if (options?.temperature !== undefined && supportsOpenAITemperature(model)) {
     params.temperature = options.temperature;


### PR DESCRIPTION
Closes #138825

## What Problem This Solves

Fixes an issue where users requesting a very small output budget through the managed OpenAI Responses transport receive HTTP 400 instead of a model response. Budgets from 1 through 15 are below the API minimum.

## Why This Change Was Made

The managed request builder forwarded the effective budget directly, while the package Responses adapter already normalized it to 16. Apply that same minimum at the request owner so normal turns and other managed callers share the behavior. The existing adapter regression now checks both builders.

No configuration, catalog, authentication, or schema changes. Production delta: +1 line for the API-contract comment; the behavioral replacement is line-neutral. Tests: +5 net lines. No alternate path is added. The separately tracked upper-cap issue #127560 remains outside this minimum-budget repair.

## User Impact

Small requested output budgets produce a valid request. Budgets of 16 or more retain their existing behavior.

## Evidence

- Live API-key before/after proof on `openai/gpt-6-astra`, low reasoning, synthetic `Reply OK.` prompt: baseline `maxTokens: 1` returned HTTP 400 stating the minimum is 16; the candidate completed without request rejection.
- [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33941617117): the floor baseline failed and candidate passed. The campaign's aggregate exit was nonzero because two separate stress-probe checks needed correction; this is not presented as an entirely green campaign.
- Extended the existing small-output/no-retry regression: failed before the fix (`1` versus `16`), passed afterward. Provider and managed-parameter tests: 17 passed. Broader shared Responses verification: 64 passed across five files.
- Changed-file formatting, typechecks, lint and guards passed. Independent Codex review found no actionable P0–P2 findings.
- Source contract: `buildOpenAIResponsesParams` owns managed request construction; `applyCommonResponsesParams` establishes sibling adapter behavior. Live provider rejection confirms the minimum rather than relying solely on mocks.
