### PR TITLE
fix(models): keep active plugins during provider sign-in

### DIFF
--- a/src/commands/models/auth.registry.test.ts
+++ b/src/commands/models/auth.registry.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createWizardPrompter } from "../../../test/helpers/wizard-prompter.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import {
+  isPluginRegistryRetired,
+  pluginLoaderCacheState,
+} from "../../plugins/registry-lifecycle.js";
+import {
+  clearActivePluginRegistry,
+  getActivePluginRegistry,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
+import { createSyncSuiteTempRootTracker } from "../../plugins/test-helpers/fs-fixtures.js";
+import { runModelsAuthLoginFlowCore } from "./auth.js";
+
+const tempDirs = createSyncSuiteTempRootTracker("models-auth-registry");
+
+afterEach(async () => {
+  await clearActivePluginRegistry();
+  pluginLoaderCacheState.clear();
+  clearPluginMetadataLifecycleCaches();
+  vi.unstubAllEnvs();
+  tempDirs.cleanup();
+});
+
+it("keeps the active plugin registry when provider sign-in is declined", async () => {
+  const root = fs.realpathSync(tempDirs.makeTempDir());
+  const pluginDir = path.join(root, "provider");
+  fs.mkdirSync(pluginDir);
+  fs.writeFileSync(
+    path.join(pluginDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: "auth-registry-fixture",
+      providers: ["fixture-provider"],
+      configSchema: { type: "object" },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, "index.cjs"),
+    `module.exports = {
+      id: "auth-registry-fixture",
+      register(api) {
+        api.registerProvider({
+          id: "fixture-provider",
+          label: "Fixture provider",
+          auth: [{
+            id: "synthetic", label: "Synthetic", kind: "custom",
+            async run() { throw new Error("Auth must not start after sign-in is declined"); }
+          }]
+        });
+      }
+    };`,
+  );
+  vi.stubEnv("OPENCLAW_STATE_DIR", root);
+  vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(root, "openclaw.json"));
+  vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+  const registry = createEmptyPluginRegistry();
+  setActivePluginRegistry(registry);
+  const declined = new Error("Sign-in declined");
+  const prompter = createWizardPrompter({
+    note: vi.fn(async () => {
+      throw declined;
+    }),
+  });
+
+  await expect(
+    runModelsAuthLoginFlowCore({
+      provider: "fixture-provider",
+      method: "synthetic",
+      agent: "main",
+      config: {
+        agents: { entries: { main: { workspace: root } } },
+        plugins: {
+          allow: ["auth-registry-fixture"],
+          load: { paths: [pluginDir] },
+        },
+      },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      prompter,
+    }),
+  ).rejects.toBe(declined);
+  expect(prompter.note).toHaveBeenCalledOnce();
+  expect(getActivePluginRegistry() === registry).toBe(true);
+  expect(isPluginRegistryRetired(registry)).toBe(false);
+});

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -14,7 +14,6 @@ type AuthRunCall = {
 };
 
 type ResolvePluginProvidersCall = {
-  activate?: boolean;
   config?: unknown;
   includeUntrustedWorkspacePlugins?: boolean;
   providerRefs?: string[];
@@ -955,8 +954,8 @@ describe("modelsAuthLoginCommand", () => {
       },
     });
     mocks.resolvePluginProvidersCore.mockImplementation(
-      (params: { activate?: boolean; providerRefs?: string[] } | undefined) =>
-        params?.activate === true && params?.providerRefs?.[0] === "anthropic"
+      (params: ResolvePluginProvidersCall | undefined) =>
+        params?.providerRefs?.[0] === "anthropic"
           ? [
               {
                 id: "anthropic",
@@ -986,7 +985,6 @@ describe("modelsAuthLoginCommand", () => {
     expect(providerResolutionCall.workspaceDir).toBe("/tmp/openclaw/workspace");
     expect(providerResolutionCall.includeUntrustedWorkspacePlugins).toBe(false);
     expect(providerResolutionCall.providerRefs).toEqual(["anthropic"]);
-    expect(providerResolutionCall.activate).toBe(true);
     expect(runClaudeCliMigration).toHaveBeenCalledOnce();
     expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
     expect(lastUpdatedConfig?.agents?.defaults?.model).toEqual({
@@ -1389,7 +1387,7 @@ describe("modelsAuthLoginCommand", () => {
     expect(runProviderAuth).toHaveBeenCalledOnce();
     expect(mocks.resolvePluginProvidersCore).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ providerRefs: ["claude-cli"], activate: true }),
+      expect.objectContaining({ providerRefs: ["claude-cli"] }),
     );
     expect(mocks.resolvePluginProvidersCore).toHaveBeenNthCalledWith(
       2,

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -270,17 +270,13 @@ async function resolveModelsAuthContext(params?: {
   const providerRef = requestedProvider
     ? normalizeManualAuthProvider(requestedProvider)
     : undefined;
+  // Auth setup also runs inside the Gateway; discovery must not replace its live registry.
   const providers = resolvePluginProvidersCore({
     config,
     workspaceDir,
     mode: "setup",
     includeUntrustedWorkspacePlugins: false,
-    ...(providerRef
-      ? {
-          providerRefs: [providerRef],
-          activate: true,
-        }
-      : {}),
+    ...(providerRef ? { providerRefs: [providerRef] } : {}),
   });
   const authProviders = preferSetupAuthProviders({
     providers,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where starting provider sign-in inside a running Gateway could retire its plugins and close their stores before authentication began. Existing Workboard requests could then fail with “workboard store is closed,” and an admitted service reload could resume on a retired registry.

## Why This Change Was Made

Auth setup now uses the provider resolver's existing local discovery behavior. Explicit provider ownership, workspace trust checks, lightweight setup providers and full runtime auth fallback remain intact. This removes accidental global publication at the auth owner without changing service shutdown, configuration, schemas, stored credentials or login cancellation.

## User Impact

Operators can begin or cancel provider sign-in while existing plugins continue serving requests. Clean-config OpenAI, Anthropic and Claude CLI discovery still finds the same auth methods.

## Evidence

- A regression using the actual plugin loader fails before the fix and passes afterward: declining sign-in preserves the active registry and leaves it unretired.
- A native before/after probe holds a real service reload across OpenAI auth setup. Before: the old registry retires, the service restarts on that retired owner, and Workboard read/write requests fail. After: the registry remains active, reload resumes normally, public Workboard requests succeed and a reopened SQLite store retains the write. Auth stops at its first note; no provider network request occurs.
- Native clean-config discovery reaches sign-in for OpenAI, Anthropic and `claude-cli`. A synthetic provider completes the real auth persistence flow, while a cancelled return leaves stored credentials unchanged. A fresh process verifies the successful profile and all three Workboard writes. The optional Gateway auth refresh contacts only a task-owned loopback refusal server.
- 123 focused tests across auth, provider ownership/trust, setup descriptors and service reload pass. The full changed-code gate passes, including core and test types, lint, dead exports, schema guard and runtime import cycles.

Production delta: +2/-6 (net -4). Tests: +91/-5 (net +86), including one real-loader regression. No schema, representation, migration, retention or concurrency changes. These are credential-free native runtime proofs, not completed real-provider authentication or live Telegram transport tests.

Fresh independent Codex review of the complete owner, caller, dependency and native evidence passed all ten parts with no actionable P0–P2 findings. The repair also resolves the provider-auth follow-up recorded in #138810.
