### PR TITLE
fix: reduce memory retained after browsing archived chats

### DIFF
--- a/src/gateway/session-transcript-index.fs.test.ts
+++ b/src/gateway/session-transcript-index.fs.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+import { afterEach, expect, test, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { SessionTranscriptProjectionUnavailableError } from "../config/sessions/session-transcript-projection-error.js";
+import * as fileReads from "../infra/file-read.js";
+import { createNestedToolActivity } from "../sessions/nested-tool-activity.js";
+import { isVisibleTranscriptRecord } from "../sessions/transcript-visible-record.js";
+import {
+  readIndexedTranscriptEntries,
+  readSessionTranscriptIndex,
+  selectArchiveTranscriptEntries,
+} from "./session-transcript-index.fs.js";
+import {
+  parseTranscriptRecord,
+  type TranscriptRecord,
+} from "./session-transcript-record-parser.js";
+
+const dirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => vi.restoreAllMocks());
+
+async function fixture(bytes: string | Buffer) {
+  const file = path.join(dirs.make("archive-index-"), "session.jsonl");
+  await fs.promises.writeFile(file, bytes);
+  return file;
+}
+
+function message(id: string | undefined, text: string) {
+  return JSON.stringify({ type: "message", id, message: { role: "user", content: text } });
+}
+
+test("keeps exact physical ranges across newline dialects and malformed UTF8", async () => {
+  const file = await fixture(
+    Buffer.concat([
+      Buffer.from(` \r\n${message("first", "α🦞".repeat(18000))}\r`),
+      Buffer.from('{"type":"message","id":"invalid-utf8","message":{"role":"user","content":"'),
+      Buffer.from([0xff]),
+      Buffer.from(
+        `"}}\n{malformed\r\n${message("", "blank raw id")}\n${message(undefined, "no id")}`,
+      ),
+    ]),
+  );
+  const records: TranscriptRecord[] = [];
+  const lines = readline.createInterface({
+    input: fs.createReadStream(file, { encoding: "utf8" }),
+    crlfDelay: Infinity,
+  });
+  for await (const line of lines) {
+    const parsed = parseTranscriptRecord(line);
+    if (parsed) {
+      records.push(parsed);
+    }
+  }
+  const expected = selectArchiveTranscriptEntries(records).filter((entry) =>
+    isVisibleTranscriptRecord(entry.record),
+  );
+  const index = await readSessionTranscriptIndex(file, "test");
+  expect(index).not.toBeNull();
+  const materialized = await readIndexedTranscriptEntries(file, index!, index!.entries, "test");
+  expect(materialized.map(({ record, byteLength, id }) => ({ record, byteLength, id }))).toEqual(
+    expected.map(({ record, byteLength, id }) => ({ record, byteLength, id })),
+  );
+  expect(index!.entries.map((entry) => entry.rawId)).toEqual([
+    "first",
+    "invalid-utf8",
+    "",
+    undefined,
+  ]);
+});
+
+test("retains duplicate order, last by-ID selection and oversized image recovery", async () => {
+  const image = JSON.stringify({
+    type: "message",
+    id: "image",
+    message: {
+      role: "assistant",
+      content: [
+        { type: "text", text: "caption" },
+        { type: "image", mimeType: "image/png", data: Buffer.alloc(300000).toString("base64") },
+      ],
+    },
+  });
+  const file = await fixture(
+    [message("same", "first"), image, message("same", "last")].join("\r\n"),
+  );
+  const index = (await readSessionTranscriptIndex(file, "test"))!;
+  const records = await readIndexedTranscriptEntries(file, index, index.entries, "test");
+  expect(records.map((entry) => entry.record.message)).toMatchObject([
+    { content: "first" },
+    { content: [{ text: "caption" }, { type: "image", omitted: true, bytes: 300000 }] },
+    { content: "last" },
+  ]);
+  expect(records[1]?.recoveredImageData).toBe(true);
+  expect(records[1]!.byteLength).toBeGreaterThan(256 * 1024);
+  const last = await readIndexedTranscriptEntries(file, index, [index.byId.get("same")!], "test");
+  expect(last[0]?.record.message).toMatchObject({ content: "last" });
+  expect(index.entries.find((entry) => entry.id === "same")?.seq).toBe(1);
+});
+
+test("keeps CRLF across chunk boundaries and physical duplicate-anchor cuts", async () => {
+  const first = message("anchor", "x".repeat(65_535 - Buffer.byteLength(message("anchor", ""))));
+  const activity = createNestedToolActivity({
+    runId: "run",
+    scopeId: "scope",
+    afterEntryId: "anchor",
+    startOrder: 1,
+    toolCallId: "tool",
+    toolName: "exec",
+    input: "retained input",
+    result: { content: [{ type: "text", text: "retained output" }] },
+    isError: false,
+    startedAt: 0,
+    timestamp: 1,
+  });
+  const file = await fixture(
+    [
+      first,
+      JSON.stringify({ type: "custom_message", id: "early", message: activity }),
+      message("anchor", "last anchor"),
+      JSON.stringify({ type: "custom_message", id: "late", message: activity }),
+    ].join("\r\n"),
+  );
+  const index = (await readSessionTranscriptIndex(file, "test"))!;
+  const entries = await readIndexedTranscriptEntries(file, index, index.entries, "test");
+  expect(entries).toHaveLength(4);
+  expect(entries[1]?.record.message).toEqual(activity);
+  expect(entries[1]?.transcriptPosition.activity).toBeUndefined();
+  expect(entries[3]?.transcriptPosition.activity).toEqual({
+    afterRawSeq: 3,
+    scopeId: "scope",
+    startOrder: 1,
+  });
+});
+
+test("batches a page and rejects a rewrite while its pinned descriptor is being read", async () => {
+  const file = await fixture(
+    Array.from({ length: 40 }, (_, i) => message(String(i), "body")).join("\n"),
+  );
+  let index = (await readSessionTranscriptIndex(file, "test"))!;
+  const actual = fileReads.readFileWindowFully;
+  const reads = vi.spyOn(fileReads, "readFileWindowFully");
+  await expect(
+    readIndexedTranscriptEntries(file, index, index.entries, "test"),
+  ).resolves.toHaveLength(40);
+  expect(reads).toHaveBeenCalledTimes(1);
+  reads.mockImplementationOnce(async (handle, buffer, position) => {
+    const bytes = await actual(handle, buffer, position);
+    await fs.promises.appendFile(file, "\n" + message("new", "rewritten"));
+    return bytes;
+  });
+  await expect(
+    readIndexedTranscriptEntries(file, index, index.entries, "test"),
+  ).rejects.toBeInstanceOf(SessionTranscriptProjectionUnavailableError);
+  index = (await readSessionTranscriptIndex(file, "test"))!;
+  await expect(
+    readIndexedTranscriptEntries(file, index, [index.entries.at(-1)!], "test"),
+  ).resolves.toMatchObject([{ record: { id: "new" } }]);
+});

