### PR TITLE
perf(channels): bound ingress pruning reads

### DIFF
--- a/src/channels/message/ingress-queue.pruning.test.ts
+++ b/src/channels/message/ingress-queue.pruning.test.ts
@@ -1,0 +1,89 @@
+// Pruning keeps durable ingress retention bounded without loading retained rows.
+import { describe, expect, it } from "vitest";
+import { trackSqliteStatementExecutions } from "../../../test/helpers/sqlite-statement-execution-counter.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import { createTestIngressQueue, withTempState } from "./ingress-drain.test-helpers.js";
+
+type ChannelIngressTestDatabase = Pick<OpenClawStateKyselyDatabase, "channel_ingress_events">;
+
+describe("channel ingress pruning", () => {
+  it("can bound pending scans and prune stale pending rows", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 1;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock++ });
+
+      await queue.enqueue("0002", { text: "second" });
+      await queue.enqueue("0001", { text: "first" });
+      await queue.enqueue("0003", { text: "third" });
+
+      expect(
+        (await queue.listPending({ limit: 2, orderBy: "id" })).map((record) => record.id),
+      ).toEqual(["0001", "0002"]);
+      expect(await queue.prune({ pendingTtlMs: 3, pendingMaxEntries: 1, now: 7 })).toBe(2);
+      expect((await queue.listPending({ limit: "all" })).map((record) => record.id)).toEqual([
+        "0003",
+      ]);
+    });
+  });
+
+  it("does not prune protected rows while enforcing max-entry limits", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir, { now: () => 10 });
+
+      await queue.enqueue("z", { text: "first" });
+      await queue.enqueue("a", { text: "second" });
+
+      expect(await queue.prune({ pendingMaxEntries: 1, protectIds: ["a"] })).toBe(0);
+      expect(
+        (await queue.listPending({ limit: "all", orderBy: "id" })).map((row) => row.id),
+      ).toEqual(["a", "z"]);
+    });
+  });
+
+  it.each(["pending", "completed", "failed"] as const)(
+    "prunes %s overflow without materializing the retained prefix",
+    async (status) => {
+      await withTempState(async (stateDir) => {
+        let clock = 1;
+        const queue = createTestIngressQueue(stateDir, { now: () => clock++ });
+
+        for (let index = 0; index < 520; index += 1) {
+          const id = String(index).padStart(4, "0");
+          await queue.enqueue(id, { text: String(index) });
+          if (status === "completed") {
+            await queue.complete(id);
+          } else if (status === "failed") {
+            await queue.fail(id, { reason: "fixture" });
+          }
+        }
+
+        const { db } = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+        const reads = trackSqliteStatementExecutions(db, ["candidates"], (sql) =>
+          sql.startsWith("select") && sql.includes('from "channel_ingress_events"')
+            ? "candidates"
+            : null,
+        );
+        try {
+          const pruneOptions = { [`${status}MaxEntries`]: 2 };
+          expect(await queue.prune(pruneOptions)).toBe(518);
+          expect(reads.rowCounts.candidates).toBe(518);
+          expect(await queue.prune(pruneOptions)).toBe(0);
+          expect(reads.rowCounts.candidates).toBe(518);
+        } finally {
+          reads.restore();
+        }
+        expect(
+          executeSqliteQuerySync(
+            db,
+            getNodeSqliteKysely<ChannelIngressTestDatabase>(db)
+              .selectFrom("channel_ingress_events")
+              .select("event_id")
+              .orderBy("event_id", "asc"),
+          ).rows.map((row) => row.event_id),
+        ).toEqual(["0518", "0519"]);
+      });
+    },
+  );
+});

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -182,56 +182,6 @@ describe("channel ingress queue", () => {
     });
   });
 
