### PR TITLE
fix(skills): preserve tracking when ClawHub lock is malformed

### DIFF
--- a/src/skills/lifecycle/clawhub-install-core.ts
+++ b/src/skills/lifecycle/clawhub-install-core.ts
@@ -473,6 +473,9 @@ export async function performClawHubSkillInstall(
         error: `Skill already exists at ${targetDir}. Re-run with force/update.`,
       };
     }
+    // Reject damaged tracking before installing files; reread at the write boundary
+    // so skills tracked during the download keep their metadata.
+    await readClawHubSkillsLockfile(params.workspaceDir);
 
     let version: string;
     let detail: ClawHubSkillDetail | undefined;

--- a/src/skills/lifecycle/clawhub-store.ts
+++ b/src/skills/lifecycle/clawhub-store.ts
@@ -8,8 +8,14 @@ import {
   type ClawHubSkillVerificationResponse,
   type ClawHubSkillsShTrustState,
 } from "../../infra/clawhub-skills.js";
-import { formatErrorMessage } from "../../infra/errors.js";
-import { readJsonIfExists, tryReadJson, writeJson } from "../../infra/json-files.js";
+import { formatErrorMessage, hasErrnoCode } from "../../infra/errors.js";
+import {
+  JsonFileReadError,
+  readJson,
+  readJsonIfExists,
+  tryReadJson,
+  writeJson,
+} from "../../infra/json-files.js";
 import { normalizeTrackedSkillSlug, validateRequestedSkillSlug } from "./archive-install.js";
 
 export { normalizeOptionalStringValue };
@@ -266,17 +272,29 @@ function normalizeClawHubSkillOrigin(
   };
 }
 
