### PR TITLE
refactor(claws): author provenance writes with Kysely

### DIFF
--- a/src/claws/package-update-provenance.ts
+++ b/src/claws/package-update-provenance.ts
@@ -1,6 +1,12 @@
 import { createHash } from "node:crypto";
 import { stableStringify } from "@openclaw/normalization-core";
 import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import type { DB } from "../state/openclaw-state-db.generated.js";
+import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
@@ -40,61 +46,57 @@ export function replaceClawPackageRefExpected(
     throw new Error("Package reference replacement requires an identity.");
   }
   runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getNodeSqliteKysely<Pick<DB, "claw_package_refs">>(db);
     if (expected) {
-      const result = db /* sqlite-allow-raw: Claw package provenance compare-and-swap delete. */
-        .prepare(
-          `DELETE FROM claw_package_refs
-            WHERE agent_id = @agent_id
-              AND package_kind = @package_kind
-              AND package_source = @package_source
-              AND package_ref = @package_ref
-              AND package_version = @package_version
-              AND package_integrity = @package_integrity
-              AND schema_version = @schema_version
-              AND claw_name = @claw_name
-              AND package_status = @package_status
-              AND relationship = @relationship
-              AND origin = @origin
-              AND independent_owner = @independent_owner
-              AND extension_id IS @extension_id
-              AND extension_format IS @extension_format
-              AND extension_detected_format IS @extension_detected_format
-              AND extension_mapped_json IS @extension_mapped_json
-              AND extension_unavailable_json IS @extension_unavailable_json
-              AND extension_adapter_identity IS @extension_adapter_identity
-              AND installed_at_ms = @installed_at_ms
-              AND updated_at_ms = @updated_at_ms`,
-        )
-        .run({
-          agent_id: expected.agentId,
-          package_kind: expected.kind,
-          package_source: expected.source,
-          package_ref: expected.ref,
-          package_version: expected.version,
-          package_integrity: expected.integrity,
-          schema_version: expected.schemaVersion,
-          claw_name: expected.clawName,
-          package_status: expected.status,
-          relationship: expected.relationship,
-          origin: expected.origin,
-          independent_owner: expected.independentOwner ? 1 : 0,
-          ...toPackageRefExtensionSqlParams(expected.extension),
-          installed_at_ms: expected.installedAtMs,
-          updated_at_ms: expected.updatedAtMs,
-        });
-      if (Number(result.changes) !== 1) {
+      const extension = toPackageRefExtensionSqlParams(expected.extension);
+      // Nullable extension fields participate in the same full-row compare-and-swap.
+      const result = executeSqliteQuerySync(
+        db,
+        kysely
+          .deleteFrom("claw_package_refs")
+          .where((eb) =>
+            eb.and({
+              agent_id: expected.agentId,
+              package_kind: expected.kind,
+              package_source: expected.source,
+              package_ref: expected.ref,
+              package_version: expected.version,
+              package_integrity: expected.integrity,
+              schema_version: expected.schemaVersion,
+              claw_name: expected.clawName,
+              package_status: expected.status,
+              relationship: expected.relationship,
+              origin: expected.origin,
+              independent_owner: expected.independentOwner ? 1 : 0,
+              installed_at_ms: expected.installedAtMs,
+              updated_at_ms: expected.updatedAtMs,
+            }),
+          )
+          .where("extension_id", "is", extension.extension_id)
+          .where("extension_format", "is", extension.extension_format)
+          .where("extension_detected_format", "is", extension.extension_detected_format)
+          .where("extension_mapped_json", "is", extension.extension_mapped_json)
+          .where("extension_unavailable_json", "is", extension.extension_unavailable_json)
+          .where("extension_adapter_identity", "is", extension.extension_adapter_identity),
+      );
+      if (result.numAffectedRows !== 1n) {
         throw new Error(
           `Package reference ${JSON.stringify(`${expected.kind}:${expected.ref}`)} changed after planning.`,
         );
       }
     } else {
-      const occupied =
-        db /* sqlite-allow-raw: Claw package provenance compare-and-swap occupancy check. */
-          .prepare(
-            `SELECT 1 FROM claw_package_refs
-            WHERE agent_id = ? AND package_kind = ? AND package_source = ? AND package_ref = ?`,
-          )
-          .get(identity.agentId, identity.kind, identity.source, identity.ref);
+      // Any version occupies this dependency edge; only one row is needed to reject it.
+      const occupied = executeSqliteQueryTakeFirstSync(
+        db,
+        kysely
+          .selectFrom("claw_package_refs")
+          .select((eb) => eb.val(1).as("occupied"))
+          .where("agent_id", "=", identity.agentId)
+          .where("package_kind", "=", identity.kind)
+          .where("package_source", "=", identity.source)
+          .where("package_ref", "=", identity.ref)
+          .limit(1),
+      );
       if (occupied) {
         throw new Error(
           `Package reference ${JSON.stringify(`${identity.kind}:${identity.ref}`)} appeared after planning.`,
@@ -102,23 +104,9 @@ export function replaceClawPackageRefExpected(
       }
     }
     if (replacement) {
-      db /* sqlite-allow-raw: Claw package provenance compare-and-swap insert. */
-        .prepare(
-          `INSERT INTO claw_package_refs (
-           agent_id, package_kind, package_source, package_ref, package_version, package_integrity,
-           schema_version, claw_name, package_status, relationship, origin, independent_owner,
-           extension_id, extension_format, extension_detected_format, extension_mapped_json,
-           extension_unavailable_json, extension_adapter_identity,
-           installed_at_ms, updated_at_ms
-         ) VALUES (
-           @agent_id, @package_kind, @package_source, @package_ref, @package_version, @package_integrity,
-           @schema_version, @claw_name, @package_status, @relationship, @origin,
-           @independent_owner, @extension_id, @extension_format, @extension_detected_format,
-           @extension_mapped_json, @extension_unavailable_json, @extension_adapter_identity,
-           @installed_at_ms, @updated_at_ms
-         )`,
-        )
-        .run({
+      executeSqliteQuerySync(
+        db,
+        kysely.insertInto("claw_package_refs").values({
           agent_id: replacement.agentId,
           package_kind: replacement.kind,
           package_source: replacement.source,
@@ -134,7 +122,8 @@ export function replaceClawPackageRefExpected(
           ...toPackageRefExtensionSqlParams(replacement.extension),
           installed_at_ms: replacement.installedAtMs,
           updated_at_ms: replacement.updatedAtMs,
-        });
+        }),
+      );
     }
   }, options);
 }

--- a/src/claws/provenance.ts
+++ b/src/claws/provenance.ts
@@ -2,7 +2,9 @@
 
 import type { DatabaseSync } from "node:sqlite";
 import { stableStringify } from "@openclaw/normalization-core";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
+import type { DB } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -34,6 +36,8 @@ export {
   CLAW_PACKAGE_REF_SCHEMA_VERSION,
   type PersistedClawPackageRef,
 } from "./package-extension-provenance.js";
+
+type ClawProvenanceDatabase = Pick<DB, "claw_installs" | "claw_package_refs">;
 
 export type ClawInstallStatus =
   | "pending"
@@ -219,43 +223,33 @@ export function persistClawInstallRecord(
         `Claw install record for agent ${JSON.stringify(plan.agent.finalId)} already exists.`,
       );
     }
