### PR TITLE
fix(auto-reply): fold trailing transcript growth into memory-flush fresh totals

### DIFF
--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -342,6 +342,10 @@ The selected memory provider owns the reserve and flush margin; without a flush
 plan, maintenance still uses the effective compaction reserve. Nonpositive
 thresholds suppress token triggers. Transcript byte guards remain independent.
 
+When memory flush refreshes stale usage, it includes projected messages appended
+after the latest valid provider usage report before saving the total as fresh.
+The following compaction check therefore accounts for that later transcript growth.
+
 Notes:
 
 - The built-in prompt and system prompt include a `NO_REPLY` hint to suppress delivery.

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2849,6 +2849,54 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not stamp a fresh total from a stale usage anchor when later transcript growth is unaccounted (issue #138871)", async () => {
+    const storePath = path.join(rootDir, "sessions.json");
+    await writeTestSessionTranscript({
+      rootDir,
+      events: [
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            content: "small answer",
+            usage: { input: 40_000, output: 2_000 },
+          },
+        },
+        {
+          type: "message",
+          message: {
+            role: "user",
+            content: `large follow-up ${"x".repeat(450_000)}`,
+          },
+        },
+      ],
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+      compactionCount: 0,
+      // Already flushed for the current compaction cycle so the large corrected
+      // total below cannot also trigger an actual flush attempt in this call.
+      memoryFlush: { kind: "succeeded", compactionCount: 0 },
+    };
+    await writeTestSessionStore(storePath, "main", sessionEntry);
+
+    const flushResult = await runDefaultMemoryFlush(sessionEntry, { storePath });
+
+    expect(flushResult.outcome).toBe("skipped");
+    const persistedAfterFlush = loadMainSessionEntry(storePath);
+    expect(persistedAfterFlush.totalTokensFresh).toBe(true);
+    // The bare usage anchor alone is 40,000 prompt tokens; the 450,000-character
+    // follow-up appended after it must be folded in before the total is trusted
+    // as fresh, or a later compaction check will skip re-reading the transcript.
+    expect(persistedAfterFlush.totalTokens).toBeGreaterThan(80_000);
+
+    await runDefaultPreflight(persistedAfterFlush, { storePath });
+
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalled();
+  });
+
   it("fails when required preflight compaction returns an unknown successful no-op", async () => {
     compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
       ok: true,

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2849,7 +2849,7 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not stamp a fresh total from a stale usage anchor when later transcript growth is unaccounted (issue #138871)", async () => {
+  it("includes appended transcript growth before persisting fresh usage", async () => {
     const storePath = path.join(rootDir, "sessions.json");
     await writeTestSessionTranscript({
       rootDir,
@@ -2876,8 +2876,7 @@ describe("runMemoryFlushIfNeeded", () => {
       updatedAt: Date.now(),
       totalTokensFresh: false,
       compactionCount: 0,
-      // Already flushed for the current compaction cycle so the large corrected
-      // total below cannot also trigger an actual flush attempt in this call.
+      // A prior flush prevents a new model usage report from hiding the stale anchor.
       memoryFlush: { kind: "succeeded", compactionCount: 0 },
     };
     await writeTestSessionStore(storePath, "main", sessionEntry);
@@ -2887,9 +2886,6 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(flushResult.outcome).toBe("skipped");
     const persistedAfterFlush = loadMainSessionEntry(storePath);
     expect(persistedAfterFlush.totalTokensFresh).toBe(true);
-    // The bare usage anchor alone is 40,000 prompt tokens; the 450,000-character
-    // follow-up appended after it must be folded in before the total is trusted
-    // as fresh, or a later compaction check will skip re-reading the transcript.
     expect(persistedAfterFlush.totalTokens).toBeGreaterThan(80_000);
 
     await runDefaultPreflight(persistedAfterFlush, { storePath });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1297,12 +1297,26 @@ export async function runMemoryFlushIfNeeded(params: {
     typeof transcriptByteSize === "number" && transcriptByteSize >= forceFlushTranscriptBytes;
 
   const transcriptUsageSnapshot = sessionLogSnapshot?.usage;
-  const transcriptPromptTokens = transcriptUsageSnapshot?.promptTokens;
+  const transcriptPromptTokensAnchor = transcriptUsageSnapshot?.promptTokens;
   const transcriptOutputTokens = transcriptUsageSnapshot?.outputTokens;
-  const hasReliableTranscriptPromptTokens =
-    typeof transcriptPromptTokens === "number" &&
-    Number.isFinite(transcriptPromptTokens) &&
-    transcriptPromptTokens > 0;
+  const hasReliableTranscriptPromptTokensAnchor =
+    typeof transcriptPromptTokensAnchor === "number" &&
+    Number.isFinite(transcriptPromptTokensAnchor) &&
+    transcriptPromptTokensAnchor > 0;
+  // The anchor is the last provider-reported prompt total; messages appended after it
+  // (trailingMessages) are real, unaccounted growth. Fold their projected size in before
+  // trusting this as the "fresh" total downstream compaction checks skip re-deriving.
+  const transcriptTrailingProjectedTokens = hasReliableTranscriptPromptTokensAnchor
+    ? await estimateProviderPromptTokensFromMessages(
+        transcriptUsageSnapshot?.trailingMessages ?? [],
+        contextWindowTokens,
+      )
+    : undefined;
+  const transcriptPromptTokens =
+    hasReliableTranscriptPromptTokensAnchor && transcriptTrailingProjectedTokens !== undefined
+      ? transcriptPromptTokensAnchor + transcriptTrailingProjectedTokens
+      : undefined;
+  const hasReliableTranscriptPromptTokens = typeof transcriptPromptTokens === "number";
   const shouldPersistTranscriptPromptTokens =
     hasReliableTranscriptPromptTokens &&
     (!hasFreshPersistedPromptTokens ||

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -577,6 +577,22 @@ async function estimateProviderPromptTokensFromMessages(
   return Number.isFinite(tokens) && tokens >= 0 ? Math.ceil(tokens) : undefined;
 }
 
+// Shared by preflight compaction and memory flush so a stale usage anchor never gets
+// stamped as the "fresh" total without folding in the trailing messages appended after it.
+async function resolveAnchoredPromptTokens(
+  usage: SessionTranscriptUsageSnapshot | undefined,
+  contextWindowTokens: number,
+): Promise<number | undefined> {
+  if (!hasUsableProviderPromptUsage(usage)) {
+    return undefined;
+  }
+  const trailingTokens = await estimateProviderPromptTokensFromMessages(
+    usage.trailingMessages,
+    contextWindowTokens,
+  );
+  return trailingTokens === undefined ? undefined : Math.ceil(usage.promptTokens) + trailingTokens;
+}
+
 async function estimatePromptTokensFromSessionTranscript(params: {
   agentId?: string;
   sessionId?: string;
@@ -620,18 +636,16 @@ async function estimatePromptTokensFromSessionTranscript(params: {
         ? Math.ceil(usage.outputTokens)
         : undefined;
     if (hasUsableProviderPromptUsage(usage)) {
-      const trailingMessages = usage.trailingMessages;
-      const trailingTokens = await estimateProviderPromptTokensFromMessages(
-        trailingMessages,
-        params.contextWindowTokens,
-      );
-      if (trailingTokens === undefined) {
+      const promptTokens = await resolveAnchoredPromptTokens(usage, params.contextWindowTokens);
+      if (promptTokens === undefined) {
         return undefined;
       }
       return {
-        promptTokens: Math.ceil(usage.promptTokens) + trailingTokens,
+        promptTokens,
         promptTokenSource:
-          trailingMessages.length > 0 ? "provider_usage_plus_prompt_projection" : "provider_usage",
+          usage.trailingMessages.length > 0
+            ? "provider_usage_plus_prompt_projection"
+            : "provider_usage",
         outputTokens: normalizedOutputTokens,
         transcriptByteSize: snapshot.byteSize,
       };
@@ -1297,25 +1311,11 @@ export async function runMemoryFlushIfNeeded(params: {
     typeof transcriptByteSize === "number" && transcriptByteSize >= forceFlushTranscriptBytes;
 
   const transcriptUsageSnapshot = sessionLogSnapshot?.usage;
-  const transcriptPromptTokensAnchor = transcriptUsageSnapshot?.promptTokens;
   const transcriptOutputTokens = transcriptUsageSnapshot?.outputTokens;
-  const hasReliableTranscriptPromptTokensAnchor =
-    typeof transcriptPromptTokensAnchor === "number" &&
-    Number.isFinite(transcriptPromptTokensAnchor) &&
-    transcriptPromptTokensAnchor > 0;
-  // The anchor is the last provider-reported prompt total; messages appended after it
-  // (trailingMessages) are real, unaccounted growth. Fold their projected size in before
-  // trusting this as the "fresh" total downstream compaction checks skip re-deriving.
-  const transcriptTrailingProjectedTokens = hasReliableTranscriptPromptTokensAnchor
-    ? await estimateProviderPromptTokensFromMessages(
-        transcriptUsageSnapshot?.trailingMessages ?? [],
-        contextWindowTokens,
-      )
-    : undefined;
-  const transcriptPromptTokens =
-    hasReliableTranscriptPromptTokensAnchor && transcriptTrailingProjectedTokens !== undefined
-      ? transcriptPromptTokensAnchor + transcriptTrailingProjectedTokens
-      : undefined;
+  const transcriptPromptTokens = await resolveAnchoredPromptTokens(
+    transcriptUsageSnapshot,
+    contextWindowTokens,
+  );
   const hasReliableTranscriptPromptTokens = typeof transcriptPromptTokens === "number";
   const shouldPersistTranscriptPromptTokens =
     hasReliableTranscriptPromptTokens &&

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -556,12 +556,14 @@ type TranscriptTokenEstimate = {
   transcriptByteSize?: number;
 };
 
-async function estimateProviderPromptTokensFromMessages(
+// Fresh totals include the provider usage anchor and any later projected messages.
+async function estimateProviderPromptTokens(
   messages: AgentMessage[],
   contextWindowTokens: number,
+  priorPromptTokens = 0,
 ): Promise<number | undefined> {
   if (messages.length === 0) {
-    return 0;
+    return Math.ceil(priorPromptTokens);
   }
   const { truncateOversizedToolResultsInMessages } = await toolResultTruncationRuntimeLoader.load();
   // Match first-dispatch trailing-result protection without freezing replacements
@@ -574,23 +576,9 @@ async function estimateProviderPromptTokensFromMessages(
     createToolResultPromptProjectionState(),
   ).messages;
   const tokens = estimateMessagesTokens(projected);
-  return Number.isFinite(tokens) && tokens >= 0 ? Math.ceil(tokens) : undefined;
-}
-
-// Shared by preflight compaction and memory flush so a stale usage anchor never gets
-// stamped as the "fresh" total without folding in the trailing messages appended after it.
-async function resolveAnchoredPromptTokens(
-  usage: SessionTranscriptUsageSnapshot | undefined,
-  contextWindowTokens: number,
-): Promise<number | undefined> {
-  if (!hasUsableProviderPromptUsage(usage)) {
-    return undefined;
-  }
-  const trailingTokens = await estimateProviderPromptTokensFromMessages(
-    usage.trailingMessages,
-    contextWindowTokens,
-  );
-  return trailingTokens === undefined ? undefined : Math.ceil(usage.promptTokens) + trailingTokens;
+  return Number.isFinite(tokens) && tokens >= 0
+    ? Math.ceil(priorPromptTokens) + Math.ceil(tokens)
+    : undefined;
 }
 
 async function estimatePromptTokensFromSessionTranscript(params: {
@@ -636,7 +624,11 @@ async function estimatePromptTokensFromSessionTranscript(params: {
         ? Math.ceil(usage.outputTokens)
         : undefined;
     if (hasUsableProviderPromptUsage(usage)) {
-      const promptTokens = await resolveAnchoredPromptTokens(usage, params.contextWindowTokens);
+      const promptTokens = await estimateProviderPromptTokens(
+        usage.trailingMessages,
+        params.contextWindowTokens,
+        usage.promptTokens,
+      );
       if (promptTokens === undefined) {
         return undefined;
       }
@@ -662,7 +654,7 @@ async function estimatePromptTokensFromSessionTranscript(params: {
         reason: "preflight-compaction-estimate",
       },
     )) as AgentMessage[];
-    const estimatedTokens = await estimateProviderPromptTokensFromMessages(
+    const estimatedTokens = await estimateProviderPromptTokens(
       messages,
       params.contextWindowTokens,
     );
@@ -1252,14 +1244,8 @@ export async function runMemoryFlushIfNeeded(params: {
   const promptTokenEstimate = estimatePromptTokensForMemoryFlush(
     params.promptForEstimate ?? params.followupRun.prompt,
   );
-  const persistedPromptTokensRaw = entry?.totalTokens;
-  const persistedPromptTokens =
-    typeof persistedPromptTokensRaw === "number" &&
-    Number.isFinite(persistedPromptTokensRaw) &&
-    persistedPromptTokensRaw > 0
-      ? persistedPromptTokensRaw
-      : undefined;
-  const hasFreshPersistedPromptTokens = resolveFreshSessionTotalTokens(entry) !== undefined;
+  const persistedPromptTokens = resolveFreshSessionTotalTokens(entry);
+  const hasFreshPersistedPromptTokens = persistedPromptTokens !== undefined;
 
   // The soft margin belongs only to early flushing, leaving room before blocking compaction.
   const flushThreshold = Math.max(
@@ -1312,10 +1298,13 @@ export async function runMemoryFlushIfNeeded(params: {
 
   const transcriptUsageSnapshot = sessionLogSnapshot?.usage;
   const transcriptOutputTokens = transcriptUsageSnapshot?.outputTokens;
-  const transcriptPromptTokens = await resolveAnchoredPromptTokens(
-    transcriptUsageSnapshot,
-    contextWindowTokens,
-  );
+  const transcriptPromptTokens = hasUsableProviderPromptUsage(transcriptUsageSnapshot)
+    ? await estimateProviderPromptTokens(
+        transcriptUsageSnapshot.trailingMessages,
+        contextWindowTokens,
+        transcriptUsageSnapshot.promptTokens,
+      )
+    : undefined;
   const hasReliableTranscriptPromptTokens = typeof transcriptPromptTokens === "number";
   const shouldPersistTranscriptPromptTokens =
     hasReliableTranscriptPromptTokens &&
@@ -1366,17 +1355,14 @@ export async function runMemoryFlushIfNeeded(params: {
     hasFreshPersistedPromptTokens ? (persistedPromptTokens ?? 0) : 0,
     hasReliableTranscriptPromptTokens ? (transcriptPromptTokens ?? 0) : 0,
   );
-  const hasFreshPromptTokensSnapshot =
-    promptTokensSnapshot > 0 &&
-    (hasFreshPersistedPromptTokens || hasReliableTranscriptPromptTokens);
-
-  const projectedTokenCount = hasFreshPromptTokensSnapshot
-    ? resolveEffectivePromptTokens(
-        promptTokensSnapshot,
-        transcriptOutputTokens,
-        promptTokenEstimate,
-      )
-    : undefined;
+  const projectedTokenCount =
+    promptTokensSnapshot > 0
+      ? resolveEffectivePromptTokens(
+          promptTokensSnapshot,
+          transcriptOutputTokens,
+          promptTokenEstimate,
+        )
+      : undefined;
   const tokenCountForFlush =
     typeof projectedTokenCount === "number" &&
     Number.isFinite(projectedTokenCount) &&


### PR DESCRIPTION
## What Problem This Solves

Related: #138871.

When conversation messages arrived after the latest provider usage report, memory maintenance could save that older report as a fresh context total. The following compaction check trusted the undercount and let an oversized conversation continue without compacting.

## Why This Change Was Made

Both maintenance paths now use the existing provider-visible projection to combine a validated usage report with later messages before saving fresh usage. The same owner projects oversized tool results, keeps output accounting separate, and estimates full history when no usable report exists. Canonical freshness validation replaces duplicated raw-token checks and a redundant freshness condition.

## User Impact

Sessions account for later transcript growth when deciding whether to compact. Existing fresh totals, no-tail reports, runtime ownership, and compaction thresholds retain their behavior. This fixes the demonstrated stale-accounting path; the linked issue's broader provider-outage and status-display observations are not independently claimed resolved.

## Evidence

Reviewed head: `6e35e84125650ffcd49f41fdaa92d0a6c42b393f`. Production **+34/-34, net 0**; regression tests **+44/-0**; reference documentation **+4/-0**.

[Real Gateway comparison](https://github.com/steipete/openclaw/actions/runs/34014354186) runs the same realistic history against baseline and candidate: a 40,000-token report followed by 450,000 characters of readable conversation. The baseline persisted 40,000 as fresh and committed no compaction. Before releasing the first provider response, the candidate had persisted **152,570** and requested summarization. It then committed **one transcript compaction boundary**, recorded **compactionCount 1**, and delivered the reply. A subsequent turn consumed the committed summary and delivered its reply without repeating or losing compaction.

The no-tail, stale-high, old-version, fresh-zero, and fresh-low controls completed unchanged on both sides. The proof uses a built isolated Gateway, real compaction and SQLite transcript persistence, and a deterministic loopback HTTP provider; it does not claim authenticated external-provider coverage. Its source is pinned main `342b7fc95009cca85425a38ccbd360b859ac0f0e` plus this exact reviewed production/test patch, with emitted source hashes checked.

[Focused regression and sibling suites](https://github.com/steipete/openclaw/actions/runs/33997138504) established the intended baseline failure and **123 passing candidate tests**. That run's initial real-flow fixture failed; diagnostics traced it to an oversized single-token ask that a valid bounded summary could not preserve. The quality guard remained intact. The successful comparison above uses a faithful summary of realistic history on both sides, with unchanged production code and deadlines.

[Required CI](https://github.com/openclaw/openclaw/actions/runs/33995512684/job/101386380362) passed on the reviewed head. Pinned formatting and `git diff --check` passed; fresh isolated Codex review through P2 found no actionable findings.

The original contributor commits remain ancestors of this head, with human credit preserved. This change adds no configuration or storage schema and leaves native runtime compaction ownership unchanged.
