### PR TITLE
fix(signal): repair unconfigured account keys in doctor

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -83,6 +83,8 @@ Minimal config:
 
 Multi-account support: use `channels.signal.accounts` with per-account config and optional `name`. Each named account owns its `transport`; it does not inherit the top-level transport. The top-level transport belongs only to the implicit `default` account. See [Multi-account channels](/gateway/config-channels#multi-account-all-channels) for the shared pattern.
 
+If an account key such as `Work Phone` is listed as `work-phone` but reported unconfigured, run `openclaw doctor --fix` and restart the Gateway. Doctor preserves the account settings when moving an unambiguous key. If multiple keys normalize to the same account ID, or moving a key could change an account already using channel defaults, Doctor leaves it unchanged and asks you to review and rename it.
+
 Omitted account `dmPolicy` and `groupPolicy` inherit the channel root; explicit account policies win. If neither scope sets them, DMs use `pairing` and groups use `allowlist`.
 
 ## What it is

--- a/extensions/signal/config-doctor-api.ts
+++ b/extensions/signal/config-doctor-api.ts
@@ -6,6 +6,7 @@ import type {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { repairSignalAccountKeys } from "./src/account-key-repair.js";
 import { migrateLegacySignalTransportConfigSync } from "./src/config-compat.js";
 
 const RETIRED_SIGNAL_ACCOUNT_TRANSPORT_FIELDS = [
@@ -65,11 +66,12 @@ export function normalizeCompatibilityConfig({
 }: {
   cfg: OpenClawConfig;
 }): ChannelDoctorConfigMutation {
-  const streaming = streamingAliasMigration.normalizeChannelConfig({ cfg });
+  const accountKeys = repairSignalAccountKeys({ cfg });
+  const streaming = streamingAliasMigration.normalizeChannelConfig({ cfg: accountKeys.config });
   const transport = migrateLegacySignalTransportConfigSync(streaming.config);
   return {
     config: transport.config,
-    changes: [...streaming.changes, ...transport.changes],
+    changes: [...accountKeys.changes, ...streaming.changes, ...transport.changes],
     ...(transport.warnings?.length ? { warnings: transport.warnings } : {}),
   };
 }

--- a/extensions/signal/doctor-contract-api.test.ts
+++ b/extensions/signal/doctor-contract-api.test.ts
@@ -3,11 +3,109 @@ import { expectDefined } from "@openclaw/normalization-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it, vi } from "vitest";
 import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract-api.js";
+import { resolveSignalAccount } from "./src/accounts.js";
 import { migrateLegacySignalTransportConfig } from "./src/config-compat.js";
+import { signalDoctor } from "./src/doctor.js";
 
 function signalConfig(entry: Record<string, unknown>): OpenClawConfig {
   return { channels: { signal: entry } } as never;
 }
+
+describe("Signal Doctor account key repair", () => {
+  it("makes the complete named account resolvable and leaves other channels intact", () => {
+    const entry = {
+      account: "+12025550123",
+      transport: { kind: "external-native" as const, url: "http://127.0.0.1:18996" },
+      dmPolicy: "disabled" as const,
+      textChunkLimit: 321,
+      replyToMode: "off" as const,
+    };
+    const cfg: OpenClawConfig = {
+      channels: {
+        signal: { accounts: { "Work Phone": entry, personal: { enabled: false } } },
+        telegram: { accounts: { "Work Phone": { enabled: false } } },
+      },
+    };
+    const result = normalizeCompatibilityConfig({ cfg });
+    expect(result.config.channels?.signal?.accounts).toEqual({
+      "work-phone": entry,
+      personal: { enabled: false },
+    });
+    expect(resolveSignalAccount({ cfg: result.config, accountId: "work-phone" })).toMatchObject({
+      configured: true,
+      config: entry,
+    });
+    expect(result.config.channels?.telegram).toEqual(cfg.channels?.telegram);
+    expect(cfg.channels?.signal?.accounts).toHaveProperty("Work Phone");
+    expect(normalizeCompatibilityConfig({ cfg: result.config }).changes).toEqual([]);
+  });
+
+  it.each(["Work Phone", "Default.", "!!!"])(
+    "preserves a working inherited account for %s",
+    (key) => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          signal: { account: "+12025550123", accounts: { [key]: { account: "+12025550124" } } },
+        },
+      };
+      const result = normalizeCompatibilityConfig({ cfg });
+      const accountId = key === "Work Phone" ? "work-phone" : "default";
+      expect(resolveSignalAccount({ cfg: result.config, accountId }).config.account).toBe(
+        "+12025550123",
+      );
+      expect(result.config.channels?.signal?.accounts).toEqual(cfg.channels?.signal?.accounts);
+      expect(
+        signalDoctor.collectPreviewWarnings?.({ cfg, doctorFixCommand: "openclaw doctor --fix" }),
+      ).toEqual([
+        expect.stringContaining("Doctor preserved it to avoid changing a working account"),
+      ]);
+    },
+  );
+
+  it.each(["Work.Phone", "work-phone", "WORK-PHONE"])(
+    "reports colliding %s without choosing an entry",
+    (key) => {
+      const accounts = {
+        "Work Phone": { account: "+12025550123" },
+        [key]: { account: "+12025550124" },
+      };
+      const cfg: OpenClawConfig = { channels: { signal: { accounts } } };
+      const result = normalizeCompatibilityConfig({ cfg });
+      expect(result.config.channels?.signal?.accounts).toEqual(accounts);
+      expect(result.changes).toEqual([]);
+      expect(
+        signalDoctor.collectPreviewWarnings?.({ cfg, doctorFixCommand: "openclaw doctor --fix" }),
+      ).toEqual([
+        expect.stringContaining('resolve to "work-phone". Doctor preserved them; rename them'),
+      ]);
+    },
+  );
+
+  it("keeps the active default transport while repairing an independent named account", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        signal: {
+          transport: { kind: "external-native", url: "http://127.0.0.1:18996" },
+          accounts: {
+            "Default.": { account: "+12025550124" },
+            "Work Phone": { account: "+12025550123" },
+          },
+        },
+      },
+    };
+    const result = normalizeCompatibilityConfig({ cfg });
+    expect(Object.keys(result.config.channels?.signal?.accounts ?? {})).toEqual([
+      "Default.",
+      "work-phone",
+    ]);
+    expect(resolveSignalAccount({ cfg: result.config, accountId: "default" }).baseUrl).toBe(
+      "http://127.0.0.1:18996",
+    );
+    expect(
+      resolveSignalAccount({ cfg: result.config, accountId: "default" }).config.account,
+    ).toBeUndefined();
+  });
+});
 
 describe("signal streaming legacy config rules", () => {
   const rootRule = legacyConfigRules.find((rule) => rule.path.join(".") === "channels.signal");

--- a/extensions/signal/doctor-contract-api.test.ts
+++ b/extensions/signal/doctor-contract-api.test.ts
@@ -1,11 +1,13 @@
 // Signal tests cover doctor contract api plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { moveSingleAccountChannelSectionToDefaultAccount } from "openclaw/plugin-sdk/setup";
 import { describe, expect, it, vi } from "vitest";
 import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract-api.js";
 import { resolveSignalAccount } from "./src/accounts.js";
 import { migrateLegacySignalTransportConfig } from "./src/config-compat.js";
 import { signalDoctor } from "./src/doctor.js";
+import { signalSetupAdapter } from "./src/setup-core.js";
 
 function signalConfig(entry: Record<string, unknown>): OpenClawConfig {
   return { channels: { signal: entry } } as never;
@@ -42,21 +44,24 @@ describe("Signal Doctor account key repair", () => {
 
   it.each(["Work Phone", "Default.", "!!!"])(
     "preserves a working inherited account for %s",
-    (key) => {
+    async (key) => {
       const cfg: OpenClawConfig = {
         channels: {
           signal: { account: "+12025550123", accounts: { [key]: { account: "+12025550124" } } },
         },
       };
-      const result = normalizeCompatibilityConfig({ cfg });
+      const promoted = moveSingleAccountChannelSectionToDefaultAccount({
+        cfg,
+        channelKey: "signal",
+        setupSurface: signalSetupAdapter,
+      });
+      const result = normalizeCompatibilityConfig({ cfg: promoted });
       const accountId = key === "Work Phone" ? "work-phone" : "default";
       expect(resolveSignalAccount({ cfg: result.config, accountId }).config.account).toBe(
         "+12025550123",
       );
       expect(result.config.channels?.signal?.accounts).toEqual(cfg.channels?.signal?.accounts);
-      expect(
-        signalDoctor.collectPreviewWarnings?.({ cfg, doctorFixCommand: "openclaw doctor --fix" }),
-      ).toEqual([
+      expect((await signalDoctor.cleanStaleConfig?.({ cfg: result.config }))?.warnings).toEqual([
         expect.stringContaining("Doctor preserved it to avoid changing a working account"),
       ]);
     },
@@ -64,7 +69,7 @@ describe("Signal Doctor account key repair", () => {
 
   it.each(["Work.Phone", "work-phone", "WORK-PHONE"])(
     "reports colliding %s without choosing an entry",
-    (key) => {
+    async (key) => {
       const accounts = {
         "Work Phone": { account: "+12025550123" },
         [key]: { account: "+12025550124" },
@@ -73,9 +78,7 @@ describe("Signal Doctor account key repair", () => {
       const result = normalizeCompatibilityConfig({ cfg });
       expect(result.config.channels?.signal?.accounts).toEqual(accounts);
       expect(result.changes).toEqual([]);
-      expect(
-        signalDoctor.collectPreviewWarnings?.({ cfg, doctorFixCommand: "openclaw doctor --fix" }),
-      ).toEqual([
+      expect((await signalDoctor.cleanStaleConfig?.({ cfg: result.config }))?.warnings).toEqual([
         expect.stringContaining('resolve to "work-phone". Doctor preserved them; rename them'),
       ]);
     },

--- a/extensions/signal/src/account-key-repair.ts
+++ b/extensions/signal/src/account-key-repair.ts
@@ -1,0 +1,64 @@
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-resolution";
+import type { ChannelDoctorConfigMutation } from "openclaw/plugin-sdk/channel-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export function repairSignalAccountKeys({
+  cfg,
+}: {
+  cfg: OpenClawConfig;
+}): ChannelDoctorConfigMutation {
+  const signal = cfg.channels?.signal;
+  const accounts = signal?.accounts;
+  if (!accounts) {
+    return { config: cfg, changes: [] };
+  }
+  const groups = new Map<string, string[]>();
+  for (const key of Object.keys(accounts)) {
+    if (key) {
+      const id = normalizeAccountId(key);
+      groups.set(id, [...(groups.get(id) ?? []), key]);
+    }
+  }
+  const moves = new Map<string, string>();
+  const warnings: string[] = [];
+  for (const [id, keys] of groups) {
+    if (keys.length > 1) {
+      warnings.push(
+        `Signal account keys ${keys.map((key) => JSON.stringify(key)).join(", ")} resolve to "${id}". Doctor preserved them; rename them so each account has a unique normalized key.`,
+      );
+      continue;
+    }
+    for (const key of keys) {
+      if (normalizeLowercaseStringOrEmpty(key) !== id) {
+        // An unreachable entry currently inherits the root number/default transport.
+        // Making its overrides reachable must not redirect an already working route.
+        if (
+          normalizeOptionalString(signal?.account) ||
+          (id === DEFAULT_ACCOUNT_ID && signal?.transport)
+        ) {
+          warnings.push(
+            `Signal account "${key}" is listed as "${id}" but currently uses the channel defaults. Doctor preserved it to avoid changing a working account; check its settings before renaming the key to "${id}".`,
+          );
+          continue;
+        }
+        moves.set(key, id);
+      }
+    }
+  }
+  const repaired = Object.fromEntries(
+    Object.entries(accounts).map(([key, entry]) => [moves.get(key) ?? key, entry]),
+  );
+  return {
+    config: moves.size
+      ? { ...cfg, channels: { ...cfg.channels, signal: { ...signal, accounts: repaired } } }
+      : cfg,
+    changes: [...moves].map(
+      ([from, to]) => `Moved Signal account "${from}" to channels.signal.accounts.${to}.`,
+    ),
+    warnings,
+  };
+}

--- a/extensions/signal/src/doctor.ts
+++ b/extensions/signal/src/doctor.ts
@@ -1,10 +1,12 @@
 // Signal doctor resolves ambiguous shipped auto-mode endpoints once and persists a concrete kind.
 import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
 import { normalizeCompatibilityConfig } from "../doctor-contract-api.js";
+import { repairSignalAccountKeys } from "./account-key-repair.js";
 import { migrateLegacySignalTransportConfig } from "./config-compat.js";
 
 export const signalDoctor: ChannelDoctorAdapter = {
   normalizeCompatibilityConfig,
+  collectPreviewWarnings: ({ cfg }) => repairSignalAccountKeys({ cfg }).warnings ?? [],
   cleanStaleConfig: async ({ cfg }) => {
     const { detectSignalTransport } = await import("./transport-detection.runtime.js");
     return await migrateLegacySignalTransportConfig({ cfg, detect: detectSignalTransport });

--- a/extensions/signal/src/doctor.ts
+++ b/extensions/signal/src/doctor.ts
@@ -6,9 +6,18 @@ import { migrateLegacySignalTransportConfig } from "./config-compat.js";
 
 export const signalDoctor: ChannelDoctorAdapter = {
   normalizeCompatibilityConfig,
-  collectPreviewWarnings: ({ cfg }) => repairSignalAccountKeys({ cfg }).warnings ?? [],
   cleanStaleConfig: async ({ cfg }) => {
     const { detectSignalTransport } = await import("./transport-detection.runtime.js");
-    return await migrateLegacySignalTransportConfig({ cfg, detect: detectSignalTransport });
+    const transport = await migrateLegacySignalTransportConfig({
+      cfg,
+      detect: detectSignalTransport,
+    });
+    return {
+      ...transport,
+      warnings: [
+        ...(repairSignalAccountKeys({ cfg: transport.config }).warnings ?? []),
+        ...(transport.warnings ?? []),
+      ],
+    };
   },
 };

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -377,6 +377,8 @@ function restorePromotedSignalDefaultAccount(cfg: OpenClawConfig): OpenClawConfi
 
 export const signalSetupAdapter: ChannelSetupAdapter<SignalSetupInput> = {
   ...signalSetupAdapterBase,
+  // Named accounts inherit the root number; moving it would change existing routes.
+  namedAccountPromotionKeys: [],
   prepareAccountConfigInput: ({ cfg, accountId, input }) =>
     prepareSignalSetupInput({ cfg, accountId, input }),
   singleAccountKeysToMove: [


### PR DESCRIPTION
## What Problem This Solves

Configured Signal accounts such as `Work Phone` appeared as `work-phone` but were skipped as unconfigured, preventing account startup.

Credit: @marmar9615-cloud for the original report and Doctor repair approach.

## Why This Change Was Made

Account listing normalized names that runtime lookup could not resolve. Signal Doctor now moves unambiguous keys to those normalized names while preserving complete account settings. It leaves collisions and working inherited routes unchanged and gives rename guidance.

## User Impact

Run `openclaw doctor --fix`, then restart the Gateway to activate the repaired account. Accounts that need a manual rename receive guidance.

Older saved configuration is repaired through the existing Doctor flow; complete settings and working default routes are preserved.

## Evidence

- The real Gateway listed the account as unconfigured and skipped startup before the fix; after Doctor repair and restart, it reported the account configured and running at its authored endpoint.
- A source-built `v2026.9.4` command line wrote the saved configuration and its Gateway reproduced the failure; the fixed version repaired and started that account.
- Doctor preview explained the move without changing the authored key. A second repair left the complete Signal configuration unchanged.
- Gateway checks preserved canonical settings, inherited routes, and other channels, and verified collision guidance. Live reload, Signal daemon health, and message delivery were not verified.

## Consumers

- Signal Doctor users: can repair unreachable account names or receive guidance when a rename needs a decision.
- Signal Gateway startup and account-status callers: recognize repaired accounts and start them with their saved settings after restart.
