### PR TITLE
perf(logging): reuse current run owner in activity snapshots

### DIFF
--- a/src/logging/diagnostic-argument-churn-activity.ts
+++ b/src/logging/diagnostic-argument-churn-activity.ts
@@ -1,3 +1,5 @@
+import { resolveCurrentDiagnosticRunId } from "./diagnostic-embedded-run-index.js";
+
 // A semantic-stall clock remains continuous across short model/tool handoffs,
 // but later model progress wins once no churn observation refreshes this lease.
 const ARGUMENT_CHURN_CONTINUITY_WINDOW_MS = 60_000;
@@ -36,18 +38,6 @@ export type DiagnosticArgumentChurnObservationParams = {
   now?: number;
 };
 
-function resolveCurrentArgumentChurnOwner<T extends { sequence: number }>(
-  owners: Iterable<T>,
-): T | undefined {
-  let currentOwner: T | undefined;
-  for (const owner of owners) {
-    if (!currentOwner || owner.sequence > currentOwner.sequence) {
-      currentOwner = owner;
-    }
-  }
-  return currentOwner;
-}
-
 function hasArgumentChurnContinuityExpired(
   activity: DiagnosticArgumentChurnActivity & { lastProgressAt?: number },
   now: number,
@@ -69,15 +59,14 @@ function hasArgumentChurnContinuityExpired(
   );
 }
 
