### PR TITLE
refactor: simplify avatar cleanup and loading fixtures

### DIFF
--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -625,10 +625,9 @@ export async function handleControlUiAvatarRequest(
 
   const identity = resolveAssistantIdentity({ cfg: opts.config, agentId });
   const projection = openGatewayAssistantAvatar({ cfg: opts.config, identity });
-  const resolved = projection.resolution;
-
-  if (url.searchParams.get("meta") === "1") {
-    try {
+  try {
+    const resolved = projection.resolution;
+    if (url.searchParams.get("meta") === "1") {
       const meta = controlUiAvatarResolutionMeta(resolved);
       const avatarUrl =
         gatewayAssistantAvatarUrl(projection, basePath, agentId) ??
@@ -639,65 +638,59 @@ export async function handleControlUiAvatarRequest(
         avatarStatus: meta.avatarStatus,
         avatarReason: meta.avatarReason,
       } satisfies ControlUiAvatarMeta);
-    } finally {
-      if (projection.openedFile) {
-        fs.closeSync(projection.openedFile.fd);
-      }
-    }
-    return true;
-  }
-
-  if (url.searchParams.has("v") && (projection.openedFile || resolved?.kind === "data")) {
-    const source = projection.openedFile
-      ? { file: projection.openedFile }
-      : { dataUrl: identity.avatar };
-    try {
-      const image = await (await loadAvatarThumbnail()).readGatewayAvatarThumbnail(source);
-      // Browser HTTP caches must not reuse authenticated bytes after a credential switch.
-      res.setHeader("vary", "Authorization, Cookie");
-      sendHttpImageResponse({
-        req,
-        res,
-        image,
-        filename: "avatar",
-        cacheControl:
-          url.searchParams.get("v") === gatewayAvatarImageRevision(source)
-            ? "private, max-age=31536000, immutable"
-            : "private, no-cache",
-      });
-    } catch {
-      respondControlUiNotFound(res);
-    } finally {
-      if (projection.openedFile) {
-        fs.closeSync(projection.openedFile.fd);
-      }
-    }
-    return true;
-  }
-
-  if (resolved?.kind !== "local" || !projection.openedFile) {
-    respondControlUiNotFound(res);
-    return true;
-  }
-
-  try {
-    res.setHeader("Content-Type", resolveAvatarMime(projection.openedFile.path));
-    res.setHeader("Cache-Control", "no-cache");
-    if (req.method === "HEAD") {
-      res.statusCode = 200;
-      // The pinned descriptor exposes GET's exact byte count without reading the avatar.
-      res.setHeader("Content-Length", String(projection.openedFile.stat.size));
-      res.end();
       return true;
     }
-    const body = await readFileDescriptorBounded(projection.openedFile.fd, AVATAR_MAX_BYTES);
-    res.end(body);
-    return true;
-  } catch {
-    respondControlUiNotFound(res);
-    return true;
+
+    if (url.searchParams.has("v") && (projection.openedFile || resolved?.kind === "data")) {
+      const source = projection.openedFile
+        ? { file: projection.openedFile }
+        : { dataUrl: identity.avatar };
+      try {
+        const image = await (await loadAvatarThumbnail()).readGatewayAvatarThumbnail(source);
+        // Browser HTTP caches must not reuse authenticated bytes after a credential switch.
+        res.setHeader("vary", "Authorization, Cookie");
+        sendHttpImageResponse({
+          req,
+          res,
+          image,
+          filename: "avatar",
+          cacheControl:
+            url.searchParams.get("v") === gatewayAvatarImageRevision(source)
+              ? "private, max-age=31536000, immutable"
+              : "private, no-cache",
+        });
+      } catch {
+        respondControlUiNotFound(res);
+      }
+      return true;
+    }
+
+    if (resolved?.kind !== "local" || !projection.openedFile) {
+      respondControlUiNotFound(res);
+      return true;
+    }
+
+    try {
+      res.setHeader("Content-Type", resolveAvatarMime(projection.openedFile.path));
+      res.setHeader("Cache-Control", "no-cache");
+      if (req.method === "HEAD") {
+        res.statusCode = 200;
+        // The pinned descriptor exposes GET's exact byte count without reading the avatar.
+        res.setHeader("Content-Length", String(projection.openedFile.stat.size));
+        res.end();
+        return true;
+      }
+      const body = await readFileDescriptorBounded(projection.openedFile.fd, AVATAR_MAX_BYTES);
+      res.end(body);
+      return true;
+    } catch {
+      respondControlUiNotFound(res);
+      return true;
+    }
   } finally {
-    fs.closeSync(projection.openedFile.fd);
+    if (projection.openedFile) {
+      fs.closeSync(projection.openedFile.fd);
+    }
   }
 }
 

--- a/ui/src/e2e/dashboard-gallery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-gallery.e2e.test.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { expect, it } from "vitest";
 import type { SessionsResolveResult } from "../../../packages/gateway-protocol/src/index.js";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
@@ -19,27 +18,29 @@ const selectedResolution = {
   displayName: "Release health",
   boardFace: "dashboard",
 } satisfies SessionsResolveResult;
-const dashboardRows = [
-  [selectedSessionKey, selectedResolution.displayName, "mira", "Mira", 3_000, "running"],
-  ["agent:main:dashboard:model-spend", "Model spend", "peter", "Peter", 8_000, "done"],
-  ["agent:main:dashboard:support-radar", "Support radar", "mira", "Mira", 18_000, "done"],
-  ["agent:main:dashboard:ci-signal", "CI signal", "peter", "Peter", 42_000, "done"],
-  ["agent:main:dashboard:community-pulse", "Community pulse", "mira", "Mira", 75_000, "done"],
-  ["agent:main:dashboard:gateway-fleet", "Gateway fleet", "peter", "Peter", 130_000, "done"],
-  ["agent:main:dashboard:deployments", "Deployments", "mira", "Mira", 160_000, "done"],
-  ["agent:main:dashboard:incidents", "Incidents", "peter", "Peter", 190_000, "done"],
-  ["agent:main:dashboard:traffic", "Traffic", "mira", "Mira", 220_000, "done"],
-  ["agent:main:dashboard:queues", "Queues", "peter", "Peter", 250_000, "done"],
-  ["agent:main:dashboard:workers", "Workers", "mira", "Mira", 280_000, "done"],
-  ["agent:main:dashboard:capacity", "Capacity", "peter", "Peter", 310_000, "done"],
-].map(([key, displayName, actorId, actorLabel, age, status]) => ({
-  key: String(key),
+const dashboardRows = (
+  [
+    [selectedSessionKey, selectedResolution.displayName, "mira", "Mira", 3_000, "running"],
+    ["agent:main:dashboard:model-spend", "Model spend", "peter", "Peter", 8_000, "done"],
+    ["agent:main:dashboard:support-radar", "Support radar", "mira", "Mira", 18_000, "done"],
+    ["agent:main:dashboard:ci-signal", "CI signal", "peter", "Peter", 42_000, "done"],
+    ["agent:main:dashboard:community-pulse", "Community pulse", "mira", "Mira", 75_000, "done"],
+    ["agent:main:dashboard:gateway-fleet", "Gateway fleet", "peter", "Peter", 130_000, "done"],
+    ["agent:main:dashboard:deployments", "Deployments", "mira", "Mira", 160_000, "done"],
+    ["agent:main:dashboard:incidents", "Incidents", "peter", "Peter", 190_000, "done"],
+    ["agent:main:dashboard:traffic", "Traffic", "mira", "Mira", 220_000, "done"],
+    ["agent:main:dashboard:queues", "Queues", "peter", "Peter", 250_000, "done"],
+    ["agent:main:dashboard:workers", "Workers", "mira", "Mira", 280_000, "done"],
+    ["agent:main:dashboard:capacity", "Capacity", "peter", "Peter", 310_000, "done"],
+  ] as const
+).map(([key, displayName, actorId, actorLabel, age, status]) => ({
+  key,
   kind: "direct",
   boardFace: "dashboard",
-  displayName: String(displayName),
-  updatedAt: now - Number(age),
-  status: String(status),
-  createdActor: { type: "human", id: String(actorId), label: String(actorLabel) },
+  displayName,
+  updatedAt: now - age,
+  status,
+  createdActor: { type: "human", id: actorId, label: actorLabel },
 }));
 
 const previewMarkup = encodeURIComponent(
@@ -150,9 +151,7 @@ suite.define(() => {
         expect(await gateway.getRequests("board.widget.appView")).toHaveLength(0);
         const capacityKey = "agent:main:dashboard:capacity";
         const capacityRequested = async () =>
-          (await gateway.getRequests("board.get")).some(
-            (request) => isRecord(request.params) && request.params.sessionKey === capacityKey,
-          );
+          (await gateway.getRequests("board.get", { sessionKey: capacityKey })).length > 0;
         expect(await capacityRequested()).toBe(false);
         const capacityCard = gallery.locator(`[data-dashboard-session="${capacityKey}"]`);
         await capacityCard.scrollIntoViewIfNeeded();

--- a/ui/src/lib/agents/identity.test.ts
+++ b/ui/src/lib/agents/identity.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentIdentityResult } from "../../api/types.ts";
 import type { ApplicationGatewayPhase } from "../../app/gateway.ts";
@@ -9,22 +10,14 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
-
 it("rejects stale identities after reconnecting the same client", async () => {
-  const oldRequest = deferred<AgentIdentityResult>();
-  const currentRequest = deferred<AgentIdentityResult>();
+  const oldRequest = createDeferred<AgentIdentityResult>();
+  const currentRequest = createDeferred<AgentIdentityResult>();
   const request = vi
     .fn()
     .mockImplementationOnce(() => oldRequest.promise)
     .mockImplementationOnce(() => currentRequest.promise);
-  const client = { request } as unknown as GatewayBrowserClient;
+  const client = createTestGatewayClient(request);
   let snapshot: { client: GatewayBrowserClient | null; phase: ApplicationGatewayPhase } = {
     client,
     phase: "connected",
@@ -51,25 +44,25 @@ it("rejects stale identities after reconnecting the same client", async () => {
   publish(true);
   const current = capability.ensure(["main"]);
 
-  oldRequest.resolve({ agentId: "main", name: "Stale" } as AgentIdentityResult);
+  oldRequest.resolve({ agentId: "main", name: "Stale", avatar: "" });
   await stale;
   expect(capability.entries()).toEqual([]);
 
-  currentRequest.resolve({ agentId: "main", name: "Current" } as AgentIdentityResult);
+  currentRequest.resolve({ agentId: "main", name: "Current", avatar: "" });
   await current;
   expect(capability.get("main")?.name).toBe("Current");
 });
 
 it("rejects an in-flight identity after that agent is invalidated", async () => {
-  const staleRequest = deferred<AgentIdentityResult>();
-  const currentRequest = deferred<AgentIdentityResult>();
+  const staleRequest = createDeferred<AgentIdentityResult>();
+  const currentRequest = createDeferred<AgentIdentityResult>();
   const request = vi
     .fn()
     .mockImplementationOnce(() => staleRequest.promise)
     .mockImplementationOnce(() => currentRequest.promise);
-  const client = { request } as unknown as GatewayBrowserClient;
+  const client = createTestGatewayClient(request);
   const capability = createAgentIdentityCapability({
-    snapshot: { client, phase: "connected" as const },
+    snapshot: { client, phase: "connected" },
     subscribe: () => () => undefined,
   });
 
@@ -77,29 +70,30 @@ it("rejects an in-flight identity after that agent is invalidated", async () => 
   capability.invalidate(["main"]);
   const current = capability.ensure(["main"]);
 
-  staleRequest.resolve({ agentId: "main", name: "Stale" } as AgentIdentityResult);
+  staleRequest.resolve({ agentId: "main", name: "Stale", avatar: "" });
   await stale;
   expect(capability.entries()).toEqual([]);
 
-  currentRequest.resolve({ agentId: "main", name: "Current" } as AgentIdentityResult);
+  currentRequest.resolve({ agentId: "main", name: "Current", avatar: "" });
   await current;
   expect(capability.get("main")?.name).toBe("Current");
 });
 
 it("publishes each fetched snapshot once under overlapping roster and stream updates", async () => {
-  const pending = deferred<AgentIdentityResult>();
+  const pending = createDeferred();
   const ids = Array.from({ length: 24 }, (_, index) => `agent-${index}`);
-  const request = vi.fn((_method: string, { agentId }: { agentId: string }) =>
-    pending.promise.then(() => ({ agentId, name: agentId })),
-  );
+  const request = vi.fn((_method: string, params: unknown) => {
+    const { agentId } = params as { agentId: string };
+    return pending.promise.then(() => ({ agentId, name: agentId, avatar: "" }));
+  });
   const capability = createAgentIdentityCapability({
-    snapshot: { client: { request } as unknown as GatewayBrowserClient, phase: "connected" },
+    snapshot: { client: createTestGatewayClient(request), phase: "connected" },
     subscribe: () => () => undefined,
   });
   const publish = vi.fn();
   capability.subscribe(publish);
   const updates = Array.from({ length: 40 }, () => capability.ensure(ids));
-  pending.resolve({ agentId: ids[0], name: ids[0] } as AgentIdentityResult);
+  pending.resolve();
   await Promise.all(updates);
   expect(request).toHaveBeenCalledTimes(ids.length);
   expect(capability.entries()).toHaveLength(ids.length);
@@ -134,7 +128,7 @@ it.each(["sidebar", "chat"])(
     const clock = vi.spyOn(Date, "now").mockReturnValue(0);
     const oldIdentity = { agentId: "main", name: "Main", avatar: "/avatar/main?v=old" };
     const replacement = { ...oldIdentity, avatar: "/avatar/main?v=replaced" };
-    const refresh = deferred<AgentIdentityResult>();
+    const refresh = createDeferred<AgentIdentityResult>();
     const request = vi.fn().mockResolvedValueOnce(oldIdentity).mockReturnValueOnce(refresh.promise);
     const client = createTestGatewayClient(request);
     const capability = createAgentIdentityCapability({

--- a/ui/src/pages/chat/session-prefetch.test-support.ts
+++ b/ui/src/pages/chat/session-prefetch.test-support.ts
@@ -1,5 +1,4 @@
 import { IDBFactory } from "fake-indexeddb";
-import type { ReactiveController } from "lit";
 import { vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
@@ -16,7 +15,6 @@ export type SessionPrefetchUpdate = {
   client: GatewayBrowserClient | null;
   listRevision: number;
   openSessionKeys: readonly string[];
-  /** Presented panes still fetching their transcript; omitted panes report committed. */
   loadingSessionKeys?: readonly string[];
   rows: readonly GatewaySessionRow[] | null;
 };
@@ -60,26 +58,12 @@ export function createSessionPrefetchFixture() {
   vi.setSystemTime(PREFETCH_TEST_NOW);
   vi.stubGlobal("indexedDB", new IDBFactory());
   let visibility: DocumentVisibilityState = "visible";
-  const originalVisibility = Object.getOwnPropertyDescriptor(document, "visibilityState");
-  Object.defineProperty(document, "visibilityState", {
-    configurable: true,
-    get: () => visibility,
-  });
+  vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibility);
   const originalLocks = Object.getOwnPropertyDescriptor(navigator, "locks");
-  const originalRequestIdleCallback = Object.getOwnPropertyDescriptor(
-    window,
-    "requestIdleCallback",
+  vi.stubGlobal("requestIdleCallback", (callback: IdleRequestCallback) =>
+    window.setTimeout(() => callback({ didTimeout: false, timeRemaining: () => 50 }), 0),
   );
-  const originalCancelIdleCallback = Object.getOwnPropertyDescriptor(window, "cancelIdleCallback");
-  Object.defineProperty(window, "requestIdleCallback", {
-    configurable: true,
-    value: (callback: IdleRequestCallback) =>
-      window.setTimeout(() => callback({ didTimeout: false, timeRemaining: () => 50 }), 0),
-  });
-  Object.defineProperty(window, "cancelIdleCallback", {
-    configurable: true,
-    value: (handle: number) => window.clearTimeout(handle),
-  });
+  vi.stubGlobal("cancelIdleCallback", (handle: number) => window.clearTimeout(handle));
   Object.defineProperty(navigator, "locks", { configurable: true, value: undefined });
   const cache: ChatMessageCache = new Map();
   const store = new SessionSnapshotStore(cache);
@@ -92,20 +76,15 @@ export function createSessionPrefetchFixture() {
     rows: null,
   };
   const connection = createGatewayConnectionLifecycle({ client: null, phase: "stopped" });
-  const gatewayListeners = new Set<() => void>();
   const context = {
     agents: { state: { agentsList: null } },
     gateway: {
       snapshot: { assistantAgentId: "main", hello: null },
-      subscribe: (listener: () => void) => {
-        gatewayListeners.add(listener);
-        return () => gatewayListeners.delete(listener);
-      },
+      subscribe: () => () => undefined,
     },
     sessions: {
-      captureConnectionScope: () => connection.capture(),
-      isConnectionScopeCurrent: (scope: Parameters<typeof connection.isCurrent>[0]) =>
-        connection.isCurrent(scope),
+      captureConnectionScope: connection.capture,
+      isConnectionScopeCurrent: connection.isCurrent,
       subscribe: () => () => undefined,
       get canonicalListRevision() {
         return current.listRevision;
@@ -116,8 +95,8 @@ export function createSessionPrefetchFixture() {
     },
   };
   const host = Object.assign(document.createElement("div"), {
-    addController: (_controller: ReactiveController) => undefined,
-    removeController: (_controller: ReactiveController) => undefined,
+    addController: () => undefined,
+    removeController: () => undefined,
     requestUpdate: () => undefined,
     updateComplete: Promise.resolve(true),
   });
@@ -160,25 +139,10 @@ export function createSessionPrefetchFixture() {
       store.disconnect();
       await store.whenIdle();
       await clearStoredChatSnapshots();
-      if (originalVisibility) {
-        Object.defineProperty(document, "visibilityState", originalVisibility);
-      } else {
-        Reflect.deleteProperty(document, "visibilityState");
-      }
       if (originalLocks) {
         Object.defineProperty(navigator, "locks", originalLocks);
       } else {
         Reflect.deleteProperty(navigator, "locks");
-      }
-      if (originalRequestIdleCallback) {
-        Object.defineProperty(window, "requestIdleCallback", originalRequestIdleCallback);
-      } else {
-        Reflect.deleteProperty(window, "requestIdleCallback");
-      }
-      if (originalCancelIdleCallback) {
-        Object.defineProperty(window, "cancelIdleCallback", originalCancelIdleCallback);
-      } else {
-        Reflect.deleteProperty(window, "cancelIdleCallback");
       }
       vi.useRealTimers();
       vi.restoreAllMocks();


### PR DESCRIPTION
Related: #138635, #138793

## What Problem This Solves

Maintainer-requested cleanup of the chat-loading and avatar work. The avatar route repeated descriptor cleanup across three branches, and the tests duplicated lifecycle machinery already provided by Vitest and shared helpers.

## Why This Change Was Made

One outer `finally` now owns the avatar descriptor; the existing metadata and byte-response error handling stays intact. Tests use tracked global restoration, the shared deferred helper, typed client fixtures, literal tuples, and the mock Gateway's request matcher. Unused subscription bookkeeping is removed.

Production: net -7 lines. Tests and fixtures: net -43 lines. No assertions or behavior guards are removed.

## User Impact

No intended behavior change. Avatar caching, authentication, file lifetime, reconnect protection, and foreground chat priority are preserved.

## Evidence

- 89 focused UI tests passed across prefetch, lifecycle, identity, and chat avatars.
- 45 avatar-related HTTP tests passed, including metadata, HEAD, versioned images, caching, and authentication.
- The gallery Chromium test passed after a fresh UI build, including cold reload, lazy previews, desktop layouts, and mobile width. All five retained screenshots were inspected.
- Independent Codex review through P2 found no actionable defects.
- [Fresh real-Gateway Chromium proof](https://github.com/openclaw/openclaw/actions/runs/33943282369/job/101244727337): all 13 files / 24 tests passed, including selected-chat startup priority, full backscroll, and authenticated avatar caching/304 revalidation.
- Changed-file formatting, typechecks, lint, and guards passed. [CI passed on the final commit](https://github.com/openclaw/openclaw/actions/runs/33943282369).

The gallery still contains the incomplete synthetic MCP placeholder documented in #138793. The test bootstrap also emits an existing Vite dynamic-import warning; the build and browser test complete successfully. Neither is changed by this cleanup.

Before cleanup (from #138793):

![Before: expanded synthetic dashboard](https://github.com/user-attachments/assets/e5852434-321a-4aec-a37b-816a57619f69)

![After cleanup: identical expanded dashboard; known incomplete MCP placeholder retained](https://github.com/user-attachments/assets/ae233a4d-3941-4793-9526-819815490600)


<details>
<summary>Local verification commands</summary>

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/pages/chat/session-prefetch.test.ts ui/src/pages/chat/session-prefetch-lifecycle.test.ts ui/src/lib/agents/identity.test.ts ui/src/pages/chat/chat-avatar.test.ts
node scripts/run-vitest.mjs src/gateway/assistant-avatar-http.test.ts src/gateway/control-ui.http.test.ts -t avatar
OPENCLAW_UI_E2E_RECORD=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/dashboard-gallery.e2e.test.ts
node scripts/check-changed.mjs -- src/gateway/control-ui.ts ui/src/lib/agents/identity.test.ts ui/src/pages/chat/session-prefetch.test-support.ts ui/src/e2e/dashboard-gallery.e2e.test.ts
```

</details>


## Review resolution

Resolved the reviewer-access limitation in the latest ClawSweeper review. The maintainer directly inspected the installed, pinned Vitest 4.1.11 implementation: `stubGlobal` captures the original global property descriptor, `unstubAllGlobals` restores it or deletes a previously absent property, and the jsdom environment aliases `window` to `globalThis`. The existing 89 UI tests passed with this restoration path.

The maintainer also inspected all five retained browser screenshots and the final real-Gateway job log linked above (13 files / 24 tests passed). The review reports no code or security findings; its unavailable network/dependency evidence is supplied by these direct checks. No source change or additional mitigation is needed, and the tested head remains `9f63e8040042143b2c309b0bbb6615dde5ff2ea0`.
