### PR TITLE
improve(skills): reduce payload copying for library lists

### DIFF
--- a/src/gateway/server-methods/skills-library.ts
+++ b/src/gateway/server-methods/skills-library.ts
@@ -27,7 +27,7 @@ import {
   selectSkillLibraryRow,
   projectSkillLibraryEntry,
   requireSkillLibraryEntry,
-  selectSkillLibraryRevision,
+  selectSkillLibraryRevisionMetadata,
   type SkillLibraryAuthority,
 } from "../../skills/library/store.js";
 import { resolvePluginSessionOwnershipError } from "../session-plugin-ownership.js";
@@ -98,7 +98,7 @@ export async function activateLibrarySelection(
             continue;
           }
           const entry = requireSkillLibraryEntry(db, pin.skillId, authority);
-          if (entry.removed || !selectSkillLibraryRevision(db, pin.skillId, pin.revision)) {
+          if (entry.removed || !selectSkillLibraryRevisionMetadata(db, pin.skillId, pin.revision)) {
             throw new SkillLibraryError(
               "CONFLICT",
               "Skill access changed during activation. Refresh the library and retry.",

--- a/src/skills/library/import.ts
+++ b/src/skills/library/import.ts
@@ -18,7 +18,6 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../../state/openclaw-state-db.js";
-import { selectResolvedUserProfileById } from "../../state/user-profiles-internal.js";
 import { installSkillFromClawHub } from "../lifecycle/clawhub.js";
 import {
   prepareSkillLibraryBundle,
@@ -33,6 +32,7 @@ import {
   requireSkillLibraryEntry,
   requireSkillLibraryProfile,
   requireSkillLibraryUpload,
+  selectSkillLibraryOwner,
   skillLibraryDb,
   type SkillLibraryAuthority,
 } from "./store.js";
@@ -122,7 +122,7 @@ export async function uploadSkillLibrary(
       if (
         activeUploads.length >= MAX_ACTIVE_UPLOADS ||
         activeUploads.filter(
-          (upload) => selectResolvedUserProfileById(db, upload.owner_profile_id)?.id === actor,
+          (upload) => selectSkillLibraryOwner(db, upload.owner_profile_id)?.id === actor,
         ).length >=
           MAX_ACTIVE_UPLOADS / 2
       ) {

--- a/src/skills/library/selection.ts
+++ b/src/skills/library/selection.ts
@@ -23,6 +23,7 @@ import {
   requireSkillLibraryEntry,
   resolveSkillLibraryActor,
   selectSkillLibraryRevision,
+  selectSkillLibraryRevisionMetadata,
   skillLibraryDb,
   type SkillLibraryAuthority,
 } from "./store.js";
@@ -118,7 +119,7 @@ export function seedSkillLibrarySelection(
           if (
             entry.removed ||
             !entry.enabled ||
-            !selectSkillLibraryRevision(db, pin.skillId, pin.revision)
+            !selectSkillLibraryRevisionMetadata(db, pin.skillId, pin.revision)
           ) {
             throw new SkillLibraryError(
               "CONFLICT",
@@ -165,7 +166,7 @@ export function changeSkillLibrarySelection(
         );
       }
       const revision = params.revision ?? entry.revision;
-      if (!selectSkillLibraryRevision(db, skillId, revision)) {
+      if (!selectSkillLibraryRevisionMetadata(db, skillId, revision)) {
         throw new SkillLibraryError("NOT_FOUND", "Skill revision not found.");
       }
       next.set(skillId, {
@@ -207,7 +208,11 @@ export function loadSkillLibrarySelection(
   const entries = readSkillLibraryStore(
     (db) =>
       selections.map((selection) => {
-        const revision = selectSkillLibraryRevision(db, selection.skillId, selection.revision);
+        const revision = selectSkillLibraryRevisionMetadata(
+          db,
+          selection.skillId,
+          selection.revision,
+        );
         if (!revision) {
           throw new SkillLibraryError(
             "NOT_FOUND",

--- a/src/skills/library/service.test.ts
+++ b/src/skills/library/service.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { constants } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SKILL_LIBRARY_MAX_FILE_BYTES } from "../../../packages/gateway-protocol/src/schema/skill-library.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
@@ -9,7 +10,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import { ensureProfileForEmail, linkEmail } from "../../state/user-profiles.js";
+import { ensureProfileForEmail, linkEmail, setDisplayName } from "../../state/user-profiles.js";
 import { withEnv, withEnvAsync } from "../../test-utils/env.js";
 import { materializeSkillResources, prepareSkillResourceDelivery } from "../runtime/resources.js";
 import { prepareSkillLibraryBundle, skillLibraryRevisionDir } from "./bundle.js";
@@ -182,11 +183,24 @@ describe("profile-owned skill publication and selection", () => {
       const read = await readSkillLibrary(anonymousAdmin, skillId, undefined, options);
       expect(read.content).toBe(content);
       expect(read.entry.canEdit).toBe(false);
-      expect(listSkillLibrary(anonymousAdmin, {}, options)).toMatchObject({
-        defaultTarget: "workspace",
-        canManageWorkspace: true,
-        entries: [expect.objectContaining({ skillId, canEdit: false })],
+      const { db } = openOpenClawStateDatabase(options);
+      // Presentation needs metadata; the artifact read above still needs its full manifest.
+      db.setAuthorizer((action, table, column) => {
+        return action === constants.SQLITE_READ &&
+          ((table === "user_profiles" && column === "avatar") ||
+            (table === "skill_library_revisions" && column === "files_json"))
+          ? constants.SQLITE_DENY
+          : constants.SQLITE_OK;
       });
+      try {
+        expect(listSkillLibrary(anonymousAdmin, {}, options)).toMatchObject({
+          defaultTarget: "workspace",
+          canManageWorkspace: true,
+          entries: [expect.objectContaining({ skillId, canEdit: false })],
+        });
+      } finally {
+        db.setAuthorizer(null);
+      }
       await expect(
         saveSkillLibrary(
           anonymousAdmin,
@@ -317,6 +331,7 @@ describe("profile-owned skill publication and selection", () => {
     const bob = actor(ensureProfileForEmail("bob@example.test", options).id);
     const a = await saveSkillLibrary(alice, draft(), options);
     const b = await saveSkillLibrary(bob, draft(), options);
+    setDisplayName(alice.profileId!, "Alice 雪 · 🦞", options);
     await expect(saveSkillLibrary(alice, draft(), options)).rejects.toMatchObject({
       code: "NAME_CONFLICT",
     });
@@ -326,6 +341,7 @@ describe("profile-owned skill publication and selection", () => {
       [a.entry.skillId, b.entry.skillId].toSorted(),
     );
     expect(new Set(entries.map((entry) => entry.name)).size).toBe(2);
+    expect(entries.every((entry) => entry.ownerLabel === "Alice 雪 · 🦞")).toBe(true);
     expect(
       (await readSkillLibrary(alice, b.entry.skillId, undefined, options)).entry.ownerProfileId,
     ).toBe(alice.profileId);

--- a/src/skills/library/service.ts
+++ b/src/skills/library/service.ts
@@ -42,6 +42,7 @@ import {
   requireSkillLibraryUpload,
   resolveSkillLibraryActor,
   selectSkillLibraryRevision,
+  selectSkillLibraryRevisionMetadata,
   selectSkillLibraryRow,
   skillLibraryDb,
   type SkillLibraryAuthority,
@@ -422,7 +423,7 @@ export function mutateSkillLibrary(
         case "rollback":
           if (
             !params.revision ||
-            !selectSkillLibraryRevision(db, current.skillId, params.revision)
+            !selectSkillLibraryRevisionMetadata(db, current.skillId, params.revision)
           ) {
             throw new SkillLibraryError(
               "NOT_FOUND",

--- a/src/skills/library/store.ts
+++ b/src/skills/library/store.ts
@@ -18,7 +18,11 @@ import {
   type OpenClawStateDatabaseOptions,
 } from "../../state/openclaw-state-db.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "../../state/openclaw-state-schema.js";
-import { selectResolvedUserProfileById } from "../../state/user-profiles-internal.js";
+import {
+  selectResolvedUserProfile,
+  selectResolvedUserProfileById,
+  userProfilesDb,
+} from "../../state/user-profiles-internal.js";
 import { managedSkillCommandName } from "./command-name.js";
 import { SkillLibraryError } from "./errors.js";
 
@@ -141,7 +145,7 @@ export function requireSkillLibraryUpload(
   if (
     !upload ||
     upload.expires_at <= Date.now() ||
-    selectResolvedUserProfileById(db, upload.owner_profile_id)?.id !== actor
+    selectSkillLibraryOwner(db, upload.owner_profile_id)?.id !== actor
   ) {
     throw new SkillLibraryError(
       "NOT_FOUND",
@@ -163,6 +167,13 @@ export function selectSkillLibraryRow(
       .where("skill_id", "=", skillId),
   );
 }
+function skillLibraryRevisionQuery(db: DatabaseSync, skillId: string, revision: string) {
+  return skillLibraryDb(db)
+    .selectFrom("skill_library_revisions")
+    .where("skill_id", "=", skillId)
+    .where("revision", "=", revision);
+}
+
 export function selectSkillLibraryRevision(
   db: DatabaseSync,
   skillId: string,
@@ -170,17 +181,33 @@ export function selectSkillLibraryRevision(
 ): SkillLibraryRevisionRow | undefined {
   return executeSqliteQueryTakeFirstSync(
     db,
-    skillLibraryDb(db)
-      .selectFrom("skill_library_revisions")
-      .selectAll()
-      .where("skill_id", "=", skillId)
-      .where("revision", "=", revision),
+    skillLibraryRevisionQuery(db, skillId, revision).selectAll(),
+  );
+}
+
+export function selectSkillLibraryRevisionMetadata(
+  db: DatabaseSync,
+  skillId: string,
+  revision: string,
+) {
+  return executeSqliteQueryTakeFirstSync(
+    db,
+    skillLibraryRevisionQuery(db, skillId, revision).select("description"),
+  );
+}
+
+export function selectSkillLibraryOwner(db: DatabaseSync, profileId: string) {
+  // Actor resolution stays separate because existing profile tables may omit its optional role.
+  return selectResolvedUserProfile(
+    db,
+    profileId,
+    userProfilesDb(db).selectFrom("user_profiles").select(["id", "display_name", "merged_into"]),
   );
 }
 
 function canonicalOwner(db: DatabaseSync, owner: string | null): string | null {
   return owner && tableExists(db, "user_profiles")
-    ? (selectResolvedUserProfileById(db, owner)?.id ?? owner)
+    ? (selectSkillLibraryOwner(db, owner)?.id ?? owner)
     : owner;
 }
 
@@ -203,7 +230,7 @@ export function projectSkillLibraryEntry(
   ) {
     return undefined;
   }
-  const metadata = selectSkillLibraryRevision(db, row.skill_id, revision);
+  const metadata = selectSkillLibraryRevisionMetadata(db, row.skill_id, revision);
   if (!metadata) {
     return undefined;
   }
@@ -212,7 +239,7 @@ export function projectSkillLibraryEntry(
     slug: row.slug,
     name: managedSkillCommandName(row.slug, row.skill_id),
     ownerLabel:
-      owner === null ? "Team" : (selectResolvedUserProfileById(db, owner)?.display_name ?? owner),
+      owner === null ? "Team" : (selectSkillLibraryOwner(db, owner)?.display_name ?? owner),
     description: metadata.description,
     ownerProfileId: owner,
     authorProfileId: row.author_profile_id,


### PR DESCRIPTION
## What Problem This Solves

Skill-library lists and new-session defaults copied profile avatars and full revision manifests while using only owner IDs, display names, and descriptions. Repeated metadata reads made those synchronous operations allocate payloads proportional to the library size.

## Why This Change Was Made

Reuse the existing merge-aware profile reader with a small owner projection, and share the exact revision-key query between description-only metadata reads and full artifact reads. All six metadata/existence consumers use the narrow projection; the two artifact consumers keep full manifests. Actor-role resolution, upload archive reads, authority checks, profile merging, quotas, and selection ordering remain unchanged.

## User Impact

Library contents, permissions, immutable pins, and import behavior stay the same. A synthetic 32-skill fixture now copies 34.08 MiB less payload for each list or new-session default operation. This measures avoided payload copies, not peak RSS or a claimed latency improvement.

## Evidence

- Node 24.20.0 native before/after: avatar rows 97 → 33 and manifest rows 32 → 0 for both list and seed. List queries/authority callbacks remain 131/35; seed remains 130/33. The retained actor reads preserve optional legacy role-column behavior.
- Extended existing ACL coverage with SQLite's real authorizer: the original code fails when metadata listing is denied access to avatar/manifest payloads; the candidate passes. Merged-owner coverage also verifies a Unicode display label.
- 54 focused tests passed across service, persistence, Gateway projection/authoring, and CLI owners with two workers. Full `check-changed` passed, including core/test types, lint, schema guards, dead exports, and import cycles.
- Real isolated Gateway behind an authenticated loopback proxy: two process starts verified Unicode owner/description, private/team list order, new-session pins, detach/attach, revision rollback, and exact 70 KiB binary plus executable metadata for a removed pin after restart. Gateway and proxy shut down cleanly.

Production +51/-18 (net +33); tests +21/-5 (net +16). The added production lines provide the two metadata projections and shared keyed query owner. Upload authorization's archive hydration remains a separate follow-up.

Independent Codex review completed five passes with no P0–P2 findings. Full current/base owners, direct dependency sources, native harnesses and live proof were included. The live trace records RPC method success and harness assertions; it is not a full WebSocket frame capture.
