### PR TITLE
fix: retain event-loop stalls across health reads

### DIFF
--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -74,7 +74,9 @@ Remote unauthenticated startup responses contain only `ok` and `status`. Local-d
 
 ### CPU pressure and event-loop delay
 
-Detailed readiness can include an `eventLoop` diagnostic snapshot. Its
+Detailed readiness can include the latest completed `eventLoop` diagnostic
+snapshot. The sampler owns observation windows; health reads do not reset a
+pending measurement. No snapshot is available until the first window completes. Its
 `cpuCoreRatio` measures user and system CPU time across the whole Gateway process,
 including worker and native threads, divided by elapsed wall time. The unit is
 core equivalents: `1` means one CPU core fully occupied over the interval, and

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -572,17 +572,19 @@ measure the main thread separately. See
 These metrics use the existing diagnostics plugin setup and require metrics to
 be active. Each accepted health-monitor window is recorded once, so a later
 healthy readiness result does not erase an earlier high-delay observation.
-Cached reads do not add samples. The process-wide observations carry no request
+Health and scrape reads do not commit or reset samples. The process-wide observations carry no request
 trace context and create no spans or logs, including with a preloaded SDK.
 
-Windows follow existing health readers, normally completing after at least one
-second or sooner for a delay warning. Counts and quantiles describe completed
-windows and their maxima, not individual stalls or the native delay distribution's
+The monitor samples elapsed event-loop intervals every 20 milliseconds and
+completes windows after at least one second or sooner for a delay warning.
+Ordinary window resets preserve the pending interval even when health is read
+before an overdue sample. Counts and quantiles describe completed windows and
+their maxima, not individual stalls or the sampled delay distribution's
 overall p99. Intentional monitor resets discard unfinished windows; collection
 does not backfill periods without an interested exporter. Diagnostic queue drops,
 SDK/export failures, and restarts limit coverage. Use the represented-duration
