### PR TITLE
fix(codex): let stopped turns finish when transcript writes are blocked

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -104,16 +104,16 @@ export async function finalizeCodexAttempt(
   } = activeTurn;
   await completion;
   const abortGraceElapsed = createDeferred<void>();
-  let settlementClosed = false;
+  let settlementPhase: "active" | "expired" | "closed" = "active";
   let abortGraceTimer: ReturnType<typeof setTimeout> | undefined;
   const beginAbortGrace = () => {
-    if (settlementClosed) {
+    if (settlementPhase !== "active") {
       return;
     }
-    abortGraceTimer = setTimeout(
-      () => abortGraceElapsed.resolve(),
-      TURN_FINALIZE_DRAIN_ABORT_GRACE_MS,
-    );
+    abortGraceTimer = setTimeout(() => {
+      settlementPhase = "expired";
+      abortGraceElapsed.resolve();
+    }, TURN_FINALIZE_DRAIN_ABORT_GRACE_MS);
     abortGraceTimer.unref?.();
   };
   const abortListener = addAbortListener(runAbortController.signal, () => {
@@ -125,439 +125,523 @@ export async function finalizeCodexAttempt(
     state.projectionClosed = true;
     return activeProjector.closeProjection();
   };
-  const settlement = drainNotificationQueue().then(closeProjection);
-  try {
-    // Native completion does not end accepted projection or checkpoint work.
-    // Both remain under the original receipt-anchored settlement deadline.
-    await Promise.race([settlement, abortGraceElapsed.promise]);
-    if (runAbortController.signal.aborted) {
-      await state.abortCleanup;
+  const closeSettlement = () => {
+    if (settlementPhase === "closed") {
+      return;
     }
-  } finally {
-    settlementClosed = true;
+    settlementPhase = "closed";
     abortListener[Symbol.dispose]();
     clearTimeout(abortGraceTimer);
     deadlines.dispose();
-    if (!state.projectionClosed) {
-      await resources.runCleanupStep("codex-transcript-checkpoint", closeProjection);
-    }
-  }
-  const result = activeProjector.buildResult(toolBridge.telemetry, {
-    yieldDetected: toolState.yieldDetected,
-  });
-  const projectedTerminal = attemptTerminal.project(result.terminal);
-  const effectiveTimedOut = state.timeout !== undefined;
-  // Transport loss aborts in-flight work mechanically, but its terminal outcome
-  // must remain a failure unless the operator explicitly canceled the attempt.
-  const isFinalAborted = () =>
-    terminalState.explicitCancellationObserved ||
-    (!resourceState.executionDisconnectError &&
-      (projectedTerminal.aborted ||
-        (runAbortController.signal.aborted && !state.clientClosedAbort)));
-  const clientClosedPromptErrorForFinal = state.clientClosedPromptError;
-  let finalPromptError =
-    resourceState.executionDisconnectError ??
-    clientClosedPromptErrorForFinal ??
-    (state.timeout?.kind === "settlement"
-      ? "codex app-server terminal settlement timed out"
-      : state.timeout?.kind === "execution"
-        ? "codex app-server execution budget timed out"
-        : projectedTerminal.promptError);
-  const finalPromptErrorMessage =
-    typeof finalPromptError === "string"
-      ? finalPromptError
-      : finalPromptError instanceof Error
-        ? finalPromptError.message
-        : finalPromptError
-          ? formatErrorMessage(finalPromptError)
-          : undefined;
-  if (isInvalidCodexImagePayloadError(finalPromptErrorMessage)) {
-    await clearCodexBindingAfterInvalidImagePayload(
-      bindingStore,
-      bindingIdentity,
-      {
-        phase: "turn_completed",
-        threadId: resourceState.thread.threadId,
-        turnId: activeTurnId,
-        error: finalPromptErrorMessage,
-      },
-      params.expectedSessionRuntimeOwnership,
-    );
-  }
-  if (
-    resourceState.thread.connectionScope !== "supervision" &&
-    shouldUseFreshCodexThreadAfterContextEngineOverflow({
-      error: finalPromptError,
-      contextEngineActive: Boolean(activeContextEngine),
-      thread: resourceState.thread,
-    }) &&
-    canClearBindingForRecovery("clearing a native context after overflow")
-  ) {
-    embeddedAgentLog.warn(
-      "codex app-server context-engine turn overflowed after resume; clearing thread binding for recovery",
-      {
-        threadId: resourceState.thread.threadId,
-        turnId: activeTurnId,
-        error: finalPromptErrorMessage,
-      },
-    );
-    await bindingStore.mutate(bindingIdentity, {
-      kind: "clear",
-      threadId: resourceState.thread.threadId,
-    });
-  }
-  const refreshedUsageLimitPromptError = await refreshCodexUsageLimitPromptError({
-    client: resourceState.client,
-    message: finalPromptErrorMessage,
-    timeoutMs: appServer.requestTimeoutMs,
-    signal: runAbortController.signal,
-  });
-  if (refreshedUsageLimitPromptError) {
-    await markCodexAuthProfileBlockedFromRateLimits({
-      params,
-      authProfileId: startupAuthProfileId,
-      rateLimits: refreshedUsageLimitPromptError.rateLimitsForProfile,
-    });
-    finalPromptError = new CodexUsageLimitPromptError(refreshedUsageLimitPromptError.message);
-  } else if (
-    finalPromptError instanceof CodexUsageLimitPromptError &&
-    state.rateLimitsRevisionBeforeLastTurnStart !== undefined &&
-    readCodexRateLimitsRevision(resourceState.client) > state.rateLimitsRevisionBeforeLastTurnStart
-  ) {
-    await markCodexAuthProfileBlockedFromRateLimits({
-      params,
-      authProfileId: startupAuthProfileId,
-      rateLimits: readRecentCodexRateLimits(resourceState.client),
-    });
-  }
-  // Device loss can arrive during asynchronous failure enrichment. Re-read its
-  // owner before freezing derived success, cancellation, and terminal state.
-  finalPromptError = resourceState.executionDisconnectError ?? finalPromptError;
-  const finalPromptErrorSource =
-    effectiveTimedOut || clientClosedPromptErrorForFinal
-      ? "prompt"
-      : projectedTerminal.promptErrorSource;
-  const codexAppServerFailureKind = clientClosedPromptErrorForFinal
-    ? "client_closed_before_turn_completed"
-    : state.timeout?.kind === "settlement"
-      ? "turn_settlement_timeout"
-      : undefined;
-  const replayBlockedReason = codexAppServerFailureKind
-    ? resolveCodexAppServerReplayBlockedReason(result)
-    : undefined;
-  const promptTimeoutOutcome = buildCodexAppServerPromptTimeoutOutcome(state.timeout);
-  const failureDiagnostics =
-    codexAppServerFailureKind === "client_closed_before_turn_completed" &&
-    state.clientClosedDiagnostic
-      ? { transportError: state.clientClosedDiagnostic }
-      : state.timeout?.kind === "settlement"
-        ? { timeoutMs: state.timeout.timeoutMs }
-        : undefined;
-  const codexAppServerFailure = codexAppServerFailureKind
-    ? ({
-        kind: codexAppServerFailureKind,
-        transport: appServer.start.transport,
-        threadId: resourceState.thread.threadId,
-        turnId: activeTurnId,
-        replaySafe:
-          codexAppServerFailureKind === "client_closed_before_turn_completed" &&
-          replayBlockedReason === undefined,
-        ...(replayBlockedReason ? { replayBlockedReason } : {}),
-        ...(failureDiagnostics ? { diagnostics: failureDiagnostics } : {}),
-      } satisfies NonNullable<EmbeddedRunAttemptResult["codexAppServerFailure"]>)
-    : undefined;
-  const finalAborted = isFinalAborted();
-  const completedTurnStatus = activeProjector.getCompletedTurnStatus();
-  const locallyCompletedTurn =
-    state.completed &&
-    state.localCompletionRequested &&
-    !state.timeout &&
-    clientClosedPromptErrorForFinal === undefined;
-  const turnSucceeded =
-    !finalAborted &&
-    !effectiveTimedOut &&
-    (finalPromptError === null || finalPromptError === undefined) &&
-    (completedTurnStatus === "completed" || locallyCompletedTurn);
-  const completedSourceReply = toolBridge.telemetry.messagingToolSentTargets.some(
-    (target) => target.sourceReplyFinal === true,
-  );
-  if (completedSourceReply) {
-    // Harness classification only sees assistant/reasoning/plan projections.
-    // A reply delivered entirely through the source message tool is visible
-    // output, so an empty/reasoning-only classification is stale at this point.
-    result.agentHarnessResultClassification = undefined;
-  }
-  const attemptSucceeded = turnSucceeded && result.agentHarnessResultClassification === undefined;
-  terminalState.turnSucceeded = turnSucceeded;
-  terminalState.sharedAbortAllowedAfterTerminalOutcome = shouldKeepCodexSharedAbortOpen({
-    trigger: params.trigger,
-    result,
-    attemptSucceeded,
-    explicitCancellationObserved: terminalState.explicitCancellationObserved,
-  });
-  // Every terminal observer must see the same immutable outcome.
-  freezeRunTerminalOutcome();
-  result.terminal = attemptTerminal.normalize({
-    timedOut: effectiveTimedOut,
-    aborted: finalAborted,
-    promptError: finalPromptError,
-    promptErrorSource: finalPromptErrorSource,
-  });
-  // Failure enrichment can change the outcome after projection. Update this turn's
-  // terminal rows before transcript hooks read them; earlier work keeps its own outcome.
-  for (const message of [
-    result.lastAssistant,
-    result.currentAttemptAssistant,
-    result.messagesSnapshot.find(
-      (candidate) => readMirrorIdentity(candidate) === `${activeTurnId}:assistant`,
-    ),
-  ]) {
-    if (message?.role === "assistant") {
-      const providerRefusal = message.diagnostics?.some(
-        (diagnostic) => diagnostic.type === "provider_refusal",
-      );
-      // The projector owns refusal classification. Preserve it unless a stronger
-      // local abort or prompt failure supersedes this turn's provider outcome.
-      if (!providerRefusal || finalAborted || finalPromptError) {
-        message.stopReason = finalAborted ? "aborted" : finalPromptError ? "error" : "stop";
-        message.errorMessage = finalPromptError ? formatErrorMessage(finalPromptError) : undefined;
+  };
+  const settlement = drainNotificationQueue().then(closeProjection);
+  let projectionDrained = false;
+  try {
+    try {
+      // Native completion does not end accepted projection or checkpoint work.
+      // Both remain under the original receipt-anchored settlement deadline.
+      projectionDrained = await Promise.race([
+        settlement.then(() => true),
+        abortGraceElapsed.promise.then(() => false),
+      ]);
+      if (runAbortController.signal.aborted) {
+        await state.abortCleanup;
+      }
+    } finally {
+      if (!state.projectionClosed) {
+        await resources.runCleanupStep("codex-transcript-checkpoint", closeProjection);
       }
     }
-  }
-  const modelCallFailureKind =
-    classifyCodexModelCallFailureKind({
-      error: finalPromptError,
-      timedOut: effectiveTimedOut,
-      runAborted: finalAborted,
-      abortReason: terminalState.explicitCancellationReason ?? runAbortController.signal.reason,
-      clientClosedAbort: state.clientClosedAbort,
-      formatError: formatErrorMessage,
-    }) ?? (finalAborted ? "aborted" : undefined);
-  if (modelCallFailureKind) {
-    codexModelCallDiagnostics.emitError(
-      finalPromptError ?? "codex app-server attempt interrupted",
-      {
-        failureKind: modelCallFailureKind,
-      },
-    );
-  } else if (finalPromptError) {
-    codexModelCallDiagnostics.emitError(finalPromptError);
-  } else {
-    codexModelCallDiagnostics.emitCompleted(result);
-  }
-  const mirrorOutcome = await codexTranscriptMirrorRuntime.mirrorBestEffort({
-    params,
-    agentId: sessionAgentId,
-    notifyUserMessagePersisted,
-    result,
-    sessionKey: contextSessionKey,
-    cwd: effectiveCwd,
-    threadId: resourceState.thread.threadId,
-    turnId: activeTurnId,
-  });
-  const { assistantTranscriptOwned, assistantTranscriptIdempotencyKey, terminalAnchor } =
-    mirrorOutcome;
-  const shouldCaptureSettledTurnFinalizationContext =
-    result.assistantTexts.every((text) => !text.trim()) &&
-    result.messagesSnapshot.some((message) => message.role === "toolResult") &&
-    (!finalPromptError || activeProjector.settledTurnFailureFinalizationAllowed);
-  // Supervised auth belongs to its native connection, which has no generic stock
-  // tool-free summary operation. Retain fallback eligibility instead of selecting host auth.
-  const settledTurnFinalizationContext = shouldCaptureSettledTurnFinalizationContext
-    ? ((!usesSupervisionConnection
-        ? await captureCodexSettledTurnFinalizationContext({
-            ...activeTranscriptTarget,
-            model: resourceState.thread.model,
-            modelProvider: resourceState.thread.modelProvider,
-            authProfileId: startupAuthProfileId,
-            mirroredMessages: mirrorOutcome.mirroredMessages,
-            settledMessages: result.messagesSnapshot,
-            turnId: activeTurnId,
-            signal: params.abortSignal,
-            assertActive: connection.assertCurrent,
-          })
-        : undefined) ?? Object.freeze({ source: "unavailable" as const }))
-    : undefined;
-  if (settledTurnFinalizationContext?.source === "unavailable") {
-    embeddedAgentLog.warn("codex settled-turn finalization context is unavailable", {
-      runId: params.runId,
-      threadId: resourceState.thread.threadId,
-      turnId: activeTurnId,
-      reason: usesSupervisionConnection
-        ? "native_auth_finalization_unsupported"
-        : "context_unavailable",
+    const result = activeProjector.buildResult(toolBridge.telemetry, {
+      yieldDetected: toolState.yieldDetected,
     });
-  }
-  runAgentHarnessLlmOutputHook({
-    event: {
-      runId: params.runId,
-      sessionId: params.sessionId,
-      provider: usesSupervisionConnection
-        ? (resourceState.thread.modelProvider ?? effectiveRuntimeProviderId)
-        : params.provider,
-      model: usesSupervisionConnection
-        ? (resourceState.thread.model ?? effectiveRuntimeModelId)
-        : params.modelId,
-      ...hookContextWindowFields,
-      resolvedRef: usesSupervisionConnection
-        ? `${resourceState.thread.modelProvider ?? effectiveRuntimeProviderId}/${resourceState.thread.model ?? effectiveRuntimeModelId}`
-        : (params.runtimePlan?.observability.resolvedRef ?? `${params.provider}/${params.modelId}`),
-      ...(!usesSupervisionConnection && params.runtimePlan?.observability.harnessId
-        ? { harnessId: params.runtimePlan.observability.harnessId }
-        : {}),
-      assistantTexts: result.assistantTexts,
-      ...(result.lastAssistant ? { lastAssistant: result.lastAssistant } : {}),
-      ...(result.attemptUsage ? { usage: result.attemptUsage } : {}),
-    },
-    ctx: hookContext,
-    hookRunner,
-  });
-  await runCodexAgentEndHook(params, {
-    event: {
-      messages: result.messagesSnapshot,
-      success: !finalAborted && !finalPromptError,
-      ...(finalPromptError ? { error: formatErrorMessage(finalPromptError) } : {}),
-      durationMs: Date.now() - attemptStartedAt,
-    },
-    ctx: {
-      ...hookContext,
-      modelProviderId: resourceState.thread.modelProvider ?? effectiveRuntimeProviderId,
-      modelId: resourceState.thread.model ?? effectiveRuntimeModelId,
-      authProfileId: resourceState.thread.authProfileId ?? startupAuthProfileId,
-      modelIterations: result.modelIterations ?? 0,
-      skillWorkshopAvailable: flattenCodexDynamicToolFunctions(
-        attemptTools.toolBridge.availableSpecs,
-      ).some((tool) => tool.name === "skill_workshop"),
-      compacted: (result.compactionCount ?? 0) > 0,
-      senderId: params.senderId ?? undefined,
-      foregroundPromptContext: buildEmbeddedForegroundPromptContext(
-        { ...params, agentId: sessionAgentId },
-        agentDir,
-      ),
-    },
-    hookRunner,
-  });
-  state.shouldDelayNativeHookRelayUnregister =
-    completedTurnStatus === "completed" &&
-    !effectiveTimedOut &&
-    !runAbortController.signal.aborted &&
-    !finalAborted &&
-    !finalPromptError;
-  if (state.shouldDelayNativeHookRelayUnregister) {
-    try {
-      // Only no-engine continuity prompts may calibrate their measured history.
-      // Billing spans every model call; density needs only the latest full prompt.
-      const continuityCalibration = context.promptState.noEngineContinuityProjectionApplied
-        ? buildCodexContinuityCalibration({
-            promptChars: prompt.turnState.codexTurnPromptText.length,
-            inputTokens:
-              result.attemptUsage?.contextUsage?.state === "available"
-                ? (result.attemptUsage.contextUsage.promptTokens ?? 0)
-                : 0,
-          })
-        : undefined;
-      await bindingStore.mutate(
+    const projectedTerminal = attemptTerminal.project(result.terminal);
+    // Transport loss aborts in-flight work mechanically, but its terminal outcome
+    // must remain a failure unless the operator explicitly canceled the attempt.
+    const isFinalAborted = () =>
+      terminalState.explicitCancellationObserved ||
+      (!resourceState.executionDisconnectError &&
+        (projectedTerminal.aborted ||
+          (runAbortController.signal.aborted && !state.clientClosedAbort)));
+    let enrichedPromptError =
+      resourceState.executionDisconnectError ??
+      state.clientClosedPromptError ??
+      (state.timeout?.kind === "settlement"
+        ? "codex app-server terminal settlement timed out"
+        : state.timeout?.kind === "execution"
+          ? "codex app-server execution budget timed out"
+          : projectedTerminal.promptError);
+    const enrichedPromptErrorMessage =
+      typeof enrichedPromptError === "string"
+        ? enrichedPromptError
+        : enrichedPromptError instanceof Error
+          ? enrichedPromptError.message
+          : enrichedPromptError
+            ? formatErrorMessage(enrichedPromptError)
+            : undefined;
+    if (isInvalidCodexImagePayloadError(enrichedPromptErrorMessage)) {
+      await clearCodexBindingAfterInvalidImagePayload(
+        bindingStore,
         bindingIdentity,
         {
-          kind: "patch",
+          phase: "turn_completed",
           threadId: resourceState.thread.threadId,
-          patch: {
-            historyCoveredThrough: new Date().toISOString(),
-            ...(continuityCalibration ? { continuityCalibration } : {}),
-          },
+          turnId: activeTurnId,
+          error: enrichedPromptErrorMessage,
         },
-        connection.assertCurrent,
+        params.expectedSessionRuntimeOwnership,
       );
-    } catch (error) {
-      if (resourceState.thread.connectionScope === "supervision") {
-        throw error;
+    }
+    if (
+      resourceState.thread.connectionScope !== "supervision" &&
+      shouldUseFreshCodexThreadAfterContextEngineOverflow({
+        error: enrichedPromptError,
+        contextEngineActive: Boolean(activeContextEngine),
+        thread: resourceState.thread,
+      }) &&
+      canClearBindingForRecovery("clearing a native context after overflow")
+    ) {
+      embeddedAgentLog.warn(
+        "codex app-server context-engine turn overflowed after resume; clearing thread binding for recovery",
+        {
+          threadId: resourceState.thread.threadId,
+          turnId: activeTurnId,
+          error: enrichedPromptErrorMessage,
+        },
+      );
+      await bindingStore.mutate(bindingIdentity, {
+        kind: "clear",
+        threadId: resourceState.thread.threadId,
+      });
+    }
+    const refreshedUsageLimitPromptError = await refreshCodexUsageLimitPromptError({
+      client: resourceState.client,
+      message: enrichedPromptErrorMessage,
+      timeoutMs: appServer.requestTimeoutMs,
+      signal: runAbortController.signal,
+    });
+    if (refreshedUsageLimitPromptError) {
+      await markCodexAuthProfileBlockedFromRateLimits({
+        params,
+        authProfileId: startupAuthProfileId,
+        rateLimits: refreshedUsageLimitPromptError.rateLimitsForProfile,
+      });
+      enrichedPromptError = new CodexUsageLimitPromptError(refreshedUsageLimitPromptError.message);
+    } else if (
+      enrichedPromptError instanceof CodexUsageLimitPromptError &&
+      state.rateLimitsRevisionBeforeLastTurnStart !== undefined &&
+      readCodexRateLimitsRevision(resourceState.client) >
+        state.rateLimitsRevisionBeforeLastTurnStart
+    ) {
+      await markCodexAuthProfileBlockedFromRateLimits({
+        params,
+        authProfileId: startupAuthProfileId,
+        rateLimits: readRecentCodexRateLimits(resourceState.client),
+      });
+    }
+    const projectTerminalOutcome = () => {
+      const effectiveTimedOut = state.timeout !== undefined;
+      const clientClosedPromptErrorForFinal = state.clientClosedPromptError;
+      const finalPromptError =
+        resourceState.executionDisconnectError ??
+        clientClosedPromptErrorForFinal ??
+        (state.timeout?.kind === "settlement"
+          ? "codex app-server terminal settlement timed out"
+          : state.timeout?.kind === "execution"
+            ? "codex app-server execution budget timed out"
+            : enrichedPromptError);
+      const finalPromptErrorSource =
+        effectiveTimedOut || clientClosedPromptErrorForFinal
+          ? "prompt"
+          : projectedTerminal.promptErrorSource;
+      const codexAppServerFailureKind = clientClosedPromptErrorForFinal
+        ? "client_closed_before_turn_completed"
+        : state.timeout?.kind === "settlement"
+          ? "turn_settlement_timeout"
+          : undefined;
+      const replayBlockedReason = codexAppServerFailureKind
+        ? resolveCodexAppServerReplayBlockedReason(result)
+        : undefined;
+      const promptTimeoutOutcome = buildCodexAppServerPromptTimeoutOutcome(state.timeout);
+      const failureDiagnostics =
+        codexAppServerFailureKind === "client_closed_before_turn_completed" &&
+        state.clientClosedDiagnostic
+          ? { transportError: state.clientClosedDiagnostic }
+          : state.timeout?.kind === "settlement"
+            ? { timeoutMs: state.timeout.timeoutMs }
+            : undefined;
+      const codexAppServerFailure = codexAppServerFailureKind
+        ? ({
+            kind: codexAppServerFailureKind,
+            transport: appServer.start.transport,
+            threadId: resourceState.thread.threadId,
+            turnId: activeTurnId,
+            replaySafe:
+              codexAppServerFailureKind === "client_closed_before_turn_completed" &&
+              replayBlockedReason === undefined,
+            ...(replayBlockedReason ? { replayBlockedReason } : {}),
+            ...(failureDiagnostics ? { diagnostics: failureDiagnostics } : {}),
+          } satisfies NonNullable<EmbeddedRunAttemptResult["codexAppServerFailure"]>)
+        : undefined;
+      const finalAborted = isFinalAborted();
+      if (finalAborted && result.attemptUsage) {
+        result.attemptUsage = { ...result.attemptUsage, contextUsage: { state: "unavailable" } };
       }
-      if (canClearBindingForRecovery("clearing native coverage after a completed turn")) {
-        const cleared = await bindingStore.mutate(
+      const completedTurnStatus = activeProjector.getCompletedTurnStatus();
+      const locallyCompletedTurn =
+        state.completed &&
+        state.localCompletionRequested &&
+        !state.timeout &&
+        clientClosedPromptErrorForFinal === undefined;
+      const turnSucceeded =
+        !finalAborted &&
+        !effectiveTimedOut &&
+        (finalPromptError === null || finalPromptError === undefined) &&
+        (completedTurnStatus === "completed" || locallyCompletedTurn);
+      const completedSourceReply = toolBridge.telemetry.messagingToolSentTargets.some(
+        (target) => target.sourceReplyFinal === true,
+      );
+      if (completedSourceReply) {
+        // Harness classification only sees assistant/reasoning/plan projections.
+        // A reply delivered entirely through the source message tool is visible
+        // output, so an empty/reasoning-only classification is stale at this point.
+        result.agentHarnessResultClassification = undefined;
+      }
+      const attemptSucceeded =
+        turnSucceeded && result.agentHarnessResultClassification === undefined;
+      result.terminal = attemptTerminal.normalize({
+        timedOut: effectiveTimedOut,
+        aborted: finalAborted,
+        promptError: finalPromptError,
+        promptErrorSource: finalPromptErrorSource,
+      });
+      // Failure enrichment can change the outcome after projection. Update this turn's
+      // terminal rows before transcript hooks read them; earlier work keeps its own outcome.
+      for (const message of [
+        result.lastAssistant,
+        result.currentAttemptAssistant,
+        result.messagesSnapshot.find(
+          (candidate) => readMirrorIdentity(candidate) === `${activeTurnId}:assistant`,
+        ),
+      ]) {
+        if (message?.role === "assistant") {
+          const providerRefusal = message.diagnostics?.some(
+            (diagnostic) => diagnostic.type === "provider_refusal",
+          );
+          // The projector owns refusal classification. Preserve it unless a stronger
+          // local abort or prompt failure supersedes this turn's provider outcome.
+          if (!providerRefusal || finalAborted || finalPromptError) {
+            message.stopReason = finalAborted ? "aborted" : finalPromptError ? "error" : "stop";
+            message.errorMessage = finalPromptError
+              ? formatErrorMessage(finalPromptError)
+              : undefined;
+          }
+        }
+      }
+      return {
+        effectiveTimedOut,
+        finalPromptError,
+        codexAppServerFailure,
+        promptTimeoutOutcome,
+        finalAborted,
+        turnSucceeded,
+        attemptSucceeded,
+        completedTurnStatus,
+      };
+    };
+    // Message-write hooks see the enriched native outcome. The same projection
+    // runs after the bounded mirror join if Stop or the deadline arrives there.
+    const mirrorTerminal = projectTerminalOutcome();
+    type MirrorOutcome = Awaited<ReturnType<typeof codexTranscriptMirrorRuntime.mirrorBestEffort>>;
+    const unavailableMirror: MirrorOutcome = {
+      assistantTranscriptOwned: false,
+      mirroredMessages: [],
+    };
+    let mirrorOutcome = unavailableMirror;
+    try {
+      if (projectionDrained && settlementPhase === "active") {
+        mirrorOutcome = await Promise.race([
+          codexTranscriptMirrorRuntime.mirrorBestEffort({
+            assertWriteCurrent: () => {
+              if (settlementPhase !== "active") {
+                throw new Error("Codex transcript settlement is no longer active");
+              }
+              const current = projectTerminalOutcome();
+              if (
+                current.finalAborted !== mirrorTerminal.finalAborted ||
+                current.effectiveTimedOut !== mirrorTerminal.effectiveTimedOut ||
+                current.finalPromptError !== mirrorTerminal.finalPromptError
+              ) {
+                throw new Error("Codex transcript terminal outcome changed before write");
+              }
+            },
+            params,
+            agentId: sessionAgentId,
+            notifyUserMessagePersisted,
+            result,
+            sessionKey: contextSessionKey,
+            cwd: effectiveCwd,
+            threadId: resourceState.thread.threadId,
+            turnId: activeTurnId,
+          }),
+          abortGraceElapsed.promise.then(() => unavailableMirror),
+        ]);
+      }
+      if (runAbortController.signal.aborted) {
+        await state.abortCleanup;
+      }
+    } finally {
+      // Retire this exact write before releasing the run. A queued mirror cannot
+      // borrow a later session writer after its settlement deadline has elapsed.
+      closeSettlement();
+    }
+    const {
+      effectiveTimedOut,
+      finalPromptError,
+      codexAppServerFailure,
+      promptTimeoutOutcome,
+      finalAborted,
+      turnSucceeded,
+      attemptSucceeded,
+      completedTurnStatus,
+    } = projectTerminalOutcome();
+    terminalState.turnSucceeded = turnSucceeded;
+    terminalState.sharedAbortAllowedAfterTerminalOutcome = shouldKeepCodexSharedAbortOpen({
+      trigger: params.trigger,
+      result,
+      attemptSucceeded,
+      explicitCancellationObserved: terminalState.explicitCancellationObserved,
+    });
+    // Every terminal observer must see the same immutable outcome.
+    freezeRunTerminalOutcome();
+    const modelCallFailureKind =
+      classifyCodexModelCallFailureKind({
+        error: finalPromptError,
+        timedOut: effectiveTimedOut,
+        runAborted: finalAborted,
+        abortReason: terminalState.explicitCancellationReason ?? runAbortController.signal.reason,
+        clientClosedAbort: state.clientClosedAbort,
+        formatError: formatErrorMessage,
+      }) ?? (finalAborted ? "aborted" : undefined);
+    if (modelCallFailureKind) {
+      codexModelCallDiagnostics.emitError(
+        finalPromptError ?? "codex app-server attempt interrupted",
+        {
+          failureKind: modelCallFailureKind,
+        },
+      );
+    } else if (finalPromptError) {
+      codexModelCallDiagnostics.emitError(finalPromptError);
+    } else {
+      codexModelCallDiagnostics.emitCompleted(result);
+    }
+    const { assistantTranscriptOwned, assistantTranscriptIdempotencyKey, terminalAnchor } =
+      mirrorOutcome;
+    const shouldCaptureSettledTurnFinalizationContext =
+      result.assistantTexts.every((text) => !text.trim()) &&
+      result.messagesSnapshot.some((message) => message.role === "toolResult") &&
+      (!finalPromptError || activeProjector.settledTurnFailureFinalizationAllowed);
+    // Supervised auth belongs to its native connection, which has no generic stock
+    // tool-free summary operation. Retain fallback eligibility instead of selecting host auth.
+    const settledTurnFinalizationContext = shouldCaptureSettledTurnFinalizationContext
+      ? ((!usesSupervisionConnection
+          ? await captureCodexSettledTurnFinalizationContext({
+              ...activeTranscriptTarget,
+              model: resourceState.thread.model,
+              modelProvider: resourceState.thread.modelProvider,
+              authProfileId: startupAuthProfileId,
+              mirroredMessages: mirrorOutcome.mirroredMessages,
+              settledMessages: result.messagesSnapshot,
+              turnId: activeTurnId,
+              signal: params.abortSignal,
+              assertActive: connection.assertCurrent,
+            })
+          : undefined) ?? Object.freeze({ source: "unavailable" as const }))
+      : undefined;
+    if (settledTurnFinalizationContext?.source === "unavailable") {
+      embeddedAgentLog.warn("codex settled-turn finalization context is unavailable", {
+        runId: params.runId,
+        threadId: resourceState.thread.threadId,
+        turnId: activeTurnId,
+        reason: usesSupervisionConnection
+          ? "native_auth_finalization_unsupported"
+          : "context_unavailable",
+      });
+    }
+    runAgentHarnessLlmOutputHook({
+      event: {
+        runId: params.runId,
+        sessionId: params.sessionId,
+        provider: usesSupervisionConnection
+          ? (resourceState.thread.modelProvider ?? effectiveRuntimeProviderId)
+          : params.provider,
+        model: usesSupervisionConnection
+          ? (resourceState.thread.model ?? effectiveRuntimeModelId)
+          : params.modelId,
+        ...hookContextWindowFields,
+        resolvedRef: usesSupervisionConnection
+          ? `${resourceState.thread.modelProvider ?? effectiveRuntimeProviderId}/${resourceState.thread.model ?? effectiveRuntimeModelId}`
+          : (params.runtimePlan?.observability.resolvedRef ??
+            `${params.provider}/${params.modelId}`),
+        ...(!usesSupervisionConnection && params.runtimePlan?.observability.harnessId
+          ? { harnessId: params.runtimePlan.observability.harnessId }
+          : {}),
+        assistantTexts: result.assistantTexts,
+        ...(result.lastAssistant ? { lastAssistant: result.lastAssistant } : {}),
+        ...(result.attemptUsage ? { usage: result.attemptUsage } : {}),
+      },
+      ctx: hookContext,
+      hookRunner,
+    });
+    await runCodexAgentEndHook(params, {
+      event: {
+        messages: result.messagesSnapshot,
+        success: !finalAborted && !finalPromptError,
+        ...(finalPromptError ? { error: formatErrorMessage(finalPromptError) } : {}),
+        durationMs: Date.now() - attemptStartedAt,
+      },
+      ctx: {
+        ...hookContext,
+        modelProviderId: resourceState.thread.modelProvider ?? effectiveRuntimeProviderId,
+        modelId: resourceState.thread.model ?? effectiveRuntimeModelId,
+        authProfileId: resourceState.thread.authProfileId ?? startupAuthProfileId,
+        modelIterations: result.modelIterations ?? 0,
+        skillWorkshopAvailable: flattenCodexDynamicToolFunctions(
+          attemptTools.toolBridge.availableSpecs,
+        ).some((tool) => tool.name === "skill_workshop"),
+        compacted: (result.compactionCount ?? 0) > 0,
+        senderId: params.senderId ?? undefined,
+        foregroundPromptContext: buildEmbeddedForegroundPromptContext(
+          { ...params, agentId: sessionAgentId },
+          agentDir,
+        ),
+      },
+      hookRunner,
+    });
+    state.shouldDelayNativeHookRelayUnregister =
+      completedTurnStatus === "completed" &&
+      !effectiveTimedOut &&
+      !runAbortController.signal.aborted &&
+      !finalAborted &&
+      !finalPromptError;
+    if (state.shouldDelayNativeHookRelayUnregister) {
+      try {
+        // Only no-engine continuity prompts may calibrate their measured history.
+        // Billing spans every model call; density needs only the latest full prompt.
+        const continuityCalibration = context.promptState.noEngineContinuityProjectionApplied
+          ? buildCodexContinuityCalibration({
+              promptChars: prompt.turnState.codexTurnPromptText.length,
+              inputTokens:
+                result.attemptUsage?.contextUsage?.state === "available"
+                  ? (result.attemptUsage.contextUsage.promptTokens ?? 0)
+                  : 0,
+            })
+          : undefined;
+        await bindingStore.mutate(
           bindingIdentity,
-          { kind: "clear", threadId: resourceState.thread.threadId },
+          {
+            kind: "patch",
+            threadId: resourceState.thread.threadId,
+            patch: {
+              historyCoveredThrough: new Date().toISOString(),
+              ...(continuityCalibration ? { continuityCalibration } : {}),
+            },
+          },
           connection.assertCurrent,
         );
-        if (!cleared) {
+      } catch (error) {
+        if (resourceState.thread.connectionScope === "supervision") {
           throw error;
         }
-        embeddedAgentLog.warn(
-          "codex app-server binding coverage update failed after completed turn; cleared stale binding",
-          { threadId: resourceState.thread.threadId, turnId: activeTurnId, error },
-        );
+        if (canClearBindingForRecovery("clearing native coverage after a completed turn")) {
+          const cleared = await bindingStore.mutate(
+            bindingIdentity,
+            { kind: "clear", threadId: resourceState.thread.threadId },
+            connection.assertCurrent,
+          );
+          if (!cleared) {
+            throw error;
+          }
+          embeddedAgentLog.warn(
+            "codex app-server binding coverage update failed after completed turn; cleared stale binding",
+            { threadId: resourceState.thread.threadId, turnId: activeTurnId, error },
+          );
+        }
       }
     }
-  }
-  recordCodexTrajectoryCompletion(trajectoryRecorder, {
-    attempt: params,
-    result,
-    threadId: resourceState.thread.threadId,
-    turnId: activeTurnId,
-    timedOut: effectiveTimedOut,
-    yieldDetected: toolState.yieldDetected,
-  });
-  trajectoryRecorder?.recordEvent("session.ended", {
-    status: finalPromptError
-      ? "error"
-      : finalAborted || effectiveTimedOut
-        ? "interrupted"
-        : "success",
-    threadId: resourceState.thread.threadId,
-    turnId: activeTurnId,
-    timedOut: effectiveTimedOut,
-    yieldDetected: toolState.yieldDetected,
-    promptError: normalizeCodexTrajectoryError(finalPromptError),
-  });
-  markTrajectoryEndRecorded();
-  const terminalAssistantText = collectTerminalAssistantText(result);
-  if (
-    terminalAssistantText &&
-    (!streamState.eventEmitted || streamState.needsTerminalSnapshot) &&
-    !finalAborted &&
-    !finalPromptError
-  ) {
-    void emitCodexAppServerEvent(params, {
-      stream: "assistant",
-      data: { text: terminalAssistantText },
+    recordCodexTrajectoryCompletion(trajectoryRecorder, {
+      attempt: params,
+      result,
+      threadId: resourceState.thread.threadId,
+      turnId: activeTurnId,
+      timedOut: effectiveTimedOut,
+      yieldDetected: toolState.yieldDetected,
     });
+    trajectoryRecorder?.recordEvent("session.ended", {
+      status: finalPromptError
+        ? "error"
+        : finalAborted || effectiveTimedOut
+          ? "interrupted"
+          : "success",
+      threadId: resourceState.thread.threadId,
+      turnId: activeTurnId,
+      timedOut: effectiveTimedOut,
+      yieldDetected: toolState.yieldDetected,
+      promptError: normalizeCodexTrajectoryError(finalPromptError),
+    });
+    markTrajectoryEndRecorded();
+    const terminalAssistantText = collectTerminalAssistantText(result);
+    if (
+      terminalAssistantText &&
+      (!streamState.eventEmitted || streamState.needsTerminalSnapshot) &&
+      !finalAborted &&
+      !finalPromptError
+    ) {
+      void emitCodexAppServerEvent(params, {
+        stream: "assistant",
+        data: { text: terminalAssistantText },
+      });
+    }
+    emitLifecycleTerminal(
+      finalPromptError
+        ? {
+            phase: "error",
+            error: formatErrorMessage(finalPromptError),
+            ...buildLifecycleTerminalMeta({ aborted: finalAborted, timedOut: effectiveTimedOut }),
+          }
+        : {
+            phase: "end",
+            ...buildLifecycleTerminalMeta({
+              aborted: finalAborted,
+              timedOut: effectiveTimedOut,
+              yielded: toolState.yieldDetected,
+            }),
+          },
+    );
+    // Preserve the exact result identity carrying host-issued TTS delivery provenance.
+    const finalizedResult: EmbeddedRunAttemptResult = Object.assign(result, {
+      ...(runtimeModelSelection ? { runtimeModelSelection } : {}),
+      ...(toolState.yieldAcknowledgment
+        ? { yieldAcknowledgment: toolState.yieldAcknowledgment }
+        : {}),
+      ...(codexAppServerFailure ? { codexAppServerFailure } : {}),
+      ...(promptTimeoutOutcome ? { promptTimeoutOutcome } : {}),
+      ...(assistantTranscriptOwned ? { assistantTranscriptOwned: true } : {}),
+      ...(assistantTranscriptIdempotencyKey ? { assistantTranscriptIdempotencyKey } : {}),
+      ...(terminalAnchor ? { contextEngineTerminalAnchor: terminalAnchor } : {}),
+      ...(settledTurnFinalizationContext ? { settledTurnFinalizationContext } : {}),
+      ...(resourceState.runtimeArtifact ? { runtimeArtifact: resourceState.runtimeArtifact } : {}),
+      ...(resourceState.runtimeContinuationStarted ? { runtimeContinuationStarted: true } : {}),
+      ...(!finalAborted && !effectiveTimedOut && !finalPromptError && preparedAuthBinding
+        ? { authBindingFingerprint: preparedAuthBinding.fingerprint }
+        : {}),
+      systemPromptReport,
+    });
+    if (turnSucceeded && toolState.yieldDetected && !runAbortController.signal.aborted) {
+      resourceState.nativeHookRelay?.authorizeRetentionAfterSuccessfulYield();
+    }
+    return finalizedResult;
+  } finally {
+    closeSettlement();
   }
-  emitLifecycleTerminal(
-    finalPromptError
-      ? {
-          phase: "error",
-          error: formatErrorMessage(finalPromptError),
-          ...buildLifecycleTerminalMeta({ aborted: finalAborted, timedOut: effectiveTimedOut }),
-        }
-      : {
-          phase: "end",
-          ...buildLifecycleTerminalMeta({
-            aborted: finalAborted,
-            timedOut: effectiveTimedOut,
-            yielded: toolState.yieldDetected,
-          }),
-        },
-  );
-  // Preserve the exact result identity carrying host-issued TTS delivery provenance.
-  const finalizedResult: EmbeddedRunAttemptResult = Object.assign(result, {
-    ...(runtimeModelSelection ? { runtimeModelSelection } : {}),
-    ...(toolState.yieldAcknowledgment
-      ? { yieldAcknowledgment: toolState.yieldAcknowledgment }
-      : {}),
-    ...(codexAppServerFailure ? { codexAppServerFailure } : {}),
-    ...(promptTimeoutOutcome ? { promptTimeoutOutcome } : {}),
-    ...(assistantTranscriptOwned ? { assistantTranscriptOwned: true } : {}),
-    ...(assistantTranscriptIdempotencyKey ? { assistantTranscriptIdempotencyKey } : {}),
-    ...(terminalAnchor ? { contextEngineTerminalAnchor: terminalAnchor } : {}),
-    ...(settledTurnFinalizationContext ? { settledTurnFinalizationContext } : {}),
-    ...(resourceState.runtimeArtifact ? { runtimeArtifact: resourceState.runtimeArtifact } : {}),
-    ...(resourceState.runtimeContinuationStarted ? { runtimeContinuationStarted: true } : {}),
-    ...(!finalAborted && !effectiveTimedOut && !finalPromptError && preparedAuthBinding
-      ? { authBindingFingerprint: preparedAuthBinding.fingerprint }
-      : {}),
-    systemPromptReport,
-  });
-  if (turnSucceeded && toolState.yieldDetected && !runAbortController.signal.aborted) {
-    resourceState.nativeHookRelay?.authorizeRetentionAfterSuccessfulYield();
-  }
-  return finalizedResult;
 }

--- a/extensions/codex/src/app-server/run-attempt.settlement.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.settlement.test.ts
@@ -2,7 +2,12 @@
 import path from "node:path";
 import { resolveActiveEmbeddedRunSessionId } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { onInternalSessionTranscriptUpdate } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
+import {
+  readSessionTranscriptEvents,
+  withSessionTranscriptWriteLock,
+} from "openclaw/plugin-sdk/session-transcript-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
 import {
@@ -10,6 +15,7 @@ import {
   TURN_TERMINAL_SETTLEMENT_TIMEOUT_MS,
 } from "./attempt-timeouts.js";
 import { CodexAppServerClient } from "./client.js";
+import { isJsonObject } from "./protocol.js";
 import { turnCompleted } from "./protocol.test-helpers.js";
 import {
   createNativeRunParams,
@@ -221,78 +227,267 @@ describe("Codex app-server terminal settlement", () => {
     }
   });
 
-  it("reports settlement failure when a terminal checkpoint remains blocked", async () => {
-    const params = createTestParams();
-    await attachSqliteSessionTarget(
-      params,
-      path.join(tempDir, "settlement-checkpoint.sqlite"),
-      "session-checkpoint",
-    );
-    const checkpoint = createDeferred<void>();
-    const mirror = codexTranscriptMirrorRuntime.mirror;
-    const checkpointWrites: Promise<unknown>[] = [];
-    const checkpointMirror = vi
-      .spyOn(codexTranscriptMirrorRuntime, "mirror")
-      .mockImplementation((input) => {
-        const writing = checkpoint.promise.then(() => mirror(input));
-        checkpointWrites.push(writing);
-        return writing;
+  it.each([
+    { boundary: "callback", termination: "timeout", release: "after cutoff" },
+    { boundary: "checkpoint", termination: "timeout", release: "after cutoff" },
+    { boundary: "final", termination: "timeout", release: "after cutoff" },
+    { boundary: "checkpoint", termination: "abort", release: "after cutoff" },
+    { boundary: "final", termination: "abort", release: "after cutoff" },
+    { boundary: "final", termination: "abort", release: "during grace" },
+    { boundary: "checkpoint", termination: "abort", release: "during grace" },
+    { boundary: "publication", termination: "abort", release: "on publication" },
+  ] as const)(
+    "settles $termination at $boundary with writer release $release",
+    async ({ boundary, termination, release }) => {
+      const params = createTestParams();
+      await attachSqliteSessionTarget(
+        params,
+        path.join(tempDir, "settlement-checkpoint.sqlite"),
+        "session-checkpoint",
+      );
+      const target = params.sessionTarget;
+      if (!target?.sessionId || !target.sessionKey) {
+        throw new Error("SQLite transcript target was not attached");
+      }
+      const transcriptTarget = {
+        ...target,
+        sessionId: target.sessionId,
+        sessionKey: target.sessionKey,
+      };
+      const checkpoint = createDeferred<void>();
+      const mirror = codexTranscriptMirrorRuntime.mirror;
+      const checkpointWrites: Promise<unknown>[] = [];
+      const holdWriter = async () => {
+        const writerAcquired = createDeferred<void>();
+        checkpointWrites.push(
+          withSessionTranscriptWriteLock(transcriptTarget, async () => {
+            writerAcquired.resolve();
+            await checkpoint.promise;
+          }),
+        );
+        await writerAcquired.promise;
+      };
+      const checkpointMirror = vi.spyOn(codexTranscriptMirrorRuntime, "mirror");
+      if (boundary === "callback") {
+        checkpointMirror.mockImplementation((input) => {
+          const writing = checkpoint.promise.then(() => mirror(input));
+          checkpointWrites.push(writing);
+          return writing;
+        });
+      }
+      const finalMirrorStarted = createDeferred<void>();
+      if (boundary === "final") {
+        const finalMirror = codexTranscriptMirrorRuntime.mirrorBestEffort;
+        vi.spyOn(codexTranscriptMirrorRuntime, "mirrorBestEffort").mockImplementationOnce(
+          async (input) => {
+            await holdWriter();
+            const writing = finalMirror(input);
+            checkpointWrites.push(writing);
+            finalMirrorStarted.resolve();
+            return await writing;
+          },
+        );
+      }
+      const harness = createStartedThreadHarness();
+      const onAttemptTimeout = vi.fn();
+      const onAgentEvent = vi.fn();
+      const abort = new AbortController();
+      const successorAbort = new AbortController();
+      const publishedTerminal = vi.fn();
+      const unsubscribe = onInternalSessionTranscriptUpdate((update) => {
+        if (boundary === "publication" && update.runId === params.runId) {
+          publishedTerminal(update);
+          abort.abort("cancelled after transcript commit");
+        }
       });
-    const harness = createStartedThreadHarness();
-    const onAttemptTimeout = vi.fn();
-    params.onAttemptTimeout = onAttemptTimeout;
-    params.timeoutMs = 60 * 60_000;
-    vi.useFakeTimers();
-    const settled = vi.fn();
-    const run = runCodexAppServerAttempt(params);
-    void run.then(settled, settled);
-    try {
-      await harness.waitForMethod("turn/start");
-      const receivedAt = Date.now();
-      await harness.notify(
-        turnCompleted({
-          id: "turn-1",
-          status: "completed",
-          items: [
-            {
-              id: "checkpoint-command",
-              type: "commandExecution",
-              command: "echo saved",
-              cwd: params.workspaceDir,
-              commandActions: [],
-              processId: null,
-              source: "agent",
-              status: "completed",
-              aggregatedOutput: "saved",
-              exitCode: 0,
-              durationMs: 1,
+      params.abortSignal = abort.signal;
+      params.onAttemptTimeout = onAttemptTimeout;
+      params.onAgentEvent = onAgentEvent;
+      params.timeoutMs = 60 * 60_000;
+      vi.useFakeTimers();
+      const settled = vi.fn();
+      const run = runCodexAppServerAttempt(params);
+      let successor: ReturnType<typeof runCodexAppServerAttempt> | undefined;
+      void run.then(settled, settled);
+      try {
+        await harness.waitForMethod("turn/start");
+        if (boundary === "checkpoint") {
+          await holdWriter();
+        }
+        await harness.notify({
+          method: "rawResponse/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            responseId: "response-1",
+            usage: {
+              totalTokens: 12,
+              inputTokens: 5,
+              cachedInputTokens: 2,
+              outputTokens: 7,
+              reasoningOutputTokens: 0,
             },
-            { id: "checkpoint-answer", type: "agentMessage", text: "Completed before checkpoint." },
-          ],
-        }),
-      );
-      await vi.waitFor(() => expect(checkpointMirror).toHaveBeenCalledOnce(), fastWait);
-      await vi.advanceTimersByTimeAsync(
-        receivedAt + TURN_TERMINAL_SETTLEMENT_TIMEOUT_MS - Date.now(),
-      );
-      expect(onAttemptTimeout).toHaveBeenCalledExactlyOnceWith(
-        expect.objectContaining({ message: "codex app-server terminal settlement timed out" }),
-      );
-      await vi.advanceTimersByTimeAsync(TURN_FINALIZE_DRAIN_ABORT_GRACE_MS);
-      await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce(), fastWait);
-      const result = await run;
-      expect(readAttemptTerminal(result)).toMatchObject({
-        aborted: true,
-        timedOut: true,
-        promptError: "codex app-server terminal settlement timed out",
-      });
-      expect(result.codexAppServerFailure?.kind).toBe("turn_settlement_timeout");
-      expect(result.promptTimeoutOutcome).toMatchObject({ replayInvalid: true });
-      expect(result.assistantTexts).toEqual(["Completed before checkpoint."]);
-    } finally {
-      checkpoint.resolve();
-      vi.useRealTimers();
-      await Promise.allSettled([run, ...checkpointWrites]);
-    }
-  });
+          },
+        });
+        const receivedAt = Date.now();
+        await harness.notify(
+          turnCompleted({
+            id: "turn-1",
+            status: "completed",
+            items: [
+              {
+                id: "checkpoint-command",
+                type: "commandExecution",
+                command: "echo saved",
+                cwd: params.workspaceDir,
+                commandActions: [],
+                processId: null,
+                source: "agent",
+                status: "completed",
+                aggregatedOutput: "saved",
+                exitCode: 0,
+                durationMs: 1,
+              },
+              {
+                id: "checkpoint-answer",
+                type: "agentMessage",
+                text: "Completed before checkpoint.",
+              },
+            ],
+          }),
+        );
+        await vi.waitFor(() => expect(checkpointMirror).toHaveBeenCalledOnce(), fastWait);
+        if (boundary === "final") {
+          await finalMirrorStarted.promise;
+        }
+        if (termination === "timeout") {
+          await vi.advanceTimersByTimeAsync(
+            receivedAt + TURN_TERMINAL_SETTLEMENT_TIMEOUT_MS - Date.now(),
+          );
+          expect(onAttemptTimeout).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({ message: "codex app-server terminal settlement timed out" }),
+          );
+        } else if (boundary === "publication") {
+          await vi.waitFor(() => expect(publishedTerminal).toHaveBeenCalledOnce(), fastWait);
+        } else {
+          abort.abort("cancelled");
+        }
+        if (release === "after cutoff") {
+          await vi.advanceTimersByTimeAsync(TURN_FINALIZE_DRAIN_ABORT_GRACE_MS);
+        } else {
+          checkpoint.resolve();
+          await Promise.allSettled(checkpointWrites);
+        }
+        await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce(), fastWait);
+        const result = await run;
+        expect(readAttemptTerminal(result)).toMatchObject({
+          aborted: true,
+          timedOut: termination === "timeout",
+          promptError:
+            termination === "timeout" ? "codex app-server terminal settlement timed out" : null,
+        });
+        expect(result.codexAppServerFailure?.kind).toBe(
+          termination === "timeout" ? "turn_settlement_timeout" : undefined,
+        );
+        if (termination === "timeout") {
+          expect(result.promptTimeoutOutcome).toMatchObject({ replayInvalid: true });
+        } else {
+          expect(onAttemptTimeout).not.toHaveBeenCalled();
+        }
+        expect(result.assistantTexts).toEqual(["Completed before checkpoint."]);
+        expect(result.lastAssistant?.stopReason).toBe("aborted");
+        expect(result.attemptUsage).toMatchObject({ input: 3, output: 7, cacheRead: 2, total: 12 });
+        expect(result.attemptUsage?.contextUsage).toEqual({ state: "unavailable" });
+        const assistantCommitted =
+          boundary === "publication" || (boundary === "checkpoint" && release === "during grace");
+        expect(
+          onAgentEvent.mock.calls.filter(
+            ([event]) =>
+              event.stream === "lifecycle" &&
+              (event.data.phase === "end" || event.data.phase === "error"),
+          ),
+        ).toHaveLength(1);
+        expect(resolveActiveEmbeddedRunSessionId(transcriptTarget.sessionKey)).toBeUndefined();
+        if (release !== "after cutoff" || (boundary === "final" && termination === "abort")) {
+          checkpoint.resolve();
+          await Promise.allSettled(checkpointWrites);
+          const events = await readSessionTranscriptEvents(transcriptTarget);
+          const assistantRows = events.filter(
+            (event) =>
+              isJsonObject(event) &&
+              isJsonObject(event.message) &&
+              event.message.role === "assistant" &&
+              isJsonObject(event.message["__openclaw"]) &&
+              event.message["__openclaw"].mirrorIdentity === "turn-1:assistant",
+          );
+          if (assistantCommitted) {
+            expect(assistantRows).toEqual([
+              expect.objectContaining({
+                id: result.contextEngineTerminalAnchor?.entryId,
+                message: expect.objectContaining({
+                  stopReason: boundary === "publication" ? "stop" : "aborted",
+                  idempotencyKey: result.assistantTranscriptIdempotencyKey,
+                }),
+              }),
+            ]);
+            if (boundary === "publication") {
+              expect(publishedTerminal).toHaveBeenCalledExactlyOnceWith(
+                expect.objectContaining({ messageId: result.contextEngineTerminalAnchor?.entryId }),
+              );
+            }
+          } else {
+            expect(assistantRows).toEqual([]);
+          }
+        }
+        if (assistantCommitted) {
+          expect(result.assistantTranscriptOwned).toBe(true);
+          expect(result.assistantTranscriptIdempotencyKey).toEqual(expect.any(String));
+          expect(result.contextEngineTerminalAnchor).toMatchObject({
+            idempotencyKey: result.assistantTranscriptIdempotencyKey,
+          });
+        } else {
+          expect(result.assistantTranscriptOwned).not.toBe(true);
+          expect(result.assistantTranscriptIdempotencyKey).toBeUndefined();
+          expect(result.contextEngineTerminalAnchor).toBeUndefined();
+        }
+        if (boundary === "final" && termination === "abort" && release === "after cutoff") {
+          const nextHarness = createStartedThreadHarness(
+            async (method) => {
+              if (method === "thread/resume") {
+                return threadStartResult("thread-1");
+              }
+              return method === "turn/start" ? turnStartResult("turn-next") : undefined;
+            },
+            { persistedThreads: ["thread-1"] },
+          );
+          successor = runCodexAppServerAttempt({
+            ...params,
+            runId: "run-next",
+            abortSignal: successorAbort.signal,
+          });
+          await nextHarness.waitForMethod("turn/start");
+          await nextHarness.notify(
+            turnCompleted({
+              id: "turn-next",
+              status: "completed",
+              items: [{ id: "next-answer", type: "agentMessage", text: "Next turn saved." }],
+            }),
+          );
+          const next = await successor;
+          expect(readAttemptTerminal(next)).toMatchObject({ aborted: false, timedOut: false });
+          expect(next.assistantTranscriptOwned).toBe(true);
+          const history = JSON.stringify(await readSessionTranscriptEvents(transcriptTarget));
+          expect(history).toContain("Next turn saved.");
+          expect(history).not.toContain("Completed before checkpoint.");
+        }
+      } finally {
+        unsubscribe();
+        checkpoint.resolve();
+        abort.abort("test cleanup");
+        successorAbort.abort("test cleanup");
+        vi.useRealTimers();
+        await Promise.allSettled([run, ...checkpointWrites, ...(successor ? [successor] : [])]);
+      }
+    },
+  );
 });

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -113,6 +113,7 @@ export async function importCodexThreadHistoryToTranscript(params: {
 }
 
 async function mirrorBestEffort(params: {
+  assertWriteCurrent?: () => void;
   params: EmbeddedRunAttemptParams;
   agentId?: string;
   notifyUserMessagePersisted: UserMessagePersistenceNotifier;
@@ -136,7 +137,9 @@ async function mirrorBestEffort(params: {
       messagesSnapshot: params.result.messagesSnapshot,
       turnId: params.turnId,
     });
+    params.assertWriteCurrent?.();
     const mirrorResult = await mirror({
+      assertWriteCurrent: params.assertWriteCurrent,
       agentId: params.agentId,
       sessionKey: params.sessionKey,
       sessionId: params.params.sessionId,
@@ -331,6 +334,7 @@ function buildMirrorDedupeIdentity(message: MirroredAgentMessage): string {
 
 async function mirror(params: {
   assertCurrent?: () => void;
+  assertWriteCurrent?: () => void;
   sessionId: string;
   cwd?: string;
   sessionKey?: string;
@@ -374,11 +378,17 @@ async function mirror(params: {
     idempotencyKey ? [idempotencyKey] : [],
   );
   const transcriptTarget = resolveCodexMirrorTranscriptTarget(params);
-  params.assertCurrent?.();
+  // A queued terminal must still match its prepared outcome before committing.
+  // Publication may trigger Stop afterward; that cannot erase a committed receipt.
+  const assertWritable = () => {
+    params.assertCurrent?.();
+    params.assertWriteCurrent?.();
+  };
+  assertWritable();
   const mirrorBatch = await withCodexSessionTranscriptMirrorWriteLock(
     { ...transcriptTarget, config: params.config },
     async (transcript) => {
-      params.assertCurrent?.();
+      assertWritable();
       const nextAppendedUpdates: Array<{
         messageId: string;
         message: AgentMessage;
@@ -392,7 +402,7 @@ async function mirror(params: {
       const mirrorFacts = await transcript.readMessageFacts({
         idempotencyKeys: candidateIdempotencyKeys,
       });
-      params.assertCurrent?.();
+      assertWritable();
       for (const { dedupeIdentity, idempotencyKey, message, sourceFingerprint } of candidates) {
         const mirrorIdentity = readMirrorIdentity(message);
         const ownsRun = Boolean(
@@ -433,6 +443,7 @@ async function mirror(params: {
           }
           continue;
         }
+        assertWritable();
         const preparedUserMessage =
           transcriptMessage.role === "user"
             ? {
@@ -497,13 +508,13 @@ async function mirror(params: {
           hidden: (message as { display?: boolean }).display === false,
           message: messageToAppend,
         });
-        params.assertCurrent?.();
+        assertWritable();
         const { messageSeq, result: appended } = await transcript.appendMessageWithMessageSequence({
           message: messageToAppend,
-          ...(params.assertCurrent
+          ...(params.assertCurrent || params.assertWriteCurrent
             ? {
                 prepareMessageAfterIdempotencyCheck: (preparedMessage: typeof messageToAppend) => {
-                  params.assertCurrent?.();
+                  assertWritable();
                   return preparedMessage;
                 },
               }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a maintainer-owned branch in the same repository.

</details>

## What Problem This Solves

Fixes an issue where users stopping a Codex turn could leave it active after native completion when the final transcript write waited behind another writer. The same wait could bypass the existing terminal-settlement timeout.

## Why This Change Was Made

The finalizer previously disposed its settlement deadline before awaiting the final transcript mirror. It now retains that same deadline and abort grace through the final write, then closes queued-write authority before publishing the immutable terminal result.

A queued mirror revalidates its prepared terminal classification at the write boundary. An already-aborted result may drain within grace; a success prepared before Stop cannot commit afterward. A row already committed before a publication-triggered Stop retains its exact ownership receipt. Existing native cleanup, writer fences, refusal handling, attachment attestation, and hook ordering stay with their current owners.

## User Impact

Stopped or timed-out Codex turns can finish finalization while the transcript writer remains blocked. Late queued work cannot append an obsolete successful answer, and the next turn can reuse the session once the writer is released.

## Evidence

- Baseline real-writer reproductions fail because the final mirror omits the settlement timeout and leaves explicit Stop unsettled. A separate interleaving reproduces a stale successful terminal row when Stop arrives before a queued write commits.
- Current-main integration at `30dfc0c64726e27ce2ebf159f514d2d9f70e02bc`: **70 passed** across six files, including all nine settlement cases, native cleanup/router/lifecycle tests, and selected queued-terminal, cancellation, and recovery cases. Source hashes were unchanged throughout the run.
- Production and test type checks passed. Codex P2 review found no actionable findings on the exact current-main patch. Final targeted lint, formatting, and diff checks passed. No source changes followed the review.
- The earlier local changed check passed 19 gates, then its production and full-tree Knip scans hit the existing 600-second limit. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33950180815) passed on `23fd4c23f5aa48acf2373854d05faaa0347c4853`, including `check-dependencies`, resolving that incomplete gate without increasing a timeout or waiving a check.

The regressions use real OpenClaw attempt/cancellation/SQLite owners with synthetic Codex protocol notifications and virtual time. They do not constitute authenticated provider or deployment-latency proof.

Production LOC: +520/-425 (net +95); tests +267/-72. The added ownership boundary keeps one settlement lifetime through the final awaited write and validates terminal state before commit; duplicate local lifetime/error state was removed. No schema, stored representation, configuration, public protocol, or dependency changes.
