### PR TITLE
refactor(sessions): share typed collaboration identity reads

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2647,11 +2647,10 @@ src/config/sessions/session-accessor.transcript-range.ts	3
 src/config/sessions/session-accessor.transcript-turn.ts	1
 src/config/sessions/session-entry-json.ts	1
 src/config/sessions/session-reset-boundary-event.ts	5
-src/config/sessions/session-sharing-store.ts	2
 src/config/sessions/session-snapshot-merge.ts	26
 src/config/sessions/session-sqlite-target.ts	3
 src/config/sessions/session-store-config.ts	2
-src/config/sessions/session-suggestion-store.ts	4
+src/config/sessions/session-suggestion-store.ts	2
 src/config/sessions/session-transcript-projection-rebuild.ts	6
 src/config/sessions/session-transcript-reconcile.worker.ts	1
 src/config/sessions/session-transcript-search.ts	1

--- a/src/config/sessions/session-accessor.sqlite-entry-identity.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-identity.ts
@@ -1,0 +1,28 @@
+import { asOptionalRecord, readStringField } from "@openclaw/normalization-core/record-coerce";
+import { executeSqliteQueryTakeFirstSync } from "../../infra/kysely-sync.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
+
+// Collaboration guards need only the node/entry link, without full entry normalization.
+// Decode raw JSON in JS so malformed JSON and duplicate keys retain their existing meaning.
+export function readSessionEntryInstanceId(
+  database: Pick<OpenClawAgentDatabase, "db">,
+  sessionKey: string,
+): string | undefined {
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    getSessionKysely(database.db)
+      .selectFrom("session_nodes")
+      .select(["current_session_id", "entry_json"])
+      .where("session_key", "=", sessionKey),
+  );
+  if (!row?.entry_json) {
+    return undefined;
+  }
+  try {
+    const sessionId = readStringField(asOptionalRecord(JSON.parse(row.entry_json)), "sessionId");
+    return sessionId === row.current_session_id ? sessionId : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/config/sessions/session-sharing-store.test.ts
+++ b/src/config/sessions/session-sharing-store.test.ts
@@ -140,6 +140,48 @@ describe("session sharing store", () => {
     });
   });
 
