### PR TITLE
fix(typing): clear activity after late provider starts

### DIFF
--- a/src/auto-reply/reply/typing-persistence.test.ts
+++ b/src/auto-reply/reply/typing-persistence.test.ts
@@ -83,6 +83,31 @@ describe("typing persistence bug fix", () => {
     expect(onReplyStartSpy).toHaveBeenCalledTimes(1); // Still only the initial call
   });
 
+  it.each(["cleanup", "run-first", "idle-first"] as const)(
+    "disposes typing when %s closes the controller before start settles",
+    async (completion) => {
+      const starting = controller.startTypingLoop();
+      if (completion === "cleanup") {
+        controller.cleanup();
+      } else if (completion === "run-first") {
+        controller.markRunComplete();
+        controller.markDispatchIdle();
+      } else {
+        controller.markDispatchIdle();
+        controller.markRunComplete();
+      }
+      await starting;
+      await controller.startTypingOnText("late text");
+      controller.cleanup();
+
+      expect(controller.isActive()).toBe(false);
+      expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(12_000);
+      expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it("should prevent typing restart even if cleanup is delayed", async () => {
     // Start typing
     await controller.startTypingLoop();

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -6,7 +6,6 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { createTypingKeepaliveLoop } from "../../channels/typing-lifecycle.js";
-import { createTypingStartGuard } from "../../channels/typing-start-guard.js";
 import { isSilentReplyPrefixText, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 
 const DEFAULT_TYPING_INTERVAL_SECONDS = 6;
@@ -146,22 +145,14 @@ export function createTypingController(params: {
 
   const isActive = () => active && !sealed;
 
-  const startGuard = createTypingStartGuard({
-    isSealed: () => sealed,
-    shouldBlock: () => runComplete,
-    rethrowOnError: true,
-  });
-
   const triggerTyping = async () => {
-    if (triggerInFlight) {
+    if (triggerInFlight || sealed || runComplete) {
       return;
     }
     triggerInFlight = true;
     try {
-      await startGuard.run(async () => {
-        await onReplyStart?.();
-        refreshTypingTtl();
-      });
+      await onReplyStart?.();
+      refreshTypingTtl();
     } catch (err) {
       log?.(`typing start failed: ${String(err)}`);
     } finally {
@@ -180,16 +171,11 @@ export function createTypingController(params: {
   });
 
   const ensureStart = async () => {
-    if (sealed) {
-      return;
-    }
     // Late callbacks after a run completed should never restart typing.
-    if (runComplete) {
+    if (sealed || runComplete) {
       return;
     }
-    if (!active) {
-      active = true;
-    }
+    active = true;
     if (started) {
       return;
     }
@@ -208,10 +194,7 @@ export function createTypingController(params: {
   };
 
   const startTypingLoop = async () => {
-    if (sealed) {
-      return;
-    }
-    if (runComplete) {
+    if (sealed || runComplete) {
       return;
     }
     // Always refresh TTL when called, even if loop already running.
@@ -228,7 +211,11 @@ export function createTypingController(params: {
       return;
     }
     await ensureStart();
-    typingLoop.start();
+    // Cleanup or completion can run while the start callback yields. The loop
+    // must not acquire a timer after its owning controller has closed.
+    if (!sealed && !runComplete) {
+      typingLoop.start();
+    }
   };
 
   const startTypingOnText = async (text?: string) => {

--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -1,6 +1,7 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 // Typing tests cover typing indicator start, update, and cleanup behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { createTypingCallbacks } from "./typing.js";
 
 type TypingCallbackOverrides = Partial<Parameters<typeof createTypingCallbacks>[0]>;
@@ -178,37 +179,64 @@ describe("createTypingCallbacks", () => {
     });
   });
 
-  it("does not arm timers or restart after cleanup while a start settles late", async () => {
-    await withFakeTimers(async () => {
-      let resolveStart: (() => void) | undefined;
-      const { start, stop, callbacks } = createTypingHarness({
-        maxDurationMs: 10_000,
-        start: vi.fn(
-          () =>
-            new Promise<void>((resolve) => {
-              resolveStart = resolve;
-            }),
-        ),
+  it.each([
+    { phase: "initial", finish: "cleanup", rejected: false },
+    { phase: "initial", finish: "idle", rejected: false },
+    { phase: "keepalive", finish: "cleanup", rejected: false },
+    { phase: "keepalive", finish: "idle", rejected: false },
+    { phase: "keepalive", finish: "TTL", rejected: false },
+    { phase: "keepalive", finish: "cleanup", rejected: true },
+  ])(
+    "orders $finish stop after the pending $phase start (rejected=$rejected)",
+    async ({ phase, finish, rejected }) => {
+      await withFakeTimers(async () => {
+        const { promise, resolve, reject } = createDeferred();
+        const startImplementation = vi.fn<() => Promise<void>>();
+        if (phase === "keepalive") {
+          startImplementation.mockResolvedValueOnce(undefined);
+        }
+        startImplementation.mockReturnValueOnce(promise);
+        const { start, stop, onStartError, callbacks } = createTypingHarness({
+          maxDurationMs: 10_000,
+          start: startImplementation,
+        });
+
+        await callbacks.onReplyStart();
+        if (phase === "keepalive") {
+          await vi.advanceTimersByTimeAsync(3_000);
+        }
+        const admittedStarts = start.mock.calls.length;
+        if (finish === "TTL") {
+          vi.spyOn(console, "warn").mockImplementation(() => {});
+          await vi.advanceTimersByTimeAsync(7_000);
+        } else if (finish === "idle") {
+          callbacks.onIdle?.();
+        } else {
+          callbacks.onCleanup?.();
+        }
+        callbacks.onCleanup?.();
+        expect(stop).not.toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(0);
+
+        const failure = new Error("typing unavailable");
+        if (rejected) {
+          reject(failure);
+        } else {
+          resolve();
+        }
+        await flushMicrotasks();
+        expect(stop).toHaveBeenCalledTimes(1);
+        expect(onStartError).toHaveBeenCalledTimes(rejected ? 1 : 0);
+        if (rejected) {
+          expect(onStartError).toHaveBeenCalledWith(failure);
+        }
+        expect(vi.getTimerCount()).toBe(0);
+        await vi.advanceTimersByTimeAsync(20_000);
+        await callbacks.onReplyStart();
+        expect(start).toHaveBeenCalledTimes(admittedStarts);
       });
-
-      await callbacks.onReplyStart();
-      expect(start).toHaveBeenCalledTimes(1);
-      expect(vi.getTimerCount()).toBe(0);
-
-      callbacks.onCleanup?.();
-      if (!resolveStart) {
-        throw new Error("Expected typing start resolver to be initialized");
-      }
-      resolveStart();
-      await flushMicrotasks();
-
-      expect(stop).toHaveBeenCalledTimes(1);
-      expect(vi.getTimerCount()).toBe(0);
-      await vi.advanceTimersByTimeAsync(20_000);
-      await callbacks.onReplyStart();
-      expect(start).toHaveBeenCalledTimes(1);
-    });
-  });
+    },
+  );
 
   it("invokes stop on idle and reports stop errors", async () => {
     const { stop, onStopError, callbacks } = createTypingHarness({

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -32,23 +32,14 @@ function resolvePositiveIntegerOption(value: number | undefined, fallback: numbe
   return parsed === undefined || parsed <= 0 ? fallback : Math.max(1, Math.floor(parsed));
 }
 
-function resolveKeepaliveIntervalMs(value: number | undefined): number {
-  return resolveTimerTimeoutMs(value, 3_000, 0);
-}
-
-function resolveDurationMsOption(value: number | undefined, fallback: number): number {
-  return resolveTimerTimeoutMs(value, fallback, 0);
-}
-
 export function createTypingCallbacks(params: CreateTypingCallbacksParams): TypingCallbacks {
   const stop = params.stop;
-  const keepaliveIntervalMs = resolveKeepaliveIntervalMs(params.keepaliveIntervalMs);
+  const keepaliveIntervalMs = resolveTimerTimeoutMs(params.keepaliveIntervalMs, 3_000, 0);
   const maxConsecutiveFailures = resolvePositiveIntegerOption(
     params.maxConsecutiveFailures,
     DEFAULT_MAX_CONSECUTIVE_TYPING_FAILURES,
   );
-  const maxDurationMs = resolveDurationMsOption(params.maxDurationMs, 60_000);
-  let stopSent = false;
+  const maxDurationMs = resolveTimerTimeoutMs(params.maxDurationMs, 60_000, 0);
   let closed = false;
   let ttlTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -105,7 +96,6 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
     if (closed) {
       return;
     }
-    stopSent = false;
     startGuard.reset();
     clearTtlTimer();
     const startPromise = fireStart();
@@ -123,14 +113,20 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
   };
 
   const fireStop = () => {
+    if (closed) {
+      return;
+    }
     closed = true;
     keepaliveLoop.stop();
     clearTtlTimer();
-    if (!stop || stopSent) {
+    if (!stop) {
       return;
     }
-    stopSent = true;
-    void stop().catch((err: unknown) => (params.onStopError ?? params.onStartError)(err));
+    // An admitted start may publish activity after cleanup. Its terminal stop
+    // must follow that work so late acknowledgments cannot leave typing visible.
+    void (startInFlight ? startInFlight.then(stop) : stop()).catch((err: unknown) =>
+      (params.onStopError ?? params.onStartError)(err),
+    );
   };
 
   return { onReplyStart, onIdle: fireStop, onCleanup: fireStop };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where completed, cancelled, or silent replies could leave typing indicators or activity reactions behind when a provider start request completed after cleanup. A related startup race could also leave a periodic typing timer alive after its core controller had closed.

Closes #127564.

## Why This Change Was Made

Each typing lifecycle now finishes the work it already admitted before sending its one terminal stop. The core controller also rechecks completion after its startup await before arming a timer. Both changes stay with the existing lifecycle owners and preserve nonblocking reply dispatch. Redundant stop state, the core's rethrow-only circuit-breaker wrapper, and two one-use timer wrappers are removed.

## User Impact

Typing and activity cleanup remains effective when provider acknowledgments arrive late. Existing typing modes, refresh intervals, error reporting, and account/target bindings are preserved.

## Evidence

- Before the fix, all three new core shutdown-order cases leaked one interval. All six strengthened channel cases called stop before a pending initial or keepalive start settled, covering cleanup, idle, TTL, and a rejected renewal. The same cases pass after the fix.
- 167 focused tests passed across core typing persistence, reply utility callers, channel typing callbacks, and the retained channel circuit breaker. Five typing-policy tests and 11 selected Feishu, Matrix, and Slack typing tests also passed.
- Real event-loop probes used ephemeral localhost HTTP transports with synthetic data. Normal keepalives stopped and all three core shutdown orders left zero live intervals. A delayed-acknowledgment reaction probe failed against the original source with a retained reaction, then passed against the candidate: two accounts completed in reverse order, each removed its exact reaction handle once, and zero reactions remained. These probes are synthetic transports, not authenticated live-channel sessions.
- Gateway integration: the existing Matrix per-room DM scenario passed (1/1, 18.25 seconds) through a fresh candidate QA build, an ephemeral gateway, the real Matrix plugin, a mock model provider, and Crabline's local Matrix API. Both rooms recorded accepted typing start → marker reply → typing stop against the same room/bot target, with no later starts. This proves the normal gateway/reply-dispatch/adapter path; delayed acknowledgments are covered separately by the owner-level differential above.
- Independent Codex review: no actionable P0–P2 findings.
- Production LOC: +22/-39, net **-17**. Tests: +83/-30, net **+53**.

Focused owner/caller command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/channels/typing.test.ts src/channels/typing-start-guard.test.ts \
  src/auto-reply/reply/typing-persistence.test.ts src/auto-reply/reply/reply-utils.test.ts
```

Selected plugin caller command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/feishu/src/reply-dispatcher.test.ts \
  extensions/matrix/src/matrix/monitor/handler.test.ts \
  extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts \
  --testNamePattern typing
```

Observed delayed-provider result:

```json
{
  "verdict": "pass",
  "delayedProviderAcknowledgments": true,
  "nonblockingCleanup": true,
  "independentAccounts": true,
  "retainedReactions": 0
}
```

Gateway integration command:

```sh
OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/run-node.mjs qa suite \
  --provider-mode mock-openai --scenario dm-per-room-session \
  --channel-driver crabline --channel matrix \
  --output-dir .artifacts/deslop-typing/gateway-matrix
```

The runtime build stamps identify candidate `ea6179c6a1b38a0a38e550ef6d16ac16982b71a5`. The provider recorder contains 38 events: room A start/reply/stop at zero-based indices 14/18/20, room B at 29/33/35; all six operations were accepted. The run used synthetic identities and local services only and completed gateway teardown. The report and raw recorder are retained under the output directory; `.artifacts/deslop-typing/gateway-matrix-typing-proof.json` records the asserted sequences and build binding.

Named QA follow-up: add native Slack fixture identities and reaction/status methods to Crabline's Slack provider before using it for typing proof. The attempted generic DM scenario rejected its logical conversation ID before inbound, and that provider does not implement typing reactions/status. This limitation is confined to the test transport; Matrix supplies the real-adapter gateway proof here.

The complete changed checks passed, including core production and test typechecks, lint, dead exports, plugin boundaries, state/schema guards, and runtime import-cycle checks:

```sh
node scripts/check-changed.mjs -- \
  src/auto-reply/reply/typing.ts src/auto-reply/reply/typing-persistence.test.ts \
  src/channels/typing.ts src/channels/typing.test.ts
```
