### PR TITLE
fix(claws): align cron results with stored provenance

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2256,7 +2256,7 @@ src/channels/turn/lifecycle.ts	3
 src/channels/turn/route-dm-scope.ts	1
 src/channels/turn/run-channel-turn.ts	6
 src/claws/add.ts	7
-src/claws/cron.ts	15
+src/claws/cron.ts	13
 src/claws/doctor.ts	2
 src/claws/export.ts	8
 src/claws/lifecycle-delete-support.ts	7

--- a/src/claws/cron.test.ts
+++ b/src/claws/cron.test.ts
@@ -3,8 +3,18 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { validateCronAddParams } from "../../packages/gateway-protocol/src/index.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { normalizeCronJobCreate } from "../cron/normalize.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { clawCronGatewayInput, installClawCronJobs, readClawCronRefs } from "./cron.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import {
+  clawCronGatewayInput,
+  deleteClawCronRef,
+  installClawCronJobs,
+  markClawCronRefRemoved,
+  readClawCronRefs,
+  upsertClawCronRef,
+} from "./cron.js";
 import { buildClawAddPlan } from "./lifecycle.js";
 import { parseClawManifest } from "./schema.js";
 import type { ClawSourceIdentity } from "./types.js";
@@ -259,6 +269,8 @@ describe("installClawCronJobs", () => {
     expect(refs).toMatchObject([
       { schedulerJobId: "scheduler-after-lost-response", status: "complete" },
     ]);
+    expect(refs[0]).not.toHaveProperty("error");
+    expect(refs).toEqual(readClawCronRefs("worker-two", { env: current.env }));
   });
 
   it("converges concurrent installs through the declaration key", async () => {
@@ -284,5 +296,77 @@ describe("installClawCronJobs", () => {
     expect(jobs.size).toBe(1);
     expect(first[0]).toMatchObject({ schedulerJobId: "scheduler-converged", status: "complete" });
     expect(second[0]).toMatchObject({ schedulerJobId: "scheduler-converged", status: "complete" });
+  });
+
+  it("retains creation time across replacement and scopes removal to the owning agent", async () => {
+    const current = await fixture();
+    const options = { env: current.env };
+    const [original] = await installClawCronJobs(current.plan, {
+      ...options,
+      gateway: { add: async () => ({ id: "scheduler-original" }) },
+      nowMs: 42,
+    });
+    const replacement = {
+      ...original!,
+      schedulerJobId: "scheduler-replacement",
+      job: { ...original!.job, message: 'Report "quoted" \\ 日本語\n\u0000' },
+      error: "previous failure",
+      createdAtMs: 999,
+      updatedAtMs: 100,
+    };
+    upsertClawCronRef(replacement, options);
+    const otherAgent = {
+      ...original!,
+      agentId: "other-agent",
+      declarationKey: "claw:other-agent:daily-report",
+      schedulerJobId: "scheduler-other",
+    };
+    upsertClawCronRef(otherAgent, options);
+    expect(readClawCronRefs("worker-two", options)).toEqual([{ ...replacement, createdAtMs: 42 }]);
+
+    const removed = markClawCronRefRemoved("worker-two", "daily-report", {
+      ...options,
+      nowMs: 200,
+    });
+    expect(removed).toMatchObject({ status: "removed", createdAtMs: 42, updatedAtMs: 200 });
+    expect(removed).not.toHaveProperty("schedulerJobId");
+    expect(removed).not.toHaveProperty("error");
+    expect(readClawCronRefs("worker-two", options)).toEqual([removed]);
+    expect(markClawCronRefRemoved("worker-two", "missing", options)).toBeUndefined();
+    deleteClawCronRef("worker-two", "daily-report", options);
+    deleteClawCronRef("worker-two", "daily-report", options);
+    expect(readClawCronRefs("worker-two", options)).toEqual([]);
+    expect(readClawCronRefs("other-agent", options)).toEqual([otherAgent]);
+  });
+
+  it("parses the full agent list before removal while installation reads only its declaration", async () => {
+    const current = await fixture();
+    const options = { env: current.env };
+    const gateway = { add: vi.fn().mockResolvedValue({ id: "scheduler-valid" }) };
+    const [original] = await installClawCronJobs(current.plan, { ...options, gateway });
+    upsertClawCronRef(
+      {
+        ...original!,
+        manifestId: "zz-malformed",
+        declarationKey: "claw:worker-two:zz-malformed",
+        schedulerJobId: "scheduler-malformed",
+      },
+      options,
+    );
+    const db = openOpenClawStateDatabase(options).db;
+    db.prepare("UPDATE claw_cron_refs SET job_json = ? WHERE manifest_id = ?").run(
+      "{",
+      "zz-malformed",
+    );
+
+    expect(() => readClawCronRefs("worker-two", options)).toThrow(SyntaxError);
+    expect(() => markClawCronRefRemoved("worker-two", "daily-report", options)).toThrow(
+      SyntaxError,
+    );
+    expect(() => markClawCronRefRemoved("worker-two", "missing", options)).toThrow(SyntaxError);
+    await expect(installClawCronJobs(current.plan, { ...options, gateway })).resolves.toEqual([
+      original,
+    ]);
+    expect(gateway.add).toHaveBeenCalledOnce();
   });
 });

