### PR TITLE
fix(chat): keep replies stable across history refresh

### DIFF
--- a/packages/gateway-client/src/session-projection-run-terminal.test.ts
+++ b/packages/gateway-client/src/session-projection-run-terminal.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   createSessionProjection,
   hasSessionProjectionAcceptedFinal,
+  projectLiveSessionMessage,
+  reconcileSessionProjectionSnapshot,
   reduceSessionProjection,
   type SessionProjectionScope,
 } from "./session-projection.js";
@@ -28,6 +30,53 @@ function createMessage(
 
 /** Run-scoped terminal state: final acceptance, late diagnostics, and retention. */
 describe("session run terminal bookkeeping", () => {
+  it.each(["live", "snapshot"])(
+    "keeps display parts distinct and adopts one final after %s history",
+    (arrival) => {
+      const runId = "tool-run";
+      const history = [
+        createMessage("user", "First check", { id: "previous-user", seq: 1 }),
+        createMessage("assistant", "17", { id: "previous-final", seq: 2, runId: "previous-run" }),
+        createMessage("user", "Check twice", { id: "current-user", seq: 3, runId }),
+      ];
+      const parts = ["first", "second"].flatMap((itemId, index) => {
+        const metadata = { id: `row-${itemId}`, seq: index + 4, runId };
+        return [
+          {
+            ...createMessage("assistant", "Checking inventory.", metadata),
+            openclawStreamFallback: { source: "segment", itemId },
+          },
+          {
+            role: "assistant",
+            content: [{ type: "toolCall", id: `call-${itemId}`, name: "read", arguments: {} }],
+            stopReason: "toolUse",
+            __openclaw: metadata,
+          },
+        ];
+      });
+      const final = createMessage("assistant", "17", { id: "final-row", seq: 6, runId });
+      const expected = [...history, ...parts, final];
+      let state =
+        arrival === "snapshot"
+          ? createSessionProjection(primaryScope, [...history, ...parts])
+          : parts.reduce(
+              (projection, message) => projectLiveSessionMessage(projection, message),
+              createSessionProjection(primaryScope, history),
+            );
+      state = projectLiveSessionMessage(state, final);
+      state = projectLiveSessionMessage(state, createMessage("assistant", "17"), { runId });
+      expect(state.messages).toEqual(expected);
+
+      state = reduceSessionProjection(state, { type: "transportGap" });
+      state = reduceSessionProjection(state, { type: "reconnected" });
+      state = reconcileSessionProjectionSnapshot(state, structuredClone(expected));
+      for (const message of parts) {
+        state = projectLiveSessionMessage(state, message);
+      }
+      expect(state.messages).toEqual(expected);
+    },
+  );
+
   it("does not reopen a completed run when a stale stream delta arrives", () => {
     const completed = reduceSessionProjection(createSessionProjection(primaryScope), {
       type: "runTerminal",

--- a/packages/gateway-client/src/session-projection.ts
+++ b/packages/gateway-client/src/session-projection.ts
@@ -236,12 +236,20 @@ function entryMatches(
   right: SessionProjectionEntry,
   allowSnapshotPromotion = false,
 ): boolean {
+  const leftSegment = readAssistantStreamSegmentIdentity(left.message);
+  const rightSegment = readAssistantStreamSegmentIdentity(right.message);
+  // A transcript row can project commentary and a separate body/tool part.
+  // Row identity never joins different display parts, even when their text agrees.
+  if (leftSegment?.itemId !== rightSegment?.itemId) {
+    return false;
+  }
   if (sameTranscriptIdentity(left.identity, right.identity)) {
     return true;
   }
   const durableEntry = left.identity?.id ? left : right.identity?.id ? right : null;
   const provisionalEntry = durableEntry === left ? right : durableEntry === right ? left : null;
-  const durableMetadata = readRecord(readRecord(durableEntry?.message)?.["__openclaw"]);
+  const durableMessage = readRecord(durableEntry?.message);
+  const durableMetadata = readRecord(durableMessage?.["__openclaw"]);
   if (
     durableEntry?.identity?.role === "assistant" &&
     provisionalEntry?.identity?.role === "assistant" &&
@@ -249,8 +257,8 @@ function entryMatches(
     !provisionalEntry.identity.isImported &&
     !provisionalEntry.identity.id
   ) {
-    const durableSegment = readAssistantStreamSegmentIdentity(durableEntry.message);
-    const provisionalSegment = readAssistantStreamSegmentIdentity(provisionalEntry.message);
+    const durableSegment = durableEntry === left ? leftSegment : rightSegment;
+    const provisionalSegment = durableEntry === left ? rightSegment : leftSegment;
     // Terminal cleanup can materialize commentary before cursor history catches up.
     // Adopt its exact item/run without joining distinct durable rows or equal prose.
     if (
@@ -261,10 +269,12 @@ function entryMatches(
     ) {
       return true;
     }
-    // History changes retention, not identity: a hydrated row still owns its
-    // unsequenced run projection. Item-keyed commentary remains separate.
+    // Only a reply can own an unkeyed run terminal. Hydrated commentary and
+    // tool-use continuations otherwise make the real final look ambiguous.
     if (
       provisionalEntry.live &&
+      !durableSegment &&
+      durableMessage?.stopReason !== "toolUse" &&
       provisionalEntry.identity.sequence === null &&
       (provisionalEntry.afterSequence === undefined ||
         (provisionalEntry.afterSequence !== null &&

--- a/src/gateway/chat-display-projection.media.test.ts
+++ b/src/gateway/chat-display-projection.media.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { applyAssistantDeliveryDirectives } from "../config/sessions/transcript-assistant-delivery.js";
-import { projectSessionMessagePayload } from "./session-transcript-message.js";
+import { projectSessionMessagePayloads } from "./session-transcript-message.js";
 
 describe("assistant media directive display projection", () => {
   it("withholds relative MEDIA directives until managed attachment blocks replace them", () => {
-    const { payload } = projectSessionMessagePayload({
+    const {
+      payloads: [payload],
+    } = projectSessionMessagePayloads({
       sessionKey: "agent:main:main",
       message: {
         role: "assistant",
@@ -31,7 +33,9 @@ describe("assistant media directive display projection", () => {
   });
 
   it("keeps a media-only assistant row pending for its structured rewrite", () => {
-    const { payload } = projectSessionMessagePayload({
+    const {
+      payloads: [payload],
+    } = projectSessionMessagePayloads({
       sessionKey: "agent:main:main",
       message: {
         role: "assistant",
@@ -48,7 +52,9 @@ describe("assistant media directive display projection", () => {
 
   it("preserves fenced MEDIA examples as ordinary assistant text", () => {
     const text = ["```text", "MEDIA:./example.jpg", "```", ""].join("\n");
-    const { payload } = projectSessionMessagePayload({
+    const {
+      payloads: [payload],
+    } = projectSessionMessagePayloads({
       sessionKey: "agent:main:main",
       message: { role: "assistant", content: [{ type: "text", text }] },
     });
@@ -60,7 +66,9 @@ describe("assistant media directive display projection", () => {
 
   it("preserves legacy remote MEDIA references for client-side attachment projection", () => {
     const text = "MEDIA:https://cdn.example.test/legacy.jpg";
-    const { payload } = projectSessionMessagePayload({
+    const {
+      payloads: [payload],
+    } = projectSessionMessagePayloads({
       sessionKey: "agent:main:main",
       message: { role: "assistant", content: [{ type: "text", text }] },
     });
@@ -77,7 +85,9 @@ describe("assistant media directive display projection", () => {
         role: "assistant",
         content: [{ type: "text", text }],
       });
-      const { payload } = projectSessionMessagePayload({
+      const {
+        payloads: [payload],
+      } = projectSessionMessagePayloads({
         sessionKey: "agent:main:main",
         message: persisted,
       });
@@ -87,7 +97,9 @@ describe("assistant media directive display projection", () => {
   );
 
   it("withholds only relative directives from a mixed legacy batch", () => {
-    const { payload } = projectSessionMessagePayload({
+    const {
+      payloads: [payload],
+    } = projectSessionMessagePayloads({
       sessionKey: "agent:main:main",
       message: {
         role: "assistant",

--- a/src/gateway/server-methods/chat-history-delta.ts
+++ b/src/gateway/server-methods/chat-history-delta.ts
@@ -9,7 +9,7 @@ import { jsonUtf8BytesOrInfinity } from "../../infra/json-utf8-bytes.js";
 import { createCurrentUserProfileMessageProjector } from "../chat-display-projection.js";
 import { resolveCurrentUserProfileDisplay } from "../current-user-profile-display.js";
 import {
-  projectSessionMessagePayload,
+  projectSessionMessagePayloads,
   type SessionMessageProjectionState,
 } from "../session-transcript-message.js";
 
@@ -85,7 +85,7 @@ export function readChatHistoryDelta(params: {
     if (!event || row.messageSeq === undefined) {
       continue;
     }
-    const projected = projectSessionMessagePayload({
+    const projected = projectSessionMessagePayloads({
       agentId: params.agentId,
       message: event.message,
       ...(event.messageId ? { messageId: event.messageId } : {}),
@@ -97,12 +97,12 @@ export function readChatHistoryDelta(params: {
       sessionSnapshot: params.sessionSnapshot,
     });
     projectionState = projected.projectionState;
-    if (projected.payload) {
-      messagesBytes += jsonUtf8BytesOrInfinity(projected.payload) + (messages.length > 0 ? 1 : 0);
+    for (const payload of projected.payloads) {
+      messagesBytes += jsonUtf8BytesOrInfinity(payload) + (messages.length > 0 ? 1 : 0);
       if (messagesBytes > maxBytes) {
         return { kind: "reset" };
       }
-      messages.push(projected.payload);
+      messages.push(payload);
     }
   }
   return {

--- a/src/gateway/server-session-events.test-support.ts
+++ b/src/gateway/server-session-events.test-support.ts
@@ -16,7 +16,6 @@ const sessionRow = vi.hoisted(() => ({
 }));
 const resolveEmbeddedAgentRunProgressStateMock = vi.hoisted(() => vi.fn());
 const loadGatewaySessionRowMock = vi.hoisted(() => vi.fn());
-const projectChatDisplayMessageMock = vi.hoisted(() => vi.fn((message: unknown) => message));
 const listAccessorSessionEntriesReadOnlyMock = vi.hoisted(() => vi.fn());
 const loadAccessorSessionEntryReadOnlyMock = vi.hoisted(() => vi.fn());
 const loadGatewaySessionEntryReadOnlyMock = vi.hoisted(() => vi.fn());
@@ -34,10 +33,6 @@ vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => {
     loadSessionEntryReadOnly: loadAccessorSessionEntryReadOnlyMock,
     resolveTranscriptSessionKeyBySessionId: resolveTranscriptSessionKeyBySessionIdMock,
   };
-});
-vi.mock("./chat-display-projection.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./chat-display-projection.js")>();
-  return { ...actual, projectChatDisplayMessage: projectChatDisplayMessageMock };
 });
 vi.mock("./session-utils.js", () => ({
   attachOpenClawTranscriptMeta: (message: unknown) => message,
@@ -175,7 +170,6 @@ export {
   loadGatewaySessionEntryReadOnlyMock,
   loadGatewaySessionRowMock,
   ownerGoal,
-  projectChatDisplayMessageMock,
   readSessionMessageByIdAsyncMock,
   readSessionMessageCountAsyncMock,
   resolveEmbeddedAgentRunProgressStateMock,

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -12,7 +12,6 @@ import {
   loadGatewaySessionEntryReadOnlyMock,
   loadGatewaySessionRowMock,
   ownerGoal,
-  projectChatDisplayMessageMock,
   readSessionMessageByIdAsyncMock,
   readSessionMessageCountAsyncMock,
   resolveEmbeddedAgentRunProgressStateMock,
@@ -666,13 +665,11 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       sessionMessageSubscribers: { get: () => new Set() },
       chatAbortControllers: new Map(),
     });
-    projectChatDisplayMessageMock.mockReturnValueOnce(undefined).mockReturnValueOnce(undefined);
-
     try {
       await handler({
         sessionFile: "/tmp/sess-main.jsonl",
         sessionKey: "agent:main:main",
-        message: { role: "toolResult", content: [] },
+        message: { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
         messageId: "message-1",
         messageSeq: 1,
       });

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -38,7 +38,7 @@ import {
   resolveSessionSubscriptionKey,
   resolveSessionSubscriptionKeys,
 } from "./session-subscription-keys.js";
-import { projectSessionMessagePayload } from "./session-transcript-message.js";
+import { projectSessionMessagePayloads } from "./session-transcript-message.js";
 import {
   readSessionMessageByIdAsync,
   readSessionMessageCountAsync,
@@ -371,7 +371,7 @@ async function handleTranscriptUpdateBroadcast(
     );
     return;
   }
-  const projected = projectSessionMessagePayload({
+  const projected = projectSessionMessagePayloads({
     sessionKey,
     ...(eventAgentId ? { agentId: eventAgentId } : {}),
     message,
@@ -381,8 +381,10 @@ async function handleTranscriptUpdateBroadcast(
     ...(update.runId ? { runId: update.runId } : {}),
     sessionSnapshot,
   });
-  if (projected.payload) {
-    params.broadcastToConnIds("session.message", projected.payload, connIds);
+  if (projected.payloads.length > 0) {
+    for (const payload of projected.payloads) {
+      params.broadcastToConnIds("session.message", payload, connIds);
+    }
     return;
   }
 

--- a/src/gateway/server.chat-history-cursor.test.ts
+++ b/src/gateway/server.chat-history-cursor.test.ts
@@ -638,6 +638,37 @@ describe("chat.history cursor catch-up", () => {
       },
     },
     {
+      name: "commentary display parts",
+      append: async (storePath: string) => {
+        const call = await appendTranscriptMessage(currentScope(storePath), {
+          eventId: "phased-tool",
+          parentId: "cached",
+          message: {
+            role: "assistant",
+            content: [
+              ...["first", "second"].map((id) => ({
+                type: "text",
+                text: "Checking inventory.",
+                textSignature: JSON.stringify({ v: 1, id, phase: "commentary" }),
+              })),
+              { type: "toolCall", id: "call-1", name: "read", arguments: {} },
+            ],
+            stopReason: "toolUse",
+            __openclaw: { runId: "phased-run" },
+          },
+        });
+        await appendTranscriptMessage(currentScope(storePath), {
+          eventId: "phased-final",
+          parentId: call?.messageId,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "17" }],
+            __openclaw: { runId: "phased-run" },
+          },
+        });
+      },
+    },
+    {
       name: "heartbeat boundary",
       append: async (storePath: string) => {
         const heartbeat = await appendTranscriptMessage(currentScope(storePath), {
@@ -692,6 +723,14 @@ describe("chat.history cursor catch-up", () => {
     }>(context, "chat.history", { cursor: cached.payload?.deltaCursor });
     expect(delta.ok).toBe(true);
     expect(delta.payload?.kind).toBe("delta");
+    if (name === "commentary display parts") {
+      expect(delta.payload?.messages).toMatchObject([
+        { message: { openclawStreamFallback: { itemId: "first" } } },
+        { message: { openclawStreamFallback: { itemId: "second" } } },
+        { message: { content: [{ type: "toolCall", id: "call-1" }] } },
+        { message: { content: [{ type: "text", text: "17" }] } },
+      ]);
+    }
     if (name === "tool result pairing") {
       expect(delta.payload?.messages?.at(-1)?.message).toMatchObject({
         role: "toolResult",

--- a/src/gateway/session-transcript-message.test.ts
+++ b/src/gateway/session-transcript-message.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { createNestedToolActivity } from "../sessions/nested-tool-activity.js";
 import { projectChatDisplayMessage } from "./chat-display-projection.js";
 import {
-  projectSessionMessagePayload,
+  projectSessionMessagePayloads,
   projectTranscriptEntryMessage,
 } from "./session-transcript-message.js";
 
@@ -41,13 +41,13 @@ describe("trusted transcript display metadata", () => {
         position,
       ),
     );
-    const live = projectSessionMessagePayload({
+    const live = projectSessionMessagePayloads({
       message: activity,
       messageId: "entry",
       messageSeq: 2,
       transcriptPosition: position,
       sessionKey: "agent:main:dashboard:nested",
-    }).payload?.message;
+    }).payloads[0]?.message;
     for (const projected of [history, live]) {
       expect(readSessionMessageIdentity(projected)).toMatchObject({
         id: "entry",
@@ -71,13 +71,13 @@ describe("trusted transcript display metadata", () => {
         2,
         transcriptPosition,
       );
-      const live = projectSessionMessagePayload({
+      const live = projectSessionMessagePayloads({
         message,
         messageId: "entry",
         messageSeq: 2,
         transcriptPosition,
         sessionKey: "agent:main:main",
-      }).payload?.message;
+      }).payloads[0]?.message;
       for (const projected of [history, live]) {
         const metadata = asOptionalRecord(asOptionalRecord(projected)?.["__openclaw"]);
         expect(metadata?.transcriptPosition).toEqual(transcriptPosition);

--- a/src/gateway/session-transcript-message.ts
+++ b/src/gateway/session-transcript-message.ts
@@ -2,7 +2,6 @@ import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { TranscriptDisplayPosition } from "../chat/transcript-display-position.js";
 import {
   createCurrentUserProfileMessageProjector,
-  projectChatDisplayMessage,
   projectChatDisplayMessagesWithState,
 } from "./chat-display-projection.js";
 import { resolveCurrentUserProfileDisplay } from "./current-user-profile-display.js";
@@ -50,8 +49,8 @@ function readTranscriptMessageSenderIsOwner(message: unknown): boolean | undefin
   return typeof value === "boolean" ? value : undefined;
 }
 
-/** Project one transcript message into the exact payload emitted as session.message. */
-export function projectSessionMessagePayload(params: {
+/** Project every display part of a transcript row into ordered session.message payloads. */
+export function projectSessionMessagePayloads(params: {
   agentId?: string;
   message: unknown;
   messageId?: string;
@@ -62,7 +61,7 @@ export function projectSessionMessagePayload(params: {
   runId?: string;
   sessionKey: string;
   sessionSnapshot?: Record<string, unknown>;
-}): { payload?: Record<string, unknown>; projectionState: SessionMessageProjectionState } {
+}): { payloads: Record<string, unknown>[]; projectionState: SessionMessageProjectionState } {
   const idempotencyKey = readTranscriptMessageIdempotencyKey(params.message);
   const senderIsOwner = readTranscriptMessageSenderIsOwner(params.message);
   const rawMessage = attachOpenClawTranscriptMeta(params.message, {
@@ -72,29 +71,15 @@ export function projectSessionMessagePayload(params: {
     ...(idempotencyKey ? { idempotencyKey } : {}),
     ...(params.messageSeq !== undefined ? { seq: params.messageSeq } : {}),
   });
-  const projected = params.projectionState
-    ? projectChatDisplayMessagesWithState([rawMessage], {
-        streamErrorFallbackPending: params.projectionState.streamErrorFallbackPending,
-        turnBoundaryPending: params.projectionState.turnBoundaryPending,
-      })
-    : {
-        messages: [projectChatDisplayMessage(rawMessage)],
-        streamErrorFallbackPending: false,
-        turnBoundaryPending: false,
-      };
-  const projectionState = {
-    streamErrorFallbackPending: projected.streamErrorFallbackPending,
-    turnBoundaryPending: projected.turnBoundaryPending,
-  };
-  const message = projected.messages[0];
-  if (!message) {
-    return { projectionState };
-  }
+  const projected = projectChatDisplayMessagesWithState([rawMessage], {
+    ...params.projectionState,
+    includeCommentaryFallbacks: true,
+  });
   const projectCurrentUserProfile =
     params.projectCurrentUserProfile ??
     createCurrentUserProfileMessageProjector(resolveCurrentUserProfileDisplay);
   return {
-    payload: {
+    payloads: projected.messages.map((message) => ({
       sessionKey: params.sessionKey,
       ...(senderIsOwner === undefined ? {} : { senderIsOwner }),
       ...(params.agentId ? { agentId: params.agentId } : {}),
@@ -103,8 +88,11 @@ export function projectSessionMessagePayload(params: {
       ...(params.messageSeq !== undefined ? { messageSeq: params.messageSeq } : {}),
       ...params.sessionSnapshot,
       ...(params.runId ? { runId: params.runId } : {}),
+    })),
+    projectionState: {
+      streamErrorFallbackPending: projected.streamErrorFallbackPending,
+      turnBoundaryPending: projected.turnBoundaryPending,
     },
-    projectionState,
   };
 }
 

--- a/src/gateway/worker-environments/placement-store.turn-claim-closure.test.ts
+++ b/src/gateway/worker-environments/placement-store.turn-claim-closure.test.ts
@@ -21,7 +21,7 @@ import {
   openOpenClawStateDatabase,
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import { projectSessionMessagePayload } from "../session-transcript-message.js";
+import { projectSessionMessagePayloads } from "../session-transcript-message.js";
 import type { WorkerConnectionIdentity } from "./connection-identity.js";
 import { placementTurnOwner, type WorkerSessionPlacementIdentity } from "./placement-record.js";
 import {
@@ -365,11 +365,11 @@ it.each([
     const unsubscribe = onSessionTranscriptUpdate((update) => {
       if (update.sessionId === SESSION.sessionId) {
         published.push(
-          projectSessionMessagePayload({
+          ...projectSessionMessagePayloads({
             ...update,
             message: update.message,
             sessionKey: SESSION.sessionKey,
-          }).payload,
+          }).payloads,
         );
       }
     });


### PR DESCRIPTION
Fixes #138735. Reported by @PanyhP.

## What Problem This Solves

Fixes an issue where Control UI users could see a duplicated final answer after refreshing a tool-using turn. Cursor-based history also omitted saved commentary parts that full history displayed.

## Why This Change Was Made

Keep commentary item identity separate from the parent transcript row. Commentary and tool-use continuation rows cannot own an unkeyed final answer. Live events and cursor history now use one ordered display projection, including the same commentary parts as full history.

Stored transcripts, commentary preferences, schemas, and protocol fields are unchanged. Genuine same-text items and ambiguous distinct final messages remain separate.

## User Impact

Assistant output stays consistent during a run, after a page refresh, and after reconnect. Repeated commentary from two distinct items remains visible as two items, not one merged message.

## Evidence

- Baseline: `d5992278b3b8a8f3e1e37c23749b86efec65215f`.
- Live-tested package: `94f79b3db88e8d62cf8ab50cc465fe50d1f744bb`.
- PR head: `cc4d64bf0026a9a346162d942d3cb27cf1661cff`. Its follow-up removes a stale test mock and uses a real hidden reply. Production, dependencies, build configuration, and live-scenario inputs are unchanged; the retained live proof keeps its original package identity.
- Real Gateway and built Control UI, using the OpenClaw runtime and OpenAI Responses. The observed provider stream contains separate commentary item IDs, tool calls, and a final-answer phase. This is not mock-provider or source-import UI proof.
- Before: after a mid-run refresh, one stored final answer displayed as `17 ×2`. A later full refresh showed one `17`.
- After: two sequential file-read tool calls, equal-text but distinct commentary items, a mid-run refresh, and a separate connection-loss/reconnect control retain each commentary item and one final answer. Read-only SQLite inspection confirms one stored copy per item.
- Candidate startup preserved the baseline transcript export byte-for-byte. The served browser bundle changed to the candidate build.
- The shared-client regression and cursor-history regression failed before their owning repairs. A 615-test sibling run passed across Gateway, Control UI, media, worker closure, and terminal UI code. The final shared-client test placement passed 101 tests. The CI fixture correction passed 43 event/lifecycle tests. Focused type-aware lint and pinned formatting passed. Baseline and both candidate revisions built successfully on the isolated proof host.
- Production: `+38/-38` (net zero). Tests and test support: `+116/-25`.

Provider limitation: the approved proof environment has no DeepSeek key. The tested Responses route has observed equivalent phase/item metadata. The reported DeepSeek-specific route was not live-tested; current and reported-release DeepSeek catalog code selects Chat Completions by default.

### Before and after

| Before: one stored final displayed twice | After: one final, with both commentary items retained |
| --- | --- |
| ![Before refresh repair](https://github.com/user-attachments/assets/64c77427-dbf8-4484-9425-6abff177197b) | ![After refresh repair](https://github.com/user-attachments/assets/11235a65-5227-4df8-93d6-d353d577bf39) |

<details>
<summary>Real browser recordings</summary>

Before:

https://github.com/user-attachments/assets/c3498578-8630-4655-aef7-8568582cb1ae

After:

https://github.com/user-attachments/assets/3b5bb32c-646c-46c1-b63a-468b8181964d

</details>
