### PR TITLE
refactor(hooks): share validated directory installation

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -671,7 +671,6 @@ src/gateway/watch-node-http.ts
 src/gateway/worker-environments/bootstrap.ts
 src/gateway/worker-environments/inference-runtime.ts
 src/gateway/worker-environments/store.ts
-src/hooks/install.ts
 src/infra/approval-handler-runtime.ts
 src/infra/backup-create.test.ts
 src/infra/command-explainer/extract.ts

--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -396,14 +396,97 @@ async function validateHookDir(hookDir: string): Promise<{ handlerEntry: string 
   return { handlerEntry };
 }
 
+async function installValidatedHookDirectory(
+  params: HookInstallForwardParams,
+  source: {
+    directory: string;
+    label: "hook" | "hook pack";
+    hookEntries: string[];
+    packageName?: string;
+    manifest?: HookPackageManifest;
+    options: {
+      logger: HookInstallLogger;
+      mode: "install" | "update";
+      dryRun: boolean;
+      timeoutMs: number;
+    };
+    metadata: Pick<
+      Extract<InstallHooksResult, { ok: true }>,
+      "hookPackId" | "hooks" | "packageKind" | "version"
+    >;
+  },
+): Promise<InstallHooksResult> {
+  const runtime = await loadHookInstallRuntime();
+  const { logger, mode, dryRun, timeoutMs } = source.options;
+  const { hookPackId, version } = source.metadata;
+  if (params.inspection === "package-kind") {
+    const target = resolveHookInstallTargetPath(hookPackId, params.hooksDir);
+    return target.ok ? { ...target, ...source.metadata } : target;
+  }
+
+  const preparedTarget = await resolvePreparedHookInstallTarget({
+    id: hookPackId,
+    hooksDir: params.hooksDir,
+    requestedMode: mode,
+    alreadyExistsError: (targetDir) =>
+      `${source.label} already exists: ${targetDir} (delete it first)`,
+  });
+  if (!preparedTarget.ok) {
+    return preparedTarget;
+  }
+  const { targetDir, effectiveMode } = preparedTarget.target;
+
+  const policyFailure = await runHookInstallPolicy({
+    hookPackId,
+    hookEntries: source.hookEntries,
+    packageName: source.packageName,
+    version,
+    packageDir: source.directory,
+    forward: params,
+    logger,
+    mode: effectiveMode,
+  });
+  if (policyFailure) {
+    return policyFailure;
+  }
+  if (dryRun) {
+    return { ok: true, ...source.metadata, targetDir };
+  }
+
+  const hasDeps = source.manifest ? hasPackageRuntimeDependencies(source.manifest) : false;
+  const installRes = await runtime.installPackageDir(
+    copyPackageDirInstallTransactionRequest(params, {
+      sourceDir: source.directory,
+      targetDir,
+      mode: effectiveMode,
+      timeoutMs,
+      logger,
+      copyErrorPrefix: `failed to copy ${source.label}`,
+      depsLogMessage: `Installing ${source.label} dependencies…`,
+      hasDeps,
+      sourceHardlinks: hasDeps ? "package-manager" : "reject",
+      beforePersistentApply: params.beforePersistentApply,
+      afterInstall: async (installedDir) => {
+        const failure = await runHookInstalledDependencyPolicy({
+          hookPackId,
+          installedDir,
+          forward: params,
+          logger,
+          mode: effectiveMode,
+        });
+        return failure ?? { ok: true };
+      },
+    }),
+  );
+  // Preserve the attached transaction so the caller can settle payload and config together.
+  return installRes.ok ? { ...installRes, ...source.metadata, targetDir } : installRes;
+}
+
 async function installHookPackageFromDir(
   params: HookPackageInstallParams & { packageKind?: "plugin-capable" },
 ): Promise<InstallHooksResult> {
   const runtime = await loadHookInstallRuntime();
-  const { logger, timeoutMs, mode, dryRun } = runtime.resolveTimedInstallModeOptions(
-    params,
-    defaultLogger,
-  );
+  const options = runtime.resolveTimedInstallModeOptions(params, defaultLogger);
 
   const manifestPath = path.join(params.packageDir, "package.json");
   if (!(await runtime.fileExists(manifestPath))) {
@@ -472,95 +555,20 @@ async function installHookPackageFromDir(
     resolvedHooks.add(hookName);
   }
   const hookNames = [...resolvedHooks];
-
-  if (params.inspection === "package-kind") {
-    const targetDirResult = resolveHookInstallTargetPath(hookPackId, params.hooksDir);
-    if (!targetDirResult.ok) {
-      return targetDirResult;
-    }
-    return {
-      ok: true,
-      hookPackId,
-      hooks: hookNames,
-      packageKind,
-      targetDir: targetDirResult.targetDir,
-      version: typeof manifest.version === "string" ? manifest.version : undefined,
-    };
-  }
-
-  const preparedTarget = await resolvePreparedHookInstallTarget({
-    id: hookPackId,
-    hooksDir: params.hooksDir,
-    requestedMode: mode,
-    alreadyExistsError: (targetDir) => `hook pack already exists: ${targetDir} (delete it first)`,
-  });
-  if (!preparedTarget.ok) {
-    return preparedTarget;
-  }
-  const { targetDir, effectiveMode } = preparedTarget.target;
-
-  const policyFailure = await runHookInstallPolicy({
-    hookPackId,
+  return await installValidatedHookDirectory(params, {
+    directory: params.packageDir,
+    label: "hook pack",
     hookEntries,
-    ...(pkgName ? { packageName: pkgName } : {}),
-    ...(typeof manifest.version === "string" ? { version: manifest.version } : {}),
-    packageDir: params.packageDir,
-    forward: params,
-    logger,
-    mode: effectiveMode,
-  });
-  if (policyFailure) {
-    return policyFailure;
-  }
-
-  if (dryRun) {
-    return {
-      ok: true,
+    packageName: pkgName,
+    manifest,
+    options,
+    metadata: {
       hookPackId,
       hooks: hookNames,
       packageKind,
-      targetDir,
       version: typeof manifest.version === "string" ? manifest.version : undefined,
-    };
-  }
-
-  const hasDeps = hasPackageRuntimeDependencies(manifest);
-  const installRes = await runtime.installPackageDir(
-    copyPackageDirInstallTransactionRequest(params, {
-      sourceDir: params.packageDir,
-      targetDir,
-      mode: effectiveMode,
-      timeoutMs,
-      logger,
-      copyErrorPrefix: "failed to copy hook pack",
-      depsLogMessage: "Installing hook pack dependencies…",
-      hasDeps,
-      sourceHardlinks: hasDeps ? "package-manager" : "reject",
-      beforePersistentApply: params.beforePersistentApply,
-      afterInstall: async (installedDir) => {
-        const dependencyPolicyFailure = await runHookInstalledDependencyPolicy({
-          hookPackId,
-          installedDir,
-          forward: params,
-          logger,
-          mode: effectiveMode,
-        });
-        return dependencyPolicyFailure ?? { ok: true };
-      },
-    }),
-  );
-  if (!installRes.ok) {
-    return installRes;
-  }
-
-  return {
-    ...installRes,
-    hookPackId,
-    hooks: hookNames,
-    packageKind,
-    targetDir,
-    version: typeof manifest.version === "string" ? manifest.version : undefined,
-  };
+    },
+  });
 }
 
 async function installHookFromDir(
@@ -570,8 +578,10 @@ async function installHookFromDir(
   } & HookInstallForwardParams,
 ): Promise<InstallHooksResult> {
   const runtime = await loadHookInstallRuntime();
-  const { logger, mode, dryRun } = runtime.resolveInstallModeOptions(params, defaultLogger);
-
+  const options = {
+    ...runtime.resolveInstallModeOptions(params, defaultLogger),
+    timeoutMs: 120_000,
+  };
   const { handlerEntry } = await validateHookDir(params.hookDir);
   const hookName = await resolveHookNameFromDir(params.hookDir);
   const packageKind = params.packageKind ?? "hook-only";
@@ -593,87 +603,17 @@ async function installHookFromDir(
     };
   }
 
-  if (params.inspection === "package-kind") {
-    const targetDirResult = resolveHookInstallTargetPath(hookName, params.hooksDir);
-    if (!targetDirResult.ok) {
-      return targetDirResult;
-    }
-    return {
-      ok: true,
-      hookPackId: hookName,
-      hooks: [hookName],
-      packageKind,
-      targetDir: targetDirResult.targetDir,
-    };
-  }
-
-  const preparedTarget = await resolvePreparedHookInstallTarget({
-    id: hookName,
-    hooksDir: params.hooksDir,
-    requestedMode: mode,
-    alreadyExistsError: (targetDir) => `hook already exists: ${targetDir} (delete it first)`,
-  });
-  if (!preparedTarget.ok) {
-    return preparedTarget;
-  }
-  const { targetDir, effectiveMode } = preparedTarget.target;
-
-  const policyFailure = await runHookInstallPolicy({
-    hookPackId: hookName,
+  return await installValidatedHookDirectory(params, {
+    directory: params.hookDir,
+    label: "hook",
     hookEntries: [handlerEntry],
-    packageDir: params.hookDir,
-    forward: params,
-    logger,
-    mode: effectiveMode,
-  });
-  if (policyFailure) {
-    return policyFailure;
-  }
-
-  if (dryRun) {
-    return {
-      ok: true,
+    options,
+    metadata: {
       hookPackId: hookName,
       hooks: [hookName],
       packageKind,
-      targetDir,
-    };
-  }
-
-  const installRes = await runtime.installPackageDir(
-    copyPackageDirInstallTransactionRequest(params, {
-      sourceDir: params.hookDir,
-      targetDir,
-      mode: effectiveMode,
-      timeoutMs: 120_000,
-      logger,
-      copyErrorPrefix: "failed to copy hook",
-      hasDeps: false,
-      depsLogMessage: "Installing hook dependencies…",
-      beforePersistentApply: params.beforePersistentApply,
-      afterInstall: async (installedDir) => {
-        const stagedPolicyFailure = await runHookInstalledDependencyPolicy({
-          hookPackId: hookName,
-          installedDir,
-          forward: params,
-          logger,
-          mode: effectiveMode,
-        });
-        return stagedPolicyFailure ?? { ok: true };
-      },
-    }),
-  );
-  if (!installRes.ok) {
-    return installRes;
-  }
-
-  return {
-    ...installRes,
-    hookPackId: hookName,
-    hooks: [hookName],
-    packageKind,
-    targetDir,
-  };
+    },
+  });
 }
 
 /** Install hooks from an archive after extracting and validating the archive root. */
