### PR TITLE
fix(agents): preserve configured hooks on non-default model turns

### DIFF
--- a/src/agents/runtime-plugins.hooks.integration.test.ts
+++ b/src/agents/runtime-plugins.hooks.integration.test.ts
@@ -1,0 +1,76 @@
+// Verifies direct agent registry scopes load enabled hook-only plugins so their
+// typed hooks dispatch without a Gateway request registry (issue #138368).
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createHookRunner } from "../plugins/hooks.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import { withAgentPluginRegistry } from "./runtime-plugins.js";
+
+afterEach(() => {
+  resetPluginLoaderTestStateForTest();
+});
+
+afterAll(() => {
+  cleanupPluginLoaderFixturesForTest();
+});
+
+it("loads and dispatches hook-only plugins for ingress without a request registry", async () => {
+  useNoBundledPlugins();
+  const pluginId = "prompt-hook-probe";
+  const configSchema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {},
+  };
+  const plugin = writePlugin({
+    id: pluginId,
+    configSchema,
+    body: `module.exports = {
+  id: ${JSON.stringify(pluginId)},
+  register(api) {
+    api.on("before_prompt_build", async () => ({ prependContext: "hook-injected" }));
+  },
+};\n`,
+  });
+  fs.writeFileSync(
+    path.join(plugin.dir, "openclaw.plugin.json"),
+    JSON.stringify({ id: pluginId, configSchema }),
+    "utf8",
+  );
+  const config = {
+    plugins: {
+      entries: {
+        [pluginId]: {
+          enabled: true,
+          config: {},
+          hooks: { allowConversationAccess: true },
+        },
+      },
+      load: { paths: [plugin.dir] },
+    },
+  } satisfies OpenClawConfig;
+  const workspaceDir = makePluginLoaderTempDir();
+
+  await withAgentPluginRegistry({
+    config,
+    workspaceDir,
+    run: async () => {
+      const scopedRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+      expect(scopedRegistry).toBeDefined();
+      expect(scopedRegistry?.plugins.map((entry) => entry.id)).toContain(pluginId);
+      // Dispatch through the loaded plugin instead of asserting mocked loader arguments.
+      const runner = createHookRunner(scopedRegistry!);
+      const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
+      expect(result?.prependContext).toBe("hook-injected");
+    },
+  });
+});

--- a/src/agents/runtime-plugins.hooks.integration.test.ts
+++ b/src/agents/runtime-plugins.hooks.integration.test.ts
@@ -1,7 +1,4 @@
-// Verifies direct agent registry scopes load enabled hook-only plugins so their
-// typed hooks dispatch without a Gateway request registry (issue #138368).
-import fs from "node:fs";
-import path from "node:path";
+// Verifies hook dispatch follows configured policy and explicit agent registry scopes.
 import { afterAll, afterEach, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createHookRunner } from "../plugins/hooks.js";
@@ -12,28 +9,30 @@ import {
   useNoBundledPlugins,
   writePlugin,
 } from "../plugins/loader.test-fixtures.js";
-import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
-import { withAgentPluginRegistry } from "./runtime-plugins.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import {
+  loadAgentRuntimePluginRegistryHandle,
+  withAgentPluginRegistry,
+} from "./runtime-plugins.js";
 
-afterEach(() => {
-  resetPluginLoaderTestStateForTest();
-});
+afterEach(resetPluginLoaderTestStateForTest);
+afterAll(cleanupPluginLoaderFixturesForTest);
 
