### PR TITLE
perf(sessions): stream lifecycle marker scans

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts
@@ -14,6 +14,7 @@ import {
   loadTranscriptEvents,
   replaceSessionEntry,
 } from "./session-accessor.js";
+import { planSessionLifecycleArtifactCleanup } from "./session-accessor.sqlite-lifecycle-state.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 
@@ -82,6 +83,58 @@ describe("SQLite lifecycle cleanup reclamation", () => {
     }
     expect(workersStarted).toBe(0);
     expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject(entry);
+  });
+
+  it("rejects cleanup planning when a native scan fails after an orphan marker", async () => {
+    const sessionKey = "agent:main:marker-scan-history";
+    const sessionId = "marker-scan-history";
+    const events = [
+      { type: "metadata", runId: "cleanup-race-marker" },
+      { type: "metadata", runId: "failing-tail" },
+    ];
+    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: 1 });
+    await replaceTranscriptEvents({ sessionKey, sessionId, storePath }, events);
+    await replaceSessionEntry(
+      { sessionKey, storePath },
+      { sessionId: "marker-scan-current", updatedAt: Date.now() },
+    );
+    const database = openDatabase(storePath);
+    const failure = new Error("late native transcript read failure");
+    const observed: unknown[] = [];
+    database.db.function("cleanup_marker_event", (eventJson) => {
+      observed.push(eventJson);
+      if (eventJson === JSON.stringify(events[1])) {
+        throw failure;
+      }
+      return eventJson;
+    });
+    // A connection-local view fails during native stepping without changing the saved schema.
+    database.db.exec(`CREATE TEMP VIEW transcript_events AS
+      SELECT session_id, seq, cleanup_marker_event(event_json) AS event_json, created_at
+      FROM main.transcript_events`);
+    let caught: unknown;
+    try {
+      planSessionLifecycleArtifactCleanup(database, {
+        archiveRemovedEntryTranscripts: false,
+        archiveDirectory: path.dirname(storePath),
+        sessionKeySegmentPrefix: "unrelated-prefix-",
+        transcriptContentMarker: "cleanup-race-marker",
+        orphanTranscriptMinAgeMs: 0,
+        nowMs: Date.now(),
+      });
+    } catch (error) {
+      caught = error;
+    } finally {
+      database.db.exec("DROP VIEW temp.transcript_events");
+    }
+    expect(caught).toBe(failure);
+    expect(observed).toContain(JSON.stringify(events[0]));
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      sessionId: "marker-scan-current",
+    });
+    await expect(loadTranscriptEvents({ sessionKey, sessionId, storePath })).resolves.toEqual(
+      events,
+    );
   });
 
   it("reclaims orphan-only history and republishes pending archives on an empty pass", async () => {

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -149,15 +149,20 @@ function sqliteTranscriptStateHasMarker(params: {
   transcriptContentMarker: string;
 }): boolean {
   const db = getSessionKysely(params.database.db);
-  const rows = executeSqliteQuerySync(
+  const rows = iterateSqliteQuerySync(
     params.database.db,
     db
       .selectFrom("transcript_events")
       .select("event_json")
       .where("session_id", "=", params.sessionId)
       .orderBy("seq", "asc"),
-  ).rows;
-  return rows.some((row) => row.event_json.includes(params.transcriptContentMarker));
+  );
+  // Consume every row so late SQLite errors still abort cleanup planning.
+  let hasMarker = false;
+  for (const row of rows) {
+    hasMarker ||= row.event_json.includes(params.transcriptContentMarker);
+  }
+  return hasMarker;
 }
 
 /** Session ids protected by live node state. */


### PR DESCRIPTION
## What Problem This Solves

Orphan transcript cleanup materialized every event payload before looking for its lifecycle marker. Large histories therefore retained a full extra array of transcript strings during planning.

## Why This Change Was Made

The existing lifecycle owner now folds the same ordered Kysely query through its synchronous iterator. JavaScript substring matching is unchanged, and the iterator is fully consumed even after a match: a later SQLite error must still abort planning. No SQL string matching, early termination, new cache or query abstraction is introduced.

## User Impact

Cleanup retains less transient payload memory while selecting and archiving the same histories. Schema, stored bytes, retention, ownership, snapshot validation and archive publication remain unchanged.

## Evidence

- 64 relevant test cases passed, plus the receiving four-case reclamation suite after relocating the new test. Full changed-file gate passed. The late-native-error regression also passes on the baseline, documenting behavior that the optimization must preserve.
- Fourteen actual-owner baseline/candidate scenarios matched, including Unicode/NUL/literal markers, a native error after an early match, and second-connection inserts during the scan. The changed owner is imported directly, without substituting a proposed function in memory.
- A 96-row, 100,663,314-byte fixture scanned every row in both versions. Median peak heap growth fell from 102,164,480 to 66,465,144 bytes; a separate forced-GC observation at the last row fell from 101,692,712 to 4,163,608 retained bytes. This is a memory improvement; no latency improvement is claimed.
- The public SDK cleanup flow archived exactly 2,097,260 decoded bytes, retained the current and unmatched histories, passed native reopen/integrity checks and produced an empty second cleanup. Synthetic state and staging files were removed.
- Five independent Codex P0–P2 review passes found no actionable findings. Full source, dependencies, native harnesses and receipts were supplied and directly inspected by the acting maintainer.

Production delta: +8/-3, net +5 lines for the streaming fold and its full-scan invariant. Tests: +53 lines. The first changed gate caught the existing cleanup-race test file's size limit; the regression was moved to the smaller reclamation suite and the complete gate passed. No full build is claimed for this private, import-neutral fold; the real source Worker/archive flow was exercised.
