### PR TITLE
fix(gateway): prevent stalls during worker recovery

### DIFF
--- a/src/gateway/server-worker-placement-dispatch-admission.ts
+++ b/src/gateway/server-worker-placement-dispatch-admission.ts
@@ -17,6 +17,7 @@ export function createGatewayWorkerDispatchAdmission(
         key: request.sessionKey,
         agentId: request.agentId,
         clone: false,
+        exactRead: true,
       });
     const target = resolve();
     const entry = runtime.resolveCanonicalSessionEntryFromStoreKeys(target.store, target.storeKeys);

--- a/src/gateway/server-worker-placement-move-barrier.ts
+++ b/src/gateway/server-worker-placement-move-barrier.ts
@@ -38,6 +38,7 @@ export function createGatewayWorkerPlacementMoveBarrier(params: {
       key: sessionKey,
       agentId,
       clone: false,
+      exactRead: true,
     });
     const lifecycleIdentities = [sessionKey, target.canonicalKey, ...target.storeKeys, sessionId];
     let begun: Awaited<ReturnType<typeof begin>> | undefined;

--- a/src/gateway/server-worker-placement-reclaim.ts
+++ b/src/gateway/server-worker-placement-reclaim.ts
@@ -50,6 +50,7 @@ export function createGatewayWorkerPlacementReclaimBarriers(
       key: sessionKey,
       agentId,
       clone: false,
+      exactRead: true,
     });
     const lifecycleIdentities = [sessionKey, target.canonicalKey, ...target.storeKeys, sessionId];
     const cancelAndDrain = async (
@@ -146,6 +147,7 @@ export function createGatewayWorkerPlacementReclaimBarriers(
         key: sessionKey,
         agentId,
         clone: false,
+        exactRead: true,
       });
       const currentEntry = sessionRuntime.resolveCanonicalSessionEntryFromStoreKeys(
         current.store,
@@ -311,6 +313,7 @@ export function createGatewayWorkerPlacementReclaimBarriers(
           key: sessionKey,
           agentId,
           clone: false,
+          exactRead: true,
         });
         const currentEntry = sessionRuntime.resolveCanonicalSessionEntryFromStoreKeys(
           currentTarget.store,

--- a/src/gateway/server-worker-placement-session-target.test.ts
+++ b/src/gateway/server-worker-placement-session-target.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveSessionStorePathCore } from "../config/sessions.js";
+import {
+  loadExactSessionEntryReadOnly,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { resolveWorkerPlacementSessionTarget } from "./server-worker-placement-session-target.js";
+import { resolveGatewaySessionStoreTargetWithStore } from "./session-utils-store-lookup.js";
+import { resolveCanonicalSessionEntryFromStoreKeys } from "./session-utils-store.js";
+
+afterEach(() => resetConfigRuntimeState());
+
+test("resolves consecutive placement workspaces without decoding unrelated session payloads", async () => {
+  await withStateDirEnv("worker-exact-target-", async () => {
+    const config: OpenClawConfig = { agents: { list: [{ id: "main", default: true }] } };
+    setRuntimeConfigSnapshot(config, config);
+    const storePath = resolveSessionStorePathCore(undefined, { agentId: "main" });
+    const keys = ["agent:main:placement-a", "agent:main:placement-b"] as const;
+    for (const key of keys) {
+      await replaceSessionEntry(
+        { storePath, sessionKey: key },
+        {
+          sessionId: key,
+          updatedAt: 1,
+          worktree: { id: key, branch: "synthetic", repoRoot: "/synthetic" },
+        },
+      );
+    }
+    for (let index = 0; index < 24; index++) {
+      await replaceSessionEntry(
+        { storePath, sessionKey: `agent:main:unrelated-${index}` },
+        {
+          sessionId: `unrelated-payload-${index}`,
+          updatedAt: 1,
+          skillsSnapshot: { prompt: "unrelated-payload-" + "x".repeat(4096), skills: [] },
+        },
+      );
+    }
+    // Canonical store admission runs once before repeated startup workspace lookups.
+    expect(loadExactSessionEntryReadOnly({ storePath, sessionKey: keys[0] })?.entry).toBeDefined();
+    const parse = vi.spyOn(JSON, "parse");
+    try {
+      for (const sessionKey of keys) {
+        const resolved = resolveWorkerPlacementSessionTarget({
+          sessionRuntime: {
+            resolveGatewaySessionStoreTargetWithStore,
+            resolveCanonicalSessionEntryFromStoreKeys,
+            managedWorktrees: {
+              findLiveByOwner: (_kind, ownerId) => ({
+                id: ownerId,
+                ownerId,
+                path: `/synthetic/${ownerId}`,
+              }),
+            },
+          },
+          config,
+          sessionId: sessionKey,
+          sessionKey,
+          agentId: "main",
+          errorMessage: "placement identity changed",
+        });
+        expect(resolved.entry.sessionId).toBe(sessionKey);
+        expect(resolved.worktree.path).toBe(`/synthetic/${sessionKey}`);
+      }
+      expect(
+        parse.mock.calls.filter(([value]) => value.includes("unrelated-payload-")),
+      ).toHaveLength(0);
+    } finally {
+      parse.mockRestore();
+    }
+  });
+});

--- a/src/gateway/server-worker-placement-session-target.ts
+++ b/src/gateway/server-worker-placement-session-target.ts
@@ -34,6 +34,7 @@ export async function runWorkerPlacementSessionBarrier<T>(params: {
     key: params.sessionKey,
     agentId: params.agentId,
     clone: false,
+    exactRead: true,
   });
   return await runExclusiveSessionLifecycleMutation({
     scope: target.storePath,
@@ -105,6 +106,7 @@ export function resolveWorkerPlacementSessionTarget<
       key: string;
       agentId: string;
       clone: false;
+      exactRead: true;
     }) => Target;
     resolveCanonicalSessionEntryFromStoreKeys: (
       store: Store,
@@ -126,6 +128,7 @@ export function resolveWorkerPlacementSessionTarget<
     key: params.sessionKey,
     agentId: params.agentId,
     clone: false,
+    exactRead: true,
   });
   const entry = params.sessionRuntime.resolveCanonicalSessionEntryFromStoreKeys(
     target.store,

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -270,6 +270,7 @@ export function createGatewayWorkerPlacementRuntime(
           key: sessionKey,
           agentId,
           clone: false,
+          exactRead: true,
         });
         const lifecycleIdentities = [
           sessionKey,

--- a/src/gateway/worker-workspace-conflict-transcript.ts
+++ b/src/gateway/worker-workspace-conflict-transcript.ts
@@ -33,6 +33,7 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
       key: identity.sessionKey,
       agentId: identity.agentId,
       clone: false,
+      exactRead: true,
     });
     const lostSession = () => {
       if (missingMessage) {


### PR DESCRIPTION
## What Problem This Solves

Fixes Gateway stalls during worker recovery when a session store contains many sessions. Looking up one placement workspace decoded every session entry; repeating that lookup for multiple placements multiplied the work.

## Why This Change Was Made

Worker placement now requests the existing exact session-read path for workspace resolution, activation/recovery, dispatch, move, reclaim and conflict-report lookups. The canonical accessor still resolves the same candidate keys and stores, detects duplicate/noncanonical entries, and returns full selected-entry fields. Lifecycle and authority checks remain at their existing boundaries.

## User Impact

Worker operations no longer deserialize unrelated session payloads while resolving a single session. This removes repeated full-store work without adding a cache, changing storage or configuration, or discarding history.

## Evidence

- Real SQLite regression: two consecutive workspace lookups decoded 48 unrelated payloads before the repair and 0 afterward, while resolving the same session/worktree identities.
- 348 related tests passed across 10 files, covering worker lifecycle, move/reclaim, provisioning cancellation, canonical aliases, ownership and exact-row access.
- Independent Codex review through P2: scoped-clean.
- Synthetic Linux/Node 26 proof used the exact PR resolver and installed canonical SQLite accessors. Two consecutive lookups decoded 48 unrelated rows before the repair and 0 afterward, with identical selected session/worktree results and preserved fixture rows. Both processes exited naturally with status 0 and empty stderr. The worktree registry was synthetic; this did not allocate a real worker.
- [CI for the reviewed head](https://github.com/openclaw/openclaw/actions/runs/33947541525): 106 successful checks and 17 skipped, including successful production and test typechecks.
- Production delta: +10/-0 lines (nine explicit existing read-mode selections and one private input constraint); regression coverage: +75 lines. A new adapter would add more surface than these selections.

Local changed checks passed 15 formatting and guard steps, then the declaration-input guard refused the shared dependency symlink before TypeScript ran. CI completed that verification with its own installed dependencies.

ClawSweeper merge-risk disposition: the isolated Linux owner proof and lifecycle/alias regression coverage were accepted for this focused reuse of the existing exact accessor. The subsequent managed rollout of [c5d8148f](https://github.com/openclaw/openclaw/commit/c5d8148f4b9fed0b1c9b3410fa4f1f9d45bfa66f) was accepted. A real Gateway/OpenAI native voice smoke test completed the synthetic response “323 gateway voice verified”, with 14/14 timed playback acknowledgements. Audio used a timed synthetic output sink; this does not establish physical Discord playback.

A standalone 180-second post-merge observation recorded 91/91 HTTP 200 responses, median latency 1.494 ms and maximum 145.621 ms. Main-thread CPU use averaged 0.071833 cores, with a peak of 0.55068 cores over a two-second interval. This is a standalone post-merge observation, not a matched before/after startup benchmark or proof that all Gateway stalls are resolved.
