### PR TITLE
fix: large new files show zero added lines in Review

### DIFF
--- a/src/gateway/server-methods/sessions-diff.test.ts
+++ b/src/gateway/server-methods/sessions-diff.test.ts
@@ -618,19 +618,129 @@ describe("loadSessionDiff", () => {
     expect(result.files.map((file) => file.path)).toEqual(["AGENTS.md"]);
   });
 
-  it("counts untracked additions whose content begins with plus signs", async () => {
+  it("keeps exact large-file counts and later previews when untracked patches are omitted", async () => {
+    initRepo(repoRoot);
+    const additions = 140_000;
+    fs.writeFileSync(path.join(repoRoot, "a-large.txt"), `${"x".repeat(127)}\n`.repeat(additions));
+    fs.writeFileSync(path.join(repoRoot, "b-large.bin"), Buffer.alloc(4 * 1024 * 1024 + 1));
+    // Each added line's prefix can push a small input beyond the output cap.
+    fs.writeFileSync(path.join(repoRoot, "c-expanded.txt"), "\n".repeat(100_000));
+    fs.writeFileSync(path.join(repoRoot, "z-small.txt"), "small addition\n");
+    mockSession(repoRoot);
+
+    const result = await loadSessionDiff({ sessionKey: "agent:main:s1" });
+
+    expect(result.files[0]).toEqual({
+      path: "a-large.txt",
+      status: "added",
+      additions,
+      deletions: 0,
+      untracked: true,
+      truncated: true,
+    });
+    expect(result.files[1]).toEqual({
+      path: "b-large.bin",
+      status: "added",
+      additions: 0,
+      deletions: 0,
+      untracked: true,
+      binary: true,
+    });
+    expect(result.files[2]).toEqual({
+      path: "c-expanded.txt",
+      status: "added",
+      additions: 100_000,
+      deletions: 0,
+      untracked: true,
+      truncated: true,
+    });
+    expect(result.files[3]?.patch).toContain("+small addition");
+    expect(result.additions).toBe(additions + 100_000 + 1);
+    expect(result.deletions).toBe(0);
+    expect(result.truncated).toBe(true);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "preserves tab, newline, and non-ASCII filenames in tracked and untracked statistics",
+    async () => {
+      initRepo(repoRoot);
+      const trackedPath = "tracked\tname\ncafé.txt";
+      const untrackedPath = "untracked\tname\ncafé.txt";
+      fs.writeFileSync(path.join(repoRoot, trackedPath), "initial\n");
+      git(repoRoot, "add", ".");
+      git(repoRoot, "commit", "-qm", "init");
+      fs.appendFileSync(path.join(repoRoot, trackedPath), "later\n");
+      fs.writeFileSync(path.join(repoRoot, untrackedPath), "one\ntwo\n");
+      mockSession(repoRoot);
+
+      const result = await loadSessionDiff({ sessionKey: "agent:main:s1" });
+
+      expect(result.files.map((file) => [file.path, file.additions, file.deletions])).toEqual([
+        [trackedPath, 1, 0],
+        [untrackedPath, 2, 0],
+      ]);
+      expect(result.additions).toBe(3);
+    },
+  );
+
+  it.each([
+    {
+      name: "ident contraction",
+      attribute: "ident",
+      content: Buffer.from(`$Id: ${"x".repeat(150_000)}$\n`),
+      normalized: "$Id$\n",
+    },
+    {
+      name: "working-tree encoding",
+      attribute: "working-tree-encoding=UTF-16LE",
+      content: Buffer.from(`${"A".repeat(60_000)}\n`, "utf16le"),
+      normalized: `${"A".repeat(60_000)}\n`,
+    },
+  ])(
+    "keeps fitting untracked previews after $name with verbose diagnostics",
+    async ({ attribute, content, normalized }) => {
+      initRepo(repoRoot);
+      fs.writeFileSync(
+        path.join(repoRoot, ".git", "verbose-filter.mjs"),
+        'process.stderr.write("diagnostic\\n".repeat(10_000)); process.stdin.pipe(process.stdout);\n',
+      );
+      git(repoRoot, "config", "filter.verbose.clean", "node .git/verbose-filter.mjs");
+      fs.writeFileSync(
+        path.join(repoRoot, ".gitattributes"),
+        `converted.txt ${attribute} filter=verbose\n`,
+      );
+      git(repoRoot, "add", ".gitattributes");
+      git(repoRoot, "commit", "-qm", "attributes");
+      fs.writeFileSync(path.join(repoRoot, "converted.txt"), content);
+      mockSession(repoRoot);
+
+      const result = await loadSessionDiff({ sessionKey: "agent:main:s1" });
+
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0]?.additions).toBe(1);
+      expect(result.files[0]?.patch?.includes(`+${normalized}`)).toBe(true);
+      expect(result.files[0]?.truncated).toBeUndefined();
+    },
+  );
+
+  it.each([
+    { name: "plus-prefixed content", content: "++i\n+++more\nplain\n", additions: 3 },
+    { name: "an empty file", content: "", additions: 0 },
+    { name: "an unterminated last line", content: "one\nlast", additions: 2 },
+  ])("counts untracked additions for $name", async ({ content, additions }) => {
     initRepo(repoRoot);
     fs.writeFileSync(path.join(repoRoot, "seed.txt"), "seed\n");
     git(repoRoot, "add", ".");
     git(repoRoot, "commit", "-qm", "init");
-    // Content lines rendered as `+++more`/`++i` must not be read as the header.
-    fs.writeFileSync(path.join(repoRoot, "diffish.txt"), "++i\n+++more\nplain\n");
+    fs.writeFileSync(path.join(repoRoot, "diffish.txt"), content);
     mockSession(repoRoot);
 
     const result = await loadSessionDiff({ sessionKey: "agent:main:s1" });
 
     const file = result.files.find((entry) => entry.path === "diffish.txt");
-    expect(file?.additions).toBe(3);
+    expect(file?.additions).toBe(additions);
+    expect(file?.patch).toBeDefined();
+    expect(file?.truncated).toBeUndefined();
   });
 
   it("rejects invalid params through the handler", async () => {

--- a/src/gateway/server-methods/sessions-diff.test.ts
+++ b/src/gateway/server-methods/sessions-diff.test.ts
@@ -1,6 +1,6 @@
 // Session diff RPC tests run against real throwaway git repos so the parsing
 // stays honest about git's -z output and --no-index untracked handling.
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -660,6 +660,57 @@ describe("loadSessionDiff", () => {
     expect(result.truncated).toBe(true);
   });
 
+  it.each([
+    { name: "custom prefixes", config: "srcPrefix = before/\n dstPrefix = after/" },
+    { name: "no prefixes", config: "noprefix = true" },
+    { name: "mnemonic prefixes", config: "mnemonicPrefix = true" },
+    { name: "oversized prefixes", config: `srcPrefix = ${"x".repeat(220_000)}` },
+  ])("keeps tracked and untracked previews under $name", async ({ config }) => {
+    initRepo(repoRoot);
+    fs.writeFileSync(path.join(repoRoot, "tracked.txt"), "before\n");
+    git(repoRoot, "add", ".");
+    git(repoRoot, "commit", "-qm", "init");
+    fs.appendFileSync(path.join(repoRoot, ".git", "config"), `\n[diff]\n ${config}\n`);
+    fs.appendFileSync(path.join(repoRoot, "tracked.txt"), "after\n");
+    fs.writeFileSync(path.join(repoRoot, "untracked.txt"), "new\n");
+    mockSession(repoRoot);
+
+    const result = await loadSessionDiff({ sessionKey: "agent:main:s1" });
+
+    expect(result.files.map((file) => [file.path, file.additions])).toEqual([
+      ["tracked.txt", 1],
+      ["untracked.txt", 1],
+    ]);
+    for (const file of result.files) {
+      expect(file.patch).toContain(`+++ b/${file.path}\n`);
+      expect(file.truncated).toBeUndefined();
+    }
+    expect(result.files[0]?.patch).toContain("--- a/tracked.txt\n");
+  });
+
+  it("keeps carriage-return header-like content as text in both diff paths", async () => {
+    initRepo(repoRoot);
+    fs.writeFileSync(path.join(repoRoot, "tracked.txt"), "before\n");
+    git(repoRoot, "add", ".");
+    git(repoRoot, "commit", "-qm", "init");
+    const content =
+      "\rBinary files a/x and b/x differ\n\r@@ -0,0 +1,999 @@\n\rdiff --git a/fake b/fake\n\r+++ b/fake\nlast\n";
+    fs.appendFileSync(path.join(repoRoot, "tracked.txt"), content);
+    fs.writeFileSync(path.join(repoRoot, "untracked.txt"), content);
+    mockSession(repoRoot);
+
+    const result = await loadSessionDiff({ sessionKey: "agent:main:s1" });
+
+    for (const file of result.files) {
+      expect(file.additions).toBe(5);
+      expect(file.binary).not.toBe(true);
+      for (const line of content.split("\n").slice(0, -1)) {
+        expect(file.patch).toContain(`+${line}\n`);
+      }
+    }
+    expect(result.additions).toBe(10);
+  });
+
   it.skipIf(process.platform === "win32")(
     "preserves tab, newline, and non-ASCII filenames in tracked and untracked statistics",
     async () => {
@@ -697,12 +748,12 @@ describe("loadSessionDiff", () => {
       normalized: `${"A".repeat(60_000)}\n`,
     },
   ])(
-    "keeps fitting untracked previews after $name with verbose diagnostics",
+    "keeps fitting untracked previews after $name without extra conversion passes",
     async ({ attribute, content, normalized }) => {
       initRepo(repoRoot);
       fs.writeFileSync(
         path.join(repoRoot, ".git", "verbose-filter.mjs"),
-        'process.stderr.write("diagnostic\\n".repeat(10_000)); process.stdin.pipe(process.stdout);\n',
+        'import { appendFileSync } from "node:fs"; appendFileSync(".git/filter-calls", "call\\n"); process.stderr.write("diagnostic\\n".repeat(10_000)); process.stdin.pipe(process.stdout);\n',
       );
       git(repoRoot, "config", "filter.verbose.clean", "node .git/verbose-filter.mjs");
       fs.writeFileSync(
@@ -712,6 +763,27 @@ describe("loadSessionDiff", () => {
       git(repoRoot, "add", ".gitattributes");
       git(repoRoot, "commit", "-qm", "attributes");
       fs.writeFileSync(path.join(repoRoot, "converted.txt"), content);
+      const native = spawnSync(
+        "git",
+        [
+          "-C",
+          repoRoot,
+          "diff",
+          "--no-color",
+          "--no-ext-diff",
+          "--no-textconv",
+          "--no-index",
+          "--",
+          "/dev/null",
+          "converted.txt",
+        ],
+        { encoding: "utf8" },
+      );
+      expect(native.status).toBe(1);
+      const callsPath = path.join(repoRoot, ".git", "filter-calls");
+      const nativeCalls = fs.readFileSync(callsPath, "utf8");
+      expect(nativeCalls.length).toBeGreaterThan(0);
+      fs.writeFileSync(callsPath, "");
       mockSession(repoRoot);
 
       const result = await loadSessionDiff({ sessionKey: "agent:main:s1" });
@@ -720,6 +792,7 @@ describe("loadSessionDiff", () => {
       expect(result.files[0]?.additions).toBe(1);
       expect(result.files[0]?.patch?.includes(`+${normalized}`)).toBe(true);
       expect(result.files[0]?.truncated).toBeUndefined();
+      expect(fs.readFileSync(callsPath, "utf8")).toBe(nativeCalls);
     },
   );
 

--- a/src/sessions/session-diff.ts
+++ b/src/sessions/session-diff.ts
@@ -28,6 +28,16 @@ const MAX_BASELINE_TOTAL_BYTES = 16 * 1024 * 1024;
 // Past this the full-patch git call is skipped entirely: runGit buffers stdout
 // in memory, so a pathological diff must degrade to stats-only entries.
 const MAX_TOTAL_CHANGED_LINES = 100_000;
+// Patch consumers require a/b paths. Pin formatting without changing Git's
+// content conversions; read-scoped RPCs must not execute diff/textconv drivers.
+const PATCH_DIFF_ARGS = [
+  "--patch",
+  "--no-color",
+  "--no-ext-diff",
+  "--no-textconv",
+  "--src-prefix=a/",
+  "--dst-prefix=b/",
+];
 
 type FileStatus = SessionDiffFile["status"];
 
@@ -146,21 +156,21 @@ export function parseNumstatZ(text: string): Map<string, NumstatEntry> {
 }
 
 function chunkPath(chunk: string): string | null {
-  const newFile = /^\+\+\+ b\/(.+)$/m.exec(chunk);
+  const newFile = /(?:^|\n)\+\+\+ b\/([^\n]+)(?:\n|$)/.exec(chunk);
   if (newFile) {
     return expectDefined(newFile[1], "new file capture group 1");
   }
   // Deleted files have `+++ /dev/null`; key the chunk by the old path.
-  const oldFile = /^--- a\/(.+)$/m.exec(chunk);
+  const oldFile = /(?:^|\n)--- a\/([^\n]+)(?:\n|$)/.exec(chunk);
   if (oldFile) {
     return expectDefined(oldFile[1], "old file capture group 1");
   }
   // Pure renames and binary chunks have neither marker line.
-  const renameTo = /^rename to (.+)$/m.exec(chunk);
+  const renameTo = /(?:^|\n)rename to ([^\n]+)(?:\n|$)/.exec(chunk);
   if (renameTo) {
     return expectDefined(renameTo[1], "rename to capture group 1");
   }
-  const header = /^diff --git a\/.+ b\/(.+)$/m.exec(chunk);
+  const header = /(?:^|\n)diff --git a\/[^\n]+ b\/([^\n]+)(?:\n|$)/.exec(chunk);
   return header ? expectDefined(header[1], "header capture group 1") : null;
 }
 
@@ -170,7 +180,8 @@ export function splitPatchByFile(patch: string): Map<string, string> {
   if (!patch.trim()) {
     return byPath;
   }
-  const parts = patch.split(/^(?=diff --git )/m);
+  // Git records end at LF; JavaScript multiline anchors also match content CRs.
+  const parts = patch.split(/(?<=\n)(?=diff --git )/);
   for (const part of parts) {
     if (!part.startsWith("diff --git ")) {
       continue;
@@ -183,8 +194,18 @@ export function splitPatchByFile(patch: string): Map<string, string> {
   return byPath;
 }
 
-function isBinaryChunk(chunk: string): boolean {
-  return /^Binary files .* differ$/m.test(chunk) || chunk.includes("\nGIT binary patch\n");
+function readPatchHeader(chunk: string): { additions?: number; binary: boolean } {
+  // A null-to-file addition has one hunk spanning the converted postimage.
+  // Stop at the first LF-delimited header so content (including CR) cannot
+  // masquerade as binary metadata or a later hunk.
+  const header = /(?:^|\n)(@@ [^\n]*|Binary files [^\n]* differ|GIT binary patch)\n/.exec(
+    chunk,
+  )?.[1];
+  const added = /^@@ -0,0 \+1(?:,(\d+))? @@(?: |$)/.exec(header ?? "");
+  return {
+    ...(added ? { additions: Number(added[1] ?? 1) } : {}),
+    binary: header !== undefined && !header.startsWith("@@ "),
+  };
 }
 
 /**
@@ -251,12 +272,6 @@ async function collectUntrackedFiles(
       file.truncated = true;
       continue;
     }
-    const patchLimit = Math.min(MAX_PATCH_BYTES_PER_FILE, budget.remaining);
-    // Git converts working-tree contents before diffing, so raw file size
-    // cannot establish whether its patch fits the remaining preview budget.
-    const includePatch = patchLimit > 0;
-    // --no-textconv: checkout-configurable textconv drivers must never run
-    // from this read-scoped RPC (same reason as --no-ext-diff).
     const result = await runCommandBuffered(
       [
         "git",
@@ -265,12 +280,7 @@ async function collectUntrackedFiles(
         "-c",
         "core.quotePath=false",
         "diff",
-        "--numstat",
-        "-z",
-        ...(includePatch ? ["--patch"] : []),
-        "--no-color",
-        "--no-ext-diff",
-        "--no-textconv",
+        ...PATCH_DIFF_ARGS,
         "--no-index",
         "--",
         "/dev/null",
@@ -279,18 +289,16 @@ async function collectUntrackedFiles(
       {
         timeoutMs: GIT_TIMEOUT_MS,
         env: gitEnvironment(),
-        maxOutputBytes: MAX_PATCH_BYTES_PER_FILE + patchLimit,
+        maxOutputBytes: MAX_PATCH_BYTES_PER_FILE,
         // This RPC does not consume Git diagnostics. Verbose converters must
         // not abort otherwise valid diff output by filling an unused stream.
         discardOutput: { stderr: true },
       },
     );
     const patchTruncated =
-      includePatch &&
-      result.termination === "output-limit" &&
-      result.outputLimitStream === "stdout";
-    // --no-index exits 1 for differences, but also for missing input. Require
-    // complete numstat metadata before retaining counts from a capped patch.
+      result.termination === "output-limit" && result.outputLimitStream === "stdout";
+    // --no-index exits 1 for differences, but also for missing input, which
+    // has no patch. A complete first hunk retains counts even when its body clips.
     if (
       !patchTruncated &&
       (result.termination !== "exit" || (result.code !== 0 && result.code !== 1))
@@ -298,26 +306,18 @@ async function collectUntrackedFiles(
       file.truncated = true;
       continue;
     }
-    const output = result.stdout.toString("utf8");
-    // Git separates NUL-delimited numstat records from the patch with an
-    // additional NUL; pathnames cannot contain this boundary.
-    const metadataEnd = includePatch
-      ? output.indexOf("\0\0") + 1
-      : output.endsWith("\0")
-        ? output.length
-        : 0;
-    const stat = parseNumstatZ(output.slice(0, metadataEnd)).get(filePath);
-    if (!stat) {
+    const patch = result.stdout.toString("utf8");
+    if (!patch.startsWith("diff --git ")) {
       file.truncated = true;
       continue;
     }
-    file.additions = stat.additions;
-    if (stat.binary) {
+    const header = readPatchHeader(patch);
+    file.additions = header.additions ?? 0;
+    if (header.binary) {
       file.binary = true;
       continue;
     }
-    const patch = includePatch && !patchTruncated ? output.slice(metadataEnd + 1) : undefined;
-    Object.assign(file, takePatch(patch, budget));
+    Object.assign(file, takePatch(patchTruncated ? undefined : patch, budget));
   }
   return { files, truncated };
 }
@@ -343,19 +343,17 @@ async function collectTrackedFiles(
     (sum, entry) => sum + entry.additions + entry.deletions,
     0,
   );
-  // --no-textconv alongside --no-ext-diff: repo config + .gitattributes can
-  // define textconv commands, and a read RPC must never execute them.
   const patchText =
     totalChangedLines > MAX_TOTAL_CHANGED_LINES
       ? null
-      : await gitOut(root, diffArgs(["--patch", "--no-color", "--no-ext-diff", "--no-textconv"]));
+      : await gitOut(root, diffArgs(PATCH_DIFF_ARGS));
   const chunks = patchText === null ? new Map<string, string>() : splitPatchByFile(patchText);
   const truncated = entries.length > MAX_FILES;
   const files: SessionDiffFile[] = [];
   for (const entry of entries.slice(0, MAX_FILES)) {
     const stat = numstat.get(entry.path);
     const chunk = chunks.get(entry.path);
-    const binary = stat?.binary === true || (chunk !== undefined && isBinaryChunk(chunk));
+    const binary = stat?.binary === true || (chunk !== undefined && readPatchHeader(chunk).binary);
     const file: SessionDiffFile = {
       path: entry.path,
       status: entry.status,

--- a/src/sessions/session-diff.ts
+++ b/src/sessions/session-diff.ts
@@ -10,6 +10,7 @@ import type {
 } from "../../packages/gateway-protocol/src/index.js";
 import { gitEnvironment, runGit } from "../agents/worktrees/git.js";
 import type { SessionDiffBaseline } from "../config/sessions/types.js";
+import { GIT_TIMEOUT_MS } from "../infra/git-exec.js";
 import { runCommandBuffered } from "../process/exec.js";
 import {
   loadSessionDiffBranchMetadata,
@@ -119,7 +120,8 @@ export function parseNumstatZ(text: string): Map<string, NumstatEntry> {
     if (!token) {
       continue;
     }
-    const [added, deleted, inlinePath] = token.split("\t");
+    const [added, deleted, ...pathParts] = token.split("\t");
+    const inlinePath = pathParts.join("\t");
     if (added === undefined || deleted === undefined) {
       continue;
     }
@@ -185,23 +187,6 @@ function isBinaryChunk(chunk: string): boolean {
   return /^Binary files .* differ$/m.test(chunk) || chunk.includes("\nGIT binary patch\n");
 }
 
-function countPatchAdditions(chunk: string): number {
-  let additions = 0;
-  let inHunk = false;
-  for (const line of chunk.split("\n")) {
-    if (line.startsWith("@@")) {
-      inHunk = true;
-      continue;
-    }
-    // Count only hunk-body additions so a `+++foo` content line is not mistaken
-    // for the `+++ b/path` header (which always precedes the first hunk).
-    if (inHunk && line.startsWith("+")) {
-      additions += 1;
-    }
-  }
-  return additions;
-}
-
 /**
  * A patch-producing `git diff` reads working-tree file contents, so a
  * checkout-planted hardlink to an out-of-tree secret would otherwise leak
@@ -253,25 +238,36 @@ async function collectUntrackedFiles(
   const truncated = paths.length > MAX_UNTRACKED_FILES;
   const files: SessionDiffFile[] = [];
   for (const filePath of paths.slice(0, MAX_UNTRACKED_FILES)) {
+    const file: SessionDiffFile = {
+      path: filePath,
+      status: "added",
+      additions: 0,
+      deletions: 0,
+      untracked: true,
+    };
+    files.push(file);
     // Hardlink/escape guard before git reads the file contents.
     if (!(await isPatchableWorkingTreePath(realRoot, filePath))) {
-      files.push({
-        path: filePath,
-        status: "added",
-        additions: 0,
-        deletions: 0,
-        untracked: true,
-        truncated: true,
-      });
+      file.truncated = true;
       continue;
     }
-    // Exit code 1 is git's "files differ" for --no-index, not a failure.
+    const patchLimit = Math.min(MAX_PATCH_BYTES_PER_FILE, budget.remaining);
+    // Git converts working-tree contents before diffing, so raw file size
+    // cannot establish whether its patch fits the remaining preview budget.
+    const includePatch = patchLimit > 0;
     // --no-textconv: checkout-configurable textconv drivers must never run
     // from this read-scoped RPC (same reason as --no-ext-diff).
-    const patch = await gitOut(
-      root,
+    const result = await runCommandBuffered(
       [
+        "git",
+        "-C",
+        root,
+        "-c",
+        "core.quotePath=false",
         "diff",
+        "--numstat",
+        "-z",
+        ...(includePatch ? ["--patch"] : []),
         "--no-color",
         "--no-ext-diff",
         "--no-textconv",
@@ -280,39 +276,48 @@ async function collectUntrackedFiles(
         "/dev/null",
         filePath,
       ],
-      [0, 1],
+      {
+        timeoutMs: GIT_TIMEOUT_MS,
+        env: gitEnvironment(),
+        maxOutputBytes: MAX_PATCH_BYTES_PER_FILE + patchLimit,
+        // This RPC does not consume Git diagnostics. Verbose converters must
+        // not abort otherwise valid diff output by filling an unused stream.
+        discardOutput: { stderr: true },
+      },
     );
-    if (patch === null) {
-      files.push({
-        path: filePath,
-        status: "added",
-        additions: 0,
-        deletions: 0,
-        untracked: true,
-        truncated: true,
-      });
+    const patchTruncated =
+      includePatch &&
+      result.termination === "output-limit" &&
+      result.outputLimitStream === "stdout";
+    // --no-index exits 1 for differences, but also for missing input. Require
+    // complete numstat metadata before retaining counts from a capped patch.
+    if (
+      !patchTruncated &&
+      (result.termination !== "exit" || (result.code !== 0 && result.code !== 1))
+    ) {
+      file.truncated = true;
       continue;
     }
-    if (isBinaryChunk(patch)) {
-      files.push({
-        path: filePath,
-        status: "added",
-        additions: 0,
-        deletions: 0,
-        untracked: true,
-        binary: true,
-      });
+    const output = result.stdout.toString("utf8");
+    // Git separates NUL-delimited numstat records from the patch with an
+    // additional NUL; pathnames cannot contain this boundary.
+    const metadataEnd = includePatch
+      ? output.indexOf("\0\0") + 1
+      : output.endsWith("\0")
+        ? output.length
+        : 0;
+    const stat = parseNumstatZ(output.slice(0, metadataEnd)).get(filePath);
+    if (!stat) {
+      file.truncated = true;
       continue;
     }
-    const additions = countPatchAdditions(patch);
-    files.push({
-      path: filePath,
-      status: "added",
-      additions,
-      deletions: 0,
-      untracked: true,
-      ...takePatch(patch, budget),
-    });
+    file.additions = stat.additions;
+    if (stat.binary) {
+      file.binary = true;
+      continue;
+    }
+    const patch = includePatch && !patchTruncated ? output.slice(metadataEnd + 1) : undefined;
+    Object.assign(file, takePatch(patch, budget));
   }
   return { files, truncated };
 }


### PR DESCRIPTION
Related: #138877

## What Problem This Solves

Review can report zero added lines for very large new text files, omit tracked previews when Git uses custom path prefixes, or mistake carriage-return text for binary metadata or another file.

## Why This Change Was Made

The session diff owner now reads a new file's complete line count from Git's first hunk header, which describes the entire converted postimage for `/dev/null` additions. It captures one bounded patch prefix instead of counting lines in a clipped tail or requesting a second statistics pass. Tracked counts continue to use Git's NUL-delimited numstat metadata.

Both patch-producing paths explicitly use the `a/` and `b/` prefixes already expected by the parser. Header classification and file splitting recognize LF record boundaries, so carriage returns in content cannot impersonate metadata. Git still owns clean filters, working-tree encoding, `ident`, and binary classification.

## User Impact

Large files retain accurate counts when their previews are omitted, and later small-file previews remain available. Valid custom, absent, or mnemonic Git prefixes no longer hide previews. Text containing header-like content stays visible as text.

The Gateway retains at most 100,000 stdout bytes per new-file command and preserves the existing 100 KB per-file /1.5 MB total preview budgets. Fitting converted files retain their previews; verbose unused diagnostics cannot abort valid output. The final flow matches native patch-only Git's converter invocation count. This bounds Gateway capture and parsing work; it is not a production latency benchmark.

## Evidence

- The original real-Git regression fails with a 140,000-line, 17,920,000-byte new file reporting zero additions. The repaired owner retains the full count without returning a clipped preview.
- Seven additional real-owner regressions failed on the preceding candidate: four configured-prefix variants, carriage-return text misclassified as binary, and two converters running four times versus native Git's two. A strengthened carriage-return case separately reproduced a fake-file split before the LF-boundary repair.
- All 57 focused tests pass across the RPC, revision, and baseline owners. Coverage includes binary and empty files, missing final newlines, plus-prefixed content, large patches and later previews, odd filename counts, commit scopes, baseline filtering, hardlinks, and textconv/fsmonitor guards.
- Ident and UTF-16 cases compare actual converter invocation logs with native patch-only Git, preserving fitting previews and 110 KB of diagnostic output per invocation.
- Fresh managed independent P2 review found no actionable findings. The complete Linux changed-source gate passed all 29 checks in 728.123 seconds, and the separately built Gateway/Control UI comparison passed the four-file contract.
- The original CI run exposed an unrelated timer-fixture failure (`slot.idleTimer.unref is not a function`). That issue is now fixed on main by [#138980](https://github.com/openclaw/openclaw/pull/138980), merged as `cd4504de2dae09abbd1786ccca3b193535a1a01d`, with its exact-head CI green. This PR leaves those fixtures unchanged and retains only the two-file Review repair.
- The final PR head is the exact reviewed and Linux-tested `a6ceb4401e60b32b5778e421666f4ddf82dd04bd`. It merges cleanly with main containing the upstream timer repair; [fresh exact-head CI33960532559](https://github.com/openclaw/openclaw/actions/runs/33960532559) completed successfully before landing.

Local Git 2.55.0 and direct upstream source establish the count contract: [contiguous edit script](https://github.com/git/git/blob/v2.55.0/xdiff/xdiffi.c#L975), [complete range emitted before the body](https://github.com/git/git/blob/v2.55.0/xdiff/xemit.c#L238), and [hunk header grammar](https://github.com/git/git/blob/v2.55.0/xdiff/xutils.c#L391). Stable v2026.9.1 contains the original tail-counting mechanism; introduction provenance is unknown.

Production is +76/-73 (net 3); tests are +188/-5. The small production increase is the bounded header/result handling and canonical format boundary after removing the manual line counter and repeated patch flags. No OpenClaw configuration, schema, dependency, or RPC shape change. Serial Git discovery/command cost and existing quoted tab/newline filename preview parsing remain separate follow-ups.

The first Linux launch stopped before upload because its isolated clone lacked the canonical main reference. Only that staging metadata was repaired; the unchanged candidate then passed. The original staging failure and the unrelated initial CI failure remain in the proof record.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/138961#issuecomment-5551000642) found no code defect and requested the built Gateway/Review before-and-after evidence. That request is complete in the verified evidence and captures below; no requested move is skipped.

### Before and after

The actual CLI and browser agree: the baseline reports 7 additions and hides the tracked preview; the fix reports 140,007 and renders all five tracked text lines. Both revisions invoke the converter twice per CLI/browser phase. All screenshots and recordings contain synthetic data only.

**Before**

![Before: zero large-file count and missing tracked preview](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjU4NDkz/openclaw/pr-138961/sessions-diff-v5-20260905-a6ceb440/before.png?X-Amz-Expires=604800&X-Amz-Date=20260905T100106Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260905%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=7754e60bb344f8ebfd906e48a11ded6f194305e49c6cfe6fafc1654904159a08)

**After**

![After: complete counts and tracked text preview](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjU4NDkz/openclaw/pr-138961/sessions-diff-v5-20260905-a6ceb440/after.png?X-Amz-Expires=604800&X-Amz-Date=20260905T100106Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260905%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=50bdafd6c586edba0f4495f51bcc813caac2008a6c4355241e8727c4ccd34419)

**Before recording**

https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjU4NDkz/openclaw/pr-138961/sessions-diff-v5-20260905-a6ceb440/before.webm?X-Amz-Expires=604800&X-Amz-Date=20260905T100106Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260905%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=ace8dc706c7e069bb856ae1a1fecf411c0c8907d1144282485eb6a8a486326fc

**After recording**

https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjU4NDkz/openclaw/pr-138961/sessions-diff-v5-20260905-a6ceb440/after.webm?X-Amz-Expires=604800&X-Amz-Date=20260905T100106Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260905%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=95f19fa3b29894196312c891b1ea8bf5f42686337b40e7d372fc0bc2a56759de

[Proof summary](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjU4NDkz/openclaw/pr-138961/sessions-diff-v5-20260905-a6ceb440/summary.md?X-Amz-Expires=604800&X-Amz-Date=20260905T100106Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260905%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=a9b7a51117e269778087a733b167eda8a4b8d96d97211535918dd44c394e9276) · [Artifact manifest](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjU4NDkz/openclaw/pr-138961/sessions-diff-v5-20260905-a6ceb440/artifact-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260905T100112Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260905%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=dab880836dfd47c8f4ff3d349524d24303a5808c58ca40e6adfca8a97f02f273)

Media links expire September 12, 2026 at 10:01 UTC. The original candidate recording has compression artifacts near its end; the full screenshots and earlier frames show the result clearly.
