### PR TITLE
fix(feishu): return complete Bitable metadata

### DIFF
--- a/extensions/feishu/src/bitable-schema.ts
+++ b/extensions/feishu/src/bitable-schema.ts
@@ -1,0 +1,83 @@
+// Feishu helper module supports Bitable schema behavior.
+import { optionalPositiveIntegerSchema } from "openclaw/plugin-sdk/channel-actions";
+import { Type } from "typebox";
+
+const BITABLE_APP_TOKEN_DESCRIPTION =
+  "Bitable application token (the /base/ URL identifier, or app_token from metadata). Not the node token in a /wiki/ URL.";
+const BITABLE_RECORD_FIELDS_DESCRIPTION =
+  "Field values keyed by field name. Format by type: Text='string', Number=123, SingleSelect='Option', MultiSelect=['A','B'], DateTime=timestamp_ms, User=[{id:'ou_xxx'}], URL={text:'Display',link:'https://...'}";
+
+// TypeBox emits an empty schema for Any/Unknown, which Bedrock-backed validators
+// can reject inside patternProperties. Keep the existing any-JSON-value contract explicit.
+const BitableFieldValueSchema = Type.Unsafe<unknown>({
+  type: ["string", "number", "boolean", "object", "array", "null"],
+});
+
+export const FeishuBitableSchema = {
+  getMeta: Type.Object({
+    url: Type.String({
+      description: "Bitable URL. Supports both formats: /base/XXX?table=YYY or /wiki/XXX?table=YYY",
+    }),
+  }),
+  listFields: Type.Object({
+    app_token: Type.String({ description: BITABLE_APP_TOKEN_DESCRIPTION }),
+    table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+  }),
+  listRecords: Type.Object({
+    app_token: Type.String({ description: BITABLE_APP_TOKEN_DESCRIPTION }),
+    table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+    page_size: optionalPositiveIntegerSchema({
+      description: "Number of records per page (1-500, default 100)",
+      maximum: 500,
+    }),
+    page_token: Type.Optional(
+      Type.String({ description: "Pagination token from previous response" }),
+    ),
+  }),
+  getRecord: Type.Object({
+    app_token: Type.String({ description: BITABLE_APP_TOKEN_DESCRIPTION }),
+    table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+    record_id: Type.String({ description: "Record ID to retrieve" }),
+  }),
+  createRecord: Type.Object({
+    app_token: Type.String({ description: BITABLE_APP_TOKEN_DESCRIPTION }),
+    table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+    fields: Type.Record(Type.String(), BitableFieldValueSchema, {
+      description: BITABLE_RECORD_FIELDS_DESCRIPTION,
+    }),
+  }),
+  createApp: Type.Object({
+    name: Type.String({
+      description: "Name for the new Bitable application",
+    }),
+    folder_token: Type.Optional(
+      Type.String({
+        description: "Optional folder token to place the Bitable in a specific folder",
+      }),
+    ),
+  }),
+  createField: Type.Object({
+    app_token: Type.String({ description: BITABLE_APP_TOKEN_DESCRIPTION }),
+    table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+    field_name: Type.String({ description: "Name for the new field" }),
+    field_type: Type.Number({
+      description:
+        "Field type ID: 1=Text, 2=Number, 3=SingleSelect, 4=MultiSelect, 5=DateTime, 7=Checkbox, 11=User, 13=Phone, 15=URL, 17=Attachment, 18=SingleLink, 19=Lookup, 20=Formula, 21=DuplexLink, 22=Location, 23=GroupChat, 1001=CreatedTime, 1002=ModifiedTime, 1003=CreatedUser, 1004=ModifiedUser, 1005=AutoNumber",
+      minimum: 1,
+    }),
+    property: Type.Optional(
+      Type.Record(Type.String(), BitableFieldValueSchema, {
+        description:
+          "Field-specific properties (e.g., options for SingleSelect, format for Number)",
+      }),
+    ),
+  }),
+  updateRecord: Type.Object({
+    app_token: Type.String({ description: BITABLE_APP_TOKEN_DESCRIPTION }),
+    table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+    record_id: Type.String({ description: "Record ID to update" }),
+    fields: Type.Record(Type.String(), BitableFieldValueSchema, {
+      description: BITABLE_RECORD_FIELDS_DESCRIPTION,
+    }),
+  }),
+};