-counter and exporter/drop telemetry to assess it. Readiness and persistent
-liveness-warning behavior are unchanged. For pull metrics and example queries,
+counter and exporter/drop telemetry to assess it. Readiness decisions and
+persistent liveness-warning thresholds are unchanged. For pull metrics and example queries,
 see [Prometheus event-loop windows](/gateway/prometheus#event-loop-observation-windows).
 
 ### Harness lifecycle

--- a/docs/gateway/prometheus.md
+++ b/docs/gateway/prometheus.md
@@ -191,14 +191,15 @@ it alongside main-thread delay and utilization; see
 
 The event-loop histogram records the maximum delay from each completed Gateway
 health-monitor window. The counter sums the seconds represented by those
-windows. Both are cumulative: a readiness or status read can complete a window
-before Prometheus scrapes it, and a later healthy window does not erase the
-earlier observation. Repeated scrapes and cached health reads add no samples.
+windows. Both are cumulative: a later healthy window does not erase an earlier
+high-delay observation. Readiness, status, and scrape requests consume completed
+observations without advancing or resetting the sampling window.
 
-Windows are defined by existing health readers, not by the scrape interval or a
-new timer. Normally a window completes after at least one second; a delay
-warning can complete it sooner. Histogram counts are window counts, not stall
-counts. Histogram quantiles describe window maxima, not the native event-loop
+The monitor samples elapsed event-loop intervals every 20 milliseconds and
+completes a window after at least one second, or sooner for a delay warning.
+It preserves the pending interval across ordinary window resets, so reading
+health before an overdue sample cannot erase that delay. Histogram counts are window counts, not stall
+counts. Histogram quantiles describe window maxima, not the sampled event-loop
 delay distribution or its overall p99. These metrics have no request labels or
 trace attribution and do not identify the JavaScript function that blocked.
 
@@ -207,7 +208,7 @@ metrics exporter is running; it does not backfill earlier windows. Intentional
 monitor resets discard the unfinished window. Diagnostic queue drops, the
 exporter's series cap, and process restarts can also lose observations. Watch
 the existing drop counters and the represented-duration counter when assessing
-coverage. Readiness decisions and persistent liveness warnings are unchanged.
+coverage. Readiness decisions and persistent liveness-warning thresholds are unchanged.
 
 ## Label policy
 

--- a/src/gateway/server-http.event-loop-health.test.ts
+++ b/src/gateway/server-http.event-loop-health.test.ts
@@ -1,0 +1,110 @@
+import { get } from "node:http";
+import { performance } from "node:perf_hooks";
+import { describe, expect, it } from "vitest";
+import { AUTH_NONE, withGatewayServer } from "./server-http.test-harness.js";
+import { createGatewayEventLoopHealthMonitor } from "./server/event-loop-health.js";
+
+async function readJson(url: string): Promise<Record<string, unknown>> {
+  const { statusCode, body: responseBody } = await new Promise<{
+    statusCode: number | undefined;
+    body: string;
+  }>((resolve, reject) => {
+    const request = get(url, { agent: false }, (response) => {
+      let body = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      response.once("end", () => {
+        resolve({ statusCode: response.statusCode, body });
+      });
+    });
+    request.once("error", reject);
+  });
+  expect(statusCode).toBe(200);
+  return JSON.parse(responseBody);
+}
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+describe("Gateway HTTP event-loop sampling", () => {
+  it("retains a blocked request interval when readiness is read before the sampler resumes", async () => {
+    const monitor = createGatewayEventLoopHealthMonitor();
+    const startedAt = Date.now();
+    let blockNextRead = false;
+    let blockedMs = 0;
+    try {
+      await withGatewayServer({
+        prefix: "event-loop-http-owner",
+        resolvedAuth: AUTH_NONE,
+        overrides: {
+          getReadiness: () => {
+            if (blockNextRead) {
+              blockNextRead = false;
+              const start = performance.now();
+              while (performance.now() - start < 1_200) {
+                // Reproduce synchronous request work before the overdue timer can run.
+              }
+              blockedMs = performance.now() - start;
+              const beforePendingSample = monitor.snapshot();
+              for (let index = 0; index < 100; index++) {
+                expect(monitor.snapshot()).toBe(beforePendingSample);
+              }
+            }
+            return {
+              ready: true,
+              failing: [],
+              uptimeMs: Date.now() - startedAt,
+              eventLoop: monitor.snapshot(),
+            };
+          },
+        },
+        run: async (server) => {
+          await new Promise<void>((resolve) => {
+            server.listen(0, "127.0.0.1", resolve);
+          });
+          try {
+            const address = server.address();
+            if (!address || typeof address === "string") {
+              throw new Error("expected a TCP listener");
+            }
+            const url = `http://127.0.0.1:${address.port}/readyz`;
+            await delay(1_100);
+            const initial = await readJson(url);
+            expect(initial.ready).toBe(true);
+            blockNextRead = true;
+            await readJson(url);
+            expect(blockedMs).toBeGreaterThanOrEqual(1_200);
+            await delay(100);
+            const after = await readJson(url);
+            expect(after).toMatchObject({
+              ready: true,
+              eventLoop: {
+                degraded: true,
+                reasons: expect.arrayContaining(["event_loop_delay"]),
+                delayMaxMs: expect.any(Number),
+              },
+            });
+            expect((after.eventLoop as { delayMaxMs: number }).delayMaxMs).toBeGreaterThanOrEqual(
+              1_000,
+            );
+            await delay(1_100);
+            const recovered = await readJson(url);
+            expect(recovered).toMatchObject({ ready: true, eventLoop: { degraded: false } });
+          } finally {
+            server.closeAllConnections();
+            await new Promise<void>((resolve, reject) => {
+              server.close((error) => (error ? reject(error) : resolve()));
+            });
+          }
+        },
+      });
+    } finally {
+      monitor.stop();
+    }
+    expect(monitor.snapshot()).toBeUndefined();
+  });
+});

--- a/src/gateway/server/event-loop-health.test.ts
+++ b/src/gateway/server/event-loop-health.test.ts
@@ -1,5 +1,5 @@
-// Event-loop health tests cover delay, CPU, and utilization degradation classification.
-import type { monitorEventLoopDelay, performance } from "node:perf_hooks";
+// Event-loop health tests cover sampling ownership and delay/load classification.
+import type { performance } from "node:perf_hooks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getInternalDiagnosticEventSequence,
@@ -22,271 +22,187 @@ import {
 import { registerSkillUsageTracking } from "../../skills/workshop/curator.js";
 import { createGatewayEventLoopHealthMonitor } from "./event-loop-health.js";
 
-/**
- * Event-loop health regression tests for delay, CPU, and utilization signals.
- */
 type CpuUsage = ReturnType<typeof process.cpuUsage>;
-type DelayMonitor = ReturnType<typeof monitorEventLoopDelay>;
 type EventLoopUtilization = ReturnType<typeof performance.eventLoopUtilization>;
-type GatewayEventLoopHealthMonitorDeps = NonNullable<
-  Parameters<typeof createGatewayEventLoopHealthMonitor>[0]
->;
+const monitors: ReturnType<typeof createGatewayEventLoopHealthMonitor>[] = [];
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+});
+afterEach(() => {
+  for (const monitor of monitors.splice(0)) {
+    monitor.stop();
+  }
+  vi.useRealTimers();
+});
 
 function createMonitorHarness(params?: { cpuMsPerWallMs?: number; utilization?: number }) {
-  const startedAt = 10_000;
-  let nowMs = startedAt;
-  let delayP99Ms = 0;
-  let delayMaxMs = 0;
-  const cpuMsPerWallMs = params?.cpuMsPerWallMs ?? 1;
-  const utilization = params?.utilization ?? 1;
-  const delayMonitor = {
-    enable: vi.fn(),
-    disable: vi.fn(),
-    reset: vi.fn(() => {
-      delayP99Ms = 0;
-      delayMaxMs = 0;
-    }),
-    percentile: vi.fn(() => delayP99Ms * 1_000_000),
-    get max() {
-      return delayMaxMs * 1_000_000;
-    },
-  } as unknown as DelayMonitor;
+  let nowMs = 10_000;
+  const cpuMsPerWallMs = params?.cpuMsPerWallMs ?? 0.1;
+  const utilization = params?.utilization ?? 0.2;
   const cpuUsage = vi.fn((previous?: CpuUsage) => {
-    const current = {
-      user: Math.round(nowMs * cpuMsPerWallMs * 1_000),
-      system: 0,
-    };
-    if (!previous) {
-      return current;
-    }
-    return {
-      user: current.user - previous.user,
-      system: current.system - previous.system,
-    };
-  }) as NonNullable<GatewayEventLoopHealthMonitorDeps["cpuUsage"]>;
+    const current = { user: Math.round(nowMs * cpuMsPerWallMs * 1_000), system: 0 };
+    return previous
+      ? { user: current.user - previous.user, system: current.system - previous.system }
+      : current;
+  });
   const eventLoopUtilization = vi.fn(
-    (current?: EventLoopUtilization, previous?: EventLoopUtilization) => {
-      if (!current || !previous) {
-        return { idle: 0, active: nowMs, utilization };
-      }
-      return {
-        idle: 0,
-        active: current.active - previous.active,
-        utilization,
-      };
-    },
-  ) as NonNullable<GatewayEventLoopHealthMonitorDeps["eventLoopUtilization"]>;
+    (current?: EventLoopUtilization, previous?: EventLoopUtilization) => ({
+      idle: 0,
+      active: current && previous ? current.active - previous.active : nowMs,
+      utilization,
+    }),
+  );
   const monitor = createGatewayEventLoopHealthMonitor({
     now: () => nowMs,
     cpuUsage,
     eventLoopUtilization,
-    createDelayMonitor: () => delayMonitor,
   });
