### PR TITLE
fix(control-ui): recover bundled startup without losing sign-in

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -60,6 +60,9 @@ Notes:
 - `browserUrl` carries a single-use, ten-minute bootstrap in the URL fragment. The Control UI strips
   it immediately, binds it to the browser's signed device identity, and stores only the resulting
   administrator per-device credential. Another browser profile cannot inherit or replay that grant.
+- The pairing link includes its Gateway destination. If another Gateway is selected in the browser,
+  confirm the destination before pairing; canceling keeps the existing selection. This also applies
+  when a Gateway update reloads the dashboard before pairing completes.
 - Follows `gateway.tls.enabled`: TLS-enabled gateways print/open `https://` Control UI URLs and connect over `wss://`.
 - For `lan` or a wildcard `custom` bind, same-host launches always use loopback because a wildcard is not a browser destination. Plaintext `tailnet` and `custom` binds also use `127.0.0.1` so the browser has a secure context; TLS-enabled specific hosts keep the configured address so certificate names match.
 - Before delivering an authenticated loopback URL for a specific-interface bind, the command probes the configured interface and verifies that it and `127.0.0.1` are owned by the same Gateway process. Ambiguous listener ownership fails closed with status guidance.

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -128,7 +128,7 @@ reloads on relevant source, config, and bundled-plugin metadata changes. If the
 watched Gateway exits during startup, `gateway:watch` runs
 `openclaw doctor --fix --non-interactive` once and retries; set
 `OPENCLAW_GATEWAY_WATCH_AUTO_DOCTOR=0` to disable that dev-only repair pass.
-TypeScript rebuilds triggered by `pnpm openclaw ...` or `pnpm gateway:watch` preserve existing `dist/control-ui` assets but do not rebuild them. Run `pnpm ui:build` once and again after `ui/` changes, or use `pnpm ui:dev` while developing the Control UI.
+TypeScript rebuilds triggered by `pnpm openclaw ...` or `pnpm gateway:watch` preserve existing `dist/control-ui` assets. When the Gateway starts, it rebuilds missing, incomplete, or stale bundled UI assets before serving them. Headless commands do not rebuild the UI. Run `pnpm ui:build` after `ui/` changes, or use `pnpm ui:dev` while developing the Control UI.
 
 ### 2) Point the macOS app at your running Gateway
 

