### PR TITLE
fix(codex): avoid long-history stalls and hidden prompt warnings

### DIFF
--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -277,6 +277,35 @@ describe("projectContextEngineAssemblyForCodex", () => {
     expect(result.promptText.length).toBeLessThan(25_000);
   });
 
+  it.each([
+    [40, "[truncated 369 chars from older context]"],
+    [70, "[truncated 340 chars from older context]\nl [＠pkg](plugin://pkg) suffix"],
+    [77, "[truncated 333 chars from older context]\n＄skill [＠pkg](plugin://pkg) suffix"],
+    [78, "[truncated 332 chars from older context]\n😀 ＄skill [＠pkg](plugin://pkg) suffix"],
+  ])(
+    "preserves the exact history suffix and omission count at a %i-char budget",
+    (cap, expected) => {
+      const messages = [
+        textMessage("assistant", "older $ignored ".repeat(20)),
+        textMessage("user", " "),
+        textMessage("assistant", "prefix 😀 $skill [@pkg](plugin://pkg) suffix"),
+        textMessage("user", "current"),
+      ];
+      const result = projectContextEngineAssemblyForCodex({
+        assembledMessages: messages,
+        originalHistoryMessages: messages,
+        prompt: "current",
+        maxRenderedContextChars: cap,
+      });
+
+      expect(
+        result.promptText.slice(result.promptContextRange?.start, result.promptContextRange?.end),
+      ).toBe(expected);
+      expect(result.assembledMessages).toBe(messages);
+      expect(result.prePromptMessageCount).toBe(messages.length);
+    },
+  );
+
   it("can scale the rendered context cap for larger Codex context windows", () => {
     const result = projectContextEngineAssemblyForCodex({
       assembledMessages: Array.from({ length: 12 }, (_, index) =>

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -364,7 +364,8 @@ function renderMessagesForCodexContext(
       retainedChars += retained.length;
     }
   }
-  return truncateOlderContext(tail.reverse().join(""), options.maxRenderedContextChars, totalChars);
+  const retainedContext = tail.toReversed().join("");
+  return truncateOlderContext(retainedContext, options.maxRenderedContextChars, totalChars);
 }
 
 function renderMessageBody(

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -61,15 +61,11 @@ export function projectContextEngineAssemblyForCodex(params: {
   const prompt = params.prompt.trim();
   const contextMessages = dropDuplicateTrailingPrompt(params.assembledMessages, prompt);
   const maxRenderedContextChars = normalizeRenderedContextMaxChars(params.maxRenderedContextChars);
-  const renderedContext = neutralizeCodexExplicitMentionSigils(
-    renderMessagesForCodexContext(contextMessages, {
-      maxTextPartChars: resolveTextPartMaxChars(maxRenderedContextChars),
-      toolPayloadMode: params.toolPayloadMode ?? "elide",
-    }),
-  );
-  const boundedContext = renderedContext
-    ? truncateOlderContext(renderedContext, maxRenderedContextChars)
-    : undefined;
+  const boundedContext = renderMessagesForCodexContext(contextMessages, {
+    maxTextPartChars: resolveTextPartMaxChars(maxRenderedContextChars),
+    toolPayloadMode: params.toolPayloadMode ?? "elide",
+    maxRenderedContextChars,
+  });
   const promptPrefix = boundedContext
     ? [CONTEXT_HEADER, CONTEXT_SAFETY_NOTE, "", CONTEXT_OPEN].join("\n") + "\n"
     : undefined;
@@ -341,15 +337,34 @@ function dropDuplicateTrailingPrompt(messages: AgentMessage[], prompt: string): 
 
 function renderMessagesForCodexContext(
   messages: AgentMessage[],
-  options: { maxTextPartChars: number; toolPayloadMode: "elide" | "preserve" },
+  options: {
+    maxTextPartChars: number;
+    toolPayloadMode: "elide" | "preserve";
+    maxRenderedContextChars: number;
+  },
 ): string {
-  return messages
-    .map((message) => {
-      const text = renderMessageBody(message, options);
-      return text ? `[${message.role}]\n${text}` : undefined;
-    })
-    .filter((value): value is string => Boolean(value))
-    .join("\n\n");
+  const tail: string[] = [];
+  let totalChars = 0;
+  let retainedChars = 0;
+  // Count the discarded prefix for the existing marker, but never materialize the
+  // whole history. Sigil neutralization preserves UTF-16 length and cannot span separators.
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    const text = renderMessageBody(message, options);
+    if (!text) {
+      continue;
+    }
+    const chunk = `[${message.role}]\n${text}${totalChars > 0 ? "\n\n" : ""}`;
+    totalChars += chunk.length;
+    const remaining = options.maxRenderedContextChars - retainedChars;
+    if (remaining > 0) {
+      // The final truncation below owns the surrogate-safe boundary after adding its marker.
+      const retained = neutralizeCodexExplicitMentionSigils(chunk).slice(-remaining);
+      tail.push(retained);
+      retainedChars += retained.length;
+    }
+  }
+  return truncateOlderContext(tail.reverse().join(""), options.maxRenderedContextChars, totalChars);
 }
 
 function renderMessageBody(
@@ -578,8 +593,8 @@ function truncateText(text: string, maxChars: number): string {
   return `${truncated}\n[truncated ${text.length - truncated.length} chars]`;
 }
 
-function truncateOlderContext(text: string, maxChars: number): string {
-  if (text.length <= maxChars) {
+function truncateOlderContext(text: string, maxChars: number, totalChars = text.length): string {
+  if (totalChars <= maxChars) {
     return text;
   }
   if (maxChars <= 0) {
@@ -588,9 +603,9 @@ function truncateOlderContext(text: string, maxChars: number): string {
 
   const buildMarker = (omittedChars: number): string =>
     `[truncated ${omittedChars} chars from older context]\n`;
-  let marker = buildMarker(text.length - maxChars);
+  let marker = buildMarker(totalChars - maxChars);
   let tailChars = Math.max(0, maxChars - marker.length);
-  marker = buildMarker(text.length - tailChars);
+  marker = buildMarker(totalChars - tailChars);
   if (marker.length >= maxChars) {
     return marker.slice(0, maxChars);
   }

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -349,7 +349,7 @@ function renderMessagesForCodexContext(
   // Count the discarded prefix for the existing marker, but never materialize the
   // whole history. Sigil neutralization preserves UTF-16 length and cannot span separators.
   for (let index = messages.length - 1; index >= 0; index--) {
-    const message = messages[index];
+    const message = messages[index]!;
     const text = renderMessageBody(message, options);
     if (!text) {
       continue;

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -267,7 +267,10 @@ export async function mirrorPromptAtTurnStartBestEffort(params: {
           params.upstreamUserText,
         ),
       });
-      if (params.params.userTurnTranscriptRecorder?.getAdmissionReceipt()) {
+      const recorder = params.params.userTurnTranscriptRecorder;
+      // Hidden admissions intentionally have no annotation authority. Use the host's
+      // persisted row, since hooks can change visibility after prompt preparation.
+      if (recorder?.getAdmissionReceipt() && recorder.getPersistedMessage?.()?.display !== false) {
         const annotate = params.params.hostCapabilities.annotateCurrentUserTurn;
         if (!annotate || userPromptMessage.role !== "user") {
           throw new Error("current host admission is unavailable for native prompt annotation");

--- a/test/canonical-descendant.integration.test.ts
+++ b/test/canonical-descendant.integration.test.ts
@@ -18,6 +18,7 @@ import {
   setRuntimeAuthProfileStoreSnapshot,
   clearRuntimeAuthProfileStoreSnapshots,
 } from "../src/agents/auth-profiles/runtime-snapshots.js";
+import { log as embeddedAgentLog } from "../src/agents/embedded-agent-runner/logger.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../src/agents/harness/hook-helpers.js";
 import { createAgentHarnessHostCapabilities } from "../src/agents/harness/host-capability.js";
 import { listRegisteredAgentHarnesses } from "../src/agents/harness/registry.js";
@@ -115,6 +116,7 @@ async function withFixture(
     codexPlugins?: Parameters<typeof createCanonicalForkFixtureForTest>[0]["codexPlugins"];
     desktopGenerationFingerprint?: string;
     senderIsOwner?: boolean;
+    transcript?: { display?: false; excludeFromContext?: true };
     mcpResolver?: OpenClawPluginMcpServerConnectionResolver;
   } = {},
 ) {
@@ -165,6 +167,7 @@ async function withFixture(
         const target = { agentId: "main", sessionId, sessionKey, storePath };
         const recorder = createUserTurnTranscriptRecorder({
           input: {
+            ...options.transcript,
             text: prompt,
             timestamp: 123,
             idempotencyKey: buildRunUserTurnIdempotencyKey(runId),
@@ -786,6 +789,33 @@ describe("canonical descendant lifecycle through real owners", () => {
       );
       expect(await loadTranscriptEvents(target)).toEqual(before);
     });
+  }, 180_000);
+
+  it("preserves hidden admitted consult prompts without requesting visible-row annotation", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    await withFixture(
+      async (fixture, _fork, _revoke, admissions) => {
+        const source = await fixture.adopt();
+        await fixture.turn(source.sessionKey, "Hidden voice consultation");
+        const { recorder, before } = admissions.at(-1)!;
+        expect(recorder.getAdmissionReceipt()).toBeDefined();
+        expect(recorder.getPersistedMessage?.()).toMatchObject({
+          display: false,
+          excludeFromContext: true,
+        });
+        const target = {
+          ...fixture.identity(source.sessionKey),
+          sessionKey: source.sessionKey,
+          storePath: fixture.storePath,
+        };
+        expect(await loadTranscriptEvents(target)).toEqual(before);
+        expect(warn).not.toHaveBeenCalledWith(
+          "failed to mirror codex app-server prompt at turn start",
+          expect.anything(),
+        );
+      },
+      { transcript: { display: false, excludeFromContext: true } },
+    );
   }, 180_000);
 
   it("annotates the pre-admitted Gateway user without replacing its event or read fence", async () => {


### PR DESCRIPTION
Related: #138485 (Codex context hydration performance).

## What Problem This Solves

Long Codex-backed sessions can stall the Gateway while preparing a bounded prompt: the renderer builds and rewrites the entire selected history before discarding its older prefix. A synthetic 16,966-message history produced over 800 MB of immediate heap growth for a final prompt of only 24,205 characters.

Internal hidden voice consultations can also report a prompt-mirroring failure after their input was admitted successfully. The host intentionally does not grant visible-row annotation authority for a hidden archived prompt.

## Why This Change Was Made

The Codex renderer retains only the required suffix while counting the complete rendered length for the existing truncation marker. It preserves exact prompt bytes, historical mention neutralization, Unicode boundaries, redacted tool payloads, original message ownership, and output ranges. No new cache, worker, option, or storage path is introduced.

The adjacent prompt-mirroring repair uses the recorder's persisted visibility fact before requesting visible-row annotation. Visible admissions retain their existing checks and annotation flow; the core authority binder remains unchanged.

## User Impact

Preparing a Codex continuation from a long history avoids allocating the discarded history as one large string. Hidden internal consultations retain their existing archival behavior without the spurious annotation warning. Prompt content, retained history, and visible-user admission behavior stay the same.

## Evidence

- 60 unique focused tests passed: 48 projection cases, 7 hidden-admission/visible-authority/warning cases, and 5 shared doctor-contract cases (the doctor cases also passed independently in the other lane).
- 27,600 deterministic comparisons against the original renderer preserved output exactly, covering tiny and large budgets, empty messages, summaries, UTF-16 boundaries, historical mentions, multipart content, preserved/elided tools, nested redaction, and circular tool payloads.
- Standalone Node 26.8.1 synthetic resource regression: the original renderer exhausted a 128 MiB heap; the repaired renderer completed with the same 24,205-character prompt and SHA-256 `e62671a882a4294abf1ebab0b7fb3613c94173c2593fee1b8998334af1e8f521`. Core dumps were disabled. Both sides used the same dependency closure.
- Hidden admission reproduction failed before the fix with the observed annotation warning; it passed afterward with unchanged archived transcript rows. Visible admission/fork and authority siblings passed.
- Fresh independent Codex reviews: no actionable findings through P2 for both repairs and the compiler-only bounded-index correction.
- Local changed checks passed the first 15 gates, including formatting and plugin boundaries. Typechecking and typed lint preparation were blocked before analysis because the declaration owner rejects the checkout's shared dependency symlink. Required PR CI must verify these using its private dependency install. The local synthetic dependency closure used `@openclaw/fs-safe` 0.7.0; installed-runtime proof is tracked separately.

The final candidate was tested in a separate paired synthetic benchmark on the live Linux host used its installed `@openclaw/fs-safe` 0.7.2 and a verified 21-package dependency closure. Projection time fell from 1,515 ms to 31 ms, 10 ms timer lateness from 1,505 ms to 21 ms, and immediate heap growth from 840.5 MB to 5.9 MB, with identical prompt bytes. The 128 MiB heap regression again distinguished baseline exhaustion from successful candidate completion. These are isolated diagnostic-child measurements, not Gateway timer measurements or proof that the fix is deployed. The Gateway generation, configuration, executable payloads and dependencies remained unchanged.

Required [CI run 33944879243](https://github.com/openclaw/openclaw/actions/runs/33944879243) passed for head `37752431a1b5707f985729945321cd2807e8dcc3`: 83 successful jobs and 17 skips. This includes the private-install checks blocked by the local shared dependency boundary. A managed candidate containing the exact reviewed source files was accepted by the deployment owner. The serving Gateway then passed an authenticated native OpenAI realtime → configured-agent consult → speech-output test: the final answer was “323. Gateway voice verified.”, with 211,200 PCM bytes (4.4 seconds), 12/12 playback acknowledgments, and no hidden prompt-mirroring warning. A timed null sink verified output drain; this does not claim physical Discord transport or human hearing. The temporary startup profiler completed and was removed without restarting the accepted Gateway.

Production delta: +19 net lines (+16 for suffix rendering and exact omission accounting, +3 for persisted hidden-admission handling); tests: +59 lines. The growth introduces the bounded-memory accumulation needed to preserve exact prompt bytes. No public API, configuration, protocol, or SQLite/schema change.

### Follow-up and scope

The separate model-context worker return still requires main-thread structured cloning, detached-session partition validation, and navigation/context construction. Preparing the existing partition in that worker is a named follow-up requiring full-read performance proof plus mutable-session, reset-prelude, admission, and cancellation coverage. This PR repairs the independently reproduced projection allocation and does not attribute every observed Gateway pause to that renderer.

Separate full-history/worker-return and worker-entry lookup costs remain under investigation; this landing does not claim that all Gateway latency is resolved.
