### PR TITLE
fix(gateway): avoid presence traffic delaying new connections

### DIFF
--- a/src/gateway/server.auth.hello-order.test.ts
+++ b/src/gateway/server.auth.hello-order.test.ts
@@ -1,0 +1,172 @@
+import { once } from "node:events";
+import { describe, expect, test, vi } from "vitest";
+import { WebSocket } from "ws";
+import { writeConfigFile } from "../config/config.js";
+import type { SystemPresence } from "../infra/system-presence.js";
+import {
+  connectReq,
+  CONTROL_UI_CLIENT,
+  installGatewayTestHooks,
+  openWs,
+  onceMessage,
+  testState,
+  withGatewayServer,
+} from "./server.auth.test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const origin = "https://control.example.com";
+
+type ObservedFrame = {
+  type?: string;
+  event?: string;
+  payload?: {
+    type?: string;
+    presence?: SystemPresence[];
+    snapshot?: { presence?: SystemPresence[] };
+  };
+};
+
+async function configureAuth() {
+  const auth = {
+    mode: "trusted-proxy" as const,
+    trustedProxy: {
+      userHeader: "x-forwarded-user",
+      requiredHeaders: ["x-forwarded-proto"],
+      allowLoopback: true,
+    },
+  };
+  testState.gatewayAuth = auth;
+  testState.gatewayControlUi = { allowedOrigins: [origin] };
+  await writeConfigFile({
+    gateway: {
+      auth,
+      trustedProxies: ["127.0.0.1"],
+      controlUi: { allowedOrigins: [origin] },
+    },
+  });
+}
+
+async function openBrowser(port: number, instanceId: string) {
+  const socket = await openWs(port, {
+    origin,
+    "x-forwarded-for": "203.0.113.50",
+    "x-forwarded-proto": "https",
+    "x-forwarded-user": `${instanceId}@example.com`,
+  });
+  const frames: ObservedFrame[] = [];
+  socket.on("message", (data) => frames.push(JSON.parse(data.toString())));
+  return {
+    socket,
+    frames,
+    connect: () =>
+      connectReq(socket, {
+        skipDefaultAuth: true,
+        prePairDevice: true,
+        client: { ...CONTROL_UI_CLIENT, instanceId },
+        scopes: ["operator.read"],
+        browserOrigin: origin,
+      }),
+  };
+}
+
+function presenceReasons(frames: ObservedFrame[], instanceId: string) {
+  return frames
+    .filter((frame) => frame.event === "presence")
+    .flatMap((frame) => frame.payload?.presence ?? [])
+    .filter((entry) => entry.instanceId === instanceId)
+    .map((entry) => entry.reason);
+}
+
+describe("Gateway hello publication", () => {
+  test("sends hello before connect presence and promptly notifies established readers", async () => {
+    await configureAuth();
+    await withGatewayServer(async ({ port }) => {
+      const reader = await openBrowser(port, "established-reader");
+      const joining = await openBrowser(port, "joining-browser");
+      try {
+        expect((await reader.connect()).ok).toBe(true);
+        const notified = onceMessage<ObservedFrame>(
+          reader.socket,
+          (frame) =>
+            frame.event === "presence" &&
+            frame.payload?.presence?.some(
+              (entry) => entry.instanceId === "joining-browser" && entry.reason === "connect",
+            ) === true,
+        );
+        const [result] = await Promise.all([joining.connect(), notified]);
+        expect(result.ok, JSON.stringify(result.error)).toBe(true);
+        const firstFrame = joining.frames.find((frame) => frame.event !== "connect.challenge");
+        expect(firstFrame?.payload?.type ?? firstFrame?.event).toBe("hello-ok");
+        expect(firstFrame?.payload?.snapshot?.presence?.map((entry) => entry.instanceId)).toContain(
+          "joining-browser",
+        );
+        expect(presenceReasons(reader.frames, "joining-browser")).toContain("connect");
+      } finally {
+        joining.socket.close();
+        reader.socket.close();
+      }
+    });
+  });
+
+  test.each(["write-error", "closed-before-callback"] as const)(
+    "does not publish connect presence after hello %s and retains disconnect cleanup",
+    async (failure) => {
+      await configureAuth();
+      const failedInstanceId = `failed-${failure}`;
+      await withGatewayServer(async ({ port }) => {
+        const reader = await openBrowser(port, "established-reader");
+        const joining = await openBrowser(port, failedInstanceId);
+        let failNextHello = true;
+        try {
+          expect((await reader.connect()).ok).toBe(true);
+          const originalSend = Reflect.get(WebSocket.prototype, "send");
+          const sendSpy = vi.spyOn(WebSocket.prototype, "send").mockImplementation(function (
+            this: WebSocket,
+            ...args: Parameters<WebSocket["send"]>
+          ) {
+            if (failNextHello && typeof args[0] === "string" && args[0].includes('"hello-ok"')) {
+              failNextHello = false;
+              const callback = args.findLast((arg) => typeof arg === "function");
+              if (failure === "closed-before-callback") {
+                this.close(1000, "test close before hello");
+              }
+              if (typeof callback === "function") {
+                callback(
+                  failure === "write-error" ? new Error("test hello write failure") : undefined,
+                );
+              }
+              return;
+            }
+            Reflect.apply(originalSend, this, args);
+          });
+          try {
+            const closed = once(joining.socket, "close");
+            const disconnected = onceMessage<ObservedFrame>(
+              reader.socket,
+              (frame) =>
+                frame.event === "presence" &&
+                frame.payload?.presence?.some(
+                  (entry) => entry.instanceId === failedInstanceId && entry.reason === "disconnect",
+                ) === true,
+            );
+            await Promise.all([
+              expect(joining.connect()).rejects.toThrow(/closed/),
+              closed,
+              disconnected,
+            ]);
+            expect(failNextHello).toBe(false);
+            const reasons = presenceReasons(reader.frames, failedInstanceId);
+            expect(reasons).not.toContain("connect");
+            expect(reasons).toContain("disconnect");
+          } finally {
+            sendSpy.mockRestore();
+          }
+        } finally {
+          joining.socket.close();
+          reader.socket.close();
+        }
+      });
+    },
+  );
+});