@@ -795,4 +735,3 @@ export async function installHooksFromPath(
     ...forwardParams,
   });
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

The hook installation workflow maintains separate implementations of the same inspection, policy, staging, and publication steps for single hooks and hook packs. Each installation fix must keep both paths aligned, including the lifecycle authority and rollback guarantees used by the unified plugin installer.

## Why This Change Was Made

Keep source validation with its existing owner and share the installation stages after validation. The common flow preserves validation order, error text, option snapshots, package and single-hook timeouts, runtime dependency handling, side-effect-free inspection, both policy stages, and the attached deferred transaction that lets the caller settle payload, install records, and config together.

This removes 61 production lines: 107 added and 168 deleted. Tests are unchanged. The smaller file also allows removal of its max-lines suppression and the corresponding baseline entry.

## User Impact

No intended user-visible behavior change. Copied and linked single hooks, hook packs, archive and npm sources, install/update handling, and rollback retain their existing contracts. Public APIs, configuration, dependencies, and persisted representations are unchanged.

## Evidence

The same 57 tests passed on the unmodified base `cf127a39cb9` and the candidate. These include real installation, config and install-record persistence, discovery, loading, and execution for copied/linked layouts; policy refusal after authority closes; optional dependencies; and deferred rollback across package, single-hook, archive, and npm sources in install and update modes.

