### PR TITLE
fix: stop rejecting plugin-owned build dependencies in release checks

### DIFF
--- a/scripts/lib/package-root-imports.ts
+++ b/scripts/lib/package-root-imports.ts
@@ -1,0 +1,661 @@
+import { createRequire } from "node:module";
+import { isAbsolute, win32 } from "node:path";
+import type ts from "typescript";
+
+const require = createRequire(import.meta.url);
+type Origin =
+  | "root"
+  | "caller"
+  | "factory"
+  | "module"
+  | "process"
+  | "path"
+  | "fs"
+  | "fs-promises"
+  | "builtin"
+  | "join"
+  | "resolve"
+  | "realpath"
+  | "realpath-async"
+  | "cwd"
+  | "chdir"
+  | "location"
+  | "input"
+  | "caller-path"
+  | "caller-string"
+  | "literal"
+  | "relative"
+  | "scalar"
+  | "unknown"
+  | "unlocated";
+const namespaces = new Map<string, Origin>([
+  ["node:module", "module"],
+  ["module", "module"],
+  ["node:process", "process"],
+  ["process", "process"],
+  ["node:path", "path"],
+  ["path", "path"],
+  ["node:fs", "fs"],
+  ["fs", "fs"],
+  ["node:fs/promises", "fs-promises"],
+  ["fs/promises", "fs-promises"],
+]);
+const members = new Map<Origin, ReadonlyMap<string, Origin>>([
+  ["module", new Map([["createRequire", "factory"]])],
+  [
+    "process",
+    new Map([
+      ["getBuiltinModule", "builtin"],
+      ["cwd", "cwd"],
+      ["chdir", "chdir"],
+    ]),
+  ],
+  [
+    "path",
+    new Map([
+      ["join", "join"],
+      ["resolve", "resolve"],
+    ]),
+  ],
+  [
+    "fs",
+    new Map([
+      ["realpathSync", "realpath"],
+      ["promises", "fs-promises"],
+    ]),
+  ],
+  ["fs-promises", new Map([["realpath", "realpath-async"]])],
+]);
+const ambient = new Map<string, Origin>([
+  ["require", "root"],
+  ["__filename", "location"],
+  ["process", "process"],
+]);
+const loaders = new Set<Origin>(["root", "caller", "unlocated"]);
+const snapshotsKinds = new Set<Origin>(["caller-path", "caller-string", "caller", "root"]);
+const callerValues = new Set<Origin>(["input", "caller-path", "caller-string"]);
+const pathValues = new Set<Origin>([...callerValues, "literal", "relative"]);
+const readableValues = new Set<Origin>([
+  ...pathValues,
+  "module",
+  "process",
+  "path",
+  "fs",
+  "fs-promises",
+  "scalar",
+]);
+const pureCalls = new Set<Origin>([
+  "factory",
+  "builtin",
+  "join",
+  "resolve",
+  "realpath",
+  "realpath-async",
+  "cwd",
+]);
+function union(...values: Origin[][]): Origin[] {
+  const result = [...new Set(values.flat())];
+  return result.length ? result : ["unknown"];
+}
+
+/** Read dependency ownership without resolving or executing the inspected package. */
+export function collectPackageRootImports(source: string): Set<string> {
+  const ts = require("typescript") as typeof import("typescript");
+  const file = ts.createSourceFile(
+    "dist.js",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS,
+  );
+  const imports = new Set<string>();
+  const calls: ts.CallExpression[] = [];
+  const scopes: Array<ts.SourceFile | ts.FunctionLikeDeclaration> = [file];
+  const assignments: Array<[ts.Identifier, ts.Expression | undefined]> = [];
+  const cwdReferences: Array<ts.Expression | ts.ImportSpecifier | ts.BindingElement> = [];
+  // Only const primitive paths and bound Node loaders survive the entry prefix; raw inputs do not.
+  const snapshots = new Map<ts.Symbol, Origin[]>();
+  let changedCwd = false;
+  let checker: ts.TypeChecker | undefined;
+  function symbolAt(node: ts.Node): ts.Symbol | undefined {
+    checker ??= ts
+      .createProgram(
+        [file.fileName],
+        { allowJs: true, noLib: true, noResolve: true },
+        {
+          getSourceFile: (name) => (name === file.fileName ? file : undefined),
+          getDefaultLibFileName: () => "",
+          writeFile: () => {},
+          getCurrentDirectory: () => "",
+          getCanonicalFileName: (name) => name,
+          useCaseSensitiveFileNames: () => true,
+          getNewLine: () => "\n",
+          fileExists: (name) => name === file.fileName,
+          readFile: (name) => (name === file.fileName ? source : undefined),
+        },
+      )
+      .getTypeChecker();
+    return ts.isShorthandPropertyAssignment(node.parent) && node.parent.name === node
+      ? checker.getShorthandAssignmentValueSymbol(node.parent)
+      : checker.getSymbolAtLocation(node);
+  }
+  function literal(node: ts.Expression | undefined): string | undefined {
+    let value = node;
+    while (value && ts.isParenthesizedExpression(value)) {
+      value = value.expression;
+    }
+    return value && ts.isStringLiteral(value) ? value.text : undefined;
+  }
+  function property(node: ts.Node): string | undefined {
+    return ts.isIdentifier(node) || ts.isStringLiteral(node)
+      ? node.text
+      : ts.isComputedPropertyName(node)
+        ? literal(node.expression)
+        : undefined;
+  }
+  const logical = new Set([
+    ts.SyntaxKind.BarBarToken,
+    ts.SyntaxKind.AmpersandAmpersandToken,
+    ts.SyntaxKind.QuestionQuestionToken,
+    ts.SyntaxKind.BarBarEqualsToken,
+    ts.SyntaxKind.AmpersandAmpersandEqualsToken,
+    ts.SyntaxKind.QuestionQuestionEqualsToken,
+  ]);
+  function recordWrite(node: ts.Node, value?: ts.Expression) {
+    if (ts.isIdentifier(node)) {
+      assignments.push([node, value]);
+    } else if (ts.isParenthesizedExpression(node)) {
+      recordWrite(node.expression, value);
+    } else if (ts.isPropertyAssignment(node)) {
+      recordWrite(node.initializer);
+    } else if (ts.isShorthandPropertyAssignment(node) || ts.isBindingElement(node)) {
+      recordWrite(node.name);
+    } else if (ts.isBinaryExpression(node)) {
+      recordWrite(node.left);
+    } else if (!ts.isPropertyAccessExpression(node) && !ts.isElementAccessExpression(node)) {
+      ts.forEachChild(node, (child) => recordWrite(child));
+    }
+  }
+  const pending: ts.Node[] = [file];
+  let hasLoader = false;
+  while (pending.length) {
+    const node = pending.pop()!;
+    if (
+      (ts.isIdentifier(node) || ts.isStringLiteral(node)) &&
+      ["require", "createRequire", "getBuiltinModule"].includes(node.text)
+    ) {
+      hasLoader = true;
+    }
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      const specifier = literal(node.moduleSpecifier);
+      if (specifier !== undefined) {
+        imports.add(specifier);
+      }
+    }
+    if (ts.isCallExpression(node)) {
+      const specifier = literal(node.arguments[0]);
+      if (node.expression.kind === ts.SyntaxKind.ImportKeyword && specifier !== undefined) {
+        imports.add(specifier);
+      } else {
+        calls.push(node);
+      }
+    }
+    if (ts.isFunctionLike(node) && "body" in node && node.body) {
+      scopes.push(node);
+    }
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+      node.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+    ) {
+      recordWrite(node.left, node.right);
+    }
+    if (
+      (ts.isForOfStatement(node) || ts.isForInStatement(node)) &&
+      !ts.isVariableDeclarationList(node.initializer)
+    ) {
+      recordWrite(node.initializer);
+    }
+    if (
+      (ts.isPropertyAccessExpression(node) && node.name.text === "chdir") ||
+      (ts.isElementAccessExpression(node) && literal(node.argumentExpression) === "chdir") ||
+      ((ts.isImportSpecifier(node) || ts.isBindingElement(node)) &&
+        property(node.propertyName ?? node.name) === "chdir")
+    ) {
+      cwdReferences.push(node);
+    }
+    ts.forEachChild(node, (child) => {
+      pending.push(child);
+    });
+  }
+  if (!hasLoader) {
+    return imports;
+  }
+  const writes = new Map<ts.Symbol, Array<ts.Expression | undefined>>();
+  for (const [name, value] of assignments) {
+    const symbol = symbolAt(name);
+    if (symbol) {
+      writes.set(symbol, [...(writes.get(symbol) ?? []), value]);
+    }
+  }
+  function memberOrigins(owners: Origin[], name: string | undefined): Origin[] {
+    return union(
+      owners.map((owner) =>
+        owner === "input"
+          ? "input"
+          : name === undefined
+            ? "unknown"
+            : (members.get(owner)?.get(name) ?? "unknown"),
+      ),
+    );
+  }
+  function origins(
+    expression: ts.Expression,
+    seen = new Set<ts.Symbol>(),
+    inputScope?: ts.Node,
+    awaited = false,
+  ): Origin[] {
+    if (ts.isParenthesizedExpression(expression)) {
+      return origins(expression.expression, seen, inputScope, awaited);
+    }
+    if (ts.isAwaitExpression(expression)) {
+      return origins(expression.expression, seen, inputScope, true);
+    }
+    if (ts.isStringLiteralLike(expression)) {
+      return [
+        isAbsolute(expression.text) ||
+        win32.isAbsolute(expression.text) ||
+        URL.canParse(expression.text)
+          ? "literal"
+          : "relative",
+      ];
+    }
+    if (
+      ts.isNumericLiteral(expression) ||
+      [ts.SyntaxKind.TrueKeyword, ts.SyntaxKind.FalseKeyword, ts.SyntaxKind.NullKeyword].includes(
+        expression.kind,
+      )
+    ) {
+      return ["literal"];
+    }
+    if (ts.isConditionalExpression(expression)) {
+      return union(
+        origins(expression.whenTrue, new Set(seen), inputScope),
+        origins(expression.whenFalse, new Set(seen), inputScope),
+      );
+    }
+    if (ts.isBinaryExpression(expression)) {
+      const op = expression.operatorToken.kind;
+      if (op === ts.SyntaxKind.EqualsToken || op === ts.SyntaxKind.CommaToken) {
+        return origins(expression.right, seen, inputScope);
+      }
+      const values = union(
+        origins(expression.left, new Set(seen), inputScope),
+        origins(expression.right, new Set(seen), inputScope),
+      );
+      if (logical.has(op)) {
+        return values;
+      }
+      if (
+        op === ts.SyntaxKind.PlusToken &&
+        values.some((value) => callerValues.has(value)) &&
+        values.every((value) => pathValues.has(value))
+      ) {
+        return ["caller-string"];
+      }
+      return ["scalar"];
+    }
+    if (ts.isIdentifier(expression)) {
+      const symbol = symbolAt(expression);
+      if (!symbol?.declarations?.length) {
+        return [ambient.get(expression.text) ?? "unknown"];
+      }
+      const snapshot = snapshots.get(symbol);
+      if (snapshot) {
+        return snapshot;
+      }
+      if (seen.has(symbol)) {
+        return ["unknown"];
+      }
+      seen.add(symbol);
+      const entryParameter = symbol.declarations.some(
+        (declaration) =>
+          ts.isParameter(declaration) &&
+          ts.findAncestor(declaration.parent, ts.isFunctionLike) === inputScope,
+      );
+      return union(
+        ...symbol.declarations.map((declaration) =>
+          declarationOrigins(declaration, new Set(seen), inputScope),
+        ),
+        ...(entryParameter ? [] : (writes.get(symbol) ?? [])).map((value): Origin[] =>
+          value ? origins(value, new Set(seen), inputScope) : ["unknown"],
+        ),
+      );
+    }
+    if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+      const name = ts.isPropertyAccessExpression(expression)
+        ? expression.name.text
+        : literal(expression.argumentExpression);
+      if (
+        name === "url" &&
+        ts.isMetaProperty(expression.expression) &&
+        expression.expression.keywordToken === ts.SyntaxKind.ImportKeyword
+      ) {
+        return ["location"];
+      }
+      return memberOrigins(origins(expression.expression, seen, inputScope), name);
+    }
+    if (ts.isCallExpression(expression)) {
+      const specifier = literal(expression.arguments[0]);
+      const namespace = specifier === undefined ? undefined : namespaces.get(specifier);
+      if (expression.expression.kind === ts.SyntaxKind.ImportKeyword) {
+        return [namespace ?? "unknown"];
+      }
+      const locations = expression.arguments.map((value) =>
+        origins(value, new Set(seen), inputScope),
+      );
+      return union(
+        ...origins(expression.expression, new Set(seen), inputScope).map((loader): Origin[] => {
+          if (loader === "factory") {
+            return (locations[0] ?? ["unknown"]).map((location) =>
+              location === "location"
+                ? "root"
+                : callerValues.has(location)
+                  ? "caller"
+                  : "unlocated",
+            );
+          }
+          if (loaders.has(loader) || loader === "builtin") {
+            return [namespace ?? "unknown"];
+          }
+          if (loader === "cwd") {
+            return [inputScope && !changedCwd ? "caller-path" : "scalar"];
+          }
+          // Only the awaited default result is a string; the Promise itself is mutable.
+          if (loader === "realpath-async" && !awaited) {
+            return ["unknown"];
+          }
+          if (
+            loader === "resolve" ||
+            ((loader === "realpath" || loader === "realpath-async") &&
+              expression.arguments.length === 1)
+          ) {
+            const values = loader === "resolve" ? locations.flat() : (locations[0] ?? ["unknown"]);
+            return [
+              !changedCwd &&
+              values.every((value) =>
+                ["input", "caller-path", "caller-string", "relative"].includes(value),
+              ) &&
+              (inputScope || values.includes("caller-path")) &&
+              (inputScope || !values.includes("caller-string"))
+                ? "caller-path"
+                : "scalar",
+            ];
+          }
+          if (loader === "join") {
+            const values = locations.flat();
+            if (
+              values.every((value) => pathValues.has(value)) &&
+              values.some((value) => callerValues.has(value))
+            ) {
+              return [
+                locations[0]?.every((value) => value === "caller-path")
+                  ? "caller-path"
+                  : "caller-string",
+              ];
+            }
+            return ["scalar"];
+          }
+          return ["unknown"];
+        }),
+      );
+    }
+    return ["unknown"];
+  }
+  function declarationOrigins(
+    declaration: ts.Declaration,
+    seen: Set<ts.Symbol>,
+    inputScope?: ts.Node,
+  ): Origin[] {
+    if (ts.isParameter(declaration)) {
+      // A nested function cannot recapture a mutable input belonging to an outer invocation.
+      const input: Origin =
+        inputScope && ts.findAncestor(declaration.parent, ts.isFunctionLike) === inputScope
+          ? "input"
+          : "unknown";
+      const initial = declaration.initializer
+        ? origins(declaration.initializer, seen, inputScope)
+        : [];
+      return union(
+        [input],
+        declaration.initializer && !ts.isIdentifier(declaration.name) ? ["unknown"] : initial,
+      );
+    }
+    if (ts.isBindingElement(declaration)) {
+      let owner: ts.Node = declaration;
+      const defaults: Origin[][] = [];
+      while (
+        ts.isBindingElement(owner) ||
+        ts.isObjectBindingPattern(owner) ||
+        ts.isArrayBindingPattern(owner)
+      ) {
+        if (ts.isBindingElement(owner) && owner.initializer) {
+          defaults.push(
+            owner === declaration
+              ? origins(owner.initializer, new Set(seen), inputScope)
+              : ["unknown"],
+          );
+        }
+        owner = owner.parent;
+      }
+      const incoming: Origin[] = ts.isParameter(owner)
+        ? declarationOrigins(owner, new Set(seen), inputScope)
+        : ts.isVariableDeclaration(owner) && owner.initializer
+          ? origins(owner.initializer, new Set(seen), inputScope)
+          : ["unknown"];
+      const name = property(declaration.propertyName ?? declaration.name);
+      const projected: Origin[] = ts.isParameter(owner)
+        ? incoming
+        : ts.isObjectBindingPattern(declaration.parent) &&
+            declaration.parent.parent === owner &&
+            name !== undefined
+          ? memberOrigins(incoming, name)
+          : ["unknown"];
+      return union(
+        projected,
+        ...defaults,
+        !ts.isParameter(owner) && !(ts.getCombinedNodeFlags(declaration) & ts.NodeFlags.Const)
+          ? ["unknown"]
+          : [],
+      );
+    }
+    if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+      return union(
+        origins(declaration.initializer, seen, inputScope),
+        ts.getCombinedNodeFlags(declaration) & ts.NodeFlags.Const ? [] : ["unknown"],
+      );
+    }
+    if (
+      ts.isImportSpecifier(declaration) ||
+      ts.isNamespaceImport(declaration) ||
+      ts.isImportClause(declaration)
+    ) {
+      const owner = ts.findAncestor(declaration, ts.isImportDeclaration);
+      const namespace =
+        owner && ts.isStringLiteral(owner.moduleSpecifier)
+          ? namespaces.get(owner.moduleSpecifier.text)
+          : undefined;
+      if (namespace) {
+        return ts.isImportSpecifier(declaration)
+          ? memberOrigins([namespace], (declaration.propertyName ?? declaration.name).text)
+          : [namespace];
+      }
+    }
+    return ["unknown"];
+  }
+  function pure(node: ts.Expression, scope: ts.Node): boolean {
+    // Admission is closed: coercion, iteration, defaults and unknown syntax may execute caller code.
+    if (ts.isIdentifier(node)) {
+      return Boolean(symbolAt(node)) || ambient.has(node.text) || node.text === "undefined";
+    }
+    if (
+      ts.isStringLiteralLike(node) ||
+      ts.isNumericLiteral(node) ||
+      [ts.SyntaxKind.TrueKeyword, ts.SyntaxKind.FalseKeyword, ts.SyntaxKind.NullKeyword].includes(
+        node.kind,
+      )
+    ) {
+      return true;
+    }
+    if (ts.isParenthesizedExpression(node)) {
+      return pure(node.expression, scope);
+    }
+    if (ts.isBinaryExpression(node)) {
+      return (
+        logical.has(node.operatorToken.kind) &&
+        node.operatorToken.kind < ts.SyntaxKind.FirstAssignment &&
+        pure(node.left, scope) &&
+        pure(node.right, scope)
+      );
+    }
+    if (ts.isConditionalExpression(node)) {
+      return (
+        pure(node.condition, scope) && pure(node.whenTrue, scope) && pure(node.whenFalse, scope)
+      );
+    }
+    if (ts.isAwaitExpression(node)) {
+      let value: ts.Expression = node.expression;
+      while (ts.isParenthesizedExpression(value)) {
+        value = value.expression;
+      }
+      if (!ts.isCallExpression(value)) {
+        return false;
+      }
+      const specifier = literal(value.arguments[0]);
+      const native = origins(value.expression, new Set(), scope).every(
+        (origin) => origin === "realpath-async",
+      );
+      const builtin =
+        value.expression.kind === ts.SyntaxKind.ImportKeyword &&
+        specifier !== undefined &&
+        namespaces.has(specifier);
+      return (native || builtin) && pure(value, scope);
+    }
+    if (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) {
+      if (origins(node, new Set(), scope).includes("location")) {
+        return true;
+      }
+      return (
+        origins(node.expression, new Set(), scope).every((value) => readableValues.has(value)) &&
+        pure(node.expression, scope) &&
+        (!ts.isElementAccessExpression(node) || literal(node.argumentExpression) !== undefined)
+      );
+    }
+    if (!ts.isCallExpression(node)) {
+      return false;
+    }
+    const builtin = literal(node.arguments[0]);
+    const builtinCall =
+      builtin !== undefined && namespaces.has(builtin) && node.arguments.length === 1;
+    if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      return builtinCall;
+    }
+    return (
+      origins(node.expression, new Set(), scope).every(
+        (value) =>
+          (pureCalls.has(value) &&
+            (value === "join" ||
+              value === "resolve" ||
+              node.arguments.length === (value === "cwd" ? 0 : 1))) ||
+          (loaders.has(value) && builtinCall),
+      ) &&
+      pure(node.expression, scope) &&
+      node.arguments.every((argument) => pure(argument, scope))
+    );
+  }
+  changedCwd = cwdReferences.some((reference) =>
+    (ts.isImportSpecifier(reference) || ts.isBindingElement(reference)
+      ? declarationOrigins(reference, new Set())
+      : origins(reference)
+    ).includes("chdir"),
+  );
+  // Effects or control flow end admission; later loaders may still use captured immutable paths.
+  for (const scope of scopes.toSorted((a, b) => a.pos - b.pos)) {
+    const body = ts.isSourceFile(scope) ? scope : scope.body;
+    if (!body || (!ts.isSourceFile(body) && !ts.isBlock(body))) {
+      continue;
+    }
+    if (
+      !ts.isSourceFile(scope) &&
+      scope.parameters.some(
+        (parameter) =>
+          !ts.isIdentifier(parameter.name) ||
+          Boolean(parameter.initializer) ||
+          Boolean(parameter.dotDotDotToken),
+      )
+    ) {
+      continue;
+    }
+    prefix: for (const statement of body.statements) {
+      if (
+        ts.isImportDeclaration(statement) ||
+        ts.isExportDeclaration(statement) ||
+        ts.isFunctionDeclaration(statement) ||
+        ts.isEmptyStatement(statement) ||
+        (ts.isExpressionStatement(statement) && ts.isStringLiteral(statement.expression))
+      ) {
+        continue;
+      }
+      if (
+        !ts.isVariableStatement(statement) ||
+        !(statement.declarationList.flags & ts.NodeFlags.Const)
+      ) {
+        break;
+      }
+      for (const declaration of statement.declarationList.declarations) {
+        if (
+          !ts.isIdentifier(declaration.name) ||
+          !declaration.initializer ||
+          !pure(declaration.initializer, scope)
+        ) {
+          break prefix;
+        }
+        const values = origins(declaration.initializer, new Set(), scope);
+        if (
+          !values.every(
+            (value) =>
+              snapshotsKinds.has(value) ||
+              ["literal", "relative", ...namespaces.values(), ...pureCalls].includes(value),
+          )
+        ) {
+          break prefix;
+        }
+        const symbol = symbolAt(declaration.name);
+        if (symbol && values.every((value) => snapshotsKinds.has(value))) {
+          snapshots.set(symbol, values);
+        }
+      }
+    }
+  }
+  for (const node of calls) {
+    const specifier = literal(node.arguments[0]);
+    if (node.arguments.length !== 1 || specifier === undefined) {
+      continue;
+    }
+    const values = origins(node.expression);
+    let callee: ts.Expression = node.expression;
+    while (ts.isParenthesizedExpression(callee)) {
+      callee = callee.expression;
+    }
+    // Unproven literal require calls retain the original conservative manifest check.
+    if (
+      values.includes("root") ||
+      (ts.isIdentifier(callee) &&
+        callee.text === "require" &&
+        !values.every((value) => value === "caller"))
+    ) {
+      imports.add(specifier);
+    }
+  }
+  return imports;
+}

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -31,6 +31,7 @@ import {
   comparePackageDistInventory,
   PACKAGE_DIST_INVENTORY_RELATIVE_PATH,
 } from "./lib/package-dist-inventory-contract.mts";
