### PR TITLE
fix(discord): keep Components v2 text in thread starters

### DIFF
--- a/extensions/discord/src/monitor/message-forwarded.ts
+++ b/extensions/discord/src/monitor/message-forwarded.ts
@@ -52,7 +52,8 @@ export function resolveDiscordMessageStickers(message: Message): APIStickerItem[
 }
 
 export function resolveDiscordSnapshotStickers(snapshot: DiscordSnapshotMessage): APIStickerItem[] {
-  return normalizeDiscordStickerItems(snapshot.stickers ?? snapshot.sticker_items);
+  const stickers = normalizeDiscordStickerItems(snapshot.stickers);
+  return stickers.length > 0 ? stickers : normalizeDiscordStickerItems(snapshot.sticker_items);
 }
 
 export function hasDiscordMessageStickers(message: Message): boolean {

--- a/extensions/discord/src/monitor/message-text.ts
+++ b/extensions/discord/src/monitor/message-text.ts
@@ -13,7 +13,7 @@ import {
 } from "./message-forwarded.js";
 import { formatDiscordMediaText } from "./message-media.js";
 
-export function resolveDiscordEmbedText(
+function resolveDiscordEmbedText(
   embeds?: readonly { title?: string | null; description?: string | null }[] | null,
 ): string {
   return (embeds ?? [])
@@ -142,7 +142,7 @@ function collectDiscordTextDisplayContent(value: unknown, parts: string[]): void
   collectDiscordTextDisplayContent(component.component, parts);
 }
 
-export function resolveDiscordForwardedMessagesTextFromSnapshots(snapshots: unknown): string {
+function resolveDiscordForwardedMessagesTextFromSnapshots(snapshots: unknown): string {
   const forwardedBlocks = normalizeDiscordMessageSnapshots(snapshots)
     .map((snapshot) => buildDiscordForwardedMessageBlock(snapshot.message))
     .filter((entry): entry is string => Boolean(entry));
@@ -158,7 +158,7 @@ function buildDiscordForwardedMessageBlock(
   if (!snapshotMessage) {
     return null;
   }
-  const text = resolveDiscordSnapshotMessageText(snapshotMessage);
+  const text = resolveDiscordRawMessageText(snapshotMessage);
   if (!text) {
     return null;
   }
@@ -167,14 +167,18 @@ function buildDiscordForwardedMessageBlock(
   return `${heading}\n${text}`;
 }
 
-function resolveDiscordSnapshotMessageText(snapshot: DiscordSnapshotMessage): string {
-  const content = normalizeOptionalString(snapshot.content) ?? "";
-  const attachmentText = formatDiscordMediaText({
-    attachments: snapshot.attachments ?? undefined,
-    stickers: resolveDiscordSnapshotStickers(snapshot),
+/** Single owner for raw Discord message payloads (REST fetches and forwarded snapshots). */
+export function resolveDiscordRawMessageText(
+  message: DiscordSnapshotMessage & { message_snapshots?: unknown },
+): string {
+  const content = normalizeOptionalString(message.content) ?? "";
+  const mediaText = formatDiscordMediaText({
+    attachments: message.attachments ?? undefined,
+    stickers: resolveDiscordSnapshotStickers(message),
   });
-  const embedText = resolveDiscordEmbedText(snapshot.embeds);
-  const componentText = extractDiscordComponentsV2Text(snapshot.components);
-  const text = content || embedText || componentText;
-  return [text, attachmentText].filter(Boolean).join("\n");
+  const embedText = resolveDiscordEmbedText(message.embeds);
+  const componentText = extractDiscordComponentsV2Text(message.components);
+  const forwardedText = resolveDiscordForwardedMessagesTextFromSnapshots(message.message_snapshots);
+  const text = content || embedText || componentText || forwardedText;
+  return [text, mediaText].filter(Boolean).join("\n");
 }

--- a/extensions/discord/src/monitor/threading.starter.test.ts
+++ b/extensions/discord/src/monitor/threading.starter.test.ts
@@ -1,5 +1,5 @@
 // Discord tests cover threading.starter plugin behavior.
-import { StickerFormatType } from "discord-api-types/v10";
+import { ComponentType, MessageFlags, StickerFormatType } from "discord-api-types/v10";
 import { describe, expect, it, vi } from "vitest";
 import { ChannelType, DiscordError, type Client } from "../internal/discord.js";
 import { getCachedThreadStarter, setCachedThreadStarter } from "./threading.cache.js";
@@ -10,6 +10,8 @@ let threadIdIndex = 0;
 
 type ThreadStarterRestMessage = {
   content?: string | null;
+  components?: unknown;
+  flags?: number;
   attachments?: unknown[];
   embeds?: Array<{ title?: string | null; description?: string | null }>;
   message_snapshots?: Array<{
@@ -21,6 +23,7 @@ type ThreadStarterRestMessage = {
     };
   }>;
   sticker_items?: unknown[];
+  stickers?: unknown[];
   author?: {
     id?: string | null;
     username?: string | null;
@@ -68,6 +71,20 @@ function createStarterMessage(overrides: ThreadStarterRestMessage = {}): ThreadS
     ...overrides,
   };
 }
+
+const COMPONENTS_V2_STARTER_BODY = [
+  {
+    type: ComponentType.Container,
+    components: [
+      { type: ComponentType.TextDisplay, content: "Deploy failed" },
+      {
+        type: ComponentType.Section,
+        components: [{ type: ComponentType.TextDisplay, content: "staging pipeline exited 1" }],
+        accessory: { type: ComponentType.Thumbnail, media: { url: "attachment://log.png" } },
+      },
+    ],
+  },
+];
 
 function createDiscordError(status: number): DiscordError {
   return new DiscordError(new Response(null, { status }), {});
@@ -441,6 +458,68 @@ describe("resolveDiscordThreadStarter", () => {
       throw new Error("starter content should have produced a resolved starter payload");
     }
     expect(result.text).toBe("starter content");
+  });
+
+  it.each([
+    { name: "text channel", parentType: ChannelType.GuildText },
+    { name: "forum", parentType: ChannelType.GuildForum },
+  ])(
+    "keeps Components v2 text from a component-only starter in a $name thread",
+    async ({ parentType }) => {
+      const { result } = await resolveStarter({
+        message: createStarterMessage({
+          components: COMPONENTS_V2_STARTER_BODY,
+          flags: MessageFlags.IsComponentsV2,
+        }),
+        parentType,
+      });
+
+      expect(requireThreadStarter(result).text).toBe("Deploy failed\nstaging pipeline exited 1");
+    },
+  );
+
+  it("prefers starter content over Components v2 text", async () => {
+    const { result } = await resolveStarter({
+      message: createStarterMessage({
+        content: "starter content",
+        components: COMPONENTS_V2_STARTER_BODY,
+      }),
+    });
+
+    expect(requireThreadStarter(result).text).toBe("starter content");
+  });
+
+  it("prefers Components v2 text over a forwarded snapshot when a starter carries both", async () => {
+    const { result } = await resolveStarter({
+      message: createStarterMessage({
+        components: COMPONENTS_V2_STARTER_BODY,
+        flags: MessageFlags.IsComponentsV2 | MessageFlags.HasSnapshot,
+        message_snapshots: [createForwardedSnapshot({ content: "forwarded content" })],
+      }),
+    });
+
+    expect(requireThreadStarter(result).text).toBe("Deploy failed\nstaging pipeline exited 1");
+  });
+
+  it("renders the sticker placeholder for every REST sticker shape", async () => {
+    const sticker = { id: "s1", name: "party", format_type: StickerFormatType.PNG };
+    const shapes: Record<string, ThreadStarterRestMessage> = {
+      stickerItemsOnly: { sticker_items: [sticker] },
+      stickersOnly: { stickers: [sticker] },
+      emptyStickersBesideStickerItems: { stickers: [], sticker_items: [sticker] },
+    };
+
+    const texts: Record<string, string | null> = {};
+    for (const [name, message] of Object.entries(shapes)) {
+      const { result } = await resolveStarter({ message: createStarterMessage(message) });
+      texts[name] = result?.text ?? null;
+    }
+
+    expect(texts).toEqual({
+      stickerItemsOnly: "<media:sticker>",
+      stickersOnly: "<media:sticker>",
+      emptyStickersBesideStickerItems: "<media:sticker>",
+    });
   });
 
   it("preserves username, tag, and role metadata for downstream visibility checks", async () => {

--- a/extensions/discord/src/monitor/threading.starter.ts
+++ b/extensions/discord/src/monitor/threading.starter.ts
@@ -16,11 +16,7 @@ import {
   resolveDiscordMessageChannelId,
 } from "./message-channel-info.js";
 import type { DiscordChannelInfo, DiscordChannelInfoClient } from "./message-channel-info.js";
-import { formatDiscordMediaText } from "./message-media.js";
-import {
-  resolveDiscordEmbedText,
-  resolveDiscordForwardedMessagesTextFromSnapshots,
-} from "./message-text.js";
+import { resolveDiscordRawMessageText } from "./message-text.js";
 import { getCachedThreadStarter, setCachedThreadStarter } from "./threading.cache.js";
 import type {
   DiscordMessageEvent,
@@ -203,7 +199,7 @@ function buildDiscordThreadStarterPayload(params: {
   starter: DiscordThreadStarterRestMessage;
   resolveTimestampMs: (value?: string | null) => number | undefined;
 }): DiscordThreadStarter | null {
-  const text = resolveDiscordThreadStarterText(params.starter);
+  const text = resolveDiscordRawMessageText(params.starter);
   if (!text) {
     return null;
   }
@@ -212,18 +208,6 @@ function buildDiscordThreadStarterPayload(params: {
     ...resolveDiscordThreadStarterIdentity(params.starter),
     timestamp: params.resolveTimestampMs(params.starter.timestamp) ?? undefined,
   };
-}
-
-function resolveDiscordThreadStarterText(starter: DiscordThreadStarterRestMessage): string {
-  const content = normalizeOptionalString(starter.content) ?? "";
-  const embedText = resolveDiscordEmbedText(starter.embeds);
-  const forwardedText = resolveDiscordForwardedMessagesTextFromSnapshots(starter.message_snapshots);
-  const text = content || embedText || forwardedText;
-  const mediaText = formatDiscordMediaText({
-    attachments: starter.attachments ?? undefined,
-    stickers: starter.sticker_items ?? undefined,
-  });
-  return [text, mediaText].filter(Boolean).join("\n");
 }
 
 function resolveDiscordThreadStarterIdentity(

--- a/extensions/discord/src/monitor/threading.types.ts
+++ b/extensions/discord/src/monitor/threading.types.ts
@@ -55,6 +55,7 @@ export type DiscordThreadStarterRestMember = {
 
 export type DiscordThreadStarterRestMessage = {
   content?: string | null;
+  components?: unknown;
   attachments?: APIAttachment[] | null;
   embeds?: DiscordThreadStarterRestEmbed[] | null;
   message_snapshots?: Array<{ message?: DiscordThreadStarterRestSnapshotMessage | null }> | null;


### PR DESCRIPTION
## What Problem This Solves

Discord Components v2 messages carry their readable text in a `components` tree. A thread opened on such a message could reach the agent without its starter text. The default `includeThreadStarter` and context-visibility settings do not prevent this loss: the private starter parser returned no text before the visibility check could run.

## Why This Change Was Made

The starter had a separate text builder for content, embeds, forwards, and media. It omitted the component extractor already used by other Discord readers.

This patch removes that builder and uses `resolveDiscordRawMessageText` for REST starters and forwarded snapshots. The shared reader selects content, embeds, component text, then a forwarded snapshot, and appends media text. Ordinary Gateway messages retain their separate mention-resolution and forward-append behavior.

The sticker reader uses the first non-empty `stickers` or `sticker_items` array. This prevents an empty legacy array from hiding a valid sticker while the starter moves to the shared owner. Both fields are present in the pinned Discord API types.

Production change: **+21 / -31, net -10 lines**. Tests: **+80 / -1**.

Implementation and original investigation: @marmar9615-cloud. Maintainer validation kept the contributor's code unchanged.

## User Impact

The agent can see the nested text of a Components v2 thread starter on its first admitted turn. Existing source precedence, forwarded text, media placeholders, sender visibility, cache behavior, and ordinary-message behavior stay with their existing owners.

No configuration, dependency, permission, or public API is added.

## Evidence

AI-assisted maintainer validation on 2026-09-05:

- Baseline main: `70743185c7a8070f344e2172a090668cf3f25329`.
- Tested candidate, submitted for independent review: `56afc70693a3902380d5d7f369093522330e49b4`.
- Real Discord REST creation/fetch and Gateway ingress were used with leased test bots. A deterministic provider recorded the complete first admitted request; it did not decide whether the patch was correct.
- The installed Discord E2E runner drove the mention and recorded the Gateway events. A task-owned fixture created the starter/thread before that drive.

| Scenario | Observed result |
| --- | --- |
| Baseline: nested Components v2 text-thread starter | REST returned both text blocks. The first admitted prompt omitted the starter block, while the bot still replied. |
| Candidate: same nested text-thread starter | The first admitted prompt contained both text blocks in order. |
| Candidate: unmentioned reply before the first mention | One provider request was admitted. It contained the prior reply as history and retained both starter text blocks. |
| Candidate: content, embed, and document attachment | Content won over the embed; the starter retained `<media:document>`. |
| Candidate: forwarded Components v2 starter | The real REST snapshot reached the prompt with `[Forwarded message]` and both nested text blocks. |
| Candidate: starter authored outside the sender allowlist | The starter was fetched but omitted under `contextVisibility: "allowlist"`; the allowed driver's turn still reached the provider. |

Each candidate live case recorded one provider request and one public response from the system under test. The primary after-fix prompt contained:

```text
[Thread starter - for context]
STARTER_CONTAINER_TEXT: the meeting is on Tuesday.
STARTER_SECTION_TEXT: bring the blue notebook.
```

The baseline prompt had no such block.

### Forum coverage and remaining observation gap

**No live forum scenario was run.** Creating a forum returned Discord `403 Missing Permissions`. A bounded read-only inventory of the three available QA guilds found no forum channels; neither bot in any pair had `Manage Channels` or `Administrator`.

Without new permissions, the existing regression test exercises the forum REST route selection and the same raw-message parser. That test fails against baseline production code and passes on this candidate. Source inspection confirms that forum/media parents fetch the starter from the thread itself, then call the same extraction owner as text-thread starters. The routing, visibility, and first-turn gates are unchanged by this patch.

This is **forum route/parser contract coverage**, not a claim that a real forum starter reached a provider prompt. Complete live observations, fixture source, source/dependency context, cleanup results, and this gap are supplied to the independent review.

### Checks

```sh
pnpm exec vitest run \
  extensions/discord/src/monitor/threading.starter.test.ts \
  extensions/discord/src/monitor/message-text.test.ts \
  --config test/vitest/vitest.extension-discord.config.ts --maxWorkers=2
```

- Candidate: **55 tests passed** across both files.
- The candidate's starter regression tests against baseline production: **4 failed, 26 passed**. The failures cover the two component-only topologies, component/forward precedence, and the legacy sticker-only shape.
- All five changed files passed the pinned `oxfmt` **0.65.0** check.
- Each source had one successful remote `qaRuntime` build. No unchanged build was repeated.
- `git diff --check` passed.
- Exact-head [CI run 33953807169](https://github.com/openclaw/openclaw/actions/runs/33953807169) passed, including lint, type checks, build, changed Discord tests, and the CI gate.
- `distill` and the repository `deslop` pass found no further behavior-neutral source change to make.

Direct dependency inspection used `discord-api-types@0.38.53`: `APIMessage` includes components and snapshots; `APIMessageSnapshotFields` includes components but not nested snapshots. Discord's Components v2 contract disables ordinary content/embeds and stickers on v2 messages, so the live precedence/media control uses an ordinary message rather than an invalid mixed v2 payload.
