### PR TITLE
chore(test): await submenu opening before hide interruption

### DIFF
--- a/ui/src/components/web-awesome-dropdown.browser.test.ts
+++ b/ui/src/components/web-awesome-dropdown.browser.test.ts
@@ -260,7 +260,8 @@ describe.runIf(browserMode)("Web Awesome dropdown lifecycle", () => {
   it("keeps a reopened submenu visible after its interrupted hide finishes", async () => {
     const f = await fixture();
     await open(f);
-    f.parent.submenuOpen = true;
+    // Focus precedes the opening animation; settle it before pausing the hide.
+    await f.parent.openSubmenu();
     await expect.poll(() => document.activeElement).toBe(f.nested);
     const submenu = f.parent.submenuElement;
     await duringElementAnimation(


### PR DESCRIPTION
Related: #137201

## What Problem This Solves

The Vitest 5 migration needs equivalent, deterministic UI lifecycle coverage on both sides of its paired benchmark. The reopened-submenu regression could begin the interrupted hide while the asynchronous opening animation was still active, making the result depend on timing rather than the behavior under test.

## Why This Change Was Made

The existing test now awaits the dropdown item's public `openSubmenu()` flow before interrupting the hide. This preserves current behavior while ensuring the opening animation and focus transition have settled before the test exercises reopen-during-hide behavior.

## User Impact

No production behavior changes. This makes the UI regression coverage and upcoming Vitest 4/5 comparison more reliable.

## Evidence

Test-audit authoring gate:

- Observable invariant: after a submenu hide is interrupted by reopening it, the submenu remains open, visible, in the popover top layer, and focused.
- Credible pre-fix failure: directly setting `submenuOpen` starts asynchronous opening work but can begin the hide before that opening animation settles, producing an ordering-dependent failure.
- Existing coverage gap: the existing assertions observe the final state, but the test previously did not establish the required settled-open precondition before starting the interrupted hide.
- Production seam: none. The test uses the existing public `openSubmenu()` behavior.
- Focused proof: `node scripts/run-vitest.mjs ui/src/components/web-awesome-dropdown.browser.test.ts` passed 1 file and 28 tests.
- Formatting and lint: `oxfmt --check` and focused `run-oxlint.mjs` passed.
- Changed-file classification: `check-changed.mjs --dry-run` classified the file as `UI test` in the `coreTests` lane.
- Diff integrity: `git diff --check` passed.
- LOC: production `+0/-0`; tests `+2/-1`.

Proof gap: `tsgo:ui` cannot run in this sparse GWT because the repository wrapper rejects the intentionally shared declaration binary. This lane did not run `pnpm install`; hosted CI will provide the exact-head typecheck.
