### PR TITLE
fix(sessions): avoid slow key normalization on large inventories

### DIFF
--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -153,8 +153,7 @@ function writeNormalizedSessionKeyCache(raw: string, normalized: string): void {
   pruneMapToMaxSize(normalizedSessionKeyCache, NORMALIZED_SESSION_KEY_CACHE_MAX_ENTRIES);
 }
 
-function mayContainCasePreservingPeer(raw: string): boolean {
-  const folded = raw.toLowerCase();
+function mayContainCasePreservingPeer(folded: string): boolean {
   return CASE_PRESERVING_PEERS.some((descriptor) => folded.includes(`${descriptor.channel}:`));
 }
 
@@ -212,10 +211,11 @@ export function normalizeSessionKeyPreservingOpaquePeerIds(
   if (cached !== undefined) {
     return cached;
   }
-  if (!mayContainCasePreservingPeer(raw)) {
-    const normalized = raw.toLowerCase();
-    writeNormalizedSessionKeyCache(raw, normalized);
-    return normalized;
+  const folded = raw.toLowerCase();
+  // Ordinary inventory keys are cheap to fold and would churn the bounded
+  // opaque-key cache, repeatedly scanning deleted Map entries during eviction.
+  if (!mayContainCasePreservingPeer(folded)) {
+    return folded;
   }
   const spans = collectCasePreservedSpans(raw)
     .filter((span) => span.end > span.start)


### PR DESCRIPTION
## What Problem This Solves

Fixes unnecessary CPU work when refreshing session inventories larger than the session-key normalizer's 2,048-entry cache. Repeated scans evict an entry for every ordinary key, making cache maintenance more expensive than the normalization it saves.

## Why This Change Was Made

Return the already-folded value for ordinary keys without caching it. Keep raw-key cache hits first and retain bounded caching for possible case-sensitive Matrix/Signal identifiers. This repairs the cache producer with a net-zero production diff (+6/-6).

V8 initializes each new Map iterator at index zero and walks deleted slots before returning the next key ([iterator allocation](https://github.com/nodejs/node/blob/v26.7.0/deps/v8/src/builtins/builtins-collections-gen.cc#L724-L741), [hole skipping](https://github.com/nodejs/node/blob/v26.7.0/deps/v8/src/builtins/builtins-collections-gen.cc#L1411-L1464)). Reusing a cursor within one bulk prune did not prevent repeated single-entry prunes from restarting that walk.

## User Impact

Large ordinary-key inventories spend less CPU on listing and routing normalization. Output identities remain byte-identical, including opaque peers, nested wrappers, and thread markers. Small inventories lose inexpensive ordinary-key cache hits; large opaque-key inventories can still exercise the bounded FIFO.

## Evidence

Measurements compare [3a3b8538](https://github.com/openclaw/openclaw/commit/3a3b8538a35655e711eee99434f0a4d3543001ed) with this patch. Node 26.7.0 / V8 14.6.202.34-node.28, four same-order parser scans, median process CPU across five paired rounds:

| Distinct keys | Before | After |
| --- | ---: | ---: |
| 1,000 | 1.54 ms | 1.94 ms |
| 2,049 | 14.25 ms | 2.61 ms |
| 5,000 | 29.58 ms | 4.75 ms |
| 10,000 | 56.91 ms | 9.11 ms |

The real list projection with two synthetic agents, 60 returned rows and derived titles also improved: at 10,000 sessions, selection CPU was 33.63→26.14 ms and full-list CPU 64.83→60.40 ms (same Node 26.5.0). Pruning fell from 198/750 CPU samples to 0/721. These are scoped CPU measurements under host load, not production wall-time guarantees.

72,234 differential normalization/parser comparisons passed, including Matrix/Signal, malformed and nested keys, Unicode/lone surrogates, and long inputs. Existing semantic suites cover stored-key identity and routing. The performance regression is an executable before/after measurement; no timing-sensitive unit threshold or implementation-coupled cache spy was added.

Validation: 173 semantic tests passed across six existing key/routing/store suites; two existing real Gateway WebSocket cases passed for agent-scoped listing and main-alias resolution/patching. Independent Codex P2 review is clean. The sourcePerformance build passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33948574001) passed, including production types, both core test-type groups, guards, lint, build, and runtime tests. The duplicate local broad gate was stopped after core types passed; its terminal result is recorded as cancellation, not local full success.

<details>
<summary>Reproduce the normalization workload on the base and PR checkout</summary>

```sh
node --import ./scripts/tsx.mjs --input-type=module <<'JS'
import { parseAgentSessionKey } from './src/sessions/session-key-utils.ts';
const keys = Array.from({ length: 10000 }, (_, i) => `agent:main:inventory-${i}`);
const samples = [];
let checksum = 0;
for (let round = 0; round < 7; round++) {
  const start = process.cpuUsage();
  for (let pass = 0; pass < 4; pass++) {
    for (const key of keys) checksum += parseAgentSessionKey(key).rest.length;
  }
  const cpu = process.cpuUsage(start);
  if (round >= 2) samples.push((cpu.user + cpu.system) / 1000);
}
console.log({ medianCpuMs: samples.toSorted((a, b) => a - b)[2], checksum });
JS
```

Use the same Node version in both checkouts. This exercises the capacity cliff; it is not an assertion on whole-Gateway latency.

</details>
