### PR TITLE
fix(gateway): avoid cold dashboard delays on unrelated HTTP requests

### DIFF
--- a/src/gateway/control-ui-resource-routes.ts
+++ b/src/gateway/control-ui-resource-routes.ts
@@ -4,6 +4,14 @@ import {
   CONTROL_UI_USER_AVATAR_PATH_SUFFIX,
 } from "./control-ui-user-avatar-route.js";
 
+const CONTROL_UI_ASSISTANT_MEDIA_PREFIX = "/__openclaw__/assistant-media";
+
+export function resolveAssistantMediaRoutePath(basePath?: string): string {
+  const normalizedBasePath =
+    basePath && basePath !== "/" ? (basePath.endsWith("/") ? basePath.slice(0, -1) : basePath) : "";
+  return `${normalizedBasePath}${CONTROL_UI_ASSISTANT_MEDIA_PREFIX}`;
+}
+
 const CONTROL_UI_RESOURCE_ROUTES = {
   agentAvatar: { prefix: "/avatar", suffix: "" },
   catalogIcon: { prefix: "/__openclaw__/catalog-icon", suffix: "" },

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -78,6 +78,7 @@ import {
   respondNotFound as respondControlUiNotFound,
   respondPlainText,
 } from "./control-ui-http-utils.js";
+import { resolveAssistantMediaRoutePath } from "./control-ui-resource-routes.js";
 import {
   classifyControlUiRequest,
   isControlUiApprovalDocumentPath,
@@ -111,7 +112,6 @@ import { authorizeControlUiReadRequestOrReply } from "./http-utils.js";
 import { isTerminalConfigEnabled } from "./terminal/enabled.js";
 
 const ROOT_PREFIX = "/";
-const CONTROL_UI_ASSISTANT_MEDIA_PREFIX = "/__openclaw__/assistant-media";
 const CONTROL_UI_ASSISTANT_MEDIA_TICKET_SCOPE = "assistant-media";
 const CONTROL_UI_ASSISTANT_MEDIA_TICKET_TTL_MS = 5 * 60 * 1000;
 const CONTROL_UI_ASSETS_MISSING_MESSAGE =
@@ -265,12 +265,6 @@ function normalizeAssistantMediaSource(source: string): string | null {
     return resolveUserPath(trimmed);
   }
   return trimmed;
-}
-
-function resolveAssistantMediaRoutePath(basePath?: string): string {
-  const normalizedBasePath =
-    basePath && basePath !== "/" ? (basePath.endsWith("/") ? basePath.slice(0, -1) : basePath) : "";
-  return `${normalizedBasePath}${CONTROL_UI_ASSISTANT_MEDIA_PREFIX}`;
 }
 
 type AssistantMediaAvailability =

--- a/src/gateway/server-http.control-ui-lazy.test.ts
+++ b/src/gateway/server-http.control-ui-lazy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { AUTH_NONE, sendRequest, withGatewayServer } from "./server-http.test-harness.js";
+
+vi.mock("./control-ui.js", () => {
+  throw new Error("Control UI runtime is unavailable");
+});
+
+describe("Control UI HTTP loading", () => {
+  it.each([
+    { basePath: "", method: "POST", path: "/slack/events" },
+    { basePath: "", method: "GET", path: "/api/unclaimed" },
+    { basePath: "/console", method: "GET", path: "/outside-console" },
+  ])("keeps $method $path independent of the UI runtime", async ({ basePath, method, path }) => {
+    let ready = false;
+    const handlePluginRequest = vi.fn(async () => false);
+    await withGatewayServer({
+      prefix: "control-ui-lazy-routing",
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        controlUiEnabled: true,
+        controlUiBasePath: basePath,
+        handlePluginRequest,
+        shouldEnforcePluginGatewayAuth: () => false,
+        isStartupPluginRuntimeReady: () => ready,
+      },
+      run: async (server) => {
+        const starting = await sendRequest(server, { method, path });
+        expect(starting.res.statusCode).toBe(503);
+        expect(starting.getBody()).toBe("Plugin runtime is starting");
+        expect(starting.setHeader).toHaveBeenCalledWith("Retry-After", "1");
+
+        ready = true;
+        const settled = await sendRequest(server, { method, path });
+        expect(settled.res.statusCode).toBe(404);
+        expect(settled.getBody()).toBe("Not Found");
+        expect(handlePluginRequest).toHaveBeenCalledTimes(2);
+      },
+    });
+  });
+});

