### PR TITLE
perf(plugins): reuse normalized loader configuration facts

### DIFF
--- a/src/plugins/loader-cache.test.ts
+++ b/src/plugins/loader-cache.test.ts
@@ -3,17 +3,27 @@ import { describe, expect, it } from "vitest";
 import { resolvePluginRegistryLoadCacheKey } from "./loader-cache.js";
 
 describe("resolvePluginRegistryLoadCacheKey", () => {
-  it("separates absent, disabled, and enabled channel flags", () => {
-    // channels.<id>.enabled steers activation on both sides, so each state needs its own registry.
-    const keyFor = (channel: Record<string, unknown>) =>
-      resolvePluginRegistryLoadCacheKey({
-        config: { channels: { telegram: channel } },
-        env: {},
-      });
-    const absent = keyFor({});
-    const disabled = keyFor({ enabled: false });
-    const enabled = keyFor({ enabled: true });
+  it.each(["same config", "shared plugin config"] as const)(
+    "separates absent, disabled, and enabled channel flags with %s",
+    (mode) => {
+      // channels.<id>.enabled steers activation on both sides, so each state needs its own registry.
+      const plugins = {};
+      const keyFor = (channel: Record<string, unknown>) => {
+        const source = { plugins, channels: { telegram: channel } };
+        return resolvePluginRegistryLoadCacheKey({
+          config:
+            mode === "same config"
+              ? source
+              : { plugins, channels: { telegram: { enabled: true } } },
+          activationSourceConfig: source,
+          env: {},
+        });
+      };
+      const absent = keyFor({});
+      const disabled = keyFor({ enabled: false });
+      const enabled = keyFor({ enabled: true });
 
-    expect(new Set([absent, disabled, enabled]).size).toBe(3);
-  });
+      expect(new Set([absent, disabled, enabled]).size).toBe(3);
+    },
+  );
 });

--- a/src/plugins/loader-load-context.ts
+++ b/src/plugins/loader-load-context.ts
@@ -265,7 +265,7 @@ function resolveCoreGatewayMethodNames(options: PluginLoadOptions): string[] {
 }
 
 function mergePluginTrustList(runtimeList: string[], sourceList: readonly string[]): string[] {
-  if (sourceList.length === 0) {
+  if (runtimeList === sourceList || sourceList.length === 0) {
     return runtimeList;
   }
   const merged = [...runtimeList];
@@ -320,7 +320,11 @@ export function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
       }) as OpenClawConfig)
     : rawActivationSourceConfig;
   const normalized = normalizePluginsConfig(cfg.plugins);
-  const activationSource = createPluginActivationSource({ config: activationSourceConfig });
+  // Identical plugin inputs may share facts; source channel policy keeps its own root config.
+  const activationSource = createPluginActivationSource({
+    config: activationSourceConfig,
+    plugins: cfg.plugins === activationSourceConfig.plugins ? normalized : undefined,
+  });
   const trustNormalized = mergeTrustPluginConfigFromActivationSource({
     normalized,
     activationSource,


### PR DESCRIPTION
## What Problem This Solves

Plugin registry lookups normalize the same plugin configuration twice and rebuild identical trust lists before constructing their cache key. This repeats allocation and traversal even when the runtime and activation source share exactly the same plugin input.

## Why This Change Was Made

Reuse the already normalized facts when the two plugin inputs are the same object, while keeping the activation source's own root configuration for channel policy. Trust-list merging returns its existing array when both inputs are identical. Distinct inputs still follow the existing normalization and ordered union paths.

Production LOC: +6/-2 (net +4). Tests: +22/-12 (net +10). The four added production lines pass prepared facts through the existing activation-source constructor; there is no new cache, helper, configuration option or persistence surface. Caching whole configurations or reusing the runtime root would create freshness or channel-policy problems, so neither is introduced.

## User Impact

Plugin registry cache-key construction does less repeated work. Public behavior, configuration interpretation, activation policy and cache-key bytes remain unchanged. This is not a claim that every Gateway operation or model turn becomes faster.

## Evidence

The fixed before/candidate/candidate/before study measured the complete exported cache-key operation across six workloads. It retained 66,840 timed outputs, 12 additional proof outputs, 1,536 sample means and all 934 comparisons, including 258 adverse observations. Complete outputs and input preservation were checked independently. There was no aggregate numerical acceptance threshold and no retry seeking a better result.

| Workload | Median change, first order | Median change, reverse order |
| --- | ---: | ---: |
| No plugin configuration | +0.73% | -3.10% |
| Shared eight-plugin configuration | -14.05% | -11.59% |
| Shared 128-plugin configuration | -18.68% | -22.09% |
| Equal but separately allocated configuration | +1.31% | -1.27% |
| Distinct trust and channel configuration | -2.69% | -2.39% |
| Raw environment substitution | -2.10% | -11.43% |

Adverse results remain part of the judgment: the first eight-plugin call increased by 79 microseconds (+15.94%) in the first order; the equal-but-distinct case's first-order mean and p95 rose 0.57% and 3.11%. The distinct-trust case's p95 rose 1.44% and 0.96%. Sampled tree RSS increased 0.06%/1.06%, and kernel child peak RSS increased 0.09%/1.22%; no allocation or memory improvement is claimed. Samples share a process, and the first call is not guaranteed cold. The larger ordinary/scaling gains justify the small owner-local reuse without attributing adverse samples to noise or GC.

Validation:

- The same 145 cases across six complete loader/config/activation files passed before and after. Expanded existing coverage verifies absent, disabled and enabled channel policy stays distinct when plugin inputs are shared across different source roots.
- The normal pinned-base changed check passed all 29 stages; no narrowed gates or timeout changes.
- Independent managed Codex review completed both context partitions with zero P0-P2 findings (0.80 confidence).
- A normal full mapped build passed. All 16,120 emitted files and 288 links remained unchanged through the runtime proof; complete source-map content matches bind the changed owner and its callers to ordinary Gateway chunks. Existing dependency eval, worker-map and browser externalization build warnings are retained; content equality does not establish every generated map position.
- One isolated compiled Gateway passed `health`, `status`, `tts.providers` and `plugins.list` through the authenticated ordinary client. The complete 166-plugin inventory had no diagnostics, expected disabled states and intact bundled ownership. The speech response matched the complete expected Microsoft/OpenAI catalog. The nonempty request-owned speech load exercises the changed loader; readiness alone does not prove that, and this flow does not isolate the same-reference fast branch.
- Observed RPC times were 4.81, 8.49, 18.69 and 440.28 ms, respectively. These are single correctness-run observations, not paired Gateway speed measurements. Readiness recovered from connection refusal and one pre-ready timeout before HTTP 200.
- The Gateway exited normally, without forced shutdown or warning/error logs. All nine observed PIDs and four process groups were absent, and its port refused connections and could be rebound. Fresh source/dependency/build checks passed. No provider credential or model request was used; the Gateway-only token scan found zero matches in the bytes present at scan time.

Release-note context: reduce duplicate plugin normalization during registry lookup without changing activation or channel policy.