+function parseClawHubSkillsLockfile(
+  raw: Partial<ClawHubSkillsLockfile> | null,
+): ClawHubSkillsLockfile {
+  if (raw?.version !== 1 || !raw.skills || typeof raw.skills !== "object") {
+    throw new Error("expected version 1 lockfile with skills");
+  }
+  return { version: 1, skills: raw.skills };
+}
+
 export async function readClawHubSkillsLockfile(
   workspaceDir: string,
 ): Promise<ClawHubSkillsLockfile> {
   for (const candidate of metadataPaths(workspaceDir, "lock.json")) {
     try {
-      const raw = await tryReadJson<Partial<ClawHubSkillsLockfile>>(candidate);
-      if (raw?.version === 1 && raw.skills && typeof raw.skills === "object") {
-        return { version: 1, skills: raw.skills };
+      return parseClawHubSkillsLockfile(await readJson<Partial<ClawHubSkillsLockfile>>(candidate));
+    } catch (err) {
+      if (err instanceof JsonFileReadError && hasErrnoCode(err.cause, "ENOENT")) {
+        continue;
       }
-    } catch {
-      // ignore
+      throw new Error(
+        `Malformed workspace ClawHub lockfile at ${candidate}: ${formatErrorMessage(err)}. Repair or restore it before retrying.`,
+        { cause: err },
+      );
     }
   }
   return { version: 1, skills: {} };
@@ -313,14 +331,11 @@ export function readClawHubSkillsLockfileStatusSync(
       if (!read.exists) {
         continue;
       }
-      const raw = read.value as Partial<ClawHubSkillsLockfile>;
-      return raw?.version === 1 && raw.skills && typeof raw.skills === "object"
-        ? { kind: "found", path: candidate, lock: { version: 1, skills: raw.skills } }
-        : {
-            kind: "malformed",
-            path: candidate,
-            error: "expected version 1 lockfile with skills",
-          };
+      return {
+        kind: "found",
+        path: candidate,
+        lock: parseClawHubSkillsLockfile(read.value as Partial<ClawHubSkillsLockfile>),
+      };
     } catch (err) {
       return { kind: "malformed", path: candidate, error: formatErrorMessage(err) };
     }

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -87,10 +87,13 @@ const { ClawHubRequestError } = await import("../../infra/clawhub-client.js");
 const {
   installSkillFromClawHub,
   preflightSkillFromClawHub,
+  readClawHubSkillsLockfileStatusSync,
+  readTrackedClawHubSkillSlugs,
   readVerifiedClawHubSkillSourceUrl,
   resolveClawHubSkillStatusLinkSync,
   resolveClawHubSkillVerificationTarget,
   searchSkillsFromClawHub,
+  untrackClawHubSkill,
   updateSkillsFromClawHub,
 } = await import("./clawhub.js");
 
@@ -1338,6 +1341,98 @@ describe("skills-clawhub", () => {
     }
     expect(result.error).toContain("Invalid ClawHub owner handle");
     expect(fetchClawHubSkillInstallResolutionMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["truncated JSON", '{"version":1,"skills":{"weather":'],
+    ["JSON null", "null"],
+    ["invalid lock shape", '{"version":2,"skills":{}}'],
+  ])("preserves a shared lock with %s instead of installing over it", async (_label, damaged) => {
+    const workspaceDir = await tempDirs.make("openclaw-skills-damaged-lock-");
+    const skillDir = await writeTrackedSkill(workspaceDir, "weather", {
+      skillMd: "---\nname: weather\n---\n",
+    });
+    const lockPath = path.join(workspaceDir, ".clawhub", "lock.json");
+    await fs.mkdir(path.join(workspaceDir, ".clawdhub"));
+    await fs.copyFile(lockPath, path.join(workspaceDir, ".clawdhub", "lock.json"));
+    await fs.writeFile(lockPath, damaged);
+    const originalSkill = await fs.readFile(path.join(skillDir, "SKILL.md"), "utf8");
+    mockInstalledSkillFile("---\nname: agentreceipt\n---\n");
+    mockInstalledSkillFile("---\nname: replacement\n---\n");
+
+    for (const slug of ["agentreceipt", "weather"]) {
+      const result = await installTestSkill(workspaceDir, slug, { force: slug === "weather" });
+      expect(result).toMatchObject({
+        ok: false,
+        error: expect.stringContaining("Malformed workspace ClawHub lockfile"),
+      });
+    }
+    expect(installPackageDirMock).not.toHaveBeenCalled();
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toBe(damaged);
+    await expect(fs.readFile(path.join(skillDir, "SKILL.md"), "utf8")).resolves.toBe(originalSkill);
+    await expect(fs.stat(path.join(workspaceDir, "skills", "agentreceipt"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it.each([".clawhub", ".clawdhub"])(
+    "rejects damaged %s tracking in update, untracking, status and verification",
+    async (directory) => {
+      const workspaceDir = await tempDirs.make("openclaw-skills-damaged-tracking-");
+      const lockPath = path.join(workspaceDir, directory, "lock.json");
+      const damaged = '{"version":1,"skills":{"weather":';
+      await fs.mkdir(path.dirname(lockPath));
+      await fs.writeFile(lockPath, damaged);
+
+      await expect(readTrackedClawHubSkillSlugs(workspaceDir)).rejects.toThrow(
+        "Malformed workspace ClawHub lockfile",
+      );
+      await expect(untrackClawHubSkill(workspaceDir, "weather")).rejects.toThrow(
+        "Malformed workspace ClawHub lockfile",
+      );
+      await expect(updateTestSkill(workspaceDir)).rejects.toThrow(
+        "Malformed workspace ClawHub lockfile",
+      );
+      expect(readClawHubSkillsLockfileStatusSync(workspaceDir)).toMatchObject({
+        kind: "malformed",
+        path: lockPath,
+      });
+      await expect(
+        resolveClawHubSkillVerificationTarget({ workspaceDir, slug: "weather" }),
+      ).resolves.toMatchObject({
+        ok: false,
+        error: expect.stringContaining("Malformed workspace ClawHub lockfile"),
+      });
+      await expect(fs.readFile(lockPath, "utf8")).resolves.toBe(damaged);
+    },
+  );
+
+  it("preserves tracking added while a skill is downloading", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skills-install-tracking-");
+    await writeTrackedSkill(workspaceDir, "weather");
+    const lockPath = path.join(workspaceDir, ".clawhub", "lock.json");
+    const existing = await readJson<{ skills: Record<string, unknown> }>(lockPath);
+    const added = { version: "3.0.0", installedAt: 456, verification: { decision: "pass" } };
+    mockInstalledSkillFile("---\nname: agentreceipt\n---\n");
+    downloadClawHubSkillArchiveUrlMock.mockImplementationOnce(async () => {
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({ ...existing, skills: { ...existing.skills, calendar: added } }),
+      );
+      return {
+        archivePath: "/tmp/agentreceipt.zip",
+        integrity: "sha256-test",
+        sha256Hex: "a".repeat(64),
+        artifact: "archive",
+        cleanup: archiveCleanupMock,
+      };
+    });
+
+    expectInstalledSkill(await installTestSkill(workspaceDir, "agentreceipt"));
+    const installed = await readJson<{ skills: Record<string, unknown> }>(lockPath);
+    expect(installed.skills.weather).toEqual(existing.skills.weather);
+    expect(installed.skills.calendar).toEqual(added);
+    expect(installed.skills.agentreceipt).toMatchObject({ version: "1.0.0" });
   });
 
   it("persists install artifact and verification provenance in the ClawHub lockfile", async () => {


### PR DESCRIPTION
Closes #127986. Reported by @yetval.

## What Problem This Solves

Installing a skill with a malformed shared lockfile could discard other skills' tracking data. Updates could incorrectly report that no skills were tracked.

## Why This Change Was Made

Install, update, and verification now share strict lock validation. Installation checks before changing files and reads again before saving, preserving tracking added during a download.

## User Impact

A damaged lock stops the operation with repair guidance and remains untouched. Valid and missing-lock installs still work. No format or configuration change.

## Evidence

Installed CLI tests with real skill downloads reproduced data loss before the fix. Afterward, the damaged lock and existing directories remained intact; restoring the valid lock allowed install, verification, and update. Five regression cases and 265 lifecycle, uninstall, and CLI tests passed, including concurrent tracking changes.
