### PR TITLE
fix: preserve literal final tags in delivered code examples

### DIFF
--- a/docs/concepts/markdown-formatting.md
+++ b/docs/concepts/markdown-formatting.md
@@ -147,6 +147,10 @@ content is hidden or lost.
   lands on its own line.
 - Code-span parsing preserves all-space content. It removes one surrounding
   space from each end only when both are present and the content is not all spaces.
+- Assistant-reply cleanup removes valid `<final>` markers outside Markdown code,
+  including nested or stray markers, while keeping their enclosed answer text.
+  Put literal `<final>payload</final>` examples in inline code or fenced code
+  blocks so their tags are preserved.
 
 ## Related
 

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -27,6 +27,15 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("Hi <final>there</final>!")).toBe("Hi there!");
   });
 
+  it.each([
+    "Example:\n```xml\n<final data-model=\"demo\">payload</final>\n```",
+    "Write `<final>payload</final>` as XML.",
+  ])("preserves literal final tags through user-facing sanitization: %s", (example) => {
+    expect(sanitizeUserFacingText(`${example}\n<final>Outside answer</final>`)).toBe(
+      `${example}\nOutside answer`,
+    );
+  });
+
   it("strips self-closing and attributed final tags", () => {
     expect(sanitizeUserFacingText("<final/>Hello")).toBe("Hello");
     expect(sanitizeUserFacingText("<final data-model='gemini'>Hello</final>")).toBe("Hello");

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -28,7 +28,7 @@ describe("sanitizeUserFacingText", () => {
   });
 
   it.each([
-    "Example:\n```xml\n<final data-model=\"demo\">payload</final>\n```",
+    'Example:\n```xml\n<final data-model="demo">payload</final>\n```',
     "Write `<final>payload</final>` as XML.",
   ])("preserves literal final tags through user-facing sanitization: %s", (example) => {
     expect(sanitizeUserFacingText(`${example}\n<final>Outside answer</final>`)).toBe(

--- a/src/shared/text/final-tags.test.ts
+++ b/src/shared/text/final-tags.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { stripFinalTags } from "./final-tags.js";
+
+describe("stripFinalTags", () => {
+  it.each([
+    "Example:\n```xml\n<final data-model=\"demo\">payload</final>\n```",
+    "Example:\n~~~xml\n<final>payload</final>\n~~~",
+    "Write `<final>payload</final>` as XML.",
+    "Use ``<final data-note='`'>payload</final>`` literally.",
+    "Example:\n\n    <final>payload</final>",
+    "Example:\n```xml\n<final>payload</final>",
+    "> ```xml\n> <final>payload</final>\n> ```",
+  ])("preserves literal final tags in Markdown code: %s", (input) => {
+    expect(stripFinalTags(input)).toBe(input);
+  });
+
+  it("strips outside markers without removing their answer or code examples", () => {
+    const example = "```xml\n<final>payload</final>\n```";
+    expect(stripFinalTags(`<final>Outside answer</final>\n${example}\n<final/>Done`)).toBe(
+      `Outside answer\n${example}\nDone`,
+    );
+  });
+
+  it("preserves many ordered code regions while removing interleaved outside markers", () => {
+    const example = "`<final>literal</final>`";
+    const input = `${example}<final>visible</final> `.repeat(2_000);
+    expect(stripFinalTags(input)).toBe(`${example}visible `.repeat(2_000));
+  });
+
+  it.each([
+    ["<final>Hello</final>", "Hello"],
+    ["<final data-model='demo'>Hello</final>", "Hello"],
+    ["Unclosed `<final>Hello</final>", "Unclosed `Hello"],
+    ["<final-result>Hello</final-result>", "<final-result>Hello</final-result>"],
+    ["Plain text", "Plain text"],
+    ["", ""],
+  ])("retains existing outside-tag behavior: %s", (input, expected) => {
+    expect(stripFinalTags(input)).toBe(expected);
+  });
+});

--- a/src/shared/text/final-tags.test.ts
+++ b/src/shared/text/final-tags.test.ts
@@ -3,7 +3,7 @@ import { stripFinalTags } from "./final-tags.js";
 
 describe("stripFinalTags", () => {
   it.each([
-    "Example:\n```xml\n<final data-model=\"demo\">payload</final>\n```",
+    'Example:\n```xml\n<final data-model="demo">payload</final>\n```',
     "Example:\n~~~xml\n<final>payload</final>\n~~~",
     "Write `<final>payload</final>` as XML.",
     "Use ``<final data-note='`'>payload</final>`` literally.",

--- a/src/shared/text/final-tags.ts
+++ b/src/shared/text/final-tags.ts
@@ -132,7 +132,7 @@ export function findFinalTagMatches(text: string): FinalTagMatch[] {
   return matches;
 }
 
-/** Removes valid `<final>` tags while preserving their enclosed visible answer text. */
+/** Removes final-answer markers outside Markdown code while preserving their enclosed answer. */
 export function stripFinalTags(text: string): string {
   const matches = findFinalTagMatches(text);
   if (matches.length === 0) {

--- a/src/shared/text/final-tags.ts
+++ b/src/shared/text/final-tags.ts
@@ -1,4 +1,6 @@
 // Final tag helpers detect final-answer tag regions in assistant text.
+import { findCodeRegions } from "./code-regions.js";
+
 type FinalTagMatch = {
   index: number;
   text: string;
@@ -132,9 +134,23 @@ export function findFinalTagMatches(text: string): FinalTagMatch[] {
 
 /** Removes valid `<final>` tags while preserving their enclosed visible answer text. */
 export function stripFinalTags(text: string): string {
+  const matches = findFinalTagMatches(text);
+  if (matches.length === 0) {
+    return text;
+  }
+  // Literal examples must survive the final delivery sanitizer, just as they do reasoning cleanup.
+  const codeRegions = findCodeRegions(text);
+  let codeIndex = 0;
   let output = "";
   let lastIndex = 0;
-  for (const match of findFinalTagMatches(text)) {
+  for (const match of matches) {
+    // Both lists are ordered; advance once rather than rescanning every code region per tag.
+    while (codeIndex < codeRegions.length && codeRegions[codeIndex].end <= match.index) {
+      codeIndex += 1;
+    }
+    if (codeIndex < codeRegions.length && codeRegions[codeIndex].start <= match.index) {
+      continue;
+    }
     output += text.slice(lastIndex, match.index);
     lastIndex = match.index + match.text.length;
   }

--- a/src/shared/text/final-tags.ts
+++ b/src/shared/text/final-tags.ts
@@ -145,10 +145,12 @@ export function stripFinalTags(text: string): string {
   let lastIndex = 0;
   for (const match of matches) {
     // Both lists are ordered; advance once rather than rescanning every code region per tag.
-    while (codeIndex < codeRegions.length && codeRegions[codeIndex].end <= match.index) {
+    let codeRegion = codeRegions[codeIndex];
+    while (codeRegion && codeRegion.end <= match.index) {
       codeIndex += 1;
+      codeRegion = codeRegions[codeIndex];
     }
-    if (codeIndex < codeRegions.length && codeRegions[codeIndex].start <= match.index) {
+    if (codeRegion && codeRegion.start <= match.index) {
       continue;
     }
     output += text.slice(lastIndex, match.index);

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -200,6 +200,10 @@ describe("stripReasoningTagsFromText", () => {
         expected: "`<final>` in code, visible outside",
       },
       {
+        input: "  `<final>literal</final>`  ",
+        expected: "`<final>literal</final>`",
+      },
+      {
         input: "A <FINAL data-x='1'>visible</Final> B",
         expected: "A visible B",
       },

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -3,8 +3,7 @@ import {
   stripReasoningTagsFromMarkdown,
 } from "../../../packages/markdown-core/src/reasoning-tags.js";
 // Reasoning tag helpers find and remove model reasoning tag blocks from text.
-import { findCodeRegions, isInsideCode } from "./code-regions.js";
-import { findFinalTagMatches } from "./final-tags.js";
+import { findFinalTagMatches, stripFinalTags } from "./final-tags.js";
 export type ReasoningTagMode = "strict" | "preserve";
 export type ReasoningTagTrim = "none" | "start" | "both";
 export type ReasoningTagScope = "all" | "leading";
@@ -42,16 +41,7 @@ export function stripReasoningTagsFromText(
     return text;
   }
   if (matches.length > 0) {
-    const preCodeRegions = findCodeRegions(cleaned);
-    let visible = "";
-    let lastIndex = 0;
-    for (const match of matches) {
-      if (!isInsideCode(match.index, preCodeRegions)) {
-        visible += cleaned.slice(lastIndex, match.index);
-        lastIndex = match.index + match.text.length;
-      }
-    }
-    cleaned = visible + cleaned.slice(lastIndex);
+    cleaned = stripFinalTags(cleaned);
   }
 
   const stripped = stripReasoningTagsFromMarkdown(cleaned, {


### PR DESCRIPTION
Related: #133152 (the explicitly recorded final-delivery sanitizer follow-up).

## What Problem This Solves

Fixes an issue where users receiving XML examples would lose literal `<final>` tags inside fenced or inline code when the reply passed through final delivery sanitization. The raw answer could contain the correct example while the delivered text silently changed it.

The merged maintainer-authored #133152 records this exact failed live scenario and leaves it as a named follow-up. This PR repairs that remaining behavior.

## Why This Change Was Made

The final-tag owner now reuses the existing Markdown Core code regions, preserving literal code while removing control markers outside it. Ordered tag matches and code regions are traversed with one advancing cursor, avoiding a per-tag scan of every region. Reasoning cleanup delegates to this same owner instead of retaining its duplicate stripping loop; its original early-return and trimming conditions remain unchanged.

Existing-solutions preflight: OpenClaw already has the required CommonMark parser and code-region contract. No new parser, dependency, plugin, configuration, or alternative execution path is needed.

Production: **+22/-14, net +8**, across two files. Tests: **+53**, across three files. Documentation: **+4** in the canonical Markdown formatting guide, clarifying the same boundary as the helper API comment. The production growth protects literal source text and bounds region lookup; the connected duplicate loop is removed. No changelog or proof assets are added to the product branch.

## User Impact

Code examples retain their original XML tags. Real final-answer markers outside code are still removed without deleting the answer they enclose. Fenced, inline, indented, blockquoted, and unfinished fenced examples are covered, including attributed tags and mixed code/control text.

No config/default, protocol/schema, permissions, security-policy, persistence, migration, or upgrade change. This does not expose reasoning contents or relax private-scaffolding filtering; those are separate policies.

## Evidence

### Recorded CLI Behavior Receipt

- **Product head:** `5654f5f36b2dadaab504060017d440cb858e6dc9`.
- **Current PR head:** `c22b1b79cf975dc9335bb45dd19b19ac3e60203a`. The recorded CLI receipt predates the behavior-equivalent cursor type correction and documentation/API-comment clarification. The latter emits identical JavaScript with comments removed; the CLI evidence remains applicable.
- **Baseline:** `336b75a11d13bd173582dc7e3064b412c133bdcd`. Both affected production files remain byte-identical on current main at the final pre-publication check.
- **Real entry:** built OpenClaw CLI, using an isolated agent and the repository's existing loopback mock OpenAI server. The fixture explicitly selects the OpenClaw runtime, not Codex.

```sh
pnpm --silent openclaw agent --local --agent main \
  --session-id alix-final-tags-patched --channel telegram \
  --message "Return the fixture response exactly." \
  --thinking off --timeout 60 --json
```

No `--deliver` is supplied. The explicit channel selects real reply normalization without dispatching a channel message. The assertion reads canonical `payloads[].text`, not raw assistant metadata or a direct helper result.

- **Canonical owner exercised:** agent command post-run delivery -> reply normalization -> `sanitizeUserFacingText` -> `stripFinalTags`.
- **Recorder/readback:** actual CLI JSON output plus a recorded `POST /v1/responses` at the loopback provider. The receipt retains the exact command, input, expected/actual output, source SHA, session ID and observation time.
- **Acceptance red:** baseline session `alix-final-tags-baseline` returned `payload` instead of `<final data-model="demo">payload</final>` inside the XML fence, and `inline` instead of `<final>inline</final>` inside inline code. [Baseline run and logs](https://github.com/Alix-007/openclaw/actions/runs/33950401290/job/101263961256).
- **Acceptance green:** the same entry and fixture on product head preserve both examples byte-for-byte. Observed `2026-09-05T09:45:33.911Z`, session `alix-final-tags-patched`. [Exact-head run](https://github.com/Alix-007/openclaw/actions/runs/33958481136).
- **Legal control:** `<final>Outside answer</final>` becomes `Outside answer` on both baseline and patched runs. The fixture combines this control with both literal-code cases in one reply.
- **Inspectable artifact:** [receipt, actual CLI output, test and formatting logs, cleanup receipt](https://github.com/Alix-007/openclaw/actions/runs/33958481136/artifacts/9967254686). Retained for 30 days. The baseline artifact upload excluded its hidden directory, so baseline evidence is in its retained run log; the patched upload explicitly includes it.
- **Reproduction driver:** [pinned isolated proof driver](https://github.com/Alix-007/openclaw/blob/9c948f1a0a4d89dcc6dd7ebfcae3d81130f421f6/.github/proof/final-tags/cli-proof.mjs) and [workflow](https://github.com/Alix-007/openclaw/blob/9c948f1a0a4d89dcc6dd7ebfcae3d81130f421f6/.github/workflows/alix-final-tags-proof.yml). These are fork-only evidence tooling, not part of this PR.
- **Cleanup and limitations:** the owned mock process stopped and disposable state/workspace were removed. No production instance or external channel was touched. This proves real CLI/final-payload behavior with a mock provider, not a live provider, Telegram transport, or browser session.

### Tests and Review

- Baseline with the initial regression patch: **10 failed, 116 passed**, with the failures demonstrating lost code literals.
- Product head: **202 tests passed** across final-tag owner, reasoning-tag sibling and user-facing sanitizer files. Includes outside-marker controls, literal-only whitespace trimming and 2,000 interleaved code regions.
- Exact-head `pnpm build`, focused repository formatting, and diff hygiene passed in secretless fork CI.
- Fresh automated source review through P2 on `c22b1b79cf975dc9335bb45dd19b19ac3e60203a`: **pass, no findings**. The original quadratic lookup finding and later cursor type-narrowing finding are resolved.
- Not run: full repository test suite, separate full typecheck/lint fan-out, live external channels/providers or browser QA. Upstream required CI remains authoritative for its additional lanes.

AI-assisted implementation and review; the behavior results above were read back from the isolated executions, not inferred from passing unit tests.
