### PR TITLE
ci: trim redundant real-Gateway test work

### DIFF
--- a/extensions/qa-lab/src/control-ui-automation-management.real-gateway.e2e.test.ts
+++ b/extensions/qa-lab/src/control-ui-automation-management.real-gateway.e2e.test.ts
@@ -21,6 +21,7 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
 });
 
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 type AutomationAction = "list" | "get" | "update" | "run" | "remove";
 const actions = ["list", "get", "update", "run", "remove"] as const;
 const automationName = "Telegram-created reminder";
@@ -248,7 +249,9 @@ suite.define(() => {
         await suite.withPage(
           {
             locale: "en-US",
-            recordVideo: { dir: proofDir, size: { width: 1280, height: 900 } },
+            ...(captureUiProof
+              ? { recordVideo: { dir: proofDir, size: { width: 1280, height: 900 } } }
+              : {}),
             viewport: { width: 1280, height: 900 },
             serviceWorkers: "block",
           },
@@ -270,7 +273,9 @@ suite.define(() => {
               await page
                 .locator(".agent-chat__composer-combobox textarea")
                 .fill(`${action} the Telegram-created reminder. [automation-proof:${marker}]`);
-              await page.screenshot({ path: path.join(proofDir, `${marker}-request.png`) });
+              if (captureUiProof) {
+                await page.screenshot({ path: path.join(proofDir, `${marker}-request.png`) });
+              }
               await page.getByRole("button", { name: "Send message" }).click();
               await expect.poll(() => provider.results.has(marker), { timeout: 60_000 }).toBe(true);
               const result = readResult(provider.results.get(marker) ?? "null");
@@ -314,7 +319,9 @@ suite.define(() => {
                 .getByText(new RegExp(`^${marker}:`, "u"))
                 .first()
                 .waitFor();
-              await page.screenshot({ path: path.join(proofDir, `${marker}-result.png`) });
+              if (captureUiProof) {
+                await page.screenshot({ path: path.join(proofDir, `${marker}-result.png`) });
+              }
               adminResults[action] = "succeeded";
             }
           },

--- a/extensions/qa-lab/src/control-ui-media-transcript.real-gateway.e2e.test.ts
+++ b/extensions/qa-lab/src/control-ui-media-transcript.real-gateway.e2e.test.ts
@@ -20,6 +20,7 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
 });
 
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const replayModel: Model<"openai-responses"> = {
   id: "gpt-5.6-luna",
   name: "Mock OpenAI",
@@ -161,7 +162,9 @@ suite.define(() => {
       await suite.withPage(
         {
           locale: "en-US",
-          recordVideo: { dir: suite.artifactDir, size: { width: 1280, height: 900 } },
+          ...(captureUiProof
+            ? { recordVideo: { dir: suite.artifactDir, size: { width: 1280, height: 900 } } }
+            : {}),
           serviceWorkers: "block",
           viewport: { width: 1280, height: 900 },
         },
@@ -187,7 +190,9 @@ suite.define(() => {
             .locator("a, button, img, audio, video")
             .count();
           expect(omittedInteractiveDescendantCount).toBe(0);
-          await page.screenshot({ path: path.join(suite.artifactDir, "01-omitted-image.png") });
+          if (captureUiProof) {
+            await page.screenshot({ path: path.join(suite.artifactDir, "01-omitted-image.png") });
+          }
 
           await navigateToControlUiSession(page, retainedSessionKey);
           const retainedPane = page.locator('openclaw-chat-pane[aria-hidden="false"]');
@@ -226,7 +231,9 @@ suite.define(() => {
               2,
             )}\n`,
           );
-          await page.screenshot({ path: path.join(suite.artifactDir, "02-retained-image.png") });
+          if (captureUiProof) {
+            await page.screenshot({ path: path.join(suite.artifactDir, "02-retained-image.png") });
+          }
         },
       );
     } finally {
@@ -258,7 +265,9 @@ suite.define(() => {
         await suite.withPage(
           {
             locale: "en-US",
-            recordVideo: { dir: proofDir, size: { width: 1280, height: 900 } },
+            ...(captureUiProof
+              ? { recordVideo: { dir: proofDir, size: { width: 1280, height: 900 } } }
+              : {}),
             serviceWorkers: "block",
             viewport: { width: 1280, height: 900 },
           },
@@ -282,7 +291,9 @@ suite.define(() => {
             });
             await card.waitFor();
             const firstCardText = (await card.textContent()) ?? "";
-            await page.screenshot({ path: path.join(proofDir, "01-pptx-result.png") });
+            if (captureUiProof) {
+              await page.screenshot({ path: path.join(proofDir, "01-pptx-result.png") });
+            }
             const firstHistory = await gateway.gateway.call("chat.history", {
               sessionKey: "agent:qa:main",
               limit: 20,
@@ -349,7 +360,9 @@ suite.define(() => {
             const rawDisplayContent = rawAssistantMessages.flatMap((message) =>
               Array.isArray(message.openclawDisplayContent) ? message.openclawDisplayContent : [],
             );
-            await page.screenshot({ path: path.join(proofDir, "02-next-turn-result.png") });
+            if (captureUiProof) {
+              await page.screenshot({ path: path.join(proofDir, "02-next-turn-result.png") });
+            }
             const verdict = {
               failureCardVisible,
               failurePathHealthy,

--- a/extensions/qa-lab/src/control-ui-openclaw-delegation.real-gateway.e2e.test.ts
+++ b/extensions/qa-lab/src/control-ui-openclaw-delegation.real-gateway.e2e.test.ts
@@ -12,6 +12,7 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
 });
 
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const prompt = "tool search qa check target=openclaw openclaw_fixture=logging-level-info";
 
 function loggingLevel(config: unknown): unknown {
@@ -103,7 +104,9 @@ suite.define(() => {
       await suite.withPage(
         {
           locale: "en-US",
-          recordVideo: { dir: proofDir, size: { width: 1280, height: 900 } },
+          ...(captureUiProof
+            ? { recordVideo: { dir: proofDir, size: { width: 1280, height: 900 } } }
+            : {}),
           serviceWorkers: "block",
           viewport: { width: 1280, height: 900 },
         },
@@ -235,7 +238,9 @@ suite.define(() => {
           expect(pendingPageText).not.toContain("/approve");
           expect(pendingPageText).not.toContain("needsApproval");
           expect(pendingPageText).not.toContain("proposalId");
-          await page.screenshot({ path: path.join(proofDir, "01-native-approval.png") });
+          if (captureUiProof) {
+            await page.screenshot({ path: path.join(proofDir, "01-native-approval.png") });
+          }
 
           const approvalFallbackWasObserved = () =>
             page.evaluate(
@@ -407,7 +412,9 @@ suite.define(() => {
         await suite.withPage(
           {
             locale: "en-US",
-            recordVideo: { dir: proofDir, size: { width: 1280, height: 900 } },
+            ...(captureUiProof
+              ? { recordVideo: { dir: proofDir, size: { width: 1280, height: 900 } } }
+              : {}),
             serviceWorkers: "block",
             viewport: { width: 1280, height: 900 },
           },
@@ -453,7 +460,9 @@ suite.define(() => {
             await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
             const composer = page.locator(".agent-chat__composer-combobox textarea");
             await composer.fill(prompt);
-            await page.screenshot({ path: path.join(proofDir, "01-request.png") });
+            if (captureUiProof) {
+              await page.screenshot({ path: path.join(proofDir, "01-request.png") });
+            }
             await page.getByRole("button", { name: "Send message" }).click();
 
             await expect.poll(() => finalEvents, { timeout: 60_000 }).toBeGreaterThan(0);
@@ -479,7 +488,9 @@ suite.define(() => {
             await appliedResult.waitFor();
             await appliedResult.scrollIntoViewIfNeeded();
             expect(await page.locator(".chat-inline-approval [data-approval-id]").count()).toBe(0);
-            await page.screenshot({ path: path.join(proofDir, "02-applied.png") });
+            if (captureUiProof) {
+              await page.screenshot({ path: path.join(proofDir, "02-applied.png") });
+            }
             // Keep public proof independent of runtime tokens, paths, model metadata, and run ids.
             await writeFile(
               path.join(proofDir, "verdict.json"),

--- a/extensions/qa-lab/src/session-host-command-state.real-gateway.e2e.test.ts
+++ b/extensions/qa-lab/src/session-host-command-state.real-gateway.e2e.test.ts
@@ -17,6 +17,7 @@ const NODE_WORKER_ENVIRONMENT_SESSION_VERSION = 1;
 const NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE = "node-worker-supervisor-v6";
 const REQUEST_TIMEOUT_MS = 20_000;
 const TEST_TIMEOUT_MS = 180_000;
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const helloCounts = new WeakMap<GatewayClient, number>();
 
 const gatewayOwners: ReturnType<typeof createQaGatewayChild>[] = [];
@@ -162,7 +163,9 @@ suite.define(() => {
         await suite.withPage(
           {
             locale: "en-US",
-            recordVideo: { dir: suite.artifactDir, size: { height: 900, width: 1440 } },
+            ...(captureUiProof
+              ? { recordVideo: { dir: suite.artifactDir, size: { height: 900, width: 1440 } } }
+              : {}),
             serviceWorkers: "block",
             viewport: { height: 900, width: 1440 },
           },
@@ -189,16 +192,18 @@ suite.define(() => {
               .toContain(
                 `Ask an administrator to approve the pending ${COMMAND} request, or pick another device.`,
               );
-            // Keep captures at the recorded viewport size: clips and larger full-page
-            // screenshots temporarily resize Chromium's shared screencast surface.
-            await page.screenshot({
-              animations: "disabled",
-              path: path.join(suite.artifactDir, "00-undeclared.png"),
-            });
-            await page.screenshot({
-              animations: "disabled",
-              path: path.join(suite.artifactDir, "01-pending-approval.png"),
-            });
+            if (captureUiProof) {
+              // Keep captures at the recorded viewport size: clips and larger full-page
+              // screenshots temporarily resize Chromium's shared screencast surface.
+              await page.screenshot({
+                animations: "disabled",
+                path: path.join(suite.artifactDir, "00-undeclared.png"),
+              });
+              await page.screenshot({
+                animations: "disabled",
+                path: path.join(suite.artifactDir, "01-pending-approval.png"),
+              });
+            }
             await page.keyboard.press("Escape");
 
             const beforeConfig = await operator.request<{ hash: string }>("config.get", {});
@@ -229,10 +234,12 @@ suite.define(() => {
               .toContain(
                 `Authorize ${COMMAND} in the Gateway node command policy, or pick another device.`,
               );
-            await page.screenshot({
-              animations: "disabled",
-              path: path.join(suite.artifactDir, "02-unauthorized-after-hot-reload.png"),
-            });
+            if (captureUiProof) {
+              await page.screenshot({
+                animations: "disabled",
+                path: path.join(suite.artifactDir, "02-unauthorized-after-hot-reload.png"),
+              });
+            }
             expect(helloCounts.get(unauthorizedNode)).toBe(unauthorizedHelloCount);
             await page.keyboard.press("Escape");
 
@@ -262,10 +269,12 @@ suite.define(() => {
             await page.locator("#new-session-where-trigger").click();
             await row(unauthorizedIdentity.deviceId).waitFor();
             expect(await row(unauthorizedIdentity.deviceId).isEnabled()).toBe(true);
-            await page.screenshot({
-              animations: "disabled",
-              path: path.join(suite.artifactDir, "03-invocable-after-reallow.png"),
-            });
+            if (captureUiProof) {
+              await page.screenshot({
+                animations: "disabled",
+                path: path.join(suite.artifactDir, "03-invocable-after-reallow.png"),
+              });
+            }
           },
         );
       } finally {

--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -620,48 +620,43 @@ suite.define(() => {
             observeMcpAppNetwork(standalonePage, "timing", diagnostics);
             await standalonePage.goto("http://127.0.0.1:" + gatewayPort + standaloneUrl);
             let app = await findAppFrame(standalonePage);
-            for (const spec of [
-              { scenario: "warm-call8", callDelayMs: 8000, refresh: false },
-              { scenario: "list8-call1", callDelayMs: 1000, refresh: true },
-              { scenario: "list8-call8", callDelayMs: 8000, refresh: true },
-            ]) {
-              await fixture.configure(spec);
-              if (spec.refresh) {
-                await app.locator("#arm-refresh").click();
-                await waitForText(app.locator("#arm-result"), "armed");
-                // The real notification owns this transition. No catalog field is assigned.
-                await expect.poll(() => runtime.peekCatalog()).toBeNull();
-              } else {
-                expect(runtime.peekCatalog()).not.toBeNull();
-              }
-              const startedAtMs = Date.now();
-              diagnostics.push({
-                event: "timing-call-start",
-                atMs: startedAtMs,
-                scenario: spec.scenario,
-              });
-              await app.locator("#call-app").click();
-              await expect
-                .poll(() => app.locator("#app-tool").textContent(), { timeout: 25_000 })
-                .not.toBe("pending");
-              const settledAtMs = Date.now();
-              const output = await app.locator("#app-tool").textContent();
-              const events = await waitForMcpAppTimingEvents(fixture.readEvents, spec.scenario);
-              timingResults.push({
-                scenario: spec.scenario,
-                output,
-                events,
-                startedAtMs,
-                settledAtMs,
-              });
-              await recordHost(standalonePage, spec.scenario);
-              await fs.writeFile(
-                path.join(proofDir, "timing-results.json"),
-                JSON.stringify(timingResults, null, 2),
-              );
-              assertMcpAppTimingEvents(events, spec);
-              expect(output).toContain("companion-called");
-            }
+            // Each RPC stays below 10s; their composition must cross the former 15s HTTP cutoff.
+            const timingSpec = { scenario: "list8-call8", callDelayMs: 8000 };
+            await fixture.configure(timingSpec);
+            await app.locator("#arm-refresh").click();
+            await waitForText(app.locator("#arm-result"), "armed");
+            // The real notification owns this transition. No catalog field is assigned.
+            await expect.poll(() => runtime.peekCatalog()).toBeNull();
+            const timingStartedAtMs = Date.now();
+            diagnostics.push({
+              event: "timing-call-start",
+              atMs: timingStartedAtMs,
+              scenario: timingSpec.scenario,
+            });
+            await app.locator("#call-app").click();
+            await expect
+              .poll(() => app.locator("#app-tool").textContent(), { timeout: 25_000 })
+              .not.toBe("pending");
+            const settledAtMs = Date.now();
+            const output = await app.locator("#app-tool").textContent();
+            const timingEvents = await waitForMcpAppTimingEvents(
+              fixture.readEvents,
+              timingSpec.scenario,
+            );
+            timingResults.push({
+              scenario: timingSpec.scenario,
+              output,
+              events: timingEvents,
+              startedAtMs: timingStartedAtMs,
+              settledAtMs,
+            });
+            await recordHost(standalonePage, timingSpec.scenario);
+            await fs.writeFile(
+              path.join(proofDir, "timing-results.json"),
+              JSON.stringify(timingResults, null, 2),
+            );
+            assertMcpAppTimingEvents(timingEvents, timingSpec);
+            expect(output).toContain("companion-called");
             const initializations = (await fixture.readEvents()).filter(
               (event) => event.method === "initialize",
             ).length;

--- a/ui/src/e2e/mcp-app-timing.test-support.ts
+++ b/ui/src/e2e/mcp-app-timing.test-support.ts
@@ -33,7 +33,7 @@ export async function waitForMcpAppTimingEvents(
 
 export function assertMcpAppTimingEvents(
   events: McpAppFixtureEvent[],
-  spec: { callDelayMs: number; refresh: boolean },
+  spec: { callDelayMs: number },
 ): void {
   expect(events.filter((event) => event.event === "tool-start")).toHaveLength(1);
   expect(events.filter((event) => event.event === "tool-complete")).toHaveLength(1);
@@ -69,27 +69,25 @@ export function assertMcpAppTimingEvents(
   expect(complete.monotonicMs - call.monotonicMs).toBeLessThan(10_000);
   expect(complete.monotonicMs - start.monotonicMs).toBeGreaterThanOrEqual(spec.callDelayMs - 100);
   expect(complete.monotonicMs - start.monotonicMs).toBeLessThan(10_000);
-  if (spec.refresh) {
-    expect(
-      events.filter((event) => event.event === "incoming" && event.method === "tools/list"),
-    ).toHaveLength(1);
-    expect(events.filter((event) => event.event === "notification-sent")).toHaveLength(1);
-    const ready = events.find((event) => event.event === "list-response-ready");
-    const sent = events.find((event) => event.event === "list-response-send");
-    const written = events.find(
-      (event) => event.event === "response-written" && event.method === "tools/list",
-    );
-    const incoming = events.find(
-      (event) => event.event === "incoming" && event.method === "tools/list",
-    );
-    if (!ready || !sent || !written || !incoming) {
-      throw new Error("Missing correlated catalog response events");
-    }
-    expect(written.id).toBe(incoming.id);
-    expect(ready.id).toBe(incoming.id);
-    expect(written.monotonicMs - incoming.monotonicMs).toBeLessThan(10_000);
-    expect(sent.monotonicMs - ready.monotonicMs).toBeGreaterThanOrEqual(7900);
-    expect(sent.monotonicMs - ready.monotonicMs).toBeLessThan(10_000);
-    expect(start.monotonicMs).toBeGreaterThanOrEqual(written.monotonicMs);
+  expect(
+    events.filter((event) => event.event === "incoming" && event.method === "tools/list"),
+  ).toHaveLength(1);
+  expect(events.filter((event) => event.event === "notification-sent")).toHaveLength(1);
+  const ready = events.find((event) => event.event === "list-response-ready");
+  const sent = events.find((event) => event.event === "list-response-send");
+  const written = events.find(
+    (event) => event.event === "response-written" && event.method === "tools/list",
+  );
+  const incoming = events.find(
+    (event) => event.event === "incoming" && event.method === "tools/list",
+  );
+  if (!ready || !sent || !written || !incoming) {
+    throw new Error("Missing correlated catalog response events");
   }
+  expect(written.id).toBe(incoming.id);
+  expect(ready.id).toBe(incoming.id);
+  expect(written.monotonicMs - incoming.monotonicMs).toBeLessThan(10_000);
+  expect(sent.monotonicMs - ready.monotonicMs).toBeGreaterThanOrEqual(7900);
+  expect(sent.monotonicMs - ready.monotonicMs).toBeLessThan(10_000);
+  expect(start.monotonicMs).toBeGreaterThanOrEqual(written.monotonicMs);
 }


### PR DESCRIPTION
## What Problem This Solves

The serial real-Gateway CI suite repeats two MCP timing controls and records success media even when proof capture is disabled. This adds work to the critical path while maintainers are reducing CI fanout.

## Why This Change Was Made

Keep the strongest MCP lifetime regression: an eight-second catalog refresh followed by an eight-second tool call. Each RPC remains below its ten-second budget, while their composition crosses the former fifteen-second HTTP cutoff. Remove the redundant warm-call and short-call timing variants, saving seventeen seconds of configured waits. Both top-level MCP cases, all five cancellation paths, late-response barriers, and navigation checks remain.

The four QA browser suites now honor the existing `OPENCLAW_CAPTURE_UI_PROOF=1` switch for successful screenshots and video recording. Their seven behavior cases retain every assertion, wait, viewport, and cleanup step. Failure diagnostics keep their existing owner and remain enabled independently.

## User Impact

No product behavior changes. Ordinary CI avoids seven videos and twenty-three successful screenshots from these suites; explicit proof capture retains the same filenames and recording options. No additional shards or test retries are introduced. Production LOC is unchanged; the diff is confined to tests and test support.

## Evidence

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33944802243) is green: 94 successful jobs and 13 scope skips. The real-Gateway job passed all 13 files / 24 cases with ordinary capture disabled. Its test step took 5m01s; the job took 7m19s. Non-Windows work finished at 8m06s and the CI gate at 8m14s. Windows was scope-skipped for this test-only change. All seven UI E2E shards, all four QA smoke profiles, 48 compact Node jobs, three changed-plugin config jobs, and both core lint jobs passed.

The previous broader CI PR's real-Gateway test step took 5m28s. This run is 27 seconds lower, but source, scope and setup differ, so this is an observed trend, not an isolated attribution. The patch removes seventeen seconds of configured MCP waits and the seven routine recordings / twenty-three screenshots described above.

The canonical changed-file gate passed, including both typechecks, all three dead-export scans, formatting, and both lints. Independent review of the final six-file source found no actionable findings.

A standalone Linux baseline passed 13 files / 24 cases in 319.336 seconds, but the paired comparison did not complete: the first attempt lacked Playwright's encoder and used an invalid external baseline artifact directory; the corrected attempt's prepared candidate lacked an older declared SDK dependency. Neither failure is reported as a speedup. Native CI supplies final candidate coverage. On the exact committed source, a fresh Linux Testbox passed all four capture-enabled suites / seven cases (181.913 seconds), produced seven finalized videos and twenty-three screenshots, and passed the three existing shared capture/diagnostic tests. Media inventory and video metadata were verified; a representative screenshot was inspected. The first extracted video frame was blank prerender and is not used as visual evidence.
