### PR TITLE
fix: preserve Responses terminal details for unfinished tools

### DIFF
--- a/packages/ai/src/transports/openai-responses-client.terminal-error.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.terminal-error.test.ts
@@ -37,6 +37,7 @@ vi.mock("openai/resources/responses/ws.js", () => ({
 }));
 
 import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+import type { OpenAIResponsesOptions } from "./openai-responses-contracts.js";
 
 const model = {
   id: "gpt-5.6-luna",
@@ -52,31 +53,122 @@ const model = {
 } satisfies Model<"openai-responses">;
 
 describe("managed Responses transport terminal errors", () => {
-  it("preserves the provider incomplete_reason instead of a generic message", async () => {
-    sseState.outcomes.push({
-      data: (async function* () {
-        yield {
-          type: "response.incomplete",
-          response: {
-            id: "resp_filtered",
-            status: "incomplete",
-            incomplete_details: { reason: "content_filter" },
-          },
-        };
-      })(),
-      response: new Response(null, { status: 200 }),
-    });
-    const stream = await createOpenAIResponsesTransportStreamFn()(
-      model,
-      { messages: [], tools: [] },
-      {
+  it.each([false, true])(
+    "retains usage when truncated tool output has an item-done event: %s",
+    async (itemDone) => {
+      const partialCall = {
+        type: "function_call",
+        id: "fc_truncated",
+        call_id: "call_truncated",
+        name: "probe",
+        arguments: '{"token":"unfinished',
+        status: "incomplete",
+      };
+      sseState.outcomes.push({
+        data: (async function* () {
+          yield {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: { ...partialCall, arguments: "", status: "in_progress" },
+          };
+          yield {
+            type: "response.function_call_arguments.delta",
+            output_index: 0,
+            item_id: partialCall.id,
+            delta: partialCall.arguments,
+          };
+          if (itemDone) {
+            yield { type: "response.output_item.done", output_index: 0, item: partialCall };
+          }
+          yield {
+            type: "response.incomplete",
+            response: {
+              id: "resp_truncated",
+              model: "served-model",
+              status: "incomplete",
+              incomplete_details: { reason: "max_output_tokens" },
+              output: [partialCall],
+              usage: {
+                input_tokens: 20,
+                output_tokens: 9,
+                total_tokens: 29,
+                input_tokens_details: { cached_tokens: 4 },
+                output_tokens_details: { reasoning_tokens: 3 },
+              },
+            },
+          };
+        })(),
+        response: new Response(null, { status: 200 }),
+      });
+      const options = { apiKey: "test-key", transport: "sse" } satisfies OpenAIResponsesOptions;
+      const stream = await createOpenAIResponsesTransportStreamFn()(
+        model,
+        { messages: [], tools: [] },
+        options,
+      );
+      const events: string[] = [];
+      for await (const event of stream) {
+        events.push(event.type);
+      }
+      const result = await stream.result();
+      expect(result.stopReason).toBe("error");
+      expect(events.filter((type) => type === "done" || type === "error")).toEqual(["error"]);
+      expect(events).not.toContain("toolcall_end");
+      expect(result.usage).toMatchObject({
+        input: 16,
+        cacheRead: 4,
+        output: 9,
+        totalTokens: 29,
+        reasoningTokens: 3,
+      });
+      expect(result.responseId).toBe("resp_truncated");
+      expect(result.responseModel).toBe("served-model");
+    },
+  );
+
+  it.each([false, true])(
+    "preserves the provider incomplete_reason with an active tool: %s",
+    async (activeTool) => {
+      sseState.outcomes.push({
+        data: (async function* () {
+          if (activeTool) {
+            yield {
+              type: "response.output_item.added",
+              output_index: 0,
+              item: {
+                type: "function_call",
+                id: "fc_filtered",
+                call_id: "call_filtered",
+                name: "probe",
+                arguments: "",
+                status: "in_progress",
+              },
+            };
+          }
+          yield {
+            type: "response.incomplete",
+            response: {
+              id: "resp_filtered",
+              status: "incomplete",
+              incomplete_details: { reason: "content_filter" },
+            },
+          };
+        })(),
+        response: new Response(null, { status: 200 }),
+      });
+      const options = {
         apiKey: "test-key",
         sessionId: "session-terminal-error",
         transport: "sse",
-      } as never,
-    );
-    const result = await stream.result();
-    expect(result.stopReason).toBe("error");
-    expect(result.errorMessage).toBe("Provider incomplete_reason: content_filter");
-  });
+      } satisfies OpenAIResponsesOptions;
+      const stream = await createOpenAIResponsesTransportStreamFn()(
+        model,
+        { messages: [], tools: [] },
+        options,
+      );
+      const result = await stream.result();
+      expect(result.stopReason).toBe("error");
+      expect(result.errorMessage).toBe("Provider incomplete_reason: content_filter");
+    },
+  );
 });

--- a/packages/ai/src/transports/openai-responses-client.terminal-error.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.terminal-error.test.ts
@@ -53,6 +53,87 @@ const model = {
 } satisfies Model<"openai-responses">;
 
 describe("managed Responses transport terminal errors", () => {
+  it.each(["incomplete", "completed", "filtered", "failed", "eof", "aborted"] as const)(
+    "fences later tool completions after truncated output until %s",
+    async (ending) => {
+      const controller = new AbortController();
+      const calls = [0, 1].map((index) => ({
+        type: "function_call",
+        id: `fc_parallel_${index}`,
+        call_id: `call_parallel_${index}`,
+        name: "probe",
+        arguments: index === 0 ? '{"token":"unfinished' : '{"token":"complete"}',
+        status: index === 0 ? "incomplete" : "completed",
+        async: true,
+      }));
+      sseState.outcomes.push({
+        data: (async function* () {
+          for (const [output_index, item] of calls.entries()) {
+            yield {
+              type: "response.output_item.added",
+              output_index,
+              item: { ...item, arguments: "", status: "in_progress" },
+            };
+          }
+          for (const [output_index, item] of calls.entries()) {
+            yield { type: "response.output_item.done", output_index, item };
+          }
+          if (ending === "aborted") {
+            controller.abort();
+          }
+          if (ending === "eof" || ending === "aborted") {
+            return;
+          }
+          const status = ending === "filtered" ? "incomplete" : ending;
+          yield {
+            type: `response.${status}`,
+            response: {
+              id: "resp_parallel_truncated",
+              model: "served-model",
+              status,
+              incomplete_details: {
+                reason: ending === "filtered" ? "content_filter" : "max_output_tokens",
+              },
+              error:
+                ending === "failed" ? { code: "server_error", message: "provider failed" } : null,
+              output: calls,
+              usage: { input_tokens: 20, output_tokens: 9, total_tokens: 29 },
+            },
+          };
+        })(),
+        response: new Response(null, { status: 200 }),
+      });
+      const stream = await createOpenAIResponsesTransportStreamFn()(
+        { ...model, id: "gpt-6-astra" },
+        { messages: [], tools: [] },
+        {
+          apiKey: "test-key",
+          transport: "sse",
+          asyncToolExecution: true,
+          signal: controller.signal,
+        } satisfies OpenAIResponsesOptions,
+      );
+      const events: string[] = [];
+      for await (const event of stream) {
+        events.push(event.type);
+      }
+      const result = await stream.result();
+      expect(events).not.toContain("toolcall_end");
+      expect(events.filter((type) => type === "done" || type === "error")).toEqual(["error"]);
+      expect(result.stopReason).toBe(ending === "aborted" ? "aborted" : "error");
+      if (ending !== "eof" && ending !== "aborted") {
+        expect(result.usage).toMatchObject({ input: 20, output: 9, totalTokens: 29 });
+        expect(result.responseId).toBe("resp_parallel_truncated");
+        expect(result.responseModel).toBe("served-model");
+      }
+      if (ending === "filtered") {
+        expect(result.errorMessage).toBe("Provider incomplete_reason: content_filter");
+      } else if (ending === "failed") {
+        expect(result.errorMessage).toContain("provider failed");
+      }
+    },
+  );
+
   it.each([false, true])(
     "retains usage when truncated tool output has an item-done event: %s",
     async (itemDone) => {

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -74,6 +74,7 @@ export async function processResponsesStream<TApi extends Api>(
   const outputSlots = createResponsesOutputSlotTracker<ResponsesOutputSlot>();
   const outputs = createResponsesOutputTracker();
   let terminalResponse: CompletedResponse | null | undefined;
+  let incompleteToolCall: CompletedToolCall | undefined;
   let lastTextBlock: TextBlockReference | null = null;
   const blocks = output.content;
   const compactionTracker = createCompactionTracker(output, model, options);
@@ -319,6 +320,24 @@ export async function processResponsesStream<TApi extends Api>(
       // provider progress; keep the idle watchdog alive without exposing them,
       // matching the completions and anthropic transports.
       notifyLlmRequestActivity(options?.signal);
+      if (
+        event.type === "response.output_item.done" &&
+        event.item.type === "function_call" &&
+        event.item.status === "incomplete"
+      ) {
+        incompleteToolCall ??= event.item;
+      }
+      // An incomplete call closes output admission; only drain terminal facts.
+      // Later async tool completions must not authorize side effects.
+      if (
+        incompleteToolCall &&
+        event.type !== "response.completed" &&
+        event.type !== "response.incomplete" &&
+        event.type !== "response.failed" &&
+        event.type !== "error"
+      ) {
+        continue;
+      }
       if (event.type === "response.created") {
         output.responseId = event.response.id;
       } else if (event.type === "response.output_item.added") {
@@ -611,7 +630,7 @@ export async function processResponsesStream<TApi extends Api>(
             });
           }
           outputSlots.forget(outputSlot);
-        } else if (item.type === "function_call" && item.status !== "incomplete") {
+        } else if (item.type === "function_call") {
           if (outputs.get(item, readResponsesOutputIndex(event))?.completed) {
             continue;
           }
@@ -643,6 +662,12 @@ export async function processResponsesStream<TApi extends Api>(
       } else if (event.type === "response.completed" || event.type === "response.incomplete") {
         // Preserve reported accounting before rejecting unfinished tool calls.
         terminal.finalizeResponse(event.response, event.type);
+        if (incompleteToolCall) {
+          if (output.errorMessage) {
+            throw new Error(output.errorMessage);
+          }
+          resolveCompletedResponsesToolCall(incompleteToolCall);
+        }
         if (event.type === "response.incomplete" && streamingToolCalls.hasActive()) {
           throw new Error(
             output.errorMessage ?? "Responses stream completed with unresolved tool calls",

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -611,7 +611,7 @@ export async function processResponsesStream<TApi extends Api>(
             });
           }
           outputSlots.forget(outputSlot);
-        } else if (item.type === "function_call") {
+        } else if (item.type === "function_call" && item.status !== "incomplete") {
           if (outputs.get(item, readResponsesOutputIndex(event))?.completed) {
             continue;
           }
@@ -641,10 +641,13 @@ export async function processResponsesStream<TApi extends Api>(
           finalizeToolCall(item, readResponsesOutputIndex(event), streamingToolCall, validated);
         }
       } else if (event.type === "response.completed" || event.type === "response.incomplete") {
-        if (event.type === "response.incomplete" && streamingToolCalls.hasActive()) {
-          throw new Error("Responses stream completed with unresolved tool calls");
-        }
+        // Preserve reported accounting before rejecting unfinished tool calls.
         terminal.finalizeResponse(event.response, event.type);
+        if (event.type === "response.incomplete" && streamingToolCalls.hasActive()) {
+          throw new Error(
+            output.errorMessage ?? "Responses stream completed with unresolved tool calls",
+          );
+        }
         if (event.type === "response.completed" || output.stopReason === "length") {
           const items = event.response.output ?? [];
           const completeToolCall =

--- a/packages/ai/src/transports/openai-responses-stream-terminal-recovery.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-recovery.test.ts
@@ -140,7 +140,7 @@ const rejectedStreamedToolFixture = (params: {
             },
           ]
         : [],
-      responseId: null,
+      responseId: params.status === "incomplete" ? "resp_rejected_streamed_tool" : null,
       stopReason: "stop",
       error: params.error,
     },


### PR DESCRIPTION
Closes #138874

## What Problem This Solves

Fixes an issue where Responses tool output reaching its token limit returns zero usage despite the provider reporting consumed tokens. An unfinished tool can also obscure the provider's specific terminal failure reason.

## Why This Change Was Made

The shared Responses stream processor rejected incomplete function-call items before reading the terminal response, and rejected active tools before recording terminal facts. It now closes output admission at the first incomplete function-call item, drains terminal accounting, then preserves the error and any provider-specific reason. Later parallel tool completions cannot become executable while those facts are being collected.

Unfinished tools remain non-executable: no `toolcall_end` is emitted. Completed-call validation is unchanged. Both managed and package Responses streams use this owner; no new retry, configuration, dependency, or execution path is added.

Production delta: +28 net lines for a single incomplete-call admission state and terminal-only drain; it reuses canonical validation rather than adding a second tool execution or validation path. Tests: +173 net lines, extending accounting, provider-error and parallel-tool ordering coverage. Release-note context is this correction to failed-call reporting; no changelog edit is required at normal landing.

## User Impact

Callers retain token usage, served-model information, response identity, and specific provider terminal errors when tool output cannot complete. The error still prevents the unfinished tool from executing.

## Evidence

[Live API-key proof and baseline rerun](https://github.com/openclaw/openclaw/actions/runs/33944934983), using `openai/gpt-6-astra`, low reasoning, a forced synthetic function call with a long literal argument, and a 128-token output budget:

| Observed result | Baseline | Candidate |
|---|---:|---:|
| Provider terminal | incomplete | incomplete |
| Provider-reported output tokens | 128 | 128 |
| Returned output usage | 0 | 128 |
| Unfinished tool made executable | no | no |
| Served model retained | no | yes |

The baseline's raw terminal reported 1,192 total tokens while the returned usage was entirely zero. The candidate retained the reported accounting and model. An initial baseline attempt hit a shared provider rate limit; the focused rerun above reproduced the actual defect.

- Both accounting regressions failed before the repair, covering incomplete tool output with and without an item-done event.
- The additional active-tool provider-reason regression failed before its correction. Synthetic `content_filter` terminal events cover this branch; ordinary harmless live requests cannot reliably trigger it. The token-limit branch's behavior is unchanged by that error-reason correction.
- Six additional ordering regressions failed before the final correction: a later parallel tool completion must remain blocked through incomplete, completed, filtered, failed, EOF, and aborted endings. All 292 tests across 11 related suites pass, including stream/recovery/activity, OpenAI/Azure providers, request hooks, and agent-core async execution. These deliberately ordered protocol cases use synthetic events; the primary truncation case is live.
- Full changed-file checks passed in an isolated checkout with its own frozen dependencies. A borrowed worktree install had an older filesystem dependency; that environment mismatch was avoided rather than changing unrelated installer code.
- Fresh independent Codex review found no actionable P0–P2 defects.

The broader Astra campaign also passed all seven exposed reasoning levels, tool round-trips, warm switching, four-way concurrency, cancellation/reuse, and actual SSE/cached WebSocket operation without fallback. The native cancellation repair is tracked separately in #138864.

Final changed-source candidate smoke: [run 33948599920](https://github.com/openclaw/openclaw/actions/runs/33948599920) passed all three Responses cases after the parallel-tool correction. Truncated output retained 128 output / 1,192 total tokens without tool execution; SSE and cached WebSocket each completed three low/max/off turns, with two WebSocket reuses and no fallback. Changed-source hashes matched the published candidate.
