### PR TITLE
fix(doctor): unblock service startup with retired plugin config

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2502,7 +2502,6 @@ src/commands/doctor/shared/legacy-config-state-migration-input.ts	2
 src/commands/doctor/shared/legacy-talk-config-normalizer.ts	2
 src/commands/doctor/shared/legacy-web-tools-migrate.ts	1
 src/commands/doctor/shared/open-policy-allowfrom.ts	2
-src/commands/doctor/shared/plugin-registry-migration.ts	1
 src/commands/doctor/shared/plugin-runtime-symlinks.ts	4
 src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts	2
 src/commands/doctor/shared/preview-warnings.ts	2

--- a/scripts/lib/vitest-build-prerequisites.mts
+++ b/scripts/lib/vitest-build-prerequisites.mts
@@ -45,6 +45,7 @@ const runtimeConsumers = [
   ...[
     "src/commands/doctor-config-preflight.process.test.ts",
     "src/commands/doctor-config-preflight.v17-atomicity.process.test.ts",
+    "src/commands/doctor-plugin-install-config.process.test.ts",
   ].map((file) => ({
     file,
     configs: ["test/vitest/vitest.commands.config.ts"],

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -15,9 +15,11 @@ import { readRecentConfigAuditRecords } from "../config/io.audit.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
 import { CONFIG_PATH } from "../config/paths.js";
+import { inspectShippedPluginInstallConfigRecords } from "../config/plugin-install-config-migration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { isPathInside } from "../infra/path-guards.js";
+import { withoutPluginInstallRecords } from "../plugins/installed-plugin-index-records.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createPluginCapabilityConsentPrompter } from "../wizard/plugin-capability-consent.js";
 import {
@@ -26,7 +28,10 @@ import {
   noteOpencodeProviderOverrides,
   noteSandboxOriginProxyWarning,
 } from "./doctor-config-analysis.js";
-import { runDoctorConfigPreflight } from "./doctor-config-preflight.js";
+import {
+  runDoctorConfigPreflight,
+  shouldSkipPluginValidationForDoctorConfigPreflight,
+} from "./doctor-config-preflight.js";
 import type { DoctorOptions, DoctorPrompter } from "./doctor-prompter.js";
 import { cronCodexRuntimePolicyTargetKey } from "./doctor/cron/store-migration.js";
 import { emitDoctorNotes, sanitizeDoctorNote } from "./doctor/emit-notes.js";
@@ -40,7 +45,11 @@ import {
   type DoctorConfigMutationResult,
   type DoctorConfigMutationState,
 } from "./doctor/shared/config-mutation-state.js";
-import { isSingleTopLevelIncludeMigration } from "./doctor/shared/include-migration-ownership.js";
+import { listDoctorConfiguredChannelIds } from "./doctor/shared/configured-channel-ids.js";
+import {
+  containsAuthoredInclude,
+  isSingleTopLevelIncludeMigration,
+} from "./doctor/shared/include-migration-ownership.js";
 import { normalizeCompatibilityConfigValues } from "./doctor/shared/legacy-config-core-migrate.js";
 import type { DoctorPluginMetadataSnapshotState } from "./doctor/shared/plugin-metadata-snapshot-scope.js";
 
@@ -88,17 +97,6 @@ function collectUnsupportedInternalHookEntryWarnings(cfg: OpenClawConfig): strin
     ({ hookKey, unsupportedKeys }) =>
       `- hooks.internal.entries.${hookKey}: unsupported loader key${unsupportedKeys.length === 1 ? "" : "s"} ${unsupportedKeys.join(", ")} will not load hook modules. Use bootstrap-extra-files for session bootstrap content, or create a managed/workspace hook directory with HOOK.md + handler.js. Doctor cannot rewrite this automatically because per-hook entry keys are open-ended hook configuration.`,
   );
-}
-
-function collectConfiguredChannelIds(cfg: OpenClawConfig): string[] {
-  const channels =
-    cfg.channels && typeof cfg.channels === "object" && !Array.isArray(cfg.channels)
-      ? cfg.channels
-      : null;
-  if (!channels) {
-    return [];
-  }
-  return Object.keys(channels).filter((channelId) => channelId !== "defaults");
 }
 
 // Repair-mode "Doctor changes" panels queue until the final candidate passes the
@@ -164,7 +162,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   prompter?: DoctorPrompter;
 }) {
   const shouldRepair = params.options.repair === true || params.options.yes === true;
-  const preflight = await withProgress(
+  let preflight = await withProgress(
     {
       label: "Checking OpenClaw state…",
       enabled: params.options.nonInteractive !== true && params.options.json !== true,
@@ -182,6 +180,28 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
         },
       }),
   );
+  const { importShippedPluginInstallConfigForDoctor } =
+    await import("./doctor/shared/plugin-registry-migration.js");
+  const pluginInstallConfigImport =
+    inspectShippedPluginInstallConfigRecords(preflight.snapshot.sourceConfig).status === "valid"
+      ? await importShippedPluginInstallConfigForDoctor(preflight.snapshot)
+      : undefined;
+  if (pluginInstallConfigImport?.pluginInventoryChanged) {
+    const { readDoctorConfigPreflightSnapshot } =
+      await import("./doctor-config-preflight-plugin-index.js");
+    const refreshed = await readDoctorConfigPreflightSnapshot({
+      allowCurrentPluginMetadata: false,
+      includePluginMetadata: true,
+      preparePluginMetadataSnapshot: true,
+      skipPluginValidation: shouldSkipPluginValidationForDoctorConfigPreflight(),
+    });
+    preflight = {
+      ...preflight,
+      snapshot: refreshed.snapshot,
+      baseConfig: refreshed.snapshot.sourceConfig,
+      pluginMetadataSnapshot: refreshed.pluginMetadataSnapshot,
+    };
+  }
   const snapshot = preflight.snapshot;
   const baseCfg = preflight.baseConfig;
   const pluginMetadataSnapshotState: DoctorPluginMetadataSnapshotState = {
@@ -499,7 +519,8 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     note(sanitizeDoctorNote(pluginToolAllowlistWarnings.join("\n")), "Doctor warnings");
   }
 
-  const hasConfiguredChannels = collectConfiguredChannelIds(state.candidate).length > 0;
+  const hasConfiguredChannels =
+    listDoctorConfiguredChannelIds(state.candidate, { configEntryPolicy: "raw" }).length > 0;
   let collectMutableAllowlistWarnings:
     | typeof import("./doctor/shared/channel-doctor.js").collectChannelDoctorMutableAllowlistWarnings
     | undefined;
@@ -631,6 +652,18 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     note(unknownStep.warnings.join("\n"), "Doctor warnings");
   }
 
