### PR TITLE
fix: resume failed Codex sessions without false runner conflicts

### DIFF
--- a/extensions/codex/src/app-server/event-projector.terminal-errors.test.ts
+++ b/extensions/codex/src/app-server/event-projector.terminal-errors.test.ts
@@ -533,3 +533,31 @@ describe("CodexAppServerEventProjector terminal errors", () => {
     expect(readAttemptTerminal(result).promptErrorSource).toBe("prompt");
   });
 });
+
+it.each(["misalignmentPolicyViolation"])(
+  "preserves %s as terminal on both error and completed notifications",
+  async (codexErrorInfo) => {
+    const projector = await createProjector();
+    const message = "Provider rejected this request";
+    await projector.handleNotification(
+      appServerError({ message, willRetry: false, codexErrorInfo }),
+    );
+    expect(
+      readAttemptTerminal(projector.buildResult(buildEmptyToolTelemetry())).promptError,
+    ).toMatchObject({
+      name: "AgentHarnessTerminalError",
+      message,
+    });
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: { id: TURN_ID, status: "failed", items: [], error: { message, codexErrorInfo } },
+      }),
+    );
+    expect(
+      readAttemptTerminal(projector.buildResult(buildEmptyToolTelemetry())).promptError,
+    ).toMatchObject({
+      name: "AgentHarnessTerminalError",
+      message,
+    });
+  },
+);

--- a/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
@@ -225,7 +225,10 @@ async function preparePendingCodexThreadResume(
   );
   assertCurrent();
   const statusType = thread.status?.type;
