### PR TITLE
refactor(process): consolidate quoted argument parsing

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -277,6 +277,13 @@ managed stdio or the local Unix control socket for production workloads.
 | `networkProxy`                   | disabled                                               | Opt into Codex permissions-profile networking for app-server commands. OpenClaw defines the selected `permissions.<profile>.network` config and selects it with `default_permissions` instead of sending `sandbox`.                                                                                                                                                                                                                |
 | `experimental.sandboxExecServer` | `false`                                                | Preview opt-in that registers an OpenClaw sandbox-backed Codex environment with the supported Codex app-server so native Codex execution can run inside the active OpenClaw sandbox.                                                                                                                                                                                                                                               |
 
+`appServer.args` accepts an array (recommended) or a quoted argument string.
+`OPENCLAW_CODEX_APP_SERVER_ARGS` uses the same string parsing. On macOS and
+Linux, backslash escapes preserve quoted TOML values and spaces in paths;
+Windows keeps path backslashes literal. `#` is always a literal argument character.
+Unterminated quotes or incomplete escapes fail before launch. Use the array form
+when arguments need literal quotes or backslashes.
+
 `appServer.serviceTier` is used only when no shared Fast-mode run control is
 supplied. On Codex harness turns, shared Fast on sends `priority`, Fast off
 sends `null` to clear the OpenClaw-owned tier, and auto decides for each model

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -278,11 +278,27 @@ managed stdio or the local Unix control socket for production workloads.
 | `experimental.sandboxExecServer` | `false`                                                | Preview opt-in that registers an OpenClaw sandbox-backed Codex environment with the supported Codex app-server so native Codex execution can run inside the active OpenClaw sandbox.                                                                                                                                                                                                                                               |
 
 `appServer.args` accepts an array (recommended) or a quoted argument string.
-`OPENCLAW_CODEX_APP_SERVER_ARGS` uses the same string parsing. On macOS and
-Linux, backslash escapes preserve quoted TOML values and spaces in paths;
-Windows keeps path backslashes literal. `#` is always a literal argument character.
-Unterminated quotes or incomplete escapes fail before launch. Use the array form
-when arguments need literal quotes or backslashes.
+`OPENCLAW_CODEX_APP_SERVER_ARGS` uses the same string parsing on every platform:
+single and double quotes group words, backslashes and `#` stay literal, and an
+unfinished quote groups the remaining text. This preserves the string grammar
+shipped in `v2026.9.1`; strings do not use shell escaping.
+
+Use array entries for values containing embedded quotes, such as
+`'model="gpt-5.6-luna"'`. For a directory containing a literal backslash, both
+forms below pass the same path to Codex:
+
+```json5 validate=false
+args: "app-server --listen stdio:// -c log_dir=/tmp/openclaw\\logs"
+```
+
+```json5 validate=false
+args: ["app-server", "--listen", "stdio://", "-c", "log_dir=/tmp/openclaw\\logs"]
+```
+
+The `\\` in JSON5 encodes one backslash. Array entries preserve embedded quotes
+and backslashes, but surrounding whitespace is trimmed and empty entries are
+omitted. Strings also omit empty quoted arguments. Account for these limits
+before converting existing strings to arrays.
 
 `appServer.serviceTier` is used only when no shared Fast-mode run control is
 supplied. On Codex harness turns, shared Fast on sends `priority`, Fast off

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -1434,7 +1434,8 @@ does not reserve it against a subsequent native reload.
 
 - `OPENCLAW_CODEX_APP_SERVER_BIN` bypasses the managed binary when
   `appServer.command` is unset.