-afterAll(() => {
-  cleanupPluginLoaderFixturesForTest();
-});
-
-it("loads and dispatches hook-only plugins for ingress without a request registry", async () => {
+it.each([
+  "configured",
+  "globally disabled",
+  "disabled plugin",
+  "not allowlisted",
+  "denied plugin",
+  "empty base",
+  "empty request",
+])("dispatches configured hooks while preserving %s scope", async (scope) => {
   useNoBundledPlugins();
   const pluginId = "prompt-hook-probe";
-  const configSchema = {
-    type: "object",
-    additionalProperties: false,
-    properties: {},
-  };
   const plugin = writePlugin({
     id: pluginId,
-    configSchema,
     body: `module.exports = {
   id: ${JSON.stringify(pluginId)},
   register(api) {
@@ -41,36 +40,35 @@ it("loads and dispatches hook-only plugins for ingress without a request registr
   },
 };\n`,
   });
-  fs.writeFileSync(
-    path.join(plugin.dir, "openclaw.plugin.json"),
-    JSON.stringify({ id: pluginId, configSchema }),
-    "utf8",
-  );
   const config = {
     plugins: {
+      enabled: scope !== "globally disabled",
+      ...(scope === "not allowlisted" ? { allow: ["other-plugin"] } : {}),
+      ...(scope === "denied plugin" ? { deny: [pluginId] } : {}),
       entries: {
         [pluginId]: {
-          enabled: true,
-          config: {},
+          enabled: scope !== "disabled plugin",
           hooks: { allowConversationAccess: true },
         },
       },
-      load: { paths: [plugin.dir] },
+      load: { paths: [plugin.file] },
     },
   } satisfies OpenClawConfig;
   const workspaceDir = makePluginLoaderTempDir();
-
-  await withAgentPluginRegistry({
-    config,
-    workspaceDir,
-    run: async () => {
-      const scopedRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
-      expect(scopedRegistry).toBeDefined();
-      expect(scopedRegistry?.plugins.map((entry) => entry.id)).toContain(pluginId);
-      // Dispatch through the loaded plugin instead of asserting mocked loader arguments.
-      const runner = createHookRunner(scopedRegistry!);
-      const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
-      expect(result?.prependContext).toBe("hook-injected");
-    },
-  });
+  const run = async (registry: PluginRegistry) => {
+    const result = await createHookRunner(registry).runBeforePromptBuild(
+      { prompt: "test", messages: [] },
+      {},
+    );
+    expect(result?.prependContext).toBe(scope === "configured" ? "hook-injected" : undefined);
+  };
+  if (scope === "empty base") {
+    await run(loadAgentRuntimePluginRegistryHandle({ config, workspaceDir, basePluginIds: [] }));
+  } else if (scope === "empty request") {
+    await withPluginRuntimeRegistryScope(createEmptyPluginRegistry(), () =>
+      withAgentPluginRegistry({ config, workspaceDir, run }),
+    );
+  } else {
+    await withAgentPluginRegistry({ config, workspaceDir, run });
+  }
 });

--- a/src/agents/runtime-plugins.memory-corpus.integration.test.ts
+++ b/src/agents/runtime-plugins.memory-corpus.integration.test.ts
@@ -78,7 +78,6 @@ it("keeps root-owned memory sidecars in a direct agent registry", async () => {
     workspaceDir,
     run: async () => {
       expect(listMemoryCorpusSupplements().map((entry) => entry.pluginId)).toEqual([pluginId]);
-      expect(listMemoryCorpusSupplements()[0]?.supplement).toBe(rootSupplement);
       const promptParams = { availableTools: new Set(["memory_search"]) };
       const prepared = await prepareMemoryPromptSection(promptParams);
       expect(buildMemoryPromptSection(promptParams, prepared)).toEqual([
@@ -91,7 +90,11 @@ it("keeps root-owned memory sidecars in a direct agent registry", async () => {
     config,
     workspaceDir: makePluginLoaderTempDir(),
     run: async () => {
-      expect(listMemoryCorpusSupplements()).toEqual([]);
+      // A direct scope for a different workspace loads the configured plugin fresh instead
+      // of adopting the root's sidecar instance; adoption only applies on workspace match.
+      const supplements = listMemoryCorpusSupplements();
+      expect(supplements.map((entry) => entry.pluginId)).toEqual([pluginId]);
+      expect(supplements[0]?.supplement).not.toBe(rootSupplement);
     },
   });
   await withAgentPluginRegistry({

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -570,10 +570,37 @@ describe("agent runtime plugin registries", () => {
     expect(hoisted.resolveAgentRuntimePluginLoadPlan).toHaveBeenCalledWith({
       config,
       workspaceDir: "/tmp/workspace",
-      basePluginIds: [],
+      basePluginIds: undefined,
       selections: [],
       metadataSnapshot: expect.any(Object),
     });
+  });
+
+  it("inherits active runtime ids for direct hosts without a request registry", async () => {
+    const config = {} as never;
+    hoisted.getActivePluginRegistry.mockReturnValue({
+      plugins: [
+        createPluginRecord({ id: "startup-channel", status: "loaded" }),
+        createPluginRecord({ id: "startup-provider", status: "loaded" }),
+      ],
+    });
+    const pluginRegistry = createEmptyPluginRegistry();
+    hoisted.loadPluginRegistryHandle.mockReturnValue(pluginRegistry);
+
+    await withAgentPluginRegistry({
+      config,
+      workspaceDir: "/tmp/workspace",
+      run: async () => {},
+    });
+
+    expect(hoisted.resolveAgentRuntimePluginLoadPlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        basePluginIds: ["startup-channel", "startup-provider"],
+      }),
+    );
+    expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledWith(
+      expect.objectContaining({ onlyPluginIds: ["codex", "memory-core"] }),
+    );
   });
 
   it.each([

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -157,9 +157,12 @@ export async function withAgentPluginRegistry<T>(params: {
       : { metadataSnapshot: loadPluginMetadataSnapshot(params) }),
   });
   const pluginRegistry = loadAgentRuntimePluginRegistryHandle({
+    // An ingress without a request registry inherits the configured plugin scope through the
+    // metadata/active-id fallback chain. An explicit empty base here would defeat that chain
+    // and silently drop enabled hook-only plugins from the run (issue #138368).
     basePluginIds: requestPluginRegistry
       ? listRuntimePluginIdsFromRegistry(requestPluginRegistry)
-      : [],
+      : undefined,
     config: params.config,
     env: context.env,
     metadataSnapshot: context.metadataSnapshot,

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -156,13 +156,8 @@ export async function withAgentPluginRegistry<T>(params: {
       ? { manifestRegistry: { plugins: [], diagnostics: [] } }
       : { metadataSnapshot: loadPluginMetadataSnapshot(params) }),
   });
+  // The resolver inherits request or configured scope; an empty override drops hook-only plugins.
   const pluginRegistry = loadAgentRuntimePluginRegistryHandle({
-    // An ingress without a request registry inherits the configured plugin scope through the
-    // metadata/active-id fallback chain. An explicit empty base here would defeat that chain
-    // and silently drop enabled hook-only plugins from the run (issue #138368).
-    basePluginIds: requestPluginRegistry
-      ? listRuntimePluginIdsFromRegistry(requestPluginRegistry)
-      : undefined,
     config: params.config,
     env: context.env,
     metadataSnapshot: context.metadataSnapshot,


### PR DESCRIPTION
Fixes #138368

## What Problem This Solves

Configured hook-only plugins could silently disappear when an HTTP turn selected a non-default model. The model received the stock prompt, while `before_prompt_build` and `llm_input` did not run. The local agent path shared the same omission.

## Why This Change Was Made

`withAgentPluginRegistry` supplied an explicit empty base when no request registry existed. That suppressed the owning resolver's request/metadata/active-plugin inheritance. Fresh model generations then carried an incomplete registry, and hook dispatch correctly used that generation without overlaying process-root hooks.

Remove the duplicate base selection from the caller and let the existing resolver own inheritance. Deliberate empty scopes, request-owned registries, plugin enablement, deny rules, and allowlists retain their existing behavior. No configuration, storage, or protocol contract changes.

Production delta: **+1/-3, net -2**. Test delta: **+107/-3, net +104**. The integration fixture reuses the existing plugin writer and checks real hook dispatch across seven policy/scope cases.

## User Impact

Enabled plugin hooks remain available when switching models, including their prompt changes in the actual model request. The existing registry cache remains in use.

Thanks to @syncword for the report and installed-build investigation, and @xialonglee for the original repair and regression coverage. Maintainer follow-up was AI-assisted.

## Evidence

Baseline: `8797856260efeb94b71d88029850409416d7f74c`.
Candidate: `62b8743a032f0856a1a3d2ee785e1f59cfffbddd`.

Ran real OpenClaw Gateways with a configured hook-only plugin and a real local model server. A recorder forwarded complete requests unchanged and captured the model input. The default and alternate model IDs used the same model weights, isolating model selection from model capability.

| Real HTTP observation | Baseline main | Candidate |
| --- | --- | --- |
| Default model: both hooks run | Yes | Yes |
| Non-default model in the same session: both hooks run | No | Yes |
| Non-default model: injected context reaches the model | No | Yes |
| Repeated non-default and return-to-default turns | Not needed for red | Both hooks and injected input retained |
| Responses endpoint with non-default model | Not exercised for red | Both hooks and injected input retained |

All five candidate requests returned HTTP 200. Complete provider input, rather than the small model's unreliable answer wording, establishes that the prompt hook affected the actual model call. The server used a 32,768-token context and reported no truncation. Separate background summarization calls were distinguished from agent calls.

After initial warm-up, four further turns caused **zero additional hook-plugin registrations**. Their request-to-model-dispatch times were **130–185 ms**. This checks the reported cold-load concern without adding a runtime cache or instrumentation seam.

```text
node scripts/run-vitest.mjs run src/agents/runtime-plugins.test.ts \
  src/agents/runtime-plugins.hooks.integration.test.ts \
  src/agents/runtime-plugins.memory-corpus.integration.test.ts \
  src/agents/runtime-plugins.context-engine.integration.test.ts \
  src/agents/prepared-model-runtime.inbound-registry.test.ts \
  src/agents/prepared-model-runtime.plugin-context.test.ts \
  src/agents/prepared-model-runtime.reply-fallback.test.ts
56 tests passed in seven files.
```

The expanded hook regression fails on baseline main only for the configured-hook case; all six restriction controls pass. Candidate checks include disabled plugins, a restrictive allowlist, a deny rule, explicit empty base scope, and an empty request registry. Existing tests also cover selected-harness request ownership and memory/context-engine behavior.

Focused lint: zero warnings/errors. Formatting: pinned `oxfmt 0.65.0`. Both source revisions built with the supported `pnpm build qaRuntime` profile in isolated containers. Archive-based build stamps have no Git checkout metadata; source provenance was retained from the archived SHAs, committed repair files, and explicit build commands.

The prior ClawSweeper request for real default/non-default Gateway proof is addressed above. Native channels and external hosted models were not required for this HTTP registry-selection defect.

Real non-default HTTP controls also passed with the plugin disabled and with an effective allowlist excluding it: both returned HTTP 200/MISSING, and the plugin registered no handlers. The allowlist control kept the plugin discoverable but omitted its material configuration entry, respecting the existing startup rule that admits explicitly configured plugins.