--- a/extensions/feishu/src/bitable.test.ts
+++ b/extensions/feishu/src/bitable.test.ts
@@ -18,6 +18,23 @@ type MockRecord = {
   fields?: Record<string, unknown>;
 };
 
+type MetadataListPayload = {
+  params?: {
+    page_size?: number;
+    page_token?: string;
+  };
+};
+
+type MetadataPageResponse = {
+  code: number;
+  msg?: string;
+  data?: {
+    items?: Array<Record<string, unknown>>;
+    has_more?: boolean;
+    page_token?: string;
+  };
+};
+
 function createConfig(): OpenClawPluginApi["config"] {
   return {
     channels: {
@@ -70,6 +87,42 @@ function createBitableClient(records: MockRecord[]) {
   } as unknown as Lark.Client;
 
   return { batchDelete, client };
+}
+
+function createMetadataList(responses: Array<MetadataPageResponse | Error>) {
+  const remaining = [...responses];
+  return vi.fn(async (_payload?: MetadataListPayload) => {
+    const response = remaining.shift();
+    if (!response) {
+      throw new Error("Unexpected Bitable metadata request");
+    }
+    if (response instanceof Error) {
+      throw response;
+    }
+    return response;
+  });
+}
+
+function createMetadataClient(params: {
+  tablePages?: Array<MetadataPageResponse | Error>;
+  fieldPages?: Array<MetadataPageResponse | Error>;
+}) {
+  const tableList = createMetadataList(params.tablePages ?? []);
+  const fieldList = createMetadataList(params.fieldPages ?? []);
+  const client = {
+    bitable: {
+      app: {
+        get: vi.fn(async () => ({
+          code: 0,
+          data: { app: { name: "Project Tracker" } },
+        })),
+      },
+      appTable: { list: tableList },
+      appTableField: { list: fieldList },
+    },
+  } as unknown as Lark.Client;
+  createFeishuClientMock.mockReturnValue(client);
+  return { client, fieldList, tableList };
 }
 
 describe("feishu bitable create app cleanup", () => {
@@ -216,6 +269,157 @@ describe("feishu bitable create app cleanup", () => {
       "page_size must be a positive integer between 1 and 500",
     );
     expect(client.bitable.appTableRecord.list).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      name: "table discovery",
+      toolName: "feishu_bitable_get_meta",
+      params: { url: "https://example.feishu.cn/base/app_token" },
+      rowsKey: "tables",
+      pageKind: "table" as const,
+      firstItem: { table_id: "tbl_first", name: "First" },
+      lastItem: { table_id: "tbl_last", name: "Last" },
+    },
+    {
+      name: "field listing",
+      toolName: "feishu_bitable_list_fields",
+      params: { app_token: "app_token", table_id: "tbl_main" },
+      rowsKey: "fields",
+      pageKind: "field" as const,
+      firstItem: { field_id: "fld_first", field_name: "First", type: 1 },
+      lastItem: { field_id: "fld_last", field_name: "Last", type: 2 },
+    },
+  ])(
+    "returns every $name page while preserving opaque cursor identity",
+    async ({ toolName, params, rowsKey, pageKind, firstItem, lastItem }) => {
+      const pages = [
+        {
+          code: 0,
+          data: { items: [firstItem], has_more: true, page_token: "page-2" },
+        },
+        {
+          code: 0,
+          data: { items: [], has_more: true, page_token: " page-2 " },
+        },
+        { code: 0, data: { items: [lastItem], has_more: false } },
+      ];
+      const { fieldList, tableList } = createMetadataClient(
+        pageKind === "table" ? { tablePages: pages } : { fieldPages: pages },
+      );
+      const { api, resolveTool } = createToolFactoryHarness(createConfig());
+      registerFeishuBitableTools(api);
+
+      const result = await resolveTool(toolName).execute("call_metadata", params);
+      const details = result.details as Record<string, unknown>;
+      const list = pageKind === "table" ? tableList : fieldList;
+
+      expect(details[rowsKey]).toEqual([
+        expect.objectContaining(firstItem),
+        expect.objectContaining(lastItem),
+      ]);
+      if (rowsKey === "fields") {
+        expect(details.total).toBe(2);
+      }
+      expect(list.mock.calls.map(([payload]) => payload?.params)).toEqual([
+        { page_size: 100 },
+        { page_size: 100, page_token: "page-2" },
+        { page_size: 100, page_token: " page-2 " },
+      ]);
+    },
+  );
+
+  it("keeps the selected-table metadata fast path to one app request", async () => {
+    const { client, tableList } = createMetadataClient({});
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuBitableTools(api);
+
+    const result = await resolveTool("feishu_bitable_get_meta").execute("call_selected", {
+      url: "https://example.feishu.cn/base/apptoken?table=tbl_selected",
+    });
+
+    expect(result.details).toMatchObject({
+      app_token: "apptoken",
+      table_id: "tbl_selected",
+      name: "Project Tracker",
+    });
+    expect(client.bitable.app.get).toHaveBeenCalledOnce();
+    expect(tableList).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "a blank cursor",
+      responses: [
+        { code: 0, data: { items: [], has_more: true, page_token: "   " } },
+      ] satisfies Array<MetadataPageResponse | Error>,
+      error: /missing page token/i,
+      calls: 1,
+    },
+    {
+      name: "an exactly repeated cursor",
+      responses: [
+        { code: 0, data: { items: [], has_more: true, page_token: "same" } },
+        { code: 0, data: { items: [], has_more: true, page_token: "same" } },
+      ] satisfies Array<MetadataPageResponse | Error>,
+      error: /repeated page token/i,
+      calls: 2,
+    },
+    {
+      name: "a later provider failure",
+      responses: [
+        { code: 0, data: { items: [], has_more: true, page_token: "page-2" } },
+        { code: 91403, msg: "Bitable access was revoked" },
+      ] satisfies Array<MetadataPageResponse | Error>,
+      error: /Bitable access was revoked/i,
+      calls: 2,
+    },
+    {
+      name: "a later transport failure",
+      responses: [
+        { code: 0, data: { items: [], has_more: true, page_token: "page-2" } },
+        new Error("Feishu transport disconnected"),
+      ] satisfies Array<MetadataPageResponse | Error>,
+      error: /Feishu transport disconnected/i,
+      calls: 2,
+    },
+    {
+      name: "a successful response without data",
+      responses: [{ code: 0 }] satisfies Array<MetadataPageResponse | Error>,
+      error: /missing response data/i,
+      calls: 1,
+    },
+  ])("rejects field metadata pagination with $name", async ({ responses, error, calls }) => {
+    const { fieldList } = createMetadataClient({ fieldPages: responses });
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuBitableTools(api);
+
+    const result = await resolveTool("feishu_bitable_list_fields").execute("call_fields", {
+      app_token: "app_token",
+      table_id: "tbl_main",
+    });
+
+    expect(result.details.error).toMatch(error);
+    expect(result.details).not.toHaveProperty("fields");
+    expect(fieldList).toHaveBeenCalledTimes(calls);
+  });
+
+  it("stops field metadata pagination after 100 requests", async () => {
+    const pages = Array.from({ length: 100 }, (_, index) => ({
+      code: 0,
+      data: { items: [], has_more: true, page_token: `page-${index + 1}` },
+    }));
+    const { fieldList } = createMetadataClient({ fieldPages: pages });
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuBitableTools(api);
+
+    const result = await resolveTool("feishu_bitable_list_fields").execute("call_fields", {
+      app_token: "app_token",
+      table_id: "tbl_main",
+    });
+
+    expect(result.details.error).toMatch(/pagination exceeded 100 pages/i);
+    expect(fieldList).toHaveBeenCalledTimes(100);
   });
 });
 

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -1,10 +1,10 @@
 // Feishu plugin module implements bitable behavior.
 import type * as Lark from "@larksuiteoapi/node-sdk";