-export function resolveArgumentChurnProgress<T extends { runId: string; sequence: number }>(
+export function resolveArgumentChurnProgress(
   activity: DiagnosticArgumentChurnActivity & {
     lastProgressAt: number;
     lastProgressReason?: string;
   },
-  owners: Iterable<T>,
+  currentOwnerRunId: string | undefined,
   now: number,
 ): { lastProgressAt: number; lastProgressReason?: string } {
-  const currentOwnerRunId = resolveCurrentArgumentChurnOwner(owners)?.runId;
   if (
     currentOwnerRunId !== undefined &&
     activity.argumentChurnPolicyWaitRunId === currentOwnerRunId &&
@@ -186,7 +175,7 @@ export function applyArgumentChurnObservation<T extends { runId: string; sequenc
 ): void {
   const now = params.now ?? Date.now();
   const runId = params.runId?.trim() || undefined;
-  const currentOwnerRunId = resolveCurrentArgumentChurnOwner(owners)?.runId;
+  const currentOwnerRunId = resolveCurrentDiagnosticRunId(owners);
   if (currentOwnerRunId !== undefined && currentOwnerRunId !== runId) {
     return;
   }

--- a/src/logging/diagnostic-embedded-run-index.ts
+++ b/src/logging/diagnostic-embedded-run-index.ts
@@ -1,3 +1,16 @@
+// Re-arming a work key can advance its sequence without changing Map iteration order.
+export function resolveCurrentDiagnosticRunId(
+  owners: Iterable<{ runId: string; sequence: number }>,
+): string | undefined {
+  let currentOwner: { runId: string; sequence: number } | undefined;
+  for (const owner of owners) {
+    if (!currentOwner || owner.sequence > currentOwner.sequence) {
+      currentOwner = owner;
+    }
+  }
+  return currentOwner?.runId;
+}
+
 type EmbeddedRunActivity<TRun extends { runId: string }> = {
   activeEmbeddedRuns: Map<string, TRun>;
 };

--- a/src/logging/diagnostic-repeated-request-activity.ts
+++ b/src/logging/diagnostic-repeated-request-activity.ts
@@ -1,3 +1,5 @@
+import { resolveCurrentDiagnosticRunId } from "./diagnostic-embedded-run-index.js";
+
 // Mechanical request retries stay continuous for one run owner. Only typed
 // semantic progress or owner teardown can clear the clock that recovery reads.
 type RepeatedRequestOwner = { runId: string; sequence: number };
@@ -16,16 +18,6 @@ function nextMutationSequence(): number {
   return mutationSequence;
 }
 
-function currentOwner(owners: Iterable<RepeatedRequestOwner>): RepeatedRequestOwner | undefined {
-  let current: RepeatedRequestOwner | undefined;
-  for (const owner of owners) {
-    if (!current || owner.sequence > current.sequence) {
-      current = owner;
-    }
-  }
-  return current;
-}
-
 export function recordRepeatedRequestObservation(
   activity: DiagnosticRepeatedRequestActivity,
   owners: Iterable<RepeatedRequestOwner>,
@@ -38,9 +30,9 @@ export function recordRepeatedRequestObservation(
   if (params.observationUnit === "turn") {
     return;
   }
-  const owner = currentOwner(owners);
+  const currentOwnerRunId = resolveCurrentDiagnosticRunId(owners);
   const runId = params.runId?.trim();
-  if (!owner || !runId || owner.runId !== runId) {
+  if (currentOwnerRunId === undefined || !runId || currentOwnerRunId !== runId) {
     return;
   }
   if (activity.repeatedRequestOwnerRunId !== runId) {
@@ -93,13 +85,12 @@ export function mergeRepeatedRequestActivity(
 
 export function resolveRepeatedRequestNoProgressAgeMs(
   activity: DiagnosticRepeatedRequestActivity,
-  owners: Iterable<RepeatedRequestOwner>,
+  currentOwnerRunId: string | undefined,
   now: number,
 ): number | undefined {
-  const owner = currentOwner(owners);
   if (
-    !owner ||
-    owner.runId !== activity.repeatedRequestOwnerRunId ||
+    currentOwnerRunId === undefined ||
+    currentOwnerRunId !== activity.repeatedRequestOwnerRunId ||
     (activity.repeatedRequestCount ?? 0) < 2 ||
     activity.repeatedRequestFirstStartedAt === undefined
   ) {

--- a/src/logging/diagnostic-run-activity-snapshot.ts
+++ b/src/logging/diagnostic-run-activity-snapshot.ts
@@ -3,6 +3,7 @@ import {
   type DiagnosticArgumentChurnActivity,
   resolveArgumentChurnProgress,
 } from "./diagnostic-argument-churn-activity.js";
+import { resolveCurrentDiagnosticRunId } from "./diagnostic-embedded-run-index.js";
 import {
   type DiagnosticRepeatedRequestActivity,
   resolveRepeatedRequestNoProgressAgeMs,
@@ -69,11 +70,8 @@ export function buildDiagnosticSessionActivitySnapshot(
       activeTool = tool;
     }
   }
-  const churnProgress = resolveArgumentChurnProgress(
-    activity,
-    activity.activeEmbeddedRuns.values(),
-    now,
-  );
+  const currentOwnerRunId = resolveCurrentDiagnosticRunId(activity.activeEmbeddedRuns.values());
+  const churnProgress = resolveArgumentChurnProgress(activity, currentOwnerRunId, now);
   return {
     activeWorkKind,
     ...(activity.activeEmbeddedRuns.size > 0 ? { hasActiveEmbeddedRun: true } : {}),
@@ -85,7 +83,7 @@ export function buildDiagnosticSessionActivitySnapshot(
     lastProgressReason: churnProgress.lastProgressReason,
     repeatedRequestNoProgressAgeMs: resolveRepeatedRequestNoProgressAgeMs(
       activity,
-      activity.activeEmbeddedRuns.values(),
+      currentOwnerRunId,
       now,
     ),
     activeModelCallRequestTimeoutMs,

--- a/src/logging/diagnostic-run-activity.test.ts
+++ b/src/logging/diagnostic-run-activity.test.ts
@@ -43,6 +43,46 @@ afterEach(() => {
 });
 
 describe("core model owner generations", () => {
+  it("keeps the newest run's clocks when an earlier work key is rearmed", async () => {
+    vi.useFakeTimers();
+    const startedAt = Date.parse("2026-09-04T00:00:00Z");
+    vi.setSystemTime(startedAt);
+    const ref = { sessionId: "rearmed-session", sessionKey: "agent:main:rearmed" };
+    const earlier = { ...ref, runId: "earlier-run", workKey: "first" };
+    const later = { ...ref, runId: "later-run", workKey: "second" };
+    const earlierOwner = createDiagnosticEmbeddedRunOwner(earlier);
+    const laterOwner = createDiagnosticEmbeddedRunOwner(later);
+    startDiagnosticRunActivityTracking();
+    markDiagnosticEmbeddedRunStarted({ ...earlier, owner: earlierOwner });
+    markDiagnosticEmbeddedRunStarted({ ...later, owner: laterOwner });
+    markDiagnosticEmbeddedRunStarted({ ...earlier, owner: earlierOwner });
+    markDiagnosticArgumentChurnObservation({ ...ref, runId: earlier.runId, active: true });
+    for (const callId of ["request-1", "request-2"]) {
+      emitCoreModelRequestStartedDiagnosticEvent(
+        { ...ref, runId: earlier.runId, callId, provider: "core", model: "request-model" },
+        earlierOwner.generation,
+      );
+    }
+    await vi.advanceTimersByTimeAsync(0);
+    await waitForDiagnosticEventsDrained();
+
+    expect(getDiagnosticSessionActivitySnapshot(ref, startedAt + 30_000)).toMatchObject({
+      activeWorkKind: "model_call",
+      lastProgressReason: "tool_loop:argument_churn",
+      lastProgressAgeMs: 30_000,
+      repeatedRequestNoProgressAgeMs: 30_000,
+    });
+
+    closeDiagnosticEmbeddedRunOwner(earlierOwner);
+    expect(getDiagnosticSessionActivitySnapshot(ref, startedAt + 30_000)).toMatchObject({
+      activeWorkKind: "embedded_run",
+      hasActiveEmbeddedRun: true,
+      lastProgressReason: "embedded_run:ended",
+      repeatedRequestNoProgressAgeMs: undefined,
+    });
+    closeDiagnosticEmbeddedRunOwner(laterOwner);
+  });
+
   it("keeps exact-call recovery policy intact across forged terminals and run completion", async () => {
     const ref = { sessionId: "core-owner-session", sessionKey: "agent:main:core-owner" };
     const runId = "core-owner-run";


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Allow edits from maintainers remains enabled.

</details>

## What Problem This Solves

Diagnostic snapshots scan the same active run owners separately to decide which run owns argument-churn and repeated-request clocks. Heartbeats and recovery readers pay for those repeated scans, and two copies of the newest-owner rule can drift apart.

## Why This Change Was Made

Select the current run ID once per snapshot and pass that fact to both clock projections. Observation producers use the same selector when accepting new events. Selection remains greatest sequence, with the first entry winning ties; rearming a Map key does not incorrectly make iteration order authoritative. Ownerless churn and repeated-request ownership deliberately retain their different rules.

The separate selectors are deleted. This is an internal ownership refactor with no cache, changed diagnostic protocol, new configuration, or storage change. Production is +29/−38, **net −9 lines**; a lifecycle preservation test adds **40 lines**.

## User Impact

The same diagnostic and recovery information requires less repeated owner selection. This is a component improvement, not a claim that complete agent turns, Gateway startup, or memory usage improve.

## Evidence

The complete 117-case owner/getter test pair and 29 ordinary changed checks passed. Managed Codex review returned no P0–P2 findings in two partitions, confidence 0.90. A normal mapped build passed, with source correspondence checked for the four changed owners, public getter, heartbeat caller, and Gateway startup/RPC path.

The fixed before/candidate proofs and B0/C0/C1/B1 measurements retain **33,328 complete outputs**, **2,048 measured means**, **1,372 comparisons**, and **282 adverse comparisons**. A separate root audit decoded the full retained V8 inputs/outputs and recomputed every comparison. There was no numerical acceptance threshold and no measurement rerun.

| Public activity snapshot case | Forward median | Reverse median |
| --- | ---: | ---: |
| Empty retained activity | −20.43% | −22.07% |
| One ordinary owner | −2.88% | −12.07% |
| Two ordinary owners, newest first | −15.14% | −1.05% |
| Two owners with both clocks | −19.00% | **+4.10% (+24.781 ns)** |
| Two owners with pending policy tokens | −9.87% | −6.26% |
| One owner with concurrent tools and model calls | −9.64% | −7.75% |
| Retired owner with retained stale clock fields | −2.95% | −5.21% |
| Sixteen-owner labeled stress, newest first | −20.60% | −25.20% |

Fifteen of sixteen paired medians improved, but this was not uniformly faster. The concurrent tools/model-call case’s forward maximum batch mean increased 738.48% (+9.943 µs), its mean 15.15% and p95 10.23%. The two-owner/two-clock case’s reverse first call increased 12.125 µs/47.86% and p95 22.72%. p95 and maximum are statistics of 64 batch means, not individual-call latency. Whole-host elapsed increased 2.17%/1.12%; sampled RSS missed transient peaks. There is no whole-host latency, allocation, or memory-benefit claim. The cleanup and scoped median gains justify retaining the change with these adverse observations disclosed.

A separate real OpenAI turn on the built candidate ran one ordinary foreground Node command for 35 seconds, returned its exact result, and completed all eight public RPCs. The ordinary 30-second diagnostic heartbeat reported one active run, no waiting work and no queued work while that command was running. A Node CPU profile sampled the actual heartbeat → public getter → changed snapshot-builder stack. This proves execution of the changed path; one sampled builder frame does not quantify its cost. The main profile contains two negative timestamp deltas, so only stack identities and counts are used, not weighted CPU time.

The original closed verifier exited 1 because it incorrectly required globally increasing sequence numbers in the diagnostic ring. The recorder intentionally retains delivery order: an asynchronously delivered model completion arrived after a newer synchronous session-state event. That failure is retained, without rerunning the provider task or changing production telemetry. Independent examination of the same complete RPCs, transcript, seed output, heartbeat and profile supplies the changed-path evidence. Mixed-delivery cursor semantics are recorded as a separate follow-up, not claimed fixed here.

The live Gateway exited normally; all 18 observed process IDs and six groups were absent afterward, and its port refused connections and could be rebound. The task credential window was removed. The exact provider/service-value scan found zero matches in the 12,281,374 run bytes then present; later analysis/receipt files are outside that scan scope. Full source/build binding remained unchanged after the observation. This real turn used the OpenClaw runtime; it does not claim Codex runtime coverage or all multi-owner lifecycle cases, which remain covered by the behavior suite.
