### PR TITLE
fix: show real Claude session titles when metadata precedes the prompt

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeClaudeSessionCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeClaudeSessionCatalog.swift
@@ -818,6 +818,7 @@ extension MacNodeClaudeSessionCatalog {
         }
         guard self.isCLIEntrypoint(row["entrypoint"]),
               row["type"] as? String == "user",
+              row["isMeta"] as? Bool != true,
               let message = row["message"] as? [String: Any],
               message["role"] as? String == "user",
               let content = message["content"]

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeClaudeSessionCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeClaudeSessionCatalogTests.swift
@@ -254,8 +254,11 @@ struct MacNodeClaudeSessionCatalogTests {
             (cliId, "Interactive CLI prompt", "cli", "/work/cli", "2.1.216"),
             (sdkCLIId, "Headless CLI prompt", "sdk-cli", "/work/sdk", "2.1.204"),
         ] {
+            var meta = fixture.message(
+                id, "<local-command-caveat>CLI metadata</local-command-caveat>", entrypoint: entrypoint)
+            meta["isMeta"] = true
             try fixture.writeTranscript(
-                [fixture.message(
+                [meta, fixture.message(
                     id,
                     text,
                     entrypoint: entrypoint,

--- a/extensions/anthropic/session-catalog-discovery.ts
+++ b/extensions/anthropic/session-catalog-discovery.ts
@@ -350,6 +350,7 @@ async function discoverCliRecords(
         if (
           !isCliEntrypoint(raw.entrypoint) ||
           raw.type !== "user" ||
+          raw.isMeta === true ||
           !isRecord(raw.message) ||
           raw.message.role !== "user"
         ) {

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -1684,6 +1684,16 @@ describe("Claude session catalog", () => {
         "unindexed-session": [message("unindexed-session", "user", "unindexed", 1)],
         "cli-session": [
           {
+            ...message(
+              "cli-session",
+              "user",
+              "<local-command-caveat>CLI metadata</local-command-caveat>",
+              1,
+            ),
+            entrypoint: "cli",
+            isMeta: true,
+          },
+          {
             ...message("cli-session", "user", "Interactive CLI prompt", 1),
             entrypoint: "cli",
             cwd: "/work/cli",


### PR DESCRIPTION
Closes #138843 — Claude catalog titles select internal metadata.

## What Problem This Solves

Fixes an issue where users browsing Claude CLI sessions would see internal CLI metadata as the session title when a metadata row preceded the first real user prompt.

## Why This Change Was Made

Both the gateway and native Mac catalog now honor Claude's `isMeta` marker before selecting the first prompt. This extends the native metadata boundary already used by imported history (#130269), without matching particular instruction text or changing transcript files.

## User Impact

Fallback-discovered sessions show the real first prompt and retain its working-directory and CLI metadata. Existing explicit titles and session eligibility rules keep their current behavior.

## Evidence

- Frozen main `58d8871d`: extended TypeScript and Swift fallback regressions each fail because the title is the preceding metadata message.
- Fixed: all 72 TypeScript catalog tests and all 9 native Mac catalog tests pass.
- Fresh independent autoreview: no actionable P0/P1 findings.
- Full `pnpm build` passed, including plugin runtime loads and Control UI assets.
- Production catalog API proof with a temporary synthetic transcript returned `Interactive CLI prompt` after the metadata row.
- Complete four-path `node scripts/check-changed.mjs -- <changed paths>` passed, including extension production/test typechecks, lint, macOS tooling tests, storage guards, and import-cycle checks. Pinned SwiftLint passed; scoped SwiftFormat with `config/swiftformat` reports 0 files needing formatting.
- [Sanitized real Control UI before/after screenshots](https://github.com/openclaw/openclaw/issues/138843#issuecomment-5549254301): release 2026.9.1 displays `CLI metadata`; the current-main repair displays `Interactive CLI prompt` for the same synthetic transcript.
- Production delta: +2 lines, one native-marker predicate in each existing reader; no new abstraction, configuration, or dependency.

Named follow-ups: native Mac catalog support for later custom-title metadata, and omission of `isMeta` rows from native transcript read pages, remain separate from this first-prompt selection repair.

AI-assisted: built with Codex.
