### PR TITLE
fix: preserve restored plugin state during queued cleanup

### DIFF
--- a/src/config/sessions/session-accessor.lifecycle.ts
+++ b/src/config/sessions/session-accessor.lifecycle.ts
@@ -298,6 +298,9 @@ export async function cleanupPluginHostSessionStore(
     agentId: params.agentId,
     storePath: params.storePath,
   })) {
+    if (params.shouldCleanup && !params.shouldCleanup()) {
+      break;
+    }
     if (isLockedHarnessSessionOwnedByPlugin(entry, params.preserveLockedHarnessIds)) {
       continue;
     }
@@ -307,7 +310,7 @@ export async function cleanupPluginHostSessionStore(
     ) {
       continue;
     }
-    const updated = await patchSessionEntryCore(
+    await patchSessionEntryCore(
       { agentId: params.agentId, sessionKey, storePath: params.storePath },
       (currentEntry) => {
         if (isLockedHarnessSessionOwnedByPlugin(currentEntry, params.preserveLockedHarnessIds)) {
@@ -321,13 +324,14 @@ export async function cleanupPluginHostSessionStore(
         return currentEntry;
       },
       {
+        shouldCommit: params.shouldCleanup,
+        onCommitted: () => {
+          cleared += 1;
+        },
         replaceEntry: true,
         skipMaintenance: true,
       },
     );
-    if (updated) {
-      cleared += 1;
-    }
   }
   return cleared;
 }

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -87,6 +87,8 @@ export {
 
 type SqliteSessionEntryPatchOptions = SessionEntryPatchOptions & {
   skipMaintenance?: boolean;
+  /** Recheck owner cancellation after async preparation, immediately before committing. */
+  shouldCommit?: () => boolean;
   /** Synchronous owner bookkeeping after COMMIT, before observers can cancel the caller. */
   onCommitted?: (entry: SessionEntry) => void;
 };
@@ -506,6 +508,9 @@ async function patchSqliteSessionEntrySnapshot(
     let previousIdentity = new Map<string, SessionEntry>();
     let currentIdentity = new Map<string, SessionEntry>();
     runOpenClawAgentWriteTransaction((writeDatabase) => {
+      if (options.shouldCommit?.() === false) {
+        return;
+      }
       const fresh = params.readSnapshot(writeDatabase);
       assertLifecycleTargetSnapshotUnchanged(prepared, fresh, params.operationLabel);
       options.assertCommitAllowed?.();

--- a/src/config/sessions/session-accessor.sqlite-session-row.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-session-row.test.ts
@@ -89,7 +89,7 @@ describe("SQLite session row persistence", () => {
     },
   );
 
-  it.each(["committed", "declined", "revoked"] as const)(
+  it.each(["committed", "declined", "cancelled", "revoked"] as const)(
     "records only committed owner facts before cancellation observers (%s)",
     async (mode) => {
       const env = {
@@ -109,6 +109,7 @@ describe("SQLite session row persistence", () => {
       const controller = new AbortController();
       const cancelled = new Error("cancelled after identity publication");
       const revoked = new Error("writer revoked before commit");
+      let commitAllowed = true;
       const facts: InternalSessionEntry[] = [];
       const observed: Array<{ acceptedId?: string; persistedId?: string }> = [];
       const unsubscribe = onSessionIdentityMutation((mutation) => {
@@ -124,6 +125,7 @@ describe("SQLite session row persistence", () => {
       const clone = vi.spyOn(globalThis, "structuredClone");
       try {
         const options = {
+          shouldCommit: () => commitAllowed,
           onCommitted: (entry: InternalSessionEntry) => {
             facts.push(entry);
           },
@@ -135,13 +137,23 @@ describe("SQLite session row persistence", () => {
         };
         const pending = patchSessionEntryCore(
           scope,
-          () => (mode === "declined" ? null : { sessionId: "successor" }),
+          () => {
+            if (mode === "cancelled") {
+              queueMicrotask(() => {
+                commitAllowed = false;
+              });
+            }
+            return mode === "declined" ? null : { sessionId: "successor" };
+          },
           options,
         );
         if (mode === "revoked") {
           await expect(pending).rejects.toBe(revoked);
         } else {
-          await pending;
+          const result = await pending;
+          if (mode === "cancelled") {
+            expect(result).toBeNull();
+          }
         }
         if (mode === "committed") {
           expect(facts).toHaveLength(1);

--- a/src/plugins/host-hook-cleanup.session-store.test.ts
+++ b/src/plugins/host-hook-cleanup.session-store.test.ts
@@ -10,6 +10,7 @@ import {
 import { SQLITE_SESSION_WRITER_QUEUES } from "../config/sessions/store-writer-state.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
@@ -84,8 +85,8 @@ describe("plugin host cleanup session stores", () => {
           },
         },
       });
-      const entered = Promise.withResolvers<void>();
-      const release = Promise.withResolvers<void>();
+      const entered = createDeferredCore();
+      const release = createDeferredCore();
       const blocker = patchSessionEntryCore(
         scope,
         async (entry) => {

--- a/src/plugins/host-hook-cleanup.session-store.test.ts
+++ b/src/plugins/host-hook-cleanup.session-store.test.ts
@@ -1,10 +1,14 @@
 // Verifies host hook cleanup behavior for session-store state.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  loadSessionEntry,
+  patchSessionEntryCore,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import { SQLITE_SESSION_WRITER_QUEUES } from "../config/sessions/store-writer-state.js";
 import type { SessionEntry } from "../config/sessions/types.js";
-import * as jsonFiles from "../infra/json-files.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
@@ -26,7 +30,7 @@ describe("plugin host cleanup session stores", () => {
     stateDir = undefined;
   });
 
-  it("does not rewrite session stores when cleanup scans find no plugin-owned state", async () => {
+  it("leaves entries unchanged when cleanup finds no plugin-owned state", async () => {
     stateDir = await fs.mkdtemp(
       path.join(resolvePreferredOpenClawTmpDir(), "openclaw-host-cleanup-noop-"),
     );
@@ -36,7 +40,7 @@ describe("plugin host cleanup session stores", () => {
       sessionId: "session-id",
       updatedAt: Date.now(),
     } satisfies SessionEntry);
-    const writeSpy = vi.spyOn(jsonFiles, "writeTextAtomic");
+    const before = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
 
     const result = await runPluginHostCleanup({
       cfg: { session: { store: storePath } },
@@ -46,8 +50,118 @@ describe("plugin host cleanup session stores", () => {
     });
 
     expect(result).toEqual({ cleanupCount: 0, failures: [] });
-    expect(writeSpy).not.toHaveBeenCalled();
+    expect(loadSessionEntry({ sessionKey: "agent:main:main", storePath })).toEqual(before);
   });
+
+  it.each(["cancelled", "already-cleared", "locked", "revoked", "committed"] as const)(
+    "revalidates queued cleanup and counts only committed changes (%s)",
+    async (mode) => {
+      stateDir = await fs.realpath(
+        await fs.mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-cleanup-queued-")),
+      );
+      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+      const scope = {
+        agentId: "main",
+        sessionKey: "agent:main:cleanup-target",
+        storePath: path.join(stateDir, "agents", "main", "sessions", "sessions.json"),
+      };
+      await replaceSessionEntry(scope, {
+        sessionId: "cleanup-target",
+        updatedAt: 100,
+        pluginExtensions: { fixture: { state: true }, other: { state: true } },
+      });
+      const before = loadSessionEntry(scope);
+      const registry = createEmptyPluginRegistry();
+      registry.agentHarnesses.push({
+        pluginId: "fixture",
+        source: "test",
+        harness: {
+          id: "fixture-harness",
+          label: "Fixture harness",
+          supports: () => ({ supported: true }),
+          runAttempt: async () => {
+            throw new Error("unused test harness");
+          },
+        },
+      });
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const blocker = patchSessionEntryCore(
+        scope,
+        async (entry) => {
+          entered.resolve();
+          await release.promise;
+          if (mode === "already-cleared") {
+            entry.pluginExtensions = { other: { state: true } };
+            return entry;
+          }
+          if (mode === "locked") {
+            entry.modelSelectionLocked = true;
+            entry.agentHarnessId = "fixture-harness";
+            return entry;
+          }
+          return null;
+        },
+        { replaceEntry: true, skipMaintenance: true },
+      );
+      await entered.promise;
+      let current = true;
+      const revoked = new Error("session reset authority changed");
+      const cleanup = runPluginHostCleanup({
+        cfg: {},
+        registry,
+        reason: mode === "revoked" ? "reset" : "disable",
+        pluginId: "fixture",
+        sessionKey: scope.sessionKey,
+        sessionStoreTargets: [{ agentId: scope.agentId, storePath: scope.storePath }],
+        shouldCleanup: () => {
+          if (!current && mode === "revoked") {
+            throw revoked;
+          }
+          return current;
+        },
+      });
+      const settled = Promise.allSettled([blocker, cleanup]);
+      try {
+        expect(
+          [...SQLITE_SESSION_WRITER_QUEUES.values()].reduce(
+            (count, queue) => count + queue.pending.length,
+            0,
+          ),
+        ).toBe(1);
+        current = mode !== "cancelled" && mode !== "revoked";
+        release.resolve();
+        const [blockedWrite, result] = await settled;
+        expect(blockedWrite.status).toBe("fulfilled");
+        expect(result).toEqual(
+          mode === "revoked"
+            ? { status: "rejected", reason: revoked }
+            : {
+                status: "fulfilled",
+                value: { cleanupCount: mode === "committed" ? 1 : 0, failures: [] },
+              },
+        );
+        const after = loadSessionEntry(scope);
+        if (mode === "committed") {
+          expect(after?.pluginExtensions).toEqual({ other: { state: true } });
+          expect(after?.updatedAt).toBeGreaterThan(100);
+        } else if (mode === "already-cleared") {
+          expect(after).toEqual({ ...before, pluginExtensions: { other: { state: true } } });
+        } else if (mode === "locked") {
+          expect(after).toEqual({
+            ...before,
+            modelSelectionLocked: true,
+            agentHarnessId: "fixture-harness",
+          });
+        } else {
+          expect(after).toEqual(before);
+        }
+      } finally {
+        release.resolve();
+        await settled;
+      }
+    },
+  );
 
   it("can defer persistent session-state cleanup to an atomic owner", async () => {
     stateDir = await fs.mkdtemp(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where restoring a plugin registry during replacement could still erase its persistent session state when the previous registry's cleanup was waiting behind another session write. Cleanup could also report a cleared entry when a preceding writer had already removed the target state or locked the session.

## Why This Change Was Made

The session writer now rechecks the cleanup owner's cancellation predicate inside its existing synchronous commit section, after asynchronous preparation. A withdrawn cleanup returns a normal no-op; genuine authority errors still propagate. Cleanup counts come from the existing committed-write callback instead of a truthy prior-entry result. Both plugin-owned state and promoted session slots use this owner.

This adds no schema, migration, configuration, public API, queue, or logging policy. Production is +13/-4 (net +9): a private synchronous cancellation boundary and committed-count bookkeeping. Checking only inside the updater would leave its awaited return vulnerable to cancellation before commit.

## User Impact

A restored registry keeps its plugin session state, and cleanup reports only entries it actually changed.

## Evidence

- Five focused baseline cases failed: queued cancellation, cancellation in the microtask after updater return, an already-cleared target, a newly locked session, and reset authority revoked while queued. All pass with the repair; successful writes and throwing commit-authority controls remain covered.
- 189 tests passed across seven owner, runtime cleanup, reset, and promoted-slot contract suites on the production-identical candidate.
- A standalone isolated process exercised the real registry set/capture/replace/restore APIs while holding the physical session writer. Baseline restored the registry but deleted its persistent plugin state; the candidate preserved the complete stored entry and timestamp. Both runs drained writers, cleared the registry and removed temporary state. This is real local runtime/SQLite proof with synthetic state, not production traffic.
- Independent P0–P2 review found no actionable findings.
- Local changed checks passed the preceding guards, then were stopped before the full type/declaration gate because the borrowed dependency layout is unsupported by that gate. A first attempt inherited remote routing and was interrupted before any owned accepted lease was found. Full type and integration gates passed in [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33955467842); this PR does not claim a complete local changed-check pass.

Related: #138946 optimizes the same cleanup inventory scan independently. Regression introduction is unknown; the defective behavior is reproduced on the current owner implementation.

The first exact-head CI run caught two direct `Promise.withResolvers` calls unavailable in the test stripe's declared library. The fixture now uses the existing typed `createDeferredCore` helper, which calls the same runtime implementation. Production files remain byte-identical to the local RED/GREEN candidate. [Final exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33955467842). ClawSweeper reviewed the same head with no findings or required pre-merge changes.