--- a/src/gateway/server.auth.hello-order.test.ts
+++ b/src/gateway/server.auth.hello-order.test.ts
@@ -1,4 +1,5 @@
 import { once } from "node:events";
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 import { writeConfigFile } from "../config/config.js";
@@ -55,7 +56,7 @@ async function openBrowser(port: number, instanceId: string) {
     "x-forwarded-user": `${instanceId}@example.com`,
   });
   const frames: ObservedFrame[] = [];
-  socket.on("message", (data) => frames.push(JSON.parse(data.toString())));
+  socket.on("message", (data) => frames.push(JSON.parse(rawDataToString(data))));
   return {
     socket,
     frames,

--- a/src/gateway/server.auth.presence-audience.test.ts
+++ b/src/gateway/server.auth.presence-audience.test.ts
@@ -390,10 +390,24 @@ describe("gateway presence audience", () => {
           [idle, 1],
           [overlap, 0],
         ] as const) {
+          const isLiveIdle = (entry: SystemPresence) =>
+            entry.user?.id === idlePerson.user?.id && entry.reason !== "disconnect";
+          // A different socket's response cannot join this connection's server close.
+          const disconnected = onceMessage<{
+            type: string;
+            event: string;
+            payload: { presence: SystemPresence[] };
+          }>(
+            watcher.ws,
+            (frame) =>
+              frame.type === "event" &&
+              frame.event === "presence" &&
+              frame.payload.presence.filter(isLiveIdle).length === remaining,
+          );
           const closed = once(connection.ws, "close");
           connection.ws.close();
-          await closed;
-          const rows = await liveIdleRows();
+          const [, event] = await Promise.all([closed, disconnected]);
+          const rows = event.payload.presence.filter(isLiveIdle);
           expect(rows, "disconnect publishes only the surviving sockets").toHaveLength(remaining);
           if (remaining) {
             expect(rows[0]?.onlineSince).toBe(idlePerson.onlineSince);

--- a/src/gateway/server/ws-connection/connect-hello.setup-completion.test.ts
+++ b/src/gateway/server/ws-connection/connect-hello.setup-completion.test.ts
@@ -49,118 +49,136 @@ afterEach(() => {
 });
 
 describe("sendGatewayHello setup completion ordering", () => {
-  it("persists setup status before the successful hello handoff can pause", async () => {
-    await withOpenClawTestState(
-      { label: "ws-setup-completion-order", layout: "state-only" },
-      async () => {
-        const paired: PairedDevice = {
-          deviceId: "device-setup-order",
-          publicKey: "public-key-setup-order",
-          displayName: "Test phone",
-          createdAtMs: 1,
-          approvedAtMs: 2,
-        };
-        persistDevicePairingStoreState(
-          { pendingById: {}, pairedByDeviceId: { [paired.deviceId]: paired } },
-          undefined,
-          "paired",
-        );
-        const issued = await issueDevicePairSetupBootstrapToken({
-          profile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
-        });
-        await expect(
-          verifyDeviceBootstrapToken({
-            token: issued.token,
-            deviceId: paired.deviceId,
-            publicKey: paired.publicKey,
-            role: "operator",
-            scopes: PAIRING_SETUP_BOOTSTRAP_PROFILE.scopes,
-          }),
-        ).resolves.toEqual({ ok: true });
-
-        const handoffStarted = createDeferred();
-        const releaseHandoff = createDeferred();
-        const broadcast = vi.fn();
-        const context = {
-          handler: {
-            getClient: () => null,
-            connId: "conn-setup-order",
-            gatewayMethods: [],
-            events: [],
-            buildRequestContext: () => ({
-              broadcast,
-              nodeRegistry: { get: () => undefined },
+  it.each([false, true])(
+    "persists setup status before presence publication (failure=%s)",
+    async (presenceFails) => {
+      await withOpenClawTestState(
+        { label: "ws-setup-completion-order", layout: "state-only" },
+        async () => {
+          const paired: PairedDevice = {
+            deviceId: "device-setup-order",
+            publicKey: "public-key-setup-order",
+            displayName: "Test phone",
+            createdAtMs: 1,
+            approvedAtMs: 2,
+          };
+          persistDevicePairingStoreState(
+            { pendingById: {}, pairedByDeviceId: { [paired.deviceId]: paired } },
+            undefined,
+            "paired",
+          );
+          const issued = await issueDevicePairSetupBootstrapToken({
+            profile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
+          });
+          await expect(
+            verifyDeviceBootstrapToken({
+              token: issued.token,
+              deviceId: paired.deviceId,
+              publicKey: paired.publicKey,
+              role: "operator",
+              scopes: PAIRING_SETUP_BOOTSTRAP_PROFILE.scopes,
             }),
-            refreshHealthSnapshot: vi.fn(async () => ({})),
-            close: vi.fn(),
-            advanceHandshakePhase: vi.fn(),
-            setCloseCause: vi.fn(),
-            logGateway: { warn: vi.fn() },
-            logHealth: { error: vi.fn() },
-          },
-          frame: { id: "hello-setup-order" },
-          connectParams: {
-            client: {
-              id: "openclaw-ios",
-              version: "dev",
-              platform: "test",
-              mode: "backend",
+          ).resolves.toEqual({ ok: true });
+
+          const handoffStarted = createDeferred();
+          const releaseHandoff = createDeferred();
+          const broadcast = vi.fn((event: string) => {
+            if (presenceFails && event === "presence") {
+              throw new Error("test presence publication failure");
+            }
+          });
+          const context = {
+            handler: {
+              getClient: () => ({ presenceKey: "conn-setup-order", socket: { readyState: 1 } }),
+              isClosed: () => false,
+              connId: "conn-setup-order",
+              gatewayMethods: [],
+              events: [],
+              buildRequestContext: () => ({
+                broadcast,
+                incrementPresenceVersion: () => 2,
+                getHealthVersion: () => 1,
+                nodeRegistry: { get: () => undefined },
+              }),
+              refreshHealthSnapshot: vi.fn(async () => ({})),
+              close: vi.fn(),
+              advanceHandshakePhase: vi.fn(),
+              setCloseCause: vi.fn(),
+              logGateway: { warn: vi.fn() },
+              logHealth: { error: vi.fn() },
             },
+            frame: { id: "hello-setup-order" },
+            connectParams: {
+              client: {
+                id: "openclaw-ios",
+                version: "dev",
+                platform: "test",
+                mode: "backend",
+              },
+              role: "operator",
+              scopes: PAIRING_SETUP_BOOTSTRAP_PROFILE.scopes,
+            },
+            configSnapshot: {},
+            sendFrame: vi.fn(async () => {
+              handoffStarted.resolve();
+              await releaseHandoff.promise;
+            }),
+            pendingNodePairingCleanup: {},
+            releasePendingNodePairingCleanup: vi.fn(async () => undefined),
+          };
+          const state = {
+            resolvedAuth: { mode: "none" },
             role: "operator",
             scopes: PAIRING_SETUP_BOOTSTRAP_PROFILE.scopes,
-          },
-          configSnapshot: {},
-          sendFrame: vi.fn(async () => {
-            handoffStarted.resolve();
-            await releaseHandoff.promise;
-          }),
-          pendingNodePairingCleanup: {},
-          releasePendingNodePairingCleanup: vi.fn(async () => undefined),
-        };
-        const state = {
-          resolvedAuth: { mode: "none" },
-          role: "operator",
-          scopes: PAIRING_SETUP_BOOTSTRAP_PROFILE.scopes,
-          device: { id: paired.deviceId },
-          devicePublicKey: paired.publicKey,
-          hasTokenAuth: false,
-          hasPasswordAuth: false,
-          bootstrapTokenCandidate: issued.token,
-          authResult: { ok: true, method: "bootstrap-token" },
-          authMethod: "bootstrap-token",
-          issuedBootstrapProfile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
-          handoffBootstrapProfile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
-          deviceToken: null,
-          bootstrapDeviceTokens: [],
-        };
+            device: { id: paired.deviceId },
+            devicePublicKey: paired.publicKey,
+            hasTokenAuth: false,
+            hasPasswordAuth: false,
+            bootstrapTokenCandidate: issued.token,
+            authResult: { ok: true, method: "bootstrap-token" },
+            authMethod: "bootstrap-token",
+            issuedBootstrapProfile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
+            handoffBootstrapProfile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
+            deviceToken: null,
+            bootstrapDeviceTokens: [],
+          };
 
-        const hello = sendGatewayHello(context as never, state as never, {});
-        await handoffStarted.promise;
-        const completionAtHandoff = await readDevicePairSetupCompletion({
-          setupId: issued.setupId,
-        });
-        releaseHandoff.resolve();
-        await hello;
-        const completionAfterHandoff = await readDevicePairSetupCompletion({
-          setupId: issued.setupId,
-        });
+          const hello = sendGatewayHello(context as never, state as never, {});
+          await handoffStarted.promise;
+          const completionAtHandoff = await readDevicePairSetupCompletion({
+            setupId: issued.setupId,
+          });
+          releaseHandoff.resolve();
+          if (presenceFails) {
+            await expect(hello).rejects.toThrow("test presence publication failure");
+          } else {
+            await hello;
+          }
+          const completionAfterHandoff = await readDevicePairSetupCompletion({
+            setupId: issued.setupId,
+          });
 
-        expect(completionAtHandoff).toMatchObject({
-          setupId: issued.setupId,
-          deviceId: paired.deviceId,
-          deviceName: paired.displayName,
-          access: "limited",
-          deliveryState: "uncertain",
-        });
-        expect(completionAfterHandoff).toMatchObject({ deliveryState: "confirmed" });
-        expect(broadcast).toHaveBeenCalledWith(
-          "device.pair.setup.completed",
-          expect.objectContaining({ setupId: issued.setupId }),
-          { dropIfSlow: true },
-        );
-      },
-    );
-  });
+          expect(completionAtHandoff).toMatchObject({
+            setupId: issued.setupId,
+            deviceId: paired.deviceId,
+            deviceName: paired.displayName,
+            access: "limited",
+            deliveryState: "uncertain",
+          });
+          expect(completionAfterHandoff).toMatchObject({ deliveryState: "confirmed" });
+          expect(broadcast).toHaveBeenCalledWith(
+            "device.pair.setup.completed",
+            expect.objectContaining({ setupId: issued.setupId }),
+            { dropIfSlow: true },
+          );
+          const publications = broadcast.mock.calls.map(([event]) => event);
+          expect(publications.indexOf("device.pair.setup.completed")).toBeLessThan(
+            publications.indexOf("presence"),
+          );
+        },
+      );
+    },
+  );
 
   it("keeps correlated setup completion uncertain when hello delivery fails", async () => {
     await withOpenClawTestState(

--- a/src/gateway/server/ws-connection/connect-hello.ts
+++ b/src/gateway/server/ws-connection/connect-hello.ts
@@ -32,11 +32,17 @@ import {
 import { canReadDetailedUpdateMetadata } from "../../events.js";
 import { ADMIN_SCOPE } from "../../method-scopes.js";
 import { scheduleNodeConnectionNotification } from "../../node-connection-notifications.js";
-import { MAX_BUFFERED_BYTES, MAX_PAYLOAD_BYTES, TICK_INTERVAL_MS } from "../../server-constants.js";
+import {
+  MAX_BUFFERED_BYTES,
+  MAX_PAYLOAD_BYTES,
+  TICK_INTERVAL_MS,
+  WEBSOCKET_OPEN_READY_STATE,
+} from "../../server-constants.js";
 import { formatError } from "../../server-utils.js";
 import { allowedSessionVisibilities } from "../../session-sharing.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import { buildGatewaySnapshot, getHealthCache, getHealthVersion } from "../health-state.js";
+import { broadcastPresenceSnapshot } from "../presence-events.js";
 import { emitGatewayAuthSecurityEvent } from "./connect-auth-security.js";
 import type {
   DeviceAuthorizedGatewayConnect,
@@ -400,4 +406,15 @@ export async function sendGatewayHello(
   void refreshHealthSnapshot({ probe: false }).catch((err: unknown) =>
     logHealth.error(`post-connect health refresh failed: ${formatError(err)}`),
   );
+  const client = context.handler.getClient();
+  if (
+    client?.presenceKey &&
+    !client.invalidated &&
+    client.socket.readyState === WEBSOCKET_OPEN_READY_STATE &&
+    !context.handler.isClosed()
+  ) {
+    // The row is already in hello's snapshot. Notify established readers now,
+    // without queueing this connection's redundant snapshot ahead of hello.
+    broadcastPresenceSnapshot(buildRequestContext());
+  }
 }

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -45,7 +45,6 @@ import {
 import { WEBSOCKET_OPEN_READY_STATE } from "../../server-constants.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
-import { broadcastPresenceSnapshot } from "../presence-events.js";
 import type { GatewayWsClient } from "../ws-types.js";
 import {
   rejectGatewayConnectOrigin,
@@ -611,9 +610,6 @@ export async function attachAuthenticatedGatewayConnect(
       ...(authenticatedPresenceUser ? { user: authenticatedPresenceUser } : {}),
       reason: "connect",
     });
-    // Publish the completed row before hello snapshots it; existing readers do
-    // not receive this connection's hello and must not wait for later activity.
-    broadcastPresenceSnapshot(buildRequestContext());
   }
   if (admittedNodePairing) {
     const pairingGeneration = admittedNodePairing.generation?.key;


### PR DESCRIPTION
Related: #130664

## What Problem This Solves

Fixes an issue where new Control UI connections could remain connecting or time out while outgoing WebSocket traffic was backed up.

## Why This Change Was Made

The Gateway queued a connect-triggered presence snapshot before hello. Keep authenticated registration and the presence row in place, then publish the notification after the hello write and required setup/node bookkeeping complete. Check connection liveness again after the write so failed or closing connections are not announced as connected.

The setup regression also verifies that a throwing presence callback cannot skip durable handoff confirmation. The existing presence audience test now observes the actual disconnect event; a health response on another socket cannot acknowledge that close.

## User Impact

New clients receive hello before their own connect-triggered presence notification. Established readers continue to receive connect and reconnect updates without waiting for later activity, with the same audience filtering.

Follow-ups: general concurrent/bootstrap fanout ordering and node voicewake/bin startup ordering. Node startup events use pairing-bound direct delivery; the existing macOS bin readiness delay must be preserved when that separate path is changed.

## Evidence

- 97 focused tests across six suites passed, including real Gateway/WebSocket connection ordering, failed and closing hello writes, presence audiences and reconnects, setup confirmation, auth scope/recovery, and real node admission.
- All three connection regressions fail against the original owner. A real ws 8.21.3/shared-client probe demonstrates that delayed compression ahead of hello can trigger the unchanged 15-second connect watchdog; that controlled delay is a mechanism proof, not a production speedup measurement.
- Final independent P2 review passed. The latest ClawSweeper review reports high confidence and no introduced findings; its reviewer-side dependency-access limitation is covered by the maintainer's [direct ws source verification and real-socket proof](https://github.com/openclaw/openclaw/pull/138865#issuecomment-5549579938). [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33946769383) is green.
- Crabbox Linux on Node 24.19.0 passed all 97 tests and the complete changed-file gate with unchanged source/dependency hashes. The [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33948645813) returned command exit 0 and collected its required verdict before stopping the lease; its orchestration step may show cancelled after cleanup.
- Validation caught and fixed a test decoder lint error. An older-source/current-main dependency mismatch in Testbox was resolved by installing the frozen lockfile after source overlay before the final passing run.

Production LOC: +18/-5 (net +13, including import formatting). Growth is the post-write liveness check needed before publishing the connection notification.
