### PR TITLE
fix(test): observe bounded Gateway client cleanup

### DIFF
--- a/src/gateway/test-helpers.acquisition.test.ts
+++ b/src/gateway/test-helpers.acquisition.test.ts
@@ -33,6 +33,7 @@ type PeerBehavior =
   | "no challenge"
   | "no response"
   | "reject auth"
+  | "reject auth without close"
   | "transport error"
   | "upgrade then transport error"
   | "hello then transport error"
@@ -59,6 +60,7 @@ async function withAcquisitionPeer(
   const errors: Error[] = [];
   const unownedErrors: Error[] = [];
   const transportFailure = createDeferred<Error>();
+  const rejectAuth = behavior === "reject auth" || behavior === "reject auth without close";
   // Observe the real dependency; keep otherwise-unhandled errors local to this case.
   // Counting the remaining listeners makes a removed owner handler observable.
   vi.doMock("ws", async (importOriginal) => {
@@ -138,17 +140,24 @@ async function withAcquisitionPeer(
             JSON.stringify({
               type: "res",
               id: frame.id,
-              ok: behavior !== "reject auth",
-              ...(behavior === "reject auth"
+              ok: !rejectAuth,
+              ...(rejectAuth
                 ? { error: { code: "UNAUTHORIZED", message: "synthetic auth rejection" } }
                 : { payload: buildMinimalGatewayHelloOkPayload() }),
             }),
           );
+          if (behavior === "reject auth without close") {
+            ws.pause();
+          }
         }
       });
     });
   });
   const close = async () => {
+    // Release a withheld close handshake only after acquisition has entered server cleanup.
+    for (const peer of wss.clients) {
+      peer.resume();
+    }
     if (server.listening) {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
@@ -223,7 +232,7 @@ function mockPeerGateway(peer: AcquisitionPeer, close = peer.close) {
 
 type CompositeAcquisitionCase = {
   helper: "raw" | "GatewayClient";
-  failure: "construction" | "open" | "authentication";
+  failure: "construction" | "open" | "authentication" | "authentication without close";
   shutdown: "joined" | "rejected";
 };
 
@@ -240,11 +249,13 @@ export async function verifyCompositeAcquisition({
     },
     async (state) => {
       const behavior =
-        failure === "open"
-          ? "reject upgrade"
-          : failure === "authentication"
-            ? "reject auth"
-            : "reply";
+        failure === "authentication without close"
+          ? "reject auth without close"
+          : failure === "open"
+            ? "reject upgrade"
+            : failure === "authentication"
+              ? "reject auth"
+              : "reply";
       await withAcquisitionPeer(behavior, async (peer) => {
         const closing = createDeferred();
         const release = createDeferred();
@@ -260,6 +271,16 @@ export async function verifyCompositeAcquisition({
         const { startServerWithClient, startConnectedServerWithClient } =
           await import("./test-helpers.server.js");
         const { startGatewayWithClient } = await import("./test-helpers.e2e.js");
+        const { GatewayClient } = await import("./client.js");
+        // oxlint-disable-next-line typescript/unbound-method -- The observer calls the original on its acquired client.
+        const stopAndWait = GatewayClient.prototype.stopAndWait;
+        let clientStopSettled = false;
+        const stopSpy = vi
+          .spyOn(GatewayClient.prototype, "stopAndWait")
+          .mockImplementation(async function (this: InstanceType<typeof GatewayClient>, options) {
+            await stopAndWait.call(this, options);
+            clientStopSettled = true;
+          });
         const selector = helper === "raw" ? "OPENCLAW_GATEWAY_TOKEN" : "OPENCLAW_GATEWAY_PORT";
         const ownedSelector = helper === "raw" ? "synthetic-owned-token" : String(peer.port);
         const previousSelector = process.env[selector];
@@ -283,7 +304,13 @@ export async function verifyCompositeAcquisition({
           expect(first).toBe("closing");
           expect(process.env[selector]).toBe(ownedSelector);
           expect(peer.isListening()).toBe(true);
-          expect(peer.clients.every((client) => peer.closed.has(client))).toBe(true);
+          // GatewayClient owns a bounded stop; raw helpers promise the transport close event.
+          if (helper === "GatewayClient") {
+            expect(peer.clients).toHaveLength(1);
+            expect(clientStopSettled).toBe(true);
+          } else {
+            expect(peer.clients.every((client) => peer.closed.has(client))).toBe(true);
+          }
           release.resolve();
           const result = await acquisition;
           const originalError = result instanceof AggregateError ? result.errors[0] : result;
@@ -309,6 +336,7 @@ export async function verifyCompositeAcquisition({
         } finally {
           release.resolve();
           await acquisition;
+          stopSpy.mockRestore();
         }
       });
     },
@@ -572,6 +600,8 @@ describe("raw Gateway helper acquisition ownership", () => {
     { helper: "raw", failure: "authentication", shutdown: "rejected" },
     { helper: "GatewayClient", failure: "authentication", shutdown: "joined" },
     { helper: "GatewayClient", failure: "authentication", shutdown: "rejected" },
+    { helper: "GatewayClient", failure: "authentication without close", shutdown: "joined" },
+    { helper: "GatewayClient", failure: "authentication without close", shutdown: "rejected" },
   ] as const)(
     "$helper retains server ownership after $failure failure and $shutdown shutdown",
     async (scenario, context) => {


### PR DESCRIPTION
## What Problem This Solves

An acquisition-lifetime test incorrectly required a raw socket close event after the client had already completed its supported bounded stop.

## Why This Change Was Made

Observe the client’s actual stop promise, retaining raw-close assertions for raw helpers. Add real-peer cases that withhold the close handshake while preserving shutdown, environment, and error checks.

## User Impact

No production behavior, timeout, permission, or protocol changes. Tests accept supported termination while still rejecting cleanup that releases too early.

## Evidence

A real peer reproduced both original assertion failures with unchanged production code. All four corrected client cases passed, including withheld-close cases. Removing the acquisition helper’s await made all four fail as intended; the mutation was removed. The complete acquisition and real-Gateway environment suites passed 41 tests. Focused lint and formatting passed.

Related: #138813. Verification was AI-assisted.
