### PR TITLE
Feat/feishu askuser question buttons

### DIFF
--- a/extensions/feishu/src/card-action.question-answer.test.ts
+++ b/extensions/feishu/src/card-action.question-answer.test.ts
@@ -1,0 +1,317 @@
+import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
+import { processedCardActions } from "./card-action-state.js";
+import {
+  FEISHU_QUESTION_ANSWER_ACTION,
+  handleFeishuCardAction,
+  type FeishuCardActionEvent,
+} from "./card-action.js";
+import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
+
+// Mock account resolution
+vi.mock("./accounts.js", () => ({
+  resolveFeishuAccount: vi.fn().mockReturnValue({ accountId: "mock-account" }),
+  resolveFeishuRuntimeAccount: vi
+    .fn()
+    .mockReturnValue({ accountId: "mock-account", configured: true }),
+}));
+
+// Mock bot.js to prove question answers never dispatch a synthetic message
+vi.mock("./bot.js", () => ({
+  handleFeishuMessage: vi.fn(),
+}));
+
+// Mock the gateway question runtime used for button resolution
+vi.mock("openclaw/plugin-sdk/question-gateway-runtime", () => ({
+  questionGatewayRuntime: { resolveOption: vi.fn() },
+}));
+
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
+const messageReactionCreateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
+
+vi.mock("./send.js", () => ({
+  sendCardFeishu: vi.fn(),
+  sendMessageFeishu: sendMessageFeishuMock,
+}));
+
+import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
+import { handleFeishuMessage } from "./bot.js";
+
+describe("Feishu Card Action question button answers", () => {
+  const cfg: ClawdbotConfig = {};
+  const runtime: RuntimeEnv = createRuntimeEnv();
+  const resolveOptionMock = vi.mocked(questionGatewayRuntime.resolveOption);
+
+  afterAll(() => {
+    vi.doUnmock("./accounts.js");
+    vi.doUnmock("./bot.js");
+    vi.doUnmock("./client.js");
+    vi.doUnmock("./send.js");
+    vi.doUnmock("openclaw/plugin-sdk/question-gateway-runtime");
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    processedCardActions.clear();
+    createFeishuClientMock.mockReset().mockReturnValue({
+      im: {
+        messageReaction: {
+          create: messageReactionCreateMock,
+        },
+      },
+    });
+    messageReactionCreateMock.mockReset().mockResolvedValue({
+      code: 0,
+      data: { reaction_id: "reaction-1" },
+    });
+    resolveOptionMock.mockReset().mockResolvedValue({
+      status: "answered",
+      questionId: "unused",
+      optionValue: "unused",
+    });
+    vi.mocked(handleFeishuMessage)
+      .mockReset()
+      .mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function createQuestionAnswerEvent(params: {
+    token: string;
+    questionId: string;
+    optionValue: string;
+    contextOpenMessageId?: string;
+    openMessageId?: string;
+    operatorOpenId?: string;
+  }): FeishuCardActionEvent {
+    const openId = params.operatorOpenId ?? "u123";
+    return {
+      operator: { open_id: openId, user_id: "uid1", union_id: "un1" },
+      token: params.token,
+      action: {
+        value: createFeishuCardInteractionEnvelope({
+          k: "button",
+          a: FEISHU_QUESTION_ANSWER_ACTION,
+          q: params.questionId,
+          m: { o: params.optionValue },
+        }),
+        tag: "button",
+      },
+      context: {
+        open_id: openId,
+        user_id: "uid1",
+        chat_id: "chat1",
+        ...(params.contextOpenMessageId
+          ? { open_message_id: params.contextOpenMessageId }
+          : {}),
+      },
+      ...(params.openMessageId ? { open_message_id: params.openMessageId } : {}),
+    };
+  }
+
+  it("resolves an answered question button through the gateway and acks with an OK reaction", async () => {
+    const questionId = "ask_11111111111111111111111111111111";
+    const event = createQuestionAnswerEvent({
+      token: "tok-q-answered",
+      questionId,
+      optionValue: "Option A",
+      contextOpenMessageId: "om_question_card_1",
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(resolveOptionMock).toHaveBeenCalledTimes(1);
+    expect(resolveOptionMock).toHaveBeenCalledWith({
+      cfg,
+      questionId,
+      senderId: "u123",
+      optionValue: "Option A",
+    });
+    expect(messageReactionCreateMock).toHaveBeenCalledWith({
+      path: { message_id: "om_question_card_1" },
+      data: { reaction_type: { emoji_type: "OK" } },
+    });
+    // A button answer must never be re-injected as a synthetic user message.
+    expect(handleFeishuMessage).not.toHaveBeenCalled();
+  });
+
+  it("skips the ack reaction when the question is already terminal", async () => {
+    resolveOptionMock.mockResolvedValue({
+      status: "already-terminal",
+      reason: "already-terminal",
+    } as never);
+    const event = createQuestionAnswerEvent({
+      token: "tok-q-terminal",
+      questionId: "ask_22222222222222222222222222222222",
+      optionValue: "Option A",
+      contextOpenMessageId: "om_question_card_2",
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(resolveOptionMock).toHaveBeenCalledTimes(1);
+    expect(messageReactionCreateMock).not.toHaveBeenCalled();
+    expect(handleFeishuMessage).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the event-level message id for the ack reaction", async () => {
+    const event = createQuestionAnswerEvent({
+      token: "tok-q-top-id",
+      questionId: "ask_33333333333333333333333333333333",
+      optionValue: "Option A",
+      openMessageId: "om_question_card_3",
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(messageReactionCreateMock).toHaveBeenCalledWith({
+      path: { message_id: "om_question_card_3" },
+      data: { reaction_type: { emoji_type: "OK" } },
+    });
+  });
+
+  it("skips the ack reaction when the callback carries no message id", async () => {
+    const event = createQuestionAnswerEvent({
+      token: "tok-q-no-id",
+      questionId: "ask_44444444444444444444444444444444",
+      optionValue: "Option A",
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(resolveOptionMock).toHaveBeenCalledTimes(1);
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed question envelopes without resolving", async () => {
+    const event = createQuestionAnswerEvent({
+      token: "tok-q-missing-q",
+      questionId: "",
+      optionValue: "Option A",
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(resolveOptionMock).not.toHaveBeenCalled();
+    expect(messageReactionCreateMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    const args = sendMessageFeishuMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(args.to).toBe("chat:chat1");
+    expect(String(args.text)).toContain("payload is invalid");
+  });
+
+  it("rejects over-long question options as malformed", async () => {
+    const event = createQuestionAnswerEvent({
+      token: "tok-q-overlong",
+      questionId: "ask_55555555555555555555555555555555",
+      optionValue: "x".repeat(513),
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(resolveOptionMock).not.toHaveBeenCalled();
+    expect(messageReactionCreateMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores repeated taps on the same question within the dedupe window", async () => {
+    const log = vi.fn();
+    const customRuntime = { ...runtime, log };
+    const questionId = "ask_66666666666666666666666666666666";
+
+    await handleFeishuCardAction({
+      cfg,
+      event: createQuestionAnswerEvent({
+        token: "tok-q-repeat-1",
+        questionId,
+        optionValue: "Option A",
+        contextOpenMessageId: "om_question_card_6",
+      }),
+      runtime: customRuntime,
+    });
+    await handleFeishuCardAction({
+      cfg,
+      event: createQuestionAnswerEvent({
+        token: "tok-q-repeat-2",
+        questionId,
+        optionValue: "Option A",
+        contextOpenMessageId: "om_question_card_6",
+      }),
+      runtime: customRuntime,
+    });
+
+    expect(resolveOptionMock).toHaveBeenCalledTimes(1);
+    expect(messageReactionCreateMock).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(
+      `feishu[mock-account]: skipping repeated question button answer ${questionId} from u123`,
+    );
+  });
+
+  it("swallows gateway resolution failures and still completes the card action", async () => {
+    const log = vi.fn();
+    resolveOptionMock.mockRejectedValue(new Error("gateway unavailable"));
+    const event = createQuestionAnswerEvent({
+      token: "tok-q-failure",
+      questionId: "ask_77777777777777777777777777777777",
+      optionValue: "Option A",
+      contextOpenMessageId: "om_question_card_7",
+    });
+
+    await expect(
+      handleFeishuCardAction({ cfg, event, runtime: { ...runtime, log } }),
+    ).resolves.toBeUndefined();
+
+    expect(messageReactionCreateMock).not.toHaveBeenCalled();
+    expect(handleFeishuMessage).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(
+      "feishu[mock-account]: question ask_77777777777777777777777777777777 answer failed: gateway unavailable",
+    );
+  });
+
+  it("swallows ack reaction failures without blocking the answer", async () => {
+    const log = vi.fn();
+    messageReactionCreateMock.mockRejectedValue(new Error("reaction denied"));
+    const event = createQuestionAnswerEvent({
+      token: "tok-q-ack-failure",
+      questionId: "ask_88888888888888888888888888888888",
+      optionValue: "Option A",
+      contextOpenMessageId: "om_question_card_8",
+    });
+
+    await expect(
+      handleFeishuCardAction({ cfg, event, runtime: { ...runtime, log } }),
+    ).resolves.toBeUndefined();
+
+    expect(resolveOptionMock).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(
+      "feishu[mock-account]: question ack reaction skipped (non-fatal): reaction denied",
+    );
+  });
+
+  it("allows a re-answer once the dedupe window has expired", async () => {
+    vi.useFakeTimers();
+    const questionId = "ask_99999999999999999999999999999999";
+    const event = createQuestionAnswerEvent({
+      token: "tok-q-ttl-1",
+      questionId,
+      optionValue: "Option A",
+      contextOpenMessageId: "om_question_card_9",
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+    await vi.advanceTimersByTimeAsync(61_000);
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(resolveOptionMock).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+});

--- a/extensions/feishu/src/card-action.question-answer.test.ts
+++ b/extensions/feishu/src/card-action.question-answer.test.ts
@@ -300,16 +300,25 @@ describe("Feishu Card Action question button answers", () => {
   it("allows a re-answer once the dedupe window has expired", async () => {
     vi.useFakeTimers();
     const questionId = "ask_99999999999999999999999999999999";
-    const event = createQuestionAnswerEvent({
+    // A fresh card-action token per tap: the 15-minute token dedupe must not
+    // block the second tap, so this exercises the 60-second question dedupe
+    // window expiring and allowing a re-answer.
+    const firstTap = createQuestionAnswerEvent({
       token: "tok-q-ttl-1",
       questionId,
       optionValue: "Option A",
       contextOpenMessageId: "om_question_card_9",
     });
+    const secondTap = createQuestionAnswerEvent({
+      token: "tok-q-ttl-2",
+      questionId,
+      optionValue: "Option A",
+      contextOpenMessageId: "om_question_card_9",
+    });
 
-    await handleFeishuCardAction({ cfg, event, runtime });
+    await handleFeishuCardAction({ cfg, event: firstTap, runtime });
     await vi.advanceTimersByTimeAsync(61_000);
-    await handleFeishuCardAction({ cfg, event, runtime });
+    await handleFeishuCardAction({ cfg, event: secondTap, runtime });
 
     expect(resolveOptionMock).toHaveBeenCalledTimes(2);
     vi.useRealTimers();

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -4,6 +4,7 @@ import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ClawdbotConfig, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
@@ -42,6 +43,39 @@ export type FeishuCardActionEvent = {
 
 const FEISHU_APPROVAL_CARD_TTL_MS = 5 * 60_000;
 const FEISHU_CARD_ACTION_TOKEN_TTL_MS = 15 * 60_000;
+
+/** Card action dispatched when an ask_user option button is tapped. */
+export const FEISHU_QUESTION_ANSWER_ACTION = "feishu.question.answer";
+const FEISHU_QUESTION_OPTION_MAX_LENGTH = 512;
+const FEISHU_QUESTION_ANSWER_DEDUPE_TTL_MS = 60 * 1000;
+
+// A resolved question is terminal; tapping the same card again must not resolve the
+// same option twice. Remember (account, question, tapUser) for a short window so only
+// the first tap reaches the gateway question-resolution path.
+const dispatchedFeishuQuestionAnswers = new Map<string, number>();
+function pruneDispatchedFeishuQuestionAnswers(now: number): void {
+  for (const [key, expiresAt] of dispatchedFeishuQuestionAnswers) {
+    if (expiresAt <= now) {
+      dispatchedFeishuQuestionAnswers.delete(key);
+    }
+  }
+}
+function claimFeishuQuestionAnswerDispatch(params: {
+  accountId: string;
+  questionId: string;
+  operatorOpenId: string;
+}): boolean {
+  const now = Date.now();
+  pruneDispatchedFeishuQuestionAnswers(now);
+  const key = `${params.accountId}:${params.questionId}:${params.operatorOpenId}`;
+  const existing = dispatchedFeishuQuestionAnswers.get(key);
+  if (existing !== undefined && existing > now) {
+    return false;
+  }
+  dispatchedFeishuQuestionAnswers.set(key, now + FEISHU_QUESTION_ANSWER_DEDUPE_TTL_MS);
+  return true;
+}
+
 function pruneProcessedCardActionTokens(now: number): void {
   const validNow = asDateTimestampMs(now);
   if (validNow === undefined) {
@@ -101,6 +135,70 @@ function completeFeishuCardAction(actionId: string, accountId: string, now = Dat
     status: "completed",
     expiresAt,
   });
+}
+
+type FeishuQuestionAnswerResolveStatus = Awaited<
+  ReturnType<typeof questionGatewayRuntime.resolveOption>
+>["status"];
+
+/**
+ * Resolves one Feishu ask_user button answer through the Gateway question runtime
+ * (question.get + question.resolve). A synthetic text message would start a brand-new
+ * agent run and never wake the pending question.waitAnswer owned by the original
+ * ask_user call, so the agent only continued after the wait timed out. Gateway-backed
+ * resolution wakes the pending ask_user immediately.
+ */
+async function resolveFeishuQuestionAnswerOption(params: {
+  cfg: ClawdbotConfig;
+  questionId: string;
+  optionValue: string;
+  operatorOpenId: string;
+}): Promise<FeishuQuestionAnswerResolveStatus> {
+  const result = await questionGatewayRuntime.resolveOption({
+    cfg: params.cfg,
+    questionId: params.questionId,
+    senderId: params.operatorOpenId,
+    optionValue: params.optionValue,
+  });
+  return result?.status ?? "already-terminal";
+}
+
+// Click acknowledgement: once the answer is accepted via the gateway, react on the
+// original question card message so the user instantly sees the bot received their
+// button choice. Strictly best-effort: failures are logged and swallowed so answering
+// is never blocked by the ack, and missing or temporary message ids (e.g. card-action-*)
+// are skipped. Uses the same im.messageReaction.create surface as the typing indicator,
+// i.e. the app's existing reaction scope, no extra permission needed.
+const FEISHU_QUESTION_ANSWER_ACK_EMOJI = "OK";
+async function ackFeishuQuestionAnswerReaction(params: {
+  cfg: ClawdbotConfig;
+  event: FeishuCardActionEvent;
+  accountId: string;
+  log: (message: string) => void;
+}): Promise<void> {
+  const messageId = params.event.context?.open_message_id ?? params.event.open_message_id;
+  const normalizedMessageId = typeof messageId === "string" ? messageId.trim() : "";
+  if (!normalizedMessageId || normalizedMessageId.startsWith("card-action-")) {
+    return;
+  }
+  const account = resolveFeishuRuntimeAccount({ cfg: params.cfg, accountId: params.accountId });
+  if (!account.configured) {
+    return;
+  }
+  try {
+    await createFeishuClient(account).im.messageReaction.create({
+      path: { message_id: normalizedMessageId },
+      data: { reaction_type: { emoji_type: FEISHU_QUESTION_ANSWER_ACK_EMOJI } },
+    });
+    params.log(
+      `feishu[${params.accountId}]: question ack reaction ${FEISHU_QUESTION_ANSWER_ACK_EMOJI} added on message ${normalizedMessageId}`,
+    );
+  } catch (err) {
+    const reactionError = err instanceof Error ? err.message : "unknown";
+    params.log(
+      `feishu[${params.accountId}]: question ack reaction skipped (non-fatal): ${sanitizeLogValue(reactionError)}`,
+    );
+  }
 }
 
 function buildSyntheticMessageEvent(
@@ -424,6 +522,74 @@ export async function handleFeishuCardAction(params: {
           text: "Cancelled.",
           accountId,
         });
+        completeFeishuCardAction(event.token, account.accountId);
+        return;
+      }
+
+      if (envelope.a === FEISHU_QUESTION_ANSWER_ACTION) {
+        const questionId = envelope.q?.trim();
+        const optionValue =
+          typeof envelope.m?.o === "string" ? envelope.m.o.trim() : "";
+        if (
+          !questionId ||
+          !optionValue ||
+          optionValue.length > FEISHU_QUESTION_OPTION_MAX_LENGTH
+        ) {
+          await sendInvalidInteractionNotice({
+            cfg,
+            event,
+            reason: "malformed",
+            accountId,
+          });
+          completeFeishuCardAction(event.token, account.accountId);
+          return;
+        }
+        if (
+          !claimFeishuQuestionAnswerDispatch({
+            accountId: account.accountId,
+            questionId,
+            operatorOpenId: event.operator.open_id,
+          })
+        ) {
+          log(
+            `feishu[${account.accountId}]: skipping repeated question button answer ${questionId} from ${event.operator.open_id}`,
+          );
+          completeFeishuCardAction(event.token, account.accountId);
+          return;
+        }
+        log(
+          `feishu[${account.accountId}]: answering question ${questionId} from ${event.operator.open_id}`,
+        );
+        let answerAccepted = false;
+        try {
+          const status = await resolveFeishuQuestionAnswerOption({
+            cfg,
+            questionId,
+            optionValue,
+            operatorOpenId: event.operator.open_id,
+          });
+          if (status === "answered") {
+            log(`feishu[${account.accountId}]: question ${questionId} answered via gateway`);
+            answerAccepted = true;
+          } else {
+            log(
+              `feishu[${account.accountId}]: question ${questionId} resolve terminal (${status}); button answer ignored`,
+            );
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "unknown";
+          log(
+            `feishu[${account.accountId}]: question ${questionId} answer failed: ${sanitizeLogValue(message)}`,
+          );
+        }
+        if (answerAccepted) {
+          await ackFeishuQuestionAnswerReaction({
+            cfg,
+            event,
+            accountId: account.accountId,
+            log,
+          });
+        }
         completeFeishuCardAction(event.token, account.accountId);
         return;
       }

--- a/extensions/feishu/src/presentation-card.question.test.ts
+++ b/extensions/feishu/src/presentation-card.question.test.ts
@@ -1,0 +1,143 @@
+import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
+import { describe, expect, it } from "vitest";
+import {
+  FEISHU_PAYLOAD_QUESTION_ACTION,
+  buildFeishuPresentationCard,
+} from "./presentation-card.js";
+
+const QUESTION_ID = "ask_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d";
+
+function renderButtonsBlock(button: Record<string, unknown>) {
+  const presentation = normalizeMessagePresentation({
+    blocks: [{ type: "buttons", buttons: [button] }],
+  });
+  if (!presentation) {
+    throw new Error("expected valid presentation");
+  }
+  return buildFeishuPresentationCard({ presentation }).body.elements as Array<
+    Record<string, unknown>
+  >;
+}
+
+describe("buildFeishuPresentationCard question option buttons", () => {
+  it("renders ask_user option buttons as tappable card callbacks", () => {
+    const [element] = renderButtonsBlock({
+      label: "Option A",
+      action: {
+        type: "question",
+        questionId: QUESTION_ID,
+        optionValue: "Option A",
+      },
+    });
+
+    expect(element).toMatchObject({
+      tag: "button",
+      text: { tag: "plain_text", content: "Option A" },
+      behaviors: [
+        {
+          type: "callback",
+          value: {
+            oc: "ocf1",
+            k: "button",
+            a: FEISHU_PAYLOAD_QUESTION_ACTION,
+            q: QUESTION_ID,
+            m: { o: "Option A" },
+          },
+        },
+      ],
+    });
+  });
+
+  it("keeps command buttons on the existing quick-command envelope", () => {
+    const [element] = renderButtonsBlock({
+      label: "Run /deploy",
+      action: { type: "command", command: "/deploy" },
+    });
+
+    expect(element).toMatchObject({
+      tag: "button",
+      behaviors: [
+        {
+          type: "callback",
+          value: {
+            oc: "ocf1",
+            k: "quick",
+            a: "feishu.payload.button",
+            q: "/deploy",
+          },
+        },
+      ],
+    });
+  });
+
+  it("keeps legacy value buttons on the quick-command envelope", () => {
+    const [element] = renderButtonsBlock({
+      label: "Custom",
+      value: "custom-value",
+    });
+
+    expect(element).toMatchObject({
+      tag: "button",
+      behaviors: [
+        {
+          type: "callback",
+          value: {
+            oc: "ocf1",
+            k: "quick",
+            a: "feishu.payload.button",
+            q: "custom-value",
+          },
+        },
+      ],
+    });
+  });
+
+  it("falls back to text for custom-input (Other) question buttons", () => {
+    const [element] = renderButtonsBlock({
+      label: "Other…",
+      action: {
+        type: "question",
+        questionId: QUESTION_ID,
+        intent: "custom-input",
+      },
+    });
+
+    expect(element).toEqual({
+      tag: "markdown",
+      content: "- Other…",
+    });
+  });
+
+  it("falls back to text when the question option exceeds the 512-char envelope limit", () => {
+    const [element] = renderButtonsBlock({
+      label: "Long option",
+      action: {
+        type: "question",
+        questionId: QUESTION_ID,
+        optionValue: "x".repeat(513),
+      },
+    });
+
+    expect(element).toEqual({
+      tag: "markdown",
+      content: "- Long option",
+    });
+  });
+
+  it("keeps disabled question buttons visible as plain text", () => {
+    const [element] = renderButtonsBlock({
+      label: "Unavailable option",
+      disabled: true,
+      action: {
+        type: "question",
+        questionId: QUESTION_ID,
+        optionValue: "Unavailable option",
+      },
+    });
+
+    expect(element).toEqual({
+      tag: "markdown",
+      content: "- Unavailable option",
+    });
+  });
+});

--- a/extensions/feishu/src/presentation-card.ts
+++ b/extensions/feishu/src/presentation-card.ts
@@ -33,6 +33,10 @@ type FeishuPresentationTextFormat = "plain" | "markdown";
 const RENDERED_FEISHU_CARD = Symbol("openclaw.renderedFeishuCard");
 const FEISHU_PRESENTATION_FALLBACK_MARKER = "__openclawPresentationFallback";
 
+/** Card action dispatched when an ask_user option button is tapped. */
+export const FEISHU_PAYLOAD_QUESTION_ACTION = "feishu.question.answer";
+const FEISHU_QUESTION_OPTION_MAX_LENGTH = 512;
+
 export const FEISHU_PRESENTATION_CAPABILITIES = {
   supported: true,
   buttons: true,
@@ -195,9 +199,28 @@ function mapFeishuButtonType(style: MessagePresentationButton["style"]) {
   return "default";
 }
 
+function resolveFeishuPayloadQuestionOption(button: MessagePresentationButton):
+  | { questionId: string; optionValue: string }
+  | undefined {
+  const action = button.action;
+  if (action?.type !== "question" || !("optionValue" in action)) {
+    // Plain option buttons carry optionValue; the custom-input (Other) button does not.
+    return undefined;
+  }
+  const { questionId, optionValue } = action;
+  if (!questionId.trim() || !optionValue.trim()) {
+    return undefined;
+  }
+  if (optionValue.length > FEISHU_QUESTION_OPTION_MAX_LENGTH) {
+    return undefined;
+  }
+  return { questionId, optionValue };
+}
+
 function buildFeishuPayloadButton(button: MessagePresentationButton): Record<string, unknown> {
   const url = resolveSafeFeishuButtonUrl(resolveFeishuButtonUrl(button));
-  const value = resolveFeishuCommandButtonValue(button);
+  const question = resolveFeishuPayloadQuestionOption(button);
+  const value = question ? question.optionValue : resolveFeishuCommandButtonValue(button);
   if (button.disabled || (!url && !value)) {
     // Keep each unavailable control visible without exposing rejected URLs or opaque values.
     return { tag: "markdown", content: `- ${escapeFeishuCardPlainText(button.label)}` };
@@ -210,9 +233,10 @@ function buildFeishuPayloadButton(button: MessagePresentationButton): Record<str
     behaviors.push({
       type: "callback",
       value: createFeishuCardInteractionEnvelope({
-        k: "quick",
-        a: "feishu.payload.button",
-        q: value,
+        k: question ? "button" : "quick",
+        a: question ? FEISHU_PAYLOAD_QUESTION_ACTION : "feishu.payload.button",
+        q: question ? question.questionId : value,
+        ...(question ? { m: { o: question.optionValue } } : {}),
       }),
     });
   }


### PR DESCRIPTION
## What Problem This Solves

Feishu/Lark is the only major OpenClaw messaging channel where `ask_user`
questions render as plain text ("reply 1/2/3") instead of tappable buttons.
The core question-action buttons are implemented only for
Telegram/Discord/Slack (and reaction-based fallback for WhatsApp/Signal/
iMessage); Feishu falls into the "degrade to label text" bucket. This change
makes ask_user options on Feishu real, tappable card buttons and closes the
answer loop.

## Evidence

Verified end-to-end on OpenClaw 2026.9.1 with a patched `@openclaw/feishu`:

- **Render**: ask_user single-select options now render as interactive card
  buttons (ocf1 interaction envelope), instead of a `- option` text list.
- **Click → answer**: tapping a button dispatches `card.action.trigger` with
  `feishu.question.answer`; the branch validates sender + option, dedupes
  repeated taps (60s), and resolves through the core question gateway, waking
  the pending `ask_user` immediately.
- **ACK**: after a successful answer the bot adds an `OK` reaction to the
  card message as visible confirmation.

Live logs from the verified run:

handling structured card action feishu.question.answer from ou_...
answering question ask_<id> from ou_...
question.waitAnswer <10ms>   (previously waited out a 100s+ timeout)
question <id> answered via gateway
question ack reaction OK added on message om_...

Unit tests (new): rendering branch + answer/callback branch, including
malformed envelopes, dedupe/TTL, already-terminal, and regression coverage
for existing command buttons.
Tested channel: Feishu DM (self-built app, WebSocket mode), interaction
available after subscribing `card.action.trigger`.
## Related
N/A (no issue filed; community-maintained Feishu plugin).