### PR TITLE
fix(sessions): keep accepted input active during transcript rewrites

### DIFF
--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -10,8 +10,16 @@ import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqli
 import {
   appendTranscriptMessage,
   loadTranscriptEvents,
+  readActiveTranscriptEntryAnchor,
   replaceSessionEntry,
 } from "../../config/sessions/session-accessor.js";
+import {
+  bindSessionPendingInputSources,
+  listSessionPendingInputs,
+  stageSessionPendingInput,
+  withSessionPendingInputPersistence,
+} from "../../config/sessions/session-accessor.pending-inputs.js";
+import { waitForSessionTranscriptProjection } from "../../config/sessions/session-transcript-reconcile.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 
 let rewriteTranscriptEntriesInSessionManager: typeof import("./transcript-rewrite.js").rewriteTranscriptEntriesInSessionManager;
@@ -144,6 +152,119 @@ beforeAll(async () => {
 });
 
 describe("rewriteTranscriptEntriesInSessionManager", () => {
+  it.each([
+    { collected: false, excludeFromContext: false },
+    { collected: false, excludeFromContext: true },
+    { collected: true, excludeFromContext: false },
+    { collected: true, excludeFromContext: true },
+  ])(
+    "preserves admitted input custody through repeated history rewrites ($collected, $excludeFromContext)",
+    async ({ collected, excludeFromContext }) => {
+      const directory = tempDirs.make("openclaw-admitted-rewrite-");
+      const target = {
+        agentId: "main",
+        sessionId: "admitted-rewrite",
+        sessionKey: "agent:main:admitted-rewrite",
+        storePath: path.join(directory, "sessions.json"),
+      };
+      await replaceSessionEntry(target, { sessionId: target.sessionId, updatedAt: 1 });
+      const manager = SessionManager.open(target, directory);
+      const toolEntryId = appendSessionMessages(manager, [
+        asAppendMessage({ role: "user", content: "read file", timestamp: 1 }),
+        asAppendMessage({
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+          timestamp: 2,
+        }),
+        asAppendMessage(createToolResultReplacement("read", "large original result", 3)),
+      ])[2];
+      const message: Parameters<typeof stageSessionPendingInput>[1]["message"] = {
+        role: "user" as const,
+        content: "Continue the work",
+        timestamp: 4,
+        idempotencyKey: "admitted-rewrite:user",
+        ...(excludeFromContext ? { excludeFromContext: true } : {}),
+      };
+      const source = requireValue(
+        await stageSessionPendingInput(target, {
+          runId: "admitted-rewrite",
+          message,
+          assertCurrent: () => {},
+        }),
+        "pending input receipt",
+      );
+      const receipt = collected
+        ? requireValue(
+            bindSessionPendingInputSources([source], {
+              ...message,
+              idempotencyKey: "collected-rewrite:user",
+            }),
+            "collected input receipt",
+          )
+        : source;
+      try {
+        await receipt.run(() => appendTranscriptMessage(target, { message: receipt.message }));
+        manager.reloadPersistedTranscript();
+        const originalRows = await loadTranscriptEvents(target);
+        let rewriteTarget = requireValue(toolEntryId, "tool result entry");
+        let currentEntryId = receipt.inputId;
+        for (const replacementText of ["short result", "shorter"]) {
+          const rewritten = receipt.run(() =>
+            rewriteTranscriptEntriesInSessionManager({
+              sessionManager: manager,
+              replacements: [
+                {
+                  entryId: rewriteTarget,
+                  message: createToolResultReplacement("read", replacementText, 3),
+                },
+              ],
+            }),
+          );
+          expect(rewritten.changed).toBe(true);
+          await waitForSessionTranscriptProjection(target);
+          const reopened = SessionManager.open(target, directory);
+          const activeUsers = reopened
+            .getBranch()
+            .filter(
+              (entry) =>
+                entry.type === "message" &&
+                entry.message.role === "user" &&
+                "idempotencyKey" in entry.message &&
+                entry.message.idempotencyKey === receipt.message.idempotencyKey,
+            );
+          expect(activeUsers).toHaveLength(1);
+          currentEntryId = requireValue(activeUsers[0], "active admitted user").id;
+          expect(currentEntryId).not.toBe(receipt.inputId);
+          expect(
+            readActiveTranscriptEntryAnchor({ ...target, entryId: currentEntryId }),
+          ).toBeDefined();
+          expect(
+            await receipt.run(() => appendTranscriptMessage(target, { message: receipt.message })),
+          ).toMatchObject({ appended: false, messageId: currentEntryId });
+          rewriteTarget = requireValue(
+            reopened
+              .getBranch()
+              .find((entry) => entry.type === "message" && entry.message.role === "toolResult"),
+            "rewritten tool result",
+          ).id;
+        }
+        expect((await loadTranscriptEvents(target)).slice(0, originalRows.length)).toEqual(
+          originalRows,
+        );
+        expect(listSessionPendingInputs(target)).toEqual({ items: [], total: 0 });
+        receipt.finish("cancelled");
+        expect(() => receipt.run(() => {})).toThrow("ownership ended");
+        expect(
+          await withSessionPendingInputPersistence(receipt, () =>
+            appendTranscriptMessage(target, { message: receipt.message }),
+          ),
+        ).toMatchObject({ appended: false, messageId: currentEntryId });
+      } finally {
+        receipt.finish("interrupted");
+      }
+    },
+  );
+
   it("branches from the first replaced message and re-appends the remaining suffix", () => {
     const { sessionManager, toolResultEntryId } = createReadRewriteSession();
 

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -1,5 +1,6 @@
 /** Rewrites transcript entries by branching and re-appending the active suffix. */
 import { stripCompactionReplayCheckpoint } from "@openclaw/ai/transports";
+import { withSessionPendingInputRelocation } from "../../config/sessions/session-accessor.js";
 import type {
   TranscriptRewriteReplacement,
   TranscriptRewriteResult,
@@ -61,9 +62,10 @@ function appendBranchEntry(params: {
 }): string {
   const { sessionManager, entry, rewrittenEntryIds, appendMessage } = params;
   if (entry.type === "message") {
-    return appendMessage(
-      stripStalePrefixReplay(entry.message) as Parameters<typeof sessionManager.appendMessage>[0],
-    );
+    const message = stripStalePrefixReplay(entry.message) as Parameters<
+      typeof sessionManager.appendMessage
+    >[0];
+    return withSessionPendingInputRelocation(entry.id, message, () => appendMessage(message));
   }
   if (entry.type === "compaction") {
     const { __openclaw: identity } = entry;
@@ -204,13 +206,16 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
             rewrittenEntryIds,
             appendMessage,
           })
-        : appendMessage(
-            (params.preserveReplacementCompactionReplay
-              ? replacement
-              : stripStalePrefixReplay(replacement)) as Parameters<
-              typeof params.sessionManager.appendMessage
-            >[0],
-          );
+        : (() => {
+            const message = (
+              params.preserveReplacementCompactionReplay
+                ? replacement
+                : stripStalePrefixReplay(replacement)
+            ) as Parameters<typeof params.sessionManager.appendMessage>[0];
+            return withSessionPendingInputRelocation(entry.id, message, () =>
+              appendMessage(message),
+            );
+          })();
     rewrittenEntryIds.set(entry.id, newEntryId);
   }
 

--- a/src/config/sessions/session-accessor.pending-inputs.test.ts
+++ b/src/config/sessions/session-accessor.pending-inputs.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../state/openclaw-agent-db.js";
 import {
   appendTranscriptMessage,
+  appendTranscriptMessageSync,
   deleteSessionEntryLifecycle,
   loadTranscriptEvents,
   readActiveTranscriptEntryAnchor,
@@ -30,6 +31,7 @@ import {
   type SessionPendingInputReceipt,
 } from "./session-accessor.pending-inputs.js";
 import { copySessionNodeArtifactsForRepair } from "./session-accessor.sqlite-node-artifacts.js";
+import { withSessionPendingInputRelocation } from "./session-accessor.sqlite-pending-inputs.js";
 import {
   resolveSqliteScope,
   runExclusiveSqliteSessionWrite,
@@ -143,6 +145,59 @@ describe("accepted input custody", () => {
     database().db.exec("DROP TRIGGER reject_pending_consume");
     expect(await promote(receipt)).toMatchObject({ appended: true, messageId: receipt.inputId });
     expect(readSessionPendingInput(scope(), receipt.inputId)).toBeUndefined();
+  });
+
+  it("moves transcript custody only after an authorized relocation commits", async () => {
+    const receipt = await stage("relocation");
+    await promote(receipt);
+    const appendCopy = (sourceInputId: string, eventId: string) =>
+      withSessionPendingInputRelocation(sourceInputId, receipt.message, () =>
+        appendTranscriptMessageSync(scope(), {
+          eventId,
+          idempotencyLookup: "caller-checked",
+          message: receipt.message,
+          parentId: null,
+        }),
+      );
+
+    expect(
+      receipt.run(() =>
+        appendTranscriptMessageSync(scope(), {
+          eventId: "unauthorized-copy",
+          idempotencyLookup: "caller-checked",
+          message: receipt.message,
+        }),
+      ),
+    ).toMatchObject({ ok: true, value: { appended: false, messageId: receipt.inputId } });
+
+    database().db.exec(
+      "CREATE TRIGGER reject_relocation BEFORE INSERT ON transcript_events WHEN NEW.event_json LIKE '%relocation-copy%' BEGIN SELECT RAISE(ABORT, 'relocation failed'); END",
+    );
+    expect(() => receipt.run(() => appendCopy(receipt.inputId, "relocation-copy"))).toThrow(
+      "relocation failed",
+    );
+    database().db.exec("DROP TRIGGER reject_relocation");
+    expect(
+      await receipt.run(() => appendTranscriptMessage(scope(), { message: receipt.message })),
+    ).toMatchObject({ appended: false, messageId: receipt.inputId });
+
+    expect(receipt.run(() => appendCopy(receipt.inputId, "relocated-user"))).toMatchObject({
+      ok: true,
+      value: { appended: true, messageId: "relocated-user" },
+    });
+    expect(() => receipt.run(() => appendCopy(receipt.inputId, "stale-source-copy"))).toThrow(
+      "does not match",
+    );
+    receipt.finish("cancelled");
+    expect(appendCopy("relocated-user", "closed-owner-copy")).toMatchObject({
+      ok: true,
+      value: { appended: true, messageId: "closed-owner-copy" },
+    });
+    await expect(
+      withSessionPendingInputPersistence(receipt, () =>
+        appendTranscriptMessage(scope(), { message: receipt.message }),
+      ),
+    ).rejects.toThrow("conflicts with the admitted message");
   });
 
   it("promotes a queued input with its own custody after another receipt releases the writer", async () => {

--- a/src/config/sessions/session-accessor.pending-inputs.ts
+++ b/src/config/sessions/session-accessor.pending-inputs.ts
@@ -31,6 +31,7 @@ import {
   releaseSessionPendingInputOwner,
   runWithSessionPendingInput,
   runWithSessionPendingInputPersistence,
+  withSessionPendingInputRelocation,
   type SessionPendingInput,
   type SessionPendingInputOwner,
   type SessionPendingInputPage,
@@ -50,6 +51,7 @@ import {
 } from "./session-accessor.sqlite-transcript-store.js";
 import { sessionTranscriptIndexNeedsReconcile } from "./session-transcript-index.js";
 
+export { withSessionPendingInputRelocation };
 export type { SessionPendingInput, SessionPendingInputPage };
 type PendingInputScope = SessionAccessScope & { agentId: string; sessionId: string };
 export type SessionPendingInputReceipt = {
@@ -123,9 +125,11 @@ export function bindSessionPendingInputSources(
   if (Buffer.byteLength(messageJson, "utf8") > MAX_PAYLOAD_BYTES) {
     throw new Error("Collected input exceeds the Gateway payload limit");
   }
+  const aggregateInputId = randomUUID();
   return ownerReceipt({
     ...first,
-    inputId: randomUUID(),
+    inputId: aggregateInputId,
+    transcriptInputId: aggregateInputId,
     idempotencyKey,
     messageJson,
     sources,
@@ -257,6 +261,7 @@ export async function stageSessionPendingInput(
     let finished = false;
     const owner: SessionPendingInputOwner = {
       inputId,
+      transcriptInputId: inputId,
       sessionId: scope.sessionId,
       sessionKey: resolved.sessionKey,
       databasePath: database.path,

--- a/src/config/sessions/session-accessor.sqlite-pending-inputs.ts
+++ b/src/config/sessions/session-accessor.sqlite-pending-inputs.ts
@@ -38,6 +38,7 @@ type PendingInputDatabase = Pick<OpenClawAgentDatabase, "db" | "path">;
 
 export type SessionPendingInputOwner = {
   inputId: string;
+  transcriptInputId: string;
   sessionId: string;
   sessionKey: string;
   databasePath: string;
@@ -54,6 +55,10 @@ export type SessionPendingInputOwner = {
 const owners = resolveGlobalSingleton(Symbol.for("openclaw.sessionPendingInputOwners"), () => ({
   live: new Map<string, SessionPendingInputOwner>(),
   current: new AsyncLocalStorage<SessionPendingInputOwner>(),
+  relocation: new AsyncLocalStorage<{
+    owner: SessionPendingInputOwner;
+    sourceInputId: string;
+  }>(),
 }));
 
 registerAgentEventLifecycleRotationHandler("session-pending-inputs", () => {
@@ -110,6 +115,24 @@ export function runWithSessionPendingInputPersistence<T>(
   persist: () => T,
 ): T {
   return owners.current.run(owner, persist);
+}
+
+/** A transcript rewrite may move only the exact current user owned by the live admitted turn. */
+export function withSessionPendingInputRelocation<T>(
+  sourceInputId: string,
+  message: unknown,
+  append: () => T,
+): T {
+  const owner = owners.current.getStore();
+  const record = asOptionalRecord(message);
+  if (!owner || record?.role !== "user" || record.idempotencyKey !== owner.idempotencyKey) {
+    return append();
+  }
+  assertPendingInputOwnerCurrent(owner);
+  if (owner.transcriptInputId !== sourceInputId || JSON.stringify(message) !== owner.messageJson) {
+    throw new Error("Pending input relocation does not match its admitted transcript entry");
+  }
+  return owners.relocation.run({ owner, sourceInputId }, append);
 }
 
 /** Registration owns disposition; execution and promotion check the private operational predicates. */
@@ -192,6 +215,7 @@ export type SessionPendingInputAppend = {
   message: PersistedUserTurnMessage;
   alreadyPromoted: boolean;
   sourceInputIds?: readonly string[];
+  commitRelocation?: (destinationInputId: string) => void;
 };
 
 /** The private call-path owner, not a copied id or durable row, permits promotion. */
@@ -225,6 +249,15 @@ export function resolveSessionPendingInputAppend(
   ) {
     throw new Error("Pending input cannot be appended outside its admitted turn");
   }
+  const relocation = owners.relocation.getStore();
+  const relocationCommit =
+    relocation?.owner === owner && relocation.sourceInputId === owner.transcriptInputId
+      ? (destinationInputId: string) => {
+          if (owner.transcriptInputId === relocation.sourceInputId) {
+            owner.transcriptInputId = destinationInputId;
+          }
+        }
+      : undefined;
   if (owner.sources) {
     const acceptedByKey = new Map(
       executeSqliteQuerySync(
@@ -261,10 +294,11 @@ export function resolveSessionPendingInputAppend(
       assertPendingInputOwnerCurrent(owner);
     }
     return {
-      inputId: owner.inputId,
+      inputId: owner.transcriptInputId,
       message: parseSessionPendingInputMessage(owner.messageJson),
       alreadyPromoted,
       sourceInputIds: sources.map((source) => source.input_id),
+      ...(alreadyPromoted && relocationCommit ? { commitRelocation: relocationCommit } : {}),
     };
   }
   // Terminal mirroring may replay a consumed input after cancellation. The caller
@@ -273,9 +307,10 @@ export function resolveSessionPendingInputAppend(
     assertPendingInputOwnerCurrent(owner);
   }
   return {
-    inputId: owner.inputId,
+    inputId: owner.transcriptInputId,
     message: parseSessionPendingInputMessage(row?.message_json ?? owner.messageJson),
     alreadyPromoted: !row,
+    ...(!row && relocationCommit ? { commitRelocation: relocationCommit } : {}),
   };
 }
 

--- a/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
@@ -2,7 +2,10 @@ import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import {
+  deferOpenClawAgentPostCommitPublication,
+  type OpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
 import type {
   TranscriptMessageAppendOptions,
   TranscriptMessageAppendResult,
@@ -113,7 +116,7 @@ export function appendTranscriptMessageInTransaction<TMessage>(
     }
   }
 
-  if (pending?.alreadyPromoted) {
+  if (pending?.alreadyPromoted && !pending.commitRelocation) {
     const committed = readTranscriptMessageByEventId(database, resolved, pending.inputId);
     if (!committed) {
       throw new Error("Pending input custody ended before transcript promotion");
@@ -130,7 +133,8 @@ export function appendTranscriptMessageInTransaction<TMessage>(
     return undefined;
   }
 
-  const messageId = pending?.inputId ?? options.eventId ?? randomUUID();
+  const messageId =
+    pending && !pending.alreadyPromoted ? pending.inputId : (options.eventId ?? randomUUID());
   const now = options.now ?? Date.now();
   const finalMessage = pending ? prepared : serializeForStorage(prepared);
   ensureTranscriptHeader(database, resolved, options.cwd);
@@ -186,7 +190,17 @@ export function appendTranscriptMessageInTransaction<TMessage>(
   const persistedMessage = (JSON.parse(appended) as typeof event).message;
   const anchor = readAnchor({ message: persistedMessage, messageId });
   if (pending) {
-    consumeSessionPendingInput(database, pending);
+    if (pending.commitRelocation) {
+      if (
+        !deferOpenClawAgentPostCommitPublication(database, () =>
+          pending.commitRelocation?.(messageId),
+        )
+      ) {
+        throw new Error("Pending input relocation requires a transcript write transaction");
+      }
+    } else {
+      consumeSessionPendingInput(database, pending);
+    }
   }
   return {
     appended: true,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -13,6 +13,7 @@ export {
   readSessionSubmittedInput,
   stageSessionPendingInput,
   withSessionPendingInputPersistence,
+  withSessionPendingInputRelocation,
   type SessionPendingInput,
   type SessionPendingInputPage,
   type SessionPendingInputReceipt,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an accepted chat message could disappear from the active transcript and fail with `Pending input is no longer active in its admitted transcript` when maintenance rewrote earlier history during the same turn.

## Why This Change Was Made

Transcript rewrites create new event IDs for the copied active suffix, but accepted-input custody remained bound to the old event ID. This change keeps immutable request identity separate from the current transcript location. Only the exact keyed user owned by the live admitted turn may move that location, and the move becomes visible only after the SQLite rewrite commits.

The existing inactive-branch, ownership, and idempotency checks remain in force. This does not add a generic retry, change schemas, alter provider behavior, or weaken the keyed-turn safety checks.

## User Impact

Accepted chat input remains visible and replayable when transcript maintenance truncates or replaces earlier history. Direct and collected inputs both retain one active user entry through repeated rewrites, including context-excluded inputs.

## Evidence

- Current upstream `961464a5177e02cf037b7783fed0dc842619f16d`: all four synthetic direct/collected and context-exclusion variants fail with the exact admitted-transcript error.
- Exact head `3da9a361da67cad12fae63c116f2503f34a04644`: all four variants pass, including repeated rewrites, replay against the relocated event ID, and closed-owner terminal replay.
- Focused and adjacent sweep: 200 tests passed across transcript rewriting, pending-input custody, user-turn media/persistence, interrupted replay, chat admission, and requester-wake coverage.
- Negative controls cover unauthorized caller-checks, transaction rollback, stale source IDs, closed owners, and aggregate receipt consumption.
- Source-blind behavior validation passed 5/5 clauses and repeated the green head run.
- Fresh autoreview found no actionable P0 defect.
- `OPENCLAW_TESTBOX=1 pnpm check:changed`: passed on the exact head in Testbox.

The merged keyed-compaction repair #133094 and accepted-send retry repair #137267 are both present in the reproduced base. Neither covers event-ID relocation during a transcript rewrite.

## Worked on by

- @fuller-stack-dev