-
+  monitors.push(monitor);
+  const sample = (elapsedMs = 20) => {
+    nowMs += elapsedMs;
+    vi.advanceTimersByTime(20);
+  };
   return {
     monitor,
-    delayMonitor,
     cpuUsage,
     eventLoopUtilization,
-    setNow: (value: number) => {
-      nowMs = startedAt + value;
+    sample,
+    samples: (count: number, elapsedMs = 20) => {
+      for (let index = 0; index < count; index++) {
+        sample(elapsedMs);
+      }
     },
-    setDelay: (value: { p99Ms?: number; maxMs?: number }) => {
-      delayP99Ms = value.p99Ms ?? delayP99Ms;
-      delayMaxMs = value.maxMs ?? delayMaxMs;
+    elapseWithoutSampling: (elapsedMs: number) => {
+      nowMs += elapsedMs;
     },
   };
 }
 
-function expectSnapshotFields(snapshot: unknown, expected: Record<string, unknown>) {
-  if (!snapshot || typeof snapshot !== "object") {
-    throw new Error("expected event loop health snapshot");
-  }
-  const actual = snapshot as Record<string, unknown>;
-  for (const [key, value] of Object.entries(expected)) {
-    expect(actual[key]).toEqual(value);
-  }
-  return actual;
-}
-
-function expectSaturatedLoadSnapshot(snapshot: unknown) {
-  return expectSnapshotFields(snapshot, {
-    degraded: true,
-    degradedSinceMs: 0,
-    reasons: ["event_loop_utilization", "cpu"],
-    intervalMs: 1_000,
-    delayP99Ms: 30,
-    delayMaxMs: 0,
-    utilization: 1,
-    cpuCoreRatio: 1,
-  });
-}
-
 describe("createGatewayEventLoopHealthMonitor", () => {
-  it("waits for delay co-evidence before reporting load-only saturation", () => {
-    const harness = createMonitorHarness();
-
-    harness.setNow(42);
-    expect(harness.monitor.snapshot()).toBeUndefined();
+  it("does not turn reads without samples into healthy observations", () => {
+    const harness = createMonitorHarness({ cpuMsPerWallMs: 1, utilization: 1 });
+    harness.elapseWithoutSampling(1_200);
+    for (let index = 0; index < 100; index++) {
+      expect(harness.monitor.snapshot()).toBeUndefined();
+      expect(harness.monitor.persistentDegradationSnapshot()).toBeUndefined();
+    }
     expect(harness.cpuUsage).toHaveBeenCalledTimes(1);
     expect(harness.eventLoopUtilization).toHaveBeenCalledTimes(1);
+    harness.sample();
+    expect(harness.monitor.snapshot()).toMatchObject({
+      degraded: true,
+      intervalMs: 1_220,
+      delayMaxMs: 1_220.5,
+      reasons: ["event_loop_delay", "event_loop_utilization", "cpu"],
+    });
+  });
 
-    harness.setNow(1_000);
-    expectSnapshotFields(harness.monitor.snapshot(), {
+  it("waits for delay co-evidence before reporting load saturation", () => {
+    const harness = createMonitorHarness({ cpuMsPerWallMs: 1, utilization: 1 });
+    harness.samples(49);
+    expect(harness.monitor.snapshot()).toBeUndefined();
+    harness.sample();
+    expect(harness.monitor.snapshot()).toMatchObject({
       degraded: false,
-      degradedSinceMs: null,
       reasons: [],
       intervalMs: 1_000,
-      delayP99Ms: 0,
-      delayMaxMs: 0,
+      delayMaxMs: 20,
       utilization: 1,
       cpuCoreRatio: 1,
     });
   });
 
-  it("reports CPU and utilization saturation when delay co-evidence is present", () => {
-    const harness = createMonitorHarness();
-    harness.setDelay({ p99Ms: 30 });
-    harness.setNow(1_000);
-
-    expectSaturatedLoadSnapshot(harness.monitor.snapshot());
-  });
-
-  it("does not wait for the sustained sample window before reporting event-loop delay", () => {
-    const harness = createMonitorHarness();
-    harness.setDelay({ maxMs: 1_500 });
-    harness.setNow(42);
-
-    expectSnapshotFields(harness.monitor.snapshot(), {
+  it.each([
+    { cpuMsPerWallMs: 1, utilization: 0.2, reasons: ["cpu"] },
+    { cpuMsPerWallMs: 0.1, utilization: 1, reasons: ["event_loop_utilization"] },
+    { cpuMsPerWallMs: 1, utilization: 1, reasons: ["event_loop_utilization", "cpu"] },
+  ])("preserves load classification with delay co-evidence: $reasons", (params) => {
+    const harness = createMonitorHarness(params);
+    harness.samples(34, 30);
+    expect(harness.monitor.snapshot()).toMatchObject({
       degraded: true,
-      reasons: ["event_loop_delay"],
-      intervalMs: 42,
-      delayP99Ms: 0,
-      delayMaxMs: 1_500,
+      degradedSinceMs: 0,
+      intervalMs: 1_020,
+      delayP99Ms: 30,
+      delayMaxMs: 30,
+      reasons: params.reasons,
     });
   });
 
-  it("returns a non-degraded snapshot when the sustained load sample is healthy", () => {
-    const harness = createMonitorHarness({ cpuMsPerWallMs: 0.1, utilization: 0.2 });
-    harness.setNow(1_000);
+  it.each([false, true])(
+    "preserves overdue delay across reads with prior window=%s",
+    (priorWindow) => {
+      const harness = createMonitorHarness();
+      harness.samples(priorWindow ? 50 : 4);
+      const previous = harness.monitor.snapshot();
+      harness.elapseWithoutSampling(1_200);
+      for (let index = 0; index < 100; index++) {
+        expect(harness.monitor.snapshot()).toBe(previous);
+      }
+      harness.sample();
+      const current = harness.monitor.snapshot();
+      expect(current?.delayMaxMs).toBeGreaterThanOrEqual(1_200);
+      expect(current).toMatchObject({ degraded: true, reasons: ["event_loop_delay"] });
+      expect(harness.monitor.snapshot()).toBe(current);
+    },
+  );
 
-    expectSnapshotFields(harness.monitor.snapshot(), {
+  it("retains completed observations until the next sampling window", () => {
+    const harness = createMonitorHarness();
+    harness.samples(50);
+    const first = harness.monitor.snapshot();
+    expect(first).toMatchObject({ degraded: false, intervalMs: 1_000 });
+    expect(harness.cpuUsage).toHaveBeenCalledTimes(3);
+    harness.samples(12);
+    expect(harness.monitor.snapshot()).toBe(first);
+    expect(harness.cpuUsage).toHaveBeenCalledTimes(3);
+    harness.samples(38);
+    expect(harness.monitor.snapshot()).not.toBe(first);
+    expect(harness.monitor.snapshot()).toMatchObject({ intervalMs: 1_000 });
+  });
+
+  it("tracks persistent degradation at completed samples and clears on recovery", () => {
+    const harness = createMonitorHarness();
+    harness.sample(1_500);
+    expect(harness.monitor.snapshot()).toMatchObject({ degraded: true, degradedSinceMs: 0 });
+    harness.sample(59_999);
+    expect(harness.monitor.persistentDegradationSnapshot()).toBeUndefined();
+    harness.sample(1_000);
+    expect(harness.monitor.persistentDegradationSnapshot()).toMatchObject({
+      degraded: true,
+      degradedSinceMs: 60_999,
+    });
+    harness.samples(50);
+    expect(harness.monitor.snapshot()).toMatchObject({ degraded: false, degradedSinceMs: null });
+    expect(harness.monitor.persistentDegradationSnapshot()).toBeUndefined();
+  });
+
+  it("discards the pending interval and rate baselines only for an explicit host-thaw reset", () => {
+    const harness = createMonitorHarness();
+    harness.sample(1_500);
+    harness.elapseWithoutSampling(90_000);
+    harness.monitor.reset();
+    expect(harness.monitor.snapshot()).toBeUndefined();
+    harness.samples(50);
+    expect(harness.monitor.snapshot()).toMatchObject({
       degraded: false,
-      degradedSinceMs: null,
-      reasons: [],
       intervalMs: 1_000,
-      utilization: 0.2,
+      delayMaxMs: 20,
       cpuCoreRatio: 0.1,
     });
   });
 
-  it("tracks continuous degradation and clears it on the first healthy snapshot", () => {
-    const harness = createMonitorHarness({ cpuMsPerWallMs: 0.1, utilization: 0.2 });
-    harness.setNow(1_000);
-    expectSnapshotFields(harness.monitor.snapshot(), {
-      degraded: false,
-      degradedSinceMs: null,
-    });
-
-    harness.setDelay({ maxMs: 1_500 });
-    harness.setNow(2_000);
-    expectSnapshotFields(harness.monitor.snapshot(), {
-      degraded: true,
-      degradedSinceMs: 0,
-    });
-
-    harness.setDelay({ maxMs: 1_500 });
-    harness.setNow(3_500);
-    expectSnapshotFields(harness.monitor.snapshot(), {
-      degraded: true,
-      degradedSinceMs: 1_500,
-    });
-
-    harness.setNow(4_500);
-    expectSnapshotFields(harness.monitor.snapshot(), {
-      degraded: false,
-      degradedSinceMs: null,
-    });
-  });
-
-  it("exposes persistent degradation only after the warning threshold", () => {
-    const harness = createMonitorHarness({ cpuMsPerWallMs: 0.1, utilization: 0.2 });
-    harness.setDelay({ maxMs: 1_500 });
-    harness.setNow(1_000);
-    expect(harness.monitor.persistentDegradationSnapshot()).toBeUndefined();
-
-    harness.setDelay({ maxMs: 1_500 });
-    harness.setNow(60_999);
-    expect(harness.monitor.persistentDegradationSnapshot()).toBeUndefined();
-
-    harness.setDelay({ maxMs: 1_500 });
-    harness.setNow(61_000);
-    expectSnapshotFields(harness.monitor.persistentDegradationSnapshot(), {
-      degraded: true,
-      degradedSinceMs: 60_000,
-    });
-  });
-
-  it("keeps rate baselines and the last snapshot until a full sample window is available", () => {
-    const harness = createMonitorHarness({ cpuMsPerWallMs: 0.1, utilization: 0.2 });
-    harness.setNow(1_000);
-    const first = harness.monitor.snapshot();
-
-    expectSnapshotFields(first, { intervalMs: 1_000 });
-    expect(harness.cpuUsage).toHaveBeenCalledTimes(3);
-    expect(harness.eventLoopUtilization).toHaveBeenCalledTimes(3);
-
-    harness.setNow(1_250);
-    expect(harness.monitor.snapshot()).toBe(first);
-    expect(harness.cpuUsage).toHaveBeenCalledTimes(3);
-    expect(harness.eventLoopUtilization).toHaveBeenCalledTimes(3);
-
-    harness.setNow(2_000);
-    const second = harness.monitor.snapshot();
-
-    expectSnapshotFields(second, { intervalMs: 1_000 });
-    expect(second).not.toBe(first);
-  });
-
-  it("preserves moderate delay co-evidence across rapid probes until the load window completes", () => {
+  it("releases its only timer and cached observation when stopped", () => {
     const harness = createMonitorHarness();
-    harness.setNow(1_000);
-    const first = harness.monitor.snapshot();
-
-    harness.setDelay({ p99Ms: 30 });
-    harness.setNow(1_250);
-    expect(harness.monitor.snapshot()).toBe(first);
-
-    harness.setNow(2_000);
-    expectSaturatedLoadSnapshot(harness.monitor.snapshot());
-  });
-
-  it("clears the cached snapshot when stopped", () => {
-    const harness = createMonitorHarness({ cpuMsPerWallMs: 0.1, utilization: 0.2 });
-    harness.setNow(1_000);
-
-    expectSnapshotFields(harness.monitor.snapshot(), { degraded: false, intervalMs: 1_000 });
-
-    harness.setNow(1_250);
+    expect(vi.getTimerCount()).toBe(1);
+    harness.samples(50);
     harness.monitor.stop();
-
-    expect(harness.delayMonitor["disable"]).toHaveBeenCalledTimes(1);
-    expect(harness.monitor.snapshot()).toBeUndefined();
-  });
-
-  it("resets delay and rate baselines after a host thaw", () => {
-    const harness = createMonitorHarness({ cpuMsPerWallMs: 0.1, utilization: 0.2 });
-    harness.setDelay({ maxMs: 90_000 });
-    harness.setNow(90_000);
-
+    expect(vi.getTimerCount()).toBe(0);
+    harness.samples(100);
     harness.monitor.reset();
-    harness.setNow(91_000);
-
-    expectSnapshotFields(harness.monitor.snapshot(), {
-      degraded: false,
-      intervalMs: 1_000,
-      delayMaxMs: 0,
-    });
+    expect(harness.monitor.snapshot()).toBeUndefined();
+    expect(vi.getTimerCount()).toBe(0);
   });
 });
 
@@ -297,48 +213,37 @@ describe("event-loop measurement telemetry", () => {
     resetDiagnosticEventsForTest();
   });
 
-  it("records completed windows once while later readiness recovers and cached readers reuse them", async () => {
-    const harness = createMonitorHarness({ cpuMsPerWallMs: 0.1, utilization: 0.2 });
+  it("records each sampling window once without needing a reader or inheriting reader context", async () => {
+    const harness = createMonitorHarness();
     const events: DiagnosticEventPayload[] = [];
     onInternalDiagnosticEvent((event) => events.push(event), {
       include: ["gateway.event_loop.sample"],
     });
     const readerTrace = createDiagnosticTraceContext();
-    harness.setDelay({ maxMs: 1_500 });
-    harness.setNow(1_000);
-    const early = runWithDiagnosticTraceContext(readerTrace, () => {
-      const snapshot = harness.monitor.snapshot();
+    runWithDiagnosticTraceContext(readerTrace, () => {
+      harness.sample(1_500);
+      const first = harness.monitor.snapshot();
+      for (let index = 0; index < 10; index++) {
+        expect(harness.monitor.snapshot()).toBe(first);
+      }
       expect(getActiveDiagnosticTraceContext()?.traceId).toBe(readerTrace.traceId);
-      return snapshot;
     });
-    expectSnapshotFields(early, { degraded: true, delayMaxMs: 1_500 });
-    harness.setNow(1_250);
-    expect(harness.monitor.snapshot()).toBe(early);
-    harness.setNow(2_000);
-    const recovered = harness.monitor.snapshot();
-    expectSnapshotFields(recovered, { degraded: false, delayMaxMs: 0 });
-    expect(harness.monitor.snapshot()).toBe(recovered);
-    expect(events).toEqual([]);
-
+    harness.samples(50);
     await waitForDiagnosticEventsDrained();
-
-    expect(events).toHaveLength(2);
     expect(events).toMatchObject([
-      { type: "gateway.event_loop.sample", intervalMs: 1_000, delayMaxMs: 1_500 },
-      { type: "gateway.event_loop.sample", intervalMs: 1_000, delayMaxMs: 0 },
+      { type: "gateway.event_loop.sample", intervalMs: 1_500, delayMaxMs: 1_500.5 },
+      { type: "gateway.event_loop.sample", intervalMs: 1_000, delayMaxMs: 20 },
     ]);
     expect(events.map((event) => event.trace)).toEqual([undefined, undefined]);
   });
 
-  it("keeps diagnostics-disabled readiness sampling unchanged without emitting telemetry", async () => {
+  it("keeps diagnostics-disabled sampling active without emitting telemetry", async () => {
     const listener = vi.fn();
     onInternalDiagnosticEvent(listener, { include: ["gateway.event_loop.sample"] });
     setDiagnosticsEnabledForProcess(false);
     const harness = createMonitorHarness();
-    harness.setDelay({ maxMs: 1_500 });
-    harness.setNow(1_000);
-
-    expectSnapshotFields(harness.monitor.snapshot(), { degraded: true, delayMaxMs: 1_500 });
+    harness.sample(1_500);
+    expect(harness.monitor.snapshot()?.reasons).toEqual(["event_loop_delay"]);
     await waitForDiagnosticEventsDrained();
     expect(listener).not.toHaveBeenCalled();
     expect(getInternalDiagnosticEventSequence()).toBe(0);
@@ -359,13 +264,12 @@ describe("event-loop measurement telemetry", () => {
       },
     },
     { name: "skill tracking", subscribe: () => registerSkillUsageTracking() },
-  ])("does not produce exporter samples with only $name", async ({ subscribe }) => {
+  ])("does not emit exporter windows with only $name", async ({ subscribe }) => {
     const unsubscribe = subscribe();
     try {
       const harness = createMonitorHarness();
-      harness.setDelay({ maxMs: 1_500 });
-      harness.setNow(1_000);
-      expectSnapshotFields(harness.monitor.snapshot(), { delayMaxMs: 1_500 });
+      harness.sample(1_500);
+      expect(harness.monitor.snapshot()?.reasons).toEqual(["event_loop_delay"]);
       await waitForDiagnosticEventsDrained();
       expect(getInternalDiagnosticEventSequence()).toBe(0);
     } finally {
@@ -373,23 +277,21 @@ describe("event-loop measurement telemetry", () => {
     }
   });
 
-  it("does not turn intentional reset or stop into extra completed windows", async () => {
+  it("does not turn reset, stop, or repeated reads into completed windows", async () => {
     const events: DiagnosticEventPayload[] = [];
     onInternalDiagnosticEvent((event) => events.push(event), {
       include: ["gateway.event_loop.sample"],
     });
-    const harness = createMonitorHarness({ cpuMsPerWallMs: 0.1, utilization: 0.2 });
-    harness.setDelay({ maxMs: 1_500 });
-    harness.setNow(1_000);
+    const harness = createMonitorHarness();
+    harness.samples(4);
+    harness.elapseWithoutSampling(1_500);
     harness.monitor.reset();
-    harness.setNow(2_000);
-    expectSnapshotFields(harness.monitor.snapshot(), { degraded: false, delayMaxMs: 0 });
+    harness.samples(50);
     harness.monitor.stop();
     expect(harness.monitor.snapshot()).toBeUndefined();
     await waitForDiagnosticEventsDrained();
     expect(events).toMatchObject([
-      { type: "gateway.event_loop.sample", intervalMs: 1_000, delayMaxMs: 0 },
+      { type: "gateway.event_loop.sample", intervalMs: 1_000, delayMaxMs: 20 },
     ]);
-    expect(events).toHaveLength(1);
   });
 });

--- a/src/gateway/server/event-loop-health.ts
+++ b/src/gateway/server/event-loop-health.ts
@@ -1,5 +1,5 @@
 // Event-loop health monitor samples delay, utilization, and CPU pressure for gateway readiness snapshots.
-import { monitorEventLoopDelay, performance } from "node:perf_hooks";
+import { createHistogram, performance, type RecordableHistogram } from "node:perf_hooks";
 import { hasInternalDiagnosticEventInterest } from "../../infra/diagnostic-event-listener-presence.js";
 import {
   areDiagnosticsEnabledForProcess,
@@ -16,9 +16,7 @@ const PERSISTENT_DEGRADATION_WARN_AFTER_MS = 60_000;
 const LOAD_DEGRADATION_DELAY_COEVIDENCE_MS = 25;
 const SUSTAINED_LOAD_SAMPLE_MIN_INTERVAL_MS = 1_000;
 
-type EventLoopDelayMonitor = ReturnType<typeof monitorEventLoopDelay>;
 type EventLoopUtilization = ReturnType<typeof performance.eventLoopUtilization>;
-type CpuUsage = ReturnType<typeof process.cpuUsage>;
 
 type GatewayEventLoopHealthReason = "event_loop_delay" | "event_loop_utilization" | "cpu";
 
@@ -42,13 +40,10 @@ type GatewayEventLoopHealthMonitor = {
 
 type EventLoopUtilizationReader = typeof performance.eventLoopUtilization;
 
-type EventLoopDelayMonitorFactory = (resolutionMs: number) => EventLoopDelayMonitor;
-
 type GatewayEventLoopHealthMonitorDeps = {
   now?: () => number;
   cpuUsage?: typeof process.cpuUsage;
   eventLoopUtilization?: EventLoopUtilizationReader;
-  createDelayMonitor?: EventLoopDelayMonitorFactory;
 };
 
 type GatewayEventLoopHealthMetrics = Pick<
@@ -108,39 +103,40 @@ export function createGatewayEventLoopHealthMonitor(
   const readCpuUsage = deps.cpuUsage ?? process.cpuUsage.bind(process);
   const readEventLoopUtilization =
     deps.eventLoopUtilization ?? performance.eventLoopUtilization.bind(performance);
-  const createDelayMonitor =
-    deps.createDelayMonitor ??
-    ((resolutionMs: number) => monitorEventLoopDelay({ resolution: resolutionMs }));
-  let monitor: EventLoopDelayMonitor | null = null;
-  let lastWallAt: number | null = nowMs();
-  let lastCpuUsage: CpuUsage | null = readCpuUsage();
-  let lastEventLoopUtilization: EventLoopUtilization | null = readEventLoopUtilization();
+  let histogram: RecordableHistogram | null = null;
+  let lastSampleAt = nowMs();
+  let lastWallAt = lastSampleAt;
+  let lastCpuUsage = readCpuUsage();
+  let lastEventLoopUtilization: EventLoopUtilization = readEventLoopUtilization();
   let lastSnapshot: GatewayEventLoopHealth | undefined;
   let firstDegradedAtMs: number | null = null;
 
   try {
-    monitor = createDelayMonitor(EVENT_LOOP_MONITOR_RESOLUTION_MS);
-    monitor.enable();
-    monitor.reset();
+    // Match Node's interval delay histogram range and precision.
+    histogram = createHistogram({ lowest: 1_000n, highest: 2n ** 63n - 1n, figures: 3 });
   } catch {
-    monitor = null;
+    histogram = null;
   }
 
-  const snapshot = (): GatewayEventLoopHealth | undefined => {
-    if (!monitor || !lastCpuUsage || !lastEventLoopUtilization || lastWallAt === null) {
-      return undefined;
+  const sample = () => {
+    if (!histogram) {
+      return;
     }
 
     const now = nowMs();
+    // A window reset must not erase the pending sample's monotonic anchor.
+    // Native interval histograms reset that anchor before an overdue callback runs.
+    histogram.record(BigInt(Math.max(1, Math.round((now - lastSampleAt) * 1_000_000))));
+    lastSampleAt = now;
     const intervalMs = Math.max(1, now - lastWallAt);
-    const delayP99Ms = nanosecondsToMilliseconds(monitor.percentile(99));
-    const delayMaxMs = nanosecondsToMilliseconds(monitor.max);
-    const hasDelayWarning =
-      delayP99Ms >= EVENT_LOOP_DELAY_WARN_MS || delayMaxMs >= EVENT_LOOP_DELAY_WARN_MS;
-
-    if (!hasDelayWarning && intervalMs < SUSTAINED_LOAD_SAMPLE_MIN_INTERVAL_MS) {
-      return lastSnapshot;
+    const delayMaxMs = nanosecondsToMilliseconds(histogram.max);
+    if (
+      delayMaxMs < EVENT_LOOP_DELAY_WARN_MS &&
+      intervalMs < SUSTAINED_LOAD_SAMPLE_MIN_INTERVAL_MS
+    ) {
+      return;
     }
+    const delayP99Ms = nanosecondsToMilliseconds(histogram.percentile(99));
 
     const cpuUsage = readCpuUsage(lastCpuUsage);
     const currentEventLoopUtilization = readEventLoopUtilization();
@@ -175,13 +171,13 @@ export function createGatewayEventLoopHealthMonitor(
       cpuCoreRatio,
     };
 
-    monitor.reset();
+    histogram.reset();
     lastWallAt = now;
     lastCpuUsage = readCpuUsage();
     lastEventLoopUtilization = currentEventLoopUtilization;
     lastSnapshot = health;
 
-    // Publish only committed windows. The process-wide sample is not caused by its reader.
+    // Publish once at the sampling owner; readers never reset or commit observations.
     if (
       areDiagnosticsEnabledForProcess() &&
       hasInternalDiagnosticEventInterest("gateway.event_loop.sample")
@@ -190,13 +186,15 @@ export function createGatewayEventLoopHealthMonitor(
         emitInternalDiagnosticEvent({ type: "gateway.event_loop.sample", intervalMs, delayMaxMs }),
       );
     }
-
-    return health;
   };
 
+  const timer = histogram ? setInterval(sample, EVENT_LOOP_MONITOR_RESOLUTION_MS) : undefined;
+  timer?.unref();
+
   const reset = () => {
-    monitor?.reset();
-    lastWallAt = nowMs();
+    histogram?.reset();
+    lastSampleAt = nowMs();
+    lastWallAt = lastSampleAt;
     lastCpuUsage = readCpuUsage();
     lastEventLoopUtilization = readEventLoopUtilization();
     lastSnapshot = undefined;
@@ -204,11 +202,10 @@ export function createGatewayEventLoopHealthMonitor(
   };
 
   return {
-    snapshot,
-    // The diagnostic heartbeat is the timer owner. This filtered pull keeps
-    // persistence policy with the monitor without adding another gateway loop.
+    snapshot: () => lastSnapshot,
+    // The heartbeat consumes the sampler's snapshot without advancing its window.
     persistentDegradationSnapshot: () => {
-      const current = snapshot();
+      const current = lastSnapshot;
       return current?.degradedSinceMs != null &&
         current.degradedSinceMs >= PERSISTENT_DEGRADATION_WARN_AFTER_MS
         ? current
@@ -216,11 +213,8 @@ export function createGatewayEventLoopHealthMonitor(
     },
     reset,
     stop: () => {
-      monitor?.disable();
-      monitor = null;
-      lastWallAt = null;
-      lastCpuUsage = null;
-      lastEventLoopUtilization = null;
+      clearInterval(timer);
+      histogram = null;
       lastSnapshot = undefined;
       firstDegradedAtMs = null;
     },


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Gateway health and exported event-loop metrics can report a healthy, near-zero delay after a synchronous stall when a readiness or RPC reader runs before the overdue sampling callback. The failing reproduction blocks for 1.2 seconds and reads health repeatedly before timers resume; the old monitor permanently loses the long interval.

## Why This Change Was Made

Node's interval histogram resets both its distribution and its previous-sample timestamp. A reader that commits and resets a window can therefore erase an interval that the native timer has not recorded yet. One unreferenced 20 ms sampler now records elapsed time in Node's recordable histogram before committing a window, keeping its monotonic anchor outside distribution resets. Readiness, RPC, heartbeat, and exporters consume the completed observation; readers no longer commit or reset it.

The existing delay/load thresholds, whole-process CPU meaning, metric fields, host-thaw reset, and stop lifecycle remain unchanged. Windows normally complete after at least one second, or immediately after the sampler records a delay warning. p99 is computed only on commit: for the same nonempty HDR histogram it cannot exceed max, so max alone can decide whether to commit early. Production changes are +36/-42 (net -6), removing the native interval monitor and its test-only factory seam.

## User Impact

Operators can see stalls that were previously erased by health reads, with one diagnostic publication per completed observation. Health reads reuse the latest completed window, and the existing distinction between diagnostic degradation and readiness remains intact. Documentation now describes sampler-completed windows.

## Evidence

- Exact pre-fix and stable v2026.9.1 code reproduced the loss on Node 24.15.0. The fixed owner passes on Node 24.15.0 and 26.5.0, including both first-window and prior-window sequences with 100 reads before the pending timer.
- A real loopback TCP request through the Gateway HTTP server and readiness router fails against the old owner and passes against the fix: the 1.2-second blocked request is retained, readiness remains true, and a later healthy window recovers. This exercises the actual HTTP router with isolated test configuration; it is not a packaged Gateway/provider or production replay.
- Focused coverage exercises reader independence, load co-evidence, persistence, host-thaw reset, stop, diagnostic-interest gating, trace isolation, and exactly-once publication. Final typed lint passed and both focused files passed all 20 tests, including the real HTTP case.
- Direct Node 24 source/API inspection confirms supported recordable-histogram bounds, reset behavior, timer unref, and HDR percentile/max ordering; 72 boundary/sample-count cases preserve the early-commit predicate. The original native loss sequences are retained as failing evidence.
- Paired five-second observer measurements on a loaded shared host put the refined sampler near 5.47–5.49 CPU ms/s versus 2.51–2.73 for the native monitor (roughly 0.3% of one core added). This is an observer-cost qualification, not a production performance forecast.
- Independent Codex review found no actionable P0–P2 findings. Local changed checks passed core types, all 16 core test-type graphs, and preceding guards, then the full-tree dead-export scan reached its existing 600-second timeout. Trailing database, media, sidecar, cycle, webhook, and pairing guards passed. The full local changed gate is not claimed green; exact-head hosted CI remains required.

One existing sibling probe independently timed out at its unchanged 15-second budget on an unclaimed webhook POST with Control UI enabled, before the sampler test and without constructing a sampler; the exact isolated retry did the same. Cold-route qualification is a separate follow-up. No timeout was increased. Introducing commit/author provenance is unknown; the loss is reproduced in stable v2026.9.1 and predates the later telemetry publication changes. This diagnostic repair does not establish the cause of any production request timeout.
