### PR TITLE
fix: speed up attachment downloads from long histories

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2949,7 +2949,7 @@ src/gateway/session-sharing-target-input.ts	2
 src/gateway/session-sharing.ts	1
 src/gateway/session-transcript-derived-readers.ts	2
 src/gateway/session-transcript-files.fs.ts	2
-src/gateway/session-transcript-message.ts	4
+src/gateway/session-transcript-message.ts	3
 src/gateway/session-transcript-title-reader.ts	1
 src/gateway/session-utils-core.ts	1
 src/gateway/session-utils-row.ts	1

--- a/src/config/sessions/session-accessor.sqlite-history-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.ts
@@ -4,6 +4,7 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
 } from "../../infra/kysely-sync.js";
+import { isVisibleTranscriptRecord } from "../../sessions/transcript-visible-record.js";
 import type {
   SessionTranscriptMessageAnchorPage,
   SessionTranscriptMessageEventPage,
@@ -30,6 +31,9 @@ import {
   readTranscriptDisplaySource,
 } from "./session-accessor.sqlite-display-position.js";
 import {
+  assertVisibleMessageRangeJson,
+  hasUnindexedVisibleMessages,
+  iterateVisibleMessageRange,
   readVisibleMessageMetadata,
   readVisibleMessageRange,
   resolveVisibleMessagePositions,
@@ -180,30 +184,47 @@ function readVisibleHistoryRange(
   endExclusive: number,
   history = resolveVisibleHistoryProjection(projection),
 ): SessionTranscriptMessageEvent[] {
-  const { boundedEnd, boundedStart, boundaries, messageEnd, messageStart } =
-    resolveVisibleHistoryRange(history, start, endExclusive);
-  if (boundedEnd <= boundedStart) {
+  const range = resolveVisibleHistoryRange(history, start, endExclusive);
+  if (range.boundedEnd <= range.boundedStart) {
     return [];
   }
-  const messages = readVisibleMessageRange(projection, messageStart, messageEnd);
-  const boundaryEvents = readBoundaryEvents(projection, boundaries.values());
-  let messageIndex = 0;
-  const events: SessionTranscriptMessageEvent[] = [];
-  for (let displayPosition = boundedStart; displayPosition < boundedEnd; displayPosition += 1) {
-    const boundary = boundaries.get(displayPosition);
-    if (boundary) {
-      const event = boundaryEvents.get(boundary.eventSeq);
-      if (event) {
-        events.push({ event, eventSeq: boundary.eventSeq, seq: displayPosition + 1 });
+  const messages = readVisibleMessageRange(projection, range.messageStart, range.messageEnd);
+  const boundaryEvents = readBoundaryEvents(projection, range.boundaries.values());
+  return positionTranscriptDisplayEvents(
+    projection,
+    history.displaySource,
+    Array.from(mergeVisibleHistoryEvents(range, messages, boundaryEvents)),
+  );
+}
+
+function* mergeVisibleHistoryEvents(
+  range: ReturnType<typeof resolveVisibleHistoryRange>,
+  messages: Iterable<SessionTranscriptMessageEvent>,
+  boundaryEvents: Map<number, TranscriptEvent>,
+): IterableIterator<SessionTranscriptMessageEvent> {
+  const iterator = messages[Symbol.iterator]();
+  try {
+    for (
+      let displayPosition = range.boundedStart;
+      displayPosition < range.boundedEnd;
+      displayPosition += 1
+    ) {
+      const boundary = range.boundaries.get(displayPosition);
+      if (boundary) {
+        const event = boundaryEvents.get(boundary.eventSeq);
+        if (event) {
+          yield { event, eventSeq: boundary.eventSeq, seq: displayPosition + 1 };
+        }
+        continue;
       }
-      continue;
+      const message = iterator.next();
+      if (!message.done) {
+        yield { ...message.value, seq: displayPosition + 1 };
+      }
     }
-    const message = messages[messageIndex++];
-    if (message) {
-      events.push({ ...message, seq: displayPosition + 1 });
-    }
+  } finally {
+    iterator.return?.();
   }
-  return positionTranscriptDisplayEvents(projection, history.displaySource, events);
 }
 
 function resolveRecentHistoryStart(
@@ -498,6 +519,56 @@ export function readSessionTranscriptHistoryEventById(
     return event
       ? positionTranscriptDisplayEvents(projection, history.displaySource, [event])[0]
       : undefined;
+  });
+}
+
+/** Select ID candidates and projected-history presence from one validated snapshot. */
+export function readSessionTranscriptHistoryEventLookup(
+  scope: SessionTranscriptReadScope,
+  eventId: string,
+): { events: SessionTranscriptMessageEvent[]; hasDisplayMessages: boolean } {
+  return withCurrentProjectionSnapshot(scope, (projection) => {
+    const history = resolveVisibleHistoryProjection(projection);
+    const range = resolveVisibleHistoryRange(history, 0, history.total);
+    if (
+      !eventId.trim() ||
+      hasUnindexedVisibleMessages(projection, range.messageStart, range.messageEnd)
+    ) {
+      // Unindexed stored rows can retain message.__openclaw.id during projection.
+      // Let the full reader select those candidates; the caller matches projected IDs.
+      const events = readVisibleHistoryRange(projection, 0, history.total, history);
+      return {
+        events,
+        hasDisplayMessages: events.some((row) => isVisibleTranscriptRecord(row.event)),
+      };
+    }
+    assertVisibleMessageRangeJson(projection, range.messageStart, range.messageEnd);
+    const boundaryEvents = readBoundaryEvents(projection, range.boundaries.values());
+    let first: SessionTranscriptMessageEvent | undefined;
+    let hasDisplayMessages = false;
+    for (const event of mergeVisibleHistoryEvents(
+      range,
+      iterateVisibleMessageRange(projection, range.messageStart, range.messageEnd),
+      boundaryEvents,
+    )) {
+      first ??= event;
+      if (isVisibleTranscriptRecord(event.event)) {
+        hasDisplayMessages = true;
+        break;
+      }
+    }
+    const event = resolveHistoryEventById(projection, eventId.trim(), history);
+    // Nonempty history validates the current-turn admission even when the requested
+    // ID is absent. Keep that fence while positioning only the selected/first row.
+    const positioned = positionTranscriptDisplayEvents(
+      projection,
+      history.displaySource,
+      event ? [event] : first ? [first] : [],
+    );
+    return {
+      events: event ? positioned : [],
+      hasDisplayMessages,
+    };
   });
 }
 

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -391,15 +391,14 @@ export function assertVisibleMessageRangeJson(
       projection.database.db,
       range.query
         .select(["active.event_seq", "active.message_position", "event.event_json"])
-        .where((eb) =>
-          eb.or([
-            // The raw check rejects extra values; the enclosing array cannot end at a NUL.
-            /* kysely-allow-raw: validate ordinary payloads without materializing them in JavaScript. */
-            eb(sql<number>`json_valid(event.event_json)`, "=", 0),
-            /* kysely-allow-raw: require a closing delimiter beyond SQLite's NUL-terminated JSON input. */
-            eb(sql<number>`json_valid('[' || event.event_json || ']')`, "=", 0),
-          ]),
-        ),
+        .where((eb) => {
+          // The raw check rejects extra values; the enclosing array cannot end at a NUL.
+          const enclosed = eb(eb.val("["), "||", eb("event.event_json", "||", eb.val("]")));
+          return eb.or([
+            eb(eb.fn<number>("json_valid", ["event.event_json"]), "=", 0),
+            eb(eb.fn<number>("json_valid", [enclosed]), "=", 0),
+          ]);
+        }),
     )) {
       // SQLite's nesting limit is stricter than JSON.parse. Keep readable deep
       // rows and let the existing parser own actual malformed-row failures.

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -358,6 +358,56 @@ export function* iterateVisibleMessageRange(
   }
 }
 
+export function hasUnindexedVisibleMessages(
+  projection: CurrentTranscriptProjection,
+  start: number,
+  endExclusive: number,
+): boolean {
+  return selectVisibleMessageRanges(projection, start, endExclusive).some(
+    (range) =>
+      executeSqliteQueryTakeFirstSync(
+        projection.database.db,
+        range.query
+          .leftJoin("transcript_event_identities as identity", (join) =>
+            join
+              .onRef("identity.session_id", "=", "active.session_id")
+              .onRef("identity.seq", "=", "active.event_seq"),
+          )
+          .select("active.event_seq")
+          .where("identity.seq", "is", null)
+          .limit(1),
+      ) !== undefined,
+  );
+}
+
+/** Validate the whole selected history without materializing ordinary payloads in JavaScript. */
+export function assertVisibleMessageRangeJson(
+  projection: CurrentTranscriptProjection,
+  start: number,
+  endExclusive: number,
+): void {
+  for (const range of selectVisibleMessageRanges(projection, start, endExclusive)) {
+    for (const row of iterateSqliteQuerySync(
+      projection.database.db,
+      range.query
+        .select(["active.event_seq", "active.message_position", "event.event_json"])
+        .where((eb) =>
+          eb.or([
+            // The raw check rejects extra values; the enclosing array cannot end at a NUL.
+            /* kysely-allow-raw: validate ordinary payloads without materializing them in JavaScript. */
+            eb(sql<number>`json_valid(event.event_json)`, "=", 0),
+            /* kysely-allow-raw: require a closing delimiter beyond SQLite's NUL-terminated JSON input. */
+            eb(sql<number>`json_valid('[' || event.event_json || ']')`, "=", 0),
+          ]),
+        ),
+    )) {
+      // SQLite's nesting limit is stricter than JSON.parse. Keep readable deep
+      // rows and let the existing parser own actual malformed-row failures.
+      parseActiveTranscriptMessageRow(row);
+    }
+  }
+}
+
 /** Sizes the same logical ranges without fetching or parsing excluded payloads. */
 export function readVisibleMessageMetadata(
   projection: CurrentTranscriptProjection,

--- a/src/gateway/managed-image-attachments.sqlite-visibility.test.ts
+++ b/src/gateway/managed-image-attachments.sqlite-visibility.test.ts
@@ -1,7 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
 import {
@@ -12,6 +13,12 @@ import {
   publishEncodedSessionTranscriptArchive,
   resolveSqliteTranscriptArchivePath,
 } from "../config/sessions/session-accessor.sqlite-archive.js";
+import { rewriteSqliteTranscriptEventRowsInTransaction } from "../config/sessions/session-accessor.sqlite-transcript-store.js";
+import {
+  runWithSessionTranscriptReadFence,
+  SessionTranscriptReadFenceError,
+} from "../config/sessions/session-transcript-read-fence.js";
+import { appendSessionTranscriptMessageByIdentity } from "../plugin-sdk/session-transcript-runtime.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -30,6 +37,7 @@ import {
 } from "./managed-image-record-store.js";
 import {
   readSessionMessageCountAsync,
+  readSessionMessagesMatchingIdAsync,
   readSessionMessagesWithSourceAsync,
 } from "./session-transcript-readers.js";
 
@@ -42,7 +50,7 @@ function message(id: string, parentId: string | null, content: unknown) {
   return { type: "message", id, parentId, timestamp, message: { role: "assistant", content } };
 }
 
-async function fixture() {
+async function fixture(messageId = "attached") {
   const sessionId = `managed-visibility-${randomUUID()}`;
   const sessionKey = `agent:main:${sessionId}`;
   const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
@@ -55,7 +63,6 @@ async function fixture() {
   const originalPath = path.join(mediaRoot, MANAGED_OUTGOING_ORIGINALS_SUBDIR, mediaId);
   fs.mkdirSync(path.dirname(originalPath), { recursive: true });
   fs.writeFileSync(originalPath, body);
-  const messageId = "attached";
   insertManagedImageRecord(
     {
       attachmentId,
@@ -97,12 +104,12 @@ async function seed(f: Awaited<ReturnType<typeof fixture>>, events: unknown[]) {
   await readSessionMessageCountAsync(f.scope);
 }
 
-function archive(f: Awaited<ReturnType<typeof fixture>>) {
+function archive(
+  f: Awaited<ReturnType<typeof fixture>>,
+  events: unknown[] = [message(f.messageId, null, [f.block])],
+) {
   const bytes = Buffer.from(
-    [
-      { type: "session", version: 3, id: f.scope.sessionId, timestamp, cwd: stateDir },
-      message(f.messageId, null, [f.block]),
-    ]
+    [{ type: "session", version: 3, id: f.scope.sessionId, timestamp, cwd: stateDir }, ...events]
       .map((event) => JSON.stringify(event))
       .join("\n") + "\n",
   );
@@ -139,6 +146,225 @@ afterEach(() => {
 });
 
 describe("managed attachment SQLite visibility", () => {
+  it("does not decode every unrelated payload when resolving one attachment", async () => {
+    const f = await fixture();
+    const marker = "managed-membership-wide-payload";
+    const text = marker + "x".repeat(16 * 1024);
+    const unrelated = Array.from({ length: 40 }, (_, index) =>
+      message(`other-${index}`, index === 0 ? null : `other-${index - 1}`, [
+        { type: "text", text },
+      ]),
+    );
+    await seed(f, [...unrelated, message(f.messageId, "other-39", [f.block])]);
+    const parse = JSON.parse;
+    let decodedUnrelatedPayloads = 0;
+    const spy = vi.spyOn(JSON, "parse").mockImplementation((value, reviver) => {
+      if (typeof value === "string" && value.includes(marker)) {
+        decodedUnrelatedPayloads += 1;
+      }
+      return parse(value, reviver);
+    });
+    try {
+      expect((await f.download())?.artifactId).toBe(
+        `${MANAGED_OUTGOING_IMAGE_ARTIFACT_ID_PREFIX}${f.attachmentId}`,
+      );
+      // One payload can establish nonempty display history; the requested record
+      // must not require decoding the remaining unrelated message bodies.
+      expect(decodedUnrelatedPayloads).toBeLessThanOrEqual(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it.each([" padded-id ", "   "])("preserves raw message ID %j", async (messageId) => {
+    const f = await fixture(messageId);
+    await seed(f, [message(messageId, null, [f.block])]);
+    const full = await readSessionMessagesWithSourceAsync(f.scope, {
+      mode: "full",
+      reason: "raw managed attachment identity",
+      allowResetArchiveFallback: true,
+    });
+    expect(full.messages).toMatchObject([{ __openclaw: { id: messageId } }]);
+    expect((await f.download())?.artifactId).toBe(
+      `${MANAGED_OUTGOING_IMAGE_ARTIFACT_ID_PREFIX}${f.attachmentId}`,
+    );
+  });
+
+  it.each(["active", "archive"] as const)(
+    "preserves %s ID-less rows with an existing projected message ID",
+    async (source) => {
+      const f = await fixture();
+      const event = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [f.block],
+          __openclaw: { id: f.messageId },
+        },
+      };
+      await seed(f, source === "active" ? [event] : []);
+      if (source === "archive") {
+        archive(f, [event]);
+      }
+      const full = await readSessionMessagesWithSourceAsync(f.scope, {
+        mode: "full",
+        reason: "retained message metadata ID",
+        allowResetArchiveFallback: true,
+      });
+      expect(full.messages).toMatchObject([{ __openclaw: { id: f.messageId } }]);
+      expect(await f.download()).not.toBeNull();
+    },
+  );
+
+  it("falls back to archives only when no live row projects a message", async () => {
+    const f = await fixture();
+    archive(f);
+    await seed(f, [
+      { type: "message", id: "null", parentId: null, message: null },
+      { type: "message", id: "false", parentId: "null", message: false },
+      { type: "message", id: "empty", parentId: "false", message: "" },
+    ]);
+    expect(await readSessionMessageCountAsync(f.scope)).toBe(3);
+    expect(await f.download()).not.toBeNull();
+    await seed(f, [message("live", null, [])]);
+    expect(await f.download()).toBeNull();
+  });
+
+  it.each([
+    ["selected", 1_100],
+    ["unrelated", 1_100],
+    ["unrelated", 999],
+  ] as const)("accepts JavaScript-readable %s JSON at depth %i", async (kind, depth) => {
+    const f = await fixture();
+    const deep = JSON.parse("[".repeat(depth) + "0" + "]".repeat(depth));
+    const other = message("other", null, "other");
+    const attached = message(f.messageId, "other", [f.block]);
+    Object.assign(kind === "selected" ? attached : other, { deep, escapedNul: "valid\u0000text" });
+    await seed(f, [other, attached]);
+    expect(await f.download()).not.toBeNull();
+    expect(
+      await cleanupManagedOutgoingMediaRecords({ stateDir, sessionKey: f.scope.sessionKey }),
+    ).toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
+  });
+
+  it("preserves archive duplicates and full-reader oversized recovery", async () => {
+    const f = await fixture();
+    await seed(f, []);
+    // Parentless duplicate records remain in the archive's flat selected history.
+    const { parentId: _parent, ...attached } = message(f.messageId, null, [f.block]);
+    archive(f, [
+      {
+        ...attached,
+        message: {
+          role: "assistant",
+          content: [
+            f.block,
+            {
+              type: "image",
+              data: Buffer.alloc(300_000, 97).toString("base64"),
+              mimeType: "image/png",
+            },
+          ],
+        },
+      },
+      {
+        ...attached,
+        message: { role: "assistant", content: "later duplicate without attachment" },
+      },
+    ]);
+    const full = await readSessionMessagesWithSourceAsync(f.scope, {
+      mode: "full",
+      reason: "archive membership parity",
+      allowResetArchiveFallback: true,
+    });
+    expect(full.messages.length).toBe(2);
+    expect(await readSessionMessagesMatchingIdAsync(f.scope, f.messageId)).toEqual(full.messages);
+    expect(await f.download()).not.toBeNull();
+  });
+
+  it("validates the admitted generation on both matching and missing IDs", async () => {
+    const f = await fixture();
+    await seed(f, [message(f.messageId, null, [f.block])]);
+    const admitted = await appendSessionTranscriptMessageByIdentity({
+      ...f.scope,
+      message: { role: "user", content: "current admission" },
+      parentId: f.messageId,
+    });
+    if (!admitted?.anchor) {
+      throw new Error("expected admitted transcript anchor");
+    }
+    const receipt = { ...admitted.anchor, logicalTurnId: "membership-turn", role: "user" as const };
+    for (const id of [f.messageId, "missing"]) {
+      await runWithSessionTranscriptReadFence(receipt, async () => {
+        const full = await readSessionMessagesWithSourceAsync(f.scope, {
+          mode: "full",
+          reason: "fenced membership parity",
+          allowResetArchiveFallback: true,
+        });
+        expect(await readSessionMessagesMatchingIdAsync(f.scope, id)).toEqual(
+          full.messages.filter(
+            (row) => (row as { __openclaw: { id: string } })["__openclaw"].id === id,
+          ),
+        );
+      });
+      await expect(
+        runWithSessionTranscriptReadFence({ ...receipt, generation: "stale" }, () =>
+          readSessionMessagesMatchingIdAsync(f.scope, id),
+        ),
+      ).rejects.toBeInstanceOf(SessionTranscriptReadFenceError);
+    }
+    expect(openOpenClawAgentDatabase({ agentId: "main" }).db.isTransaction).toBe(false);
+  });
+
+  it("keeps validation, presence and selected content on one snapshot across a writer", async () => {
+    const f = await fixture();
+    const other = message("other", null, "snapshot writer trigger");
+    const attached = message(f.messageId, "other", [f.block]);
+    await seed(f, [other, attached]);
+    const database = openOpenClawAgentDatabase({ agentId: "main" });
+    const row = database.db
+      .prepare(
+        "SELECT seq, event_json FROM transcript_events WHERE session_id = ? AND seq = (SELECT seq FROM transcript_event_identities WHERE session_id = ? AND event_id = ?)",
+      )
+      .get(f.scope.sessionId, f.scope.sessionId, f.messageId) as {
+      seq: number;
+      event_json: string;
+    };
+    const writer = new DatabaseSync(database.path);
+    const parse = JSON.parse;
+    let rewrote = false;
+    const spy = vi.spyOn(JSON, "parse").mockImplementation((value, reviver) => {
+      if (!rewrote && value === JSON.stringify(other)) {
+        rewrote = true;
+        expect(database.db.isTransaction).toBe(true);
+        writer.exec("BEGIN IMMEDIATE");
+        try {
+          rewriteSqliteTranscriptEventRowsInTransaction({ ...database, db: writer }, f.scope, [
+            {
+              seq: row.seq,
+              expectedEventJson: row.event_json,
+              event: message(f.messageId, "other", []),
+            },
+          ]);
+          writer.exec("COMMIT");
+        } catch (error) {
+          writer.exec("ROLLBACK");
+          throw error;
+        }
+      }
+      return parse(value, reviver);
+    });
+    try {
+      expect(await f.download()).not.toBeNull();
+      expect(rewrote).toBe(true);
+      expect(database.db.isTransaction).toBe(false);
+    } finally {
+      spy.mockRestore();
+      writer.close();
+    }
+    expect(await f.download()).toBeNull();
+  });
+
   it.each(["fresh-message", "reset-only", "inactive-branch"] as const)(
     "rechecks archive membership after the active history becomes %s",
     async (kind) => {
@@ -177,24 +403,89 @@ describe("managed attachment SQLite visibility", () => {
     },
   );
 
-  it.each(["selected", "unrelated", "unrelated-missing"] as const)(
-    "retains records when %s history JSON is malformed",
-    async (fault) => {
+  it.each([
+    { location: "other-session", retainedCount: 2 },
+    { location: "before-reset", retainedCount: 1 },
+  ] as const)(
+    "ignores NUL-corrupt history outside the visible range: $location",
+    async ({ location, retainedCount }) => {
       const f = await fixture();
+      const corrupt = location === "other-session" ? await fixture("hidden") : f;
+      const hidden = message("hidden", null, "hidden history");
+      if (location === "other-session") {
+        await seed(corrupt, [hidden]);
+        await seed(f, [message(f.messageId, null, [f.block])]);
+      } else {
+        await seed(f, [
+          hidden,
+          { type: "reset", id: "reset", parentId: "hidden", timestamp, reason: "fresh" },
+          message(f.messageId, "reset", [f.block]),
+        ]);
+      }
+      openOpenClawAgentDatabase({ agentId: "main" })
+        .db.prepare(`UPDATE transcript_events SET event_json = event_json || ? WHERE session_id = ? AND seq = (
+          SELECT seq FROM transcript_event_identities WHERE session_id = ? AND event_id = 'hidden'
+        )`)
+        .run("\u0000trailing", corrupt.scope.sessionId, corrupt.scope.sessionId);
+      const full = await readSessionMessagesWithSourceAsync(f.scope, {
+        mode: "full",
+        reason: "excluded corrupt attachment history",
+        allowResetArchiveFallback: true,
+      });
+      expect(full.messages).toContainEqual(
+        expect.objectContaining({
+          __openclaw: expect.objectContaining({ id: f.messageId }),
+        }),
+      );
+      expect(await f.download()).not.toBeNull();
+      expect(
+        await cleanupManagedOutgoingMediaRecords({ stateDir, sessionKey: f.scope.sessionKey }),
+      ).toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount });
+    },
+  );
+
+  it.each([
+    ...(["selected", "unrelated", "unrelated-missing"] as const).flatMap((fault) =>
+      (["invalid syntax", "literal NUL"] as const).map((corruption) => ({ fault, corruption })),
+    ),
+    { fault: "unrelated", corruption: "multiple values" },
+    { fault: "unrelated", corruption: "premature envelope close" },
+  ] as const)(
+    "retains records when $fault history JSON has $corruption",
+    async ({ fault, corruption }) => {
+      const f = await fixture();
+      const unrelated = message("unrelated", "first", "unrelated content");
+      const attached = message(f.messageId, "unrelated", [f.block]);
       await seed(f, [
-        message("unrelated", null, "unrelated content"),
-        ...(fault === "unrelated-missing" ? [] : [message(f.messageId, "unrelated", [f.block])]),
+        message("first", null, "first visible content"),
+        unrelated,
+        ...(fault === "unrelated-missing" ? [] : [attached]),
       ]);
+      const sourceJson = JSON.stringify(fault === "selected" ? attached : unrelated);
+      const invalidJson = {
+        "invalid syntax": "{malformed",
+        "literal NUL": sourceJson + "\u0000trailing",
+        "multiple values": sourceJson + ",{}",
+        "premature envelope close": sourceJson + "]\u0000trailing",
+      }[corruption];
       const database = openOpenClawAgentDatabase({ agentId: "main" });
       database.db
-        .prepare(`UPDATE transcript_events SET event_json = '{malformed' WHERE session_id = ? AND seq = (
+        .prepare(`UPDATE transcript_events SET event_json = ? WHERE session_id = ? AND seq = (
         SELECT seq FROM transcript_event_identities WHERE session_id = ? AND event_id = ?
       )`)
         .run(
+          invalidJson,
           f.scope.sessionId,
           f.scope.sessionId,
           fault === "selected" ? f.messageId : "unrelated",
         );
+      await expect(
+        readSessionMessagesWithSourceAsync(f.scope, {
+          mode: "full",
+          reason: "corrupt managed attachment history",
+          allowResetArchiveFallback: true,
+        }),
+      ).rejects.toBeInstanceOf(SyntaxError);
       await expect(f.download()).rejects.toBeInstanceOf(SyntaxError);
       await expect(
         cleanupManagedOutgoingMediaRecords({ stateDir, sessionKey: f.scope.sessionKey }),

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -85,6 +85,10 @@ vi.mock("./session-utils.js", () => ({
 
 vi.mock("./session-transcript-readers.js", () => ({
   readSessionMessagesAsync: readSessionMessagesMock,
+  readSessionMessagesMatchingIdAsync: async (scope: unknown, messageId: string) =>
+    (await readSessionMessagesMock(scope)).filter(
+      (message: { __openclaw?: { id?: string } }) => message["__openclaw"]?.id === messageId,
+    ),
   readSessionMessagesWithSourceAsync: async (...args: unknown[]) => ({
     messages: await readSessionMessagesMock(...args),
   }),

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -70,7 +70,10 @@ import {
 } from "./managed-image-record-store.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "./session-request-agent.js";
-import { readSessionMessagesWithSourceAsync } from "./session-transcript-readers.js";
+import {
+  readSessionMessagesMatchingIdAsync,
+  readSessionMessagesWithSourceAsync,
+} from "./session-transcript-readers.js";
 import { loadGatewaySessionEntryReadOnly } from "./session-utils.js";
 
 const OUTGOING_IMAGE_ROUTE_PREFIX = "/api/chat/media/outgoing";
@@ -170,17 +173,6 @@ type CleanupManagedOutgoingMediaRecordsResult = {
 };
 
 type SessionManagedOutgoingAttachmentIndex = Set<string>;
-type SessionManagedOutgoingAttachmentIndexRead =
-  | { kind: "available"; index: SessionManagedOutgoingAttachmentIndex | null }
-  | {
-      kind: "unavailable";
-      reason:
-        | "database-missing"
-        | "schema-missing"
-        | "table-missing"
-        | "row-invalid"
-        | "read-failed";
-    };
 type ManagedOutgoingTranscriptMatch = "match" | "missing" | "unavailable";
 type SessionStoreAvailabilityRead = ReturnType<
   typeof resolveExistingAgentSessionStoreTargetsReadOnlyResult
@@ -1066,24 +1058,28 @@ async function loadPendingPreparedAttachmentIds(stateDir: string): Promise<Set<s
   }
 }
 
-async function getSessionManagedOutgoingAttachmentIndex(
-  sessionKey: string,
+async function recordMatchesTranscriptMessage(
+  record: ManagedImageRecord,
   cache?: Map<string, SessionManagedOutgoingAttachmentIndex | null>,
-  agentId?: string,
   storeAvailabilityCache?: Map<string, SessionStoreAvailabilityRead>,
   storeTargetsReadCache?: SessionStoreTargetsReadCache,
   stateDir?: string,
-): Promise<SessionManagedOutgoingAttachmentIndexRead> {
+): Promise<ManagedOutgoingTranscriptMatch> {
+  if (!record.messageId) {
+    return "missing";
+  }
+  const { sessionKey, agentId, messageId: requestedMessageId } = record;
+  const refKey = buildManagedOutgoingAttachmentRefKey(requestedMessageId, record.attachmentId);
   const cacheKey = buildSessionManagedOutgoingAttachmentIndexCacheKey(sessionKey, agentId);
   if (cache?.has(cacheKey)) {
-    return { kind: "available", index: cache.get(cacheKey) ?? null };
+    return cache.get(cacheKey)?.has(refKey) ? "match" : "missing";
   }
   const cfg = getRuntimeConfig();
   const ownerAgentId =
     resolveManagedSessionOwnerAgentId(sessionKey, agentId) ??
     tryResolveSessionCompatibilityOwnerAgentId(cfg, sessionKey);
   if (!ownerAgentId) {
-    return { kind: "unavailable", reason: "read-failed" };
+    return "unavailable";
   }
   const discovery =
     storeAvailabilityCache?.get(ownerAgentId) ??
@@ -1093,7 +1089,7 @@ async function getSessionManagedOutgoingAttachmentIndex(
     });
   storeAvailabilityCache?.set(ownerAgentId, discovery);
   if (!discovery.available) {
-    return { kind: "unavailable", reason: discovery.reason };
+    return "unavailable";
   }
   const usesRuntimeState = !stateDir || path.resolve(stateDir) === path.resolve(resolveStateDir());
   const env = stateDir ? { ...process.env, OPENCLAW_STATE_DIR: stateDir } : process.env;
@@ -1108,7 +1104,7 @@ async function getSessionManagedOutgoingAttachmentIndex(
       storePath: target.storePath,
     });
     if (!exact.found) {
-      return { kind: "unavailable", reason: exact.reason };
+      return "unavailable";
     }
     let targetEntry = exact.value?.entry;
     if (!targetEntry) {
@@ -1124,12 +1120,12 @@ async function getSessionManagedOutgoingAttachmentIndex(
           { readOnly: true },
         ).existing;
       } catch {
-        return { kind: "unavailable", reason: "row-invalid" };
+        return "unavailable";
       }
     }
     if (targetEntry) {
       if (matched) {
-        return { kind: "unavailable", reason: "read-failed" };
+        return "unavailable";
       }
       matched = { entry: targetEntry, storePath: target.storePath };
     }
@@ -1145,7 +1141,7 @@ async function getSessionManagedOutgoingAttachmentIndex(
       storePath: loaded.storePath,
     });
     if (!exact.found) {
-      return { kind: "unavailable", reason: exact.reason };
+      return "unavailable";
     }
     entry = exact.value?.entry ?? loaded.entry;
     storePath = loaded.storePath;
@@ -1153,25 +1149,21 @@ async function getSessionManagedOutgoingAttachmentIndex(
   const sessionId = entry?.sessionId;
   if (!sessionId) {
     cache?.set(cacheKey, null);
-    return { kind: "available", index: null };
+    return "missing";
   }
 
   // Archive file stats cannot establish current SQLite visibility. Reuse membership
   // only within a cleanup pass; each new request must select canonical history again.
-  const { messages } = await readSessionMessagesWithSourceAsync(
-    {
-      agentId,
-      sessionEntry: entry,
-      sessionId,
-      sessionKey,
-      storePath,
-    },
-    {
-      mode: "full",
-      reason: "managed outgoing attachment index",
-      allowResetArchiveFallback: true,
-    },
-  );
+  const scope = { agentId, sessionEntry: entry, sessionId, sessionKey, storePath };
+  const messages = cache
+    ? (
+        await readSessionMessagesWithSourceAsync(scope, {
+          mode: "full",
+          reason: "managed outgoing attachment index",
+          allowResetArchiveFallback: true,
+        })
+      ).messages
+    : await readSessionMessagesMatchingIdAsync(scope, requestedMessageId);
   const index: SessionManagedOutgoingAttachmentIndex = new Set();
   for (const message of messages) {
     const meta = (message as { __openclaw?: { id?: string } } | null)?.["__openclaw"];
@@ -1188,35 +1180,7 @@ async function getSessionManagedOutgoingAttachmentIndex(
   }
 
   cache?.set(cacheKey, index);
-  return { kind: "available", index };
-}
-
-async function recordMatchesTranscriptMessage(
-  record: ManagedImageRecord,
-  cache?: Map<string, SessionManagedOutgoingAttachmentIndex | null>,
-  storeAvailabilityCache?: Map<string, SessionStoreAvailabilityRead>,
-  storeTargetsReadCache?: SessionStoreTargetsReadCache,
-  stateDir?: string,
-): Promise<ManagedOutgoingTranscriptMatch> {
-  if (!record.messageId) {
-    return "missing";
-  }
-  const read = await getSessionManagedOutgoingAttachmentIndex(
-    record.sessionKey,
-    cache,
-    record.agentId,
-    storeAvailabilityCache,
-    storeTargetsReadCache,
-    stateDir,
-  );
-  if (read.kind === "unavailable") {
-    return "unavailable";
-  }
-  return read.index?.has(
-    buildManagedOutgoingAttachmentRefKey(record.messageId, record.attachmentId),
-  )
-    ? "match"
-    : "missing";
+  return index.has(refKey) ? "match" : "missing";
 }
 
 async function resolveManagedOutgoingMediaArtifactDownloadForRecord(

--- a/src/gateway/session-transcript-index.fs.ts
+++ b/src/gateway/session-transcript-index.fs.ts
@@ -9,6 +9,7 @@ import {
   createTranscriptDisplayPosition,
   createTranscriptDisplaySource,
 } from "../sessions/transcript-display-position.js";
+import { isVisibleTranscriptRecord } from "../sessions/transcript-visible-record.js";
 import {
   parseTranscriptRecord,
   type TranscriptRecord,
@@ -48,10 +49,6 @@ export function assertArchiveTranscriptSource(
   if (transcriptArtifactDisplaySource(filePath, stat) !== displaySource) {
     throw new SessionTranscriptProjectionUnavailableError(sessionId);
   }
-}
-
-export function isVisibleTranscriptRecord(record: Record<string, unknown>): boolean {
-  return Boolean(record.message) || record.type === "compaction" || record.type === "reset";
 }
 
 export function selectArchiveTranscriptEntries<T extends TranscriptRecord>(

--- a/src/gateway/session-transcript-message.ts
+++ b/src/gateway/session-transcript-message.ts
@@ -1,5 +1,6 @@
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { TranscriptDisplayPosition } from "../chat/transcript-display-position.js";
+import { isVisibleTranscriptRecord } from "../sessions/transcript-visible-record.js";
 import {
   createCurrentUserProfileMessageProjector,
   projectChatDisplayMessage,
@@ -114,10 +115,10 @@ export function projectTranscriptEntryMessage(
   seq: number,
   transcriptPosition?: TranscriptDisplayPosition,
 ): unknown {
-  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+  if (!isVisibleTranscriptRecord(entry)) {
     return null;
   }
-  const record = entry as Record<string, unknown>;
+  const record = entry;
   if (record.message) {
     const recordTimestampMs =
       typeof record.timestamp === "string"

--- a/src/gateway/session-transcript-readers.markers.test.ts
+++ b/src/gateway/session-transcript-readers.markers.test.ts
@@ -11,6 +11,7 @@ import {
   readSessionMessageByIdAsync,
   readSessionMessageCountAsync,
   readSessionMessagesAsync,
+  readSessionMessagesMatchingIdAsync,
   readSessionMessagesPageWithStatsAsync,
   visitSessionMessagesAsync,
   type SessionTranscriptReadScope,
@@ -193,6 +194,7 @@ describe("session transcript reader marker projection", () => {
         messageId: id,
         maxMessages: 10,
       });
+      expect(await readSessionMessagesMatchingIdAsync(scope, id)).toEqual([full[index]]);
       expect(messageIds(page.messages)).toEqual([id]);
       expect(page.totalMessages).toBe(fixture.expectedIds.length);
       expect(byId).toMatchObject({ found: true, seq: index + 1 });
@@ -217,6 +219,7 @@ describe("session transcript reader marker projection", () => {
     for (const { id } of fixture.events.filter(
       (event) => !fixture.expectedIds.includes(event.id),
     )) {
+      expect(await readSessionMessagesMatchingIdAsync(scope, id)).toEqual([]);
       expect(await readSessionMessageByIdAsync(scope, id)).toMatchObject({ found: false });
       expect(
         await readSessionMessagesAroundIdWithStatsAsync(scope, { messageId: id, maxMessages: 10 }),

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -17,6 +17,7 @@ import {
   readRecentSessionTranscriptHistoryEvents,
   readSessionTranscriptHistoryEventById,
   readSessionTranscriptHistoryEventCount,
+  readSessionTranscriptHistoryEventLookup,
   readSessionTranscriptHistoryEventPage,
   readSessionTranscriptHistoryEvents,
 } from "../config/sessions/session-accessor.sqlite-history-events.js";
@@ -277,6 +278,24 @@ export async function readSessionMessageByIdAsync(
     });
   }
   return { found: false, oversized: false };
+}
+
+/** Read exact membership while retaining full-history validity and empty-only archive fallback. */
+export async function readSessionMessagesMatchingIdAsync(
+  scope: SessionTranscriptReadScope,
+  messageId: string,
+): Promise<unknown[]> {
+  const target = resolveTranscriptReadTarget(scope);
+  const lookup = readSessionTranscriptHistoryEventLookup(toTranscriptReadScope(target), messageId);
+  const messages = lookup.hasDisplayMessages
+    ? projectSqliteHistoryEvents(lookup.events)
+    : await archivedTranscriptReader(target).readMessageCandidatesById(messageId, {
+        allowResetArchiveFallback: true,
+        resetArchiveOnly: true,
+      });
+  return messages.filter(
+    (message) => asOptionalRecord(asOptionalRecord(message)?.["__openclaw"])?.id === messageId,
+  );
 }
 
 /** Visits raw message payloads within the SQLite read snapshot. */

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -11,6 +11,7 @@ import type { TranscriptEvent } from "../config/sessions/session-accessor.js";
 import { streamSessionTranscriptLines } from "../config/sessions/transcript-stream.js";
 import { readFileWindowFully } from "../infra/file-read.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
+import { isVisibleTranscriptRecord } from "../sessions/transcript-visible-record.js";
 import { projectSessionDisplayMessage } from "./session-display-projection.js";
 import {
   aggregateSessionTranscriptUsage,
@@ -22,7 +23,6 @@ import {
 } from "./session-transcript-files.fs.js";
 import {
   assertArchiveTranscriptSource,
-  isVisibleTranscriptRecord,
   readSessionTranscriptIndex,
   selectArchiveTranscriptEntries,
   type IndexedTranscriptEntry,
@@ -277,6 +277,26 @@ export class ArchivedTranscriptReader {
       oversized: false,
       found: true,
     };
+  }
+
+  async readMessageCandidatesById(
+    messageId: string,
+    opts: { allowResetArchiveFallback?: boolean; resetArchiveOnly?: boolean },
+  ): Promise<unknown[]> {
+    const artifact = await this.resolveArtifact(opts);
+    if (!artifact) {
+      return [];
+    }
+    const index = await readSessionTranscriptIndex(artifact.path, this.scope.sessionId);
+    // Preserve duplicate/oversized full-reader entries and ID-less rows whose
+    // projected metadata can supply the ID. The caller matches after projection.
+    return (
+      index?.entries.flatMap((entry) =>
+        typeof entry.record.id !== "string" || entry.record.id === messageId
+          ? indexedTranscriptEntryToMessages(entry)
+          : [],
+      ) ?? []
+    );
   }
 
   async readRecentWithStats(

--- a/src/sessions/transcript-visible-record.ts
+++ b/src/sessions/transcript-visible-record.ts
@@ -1,0 +1,6 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+
+export function isVisibleTranscriptRecord(value: unknown): value is Record<string, unknown> {
+  const record = asOptionalRecord(value);
+  return Boolean(record?.message) || record?.type === "compaction" || record?.type === "reset";
+}


### PR DESCRIPTION
Related: #138377

## What Problem This Solves

Attachment downloads from long conversations deserialize the entire visible transcript for each image, thumbnail, or artifact request. Repeated downloads therefore allocate large message arrays and occupy the Gateway event loop even when only one message owns the requested attachment.

## Why This Change Was Made

The canonical transcript reader now selects the requested record and determines whether current history projects any messages in one existing read snapshot. It validates the complete visible history through SQLite, routes unsupported or malformed JSON through the existing parser, and preserves raw/projected IDs, reset boundaries, display positions, and admission fences. Archive fallback remains limited to projected-empty current history; cleanup retains its existing full-history scan.

The old single-consumer membership wrapper is absorbed into its owner. Production grows by 127 lines to keep selective lookup and full-reader validity in one place; tests grow by 298 lines. Database schemas, indexes, configuration, and retention policy are unchanged.

## User Impact

Users can retrieve attachments from large histories with less CPU work. Changing the active transcript still invalidates attachment access, including previously issued image tickets.

## Evidence

The full Linux/build/live comparison below tested commit `a071ef489c3c52f7f5609e4df968281fb0b5db15` (tree `cde7009a35981389c98b4c46725d835f8e0c8db7`). Follow-up commit `92be95ff10708ceae81b0595e560e8dc5551d2b5` replaces two equivalent raw SQLite expressions with Kysely function/binary builders after hosted CI identified a guardrail violation. It preserves the selected rows and removes the raw-expression exceptions. The new expression passed 51 native SQLite row cases across UTF-8, UTF-16LE, and UTF-16BE, the Kysely guard, and all 145 owner tests. The earlier build/live timings belong to the original tested commit.

The regression demonstrates that resolving one attachment decoded 40 unrelated 16KiB payloads before the change; the candidate decodes at most one unrelated payload to establish projected presence. Coverage also exercises malformed and literal-NUL JSON, sparse reset/compaction windows, missing IDs, legacy embedded IDs, duplicate/oversized archive entries, and a real second SQLite connection rewriting history during the read.

A Linux Node 24.19.0 comparison on four logical CPUs used the same synthetic 10,000-message histories, restored state, and 12 warm samples per case. Returned artifact metadata was identical after excluding the time-dependent ticket and expiry:

| History | Baseline median wall / CPU | Candidate median wall / CPU |
| --- | ---: | ---: |
| Active | 54.77 / 77.84 ms | 37.56 / 38.37 ms |
| Archive | 5.95 / 6.05 ms | 0.95 / 1.15 ms |
| Reset | 0.76 / 1.00 ms | 0.90 / 1.15 ms |

The benchmark uses synthetic data and fixed order. Native validation still scales with visible history size. Both builds reported CPU or event-loop-utilization degradation in sampled readiness snapshots during the fixture; all readiness probes succeeded, with maxima of 82.8 ms before and 108.2 ms after. General event-loop stability and production impact require continued measurement after deployment.

- Original `a071ef4` focused tests: 145 passed across three suites; targeted type-aware lint passed.
- Independent P2 review: two complete evidence passes plus a focused follow-up review of the Kysely builders; no actionable findings.
- Original `a071ef4` Linux proof: 239 tests across six files; full `check:changed`; baseline and candidate `pnpm build`; all passed on [Testbox run 33942216065](https://github.com/openclaw/openclaw/actions/runs/33942216065).
- Built Gateway proof: 39 sampled download rounds and 18 control results per variant. Each round exercises `artifacts.download` plus ticket and bearer HTTP reads. Attachment bytes match, a real transcript rewrite revokes full/thumbnail access, and both Gateways exit cleanly. Active-history RPC median improved from 55.37 to 39.01 ms; ticketed HTTP from 61.23 to 38.37 ms.
- Complete source inventories remained unchanged before and after builds and live execution. Evidence was hash-verified before the owned Testbox was stopped and confirmed completed.

The first full gate identified four test-style lint errors; all were corrected before the final run. Its connection also dropped while the original remote process continued. The original process outcomes and hash-verified artifacts were recovered, and that lease was closed. Full proof archives are collected through the canonical prepared-workspace binding using the supported download command.

Initial hosted CI also failed while downloading the Matrix crypto dependency (`ECONNRESET`, then its downloader error handler threw); the Control UI performance test had not started. The initial run also failed a session-observer timer-count assertion (expected 0, observed 1); its provenance is being investigated independently. An additional local type-aware lint attempt timed out after 300 seconds during plugin SDK declaration preparation, before lint ran. The refreshed head passed hosted type/lint and all required CI in [run 33946422854](https://github.com/openclaw/openclaw/actions/runs/33946422854), including the previously failing observer shard. The separate investigation of that original timer failure continues.
