### PR TITLE
perf(agents): reduce CPU work in identity lookups

### DIFF
--- a/src/agents/identity.ts
+++ b/src/agents/identity.ts
@@ -5,7 +5,8 @@
  */
 import type { HumanDelayConfig, IdentityConfig } from "../config/types.base.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveAgentConfig } from "./agent-scope.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { resolveAgentEntry } from "./agent-scope-config.js";
 
 const DEFAULT_ACK_REACTION = "👀";
 
@@ -14,7 +15,8 @@ export function resolveAgentIdentity(
   cfg: OpenClawConfig,
   agentId: string,
 ): IdentityConfig | undefined {
-  return resolveAgentConfig(cfg, agentId)?.identity;
+  // Keep merged-config request normalization for raw Plugin SDK agent ids.
+  return resolveAgentEntry(cfg, normalizeAgentId(agentId))?.identity;
 }
 
 /** Resolve the acknowledgement reaction using account, channel, global, then identity fallback. */
@@ -168,7 +170,7 @@ export function resolveHumanDelayConfig(
   agentId: string,
 ): HumanDelayConfig | undefined {
   const defaults = cfg.agents?.defaults?.humanDelay;
-  const overrides = resolveAgentConfig(cfg, agentId)?.humanDelay;
+  const overrides = resolveAgentEntry(cfg, normalizeAgentId(agentId))?.humanDelay;
   if (!defaults && !overrides) {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Session lists resolve agent identities for each candidate row. These lookups unnecessarily construct the complete merged agent configuration, including unrelated model, context, and tool fields. A synthetic two-agent, 50,000-session profile identified this work in the listing path.

## Why This Change Was Made

Read identity and human-delay overrides through the existing canonical agent-entry resolver. Both fields were already copied directly from that entry. Preserve the existing request-ID normalization and human-delay defaults, including raw legacy Plugin SDK inputs. The configured identity, roster precedence, batch lookup behavior, and downstream name/avatar/prefix handling stay the same.

This adds no cache, resolver, API, configuration option, or persisted-state change. Production delta: +5/-3 (net +2, including the preserved-normalization explanation and import); tests unchanged.

## User Impact

Agent identity lookups do less CPU work while returning the same values. This benefits session-owner projection and other identity consumers. End-to-end session-list latency improvement has not been established by the loaded-host measurements below.

## Evidence

On Node 26.7.0, six alternating rounds of 50,000 calls using the same minimal per-agent identity configuration as the list reproduction and the final identity helper produced these CPU medians:

| Configured agents | Merged config lookup | Direct entry lookup |
| --- | ---: | ---: |
| 2 | 23.27 ms | 18.16 ms |
| 20 | 65.81 ms | 60.96 ms |
| 100 | 333.27 ms | 327.03 ms |

The pre-edit parity probe passed 2,376 comparisons across 54 keyed, legacy, missing, and default configurations, both inside and outside roster batches. A naive substitution failed a real non-idempotent-ID case before editing; the final implementation preserves the original caller normalization. The post-edit probe also compares against the unchanged merged-config owner.

The actual `listSessionsFromStoreAsync` path was replayed four times each with 1,000, 5,000, and 10,000 synthetic sessions, two named agents, and a 60-row page. Complete serialized responses matched before and after, including owner labels, ordering, and counts. Selection CPU medians fell from 9.12/18.94/36.64 ms to 3.49/16.79/29.86 ms. Total list CPU was mixed, so these measurements support reduced lookup work rather than an overall latency claim.

Focused owner/sibling validation passed: **97 tests across 8 files**. This includes acknowledgment and prefix precedence, human-delay defaults, configured/workspace avatars, roster behavior, assistant identity, outbound identity, and gateway owner/participant projections. The post-edit probe passed 3,564 comparisons against the preserved contract. Fresh independent Codex autoreview was scoped-clean at P2; formatting, typed lint, and diff checks passed.

```bash
node scripts/run-vitest.mjs \
  src/agents/identity.test.ts \
  src/agents/identity.human-delay.test.ts \
  src/agents/identity.per-channel-prefix.test.ts \
  src/agents/identity-avatar.test.ts \
  src/agents/agent-scope-config.test.ts \
  src/gateway/assistant-identity.test.ts \
  src/gateway/session-utils-owners.test.ts \
  src/infra/outbound/identity.test.ts
```

The first isolated list probe stopped during import because the borrowed workspace package dependency links were absent; after supplying the matching read-only package links, baseline and candidate both completed. Broad validation and build are checked by hosted CI before native landing.

Separate follow-up: the permissive agent-ID normalizer can be non-idempotent for long underscore-prefixed raw inputs. This PR preserves current behavior and does not change identifier or stored-key contracts.