--- a/src/gateway/session-transcript-index.fs.ts
+++ b/src/gateway/session-transcript-index.fs.ts
@@ -1,13 +1,16 @@
 import fs from "node:fs";
-import readline from "node:readline";
+import type { FileHandle } from "node:fs/promises";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { TranscriptDisplayPosition } from "../chat/transcript-display-position.js";
 import { SessionTranscriptProjectionUnavailableError } from "../config/sessions/session-transcript-projection-error.js";
 import { selectSessionTranscriptActiveEntries } from "../config/sessions/transcript-tree.js";
+import { readFileWindowFully } from "../infra/file-read.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
+import { readNestedToolActivity } from "../sessions/nested-tool-activity.js";
 import {
-  createTranscriptDisplayPosition,
+  createTranscriptDisplayPositionFromActivity,
   createTranscriptDisplaySource,
+  type TranscriptDisplayActivity,
 } from "../sessions/transcript-display-position.js";
 import { isVisibleTranscriptRecord } from "../sessions/transcript-visible-record.js";
 import {
@@ -15,10 +18,18 @@ import {
   type TranscriptRecord,
 } from "./session-transcript-record-parser.js";
 
-export type IndexedTranscriptEntry = TranscriptRecord & {
+export type IndexedTranscriptEntry = {
+  id?: string;
+  /** Selection sometimes compares the raw ID, including blank strings. */
+  rawId?: string;
+  offset: number;
+  /** Physical bytes, distinct from the parser's decoded/sanitized byteLength. */
+  length: number;
   seq: number;
   transcriptPosition: TranscriptDisplayPosition;
 };
+
+export type MaterializedTranscriptEntry = TranscriptRecord & IndexedTranscriptEntry;
 
 export type SessionTranscriptIndex = {
   entries: IndexedTranscriptEntry[];
@@ -33,6 +44,8 @@ type CachedTranscriptIndex = {
 
 const transcriptIndexes = new Map<string, CachedTranscriptIndex>();
 const MAX_TRANSCRIPT_INDEXES = 256;
+const ARCHIVE_READ_BYTES = 64 * 1024;
+const ARCHIVE_BATCH_BYTES = 1024 * 1024;
 
 function transcriptArtifactDisplaySource(filePath: string, stat: fs.Stats): string {
   // Inode/ctime distinguish replacement or rewrite even when size and mtime are preserved.
@@ -81,59 +94,154 @@ export function selectArchiveTranscriptEntries<T extends TranscriptRecord>(
   return [...kept, ...entries.slice(boundaryIndex)];
 }
 
+async function* readArchiveLines(filePath: string, handle: FileHandle) {
+  const stream = fs.createReadStream(filePath, {
+    fd: handle,
+    autoClose: false,
+    highWaterMark: ARCHIVE_READ_BYTES,
+  });
+  let offset = 0;
+  let length = 0;
+  let afterCr = false;
+  const fragments: Buffer[] = [];
+  try {
+    // SAFETY: This ReadStream emits raw Buffers; it has no encoding or setEncoding call.
+    for await (const chunk of stream as AsyncIterable<Buffer>) {
+      let start = 0;
+      // Match readline's CR, LF and CRLF semantics, even across read boundaries.
+      if (afterCr && chunk[0] === 10) {
+        start = 1;
+        offset++;
+      }
+      afterCr = false;
+      while (start < chunk.length) {
+        const lf = chunk.indexOf(10, start);
+        const cr = chunk.indexOf(13, start);
+        const end = lf < 0 ? cr : cr < 0 ? lf : Math.min(lf, cr);
+        if (end < 0) {
+          fragments.push(chunk.subarray(start));
+          length += chunk.length - start;
+          break;
+        }
+        const last = chunk.subarray(start, end);
+        length += last.length;
+        const line = fragments.length ? Buffer.concat([...fragments, last], length) : last;
+        yield { line: line.toString("utf8"), offset, length };
+        fragments.length = 0;
+        offset += length + 1;
+        length = 0;
+        start = end + 1;
+        if (chunk[end] === 13) {
+          if (chunk[start] === 10) {
+            start++;
+            offset++;
+          } else {
+            afterCr = start === chunk.length;
+          }
+        }
+      }
+    }
+    if (length > 0) {
+      yield { line: Buffer.concat(fragments, length).toString("utf8"), offset, length };
+    }
+  } finally {
+    // Destroy closes the descriptor even with autoClose:false. A completed scan
+    // leaves it with the outer owner for its final identity check and close.
+    if (!stream.readableEnded) {
+      stream.destroy();
+    }
+  }
+}
+
+function archiveNavigationRecord(record: Record<string, unknown>): Record<string, unknown> {
+  const navigation: Record<string, unknown> = {};
+  for (const key of [
+    "id",
+    "type",
+    "parentId",
+    "targetId",
+    "appendParentId",
+    "appendMode",
+    "firstKeptEntryId",
+  ]) {
+    if (Object.hasOwn(record, key)) {
+      const value = record[key];
+      navigation[key] = typeof value === "string" || value === null ? value : false;
+    }
+  }
+  // The tree/reset selector needs message presence and role, never its payload.
+  const role = asOptionalRecord(record.message)?.role;
+  navigation.message = record.message
+    ? { role: role === "user" || role === "assistant" ? role : undefined }
+    : false;
+  return navigation;
+}
+
 async function buildSessionTranscriptIndex(
   filePath: string,
   displaySource: string,
   sessionId: string,
 ): Promise<SessionTranscriptIndex> {
-  const records: Array<TranscriptRecord & { rawSeq: number }> = [];
+  const records: Array<
+    TranscriptRecord & {
+      rawSeq: number;
+      offset: number;
+      length: number;
+      activity?: TranscriptDisplayActivity;
+    }
+  > = [];
   const rawSeqById = new Map<string, number>();
   const handle = await fs.promises.open(filePath, "r");
   try {
     const stat = await handle.stat();
     assertArchiveTranscriptSource(filePath, stat, displaySource, sessionId);
-    // The handle pins the scan across path replacement and owns stream shutdown on failure.
-    const stream = fs.createReadStream(filePath, {
-      encoding: "utf8",
-      fd: handle,
-      autoClose: false,
-    });
-    const lines = readline.createInterface({ input: stream, crlfDelay: Infinity });
-    try {
-      for await (const line of lines) {
-        if (!line.trim()) {
-          continue;
-        }
-        const record = parseTranscriptRecord(line);
-        if (record) {
-          const rawSeq = records.length + 1;
-          records.push({ ...record, rawSeq });
-          if (record.id) {
-            // Capture physical cuts before branch/reset selection removes their control rows.
-            rawSeqById.set(record.id, rawSeq);
-          }
+    for await (const { line, offset, length } of readArchiveLines(filePath, handle)) {
+      if (!line.trim()) {
+        continue;
+      }
+      const record = parseTranscriptRecord(line);
+      if (record) {
+        const rawSeq = records.length + 1;
+        const activity = readNestedToolActivity(record.record.message)?.details;
+        records.push({
+          ...record,
+          record: archiveNavigationRecord(record.record),
+          rawSeq,
+          offset,
+          length,
+          ...(activity
+            ? {
+                activity: {
+                  afterEntryId: activity.afterEntryId,
+                  scopeId: activity.scopeId,
+                  startOrder: activity.startOrder,
+                },
+              }
+            : {}),
+        });
+        if (record.id) {
+          // Capture physical cuts before branch/reset selection removes their control rows.
+          rawSeqById.set(record.id, rawSeq);
         }
       }
-      const finalStat = await handle.stat();
-      assertArchiveTranscriptSource(filePath, finalStat, displaySource, sessionId);
-    } finally {
-      lines.close();
     }
+    const finalStat = await handle.stat();
+    assertArchiveTranscriptSource(filePath, finalStat, displaySource, sessionId);
   } finally {
     await handle.close();
   }
   const entries = selectArchiveTranscriptEntries(records)
     .filter((entry) => isVisibleTranscriptRecord(entry.record))
     .map((entry, index): IndexedTranscriptEntry => ({
-      byteLength: entry.byteLength,
       id: entry.id,
-      recoveredImageData: entry.recoveredImageData,
-      record: entry.record,
+      rawId: typeof entry.record.id === "string" ? entry.record.id : undefined,
+      offset: entry.offset,
+      length: entry.length,
       seq: index + 1,
-      transcriptPosition: createTranscriptDisplayPosition(
+      transcriptPosition: createTranscriptDisplayPositionFromActivity(
         displaySource,
         entry.rawSeq,
-        entry.record.message,
+        entry.activity,
         (id) => rawSeqById.get(id),
       ),
     }));
@@ -142,6 +250,57 @@ async function buildSessionTranscriptIndex(
     byId: new Map(entries.flatMap((entry) => (entry.id ? [[entry.id, entry] as const] : []))),
     displaySource,
   };
+}
+
+/** Read selected payloads in bounded asynchronous batches; the cache owns no payload objects. */
+export async function readIndexedTranscriptEntries(
+  filePath: string,
+  index: SessionTranscriptIndex,
+  selected: readonly IndexedTranscriptEntry[],
+  sessionId: string,
+): Promise<MaterializedTranscriptEntry[]> {
+  const handle = await fs.promises.open(filePath, "r");
+  try {
+    assertArchiveTranscriptSource(filePath, await handle.stat(), index.displaySource, sessionId);
+    const physical = selected
+      .map((entry, order) => ({ entry, order }))
+      .toSorted((left, right) => left.entry.offset - right.entry.offset);
+    const result: MaterializedTranscriptEntry[] = [];
+    for (let start = 0; start < physical.length;) {
+      const first = physical[start]!.entry;
+      let end = start + 1;
+      let byteEnd = first.offset + first.length;
+      while (end < physical.length) {
+        const next = physical[end]!.entry;
+        if (next.offset + next.length - first.offset > ARCHIVE_BATCH_BYTES) {
+          break;
+        }
+        byteEnd = Math.max(byteEnd, next.offset + next.length);
+        end++;
+      }
+      // One oversized record still follows the existing parser's recovery contract.
+      const buffer = Buffer.allocUnsafe(byteEnd - first.offset);
+      if ((await readFileWindowFully(handle, buffer, first.offset)) !== buffer.length) {
+        throw new SessionTranscriptProjectionUnavailableError(sessionId);
+      }
+      for (let position = start; position < end; position++) {
+        const { entry, order } = physical[position]!;
+        const relative = entry.offset - first.offset;
+        const parsed = parseTranscriptRecord(
+          buffer.toString("utf8", relative, relative + entry.length),
+        );
+        if (!parsed) {
+          throw new SessionTranscriptProjectionUnavailableError(sessionId);
+        }
+        result[order] = { ...entry, ...parsed };
+      }
+      start = end;
+    }
+    assertArchiveTranscriptSource(filePath, await handle.stat(), index.displaySource, sessionId);
+    return result;
+  } finally {
+    await handle.close();
+  }
 }
 
 export async function readSessionTranscriptIndex(

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -23,9 +23,10 @@ import {
 } from "./session-transcript-files.fs.js";
 import {
   assertArchiveTranscriptSource,
+  readIndexedTranscriptEntries,
   readSessionTranscriptIndex,
   selectArchiveTranscriptEntries,
-  type IndexedTranscriptEntry,
+  type MaterializedTranscriptEntry,
   type SessionTranscriptIndex,
 } from "./session-transcript-index.fs.js";
 import { projectTranscriptEntryMessage } from "./session-transcript-message.js";
@@ -244,7 +245,16 @@ export class ArchivedTranscriptReader {
     }
     const index = await readSessionTranscriptIndex(artifact.path, this.scope.sessionId);
     return {
-      messages: index?.entries.flatMap(indexedTranscriptEntryToMessages) ?? [],
+      messages: index
+        ? (
+            await readIndexedTranscriptEntries(
+              artifact.path,
+              index,
+              index.entries,
+              this.scope.sessionId,
+            )
+          ).flatMap(indexedTranscriptEntryToMessages)
+        : [],
       transcriptPath: artifact.path,
     };
   }
@@ -257,8 +267,16 @@ export class ArchivedTranscriptReader {
     if (!artifact) {
       return { oversized: false, found: false };
     }
-    const entry = (await readSessionTranscriptIndex(artifact.path, this.scope.sessionId))?.byId.get(
-      messageId,
+    const index = await readSessionTranscriptIndex(artifact.path, this.scope.sessionId);
+    const selected = index?.byId.get(messageId);
+    if (!index || !selected) {
+      return { oversized: false, found: false };
+    }
+    const [entry] = await readIndexedTranscriptEntries(
+      artifact.path,
+      index,
+      [selected],
+      this.scope.sessionId,
     );
     if (!entry) {
       return { oversized: false, found: false };
@@ -288,15 +306,18 @@ export class ArchivedTranscriptReader {
       return [];
     }
     const index = await readSessionTranscriptIndex(artifact.path, this.scope.sessionId);
+    if (!index) {
+      return [];
+    }
     // Preserve duplicate/oversized full-reader entries and ID-less rows whose
     // projected metadata can supply the ID. The caller matches after projection.
-    return (
-      index?.entries.flatMap((entry) =>
-        typeof entry.record.id !== "string" || entry.record.id === messageId
-          ? indexedTranscriptEntryToMessages(entry)
-          : [],
-      ) ?? []
+    const entries = await readIndexedTranscriptEntries(
+      artifact.path,
+      index,
+      index.entries.filter((entry) => entry.rawId === undefined || entry.rawId === messageId),
+      this.scope.sessionId,
     );
+    return entries.flatMap(indexedTranscriptEntryToMessages);
   }
 
   async readRecentWithStats(
@@ -341,7 +362,12 @@ export class ArchivedTranscriptReader {
     const offset = Math.min(resolveNonNegativeIntegerOption(opts.offset, 0), totalMessages);
     const endExclusive = Math.max(0, totalMessages - offset);
     const start = Math.max(0, endExclusive - resolveNonNegativeIntegerOption(opts.maxMessages, 0));
-    const entries = index.entries.slice(start, endExclusive);
+    const entries = await readIndexedTranscriptEntries(
+      artifact.path,
+      index,
+      index.entries.slice(start, endExclusive),
+      this.scope.sessionId,
+    );
     return {
       displaySource: index.displaySource,
       messages: entries.flatMap(indexedTranscriptEntryToMessages),
@@ -411,13 +437,17 @@ export class ArchivedTranscriptReader {
       );
       const endExclusive = Math.min(index.entries.length, start + pageSize);
       const readStart = Math.max(0, start - 1);
+      const entries = await readIndexedTranscriptEntries(
+        artifact.path,
+        index,
+        index.entries.slice(readStart, endExclusive),
+        this.scope.sessionId,
+      );
       return {
         displaySource: index.displaySource,
         found: true,
         hasOverreadContext: readStart < start,
-        messages: index.entries
-          .slice(readStart, endExclusive)
-          .flatMap(indexedTranscriptEntryToMessages),
+        messages: entries.flatMap(indexedTranscriptEntryToMessages),
         offset: index.entries.length - endExclusive,
         totalMessages: index.entries.length,
         transcriptPath: artifact.path,
@@ -450,11 +480,11 @@ async function readRecentSessionSnapshotFromPathAsync(
   return parseRecentTranscriptTailSnapshot(lines, opts.maxMessages, index);
 }
 
-function indexedTranscriptEntryToMessage(entry: IndexedTranscriptEntry): unknown {
+function indexedTranscriptEntryToMessage(entry: MaterializedTranscriptEntry): unknown {
   return projectTranscriptEntryMessage(entry.record, entry.seq, entry.transcriptPosition);
 }
 
-function indexedTranscriptEntryToMessages(entry: IndexedTranscriptEntry): unknown[] {
+function indexedTranscriptEntryToMessages(entry: MaterializedTranscriptEntry): unknown[] {
   const message = indexedTranscriptEntryToMessage(entry);
   return message ? [message] : [];
 }

--- a/src/sessions/transcript-display-position.ts
+++ b/src/sessions/transcript-display-position.ts
@@ -1,6 +1,11 @@
 import { createHash } from "node:crypto";
 import type { TranscriptDisplayPosition } from "../chat/transcript-display-position.js";
-import { readNestedToolActivity } from "./nested-tool-activity.js";
+import { readNestedToolActivity, type NestedToolActivity } from "./nested-tool-activity.js";
+
+export type TranscriptDisplayActivity = Pick<
+  NestedToolActivity["details"],
+  "afterEntryId" | "scopeId" | "startOrder"
+>;
 
 /** Keep source namespaces and rewrite generations separate without exposing storage paths. */
 export function createTranscriptDisplaySource(parts: readonly string[]): string {
@@ -13,12 +18,26 @@ export function createTranscriptDisplayPosition(
   message: unknown,
   entrySeq: (id: string) => number | undefined,
 ): TranscriptDisplayPosition {
+  return createTranscriptDisplayPositionFromActivity(
+    source,
+    rawSeq,
+    readNestedToolActivity(message)?.details,
+    entrySeq,
+  );
+}
+
+/** Archive indexes retain validated placement facts without retaining tool input/output. */
+export function createTranscriptDisplayPositionFromActivity(
+  source: string,
+  rawSeq: number,
+  activity: TranscriptDisplayActivity | undefined,
+  entrySeq: (id: string) => number | undefined,
+): TranscriptDisplayPosition {
   const position: TranscriptDisplayPosition = { source, rawSeq };
-  const activity = readNestedToolActivity(message);
   if (!activity) {
     return position;
   }
-  const { afterEntryId, scopeId, startOrder } = activity.details;
+  const { afterEntryId, scopeId, startOrder } = activity;
   const afterRawSeq = afterEntryId === null ? null : entrySeq(afterEntryId);
   // The dispatch cut is a physical fact, not the anchor's relocated display position.
   // Unresolved or rewritten anchors keep completion order rather than guessing a parent.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where browsing large retained reset archives left their message payloads in the Gateway heap after the request finished. Each page read retained its archive’s complete parsed messages; the process cache could keep up to 256 such files.

## Why This Change Was Made

The archive index now retains navigation and physical byte offsets. One descriptor-verified asynchronous batch reader materializes selected records through the existing parser. Full reads, pagination, around-ID lookup and attachment membership share that owner. A byte cap alone would discard navigation and force complete archive scans after eviction.

Recent-tail bounds, branch/reset selection, duplicate ordering, oversized-image recovery and display positions retain their contracts. This composes with #138857, including raw and embedded message IDs. No schema, configuration, dependency or retention changes. The +208 production lines provide the byte index and single bounded reader instead of a retained payload graph.

## User Impact

Gateways that read large retained reset archives keep less transcript data between requests. This is a memory tradeoff: a synthetic Node 26 workload of 12 archives × 2,048 messages × 4 KiB reduced retained heap from **106.0 MiB to 4.1 MiB**, while the warm one-message page median increased from **0.63 ms to 3.71 ms** across 40 alternating pairs. Those measurements precede the membership integration; they are not a production traffic-frequency or whole-process RSS claim.

## Evidence

- Current-base isolated Linux, Node 24.19.0: complete changed gate, **233 tests across 5 files**, and build passed; all four source hashes matched before and after.
- Real Gateway + Chromium with isolated synthetic state: retained-archive startup, an actual `chat.history` request at offset 80 and the oldest of 400 linked messages visible, then populated SQLite history taking precedence. Gateway/state cleanup completed and all child processes joined.
- Covers archive branches, resets/compactions, duplicate and embedded IDs, oversized images, current-history revocation, CR/LF/CRLF and invalid UTF-8, and replacement during a descriptor read. General HTTP tests mock transcript/auth inputs; the SQLite visibility suite exercises the actual archive/membership owners.
- Independent Codex review through P2: clean, with no actionable findings.

The live fixture creates a retained legacy reset artifact through the existing file archiver. It does not claim that current SQLite reset flows publish such artifacts.

<details>
<summary>Synthetic real-Gateway browser proof</summary>

![Retained archive startup](https://github.com/user-attachments/assets/536329c0-d32a-49e1-ae6a-c96afae4fd9d)

![Older archive messages loaded through browser pagination](https://github.com/user-attachments/assets/32ed0fb7-85d2-4995-bf40-075b7a209eef)

![Current SQLite history takes precedence](https://github.com/user-attachments/assets/adc5c2c0-449e-438e-985f-afc8f0ef7fc1)

https://github.com/user-attachments/assets/d69c303d-d957-408a-98bf-c04559cb27b0

</details>
