### PR TITLE
fix: session diff includes unchanged files after large additions

### DIFF
--- a/src/gateway/server-methods/sessions-diff.test.ts
+++ b/src/gateway/server-methods/sessions-diff.test.ts
@@ -573,6 +573,23 @@ describe("loadSessionDiff", () => {
     expect(changed.files[0]?.binary).toBe(true);
   });
 
+  it("keeps pre-session changes hidden when new files exceed the fingerprint budget", async () => {
+    initRepo(repoRoot);
+    fs.writeFileSync(path.join(repoRoot, "z-existing.txt"), "preexisting work\n");
+    const baseline = await captureSessionDiffBaseline({ cwd: repoRoot, sessionId: "s1" });
+    expect(baseline?.files.map((file) => file.path)).toEqual(["z-existing.txt"]);
+    const addedPaths = Array.from({ length: 4 }, (_, index) => `a-new-${index}.bin`);
+    for (const filePath of addedPaths) {
+      fs.writeFileSync(path.join(repoRoot, filePath), Buffer.alloc(4 * 1024 * 1024));
+    }
+    mockSession(repoRoot, { sessionDiffBaseline: baseline });
+
+    const result = await loadSessionDiff({ sessionKey: "agent:main:s1" });
+
+    expect(result.files.map((file) => file.path)).toEqual(addedPaths);
+    expect(result.additions).toBe(0);
+  });
+
   it("skips oversized files instead of materializing them during baseline capture", async () => {
     initRepo(repoRoot);
     fs.writeFileSync(path.join(repoRoot, "large.txt"), Buffer.alloc(4 * 1024 * 1024 + 1, 97));

--- a/src/sessions/session-diff.ts
+++ b/src/sessions/session-diff.ts
@@ -726,8 +726,10 @@ export async function applySessionDiffBaseline(params: {
     return diff;
   }
   const fingerprints = new Map(baseline.files.map((file) => [file.path, file.fingerprint]));
+  // New paths cannot match the baseline; hashing them can exhaust the budget
+  // before an unchanged pre-session file is compared.
   const current = await fingerprintBaselineCandidates({
-    candidates: diff.files,
+    candidates: diff.files.filter((file) => fingerprints.has(file.path)),
     root: diff.root,
   });
   const currentFingerprints = new Map(current.files.map((file) => [file.path, file.fingerprint]));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the session diff panel shows unchanged pre-session files as session changes after enough large new files are added. Those unrelated files can also inflate the displayed additions count.

## Why This Change Was Made

Baseline comparison now fingerprints only paths that were captured at session start. Newly created paths cannot match that baseline, and reading them consumed the bounded hash budget before existing paths could be compared. The existing session/root checks, content-safety checks, and hash limits stay in the same owner.

## User Impact

Unchanged pre-session files remain hidden while new files remain visible. Diff refresh also avoids reading and hashing new file content solely for baseline comparison.

## Evidence

- The added real-Git regression fails before the fix: four new 4 MiB files cause an unchanged `z-existing.txt` to reappear. It passes after the fix.
- All 46 focused tests pass across the session-diff RPC, baseline lifecycle, and revision owners, including binary files, filenames containing newlines, hardlinks, textconv/fsmonitor refusal, commit scopes, and session-generation checks.
- A separate real-filesystem probe reduces baseline comparison reads from 16 MiB to the existing file's 17 bytes; an empty baseline reads zero file content. These are synthetic local observations, not attribution for production latency.
- Fresh independent review found no actionable P0–P2 findings. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33946554087) is green. The complete Linux changed-source gate passed in 732.79 seconds, including core/test typechecks, lint, dead-export scans, and import-cycle checks.

Production is +3/-1 (two explanatory comment lines); the regression test adds 17 lines. No configuration, schema, dependency, or RPC change. The separate cost of serial Git commands for untracked files remains a follow-up. A second recorded follow-up concerns large untracked text: a synthetic 140,000-line file is marked truncated but reports zero additions when the bounded 16 MiB subprocess tail drops its patch hunk header. That stats/patch ownership repair is separate from this baseline-comparison fix.

## Real Gateway and browser proof

An independent Linux comparison built the runtime and bundled Control UI separately from baseline `d5992278b3b8a8f3e1e37c23749b86efec65215f` and the exact candidate `e4827c2ebb31682f82169462b3b9f36c912ee48a`. A synthetic session captured its baseline before the four new binary files were created. The real compiled Gateway RPC and Chromium Files → Review flow both failed the same four-file assertion before the repair and passed afterward: `z-existing.txt` disappeared from Review, and the four new files stayed visible.

The fixture seeds session state through the canonical owner and uses synthetic messages; it does not invoke a model provider. Node 24.19.0, pnpm 12.1.0, Git 2.52.0. All 37,956 tracked files per revision and the complete built-artifact inventory were verified unchanged across the proof. Both Gateway processes closed successfully, with no signals or surviving owned process groups. Screenshots and video frames were personally inspected and contain only synthetic data.

The first remote attempt failed before installation because the source capsule lacked the original baseline Git object. The next attempt fetched that exact public commit and completed the unchanged comparison. Local full-gate attempts were canceled and fully joined under host filesystem contention; those are not reported as passing checks. An initial local test import failed because package-local dependency links were missing; after matching dependency manifests and wiring the existing dependency tree, all 46 tests passed.

Direct GitHub image upload returned HTTP 403; the inspected media uses the canonical Crabbox artifact publisher. The full proof archive is 2,026,674 bytes, SHA-256 `cbb3e0076dc444e75f0e19ac554ba8c64950b77668c28415c3862a145aa9eb54`.

The complete changed gate verified the same 37,956 source files before and after, exited successfully, and left no owned process groups. Its compact archive SHA-256 is `616cb107ce41002b2fd84ee30e8a6bc69944744705d2ebaeb86255de854c5658`. The Linux lease was stopped through its canonical owner and is completed.

## Review disposition

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/138877#issuecomment-5549753990) has no code or security findings. Its two before-merge evidence requests and sole Rank-up move are addressed by the real Gateway/browser comparison and inspected captures below. The source has not changed since that review.

## Inspected captures

[Crabbox artifact manifest](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjU4NDkz/openclaw/pr-138877/sessions-diff-20260905-e4827c2/artifact-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260905T060410Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260905%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=ba80393648929cf110edf9756e18f11ada5c5de02da7cd93ef7454ff8b4f568b). The signed links expire **September 12, 2026 at 06:04 UTC**; the original media and full hashed proof receipts are retained.

Before: the unchanged pre-session file appears as an added line.

![Before: four new binary files plus an unchanged pre-session file](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjU4NDkz/openclaw/pr-138877/sessions-diff-20260905-e4827c2/before.png?X-Amz-Expires=604800&X-Amz-Date=20260905T060405Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260905%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=54b8c771f89aa364303fb733e86e0be1ca5809522d5bcb9cc9dc60fc5e90ad8d)

After: only the four new files appear.

![After: only the four new binary files](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjU4NDkz/openclaw/pr-138877/sessions-diff-20260905-e4827c2/after.png?X-Amz-Expires=604800&X-Amz-Date=20260905T060405Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260905%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=9d06ebb5ee8f80b20c53136bb581a5cfee7c3adcb671c98b086a0b6e2c25f897)

Before recording:

https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjU4NDkz/openclaw/pr-138877/sessions-diff-20260905-e4827c2/before.webm?X-Amz-Expires=604800&X-Amz-Date=20260905T060405Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260905%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=f1ea955bc81b76b8ea923c6f56bc6e66854e009457d4f6bb88e56e1c30aa31de

After recording:

https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjU4NDkz/openclaw/pr-138877/sessions-diff-20260905-e4827c2/after.webm?X-Amz-Expires=604800&X-Amz-Date=20260905T060405Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260905%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=7860eb591d5e7cd747b0802d9d8207c908dd706f7faf45c404d4602232af7df2
