### PR TITLE
refactor(state): use typed queries for Claw adoption

### DIFF
--- a/src/claws/mcp.test.ts
+++ b/src/claws/mcp.test.ts
@@ -4,7 +4,12 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { markClawMcpServerIndependentlyOwned } from "../state/claw-mcp-adoption.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { buildClawAddPlan } from "./lifecycle.js";
-import { deleteClawMcpServerRef, installClawMcpServers, planClawMcpServerRemoval } from "./mcp.js";
+import {
+  deleteClawMcpServerRef,
+  installClawMcpServers,
+  planClawMcpServerRemoval,
+  readClawMcpServerRefs,
+} from "./mcp.js";
 import { parseClawManifest } from "./schema.js";
 import type { ClawSourceIdentity } from "./types.js";
 
@@ -343,17 +348,20 @@ describe("installClawMcpServers", () => {
 
   it("retains a managed server after an ordinary MCP owner adopts it", async () => {
     const current = await fixture();
-    const refs = await installClawMcpServers(current.plan, {
+    await installClawMcpServers(current.plan, {
       env: current.env,
       setMcpServer: vi.fn().mockResolvedValue(listedMcpServers()),
       listMcpServers: vi.fn().mockResolvedValue(listedMcpServers()),
     });
 
     expect(markClawMcpServerIndependentlyOwned("docs", { env: current.env, nowMs: 50 })).toBe(1);
-    const status = planClawMcpServerRemoval(
-      { ...refs[0]!, independentOwner: true },
-      { env: current.env },
-    );
+    expect(markClawMcpServerIndependentlyOwned("docs", { env: current.env, nowMs: 60 })).toBe(0);
+    const refs = readClawMcpServerRefs("worker", { env: current.env });
+    expect(refs).toMatchObject([
+      { name: "docs", independentOwner: true, updatedAtMs: 50 },
+      { name: "linear", independentOwner: false },
+    ]);
+    const status = planClawMcpServerRemoval(refs[0]!, { env: current.env });
     expect(status).toMatchObject({ action: "release", blocked: false });
   });
 

--- a/src/state/claw-mcp-adoption.ts
+++ b/src/state/claw-mcp-adoption.ts
@@ -1,4 +1,6 @@
 import { existsSync } from "node:fs";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB } from "./openclaw-state-db.generated.js";
 import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
@@ -16,15 +18,15 @@ export function markClawMcpServerIndependentlyOwned(
   }
   try {
     return runOpenClawStateWriteTransaction(({ db }) => {
-      const result =
-        db /* sqlite-allow-raw: record a current non-Claw MCP owner after direct config. */
-          .prepare(
-            `UPDATE claw_mcp_server_refs
-                SET independent_owner = 1, updated_at_ms = @updated_at_ms
-              WHERE name = @name AND independent_owner <> 1`,
-          )
-          .run({ name, updated_at_ms: options.nowMs ?? Date.now() });
-      return Number(result.changes);
+      const result = executeSqliteQuerySync(
+        db,
+        getNodeSqliteKysely<Pick<DB, "claw_mcp_server_refs">>(db)
+          .updateTable("claw_mcp_server_refs")
+          .set({ independent_owner: 1, updated_at_ms: options.nowMs ?? Date.now() })
+          .where("name", "=", name)
+          .where("independent_owner", "!=", 1),
+      );
+      return Number(result.numAffectedRows);
     }, options);
   } catch {
     // The canonical MCP write already succeeded; Claw status still detects config drift.

--- a/src/state/claw-package-adoption.test.ts
+++ b/src/state/claw-package-adoption.test.ts
@@ -86,39 +86,46 @@ describe("Claw package independent adoption", () => {
     for (const agentId of ["first", "second"]) {
       const current = plan(agentId, `/tmp/${agentId}`);
       persistClawInstallRecord(current, { env });
-      persistClawPackageRef(
-        current,
-        {
-          kind: "plugin",
-          source: "clawhub",
-          ref: "@acme/audit",
-          version: "1.0.0",
-          integrity: packageIntegrity,
-        },
-        {
-          env,
-          relationship: "referenced",
-          origin: "claw-introduced",
-          independentOwner: false,
-        },
-      );
+      for (const version of ["1.0.0", "2.0.0"]) {
+        persistClawPackageRef(
+          current,
+          {
+            kind: "plugin",
+            source: "clawhub",
+            ref: "@acme/audit",
+            version,
+            integrity: packageIntegrity,
+          },
+          {
+            env,
+            nowMs: 10,
+            relationship: "referenced",
+            origin: "claw-introduced",
+            independentOwner: false,
+          },
+        );
+      }
     }
 
-    expect(
-      markClawPackageIndependentlyOwned(
-        {
-          kind: "plugin",
-          source: "clawhub",
-          ref: "@acme/audit",
-          version: "1.0.0",
-        },
-        { env, nowMs: 42 },
-      ),
-    ).toBe(2);
-    expect(readClawPackageRefs({ env })).toMatchObject([
-      { origin: "claw-introduced", independentOwner: true, updatedAtMs: 42 },
-      { origin: "claw-introduced", independentOwner: true, updatedAtMs: 42 },
+    const artifact = {
+      kind: "plugin",
+      source: "clawhub",
+      ref: "@acme/audit",
+      version: "1.0.0",
+    } as const;
+    expect(markClawPackageIndependentlyOwned(artifact, { env, nowMs: 42 })).toBe(2);
+    expect(markClawPackageIndependentlyOwned(artifact, { env, nowMs: 99 })).toBe(0);
+    const refs = readClawPackageRefs({ env }).toSorted(
+      (left, right) =>
+        left.agentId.localeCompare(right.agentId) || left.version.localeCompare(right.version),
+    );
+    expect(refs).toMatchObject([
+      { version: "1.0.0", independentOwner: true, updatedAtMs: 42 },
+      { version: "2.0.0", independentOwner: false, updatedAtMs: 10 },
+      { version: "1.0.0", independentOwner: true, updatedAtMs: 42 },
+      { version: "2.0.0", independentOwner: false, updatedAtMs: 10 },
     ]);
+    expect(refs.every((ref) => ref.origin === "claw-introduced")).toBe(true);
   });
 
   it("scopes skill adoption to the owning agent workspace", () => {

--- a/src/state/claw-package-adoption.ts
+++ b/src/state/claw-package-adoption.ts
@@ -1,4 +1,6 @@
 import { existsSync } from "node:fs";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB } from "./openclaw-state-db.generated.js";
 import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
@@ -25,39 +27,28 @@ export function markClawPackageIndependentlyOwned(
   const nowMs = options.nowMs ?? Date.now();
   try {
     return runOpenClawStateWriteTransaction(({ db }) => {
-      const workspaceScope =
-        artifact.kind === "skill"
-          ? `AND agent_id IN (
-             SELECT agent_id FROM claw_installs WHERE workspace = @workspace
-           )`
-          : "";
-      const versionScope = artifact.version ? "AND package_version = @package_version" : "";
-      const statement =
-        db /* sqlite-allow-raw: record a current non-Claw package owner after direct install. */
-          .prepare(
-            `UPDATE claw_package_refs
-            SET independent_owner = 1, updated_at_ms = @updated_at_ms
-          WHERE package_kind = @package_kind
-            AND package_source = @package_source
-            AND package_ref = @package_ref
-            ${versionScope}
-            AND independent_owner <> 1
-            ${workspaceScope}`,
-          );
-      const bindings: Record<string, string | number> = {
-        package_kind: artifact.kind,
-        package_source: artifact.source,
-        package_ref: artifact.ref,
-        updated_at_ms: nowMs,
-      };
+      const kysely = getNodeSqliteKysely<Pick<DB, "claw_package_refs" | "claw_installs">>(db);
+      let query = kysely
+        .updateTable("claw_package_refs")
+        .set({ independent_owner: 1, updated_at_ms: nowMs })
+        .where("package_kind", "=", artifact.kind)
+        .where("package_source", "=", artifact.source)
+        .where("package_ref", "=", artifact.ref)
+        .where("independent_owner", "!=", 1);
       if (artifact.version) {
-        bindings.package_version = artifact.version;
+        query = query.where("package_version", "=", artifact.version);
       }
       if (artifact.kind === "skill") {
-        bindings.workspace = artifact.workspace ?? "";
+        query = query.where(
+          "agent_id",
+          "in",
+          kysely
+            .selectFrom("claw_installs")
+            .select("agent_id")
+            .where("workspace", "=", artifact.workspace ?? ""),
+        );
       }
-      const result = statement.run(bindings);
-      return Number(result.changes);
+      return Number(executeSqliteQuerySync(db, query).numAffectedRows);
     }, options);
   } catch {
     // The canonical install already succeeded. Removal also checks its newer owner timestamp.


### PR DESCRIPTION
## What Problem This Solves

Direct package installation and MCP configuration can adopt resources previously introduced by a Claw. Those adoption owners still built ordinary UPDATE statements and optional SQL fragments by hand, making their predicates harder to check against the canonical state schema.

## Why This Change Was Made

Use the generated state database types and existing synchronous Kysely executor inside each owner's existing transaction. Delete the raw statements and binding maps. Preserve exact artifact/name matching, the optional version and workspace filters, each owner's timestamp location, affected-row counts, repeat-call timestamps, and caught-failure behavior.

This is the existing SQLite backend and transaction boundary. It adds no schema, migration, configuration, storage format, concurrency policy, or public API. Production is 31 added / 38 removed (net **−7**); tests are 51 added / 36 removed (net **+15**).

## User Impact

No intended user-visible change. Independently adopted resources remain protected from Claw removal. Two existing tests now verify the actual persisted ownership marker and version isolation, including a repeat claim leaving timestamps unchanged.

## Evidence

- **44 focused tests** across package adoption, MCP ownership, lifecycle state, MCP config mutation, and MCP config; the two owner suites and final ordering assertion also passed after test refinement.
- **Full changed-file gate passed**, including types, lint, formatting, schema/SQLite guards, dead exports and import cycles.
- **Independent Codex P0–P2 review:** three scoped passes, no actionable findings. The dataset includes complete owners, callers, sibling removal paths, canonical schema, installed Kysely compiler/parser source, Node SQLite statement source, and native proof.
- **Native baseline/candidate process proof:** eight exercise phases plus a fresh-process reopen per revision, using Node 24.20.0 and real canonical SQLite, configuration and removal owners. Both passed missing/invalid state, supplied handle with missing path, exact/empty/omitted version selection, workspace scope, Unicode/quote/NUL identities, shared references, both timestamp locations, repeated claims, real SQLite trigger failures with complete rollback/retry, and unchanged schema. Config publication remained successful when adoption failed; a later retry durably changed removal from remove to release. An adopted skill was retained by the actual package-removal owner.

The native proof invokes real storage/config/removal owners in isolated processes; it does not claim a network package download or running-Gateway test. Synthetic databases were retained for inspection. The initial baseline fixture tried to create the same completed install twice and was rejected; the fixture was corrected before production edits, and both revisions then used the same runner.

Focused command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  src/state/claw-package-adoption.test.ts src/claws/mcp.test.ts \
  src/claws/lifecycle-state-mcp.test.ts src/agents/mcp-config-mutation.test.ts \
  src/config/mcp-config.test.ts
```

The Kysely update/set/value/subquery compiler and Node native statement contracts were inspected directly. No dependency or Codex protocol/runtime behavior changes are involved.
