### PR TITLE
fix: keep database preflight responsive during gateway startup

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -2145,8 +2145,8 @@ describe("runGatewayLoop", () => {
       vi.clearAllMocks();
       await withIsolatedSignals(async ({ captureSignal }) => {
         const entered = createDeferredCore<AbortSignal>();
-        const cleanup = createDeferredCore<void>();
-        const activeDrain = createDeferredCore<void>();
+        const cleanup = createDeferredCore();
+        const activeDrain = createDeferredCore();
         waitForGatewayActiveWork.mockImplementationOnce(async () => {
           await activeDrain.promise;
           return { drained: true, snapshot: idleActiveWorkSnapshot };
@@ -2159,9 +2159,9 @@ describe("runGatewayLoop", () => {
         const start: Parameters<typeof runGatewayLoop>[0]["start"] = async (options) => {
           await options!.startupOperation!(async (signal) => {
             entered.resolve(signal);
-            await new Promise<void>((resolve) =>
-              signal.addEventListener("abort", () => resolve(), { once: true }),
-            );
+            await new Promise<void>((resolve) => {
+              signal.addEventListener("abort", () => resolve(), { once: true });
+            });
             await cleanup.promise;
             throw scenario === "cleanup-failure" ? cleanupFailure : signal.reason;
           });
@@ -2187,11 +2187,15 @@ describe("runGatewayLoop", () => {
           expect(signal.aborted).toBe(true);
           // A duplicate signal cannot bypass the already admitted cleanup join.
           captureSignal("SIGINT")();
-          await new Promise<void>((resolve) => setImmediate(resolve));
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
           expect(runtime.exit).not.toHaveBeenCalled();
           expect(completeBoot).not.toHaveBeenCalled();
           cleanup.resolve();
-          await new Promise<void>((resolve) => setImmediate(resolve));
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
           expect(loopFinished).toBe(false);
           expect(runtime.exit).not.toHaveBeenCalled();
           expect(completeBoot).not.toHaveBeenCalled();
@@ -2228,7 +2232,7 @@ describe("runGatewayLoop", () => {
     async (phase) => {
       await withIsolatedSignals(async ({ captureSignal }) => {
         const entered = createDeferredCore<GatewayStartupOperation>();
-        const resumeStartup = createDeferredCore<void>();
+        const resumeStartup = createDeferredCore();
         const close = createCloseMock();
         const acquireResource = vi.fn(async () => {});
         const { runtime, exited } = createRuntimeWithExitSignal();
@@ -2249,7 +2253,9 @@ describe("runGatewayLoop", () => {
             captureSignal("SIGINT")();
             await exited;
           } else {
-            await new Promise<void>((resolve) => setImmediate(resolve));
+            await new Promise<void>((resolve) => {
+              setImmediate(resolve);
+            });
           }
           await expect(startupOperation(acquireResource)).rejects.toMatchObject({
             name: "AbortError",

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { HostedGatewayStop } from "../../daemon/hosted-stop.js";
-import type { GatewayServer } from "../../gateway/server-public.js";
+import type { GatewayServer, GatewayStartupOperation } from "../../gateway/server-public.js";
 import type { GatewayBonjourBeacon } from "../../infra/bonjour-discovery.js";
 import type { GatewayActiveWorkSnapshot } from "../../infra/gateway-active-work.js";
 import type { GatewayBootLifecycleCompletion } from "../../infra/gateway-boot-lifecycle.js";
@@ -1145,6 +1145,7 @@ describe("runGatewayLoop", () => {
           startupStartedAt: expect.any(Number),
           requestHotReloadRecovery: requestGatewayRestartWithSignalAdmission,
           hostLifecycle: { request: expect.any(Function) },
+          startupOperation: expect.any(Function),
         });
         expect(runtime.exit).toHaveBeenCalledWith(0);
         expect(stopManagedProviderLocalServices).toHaveBeenCalledOnce();
@@ -2137,6 +2138,135 @@ describe("runGatewayLoop", () => {
       vi.useRealTimers();
     }
   });
+
+  it.each(["stop", "restart-then-stop", "cleanup-failure"] as const)(
+    "joins admitted startup cleanup for %s before exiting",
+    async (scenario) => {
+      vi.clearAllMocks();
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const entered = createDeferredCore<AbortSignal>();
+        const cleanup = createDeferredCore<void>();
+        const activeDrain = createDeferredCore<void>();
+        waitForGatewayActiveWork.mockImplementationOnce(async () => {
+          await activeDrain.promise;
+          return { drained: true, snapshot: idleActiveWorkSnapshot };
+        });
+        const cleanupFailure = new Error("startup snapshot cleanup failed");
+        const completeBoot = vi.fn();
+        const close = createCloseMock();
+        const { runtime, exited } = createRuntimeWithExitSignal();
+        const { runGatewayLoop } = await import("./run-loop.js");
+        const start: Parameters<typeof runGatewayLoop>[0]["start"] = async (options) => {
+          await options!.startupOperation!(async (signal) => {
+            entered.resolve(signal);
+            await new Promise<void>((resolve) =>
+              signal.addEventListener("abort", () => resolve(), { once: true }),
+            );
+            await cleanup.promise;
+            throw scenario === "cleanup-failure" ? cleanupFailure : signal.reason;
+          });
+          return createGatewayServer(close);
+        };
+        const loop = runGatewayLoop({ start, runtime, completeBoot });
+        const settled = Promise.allSettled([loop]);
+        let loopFinished = false;
+        void settled.then(() => {
+          loopFinished = true;
+        });
+        const signal = await entered.promise;
+        try {
+          if (scenario === "restart-then-stop") {
+            captureSignal("SIGUSR1")();
+            await waitForLoopCondition(
+              () => markGatewaySigusr1RestartHandled.mock.calls.length > 0,
+              "expected queued startup restart",
+            );
+            expect(signal.aborted).toBe(false);
+          }
+          captureSignal("SIGINT")();
+          expect(signal.aborted).toBe(true);
+          // A duplicate signal cannot bypass the already admitted cleanup join.
+          captureSignal("SIGINT")();
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          expect(runtime.exit).not.toHaveBeenCalled();
+          expect(completeBoot).not.toHaveBeenCalled();
+          cleanup.resolve();
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          expect(loopFinished).toBe(false);
+          expect(runtime.exit).not.toHaveBeenCalled();
+          expect(completeBoot).not.toHaveBeenCalled();
+          activeDrain.resolve();
+          await expect(exited).resolves.toBe(scenario === "cleanup-failure" ? 1 : 0);
+          if (scenario === "cleanup-failure") {
+            expect(await settled).toEqual([{ status: "rejected", reason: cleanupFailure }]);
+            expect(completeBoot).toHaveBeenCalledExactlyOnceWith({
+              outcome: "forced_stop",
+              reason: "gateway.stop_close_failed",
+            });
+          } else {
+            expect(await settled).toEqual([{ status: "fulfilled", value: undefined }]);
+            expect(completeBoot).toHaveBeenCalledExactlyOnceWith({
+              outcome: "clean_stop",
+              reason: "gateway.stop",
+            });
+          }
+          expect(close).not.toHaveBeenCalled();
+        } finally {
+          if (!signal.aborted) {
+            captureSignal("SIGINT")();
+          }
+          cleanup.resolve();
+          activeDrain.resolve();
+          await settled;
+        }
+      });
+    },
+  );
+
+  it.each(["stopped", "started"] as const)(
+    "refuses retained startup work after %s",
+    async (phase) => {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const entered = createDeferredCore<GatewayStartupOperation>();
+        const resumeStartup = createDeferredCore<void>();
+        const close = createCloseMock();
+        const acquireResource = vi.fn(async () => {});
+        const { runtime, exited } = createRuntimeWithExitSignal();
+        const { runGatewayLoop } = await import("./run-loop.js");
+        const start: Parameters<typeof runGatewayLoop>[0]["start"] = async (options) => {
+          entered.resolve(options!.startupOperation!);
+          if (phase === "stopped") {
+            await resumeStartup.promise;
+            await options!.startupOperation!(acquireResource);
+          }
+          return createGatewayServer(close);
+        };
+        const loop = runGatewayLoop({ start, runtime });
+        const observed = loop.catch(() => {});
+        const startupOperation = await entered.promise;
+        try {
+          if (phase === "stopped") {
+            captureSignal("SIGINT")();
+            await exited;
+          } else {
+            await new Promise<void>((resolve) => setImmediate(resolve));
+          }
+          await expect(startupOperation(acquireResource)).rejects.toMatchObject({
+            name: "AbortError",
+          });
+          expect(acquireResource).not.toHaveBeenCalled();
+        } finally {
+          resumeStartup.resolve();
+          if (phase === "started") {
+            captureSignal("SIGINT")();
+            await exited;
+          } else {
+            await observed;
+          }
+        }
+      });
+    },
+  );
 
   it("processes SIGINT immediately before startup returns a server", async () => {
     vi.clearAllMocks();

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -12,7 +12,7 @@ import {
   markGatewayRestartTrace,
   startGatewayRestartTrace,
 } from "../../gateway/restart-trace.js";
-import type { GatewayHostLifecycle } from "../../gateway/server-public.js";
+import type { GatewayHostLifecycle, GatewayStartupOperation } from "../../gateway/server-public.js";
 import { GatewayStartupCleanupError } from "../../gateway/server-shutdown.js";
 import type { startGatewayServer } from "../../gateway/server.js";
 import { flushDiagnosticsTimeline } from "../../infra/diagnostics-timeline.js";
@@ -30,6 +30,7 @@ import { flushLogger } from "../../logging/logger.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { runOutsideGatewayRootWorkAdmission } from "../../process/gateway-work-admission.js";
 import type { RuntimeEnv } from "../../runtime.js";
+import { AsyncWorkScope } from "../../shared/async-work-scope.js";
 import { drainGlobalSingletonLifecycleState } from "../../shared/global-singleton.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import {
@@ -103,12 +104,54 @@ async function waitForHealthyGatewayChild(
   return false;
 }
 
+function createGatewayStartupOperations(): {
+  run: GatewayStartupOperation;
+  signal: AbortSignal;
+  close(): void;
+  failedWith(error: unknown): boolean;
+  stopCompletion?: Promise<void>;
+  drain(): Promise<void>;
+} {
+  const scope = new AsyncWorkScope();
+  let failure: { error: unknown } | undefined;
+  const run: GatewayStartupOperation = async (operation) => {
+    if (scope.isClosing) {
+      throw scope.signal.reason;
+    }
+    return await scope.track(async () => {
+      try {
+        return await operation(scope.signal);
+      } catch (error) {
+        if (!scope.signal.aborted || error !== scope.signal.reason) {
+          failure ??= { error };
+        }
+        throw error;
+      }
+    });
+  };
+  return {
+    run,
+    signal: scope.signal,
+    close: () => scope.beginClose(),
+    failedWith: (error: unknown) => failure !== undefined && failure.error === error,
+    async drain() {
+      await scope.drain();
+      // AsyncWorkScope joins descendants with allSettled; failed cleanup must
+      // still make the accepted stop fail rather than certify a clean exit.
+      if (failure) {
+        throw failure.error;
+      }
+    },
+  };
+}
+
 export async function runGatewayLoop(params: {
   start: (params?: {
     processStartedAt?: number;
     startupStartedAt?: number;
     requestHotReloadRecovery?: GatewayRestartEmitter;
     hostLifecycle?: GatewayHostLifecycle;
+    startupOperation?: GatewayStartupOperation;
   }) => Promise<Awaited<ReturnType<typeof startGatewayServer>>>;
   runtime: RuntimeEnv;
   /** Grants this run loop authority over the process it exclusively owns. */
@@ -148,6 +191,7 @@ export async function runGatewayLoop(params: {
   let lock = await acquireGatewayLock({ port: params.lockPort });
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
   let hostLifecycle: ReturnType<typeof createGatewayHostLifecycle> | undefined;
+  let startupOperations = createGatewayStartupOperations();
   let terminalHostedStop: ReturnType<typeof createGatewayHostLifecycle> | undefined;
   let shuttingDown = false;
   let restartResolver: (() => void) | null = null;
@@ -611,6 +655,12 @@ export async function runGatewayLoop(params: {
   const runAcceptedRequest = (acceptedRequest: GatewayRunSignalRequest) => {
     const { action, restartIntent } = acceptedRequest;
     const isRestart = action !== "stop";
+    const acceptedStartupOperations = startupOperations;
+    if (acceptedRequest.action === "stop") {
+      // A queued restart still needs startup's close handle. Only an effective
+      // stop cancels preflight, including a stop overriding that queued restart.
+      acceptedStartupOperations.close();
+    }
     if (action === "restart") {
       activeRestartRequest = acceptedRequest;
     } else if (!isRestart) {
@@ -654,7 +704,7 @@ export async function runGatewayLoop(params: {
       };
     }
 
-    void (async () => {
+    const completion = (async () => {
       let managedUpdateOwner: GatewayRestartIntent["successorOwner"];
       let managedUpdateCancellation:
         | false
@@ -828,6 +878,9 @@ export async function runGatewayLoop(params: {
           : restartDrainTimeoutMs === undefined
             ? SHUTDOWN_TIMEOUT_MS - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS
             : Math.max(0, (restartDrainDeadlineAt ?? Date.now()) - Date.now());
+        if (acceptedRequest.action === "stop") {
+          await acceptedStartupOperations.drain();
+        }
         await server?.close({
           reason: isRestart ? "gateway restarting" : "gateway stopping",
           restartExpectedMs: isRestart ? 1500 : null,
@@ -883,6 +936,14 @@ export async function runGatewayLoop(params: {
         }
       }
     })();
+    if (acceptedRequest.action === "stop") {
+      acceptedStartupOperations.stopCompletion = completion;
+    }
+    // Startup can still be awaiting unrelated work; observe shutdown immediately
+    // while retaining its rejecting promise for the cancelled startup's join.
+    void completion.catch((error: unknown) => {
+      gatewayLog.error(`gateway lifecycle completion failed: ${formatErrorMessage(error)}`);
+    });
   };
   const flushPendingStartupRequest = (opts: { allowMissingServer?: boolean } = {}) => {
     if (!pendingStartupRequest || !restartResolver) {
@@ -1175,6 +1236,10 @@ export async function runGatewayLoop(params: {
     // SIGTERM/SIGINT still exit after a graceful shutdown.
     let isFirstIteration = true;
     for (;;) {
+      const iterationStartupOperations = isFirstIteration
+        ? startupOperations
+        : createGatewayStartupOperations();
+      startupOperations = iterationStartupOperations;
       await hostLifecycle?.retire();
       const iterationHost = createGatewayHostLifecycle({
         processOwner: {
@@ -1203,7 +1268,9 @@ export async function runGatewayLoop(params: {
           startupStartedAt,
           requestHotReloadRecovery: eagerLifecycleRuntime.requestGatewayRestartWithSignalAdmission,
           hostLifecycle: iterationHost.capability,
+          startupOperation: iterationStartupOperations.run,
         });
+        iterationStartupOperations.close();
         server = startedServer;
         startupFailedWithoutServerHandle = false;
         await new Promise<void>((resolve, reject) => {
@@ -1215,6 +1282,18 @@ export async function runGatewayLoop(params: {
           flushPendingStartupRequest();
         });
       } catch (err) {
+        iterationStartupOperations.close();
+        if (
+          iterationStartupOperations.stopCompletion &&
+          (err === iterationStartupOperations.signal.reason ||
+            iterationStartupOperations.failedWith(err))
+        ) {
+          await iterationStartupOperations.stopCompletion;
+          if (err === iterationStartupOperations.signal.reason) {
+            return;
+          }
+          throw err;
+        }
         await iterationHost.retire();
         const failedServer = server;
         server = null;

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -1124,6 +1124,7 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
         startupStartedAt,
         requestHotReloadRecovery,
         hostLifecycle,
+        startupOperation,
       } = {}) => {
         const startupConfigSnapshotReadForThisStart = startupConfigSnapshotReadForNextStart;
         startupConfigSnapshotReadForNextStart = undefined;
@@ -1135,6 +1136,7 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
           ...(processStartedAt !== undefined ? { processStartedAt } : {}),
           startupStartedAt,
           hostLifecycle,
+          startupOperation,
           ...(requestHotReloadRecovery ? { hotReloadRecovery: requestHotReloadRecovery } : {}),
           ...(startupConfigSnapshotReadForThisStart
             ? { startupConfigSnapshotRead: startupConfigSnapshotReadForThisStart }

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -7186,6 +7186,51 @@ describe("update-cli", () => {
     }
   });
 
+  it.each(["interrupted", "completed"] as const)(
+    "refuses mutation through a %s Windows task recovery owner",
+    async (outcome) => {
+      const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      const processOnSpy = vi.spyOn(process, "on");
+      const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+      const { maybeStopManagedServiceBeforeMutableUpdate, UpdateCommandAbort } =
+        await import("./update-cli/update-command-service.js");
+      mockRunningManagedGateway(["node", path.join(process.cwd(), "dist", "index.js"), "gateway"]);
+      suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(true);
+      resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(true);
+      const stopped = await maybeStopManagedServiceBeforeMutableUpdate({
+        root: process.cwd(),
+        updateInstallKind: "package",
+        shouldRestart: true,
+        jsonMode: true,
+      });
+      const recovery = requireValue(stopped.windowsTaskAutoStartRecovery, "task recovery owner");
+      try {
+        if (outcome === "interrupted") {
+          const listener = processOnSpy.mock.calls.find(([event]) => event === "SIGINT")?.[1];
+          if (typeof listener !== "function") {
+            throw new Error("missing task recovery signal handler");
+          }
+          listener();
+        } else {
+          await recovery.restore();
+          recovery.complete();
+        }
+        expect(() => recovery.beginMutation()).toThrow(UpdateCommandAbort);
+      } finally {
+        await recovery.restore();
+        recovery.complete();
+        if (outcome === "interrupted") {
+          await vi.waitFor(() => expect(processExitSpy).toHaveBeenCalledWith(130));
+        }
+        platformSpy.mockRestore();
+        processOnSpy.mockRestore();
+        processExitSpy.mockRestore();
+      }
+      expect(resumeScheduledTaskAutoStartAfterUpdate).toHaveBeenCalledOnce();
+      expect(packageInstallCommandCall()).toBeUndefined();
+    },
+  );
+
   it("does not restore autostart on a pinned Windows task replaced during service stop", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     mockRunningManagedGateway(["node", path.join(process.cwd(), "dist", "index.js"), "gateway"]);
@@ -7222,19 +7267,39 @@ describe("update-cli", () => {
     expect(packageInstallCommandCall()).toBeUndefined();
   });
 
-  it.each(["SIGINT", "SIGBREAK"] as const)(
-    "restores Windows Scheduled Task autostart on %s during suspension",
-    async (signal) => {
+  it.each(
+    (["SIGINT", "SIGBREAK"] as const).flatMap((signal) =>
+      (["suspension", "schema preflight"] as const).map((phase) => ({ signal, phase })),
+    ),
+  )(
+    "restores Windows Scheduled Task autostart on $signal during $phase",
+    async ({ signal, phase }) => {
       const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
       const processOnSpy = vi.spyOn(process, "on");
       const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-      let finishSuspension: ((suspended: boolean) => void) | undefined;
-      suspendScheduledTaskAutoStartForUpdate.mockImplementationOnce(
-        () =>
-          new Promise<boolean>((resolve) => {
-            finishSuspension = resolve;
-          }),
-      );
+      const gate = createDeferred<void>();
+      const entered = createDeferred<void>();
+      const waitForSignal = async () => {
+        entered.resolve();
+        await gate.promise;
+      };
+      suspendScheduledTaskAutoStartForUpdate.mockImplementationOnce(async () => {
+        if (phase === "suspension") {
+          await waitForSignal();
+        }
+        return true;
+      });
+      if (phase === "schema preflight") {
+        vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(
+          packageTargetStatus({ schemaVersions: { state: 3, agent: 11 } }),
+        );
+        databasePreflightMocks.preflightOpenClawDatabaseSchemas
+          .mockReturnValueOnce({ incompatible: [], indeterminate: [] })
+          .mockImplementationOnce(async () => {
+            await waitForSignal();
+            return { incompatible: [], indeterminate: [] };
+          });
+      }
       resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(true);
       mockPackageInstallStatus(createCaseDir("openclaw-update-suspension-signal"));
       primeServiceCommand(["openclaw", "gateway", "run"], {
@@ -7244,31 +7309,42 @@ describe("update-cli", () => {
       serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
 
       const updatePromise = updateCommand({ yes: true, restart: false });
-      await vi.waitFor(() => expect(suspendScheduledTaskAutoStartForUpdate).toHaveBeenCalledOnce());
-      const signalListener = processOnSpy.mock.calls.find(([event]) => event === signal)?.[1];
-      if (typeof signalListener !== "function" || !finishSuspension) {
-        throw new Error(`expected armed ${signal} recovery and pending task suspension`);
-      }
-      signalListener();
-      signalListener();
-      expect(resumeScheduledTaskAutoStartAfterUpdate).not.toHaveBeenCalled();
-      finishSuspension(true);
+      try {
+        await Promise.race([
+          entered.promise,
+          updatePromise.then(() => {
+            throw new Error(`update completed before ${phase}`);
+          }),
+        ]);
+        const signalListener = processOnSpy.mock.calls.find(([event]) => event === signal)?.[1];
+        if (typeof signalListener !== "function") {
+          throw new Error(`expected armed ${signal} recovery during ${phase}`);
+        }
+        signalListener();
+        signalListener();
+        expect(resumeScheduledTaskAutoStartAfterUpdate).not.toHaveBeenCalled();
+        expect(packageInstallCommandCall()).toBeUndefined();
+        gate.resolve();
 
-      await updatePromise;
-      expect(resumeScheduledTaskAutoStartAfterUpdate).toHaveBeenCalledTimes(1);
-      expect(serviceStop).not.toHaveBeenCalled();
-      expect(packageInstallCommandCall()).toBeUndefined();
-      expect(listUpdateRuns({ limit: 1 })).toMatchObject([
-        { phase: "finished", status: "skipped", reason: "cancelled" },
-      ]);
-      expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
-      await vi.waitFor(() => {
-        expect(processExitSpy).toHaveBeenCalledTimes(2);
-        expect(processExitSpy).toHaveBeenCalledWith(130);
-      });
-      platformSpy.mockRestore();
-      processOnSpy.mockRestore();
-      processExitSpy.mockRestore();
+        await updatePromise;
+        expect(resumeScheduledTaskAutoStartAfterUpdate).toHaveBeenCalledOnce();
+        expect(serviceStop).not.toHaveBeenCalled();
+        expect(packageInstallCommandCall()).toBeUndefined();
+        expect(listUpdateRuns({ limit: 1 })).toMatchObject([
+          { phase: "finished", status: "skipped", reason: "cancelled" },
+        ]);
+        expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+        await vi.waitFor(() => {
+          expect(processExitSpy).toHaveBeenCalledTimes(2);
+          expect(processExitSpy).toHaveBeenCalledWith(130);
+        });
+      } finally {
+        gate.resolve();
+        await updatePromise;
+        platformSpy.mockRestore();
+        processOnSpy.mockRestore();
+        processExitSpy.mockRestore();
+      }
     },
   );
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -7277,8 +7277,8 @@ describe("update-cli", () => {
       const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
       const processOnSpy = vi.spyOn(process, "on");
       const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-      const gate = createDeferred<void>();
-      const entered = createDeferred<void>();
+      const gate = createDeferred();
+      const entered = createDeferred();
       const waitForSignal = async () => {
         entered.resolve();
         await gate.promise;

--- a/src/cli/update-cli/schema-preflight.ts
+++ b/src/cli/update-cli/schema-preflight.ts
@@ -29,10 +29,10 @@ export function formatSchemaRefusalLines(
   ];
 }
 
-export function checkTargetDatabaseSchemas(
+export async function checkTargetDatabaseSchemas(
   supportedVersions: OpenClawSchemaVersions | undefined,
   env: NodeJS.ProcessEnv = process.env,
-): OpenClawDatabaseSchemaPreflight {
+): Promise<OpenClawDatabaseSchemaPreflight> {
   return supportedVersions
     ? preflightOpenClawDatabaseSchemas({ env, supportedVersions })
     : { incompatible: [], indeterminate: [] };

--- a/src/cli/update-cli/update-command-execution.ts
+++ b/src/cli/update-cli/update-command-execution.ts
@@ -252,7 +252,7 @@ export async function executeMutableUpdate(params: {
     }
     const postStopPackageSchemaPreflight =
       params.updateInstallKind === "package"
-        ? checkTargetDatabaseSchemas(
+        ? await checkTargetDatabaseSchemas(
             params.packageTargetSchemaVersions,
             preManagedServiceStop?.serviceEnv ?? process.env,
           )

--- a/src/cli/update-cli/update-command-git.ts
+++ b/src/cli/update-cli/update-command-git.ts
@@ -140,7 +140,7 @@ export function createBeforeGitMutation(params: {
         `Update refused: could not inspect the target's schema support (${target.metadataUnreadable}). Retry, or see ${OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
       );
     }
-    const preStopSchemas = checkTargetDatabaseSchemas(target?.schemaVersions);
+    const preStopSchemas = await checkTargetDatabaseSchemas(target?.schemaVersions);
     if (hasSchemaRefusal(preStopSchemas)) {
       throw new UpdatePreMutationError(
         "database-schema-preflight",
@@ -149,7 +149,7 @@ export function createBeforeGitMutation(params: {
     }
     await params.stopManagedService(params.roots);
     const preManagedServiceStop = params.getPreManagedServiceStop();
-    const postStopSchemas = checkTargetDatabaseSchemas(
+    const postStopSchemas = await checkTargetDatabaseSchemas(
       target?.schemaVersions,
       preManagedServiceStop?.serviceEnv ?? process.env,
     );

--- a/src/cli/update-cli/update-command-service-maintenance.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.ts
@@ -354,6 +354,11 @@ async function maybeSuspendWindowsTaskAutoStartForUpdate(params: {
   const suspensionPromise = suspendScheduledTaskAutoStartForUpdate(serviceEnv);
   const recovery: WindowsTaskAutoStartRecovery = {
     beginMutation: () => {
+      // Async preflight may outlive a signal or settled recovery. Admit mutation
+      // only while this owner can still keep native autostart suspended.
+      if (interrupted || !finishUpdate) {
+        throw new UpdateCommandAbort();
+      }
       restoreAllowed = false;
     },
     restore,

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -477,7 +477,7 @@ async function updateCommandInternal(
     { env: run.env },
   );
   recordUpdateRunPhase(run.runId, "validating", undefined, { env: run.env });
-  const packageSchemaPreflight = checkTargetDatabaseSchemas(packageTargetSchemaVersions);
+  const packageSchemaPreflight = await checkTargetDatabaseSchemas(packageTargetSchemaVersions);
   if (!opts.dryRun && hasSchemaRefusal(packageSchemaPreflight)) {
     await refuseUpdate(
       "database-schema-preflight",

--- a/src/cli/update-cli/update-package-executor.test.ts
+++ b/src/cli/update-cli/update-package-executor.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import type { PackageInstallUpdateParams } from "./update-command-package.js";
 import type { PackageUpdateExecutor, PackageUpdatePreparation } from "./update-package-executor.js";
@@ -243,12 +244,23 @@ describe("mutable update execution", () => {
         },
       };
     });
-    mocks.checkTargetSchemas.mockImplementation(() => {
+    const schemaGate = createDeferred<void>();
+    mocks.checkTargetSchemas.mockImplementation(async () => {
       events.push("schema");
+      await schemaGate.promise;
       return { incompatible: [], indeterminate: [] };
     });
 
-    const execution = await executeMutableUpdate(executionParams("package"));
+    const pendingExecution = executeMutableUpdate(executionParams("package"));
+    try {
+      await vi.waitFor(() => expect(mocks.checkTargetSchemas).toHaveBeenCalledOnce());
+      expect(events).toEqual(["prepare", "stop", "schema"]);
+      expect(mocks.runPackageUpdate).not.toHaveBeenCalled();
+    } finally {
+      schemaGate.resolve();
+      await pendingExecution;
+    }
+    const execution = await pendingExecution;
 
     expect(events).toEqual(["prepare", "stop", "schema", "activate"]);
     expect(execution?.result).toBe(successfulUpdate);

--- a/src/cli/update-cli/update-package-executor.test.ts
+++ b/src/cli/update-cli/update-package-executor.test.ts
@@ -244,7 +244,7 @@ describe("mutable update execution", () => {
         },
       };
     });
-    const schemaGate = createDeferred<void>();
+    const schemaGate = createDeferred();
     mocks.checkTargetSchemas.mockImplementation(async () => {
       events.push("schema");
       await schemaGate.promise;

--- a/src/commands/doctor-maintenance.ts
+++ b/src/commands/doctor-maintenance.ts
@@ -50,7 +50,7 @@ async function assertDoctorMaintenanceSchemasCompatible(env: NodeJS.ProcessEnv):
     pluginValidation: "core-only",
   }).readConfigFileSnapshot();
   const cfg = snapshot.sourceConfig ?? snapshot.config;
-  const schemas = preflightOpenClawDatabaseSchemas({
+  const schemas = await preflightOpenClawDatabaseSchemas({
     env,
     supportedVersions: {
       state: OPENCLAW_STATE_SCHEMA_VERSION,

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -21,7 +21,7 @@ async function assertDoctorDatabaseSchemasCompatible(): Promise<void> {
     import("../state/openclaw-agent-db-contract.js"),
     import("../state/openclaw-state-db-contract.js"),
   ]);
-  const databaseSchemas = databasePreflight.preflightOpenClawDatabaseSchemas({
+  const databaseSchemas = await databasePreflight.preflightOpenClawDatabaseSchemas({
     env: process.env,
     supportedVersions: {
       state: stateDatabase.OPENCLAW_STATE_SCHEMA_VERSION,
@@ -150,7 +150,7 @@ export async function runDoctorHealthFlow(runtime?: RuntimeEnv, options: DoctorO
         await import("../state/openclaw-database-preflight.js");
       const { resolveConfiguredAgentDatabaseTargets } =
         await import("../config/sessions/targets.js");
-      assertOpenClawDatabasesReady({
+      await assertOpenClawDatabasesReady({
         env: process.env,
         operation: "doctor",
         configuredAgentDatabaseTargets: resolveConfiguredAgentDatabaseTargets(ctx.cfg, {

--- a/src/gateway/server-public.ts
+++ b/src/gateway/server-public.ts
@@ -22,6 +22,9 @@ export type GatewayHostLifecycle = {
   ): Promise<Result<{ outcome: "already-running" | "scheduled" }, string>>;
 };
 
+/** Runs resource-owning startup work under the current host's stop-and-cleanup join. */
+export type GatewayStartupOperation = <T>(run: (signal: AbortSignal) => Promise<T>) => Promise<T>;
+
 export type GatewayServer = {
   /** Process-local endpoint used by OpenClaw-managed Tailscale proxying. */
   getTailscaleIngressEndpoint: () => GatewayTailscaleIngressEndpoint | undefined;
@@ -37,6 +40,8 @@ export type GatewayServer = {
 export type GatewayServerOptions = {
   /** Internal, closure-bound host authority. Direct servers have no native lifecycle owner. */
   hostLifecycle?: GatewayHostLifecycle;
+  /** Internal startup ownership; direct callers own their awaited startup work. */
+  startupOperation?: GatewayStartupOperation;
   /** Exact lifecycle generation projected to connected clients. */
   bootId?: string;
   /**

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -89,13 +89,17 @@ export async function prepareGatewayServerBootstrap(input: {
   if (startupElapsedMs > 0) {
     startupTrace.mark("process.bootstrap");
   }
-  await startupTrace.measure("state.ownership", async () => {
+  const inspectStateOwnership = async (signal?: AbortSignal) => {
     normalizeStateDirEnv(process.env);
     await assertOpenClawStateWriteAllowedAtPath({
       databasePath: resolveOpenClawStateSqlitePath(process.env),
       env: process.env,
+      signal,
     });
-  });
+  };
+  await startupTrace.measure("state.ownership", () =>
+    opts.startupOperation ? opts.startupOperation(inspectStateOwnership) : inspectStateOwnership(),
+  );
   const [
     {
       OPENCLAW_DATABASE_SCHEMA_DOCS_URL,

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -111,14 +111,19 @@ export async function prepareGatewayServerBootstrap(input: {
       import("../state/openclaw-state-db-contract.js"),
     ]),
   );
-  const databaseSchemas = await startupTrace.measure("state.schema-preflight", () =>
+  const inspectDatabaseSchemas = (signal?: AbortSignal) =>
     preflightOpenClawDatabaseSchemas({
+      signal,
       env: process.env,
       supportedVersions: {
         state: stateDatabase.OPENCLAW_STATE_SCHEMA_VERSION,
         agent: agentDatabase.OPENCLAW_AGENT_SCHEMA_VERSION,
       },
-    }),
+    });
+  const databaseSchemas = await startupTrace.measure("state.schema-preflight", () =>
+    opts.startupOperation
+      ? opts.startupOperation(inspectDatabaseSchemas)
+      : inspectDatabaseSchemas(),
   );
   if (databaseSchemas.incompatible.length > 0) {
     for (const database of databaseSchemas.incompatible) {

--- a/src/infra/sqlite-readonly-location.cancellation.test.ts
+++ b/src/infra/sqlite-readonly-location.cancellation.test.ts
@@ -1,0 +1,156 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import * as workerUrls from "./runtime-worker-url.js";
+import {
+  prepareSqliteReadOnlyLocation,
+  SQLITE_READONLY_CHILD_ARG,
+} from "./sqlite-readonly-location.js";
+
+const processMocks = vi.hoisted(() => ({
+  execFile: vi.fn<typeof import("node:child_process").execFile>(),
+}));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  processMocks.execFile.mockImplementation(actual.execFile);
+  Object.defineProperties(processMocks.execFile, Object.getOwnPropertyDescriptors(actual.execFile));
+  return { ...actual, execFile: processMocks.execFile };
+});
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    cleanup();
+  });
+});
+let cacheRoot: string;
+beforeEach(() => {
+  processMocks.execFile.mockClear();
+  cacheRoot = tempDirs.make("openclaw-readonly-cancellation-cache-");
+  vi.stubEnv("XDG_CACHE_HOME", cacheRoot);
+});
+
+function createDatabase(): string {
+  const pathname = path.join(tempDirs.make("openclaw-readonly-cancellation-"), "source.sqlite");
+  const database = new (requireNodeSqlite().DatabaseSync)(pathname);
+  database.exec("CREATE TABLE probe (value TEXT); INSERT INTO probe VALUES ('preserved');");
+  database.close();
+  return pathname;
+}
+
+describe("SQLite read-only worker cancellation", () => {
+  it("rejects stopped ownership before staging or spawning", async () => {
+    const controller = new AbortController();
+    const reason = new Error("startup stopped");
+    controller.abort(reason);
+    await expect(
+      prepareSqliteReadOnlyLocation(path.join(cacheRoot, "unused.sqlite"), {
+        preserveSourceArtifacts: true,
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
+    expect(processMocks.execFile).not.toHaveBeenCalled();
+    expect(fs.readdirSync(cacheRoot)).toEqual([]);
+  });
+
+  // Windows terminates SIGTERM targets; POSIX can hold a signal handler open.
+  it.runIf(process.platform !== "win32")(
+    "joins a signalled child before rejecting and removes its unpublished partial snapshot",
+    async () => {
+      const fixture = tempDirs.make("openclaw-readonly-held-worker-");
+      const worker = path.join(fixture, "worker.mjs");
+      const signalled = path.join(fixture, "signalled");
+      const release = path.join(fixture, "release");
+      fs.writeFileSync(
+        worker,
+        `import fs from 'node:fs';
+       import path from 'node:path';
+       const root = process.argv[5];
+       process.on('SIGTERM', () => {
+         fs.writeFileSync(${JSON.stringify(signalled)}, 'received');
+         const poll = setInterval(() => {
+           if (fs.existsSync(${JSON.stringify(release)})) { clearInterval(poll); process.exit(0); }
+         }, 5);
+       });
+       fs.writeFileSync(path.join(root, 'partial.sqlite'), 'private partial snapshot');
+       setTimeout(() => process.exit(2), 5000);`,
+      );
+      vi.spyOn(workerUrls, "resolveRuntimeWorkerUrl").mockReturnValue(pathToFileURL(worker));
+      const controller = new AbortController();
+      const reason = new Error("startup stopped");
+      let settled = false;
+      const operation = prepareSqliteReadOnlyLocation(path.join(fixture, "unused.sqlite"), {
+        preserveSourceArtifacts: true,
+        signal: controller.signal,
+      });
+      void operation.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+      let childClosed: Promise<void> | undefined;
+      try {
+        const workerIndex = () =>
+          processMocks.execFile.mock.calls.findIndex(
+            (call) => Array.isArray(call[1]) && call[1].includes(SQLITE_READONLY_CHILD_ARG),
+          );
+        await vi.waitFor(() => expect(workerIndex()).toBeGreaterThanOrEqual(0));
+        const callIndex = workerIndex();
+        const child = processMocks.execFile.mock.results[callIndex]?.value;
+        expect(child).toBeDefined();
+        childClosed = new Promise<void>((resolve) => child.once("close", () => resolve()));
+        const argv = processMocks.execFile.mock.calls[callIndex]?.[1];
+        if (!Array.isArray(argv)) throw new Error("worker arguments missing");
+        const stagingRoot = argv.at(-1)!;
+        await vi.waitFor(() =>
+          expect(fs.existsSync(path.join(stagingRoot, "partial.sqlite"))).toBe(true),
+        );
+        controller.abort(reason);
+        await vi.waitFor(() => expect(fs.existsSync(signalled)).toBe(true));
+        expect(settled).toBe(false);
+        expect(child.exitCode).toBeNull();
+        expect(fs.existsSync(stagingRoot)).toBe(true);
+        fs.writeFileSync(release, "release");
+        await expect(operation).rejects.toBe(reason);
+        await childClosed;
+        expect(child.exitCode).toBe(0);
+        expect(fs.existsSync(stagingRoot)).toBe(false);
+        expect(fs.readdirSync(path.join(cacheRoot, "openclaw"))).toEqual([]);
+      } finally {
+        fs.writeFileSync(release, "release");
+        controller.abort(reason);
+        await Promise.allSettled([operation, childClosed]);
+      }
+    },
+  );
+
+  it("reports failed owned cleanup and keeps it retryable", async () => {
+    const source = createDatabase();
+    const before = fs.readFileSync(source);
+    const prepared = await prepareSqliteReadOnlyLocation(source, {
+      preserveSourceArtifacts: true,
+      signal: new AbortController().signal,
+    });
+    const remove = fs.rmSync;
+    const failure = Object.assign(new Error("private snapshot busy"), { code: "EBUSY" });
+    const stub = vi.spyOn(fs, "rmSync").mockImplementationOnce(() => {
+      throw failure;
+    });
+    try {
+      expect(() => prepared.cleanup()).toThrow("snapshot cleanup failed");
+      expect(fs.existsSync(prepared.location)).toBe(true);
+    } finally {
+      stub.mockImplementation(remove);
+      expect(prepared.cleanup()).toBe(true);
+    }
+    expect(fs.readFileSync(source)).toEqual(before);
+    expect(fs.readdirSync(path.join(cacheRoot, "openclaw"))).toEqual([]);
+  });
+});

--- a/src/infra/sqlite-readonly-location.cancellation.test.ts
+++ b/src/infra/sqlite-readonly-location.cancellation.test.ts
@@ -5,10 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import * as workerUrls from "./runtime-worker-url.js";
-import {
-  prepareSqliteReadOnlyLocation,
-  SQLITE_READONLY_CHILD_ARG,
-} from "./sqlite-readonly-location.js";
+import { prepareSqliteReadOnlyLocation } from "./sqlite-readonly-location.js";
+import { SQLITE_READONLY_CHILD_ARG } from "./sqlite-readonly-worker.js";
 
 const processMocks = vi.hoisted(() => ({
   execFile: vi.fn<typeof import("node:child_process").execFile>(),
@@ -105,9 +103,13 @@ describe("SQLite read-only worker cancellation", () => {
         const callIndex = workerIndex();
         const child = processMocks.execFile.mock.results[callIndex]?.value;
         expect(child).toBeDefined();
-        childClosed = new Promise<void>((resolve) => child.once("close", () => resolve()));
+        childClosed = new Promise<void>((resolve) => {
+          child.once("close", () => resolve());
+        });
         const argv = processMocks.execFile.mock.calls[callIndex]?.[1];
-        if (!Array.isArray(argv)) throw new Error("worker arguments missing");
+        if (!Array.isArray(argv)) {
+          throw new Error("worker arguments missing");
+        }
         const stagingRoot = argv.at(-1)!;
         await vi.waitFor(() =>
           expect(fs.existsSync(path.join(stagingRoot, "partial.sqlite"))).toBe(true),

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -1,5 +1,4 @@
 // Prepares consistent private SQLite read-only snapshots.
-import { execFile, spawnSync } from "node:child_process";
 import fs, { type BigIntStats } from "node:fs";
 import path from "node:path";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
@@ -8,13 +7,12 @@ import {
   requireNodeSqlite,
   resolveSqliteFilesystemPath,
 } from "./node-sqlite.js";
-import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
-import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
 import {
   createPrivateSqliteTempDirectory,
   createPrivateSqliteTempDirectorySync,
   resolvePrivateSqliteSnapshotStagingRoot,
 } from "./sqlite-private-directory.js";
+import { runSqliteReadOnlyWorker, runSqliteReadOnlyWorkerSync } from "./sqlite-readonly-worker.js";
 
 const MAX_SNAPSHOT_ATTEMPTS = 10;
 const COPY_BUFFER_BYTES = 1024 * 1024;
@@ -23,8 +21,6 @@ const SQLITE_READONLY_RESULT_CODE = 8;
 const SQLITE_RESULT_CODE_MASK = 0xff;
 const SQLITE_JOURNAL_MAGIC = Buffer.from([0xd9, 0xd5, 0x05, 0xf9, 0x20, 0xa1, 0x63, 0xd7]);
 const SQLITE_SNAPSHOT_STAGING_PREFIX = `openclaw-sqlite-readonly-${process.pid}-`;
-export const SQLITE_READONLY_CHILD_ARG = "--openclaw-sqlite-readonly-child";
-const SQLITE_READONLY_STDERR_TAIL_CHARS = 4_000;
 const pendingTempDirectoryCleanup = new Set<string>();
 let cleanupExitHandlerInstalled = false;
 
@@ -46,8 +42,6 @@ type PreparedSqliteReadOnlyLocation = {
   cleanup: () => boolean;
   location: string;
 };
-
-type SqliteReadOnlyWorkerResult = { ok: true; location: string } | { ok: false; message: string };
 
 class SqliteSourceChangedError extends Error {}
 
@@ -608,74 +602,10 @@ export function prepareSqliteReadOnlyLocationSyncInProcess(
   });
 }
 
-function isSqliteReadOnlyWorkerResult(value: unknown): value is SqliteReadOnlyWorkerResult {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-  if (Object.keys(value).length !== 2 || !("ok" in value)) {
-    return false;
-  }
-  return (
-    (value.ok === true && "location" in value && typeof value.location === "string") ||
-    (value.ok === false && "message" in value && typeof value.message === "string")
-  );
-}
-
-function createSqliteReadOnlyWorkerError(message: string, stderr: string): Error {
-  const stderrTail = stderr.trim().slice(-SQLITE_READONLY_STDERR_TAIL_CHARS);
-  return new Error(
-    `SQLite read-only worker ${message}${stderrTail ? `\nstderr (tail): ${stderrTail}` : ""}`,
-  );
-}
-
-function parseSqliteReadOnlyWorkerResult(
-  stdout: string,
-  stderr: string,
-): SqliteReadOnlyWorkerResult {
-  if (!stdout.trim()) {
-    throw createSqliteReadOnlyWorkerError("returned no JSON result", stderr);
-  }
-  let message: unknown;
-  try {
-    message = JSON.parse(stdout);
-  } catch {
-    throw createSqliteReadOnlyWorkerError("returned invalid JSON", stderr);
-  }
-  if (!isSqliteReadOnlyWorkerResult(message)) {
-    throw createSqliteReadOnlyWorkerError("returned an invalid result", stderr);
-  }
-  return message;
-}
-
-function adoptSqliteReadOnlyWorkerResult(params: {
-  failure?: string;
-  stderr: string;
-  stdout: string;
-  stagingRoot?: string;
-}): PreparedSqliteReadOnlyLocation {
-  let result: SqliteReadOnlyWorkerResult;
-  try {
-    result = parseSqliteReadOnlyWorkerResult(params.stdout, params.stderr);
-  } catch (error) {
-    if (params.failure) {
-      throw createSqliteReadOnlyWorkerError(params.failure, params.stderr);
-    }
-    throw error;
-  }
-  if (params.failure || !result.ok) {
-    throw createSqliteReadOnlyWorkerError(
-      !result.ok ? result.message : (params.failure ?? "failed"),
-      params.stderr,
-    );
-  }
-  return adoptPreparedLocation(result.location, params.stagingRoot);
-}
-
 export async function prepareSqliteReadOnlyLocation(
   pathname: string,
   options: { preserveSourceArtifacts?: boolean; signal?: AbortSignal } = {},
 ): Promise<PreparedSqliteReadOnlyLocation> {
-  const workerUrl = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sqliteReadOnly);
   let stagingRoot: string | undefined;
   try {
     options.signal?.throwIfAborted();
@@ -685,44 +615,13 @@ export async function prepareSqliteReadOnlyLocation(
       stagingRoot = await createSqliteSnapshotStagingDirectory();
     }
     options.signal?.throwIfAborted();
-    const prepared = await new Promise<PreparedSqliteReadOnlyLocation>((resolve, reject) => {
-      let output: Parameters<typeof adoptSqliteReadOnlyWorkerResult>[0] = {
-        stderr: "",
-        stdout: "",
-        stagingRoot,
-      };
-      const child = execFile(
-        process.execPath,
-        [
-          ...resolveRuntimeWorkerArgv(workerUrl),
-          SQLITE_READONLY_CHILD_ARG,
-          options.preserveSourceArtifacts ? "sync" : "async",
-          path.resolve(pathname),
-          ...(stagingRoot ? [stagingRoot] : []),
-        ],
-        { encoding: "utf8", signal: options.signal },
-        (error, stdout, stderr) => {
-          output = {
-            failure: error ? `exited unsuccessfully: ${error.message}` : undefined,
-            stderr,
-            stdout,
-            stagingRoot,
-          };
-        },
-      );
-      // execFile can report an abort/error before close. Ownership ends only
-      // after the process and its pipes have closed, including failed launches.
-      child.once("close", () => {
-        try {
-          options.signal?.throwIfAborted();
-          resolve(adoptSqliteReadOnlyWorkerResult(output));
-        } catch (workerError) {
-          reject(workerError instanceof Error ? workerError : new Error(String(workerError)));
-        }
-      });
+    const location = await runSqliteReadOnlyWorker(pathname, {
+      mode: options.preserveSourceArtifacts ? "sync" : "async",
+      signal: options.signal,
+      stagingRoot,
     });
     options.signal?.throwIfAborted();
-    return prepared;
+    return adoptPreparedLocation(location, stagingRoot);
   } catch (error) {
     if (stagingRoot && !removeTempDirectory(stagingRoot)) {
       throw new Error(`SQLite read-only worker snapshot cleanup failed: ${stagingRoot}`, {
@@ -737,23 +636,7 @@ export async function prepareSqliteReadOnlyLocation(
 export function prepareSqliteReadOnlyLocationSync(
   pathname: string,
 ): PreparedSqliteReadOnlyLocation {
-  const workerUrl = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sqliteReadOnly);
-  const result = spawnSync(
-    process.execPath,
-    [
-      ...resolveRuntimeWorkerArgv(workerUrl),
-      SQLITE_READONLY_CHILD_ARG,
-      "sync",
-      path.resolve(pathname),
-    ],
-    { encoding: "utf8" },
-  );
-  const failure = result.error
-    ? `failed to start: ${result.error.message}`
-    : result.status === 0
-      ? undefined
-      : `exited with ${result.signal ? `signal ${result.signal}` : `code ${result.status}`}`;
-  return adoptSqliteReadOnlyWorkerResult({ failure, stderr: result.stderr, stdout: result.stdout });
+  return adoptPreparedLocation(runSqliteReadOnlyWorkerSync(pathname));
 }
 
 async function prepareSqliteSnapshotSource(

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -307,8 +307,11 @@ function removeTempDirectory(tempDir: string): boolean {
   }
 }
 
-function adoptPreparedLocation(location: string): PreparedSqliteReadOnlyLocation {
-  const tempDir = path.dirname(location);
+function adoptPreparedLocation(
+  location: string,
+  ownedRoot?: string,
+): PreparedSqliteReadOnlyLocation {
+  const tempDir = ownedRoot ?? path.dirname(location);
   let active = true;
   return {
     location,
@@ -319,6 +322,8 @@ function adoptPreparedLocation(location: string): PreparedSqliteReadOnlyLocation
       const removed = removeTempDirectory(tempDir);
       if (removed) {
         active = false;
+      } else if (ownedRoot) {
+        throw new Error(`SQLite read-only worker snapshot cleanup failed: ${tempDir}`);
       }
       return removed;
     },
@@ -351,9 +356,11 @@ function createStableReadOnlyCopyInTempDirectory(
   pathname: string,
   journalMode: Exclude<SourceJournalMode, "unknown">,
   existingTempDir?: string,
+  stagingRoot = existingTempDir
+    ? path.dirname(existingTempDir)
+    : resolvePrivateSqliteSnapshotStagingRoot(),
 ): PreparedSqliteReadOnlyLocation {
   let tempDir = existingTempDir;
-  const stagingRoot = tempDir ? path.dirname(tempDir) : resolvePrivateSqliteSnapshotStagingRoot();
   try {
     tempDir ??= createPrivateSqliteTempDirectorySync(stagingRoot, SQLITE_SNAPSHOT_STAGING_PREFIX);
     const snapshotPath = path.join(tempDir, "database.sqlite");
@@ -411,8 +418,9 @@ function createStableReadOnlyCopyInTempDirectory(
   }
 }
 
-async function createSqliteSnapshotStagingDirectory(): Promise<string> {
-  const stagingRoot = resolvePrivateSqliteSnapshotStagingRoot();
+async function createSqliteSnapshotStagingDirectory(
+  stagingRoot = resolvePrivateSqliteSnapshotStagingRoot(),
+): Promise<string> {
   try {
     return await createPrivateSqliteTempDirectory(stagingRoot, SQLITE_SNAPSHOT_STAGING_PREFIX);
   } catch (error) {
@@ -423,15 +431,17 @@ async function createSqliteSnapshotStagingDirectory(): Promise<string> {
 async function createStableReadOnlyCopy(
   pathname: string,
   journalMode: Exclude<SourceJournalMode, "unknown">,
+  stagingRoot?: string,
 ): Promise<PreparedSqliteReadOnlyLocation> {
-  const tempDir = await createSqliteSnapshotStagingDirectory();
+  const tempDir = await createSqliteSnapshotStagingDirectory(stagingRoot);
   return createStableReadOnlyCopyInTempDirectory(pathname, journalMode, tempDir);
 }
 
 async function createOnlineReadOnlyBackup(
   pathname: string,
+  stagingRoot?: string,
 ): Promise<PreparedSqliteReadOnlyLocation> {
-  const tempDir = await createSqliteSnapshotStagingDirectory();
+  const tempDir = await createSqliteSnapshotStagingDirectory(stagingRoot);
   const snapshotPath = path.join(tempDir, "database.sqlite");
   const sqlite = requireNodeSqlite();
   try {
@@ -477,6 +487,7 @@ async function createOnlineReadOnlyBackup(
  */
 export async function prepareSqliteReadOnlyLocationInProcess(
   pathname: string,
+  stagingRoot?: string,
 ): Promise<PreparedSqliteReadOnlyLocation> {
   const canonicalPath = fs.realpathSync.native(pathname);
   let lastChange: Error | undefined;
@@ -493,7 +504,7 @@ export async function prepareSqliteReadOnlyLocationInProcess(
     }
     if (journalMode === "empty") {
       try {
-        return await createStableReadOnlyCopy(canonicalPath, journalMode);
+        return await createStableReadOnlyCopy(canonicalPath, journalMode, stagingRoot);
       } catch (error) {
         if (!(error instanceof SqliteSourceChangedError)) {
           throw error;
@@ -505,7 +516,7 @@ export async function prepareSqliteReadOnlyLocationInProcess(
     const sidecars = readSourceSidecars(canonicalPath);
     if (journalMode !== "wal" || (sidecars.wal && sidecars.shm)) {
       try {
-        return await createOnlineReadOnlyBackup(canonicalPath);
+        return await createOnlineReadOnlyBackup(canonicalPath, stagingRoot);
       } catch (error) {
         // A writer can add or remove sidecars before SQLite opens. Retry
         // incomplete WAL state or rollback crash residue through private copy.
@@ -525,7 +536,7 @@ export async function prepareSqliteReadOnlyLocationInProcess(
             throw error;
           }
           try {
-            return await createStableReadOnlyCopy(canonicalPath, "rollback");
+            return await createStableReadOnlyCopy(canonicalPath, "rollback", stagingRoot);
           } catch (copyError) {
             if (!(copyError instanceof SqliteSourceChangedError)) {
               throw copyError;
@@ -542,7 +553,7 @@ export async function prepareSqliteReadOnlyLocationInProcess(
       }
     }
     try {
-      return await createStableReadOnlyCopy(canonicalPath, "wal");
+      return await createStableReadOnlyCopy(canonicalPath, "wal", stagingRoot);
     } catch (error) {
       if (!(error instanceof SqliteSourceChangedError)) {
         throw error;
@@ -557,6 +568,7 @@ export async function prepareSqliteReadOnlyLocationInProcess(
 
 export function prepareSqliteReadOnlyLocationSyncInProcess(
   pathname: string,
+  stagingRoot?: string,
 ): PreparedSqliteReadOnlyLocation {
   const canonicalPath = fs.realpathSync.native(pathname);
   let lastChange: Error | undefined;
@@ -578,7 +590,12 @@ export function prepareSqliteReadOnlyLocationSyncInProcess(
       continue;
     }
     try {
-      return createStableReadOnlyCopyInTempDirectory(canonicalPath, journalMode);
+      return createStableReadOnlyCopyInTempDirectory(
+        canonicalPath,
+        journalMode,
+        undefined,
+        stagingRoot,
+      );
     } catch (error) {
       if (!(error instanceof SqliteSourceChangedError)) {
         throw error;
@@ -634,6 +651,7 @@ function adoptSqliteReadOnlyWorkerResult(params: {
   failure?: string;
   stderr: string;
   stdout: string;
+  stagingRoot?: string;
 }): PreparedSqliteReadOnlyLocation {
   let result: SqliteReadOnlyWorkerResult;
   try {
@@ -650,33 +668,70 @@ function adoptSqliteReadOnlyWorkerResult(params: {
       params.stderr,
     );
   }
-  return adoptPreparedLocation(result.location);
+  return adoptPreparedLocation(result.location, params.stagingRoot);
 }
 
 export async function prepareSqliteReadOnlyLocation(
   pathname: string,
+  options: { preserveSourceArtifacts?: boolean; signal?: AbortSignal } = {},
 ): Promise<PreparedSqliteReadOnlyLocation> {
   const workerUrl = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sqliteReadOnly);
-  return await new Promise((resolve, reject) => {
-    execFile(
-      process.execPath,
-      [
-        ...resolveRuntimeWorkerArgv(workerUrl),
-        SQLITE_READONLY_CHILD_ARG,
-        "async",
-        path.resolve(pathname),
-      ],
-      { encoding: "utf8" },
-      (error, stdout, stderr) => {
+  let stagingRoot: string | undefined;
+  try {
+    options.signal?.throwIfAborted();
+    // A stopped worker may never publish its random snapshot path. Allocate its
+    // private parent first so cancellation can join the child and remove all copies.
+    if (options.signal) {
+      stagingRoot = await createSqliteSnapshotStagingDirectory();
+    }
+    options.signal?.throwIfAborted();
+    const prepared = await new Promise<PreparedSqliteReadOnlyLocation>((resolve, reject) => {
+      let output: Parameters<typeof adoptSqliteReadOnlyWorkerResult>[0] = {
+        stderr: "",
+        stdout: "",
+        stagingRoot,
+      };
+      const child = execFile(
+        process.execPath,
+        [
+          ...resolveRuntimeWorkerArgv(workerUrl),
+          SQLITE_READONLY_CHILD_ARG,
+          options.preserveSourceArtifacts ? "sync" : "async",
+          path.resolve(pathname),
+          ...(stagingRoot ? [stagingRoot] : []),
+        ],
+        { encoding: "utf8", signal: options.signal },
+        (error, stdout, stderr) => {
+          output = {
+            failure: error ? `exited unsuccessfully: ${error.message}` : undefined,
+            stderr,
+            stdout,
+            stagingRoot,
+          };
+        },
+      );
+      // execFile can report an abort/error before close. Ownership ends only
+      // after the process and its pipes have closed, including failed launches.
+      child.once("close", () => {
         try {
-          const failure = error ? `exited unsuccessfully: ${error.message}` : undefined;
-          resolve(adoptSqliteReadOnlyWorkerResult({ failure, stderr, stdout }));
+          options.signal?.throwIfAborted();
+          resolve(adoptSqliteReadOnlyWorkerResult(output));
         } catch (workerError) {
           reject(workerError instanceof Error ? workerError : new Error(String(workerError)));
         }
-      },
-    );
-  });
+      });
+    });
+    options.signal?.throwIfAborted();
+    return prepared;
+  } catch (error) {
+    if (stagingRoot && !removeTempDirectory(stagingRoot)) {
+      throw new Error(`SQLite read-only worker snapshot cleanup failed: ${stagingRoot}`, {
+        cause: error,
+      });
+    }
+    options.signal?.throwIfAborted();
+    throw error;
+  }
 }
 
 export function prepareSqliteReadOnlyLocationSync(

--- a/src/infra/sqlite-readonly-location.worker.test.ts
+++ b/src/infra/sqlite-readonly-location.worker.test.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { prepare } = vi.hoisted(() => ({ prepare: vi.fn() }));
 vi.mock("./sqlite-readonly-location.js", () => ({
-  SQLITE_READONLY_CHILD_ARG: "--openclaw-sqlite-readonly-child",
   prepareSqliteReadOnlyLocationInProcess: prepare,
   prepareSqliteReadOnlyLocationSyncInProcess: prepare,
 }));

--- a/src/infra/sqlite-readonly-location.worker.ts
+++ b/src/infra/sqlite-readonly-location.worker.ts
@@ -1,10 +1,10 @@
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
 import { formatSqliteErrorCodeSuffix } from "./sqlite-error-diagnostics.js";
 import {
-  SQLITE_READONLY_CHILD_ARG,
   prepareSqliteReadOnlyLocationInProcess,
   prepareSqliteReadOnlyLocationSyncInProcess,
 } from "./sqlite-readonly-location.js";
+import { SQLITE_READONLY_CHILD_ARG } from "./sqlite-readonly-worker.js";
 
 // The sync strategy raw-copies without attaching SQLite to the source, so sync
 // callers stay byte-neutral on the live family; the async strategy holds a read

--- a/src/infra/sqlite-readonly-location.worker.ts
+++ b/src/infra/sqlite-readonly-location.worker.ts
@@ -12,6 +12,7 @@ import {
 async function runWorker(): Promise<void> {
   const mode = process.argv[3];
   const pathname = process.argv[4];
+  const stagingRoot = process.argv[5];
   if ((mode !== "sync" && mode !== "async") || !pathname) {
     process.exitCode = 1;
     process.stdout.write(
@@ -25,8 +26,8 @@ async function runWorker(): Promise<void> {
   try {
     const prepared =
       mode === "sync"
-        ? prepareSqliteReadOnlyLocationSyncInProcess(pathname)
-        : await prepareSqliteReadOnlyLocationInProcess(pathname);
+        ? prepareSqliteReadOnlyLocationSyncInProcess(pathname, stagingRoot)
+        : await prepareSqliteReadOnlyLocationInProcess(pathname, stagingRoot);
     process.stdout.write(JSON.stringify({ ok: true, location: prepared.location }));
   } catch (error) {
     process.exitCode = 1;

--- a/src/infra/sqlite-readonly-worker.ts
+++ b/src/infra/sqlite-readonly-worker.ts
@@ -1,0 +1,126 @@
+import { execFile, spawnSync } from "node:child_process";
+import path from "node:path";
+import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
+import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
+
+export const SQLITE_READONLY_CHILD_ARG = "--openclaw-sqlite-readonly-child";
+const SQLITE_READONLY_STDERR_TAIL_CHARS = 4_000;
+
+type SqliteReadOnlyWorkerResult = { ok: true; location: string } | { ok: false; message: string };
+type SqliteReadOnlyWorkerOutput = { failure?: string; stderr: string; stdout: string };
+
+function isSqliteReadOnlyWorkerResult(value: unknown): value is SqliteReadOnlyWorkerResult {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  if (Object.keys(value).length !== 2 || !("ok" in value)) {
+    return false;
+  }
+  return (
+    (value.ok === true && "location" in value && typeof value.location === "string") ||
+    (value.ok === false && "message" in value && typeof value.message === "string")
+  );
+}
+
+function createSqliteReadOnlyWorkerError(message: string, stderr: string): Error {
+  const stderrTail = stderr.trim().slice(-SQLITE_READONLY_STDERR_TAIL_CHARS);
+  return new Error(
+    `SQLite read-only worker ${message}${stderrTail ? `\nstderr (tail): ${stderrTail}` : ""}`,
+  );
+}
+
+function parseSqliteReadOnlyWorkerResult(
+  stdout: string,
+  stderr: string,
+): SqliteReadOnlyWorkerResult {
+  if (!stdout.trim()) {
+    throw createSqliteReadOnlyWorkerError("returned no JSON result", stderr);
+  }
+  let message: unknown;
+  try {
+    message = JSON.parse(stdout);
+  } catch {
+    throw createSqliteReadOnlyWorkerError("returned invalid JSON", stderr);
+  }
+  if (!isSqliteReadOnlyWorkerResult(message)) {
+    throw createSqliteReadOnlyWorkerError("returned an invalid result", stderr);
+  }
+  return message;
+}
+
+function readSqliteReadOnlyWorkerLocation(params: SqliteReadOnlyWorkerOutput): string {
+  let result: SqliteReadOnlyWorkerResult;
+  try {
+    result = parseSqliteReadOnlyWorkerResult(params.stdout, params.stderr);
+  } catch (error) {
+    if (params.failure) {
+      throw createSqliteReadOnlyWorkerError(params.failure, params.stderr);
+    }
+    throw error;
+  }
+  if (params.failure || !result.ok) {
+    throw createSqliteReadOnlyWorkerError(
+      !result.ok ? result.message : (params.failure ?? "failed"),
+      params.stderr,
+    );
+  }
+  return result.location;
+}
+
+function sqliteReadOnlyWorkerArgv(pathname: string, mode: "sync" | "async", stagingRoot?: string) {
+  const workerUrl = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.sqliteReadOnly);
+  return [
+    ...resolveRuntimeWorkerArgv(workerUrl),
+    SQLITE_READONLY_CHILD_ARG,
+    mode,
+    path.resolve(pathname),
+    ...(stagingRoot ? [stagingRoot] : []),
+  ];
+}
+
+export function runSqliteReadOnlyWorker(
+  pathname: string,
+  options: { mode: "sync" | "async"; stagingRoot?: string; signal?: AbortSignal },
+): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let output: SqliteReadOnlyWorkerOutput = { stderr: "", stdout: "" };
+    const child = execFile(
+      process.execPath,
+      sqliteReadOnlyWorkerArgv(pathname, options.mode, options.stagingRoot),
+      { encoding: "utf8", signal: options.signal },
+      (error, stdout, stderr) => {
+        output = {
+          failure: error ? `exited unsuccessfully: ${error.message}` : undefined,
+          stderr,
+          stdout,
+        };
+      },
+    );
+    // execFile can report an abort/error before close. Ownership ends only
+    // after the process and its pipes have closed, including failed launches.
+    child.once("close", () => {
+      try {
+        options.signal?.throwIfAborted();
+        resolve(readSqliteReadOnlyWorkerLocation(output));
+      } catch (workerError) {
+        reject(workerError instanceof Error ? workerError : new Error(String(workerError)));
+      }
+    });
+  });
+}
+
+export function runSqliteReadOnlyWorkerSync(pathname: string): string {
+  const result = spawnSync(process.execPath, sqliteReadOnlyWorkerArgv(pathname, "sync"), {
+    encoding: "utf8",
+  });
+  const failure = result.error
+    ? `failed to start: ${result.error.message}`
+    : result.status === 0
+      ? undefined
+      : `exited with ${result.signal ? `signal ${result.signal}` : `code ${result.status}`}`;
+  return readSqliteReadOnlyWorkerLocation({
+    failure,
+    stderr: result.stderr,
+    stdout: result.stdout,
+  });
+}

--- a/src/infra/state-migrations.media-persistence-targets.test.ts
+++ b/src/infra/state-migrations.media-persistence-targets.test.ts
@@ -160,25 +160,25 @@ describe("media persistence migration targets", () => {
       schemaVersion: PREVIOUS_VERSION,
     });
 
-    expect(() =>
+    await expect(
       assertOpenClawDatabasesReady({
         env,
         operation: "doctor",
         configuredAgentDatabaseTargets: [],
       }),
-    ).toThrow(/uses schema version 16/);
+    ).rejects.toThrow(/uses schema version 16/);
     const result = await migrateLegacyMediaPersistence({ env });
 
     expect(result.warnings).toEqual([]);
     expect(readUserVersion(filesystemPath)).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
     expect(readUserVersion(lexicalPath)).toBe(PREVIOUS_VERSION);
-    expect(() =>
+    await expect(
       assertOpenClawDatabasesReady({
         env,
         operation: "doctor",
         configuredAgentDatabaseTargets: [],
       }),
-    ).not.toThrow();
+    ).resolves.toBeUndefined();
   });
 
   it("unregisters foreign registry paths without touching their databases", async () => {
@@ -285,13 +285,13 @@ describe("media persistence migration targets", () => {
       schemaVersion: PREVIOUS_VERSION,
     });
 
-    expect(() =>
+    await expect(
       assertOpenClawDatabasesReady({
         env,
         operation: "doctor",
         configuredAgentDatabaseTargets: [{ agentId: "new", path: databasePath }],
       }),
-    ).toThrow(/uses schema version 16/);
+    ).rejects.toThrow(/uses schema version 16/);
     expect(
       listOpenClawRegisteredAgentDatabases({ env, includeIncompatibleSchemaVersions: true }),
     ).toEqual([expect.objectContaining({ agentId: "old", path: databasePath })]);
@@ -328,13 +328,13 @@ describe("media persistence migration targets", () => {
     insert.run("missing", missingPath, OPENCLAW_AGENT_SCHEMA_VERSION, 1, null);
     insert.run("archived", archivedPath, 8, 1, null);
 
-    expect(() =>
+    await expect(
       assertOpenClawDatabasesReady({
         env,
         operation: "doctor",
         configuredAgentDatabaseTargets: [],
       }),
-    ).not.toThrow();
+    ).resolves.toBeUndefined();
     expect(
       state.db.prepare("SELECT agent_id FROM agent_databases ORDER BY agent_id").all(),
     ).toEqual([{ agent_id: "archived" }, { agent_id: "missing" }]);

--- a/src/state/openclaw-database-paths.windows.test.ts
+++ b/src/state/openclaw-database-paths.windows.test.ts
@@ -111,7 +111,7 @@ describe("OpenClaw database paths on Windows", () => {
         },
       });
       expect(
-        preflightOpenClawDatabaseSchemas({
+        await preflightOpenClawDatabaseSchemas({
           env,
           supportedVersions: {
             state: OPENCLAW_STATE_SCHEMA_VERSION,

--- a/src/state/openclaw-database-preflight.artifacts.test.ts
+++ b/src/state/openclaw-database-preflight.artifacts.test.ts
@@ -87,11 +87,11 @@ function sourceArtifacts(paths: string[]): unknown {
 }
 
 describe("schema preflight source artifacts", () => {
-  it.each(["compatible", "refusal"])("preserves closed WAL stores on %s", (outcome) => {
+  it.each(["compatible", "refusal"])("preserves closed WAL stores on %s", async (outcome) => {
     const fixture = createFixture();
     fixture.close();
     const before = sourceArtifacts(fixture.paths);
-    const result = checkTargetDatabaseSchemas(
+    const result = await checkTargetDatabaseSchemas(
       outcome === "compatible"
         ? supportedVersions
         : { state: supportedVersions.state - 1, agent: supportedVersions.agent - 1 },
@@ -104,29 +104,38 @@ describe("schema preflight source artifacts", () => {
     expect(sourceArtifacts(fixture.paths)).toEqual(before);
   });
 
-  it("reads newer committed schema versions from live WAL without changing the family", () => {
+  it("reads newer committed schema versions from live WAL without blocking or changing the family", async () => {
     const fixture = createFixture();
     fixture.state.db.exec(`PRAGMA user_version = ${supportedVersions.state + 10};`);
     fixture.main.db.exec(`PRAGMA user_version = ${supportedVersions.agent + 10};`);
     fixture.worker.db.exec(`PRAGMA user_version = ${supportedVersions.agent + 10};`);
     const before = sourceArtifacts(fixture.paths);
-    const result = preflightOpenClawDatabaseSchemas({
-      env: fixture.env,
-      supportedVersions,
-      verifyCurrentSchemaShape: true,
+    let eventLoopServiced = false;
+    const immediate = setImmediate(() => {
+      eventLoopServiced = true;
     });
-    expect(result.indeterminate).toEqual([]);
-    expect(
-      result.incompatible.map(({ path: pathname, foundVersion }) => [pathname, foundVersion]),
-    ).toEqual([
-      [fixture.state.path, supportedVersions.state + 10],
-      [fixture.main.path, supportedVersions.agent + 10],
-      [fixture.worker.path, supportedVersions.agent + 10],
-    ]);
-    expect(sourceArtifacts(fixture.paths)).toEqual(before);
+    try {
+      const result = await preflightOpenClawDatabaseSchemas({
+        env: fixture.env,
+        supportedVersions,
+        verifyCurrentSchemaShape: true,
+      });
+      expect(eventLoopServiced).toBe(true);
+      expect(result.indeterminate).toEqual([]);
+      expect(
+        result.incompatible.map(({ path: pathname, foundVersion }) => [pathname, foundVersion]),
+      ).toEqual([
+        [fixture.state.path, supportedVersions.state + 10],
+        [fixture.main.path, supportedVersions.agent + 10],
+        [fixture.worker.path, supportedVersions.agent + 10],
+      ]);
+      expect(sourceArtifacts(fixture.paths)).toEqual(before);
+    } finally {
+      clearImmediate(immediate);
+    }
   });
 
-  it("ignores uncommitted writer versions without ending the owning transactions", () => {
+  it("ignores uncommitted writer versions without ending the owning transactions", async () => {
     const fixture = createFixture();
     const databases = [fixture.state, fixture.main, fixture.worker];
     for (const opened of databases) {
@@ -136,7 +145,7 @@ describe("schema preflight source artifacts", () => {
       const before = sourceArtifacts(fixture.paths);
       const locks =
         process.platform === "linux" ? fixture.paths.map(readMainDatabasePosixLocks) : [];
-      expect(checkTargetDatabaseSchemas(supportedVersions, fixture.env)).toEqual({
+      expect(await checkTargetDatabaseSchemas(supportedVersions, fixture.env)).toEqual({
         incompatible: [],
         indeterminate: [],
       });
@@ -156,7 +165,7 @@ describe("schema preflight source artifacts", () => {
     }
   });
 
-  it("preserves a candidate symlink locator and reads the physical database", () => {
+  it("preserves a candidate symlink locator and reads the physical database", async () => {
     const fixture = createFixture();
     unregisterOpenClawAgentDatabase({
       agentId: "worker",
@@ -167,7 +176,7 @@ describe("schema preflight source artifacts", () => {
     const alias = path.join(fixture.env.OPENCLAW_STATE_DIR, "worker-alias.sqlite");
     fs.symlinkSync(fixture.worker.path, alias);
     const before = sourceArtifacts([...fixture.paths, alias]);
-    const result = preflightOpenClawDatabaseSchemas({
+    const result = await preflightOpenClawDatabaseSchemas({
       env: fixture.env,
       supportedVersions: { ...supportedVersions, agent: supportedVersions.agent - 1 },
       configuredAgentDatabaseCandidatePaths: [alias],
@@ -182,7 +191,7 @@ describe("schema preflight source artifacts", () => {
 
   it.each(["registered", "candidate"] as const)(
     "preserves native traversal and deduplication for a %s dot-dot locator",
-    (kind) => {
+    async (kind) => {
       const fixture = createFixture();
       fixture.worker.db.exec(`PRAGMA user_version = ${supportedVersions.agent + 10};`);
       unregisterOpenClawAgentDatabase({
@@ -204,7 +213,7 @@ describe("schema preflight source artifacts", () => {
       expect(fs.realpathSync(locator)).toBe(fs.realpathSync.native(lexicalPath));
       const paths = [...fixture.paths, lexicalPath];
       const before = sourceArtifacts(paths);
-      const result = preflightOpenClawDatabaseSchemas({
+      const result = await preflightOpenClawDatabaseSchemas({
         env: fixture.env,
         supportedVersions,
         configuredAgentDatabaseCandidatePaths:
@@ -225,18 +234,20 @@ describe("schema preflight source artifacts", () => {
 
   it.each(["state", "main"] as const)(
     "fails closed when the %s snapshot cannot be prepared",
-    (kind) => {
+    async (kind) => {
       const fixture = createFixture();
       fixture.close();
       const before = sourceArtifacts(fixture.paths);
-      const prepare = snapshots.prepareSqliteReadOnlyLocationSync;
-      vi.spyOn(snapshots, "prepareSqliteReadOnlyLocationSync").mockImplementation((pathname) => {
-        if (pathname === fixture[kind].path) {
-          throw new Error("inert snapshot admission failure");
-        }
-        return prepare(pathname);
-      });
-      const result = checkTargetDatabaseSchemas(supportedVersions, fixture.env);
+      const prepare = snapshots.prepareSqliteReadOnlyLocation;
+      vi.spyOn(snapshots, "prepareSqliteReadOnlyLocation").mockImplementation(
+        async (pathname, options) => {
+          if (pathname === fixture[kind].path) {
+            throw new Error("inert snapshot admission failure");
+          }
+          return await prepare(pathname, options);
+        },
+      );
+      const result = await checkTargetDatabaseSchemas(supportedVersions, fixture.env);
       expect(result.incompatible).toEqual([]);
       expect(result.indeterminate).toEqual([
         {
@@ -251,25 +262,27 @@ describe("schema preflight source artifacts", () => {
 
   it.each(["state", "main"] as const)(
     "cleans the %s snapshot when its private open fails",
-    (kind) => {
+    async (kind) => {
       const fixture = createFixture();
       fixture.close();
       const before = sourceArtifacts(fixture.paths);
-      const prepare = snapshots.prepareSqliteReadOnlyLocationSync;
+      const prepare = snapshots.prepareSqliteReadOnlyLocation;
       const cleanups: Array<{ location: string; cleanup: ReturnType<typeof vi.fn> }> = [];
-      vi.spyOn(snapshots, "prepareSqliteReadOnlyLocationSync").mockImplementation((pathname) => {
-        const prepared = prepare(pathname);
-        const cleanup = vi.fn(prepared.cleanup);
-        cleanups.push({ location: prepared.location, cleanup });
-        return {
-          location:
-            pathname === fixture[kind].path
-              ? path.join(path.dirname(prepared.location), "missing.sqlite")
-              : prepared.location,
-          cleanup,
-        };
-      });
-      const result = checkTargetDatabaseSchemas(supportedVersions, fixture.env);
+      vi.spyOn(snapshots, "prepareSqliteReadOnlyLocation").mockImplementation(
+        async (pathname, options) => {
+          const prepared = await prepare(pathname, options);
+          const cleanup = vi.fn(prepared.cleanup);
+          cleanups.push({ location: prepared.location, cleanup });
+          return {
+            location:
+              pathname === fixture[kind].path
+                ? path.join(path.dirname(prepared.location), "missing.sqlite")
+                : prepared.location,
+            cleanup,
+          };
+        },
+      );
+      const result = await checkTargetDatabaseSchemas(supportedVersions, fixture.env);
       expect(result.indeterminate).toEqual([
         expect.objectContaining({
           kind: kind === "state" ? "state" : "agent",

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -334,14 +334,14 @@ describe("OpenClaw database schema preflight", () => {
     });
   });
 
-  it("accepts a supported state schema", () => {
+  it("accepts a supported state schema", async () => {
     const stateDir = tempDirs.make("openclaw-database-preflight-supported-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     openOpenClawStateDatabase({ env });
     closeOpenClawStateDatabaseForTest();
 
     expect(
-      preflightOpenClawDatabaseSchemas({
+      await preflightOpenClawDatabaseSchemas({
         env,
         verifyCurrentSchemaShape: true,
         supportedVersions: {
@@ -350,10 +350,12 @@ describe("OpenClaw database schema preflight", () => {
         },
       }),
     ).toEqual({ incompatible: [], indeterminate: [] });
-    expect(() => assertOpenClawDatabasesReady({ env, operation: "gateway-restart" })).not.toThrow();
+    await expect(
+      assertOpenClawDatabasesReady({ env, operation: "gateway-restart" }),
+    ).resolves.toBeUndefined();
   });
 
-  it("accepts an older v6 state database without the lazy setup id during restart preflight", () => {
+  it("accepts an older v6 state database without the lazy setup id during restart preflight", async () => {
     const stateDir = tempDirs.make("openclaw-database-preflight-older-v6-setup-id-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const statePath = openOpenClawStateDatabase({ env }).path;
@@ -366,10 +368,12 @@ describe("OpenClaw database schema preflight", () => {
     } finally {
       state.close();
     }
-    expect(() => assertOpenClawDatabasesReady({ env, operation: "gateway-restart" })).not.toThrow();
+    await expect(
+      assertOpenClawDatabasesReady({ env, operation: "gateway-restart" }),
+    ).resolves.toBeUndefined();
   });
 
-  it("reports a current but noncanonical state schema as indeterminate", () => {
+  it("reports a current but noncanonical state schema as indeterminate", async () => {
     const stateDir = tempDirs.make("openclaw-database-preflight-noncanonical-state-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const statePath = openOpenClawStateDatabase({ env }).path;
@@ -387,7 +391,7 @@ describe("OpenClaw database schema preflight", () => {
     }
 
     expect(
-      preflightOpenClawDatabaseSchemas({
+      await preflightOpenClawDatabaseSchemas({
         env,
         verifyCurrentSchemaShape: true,
         supportedVersions: {
@@ -405,14 +409,14 @@ describe("OpenClaw database schema preflight", () => {
         },
       ],
     });
-    expect(() => assertOpenClawDatabasesReady({ env, operation: "gateway-restart" })).toThrow(
-      /Gateway refused restart.*column definitions differ for worktrees/u,
-    );
+    await expect(
+      assertOpenClawDatabasesReady({ env, operation: "gateway-restart" }),
+    ).rejects.toThrow(/Gateway refused restart.*column definitions differ for worktrees/u);
   });
 
   it.each(["default", "configured"])(
     "checks an unregistered %s store without creating shared state",
-    (layout) => {
+    async (layout) => {
       const stateDir = tempDirs.make("openclaw-unregistered-readiness-");
       const env = { OPENCLAW_STATE_DIR: stateDir };
       const customPath = path.join(tempDirs.make("openclaw-configured-readiness-"), "agent.sqlite");
@@ -438,7 +442,7 @@ describe("OpenClaw database schema preflight", () => {
           layout === "configured" ? [{ agentId: "main", path: agent.path }] : [],
       };
       const before = snapshotSourceFamily(agent.path);
-      expect(() => assertOpenClawDatabasesReady(options)).not.toThrow();
+      await expect(assertOpenClawDatabasesReady(options)).resolves.toBeUndefined();
       expect(snapshotSourceFamily(agent.path)).toEqual(before);
       expect(fs.existsSync(statePath)).toBe(false);
       const legacyWriter = new DatabaseSync(agent.path);
@@ -447,7 +451,7 @@ describe("OpenClaw database schema preflight", () => {
       );
       legacyWriter.close();
       const legacy = snapshotSourceFamily(agent.path);
-      expect(() => assertOpenClawDatabasesReady(options)).toThrow(
+      await expect(assertOpenClawDatabasesReady(options)).rejects.toThrow(
         /Doctor.*database readiness.*schema version 17/,
       );
       expect(snapshotSourceFamily(agent.path)).toEqual(legacy);
@@ -455,7 +459,7 @@ describe("OpenClaw database schema preflight", () => {
     },
   );
 
-  it("leaves archive-only state alone when no runtime database exists", () => {
+  it("leaves archive-only state alone when no runtime database exists", async () => {
     const stateDir = tempDirs.make("openclaw-readiness-archive-only-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const archivePath = path.join(
@@ -468,19 +472,19 @@ describe("OpenClaw database schema preflight", () => {
     fs.mkdirSync(path.dirname(archivePath), { recursive: true });
     fs.writeFileSync(archivePath, "unreadable archive\n");
     const before = snapshotSourceFamily(archivePath);
-    expect(() =>
+    await expect(
       assertOpenClawDatabasesReady({
         env,
         operation: "doctor",
         configuredAgentDatabaseTargets: [],
       }),
-    ).not.toThrow();
+    ).resolves.toBeUndefined();
     expect(snapshotSourceFamily(archivePath)).toEqual(before);
     expect(fs.existsSync(resolveOpenClawStateSqlitePath(env))).toBe(false);
     expect(fs.existsSync(path.join(stateDir, "agents", "main", "agent"))).toBe(false);
   });
 
-  it("collects newer state and registered agent schemas with writer builds", () => {
+  it("collects newer state and registered agent schemas with writer builds", async () => {
     const stateDir = tempDirs.make("openclaw-database-preflight-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const statePath = openOpenClawStateDatabase({ env }).path;
@@ -509,7 +513,7 @@ describe("OpenClaw database schema preflight", () => {
     }
 
     expect(
-      preflightOpenClawDatabaseSchemas({
+      await preflightOpenClawDatabaseSchemas({
         env,
         supportedVersions: {
           state: OPENCLAW_STATE_SCHEMA_VERSION,
@@ -540,7 +544,7 @@ describe("OpenClaw database schema preflight", () => {
 
   it.each(["absent", "installed", "drifted"])(
     "preflights the %s transcript eligibility index without repairing it",
-    (shape) => {
+    async (shape) => {
       const stateDir = tempDirs.make("openclaw-transcript-eligibility-preflight-");
       const env = { OPENCLAW_STATE_DIR: stateDir };
       const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
@@ -562,7 +566,7 @@ describe("OpenClaw database schema preflight", () => {
       } finally {
         agent.close();
       }
-      const result = preflightOpenClawDatabaseSchemas({
+      const result = await preflightOpenClawDatabaseSchemas({
         env,
         verifyCurrentSchemaShape: true,
         supportedVersions: {
@@ -600,7 +604,7 @@ describe("OpenClaw database schema preflight", () => {
     },
   );
 
-  it("checks every registered owner before permitting Gateway restart", () => {
+  it("checks every registered owner before permitting Gateway restart", async () => {
     const stateDir = tempDirs.make("openclaw-preflight-conflicting-owners-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "main", env }).path;
@@ -616,10 +620,10 @@ describe("OpenClaw database schema preflight", () => {
       .run("ops", agentPath, OPENCLAW_AGENT_SCHEMA_VERSION, 1, null);
     registry.close();
 
-    expect(() => assertOpenClawDatabasesReady({ env, operation: "gateway-restart" })).toThrow(
-      /Gateway refused restart.*belongs to agent main; requested agent ops/,
-    );
-    const result = preflightOpenClawDatabaseSchemas({
+    await expect(
+      assertOpenClawDatabasesReady({ env, operation: "gateway-restart" }),
+    ).rejects.toThrow(/Gateway refused restart.*belongs to agent main; requested agent ops/);
+    const result = await preflightOpenClawDatabaseSchemas({
       env,
       supportedVersions: {
         state: OPENCLAW_STATE_SCHEMA_VERSION,
@@ -637,7 +641,7 @@ describe("OpenClaw database schema preflight", () => {
     ]);
   });
 
-  it("reports a current but noncanonical registered agent schema as indeterminate", () => {
+  it("reports a current but noncanonical registered agent schema as indeterminate", async () => {
     const stateDir = tempDirs.make("openclaw-database-preflight-noncanonical-agent-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
@@ -655,7 +659,7 @@ describe("OpenClaw database schema preflight", () => {
     }
 
     expect(
-      preflightOpenClawDatabaseSchemas({
+      await preflightOpenClawDatabaseSchemas({
         env,
         verifyCurrentSchemaShape: true,
         supportedVersions: {
@@ -675,7 +679,7 @@ describe("OpenClaw database schema preflight", () => {
     });
   });
 
-  it("reports an existing unreadable state database as indeterminate", () => {
+  it("reports an existing unreadable state database as indeterminate", async () => {
     const stateDir = tempDirs.make("openclaw-database-preflight-unreadable-state-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const statePath = openOpenClawStateDatabase({ env }).path;
@@ -683,7 +687,7 @@ describe("OpenClaw database schema preflight", () => {
     fs.writeFileSync(statePath, "not a sqlite database");
 
     expect(
-      preflightOpenClawDatabaseSchemas({
+      await preflightOpenClawDatabaseSchemas({
         env,
         supportedVersions: {
           state: OPENCLAW_STATE_SCHEMA_VERSION,
@@ -698,7 +702,7 @@ describe("OpenClaw database schema preflight", () => {
     });
   });
 
-  it("reports a failed agent registry query as indeterminate", () => {
+  it("reports a failed agent registry query as indeterminate", async () => {
     const stateDir = tempDirs.make("openclaw-database-preflight-registry-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const statePath = openOpenClawStateDatabase({ env }).path;
@@ -712,7 +716,7 @@ describe("OpenClaw database schema preflight", () => {
     }
 
     expect(
-      preflightOpenClawDatabaseSchemas({
+      await preflightOpenClawDatabaseSchemas({
         env,
         supportedVersions: {
           state: OPENCLAW_STATE_SCHEMA_VERSION,
@@ -731,7 +735,7 @@ describe("OpenClaw database schema preflight", () => {
     });
   });
 
-  it("reports an existing unreadable registered agent database as indeterminate", () => {
+  it("reports an existing unreadable registered agent database as indeterminate", async () => {
     const stateDir = tempDirs.make("openclaw-database-preflight-unreadable-agent-");
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentPath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
@@ -740,7 +744,7 @@ describe("OpenClaw database schema preflight", () => {
     fs.writeFileSync(agentPath, "not a sqlite database");
 
     expect(
-      preflightOpenClawDatabaseSchemas({
+      await preflightOpenClawDatabaseSchemas({
         env,
         supportedVersions: {
           state: OPENCLAW_STATE_SCHEMA_VERSION,

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -9,7 +9,7 @@ import {
 } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase, resolveImmutableSqliteFileUri } from "../infra/node-sqlite.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
-import { prepareSqliteReadOnlyLocationSync } from "../infra/sqlite-readonly-location.js";
+import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
 import {
   collectSqliteSchemaIssues,
   type SqliteSchemaIssue,
@@ -120,7 +120,7 @@ export class OpenClawDatabaseSchemaPreflightError extends SqliteSchemaVersionErr
 }
 
 /** Verify persisted runtime schemas before certifying repair or accepting restart. */
-export function assertOpenClawDatabasesReady(
+export async function assertOpenClawDatabasesReady(
   options: {
     env: NodeJS.ProcessEnv;
   } & (
@@ -130,8 +130,8 @@ export function assertOpenClawDatabasesReady(
       }
     | { operation: "gateway-restart" }
   ),
-): void {
-  const schemas = preflightOpenClawDatabaseSchemas({
+): Promise<void> {
+  const schemas = await preflightOpenClawDatabaseSchemas({
     env: options.env,
     supportedVersions: {
       state: OPENCLAW_STATE_SCHEMA_VERSION,
@@ -324,8 +324,9 @@ export async function preflightOpenClawStateDatabasePath(
 }
 
 /** Read schema headers and optionally verify current schema shape without repairing it. */
-export function preflightOpenClawDatabaseSchemas(options: {
+export async function preflightOpenClawDatabaseSchemas(options: {
   env: NodeJS.ProcessEnv;
+  signal?: AbortSignal;
   supportedVersions: OpenClawSchemaVersions;
   verifyCurrentSchemaShape?: boolean;
   configuredAgentDatabaseTargets?:
@@ -334,17 +335,22 @@ export function preflightOpenClawDatabaseSchemas(options: {
         registeredDatabases: readonly { agentId: string; path: string }[],
       ) => readonly { agentId: string; path: string }[]);
   configuredAgentDatabaseCandidatePaths?: readonly string[];
-}): OpenClawDatabaseSchemaPreflight {
+}): Promise<OpenClawDatabaseSchemaPreflight> {
+  options.signal?.throwIfAborted();
   const result: OpenClawDatabaseSchemaPreflight = { incompatible: [], indeterminate: [] };
   const statePath = path.resolve(resolveOpenClawStateSqlitePath(options.env));
   let registeredDatabases: ReturnType<typeof readRegisteredAgentDatabases> = [];
   let stateDatabase: DatabaseSync | undefined;
-  let stateSnapshot: ReturnType<typeof prepareSqliteReadOnlyLocationSync> | undefined;
+  let stateSnapshot: Awaited<ReturnType<typeof prepareSqliteReadOnlyLocation>> | undefined;
   try {
     if (existsSync(statePath)) {
-      // Even a read-only source connection can create WAL/SHM. The sync worker
+      // Even a read-only source connection can create WAL/SHM. The copy worker
       // preserves source artifacts and cannot release this process's writer locks.
-      stateSnapshot = prepareSqliteReadOnlyLocationSync(realpathSync.native(statePath));
+      stateSnapshot = await prepareSqliteReadOnlyLocation(realpathSync.native(statePath), {
+        preserveSourceArtifacts: true,
+        signal: options.signal,
+      });
+      options.signal?.throwIfAborted();
       stateDatabase = openNodeSqliteDatabase(stateSnapshot.location, {
         readOnly: true,
       });
@@ -387,6 +393,11 @@ export function preflightOpenClawDatabaseSchemas(options: {
       }
     }
   } catch (error) {
+    // Accepted stop must not turn cancellation or failed cleanup into a
+    // warn-and-continue result that launches the remaining startup runtime.
+    if (options.signal?.aborted) {
+      throw error;
+    }
     result.indeterminate.push({
       kind: "state",
       path: statePath,
@@ -436,7 +447,7 @@ export function preflightOpenClawDatabaseSchemas(options: {
       continue;
     }
     let agentDatabase: DatabaseSync | undefined;
-    let agentSnapshot: ReturnType<typeof prepareSqliteReadOnlyLocationSync> | undefined;
+    let agentSnapshot: Awaited<ReturnType<typeof prepareSqliteReadOnlyLocation>> | undefined;
     try {
       // Preserve SQLite's filesystem traversal through symlink/.. locators.
       const realAgentPath = realpathSync.native(agentPath);
@@ -444,7 +455,11 @@ export function preflightOpenClawDatabaseSchemas(options: {
         continue;
       }
       inspectedAgentPaths.add(realAgentPath);
-      agentSnapshot = prepareSqliteReadOnlyLocationSync(realAgentPath);
+      agentSnapshot = await prepareSqliteReadOnlyLocation(realAgentPath, {
+        preserveSourceArtifacts: true,
+        signal: options.signal,
+      });
+      options.signal?.throwIfAborted();
       agentDatabase = openNodeSqliteDatabase(agentSnapshot.location, {
         readOnly: true,
       });
@@ -471,6 +486,9 @@ export function preflightOpenClawDatabaseSchemas(options: {
         ...(writerAppVersion ? { writerAppVersion } : {}),
       });
     } catch (error) {
+      if (options.signal?.aborted) {
+        throw error;
+      }
       result.indeterminate.push({
         kind: "agent",
         path: agentPath,

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -148,6 +148,74 @@ describe("external shared-state ownership", () => {
     expect(fs.existsSync(missingStateDir)).toBe(false);
   });
 
+  it.each(["missing", "orphaned", "existing"])(
+    "rejects canceled %s ownership admission before recovery or staging",
+    async (layout) => {
+      const env = createEnv();
+      const databasePath = resolveOpenClawStateSqlitePath(env);
+      if (layout === "existing") {
+        openOpenClawStateDatabase({ env });
+        closeOpenClawStateDatabaseForTest();
+      } else if (layout === "orphaned") {
+        fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+        fs.writeFileSync(`${databasePath}-wal`, Buffer.alloc(64, 1));
+      }
+      const before = layout === "missing" ? undefined : snapshotSqliteFamily(databasePath);
+      const controller = new AbortController();
+      const reason = new Error("ownership admission stopped");
+      controller.abort(reason);
+      const snapshot = vi.spyOn(sqliteReadonlyLocation, "prepareSqliteReadOnlyLocation");
+      try {
+        const options = { databasePath, env, signal: controller.signal };
+        await expect(assertOpenClawStateWriteAllowedAtPath(options)).rejects.toBe(reason);
+        expect(snapshot).not.toHaveBeenCalled();
+        if (layout === "missing") {
+          expect(fs.existsSync(path.dirname(databasePath))).toBe(false);
+        } else {
+          assert.deepStrictEqual(snapshotSqliteFamily(databasePath), before);
+        }
+      } finally {
+        snapshot.mockRestore();
+      }
+    },
+  );
+
+  it.each([
+    { mode: "unmarked", external: false, recoverOrphanedSidecars: undefined },
+    { mode: "external preview", external: true, recoverOrphanedSidecars: false },
+  ])("cleans an adopted snapshot when $mode ownership admission stops", async (scenario) => {
+    const env = createEnv(scenario.external);
+    const databasePath = openOpenClawStateDatabase({ env }).path;
+    closeOpenClawStateDatabaseForTest();
+    const before = snapshotSqliteFamily(databasePath);
+    const controller = new AbortController();
+    const reason = new Error("ownership admission stopped after snapshot");
+    const prepare = sqliteReadonlyLocation.prepareSqliteReadOnlyLocation;
+    let prepared: Awaited<ReturnType<typeof prepare>> | undefined;
+    const snapshot = vi
+      .spyOn(sqliteReadonlyLocation, "prepareSqliteReadOnlyLocation")
+      .mockImplementationOnce(async (pathname, options) => {
+        prepared = await prepare(pathname, options);
+        controller.abort(reason);
+        return prepared;
+      });
+    try {
+      const options = {
+        databasePath,
+        env,
+        recoverOrphanedSidecars: scenario.recoverOrphanedSidecars,
+        signal: controller.signal,
+      };
+      await expect(assertOpenClawStateWriteAllowedAtPath(options)).rejects.toBe(reason);
+      expect(prepared).toBeDefined();
+      expect(fs.existsSync(path.dirname(prepared!.location))).toBe(false);
+      assert.deepStrictEqual(snapshotSqliteFamily(databasePath), before);
+    } finally {
+      snapshot.mockRestore();
+      prepared?.cleanup();
+    }
+  });
+
   it("keeps missing-database admission eligible for pristine startup", async () => {
     const home = tempDirs.make("openclaw-state-ownership-pristine-");
     const stateDir = path.join(home, "state");

--- a/src/state/openclaw-state-ownership.ts
+++ b/src/state/openclaw-state-ownership.ts
@@ -273,7 +273,9 @@ export async function assertOpenClawStateWriteAllowedAtPath(options: {
   databasePath: string;
   env?: NodeJS.ProcessEnv;
   recoverOrphanedSidecars?: boolean;
+  signal?: AbortSignal;
 }): Promise<void> {
+  options.signal?.throwIfAborted();
   const databasePath = path.resolve(options.databasePath);
   const recoverOrphanedSidecars = options.recoverOrphanedSidecars !== false;
   if (recoverOrphanedSidecars) {
@@ -291,8 +293,9 @@ export async function assertOpenClawStateWriteAllowedAtPath(options: {
     );
     return;
   }
-  const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+  const prepared = await prepareSqliteReadOnlyLocation(databasePath, { signal: options.signal });
   try {
+    options.signal?.throwIfAborted();
     assertOwnershipAllowsWrite(
       inspectOwnershipThroughConnection(prepared.location, databasePath),
       databasePath,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway startup and database maintenance become unresponsive while inspecting large existing SQLite stores.

## Why This Change Was Made

Schema preflight now awaits the existing isolated, byte-preserving snapshot strategy. It keeps version/shape checks, per-database ordering, source-file protection, and cleanup at their existing owners.

The Gateway run loop owns the resource-bearing ownership and schema checks through one per-start work scope. Accepted stops cancel and join the child and its private staging before exit; queued startup restarts retain their existing behavior. Snapshot errors settle after child close, and cleanup failures remain failures. The sync and async worker transports share argument construction, result validation, and process completion handling; snapshot strategy, staging, and cleanup remain in their existing owner. The Windows update owner also rejects mutation after interruption or completed recovery, including signals received during the newly awaited schema check.

Database schemas, migration decisions, shutdown deadlines, configuration, and dependencies remain unchanged.

## User Impact

The event loop can service work while snapshot preparation runs, and Gateway stop joins its database workers and staging cleanup before reporting a clean exit. Overall startup duration still depends on copying and validation.

Direct in-process container onboarding still has its existing noncancellable startup-before-handle limitation. This change does not claim clean child teardown after forced process exit in that path.

## Evidence

- A compiled Gateway with a valid synthetic 136 MB state database spent 3,318.7 ms in schema preflight, used 101.2 ms of parent CPU, and serviced zero timer callbacks. It subsequently reached readiness and shut down cleanly. These are instrumented macOS/Node 26.8.1 observations, not a production latency distribution.
- The real live-WAL regression fails on the original code because the event loop is not serviced; it passes with the fix while preserving source-family and schema assertions.
- A transport-only intermediate implementation reproduced a real shutdown defect: the Gateway exited with code 0 while its snapshot worker remained running under PID 1 with partial staging. The final owner tests require actual child close and cleanup before settlement, including a child that acknowledges SIGTERM but waits for an explicit release.
- Earlier broad owner/sibling run: 581 tests passed; one Linux-only POSIX-lock case was skipped on macOS. The full run-loop suite separately passed all 78 tests. Deferred update-preflight and interrupted/completed recovery regressions have recorded RED/GREEN results.
- Composition with the merged external-restart handoff passed 135 lifecycle and cancellation cases. The refreshed candidate passed 193 owner/lifecycle tests (one Linux-only POSIX case skipped on macOS) and type-aware lint across all 26 changed files. Fresh whole-candidate P2 review found no actionable issues.
- An exact-source compiled Linux/Node 26.7 probe of the prior revision (`a6cb4a10c351`) confirmed the earlier ownership gap: after parent-only SIGTERM, the Gateway exited/closed with code 0 in 30 ms while its deliberately paused snapshot worker remained alive under PID 1. Source/dist/harness seals were stable; recovery and fixture cleanup were recorded separately. This controlled pause proves lifetime ownership, not natural latency or production frequency.
- Five added ownership-cancellation regressions all failed on the original helper and passed with signal propagation, preserving source files and cleaning adopted snapshots.

Final verification on public head `1ce6848dbbe3fbb83f91dadded8704ee517a5162` is complete:

- Matched Linux/Node 26.7 compiled runs: baseline schema preflight took 185.4 ms with zero timer callbacks; candidate took 169.4 ms while servicing 33 callbacks, with a 5.41 ms largest adjacent in-phase gap. Both reached an owned `/readyz` 200. These single instrumented runs establish scheduling progress; they do not establish overall startup acceleration or a latency distribution.
- Schema-stage STOP interrupted a real 10 MB partial copy: child SIGTERM close in 7.15 ms, parent clean close in 28.84 ms, no later network bootstrap. Ownership-stage STOP retained the live parent while its exact child was deliberately paused; after the timing control was released, actual child SIGTERM close and staging cleanup preceded parent exit 0.
- Both stop cases had no fallback signals, residual workers, process group, or snapshot staging. Complete source/build/harness seals matched. The baseline had its own checkout and frozen dependency install.
- All 32 changed checks passed. Focused Linux coverage passed 772 tests; one Windows-only case was skipped. Live-WAL POSIX locks and uncommitted writer-version assertions passed explicitly. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33961644334) passed.

Remote proof used Crabbox 0.49.1 with the configured Blacksmith Testbox backend, lease `tbx_01m1rk2v2zfwjsydpj9f4xxyce`. The delegated command exited 0; the 24,862,800-byte evidence archive was downloaded and SHA-256 verified before lease closure (`514242a6ac34fada8580155492683a75276094dbebd4f73012880898185a820f`). The persistent [Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33961743852) shows cancelled after normal lease cleanup; its command result and retained receipts are successful.

Validation history is retained: an initial pre-lease base-ref guard refused a raw SHA, the next Linux gate rejected a widening assertion, and earlier CI found test syntax/file-length issues. The final revision passes those guards without suppressions or longer timeouts.

The data-model review heuristic refers to private child-process JSON replies moved between modules. Their `{ ok, location }` / `{ ok, message }` shapes are unchanged; no persisted tables, schema definitions, migrations, or SQLite transaction policy change. The extra worker argument names only caller-owned temporary staging. Existing schema compatibility/refusal and source-artifact tests remain in the completed proof.


Production LOC: +335/-149 (net +186, including the worker transport move). Tests: +592/-126. The production growth supplies the startup operation lifetime and parent-owned temporary staging required to cancel and join safely; changing only the blocking transport reproduced the orphan-worker failure above.