+import { collectPackageRootImports } from "./lib/package-root-imports.ts";
 import {
   collectRuntimeDependencySpecs,
   packageNameFromSpecifier,
@@ -666,77 +667,14 @@ type ParsedImportSpecifiersResult =
   | { ok: true; specifiers: Set<string> }
   | { ok: false; error: string };
 
-function extractLiteralSpecifier(node: unknown): string | null {
-  if (!node || typeof node !== "object") {
-    return null;
-  }
-  const candidate = node as { type?: string; value?: unknown };
-  if (candidate.type === "Literal" && typeof candidate.value === "string") {
-    return candidate.value;
-  }
-  return null;
-}
-
 function extractJavaScriptImportSpecifiers(source: string): ParsedImportSpecifiersResult {
-  const specifiers = new Set<string>();
-  let program: unknown;
   try {
-    program = acorn.parse(source, {
-      allowHashBang: true,
-      ecmaVersion: "latest",
-      sourceType: "module",
-    });
+    // Keep strict JavaScript validation: TypeScript accepts some invalid JS bindings/contexts.
+    acorn.parse(source, { allowHashBang: true, ecmaVersion: "latest", sourceType: "module" });
+    return { ok: true, specifiers: collectPackageRootImports(source) };
   } catch (error) {
     return { ok: false, error: formatErrorMessage(error) };
   }
-
-  const visited = new Set<unknown>();
-  const pending: unknown[] = [program];
-  while (pending.length > 0) {
-    const current = pending.pop();
-    if (!current || typeof current !== "object" || visited.has(current)) {
-      continue;
-    }
-    visited.add(current);
-    const node = current as Record<string, unknown>;
-    const nodeType = typeof node.type === "string" ? node.type : null;
-
-    if (nodeType === "ImportDeclaration") {
-      const specifier = extractLiteralSpecifier(node.source);
-      if (specifier) {
-        specifiers.add(specifier);
-      }
-    } else if (nodeType === "ExportAllDeclaration" || nodeType === "ExportNamedDeclaration") {
-      const specifier = extractLiteralSpecifier(node.source);
-      if (specifier) {
-        specifiers.add(specifier);
-      }
-    } else if (nodeType === "ImportExpression") {
-      const specifier = extractLiteralSpecifier(node.source);
-      if (specifier) {
-        specifiers.add(specifier);
-      }
-    } else if (nodeType === "CallExpression") {
-      const callee = node.callee as { type?: string; name?: string } | undefined;
-      const args = Array.isArray(node.arguments) ? node.arguments : [];
-      if (callee?.type === "Identifier" && callee.name === "require" && args.length === 1) {
-        const specifier = extractLiteralSpecifier(args[0]);
-        if (specifier) {
-          specifiers.add(specifier);
-        }
-      }
-    }
-
-    for (const value of Object.values(node)) {
-      if (Array.isArray(value)) {
-        pending.push(...value);
-      } else if (value && typeof value === "object") {
-        pending.push(value);
-      }
-    }
-  }
-
-  return { ok: true, specifiers };
 }
 
 export function collectInstalledRootDependencyManifestErrors(packageRoot: string): string[] {

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -1193,6 +1193,453 @@ describe("collectInstalledRootDependencyManifestErrors", () => {
     }
   });
 
+  it.each([
+    [
+      "plugin-owned loader",
+      'import { createRequire } from "node:module"; function build(root) { const require = createRequire(root); require("plugin-build-tool"); }',
+      [],
+    ],
+    [
+      "aliased root loader",
+      'import { createRequire as makeRequire } from "node:module"; const load = makeRequire(import.meta.url); load("root-runtime");',
+      ["root-runtime"],
+    ],
+    ["aliased CommonJS loader", 'const load = require; load("root-runtime");', ["root-runtime"]],
+    [
+      "root loader alongside plugin loader",
+      'import { createRequire } from "node:module"; const require = createRequire(import.meta.url); require("root-runtime"); function build(root) { const require = createRequire(root); require("plugin-build-tool"); }',
+      ["root-runtime"],
+    ],
+    [
+      "unknown require parameters stay conservative",
+      'function render(require) { require("view-name"); } require("root-runtime");',
+      ["root-runtime", "view-name"],
+    ],
+    [
+      "block shadow",
+      '{ const require = (name) => name; require("view-name"); } require("root-runtime");',
+      ["root-runtime", "view-name"],
+    ],
+    [
+      "hoisted function shadow",
+      'function build() { require("view-name"); function require(name) { return name; } } require("root-runtime");',
+      ["root-runtime", "view-name"],
+    ],
+    [
+      "aliased plugin loader",
+      'import { createRequire as makeRequire } from "node:module"; function build(root) { const load = makeRequire(root); const require = load; require("plugin-build-tool"); }',
+      [],
+    ],
+    [
+      "destructured CommonJS factory",
+      'const { createRequire: make } = require("node:module"); const load = make(__filename); load("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "reassigned loader",
+      'import { createRequire } from "node:module"; let require = createRequire(pluginPath); require = createRequire(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "reassigned loader alias",
+      'import { createRequire } from "node:module"; let load = createRequire(pluginPath); load = createRequire(import.meta.url); load("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "assigned loader without initializer",
+      'import { createRequire } from "node:module"; let load; load = createRequire(import.meta.url); load("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "assigned factory alias",
+      'import { createRequire } from "node:module"; let make; make = createRequire; const require = make(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "assigned parameter binding",
+      'import { createRequire } from "node:module"; function run(require) { require = createRequire(import.meta.url); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "assigned destructured binding",
+      'import { createRequire } from "node:module"; let { load } = loaders; load = createRequire(import.meta.url); load("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "redeclared loader",
+      'import { createRequire } from "node:module"; var require; var require = createRequire(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "factory with alternative root alias",
+      'import { createRequire } from "node:module"; const root = createRequire(import.meta.url); let make = createRequire; const load = make(import.meta.url); make = root; load("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "conditional roots",
+      'import { createRequire } from "node:module"; const require = usePlugin ? createRequire(pluginPath) : createRequire(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "external module factory",
+      'import { createRequire } from "node:module"; const pluginLoad = createRequire(pluginPath); const require = pluginLoad("node:module").createRequire(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "logical factory",
+      'import { createRequire } from "node:module"; const preferred = null; const make = preferred || createRequire; const require = make(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "comma factory",
+      'import { createRequire } from "node:module"; const require = (0, createRequire)(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "quoted namespace",
+      'import * as module from "node:module"; const require = module["createRequire"](import.meta["url"]); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "quoted factory binding",
+      'const { "createRequire": make } = require("node:module"); const load = make(__filename); load("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "awaited builtin",
+      'const { createRequire: make } = await import("node:module"); const require = make(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "assignment factory",
+      'import { createRequire } from "node:module"; let make; const require = (make = createRequire)(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "conditional external",
+      'import { createRequire } from "node:module"; function build(useFirst, firstPath, secondPath) { const require = useFirst ? createRequire(firstPath) : createRequire(secondPath); require("plugin-build-tool"); }',
+      [],
+    ],
+    [
+      "logical assignment or",
+      'import { createRequire } from "node:module"; let require; require ||= createRequire(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "logical assignment nullish",
+      'import { createRequire } from "node:module"; let require; require ??= createRequire(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "logical assignment and",
+      'import { createRequire } from "node:module"; let require = createRequire(pluginPath); require &&= createRequire(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "global builtin accessor",
+      'const getBuiltinModule = process.getBuiltinModule; const moduleNamespace = getBuiltinModule("module"); const require = moduleNamespace.createRequire(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "imported builtin accessor",
+      'import { getBuiltinModule as get } from "node:process"; const require = get("module").createRequire(import.meta.url); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "process namespace accessor",
+      'const processNamespace = require("node:process"); const load = processNamespace.getBuiltinModule("node:module").createRequire(__filename); load("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "shadowed builtin accessor",
+      'function render(process) { const load = process.getBuiltinModule("module").createRequire(import.meta.url); load("view-name"); }',
+      [],
+    ],
+    ["uninitialized CommonJS require", 'var require; require("root-runtime");', ["root-runtime"]],
+    [
+      "destructured process accessor",
+      'const { getBuiltinModule } = process; const load = getBuiltinModule("module").createRequire(import.meta.url); load("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "unknown loader provenance",
+      'const require = opaqueLoader(); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "unknown factory anchor",
+      'import { createRequire } from "node:module"; const require = createRequire(opaqueLocation()); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "unknown alternative to caller loader",
+      'import { createRequire } from "node:module"; function build(root, chooseCaller) { const require = chooseCaller ? createRequire(root) : opaqueLoader(); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "caller-derived package anchor",
+      'import { createRequire } from "node:module"; import fs from "node:fs/promises"; import path from "node:path"; async function build(opts) { const root = await fs.realpath(path.resolve(opts.root ?? process.cwd())); const require = createRequire(path.join(root, "package.json")); require("plugin-build-tool"); }',
+      [],
+    ],
+    [
+      "unknown dynamic caller property",
+      'import { createRequire } from "node:module"; function build(opts, key, choose) { const selection = choose ? opts : opaqueOptions(); const require = createRequire(selection[key]); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "array destructuring loader write",
+      'import { createRequire } from "node:module"; function build(anchor) { let require = createRequire(anchor); [require] = [createRequire(import.meta.url)]; require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "object destructuring loader write",
+      'import { createRequire } from "node:module"; function build(anchor) { let require = createRequire(anchor); ({ nested: [require] } = opaqueLoaders()); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "iteration loader write",
+      'import { createRequire } from "node:module"; function build(anchor) { let require = createRequire(anchor); for (require of [createRequire(import.meta.url)]) { require("root-runtime"); } }',
+      ["root-runtime"],
+    ],
+    [
+      "destructuring anchor default",
+      'import { createRequire } from "node:module"; function build(opts) { const { anchor = import.meta.url } = opts; const require = createRequire(anchor); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "function wrapper remains unknown",
+      'import { createRequire as make } from "node:module"; const load = make(import.meta.url); function require(name) { return load(name); } require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "unknown supplied loader with caller default",
+      'import { createRequire } from "node:module"; function build(root, loaders) { const [require = createRequire(root)] = loaders; require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "mutated caller member",
+      'import { createRequire } from "node:module"; function build(options) { options.filename = import.meta.url; const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "mutated caller member through alias",
+      'import { createRequire } from "node:module"; function build(options) { const alias = options; alias.filename = import.meta.url; const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "mutated caller URL",
+      'import { createRequire } from "node:module"; function build(location) { location.href = import.meta.url; const require = createRequire(location); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "compound caller location write",
+      'import { createRequire } from "node:module"; function build(location) { location += import.meta.url; const require = createRequire(location); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "compound caller member write",
+      'import { createRequire } from "node:module"; function build(options) { options.filename += import.meta.url; const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "initialized CommonJS require before assignment",
+      'require("root-runtime"); var require = process.getBuiltinModule("module").createRequire(process.cwd() + "/package.json");',
+      ["root-runtime"],
+    ],
+    [
+      "mutable caller var remains conservative",
+      'import { createRequire } from "node:module"; function build(root) { var require = createRequire(root); require("plugin-build-tool"); }',
+      ["plugin-build-tool"],
+    ],
+    ["parenthesized require specifier", 'require(("root-runtime"));', ["root-runtime"]],
+    ["parenthesized dynamic import specifier", 'import(("root-runtime"));', ["root-runtime"]],
+    [
+      "shorthand loader write",
+      'import { createRequire } from "node:module"; function build(anchor) { let require = createRequire(anchor); ({ require } = { require: createRequire(import.meta.url) }); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "opaque input normalization",
+      'import { createRequire } from "node:module"; function build(options) { Object.assign(options, { filename: import.meta.url }); const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "opaque input before scalar normalization",
+      'import { createRequire } from "node:module"; import path from "node:path"; function build(options) { Object.assign(options, { filename: import.meta.url }); const root = path.resolve(options.filename); const require = createRequire(root); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "normalized paths passed to helpers",
+      'import { createRequire } from "node:module"; import path from "node:path"; function build(options) { const root = path.resolve(options.filename); consume(root); const require = createRequire(root); require("plugin-build-tool"); }',
+      [],
+    ],
+    [
+      "opaque caller receiver",
+      'import { createRequire } from "node:module"; function build(options) { options.normalize(); const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "opaque constructor input",
+      'import { createRequire } from "node:module"; function build(options) { new Mutator(options); const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "opaque container input alias",
+      'import { createRequire } from "node:module"; function build(options) { const wrapper = { options }; normalize(wrapper); const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "callback input owns its escape",
+      'import { createRequire } from "node:module"; import path from "node:path"; function build(options) { const root = path.resolve(options.filename); files.forEach(file => normalize(file.path)); const require = createRequire(root); require("plugin-build-tool"); }',
+      [],
+    ],
+    [
+      "opaque projected input default",
+      'import { createRequire } from "node:module"; function build(options) { let alias; ({ alias = options } = {}); normalize(alias); const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "opaque iterable input alias",
+      'import { createRequire } from "node:module"; function build(options) { let alias; for (alias of [options]) normalize(alias); const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "raw caller after loop remains conservative",
+      'import { createRequire } from "node:module"; function build(options) { for (const key in options) consume(key); const require = createRequire(options.filename); require("plugin-build-tool"); }',
+      ["plugin-build-tool"],
+    ],
+    [
+      "opaque nested input projection",
+      'import { createRequire } from "node:module"; function build(options) { const { nested: { alias } } = options; normalize(alias); const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "nested parameter default remains unknown",
+      'import { createRequire } from "node:module"; function build({ nested: { filename } = { filename: import.meta.url } }) { const require = createRequire(filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "locally changed cwd",
+      'import { createRequire } from "node:module"; import path from "node:path"; import { fileURLToPath } from "node:url"; process.chdir(path.dirname(fileURLToPath(import.meta.url))); const require = createRequire(path.resolve("bridge.cjs")); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "aliased cwd mutation",
+      'import { createRequire } from "node:module"; import path from "node:path"; const { chdir: move } = process; move(opaquePath()); const require = createRequire(path.resolve("bridge.cjs")); require("root-runtime");',
+      ["root-runtime"],
+    ],
+    [
+      "raw caller after cwd mutation remains conservative",
+      'import { createRequire } from "node:module"; function build(root) { process.chdir(opaquePath()); const require = createRequire(root); require("plugin-build-tool"); }',
+      ["plugin-build-tool"],
+    ],
+    [
+      "binary coercion before snapshot",
+      'import { createRequire } from "node:module"; function build(options) { const unused = options + ""; const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "unary coercion before snapshot",
+      'import { createRequire } from "node:module"; function build(options) { const unused = +options; const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "extra factory getter argument",
+      'import { createRequire } from "node:module"; function build(location, options) { const require = createRequire(location, options.unused); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "destructured parameter remains conservative",
+      'import { createRequire } from "node:module"; function build(options, { unused }) { const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "raw declaration ends admission",
+      'import { createRequire } from "node:module"; function build(options) { const unused = options.unused; const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "template coercion before snapshot",
+      'import { createRequire } from "node:module"; function build(options) { const unused = `${options}`; const require = createRequire(options.filename); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "parameter iterator before snapshot",
+      'import { createRequire } from "node:module"; function build(options, [unused]) { const require = createRequire(options); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "spread before snapshot",
+      'import { createRequire } from "node:module"; function build(options) { const unused = [...options]; const require = createRequire(options); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "effectful parameter default before snapshot",
+      'import { createRequire } from "node:module"; import path from "node:path"; function build(options, ignored = Object.assign(options, { filename: import.meta.url })) { const root = path.resolve(options.filename); const require = createRequire(root); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "ignored initializer effect before snapshot",
+      'import { createRequire } from "node:module"; import path from "node:path"; function build(options) { const root = (normalize(options), path.resolve(options.filename)); const require = createRequire(root); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "ignored factory argument effect",
+      'import { createRequire } from "node:module"; function build(location) { const require = createRequire(location, location.href = import.meta.url); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "captured mutable input cannot restart prefix",
+      'import { createRequire } from "node:module"; import path from "node:path"; function outer(options) { Object.assign(options, { filename: import.meta.url }); return function build() { const root = path.resolve(options.filename); const require = createRequire(root); require("root-runtime"); }; }',
+      ["root-runtime"],
+    ],
+    [
+      "captured immutable snapshot survives effects",
+      'import { createRequire } from "node:module"; import path from "node:path"; function outer(options) { const root = path.resolve(options.filename); normalize(options); return function build() { const require = createRequire(root); require("plugin-build-tool"); }; }',
+      [],
+    ],
+    [
+      "pending normalization is not a string snapshot",
+      'import { createRequire } from "node:module"; import fs from "node:fs/promises"; function build(options) { const pending = fs.realpath(options.filename); normalize(pending); return (async () => { const root = await pending; const require = createRequire(root); require("root-runtime"); })(); }',
+      ["root-runtime"],
+    ],
+    [
+      "awaited input ends admission",
+      'import { createRequire } from "node:module"; async function build(options) { const unused = await options; const require = createRequire(options); require("root-runtime"); }',
+      ["root-runtime"],
+    ],
+    [
+      "compiled control UI builder ordering",
+      'import { createRequire } from "node:module"; import fs from "node:fs/promises"; import path from "node:path"; async function build(params) { const rootDir = await fs.realpath(params.rootDir); const entry = await fs.realpath(path.resolve(rootDir, params.source)); if (!entry) throw new Error("missing entry"); const require = createRequire(path.join(rootDir, "package.json")); require("plugin-build-tool"); }',
+      [],
+    ],
+    [
+      "compiled pack builder ordering",
+      'import { createRequire } from "node:module"; import fs from "node:fs/promises"; import path from "node:path"; async function build(opts) { const rootDir = await fs.realpath(path.resolve(opts.root ?? process.cwd())); const valid = validate(rootDir); if (!valid) throw new Error("invalid"); createRequire(path.join(rootDir, "package.json"))("plugin-build-tool"); }',
+      [],
+    ],
+    [
+      "namespace root loader",
+      'import * as module from "node:module"; const load = module.createRequire(import.meta.url); load("root-runtime");',
+      ["root-runtime"],
+    ],
+  ])("follows lexical require ownership: %s", (_name, source, dependencies) => {
+    const packageRoot = makeInstalledPackageRoot();
+    try {
+      writePackageFile(packageRoot, "package.json", { dependencies: {} });
+      mkdirSync(join(packageRoot, "dist"), { recursive: true });
+      writeFileSync(join(packageRoot, "dist", "runtime.js"), source);
+      expect(collectInstalledRootDependencyManifestErrors(packageRoot)).toEqual(
+        dependencies.map(
+          (name) =>
+            `installed package root is missing declared runtime dependency '${name}' for dist importers: runtime.js. Add it to package.json dependencies/optionalDependencies.`,
+        ),
+      );
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
   it("ignores import-like text inside comments", () => {
     const packageRoot = makeInstalledPackageRoot();
 


### PR DESCRIPTION
The pre/postpublish root dependency check rejects a correctly packaged plugin builder because it treats every call named `require` as a core import. The Control UI builder anchors Node's `createRequire` to the caller plugin's `package.json`; its build tool belongs to that plugin. The existing checker limitation became visible when that builder was added in #134943.

Replace the name-only walk with lexical loader ownership using the existing TypeScript dependency, retaining strict Acorn syntax validation. Module-relative loaders and their known aliases count as root imports. Caller ownership is admitted only through a closed entry declaration prefix with plain parameters and supported Node normalization/factory calls; only immutable path and loader snapshots survive subsequent effects. Unsupported bindings, raw coercion, unknown calls and other unproved shapes retain the conservative literal-`require` check. This does not evaluate arbitrary paths or helper implementations.

The source change is release tooling only: +599 net tooling lines, +447 test lines, and no product runtime or dependency changes. The growth supplies the lexical owner boundary absent from the old walker, replacing its 66 lines; it handles aliases and unknown states without plugin-specific exemptions or an object mutation graph. Public collector tests cover both emitted builder orderings, root aliases, shadowing/reassignment/defaults, unknown loaders, and conservative effects. Existing manifest, syntax, comments/strings, bounds and package-exclusion coverage remains.

The full 146-test owner suite and complete changed-file gates passed on the main-derived candidate based on `805c6fb9cf2d4ec921603b95418ee5e21dbc9fde`, using [this Testbox run](https://github.com/openclaw/openclaw/actions/runs/33951447781). Against identical extracted bytes from the [failed release validation](https://github.com/openclaw/openclaw/actions/runs/33936309800), the old checker rejects only esbuild and the new checker passes. Core artifact SHA-256: `57417cd2fced0ab19c6d4802184559a2ed47122bbd9859283f49c69850f607bb`; source `d3ebbd01d60ed316f2cefd7734f911039969ceb6`, tooling `2329399cf6a9a2ca0c19d6c620b713a2768f9125`.

The dependency comparison removes only `esbuild` from `plugins-authoring-command-D5654nve.js` and adds seven recognized root-loader importer edges: roots 46 → 47 and importer edges 370 → 376. Paired extracted-tree scans took 14.075 s / 2,029,188 KB peak RSS before and 29.656 s / 2,877,400 KB after; existing scan limits remain unchanged.

Separately, the previously completed installed compiled-plugin flow used the exact matching root + AI tarballs, with no root esbuild: init, build, validate, build --check, and pack all passed with plugin-owned build tools. Those runtime artifacts are unchanged by this scanner repair. Fresh managed review found no actionable P0–P2 findings.
