### PR TITLE
fix(transcripts): preserve capture identity across startup retries

### DIFF
--- a/src/agents/tools/transcripts-auto-start.ts
+++ b/src/agents/tools/transcripts-auto-start.ts
@@ -142,6 +142,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
     entry: ResolvedTranscriptsAutoStartConfig,
     attempt: number,
     store: TranscriptsStore,
+    startedAt = new Date().toISOString(),
   ) => {
     if (stopped || startedSessions.has(entry.sessionId ?? "")) {
       return;
@@ -156,6 +157,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
           startupWaitMs: AUTO_START_PROVIDER_READY_TIMEOUT_MS,
           configuredLifecycle: true,
           lifecycleToken,
+          startedAt,
           rawParams: { action: "start", ...entry },
         });
         const sessionId = result.details.sessionId;
@@ -171,7 +173,11 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
             `transcripts autoStart failed provider=${entry.providerId}: ${formatAutoStopDiagnostic(error)} (check the transcripts.autoStart entry in your config)`,
           );
         } else {
-          schedule(() => startContinuous(entry, attempt + 1, store), AUTO_START_RETRY_MS);
+          // Retries keep the persisted identity; a new timestamp collides with its daily selector.
+          schedule(
+            () => startContinuous(entry, attempt + 1, store, startedAt),
+            AUTO_START_RETRY_MS,
+          );
         }
       }
     });