--- a/src/claws/cron.ts
+++ b/src/claws/cron.ts
@@ -98,10 +98,10 @@ function persistPendingRef(
     .where("agent_id", "=", plan.agent.finalId)
     .where("manifest_id", "=", job.id)
     .compile();
-  // SAFETY: Compiled predicates bind strings; the canonical schema supplies the row shape.
   const existing =
     database.db /* sqlite-allow-raw: execute compiled Kysely with the existing native read error boundary. */
       .prepare(query.sql)
+      // SAFETY: Compiled predicates bind strings; the canonical schema supplies the row shape.
       .get(...(query.parameters as SQLInputValue[])) as CronRefRow | undefined;
   if (existing) {
     const ref = rowToRef(existing);
@@ -420,10 +420,10 @@ export function readClawCronRefs(
     .where("agent_id", "=", agentId)
     .orderBy("manifest_id")
     .compile();
-  // SAFETY: The compiled predicate binds a string; the canonical schema supplies the row shape.
   const rows =
     database.db /* sqlite-allow-raw: execute compiled Kysely with the existing native read error boundary. */
       .prepare(query.sql)
+      // SAFETY: The compiled predicate binds a string; the canonical schema supplies the row shape.
       .all(...(query.parameters as SQLInputValue[])) as CronRefRow[];
   return rows.map(rowToRef);
 }

--- a/src/claws/cron.ts
+++ b/src/claws/cron.ts
@@ -1,10 +1,14 @@
+import type { SQLInputValue } from "node:sqlite";
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
+import type { Selectable } from "kysely";
 import { resolveCronJobConfigRevision } from "../cron/config-revision.js";
 import { normalizeCronJobCreate } from "../cron/normalize.js";
 import { createTrustedCronScheduledToolPolicy } from "../cron/scheduled-tool-policy.js";
 import { applyDefaultCronToolsAllow } from "../cron/tools-allow.js";
 import type { CronJob } from "../cron/types.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
+import type { DB } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -27,18 +31,8 @@ export type PersistedClawCronRef = {
   updatedAtMs: number;
 };
 
-type CronRefRow = {
-  schema_version: string;
-  agent_id: string;
-  manifest_id: string;
-  declaration_key: string;
-  scheduler_job_id: string | null;
-  status: PersistedClawCronRef["status"];
-  job_json: string;
-  error: string | null;
-  created_at_ms: number | bigint;
-  updated_at_ms: number | bigint;
-};
+type CronRefDatabase = Pick<DB, "claw_cron_refs">;
+type CronRefRow = Selectable<CronRefDatabase["claw_cron_refs"]>;
 
 export type ClawCronGateway = {
   add: (input: Record<string, unknown>) => Promise<unknown>;
@@ -66,11 +60,27 @@ function rowToRef(row: CronRefRow): PersistedClawCronRef {
     manifestId: row.manifest_id,
     declarationKey: row.declaration_key,
     ...(row.scheduler_job_id ? { schedulerJobId: row.scheduler_job_id } : {}),
-    status: row.status,
+    // SAFETY: Lifecycle writers own the existing persisted status enum.
+    status: row.status as PersistedClawCronRef["status"],
     job: JSON.parse(row.job_json) as ClawCronJob,
     ...(row.error ? { error: row.error } : {}),
     createdAtMs: sqliteNumber(row.created_at_ms),
     updatedAtMs: sqliteNumber(row.updated_at_ms),
+  };
+}
+
+function refToRow(ref: PersistedClawCronRef): CronRefRow {
+  return {
+    schema_version: ref.schemaVersion,
+    agent_id: ref.agentId,
+    manifest_id: ref.manifestId,
+    declaration_key: ref.declarationKey,
+    scheduler_job_id: ref.schedulerJobId ?? null,
+    status: ref.status,
+    job_json: JSON.stringify(ref.job),
+    error: ref.error ?? null,
+    created_at_ms: ref.createdAtMs,
+    updated_at_ms: ref.updatedAtMs,
   };
 }
 
@@ -82,15 +92,17 @@ function persistPendingRef(
   const nowMs = options.nowMs ?? Date.now();
   const declarationKey = `claw:${plan.agent.finalId}:${job.id}`;
   const database = openOpenClawStateDatabase(options);
+  const query = getNodeSqliteKysely<CronRefDatabase>(database.db)
+    .selectFrom("claw_cron_refs")
+    .selectAll()
+    .where("agent_id", "=", plan.agent.finalId)
+    .where("manifest_id", "=", job.id)
+    .compile();
+  // SAFETY: Compiled predicates bind strings; the canonical schema supplies the row shape.
   const existing =
-    database.db /* sqlite-allow-raw: read one Claw cron ownership row by closed agent and manifest ids. */
-      .prepare(
-        `SELECT schema_version, agent_id, manifest_id, declaration_key, scheduler_job_id,
-              status, job_json, error, created_at_ms, updated_at_ms
-         FROM claw_cron_refs
-        WHERE agent_id = ? AND manifest_id = ?`,
-      )
-      .get(plan.agent.finalId, job.id) as CronRefRow | undefined;
+    database.db /* sqlite-allow-raw: execute compiled Kysely with the existing native read error boundary. */
+      .prepare(query.sql)
+      .get(...(query.parameters as SQLInputValue[])) as CronRefRow | undefined;
   if (existing) {
     const ref = rowToRef(existing);
     if (ref.declarationKey !== declarationKey || JSON.stringify(ref.job) !== JSON.stringify(job)) {
@@ -116,26 +128,12 @@ function persistPendingRef(
     updatedAtMs: nowMs,
   };
   runOpenClawStateWriteTransaction(({ db }) => {
-    db /* sqlite-allow-raw: insert one pending Claw cron ownership row. */
-      .prepare(
-        `INSERT INTO claw_cron_refs (
-         agent_id, manifest_id, schema_version, declaration_key, scheduler_job_id,
-         status, job_json, error, created_at_ms, updated_at_ms
-       ) VALUES (
-         @agent_id, @manifest_id, @schema_version, @declaration_key, NULL,
-         @status, @job_json, NULL, @created_at_ms, @updated_at_ms
-       )`,
-      )
-      .run({
-        agent_id: record.agentId,
-        manifest_id: record.manifestId,
-        schema_version: record.schemaVersion,
-        declaration_key: record.declarationKey,
-        status: record.status,
-        job_json: JSON.stringify(record.job),
-        created_at_ms: nowMs,
-        updated_at_ms: nowMs,
-      });
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<CronRefDatabase>(db)
+        .insertInto("claw_cron_refs")
+        .values(refToRow(record)),
+    );
   }, options);
   return record;
 }
@@ -145,29 +143,27 @@ function updateRef(
   update: { schedulerJobId?: string; status: PersistedClawCronRef["status"]; error?: string },
   options: OpenClawStateDatabaseOptions & { nowMs?: number },
 ): PersistedClawCronRef {
+  // Omitted fields are cleared in SQLite and must not survive in the returned result.
+  const { schedulerJobId: _schedulerJobId, error: _error, ...retained } = ref;
   const updated = {
-    ...ref,
+    ...retained,
     ...update,
     updatedAtMs: options.nowMs ?? Date.now(),
   };
   runOpenClawStateWriteTransaction(({ db }) => {
-    db /* sqlite-allow-raw: update one Claw cron ownership row. */
-      .prepare(
-        `UPDATE claw_cron_refs
-          SET scheduler_job_id = @scheduler_job_id,
-              status = @status,
-              error = @error,
-              updated_at_ms = @updated_at_ms
-        WHERE agent_id = @agent_id AND manifest_id = @manifest_id`,
-      )
-      .run({
-        agent_id: ref.agentId,
-        manifest_id: ref.manifestId,
-        scheduler_job_id: update.schedulerJobId ?? null,
-        status: update.status,
-        error: update.error ?? null,
-        updated_at_ms: updated.updatedAtMs,
-      });
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<CronRefDatabase>(db)
+        .updateTable("claw_cron_refs")
+        .set({
+          scheduler_job_id: updated.schedulerJobId ?? null,
+          status: updated.status,
+          error: updated.error ?? null,
+          updated_at_ms: updated.updatedAtMs,
+        })
+        .where("agent_id", "=", ref.agentId)
+        .where("manifest_id", "=", ref.manifestId),
+    );
   }, options);
   return updated;
 }
@@ -418,15 +414,17 @@ export function readClawCronRefs(
   ) {
     return [];
   }
-  const rows = database.db /* sqlite-allow-raw: read Claw cron ownership rows by closed agent id. */
-    .prepare(
-      `SELECT schema_version, agent_id, manifest_id, declaration_key, scheduler_job_id,
-              status, job_json, error, created_at_ms, updated_at_ms
-         FROM claw_cron_refs
-        WHERE agent_id = ?
-        ORDER BY manifest_id`,
-    )
-    .all(agentId) as CronRefRow[];
+  const query = getNodeSqliteKysely<CronRefDatabase>(database.db)
+    .selectFrom("claw_cron_refs")
+    .selectAll()
+    .where("agent_id", "=", agentId)
+    .orderBy("manifest_id")
+    .compile();
+  // SAFETY: The compiled predicate binds a string; the canonical schema supplies the row shape.
+  const rows =
+    database.db /* sqlite-allow-raw: execute compiled Kysely with the existing native read error boundary. */
+      .prepare(query.sql)
+      .all(...(query.parameters as SQLInputValue[])) as CronRefRow[];
   return rows.map(rowToRef);
 }
 
@@ -436,9 +434,13 @@ export function deleteClawCronRef(
   options: OpenClawStateDatabaseOptions = {},
 ): void {
   runOpenClawStateWriteTransaction(({ db }) => {
-    db /* sqlite-allow-raw: delete one Claw cron ownership row after scheduler cleanup. */
-      .prepare("DELETE FROM claw_cron_refs WHERE agent_id = ? AND manifest_id = ?")
-      .run(agentId, manifestId);
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<CronRefDatabase>(db)
+        .deleteFrom("claw_cron_refs")
+        .where("agent_id", "=", agentId)
+        .where("manifest_id", "=", manifestId),
+    );
   }, options);
 }
 