-import { optionalPositiveIntegerSchema } from "openclaw/plugin-sdk/channel-actions";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
-import { Type, type TSchema } from "typebox";
+import type { TSchema } from "typebox";
 import type { OpenClawPluginApi } from "../runtime-api.js";
+import { FeishuBitableSchema } from "./bitable-schema.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import { feishuExternalToolResult as json } from "./tool-result.js";
 
@@ -19,6 +19,11 @@ type BitableRecordFields = NonNullable<NonNullable<BitableRecordCreatePayload["d
 type BitableRecordUpdateFields = NonNullable<
   NonNullable<BitableRecordUpdatePayload["data"]>["fields"]
 >;
+type BitableMetadataResponse<T> = LarkResponse<{
+  items?: T[];
+  has_more?: boolean;
+  page_token?: string;
+}>;
 
 class LarkApiError extends Error {
   readonly code: number;
@@ -41,6 +46,42 @@ function ensureLarkSuccess<T>(
   if (res.code !== 0) {
     throw new LarkApiError(res.code ?? -1, res.msg ?? "unknown error", api, context);
   }
+}
+
+async function listBitableMetadataItems<T>(
+  loadPage: (pageToken?: string) => Promise<BitableMetadataResponse<T>>,
+  api: string,
+  context?: Record<string, unknown>,
+): Promise<T[]> {
+  const items: T[] = [];
+  const seenPageTokens = new Set<string>();
+  let pageToken: string | undefined;
+
+  for (let page = 0; page < 100; page += 1) {
+    const response = await loadPage(pageToken);
+    ensureLarkSuccess(response, api, context);
+    const data = response.data;
+    if (!data) {
+      throw new Error(`${api} returned missing response data`);
+    }
+    items.push(...(data.items ?? []));
+    if (data.has_more !== true) {
+      return items;
+    }
+
+    // Provider cursors are opaque: validate blanks without changing token identity.
+    const nextPageToken = data.page_token;
+    if (!nextPageToken?.trim()) {
+      throw new Error(`${api} pagination returned a missing page token`);
+    }
+    if (seenPageTokens.has(nextPageToken)) {
+      throw new Error(`${api} pagination returned a repeated page token`);
+    }
+    seenPageTokens.add(nextPageToken);
+    pageToken = nextPageToken;
+  }
+
+  throw new Error(`${api} pagination exceeded 100 pages`);
 }
 
 /** Field type ID to human-readable name */
@@ -139,18 +180,19 @@ async function getBitableMeta(client: Lark.Client, url: string) {
   ensureLarkSuccess(res, "bitable.app.get", { appToken });
 
   // List tables if no table_id specified
-  let tables: { table_id: string; name: string }[] = [];
-  if (!parsed.tableId) {
-    const tablesRes = await client.bitable.appTable.list({
-      path: { app_token: appToken },
-    });
-    if (tablesRes.code === 0) {
-      tables = (tablesRes.data?.items ?? []).map((t) => ({
-        table_id: t.table_id!,
-        name: t.name!,
-      }));
-    }
-  }
+  const tables = parsed.tableId
+    ? []
+    : (
+        await listBitableMetadataItems(
+          (pageToken) =>
+            client.bitable.appTable.list({
+              path: { app_token: appToken },
+              params: { page_size: 100, page_token: pageToken },
+            }),
+          "bitable.appTable.list",
+          { appToken },
+        )
+      ).map((table) => ({ table_id: table.table_id!, name: table.name! }));
 
   return {
     app_token: appToken,
@@ -165,12 +207,15 @@ async function getBitableMeta(client: Lark.Client, url: string) {
 }
 
 async function listFields(client: Lark.Client, appToken: string, tableId: string) {
-  const res = await client.bitable.appTableField.list({
-    path: { app_token: appToken, table_id: tableId },
-  });
-  ensureLarkSuccess(res, "bitable.appTableField.list", { appToken, tableId });
-
-  const fields = res.data?.items ?? [];
+  const fields = await listBitableMetadataItems(
+    (pageToken) =>
+      client.bitable.appTableField.list({
+        path: { app_token: appToken, table_id: tableId },
+        params: { page_size: 100, page_token: pageToken },
+      }),
+    "bitable.appTableField.list",
+    { appToken, tableId },
+  );
   return {
     fields: fields.map((f) => ({
       field_id: f.field_id,
@@ -483,92 +528,6 @@ async function updateRecord(
   };
 }
 
-// ============ Schemas ============
-
-const BITABLE_APP_TOKEN_DESCRIPTION =
-  "Bitable application token (the /base/ URL identifier, or app_token from metadata). Not the node token in a /wiki/ URL.";
-const BITABLE_RECORD_FIELDS_DESCRIPTION =
-  "Field values keyed by field name. Format by type: Text='string', Number=123, SingleSelect='Option', MultiSelect=['A','B'], DateTime=timestamp_ms, User=[{id:'ou_xxx'}], URL={text:'Display',link:'https://...'}";
-
-const GetMetaSchema = Type.Object({
-  url: Type.String({
-    description: "Bitable URL. Supports both formats: /base/XXX?table=YYY or /wiki/XXX?table=YYY",
-  }),
-});
-
-const ListFieldsSchema = Type.Object({
-  app_token: Type.String({ description: BITABLE_APP_TOKEN_DESCRIPTION }),
-  table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
-});
-
-const ListRecordsSchema = Type.Object({
-  app_token: Type.String({ description: BITABLE_APP_TOKEN_DESCRIPTION }),
-  table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
-  page_size: optionalPositiveIntegerSchema({
-    description: "Number of records per page (1-500, default 100)",
-    maximum: 500,
-  }),
-  page_token: Type.Optional(
-    Type.String({ description: "Pagination token from previous response" }),
-  ),
-});
-
-const GetRecordSchema = Type.Object({
-  app_token: Type.String({ description: BITABLE_APP_TOKEN_DESCRIPTION }),
-  table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
-  record_id: Type.String({ description: "Record ID to retrieve" }),
-});
-
-// TypeBox emits an empty schema for Any/Unknown, which Bedrock-backed validators
-// can reject inside patternProperties. Keep the existing any-JSON-value contract explicit.
-const BitableFieldValueSchema = Type.Unsafe<unknown>({
-  type: ["string", "number", "boolean", "object", "array", "null"],
-});
-
-const CreateRecordSchema = Type.Object({
-  app_token: Type.String({ description: BITABLE_APP_TOKEN_DESCRIPTION }),
-  table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
-  fields: Type.Record(Type.String(), BitableFieldValueSchema, {
-    description: BITABLE_RECORD_FIELDS_DESCRIPTION,
-  }),
-});
-
-const CreateAppSchema = Type.Object({
-  name: Type.String({
-    description: "Name for the new Bitable application",
-  }),
-  folder_token: Type.Optional(
-    Type.String({
-      description: "Optional folder token to place the Bitable in a specific folder",
-    }),
-  ),
-});
-
-const CreateFieldSchema = Type.Object({
-  app_token: Type.String({ description: BITABLE_APP_TOKEN_DESCRIPTION }),
-  table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
-  field_name: Type.String({ description: "Name for the new field" }),
-  field_type: Type.Number({
-    description:
-      "Field type ID: 1=Text, 2=Number, 3=SingleSelect, 4=MultiSelect, 5=DateTime, 7=Checkbox, 11=User, 13=Phone, 15=URL, 17=Attachment, 18=SingleLink, 19=Lookup, 20=Formula, 21=DuplexLink, 22=Location, 23=GroupChat, 1001=CreatedTime, 1002=ModifiedTime, 1003=CreatedUser, 1004=ModifiedUser, 1005=AutoNumber",
-    minimum: 1,
-  }),
-  property: Type.Optional(
-    Type.Record(Type.String(), BitableFieldValueSchema, {
-      description: "Field-specific properties (e.g., options for SingleSelect, format for Number)",
-    }),
-  ),
-});
-
-const UpdateRecordSchema = Type.Object({
-  app_token: Type.String({ description: BITABLE_APP_TOKEN_DESCRIPTION }),
-  table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
-  record_id: Type.String({ description: "Record ID to update" }),
-  fields: Type.Record(Type.String(), BitableFieldValueSchema, {
-    description: BITABLE_RECORD_FIELDS_DESCRIPTION,
-  }),
-});
-
 // ============ Tool Registration ============
 
 export function registerFeishuBitableTools(api: OpenClawPluginApi) {
@@ -630,7 +589,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable Get Meta",
     description:
       "Parse a Bitable URL and get app_token, table_id, and table list. Use this first when given a /wiki/ or /base/ URL.",
-    parameters: GetMetaSchema,
+    parameters: FeishuBitableSchema.getMeta,
     async execute({ params, defaultAccountId }) {
       return getBitableMeta(getClient(params, defaultAccountId), params.url);
     },
@@ -640,7 +599,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     name: "feishu_bitable_list_fields",
     label: "Feishu Bitable List Fields",
     description: "List all fields (columns) in a Bitable table with their types and properties",
-    parameters: ListFieldsSchema,
+    parameters: FeishuBitableSchema.listFields,
     async execute({ params, defaultAccountId }) {
       return listFields(getClient(params, defaultAccountId), params.app_token, params.table_id);
     },
@@ -656,7 +615,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     name: "feishu_bitable_list_records",
     label: "Feishu Bitable List Records",
     description: "List records (rows) from a Bitable table with pagination support",
-    parameters: ListRecordsSchema,
+    parameters: FeishuBitableSchema.listRecords,
     async execute({ params, defaultAccountId }) {
       return listRecords(
         getClient(params, defaultAccountId),
@@ -677,7 +636,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     name: "feishu_bitable_get_record",
     label: "Feishu Bitable Get Record",
     description: "Get a single record by ID from a Bitable table",
-    parameters: GetRecordSchema,
+    parameters: FeishuBitableSchema.getRecord,
     async execute({ params, defaultAccountId }) {
       return getRecord(
         getClient(params, defaultAccountId),
@@ -697,7 +656,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     name: "feishu_bitable_create_record",
     label: "Feishu Bitable Create Record",
     description: "Create a new record (row) in a Bitable table",
-    parameters: CreateRecordSchema,
+    parameters: FeishuBitableSchema.createRecord,
     async execute({ params, defaultAccountId }) {
       return createRecord(
         getClient(params, defaultAccountId),
@@ -718,7 +677,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     name: "feishu_bitable_update_record",
     label: "Feishu Bitable Update Record",
     description: "Update an existing record (row) in a Bitable table",
-    parameters: UpdateRecordSchema,
+    parameters: FeishuBitableSchema.updateRecord,
     async execute({ params, defaultAccountId }) {
       return updateRecord(
         getClient(params, defaultAccountId),
@@ -734,7 +693,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     name: "feishu_bitable_create_app",
     label: "Feishu Bitable Create App",
     description: "Create a new Bitable (multidimensional table) application",
-    parameters: CreateAppSchema,
+    parameters: FeishuBitableSchema.createApp,
     async execute({ params, defaultAccountId }) {
       return createApp(getClient(params, defaultAccountId), params.name, params.folder_token, {
         debug: (msg) => api.logger.debug?.(msg),
@@ -754,7 +713,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     name: "feishu_bitable_create_field",
     label: "Feishu Bitable Create Field",
     description: "Create a new field (column) in a Bitable table",
-    parameters: CreateFieldSchema,
+    parameters: FeishuBitableSchema.createField,
     async execute({ params, defaultAccountId }) {
       return createField(
         getClient(params, defaultAccountId),


### PR DESCRIPTION
Supersedes https://github.com/openclaw/openclaw/pull/117455 while leaving that contributor PR open. Original repair and authorship are credited to @steipete; exact head `fd310f0d17bfe7cb8a7eedae70b969fbcc798917` retains Peter Steinberger as commit author.

## What This Solves

Feishu Bitable table discovery and field listing previously returned only the first provider page. This repair uses one bounded Feishu-local collector for both metadata operations, preserves opaque continuation tokens exactly, rejects blank or repeated cursors, caps pagination at 100 requests, and fails the whole operation on later-page provider or transport errors. The tool schemas were mechanically moved into a private `bitable-schema.ts` module; no public export was added.

## Reviewed State

- Reviewed base: `ea1233bb131fb8d93ae86871f51ddfb8b21e09f5`.
- Exact head: `fd310f0d17bfe7cb8a7eedae70b969fbcc798917`.
- At `2026-09-05T07:30:49Z`, exact main was `9a6a97f8b72ec17c330d281fb12160e29d5719f0`. Main had no changes to the three owned Feishu Bitable paths since the reviewed base, and the merge-tree had no conflict.
- Production diff: raw `+156/-114`, net `+42`. Of the additions, 83 lines are the mechanical move of existing private schemas/constants into `bitable-schema.ts`; the remaining change owns bounded, fail-closed pagination and registration wiring. Tests add `+204`.

## Dependency Contract

Direct inspection of installed `@larksuiteoapi/node-sdk@1.73.0` runtime source confirmed that `appTable.list()` and `appTableField.list()` pass caller parameters to `httpInstance.request()` and rethrow request errors. Their `listWithIterator()` variants catch and log request errors without rethrowing; the iterator can yield `null` and stop. The direct `list()` APIs are therefore required for complete-or-error behavior.

## Evidence

- Pre-fix red proof: https://github.com/openclaw/openclaw/actions/runs/33947809514 — `8 failed / 13 passed`.
- Exact-head Testbox proof: https://github.com/openclaw/openclaw/actions/runs/33949922768, lease `tbx_01m1r42r8nt8zvgh5mt9hzr8sw` — `47/47` focused tests, `5/5` changed-gate contract tests, and all 25 planned checks passed.
- Formal autoreview exited `0`: scoped-clean through P0-P2, confidence `0.97`.
- Exact-head native CI: https://github.com/openclaw/openclaw/actions/runs/33950483310 — attempt 2 succeeded. Attempt 1 had two unrelated flakes in unchanged owner paths; both passed the single failed-jobs-only rerun.
- Codex source was inspected directly at `codex-rs/core/src/session/mcp.rs`, `codex-rs/protocol/src/mcp.rs`, and `codex-rs/protocol/src/capabilities.rs`. This repair does not depend on Codex runtime or protocol behavior.

## Mandatory Blocker

No disposable authenticated Feishu/Lark credential exists in the operator surfaces available for this work: operator config, ambient environment, or repository, organization, and environment secrets/variables. Authenticated runtime proof for pagination beyond 100 fields and for table-list denial therefore cannot be performed.

The deterministic regression tests are not live provider proof. This PR remains draft and must not merge until that evidence gap is resolved or explicitly accepted by a maintainer.
