### PR TITLE
fix(canvas): recognize connected Macs with versioned platform labels

### DIFF
--- a/extensions/canvas/src/node-eligibility.ts
+++ b/extensions/canvas/src/node-eligibility.ts
@@ -16,7 +16,7 @@ export const CANVAS_PRESENT_COMMAND = "canvas.present";
 export function isEligibleCanvasNode(node: CanvasNodeDescriptor): boolean {
   const commands = node.invocableCommands ?? node.commands ?? [];
   return (
-    node.platform === "macos" &&
+    /^macos(?:\s|$)/i.test(node.platform ?? "") &&
     node.connected === true &&
     commands.includes(CANVAS_PRESENT_COMMAND)
   );

--- a/extensions/canvas/src/tool.test.ts
+++ b/extensions/canvas/src/tool.test.ts
@@ -149,6 +149,24 @@ describe("Canvas presenter tool", () => {
     expect(mocks.callGatewayTool).not.toHaveBeenCalled();
   });
 
+  it("accepts a versioned macOS platform reported by a connected node", async () => {
+    mocks.listNodes.mockResolvedValue([
+      {
+        ...eligibleMac,
+        platform: "macOS 26.6.2",
+      },
+    ]);
+
+    const result = await createCanvasTool().execute("tool-call", { action: "present" });
+
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      { timeoutMs: 40_000 },
+      expect.objectContaining({ nodeId: "mac-1", command: "canvas.present" }),
+    );
+    expect(result.details).toMatchObject({ ok: true, node: "mac-1" });
+  });
+
   it("rejects malformed presenter arguments before invoking a node", async () => {
     const tool = createCanvasTool();
 

--- a/extensions/canvas/src/widget-presenter.test.ts
+++ b/extensions/canvas/src/widget-presenter.test.ts
@@ -15,7 +15,7 @@ function createNodesRuntime(
 }
 
 describe("Canvas widget presenter", () => {
-  it("prefers the existing local Mac default and presents the hosted URL atomically", async () => {
+  it.each(["macos", "macOS 26.6.2"])("presents the hosted URL on a %s node", async (platform) => {
     const runtime = createNodesRuntime([
       {
         nodeId: "android-recent",
@@ -29,7 +29,7 @@ describe("Canvas widget presenter", () => {
       {
         nodeId: "mac-local",
         displayName: "Studio",
-        platform: "macos",
+        platform,
         connected: true,
         connectedAtMs: 10,
         caps: ["canvas"],


### PR DESCRIPTION
Closes #138956

## What Problem This Solves

Fixes an issue where users cannot present Canvas panels on connected Macs whose node metadata reports a versioned platform such as `macOS 26.6.2`. The tool rejects the Mac as ineligible even though direct `canvas.present` invocation succeeds.

## Why This Change Was Made

Recognize bare and versioned macOS platform labels case-insensitively in the shared Canvas eligibility predicate. The existing connection and advertised-command requirements remain enforced. The same correction serves agent tool calls and widget presentation.

## User Impact

Connected Macs reporting their OS version can be selected for Canvas presentation. Linux and Android nodes remain excluded.

## Evidence

- Live reproduction on OpenClaw 2026.9.1: `node.list` reports a connected Mac with `canvas.present`; the Canvas tool rejects it with no eligible node, while direct node invocation succeeds.
- The new tool regression and parameterized widget-presenter regression both fail on pre-fix code for the eligibility error.
- `node scripts/run-vitest.mjs extensions/canvas/src/tool.test.ts extensions/canvas/src/widget-presenter.test.ts extensions/canvas/src/cli.test.ts` — 36 passed.
- `node scripts/check-changed.mjs -- extensions/canvas/src/node-eligibility.ts extensions/canvas/src/tool.test.ts extensions/canvas/src/widget-presenter.test.ts` — passed, including extension typechecks, lint and runtime cycle checks.
- Independent autoreview: scoped-clean through P2.
- Production delta: 1 line replaced, net zero. Tests: 20 added, 2 removed.

- Installed the compiled patched Canvas plugin through the supported plugin installer. Live `tools.invoke` for both `canvas` actions `present` and `hide` now returns `ok: true` for the same Mac. Plugin doctor reports no errors or warnings.

This is a node-selection fix with no visual layout changes; before/after proof is the failed/successful tool invocation against the same connected device.

## Maintainer verification

Independent [GitHub-hosted proof](https://github.com/steipete/openclaw/actions/runs/33979940254) exercised the production Canvas tool and widget presenter through a synthetic WebSocket Gateway on trusted main `8637d26b73b3a8af65ecebd309d401c979a16813`. The baseline rejected native versioned and uppercase Mac labels. The exact selector repair passed eight cases across tool present/hide, widget availability, and widget presentation; non-Mac, disconnected, missing-command, and macOS-prefix impostor controls dispatched nothing. The 34 current-main tool/presenter/CLI tests also passed. The executed selector's SHA-256 matches this PR's production file byte-for-byte.

The [original exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33954346296) is green, and fresh independent Codex review through P2 found no actionable defects. Production remains +1/-1 (net zero), tests +20/-2 (net +18).

The independent proof uses a synthetic Gateway transport; it does not show the native panel rendering. Native screenshots could not be collected in this secretless Linux job, which has no paired macOS app or signing identity. The reporter's real-device present/hide results above remain separately attributed. No visual layout code changes.