-    // sqlite-allow-raw: this Claw prototype state-table write is scoped to one owned row.
-    db.prepare(
-      `INSERT INTO claw_installs (
-         agent_id, schema_version, source_kind, claw_name, claw_version,
-         package_root, manifest_path, integrity_kind, integrity, source_byte_length,
-         manifest_schema_version, plan_integrity, workspace, agent_config_digest,
-         agent_owned_paths_json, bootstrap_source_path, bootstrap_content_digest,
-         status, added_at_ms, updated_at_ms
-       ) VALUES (
-         @agent_id, @schema_version, @source_kind, @claw_name, @claw_version,
-         @package_root, @manifest_path, @integrity_kind, @integrity, @source_byte_length,
-         @manifest_schema_version, @plan_integrity, @workspace, @agent_config_digest,
-         @agent_owned_paths_json, @bootstrap_source_path, @bootstrap_content_digest,
-         @status, @added_at_ms, @updated_at_ms
-       )`,
-    ).run({
-      agent_id: plan.agent.finalId,
-      schema_version: installRecordSchema.CLAW_INSTALL_RECORD_SCHEMA_VERSION,
-      source_kind: plan.claw.kind,
-      claw_name: plan.claw.name,
-      claw_version: plan.claw.version,
-      package_root: plan.claw.packageRoot,
-      manifest_path: plan.claw.manifestPath,
-      integrity_kind: plan.claw.integrityKind,
-      integrity: plan.claw.integrity,
-      source_byte_length: plan.claw.byteLength,
-      manifest_schema_version: plan.manifestSchemaVersion,
-      plan_integrity: plan.planIntegrity,
-      workspace: plan.agent.workspace,
-      agent_config_digest: agentConfigDigest,
-      agent_owned_paths_json: JSON.stringify(ownedPaths),
-      bootstrap_source_path: bootstrap?.sourcePath ?? null,
-      bootstrap_content_digest: bootstrap?.contentDigest ?? null,
-      status,
-      added_at_ms: nowMs,
-      updated_at_ms: nowMs,
-    });
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<ClawProvenanceDatabase>(db)
+        .insertInto("claw_installs")
+        .values({
+          agent_id: plan.agent.finalId,
+          schema_version: installRecordSchema.CLAW_INSTALL_RECORD_SCHEMA_VERSION,
+          source_kind: plan.claw.kind,
+          claw_name: plan.claw.name,
+          claw_version: plan.claw.version,
+          package_root: plan.claw.packageRoot,
+          manifest_path: plan.claw.manifestPath,
+          integrity_kind: plan.claw.integrityKind,
+          integrity: plan.claw.integrity,
+          source_byte_length: plan.claw.byteLength,
+          manifest_schema_version: plan.manifestSchemaVersion,
+          plan_integrity: plan.planIntegrity,
+          workspace: plan.agent.workspace,
+          agent_config_digest: agentConfigDigest,
+          agent_owned_paths_json: JSON.stringify(ownedPaths),
+          bootstrap_source_path: bootstrap?.sourcePath ?? null,
+          bootstrap_content_digest: bootstrap?.contentDigest ?? null,
+          status,
+          added_at_ms: nowMs,
+          updated_at_ms: nowMs,
+        }),
+    );
     return {
       schemaVersion: installRecordSchema.CLAW_INSTALL_RECORD_SCHEMA_VERSION,
       claw: plan.claw,
@@ -290,19 +284,14 @@ export function updateClawInstallRecordStatus(
 ): void {
   runOpenClawStateWriteTransaction(({ db }) => {
     const expectedStatuses = options.expectedStatuses ?? [];
-    const expectedClause =
-      expectedStatuses.length > 0
-        ? ` AND status IN (${expectedStatuses.map(() => "?").join(", ")})`
-        : "";
-    const result =
-      db /* sqlite-allow-raw: this Claw prototype state-table write is scoped to one owned row. */
-        .prepare(
-          `UPDATE claw_installs
-            SET status = ?, updated_at_ms = ?
-          WHERE agent_id = ?${expectedClause}`,
-        )
-        .run(status, options.nowMs ?? Date.now(), agentId, ...expectedStatuses);
-    if (result.changes !== 1) {
+    let query = getNodeSqliteKysely<ClawProvenanceDatabase>(db)
+      .updateTable("claw_installs")
+      .set({ status, updated_at_ms: options.nowMs ?? Date.now() })
+      .where("agent_id", "=", agentId);
+    if (expectedStatuses.length > 0) {
+      query = query.where("status", "in", expectedStatuses);
+    }
+    if (executeSqliteQuerySync(db, query).numAffectedRows !== 1n) {
       throw new Error(
         `Claw install record for agent ${JSON.stringify(agentId)} did not match the expected phase.`,
       );
@@ -316,15 +305,13 @@ export function deleteClawInstallRecord(
 ): void {
   runOpenClawStateWriteTransaction(({ db }) => {
     const expectedStatuses = options.expectedStatuses ?? [];
-    const expectedClause =
-      expectedStatuses.length > 0
-        ? ` AND status IN (${expectedStatuses.map(() => "?").join(", ")})`
-        : "";
-    const result =
-      db /* sqlite-allow-raw: this Claw prototype state-table delete is scoped to one owned row. */
-        .prepare(`DELETE FROM claw_installs WHERE agent_id = ?${expectedClause}`)
-        .run(agentId, ...expectedStatuses);
-    if (result.changes !== 1) {
+    let query = getNodeSqliteKysely<ClawProvenanceDatabase>(db)
+      .deleteFrom("claw_installs")
+      .where("agent_id", "=", agentId);
+    if (expectedStatuses.length > 0) {
+      query = query.where("status", "in", expectedStatuses);
+    }
+    if (executeSqliteQuerySync(db, query).numAffectedRows !== 1n) {
       throw new Error(
         `Claw install record for agent ${JSON.stringify(agentId)} did not match the expected phase.`,
       );
@@ -376,55 +363,35 @@ export function updateClawInstallRecord(
     .map((action) => action.target);
   const bootstrap = bootstrapProvenance(plan) ?? current.bootstrap;
   runOpenClawStateWriteTransaction(({ db }) => {
-    const result = db /* sqlite-allow-raw: Claw install provenance compare-and-swap write. */
-      .prepare(
-        `UPDATE claw_installs
-            SET schema_version = @schema_version,
-                source_kind = @source_kind,
-                claw_name = @claw_name,
-                claw_version = @claw_version,
-                package_root = @package_root,
-                manifest_path = @manifest_path,
-                integrity_kind = @integrity_kind,
-                integrity = @integrity,
-                source_byte_length = @source_byte_length,
-                manifest_schema_version = @manifest_schema_version,
-                plan_integrity = @plan_integrity,
-                workspace = @workspace,
-                agent_config_digest = @agent_config_digest,
-                agent_owned_paths_json = @agent_owned_paths_json,
-                bootstrap_source_path = @bootstrap_source_path,
-                bootstrap_content_digest = @bootstrap_content_digest,
-                status = @status,
-                updated_at_ms = @updated_at_ms
-          WHERE agent_id = @agent_id
-            AND claw_version = @expected_claw_version
-            AND integrity = @expected_integrity`,
-      )
-      .run({
-        agent_id: plan.agent.finalId,
-        schema_version: installRecordSchema.CLAW_INSTALL_RECORD_SCHEMA_VERSION,
-        source_kind: plan.claw.kind,
-        claw_name: plan.claw.name,
-        claw_version: plan.claw.version,
-        package_root: plan.claw.packageRoot,
-        manifest_path: plan.claw.manifestPath,
-        integrity_kind: plan.claw.integrityKind,
-        integrity: plan.claw.integrity,
-        source_byte_length: plan.claw.byteLength,
-        manifest_schema_version: plan.manifestSchemaVersion,
-        plan_integrity: plan.planIntegrity,
-        workspace: plan.agent.workspace,
-        agent_config_digest: agentConfigDigest,
-        agent_owned_paths_json: JSON.stringify(ownedAgentPaths),
-        bootstrap_source_path: bootstrap?.sourcePath ?? null,
-        bootstrap_content_digest: bootstrap?.contentDigest ?? null,
-        status,
-        updated_at_ms: updatedAtMs,
-        expected_claw_version: options.expectedClaw?.version ?? current.claw.version,
-        expected_integrity: options.expectedClaw?.integrity ?? current.claw.integrity,
-      });
-    if (Number(result.changes) !== 1) {
+    const result = executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<ClawProvenanceDatabase>(db)
+        .updateTable("claw_installs")
+        .set({
+          schema_version: installRecordSchema.CLAW_INSTALL_RECORD_SCHEMA_VERSION,
+          source_kind: plan.claw.kind,
+          claw_name: plan.claw.name,
+          claw_version: plan.claw.version,
+          package_root: plan.claw.packageRoot,
+          manifest_path: plan.claw.manifestPath,
+          integrity_kind: plan.claw.integrityKind,
+          integrity: plan.claw.integrity,
+          source_byte_length: plan.claw.byteLength,
+          manifest_schema_version: plan.manifestSchemaVersion,
+          plan_integrity: plan.planIntegrity,
+          workspace: plan.agent.workspace,
+          agent_config_digest: agentConfigDigest,
+          agent_owned_paths_json: JSON.stringify(ownedAgentPaths),
+          bootstrap_source_path: bootstrap?.sourcePath ?? null,
+          bootstrap_content_digest: bootstrap?.contentDigest ?? null,
+          status,
+          updated_at_ms: updatedAtMs,
+        })
+        .where("agent_id", "=", plan.agent.finalId)
+        .where("claw_version", "=", options.expectedClaw?.version ?? current.claw.version)
+        .where("integrity", "=", options.expectedClaw?.integrity ?? current.claw.integrity),
+    );
+    if (result.numAffectedRows !== 1n) {
       throw new Error(
         `Claw install record changed for agent ${JSON.stringify(plan.agent.finalId)}.`,
       );
@@ -518,30 +485,34 @@ export function persistClawPackageRef(
         independentOwner: previous.independentOwner || record.independentOwner,
         installedAtMs: previous.installedAtMs,
       };
-      db /* sqlite-allow-raw: exact owned package-ref retry update. */
-        .prepare(
-          `UPDATE claw_package_refs
-            SET schema_version = @schema_version,
-                claw_name = @claw_name,
-                package_status = @package_status,
-                relationship = @relationship,
-                origin = @origin,
-                independent_owner = @independent_owner,
-                extension_id = @extension_id,
-                extension_format = @extension_format,
-                extension_detected_format = @extension_detected_format,
-                extension_mapped_json = @extension_mapped_json,
-                extension_unavailable_json = @extension_unavailable_json,
-                extension_adapter_identity = @extension_adapter_identity,
-                updated_at_ms = @updated_at_ms
-          WHERE agent_id = @agent_id
-            AND package_kind = @package_kind
-            AND package_source = @package_source
-            AND package_ref = @package_ref
-            AND package_version = @package_version
-            AND package_integrity = @package_integrity`,
-        )
-        .run({
+      executeSqliteQuerySync(
+        db,
+        getNodeSqliteKysely<ClawProvenanceDatabase>(db)
+          .updateTable("claw_package_refs")
+          .set({
+            schema_version: record.schemaVersion,
+            claw_name: record.clawName,
+            package_status: record.status,
+            relationship: record.relationship,
+            origin: record.origin,
+            independent_owner: record.independentOwner ? 1 : 0,
+            ...toPackageRefExtensionSqlParams(record.extension),
+            updated_at_ms: record.updatedAtMs,
+          })
+          .where("agent_id", "=", record.agentId)
+          .where("package_kind", "=", record.kind)
+          .where("package_source", "=", record.source)
+          .where("package_ref", "=", record.ref)
+          .where("package_version", "=", record.version)
+          .where("package_integrity", "=", record.integrity),
+      );
+      return;
+    }
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<ClawProvenanceDatabase>(db)
+        .insertInto("claw_package_refs")
+        .values({
           agent_id: record.agentId,
           package_kind: record.kind,
           package_source: record.source,
@@ -555,46 +526,10 @@ export function persistClawPackageRef(
           origin: record.origin,
           independent_owner: record.independentOwner ? 1 : 0,
           ...toPackageRefExtensionSqlParams(record.extension),
+          installed_at_ms: record.installedAtMs,
           updated_at_ms: record.updatedAtMs,
-        });
-      return;
-    }
-    // sqlite-allow-raw: this Claw prototype state-table write is scoped to one owned row.
-    db /* sqlite-allow-raw: Claw package provenance upsert. */
-      .prepare(
-        `INSERT INTO claw_package_refs (
-         agent_id, package_kind, package_source, package_ref, package_version,
-         package_integrity, schema_version, claw_name, package_status, relationship, origin,
-         independent_owner, extension_id, extension_format, extension_detected_format,
-         extension_mapped_json, extension_unavailable_json, extension_adapter_identity,
-         installed_at_ms,
-         updated_at_ms
-       ) VALUES (
-         @agent_id, @package_kind, @package_source, @package_ref, @package_version,
-         @package_integrity, @schema_version, @claw_name, @package_status, @relationship, @origin,
-         @independent_owner, @extension_id, @extension_format, @extension_detected_format,
-         @extension_mapped_json, @extension_unavailable_json, @extension_adapter_identity,
-         @installed_at_ms,
-         @updated_at_ms
-       )`,
-      )
-      .run({
-        agent_id: record.agentId,
-        package_kind: record.kind,
-        package_source: record.source,
-        package_ref: record.ref,
-        package_version: record.version,
-        package_integrity: record.integrity,
-        schema_version: record.schemaVersion,
-        claw_name: record.clawName,
-        package_status: record.status,
-        relationship: record.relationship,
-        origin: record.origin,
-        independent_owner: record.independentOwner ? 1 : 0,
-        ...toPackageRefExtensionSqlParams(record.extension),
-        installed_at_ms: record.installedAtMs,
-        updated_at_ms: record.updatedAtMs,
-      });
+        }),
+    );
   }, options);
   return record;
 }
@@ -606,26 +541,18 @@ export function updateClawPackageRefStatus(
 ): PersistedClawPackageRef {
   const nowMs = options.nowMs ?? Date.now();
   runOpenClawStateWriteTransaction(({ db }) => {
-    // sqlite-allow-raw: this Claw package reference status update is scoped to one owned row.
-    db.prepare(
-      `UPDATE claw_package_refs
-          SET package_status = @package_status, updated_at_ms = @updated_at_ms
-        WHERE agent_id = @agent_id
-          AND package_kind = @package_kind
-          AND package_source = @package_source
-          AND package_ref = @package_ref
-          AND package_version = @package_version
-          AND package_integrity = @package_integrity`,
-    ).run({
-      agent_id: ref.agentId,
-      package_kind: ref.kind,
-      package_source: ref.source,
-      package_ref: ref.ref,
-      package_version: ref.version,
-      package_integrity: ref.integrity,
-      package_status: status,
-      updated_at_ms: nowMs,
-    });
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<ClawProvenanceDatabase>(db)
+        .updateTable("claw_package_refs")
+        .set({ package_status: status, updated_at_ms: nowMs })
+        .where("agent_id", "=", ref.agentId)
+        .where("package_kind", "=", ref.kind)
+        .where("package_source", "=", ref.source)
+        .where("package_ref", "=", ref.ref)
+        .where("package_version", "=", ref.version)
+        .where("package_integrity", "=", ref.integrity),
+    );
   }, options);
   return { ...ref, status, updatedAtMs: nowMs };
 }


### PR DESCRIPTION
## What Problem This Solves

Claw root and package provenance writers maintained raw SQL column and placeholder lists alongside their value objects. That duplicate query definition made storage contracts harder to check against the canonical schema.

## Why This Change Was Made

The seven current writers and package compare-and-swap queries now use generated-schema Kysely statements. The existing state transaction remains the write owner. Package replacement still deletes the exact expected row and inserts its replacement atomically, including nullable extension metadata and timestamps; the occupancy query remains version-independent and stops after one row. Replay integrity, relationship/origin/independent ownership, empty expected-status filters, affected-row checks, and post-commit provenance-cache publication are preserved. Legacy read projections and consent-bound schema upgrades are unchanged.


## User Impact

No intended user-visible change. Consent, replay, update and removal keep their existing persisted ownership and recovery behavior.

## Evidence

- 52 tests passed across provenance, package update, schema-version handoff, runtime provenance cache, and read-only older-column compatibility.
- Full changed gate passed, including core and test typechecks, scoped lint, database guards, and runtime import-cycle checks.
- Native SQLite baseline/candidate proof matched stored rows and all nine expected failure messages, including rejected replacement insertion rolling back and surviving physical close/reopen. Random temporary workspace-derived digest fields were compared for within-run cache consistency and excluded from cross-run equality.
- One qaRuntime build passed. Twelve normal built CLI commands exercised project creation, add preview, stale-consent rejection, consented add, status, update preview/apply, fresh-process status, remove preview/apply, and absent/empty status. Update retained addedAtMs and changed the package version and managed SOUL.md bytes; removal retained an unowned workspace artifact, removed the agent, and left zero Claw rows with integrity_check=ok. Synthetic state was removed and source hashes were unchanged.

Production delta: +174/-258, net -84 lines across two files. Tests/test support: unchanged. No schema, config, public API, retention, or recovery-policy changes; no new dependency, cache, or storage abstraction.

The initial native proof command invoked the TypeScript preload as an entry point and did no work. The corrected --import command ran the real owner baseline successfully; the candidate and CLI proof passed without product changes or proof retries. Remaining current-schema read cleanup is separate because nontransactional query-error ownership and legacy physical projections require their own contracts.

Independent Codex P0–P2 review completed three scoped passes with no actionable findings. Full owner/caller/sibling source, pinned compiler/parser/native binding contracts, and all native/CLI receipts were supplied. The acting maintainer also inspected these source contracts and both complete proof harnesses directly.
