### PR TITLE
refactor(agents): remove unused deletion lifecycle bookkeeping

### DIFF
--- a/src/agents/agent-create.integration.test.ts
+++ b/src/agents/agent-create.integration.test.ts
@@ -214,7 +214,6 @@ it("finishes creation bookkeeping when delegated authority closes after successf
     sessionsDir: state.sessionsDir("published"),
     deleteFiles: false,
   });
-  deletion.commit();
   deletion.finish();
   const rollback = vi.fn();
   try {

--- a/src/agents/agent-lifecycle-registry.test.ts
+++ b/src/agents/agent-lifecycle-registry.test.ts
@@ -86,7 +86,6 @@ describe("agent lifecycle registry", () => {
     const before = readAgentProvenance("main", options);
     const binding = captureAgentLifecycleBinding(config, "main", options);
     const first = beginAgentDeletion(createEntry("main"), options);
-    first.commit();
 
     expect(readAgentProvenance("main", options)).toEqual(before);
     expect(isAgentDeletionBlocked("main", options)).toBe(true);
@@ -108,12 +107,11 @@ describe("agent lifecycle registry", () => {
     expect(binding && matchesAgentLifecycleBinding(config, binding, options)).toBe(false);
   });
 
-  it("keeps a committed deletion fenced until recreation claims cleanup", () => {
+  it("keeps a completed deletion fenced until recreation claims cleanup", () => {
     const options = createOptions();
     const deletion = beginAgentDeletion(createEntry("Recreated-Agent"), options);
 
     expect(isAgentDeletionBlocked("recreated-agent", options)).toBe(true);
-    deletion.commit();
     expect(readAgentDeletionJournal("RECREATED-AGENT", options)).toMatchObject({
       agentId: "recreated-agent",
       agentDir: "/agents/Recreated-Agent",
@@ -210,10 +208,9 @@ describe("agent lifecycle registry", () => {
     expect(isAgentDeletionBlocked("rollback-claimed-agent", options)).toBe(false);
   });
 
-  it("clears stale process state after another process claims the tombstone", () => {
+  it("observes a tombstone claimed outside the lifecycle wrapper", () => {
     const options = createOptions();
     const deletion = beginAgentDeletion(createEntry("cross-process-agent"), options);
-    deletion.commit();
     deletion.finish();
 
     expect(

--- a/src/agents/agent-lifecycle-registry.ts
+++ b/src/agents/agent-lifecycle-registry.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
-import { resolveGlobalMap } from "../shared/global-singleton.js";
 import { createAgentDeletionDatabaseCleanup } from "../state/agent-deletion-cleanup.js";
 import {
   beginAgentDeletionJournal,
@@ -22,12 +21,6 @@ import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-co
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
 
-const AGENT_LIFECYCLE_KEY = Symbol.for("openclaw.agentLifecycle");
-const agentLifecycle = resolveGlobalMap<string, "deleting" | "deleted">(
-  AGENT_LIFECYCLE_KEY,
-  "close-and-restart",
-);
-
 export class AgentDeletionAuthorityRollbackError extends AggregateError {}
 
 export class AgentDeletionCommitUncertainError extends Error {
@@ -40,13 +33,6 @@ export type AgentLifecycleBinding = Readonly<{
   agentId: string;
   provenance: AgentProvenance | null;
 }>;
-
-function lifecycleKey(agentId: string, options: OpenClawStateDatabaseOptions): string {
-  const databasePath = path.resolve(
-    options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env),
-  );
-  return `${databasePath}\0${agentId}`;
-}
 
 /** Fence authority producers while an agent deletion is pending or committed. */
 export function beginAgentDeletion(
@@ -66,7 +52,6 @@ export function beginAgentDeletion(
   options: OpenClawStateDatabaseOptions = {},
 ): {
   entry: AgentDeletionJournalEntry;
-  commit: () => void;
   fenceDatabasePaths: (paths: readonly string[]) => void;
   fenceCleanupPaths: (paths: readonly AgentDeletionJournalCleanupPath[]) => void;
   finish: () => void;
@@ -78,7 +63,6 @@ export function beginAgentDeletion(
     options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env),
   );
   const stateOptions = { ...options, path: statePath, env: options.env && { ...options.env } };
-  const key = lifecycleKey(id, stateOptions);
   const operationId = crypto.randomUUID();
   const journal = beginAgentDeletionJournal(
     { ...entry, agentId: id, operationId, deleteFiles: entry.deleteFiles !== false },
@@ -112,11 +96,9 @@ export function beginAgentDeletion(
       assertJournal(statePath, current ? [current] : []);
     },
   });
-  agentLifecycle.set(key, "deleting");
   return {
     entry: journal,
     runDatabaseCleanup,
-    commit: () => agentLifecycle.set(key, "deleted"),
     fenceDatabasePaths: (paths) => {
       if (!updateAgentDeletionJournalDatabasePaths(id, operationId, paths, stateOptions)) {
         throw new Error(`Failed to fence database cleanup paths for agent ${id}.`);
@@ -131,18 +113,14 @@ export function beginAgentDeletion(
     },
     finish: () => {
       try {
-        if (completeAgentDeletionJournal(id, operationId, stateOptions)) {
-          agentLifecycle.set(key, "deleted");
-        }
+        completeAgentDeletionJournal(id, operationId, stateOptions);
       } finally {
         active = false;
       }
     },
     rollback: () => {
       try {
-        if (removeAgentDeletionJournal(id, operationId, stateOptions)) {
-          agentLifecycle.delete(key);
-        }
+        removeAgentDeletionJournal(id, operationId, stateOptions);
       } finally {
         active = false;
       }
@@ -156,12 +134,7 @@ export function claimCompletedAgentDeletion(
   operationId: string,
   options: OpenClawStateDatabaseOptions = {},
 ): boolean {
-  const id = normalizeAgentId(agentId);
-  const removed = claimCompletedAgentDeletionJournal(id, operationId, options);
-  if (removed) {
-    agentLifecycle.delete(lifecycleKey(id, options));
-  }
-  return removed;
+  return claimCompletedAgentDeletionJournal(normalizeAgentId(agentId), operationId, options);
 }
 
 /** Return whether this process must refuse new authority for an agent id. */
@@ -169,13 +142,7 @@ export function isAgentDeletionBlocked(
   agentId: string,
   options: OpenClawStateDatabaseOptions = {},
 ): boolean {
-  const id = normalizeAgentId(agentId);
-  const key = lifecycleKey(id, options);
-  const journal = readAgentDeletionJournal(id, options);
-  if (!journal) {
-    agentLifecycle.delete(key);
-  }
-  return Boolean(journal);
+  return Boolean(readAgentDeletionJournal(normalizeAgentId(agentId), options));
 }
 
 /** Captures the exact durable incarnation of an existing, deletion-safe agent. */

--- a/src/claws/lifecycle-config-removal.ts
+++ b/src/claws/lifecycle-config-removal.ts
@@ -213,7 +213,6 @@ export async function withClawAgentConfigRemoval<T>(
         async () => commitClawAgentConfigRemoval({ ...params, config }),
         params.stateDatabase,
       );
-      deletion.commit();
       committed = true;
       return {
         ...result,

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -311,7 +311,6 @@ export async function agentsDeleteCommand(
       // Credential resolution fails before transport, so a live scheduler may still own the store.
       await commitRoster();
     }
-    deletion.commit();
   } catch (error) {
     if (!existingJournal) {
       deletion.rollback();

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -39,7 +39,6 @@ const mocks = vi.hoisted(() => ({
   withAgentExecApprovalsRemoved: vi.fn(
     async (_agentId: string, commit: () => Promise<unknown>) => await commit(),
   ),
-  beginAgentDeletionCommit: vi.fn(),
   beginAgentDeletionRollback: vi.fn(),
   beginAgentDeletionFinish: vi.fn(),
   runAgentDatabaseCleanup: vi.fn(
@@ -239,7 +238,6 @@ vi.mock("../../agents/agent-lifecycle-registry.js", () => ({
       databasePaths: entry.databasePaths ?? [],
       cleanupPaths: entry.cleanupPaths ?? [],
     }),
-    commit: mocks.beginAgentDeletionCommit,
     fenceDatabasePaths: (paths: string[]) => {
       entry.databasePaths = [...new Set(paths)];
     },
@@ -393,7 +391,6 @@ beforeEach(() => {
   mocks.withAgentExecApprovalsRemoved
     .mockReset()
     .mockImplementation(async (_agentId: string, commit: () => Promise<unknown>) => await commit());
-  mocks.beginAgentDeletionCommit.mockReset();
   mocks.beginAgentDeletionRollback.mockReset();
   mocks.beginAgentDeletionFinish.mockReset();
   mocks.readAgentDeletionJournal.mockReset().mockReturnValue(undefined);
@@ -1404,9 +1401,6 @@ describe("agents.delete", () => {
     mocks.writeConfigFile.mockImplementationOnce(async () => {
       events.push("config");
     });
-    mocks.beginAgentDeletionCommit.mockImplementationOnce(() => {
-      events.push("lifecycle");
-    });
     mocks.unregisterResolvedAgentDir.mockImplementationOnce(() => {
       events.push("directory");
       return true;
@@ -1442,7 +1436,7 @@ describe("agents.delete", () => {
       agentId: "test-agent",
       agentDir: "/agents/test-agent",
     });
-    expect(events).toEqual(["database", "cron", "approvals", "config", "lifecycle", "directory"]);
+    expect(events).toEqual(["database", "cron", "approvals", "config", "directory"]);
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
@@ -2745,7 +2739,6 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, { ok: true });
-    expect(mocks.beginAgentDeletionCommit).toHaveBeenCalledOnce();
     expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
     expect(mocks.unregisterResolvedAgentDir).toHaveBeenCalledWith({
       agentId: "test-agent",
@@ -3081,7 +3074,6 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondErrorContaining(respond, 'agent "агент✨" not found');
-    expect(mocks.beginAgentDeletionCommit).not.toHaveBeenCalled();
     expect(mocks.writeConfigFile).not.toHaveBeenCalled();
     expect(mocks.movePathToTrash).not.toHaveBeenCalled();
   });
@@ -3102,7 +3094,6 @@ describe("agents.delete", () => {
       await promise;
 
       expectRespondOk(respond, { ok: true, agentId: "main" });
-      expect(mocks.beginAgentDeletionCommit).toHaveBeenCalledOnce();
       expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
       expect(mocks.writeConfigFile).toHaveBeenCalledOnce();
     },
@@ -3121,7 +3112,6 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondErrorContaining(respond, "owns inherited credentials");
-    expect(mocks.beginAgentDeletionCommit).not.toHaveBeenCalled();
     expect(mocks.movePathToTrash).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -1157,7 +1157,6 @@ export const agentsHandlers: GatewayRequestHandlers = {
                 }
               }),
           );
-          deletion.commit();
         } catch (error) {
           let canReleaseFence =
             !rosterCommitted &&

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3159,7 +3159,6 @@ describe("openclaw agent database", () => {
     );
     try {
       expect(disposeOpenClawAgentDatabaseByPath(original.path, { env })).toBe(true);
-      deletion.commit();
       expect(original.db.isOpen).toBe(false);
       expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
       fs.mkdirSync(path.dirname(archivedDir), { recursive: true });


### PR DESCRIPTION
## What Problem This Solves

Agent deletion carried a separate process-local phase that appeared to commit deletion, although every admission decision already came from the durable deletion journal. This made the lifecycle harder to audit without affecting its behavior.

## Why This Change Was Made

Remove the unread lifecycle map and its private `commit()` phase from CLI, Gateway and Claw deletion. Keep the existing journal as the single deletion-state owner, including exact-operation fencing, rollback, cleanup, and recreation. The callers' real config-commit facts and cleanup capabilities remain intact.

This removes 36 production lines and 15 test lines. No schema, config, migration, retention, authorization, or public API changes.

## User Impact

No user-visible behavior change. Deletion, interrupted-cleanup recovery, and recreation follow the existing durable journal contract.

## Evidence

- Eight focused files passed: **310 tests**, with four existing platform skips, covering registry fencing, native database cleanup, CLI deletion, Gateway mutation, Claw removal/approvals, and recreation.
- Full changed-code gate passed, including core/core-test types, formatting, lint, three deadcode scans, schema and ownership guards.
- A synthetic native proof ran the real CLI command owner across four fresh Node processes: interrupt archive publication after session deletion, reopen and refuse premature recreation, retry cleanup, recreate the same ID, then reopen its new session. The journal and provenance followed their existing lifecycle; the surviving agent's session and approvals remained intact. The archive published once successfully after two attempts, with its multilingual content intact. Final integrity/foreign-key checks passed and zero agent-database leases remained.

The live proof invokes the CLI command owner directly; it does not claim packaged CLI parser or running-Gateway coverage.

Independent Codex review completed four evidence parts with no actionable P2-or-higher findings. The reviewed eight source hashes match the committed files.
