### PR TITLE
perf(plugins): avoid repeated installed record scans

### DIFF
--- a/src/plugins/installed-plugin-index.ts
+++ b/src/plugins/installed-plugin-index.ts
@@ -200,8 +200,18 @@ export function createInstalledPluginEnabledPredicate(
 ): (pluginId: string) => boolean {
   let source: PluginActivationConfigSource | undefined;
   let bundledSource: PluginActivationConfigSource | undefined;
+  let records: Map<string, InstalledPluginIndexRecord> | undefined;
   return (pluginId) => {
-    const record = plugins.find((plugin) => plugin.pluginId === pluginId);
+    if (!records) {
+      records = new Map();
+      // Inventory is fixed for this operation; retain the first duplicate like find().
+      for (const entry of plugins) {
+        if (!records.has(entry.pluginId)) {
+          records.set(entry.pluginId, entry);
+        }
+      }
+    }
+    const record = records.get(pluginId);
     if (!record || !config) {
       return record?.enabled ?? false;
     }


### PR DESCRIPTION
## What Problem This Solves

Plugin inventory and registry operations repeatedly scan the same installed-plugin list when checking which plugins are enabled. Checking a complete inventory performs a quadratic number of record comparisons as the inventory grows.

## Why This Change Was Made

Build one lazy, operation-local record index inside `createInstalledPluginEnabledPredicate` and reuse it for subsequent checks. The inventory is fixed for the operation; this introduces no process cache, freshness policy, configuration option or persistence change. The first duplicate ID still wins, matching the previous `find` behavior. No-query callers still construct no index, and activation policy and missing-record behavior are unchanged.

Production delta is +10 lines, with no test changes. The growth replaces repeated linear scans with one indexed lookup path while preserving lazy construction and duplicate precedence. The existing manifest `byPluginId` map has different record and duplicate semantics and is not a substitute.

## User Impact

Operations that check a complete plugin inventory do less repeated work. No visible behavior or public API changes. Single-query callers pay the index construction cost, so this is an inventory optimization rather than a universal lookup or Gateway speedup.

## Evidence

A fixed before/candidate/candidate/before sequence measured complete predicate construction and all selected queries, retained 9,304 validated outputs and 512 sample means, and kept all 358 comparisons, including 212 adverse observations. Both orders were retained; there was no aggregate numeric acceptance threshold.

| Workload | Candidate median change, first order | Candidate median change, reverse order |
| --- | ---: | ---: |
| Full 32-plugin inventory | -47.21% | -44.13% |
| Full 256-plugin inventory | -89.29% | -89.63% |
| First hit in 32 plugins | +494% | +487% |
| Single last hit in 256 plugins | +24.7% | +44.7% |

The first-hit increases were about 0.67–0.70 microseconds and the last-hit increases about 1.7–2.9 microseconds. The 32-plugin inventory p95 worsened by 228–250% (about 52–54 microseconds); those samples remain in the results without an asserted GC or noise explanation. Scalar cases were mixed/slower. Kernel peak RSS increased 0.76–1.08%; no memory benefit or end-to-end Gateway latency benefit is claimed. Accepting the change is an engineering judgment about the complete-inventory callers, not a claim that every case improved.

Validation:

- The same 118 tests across seven complete files passed before and after: installed index, compatibility, registry, current snapshot contributions, provider environment discovery, management listing and inspection.
- `node scripts/check-changed.mjs -- src/plugins/installed-plugin-index.ts` passed all 28 normal stages.
- Independent managed Codex review returned no findings across three partitions (0.87 confidence); the source stayed unchanged afterward.
- A normal mapped build passed. The emitted installed-index owner matches the candidate source, and the full 15,845-entry root dist census (including 288 symlinks) remained unchanged through proof.
- A real, isolated built Gateway passed six read-only RPCs. Two complete, ordered 167-entry plugin inventories were byte-identical, as were repeated fixture inspections; disabled OpenAI and Workboard inspections matched the inventory. This was candidate correctness proof, not a paired latency measurement. No provider request or real API key was needed.
- The Gateway exited normally without forced shutdown; all nine observed PIDs and three known process groups were absent and its port was refused and bindable afterward. Five caught `GatewayDrainingError` warnings from background startup/shutdown work remain disclosed; this does not claim all background work quiesced cleanly. Zero-byte SQLite lock artifacts remained in the synthetic state; process/port checks, not filename absence, establish closure.
