### PR TITLE
feat(slack): teach agents proactive Block Kit replies

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -864,6 +864,10 @@ const config = {
       "src/profile-evidence-sharding.ts!",
     ]),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/senseaudio`]: bundledPluginWorkspace(),
+    [`${BUNDLED_PLUGIN_ROOT_DIR}/slack`]: bundledPluginWorkspace([
+      // The vendor integrity test executes this verifier by path.
+      "scripts/verify-official-skills.mjs!",
+    ]),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/tavily`]: bundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/tencent`]: bundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/vllm`]: bundledPluginWorkspace(),

--- a/extensions/slack/scripts/verify-official-skills.mjs
+++ b/extensions/slack/scripts/verify-official-skills.mjs
@@ -13,8 +13,23 @@ function sha256(content) {
 async function main() {
   const lock = JSON.parse(await readFile(lockPath, "utf8"));
   const failures = [];
+  const digestPattern = /^[0-9a-f]{64}$/;
 
   for (const file of lock.files) {
+    if (!digestPattern.test(file.sourceSha256) || !digestPattern.test(file.vendoredSha256)) {
+      failures.push(
+        `${file.destination}: source and vendored SHA-256 digests must be lowercase hex`,
+      );
+      continue;
+    }
+
+    const adapted = file.sourceSha256 !== file.vendoredSha256;
+    if (adapted && (typeof file.adaptation !== "string" || file.adaptation.trim() === "")) {
+      failures.push(`${file.destination}: adapted vendor files must explain their local changes`);
+    } else if (!adapted && file.adaptation !== undefined) {
+      failures.push(`${file.destination}: unmodified vendor files must not declare an adaptation`);
+    }
+
     const path = join(pluginRoot, file.destination);
     try {
       const actual = sha256(await readFile(path));

--- a/extensions/slack/scripts/verify-official-skills.mjs
+++ b/extensions/slack/scripts/verify-official-skills.mjs
@@ -1,0 +1,38 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pluginRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const lockPath = join(pluginRoot, "skills", "_vendor", "slack-skills-plugin.json");
+
+function sha256(content) {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+async function main() {
+  const lock = JSON.parse(await readFile(lockPath, "utf8"));
+  const failures = [];
+
+  for (const file of lock.files) {
+    const path = join(pluginRoot, file.destination);
+    try {
+      const actual = sha256(await readFile(path));
+      if (actual !== file.vendoredSha256) {
+        failures.push(`${file.destination}: expected ${file.vendoredSha256}, got ${actual}`);
+      }
+    } catch (error) {
+      failures.push(`${file.destination}: ${error.message}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Slack official skill verification failed:\n${failures.join("\n")}`);
+  }
+
+  process.stdout.write(
+    `Verified ${lock.files.length} Slack skill vendor files at ${lock.source.revision} (${lock.source.version}).\n`,
+  );
+}
+
+await main();

--- a/extensions/slack/skills/_vendor/slack-skills-plugin.LICENSE
+++ b/extensions/slack/skills/_vendor/slack-skills-plugin.LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020- Slack Technologies, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/extensions/slack/skills/_vendor/slack-skills-plugin.json
+++ b/extensions/slack/skills/_vendor/slack-skills-plugin.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "source": {
+    "repository": "https://github.com/slackapi/slack-skills-plugin.git",
+    "revision": "f3f404205cbbfa18fabc79cc9d06fb444efff075",
+    "version": "1.3.0",
+    "license": "MIT"
+  },
+  "files": [
+    {
+      "source": "LICENSE",
+      "destination": "skills/_vendor/slack-skills-plugin.LICENSE",
+      "sourceSha256": "ccbd532eabd9c4a87884b19caa6738bd6541e047460a736aca3bf1ac4fd91300",
+      "vendoredSha256": "ccbd532eabd9c4a87884b19caa6738bd6541e047460a736aca3bf1ac4fd91300"
+    },
+    {
+      "source": "skills/block-kit/SKILL.md",
+      "destination": "skills/block-kit/references/official-block-kit.md",
+      "sourceSha256": "255f2ef5be5a6b5363b57931d5549227f375fe02fc2be7ce98226b33ed18f097",
+      "vendoredSha256": "255f2ef5be5a6b5363b57931d5549227f375fe02fc2be7ce98226b33ed18f097"
+    },
+    {
+      "source": "skills/block-kit/references/common-patterns.md",
+      "destination": "skills/block-kit/references/official-common-patterns.md",
+      "sourceSha256": "b372af9aa4367fbfc6561f6629db720595e0552711d83c7208fdba512443c05e",
+      "vendoredSha256": "b372af9aa4367fbfc6561f6629db720595e0552711d83c7208fdba512443c05e"
+    }
+  ]
+}
+

--- a/extensions/slack/skills/_vendor/slack-skills-plugin.json
+++ b/extensions/slack/skills/_vendor/slack-skills-plugin.json
@@ -17,8 +17,8 @@
       "source": "skills/block-kit/SKILL.md",
       "destination": "skills/block-kit/references/official-block-kit.md",
       "sourceSha256": "255f2ef5be5a6b5363b57931d5549227f375fe02fc2be7ce98226b33ed18f097",
-      "vendoredSha256": "aa5e40e4878774c8a61c1ac2ffc4b91cfc473dbef430fd5c177552071c1ffe4d",
-      "adaptation": "Replaces unavailable Slack CLI, Slack API skill, and named tool handoffs with capability-gated OpenClaw guidance; corrects the relocated common-pattern reference."
+      "vendoredSha256": "5b5c792b21d6d9bc95d46a9f11e9b274beb45c3fd3b540b9deeec070ea1a57d2",
+      "adaptation": "Replaces unavailable Slack CLI, Slack API skill, and named tool handoffs with capability-gated OpenClaw guidance; corrects the relocated common-pattern reference; URL-encodes validation form values."
     },
     {
       "source": "skills/block-kit/references/common-patterns.md",

--- a/extensions/slack/skills/_vendor/slack-skills-plugin.json
+++ b/extensions/slack/skills/_vendor/slack-skills-plugin.json
@@ -17,14 +17,15 @@
       "source": "skills/block-kit/SKILL.md",
       "destination": "skills/block-kit/references/official-block-kit.md",
       "sourceSha256": "255f2ef5be5a6b5363b57931d5549227f375fe02fc2be7ce98226b33ed18f097",
-      "vendoredSha256": "255f2ef5be5a6b5363b57931d5549227f375fe02fc2be7ce98226b33ed18f097"
+      "vendoredSha256": "aa5e40e4878774c8a61c1ac2ffc4b91cfc473dbef430fd5c177552071c1ffe4d",
+      "adaptation": "Replaces unavailable Slack CLI, Slack API skill, and named tool handoffs with capability-gated OpenClaw guidance; corrects the relocated common-pattern reference."
     },
     {
       "source": "skills/block-kit/references/common-patterns.md",
       "destination": "skills/block-kit/references/official-common-patterns.md",
       "sourceSha256": "b372af9aa4367fbfc6561f6629db720595e0552711d83c7208fdba512443c05e",
-      "vendoredSha256": "b372af9aa4367fbfc6561f6629db720595e0552711d83c7208fdba512443c05e"
+      "vendoredSha256": "b106cdeaf9a76dee386f489e37f709a3e56610c26e18246066a7ec540c90ca55",
+      "adaptation": "Formatted with the repository's Markdown formatter; content and examples are unchanged."
     }
   ]
 }
-

--- a/extensions/slack/skills/block-kit/SKILL.md
+++ b/extensions/slack/skills/block-kit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: block-kit
-description: "Use proactively for Slack replies that benefit from structure or interaction: decisions, choices, status summaries, comparisons, reports, plans, charts, tables, or next actions. Also use when asked to author or validate native Slack Block Kit JSON."
+description: "Use proactively for structured or interactive Slack replies, and when asked to author or validate native Slack Block Kit JSON."
 metadata: { "openclaw": { "emoji": "🧱", "requires": { "config": ["channels.slack"] } } }
 allowed-tools: ["message"]
 ---
@@ -32,6 +32,6 @@ A control is complete only when its value is self-contained enough for the next 
 
 ## Native Block Kit authoring
 
-When the user is building a Slack app or explicitly requests raw Block Kit JSON, read [Slack's official Block Kit skill](references/official-block-kit.md) in full. For common message, modal, and App Home layouts, also read [the official patterns](references/official-common-patterns.md).
+When the user is building a Slack app or explicitly requests raw Block Kit JSON, read [the adapted official Block Kit guide](references/official-block-kit.md) in full. For common message, modal, and App Home layouts, also read [the official patterns](references/official-common-patterns.md).
 
-Follow the official skill's live-documentation and `blocks.validate` workflow for native JSON. Do not pass native Slack blocks to OpenClaw's `presentation` field; the plugin owns that conversion.
+Follow the adapted guide's live-documentation and `blocks.validate` workflow for native JSON. Do not pass native Slack blocks to OpenClaw's `presentation` field; the plugin owns that conversion.

--- a/extensions/slack/skills/block-kit/SKILL.md
+++ b/extensions/slack/skills/block-kit/SKILL.md
@@ -24,7 +24,7 @@ Use plain text for short answers and casual conversation where structure adds no
 For a reply in Slack, call the `message` tool with `action: "send"` and a portable `presentation`. The Slack plugin renders it as native Block Kit. Use the exact schema exposed by the current tool; supported block types can include `text`, `context`, `divider`, `buttons`, `select`, `chart`, and `table`.
 
 - Put the outcome first. Keep titles, labels, and context concise.
-- Give interactive controls real follow-up semantics. Prefer typed `callback` actions for conversational choices, `command` only for an actual command, and `url` for an external destination.
+- Give interactive controls real follow-up semantics. Use typed `callback` actions for conversational choices and `url` for an external destination. Do not use generic `command` actions for Slack controls; Slack renders them as text fallback rather than clickable controls.
 - Include a useful `message` fallback that preserves the meaning without the rich layout.
 - After the visible send succeeds, do not repeat the same content in the final response.
 

--- a/extensions/slack/skills/block-kit/SKILL.md
+++ b/extensions/slack/skills/block-kit/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: block-kit
+description: "Use proactively for Slack replies that benefit from structure or interaction: decisions, choices, status summaries, comparisons, reports, plans, charts, tables, or next actions. Also use when asked to author or validate native Slack Block Kit JSON."
+metadata: { "openclaw": { "emoji": "🧱", "requires": { "config": ["channels.slack"] } } }
+allowed-tools: ["message"]
+---
+
+# Slack Block Kit
+
+Make useful Slack replies feel native. When structure or one-click follow-up improves the outcome, send a rich message without waiting for the user to ask for Block Kit.
+
+## Choose the surface
+
+Use a `presentation` when the reply has at least one of these shapes:
+
+- a decision, confirmation, or next action that belongs on buttons or a select
+- a status, comparison, report, or plan that scans better as titled sections, a table, or a chart
+- important context that should be visually separated from the primary result
+
+Use plain text for short answers and casual conversation where structure adds no value.
+
+## Send the result
+
+For a reply in Slack, call the `message` tool with `action: "send"` and a portable `presentation`. The Slack plugin renders it as native Block Kit. Use the exact schema exposed by the current tool; supported block types can include `text`, `context`, `divider`, `buttons`, `select`, `chart`, and `table`.
+
+- Put the outcome first. Keep titles, labels, and context concise.
+- Give interactive controls real follow-up semantics. Prefer typed `callback` actions for conversational choices, `command` only for an actual command, and `url` for an external destination.
+- Include a useful `message` fallback that preserves the meaning without the rich layout.
+- After the visible send succeeds, do not repeat the same content in the final response.
+
+A control is complete only when its value is self-contained enough for the next agent turn to understand and act on. When an interaction returns, acknowledge the choice visibly and continue the requested workflow.
+
+## Native Block Kit authoring
+
+When the user is building a Slack app or explicitly requests raw Block Kit JSON, read [Slack's official Block Kit skill](references/official-block-kit.md) in full. For common message, modal, and App Home layouts, also read [the official patterns](references/official-common-patterns.md).
+
+Follow the official skill's live-documentation and `blocks.validate` workflow for native JSON. Do not pass native Slack blocks to OpenClaw's `presentation` field; the plugin owns that conversion.

--- a/extensions/slack/skills/block-kit/references/official-block-kit.md
+++ b/extensions/slack/skills/block-kit/references/official-block-kit.md
@@ -1,0 +1,277 @@
+---
+name: block-kit
+description: 'Use when a developer wants to build or validate Block Kit layouts for Slack messages, modals, or Home tabs: message layouts, modals/forms/dialogs, Home tab interfaces, interactive buttons or menus, or modifying existing Block Kit JSON. Also trigger on any Slack UI component (sections, actions, inputs, headers, alerts, tables, carousels), the words "blocks" or "Block Kit Builder", a request to preview rendered blocks, or pasted JSON like "type": "section". Validates via the blocks.validate API method.'
+argument-hint: "[message | modal | home-tab]"
+---
+
+# Block Kit
+
+Help the developer build a rich Block Kit layout. If `$0` is provided, it specifies the target surface (`message`, `modal`, or `home-tab`).
+
+This skill walks through surface selection, layout planning, JSON generation, and validation. Block types, elements, and fields come from the live docs (see **Source of Truth** below) — discover them and read each component's schema there, never from memory.
+
+> **Common Block Kit mistakes (and why):** A few errors recur often enough to flag up front. Most others are caught by `blocks.validate` in Step 5, so lean on validation rather than memorizing rules.
+>
+> - **`"type": "text"` is not a thing.** Text is a composition object: `{ "type": "plain_text", "text": "..." }` or `{ "type": "mrkdwn", "text": "..." }`.
+> - **`markdown` is a _block_ type, not a text type.** A `markdown` block holds standard markdown; text objects inside other blocks use `mrkdwn` (see **mrkdwn vs. the `markdown` block** in Step 4). Slack's `mrkdwn` is `*bold*` / `_italic_` / `~strike~`, not `**bold**`.
+> - **Messages need a top-level `text` fallback.** `blocks.validate` won't flag a missing one, but notifications and screen readers display it instead of the blocks — so summarize what the layout conveys rather than leaving it empty.
+
+---
+
+## Source of Truth: the Live Docs
+
+Every block, element, and composition object is documented on `docs.slack.dev`. Append `.md` to any reference URL to fetch it as markdown with WebFetch (no auth required).
+
+- **Master index**: the authoritative list of every block, block element, and composition object, each linking to its own page: `https://docs.slack.dev/reference/block-kit.md`. WebFetch it to confirm a type exists and to get the link to its page.
+- **Per-component pages** carry the full field schema (a fields table with required/optional flags and constraints, plus JSON examples):
+  - Blocks: `https://docs.slack.dev/reference/block-kit/blocks/<slug>-block.md`
+  - Block elements: `https://docs.slack.dev/reference/block-kit/block-elements/<slug>-element.md`
+  - Composition objects: `https://docs.slack.dev/reference/block-kit/composition-objects/<slug>.md`
+- **The slug is not always the type name.** For example `datepicker` maps to `date-picker-element.md`, and every `*_select` menu (`static_select`, `users_select`, `multi_channels_select`, and so on) is documented on `select-menu-element.md`. When unsure of a slug, follow the link from the master index rather than building the URL by hand.
+- **Surface payload structure** lives in the surface guides: messages at `https://docs.slack.dev/messaging/formatting-message-text.md`, modals at `https://docs.slack.dev/surfaces/modals.md`, and Home tabs at `https://docs.slack.dev/surfaces/app-home.md`.
+
+Never use a block type, element, or field you have not seen on a live page.
+
+---
+
+## Fast Path (for clear, specific requests)
+
+If the developer's request is specific enough to determine both the target surface and the desired layout, collapse Steps 1-4 into a single pass:
+
+1. Determine the surface from `$0` or context
+2. Fetch only the doc pages for the blocks and elements mentioned
+3. Generate the JSON directly
+4. Proceed to Step 5 (validation)
+
+**Fast-path indicators** (skip the full workflow):
+
+- Developer provides existing JSON to modify → use Modification Mode instead
+- Developer names specific block types: "add an actions block with two buttons"
+- Developer describes a well-known pattern: "approval message", "feedback form", "settings modal"
+- Developer provides a complete description in one message with enough detail to build
+
+**Full-workflow indicators** (use Steps 1-7):
+
+- Vague requests: "make something cool", "build a dashboard"
+- Exploratory: "what can Block Kit do?", "show me my options"
+- Complex layouts: 10+ blocks, nested modals, conditional logic
+- Developer asks for help deciding what to build
+
+---
+
+## Modification Mode
+
+If the developer provides existing Block Kit JSON (pasted inline, in a file, or referenced from code), enter Modification Mode instead of the full creation workflow:
+
+1. **Parse the existing structure:**
+   - List each block by index, type, and a short description of its content
+   - Infer the surface: `"type": "modal"` = modal, `"type": "home"` = home tab, bare `blocks` array = message
+
+2. **Ask what changes they want:**
+   - Add blocks (where in the sequence?)
+   - Remove blocks (which ones?)
+   - Modify blocks (which block, what change?)
+   - Reorder blocks
+
+3. **Apply changes while preserving:**
+   - All existing `block_id` values (these are referenced in app interaction handlers)
+   - All existing `action_id` values (these map to event listeners)
+   - Existing styles, text content, and structure for unchanged blocks
+
+4. **Validate the modified JSON**: proceed to Step 5 (validation)
+
+**Detection:** If the developer's message contains a JSON array starting with `[{"type":` or a view object with `"blocks":`, enter Modification Mode automatically. If they say "edit", "update", "modify", or "change" in reference to existing blocks, ask them to provide the current JSON.
+
+---
+
+## Step 1: Determine the Target Surface
+
+If `$0` is provided and matches one of `message`, `modal`, or `home-tab`, use it directly.
+
+Otherwise, ask the developer using AskUserQuestion:
+
+- **Message**: Conversational content posted to a channel or DM. Max 50 blocks.
+- **Modal**: A dialog or form opened by a user action. Max 100 blocks.
+- **Home tab**: A persistent, per-user dashboard in the App Home. Max 100 blocks.
+
+Once the surface is determined, use the correct payload structure for it:
+
+- **Message**: a `{ "text": "Fallback text", "blocks": [...] }` object posted via `chat.postMessage` (and friends). The `text` field is the notification/accessibility fallback. For message text formatting (mrkdwn, mentions, dates), see `https://docs.slack.dev/messaging/formatting-message-text.md`.
+- **Modal**: a view object (`{ "type": "modal", "title": ..., "blocks": [...] }`). For the full view object structure, lifecycle, and the rule that `submit` is required when the view contains any `input` block, see `https://docs.slack.dev/surfaces/modals.md`.
+- **Home tab**: a view object (`{ "type": "home", "blocks": [...] }`) published via `views.publish`. For structure and behavior, see `https://docs.slack.dev/surfaces/app-home.md`.
+
+---
+
+## Step 2: Understand What to Build
+
+Ask the developer to describe what they want their layout to look like or accomplish.
+
+If they need inspiration, suggest examples — several map directly onto a ready-made template in `references/common-patterns.md` (named in parentheses), which you can start from in Step 3:
+
+- "A feedback form with a text input and a category selector" (Simple Form Modal)
+- "A notification message with an alert banner, description, and Approve/Reject buttons" (Notification Alert / Approval Message)
+- "A dashboard home tab with a welcome header, key metrics in fields, and quick-action buttons" (Dashboard Home Tab)
+- "A settings modal with dropdowns, checkboxes, and a time picker" (Settings Modal with Multiple Input Types)
+- "A table of sprint tasks with status and points" (Data Table)
+
+Get enough detail to plan the layout before generating any JSON.
+
+---
+
+## Step 3: Plan the Block Layout
+
+Based on the developer's description:
+
+1. **Fetch only what you need** from the live docs:
+   - WebFetch the master index (`https://docs.slack.dev/reference/block-kit.md`) to confirm the block and element types you plan to use exist and to grab links to their pages.
+   - Check `references/common-patterns.md` (the one local reference file) if the request matches a common pattern; start from the template instead of building from scratch.
+   - Defer reading individual component pages until Step 4, when you build each block's fields.
+2. Propose a numbered block outline. For example:
+
+   ```text
+   1. header: "Weekly Report"
+   2. section: Summary text with a datepicker accessory
+   3. divider
+   4. section: Status fields (Name, Role, Team)
+   5. actions: "Approve" button (primary) and "Reject" button (danger)
+   ```
+
+3. Present the outline to the developer and ask for approval or changes before generating JSON.
+
+**Surface constraints to check:**
+
+- Block count limit: 50 for messages, 100 for modals/home tabs
+- Modal-specific: if using `input` blocks, the modal payload must include a `submit` field
+- Table: only one `table` block per message
+- Surface compatibility (whether a block is valid on the chosen surface) and element compatibility (whether an element is allowed inside a given block) are not always spelled out on a component's doc page. Build the layout from the docs, and let `blocks.validate` in Step 5 confirm it. It is the authoritative check.
+
+---
+
+## Step 4: Generate the Block Kit JSON
+
+Once the layout is approved, build each block from its live doc page, fetching each page's fields table (required vs optional, constraints) and JSON example with WebFetch. The URL patterns are in **Source of Truth** above; the one slug to remember is that every `*_select` menu (`static_select`, `users_select`, `multi_channels_select`, …) lives on `select-menu-element.md`. Fetch pages as you need them and reuse what you have already fetched — don't re-fetch the same page for every block of the same type. Then build the payload block-by-block and wrap it in the surface structure from Step 1.
+
+**Guidelines:**
+
+- Use descriptive `action_id` values (e.g., `"approve_report_btn"` not `"action_1"`) — they identify the element in your interaction handlers
+- Include `block_id` values where the developer will need them for interaction handling
+- For modals, include `title`, `submit`, `close`, and `callback_id`; for home tabs, the `type: "home"` wrapper
+- Use `mrkdwn` text for rich formatting, `plain_text` where required (headers, labels, modal title)
+
+**mrkdwn vs. the `markdown` block:** `section` and `context` blocks format text with Slack's `mrkdwn` (`*bold*`, `_italic_`, `~strike~`, `` `code` ``) — use these for short, interactive layouts. The separate `markdown` block (Messages only) renders _standard_ markdown (`**bold**`, headings, tables, numbered lists) and is meant for AI/LLM-generated or long-form content that already exists in standard markdown. Reach for it when the developer has such content or needs those features in the message body; there is a cumulative 12,000-character limit across all `markdown` blocks in one message.
+
+**Accessibility** is easy to skip and hard to retrofit, so build it in now:
+
+- Give images descriptive `alt_text` (what the image shows, not just "image"), and make sure image-heavy layouts also carry the key information as text
+- Summarize the layout in the message's `text` fallback (notifications and screen readers show it instead of the blocks)
+- Use `header` blocks for logical section headings — they convey document structure to assistive tech
+
+Present the complete payload to the developer in the Step 1 surface structure.
+
+---
+
+## Step 5: Validate
+
+**Always validate.** `blocks.validate` is a public Web API method, so no auth token is required.
+
+The authoritative reference for this method (its parameters, auth requirements, and response/error shape) is the live doc. WebFetch it before relying on any detail here: `https://docs.slack.dev/reference/methods/blocks.validate.md`. It documents the accepted parameters (`blocks` for a message's blocks array, `view` for a modal/home-tab view, `message` for a full message payload; send exactly one) and the response shape.
+
+### 5a. Build the validation request
+
+Prefer the Slack CLI when it's available, since it reuses the slack-cli skill's CLI detection and needs no token wrangling. If the CLI isn't installed, fall back to curl. Both call the same public method and return the same response, so Step 5b applies either way.
+
+**Path A: Slack CLI (preferred).**
+
+Use the `slack:slack-cli` skill, **Step 1: Detect the Slack CLI**, to check whether the public CLI is installed and resolve its command (`SLACK_CMD`).
+
+If the CLI is available, use the `slack:slack-cli` skill, **Step 4: Calling Web API Methods (`slack api`)**, to invoke it. That step covers the `SLACK_CMD api <method> key=value …` syntax. Run `SLACK_CMD api --help` first to confirm the syntax **and the flag that skips authentication**. `blocks.validate` needs no token, so call it without authentication. Don't hard-code that flag from memory; read it from the help output so this stays correct if it's ever renamed. Pass the payload as a positional `key=value` argument: `blocks=<JSON array>` for messages, or `view=<JSON view object>` for modals and home tabs.
+
+**Path B: curl (fallback, when the CLI isn't installed).**
+
+POST to the endpoint with the **Bash tool**. The API uses form-urlencoded encoding, so pass the JSON directly as the parameter value.
+
+**For messages**, send the `blocks` array as a form-encoded parameter:
+
+```bash
+curl -s -X POST 'https://slack.com/api/blocks.validate' \
+  -d 'blocks=[ ... the blocks array ... ]'
+```
+
+**For modals and home tabs**, send the complete view object in the `view` field:
+
+```bash
+curl -s -X POST 'https://slack.com/api/blocks.validate' \
+  -d 'view={ "type": "modal", "title": ..., "blocks": [...] }'
+```
+
+### 5b. Handle the response
+
+**Success:**
+
+```json
+{ "ok": true }
+```
+
+Tell the developer their blocks are valid.
+
+**Failure:**
+
+```json
+{
+  "ok": false,
+  "error": "invalid_blocks",
+  "errors": [
+    {
+      "code": "missing_field",
+      "message": "missing required field: type",
+      "field": "type",
+      "pointer": "/0"
+    }
+  ]
+}
+```
+
+When validation fails:
+
+1. Read each error. `pointer` is a JSON pointer to the offending node (e.g., `/0` = first block, `/2/elements/1` = second element of the third block, `/0/text/type` = the `type` field of the first block's text object). `message` describes the problem, and `constraint` (when present) names the rule that failed and its expected values.
+2. Fix the JSON. For the authoritative meaning of an error code and the field requirements behind it, consult the live method doc (`https://docs.slack.dev/reference/methods/blocks.validate.md`) and the relevant block/element/composition-object page you fetched in Steps 3-4.
+3. Re-validate. Repeat until `"ok": true`.
+
+---
+
+## Step 6: Deliver the Final Output
+
+Present the validated payload, then help the developer put it to use.
+
+### Send it
+
+Building the payload is this skill's job; sending it (`chat.postMessage`, `views.open`, `views.publish`, and the token/scope handling around them) belongs to the Web API layer. To call the right method — via the Slack CLI, raw curl, or a Bolt SDK — use the `slack:slack-api` skill, **Step 4: Call the Method (Manage)**, passing this payload as the method's `blocks` argument (messages) or `view` argument (modals and home tabs). That skill matches the argument names to the SDK or HTTP call so we don't duplicate them here.
+
+### Preview it
+
+Help the developer view their layout with the **Block Kit Builder**. Prefer the Slack CLI if it is installed. The CLI automatically loads the blocks, saving the developer from copying and pasting. If the CLI is not available, provide the standard Builder link instead.
+
+**Path A: Slack CLI (preferred).**
+
+Use the `slack:slack-cli` skill, **Step 1: Detect the Slack CLI**, to check whether the public CLI is installed and resolve its command (`SLACK_CMD`).
+
+If the CLI is available, run `SLACK_CMD blocks preview --help` to see how to pass the blocks and open the preview. The command loads the blocks into the Block Kit Builder in the developer's browser.
+
+Because you run the CLI non-interactively, this command also needs a `--team` flag. Resolve the team ID with the `slack:slack-cli` skill, **Step 2: Command Discovery via Help**, whose "Resolving `--app` and `--team` values" guidance covers running `SLACK_CMD auth list`; Any authenticated workspace works for a preview, if several are available, pick one and mention which you used rather than blocking on the choice.
+
+**Path B: Block Kit Builder link (fallback, when the CLI isn't installed).**
+
+Offer the Block Kit Builder link so the developer can paste the JSON in and tweak visually: `https://app.slack.com/block-kit-builder`. Builder needs an object (`{ "blocks": [...] }` or a full view object), not a bare array.
+
+---
+
+## Step 7: Iterate
+
+Ask whether the developer wants to add, modify, remove, or reorder blocks, or build a layout for a different surface. If they want to change the layout you just produced, re-enter **Modification Mode** (it preserves their `block_id`/`action_id` values); for a fresh layout, loop back to Step 3.
+
+---
+
+## Notes
+
+- **Scope:** this skill owns building and validating the Block Kit payload — choosing the surface, composing the JSON from the live docs, and confirming it with `blocks.validate`. Sending it lives in the Web API layer (`slack:slack-api`), and CLI detection/auth in `slack:slack-cli`.
+- **`blocks.validate` needs no auth** — it's a public method, so it works without a token whether you call it via the CLI or curl. Always validate before finalizing (Step 5).

--- a/extensions/slack/skills/block-kit/references/official-block-kit.md
+++ b/extensions/slack/skills/block-kit/references/official-block-kit.md
@@ -10,6 +10,8 @@ Help the developer build a rich Block Kit layout. If `$0` is provided, it specif
 
 This skill walks through surface selection, layout planning, JSON generation, and validation. Block types, elements, and fields come from the live docs (see **Source of Truth** below) — discover them and read each component's schema there, never from memory.
 
+> **OpenClaw adaptation:** This copy keeps Slack's authoring guidance while using capabilities available in the current agent session. Native Block Kit JSON is developer output; ordinary Slack replies use OpenClaw's portable `presentation` field.
+
 > **Common Block Kit mistakes (and why):** A few errors recur often enough to flag up front. Most others are caught by `blocks.validate` in Step 5, so lean on validation rather than memorizing rules.
 >
 > - **`"type": "text"` is not a thing.** Text is a composition object: `{ "type": "plain_text", "text": "..." }` or `{ "type": "mrkdwn", "text": "..." }`.
@@ -20,9 +22,9 @@ This skill walks through surface selection, layout planning, JSON generation, an
 
 ## Source of Truth: the Live Docs
 
-Every block, element, and composition object is documented on `docs.slack.dev`. Append `.md` to any reference URL to fetch it as markdown with WebFetch (no auth required).
+Every block, element, and composition object is documented on `docs.slack.dev`. Append `.md` to any reference URL to fetch it as markdown with an available web-documentation capability (no auth required).
 
-- **Master index**: the authoritative list of every block, block element, and composition object, each linking to its own page: `https://docs.slack.dev/reference/block-kit.md`. WebFetch it to confirm a type exists and to get the link to its page.
+- **Master index**: the authoritative list of every block, block element, and composition object, each linking to its own page: `https://docs.slack.dev/reference/block-kit.md`. Fetch it with an available web-documentation capability to confirm a type exists and to get the link to its page.
 - **Per-component pages** carry the full field schema (a fields table with required/optional flags and constraints, plus JSON examples):
   - Blocks: `https://docs.slack.dev/reference/block-kit/blocks/<slug>-block.md`
   - Block elements: `https://docs.slack.dev/reference/block-kit/block-elements/<slug>-element.md`
@@ -88,7 +90,7 @@ If the developer provides existing Block Kit JSON (pasted inline, in a file, or 
 
 If `$0` is provided and matches one of `message`, `modal`, or `home-tab`, use it directly.
 
-Otherwise, ask the developer using AskUserQuestion:
+Otherwise, ask the developer:
 
 - **Message**: Conversational content posted to a channel or DM. Max 50 blocks.
 - **Modal**: A dialog or form opened by a user action. Max 100 blocks.
@@ -106,7 +108,7 @@ Once the surface is determined, use the correct payload structure for it:
 
 Ask the developer to describe what they want their layout to look like or accomplish.
 
-If they need inspiration, suggest examples — several map directly onto a ready-made template in `references/common-patterns.md` (named in parentheses), which you can start from in Step 3:
+If they need inspiration, suggest examples — several map directly onto a ready-made template in `official-common-patterns.md` (named in parentheses), which you can start from in Step 3:
 
 - "A feedback form with a text input and a category selector" (Simple Form Modal)
 - "A notification message with an alert banner, description, and Approve/Reject buttons" (Notification Alert / Approval Message)
@@ -123,8 +125,8 @@ Get enough detail to plan the layout before generating any JSON.
 Based on the developer's description:
 
 1. **Fetch only what you need** from the live docs:
-   - WebFetch the master index (`https://docs.slack.dev/reference/block-kit.md`) to confirm the block and element types you plan to use exist and to grab links to their pages.
-   - Check `references/common-patterns.md` (the one local reference file) if the request matches a common pattern; start from the template instead of building from scratch.
+   - Fetch the master index (`https://docs.slack.dev/reference/block-kit.md`) with an available web-documentation capability to confirm the block and element types you plan to use exist and to grab links to their pages.
+   - Check `official-common-patterns.md` (the one local reference file) if the request matches a common pattern; start from the template instead of building from scratch.
    - Defer reading individual component pages until Step 4, when you build each block's fields.
 2. Propose a numbered block outline. For example:
 
@@ -149,7 +151,7 @@ Based on the developer's description:
 
 ## Step 4: Generate the Block Kit JSON
 
-Once the layout is approved, build each block from its live doc page, fetching each page's fields table (required vs optional, constraints) and JSON example with WebFetch. The URL patterns are in **Source of Truth** above; the one slug to remember is that every `*_select` menu (`static_select`, `users_select`, `multi_channels_select`, …) lives on `select-menu-element.md`. Fetch pages as you need them and reuse what you have already fetched — don't re-fetch the same page for every block of the same type. Then build the payload block-by-block and wrap it in the surface structure from Step 1.
+Once the layout is approved, build each block from its live doc page, fetching each page's fields table (required vs optional, constraints) and JSON example with an available web-documentation capability. The URL patterns are in **Source of Truth** above; the one slug to remember is that every `*_select` menu (`static_select`, `users_select`, `multi_channels_select`, …) lives on `select-menu-element.md`. Fetch pages as you need them and reuse what you have already fetched — don't re-fetch the same page for every block of the same type. Then build the payload block-by-block and wrap it in the surface structure from Step 1.
 
 **Guidelines:**
 
@@ -174,21 +176,11 @@ Present the complete payload to the developer in the Step 1 surface structure.
 
 **Always validate.** `blocks.validate` is a public Web API method, so no auth token is required.
 
-The authoritative reference for this method (its parameters, auth requirements, and response/error shape) is the live doc. WebFetch it before relying on any detail here: `https://docs.slack.dev/reference/methods/blocks.validate.md`. It documents the accepted parameters (`blocks` for a message's blocks array, `view` for a modal/home-tab view, `message` for a full message payload; send exactly one) and the response shape.
+The authoritative reference for this method (its parameters, auth requirements, and response/error shape) is the live doc. Fetch it before relying on any detail here: `https://docs.slack.dev/reference/methods/blocks.validate.md`. It documents the accepted parameters (`blocks` for a message's blocks array, `view` for a modal/home-tab view, `message` for a full message payload; send exactly one) and the response shape.
 
 ### 5a. Build the validation request
 
-Prefer the Slack CLI when it's available, since it reuses the slack-cli skill's CLI detection and needs no token wrangling. If the CLI isn't installed, fall back to curl. Both call the same public method and return the same response, so Step 5b applies either way.
-
-**Path A: Slack CLI (preferred).**
-
-Use the `slack:slack-cli` skill, **Step 1: Detect the Slack CLI**, to check whether the public CLI is installed and resolve its command (`SLACK_CMD`).
-
-If the CLI is available, use the `slack:slack-cli` skill, **Step 4: Calling Web API Methods (`slack api`)**, to invoke it. That step covers the `SLACK_CMD api <method> key=value …` syntax. Run `SLACK_CMD api --help` first to confirm the syntax **and the flag that skips authentication**. `blocks.validate` needs no token, so call it without authentication. Don't hard-code that flag from memory; read it from the help output so this stays correct if it's ever renamed. Pass the payload as a positional `key=value` argument: `blocks=<JSON array>` for messages, or `view=<JSON view object>` for modals and home tabs.
-
-**Path B: curl (fallback, when the CLI isn't installed).**
-
-POST to the endpoint with the **Bash tool**. The API uses form-urlencoded encoding, so pass the JSON directly as the parameter value.
+Use an available HTTP capability to POST to `https://slack.com/api/blocks.validate`. The API uses form-urlencoded encoding, so pass the JSON directly as the parameter value. If the current session has no HTTP capability, deliver the payload with a clear note that live validation remains pending.
 
 **For messages**, send the `blocks` array as a form-encoded parameter:
 
@@ -245,23 +237,11 @@ Present the validated payload, then help the developer put it to use.
 
 ### Send it
 
-Building the payload is this skill's job; sending it (`chat.postMessage`, `views.open`, `views.publish`, and the token/scope handling around them) belongs to the Web API layer. To call the right method — via the Slack CLI, raw curl, or a Bolt SDK — use the `slack:slack-api` skill, **Step 4: Call the Method (Manage)**, passing this payload as the method's `blocks` argument (messages) or `view` argument (modals and home tabs). That skill matches the argument names to the SDK or HTTP call so we don't duplicate them here.
+Building the native payload is this skill's job. Return it for the developer's Slack app integration. Do not pass native Slack blocks to OpenClaw's `presentation` field; translate the result into the portable presentation schema when the user instead wants the current OpenClaw agent to post it.
 
 ### Preview it
 
-Help the developer view their layout with the **Block Kit Builder**. Prefer the Slack CLI if it is installed. The CLI automatically loads the blocks, saving the developer from copying and pasting. If the CLI is not available, provide the standard Builder link instead.
-
-**Path A: Slack CLI (preferred).**
-
-Use the `slack:slack-cli` skill, **Step 1: Detect the Slack CLI**, to check whether the public CLI is installed and resolve its command (`SLACK_CMD`).
-
-If the CLI is available, run `SLACK_CMD blocks preview --help` to see how to pass the blocks and open the preview. The command loads the blocks into the Block Kit Builder in the developer's browser.
-
-Because you run the CLI non-interactively, this command also needs a `--team` flag. Resolve the team ID with the `slack:slack-cli` skill, **Step 2: Command Discovery via Help**, whose "Resolving `--app` and `--team` values" guidance covers running `SLACK_CMD auth list`; Any authenticated workspace works for a preview, if several are available, pick one and mention which you used rather than blocking on the choice.
-
-**Path B: Block Kit Builder link (fallback, when the CLI isn't installed).**
-
-Offer the Block Kit Builder link so the developer can paste the JSON in and tweak visually: `https://app.slack.com/block-kit-builder`. Builder needs an object (`{ "blocks": [...] }` or a full view object), not a bare array.
+Help the developer view their layout with the **Block Kit Builder**. Offer `https://app.slack.com/block-kit-builder` so they can paste the JSON in and tweak visually. Builder needs an object (`{ "blocks": [...] }` or a full view object), not a bare array.
 
 ---
 
@@ -273,5 +253,5 @@ Ask whether the developer wants to add, modify, remove, or reorder blocks, or bu
 
 ## Notes
 
-- **Scope:** this skill owns building and validating the Block Kit payload — choosing the surface, composing the JSON from the live docs, and confirming it with `blocks.validate`. Sending it lives in the Web API layer (`slack:slack-api`), and CLI detection/auth in `slack:slack-cli`.
-- **`blocks.validate` needs no auth** — it's a public method, so it works without a token whether you call it via the CLI or curl. Always validate before finalizing (Step 5).
+- **Scope:** this skill owns building and validating native Block Kit payloads for a developer. OpenClaw conversation delivery uses portable `presentation` instead.
+- **`blocks.validate` needs no auth** — it's a public method. Always validate before finalizing when the current session has an HTTP capability (Step 5).

--- a/extensions/slack/skills/block-kit/references/official-block-kit.md
+++ b/extensions/slack/skills/block-kit/references/official-block-kit.md
@@ -186,14 +186,14 @@ Use an available HTTP capability to POST to `https://slack.com/api/blocks.valida
 
 ```bash
 curl -s -X POST 'https://slack.com/api/blocks.validate' \
-  -d 'blocks=[ ... the blocks array ... ]'
+  --data-urlencode 'blocks=[ ... the blocks array ... ]'
 ```
 
 **For modals and home tabs**, send the complete view object in the `view` field:
 
 ```bash
 curl -s -X POST 'https://slack.com/api/blocks.validate' \
-  -d 'view={ "type": "modal", "title": ..., "blocks": [...] }'
+  --data-urlencode 'view={ "type": "modal", "title": ..., "blocks": [...] }'
 ```
 
 ### 5b. Handle the response

--- a/extensions/slack/skills/block-kit/references/official-common-patterns.md
+++ b/extensions/slack/skills/block-kit/references/official-common-patterns.md
@@ -1,0 +1,377 @@
+# Common Block Kit Patterns
+
+> Starting scaffolds for frequent use cases — copy one and customize rather than building from scratch.
+> They were valid when written, but the live docs (the skill's **Source of Truth**) remain authoritative for field schemas, and Block Kit evolves. Confirm any field you change against the component's doc page, and re-run the customized payload through `blocks.validate` (Step 5) before shipping.
+
+---
+
+## Approval Message [M]
+
+A notification with context and Approve/Reject buttons.
+
+```json
+{
+  "channel": "C0123456789",
+  "text": "New request from Jane awaiting approval",
+  "blocks": [
+    {
+      "type": "header",
+      "text": { "type": "plain_text", "text": "New Approval Request" }
+    },
+    {
+      "type": "section",
+      "text": { "type": "mrkdwn", "text": "*Requester:* <@U0123456789>\n*Type:* Access request\n*Details:* Production database read access" }
+    },
+    { "type": "divider" },
+    {
+      "type": "actions",
+      "block_id": "approval_actions",
+      "elements": [
+        {
+          "type": "button",
+          "text": { "type": "plain_text", "text": "Approve" },
+          "style": "primary",
+          "action_id": "approve_btn",
+          "value": "request_123"
+        },
+        {
+          "type": "button",
+          "text": { "type": "plain_text", "text": "Reject" },
+          "style": "danger",
+          "action_id": "reject_btn",
+          "value": "request_123"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Customization points:** Header text, section fields, button values, adding a confirmation dialog to the Reject button.
+
+---
+
+## Simple Form Modal [V]
+
+A modal with text input, select menu, and optional checkbox.
+
+```json
+{
+  "type": "modal",
+  "callback_id": "feedback_form",
+  "title": { "type": "plain_text", "text": "Submit Feedback" },
+  "submit": { "type": "plain_text", "text": "Submit" },
+  "close": { "type": "plain_text", "text": "Cancel" },
+  "blocks": [
+    {
+      "type": "input",
+      "block_id": "category_block",
+      "label": { "type": "plain_text", "text": "Category" },
+      "element": {
+        "type": "static_select",
+        "action_id": "category_select",
+        "placeholder": { "type": "plain_text", "text": "Choose a category" },
+        "options": [
+          { "text": { "type": "plain_text", "text": "Bug Report" }, "value": "bug" },
+          { "text": { "type": "plain_text", "text": "Feature Request" }, "value": "feature" },
+          { "text": { "type": "plain_text", "text": "General Feedback" }, "value": "general" }
+        ]
+      }
+    },
+    {
+      "type": "input",
+      "block_id": "description_block",
+      "label": { "type": "plain_text", "text": "Description" },
+      "element": {
+        "type": "plain_text_input",
+        "action_id": "description_input",
+        "multiline": true,
+        "placeholder": { "type": "plain_text", "text": "Tell us more..." }
+      }
+    },
+    {
+      "type": "input",
+      "block_id": "urgency_block",
+      "label": { "type": "plain_text", "text": "Priority" },
+      "element": {
+        "type": "radio_buttons",
+        "action_id": "urgency_select",
+        "options": [
+          { "text": { "type": "plain_text", "text": "Low" }, "value": "low" },
+          { "text": { "type": "plain_text", "text": "Medium" }, "value": "medium" },
+          { "text": { "type": "plain_text", "text": "High" }, "value": "high" }
+        ]
+      },
+      "optional": true
+    }
+  ]
+}
+```
+
+**Customization points:** Title, callback_id, input types, options list, adding/removing input blocks.
+
+---
+
+## Notification Alert [M]
+
+An alert banner with description and timestamp context.
+
+```json
+{
+  "channel": "C0123456789",
+  "text": "Alert: Deployment failed for api-gateway",
+  "blocks": [
+    {
+      "type": "alert",
+      "text": { "type": "plain_text", "text": "Deployment failed for api-gateway" },
+      "level": "error"
+    },
+    {
+      "type": "section",
+      "text": { "type": "mrkdwn", "text": "The deployment to *production* failed during the health check phase.\n\n*Error:* `Connection timeout after 30s`\n*Commit:* `a1b2c3d`" }
+    },
+    {
+      "type": "context",
+      "elements": [
+        { "type": "mrkdwn", "text": "Triggered by <@U0123456789> | <!date^1700000000^{date_short} at {time}|Nov 14, 2023>" }
+      ]
+    },
+    {
+      "type": "actions",
+      "elements": [
+        {
+          "type": "button",
+          "text": { "type": "plain_text", "text": "View Logs" },
+          "url": "https://logs.example.com/deploy/456",
+          "action_id": "view_logs_btn"
+        },
+        {
+          "type": "button",
+          "text": { "type": "plain_text", "text": "Retry" },
+          "style": "primary",
+          "action_id": "retry_deploy_btn"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Customization points:** Level (`info`, `warning`, `error`, `success`), description text, action buttons.
+
+---
+
+## Dashboard Home Tab [H]
+
+A welcome dashboard with metrics fields and quick-action buttons.
+
+```json
+{
+  "type": "home",
+  "blocks": [
+    {
+      "type": "header",
+      "text": { "type": "plain_text", "text": "Welcome to AppName" }
+    },
+    {
+      "type": "section",
+      "text": { "type": "mrkdwn", "text": "Here's your overview for today:" }
+    },
+    {
+      "type": "section",
+      "fields": [
+        { "type": "mrkdwn", "text": "*Open Tickets:*\n12" },
+        { "type": "mrkdwn", "text": "*Resolved Today:*\n5" },
+        { "type": "mrkdwn", "text": "*Avg Response:*\n2.4 hrs" },
+        { "type": "mrkdwn", "text": "*SLA Status:*\n:white_check_mark: On Track" }
+      ]
+    },
+    { "type": "divider" },
+    {
+      "type": "actions",
+      "elements": [
+        {
+          "type": "button",
+          "text": { "type": "plain_text", "text": "New Ticket" },
+          "style": "primary",
+          "action_id": "new_ticket_btn"
+        },
+        {
+          "type": "button",
+          "text": { "type": "plain_text", "text": "My Queue" },
+          "action_id": "my_queue_btn"
+        },
+        {
+          "type": "button",
+          "text": { "type": "plain_text", "text": "Settings" },
+          "action_id": "settings_btn"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Customization points:** Metrics fields, action buttons, adding image blocks or additional sections.
+
+---
+
+## Confirmation with Dialog [M]
+
+An action button with a confirmation dialog attached (prevents accidental clicks).
+
+```json
+{
+  "channel": "C0123456789",
+  "text": "Server shutdown requested",
+  "blocks": [
+    {
+      "type": "section",
+      "text": { "type": "mrkdwn", "text": "Are you sure you want to shut down *prod-server-01*?" }
+    },
+    {
+      "type": "actions",
+      "elements": [
+        {
+          "type": "button",
+          "text": { "type": "plain_text", "text": "Shut Down" },
+          "style": "danger",
+          "action_id": "shutdown_btn",
+          "value": "prod-server-01",
+          "confirm": {
+            "title": { "type": "plain_text", "text": "Confirm Shutdown" },
+            "text": { "type": "plain_text", "text": "This will immediately terminate the server. Active connections will be dropped." },
+            "confirm": { "type": "plain_text", "text": "Shut Down" },
+            "deny": { "type": "plain_text", "text": "Cancel" },
+            "style": "danger"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Customization points:** Confirmation title/text (title max 100 chars, text max 300 chars, confirm/deny max 30 chars), button style.
+
+---
+
+## Data Table [M]
+
+A structured table for displaying tabular data. Only one table block per message.
+
+```json
+{
+  "channel": "C0123456789",
+  "text": "Team sprint summary",
+  "blocks": [
+    {
+      "type": "header",
+      "text": { "type": "plain_text", "text": "Sprint Summary" }
+    },
+    {
+      "type": "table",
+      "column_settings": [
+        { "is_wrapped": true },
+        { "align": "center" },
+        { "align": "right" }
+      ],
+      "rows": [
+        [
+          { "type": "raw_text", "text": "Name" },
+          { "type": "raw_text", "text": "Status" },
+          { "type": "raw_text", "text": "Points" }
+        ],
+        [
+          { "type": "raw_text", "text": "Auth refactor" },
+          { "type": "raw_text", "text": "In Progress" },
+          { "type": "raw_text", "text": "5" }
+        ],
+        [
+          { "type": "raw_text", "text": "API docs update" },
+          { "type": "raw_text", "text": "Done" },
+          { "type": "raw_text", "text": "2" }
+        ],
+        [
+          { "type": "raw_text", "text": "Bug #1234" },
+          { "type": "raw_text", "text": "Blocked" },
+          { "type": "raw_text", "text": "3" }
+        ]
+      ]
+    }
+  ]
+}
+```
+
+**Customization points:** Column settings (alignment: `left`/`center`/`right`, wrapping: `is_wrapped`), row data, cell type (`raw_text` for plain content, `rich_text` for formatted content with links/emoji/mentions). Max 100 rows, max 20 cells per row. First row is the header. Only one table block per message.
+
+---
+
+## Settings Modal with Multiple Input Types [V]
+
+A modal combining different input types for a settings/preferences form.
+
+```json
+{
+  "type": "modal",
+  "callback_id": "settings_modal",
+  "title": { "type": "plain_text", "text": "Notification Settings" },
+  "submit": { "type": "plain_text", "text": "Save" },
+  "close": { "type": "plain_text", "text": "Cancel" },
+  "blocks": [
+    {
+      "type": "input",
+      "block_id": "channel_block",
+      "label": { "type": "plain_text", "text": "Notification Channel" },
+      "element": {
+        "type": "conversations_select",
+        "action_id": "channel_select",
+        "default_to_current_conversation": true
+      }
+    },
+    {
+      "type": "input",
+      "block_id": "frequency_block",
+      "label": { "type": "plain_text", "text": "Digest Frequency" },
+      "element": {
+        "type": "static_select",
+        "action_id": "frequency_select",
+        "options": [
+          { "text": { "type": "plain_text", "text": "Real-time" }, "value": "realtime" },
+          { "text": { "type": "plain_text", "text": "Hourly" }, "value": "hourly" },
+          { "text": { "type": "plain_text", "text": "Daily" }, "value": "daily" }
+        ],
+        "initial_option": { "text": { "type": "plain_text", "text": "Daily" }, "value": "daily" }
+      }
+    },
+    {
+      "type": "input",
+      "block_id": "events_block",
+      "label": { "type": "plain_text", "text": "Notify me about" },
+      "element": {
+        "type": "checkboxes",
+        "action_id": "events_checkboxes",
+        "options": [
+          { "text": { "type": "plain_text", "text": "New deployments" }, "value": "deploys" },
+          { "text": { "type": "plain_text", "text": "Failed builds" }, "value": "failures" },
+          { "text": { "type": "plain_text", "text": "PR reviews needed" }, "value": "reviews" }
+        ]
+      }
+    },
+    {
+      "type": "input",
+      "block_id": "quiet_hours_block",
+      "label": { "type": "plain_text", "text": "Quiet hours start" },
+      "element": {
+        "type": "timepicker",
+        "action_id": "quiet_start",
+        "initial_time": "22:00",
+        "placeholder": { "type": "plain_text", "text": "Select time" }
+      },
+      "optional": true
+    }
+  ]
+}
+```
+
+**Customization points:** Input types, options, initial values, adding `hint` text to inputs, marking fields as `optional`.

--- a/extensions/slack/skills/block-kit/references/official-common-patterns.md
+++ b/extensions/slack/skills/block-kit/references/official-common-patterns.md
@@ -20,7 +20,10 @@ A notification with context and Approve/Reject buttons.
     },
     {
       "type": "section",
-      "text": { "type": "mrkdwn", "text": "*Requester:* <@U0123456789>\n*Type:* Access request\n*Details:* Production database read access" }
+      "text": {
+        "type": "mrkdwn",
+        "text": "*Requester:* <@U0123456789>\n*Type:* Access request\n*Details:* Production database read access"
+      }
     },
     { "type": "divider" },
     {
@@ -128,12 +131,18 @@ An alert banner with description and timestamp context.
     },
     {
       "type": "section",
-      "text": { "type": "mrkdwn", "text": "The deployment to *production* failed during the health check phase.\n\n*Error:* `Connection timeout after 30s`\n*Commit:* `a1b2c3d`" }
+      "text": {
+        "type": "mrkdwn",
+        "text": "The deployment to *production* failed during the health check phase.\n\n*Error:* `Connection timeout after 30s`\n*Commit:* `a1b2c3d`"
+      }
     },
     {
       "type": "context",
       "elements": [
-        { "type": "mrkdwn", "text": "Triggered by <@U0123456789> | <!date^1700000000^{date_short} at {time}|Nov 14, 2023>" }
+        {
+          "type": "mrkdwn",
+          "text": "Triggered by <@U0123456789> | <!date^1700000000^{date_short} at {time}|Nov 14, 2023>"
+        }
       ]
     },
     {
@@ -240,7 +249,10 @@ An action button with a confirmation dialog attached (prevents accidental clicks
           "value": "prod-server-01",
           "confirm": {
             "title": { "type": "plain_text", "text": "Confirm Shutdown" },
-            "text": { "type": "plain_text", "text": "This will immediately terminate the server. Active connections will be dropped." },
+            "text": {
+              "type": "plain_text",
+              "text": "This will immediately terminate the server. Active connections will be dropped."
+            },
             "confirm": { "type": "plain_text", "text": "Shut Down" },
             "deny": { "type": "plain_text", "text": "Cancel" },
             "style": "danger"
@@ -271,11 +283,7 @@ A structured table for displaying tabular data. Only one table block per message
     },
     {
       "type": "table",
-      "column_settings": [
-        { "is_wrapped": true },
-        { "align": "center" },
-        { "align": "right" }
-      ],
+      "column_settings": [{ "is_wrapped": true }, { "align": "center" }, { "align": "right" }],
       "rows": [
         [
           { "type": "raw_text", "text": "Name" },

--- a/extensions/slack/skills/slack/SKILL.md
+++ b/extensions/slack/skills/slack/SKILL.md
@@ -18,5 +18,3 @@ Use the `message` tool with `channel: "slack"`. The tool schema lists the action
 - Confirm destructive deletes when the target or intent is unclear.
 
 Slack formatting, mentions, and available actions are described automatically by the current `message` tool hints. Follow those hints instead of maintaining a second action catalog here.
-
-For decisions, status summaries, comparisons, reports, plans, charts, tables, or next actions, use the `block-kit` skill proactively. Send its portable `presentation` through the `message` tool; never invent a raw `blocks` argument.

--- a/extensions/slack/skills/slack/SKILL.md
+++ b/extensions/slack/skills/slack/SKILL.md
@@ -17,4 +17,6 @@ Use the `message` tool with `channel: "slack"`. The tool schema lists the action
 - When multiple Slack accounts are configured, pass `accountId` rather than guessing.
 - Confirm destructive deletes when the target or intent is unclear.
 
-Slack formatting, mentions, tables, charts, and interactive controls are described automatically by the current `message` tool hints. Follow those hints instead of maintaining a second action or formatting catalog here.
+Slack formatting, mentions, and available actions are described automatically by the current `message` tool hints. Follow those hints instead of maintaining a second action catalog here.
+
+For decisions, status summaries, comparisons, reports, plans, charts, tables, or next actions, use the `block-kit` skill proactively. Send its portable `presentation` through the `message` tool; never invent a raw `blocks` argument.

--- a/extensions/slack/src/official-skills-vendor.test.ts
+++ b/extensions/slack/src/official-skills-vendor.test.ts
@@ -75,6 +75,8 @@ describe("official Slack skill vendor", () => {
 
     expect(guide).toContain("official-common-patterns.md");
     expect(guide).toContain("blocks.validate");
+    expect(guide.match(/--data-urlencode/g)).toHaveLength(2);
+    expect(guide).not.toMatch(/^\s+-d '(?:blocks|view)=/m);
     expect(guide).not.toMatch(
       /slack:slack-(?:api|cli)|AskUserQuestion|WebFetch|Bash tool|`references\/common-patterns\.md`/,
     );

--- a/extensions/slack/src/official-skills-vendor.test.ts
+++ b/extensions/slack/src/official-skills-vendor.test.ts
@@ -22,7 +22,7 @@ function listPublishedSkills() {
 }
 
 describe("official Slack skill vendor", () => {
-  it("matches the pinned upstream inventory", async () => {
+  it("preserves pinned vendor bytes and declared adaptations", async () => {
     const { stdout } = await execFileAsync(process.execPath, [
       path.join(pluginRoot, "scripts", "verify-official-skills.mjs"),
     ]);
@@ -39,14 +39,6 @@ describe("official Slack skill vendor", () => {
 
     expect(manifest.skills).toEqual(["./skills"]);
     expect(published).toEqual(["block-kit", "slack"]);
-    expect(
-      fs.existsSync(path.join(skillsRoot, "block-kit", "references", "official-block-kit.md")),
-    ).toBe(true);
-    expect(
-      fs.existsSync(
-        path.join(skillsRoot, "block-kit", "references", "official-common-patterns.md"),
-      ),
-    ).toBe(true);
   });
 
   it("keeps published skill metadata and local references valid", () => {
@@ -73,5 +65,18 @@ describe("official Slack skill vendor", () => {
         expect(fs.existsSync(path.resolve(path.dirname(skillPath), target)), target).toBe(true);
       }
     }
+  });
+
+  it("keeps the official guide adapted to OpenClaw's available capabilities", () => {
+    const guide = fs.readFileSync(
+      path.join(skillsRoot, "block-kit", "references", "official-block-kit.md"),
+      "utf8",
+    );
+
+    expect(guide).toContain("official-common-patterns.md");
+    expect(guide).toContain("blocks.validate");
+    expect(guide).not.toMatch(
+      /slack:slack-(?:api|cli)|AskUserQuestion|WebFetch|Bash tool|`references\/common-patterns\.md`/,
+    );
   });
 });

--- a/extensions/slack/src/official-skills-vendor.test.ts
+++ b/extensions/slack/src/official-skills-vendor.test.ts
@@ -1,0 +1,77 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+const execFileAsync = promisify(execFile);
+const pluginRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const skillsRoot = path.join(pluginRoot, "skills");
+
+function listPublishedSkills() {
+  return fs
+    .readdirSync(skillsRoot, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isDirectory() && fs.existsSync(path.join(skillsRoot, entry.name, "SKILL.md")),
+    )
+    .map((entry) => entry.name)
+    .toSorted();
+}
+
+describe("official Slack skill vendor", () => {
+  it("matches the pinned upstream inventory", async () => {
+    const { stdout } = await execFileAsync(process.execPath, [
+      path.join(pluginRoot, "scripts", "verify-official-skills.mjs"),
+    ]);
+
+    expect(stdout).toContain("Verified 3 Slack skill vendor files");
+    expect(stdout).toContain("f3f404205cbbfa18fabc79cc9d06fb444efff075");
+  });
+
+  it("publishes only the Slack conversation and Block Kit skills", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(pluginRoot, "openclaw.plugin.json"), "utf8"),
+    ) as { skills?: string[] };
+    const published = listPublishedSkills();
+
+    expect(manifest.skills).toEqual(["./skills"]);
+    expect(published).toEqual(["block-kit", "slack"]);
+    expect(
+      fs.existsSync(path.join(skillsRoot, "block-kit", "references", "official-block-kit.md")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(skillsRoot, "block-kit", "references", "official-common-patterns.md"),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps published skill metadata and local references valid", () => {
+    for (const skillName of listPublishedSkills()) {
+      const skillPath = path.join(skillsRoot, skillName, "SKILL.md");
+      const source = fs.readFileSync(skillPath, "utf8");
+      const frontmatterMatch = /^---\n([\s\S]*?)\n---\n/.exec(source);
+
+      expect(frontmatterMatch, `${skillName} must start with YAML frontmatter`).not.toBeNull();
+      const frontmatter = parseYaml(frontmatterMatch?.[1] ?? "") as {
+        name?: unknown;
+        description?: unknown;
+        "allowed-tools"?: unknown;
+      };
+      expect(frontmatter.name).toBe(skillName);
+      expect(typeof frontmatter.description).toBe("string");
+      expect(frontmatter["allowed-tools"]).toEqual(["message"]);
+
+      for (const link of source.matchAll(/\]\(([^)]+)\)/g)) {
+        const target = link[1]?.split("#", 1)[0]?.trim();
+        if (!target || /^[a-z]+:/i.test(target)) {
+          continue;
+        }
+        expect(fs.existsSync(path.resolve(path.dirname(skillPath), target)), target).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Slack agents tend to answer decision, status, and report prompts as plain prose even when Slack's native structure and one-click actions would make the response materially easier to use. The official Slack authoring guidance also assumes Slack CLI/API skills that are not part of the OpenClaw agent's tool surface.

## Why This Change Was Made

The Slack plugin now publishes exactly two skills: its existing conversation skill and a new proactive `block-kit` skill. The latter combines an OpenClaw-specific portable-presentation playbook with Slack's official Block Kit guide and patterns pinned to `slackapi/slack-skills-plugin` v1.3.0.

Vendored files record both upstream and local SHA-256 hashes. OpenClaw adaptations are explicit and tested so a future sync cannot silently restore unavailable Slack CLI/API/tool handoffs. No runtime, configuration, schema, or new plugin dependency changes are included.

Possible follow-up update automation, in preference order:

1. A scheduled/manual GitHub Action that compares the pinned revision with the latest Slack release and opens a reviewed update PR.
2. Renovate's generic datasource plus regex manager to update the revision and hashes.
3. A lightweight scheduled drift check that files an issue without changing files.
4. Leave the pin manual until upstream changes justify the maintenance cost; the verifier still catches accidental local drift.

## User Impact

In Slack, a natural decision or status prompt can now trigger a native table, sections, and interactive actions without the user explicitly asking for Block Kit. Developers can still ask for raw Block Kit JSON and receive official, live-doc-driven authoring and `blocks.validate` guidance.

The Slack CLI, app scaffolding, general API, docs, test-app, archived messaging, and search skills are intentionally not published because they do not improve the normal OpenClaw Slack conversation flow.

## Evidence

Both runs used this exact prompt in the local `#general` channel:

> We are deciding whether to ship the Slack plugin update today. Here is the current picture: 248/248 unit tests pass, docs pass, the macOS smoke test passes, the Windows smoke test is still pending, and Patrick owns rollback. Help me get a decision from the team in this channel.

| Before — baseline plugin | After — only the new Block Kit skill added |
| --- | --- |
| The agent returned a plain-text checklist and did not call the message tool. | The agent proactively sent a portable presentation that Slack rendered as a native evidence table and three one-click decision actions. |
| ![Before: plain-text Slack decision reply](https://github.com/user-attachments/assets/c3594ea5-2efc-4b33-a0ec-dce4504b814c) | ![After: native Slack table and decision buttons](https://github.com/user-attachments/assets/04589554-fcf7-4431-886c-2bc56475cd09) |

Live run IDs: baseline `ae66bf7b-5d9e-41a1-8834-dd50b779e7d1`; candidate `b27f1a9c-be09-494f-9cdc-41c854a6cf72`.

Validation:

- `node extensions/slack/scripts/verify-official-skills.mjs`
- `node scripts/run-vitest.mjs extensions/slack/src/official-skills-vendor.test.ts extensions/slack/src/shared-interactive.test.ts` — 40 tests passed
- `pnpm deadcode:dependencies`
- `pnpm check:changed`
- live `blocks.validate` request containing `R&D` — `{"ok":true}`
- branch autoreview — no actionable findings; patch correct (0.99)


