### PR TITLE
fix(code-mode): prevent shell classification stalls

### DIFF
--- a/src/agents/code-mode-shell-source.test.ts
+++ b/src/agents/code-mode-shell-source.test.ts
@@ -43,6 +43,9 @@ describe("isShellLikeCodeModeSource", () => {
     'GREETING="hello world" npm test',
     "GREETING='hello world' ./gradlew test",
     "EMPTY= npm test",
+    String.raw`A="\\" ls "file" argument`,
+    String.raw`A="\\" B='a b' ls "file" argument`,
+    "A=\\😀\r\n  ls -1",
     "// inspect the workspace\npwd",
     "/* inspect the workspace */ pwd;",
     "// use a clean environment\nNODE_ENV=test npm test",
@@ -204,6 +207,22 @@ describe("isShellLikeCodeModeSource", () => {
     },
   ])("preserves transpiled command-like TypeScript: $source", ({ source, preparedSource }) => {
     expect(isShellLikeCodeModeSource(source, preparedSource)).toBe(false);
+  });
+
+  it.each([
+    ["repeated quotes", `A=${'""'.repeat(22)}`],
+    ["escaped quotes", `A="${'\\"'.repeat(32_000)}`],
+  ])("classifies an unfinished assignment with %s promptly", (_name, source) => {
+    const started = performance.now();
+    expect(isShellLikeCodeModeSource(source)).toBe(false);
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+
+  it("classifies a long chain of assignments without rescanning each suffix", () => {
+    const source = `${"A=x ".repeat(32_000)}ls -1`;
+    const started = performance.now();
+    expect(isShellLikeCodeModeSource(source)).toBe(true);
+    expect(performance.now() - started).toBeLessThan(1_000);
   });
 
   it("explains how to execute a real catalog tool without retrying shell source", () => {

--- a/src/agents/code-mode-shell-source.ts
+++ b/src/agents/code-mode-shell-source.ts
@@ -15,8 +15,6 @@ const SHELL_EXECUTABLE_PATH =
   /^(?:(?:\.{1,2}|~)[\\/]|\/|[A-Za-z]:[\\/])[^\s;|&()]+(?=$|[\t \r\n;&|])/u;
 const SHELL_ARGUMENT =
   /^(?:-{1,2}[a-z\d][\w-]*(?:[\t =;&|]|$)|(?:(?:\.{1,2}|~)[\\/]|\/|[A-Za-z]:[\\/])[^\s]+)/iu;
-const SHELL_ENV_ASSIGNMENT =
-  /^[A-Za-z_]\w*=(?:"(?:\\.|[^"])*"|'[^']*'|\\.|[^\s;&|])*(?:[\t ]+|[\t ]*\r?\n[\t ]*)(?=\S)/u;
 const SHELL_CONTROL =
   /^(?:(?:if|elif|while|until)[\t ]+(?:\[{1,2}(?=[\t ]|$)|test\b|[A-Za-z_][\w-]*(?=[\t ;]))|for[\t ]+(?:[A-Za-z_]\w*[\t ]+in\b|\(\([^\r\n]*\)\)[\t ]*;[\t ]*do\b)|case[\t ]+\S+[\t ]+in\b|function[\t ]+[A-Za-z_][\w-]*[\t ]*\{)/u;
 const SHELL_REDIRECTION = /^(?:\d*(?:>>?|<<?)|&>>?)/u;
@@ -40,6 +38,67 @@ function hasHoistedGuestBinding(source: string, name: string): boolean {
   );
 }
 
+function stripShellEnvAssignments(source: string): string {
+  const name = /[A-Za-z_]\w*=/uy;
+  if (!name.test(source)) {
+    return source;
+  }
+  // Each state stores the first successful endpoint in regex alternative order;
+  // zero means no match. Reverse evaluation visits each suffix once, including
+  // quoted fallbacks, instead of backtracking over overlapping alternatives.
+  const value = new Uint32Array(source.length + 3);
+  const doubleQuoted = new Uint32Array(source.length + 3);
+  const singleQuoted = new Uint32Array(source.length + 3);
+  let blanksEnd = 0;
+  let newlineEnd = 0;
+  for (let index = source.length - 1; index >= name.lastIndex; index -= 1) {
+    const character = source[index]!;
+    const blank = character === " " || character === "\t";
+    const whitespace = /\s/u.test(character);
+    const separator = blank
+      ? blanksEnd || newlineEnd
+      : character === "\n"
+        ? blanksEnd
+        : character === "\r" && source[index + 1] === "\n"
+          ? newlineEnd
+          : 0;
+    if (!blank) {
+      blanksEnd = whitespace ? 0 : index;
+      newlineEnd = separator;
+    }
+    // The original escape's dot consumes a Unicode point, excluding line breaks.
+    const escaped =
+      character === "\\" &&
+      index + 1 < source.length &&
+      !/[\r\n\u2028\u2029]/u.test(source[index + 1]!);
+    const afterEscape = index + (escaped && source.codePointAt(index + 1)! > 0xffff ? 3 : 2);
+    doubleQuoted[index] =
+      (escaped ? doubleQuoted[afterEscape]! : 0) ||
+      (character === '"' ? value[index + 1]! : doubleQuoted[index + 1]!);
+    singleQuoted[index] = character === "'" ? value[index + 1]! : singleQuoted[index + 1]!;
+    value[index] =
+      (character === '"' ? doubleQuoted[index + 1]! : 0) ||
+      (character === "'" ? singleQuoted[index + 1]! : 0) ||
+      (escaped ? value[afterEscape]! : 0) ||
+      (!whitespace && character !== ";" && character !== "&" && character !== "|"
+        ? value[index + 1]!
+        : 0) ||
+      separator;
+  }
+  let commandStart = 0;
+  // Reuse the suffix table across every leading assignment, rather than
+  // scanning the remaining command again for each NAME=value prefix.
+  do {
+    const end = value[name.lastIndex]!;
+    if (!end) {
+      break;
+    }
+    commandStart = end;
+    name.lastIndex = end;
+  } while (name.test(source));
+  return source.slice(commandStart);
+}
+
 /** Reject recognizable shell commands without guessing at JavaScript expressions. */
 export function isShellLikeCodeModeSource(source: string, preparedSource = source): boolean {
   const trimmed = source.trim();
@@ -55,14 +114,7 @@ export function isShellLikeCodeModeSource(source: string, preparedSource = sourc
   }
   // Shell environment prefixes cannot make a recognizable executable safe;
   // strip them before deciding whether the guest worker should start.
-  let commandSource = uncommented;
-  for (;;) {
-    const assignment = SHELL_ENV_ASSIGNMENT.exec(commandSource);
-    if (!assignment) {
-      break;
-    }
-    commandSource = commandSource.slice(assignment[0].length);
-  }
+  const commandSource = stripShellEnvAssignments(uncommented);
 
   const knownCommand = SHELL_COMMAND.exec(commandSource);
   const unknownCommand = SHELL_IDENTIFIER.exec(commandSource);

--- a/src/agents/code-mode.guest-source.test.ts
+++ b/src/agents/code-mode.guest-source.test.ts
@@ -119,6 +119,7 @@ describe("Code Mode guest source validation", () => {
     { code: "NODE_ENV=test\nnpm test" },
     { code: "FOO=bar ./gradlew test" },
     { command: 'GREETING="hello world" npm test' },
+    { code: String.raw`A="\\" ls "file" argument` },
     { command: "whoami" },
     { code: "set -euo pipefail" },
     { command: "exit" },


### PR DESCRIPTION
Fixes #138897.

## What Problem This Solves

Fixes an issue where Code Mode `exec` stalls while classifying assignment-prefixed source with repeated quotes. In a real Gateway turn, the 46-byte reported input took 9.2 seconds to return a syntax error. A 50-byte input occupied a worker until the parent watchdog returned a timeout after 12.2 seconds.

## Why This Change Was Made

The assignment regex lets quoted, escaped, and ordinary-character alternatives consume overlapping input. The classifier now evaluates each value and quoted-body suffix once, retaining the first successful result in the original alternative order. It reuses those results across consecutive assignments.

This also addresses both ClawSweeper findings and rank-up moves: doubled-backslash quote precedence is preserved, and escaped quotes no longer trigger repeated suffix walks. The incoming scanner's endpoint enumeration and sorting are removed. The repair preserves @lzhan011's report and contribution.

## User Impact

Malformed source reaches its normal syntax error promptly. Recognizable shell commands retain the existing actionable JavaScript/TypeScript guidance. Valid JavaScript, TypeScript, and command-like hoisted bindings still execute. The execution budget and parent watchdog are unchanged; no input cap, retry, configuration, or dependency is added.

## Evidence

Real flow: isolated built Gateway → `/v1/responses` → agent → deterministic local provider → production Code Mode `exec` → worker → public tool result. The fixture submits the exact source; it does not call the classifier directly. Baseline: `6c745b31f1fcb953470390279d5e899d6229a72a`. Candidate: `8e191c9cbb889149ffcea7986800db5f38f277e4`.

| Scenario | Before | After |
|---|---|---|
| 46-byte repeated-quote assignment | Guest syntax error after 9,208 ms | Same syntax error after 137 ms |
| 50-byte repeated-quote assignment | Parent worker timeout after 12,155 ms | Guest syntax error after 120 ms |
| CPU for the 50-byte turn, including fixture/Gateway overhead | 12,730 ms | 175 ms |
| Next valid JavaScript cell | Completes with 11 | Completes with 11 |
| Doubled-backslash assignment before `ls` | Shell-specific `invalid_input` | Same guidance |
| TypeScript shell / hoisted binding / typed return | Guidance / 7 / 42 | Guidance / 7 / 42 |

Escaped-quote inputs from 1,000 through 16,000 pairs returned their normal syntax error in 110–131 ms through the Gateway. Separate matcher measurements cover quotes, escaped quotes, blank separators, and assignment chains through 128,000 units. An independent comparison of 554,312 exhaustive/randomized inputs found identical match endpoints to the old regex, including Unicode whitespace and escaped Unicode characters.

- Regression demonstrated on pre-fix source: the repeated-quote test failed at 63,536 ms against a 1,000 ms bound in the cold test runner.
- 439 tests passed across classifier, source preparation, guest source, TypeScript, worker lifecycle, and headless validation suites.
- Type-aware lint: 0 warnings/errors. Pinned formatter check and `git diff --check` passed.
- Runtime builds and all execution checks ran in a secretless isolated container. Exact-head CI and independent review are required before landing.

Commands: `node scripts/run-vitest.mjs src/agents/code-mode-shell-source.test.ts src/agents/code-mode-runtime.test.ts src/agents/code-mode.guest-source.test.ts src/agents/code-mode.typescript.test.ts src/agents/code-mode-worker-lifecycle.test.ts src/agents/code-mode-headless.validation.test.ts`; targeted `node scripts/run-oxlint.mjs`; `node --import ./scripts/tsx.mjs scripts/build-all.mts qaRuntime`.

Production: +62/−10, net +52; tests: +20. The added matcher state preserves the shipped overlapping grammar while bounding evaluation; retaining the regex or dropping its quote/escape alternatives would not satisfy that contract. This replaces the incoming +161-line scanner.
