### PR TITLE
fix(auto-reply): stop a malformed flush from crashing the gateway (#125079)

### DIFF
--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -133,6 +133,20 @@ function createInboundDebounceFlush(params: {
 const DEFAULT_MAX_TRACKED_KEYS = 2048;
 const MAX_DEBOUNCE_WINDOW_MULTIPLIER = 5;
 
+/**
+ * A flush is only usable if it carries real admission/completion promises.
+ * onFlush is contracted to return them (normally via createInboundDebounceFlush),
+ * but a malformed return must be rejected before we deref them — otherwise the
+ * `.catch` access in runFlush throws an uncaught TypeError and crashes the process.
+ */
+function isFlushPromise(value: unknown): value is Promise<void> {
+  if (value === null || (typeof value !== "object" && typeof value !== "function")) {
+    return false;
+  }
+  const candidate = value as { then?: unknown; catch?: unknown };
+  return typeof candidate.then === "function" && typeof candidate.catch === "function";
+}
+
 /** Options for creating a keyed inbound debouncer. */
 export type InboundDebounceCreateParams<T> = {
   debounceMs: number;
@@ -175,6 +189,19 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       flush = params.onFlush(items, createInboundDebounceFlush);
     } catch (err) {
       reportFlushError(err, items);
+      return;
+    }
+    // A malformed flush (missing admission/completion) would crash the process
+    // on the `.catch` deref below. Route it through the same non-fatal path a
+    // thrown onFlush already takes so one bad inbound event can't take the
+    // gateway down. See openclaw/openclaw#125079.
+    if (!isFlushPromise(flush?.admission) || !isFlushPromise(flush?.completion)) {
+      reportFlushError(
+        new Error(
+          "Inbound debounce onFlush returned a malformed flush (missing admission/completion promise)",
+        ),
+        items,
+      );
       return;
     }
     let reported = false;

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -434,6 +434,28 @@ describe("createInboundDebouncer", () => {
     return { admission: completion, completion };
   };
 
+  it("reports, without crashing, when onFlush returns a malformed flush (openclaw#125079)", async () => {
+    const errors: unknown[] = [];
+    // A consumer returning an object without admission/completion promises used
+    // to throw an uncaught TypeError on the `.catch` deref and take the process
+    // down. It must now surface via onError instead.
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 0,
+      buildKey: (item) => item.key,
+      onFlush: () => ({}) as unknown as TestInboundDebounceFlush,
+      onError: (err) => {
+        errors.push(err);
+      },
+    });
+
+    // A rejection here would be the pre-fix crash surfacing; awaiting is the assertion.
+    await debouncer.enqueue({ key: "a", id: "1" });
+    await debouncer.drain();
+
+    expect(errors).toHaveLength(1);
+    expect(String(errors[0])).toContain("malformed flush");
+  });
+
   it("debounces and combines items", async () => {
     vi.useFakeTimers();
     const calls: Array<string[]> = [];


### PR DESCRIPTION
## Problem

Fixes #125079.

`runFlush` in `src/auto-reply/inbound-debounce.ts` dereferences the flush's promises **immediately after** calling the consumer's `onFlush`, and **outside** the `try/catch` that guards the `onFlush` call itself:

```ts
try {
  flush = params.onFlush(items, createInboundDebounceFlush);
} catch (err) {
  reportFlushError(err, items);
  return;
}
// ...
const admission = flush.admission.catch(reportOnce);   // <-- throws if flush.admission is undefined
const completion = flush.completion.catch(reportOnce);
```

`onFlush` is contracted to return `{ admission, completion }` promises (normally via `createInboundDebounceFlush`), but if a channel consumer returns a malformed object without them, `flush.admission.catch` throws:

```
TypeError: Cannot read properties of undefined (reading 'catch')
```

Because this deref sits outside the `try/catch`, the throw isn't contained — it surfaces as an uncaught error and **takes the whole gateway process down**. In #125079 this is triggered by `lid`-addressed WhatsApp inbound events, which get dead-lettered ~24h later after the crash/retry churn. In production I also observed it as a hard restart loop (`NRestarts` climbing, one crash per matching inbound event).

## Fix

Validate the flush shape before consuming it. If `admission`/`completion` aren't thenables, route the event through the **existing** non-fatal `reportFlushError` path — exactly what a *thrown* `onFlush` already does — so the bad event reaches `onError`/retry instead of killing the process:

```ts
if (!isFlushPromise(flush?.admission) || !isFlushPromise(flush?.completion)) {
  reportFlushError(new Error("Inbound debounce onFlush returned a malformed flush (missing admission/completion promise)"), items);
  return;
}
```

This is a defensive hardening at the debounce boundary: one malformed inbound event can no longer crash the gateway. It is intentionally **not** an attempt to fix *why* a particular channel produces a malformed flush for `lid` events (see the extension-side discussion in #125079) — it makes the core resilient regardless of which consumer misbehaves.

## Testing

- Added a regression test in `src/auto-reply/inbound.test.ts` (`createInboundDebouncer` block) that returns a malformed flush and asserts the debouncer surfaces one `onError` **without throwing**.
- Verified before/after against the actual edited module in isolation (transpiled with its two runtime imports stubbed):
  - **before** the guard: `enqueue`/`drain` throws the `TypeError`, `onError` never fires;
  - **after** the guard: no throw, exactly one `onError` carrying the "malformed flush" message.

Full unit suite (`pnpm test:unit`) wasn't run locally against the 3.6 GB monorepo — leaving that to CI on this PR.