@@ -458,35 +460,22 @@ export function upsertClawCronRef(
   options: OpenClawStateDatabaseOptions = {},
 ): void {
   runOpenClawStateWriteTransaction(({ db }) => {
-    db /* sqlite-allow-raw: Claw cron lifecycle provenance write. */
-      .prepare(
-        `INSERT INTO claw_cron_refs (
-         agent_id, manifest_id, schema_version, declaration_key, scheduler_job_id,
-         status, job_json, error, created_at_ms, updated_at_ms
-       ) VALUES (
-         @agent_id, @manifest_id, @schema_version, @declaration_key, @scheduler_job_id,
-         @status, @job_json, @error, @created_at_ms, @updated_at_ms
-       )
-       ON CONFLICT(agent_id, manifest_id) DO UPDATE SET
-         schema_version = excluded.schema_version,
-         declaration_key = excluded.declaration_key,
-         scheduler_job_id = excluded.scheduler_job_id,
-         status = excluded.status,
-         job_json = excluded.job_json,
-         error = excluded.error,
-         updated_at_ms = excluded.updated_at_ms`,
-      )
-      .run({
-        agent_id: ref.agentId,
-        manifest_id: ref.manifestId,
-        schema_version: ref.schemaVersion,
-        declaration_key: ref.declarationKey,
-        scheduler_job_id: ref.schedulerJobId ?? null,
-        status: ref.status,
-        job_json: JSON.stringify(ref.job),
-        error: ref.error ?? null,
-        created_at_ms: ref.createdAtMs,
-        updated_at_ms: ref.updatedAtMs,
-      });
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<CronRefDatabase>(db)
+        .insertInto("claw_cron_refs")
+        .values(refToRow(ref))
+        .onConflict((conflict) =>
+          conflict.columns(["agent_id", "manifest_id"]).doUpdateSet((eb) => ({
+            schema_version: eb.ref("excluded.schema_version"),
+            declaration_key: eb.ref("excluded.declaration_key"),
+            scheduler_job_id: eb.ref("excluded.scheduler_job_id"),
+            status: eb.ref("excluded.status"),
+            job_json: eb.ref("excluded.job_json"),
+            error: eb.ref("excluded.error"),
+            updated_at_ms: eb.ref("excluded.updated_at_ms"),
+          })),
+        ),
+    );
   }, options);
 }


