### PR TITLE
test: isolate stateful test mock helpers

### DIFF
--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -251,6 +251,7 @@ describe("unit-fast vitest lane", () => {
 
   it("keeps untracked tests in their planned fast lane and execution include list", () => {
     const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-untracked-")));
+    const mockHelper = "src/hooks/mock-helper.test.ts";
     const pure = "src/hooks/pure.test.ts";
     const stateful = "src/hooks/stateful.test.ts";
     const quoted = "src/hooks/quoted-[é].test.ts";
@@ -273,9 +274,19 @@ describe("unit-fast vitest lane", () => {
         path.join(cwd, "src/hooks/stateful.test-support.ts"),
         'import { vi } from "vitest"; export const check = vi.fn();',
       );
+      fs.writeFileSync(
+        path.join(cwd, mockHelper),
+        'import { it } from "vitest"; import { check } from "./mock-helper.test-mocks.js"; it("helper", check);',
+      );
+      fs.writeFileSync(
+        path.join(cwd, "src/hooks/mock-helper.test-mocks.ts"),
+        'import { vi } from "vitest"; export const check = vi.fn();',
+      );
       expect(spawnSync("git", ["init"], { cwd }).status).toBe(0);
       expect(
-        spawnSync("git", ["ls-files", "--error-unmatch", "--", pure, stateful], { cwd }).status,
+        spawnSync("git", ["ls-files", "--error-unmatch", "--", mockHelper, pure, stateful], {
+          cwd,
+        }).status,
       ).toBe(1);
       // Fresh process: discovery snapshots must be taken after the fixture exists.
       const result = spawnNodeEvalSync(
@@ -287,7 +298,7 @@ describe("unit-fast vitest lane", () => {
         const { createUnitFastIsolatedVitestConfig } = await import(${moduleUrl("test/vitest/vitest.unit-fast-isolated.config.ts")});
         const { createScopedVitestConfig } = await import(${moduleUrl("test/vitest/vitest.scoped-config.ts")});
         const fs = await import("node:fs");
-        const specs = createVitestRunSpecs(${JSON.stringify([pure, stateful])}, { baseEnv: {} });
+        const specs = createVitestRunSpecs(${JSON.stringify([mockHelper, pure, stateful])}, { baseEnv: {} });
         const factories = {
           "test/vitest/vitest.unit-fast.config.ts": createUnitFastVitestConfig,
           "test/vitest/vitest.unit-fast-isolated.config.ts": createUnitFastIsolatedVitestConfig,
@@ -314,13 +325,16 @@ describe("unit-fast vitest lane", () => {
       );
       expect(result.status, result.stderr).toBe(0);
       expect(JSON.parse(result.stdout)).toEqual({
-        inventory: [pure, quoted, stateful],
-        isolated: [stateful],
+        inventory: [mockHelper, pure, quoted, stateful],
+        isolated: [mockHelper, stateful],
         runs: [
           { config: "test/vitest/vitest.unit-fast.config.ts", include: [pure] },
-          { config: "test/vitest/vitest.unit-fast-isolated.config.ts", include: [stateful] },
+          {
+            config: "test/vitest/vitest.unit-fast-isolated.config.ts",
+            include: [mockHelper, stateful],
+          },
         ],
-        excluded: [pure, quoted, stateful],
+        excluded: [mockHelper, pure, quoted, stateful],
         ignored: null,
         literalMembership: true,
       });
@@ -488,6 +502,7 @@ describe("unit-fast vitest lane", () => {
       "src/agents/tools/computer-tool.schema.test.ts",
       "src/agents/tools/computer-tool.v2.test.ts",
       "src/auto-reply/reply/agent-runner-execution-runtime.test.ts",
+      "src/infra/provider-usage.test.ts",
     ];
     for (const file of files) {
       const analysis = unitFastAnalysis.find((entry) => entry.file === file);

--- a/test/vitest/vitest.unit-fast-paths.mjs
+++ b/test/vitest/vitest.unit-fast-paths.mjs
@@ -263,7 +263,7 @@ const disqualifyingPatterns = [
 ];
 
 const statefulTestHelperImportPattern =
-  /\bfrom\s+["']([^"']*(?:test-support|\.harness|prepared-model-runtime\.test-harness|message-action-runner\.test-helpers|computer-tool\.test-helpers)(?:\.js|\.ts)?)["']/gu;
+  /\bfrom\s+["']([^"']*(?:test-support|\.harness|\.test-mocks|prepared-model-runtime\.test-harness|message-action-runner\.test-helpers|computer-tool\.test-helpers)(?:\.js|\.ts)?)["']/gu;
 const statefulTestHelperByKey = new Map();
 
 function importsStatefulTestHelper(cwd, file, source) {


### PR DESCRIPTION
Related: #137201

## What Problem This Solves

Tests importing stateful `*.test-mocks` helpers can remain in the shared `unit-fast` lane, where `isolate: false` allows mock state to leak between files. This is migration preparation for stable Vitest 5.

## Why This Change Was Made

The existing stateful-helper classifier now recognizes `.test-mocks` imports. The existing untracked-test routing regression covers the new helper suffix, and the audited real consumer remains asserted in the isolated lane.

No production behavior, dependency, configuration, or public API changes.

## User Impact

Developers and CI get deterministic ownership for tests backed by stateful mock helpers. Runtime users are unaffected.

## Evidence

- Pre-fix reproduction: a synthetic untracked test importing `mock-helper.test-mocks.ts` was classified as `unitFast: true` with `reasons: []`, leaving it in the shared lane.
- Focused proof: `node scripts/run-vitest.mjs run test/vitest-unit-fast-config.test.ts` — 1 file, 14 tests passed.
- Changed-file classification: `node scripts/check-changed.mjs --dry-run -- test/vitest-unit-fast-config.test.ts test/vitest/vitest.unit-fast-paths.mjs` — lanes `testRoot, tooling`.
- Changed-file gate passed conflict-marker, attribution, deprecation-registry, extension-boundary, duplicate-coverage, dependency-pin, formatting, package-patch, temp-creation, and core-boundary checks.
- Targeted Oxlint, coercion-helper guard, and script lint passed.
- `git diff --check` passed.
- Local test-root `tsgo` could not run because the required worktree uses a shared `node_modules` symlink and the checker rejects declaration inputs outside the checkout. This lane was explicitly prohibited from running `pnpm install`; exact-head CI will provide the clean-checkout type proof.

### Test Audit Authoring Gate

- Observable invariant: a test importing a stateful `*.test-mocks` helper must route to the isolated unit-fast lane, never the shared `isolate: false` lane.
- Credible pre-fix failure: shared mock history or implementations can survive into another test file and make results order-dependent under Vitest 5.
- Existing coverage gap: the routing test covered `test-support` helpers but not the `.test-mocks` naming convention used by real tests.
- Production seam: none. The repair and regression remain entirely in test routing and test support.
- Focused proof: the routing owner suite passes all 14 cases, including synthetic untracked discovery and the real `src/infra/provider-usage.test.ts` consumer.
- LOC: production `+0/-0`; test and test-support `+22/-7`.
