### PR TITLE
fix(sessions): avoid false edited-admission errors after serialization

### DIFF
--- a/src/agents/harness/host-capability.annotation.test.ts
+++ b/src/agents/harness/host-capability.annotation.test.ts
@@ -510,7 +510,9 @@ describe("host-owned current admission annotation", () => {
     await withAdmission(
       async (f) => {
         const before = structuredClone(f.recorder.getPersistedMessage?.());
+        const stored = asOptionalRecord((await loadTranscriptEvents(f.target)).at(-1))?.message;
         await f.annotate();
+        expect(before).toStrictEqual(stored);
         expect(f.recorder.getPersistedMessage?.()).toEqual({
           ...before,
           __openclaw: { ...before?.["__openclaw"], ...nativeAnnotation(), runId: f.attempt.runId },
@@ -524,6 +526,7 @@ describe("host-owned current admission annotation", () => {
           media: [{ path: "/tmp/fixture-image.png", contentType: "image/png" }],
           replyToId: "prior",
           replyToPreview: { text: "prior prompt" },
+          transport: { channel: "webchat", messageId: undefined },
         },
         beforeMessageWrite: hook,
       },

--- a/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
@@ -182,7 +182,9 @@ export function appendTranscriptMessageInTransaction<TMessage>(
   if (!appended) {
     throw new Error(`SQLite transcript append did not insert message ${messageId}.`);
   }
-  const anchor = readAnchor({ message: finalMessage, messageId });
+  // SAFETY: Receipt custody comes from this event's exact committed JSON after storage normalization.
+  const persistedMessage = (JSON.parse(appended) as typeof event).message;
+  const anchor = readAnchor({ message: persistedMessage, messageId });
   if (pending) {
     consumeSessionPendingInput(database, pending);
   }
@@ -190,7 +192,7 @@ export function appendTranscriptMessageInTransaction<TMessage>(
     appended: true,
     ...(anchor ? { anchor } : {}),
     effectiveParentId: parentId ?? null,
-    message: finalMessage,
+    message: persistedMessage,
     messageId,
   };
 }

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.test.ts
@@ -46,38 +46,36 @@ describe("SQLite transcript append", () => {
   it("canonicalizes assistant media at the generic transcript append owner", async () => {
     const stateDir = makeTempDir(tempDirs, "media-persistence-append-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    runOpenClawAgentWriteTransaction(
-      (database) => {
-        expect(
-          appendTranscriptEventInTransaction(
-            database,
-            {
-              agentId: "main",
-              env,
-              sessionId: "append-session",
-              sessionKey: "agent:main:append-session",
+    const committedJson = runOpenClawAgentWriteTransaction(
+      (database) =>
+        appendTranscriptEventInTransaction(
+          database,
+          {
+            agentId: "main",
+            env,
+            sessionId: "append-session",
+            sessionKey: "agent:main:append-session",
+          },
+          {
+            type: "message",
+            id: "event-1",
+            parentId: null,
+            timestamp: 1000,
+            message: {
+              role: "assistant",
+              content: "append",
+              MediaPaths: ["/media/a.png"],
+              MediaTypes: ["image/png"],
             },
-            {
-              type: "message",
-              id: "event-1",
-              parentId: null,
-              timestamp: 1000,
-              message: {
-                role: "assistant",
-                content: "append",
-                MediaPaths: ["/media/a.png"],
-                MediaTypes: ["image/png"],
-              },
-            },
-          ),
-        ).toBe(true);
-      },
+          },
+        ),
       { agentId: "main", env },
     );
     const database = openOpenClawAgentDatabase({ agentId: "main", env });
     const row = database.db
       .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? AND seq = 0")
       .get("append-session") as { event_json: string };
+    expect(committedJson).toBe(row.event_json);
     const message = (JSON.parse(row.event_json) as { message: Record<string, unknown> }).message;
     expect(message).toMatchObject({ role: "assistant", content: "append" });
     expect(message).not.toHaveProperty("MediaPaths");

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -112,12 +112,13 @@ function createTranscriptIdentityInserter(
   );
 }
 
+/** Returns the exact committed JSON, or false when an existing identity owns the event. */
 export function appendTranscriptEventInTransaction(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
   event: TranscriptEvent,
   options: TranscriptAppendOptions = {},
-): boolean {
+): string | false {
   return appendTranscriptEvent(database, scope, event, options);
 }
 
@@ -127,7 +128,7 @@ function appendTranscriptEvent(
   event: TranscriptEvent,
   options: TranscriptAppendOptions,
   cursor: TranscriptAppendCursor = {},
-): boolean {
+): string | false {
   const persistedEvent = canonicalizeTranscriptEventMedia(event);
   const db = getSessionKysely(database.db);
   const createdAt = readEventTimestamp(persistedEvent) ?? Date.now();
@@ -164,7 +165,8 @@ function appendTranscriptEvent(
   }
   const seq = cursor.nextSeq ?? readNextTranscriptSeq(database, scope.sessionId);
   cursor.insertEvent ??= createTranscriptEventInserter(database, scope.sessionId);
-  cursor.insertEvent({ seq, eventJson: JSON.stringify(persistedEvent), createdAt });
+  const eventJson = JSON.stringify(persistedEvent);
+  cursor.insertEvent({ seq, eventJson, createdAt });
   cursor.nextSeq = seq + 1;
   if (options.touchMutation !== false) {
     touchTranscriptMutationInTransaction(database, scope.sessionId);
@@ -200,7 +202,7 @@ function appendTranscriptEvent(
     cursor.insertIdentity({ ...identity, seq, createdAt });
   }
   scheduleTranscriptProjectionReconcile(database, scope.sessionId, projectionNeedsRebuild, options);
-  return true;
+  return eventJson;
 }
 
 function scheduleTranscriptProjectionReconcile(
@@ -251,7 +253,7 @@ export function appendTranscriptEventsInTransaction(
       }
       // Streaming imports acknowledge only inserted rows in their byte-dedupe
       // spool; ordinary array iterators ignore this feedback.
-      next = iterator.next(inserted);
+      next = iterator.next(inserted !== false);
     }
   } catch (error) {
     try {

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -332,10 +332,12 @@ export function appendTranscriptEventSync(
       return;
     }
     result = ok(
-      appendTranscriptEventInTransaction(
-        database,
-        resolved,
-        resolveTranscriptEventAppendParent(database, resolved.sessionId, event, options),
+      Boolean(
+        appendTranscriptEventInTransaction(
+          database,
+          resolved,
+          resolveTranscriptEventAppendParent(database, resolved.sessionId, event, options),
+        ),
       ),
     );
   }, toDatabaseOptions(resolved));

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -6,13 +6,11 @@ import {
   readSessionArchiveContentSync,
   SESSION_ARCHIVE_ZSTD_SUFFIX,
 } from "../config/sessions/archive-compression.js";
-import { appendTranscriptEventInTransaction } from "../config/sessions/session-accessor.sqlite-transcript-store.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   listOpenClawRegisteredAgentDatabases,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   openOpenClawAgentDatabase,
-  runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import * as nodeSqlite from "./node-sqlite.js";
@@ -57,49 +55,6 @@ describe("legacy media persistence doctor migration", () => {
     } finally {
       spy.mockRestore();
     }
-  });
-
-  it("canonicalizes assistant media at the generic transcript append owner", async () => {
-    const stateDir = makeTempDir(tempDirs, "media-persistence-append-");
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    runOpenClawAgentWriteTransaction(
-      (database) => {
-        expect(
-          appendTranscriptEventInTransaction(
-            database,
-            {
-              agentId: "main",
-              env,
-              sessionId: "append-session",
-              sessionKey: "agent:main:append-session",
-            },
-            createEvent({
-              id: "event-1",
-              parentId: null,
-              timestamp: 1000,
-              message: {
-                role: "assistant",
-                content: "append",
-                MediaPaths: ["/media/a.png"],
-                MediaTypes: ["image/png"],
-              },
-            }),
-          ),
-        ).toBe(true);
-      },
-      { agentId: "main", env },
-    );
-    const database = openOpenClawAgentDatabase({ agentId: "main", env });
-    const row = database.db
-      .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? AND seq = 0")
-      .get("append-session") as { event_json: string };
-    const message = (JSON.parse(row.event_json) as { message: Record<string, unknown> }).message;
-    expect(message).toMatchObject({ role: "assistant", content: "append" });
-    expect(message).not.toHaveProperty("MediaPaths");
-    expect(message).not.toHaveProperty("MediaTypes");
-    expect(message["__openclaw"]).toMatchObject({
-      media: [expect.objectContaining({ path: "/media/a.png", contentType: "image/png" })],
-    });
   });
 
   it("rewrites every active shape and trajectory snapshot, migrates mixed archives, and reruns as a no-op", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where native agent turns can report `native prompt annotation cannot replace an edited admission` for a message that nobody edited. An optional metadata property such as `transport.messageId: undefined` remains in the first-append receipt but disappears from persisted JSON, so the native annotation guard compares different representations of the same admitted message.

## Why This Change Was Made

The transcript storage owner now returns the exact JSON it already inserted. First-append message receipts use that representation, matching the existing replay path. This also includes the storage owner's canonical media representation without another database read or serialization pass.

The public synchronous append API and streaming import feedback retain boolean results. Stored JSON bytes, schema, redaction, deduplication and the guard against actual edits remain unchanged. Production changes are +17/-11 lines (net +6); tests are +26/-70 (net -44). The small production increase carries the existing storage result across its receipt boundary.

## User Impact

Native prompt annotation accepts unchanged admitted messages whose optional metadata is omitted during serialization. Real edits, stale branches and lost run authority still prevent annotation.

## Evidence

- A real SQLite/recorder/host reproduction fails before the fix with the exact edited-admission diagnostic when only an optional undefined metadata field is added; the regression passes after the fix.
- 220 tests passed across host annotation, transcript storage, session accessors, streaming import and transcript redaction. Coverage includes actual edited-row refusal, canonical media, hook preservation, rollback, dedupe and synchronous APIs. Generic append coverage is consolidated in its storage-owner suite; all 14 migration regressions remain and pass.
- Independent P2 reviews found no actionable findings. Fifteen local changed-check phases passed. The [exact-head CI gate](https://github.com/openclaw/openclaw/actions/runs/33946498523/job/101254848022) passed, including production/test typechecks and Windows tests. Those CI checks cover the local declaration-owner limitation that prevented compilation with a shared dependency symlink.
- Isolated Node 26 parsing of an already-serialized event measured median 0.319 ms for 1 MiB and 2.752 ms for 8 MiB, with roughly one payload-sized allocation. This measures the added receipt parse, not full SQLite append latency; bulk imports do not parse receipts.

An isolated Linux run of the exact PR source passed on Node 26.8.1 using real SQLite, the production recorder, admitted host binding and annotation guard. Ordinary messages and messages with optional undefined transport metadata returned receipts strictly equal to the stored row and annotated successfully. A deliberately edited stored row was still refused and preserved. The run completed in 23.10 seconds; database access was restricted to synthetic fixture state, and the existing Gateway process, configuration and deployment binding were unchanged. This is isolated production-owner proof, not acceptance of a deployed Gateway candidate.

ClawSweeper review disposition: the requested Linux owner result is recorded above. Its data-model compatibility concern does not require a migration: this patch changes only the internal return value, reusing the very same JSON string passed to SQLite. It changes neither persisted bytes nor schema. The canonical storage test checks returned JSON against the actual row; all 14 existing migration regressions passed. No patch or security findings were reported.

The regression establishes this serialization mismatch; it does not attribute a separately observed production occurrence without its original in-memory receipt.
