### PR TITLE
fix(auto-reply): stop tool metadata path check from backtracking

### DIFF
--- a/src/auto-reply/tool-meta.test.ts
+++ b/src/auto-reply/tool-meta.test.ts
@@ -56,4 +56,23 @@ describe("tool meta formatting", () => {
       expect(out).toBe("🛠️ elevated · `cd ~/dir && gemini 2>&1`");
     });
   });
+
+  it("still groups path-shaped metadata by directory", () => {
+    expect(formatToolAggregate("fs", ["/tmp/dir/a.txt", "/tmp/dir/b.txt"])).toBe(
+      "🧩 Fs: /tmp/dir/{a.txt, b.txt}",
+    );
+    expect(formatToolAggregate("fs", ["/only"])).toBe("🧩 Fs: /only");
+  });
+
+  it("stays responsive on path-shaped metadata that ends in a tab", () => {
+    // `(\/[^\s]+)+` split the tail ambiguously and backtracked exponentially
+    // once the value ended in whitespace the earlier checks do not reject.
+    const meta = `/${"!/".repeat(30)}\t`;
+    const started = process.hrtime.bigint();
+    const out = formatToolAggregate("fs", [meta]);
+    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+
+    expect(out).toContain(meta);
+    expect(elapsedMs).toBeLessThan(1_000);
+  });
 });

--- a/src/auto-reply/tool-meta.ts
+++ b/src/auto-reply/tool-meta.ts
@@ -135,7 +135,11 @@ function isPathLike(value: string): boolean {
   if (value.includes("&&") || value.includes("||")) {
     return false;
   }
-  return /^~?(\/[^\s]+)+$/.test(value);
+  // One `[^\s]+` already spans the whole tail, `/` included, so the repeated
+  // group `(\/[^\s]+)+` only added an ambiguous split of the same language and
+  // backtracked exponentially on a path-shaped value ending in a tab or newline
+  // (the checks above reject only a plain space).
+  return /^~?\/[^\s]+$/.test(value);
 }
 
 function maybeWrapMarkdown(value: string, markdown?: boolean): string {


### PR DESCRIPTION
## What Problem This Solves

`isPathLike` in the tool-metadata formatter tested `^~?(\/[^\s]+)+$`. `[^\s]`
already matches `/`, so one `[^\s]+` spans the whole tail on its own — the
repeated group accepts exactly the same strings while adding an ambiguous way to
split them. When the value ends in whitespace the pattern cannot consume, the
engine walks that split exponentially before failing.

The function's earlier checks reject a value containing a plain space, so a
space-terminated value is never reached. A **tab or newline is not rejected**,
and either one reaches the regex:

| value | length | before | after |
|---|---:|---:|---:|
| `/` + `!/`×22 + tab | 46 B | 86 ms | 0 ms |
| `/` + `!/`×26 + tab | 54 B | 1,377 ms | 0 ms |
| `/` + `!/`×30 + tab | 62 B | 22,177 ms | 0 ms |
| `/` + `!/`×40 + tab | 82 B | did not finish in 10 min | 0 ms |

Time roughly multiplies by 16 for every 4 added repetitions — exponential, not
polynomial. 62 bytes is enough to hold the event loop for 22 seconds.

## Why This Change Was Made

`formatToolAggregate` / `formatToolAggregateParts` build the streamed
tool-progress lines in `src/channels/streaming.ts`, so the metadata is tool-call
text rather than runtime-authored text, and the cost lands on the single event
loop that serves every session.

The repeated group is removed: `^~?\/[^\s]+$` accepts the same language and
matches in linear time. Exhaustive comparison of the old and new patterns over
every string up to length 6 drawn from `/`, `a`, `~`, space, tab, newline, `.`,
`-` — 299,593 strings, covering every character class the pattern distinguishes
— found **0 differences**.

## User Impact

A path-shaped tool-metadata value ending in a tab or newline no longer stalls
message streaming. Grouping behavior is unchanged.

## Evidence

**Regression test.** `stays responsive on path-shaped metadata that ends in a
tab` fails on the pre-fix source and passes on the fixed source:

```
# pre-fix
× stays responsive on path-shaped metadata that ends in a tab 24241ms
  → expected 24233.325448 to be less than 1000
  Tests  1 failed | 6 passed (7)

# fixed
✓ stays responsive on path-shaped metadata that ends in a tab 1ms
  Tests  7 passed (7)
```

A second test pins the grouping behavior the regex feeds (`/tmp/dir/{a.txt,
b.txt}` and the single-segment `/only` case).

**Checks.** `oxfmt --check` and `oxlint` on both changed files — clean.

**Pre-existing failure, not from this change.** `pnpm tsgo:core` fails on
`src/infra/install-package-dir.ts(551,15): error TS2353 ... 'assertBeforeRename'
does not exist in type 'MovePathWithCopyFallbackOptions'`, which reproduces on
this branch's base with the changed files stashed.

## How This Was Found

CodeQL `js/redos` over a database of `src/` flagged this pattern as exponential
on "strings starting with `/` and containing many repetitions of `!/`". The
witness CodeQL suggests is space-terminated and is rejected by the guards above
the regex; substituting a tab reaches it, which is what the numbers above
measure.

## Diff accounting

- production: +5 / -1
- tests: +19 / -0
