### PR TITLE
improve(sessions): reduce suggestion query row copying

### DIFF
--- a/src/config/sessions/session-suggestion-store.test.ts
+++ b/src/config/sessions/session-suggestion-store.test.ts
@@ -183,7 +183,11 @@ describe("session suggestion store", () => {
     });
   });
 
-  it("bounds pending suggestions per author", async () => {
+  it.each([
+    ["ordinary", "alice", true],
+    ["embedded NUL", "a\0b", true],
+    ["lone surrogate", "\ud800", false],
+  ] as const)("bounds pending suggestions for %s author IDs", async (_, authorId, capped) => {
     await withTestDir({ prefix: "openclaw-session-suggestions-limit-" }, async (dir) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
       const scope = { agentId: "main", env, sessionKey: "agent:main:main" };
@@ -191,18 +195,22 @@ describe("session suggestion store", () => {
       for (let index = 0; index < MAX_PENDING_SESSION_SUGGESTIONS_PER_AUTHOR; index += 1) {
         addSessionSuggestion(scope, {
           id: `suggestion-${index}`,
-          authorId: "alice",
+          authorId,
           text: `idea ${index}`,
           expectedSessionId: "session-a",
         });
       }
-      expect(() =>
+      const addAtLimit = () =>
         addSessionSuggestion(scope, {
-          authorId: "alice",
+          authorId,
           text: "one too many",
           expectedSessionId: "session-a",
-        }),
-      ).toThrow(/author pending suggestion limit/);
+        });
+      if (capped) {
+        expect(addAtLimit).toThrow(/author pending suggestion limit/);
+      } else {
+        expect(addAtLimit).not.toThrow();
+      }
 
       resolvePendingSuggestion({
         scope,
@@ -212,11 +220,39 @@ describe("session suggestion store", () => {
       });
       expect(() =>
         addSessionSuggestion(scope, {
-          authorId: "alice",
+          authorId,
           text: "replacement",
           expectedSessionId: "session-a",
         }),
       ).not.toThrow();
+    });
+  });
+
+  it("checks the session cap before the author cap and frees admission after resolution", async () => {
+    await withTestDir({ prefix: "openclaw-session-suggestions-session-limit-" }, async (dir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+      const scope = { agentId: "main", env, sessionKey: "agent:main:main" };
+      await upsertSessionEntryCore(scope, { sessionId: "session-a", updatedAt: 1 });
+      for (let index = 0; index < 100; index += 1) {
+        addSessionSuggestion(scope, {
+          id: `suggestion-${index}`,
+          authorId: `author-${Math.floor(index / MAX_PENDING_SESSION_SUGGESTIONS_PER_AUTHOR)}`,
+          text: "idea",
+          expectedSessionId: "session-a",
+        });
+      }
+      const add = (authorId: string) =>
+        addSessionSuggestion(scope, { authorId, text: "next", expectedSessionId: "session-a" });
+      expect(() => add("author-0")).toThrow("session pending suggestion limit reached");
+      resolvePendingSuggestion({
+        scope,
+        id: "suggestion-20",
+        state: "dismissed",
+        expectedSessionId: "session-a",
+      });
+      expect(() => add("author-0")).toThrow("author pending suggestion limit reached");
+      expect(() => add("author-1")).not.toThrow();
+      expect(listSessionSuggestions(scope, { pendingOnly: true })).toHaveLength(100);
     });
   });
 
@@ -226,18 +262,18 @@ describe("session suggestion store", () => {
       const scope = { agentId: "main", env, sessionKey: "agent:main:main" };
       await upsertSessionEntryCore(scope, { sessionId: "session-a", updatedAt: 1 });
       for (let index = 0; index <= MAX_RETAINED_RESOLVED_SESSION_SUGGESTIONS; index += 1) {
-        const id = `resolved-${index}`;
+        const id = index === 0 ? "z-oldest" : index === 1 ? "a-oldest" : `resolved-${index}`;
         addSessionSuggestion(scope, {
           id,
           authorId: "alice",
           text: `resolved ${index}`,
-          createdAt: index + 1,
+          createdAt: index < 2 ? 1 : index + 1,
           expectedSessionId: "session-a",
         });
         resolvePendingSuggestion({
           scope,
           id,
-          state: "dismissed",
+          state: index % 2 === 0 ? "accepted" : "dismissed",
           expectedSessionId: "session-a",
         });
       }
@@ -245,7 +281,8 @@ describe("session suggestion store", () => {
       expect(rows.filter((row) => row.state !== "pending")).toHaveLength(
         MAX_RETAINED_RESOLVED_SESSION_SUGGESTIONS,
       );
-      expect(rows.some((row) => row.id === "resolved-0")).toBe(false);
+      expect(rows.some((row) => row.id === "a-oldest")).toBe(false);
+      expect(rows.some((row) => row.id === "z-oldest")).toBe(true);
     });
   });
 

--- a/src/config/sessions/session-suggestion-store.ts
+++ b/src/config/sessions/session-suggestion-store.ts
@@ -87,8 +87,11 @@ function pruneResolvedSessionSuggestions(
       .where("session_key", "=", sessionKey)
       .where("state", "!=", "pending")
       .orderBy("created_at", "desc")
-      .orderBy("id", "desc"),
-  ).rows.slice(MAX_RETAINED_RESOLVED_SESSION_SUGGESTIONS);
+      .orderBy("id", "desc")
+      // SQLite requires LIMIT for OFFSET; -1 preserves the unbounded deletion tail.
+      .limit((eb) => eb.lit(-1))
+      .offset((eb) => eb.lit(MAX_RETAINED_RESOLVED_SESSION_SUGGESTIONS)),
+  ).rows;
   if (resolvedRows.length === 0) {
     return;
   }
@@ -133,21 +136,27 @@ export function addSessionSuggestion(
     assertSessionInstance(database, sessionKey, params.expectedSessionId);
     const db = suggestionDb(database);
     pruneResolvedSessionSuggestions(database, sessionKey);
-    const pendingRows = executeSqliteQuerySync(
+    // Compare decoded IDs in JS; binding the author here changes malformed-ID
+    // matching and can move binding errors ahead of the session-cap error.
+    const pendingCounts = executeSqliteQuerySync(
       database.db,
       db
         .selectFrom("session_suggestions")
-        .select("author_id")
+        .select((eb) => ["author_id", eb.fn.countAll<number>().as("count")])
         .where("session_key", "=", sessionKey)
-        .where("state", "=", "pending"),
-    ).rows;
-    if (pendingRows.length >= MAX_PENDING_SESSION_SUGGESTIONS_PER_SESSION) {
+        .where("state", "=", "pending")
+        .groupBy("author_id"),
+    ).rows.reduce(
+      (counts, row) => ({
+        session: counts.session + row.count,
+        author: counts.author + (row.author_id === suggestion.authorId ? row.count : 0),
+      }),
+      { session: 0, author: 0 },
+    );
+    if (pendingCounts.session >= MAX_PENDING_SESSION_SUGGESTIONS_PER_SESSION) {
       throw new Error("session pending suggestion limit reached");
     }
-    if (
-      pendingRows.filter((row) => row.author_id === suggestion.authorId).length >=
-      MAX_PENDING_SESSION_SUGGESTIONS_PER_AUTHOR
-    ) {
+    if (pendingCounts.author >= MAX_PENDING_SESSION_SUGGESTIONS_PER_AUTHOR) {
       throw new Error("author pending suggestion limit reached");
     }
     executeSqliteQuerySync(


### PR DESCRIPTION
## What Problem This Solves

Session suggestion admission copied every pending author row to count limits, and retention reads copied the 200 rows they would immediately skip. Both synchronous paths did unnecessary row materialization inside their existing transactions.

## Why This Change Was Made

Have SQLite return grouped pending counts and only the resolved deletion tail. Keep the same expanded-ID DELETE, ordering, empty-tail early return, bound user values, session-cap-before-author-cap errors, and native-decoded author comparison. Literal pagination constants consume no additional bind slots. The eight other store functions, instance identity helper, schema, retention limits and transaction boundaries are unchanged.

Production grows by nine lines to preserve these error and binding contracts while narrowing results; existing tests grow by 37 lines. SQLite's unbounded LIMIT idiom remains explicit. This does not enable a PostgreSQL backend.

## User Impact

Suggestion results, admission limits, retained history and rollback behavior stay the same. In the native fixture, an add with 201 resolved and 100 pending suggestions copies 7 rows instead of 302 across the same three reads; finalization with 200 resolved rows copies 3 instead of 203. Grouping returns one row per distinct author and adds a GROUP BY temporary B-tree, so the benefit depends on the author distribution. No latency improvement is claimed.

## Evidence

- 32 owner/Gateway tests pass. Extended preservation cases also pass the original code. The full changed gate and qaRuntime build pass.
- 47 actual exported-owner scenarios match baseline results and stored-state hashes, with 94 fresh-process readbacks in total. Coverage includes ties, native text decoding, cap precedence, bind limits, trigger failures, nested rollback, finalization and stale instance rejection.
- Eight additional native error/callback scenarios match exact messages, codes and callback object identity.
- A real built Gateway passed 60 RPCs across restart on its first attempt, covering author/session caps, resolution freeing admission, tied retention ordering and exact reopened lists/rows. Native observation confirms reads and the one deletion remain inside transactions. No provider dispatch or transcript write occurred; synthetic state, processes and listener were cleaned up.
- Independent Codex review completed seven passes with no P0–P2 findings. Root inspected the complete affected owners, direct SQLite/Kysely contracts, full proof harnesses and final receipts.