### PR DESCRIPTION
## What Problem This Solves

After a lost scheduler response, a successful Claw add retry could return a completed cron entry containing the previous transport error. SQLite had already cleared that error, so the command result disagreed with a fresh status read. The same producer could return an old scheduler ID after clearing it during removal.

## Why This Change Was Made

The cron provenance owner now constructs its result from the fields it actually writes, clearing omitted optional fields before returning. Its six ordinary CRUD statements also use generated-schema Kysely queries and one insert/upsert codec. Existing synchronous transactions own writes; compiled reads keep the original native error boundary. Creation timestamps, declaration-key recovery, full-list parsing, per-agent isolation and stored JSON remain unchanged.

## User Impact

A recovered add reports completion without a stale error and agrees with status. This does not change scheduler retries, persistent data, schema, consent or recovery policy.

## Evidence

- The extended lost-response regression failed on original production and passes with the fix. All 66 tests across six owner/sibling suites, the full changed-file gate and Kysely guard passed.
- Eight paired native owner scenarios and eight fresh-process database readbacks matched exactly except the three intended stale returned fields. Coverage includes duplicate replay, creation-time retention, malformed full-list versus point-read behavior, agent isolation, transaction rollback and update compensation.
- A qaRuntime build passed. Two isolated runs through the actual built CLI and local Gateway withheld one successful post-commit cron.add response. Both returned partial failure, then recovered the original scheduler ID through the same-plan retry and returned complete without the stale error. The instrumented run issued only one cron.add for this recovery. Actual status agreed, including three fresh CLI reads after Gateway shutdown. No cron job or provider ran; native reopens showed zero run receipts and task runs.
- Five independent Codex P0–P2 review passes found no actionable findings. The acting maintainer inspected the full owner/dependency context, native harness and paired results, and the actual CLI/Gateway harness and receipts.

The expanded live runs also exposed two separate failures in unchanged owners: a second-agent readiness check accepted an old applied config before the watcher saw the new agent, and the removal planner classified the system-owned skill-review monitor as operator-owned work. The first was preserved and followed by one explicit retry after observing the new applied config; the second was respected without attempting removal. The expanded harnesses retain their exit-1 results, so successful live Claw removal is not claimed here. Both have named owner follow-ups; native removal/rollback behavior is covered by the paired proof. All Gateway processes joined with exit 0 and relays closed; synthetic databases remain only as evidence.

Production delta: +90/-101, net -11 lines. Tests: +86/-2, net +84. No schema, configuration, retention, public API or stored-representation change. Required safety annotations and formatting were corrected after initial lint failures; the final complete gate is green.