--- a/src/commands/control-ui-handoff.ts
+++ b/src/commands/control-ui-handoff.ts
@@ -138,7 +138,10 @@ export async function hasVerifiedControlUiLoopbackAlias(target: {
 }
 
 /** Mint the Control-UI-scoped one-time device grant immediately before actual delivery. */
-export async function issueControlUiBrowserHandoff(httpUrl: string): Promise<{
+export async function issueControlUiBrowserHandoff({
+  httpUrl,
+  wsUrl,
+}: ControlUiHandoffTarget["links"]): Promise<{
   browserUrl: string;
   expiresAtMs: number;
 }> {
@@ -148,6 +151,7 @@ export async function issueControlUiBrowserHandoff(httpUrl: string): Promise<{
   const fragment = new URLSearchParams({
     bootstrapToken: issued.token,
     [CONTROL_UI_BOOTSTRAP_PROFILE_FRAGMENT_PARAM]: CONTROL_UI_OWNER_BOOTSTRAP_PROFILE_HINT,
+    gatewayUrl: wsUrl,
   });
   return {
     browserUrl: `${httpUrl}#${fragment.toString()}`,

--- a/src/commands/dashboard.links.test.ts
+++ b/src/commands/dashboard.links.test.ts
@@ -165,10 +165,10 @@ describe("dashboardCommand", () => {
       },
     });
     expect(copyToClipboardMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner&gatewayUrl=ws%3A%2F%2F127.0.0.1%3A18789",
     );
     expect(openUrlMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner&gatewayUrl=ws%3A%2F%2F127.0.0.1%3A18789",
     );
     expect(runtime.log).toHaveBeenCalledWith(
       "Opened in your browser. Keep that tab to control OpenClaw.",
@@ -186,10 +186,10 @@ describe("dashboardCommand", () => {
 
     // Clipboard and browser receive only the short-lived browser bootstrap.
     expect(copyToClipboardMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner&gatewayUrl=ws%3A%2F%2F127.0.0.1%3A18789",
     );
     expect(openUrlMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner&gatewayUrl=ws%3A%2F%2F127.0.0.1%3A18789",
     );
 
     // The logged output must never contain the token — it flows into
@@ -381,7 +381,7 @@ describe("dashboardCommand", () => {
     await dashboardCommand(runtime);
 
     expect(copyToClipboardMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner&gatewayUrl=ws%3A%2F%2F127.0.0.1%3A18789",
     );
     expectNoLogWith("Token auto-auth unavailable");
     expectNoLogWith("missing env var");
@@ -402,10 +402,10 @@ describe("dashboardCommand", () => {
     await dashboardCommand(runtime);
 
     expect(copyToClipboardMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner&gatewayUrl=ws%3A%2F%2F127.0.0.1%3A18789",
     );
     expect(openUrlMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner&gatewayUrl=ws%3A%2F%2F127.0.0.1%3A18789",
     );
     expectNoLogWith("Token auto-auth is disabled for SecretRef-managed");
     expectNoLogWith("Token auto-auth unavailable");
@@ -420,10 +420,10 @@ describe("dashboardCommand", () => {
     await dashboardCommand(runtime);
 
     expect(copyToClipboardMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner&gatewayUrl=ws%3A%2F%2F127.0.0.1%3A18789",
     );
     expect(openUrlMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner&gatewayUrl=ws%3A%2F%2F127.0.0.1%3A18789",
     );
     expectNoLogWith("Token auto-auth unavailable");
     expectNoLogWith("Token auto-auth is disabled for SecretRef-managed");

--- a/src/commands/dashboard.test.ts
+++ b/src/commands/dashboard.test.ts
@@ -205,7 +205,7 @@ describe("dashboardCommand bind selection", () => {
       tlsEnabled: false,
     });
     expect(mocks.copyToClipboard).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
+      "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner&gatewayUrl=ws%3A%2F%2F127.0.0.1%3A18789",
     );
   });
 
@@ -341,5 +341,9 @@ describe("dashboardCommand bind selection", () => {
       tlsEnabled: true,
     });
     expect(mocks.inspectPortUsage).not.toHaveBeenCalled();
+    const delivered = new URL(mocks.copyToClipboard.mock.calls[0]![0]);
+    expect(new URLSearchParams(delivered.hash.slice(1)).get("gatewayUrl")).toBe(
+      `wss://${params.host}:18789`,
+    );
   });
 });

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -91,7 +91,7 @@ async function dashboardJsonCommand(runtime: RuntimeEnv): Promise<void> {
       dashboardJsonFailure(runtime, document.reason);
       return;
     }
-    const browserHandoff = await issueControlUiBrowserHandoff(target.links.httpUrl);
+    const browserHandoff = await issueControlUiBrowserHandoff(target.links);
 
     writeRuntimeJson(
       runtime,
@@ -178,7 +178,7 @@ export async function dashboardCommand(
   }
   let browserUrl: string;
   try {
-    browserUrl = (await issueControlUiBrowserHandoff(target.links.httpUrl)).browserUrl;
+    browserUrl = (await issueControlUiBrowserHandoff(target.links)).browserUrl;
   } catch (error) {
     runtime.error(
       `Could not create a one-time browser pairing link: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/commands/dashboard/json.test.ts
+++ b/src/commands/dashboard/json.test.ts
@@ -123,7 +123,7 @@ describe("dashboardCommand --json", () => {
         port: 18789,
         tokenIncluded: true,
         browserUrl:
-          "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner",
+          "http://127.0.0.1:18789/#bootstrapToken=browser-bootstrap&bootstrapProfile=owner&gatewayUrl=ws%3A%2F%2F127.0.0.1%3A18789",
         browserBootstrapExpiresAtMs: 123_456,
       },
       0,

--- a/src/commands/doctor-ui.repair.test.ts
+++ b/src/commands/doctor-ui.repair.test.ts
@@ -3,11 +3,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CONTROL_UI_BUILD_ID_ATTRIBUTE } from "../gateway/control-ui-root-assets.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
 const mocks = vi.hoisted(() => ({
   root: "",
+  buildId: "doctor-runtime-build",
   ensureControlUiAssetsBuilt: vi.fn(),
   note: vi.fn(),
   runCommandWithTimeout: vi.fn(),
@@ -19,6 +21,10 @@ vi.mock("../infra/openclaw-root.js", () => ({
   resolveOpenClawPackageRootSync: vi.fn(() => mocks.root),
 }));
 vi.mock("../process/exec.js", () => ({ runCommandWithTimeout: mocks.runCommandWithTimeout }));
+vi.mock("../version.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../version.js")>()),
+  resolveRuntimeServiceBuildId: () => mocks.buildId,
+}));
 vi.mock("../infra/control-ui-assets.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../infra/control-ui-assets.js")>()),
   ensureControlUiAssetsBuilt: mocks.ensureControlUiAssetsBuilt,
@@ -38,7 +44,9 @@ function createPrompter(): DoctorPrompter {
 describe("Control UI doctor repair owner", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
-    mocks.root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-ui-repair-"));
+    mocks.root = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-ui-repair-")),
+    );
     await fs.mkdir(path.join(mocks.root, "ui"), { recursive: true });
     await fs.writeFile(path.join(mocks.root, "ui", "package.json"), "{}");
     mocks.ensureControlUiAssetsBuilt.mockImplementation(async (_runtime, opts) => {
@@ -68,6 +76,7 @@ describe("Control UI doctor repair owner", () => {
     expect(prompter.confirmAggressiveAutoFix).not.toHaveBeenCalled();
     expect(mocks.ensureControlUiAssetsBuilt).toHaveBeenCalledWith(runtime, {
       root: mocks.root,
+      expectedBuildId: mocks.buildId,
       force: false,
       onBuildStart: expect.any(Function),
     });
@@ -85,44 +94,84 @@ describe("Control UI doctor repair owner", () => {
     expect(prompter.confirmAutoFix).toHaveBeenCalledOnce();
     expect(mocks.ensureControlUiAssetsBuilt).toHaveBeenCalledWith(runtime, {
       root: mocks.root,
+      expectedBuildId: mocks.buildId,
       force: false,
       onBuildStart: expect.any(Function),
     });
     expect(mocks.runCommandWithTimeout).not.toHaveBeenCalled();
   });
 
-  it("advises reinstalling incomplete packaged bundles without attempting a source build", async () => {
-    const indexPath = path.join(mocks.root, "dist", "control-ui", "index.html");
-    await fs.mkdir(path.dirname(indexPath), { recursive: true });
-    await fs.writeFile(indexPath, '<script src="./assets/startup.js"></script>');
-    await fs.rm(path.join(mocks.root, "ui", "package.json"));
+  it.each(["incomplete", "markerless", "different-build", "current-build", "dev-build"])(
+    "checks packaged UI identity without rebuilding it: %s",
+    async (failure) => {
+      const indexPath = path.join(mocks.root, "dist", "control-ui", "index.html");
+      await fs.mkdir(path.dirname(indexPath), { recursive: true });
+      const buildId =
+        failure === "different-build"
+          ? "older-build"
+          : failure === "current-build"
+            ? mocks.buildId
+            : failure === "dev-build"
+              ? "dev"
+              : null;
+      const marker = buildId
+        ? ` ${CONTROL_UI_BUILD_ID_ATTRIBUTE}="${buildId}-${"a".repeat(64)}"`
+        : "";
+      const html = `<html${marker}><script src="./assets/startup.js"></script></html>`;
+      await fs.writeFile(indexPath, html);
+      if (failure !== "incomplete") {
+        await fs.mkdir(path.join(path.dirname(indexPath), "assets"));
+        await fs.writeFile(path.join(path.dirname(indexPath), "assets/startup.js"), "// startup");
+      }
+      await fs.rm(path.join(mocks.root, "ui", "package.json"));
 
-    await maybeRepairUiProtocolFreshness(runtime, createPrompter());
+      await maybeRepairUiProtocolFreshness(runtime, createPrompter());
 
-    expect(mocks.note).toHaveBeenCalledWith(
-      expect.stringContaining("Reinstall OpenClaw to restore bundled Control UI assets."),
-      "UI",
-    );
-    expect(mocks.ensureControlUiAssetsBuilt).not.toHaveBeenCalled();
-  });
+      if (failure === "current-build" || failure === "dev-build") {
+        expect(mocks.note).not.toHaveBeenCalled();
+      } else {
+        expect(mocks.note).toHaveBeenCalledWith(
+          expect.stringContaining("Reinstall OpenClaw to restore bundled Control UI assets."),
+          expect.any(String),
+        );
+      }
+      expect(mocks.ensureControlUiAssetsBuilt).not.toHaveBeenCalled();
+      expect(mocks.runCommandWithTimeout).not.toHaveBeenCalled();
+      expect(await fs.readFile(indexPath, "utf8")).toBe(html);
+    },
+  );
 
-  it("forces the canonical owner to rebuild stale existing assets", async () => {
-    const indexPath = path.join(mocks.root, "dist", "control-ui", "index.html");
-    await fs.mkdir(path.dirname(indexPath), { recursive: true });
-    await fs.writeFile(indexPath, "<html></html>");
-    const prompter = createPrompter();
+  it.each(["markerless", "different-build", "protocol-changes"])(
+    "forces the canonical owner to rebuild stale source assets: %s",
+    async (reason) => {
+      const indexPath = path.join(mocks.root, "dist", "control-ui", "index.html");
+      await fs.mkdir(path.dirname(indexPath), { recursive: true });
+      const buildId = reason === "protocol-changes" ? mocks.buildId : "older-build";
+      await fs.writeFile(
+        indexPath,
+        reason === "markerless"
+          ? "<html></html>"
+          : `<html ${CONTROL_UI_BUILD_ID_ATTRIBUTE}="${buildId}-${"a".repeat(64)}"></html>`,
+      );
+      const prompter = createPrompter();
 
-    await maybeRepairUiProtocolFreshness(runtime, prompter);
+      await maybeRepairUiProtocolFreshness(runtime, prompter);
 
-    expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
-    expect(prompter.confirmAggressiveAutoFix).toHaveBeenCalledOnce();
-    expect(mocks.ensureControlUiAssetsBuilt).toHaveBeenCalledWith(runtime, {
-      root: mocks.root,
-      force: true,
-      onBuildStart: expect.any(Function),
-    });
-    expect(mocks.note).toHaveBeenCalledWith("UI rebuild complete.", "UI");
-  });
+      expect(prompter.confirmAutoFix).not.toHaveBeenCalled();
+      expect(prompter.confirmAggressiveAutoFix).toHaveBeenCalledOnce();
+      expect(mocks.ensureControlUiAssetsBuilt).toHaveBeenCalledWith(runtime, {
+        root: mocks.root,
+        expectedBuildId: mocks.buildId,
+        force: true,
+        onBuildStart: expect.any(Function),
+      });
+      expect(mocks.note).toHaveBeenCalledWith("UI rebuild complete.", "UI");
+      expect(mocks.note).toHaveBeenCalledWith(expect.stringContaining("ui:build"), "UI Freshness");
+      expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(
+        reason === "protocol-changes" ? 1 : 0,
+      );
+    },
+  );
 
   it("reports owner-normalized build failures instead of claiming repair success", async () => {
     mocks.ensureControlUiAssetsBuilt.mockResolvedValueOnce({

--- a/src/commands/doctor-ui.ts
+++ b/src/commands/doctor-ui.ts
@@ -1,4 +1,4 @@
-/** Doctor checks and repairs for Control UI assets after gateway protocol changes. */
+/** Doctor checks and repairs Control UI build identity and protocol freshness. */
 import fs from "node:fs/promises";
 import path from "node:path";
 import { note } from "../../packages/terminal-core/src/note.js";
@@ -12,24 +12,19 @@ import {
 import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { resolveRuntimeServiceBuildId } from "../version.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
-type UiProtocolFreshnessIssue =
-  | {
-      readonly kind: "missing-assets";
-      readonly root: string;
-      readonly uiIndexPath: string;
-      readonly canBuild: boolean;
-    }
-  | {
-      readonly kind: "stale-assets";
-      readonly root: string;
-      readonly uiIndexPath: string;
-      readonly changesSinceBuild: readonly string[];
-      readonly canBuild: boolean;
-    };
+type UiProtocolFreshnessIssue = {
+  readonly root: string;
+  readonly uiIndexPath: string;
+  readonly canBuild: boolean;
+} & (
+  | { readonly kind: "missing-assets" }
+  | { readonly kind: "stale-assets"; readonly changesSinceBuild: readonly string[] }
+);
 
-/** Detects missing or stale Control UI build artifacts relative to protocol schema changes. */
+/** Detects unusable installed UI assets and subsequent source protocol changes. */
 export async function detectUiProtocolFreshnessIssues(
   opts: {
     readonly root?: string;
@@ -52,37 +47,36 @@ export async function detectUiProtocolFreshnessIssues(
     return [];
   }
 
-  const uiHealth = await resolveControlUiAssetHealth({ root });
+  // Doctor checks its loaded install; updater callers may inspect a newer target build.
+  const uiHealth = await resolveControlUiAssetHealth({
+    root,
+    expectedBuildId: resolveRuntimeServiceBuildId(),
+  });
   const uiIndexPath = uiHealth.indexPath ?? resolveControlUiDistIndexPathForRoot(root);
-  const uiSourcesPath = path.join(root, "ui/package.json");
 
   try {
-    const [uiStats, uiSourcesStats] = await Promise.all([
-      fs.stat(uiIndexPath).catch(() => null),
-      fs.stat(uiSourcesPath).catch(() => null),
-    ]);
-    const canBuild = uiSourcesStats !== null;
-    if (!uiStats || uiHealth.kind !== "ready") {
-      return [{ kind: "missing-assets", root, uiIndexPath, canBuild }];
+    const canBuild = await fs.stat(path.join(root, "ui/package.json")).then(
+      () => true,
+      () => false,
+    );
+    const issue = { root, uiIndexPath, canBuild };
+    if (uiHealth.kind !== "ready") {
+      return [
+        uiHealth.kind === "stale"
+          ? { ...issue, kind: "stale-assets", changesSinceBuild: [] }
+          : { ...issue, kind: "missing-assets" },
+      ];
     }
     if (!canBuild) {
       return [];
     }
     const changesSinceBuild = await (
       opts.collectChangesSinceBuild ?? collectProtocolSchemaChangesSince
-    )(root, uiStats.mtime);
+    )(root, (await fs.stat(uiIndexPath)).mtime);
     if (changesSinceBuild === null || changesSinceBuild.length === 0) {
       return [];
     }
-    return [
-      {
-        kind: "stale-assets",
-        root,
-        uiIndexPath,
-        changesSinceBuild,
-        canBuild,
-      },
-    ];
+    return [{ ...issue, kind: "stale-assets", changesSinceBuild }];
   } catch {
     return [];
   }
@@ -149,20 +143,18 @@ export function uiProtocolFreshnessIssueToRepairEffects(
 }
 
 function formatUiProtocolFreshnessIssue(issue: UiProtocolFreshnessIssue): string {
-  if (issue.kind === "missing-assets") {
-    return [
-      "- Control UI assets are missing.",
-      issue.canBuild
-        ? `- Run: ${formatControlUiSourceCommand(issue.root, "build")}`
-        : "- Reinstall OpenClaw to restore bundled Control UI assets.",
-    ].join("\n");
-  }
-  if (issue.changesSinceBuild.length === 0) {
-    return "UI assets are older than the protocol schema.";
-  }
-  return `UI assets are older than the protocol schema.\nFunctional changes since last build:\n${issue.changesSinceBuild
-    .map((line) => `- ${line}`)
-    .join("\n")}`;
+  const message =
+    issue.kind === "missing-assets"
+      ? "- Control UI assets are missing or incomplete."
+      : issue.changesSinceBuild.length === 0
+        ? "Control UI assets do not match the current Gateway build."
+        : `UI assets are older than the protocol schema.\nFunctional changes since last build:\n${issue.changesSinceBuild.map((line) => `- ${line}`).join("\n")}`;
+  return [
+    message,
+    issue.canBuild
+      ? `- Run: ${formatControlUiSourceCommand(issue.root, "build")}`
+      : "- Reinstall OpenClaw to restore bundled Control UI assets.",
+  ].join("\n");
 }
 
 /** Prompts to build or rebuild Control UI assets when doctor detects missing or stale output. */
@@ -179,7 +171,7 @@ export async function maybeRepairUiProtocolFreshness(
     }
     const shouldRepair = stale
       ? await prompter.confirmAggressiveAutoFix({
-          message: "Rebuild UI now? (Detected protocol mismatch requiring update)",
+          message: "Rebuild stale Control UI assets now?",
           initialValue: true,
         })
       : await prompter.confirmAutoFix({
@@ -191,6 +183,7 @@ export async function maybeRepairUiProtocolFreshness(
     }
     const result = await ensureControlUiAssetsBuilt(runtime, {
       root: issue.root,
+      expectedBuildId: resolveRuntimeServiceBuildId(),
       force: stale,
       onBuildStart: () =>
         note(

--- a/src/commands/onboard-browser-handoff.test.ts
+++ b/src/commands/onboard-browser-handoff.test.ts
@@ -42,7 +42,7 @@ vi.mock("./onboard-helpers.js", async (importOriginal) => ({
 
 const target = {
   config: {},
-  dashboardUrl: "http://127.0.0.1:18789/",
+  links: { httpUrl: "http://127.0.0.1:18789/", wsUrl: "ws://127.0.0.1:18789" },
   documentUrl: "http://127.0.0.1:18789/",
   sshHint: "ssh -N -L 18789:127.0.0.1:18789 user@host",
   port: 18789,
@@ -54,10 +54,12 @@ beforeEach(() => {
   sharedMocks.waitForControlUiDocument.mockReset();
   sharedMocks.waitForControlUiDocument.mockResolvedValue({ ready: true });
   sharedMocks.issueControlUiBrowserHandoff.mockReset();
-  sharedMocks.issueControlUiBrowserHandoff.mockImplementation(async (url: string) => ({
-    browserUrl: `${url}#bootstrapToken=one-time-bootstrap`,
-    expiresAtMs: 123_456,
-  }));
+  sharedMocks.issueControlUiBrowserHandoff.mockImplementation(
+    async (links: typeof target.links) => ({
+      browserUrl: `${links.httpUrl}#bootstrapToken=one-time-bootstrap&gatewayUrl=${encodeURIComponent(links.wsUrl)}`,
+      expiresAtMs: 123_456,
+    }),
+  );
   sharedMocks.detectBrowserOpenSupport.mockReset().mockResolvedValue({ ok: false });
   sharedMocks.resolveAdvertisedLanHostCore.mockReset();
   sharedMocks.resolveAdvertisedLanHostCore.mockResolvedValue(null);
@@ -157,9 +159,9 @@ describe("runBrowserHatchHandoff", () => {
       expect.objectContaining({ env, platform }),
     );
     expect(openBrowser).toHaveBeenCalledWith(
-      "http://127.0.0.1:18789/#bootstrapToken=one-time-bootstrap",
+      "http://127.0.0.1:18789/#bootstrapToken=one-time-bootstrap&gatewayUrl=ws%3A%2F%2F127.0.0.1%3A18789",
     );
-    expect(sharedMocks.issueControlUiBrowserHandoff).toHaveBeenCalledWith(target.dashboardUrl);
+    expect(sharedMocks.issueControlUiBrowserHandoff).toHaveBeenCalledWith(target.links);
     expect(probePresence).toHaveBeenCalledTimes(2);
     expect(prompter.note).toHaveBeenCalledWith(
       "Dashboard connected — continuing in your browser.",
@@ -173,7 +175,7 @@ describe("runBrowserHatchHandoff", () => {
       ...target,
       config,
       port: 19001,
-      dashboardUrl: "http://127.0.0.1:19001/",
+      links: { httpUrl: "http://127.0.0.1:19001/", wsUrl: "ws://127.0.0.1:19001" },
       documentUrl: "http://127.0.0.1:19001/",
     };
     sharedMocks.callGateway
@@ -226,12 +228,12 @@ describe("runBrowserHatchHandoff", () => {
 
     expect(result).toEqual({ handedOff: true });
     expect(openBrowser).not.toHaveBeenCalled();
-    expect(sharedMocks.issueControlUiBrowserHandoff).toHaveBeenCalledWith(target.dashboardUrl);
+    expect(sharedMocks.issueControlUiBrowserHandoff).toHaveBeenCalledWith(target.links);
     expect(pollForClient).toHaveBeenCalledWith(
       expect.objectContaining({ target, timeoutMs: 300_000 }),
     );
     expect(prompter.note).toHaveBeenCalledWith(
-      expect.stringContaining(`${target.dashboardUrl}#bootstrapToken=one-time-bootstrap`),
+      expect.stringContaining(`${target.links.httpUrl}#bootstrapToken=one-time-bootstrap`),
       "Continue in your browser",
     );
     expect(prompter.note).toHaveBeenCalledWith(
@@ -324,7 +326,7 @@ describe("runBrowserHatchHandoff", () => {
         expect.objectContaining({ env, platform: "linux" }),
       );
       expect(openBrowser).toHaveBeenCalledWith(
-        "http://127.0.0.1:18789/#bootstrapToken=one-time-bootstrap",
+        "http://127.0.0.1:18789/#bootstrapToken=one-time-bootstrap&gatewayUrl=ws%3A%2F%2F127.0.0.1%3A18789",
       );
       expect(prompter.note).toHaveBeenCalledWith(
         expect.stringContaining(target.sshHint),
@@ -357,7 +359,7 @@ describe("runBrowserHatchHandoff", () => {
     );
 
     expect(prompter.note).toHaveBeenCalledWith(
-      expect.stringContaining(`${target.dashboardUrl}#bootstrapToken=one-time-bootstrap`),
+      expect.stringContaining(`${target.links.httpUrl}#bootstrapToken=one-time-bootstrap`),
       "Continue in your browser",
     );
     const displayed = vi
@@ -388,7 +390,10 @@ describe("runBrowserHatchHandoff", () => {
           controlUi: { basePath: "/dashboard" },
         },
       },
-      dashboardUrl: "http://127.0.0.1:18789/dashboard/",
+      links: {
+        httpUrl: "http://127.0.0.1:18789/dashboard/",
+        wsUrl: "ws://127.0.0.1:18789/dashboard",
+      },
       documentUrl: "http://127.0.0.1:18789/dashboard/",
       sshHint: undefined,
     };
@@ -417,9 +422,7 @@ describe("runBrowserHatchHandoff", () => {
     expect(displayed).not.toContain("#token=");
     expect(displayed).toContain("#bootstrapToken=one-time-bootstrap");
     expect(sharedMocks.resolveAdvertisedControlUiLinks).not.toHaveBeenCalled();
-    expect(sharedMocks.issueControlUiBrowserHandoff).toHaveBeenCalledWith(
-      remoteTarget.dashboardUrl,
-    );
+    expect(sharedMocks.issueControlUiBrowserHandoff).toHaveBeenCalledWith(remoteTarget.links);
   });
 
   it.each([
@@ -438,7 +441,10 @@ describe("runBrowserHatchHandoff", () => {
           tls: { enabled: true },
         },
       },
-      dashboardUrl: `https://${bind === "lan" ? "127.0.0.1" : host}:18789/dashboard/`,
+      links: {
+        httpUrl: `https://${bind === "lan" ? "127.0.0.1" : host}:18789/dashboard/`,
+        wsUrl: `wss://${bind === "lan" ? "127.0.0.1" : host}:18789/dashboard`,
+      },
       documentUrl: "https://127.0.0.1:18789/dashboard/",
       tlsConfig: { enabled: true },
       sshHint: undefined,
@@ -466,6 +472,9 @@ describe("runBrowserHatchHandoff", () => {
     expect(displayed).toContain(
       `https://${host}:18789/dashboard/#bootstrapToken=one-time-bootstrap`,
     );
+    expect(displayed).toContain(
+      `gatewayUrl=${encodeURIComponent(`wss://${host}:18789/dashboard`)}`,
+    );
     expect(displayed).not.toContain("ssh -N -L");
     expect(displayed).not.toContain("test-token");
     expect(displayed).not.toContain("#token=");
@@ -477,9 +486,7 @@ describe("runBrowserHatchHandoff", () => {
       basePath: "/dashboard",
       tlsEnabled: true,
     });
-    expect(sharedMocks.issueControlUiBrowserHandoff).toHaveBeenCalledWith(
-      remoteTarget.dashboardUrl,
-    );
+    expect(sharedMocks.issueControlUiBrowserHandoff).toHaveBeenCalledWith(remoteTarget.links);
   });
 
   it("keeps headless TLS handoff available when all LAN discovery fails", async () => {
@@ -493,7 +500,10 @@ describe("runBrowserHatchHandoff", () => {
           tls: { enabled: true },
         },
       },
-      dashboardUrl: "https://127.0.0.1:18789/dashboard/",
+      links: {
+        httpUrl: "https://127.0.0.1:18789/dashboard/",
+        wsUrl: "wss://127.0.0.1:18789/dashboard",
+      },
       documentUrl: "https://127.0.0.1:18789/dashboard/",
       tlsConfig: { enabled: true },
       sshHint: undefined,
@@ -574,7 +584,7 @@ describe("runBrowserHatchHandoff", () => {
       .join("\n");
     expect(displayed).not.toContain(gatewayPassword);
     expect(displayed).toContain("#bootstrapToken=one-time-bootstrap");
-    expect(sharedMocks.issueControlUiBrowserHandoff).toHaveBeenCalledWith(target.dashboardUrl);
+    expect(sharedMocks.issueControlUiBrowserHandoff).toHaveBeenCalledWith(target.links);
   });
 
   it("returns the poll timeout without claiming a handoff", async () => {

--- a/src/commands/onboard-browser-handoff.ts
+++ b/src/commands/onboard-browser-handoff.ts
@@ -33,7 +33,7 @@ const HANDOFF_PROBE_TIMEOUT_MS = 5_000;
 
 type BrowserHatchTarget = {
   config: OpenClawConfig;
-  dashboardUrl: string;
+  links: ControlUiHandoffTarget["links"];
   documentUrl: string;
   sshHint?: string;
   port: number;
@@ -98,7 +98,7 @@ async function resolveBrowserHatchTarget(
   const setupAuthValue = authMode === "password" ? credentials.password : undefined;
   const target: BrowserHatchTarget = {
     config,
-    dashboardUrl: shared.links.httpUrl,
+    links: shared.links,
     documentUrl: shared.documentUrl,
     port: shared.port,
     ...(shared.loopbackAliasHost ? { loopbackAliasHost: shared.loopbackAliasHost } : {}),
@@ -128,10 +128,15 @@ function isConnectedControlUi(entry: SystemPresence): boolean {
   );
 }
 
-function retargetBrowserHandoffUrl(browserUrl: string, visibleBaseUrl: string): string {
+function retargetBrowserHandoffUrl(
+  browserUrl: string,
+  links: ControlUiHandoffTarget["links"],
+): string {
   const issued = new URL(browserUrl);
-  const visible = new URL(visibleBaseUrl);
-  visible.hash = issued.hash;
+  const visible = new URL(links.httpUrl);
+  const fragment = new URLSearchParams(issued.hash.slice(1));
+  fragment.set("gatewayUrl", links.wsUrl);
+  visible.hash = fragment.toString();
   return visible.toString();
 }
 
@@ -267,7 +272,7 @@ export async function runBrowserHatchHandoff(
   let browserUrl: string;
   try {
     const browserHandoff = await (deps.issueBrowserHandoff ?? issueControlUiBrowserHandoff)(
-      target.dashboardUrl,
+      target.links,
     );
     browserUrl = browserHandoff.browserUrl;
   } catch {
@@ -314,18 +319,16 @@ export async function runBrowserHatchHandoff(
             : undefined))
         : undefined;
     const sshHint = tunnelHint ? `\n\n${tunnelHint}` : "";
-    const visibleBaseUrl = directRemoteDisplay
-      ? (
-          await resolveAdvertisedControlUiLinks({
-            bind,
-            port: target.port,
-            customBindHost: target.config.gateway?.customBindHost,
-            basePath: target.config.gateway?.controlUi?.basePath,
-            tlsEnabled: target.tlsConfig?.enabled === true,
-          })
-        ).httpUrl
-      : target.dashboardUrl;
-    const visibleUrl = retargetBrowserHandoffUrl(browserUrl, visibleBaseUrl);
+    const visibleLinks = directRemoteDisplay
+      ? await resolveAdvertisedControlUiLinks({
+          bind,
+          port: target.port,
+          customBindHost: target.config.gateway?.customBindHost,
+          basePath: target.config.gateway?.controlUi?.basePath,
+          tlsEnabled: target.tlsConfig?.enabled === true,
+        })
+      : target.links;
+    const visibleUrl = retargetBrowserHandoffUrl(browserUrl, visibleLinks);
     await params.prompter.note(
       `${t("wizard.guided.browserHandoffCopy", { url: visibleUrl })}${sshHint}`,
       t("wizard.guided.browserHandoffTitle"),

--- a/src/gateway/server-control-ui-root.identity.test.ts
+++ b/src/gateway/server-control-ui-root.identity.test.ts
@@ -1,0 +1,211 @@
+/** Exercises source UI preparation against the Gateway's loaded build identity. */
+import fs from "node:fs/promises";
+import type { IncomingMessage } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { writeRetentionBuild } from "./control-ui-asset-retention.test-support.js";
+
+const fixture = vi.hoisted(() => ({
+  root: "",
+  selectedRoot: "",
+  buildId: "2026.9.1-runtime-b",
+  build: vi.fn(),
+}));
+vi.mock("../infra/openclaw-root.js", () => ({
+  resolveOpenClawPackageRoot: async () => fixture.root,
+  resolveOpenClawPackageRootSync: () => fixture.root,
+}));
+vi.mock("../infra/control-ui-assets.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/control-ui-assets.js")>()),
+  resolveControlUiRootSync: () => fixture.selectedRoot,
+}));
+vi.mock("../process/exec.js", () => ({ runCommandWithTimeout: fixture.build }));
+vi.mock("../version.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../version.js")>()),
+  resolveRuntimeServiceBuildId: () => fixture.buildId,
+}));
+
+import { handleControlUiHttpRequest, type ControlUiRootState } from "./control-ui.js";
+import { createGatewayControlUiRootLifecycle } from "./server-control-ui-root.js";
+import { makeMockHttpResponse } from "./test-http-response.js";
+
+async function requestIndex(root: ControlUiRootState) {
+  const response = makeMockHttpResponse();
+  await handleControlUiHttpRequest(
+    { url: "/", method: "GET", headers: { host: "gateway.example.test" } } as IncomingMessage,
+    response.res,
+    { root },
+  );
+  return response;
+}
+
+async function writeUi(root: string, buildId: string) {
+  await writeRetentionBuild(root, buildId, { assetPath: "assets/startup.js" });
+  await fs.writeFile(
+    path.join(root, "index.html"),
+    `<html data-openclaw-control-ui-build-id="${buildId}-${"a".repeat(64)}"><script src="./assets/startup.js"></script></html>`,
+  );
+}
+
+function createLifecycle(override?: string) {
+  const warn = vi.fn();
+  const lifecycle = createGatewayControlUiRootLifecycle({
+    controlUiRootOverride: override,
+    controlUiEnabled: true,
+    gatewayRuntime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    log: { warn },
+  });
+  return { lifecycle, warn };
+}
+
+describe("source-selected Control UI identity preparation", () => {
+  beforeEach(async () => {
+    fixture.buildId = "2026.9.1-runtime-b";
+    fixture.root = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-identity-")),
+    );
+    fixture.selectedRoot = path.join(fixture.root, "dist", "control-ui");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(fixture.root, "state"));
+    await fs.mkdir(path.join(fixture.root, "ui"));
+    await fs.mkdir(path.join(fixture.root, "scripts"));
+    await fs.writeFile(path.join(fixture.root, "ui", "vite.config.ts"), "export {};");
+    await fs.writeFile(path.join(fixture.root, "scripts", "ui.js"), "");
+    await writeUi(fixture.selectedRoot, "2026.9.1-runtime-a");
+    fixture.build.mockReset();
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  });
+
+  test("prepares a complete stale source UI before publishing its shared root", async () => {
+    const selectedRoot = fixture.selectedRoot;
+    const buildId = fixture.buildId;
+    const provenancePath = path.join(fixture.root, "dist", "build-info.json");
+    const provenance = JSON.stringify({ buildId });
+    await fs.writeFile(provenancePath, provenance);
+    let finishBuild!: () => Promise<void>;
+    fixture.build.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishBuild = async () => {
+            await writeUi(selectedRoot, buildId);
+            resolve({
+              stdout: "",
+              stderr: "",
+              code: 0,
+              signal: null,
+              killed: false,
+              termination: "exit",
+            });
+          };
+        }),
+    );
+    const { lifecycle, warn } = createLifecycle();
+    const rootReference = lifecycle.state;
+    expect(rootReference).toEqual({ kind: "preparing" });
+    const unavailable = await requestIndex(rootReference);
+    expect(unavailable.res.statusCode).toBe(503);
+    expect(unavailable.setHeader).toHaveBeenCalledWith("Retry-After", "1");
+
+    const preparing = lifecycle.start();
+    expect(lifecycle.start()).toBe(preparing);
+    await vi.waitFor(() => expect(fixture.build).toHaveBeenCalledOnce());
+    expect(rootReference).toEqual({ kind: "preparing" });
+    fixture.selectedRoot = path.join(fixture.root, "other", "control-ui");
+    fixture.buildId = "2026.9.1-runtime-c";
+    await writeUi(fixture.selectedRoot, fixture.buildId);
+    await finishBuild();
+    await preparing;
+
+    expect(lifecycle.state).toBe(rootReference);
+    expect(rootReference).toMatchObject({
+      kind: "bundled",
+      path: selectedRoot,
+      publicAssetBuildId: `${buildId}-${"a".repeat(64)}`,
+    });
+    const ready = await requestIndex(rootReference);
+    expect(ready.res.statusCode).toBe(200);
+    expect(String(ready.end.mock.calls[0]?.[0])).toContain(`${buildId}-${"a".repeat(64)}`);
+    await lifecycle.start();
+    await lifecycle.stop();
+    expect(fixture.build).toHaveBeenCalledOnce();
+    expect(warn).not.toHaveBeenCalled();
+    expect(await fs.readFile(provenancePath, "utf8")).toBe(provenance);
+  });
+
+  test.each(["matching", "dev", "configured", "macOS"])(
+    "preserves the %s root without rebuilding",
+    async (kind) => {
+      if (kind === "macOS") {
+        fixture.selectedRoot = path.join(
+          fixture.root,
+          "OpenClaw.app",
+          "Contents",
+          "Resources",
+          "control-ui",
+        );
+      }
+      await writeUi(
+        fixture.selectedRoot,
+        kind === "dev" ? "dev" : kind === "configured" ? "custom-build" : fixture.buildId,
+      );
+      const { lifecycle, warn } = createLifecycle(
+        kind === "configured" ? fixture.selectedRoot : undefined,
+      );
+      expect(lifecycle.state).toMatchObject({
+        kind: kind === "configured" || kind === "macOS" ? "resolved" : "bundled",
+        path: fixture.selectedRoot,
+      });
+      await lifecycle.start();
+      await lifecycle.stop();
+      expect(fixture.build).not.toHaveBeenCalled();
+      expect(warn).not.toHaveBeenCalled();
+    },
+  );
+
+  test("reports an unchanged UI after a successful builder instead of publishing it", async () => {
+    fixture.build.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    });
+    const { lifecycle, warn } = createLifecycle();
+    await lifecycle.start();
+    await lifecycle.stop();
+    expect(lifecycle.state).toEqual({ kind: "failed" });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("expected 2026.9.1-runtime-b"));
+    expect(fixture.build).toHaveBeenCalledOnce();
+  });
+
+  test.each(["stale", "incomplete"])(
+    "does not mask %s macOS Resources with a healthy source dist",
+    async (kind) => {
+      await writeUi(fixture.selectedRoot, fixture.buildId);
+      fixture.selectedRoot = path.join(
+        fixture.root,
+        "OpenClaw.app",
+        "Contents",
+        "Resources",
+        "control-ui",
+      );
+      await writeUi(fixture.selectedRoot, "2026.9.1-runtime-a");
+      if (kind === "incomplete") {
+        await fs.unlink(path.join(fixture.selectedRoot, "assets", "startup.js"));
+      }
+      const { lifecycle, warn } = createLifecycle();
+      expect(lifecycle.state).toEqual({ kind: "preparing" });
+      await lifecycle.start();
+      await lifecycle.stop();
+      expect(lifecycle.state).toEqual({ kind: "failed" });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(fixture.selectedRoot));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("Reinstall OpenClaw"));
+      expect(fixture.build).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/gateway/server-control-ui-root.resolve.test.ts
+++ b/src/gateway/server-control-ui-root.resolve.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 const controlUiAssetsMocks = vi.hoisted(() => ({
   ensureControlUiAssetsBuilt: vi.fn(),
   isPackageProvenControlUiRootSync: vi.fn(),
-  isControlUiStartupAssetsReady: vi.fn(),
+  inspectControlUiRootAssets: vi.fn(),
   resolveControlUiRootOverrideSync: vi.fn(),
   resolveControlUiRootSync: vi.fn(),
 }));
@@ -17,23 +17,28 @@ const retentionMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../infra/control-ui-assets.js", () => controlUiAssetsMocks);
+vi.mock("../version.js", () => ({ resolveRuntimeServiceBuildId: () => "gateway-build" }));
 vi.mock("./control-ui-asset-retention.js", () => ({
   createControlUiAssetRetention: vi.fn(() => retentionMocks),
 }));
 
 import { createGatewayControlUiRootLifecycle } from "./server-control-ui-root.js";
 
+function readyAssets(root = "/repo/dist/control-ui", publicAssetBuildId?: string) {
+  return { kind: "ready", indexPath: `${root}/index.html`, publicAssetBuildId };
+}
+
 describe("createGatewayControlUiRootLifecycle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(fs, "realpathSync").mockImplementation((rootPath) => String(rootPath));
-    vi.spyOn(fs, "readFileSync").mockReturnValue("<html></html>");
     controlUiAssetsMocks.ensureControlUiAssetsBuilt.mockResolvedValue({
       ok: true,
       built: false,
+      assets: readyAssets(),
     });
     controlUiAssetsMocks.isPackageProvenControlUiRootSync.mockReturnValue(false);
-    controlUiAssetsMocks.isControlUiStartupAssetsReady.mockReturnValue(true);
+    controlUiAssetsMocks.inspectControlUiRootAssets.mockImplementation((root) => readyAssets(root));
     controlUiAssetsMocks.resolveControlUiRootOverrideSync.mockReturnValue(null);
     controlUiAssetsMocks.resolveControlUiRootSync.mockReturnValue(null);
     retentionMocks.prepare.mockResolvedValue(undefined);
@@ -90,23 +95,17 @@ describe("createGatewayControlUiRootLifecycle", () => {
   test("snapshots public asset identity only for a bundled root", () => {
     controlUiAssetsMocks.resolveControlUiRootSync.mockReturnValue("/repo/dist/control-ui");
     controlUiAssetsMocks.isPackageProvenControlUiRootSync.mockReturnValue(true);
-    vi.mocked(fs.readFileSync).mockReturnValue(
-      '<html data-openclaw-control-ui-build-id="build-content-digest"></html>',
+    controlUiAssetsMocks.inspectControlUiRootAssets.mockReturnValue(
+      readyAssets("/repo/dist/control-ui", "build-content-digest"),
     );
     const { lifecycle } = createLifecycle();
     expect(lifecycle.state).toMatchObject({
       kind: "bundled",
       publicAssetBuildId: "build-content-digest",
     });
-    expect(fs.readFileSync).toHaveBeenCalledExactlyOnceWith(
-      "/repo/dist/control-ui/index.html",
-      "utf8",
-    );
-    vi.mocked(fs.readFileSync).mockClear();
     controlUiAssetsMocks.resolveControlUiRootOverrideSync.mockReturnValue("/repo/dist/control-ui");
     const custom = createLifecycle({ override: "/repo/dist/control-ui" });
     expect(custom.lifecycle.state).not.toHaveProperty("publicAssetBuildId");
-    expect(fs.readFileSync).not.toHaveBeenCalled();
   });
 
   test("cancels retained-generation preparation without warning during shutdown", async () => {
@@ -132,10 +131,12 @@ describe("createGatewayControlUiRootLifecycle", () => {
 
   test("rebuilds incomplete auto-discovered roots before publishing them", async () => {
     controlUiAssetsMocks.resolveControlUiRootSync.mockReturnValue("/repo/dist/control-ui");
-    controlUiAssetsMocks.isControlUiStartupAssetsReady.mockReturnValue(false);
+    controlUiAssetsMocks.inspectControlUiRootAssets.mockReturnValue({ kind: "incomplete" });
     controlUiAssetsMocks.ensureControlUiAssetsBuilt.mockImplementationOnce(async () => {
-      controlUiAssetsMocks.isControlUiStartupAssetsReady.mockReturnValue(true);
-      return { ok: true, built: true };
+      controlUiAssetsMocks.inspectControlUiRootAssets.mockImplementation((root) =>
+        readyAssets(root),
+      );
+      return { ok: true, built: true, assets: readyAssets() };
     });
     controlUiAssetsMocks.isPackageProvenControlUiRootSync.mockReturnValue(true);
     const { lifecycle } = createLifecycle();
@@ -157,26 +158,11 @@ describe("createGatewayControlUiRootLifecycle", () => {
     expect(retentionMocks.prepare).toHaveBeenCalledOnce();
   });
 
-  test("keeps corrupt packaged Resources terminal when another dist build is healthy", async () => {
-    controlUiAssetsMocks.resolveControlUiRootSync.mockReturnValue("/App/Resources/control-ui");
-    controlUiAssetsMocks.isControlUiStartupAssetsReady.mockReturnValue(false);
-    controlUiAssetsMocks.ensureControlUiAssetsBuilt.mockResolvedValue({ ok: true, built: false });
-    const { lifecycle, warn } = createLifecycle();
-
-    expect(lifecycle.state).toEqual({ kind: "preparing" });
-    await lifecycle.start();
-
-    expect(lifecycle.state).toEqual({ kind: "failed" });
-    expect(warn).toHaveBeenCalledWith(
-      "gateway: Control UI assets at /App/Resources/control-ui remain incomplete. Run `openclaw doctor --fix` or reinstall OpenClaw.",
-    );
-  });
-
   test("starts only after scheduling and promotes the same root reference once", async () => {
     let finishBuild: (() => void) | undefined;
     controlUiAssetsMocks.ensureControlUiAssetsBuilt.mockReturnValue(
       new Promise((resolve) => {
-        finishBuild = () => resolve({ ok: true, built: true });
+        finishBuild = () => resolve({ ok: true, built: true, assets: readyAssets() });
       }),
     );
     const { lifecycle, gatewayRuntime, warn } = createLifecycle();
@@ -192,6 +178,9 @@ describe("createGatewayControlUiRootLifecycle", () => {
     );
     expect(controlUiAssetsMocks.ensureControlUiAssetsBuilt).toHaveBeenCalledWith(gatewayRuntime, {
       signal: expect.any(AbortSignal),
+      assetRoot: undefined,
+      expectedBuildId: expect.anything(),
+      moduleUrl: expect.any(String),
     });
     expect(rootReference).toEqual({ kind: "preparing" });
 
@@ -222,7 +211,7 @@ describe("createGatewayControlUiRootLifecycle", () => {
       realPath: "/custom/ui",
     });
     expect(controlUiAssetsMocks.ensureControlUiAssetsBuilt).not.toHaveBeenCalled();
-    expect(controlUiAssetsMocks.isControlUiStartupAssetsReady).not.toHaveBeenCalled();
+    expect(controlUiAssetsMocks.inspectControlUiRootAssets).not.toHaveBeenCalled();
   });
 
   test("keeps invalid configured roots terminal without starting a default build", () => {
@@ -324,7 +313,7 @@ describe("createGatewayControlUiRootLifecycle", () => {
       let finishBuild: (() => void) | undefined;
       controlUiAssetsMocks.ensureControlUiAssetsBuilt.mockReturnValue(
         new Promise((resolve) => {
-          finishBuild = () => resolve({ ok: true, built: true });
+          finishBuild = () => resolve({ ok: true, built: true, assets: readyAssets() });
         }),
       );
       if (initiallyFailed) {
@@ -356,7 +345,7 @@ describe("createGatewayControlUiRootLifecycle", () => {
     controlUiAssetsMocks.ensureControlUiAssetsBuilt.mockImplementationOnce(
       async () =>
         await new Promise((resolve) => {
-          finishBuild = () => resolve({ ok: true, built: true });
+          finishBuild = () => resolve({ ok: true, built: true, assets: readyAssets() });
         }),
     );
     const { lifecycle, warn } = createLifecycle();
@@ -400,17 +389,5 @@ describe("createGatewayControlUiRootLifecycle", () => {
     expect(lifecycle.state).toBe(rootReference);
     expect(rootReference).toMatchObject({ kind: "resolved", path: "/repo/dist/control-ui" });
     await lifecycle.stop();
-  });
-
-  test("fails when a successful build still cannot resolve an effective root", async () => {
-    controlUiAssetsMocks.ensureControlUiAssetsBuilt.mockResolvedValue({ ok: true, built: true });
-    const { lifecycle, warn } = createLifecycle();
-
-    await lifecycle.start();
-
-    expect(lifecycle.state).toEqual({ kind: "failed" });
-    expect(warn).toHaveBeenCalledWith(
-      "gateway: Control UI build completed, but its assets are still unavailable. Run `openclaw doctor --fix` or reinstall OpenClaw.",
-    );
   });
 });

--- a/src/gateway/server-control-ui-root.ts
+++ b/src/gateway/server-control-ui-root.ts
@@ -3,15 +3,15 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   ensureControlUiAssetsBuilt,
+  inspectControlUiRootAssets,
   isPackageProvenControlUiRootSync,
-  isControlUiStartupAssetsReady,
   resolveControlUiRootOverrideSync,
   resolveControlUiRootSync,
 } from "../infra/control-ui-assets.js";
 import { runOutsideGatewayRootWorkAdmission } from "../process/gateway-work-admission.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { resolveRuntimeServiceBuildId } from "../version.js";
 import { createControlUiAssetRetention } from "./control-ui-asset-retention.js";
-import { CONTROL_UI_BUILD_ID_ATTRIBUTE } from "./control-ui-root-assets.js";
 import type { ControlUiRootState } from "./control-ui.js";
 
 type GatewayControlUiRootParams = {
@@ -36,46 +36,39 @@ function resolveAutoRoot(): string | null {
   });
 }
 
-function createResolvedRootState(root: string, configured = false): ControlUiRootState {
-  const bundled =
-    !configured &&
-    isPackageProvenControlUiRootSync(root, {
-      moduleUrl: import.meta.url,
-      argv1: process.argv[1],
-      cwd: process.cwd(),
-    });
-  return bundled
-    ? {
-        kind: "bundled",
-        path: root,
-        realPath: fs.realpathSync(root),
-        // Snapshot build metadata at the root lifecycle boundary, never per request.
-        publicAssetBuildId: new RegExp(
-          `${CONTROL_UI_BUILD_ID_ATTRIBUTE}="([a-zA-Z0-9._-]{1,161})"`,
-        ).exec(fs.readFileSync(path.join(root, "index.html"), "utf8"))?.[1],
-        retainedAssets: createControlUiAssetRetention(root),
-      }
-    : {
-        kind: "resolved",
-        path: root,
-        realPath: fs.realpathSync(root),
-      };
-}
-
-function prepareResolvedRootState(params: {
+function prepareResolvedRootState({
+  root,
+  configured = false,
+  publicAssetBuildId,
+  log,
+}: {
   root: string;
   configured?: boolean;
+  publicAssetBuildId?: string;
   log: GatewayControlUiRootParams["log"];
 }): ControlUiRootState {
   try {
-    return createResolvedRootState(params.root, params.configured);
+    const bundled =
+      !configured &&
+      isPackageProvenControlUiRootSync(root, {
+        moduleUrl: import.meta.url,
+        argv1: process.argv[1],
+        cwd: process.cwd(),
+      });
+    const resolvedRoot = { path: root, realPath: fs.realpathSync(root) };
+    return bundled
+      ? {
+          kind: "bundled",
+          ...resolvedRoot,
+          publicAssetBuildId,
+          retainedAssets: createControlUiAssetRetention(root),
+        }
+      : { kind: "resolved", ...resolvedRoot };
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    const message = `Control UI assets are unavailable at ${params.root}: ${detail}`;
-    params.log.warn(`gateway: ${message}`);
-    return params.configured
-      ? { kind: "invalid", path: path.resolve(params.root) }
-      : { kind: "failed" };
+    const message = `Control UI assets are unavailable at ${root}: ${detail}`;
+    log.warn(`gateway: ${message}`);
+    return configured ? { kind: "invalid", path: path.resolve(root) } : { kind: "failed" };
   }
 }
 
@@ -83,6 +76,7 @@ function prepareResolvedRootState(params: {
 export function createGatewayControlUiRootLifecycle(
   params: GatewayControlUiRootParams,
 ): GatewayControlUiRootLifecycle {
+  const expectedBuildId = resolveRuntimeServiceBuildId();
   let state: ControlUiRootState = { kind: "preparing" };
   if (params.controlUiRootOverride) {
     const resolvedOverride = resolveControlUiRootOverrideSync(params.controlUiRootOverride);
@@ -99,9 +93,14 @@ export function createGatewayControlUiRootLifecycle(
     }
   } else if (params.controlUiEnabled) {
     const resolvedRoot = resolveAutoRoot();
+    const assets = resolvedRoot ? inspectControlUiRootAssets(resolvedRoot, expectedBuildId) : null;
     state =
-      resolvedRoot && isControlUiStartupAssetsReady(resolvedRoot)
-        ? prepareResolvedRootState({ root: resolvedRoot, log: params.log })
+      resolvedRoot && assets?.kind === "ready"
+        ? prepareResolvedRootState({
+            root: resolvedRoot,
+            publicAssetBuildId: assets.publicAssetBuildId,
+            log: params.log,
+          })
         : { kind: "preparing" };
   }
 
@@ -117,34 +116,37 @@ export function createGatewayControlUiRootLifecycle(
       if (state.kind === "preparing") {
         // Initially disabled gateways discover assets only when enabled. Reuse a
         // finished build after cancellation without reviving its retired preparer.
-        let resolvedRoot = resolveAutoRoot();
-        if (!resolvedRoot || !isControlUiStartupAssetsReady(resolvedRoot)) {
-          const result = await ensureControlUiAssetsBuilt(params.gatewayRuntime, { signal });
+        const resolvedRoot = resolveAutoRoot();
+        let assets = resolvedRoot
+          ? inspectControlUiRootAssets(resolvedRoot, expectedBuildId)
+          : null;
+        if (assets?.kind !== "ready") {
+          const result = await ensureControlUiAssetsBuilt(params.gatewayRuntime, {
+            assetRoot: resolvedRoot ?? undefined,
+            expectedBuildId,
+            moduleUrl: import.meta.url,
+            signal,
+          });
           if (isStopped()) {
             return;
           }
           if (!result.ok) {
             Object.assign(state, { kind: "failed" });
-            params.log.warn(
-              `gateway: ${result.message ?? "Control UI assets could not be built."}`,
-            );
+            params.log.warn(`gateway: ${result.message}`);
             return;
           }
-          resolvedRoot = resolveAutoRoot();
-        }
-        if (!resolvedRoot || !isControlUiStartupAssetsReady(resolvedRoot)) {
-          const message = resolvedRoot
-            ? `Control UI assets at ${resolvedRoot} remain incomplete.`
-            : "Control UI build completed, but its assets are still unavailable.";
-          Object.assign(state, { kind: "failed" });
-          params.log.warn(
-            `gateway: ${message} Run \`openclaw doctor --fix\` or reinstall OpenClaw.`,
-          );
-          return;
+          assets = result.assets;
         }
         // Listeners retain this object from before bind; replacing it would strand
         // their routes in the preparing state after a successful background build.
-        Object.assign(state, createResolvedRootState(resolvedRoot));
+        Object.assign(
+          state,
+          prepareResolvedRootState({
+            root: path.dirname(assets.indexPath),
+            publicAssetBuildId: assets.publicAssetBuildId,
+            log: params.log,
+          }),
+        );
       }
     } catch (error) {
       if (!isStopped()) {

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -80,7 +80,7 @@ vi.mock("../process/exec.js", () => ({
 }));
 
 let ensureControlUiAssetsBuilt: typeof import("./control-ui-assets.js").ensureControlUiAssetsBuilt;
-let isControlUiStartupAssetsReady: typeof import("./control-ui-assets.js").isControlUiStartupAssetsReady;
+let inspectControlUiRootAssets: typeof import("./control-ui-assets.js").inspectControlUiRootAssets;
 let resolveControlUiAssetHealth: typeof import("./control-ui-assets.js").resolveControlUiAssetHealth;
 let isPackageProvenControlUiRootSync: typeof import("./control-ui-assets.js").isPackageProvenControlUiRootSync;
 let resolveControlUiRootOverrideSync: typeof import("./control-ui-assets.js").resolveControlUiRootOverrideSync;
@@ -91,7 +91,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
   beforeAll(async () => {
     ({
       ensureControlUiAssetsBuilt,
-      isControlUiStartupAssetsReady,
+      inspectControlUiRootAssets,
       resolveControlUiAssetHealth,
       isPackageProvenControlUiRootSync,
       resolveControlUiRootOverrideSync,
@@ -139,14 +139,37 @@ describe("control UI assets helpers (fs-mocked)", () => {
     const root = abs("fixtures/effective-resources");
     const indexPath = path.join(root, "index.html");
 
-    expect(isControlUiStartupAssetsReady(root)).toBe(false);
+    expect(inspectControlUiRootAssets(root).kind).not.toBe("ready");
 
     setFile(indexPath, '<script src="/configured/base/assets/startup.js"></script>');
-    expect(isControlUiStartupAssetsReady(root)).toBe(false);
+    expect(inspectControlUiRootAssets(root).kind).not.toBe("ready");
 
     setFile(path.join(root, "assets", "startup.js"));
-    expect(isControlUiStartupAssetsReady(root)).toBe(true);
+    expect(inspectControlUiRootAssets(root).kind).toBe("ready");
   });
+
+  it.each([
+    { marker: `runtime-b-${"a".repeat(64)}`, kind: "ready" },
+    { marker: `runtime-b-${"b".repeat(64)}`, kind: "ready" },
+    { marker: `dev-${"a".repeat(64)}`, kind: "ready" },
+    { marker: `runtime-a-${"a".repeat(64)}`, kind: "stale" },
+    { marker: `runtime-b-other-${"a".repeat(64)}`, kind: "stale" },
+    { marker: `runtime-b-${"a".repeat(63)}`, kind: "stale" },
+    { marker: "runtime-b", kind: "stale" },
+    { marker: "", kind: "stale" },
+  ])(
+    "checks the runtime identity independently of its public digest: $marker",
+    ({ marker, kind }) => {
+      const root = abs("fixtures/build-identity");
+      setFile(
+        path.join(root, "index.html"),
+        `<html data-openclaw-control-ui-build-id="${marker}"></html>`,
+      );
+      expect(inspectControlUiRootAssets(root, "runtime-b").kind).toBe(kind);
+      // Doctor and update checks without a loaded Gateway retain completeness-only inspection.
+      expect(inspectControlUiRootAssets(root).kind).toBe("ready");
+    },
+  );
 
   it("rejects traversing startup references without inspecting files outside the asset root", () => {
     const root = abs("fixtures/effective-traversal");
@@ -163,7 +186,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
         "/base/../assets/startup.js",
       ]) {
         setFile(indexPath, `<script src="${reference}"></script>`);
-        expect(isControlUiStartupAssetsReady(root)).toBe(false);
+        expect(inspectControlUiRootAssets(root).kind).not.toBe("ready");
       }
       expect(exists).not.toHaveBeenCalledWith(outsideAsset);
     } finally {
@@ -177,10 +200,10 @@ describe("control UI assets helpers (fs-mocked)", () => {
     const reference = '<script src="./assets/startup.js"></script>';
     setFile(path.join(root, "assets", "startup.js"));
     setFile(indexPath, reference.repeat(128));
-    expect(isControlUiStartupAssetsReady(root)).toBe(true);
+    expect(inspectControlUiRootAssets(root).kind).toBe("ready");
 
     setFile(indexPath, reference.repeat(129));
-    expect(isControlUiStartupAssetsReady(root)).toBe(false);
+    expect(inspectControlUiRootAssets(root).kind).not.toBe("ready");
   });
 
   it("keeps a truncated build failure diagnostic within its UTF-16 limit", async () => {
@@ -226,22 +249,42 @@ describe("control UI assets helpers (fs-mocked)", () => {
     }
   });
 
-  it("recognizes macOS packaged assets without trying to build the unused dist root", async () => {
-    const root = abs("fixtures/packaged-app");
-    const execPath = path.join(root, "OpenClaw.app", "Contents", "MacOS", "OpenClaw");
-    const bundledUiDir = path.join(root, "OpenClaw.app", "Contents", "Resources", "control-ui");
-    state.realpaths.set(execPath, execPath);
-    setFile(path.join(bundledUiDir, "index.html"), "<html>packaged</html>");
+  it.each(["ready", "stale", "incomplete"])(
+    "checks %s macOS Resources ahead of a healthy unused dist root",
+    async (kind) => {
+      const root = abs("fixtures/packaged-app");
+      const execPath = path.join(root, "OpenClaw.app", "Contents", "MacOS", "OpenClaw");
+      const bundledUiDir = path.join(root, "OpenClaw.app", "Contents", "Resources", "control-ui");
+      const indexPath = path.join(bundledUiDir, "index.html");
+      const document = (buildId: string) =>
+        `<html data-openclaw-control-ui-build-id="${buildId}-${"a".repeat(64)}"><script src="./assets/startup.js"></script></html>`;
+      state.realpaths.set(execPath, execPath);
+      setFile(indexPath, document(kind === "stale" ? "runtime-a" : "runtime-b"));
+      if (kind !== "incomplete") {
+        setFile(path.join(bundledUiDir, "assets", "startup.js"));
+      }
+      setFile(path.join(root, "dist", "control-ui", "index.html"), document("runtime-b"));
+      setFile(path.join(root, "dist", "control-ui", "assets", "startup.js"));
+      setFile(path.join(root, "ui", "vite.config.ts"));
+      setFile(path.join(root, "scripts", "ui.js"));
+      vi.mocked(openclawRoot.resolveOpenClawPackageRootSync).mockReturnValue(root);
 
-    await expect(
-      ensureControlUiAssetsBuilt(undefined, {
+      const result = await ensureControlUiAssetsBuilt(undefined, {
         argv1: path.join(root, "entry.js"),
         cwd: root,
         execPath,
-      }),
-    ).resolves.toEqual({ ok: true, built: false });
-    expect(state.runCommandWithTimeout).not.toHaveBeenCalled();
-  });
+        expectedBuildId: "runtime-b",
+      });
+      expect(result).toMatchObject({ ok: kind === "ready", built: false });
+      if (result.ok) {
+        expect(result.assets.indexPath).toBe(indexPath);
+      } else {
+        expect(result.message).toContain(indexPath);
+        expect(result.message).toContain("Reinstall OpenClaw");
+      }
+      expect(state.runCommandWithTimeout).not.toHaveBeenCalled();
+    },
+  );
 
   it("tells packaged installs to reinstall when their bundled assets are missing", async () => {
     const root = abs("fixtures/packaged-missing");
@@ -281,7 +324,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
       ].join(""),
     );
 
-    await expect(ensureControlUiAssetsBuilt(undefined, { root })).resolves.toEqual({
+    await expect(ensureControlUiAssetsBuilt(undefined, { root })).resolves.toMatchObject({
       ok: true,
       built: false,
     });
@@ -291,7 +334,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
     const root = abs("fixtures/packaged-oversized");
     const uiRoot = path.join(root, "dist", "control-ui");
     setFile(path.join(uiRoot, "index.html"), "x".repeat(256 * 1024));
-    expect(isControlUiStartupAssetsReady(uiRoot)).toBe(true);
+    expect(inspectControlUiRootAssets(uiRoot).kind).toBe("ready");
 
     setFile(path.join(uiRoot, "index.html"), "x".repeat(256 * 1024 + 1));
 
@@ -323,7 +366,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
         argv1: path.join(packagedRoot, "dist", "entry.js"),
         cwd: checkoutRoot,
       }),
-    ).resolves.toEqual({ ok: true, built: true });
+    ).resolves.toMatchObject({ ok: true, built: true });
     const message = runtime.log.mock.calls.flat().join("\n");
     const commands = [...message.matchAll(/`(pnpm [^`]+)`/gu)].map((match) => match[1]);
     expect(commands).toHaveLength(2);
@@ -355,7 +398,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
 
     await expect(
       ensureControlUiAssetsBuilt(undefined, { root, force: true, signal: controller.signal }),
-    ).resolves.toEqual({ ok: true, built: true });
+    ).resolves.toMatchObject({ ok: true, built: true });
     expect(state.runCommandWithTimeout).toHaveBeenCalledWith(
       [process.execPath, path.join(root, "scripts", "ui.js"), "build"],
       { cwd: root, timeoutMs: 600_000, signal: controller.signal },
@@ -382,7 +425,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
       return { stdout: "", stderr: "", code: 0, signal: null, killed: false, termination: "exit" };
     });
 
-    await expect(ensureControlUiAssetsBuilt(undefined, { root })).resolves.toEqual({
+    await expect(ensureControlUiAssetsBuilt(undefined, { root })).resolves.toMatchObject({
       ok: true,
       built: true,
     });

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -159,15 +159,19 @@ describe("control UI assets helpers (fs-mocked)", () => {
     { marker: "", kind: "stale" },
   ])(
     "checks the runtime identity independently of its public digest: $marker",
-    ({ marker, kind }) => {
+    async ({ marker, kind }) => {
       const root = abs("fixtures/build-identity");
+      const assetRoot = path.join(root, "dist", "control-ui");
       setFile(
-        path.join(root, "index.html"),
+        path.join(assetRoot, "index.html"),
         `<html data-openclaw-control-ui-build-id="${marker}"></html>`,
       );
-      expect(inspectControlUiRootAssets(root, "runtime-b").kind).toBe(kind);
-      // Doctor and update checks without a loaded Gateway retain completeness-only inspection.
-      expect(inspectControlUiRootAssets(root).kind).toBe("ready");
+      expect(inspectControlUiRootAssets(assetRoot, "runtime-b").kind).toBe(kind);
+      await expect(
+        resolveControlUiAssetHealth({ root, expectedBuildId: "runtime-b" }),
+      ).resolves.toMatchObject({ kind });
+      // Updaters may inspect a newly built target from an older running process.
+      await expect(resolveControlUiAssetHealth({ root })).resolves.toMatchObject({ kind: "ready" });
     },
   );
 

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { quoteCliArg, quotePowerShellArg } from "../cli/quote-cli-arg.js";
+import { CONTROL_UI_BUILD_ID_ATTRIBUTE } from "../gateway/control-ui-root-assets.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import * as controlUiFsRuntime from "./control-ui-assets.fs.runtime.js";
@@ -21,7 +22,8 @@ export function resolveControlUiDistIndexPathForRoot(root: string): string {
 type ControlUiAssetHealth =
   | { kind: "missing-index"; indexPath: string | null }
   | { kind: "incomplete"; indexPath: string; missingAsset: string }
-  | { kind: "ready"; indexPath: string };
+  | { kind: "stale"; indexPath: string; buildId: string | null }
+  | { kind: "ready"; indexPath: string; publicAssetBuildId?: string };
 
 export async function resolveControlUiAssetHealth(
   opts: {
@@ -263,14 +265,14 @@ export function isPackageProvenControlUiRootSync(
   return pathsMatchByRealpathOrResolve(root, packageDistRoot);
 }
 
-type EnsureControlUiAssetsResult = {
-  ok: boolean;
-  built: boolean;
-  message?: string;
-};
+type EnsureControlUiAssetsResult =
+  | { ok: true; built: boolean; assets: Extract<ControlUiAssetHealth, { kind: "ready" }> }
+  | { ok: false; built: boolean; message: string };
 
 type EnsureControlUiAssetsOptions = ControlUiRootResolveOptions & {
   root?: string;
+  assetRoot?: string;
+  expectedBuildId?: string | null;
   force?: boolean;
   signal?: AbortSignal;
   timeoutMs?: number;
@@ -283,7 +285,10 @@ function controlUiAssetsFailure(message: string, built = false): EnsureControlUi
   return { ok: false, built, message };
 }
 
-function inspectControlUiAssetHealth(indexPath: string | null): ControlUiAssetHealth {
+function inspectControlUiAssetHealth(
+  indexPath: string | null,
+  expectedBuildId?: string | null,
+): ControlUiAssetHealth {
   if (!indexPath) {
     return { kind: "missing-index", indexPath };
   }
@@ -319,11 +324,23 @@ function inspectControlUiAssetHealth(indexPath: string | null): ControlUiAssetHe
       return { kind: "incomplete", indexPath, missingAsset: asset };
     }
   }
-  return { kind: "ready", indexPath };
+  const publicAssetBuildId = new RegExp(
+    `${CONTROL_UI_BUILD_ID_ATTRIBUTE}="([a-zA-Z0-9._-]{1,161})"`,
+  ).exec(html)?.[1];
+  // Vite appends a public-file digest to the runtime ID; the cache namespace
+  // must not substitute for the identity used by same-origin admission.
+  const buildId = publicAssetBuildId?.match(/^([a-zA-Z0-9._-]{1,96})-[a-f0-9]{64}$/u)?.[1] ?? null;
+  if (expectedBuildId && buildId !== "dev" && buildId !== expectedBuildId) {
+    return { kind: "stale", indexPath, buildId };
+  }
+  return { kind: "ready", indexPath, ...(publicAssetBuildId ? { publicAssetBuildId } : {}) };
 }
 
-export function isControlUiStartupAssetsReady(root: string): boolean {
-  return inspectControlUiAssetHealth(path.join(root, "index.html")).kind === "ready";
+export function inspectControlUiRootAssets(
+  root: string,
+  expectedBuildId?: string | null,
+): ControlUiAssetHealth {
+  return inspectControlUiAssetHealth(path.join(root, "index.html"), expectedBuildId);
 }
 
 function summarizeCommandOutput(text: string): string | undefined {
@@ -342,54 +359,38 @@ export async function ensureControlUiAssetsBuilt(
   runtime: RuntimeEnv = defaultRuntime,
   opts: EnsureControlUiAssetsOptions = {},
 ): Promise<EnsureControlUiAssetsResult> {
-  const argv1 = opts.argv1 ?? process.argv[1];
-  const health = await resolveControlUiAssetHealth({
-    ...(opts.root ? { root: opts.root } : {}),
-    argv1,
-    moduleUrl: opts.moduleUrl,
-  });
-  const indexFromDist = health.indexPath;
-  let missingStartupAsset = health.kind === "incomplete" ? health.missingAsset : undefined;
+  const assetRoot =
+    opts.assetRoot ??
+    (opts.root
+      ? path.dirname(resolveControlUiDistIndexPathForRoot(opts.root))
+      : resolveControlUiRootSync(opts));
+  const selectedIndex = assetRoot
+    ? path.join(assetRoot, "index.html")
+    : await resolveControlUiDistIndexPath(opts);
+  const health = inspectControlUiAssetHealth(selectedIndex, opts.expectedBuildId);
   if (!opts.force && health.kind === "ready") {
-    return { ok: true, built: false };
-  }
-  if (!opts.force && !opts.root) {
-    const detectedRoot = resolveControlUiRootSync({
-      argv1,
-      moduleUrl: opts.moduleUrl,
-      cwd: opts.cwd,
-      execPath: opts.execPath,
-    });
-    if (detectedRoot) {
-      const detectedHealth = inspectControlUiAssetHealth(path.join(detectedRoot, "index.html"));
-      missingStartupAsset =
-        detectedHealth.kind === "incomplete" ? detectedHealth.missingAsset : undefined;
-      if (detectedHealth.kind === "ready") {
-        return { ok: true, built: false };
-      }
-    }
+    return { ok: true, built: false, assets: health };
   }
 
-  const repoRoot = resolveControlUiRepoRoot({
-    root: opts.root,
-    argv1,
-    moduleUrl: opts.moduleUrl,
-    cwd: opts.cwd,
-  });
-  if (!repoRoot) {
-    const hint = missingStartupAsset
-      ? `Incomplete Control UI assets${indexFromDist ? ` at ${indexFromDist}` : ""} (missing ${missingStartupAsset})`
-      : indexFromDist
-        ? `Missing Control UI assets at ${indexFromDist}`
-        : "Missing Control UI assets";
+  const repoRoot = resolveControlUiRepoRoot(opts);
+  const indexPath = repoRoot ? resolveControlUiDistIndexPathForRoot(repoRoot) : null;
+  // Only the selected source tree owns its output. A healthy checkout beside a
+  // damaged app's Resources directory cannot repair the assets that app serves.
+  if (
+    !repoRoot ||
+    !indexPath ||
+    (assetRoot && !pathsMatchByRealpathOrResolve(assetRoot, path.dirname(indexPath)))
+  ) {
+    const location = selectedIndex ? ` at ${selectedIndex}` : "";
+    const hint =
+      health.kind === "stale"
+        ? `Stale Control UI assets${location} (build ${health.buildId ?? "unknown"}; expected ${opts.expectedBuildId})`
+        : health.kind === "incomplete"
+          ? `Incomplete Control UI assets${location} (missing ${health.missingAsset})`
+          : `Missing Control UI assets${location}`;
     return controlUiAssetsFailure(
       `${hint}. Reinstall OpenClaw to restore bundled Control UI assets.`,
     );
-  }
-
-  const indexPath = resolveControlUiDistIndexPathForRoot(repoRoot);
-  if (!opts.force && inspectControlUiAssetHealth(indexPath).kind === "ready") {
-    return { ok: true, built: false };
   }
 
   const uiScript = path.join(repoRoot, "scripts", "ui.js");
@@ -407,7 +408,7 @@ export async function ensureControlUiAssetsBuilt(
     const buildCommand = formatControlUiSourceCommand(repoRoot, "build");
     const devCommand = formatControlUiSourceCommand(repoRoot, "dev");
     runtime.log(
-      `Control UI assets missing; building them now (rerun \`${buildCommand}\` after UI changes, or use \`${devCommand}\` while developing the Control UI)…`,
+      `Control UI assets need rebuilding; building them now (rerun \`${buildCommand}\` after UI changes, or use \`${devCommand}\` while developing the Control UI)…`,
     );
   }
 
@@ -436,19 +437,15 @@ export async function ensureControlUiAssetsBuilt(
     );
   }
 
-  const builtHealth = inspectControlUiAssetHealth(indexPath);
-  if (builtHealth.kind === "missing-index") {
-    return controlUiAssetsFailure(
-      `Control UI build completed but ${indexPath} is still missing.`,
-      true,
-    );
+  const builtHealth = inspectControlUiAssetHealth(indexPath, opts.expectedBuildId);
+  if (builtHealth.kind !== "ready") {
+    const issue =
+      builtHealth.kind === "missing-index"
+        ? `${indexPath} is still missing.`
+        : builtHealth.kind === "incomplete"
+          ? `startup asset ${builtHealth.missingAsset} is missing.`
+          : `its identity is ${builtHealth.buildId ?? "unknown"}; expected ${opts.expectedBuildId}. Restart the Gateway after rebuilding its runtime and UI together.`;
+    return controlUiAssetsFailure(`Control UI build completed but ${issue}`, true);
   }
-  if (builtHealth.kind === "incomplete") {
-    return controlUiAssetsFailure(
-      `Control UI build completed but startup asset ${builtHealth.missingAsset} is missing.`,
-      true,
-    );
-  }
-
-  return { ok: true, built: true };
+  return { ok: true, built: true, assets: builtHealth };
 }

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -30,6 +30,7 @@ export async function resolveControlUiAssetHealth(
     root?: string;
     argv1?: string;
     moduleUrl?: string;
+    expectedBuildId?: string | null;
   } = {},
 ): Promise<ControlUiAssetHealth> {
   const indexPath = opts.root
@@ -38,7 +39,7 @@ export async function resolveControlUiAssetHealth(
         argv1: opts.argv1 ?? process.argv[1],
         moduleUrl: opts.moduleUrl,
       });
-  return inspectControlUiAssetHealth(indexPath);
+  return inspectControlUiAssetHealth(indexPath, opts.expectedBuildId);
 }
 
 function resolveControlUiRepoRoot(opts: {

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -505,7 +505,6 @@ vi.mock("../daemon/systemd.js", () => ({
 vi.mock("../infra/control-ui-assets.js", () => ({
   CONTROL_UI_ASSETS_BUILD_TIMEOUT_MS: 600_000,
   ensureControlUiAssetsBuilt,
-  isControlUiStartupAssetsReady: vi.fn(() => true),
 }));
 
 vi.mock("../plugins/status.js", () => ({

--- a/ui/src/app/app-host-refresh-control-ui.test.ts
+++ b/ui/src/app/app-host-refresh-control-ui.test.ts
@@ -1,87 +1,182 @@
 /* @vitest-environment jsdom */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { setAvatarGatewayOrigin } from "../lib/identity-avatar-context.ts";
 import type { ApplicationRuntime } from "./bootstrap.ts";
-import type { retryStaleChunkReloadWhenReachable } from "./stale-chunk-reload.ts";
-
-type RetryOptions = Parameters<typeof retryStaleChunkReloadWhenReachable>[0];
-
-const retryHarness = vi.hoisted(() => ({
-  retry: vi.fn<(options: RetryOptions) => Promise<boolean>>(),
-}));
-
-vi.mock("./stale-chunk-reload.ts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./stale-chunk-reload.ts")>();
-  return {
-    ...actual,
-    retryStaleChunkReloadWhenReachable: retryHarness.retry,
-  };
-});
-
+import {
+  createGatewayStoreTestStore,
+  stubGatewayStoreTestGlobals,
+} from "./gateway-store.test-support.ts";
+import { createApplicationUpdateOverlays } from "./overlays-updates.ts";
+import { loadSettings } from "./settings.ts";
+import { resolveApplicationStartupSettings } from "./startup-settings.ts";
 import "./app-host.ts";
+
+vi.hoisted(() => {
+  vi.stubGlobal("OPENCLAW_CONTROL_UI_BUILD_INFO", {
+    version: "1.0.0",
+    buildId: "serving-build",
+    commit: null,
+    commitAt: null,
+    builtAt: null,
+    branch: null,
+    dirty: null,
+    release: false,
+  });
+});
 
 type RefreshShell = HTMLElement & {
   runtime: ApplicationRuntime;
   refreshControlUi: () => Promise<boolean>;
 };
 
-function deferred() {
-  let resolve: (value: boolean) => void = () => undefined;
-  const promise = new Promise<boolean>((settle) => {
-    resolve = settle;
-  });
-  return { promise, resolve };
-}
-
-function createRefreshShell() {
+function createRefreshShell(gateway: ApplicationRuntime["context"]["gateway"]) {
   const snapshot = { controlUiRefreshRequired: true };
   const shell = document.createElement("openclaw-app-shell") as RefreshShell;
   shell.runtime = {
-    context: { overlays: { snapshot } },
+    context: { overlays: { snapshot }, gateway },
   } as unknown as ApplicationRuntime;
   return { shell, snapshot };
 }
 
-function installRetryProbe() {
-  const probe = deferred();
-  const reload = vi.fn();
-  retryHarness.retry.mockImplementation(async (options) => {
-    const reachable = await probe.promise;
-    if (!reachable || options?.canReload?.() === false) {
-      return false;
-    }
-    reload();
-    return true;
-  });
-  return { probe, reload };
-}
-
-afterEach(() => {
-  retryHarness.retry.mockReset();
-  document.body.replaceChildren();
-});
-
 describe("OpenClaw shell Control UI refresh", () => {
-  it("does not reload after the recovery state clears during a successful probe", async () => {
-    const { probe, reload } = installRetryProbe();
-    const { shell, snapshot } = createRefreshShell();
+  let store: ReturnType<typeof createGatewayStoreTestStore>;
+  let probe: ReturnType<typeof createDeferred<Response>>;
+  let replace: ReturnType<typeof vi.fn<(url: string) => void>>;
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
 
-    const refresh = shell.refreshControlUi();
-    snapshot.controlUiRefreshRequired = false;
-    probe.resolve(true);
-
-    await expect(refresh).resolves.toBe(false);
-    expect(reload).not.toHaveBeenCalled();
+  beforeEach(() => {
+    stubGatewayStoreTestGlobals();
+    replace = vi.fn();
+    const location = Object.assign(new URL("http://127.0.0.1:18789/chat/main"), { replace });
+    vi.stubGlobal("location", location);
+    vi.stubGlobal("window", { location });
+    probe = createDeferred<Response>();
+    fetchMock = vi.fn<typeof fetch>(() => probe.promise);
+    vi.stubGlobal("fetch", fetchMock);
+    store = createGatewayStoreTestStore();
+    store.gateway.connect({
+      bootstrapToken: "synthetic-owner-bootstrap",
+      bootstrapProfile: "owner",
+    });
   });
 
-  it("allows a successful reload while the same recovery state is still current", async () => {
-    const { probe, reload } = installRetryProbe();
-    const { shell } = createRefreshShell();
+  afterEach(() => {
+    store.gateway.stop();
+    setAvatarGatewayOrigin(null);
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it.each(["clear", "replace"])(
+    "does not reload after the shell recovery state changes: %s",
+    async (action) => {
+      const { shell, snapshot } = createRefreshShell(store.gateway);
+      const refresh = shell.refreshControlUi();
+      if (action === "clear") {
+        snapshot.controlUiRefreshRequired = false;
+      } else {
+        shell.runtime = createRefreshShell(store.gateway).shell.runtime;
+      }
+      probe.resolve(new Response(null, { status: 200 }));
+
+      await expect(refresh).resolves.toBe(false);
+      expect(replace).not.toHaveBeenCalled();
+    },
+  );
+
+  it("continues the browser handoff when manual refresh follows a failed automatic probe", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+    store.current().opts.onClose?.({
+      code: 1008,
+      reason: "Control UI updated",
+      error: {
+        code: "UNAVAILABLE",
+        message: "Control UI updated",
+        details: {
+          code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
+          gatewayBuildId: "replacement-build",
+          reloadRequired: true,
+        },
+      },
+      willRetry: false,
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(replace).not.toHaveBeenCalled();
+    const { shell } = createRefreshShell(store.gateway);
 
     const refresh = shell.refreshControlUi();
-    probe.resolve(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    probe.resolve(new Response(null, { status: 200 }));
 
     await expect(refresh).resolves.toBe(true);
-    expect(reload).toHaveBeenCalledOnce();
+    expect(replace).toHaveBeenCalledOnce();
+    const resumed = resolveApplicationStartupSettings(
+      loadSettings(),
+      new URL(replace.mock.calls[0]![0]),
+    );
+    expect(resumed.pendingBootstrapToken).toBe("synthetic-owner-bootstrap");
+    expect(resumed.pendingBootstrapProfile).toBe("owner");
+    expect(resumed.location.hash).toBe("");
+  });
+
+  it.each(["browser", "native"] as const)(
+    "preserves the producer-offered cross-origin manual Refresh for %s",
+    async (surface) => {
+      store.gateway.stop();
+      store = createGatewayStoreTestStore({
+        clientOptions:
+          surface === "native" ? { clientName: "openclaw-ios", mode: "ui" } : undefined,
+      });
+      const updates = createApplicationUpdateOverlays(store.gateway, vi.fn());
+      const unsubscribe = store.gateway.subscribe(updates.synchronizeGateway);
+      try {
+        store.gateway.connect({ gatewayUrl: "wss://remote-gateway.example" });
+        store.current().opts.onHello?.({
+          type: "hello-ok",
+          protocol: 1,
+          auth: { role: "operator", scopes: ["operator.read"] },
+          server: { version: "1.0.0", buildId: "remote-build", connId: "remote-connection" },
+        });
+        expect(store.gateway.snapshot.phase).toBe("connected");
+        expect(store.gateway.connection.bootstrapToken).toBe("");
+        expect(updates.snapshot.controlUiRefreshRequired).toBe(true);
+        const { shell } = createRefreshShell(store.gateway);
+        shell.runtime = {
+          context: { gateway: store.gateway, overlays: updates },
+        } as unknown as ApplicationRuntime;
+        const refresh = shell.refreshControlUi();
+        probe.resolve(new Response(null, { status: 200 }));
+
+        await expect(refresh).resolves.toBe(true);
+        expect(fetchMock).toHaveBeenCalledOnce();
+        expect(replace).toHaveBeenCalledOnce();
+        const destination = new URL(replace.mock.calls[0]![0]);
+        expect(destination.origin).toBe("http://127.0.0.1:18789");
+        expect(destination.hash).toBe("");
+      } finally {
+        unsubscribe();
+        updates.dispose();
+      }
+    },
+  );
+
+  it("keeps a pending remote handoff out of the serving document on manual Refresh", async () => {
+    store.gateway.connect({
+      gatewayUrl: "wss://remote-gateway.example",
+      bootstrapToken: "synthetic-remote-bootstrap",
+    });
+    const { shell } = createRefreshShell(store.gateway);
+    const refresh = shell.refreshControlUi();
+    probe.resolve(new Response(null, { status: 200 }));
+
+    await expect(refresh).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/app/app-host.gateway-lineage.test.ts
+++ b/ui/src/app/app-host.gateway-lineage.test.ts
@@ -1,3 +1,4 @@
+import { parseControlUiFocusLocation } from "@openclaw/session-url-contract";
 import { render } from "lit";
 /* @vitest-environment jsdom */
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -39,6 +40,7 @@ import {
 } from "../test-helpers/gateway-client.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import "./app-host.ts";
+import { resolveControlUiDocumentMode } from "./approval-deep-link.ts";
 import type { ApplicationRuntime } from "./bootstrap.ts";
 import type { ApplicationContext, ApplicationGateway } from "./context.ts";
 import { createApplicationGateway } from "./gateway-store.ts";
@@ -93,37 +95,51 @@ function createGatewayHarness() {
   return { gateway, clients };
 }
 
+function createGatewaySurface(gateway: ApplicationGateway, pathname = "/chat") {
+  const app = document.createElement("openclaw-app") as unknown as {
+    runtime: Pick<
+      ApplicationRuntime,
+      | "context"
+      | "documentMode"
+      | "focusLocation"
+      | "confirmPendingGatewayConnection"
+      | "cancelPendingGatewayConnection"
+    >;
+    pendingGatewayUrl: string | null;
+    render: () => unknown;
+    synchronizeGateway: (gateway: ApplicationGateway) => void;
+  };
+  app.runtime = {
+    documentMode: resolveControlUiDocumentMode(pathname, ""),
+    focusLocation: parseControlUiFocusLocation(pathname, ""),
+    confirmPendingGatewayConnection: vi.fn(),
+    cancelPendingGatewayConnection: vi.fn(),
+    context: {
+      gateway,
+      basePath: "",
+      agentSelection: { state: { selectedId: null } },
+      config: { current: { terminalEnabled: false } },
+      theme: { resolvedMode: "dark" },
+    } as unknown as ApplicationContext,
+  };
+  const container = document.createElement("div");
+  const draw = () => {
+    app.synchronizeGateway(gateway);
+    render(app.render(), container);
+  };
+  return { app, container, draw };
+}
+
 function renderGatewaySurface(
   gateway: ApplicationGateway,
   documentView?: "desktop" | "terminal",
 ): string {
-  const originalUrl = `${location.pathname}${location.search}${location.hash}`;
-  if (documentView) {
-    history.replaceState({}, "", `?view=${documentView}`);
-  }
-  try {
-    const app = document.createElement("openclaw-app") as unknown as {
-      runtime: Pick<ApplicationRuntime, "context" | "documentMode">;
-      render: () => { strings: readonly string[] };
-      synchronizeGateway: (gateway: ApplicationGateway) => void;
-    };
-    app.runtime = {
-      documentMode: null,
-      context: {
-        gateway,
-        basePath: "",
-        agentSelection: { state: { selectedId: null } },
-        config: { current: { terminalEnabled: false } },
-        theme: { resolvedMode: "dark" },
-      } as unknown as ApplicationContext,
-    };
-    app.synchronizeGateway(gateway);
-    const container = document.createElement("div");
-    render(app.render(), container);
-    return container.innerHTML;
-  } finally {
-    history.replaceState({}, "", originalUrl);
-  }
+  const surface = createGatewaySurface(
+    gateway,
+    documentView ? `/focus/${documentView}` : undefined,
+  );
+  surface.draw();
+  return surface.container.innerHTML;
 }
 
 afterEach(() => {
@@ -132,6 +148,54 @@ afterEach(() => {
 });
 
 describe("Control UI Gateway target lineage", () => {
+  it.each([
+    { pathname: "/focus/terminal", phase: "connecting" },
+    { pathname: "/focus/desktop", phase: "connecting" },
+    { pathname: "/focus/dashboard/main", phase: "connecting" },
+    { pathname: "/settings/connection", phase: "connecting" },
+    { pathname: "/settings/connection", phase: "stopped" },
+    { pathname: "/settings/connection", phase: "connected" },
+    { pathname: "/approve/pending", phase: "connected" },
+    { pathname: "/question/pending", phase: "connected" },
+  ])("keeps Gateway confirmation actionable at $pathname while $phase", ({ pathname, phase }) => {
+    const { gateway, clients } = createGatewayHarness();
+    gateway.start();
+    if (phase === "connected") {
+      clients[0]!.opts.onHello?.(HELLO);
+    } else if (phase === "stopped") {
+      clients[0]!.opts.onClose?.({ code: 1006, reason: "login required", willRetry: false });
+    }
+    const { app, container, draw } = createGatewaySurface(gateway, pathname);
+    try {
+      for (const action of ["onConfirm", "onCancel"] as const) {
+        app.pendingGatewayUrl = "wss://pending-gateway.example";
+        draw();
+        const confirmations = container.querySelectorAll("openclaw-gateway-url-confirmation");
+        expect(confirmations).toHaveLength(1);
+        const confirmation = confirmations[0] as HTMLElement & {
+          props: { pendingGatewayUrl: string; onConfirm(): void; onCancel(): void };
+        };
+        expect(confirmation.closest("openclaw-tooltip-provider")).not.toBeNull();
+        expect(confirmation.props.pendingGatewayUrl).toBe(app.pendingGatewayUrl);
+        if (pathname.startsWith("/approve/")) {
+          expect(container.querySelector("openclaw-approval-page")).toBeNull();
+        }
+        confirmation.props[action]();
+        draw();
+        expect(container.querySelector("openclaw-gateway-url-confirmation")).toBeNull();
+        expect(app.pendingGatewayUrl).toBeNull();
+      }
+      expect(app.runtime.confirmPendingGatewayConnection).toHaveBeenCalledOnce();
+      expect(app.runtime.cancelPendingGatewayConnection).toHaveBeenCalledOnce();
+      if (pathname.startsWith("/approve/")) {
+        expect(container.querySelector("openclaw-approval-page")).not.toBeNull();
+      }
+    } finally {
+      render(null, container);
+      gateway.stop();
+    }
+  });
+
   it.each(
     [false, true].flatMap((incognito) =>
       ["synthetic-recovery-a", "synthetic-recovery-b"].map((nextRecovery) => ({

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -49,6 +49,7 @@ import { renderApplicationShell, type ShellViewHost } from "./app-shell-view.ts"
 import type { ApplicationRuntime } from "./bootstrap.ts";
 import type { ApplicationContext, ApplicationNavigationOptions } from "./context.ts";
 import { syncControlUiSystemChrome } from "./control-ui-presentation.ts";
+import { createGatewayControlUiReloadOptions } from "./gateway-control-ui-reload.ts";
 import {
   BROWSER_PANEL_ELEMENT,
   COMMAND_PALETTE_ELEMENT,
@@ -582,11 +583,19 @@ class OpenClawShell
   readonly handleWindowResize = this.shellChrome.handleWindowResize;
   readonly handleDocumentKeydown = this.shellChrome.handleDocumentKeydown;
   readonly openPalette = this.shellChrome.openPalette;
-  readonly refreshControlUi = (): Promise<boolean> =>
-    retryStaleChunkReloadWhenReachable({
+  readonly refreshControlUi = (): Promise<boolean> => {
+    const context = this.context;
+    if (!context) {
+      return Promise.resolve(false);
+    }
+    return retryStaleChunkReloadWhenReachable({
       timeoutMs: 0,
-      canReload: () => this.context?.overlays.snapshot.controlUiRefreshRequired === true,
+      ...createGatewayControlUiReloadOptions(
+        context.gateway,
+        () => this.context === context && context.overlays.snapshot.controlUiRefreshRequired,
+      ),
     });
+  };
   readonly handleShellNavDrawerToggle = this.shellChrome.handleShellNavDrawerToggle;
   readonly openApprovals = this.shellChrome.openApprovals;
   readonly handleCommandPaletteSlashCommand = this.shellChrome.handleCommandPaletteSlashCommand;

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -408,11 +408,9 @@ export class OpenClawApp extends OpenClawLightDomElement {
         <section class="card board-document__state">
           <h2>${t("chat.sessionRoute.chooseTitle")}</h2>
           <p>
-            ${
-              route.data.candidates.length > 1
-                ? t("chat.sessionRoute.multipleMatches", { shortId: route.data.shortId })
-                : t("chat.sessionRoute.additionalMatches")
-            }
+            ${route.data.candidates.length > 1
+              ? t("chat.sessionRoute.multipleMatches", { shortId: route.data.shortId })
+              : t("chat.sessionRoute.additionalMatches")}
           </p>
           ${route.data.candidates.map(
             (candidate) => html`<p>
@@ -420,11 +418,9 @@ export class OpenClawApp extends OpenClawLightDomElement {
               <small>${candidate.agentId} · ${candidate.idPrefix}</small>
             </p>`,
           )}
-          ${
-            route.data.truncated
-              ? html`<p><small>${t("chat.sessionRoute.additionalMatches")}</small></p>`
-              : nothing
-          }
+          ${route.data.truncated
+            ? html`<p><small>${t("chat.sessionRoute.additionalMatches")}</small></p>`
+            : nothing}
           ${this.renderFocusEscape(t("dashboardDocument.close"))}
         </section>
       </main>`;
@@ -433,15 +429,13 @@ export class OpenClawApp extends OpenClawLightDomElement {
       <openclaw-board-document
         .gatewaySnapshot=${gatewaySnapshot}
         .sessionKey=${route.data.sessionKey}
-        .onDocumentClose=${
-          isNativeWebChromeHost() ? null : () => this.closeDocument(this.context?.basePath ?? "")
-        }
+        .onDocumentClose=${isNativeWebChromeHost()
+          ? null
+          : () => this.closeDocument(this.context?.basePath ?? "")}
       ></openclaw-board-document>
-      ${
-        !gatewayConnected && gatewaySnapshot.lastError === null
-          ? renderConnectingSplash(gatewayStartupStatus)
-          : nothing
-      }
+      ${!gatewayConnected && gatewaySnapshot.lastError === null
+        ? renderConnectingSplash(gatewayStartupStatus)
+        : nothing}
       ${gatewayConnected ? this.renderLazyDocumentState(DASHBOARD_DOCUMENT_ELEMENT) : nothing}
     `;
   }
@@ -452,10 +446,6 @@ export class OpenClawApp extends OpenClawLightDomElement {
     if (!context || !runtime) {
       return html`<main class="app-shell app-shell--booting" aria-busy="true"></main>`;
     }
-    const gatewaySnapshot = context.gateway.snapshot;
-    const gatewayConnected = gatewaySnapshot.phase === "connected";
-    const gatewayStartupStatus =
-      gatewaySnapshot.phase === "starting" ? t("common.gatewayStarting") : undefined;
     const gatewayUrlConfirmation = this.pendingGatewayUrl
       ? html`
           <openclaw-gateway-url-confirmation
@@ -473,6 +463,16 @@ export class OpenClawApp extends OpenClawLightDomElement {
           ></openclaw-gateway-url-confirmation>
         `
       : nothing;
+    return html`<openclaw-tooltip-provider>
+      ${this.renderDocument(context, runtime)} ${gatewayUrlConfirmation}
+    </openclaw-tooltip-provider>`;
+  }
+
+  private renderDocument(context: ApplicationContext<RouteId>, runtime: ApplicationRuntime) {
+    const gatewaySnapshot = context.gateway.snapshot;
+    const gatewayConnected = gatewaySnapshot.phase === "connected";
+    const gatewayStartupStatus =
+      gatewaySnapshot.phase === "starting" ? t("common.gatewayStarting") : undefined;
     if (runtime.focusLocation?.status === "unsupported") {
       return html`<main class="connect-splash" role="alert">
         <div class="stack">
@@ -501,22 +501,18 @@ export class OpenClawApp extends OpenClawLightDomElement {
           .themeMode=${context.theme.resolvedMode}
           fullscreen
         ></openclaw-terminal-panel>
-        ${
-          !gatewayConnected && gatewaySnapshot.lastError === null
-            ? renderConnectingSplash(gatewayStartupStatus)
-            : nothing
-        }
+        ${!gatewayConnected && gatewaySnapshot.lastError === null
+          ? renderConnectingSplash(gatewayStartupStatus)
+          : nothing}
         ${terminalAvailable ? this.renderLazyDocumentState(TERMINAL_PANEL_ELEMENT) : nothing}
-        ${
-          !terminalAvailable && (gatewayConnected || gatewaySnapshot.lastError)
-            ? html`<div class="terminal-view-unavailable">
-                <div class="stack">
-                  <span>${t("terminal.unavailable")}</span>
-                  ${this.renderFocusEscape(t("common.back"))}
-                </div>
-              </div>`
-            : nothing
-        }
+        ${!terminalAvailable && (gatewayConnected || gatewaySnapshot.lastError)
+          ? html`<div class="terminal-view-unavailable">
+              <div class="stack">
+                <span>${t("terminal.unavailable")}</span>
+                ${this.renderFocusEscape(t("common.back"))}
+              </div>
+            </div>`
+          : nothing}
       `;
     }
     // Desktop documents share the panel's connection owner but none of its
@@ -536,22 +532,18 @@ export class OpenClawApp extends OpenClawLightDomElement {
           .documentControl=${focusTarget.control}
           .onDocumentClose=${() => this.closeDocument(context.basePath)}
         ></openclaw-desktop-panel>
-        ${
-          !gatewayConnected && gatewaySnapshot.lastError === null
-            ? renderConnectingSplash(gatewayStartupStatus)
-            : nothing
-        }
+        ${!gatewayConnected && gatewaySnapshot.lastError === null
+          ? renderConnectingSplash(gatewayStartupStatus)
+          : nothing}
         ${desktopAvailable ? this.renderLazyDocumentState(DESKTOP_PANEL_ELEMENT) : nothing}
-        ${
-          !desktopAvailable && (gatewayConnected || gatewaySnapshot.lastError)
-            ? html`<div class="desktop-view-unavailable">
-                <div class="stack">
-                  <span>${t("desktop.unavailable")}</span>
-                  ${this.renderFocusEscape(t("common.back"))}
-                </div>
-              </div>`
-            : nothing
-        }
+        ${!desktopAvailable && (gatewayConnected || gatewaySnapshot.lastError)
+          ? html`<div class="desktop-view-unavailable">
+              <div class="stack">
+                <span>${t("desktop.unavailable")}</span>
+                ${this.renderFocusEscape(t("common.back"))}
+              </div>
+            </div>`
+          : nothing}
       `;
     }
     if (focusTarget?.kind === "dashboard") {
@@ -567,11 +559,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
       (gatewaySnapshot.phase === "starting" ||
         (gatewaySnapshot.phase === "connecting" && !this.loginGatePinned));
     if (initialConnectPending) {
-      return html`
-        <openclaw-tooltip-provider>
-          ${renderConnectingSplash(gatewayStartupStatus)} ${gatewayUrlConfirmation}
-        </openclaw-tooltip-provider>
-      `;
+      return renderConnectingSplash(gatewayStartupStatus);
     }
     const shellOwnsRecovery =
       gatewaySnapshot.phase === "reconnecting" || gatewaySnapshot.phase === "reload-required";
@@ -583,100 +571,81 @@ export class OpenClawApp extends OpenClawLightDomElement {
       if (!loadState) {
         this.loginGateLoader.preload(LOGIN_GATE_ELEMENT, { reportError: true });
       }
-      return html`<openclaw-tooltip-provider>
-        ${
-          loadState?.status === "error"
-            ? renderLazyViewError({
-                error: loadState.error,
-                stale: loadState.stale,
-                onRetry: () => this.loginGateLoader.retry(),
-              })
-            : renderConnectingSplash()
-        }
-        ${gatewayUrlConfirmation}
-      </openclaw-tooltip-provider>`;
+      return loadState?.status === "error"
+        ? renderLazyViewError({
+            error: loadState.error,
+            stale: loadState.stale,
+            onRetry: () => this.loginGateLoader.retry(),
+          })
+        : renderConnectingSplash();
     }
     if (showLoginGate) {
       return html`
-        <openclaw-tooltip-provider>
-          <openclaw-login-gate
-            .props=${{
-              resourceBasePath: context.resourceBasePath,
-              connected: gatewayConnected,
-              lastError: gatewaySnapshot.lastError,
-              lastErrorCode: gatewaySnapshot.lastErrorCode,
-              lastErrorAuthReason: gatewaySnapshot.lastErrorAuthReason,
-              hasToken: Boolean(this.loginToken.trim()),
-              hasPassword: Boolean(this.loginPassword.trim()),
-              gatewayUrl: this.loginGatewayUrl,
-              token: this.loginToken,
-              password: this.loginPassword,
-              showGatewayToken: this.loginShowGatewayToken,
-              showGatewayPassword: this.loginShowGatewayPassword,
-              onGatewayUrlChange: (value: string) => {
-                this.updateLoginGatewayUrl(value);
-              },
-              onTokenChange: (value: string) => {
-                this.loginToken = value;
-              },
-              onPasswordChange: (value: string) => {
-                this.loginPassword = value;
-              },
-              onToggleGatewayToken: () => {
-                this.loginShowGatewayToken = !this.loginShowGatewayToken;
-              },
-              onToggleGatewayPassword: () => {
-                this.loginShowGatewayPassword = !this.loginShowGatewayPassword;
-              },
-              onConnect: () => {
-                this.loginGatePinned = true;
-                context.gateway.connect({
-                  gatewayUrl: this.loginGatewayUrl,
-                  token: this.loginToken,
-                  password: this.loginPassword,
-                });
-              },
-            }}
-          ></openclaw-login-gate>
-          ${gatewayUrlConfirmation}
-        </openclaw-tooltip-provider>
+        <openclaw-login-gate
+          .props=${{
+            resourceBasePath: context.resourceBasePath,
+            connected: gatewayConnected,
+            lastError: gatewaySnapshot.lastError,
+            lastErrorCode: gatewaySnapshot.lastErrorCode,
+            lastErrorAuthReason: gatewaySnapshot.lastErrorAuthReason,
+            hasToken: Boolean(this.loginToken.trim()),
+            hasPassword: Boolean(this.loginPassword.trim()),
+            gatewayUrl: this.loginGatewayUrl,
+            token: this.loginToken,
+            password: this.loginPassword,
+            showGatewayToken: this.loginShowGatewayToken,
+            showGatewayPassword: this.loginShowGatewayPassword,
+            onGatewayUrlChange: (value: string) => {
+              this.updateLoginGatewayUrl(value);
+            },
+            onTokenChange: (value: string) => {
+              this.loginToken = value;
+            },
+            onPasswordChange: (value: string) => {
+              this.loginPassword = value;
+            },
+            onToggleGatewayToken: () => {
+              this.loginShowGatewayToken = !this.loginShowGatewayToken;
+            },
+            onToggleGatewayPassword: () => {
+              this.loginShowGatewayPassword = !this.loginShowGatewayPassword;
+            },
+            onConnect: () => {
+              this.loginGatePinned = true;
+              context.gateway.connect({
+                gatewayUrl: this.loginGatewayUrl,
+                token: this.loginToken,
+                password: this.loginPassword,
+              });
+            },
+          }}
+        ></openclaw-login-gate>
       `;
     }
     if (runtime.documentMode?.kind === "approval") {
-      return html`
-        <openclaw-tooltip-provider>
-          ${this.pendingGatewayUrl ? gatewayUrlConfirmation : this.renderApprovalDocument(runtime)}
-        </openclaw-tooltip-provider>
-      `;
+      return this.pendingGatewayUrl ? nothing : this.renderApprovalDocument(runtime);
     }
     if (runtime.documentMode?.kind === "question") {
-      return html`
-        <openclaw-tooltip-provider>
-          ${gatewayUrlConfirmation} ${this.renderQuestionDocument(runtime)}
-        </openclaw-tooltip-provider>
-      `;
+      return this.renderQuestionDocument(runtime);
     }
     return html`
-      <openclaw-tooltip-provider>
-        <openclaw-github-link-hovercard-provider
+      <openclaw-github-link-hovercard-provider
+        .client=${gatewaySnapshot.client}
+        .agentId=${context.agentSelection.state.selectedId ??
+        gatewaySnapshot.assistantAgentId ??
+        undefined}
+      >
+        <openclaw-session-progress-hovercard-provider
           .client=${gatewaySnapshot.client}
-          .agentId=${
-            context.agentSelection.state.selectedId ?? gatewaySnapshot.assistantAgentId ?? undefined
-          }
+          .context=${context}
+          .gateway=${context.gateway}
         >
-          <openclaw-session-progress-hovercard-provider
-            .client=${gatewaySnapshot.client}
-            .context=${context}
-            .gateway=${context.gateway}
-          >
-            ${gatewayUrlConfirmation}
-            <openclaw-app-shell
-              .runtime=${runtime}
-              .onboarding=${this.onboarding}
-            ></openclaw-app-shell>
-          </openclaw-session-progress-hovercard-provider>
-        </openclaw-github-link-hovercard-provider>
-      </openclaw-tooltip-provider>
+          <openclaw-app-shell
+            .runtime=${runtime}
+            .onboarding=${this.onboarding}
+          ></openclaw-app-shell>
+        </openclaw-session-progress-hovercard-provider>
+      </openclaw-github-link-hovercard-provider>
     `;
   }
 }

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -408,9 +408,11 @@ export class OpenClawApp extends OpenClawLightDomElement {
         <section class="card board-document__state">
           <h2>${t("chat.sessionRoute.chooseTitle")}</h2>
           <p>
-            ${route.data.candidates.length > 1
-              ? t("chat.sessionRoute.multipleMatches", { shortId: route.data.shortId })
-              : t("chat.sessionRoute.additionalMatches")}
+            ${
+              route.data.candidates.length > 1
+                ? t("chat.sessionRoute.multipleMatches", { shortId: route.data.shortId })
+                : t("chat.sessionRoute.additionalMatches")
+            }
           </p>
           ${route.data.candidates.map(
             (candidate) => html`<p>
@@ -418,9 +420,11 @@ export class OpenClawApp extends OpenClawLightDomElement {
               <small>${candidate.agentId} · ${candidate.idPrefix}</small>
             </p>`,
           )}
-          ${route.data.truncated
-            ? html`<p><small>${t("chat.sessionRoute.additionalMatches")}</small></p>`
-            : nothing}
+          ${
+            route.data.truncated
+              ? html`<p><small>${t("chat.sessionRoute.additionalMatches")}</small></p>`
+              : nothing
+          }
           ${this.renderFocusEscape(t("dashboardDocument.close"))}
         </section>
       </main>`;
@@ -429,13 +433,15 @@ export class OpenClawApp extends OpenClawLightDomElement {
       <openclaw-board-document
         .gatewaySnapshot=${gatewaySnapshot}
         .sessionKey=${route.data.sessionKey}
-        .onDocumentClose=${isNativeWebChromeHost()
-          ? null
-          : () => this.closeDocument(this.context?.basePath ?? "")}
+        .onDocumentClose=${
+          isNativeWebChromeHost() ? null : () => this.closeDocument(this.context?.basePath ?? "")
+        }
       ></openclaw-board-document>
-      ${!gatewayConnected && gatewaySnapshot.lastError === null
-        ? renderConnectingSplash(gatewayStartupStatus)
-        : nothing}
+      ${
+        !gatewayConnected && gatewaySnapshot.lastError === null
+          ? renderConnectingSplash(gatewayStartupStatus)
+          : nothing
+      }
       ${gatewayConnected ? this.renderLazyDocumentState(DASHBOARD_DOCUMENT_ELEMENT) : nothing}
     `;
   }
@@ -501,18 +507,22 @@ export class OpenClawApp extends OpenClawLightDomElement {
           .themeMode=${context.theme.resolvedMode}
           fullscreen
         ></openclaw-terminal-panel>
-        ${!gatewayConnected && gatewaySnapshot.lastError === null
-          ? renderConnectingSplash(gatewayStartupStatus)
-          : nothing}
+        ${
+          !gatewayConnected && gatewaySnapshot.lastError === null
+            ? renderConnectingSplash(gatewayStartupStatus)
+            : nothing
+        }
         ${terminalAvailable ? this.renderLazyDocumentState(TERMINAL_PANEL_ELEMENT) : nothing}
-        ${!terminalAvailable && (gatewayConnected || gatewaySnapshot.lastError)
-          ? html`<div class="terminal-view-unavailable">
-              <div class="stack">
-                <span>${t("terminal.unavailable")}</span>
-                ${this.renderFocusEscape(t("common.back"))}
-              </div>
-            </div>`
-          : nothing}
+        ${
+          !terminalAvailable && (gatewayConnected || gatewaySnapshot.lastError)
+            ? html`<div class="terminal-view-unavailable">
+                <div class="stack">
+                  <span>${t("terminal.unavailable")}</span>
+                  ${this.renderFocusEscape(t("common.back"))}
+                </div>
+              </div>`
+            : nothing
+        }
       `;
     }
     // Desktop documents share the panel's connection owner but none of its
@@ -532,18 +542,22 @@ export class OpenClawApp extends OpenClawLightDomElement {
           .documentControl=${focusTarget.control}
           .onDocumentClose=${() => this.closeDocument(context.basePath)}
         ></openclaw-desktop-panel>
-        ${!gatewayConnected && gatewaySnapshot.lastError === null
-          ? renderConnectingSplash(gatewayStartupStatus)
-          : nothing}
+        ${
+          !gatewayConnected && gatewaySnapshot.lastError === null
+            ? renderConnectingSplash(gatewayStartupStatus)
+            : nothing
+        }
         ${desktopAvailable ? this.renderLazyDocumentState(DESKTOP_PANEL_ELEMENT) : nothing}
-        ${!desktopAvailable && (gatewayConnected || gatewaySnapshot.lastError)
-          ? html`<div class="desktop-view-unavailable">
-              <div class="stack">
-                <span>${t("desktop.unavailable")}</span>
-                ${this.renderFocusEscape(t("common.back"))}
-              </div>
-            </div>`
-          : nothing}
+        ${
+          !desktopAvailable && (gatewayConnected || gatewaySnapshot.lastError)
+            ? html`<div class="desktop-view-unavailable">
+                <div class="stack">
+                  <span>${t("desktop.unavailable")}</span>
+                  ${this.renderFocusEscape(t("common.back"))}
+                </div>
+              </div>`
+            : nothing
+        }
       `;
     }
     if (focusTarget?.kind === "dashboard") {
@@ -631,9 +645,9 @@ export class OpenClawApp extends OpenClawLightDomElement {
     return html`
       <openclaw-github-link-hovercard-provider
         .client=${gatewaySnapshot.client}
-        .agentId=${context.agentSelection.state.selectedId ??
-        gatewaySnapshot.assistantAgentId ??
-        undefined}
+        .agentId=${
+          context.agentSelection.state.selectedId ?? gatewaySnapshot.assistantAgentId ?? undefined
+        }
       >
         <openclaw-session-progress-hovercard-provider
           .client=${gatewaySnapshot.client}

--- a/ui/src/app/bootstrap.gateway-credentials.test.ts
+++ b/ui/src/app/bootstrap.gateway-credentials.test.ts
@@ -1,6 +1,8 @@
 /* @vitest-environment jsdom */
 /* @vitest-environment-options {"url":"https://gateway.example/"} */
 
+import { webcrypto } from "node:crypto";
+import type { ConnectParams } from "@openclaw/gateway-client/browser";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
@@ -8,7 +10,8 @@ import { createStorageMock } from "../test-helpers/storage.ts";
 import { bootstrapApplication, type ApplicationRuntime } from "./bootstrap.ts";
 import { createGatewayStoreTestStore } from "./gateway-store.test-support.ts";
 import * as gatewayStore from "./gateway-store.ts";
-import { loadSettings, persistSessionToken } from "./settings.ts";
+import { loadSettings, loadUiPreferences, patchSettings, persistSessionToken } from "./settings.ts";
+import * as staleChunkReload from "./stale-chunk-reload.ts";
 
 const NATIVE_AUTH_KEY = "__OPENCLAW_NATIVE_CONTROL_AUTH__";
 const originalUrl = window.location.href;
@@ -33,6 +36,142 @@ afterEach(() => {
 });
 
 describe("pending Gateway credentials", () => {
+  it.each([
+    { decision: "confirm", queryGatewayUrl: "" },
+    { decision: "cancel", queryGatewayUrl: "" },
+    { decision: "confirm", queryGatewayUrl: "wss://query-gateway.example" },
+  ] as const)(
+    "binds a reloaded bootstrap after another tab selects a remote ($decision, query: $queryGatewayUrl)",
+    async ({ decision, queryGatewayUrl }) => {
+      const sockets: RecordingWebSocket[] = [];
+      class RecordingWebSocket extends EventTarget {
+        static OPEN = 1;
+        readyState = 0;
+        sent: Array<{ id: string; method: string; params: ConnectParams }> = [];
+
+        constructor(readonly url: string) {
+          super();
+          sockets.push(this);
+        }
+
+        send(data: string) {
+          this.sent.push(JSON.parse(data));
+        }
+
+        close(code = 1000, reason = "") {
+          this.readyState = 3;
+          this.dispatchEvent(new CloseEvent("close", { code, reason }));
+        }
+
+        deliver(frame: unknown) {
+          this.dispatchEvent(new MessageEvent("message", { data: JSON.stringify(frame) }));
+        }
+
+        async connectFrame() {
+          this.readyState = RecordingWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+          this.deliver({
+            type: "event",
+            event: "connect.challenge",
+            payload: { nonce: "synthetic-challenge", ts: Date.now() },
+          });
+          await vi.waitFor(() => expect(this.sent).toHaveLength(1));
+          expect(this.sent[0]?.method).toBe("connect");
+          return this.sent[0]!;
+        }
+      }
+      vi.stubGlobal("WebSocket", RecordingWebSocket);
+      vi.stubGlobal("crypto", webcrypto);
+      const bootstrapToken = "synthetic-bound-bootstrap";
+      const originalGatewayUrl = "wss://gateway.example";
+      const remoteGatewayUrl = "wss://other-gateway.example/openclaw";
+      window.history.replaceState(
+        {},
+        "",
+        `/settings/appearance#bootstrapToken=${bootstrapToken}&bootstrapProfile=owner`,
+      );
+      const probe = createDeferred<Response>();
+      const fetchMock = vi.fn<typeof fetch>(() => probe.promise);
+      vi.stubGlobal("fetch", fetchMock);
+      const reload = vi
+        .spyOn(staleChunkReload, "reloadControlUiDocument")
+        .mockImplementation(() => {});
+      const startDocument = async () => {
+        runtime = bootstrapApplication();
+        vi.spyOn(runtime.router, "start").mockResolvedValue(undefined);
+        await runtime.start();
+        return sockets.at(-1)!;
+      };
+      const originalSocket = await startDocument();
+      const firstConnect = await originalSocket.connectFrame();
+      expect(originalSocket.url).toBe(originalGatewayUrl);
+      expect(firstConnect.params.auth?.bootstrapToken).toBe(bootstrapToken);
+      if (queryGatewayUrl) {
+        window.history.replaceState(
+          {},
+          "",
+          `/settings/appearance?gatewayUrl=${encodeURIComponent(queryGatewayUrl)}`,
+        );
+      }
+      originalSocket.deliver({
+        type: "res",
+        id: firstConnect.id,
+        ok: false,
+        error: {
+          code: "UNAVAILABLE",
+          message: "protocol mismatch: Control UI updated; reload this page to continue",
+          details: {
+            code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
+            gatewayBuildId: "replacement-build",
+            reloadRequired: true,
+          },
+        },
+      });
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+
+      // Another tab's selection persists without retargeting this mounted connection.
+      patchSettings({ gatewayUrl: remoteGatewayUrl });
+      expect(loadUiPreferences().gatewayUrl).toBe(remoteGatewayUrl);
+      expect(runtime!.context.gateway.connection.gatewayUrl).toBe(originalGatewayUrl);
+      probe.resolve(new Response(null, { status: 200 }));
+      await vi.waitFor(() => expect(reload).toHaveBeenCalledOnce());
+      const destination = reload.mock.calls[0]![0]!;
+      runtime!.stop();
+      window.history.replaceState({}, "", destination);
+
+      const remoteSocket = await startDocument();
+      const remoteConnect = await remoteSocket.connectFrame();
+      expect(remoteSocket.url).toBe(remoteGatewayUrl);
+      expect(remoteConnect.params.auth?.bootstrapToken).toBeUndefined();
+      expect(runtime!.pendingGatewayConnection?.gatewayUrl).toBe(originalGatewayUrl);
+      expect(loadUiPreferences().gatewayUrl).toBe(remoteGatewayUrl);
+      expect(window.location.hash).toBe("");
+
+      if (decision === "confirm") {
+        runtime!.confirmPendingGatewayConnection();
+        const confirmedSocket = sockets.at(-1)!;
+        const confirmedConnect = await confirmedSocket.connectFrame();
+        expect(confirmedSocket.url).toBe(originalGatewayUrl);
+        expect(confirmedConnect.params.auth?.bootstrapToken).toBe(bootstrapToken);
+        expect(confirmedConnect.params.scopes).toContain("operator.admin");
+        expect(loadUiPreferences().gatewayUrl).toBe(originalGatewayUrl);
+      } else {
+        runtime!.cancelPendingGatewayConnection();
+        runtime!.confirmPendingGatewayConnection();
+        expect(sockets).toHaveLength(2);
+        expect(remoteSocket.sent).toEqual([remoteConnect]);
+        expect(runtime!.context.gateway.connection.gatewayUrl).toBe(remoteGatewayUrl);
+        expect(loadUiPreferences().gatewayUrl).toBe(remoteGatewayUrl);
+      }
+      expect(runtime!.pendingGatewayConnection).toBeNull();
+      for (const storage of [localStorage, sessionStorage]) {
+        for (let index = 0; index < storage.length; index++) {
+          expect(storage.getItem(storage.key(index)!)).not.toContain(bootstrapToken);
+        }
+      }
+    },
+  );
+
   it.each([
     {
       name: "an initial missing token",

--- a/ui/src/app/gateway-control-ui-reload.ts
+++ b/ui/src/app/gateway-control-ui-reload.ts
@@ -23,9 +23,11 @@ export function createGatewayControlUiReloadOptions(
     reload: () => {
       const url = new URL(window.location.href);
       if (connection.bootstrapToken) {
-        // No hello delivered a device grant yet. Reuse only this browser's
-        // pending handoff; startup strips the fragment again after reload.
+        // Another tab can change the saved Gateway during the probe. Keep this
+        // pending handoff bound to its destination through startup confirmation.
+        url.searchParams.delete("gatewayUrl");
         const fragment = new URLSearchParams(url.hash.slice(1));
+        fragment.set("gatewayUrl", connection.gatewayUrl);
         fragment.set("bootstrapToken", connection.bootstrapToken);
         if (connection.bootstrapProfile) {
           fragment.set(CONTROL_UI_BOOTSTRAP_PROFILE_FRAGMENT_PARAM, connection.bootstrapProfile);

--- a/ui/src/app/gateway-control-ui-reload.ts
+++ b/ui/src/app/gateway-control-ui-reload.ts
@@ -1,0 +1,46 @@
+import { CONTROL_UI_BOOTSTRAP_PROFILE_FRAGMENT_PARAM } from "../../../src/gateway/control-ui-bootstrap-contract.js";
+import type { ApplicationGateway } from "./gateway.ts";
+import { reloadControlUiDocument } from "./stale-chunk-reload.ts";
+
+export function createGatewayControlUiReloadOptions(
+  gateway: ApplicationGateway,
+  canReload?: () => boolean,
+) {
+  const {
+    connection,
+    snapshot: { client },
+  } = gateway;
+  return {
+    // Snapshot observers can replace the original callback's client before scheduling;
+    // document probes can then outlive the connection captured here as well.
+    canReload: () =>
+      canReload?.() !== false &&
+      client !== null &&
+      gateway.snapshot.client === client &&
+      gateway.connection === connection &&
+      // Ordinary refreshes carry no credential into the serving document.
+      (!connection.bootstrapToken || isSameOriginGateway(connection.gatewayUrl)),
+    reload: () => {
+      const url = new URL(window.location.href);
+      if (connection.bootstrapToken) {
+        // No hello delivered a device grant yet. Reuse only this browser's
+        // pending handoff; startup strips the fragment again after reload.
+        const fragment = new URLSearchParams(url.hash.slice(1));
+        fragment.set("bootstrapToken", connection.bootstrapToken);
+        if (connection.bootstrapProfile) {
+          fragment.set(CONTROL_UI_BOOTSTRAP_PROFILE_FRAGMENT_PARAM, connection.bootstrapProfile);
+        }
+        url.hash = fragment.toString();
+      }
+      reloadControlUiDocument(url);
+    },
+  };
+}
+
+export function isSameOriginGateway(gatewayUrl: string): boolean {
+  try {
+    return new URL(gatewayUrl.replace(/^ws/u, "http")).origin === globalThis.location?.origin;
+  } catch {
+    return false;
+  }
+}

--- a/ui/src/app/gateway-store.auth.test.ts
+++ b/ui/src/app/gateway-store.auth.test.ts
@@ -1,12 +1,26 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar-context.ts";
 import {
   createGatewayStoreTestStore as createStore,
   GATEWAY_STORE_TEST_HELLO as HELLO,
   stubGatewayStoreTestGlobals,
 } from "./gateway-store.test-support.ts";
+import { loadSettings } from "./settings.ts";
+import { resolveApplicationStartupSettings } from "./startup-settings.ts";
+
+function stubBuildReloadDocument(href = "http://127.0.0.1:18789/chat/main") {
+  const replace = vi.fn<(url: string) => void>();
+  const location = Object.assign(new URL(href), { replace });
+  vi.stubGlobal("location", location);
+  vi.stubGlobal("window", { location });
+  const probe = createDeferred<Response>();
+  const fetchMock = vi.fn<typeof fetch>(() => probe.promise);
+  vi.stubGlobal("fetch", fetchMock);
+  return { replace, probe, fetchMock };
+}
 
 describe("createApplicationGateway authentication diagnostics", () => {
   let store: ReturnType<typeof createStore>;
@@ -22,6 +36,128 @@ describe("createApplicationGateway authentication diagnostics", () => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
+
+  function rejectStaleBuild() {
+    store.current().opts.onClose?.({
+      code: 1008,
+      reason: "protocol mismatch: Control UI updated; reload this page to continue",
+      error: {
+        code: "UNAVAILABLE",
+        message: "protocol mismatch: Control UI updated; reload this page to continue",
+        details: {
+          code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
+          gatewayBuildId: "replacement-build",
+          reloadRequired: true,
+        },
+      },
+      willRetry: false,
+    });
+  }
+
+  it("preserves an unfinished browser handoff across a build recovery reload", async () => {
+    const bootstrapToken = "synthetic-owner-bootstrap";
+    const initialUrl = new URL(
+      `http://127.0.0.1:18789/settings/appearance?keep=yes#tab=keep&bootstrapToken=${bootstrapToken}&bootstrapProfile=owner`,
+    );
+    const startup = resolveApplicationStartupSettings(loadSettings(), initialUrl);
+    expect(startup.location.hash).toBe("#tab=keep");
+    const { pathname, search, hash } = startup.location;
+    const { replace, probe, fetchMock } = stubBuildReloadDocument(
+      new URL(`${pathname}${search}${hash}`, initialUrl).href,
+    );
+    store.gateway.connect({
+      bootstrapToken: startup.pendingBootstrapToken ?? "",
+      bootstrapProfile: startup.pendingBootstrapProfile ?? undefined,
+    });
+    rejectStaleBuild();
+    expect(store.gateway.snapshot.phase).toBe("reload-required");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0]?.[1]?.method).toBe("HEAD");
+    probe.resolve(new Response(null, { status: 200 }));
+    await vi.waitFor(() => expect(replace).toHaveBeenCalledOnce());
+    const destination = new URL(replace.mock.calls[0]![0]);
+    const resumed = resolveApplicationStartupSettings(loadSettings(), destination);
+    expect(resumed.pendingBootstrapToken).toBe(bootstrapToken);
+    expect(resumed.pendingBootstrapProfile).toBe("owner");
+    expect(resumed.location.pathname).toBe("/settings/appearance");
+    expect(new URLSearchParams(resumed.location.search).get("keep")).toBe("yes");
+    expect(resumed.location.hash).toBe("#tab=keep");
+    expect(resumed.settings.token).toBe("");
+    for (const storage of [localStorage, sessionStorage]) {
+      for (let index = 0; index < storage.length; index++) {
+        expect(storage.getItem(storage.key(index)!)).not.toContain(bootstrapToken);
+      }
+    }
+  });
+
+  it("lets the replacement handoff join the pending document probe for the same build", async () => {
+    const { replace, probe, fetchMock } = stubBuildReloadDocument();
+    const { gateway } = store;
+    gateway.connect({ bootstrapToken: "retired-bootstrap" });
+    rejectStaleBuild();
+    gateway.connect({ bootstrapToken: "replacement-bootstrap", bootstrapProfile: "owner" });
+    rejectStaleBuild();
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    probe.resolve(new Response(null, { status: 200 }));
+    await vi.waitFor(() => expect(replace).toHaveBeenCalledOnce());
+    const resumed = resolveApplicationStartupSettings(
+      loadSettings(),
+      new URL(replace.mock.calls[0]![0]),
+    );
+    expect(resumed.pendingBootstrapToken).toBe("replacement-bootstrap");
+    expect(resumed.pendingBootstrapProfile).toBe("owner");
+  });
+
+  it.each(["stop", "reconnect", "credential", "retarget"] as const)(
+    "does not finish retired handoff recovery after %s during the document probe",
+    async (action) => {
+      const { replace, probe, fetchMock } = stubBuildReloadDocument();
+      const { gateway } = store;
+      gateway.connect({ bootstrapToken: "synthetic-owner-bootstrap", bootstrapProfile: "owner" });
+      rejectStaleBuild();
+      expect(fetchMock).toHaveBeenCalledOnce();
+
+      if (action === "stop") {
+        gateway.stop();
+      } else if (action === "reconnect") {
+        gateway.connect();
+      } else if (action === "credential") {
+        gateway.connect({ bootstrapToken: "replacement-bootstrap" });
+      } else {
+        gateway.connect({ gatewayUrl: "wss://other-gateway.example" });
+      }
+      probe.resolve(new Response(null, { status: 200 }));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(replace).not.toHaveBeenCalled();
+      expect(sessionStorage.getItem("openclaw.controlUi.staleChunkReloadBuildId")).toBeNull();
+    },
+  );
+
+  it.each(["", "synthetic-remote-bootstrap"])(
+    "does not automatically reload for a remote Gateway (bootstrap: %s)",
+    async (bootstrapToken) => {
+      const { replace, probe, fetchMock } = stubBuildReloadDocument();
+      store.gateway.connect({
+        gatewayUrl: "wss://other-gateway.example",
+        bootstrapToken,
+        bootstrapProfile: "owner",
+      });
+      rejectStaleBuild();
+      probe.resolve(new Response(null, { status: 200 }));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(replace).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(store.gateway.snapshot.phase).toBe("reload-required");
+    },
+  );
 
   it.each([
     {

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar-context.ts";
 import { resolveAvatar } from "../lib/identity-avatar.ts";
 import {
@@ -10,13 +11,15 @@ import {
   stubGatewayStoreTestGlobals,
 } from "./gateway-store.test-support.ts";
 import { loadSettings } from "./settings.ts";
+import type { scheduleStaleChunkReload } from "./stale-chunk-reload.ts";
 import { readPresenceEntries, resolveCurrentSelfUser } from "./user-profile.ts";
 
 const { scheduleStaleChunkReloadMock } = vi.hoisted(() => ({
-  scheduleStaleChunkReloadMock: vi.fn(async () => true),
+  scheduleStaleChunkReloadMock: vi.fn<typeof scheduleStaleChunkReload>(async () => true),
 }));
 
-vi.mock("./stale-chunk-reload.ts", () => ({
+vi.mock("./stale-chunk-reload.ts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./stale-chunk-reload.ts")>()),
   scheduleStaleChunkReload: scheduleStaleChunkReloadMock,
 }));
 
@@ -106,6 +109,69 @@ describe("createApplicationGateway connection phase", () => {
 
     expect(current().opts).toMatchObject(clientOptions);
   });
+
+  it("retires a completed native handoff while keeping stale hello operations fenced", () => {
+    const { gateway, current } = createStore({
+      clientOptions: { clientName: "openclaw-ios", mode: "ui" },
+    });
+    gateway.connect({ bootstrapToken: "synthetic-native-bootstrap", bootstrapProfile: "owner" });
+
+    current().opts.onHello?.({
+      ...HELLO,
+      server: { version: "2026.7.19", buildId: "replacement-build", connId: "native-conn" },
+      pluginSurfaceUrls: { canvas: "https://canvas.test/__openclaw__/cap/hello" },
+    });
+
+    expect(gateway.snapshot.phase).toBe("reconnecting");
+    expect(gateway.snapshot.canvasPluginSurfaceUrl).toBeNull();
+    expect(current().request).not.toHaveBeenCalled();
+    gateway.connect();
+    expect(current().opts.bootstrapToken).toBeUndefined();
+    expect(current().opts.bootstrapProfile).toBeUndefined();
+    gateway.stop();
+  });
+
+  it.each(["snapshot", "probe"])(
+    "does not reload a native stale hello after its %s replaces the connection",
+    async (stage) => {
+      const actual =
+        await vi.importActual<typeof import("./stale-chunk-reload.ts")>("./stale-chunk-reload.ts");
+      scheduleStaleChunkReloadMock.mockImplementationOnce(actual.scheduleStaleChunkReload);
+      const probe = createDeferred<Response>();
+      const fetchMock = vi.fn<typeof fetch>(() => probe.promise);
+      vi.stubGlobal("fetch", fetchMock);
+      const replace = vi.fn();
+      const location = Object.assign(new URL("http://127.0.0.1:18789/chat/main"), { replace });
+      vi.stubGlobal("window", { location });
+      const { gateway, current } = createStore({
+        clientOptions: { clientName: "openclaw-ios", mode: "ui" },
+      });
+      gateway.connect({ bootstrapToken: "synthetic-native-bootstrap", bootstrapProfile: "owner" });
+      if (stage === "snapshot") {
+        gateway.subscribe((snapshot) => {
+          if (snapshot.phase === "reconnecting") {
+            gateway.connect();
+          }
+        });
+      }
+      current().opts.onHello?.({
+        ...HELLO,
+        server: { version: "2026.7.19", buildId: "replacement-build", connId: "native-conn" },
+      });
+      if (stage === "probe") {
+        gateway.connect();
+      }
+      probe.resolve(new Response(null, { status: 200 }));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(stage === "probe" ? 1 : 0);
+      expect(replace).not.toHaveBeenCalled();
+      expect(sessionStorage.getItem("openclaw.controlUi.staleChunkReloadBuildId")).toBeNull();
+      gateway.stop();
+    },
+  );
 
   it("keeps legacy version fallback on reconnect instead of first admission", () => {
     const { gateway, current } = createStore();
@@ -541,9 +607,9 @@ describe("createApplicationGateway connection phase", () => {
       willRetry: false,
     });
 
-    expect(scheduleStaleChunkReloadMock).toHaveBeenCalledExactlyOnceWith({
-      buildId: "replacement-build",
-    });
+    expect(scheduleStaleChunkReloadMock).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ buildId: "replacement-build" }),
+    );
     expect(gateway.snapshot.phase).toBe("reload-required");
   });
 
@@ -568,9 +634,9 @@ describe("createApplicationGateway connection phase", () => {
       willRetry: true,
     });
 
-    expect(scheduleStaleChunkReloadMock).toHaveBeenCalledExactlyOnceWith({
-      buildId: "replacement-build",
-    });
+    expect(scheduleStaleChunkReloadMock).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ buildId: "replacement-build" }),
+    );
     expect(gateway.snapshot.phase).toBe("reload-required");
     expect(gateway.snapshot.lastError).toContain("Control UI updated");
     expect(gateway.snapshot.lastErrorCode).toBe(ConnectErrorDetailCodes.PROTOCOL_MISMATCH);

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -35,6 +35,10 @@ import type {
 } from "./context.ts";
 import { resolveControlUiAuthCandidates } from "./control-ui-auth.ts";
 import {
+  createGatewayControlUiReloadOptions,
+  isSameOriginGateway,
+} from "./gateway-control-ui-reload.ts";
+import {
   loadGatewaySessionSelection,
   loadSettings,
   patchSettings,
@@ -460,6 +464,8 @@ export function createApplicationGateway(
         if (client !== nextClient) {
           return;
         }
+        // A successful hello retires bootstrap; the client has processed any issued device grant.
+        connection = { ...connection, bootstrapToken: "", bootstrapProfile: undefined };
         const exactBuildIdentityAvailable = Boolean(hello.server?.buildId?.trim());
         const controlUiBuildFresh = !(
           isSameOriginGateway(nextConnection.gatewayUrl) &&
@@ -486,12 +492,17 @@ export function createApplicationGateway(
           });
           const targetBuildId = hello.server?.buildId?.trim() || hello.server?.version?.trim();
           if (targetBuildId) {
-            void scheduleStaleChunkReload({ buildId: targetBuildId });
+            void scheduleStaleChunkReload({
+              buildId: targetBuildId,
+              ...createGatewayControlUiReloadOptions(
+                gateway,
+                () => isCurrentClient(nextClient) && isSameOriginGateway(nextConnection.gatewayUrl),
+              ),
+            });
           }
           return;
         }
         updateAvatarContext(hello);
-        connection = { ...connection, bootstrapToken: "", bootstrapProfile: undefined };
         if (persistConnectionSettings) {
           settings = loadSettings();
         }
@@ -551,7 +562,13 @@ export function createApplicationGateway(
         stopCanvasSurfaceLease();
         const mismatchedBuildId = readControlUiBuildMismatchId(error?.details);
         if (mismatchedBuildId) {
-          void scheduleStaleChunkReload({ buildId: mismatchedBuildId });
+          void scheduleStaleChunkReload({
+            buildId: mismatchedBuildId,
+            ...createGatewayControlUiReloadOptions(
+              gateway,
+              () => isCurrentClient(nextClient) && isSameOriginGateway(nextConnection.gatewayUrl),
+            ),
+          });
         }
         const startupPending =
           mismatchedBuildId === null &&
@@ -717,14 +734,6 @@ export function createApplicationGateway(
     },
   };
   return gateway;
-}
-
-function isSameOriginGateway(gatewayUrl: string): boolean {
-  try {
-    return new URL(gatewayUrl.replace(/^ws/u, "http")).origin === globalThis.location?.origin;
-  } catch {
-    return false;
-  }
 }
 
 function normalizeCanvasPluginSurfaceUrl(value: string | undefined): string | null {

--- a/ui/src/app/stale-chunk-reload.test.ts
+++ b/ui/src/app/stale-chunk-reload.test.ts
@@ -286,37 +286,73 @@ describe("scheduleStaleChunkReload", () => {
     expect(storage.getItem(GUARD_KEY)).toBe("build-b");
   });
 
-  it("reprobes a newer build after its joined older-build probe fails", async () => {
-    const olderProbe = deferred<Response>();
+  it("does not let an unrelated pending probe bypass a failed build's cooldown", async () => {
+    const pending = deferred<Response>();
     const fetchMock = vi
       .fn<typeof fetch>()
-      .mockImplementationOnce(async () => olderProbe.promise)
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockImplementationOnce(() => pending.promise)
       .mockResolvedValueOnce(new Response(null, { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
-    const reload = vi.fn();
     const storage = memoryStorage();
+    const reload = vi.fn();
+    const attempt = (buildId: string) =>
+      scheduleStaleChunkReload({ now: () => 1000, buildId, storage, reload });
+    await expect(attempt("build-a")).resolves.toBe(false);
+    const newer = attempt("build-b");
+    const repeated = attempt("build-a");
 
-    const olderBuild = scheduleStaleChunkReload({
-      now: () => 1000,
-      buildId: "build-a",
-      storage,
-      reload,
-    });
-    const newerBuild = scheduleStaleChunkReload({
-      now: () => 2000,
-      buildId: "build-b",
-      storage,
-      reload,
-    });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-
-    olderProbe.resolve(new Response(null, { status: 503 }));
-    await expect(Promise.all([olderBuild, newerBuild])).resolves.toEqual([false, true]);
-
+    pending.resolve(new Response(null, { status: 503 }));
+    await expect(Promise.all([newer, repeated])).resolves.toEqual([false, false]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(reload).toHaveBeenCalledTimes(1);
-    expect(storage.getItem(GUARD_KEY)).toBe("build-b");
+    expect(reload).not.toHaveBeenCalled();
   });
+
+  it.each([false, true])(
+    "reprobes a newer build after its joined older-build probe fails (replacement: %s)",
+    async (replaceOwner) => {
+      const olderProbe = deferred<Response>();
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockImplementationOnce(async () => olderProbe.promise)
+        .mockResolvedValueOnce(new Response(null, { status: 200 }));
+      vi.stubGlobal("fetch", fetchMock);
+      const reload = vi.fn();
+      const storage = memoryStorage();
+
+      const olderBuild = scheduleStaleChunkReload({
+        now: () => 1000,
+        buildId: "build-a",
+        storage,
+        reload,
+      });
+      let ownsNewerBuild = true;
+      const newerBuild = scheduleStaleChunkReload({
+        now: () => 2000,
+        buildId: "build-b",
+        storage,
+        reload,
+        canReload: () => ownsNewerBuild,
+      });
+      const results = [olderBuild, newerBuild];
+      if (replaceOwner) {
+        ownsNewerBuild = false;
+        results.push(
+          scheduleStaleChunkReload({ now: () => 2000, buildId: "build-b", storage, reload }),
+        );
+      }
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      olderProbe.resolve(new Response(null, { status: 503 }));
+      await expect(Promise.all(results)).resolves.toEqual(
+        replaceOwner ? [false, false, true] : [false, true],
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(reload).toHaveBeenCalledTimes(1);
+      expect(storage.getItem(GUARD_KEY)).toBe("build-b");
+    },
+  );
 
   it("reloads only the newest build after a shared document probe succeeds", async () => {
     const sharedProbe = deferred<Response>();

--- a/ui/src/app/stale-chunk-reload.ts
+++ b/ui/src/app/stale-chunk-reload.ts
@@ -29,6 +29,7 @@ type StaleChunkReloadDeps = {
   buildId?: string;
   storage?: Pick<Storage, "getItem" | "setItem"> | null;
   reload?: () => void;
+  canReload?: () => boolean;
 };
 
 type MissingStylesheetRecoveryDeps = {
@@ -49,8 +50,7 @@ export function isStaleChunkImportError(error: unknown): boolean {
   return error instanceof Error && MODULE_IMPORT_ERROR_PATTERN.test(error.message);
 }
 
-export function reloadControlUiDocument(): void {
-  const url = new URL(window.location.href);
+export function reloadControlUiDocument(url = new URL(window.location.href)): void {
   // The pre-app mount recovery strips this one-shot cache buster before bootstrap.
   url.searchParams.set("openclaw_mount_recovery", String(Date.now()));
   window.location.replace(url.href);
@@ -108,7 +108,7 @@ function persistGuardBuildId(
  * app webviews) instead of the recoverable panel error.
  */
 export async function scheduleStaleChunkReload(deps: StaleChunkReloadDeps = {}): Promise<boolean> {
-  if (!canReloadControlUiDocument()) {
+  if (deps.canReload?.() === false || !canReloadControlUiDocument()) {
     return false;
   }
   const storage = deps.storage === undefined ? getSafeSessionStorage() : deps.storage;
@@ -132,7 +132,9 @@ export async function scheduleStaleChunkReload(deps: StaleChunkReloadDeps = {}):
       attemptsByBuild.delete(attemptedBuildId);
     }
   }
-  if (attemptsByBuild.has(buildId)) {
+  // A replacement connection can join a pending probe; only starting another
+  // probe is throttled, so retiring the first caller cannot strand its successor.
+  if (attemptsByBuild.has(buildId) && (!inFlightDocumentProbe || recovery[1] !== buildId)) {
     return false;
   }
   attemptsByBuild.set(buildId, now);
@@ -154,6 +156,7 @@ export async function scheduleStaleChunkReload(deps: StaleChunkReloadDeps = {}):
   const reload = deps.reload ?? reloadControlUiDocument;
   if (
     !canReloadControlUiDocument() ||
+    deps.canReload?.() === false ||
     recovery[1] !== buildId ||
     !persistGuardBuildId(storage, buildId)
   ) {
@@ -202,7 +205,6 @@ export async function retryStaleChunkReloadWhenReachable(
     intervalMs?: number;
     probe?: () => Promise<boolean>;
     wait?: (ms: number) => Promise<void>;
-    canReload?: () => boolean;
   } = {},
 ): Promise<boolean> {
   if (deps.canReload?.() === false || !canReloadControlUiDocument(true)) {


### PR DESCRIPTION
## What Problem This Solves

A source Gateway restart could serve an old Control UI that its own build admission rejected. Recovery then lost an unfinished browser pairing handoff, and another tab changing the saved Gateway could redirect that pending credential. Focused desktop and terminal documents also omitted the Gateway confirmation dialog. Complete but stale packaged assets exposed a related diagnostic gap: Gateway refused them while offline Doctor reported no UI problem.

## What Changed

Startup checks completeness and build identity at the selected UI root, repairs source-owned output, and carries the prepared result forward. A damaged package cannot borrow assets from an unrelated checkout. Explicit custom roots, development UI, and strict build admission retain their contracts.

One browser reload owner preserves the pending one-shot handoff together with its captured Gateway destination and rechecks client/connection identity after asynchronous probes. Dashboard and onboarding issuers carry their already-resolved HTTP/WebSocket pair. Existing startup confirmation owns the destination choice: Cancel retains the saved Gateway; Confirm sends the bootstrap only to the named Gateway. One outer renderer makes this confirmation available across normal and focused documents.

Doctor opts into the same build-identity inspection for its loaded installation, prints source-build or package-reinstall guidance, and validates source rebuild output. Updater completeness-only checks remain unchanged because an old updater process can inspect a newer target. No configuration, dependency, database, or protocol surface is added.

## Verification

- Final tree `07302f01eeab6653479a6558c141ca580e073b16` passed 283 focused source tests, 31 focused UI tests, the full changed gate, canonical build, and package integrity. This is the tree committed by `41693be8eebb033d38a0c50253a27e0ecee97f43`.
- The broader UI suite passed 15,226 tests with one skip across 932 files. That run preceded a mechanical formatter correction; focused UI tests and full UI types passed again on the final bytes.
- The built tarball passed fresh installation and a real published `openclaw@2026.9.1` CLI upgrade, serving all expected startup assets and preserving isolated configuration/workspace state. Deliberately mixing complete old UI into the new runtime produced terminal 503. Stopped-Gateway Doctor now prints reinstall guidance; reinstalling the identical candidate tarball restores 200. Healthy upgrades do not produce a false UI warning.
- The original real Chrome restart proof preserved a pending handoff through runtime-only rebuild, normal UI preparation, stale-build rejection, automatic reload, bootstrap authentication, and a subsequent device-token reload. It observed 25 preparing responses with `Retry-After: 1` before matching UI became ready.
- Final real Chrome cross-tab proof passed on `41693be8`: a mounted old document retained an unconsumed handoff for Gateway A while offline; another tab saved Gateway B. A real build-mismatch rejection triggered automatic reload to the final runtime. The fresh document kept B selected and restored the confirmation naming A. Cancel kept B, with zero bootstrap-authentication events at A. A separate fresh Confirm authenticated at A with the bootstrap and received `hello-ok`; an ordinary reload then authenticated with the device credential, without another bootstrap authentication.
- The disposable B receiver recorded 14 real connect requests: zero bootstrap, shared, or device credential fields, zero invalid messages or socket errors, and zero active connections on clean shutdown. The browser fragment and task clipboard were clear. Stopped/replaced clients, reconnect races, and destination changes during an outstanding readiness probe also pass deterministic owner/scheduler regressions with a simulated client/transport; those individual races are not claimed as live-browser reproductions. The separate cross-document credential test uses the real Gateway browser client with a recording WebSocket.
- Codex P0–P2 review is clean on the final patch. [GitHub CI run 33966992384](https://github.com/openclaw/openclaw/actions/runs/33966992384) passed on final commit `41693be8`, including the required `openclaw/ci-gate`. The required translation verification passed; its separate advisory catalog audit reported existing fallback-baseline drift.

The earlier provider teardown CI timeout did not reproduce in original-head or exact-merge cold/warm full shard replays; the original hosted retry passed. No timeout or assertion was weakened. The local checkout's older formatter changed an intermediate commit; the canonical pinned formatter restored the exact remote-verified bytes before publication.

Startup bundle budgets pass at eight JS requests / 345,577 bytes gzip and one CSS request / 43,989 bytes gzip. These are size measurements, not a claimed runtime speedup.

## Before / After

Both captures are synthetic-only and show the same desktop-focus pairing flow.

| Before: no way to confirm the pending Gateway | After: confirmation is visible and actionable |
| --- | --- |
| ![Desktop focus without its pending confirmation](https://github.com/user-attachments/assets/86ac9e72-14f1-4679-aaeb-51483a411c4b) | ![Desktop focus with the Gateway confirmation](https://github.com/user-attachments/assets/bfc5ecad-ec9f-4b8c-91c1-3eb1a59d6351) |

## Size And Follow-ups

Production +51 lines (357 added / 306 removed); tests/support +833; docs +3. The shared reload owner accounts for 48 production lines protecting captured connection identity and destination-bound credential delivery. Other production changes total +3; Doctor, the root renderer, and asset ownership code shrink. No generated files, lockfiles, or snapshots change.

- **Atomic macOS packaging and Gateway watcher ownership:** publish one coherent runtime/UI snapshot through the existing artifact owner and restart once per completed generation.
- **Operation-bound ready-pool allocation and fenced return (Crabbox + OpenClaw):** safe warm-worker reuse requires replayable borrowing and exact cleanup. This PR makes no cold-cloud startup latency claim.
- **CI capacity environment parsing:** `ci-run-node-test-shard.mts` treats only `CI=true` as enabled; `CI=1` differs from neighboring canonical boolean parsing. Recorded separately from the provider teardown timeout; no causal claim or workaround here.
