### PR TITLE
fix(agents): prevent transcript timer mocks from failing CI

### DIFF
--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import { waitForSessionTranscriptIndexReconcile } from "../../config/sessions/session-transcript-reconcile.js";
 import { closeOpenClawAgentDatabaseByPath } from "../../state/openclaw-agent-db.js";
@@ -569,57 +570,52 @@ describe("claudeCliSessionTranscriptHasContent", () => {
       })}\n`,
     );
 
+    const graceStarted = createDeferred();
+    const releaseGrace = createDeferred();
+    const schedule = globalThis.setTimeout;
     let graceFires = 0;
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
-      handler: (...args: unknown[]) => void,
-      delay?: number,
-    ) => {
-      if (delay === GRACE_MS) {
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((handler, delay, ...args) => {
+        if (delay !== GRACE_MS) {
+          return schedule(handler, delay, ...args);
+        }
+        // Hold only this probe's grace sleep; worker completion must retain native timers.
+        setTimeoutSpy.mockRestore();
         graceFires += 1;
-        const flush = fs.appendFile(
-          file,
-          `${JSON.stringify({
-            type: "assistant",
-            message: { role: "assistant", content: [{ type: "text", text: "ack" }] },
-          })}\n`,
-          "utf-8",
-        );
-        void flush.then(() => {
-          handler();
-        });
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      }
-      return 0 as unknown as ReturnType<typeof setTimeout>;
-    }) as typeof setTimeout);
-
+        graceStarted.resolve();
+        return schedule(() => {
+          void releaseGrace.promise.then(() => handler(...args));
+        }, delay);
+      });
+    const probe = claudeCliSessionTranscriptHasContent({
+      sessionId,
+      workspaceDir,
+      homeDir: tmpDir,
+    });
     try {
-      expect(
-        await claudeCliSessionTranscriptHasContent({
-          sessionId,
-          workspaceDir,
-          homeDir: tmpDir,
-        }),
-      ).toBe(true);
+      await Promise.race([graceStarted.promise, probe]);
       expect(graceFires).toBe(1);
+      await fs.appendFile(
+        file,
+        `${JSON.stringify({
+          type: "assistant",
+          message: { role: "assistant", content: [{ type: "text", text: "ack" }] },
+        })}\n`,
+        "utf-8",
+      );
+      releaseGrace.resolve();
+      expect(await probe).toBe(true);
     } finally {
       setTimeoutSpy.mockRestore();
+      releaseGrace.resolve();
+      await probe;
     }
   });
 
   it("returns false and emits a structured v4 warn when the JSONL never appears", async () => {
     const workspaceDir = await makeWorkspace();
     const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
-      handler: (...args: unknown[]) => void,
-      delay?: number,
-    ) => {
-      if (delay === GRACE_MS) {
-        handler();
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      }
-      return 0 as unknown as ReturnType<typeof setTimeout>;
-    }) as typeof setTimeout);
-
     try {
       expect(
         await claudeCliSessionTranscriptHasContent({
@@ -644,7 +640,6 @@ describe("claudeCliSessionTranscriptHasContent", () => {
         })}`,
       );
     } finally {
-      setTimeoutSpy.mockRestore();
       warnSpy.mockRestore();
     }
   });
@@ -662,17 +657,6 @@ describe("claudeCliSessionTranscriptHasContent", () => {
     );
 
     const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
-      handler: (...args: unknown[]) => void,
-      delay?: number,
-    ) => {
-      if (delay === GRACE_MS) {
-        handler();
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      }
-      return 0 as unknown as ReturnType<typeof setTimeout>;
-    }) as typeof setTimeout);
-
     try {
       expect(
         await claudeCliSessionTranscriptHasContent({
@@ -687,7 +671,6 @@ describe("claudeCliSessionTranscriptHasContent", () => {
       expect(v4Warnings).toHaveLength(1);
       expect(v4Warnings[0]?.[0]).toContain("fileExists=true");
     } finally {
-      setTimeoutSpy.mockRestore();
       warnSpy.mockRestore();
     }
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a passing agents test shard could fail with an unhandled `slot.idleTimer.unref is not a function` while a Claude transcript-probe test awaited a file append. This unrelated failure surfaced in #138960.

## Why This Change Was Made

Three tests replaced global timers with numeric handles and dropped unrelated callbacks. A native worker completing during that interval could throw before settling its result. The warning cases now use native scheduling; the delayed-flush test restores its one-shot grace observer before awaiting the append, then releases and joins its probe in `finally`.

The fix belongs to the tests that changed the global timer contract. Production code is unchanged; tests are +35/−52, net −17 lines. Existing success, grace-window, and structured-warning assertions remain.

## User Impact

No runtime behavior changes. CI can exercise transcript persistence alongside native worker completion without these tests corrupting timer handles or leaving asynchronous work unjoined.

## Evidence

The unchanged-source diagnostic released a real repository Worker/SAB fixture during the existing test's append and reproduced the exact native idle-timer error with an unsettled result. The same candidate scenario proves result settlement, successor thread reuse, idle retirement, replacement execution, and joined close. Injecting an append failure produces only the expected test failure; the probe joins and the global timer is restored.

The 59 transcript-helper tests, 13 native worker-pool tests, and full changed-file gate pass. The original 62-file CI subgroup passes 1,067 tests with one existing skip, using normal isolation, unchanged disk-reserve rules, and two workers. Six independent Codex review passes found no P0–P2 findings. Pinned Node timer declarations and Vitest spy implementation were inspected directly.

The local reproduction establishes the timer contract defect, but does not identify which production worker originally overlapped in hosted CI. Earlier full-shard attempts hit the host's real disk-capacity reserve; the final complete pass followed cleanup. The failing baseline diagnostic also triggered Vitest's process-exit trap during its own cleanup; that secondary instrumentation error is separate from the recorded native timer failure.
