### PR TITLE
fix(test): await target EOF settlement

### DIFF
--- a/src/node-host/node-stream-transport.test.ts
+++ b/src/node-host/node-stream-transport.test.ts
@@ -148,7 +148,11 @@ describe.each([false, true])("node stream TLS (managed proxy: %s)", (managed) =>
       });
       try {
         if (correctPin) {
-          await expect.poll(() => frames).toEqual([JSON.stringify({ ok: true }), "stream-echo"]);
+          if (closeMode === "target-eof") {
+            await running;
+          } else {
+            await expect.poll(() => frames).toEqual([JSON.stringify({ ok: true }), "stream-echo"]);
+          }
           expect(failure).toBeUndefined();
           expect(accessHeaders).toEqual(["fixture-client-secret"]);
           if (closeMode === "owner-abort") {
@@ -163,6 +167,7 @@ describe.each([false, true])("node stream TLS (managed proxy: %s)", (managed) =>
             }
           }
           await running;
+          expect(frames).toEqual([JSON.stringify({ ok: true }), "stream-echo"]);
           await expect
             .poll(async () => {
               await logCapture.flush();


### PR DESCRIPTION
Related: #137201

## What Problem This Solves

Resolves an ordering-sensitive node stream test failure where the target-EOF case could inspect delivered frames before the transport lifecycle had reached its terminal state.

## Why This Change Was Made

The target-EOF path now awaits the transport owner before checking the delivered frames. Other close paths retain their existing polling behavior, and the shared post-settlement assertion verifies the same exact metadata and echo frames for every successful case.

## User Impact

No production or user-visible behavior changes. This keeps the node stream lifecycle suite deterministic for the Vitest 5 migration baseline.

## Evidence

### Test Audit Authoring Gate

- Observable invariant: after a successful node stream reaches terminal settlement, it has delivered exactly the metadata frame and echoed stream frame.
- Credible pre-fix failure: target EOF can settle the transport while the test is still sampling an intermediate `frames` array, causing a scheduling-dependent assertion failure despite correct terminal output.
- Existing coverage gap: every successful close mode used the same pre-settlement poll, while target EOF is the only case whose target owns termination. Normal runs often schedule frame delivery first, so the race is intermittent.
- Production seam: none. The change only reorders assertions in the existing owner-boundary test.
- Focused proof: `node scripts/run-vitest.mjs src/node-host/node-stream-transport.test.ts` - 1 file passed, 30 tests passed.
- Production versus test LOC: production +0/-0; tests +6/-1.

### Checks

- `node_modules/.bin/oxfmt --check src/node-host/node-stream-transport.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/node-host/node-stream-transport.test.ts`
- `node scripts/check-changed.mjs --dry-run -- src/node-host/node-stream-transport.test.ts` - classified as `coreTests`.
- `git diff --check`

Mandatory exact-head autoreview is pending after draft PR creation.
