### PR TITLE
fix(doctor): preserve settings when repairing legacy agent rosters

### DIFF
--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -256,6 +256,8 @@ That stages grounded durable candidates into the short-term dreaming store while
 
     Other commands that encounter legacy keys still ask you to run `openclaw doctor`. Doctor explains the issues, shows its migrations, and rewrites `~/.openclaw/openclaw.json` with the updated schema. Cron job store migrations are also handled by `openclaw doctor --fix`; automatic config-key migration does not import legacy session stores or repair services.
 
+    When a readable active config can be fully migrated, Doctor preserves it before considering last-known-good recovery. This includes legacy multi-agent rosters with a `default: true` owner: unrelated settings and the original agent ownership survive the migration.
+
     Per-agent migrations apply to both keyed `agents.entries` and legacy `agents.list` rosters, including rosters that already set `agents.ownership: "explicit"`. For example, Doctor preserves an agent's legacy `memorySearch` settings under `memory.search` and converts `sandbox.perSession` to `sandbox.scope`. Existing values at the current config paths take precedence.
 
     <Note>

--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -534,6 +534,53 @@ describe("runDoctorConfigPreflight", () => {
     },
   );
 
+  it("preserves a legacy multi-agent owner when repairing active config before recovery", async () => {
+    await withTempHome(async (home) => {
+      const configPath = await writeOpenClawConfig(home, {
+        gateway: { mode: "local", port: 19091 },
+      });
+      await promoteConfigSnapshotToLastKnownGood(await readConfigFileSnapshot());
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          meta: { lastTouchedAt: "2026-08-01T00:00:00.000Z" },
+          gateway: { mode: "local", port: 19092 },
+          update: { channel: "beta" },
+          agents: { list: [{ id: "ops" }, { id: "main", default: true }] },
+        }),
+      );
+
+      const before = await readConfigFileSnapshot();
+      const repaired = await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
+        runDoctorConfigPreflight({
+          migrateState: false,
+          migrateLegacyConfig: false,
+          repairPrefixedConfig: true,
+          invalidConfigNote: false,
+        }),
+      );
+
+      expect(repaired.snapshot.valid).toBe(true);
+      expect(isStartupConfigRepairResult(before, repaired.snapshot)).toBe(true);
+      expect(repaired.snapshot.config.gateway?.port).toBe(19092);
+      expect(repaired.snapshot.config.update?.channel).toBe("beta");
+      expect(Object.keys(repaired.snapshot.config.agents?.entries ?? {}).toSorted()).toEqual([
+        "main",
+        "ops",
+      ]);
+      expect(repaired.snapshot.config.agents?.defaults?.systemAgent?.agentId).toBe("main");
+      expect(repaired.snapshot.config).not.toHaveProperty("meta.lastTouchedAt");
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8"));
+      expect(persisted.agents.ownership).toBe("explicit");
+      expect(persisted.agents).not.toHaveProperty("list");
+      const reread = await readConfigFileSnapshot();
+      expect(reread.valid).toBe(true);
+      expect(reread.config.agents?.defaults?.systemAgent?.agentId).toBe("main");
+      const entries = await fs.readdir(path.dirname(configPath));
+      expect(entries.filter((entry) => entry.startsWith("openclaw.json.clobbered."))).toEqual([]);
+    });
+  });
+
   it("migrates readable active config after preserving its state locators", async () => {
     await withTempHome(async (home) => {
       const storePath = path.join(home, "custom-cron", "jobs.json");

--- a/src/commands/doctor/shared/automatic-startup-config-repair.test.ts
+++ b/src/commands/doctor/shared/automatic-startup-config-repair.test.ts
@@ -170,6 +170,13 @@ describe("automatic startup config repair", () => {
   it.each([
     { name: "a non-legacy type error", config: { gateway: { port: "not-a-number" } } },
     {
+      name: "ambiguous legacy default owners",
+      config: {
+        session: { idleMinutes: 45 },
+        agents: { entries: { main: { default: true }, ops: { default: true } } },
+      },
+    },
+    {
       name: "a migration with a remaining type error",
       config: { session: { idleMinutes: 45 }, gateway: { port: "not-a-number" } },
     },

--- a/src/commands/doctor/shared/automatic-startup-config-repair.ts
+++ b/src/commands/doctor/shared/automatic-startup-config-repair.ts
@@ -6,6 +6,7 @@ import {
 import { resolveConfigSnapshotHash, transformConfigFile } from "../../../config/config.js";
 import { stampConfigWriteMetadata } from "../../../config/io.meta.js";
 import { containsConfigIncludeDirective } from "../../../config/io.read-helpers.js";
+import { prepareConfigWriteTopology } from "../../../config/io.write-topology.js";
 import { findLegacyConfigIssues } from "../../../config/legacy.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../../../config/types.js";
 import {
@@ -133,9 +134,19 @@ export function isStartupConfigRepairResult(
   after: ConfigFileSnapshot,
 ): boolean {
   const plan = planAutomaticConfigRepair(before);
+  const unsetPaths = resolveManagedUnsetPathsForWrite(undefined);
   const expected = plan
     ? stampConfigWriteMetadata(
-        applyUnsetPathsForWrite(plan.config, resolveManagedUnsetPathsForWrite(undefined)),
+        applyUnsetPathsForWrite(
+          prepareConfigWriteTopology({
+            snapshot: before,
+            nextConfig: plan.config,
+            options: { persistCanonicalAgentRoster: true },
+            unsetPaths,
+            env: process.env,
+          }).nextConfig,
+          unsetPaths,
+        ),
         undefined,
         undefined,
         before.parsed,
@@ -167,6 +178,9 @@ export async function commitAutomaticConfigRepair(
       auditOrigin: "doctor",
       skipOutputLogs: true,
       skipRuntimeSnapshotRefresh: true,
+      // The reader retired legacy markers; persist their canonical owners in this write.
+      // Startup verification above uses the same writer topology preparation.
+      persistCanonicalAgentRoster: true,
     },
   });
 }

--- a/src/commands/doctor/shared/legacy-config-compat.ts
+++ b/src/commands/doctor/shared/legacy-config-compat.ts
@@ -1,4 +1,5 @@
 // Top-level legacy config migration runner used before full config validation.
+import { inheritLegacyDefaultAgentId } from "../../../config/legacy.default-agent-owner.js";
 import type { LegacyConfigMigrationContext } from "../../../config/legacy.shared.js";
 import { applyChannelDoctorCompatibilityMigrations } from "./channel-legacy-config-migrate.js";
 import { LEGACY_CONFIG_MIGRATIONS } from "./legacy-config-migrations.js";
@@ -33,5 +34,7 @@ export function applyLegacyDoctorMigrations(
   if (changes.length === 0) {
     return { next: null, changes: [] };
   }
-  return { next: compat.next, changes };
+  // The config reader keeps the retired default-agent marker outside the object.
+  // Cloning must retain that owner so validation does not roll back a repairable roster.
+  return { next: inheritLegacyDefaultAgentId(original, compat.next), changes };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading a legacy multi-agent configuration could lose active settings when Doctor restored an older last-known-good file. Both update-restart-auth lanes in [Full Release Validation](https://github.com/openclaw/openclaw/actions/runs/33936309800) reproduced it: the updater reported success after Doctor restored an earlier service-auth bootstrap snapshot and discarded the authored update channel and other settings.

## Why This Change Was Made

The config reader normalizes the legacy roster and retains its default owner outside the object. The legacy migration cloned the object without carrying that fact forward, causing complete validation to reject the repaired roster. Preserve that ownership metadata through migration, persist the canonical roster through the writer's existing ownership preparation, and use that same preparation when verifying the permitted startup repair. Recovery and strict validation keep their existing responsibilities.

## User Impact

Migratable configurations retain their settings and original agent ownership through automatic Doctor repair. The regression checks the actual persisted canonical roster, retained settings, valid reread, startup verification, and absence of rollback files. Ambiguous default owners remain rejected; existing state-migration coverage remains intact.

## Evidence

- The regression failed on the original code by restoring port `19091` instead of active port `19092`.
- All 77 owner tests passed across Doctor preflight, automatic startup repair, canonical roster migration, and legacy roster validation, including the unchanged state-locator migration test.
- Changed checks passed, including core/test typechecks, lint, storage guards, and zero runtime import cycles.
- Independent Codex review: scoped-clean through P2.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33943383380): 107 successful checks, 16 skipped.
- [Exact-head packaged Testbox replay](https://github.com/openclaw/openclaw/actions/runs/33944474931) passed the original published `2026.7.1-2` → candidate `2026.8.1` base/auto-auth update scenario under frozen harness `2329399cf6a9a2ca0c19d6c620b713a2768f9125`, with unchanged 1500s and subcommand limits. All ten config intents were accepted; none skipped. Automatic config/state assertions passed before later standalone Doctor/fixture checks; no `openclaw update repair` recovery command was required. The original candidate-owned restart sequence passed in 46s, with health/readiness/status probes passing. The lease is stopped.
- Candidate build info identifies `748581a0cfd60a1c6014aed5f7f6f4b62e83b59c`; tarball SHA256 `bc3618bb126375be11b4d7c3f21867a30eb9fb2a7f76bbde791ca3aae1c4e91c`. Packaged proof used synthetic authenticated service fixtures, with no live provider/channel claim.

Production: +19/-2 (net +17); tests: +54/-0; docs: +2/-0. The added production lines carry the existing owner fact and invoke the canonical writer topology when matching startup repair, covering the same ownership decisions as the actual write. No new configuration option, schema, recovery branch, or compatibility reader is introduced.