+  if (inspectShippedPluginInstallConfigRecords(state.candidate).status === "valid") {
+    applyConfigMutation(
+      {
+        config: withoutPluginInstallRecords(state.candidate, {
+          preserveEmptyPlugins: containsAuthoredInclude(snapshot.parsed),
+        }),
+        changes: ["Removed retired plugins.installs after preserving plugin install records."],
+      },
+      { fixHint: `Run "${doctorFixCommand}" to migrate retired plugin install records.` },
+    );
+  }
+
   const finalized = await finalizeDoctorConfigFlow({
     cfg: state.cfg,
     candidate: state.candidate,
@@ -681,6 +714,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
 
   return {
     cfg,
+    ...(pluginInstallConfigImport ? { pluginInstallConfigImport } : {}),
     path: snapshot.path ?? CONFIG_PATH,
     shouldWriteConfig,
     ...(shouldWriteConfig && pendingChangePanels.length > 0 ? { pendingChangePanels } : {}),

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -12,6 +12,7 @@ import type { ConfigSnapshotReadMeasure } from "../config/io.js";
 import { logConfigWarningsOnce } from "../config/io.warnings.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { resolveStateDir } from "../config/paths.js";
+import { inspectShippedPluginInstallConfigRecords } from "../config/plugin-install-config-migration.js";
 import type { ConfigFileSnapshot } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
@@ -317,6 +318,8 @@ export async function runDoctorConfigPreflight(
     let snapshot = configSnapshotRead.snapshot;
     let activeConfigRepair: ReturnType<typeof planAutomaticConfigRepair> = null;
     if (options.repairPrefixedConfig === true && snapshot.exists && !snapshot.valid) {
+      const pendingPluginInstallConfig =
+        inspectShippedPluginInstallConfigRecords(snapshot.sourceConfig).status !== "missing";
       // Migrate readable active bytes before rollback; otherwise one retired key can discard
       // newer valid settings that the canonical Doctor migration would preserve.
       activeConfigRepair =
@@ -335,6 +338,8 @@ export async function runDoctorConfigPreflight(
         configRepaired = true;
       } else if (
         !activeConfigRepair &&
+        // Config preparation imports these records; backup recovery would erase its source.
+        !pendingPluginInstallConfig &&
         (await recoverConfigFromLastKnownGood({ snapshot, reason: "doctor-invalid-config" }))
       ) {
         note(

--- a/src/commands/doctor-plugin-install-config.process.test.ts
+++ b/src/commands/doctor-plugin-install-config.process.test.ts
@@ -1,0 +1,266 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  readPersistedInstalledPluginIndexInstallRecords,
+  writePersistedInstalledPluginIndexInstallRecords,
+} from "../plugins/installed-plugin-index-records.js";
+import {
+  createBuiltRuntime,
+  runBuiltRuntime,
+  runIsolatedModuleScript,
+} from "./doctor-config-preflight.process.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterAll);
+const doctorArgs = ["doctor", "--fix", "--non-interactive", "--no-workspace-suggestions"];
+let runtimeRoot: string;
+
+beforeAll(() => {
+  runtimeRoot = createBuiltRuntime(fs.realpathSync(tempDirs.make("doctor-plugin-config-runtime-")));
+});
+
+function createDoctorFixture() {
+  const root = fs.realpathSync(tempDirs.make("doctor-plugin-config-"));
+  const stateDir = path.join(root, "state");
+  const configPath = path.join(stateDir, "openclaw.json");
+  fs.mkdirSync(stateDir, { recursive: true });
+  const env: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH,
+    SystemRoot: process.env.SystemRoot,
+    WINDIR: process.env.WINDIR,
+    ComSpec: process.env.ComSpec,
+    HOME: root,
+    USERPROFILE: root,
+    TMPDIR: root,
+    OPENCLAW_STATE_DIR: stateDir,
+    OPENCLAW_CONFIG_PATH: configPath,
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    NO_COLOR: "1",
+  };
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      gateway: { mode: "local", auth: { mode: "none" } },
+      plugins: { enabled: false },
+    }),
+  );
+  const bootstrap = runBuiltRuntime(runtimeRoot, env, doctorArgs, 60_000);
+  expect(bootstrap.status, `${bootstrap.stdout}\n${bootstrap.stderr}`).toBe(0);
+  const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as OpenClawConfig;
+  return { root, stateDir, configPath, env, config };
+}
+
+describe("Doctor retired plugin install config", () => {
+  it.each(["empty", "populated", "included", "empty-included"] as const)(
+    "removes %s legacy records after preserving the canonical install index",
+    async (kind) => {
+      const { root, stateDir, configPath, env, config } = createDoctorFixture();
+      const empty = kind === "empty" || kind === "empty-included";
+      const included = kind === "included" || kind === "empty-included";
+      const durable = { source: "path" as const, installPath: path.join(root, "current-plugin") };
+      await writePersistedInstalledPluginIndexInstallRecords(
+        { existing: durable },
+        { stateDir, env, config },
+      );
+      const legacy = { source: "path" as const, installPath: path.join(root, "missing-plugin") };
+      config.plugins = {
+        ...(kind === "empty-included" ? {} : config.plugins),
+        installs: empty ? {} : { existing: legacy, imported: legacy },
+      };
+      if (included) {
+        fs.writeFileSync(path.join(stateDir, "plugins.json"), JSON.stringify(config.plugins));
+      }
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify(included ? { ...config, plugins: { $include: "./plugins.json" } } : config),
+      );
+      // A promoted backup would restore an older file and hide the missing migration.
+      expect(fs.existsSync(`${configPath}.last-good`)).toBe(false);
+
+      for (const pass of ["repair", "repeat"]) {
+        const result = runBuiltRuntime(runtimeRoot, env, doctorArgs, 60_000);
+        const output = `${pass}: ${result.stdout}\n${result.stderr}`;
+        expect(result.error, output).toBeUndefined();
+        expect(result.status, output).toBe(0);
+        const repaired = JSON.parse(fs.readFileSync(configPath, "utf8")) as OpenClawConfig;
+        expect(repaired.plugins, output).not.toHaveProperty("installs");
+        if (included) {
+          expect(repaired.plugins).toEqual({ $include: "./plugins.json" });
+          expect(JSON.parse(fs.readFileSync(path.join(stateDir, "plugins.json"), "utf8"))).toEqual(
+            kind === "empty-included" ? {} : { enabled: false },
+          );
+        }
+        expect(await readPersistedInstalledPluginIndexInstallRecords({ stateDir, env })).toEqual(
+          empty ? { existing: durable } : { existing: durable, imported: legacy },
+        );
+        const validation = runBuiltRuntime(runtimeRoot, env, ["config", "validate"], 30_000);
+        expect(validation.status, `${validation.stdout}\n${validation.stderr}`).toBe(0);
+      }
+    },
+    120_000,
+  );
+
+  it("preserves records when plain Doctor gains config-write consent after preflight", async () => {
+    const { root, stateDir, configPath, env, config } = createDoctorFixture();
+    const legacy = { source: "path" as const, installPath: path.join(root, "missing-plugin") };
+    const candidate = { ...config, plugins: { ...config.plugins, installs: { imported: legacy } } };
+    fs.writeFileSync(configPath, JSON.stringify({ ...candidate, unknownKey: true }));
+    const writerUrl = new URL(
+      "../flows/doctor-health-contribution-runners.config.ts",
+      import.meta.url,
+    );
+    const configFlowUrl = new URL("./doctor-config-flow.ts", import.meta.url).href;
+    const result = await runIsolatedModuleScript(
+      env,
+      `
+      const { runWriteConfigHealth } = await import(${JSON.stringify(writerUrl.href)});
+      const { loadAndMaybeMigrateDoctorConfig } = await import(${JSON.stringify(configFlowUrl)});
+      const runtime = { log() {}, error() {}, exit(code) { throw new Error(String(code)); } };
+      const configResult = await loadAndMaybeMigrateDoctorConfig({
+        options: {}, confirm: async () => true, runtime,
+      });
+      const cfg = configResult.cfg;
+      await runWriteConfigHealth({
+        runtime,
+        options: {},
+        prompter: { shouldRepair: false },
+        configResult,
+        cfg,
+        cfgForPersistence: { ...cfg, unknownKey: true },
+        sourceConfigValid: false,
+        configPath: ${JSON.stringify(configPath)},
+        invalidatePluginMetadataSnapshot: configResult.invalidatePluginMetadataSnapshot,
+        runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot,
+      });
+    `,
+      { timeoutMs: 60_000 },
+    );
+    const repaired = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    expect(repaired.plugins, result.stderr).not.toHaveProperty("installs");
+    expect(repaired).not.toHaveProperty("unknownKey");
+    expect(await readPersistedInstalledPluginIndexInstallRecords({ stateDir, env })).toEqual({
+      imported: legacy,
+    });
+  }, 90_000);
+
+  it("leaves malformed source records untouched before other config repairs", () => {
+    const { configPath, env, config } = createDoctorFixture();
+    const raw = JSON.stringify({
+      ...config,
+      unknownKey: true,
+      plugins: { ...config.plugins, installs: { broken: { source: "invalid" } } },
+    });
+    fs.writeFileSync(configPath, raw);
+    const result = runBuiltRuntime(runtimeRoot, env, doctorArgs, 60_000);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      "plugins.installs contains invalid records",
+    );
+    expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+  }, 90_000);
+
+  it("does not replay source records after later registry cleanup", async () => {
+    const { root, stateDir, configPath, env, config } = createDoctorFixture();
+    const legacy = { source: "path", installPath: path.join(root, "missing-plugin") };
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ ...config, plugins: { ...config.plugins, installs: { retired: legacy } } }),
+    );
+    const configFlowUrl = new URL("./doctor-config-flow.ts", import.meta.url).href;
+    const writerUrl = new URL(
+      "../flows/doctor-health-contribution-runners.config.ts",
+      import.meta.url,
+    ).href;
+    const recordsUrl = new URL("../plugins/installed-plugin-index-records.ts", import.meta.url)
+      .href;
+    const result = await runIsolatedModuleScript(
+      env,
+      `
+      import fs from "node:fs";
+      const { loadAndMaybeMigrateDoctorConfig } = await import(${JSON.stringify(configFlowUrl)});
+      const { runInitialConfigWriteHealth, runWriteConfigHealth } = await import(${JSON.stringify(writerUrl)});
+      const { writePersistedInstalledPluginIndexInstallRecords } = await import(${JSON.stringify(recordsUrl)});
+      const runtime = { log() {}, error() {}, exit(code) { throw new Error(String(code)); } };
+      const options = { repair: true, nonInteractive: true, workspaceSuggestions: false };
+      const configResult = await loadAndMaybeMigrateDoctorConfig({
+        options, confirm: async () => true, runtime,
+      });
+      const ctx = {
+        runtime, options, configResult, cfg: configResult.cfg,
+        cfgForPersistence: structuredClone(configResult.cfg),
+        sourceConfigValid: false, configPath: ${JSON.stringify(configPath)},
+        prompter: { shouldRepair: true },
+        invalidatePluginMetadataSnapshot: configResult.invalidatePluginMetadataSnapshot,
+        runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot,
+      };
+      await writePersistedInstalledPluginIndexInstallRecords({}, { config: ctx.cfg });
+      await runInitialConfigWriteHealth(ctx);
+      fs.copyFileSync(ctx.configPath, ${JSON.stringify(path.join(root, "first-write.json"))});
+      ctx.cfg = { ...ctx.cfg, gateway: { ...ctx.cfg.gateway, bind: "loopback" } };
+      await runWriteConfigHealth(ctx);
+    `,
+      { timeoutMs: 60_000 },
+    );
+    expect(
+      JSON.parse(fs.readFileSync(path.join(root, "first-write.json"), "utf8")).plugins,
+      result.stderr,
+    ).not.toHaveProperty("installs");
+    expect(await readPersistedInstalledPluginIndexInstallRecords({ stateDir, env })).toEqual({});
+    expect(JSON.parse(fs.readFileSync(configPath, "utf8")).plugins).not.toHaveProperty("installs");
+  }, 90_000);
+
+  it("preserves enabled custom-path plugin settings before stale-config repair", async () => {
+    const { root, stateDir, configPath, env, config } = createDoctorFixture();
+    const pluginDir = path.join(root, "custom-plugin");
+    fs.mkdirSync(pluginDir);
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "migration-proof-plugin",
+        version: "1.0.0",
+        type: "module",
+        openclaw: { extensions: ["./index.js"] },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "migration-proof-plugin",
+        configSchema: {
+          type: "object",
+          properties: { sentinel: { type: "string" } },
+          additionalProperties: false,
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "index.js"),
+      'export default { id: "migration-proof-plugin", register() {} };\n',
+    );
+    const legacy = { source: "path" as const, sourcePath: pluginDir, installPath: pluginDir };
+    const entry = { enabled: true, config: { sentinel: "preserved" } };
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        ...config,
+        plugins: {
+          enabled: true,
+          entries: { "migration-proof-plugin": entry },
+          installs: { "migration-proof-plugin": legacy },
+        },
+      }),
+    );
+    const result = runBuiltRuntime(runtimeRoot, env, doctorArgs, 60_000);
+    const output = `${result.stdout}\n${result.stderr}`;
+    expect(result.status, output).toBe(0);
+    const repaired = JSON.parse(fs.readFileSync(configPath, "utf8")) as OpenClawConfig;
+    expect(repaired.plugins, output).not.toHaveProperty("installs");
+    expect(repaired.plugins?.entries?.["migration-proof-plugin"], output).toEqual(entry);
+    expect(
+      (await readPersistedInstalledPluginIndexInstallRecords({ stateDir, env }))?.[
+        "migration-proof-plugin"
+      ],
+    ).toEqual(legacy);
+  }, 90_000);
+});

