### PR TITLE
refactor(claws): share JSON-only YAML parsing

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2262,14 +2262,14 @@ src/claws/doctor.ts	2
 src/claws/export.ts	8
 src/claws/lifecycle-delete-support.ts	7
 src/claws/mcp.ts	4
-src/claws/openclaw-profile.ts	2
+src/claws/openclaw-profile.ts	1
 src/claws/package-update.ts	1
 src/claws/packages.ts	1
 src/claws/project-build.ts	4
 src/claws/project.ts	4
 src/claws/provenance-runtime-read.ts	1
 src/claws/provenance.ts	6
-src/claws/reader.ts	8
+src/claws/reader.ts	7
 src/claws/schema.ts	3
 src/claws/update-capability-changes.ts	11
 src/claws/workspace.ts	2

--- a/src/claws/openclaw-profile.test.ts
+++ b/src/claws/openclaw-profile.test.ts
@@ -91,6 +91,63 @@ describe("OpenClaw profile schema", () => {
 });
 
 describe("OpenClaw profile reader", () => {
+  it.each([
+    ["anchor", "agent: &agent {}", "anchors"],
+    ["alias", "agent: *agent", "aliases"],
+    ["tag", "agent: !!map {}", "explicit tags"],
+    ["merge", "agent: { <<: {} }", "merge keys"],
+  ])(
+    "rejects profile YAML %s with its profile diagnostic",
+    async (_label, declaration, feature) => {
+      const root = tempDirs.make("openclaw-claw-profile-yaml-");
+      await mkdir(join(root, "profiles"));
+      const manifestPath = join(root, "openclaw.claw.json");
+      await writeFile(manifestPath, JSON.stringify({ schemaVersion: 1, agent: { id: "triage" } }));
+      await writeFile(join(root, "profiles", "openclaw.yml"), `schemaVersion: 1\n${declaration}\n`);
+
+      const result = await readClawManifestFile(manifestPath);
+
+      expect(result).toMatchObject({
+        ok: false,
+        diagnostics: [
+          {
+            level: "error",
+            phase: "parse",
+            path: "$",
+            code: "unsupported_openclaw_profile_yaml_feature",
+            message: `profiles/openclaw.yml uses ${feature}; OpenClaw profile YAML must map directly to JSON data.`,
+          },
+        ],
+      });
+    },
+  );
+
+  it.each([
+    ["duplicate key", "schemaVersion: 1\nschemaVersion: 1\nagent: {}\n"],
+    ["invalid syntax", "schemaVersion: 1\nagent: [\n"],
+  ])("reports a profile YAML %s as a parse failure", async (_label, profile) => {
+    const root = tempDirs.make("openclaw-claw-profile-yaml-invalid-");
+    await mkdir(join(root, "profiles"));
+    const manifestPath = join(root, "openclaw.claw.json");
+    await writeFile(manifestPath, JSON.stringify({ schemaVersion: 1, agent: { id: "triage" } }));
+    await writeFile(join(root, "profiles", "openclaw.yml"), profile);
+
+    const result = await readClawManifestFile(manifestPath);
+
+    expect(result).toMatchObject({
+      ok: false,
+      diagnostics: [
+        {
+          level: "error",
+          phase: "parse",
+          path: "$",
+          code: "invalid_openclaw_profile",
+          message: expect.stringContaining("Could not parse profiles/openclaw.yml:"),
+        },
+      ],
+    });
+  });
+
   it("loads and integrity-binds the conventional profile", async () => {
     const root = tempDirs.make("openclaw-claw-profile-");
     await mkdir(join(root, "profiles"));

--- a/src/claws/openclaw-profile.ts
+++ b/src/claws/openclaw-profile.ts
@@ -1,6 +1,5 @@
 // Safe loader for the conventional package-local OpenClaw profile.
 import { asOptionalRecord as record } from "@openclaw/normalization-core/record-coerce";
-import { isScalar, parseDocument, visit } from "yaml";
 import type { ToolProfileId } from "../agents/tool-policy-shared.js";
 import { FsSafeError, root as fsSafeRoot } from "../infra/fs-safe.js";
 import { isSafeClawRelativePath } from "./schema-portability.js";
@@ -10,6 +9,7 @@ import {
   resolveClawToolProfileSnapshot,
 } from "./tool-profile-consent.js";
 import type { ClawDiagnostic, ClawOpenClawProfile } from "./types.js";
+import { parseClawYaml } from "./yaml-document.js";
 
 const MAX_PROFILE_BYTES = 256 * 1024;
 const CLAW_PROFILE_PATH = "profiles/openclaw.yml";
@@ -23,66 +23,6 @@ function diagnostic(code: string, message: string, path = "$"): ClawDiagnostic {
 
 function warning(code: string, message: string, path: string): ClawDiagnostic {
   return { level: "warning", code, phase: "parse", path, message };
-}
-
-function parseProfileYaml(
-  raw: string,
-  path: string,
-): { ok: true; value: unknown } | { ok: false; diagnostics: ClawDiagnostic[] } {
-  const document = parseDocument(raw.startsWith("\uFEFF") ? raw.slice(1) : raw, {
-    prettyErrors: false,
-    uniqueKeys: true,
-  });
-  if (document.errors.length > 0) {
-    return {
-      ok: false,
-      diagnostics: document.errors.map((error) =>
-        diagnostic("invalid_openclaw_profile", `Could not parse ${path}: ${error.message}`),
-      ),
-    };
-  }
-  let unsupportedFeature: string | undefined;
-  visit(document, {
-    Alias() {
-      unsupportedFeature ??= "aliases";
-    },
-    Node(_key, node) {
-      if (node.anchor) {
-        unsupportedFeature ??= "anchors";
-      } else if (node.tag) {
-        unsupportedFeature ??= "explicit tags";
-      }
-    },
-    Pair(_key, pair) {
-      if (isScalar(pair.key) && pair.key.value === "<<") {
-        unsupportedFeature ??= "merge keys";
-      }
-    },
-  });
-  if (unsupportedFeature) {
-    return {
-      ok: false,
-      diagnostics: [
-        diagnostic(
-          "unsupported_openclaw_profile_yaml_feature",
-          `${path} uses ${unsupportedFeature}; OpenClaw profile YAML must map directly to JSON data.`,
-        ),
-      ],
-    };
-  }
-  try {
-    return { ok: true, value: document.toJSON() };
-  } catch (error) {
-    return {
-      ok: false,
-      diagnostics: [
-        diagnostic(
-          "invalid_openclaw_profile",
-          `Could not parse ${path}: ${(error as Error).message}`,
-        ),
-      ],
-    };
-  }
 }
 
 function isToolProfileId(value: string): value is ToolProfileId {
@@ -266,7 +206,12 @@ export async function readClawOpenClawProfile(params: {
     };
   }
 
-  const yaml = parseProfileYaml(raw.toString("utf8"), declaredPath);
+  const text = raw.toString("utf8");
+  const yaml = parseClawYaml(
+    text.startsWith("\uFEFF") ? text.slice(1) : text,
+    declaredPath,
+    "profile",
+  );
   if (!yaml.ok) {
     return yaml;
   }

--- a/src/claws/reader.ts
+++ b/src/claws/reader.ts
@@ -2,7 +2,6 @@
 import { createHash } from "node:crypto";
 import { realpath, stat } from "node:fs/promises";
 import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
-import { isScalar, parseDocument, visit } from "yaml";
 import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../agents/workspace-bootstrap-read.js";
 import { assertNoSymlinkParents } from "../infra/fs-safe-advanced.js";
 import { FsSafeError, root as fsSafeRoot, type OpenResult } from "../infra/fs-safe.js";
@@ -21,6 +20,7 @@ import type {
   ClawSourceIdentity,
   ClawWorkspaceSourceSnapshot,
 } from "./types.js";
+import { parseClawYaml } from "./yaml-document.js";
 
 type PackageJson = {
   name: string;
@@ -387,57 +387,8 @@ export function parseClawMarkdown(
       ],
     };
   }
-  const document = parseDocument(frontmatter, { prettyErrors: false, uniqueKeys: true });
-  if (document.errors.length > 0) {
-    return {
-      ok: false,
-      diagnostics: document.errors.map((error) =>
-        fileDiagnostic("invalid_claw_frontmatter", `Could not parse ${path}: ${error.message}`),
-      ),
-    };
-  }
-  let unsupportedFeature: string | undefined;
-  visit(document, {
-    Alias() {
-      unsupportedFeature ??= "aliases";
-    },
-    Node(_key, node) {
-      if (node.anchor) {
-        unsupportedFeature ??= "anchors";
-      } else if (node.tag) {
-        unsupportedFeature ??= "explicit tags";
-      }
-    },
-    Pair(_key, pair) {
-      if (isScalar(pair.key) && pair.key.value === "<<") {
-        unsupportedFeature ??= "merge keys";
-      }
-    },
-  });
-  if (unsupportedFeature) {
-    return {
-      ok: false,
-      diagnostics: [
-        fileDiagnostic(
-          "unsupported_claw_yaml_feature",
-          `${path} uses ${unsupportedFeature}; CLAW.md frontmatter must map directly to JSON data.`,
-        ),
-      ],
-    };
-  }
-  try {
-    return { ok: true, value: document.toJSON(), body };
-  } catch (error) {
-    return {
-      ok: false,
-      diagnostics: [
-        fileDiagnostic(
-          "invalid_claw_frontmatter",
-          `Could not parse ${path}: ${(error as Error).message}`,
-        ),
-      ],
-    };
-  }
+  const parsed = parseClawYaml(frontmatter, path, "frontmatter");
+  return parsed.ok ? { ...parsed, body } : parsed;
 }
 
 function parseClawManifestDocument(

--- a/src/claws/yaml-document.ts
+++ b/src/claws/yaml-document.ts
@@ -1,0 +1,73 @@
+import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
+import { isScalar, parseDocument, visit } from "yaml";
+import type { ClawDiagnostic } from "./types.js";
+
+function diagnostic(code: string, message: string): ClawDiagnostic {
+  return { level: "error", code, phase: "parse", path: "$", message };
+}
+
+export function parseClawYaml(
+  raw: string,
+  path: string,
+  kind: "frontmatter" | "profile",
+): { ok: true; value: unknown } | { ok: false; diagnostics: ClawDiagnostic[] } {
+  const [invalidCode, unsupportedCode, label]: [string, string, string] =
+    kind === "frontmatter"
+      ? ["invalid_claw_frontmatter", "unsupported_claw_yaml_feature", "CLAW.md frontmatter"]
+      : [
+          "invalid_openclaw_profile",
+          "unsupported_openclaw_profile_yaml_feature",
+          "OpenClaw profile YAML",
+        ];
+  const document = parseDocument(raw, {
+    prettyErrors: false,
+    uniqueKeys: true,
+  });
+  if (document.errors.length > 0) {
+    return {
+      ok: false,
+      diagnostics: document.errors.map((error) =>
+        diagnostic(invalidCode, `Could not parse ${path}: ${error.message}`),
+      ),
+    };
+  }
+  let unsupportedFeature: string | undefined;
+  visit(document, {
+    Alias() {
+      unsupportedFeature ??= "aliases";
+    },
+    Node(_key, node) {
+      if (node.anchor) {
+        unsupportedFeature ??= "anchors";
+      } else if (node.tag) {
+        unsupportedFeature ??= "explicit tags";
+      }
+    },
+    Pair(_key, pair) {
+      if (isScalar(pair.key) && pair.key.value === "<<") {
+        unsupportedFeature ??= "merge keys";
+      }
+    },
+  });
+  if (unsupportedFeature) {
+    return {
+      ok: false,
+      diagnostics: [
+        diagnostic(
+          unsupportedCode,
+          `${path} uses ${unsupportedFeature}; ${label} must map directly to JSON data.`,
+        ),
+      ],
+    };
+  }
+  try {
+    return { ok: true, value: document.toJSON() };
+  } catch (error) {
+    return {
+      ok: false,
+      diagnostics: [
+        diagnostic(invalidCode, `Could not parse ${path}: ${coerceErrorMessage(error)}`),
+      ],
+    };
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Claw packages enforce the same JSON-only YAML contract in `CLAW.md` frontmatter and `profiles/openclaw.yml`, but the two readers duplicated parsing, feature rejection, and conversion. This maintainer-requested refactor gives that policy one owner so the two package surfaces stay aligned.

## Why This Change Was Made

Both readers now use one Claw YAML parser while retaining their surface-specific diagnostic codes and messages. The existing readers continue to own BOM handling, exact Markdown body bytes, bounded file access, schema validation, and package integrity. The shared conversion path uses the canonical error-message coercion helper.

Production LOC: +83/-114 (**net -31**). Tests: +57/-0. Two assertion-baseline counts decrease to reflect the removed casts. The six new profile-reader cases add boundary coverage for its diagnostics and rejection behavior.

## User Impact

No intended user-visible behavior change. Valid Claw manifests and profiles keep loading, and invalid YAML retains the same diagnostics and exit behavior across inspect, project validation, workspace materialization, and update/export callers.

## Evidence

- Full `pnpm build` passed; no ineffective dynamic-import warning.
- `node scripts/check-changed.mjs -- src/claws/yaml-document.ts src/claws/reader.ts src/claws/openclaw-profile.ts src/claws/openclaw-profile.test.ts config/assertion-safety-baseline.txt` passed, including core/test typechecks, lint, dead-export scans, and guards.
- `node scripts/run-vitest.mjs src/claws/openclaw-profile.test.ts src/claws/claw-markdown.test.ts src/claws/schema.test.ts src/claws/project.test.ts src/claws/workspace.test.ts`: **118 passed, 1 existing skipped**, across five files.
- **16 real CLI cases** passed through `node openclaw.mjs claws inspect "$fixture/CLAW.md" --json`, using synthetic files and isolated configuration/state. Both frontmatter and profile cases accepted valid Unicode/BOM input and rejected anchors, aliases, tags, merge keys, duplicate keys, and invalid syntax. Assertions checked process exit, validity, diagnostic code/path/message, parsed Unicode, and snapshot identity.
- Inspected installed `yaml@2.9.0` parsing, visitor ordering, `Document.toJSON` conversion, and native error contracts. Existing Markdown body/integrity and workspace tests cover the sibling consumer.
- Independent Codex autoreview was scoped-clean with no actionable P0–P2 findings.

The CLI proof uses the package launcher against compiled output; the development runner rebuilds dirty source trees and timed out during the initial probe. No provider or channel credentials were needed.
