### PR TITLE
fix: recover interrupted tasks after acceptance write failures

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -735,6 +735,10 @@ session identities. The task returns to `running` as the replacement execution
 continues, and the aborted marker is cleared after acceptance. You do not need
 to send another prompt to restart the work.
 
+If saving an accepted recovery temporarily fails, the Gateway retries adopting
+that same execution into its original task. Cancellation, replacement by a newer
+run, or another Gateway restart prevents that adoption.
+
 For sub-agents that announce completion, OpenClaw also attempts a notice to the
 original requester: “Resumed your interrupted task after the Gateway restart.”
 Failed or suppressed notices are retried without launching another recovery

--- a/src/agents/subagents/registry/subagent-registry-recovery-acceptance.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-recovery-acceptance.test.ts
@@ -1,0 +1,370 @@
+import { expect, it, vi } from "vitest";
+import { getRuntimeConfig } from "../../../config/config.js";
+import { loadSessionEntry } from "../../../config/sessions/session-accessor.js";
+import type { GatewayRecoveryRuntime } from "../../../gateway/server-instance-runtime.types.js";
+import {
+  getAgentEventLifecycleGeneration,
+  rotateAgentEventLifecycleGeneration,
+} from "../../../infra/agent-events.js";
+import { openOpenClawStateDatabase } from "../../../state/openclaw-state-db.js";
+import { reloadTaskRuntimeStateFromStore } from "../../../tasks/runtime-internal.js";
+import { getTaskFlowById } from "../../../tasks/task-flow-registry.js";
+import { findTaskByRunId, getTaskById } from "../../../tasks/task-registry.js";
+import { useSubagentControlFixture } from "./subagent-control.test-support.js";
+import { subagentRegistryDeps } from "./subagent-registry-deps.js";
+import { getSubagentRunsForChildSession, subagentRuns } from "./subagent-registry-memory.js";
+import { getLatestSubagentRunByChildSessionKeyFromRuns } from "./subagent-registry-queries.js";
+import { recoverInterruptedSubagentRow } from "./subagent-registry-restart-recovery.js";
+import { createSubagentRunManager } from "./subagent-registry-run-manager.js";
+import { persistSubagentRunsToDiskOrThrow } from "./subagent-registry-state.js";
+import { registerSubagentRun } from "./subagent-registry.js";
+import {
+  removeSubagentSessionEntry,
+  writeSubagentSessionEntry,
+} from "./subagent-registry.persistence.test-support.js";
+import {
+  loadSubagentRegistryFromSqlite,
+  saveSubagentRegistryChangesToSqlite,
+} from "./subagent-registry.store.sqlite.js";
+
+const fixture = useSubagentControlFixture();
+
+async function setupAcceptedRecovery(persistedPhase: "attempted" | "consumed" = "consumed") {
+  const sessionKey = "agent:main:subagent:acceptance-write";
+  const sessionId = "acceptance-write-session";
+  const lifecycleRevision = "acceptance-session-revision";
+  const storePath = await writeSubagentSessionEntry({
+    stateDir: fixture.stateDir,
+    agentId: "main",
+    sessionKey,
+    defaultSessionId: sessionId,
+    lifecycleRevision,
+    abortedLastRun: true,
+  });
+  registerSubagentRun({
+    runId: "acceptance-predecessor",
+    childSessionKey: sessionKey,
+    requesterSessionKey: "agent:main:main",
+    requesterDisplayKey: "main",
+    task: "Recover accepted work",
+    cleanup: "keep",
+    spawnMode: "session",
+    expectsCompletionMessage: true,
+  });
+  const source = subagentRuns.get("acceptance-predecessor")!;
+  const task = findTaskByRunId(source.runId)!;
+  const noop = () => {};
+  const resumed = vi.fn();
+  const createManager = () =>
+    createSubagentRunManager({
+      runs: subagentRuns,
+      getRunsForChildSession: getSubagentRunsForChildSession,
+      resumedRuns: new Set(),
+      persist: (...runIds) => persistSubagentRunsToDiskOrThrow(subagentRuns, runIds),
+      persistOrThrow: (...runIds) => persistSubagentRunsToDiskOrThrow(subagentRuns, runIds),
+      callGateway: subagentRegistryDeps.callGateway,
+      getRuntimeConfig,
+      ensureListener: noop,
+      startSweeper: noop,
+      stopSweeper: noop,
+      resumeSubagentRun: resumed,
+      clearPendingLifecycleError: noop,
+      clearPendingLifecycleTimeout: noop,
+      resolveSubagentWaitTimeoutMs: () => 1_000,
+      scheduleSweep: noop,
+      resolveSubagentSessionCompletion: () => null,
+      resolveSubagentSessionStartedAt: () => undefined,
+      notifyContextEngineSubagentEnded: async () => {},
+      completeCleanupBookkeeping: noop,
+      completeSubagentRun: async () => {},
+      resolveSubagentTask: () => ({ lookup: "available", task: getTaskById(task.taskId) }),
+    });
+  const manager = createManager();
+  const launch = {
+    runId: source.runId,
+    expected: source,
+    sessionMarker: `${sessionId}:${loadSessionEntry({ storePath, sessionKey })!.updatedAt}`,
+    idempotencyKey: "acceptance-successor",
+  };
+  expect(
+    manager.reserveSubagentRestartRecoveryLaunch({
+      ...launch,
+      sessionId,
+      sessionLifecycleRevision: lifecycleRevision,
+    }),
+  ).toBe(launch.idempotencyKey);
+  expect(
+    manager.markSubagentRestartRecoveryLaunchAttempted({
+      ...launch,
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
+    })?.phase,
+  ).toBe("attempted");
+
+  const database = openOpenClawStateDatabase().db;
+  const rejectedPhases = persistedPhase === "attempted" ? "'consumed', 'accepted'" : "'accepted'";
+  database.exec(`CREATE TEMP TRIGGER reject_recovery_receipt
+    BEFORE UPDATE ON subagent_runs
+    WHEN NEW.run_id = 'acceptance-predecessor'
+      AND json_extract(NEW.payload_json, '$.execution.restartRecovery.phase') IN (${rejectedPhases})
+    BEGIN SELECT RAISE(ABORT, 'recovery receipt write rejected'); END`);
+  let receipt: ReturnType<typeof manager.markSubagentRestartRecoveryLaunchAccepted>;
+  try {
+    if (persistedPhase === "attempted") {
+      expect(() => manager.markSubagentRestartRecoveryLaunchConsumed(launch)).toThrow(
+        "recovery receipt write rejected",
+      );
+    } else {
+      expect(manager.markSubagentRestartRecoveryLaunchConsumed(launch)?.phase).toBe("consumed");
+    }
+    receipt = manager.markSubagentRestartRecoveryLaunchAccepted(launch);
+    expect(receipt?.phase).toBe("accepted");
+    expect(source.execution.restartRecovery).toBe(receipt);
+    expect(
+      loadSubagentRegistryFromSqlite().get(source.runId)?.execution.restartRecovery?.phase,
+    ).toBe(persistedPhase);
+  } finally {
+    database.exec("DROP TRIGGER reject_recovery_receipt");
+  }
+  if (!receipt) {
+    throw new Error("Expected the live acceptance receipt after its failed write");
+  }
+
+  const dispatchAgent = vi.fn(async (): Promise<never> => {
+    throw new Error("Already accepted recovery must not dispatch another turn");
+  });
+  const gatewayRuntime: GatewayRecoveryRuntime = {
+    dispatchAgent,
+    waitForAgent: async () => {
+      throw new Error("Recovery settlement must not wait through Gateway");
+    },
+    abortAgent: async () => {
+      throw new Error("Recovery settlement must not abort its accepted turn");
+    },
+    sendRecoveryNotice: async () => ({ suppressed: false }),
+  };
+  const replace = (
+    overrides: Partial<Parameters<typeof manager.replaceSubagentRunAfterSteer>[0]> = {},
+    owner = manager,
+  ) =>
+    owner.replaceSubagentRunAfterSteer({
+      previousRunId: source.runId,
+      nextRunId: launch.idempotencyKey,
+      expected: source,
+      restartRecovery: receipt,
+      persistenceFailure: "return-false",
+      ...overrides,
+    });
+  const recover = () =>
+    recoverInterruptedSubagentRow({
+      runId: source.runId,
+      entry: source,
+      now: Date.now(),
+      gatewayRuntime,
+      isCurrent: (runId, entry) =>
+        subagentRuns.get(runId) === entry &&
+        getLatestSubagentRunByChildSessionKeyFromRuns(
+          getSubagentRunsForChildSession(entry.childSessionKey),
+          entry.childSessionKey,
+        ) === entry,
+      getRun: (runId) => subagentRuns.get(runId),
+      abandonLaunch: manager.abandonSubagentRestartRecoveryLaunch,
+      clearAcceptedRecovery: manager.clearAcceptedSubagentRestartRecovery,
+      clearPendingNotice: manager.clearPendingSubagentRecoveryNotice,
+      resumeAcceptedRecovery: manager.resumeSettledSubagentRestartRecovery,
+      replaceRun: manager.replaceSubagentRunAfterSteer,
+      markLaunchAttempted: manager.markSubagentRestartRecoveryLaunchAttempted,
+      markLaunchAccepted: manager.markSubagentRestartRecoveryLaunchAccepted,
+      markLaunchConsumed: manager.markSubagentRestartRecoveryLaunchConsumed,
+      reserveLaunch: manager.reserveSubagentRestartRecoveryLaunch,
+      resetLaunchAttempt: manager.resetSubagentRestartRecoveryLaunchAttempt,
+      warn: vi.fn(),
+    });
+  const expectRejected = (attempt = () => replace()) => {
+    const before = loadSubagentRegistryFromSqlite();
+    const taskBefore = getTaskById(task.taskId);
+    const flowBefore = getTaskFlowById(task.parentFlowId!);
+    expect(attempt()).toBe(false);
+    expect(loadSubagentRegistryFromSqlite()).toEqual(before);
+    expect(subagentRuns.has(launch.idempotencyKey)).toBe(false);
+    expect(getTaskById(task.taskId)).toEqual(taskBefore);
+    expect(getTaskFlowById(task.parentFlowId!)).toEqual(flowBefore);
+  };
+  return {
+    source,
+    task,
+    receipt,
+    manager,
+    createManager,
+    session: { sessionKey, sessionId, storePath, lifecycleRevision },
+    database,
+    replace,
+    recover,
+    expectRejected,
+    dispatchAgent,
+    resumed,
+  };
+}
+
+it.each(["attempted", "consumed"] as const)(
+  "adopts witnessed acceptance when failed receipt writes left durable %s",
+  async (persistedPhase) => {
+    const state = await setupAcceptedRecovery(persistedPhase);
+    expect(state.replace()).toBe(true);
+    const stored = loadSubagentRegistryFromSqlite();
+    expect(stored.has(state.source.runId)).toBe(false);
+    expect(stored.get(state.receipt.idempotencyKey)?.execution.restartRecovery).toEqual(
+      state.receipt,
+    );
+    reloadTaskRuntimeStateFromStore();
+    expect(getTaskById(state.task.taskId)).toMatchObject({
+      runId: state.source.runId,
+      status: "running",
+      detail: { generation: state.source.generation! + 1 },
+    });
+    expect(getTaskFlowById(state.task.parentFlowId!)?.status).toBe("running");
+  },
+);
+
+it.each(["source payload", "receipt identity", "reserved phase", "abandoned phase"] as const)(
+  "does not reconcile a durable %s conflict",
+  async (conflict) => {
+    const state = await setupAcceptedRecovery();
+    const stored = loadSubagentRegistryFromSqlite();
+    const source = stored.get(state.source.runId)!;
+    if (conflict === "source payload") {
+      source.task = "Changed by another owner";
+    } else if (conflict === "receipt identity") {
+      source.execution.restartRecovery!.sessionMarker = "different-session-marker";
+    } else {
+      source.execution.restartRecovery!.phase =
+        conflict === "reserved phase" ? "reserved" : "abandoned";
+    }
+    saveSubagentRegistryChangesToSqlite(stored, [source.runId]);
+    state.expectRejected();
+  },
+);
+
+it.each(["source", "receipt", "manager"] as const)(
+  "does not transfer failed-write authority to a copied %s",
+  async (copied) => {
+    const state = await setupAcceptedRecovery();
+    if (copied === "manager") {
+      state.expectRejected(() => state.replace({}, state.createManager()));
+    } else if (copied === "source") {
+      const source = structuredClone(state.source);
+      source.execution.restartRecovery = state.receipt;
+      subagentRuns.set(source.runId, source);
+      state.expectRejected(() => state.replace({ expected: source }));
+      expect(subagentRuns.get(source.runId)).toBe(source);
+    } else {
+      const receipt = structuredClone(state.receipt);
+      state.source.execution.restartRecovery = receipt;
+      state.expectRejected(() => state.replace({ restartRecovery: receipt }));
+    }
+  },
+);
+
+it("accepts an exact persisted accepted row without failed-write authority", async () => {
+  const state = await setupAcceptedRecovery();
+  saveSubagentRegistryChangesToSqlite(subagentRuns, [state.source.runId]);
+  expect(state.replace({}, state.createManager())).toBe(true);
+});
+
+it("does not change the witnessed identity through a retained receipt", async () => {
+  const state = await setupAcceptedRecovery();
+  Reflect.set(state.receipt, "sessionMarker", "unwitnessed-marker");
+  const stored = loadSubagentRegistryFromSqlite();
+  stored.get(state.source.runId)!.execution.restartRecovery!.sessionMarker = "unwitnessed-marker";
+  saveSubagentRegistryChangesToSqlite(stored, [state.source.runId]);
+  state.expectRejected();
+});
+
+it.each([
+  "retired lifecycle",
+  "cancelled",
+  "terminal",
+  "reset session",
+  "deleted session",
+  "newer sibling",
+] as const)("rejects witnessed recovery after its owner is invalidated by %s", async (reason) => {
+  const state = await setupAcceptedRecovery();
+  if (reason === "retired lifecycle") {
+    rotateAgentEventLifecycleGeneration();
+  } else if (reason === "cancelled") {
+    expect(
+      state.manager.claimSubagentRunKill({
+        runId: state.source.runId,
+        expected: state.source,
+        sessionId: state.session.sessionId,
+        sessionLifecycleRevision: state.session.lifecycleRevision,
+      }),
+    ).toBeDefined();
+  } else if (reason === "terminal") {
+    state.source.execution = {
+      ...state.source.execution,
+      status: "terminal",
+      endedAt: Date.now(),
+      outcome: { status: "error", error: "Owner already settled" },
+    };
+  } else if (reason === "reset session") {
+    await writeSubagentSessionEntry({
+      stateDir: fixture.stateDir,
+      agentId: "main",
+      sessionKey: state.session.sessionKey,
+      defaultSessionId: state.session.sessionId,
+      lifecycleRevision: "reset-session-revision",
+    });
+  } else if (reason === "deleted session") {
+    await removeSubagentSessionEntry({
+      stateDir: fixture.stateDir,
+      agentId: "main",
+      sessionKey: state.session.sessionKey,
+    });
+  } else {
+    registerSubagentRun({
+      runId: "newer-retained-owner",
+      childSessionKey: state.session.sessionKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "Newer work owns this session",
+      cleanup: "keep",
+      expectsCompletionMessage: false,
+    });
+    expect(subagentRuns.get(state.source.runId)).toBe(state.source);
+  }
+  state.expectRejected();
+});
+
+it.each(["successor", "task", "flow"] as const)(
+  "retries accepted recovery after the atomic %s write fails without redispatching",
+  async (rejectedWrite) => {
+    const state = await setupAcceptedRecovery();
+    const before = loadSubagentRegistryFromSqlite();
+    const taskBefore = getTaskById(state.task.taskId);
+    const flowBefore = getTaskFlowById(state.task.parentFlowId!);
+    state.database.exec(`CREATE TEMP TRIGGER reject_recovery_replacement
+      ${rejectedWrite === "successor" ? "BEFORE INSERT ON subagent_runs WHEN NEW.run_id = 'acceptance-successor'" : rejectedWrite === "task" ? "BEFORE UPDATE ON task_runs" : "BEFORE UPDATE ON flow_runs"}
+      BEGIN SELECT RAISE(ABORT, 'atomic recovery write rejected'); END`);
+    try {
+      await expect(state.recover()).resolves.toEqual({ status: "deferred" });
+      expect(subagentRuns.get(state.source.runId)).toBe(state.source);
+      expect(loadSubagentRegistryFromSqlite()).toEqual(before);
+      expect(getTaskById(state.task.taskId)).toEqual(taskBefore);
+      expect(getTaskFlowById(state.task.parentFlowId!)).toEqual(flowBefore);
+      expect(state.resumed).not.toHaveBeenCalled();
+    } finally {
+      state.database.exec("DROP TRIGGER reject_recovery_replacement");
+    }
+    await expect(state.recover()).resolves.toEqual({ status: "accepted" });
+    expect(state.dispatchAgent).not.toHaveBeenCalled();
+    expect(state.resumed).toHaveBeenCalledExactlyOnceWith(state.receipt.idempotencyKey);
+    const stored = loadSubagentRegistryFromSqlite();
+    expect(stored.has(state.source.runId)).toBe(false);
+    expect(stored.get(state.receipt.idempotencyKey)?.execution.restartRecovery).toBeUndefined();
+    expect(loadSessionEntry(state.session)).toMatchObject({
+      sessionId: state.session.sessionId,
+      lifecycleRevision: state.session.lifecycleRevision,
+      abortedLastRun: false,
+    });
+  },
+);

