### PR TITLE
fix(ui): show inferred extended-stable update channel

### DIFF
--- a/ui/src/pages/config/updates.test.ts
+++ b/ui/src/pages/config/updates.test.ts
@@ -159,7 +159,7 @@ describe("renderUpdates", () => {
     expect(onUpdateNow).toHaveBeenCalledOnce();
   });
 
-  it("shows extended stable only for the exact authored value and disables auto-apply", () => {
+  it("shows extended stable for an authored channel and disables auto-apply", () => {
     render(
       renderUpdates(
         createProps({
@@ -179,6 +179,58 @@ describe("renderUpdates", () => {
     const automaticRow = row("Automatic updates");
     expect(automaticRow.textContent).toContain("never installs them automatically");
     expect(automaticRow.querySelector("wa-switch")?.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("reports a configless extended-stable package install by the Gateway channel and gates auto-apply", () => {
+    // A direct `npm install -g openclaw@extended-stable` never writes update.channel;
+    // the Gateway still resolves and publishes extended-stable as the schedule channel.
+    render(
+      renderUpdates(
+        createProps({
+          configObject: { update: { auto: { enabled: true } } },
+          schedule: { channel: "extended-stable", autoEnabled: true, install: { kind: "package" } },
+          updateAvailable: null,
+        }),
+      ),
+      container,
+    );
+
+    const channel = row("Release channel").querySelector<HTMLElement & { value: string }>(
+      "wa-radio-group",
+    );
+    expect(channel?.value).toBe("extended-stable");
+    expect(
+      [...container.querySelectorAll("wa-radio")].map((option) => option.textContent?.trim()),
+    ).toEqual(["Stable", "Beta", "Dev", "Extended stable"]);
+    const selected = channel?.querySelector<HTMLElement & { checked: boolean }>(
+      'wa-radio[value="extended-stable"]',
+    );
+    expect(selected?.checked).toBe(true);
+    const automatic = automaticUpdatesControl().toggle;
+    expect(automatic.checked).toBe(false);
+    expect(automatic.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("keeps the authored channel ahead of the Gateway schedule channel", () => {
+    render(
+      renderUpdates(
+        createProps({
+          configObject: { update: { channel: "beta", auto: { enabled: false } } },
+          schedule: { channel: "extended-stable", autoEnabled: true, install: { kind: "package" } },
+          updateAvailable: null,
+        }),
+      ),
+      container,
+    );
+
+    const channel = row("Release channel").querySelector<HTMLElement & { value: string }>(
+      "wa-radio-group",
+    );
+    expect(channel?.value).toBe("beta");
+    expect(
+      [...container.querySelectorAll("wa-radio")].map((option) => option.textContent?.trim()),
+    ).toEqual(["Stable", "Beta", "Dev"]);
+    expect(automaticUpdatesControl().toggle.hasAttribute("disabled")).toBe(false);
   });
 
   it("lets an admin resume disabled checks while preserving the automatic-update preference", () => {

--- a/ui/src/pages/config/updates.ts
+++ b/ui/src/pages/config/updates.ts
@@ -29,7 +29,8 @@ import { formatDateTimeMs, formatTimeAgo } from "../../lib/format.ts";
 
 registerSettingsEnglish();
 
-type UpdatesChannel = "stable" | "beta" | "dev" | "extended-stable";
+const UPDATES_CHANNELS = ["stable", "beta", "dev", "extended-stable"] as const;
+type UpdatesChannel = (typeof UPDATES_CHANNELS)[number];
 
 type UpdatesViewProps = {
   nativeDeviceSettings?: NativeDeviceSettingsCapability | null;
@@ -196,25 +197,21 @@ function renderRecordedAttempt(props: UpdatesViewProps) {
 function readUpdatesSettings(
   configObject: Record<string, unknown>,
   schedule: UpdateScheduleState | null,
-): { channel: UpdatesChannel; autoEnabled: boolean; extendedStableAuthored: boolean } {
+): { channel: UpdatesChannel; autoEnabled: boolean; extendedStable: boolean } {
   const update = asConfigRecord(configObject.update);
   const auto = asConfigRecord(update?.auto);
-  const authoredChannel = update?.channel;
-  const extendedStableAuthored = authoredChannel === "extended-stable";
+  // The saved (or drafted) channel owns policy; the Gateway schedule reports the
+  // channel a configless install resolved to, since a direct
+  // openclaw@extended-stable package install never writes update.channel.
   const channel =
-    authoredChannel === "stable" ||
-    authoredChannel === "beta" ||
-    authoredChannel === "dev" ||
-    extendedStableAuthored
-      ? authoredChannel
-      : schedule?.channel === "beta" || schedule?.channel === "dev"
-        ? schedule.channel
-        : "stable";
+    UPDATES_CHANNELS.find((candidate) => candidate === update?.channel) ??
+    UPDATES_CHANNELS.find((candidate) => candidate === schedule?.channel) ??
+    "stable";
   return {
     channel,
     autoEnabled:
       typeof auto?.enabled === "boolean" ? auto.enabled : (schedule?.autoEnabled ?? false),
-    extendedStableAuthored,
+    extendedStable: channel === "extended-stable",
   };
 }
 
@@ -404,7 +401,7 @@ export function renderUpdates(props: UpdatesViewProps): TemplateResult {
     { value: "beta", label: t("updates.channel.beta") },
     { value: "dev", label: t("updates.channel.dev") },
   ];
-  if (settings.extendedStableAuthored) {
+  if (settings.extendedStable) {
     channelOptions.push({
       value: "extended-stable",
       label: t("updates.channel.extendedStable"),


### PR DESCRIPTION
Fix Settings → Updates showing **Stable** for a package that the Gateway resolves as **Extended stable** when the entire `update` configuration section is absent. The old page also omitted the Extended stable option and enabled an automatic-update switch that this channel cannot use.

Resolve the page’s channel from the existing supported values, keeping the saved or drafted choice ahead of the Gateway schedule. Use that resolved channel for both the radio options and automatic-update eligibility. Gateway detection, scheduling and configuration writing retain their existing owners. Production change: +11/−14 lines.

| Installed package, no authored update settings | Before | After |
| --- | --- | --- |
| Gateway schedule | Extended stable | Extended stable |
| Selected channel | Stable | Extended stable |
| Channel choices | Stable, Beta, Dev | Stable, Beta, Dev, Extended stable |
| Automatic updates | Off, enabled | Off, disabled |

Verified on pinned main `e62272f04a3ed701ae1a2f13d5ae29beb85f9224` and a private composition of this PR’s unchanged `64dcb1c5fc45f0a7f24520c0fc64fa721a23ceba` UI delta onto that same main. Separate checked packages used synthetic version `2026.9.35`, staged **before** the combined runtime/UI build. Both passed the canonical self-contained package checker and normal root install lifecycle. Source-bound hosted declarations were preserved through the supported runtime-only builds; no package metadata was changed after packing.

Real installed Gateways reported `channel.source: installed-version` and published the extended-stable schedule to the authenticated, same-origin browser. Chromium screenshots and live control properties showed the before/after behavior above. Each page served 64 checked assets matching its installed bundle. Rendering left configuration bytes unchanged; a deliberate change to **Beta** used the existing `config.set` autosave and persisted the choice. Reselecting an already-selected radio is not a write guarantee.

Validation:

- The added regression failed against baseline production with `expected 'stable' to be 'extended-stable'`; the other 29 cases passed.
- Candidate renderer: 30 committed cases passed; 10 additional private controls covered fully absent update settings, stable/beta/dev variants, write-free rendering and independent capability gates.
- Existing page/method controls: 15 passed. Existing routed Updates browser suite: 4 passed.
- Fresh source-blind acceptance independently repeated the installed browser flow, inspected before/after pixels, and verified zero surviving processes.
- Changed-file formatting, syntax lint and combined runtime/UI build passed. Exact-head CI: [run 33959979007](https://github.com/openclaw/openclaw/actions/runs/33959979007).

Known unchanged limitation: with checks disabled on a cold start and no cached or authored channel, the Gateway can publish Stable before installed-version inference. This UI repair preserves that existing behavior. No real update, release publication, production installation or service change was used for proof.

Earlier contributor captures used a package-only version rewrite and showed a different embedded UI version; those captures are historical evidence, not the new matched-package proof. The prior screenshot-access failure and repeated proof requests remain recorded in the review discussion. New proof also retains its setup failures: missing synthetic changelog notes, npm lifecycle-policy corrections, a terminal-process observation race, and an overlong browser socket path. All were resolved or reconciled with explicit teardown evidence before final acceptance.