```sh
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs src/hooks/install.test.ts src/hooks/install-policy-warning.test.ts src/hooks/hooks-install.test.ts src/hooks/update.test.ts
node scripts/check-changed.mjs -- src/hooks/install.ts
node scripts/check-changed.mjs --dry-run -- src/hooks/install.ts config/max-lines-baseline.txt
pnpm lint:core
pnpm lint:scripts
pnpm format:check --no-error-on-unmatched-pattern -- config/max-lines-baseline.txt src/hooks/install.ts
pnpm build
git diff --check
```

All completed successfully. The baseline-file classification adds tooling, so the full core and scripts lint lanes above supplement the source changed gate. The first changed-gate run identified the now-unused max-lines suppression; the suppression and exact baseline entry were removed, then final gates passed. The build reported no ineffective dynamic import. Independent Codex autoreview through P2 was scoped-clean with no actionable findings.

Live proof used the built CLI with an isolated home, state directory, config, workspace, and loopback gateway on an available port. The driver command was `node /tmp/deslop-hook-install-live.mjs`. It installed synthetic fixtures through `node openclaw.mjs plugins install <source> --force`, adding `--link` for the linked fixture, then ran `node openclaw.mjs gateway run` and `node openclaw.mjs hooks list --json` against that isolated instance.

| Installation path | Actual gateway startup handler | Gateway inventory |
| --- | --- | --- |
| Copied single hook | `deslop-proof-single`: `gateway:startup` recorded | Loadable |
| Copied hook pack | `deslop-proof-pack`: `gateway:startup` recorded | Loadable |
| Linked single hook | `deslop-proof-linked`: `gateway:startup` recorded | Loadable |

All three handlers wrote their expected synthetic marker. The owned gateway stopped after verification, and its port had no remaining listener. This live run covered local installation and actual startup execution; archive/npm transport and deferred rollback were covered by the existing tests. No external provider or channel was used.
