### PR TITLE
fix(buzz): keep implicit replies at thread root

### DIFF
--- a/extensions/buzz/src/channel.test.ts
+++ b/extensions/buzz/src/channel.test.ts
@@ -14,30 +14,41 @@ describe("Buzz channel guidance", () => {
   });
 
   it.each([
-    { mode: "off", automatic: true, flat: true },
-    { mode: "all", automatic: true, flat: true },
-    { mode: "off", automatic: false, flat: false },
-    { mode: "all", automatic: false, flat: false },
-  ] as const)(
-    "routes $mode automatic=$automatic without flattening explicit tools",
-    ({ mode, automatic, flat }) => {
-      const original = { threadId: "thread-root", replyToId: "requested-parent" };
-      const transport =
-        buzzPlugin.threading?.resolveReplyTransport?.({
-          cfg: {},
-          ...original,
-          replyToIsExplicit: !automatic,
-          replyDelivery: automatic ? { replyToMode: mode } : undefined,
-        }) ?? original;
-      expect(transport).toEqual(
-        flat
-          ? mode === "all" && automatic
-            ? { threadId: "thread-root", replyToId: "thread-root" }
-            : { threadId: null, replyToId: null }
-          : original,
-      );
+    {
+      label: "automatic off",
+      replyDelivery: { replyToMode: "off" as const },
+      explicit: false,
+      expected: { threadId: null, replyToId: null },
     },
-  );
+    {
+      label: "automatic all",
+      replyDelivery: { replyToMode: "all" as const },
+      explicit: false,
+      expected: { threadId: "thread-root", replyToId: "thread-root" },
+    },
+    {
+      label: "implicit message tool",
+      replyDelivery: undefined,
+      explicit: false,
+      expected: { threadId: "thread-root", replyToId: "thread-root" },
+    },
+    {
+      label: "explicit child",
+      replyDelivery: undefined,
+      explicit: true,
+      expected: { threadId: "thread-root", replyToId: "requested-parent" },
+    },
+  ])("routes $label replies at the intended depth", ({ replyDelivery, explicit, expected }) => {
+    const original = { threadId: "thread-root", replyToId: "requested-parent" };
+    const transport =
+      buzzPlugin.threading?.resolveReplyTransport?.({
+        cfg: {},
+        ...original,
+        replyToIsExplicit: explicit,
+        replyDelivery,
+      }) ?? original;
+    expect(transport).toEqual(expected);
+  });
   it("advertises directory room targets and native mention syntax", () => {
     const hints = buzzPlugin.agentPrompt?.messageToolHints?.({} as never) ?? [];
 

--- a/extensions/buzz/src/channel.test.ts
+++ b/extensions/buzz/src/channel.test.ts
@@ -15,8 +15,9 @@ describe("Buzz channel guidance", () => {
 
   it.each([
     { mode: "off", automatic: true, flat: true },
-    { mode: "all", automatic: true, flat: false },
+    { mode: "all", automatic: true, flat: true },
     { mode: "off", automatic: false, flat: false },
+    { mode: "all", automatic: false, flat: false },
   ] as const)(
     "routes $mode automatic=$automatic without flattening explicit tools",
     ({ mode, automatic, flat }) => {
@@ -28,7 +29,13 @@ describe("Buzz channel guidance", () => {
           replyToIsExplicit: !automatic,
           replyDelivery: automatic ? { replyToMode: mode } : undefined,
         }) ?? original;
-      expect(transport).toEqual(flat ? { threadId: null, replyToId: null } : original);
+      expect(transport).toEqual(
+        flat
+          ? mode === "all" && automatic
+            ? { threadId: "thread-root", replyToId: "thread-root" }
+            : { threadId: null, replyToId: null }
+          : original,
+      );
     },
   );
   it("advertises directory room targets and native mention syntax", () => {

--- a/extensions/buzz/src/channel.ts
+++ b/extensions/buzz/src/channel.ts
@@ -72,8 +72,15 @@ export const buzzPlugin = createChatChannelPlugin<ResolvedBuzzAccount, BuzzProbe
     },
     threading: {
       // Only automatic replies carry replyDelivery; explicit message-tool targets stay intact.
-      resolveReplyTransport: ({ replyDelivery }) =>
-        replyDelivery?.replyToMode === "off" ? { threadId: null, replyToId: null } : null,
+      resolveReplyTransport: ({ replyDelivery, threadId, replyToId, replyToIsExplicit }) => {
+        if (replyDelivery?.replyToMode === "off") {
+          return { threadId: null, replyToId: null };
+        }
+        if (threadId && replyToId && !replyToIsExplicit && replyToId !== threadId) {
+          return { threadId, replyToId: String(threadId) };
+        }
+        return null;
+      },
     },
     agentPrompt: {
       messageToolHints: () => [

--- a/extensions/buzz/src/channel.ts
+++ b/extensions/buzz/src/channel.ts
@@ -71,15 +71,14 @@ export const buzzPlugin = createChatChannelPlugin<ResolvedBuzzAccount, BuzzProbe
       threads: true,
     },
     threading: {
-      // Only automatic replies carry replyDelivery; explicit message-tool targets stay intact.
       resolveReplyTransport: ({ replyDelivery, threadId, replyToId, replyToIsExplicit }) => {
         if (replyDelivery?.replyToMode === "off") {
           return { threadId: null, replyToId: null };
         }
-        if (threadId && replyToId && !replyToIsExplicit && replyToId !== threadId) {
-          return { threadId, replyToId: String(threadId) };
-        }
-        return null;
+        // Implicit replies belong to the root; explicit child targets keep their nesting.
+        return threadId && replyToId && !replyToIsExplicit
+          ? { threadId, replyToId: String(threadId) }
+          : null;
       },
     },
     agentPrompt: {


### PR DESCRIPTION
## What Problem This Solves

Fixes Buzz implicit replies that nest under the triggering child message instead of staying at the thread root. Fixes #138812.

## Why This Change Was Made

The shared message-action path already supplies the thread root and whether the reply target was explicit. The Buzz plugin now uses that existing threading hook to normalize implicit replies to the root. Explicit child replies keep their nesting, and automatic off-mode replies retain their top-level behavior. The encoder and generic routing policy are unchanged.

The maintainer refinement removes a redundant unequal-ID check, replaces a stale comment, and makes the regression table explicitly cover message-tool calls without `replyDelivery` metadata. The original contributor commits remain in the ancestry.

## User Impact

Implicit Buzz replies remain in the active thread. Explicit child replies and top-level sends continue to work.

## Evidence

The [independent hosted proof](https://github.com/steipete/openclaw/actions/runs/33981049209) exercised production `runMessageAction`, the Buzz adapter, and an authenticated signed local WebSocket relay. The baseline emitted both root and child-reply tags for an implicit reply; the candidate emitted only the root reply tag. Explicit-child, explicit-root, off-mode, and top-level controls passed. All 51 focused channel, inbound, and bus tests passed. The executed production file matches the published candidate byte-for-byte. The parent proof run is red because the separate Feishu lane referenced a stale test filename; the Buzz job passed.

This is synthetic relay transport proof, not a hosted Buzz service or native-client recording. The existing reporter reproduction supplies the client symptom. Direct inspection of [Buzz's threading implementation](https://github.com/block/buzz/blob/main/desktop/src/features/messages/lib/threading.ts) confirms its root/child tag contract.

Fresh independent Codex review through P2 found no actionable defects. Production +9/-3 (net +6), tests +34/-16 (net +18). The small production addition is the missing plugin-owned default-routing decision; putting it in the encoder would flatten explicit child replies, and putting it in core would impose Buzz policy on other channels. [Exact published-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33981559098).

Thanks @sunlit-deng for the original fix and reproduction.
