### PR TITLE
Voice-call: add opt-in Twilio call recording

### DIFF
--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -834,6 +834,14 @@ describe("voice-call plugin", () => {
       state: "completed",
       endReason: "completed",
       endedAt: Date.UTC(2026, 4, 2, 9, 18, 23),
+      recording: {
+        sid: "RE123",
+        url: "https://api.twilio.com/recordings/RE123",
+        status: "completed",
+        durationSeconds: 18,
+        channels: 2,
+        updatedAt: Date.UTC(2026, 4, 2, 9, 18, 25),
+      },
     });
     runtimeStub.manager.getCallFromMemoryOrStore = vi.fn(async () => completed);
     const { tools } = setup({ provider: "mock" });
@@ -843,10 +851,16 @@ describe("voice-call plugin", () => {
     const result = (await tool.execute("id", {
       action: "get_status",
       callId: "call-1",
-    })) as { details: { found?: boolean; call?: { state?: string } } };
+    })) as {
+      details: {
+        found?: boolean;
+        call?: { state?: string; recording?: { sid?: string; status?: string } };
+      };
+    };
     expect(runtimeStub.manager["getCallFromMemoryOrStore"]).toHaveBeenCalledWith("call-1");
     expect(result.details.found).toBe(true);
     expect(result.details.call?.state).toBe("completed");
+    expect(result.details.call?.recording).toMatchObject({ sid: "RE123", status: "completed" });
   });
 
   it("tool get_status reports found:false when the call is neither active nor persisted", async () => {

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -53,6 +53,7 @@ const VoiceCallToolSchema = Type.Union([
     mode: Type.Optional(Type.Union([Type.Literal("notify"), Type.Literal("conversation")])),
     sessionKey: Type.Optional(Type.String({ description: "OpenClaw session key for the call" })),
     dtmfSequence: Type.Optional(Type.String({ description: "DTMF digits to play before connect" })),
+    record: Type.Optional(Type.Boolean({ description: "Record this call (Twilio only)" })),
   }),
   Type.Object({
     action: Type.Literal("continue_call"),
@@ -84,6 +85,7 @@ const VoiceCallToolSchema = Type.Union([
     message: Type.Optional(Type.String({ description: "Optional intro message" })),
     sessionKey: Type.Optional(Type.String({ description: "OpenClaw session key for the call" })),
     dtmfSequence: Type.Optional(Type.String({ description: "DTMF digits to play before connect" })),
+    record: Type.Optional(Type.Boolean({ description: "Record this call (Twilio only)" })),
   }),
 ]);
 
@@ -332,6 +334,7 @@ export default definePluginEntry({
             params?.mode === "notify" || params?.mode === "conversation" ? params.mode : undefined,
           sessionKey: normalizeOptionalString(params?.sessionKey),
           requesterSessionKey: normalizeOptionalString(params?.requesterSessionKey),
+          record: params?.record === true,
         });
       },
       VOICE_CALL_WRITE_METHOD_SCOPE,
@@ -438,6 +441,7 @@ export default definePluginEntry({
           sessionKey: normalizeOptionalString(params?.sessionKey),
           requesterSessionKey: normalizeOptionalString(params?.requesterSessionKey),
           agentId: normalizedAgentId,
+          record: params?.record === true,
         });
       },
       VOICE_CALL_WRITE_METHOD_SCOPE,
@@ -479,6 +483,7 @@ export default definePluginEntry({
                     sessionKey: normalizeOptionalString(rawParams.sessionKey),
                     agentId,
                     requesterSessionKey,
+                    record: rawParams.record === true,
                   }),
                 );
               }
@@ -533,6 +538,7 @@ export default definePluginEntry({
                 sessionKey: normalizeOptionalString(rawParams.sessionKey),
                 agentId,
                 requesterSessionKey,
+                record: rawParams.record === true,
               },
               "to required for call",
             ),

--- a/extensions/voice-call/src/command-service.ts
+++ b/extensions/voice-call/src/command-service.ts
@@ -15,6 +15,7 @@ type VoiceCallStatus = Pick<
   | "answeredAt"
   | "endedAt"
   | "endReason"
+  | "recording"
 >;
 
 export class VoiceCallCommandInputError extends Error {}
@@ -30,6 +31,7 @@ function toVoiceCallStatus(call: CallRecord): VoiceCallStatus {
     ...(call.answeredAt !== undefined ? { answeredAt: call.answeredAt } : {}),
     ...(call.endedAt !== undefined ? { endedAt: call.endedAt } : {}),
     ...(call.endReason !== undefined ? { endReason: call.endReason } : {}),
+    ...(call.recording !== undefined ? { recording: call.recording } : {}),
   };
 }
 
