### PR TITLE
docs(ios): add 2026.8.2 mobile release notes

### DIFF
--- a/apps/ios/CHANGELOG.md
+++ b/apps/ios/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Adds richer mobile chat controls, remote desktop viewing, live subagent progress, session organization, easier agent switching, and reply notifications.
+- Improves queued-message and offline-history recovery, shared attachments, Talk playback, photo orientation, notification consent, and Gateway proxy connections.
+
 ## 2026.8.11
 
 - Choose one of eight session colors from existing session menus, with matching sidebar stripes and chat title dots; select Default to clear a color.


### PR DESCRIPTION
## What Problem This Solves

The 2026.8.2 mobile release cutter cannot prepare a candidate while the iOS `Unreleased` section is empty, leaving the guarded TestFlight and Play Internal release path blocked.

## Why This Change Was Made

Adds the concise, source-backed mobile release summary under `apps/ios/CHANGELOG.md` `## Unreleased`. It deliberately does not add a fixed App Store version heading: the later credentialed iOS planner owns the encoded App Store revision.

## User Impact

Maintainers can prepare the 2026.8.2 mobile candidate from the shared cutter without inventing release notes or hardcoding an App Store revision.

## Evidence

- Red: cutter prepare check exited 1 with an empty `Unreleased` section and reported missing Android changelog notes for 2026.8.2.
- Green: in a retained disposable proof copy, cutter prepare `--write` then `--check` completed successfully.
- Generated proof changed only four authorized mobile paths: `apps/ios/CHANGELOG.md`, `apps/mobile/version.json`, `apps/android/Config/Version.properties`, and the Play release-notes file.
- Generated Android codes: phone `2026080201`, Wear `2026080251`; Play notes: 318 characters.
- Focused cutter and release-authority tests: 48/48 passed.
- Repository changed-file contribution gate passed, including release metadata and Android version consistency.
- P1 autoreview: scoped clean, correctness 0.99.
- PR production delta: 0; documentation delta: +3 lines. The PR itself changes only `apps/ios/CHANGELOG.md`.

## Boundaries

- No credentials, protected environments, store APIs, release refs, workflow dispatches, candidate finalize step, or uploads were touched.
- Candidate freeze and release-branch replacement remain blocked on the separate credential gate.

Punchcard-Session: calm-meadow-summit-7q
