### PR TITLE
refactor(cli): consolidate root argument scanners

### DIFF
--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -12,8 +12,8 @@ import { CORE_CLI_COMMAND_DESCRIPTORS } from "./program/core-command-descriptors
 import { SUB_CLI_DESCRIPTORS } from "./program/subcli-descriptors.js";
 
 const HELP_FLAGS = new Set(["-h", "--help"]);
-const VERSION_FLAGS = new Set(["-V", "--version"]);
-const ROOT_VERSION_ALIAS_FLAG = "-v";
+const ROOT_VERSION_ALIAS_FLAGS = new Set(["-v"]);
+const VERSION_FLAGS = new Set(["-V", "--version", ...ROOT_VERSION_ALIAS_FLAGS]);
 const ROOT_COMMAND_DESCRIPTORS = [
   ...CORE_CLI_COMMAND_DESCRIPTORS.filter(
     (descriptor) => descriptor.name !== "claws" || isExperimentalClawsEnabled(),
@@ -92,42 +92,14 @@ export function hasFlag(argv: string[], name: string): boolean {
 }
 
 export function hasRootVersionAlias(argv: string[]): boolean {
-  const args = argv.slice(2);
-  let hasAlias = false;
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i];
-    if (!arg) {
-      continue;
-    }
-    if (arg === FLAG_TERMINATOR) {
-      break;
-    }
-    if (arg === ROOT_VERSION_ALIAS_FLAG) {
-      hasAlias = true;
-      continue;
-    }
-    const consumed = consumeRootOptionToken(args, i);
-    if (consumed > 0) {
-      i += consumed - 1;
-      continue;
-    }
-    if (arg.startsWith("-")) {
-      return false;
-    }
-    return false;
-  }
-  return hasAlias;
+  return isRootInvocationForFlags(argv, ROOT_VERSION_ALIAS_FLAGS);
 }
 
 export function isRootVersionInvocation(argv: string[]): boolean {
-  return isRootInvocationForFlags(argv, VERSION_FLAGS, { includeVersionAlias: true });
+  return isRootInvocationForFlags(argv, VERSION_FLAGS);
 }
 