@@ -100,6 +102,7 @@ export function createVoiceCallCommandService(ensureRuntime: () => Promise<Voice
         dtmfSequence?: string;
         requesterSessionKey?: string;
         agentId?: string;
+        record?: boolean;
       },
       missingToMessage = "to required",
     ) {
@@ -111,6 +114,7 @@ export function createVoiceCallCommandService(ensureRuntime: () => Promise<Voice
         dtmfSequence: params.dtmfSequence,
         ...(params.requesterSessionKey ? { requesterSessionKey: params.requesterSessionKey } : {}),
         ...(params.agentId ? { agentId: params.agentId } : {}),
+        ...(params.record ? { record: true } : {}),
       });
       requireSuccess(result, "initiate failed");
       return { callId: result.callId, initiated: true };

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -13,7 +13,7 @@ import type { CallRecord, HangupCallInput, NormalizedEvent } from "../types.js";
 import { processEvent } from "./events.js";
 import { speakInitialMessage } from "./outbound.js";
 import { MAX_CALL_REPLAY_KEYS } from "./replay-keys.js";
-import { persistCallRecord } from "./store.js";
+import { findCallInStore, persistCallRecord } from "./store.js";
 
 const logSpy = vi.hoisted(() => {
   const logEntries: string[] = [];
@@ -688,6 +688,51 @@ describe("processEvent (functional)", () => {
         digits: "1",
       }),
     ).toEqual({ kind: "ignored" });
+  });
+
+  it("persists a recording callback that arrives after the call ended", () => {
+    const ctx = createContext();
+    const endedAt = Date.now();
+    persistCallRecord(ctx.storePath, {
+      callId: "call-recorded",
+      providerCallId: "CA-recorded",
+      provider: "twilio",
+      direction: "outbound",
+      state: "completed",
+      from: "+15550000000",
+      to: "+15550000001",
+      startedAt: endedAt - 30_000,
+      endedAt,
+      endReason: "completed",
+      transcript: [],
+      processedEventIds: [],
+      metadata: { recordingRequested: true },
+    });
+
+    const result = processEvent(ctx, {
+      id: "evt-recording-completed",
+      dedupeKey: "recording:RE123:completed",
+      type: "call.recording",
+      callId: "call-recorded",
+      providerCallId: "CA-recorded",
+      timestamp: endedAt + 1_000,
+      recordingSid: "RE123",
+      recordingUrl: "https://api.twilio.com/recordings/RE123",
+      status: "completed",
+      durationSeconds: 28,
+      channels: 2,
+    });
+
+    expect(result).toEqual({ kind: "processed" });
+    expect(findCallInStore(ctx.storePath, "call-recorded")?.recording).toEqual({
+      sid: "RE123",
+      url: "https://api.twilio.com/recordings/RE123",
+      status: "completed",
+      durationSeconds: 28,
+      channels: 2,
+      updatedAt: endedAt + 1_000,
+    });
+    expect(ctx.processedEventIds.has("recording:RE123:completed")).toBe(true);
   });
 
   it("keeps retryable call.error events replayable", () => {

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -177,6 +177,21 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
     if (!retained && providerCallId && providerCallId !== event.callId) {
       retained = findCallInStore(ctx.storePath, providerCallId);
     }
+    if (retained && event.type === "call.recording") {
+      retained.recording = {
+        sid: event.recordingSid,
+        ...(event.recordingUrl ? { url: event.recordingUrl } : {}),
+        status: event.status,
+        ...(event.durationSeconds !== undefined ? { durationSeconds: event.durationSeconds } : {}),
+        ...(event.channels !== undefined ? { channels: event.channels } : {}),
+        ...(event.errorCode ? { errorCode: event.errorCode } : {}),
+        updatedAt: event.timestamp,
+      };
+      appendCallReplayKey(retained.processedEventIds, dedupeKey);
+      persistCallRecord(ctx.storePath, retained);
+      rememberManagerReplayKey(ctx.processedEventIds, dedupeKey);
+      return { kind: "processed" };
+    }
     // A policy rejection records an attempt, not confirmed carrier termination.
     if (retained && retained.metadata?.rejectionReason !== "inbound-policy") {
       call = ctx.activeCalls.get(retained.callId);
@@ -262,6 +277,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
     answeredAt: activeCall.answeredAt,
     endedAt: activeCall.endedAt,
     endReason: activeCall.endReason,
+    recording: activeCall.recording,
     transcriptLength: activeCall.transcript.length,
     processedEventIds: [...activeCall.processedEventIds],
   };
@@ -397,6 +413,20 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
       case "call.dtmf":
         break;
 
+      case "call.recording":
+        activeCall.recording = {
+          sid: event.recordingSid,
+          ...(event.recordingUrl ? { url: event.recordingUrl } : {}),
+          status: event.status,
+          ...(event.durationSeconds !== undefined
+            ? { durationSeconds: event.durationSeconds }
+            : {}),
+          ...(event.channels !== undefined ? { channels: event.channels } : {}),
+          ...(event.errorCode ? { errorCode: event.errorCode } : {}),
+          updatedAt: event.timestamp,
+        };
+        break;
+
       case "call.ended":
         finalizeCall({
           ctx,
@@ -439,6 +469,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
       answeredAt: previousCall.answeredAt,
       endedAt: previousCall.endedAt,
       endReason: previousCall.endReason,
+      recording: previousCall.recording,
     });
     activeCall.transcript.length = previousCall.transcriptLength;
     activeCall.processedEventIds.splice(

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -169,6 +169,14 @@ export async function initiateCall(
     return { callId: "", success: false, error: "Webhook URL not configured" };
   }
 
+  if (opts.record && ctx.provider.name !== "twilio") {
+    return {
+      callId: "",
+      success: false,
+      error: `${ctx.provider.name} does not support call recording`,
+    };
+  }
+
   if (ctx.activeCalls.size >= ctx.config.maxConcurrentCalls) {
     return {
       callId: "",
@@ -206,6 +214,7 @@ export async function initiateCall(
       ...(initialMessage && { initialMessage }),
       mode,
       ...(requesterSessionKey ? { requesterSessionKey } : {}),
+      ...(opts.record ? { recordingRequested: true } : {}),
     },
   };
 
@@ -246,6 +255,7 @@ export async function initiateCall(
       webhookUrl: ctx.webhookUrl,
       inlineTwiml,
       preConnectTwiml,
+      record: opts.record,
       ...(streamSession
         ? { streamUrl: streamSession.streamUrl, streamAuthToken: streamSession.token }
         : {}),

--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -278,6 +278,74 @@ describe("TwilioProvider", () => {
       "https://example.ngrok.app/voice/webhook?callId=call-1&type=status",
     );
     expect(params).not.toHaveProperty("Twiml");
+    expect(params).not.toHaveProperty("Record");
+  });
+
+  it("requests dual-channel recording and normalizes the completion callback", async () => {
+    const provider = createProvider();
+    const apiRequest = createApiRequestMock(async () => ({ sid: "CA123", status: "queued" }));
+    (
+      provider as unknown as {
+        apiRequest: TwilioApiRequest;
+      }
+    ).apiRequest = apiRequest;
+
+    await provider.initiateCall({
+      callId: "call-recorded",
+      from: "+14155550100",
+      to: "+14155550123",
+      webhookUrl: "https://example.ngrok.app/voice/webhook",
+      record: true,
+    });
+
+    const [, params] = expectDefined(apiRequest.mock.calls[0], "Twilio API call");
+    expect(params).toMatchObject({
+      Record: "true",
+      RecordingChannels: "dual",
+      RecordingTrack: "both",
+      RecordingStatusCallback:
+        "https://example.ngrok.app/voice/webhook?callId=call-recorded&type=recording",
+      RecordingStatusCallbackEvent: ["completed", "absent"],
+    });
+
+    const callback = provider.parseWebhookEvent(
+      createContext(
+        "CallSid=CA123&RecordingSid=RE123&RecordingStatus=completed&RecordingUrl=https%3A%2F%2Fapi.twilio.com%2Frecordings%2FRE123&RecordingDuration=42&RecordingChannels=2",
+        { callId: "call-recorded", type: "recording" },
+      ),
+    );
+
+    expect(callback.events).toEqual([
+      expect.objectContaining({
+        type: "call.recording",
+        callId: "call-recorded",
+        providerCallId: "CA123",
+        recordingSid: "RE123",
+        recordingUrl: "https://api.twilio.com/recordings/RE123",
+        status: "completed",
+        durationSeconds: 42,
+        channels: 2,
+      }),
+    ]);
+  });
+
+  it("keeps recorded call status callbacks on the terminal lifecycle path", () => {
+    const provider = createProvider();
+    const callback = provider.parseWebhookEvent(
+      createContext(
+        "CallSid=CA123&CallStatus=completed&RecordingSid=RE123&RecordingUrl=https%3A%2F%2Fapi.twilio.com%2Frecordings%2FRE123&RecordingDuration=42",
+        { callId: "call-recorded", type: "status" },
+      ),
+    );
+
+    expect(callback.events).toEqual([
+      expect.objectContaining({
+        type: "call.ended",
+        callId: "call-recorded",
+        providerCallId: "CA123",
+        reason: "completed",
+      }),
+    ]);
   });
 
   it("returns streaming TwiML for outbound conversation calls before in-progress", () => {

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -35,6 +35,10 @@ import { guardedJsonApiRequest } from "./shared/guarded-json-api.js";
 import { resolveTwilioApiBaseUrl, type TwilioRegion } from "./twilio-region.js";
 import type { TwilioProviderOptions } from "./twilio.types.js";
 import { TwilioApiError, twilioApiRequest } from "./twilio/api.js";
+import {
+  buildTwilioRecordingRequestFields,
+  normalizeTwilioRecordingEvent,
+} from "./twilio/recording.js";
 import { decideTwimlResponse, readTwimlRequestView } from "./twilio/twiml-policy.js";
 import { verifyTwilioProviderWebhook } from "./twilio/webhook.js";
 export type { TwilioProviderOptions } from "./twilio.types.js";
@@ -289,11 +293,13 @@ export class TwilioProvider implements VoiceCallProvider {
       const params = new URLSearchParams(ctx.rawBody);
       const callIdFromQuery = normalizeOptionalString(ctx.query?.callId);
       const turnTokenFromQuery = normalizeOptionalString(ctx.query?.turnToken);
+      const callbackType = normalizeOptionalString(ctx.query?.type);
       const dedupeKey = createTwilioRequestDedupeKey(ctx, options?.verifiedRequestKey);
       const event = this.normalizeEvent(params, {
         callIdOverride: callIdFromQuery,
         dedupeKey,
         turnToken: turnTokenFromQuery,
+        callbackType,
       });
 
       if (
@@ -351,6 +357,7 @@ export class TwilioProvider implements VoiceCallProvider {
       callIdOverride?: string;
       dedupeKey?: string;
       turnToken?: string;
+      callbackType?: string;
     },
   ): NormalizedEvent | null {
     const callSid = params.get("CallSid") || "";
@@ -367,6 +374,13 @@ export class TwilioProvider implements VoiceCallProvider {
       from: params.get("From") || undefined,
       to: params.get("To") || undefined,
     };
+
+    if (options?.callbackType === "recording") {
+      const recordingEvent = normalizeTwilioRecordingEvent(params, baseEvent);
+      if (recordingEvent) {
+        return recordingEvent;
+      }
+    }
 
     // Handle speech result (from <Gather>)
     const speechResult = params.get("SpeechResult");
@@ -577,6 +591,11 @@ export class TwilioProvider implements VoiceCallProvider {
       StatusCallback: statusUrl.toString(),
       StatusCallbackEvent: ["initiated", "ringing", "answered", "completed"],
       Timeout: "30",
+      ...buildTwilioRecordingRequestFields({
+        webhookUrl: input.webhookUrl,
+        callId: input.callId,
+        record: input.record,
+      }),
     };
 
     if (input.inlineTwiml) {

--- a/extensions/voice-call/src/providers/twilio/recording.ts
+++ b/extensions/voice-call/src/providers/twilio/recording.ts
@@ -1,0 +1,55 @@
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { NormalizedEvent } from "../../types.js";
+
+type RecordingEvent = Extract<NormalizedEvent, { type: "call.recording" }>;
+type RecordingEventBase = Omit<
+  RecordingEvent,
+  "type" | "recordingSid" | "recordingUrl" | "status" | "durationSeconds" | "channels" | "errorCode"
+>;
+
+export function normalizeTwilioRecordingEvent(
+  params: URLSearchParams,
+  baseEvent: RecordingEventBase,
+): RecordingEvent | null {
+  const recordingSid = normalizeOptionalString(params.get("RecordingSid"));
+  if (!recordingSid) {
+    return null;
+  }
+  const rawStatus = normalizeOptionalString(params.get("RecordingStatus"));
+  const status =
+    rawStatus === "in-progress" || rawStatus === "completed" || rawStatus === "absent"
+      ? rawStatus
+      : "failed";
+  const duration = Number.parseInt(params.get("RecordingDuration") ?? "", 10);
+  const channels = Number.parseInt(params.get("RecordingChannels") ?? "", 10);
+  return {
+    ...baseEvent,
+    type: "call.recording",
+    recordingSid,
+    recordingUrl: normalizeOptionalString(params.get("RecordingUrl")),
+    status,
+    durationSeconds: Number.isFinite(duration) && duration >= 0 ? duration : undefined,
+    channels: Number.isFinite(channels) && channels > 0 ? channels : undefined,
+    errorCode: normalizeOptionalString(params.get("ErrorCode")),
+  };
+}
+
+export function buildTwilioRecordingRequestFields(params: {
+  webhookUrl: string;
+  callId: string;
+  record?: boolean;
+}): Record<string, string | string[]> {
+  if (!params.record) {
+    return {};
+  }
+  const callbackUrl = new URL(params.webhookUrl);
+  callbackUrl.searchParams.set("callId", params.callId);
+  callbackUrl.searchParams.set("type", "recording");
+  return {
+    Record: "true",
+    RecordingChannels: "dual",
+    RecordingTrack: "both",
+    RecordingStatusCallback: callbackUrl.toString(),
+    RecordingStatusCallbackEvent: ["completed", "absent"],
+  };
+}

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -124,6 +124,15 @@ const NormalizedEventSchema = z.discriminatedUnion("type", [
     digits: z.string(),
   }),
   BaseEventSchema.extend({
+    type: z.literal("call.recording"),
+    recordingSid: z.string(),
+    recordingUrl: z.string().optional(),
+    status: z.enum(["in-progress", "completed", "absent", "failed"]),
+    durationSeconds: z.number().int().nonnegative().optional(),
+    channels: z.number().int().positive().optional(),
+    errorCode: z.string().optional(),
+  }),
+  BaseEventSchema.extend({
     type: z.literal("call.ended"),
     reason: EndReasonSchema,
   }),
@@ -153,6 +162,15 @@ const TranscriptEntrySchema = z.object({
 });
 export type TranscriptEntry = z.infer<typeof TranscriptEntrySchema>;
 
+const CallRecordingSchema = z.object({
+  sid: z.string(),
+  url: z.string().optional(),
+  status: z.enum(["in-progress", "completed", "absent", "failed"]),
+  durationSeconds: z.number().int().nonnegative().optional(),
+  channels: z.number().int().positive().optional(),
+  errorCode: z.string().optional(),
+  updatedAt: z.number(),
+});
 export const CallRecordSchema = z.object({
   callId: z.string(),
   providerCallId: z.string().optional(),
@@ -169,6 +187,7 @@ export const CallRecordSchema = z.object({
   endedAt: z.number().optional(),
   endReason: EndReasonSchema.optional(),
   transcript: z.array(TranscriptEntrySchema).default([]),
+  recording: CallRecordingSchema.optional(),
   processedEventIds: z.array(z.string()).default([]),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
@@ -233,6 +252,8 @@ export type InitiateCallInput = {
   streamUrl?: string;
   /** Per-call auth token the carrier echoes back on the WS upgrade. */
   streamAuthToken?: string;
+  /** Request provider-side recording for this call. */
+  record?: boolean;
 };
 
 export type InitiateCallResult = {
@@ -321,4 +342,6 @@ export type OutboundCallOptions = {
   requesterSessionKey?: string;
   /** Agent selected for this call instead of the plugin default. */
   agentId?: string;
+  /** Request provider-side recording for this call. */
+  record?: boolean;
 };


### PR DESCRIPTION
## What Problem This Solves

Delegated calls can persist transcripts but cannot currently request or track a provider audio recording. When informed consent has been obtained, callers need an opt-in, auditable recording artifact linked to the OpenClaw call record.

## Summary

- add an opt-in record flag for Twilio outbound calls
- request dual-channel, both-track recordings and persist signed recording callbacks
- expose recording metadata through call status, including callbacks received after call termination
- reject recording requests on unsupported providers

Closes #138842

## Security and privacy

Recording remains disabled by default and must be requested per call. Recording callbacks use the existing provider webhook verification and replay-deduplication path. Audio URLs are persisted as metadata; no credentials or audio bytes are returned.

## Evidence

- 114 focused voice-call tests passed
- pnpm check:changed passed, including extension typechecks, lint, dead-export scan, storage guards, and import-cycle checks
- pnpm build passed after the final fix
- independent autoreview found a status/recording callback routing collision; fixed by requiring the dedicated type=recording route and covered by a regression test
- packed the built voice-call plugin candidate successfully (27 files, 135365-byte tarball)

## Protocol compatibility

Inspected Codex MCP handling before changing the tool schema: structured tool output is serialized generically, so the optional record input and optional recording status object are additive.