### PR TITLE
refactor(claws): type workspace provenance and removal queries

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2259,7 +2259,7 @@ src/claws/add.ts	7
 src/claws/cron.ts	15
 src/claws/doctor.ts	2
 src/claws/export.ts	8
-src/claws/lifecycle-delete-support.ts	7
+src/claws/lifecycle-delete-support.ts	5
 src/claws/mcp.ts	4
 src/claws/openclaw-profile.ts	2
 src/claws/package-update.ts	1

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -149,10 +149,10 @@ export function readAttachedCronJobs(
       )
       .orderBy("job_id");
   });
-  // Keep native inventory failure handling outside the write-transaction owner.
-  const rows = db.prepare(compiled.sql).all(...bind(agentId)) as Array<
-    Omit<AttachedCronJob, "enabled"> & { enabled: number }
-  >;
+  const rows =
+    db /* sqlite-allow-raw: preserve native inventory errors outside the write-transaction owner. */
+      .prepare(compiled.sql)
+      .all(...bind(agentId)) as Array<Omit<AttachedCronJob, "enabled"> & { enabled: number }>;
   return rows.map((row) => ({
     id: row.id,
     name: row.name,

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -1,7 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { DatabaseSync } from "node:sqlite";
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
 import {
   isPathOwnedBySurvivingAgent,
@@ -29,10 +28,16 @@ import { moveToTrash } from "../commands/cleanup-utils.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { root as fsSafeRoot, FsSafeError } from "../infra/fs-safe.js";
-import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
+import {
+  compileSqliteQueryBindings,
+  executeSqliteQuerySync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { unregisterOpenClawAgentDatabases } from "../state/openclaw-agent-db-registry.js";
 import type { OpenClawStateDatabase } from "../state/openclaw-state-db-contract.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import type { DB } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -42,17 +47,10 @@ import { deleteCachedClawInstallSchemaVersion } from "./provenance-runtime-read.
 import type { PersistedClawInstall } from "./provenance.js";
 import type { PersistedClawWorkspaceFile } from "./workspace.js";
 
-type WorkspaceFileRow = {
-  schema_version: string;
-  agent_id: string;
-  workspace: string;
-  target_path: string;
-  source_path: string;
-  content_digest: string;
-  status: PersistedClawWorkspaceFile["status"];
-  created_at_ms: number | bigint;
-  updated_at_ms: number | bigint;
-};
+type ClawRemovalDatabase = Pick<
+  DB,
+  "claw_workspace_files" | "claw_package_refs" | "claw_installs" | "cron_jobs"
+>;
 
 export class ClawRemoveError extends Error {
   constructor(
@@ -62,46 +60,6 @@ export class ClawRemoveError extends Error {
     super(message);
     this.name = "ClawRemoveError";
   }
-}
-
-function clawStateTableExists(db: DatabaseSync, name: string): boolean {
-  return Boolean(
-    db /* sqlite-allow-raw: schema probe for optional Claw state tables. */
-      .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
-      .get(name),
-  );
-}
-
-function rowToWorkspaceFile(row: WorkspaceFileRow): PersistedClawWorkspaceFile {
-  return {
-    schemaVersion: row.schema_version as PersistedClawWorkspaceFile["schemaVersion"],
-    agentId: row.agent_id,
-    workspace: row.workspace,
-    path: row.target_path,
-    sourcePath: row.source_path,
-    contentDigest: row.content_digest,
-    status: row.status,
-    createdAtMs: sqliteNumber(row.created_at_ms),
-    updatedAtMs: sqliteNumber(row.updated_at_ms),
-  };
-}
-
-export function readAllClawWorkspaceFiles(
-  options: OpenClawStateDatabaseOptions,
-): PersistedClawWorkspaceFile[] {
-  const database = openOpenClawStateDatabase(options);
-  if (!clawStateTableExists(database.db, "claw_workspace_files")) {
-    return [];
-  }
-  const rows = database.db /* sqlite-allow-raw: read-only Claw workspace-file orphan inventory. */
-    .prepare(
-      `SELECT schema_version, agent_id, workspace, target_path, source_path,
-              content_digest, status, created_at_ms, updated_at_ms
-         FROM claw_workspace_files
-        ORDER BY agent_id, target_path`,
-    )
-    .all() as WorkspaceFileRow[];
-  return rows.map(rowToWorkspaceFile);
 }
 
 export function synthesizeOrphanInstall(params: {
@@ -171,34 +129,37 @@ export function readAttachedCronJobs(
   agentId: string,
   options: OpenClawStateDatabaseOptions,
 ): AttachedCronJob[] {
-  const database = openOpenClawStateDatabase(options);
-  if (!clawStateTableExists(database.db, "cron_jobs")) {
+  const { db } = openOpenClawStateDatabase(options);
+  if (!tableExists(db, "cron_jobs")) {
     return [];
   }
-  return database.db /* sqlite-allow-raw: read-only cron references for Claw removal planning. */
-    .prepare(
-      `SELECT job_id AS id, name, enabled, agent_id AS agentId, owner_agent_id AS ownerAgentId
-         FROM cron_jobs
-        WHERE agent_id = ? OR owner_agent_id = ?
-        ORDER BY job_id`,
-    )
-    .all(agentId, agentId)
-    .map((row) => {
-      const value = row as {
-        id: string;
-        name: string;
-        enabled: number;
-        agentId: string | null;
-        ownerAgentId: string | null;
-      };
-      return {
-        id: value.id,
-        name: value.name,
-        enabled: value.enabled === 1,
-        agentId: value.agentId,
-        ownerAgentId: value.ownerAgentId,
-      };
-    });
+  const { compiled, bind } = compileSqliteQueryBindings<string>((parameter) => {
+    const boundAgentId = parameter((value) => value);
+    return getNodeSqliteKysely<ClawRemovalDatabase>(db)
+      .selectFrom("cron_jobs")
+      .select([
+        "job_id as id",
+        "name",
+        "enabled",
+        "agent_id as agentId",
+        "owner_agent_id as ownerAgentId",
+      ])
+      .where((eb) =>
+        eb.or([eb("agent_id", "=", boundAgentId), eb("owner_agent_id", "=", boundAgentId)]),
+      )
+      .orderBy("job_id");
+  });
+  // Keep native inventory failure handling outside the write-transaction owner.
+  const rows = db.prepare(compiled.sql).all(...bind(agentId)) as Array<
+    Omit<AttachedCronJob, "enabled"> & { enabled: number }
+  >;
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    enabled: row.enabled === 1,
+    agentId: row.agentId,
+    ownerAgentId: row.ownerAgentId,
+  }));
 }
 
 export type ClawCleanupTargets = {
@@ -497,26 +458,30 @@ export function releaseClawRemoveRows(
   }
   runOpenClawStateWriteTransaction((database) => {
     const { db } = database;
-    if (clawStateTableExists(db, "claw_workspace_files")) {
+    const query = getNodeSqliteKysely<ClawRemovalDatabase>(db);
+    if (tableExists(db, "claw_workspace_files")) {
       for (const file of files.filter((candidate) => candidate.action !== "error")) {
-        db /* sqlite-allow-raw: remove one owned Claw workspace-file row. */
-          .prepare("DELETE FROM claw_workspace_files WHERE agent_id = ? AND target_path = ?")
-          .run(agentId, file.path);
+        executeSqliteQuerySync(
+          db,
+          query
+            .deleteFrom("claw_workspace_files")
+            .where("agent_id", "=", agentId)
+            .where("target_path", "=", file.path),
+        );
       }
     }
     // Partial removals keep both the journal fence and install retry owner intact.
     if (!complete) {
       return;
     }
-    if (clawStateTableExists(db, "claw_package_refs")) {
-      db /* sqlite-allow-raw: release package refs for a removed Claw agent. */
-        .prepare("DELETE FROM claw_package_refs WHERE agent_id = ?")
-        .run(agentId);
+    if (tableExists(db, "claw_package_refs")) {
+      executeSqliteQuerySync(
+        db,
+        query.deleteFrom("claw_package_refs").where("agent_id", "=", agentId),
+      );
     }
-    if (clawStateTableExists(db, "claw_installs")) {
-      db /* sqlite-allow-raw: remove the completed Claw install owner row. */
-        .prepare("DELETE FROM claw_installs WHERE agent_id = ?")
-        .run(agentId);
+    if (tableExists(db, "claw_installs")) {
+      executeSqliteQuerySync(db, query.deleteFrom("claw_installs").where("agent_id", "=", agentId));
     }
     // Complete removals release the fence and retry owner in the same transaction.
     completeDeletion(database);

--- a/src/claws/lifecycle-status.ts
+++ b/src/claws/lifecycle-status.ts
@@ -16,7 +16,6 @@ import {
   ClawRemoveError,
   inspectClawBootstrap,
   inspectClawWorkspaceFile,
-  readAllClawWorkspaceFiles,
   synthesizeOrphanInstall,
   type ClawManagedFileStatus,
   type ClawBootstrapStatus,
@@ -39,7 +38,7 @@ import {
   type PersistedClawPackageRef,
 } from "./provenance.js";
 import { CLAW_OUTPUT_STABILITY, type ClawPackagePreflight } from "./types.js";
-import { readClawWorkspaceFiles } from "./workspace.js";
+import { readAllClawWorkspaceFiles, readClawWorkspaceFiles } from "./workspace.js";
 
 const CLAW_STATUS_SCHEMA_VERSION = "openclaw.clawStatus.v1" as const;
 

--- a/src/claws/workspace-update.test.ts
+++ b/src/claws/workspace-update.test.ts
@@ -79,11 +79,13 @@ describe("applyClawWorkspaceUpdate", () => {
     let config: OpenClawConfig = {};
     await applyClawAddPlan(currentAddPlan, {
       env,
+      nowMs: 10,
       consentPlanIntegrity: currentAddPlan.planIntegrity,
       commitConfig: async (transform) => {
         config = transform(config);
       },
     });
+    const originalFiles = readClawWorkspaceFiles("worker", { env });
     const updatePlan = await buildClawUpdatePlan({
       agentId: "worker",
       targetManifest: targetParsed.manifest,
@@ -119,10 +121,7 @@ describe("applyClawWorkspaceUpdate", () => {
     await expect(readFile(join(workspace, "SOUL.md"), "utf8")).resolves.toBe("current soul\n");
     await expect(readFile(join(workspace, "OLD.md"), "utf8")).resolves.toBe("old\n");
     await expect(access(join(workspace, "NEW.md"))).rejects.toThrow();
-    expect(readClawWorkspaceFiles("worker", { env }).map((record) => record.path)).toEqual([
-      "OLD.md",
-      "SOUL.md",
-    ]);
+    expect(readClawWorkspaceFiles("worker", { env })).toEqual(originalFiles);
 
     await rm(join(workspace, "OLD.md"));
     await expect(

--- a/src/claws/workspace.test.ts
+++ b/src/claws/workspace.test.ts
@@ -12,7 +12,13 @@ import { applyClawAddPlan } from "./add.js";
 import { buildClawAddPlan } from "./lifecycle.js";
 import { parseClawManifest } from "./schema.js";
 import type { ClawAddPlan, ClawSourceIdentity } from "./types.js";
-import { ClawWorkspaceWriteError, createClawWorkspaceFiles } from "./workspace.js";
+import {
+  CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION,
+  ClawWorkspaceWriteError,
+  createClawWorkspaceFiles,
+  readAllClawWorkspaceFiles,
+  readClawWorkspaceFiles,
+} from "./workspace.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -116,6 +122,40 @@ function readInstallStatus(agentId: string, root: string): string | undefined {
 }
 
 describe("createClawWorkspaceFiles", () => {
+  it.each([
+    { schemaVersion: "future.workspace.v9", status: "complete" },
+    { schemaVersion: CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION, status: "unknown" },
+  ])(
+    "rejects retry with $schemaVersion/$status while preserving inventory",
+    async ({ schemaVersion, status }) => {
+      const { root, workspace, plan } = await makePlan();
+      const env = stateEnv(root);
+      await createClawWorkspaceFiles(plan, { env, nowMs: 10 });
+      const { db } = openOpenClawStateDatabase({ env });
+      db.prepare(
+        "UPDATE claw_workspace_files SET schema_version = ?, status = ? WHERE agent_id = ? AND target_path = ?",
+      ).run(schemaVersion, status, plan.agent.finalId, "AGENTS.md");
+      const selectRows = () =>
+        db.prepare("SELECT * FROM claw_workspace_files ORDER BY target_path").all();
+      const before = selectRows();
+
+      expect(readClawWorkspaceFiles(plan.agent.finalId, { env })[0]).toMatchObject({
+        schemaVersion: CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION,
+        status,
+      });
+      expect(readAllClawWorkspaceFiles({ env })[0]).toMatchObject({ schemaVersion, status });
+      await expect(createClawWorkspaceFiles(plan, { env, nowMs: 20 })).rejects.toMatchObject({
+        diagnostics: [
+          expect.objectContaining({
+            message: expect.stringContaining("unsupported provenance state"),
+          }),
+        ],
+      });
+      expect(selectRows()).toEqual(before);
+      await expect(readFile(join(workspace, "AGENTS.md"), "utf8")).resolves.toBe("# Agent\n");
+    },
+  );
+
   it("materializes the CLAW.md body as managed SOUL.md content", async () => {
     const root = tempDirs.make("openclaw-claw-body-workspace-");
     const workspace = join(root, "workspace-agent");

--- a/src/claws/workspace.ts
+++ b/src/claws/workspace.ts
@@ -2,9 +2,19 @@
 import { createHash } from "node:crypto";
 import { realpath } from "node:fs/promises";
 import { resolve, sep } from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
+import type { Selectable } from "kysely";
 import { root as fsSafeRoot, FsSafeError, type Root } from "../infra/fs-safe.js";
+import {
+  compileSqliteQueryBindings,
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
 import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import type { DB } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -43,29 +53,54 @@ export class ClawWorkspaceWriteError extends Error {
 
 class ClawWorkspaceSourceAliasError extends Error {}
 
-type WorkspaceFileRow = {
-  schema_version: string;
-  agent_id: string;
-  workspace: string;
-  target_path: string;
-  source_path: string;
-  content_digest: string;
-  status: PersistedClawWorkspaceFile["status"];
-  created_at_ms: number | bigint;
-  updated_at_ms: number | bigint;
-};
+type WorkspaceDatabase = Pick<DB, "claw_workspace_files">;
+type WorkspaceFileRow = Selectable<DB["claw_workspace_files"]>;
 
-function rowToWorkspaceFile(row: WorkspaceFileRow): PersistedClawWorkspaceFile {
+function selectWorkspaceFiles(db: DatabaseSync) {
+  return getNodeSqliteKysely<WorkspaceDatabase>(db)
+    .selectFrom("claw_workspace_files")
+    .select([
+      "schema_version",
+      "agent_id",
+      "workspace",
+      "target_path",
+      "source_path",
+      "content_digest",
+      "status",
+      "created_at_ms",
+      "updated_at_ms",
+    ]);
+}
+
+function rowToWorkspaceFile(
+  row: WorkspaceFileRow,
+  schemaVersion: PersistedClawWorkspaceFile["schemaVersion"] = CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION,
+): PersistedClawWorkspaceFile {
   return {
-    schemaVersion: CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION,
+    schemaVersion,
     agentId: row.agent_id,
     workspace: row.workspace,
     path: row.target_path,
     sourcePath: row.source_path,
     contentDigest: row.content_digest,
-    status: row.status,
+    // SAFETY: Inventory keeps its unchecked status contract; the retry reader validates it first.
+    status: row.status as PersistedClawWorkspaceFile["status"],
     createdAtMs: sqliteNumber(row.created_at_ms),
     updatedAtMs: sqliteNumber(row.updated_at_ms),
+  };
+}
+
+function workspaceFileToRow(record: PersistedClawWorkspaceFile): WorkspaceFileRow {
+  return {
+    agent_id: record.agentId,
+    target_path: record.path,
+    schema_version: record.schemaVersion,
+    workspace: record.workspace,
+    source_path: record.sourcePath,
+    content_digest: record.contentDigest,
+    status: record.status,
+    created_at_ms: record.createdAtMs,
+    updated_at_ms: record.updatedAtMs,
   };
 }
 
@@ -121,42 +156,14 @@ function persistWorkspaceFile(
   options: OpenClawStateDatabaseOptions,
 ): void {
   runOpenClawStateWriteTransaction(({ db }) => {
-    // sqlite-allow-raw: this Claw prototype state-table write is scoped to one owned row.
-    db /* sqlite-allow-raw: Claw workspace-file provenance write. */
-      .prepare(
-        `INSERT INTO claw_workspace_files (
-         agent_id, target_path, schema_version, workspace, source_path,
-         content_digest, status, created_at_ms, updated_at_ms
-       ) VALUES (
-         @agent_id, @target_path, @schema_version, @workspace, @source_path,
-         @content_digest, @status, @created_at_ms, @updated_at_ms
-       )`,
-      )
-      .run({
-        agent_id: record.agentId,
-        target_path: record.path,
-        schema_version: record.schemaVersion,
-        workspace: record.workspace,
-        source_path: record.sourcePath,
-        content_digest: record.contentDigest,
-        status: record.status,
-        created_at_ms: record.createdAtMs,
-        updated_at_ms: record.updatedAtMs,
-      });
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<WorkspaceDatabase>(db)
+        .insertInto("claw_workspace_files")
+        .values(workspaceFileToRow(record)),
+    );
   }, options);
 }
-
-type PersistedClawWorkspaceFileRow = {
-  schema_version: string;
-  agent_id: string;
-  workspace: string;
-  target_path: string;
-  source_path: string;
-  content_digest: string;
-  status: string;
-  created_at_ms: number | bigint;
-  updated_at_ms: number | bigint;
-};
 
 function readWorkspaceFile(
   agentId: string,
@@ -164,14 +171,13 @@ function readWorkspaceFile(
   options: OpenClawStateDatabaseOptions,
 ): PersistedClawWorkspaceFile | undefined {
   return runOpenClawStateWriteTransaction(({ db }) => {
-    const statement = db /* sqlite-allow-raw: one owned Claw state-table row */
-      .prepare(
-        `SELECT schema_version, agent_id, workspace, target_path, source_path,
-              content_digest, status, created_at_ms, updated_at_ms
-         FROM claw_workspace_files
-        WHERE agent_id = ? AND target_path = ?`,
-      );
-    const row = statement.get(agentId, targetPath) as PersistedClawWorkspaceFileRow | undefined;
+    const row = executeSqliteQueryTakeFirstSync(
+      db,
+      selectWorkspaceFiles(db)
+        .where("agent_id", "=", agentId)
+        .where("target_path", "=", targetPath)
+        .limit(1),
+    );
     if (!row) {
       return undefined;
     }
@@ -183,17 +189,7 @@ function readWorkspaceFile(
         `Claw workspace file ${JSON.stringify(targetPath)} has unsupported provenance state.`,
       );
     }
-    return {
-      schemaVersion: CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION,
-      agentId: row.agent_id,
-      workspace: row.workspace,
-      path: row.target_path,
-      sourcePath: row.source_path,
-      contentDigest: row.content_digest,
-      status: row.status,
-      createdAtMs: sqliteNumber(row.created_at_ms),
-      updatedAtMs: sqliteNumber(row.updated_at_ms),
-    };
+    return rowToWorkspaceFile(row);
   }, options);
 }
 
@@ -217,22 +213,16 @@ function updateWorkspaceFileStatus(
   options: OpenClawStateDatabaseOptions,
 ): void {
   runOpenClawStateWriteTransaction(({ db }) => {
-    const expectedPlaceholders = expectedStatuses.map(() => "?").join(", ");
-    const statement = db /* sqlite-allow-raw: one owned Claw state-table row */
-      .prepare(
-        `UPDATE claw_workspace_files
-          SET status = ?, updated_at_ms = ?
-        WHERE agent_id = ? AND target_path = ?
-          AND status IN (${expectedPlaceholders})`,
-      );
-    const result = statement.run(
-      record.status,
-      record.updatedAtMs,
-      record.agentId,
-      record.path,
-      ...expectedStatuses,
+    const result = executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<WorkspaceDatabase>(db)
+        .updateTable("claw_workspace_files")
+        .set({ status: record.status, updated_at_ms: record.updatedAtMs })
+        .where("agent_id", "=", record.agentId)
+        .where("target_path", "=", record.path)
+        .where("status", "in", expectedStatuses),
     );
-    if (Number(result.changes) !== 1) {
+    if (result.numAffectedRows !== 1n) {
       throw new Error(
         `Claw workspace file ${JSON.stringify(record.path)} changed ownership state concurrently.`,
       );
@@ -245,35 +235,24 @@ export function upsertClawWorkspaceFile(
   options: OpenClawStateDatabaseOptions = {},
 ): void {
   runOpenClawStateWriteTransaction(({ db }) => {
-    db /* sqlite-allow-raw: Claw workspace-file provenance write. */
-      .prepare(
-        `INSERT INTO claw_workspace_files (
-         agent_id, target_path, schema_version, workspace, source_path,
-         content_digest, status, created_at_ms, updated_at_ms
-       ) VALUES (
-         @agent_id, @target_path, @schema_version, @workspace, @source_path,
-         @content_digest, @status, @created_at_ms, @updated_at_ms
-       )
-       ON CONFLICT(agent_id, target_path) DO UPDATE SET
-         schema_version = excluded.schema_version,
-         workspace = excluded.workspace,
-         source_path = excluded.source_path,
-         content_digest = excluded.content_digest,
-         status = excluded.status,
-         created_at_ms = excluded.created_at_ms,
-         updated_at_ms = excluded.updated_at_ms`,
-      )
-      .run({
-        agent_id: record.agentId,
-        target_path: record.path,
-        schema_version: record.schemaVersion,
-        workspace: record.workspace,
-        source_path: record.sourcePath,
-        content_digest: record.contentDigest,
-        status: record.status,
-        created_at_ms: record.createdAtMs,
-        updated_at_ms: record.updatedAtMs,
-      });
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<WorkspaceDatabase>(db)
+        .insertInto("claw_workspace_files")
+        .values(workspaceFileToRow(record))
+        .onConflict((conflict) =>
+          conflict.columns(["agent_id", "target_path"]).doUpdateSet((eb) => ({
+            schema_version: eb.ref("excluded.schema_version"),
+            workspace: eb.ref("excluded.workspace"),
+            source_path: eb.ref("excluded.source_path"),
+            content_digest: eb.ref("excluded.content_digest"),
+            status: eb.ref("excluded.status"),
+            // Update rollback restores the complete prior record, including its creation time.
+            created_at_ms: eb.ref("excluded.created_at_ms"),
+            updated_at_ms: eb.ref("excluded.updated_at_ms"),
+          })),
+        ),
+    );
   }, options);
 }
 
@@ -283,9 +262,13 @@ export function deleteClawWorkspaceFileRecord(
   options: OpenClawStateDatabaseOptions = {},
 ): void {
   runOpenClawStateWriteTransaction(({ db }) => {
-    db /* sqlite-allow-raw: Claw workspace-file provenance write. */
-      .prepare("DELETE FROM claw_workspace_files WHERE agent_id = ? AND target_path = ?")
-      .run(agentId, path);
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<WorkspaceDatabase>(db)
+        .deleteFrom("claw_workspace_files")
+        .where("agent_id", "=", agentId)
+        .where("target_path", "=", path),
+    );
   }, options);
 }
 
@@ -297,27 +280,38 @@ export function readClawWorkspaceFiles(
   agentId: string,
   options: OpenClawStateDatabaseOptions = {},
 ): PersistedClawWorkspaceFile[] {
-  const database = openOpenClawStateDatabase(options);
-  if (
-    options.readOnly &&
-    !database.db /* sqlite-allow-raw: read-only Claw workspace-file table-existence probe. */
-      .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'claw_workspace_files'")
-      .get()
-  ) {
+  const { db } = openOpenClawStateDatabase(options);
+  if (options.readOnly && !tableExists(db, "claw_workspace_files")) {
     return [];
   }
-  // sqlite-allow-raw: read-only Claw workspace-file lookup with a closed agent-id filter.
-  const rows =
-    database.db /* sqlite-allow-raw: read-only Claw workspace-file lookup with a closed agent-id filter. */
-      .prepare(
-        `SELECT schema_version, agent_id, workspace, target_path, source_path,
-              content_digest, status, created_at_ms, updated_at_ms
-         FROM claw_workspace_files
-        WHERE agent_id = ?
-        ORDER BY target_path`,
+  const { compiled, bind } = compileSqliteQueryBindings<string, WorkspaceFileRow>((parameter) =>
+    selectWorkspaceFiles(db)
+      .where(
+        "agent_id",
+        "=",
+        parameter((value) => value),
       )
-      .all(agentId) as WorkspaceFileRow[];
-  return rows.map(rowToWorkspaceFile);
+      .orderBy("target_path"),
+  );
+  // Preserve native list-read errors; write transactions own their separate failure lifecycle.
+  const rows = db.prepare(compiled.sql).all(...bind(agentId)) as WorkspaceFileRow[];
+  return rows.map((row) => rowToWorkspaceFile(row));
+}
+
+export function readAllClawWorkspaceFiles(
+  options: OpenClawStateDatabaseOptions,
+): PersistedClawWorkspaceFile[] {
+  const { db } = openOpenClawStateDatabase(options);
+  if (!tableExists(db, "claw_workspace_files")) {
+    return [];
+  }
+  const compiled = selectWorkspaceFiles(db).orderBy("agent_id").orderBy("target_path").compile();
+  // SAFETY: The canonical table and shared explicit projection provide this generated row shape.
+  const rows = db.prepare(compiled.sql).all() as WorkspaceFileRow[];
+  // Orphan inventory reports the stored version; per-agent inventory uses the current constant.
+  return rows.map((row) =>
+    rowToWorkspaceFile(row, row.schema_version as PersistedClawWorkspaceFile["schemaVersion"]),
+  );
 }
 
 export async function createClawWorkspaceFiles(

--- a/src/claws/workspace.ts
+++ b/src/claws/workspace.ts
@@ -293,8 +293,10 @@ export function readClawWorkspaceFiles(
       )
       .orderBy("target_path"),
   );
-  // Preserve native list-read errors; write transactions own their separate failure lifecycle.
-  const rows = db.prepare(compiled.sql).all(...bind(agentId)) as WorkspaceFileRow[];
+  const rows =
+    db /* sqlite-allow-raw: preserve native list errors outside the write-transaction owner. */
+      .prepare(compiled.sql)
+      .all(...bind(agentId)) as WorkspaceFileRow[];
   return rows.map((row) => rowToWorkspaceFile(row));
 }
 
@@ -306,8 +308,11 @@ export function readAllClawWorkspaceFiles(
     return [];
   }
   const compiled = selectWorkspaceFiles(db).orderBy("agent_id").orderBy("target_path").compile();
-  // SAFETY: The canonical table and shared explicit projection provide this generated row shape.
-  const rows = db.prepare(compiled.sql).all() as WorkspaceFileRow[];
+  const rows =
+    db /* sqlite-allow-raw: preserve native orphan inventory errors without a write transaction. */
+      .prepare(compiled.sql)
+      // SAFETY: The canonical table and shared explicit projection provide this generated row shape.
+      .all() as WorkspaceFileRow[];
   // Orphan inventory reports the stored version; per-agent inventory uses the current constant.
   return rows.map((row) =>
     rowToWorkspaceFile(row, row.schema_version as PersistedClawWorkspaceFile["schemaVersion"]),


### PR DESCRIPTION
## What Problem This Solves

Claw workspace provenance, status inventory, and removal maintained eleven ordinary SQL statement sites and duplicate row decoding beside the shared typed database layer. That made ownership and rollback behavior harder to maintain consistently.

## Why This Change Was Made

Move those queries to existing Kysely helpers and generated table types. The workspace owner now supplies the shared projection and global orphan inventory. Preserve the distinct strict point-read and permissive inventory contracts, all seven upsert replacement fields, exact affected-row refusal, native read error ownership, and ordered synchronous removal transactions.

This removes 37 production lines overall (188 added / 225 removed). Existing tests grow by 39 lines; the assertion baseline shrinks. SQLite schemas, representations, transaction boundaries, retention, configuration and public contracts are unchanged.

## User Impact

No intended behavior change. Add, update, export, retry and removal retain their current results, including edited-file preservation and rollback of creation timestamps. This continues database cleanup without enabling another database backend.

The separately reproduced config-owned monitor removal blocker remains a named follow-up: its ownership classification and Gateway cancellation barrier need a focused lifecycle repair. This query refactor preserves the current attached-job projection and policy.

## Evidence

- 190 tests passed across ten relevant files and two projects, covering workspace/update, lifecycle, approvals, read-only compatibility, export, doctor and the actual CLI suite. A final mapper-preservation edit then passed all 29 lifecycle tests and focused lint.
- The full changed gate passed, including type, formatting, lint, dead-export, ratchet, schema/storage and import-cycle checks.
- Paired native owner runs passed eight exercise phases and a fresh-process reopen with identical facts and schema fingerprint: unsupported provenance, exact affected-row refusal, full undo, opaque keys, attached-job duplicates/order, partial cleanup, warm-owner journal abort/rollback and successful retry, and borrowed read-only handle lifetime.
- Baseline and candidate each ran eleven actual local CLI commands through the source entry point against isolated synthetic state. Add, update, status, export and consented removal succeeded; invalid consent was refused without deletion; fresh status confirmed removal while edited files and sibling configuration remained intact. No Gateway or external model was needed for these local commands.
- Independent Codex review completed three passes with no P0–P2 findings. Direct Kysely and Node SQLite source contracts were inspected.

The first hosted CI run caught missing native-read exception annotations; those comments now pass the full changed gate and produce byte-identical JavaScript. A separate global timer mock failure in the same CI run was repaired in #138980 and is now merged. The annotation-only patch also passed an independent P2 review.