-  if (thread.id !== binding.threadId || (statusType !== "idle" && statusType !== "notLoaded")) {
+  if (
+    thread.id !== binding.threadId ||
+    (statusType !== "idle" && statusType !== "notLoaded" && statusType !== "systemError")
+  ) {
     throw fail("the native thread is not idle; wait for its current run to finish");
   }
   assertCodexThreadAcceptsDirectInput(thread);
@@ -303,7 +306,13 @@ function observeCodexThreadConfiguration(
   thread: CodexThread,
   assertCurrent: () => void,
 ) {
-  if (thread.status?.type !== "idle" && thread.status?.type !== "notLoaded") {
+  // Codex keeps systemError after a failed turn completes; it is loaded but not running.
+  // It still requires the same observed teardown before resume can change configuration.
+  if (
+    thread.status?.type !== "idle" &&
+    thread.status?.type !== "notLoaded" &&
+    thread.status?.type !== "systemError"
+  ) {
     throw new CodexAdoptedThreadActiveError();
   }
   let unloaded = thread.status.type === "notLoaded";

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -326,6 +326,7 @@ function createTwoCalendarAppPolicyContext() {
 async function createManualResumeFixture(
   options: {
     active?: boolean;
+    systemError?: boolean;
     cold?: boolean;
     receipt?: "none" | "stale" | "unrelated" | "malformed";
     dynamicTools?: CodexDynamicToolFunctionSpec[];
@@ -390,7 +391,7 @@ async function createManualResumeFixture(
             : {}),
           status: options.active
             ? { type: "active", activeFlags: [] }
-            : { type: options.cold ? "notLoaded" : "idle" },
+            : { type: options.cold ? "notLoaded" : options.systemError ? "systemError" : "idle" },
         },
       };
     }
@@ -1002,9 +1003,16 @@ describe("Codex app-server thread lifecycle bindings", () => {
     },
   );
 
-  it.each(["initial policy", "replacement policy", ""])(
-    "keeps ordinary warm configuration honest across policy %j",
-    async (developerInstructions) => {
+  it.each(
+    ["idle", "systemError"].flatMap((nativeStatus) =>
+      ["initial policy", "replacement policy", ""].map((developerInstructions) => ({
+        nativeStatus,
+        developerInstructions,
+      })),
+    ),
+  )(
+    "keeps ordinary warm configuration honest across $nativeStatus and policy $developerInstructions",
+    async ({ nativeStatus, developerInstructions }) => {
       const sessionFile = path.join(tempDir, "ordinary-warm-policy.jsonl");
       const workspaceDir = path.join(tempDir, "workspace");
       const threadId = "ordinary-warm-policy";
@@ -1022,7 +1030,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
           return response;
         }
         if (request.method === "thread/read") {
-          return { thread: response.thread };
+          return { thread: { ...response.thread, status: { type: nativeStatus } } };
         }
         if (request.method === "thread/unsubscribe") {
           wire.send({
@@ -1719,6 +1727,10 @@ describe("Codex app-server thread lifecycle bindings", () => {
     {
       label: "loaded native thread",
       options: { dynamicTools: [createNamedDynamicTool("example")] },
+    },
+    {
+      label: "native thread after a completed failed turn",
+      options: { systemError: true, wireClient: true },
     },
     {
       label: "cold native thread with no stored tools",

--- a/extensions/codex/src/app-server/usage-limit-error.ts
+++ b/extensions/codex/src/app-server/usage-limit-error.ts
@@ -3,6 +3,7 @@
  * marks blocked auth profiles when Codex exposes a reset time.
  */
 import {
+  AgentHarnessTerminalError,
   embeddedAgentLog,
   formatErrorMessage,
   type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
@@ -45,6 +46,9 @@ export class CodexUsageLimitPromptError extends Error {
 export function resolveCodexPromptError(
   source: Pick<CodexUsageLimitErrorSource, "message" | "codexErrorInfo" | "rateLimits">,
 ): string | Error | undefined {
+  if (source.codexErrorInfo === "misalignmentPolicyViolation") {
+    return new AgentHarnessTerminalError(source.message ?? "Codex rejected this request.");
+  }
   const usageLimitMessage = formatCodexUsageLimitErrorMessage(source);
   if (usageLimitMessage) {
     return new CodexUsageLimitPromptError(usageLimitMessage);

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -353,7 +353,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: canonical paragraph grouping and UTF-16 boundaries for channel-owned chunking.
       // +1: retained runtime config reader preserves channel owner and scoped config identity.
       // +1: shared session-catalog host publication with completion ownership.
-      4435,
+      // +1: terminal harness error preserves native no-replay decisions across fallback.
+      4436,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AssistantMessage } from "../../../llm/types.js";
+import { AgentHarnessTerminalError } from "../../harness/errors.js";
 import {
   buildEmbeddedRunnerAssistant,
   createMockUsage,
@@ -449,4 +450,15 @@ describe("recoverEmbeddedRunAttempt", () => {
     expect(failoverRetryController.advanceRateLimitAuthProfile).not.toHaveBeenCalled();
     expect(failoverRetryController.maybeMarkAuthProfileFailure).not.toHaveBeenCalled();
   });
+});
+
+it("surfaces a terminal harness refusal before transport or prompt recovery", async () => {
+  const error = new AgentHarnessTerminalError("rate limit exceeded", {
+    cause: new Error("WebSocket error"),
+  });
+  await expect(
+    recoverAfterTransportDrop({
+      terminal: { kind: "failed", source: "prompt", error },
+    }),
+  ).rejects.toBe(error);
 });

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -4,6 +4,7 @@ import { isRetryableAssistantError } from "../../../llm/utils/retry.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../defaults.js";
 import type { FailoverReason } from "../../embedded-agent-helpers.js";
+import { hasModelFallbackStop } from "../../failover-error.js";
 import { LiveSessionModelSwitchError } from "../../live-model-switch-error.js";
 import { shouldSwitchToLiveModel, clearLiveModelSwitchPending } from "../../live-model-switch.js";
 import { hasOnlyAssistantReasoningContent } from "../../replay-turn-classification.js";
@@ -134,6 +135,10 @@ export async function recoverEmbeddedRunAttempt(input: {
     timedOutDuringToolExecution,
     timedOutByRunBudget,
   } = projectAgentRunAttemptTerminal(attempt.terminal);
+  // Provider policy refusals end this admitted request before any recovery can replay it.
+  if (hasModelFallbackStop(promptError)) {
+    throw toErrorObject(promptError, "Harness request failed");
+  }
   const terminalInterrupted = isEmbeddedRunTerminalInterrupted(terminalState.outcome);
   const currentAttemptReplaySafe = isCurrentAttemptReplaySafe(attempt);
   // Mid-turn overflow continues from the persisted tool results and never

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -66,6 +66,7 @@ export function recordModelFallbackStop(error: Error): void {
 export function hasModelFallbackStop(error: unknown): boolean {
   return collectErrorGraphCandidates(error, resolveNestedErrors).some(
     (candidate) =>
+      readErrorName(candidate) === "AgentHarnessTerminalError" ||
       (candidate instanceof Error && modelFallbackStops.has(candidate)) ||
       (isFailoverError(candidate) && isCliTerminalStopCode(candidate.code)),
   );

--- a/src/agents/harness/errors.ts
+++ b/src/agents/harness/errors.ts
@@ -58,3 +58,11 @@ export function resolveAgentHarnessPreflightOwner(error: unknown): string | unde
 export function isAgentHarnessPreflightError(err: unknown): err is AgentHarnessPreflightError {
   return err instanceof AgentHarnessPreflightError;
 }
+
+/** A completed harness failure that must not replay through another profile or model. */
+export class AgentHarnessTerminalError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "AgentHarnessTerminalError";
+  }
+}

--- a/src/agents/model-fallback.terminal-boundary.test.ts
+++ b/src/agents/model-fallback.terminal-boundary.test.ts
@@ -8,7 +8,11 @@ import {
   recordModelFallbackStop,
   resolveModelFallbackError,
 } from "./failover-error.js";
-import { AgentHarnessPreflightError, recordAgentHarnessPreflightOwner } from "./harness/errors.js";
+import {
+  AgentHarnessPreflightError,
+  AgentHarnessTerminalError,
+  recordAgentHarnessPreflightOwner,
+} from "./harness/errors.js";
 import {
   type ModelFallbackStepHandler,
   runFallbackAttempt,
@@ -358,3 +362,26 @@ describe.each([
     expect(find({ cause: null, errors: [null, { error: third }] })).toBe(third);
   });
 });
+
+const terminalWrappers = [
+  (error: Error): unknown => error,
+  (error: Error): unknown => new Error("wrapper", { cause: error }),
+  (error: Error): unknown => new AggregateError([{ error }], "wrapper"),
+  (error: Error): unknown => ({ name: error.name, message: error.message }),
+];
+
+it.each(terminalWrappers)(
+  "does not retry a terminal provider refusal and permits a separate turn",
+  async (wrap) => {
+    const error = wrap(new AgentHarnessTerminalError("Provider rejected this request"));
+    const run = vi.fn().mockRejectedValueOnce(error).mockResolvedValue("next turn succeeded");
+    await expect(runWithModelFallback({ ...fallbackOptions, run })).rejects.toBe(error);
+    expect(run).toHaveBeenCalledOnce();
+    expect(providerHook).not.toHaveBeenCalled();
+    await expect(runWithModelFallback({ ...fallbackOptions, run })).resolves.toMatchObject({
+      result: "next turn succeeded",
+      model: fallbackOptions.model,
+    });
+    expect(run).toHaveBeenCalledTimes(2);
+  },
+);

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -110,6 +110,7 @@ export type {
 } from "../agents/harness/types.js";
 export {
   AgentHarnessPreflightError,
+  AgentHarnessTerminalError,
   AgentHarnessSessionSupersededError,
 } from "../agents/harness/errors.js";
 export { projectSettledTurnFinalizationAttemptResult } from "../agents/harness/settled-turn-finalization-result.js";


### PR DESCRIPTION
Closes #138835 — completed failed Codex turns are misreported as active in another runner.

## What Problem This Solves

Fixes an issue where users resuming a completed failed Codex session would see “Codex session became active in another runner.” A native terminal misalignment error could also lose its type and enter recovery or model fallback, replacing the original failure with this misleading runner error.

## Why This Change Was Made

Treat native `systemError` as non-running during ordinary and manual adoption, preserving ownership, generation, teardown, active-turn and direct-input checks. Carry `misalignmentPolicyViolation` through the shared harness error boundary and existing fallback-stop classifier, ending that request before recovery or fallback can replay it. Current structured `cyberPolicy` refusals keep their existing path. No native confirmation override is added.

## User Impact

A completed failed thread no longer produces a false concurrency error when a later native-eligible request resumes it. Terminal provider decisions retain their original message and stop the current request.

## Evidence

- Failed-first on frozen upstream main `58d8871d`: 3 lifecycle cases, 1 projector case, 4 fallback-wrapper cases and 1 recovery case reproduce the defects.
- Fixed focused suites: 200 lifecycle, 29 terminal projection, 44 fallback-boundary and 17 attempt-recovery tests pass (290 total). Existing active-thread and structured refusal cases remain covered.
- Separate benign, credential-free native Codex probe confirms that a completed HTTP 401 turn reports `systemError`; upstream native source explicitly clears the running flag in that state. Source links and sanitized trace are in the linked issue.
- Fresh independent P0/P1 review: scoped-clean. Complete `pnpm check:changed` and final `pnpm build` passed.
- Live proof limitation: the original policy failure cannot be responsibly regenerated by replaying the blocked request; no native override or fake Control UI error was used. A locally installed release-based repair completed a separate benign conversation through an isolated development Control UI and the native app. No recording of the exact failed-to-recovered flow is attached; deterministic boundary tests and the native probe provide that evidence.

AI-assisted: built with Codex.
