### PR TITLE
fix: reduce pauses during plugin session cleanup

### DIFF
--- a/src/config/sessions/session-accessor.lifecycle.ts
+++ b/src/config/sessions/session-accessor.lifecycle.ts
@@ -294,9 +294,12 @@ export async function cleanupPluginHostSessionStore(
   }
   const now = Date.now();
   let cleared = 0;
+  // Cleanup selectors use metadata; saved prompts are reserved from plugin slots.
+  // The patch owner rereads each selected full entry before changing it.
   for (const { entry, sessionKey } of listSessionEntriesCore({
     agentId: params.agentId,
     storePath: params.storePath,
+    projection: "list",
   })) {
     if (isLockedHarnessSessionOwnedByPlugin(entry, params.preserveLockedHarnessIds)) {
       continue;

--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -14,6 +14,7 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import {
   appendTranscriptEventSync,
   appendTranscriptMessage,
+  cleanupPluginHostSessionStore,
   listSessionEntriesCore,
   listSessionTranscriptInstances,
   loadSessionEntry,
@@ -122,6 +123,61 @@ function createSessionScope(label: string) {
 }
 
 describe("SQLite session entry cache", () => {
+  it.each(["plugin-owned-state", "promoted-slots"] as const)(
+    "scans plugin cleanup metadata without decoding saved prompts (%s)",
+    async (mode) => {
+      const scope = createSessionScope("plugin-cleanup");
+      const siblingScope = { ...scope, sessionKey: "agent:main:plugin-cleanup-sibling" };
+      const skillsSnapshot = { prompt: "unneeded cleanup prompt".repeat(4096), skills: [] };
+      const systemPromptReport = {
+        source: "run" as const,
+        generatedAt: 1,
+        systemPrompt: { chars: 1, projectContextChars: 0, nonProjectContextChars: 1 },
+        injectedWorkspaceFiles: [],
+        skills: { promptChars: 0, entries: [] },
+        tools: { listChars: 0, schemaChars: 0, entries: [] },
+      };
+      const entry = {
+        sessionId: "plugin-cleanup",
+        updatedAt: 1,
+        skillsSnapshot,
+        systemPromptReport,
+        pluginExtensions: { fixture: { state: { active: true } } },
+        pluginExtensionSlotKeys: { fixture: { state: "fixtureState" } },
+        fixtureState: { active: true },
+      };
+      await upsertSessionEntryCore(scope, entry);
+      await upsertSessionEntryCore(siblingScope, { ...entry, sessionId: "plugin-cleanup-sibling" });
+      const siblingBefore = loadSessionEntry(siblingScope);
+      expect(siblingBefore).toBeDefined();
+      const database = openOpenClawAgentDatabase(scope);
+
+      parseSessionEntryCalls.mockClear();
+      expect(
+        await cleanupPluginHostSessionStore({
+          agentId: scope.agentId,
+          storePath: database.path,
+          sessionKey: scope.sessionKey,
+          pluginId: "fixture",
+          sessionEntrySlotKeys: new Set(["fixtureState"]),
+          mode,
+        }),
+      ).toBe(1);
+      expect(parseSessionEntryCalls).toHaveBeenCalled();
+      expect(
+        parseSessionEntryCalls.mock.calls.every(([json]) => Buffer.byteLength(json) < 1024),
+      ).toBe(true);
+      const cleaned = loadSessionEntry(scope);
+      expect(cleaned?.skillsSnapshot).toEqual(skillsSnapshot);
+      expect(cleaned?.systemPromptReport).toEqual(systemPromptReport);
+      expect(cleaned).not.toHaveProperty("fixtureState");
+      expect(cleaned?.pluginExtensions).toEqual(
+        mode === "promoted-slots" ? entry.pluginExtensions : undefined,
+      );
+      expect(loadSessionEntry(siblingScope)).toEqual(siblingBefore);
+    },
+  );
+
   it("omits saved prompts from usage inventory while preserving full transcript reads", async () => {
     const scope = createSessionScope("usage-inventory");
     const sessionId = "usage-inventory";

--- a/src/gateway/session-companion-context.test.ts
+++ b/src/gateway/session-companion-context.test.ts
@@ -6,6 +6,7 @@ import {
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
 import * as activeTranscriptEvents from "../config/sessions/session-accessor.sqlite-active-events.js";
+import { waitForSessionTranscriptIndexReconcilesInStateDir } from "../config/sessions/session-transcript-reconcile.js";
 import * as redact from "../logging/redact.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -18,7 +19,11 @@ import { notifyGatewaySessionReset } from "./session-reset-notifications.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-afterEach(() => {
+afterEach(async () => {
+  // Deferred reconciliation must settle before its databases and fixture directories close.
+  for (const stateDir of tempDirs.dirs) {
+    await waitForSessionTranscriptIndexReconcilesInStateDir(stateDir);
+  }
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
   vi.unstubAllEnvs();


### PR DESCRIPTION
Related: #138925, #138957

## What Problem This Solves

Resolves a problem where plugin session cleanup reparsed saved prompts for every row in the selected store, causing pauses even when cleanup matched no session. The cost grew with unrelated sessions and their saved prompt payloads.

## Why This Change Was Made

Use the existing metadata projection to select cleanup targets. It retains session identity, locked-harness fields, plugin state and promoted slots; the existing patch owner rereads each full target before writing. Both omitted prompt fields are reserved against plugin slot registration.

This preserves the generic key/runtime-ID matching and existing write behavior, with no schema, index, configuration, or cache-policy changes. Production change: one projection argument and two explanatory comment lines.

## User Impact

Warm cleanup spends less time blocking the Gateway on stores with saved prompts. Full target snapshots and unrelated sessions remain intact. The per-store metadata scan still scales with row count.

## Evidence

- Actual cleanup APIs on a synthetic SQLite store with 5,000 rows and an 8 KiB saved prompt per row: six alternating warm baseline/candidate pairs in one Node 24.20.0 process reduced median elapsed time from **131.4 ms to 42.2 ms**, median next-turn delay from **131.5 ms to 42.3 ms**, and median process CPU from **130.4 ms to 40.5 ms**. All no-op results and 5,000 preserved rows were verified. Cold observations varied; this is a warm synthetic result, not a production latency claim.
- Both new resource regression cases failed on the original full scan. The corrected tests exercise actual cleanup in both modes, bound scan payloads, preserve both full prompt snapshots, and compare the untouched sibling with its persisted pre-cleanup state.
- **94 focused tests passed** across `session-accessor.sqlite-data-version.test.ts`, `session-accessor.sqlite-excluded-rows.test.ts`, `host-hook-cleanup.session-store.test.ts`, and `contracts/session-entry-projection.contract.test.ts`. Coverage includes malformed, duplicate, deep and NUL-containing JSON, opaque Matrix/Signal keys, case-insensitive runtime IDs, locked harnesses, shared stores, and promoted-slot restart behavior.
- Independent P0–P2 review: no actionable findings. Formatting and whitespace checks passed.
- Local changed-scope validation passed its initial guards, then the declaration builder rejected the borrowed dependency installation before typechecking. Full declaration/type/lint validation is required from the exact-head CI environment; the local refusal is not reported as a passing typecheck. The source was mechanically rebased onto current main, including its updated Vitest patch, without changing the reviewed patch.

Separate follow-up: already-queued cleanup can outlive restored registry authority. That independently reproduced cancellation/commit-outcome issue is addressed in #138957; this projection change preserves its current ordering.

## CI Fixture Cleanup

The initial hosted run failed the desktop stream broker's final zero-interval assertion. Investigation independently reproduced a companion-context fixture leak: deferred transcript reconciliation reopened the fixture databases after teardown, recreated the removed state directory, and allocated two SQLite maintenance intervals. The fixture now joins the existing reconciliation owner for every tracked state directory before closing databases and removing files. Native before/after proof observed two late intervals versus none, with the removed directory remaining absent after the join.

The original CI interval was not captured, so this does not identify its producer. The broker assertion is unchanged; a fresh exact-head CI run remains required. The additional change is test cleanup only (+6/−1 lines). All 38 companion-context and desktop-broker tests passed locally on Node 24.20.0 with the preserved dependency installation; its older Vitest patch means this is focused component proof, not a replay of the original hosted dependency closure or execution order. Fresh independent P0–P2 review of the combined diff found no actionable issues.