--- a/src/commands/doctor-plugin-registry.provenance.test.ts
+++ b/src/commands/doctor-plugin-registry.provenance.test.ts
@@ -1,5 +1,9 @@
+import fs from "node:fs";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { note } from "../../packages/terminal-core/src/note.js";
+import { readConfigFileSnapshot } from "../config/config.js";
+import { withEnvOverride } from "../config/test-helpers.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
 import { isTrustedOfficialPluginInstallRecord } from "../plugins/official-external-install-records.js";
@@ -10,6 +14,7 @@ import {
   hermeticEnv,
   readRequiredPersistedInstalledPluginIndex,
 } from "./doctor-plugin-registry.test-support.js";
+import { importShippedPluginInstallConfigForDoctor } from "./doctor/shared/plugin-registry-migration.js";
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({ note: vi.fn() }));
 
@@ -38,6 +43,20 @@ describe("doctor official plugin provenance", () => {
           { ...createCurrentIndex(), installRecords },
           { stateDir },
         );
+      } else {
+        const configPath = path.join(stateDir, "openclaw.json");
+        fs.writeFileSync(configPath, JSON.stringify(config));
+        await withEnvOverride(
+          {
+            ...hermeticEnv(),
+            OPENCLAW_CONFIG_PATH: configPath,
+            OPENCLAW_STATE_DIR: stateDir,
+            OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          },
+          async () => {
+            await importShippedPluginInstallConfigForDoctor(await readConfigFileSnapshot());
+          },
+        );
       }
       expect(
         isTrustedOfficialPluginInstallRecord({ pluginId, packageName, record: legacyRecord }),
@@ -47,7 +66,7 @@ describe("doctor official plugin provenance", () => {
         stateDir,
         candidates: [],
         env: hermeticEnv(),
-        config,
+        config: {},
         prompter: { shouldRepair: true },
       });
 

--- a/src/commands/doctor/shared/plugin-registry-migration.test.ts
+++ b/src/commands/doctor/shared/plugin-registry-migration.test.ts
@@ -509,7 +509,7 @@ describe("doctor plugin registry migration", () => {
     expect(requirePlugin(persisted, "demo").pluginId).toBe("demo");
   });
 
-  it("seeds first-run install records from shipped plugins.installs config", async () => {
+  it("indexes records already imported from shipped config", async () => {
     const stateDir = makeTempDir();
     const pluginDir = path.join(stateDir, "plugins", "demo");
     fs.mkdirSync(pluginDir, { recursive: true });
@@ -517,18 +517,14 @@ describe("doctor plugin registry migration", () => {
     const result = await migratePluginRegistryForDoctor({
       stateDir,
       candidates: [createCandidate(pluginDir, "demo", "global", { installOwner: "demo" })],
+      installRecords: {
+        demo: { source: "npm", spec: "demo@1.0.0", installPath: pluginDir },
+      },
       readConfig: async () => ({
         plugins: {
           entries: {
             demo: {
               enabled: true,
-            },
-          },
-          installs: {
-            demo: {
-              source: "npm",
-              spec: "demo@1.0.0",
-              installPath: pluginDir,
             },
           },
         },
@@ -557,25 +553,21 @@ describe("doctor plugin registry migration", () => {
     expectSha256(requirePlugin(persisted, "demo").installRecordHash);
   });
 
-  it("preserves shipped install records when the plugin manifest cannot be discovered", async () => {
+  it("preserves imported records when the plugin manifest cannot be discovered", async () => {
     const stateDir = makeTempDir();
     const pluginDir = path.join(stateDir, "plugins", "missing");
 
     const result = await migratePluginRegistryForDoctor({
       stateDir,
       candidates: [],
+      installRecords: {
+        missing: { source: "npm", spec: "missing-plugin@1.0.0", installPath: pluginDir },
+      },
       readConfig: async () => ({
         plugins: {
           entries: {
             missing: {
               enabled: true,
-            },
-          },
-          installs: {
-            missing: {
-              source: "npm",
-              spec: "missing-plugin@1.0.0",
-              installPath: pluginDir,
             },
           },
         },

--- a/src/commands/doctor/shared/plugin-registry-migration.ts
+++ b/src/commands/doctor/shared/plugin-registry-migration.ts
@@ -1,19 +1,21 @@
 // Doctor migration from legacy shipped plugin install config into persisted install registry.
 import fs from "node:fs";
+import { isDeepStrictEqual } from "node:util";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import {
-  extractShippedPluginInstallConfigRecords,
-  inspectShippedPluginInstallConfigRecords,
-  stripShippedPluginInstallConfigRecords,
-} from "../../../config/plugin-install-config-migration.js";
+import { ConfigMutationConflictError } from "../../../config/mutation-conflict.js";
+import { inspectShippedPluginInstallConfigRecords } from "../../../config/plugin-install-config-migration.js";
 import {
   copyPluginInstallRecordMap,
   setPluginInstallRecordMapEntry,
 } from "../../../config/plugin-install-record-map.js";
-import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../../config/types.plugins.js";
 import { inspectPersistedInstalledPluginIndexInstallRecordsSync } from "../../../plugins/installed-plugin-index-record-state.js";
-import { loadInstalledPluginIndexInstallRecords } from "../../../plugins/installed-plugin-index-records.js";
+import {
+  loadInstalledPluginIndexInstallRecords,
+  readPersistedInstalledPluginIndexInstallRecords,
+  withoutPluginInstallRecords,
+} from "../../../plugins/installed-plugin-index-records.js";
 import { writePersistedInstalledPluginIndex } from "../../../plugins/installed-plugin-index-store-write.js";
 import {
   readPersistedInstalledPluginIndexSync,
@@ -106,6 +108,120 @@ function invalidPersistedInstallRecordMessage(filePath: string): string {
 
 const INVALID_CONFIG_INSTALL_RECORD_MESSAGE =
   "plugins.installs contains invalid records. Back up openclaw.json, correct or remove the invalid retired plugins.installs record, then rerun `openclaw doctor --fix`.";
+
+export type ShippedPluginInstallConfigImport = {
+  source: Pick<ConfigFileSnapshot, "path" | "hash" | "sourceConfig">;
+  databasePath: string;
+  pluginInventoryChanged: boolean;
+};
+
+/** Check the accepted source again inside the config writer's lock. */
+export function assertShippedPluginInstallConfigImportCurrent(
+  snapshot: ConfigFileSnapshot,
+  imported: ShippedPluginInstallConfigImport | undefined,
+): void {
+  const source = inspectShippedPluginInstallConfigRecords(snapshot.sourceConfig);
+  if (source.status === "missing") {
+    return;
+  }
+  if (source.status === "invalid") {
+    throw new InvalidPluginInstallRecordStateError(INVALID_CONFIG_INSTALL_RECORD_MESSAGE);
+  }
+  if (
+    !imported ||
+    imported.databasePath !== resolveInstalledPluginIndexStorePath() ||
+    !isDeepStrictEqual(imported.source, {
+      path: snapshot.path,
+      hash: snapshot.hash,
+      sourceConfig: snapshot.sourceConfig,
+    })
+  ) {
+    throw new ConfigMutationConflictError("config changed after plugin install migration");
+  }
+}
+
+/** Preserve retired source records before Doctor can restore or rewrite their config. */
+export async function importShippedPluginInstallConfigForDoctor(
+  snapshot: ConfigFileSnapshot,
+): Promise<ShippedPluginInstallConfigImport | undefined> {
+  const source = inspectShippedPluginInstallConfigRecords(snapshot.sourceConfig);
+  if (source.status === "missing") {
+    return undefined;
+  }
+  if (source.status === "invalid") {
+    throw new InvalidPluginInstallRecordStateError(INVALID_CONFIG_INSTALL_RECORD_MESSAGE);
+  }
+  const { readConfigFileSnapshotForWrite, withConfigMutationExclusive } =
+    await import("../../../config/config.js");
+  const sourceIdentity = {
+    path: snapshot.path,
+    hash: snapshot.hash,
+    sourceConfig: snapshot.sourceConfig,
+  };
+  const receipt = (databasePath: string, pluginInventoryChanged: boolean) => ({
+    source: structuredClone(sourceIdentity),
+    databasePath,
+    pluginInventoryChanged,
+  });
+  if (Object.keys(source.records).length === 0) {
+    return receipt(resolveInstalledPluginIndexStorePath(), false);
+  }
+  const { commitPluginInstallRecordsOnly } =
+    await import("../../../plugins/install-record-commit.js");
+  const { withPluginLifecycleLease } = await import("../../../plugins/plugin-lifecycle-lease.js");
+  // Installers take the plugin lease before the config lock; retain that order here.
+  return await withPluginLifecycleLease({}, async (lease) =>
+    withConfigMutationExclusive(async () => {
+      const prepared = await readConfigFileSnapshotForWrite();
+      if (
+        prepared.snapshot.path !== snapshot.path ||
+        prepared.snapshot.hash !== snapshot.hash ||
+        !isDeepStrictEqual(prepared.snapshot.sourceConfig, snapshot.sourceConfig)
+      ) {
+        throw new ConfigMutationConflictError("config changed before plugin install migration");
+      }
+      const storeOptions = { filePath: lease.databasePath };
+      const previousInstallRecords = await loadInstalledPluginIndexInstallRecords(storeOptions);
+      const persisted = await readPersistedInstalledPluginIndexInstallRecords(storeOptions);
+      let nextInstallRecords = copyPluginInstallRecordMap(previousInstallRecords);
+      for (const [pluginId, record] of Object.entries(source.records)) {
+        // Authored provenance outranks disk recovery, but never an existing ledger owner.
+        if (!persisted || !Object.hasOwn(persisted, pluginId)) {
+          setPluginInstallRecordMapEntry(nextInstallRecords, pluginId, record);
+        }
+      }
+      nextInstallRecords = migrateOfficialPluginInstallProvenance(nextInstallRecords);
+      if (isDeepStrictEqual(nextInstallRecords, persisted)) {
+        return receipt(lease.databasePath, false);
+      }
+      await commitPluginInstallRecordsOnly({
+        previousInstallRecords,
+        nextInstallRecords,
+        nextConfig: withoutPluginInstallRecords(snapshot.sourceConfig),
+        verifyConfigFresh: async () => {
+          prepared.writeOptions.assertConfigPathForWrite?.();
+          const current = await readConfigFileSnapshotForWrite();
+          // Includes can change without changing the root hash; retain the whole write ownership.
+          if (
+            current.snapshot.path !== prepared.snapshot.path ||
+            current.snapshot.hash !== prepared.snapshot.hash ||
+            !isDeepStrictEqual(
+              current.writeOptions.includeFileHashesForWrite,
+              prepared.writeOptions.includeFileHashesForWrite,
+            ) ||
+            !isDeepStrictEqual(
+              current.writeOptions.includeFileTargetsForWrite,
+              prepared.writeOptions.includeFileTargetsForWrite,
+            )
+          ) {
+            throw new ConfigMutationConflictError("config changed during plugin install migration");
+          }
+        },
+      });
+      return receipt(lease.databasePath, true);
+    }),
+  );
+}
 
 export type PluginRegistryDoctorMigrationParams = LoadInstalledPluginIndexParams &
   InstalledPluginIndexStoreOptions & {
@@ -333,7 +449,7 @@ function listMigrationRelevantPluginRecords(params: {
   });
 }
 
-/** Persist Doctor's migrated plugin registry from legacy config/install records when needed. */
+/** Rebuild Doctor's plugin registry from canonical install records when needed. */
 export async function migratePluginRegistryForDoctor(
   params: PluginRegistryDoctorMigrationParams = {},
 ): Promise<PluginRegistryDoctorMigrationResult> {
@@ -349,16 +465,10 @@ export async function migratePluginRegistryForDoctor(
   if (inspectShippedPluginInstallConfigRecords(rawConfig).status === "invalid") {
     throw new InvalidPluginInstallRecordStateError(INVALID_CONFIG_INSTALL_RECORD_MESSAGE);
   }
-  const config = stripShippedPluginInstallConfigRecords(rawConfig) as OpenClawConfig;
-  const durableInstallRecords =
-    params.installRecords ?? (await loadInstalledPluginIndexInstallRecords(params));
-  let installRecords = copyPluginInstallRecordMap(
-    extractShippedPluginInstallConfigRecords(rawConfig),
+  const config = withoutPluginInstallRecords(rawConfig);
+  const installRecords = migrateOfficialPluginInstallProvenance(
+    params.installRecords ?? (await loadInstalledPluginIndexInstallRecords(params)),
   );
-  for (const [pluginId, record] of Object.entries(durableInstallRecords)) {
-    setPluginInstallRecordMapEntry(installRecords, pluginId, record);
-  }
-  installRecords = migrateOfficialPluginInstallProvenance(installRecords);
   const migrationParams = {
     ...params,
     config,

--- a/src/config/plugin-install-config-migration.ts
+++ b/src/config/plugin-install-config-migration.ts
@@ -1,28 +1,9 @@
-// Migrates plugin install config entries into canonical config shape.
+// Validates retired plugin install config before Doctor migrates its records.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   inspectPluginInstallRecordMap,
   type PluginInstallRecordMapState,
 } from "./plugin-install-record-map.js";
-import type { PluginInstallRecord } from "./types.plugins.js";
-
-function pruneEmptyPluginsObject(plugins: Record<string, unknown>): unknown {
-  const { installs: _installs, ...rest } = plugins;
-  return Object.keys(rest).length === 0 ? undefined : rest;
-}
-
-/**
- * Reads legacy shipped `plugins.installs` records for migration into the plugin index.
- *
- * Invalid install maps are ignored so config loading can keep using the stripped
- * runtime config while doctor/write paths decide how to report or recover.
- */
-export function extractShippedPluginInstallConfigRecords(
-  config: unknown,
-): Record<string, PluginInstallRecord> {
-  const state = inspectShippedPluginInstallConfigRecords(config);
-  return state.status === "valid" ? state.records : {};
-}
 
 export function inspectShippedPluginInstallConfigRecords(
   config: unknown,
@@ -31,14 +12,4 @@ export function inspectShippedPluginInstallConfigRecords(
     return { status: "missing" };
   }
   return inspectPluginInstallRecordMap(config.plugins.installs);
-}
-
-/** Removes legacy shipped `plugins.installs` without mutating the original config object. */
-export function stripShippedPluginInstallConfigRecords(config: unknown): unknown {
-  if (!isRecord(config) || !isRecord(config.plugins) || !("installs" in config.plugins)) {
-    return config;
-  }
-  const plugins = pruneEmptyPluginsObject(config.plugins);
-  const { plugins: _plugins, ...rest } = config;
-  return plugins === undefined ? rest : { ...rest, plugins };
 }

--- a/src/flows/doctor-health-contribution-runners.config.ts
+++ b/src/flows/doctor-health-contribution-runners.config.ts
@@ -75,9 +75,16 @@ export async function runWriteConfigHealth(
       resolveLegacyParentVersionOverride(ctx).lastTouchedVersionOverride;
     const { restoreDoctorConfigEnvRefs } =
       await import("../commands/doctor/shared/config-flow-steps.js");
+    const { assertShippedPluginInstallConfigImportCurrent } =
+      await import("../commands/doctor/shared/plugin-registry-migration.js");
     try {
       await transformConfigFile({
         transform: (_current, { snapshot }, { envSnapshotForRestore }) => {
+          // Revalidate the copied source under the config lock; never import after plugin repair.
+          assertShippedPluginInstallConfigImportCurrent(
+            snapshot,
+            ctx.configResult.pluginInstallConfigImport,
+          );
           const nextConfig = restoreDoctorConfigEnvRefs(ctx.cfg, snapshot, envSnapshotForRestore);
           return { nextConfig };
         },

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -1,6 +1,7 @@
 import type { RetiredAuthProfileCleanupPlan } from "../commands/doctor-auth-legacy-oauth.js";
 import type { probeGatewayMemoryStatus } from "../commands/doctor-gateway-health.js";
 import type { DoctorOptions, DoctorPrompter } from "../commands/doctor-prompter.js";
+import type { ShippedPluginInstallConfigImport } from "../commands/doctor/shared/plugin-registry-migration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { buildGatewayConnectionDetails } from "../gateway/call.js";
 import type { UpdatePostInstallDoctorResult } from "../infra/update-doctor-result.js";
@@ -12,6 +13,7 @@ import type { FlowContribution } from "./types.js";
 
 type DoctorConfigResult = {
   cfg: OpenClawConfig;
+  pluginInstallConfigImport?: ShippedPluginInstallConfigImport;
   path?: string;
   shouldWriteConfig?: boolean;
   /** Repair panels held back until the atomic config write commits. */

--- a/src/flows/doctor-plugin-install-config-write.test.ts
+++ b/src/flows/doctor-plugin-install-config-write.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDoctorConfigSnapshot } from "../commands/doctor-config-snapshot.test-helpers.js";
+import { createDoctorPrompter } from "../commands/doctor-prompter.js";
+import type { ConfigFileSnapshot } from "../config/types.openclaw.js";
+import { resolveInstalledPluginIndexStorePath } from "../plugins/installed-plugin-index-store.js";
+import { runWriteConfigHealth } from "./doctor-health-contribution-runners.config.js";
+import type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
+
+const mocks = vi.hoisted(() => ({
+  lockedSnapshot: vi.fn<() => ConfigFileSnapshot>(),
+  write: vi.fn(),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config.js")>()),
+  transformConfigFile: async ({
+    transform,
+  }: Parameters<typeof import("../config/config.js").transformConfigFile>[0]) => {
+    const snapshot = mocks.lockedSnapshot();
+    const next = await transform(
+      snapshot.sourceConfig,
+      { snapshot, previousHash: snapshot.hash ?? null, attempt: 0 },
+      {},
+    );
+    return mocks.write(next);
+  },
+}));
+
+vi.mock("../commands/onboard-helpers.js", () => ({
+  applyWizardMetadata: (config: unknown) => config,
+}));
+
+vi.mock("../config/logging.js", () => ({
+  logConfigUpdated() {},
+}));
+
+vi.mock("../commands/doctor/shared/config-flow-steps.js", () => ({
+  restoreDoctorConfigEnvRefs: (config: unknown) => config,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Doctor install-source write ownership", () => {
+  it.each(["root", "include"] as const)(
+    "refuses %s source records added before the locked write snapshot",
+    async (source) => {
+      const initialConfig = { plugins: { installs: {} } };
+      const changedConfig = {
+        plugins: { installs: { added: { source: "path" as const, installPath: "/new-plugin" } } },
+      };
+      const parsed =
+        source === "include" ? { plugins: { $include: "./plugins.json" } } : initialConfig;
+      const initial = {
+        ...createDoctorConfigSnapshot({ config: initialConfig, parsed }),
+        hash: "accepted-root",
+      };
+      const changed = {
+        ...createDoctorConfigSnapshot({ config: changedConfig, parsed }),
+        hash: source === "include" ? initial.hash : "changed-root",
+      };
+      mocks.lockedSnapshot.mockReturnValue(changed);
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      const options = { repair: true, nonInteractive: true };
+      const cfg = { plugins: {} };
+      const ctx: DoctorHealthFlowContext = {
+        runtime,
+        options,
+        prompter: createDoctorPrompter({ runtime, options }),
+        configResult: {
+          cfg,
+          shouldWriteConfig: true,
+          pluginInstallConfigImport: {
+            source: { path: initial.path, hash: initial.hash, sourceConfig: initial.sourceConfig },
+            databasePath: resolveInstalledPluginIndexStorePath(),
+            pluginInventoryChanged: false,
+          },
+        },
+        cfg,
+        cfgForPersistence: initialConfig,
+        sourceConfigValid: false,
+        configPath: initial.path,
+      };
+
+      await expect(runWriteConfigHealth(ctx)).rejects.toThrow(
+        "config changed after plugin install migration",
+      );
+      expect(mocks.write).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -1871,6 +1871,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     const runtimeTargets = [
       "test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts",
       ...doctorRuntimeTargets,
+      "src/commands/doctor-plugin-install-config.process.test.ts",
       "src/gateway/gateway-active-memory.test.ts",
       "src/gateway/gateway-concurrent-streams.test.ts",
       "src/gateway/gateway-cron-process-identity.windows.test.ts",
@@ -2482,7 +2483,8 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         checkName: `checks-node-${shard.shardName}`,
         configs: ["test/vitest/vitest.commands.config.ts"],
         includePatterns: shard.includePatterns,
-        ...(shard.shardName === "agentic-commands-doctor-config-state"
+        ...(shard.shardName === "agentic-commands-doctor-config-state" ||
+        shard.shardName === "agentic-commands-doctor-plugins-tools"
           ? { pretestBuildMode: "runtime" }
           : {}),
         requiresDist: false,

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -76,6 +76,11 @@ describe("test runtime prerequisites", () => {
       ["src/commands/doctor-config-preflight.v17-atomicity.process.test.ts"],
       "runtime",
     ],
+    [
+      "Doctor retired plugin config",
+      ["src/commands/doctor-plugin-install-config.process.test.ts"],
+      "runtime",
+    ],
     ["commands directory", ["src/commands"], "runtime"],
     ["commands config", ["test/vitest/vitest.commands.config.ts"], "runtime"],
     ["ordinary Doctor unit test", ["src/commands/doctor-config-preflight.test.ts"], undefined],


### PR DESCRIPTION
Closes #138652. Thanks @worldtrading520 for the report.

## What Problem This Solves

Doctor could leave retired plugin-install settings in the config, blocking service startup. Restoring an older backup could also discard pending install records.

## Why This Change Was Made

Doctor now imports validated records before discovery or cleanup, preserves existing records, then removes the retired key through the guarded config writer. Malformed records remain intact with repair guidance.

## User Impact

Valid legacy config can start the service after repair, including config with includes. Repeated repair preserves install records. No new config option or database change.

## Evidence

Installed CLI → Doctor → strict service startup reproduced the failures before the fix and passed afterward. Process regressions cover empty and populated maps, backups, includes, malformed records, cleanup ordering, and concurrent source changes. Focused config and migration suites passed. Native Windows scheduling was not tested.