+  it.each([
+    ["identity without timestamps", "session-a", '{"sessionId":"session-a"}', true],
+    ["empty identity", "", '{"sessionId":""}', true],
+    ["opaque identity", " a\0🦞 ", JSON.stringify({ sessionId: " a\0🦞 " }), true],
+    ["mismatched node", "session-b", '{"sessionId":"session-a"}', false],
+    ["malformed JSON", "session-a", "{", false],
+    ["array JSON", "session-a", '[{"sessionId":"session-a"}]', false],
+    ["last duplicate wins", "session-a", '{"sessionId":false,"sessionId":"session-a"}', true],
+    ["last duplicate invalid", "session-a", '{"sessionId":"session-a","sessionId":false}', false],
+    ["literal NUL", "session-a", '{"sessionId":"session-a"}\0', false],
+  ] as const)(
+    "preserves membership identity checks for %s",
+    async (_, sessionId, entryJson, valid) => {
+      await withTestDir({ prefix: "openclaw-session-sharing-identity-" }, async (dir) => {
+        const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+        const scope = { agentId: "main", env, sessionKey: "agent:main:main" };
+        await upsertSessionEntryCore(scope, { sessionId: "session-a", updatedAt: 1 });
+        addSessionMember(scope, { identityId: "existing", addedBy: "owner", addedAt: 2 });
+        const database = openOpenClawAgentDatabase({ agentId: "main", env });
+        database.db
+          .prepare(
+            "UPDATE session_nodes SET current_session_id = ?, entry_json = ? WHERE session_key = ?",
+          )
+          .run(sessionId, entryJson, scope.sessionKey);
+
+        const add = () =>
+          addSessionMember(scope, { identityId: "new", addedBy: "owner", addedAt: 3 });
+        const remove = () => removeSessionMember(scope, "existing");
+        if (valid) {
+          expect(add().inserted).toBe(true);
+          expect(remove()).toEqual({ identityId: "existing", addedBy: "owner", addedAt: 2 });
+        } else {
+          expect(add).toThrow("session changed before sharing mutation");
+          expect(remove).toThrow("session changed before sharing mutation");
+          expect(listSessionMembers(scope)).toEqual([
+            { identityId: "existing", addedBy: "owner", addedAt: 2 },
+          ]);
+        }
+      });
+    },
+  );
+
   it("drops members when the session instance is replaced under the same key", async () => {
     await withTestDir({ prefix: "openclaw-session-sharing-recreate-" }, async (dir) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: dir };

--- a/src/config/sessions/session-sharing-store.ts
+++ b/src/config/sessions/session-sharing-store.ts
@@ -11,6 +11,7 @@ import {
   type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
 import type { SessionAccessScope } from "./session-accessor.sqlite-contract.js";
+import { readSessionEntryInstanceId } from "./session-accessor.sqlite-entry-identity.js";
 import { resolveSqliteScope, toDatabaseOptions } from "./session-accessor.sqlite-scope.js";
 
 type SessionMemberDatabase = Pick<OpenClawAgentKyselyDatabase, "session_members">;
@@ -127,26 +128,10 @@ function assertAuthorizedSessionInstance(
   sessionKey: string,
   expectedSessionId: string | undefined,
 ): void {
-  const row =
-    database.db /* sqlite-allow-raw: sync TOCTOU re-read of canonical entry identity inside a write transaction; Kysely async execution is forbidden in synchronous commit sections */
-      .prepare("SELECT current_session_id, entry_json FROM session_nodes WHERE session_key = ?")
-      .get(sessionKey) as { current_session_id?: string; entry_json?: string } | undefined;
-  let entrySessionId: string | undefined;
-  try {
-    const entry = row?.entry_json ? (JSON.parse(row.entry_json) as unknown) : undefined;
-    const candidate =
-      entry && typeof entry === "object" && !Array.isArray(entry)
-        ? (entry as { sessionId?: unknown }).sessionId
-        : undefined;
-    entrySessionId = typeof candidate === "string" ? candidate : undefined;
-  } catch {
-    entrySessionId = undefined;
-  }
+  const sessionId = readSessionEntryInstanceId(database, sessionKey);
   if (
-    !row ||
-    entrySessionId === undefined ||
-    row.current_session_id !== entrySessionId ||
-    (expectedSessionId !== undefined && entrySessionId !== expectedSessionId)
+    sessionId === undefined ||
+    (expectedSessionId !== undefined && sessionId !== expectedSessionId)
   ) {
     throw new Error("session changed before sharing mutation");
   }

--- a/src/config/sessions/session-suggestion-store.test.ts
+++ b/src/config/sessions/session-suggestion-store.test.ts
@@ -4,12 +4,14 @@ import {
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
+import { SessionWorkStartInvalidatedError } from "./lifecycle.js";
 import { upsertSessionEntryCore } from "./session-accessor.js";
 import {
   addSessionSuggestion,
   claimSessionSuggestionDispatch,
   finalizeSessionSuggestionClaim,
   listSessionSuggestions,
+  releaseSessionSuggestionDispatch,
   SESSION_SUGGESTION_DISPATCH_CLAIM_TTL_MS,
 } from "./session-suggestion-store.js";
 
@@ -129,6 +131,55 @@ describe("session suggestion store", () => {
 
       await upsertSessionEntryCore(scope, { sessionId: "session-b", updatedAt: 2 });
       expect(listSessionSuggestions(scope)).toEqual([]);
+    });
+  });
+
+  it("skips suggestion identity checks only when the expected instance is omitted", async () => {
+    await withTestDir({ prefix: "openclaw-session-suggestions-identity-" }, async (dir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+      const scope = { agentId: "main", env, sessionKey: "agent:main:main" };
+      await upsertSessionEntryCore(scope, { sessionId: "session-a", updatedAt: 1 });
+      const database = openOpenClawAgentDatabase({ agentId: "main", env });
+      database.db
+        .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+        .run("{", scope.sessionKey);
+      const mutations = [
+        (expectedSessionId?: string) =>
+          addSessionSuggestion(scope, {
+            id: "suggestion",
+            authorId: "author",
+            text: "idea",
+            expectedSessionId,
+          }),
+        (expectedSessionId?: string) =>
+          claimSessionSuggestionDispatch(scope, {
+            id: "suggestion",
+            resolution: "edit",
+            expectedSessionId,
+          }),
+        (expectedSessionId?: string) =>
+          releaseSessionSuggestionDispatch(scope, {
+            id: "suggestion",
+            token: "other-token",
+            expectedSessionId,
+          }),
+        (expectedSessionId?: string) =>
+          finalizeSessionSuggestionClaim(scope, {
+            id: "suggestion",
+            token: "other-token",
+            state: "accepted",
+            expectedSessionId,
+          }),
+      ];
+      for (const mutate of mutations) {
+        for (const expectedSessionId of ["session-a", ""]) {
+          expect(() => mutate(expectedSessionId)).toThrow(SessionWorkStartInvalidatedError);
+          expect(() => mutate(expectedSessionId)).toThrow(
+            "session changed before suggestion mutation",
+          );
+        }
+        expect(() => mutate()).not.toThrow();
+      }
     });
   });
 

--- a/src/config/sessions/session-suggestion-store.ts
+++ b/src/config/sessions/session-suggestion-store.ts
@@ -13,6 +13,7 @@ import {
 } from "../../state/openclaw-agent-db.js";
 import { SessionWorkStartInvalidatedError } from "./lifecycle.js";
 import type { SessionAccessScope } from "./session-accessor.sqlite-contract.js";
+import { readSessionEntryInstanceId } from "./session-accessor.sqlite-entry-identity.js";
 import { resolveSqliteScope, toDatabaseOptions } from "./session-accessor.sqlite-scope.js";
 
 type SuggestionDatabase = Pick<OpenClawAgentKyselyDatabase, "session_suggestions">;
@@ -68,27 +69,7 @@ function assertSessionInstance(
   if (expectedSessionId === undefined) {
     return;
   }
-  const row =
-    database.db /* sqlite-allow-raw: sync session-instance check inside the suggestion write transaction */
-      .prepare("SELECT current_session_id, entry_json FROM session_nodes WHERE session_key = ?")
-      .get(sessionKey) as { current_session_id?: string; entry_json?: string } | undefined;
-  let entrySessionId: string | undefined;
-  try {
-    const entry = row?.entry_json ? (JSON.parse(row.entry_json) as unknown) : undefined;
-    const candidate =
-      entry && typeof entry === "object" && !Array.isArray(entry)
-        ? (entry as { sessionId?: unknown }).sessionId
-        : undefined;
-    entrySessionId = typeof candidate === "string" ? candidate : undefined;
-  } catch {
-    entrySessionId = undefined;
-  }
-  if (
-    !row ||
-    entrySessionId === undefined ||
-    row.current_session_id !== entrySessionId ||
-    entrySessionId !== expectedSessionId
-  ) {
+  if (readSessionEntryInstanceId(database, sessionKey) !== expectedSessionId) {
     throw new SessionWorkStartInvalidatedError("session changed before suggestion mutation");
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Session membership and suggestion mutations each maintained their own raw SQL identity query and JSON decoder. The duplicated checks sit at the transaction boundary that protects against reset or replacement after authorization.

## Why This Change Was Made

Both owners now use one internal, schema-typed Kysely projection of the canonical node and entry identities. The shared reader keeps JavaScript JSON parsing and string comparison; each caller retains its own admission rules and error type. Membership still requires a real matching entry when the expected ID is omitted. Suggestions still bypass the identity check only for a strictly undefined expected ID. The guards remain inside their original synchronous write transactions.

## User Impact

No intended behavior change. Stale mutations remain rejected, empty or opaque string identities retain their existing meaning, and sharing/suggestion payloads survive restart unchanged. No schema, API, authorization, retention or claim-policy changes are introduced.

## Evidence

- 59 tests passed across both stores and both Gateway handlers. Ten additional contract cases also passed against the original production code. The full changed-file gate and qaRuntime build passed.
- Actual exported store owners produced 1,824 byte-identical baseline/candidate case results across all six mutation APIs. Six warm-cache, second-connection replacement cases preserved stale rejection, outer transaction rollback, fresh-ID success and placeholder rejection. A separate process read back identical persisted rows with integrity_check=ok and no foreign-key errors.
- A real built Gateway passed 23 RPCs across restart using the normal signed TUI client and synthetic profiles. Membership add/remove/idempotence and suggestion add/dismiss/edit/pending results matched saved SQLite rows. Three replacements immediately before BEGIN rejected stale mutations without changing membership or suggestion rows. All 15 observed identity reads occurred inside transactions. No provider dispatch ran; owned processes, listener and state were removed.
- For each mutation path, 16 identity reads prepared two native statements instead of sixteen through the existing owner-enabled cache. Row and payload materialization are unchanged; no latency claim is made.
- Four independent Codex P0–P2 review passes found no actionable findings. The acting maintainer inspected the full changed owners, Gateway callers, coercion/executor contracts, native harnesses and Gateway receipts.

Production delta: +34/-40, net -6 lines; tests +93; assertion ratchet net -1. Seventeen other owner functions remain byte-identical. Two proof-fixture corrections are retained in the evidence: generated UUID normalization and replacing the intentionally unprofiled CLI connection with the normal signed TUI connection. Neither required a production change. Resolved-suggestion pruning is being audited separately.