-function isRootInvocationForFlags(
-  argv: string[],
-  targetFlags: Set<string>,
-  options?: { includeVersionAlias?: boolean },
-): boolean {
+function isRootInvocationForFlags(argv: string[], targetFlags: ReadonlySet<string>): boolean {
   const args = argv.slice(2);
   let hasTarget = false;
   for (let i = 0; i < args.length; i += 1) {
@@ -138,10 +110,7 @@ function isRootInvocationForFlags(
     if (arg === FLAG_TERMINATOR) {
       break;
     }
-    if (
-      targetFlags.has(arg) ||
-      (options?.includeVersionAlias === true && arg === ROOT_VERSION_ALIAS_FLAG)
-    ) {
+    if (targetFlags.has(arg)) {
       hasTarget = true;
       continue;
     }
@@ -338,11 +307,15 @@ function consumeRootLogLevelToken(args: readonly string[], index: number): numbe
   return 0;
 }
 
-function splitRootOptionPrefix(argv: string[]): {
-  prefix: string[];
-  rootPrefix: string[];
-  remainingArgs: string[];
-} {
+function normalizeRootOptionArgv(
+  argv: string[],
+  consumeOption: (args: readonly string[], index: number) => number,
+  shouldPreserve: (
+    remainingArgs: readonly string[],
+    index: number,
+    consumed: number,
+  ) => boolean | undefined,
+): string[] {
   const prefix = argv.slice(0, 2);
   const args = argv.slice(2);
   let rootPrefixEnd = 0;
@@ -358,19 +331,9 @@ function splitRootOptionPrefix(argv: string[]): {
     rootPrefixEnd = index + consumed;
     index += consumed - 1;
   }
-  return {
-    prefix,
-    rootPrefix: args.slice(0, rootPrefixEnd),
-    remainingArgs: args.slice(rootPrefixEnd),
-  };
-}
-
-export function normalizeRootNoColorArgv(
-  argv: string[],
-  options: NormalizeRootNoColorArgvOptions = {},
-): string[] {
-  const { prefix, rootPrefix, remainingArgs } = splitRootOptionPrefix(argv);
-  const movedNoColorArgs: string[] = [];
+  const rootPrefix = args.slice(0, rootPrefixEnd);
+  const remainingArgs = args.slice(rootPrefixEnd);
+  const movedArgs: string[] = [];
   const nextArgs: string[] = [];
   for (let index = 0; index < remainingArgs.length; index += 1) {
     const arg = remainingArgs.at(index);
@@ -381,57 +344,18 @@ export function normalizeRootNoColorArgv(
       nextArgs.push(...remainingArgs.slice(index));
       break;
     }
-    if (arg === "--no-color") {
-      // Commander can treat dash-prefixed tokens as command option values.
-      // Early callers stay conservative; final Commander parse can pass metadata.
-      const shouldPreserve =
-        options.shouldPreserveNoColor?.({ remainingArgs, noColorIndex: index }) ??
-        isPossibleCommandOptionValue(remainingArgs, index);
-      if (shouldPreserve) {
-        nextArgs.push(arg);
-        continue;
-      }
-      movedNoColorArgs.push(arg);
-      continue;
-    }
-    nextArgs.push(arg);
-  }
-
-  if (movedNoColorArgs.length === 0) {
-    return argv;
-  }
-  return [...prefix, ...rootPrefix, ...movedNoColorArgs, ...nextArgs];
-}
-
-export function normalizeRootLogLevelArgv(
-  argv: string[],
-  options: NormalizeRootLogLevelArgvOptions = {},
-): string[] {
-  const { prefix, rootPrefix, remainingArgs } = splitRootOptionPrefix(argv);
-  const movedLogLevelArgs: string[] = [];
-  const nextArgs: string[] = [];
-  for (let index = 0; index < remainingArgs.length; index += 1) {
-    const arg = remainingArgs.at(index);
-    if (arg === undefined) {
-      break;
-    }
-    if (arg === FLAG_TERMINATOR) {
-      nextArgs.push(...remainingArgs.slice(index));
-      break;
-    }
-    const consumed = consumeRootLogLevelToken(remainingArgs, index);
+    const consumed = consumeOption(remainingArgs, index);
     if (consumed > 0) {
-      const shouldPreserve =
-        options.shouldPreserveLogLevel?.({
-          remainingArgs,
-          logLevelIndex: index,
-          consumed,
-        }) ?? isPossibleCommandOptionValue(remainingArgs, index);
+      // Commander accepts dash-prefixed option values. Early callers preserve
+      // possible values; the final parse uses the registered command metadata.
+      const preserve =
+        shouldPreserve(remainingArgs, index, consumed) ??
+        isPossibleCommandOptionValue(remainingArgs, index);
       const tokens = remainingArgs.slice(index, index + consumed);
-      if (shouldPreserve) {
+      if (preserve) {
         nextArgs.push(...tokens);
       } else {
-        movedLogLevelArgs.push(...tokens);
+        movedArgs.push(...tokens);
       }
       index += consumed - 1;
       continue;
@@ -439,10 +363,34 @@ export function normalizeRootLogLevelArgv(
     nextArgs.push(arg);
   }
 
-  if (movedLogLevelArgs.length === 0) {
+  if (movedArgs.length === 0) {
     return argv;
   }
-  return [...prefix, ...rootPrefix, ...movedLogLevelArgs, ...nextArgs];
+  return [...prefix, ...rootPrefix, ...movedArgs, ...nextArgs];
+}
+
+export function normalizeRootNoColorArgv(
+  argv: string[],
+  options: NormalizeRootNoColorArgvOptions = {},
+): string[] {
+  return normalizeRootOptionArgv(
+    argv,
+    (args, index) => (args[index] === "--no-color" ? 1 : 0),
+    (remainingArgs, noColorIndex) =>
+      options.shouldPreserveNoColor?.({ remainingArgs, noColorIndex }),
+  );
+}
+
+export function normalizeRootLogLevelArgv(
+  argv: string[],
+  options: NormalizeRootLogLevelArgvOptions = {},
+): string[] {
+  return normalizeRootOptionArgv(
+    argv,
+    consumeRootLogLevelToken,
+    (remainingArgs, logLevelIndex, consumed) =>
+      options.shouldPreserveLogLevel?.({ remainingArgs, logLevelIndex, consumed }),
+  );
 }
 
 export function getFlagValue(argv: string[], name: string): string | null | undefined {

--- a/src/cli/config-output-mode.ts
+++ b/src/cli/config-output-mode.ts
@@ -1,5 +1,4 @@
-import { consumeRootOptionToken } from "../infra/cli-root-options.js";
-import { findMachineOutputRootCommandIndex } from "./machine-output-argv.js";
+import { consumeRootOptionToken, findRootCommandIndex } from "../infra/cli-root-options.js";
 
 function hasFlag(argv: readonly string[], flag: string): boolean {
   for (const arg of argv.slice(2)) {
@@ -14,17 +13,16 @@ function hasFlag(argv: readonly string[], flag: string): boolean {
 }
 
 function resolveConfigSubcommand(argv: readonly string[]): string | null {
-  const rootIndex = findMachineOutputRootCommandIndex(argv);
+  const rootIndex = findRootCommandIndex(argv);
   if (rootIndex === null) {
     return null;
   }
-  const args = argv.slice(2);
-  for (let index = rootIndex - 1; index < args.length; index += 1) {
-    const arg = args[index];
+  for (let index = rootIndex + 1; index < argv.length; index += 1) {
+    const arg = argv[index];
     if (!arg || arg === "--") {
       return null;
     }
-    const rootConsumed = consumeRootOptionToken(args, index);
+    const rootConsumed = consumeRootOptionToken(argv, index);
     if (rootConsumed > 0) {
       index += rootConsumed - 1;
       continue;

--- a/src/cli/gateway-run-argv.ts
+++ b/src/cli/gateway-run-argv.ts
@@ -1,6 +1,7 @@
 // Fast-path argv parser for `openclaw gateway ...` without full Commander registration.
 import {
   consumeRootOptionToken,
+  findRootCommandIndex,
   getCommandPositionalsWithRootOptions,
   isValueToken,
 } from "../infra/cli-root-options.js";
@@ -109,47 +110,29 @@ export function consumeGatewayFastPathRootOptionToken(
   return 0;
 }
 
-function resolveGatewayCommandStart(argv: string[]): {
-  args: string[];
-  startIndex: number;
-} | null {
-  const args = argv.slice(2);
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (!arg || arg === "--") {
-      return null;
-    }
-    const consumed = consumeRootOptionToken(args, index);
-    if (consumed > 0) {
-      index += consumed - 1;
-      continue;
-    }
-    if (arg.startsWith("-")) {
-      continue;
-    }
-    return arg === "gateway" ? { args, startIndex: index + 1 } : null;
-  }
-  return null;
+function resolveGatewayCommandStart(argv: string[]): number | null {
+  const index = findRootCommandIndex(argv);
+  return index !== null && argv[index] === "gateway" ? index + 1 : null;
 }
 
 /** Resolve the gateway command path from raw argv without full Commander registration. */
 export function resolveGatewayCommandPath(argv: string[], depth = 2): string[] | null {
-  const gateway = resolveGatewayCommandStart(argv);
-  if (!gateway) {
+  const startIndex = resolveGatewayCommandStart(argv);
+  if (startIndex === null) {
     return null;
   }
   const commandPath = ["gateway"];
-  for (let index = gateway.startIndex; index < gateway.args.length; index += 1) {
-    const arg = gateway.args[index];
+  for (let index = startIndex; index < argv.length; index += 1) {
+    const arg = argv[index];
     if (!arg || arg === "--") {
       break;
     }
-    const rootConsumed = consumeRootOptionToken(gateway.args, index);
+    const rootConsumed = consumeRootOptionToken(argv, index);
     if (rootConsumed > 0) {
       index += rootConsumed - 1;
       continue;
     }
-    const consumed = consumeGatewayRunOptionToken(gateway.args, index);
+    const consumed = consumeGatewayRunOptionToken(argv, index);
     if (consumed > 0) {
       index += consumed - 1;
       continue;
@@ -175,16 +158,16 @@ export function resolveGatewayCatalogCommandPath(argv: string[]): string[] | nul
 export function resolveGatewayRunPreBootstrapOptions(
   argv: string[],
 ): { force: boolean; reset: boolean } | null {
-  const gateway = resolveGatewayCommandStart(argv);
-  if (!gateway) {
+  const startIndex = resolveGatewayCommandStart(argv);
+  if (startIndex === null) {
     return null;
   }
   let force = false;
   let reset = false;
   let sawRun = false;
 
-  for (let index = gateway.startIndex; index < gateway.args.length; index += 1) {
-    const arg = gateway.args[index];
+  for (let index = startIndex; index < argv.length; index += 1) {
+    const arg = argv[index];
     if (!arg || arg === "--") {
       break;
     }
@@ -192,7 +175,7 @@ export function resolveGatewayRunPreBootstrapOptions(
       sawRun = true;
       continue;
     }
-    const consumed = consumeGatewayRunPreBootstrapOptionToken(gateway.args, index);
+    const consumed = consumeGatewayRunPreBootstrapOptionToken(argv, index);
     if (consumed > 0) {
       if (arg === "--force") {
         force = true;

--- a/src/cli/machine-output-argv.ts
+++ b/src/cli/machine-output-argv.ts
@@ -1,7 +1,4 @@
-import {
-  consumeRootOptionToken,
-  getRootOptionAwareCommandPath,
-} from "../infra/cli-root-options.js";
+import { getRootOptionAwareCommandPath } from "../infra/cli-root-options.js";
 
 export type MachineOutputResolverParams = {
   argv: readonly string[];
@@ -18,27 +15,6 @@ export function isMachineOutputStdoutTTY(
   stdout: { readonly isTTY?: boolean } = process.stdout,
 ): boolean {
   return stdout.isTTY === true;
-}
-
-/** Locate the root command after supported root options without loading descriptor catalogs. */
-export function findMachineOutputRootCommandIndex(argv: readonly string[]): number | null {
-  const args = argv.slice(2);
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (!arg || arg === "--") {
-      return null;
-    }
-    const consumed = consumeRootOptionToken(args, index);
-    if (consumed > 0) {
-      index += consumed - 1;
-      continue;
-    }
-    if (arg.startsWith("-")) {
-      continue;
-    }
-    return index + 2;
-  }
-  return null;
 }
 
 /** Read positional command tokens after supported root options, without importing CLI catalogs. */

--- a/src/cli/skills-output-mode.ts
+++ b/src/cli/skills-output-mode.ts
@@ -1,11 +1,8 @@
-import { consumeRootOptionToken } from "../infra/cli-root-options.js";
-import {
-  findMachineOutputRootCommandIndex,
-  hasMachineOutputOption,
-} from "./machine-output-argv.js";
+import { consumeRootOptionToken, findRootCommandIndex } from "../infra/cli-root-options.js";
+import { hasMachineOutputOption } from "./machine-output-argv.js";
 
 function resolveSkillsSubcommand(argv: readonly string[]): string | null {
-  const rootIndex = findMachineOutputRootCommandIndex(argv);
+  const rootIndex = findRootCommandIndex(argv);
   if (rootIndex === null) {
     return null;
   }
@@ -14,7 +11,7 @@ function resolveSkillsSubcommand(argv: readonly string[]): string | null {
     if (!arg || arg === "--") {
       return null;
     }
-    const rootConsumed = consumeRootOptionToken(argv.slice(2), index - 2);
+    const rootConsumed = consumeRootOptionToken(argv, index);
     if (rootConsumed > 0) {
       index += rootConsumed - 1;
       continue;

--- a/src/infra/cli-root-options.ts
+++ b/src/infra/cli-root-options.ts
@@ -37,6 +37,25 @@ export function consumeRootOptionToken(args: ReadonlyArray<string>, index: numbe
   return 0;
 }
 
+/** Locate the root command after supported root options without loading CLI catalogs. */
+export function findRootCommandIndex(argv: readonly string[]): number | null {
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg || arg === FLAG_TERMINATOR) {
+      return null;
+    }
+    const consumed = consumeRootOptionToken(argv, index);
+    if (consumed > 0) {
+      index += consumed - 1;
+      continue;
+    }
+    if (!arg.startsWith("-")) {
+      return index;
+    }
+  }
+  return null;
+}
+
 /** Read positional command tokens while accepting root options at any pre-terminator position. */
 export function getRootOptionAwareCommandPath(argv: readonly string[], depth: number): string[] {
   const args = argv.slice(2);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Maintainer-requested cleanup of CLI argument handling as part of reducing production code while preserving functionality. Global flag handling and machine-output detection used separate copies of the same scanners, making it easier for fixes to drift between command paths.

## Why This Change Was Made

Use one root-option relocation loop, the existing root flag scanner for version aliases, and one root-command index finder shared by Gateway, config, and skills. Keep each caller's existing option ownership rules and operate directly on the original argument indices.

Production LOC: **+94 / -173, net -79** across six files. Test LOC: **0**. No dependencies, configuration keys, defaults, storage, or public CLI syntax change.

## User Impact

No intended behavior change. Root and subcommand flags, dash-prefixed values, argument terminators, version aliases, Gateway pre-bootstrap flags, and clean machine output retain their existing behavior.

## Evidence

- **268 existing tests passed** across nine files: `argv`, `cli-root-options`, `run-main`, `machine-output-modes`, `banner`, `build-program.version-alias`, `argv-invocation`, `route-args`, and `help`. No duplicate tests added for this behavior-preserving refactor.
- **144,136 before/after argv cases matched**, including relocation output and return identity, preservation-callback arguments and order, help/version detection, Gateway command paths and force/reset interpretation, and config/skills output modes.
- **`pnpm build` passed** on the final source.
- **`node scripts/check-changed.mjs -- src/cli/argv.ts src/cli/gateway-run-argv.ts src/cli/machine-output-argv.ts src/cli/config-output-mode.ts src/cli/skills-output-mode.ts src/infra/cli-root-options.ts` passed**, including core/test types, lint, dead-export checks, and import-cycle checks.
- **Eight real built CLI runs passed** through `node openclaw.mjs`, using an isolated temporary home/state/config: `--version`, `-v`, `--profile argv-proof -v`, root help with `--no-color --log-level warn`, Gateway child help with trailing `--no-color`, Gateway parent help with `--log-level=debug`, `config --log-level=warn file --no-color`, and `skills --agent proof verify --help`. All exited 0 without stderr or ANSI contamination; config-file stdout was exactly the configured path. Temporary state was removed.
- **Independent Codex P2 autoreview: scoped-clean**, no accepted/actionable findings.
- Checked Commander 15's `parseOptions` source for required-value and terminator behavior, and the original helpers in stable tag `v2026.8.2`.