--- a/src/gateway/server-http.control-ui-lazy.test.ts
+++ b/src/gateway/server-http.control-ui-lazy.test.ts
@@ -10,6 +10,11 @@ describe("Control UI HTTP loading", () => {
     { basePath: "", method: "POST", path: "/slack/events" },
     { basePath: "", method: "GET", path: "/api/unclaimed" },
     { basePath: "/console", method: "GET", path: "/outside-console" },
+    {
+      basePath: "",
+      method: "POST",
+      path: "/__openclaw__/assistant-media/extra?meta=1&allow=1",
+    },
   ])("keeps $method $path independent of the UI runtime", async ({ basePath, method, path }) => {
     let ready = false;
     const handlePluginRequest = vi.fn(async () => false);

--- a/src/gateway/server-http.control-ui.test.ts
+++ b/src/gateway/server-http.control-ui.test.ts
@@ -3,9 +3,53 @@ import fs from "node:fs/promises";
 import nodePath from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-utils/temp-dir.js";
-import { AUTH_NONE, sendRequest, withGatewayServer } from "./server-http.test-harness.js";
+import {
+  AUTH_NONE,
+  AUTH_TOKEN,
+  sendRequest,
+  withGatewayServer,
+} from "./server-http.test-harness.js";
 
 describe("Gateway Control UI identity", () => {
+  it.each(["", "/console/"])("keeps UI resource authentication at base %j", async (basePath) => {
+    await withGatewayServer({
+      prefix: "control-ui-resource-auth",
+      resolvedAuth: AUTH_TOKEN,
+      overrides: { controlUiEnabled: true, controlUiBasePath: basePath },
+      run: async (server) => {
+        const base = basePath.replace(/\/$/, "");
+        for (const path of [
+          `${base}/avatar/main?meta=1`,
+          `${base}/__openclaw__/assistant-media?source=missing.png`,
+        ]) {
+          const response = await sendRequest(server, { path, method: "GET" });
+          expect(response.res.statusCode, path).toBe(401);
+        }
+      },
+    });
+  });
+
+  it("keeps the root UI POST rejection ahead of the startup fallback", async () => {
+    await withGatewayServer({
+      prefix: "control-ui-legacy-post",
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        controlUiEnabled: true,
+        controlUiBasePath: "",
+        isStartupPluginRuntimeReady: () => false,
+      },
+      run: async (server) => {
+        const response = await sendRequest(server, { path: "/ui", method: "POST" });
+        expect(response.res.statusCode).toBe(404);
+        expect(response.getBody()).toBe("Not Found");
+        expect(response.setHeader).toHaveBeenCalledWith(
+          "Permissions-Policy",
+          "camera=(self), microphone=*, geolocation=*, clipboard-write=*",
+        );
+      },
+    });
+  });
+
   it("applies dashboard enablement to subsequent requests without replacing the listener", async () => {
     await withTempDir("openclaw-http-toggle-", async (controlUiRoot) => {
       await fs.writeFile(nodePath.join(controlUiRoot, "index.html"), "<html>synthetic UI</html>\n");

--- a/src/gateway/server-http.control-ui.test.ts
+++ b/src/gateway/server-http.control-ui.test.ts
@@ -18,11 +18,12 @@ describe("Gateway Control UI identity", () => {
       overrides: { controlUiEnabled: true, controlUiBasePath: basePath },
       run: async (server) => {
         const base = basePath.replace(/\/$/, "");
-        for (const path of [
-          `${base}/avatar/main?meta=1`,
-          `${base}/__openclaw__/assistant-media?source=missing.png`,
-        ]) {
-          const response = await sendRequest(server, { path, method: "GET" });
+        for (const [method, path] of [
+          ["GET", `${base}/avatar/main?meta=1`],
+          ["GET", `${base}/__openclaw__/assistant-media?source=missing.png`],
+          ["POST", `${base}/__openclaw__/assistant-media?meta=1&allow=1&source=missing.png`],
+        ] as const) {
+          const response = await sendRequest(server, { path, method });
           expect(response.res.statusCode, path).toBe(401);
         }
       },
@@ -49,6 +50,32 @@ describe("Gateway Control UI identity", () => {
       },
     });
   });
+
+  it.each(["", "/console/"])(
+    "leaves unclaimed media writes to startup at base %j",
+    async (basePath) => {
+      await withGatewayServer({
+        prefix: "control-ui-unclaimed-media-write",
+        resolvedAuth: AUTH_TOKEN,
+        overrides: {
+          controlUiEnabled: true,
+          controlUiBasePath: basePath,
+          isStartupPluginRuntimeReady: () => false,
+        },
+        run: async (server) => {
+          const base = basePath.replace(/\/$/, "");
+          for (const query of ["meta=1", "allow=1", "meta=1&allow=0"]) {
+            const response = await sendRequest(server, {
+              method: "POST",
+              path: `${base}/__openclaw__/assistant-media?${query}&source=missing.png`,
+            });
+            expect(response.res.statusCode, query).toBe(503);
+            expect(response.getBody()).toBe("Plugin runtime is starting");
+          }
+        },
+      });
+    },
+  );
 
   it("applies dashboard enablement to subsequent requests without replacing the listener", async () => {
     await withTempDir("openclaw-http-toggle-", async (controlUiRoot) => {

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -27,6 +27,7 @@ import type { ResolvedGatewayAuth } from "./auth.js";
 import { parseControlUiUserAvatarPath, parseControlUiResourcePath } from "./control-ui-contract.js";
 import { respondNotFound, respondPlainText } from "./control-ui-http-utils.js";
 import { controlUiPluginAssetRoot } from "./control-ui-plugin-assets-contract.js";
+import { resolveAssistantMediaRoutePath } from "./control-ui-resource-routes.js";
 import {
   classifyControlUiRequest,
   isControlUiApprovalDocumentPath,
@@ -359,16 +360,17 @@ export function createGatewayHttpServer(opts: {
       };
       const loadControlUi = () => {
         const url = req.url ? new URL(req.url, "http://localhost") : undefined;
-        // UI resources share the document route boundary. Classify at dispatch
-        // so plugin fallthrough sees its current URL without loading unrelated UI code.
+        // Media owns its method/query policy, including explicit-allow POSTs.
+        // Classify the current URL so plugin fallthrough cannot load unrelated UI code.
         return url &&
-          classifyControlUiRequest({
-            basePath: normalizeControlUiBasePath(controlUiBasePath),
-            pathname: url.pathname,
-            search: url.search,
-            method: req.method,
-            accept: req.headers.accept,
-          }).kind !== "not-control-ui"
+          (url.pathname === resolveAssistantMediaRoutePath(controlUiBasePath) ||
+            classifyControlUiRequest({
+              basePath: normalizeControlUiBasePath(controlUiBasePath),
+              pathname: url.pathname,
+              search: url.search,
+              method: req.method,
+              accept: req.headers.accept,
+            }).kind !== "not-control-ui")
           ? getControlUiModule()
           : undefined;
       };

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -28,10 +28,12 @@ import { parseControlUiUserAvatarPath, parseControlUiResourcePath } from "./cont
 import { respondNotFound, respondPlainText } from "./control-ui-http-utils.js";
 import { controlUiPluginAssetRoot } from "./control-ui-plugin-assets-contract.js";
 import {
+  classifyControlUiRequest,
   isControlUiApprovalDocumentPath,
   isControlUiFocusDocumentPath,
   isControlUiPluginManagerRequest,
 } from "./control-ui-routing.js";
+import { normalizeControlUiBasePath } from "./control-ui-shared.js";
 import type { ControlUiRootState } from "./control-ui.js";
 import {
   classifyGatewayProbePath,
@@ -355,13 +357,28 @@ export function createGatewayHttpServer(opts: {
         config: configSnapshot,
         ...routeAuth,
       };
+      const loadControlUi = () => {
+        const url = req.url ? new URL(req.url, "http://localhost") : undefined;
+        // UI resources share the document route boundary. Classify at dispatch
+        // so plugin fallthrough sees its current URL without loading unrelated UI code.
+        return url &&
+          classifyControlUiRequest({
+            basePath: normalizeControlUiBasePath(controlUiBasePath),
+            pathname: url.pathname,
+            search: url.search,
+            method: req.method,
+            accept: req.headers.accept,
+          }).kind !== "not-control-ui"
+          ? getControlUiModule()
+          : undefined;
+      };
       const handleControlUiRequest = async () =>
-        (await getControlUiModule()).handleControlUiHttpRequest(req, res, {
+        (await loadControlUi())?.handleControlUiHttpRequest(req, res, {
           ...controlUiRouteOptions,
           terminalEnabled: opts.isTerminalEnabled?.() ?? isTerminalConfigEnabled(configSnapshot),
           agentId: resolveAssistantAgentId(configSnapshot),
           root: controlUiRoot,
-        });
+        }) ?? false;
       const handleStandaloneControlUiRequest = async () => {
         if (!controlUiEnabled) {
           respondNotFound(res);
@@ -674,14 +691,19 @@ export function createGatewayHttpServer(opts: {
           async () => (await loadHandler())(req, res, controlUiRouteOptions),
         );
       }
-      addRequestStage(controlUiEnabled, async () =>
-        (await getControlUiModule()).handleControlUiAssistantMediaRequest(req, res, {
-          ...controlUiRouteOptions,
-          agentId: resolveAssistantAgentId(configSnapshot),
-        }),
+      addRequestStage(
+        controlUiEnabled,
+        async () =>
+          (await loadControlUi())?.handleControlUiAssistantMediaRequest(req, res, {
+            ...controlUiRouteOptions,
+            agentId: resolveAssistantAgentId(configSnapshot),
+          }) ?? false,
       );
-      addRequestStage(controlUiEnabled, async () =>
-        (await getControlUiModule()).handleControlUiAvatarRequest(req, res, controlUiRouteOptions),
+      addRequestStage(
+        controlUiEnabled,
+        async () =>
+          (await loadControlUi())?.handleControlUiAvatarRequest(req, res, controlUiRouteOptions) ??
+          false,
       );
       addRequestStage(controlUiEnabled, handleControlUiRequest);
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where unclaimed webhook and API requests wait for unrelated Control UI code to load when the dashboard is enabled. During plugin startup this delays the intended retryable response; after startup it delays normal fallthrough.

## Why This Change Was Made

The HTTP dispatcher checks existing route ownership before loading the UI module. Assistant media uses its exact path builder, shared with its handler; documents use the existing Control UI classifier. Classification uses the current request URL and preserves dispatch order.

The media handler retains every method, query, permission, and authentication decision, including the image-allow POST added in #138856. Root `POST /ui`, mounted dashboards, static resources, and plugin fallthrough keep their existing behavior. The path-builder body and all media/avatar/document handler code are unchanged. Production is +42/-16 (net +26, including the unchanged helper move); tests are +117/-1.

## User Impact

Unclaimed webhook and API requests no longer depend on the dashboard runtime. Owned dashboard resources continue through their existing handlers, including authenticated image-preview permission requests. No operator action is required.

## Evidence

Verified commit: `c82d1052d4bb2639fe5d2d26b78ed167c3fb6a53`, tree `78d10b576ae8c576802e314f17d29fa51e60a766`, against main `7b1217e2e79e5b489ea542e3019f9e86c281529a`.

- **313 tests passed** across HTTP dispatch, probes, routing, media, and image-permission policy. Four import-dependency regressions fail on clean main; two image-allow POST regressions fail on the former loader applied to the newer base.
- **640 real-handler cases / 1,920 observations passed**, covering methods, paths, base paths, exact media writes, and malformed lookalikes.
- **Three fresh compiled builds and six real Gateway processes:** clean main, the former loader, and the repaired candidate, each with root and mounted dashboards. Clean main imports the compiled UI chunk on the first unrelated POST; the candidate makes no UI import across four unrelated POSTs and imports it once on the first owned UI request.
- **Image-allow flow preserved:** clean main and the candidate return 401 for unauthenticated allowance, initially deny an outside image, accept the authenticated allowance POST, and serve the exact image bytes through the returned ticket. The former loader returns 404 instead of reaching authentication at both base paths, reproducing the review finding through compiled HTTP.
- Observed first unrelated POST samples: root **29.1 → 12.2 ms**; mounted dashboard **27.0 → 1.8 ms**. These are two cold observations, not a latency distribution. The primary invariant is the avoided unrelated import.
- Full canonical changed check passed in **812.8 seconds**; all three `sourcePerformance` builds passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33949345180) succeeded. Independent P2 reviews found no remaining actionable issue.
- All six Gateways exited normally with no early exit, forced escalation, or cleanup error. All nine source seals were stable across setup, build, and HTTP proof. The candidate's 37,991 public files exactly match the published commit.

All 59 evidence files and the archive manifest were verified before lease cleanup. Archive SHA-256: `8767999b84c0748ae862f6c65f9e7252dc48ffe381c334f75d40104d8428fc6b`.

Earlier diagnostic setup attempts stopped before tests at output-directory and transport-history assumptions. The corrected harness verifies the transport anchor separately, fetches exact public ancestry, and checks out the published commit directly. No production guard, timeout, or coverage threshold was weakened; private proof inputs are excluded from the PR.
