### PR TITLE
refactor(ui): remove retired list and sidebar styles

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -4247,35 +4247,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     },
   );
 
-  it("keeps newly opened sidebar columns transparent while panel owners retain their surface", async () => {
-    const page = await openBrowserPage(1_000, 700);
-    try {
-      await page.setContent(
-        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
-          <div class="sidebar-region" style="--panel: rgb(12, 34, 56)">
-            <main class="sidebar-region__primary">Primary chat</main>
-          </div>
-        </body></html>`,
-      );
-
-      const backgrounds = await page.evaluate(() => {
-        const column = document.createElement("section");
-        column.className = "sidebar-column";
-        column.innerHTML = '<div class="sidebar-panel">Owned panel surface</div>';
-        document.querySelector(".sidebar-region")?.append(column);
-        return {
-          column: getComputedStyle(column).backgroundColor,
-          panel: getComputedStyle(column.firstElementChild!).backgroundColor,
-        };
-      });
-
-      expect(backgrounds.column).toBe("rgba(0, 0, 0, 0)");
-      expect(backgrounds.panel).toBe("rgb(12, 34, 56)");
-    } finally {
-      await closeBrowserPage(page);
-    }
-  });
-
   it.each([
     { dock: "narrow", width: 620, height: 600 },
     { dock: "bottom", width: 900, height: 300 },

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -215,18 +215,13 @@ openclaw-activity-page {
   gap: 4px;
 }
 
-.activity-feed__people-name,
-.activity-feed__last-active {
+.activity-feed__people-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.activity-feed__people-name {
   color: var(--text-strong);
 }
 
-.activity-feed__last-active,
 .activity-feed__people-count,
 .activity-feed__people-group-label {
   color: var(--muted);

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -397,7 +397,6 @@
   .chat-bubble.chat-bubble,
   .chat-pr.chat-pr,
   .nav-item.nav-item,
-  .list-item.list-item,
   .sidebar-recent-session.sidebar-recent-session,
   .settings-sidebar__item.settings-sidebar__item,
   .btn.btn,

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -198,17 +198,6 @@ openclaw-chat-sidebar-region,
   width: 100%;
 }
 
-.sidebar-column {
-  display: flex;
-  flex: 0 0 auto;
-  min-width: 260px;
-  min-height: 0;
-  overflow: hidden;
-  background: transparent;
-  flex-direction: column;
-  animation: chat-sidebar-fade-in 160ms ease-out;
-}
-
 /* Canonical rail header contract. The header owns geometry; actions are bare
    glyphs with an invisible hit area so generic button chrome cannot leak in. */
 .rail-header {
@@ -952,15 +941,6 @@ openclaw-chat-sidebar-region,
 
 .chat-tasks-rail__task-inspector-retry:disabled {
   opacity: 0.55;
-}
-
-@keyframes chat-sidebar-fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
 }
 
 /* Sidebar Panel */

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2161,7 +2161,6 @@ openclaw-chat-session-rail {
 }
 
 :root[data-theme-mode="light"] .code-block,
-:root[data-theme-mode="light"] .list-item,
 :root[data-theme-mode="light"] .chip {
   background: var(--bg);
 }
@@ -2397,69 +2396,8 @@ openclaw-chat-session-rail {
   container-type: inline-size;
 }
 
-.list-item {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(200px, 260px);
-  gap: 16px;
-  align-items: start;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  padding: 12px;
-  background: var(--card);
-  transition: border-color var(--duration-fast) ease;
-}
-
-.list-item-clickable {
-  text-decoration: none;
-}
-
-.list-item-clickable:hover {
-  border-color: var(--border-strong);
-}
-
-.list-main {
-  display: grid;
-  gap: 4px;
-  min-width: 0;
-}
-
 .list-title {
   font-weight: 500;
-}
-
-.list-sub {
-  color: var(--muted);
-  font-size: 12px;
-}
-
-.list-meta {
-  text-align: right;
-  color: var(--muted);
-  font-size: 12px;
-  display: grid;
-  gap: 4px;
-  min-width: 200px;
-}
-
-.list-meta .btn {
-  padding: 6px 10px;
-}
-
-.list-meta .field input,
-.list-meta .field textarea,
-.list-meta .field select {
-  width: 100%;
-}
-
-@container (max-width: 560px) {
-  .list-item {
-    grid-template-columns: 1fr;
-  }
-
-  .list-meta {
-    min-width: 0;
-    text-align: left;
-  }
 }
 
 /* ===========================================

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2493,17 +2493,6 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
   line-height: 1.35;
 }
 
-.sidebar-customize-menu__group-title {
-  margin: 6px 0 2px;
-  padding: 7px 8px 4px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-  color: var(--muted);
-  font-size: calc(10px * var(--control-ui-text-scale));
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
 .sidebar-customize-menu__item {
   display: flex;
   align-items: center;
@@ -4494,10 +4483,6 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
     position: static;
     padding: 6px 12px;
     gap: 10px;
-  }
-
-  .list-item {
-    grid-template-columns: 1fr;
   }
 }
 

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -495,17 +495,8 @@ html.openclaw-native-macos body .shell--mobile-nav .topnav-shell__actions {
   }
 
   /* Lists */
-  .list-item {
-    padding: 10px;
-    border-radius: var(--radius-md);
-  }
-
   .list-title {
     font-size: 13px;
-  }
-
-  .list-sub {
-    font-size: 12px; /* was 11px */
   }
 
   /* Code blocks */


### PR DESCRIPTION
## What Problem This Solves

The Control UI still ships styles for list layouts, Activity timestamps, and sidebar columns that its current views no longer render. An obsolete browser test also constructs the retired sidebar column instead of exercising the current panel layout.

## Why This Change Was Made

Remove the unused selectors, their dead descendant rules, and the unreferenced column animation. Keep the current list/title styles, shared Activity declarations, and panel resize divider; retain existing coverage of the current panel layout and interactions while removing the obsolete fixture. This reduces production CSS by **112 lines** and removes **29 lines** of obsolete test code.

The source audit traces the retired dashboard list to the gallery replacement in 12d6388d3eb, the removed Activity timestamp to b03d2e79e9a, and current panel ownership to d9dcdfd048c. No configuration, protocol, persistence, or application behavior changes.

## User Impact

No intended visual or functional change. Gallery filtering and mobile layout, Activity people controls, sidebar customization, and chat panel docking continue to work. An unsent chat draft remains intact while opening and docking the Files panel.

## Evidence

The existing AST dead-CSS audit went from **17 candidate selector entries to zero**. Repository-wide producer checks also covered plugin/browser sources and dynamic class families. The separate `list-item` markup in the iOS review-notes PDF generator uses its own embedded stylesheet and is unaffected.

**Automated checks**

- Bundled Chromium E2E: **6/6 passed**, including a successful UI production build, dashboard navigation, light/dark tab persistence, resizing/docking, and mobile navigation.
- Focused Activity and current stacked-panel layout tests: **13 passed**, with 129 tests outside the selected name filter skipped.
- The changed-check run passed typechecks, formatting, core lint, i18n, dead-export scans, and the remaining guards. Stylelint initially identified adjacent duplicate Activity selectors exposed by removing their retired shared member. Their declarations were merged without changing cascade order, and the final scoped stylelint run passed.
- Final independent Codex review: **scoped-clean through P2**, with no accepted/actionable findings.
- `git diff --check` passed.

Exact repository verification commands:

```sh
node scripts/audit-control-ui-dead-css.mts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-rail-columns.e2e.test.ts ui/src/e2e/dashboard-gallery.e2e.test.ts
node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts ui/src/pages/activity/session-activity-view.test.ts --testNamePattern 'keeps both stacked panels usable|person|people'
node scripts/check-changed.mjs
node --import ./scripts/tsx.mjs scripts/run-stylelint.mts ui/src/pages/chat/chat-responsive.browser.test.ts ui/src/styles/activity.css ui/src/styles/base.css ui/src/styles/chat/sidebar.css ui/src/styles/components.css ui/src/styles/layout.css ui/src/styles/layout.mobile.css
git diff --check
```

**Before/after browser proof**

Real Chromium ran the current application against the synthetic standalone mock server, started with:

```sh
node --import ./scripts/tsx.mjs scripts/control-ui-mock-dev.ts --host 127.0.0.1 --port 5197
```

Six baseline/final flows retained identical observed computed styles: desktop/mobile gallery filtering, the Activity people popover, Files panel, bottom docking with a preserved composer draft, and sidebar customization. All selected captures were inspected and contain synthetic data only. The two representative before/after screenshot pairs below were captured independently and are byte-for-byte identical.

Files panel and retained draft — before:

![Files panel and retained draft before cleanup](https://github.com/user-attachments/assets/b06efc82-10a7-492b-82e7-7a49af2355d7)

Files panel and retained draft — after:

![Files panel and retained draft after cleanup](https://github.com/user-attachments/assets/c130efdf-d664-4f54-8e7a-d9621c4080fb)

Activity people popover — before:

![Activity people popover before cleanup](https://github.com/user-attachments/assets/2ab9bcc4-a818-4059-8700-5a310ae8ee0b)

Activity people popover — after:

![Activity people popover after cleanup](https://github.com/user-attachments/assets/3e8a4c7a-d552-434d-bdbe-139ea2e75782)

The standalone gallery fixture reports that dashboard previews are unavailable for its mock connection; those captures prove the gallery layout only. The separate passing bundled gallery E2E opens a working dashboard. The standalone mock also emitted an occasional ResizeObserver notification warning on both baseline and candidate; the observed geometry and interactions remained unchanged.
