### PR TITLE
fix(discord): stop legacy TTS migration from polluting Object.prototype

### DIFF
--- a/extensions/discord/src/doctor-contract.ts
+++ b/extensions/discord/src/doctor-contract.ts
@@ -111,9 +111,14 @@ function hasUnsupportedDiscordRealtimeWakeNames(value: unknown): boolean {
   return hasUnsupportedRealtimeWakeNamesInVoice(entry.voice);
 }
 
+// Legacy config is migrated key by key, so a `__proto__` entry would otherwise be
+// walked into `Object.prototype`. The shared config migration guards the same
+// shape; this copy has to guard it too.
+const BLOCKED_OBJECT_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
 function mergeMissing(target: Record<string, unknown>, source: Record<string, unknown>) {
   for (const [key, value] of Object.entries(source)) {
-    if (value === undefined) {
+    if (value === undefined || BLOCKED_OBJECT_KEYS.has(key)) {
       continue;
     }
     const existing = target[key];

--- a/extensions/discord/src/doctor.test.ts
+++ b/extensions/discord/src/doctor.test.ts
@@ -21,6 +21,23 @@ function getDiscordCompatibilityNormalizer(): NonNullable<
 }
 
 describe("discord doctor", () => {
+  it("does not walk legacy TTS keys into Object.prototype", () => {
+    const normalize = getDiscordCompatibilityNormalizer();
+    const payload = JSON.parse('{"__proto__":{"openclawPrototypePollutionProbe":"yes"}}');
+    const result = normalize({
+      cfg: {
+        channels: { discord: { voice: { tts: { openai: payload } } } },
+      } as unknown as OpenClawConfig,
+    });
+
+    // The migration still runs; only the prototype key is skipped.
+    expect(result.changes.some((change) => change.includes("providers.openai"))).toBe(true);
+    expect(({} as Record<string, unknown>).openclawPrototypePollutionProbe).toBeUndefined();
+    expect(
+      (Object.prototype as unknown as Record<string, unknown>).openclawPrototypePollutionProbe,
+    ).toBeUndefined();
+  });
+
   it("promotes shipped nested DM access at root and account scope", () => {
     const normalize = getDiscordCompatibilityNormalizer();
     const result = normalize({


### PR DESCRIPTION
Fixes #138950.

## What Problem This Solves

`mergeMissing` in the Discord doctor contract copies legacy TTS config keys into
a target object without skipping prototype keys, so a `__proto__` entry under
`channels.discord.voice.tts.openai` is walked into `Object.prototype`.

The same helper in `src/config/legacy.shared.ts:51` already guards this — it
skips every key `isBlockedObjectKey` rejects. This copy did not.

Measured through the exported `normalizeCompatibilityConfig`:

```
A: voice.tts.openai benign
   changes: ["Moved channels.discord.voice.tts.openai → …providers.openai."]
   Object.prototype polluted: no
B: voice.tts.openai = __proto__ payload
   changes: ["Moved channels.discord.voice.tts.openai → …providers.openai."]
   Object.prototype polluted: YES
   fresh object sees it: "yes"
C: account-scoped voice.tts.openai payload
   changes: ["Moved channels.discord.accounts.main.voice.tts.openai → …providers.openai."]
   Object.prototype polluted: YES
   fresh object sees it: "yes"
```

Case A is the control: the migration message proves that path executes, so B and
C pollute through the same path rather than a different one. After the fix all
three report `polluted: no` and A/B/C still record the migration.

## Why This Change Was Made

`isBlockedObjectKey` is not exported through `openclaw/plugin-sdk`, and
extensions cannot reach into `src/`, so the guard is a local constant carrying
the same three keys (`__proto__`, `prototype`, `constructor`). Only the key
filter changes; the merge semantics are otherwise untouched.

## User Impact

A Discord voice TTS config containing a prototype key no longer mutates
`Object.prototype` during doctor normalization. The legacy
`tts.<provider>` → `tts.providers.<provider>` migration behaves exactly as
before.

## Evidence

**Regression test.** `does not walk legacy TTS keys into Object.prototype`
fails on the pre-fix source and passes on the fixed one:

```
# pre-fix
× does not walk legacy TTS keys into Object.prototype
  → expected 'yes' to be undefined
  Tests  1 failed | 18 passed (19)

# fixed
  Tests  19 passed (19)
```

The test also asserts the migration still happens
(`result.changes` contains `providers.openai`), so it fails if the guard is ever
widened into skipping ordinary keys.

**Checks.** `oxfmt --check` and `oxlint` on both changed files — clean.

**Pre-existing failure, not from this change.** `pnpm tsgo:core` fails on
`src/infra/install-package-dir.ts(551,15): error TS2353`, inherited from `main`.

## How This Was Found

CodeQL `js/prototype-polluting-function` over a database built from the
network-facing extensions. The first reproduction attempt used the wrong config
path (`channels.discord.tts`) and produced no migration at all — the benign
control above exists because "nothing happened" had to be distinguished from
"the guard worked".

## Diff accounting

- production: +6 / -1
- tests: +17 / -0