--- a/src/agents/tools/transcripts-tool-runtime.ts
+++ b/src/agents/tools/transcripts-tool-runtime.ts
@@ -392,6 +392,7 @@ export async function startTranscripts(params: {
   configuredLifecycle?: true;
   lifecycleToken?: symbol;
   existingSession?: TranscriptSessionDescriptor;
+  startedAt?: string;
   onCaptureEnded?: () => void;
 }) {
   if (params.abortSignal?.aborted) {
@@ -430,7 +431,7 @@ export async function startTranscripts(params: {
       readTranscriptStringParam(params.rawParams, "title", { trim: true }) ??
       params.existingSession?.title,
     source: sanitizeTranscriptSourceLocator(providerSource),
-    startedAt: params.existingSession?.startedAt ?? new Date().toISOString(),
+    startedAt: params.existingSession?.startedAt ?? params.startedAt ?? new Date().toISOString(),
     metadata: {
       ...params.existingSession?.metadata,
       ...(params.ctx.agentId ? { agentId: params.ctx.agentId } : {}),

--- a/src/agents/tools/transcripts-tool.occupancy.test.ts
+++ b/src/agents/tools/transcripts-tool.occupancy.test.ts
@@ -103,46 +103,52 @@ function harness() {
 }
 
 describe("occupancy-driven transcript lifecycle", () => {
-  it("retains one stopped candidate across failed starts and admits synchronous initial occupancy", async () => {
-    const h = harness();
-    const identities: Array<{ sessionId: string; startedAt: string }> = [];
-    const entered = Array.from({ length: 3 }, () => createDeferred());
-    h.provider.watchOccupancy = async (request) => {
-      request.onOccupied();
-      return { ok: true, value: { stop: h.unwatch } };
-    };
-    h.provider.start = vi.fn<NonNullable<TranscriptSourceProvider["start"]>>(async (request) => {
-      identities.push(request.session);
-      entered[identities.length - 1]!.resolve();
-      if (identities.length < 3) {
-        return { ok: false, error: "not ready" };
-      }
-      h.requests.push(request);
-      return { ok: true, session: request.session };
-    });
-    await withPluginRuntimeRegistryScope(h.registry, async () => {
-      const service = h.service();
-      try {
-        service.start();
-        for (let count = 1; count < 3; count++) {
-          await entered[count - 1]!.promise;
-          expect(identities).toHaveLength(count);
-          await vi.waitFor(async () =>
-            expect((await h.store.listSessionEntries())[0]?.session.stoppedAt).toBeDefined(),
-          );
-          await vi.advanceTimersByTimeAsync(5_000);
+  it.each([false, true])(
+    "retains one capture identity across failed starts (whenOccupied=%s)",
+    async (whenOccupied) => {
+      const h = harness();
+      const identities: Array<{ sessionId: string; startedAt: string }> = [];
+      const entered = Array.from({ length: 3 }, () => createDeferred());
+      h.provider.watchOccupancy = async (request) => {
+        request.onOccupied();
+        return { ok: true, value: { stop: h.unwatch } };
+      };
+      h.provider.start = vi.fn<NonNullable<TranscriptSourceProvider["start"]>>(async (request) => {
+        identities.push(request.session);
+        entered[identities.length - 1]!.resolve();
+        if (identities.length < 3) {
+          return { ok: false, error: "not ready" };
         }
-        await entered[2]!.promise;
-        await h.started(1);
-        expect(
-          new Set(identities.map(({ sessionId, startedAt }) => `${sessionId}/${startedAt}`)).size,
-        ).toBe(1);
-        expect(await h.store.listSessionEntries()).toHaveLength(1);
-      } finally {
-        await service.stop();
-      }
-    });
-  });
+        h.requests.push(request);
+        return { ok: true, session: request.session };
+      });
+      await withPluginRuntimeRegistryScope(h.registry, async () => {
+        const service = h.service([{ ...h.entry, whenOccupied, sessionId: undefined }]);
+        try {
+          service.start();
+          await entered[0]!.promise;
+          for (let count = 1; count < 3; count++) {
+            await vi.waitFor(() => expect(identities).toHaveLength(count));
+            expect(identities).toHaveLength(count);
+            if (whenOccupied) {
+              await vi.waitFor(async () =>
+                expect((await h.store.listSessionEntries())[0]?.session.stoppedAt).toBeDefined(),
+              );
+            }
+            await vi.advanceTimersByTimeAsync(5_000);
+          }
+          await entered[2]!.promise;
+          await h.started(1);
+          expect(
+            new Set(identities.map(({ sessionId, startedAt }) => `${sessionId}/${startedAt}`)).size,
+          ).toBe(1);
+          expect(await h.store.listSessionEntries()).toHaveLength(1);
+        } finally {
+          await service.stop();
+        }
+      });
+    },
+  );
 
   it("expires a failed-start candidate after an empty episode outside the reopen window", async () => {
     const h = harness();


### PR DESCRIPTION
## What Problem This Solves

Continuous transcript auto-start could exhaust all retries after one failed provider startup. The first attempt persisted a session, then each retry reused its ID with a new start timestamp. SQLite rejected the new capture identity because its daily selector already belonged to the first attempt. A live Discord Gateway hit `UNIQUE constraint failed: meeting_transcript_sessions.selector` with a generated session ID and continuous transcript auto-start.

## Why This Change Was Made

Keep the original start timestamp for the complete retry chain, alongside the existing stable session ID. The shared startup runtime continues to resolve and sanitize provider/account ownership for each attempt. Occupancy reopening continues to use its full existing descriptor and original timestamp.

The store's existing identity, selector, export ownership, and fixed-ID contracts are preserved. Production changes are +9/-2 (net +7): one private timestamp argument and its retry handoff, with no schema, public tool, or configuration changes.

## User Impact

Configured Discord and other continuous transcript providers can recover when startup initially fails, using one durable capture instead of exhausting retries on a selector collision. Notes, summaries, and exports retain the original capture identity.

## Evidence

- A real-SQLite lifecycle regression fails before the fix: continuous capture reaches the provider once but never reaches its second attempt. The equivalent occupancy case passes.
- The extended table now proves two failed starts followed by successful admission, one stable ID/start timestamp, and exactly one durable capture. Final occupancy/continuous suite: 12 tests passed.
- Sibling suites passed: transcript store 25 tests, tool lifecycle 17 tests, auto-start shutdown/reporting 7 tests. These cover canonical selector collision rejection, source ownership, cancellation, finalization, restart reopening, and summary/export handling.
- Scoped lint and formatting passed; independent Codex P2 review found no actionable findings.
- Current deployed configuration was verified to use generated-ID continuous transcript auto-start; its voice-channel occupancy setting is a separate control.

Local commands: `node scripts/run-vitest.mjs src/agents/tools/transcripts-tool.occupancy.test.ts`; sibling selection `src/agents/tools/transcripts-tool.auto-start.test.ts src/agents/tools/transcripts-tool.test.ts src/transcripts/store.test.ts`. The first broader run exposed a test-only initial-admission wait; it was restored to the existing deferred event before the final 12-test pass.

The local changed gate passed through the core graph boundary, then its declaration guard refused the shared dependency donor outside this worktree. Clean CI below provides passing typecheck evidence; the guard was preserved.

Deterministic retry failures are injected at the provider boundary against the real SQLite lifecycle owner. Installed acceptance then passed on integration candidate `4d9c69306bc93aedef888975de2af15f9b8fa581`, combining this PR with #138849. All three files in this PR are byte-identical between the integration candidate and reviewed head `802ba35be7c85288f3ed9224e7694fb3d68bc850`.

The canonical managed owner accepted that candidate on September 5, 2026 at 05:00 UTC. Authenticated Gateway `transcripts.list` reported one active generated Discord capture, with the configured source preserved; the same capture remained active after the voice proof. This checks the live capture owner, not just the existence of a persisted row. There were zero captured human utterances, so no human-speech transcription claim is made.

Separately, native Gateway Talk with the real OpenAI realtime provider and configured agent returned **“323. Gateway voice verified.”** It produced 211,200 PCM bytes (4.4 seconds), including 139,200 bytes after the consult result; all 12 playback marks were acknowledged after timed output drain and relay cleanup passed. This used synthetic input and a timed null output sink; it does not claim physical Discord-room audio transport or human hearing. The serving process and configuration remained stable through acceptance and both checks.

An earlier standalone candidate reached runtime readiness but failed a final cron-authority CLI handshake and rolled back. That attempt is not counted as successful acceptance; the results above belong to the subsequent accepted integration candidate.

Exact-head CI [33942838861](https://github.com/openclaw/openclaw/actions/runs/33942838861) passed on `802ba35be7c85288f3ed9224e7694fb3d68bc850`: 106 successful jobs and 17 expected skips, with no failures or incomplete jobs. The installed acceptance above resolves both pending-proof items and the rank-up move in the [ClawSweeper review](https://github.com/openclaw/openclaw/pull/138830#issuecomment-5549432063). No code changed after that review.