--- a/src/agents/subagents/registry/subagent-registry-replacement-store.ts
+++ b/src/agents/subagents/registry/subagent-registry-replacement-store.ts
@@ -62,6 +62,7 @@ export function commitSubagentTaskReplacement(params: {
   source: SubagentRunRecord;
   successor: SubagentRunRecord;
   task: PreparedCanonicalTaskActivation;
+  canReconcileAcceptedReceipt?: () => boolean;
 }): void {
   assertReplacementCorrelation(params);
   const changedRows = params.changedRunIds.flatMap((runId) => {
@@ -80,6 +81,15 @@ export function commitSubagentTaskReplacement(params: {
     (database) => {
       const storedSource = readSubagentRun(database, params.source.runId);
       const storedTask = readTaskRecord(database.db, params.task.current.taskId);
+      const storedReceipt = storedSource?.execution.restartRecovery;
+      if (
+        (storedReceipt?.phase === "attempted" || storedReceipt?.phase === "consumed") &&
+        params.canReconcileAcceptedReceipt?.()
+      ) {
+        // Acceptance was witnessed by this live owner, but its write failed.
+        // Reconcile only that phase; every other field must still match below.
+        storedReceipt.phase = "accepted";
+      }
       if (!storedSource || !isDeepStrictEqual(bindSubagentRunRecord(storedSource), sourceRow)) {
         throw new Error("replacement subagent source changed before commit");
       }

--- a/src/agents/subagents/registry/subagent-registry-run-recovery.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-recovery.ts
@@ -1,3 +1,8 @@
+import {
+  resolveAgentIdFromSessionKey,
+  resolveSessionStorePathCore,
+} from "../../../config/sessions.js";
+import { loadSessionEntryReadOnly } from "../../../config/sessions/session-accessor.js";
 import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
 /** Owns steer replacement and restart-recovery receipt transitions. */
 import {
@@ -27,7 +32,10 @@ import type {
   SubagentRestartRecoveryReceipt,
   SubagentRunRecord,
 } from "./subagent-registry.types.js";
-import { nextSubagentRunGeneration } from "./subagent-run-generation.js";
+import {
+  compareSubagentRunGeneration,
+  nextSubagentRunGeneration,
+} from "./subagent-run-generation.js";
 import {
   getSubagentSessionRuntimeMs,
   getSubagentSessionStartedAt,
@@ -36,6 +44,11 @@ import {
 const log = createSubsystemLogger("agents/subagent-registry");
 
 export class SubagentRecoveryManager extends SubagentWaitManager {
+  private readonly unpersistedAcceptances = new WeakMap<
+    SubagentRunRecord,
+    SubagentRestartRecoveryReceipt
+  >();
+
   readonly replaceSubagentRunAfterSteer = (replaceParams: {
     previousRunId: string;
     nextRunId: string;
@@ -95,6 +108,17 @@ export class SubagentRecoveryManager extends SubagentWaitManager {
       source.childSessionKey,
     );
     const cfg = this.options.getRuntimeConfig();
+    const acceptedReceipt = this.unpersistedAcceptances.get(source);
+    const acceptanceSessionTarget =
+      acceptedReceipt && this.currentRunOwnsSession(source)
+        ? {
+            storePath: resolveSessionStorePathCore(cfg.session?.store, {
+              agentId: resolveAgentIdFromSessionKey(source.childSessionKey),
+            }),
+            sessionKey: source.childSessionKey,
+            clone: false,
+          }
+        : undefined;
     const spawnMode = source.spawnMode === "session" ? "session" : "run";
     const runTimeoutSeconds = replaceParams.runTimeoutSeconds ?? source.runTimeoutSeconds ?? 0;
     const waitTimeoutMs = this.options.resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
@@ -247,6 +271,40 @@ export class SubagentRecoveryManager extends SubagentWaitManager {
         void this.waitForSubagentCompletion(nextRunId, waitTimeoutMs, next);
       }
     };
+    const canReconcileAcceptedReceipt = () => {
+      // Staging replaces the map entry before commit. Only this exact
+      // live acceptance may bridge its failed write, never a restored copy.
+      if (
+        !acceptedReceipt ||
+        !acceptanceSessionTarget ||
+        this.unpersistedAcceptances.get(source) !== acceptedReceipt ||
+        source.execution.restartRecovery !== acceptedReceipt ||
+        replaceParams.restartRecovery !== acceptedReceipt ||
+        acceptedReceipt.idempotencyKey !== nextRunId ||
+        !acceptedReceipt.lifecycleGeneration ||
+        !isAgentEventLifecycleGenerationCurrent(acceptedReceipt.lifecycleGeneration) ||
+        this.options.runs.get(nextRunId) !== next ||
+        source.generation !== sourceSnapshot.generation ||
+        source.createdAt !== sourceSnapshot.createdAt ||
+        typeof source.execution.endedAt === "number" ||
+        source.killIntent ||
+        source.killReconciliation ||
+        source.pauseReason === "sessions_yield" ||
+        source.suppressAnnounceReason === "steer-restart" ||
+        Array.from(this.options.getRunsForChildSession(source.childSessionKey)).some(
+          (candidate) =>
+            candidate !== next && compareSubagentRunGeneration(candidate, sourceSnapshot) > 0,
+        )
+      ) {
+        return false;
+      }
+      const session = loadSessionEntryReadOnly(acceptanceSessionTarget);
+      return (
+        session?.sessionId === acceptedReceipt.sessionId &&
+        (acceptedReceipt.sessionLifecycleRevision === undefined ||
+          session.lifecycleRevision === acceptedReceipt.sessionLifecycleRevision)
+      );
+    };
     const persistReplacement = (): void => {
       if (taskActivation) {
         commitSubagentTaskReplacement({
@@ -255,6 +313,7 @@ export class SubagentRecoveryManager extends SubagentWaitManager {
           source: sourceSnapshot,
           successor: next,
           task: taskActivation,
+          canReconcileAcceptedReceipt,
         });
         return;
       }
@@ -277,6 +336,7 @@ export class SubagentRecoveryManager extends SubagentWaitManager {
       }
       throw error;
     }
+    this.unpersistedAcceptances.delete(source);
     // Atomic publication can synchronously trigger another replacement. Do not
     // start stale cleanup or completion work after that newer owner takes over.
     if (this.options.runs.get(nextRunId) !== next) {
@@ -473,13 +533,14 @@ export class SubagentRecoveryManager extends SubagentWaitManager {
     if (receipt.phase !== "consumed") {
       return receipt;
     }
-    const accepted = { ...receipt, phase: "accepted" as const };
+    const accepted = Object.freeze({ ...receipt, phase: "accepted" as const });
     entry.execution.restartRecovery = accepted;
     try {
       this.options.persistOrThrow(runId);
     } catch (error) {
       // Gateway acceptance is irreversible. Keep the in-memory fact and let the
       // caller immediately attempt the strict successor remap.
+      this.unpersistedAcceptances.set(entry, accepted);
       log.warn("failed to persist accepted subagent restart recovery receipt", {
         error,
         runId,


### PR DESCRIPTION
Closes #138783. Follow-up to #138394 and #138785.

## What Problem This Solves

Fixes an issue where interrupted sub-agent tasks could remain stuck after the Gateway accepted their recovery launch but temporarily failed to save that acceptance. The execution had already started, yet its original task and mirrored flow could not adopt it.

## Why This Change Was Made

The recovery manager remembers the exact immutable acceptance only when its write fails. The existing atomic replacement transaction may reconcile the preceding receipt phase when that same live owner and session still hold the work, then applies the complete source/task/flow comparisons. Cancellation, replacement, session reset, Gateway retirement, copied receipts, and unrelated durable changes remain fenced. Failed atomic adoption retries the same execution without another model dispatch.

This implements the [approved transaction-validation design](https://github.com/openclaw/openclaw/issues/138783#issuecomment-5549007741). Stored representations and the database schema remain unchanged. The private witness disappears with its owner or successful adoption; it is never restored from persisted data.

## User Impact

A temporary acceptance-write failure can recover into the original task and flow without requiring another prompt or duplicating model work. The sub-agent documentation now explains the recovery boundary.

## Evidence

- Real-SQLite reproduction failed before the fix. Final coverage totals 72 passing acceptance, atomic replacement, recovery, and notice cases, including attempted/consumed receipts, changed rows, stale owners, mutated receipt references, and rollback/retry without redispatch.
- The full changed-file checks passed: format, core/test types, lint, dead exports, schema/storage guards, runtime cycles, webhook and pairing guards.
- Independent Codex autoreview found no actionable P0–P2 issues.

Production delta is +73/-2 (net +71); tests add 370 lines and docs add four. The added production state and checks supply exact live acceptance authority and transaction-time ownership validation; neither a blind persistence retry nor relaxing the full row comparison preserves those guarantees. Production frequency of the injected storage failure is unknown.


Real OpenAI fault proof passed on the isolated [Crabbox/Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33942582952): `gpt-5.6-luna`, five Responses API requests, all HTTP 200. A connection-local TEMP trigger rejected the exact acceptance update once (SQLite constraint error 1811); the successor was adopted before the held provider response was released. The original task, flow and requester/child sessions remained stable, generation advanced 1 → 2, and delivery produced one resumption notice and one completion. After a second hard restart and a 65-second sweep, both tool counts remained `exec: 1, wait: 1`, with one recovery request and no operator prompt.

Earlier live attempts exposed test-fixture issues: a persistent trigger correctly failed startup schema validation, console output omitted structured error details, and separate plugin registrations split the fixture counter. The final fixture uses the Gateway's cached connection and one shared counter per handle; it observed two registrations and exactly one injected failure. Production guards and code remained unchanged during these harness corrections. The live transport was the synthetic QA channel, not a third-party messaging service.
