### PR TITLE
fix: XLSM attachments are rejected from host-local paths

### DIFF
--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -221,7 +221,7 @@ Local-path behavior follows the same file-read trust model as the agent:
 - If `tools.fs.workspaceOnly` is `true`, outbound local media paths stay restricted to the OpenClaw temp root, the media cache, agent workspace paths, and sandbox-generated files.
 - If `tools.fs.workspaceOnly` is `false`, outbound local media can use host-local files the agent is already allowed to read.
 - Local paths can be absolute, workspace-relative, or home-relative with `~/`.
-- Host-local sends still only allow media and safe document types (images, audio, video, PDF, Office documents, and validated text documents such as Markdown/MD, TXT, JSON, YAML, and YML). This is an extension of the existing host-read trust boundary, not a secret scanner: if the agent can read a host-local `secret.txt` or `config.json`, it can attach that file when the extension and content validation match.
+- Host-local sends still only allow media and supported document types (images, audio, video, PDF, Office documents including macro-enabled Excel `.xlsm`, and validated text documents such as Markdown/MD, TXT, JSON, YAML, and YML). This is an extension of the existing host-read trust boundary, not a secret scanner: if the agent can read a host-local `secret.txt` or `config.json`, it can attach that file when the extension and content validation match. File-type validation does not establish that an attached workbook's macros are safe to run.
 
 Keep sensitive files outside the agent-readable filesystem, or keep `tools.fs.workspaceOnly: true` for stricter local-path sends.
 

