### PR TITLE
fix: stopping subagents stalls behind sibling cleanup

### DIFF
--- a/src/agents/subagents/registry/subagent-control-kill.ts
+++ b/src/agents/subagents/registry/subagent-control-kill.ts
@@ -57,7 +57,7 @@ type KillSelection = {
 };
 
 type KillScope = {
-  refresh: () => void;
+  refresh: () => number;
   retarget: (tree: KillTree, successor: SubagentRunRecord) => boolean;
 };
 
@@ -224,7 +224,10 @@ async function withSubagentKillScope<T>(
     const trees: KillTree[] = [];
     select(params.runs, trees, params.controller);
     const scope: KillScope = {
-      refresh: () => trees.forEach(refreshTree),
+      refresh: () => {
+        trees.forEach(refreshTree);
+        return selected.size;
+      },
       retarget(tree, successor) {
         const binding = tree.bind(successor);
         if (!binding.canTraverse()) {
@@ -348,52 +351,55 @@ type KillTraversal = {
   suppressTaskDelivery?: boolean;
 };
 
-async function killSubagentDescendants(
-  params: KillTraversal & { tree: KillTree },
-): ReturnType<typeof killSubagentRunTree> {
-  const { tree, scope } = params;
-  if (!tree.canTraverse()) {
-    return { killed: 0, labels: [] };
-  }
-  scope.refresh();
-  // Exact admin constraints belong only to its selected root, not each descendant.
-  return killSubagentRunTree({
-    cfg: params.cfg,
-    suppressTaskDelivery: params.suppressTaskDelivery,
-    scope,
-    trees: tree.children,
-  });
-}
-
 async function killSubagentRunTree(
   params: KillTraversal & { trees: KillTree[] },
 ): Promise<{ killed: number; labels: string[] }> {
-  // Interrupt siblings before waiting for any one's cleanup; each branch still
-  // drains its parent before traversing descendants. Preserve selection order.
-  const cancellations = params.trees.map(async (tree) => {
-    const labels: string[] = [];
+  const visits = new Map<KillTree, { label?: string; descendants: boolean }>();
+  const visit = async (tree: KillTree): Promise<void> => {
+    let result = visits.get(tree);
     try {
-      if (!tree.entry.execution.endedAt || tree.entry.pauseReason === "sessions_yield") {
-        const stopped = await killLatestSubagentRun({ ...params, tree });
-        if (stopped.result.error) {
-          tree.errors.add(stopped.result.error);
+      if (!result) {
+        result = { descendants: false };
+        visits.set(tree, result);
+        if (!tree.entry.execution.endedAt || tree.entry.pauseReason === "sessions_yield") {
+          const stopped = await killLatestSubagentRun({ ...params, tree });
+          if (stopped.result.error) {
+            tree.errors.add(stopped.result.error);
+          }
+          if (stopped.result.killed) {
+            result.label = resolveSubagentLabel(stopped.entry);
+          }
+          if (stopped.result.superseded) {
+            return;
+          }
         }
-        if (stopped.result.killed) {
-          labels.push(resolveSubagentLabel(stopped.entry));
-        }
-        if (stopped.result.superseded) {
-          return labels;
-        }
+        result.descendants = true;
       }
-      // Resolve recovery before checking traversal; ended ancestors need the same fence.
-      const cascade = await killSubagentDescendants({ ...params, tree });
-      labels.push(...cascade.labels);
+      if (result.descendants && tree.canTraverse()) {
+        params.scope.refresh();
+        await Promise.all(tree.children.map(visit));
+      }
     } catch (error) {
       tree.errors.add(formatErrorMessage(error));
+      if (result) {
+        result.descendants = false;
+      }
     }
-    return labels;
-  });
-  const labels = (await Promise.all(cancellations)).flat();
+  };
+  let selected: number;
+  do {
+    selected = params.scope.refresh();
+    // First visits interrupt siblings together; descendants still wait for their parent.
+    await Promise.all(params.trees.map(visit));
+    // A sibling's drain can capture children beneath an already visited branch.
+    // Complete that frontier before releasing holds, without stopping a session twice.
+  } while (params.scope.refresh() !== selected);
+  const collectLabels = (trees: KillTree[]): string[] =>
+    trees.flatMap((tree) => {
+      const label = visits.get(tree)?.label;
+      return [...(label === undefined ? [] : [label]), ...collectLabels(tree.children)];
+    });
+  const labels = collectLabels(params.trees);
   return { killed: labels.length, labels };
 }
 
@@ -409,8 +415,14 @@ async function killSubagentRoot(params: Parameters<typeof killLatestSubagentRun>
     if (stopped.result.error) {
       params.tree.errors.add(stopped.result.error);
     }
-    if (!stopped.result.superseded && !stopped.result.declined) {
-      cascade = await killSubagentDescendants(params);
+    if (!stopped.result.superseded && !stopped.result.declined && params.tree.canTraverse()) {
+      // Exact admin constraints belong only to its selected root, not each descendant.
+      cascade = await killSubagentRunTree({
+        cfg: params.cfg,
+        suppressTaskDelivery: params.suppressTaskDelivery,
+        scope: params.scope,
+        trees: params.tree.children,
+      });
     }
   } catch (error) {
     params.tree.errors.add(formatErrorMessage(error));

--- a/src/agents/subagents/registry/subagent-control-kill.ts
+++ b/src/agents/subagents/registry/subagent-control-kill.ts
@@ -368,9 +368,10 @@ async function killSubagentDescendants(
 async function killSubagentRunTree(
   params: KillTraversal & { trees: KillTree[] },
 ): Promise<{ killed: number; labels: string[] }> {
-  let killed = 0;
-  const labels: string[] = [];
-  for (const tree of params.trees) {
+  // Interrupt siblings before waiting for any one's cleanup; each branch still
+  // drains its parent before traversing descendants. Preserve selection order.
+  const cancellations = params.trees.map(async (tree) => {
+    const labels: string[] = [];
     try {
       if (!tree.entry.execution.endedAt || tree.entry.pauseReason === "sessions_yield") {
         const stopped = await killLatestSubagentRun({ ...params, tree });
@@ -378,22 +379,22 @@ async function killSubagentRunTree(
           tree.errors.add(stopped.result.error);
         }
         if (stopped.result.killed) {
-          killed += 1;
           labels.push(resolveSubagentLabel(stopped.entry));
         }
         if (stopped.result.superseded) {
-          continue;
+          return labels;
         }
       }
       // Resolve recovery before checking traversal; ended ancestors need the same fence.
       const cascade = await killSubagentDescendants({ ...params, tree });
-      killed += cascade.killed;
       labels.push(...cascade.labels);
     } catch (error) {
       tree.errors.add(formatErrorMessage(error));
     }
-  }
-  return { killed, labels };
+    return labels;
+  });
+  const labels = (await Promise.all(cancellations)).flat();
+  return { killed: labels.length, labels };
 }
 
 async function killSubagentRoot(params: Parameters<typeof killLatestSubagentRun>[0]) {

--- a/src/agents/subagents/registry/subagent-control.concurrency.test.ts
+++ b/src/agents/subagents/registry/subagent-control.concurrency.test.ts
@@ -1,0 +1,274 @@
+import { expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { getRuntimeConfig } from "../../../config/config.js";
+import {
+  beginSessionWorkAdmission,
+  getActiveSessionLifecycleMutationCount,
+  getActiveSessionWorkAdmissionCount,
+  type SessionWorkAdmissionLease,
+} from "../../../sessions/session-lifecycle-admission.js";
+import { findTaskByRunId } from "../../../tasks/task-registry.js";
+import { clearActiveEmbeddedRun, setActiveEmbeddedRun } from "../../embedded-agent-runner/runs.js";
+import { createEmbeddedRunHandle } from "../../embedded-agent-runner/runs.test-support.js";
+import { enqueueSwarmRun, releaseSwarmRun } from "../swarm/swarm-scheduler.js";
+import { killAllControlledSubagentRuns, killSubagentRunAdmin } from "./subagent-control.js";
+import { useSubagentControlFixture } from "./subagent-control.test-support.js";
+import { subagentRuns } from "./subagent-registry-memory.js";
+import { registerSubagentRun } from "./subagent-registry.js";
+import { writeSubagentSessionEntry } from "./subagent-registry.persistence.test-support.js";
+
+const fixture = useSubagentControlFixture();
+
+it.each(["bulk", "admin"] as const)(
+  "%s cancellation interrupts every sibling before waiting for any sibling to drain",
+  async (boundary) => {
+    const requester = "agent:main:main";
+    const sessionKey = (id: string) => `agent:main:subagent:${id}`;
+    const owner = boundary === "admin" ? sessionKey("root") : requester;
+    const running = Array.from({ length: 8 }, (_, index) => `running-${index}`);
+    const queued = ["queued-0", "queued-1"];
+    const selected = [...running, ...queued];
+    let storePath = "";
+    for (const id of boundary === "admin" ? ["root", ...selected] : selected) {
+      storePath = await writeSubagentSessionEntry({
+        stateDir: fixture.stateDir,
+        agentId: "main",
+        sessionKey: sessionKey(id),
+        defaultSessionId: `${id}-session`,
+      });
+      registerSubagentRun({
+        runId: id,
+        childSessionKey: sessionKey(id),
+        requesterSessionKey: id === "root" ? requester : owner,
+        requesterAgentId: "main",
+        requesterDisplayKey: requester,
+        task: id,
+        cleanup: "keep",
+        collect: true,
+        queued: queued.includes(id),
+        expectsCompletionMessage: false,
+      });
+    }
+    const start = vi.fn(async () => {});
+    for (const runId of queued) {
+      enqueueSwarmRun({
+        groupId: "sibling-cancellation",
+        runId,
+        maxConcurrent: running.length,
+        activeRunIds: running,
+        start,
+        onStartFailure: () => true,
+      });
+    }
+    const interrupted: string[] = [];
+    const firstInterrupted = createDeferred<void>();
+    const leases: SessionWorkAdmissionLease[] = [];
+    const handles = running.map((runId) => createEmbeddedRunHandle({ runId }));
+    for (const [index, runId] of running.entries()) {
+      setActiveEmbeddedRun(`${runId}-session`, handles[index], sessionKey(runId));
+      leases.push(
+        await beginSessionWorkAdmission({
+          scope: storePath,
+          identities: [sessionKey(runId), `${runId}-session`],
+          assertAllowed: () => {},
+          onInterrupt: () => {
+            interrupted.push(runId);
+            firstInterrupted.resolve();
+            // Cancellation releases real scheduler capacity while these admissions
+            // remain held. Selected queued children must still never dispatch.
+            expect(releaseSwarmRun(runId)).toBe(true);
+          },
+        }),
+      );
+    }
+    const cfg = getRuntimeConfig();
+    const pending =
+      boundary === "admin"
+        ? killSubagentRunAdmin({ cfg, sessionKey: owner, expectedRunId: "root" })
+        : killAllControlledSubagentRuns({
+            cfg,
+            controller: {
+              controllerSessionKey: owner,
+              controllerAgentId: "main",
+              callerSessionKey: owner,
+              callerIsSubagent: false,
+              controlScope: "children",
+            },
+            runs: selected.map((id) => subagentRuns.get(id)!),
+          });
+    try {
+      await firstInterrupted.promise;
+      await vi.waitFor(() => expect(interrupted.toSorted()).toEqual(running));
+      expect(getActiveSessionWorkAdmissionCount()).toBe(running.length);
+      expect(start).not.toHaveBeenCalled();
+      for (const lease of leases.toReversed()) {
+        lease.release();
+      }
+      const result = await pending;
+      expect(result).toMatchObject(
+        boundary === "admin"
+          ? { found: true, killed: true, cascadeKilled: selected.length, cascadeLabels: selected }
+          : { status: "ok", killed: selected.length, labels: selected },
+      );
+      for (const id of selected) {
+        expect(findTaskByRunId(id)?.status).toBe("cancelled");
+      }
+      expect(start).not.toHaveBeenCalled();
+    } finally {
+      for (const lease of leases) {
+        lease.release();
+      }
+      await pending;
+      for (const [index, runId] of running.entries()) {
+        clearActiveEmbeddedRun(`${runId}-session`, handles[index], sessionKey(runId));
+      }
+      expect(getActiveSessionWorkAdmissionCount()).toBe(0);
+      expect(getActiveSessionLifecycleMutationCount()).toBe(0);
+    }
+  },
+);
+
+it.each(["after interrupt", "before capacity release"] as const)(
+  "keeps a late descendant queued when registered %s on an independent sibling that releases first",
+  async (registration) => {
+    const owner = "agent:main:main";
+    const key = (id: string) => `agent:main:subagent:${id}`;
+    const parents = { a: owner, b: owner, d: key("a"), x: key("d"), g: key("d") };
+    let storePath = "";
+    const register = (id: keyof typeof parents, queued = false) =>
+      registerSubagentRun({
+        runId: id,
+        childSessionKey: key(id),
+        requesterSessionKey: parents[id],
+        controllerSessionKey: parents[id],
+        swarmRequesterSessionKey: parents[id],
+        requesterAgentId: "main",
+        requesterDisplayKey: parents[id],
+        groupId: "shared-name",
+        task: id,
+        cleanup: "keep",
+        collect: true,
+        queued,
+        expectsCompletionMessage: false,
+      });
+    for (const id of ["a", "b", "d", "x", "g"] as const) {
+      storePath = await writeSubagentSessionEntry({
+        stateDir: fixture.stateDir,
+        agentId: "main",
+        sessionKey: key(id),
+        defaultSessionId: `${id}-session`,
+      });
+      if (id !== "g") {
+        register(id);
+      }
+    }
+    const unrelatedStart = vi.fn(async () => {});
+    const startG = vi.fn(async () => {});
+    const startFailure = vi.fn(() => true);
+    enqueueSwarmRun({
+      groupId: JSON.stringify(["main", owner, "shared-name"]),
+      runId: "unrelated",
+      maxConcurrent: 2,
+      activeRunIds: ["a", "b"],
+      start: unrelatedStart,
+      onStartFailure: startFailure,
+    });
+    const aInterrupted = createDeferred<void>();
+    const bInterrupted = createDeferred<void>();
+    const bReleased = createDeferred<void>();
+    const admissionA = await beginSessionWorkAdmission({
+      scope: storePath,
+      identities: [key("a"), "a-session"],
+      assertAllowed: () => {},
+      onInterrupt: () => aInterrupted.resolve(),
+    });
+    const admissionB = await beginSessionWorkAdmission({
+      scope: storePath,
+      identities: [key("b"), "b-session"],
+      assertAllowed: () => {},
+      onInterrupt: () => bInterrupted.resolve(),
+    });
+    const interruptD = vi.fn(() => admissionD.release());
+    const admissionD = await beginSessionWorkAdmission({
+      scope: storePath,
+      identities: [key("d"), "d-session"],
+      assertAllowed: () => {},
+      onInterrupt: interruptD,
+    });
+    const registerG = () =>
+      admissionD.run(async () => {
+        register("g", true);
+        enqueueSwarmRun({
+          groupId: JSON.stringify(["main", key("d"), "shared-name"]),
+          runId: "g",
+          maxConcurrent: 1,
+          activeRunIds: ["x"],
+          start: startG,
+          onStartFailure: startFailure,
+        });
+      });
+    let lateRegistration: Promise<void> | undefined;
+    const handleB = createEmbeddedRunHandle({
+      runId: "b",
+      abort: () => {
+        if (registration === "before capacity release") {
+          lateRegistration = registerG();
+        }
+        expect(releaseSwarmRun("b")).toBe(true);
+        bReleased.resolve();
+      },
+    });
+    const handleX = createEmbeddedRunHandle({
+      runId: "x",
+      abort: () => expect(releaseSwarmRun("x")).toBe(true),
+    });
+    setActiveEmbeddedRun("b-session", handleB, key("b"));
+    setActiveEmbeddedRun("x-session", handleX, key("x"));
+    const pending = killAllControlledSubagentRuns({
+      cfg: getRuntimeConfig(),
+      controller: {
+        controllerSessionKey: owner,
+        controllerAgentId: "main",
+        callerSessionKey: owner,
+        callerIsSubagent: false,
+        controlScope: "children",
+      },
+      runs: [subagentRuns.get("a")!, subagentRuns.get("b")!],
+    });
+    try {
+      await Promise.all([aInterrupted.promise, bInterrupted.promise]);
+      expect(interruptD).not.toHaveBeenCalled();
+      // Register after B's refresh, including immediately before its capacity release.
+      // Reusing a group name does not merge different callers' scheduler lanes.
+      if (registration === "after interrupt") {
+        lateRegistration = registerG();
+        await lateRegistration;
+      }
+      admissionB.release();
+      await bReleased.promise;
+      expect(lateRegistration).toBeDefined();
+      await lateRegistration;
+      await vi.waitFor(() => expect(unrelatedStart).toHaveBeenCalledOnce());
+      expect(interruptD).not.toHaveBeenCalled();
+      expect(startG).not.toHaveBeenCalled();
+      admissionA.release();
+      expect(await pending).toMatchObject({
+        status: "ok",
+        killed: 5,
+        labels: ["a", "d", "x", "g", "b"],
+      });
+      expect(findTaskByRunId("g")?.status).toBe("cancelled");
+      expect(startG).not.toHaveBeenCalled();
+      expect(startFailure).not.toHaveBeenCalled();
+    } finally {
+      admissionA.release();
+      admissionB.release();
+      admissionD.release();
+      await pending;
+      clearActiveEmbeddedRun("b-session", handleB, key("b"));
+      clearActiveEmbeddedRun("x-session", handleX, key("x"));
+      expect(getActiveSessionWorkAdmissionCount()).toBe(0);
+      expect(getActiveSessionLifecycleMutationCount()).toBe(0);
+    }
+  },
+);

--- a/src/agents/subagents/registry/subagent-control.concurrency.test.ts
+++ b/src/agents/subagents/registry/subagent-control.concurrency.test.ts
@@ -61,11 +61,14 @@ it.each(["bulk", "admin"] as const)(
       });
     }
     const interrupted: string[] = [];
-    const firstInterrupted = createDeferred<void>();
+    const firstInterrupted = createDeferred();
     const leases: SessionWorkAdmissionLease[] = [];
-    const handles = running.map((runId) => createEmbeddedRunHandle({ runId }));
-    for (const [index, runId] of running.entries()) {
-      setActiveEmbeddedRun(`${runId}-session`, handles[index], sessionKey(runId));
+    const activeRuns = running.map((runId) => ({
+      runId,
+      handle: createEmbeddedRunHandle({ runId }),
+    }));
+    for (const { runId, handle } of activeRuns) {
+      setActiveEmbeddedRun(`${runId}-session`, handle, sessionKey(runId));
       leases.push(
         await beginSessionWorkAdmission({
           scope: storePath,
@@ -119,8 +122,8 @@ it.each(["bulk", "admin"] as const)(
         lease.release();
       }
       await pending;
-      for (const [index, runId] of running.entries()) {
-        clearActiveEmbeddedRun(`${runId}-session`, handles[index], sessionKey(runId));
+      for (const { runId, handle } of activeRuns) {
+        clearActiveEmbeddedRun(`${runId}-session`, handle, sessionKey(runId));
       }
       expect(getActiveSessionWorkAdmissionCount()).toBe(0);
       expect(getActiveSessionLifecycleMutationCount()).toBe(0);
@@ -173,9 +176,9 @@ it.each(["after interrupt", "before capacity release"] as const)(
       start: unrelatedStart,
       onStartFailure: startFailure,
     });
-    const aInterrupted = createDeferred<void>();
-    const bInterrupted = createDeferred<void>();
-    const bReleased = createDeferred<void>();
+    const aInterrupted = createDeferred();
+    const bInterrupted = createDeferred();
+    const bReleased = createDeferred();
     const admissionA = await beginSessionWorkAdmission({
       scope: storePath,
       identities: [key("a"), "a-session"],

--- a/src/agents/subagents/registry/subagent-control.publication.test.ts
+++ b/src/agents/subagents/registry/subagent-control.publication.test.ts
@@ -109,6 +109,7 @@ it.each(["canonical", "managed"] as const)(
     await captureEntered.promise;
     expect(owner.killReconciliation).toBeDefined();
     const order: string[] = [];
+    const completionCommitted = createDeferred();
     const store = getTaskRegistryStore();
     const upsert = store.upsertTaskWithDeliveryState!;
     let faults = 0;
@@ -140,31 +141,20 @@ it.each(["canonical", "managed"] as const)(
         expect(subagentRuns.get(owner.runId)).toBe(owner);
         expect(owner.generation).toBe(generation);
         expect(store.loadSnapshot().tasks.get(peer.taskId)?.status).toBe("succeeded");
+        completionCommitted.resolve();
       }
     });
-    const resolveTargetState = killRuntime.resolveSubagentKillTargetState;
-    const releaseCaptureAfterHandoff = (remaining: number): void => {
-      if (remaining === 0) {
+    const killRun = killRuntime.killSubagentRun;
+    vi.spyOn(killRuntime, "killSubagentRun").mockImplementation(async (params) => {
+      const result = await killRun(params);
+      if (params.entry === owner) {
+        const target = result.targetState;
+        order.push(`snapshot ${target?.state === "terminal" ? target.task.status : target?.state}`);
+        // Hold the actual stale result until same-owner completion commits. This
+        // exercises publication ordering without depending on promise-layer counts.
         order.push("capture released");
         capture.resolve("completed native reply");
-      } else {
-        queueMicrotask(() => releaseCaptureAfterHandoff(remaining - 1));
-      }
-    };
-    const killRun = killRuntime.killSubagentRun;
-    vi.spyOn(killRuntime, "killSubagentRun").mockImplementation((params) => {
-      const pending = killRun(params);
-      if (params.entry === owner) {
-        // Let capture finish as the real kill promises unwind; assertions below
-        // require the observed snapshot -> commit -> publication ordering.
-        releaseCaptureAfterHandoff(5);
-      }
-      return pending;
-    });
-    vi.spyOn(killRuntime, "resolveSubagentKillTargetState").mockImplementation((entry) => {
-      const result = resolveTargetState(entry);
-      if (entry === owner) {
-        order.push(`snapshot ${result?.state === "terminal" ? result.task.status : result?.state}`);
+        await completionCommitted.promise;
       }
       return result;
     });

--- a/src/agents/subagents/registry/subagent-control.publication.test.ts
+++ b/src/agents/subagents/registry/subagent-control.publication.test.ts
@@ -461,7 +461,9 @@ it.each([
         }
       }
       if (priorChildKill) {
-        expect(findTaskByRunId("publication-first")?.status).toBe("cancelled");
+        await vi.waitFor(() => {
+          expect(findTaskByRunId("publication-first")?.status).toBe("cancelled");
+        });
       }
       if (replace) {
         // The root lifecycle lock and any marker write have finished before follow-up admission.

--- a/src/agents/subagents/registry/subagent-control.recovery.test.ts
+++ b/src/agents/subagents/registry/subagent-control.recovery.test.ts
@@ -1,7 +1,7 @@
-/** Recovery accepted during an earlier sibling's drain stays in the captured kill tree. */
+/** Recovery beneath a draining control ancestor stays in the captured kill tree. */
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
-import { expect, it, vi } from "vitest";
+import { beforeEach, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import {
   clearConfigCache,
@@ -18,6 +18,7 @@ import {
   invokeChatAbortHandler,
 } from "../../../gateway/server-methods/chat.abort.test-helpers.js";
 import { sessionMutationHandlers } from "../../../gateway/server-methods/sessions-mutations.js";
+import { loadSessionsRuntimeModule } from "../../../gateway/server-methods/sessions-shared.js";
 import {
   registerAgentRunContext,
   clearAgentRunContext,
@@ -59,6 +60,16 @@ import { loadSubagentRegistryFromSqlite } from "./subagent-registry.store.sqlite
 import { releaseSubagentRun, testing } from "./subagent-registry.test-helpers.js";
 
 const fixture = useSubagentControlFixture();
+
+beforeEach(async () => {
+  // Prepare reset runtime definitions before the timed recovery races.
+  await Promise.all([
+    loadSessionsRuntimeModule(),
+    import("../../embedded-agent.js"),
+    import("../../agent-bundle-mcp-tools.js"),
+    import("../../bash-process-registry.js"),
+  ]);
+});
 
 it("does not promote a provisional task when replacement wins before admin admission", async () => {
   testing.setDepsForTest({
@@ -169,7 +180,7 @@ it.each(
       .map((scenario) => ({ boundary, scenario })),
   ),
 )(
-  "$boundary resolves accepted recovery after an earlier sibling drains (scenario=$scenario)",
+  "$boundary resolves accepted recovery after its control ancestor drains (scenario=$scenario)",
   async ({ boundary, scenario }) => {
     await writeFile(
       path.join(fixture.stateDir, "openclaw.json"),
@@ -270,7 +281,7 @@ it.each(
         runId,
         childSessionKey,
         requesterSessionKey,
-        controllerSessionKey: requesterSessionKey,
+        controllerSessionKey: runId === "b" ? aKey : requesterSessionKey,
         requesterAgentId: "main",
         requesterDisplayKey: requesterSessionKey,
         task: runId,
@@ -332,7 +343,7 @@ it.each(
     const cfg = getRuntimeConfig();
     const pending =
       boundary === "bulk"
-        ? killAllControlledSubagentRuns({ cfg, controller, runs: [a, b] })
+        ? killAllControlledSubagentRuns({ cfg, controller, runs: [a] })
         : killSubagentRunAdmin({
             cfg,
             sessionKey: parentKey,
@@ -352,7 +363,7 @@ it.each(
         entered.promise,
         pending.then((result) => {
           throw new Error(
-            `Stop completed before the sibling admission drain: ${JSON.stringify(result)}`,
+            `Stop completed before the ancestor admission drain: ${JSON.stringify(result)}`,
           );
         }),
       ]);
@@ -468,7 +479,7 @@ it.each(
             runId: "unrelated",
             childSessionKey: bKey,
             requesterSessionKey: owner,
-            controllerSessionKey: owner,
+            controllerSessionKey: aKey,
             requesterAgentId: "main",
             requesterDisplayKey: owner,
             task: "new independent owner",

--- a/src/agents/subagents/registry/subagent-control.refresh.test.ts
+++ b/src/agents/subagents/registry/subagent-control.refresh.test.ts
@@ -280,9 +280,11 @@ it.each([
       admissionA.release();
       if (phase === "later sibling drain") {
         await healthyEntered.promise;
-        expect(a.endedReason).toBe(SUBAGENT_ENDED_REASON_KILLED);
-        expect(d.endedReason).toBe(SUBAGENT_ENDED_REASON_KILLED);
-        expect(findTaskByRunId("g")?.status).toBe("cancelled");
+        await vi.waitFor(() => {
+          expect(a.endedReason).toBe(SUBAGENT_ENDED_REASON_KILLED);
+          expect(d.endedReason).toBe(SUBAGENT_ENDED_REASON_KILLED);
+          expect(findTaskByRunId("g")?.status).toBe("cancelled");
+        });
         expect(startG).not.toHaveBeenCalled();
         armed = true;
         admissionHealthy.release();

--- a/src/agents/subagents/registry/subagent-control.test.ts
+++ b/src/agents/subagents/registry/subagent-control.test.ts
@@ -1924,14 +1924,15 @@ describe("killAllControlledSubagentRuns", () => {
         createdAt: 1,
         startedAt: 2,
       });
-      const sibling = createSubagentRunRecord({
+      const activeChild = createSubagentRunRecord({
         ...parent,
-        runId: "live-sibling",
-        childSessionKey: "agent:main:subagent:live-sibling",
+        runId: "live-child",
+        childSessionKey: "agent:main:subagent:live-child",
+        controllerSessionKey: parent.childSessionKey,
       });
       addSubagentRunForTests(parent);
       if (phase === "admission drain") {
-        addSubagentRunForTests(sibling);
+        addSubagentRunForTests(activeChild);
       }
       const storePath = await writeSessionStoreFixture("late-descendant", {
         [parent.childSessionKey]: { sessionId: "late-parent-session", updatedAt: 1 },
@@ -1953,7 +1954,7 @@ describe("killAllControlledSubagentRuns", () => {
       const start = vi.fn(async () => {});
       const childKey = "agent:main:subagent:late-child";
       const registerChild = () => {
-        const requester = phase === "admission drain" ? sibling : parent;
+        const requester = phase === "admission drain" ? activeChild : parent;
         expect(requester.execution.endedAt).toBeUndefined();
         registerSubagentRun({
           runId: "late-child",
@@ -1998,7 +1999,7 @@ describe("killAllControlledSubagentRuns", () => {
       const pending = killAllControlledSubagentRuns({
         cfg,
         controller,
-        runs: phase === "admission drain" ? [parent, sibling] : [parent],
+        runs: [parent],
         beforeKill:
           phase === "parent persistence"
             ? async () => {

--- a/src/agents/subagents/spawn/subagent-spawn.authority.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.authority.test.ts
@@ -20,8 +20,11 @@ import {
 import { sessionDeleteHandlers } from "../../../gateway/server-methods/sessions-delete.js";
 import type { GatewayRequestContext } from "../../../gateway/server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "../../../gateway/server-plugin-runtime-client.js";
+import { emitAgentEvent } from "../../../infra/agent-events.js";
 import {
   claimAgentRunDelegatedAuthority,
+  clearAgentRunContext,
+  registerAgentRunContext,
   releaseAgentRunDelegatedAuthority,
   rotateAgentRunRegistryLifecycleGeneration,
 } from "../../../infra/agent-run-registry.js";
@@ -62,6 +65,7 @@ import {
 } from "../../tools/gateway-caller-context.js";
 import { createSessionsSpawnTool } from "../../tools/sessions-spawn-tool.js";
 import { subagentRuns } from "../registry/subagent-registry-memory.js";
+import { registerSubagentRun } from "../registry/subagent-registry.js";
 import {
   settleSubagentRegistryPersistenceWork,
   writeSubagentSessionEntry,
@@ -174,6 +178,232 @@ async function createBoundParent(runtime: "embedded" | "plugin-harness" = "embed
 }
 
 describe("pending spawn invocation authority", () => {
+  it.each(["sibling", "nested sibling"] as const)(
+    "stops a fresh spawn below a completed persistent sibling while a %s drain remains pending",
+    async (slowBranch) => {
+      const originalConfig = getRuntimeConfig();
+      await writeFile(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({
+          ...originalConfig,
+          agents: {
+            ...originalConfig.agents,
+            defaults: {
+              ...originalConfig.agents?.defaults,
+              subagents: { maxSpawnDepth: 2 },
+            },
+          },
+        }),
+      );
+      clearConfigCache();
+      clearRuntimeConfigSnapshot();
+      const { cfg, storePath, context, admission, parent } = await createBoundParent();
+      const sessionLifecycle = await import("../../../sessions/session-lifecycle-admission.js");
+      const key = (id: string) => `agent:main:subagent:${id}`;
+      const ids = slowBranch === "sibling" ? ["a", "b"] : ["a", "b", "d"];
+      const slowId = slowBranch === "sibling" ? "a" : "d";
+      for (const id of ids) {
+        await writeSubagentSessionEntry({
+          stateDir,
+          agentId: "main",
+          sessionKey: key(id),
+          defaultSessionId: `${id}-session`,
+          lifecycleRevision: "original",
+        });
+        registerSubagentRun({
+          runId: id,
+          childSessionKey: key(id),
+          controllerSessionKey: id === "d" ? key("a") : parentSessionKey,
+          requesterSessionKey: id === "d" ? key("a") : parentSessionKey,
+          requesterAgentId: "main",
+          requesterDisplayKey: parentSessionKey,
+          requesterTurnRunId: id === "d" ? "a" : parentRunId,
+          task: id,
+          cleanup: "keep",
+          collect: id !== "b",
+          spawnMode: id === "b" ? "session" : "run",
+          expectsCompletionMessage: false,
+        });
+        registerAgentRunContext(id, { sessionKey: key(id), sessionId: `${id}-session` });
+      }
+      const completedB = subagentRuns.get("b")!;
+      const completedGeneration = completedB.generation;
+      emitAgentEvent({
+        runId: "b",
+        sessionKey: key("b"),
+        stream: "lifecycle",
+        data: { phase: "end", endedAt: Date.now() },
+      });
+      await vi.waitFor(() => expect(findTaskByRunId("b")?.status).toBe("succeeded"));
+      clearAgentRunContext("b");
+      await settleSubagentRegistryPersistenceWork();
+      expect(completedB).toMatchObject({
+        generation: completedGeneration,
+        spawnMode: "session",
+        execution: { status: "terminal" },
+        endedReason: "subagent-complete",
+      });
+      expect(
+        Array.from(subagentRuns.values()).some((entry) => entry.controllerSessionKey === key("b")),
+      ).toBe(false);
+      const entered = createDeferred();
+      const resume = createDeferred();
+      const slow = await beginSessionWorkAdmission({
+        scope: storePath,
+        identities: [key(slowId), `${slowId}-session`],
+        assertAllowed: () => {},
+        onInterrupt: () => slow.release(),
+      });
+      const interrupt = sessionLifecycle.interruptSessionWorkAdmissions;
+      const drain = vi
+        .spyOn(sessionLifecycle, "interruptSessionWorkAdmissions")
+        .mockImplementation(async (params) => {
+          const released = await interrupt(params);
+          if (params.scope === storePath && Array.from(params.identities).includes(key(slowId))) {
+            expect(released).toBe(true);
+            entered.resolve();
+            await resume.promise;
+          }
+          return released;
+        });
+      const cancellation = invokeChatAbortHandler({
+        handler: handleChatAbortRequest,
+        context,
+        request: { sessionKey: parentSessionKey, runId: parentRunId },
+        client: { connId: "owner-connection", connect: { scopes: ["operator.write"] } },
+      });
+      const freshAdmission = prepareAgentRunAdmission({
+        cfg,
+        operationalRunInstance: createOperationalRunInstanceRef("fresh-b"),
+        facts: {
+          runId: "fresh-b",
+          agentId: "main",
+          ingress: { kind: "system", boundary: "spawn-authority-test", state: "present" },
+        },
+      });
+      let fresh: Awaited<ReturnType<typeof beginSessionWorkAdmission>> | undefined;
+      const freshInterrupted = vi.fn();
+      const dispatch = vi.fn();
+      try {
+        // Completed B visits its empty child list synchronously while the other
+        // branch enters its asynchronous mutation/drain, before this barrier opens.
+        await entered.promise;
+        expect(subagentRuns.get("b")).toBe(completedB);
+        expect(completedB.generation).toBe(completedGeneration);
+        expect(findTaskByRunId("b")?.status).toBe("succeeded");
+        const original = loadSessionEntry({ storePath, sessionKey: key("b") });
+        expect(original).toMatchObject({ sessionId: "b-session", lifecycleRevision: "original" });
+        const admitted = await freshAdmission.admit("embedded");
+        bindGatewayContextResolver(admitted, () => context as unknown as GatewayRequestContext);
+        fresh = await beginSessionWorkAdmission({
+          scope: storePath,
+          identities: [key("b"), "b-session"],
+          assertAllowed: () => {},
+          onInterrupt: () => {
+            freshInterrupted();
+            fresh?.release();
+          },
+        });
+        const blockerStarted = createDeferred();
+        enqueueSwarmRun({
+          groupId: JSON.stringify(["main", key("b"), groupId]),
+          runId: "late-spawn-blocker",
+          maxConcurrent: 1,
+          activeRunIds: [],
+          start: async () => blockerStarted.resolve(),
+          onStartFailure: () => true,
+        });
+        await blockerStarted.promise;
+        spawnTesting.setDepsForTest({
+          resolveContextEngine: async () => new LegacyContextEngine(),
+          dispatchGatewayMethodInProcess: async <T>(
+            method: string,
+            params: Record<string, unknown>,
+          ) => {
+            expect(method).toBe("agent");
+            dispatch(params.idempotencyKey);
+            return { runId: params.idempotencyKey, status: "accepted" } as T;
+          },
+        });
+        const source = createSessionsSpawnTool({
+          config: cfg,
+          agentSessionKey: key("b"),
+          requesterRunId: "fresh-b",
+          requesterTurnRunId: "fresh-b",
+        });
+        const [tool] = finalizeAgentTools({
+          tools: [
+            source,
+            createAgentsWaitTool({ config: cfg, agentSessionKey: key("b"), agentId: "main" }),
+          ],
+          hookContext: { config: cfg, agentId: "main", sessionKey: key("b"), runId: "fresh-b" },
+          abortSignal: new AbortController().signal,
+        });
+        const spawned = await fresh.run(() =>
+          withPluginRuntimeGatewayRequestScope(
+            { context: context as unknown as GatewayRequestContext, isWebchatConnect: () => false },
+            () =>
+              withGatewayToolCallerIdentity(
+                createAdmittedGatewayToolCallerIdentity({
+                  admittedRunContext: admitted,
+                  agentId: "main",
+                  sessionKey: key("b"),
+                }),
+                () =>
+                  tool!.execute!("late-spawn", {
+                    task: "late child",
+                    collect: true,
+                    context: "isolated",
+                    groupId,
+                  }),
+              ),
+          ),
+        );
+        expect(spawned).toMatchObject({ details: { status: "accepted" } });
+        const { runId } = spawned.details as { runId: string };
+        expect(subagentRuns.get(runId)).toMatchObject({
+          controllerSessionKey: key("b"),
+          requesterTurnRunId: "fresh-b",
+          execution: { status: "queued" },
+        });
+        expect(getAdmittedRunDelegatedAuthority(admitted)).toBeDefined();
+        resume.resolve();
+        expect(await cancellation).toHaveBeenCalledWith(
+          true,
+          expect.objectContaining({ aborted: true }),
+        );
+        expect(findTaskByRunId(runId)?.status).toBe("cancelled");
+        expect(subagentRuns.get("b")).toBe(completedB);
+        expect(completedB.generation).toBe(completedGeneration);
+        expect(findTaskByRunId("b")?.status).toBe("succeeded");
+        expect(loadSessionEntry({ storePath, sessionKey: key("b") })).toMatchObject({
+          sessionId: "b-session",
+          lifecycleRevision: "original",
+        });
+        expect(freshInterrupted).not.toHaveBeenCalled();
+        expect(fresh.isActive()).toBe(true);
+        expect(getAdmittedRunDelegatedAuthority(admitted)).toBeDefined();
+        releaseSwarmRun("late-spawn-blocker");
+        await Promise.resolve();
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        resume.resolve();
+        slow.release();
+        fresh?.release();
+        try {
+          await cancellation;
+        } finally {
+          drain.mockRestore();
+          releaseSwarmRun("late-spawn-blocker");
+          freshAdmission.close();
+          admission.close();
+          parent.cleanup();
+          ids.forEach((id) => clearAgentRunContext(id));
+        }
+      }
+    },
+  );
+
   it.each([
     "native abort",
     "native acceptance",

--- a/src/gateway/server-methods/chat.abort-incarnation.test.ts
+++ b/src/gateway/server-methods/chat.abort-incarnation.test.ts
@@ -110,6 +110,8 @@ it.each([false, true].flatMap((reset) => [true, false].map((completed) => ({ res
     expect(subagentRuns.get("ended")).toBe(ended);
     const entered = createDeferred();
     const resume = createDeferred();
+    const endedMutationEntered = createDeferred();
+    const resumeEndedMutation = createDeferred();
     const admission = await sessionLifecycle.beginSessionWorkAdmission({
       scope: storePath,
       identities: [activeKey, "active-session"],
@@ -117,6 +119,25 @@ it.each([false, true].flatMap((reset) => [true, false].map((completed) => ({ res
       onInterrupt: () => admission.release(),
     });
     const interruptAdmissions = sessionLifecycle.interruptSessionWorkAdmissions;
+    const mutateSession = sessionLifecycle.runExclusiveSessionLifecycleMutation;
+    let holdEndedMutation = !completed;
+    const mutation = vi
+      .spyOn(sessionLifecycle, "runExclusiveSessionLifecycleMutation")
+      .mockImplementation(async (params) => {
+        if (
+          holdEndedMutation &&
+          "scope" in params &&
+          params.scope === storePath &&
+          Array.from(params.identities).includes(endedKey)
+        ) {
+          holdEndedMutation = false;
+          // Preserve the reset/admission-before-Stop race at the actual mutation
+          // entry. Completed ancestors remain ungated late-discovery coverage.
+          endedMutationEntered.resolve();
+          await resumeEndedMutation.promise;
+        }
+        return await mutateSession(params);
+      });
     const drain = vi
       .spyOn(sessionLifecycle, "interruptSessionWorkAdmissions")
       .mockImplementation(async (params) => {
@@ -145,6 +166,9 @@ it.each([false, true].flatMap((reset) => [true, false].map((completed) => ({ res
       ]);
       expect(abort.parent.controller.signal.aborted).toBe(true);
       expect(sessionLifecycle.isSessionWorkAdmissionActive(storePath, [activeKey])).toBe(false);
+      if (!completed) {
+        await endedMutationEntered.promise;
+      }
       if (reset) {
         const respond = vi.fn();
         await sessionMutationHandlers["sessions.reset"]!({
@@ -198,6 +222,7 @@ it.each([false, true].flatMap((reset) => [true, false].map((completed) => ({ res
         onStartFailure: () => true,
       });
       resume.resolve();
+      resumeEndedMutation.resolve();
       const respond = await abort.pending;
       expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({ aborted: true }));
       expect(subagentRuns.get("active")?.endedReason).toBe("subagent-killed");
@@ -216,11 +241,13 @@ it.each([false, true].flatMap((reset) => [true, false].map((completed) => ({ res
     } finally {
       newAdmission?.release();
       resume.resolve();
+      resumeEndedMutation.resolve();
       admission.release();
       try {
         await abort.pending;
       } finally {
         drain.mockRestore();
+        mutation.mockRestore();
         releaseSwarmRun("capacity");
         releaseSwarmRun("grandchild");
       }

--- a/src/gateway/server.chat-abort-sibling-fanout.test.ts
+++ b/src/gateway/server.chat-abort-sibling-fanout.test.ts
@@ -81,10 +81,10 @@ test.each([false, true])(
 
     const socket = await gateway.openWs();
     const parentStarted = createDeferred<AgentCommandOpts>();
-    const parentFinish = createDeferred<void>();
+    const parentFinish = createDeferred();
     const leases: SessionWorkAdmissionLease[] = [];
     const interrupted: string[] = [];
-    const firstInterrupted = createDeferred<void>();
+    const firstInterrupted = createDeferred();
     const slotReleaseResults: boolean[] = [];
     const start = vi.fn(async () => {});
     let parentRequestId: string | undefined;
@@ -235,7 +235,8 @@ test.each([false, true])(
         const tasks = [...persistedTasks.snapshot.tasks.values()].filter((task) =>
           selected.includes(task.runId ?? ""),
         );
-        expect(tasks.map((task) => task.runId).toSorted()).toEqual(selected.toSorted());
+        expect(tasks).toHaveLength(selected.length);
+        expect(tasks.map((task) => task.runId)).toEqual(expect.arrayContaining(selected));
         expect([...persistedRuns.keys()].toSorted()).toEqual(selected.toSorted());
         for (const runId of selected) {
           const task = tasks.find((candidate) => candidate.runId === runId)!;

--- a/src/gateway/server.chat-abort-sibling-fanout.test.ts
+++ b/src/gateway/server.chat-abort-sibling-fanout.test.ts
@@ -1,0 +1,295 @@
+import path from "node:path";
+import { expect, test, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
+import type { AgentCommandOpts } from "../agents/command/types.js";
+import { subagentRuns } from "../agents/subagents/registry/subagent-registry-memory.js";
+import { registerSubagentRun } from "../agents/subagents/registry/subagent-registry.js";
+import {
+  settleSubagentRegistryPersistenceWork,
+  writeSubagentSessionEntry,
+} from "../agents/subagents/registry/subagent-registry.persistence.test-support.js";
+import { loadSubagentRunsForControllerFromSqlite } from "../agents/subagents/registry/subagent-registry.store.sqlite.js";
+import { resetSubagentRegistryForTests } from "../agents/subagents/registry/subagent-registry.test-helpers.js";
+import {
+  activateSwarmRun,
+  isSwarmRunActive,
+  isSwarmRunWaitingForCapacity,
+  ownsSwarmRunReservation,
+  releaseSwarmRun,
+  removeQueuedSwarmRun,
+  reserveSwarmRun,
+} from "../agents/subagents/swarm/swarm-scheduler.js";
+import { testing as schedulerTesting } from "../agents/subagents/swarm/swarm-scheduler.test-support.js";
+import {
+  beginSessionWorkAdmission,
+  getActiveSessionLifecycleMutationCount,
+  getActiveSessionWorkAdmissionCount,
+  type SessionWorkAdmissionLease,
+} from "../sessions/session-lifecycle-admission.js";
+import { SUBAGENT_KILL_TASK_ERROR } from "../tasks/detached-task-runtime-contract.js";
+import { loadTaskRegistryStateFromSqliteReadOnlyResult } from "../tasks/task-registry.store.sqlite.js";
+import {
+  agentCommandMock,
+  connectOk,
+  createGatewaySuiteHarness,
+  installGatewayTestHooks,
+  onceMessage,
+  rpcReq,
+  testState,
+  writeSessionStore,
+} from "./test-helpers.js";
+
+let gateway: Awaited<ReturnType<typeof createGatewaySuiteHarness>>;
+installGatewayTestHooks({
+  scope: "suite",
+  setup: async () => {
+    gateway = await createGatewaySuiteHarness();
+  },
+  cleanup: async () => {
+    await runQaGatewayFixture(
+      async () => gateway?.close(),
+      async () => {
+        await settleSubagentRegistryPersistenceWork();
+        resetSubagentRegistryForTests({ persist: false });
+        schedulerTesting.reset();
+      },
+    );
+  },
+});
+
+await import("./server.js");
+
+test.each([false, true])(
+  "chat.abort interrupts all siblings before cleanup and preserves failure accounting (fault=%s)",
+  async (fault) => {
+    const suffix = fault ? "fault" : "success";
+    const parentRunId = `parent-${suffix}`;
+    const parentKey = `agent:main:sibling-abort-${suffix}`;
+    const groupId = `sibling-abort-${suffix}`;
+    const running = Array.from({ length: 8 }, (_, index) => `running-${suffix}-${index}`);
+    const queued = [`queued-${suffix}-0`, `queued-${suffix}-1`];
+    const selected = [...running, ...queued];
+    const failedRunId = fault ? running[3] : undefined;
+    const sessionKey = (runId: string) => `agent:main:subagent:${runId}`;
+    const stateDir = process.env.OPENCLAW_STATE_DIR!;
+    const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+    testState.sessionStorePath = storePath;
+    await writeSessionStore({
+      entries: { [parentKey]: { sessionId: `parent-session-${suffix}`, updatedAt: Date.now() } },
+    });
+
+    const socket = await gateway.openWs();
+    const parentStarted = createDeferred<AgentCommandOpts>();
+    const parentFinish = createDeferred<void>();
+    const leases: SessionWorkAdmissionLease[] = [];
+    const interrupted: string[] = [];
+    const firstInterrupted = createDeferred<void>();
+    const slotReleaseResults: boolean[] = [];
+    const start = vi.fn(async () => {});
+    let parentRequestId: string | undefined;
+    let abortResponse: ReturnType<typeof rpcReq> | undefined;
+    let abortOutcome:
+      | Promise<
+          { ok: true; response: Awaited<ReturnType<typeof rpcReq>> } | { ok: false; error: unknown }
+        >
+      | undefined;
+    let responseSettled = false;
+
+    await runQaGatewayFixture(
+      async () => {
+        await connectOk(socket, {
+          scopes: ["operator.read", "operator.write"],
+          prePairDevice: true,
+        });
+        agentCommandMock.mockImplementationOnce(async (input) => {
+          const command = input as AgentCommandOpts;
+          expect(command.abortSignal).toBeInstanceOf(AbortSignal);
+          command.onExecutionStarted?.();
+          parentStarted.resolve(command);
+          await parentFinish.promise;
+          command.abortSignal!.throwIfAborted();
+        });
+        const accepted = await rpcReq(socket, "agent", {
+          sessionKey: parentKey,
+          message: "Keep this synthetic parent active until Stop",
+          idempotencyKey: parentRunId,
+        });
+        parentRequestId = accepted.id;
+        expect(accepted).toMatchObject({
+          ok: true,
+          payload: { runId: parentRunId, status: "accepted" },
+        });
+        await expect.poll(() => agentCommandMock.mock.calls.length, { timeout: 2_000 }).toBe(1);
+        const parent = await parentStarted.promise;
+
+        for (const runId of selected) {
+          await writeSubagentSessionEntry({
+            stateDir,
+            agentId: "main",
+            sessionKey: sessionKey(runId),
+            defaultSessionId: `${runId}-session`,
+          });
+          if (queued.includes(runId)) {
+            expect(
+              reserveSwarmRun({ groupId, runId, maxConcurrent: 8, activeRunIds: running }),
+            ).toBe(true);
+          }
+          registerSubagentRun({
+            runId,
+            childSessionKey: sessionKey(runId),
+            requesterSessionKey: parentKey,
+            requesterAgentId: "main",
+            requesterTurnRunId: parentRunId,
+            requesterDisplayKey: parentKey,
+            task: runId,
+            cleanup: "keep",
+            collect: true,
+            groupId,
+            queued: queued.includes(runId),
+            expectsCompletionMessage: false,
+            taskRowOwnership: "required",
+          });
+          if (queued.includes(runId)) {
+            activateSwarmRun({ groupId, runId, start, onStartFailure: () => true });
+          }
+        }
+        for (const runId of running) {
+          expect(isSwarmRunActive(runId)).toBe(true);
+          leases.push(
+            await beginSessionWorkAdmission({
+              scope: storePath,
+              identities: [sessionKey(runId), `${runId}-session`],
+              assertAllowed: () => {},
+              onInterrupt: () => {
+                interrupted.push(runId);
+                firstInterrupted.resolve();
+                slotReleaseResults.push(releaseSwarmRun(runId));
+                if (runId === failedRunId) {
+                  throw new Error("synthetic sibling interruption failure");
+                }
+              },
+            }),
+          );
+        }
+        for (const runId of queued) {
+          expect(isSwarmRunWaitingForCapacity(runId, subagentRuns.get(runId)!)).toBe(true);
+        }
+        const activeAdmissionCount = getActiveSessionWorkAdmissionCount();
+        expect(activeAdmissionCount).toBeGreaterThanOrEqual(running.length);
+        expect(start).not.toHaveBeenCalled();
+
+        abortResponse = rpcReq(socket, "chat.abort", {
+          sessionKey: parentKey,
+          agentId: "main",
+          runId: parentRunId,
+        });
+        abortOutcome = abortResponse.then(
+          (response) => {
+            responseSettled = true;
+            return { ok: true as const, response };
+          },
+          (error: unknown) => {
+            responseSettled = true;
+            return { ok: false as const, error };
+          },
+        );
+        await Promise.race([
+          firstInterrupted.promise,
+          abortOutcome.then(() => {
+            throw new Error("chat.abort completed before interrupting its children");
+          }),
+        ]);
+        // No child may make sibling interruption wait for this fixture-owned cleanup.
+        await expect.poll(() => interrupted.toSorted(), { timeout: 2_000 }).toEqual(running);
+        expect(parent.abortSignal!.aborted).toBe(true);
+        expect(slotReleaseResults).toEqual(running.map(() => true));
+        expect(leases.every((lease) => lease.isActive())).toBe(true);
+        expect(getActiveSessionWorkAdmissionCount()).toBe(activeAdmissionCount);
+        expect(responseSettled).toBe(false);
+        expect(start).not.toHaveBeenCalled();
+        for (const lease of leases.toReversed()) {
+          lease.release();
+        }
+        const outcome = await abortOutcome;
+        if (!outcome.ok) {
+          throw outcome.error;
+        }
+        if (fault) {
+          expect(outcome.response).toMatchObject({ ok: false, error: { code: "UNAVAILABLE" } });
+          expect(outcome.response.error?.message).toContain(
+            "synthetic sibling interruption failure",
+          );
+        } else {
+          expect(outcome.response).toMatchObject({
+            ok: true,
+            payload: { ok: true, aborted: true, runIds: [parentRunId] },
+          });
+        }
+
+        const persistedRuns = new Map(
+          loadSubagentRunsForControllerFromSqlite(parentKey).map((run) => [run.runId, run]),
+        );
+        const persistedTasks = loadTaskRegistryStateFromSqliteReadOnlyResult();
+        expect(persistedTasks.state).toBe("ready");
+        const tasks = [...persistedTasks.snapshot.tasks.values()].filter((task) =>
+          selected.includes(task.runId ?? ""),
+        );
+        expect(tasks.map((task) => task.runId).toSorted()).toEqual(selected.toSorted());
+        expect([...persistedRuns.keys()].toSorted()).toEqual(selected.toSorted());
+        for (const runId of selected) {
+          const task = tasks.find((candidate) => candidate.runId === runId)!;
+          const run = persistedRuns.get(runId)!;
+          if (runId === failedRunId) {
+            expect(task.status).toBe("running");
+            expect(run.execution.status).toBe("running");
+            expect(run.execution.endedAt).toBeUndefined();
+          } else {
+            expect(task).toMatchObject({ status: "cancelled", error: SUBAGENT_KILL_TASK_ERROR });
+            expect(run).toMatchObject({
+              endedReason: "subagent-killed",
+              execution: { status: "terminal" },
+            });
+          }
+          if (queued.includes(runId)) {
+            expect(run.execution.startedAt).toBeUndefined();
+            expect(ownsSwarmRunReservation(runId, subagentRuns.get(runId)!)).toBe(false);
+          }
+        }
+        expect(start).not.toHaveBeenCalled();
+      },
+      async () => {
+        // Cleanup is unconditional, including the expected pre-fix fanout assertion failure.
+        for (const lease of leases) {
+          lease.release();
+        }
+        const outcome = await abortOutcome;
+        if (outcome && !outcome.ok) {
+          throw outcome.error;
+        }
+      },
+      async () => {
+        const terminal = parentRequestId
+          ? onceMessage(
+              socket,
+              (frame) =>
+                frame.type === "res" &&
+                frame.id === parentRequestId &&
+                frame.payload?.status !== "accepted",
+            )
+          : undefined;
+        parentFinish.resolve();
+        await terminal;
+      },
+      () => {
+        for (const runId of selected) {
+          removeQueuedSwarmRun(runId);
+          releaseSwarmRun(runId);
+        }
+        socket.close();
+        expect(getActiveSessionLifecycleMutationCount()).toBe(0);
+        expect(getActiveSessionWorkAdmissionCount()).toBe(0);
+      },
+    );
+  },
+);


### PR DESCRIPTION
Stopping a parent with several subagents waited for each sibling's cleanup before interrupting the next. A stalled branch could therefore leave other active workers and queued children running. Start sibling cancellation together, preserve parent-before-descendant cleanup, and keep the existing selection holds until every discovered branch has been visited.

The selection can grow while another branch drains: a completed persistent child can receive a follow-up message in its bound channel thread and spawn another child. Cache each node's own cancellation result, revisit newly discovered descendants until selection stops growing, and collect results in tree order. This preserves exact run, lifecycle, session-incarnation, retirement, and admin fences without interrupting a newly admitted turn on an already visited session. The single-use descendant wrapper is removed.

Production changes are **+54/-41 (net +13)**; tests are **+874/-38 (net +836)**. The remaining runtime growth owns discovery completion and one-time cancellation in one walker. No configuration, database schema, migration, dependency, public RPC, or timeout change is introduced.

Validation covers **175 distinct focused cases** on the final production implementation, including:

- Two authenticated Gateway WebSocket cases with eight held active admissions and two queued children: every active sibling is interrupted before cleanup is released, queued work never starts, and a throwing interruption produces truthful partial-failure accounting.
- Two failing-then-passing real `sessions_spawn` producer cases beneath an already-completed persistent child, with both a held sibling and a deeper held branch. All 16 authority cases pass in their original order; the completed child's generation, session ID, lifecycle revision, and fresh admission survive.
- Six incarnation cases, ten publication cases, and the existing recovery, retirement, refresh, scheduler, error-accounting, and competing-reset coverage.
- Core production types, both affected test type graphs, scoped type-aware lint, formatting, and independent Codex reviews of the runtime repair and final fixture.

The first 172-case run remains recorded as failed: two publication fixtures depended on exactly five microtasks. They now wait at the real stale-result handoff until canonical completion commits, preserving all publication and peer assertions. The corrected fixture also passes against the unchanged prior head. The previously failing hosted incarnation cases were reproduced before repair; no validation failure was waived.

These are actual Gateway transport and admitted-producer tests with synthetic inference boundaries. They do not claim live channel transport or native-process cleanup; the latter remains a separate post-landing check. The supported persistent-thread path is documented in [Sub-agents](https://docs.openclaw.ai/tools/subagents). Exact-head hosted CI must pass before merge.

Release-note context: parent Stop interrupts sibling subagents promptly and drains late-discovered descendants before releasing queued work, while preserving replacement-session and fresh-admission boundaries.
