### PR TITLE
refactor(proxy-capture): type session and event writes

### DIFF
--- a/src/proxy-capture/store.sqlite.test.ts
+++ b/src/proxy-capture/store.sqlite.test.ts
@@ -237,6 +237,24 @@ describe("DebugProxyCaptureStore", () => {
       dbPath,
       blobDir,
     });
+    lease.store.upsertSession({
+      id: "legacy-sdk-session",
+      startedAt: 0,
+      mode: "replacement",
+      sourceScope: "openclaw",
+      sourceProcess: "updated-plugin",
+      dbPath: "unused-database",
+      blobDir: "unused-blobs",
+    });
+    expect(lease.store.listSessions()).toEqual([
+      expect.objectContaining({
+        startedAt: 1,
+        mode: "sdk",
+        sourceProcess: "updated-plugin",
+        endedAt: null,
+        proxyUrl: null,
+      }),
+    ]);
     const blob = lease.store.persistPayload(Buffer.from("legacy sdk payload"), "text/plain");
     lease.store.recordEvent({
       sessionId: "legacy-sdk-session",
@@ -374,6 +392,58 @@ describe("DebugProxyCaptureStore", () => {
     }
   });
 
+  it.each(["shared", "path"] as const)(
+    "retries a rejected %s event without retaining an implicit session",
+    (kind) => {
+      const env = makeStateEnv("openclaw-proxy-capture-write-");
+      const lease =
+        kind === "shared"
+          ? acquireDebugProxyCaptureStore({ env })
+          : acquireDebugProxyCaptureStore(
+              path.join(env.OPENCLAW_STATE_DIR!, "capture.sqlite"),
+              path.join(env.OPENCLAW_STATE_DIR!, "blobs"),
+            );
+      const event = {
+        sessionId: "rejected-event",
+        ts: 7,
+        sourceScope: "openclaw",
+        sourceProcess: "capture-test",
+        protocol: "wss",
+        direction: "inbound",
+        kind: "ws-close",
+        flowId: "write-flow",
+        status: 429,
+        closeCode: 1001,
+        headersJson: '{"x-fixture":"header"}',
+        dataText: "preview",
+        dataSha256: "payload-hash",
+        errorText: "fixture error",
+        metaJson: '{"fixture":true}',
+      } as const;
+      try {
+        lease.store.db.setAuthorizer((action, table) =>
+          action === constants.SQLITE_INSERT && table === "capture_events"
+            ? constants.SQLITE_DENY
+            : constants.SQLITE_OK,
+        );
+        expect(() => lease.store.recordEvent(event)).toThrow(/not authorized/u);
+        lease.store.db.setAuthorizer(null);
+        expect(lease.store.listSessions()).toEqual([]);
+        expect(lease.store.getSessionEvents(event.sessionId)).toEqual([]);
+
+        lease.store.recordEvent(event);
+
+        expect(lease.store.getSessionEvents(event.sessionId)).toEqual([
+          expect.objectContaining({ ...event, dataBlobId: null }),
+        ]);
+        expect(lease.store.listSessions()).toHaveLength(kind === "shared" ? 1 : 0);
+      } finally {
+        lease.store.db.setAuthorizer(null);
+        lease.release();
+      }
+    },
+  );
+
   it.runIf(process.platform !== "win32")(
     "stores capture blobs in the private shared state database",
     () => {
@@ -430,6 +500,17 @@ describe("DebugProxyCaptureStore", () => {
       data: '{"ok":true}',
       contentType: "application/json",
     });
+    const firstBlob = store.db
+      .prepare("SELECT * FROM capture_blobs WHERE blob_id = ?")
+      .get(firstPayload.dataBlobId ?? "");
+    const duplicateBlob = store.persistPayload(Buffer.from('{"ok":true}'), "text/plain");
+    expect(duplicateBlob).toMatchObject({
+      blobId: firstPayload.dataBlobId,
+      contentType: "text/plain",
+    });
+    expect(
+      store.db.prepare("SELECT * FROM capture_blobs WHERE blob_id = ?").get(duplicateBlob.blobId),
+    ).toEqual(firstBlob);
     store.recordEvent({
       sessionId: "session-1",
       ts: 1,
@@ -501,6 +582,22 @@ describe("DebugProxyCaptureStore", () => {
     expect(store.getSessionEvents("session-direct", 10)[0]).toMatchObject({
       dataBlobId: null,
     });
+    store.recordEvent({
+      sessionId: "session-direct",
+      ts: 1,
+      sourceScope: "openclaw",
+      sourceProcess: "another-provider",
+      protocol: "https",
+      direction: "outbound",
+      kind: "request",
+      flowId: "earlier-flow",
+      dataBlobId: "",
+    });
+    expect(store.listSessions()[0]).toMatchObject({ startedAt: 20, mode: "implicit" });
+    expect(store.getSessionEvents("session-direct").map((event) => event.dataBlobId)).toEqual([
+      null,
+      null,
+    ]);
 
     store.upsertSession({
       id: "session-direct",
@@ -508,12 +605,24 @@ describe("DebugProxyCaptureStore", () => {
       mode: "runtime",
       sourceScope: "openclaw",
       sourceProcess: "openclaw",
+      endedAt: 40,
+      proxyUrl: "http://synthetic.invalid",
+    });
+    store.upsertSession({
+      id: "session-direct",
+      startedAt: 30,
+      mode: "replacement",
+      sourceScope: "openclaw",
+      sourceProcess: "updated-process",
     });
 
     expect(store.listSessions(10)[0]).toMatchObject({
       id: "session-direct",
       mode: "runtime",
       startedAt: 10,
+      endedAt: null,
+      proxyUrl: null,
+      sourceProcess: "updated-process",
     });
   });
 

--- a/src/proxy-capture/store.sqlite.ts
+++ b/src/proxy-capture/store.sqlite.ts
@@ -6,6 +6,7 @@ import { StringDecoder } from "node:string_decoder";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { sha256Hex } from "../infra/crypto-digest.js";
+import { compileSqliteQueryBindings, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
@@ -16,6 +17,7 @@ import {
   registerSqliteCacheExitClose,
   type SqliteWalMaintenance,
 } from "../infra/sqlite-wal.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -45,6 +47,17 @@ type DebugProxyCaptureStoreOptions = {
 type PathBasedDebugProxyCaptureStore = {
   blobDir: string;
   walMaintenance: SqliteWalMaintenance;
+};
+
+type CaptureDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "capture_sessions" | "capture_events" | "capture_blobs"
+>;
+type LegacyCaptureDatabase = Pick<CaptureDatabase, "capture_events"> & {
+  capture_sessions: CaptureDatabase["capture_sessions"] & {
+    db_path: string;
+    blob_dir: string;
+  };
 };
 
 const DEBUG_PROXY_CAPTURE_DIR_MODE = 0o700;
@@ -251,63 +264,70 @@ class DebugProxyCaptureStoreImpl {
   }
 
   upsertSession(session: CaptureSessionRecord): void {
-    if (this.pathBased) {
-      this.db
-        .prepare(
-          `INSERT INTO capture_sessions (
-            id, started_at, ended_at, mode, source_scope, source_process, proxy_url, db_path, blob_dir
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-          ON CONFLICT(id) DO UPDATE SET
-            ended_at=excluded.ended_at,
-            proxy_url=excluded.proxy_url,
-            source_process=excluded.source_process`,
-        )
-        .run(
-          session.id,
-          session.startedAt,
-          session.endedAt ?? null,
-          session.mode,
-          session.sourceScope,
-          session.sourceProcess,
-          session.proxyUrl ?? null,
-          session.dbPath ?? this.dbPath,
-          session.blobDir ?? this.pathBased.blobDir,
+    const pathBased = this.pathBased;
+    const { compiled, bind } = compileSqliteQueryBindings<CaptureSessionRecord>((parameter) => {
+      const values = {
+        id: parameter((value) => value.id),
+        started_at: parameter((value) => value.startedAt),
+        ended_at: parameter((value) => value.endedAt ?? null),
+        mode: parameter((value) => value.mode),
+        source_scope: parameter((value) => value.sourceScope),
+        source_process: parameter((value) => value.sourceProcess),
+        proxy_url: parameter((value) => value.proxyUrl ?? null),
+      };
+      if (pathBased) {
+        return getNodeSqliteKysely<LegacyCaptureDatabase>(this.db)
+          .insertInto("capture_sessions")
+          .values({
+            ...values,
+            db_path: parameter((value) => value.dbPath ?? this.dbPath),
+            blob_dir: parameter((value) => value.blobDir ?? pathBased.blobDir),
+          })
+          .onConflict((conflict) =>
+            conflict.column("id").doUpdateSet((eb) => ({
+              ended_at: eb.ref("excluded.ended_at"),
+              proxy_url: eb.ref("excluded.proxy_url"),
+              source_process: eb.ref("excluded.source_process"),
+            })),
+          );
+      }
+      return getNodeSqliteKysely<CaptureDatabase>(this.db)
+        .insertInto("capture_sessions")
+        .values(values)
+        .onConflict((conflict) =>
+          conflict.column("id").doUpdateSet((eb) => ({
+            started_at: eb.fn<number>("min", [
+              "capture_sessions.started_at",
+              "excluded.started_at",
+            ]),
+            ended_at: eb.ref("excluded.ended_at"),
+            mode: eb
+              .case()
+              .when("capture_sessions.mode", "=", "implicit")
+              .then(eb.ref("excluded.mode"))
+              .else(eb.ref("capture_sessions.mode"))
+              .end(),
+            proxy_url: eb.ref("excluded.proxy_url"),
+            source_process: eb.ref("excluded.source_process"),
+          })),
         );
+    });
+    const upsert = () => this.db.prepare(compiled.sql).run(...bind(session));
+    if (pathBased) {
+      upsert();
       return;
     }
-    runSharedDebugProxyCaptureWrite(this, () =>
-      this.db
-        .prepare(
-          `INSERT INTO capture_sessions (
-            id, started_at, ended_at, mode, source_scope, source_process, proxy_url
-          ) VALUES (?, ?, ?, ?, ?, ?, ?)
-          ON CONFLICT(id) DO UPDATE SET
-            started_at=MIN(capture_sessions.started_at, excluded.started_at),
-            ended_at=excluded.ended_at,
-            mode=CASE
-              WHEN capture_sessions.mode = 'implicit' THEN excluded.mode
-              ELSE capture_sessions.mode
-            END,
-            proxy_url=excluded.proxy_url,
-            source_process=excluded.source_process`,
-        )
-        .run(
-          session.id,
-          session.startedAt,
-          session.endedAt ?? null,
-          session.mode,
-          session.sourceScope,
-          session.sourceProcess,
-          session.proxyUrl ?? null,
-        ),
-    );
+    runSharedDebugProxyCaptureWrite(this, upsert);
   }
 
   endSession(sessionId: string, endedAt = Date.now()): void {
-    const update = () =>
-      this.db
-        .prepare(`UPDATE capture_sessions SET ended_at = ? WHERE id = ?`)
-        .run(endedAt, sessionId);
+    const { compiled, bind } = compileSqliteQueryBindings<void>(() =>
+      getNodeSqliteKysely<CaptureDatabase>(this.db)
+        .updateTable("capture_sessions")
+        .set({ ended_at: endedAt })
+        .where("id", "=", sessionId),
+    );
+    const update = () => this.db.prepare(compiled.sql).run(...bind());
     if (this.pathBased) {
       update();
       return;
@@ -339,23 +359,22 @@ class DebugProxyCaptureStoreImpl {
         ...(contentType ? { contentType } : {}),
       };
     }
-    runSharedDebugProxyCaptureWrite(this, () =>
-      this.db
-        .prepare(
-          `INSERT OR IGNORE INTO capture_blobs (
-            blob_id, content_type, encoding, size_bytes, sha256, data, created_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-        )
-        .run(
-          blobId,
-          contentType ?? null,
-          "gzip",
-          data.byteLength,
+    const { compiled, bind } = compileSqliteQueryBindings<Buffer>((parameter) =>
+      getNodeSqliteKysely<CaptureDatabase>(this.db)
+        .insertInto("capture_blobs")
+        .orIgnore()
+        .values({
+          blob_id: blobId,
+          content_type: contentType ?? null,
+          encoding: "gzip",
+          size_bytes: parameter((value) => value.byteLength),
           sha256,
-          gzipSync(data),
-          Date.now(),
-        ),
+          data: parameter((value) => gzipSync(value)),
+          created_at: parameter(() => Date.now()),
+        }),
     );
+    // Prepare errors must precede payload compression and its creation timestamp.
+    runSharedDebugProxyCaptureWrite(this, () => this.db.prepare(compiled.sql).run(...bind(data)));
     return {
       blobId,
       encoding: "gzip",
@@ -374,55 +393,69 @@ class DebugProxyCaptureStoreImpl {
       // Capture can be invoked directly by provider seams before the top-level
       // runtime initializes. Keep the shared-schema foreign key valid without
       // making diagnostics break the request they are observing.
-      this.db
-        .prepare(
-          `INSERT OR IGNORE INTO capture_sessions (
-            id, started_at, mode, source_scope, source_process
-          ) VALUES (?, ?, 'implicit', ?, ?)`,
-        )
-        .run(event.sessionId, event.ts, event.sourceScope, event.sourceProcess);
+      const implicitSession = compileSqliteQueryBindings<CaptureEventRecord>((parameter) =>
+        getNodeSqliteKysely<CaptureDatabase>(this.db)
+          .insertInto("capture_sessions")
+          .orIgnore()
+          .values({
+            id: parameter((value) => value.sessionId),
+            started_at: parameter((value) => value.ts),
+            mode: "implicit",
+            source_scope: parameter((value) => value.sourceScope),
+            source_process: parameter((value) => value.sourceProcess),
+          }),
+      );
+      this.db.prepare(implicitSession.compiled.sql).run(...implicitSession.bind(event));
       // A concurrent purge can remove a payload before its event is recorded.
       // Keep the inline preview instead of failing the observed request.
-      const dataBlobId =
-        event.dataBlobId &&
-        this.db.prepare(`SELECT 1 FROM capture_blobs WHERE blob_id = ?`).get(event.dataBlobId)
+      let dataBlobId: string | null = null;
+      if (event.dataBlobId) {
+        const blob = compileSqliteQueryBindings<string>((parameter) =>
+          getNodeSqliteKysely<CaptureDatabase>(this.db)
+            .selectFrom("capture_blobs")
+            .select((eb) => eb.lit(1).as("present"))
+            .where(
+              "blob_id",
+              "=",
+              parameter((value) => value),
+            ),
+        );
+        dataBlobId = this.db.prepare(blob.compiled.sql).get(...blob.bind(event.dataBlobId))
           ? event.dataBlobId
           : null;
+      }
       this.insertEvent(event, dataBlobId);
     });
   }
 
   private insertEvent(event: CaptureEventRecord, dataBlobId: string | null): void {
-    this.db
-      .prepare(
-        `INSERT INTO capture_events (
-          session_id, ts, source_scope, source_process, protocol, direction, kind, flow_id,
-          method, host, path, status, close_code, content_type, headers_json,
-          data_text, data_blob_id, data_sha256, error_text, meta_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        event.sessionId,
-        event.ts,
-        event.sourceScope,
-        event.sourceProcess,
-        event.protocol,
-        event.direction,
-        event.kind,
-        event.flowId,
-        event.method ?? null,
-        event.host ?? null,
-        event.path ?? null,
-        event.status ?? null,
-        event.closeCode ?? null,
-        event.contentType ?? null,
-        event.headersJson ?? null,
-        event.dataText ?? null,
-        dataBlobId,
-        event.dataSha256 ?? null,
-        event.errorText ?? null,
-        event.metaJson ?? null,
-      );
+    const { compiled, bind } = compileSqliteQueryBindings<CaptureEventRecord>((parameter) =>
+      getNodeSqliteKysely<CaptureDatabase>(this.db)
+        .insertInto("capture_events")
+        .values({
+          session_id: parameter((value) => value.sessionId),
+          ts: parameter((value) => value.ts),
+          source_scope: parameter((value) => value.sourceScope),
+          source_process: parameter((value) => value.sourceProcess),
+          protocol: parameter((value) => value.protocol),
+          direction: parameter((value) => value.direction),
+          kind: parameter((value) => value.kind),
+          flow_id: parameter((value) => value.flowId),
+          method: parameter((value) => value.method ?? null),
+          host: parameter((value) => value.host ?? null),
+          path: parameter((value) => value.path ?? null),
+          status: parameter((value) => value.status ?? null),
+          close_code: parameter((value) => value.closeCode ?? null),
+          content_type: parameter((value) => value.contentType ?? null),
+          headers_json: parameter((value) => value.headersJson ?? null),
+          data_text: parameter((value) => value.dataText ?? null),
+          data_blob_id: dataBlobId,
+          data_sha256: parameter((value) => value.dataSha256 ?? null),
+          error_text: parameter((value) => value.errorText ?? null),
+          meta_json: parameter((value) => value.metaJson ?? null),
+        }),
+    );
+    this.db.prepare(compiled.sql).run(...bind(event));
   }
 
   listSessions(limit = 50): CaptureSessionSummary[] {


### PR DESCRIPTION
# refactor(proxy-capture): type session and event writes

## What Problem This Solves

Capture writes maintained handwritten column lists and positional bindings alongside the shared database types. That duplication makes storage changes harder to check while the store must support both its shared database and shipped path-based SDK constructor.

## Why This Change Was Made

Build the seven session, event and shared-payload queries with the generated Kysely types and existing binding compiler. Native statements still execute at their existing points: prepare errors happen before payload compression and its creation timestamp, and the shared transaction owner retains rollback and access control. The legacy session columns and differing upsert rules remain explicit.

The change consolidates the common session insert mapping without a new executor, query cache, schema or lifecycle policy. Production grows by 33 lines to express the typed bindings and two schema contracts; tests grow by 109 lines. The native throughput probe did not justify additional per-store compiled-query state.

## User Impact

Capture behavior is unchanged: implicit session promotion, first observed start time, payload deduplication, previews, blob references and the legacy file-backed constructor retain their existing behavior. This prepares the current storage owner for further database work without enabling another database.

## Evidence

- 86 focused tests passed; after the final optional-blob lookup adjustment, all 29 store/reader tests passed again. Full changed gate and Kysely guard passed.
- Paired real SQLite probes passed for both constructors: exact stored values and native errors, prepare-before-gzip/clock ordering, authorization and missing-column refusal, event rollback/retry, payload bytes and reopen.
- The actual source-entry CLI launched a child through a real loopback proxy/origin: two complete UTF-8 request/response exchanges, four persisted events and an ended session. Fresh CLI sessions/query/blob/purge commands passed.
- Public SDK HTTP and WebSocket capture persisted four more events and four exact compressed payloads, with redaction, hashes and close codes preserved across a fresh database reopen. Schema and version remained unchanged. All synthetic fixtures and servers were removed.
- Independent Codex review completed eight passes with no P0–P2 findings. The review evidence retained complete files with explicit redaction of synthetic credential URI literals from unchanged CLI fixtures; the mandatory credential scan passed.