--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -443,6 +443,22 @@ describe("media store", () => {
       },
     },
     {
+      name: "preserves original extension for generic file streams",
+      run: async () => {
+        const buffer = Buffer.from("custom binary");
+        const saved = await store.saveMediaStream(
+          Readable.from([buffer]),
+          "application/octet-stream",
+          "stream-inbound",
+          1024,
+          "report.CuStOm",
+        );
+
+        expect(store.extractOriginalFilename(saved.path)).toBe("report.CuStOm");
+        await expect(fs.readFile(saved.path)).resolves.toEqual(buffer);
+      },
+    },
+    {
       name: "prefers detected stream mime over mixed-case generic zip header extension",
       run: async () => {
         const saved = await store.saveMediaStream(
@@ -642,9 +658,9 @@ describe("media store", () => {
       name: "preserves original extension for generic file buffers",
       buffer: Buffer.from("custom binary"),
       contentType: "application/octet-stream",
-      originalFilename: "report.custom",
+      originalFilename: "report.CuStOm",
       expectedContentType: "application/octet-stream",
-      expectedExtension: ".custom",
+      expectedExtension: ".CuStOm",
     },
     {
       name: "does not preserve mixed-case image header extensions for generic container buffers",

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -378,8 +378,8 @@ function safeOriginalFilenameExtension(originalFilename?: string): string | unde
   if (!originalFilename) {
     return undefined;
   }
-  const ext = extnameFromAnyPath(originalFilename).toLowerCase();
-  return /^\.[a-z0-9]{1,16}$/.test(ext) ? ext : undefined;
+  const ext = extnameFromAnyPath(originalFilename);
+  return /^\.[a-z0-9]{1,16}$/i.test(ext) ? ext : undefined;
 }
 
 function extensionForAuthoritativeHeaderMime(contentType?: string): string | undefined {

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -333,8 +333,6 @@ describe("loadWebMedia", () => {
       "xl/workbook.xml",
       '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"/>',
     );
-    // Opaque test payload checks byte preservation, not VBA validity or execution.
-    zip.file("xl/vbaProject.bin", Buffer.from("synthetic-vba-payload"));
     return await zip.generateAsync({ type: "nodebuffer" });
   }
 
@@ -914,9 +912,7 @@ describe("loadWebMedia", () => {
       const result = await loadDocumentWithHostRead(fileName, body);
 
       expect(result.kind).toBe("document");
-      expect(result.contentType?.toLowerCase()).toBe(
-        "application/vnd.ms-excel.sheet.macroenabled.12",
-      );
+      expect(result.contentType).toBe("application/vnd.ms-excel.sheet.macroenabled.12");
       expect(result.fileName).toBe(fileName);
       expect(result.buffer).toEqual(body);
     },

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -323,6 +323,21 @@ describe("loadWebMedia", () => {
     });
   }
 
+  async function createXlsmMimeFixture() {
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/xl/workbook.xml" ContentType="application/vnd.ms-excel.sheet.macroEnabled.main+xml"/></Types>',
+    );
+    zip.file(
+      "xl/workbook.xml",
+      '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"/>',
+    );
+    // Opaque test payload checks byte preservation, not VBA validity or execution.
+    zip.file("xl/vbaProject.bin", Buffer.from("synthetic-vba-payload"));
+    return await zip.generateAsync({ type: "nodebuffer" });
+  }
+
   it.each([
     {
       name: "allows localhost file URLs for local files",
@@ -890,6 +905,53 @@ describe("loadWebMedia", () => {
       }),
       "path-not-allowed",
     );
+  });
+
+  it.each(["report.xlsm", "report.XLSM"])(
+    "allows byte-verified host-read XLSM without changing %s or its bytes",
+    async (fileName) => {
+      const body = await createXlsmMimeFixture();
+      const result = await loadDocumentWithHostRead(fileName, body);
+
+      expect(result.kind).toBe("document");
+      expect(result.contentType?.toLowerCase()).toBe(
+        "application/vnd.ms-excel.sheet.macroenabled.12",
+      );
+      expect(result.fileName).toBe(fileName);
+      expect(result.buffer).toEqual(body);
+    },
+  );
+
+  it("rejects unverified text named as a host-read XLSM file", async () => {
+    await expectLoadWebMediaErrorCode(
+      loadDocumentWithHostRead("report.xlsm", "not a workbook"),
+      "path-not-allowed",
+    );
+  });
+
+  it("keeps the host-read XLSM root boundary and byte limit", async () => {
+    const body = await createXlsmMimeFixture();
+    const filePath = path.join(fixtureRoot, "bounded.xlsm");
+    await fs.writeFile(filePath, body);
+    const readFile = vi.fn((sourcePath: string) => fs.readFile(sourcePath));
+
+    await expectLoadWebMediaErrorCode(
+      loadWebMedia(filePath, {
+        localRoots: [workspaceDir],
+        readFile,
+        hostReadCapability: true,
+      }),
+      "path-not-allowed",
+    );
+    expect(readFile).not.toHaveBeenCalled();
+    await expect(
+      loadWebMedia(filePath, {
+        maxBytes: body.length - 1,
+        localRoots: [fixtureRoot],
+        readFile,
+        hostReadCapability: true,
+      }),
+    ).rejects.toThrow(/exceeds.*limit/i);
   });
 
   it("allows host-read CSV files", async () => {

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -174,6 +174,7 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "application/msword",
   "application/pdf",
   "application/vnd.ms-excel",
+  "application/vnd.ms-excel.sheet.macroenabled.12",
   "application/vnd.ms-powerpoint",
   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",


### PR DESCRIPTION
## What Problem This Solves

A byte-detected macro-enabled Excel workbook from an allowed host-local path is rejected before upload, although Office attachments are supported. The complete delivery check also exposed that staging changed an uppercase `.XLSM` suffix to lowercase.

Related: #78292, which concerns another document type missing from the host-read allowlist.

## Why This Change Was Made

Add the existing byte-detected XLSM MIME to the shared host-read document allowlist. Keep the original case of safe filename extensions when staging uses the original extension. Buffer and stream staging share this policy; authoritative MIME extension selection retains its existing precedence.

The regression fixture uses synthetic workbook metadata. It does not need a fake macro payload, and it now asserts the canonical returned MIME directly.

## User Impact

Users can send host-local XLSM workbooks through the existing attachment path with their names and bytes intact. Allowed roots, file-size limits, byte validation, and rejection of disguised text remain enforced. Attaching a workbook does not execute its macros or establish that they are safe to run.

## Evidence

- **Before:** current main `8797856260efeb94b71d88029850409416d7f74c` sent a real Discord control message, then rejected the synthetic workbook with `path-not-allowed` and the detected MIME `application/vnd.ms-excel.sheet.macroenabled.12`. No workbook arrived. The shipped `v2026.9.1` source has the same missing MIME entry.
- **After:** a real Discord guild turn through the isolated Gateway delivered both workbooks below. Downloaded bytes match the source. The provider response was deterministic; the Gateway, attachment staging, Discord upload and download were real.

| Input filename | Received filename | Downloaded bytes | Exact source match |
| --- | --- | ---: | --- |
| `report.xlsm` | `report.xlsm` | 725 | Yes |
| `report.XLSM` | `report.XLSM` | 725 | Yes |

Both files have SHA-256 `6e020cf9d32ccd4d8cdab27d93347d9fcbbd7b4e69a922856cfccc7b2d226411`.

The same turn attempted plain text named `disguised.xlsm`. No third attachment arrived. The reply visibly reported: `⚠️ disguised.xlsm: Rejected by the local attachment allowlist. Send a supported file type.`

- The tested runtime was built from an archive of the final source. All 38,038 tracked source entries match commit `1b6b179b39b18eee614a021b7c578064f193c413`; the archive build has no Git metadata, so its build stamp intentionally has no commit. Source verification and the observed build identify the tested input without rewriting that stamp.
- `node scripts/run-vitest.mjs src/media/store.test.ts src/media/web-media.test.ts packages/media-core/src/mime.test.ts`: **351 tests pass**. Coverage includes root rejection before reading, byte limits, disguised text, canonical MIME, filename/byte preservation, and buffer/stream extension handling.
- Both XLSM acceptance regressions fail on the original main owner code. Both mixed-case staging regressions fail before the staging repair.
- Pinned `oxfmt` **0.65.0**, scoped type-aware Oxlint, `node scripts/check-docs-mdx.mjs docs/start/openclaw.md`, and `git diff --check` pass. The initial combined live/lint container run exceeded its memory limit; the scoped lint run completed after live teardown with zero warnings and errors.
- Direct inspection of `file-type` **22.0.2** confirms its ZIP detector maps the workbook content type to the XLSM MIME. No new parser or extension-only acceptance path is introduced.
- Net change: **production +1**, **tests +74**, **docs 0**. The only production growth is one MIME table entry; the staging correction changes existing lines.

The live check uses synthetic files and leased test accounts. Private test identifiers and paths are omitted. This proves attachment delivery, not Excel or VBA execution.
