### PR TITLE
fix(ci): wait for the destination pane in model picker tests

### DIFF
--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -1,6 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import type { Locator } from "playwright";
 import { expect, it } from "vitest";
+import type { ChatPaneElement } from "../pages/chat/route-draft-focus-handoff.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import {
@@ -544,22 +545,16 @@ suite.define(() => {
       await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:session-a"));
 
       const main = page.getByRole("main");
-      const openModelSelect = async () => {
-        const trigger = main.locator(
-          'openclaw-chat-pane[aria-hidden="false"] [data-chat-model-select="true"]',
-        );
-        await trigger.waitFor({ state: "visible", timeout: 10_000 });
-        return trigger;
-      };
+      const activePane = main.locator('openclaw-chat-pane[aria-hidden="false"]');
+      const modelSelect = activePane.locator('[data-chat-model-select="true"]');
       const selectModel = async (value: string) => {
-        const activePane = main.locator('openclaw-chat-pane[aria-hidden="false"]');
         await activePane.locator('[data-chat-model-select="true"]').click();
         const option = activePane.locator(`[data-chat-model-option="${value}"]`);
         await option.waitFor({ state: "visible", timeout: 10_000 });
         await option.click();
       };
 
-      let modelSelect = await openModelSelect();
+      await modelSelect.waitFor({ state: "visible", timeout: 10_000 });
       expect(await modelSelect.getAttribute("data-chat-select-value")).toBe("");
 
       await selectModel("bedrock/claude-opus-4.5");
@@ -580,7 +575,10 @@ suite.define(() => {
       await page.locator(".sidebar-recent-session--active").getByText("Session B").waitFor({
         timeout: 10_000,
       });
-      modelSelect = await openModelSelect();
+      await expect
+        .poll(() => activePane.evaluate((pane) => (pane as ChatPaneElement).sessionKey))
+        .toBe("agent:main:session-b");
+      await modelSelect.waitFor({ state: "visible", timeout: 10_000 });
       expect(await modelSelect.getAttribute("data-chat-select-value")).toBe("");
 
       await page
@@ -591,8 +589,11 @@ suite.define(() => {
       await page.locator(".sidebar-recent-session--active").getByText("Session A").waitFor({
         timeout: 10_000,
       });
+      await expect
+        .poll(() => activePane.evaluate((pane) => (pane as ChatPaneElement).sessionKey))
+        .toBe("agent:main:session-a");
 
-      modelSelect = await openModelSelect();
+      await modelSelect.waitFor({ state: "visible", timeout: 10_000 });
       expect(await modelSelect.getAttribute("data-chat-select-value")).toBe(
         "bedrock/claude-opus-4.5",
       );
@@ -810,6 +811,9 @@ suite.define(() => {
       await page.locator(".sidebar-recent-session--active").getByText("Explicit Sol").waitFor({
         timeout: 10_000,
       });
+      await expect
+        .poll(() => activePane.evaluate((pane) => (pane as ChatPaneElement).sessionKey))
+        .toBe("agent:main:session-explicit");
       await modelSelect.click();
       await expect.poll(() => modelOption.count()).toBe(1);
       await expect


### PR DESCRIPTION
Related: #138759

## What Problem This Solves

Resolves a problem where the Control UI model-picker browser tests interact with the previous retained chat pane after the sidebar has already selected the destination session. The stale pane remains attached, so Playwright can keep retrying a click against the wrong element until the test times out.

## Why This Change Was Made

Wait for the active pane's exact destination session key at all three affected navigation boundaries, then retain the existing visibility waits and model/reasoning assertions. Reuse the live locator and remove the redundant helper. No retries, timeouts, force-click behavior, or production code changes.

The separately discovered dashboard fixture defects are already fixed upstream by #138769 and #138793 and are not included here.

## User Impact

No product behavior change. This repairs CI synchronization for retained-pane navigation. Production LOC: **0**. Tests: **15 added / 11 removed, net +4**.

## Evidence

- Original local shard: 291 passed / 1 failed, with the model-picker click retrying against the retained previous pane. Inspected Playwright's installed pointer-retry and selector re-resolution implementation.
- Final one-file candidate on `185ca0df6328de3b27a56de083a0a8e9df2a0871`: all **13 browser cases passed**, no skips; focused lint passed with no warnings or errors.
- Browser proof uses signed local Chrome and synthetic mocked Gateway traffic, not a live provider or Linux-parity claim. This is test-only synchronization, with no visual product change.
- Independent managed Codex review: no actionable P0–P2 findings; canonical helper exited 0. A supplemental raw Git index hash guard changed, but all 37,942 semantic index entries matched HEAD, the staged diff remained empty, and source/context hashes were unchanged. The metadata mismatch is retained in local evidence rather than reported as a fully clean wrapper exit.
- Earlier local whole-tree dead-export checking hit its outer deadline and remains incomplete. Exact-head hosted CI must complete the full gate before landing; the focused results do not substitute for it.
