### PR TITLE
fix(sessions): preserve other agents' plugin state on delete

### DIFF
--- a/src/gateway/server.sessions.delete-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-lifecycle.test.ts
@@ -708,30 +708,47 @@ test("sessions.delete limits plugin-runtime cleanup to sessions owned by that pl
   expect(deleted.payload?.deleted).toBe(true);
 });
 
-test("sessions.delete scopes selected global deletes to the requested agent", async () => {
-  const globalStores = await createConfiguredGlobalAgentSessionStore({ writePrimeStore: true });
-
-  await expectSessionDeleteSucceeds({
-    key: "global",
-    agentId: "work",
-    deleteTranscript: false,
-  });
-  expect(
-    loadSessionEntry({
+test.each(["sessions.delete", "sessions.reset"] as const)(
+  "%s scopes selected global cleanup to the requested agent",
+  async (method) => {
+    const globalStores = await createConfiguredGlobalAgentSessionStore({ writePrimeStore: true });
+    const mainTarget = {
       agentId: "main",
       sessionKey: "global",
       storePath: globalStores.mainStorePath,
-    })?.sessionId,
-  ).toBe("sess-main-global");
-  expect(
-    loadSessionEntry({
-      agentId: "work",
-      sessionKey: "global",
-      storePath: globalStores.workStorePath,
-    }),
-  ).toBeUndefined();
-  await resetConfiguredGlobalAgentSessionStore(globalStores);
-});
+    };
+    const workTarget = { ...mainTarget, agentId: "work", storePath: globalStores.workStorePath };
+    for (const target of [mainTarget, workTarget]) {
+      await replaceSessionEntry(
+        target,
+        sessionStoreEntry(`sess-${target.agentId}-global`, {
+          pluginExtensions: { fixture: { state: { owner: target.agentId } } },
+        }),
+      );
+    }
+    const mainBefore = loadSessionEntry(mainTarget);
+    const { ws } = await openClient();
+    try {
+      const result = await rpcReq(ws, method, {
+        key: "global",
+        agentId: "work",
+        ...(method === "sessions.delete" ? { deleteTranscript: false } : {}),
+      });
+      expect(result.ok, result.error?.message).toBe(true);
+      expect(loadSessionEntry(mainTarget)).toEqual(mainBefore);
+      const workAfter = loadSessionEntry(workTarget);
+      if (method === "sessions.delete") {
+        expect(workAfter).toBeUndefined();
+      } else {
+        expect(workAfter?.sessionId).toBe("sess-work-global");
+        expect(workAfter?.pluginExtensions).toBeUndefined();
+      }
+    } finally {
+      ws.close();
+      await resetConfiguredGlobalAgentSessionStore(globalStores);
+    }
+  },
+);
 
 test("sessions.delete closes ACP runtime handles before removing ACP sessions", async () => {
   const { dir } = await createSessionStoreDir();

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -857,6 +857,8 @@ export async function cleanupSessionBeforeMutation(params: {
     registry: getActivePluginRegistry(),
     reason: params.reason === "session-reset" ? "reset" : "delete",
     sessionKey: params.target.canonicalKey ?? params.key,
+    // Unscoped keys can exist in several agent stores; this lifecycle owns only its target.
+    sessionStoreTargets: [params.target],
     shouldCleanup: () => {
       params.assertCurrent?.();
       return true;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where deleting a selected agent's global session could also clear persistent plugin state from another agent's global session. The deletion cleanup also discovered and read unrelated agent stores despite already knowing the target store.

## Why This Change Was Made

The Gateway now passes the deleted session's resolved agent/store target to the existing plugin cleanup API. This keeps persistent cleanup within the lifecycle owner while preserving the broad cleanup contract used for plugin-wide operations and runtime-session-ID cleanup. Reset already delegates persistent cleanup to its atomic owner and needs no production change.

## User Impact

Deleting a session preserves plugin state and timestamps in other agents' same-key sessions and avoids the unrelated-store scan. Session draining, archive publication, provider cleanup, and plugin callback semantics stay intact. No schema, migration, configuration, dependency, or public API changes.

## Evidence

- Before the fix, the real loopback Gateway WebSocket deletion returned success on Linux, then the existing global-owner test caught the other agent's `pluginExtensions` disappearing and its `updatedAt` changing. The reset sibling passed. The identical candidate case passes and leaves that sibling entry unchanged; the reset sibling remains green.
- The strengthened existing test checks both delete and reset and inspects canonical SQLite rows. Generic cleanup coverage retains multi-store runtime IDs, opaque Matrix/Signal keys, shared custom stores, and locked harnesses.
- Two local filtered attempts reached the existing deletion RPC deadline during cold source execution; those are retained as inconclusive. The unchanged Linux reproduction reached the intended state assertion without a timeout.
- Linux Testbox: 59 tests passed across `server.sessions.delete-lifecycle.test.ts`, `server.sessions.reset-cleanup.test.ts`, `host-hook-cleanup.session-store.test.ts`, and `host-hook-cleanup.config.test.ts`; the complete `node scripts/check-changed.mjs --base origin/main` plan passed. [Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33948824488). The wrapper pinned base `7b1217e2e79e5b489ea542e3019f9e86c281529a`; source admission and required log artifacts were retained.
- The Gateway regression uses existing mocks for external runtime cleanup; the socket, persistent plugin cleanup, store resolution, and SQLite are real. A mechanical rebase onto `24ccedcb3e5fbb47c56cbc1a8efb0c5b48c1648d` preserved both changed files byte-for-byte.
- [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/33950811740) completed successfully for exact head `810d7c9b302dc6ed765401d55847b209e19cfd11`. Completed ClawSweeper review has no findings or before-merge requests.
- Independent Codex autoreview is clean through P2. The Testbox was stopped and independently reports completed.
- This is internal persisted plugin state with no Control UI projection. The user-facing action is exercised over the actual Gateway socket; a screenshot cannot establish preservation of these fields.

Production: +2 lines (existing argument plus ownership comment); tests: +17 net lines. No production latency or event-loop attribution is claimed from the synthetic timings.
