### PR TITLE
perf(proxy-capture): stream coverage metadata reads

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3529,7 +3529,7 @@ src/projects/project-registry.ts	1
 src/provider-runtime/operation-retry.ts	3
 src/proxy-capture/env.ts	1
 src/proxy-capture/runtime.ts	10
-src/proxy-capture/store.sqlite.ts	25
+src/proxy-capture/store.sqlite.ts	23
 src/realtime-transcription/websocket-session.ts	2
 src/routing/binding-scope.ts	1
 src/runtime.ts	4

--- a/src/proxy-capture/store-readonly.ts
+++ b/src/proxy-capture/store-readonly.ts
@@ -1,11 +1,14 @@
 import { gunzipSync } from "node:zlib";
+import { normalizeNullableString as normalizeObservedValue } from "@openclaw/normalization-core/string-coerce";
 import {
+  compileSqliteQueryBindings,
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import type { CaptureObservedDimension, CaptureSessionCoverageSummary } from "./types.js";
 
 type DebugProxyCaptureDatabase = Pick<
   OpenClawStateKyselyDatabase,
@@ -55,6 +58,101 @@ export function readDebugProxyCaptureSessionEvents(
       .orderBy("id", "desc")
       .limit(limit),
   ).rows;
+}
+
+// Metadata is optional and user/tool supplied, so parse defensively for coverage
+// summaries instead of assuming every event has valid JSON.
+function parseMetaJson(metaJson: unknown): Record<string, unknown> | null {
+  if (typeof metaJson !== "string" || metaJson.trim().length === 0) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(metaJson) as unknown;
+    // SAFETY: Parsed objects, including arrays, are read only through optional label keys.
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function sortObservedCounts(counts: Map<string, number>): CaptureObservedDimension[] {
+  return [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .toSorted((left, right) => right.count - left.count || left.value.localeCompare(right.value));
+}
+
+export function summarizeDebugProxyCaptureSessionCoverage(
+  db: NodeSqliteDatabase,
+  sessionId: string,
+): CaptureSessionCoverageSummary {
+  const { compiled, bind } = compileSqliteQueryBindings<string>((parameter) =>
+    getNodeSqliteKysely<DebugProxyCaptureDatabase>(db)
+      .selectFrom("capture_events")
+      .select(["host", "meta_json as metaJson"])
+      .where(
+        "session_id",
+        "=",
+        parameter((value) => value),
+      ),
+  );
+  // Native iteration keeps corruption from evicting the borrowed shared database.
+  const rows = db /* sqlite-allow-raw -- Execute Kysely SQL with native failure ownership. */
+    .prepare(compiled.sql)
+    .iterate(...bind(sessionId));
+  const providers = new Map<string, number>();
+  const apis = new Map<string, number>();
+  const models = new Map<string, number>();
+  const hosts = new Map<string, number>();
+  const localPeers = new Map<string, number>();
+  let totalEvents = 0;
+  let unlabeledEventCount = 0;
+  try {
+    for (const row of rows) {
+      totalEvents += 1;
+      const meta = parseMetaJson(row.metaJson);
+      const provider = normalizeObservedValue(meta?.provider);
+      const api = normalizeObservedValue(meta?.api);
+      const model = normalizeObservedValue(meta?.model);
+      const host = normalizeObservedValue(row.host);
+      if (!provider && !api && !model) {
+        unlabeledEventCount += 1;
+      }
+      if (provider) {
+        providers.set(provider, (providers.get(provider) ?? 0) + 1);
+      }
+      if (api) {
+        apis.set(api, (apis.get(api) ?? 0) + 1);
+      }
+      if (model) {
+        models.set(model, (models.get(model) ?? 0) + 1);
+      }
+      if (host) {
+        hosts.set(host, (hosts.get(host) ?? 0) + 1);
+        // Local model/provider endpoints are useful to surface separately when
+        // debugging why cloud-provider labels are absent.
+        if (host.startsWith("127.0.0.1:") || host.startsWith("localhost:")) {
+          localPeers.set(host, (localPeers.get(host) ?? 0) + 1);
+        }
+      }
+    }
+  } catch (error) {
+    try {
+      rows.return?.();
+    } catch {
+      // Iterator cleanup must not replace the original read failure.
+    }
+    throw error;
+  }
+  return {
+    sessionId,
+    totalEvents,
+    unlabeledEventCount,
+    providers: sortObservedCounts(providers),
+    apis: sortObservedCounts(apis),
+    models: sortObservedCounts(models),
+    hosts: sortObservedCounts(hosts),
+    localPeers: sortObservedCounts(localPeers),
+  };
 }
 
 export function readDebugProxyCaptureBlob(db: NodeSqliteDatabase, blobId: string): string | null {

--- a/src/proxy-capture/store.sqlite.test.ts
+++ b/src/proxy-capture/store.sqlite.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { constants } from "node:sqlite";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi, type MockInstance } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
@@ -40,6 +40,105 @@ function readMode(target: string): number {
 }
 
 describe("DebugProxyCaptureStore", () => {
+  it.each(["shared", "path"] as const)(
+    "summarizes %s capture labels without materializing every metadata row",
+    (kind) => {
+      const env = makeStateEnv("openclaw-proxy-capture-coverage-");
+      const store =
+        kind === "shared"
+          ? new DebugProxyCaptureStore({ env })
+          : new DebugProxyCaptureStore(
+              path.join(env.OPENCLAW_STATE_DIR!, "capture.sqlite"),
+              path.join(env.OPENCLAW_STATE_DIR!, "blobs"),
+            );
+      const events = [
+        { host: " localhost:7 ", metaJson: '{"provider":" alpha ","api":"chat","model":"one"}' },
+        { host: "localhost:7", metaJson: '{"provider":"alpha","api":"chat","model":"two"}' },
+        { host: "remote", metaJson: '{"provider":"beta","api":"other","model":"two"}' },
+        { host: "localhost", metaJson: '{"provider":1,"api":[],"model":false}' },
+        { host: "LOCALHOST:7", metaJson: "invalid" },
+        { host: "[::1]:7", metaJson: "[]" },
+        { metaJson: " " },
+        {},
+        { metaJson: "null" },
+        { metaJson: "42" },
+        { metaJson: '"text"' },
+        { host: "remote", metaJson: '{"provider":"gamma","api":" ","model":""}' },
+      ];
+      try {
+        for (const [index, event] of [
+          ...events,
+          { metaJson: '{"provider":"excluded"}' },
+        ].entries()) {
+          store.recordEvent({
+            sessionId: index < events.length ? "coverage" : "other",
+            ts: index,
+            sourceScope: "openclaw",
+            sourceProcess: "test",
+            protocol: "http",
+            direction: "local",
+            kind: "request",
+            flowId: `flow-${index}`,
+            ...event,
+          });
+        }
+        const prepare = store.db.prepare.bind(store.db);
+        const materializations: MockInstance[] = [];
+        vi.spyOn(store.db, "prepare").mockImplementation((sql) => {
+          const statement = prepare(sql);
+          materializations.push(vi.spyOn(statement, "all"));
+          return statement;
+        });
+
+        const summary = store.summarizeSessionCoverage("coverage");
+
+        expect(summary).toMatchObject({
+          sessionId: "coverage",
+          totalEvents: 12,
+          unlabeledEventCount: 8,
+          providers: [
+            { value: "alpha", count: 2 },
+            { value: "beta", count: 1 },
+            { value: "gamma", count: 1 },
+          ],
+          apis: [
+            { value: "chat", count: 2 },
+            { value: "other", count: 1 },
+          ],
+          models: [
+            { value: "two", count: 2 },
+            { value: "one", count: 1 },
+          ],
+          localPeers: [{ value: "localhost:7", count: 2 }],
+        });
+        expect(Object.fromEntries(summary.hosts.map(({ value, count }) => [value, count]))).toEqual(
+          {
+            "localhost:7": 2,
+            remote: 2,
+            localhost: 1,
+            "LOCALHOST:7": 1,
+            "[::1]:7": 1,
+          },
+        );
+        expect(store.summarizeSessionCoverage("missing")).toEqual({
+          sessionId: "missing",
+          totalEvents: 0,
+          unlabeledEventCount: 0,
+          providers: [],
+          apis: [],
+          models: [],
+          hosts: [],
+          localPeers: [],
+        });
+        for (const materialization of materializations) {
+          expect(materialization).not.toHaveBeenCalled();
+        }
+      } finally {
+        store.close();
+      }
+    },
+  );
+
   it("keeps the cached store open until the last lease releases", () => {
     const options = { env: makeStateEnv("openclaw-proxy-capture-lease-") };
 

--- a/src/proxy-capture/store.sqlite.ts
+++ b/src/proxy-capture/store.sqlite.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { StringDecoder } from "node:string_decoder";
 import { gunzipSync, gzipSync } from "node:zlib";
-import { normalizeNullableString as normalizeObservedValue } from "@openclaw/normalization-core/string-coerce";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { sha256Hex } from "../infra/crypto-digest.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
@@ -22,11 +21,14 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
-import { readDebugProxyCaptureBlob, readDebugProxyCaptureSessionEvents } from "./store-readonly.js";
+import {
+  readDebugProxyCaptureBlob,
+  readDebugProxyCaptureSessionEvents,
+  summarizeDebugProxyCaptureSessionCoverage,
+} from "./store-readonly.js";
 import type {
   CaptureBlobRecord,
   CaptureEventRecord,
-  CaptureObservedDimension,
   CaptureQueryPreset,
   CaptureQueryRow,
   CaptureSessionCoverageSummary,
@@ -180,26 +182,6 @@ function openPathBasedDebugProxyCaptureStore(
 
 function serializeJson(value: unknown): string | null {
   return value == null ? null : JSON.stringify(value);
-}
-
-// Metadata is optional and user/tool supplied, so parse defensively for coverage
-// summaries instead of assuming every event has valid JSON.
-function parseMetaJson(metaJson: unknown): Record<string, unknown> | null {
-  if (typeof metaJson !== "string" || metaJson.trim().length === 0) {
-    return null;
-  }
-  try {
-    const parsed = JSON.parse(metaJson) as unknown;
-    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
-  } catch {
-    return null;
-  }
-}
-
-function sortObservedCounts(counts: Map<string, number>): CaptureObservedDimension[] {
-  return [...counts.entries()]
-    .map(([value, count]) => ({ value, count }))
-    .toSorted((left, right) => right.count - left.count || left.value.localeCompare(right.value));
 }
 
 type SharedDebugProxyCaptureState = {
@@ -468,56 +450,7 @@ class DebugProxyCaptureStoreImpl {
   }
 
   summarizeSessionCoverage(sessionId: string): CaptureSessionCoverageSummary {
-    const rows = this.db
-      .prepare(
-        `SELECT host, meta_json AS metaJson
-         FROM capture_events
-         WHERE session_id = ?`,
-      )
-      .all(sessionId) as Array<{ host?: string | null; metaJson?: string | null }>;
-    const providers = new Map<string, number>();
-    const apis = new Map<string, number>();
-    const models = new Map<string, number>();
-    const hosts = new Map<string, number>();
-    const localPeers = new Map<string, number>();
-    let unlabeledEventCount = 0;
-    for (const row of rows) {
-      const meta = parseMetaJson(row.metaJson);
-      const provider = normalizeObservedValue(meta?.provider);
-      const api = normalizeObservedValue(meta?.api);
-      const model = normalizeObservedValue(meta?.model);
-      const host = normalizeObservedValue(row.host);
-      if (!provider && !api && !model) {
-        unlabeledEventCount += 1;
-      }
-      if (provider) {
-        providers.set(provider, (providers.get(provider) ?? 0) + 1);
-      }
-      if (api) {
-        apis.set(api, (apis.get(api) ?? 0) + 1);
-      }
-      if (model) {
-        models.set(model, (models.get(model) ?? 0) + 1);
-      }
-      if (host) {
-        hosts.set(host, (hosts.get(host) ?? 0) + 1);
-        // Local model/provider endpoints are useful to surface separately when
-        // debugging why cloud-provider labels are absent.
-        if (host.startsWith("127.0.0.1:") || host.startsWith("localhost:")) {
-          localPeers.set(host, (localPeers.get(host) ?? 0) + 1);
-        }
-      }
-    }
-    return {
-      sessionId,
-      totalEvents: rows.length,
-      unlabeledEventCount,
-      providers: sortObservedCounts(providers),
-      apis: sortObservedCounts(apis),
-      models: sortObservedCounts(models),
-      hosts: sortObservedCounts(hosts),
-      localPeers: sortObservedCounts(localPeers),
-    };
+    return summarizeDebugProxyCaptureSessionCoverage(this.db, sessionId);
   }
 
   readBlob(blobId: string): string | null {


### PR DESCRIPTION
## What Problem This Solves

Capture coverage retained every matching event's metadata in a JavaScript array before computing its counts. Large sessions could therefore keep substantial optional metadata alive even though the report only needs label counts.

## Why This Change Was Made

The existing typed read owner now owns the coverage query and fold, and the public store delegates to it. Kysely compiles the same two-column query; a call-local native iterator processes one row at a time. Native execution deliberately retains the shipped corruption and connection-ownership behavior instead of introducing shared-cache eviction through a different executor.

## User Impact

The QA capture coverage endpoint returns the same provider, API, model, host and local-peer counts while avoiding the complete event-row array. Both shared-state and path-based SDK constructors remain supported. Counts still scan the session and retain maps proportional to distinct labels; this is not a constant-memory or constant-time claim.

## Evidence

- Before/after native probes exercise both constructors with 4,108 selected events containing 67,408,085 bytes of metadata. Before, `all()` retains the complete row array. After, there are zero `all()` calls and 4,108 rows step through the native iterator, with exact baseline summaries and unchanged stored rows/schema/version.
- Both constructor regressions fail before the change on eager materialization and pass afterward. The complete store and read-only suites pass (27 tests), including existing historical-schema and lease behavior.
- Native step failure returns the iterator exactly once, preserves the original error, and permits an exact retry. Deliberate SQLite corruption returns the same native error and leaves connection ownership unchanged for both constructors.
- The real QA HTTP server and SDK store pass `GET /api/capture/coverage`: exact report, empty session, missing parameter, denied read then successful retry, lease release and fresh database reopen. Only synthetic local state and loopback HTTP are used.

No schema, configuration, SDK signature, metadata representation, retention or recovery changes. The assertion baseline only shrinks for the removed raw row cast and relocated, documented parser assertion. Full changed-code and Kysely guard results are in the handoff manifest.

Production: **+104/−73 (net +31)**, after moving the parser/fold; this buys typed query compilation, delegation to the existing read owner, and native iterator cleanup preserving the existing error boundary. Tests: **+100/−1 (net +99)**. No new generic helper or policy flag.

Independent Codex P0–P2 review completed seven scoped passes with no actionable findings. Full owners, callers, native Node iterator source, pinned Kysely compiler/parser source, and baseline/candidate native receipts were supplied; the review service itself did not execute project code.
