### PR TITLE
refactor(sessions): stream archive queries through Kysely

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-archive.worker.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.ts
@@ -7,7 +7,11 @@ import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { parentPort, workerData } from "node:worker_threads";
 import zlib from "node:zlib";
-import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import {
+  executeSqliteQuerySync,
+  getNodeSqliteKysely,
+  iterateSqliteQuerySync,
+} from "../../infra/kysely-sync.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
@@ -176,18 +180,22 @@ function parseWorkerPlans(value: unknown): TranscriptArchiveWorkerPlan[] | undef
 }
 
 function stageTranscriptArchiveContent(
-  database: import("node:sqlite").DatabaseSync,
+  database: DatabaseSync,
   sessionId: string,
   stagedPath: string,
 ): number {
   const fd = fs.openSync(stagedPath, "wx", 0o600);
   let rowCount = 0;
   try {
-    const query = "SELECT event_json FROM transcript_events WHERE session_id = ? ORDER BY seq ASC";
-    const rows = database /* sqlite-allow-raw: the iterator keeps one row in memory at a time. */
-      .prepare(query)
-      .iterate(sessionId);
-    for (const row of rows) {
+    const db = getNodeSqliteKysely<TranscriptArchiveDatabase>(database);
+    for (const row of iterateSqliteQuerySync(
+      database,
+      db
+        .selectFrom("transcript_events")
+        .select("event_json")
+        .where("session_id", "=", sessionId)
+        .orderBy("seq", "asc"),
+    )) {
       if (typeof row.event_json !== "string") {
         throw new Error(`Invalid transcript event row for ${sessionId}`);
       }


### PR DESCRIPTION
## What Problem This Solves

The transcript archive worker retained a raw SELECT exception because it needed to stream one row at a time. The shared synchronous Kysely iterator now provides that same native streaming boundary, so the exception and its separately maintained SQL are unnecessary.

## Why This Change Was Made

The worker now selects its transcript column through the existing generated table model and shared private native iterator. The same session filter, sequence order, read transaction, newline bytes, private file mode, fsync, descriptor cleanup and archive publication remain in place. No async Kysely execution, eager row array, schema, retention, migration, configuration or public API change was added.

Production +15/-7 (+8) is the typed fluent query and multiline import. Tests are unchanged. The raw BEGIN/COMMIT/ROLLBACK statements remain the intentional SQLite snapshot primitive.

## User Impact

Session deletion and cleanup retain their existing archive bytes, restart behavior and stale-snapshot protection while using the canonical typed query path.

## Evidence

- All 52 existing worker, byte-limit, cleanup-reclamation and Kysely tests passed; the full changed-file gate and full build passed.
- Six actual native before/after cases covered normal streaming, a concurrent append, malformed rows, a native step error, file-write failure and fsync failure. Both versions used one iterator, never all(), retained at most one unwritten row and closed the file/database with the same original error or result. Exact 1,048,686-byte archive content and encoded hashes matched. The shared helper additionally returns the native iterator after a step error; rollback and cleanup remain exact.
- The actual packaged Worker ran with empty execArgv and no instrumentation. It preserved 1,048,840 exact transcript bytes and rejected a stale snapshot.
- Real CLI: `node openclaw.mjs sessions cleanup --store <synthetic>/agents/main/sessions/sessions.json --enforce --json` pruned one old session, retained the current transcript exactly, persisted the canonical archive and published identical compressed bytes. Physical database reopen verified integrity; a second CLI process pruned zero rows. No staging files remained and the isolated state was removed.
- The first offline CLI run explicitly warned that disabled native-harness plugins could not clean their resources. This synthetic fixture exercised only the SQLite/archive owner; the warning was retained, and no external runtime-resource cleanup is claimed.
- Independent Codex review completed four evidence parts with no actionable P2-or-higher findings.

Native proof used Node 24.20.0 on macOS arm64. Worker source SHA256: `50248d16bac654fcc2937eddf27e0e7e0d49ebf1732c3da5f3a2e7f3f779e7df`; built worker SHA256: `2edab15a267a359c5566cde9680b95a7446c10d833e377eb6e0f5c8e137a2b2c`. No peak-RSS, speed or other-platform claim.