-  it("can bound pending scans and prune stale pending rows", async () => {
-    await withTempState(async (stateDir) => {
-      let clock = 1;
-      const queue = createTestIngressQueue<{ index: number }>(stateDir, { now: () => clock++ });
-
-      await queue.enqueue("0002", { index: 2 });
-      await queue.enqueue("0001", { index: 1 });
-      await queue.enqueue("0003", { index: 3 });
-
-      expect(
-        (await queue.listPending({ limit: 2, orderBy: "id" })).map((record) => record.id),
-      ).toEqual(["0001", "0002"]);
-      expect(await queue.prune({ pendingTtlMs: 3, pendingMaxEntries: 1, now: 7 })).toBe(2);
-      expect((await queue.listPending({ limit: "all" })).map((record) => record.id)).toEqual([
-        "0003",
-      ]);
-    });
-  });
-
-  it("does not prune protected rows while enforcing max-entry limits", async () => {
-    await withTempState(async (stateDir) => {
-      const queue = createTestIngressQueue<{ index: number }>(stateDir, { now: () => 10 });
-
-      await queue.enqueue("z", { index: 1 });
-      await queue.enqueue("a", { index: 2 });
-
-      expect(await queue.prune({ pendingMaxEntries: 1, protectIds: ["a"] })).toBe(0);
-      expect(
-        (await queue.listPending({ limit: "all", orderBy: "id" })).map((row) => row.id),
-      ).toEqual(["a", "z"]);
-    });
-  });
-
-  it("prunes max-entry overflow across bounded batches", async () => {
-    await withTempState(async (stateDir) => {
-      let clock = 1;
-      const queue = createTestIngressQueue<{ index: number }>(stateDir, { now: () => clock++ });
-
-      for (let index = 0; index < 520; index += 1) {
-        await queue.enqueue(String(index).padStart(4, "0"), { index });
-      }
-
-      expect(await queue.prune({ pendingMaxEntries: 2 })).toBe(518);
-      expect((await queue.listPending({ limit: "all" })).map((row) => row.id)).toEqual([
-        "0518",
-        "0519",
-      ]);
-    });
-  });
-
   it("claims, releases, and skips blocked lanes", async () => {
     await withTempState(async (stateDir) => {
       let clock = 1;

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -1517,6 +1517,7 @@ export function createChannelIngressQueue<
           }
           const batchSize = 500;
           const protectedSet = new Set(protectIds);
+          // Page before filtering protected IDs; they still occupy their retention slots.
           while (true) {
             const rowsToDelete = executeSqliteQuerySync(
               tx.db,
@@ -1527,8 +1528,9 @@ export function createChannelIngressQueue<
                 .where("status", "=", status)
                 .orderBy("updated_at", "desc")
                 .orderBy("event_id", "desc")
-                .limit(maxEntries + batchSize),
-            ).rows.slice(maxEntries);
+                .limit(batchSize)
+                .offset(maxEntries),
+            ).rows;
             const ids = rowsToDelete
               .map((row) => row.event_id)
               .filter((id) => !protectedSet.has(id));


### PR DESCRIPTION
## What Problem This Solves

Channel ingress pruning allocates result rows for events that it intends to keep. At the shared 20,000-entry limits, an already-trimmed queue materializes its entire retained prefix on every pruning pass; overflow repeats that work for each deletion batch. This also affects channel plugins such as Nostr that retain larger replay histories.

## Why This Change Was Made

Move the retained-prefix offset into the existing Kysely SELECT so only the next 500 deletion candidates cross into JavaScript. Keep the same ordering, queue and status scope, synchronous transaction, TTL pass, protected-ID filtering and stopping rule. Protected rows continue occupying the same candidate positions, including the existing all-protected-window stop.

This changes query materialization only. The schema, stored rows, retention limits, replay behavior, claim authority and public API remain unchanged. SQLite may still scan the offset; the evidence below measures returned JavaScript rows, not a claimed wall-clock speedup.

## User Impact

Ingress maintenance uses less temporary memory for retained message histories. Pending messages, completed replay tombstones and failed-event diagnostics retain the same membership, bytes and lifecycle as before.

## Evidence

The existing bounded-pruning test now covers pending, completed and failed rows through real SQLite and the shared statement counter. All three cases fail before the change because pruning returns 524 rows while only 518 are candidates; they pass after it. The complete focused queue, dead-letter, read-only, monitor, drain and Nostr suites pass: 115 tests in 7 files across 3 projects. Pruning cases live together in a focused suite and reuse the existing ingress test fixtures.

Native before/after proof through the actual queue owner:

| Scenario | Returned rows before | Returned rows after | Deleted rows |
| --- | ---: | ---: | ---: |
| Three statuses at 20,000 entries each | 60,000 | 0 | 0 |
| Three statuses with 117 excess rows each | 120,351 | 351 | 351 |
| Several candidate pages | 10,554 | 1,554 | 1,554 |

All 15 native scenarios preserve retained identities, full-row hashes, deletion counts, error codes/messages, rollback/retry and database reopen results. They cover tied timestamps, protected IDs, the full protected window, other queues, claimed rows, TTL-before-cap ordering, zero/negative/fractional/large limits and NaN/±Infinity. Every resulting candidate page has at most 500 rows.

A separate real monitor/dispatcher probe starts with 40,034 terminal entries, prunes 34, admits and adopts one synthetic event, rejects its duplicate, stops cleanly and reopens in a fresh process. The new process prunes one old tombstone, retains the new completed event and performs zero replay deliveries. No external channel messages are sent.

Directly inspected installed Kysely 0.29.5 SELECT/LIMIT/OFFSET builder and compiler source, Node v24.20.0 row conversion, and the [SQLite LIMIT/OFFSET contract](https://sqlite.org/lang_select.html#the_limit_clause). The owner/callers are unchanged from stable v2026.9.1 apart from this patch.

Production delta: +4/−2 lines (net +2: the OFFSET and protected-window invariant comment). Tests: +89/−50 lines (net +39, including moved existing cases), extending the existing regression and reusing test fixtures without adding a production test seam.

Validation commands:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/channels/message/ingress-queue.test.ts src/channels/message/ingress-queue.pruning.test.ts src/channels/message/ingress-queue.dead-letters.test.ts src/channels/message/ingress-queue.read-only-access.test.ts src/channels/message/ingress-monitor.test.ts src/channels/message/ingress-drain.test.ts extensions/nostr/src/nostr-ingress.test.ts
node scripts/check-changed.mjs -- src/channels/message/ingress-queue.ts src/channels/message/ingress-queue.test.ts src/channels/message/ingress-queue.pruning.test.ts
```

The full changed-file gate passes, including production/test types, formatting, lint, dead exports and all selected guards. Independent Codex review completed all eight evidence parts with no actionable P2-or-higher findings. Exact-head CI is checked by the native landing workflow.
