### PR TITLE
chore(test): allow LAN host for SSH pairing fixture

### DIFF
--- a/src/gateway/server.node-pairing-ssh-verify.test.ts
+++ b/src/gateway/server.node-pairing-ssh-verify.test.ts
@@ -59,7 +59,26 @@ type PairingRequiredDetails = {
   pauseReconnect?: boolean;
 };
 
+type SshVerifyConfig = Exclude<GatewayNodePairingConfig["sshVerify"], boolean | undefined>;
+
+function createSshVerifyConfig(lanIp: string, overrides: SshVerifyConfig = {}): SshVerifyConfig {
+  return { cidrs: [`${lanIp}/32`], ...overrides };
+}
+
 describeWithLanNodePairingServer("gateway ssh-verified node pairing auto-approve", (attempt) => {
+  const attemptWithSshVerify: typeof attempt = async (params) => {
+    const configure = params.configure;
+    await attempt({
+      ...params,
+      configure: async (lanIp) => {
+        await writeConfigFile({
+          gateway: { nodes: { pairing: { sshVerify: createSshVerifyConfig(lanIp) } } },
+        });
+        await configure?.(lanIp);
+      },
+    });
+  };
+
   beforeEach(() => {
     // Each case uses a distinct identityName, matching the host+device cooldown key.
     probeMock.mockReset();
@@ -77,12 +96,9 @@ describeWithLanNodePairingServer("gateway ssh-verified node pairing auto-approve
     lockApproval: boolean;
     next: GatewayNodePairingConfig["sshVerify"];
   }[])("keeps pairing pending when $name", async ({ name, lockApproval, next }) => {
-    await attempt({
+    await attemptWithSshVerify({
       identityName: `ssh-policy-${name.replaceAll(" ", "-")}`,
-      configure: async () => {
-        await writeConfigFile({ gateway: { nodes: { pairing: { sshVerify: true } } } });
-      },
-      run: async ({ loaded, connectNode }) => {
+      run: async ({ lanIp, loaded, connectNode }) => {
         const probe = createDeferred<NodeIdentityProbeResult>();
         const lock = createDeferred();
         const locked = createDeferred();
@@ -114,7 +130,12 @@ describeWithLanNodePairingServer("gateway ssh-verified node pairing auto-approve
             ...current,
             gateway: {
               ...current?.gateway,
-              nodes: { ...current?.gateway?.nodes, pairing: { sshVerify: next } },
+              nodes: {
+                ...current?.gateway?.nodes,
+                pairing: {
+                  sshVerify: typeof next === "object" ? createSshVerifyConfig(lanIp, next) : next,
+                },
+              },
             },
           });
           probe.resolve({
@@ -145,7 +166,7 @@ describeWithLanNodePairingServer("gateway ssh-verified node pairing auto-approve
   });
 
   test("approves device pairing and the first capability surface on a key match", async () => {
-    await attempt({
+    await attemptWithSshVerify({
       identityName: "ssh-verify-key-match",
       run: async ({ lanIp, loaded, connectNode }) => {
         probeMock.mockImplementation(async () => ({
@@ -184,7 +205,7 @@ describeWithLanNodePairingServer("gateway ssh-verified node pairing auto-approve
   });
 
   test("does not ssh-approve a pending request that carries scopes from an earlier attempt", async () => {
-    await attempt({
+    await attemptWithSshVerify({
       identityName: "ssh-verify-scoped-refresh",
       run: async ({ loaded, connectNode }) => {
         // Seed a scoped pending request (as an earlier interactive attempt
@@ -218,7 +239,7 @@ describeWithLanNodePairingServer("gateway ssh-verified node pairing auto-approve
   });
 
   test("leaves the pairing pending when the remote identity does not match", async () => {
-    await attempt({
+    await attemptWithSshVerify({
       identityName: "ssh-verify-key-mismatch",
       run: async ({ loaded, connectNode }) => {
         // A different key than the pending request: assembled from words so the
@@ -251,7 +272,7 @@ describeWithLanNodePairingServer("gateway ssh-verified node pairing auto-approve
   });
 
   test("sshVerify: false disables the probe and keeps default reconnect pause behavior", async () => {
-    await attempt({
+    await attemptWithSshVerify({
       identityName: "ssh-verify-disabled",
       configure: async () => {
         await writeConfigFile({


### PR DESCRIPTION
Related: #137201

## What Problem This Solves

The LAN node-pairing fixture connects through the host's actual LAN address, but the SSH-verification cases relied on the default probe CIDRs. On hosts whose selected LAN address is outside those defaults, the fixture can reject the probe before exercising SSH-verified pairing.

## Why This Change Was Made

Configure each SSH-verification attempt with the selected LAN address as an exact `/32`, while preserving case-specific overrides and the explicit disabled path. This reconstructs the focused prerequisite from `270e2c485e7391cc8b5b09d48da6e553cdbaa005` on the post-benchmark-prep main base.

## User Impact

No production behavior changes. Gateway pairing tests now exercise the intended LAN-origin SSH verification path consistently, providing an equalized fixture for the Vitest 5 migration benchmark.

## Evidence

Test-audit authoring gate:

- Observable invariant: the LAN self-connect fixture must make its observed LAN client address eligible for SSH verification while preserving policy overrides and `sshVerify: false`.
- Credible pre-fix failure: a selected LAN address outside the default probe CIDRs suppresses the SSH probe, so the suite does not exercise auto-approval.
- Existing coverage gap: the cases enabled `sshVerify: true` and asserted the probe host, but never scoped eligibility to the fixture's dynamic LAN address.
- Production seam: none; this changes one test file only.

Validation:

- Exact base: `bf90b12fe5156fdcb4c65d4c6500da530198b09c`
- Exact head: `af66221315e661ecf027aca3c255a7f162a668fe`
- Stable patch ID matches the source commit: `ba722bd5f4d9e8f913a00b3a383f5aca39bfbfac`
- `node_modules/.bin/oxfmt --check src/gateway/server.node-pairing-ssh-verify.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/server.node-pairing-ssh-verify.test.ts`
- `node scripts/check-no-conflict-markers.mjs`
- `node --import ./scripts/tsx.mjs scripts/check-max-lines-ratchet.mts --base origin/main`
- `node --import ./scripts/tsx.mjs scripts/check-assertion-safety-ratchet.mts --base origin/main`
- `node scripts/check-changed.mjs --dry-run -- src/gateway/server.node-pairing-ssh-verify.test.ts` classified the change as `coreTests`
- `git diff HEAD^ HEAD --check`

Focused proof gap:

- `pnpm test src/gateway/server.node-pairing-ssh-verify.test.ts` was attempted before and after the change, but the shared worktree dependencies fail before test collection because `mdast-util-from-markdown`, `mdast-util-gfm-table`, `micromark-extension-gfm-table`, `markdown-it-cjk-friendly`, and `libphonenumber-js` are missing. Per worktree policy, no install or `node_modules` mutation was performed.
- `node scripts/run-tsgo-core-test-shards.mjs` cannot run from this sparse worktree because tracked `ui/config` inputs are omitted. Hosted exact-head CI remains the full-environment proof.

LOC:

- Production: `+0/-0`
- Tests: `+31/-10`
