### PR TITLE
fix: avoid repeated database scans during Gateway startup

### DIFF
--- a/src/commands/doctor-config-preflight.plugin-persistence.test.ts
+++ b/src/commands/doctor-config-preflight.plugin-persistence.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
-import { withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import { writeOpenClawConfig } from "../config/test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import * as migrationCheckpoint from "../infra/startup-migration-checkpoint.js";
@@ -33,6 +33,7 @@ import {
   type DoctorConfigPreflightPluginSnapshotRead,
 } from "./doctor-config-preflight-plugin-index.js";
 import { runDoctorConfigPreflight } from "./doctor-config-preflight.js";
+import { withDoctorConfigPreflightHome } from "./doctor-config-preflight.test-support.js";
 import { createDoctorPluginMetadataSnapshotScope } from "./doctor/shared/plugin-metadata-snapshot-scope.js";
 
 async function withPreflightPluginFixture(
@@ -44,7 +45,7 @@ async function withPreflightPluginFixture(
   workspaceNames: string[] = [],
   fixturePluginId = "preflight-fixture",
 ) {
-  await withTempHome(async (home) => {
+  await withDoctorConfigPreflightHome(async (home) => {
     // Scope real discovery to the synthetic plugins owned by this fixture.
     const bundledRoot = path.join(home, "bundled");
     await fs.mkdir(bundledRoot, { recursive: true });
@@ -133,6 +134,8 @@ describe("Doctor plugin persistence", () => {
     "verifies a persisted registry in the $scope scope (replacement before lease: $replaceBeforeLease)",
     async ({ scope, replaceBeforeLease }) => {
       await withPreflightPluginFixture(async (writeVersion) => {
+        const checkpointStatus = vi.spyOn(migrationCheckpoint, "readMigrationCheckpointStatus");
+        onTestFinished(() => checkpointStatus.mockRestore());
         const run = async () => {
           const owner = getPluginCache();
           const read = readPluginPreflight;
@@ -211,6 +214,7 @@ describe("Doctor plugin persistence", () => {
         } else {
           await run();
         }
+        expect(checkpointStatus).not.toHaveBeenCalled();
       });
     },
   );
@@ -606,10 +610,10 @@ describe("Doctor plugin persistence", () => {
         let identity: ReturnType<typeof resolveMigrationCheckpointIdentity> = null;
         // Pin the build input, not the result: source-only runtimes intentionally cannot record.
         // Identity, lease, formatting, and SQLite behavior still use the real checkpoint owner.
-        const realNeedsCheckpoint = migrationCheckpoint.needsStateMigrationCheckpoint;
+        const realNeedsCheckpoint = migrationCheckpoint.readMigrationCheckpointStatus;
         const realRecordCheckpoint = migrationCheckpoint.recordSuccessfulStateMigrations;
         const needsCheckpoint = vi
-          .spyOn(migrationCheckpoint, "needsStateMigrationCheckpoint")
+          .spyOn(migrationCheckpoint, "readMigrationCheckpointStatus")
           .mockImplementation((params) => realNeedsCheckpoint({ ...params, buildIdentity }));
         const recordCheckpoint = vi
           .spyOn(migrationCheckpoint, "recordSuccessfulStateMigrations")
@@ -649,7 +653,7 @@ describe("Doctor plugin persistence", () => {
                 pluginMigrationFingerprint: read.pluginMigrationFingerprint,
               });
               expect(read.pluginMetadataSnapshot?.registrySource).toBe("persisted");
-              expect(migrationCheckpoint.needsStateMigrationCheckpoint({ identity })).toBe(true);
+              expect(migrationCheckpoint.readMigrationCheckpointStatus({ identity })).toBe("stale");
               expect(readStateCheckpoint()).toBeUndefined();
               verified = true;
               if (interrupted) {
@@ -673,7 +677,9 @@ describe("Doctor plugin persistence", () => {
         );
         const recorded = !interrupted && buildIdentity !== null;
         expect(Boolean(readStateCheckpoint())).toBe(recorded);
-        expect(migrationCheckpoint.needsStateMigrationCheckpoint({ identity })).toBe(!recorded);
+        expect(migrationCheckpoint.readMigrationCheckpointStatus({ identity })).toBe(
+          recorded ? "state-current" : "stale",
+        );
       });
     },
   );

--- a/src/commands/doctor-config-preflight.state-migration.test-helpers.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test-helpers.ts
@@ -17,9 +17,10 @@ const maybeRepairPluginOpenClawHostLinks = vi.hoisted(() =>
   ),
 );
 
-vi.mock("./doctor-plugin-host-links.js", () => ({
-  maybeRepairPluginOpenClawHostLinks,
-}));
+vi.mock("./doctor-plugin-host-links.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./doctor-plugin-host-links.js")>();
+  return { ...actual, maybeRepairPluginOpenClawHostLinks };
+});
 
 export function getMaybeRepairPluginOpenClawHostLinksMock() {
   return maybeRepairPluginOpenClawHostLinks;

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -72,8 +72,9 @@ const repairLegacyCronStoreWithoutPrompt = vi.hoisted(() =>
 const collectCronCodexRuntimePolicyTargetsReadOnly = vi.hoisted(() =>
   vi.fn(async () => ({ targets: [] as Array<{ modelRef: string }>, warnings: [] as string[] })),
 );
-const needsStateMigrationCheckpoint = vi.hoisted(() => vi.fn(() => false));
-const needsStartupMigrationCheckpoint = vi.hoisted(() => vi.fn(() => false));
+const readMigrationCheckpointStatus = vi.hoisted(() =>
+  vi.fn<() => "stale" | "state-current" | "startup-current">(() => "startup-current"),
+);
 const startupMigrationLeaseHeartbeat = vi.hoisted(() => vi.fn());
 const startupMigrationLeaseRelease = vi.hoisted(() => vi.fn());
 const startupMigrationLeaseAssertOwnedInTransaction = vi.hoisted(() => vi.fn());
@@ -201,8 +202,7 @@ vi.mock("./doctor/cron/legacy-repair.js", () => ({
 
 vi.mock("../infra/startup-migration-checkpoint.js", () => ({
   acquireStartupMigrationLeaseWithWait,
-  needsStateMigrationCheckpoint,
-  needsStartupMigrationCheckpoint,
+  readMigrationCheckpointStatus,
   recordSuccessfulStateMigrations,
   recordSuccessfulStartupMigrations,
 }));
@@ -255,8 +255,8 @@ describe("runDoctorConfigPreflight state migration", () => {
     findDoctorLegacyConfigIssues.mockReset();
     findDoctorLegacyConfigIssues.mockReturnValue([]);
     setActiveDegradedPlugins([]);
-    needsStartupMigrationCheckpoint.mockReturnValue(false);
-    needsStateMigrationCheckpoint.mockImplementation(() => needsStartupMigrationCheckpoint());
+    readMigrationCheckpointStatus.mockReset();
+    readMigrationCheckpointStatus.mockReturnValue("startup-current");
     runPostCorePluginConvergence.mockResolvedValue(makeStartupConvergenceResult());
     planStartupPluginConvergence.mockResolvedValue({ required: true, installRecords: {} });
     planPristineStartupStateMigrations.mockReturnValue({
@@ -338,7 +338,7 @@ describe("runDoctorConfigPreflight state migration", () => {
       measuredStages.push(name);
       return await run();
     };
-    needsStartupMigrationCheckpoint.mockReturnValue(false);
+    readMigrationCheckpointStatus.mockReturnValue("startup-current");
 
     await runDoctorConfigPreflight({
       migrateState: true,
@@ -366,7 +366,7 @@ describe("runDoctorConfigPreflight state migration", () => {
     { name: "leaves the checkpoint stale after a warning", needed: true, warnings: ["warning"] },
   ])("$name", async ({ needed, warnings }) => {
     vi.clearAllMocks();
-    needsStateMigrationCheckpoint.mockReturnValue(needed);
+    readMigrationCheckpointStatus.mockReturnValue(needed ? "stale" : "state-current");
     autoMigrateLegacyStateDir.mockResolvedValue({
       migrated: false,
       skipped: false,
@@ -430,7 +430,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("does not touch the startup checkpoint before the startup guard accepts", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
 
     await expect(
       runDoctorConfigPreflight({
@@ -441,13 +441,13 @@ describe("runDoctorConfigPreflight state migration", () => {
       }),
     ).rejects.toThrow("selected config changed during startup");
 
-    expect(needsStartupMigrationCheckpoint).not.toHaveBeenCalled();
+    expect(readMigrationCheckpointStatus).not.toHaveBeenCalled();
     expect(acquireStartupMigrationLeaseWithWait).not.toHaveBeenCalled();
     expect(readConfigFileSnapshot).not.toHaveBeenCalled();
   });
 
   it("releases the startup lease when the fresh config guard rejects", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
     process.env.OPENCLAW_STATE_DIR = "/tmp/openclaw-original-state";
     let leaseEnv: NodeJS.ProcessEnv | undefined;
@@ -493,7 +493,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("releases the startup lease before propagating a deferred service exit", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     const deferredExit = new ExitError(78);
     const beforeStateMigrations = vi
       .fn<(_snapshot?: Record<string, unknown>) => Promise<boolean>>()
@@ -577,8 +577,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("rechecks the checkpoint after acquisition before running migrations", async () => {
-    needsStateMigrationCheckpoint.mockReturnValueOnce(true).mockReturnValue(false);
-    needsStartupMigrationCheckpoint.mockReturnValueOnce(true).mockReturnValue(false);
+    readMigrationCheckpointStatus.mockReturnValueOnce("stale").mockReturnValue("startup-current");
 
     await runDoctorConfigPreflight(startupCheckpointOptions);
 
@@ -591,7 +590,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("pins startup plugin convergence without re-persisting the installed record snapshot", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     const previousHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
     process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = "2026.7.2-beta.7";
 
@@ -613,7 +612,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("repairs managed host links before plugin state migration", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     const migrationOrder: string[] = [];
     maybeRepairPluginOpenClawHostLinks.mockImplementationOnce(async ({ env, prompter }) => {
       migrationOrder.push("host-links");
@@ -632,7 +631,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("refuses startup when fresh plugin migration inputs change during convergence", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     pluginMigrationFingerprint.mockImplementation((allowCurrentPluginMetadata) =>
       runPostCorePluginConvergence.mock.calls.length > 0 && allowCurrentPluginMetadata === false
         ? "plugin-migrations-after"
@@ -655,7 +654,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("records the authoritative startup checkpoint after notices and runtime replacement", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     pluginMigrationFingerprint.mockImplementation((allowCurrentPluginMetadata) =>
       runPostCorePluginConvergence.mock.calls.length > 0 && allowCurrentPluginMetadata !== false
         ? "plugin-migrations-runtime-current"
@@ -682,7 +681,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("checkpoints after a dreaming conflict is archived without a migration warning", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     autoMigrateLegacyPluginDoctorState.mockResolvedValueOnce({
       migrated: true,
       skipped: false,
@@ -738,7 +737,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("keeps ownerless install-record failures blocking", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     queueConfigSnapshot(
       {
         exists: true,
@@ -791,7 +790,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("checkpoints startup migrations without loading plugin convergence when the plan is empty", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     planStartupPluginConvergence.mockResolvedValueOnce({ required: false, installRecords: {} });
 
     await runDoctorConfigPreflight({
@@ -809,7 +808,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("skips legacy migration loading for a prepared pristine state root", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     planStartupPluginConvergence.mockResolvedValueOnce({ required: false, installRecords: {} });
     const beforeStateMigrations = vi.fn(async () => true);
 
@@ -834,7 +833,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("runs only plugin-owned migrations for a pristine core state root", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     planPristineStartupStateMigrations.mockReturnValueOnce({
       skipAllStateMigrations: false,
       skipCoreStateMigrations: true,
@@ -858,7 +857,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("retains the prepared core-state fact and explicit Doctor repair authority", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
 
     await runDoctorConfigPreflight({
       migrateLegacyConfig: false,
@@ -877,35 +876,31 @@ describe("runDoctorConfigPreflight state migration", () => {
     });
   });
 
-  it.each([false, true])(
-    "allows warning-only startup with checkpoint required=%s",
-    async (required) => {
-      needsStateMigrationCheckpoint.mockReturnValue(true);
-      needsStartupMigrationCheckpoint.mockReturnValue(required);
-      autoMigrateLegacyStateDir.mockResolvedValueOnce({
-        migrated: false,
-        skipped: false,
-        changes: [],
-        warnings: ["Left legacy config health state in place."],
-      });
+  it("allows warning-only startup without certifying completion", async () => {
+    readMigrationCheckpointStatus.mockReturnValue("stale");
+    autoMigrateLegacyStateDir.mockResolvedValueOnce({
+      migrated: false,
+      skipped: false,
+      changes: [],
+      warnings: ["Left legacy config health state in place."],
+    });
 
-      await expect(runDoctorConfigPreflight(startupCheckpointOptions)).resolves.toBeDefined();
+    await expect(runDoctorConfigPreflight(startupCheckpointOptions)).resolves.toBeDefined();
 
-      expect(readStartupMigrationWarning()).toContain("Left legacy config health state in place.");
-      expect(readStartupMigrationWarning()).toContain(
-        'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.',
-      );
-      expect(note.mock.calls.filter(([, title]) => title === "Doctor warnings")).toHaveLength(0);
-      expect(recordSuccessfulStateMigrations).not.toHaveBeenCalled();
-      expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
-      expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
-      await runDoctorConfigPreflight(startupCheckpointOptions);
-      expect(readStartupMigrationWarning()).toContain("Left legacy config health state in place.");
-    },
-  );
+    expect(readStartupMigrationWarning()).toContain("Left legacy config health state in place.");
+    expect(readStartupMigrationWarning()).toContain(
+      'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.',
+    );
+    expect(note.mock.calls.filter(([, title]) => title === "Doctor warnings")).toHaveLength(0);
+    expect(recordSuccessfulStateMigrations).not.toHaveBeenCalled();
+    expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
+    expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+    await runDoctorConfigPreflight(startupCheckpointOptions);
+    expect(readStartupMigrationWarning()).toContain("Left legacy config health state in place.");
+  });
 
   it("bounds and redacts startup warnings while preserving the Doctor follow-up", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     const credential = "sk-" + "syntheticfixture".repeat(4);
     autoMigrateLegacyStateDir.mockResolvedValueOnce({
       migrated: false,
@@ -924,7 +919,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("refuses startup and releases the lease when a migration errors", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     autoMigrateLegacyState.mockRejectedValueOnce(new Error("Canonical state cannot be read"));
 
     await expect(runDoctorConfigPreflight(startupCheckpointOptions)).rejects.toThrow(
@@ -936,7 +931,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("blocks gateway readiness when plugin repair warnings remain", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     runPostCorePluginConvergence.mockResolvedValueOnce(
       makeStartupConvergenceResult({
         warnings: [
@@ -971,7 +966,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("quarantines a plugin payload verification failure and checkpoints readiness", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     queueConfigSnapshot(
       {
         exists: true,
@@ -1045,7 +1040,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("does not checkpoint startup migrations when the config snapshot is invalid", async () => {
-    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    readMigrationCheckpointStatus.mockReturnValue("stale");
     queueConfigSnapshot(
       {
         exists: true,

--- a/src/commands/doctor-config-preflight.test-support.ts
+++ b/src/commands/doctor-config-preflight.test-support.ts
@@ -1,0 +1,17 @@
+import { withEnvOverride, withTempHome } from "../config/test-helpers.js";
+import { listKnownProviderAuthEnvVarNames } from "../secrets/provider-env-vars.js";
+
+/** Keep real preflight fixtures from provisioning plugins for the developer's credentials. */
+export async function withDoctorConfigPreflightHome<T>(
+  run: (home: string) => Promise<T>,
+): Promise<T> {
+  return withTempHome((home) => {
+    const providerEnv = Object.fromEntries(
+      listKnownProviderAuthEnvVarNames({ config: {}, env: process.env }).map((key) => [
+        key,
+        undefined,
+      ]),
+    );
+    return withEnvOverride(providerEnv, () => run(home));
+  });
+}

--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -6,11 +6,11 @@ import { applyCliProfileEnv } from "../cli/profile.js";
 import { promoteConfigSnapshotToLastKnownGood, readConfigFileSnapshot } from "../config/config.js";
 import { writeConfigHealthStateToStore } from "../config/io.health-state.js";
 import { createConfigHealthFingerprint } from "../config/io.observe-state.js";
-import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import { withEnvOverride, writeOpenClawConfig } from "../config/test-helpers.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import {
   hasActiveStartupMigrationLease,
-  needsStartupMigrationCheckpoint,
+  readMigrationCheckpointStatus,
 } from "../infra/startup-migration-checkpoint.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
@@ -26,6 +26,7 @@ import {
   shouldSkipPluginValidationForDoctorConfigPreflight,
 } from "./doctor-config-preflight.js";
 import { startupCheckpointOptions } from "./doctor-config-preflight.state-migration.test-helpers.js";
+import { withDoctorConfigPreflightHome } from "./doctor-config-preflight.test-support.js";
 import { isStartupConfigRepairResult } from "./doctor/shared/automatic-startup-config-repair.js";
 
 const noteMock = vi.hoisted(() => vi.fn<(message: string, title?: string) => void>());
@@ -42,8 +43,7 @@ vi.mock("../infra/startup-migration-checkpoint.js", async (importActual) => {
     ((params?: P) => fn({ buildIdentity: "test-build", ...params } as P)) as typeof fn;
   return {
     ...actual,
-    needsStartupMigrationCheckpoint: pin(actual.needsStartupMigrationCheckpoint),
-    needsStateMigrationCheckpoint: pin(actual.needsStateMigrationCheckpoint),
+    readMigrationCheckpointStatus: pin(actual.readMigrationCheckpointStatus),
     recordSuccessfulStartupMigrations: pin(actual.recordSuccessfulStartupMigrations),
     recordSuccessfulStateMigrations: pin(actual.recordSuccessfulStateMigrations),
   };
@@ -131,7 +131,7 @@ describe("runDoctorConfigPreflight", () => {
   ])(
     "migrates $name under startup preflight and checkpoints the valid reread",
     async ({ extra }) => {
-      await withTempHome(async (home) => {
+      await withDoctorConfigPreflightHome(async (home) => {
         const configPath = await writeOpenClawConfig(home, {
           gateway: { mode: "local" },
           session: { idleMinutes: 45 },
@@ -160,7 +160,7 @@ describe("runDoctorConfigPreflight", () => {
         expect(isStartupConfigRepairResult(before, preflight.snapshot)).toBe(true);
         expect(await fs.readFile(`${configPath}.bak`, "utf-8")).toBe(original);
         expect(
-          needsStartupMigrationCheckpoint({
+          readMigrationCheckpointStatus({
             identity: resolveMigrationCheckpointIdentity({
               snapshot: preflight.snapshot,
               baseConfig: preflight.baseConfig,
@@ -168,7 +168,7 @@ describe("runDoctorConfigPreflight", () => {
                 preflight.pluginMetadataSnapshot?.configFingerprint ?? null,
             }),
           }),
-        ).toBe(false);
+        ).toBe("startup-current");
         expect(noteMock).toHaveBeenCalledWith(
           expect.stringContaining("Moved session.idleMinutes"),
           "Doctor changes",
@@ -178,7 +178,7 @@ describe("runDoctorConfigPreflight", () => {
   );
 
   it("preserves retired state locators before committing the startup config migration", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       const storePath = path.join(home, "custom-cron", "jobs.json");
       const configPath = await writeOpenClawConfig(home, {
         gateway: { mode: "local" },
@@ -209,7 +209,7 @@ describe("runDoctorConfigPreflight", () => {
       updating: undefined,
     },
   ])("leaves config unchanged with the doctor hint for $name", async ({ config, updating }) => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       const configPath = await writeOpenClawConfig(home, config);
       const original = await fs.readFile(configPath, "utf-8");
       await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: updating }, async () => {
@@ -232,7 +232,7 @@ describe("runDoctorConfigPreflight", () => {
       const consoleSink = loggingState.rawConsole ?? console;
       const warnSpy = vi.spyOn(consoleSink, "warn").mockImplementation(() => undefined);
 
-      await withTempHome(async (home) => {
+      await withDoctorConfigPreflightHome(async (home) => {
         await writeOpenClawConfig(home, {
           models: { providers: { openai: { contextTokens: 64_000 } } },
         });
@@ -261,7 +261,7 @@ describe("runDoctorConfigPreflight", () => {
 
   it("renders legacy context-budget notices with their config paths", async () => {
     await withStdoutIsTTY(true, async () => {
-      await withTempHome(async (home) => {
+      await withDoctorConfigPreflightHome(async (home) => {
         await writeOpenClawConfig(home, {
           models: { providers: { openai: { contextTokens: 64_000 } } },
         });
@@ -280,7 +280,7 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("supports non-observing config reads", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       const configPath = await writeOpenClawConfig(home, { gateway: { mode: "local" } });
 
       await runDoctorConfigPreflight({
@@ -295,7 +295,7 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("migrates legacy config into the active state directory", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       await writeLegacyConfig(home);
       const stateDir = await fs.realpath(await fs.mkdtemp(path.join(home, "custom-state-")));
       const configPath = path.join(stateDir, "openclaw.json");
@@ -322,7 +322,7 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("migrates legacy config into an explicit config path", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       await writeLegacyConfig(home);
       const configRoot = await fs.realpath(await fs.mkdtemp(path.join(home, "custom-config-")));
       const configPath = path.join(configRoot, "nested", "custom-openclaw.json");
@@ -347,7 +347,7 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("migrates legacy config into the selected profile", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       await writeLegacyConfig(home);
       const profileStateDir = path.join(home, ".openclaw-work");
       const configPath = path.join(profileStateDir, "openclaw.json");
@@ -391,7 +391,7 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("collects legacy config issues outside the normal config read path", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       await writeOpenClawConfig(home, {
         memorySearch: {
           provider: "local",
@@ -418,7 +418,7 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("reports persisted literal and interpolated OTel grpc as legacy config", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       await writeOpenClawConfig(home, {
         diagnostics: { otel: { enabled: false, protocol: "grpc" } },
       });
@@ -452,7 +452,7 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("does not treat the process-only OTel protocol fallback as persisted config", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       await writeOpenClawConfig(home, {
         diagnostics: { otel: { enabled: false } },
       });
@@ -471,7 +471,7 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("restores invalid config from last-known-good only during repair preflight", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       const configPath = await writeOpenClawConfig(home, {
         gateway: { mode: "local", port: 19091 },
       });
@@ -507,7 +507,7 @@ describe("runDoctorConfigPreflight", () => {
   ] as const)(
     "migrates last-known-good gateway bind %s to %s before restoring",
     async (legacyBind, canonicalBind) => {
-      await withTempHome(async (home) => {
+      await withDoctorConfigPreflightHome(async (home) => {
         const configPath = await writeOpenClawConfig(home, {
           gateway: { mode: "local" },
         });
@@ -535,7 +535,7 @@ describe("runDoctorConfigPreflight", () => {
   );
 
   it("preserves a legacy multi-agent owner when repairing active config before recovery", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       const configPath = await writeOpenClawConfig(home, {
         gateway: { mode: "local", port: 19091 },
       });
@@ -582,7 +582,7 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("migrates readable active config after preserving its state locators", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       const storePath = path.join(home, "custom-cron", "jobs.json");
       const configPath = await writeOpenClawConfig(home, {
         gateway: { mode: "local", port: 19091 },
@@ -642,7 +642,7 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("preserves the active config when last-known-good cannot converge", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       const configPath = await writeOpenClawConfig(home, {
         gateway: { mode: "local" },
       });
@@ -669,7 +669,7 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("leaves unparseable config untouched and provides recovery steps", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");
       const brokenRaw = '{ "gateway": { "mode": "local" }, "models": {';
       await fs.mkdir(path.dirname(configPath), { recursive: true });
@@ -714,7 +714,7 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("does not restore last-known-good for stale plugins.deny entries", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       const configPath = await writeOpenClawConfig(home, {
         gateway: { mode: "local", port: 19091 },
       });
@@ -740,7 +740,7 @@ describe("runDoctorConfigPreflight", () => {
   });
 
   it("restores last-known-good for malformed plugin policy values", async () => {
-    await withTempHome(async (home) => {
+    await withDoctorConfigPreflightHome(async (home) => {
       const configPath = await writeOpenClawConfig(home, {
         gateway: { mode: "local", port: 19091 },
       });

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -162,18 +162,17 @@ export async function runDoctorConfigPreflight(
       baseConfig: snapshot.sourceConfig ?? snapshot.config ?? {},
       pluginMigrationFingerprint,
     });
-    shouldRecordStateCheckpoint =
-      stateMigrationsRequested &&
-      checkpoint.needsStateMigrationCheckpoint({
+    shouldRecordStateCheckpoint = stateMigrationsRequested;
+    shouldRecordStartupCheckpoint = gatewayStartupCheckpointRequired;
+    if (shouldRecordStateCheckpoint || shouldRecordStartupCheckpoint) {
+      // One admitted read supplies both decisions; each physical open scans the whole database.
+      const checkpointStatus = checkpoint.readMigrationCheckpointStatus({
         env: startupMigrationEnv,
         identity: migrationCheckpointIdentity,
       });
-    shouldRecordStartupCheckpoint =
-      gatewayStartupCheckpointRequired &&
-      checkpoint.needsStartupMigrationCheckpoint({
-        env: startupMigrationEnv,
-        identity: migrationCheckpointIdentity,
-      });
+      shouldRecordStateCheckpoint &&= checkpointStatus === "stale";
+      shouldRecordStartupCheckpoint &&= checkpointStatus !== "startup-current";
+    }
     shouldPersistRefreshedPluginIndex = needsRefreshedPluginIndexPersistence(snapshotRead);
   };
   const ensureStartupMigrationLease = async () => {

--- a/src/infra/startup-migration-checkpoint.test.ts
+++ b/src/infra/startup-migration-checkpoint.test.ts
@@ -25,8 +25,7 @@ import {
   acquireStartupMigrationLease,
   acquireStartupMigrationLeaseWithWait,
   hasActiveStartupMigrationLease,
-  needsStateMigrationCheckpoint,
-  needsStartupMigrationCheckpoint,
+  readMigrationCheckpointStatus,
   readStartupMigrationVersion,
   recordSuccessfulStateMigrations,
   recordSuccessfulStartupMigrations,
@@ -221,23 +220,23 @@ describe("startup migration checkpoint", () => {
 
     expect(readStartupMigrationVersion(env)).toBeNull();
     expect(
-      needsStartupMigrationCheckpoint({
+      readMigrationCheckpointStatus({
         env,
         version: "2026.7.1",
         buildIdentity: "2026-07-11T00:00:00.000Z",
         identity: migrationIdentity,
       }),
-    ).toBe(true);
+    ).toBe("stale");
     const { DatabaseSync } = requireNodeSqlite();
     const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
     expect(
-      needsStateMigrationCheckpoint({
+      readMigrationCheckpointStatus({
         env,
         version: "2026.7.1",
         buildIdentity: "2026-07-11T00:00:00.000Z",
         identity: migrationIdentity,
       }),
-    ).toBe(true);
+    ).toBe("stale");
     expect(prepare.mock.calls.filter(([sql]) => sql === "PRAGMA integrity_check;")).toHaveLength(1);
     prepare.mockRestore();
 
@@ -251,50 +250,42 @@ describe("startup migration checkpoint", () => {
 
     expect(readStartupMigrationVersion(env)).toBe("2026.7.1");
     expect(
-      needsStartupMigrationCheckpoint({
+      readMigrationCheckpointStatus({
         env,
         version: "2026.7.1",
         buildIdentity: "2026-07-11T00:00:00.000Z",
         identity: migrationIdentity,
       }),
-    ).toBe(false);
+    ).toBe("startup-current");
     expect(
-      needsStateMigrationCheckpoint({
-        env,
-        version: "2026.7.1",
-        buildIdentity: "2026-07-11T00:00:00.000Z",
-        identity: migrationIdentity,
-      }),
-    ).toBe(false);
-    expect(
-      needsStartupMigrationCheckpoint({
+      readMigrationCheckpointStatus({
         env,
         version: "2026.7.1",
         buildIdentity: "2026-07-11T00:01:00.000Z",
         identity: migrationIdentity,
       }),
-    ).toBe(true);
+    ).toBe("stale");
     expect(
-      needsStartupMigrationCheckpoint({
+      readMigrationCheckpointStatus({
         env,
         version: "2026.7.2",
         buildIdentity: "2026-07-11T00:00:00.000Z",
         identity: migrationIdentity,
       }),
-    ).toBe(true);
+    ).toBe("stale");
     for (const [field, value] of [
       ["effectiveConfigFingerprint", "effective-config-changed"],
       ["pluginDoctorConfigFingerprint", "plugin-doctor-config-changed"],
       ["pluginMigrationFingerprint", "plugin-migrations-changed"],
     ] as const) {
       expect(
-        needsStartupMigrationCheckpoint({
+        readMigrationCheckpointStatus({
           env,
           version: "2026.7.1",
           buildIdentity: "2026-07-11T00:00:00.000Z",
           identity: { ...migrationIdentity, [field]: value },
         }),
-      ).toBe(true);
+      ).toBe("stale");
     }
   });
 
@@ -311,8 +302,7 @@ describe("startup migration checkpoint", () => {
 
     recordSuccessfulStateMigrations({ ...checkpoint, nowMs: 1234 });
 
-    expect(needsStateMigrationCheckpoint(checkpoint)).toBe(false);
-    expect(needsStartupMigrationCheckpoint(checkpoint)).toBe(true);
+    expect(readMigrationCheckpointStatus(checkpoint)).toBe("state-current");
     expect(readStartupMigrationVersion(env)).toBeNull();
 
     // Older gateways recorded only startup completion, which also certifies state migrations.
@@ -329,9 +319,14 @@ describe("startup migration checkpoint", () => {
       },
       { env },
     );
-    expect(needsStateMigrationCheckpoint(checkpoint)).toBe(false);
-    expect(needsStartupMigrationCheckpoint(checkpoint)).toBe(false);
+    expect(readMigrationCheckpointStatus(checkpoint)).toBe("startup-current");
     expect(readStartupMigrationVersion(env)).toBe(checkpoint.version);
+
+    recordSuccessfulStateMigrations({ ...checkpoint, buildIdentity: "older-build" });
+    expect(readMigrationCheckpointStatus(checkpoint)).toBe("startup-current");
+    recordSuccessfulStartupMigrations({ ...checkpoint, buildIdentity: "older-build" });
+    recordSuccessfulStateMigrations(checkpoint);
+    expect(readMigrationCheckpointStatus(checkpoint)).toBe("state-current");
   });
 
   it("keeps the fast path disabled without immutable build provenance", () => {
@@ -347,30 +342,30 @@ describe("startup migration checkpoint", () => {
       nowMs: 1234,
     });
 
+    for (const identity of [
+      undefined,
+      null,
+      { ...migrationIdentity, effectiveConfigFingerprint: " " },
+      { ...migrationIdentity, pluginDoctorConfigFingerprint: " " },
+      { ...migrationIdentity, pluginMigrationFingerprint: " " },
+    ]) {
+      expect(readMigrationCheckpointStatus({ env, buildIdentity: "known-build", identity })).toBe(
+        "stale",
+      );
+      expect(existsSync(resolveOpenClawStateSqlitePath(env))).toBe(false);
+    }
     expect(
-      needsStartupMigrationCheckpoint({
-        env,
-        version: "2026.7.1",
-        buildIdentity: null,
-        identity: migrationIdentity,
-      }),
-    ).toBe(true);
+      readMigrationCheckpointStatus({ env, buildIdentity: null, identity: migrationIdentity }),
+    ).toBe("stale");
+    expect(existsSync(resolveOpenClawStateSqlitePath(env))).toBe(false);
     expect(
-      needsStartupMigrationCheckpoint({
+      readMigrationCheckpointStatus({
         env,
         version: "2026.7.1",
         buildIdentity: "2026-07-11T00:00:00.000Z",
         identity: migrationIdentity,
       }),
-    ).toBe(true);
-    expect(
-      needsStartupMigrationCheckpoint({
-        env,
-        version: "2026.7.1",
-        buildIdentity: "2026-07-11T00:00:00.000Z",
-        identity: null,
-      }),
-    ).toBe(true);
+    ).toBe("stale");
   });
 
   it("treats legacy build-only checkpoints as stale once", () => {
@@ -398,8 +393,7 @@ describe("startup migration checkpoint", () => {
       { env },
     );
 
-    expect(needsStartupMigrationCheckpoint(checkpoint)).toBe(true);
-    expect(needsStateMigrationCheckpoint(checkpoint)).toBe(true);
+    expect(readMigrationCheckpointStatus(checkpoint)).toBe("stale");
     expect(readStartupMigrationVersion(env)).toBe("2026.7.1");
   });
 
@@ -517,7 +511,7 @@ describe("startup migration checkpoint", () => {
       identity: migrationIdentity,
     };
 
-    expect(needsStartupMigrationCheckpoint(checkpoint)).toBe(true);
+    expect(readMigrationCheckpointStatus(checkpoint)).toBe("stale");
 
     const acquired = await acquireStartupMigrationLeaseWithWait({
       env,
@@ -537,7 +531,7 @@ describe("startup migration checkpoint", () => {
 
     expect(sleepCount).toBe(1);
     expect(acquired.owner).toBe("second");
-    expect(needsStartupMigrationCheckpoint(checkpoint)).toBe(false);
+    expect(readMigrationCheckpointStatus(checkpoint)).toBe("startup-current");
     acquired.release();
   });
 
@@ -708,7 +702,7 @@ describe("startup migration checkpoint", () => {
     `);
     db.close();
 
-    expect(needsStartupMigrationCheckpoint({ env, version: "2026.7.1" })).toBe(true);
+    expect(readMigrationCheckpointStatus({ env, version: "2026.7.1" })).toBe("stale");
     const lease = acquireStartupMigrationLease({ env, nowMs: 1000, owner: "first" });
     const leased = new sqlite.DatabaseSync(dbPath, { readOnly: true });
     expect(leased.prepare("PRAGMA user_version").get()).toEqual({ user_version: 0 });
@@ -727,6 +721,13 @@ describe("startup migration checkpoint", () => {
     db.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION + 1};`);
     db.close();
 
+    expect(() =>
+      readMigrationCheckpointStatus({
+        env,
+        buildIdentity: "known-build",
+        identity: migrationIdentity,
+      }),
+    ).toThrow(`newer schema version ${OPENCLAW_STATE_SCHEMA_VERSION + 1}`);
     expect(() => acquireStartupMigrationLease({ env, nowMs: 1000, owner: "first" })).toThrow(
       `newer schema version ${OPENCLAW_STATE_SCHEMA_VERSION + 1}`,
     );
@@ -737,5 +738,38 @@ describe("startup migration checkpoint", () => {
       .get() as { ok?: unknown } | undefined;
     verify.close();
     expect(row).toBeUndefined();
+  });
+
+  it("rejects foreign-key corruption before reading checkpoint status", () => {
+    const env = {
+      OPENCLAW_STATE_DIR: startupMigrationTempDirs.make("openclaw-startup-migration-corrupt-"),
+    };
+    const dbPath = resolveOpenClawStateSqlitePath(env);
+    mkdirSync(path.dirname(dbPath), { recursive: true });
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(dbPath);
+    db.exec(`
+      PRAGMA foreign_keys = OFF;
+      CREATE TABLE legacy_parent (id INTEGER PRIMARY KEY);
+      CREATE TABLE legacy_child (parent_id INTEGER REFERENCES legacy_parent(id));
+      INSERT INTO legacy_child VALUES (1);
+    `);
+    db.close();
+
+    expect(() =>
+      readMigrationCheckpointStatus({
+        env,
+        buildIdentity: "known-build",
+        identity: migrationIdentity,
+      }),
+    ).toThrow("foreign_key_check failed");
+    const verify = new DatabaseSync(dbPath, { readOnly: true });
+    try {
+      expect(
+        verify.prepare("SELECT name FROM sqlite_schema WHERE name = 'schema_meta'").get(),
+      ).toBeUndefined();
+    } finally {
+      verify.close();
+    }
   });
 });

--- a/src/infra/startup-migration-checkpoint.ts
+++ b/src/infra/startup-migration-checkpoint.ts
@@ -238,23 +238,23 @@ function formatStartupMigrationCheckpoint(params: {
 function readMigrationCheckpoints(
   env: NodeJS.ProcessEnv,
   metaKeys: MigrationCheckpointMetaKey[],
-): Array<string | null> {
+): Array<{ metaKey: string; appVersion: string | null }> {
   return withStartupMigrationCheckpointDatabase(env, (db) => {
     const stateDb = getNodeSqliteKysely<StartupMigrationCheckpointDatabase>(db);
     const result = executeSqliteQuerySync(
       db,
       stateDb
         .selectFrom("schema_meta")
-        .select("app_version as appVersion")
+        .select(["meta_key as metaKey", "app_version as appVersion"])
         .where("meta_key", "in", metaKeys),
     );
-    return result.rows.map((row) => row.appVersion);
+    return result.rows;
   });
 }
 
 export function readStartupMigrationVersion(env: NodeJS.ProcessEnv = process.env): string | null {
   return (
-    readMigrationCheckpoints(env, [STARTUP_MIGRATION_META_KEY])[0]?.split(
+    readMigrationCheckpoints(env, [STARTUP_MIGRATION_META_KEY])[0]?.appVersion?.split(
       STARTUP_MIGRATION_BUILD_SEPARATOR,
       1,
     )[0] ?? null
@@ -292,10 +292,9 @@ export function hasActiveStartupMigrationLease(
   );
 }
 
-function needsMigrationCheckpoint(
-  metaKeys: MigrationCheckpointMetaKey[],
+export function readMigrationCheckpointStatus(
   params: MigrationCheckpointParams = {},
-): boolean {
+): "stale" | "state-current" | "startup-current" {
   const env = params.env ?? process.env;
   const buildIdentity =
     params.buildIdentity === undefined
@@ -307,20 +306,18 @@ function needsMigrationCheckpoint(
     version: params.version ?? VERSION,
   });
   if (checkpoint === null) {
-    return true;
+    return "stale";
   }
-  return !readMigrationCheckpoints(env, metaKeys).includes(checkpoint);
-}
-
-export function needsStartupMigrationCheckpoint(params: MigrationCheckpointParams = {}): boolean {
-  return needsMigrationCheckpoint([STARTUP_MIGRATION_META_KEY], params);
-}
-
-export function needsStateMigrationCheckpoint(params: MigrationCheckpointParams = {}): boolean {
   // A legacy gateway checkpoint also proves state migrations completed. The inverse is false:
   // state-only commands never certify gateway plugin convergence.
-  // Read both keys in one admission: each connection validates the whole database.
-  return needsMigrationCheckpoint([STATE_MIGRATION_META_KEY, STARTUP_MIGRATION_META_KEY], params);
+  const current = readMigrationCheckpoints(env, [
+    STATE_MIGRATION_META_KEY,
+    STARTUP_MIGRATION_META_KEY,
+  ]).filter((row) => row.appVersion === checkpoint);
+  if (current.some((row) => row.metaKey === STARTUP_MIGRATION_META_KEY)) {
+    return "startup-current";
+  }
+  return current.length > 0 ? "state-current" : "stale";
 }
 
 export function acquireStartupMigrationLease(

--- a/src/plugins/plugin-registry-snapshot.state-migration.test.ts
+++ b/src/plugins/plugin-registry-snapshot.state-migration.test.ts
@@ -11,7 +11,7 @@ import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   acquireStartupMigrationLease,
-  needsStateMigrationCheckpoint,
+  readMigrationCheckpointStatus,
   recordSuccessfulStateMigrations,
   type MigrationCheckpointIdentity,
 } from "../infra/startup-migration-checkpoint.js";
@@ -224,7 +224,7 @@ describe("persisted plugin registry Doctor contract freshness", () => {
     const reused = loadPluginMetadataSnapshot({ config: {}, env, stateDir });
     expect(reused.registrySource).toBe("persisted");
     expect(checkpointIdentity(reused)).toEqual(checkpoint.identity);
-    expect(needsStateMigrationCheckpoint(checkpoint)).toBe(false);
+    expect(readMigrationCheckpointStatus(checkpoint)).toBe("state-current");
 
     fs.writeFileSync(
       contractPath,
@@ -251,7 +251,7 @@ module.exports = {
     );
     // Package changes are visible to an explicit owner refresh, not to retained generations.
     expect(loadPluginMetadataSnapshot({ config: {}, env, stateDir })).toBe(persisted);
-    expect(needsStateMigrationCheckpoint(checkpoint)).toBe(false);
+    expect(readMigrationCheckpointStatus(checkpoint)).toBe("state-current");
     clearPluginMetadataLifecycleCaches();
     await withPluginCache(createPluginCache(), async () => {
       const refreshed = loadPluginMetadataSnapshot({ config: {}, env, stateDir });
@@ -268,8 +268,8 @@ module.exports = {
       expect(refreshedIdentity.pluginMigrationFingerprint).not.toBe(
         checkpoint.identity.pluginMigrationFingerprint,
       );
-      expect(needsStateMigrationCheckpoint({ ...checkpoint, identity: refreshedIdentity })).toBe(
-        true,
+      expect(readMigrationCheckpointStatus({ ...checkpoint, identity: refreshedIdentity })).toBe(
+        "stale",
       );
 
       const migration = await autoMigrateLegacyPluginDoctorState({ config: {}, env });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway startup repeats whole-database integrity checks while deciding whether state and startup migrations are current. Large shared-state databases pay this cost twice per checkpoint refresh.

Related: #138315

## Why This Change Was Made

Preflight now gets both decisions from one admitted, keyed read. A current startup checkpoint still proves both categories; a current state checkpoint proves only state migration completion. The two old internal predicates are removed.

The post-lease refresh remains in place so a competing startup can complete the work while this process waits. Unknown build/config/plugin identity still requires migration without opening the database, and a caller requesting neither category does not read checkpoints. Acquisition, heartbeat, completion writes and release retain their existing ownership and validation paths. State completion still commits before asynchronous plugin convergence.

## User Impact

Startup avoids two redundant database admissions in the reproduced migration sequence. This reduces repeated work; the remaining shared-state checks still run synchronously.

There is no schema, checkpoint-format, migration-policy, lease, configuration, dependency or public API change. Production delta is +23/-27 (net -4); tests and support are +194/-141 (net +53).

## Evidence

**Completed on exact head `a59a10510860f68243e39b616d750ec46bc95af6`: full changed-scope Linux gate, all 94 selected native tests, both canonical builds, and the paired real Gateway/browser proof passed. [Exact-head CI also passed](https://github.com/openclaw/openclaw/actions/runs/33956828246).**

- A native SQLite reproduction in the original caller order failed before the change with eight integrity and eight foreign-key scans against an expectation of six. The same sequence passes afterward with six of each, identical checkpoint values and zero remaining leases. Only the initial and post-acquisition refreshes lose a duplicate scan; acquisition, state completion, startup completion and release each retain validation.
- Checkpoint/native and Doctor decision regressions passed (53 tests), including mixed state/startup records, unknown identity without creating a database, future-version refusal, foreign-key corruption, competing and expired leases, post-acquisition refresh, and state success followed by plugin failure.
- Broader testing exposed five preexisting fixture failures, reproduced on unchanged main: an incomplete host-link mock and ambient provider credentials causing unexpected plugin installation. The mock now preserves real exports, and the two real-preflight fixture files use a shared isolated home that clears and restores the canonical provider credential names. Those failures are resolved; the expanded run retained one 120-second legacy-cron preflight timeout. A phase-instrumented rerun passed with unchanged config/assertions/timeout, spending 49 seconds in existing legacy-state migration. The failed local run is retained. The complete selected group and full changed-scope gate subsequently passed on the qualified Linux lease, without increasing the timeout.
- Compatibility coverage includes fresh shared state, recognized native version-zero bootstrap, legacy startup-only checkpoints, mixed checkpoint records, future-version refusal and corruption rejection. No checkpoint representation, schema DDL or completion-write function changed.
- Pinned Kysely 0.29.5 query-builder, selection/reference parsers and SQLite compiler were inspected directly. A native projection probe confirms the two aliases compile into one SELECT and retain the keyed values and SQL nulls; the adapter retains Node SQLite’s null-prototype rows.
- Typed lint passes. Fresh independent review found no actionable P0–P2 issue on tree `8605df60b7540e04e04584fee67f93260fd1fb60`; normal commit hooks preserved that exact tree in `a59a10510860f68243e39b616d750ec46bc95af6`.

The paired built proof used independent synthetic databases containing 1,000,000 shared-state rows (1,493,557,248 bytes each), Node 26.7.0 / SQLite 3.53.4 on Linux, the real Gateway CLI and normal dashboard pairing.

| Measured checkpoint work | Baseline `ce7c394f` | Candidate `a59a1051` |
| --- | ---: | ---: |
| Integrity scans | 8 | 6 |
| Foreign-key scans | 8 | 6 |
| Summed integrity-check time | 7,516.40 ms | 5,626.15 ms |

The 1,890.25 ms difference is from one synthetic pair and measures checkpoint integrity checks, not total startup time or a guaranteed production improvement. Both flows reached ready, served the built assets, preserved active history and the retained branch through reload, exited cleanly, and left zero migration leases. All fixture rows remained. Foreign-key scans followed the same phase order. The remaining six checkpoint integrity scans still ran synchronously with zero event-loop ticks during each scan; further shared-state startup admission work is a separate follow-up.

The first Linux attempt failed before tests because the isolated clone lacked `origin/main`, which the normal changed-file gate requires. The repeat retained that failure and fetched the actual public main ref before rerunning the full gate; no assertion, timeout, migration or source-trust guard was bypassed. Final proof archive SHA-256: `c692b30303ba25f606c1d98ff21ad52dec43850f5ec19cb34383163564d4fd77`.

The latest ClawSweeper rank-up request is addressed by the completed built/native evidence above; the requested pinned Kysely and checkpoint compatibility checks are recorded above. No code findings remain.

Synthetic browser proof, before and after (active history and retained branch preserved):

![Baseline retained branch](https://github.com/user-attachments/assets/beddd4d3-7975-467b-afa8-5d58493afebf)

![Candidate retained branch](https://github.com/user-attachments/assets/03e34b90-fad8-41ef-bfda-df9d6e9878f9)