-- `OPENCLAW_CODEX_APP_SERVER_ARGS`
+- `OPENCLAW_CODEX_APP_SERVER_ARGS` accepts a quoted argument string; see
+  [argument parsing](/plugins/codex-harness-reference#app-server-transport).
 - `OPENCLAW_CODEX_APP_SERVER_MODE=yolo|guardian`
 - `OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY`
 - `OPENCLAW_CODEX_APP_SERVER_SANDBOX`

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -69,10 +69,11 @@ Native command probes should use `runCommandWithTimeout` from
 before returning. For commands whose output is always UTF-8, such as JSON status
 probes, use `runUtf8CommandWithTimeout` from the same subpath.
 
-Use `splitCommandArgs(raw, platform?)` from the same subpath to parse quoted
-process arguments without treating `#` as a comment or expanding variables.
-It defaults to the current platform, preserves Windows path backslashes, and
-uses POSIX backslash escapes elsewhere. Unterminated quotes or escapes return `null`.
+Use `splitCommandArgs(raw)` from the same subpath to group quoted process
+arguments. Backslashes and `#` stay literal; there is no shell expansion.
+Unfinished quotes return `null` unless the caller passes
+`{ allowUnclosedQuotes: true }` to preserve an existing permissive input contract.
+Empty quoted arguments are omitted.
 
 Existing process owners can use `signalProcessTree`. Its `onComplete` callback runs after Unix
 signaling or the bounded Windows `taskkill` attempt, not proof that every process

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -69,6 +69,11 @@ Native command probes should use `runCommandWithTimeout` from
 before returning. For commands whose output is always UTF-8, such as JSON status
 probes, use `runUtf8CommandWithTimeout` from the same subpath.
 
+Use `splitCommandArgs(raw, platform?)` from the same subpath to parse quoted
+process arguments without treating `#` as a comment or expanding variables.
+It defaults to the current platform, preserves Windows path backslashes, and
+uses POSIX backslash escapes elsewhere. Unterminated quotes or escapes return `null`.
+
 Existing process owners can use `signalProcessTree`. Its `onComplete` callback runs after Unix
 signaling or the bounded Windows `taskkill` attempt, not proof that every process
 exited. Keep the probe pending through cleanup, use `detached: true` only for a

--- a/extensions/codex/src/app-server/config-args.test.ts
+++ b/extensions/codex/src/app-server/config-args.test.ts
@@ -1,38 +1,59 @@
 import { describe, expect, it } from "vitest";
 import { resolveCodexAppServerRuntimeOptions } from "./config-runtime.js";
 
-describe("Codex app-server command arguments", () => {
-  it.skipIf(process.platform === "win32").each(["config", "env"] as const)(
-    "preserves escaped TOML quotes and paths from %s arguments",
-    (source) => {
-      const raw = String.raw`app-server -c "model=\"gpt-5.6-luna\"" --listen unix:///tmp/codex\ socket #literal`;
-      const runtime = resolveCodexAppServerRuntimeOptions({
-        pluginConfig: {
-          appServer: { mode: "yolo", ...(source === "config" ? { args: raw } : {}) },
-        },
-        env: source === "env" ? { OPENCLAW_CODEX_APP_SERVER_ARGS: raw } : {},
-        requirementsToml: null,
-        codexConfigToml: null,
-      });
-      expect(runtime.start.args).toEqual([
+describe.each(["config", "env"] as const)("Codex app-server %s arguments", (source) => {
+  it.each([
+    {
+      raw: String.raw`app-server -c log_dir=/tmp/openclaw\logs --listen stdio://`,
+      expected: [
         "app-server",
         "-c",
-        'model="gpt-5.6-luna"',
+        String.raw`log_dir=/tmp/openclaw\logs`,
         "--listen",
-        "unix:///tmp/codex socket",
-        "#literal",
-      ]);
+        "stdio://",
+      ],
     },
-  );
-
-  it("rejects unterminated arguments before launching a process", () => {
-    expect(() =>
-      resolveCodexAppServerRuntimeOptions({
-        pluginConfig: { appServer: { mode: "yolo", args: 'app-server --listen "stdio://' } },
-        env: {},
-        requirementsToml: null,
-        codexConfigToml: null,
-      }),
-    ).toThrow(/unterminated.*appServer\.args/s);
+    {
+      raw: 'app-server --listen "stdio://',
+      expected: ["app-server", "--listen", "stdio://"],
+    },
+  ])("preserves shipped string parsing: $raw", ({ raw, expected }) => {
+    const runtime = resolveCodexAppServerRuntimeOptions({
+      pluginConfig: {
+        appServer: { mode: "yolo", ...(source === "config" ? { args: raw } : {}) },
+      },
+      env: source === "env" ? { OPENCLAW_CODEX_APP_SERVER_ARGS: raw } : {},
+      requirementsToml: null,
+      codexConfigToml: null,
+    });
+    expect(runtime.start.args).toEqual(expected);
   });
+});
+
+it("preserves literal array values and existing whitespace normalization", () => {
+  const runtime = resolveCodexAppServerRuntimeOptions({
+    pluginConfig: {
+      appServer: {
+        mode: "yolo",
+        args: [
+          " app-server ",
+          "-c",
+          'model="gpt-5.6-luna"',
+          "-c",
+          String.raw`log_dir=/tmp/openclaw\logs`,
+          "",
+        ],
+      },
+    },
+    env: { OPENCLAW_CODEX_APP_SERVER_ARGS: "ignored" },
+    requirementsToml: null,
+    codexConfigToml: null,
+  });
+  expect(runtime.start.args).toEqual([
+    "app-server",
+    "-c",
+    'model="gpt-5.6-luna"',
+    "-c",
+    String.raw`log_dir=/tmp/openclaw\logs`,
+  ]);
 });

--- a/extensions/codex/src/app-server/config-args.test.ts
+++ b/extensions/codex/src/app-server/config-args.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveCodexAppServerRuntimeOptions } from "./config-runtime.js";
+
+describe("Codex app-server command arguments", () => {
+  it.skipIf(process.platform === "win32").each(["config", "env"] as const)(
+    "preserves escaped TOML quotes and paths from %s arguments",
+    (source) => {
+      const raw = String.raw`app-server -c "model=\"gpt-5.6-luna\"" --listen unix:///tmp/codex\ socket #literal`;
+      const runtime = resolveCodexAppServerRuntimeOptions({
+        pluginConfig: {
+          appServer: { mode: "yolo", ...(source === "config" ? { args: raw } : {}) },
+        },
+        env: source === "env" ? { OPENCLAW_CODEX_APP_SERVER_ARGS: raw } : {},
+        requirementsToml: null,
+        codexConfigToml: null,
+      });
+      expect(runtime.start.args).toEqual([
+        "app-server",
+        "-c",
+        'model="gpt-5.6-luna"',
+        "--listen",
+        "unix:///tmp/codex socket",
+        "#literal",
+      ]);
+    },
+  );
+
+  it("rejects unterminated arguments before launching a process", () => {
+    expect(() =>
+      resolveCodexAppServerRuntimeOptions({
+        pluginConfig: { appServer: { mode: "yolo", args: 'app-server --listen "stdio://' } },
+        env: {},
+        requirementsToml: null,
+        codexConfigToml: null,
+      }),
+    ).toThrow(/unterminated.*appServer\.args/s);
+  });
+});

--- a/extensions/codex/src/app-server/config-utils.ts
+++ b/extensions/codex/src/app-server/config-utils.ts
@@ -96,13 +96,11 @@ export function resolveArgs(configArgs: unknown, envArgs: string | undefined): s
       .map((entry) => readNonEmptyString(entry))
       .filter((entry): entry is string => entry !== undefined);
   }
-  const args = splitCommandArgs(typeof configArgs === "string" ? configArgs : (envArgs ?? ""));
-  if (!args) {
-    throw new Error(
-      "Codex app-server arguments contain an unterminated quote or escape; use appServer.args as an array for literal arguments.",
-    );
-  }
-  return args;
+  // v2026.9.1 string overrides preserve backslashes and accept unfinished quotes;
+  // applying shell escaping or strict quote validation would change existing argv.
+  return splitCommandArgs(typeof configArgs === "string" ? configArgs : (envArgs ?? ""), {
+    allowUnclosedQuotes: true,
+  });
 }
 
 export function hashSecretForKey(value: string | undefined, label: string): string | null {

--- a/extensions/codex/src/app-server/config-utils.ts
+++ b/extensions/codex/src/app-server/config-utils.ts
@@ -1,5 +1,6 @@
 import { createHmac, randomBytes } from "node:crypto";
 import { resolvePositiveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { splitCommandArgs } from "openclaw/plugin-sdk/process-runtime";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import {
   asOptionalRecord as readRecord,
@@ -95,10 +96,13 @@ export function resolveArgs(configArgs: unknown, envArgs: string | undefined): s
       .map((entry) => readNonEmptyString(entry))
       .filter((entry): entry is string => entry !== undefined);
   }
-  if (typeof configArgs === "string") {
-    return splitShellWords(configArgs);
+  const args = splitCommandArgs(typeof configArgs === "string" ? configArgs : (envArgs ?? ""));
+  if (!args) {
+    throw new Error(
+      "Codex app-server arguments contain an unterminated quote or escape; use appServer.args as an array for literal arguments.",
+    );
   }
-  return splitShellWords(envArgs ?? "");
+  return args;
 }
 
 export function hashSecretForKey(value: string | undefined, label: string): string | null {
@@ -118,36 +122,4 @@ function getStartOptionsKeySecret(): Buffer {
   };
   globalState[START_OPTIONS_KEY_SECRET_SYMBOL] ??= randomBytes(32);
   return globalState[START_OPTIONS_KEY_SECRET_SYMBOL];
-}
-
-function splitShellWords(value: string): string[] {
-  const words: string[] = [];
-  let current = "";
-  let quote: '"' | "'" | null = null;
-  for (const char of value) {
-    if (quote) {
-      if (char === quote) {
-        quote = null;
-      } else {
-        current += char;
-      }
-      continue;
-    }
-    if (char === '"' || char === "'") {
-      quote = char;
-      continue;
-    }
-    if (/\s/.test(char)) {
-      if (current) {
-        words.push(current);
-        current = "";
-      }
-      continue;
-    }
-    current += char;
-  }
-  if (current) {
-    words.push(current);
-  }
-  return words;
 }

--- a/src/agents/bash-tools.exec-script-target.ts
+++ b/src/agents/bash-tools.exec-script-target.ts
@@ -3,7 +3,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
-import { splitShellArgs } from "../utils/shell-argv.js";
+import { splitCommandArgs, splitShellArgs } from "../utils/shell-argv.js";
 
 const PREFLIGHT_ENV_OPTIONS_WITH_VALUES = new Set([
   "-C",
@@ -226,71 +226,14 @@ export function extractScriptTargetFromCommand(
   command: string,
 ): { kind: "python"; relOrAbsPaths: string[] } | { kind: "node"; relOrAbsPaths: string[] } | null {
   const raw = command.trim();
-  const splitShellArgsPreservingBackslashes = (value: string): string[] | null => {
-    const tokens: string[] = [];
-    let buf = "";
-    let inSingle = false;
-    let inDouble = false;
-
-    const pushToken = () => {
-      if (buf.length > 0) {
-        tokens.push(buf);
-        buf = "";
-      }
-    };
-
-    for (const ch of value) {
-      if (inSingle) {
-        if (ch === "'") {
-          inSingle = false;
-        } else {
-          buf += ch;
-        }
-        continue;
-      }
-      if (inDouble) {
-        if (ch === '"') {
-          inDouble = false;
-        } else {
-          buf += ch;
-        }
-        continue;
-      }
-      if (ch === "'") {
-        inSingle = true;
-        continue;
-      }
-      if (ch === '"') {
-        inDouble = true;
-        continue;
-      }
-      if (/\s/.test(ch)) {
-        pushToken();
-        continue;
-      }
-      buf += ch;
-    }
-
-    if (inSingle || inDouble) {
-      return null;
-    }
-    pushToken();
-    return tokens;
-  };
   const shouldUseWindowsPathTokenizer =
     process.platform === "win32" &&
     /(?:^|[\s"'`])(?:[A-Za-z]:\\|\\\\|[^\s"'`|&;()<>]+\\[^\s"'`|&;()<>]+)/.test(raw);
-  const candidateArgv = shouldUseWindowsPathTokenizer
-    ? [splitShellArgsPreservingBackslashes(raw)]
-    : [splitShellArgs(raw)];
-
-  for (const argv of candidateArgv) {
-    const attempts = [argv, argv ? stripPreflightEnvPrefix(argv) : null];
-    for (const attempt of attempts) {
-      const target = extractInterpreterScriptTargetFromArgv(attempt);
-      if (target) {
-        return target;
-      }
+  const argv = shouldUseWindowsPathTokenizer ? splitCommandArgs(raw, "win32") : splitShellArgs(raw);
+  for (const attempt of [argv, argv ? stripPreflightEnvPrefix(argv) : null]) {
+    const target = extractInterpreterScriptTargetFromArgv(attempt);
+    if (target) {
+      return target;
     }
   }
   return null;

--- a/src/agents/bash-tools.exec-script-target.ts
+++ b/src/agents/bash-tools.exec-script-target.ts
@@ -229,7 +229,7 @@ export function extractScriptTargetFromCommand(
   const shouldUseWindowsPathTokenizer =
     process.platform === "win32" &&
     /(?:^|[\s"'`])(?:[A-Za-z]:\\|\\\\|[^\s"'`|&;()<>]+\\[^\s"'`|&;()<>]+)/.test(raw);
-  const argv = shouldUseWindowsPathTokenizer ? splitCommandArgs(raw, "win32") : splitShellArgs(raw);
+  const argv = shouldUseWindowsPathTokenizer ? splitCommandArgs(raw) : splitShellArgs(raw);
   for (const attempt of [argv, argv ? stripPreflightEnvPrefix(argv) : null]) {
     const target = extractInterpreterScriptTargetFromArgv(attempt);
     if (target) {

--- a/src/plugin-sdk/process-runtime.ts
+++ b/src/plugin-sdk/process-runtime.ts
@@ -1,5 +1,6 @@
 // Public process helpers for plugins that spawn or probe local commands.
 
+export { splitCommandArgs } from "../utils/shell-argv.js";
 export {
   type CommandOptions,
   resolveCommandEnv,

--- a/src/utils/shell-argv.ts
+++ b/src/utils/shell-argv.ts
@@ -55,6 +55,22 @@ export function hasTopLevelShellControlOperator(raw: string): boolean {
 
 /** Splits a shell-like argv string into tokens, returning null for unterminated quotes or escapes. */
 export function splitShellArgs(raw: string): string[] | null {
+  return splitQuotedArgs(raw, "shell");
+}
+
+/** Splits process arguments without shell comments; Windows paths retain literal backslashes. */
+export function splitCommandArgs(
+  raw: string,
+  platform: NodeJS.Platform = process.platform,
+): string[] | null {
+  return splitQuotedArgs(raw, platform === "win32" ? "windows-command" : "posix-command");
+}
+
+function splitQuotedArgs(
+  raw: string,
+  syntax: "shell" | "posix-command" | "windows-command",
+): string[] | null {
+  const backslashEscapes = syntax !== "windows-command";
   const tokens: string[] = [];
   let buf = "";
   let inSingle = false;
@@ -75,7 +91,7 @@ export function splitShellArgs(raw: string): string[] | null {
       escaped = false;
       continue;
     }
-    if (!inSingle && !inDouble && ch === "\\") {
+    if (backslashEscapes && !inSingle && !inDouble && ch === "\\") {
       escaped = true;
       continue;
     }
@@ -90,7 +106,7 @@ export function splitShellArgs(raw: string): string[] | null {
     if (inDouble) {
       const next = raw[i + 1];
       // Inside double quotes, only POSIX-recognized escapes consume the backslash.
-      if (ch === "\\" && isDoubleQuoteEscape(next)) {
+      if (backslashEscapes && ch === "\\" && isDoubleQuoteEscape(next)) {
         buf += next;
         i += 1;
         continue;
@@ -112,7 +128,7 @@ export function splitShellArgs(raw: string): string[] | null {
     }
     // In POSIX shells, "#" starts a comment only when it begins a word; keep
     // inline hashes inside tokens so URLs/fragments are not truncated.
-    if (ch === "#" && buf.length === 0) {
+    if (syntax === "shell" && ch === "#" && buf.length === 0) {
       break;
     }
     if (/\s/.test(ch)) {

--- a/src/utils/shell-argv.ts
+++ b/src/utils/shell-argv.ts
@@ -58,19 +58,25 @@ export function splitShellArgs(raw: string): string[] | null {
   return splitQuotedArgs(raw, "shell");
 }
 
-/** Splits process arguments without shell comments; Windows paths retain literal backslashes. */
+/** Groups quoted process arguments, preserving literal backslashes and hash characters. */
+export function splitCommandArgs(raw: string, options: { allowUnclosedQuotes: true }): string[];
 export function splitCommandArgs(
   raw: string,
-  platform: NodeJS.Platform = process.platform,
+  options?: { allowUnclosedQuotes?: boolean },
+): string[] | null;
+export function splitCommandArgs(
+  raw: string,
+  options?: { allowUnclosedQuotes?: boolean },
 ): string[] | null {
-  return splitQuotedArgs(raw, platform === "win32" ? "windows-command" : "posix-command");
+  return splitQuotedArgs(raw, "command", options?.allowUnclosedQuotes);
 }
 
 function splitQuotedArgs(
   raw: string,
-  syntax: "shell" | "posix-command" | "windows-command",
+  syntax: "shell" | "command",
+  allowUnclosedQuotes = false,
 ): string[] | null {
-  const backslashEscapes = syntax !== "windows-command";
+  const backslashEscapes = syntax === "shell";
   const tokens: string[] = [];
   let buf = "";
   let inSingle = false;
@@ -138,7 +144,7 @@ function splitQuotedArgs(
     buf += ch;
   }
 
-  if (escaped || inSingle || inDouble) {
+  if (escaped || (!allowUnclosedQuotes && (inSingle || inDouble))) {
     return null;
   }
   pushToken();

--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { asBoolean, parseBooleanValue } from "./boolean.js";
-import { splitShellArgs } from "./shell-argv.js";
+import { splitCommandArgs, splitShellArgs } from "./shell-argv.js";
 import { safeParseJsonWithSchema, safeParseWithSchema } from "./zod-parse.js";
 
 describe("asBoolean", () => {
@@ -73,6 +73,26 @@ describe("splitShellArgs", () => {
     expect(splitShellArgs(`echo hi # comment && whoami`)).toEqual(["echo", "hi"]);
     expect(splitShellArgs(`echo "hi # still-literal"`)).toEqual(["echo", "hi # still-literal"]);
     expect(splitShellArgs(`echo hi#tail`)).toEqual(["echo", "hi#tail"]);
+  });
+});
+
+describe("splitCommandArgs", () => {
+  it.each([
+    {
+      platform: "linux",
+      input: String.raw`program "a\"b" some\ path #literal`,
+      expected: ["program", 'a"b', "some path", "#literal"],
+    },
+    {
+      platform: "win32",
+      input: String.raw`program "C:\some path\file.py" \\server\share\ #literal`,
+      expected: ["program", String.raw`C:\some path\file.py`, "\\\\server\\share\\", "#literal"],
+    },
+    { platform: "linux", input: 'program "unfinished', expected: null },
+    { platform: "win32", input: "program 'unfinished", expected: null },
+    { platform: "linux", input: "program unfinished\\", expected: null },
+  ] as const)("parses $platform process arguments: $input", ({ platform, input, expected }) => {
+    expect(splitCommandArgs(input, platform)).toEqual(expected);
   });
 });
 

--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -79,21 +79,29 @@ describe("splitShellArgs", () => {
 describe("splitCommandArgs", () => {
   it.each([
     {
-      platform: "linux",
-      input: String.raw`program "a\"b" some\ path #literal`,
-      expected: ["program", 'a"b', "some path", "#literal"],
+      input: String.raw`program some\path 'a"b' #literal`,
+      expected: ["program", String.raw`some\path`, 'a"b', "#literal"],
     },
     {
-      platform: "win32",
       input: String.raw`program "C:\some path\file.py" \\server\share\ #literal`,
       expected: ["program", String.raw`C:\some path\file.py`, "\\\\server\\share\\", "#literal"],
     },
-    { platform: "linux", input: 'program "unfinished', expected: null },
-    { platform: "win32", input: "program 'unfinished", expected: null },
-    { platform: "linux", input: "program unfinished\\", expected: null },
-  ] as const)("parses $platform process arguments: $input", ({ platform, input, expected }) => {
-    expect(splitCommandArgs(input, platform)).toEqual(expected);
+    { input: 'program "unfinished', expected: null },
+    { input: "program 'unfinished", expected: null },
+    { input: "program unfinished\\", expected: ["program", "unfinished\\"] },
+  ])("parses quote-only process arguments: $input", ({ input, expected }) => {
+    expect(splitCommandArgs(input)).toEqual(expected);
   });
+
+  it.each(['program "unfinished', "program 'unfinished"])(
+    "allows unfinished quotes when requested: %s",
+    (raw) => {
+      expect(splitCommandArgs(raw, { allowUnclosedQuotes: true })).toEqual([
+        "program",
+        "unfinished",
+      ]);
+    },
+  );
 });
 
 describe("zod parse helpers", () => {


### PR DESCRIPTION
## What Problem This Solves

Consolidates three overlapping argument scanners into one implementation while preserving their existing caller contracts. Codex startup and Windows script preflight carried private quote-only scanners alongside the shared shell parser, making the same quote/token logic expensive to maintain safely.

## Why This Change Was Made

The shared tokenizer now has shell and quote-only command modes. A narrow `splitCommandArgs` export through the existing `process-runtime` SDK lets the Codex plugin use the same owner as Windows script preflight. Windows keeps strict quote completion; Codex explicitly keeps the permissive end-of-input behavior shipped in `v2026.9.1`. Both private scanners and the redundant one-element preflight loop are removed.

Production code decreases by **64 lines**; tests add **87 lines** and docs add **30 lines**. No configuration options, environment variables, dependencies, persistence formats, or defaults are added or changed.

## User Impact

Existing Codex config strings and `OPENCLAW_CODEX_APP_SERVER_ARGS` preserve literal backslashes, literal `#`, quote grouping, and unfinished quotes. Windows path selection and strict preflight parsing remain unchanged. Array arguments retain embedded quote values and their existing whitespace/empty-entry normalization.

The [compatibility review](https://github.com/openclaw/openclaw/pull/138878#issuecomment-5549783160) is resolved by preserving the shipped grammar. No string-contract transition or operator migration is required. The docs include a verified literal-backslash string/array example and explain the limits of array conversion. Strings use quote grouping; use arrays for values containing embedded TOML quotes.

**Named follow-up: empty and surrounding-whitespace arguments.** Existing string parsing drops empty quoted arguments; Codex array normalization trims surrounding whitespace and drops empty entries. This remains unchanged. A separate argument-contract repair should cover these cases across Codex and exec-policy callers before promising universal lossless string-to-array conversion.

## Evidence

Four config/env compatibility cases failed against the earlier `e230c9399f29` candidate, which consumed literal backslashes and rejected unfinished quotes. They pass with the final consolidation. The five focused files passed across three routed shards: **274 tests passed, 4 platform-specific tests skipped**.

A deterministic **50,000-input** differential compared the final implementation with the stable `v2026.9.1` Codex scanner and baseline `cf127a39cb9` shell/Windows scanners. All three contracts were identical, including backslashes, hashes, quote completion, whitespace, and Unicode inputs.

Live proof used the exact managed **Codex 0.153.4** dependency: eleven real child processes with isolated temporary homes, `initialize`, and `config/read`. No model or authentication request was needed. Distinct real directories and sentinel contents confirmed the selected path:

| Input | Baseline/native result | Final/native result |
| --- | --- | --- |
| Config string with `log_dir=…/legacy\logs` | Literal-backslash directory | Same directory |
| Environment string with that path | Literal-backslash directory | Same directory |
| Array containing the path and `model="gpt-5.6-luna"` | Same path and model `gpt-5.6-luna` | Same path and model |
| Unfinished model quote | Native initialization and intended model | Same through config and environment |

The earlier candidate selected the different `legacylogs` directory for both string sources; the final candidate restores the original path. Array proof also exercises retained trimming and empty-entry omission. Every owned process and temporary directory was cleaned up.

Direct Codex source inspection: `codex-rs/utils/cli/src/config_override.rs:19–85`, `codex-rs/cli/src/main.rs:1245–1294`, `codex-rs/app-server/src/config_manager_service.rs:115–163`, and `codex-rs/core/src/config/mod.rs:3939–3943` at `ade0ccacf9182e665cf784de041c51a79e35bc31`. This establishes raw native override parsing and effective config readback; the managed binary proof covers the actual packaged dependency.

Commands run from the candidate checkout:

```sh
node scripts/run-vitest.mjs \
  extensions/codex/src/app-server/config-args.test.ts \
  extensions/codex/src/app-server/config.test.ts \
  extensions/codex/src/app-server/transport-stdio.test.ts \
  src/utils/utils-misc.test.ts \
  src/agents/bash-tools.exec.script-preflight.test.ts

node scripts/check-changed.mjs -- \
  src/utils/shell-argv.ts \
  src/utils/utils-misc.test.ts \
  src/plugin-sdk/process-runtime.ts \
  src/agents/bash-tools.exec-script-target.ts \
  extensions/codex/src/app-server/config-utils.ts \
  extensions/codex/src/app-server/config-args.test.ts \
  docs/plugins/sdk-runtime.md \
  docs/plugins/codex-harness-reference.md \
  docs/plugins/codex-harness.md

pnpm build
git diff --check

# Task-local evidence scripts, not shipped source:
node extensions/codex/node_modules/@openai/codex/bin/codex.js --version
node_modules/.bin/tsx .artifacts/command-argv/compatible-native-proof.mts
node_modules/.bin/tsx .artifacts/command-argv/compatible-differential-proof.mts
```

The complete changed gate passed, including core/plugin production and test typechecks, SDK exports/surface, lint, dead exports, and import-cycle checks. The full build passed in 5m22s without ineffective dynamic imports. Fresh independent Codex autoreview through P2 was scoped-clean on an isolated copy of the complete final candidate. Native Windows execution was not rerun locally; explicit Windows-input tests and the exact differential comparison cover the preserved parser behavior.
