### PR TITLE
fix(ui): recover Nostr profile requests with saved credentials

### DIFF
--- a/ui/src/app/control-ui-auth.test.ts
+++ b/ui/src/app/control-ui-auth.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  resolveControlUiAuthCandidates,
-  resolveControlUiAuthHeader,
-  resolveControlUiAuthToken,
-} from "./control-ui-auth.ts";
+import { resolveControlUiAuthCandidates, resolveControlUiAuthToken } from "./control-ui-auth.ts";
 
 describe("Control UI credentials", () => {
   it.each([
@@ -60,6 +56,5 @@ describe("Control UI credentials", () => {
   ])("$name", ({ source, expected }) => {
     expect(resolveControlUiAuthCandidates(source)).toEqual(expected);
     expect(resolveControlUiAuthToken(source)).toBe(expected[0] ?? null);
-    expect(resolveControlUiAuthHeader(source)).toBe(expected[0] ? `Bearer ${expected[0]}` : null);
   });
 });

--- a/ui/src/app/control-ui-auth.ts
+++ b/ui/src/app/control-ui-auth.ts
@@ -20,7 +20,35 @@ export function resolveControlUiAuthToken(source: ControlUiAuthSource): string |
   return resolveControlUiAuthCandidates(source)[0] ?? null;
 }
 
-export function resolveControlUiAuthHeader(source: ControlUiAuthSource): string | null {
-  const token = resolveControlUiAuthToken(source);
-  return token ? `Bearer ${token}` : null;
+export async function fetchWithControlUiAuth(
+  url: string,
+  init: Omit<RequestInit, "headers" | "signal"> & {
+    headers?: Record<string, string>;
+    signal: AbortSignal;
+  },
+  authCandidates: readonly string[],
+  isCurrent: () => boolean,
+): Promise<Response> {
+  const candidates = authCandidates.length ? authCandidates : [""];
+  const readOnly = !init.method || init.method === "GET" || init.method === "HEAD";
+  for (let index = 0; ; index++) {
+    init.signal.throwIfAborted();
+    if (!isCurrent()) {
+      throw new DOMException("Gateway request is no longer current", "AbortError");
+    }
+    const token = candidates[index];
+    const response = await fetch(url, {
+      ...init,
+      ...(token ? { headers: { ...init.headers, Authorization: `Bearer ${token}` } } : {}),
+    });
+    init.signal.throwIfAborted();
+    // A mutation's 403 is a scope/origin rejection, not a rejected credential.
+    if (
+      index === candidates.length - 1 ||
+      (response.status !== 401 && !(readOnly && response.status === 403))
+    ) {
+      return response;
+    }
+    void response.body?.cancel().catch(() => undefined);
+  }
 }

--- a/ui/src/lib/identity-avatar-context.ts
+++ b/ui/src/lib/identity-avatar-context.ts
@@ -1,4 +1,5 @@
 import { normalizeBasePath } from "../app-route-paths.ts";
+import { fetchWithControlUiAuth } from "../app/control-ui-auth.ts";
 import { isConfiguredUiDevGateway } from "../dev-gateway.ts";
 
 // Gateway startup owns connection context; avatar presentation stays in lazy views.
@@ -36,21 +37,17 @@ export async function fetchGatewayContextResource(
     throw new Error("Resource must belong to the connected Gateway");
   }
   const signal = AbortSignal.any([gatewayRequests.signal, AbortSignal.timeout(timeoutMs)]);
-  for (const token of appGatewayAuthTokens.length ? appGatewayAuthTokens : [""]) {
-    signal.throwIfAborted();
-    const response = await fetch(url, {
-      credentials: "include",
-      ...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
-      signal,
-    });
-    if (signal.aborted || response.status === 401 || response.status === 403) {
-      await response.body?.cancel();
-      signal.throwIfAborted();
-      continue;
-    }
-    return response;
+  const response = await fetchWithControlUiAuth(
+    url,
+    { credentials: "include", signal },
+    appGatewayAuthTokens,
+    () => true,
+  );
+  if (response.status === 401 || response.status === 403) {
+    await response.body?.cancel();
+    throw new Error("Gateway credentials rejected");
   }
-  throw new Error("Gateway credentials rejected");
+  return response;
 }
 
 function toHttpOrigin(url: string | null | undefined): string | null {

--- a/ui/src/pages/channels/channels-page.test.ts
+++ b/ui/src/pages/channels/channels-page.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
-import type { NostrProfile } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { createChannelCapability } from "../../lib/channels/index.ts";
 import { createRuntimeConfigCapability } from "../../lib/config/runtime-config-capability.ts";
@@ -21,19 +20,6 @@ type PairingTestPage = ChannelsPageTestElement & {
   pairingPrompt: object | null;
 };
 
-type NostrTestPage = ChannelsPageTestElement & {
-  nostrProfileFormState: {
-    values: NostrProfile;
-    saving: boolean;
-    importing: boolean;
-    error: string | null;
-  } | null;
-  nostrProfileAccountId: string | null;
-  editNostrProfile: (accountId: string, profile: NostrProfile | null) => void;
-  saveNostrProfile: () => Promise<void>;
-  importNostrProfile: () => Promise<void>;
-};
-
 type TestGateway = ApplicationContext["gateway"] & {
   emit: (patch: Partial<ApplicationGatewaySnapshot>) => void;
 };
@@ -46,7 +32,7 @@ function stubHangingFetch() {
         if (!signal) {
           throw new Error("Expected Nostr profile request to carry an AbortSignal");
         }
-        signal.addEventListener("abort", () => reject(signal.reason as Error), { once: true });
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
       }),
   );
   vi.stubGlobal("fetch", fetchMock);
@@ -130,6 +116,60 @@ function createContext(gateway: ApplicationContext["gateway"]) {
   return { context, ensureSchemaLoaded, runtimeConfig, channels };
 }
 
+function profileButton(page: HTMLElement, label: string): HTMLButtonElement {
+  const button = Array.from(page.querySelectorAll("button")).find(
+    (entry) => entry.textContent?.trim() === label,
+  );
+  if (!button) {
+    throw new Error(`Missing action: ${label}`);
+  }
+  return button;
+}
+
+async function editProfileName(page: ChannelsPageTestElement, value: string) {
+  const name = page.querySelector<HTMLInputElement>("#nostr-profile-name");
+  if (!name) {
+    throw new Error("Missing profile name");
+  }
+  name.value = value;
+  name.dispatchEvent(new Event("input", { bubbles: true }));
+  await page.updateComplete;
+}
+
+async function mountNostrProfile() {
+  const gateway = createGateway();
+  gateway.connection.token = "saved-token";
+  gateway.snapshot.hello = {
+    type: "hello-ok",
+    protocol: 3,
+    auth: { role: "operator", scopes: ["operator.admin"], deviceToken: "device-token" },
+  };
+  const source = createContext(gateway);
+  const refresh = vi.spyOn(source.channels, "refresh").mockResolvedValue();
+  source.channels.state.channelsSnapshot = {
+    ts: 0,
+    channelOrder: ["nostr"],
+    channelLabels: { nostr: "Nostr" },
+    channels: { nostr: { configured: true, profile: { name: "Alice" } } },
+    channelAccounts: {},
+    channelDefaultAccountId: {},
+  };
+  const page = document.createElement("openclaw-channels-page") as ChannelsPageTestElement;
+  page.context = source.context;
+  document.body.append(page);
+  await page.updateComplete;
+  const channel = page.querySelector<HTMLButtonElement>(".channels-item");
+  if (!channel) {
+    throw new Error("Missing Nostr channel");
+  }
+  channel.click();
+  await page.updateComplete;
+  profileButton(page, "Edit Profile").click();
+  await page.updateComplete;
+  await editProfileName(page, "Alice Updated");
+  return { gateway, source, refresh, page };
+}
+
 afterEach(() => {
   document.body.replaceChildren();
   vi.unstubAllGlobals();
@@ -148,23 +188,6 @@ describe("ChannelsPage lifecycle", () => {
   ] as const)(
     "handles credentials through rendered %s after %s then %s",
     async (action, firstStatus, nextStatus) => {
-      const gateway = createGateway();
-      gateway.connection.token = "saved-token";
-      gateway.snapshot.hello = {
-        type: "hello-ok",
-        protocol: 3,
-        auth: { role: "operator", scopes: ["operator.admin"], deviceToken: "device-token" },
-      };
-      const source = createContext(gateway);
-      vi.spyOn(source.channels, "refresh").mockResolvedValue();
-      source.channels.state.channelsSnapshot = {
-        ts: 0,
-        channelOrder: ["nostr"],
-        channelLabels: { nostr: "Nostr" },
-        channels: { nostr: { configured: true, profile: { name: "Alice" } } },
-        channelAccounts: {},
-        channelDefaultAccountId: {},
-      };
       const fetchMock = vi
         .fn<typeof fetch>()
         .mockResolvedValueOnce(new Response(null, { status: firstStatus }))
@@ -174,31 +197,8 @@ describe("ChannelsPage lifecycle", () => {
             : new Response(null, { status: nextStatus }),
         );
       vi.stubGlobal("fetch", fetchMock);
-      const page = document.createElement("openclaw-channels-page") as ChannelsPageTestElement;
-      page.context = source.context;
-      document.body.append(page);
-      await page.updateComplete;
-      page.querySelector<HTMLButtonElement>(".channels-item")?.click();
-      await page.updateComplete;
-      const click = (label: string) => {
-        const button = Array.from(page.querySelectorAll("button")).find(
-          (entry) => entry.textContent?.trim() === label,
-        );
-        if (!button) {
-          throw new Error(`Missing action: ${label}`);
-        }
-        button.click();
-      };
-      click("Edit Profile");
-      await page.updateComplete;
-      const name = page.querySelector<HTMLInputElement>("#nostr-profile-name");
-      if (!name) {
-        throw new Error("Missing profile name");
-      }
-      name.value = "Alice Updated";
-      name.dispatchEvent(new Event("input", { bubbles: true }));
-      await page.updateComplete;
-      click(action);
+      const { source, page } = await mountNostrProfile();
+      profileButton(page, action).click();
       const recovered = firstStatus === 401 && nextStatus === 200;
       await vi.waitFor(() =>
         expect(page.textContent).toContain(
@@ -737,161 +737,135 @@ describe("ChannelsPage lifecycle", () => {
     source.channels.dispose();
   });
 
-  it.each([200, 401])(
-    "drops a profile save after source replacement and status %s",
-    async (status) => {
-      const gateway = createGateway();
-      gateway.connection.token = "first-token";
-      gateway.connection.password = "saved-password";
-      const first = createContext(gateway);
-      const second = createContext(gateway);
-      const firstRefresh = vi.spyOn(first.channels, "refresh").mockResolvedValue();
-      const secondRefresh = vi.spyOn(second.channels, "refresh").mockResolvedValue();
+  it.each([
+    ["Save & Publish", "source replacement", 200],
+    ["Save & Publish", "source replacement", 401],
+    ["Import from Relays", "disconnect", 200],
+    ["Import from Relays", "disconnect", 401],
+    ["Import from Relays", "cancel", 401],
+    ["Import from Relays", "replacement form", 200],
+    ["Import from Relays", "replacement form", 401],
+    ["Save & Publish", "credential/client replacement", 401],
+    ["Import from Relays", "credential/client replacement", 401],
+    ["Save & Publish", "unmount", 401],
+    ["Import from Relays", "unmount", 401],
+  ] as const)(
+    "retires rendered %s after %s before pending %s",
+    async (action, retirement, status) => {
+      vi.useFakeTimers();
       const response = createDeferred<Response>();
-      const fetchMock = vi.fn(() => response.promise);
+      const fetchMock = vi.fn<typeof fetch>(() => response.promise);
       vi.stubGlobal("fetch", fetchMock);
-      const page = document.createElement("openclaw-channels-page") as NostrTestPage;
-      page.context = first.context;
-      document.body.append(page);
+      const { gateway, source, refresh, page } = await mountNostrProfile();
+      const second = createContext(gateway);
+      const secondRefresh = vi.spyOn(second.channels, "refresh").mockResolvedValue();
+      profileButton(page, action).click();
       await page.updateComplete;
-      page.editNostrProfile("old-account", { name: "old" });
-
-      const save = page.saveNostrProfile();
-      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
-      page.context = second.context;
-      page.requestUpdate();
-      await page.updateComplete;
-      expect(page.nostrProfileFormState).toBeNull();
-
-      response.resolve(
-        new Response(JSON.stringify({ ok: true, persisted: true }), {
-          status,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
-      await save;
-
-      expect(page.nostrProfileFormState).toBeNull();
-      expect(firstRefresh).not.toHaveBeenCalled();
-      expect(secondRefresh).not.toHaveBeenCalled();
       expect(fetchMock).toHaveBeenCalledOnce();
-      first.runtimeConfig.dispose();
+
+      switch (retirement) {
+        case "source replacement":
+          page.context = second.context;
+          page.requestUpdate();
+          break;
+        case "disconnect":
+          gateway.emit({ phase: "stopped" });
+          break;
+        case "cancel":
+        case "replacement form":
+          expect(profileButton(page, "Cancel").disabled).toBe(false);
+          profileButton(page, "Cancel").click();
+          break;
+        case "credential/client replacement":
+          gateway.connection.token = "rotated-token";
+          gateway.emit({ client: createGateway().snapshot.client });
+          break;
+        case "unmount":
+          page.remove();
+          break;
+      }
+      await page.updateComplete;
+      expect(page.querySelector("#nostr-profile-name")).toBeNull();
+      if (retirement === "replacement form") {
+        profileButton(page, "Edit Profile").click();
+        await page.updateComplete;
+        await editProfileName(page, "Fresh draft");
+      }
+      if (retirement === "credential/client replacement") {
+        await vi.advanceTimersByTimeAsync(0);
+        // Reconnection refreshes the new client before the retired request settles.
+        refresh.mockClear();
+        secondRefresh.mockClear();
+      }
+      response.resolve(
+        Response.json(
+          { ok: true, persisted: true, saved: true, merged: { name: "Stale import" } },
+          { status },
+        ),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      await page.updateComplete;
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(refresh).not.toHaveBeenCalled();
+      expect(secondRefresh).not.toHaveBeenCalled();
+      expect(page.textContent).not.toContain("Profile published");
+      expect(page.textContent).not.toContain("Profile imported");
+      expect(page.textContent).not.toContain("Last error");
+      if (retirement === "replacement form") {
+        expect(page.querySelector<HTMLInputElement>("#nostr-profile-name")?.value).toBe(
+          "Fresh draft",
+        );
+        expect(profileButton(page, "Import from Relays").disabled).toBe(false);
+      } else {
+        expect(page.querySelector("#nostr-profile-name")).toBeNull();
+      }
+      source.runtimeConfig.dispose();
+      source.channels.dispose();
       second.runtimeConfig.dispose();
-      first.channels.dispose();
       second.channels.dispose();
     },
   );
 
-  it.each([200, 401])("drops a profile import after disconnect and status %s", async (status) => {
-    const gateway = createGateway();
-    gateway.connection.token = "first-token";
-    gateway.connection.password = "saved-password";
-    const source = createContext(gateway);
-    const refresh = vi.spyOn(source.channels, "refresh").mockResolvedValue();
-    const response = createDeferred<Response>();
-    const fetchMock = vi.fn(() => response.promise);
-    vi.stubGlobal("fetch", fetchMock);
-    const page = document.createElement("openclaw-channels-page") as NostrTestPage;
-    page.context = source.context;
-    document.body.append(page);
-    await page.updateComplete;
-    page.editNostrProfile("old-account", { name: "old" });
-
-    const load = page.importNostrProfile();
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
-    gateway.emit({ phase: "stopped" });
-    expect(page.nostrProfileFormState).toBeNull();
-
-    response.resolve(
-      new Response(JSON.stringify({ ok: true, saved: true, merged: { name: "stale import" } }), {
-        status,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
-    await load;
-
-    expect(page.nostrProfileFormState).toBeNull();
-    expect(refresh).not.toHaveBeenCalled();
-    expect(fetchMock).toHaveBeenCalledOnce();
-    source.runtimeConfig.dispose();
-    source.channels.dispose();
-  });
-
-  it("does not overwrite a replacement profile form", async () => {
-    const gateway = createGateway();
-    const source = createContext(gateway);
-    const refresh = vi.spyOn(source.channels, "refresh").mockResolvedValue();
-    const response = createDeferred<Response>();
-    const fetchMock = vi.fn(() => response.promise);
-    vi.stubGlobal("fetch", fetchMock);
-    const page = document.createElement("openclaw-channels-page") as NostrTestPage;
-    page.context = source.context;
-    document.body.append(page);
-    await page.updateComplete;
-    page.editNostrProfile("old-account", { name: "old" });
-
-    const load = page.importNostrProfile();
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
-    page.editNostrProfile("new-account", { name: "fresh" });
-    response.resolve(
-      new Response(JSON.stringify({ ok: true, saved: true, merged: { name: "stale import" } }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
-    await load;
-
-    expect(page.nostrProfileAccountId).toBe("new-account");
-    expect(page.nostrProfileFormState?.values.name).toBe("fresh");
-    expect(refresh).not.toHaveBeenCalled();
-    source.runtimeConfig.dispose();
-    source.channels.dispose();
-  });
-
-  it("clears profile saving when the gateway response times out", async () => {
+  it.each([
+    ["Save & Publish", false],
+    ["Save & Publish", true],
+    ["Import from Relays", false],
+    ["Import from Relays", true],
+  ] as const)("times out rendered %s at 30 seconds with retry %s", async (action, retry) => {
     vi.useFakeTimers();
-    const gateway = createGateway();
-    const source = createContext(gateway);
     const fetchMock = stubHangingFetch();
-    const page = document.createElement("openclaw-channels-page") as NostrTestPage;
-    page.context = source.context;
-    document.body.append(page);
+    if (retry) {
+      fetchMock.mockImplementationOnce(
+        async () =>
+          await new Promise<Response>((resolve) => {
+            setTimeout(() => resolve(new Response(null, { status: 401 })), 15_000);
+          }),
+      );
+    }
+    const { source, refresh, page } = await mountNostrProfile();
+    profileButton(page, action).click();
     await page.updateComplete;
-    page.editNostrProfile("default", { name: "Alice" });
-
-    const save = page.saveNostrProfile();
-    await vi.advanceTimersByTimeAsync(NOSTR_PROFILE_REQUEST_TIMEOUT_MS);
-    await save;
-
     expect(fetchMock).toHaveBeenCalledOnce();
-    expect(page.nostrProfileFormState?.saving).toBe(false);
-    expect(page.nostrProfileFormState?.error).toBe(
+    await vi.advanceTimersByTimeAsync(14_999);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchMock).toHaveBeenCalledTimes(retry ? 2 : 1);
+    expect(
+      fetchMock.mock.calls.map(([, init]) => new Headers(init?.headers).get("Authorization")),
+    ).toEqual(retry ? ["Bearer device-token", "Bearer saved-token"] : ["Bearer device-token"]);
+    await vi.advanceTimersByTimeAsync(NOSTR_PROFILE_REQUEST_TIMEOUT_MS - 15_001);
+    expect(page.textContent).not.toContain("Request timed out");
+    expect(fetchMock.mock.calls.at(-1)?.[1]?.signal?.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await page.updateComplete;
+
+    expect(fetchMock.mock.calls.at(-1)?.[1]?.signal?.aborted).toBe(true);
+    expect(profileButton(page, action).disabled).toBe(false);
+    expect(page.textContent).toContain(
       "Request timed out after 30 seconds; the server may still have applied the change — check the profile before retrying.",
     );
-    source.runtimeConfig.dispose();
-    source.channels.dispose();
-  });
-
-  it("clears profile importing when the gateway response times out", async () => {
-    vi.useFakeTimers();
-    const gateway = createGateway();
-    const source = createContext(gateway);
-    const fetchMock = stubHangingFetch();
-    const page = document.createElement("openclaw-channels-page") as NostrTestPage;
-    page.context = source.context;
-    document.body.append(page);
-    await page.updateComplete;
-    page.editNostrProfile("default", { name: "Alice" });
-
-    const load = page.importNostrProfile();
-    await vi.advanceTimersByTimeAsync(NOSTR_PROFILE_REQUEST_TIMEOUT_MS);
-    await load;
-
-    expect(fetchMock).toHaveBeenCalledOnce();
-    expect(page.nostrProfileFormState?.importing).toBe(false);
-    expect(page.nostrProfileFormState?.error).toBe(
-      "Request timed out after 30 seconds; the server may still have applied the change — check the profile before retrying.",
-    );
+    expect(refresh).not.toHaveBeenCalled();
     source.runtimeConfig.dispose();
     source.channels.dispose();
   });

--- a/ui/src/pages/channels/channels-page.test.ts
+++ b/ui/src/pages/channels/channels-page.test.ts
@@ -32,7 +32,17 @@ function stubHangingFetch() {
         if (!signal) {
           throw new Error("Expected Nostr profile request to carry an AbortSignal");
         }
-        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        signal.addEventListener(
+          "abort",
+          () => {
+            const reason: unknown = signal.reason;
+            if (!(reason instanceof DOMException)) {
+              throw new Error("Expected profile timeout to abort with a DOMException");
+            }
+            reject(reason);
+          },
+          { once: true },
+        );
       }),
   );
   vi.stubGlobal("fetch", fetchMock);

--- a/ui/src/pages/channels/channels-page.test.ts
+++ b/ui/src/pages/channels/channels-page.test.ts
@@ -138,6 +138,89 @@ afterEach(() => {
 });
 
 describe("ChannelsPage lifecycle", () => {
+  it.each([
+    ["Save & Publish", 401, 200],
+    ["Import from Relays", 401, 200],
+    ["Save & Publish", 401, 401],
+    ["Import from Relays", 401, 401],
+    ["Save & Publish", 403, 200],
+    ["Import from Relays", 403, 200],
+  ] as const)(
+    "handles credentials through rendered %s after %s then %s",
+    async (action, firstStatus, nextStatus) => {
+      const gateway = createGateway();
+      gateway.connection.token = "saved-token";
+      gateway.snapshot.hello = {
+        type: "hello-ok",
+        protocol: 3,
+        auth: { role: "operator", scopes: ["operator.admin"], deviceToken: "device-token" },
+      };
+      const source = createContext(gateway);
+      vi.spyOn(source.channels, "refresh").mockResolvedValue();
+      source.channels.state.channelsSnapshot = {
+        ts: 0,
+        channelOrder: ["nostr"],
+        channelLabels: { nostr: "Nostr" },
+        channels: { nostr: { configured: true, profile: { name: "Alice" } } },
+        channelAccounts: {},
+        channelDefaultAccountId: {},
+      };
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response(null, { status: firstStatus }))
+        .mockResolvedValueOnce(
+          nextStatus === 200
+            ? Response.json({ ok: true, persisted: true, saved: true, merged: { name: "Alice" } })
+            : new Response(null, { status: nextStatus }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+      const page = document.createElement("openclaw-channels-page") as ChannelsPageTestElement;
+      page.context = source.context;
+      document.body.append(page);
+      await page.updateComplete;
+      page.querySelector<HTMLButtonElement>(".channels-item")?.click();
+      await page.updateComplete;
+      const click = (label: string) => {
+        const button = Array.from(page.querySelectorAll("button")).find(
+          (entry) => entry.textContent?.trim() === label,
+        );
+        if (!button) {
+          throw new Error(`Missing action: ${label}`);
+        }
+        button.click();
+      };
+      click("Edit Profile");
+      await page.updateComplete;
+      const name = page.querySelector<HTMLInputElement>("#nostr-profile-name");
+      if (!name) {
+        throw new Error("Missing profile name");
+      }
+      name.value = "Alice Updated";
+      name.dispatchEvent(new Event("input", { bubbles: true }));
+      await page.updateComplete;
+      click(action);
+      const recovered = firstStatus === 401 && nextStatus === 200;
+      await vi.waitFor(() =>
+        expect(page.textContent).toContain(
+          recovered
+            ? action === "Save & Publish"
+              ? "Profile published"
+              : "Profile imported"
+            : "Last error",
+        ),
+      );
+      expect(
+        fetchMock.mock.calls.map(([, init]) => new Headers(init?.headers).get("Authorization")),
+      ).toEqual(
+        firstStatus === 403
+          ? ["Bearer device-token"]
+          : ["Bearer device-token", "Bearer saved-token"],
+      );
+      source.runtimeConfig.dispose();
+      source.channels.dispose();
+    },
+  );
+
   it.each([false, true])(
     "prefers the exact plugin icon with owner first: %s",
     async (ownerFirst) => {
@@ -654,47 +737,55 @@ describe("ChannelsPage lifecycle", () => {
     source.channels.dispose();
   });
 
-  it("drops a profile save when the channel source is replaced", async () => {
+  it.each([200, 401])(
+    "drops a profile save after source replacement and status %s",
+    async (status) => {
+      const gateway = createGateway();
+      gateway.connection.token = "first-token";
+      gateway.connection.password = "saved-password";
+      const first = createContext(gateway);
+      const second = createContext(gateway);
+      const firstRefresh = vi.spyOn(first.channels, "refresh").mockResolvedValue();
+      const secondRefresh = vi.spyOn(second.channels, "refresh").mockResolvedValue();
+      const response = createDeferred<Response>();
+      const fetchMock = vi.fn(() => response.promise);
+      vi.stubGlobal("fetch", fetchMock);
+      const page = document.createElement("openclaw-channels-page") as NostrTestPage;
+      page.context = first.context;
+      document.body.append(page);
+      await page.updateComplete;
+      page.editNostrProfile("old-account", { name: "old" });
+
+      const save = page.saveNostrProfile();
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+      page.context = second.context;
+      page.requestUpdate();
+      await page.updateComplete;
+      expect(page.nostrProfileFormState).toBeNull();
+
+      response.resolve(
+        new Response(JSON.stringify({ ok: true, persisted: true }), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      await save;
+
+      expect(page.nostrProfileFormState).toBeNull();
+      expect(firstRefresh).not.toHaveBeenCalled();
+      expect(secondRefresh).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledOnce();
+      first.runtimeConfig.dispose();
+      second.runtimeConfig.dispose();
+      first.channels.dispose();
+      second.channels.dispose();
+    },
+  );
+
+  it.each([200, 401])("drops a profile import after disconnect and status %s", async (status) => {
     const gateway = createGateway();
-    const first = createContext(gateway);
-    const second = createContext(gateway);
-    const firstRefresh = vi.spyOn(first.channels, "refresh").mockResolvedValue();
-    const secondRefresh = vi.spyOn(second.channels, "refresh").mockResolvedValue();
-    const response = createDeferred<Response>();
-    const fetchMock = vi.fn(() => response.promise);
-    vi.stubGlobal("fetch", fetchMock);
-    const page = document.createElement("openclaw-channels-page") as NostrTestPage;
-    page.context = first.context;
-    document.body.append(page);
-    await page.updateComplete;
-    page.editNostrProfile("old-account", { name: "old" });
-
-    const save = page.saveNostrProfile();
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
-    page.context = second.context;
-    page.requestUpdate();
-    await page.updateComplete;
-    expect(page.nostrProfileFormState).toBeNull();
-
-    response.resolve(
-      new Response(JSON.stringify({ ok: true, persisted: true }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
-    await save;
-
-    expect(page.nostrProfileFormState).toBeNull();
-    expect(firstRefresh).not.toHaveBeenCalled();
-    expect(secondRefresh).not.toHaveBeenCalled();
-    first.runtimeConfig.dispose();
-    second.runtimeConfig.dispose();
-    first.channels.dispose();
-    second.channels.dispose();
-  });
-
-  it("drops a profile import when the gateway disconnects", async () => {
-    const gateway = createGateway();
+    gateway.connection.token = "first-token";
+    gateway.connection.password = "saved-password";
     const source = createContext(gateway);
     const refresh = vi.spyOn(source.channels, "refresh").mockResolvedValue();
     const response = createDeferred<Response>();
@@ -713,7 +804,7 @@ describe("ChannelsPage lifecycle", () => {
 
     response.resolve(
       new Response(JSON.stringify({ ok: true, saved: true, merged: { name: "stale import" } }), {
-        status: 200,
+        status,
         headers: { "Content-Type": "application/json" },
       }),
     );
@@ -721,6 +812,7 @@ describe("ChannelsPage lifecycle", () => {
 
     expect(page.nostrProfileFormState).toBeNull();
     expect(refresh).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledOnce();
     source.runtimeConfig.dispose();
     source.channels.dispose();
   });

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -8,7 +8,7 @@ import type {
 } from "../../api/types.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
-import { resolveControlUiAuthHeader } from "../../app/control-ui-auth.ts";
+import { resolveControlUiAuthCandidates } from "../../app/control-ui-auth.ts";
 import { hasOperatorAdminAccess, hasOperatorPairingAccess } from "../../app/operator-access.ts";
 import { loadSettings, patchSettings } from "../../app/settings.ts";
 import { renderLearnMoreLink } from "../../components/settings-ui.ts";
@@ -43,7 +43,7 @@ type NostrOperation = {
   channels: ApplicationContext["channels"];
   formAccountId: string | null;
   accountId: string;
-  headers: Record<string, string>;
+  authCandidates: readonly string[];
 };
 
 function formatNostrProfileOperationError(error: unknown, prefix: string): string {
@@ -304,13 +304,12 @@ class ChannelsPage extends OpenClawLightDomElement {
     return this.nostrProfileAccountId ?? accounts[0]?.accountId ?? "default";
   }
 
-  private buildGatewayHttpHeaders(gateway: ApplicationContext["gateway"]): Record<string, string> {
-    const authorization = resolveControlUiAuthHeader({
+  private resolveGatewayHttpCredentials(gateway: ApplicationContext["gateway"]): string[] {
+    return resolveControlUiAuthCandidates({
       hello: gateway.snapshot.hello,
       settings: { token: gateway.connection.token },
       password: gateway.connection.password,
     });
-    return authorization ? { Authorization: authorization } : {};
   }
 
   private clearNostrForm() {
@@ -346,7 +345,7 @@ class ChannelsPage extends OpenClawLightDomElement {
       channels,
       formAccountId: this.nostrProfileAccountId,
       accountId: this.resolveNostrAccountId(),
-      headers: this.buildGatewayHttpHeaders(gateway),
+      authCandidates: this.resolveGatewayHttpCredentials(gateway),
     };
   }
 
@@ -416,7 +415,8 @@ class ChannelsPage extends OpenClawLightDomElement {
     try {
       const { data, response } = await putNostrProfile({
         accountId: operation.accountId,
-        headers: operation.headers,
+        authCandidates: operation.authCandidates,
+        isCurrent: () => this.currentNostrForm(operation) !== null,
         values: form.values,
       });
       const currentForm = this.currentNostrForm(operation);
@@ -491,7 +491,8 @@ class ChannelsPage extends OpenClawLightDomElement {
     try {
       const { data, response } = await importNostrProfile({
         accountId: operation.accountId,
-        headers: operation.headers,
+        authCandidates: operation.authCandidates,
+        isCurrent: () => this.currentNostrForm(operation) !== null,
       });
       const currentForm = this.currentNostrForm(operation);
       if (!currentForm) {

--- a/ui/src/pages/channels/nostr-profile-ops.test.ts
+++ b/ui/src/pages/channels/nostr-profile-ops.test.ts
@@ -32,39 +32,52 @@ afterEach(() => {
 });
 
 describe("Nostr profile HTTP operations", () => {
-  it("aborts a profile PUT when response headers never arrive", async () => {
-    vi.useFakeTimers();
-    const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
-      return await rejectWhenAborted(requireRequestSignal(init));
-    });
-    vi.stubGlobal("fetch", fetchMock);
+  it.each([false, true])(
+    "keeps one profile PUT deadline across credential retry: %s",
+    async (retry) => {
+      vi.useFakeTimers();
+      const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+        return await rejectWhenAborted(requireRequestSignal(init));
+      });
+      if (retry) {
+        fetchMock.mockImplementationOnce(
+          async () =>
+            await new Promise<Response>((resolve) => {
+              setTimeout(() => resolve(new Response(null, { status: 401 })), 15_000);
+            }),
+        );
+      }
+      vi.stubGlobal("fetch", fetchMock);
 
-    const request = putNostrProfile({
-      accountId: "main/account",
-      headers: { Authorization: "Bearer test" },
-      values: { name: "Alice" },
-    });
-    const result = expect(request).rejects.toMatchObject({
-      name: "TimeoutError",
-      message: "Nostr profile request timed out after 30 seconds",
-    });
-    await vi.advanceTimersByTimeAsync(NOSTR_PROFILE_REQUEST_TIMEOUT_MS);
-    await result;
+      const request = putNostrProfile({
+        accountId: "main/account",
+        authCandidates: ["test", "saved"],
+        isCurrent: () => true,
+        values: { name: "Alice" },
+      });
+      const result = expect(request).rejects.toMatchObject({
+        name: "TimeoutError",
+        message: "Nostr profile request timed out after 30 seconds",
+      });
+      await vi.advanceTimersByTimeAsync(NOSTR_PROFILE_REQUEST_TIMEOUT_MS);
+      await result;
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/channels/nostr/main%2Faccount/profile",
-      expect.objectContaining({
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: "Bearer test",
-        },
-        body: JSON.stringify({ name: "Alice" }),
-        signal: expect.any(AbortSignal),
-      }),
-    );
-    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
-  });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/channels/nostr/main%2Faccount/profile",
+        expect.objectContaining({
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer test",
+          },
+          body: JSON.stringify({ name: "Alice" }),
+          signal: expect.any(AbortSignal),
+        }),
+      );
+      expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(retry ? 2 : 1);
+    },
+  );
 
   it("keeps the import deadline active while the response body is pending", async () => {
     vi.useFakeTimers();
@@ -78,7 +91,11 @@ describe("Nostr profile HTTP operations", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const request = importNostrProfile({ accountId: "default", headers: {} });
+    const request = importNostrProfile({
+      accountId: "default",
+      authCandidates: [],
+      isCurrent: () => true,
+    });
     const result = expect(request).rejects.toMatchObject({ name: "TimeoutError" });
     await vi.advanceTimersByTimeAsync(NOSTR_PROFILE_REQUEST_TIMEOUT_MS);
     await result;
@@ -108,9 +125,16 @@ describe("Nostr profile HTTP operations", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      putNostrProfile({ accountId: "default", headers: {}, values: { name: "Alice" } }),
+      putNostrProfile({
+        accountId: "default",
+        authCandidates: [],
+        isCurrent: () => true,
+        values: { name: "Alice" },
+      }),
     ).resolves.toEqual({ data: { ok: true, persisted: true }, response: putResponse });
-    await expect(importNostrProfile({ accountId: "default", headers: {} })).resolves.toEqual({
+    await expect(
+      importNostrProfile({ accountId: "default", authCandidates: [], isCurrent: () => true }),
+    ).resolves.toEqual({
       data: { ok: true, saved: true, merged: { name: "Alice" } },
       response: importResponse,
     });
@@ -120,7 +144,9 @@ describe("Nostr profile HTTP operations", () => {
     const response = new Response("gateway unavailable", { status: 503 });
     vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(response));
 
-    await expect(importNostrProfile({ accountId: "default", headers: {} })).resolves.toEqual({
+    await expect(
+      importNostrProfile({ accountId: "default", authCandidates: [], isCurrent: () => true }),
+    ).resolves.toEqual({
       data: null,
       response,
     });

--- a/ui/src/pages/channels/nostr-profile-ops.ts
+++ b/ui/src/pages/channels/nostr-profile-ops.ts
@@ -1,9 +1,16 @@
 // Nostr profile HTTP operations for the channels page: gateway REST calls for
 // publishing and importing the relay profile, plus validation-error parsing.
 import type { NostrProfile } from "../../api/types.ts";
+import { fetchWithControlUiAuth } from "../../app/control-ui-auth.ts";
 import { formatUiExternalText } from "../../lib/format-error.ts";
 
 const NOSTR_PROFILE_REQUEST_TIMEOUT_MS = 30_000;
+
+type NostrProfileRequest = {
+  accountId: string;
+  authCandidates: readonly string[];
+  isCurrent: () => boolean;
+};
 
 type NostrProfileHttpResult<T> = {
   data: T | null;
@@ -12,7 +19,8 @@ type NostrProfileHttpResult<T> = {
 
 async function requestNostrProfile<T>(
   url: string,
-  init: Omit<RequestInit, "signal">,
+  init: { method: string; headers: Record<string, string>; body: string },
+  auth: NostrProfileRequest,
 ): Promise<NostrProfileHttpResult<T>> {
   const controller = new AbortController();
   const timeout = setTimeout(
@@ -23,7 +31,12 @@ async function requestNostrProfile<T>(
     NOSTR_PROFILE_REQUEST_TIMEOUT_MS,
   );
   try {
-    const response = await fetch(url, { ...init, signal: controller.signal });
+    const response = await fetchWithControlUiAuth(
+      url,
+      { ...init, signal: controller.signal },
+      auth.authCandidates,
+      auth.isCurrent,
+    );
     let data: T | null = null;
     try {
       data = (await response.json()) as T;
@@ -64,42 +77,45 @@ function buildNostrProfileUrl(accountId: string, suffix = ""): string {
   return `/api/channels/nostr/${encodeURIComponent(accountId)}/profile${suffix}`;
 }
 
-export async function putNostrProfile(params: {
-  accountId: string;
-  headers: Record<string, string>;
-  values: NostrProfile;
-}) {
+export async function putNostrProfile(
+  params: NostrProfileRequest & {
+    values: NostrProfile;
+  },
+) {
   return await requestNostrProfile<{
     ok?: boolean;
     error?: string;
     details?: unknown;
     persisted?: boolean;
-  }>(buildNostrProfileUrl(params.accountId), {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-      ...params.headers,
+  }>(
+    buildNostrProfileUrl(params.accountId),
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(params.values),
     },
-    body: JSON.stringify(params.values),
-  });
+    params,
+  );
 }
 
-export async function importNostrProfile(params: {
-  accountId: string;
-  headers: Record<string, string>;
-}) {
+export async function importNostrProfile(params: NostrProfileRequest) {
   return await requestNostrProfile<{
     ok?: boolean;
     error?: string;
     imported?: NostrProfile;
     merged?: NostrProfile;
     saved?: boolean;
-  }>(buildNostrProfileUrl(params.accountId, "/import"), {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...params.headers,
+  }>(
+    buildNostrProfileUrl(params.accountId, "/import"),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ autoMerge: true }),
     },
-    body: JSON.stringify({ autoMerge: true }),
-  });
+    params,
+  );
 }


### PR DESCRIPTION
## What Problem This Solves

Nostr profile Save and Import failed after rejecting a paired browser's device credential, even when a valid Gateway credential was saved.

Credit: @zhangguiping-xydt for the original credential-recovery work.

## Why This Change Was Made

The profile page used only the first credential. It now uses the Control UI's shared request loop to try the next saved credential after a 401 response. The obsolete single-credential helper is removed.

## User Impact

Save and Import complete with a valid saved credential. A changed form or connection stops further attempts, the original deadline remains, and a 403 response still ends the operation.

## Evidence

- Before the fix, Save and Import in a real paired browser each stopped at 401; the same Gateway accepted the saved credential.
- The repaired browser recovered from 401 to 200 for both actions and retained successful results after reload.
- Wrong saved credentials left both actions visibly failed; restoring the credential restored both actions.
- The existing channel configuration editor still saved its disabled test configuration and retained it after reconnect and reload.

## Consumers

- Nostr profile Save and Import now use all current credentials through the shared Control UI request loop.
