### PR TITLE
fix(agents): preserve yield status after tool errors

### DIFF
--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -243,6 +243,8 @@ export async function prepareReplyAgentPayloads(state: {
   // Share this state across deliverable lanes so replyToMode=first still threads
   // at most one visible payload without hidden reasoning/commentary consuming it.
   const applyDeliveredReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
+  const isGeneratedToolWarning = (payload: ReplyPayload) =>
+    getReplyPayloadMetadata(payload)?.toolErrorWarning !== undefined;
   const applyFinalReplyToMode = (payload: ReplyPayload) => {
     const isDisabledReasoningLane =
       payload.isReasoning === true && opts?.reasoningPayloadsEnabled !== true;
@@ -250,7 +252,11 @@ export async function prepareReplyAgentPayloads(state: {
       payload.isCommentary === true && opts?.commentaryPayloadsEnabled !== true;
     const isFilteredPayload =
       normalizeReplyPayload(payload, { applyChannelTransforms: false }) === null;
-    return isDisabledReasoningLane || isDisabledCommentaryLane || isFilteredPayload
+    const shouldDeferToolWarning = yieldAcknowledgmentPayload && isGeneratedToolWarning(payload);
+    return isDisabledReasoningLane ||
+      isDisabledCommentaryLane ||
+      isFilteredPayload ||
+      shouldDeferToolWarning
       ? payload
       : applyDeliveredReplyToMode(payload);
   };
@@ -418,18 +424,29 @@ export async function prepareReplyAgentPayloads(state: {
   const payloadResult = await buildFinalPayloads(payloadCandidates);
   let { replyPayloads } = payloadResult;
   didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
-  const hasTerminalReplyPayload = replyPayloads.some(
+  const replyPayloadsWithoutToolWarnings = yieldAcknowledgmentPayload
+    ? replyPayloads.filter((payload) => !isGeneratedToolWarning(payload))
+    : replyPayloads;
+  const hasTerminalReplyPayload = replyPayloadsWithoutToolWarnings.some(
     (payload) =>
       isReplyPayloadTerminalContent(payload) &&
       normalizeReplyPayload(payload, { applyChannelTransforms: false }) !== null,
   );
+  if (yieldAcknowledgmentPayload && hasTerminalReplyPayload) {
+    replyPayloads = replyPayloadsWithoutToolWarnings;
+  }
   if (shouldDeliverTerminalFailure && !hasTerminalReplyPayload && terminalFailurePayload) {
     const terminalPayloadResult = await buildFinalPayloads([terminalFailurePayload]);
     replyPayloads = [...replyPayloads, ...terminalPayloadResult.replyPayloads];
     didLogHeartbeatStrip = terminalPayloadResult.didLogHeartbeatStrip;
   } else if (yieldAcknowledgmentPayload && !hasTerminalReplyPayload) {
     const acknowledgmentResult = await buildFinalPayloads([yieldAcknowledgmentPayload]);
-    replyPayloads = [...replyPayloads, ...acknowledgmentResult.replyPayloads];
+    replyPayloads =
+      acknowledgmentResult.replyPayloads.length > 0
+        ? [...replyPayloadsWithoutToolWarnings, ...acknowledgmentResult.replyPayloads]
+        : replyPayloads.map((payload) =>
+            isGeneratedToolWarning(payload) ? applyFinalReplyToMode(payload) : payload,
+          );
     didLogHeartbeatStrip = acknowledgmentResult.didLogHeartbeatStrip;
   } else if (hasSpecificFallbackFailure && !hasTerminalReplyPayload) {
     const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -4427,6 +4427,70 @@ describe("runReplyAgent typing (heartbeat)", () => {
     expect(onPendingContinuation).toHaveBeenCalledOnce();
   });
 
+  it("prefers a yield acknowledgment over an earlier generated tool warning", async () => {
+    const toolWarning = setReplyPayloadMetadata(
+      { text: "⚠️ Bash failed", isError: true },
+      { toolErrorWarning: { toolName: "bash" } },
+    );
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [toolWarning],
+      meta: {
+        yielded: true,
+        yieldAcknowledgment: "Research started; results will follow.",
+      },
+      acceptedSessionSpawns: [{ runId: "child", childSessionKey: "agent:main:child" }],
+    });
+    const { run } = createMinimalRun();
+
+    await expect(run()).resolves.toMatchObject({
+      text: "Research started; results will follow.",
+      replyToId: "msg",
+    });
+  });
+
+  it("keeps a generated tool warning when the yield acknowledgment is not deliverable", async () => {
+    const toolWarning = setReplyPayloadMetadata(
+      { text: "⚠️ Bash failed", isError: true },
+      { toolErrorWarning: { toolName: "bash" } },
+    );
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [toolWarning],
+      meta: {
+        yielded: true,
+        yieldAcknowledgment: "Research started; results will follow.",
+      },
+    });
+    const { run } = createMinimalRun({ currentInboundEventKind: "room_event" });
+
+    await expect(run()).resolves.toMatchObject({
+      text: "⚠️ Bash failed",
+      isError: true,
+      replyToId: "msg",
+    });
+  });
+
+  it("keeps a generated tool warning when the yield acknowledgment normalizes to empty", async () => {
+    const toolWarning = setReplyPayloadMetadata(
+      { text: "⚠️ Bash failed", isError: true },
+      { toolErrorWarning: { toolName: "bash" } },
+    );
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [toolWarning],
+      meta: {
+        yielded: true,
+        yieldAcknowledgment: "[[reply_to_current]]",
+      },
+      acceptedSessionSpawns: [{ runId: "child", childSessionKey: "agent:main:child" }],
+    });
+    const { run } = createMinimalRun();
+
+    await expect(run()).resolves.toMatchObject({
+      text: "⚠️ Bash failed",
+      isError: true,
+      replyToId: "msg",
+    });
+  });
+
   it("delivers an explicit yield acknowledgment in message-tool-only mode", async () => {
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [],
@@ -5836,6 +5900,6 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 });
 
-import { getReplyPayloadMetadata } from "../reply-payload.js";
+import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

When a turn generated a tool-error fallback before a successful `sessions_yield`, the earlier warning could replace the yield acknowledgment. Users saw a stale shell failure instead of the current waiting status.

## Why This Change Was Made

`runReplyAgent` now defers metadata-tagged generated tool warnings while the existing payload pipeline prepares a yield acknowledgment. It removes the warning only when that replacement remains renderable, and preserves genuine warnings when the acknowledgment is ineligible or normalizes to empty.

## User Impact

Paused work now shows its `sessions_yield` acknowledgment even when an earlier command failed. Silent turns without a deliverable acknowledgment still report legitimate command failures.

## Evidence

- Red on current `main`: the synthetic combined regression expected the yield acknowledgment but received `⚠️ Bash failed`.
- Focused post-fix selection tests pass for all three branches: acknowledgment wins when renderable; the warning remains when the acknowledgment is ineligible or directive-only.
- The pre-finding full owner suite passed 174/174. A post-fix clean run reached 174 passes and one unrelated active-steering timeout while attempting an unavailable Discord route; that test does not execute the changed selection branch.
- `node scripts/check-changed.mjs` passes from a clean checkout, including formatting, typechecks, lint, dead-code scans, and policy guards.
- ClawSweeper's P2 empty-normalization finding is resolved on head `c61460cb650defd76451ecdbbab3f93a21cca716`.
- Direct inspection of upstream Codex at `ddf04ad26789d040f9ef6a96736f76602e35a6cc` confirms command exit status and dynamic-tool success are present at the protocol boundary; reply selection belongs to OpenClaw.
