### PR TITLE
perf(skills): avoid redundant upload archive copies

### DIFF
--- a/src/skills/lifecycle/upload-store.sqlite.ts
+++ b/src/skills/lifecycle/upload-store.sqlite.ts
@@ -1,15 +1,12 @@
 // SQLite ownership helpers for Gateway skill-upload staging.
 import type { DatabaseSync } from "node:sqlite";
-import type { Kysely, Selectable } from "kysely";
+import type { InferResult, Kysely } from "kysely";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../../infra/kysely-sync.js";
-import type {
-  DB as OpenClawStateDatabase,
-  SkillUploads,
-} from "../../state/openclaw-state-db.generated.js";
+import type { DB as OpenClawStateDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -22,7 +19,29 @@ export type SkillUploadDatabase = Pick<
   OpenClawStateDatabase,
   "skill_upload_chunks" | "skill_uploads" | "state_leases"
 >;
-export type SkillUploadRow = Selectable<SkillUploads>;
+// Archive bytes belong to the authoritative install claim, not metadata retries.
+export function selectSkillUploadMetadata(kysely: Kysely<SkillUploadDatabase>) {
+  return kysely
+    .selectFrom("skill_uploads")
+    .select([
+      "upload_id",
+      "kind",
+      "slug",
+      "force",
+      "size_bytes",
+      "sha256",
+      "actual_sha256",
+      "received_bytes",
+      "created_at",
+      "expires_at",
+      "committed",
+      "committed_at",
+      "idempotency_key_hash",
+    ]);
+}
+export type SkillUploadMetadataRow = InferResult<
+  ReturnType<typeof selectSkillUploadMetadata>
+>[number];
 
 export function resolveSkillUploadDatabaseOptions(options: {
   env?: NodeJS.ProcessEnv;
@@ -42,14 +61,14 @@ export function openSkillUploadDatabase(options: OpenClawStateDatabaseOptions) {
   };
 }
 
-export function readSkillUploadRow(
+export function readSkillUploadMetadata(
   uploadId: string,
   options: OpenClawStateDatabaseOptions,
-): SkillUploadRow | undefined {
+): SkillUploadMetadataRow | undefined {
   const { database, kysely } = openSkillUploadDatabase(options);
   return executeSqliteQueryTakeFirstSync(
     database.db,
-    kysely.selectFrom("skill_uploads").selectAll().where("upload_id", "=", uploadId),
+    selectSkillUploadMetadata(kysely).where("upload_id", "=", uploadId),
   );
 }
 

--- a/src/skills/lifecycle/upload-store.test.ts
+++ b/src/skills/lifecycle/upload-store.test.ts
@@ -333,38 +333,83 @@ describe("skill upload store", () => {
     ).resolves.toMatchObject({ sha256: sha256(archive) });
   });
 
-  it("keeps large chunks separate until one final archive write", async () => {
+  it("keeps archive bytes out of metadata reads until the install claim", async () => {
     const { databasePath, store } = await makeStore();
-    const firstChunk = Buffer.alloc(4 * 1024 * 1024, 0x61);
-    const secondChunk = Buffer.alloc(4 * 1024 * 1024, 0x62);
-    const archive = Buffer.concat([firstChunk, secondChunk]);
-    const begin = await store.begin({
-      kind: "skill-archive",
-      slug: "large-skill",
-      sizeBytes: archive.length,
+    const db = stateDatabase(databasePath);
+    const archiveReads: Array<{ bytes: number; inTransaction: boolean }> = [];
+    const nativePrepare = db.prepare.bind(db);
+    vi.spyOn(db, "prepare").mockImplementation((sql) => {
+      const statement = nativePrepare(sql);
+      const iterate = statement.iterate.bind(statement);
+      vi.spyOn(statement, "iterate").mockImplementation(function* (...bindings) {
+        for (const row of iterate(...bindings)) {
+          if (row.archive_blob instanceof Uint8Array) {
+            archiveReads.push({
+              bytes: row.archive_blob.byteLength,
+              inTransaction: db.isTransaction,
+            });
+          }
+          yield row;
+        }
+        return undefined;
+      });
+      return statement;
     });
-    await store.chunk({
-      uploadId: begin.uploadId,
-      offset: 0,
-      dataBase64: firstChunk.toString("base64"),
-    });
-    await store.chunk({
-      uploadId: begin.uploadId,
-      offset: firstChunk.length,
-      dataBase64: secondChunk.toString("base64"),
-    });
-    const staged = stateDatabase(databasePath)
-      .prepare("SELECT length(archive_blob) AS bytes FROM skill_uploads WHERE upload_id = ?")
-      .get(begin.uploadId) as { bytes: number };
-    expect(staged.bytes).toBe(0);
-    expect(chunkCount(databasePath, begin.uploadId)).toBe(2);
+    try {
+      const firstChunk = Buffer.alloc(4 * 1024 * 1024, 0x61);
+      const secondChunk = Buffer.alloc(4 * 1024 * 1024, 0x62);
+      const archive = Buffer.concat([firstChunk, secondChunk]);
+      const begin = await store.begin({
+        kind: "skill-archive",
+        slug: "large-skill",
+        sizeBytes: archive.length,
+        idempotencyKey: "large-upload",
+      });
+      await store.chunk({
+        uploadId: begin.uploadId,
+        offset: 0,
+        dataBase64: firstChunk.toString("base64"),
+      });
+      await store.chunk({
+        uploadId: begin.uploadId,
+        offset: firstChunk.length,
+        dataBase64: secondChunk.toString("base64"),
+      });
+      const staged = stateDatabase(databasePath)
+        .prepare("SELECT length(archive_blob) AS bytes FROM skill_uploads WHERE upload_id = ?")
+        .get(begin.uploadId) as { bytes: number };
+      expect(staged.bytes).toBe(0);
+      expect(chunkCount(databasePath, begin.uploadId)).toBe(2);
 
-    await store.commit({ uploadId: begin.uploadId, sha256: sha256(archive) });
-    const committed = stateDatabase(databasePath)
-      .prepare("SELECT length(archive_blob) AS bytes FROM skill_uploads WHERE upload_id = ?")
-      .get(begin.uploadId) as { bytes: number };
-    expect(committed.bytes).toBe(archive.length);
-    expect(chunkCount(databasePath, begin.uploadId)).toBe(0);
+      await store.commit({ uploadId: begin.uploadId, sha256: sha256(archive) });
+      const committed = stateDatabase(databasePath)
+        .prepare("SELECT length(archive_blob) AS bytes FROM skill_uploads WHERE upload_id = ?")
+        .get(begin.uploadId) as { bytes: number };
+      expect(committed.bytes).toBe(archive.length);
+      expect(chunkCount(databasePath, begin.uploadId)).toBe(0);
+      await expect(
+        store.begin({
+          kind: "skill-archive",
+          slug: "large-skill",
+          sizeBytes: archive.length,
+          idempotencyKey: "large-upload",
+        }),
+      ).resolves.toMatchObject({ uploadId: begin.uploadId, receivedBytes: archive.length });
+      await expect(store.commit({ uploadId: begin.uploadId })).resolves.toMatchObject({
+        sha256: sha256(archive),
+      });
+      await expectUploadError(
+        store.chunk({ uploadId: begin.uploadId, offset: archive.length, dataBase64: "YQ==" }),
+        "upload is already committed",
+      );
+      expect(archiveReads).toEqual([]);
+      await store.withCommittedUpload(begin.uploadId, async (record) => {
+        expect(await fs.readFile(record.archivePath)).toEqual(archive);
+      });
+      expect(archiveReads).toEqual([{ bytes: archive.length, inTransaction: true }]);
+    } finally {
+      vi.restoreAllMocks();
+    }
   });
 
   it("uses the expiry and idempotency indexes", async () => {

--- a/src/skills/lifecycle/upload-store.test.ts
+++ b/src/skills/lifecycle/upload-store.test.ts
@@ -337,12 +337,19 @@ describe("skill upload store", () => {
     const { databasePath, store } = await makeStore();
     const db = stateDatabase(databasePath);
     const archiveReads: Array<{ bytes: number; inTransaction: boolean }> = [];
+    const nativeBlobs = new WeakSet<Uint8Array>();
+    const bufferFrom = vi.spyOn(Buffer, "from");
     const nativePrepare = db.prepare.bind(db);
     vi.spyOn(db, "prepare").mockImplementation((sql) => {
       const statement = nativePrepare(sql);
       const iterate = statement.iterate.bind(statement);
       vi.spyOn(statement, "iterate").mockImplementation(function* (...bindings) {
         for (const row of iterate(...bindings)) {
+          for (const bytes of [row.chunk_blob, row.archive_blob]) {
+            if (bytes instanceof Uint8Array) {
+              nativeBlobs.add(bytes);
+            }
+          }
           if (row.archive_blob instanceof Uint8Array) {
             archiveReads.push({
               bytes: row.archive_blob.byteLength,
@@ -407,6 +414,13 @@ describe("skill upload store", () => {
         expect(await fs.readFile(record.archivePath)).toEqual(archive);
       });
       expect(archiveReads).toEqual([{ bytes: archive.length, inTransaction: true }]);
+      const copiedBytes = bufferFrom.mock.calls.reduce((total, [value]) => {
+        const input: unknown = value;
+        return (
+          total + (input instanceof Uint8Array && nativeBlobs.has(input) ? input.byteLength : 0)
+        );
+      }, 0);
+      expect(copiedBytes).toBe(0);
     } finally {
       vi.restoreAllMocks();
     }

--- a/src/skills/lifecycle/upload-store.ts
+++ b/src/skills/lifecycle/upload-store.ts
@@ -308,9 +308,9 @@ function assembleArchive(
   expectedSize: number,
 ): Buffer {
   let offset = 0;
-  const buffers: Buffer[] = [];
+  const buffers: Uint8Array[] = [];
   for (const chunk of chunks) {
-    const bytes = Buffer.from(chunk.chunk_blob);
+    const bytes = chunk.chunk_blob;
     if (chunk.byte_offset !== offset || chunk.size_bytes !== bytes.length || bytes.length < 1) {
       throw new SkillUploadRequestError("uploaded archive chunks are incomplete");
     }
@@ -645,7 +645,7 @@ function createSkillUploadStore(options?: SkillUploadStoreOptions) {
           if (!current.actual_sha256) {
             throw new SkillUploadRequestError("committed upload is missing sha256");
           }
-          if (Buffer.from(current.archive_blob).length !== current.size_bytes) {
+          if (current.archive_blob.byteLength !== current.size_bytes) {
             throw new SkillUploadRequestError("uploaded archive is missing or incomplete");
           }
           executeSqliteQuerySync(
@@ -704,7 +704,8 @@ function createSkillUploadStore(options?: SkillUploadStoreOptions) {
             },
             async (tmp) => {
               const archivePath = path.join(tmp.dir, "archive.zip");
-              await fs.writeFile(archivePath, Buffer.from(row.archive_blob), { mode: 0o600 });
+              // SQLite returned a private byte snapshot that remains stable across this await.
+              await fs.writeFile(archivePath, row.archive_blob, { mode: 0o600 });
               return await action(toSkillUploadRecord(row, archivePath), {
                 remove: async () => {
                   // Only the callback that still owns the install lease may consume the upload.

--- a/src/skills/lifecycle/upload-store.ts
+++ b/src/skills/lifecycle/upload-store.ts
@@ -31,12 +31,13 @@ import {
   hasLiveSkillUploadInstallLease,
   openSkillUploadDatabase,
   readSkillUploadArchiveChunks,
-  readSkillUploadRow,
+  readSkillUploadMetadata,
   renewSkillUploadInstallLease,
   resolveSkillUploadDatabaseOptions,
+  selectSkillUploadMetadata,
   SKILL_UPLOAD_LEASE_SCOPE,
   type SkillUploadDatabase,
-  type SkillUploadRow,
+  type SkillUploadMetadataRow,
 } from "./upload-store.sqlite.js";
 
 /** Time window in which uploaded skill archive chunks may be committed. */
@@ -217,8 +218,11 @@ function decodeBase64Chunk(dataBase64: string): Buffer {
   return decoded;
 }
 
-function requireUploadRow(uploadId: string, options: OpenClawStateDatabaseOptions): SkillUploadRow {
-  const row = readSkillUploadRow(uploadId, options);
+function requireUploadMetadata(
+  uploadId: string,
+  options: OpenClawStateDatabaseOptions,
+): SkillUploadMetadataRow {
+  const row = readSkillUploadMetadata(uploadId, options);
   if (!row) {
     throw new SkillUploadRequestError(`upload not found: ${uploadId}`);
   }
@@ -226,7 +230,7 @@ function requireUploadRow(uploadId: string, options: OpenClawStateDatabaseOption
 }
 
 function assertNotExpired(
-  row: SkillUploadRow,
+  row: SkillUploadMetadataRow,
   nowMs: number,
   options: OpenClawStateDatabaseOptions,
 ): void {
@@ -241,7 +245,7 @@ function assertNotExpired(
 }
 
 function matchesBegin(
-  row: SkillUploadRow,
+  row: SkillUploadMetadataRow,
   params: {
     kind: "skill-archive";
     slug: string;
@@ -319,7 +323,7 @@ function assembleArchive(
   return Buffer.concat(buffers, expectedSize);
 }
 
-function toSkillUploadRecord(row: SkillUploadRow, archivePath: string): SkillUploadRecord {
+function toSkillUploadRecord(row: SkillUploadMetadataRow, archivePath: string): SkillUploadRecord {
   return {
     version: 1,
     kind: "skill-archive",
@@ -339,7 +343,7 @@ function toSkillUploadRecord(row: SkillUploadRow, archivePath: string): SkillUpl
   };
 }
 
-function toCommitResult(row: SkillUploadRow, requestedSha: string | undefined) {
+function toCommitResult(row: SkillUploadMetadataRow, requestedSha: string | undefined) {
   if (!row.actual_sha256) {
     throw new SkillUploadRequestError("committed upload is missing sha256");
   }
@@ -398,10 +402,7 @@ function createSkillUploadStore(options?: SkillUploadStoreOptions) {
           if (keyHash) {
             const existing = executeSqliteQueryTakeFirstSync(
               db,
-              kysely
-                .selectFrom("skill_uploads")
-                .selectAll()
-                .where("idempotency_key_hash", "=", keyHash),
+              selectSkillUploadMetadata(kysely).where("idempotency_key_hash", "=", keyHash),
             );
             if (existing) {
               if (!matchesBegin(existing, { kind: params.kind, slug, force, sizeBytes, sha256 })) {
@@ -473,12 +474,12 @@ function createSkillUploadStore(options?: SkillUploadStoreOptions) {
       });
       return await withLock(`${root}:upload:${uploadId}`, async () => {
         const currentTime = now();
-        assertNotExpired(requireUploadRow(uploadId, stateOptions), currentTime, stateOptions);
+        assertNotExpired(requireUploadMetadata(uploadId, stateOptions), currentTime, stateOptions);
         return runOpenClawStateWriteTransaction(({ db }) => {
           const kysely = getNodeSqliteKysely<SkillUploadDatabase>(db);
           const row = executeSqliteQueryTakeFirstSync(
             db,
-            kysely.selectFrom("skill_uploads").selectAll().where("upload_id", "=", uploadId),
+            selectSkillUploadMetadata(kysely).where("upload_id", "=", uploadId),
           );
           if (!row) {
             throw new SkillUploadRequestError(`upload not found: ${uploadId}`);
@@ -528,7 +529,7 @@ function createSkillUploadStore(options?: SkillUploadStoreOptions) {
       const requestedSha = normalizeSkillUploadSha256(params.sha256);
       const root = lockRoot();
       return await withLock(`${root}:upload:${uploadId}`, async () => {
-        const row = requireUploadRow(uploadId, stateOptions);
+        const row = requireUploadMetadata(uploadId, stateOptions);
         assertNotExpired(row, now(), stateOptions);
         if (row.committed === 1) {
           return toCommitResult(row, requestedSha);
@@ -551,7 +552,7 @@ function createSkillUploadStore(options?: SkillUploadStoreOptions) {
         } catch (err) {
           // Another process may commit and delete chunks after our metadata read.
           // The committed parent row is the idempotent authority in that race.
-          const current = requireUploadRow(uploadId, stateOptions);
+          const current = requireUploadMetadata(uploadId, stateOptions);
           if (current.committed === 1) {
             return toCommitResult(current, requestedSha);
           }
@@ -563,13 +564,13 @@ function createSkillUploadStore(options?: SkillUploadStoreOptions) {
           throw new SkillUploadRequestError("upload sha256 mismatch");
         }
         const committedAt = now();
-        assertNotExpired(requireUploadRow(uploadId, stateOptions), committedAt, stateOptions);
+        assertNotExpired(requireUploadMetadata(uploadId, stateOptions), committedAt, stateOptions);
 
         return runOpenClawStateWriteTransaction(({ db }) => {
           const kysely = getNodeSqliteKysely<SkillUploadDatabase>(db);
           const current = executeSqliteQueryTakeFirstSync(
             db,
-            kysely.selectFrom("skill_uploads").selectAll().where("upload_id", "=", uploadId),
+            selectSkillUploadMetadata(kysely).where("upload_id", "=", uploadId),
           );
           if (!current) {
             throw new SkillUploadRequestError(`upload not found: ${uploadId}`);
@@ -621,7 +622,7 @@ function createSkillUploadStore(options?: SkillUploadStoreOptions) {
       return await withLock(`${root}:upload:${uploadId}`, async () => {
         const leaseOwner = randomUUID();
         const currentTime = now();
-        assertNotExpired(requireUploadRow(uploadId, stateOptions), currentTime, stateOptions);
+        assertNotExpired(requireUploadMetadata(uploadId, stateOptions), currentTime, stateOptions);
         const row = runOpenClawStateWriteTransaction(({ db }) => {
           const kysely = getNodeSqliteKysely<SkillUploadDatabase>(db);
           const current = executeSqliteQueryTakeFirstSync(


### PR DESCRIPTION
## What Problem This Solves

Skill upload retries fetched the complete archive from SQLite even when they needed only metadata. Commit and install also copied native BLOBs into temporary Buffers before operations that already accept byte arrays. For an 8 MiB upload, the regressions found 32 MiB of unnecessary metadata BLOB materialization and a further 24 MiB of redundant Buffer copies across commit/install.

## Why This Change Was Made

The upload SQLite owner now defines one typed metadata projection and uses it for metadata checks and idempotent retries. The existing full-row read remains inside the authoritative install lease transaction. Chunk assembly passes native byte arrays into the existing final concat; the claim checks byteLength directly; private file materialization uses the selected byte array directly.

Node SQLite returns an independent Uint8Array snapshot, and neither the bytes nor the internal row escape to callers. Buffer.concat and fs.writeFile already accept that type. Archive validation, ordering, hashing, read timing, lease ownership, cleanup, and public results are preserved. No schema, stored format, migration, configuration, retention, or API changes.

Production +53/-32 (+21) expresses the metadata projection/inferred type and snapshot-ownership comment. Tests +89/-30 (+59) extend the existing large-archive native regression.

## User Impact

Large uploaded archives require fewer allocations during retries, commit, and installation, while preserving upload responses, errors, and recovery after restart.

## Evidence

- The metadata regression failed before the change on 32 MiB of selected archive bytes. Metadata reads now return none; installation retains the single full-row read inside its claim transaction.
- The existing native allocation regression also failed before conversion removal at 25,165,824 copied bytes (24 MiB). It passes on the edited owner with no Buffer.from copies of actual SQLite BLOBs and the required final archive concat retained.
- All 33 upload-store and Gateway handler tests passed, including chunk/commit races, expiry, lease fencing, invalid archives, policy failures, and replacement rollback.
- The final full changed gate passed. Its first attempt reported only test formatting, which was corrected before the complete rerun.
- Final immutable proof passed on 58a41c551d17e8d1ea9c127240fbe36e254f22aa: one qaRuntime build, actual compiled upload-owner allocation/reopen checks, and nine actual CLI/Gateway RPCs across a process restart. Source, harness and built artifacts remained exact; all task processes, state and temporaries were cleaned up.
- Independent Codex reviews completed all four projection and three final-copy evidence parts with no actionable P2-or-higher findings.

Canonical STRICT BLOB NOT NULL rows supply Uint8Array; forged JavaScript null/text/number rows are outside that storage contract and can have different incidental errors. Native allocation evidence is not a peak-RSS or cross-platform claim.


# Immutable skill-upload proof

Passed on the first attempt at commit `58a41c551d17e8d1ea9c127240fbe36e254f22aa`, tree `d9b9dc1398beb82820b83e78f33c7adc217951df`, with Node `v24.20.0` on macOS/arm64. No source or harness changes were needed during this run.

```sh
node --import ./scripts/tsx.mjs scripts/build-all.mts qaRuntime
node <proof>/native-owner.mjs
node <proof>/gateway.mjs
```

The runtime was built exactly once in 40.10 seconds. The actual built-owner phase passed in 4.03 seconds, and the normal CLI/Gateway phase passed in 28.21 seconds. Clean source identity, proof-script hashes, and all built runtime JS/JSON hashes matched before and after execution.

## Actual built upload owner

The existing test-only factory was loaded from the newly built skills bundle; no extracted prototype or replacement owner was used. Two actual 4 MiB chunks formed an 8 MiB archive. Native SQLite row identities were observed directly.

| Operation | Selected archive BLOBs | Redundant Buffer.from bytes | Required output |
| --- | ---: | ---: | --- |
| Chunk/commit metadata | 0 | 0 | Two chunk rows totaling 8,388,608 bytes; one final concat |
| Begin/commit retries and rejected late chunk | 0 | 0 | Same committed metadata / existing error |
| First install | 1, inside claim transaction | 0 | Exact selected 8,388,608-byte array written |
| Metadata after physical close/reopen | 0 | 0 | Same upload and committed result |
| Install after reopen | 1, inside claim transaction | 0 | Exact bytes, then owner-authorized removal |

Archive SHA256: `3507837af12a45840a31abfc8b5e56aa7ba306911741e2e01585b30ffe3cb16a`. The final concat ran once and retained the required 8,388,608-byte archive. Each file write received the exact private Uint8Array returned by the authoritative native read. Final uploads/chunks/install leases: `0/0/0`; SQLite integrity: `ok`. The canonical owner closed and both archive temporaries and isolated application state were removed.

## Normal CLI/Gateway flow

The Gateway used isolated client/server config, HOME, state, logs, workspace, synthetic authentication, and an ephemeral loopback listener. Optional plugins and heartbeat were disabled for this plugin-independent upload route; uploaded archives were explicitly enabled. The normal Gateway/CLI processes had no test flag, provider credentials, inference, channel sends, or external installation service.

```text
openclaw gateway run --port <ephemeral> --bind loopback
skills.upload.begin   -> upload created; receivedBytes=0
skills.upload.chunk   -> receivedBytes=138
skills.upload.chunk   -> receivedBytes=276
skills.upload.commit  -> expected SHA256; receivedBytes=276
skills.upload.begin   -> same upload; receivedBytes=276
skills.upload.commit  -> identical committed response
stop Gateway; restart with the same isolated state
skills.upload.commit  -> identical response in the fresh Gateway process
skills.install        -> ok=true; exact synthetic SKILL.md installed
skills.status         -> sqlite-upload-proof listed as eligible and model-visible
stop Gateway
```

All nine RPCs passed. The synthetic ZIP was `276` bytes, SHA256 `1c69fa9a125a3515c673ee09a9f7ffcf6330bc303a4e8e7e1520e9b487273cd4`. The status entry had source `openclaw-workspace`, `bundled=false`, `disabled=false`, `eligible=true`, and `modelVisible=true`.

Final uploads/chunks/install leases: `0/0/0`; SQLite integrity: `ok`. Both Gateway processes exited with code 0 without forced termination. The exact listener port was closed, the generated archive temporary was absent, and the isolated client/server/application state root was removed. No shared temporary directory or log was deleted.

This measures actual selected BLOBs and explicit Buffer conversions, not whole-process peak RSS. Other operating systems were not exercised.
