### PR TITLE
fix(sessions): preserve agents in global views and local commands

### DIFF
--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -32,6 +32,8 @@ With `session.scope: "global"`, the selected agent still owns its session.
 The shared key `global` does not merge different agents' conversations:
 commands, skills, replies, and background task notifications retain the
 agent selected by the route or explicit request.
+Session lists, model filters, previews, and sharing controls also retain the
+stored conversation's agent, rather than the aggregate view's default agent.
 
 ## DM isolation
 

--- a/src/agents/agent-runtime-metadata.ts
+++ b/src/agents/agent-runtime-metadata.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { applyAcpRuntimeOverlay, type AgentRuntimeMetadata } from "./acp-runtime-overlay.js";
 import { isDefaultAgentRuntimeId } from "./agent-runtime-id.js";
 import { resolveAvailableAgentHarnessPolicy } from "./harness/availability.js";
+import type { AgentRuntimePolicyScope } from "./model-runtime-policy.js";
 import { resolveDefaultModelForAgent } from "./model-selection.js";
 import {
   resolvePersistedSessionRuntimeId,
@@ -11,7 +12,6 @@ import {
 
 type ModelAgentRuntimeMetadataParams = {
   cfg: OpenClawConfig;
-  agentId: string;
   provider?: string;
   model?: string;
   sessionKey?: string;
@@ -21,7 +21,10 @@ type ModelAgentRuntimeMetadataParams = {
   /** Persisted ACP backend id, falling back to acpx when absent. */
   acpBackend?: string;
   agentHarnessRuntimeOverride?: string;
-};
+} & (
+  | { agentId: string; agentScope?: never }
+  | Extract<AgentRuntimePolicyScope, { agentScope: unknown }>
+);
 
 /** Resolves the runtime id/source that should be reported for a model-backed agent session. */
 export function resolveModelAgentRuntimeMetadata(
@@ -36,16 +39,17 @@ export function resolveModelAgentRuntimeMetadata(
       params.acpBackend,
     );
   }
+  const agentId = params.agentScope ? params.agentScope.agentId : params.agentId;
   const resolved =
     params.provider && params.model
       ? { provider: params.provider, model: params.model }
-      : resolveDefaultModelForAgent({ cfg: params.cfg, agentId: params.agentId });
+      : resolveDefaultModelForAgent({ cfg: params.cfg, agentId });
   const policy = resolveAvailableAgentHarnessPolicy({
+    ...params,
     mode: "projection",
     provider: resolved.provider,
     modelId: resolved.model,
     config: params.cfg,
-    agentId: params.agentId,
     sessionKey: params.sessionKey,
     agentHarnessRuntimeOverride: params.agentHarnessRuntimeOverride,
   });

--- a/src/agents/harness/policy.ts
+++ b/src/agents/harness/policy.ts
@@ -8,7 +8,10 @@ import {
   type EmbeddedAgentRuntime,
   normalizeOptionalAgentRuntimeId,
 } from "../agent-runtime-id.js";
-import { resolveModelRuntimePolicy } from "../model-runtime-policy.js";
+import {
+  resolveModelRuntimePolicy,
+  type AgentRuntimePolicyScope,
+} from "../model-runtime-policy.js";
 import { resolveOpenAIImplicitAgentRuntime } from "../openai-routing.js";
 
 /**
@@ -21,24 +24,18 @@ export type AgentHarnessPolicy = {
 };
 
 /** Resolves model/provider/runtime config into the canonical harness runtime id. */
-export function resolveAgentHarnessPolicy(params: {
-  provider?: string;
-  modelId?: string;
-  modelApi?: string | null;
-  modelBaseUrl?: unknown;
-  requestTransportOverrides?: ProviderRouteOverridePresence;
-  config?: OpenClawConfig;
-  agentId?: string;
-  sessionKey?: string;
-  env?: NodeJS.ProcessEnv;
-}): AgentHarnessPolicy {
-  const configured = resolveModelRuntimePolicy({
-    config: params.config,
-    provider: params.provider,
-    modelId: params.modelId,
-    agentId: params.agentId,
-    sessionKey: params.sessionKey,
-  });
+export function resolveAgentHarnessPolicy(
+  params: {
+    provider?: string;
+    modelId?: string;
+    modelApi?: string | null;
+    modelBaseUrl?: unknown;
+    requestTransportOverrides?: ProviderRouteOverridePresence;
+    config?: OpenClawConfig;
+    env?: NodeJS.ProcessEnv;
+  } & AgentRuntimePolicyScope,
+): AgentHarnessPolicy {
+  const configured = resolveModelRuntimePolicy(params);
   const configuredRuntime = normalizeOptionalAgentRuntimeId(configured.policy?.id);
   const runtime =
     configuredRuntime && configuredRuntime !== "default"
@@ -54,15 +51,9 @@ export function resolveAgentHarnessPolicy(params: {
     };
   }
   const openAIImplicitRuntime = resolveOpenAIImplicitAgentRuntime({
-    provider: params.provider,
-    modelId: params.modelId,
+    ...params,
     api: params.modelApi,
     baseUrl: params.modelBaseUrl,
-    config: params.config,
-    agentId: params.agentId,
-    sessionKey: params.sessionKey,
-    env: params.env,
-    requestTransportOverrides: params.requestTransportOverrides,
   });
   if (openAIImplicitRuntime) {
     return { runtime: openAIImplicitRuntime, runtimeSource };

--- a/src/agents/harness/support.ts
+++ b/src/agents/harness/support.ts
@@ -13,8 +13,11 @@ import type {
   ProviderRouteOverridePresence,
 } from "../../plugin-sdk/provider-model-types.js";
 import { resolveProviderModelRoutes } from "../../plugins/provider-model-routes.js";
-import { resolveSessionAgentIds } from "../agent-scope.js";
 import { hasAuthoredProviderRequestParams } from "../model-extra-params.js";
+import {
+  resolveAgentRuntimePolicyAgentId,
+  type AgentRuntimePolicyScope,
+} from "../model-runtime-policy.js";
 import { canonicalizeProviderModelId } from "../provider-model-route.js";
 import type { PreparedAgentRuntimeAuthAttempt } from "../runtime-plan/prepare-auth.js";
 import type { AgentRuntimeAuthPlan } from "../runtime-plan/types.js";
@@ -95,20 +98,20 @@ export function projectPreparedModelProvider(params: {
 }
 
 /** Builds the provider/model facts passed to registered harness support probes. */
-export function buildAgentHarnessSupportContext(params: {
-  provider: string;
-  modelId?: string;
-  /** Prepared provider facts take precedence over config rediscovery. */
-  modelProvider?: AgentHarnessSupportContext["modelProvider"];
-  requestedRuntime: AgentHarnessSupportContext["requestedRuntime"];
-  config?: OpenClawConfig;
-  agentId?: string;
-  sessionKey?: string;
-  /** Finalized route/auth selection; missing runtimePolicy stays undeclared. */
-  preparedModelProvider?: boolean;
-  /** Prepared selection fact; read-only projections omit it to avoid plugin metadata discovery. */
-  providerOwnership?: HarnessProviderOwnership;
-}): AgentHarnessSupportContext {
+export function buildAgentHarnessSupportContext(
+  params: {
+    provider: string;
+    modelId?: string;
+    /** Prepared provider facts take precedence over config rediscovery. */
+    modelProvider?: AgentHarnessSupportContext["modelProvider"];
+    requestedRuntime: AgentHarnessSupportContext["requestedRuntime"];
+    config?: OpenClawConfig;
+    /** Finalized route/auth selection; missing runtimePolicy stays undeclared. */
+    preparedModelProvider?: boolean;
+    /** Prepared selection fact; read-only projections omit it to avoid plugin metadata discovery. */
+    providerOwnership?: HarnessProviderOwnership;
+  } & AgentRuntimePolicyScope,
+): AgentHarnessSupportContext {
   const providerConfig = resolveMergedModelProviderConfig(params.config, params.provider);
   const authoredConfig = params.config
     ? projectConfigOntoRuntimeSourceSnapshot(params.config)
@@ -121,14 +124,7 @@ export function buildAgentHarnessSupportContext(params: {
           normalizeModelId(params.provider, configuredModelId),
       }).get(modelId)
     : undefined;
-  const agentId =
-    params.config && (params.agentId?.trim() || params.sessionKey?.trim())
-      ? resolveSessionAgentIds({
-          config: params.config,
-          agentId: params.agentId,
-          sessionKey: params.sessionKey,
-        }).sessionAgentId
-      : params.agentId;
+  const agentId = resolveAgentRuntimePolicyAgentId(params);
   const hasConfiguredProviderRequestParams = hasAuthoredProviderRequestParams({
     config: params.config,
     provider: params.provider,
@@ -241,13 +237,13 @@ function resolveHarnessRouteRuntimePolicy(params: {
 }
 
 /** Resolves the registered plugin harness that auto selection would choose. */
-export function resolveAutoAgentHarnessId(params: {
-  provider: string;
-  modelId?: string;
-  config?: OpenClawConfig;
-  agentId?: string;
-  sessionKey?: string;
-}): string | undefined {
+export function resolveAutoAgentHarnessId(
+  params: {
+    provider: string;
+    modelId?: string;
+    config?: OpenClawConfig;
+  } & AgentRuntimePolicyScope,
+): string | undefined {
   const registeredHarnesses = listRegisteredAgentHarnesses();
   if (registeredHarnesses.length === 0) {
     return undefined;

--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -572,6 +572,32 @@ describe("resolveModelRuntimePolicy", () => {
     ).toThrow(/belongs to "research"/);
   });
 
+  it.each(["openai/gpt-5.5", "openai/*"])(
+    "uses a prepared stored-row owner for %s without re-admitting global",
+    (modelKey) => {
+      const config: OpenClawConfig = {
+        session: { store: "/synthetic/shared.sqlite" },
+        agents: {
+          ownership: "explicit",
+          defaults: { sessionStore: { agentId: "ops" } },
+          entries: {
+            main: { models: { [modelKey]: { agentRuntime: { id: "openclaw" } } } },
+            ops: { models: { [modelKey]: { agentRuntime: { id: "codex" } } } },
+          },
+        },
+      };
+      expect(
+        resolveModelRuntimePolicy({
+          config,
+          provider: "openai",
+          modelId: "gpt-5.5",
+          sessionKey: "global",
+          agentScope: { kind: "prepared", agentId: "main" },
+        }),
+      ).toEqual({ policy: { id: "openclaw" }, source: "model", matchedProvider: "openai" });
+    },
+  );
+
   it("fails closed for duplicate provider-prefixed bare-model policies", () => {
     const config = {
       agents: {

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -14,6 +14,28 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAgentEntry } from "./agent-scope-config.js";
 import { resolveSessionAgentIds } from "./agent-scope.js";
 
+/** A stored-row owner is already selected; request hints still require normal admission. */
+export type AgentRuntimePolicyScope = { sessionKey?: string } & (
+  | { agentId?: string; agentScope?: never }
+  | { agentId?: never; agentScope: { kind: "prepared"; agentId: string } }
+);
+
+/** Resolve request hints; prepared owner facts never re-admit a canonical sentinel. */
+export function resolveAgentRuntimePolicyAgentId(
+  params: AgentRuntimePolicyScope & { config?: OpenClawConfig },
+): string | undefined {
+  if (params.agentScope?.kind === "prepared") {
+    return params.agentScope.agentId;
+  }
+  return params.config && (params.agentId?.trim() || params.sessionKey?.trim())
+    ? resolveSessionAgentIds({
+        config: params.config,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+      }).sessionAgentId
+    : params.agentId;
+}
+
 /** Config surface that supplied a resolved model runtime policy. */
 type ModelRuntimePolicySource = "model" | "provider";
 
@@ -147,25 +169,15 @@ function resolveAgentModelEntryRuntimePolicy(params: {
   provider?: string;
   modelId?: string;
   agentId?: string;
-  sessionKey?: string;
   matchKind: Exclude<ModelEntryMatchKind, "none">;
 }): AgentModelRuntimePolicyResolution {
   const modelId = normalizeModelIdForProvider(params.provider, params.modelId);
   if (!params.config || (!modelId && params.matchKind !== "provider-wildcard")) {
     return {};
   }
-  const hasSessionScope = Boolean(params.agentId?.trim() || params.sessionKey?.trim());
-  const sessionAgentId = hasSessionScope
-    ? resolveSessionAgentIds({
-        config: params.config,
-        agentId: params.agentId,
-        sessionKey: params.sessionKey,
-      }).sessionAgentId
-    : tryResolveLegacyCompatibilityAgentId(params.config);
   // Point lookup: projecting the whole roster per model ref made runtime
   // collection O(agents² × models) on large fleets (#135743).
-  const agentEntry =
-    sessionAgentId && params.config ? resolveAgentEntry(params.config, sessionAgentId) : undefined;
+  const agentEntry = params.agentId ? resolveAgentEntry(params.config, params.agentId) : undefined;
   const modelMaps: Array<Record<string, AgentModelEntryConfig> | undefined> = [
     agentEntry?.models,
     params.config.agents?.defaults?.models,
@@ -211,13 +223,13 @@ function resolveModelConfig(params: {
 }
 
 /** Resolves the effective runtime policy for an agent/model/provider selection. */
-export function resolveModelRuntimePolicy(params: {
-  config?: OpenClawConfig;
-  provider?: string;
-  modelId?: string;
-  agentId?: string;
-  sessionKey?: string;
-}): ResolvedModelRuntimePolicy {
+export function resolveModelRuntimePolicy(
+  params: {
+    config?: OpenClawConfig;
+    provider?: string;
+    modelId?: string;
+  } & AgentRuntimePolicyScope,
+): ResolvedModelRuntimePolicy {
   const callerProvider = normalizeProviderId(params.provider ?? "");
   const effectiveProvider = resolveEffectiveProvider(params.provider, params.modelId);
   const inferredMatchedProvider = callerProvider ? undefined : effectiveProvider;
@@ -228,8 +240,15 @@ export function resolveModelRuntimePolicy(params: {
     }
   }
 
+  const hasAgentScope = Boolean(
+    params.agentScope || params.agentId?.trim() || params.sessionKey?.trim(),
+  );
+  const agentId = hasAgentScope
+    ? resolveAgentRuntimePolicyAgentId(params)
+    : params.config && tryResolveLegacyCompatibilityAgentId(params.config);
   const agentModelPolicy = resolveAgentModelEntryRuntimePolicy({
     ...params,
+    agentId,
     provider: effectiveProvider,
     matchKind: "exact",
   });
@@ -254,6 +273,7 @@ export function resolveModelRuntimePolicy(params: {
   }
   const agentWildcardModelPolicy = resolveAgentModelEntryRuntimePolicy({
     ...params,
+    agentId,
     provider: effectiveProvider,
     matchKind: "provider-wildcard",
   });

--- a/src/agents/openai-routing.ts
+++ b/src/agents/openai-routing.ts
@@ -11,9 +11,12 @@ import {
   normalizeOptionalAgentRuntimeId,
   resolveAgentScopedRuntimeOverride,
 } from "./agent-runtime-id.js";
-import { resolveSessionAgentIds } from "./agent-scope.js";
 import { hasAuthoredProviderRequestParams } from "./model-extra-params.js";
-import { resolveModelRuntimePolicy } from "./model-runtime-policy.js";
+import {
+  resolveAgentRuntimePolicyAgentId,
+  resolveModelRuntimePolicy,
+  type AgentRuntimePolicyScope,
+} from "./model-runtime-policy.js";
 import { resolveOpenAIModelRoutes } from "./openai-model-routes.js";
 import { canonicalizeProviderModelId } from "./provider-model-route.js";
 
@@ -35,29 +38,22 @@ export function canonicalizeOpenAIModelId(provider: string | undefined, modelId:
 }
 
 /** Resolves the provider-owned implicit runtime for one concrete OpenAI route. */
-export function resolveOpenAIImplicitAgentRuntime(params: {
-  provider?: string;
-  modelId?: string;
-  api?: string | null;
-  baseUrl?: unknown;
-  config?: OpenClawConfig;
-  agentId?: string;
-  sessionKey?: string;
-  env?: Readonly<Record<string, string | undefined>>;
-  requestTransportOverrides?: ProviderRouteOverridePresence;
-}): "codex" | "openclaw" | null {
+export function resolveOpenAIImplicitAgentRuntime(
+  params: {
+    provider?: string;
+    modelId?: string;
+    api?: string | null;
+    baseUrl?: unknown;
+    config?: OpenClawConfig;
+    env?: Readonly<Record<string, string | undefined>>;
+    requestTransportOverrides?: ProviderRouteOverridePresence;
+  } & AgentRuntimePolicyScope,
+): "codex" | "openclaw" | null {
   if (!isOpenAIProvider(params.provider)) {
     return null;
   }
   const modelId = params.modelId;
-  const agentId =
-    params.config && (params.agentId?.trim() || params.sessionKey?.trim())
-      ? resolveSessionAgentIds({
-          config: params.config,
-          agentId: params.agentId,
-          sessionKey: params.sessionKey,
-        }).sessionAgentId
-      : params.agentId;
+  const agentId = resolveAgentRuntimePolicyAgentId(params);
   const hasConfiguredProviderRequestParams = hasAuthoredProviderRequestParams({
     config: params.config,
     provider: params.provider ?? OPENAI_PROVIDER_ID,

--- a/src/agents/thinking-runtime.test.ts
+++ b/src/agents/thinking-runtime.test.ts
@@ -64,6 +64,56 @@ describe("resolveEffectiveAgentRuntime", () => {
     restoreRegisteredAgentHarnesses(registeredHarnesses);
   });
 
+  it.each([false, true])(
+    "retains prepared owner request parameters through implicit and registered support (explicit=%s)",
+    (explicit) => {
+      const supports = vi.fn<AgentHarness["supports"]>(({ modelProvider }) =>
+        modelProvider?.requestTransportOverrides === "present"
+          ? { supported: false, fallbackRuntime: "openclaw" }
+          : { supported: true },
+      );
+      registerAgentHarness({
+        id: "codex",
+        label: "Codex",
+        supports,
+        runAttempt: async () => {
+          throw new Error("projection must not execute");
+        },
+      });
+      const cfg: OpenClawConfig = {
+        session: { store: "/synthetic/shared.sqlite" },
+        agents: {
+          ownership: "explicit",
+          defaults: {
+            sessionStore: { agentId: "ops" },
+            ...(explicit
+              ? { models: { "openai/gpt-5.6-luna": { agentRuntime: { id: "codex" } } } }
+              : {}),
+          },
+          entries: { main: { params: { temperature: 0.2 } }, ops: {} },
+        },
+      };
+      expect(
+        resolveEffectiveAgentRuntime({
+          cfg,
+          provider: "openai",
+          modelId: "gpt-5.6-luna",
+          sessionKey: "global",
+          agentScope: { kind: "prepared", agentId: "main" },
+        }),
+      ).toBe("openclaw");
+      if (explicit) {
+        expect(supports).toHaveBeenCalledWith(
+          expect.objectContaining({
+            modelProvider: expect.objectContaining({ requestTransportOverrides: "present" }),
+          }),
+        );
+      } else {
+        expect(supports).not.toHaveBeenCalled();
+      }
+    },
+  );
+
   it("keeps cold-start official OpenAI Luna on implicit Codex policy", () => {
     expect(
       resolveEffectiveAgentRuntime({

--- a/src/agents/thinking-runtime.ts
+++ b/src/agents/thinking-runtime.ts
@@ -11,6 +11,7 @@ import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAvailableAgentHarnessPolicy } from "./harness/availability.js";
 import { resolveAutoAgentHarnessId } from "./harness/support.js";
+import type { AgentRuntimePolicyScope } from "./model-runtime-policy.js";
 import { resolveSessionRuntimeOverrideForProvider } from "./session-runtime-compat.js";
 
 export function hasResolvedThinkingCatalogEntry(params: {
@@ -57,19 +58,19 @@ export function concretizeAgentRuntime(runtime: string): string {
 }
 
 /** Resolves an explicit session override before configured model/provider policy. */
-export function resolveEffectiveAgentRuntime(params: {
-  cfg: OpenClawConfig;
-  provider: string;
-  modelId: string;
-  modelApi?: string | null;
-  modelBaseUrl?: unknown;
-  agentId?: string;
-  sessionKey?: string;
-  sessionEntry?: Pick<
-    SessionEntry,
-    "agentHarnessId" | "agentRuntimeOverride" | "modelSelectionLocked"
-  >;
-}): string {
+export function resolveEffectiveAgentRuntime(
+  params: {
+    cfg: OpenClawConfig;
+    provider: string;
+    modelId: string;
+    modelApi?: string | null;
+    modelBaseUrl?: unknown;
+    sessionEntry?: Pick<
+      SessionEntry,
+      "agentHarnessId" | "agentRuntimeOverride" | "modelSelectionLocked"
+    >;
+  } & AgentRuntimePolicyScope,
+): string {
   const sessionRuntime = resolveSessionRuntimeOverrideForProvider({
     provider: params.provider,
     entry: params.sessionEntry,
@@ -94,6 +95,9 @@ export function resolveEffectiveAgentRuntime(params: {
         provider: params.provider,
         modelId: params.modelId,
         config: params.cfg,
+        ...(params.agentScope
+          ? { agentScope: params.agentScope, sessionKey: params.sessionKey }
+          : {}),
       }) ?? "openclaw"
     );
   }

--- a/src/agents/tools/embedded-gateway-stub.ts
+++ b/src/agents/tools/embedded-gateway-stub.ts
@@ -45,7 +45,7 @@ async function handleSessionsList(params: Record<string, unknown>) {
   const rt = await getRuntime();
   const cfg = rt.getRuntimeConfig();
   const opts = params as SessionsListParams;
-  const { storePath, store, agentIdBySessionKey } = rt.loadCombinedSessionStoreForGatewayCore(cfg, {
+  const { storePath, store, targetsBySessionKey } = rt.loadCombinedSessionStoreForGatewayCore(cfg, {
     agentId: opts.agentId,
     projection: "list",
   });
@@ -53,7 +53,7 @@ async function handleSessionsList(params: Record<string, unknown>) {
     cfg,
     storePath,
     store,
-    agentIdBySessionKey,
+    targetsBySessionKey,
     opts,
   });
 }

--- a/src/agents/tools/embedded-gateway-stub.ts
+++ b/src/agents/tools/embedded-gateway-stub.ts
@@ -45,7 +45,7 @@ async function handleSessionsList(params: Record<string, unknown>) {
   const rt = await getRuntime();
   const cfg = rt.getRuntimeConfig();
   const opts = params as SessionsListParams;
-  const { storePath, store } = rt.loadCombinedSessionStoreForGatewayCore(cfg, {
+  const { storePath, store, agentIdBySessionKey } = rt.loadCombinedSessionStoreForGatewayCore(cfg, {
     agentId: opts.agentId,
     projection: "list",
   });
@@ -53,6 +53,7 @@ async function handleSessionsList(params: Record<string, unknown>) {
     cfg,
     storePath,
     store,
+    agentIdBySessionKey,
     opts,
   });
 }

--- a/src/agents/tools/sessions-list-tool.test.ts
+++ b/src/agents/tools/sessions-list-tool.test.ts
@@ -91,6 +91,7 @@ describe("sessions-list-tool", () => {
     const sessions = entries.map(([key, entry]) =>
       buildGatewaySessionRow({
         cfg: VALID_CONFIG,
+        agentId: "main",
         storePath: "/tmp/sessions.json",
         store,
         key,

--- a/src/auto-reply/reply/directive-handling.session-list.test.ts
+++ b/src/auto-reply/reply/directive-handling.session-list.test.ts
@@ -8,7 +8,7 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createDirectChatContext } from "../../gateway/server-chat.agent-events.test-helpers.js";
 import { respondWithCachedSessionList } from "../../gateway/server-methods/sessions-list-cache.js";
-import { listSessionsFromStoreAsync } from "../../gateway/session-utils-list.js";
+import { listSessionFixture } from "../../gateway/session-list.test-support.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { handleDirectiveOnly } from "./directive-handling.impl.js";
 import { parseInlineSessionDirectives } from "./directive-handling.parse.js";
@@ -46,7 +46,7 @@ it.each([
             response = payload;
           },
           run: async () =>
-            await listSessionsFromStoreAsync({
+            await listSessionFixture({
               cfg,
               storePath,
               store: { [scope.sessionKey]: readEntry() },

--- a/src/config/sessions/combined-store-gateway.test.ts
+++ b/src/config/sessions/combined-store-gateway.test.ts
@@ -1,13 +1,50 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
-import { filterAndSortSessionEntries } from "../../gateway/session-utils-list.js";
+import {
+  filterAndSortSessionEntries,
+  listSessionsFromStoreAsync,
+} from "../../gateway/session-utils-list.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { loadCombinedSessionStoreForGatewayCore } from "./combined-store-gateway.js";
 import { replaceSessionEntrySync } from "./session-accessor.js";
 import { setCanonicalSqliteSessionMainKey } from "./session-canonical-key.js";
+
+it.each(["global", "unknown"])("projects the recorded aggregate %s owner", async (sessionKey) => {
+  await withOpenClawTestState({ label: "combined-list-owner" }, async () => {
+    const cfg: OpenClawConfig = {
+      session: { scope: "global" },
+      agents: {
+        entries: {
+          main: { default: true, model: { primary: "openai/gpt-5.4" } },
+          research: { model: { primary: "openai/gpt-5.5" } },
+        },
+      },
+    };
+    replaceSessionEntrySync(
+      { agentId: "research", sessionKey },
+      { sessionId: "research-only", updatedAt: 42 },
+    );
+    const combined = loadCombinedSessionStoreForGatewayCore(cfg);
+    expect(combined.agentIdBySessionKey.get(sessionKey)).toBe("research");
+    const opts = { includeGlobal: true, includeUnknown: true };
+    const result = await listSessionsFromStoreAsync({ cfg, ...combined, opts });
+    expect
+      .soft(result.sessions)
+      .toMatchObject([
+        { key: sessionKey, sessionId: "research-only", agentId: "research", model: "gpt-5.5" },
+      ]);
+    const searched = await listSessionsFromStoreAsync({
+      cfg,
+      ...combined,
+      opts: { ...opts, search: "gpt-5.5" },
+    });
+    expect.soft(searched.sessions.map((row) => row.sessionId)).toEqual(["research-only"]);
+    expect(searched.defaults).toEqual(result.defaults);
+  });
+});
 
 it("projects shared rows under their logical owner while retaining the physical database owner", async () => {
   await withOpenClawTestState({ label: "combined-store-owner" }, async (state) => {

--- a/src/config/sessions/combined-store-gateway.test.ts
+++ b/src/config/sessions/combined-store-gateway.test.ts
@@ -28,7 +28,7 @@ it.each(["global", "unknown"])("projects the recorded aggregate %s owner", async
       { sessionId: "research-only", updatedAt: 42 },
     );
     const combined = loadCombinedSessionStoreForGatewayCore(cfg);
-    expect(combined.agentIdBySessionKey.get(sessionKey)).toBe("research");
+    expect(combined.targetsBySessionKey.get(sessionKey)?.agentId).toBe("research");
     const opts = { includeGlobal: true, includeUnknown: true };
     const result = await listSessionsFromStoreAsync({ cfg, ...combined, opts });
     expect
@@ -68,7 +68,18 @@ it("projects shared rows under their logical owner while retaining the physical 
     for (const configuredAgentsOnly of [false, true]) {
       const combined = loadCombinedSessionStoreForGatewayCore(cfg, { configuredAgentsOnly });
       expect(combined.durableTargets).toEqual([{ agentId: "main", storePath }]);
-      expect(Object.fromEntries(combined.agentIdBySessionKey)).toEqual({
+      expect(
+        [...combined.targetsBySessionKey.values()].map(({ storeTarget }) => storeTarget),
+      ).toEqual([
+        { agentId: "main", storePath },
+        { agentId: "main", storePath },
+        { agentId: "main", storePath },
+      ]);
+      expect(
+        Object.fromEntries(
+          [...combined.targetsBySessionKey].map(([key, target]) => [key, target.agentId]),
+        ),
+      ).toEqual({
         global: "ops",
         unknown: "ops",
         "agent:worker:task": "worker",
@@ -105,7 +116,7 @@ it("keeps fixed-store ownership out of separate registered and suffixed database
     for (const agentId of ["main", "ops"]) {
       const combined = loadCombinedSessionStoreForGatewayCore(cfg, { agentId });
       expect(combined.store.global?.sessionId).toBe(`global-${agentId}`);
-      expect(combined.agentIdBySessionKey.get("global")).toBe(agentId);
+      expect(combined.targetsBySessionKey.get("global")?.agentId).toBe(agentId);
     }
 
     const registeredPath = state.statePath("separate.sqlite");
@@ -115,7 +126,10 @@ it("keeps fixed-store ownership out of separate registered and suffixed database
     );
     const combined = loadCombinedSessionStoreForGatewayCore(cfg, { configuredAgentsOnly: true });
     expect(combined.store.unknown?.sessionId).toBe("separate-main");
-    expect(combined.agentIdBySessionKey.get("unknown")).toBe("main");
+    expect(combined.targetsBySessionKey.get("unknown")).toEqual({
+      agentId: "main",
+      storeTarget: { agentId: "main", storePath: registeredPath },
+    });
   });
 });
 
@@ -161,12 +175,12 @@ it.for([false, true])(
         const combined = loadCombinedSessionStoreForGatewayCore(cfg, { configuredAgentsOnly });
         if (configuredAgentsOnly) {
           expect(combined.store["agent:main:main"]).toBeUndefined();
-          expect(combined.agentIdBySessionKey.has("agent:main:main")).toBe(false);
+          expect(combined.targetsBySessionKey.has("agent:main:main")).toBe(false);
         } else {
           expect(combined.store["agent:main:main"]?.sessionId).toBe("retired-main");
-          expect(combined.agentIdBySessionKey.get("agent:main:main")).toBe("main");
+          expect(combined.targetsBySessionKey.get("agent:main:main")?.agentId).toBe("main");
         }
-        expect(combined.agentIdBySessionKey.get("global")).toBe("ops");
+        expect(combined.targetsBySessionKey.get("global")?.agentId).toBe("ops");
         expect(combined.store.global).toMatchObject({
           parentSessionKey: "agent:main:main",
           spawnedBy: "agent:main:main",
@@ -259,7 +273,11 @@ it("filters retired stores by canonical lineage owners without selecting an impl
     });
     const filtered = loadCombinedSessionStoreForGatewayCore(cfg, { configuredAgentsOnly: true });
     expect(Object.keys(filtered.store)).toEqual(["agent:archive:configured"]);
-    expect(Object.fromEntries(filtered.agentIdBySessionKey)).toEqual({
+    expect(
+      Object.fromEntries(
+        [...filtered.targetsBySessionKey].map(([key, target]) => [key, target.agentId]),
+      ),
+    ).toEqual({
       "agent:archive:configured": "archive",
     });
     expect(filtered.store["agent:archive:configured"]).toMatchObject({
@@ -296,17 +314,17 @@ it.skipIf(process.platform === "win32")(
       for (const configuredAgentsOnly of [false, true, true]) {
         const combined = loadCombinedSessionStoreForGatewayCore(cfg, { configuredAgentsOnly });
         expect(combined.store.unknown?.sessionId).toBe("worker-unknown");
-        expect(combined.agentIdBySessionKey.get("unknown")).toBe("worker");
+        expect(combined.targetsBySessionKey.get("unknown")?.agentId).toBe("worker");
         expect(combined.store.global?.sessionId).toBe("main-global");
-        expect(combined.agentIdBySessionKey.get("global")).toBe("main");
+        expect(combined.targetsBySessionKey.get("global")?.agentId).toBe("main");
       }
       const scoped = loadCombinedSessionStoreForGatewayCore(cfg, { agentId: "worker" });
-      expect(scoped.agentIdBySessionKey.get("unknown")).toBe("worker");
+      expect(scoped.targetsBySessionKey.get("unknown")?.agentId).toBe("worker");
       expect(loadCombinedSessionStoreForGatewayCore(cfg, { agentId: "ops" }).store).toEqual({});
       expect(
-        loadCombinedSessionStoreForGatewayCore(cfg, { agentId: "main" }).agentIdBySessionKey.get(
+        loadCombinedSessionStoreForGatewayCore(cfg, { agentId: "main" }).targetsBySessionKey.get(
           "global",
-        ),
+        )?.agentId,
       ).toBe("main");
     });
   },

--- a/src/config/sessions/combined-store-gateway.ts
+++ b/src/config/sessions/combined-store-gateway.ts
@@ -30,7 +30,6 @@ import {
 } from "./session-accessor.js";
 import type { SessionEntryListScope } from "./session-accessor.types.js";
 import { canonicalSessionKeyMigrationRequiredError } from "./session-canonical-key.js";
-import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { resolvePersistedSessionStoreOwner } from "./session-store-owner.js";
 import { resolveDeliveryProvenCanonicalSessionKey } from "./store-entry.js";
 import {
@@ -44,6 +43,27 @@ import {
 import type { SessionEntry } from "./types.js";
 
 type GatewaySessionEntryProjection = NonNullable<SessionEntryListScope["projection"]>;
+
+type GatewayStoredSessionTarget = {
+  agentId: string;
+  storeTarget: SessionStoreTarget;
+};
+
+export type GatewayStoredSessionTargets = ReadonlyMap<string, GatewayStoredSessionTarget>;
+
+function storeTargetKey(target: SessionStoreTarget): string {
+  return `${target.agentId}\0${target.storePath}`;
+}
+
+function capturePhysicalStoreTargets() {
+  const physicalTargets = new Map<string, SessionStoreTarget>();
+  return {
+    physicalTargets,
+    onResolvedTarget: (selected: SessionStoreTarget, physical: SessionStoreTarget) => {
+      physicalTargets.set(storeTargetKey(selected), physical);
+    },
+  };
+}
 
 type GatewaySessionStoreOptions = {
   agentId?: string;
@@ -59,6 +79,7 @@ type ResolvedGatewaySessionStoreTargets = {
   durableStorePath?: string;
   durableTargets: ReadonlyArray<{ agentId: string; storePath: string }>;
   incognitoTargets: ReadonlyArray<{ agentId: string; storePath: string }>;
+  physicalTargets: ReadonlyMap<string, SessionStoreTarget>;
   requestedAgentId?: string;
   sharedStoreRowOwner?: { agentId: string; target: SessionStoreTarget };
   storeConfig?: string;
@@ -90,21 +111,14 @@ function resolveCombinedStorePath(paths: string[], storeConfig?: string): string
 }
 
 function resolveCombinedDatabasePath(
-  targets: ReadonlyArray<{ agentId: string; storePath: string }>,
-  defaultAgentId: string,
-  physicallyDeduped = false,
+  targets: readonly SessionStoreTarget[],
+  physicalTargets: ReadonlyMap<string, SessionStoreTarget>,
 ): string {
-  if (physicallyDeduped && targets.length !== 1) {
-    return "(multiple)";
-  }
   const paths = [
     ...new Set(
       targets.map(
         (target) =>
-          resolveSqliteTargetFromSessionStorePath(target.storePath, {
-            agentId: target.agentId,
-            defaultAgentId,
-          }).path,
+          expectDefined(physicalTargets.get(storeTargetKey(target)), "physical store").storePath,
       ),
     ),
   ];
@@ -150,12 +164,12 @@ function loadGatewayStoreEntries(params: {
 function mergeSessionEntryIntoCombined(params: {
   cfg: OpenClawConfig;
   combined: Record<string, SessionEntry>;
-  agentIdBySessionKey: Map<string, string>;
+  targetsBySessionKey: Map<string, GatewayStoredSessionTarget>;
   entry: SessionEntry;
-  agentId: string;
+  target: GatewayStoredSessionTarget;
   canonicalKey: string;
 }) {
-  const { cfg, combined, entry, agentId, canonicalKey } = params;
+  const { cfg, combined, entry, target, canonicalKey } = params;
   const existing = combined[canonicalKey];
   if (existing && (canonicalKey === "global" || canonicalKey === "unknown")) {
     // Reserved sentinels remain per-store federation state until goal 3 decides
@@ -190,13 +204,13 @@ function mergeSessionEntryIntoCombined(params: {
     }
   }
   combined[canonicalKey] = projected;
-  params.agentIdBySessionKey.set(canonicalKey, agentId);
+  params.targetsBySessionKey.set(canonicalKey, target);
 }
 
 function mergeOpenIncognitoStores(params: {
   cfg: OpenClawConfig;
   combined: Record<string, SessionEntry>;
-  agentIdBySessionKey: Map<string, string>;
+  targetsBySessionKey: Map<string, GatewayStoredSessionTarget>;
   projection: GatewaySessionEntryProjection;
   targets: ReadonlyArray<{ agentId: string; storePath: string }>;
 }): string[] {
@@ -216,9 +230,9 @@ function mergeOpenIncognitoStores(params: {
       mergeSessionEntryIntoCombined({
         cfg: params.cfg,
         combined: params.combined,
-        agentIdBySessionKey: params.agentIdBySessionKey,
+        targetsBySessionKey: params.targetsBySessionKey,
         entry,
-        agentId: target.agentId,
+        target: { agentId: target.agentId, storeTarget: target },
         canonicalKey: sessionKey,
       });
       merged = true;
@@ -234,7 +248,7 @@ function filterCombinedStoreToConfiguredAgents(params: {
   cfg: OpenClawConfig;
   configuredAgentIds: ReadonlySet<string>;
   store: Record<string, SessionEntry>;
-  agentIdBySessionKey: Map<string, string>;
+  targetsBySessionKey: Map<string, GatewayStoredSessionTarget>;
 }): void {
   const isConfiguredSessionKey = (key: string | undefined) => {
     const normalizedKey = normalizeOptionalString(key);
@@ -254,7 +268,7 @@ function filterCombinedStoreToConfiguredAgents(params: {
       isConfiguredSessionKey(entry.parentSessionKey);
     if (!keep) {
       delete params.store[key];
-      params.agentIdBySessionKey.delete(key);
+      params.targetsBySessionKey.delete(key);
     }
   }
 }
@@ -284,6 +298,7 @@ function resolvePreparedConfiguredSessionStoreTargets(
     incognitoTargets.map((target) => `${target.agentId}\0${target.storePath}`),
   );
   const diagnostics: string[] = [];
+  const { physicalTargets, onResolvedTarget } = capturePhysicalStoreTargets();
   let sharedStoreRowOwner: ResolvedGatewaySessionStoreTargets["sharedStoreRowOwner"];
   const candidates = dedupeSessionStoreTargetsBySqliteTarget(
     [
@@ -299,6 +314,7 @@ function resolvePreparedConfiguredSessionStoreTargets(
     ],
     {
       defaultAgentId,
+      onResolvedTarget,
       onDiagnostic: (diagnostic) => diagnostics.push(diagnostic.message),
       onSharedTarget: (selected, paths) => {
         sharedStoreRowOwner ??= resolveSharedStoreRowOwner(cfg, selected, paths);
@@ -312,7 +328,7 @@ function resolvePreparedConfiguredSessionStoreTargets(
     configuredAgentIds,
     defaultAgentId,
     diagnostics: Object.freeze(diagnostics),
-    durableStorePath: resolveCombinedDatabasePath(durableTargets, defaultAgentId, true),
+    durableStorePath: resolveCombinedDatabasePath(durableTargets, physicalTargets),
     durableTargets: Object.freeze(durableTargets.map((target) => Object.freeze({ ...target }))),
     incognitoTargets: Object.freeze(
       candidates
@@ -320,6 +336,7 @@ function resolvePreparedConfiguredSessionStoreTargets(
         .map((target) => Object.freeze({ ...target })),
     ),
     sharedStoreRowOwner,
+    physicalTargets,
     storeConfig,
   });
   preparedConfiguredSessionStoreTargets = {
@@ -346,6 +363,7 @@ function resolveGatewaySessionStoreTargets(
     return resolvePreparedConfiguredSessionStoreTargets(cfg, opts.includeIncognito !== false);
   }
   const defaultAgentId = normalizeAgentId(resolveSessionStoreCompatibilityAgentId(cfg));
+  const { physicalTargets, onResolvedTarget } = capturePhysicalStoreTargets();
   const incognitoTargets =
     opts.includeIncognito === false
       ? []
@@ -370,6 +388,7 @@ function resolveGatewaySessionStoreTargets(
       })),
       {
         defaultAgentId,
+        onResolvedTarget,
         onDiagnostic: (diagnostic) => diagnostics.push(diagnostic.message),
         onSharedTarget: (selected, paths) => {
           sharedStoreRowOwner ??= resolveSharedStoreRowOwner(cfg, selected, paths);
@@ -383,6 +402,7 @@ function resolveGatewaySessionStoreTargets(
       incognitoTargets,
       requestedAgentId,
       sharedStoreRowOwner,
+      physicalTargets,
       storeConfig,
     };
   }
@@ -390,14 +410,15 @@ function resolveGatewaySessionStoreTargets(
   const durableTargets = requestedAgentId
     ? dedupeSessionStoreTargetsBySqliteTarget(
         resolveAgentSessionStoreTargetsSync(cfg, requestedAgentId),
-        { defaultAgentId },
+        { defaultAgentId, onResolvedTarget },
       )
-    : resolveAllAgentSessionStoreTargetsSync(cfg);
+    : resolveAllAgentSessionStoreTargetsSync(cfg, { onResolvedTarget });
   return {
     defaultAgentId,
     diagnostics,
     durableTargets,
     incognitoTargets,
+    physicalTargets,
     requestedAgentId,
     storeConfig,
   };
@@ -438,30 +459,34 @@ export function loadCombinedSessionStoreForGatewayCore(
   durableTargets: ReadonlyArray<{ agentId: string; storePath: string }>;
   storePath: string;
   store: Record<string, SessionEntry>;
-  agentIdBySessionKey: ReadonlyMap<string, string>;
+  targetsBySessionKey: GatewayStoredSessionTargets;
 } {
   const projection = opts.projection ?? "full";
   // Count admission and projection share this exact target set. Otherwise an optional
   // prewarm can approve one database and synchronously materialize another.
   const {
     configuredAgentIds,
-    defaultAgentId,
     diagnostics,
     durableStorePath: preparedDurableStorePath,
     durableTargets,
     incognitoTargets,
+    physicalTargets,
     requestedAgentId,
     sharedStoreRowOwner,
     storeConfig,
   } = resolveGatewaySessionStoreTargets(cfg, opts);
   const combined: Record<string, SessionEntry> = {};
-  // Unqualified keys such as global retain the owner of the projected row,
-  // including when multiple stores contain that key. Consumers must not guess it.
-  const agentIdBySessionKey = new Map<string, string>();
+  // Federation chooses both the logical owner and physical store once. Fresh reads
+  // must not re-admit a sentinel through public aliases or select a different store.
+  const targetsBySessionKey = new Map<string, GatewayStoredSessionTarget>();
   for (const target of durableTargets) {
     const agentId = target.agentId;
     const storePath = target.storePath;
-    const store = loadGatewayStoreEntries({ agentId, projection, storePath });
+    const storeTarget = expectDefined(
+      physicalTargets.get(storeTargetKey(target)),
+      "physical store",
+    );
+    const store = loadGatewayStoreEntries({ ...storeTarget, projection });
     // Legacy selector paths can be shared by distinct physical agent partitions.
     const rowAgentId =
       sharedStoreRowOwner?.target.storePath === storePath &&
@@ -473,7 +498,7 @@ export function loadCombinedSessionStoreForGatewayCore(
       const canonicalKey = resolveStoredSessionKeyForAgentStore({
         cfg,
         // Qualified retired-owner keys keep their physical store's canonicalization context.
-        agentId: parsed ? agentId : rowAgentId,
+        agentId: parsed ? storeTarget.agentId : rowAgentId,
         sessionKey: key,
       });
       if (key !== canonicalKey) {
@@ -488,9 +513,9 @@ export function loadCombinedSessionStoreForGatewayCore(
       mergeSessionEntryIntoCombined({
         cfg,
         combined,
-        agentIdBySessionKey,
+        targetsBySessionKey,
         entry,
-        agentId: canonicalAgentId,
+        target: { agentId: canonicalAgentId, storeTarget },
         canonicalKey,
       });
     }
@@ -499,7 +524,7 @@ export function loadCombinedSessionStoreForGatewayCore(
   const incognitoStorePaths = mergeOpenIncognitoStores({
     cfg,
     combined,
-    agentIdBySessionKey,
+    targetsBySessionKey,
     projection,
     targets: incognitoTargets,
   });
@@ -508,13 +533,13 @@ export function loadCombinedSessionStoreForGatewayCore(
       cfg,
       configuredAgentIds,
       store: combined,
-      agentIdBySessionKey,
+      targetsBySessionKey,
     });
   }
 
   const durableStorePaths = durableTargets.map((target) => target.storePath);
   const durableStorePath =
-    preparedDurableStorePath ?? resolveCombinedDatabasePath(durableTargets, defaultAgentId);
+    preparedDurableStorePath ?? resolveCombinedDatabasePath(durableTargets, physicalTargets);
   const storePath =
     storeConfig && !isStorePathTemplate(storeConfig)
       ? incognitoStorePaths.length > 0
@@ -527,6 +552,6 @@ export function loadCombinedSessionStoreForGatewayCore(
     durableTargets,
     storePath,
     store: combined,
-    agentIdBySessionKey,
+    targetsBySessionKey,
   };
 }

--- a/src/config/sessions/targets-collision.ts
+++ b/src/config/sessions/targets-collision.ts
@@ -41,6 +41,7 @@ export function dedupeSessionStoreTargetsBySqliteTarget(
     registeredDatabases?: readonly { agentId: string; path: string }[];
     onDiagnostic?: (diagnostic: SessionStoreTargetCollisionDiagnostic) => void;
     onSharedTarget?: (selected: SessionStoreTarget, sharedStorePaths: ReadonlySet<string>) => void;
+    onResolvedTarget?: (selected: SessionStoreTarget, physical: SessionStoreTarget) => void;
   },
 ): SessionStoreTarget[] {
   // Ownership must not fall back while the authoritative registry is unreadable:
@@ -182,6 +183,7 @@ export function dedupeSessionStoreTargetsBySqliteTarget(
         : undefined);
     if (selected) {
       deduped.push(selected);
+      options.onResolvedTarget?.(selected, { agentId: ownerAgentId, storePath: sqlitePath });
       if (options.onSharedTarget) {
         // A shared alias can select a per-agent registry spelling. Preserve its
         // original shared claims so consumers need no second ownership scan.

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -296,7 +296,10 @@ function resolveExplicitSessionStoreTarget(params: {
 /** Resolves all configured and discoverable agent session stores synchronously. */
 export function resolveAllAgentSessionStoreTargetsSync(
   cfg: OpenClawConfig,
-  params: { env?: NodeJS.ProcessEnv } = {},
+  params: {
+    env?: NodeJS.ProcessEnv;
+    onResolvedTarget?: (selected: SessionStoreTarget, physical: SessionStoreTarget) => void;
+  } = {},
 ): SessionStoreTarget[] {
   const env = params.env ?? process.env;
   const { configuredTargets, agentsRoots } = resolveSessionStoreDiscoveryState(cfg, env);
@@ -361,7 +364,11 @@ export function resolveAllAgentSessionStoreTargetsSync(
   });
   return dedupeSessionStoreTargetsBySqliteTarget(
     [...validatedConfiguredTargets, ...discoveredTargets],
-    { defaultAgentId: resolveSessionStoreCompatibilityAgentId(cfg), env },
+    {
+      defaultAgentId: resolveSessionStoreCompatibilityAgentId(cfg),
+      env,
+      onResolvedTarget: params.onResolvedTarget,
+    },
   );
 }
 

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -7,7 +7,7 @@ import {
   validateChatStartupParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { CHAT_HISTORY_MAX_ENTRIES } from "../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
-import { resolveAgentConfig, resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentConfig } from "../../agents/agent-scope.js";
 import {
   resolveActiveEmbeddedRunOwner,
   resolveActiveEmbeddedRunHandleSessionId,
@@ -184,7 +184,14 @@ async function handleChatHistoryRequest({
     respond(false, undefined, requestedAgent.error);
     return;
   }
-  const { cfg, storePath, store, entry, canonicalKey } = measureDiagnosticsTimelineSpanSync(
+  const {
+    cfg,
+    agentId: sessionAgentId,
+    storePath,
+    store,
+    entry,
+    canonicalKey,
+  } = measureDiagnosticsTimelineSpanSync(
     `gateway.${method}.session_entry`,
     () =>
       loadGatewaySessionEntryReadOnly(sessionKey, {
@@ -208,11 +215,6 @@ async function handleChatHistoryRequest({
     respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, selectedAgent.error));
     return;
   }
-  const sessionAgentId = resolveSessionAgentId({
-    sessionKey,
-    config: cfg,
-    agentId: selectedAgent.agentId,
-  });
   if (requestedSessionId) {
     const transcriptSessionKey = resolveTranscriptSessionKeyBySessionId({
       agentId: sessionAgentId,
@@ -411,7 +413,7 @@ async function handleChatHistoryRequest({
         store,
         key: canonicalKey,
         entry,
-        agentId: selectedAgent.agentId,
+        agentId: sessionAgentId,
         modelCatalog: sessionModelCatalog,
       }),
     {
@@ -422,7 +424,7 @@ async function handleChatHistoryRequest({
       },
     },
   );
-  const activeRunAgentId = selectedAgent.agentId;
+  const activeRunAgentId = sessionAgentId;
   const activeRunState = resolveVisibleActiveSessionRunState({
     context,
     requestedKey: sessionKey,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -65,6 +65,7 @@ import { withEnvAsync } from "../../test-utils/env.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { consumeCronCreatorAuthorityGrant } from "../cron-creator-authority-grant.js";
 import { createChatRunState } from "../server-chat-state.js";
+import { resolveSessionStoreAgentId } from "../session-store-key.js";
 import { STALE_WORKER_BUILD_REASON } from "../worker-environments/admission.js";
 import { agentWaitHandler } from "./agent-wait.js";
 import { handleChatSend, handleTrustedInternalChatSend } from "./chat-send-handler.js";
@@ -251,15 +252,16 @@ vi.mock("../session-utils.js", async () => {
           sessionFile: mockState.transcriptPath,
           ...mockState.sessionEntry,
         };
-    return {
-      ...(typeof mockState.sessionEntry.canonicalKey === "string" ? { canonicalKey } : {}),
-      cfg: {
-        ...mockState.config,
-        session: {
-          ...(mockState.config.session as Record<string, unknown> | undefined),
-          mainKey: mockState.mainSessionKey,
-        },
+    const cfg = {
+      ...mockState.config,
+      session: {
+        ...(mockState.config.session as Record<string, unknown> | undefined),
+        mainKey: mockState.mainSessionKey,
       },
+    };
+    return {
+      cfg,
+      agentId: resolveSessionStoreAgentId(cfg, rawKey, opts?.agentId),
       storePath: mockState.storePath,
       store: entry ? { [canonicalKey]: entry } : {},
       entry,

--- a/src/gateway/server-methods/control-ui.test.ts
+++ b/src/gateway/server-methods/control-ui.test.ts
@@ -6,8 +6,13 @@ import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
 } from "../../config/runtime-snapshot.js";
+import {
+  persistSessionTranscriptTurn,
+  replaceSessionEntry,
+} from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.js";
 import { SecretSurfaceUnavailableError } from "../../secrets/runtime-degraded-state.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import type { ControlUiGitHubPreview, ControlUiSessionPreview } from "../control-ui-contract.js";
 import { ControlUiGitHubError } from "../control-ui-github-api.js";
 import { createControlUiHandlers } from "./control-ui.js";
@@ -317,6 +322,47 @@ describe("controlUi.githubPreview", () => {
 });
 
 describe("controlUi.sessionPreview", () => {
+  it("keeps the resolved owner when previewing a qualified global main alias", async () => {
+    await withOpenClawTestState({ label: "hover-global-owner" }, async () => {
+      const cfg: OpenClawConfig = {
+        session: { scope: "global" },
+        agents: { entries: { main: { default: true }, research: {} } },
+      };
+      for (const agentId of ["main", "research"]) {
+        const scope = { agentId, sessionKey: "global", sessionId: `hover-${agentId}` };
+        await replaceSessionEntry(scope, { sessionId: scope.sessionId, updatedAt: 42 });
+        await persistSessionTranscriptTurn(scope, {
+          cwd: "/tmp",
+          updateMode: "none",
+          messages: [{ message: { role: "user", content: `Title from ${agentId}` }, now: 42 }],
+        });
+      }
+      const handler = expectDefined(
+        createControlUiHandlers()["controlUi.sessionPreview"],
+        "session preview handler",
+      );
+      for (const agentId of ["main", "research"]) {
+        const respond = vi.fn<RespondFn>();
+        await handler(
+          requestOptions({ sessionKey: `agent:${agentId}:main` }, respond, {
+            context: { getRuntimeConfig: () => cfg },
+          }),
+        );
+        expect(respond).toHaveBeenCalledWith(
+          true,
+          expect.objectContaining({
+            status: "ok",
+            sessionKey: "global",
+            agentId,
+            derivedTitle: `Title from ${agentId}`,
+            lastMessagePreview: `Title from ${agentId}`,
+          }),
+          undefined,
+        );
+      }
+    });
+  });
+
   it("returns bounded, redacted metadata for one session", async () => {
     const secret = "sk-test-session-preview-secret-1234567890";
     const loadSessionPreview = vi.fn().mockResolvedValue({

--- a/src/gateway/server-methods/control-ui.ts
+++ b/src/gateway/server-methods/control-ui.ts
@@ -172,6 +172,7 @@ function loadControlUiSessionPreview(
   }
   const row = buildGatewaySessionRow({
     cfg,
+    agentId: target.agentId,
     storePath,
     store,
     key: target.canonicalKey,
@@ -182,7 +183,7 @@ function loadControlUiSessionPreview(
   });
   return {
     sessionKey: row.key,
-    agentId: row.agentId ?? target.agentId,
+    agentId: target.agentId,
     title: row.displayName,
     derivedTitle: row.derivedTitle,
     kind: row.kind,

--- a/src/gateway/server-methods/sessions-board-inventory.ts
+++ b/src/gateway/server-methods/sessions-board-inventory.ts
@@ -1,57 +1,34 @@
 import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
 import { listBoardSessionKeysReadOnly } from "../../boards/sqlite-board-store.js";
 import type { SessionEntry } from "../../config/sessions.js";
-import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
-import { listOpenIncognitoAgentDatabases } from "../../state/openclaw-agent-db.js";
+import type { GatewayStoredSessionTargets } from "../../config/sessions/combined-store-gateway.js";
 import { prepareSessionSharing } from "../session-sharing.js";
 
-function listBoardSessionKeysByAgent(
-  targets: ReadonlyArray<{ agentId: string; storePath: string }>,
-  requestedAgentId?: string,
-): ReadonlyMap<string, ReadonlySet<string>> {
-  const normalizedRequestedAgentId = requestedAgentId
-    ? normalizeAgentId(requestedAgentId)
-    : undefined;
-  const byAgent = new Map<string, Set<string>>();
-  for (const target of targets) {
-    if (normalizedRequestedAgentId && target.agentId !== normalizedRequestedAgentId) {
-      continue;
+function listBoardSessionKeys(targets: GatewayStoredSessionTargets): ReadonlySet<string> {
+  const inventories = new Map<string, ReadonlySet<string>>();
+  const keys = new Set<string>();
+  for (const [key, { storeTarget }] of targets) {
+    const identity = `${storeTarget.agentId}\0${storeTarget.storePath}`;
+    let inventory = inventories.get(identity);
+    if (!inventory) {
+      inventory = listBoardSessionKeysReadOnly({
+        agentId: storeTarget.agentId,
+        path: storeTarget.storePath,
+      });
+      inventories.set(identity, inventory);
     }
-    const databaseTarget = resolveSqliteTargetFromSessionStorePath(target.storePath, {
-      agentId: target.agentId,
-    });
-    const databaseAgentId = normalizeAgentId(databaseTarget.agentId ?? target.agentId);
-    for (const sessionKey of listBoardSessionKeysReadOnly({
-      agentId: databaseAgentId,
-      path: databaseTarget.path,
-    })) {
-      // Shared databases persist qualified keys for each logical owner. Unqualified
-      // global keys retain the target owner, matching the combined session projection.
-      const agentId = normalizeAgentId(parseAgentSessionKey(sessionKey)?.agentId ?? target.agentId);
-      const keys = byAgent.get(agentId) ?? new Set<string>();
-      keys.add(sessionKey);
-      byAgent.set(agentId, keys);
+    // Equal sentinel keys in another store do not describe this selected row's board.
+    if (inventory.has(key)) {
+      keys.add(key);
     }
   }
-  return byAgent;
+  return keys;
 }
-
-type LoadedSessionStore = {
-  agentIdBySessionKey: ReadonlyMap<string, string>;
-  durableTargets: ReadonlyArray<{ agentId: string; storePath: string }>;
-};
-
-type BoardSessionKeys = {
-  durable: ReadonlyMap<string, ReadonlySet<string>>;
-  incognito: ReadonlyMap<string, ReadonlySet<string>>;
-};
 
 export function listFilter(input: {
   cfg: Parameters<typeof prepareSessionSharing>[0]["cfg"];
   client: Parameters<typeof prepareSessionSharing>[0]["client"];
-  defaultsAgentId: string;
-  loaded: LoadedSessionStore;
+  loaded: { targetsBySessionKey: GatewayStoredSessionTargets };
   options: { excludedKeys?: ReadonlySet<string> };
   p: SessionsListParams;
 }): ((key: string, entry: SessionEntry) => boolean) | undefined {
@@ -61,29 +38,13 @@ export function listFilter(input: {
     cfg: input.cfg,
   }).entryFilter;
   const excludedKeys = input.options.excludedKeys;
-  const boardSessionKeys: BoardSessionKeys | undefined =
-    params.hasBoard === undefined
-      ? undefined
-      : {
-          durable: listBoardSessionKeysByAgent(loaded.durableTargets, params.agentId),
-          incognito: listBoardSessionKeysByAgent(listOpenIncognitoAgentDatabases(), params.agentId),
-        };
+  const boardSessionKeys =
+    params.hasBoard === undefined ? undefined : listBoardSessionKeys(loaded.targetsBySessionKey);
   if (!visibilityFilter && !boardSessionKeys && !excludedKeys?.size) {
     return undefined;
   }
-  return (key, entry) => {
-    const agentId = normalizeAgentId(
-      loaded.agentIdBySessionKey.get(key) ??
-        parseAgentSessionKey(key)?.agentId ??
-        input.defaultsAgentId,
-    );
-    const inventory =
-      entry.incognito === true ? boardSessionKeys?.incognito : boardSessionKeys?.durable;
-    const hasBoard = inventory?.get(agentId)?.has(key) ?? false;
-    return (
-      !excludedKeys?.has(key) &&
-      (visibilityFilter?.(key, entry) ?? true) &&
-      (params.hasBoard === undefined || hasBoard === params.hasBoard)
-    );
-  };
+  return (key, entry) =>
+    !excludedKeys?.has(key) &&
+    (visibilityFilter?.(key, entry) ?? true) &&
+    (params.hasBoard === undefined || boardSessionKeys?.has(key) === params.hasBoard);
 }

--- a/src/gateway/server-methods/sessions-list-cache.observer-digest.test.ts
+++ b/src/gateway/server-methods/sessions-list-cache.observer-digest.test.ts
@@ -7,12 +7,12 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { createDirectChatContext } from "../server-chat.agent-events.test-helpers.js";
+import { listSessionFixture } from "../session-list.test-support.js";
 import {
   defaultPersistDigest,
   synthesizeSessionObserverTerminalDigest,
   type SessionObserverState,
 } from "../session-observer-model.js";
-import { listSessionsFromStoreAsync } from "../session-utils-list.js";
 import type { SessionsListResult } from "../session-utils.types.js";
 import { respondWithCachedSessionList } from "./sessions-list-cache.js";
 
@@ -69,7 +69,7 @@ it("invalidates a cached sessions.list result after an observer-digest persist",
           if (!entry) {
             throw new Error("session entry missing");
           }
-          return await listSessionsFromStoreAsync({
+          return await listSessionFixture({
             cfg: config,
             storePath: "",
             store: { [sessionKey]: entry },
@@ -147,7 +147,7 @@ it("invalidates the cache after terminal observer-digest synthesis", async () =>
           if (!entry) {
             throw new Error("session entry missing");
           }
-          return await listSessionsFromStoreAsync({
+          return await listSessionFixture({
             cfg: config,
             storePath: "",
             store: { [sessionKey]: entry },

--- a/src/gateway/server-methods/sessions-read-visibility.test.ts
+++ b/src/gateway/server-methods/sessions-read-visibility.test.ts
@@ -28,6 +28,89 @@ afterEach(() => {
   closeOpenClawStateDatabaseForTest();
 });
 
+test.each([
+  { sessionKey: "global", transcript: false },
+  { sessionKey: "unknown", transcript: false },
+  { sessionKey: "global", transcript: true },
+  { sessionKey: "unknown", transcript: true },
+])(
+  "keeps the selected unscoped $sessionKey row's owner (transcript=$transcript)",
+  async ({ sessionKey, transcript }) => {
+    const ownerId = ensureProfileForEmail("aggregate-owner@example.test").id;
+    const cfg: OpenClawConfig = {
+      session: { scope: "global" },
+      agents: {
+        entries: {
+          main: { default: true, model: { primary: "openai/gpt-5.4" } },
+          research: { model: { primary: "openai/gpt-5.5" } },
+        },
+      },
+    };
+    const storePath = resolveStorePath(undefined, { agentId: "research" });
+    const sessionId = `aggregate-${sessionKey}`;
+    await replaceSessionEntry(
+      { agentId: "research", sessionKey, storePath },
+      {
+        sessionId,
+        updatedAt: 42,
+        visibility: "draft",
+        createdActor: { type: "human", source: "profile", id: ownerId },
+      },
+    );
+    await seedLinearSessionTranscript({
+      agentId: "research",
+      sessionKey,
+      sessionId,
+      storePath,
+      contents: ["Research transcript title", "Research latest message"],
+    });
+    const client = identifiedClient(ownerId);
+    const context = requestContext(cfg);
+    const request = {
+      includeGlobal: true,
+      includeUnknown: true,
+      includeDerivedTitles: transcript,
+      includeLastMessage: transcript,
+    };
+    const result = await listSessions({ client, context, request });
+    expect.soft(result.sessions).toHaveLength(1);
+    expect.soft(result.sessions[0]).toMatchObject({
+      key: sessionKey,
+      sessionId,
+      agentId: "research",
+      modelProvider: "openai",
+      model: "gpt-5.5",
+      ...(transcript
+        ? {
+            derivedTitle: "Research transcript title",
+            lastMessagePreview: "Research latest message",
+          }
+        : {}),
+      visibility: "draft",
+      sharingRole: "owner",
+    });
+    const searched = await listSessions({
+      client,
+      context,
+      request: { ...request, search: "gpt-5.5" },
+    });
+    expect.soft(searched.sessions.map((row) => row.sessionId)).toEqual([sessionId]);
+    if (sessionKey === "global") {
+      const scoped = await listSessions({
+        client,
+        context,
+        request: { ...request, agentId: "research" },
+      });
+      expect(scoped.sessions[0]).toMatchObject({
+        agentId: "research",
+        model: "gpt-5.5",
+        visibility: "draft",
+        sharingRole: "owner",
+      });
+    }
+  },
+);
+
 test("a hidden-foreign role cannot discover sessions through search, batch previews, or exact resolve", async () => {
   const ownerId = ensureProfileForEmail("role-viewer@example.com").id;
   const foreignKey = "agent:main:foreign-role-read";

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -20,7 +20,10 @@ import {
   runSessionsCleanup,
   serializeSessionCleanupResult,
 } from "../../config/sessions.js";
-import { listSessionEntriesReadOnly } from "../../config/sessions/session-accessor.js";
+import {
+  listSessionEntriesReadOnly,
+  loadExactSessionEntryCandidatesReadOnlyBatch,
+} from "../../config/sessions/session-accessor.js";
 import { searchSessionTranscripts } from "../../config/sessions/session-transcript-search.js";
 import {
   measureDiagnosticsTimelineSpan,
@@ -43,13 +46,11 @@ import {
   isGatewayAdmin,
   prepareSessionSharing,
   resolveSessionSharingTarget,
-  resolveSessionSharingTargets,
   resolveSessionVisibility,
 } from "../session-sharing.js";
 import { resolveSessionStoreAgentId } from "../session-store-key.js";
 import { readSessionPreviewItemsFromTranscript } from "../session-transcript-readers.js";
 import { projectGatewaySessionActiveRun } from "../session-utils-display.js";
-import { createGatewaySessionStoreDiscoveryCache } from "../session-utils-store-lookup.js";
 import {
   listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGatewayCore,
@@ -270,14 +271,8 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
             );
             loaded = { ...loadedStore, modelCatalogByAgent: preparedModelCatalogByAgent };
           }
-          const {
-            agentIdBySessionKey,
-            durableStorePath,
-            durableTargets,
-            modelCatalogByAgent,
-            storePath,
-          } = loaded;
-          const entryFilter = listFilter({ p, loaded, defaultsAgentId, client, cfg, options });
+          const { targetsBySessionKey, durableStorePath, modelCatalogByAgent, storePath } = loaded;
+          const entryFilter = listFilter({ p, loaded, client, cfg, options });
           const selectionRuns = p.search?.trim()
             ? createVisibleActiveSessionRunProjector(context)
             : undefined;
@@ -290,7 +285,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                 ...(entryFilter ? { entryFilter } : {}),
                 storePath,
                 store: loaded.store,
-                agentIdBySessionKey,
+                targetsBySessionKey,
                 modelCatalog: modelCatalogByAgent,
                 opts: p,
                 ...(selectionRuns
@@ -320,18 +315,33 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
               // Recheck only this page after row projection yields; unrelated sessions
               // must not be materialized again to refresh visibility and membership.
               const targets = result.sessions.map(({ key }) => ({
-                sessionKey: key,
-                agentId: expectDefined(agentIdBySessionKey.get(key), "sharing row owner"),
+                key,
+                ...expectDefined(targetsBySessionKey.get(key), "sharing row target"),
               }));
-              const resolvedSharingTargets = resolveSessionSharingTargets({
-                cfg,
-                // Preserve the listing's registered stores, including alternate agent paths.
-                targetDiscoveryCache: createGatewaySessionStoreDiscoveryCache({
-                  cfg,
-                  targets: durableTargets,
-                  agentIds: targets.map(({ agentId }) => agentId),
-                }),
-                targets,
+              // Logical owners can share a physical database. Keep that exact store
+              // through the fresh read; public aliases may reject or redirect these rows.
+              const entries = loadExactSessionEntryCandidatesReadOnlyBatch(
+                targets.map(({ key, storeTarget }) => ({
+                  ...storeTarget,
+                  sessionKeys: [key],
+                  projection: "list",
+                  clone: false,
+                })),
+              );
+              const resolvedSharingTargets = targets.map(({ key, agentId, storeTarget }, index) => {
+                const current = expectDefined(entries[index], "sharing row read");
+                const entry = current.ok ? current.value[0]?.entry : undefined;
+                return entry
+                  ? {
+                      agentId,
+                      canonicalKey: key,
+                      entry,
+                      storeKey: key,
+                      storeKeys: [key],
+                      storePath: storeTarget.storePath,
+                      storeTarget,
+                    }
+                  : null;
               });
               const resolvedMembershipKeys = new Set<string>();
               if (identityId && !isGatewayAdmin(client)) {
@@ -347,9 +357,9 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                   if (!target) {
                     continue;
                   }
-                  const groupKey = `${target.agentId}\0${target.storePath}`;
+                  const groupKey = `${target.storeTarget.agentId}\0${target.storePath}`;
                   const group = groups.get(groupKey) ?? {
-                    agentId: target.agentId,
+                    agentId: target.storeTarget.agentId,
                     sessionKeys: [],
                     storePath: target.storePath,
                   };
@@ -415,7 +425,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                         sharingRole: sharing.roleForTarget(
                           sharingTarget,
                           membershipKeys.has(
-                            `${sharingTarget.agentId}\0${sharingTarget.storePath}\0${sharingTarget.storeKey}`,
+                            `${sharingTarget.storeTarget.agentId}\0${sharingTarget.storePath}\0${sharingTarget.storeKey}`,
                           ),
                         ),
                       }

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -1,5 +1,6 @@
 // Read-only session queries.
 import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
@@ -269,7 +270,13 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
             );
             loaded = { ...loadedStore, modelCatalogByAgent: preparedModelCatalogByAgent };
           }
-          const { durableStorePath, durableTargets, modelCatalogByAgent, storePath } = loaded;
+          const {
+            agentIdBySessionKey,
+            durableStorePath,
+            durableTargets,
+            modelCatalogByAgent,
+            storePath,
+          } = loaded;
           const entryFilter = listFilter({ p, loaded, defaultsAgentId, client, cfg, options });
           const selectionRuns = p.search?.trim()
             ? createVisibleActiveSessionRunProjector(context)
@@ -283,6 +290,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
                 ...(entryFilter ? { entryFilter } : {}),
                 storePath,
                 store: loaded.store,
+                agentIdBySessionKey,
                 modelCatalog: modelCatalogByAgent,
                 opts: p,
                 ...(selectionRuns
@@ -311,22 +319,19 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
             () => {
               // Recheck only this page after row projection yields; unrelated sessions
               // must not be materialized again to refresh visibility and membership.
+              const targets = result.sessions.map(({ key }) => ({
+                sessionKey: key,
+                agentId: expectDefined(agentIdBySessionKey.get(key), "sharing row owner"),
+              }));
               const resolvedSharingTargets = resolveSessionSharingTargets({
                 cfg,
                 // Preserve the listing's registered stores, including alternate agent paths.
                 targetDiscoveryCache: createGatewaySessionStoreDiscoveryCache({
                   cfg,
                   targets: durableTargets,
-                  agentIds: result.sessions.map((session) =>
-                    session.key === "global" && p.agentId
-                      ? p.agentId
-                      : resolveSessionStoreAgentId(cfg, session.key),
-                  ),
+                  agentIds: targets.map(({ agentId }) => agentId),
                 }),
-                targets: result.sessions.map((session) => ({
-                  sessionKey: session.key,
-                  ...(session.key === "global" && p.agentId ? { agentId: p.agentId } : {}),
-                })),
+                targets,
               });
               const resolvedMembershipKeys = new Set<string>();
               if (identityId && !isGatewayAdmin(client)) {

--- a/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
@@ -215,6 +215,29 @@ function expectSessionsListActiveRun(respond: RespondFn, hasActiveRun: boolean):
   );
 }
 
+function mockListedSession(row: {
+  key: string;
+  agentId: string;
+  sessionId: string;
+  hasActiveRun?: boolean;
+}): void {
+  loadCombinedSessionStoreForGatewayMock.mockReturnValue({
+    targetsBySessionKey: new Map([
+      [
+        row.key,
+        {
+          agentId: row.agentId,
+          storeTarget: { agentId: row.agentId, storePath: "/tmp/openclaw-sessions.json" },
+        },
+      ],
+    ]),
+    durableTargets: [],
+    storePath: "/tmp/openclaw-sessions.json",
+    store: { [row.key]: { sessionId: row.sessionId, updatedAt: 1 } },
+  });
+  listSessionsFromStoreAsyncMock.mockResolvedValue({ sessions: [row] });
+}
+
 async function expectListedGlobalSessionActiveRun(params: {
   activeRun: ActiveRun;
   runId: string;
@@ -227,8 +250,11 @@ async function expectListedGlobalSessionActiveRun(params: {
     globalScope: true,
     extra: { loadGatewayModelCatalog: vi.fn().mockResolvedValue([]) },
   });
-  listSessionsFromStoreAsyncMock.mockResolvedValue({
-    sessions: [{ key: "global", agentId: params.agentId, hasActiveRun: false }],
+  mockListedSession({
+    key: "global",
+    agentId: params.agentId,
+    sessionId: `sess-${params.agentId}-global`,
+    hasActiveRun: false,
   });
   const respond = await callSessions(
     "sessions.list",
@@ -252,7 +278,7 @@ describe("sessions.abort agent scope", () => {
     listSessionsFromStoreAsyncMock.mockResolvedValue({ sessions: [] });
     loadCombinedSessionStoreForGatewayMock.mockReset();
     loadCombinedSessionStoreForGatewayMock.mockReturnValue({
-      agentIdBySessionKey: new Map(),
+      targetsBySessionKey: new Map(),
       durableTargets: [],
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
@@ -365,8 +391,10 @@ describe("sessions.abort agent scope", () => {
     const context = createContext({
       extra: { loadGatewayModelCatalog: vi.fn().mockResolvedValue([]) },
     });
-    listSessionsFromStoreAsyncMock.mockResolvedValue({
-      sessions: [{ key: "agent:main:openclaw-weixin:direct:user", sessionId: "sess-weixin" }],
+    mockListedSession({
+      key: "agent:main:openclaw-weixin:direct:user",
+      agentId: "main",
+      sessionId: "sess-weixin",
     });
     isEmbeddedAgentRunInProgressMock.mockImplementation(
       (sessionId: string) => sessionId === "sess-weixin",

--- a/src/gateway/server-methods/usage-session-selection.ts
+++ b/src/gateway/server-methods/usage-session-selection.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import type { GatewayStoredSessionTargets } from "../../config/sessions/combined-store-gateway.js";
 import { parseSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
 import {
   resolveSessionFilePathCore,
@@ -88,14 +89,14 @@ type StoredUsageSession = { key: string; entry: SessionEntry };
 
 function buildStoreBySessionIdentity(
   store: Record<string, SessionEntry>,
-  agentIdBySessionKey: ReadonlyMap<string, string>,
+  targetsBySessionKey: GatewayStoredSessionTargets,
 ) {
   const matchesByIdentity = new Map<string, Array<[string, SessionEntry]>>();
   for (const [key, entry] of Object.entries(store)) {
     if (!entry?.sessionId) {
       continue;
     }
-    const agentId = expectDefined(agentIdBySessionKey.get(key), "stored session owner");
+    const agentId = expectDefined(targetsBySessionKey.get(key), "stored session owner").agentId;
     const identity = usageSessionIdentity(agentId, entry.sessionId);
     const matches = matchesByIdentity.get(identity) ?? [];
     matches.push([key, entry]);
@@ -120,7 +121,7 @@ function buildStoreBySessionIdentity(
     { sessionId: string; matches: Array<[string, SessionEntry]> }
   >();
   for (const { key, entry } of storeByIdentity.values()) {
-    const agentId = expectDefined(agentIdBySessionKey.get(key), "stored session owner");
+    const agentId = expectDefined(targetsBySessionKey.get(key), "stored session owner").agentId;
     for (const sessionId of entry.usageFamilySessionIds ?? []) {
       const identity = usageSessionIdentity(agentId, sessionId);
       if (!storeByIdentity.has(identity)) {
@@ -202,20 +203,20 @@ export async function selectUsageSessions(params: {
   } = params;
   // Load session store for named sessions only on a result-cache miss.
   const sessionStoreOpts = effectiveAgentId ? { agentId: effectiveAgentId } : {};
-  const { store, agentIdBySessionKey } = loadCombinedSessionStoreForGatewayCore(
+  const { store, targetsBySessionKey } = loadCombinedSessionStoreForGatewayCore(
     config,
     sessionStoreOpts,
   );
   const scopedStore = Object.fromEntries(
     Object.entries(store).filter(
       ([key, entry]) =>
-        (!effectiveAgentId || agentIdBySessionKey.get(key) === effectiveAgentId) &&
+        (!effectiveAgentId || targetsBySessionKey.get(key)?.agentId === effectiveAgentId) &&
         (!visibilityFilter || visibilityFilter(key, entry)),
     ),
   );
   const { storeByIdentity: storeBySessionIdentity, familyOwners } = buildStoreBySessionIdentity(
     scopedStore,
-    agentIdBySessionKey,
+    targetsBySessionKey,
   );
   // Only an individual instance can skip discovery. Families need the actual
   // historical sources, including retained JSONL artifacts beside SQLite windows.

--- a/src/gateway/server-methods/usage.sessions-usage-cache.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage-cache.test.ts
@@ -93,7 +93,7 @@ describe("sessions.usage result cache", () => {
     vi.clearAllMocks();
     testApi.sessionsUsageCache.clear();
     mocks.loadCombinedSessionStoreForGatewayCore.mockReturnValue({
-      agentIdBySessionKey: new Map(),
+      targetsBySessionKey: new Map(),
       durableTargets: [],
       storePath: "(multiple)",
       store: {},
@@ -141,7 +141,18 @@ describe("sessions.usage result cache", () => {
       tools: { listChars: 0, schemaChars: 0, entries: [] },
     };
     mocks.loadCombinedSessionStoreForGatewayCore.mockReturnValue({
-      agentIdBySessionKey: new Map([["agent:main:main", "main"]]),
+      targetsBySessionKey: new Map([
+        [
+          "agent:main:main",
+          {
+            agentId: "main",
+            storeTarget: {
+              agentId: "main",
+              storePath: "/tmp/agents/main/agent/openclaw-agent.sqlite",
+            },
+          },
+        ],
+      ]),
       durableTargets: [],
       storePath: "(multiple)",
       store: {
@@ -230,9 +241,27 @@ describe("sessions.usage result cache", () => {
         },
       };
       mocks.loadCombinedSessionStoreForGatewayCore.mockReturnValue({
-        agentIdBySessionKey: new Map([
-          ["agent:main:first", "main"],
-          ["agent:main:second", "main"],
+        targetsBySessionKey: new Map([
+          [
+            "agent:main:first",
+            {
+              agentId: "main",
+              storeTarget: {
+                agentId: "main",
+                storePath: "/tmp/agents/main/agent/openclaw-agent.sqlite",
+              },
+            },
+          ],
+          [
+            "agent:main:second",
+            {
+              agentId: "main",
+              storeTarget: {
+                agentId: "main",
+                storePath: "/tmp/agents/main/agent/openclaw-agent.sqlite",
+              },
+            },
+          ],
         ]),
         durableTargets: [],
         storePath: "(multiple)",

--- a/src/gateway/server-methods/usage.sessions-usage-owner-attribution.integration.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage-owner-attribution.integration.test.ts
@@ -57,9 +57,9 @@ it.each([undefined, "agent:opus:slack:dm", "global"])(
       }
 
       const projected = loadCombinedSessionStoreForGatewayCore(config);
-      expect(projected.agentIdBySessionKey.get(mainKey)).toBe("main");
+      expect(projected.targetsBySessionKey.get(mainKey)?.agentId).toBe("main");
       if (opusKey) {
-        expect(projected.agentIdBySessionKey.get(opusKey)).toBe("opus");
+        expect(projected.targetsBySessionKey.get(opusKey)?.agentId).toBe("opus");
       }
       const respond = vi.fn();
       await expectDefined(

--- a/src/gateway/server-methods/usage.sessions-usage-owner-attribution.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage-owner-attribution.test.ts
@@ -73,7 +73,18 @@ async function queryUsage(options: {
         durableTargets: [],
         storePath: "(multiple)",
         store: Object.fromEntries(options.rows.map(({ key, entry }) => [key, entry])),
-        agentIdBySessionKey: new Map(options.rows.map(({ key, agentId }) => [key, agentId])),
+        targetsBySessionKey: new Map(
+          options.rows.map(({ key, agentId }) => [
+            key,
+            {
+              agentId,
+              storeTarget: {
+                agentId,
+                storePath: path.join(stateDir, "agents", agentId, "agent", "openclaw-agent.sqlite"),
+              },
+            },
+          ]),
+        ),
       };
       vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue(fixtureStore);
       vi.mocked(discoverAllSessions).mockImplementation(async ({ agentId }) =>

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createEmptyCostUsageTotals } from "../../infra/session-cost-usage-totals.js";
 import { withEnvAsync } from "../../test-utils/env.js";
@@ -26,7 +27,7 @@ vi.mock("../session-utils.js", async () => {
     ...actual,
     loadGatewaySessionEntryReadOnly: vi.fn(actual.loadGatewaySessionEntryReadOnly),
     loadCombinedSessionStoreForGatewayCore: vi.fn(() => ({
-      agentIdBySessionKey: new Map(),
+      targetsBySessionKey: new Map(),
       durableTargets: [],
       storePath: "(multiple)",
       store: {},
@@ -174,10 +175,27 @@ function expectSuccessfulSessionsUsage(
 ): Array<{ key: string; agentId: string }> {
   expect(respond).toHaveBeenCalledTimes(1);
   expect(mockArg(respond, 0, 0)).toBe(true);
-  const result = mockArg(respond, 0, 1) as {
-    sessions: Array<{ key: string; agentId: string }>;
-  };
-  return result.sessions;
+  return (mockArg(respond, 0, 1) as { sessions: Array<{ key: string; agentId: string }> }).sessions;
+}
+
+function mockCombinedStore(
+  store: Record<string, SessionEntry>,
+  owners: ReadonlyArray<readonly [string, string]>,
+) {
+  vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
+    durableTargets: [],
+    storePath: "(multiple)",
+    store,
+    targetsBySessionKey: new Map(
+      owners.map(([key, agentId]) => [
+        key,
+        {
+          agentId,
+          storeTarget: { agentId, storePath: `/tmp/agents/${agentId}/agent/openclaw-agent.sqlite` },
+        },
+      ]),
+    ),
+  });
 }
 
 function mockStoredSession(
@@ -486,18 +504,13 @@ describe("sessions.usage", () => {
 
     const sessions = expectSuccessfulSessionsUsage(respond);
     expect(sessions).toHaveLength(1);
-    expect(expectDefined(sessions[0], "sessions[0] test invariant").key).toBe(
-      "agent:codex:s-codex",
-    );
-    expect(expectDefined(sessions[0], "sessions[0] test invariant").agentId).toBe("codex");
+    expect(sessions[0]?.key).toBe("agent:codex:s-codex");
+    expect(sessions[0]?.agentId).toBe("codex");
   });
 
   it("does not attach out-of-scope store entries to list-style usage results", async () => {
-    vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
-      agentIdBySessionKey: new Map([["agent:main:s-opus", "main"]]),
-      durableTargets: [],
-      storePath: "(multiple)",
-      store: {
+    mockCombinedStore(
+      {
         "agent:main:s-opus": {
           sessionId: "s-opus",
           sessionFile: "s-opus.jsonl",
@@ -505,7 +518,8 @@ describe("sessions.usage", () => {
           updatedAt: 999,
         },
       },
-    });
+      [["agent:main:s-opus", "main"]],
+    );
 
     const respond = await runSessionsUsage({ ...BASE_USAGE_RANGE, agentId: "opus" });
 
@@ -526,11 +540,8 @@ describe("sessions.usage", () => {
       writeSessionFile("main.jsonl");
       mockStoredSession("agent:opus:main", "main");
 
-      vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
-        agentIdBySessionKey: new Map([["agent:opus:main", "opus"]]),
-        durableTargets: [],
-        storePath: "(multiple)",
-        store: {
+      mockCombinedStore(
+        {
           "agent:opus:main": {
             sessionId: "main",
             sessionFile: "main.jsonl",
@@ -538,7 +549,8 @@ describe("sessions.usage", () => {
             updatedAt: 999,
           },
         },
-      });
+        [["agent:opus:main", "opus"]],
+      );
 
       const respond = await runSessionsUsage({
         ...BASE_USAGE_RANGE,
@@ -576,20 +588,17 @@ describe("sessions.usage", () => {
       writeSessionFile("current.jsonl");
       mockStoredSession("global", "current");
 
-      const sessionEntry = {
-        sessionId: "current",
-        sessionFile: "current.jsonl",
-        label: "Opus global",
-        updatedAt: 999,
-      };
-      vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
-        agentIdBySessionKey: new Map([["global", "opus"]]),
-        durableTargets: [],
-        storePath: "(multiple)",
-        store: {
-          global: sessionEntry,
+      mockCombinedStore(
+        {
+          global: {
+            sessionId: "current",
+            sessionFile: "current.jsonl",
+            label: "Opus global",
+            updatedAt: 999,
+          },
         },
-      });
+        [["global", "opus"]],
+      );
 
       const respond = await runSessionsUsage(
         {
@@ -622,11 +631,8 @@ describe("sessions.usage", () => {
     await withUsageState(async (writeSessionFile) => {
       const sessionFile = writeSessionFile("shared.jsonl");
 
-      vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
-        agentIdBySessionKey: new Map([["agent:main:shared", "main"]]),
-        durableTargets: [],
-        storePath: "(multiple)",
-        store: {
+      mockCombinedStore(
+        {
           "agent:main:shared": {
             sessionId: "shared",
             sessionFile: "shared.jsonl",
@@ -634,7 +640,8 @@ describe("sessions.usage", () => {
             updatedAt: 999,
           },
         },
-      });
+        [["agent:main:shared", "main"]],
+      );
 
       const respond = await runSessionsUsage({
         ...BASE_USAGE_RANGE,
@@ -669,11 +676,8 @@ describe("sessions.usage", () => {
 
       // Swap the store mock for this test: the canonical key differs from the discovered key
       // but points at the same sessionId.
-      vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
-        agentIdBySessionKey: new Map([[storeKey, "opus"]]),
-        durableTargets: [],
-        storePath: "(multiple)",
-        store: {
+      mockCombinedStore(
+        {
           [storeKey]: {
             sessionId: "s-opus",
             sessionFile: "s-opus.jsonl",
@@ -681,7 +685,8 @@ describe("sessions.usage", () => {
             updatedAt: 999,
           },
         },
-      });
+        [[storeKey, "opus"]],
+      );
 
       // Query via discovered key: agent:<id>:<sessionId>
       const respond = await runSessionsUsage({ ...BASE_USAGE_RANGE, key: "agent:opus:s-opus" });
@@ -708,11 +713,8 @@ describe("sessions.usage", () => {
         { sessionId: "old", sessionFile: oldSessionFile, mtime: 1_000 },
       ]);
 
-      vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
-        agentIdBySessionKey: new Map([[storeKey, "opus"]]),
-        durableTargets: [],
-        storePath: "(multiple)",
-        store: {
+      mockCombinedStore(
+        {
           [storeKey]: {
             sessionId: "current",
             updatedAt: 1_000,
@@ -720,7 +722,8 @@ describe("sessions.usage", () => {
             usageFamilySessionIds: ["old", "current"],
           },
         },
-      });
+        [[storeKey, "opus"]],
+      );
       vi.mocked(loadSessionCostSummariesFromCache).mockImplementation(async ({ sessions }) => ({
         summaries: sessions.map((session) => {
           const historical = session.sessionId === "old";
@@ -878,14 +881,8 @@ describe("sessions.usage", () => {
       writeSessionFile("run-dup.jsonl");
       mockStoredSession(preferredKey, "run-dup");
 
-      vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
-        agentIdBySessionKey: new Map([
-          [preferredKey, "opus"],
-          ["agent:other:main", "other"],
-        ]),
-        durableTargets: [],
-        storePath: "(multiple)",
-        store: {
+      mockCombinedStore(
+        {
           [preferredKey]: {
             sessionId: "run-dup",
             sessionFile: "run-dup.jsonl",
@@ -897,7 +894,11 @@ describe("sessions.usage", () => {
             updatedAt: 2_000,
           },
         },
-      });
+        [
+          [preferredKey, "opus"],
+          ["agent:other:main", "other"],
+        ],
+      );
 
       const respond = await runSessionsUsage({
         ...BASE_USAGE_RANGE,

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -44,7 +44,7 @@ vi.mock("../session-utils.js", async () => {
   return {
     ...actual,
     loadCombinedSessionStoreForGatewayCore: vi.fn(() => ({
-      agentIdBySessionKey: new Map(),
+      targetsBySessionKey: new Map(),
       durableTargets: [],
       storePath: "(multiple)",
       store: {},

--- a/src/gateway/server-startup-handler-prewarm.ts
+++ b/src/gateway/server-startup-handler-prewarm.ts
@@ -22,15 +22,13 @@ async function prewarmGatewaySessionListData(cfg: OpenClawConfig, agentId: strin
       import("../config/sessions/combined-store-gateway.js"),
       import("./session-utils-list.js"),
     ]);
-  const { durableStorePath, storePath, store } = loadCombinedSessionStoreForGatewayCore(cfg, {
+  const loaded = loadCombinedSessionStoreForGatewayCore(cfg, {
     agentId,
     projection: "list",
   });
   await listSessionsFromStoreAsync({
     cfg,
-    durableStorePath,
-    storePath,
-    store,
+    ...loaded,
     opts: {
       agentId,
       configuredAgentsOnly: true,

--- a/src/gateway/server.sessions.face.test.ts
+++ b/src/gateway/server.sessions.face.test.ts
@@ -1,14 +1,17 @@
 /** Gateway durable session-face behavior. */
-import { expect, test } from "vitest";
+import path from "node:path";
+import { expect, onTestFinished, test } from "vitest";
 import { SqliteBoardStore } from "../boards/sqlite-board-store.js";
 import { replaceSessionEntrySync } from "../config/sessions/session-accessor.entry.js";
 import {
+  closeOpenClawAgentDatabaseByPath,
   listOpenIncognitoAgentDatabases,
   openOpenClawAgentDatabase,
   resolveIncognitoOpenClawAgentSqlitePath,
 } from "../state/openclaw-agent-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { boardStore } from "./board-store.js";
-import { rpcReq, writeSessionStore } from "./test-helpers.js";
+import { rpcReq, testState, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
   setupGatewaySessionsTestHarness,
@@ -139,6 +142,9 @@ test("sessions.list includes boards stored with incognito sessions", async () =>
   const sessionKey = "agent:main:dashboard:incognito-board";
   const incognitoPath = resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main" });
   openOpenClawAgentDatabase({ agentId: "main", path: incognitoPath });
+  onTestFinished(() => {
+    closeOpenClawAgentDatabaseByPath(incognitoPath);
+  });
   replaceSessionEntrySync(
     { agentId: "main", sessionKey, storePath: incognitoPath },
     { sessionId: "sess-incognito", updatedAt: 1, incognito: true },
@@ -170,3 +176,58 @@ test("sessions.list includes boards stored with incognito sessions", async () =>
   expect(listed.ok).toBe(true);
   expect(listed.payload?.sessions).toEqual([expect.objectContaining({ key: sessionKey })]);
 });
+
+test.each(["first", "later"] as const)(
+  "sessions.list checks a same-owner sentinel board only in its selected store (board=%s)",
+  async (boardStoreName) => {
+    const rootStateDir = process.env.OPENCLAW_STATE_DIR;
+    if (!rootStateDir) {
+      throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
+    }
+    const stateDir = path.join(rootStateDir, `board-selected-store-${boardStoreName}`);
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const firstPath = path.join(stateDir, "a-first.sqlite");
+      const laterPath = path.join(stateDir, "z-later.sqlite");
+      for (const [storePath, sessionId] of [
+        [firstPath, "selected-first"],
+        [laterPath, "unselected-later"],
+      ] as const) {
+        replaceSessionEntrySync(
+          { agentId: "main", storePath, sessionKey: "unknown" },
+          { sessionId, updatedAt: 1 },
+        );
+      }
+      const boards = new SqliteBoardStore({
+        resolveSession: () => ({
+          agentId: "main",
+          path: boardStoreName === "first" ? firstPath : laterPath,
+          sessionKey: "unknown",
+        }),
+      });
+      boards.applyOps({ sessionKey: "unknown" }, [
+        { kind: "tab_create", tabId: "main", title: "Selected-store dashboard" },
+      ]);
+      testState.agentsConfig = { list: [{ id: "main", default: true }] };
+      testState.sessionConfig = {
+        store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+      };
+      for (const hasBoard of [true, false]) {
+        const result = await directSessionReq<{
+          sessions: Array<{ key: string; agentId: string; sessionId: string }>;
+        }>("sessions.list", { configuredAgentsOnly: true, includeUnknown: true, hasBoard });
+        expect(result.ok).toBe(true);
+        expect(
+          result.payload?.sessions.map(({ key, agentId, sessionId }) => ({
+            key,
+            agentId,
+            sessionId,
+          })),
+        ).toEqual(
+          hasBoard === (boardStoreName === "first")
+            ? [{ key: "unknown", agentId: "main", sessionId: "selected-first" }]
+            : [],
+        );
+      }
+    });
+  },
+);

--- a/src/gateway/server.sessions.list-explicit-ownership.test.ts
+++ b/src/gateway/server.sessions.list-explicit-ownership.test.ts
@@ -1,15 +1,27 @@
+import fs from "node:fs/promises";
 import path from "node:path";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
+import {
+  deleteSessionEntryLifecycle,
+  replaceSessionEntrySync,
+} from "../config/sessions/session-accessor.js";
+import { addSessionMember, removeSessionMember } from "../config/sessions/session-sharing-store.js";
+import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import type { GatewayClient } from "./server-methods/types.js";
+import { sharingPolicyClient } from "./session-sharing.test-utils.js";
+import * as sessionUtils from "./session-utils.js";
+import type { SessionsListResult } from "./session-utils.types.js";
 import { testState, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
+  seedSessionTranscript,
   setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
 
 setupGatewaySessionsHandlerTestHarness();
 
-test("sessions.list excludes ownerless sentinels for explicit multi-agent federation", async () => {
+test("sessions.list preserves recorded sentinel owners for explicit multi-agent federation", async () => {
   const rootStateDir = process.env.OPENCLAW_STATE_DIR;
   if (!rootStateDir) {
     throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
@@ -43,15 +55,27 @@ test("sessions.list excludes ownerless sentinels for explicit multi-agent federa
       },
     });
 
-    await expect(
-      directSessionReq("sessions.list", {
-        includeGlobal: true,
-        includeUnknown: true,
-        configuredAgentsOnly: true,
-      }),
-    ).rejects.toThrow(
-      'Multiple agents are configured, but session key "global" has no explicit owner.',
-    );
+    const all = await directSessionReq<{
+      sessions: Array<{ key: string; agentId: string; sessionId: string }>;
+      count: number;
+      totalCount: number;
+      hasMore: boolean;
+    }>("sessions.list", {
+      includeGlobal: true,
+      includeUnknown: true,
+      configuredAgentsOnly: true,
+    });
+    expect(all.ok).toBe(true);
+    expect(all.payload).toMatchObject({ count: 5, totalCount: 5, hasMore: false });
+    expect(
+      all.payload?.sessions.map(({ key, agentId, sessionId }) => ({ key, agentId, sessionId })),
+    ).toEqual([
+      { key: `agent:research:${linkedSessionKey}`, agentId: "research", sessionId: "sess-linked" },
+      { key: "agent:research:main", agentId: "research", sessionId: "sess-research" },
+      { key: "agent:ops:main", agentId: "ops", sessionId: "sess-ops" },
+      { key: "global", agentId: "ops", sessionId: "sess-global" },
+      { key: "unknown", agentId: "ops", sessionId: "sess-unknown" },
+    ]);
 
     const linkedQuery = {
       search: linkedSessionKey,
@@ -61,30 +85,33 @@ test("sessions.list excludes ownerless sentinels for explicit multi-agent federa
       includeDerivedTitles: false,
       includeLastMessage: false,
     };
-    for (const sentinel of ["global", "unknown"]) {
-      await expect(
-        directSessionReq("sessions.list", {
-          ...linkedQuery,
-          includeGlobal: sentinel === "global",
-          includeUnknown: sentinel === "unknown",
-        }),
-      ).rejects.toThrow(
-        `Multiple agents are configured, but session key "${sentinel}" has no explicit owner.`,
-      );
+    for (const [includeGlobal, includeUnknown] of [
+      [true, false],
+      [false, true],
+      [true, true],
+      [false, false],
+    ]) {
+      const linked = await directSessionReq("sessions.list", {
+        ...linkedQuery,
+        includeGlobal,
+        includeUnknown,
+      });
+      expect(linked).toMatchObject({
+        ok: true,
+        payload: {
+          sessions: [
+            {
+              key: `agent:research:${linkedSessionKey}`,
+              agentId: "research",
+              sessionId: "sess-linked",
+            },
+          ],
+          count: 1,
+          hasMore: false,
+          totalCount: 1,
+        },
+      });
     }
-    const linked = await directSessionReq("sessions.list", {
-      ...linkedQuery,
-      includeGlobal: false,
-      includeUnknown: false,
-    });
-    expect(linked).toMatchObject({
-      ok: true,
-      payload: {
-        sessions: [{ key: `agent:research:${linkedSessionKey}`, agentId: "research" }],
-        hasMore: false,
-        totalCount: 1,
-      },
-    });
 
     const configuredOnly = await directSessionReq<{ sessions: Array<{ key: string }> }>(
       "sessions.list",
@@ -96,5 +123,219 @@ test("sessions.list excludes ownerless sentinels for explicit multi-agent federa
       "agent:research:main",
       "agent:ops:main",
     ]);
+  });
+});
+
+test("sessions.list preserves separate registered targets under a fixed store owner", async () => {
+  const rootStateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!rootStateDir) {
+    throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
+  }
+  const stateDir = path.join(rootStateDir, "fixed-owner-registered-list");
+  await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+    const storePath = path.join(stateDir, "shared.json");
+    for (const agentId of ["main", "ops"]) {
+      replaceSessionEntrySync(
+        { agentId, defaultAgentId: "main", sessionKey: "global", storePath },
+        { sessionId: `global-${agentId}`, updatedAt: 1 },
+      );
+    }
+    replaceSessionEntrySync(
+      { agentId: "main", sessionKey: "unknown", storePath: path.join(stateDir, "separate.sqlite") },
+      { sessionId: "separate-main", updatedAt: 2 },
+    );
+    testState.sessionConfig = { store: storePath };
+    testState.agentsConfig = { ownership: "explicit", list: [{ id: "main" }, { id: "ops" }] };
+    testState.agentConfig = { sessionStore: { agentId: "ops" } };
+    const client: GatewayClient = {
+      connect: {
+        minProtocol: 1,
+        maxProtocol: 1,
+        client: { id: "openclaw-control-ui", version: "test", platform: "test", mode: "webchat" },
+        role: "operator",
+        scopes: ["operator.admin"],
+      },
+    };
+    const scoped = await directSessionReq(
+      "sessions.get",
+      { key: "unknown", agentId: "main" },
+      { client },
+    );
+    expect(scoped).toMatchObject({
+      ok: false,
+      error: { code: "INVALID_REQUEST", message: expect.stringContaining("does not match") },
+    });
+    const listed = await directSessionReq<{
+      sessions: Array<{ key: string; agentId: string; sessionId: string }>;
+    }>(
+      "sessions.list",
+      { configuredAgentsOnly: true, includeGlobal: true, includeUnknown: true },
+      { client },
+    );
+    expect(listed.ok).toBe(true);
+    expect(
+      listed.payload?.sessions.map(({ key, agentId, sessionId }) => ({ key, agentId, sessionId })),
+    ).toEqual([
+      { key: "unknown", agentId: "main", sessionId: "separate-main" },
+      { key: "global", agentId: "main", sessionId: "global-main" },
+    ]);
+  });
+});
+
+test.for(
+  (["delete", "draft", "join", "leave"] as const).flatMap((change) => [
+    { change, alias: false },
+    { change, alias: true },
+  ]),
+)(
+  "sessions.list refreshes $change against the selected physical database (alias=$alias)",
+  async ({ change, alias }, context) => {
+    if (alias && process.platform === "win32") {
+      context.skip();
+    }
+    const rootStateDir = process.env.OPENCLAW_STATE_DIR;
+    if (!rootStateDir) {
+      throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
+    }
+    const stateDir = path.join(rootStateDir, `physical-sharing-${change}-${alias}`);
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const storePath = path.join(stateDir, "shared.sqlite");
+      const physicalPath = alias
+        ? path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite")
+        : storePath;
+      testState.sessionConfig = { store: storePath };
+      testState.agentsConfig = { ownership: "explicit", list: [{ id: "main" }, { id: "ops" }] };
+      testState.agentConfig = { sessionStore: { agentId: "ops" } };
+      openOpenClawAgentDatabase({ agentId: "main", path: physicalPath });
+      if (alias) {
+        await fs.symlink(physicalPath, storePath);
+      }
+      const key = "agent:ops:physical-sharing";
+      const scope = { agentId: "ops", storePath, sessionKey: key };
+      const entry = {
+        sessionId: "ops-physical-session",
+        updatedAt: 10,
+        visibility:
+          change === "join" || change === "leave" ? ("read-only" as const) : ("shared" as const),
+        createdActor: { type: "human" as const, source: "profile" as const, id: "owner" },
+      };
+      await writeSessionStore({ agentId: scope.agentId, storePath, entries: { [key]: entry } });
+      await seedSessionTranscript({
+        ...scope,
+        sessionId: entry.sessionId,
+        messages: [{ role: "user", content: "Physical database title" }],
+      });
+      if (change === "leave") {
+        addSessionMember(scope, {
+          identityId: "viewer",
+          addedBy: "owner",
+          expectedSessionId: entry.sessionId,
+        });
+      }
+      const project = sessionUtils.listSessionsFromStoreAsync;
+      const spy = vi
+        .spyOn(sessionUtils, "listSessionsFromStoreAsync")
+        .mockImplementationOnce(async (params) => {
+          const result = await project(params);
+          expect(result.sessions).toMatchObject([
+            { key, agentId: "ops", derivedTitle: "Physical database title" },
+          ]);
+          if (change === "delete") {
+            await deleteSessionEntryLifecycle({
+              agentId: scope.agentId,
+              storePath,
+              target: { canonicalKey: key, storeKeys: [key] },
+              archiveTranscript: false,
+              deleteTranscriptWithoutArchive: true,
+            });
+          } else if (change === "draft") {
+            replaceSessionEntrySync(scope, { ...entry, visibility: "draft" });
+          } else if (change === "join") {
+            addSessionMember(scope, {
+              identityId: "viewer",
+              addedBy: "owner",
+              expectedSessionId: entry.sessionId,
+            });
+          } else {
+            removeSessionMember(scope, "viewer", undefined, entry.sessionId);
+          }
+          return result;
+        });
+      try {
+        const result = await directSessionReq<SessionsListResult>(
+          "sessions.list",
+          { configuredAgentsOnly: true, includeDerivedTitles: true },
+          { client: sharingPolicyClient({ user: "viewer" }) },
+        );
+        expect(result.ok).toBe(true);
+        expect(spy).toHaveBeenCalled();
+        if (change === "delete" || change === "draft") {
+          expect(result.payload?.sessions).toEqual([]);
+        } else {
+          expect(result.payload?.sessions).toMatchObject([
+            {
+              key,
+              agentId: "ops",
+              sessionId: entry.sessionId,
+              visibility: "read-only",
+              sharingRole: change === "join" ? "member" : "viewer",
+            },
+          ]);
+        }
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  },
+);
+
+test("sessions.list never substitutes a later same-owner sentinel after the selected row disappears", async () => {
+  const rootStateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!rootStateDir) {
+    throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
+  }
+  const stateDir = path.join(rootStateDir, "same-owner-sentinel");
+  await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+    const first = {
+      agentId: "main",
+      storePath: path.join(stateDir, "a-first.sqlite"),
+      sessionKey: "unknown",
+    };
+    const second = { ...first, storePath: path.join(stateDir, "z-second.sqlite") };
+    replaceSessionEntrySync(first, { sessionId: "first-sentinel", updatedAt: 1 });
+    replaceSessionEntrySync(second, { sessionId: "later-sentinel", updatedAt: 2 });
+    testState.agentsConfig = { list: [{ id: "main", default: true }] };
+    const project = sessionUtils.listSessionsFromStoreAsync;
+    const spy = vi
+      .spyOn(sessionUtils, "listSessionsFromStoreAsync")
+      .mockImplementationOnce(async (params) => {
+        const result = await project(params);
+        expect(params.targetsBySessionKey.get("unknown")).toEqual({
+          agentId: "main",
+          storeTarget: { agentId: "main", storePath: first.storePath },
+        });
+        expect(result.sessions).toMatchObject([
+          { key: "unknown", agentId: "main", sessionId: "first-sentinel" },
+        ]);
+        await deleteSessionEntryLifecycle({
+          ...first,
+          target: { canonicalKey: "unknown", storeKeys: ["unknown"] },
+          archiveTranscript: false,
+          deleteTranscriptWithoutArchive: true,
+        });
+        return result;
+      });
+    try {
+      const result = await directSessionReq<SessionsListResult>(
+        "sessions.list",
+        { configuredAgentsOnly: true, includeUnknown: true },
+        { client: sharingPolicyClient({ user: "viewer" }) },
+      );
+      expect(result.ok).toBe(true);
+      expect(spy).toHaveBeenCalled();
+      expect(result.payload?.sessions).toEqual([]);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/gateway/server.sessions.preview-resolve.test.ts
+++ b/src/gateway/server.sessions.preview-resolve.test.ts
@@ -1,20 +1,135 @@
 /**
  * Gateway session preview resolve tests.
  */
-import { expect, test, vi } from "vitest";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, onTestFinished, test, vi } from "vitest";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import * as sessionHistoryEvents from "../config/sessions/session-accessor.sqlite-history-events.js";
+import type { ControlUiSessionPreview } from "./control-ui-contract.js";
 import type { GatewayClient } from "./server-methods/types.js";
 import { createToolSummaryPreviewTranscriptLines } from "./session-preview.test-helpers.js";
-import { rpcReq, writeSessionStore } from "./test-helpers.js";
+import type { SessionsListResult } from "./session-utils.types.js";
+import { rpcReq, testState, writeSessionStore } from "./test-helpers.js";
 import {
   setupGatewaySessionsTestHarness,
   sessionStoreEntry,
   directSessionReq,
+  getGatewayConfigModule,
   seedSessionTranscript,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir, openClient } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir, createSelectedGlobalSessionStore, openClient } =
+  setupGatewaySessionsTestHarness();
+
+test("lists and previews the selected aggregate global owner over WebSocket", async () => {
+  const config = await getGatewayConfigModule();
+  const runtime = config.getRuntimeConfigSnapshot();
+  const source = config.getRuntimeConfigSourceSnapshot();
+  const previous = {
+    agentsConfig: testState.agentsConfig,
+    sessionConfig: testState.sessionConfig,
+    sessionStorePath: testState.sessionStorePath,
+  };
+  const configPaths = new Set([config.CONFIG_PATH]);
+  if (process.env.OPENCLAW_CONFIG_PATH) {
+    configPaths.add(process.env.OPENCLAW_CONFIG_PATH);
+  }
+  if (process.env.OPENCLAW_STATE_DIR) {
+    configPaths.add(path.join(process.env.OPENCLAW_STATE_DIR, "openclaw.json"));
+  }
+  const files = new Map<string, Buffer | undefined>();
+  for (const configPath of configPaths) {
+    try {
+      files.set(configPath, await fs.readFile(configPath));
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+        throw error;
+      }
+      files.set(configPath, undefined);
+    }
+  }
+  onTestFinished(async () => {
+    Object.assign(testState, previous);
+    // The connected fixture publishes both config paths as well as its runtime snapshot.
+    for (const [configPath, contents] of files) {
+      if (contents === undefined) {
+        await fs.rm(configPath, { force: true });
+      } else {
+        await fs.writeFile(configPath, contents);
+      }
+    }
+    if (runtime) {
+      config.setRuntimeConfigSnapshot(runtime, source ?? undefined);
+    } else {
+      config.clearRuntimeConfigSnapshot();
+    }
+  });
+  const { workStorePath } = await createSelectedGlobalSessionStore();
+  testState.agentsConfig = {
+    entries: {
+      main: { default: true, model: { primary: "openai/gpt-5.4" } },
+      work: { model: { primary: "openai/gpt-5.5" } },
+    },
+  };
+  const sessionId = "aggregate-work-global";
+  await writeSessionStore({
+    agentId: "work",
+    storePath: workStorePath,
+    entries: { global: sessionStoreEntry(sessionId, { label: "Work global conversation" }) },
+  });
+  await seedSessionTranscript({
+    agentId: "work",
+    sessionId,
+    sessionKey: "global",
+    storePath: workStorePath,
+    messages: [{ role: "user", content: "Work global conversation" }],
+  });
+  const { ws } = await openClient();
+  try {
+    for (const search of [undefined, "gpt-5.5"]) {
+      const listed = await rpcReq<SessionsListResult>(ws, "sessions.list", {
+        includeGlobal: true,
+        includeDerivedTitles: true,
+        includeLastMessage: true,
+        ...(search ? { search } : {}),
+      });
+      expect(listed.ok).toBe(true);
+      expect(listed.payload?.sessions).toMatchObject([
+        {
+          key: "global",
+          sessionId,
+          agentId: "work",
+          model: "gpt-5.5",
+          derivedTitle: "Work global conversation",
+          lastMessagePreview: "Work global conversation",
+        },
+      ]);
+    }
+    const preview = await rpcReq<ControlUiSessionPreview>(ws, "controlUi.sessionPreview", {
+      sessionKey: "agent:work:main",
+    });
+    expect(preview).toMatchObject({
+      ok: true,
+      payload: { status: "ok", agentId: "work", derivedTitle: "Work global conversation" },
+    });
+    const resolved = await rpcReq(ws, "sessions.resolve", {
+      label: "Work global conversation",
+      includeGlobal: true,
+    });
+    expect(resolved).toMatchObject({
+      ok: true,
+      payload: { ok: true, key: "global", agentId: "work" },
+    });
+  } finally {
+    if (ws.readyState !== ws.CLOSED) {
+      const closed = once(ws, "close");
+      ws.close();
+      await closed;
+    }
+  }
+});
 
 async function seedPreviewTail(
   sessionId: string,

--- a/src/gateway/session-list.test-support.ts
+++ b/src/gateway/session-list.test-support.ts
@@ -28,16 +28,16 @@ export function buildSessionRowFixture(
 
 /** Synthetic stores have no loader; declare their unqualified row owner in the fixture. */
 export function listSessionFixture(
-  params: Omit<Parameters<typeof listSessionsFromStoreAsync>[0], "agentIdBySessionKey"> & {
+  params: Omit<Parameters<typeof listSessionsFromStoreAsync>[0], "targetsBySessionKey"> & {
     fixtureAgentId?: string;
   },
 ) {
   const { fixtureAgentId, ...input } = params;
-  const agentIdBySessionKey = new Map(
-    Object.keys(input.store).map((key) => [
-      key,
-      fixtureOwner(input.cfg, key, input.opts.agentId ?? fixtureAgentId),
-    ]),
+  const targetsBySessionKey = new Map(
+    Object.keys(input.store).map((key) => {
+      const agentId = fixtureOwner(input.cfg, key, input.opts.agentId ?? fixtureAgentId);
+      return [key, { agentId, storeTarget: { agentId, storePath: input.storePath } }] as const;
+    }),
   );
-  return listSessionsFromStoreAsync({ ...input, agentIdBySessionKey });
+  return listSessionsFromStoreAsync({ ...input, targetsBySessionKey });
 }

--- a/src/gateway/session-list.test-support.ts
+++ b/src/gateway/session-list.test-support.ts
@@ -1,0 +1,43 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { listAgentIds } from "../agents/agent-scope-config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+import { listSessionsFromStoreAsync } from "./session-utils-list.js";
+import { buildGatewaySessionRow } from "./session-utils-row.js";
+
+function fixtureOwner(cfg: OpenClawConfig, key: string, agentId?: string): string {
+  const configured = listAgentIds(cfg);
+  return expectDefined(
+    parseAgentSessionKey(key)?.agentId ??
+      agentId ??
+      (key !== "global" && key !== "unknown" && configured.length === 1
+        ? configured[0]
+        : undefined),
+    `fixture owner for ${key}`,
+  );
+}
+
+export function buildSessionRowFixture(
+  params: Omit<Parameters<typeof buildGatewaySessionRow>[0], "agentId"> & { agentId?: string },
+) {
+  return buildGatewaySessionRow({
+    ...params,
+    agentId: fixtureOwner(params.cfg, params.key, params.agentId),
+  });
+}
+
+/** Synthetic stores have no loader; declare their unqualified row owner in the fixture. */
+export function listSessionFixture(
+  params: Omit<Parameters<typeof listSessionsFromStoreAsync>[0], "agentIdBySessionKey"> & {
+    fixtureAgentId?: string;
+  },
+) {
+  const { fixtureAgentId, ...input } = params;
+  const agentIdBySessionKey = new Map(
+    Object.keys(input.store).map((key) => [
+      key,
+      fixtureOwner(input.cfg, key, input.opts.agentId ?? fixtureAgentId),
+    ]),
+  );
+  return listSessionsFromStoreAsync({ ...input, agentIdBySessionKey });
+}

--- a/src/gateway/session-sharing-policy.ts
+++ b/src/gateway/session-sharing-policy.ts
@@ -97,12 +97,10 @@ export function resolveSessionSharingTarget(params: {
 export function resolveSessionSharingTargets(params: {
   cfg: OpenClawConfig;
   targets: readonly { sessionKey: string; agentId?: string }[];
-  targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
 }): Array<SessionSharingTarget | null> {
   return resolveGatewaySessionStoreTargetsReadOnly({
     cfg: params.cfg,
     targets: params.targets.map(({ sessionKey, agentId }) => ({ key: sessionKey, agentId })),
-    targetDiscoveryCache: params.targetDiscoveryCache,
   }).map(toSessionSharingTarget);
 }
 

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -36,7 +36,6 @@ import {
   resolveSessionListProfileReference,
 } from "./session-identity-projection.js";
 import { type SessionEntryPair, sortAndLimitSessionEntries } from "./session-list-order.js";
-import { resolveSessionStoreAgentId } from "./session-store-key.js";
 import { readSessionTitleFieldsFromTranscriptBatch as readScopedSessionTitleFieldsFromTranscriptBatch } from "./session-transcript-title-reader.js";
 import type {
   SessionActorProfileIdentity,
@@ -74,12 +73,21 @@ const SESSIONS_LIST_ROW_CONTEXT_THRESHOLD = 10;
 const SESSIONS_LIST_DEFAULT_LIMIT = 100;
 const SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS = 100;
 
+type SessionSelectionScope =
+  | { opts: SessionsListParams; agentIdBySessionKey: ReadonlyMap<string, string> }
+  | {
+      opts: Omit<SessionsListParams, "search"> & { search?: never };
+      agentIdBySessionKey?: never;
+    };
+
 type ListSessionsFromStoreParams = {
   cfg: OpenClawConfig;
   durableStorePath?: string;
   entryFilter?: (key: string, entry: SessionEntry) => boolean;
   storePath: string;
   store: Record<string, SessionEntry>;
+  // Sentinels retain the first projected store's owner; their raw key cannot recover it.
+  agentIdBySessionKey: ReadonlyMap<string, string>;
   modelCatalog?: SessionListModelCatalog | ModelCatalogEntry[];
   opts: SessionsListParams;
   involvingActorId?: string;
@@ -130,6 +138,7 @@ function resolveSessionsListWindowLimit(limit: number | undefined, offset: numbe
 function filterSessionEntries(params: {
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
+  agentIdBySessionKey?: ReadonlyMap<string, string>;
   opts: SessionsListParams;
   now: number;
   userProfileIdentityById?: Map<string, SessionActorProfileIdentity | undefined>;
@@ -272,7 +281,7 @@ function filterSessionEntries(params: {
         search,
         now,
         visibleEntries: candidateEntries,
-        agentId: agentId || undefined,
+        agentIdBySessionKey: expectDefined(params.agentIdBySessionKey, "search row owners"),
         getRowContext: params.getRowContext,
         projectActiveRun: params.projectActiveRun,
       })
@@ -366,6 +375,7 @@ function isPhantomAgentStoreListEntry(key: string, entry: SessionEntry | undefin
 function selectSessionEntries(params: {
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
+  agentIdBySessionKey?: ReadonlyMap<string, string>;
   opts: SessionsListParams;
   now: number;
   getRowContext?: SessionListRowContextProvider;
@@ -435,6 +445,7 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
   const selection = selectSessionEntries({
     cfg,
     store,
+    agentIdBySessionKey: params.agentIdBySessionKey,
     opts,
     now,
     entryFilter,
@@ -472,7 +483,7 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
   populateSessionListAcpMetadata({
     cfg,
     entries: selection.entries,
-    opts,
+    agentIdBySessionKey: params.agentIdBySessionKey,
     rowContext: sharedRowContext,
   });
   return {
@@ -541,15 +552,16 @@ export function resolveSessionsListDefaultsAgentId(
     : normalizeAgentId(tryResolveLegacyCompatibilityAgentId(cfg) ?? LEGACY_IMPLICIT_AGENT_ID);
 }
 
-export function filterAndSortSessionEntries(params: {
-  cfg: OpenClawConfig;
-  entryFilter?: (key: string, entry: SessionEntry) => boolean;
-  store: Record<string, SessionEntry>;
-  opts: SessionsListParams;
-  now: number;
-  getRowContext?: SessionListRowContextProvider;
-  involvingActorId?: string;
-}): [string, SessionEntry][] {
+export function filterAndSortSessionEntries(
+  params: {
+    cfg: OpenClawConfig;
+    entryFilter?: (key: string, entry: SessionEntry) => boolean;
+    store: Record<string, SessionEntry>;
+    now: number;
+    getRowContext?: SessionListRowContextProvider;
+    involvingActorId?: string;
+  } & SessionSelectionScope,
+): [string, SessionEntry][] {
   return selectSessionEntries({
     ...params,
     restrictProfileReferences: params.entryFilter !== undefined,
@@ -567,7 +579,7 @@ export async function listSessionsFromStoreAsync(
   // loadPluginMetadataSnapshot scan (~100 ms).
   return withPinnedActivePluginRegistryWorkspaceDir(async () => {
     let workStartedAt = performance.now();
-    const { cfg, store, opts } = params;
+    const { cfg, store, agentIdBySessionKey } = params;
     const list = prepareSessionList(params);
     const sessions: GatewaySessionRow[] = [];
     const transcriptScopes = list.entries
@@ -576,13 +588,9 @@ export async function listSessionsFromStoreAsync(
         if (!entry.sessionId || (!list.includeDerivedTitles && !list.includeLastMessage)) {
           return [];
         }
-        const parsed = parseAgentSessionKey(key);
-        const agentId = normalizeAgentId(
-          parsed?.agentId ?? opts.agentId ?? resolveSessionStoreAgentId(cfg, key),
-        );
         return [
           {
-            agentId,
+            agentId: expectDefined(agentIdBySessionKey.get(key), "transcript row owner"),
             sessionEntry: entry,
             sessionId: entry.sessionId,
             sessionKey: key,
@@ -595,17 +603,13 @@ export async function listSessionsFromStoreAsync(
     for (let i = 0; i < list.entries.length; i++) {
       const [key, entry] = expectDefined(list.entries[i], "entries entry at i");
       const includeTranscriptFields = i < list.transcriptFieldRows;
-      const rowAgentId =
-        !parseAgentSessionKey(key) && typeof opts.agentId === "string"
-          ? normalizeAgentId(opts.agentId)
-          : undefined;
       const row = buildGatewaySessionRow({
         cfg,
         storePath: list.storePath,
         store,
         key,
         entry,
-        agentId: rowAgentId,
+        agentId: expectDefined(agentIdBySessionKey.get(key), "session row owner"),
         modelCatalog: params.modelCatalog,
         now: list.now,
         includeDerivedTitles: false,

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -14,6 +14,7 @@ import {
 import { shouldKeepSubagentRunChildLink } from "../agents/subagents/registry/subagent-run-liveness.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import type { SessionEntry } from "../config/sessions.js";
+import type { GatewayStoredSessionTargets } from "../config/sessions/combined-store-gateway.js";
 import { MAX_SESSION_PARTICIPANTS } from "../config/sessions/session-entry-provenance.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withPinnedActivePluginRegistryWorkspaceDir } from "../plugins/runtime-workspace-state.js";
@@ -74,10 +75,10 @@ const SESSIONS_LIST_DEFAULT_LIMIT = 100;
 const SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS = 100;
 
 type SessionSelectionScope =
-  | { opts: SessionsListParams; agentIdBySessionKey: ReadonlyMap<string, string> }
+  | { opts: SessionsListParams; targetsBySessionKey: GatewayStoredSessionTargets }
   | {
       opts: Omit<SessionsListParams, "search"> & { search?: never };
-      agentIdBySessionKey?: never;
+      targetsBySessionKey?: never;
     };
 
 type ListSessionsFromStoreParams = {
@@ -87,7 +88,7 @@ type ListSessionsFromStoreParams = {
   storePath: string;
   store: Record<string, SessionEntry>;
   // Sentinels retain the first projected store's owner; their raw key cannot recover it.
-  agentIdBySessionKey: ReadonlyMap<string, string>;
+  targetsBySessionKey: GatewayStoredSessionTargets;
   modelCatalog?: SessionListModelCatalog | ModelCatalogEntry[];
   opts: SessionsListParams;
   involvingActorId?: string;
@@ -138,7 +139,7 @@ function resolveSessionsListWindowLimit(limit: number | undefined, offset: numbe
 function filterSessionEntries(params: {
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
-  agentIdBySessionKey?: ReadonlyMap<string, string>;
+  targetsBySessionKey?: GatewayStoredSessionTargets;
   opts: SessionsListParams;
   now: number;
   userProfileIdentityById?: Map<string, SessionActorProfileIdentity | undefined>;
@@ -281,7 +282,7 @@ function filterSessionEntries(params: {
         search,
         now,
         visibleEntries: candidateEntries,
-        agentIdBySessionKey: expectDefined(params.agentIdBySessionKey, "search row owners"),
+        targetsBySessionKey: expectDefined(params.targetsBySessionKey, "search row owners"),
         getRowContext: params.getRowContext,
         projectActiveRun: params.projectActiveRun,
       })
@@ -375,7 +376,7 @@ function isPhantomAgentStoreListEntry(key: string, entry: SessionEntry | undefin
 function selectSessionEntries(params: {
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
-  agentIdBySessionKey?: ReadonlyMap<string, string>;
+  targetsBySessionKey?: GatewayStoredSessionTargets;
   opts: SessionsListParams;
   now: number;
   getRowContext?: SessionListRowContextProvider;
@@ -445,7 +446,7 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
   const selection = selectSessionEntries({
     cfg,
     store,
-    agentIdBySessionKey: params.agentIdBySessionKey,
+    targetsBySessionKey: params.targetsBySessionKey,
     opts,
     now,
     entryFilter,
@@ -483,7 +484,7 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
   populateSessionListAcpMetadata({
     cfg,
     entries: selection.entries,
-    agentIdBySessionKey: params.agentIdBySessionKey,
+    targetsBySessionKey: params.targetsBySessionKey,
     rowContext: sharedRowContext,
   });
   return {
@@ -579,7 +580,7 @@ export async function listSessionsFromStoreAsync(
   // loadPluginMetadataSnapshot scan (~100 ms).
   return withPinnedActivePluginRegistryWorkspaceDir(async () => {
     let workStartedAt = performance.now();
-    const { cfg, store, agentIdBySessionKey } = params;
+    const { cfg, store, targetsBySessionKey } = params;
     const list = prepareSessionList(params);
     const sessions: GatewaySessionRow[] = [];
     const transcriptScopes = list.entries
@@ -590,11 +591,10 @@ export async function listSessionsFromStoreAsync(
         }
         return [
           {
-            agentId: expectDefined(agentIdBySessionKey.get(key), "transcript row owner"),
+            ...expectDefined(targetsBySessionKey.get(key), "transcript row target").storeTarget,
             sessionEntry: entry,
             sessionId: entry.sessionId,
             sessionKey: key,
-            storePath: list.storePath,
           },
         ];
       });
@@ -609,7 +609,7 @@ export async function listSessionsFromStoreAsync(
         store,
         key,
         entry,
-        agentId: expectDefined(agentIdBySessionKey.get(key), "session row owner"),
+        agentId: expectDefined(targetsBySessionKey.get(key), "session row owner").agentId,
         modelCatalog: params.modelCatalog,
         now: list.now,
         includeDerivedTitles: false,

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -250,7 +250,7 @@ export function resolveGatewaySessionRuntimeProjection(
         : readAcpSessionMeta({ sessionKey, agentId }));
   const agentRuntime = resolveCurrentSessionAgentRuntimeMetadata({
     cfg: params.cfg,
-    agentId: params.agentId,
+    agentScope: { kind: "prepared", agentId: params.agentId },
     provider: params.provider,
     model: params.model,
     sessionKey: params.sessionKey,
@@ -279,7 +279,7 @@ export function resolveGatewaySessionThinkingProjectionInternal(
         modelId: params.model,
         modelApi: catalogEntry?.api,
         modelBaseUrl: catalogEntry?.baseUrl,
-        agentId: params.agentId,
+        agentScope: { kind: "prepared", agentId: params.agentId },
         sessionKey: params.sessionKey,
         sessionEntry: params.entry,
       });

--- a/src/gateway/session-utils-owners.test.ts
+++ b/src/gateway/session-utils-owners.test.ts
@@ -37,7 +37,7 @@ vi.mock("../state/user-profiles.js", async (importOriginal) => ({
   getUserProfileDisplay,
 }));
 
-import { listSessionsFromStoreAsync } from "./session-utils.js";
+import { listSessionFixture } from "./session-list.test-support.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -64,7 +64,7 @@ it("lets configured agents win id-only owner facet collisions", async () => {
         } satisfies SessionEntry,
       ]),
     );
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg: {
         agents: { list: [{ id: "shared-id", identity: { name: "Shared agent" } }] },
       } as OpenClawConfig,
@@ -102,7 +102,7 @@ it("returns the complete deterministic owner facet independently of pagination",
     },
   };
 
-  const result = await listSessionsFromStoreAsync({
+  const result = await listSessionFixture({
     cfg: {} as OpenClawConfig,
     storePath: "/tmp/openclaw-session-owners",
     store,
@@ -141,7 +141,7 @@ it("returns the complete deterministic owner facet independently of pagination",
   });
   expect(getUserProfileDisplay).toHaveBeenCalledTimes(2);
 
-  const filtered = await listSessionsFromStoreAsync({
+  const filtered = await listSessionFixture({
     cfg: {} as OpenClawConfig,
     storePath: "/tmp/openclaw-session-owners",
     store,
@@ -167,7 +167,7 @@ it("prepends an owner window without advancing shared-page pagination", async ()
     },
   };
 
-  const result = await listSessionsFromStoreAsync({
+  const result = await listSessionFixture({
     cfg: {} as OpenClawConfig,
     storePath: "/tmp/openclaw-session-owner-first",
     store,
@@ -225,7 +225,7 @@ it("projects only durable profiles and configured agents as effective owners", a
       } satisfies SessionEntry,
     ]),
   );
-  const result = await listSessionsFromStoreAsync({
+  const result = await listSessionFixture({
     cfg: {
       agents: {
         list: [
@@ -308,7 +308,7 @@ it("filters immutable creator and effective owner separately while preserving pr
       updatedAt: 0,
     },
   } satisfies Record<string, SessionEntry>;
-  const result = await listSessionsFromStoreAsync({
+  const result = await listSessionFixture({
     cfg: {} as OpenClawConfig,
     storePath: "/tmp/openclaw-session-owners",
     store,
@@ -342,7 +342,7 @@ it("filters immutable creator and effective owner separately while preserving pr
       label: "Bob",
     },
   ]);
-  const creatorFiltered = await listSessionsFromStoreAsync({
+  const creatorFiltered = await listSessionFixture({
     cfg: {} as OpenClawConfig,
     storePath: "/tmp/openclaw-session-owners",
     store,
@@ -358,7 +358,7 @@ it("filters immutable creator and effective owner separately while preserving pr
       owner: { actor: { id: "profile-bob", label: "Bob" } },
     },
   );
-  const ownerFiltered = await listSessionsFromStoreAsync({
+  const ownerFiltered = await listSessionFixture({
     cfg: {} as OpenClawConfig,
     storePath: "/tmp/openclaw-session-owners",
     store,
@@ -406,9 +406,9 @@ it("filters immutable creator and effective owner separately while preserving pr
       opts: { creatorId: "profile-ada" },
     };
     expect
-      .soft((await listSessionsFromStoreAsync(query)).sessions.map((row) => row.key))
+      .soft((await listSessionFixture(query)).sessions.map((row) => row.key))
       .toEqual(["agent:main:shared", "agent:main:draft"]);
-    const authorized = await listSessionsFromStoreAsync({ ...query, entryFilter });
+    const authorized = await listSessionFixture({ ...query, entryFilter });
     expect
       .soft(authorized.sessions.map((row) => row.key))
       .toEqual(
@@ -483,7 +483,7 @@ it("deduplicates participants in order, excludes the owner, and filters sessions
   const cfg: OpenClawConfig = {
     agents: { list: [{ id: "research", identity: { name: "Research" } }] },
   };
-  const result = await listSessionsFromStoreAsync({
+  const result = await listSessionFixture({
     cfg,
     storePath: "/tmp/openclaw-session-participants",
     store,
@@ -512,7 +512,7 @@ it("deduplicates participants in order, excludes the owner, and filters sessions
     participantCount: 5,
   });
 
-  const unfiltered = await listSessionsFromStoreAsync({
+  const unfiltered = await listSessionFixture({
     cfg,
     storePath: "/tmp/openclaw-session-participants",
     store,
@@ -530,7 +530,7 @@ it("deduplicates participants in order, excludes the owner, and filters sessions
     expect(participant).not.toHaveProperty("label");
     expect(participant).not.toHaveProperty("avatarUrl");
   }
-  const selected = await listSessionsFromStoreAsync({
+  const selected = await listSessionFixture({
     cfg,
     storePath: "/tmp/openclaw-session-participants",
     store,
@@ -603,7 +603,7 @@ it.each(["spawn", "talk", "cron"] as const)(
       store,
       opts: { archived: "all" as const, includePeople: true },
     };
-    const all = await listSessionsFromStoreAsync(query);
+    const all = await listSessionFixture(query);
     const creator = {
       type: "human",
       id: "former",
@@ -625,7 +625,7 @@ it.each(["spawn", "talk", "cron"] as const)(
       });
       expect(row.owner).toBeUndefined();
     }
-    const involving = await listSessionsFromStoreAsync({ ...query, involvingActorId: "current" });
+    const involving = await listSessionFixture({ ...query, involvingActorId: "current" });
     expect(involving.sessions.map((row) => row.key)).toEqual(["agent:main:historical", childKey]);
     expect(involving.sessions[0]?.participants).toEqual([
       { identity: { type: "profile", id: "current" }, label: "Current" },
@@ -633,7 +633,7 @@ it.each(["spawn", "talk", "cron"] as const)(
     expect(involving.people).toEqual([
       { identity: { type: "profile", id: "current" }, label: "Current", sessionCount: 2 },
     ]);
-    const ownerFirst = await listSessionsFromStoreAsync({
+    const ownerFirst = await listSessionFixture({
       ...query,
       opts: { archived: "all", limit: 1 },
       ownerFirstActorId: "current",
@@ -642,7 +642,7 @@ it.each(["spawn", "talk", "cron"] as const)(
 
     // Reassignment must not erase the creator's Activity association or fabricate their input.
     child.owner = { actor: { type: "agent", id: "main" } };
-    const associated = await listSessionsFromStoreAsync({
+    const associated = await listSessionFixture({
       ...query,
       opts: { ...query.opts, involvingProfileId: "former" },
     });
@@ -684,20 +684,20 @@ it("returns a canonical selected person and orders merged owners without borrowi
     store,
     opts: { archived: "all" as const, includePeople: true, involvingProfileId: "former", limit: 1 },
   };
-  const result = await listSessionsFromStoreAsync(query);
+  const result = await listSessionFixture(query);
   expect(result).toMatchObject({
     involvingProfileId: "current",
     totalCount: 1,
     peopleIncomplete: true,
   });
   expect(result.people?.some((person) => person.identity.id === "current")).toBe(true);
-  const ordered = await listSessionsFromStoreAsync({
+  const ordered = await listSessionFixture({
     ...query,
     opts: { archived: "all", limit: 1 },
     ownerFirstActorId: "current",
   });
   expect(ordered.sessions[0]?.key).toBe("agent:main:owned");
-  const involved = await listSessionsFromStoreAsync({
+  const involved = await listSessionFixture({
     ...query,
     opts: { archived: "all" },
     involvingActorId: "current",
@@ -706,7 +706,7 @@ it("returns a canonical selected person and orders merged owners without borrowi
 });
 
 it("reports the authoritative admission bound even when the visible participant list is smaller", async () => {
-  const result = await listSessionsFromStoreAsync({
+  const result = await listSessionFixture({
     cfg: {},
     storePath: "/tmp/openclaw-session-bound",
     store: {
@@ -821,9 +821,10 @@ it("preserves list output across visibility, scope, owner, and search filters", 
   } as GatewayClient;
   const entryFilter = createSessionListEntryFilter({ client: viewer });
 
-  const project = async (opts: Parameters<typeof listSessionsFromStoreAsync>[0]["opts"]) => {
-    const result = await listSessionsFromStoreAsync({
+  const project = async (opts: Parameters<typeof listSessionFixture>[0]["opts"]) => {
+    const result = await listSessionFixture({
       cfg,
+      fixtureAgentId: "main",
       ...(entryFilter ? { entryFilter } : {}),
       opts,
       store,
@@ -910,7 +911,8 @@ it("preserves list output across visibility, scope, owner, and search filters", 
 
 it("keeps the serialized list response deterministic for the current filter path", async () => {
   vi.spyOn(Date, "now").mockReturnValue(1_000_000);
-  const result = await listSessionsFromStoreAsync({
+  const result = await listSessionFixture({
+    fixtureAgentId: "main",
     cfg: {
       agents: {
         defaults: { model: { primary: "openai/gpt-5.4" } },

--- a/src/gateway/session-utils-profile-reference.test.ts
+++ b/src/gateway/session-utils-profile-reference.test.ts
@@ -10,8 +10,8 @@ import {
 } from "../state/openclaw-state-db.js";
 import { ensureProfileForEmail, linkEmail, resolveUserProfileId } from "../state/user-profiles.js";
 import type { GatewayClient } from "./server-methods/types.js";
+import { listSessionFixture } from "./session-list.test-support.js";
 import { createSessionListEntryFilter } from "./session-sharing.js";
-import { listSessionsFromStoreAsync } from "./session-utils.js";
 
 const roots = createTempDirTracker();
 let stateRoot: string;
@@ -41,7 +41,7 @@ function listActivity(
   involvingProfileId: string,
   options: Partial<SessionsListParams> = {},
 ) {
-  return listSessionsFromStoreAsync({
+  return listSessionFixture({
     cfg: {},
     storePath: stateRoot,
     store: Object.fromEntries(
@@ -151,7 +151,7 @@ it.each(["12345678-a123-4123-8123-123456789abc", "12345678-A123-4123-8123-123456
 
 it("resolves qualified retained creators without treating legacy human IDs as profiles", async () => {
   const retained = "12345678-a123-4123-8123-123456789abc";
-  const result = await listSessionsFromStoreAsync({
+  const result = await listSessionFixture({
     cfg: {},
     storePath: stateRoot,
     store: {
@@ -227,7 +227,7 @@ it.each([
   };
   for (const reference of ["12345678a123", hiddenId, hiddenId.replaceAll("-", "")]) {
     entryFilter.mockClear();
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg: {},
       storePath: stateRoot,
       store,
@@ -257,7 +257,7 @@ it("resolves merge aliases for visible owners without considering hidden profile
       authenticatedUserProfile: { profileId: target },
     } as GatewayClient,
   });
-  const result = await listSessionsFromStoreAsync({
+  const result = await listSessionFixture({
     cfg: {},
     storePath: stateRoot,
     entryFilter,

--- a/src/gateway/session-utils-projection.ts
+++ b/src/gateway/session-utils-projection.ts
@@ -9,6 +9,7 @@ import {
 } from "../agents/session-model-ref.js";
 import { buildSubagentSessionListReadIndex } from "../agents/subagents/registry/subagent-registry-read.js";
 import { resolveSessionStorePathCore, type SessionEntry } from "../config/sessions.js";
+import type { GatewayStoredSessionTargets } from "../config/sessions/combined-store-gateway.js";
 import { resolveConcreteSessionStorePath } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -213,7 +214,7 @@ export function resolveTranscriptUsageFallback(params: {
 export function populateSessionListAcpMetadata(params: {
   cfg: OpenClawConfig;
   entries: readonly SessionEntryPair[];
-  agentIdBySessionKey: ReadonlyMap<string, string>;
+  targetsBySessionKey: GatewayStoredSessionTargets;
   rowContext?: SessionListRowContext;
 }): void {
   const metadataByEntry = params.rowContext?.acpSessionMetaByEntry;
@@ -223,7 +224,7 @@ export function populateSessionListAcpMetadata(params: {
   const entries = params.entries
     .filter(([, entry]) => !metadataByEntry.has(entry))
     .map(([key, entry]) => {
-      const agentId = expectDefined(params.agentIdBySessionKey.get(key), "ACP row owner");
+      const agentId = expectDefined(params.targetsBySessionKey.get(key), "ACP row owner").agentId;
       return {
         sessionKey: resolveStoredSessionKeyForAgentStore({
           cfg: params.cfg,

--- a/src/gateway/session-utils-projection.ts
+++ b/src/gateway/session-utils-projection.ts
@@ -1,5 +1,5 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import type { SessionsListParams } from "../../packages/gateway-protocol/src/index.js";
 import { readAcpSessionMetaBatch } from "../acp/runtime/session-meta.js";
 import { readSessionRuntimeOwnership } from "../agents/harness/session-runtime-ownership.js";
 import { normalizeStoredOverrideModel } from "../agents/model-selection.js";
@@ -11,12 +11,9 @@ import { buildSubagentSessionListReadIndex } from "../agents/subagents/registry/
 import { resolveSessionStorePathCore, type SessionEntry } from "../config/sessions.js";
 import { resolveConcreteSessionStorePath } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import type { SessionEntryPair } from "./session-list-order.js";
-import {
-  resolveSessionStoreAgentId,
-  resolveStoredSessionKeyForAgentStore,
-} from "./session-store-key.js";
+import { resolveStoredSessionKeyForAgentStore } from "./session-store-key.js";
 import { readRecentSessionUsageFromTranscript as readScopedRecentSessionUsageFromTranscript } from "./session-transcript-readers.js";
 import type {
   SessionActorProfileIdentity,
@@ -216,7 +213,7 @@ export function resolveTranscriptUsageFallback(params: {
 export function populateSessionListAcpMetadata(params: {
   cfg: OpenClawConfig;
   entries: readonly SessionEntryPair[];
-  opts: SessionsListParams;
+  agentIdBySessionKey: ReadonlyMap<string, string>;
   rowContext?: SessionListRowContext;
 }): void {
   const metadataByEntry = params.rowContext?.acpSessionMetaByEntry;
@@ -226,10 +223,7 @@ export function populateSessionListAcpMetadata(params: {
   const entries = params.entries
     .filter(([, entry]) => !metadataByEntry.has(entry))
     .map(([key, entry]) => {
-      const parsed = parseAgentSessionKey(key);
-      const agentId = normalizeAgentId(
-        parsed?.agentId ?? params.opts.agentId ?? resolveSessionStoreAgentId(params.cfg, key),
-      );
+      const agentId = expectDefined(params.agentIdBySessionKey.get(key), "ACP row owner");
       return {
         sessionKey: resolveStoredSessionKeyForAgentStore({
           cfg: params.cfg,

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -26,7 +26,6 @@ import {
 } from "../config/sessions/session-entry-provenance.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { projectPluginSessionExtensionsSync } from "../plugins/host-hook-state.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveActiveSessionAgentStatus } from "../sessions/session-agent-status.js";
 import { resolveActiveFallbackState } from "../status/fallback-notice-state.js";
 import { projectSessionDeliveryFields } from "../utils/delivery-context.shared.js";
@@ -41,10 +40,7 @@ import {
   projectSessionParticipants,
 } from "./session-identity-projection.js";
 import { isSessionPermissionChangePending } from "./session-permission-change.js";
-import {
-  resolveSessionStoreAgentId,
-  resolveStoredSessionKeyForAgentStore,
-} from "./session-store-key.js";
+import { resolveStoredSessionKeyForAgentStore } from "./session-store-key.js";
 import { readSessionTitleFieldsFromTranscript as readScopedSessionTitleFieldsFromTranscript } from "./session-transcript-title-reader.js";
 import type { SessionListRowContext } from "./session-utils-contracts.js";
 import {
@@ -96,7 +92,7 @@ export function buildGatewaySessionRow(params: {
   storeChildSessionsByKey?: Map<string, string[]>;
   rowContext?: SessionListRowContext;
   configuredAgentIds?: ReadonlySet<string>;
-  agentId?: string;
+  agentId: string;
   skipTranscriptUsageFallback?: boolean;
   lightweightListRow?: boolean;
 }): GatewaySessionRow {
@@ -142,11 +138,8 @@ export function buildGatewaySessionRow(params: {
   const channelAvatarUrl = avatar
     ? buildControlUiChannelAvatarUrl(controlUiBasePath, key, channelAvatarRevision(avatar))
     : undefined;
-  const parsedAgent = parseAgentSessionKey(key);
   const displayName = resolveGatewaySessionDisplayName(key, entry);
-  const sessionAgentId = normalizeAgentId(
-    parsedAgent?.agentId ?? params.agentId ?? resolveSessionStoreAgentId(cfg, key),
-  );
+  const sessionAgentId = params.agentId;
   const skipTranscriptUsage = params.skipTranscriptUsageFallback === true;
   const rowContext = params.rowContext;
   const {

--- a/src/gateway/session-utils-search.ts
+++ b/src/gateway/session-utils-search.ts
@@ -1,3 +1,4 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -11,14 +12,12 @@ import {
   type SessionEntry,
 } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { formatAgentRuntimeLabel } from "../shared/agent-runtime-display.js";
 import { formatGoalSummary } from "../shared/session-goal-display.js";
 import { isSessionRunActive } from "../shared/session-run-state.js";
 import { sessionDeliveryChannel, sessionDeliveryOrigin } from "../utils/delivery-context.shared.js";
 import { resolveAssistantIdentity } from "./assistant-identity.js";
 import type { SessionEntryPair } from "./session-list-order.js";
-import { resolveSessionStoreAgentId } from "./session-store-key.js";
 import type {
   SessionListActiveRunProjector,
   SessionListRowContext,
@@ -102,17 +101,14 @@ export function resolveSessionListRowContext(params: {
 }
 
 function resolveSessionListSearchModelFields(params: {
-  agentId?: string;
+  agentId: string;
   cfg: OpenClawConfig;
   key: string;
   entry?: SessionEntry;
   rowContext?: SessionListRowContext;
   selectedModel?: ReturnType<typeof resolveSessionSelectedModelRef>;
 }): Array<string | undefined> {
-  const parsedAgent = parseAgentSessionKey(params.key);
-  const agentId = normalizeAgentId(
-    parsedAgent?.agentId ?? params.agentId ?? resolveSessionStoreAgentId(params.cfg, params.key),
-  );
+  const { agentId } = params;
   const subagentRun = params.rowContext
     ? params.rowContext.subagentRuns.getDisplaySubagentRun(params.key)
     : getSessionDisplaySubagentRunByChildSessionKey(params.key);
@@ -154,7 +150,7 @@ function resolveSessionListSearchModelFields(params: {
 export function createSessionListSearchMatcher(params: {
   cfg: OpenClawConfig;
   search: string;
-  agentId?: string;
+  agentIdBySessionKey: ReadonlyMap<string, string>;
   now: number;
   visibleEntries: readonly SessionEntryPair[];
   getRowContext?: SessionListRowContextProvider;
@@ -181,9 +177,7 @@ export function createSessionListSearchMatcher(params: {
     if (matchesSessionListSearch(fields, search)) {
       return true;
     }
-    const agentId = normalizeAgentId(
-      parseAgentSessionKey(key)?.agentId ?? params.agentId ?? resolveSessionStoreAgentId(cfg, key),
-    );
+    const agentId = expectDefined(params.agentIdBySessionKey.get(key), "search row owner");
     const run = projectGatewaySessionRunState({ key, entry, now, rowContext: context() }).fields;
     const active = params.projectActiveRun?.(key, entry, agentId);
     const state = projectGatewaySessionActiveRun(active, run.status);
@@ -240,7 +234,7 @@ export function createSessionListSearchMatcher(params: {
       populateSessionListAcpMetadata({
         cfg,
         entries: params.visibleEntries,
-        opts: { agentId: params.agentId },
+        agentIdBySessionKey: params.agentIdBySessionKey,
         rowContext: context(),
       });
       acpPrepared = true;
@@ -272,12 +266,12 @@ function loadGatewaySessionSnapshot(
   lightweight = false,
 ): { lifecycleRunId?: string; row: GatewaySessionRow | null } {
   const now = options?.now ?? Date.now();
-  const { cfg, storePath, store, entry, canonicalKey } = loadGatewaySessionEntryReadOnly(
+  const { cfg, agentId, storePath, store, entry, canonicalKey } = loadGatewaySessionEntryReadOnly(
     sessionKey,
     {
       clone: false,
       includeStoreChildEntries: true,
-      ...(options?.agentId ? { agentId: options.agentId } : {}),
+      agentId: options?.agentId,
     },
   );
   if (!entry) {
@@ -304,7 +298,7 @@ function loadGatewaySessionSnapshot(
       storeChildSessionsByKey,
       skipTranscriptUsageFallback: lightweight,
       lightweightListRow: lightweight,
-      ...(options?.agentId ? { agentId: options.agentId } : {}),
+      agentId,
     }),
   };
 }
@@ -329,7 +323,7 @@ export function buildGatewaySessionInfo(params: {
   store: Record<string, SessionEntry>;
   key: string;
   entry?: SessionEntry;
-  agentId?: string;
+  agentId: string;
   now?: number;
   modelCatalog?: ModelCatalogEntry[];
 }): GatewaySessionRow {

--- a/src/gateway/session-utils-search.ts
+++ b/src/gateway/session-utils-search.ts
@@ -11,6 +11,7 @@ import {
   type InternalSessionEntry,
   type SessionEntry,
 } from "../config/sessions.js";
+import type { GatewayStoredSessionTargets } from "../config/sessions/combined-store-gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatAgentRuntimeLabel } from "../shared/agent-runtime-display.js";
 import { formatGoalSummary } from "../shared/session-goal-display.js";
@@ -150,7 +151,7 @@ function resolveSessionListSearchModelFields(params: {
 export function createSessionListSearchMatcher(params: {
   cfg: OpenClawConfig;
   search: string;
-  agentIdBySessionKey: ReadonlyMap<string, string>;
+  targetsBySessionKey: GatewayStoredSessionTargets;
   now: number;
   visibleEntries: readonly SessionEntryPair[];
   getRowContext?: SessionListRowContextProvider;
@@ -177,7 +178,7 @@ export function createSessionListSearchMatcher(params: {
     if (matchesSessionListSearch(fields, search)) {
       return true;
     }
-    const agentId = expectDefined(params.agentIdBySessionKey.get(key), "search row owner");
+    const agentId = expectDefined(params.targetsBySessionKey.get(key), "search row owner").agentId;
     const run = projectGatewaySessionRunState({ key, entry, now, rowContext: context() }).fields;
     const active = params.projectActiveRun?.(key, entry, agentId);
     const state = projectGatewaySessionActiveRun(active, run.status);
@@ -234,7 +235,7 @@ export function createSessionListSearchMatcher(params: {
       populateSessionListAcpMetadata({
         cfg,
         entries: params.visibleEntries,
-        agentIdBySessionKey: params.agentIdBySessionKey,
+        targetsBySessionKey: params.targetsBySessionKey,
         rowContext: context(),
       });
       acpPrepared = true;

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -106,7 +106,6 @@ function buildGatewaySessionStoreScanTargets(params: {
 type GatewaySessionStoreDiscovery = {
   existing: SessionStoreTarget[];
   fallback: SessionStoreTarget;
-  prepared?: true;
 };
 
 function resolveGatewaySessionStoreCandidates(
@@ -136,41 +135,6 @@ function resolveGatewaySessionStoreCandidates(
  * Keep discovery agent-scoped here or each row repeats registry probes and agent-root scans.
  */
 export type GatewaySessionStoreDiscoveryCache = Map<string, GatewaySessionStoreDiscovery>;
-
-export function createGatewaySessionStoreDiscoveryCache(params: {
-  cfg: OpenClawConfig;
-  targets: readonly SessionStoreTarget[];
-  agentIds: Iterable<string>;
-}): GatewaySessionStoreDiscoveryCache {
-  const cache: GatewaySessionStoreDiscoveryCache = new Map();
-  const prepare = (rawAgentId: string, target?: SessionStoreTarget) => {
-    const agentId = normalizeAgentId(rawAgentId);
-    const current = cache.get(agentId);
-    if (current) {
-      if (target) {
-        current.existing.push(target);
-      }
-      return;
-    }
-    const fallback = {
-      agentId,
-      storePath: resolveSessionStorePathCore(params.cfg.session?.store, { agentId }),
-    };
-    const existing = target
-      ? [target]
-      : params.targets.length > 0
-        ? [...params.targets]
-        : [fallback];
-    cache.set(agentId, { existing, fallback, prepared: true });
-  };
-  for (const target of params.targets) {
-    prepare(target.agentId, target);
-  }
-  for (const agentId of params.agentIds) {
-    prepare(agentId);
-  }
-  return cache;
-}
 
 type GatewaySessionStoreLookupParams = {
   cfg: OpenClawConfig;
@@ -210,11 +174,9 @@ function prepareGatewaySessionStoreLookup(
   );
   const { existing, fallback } = discovery;
   const configured = isConfiguredSessionStoreAgentId(params.cfg, params.agentId);
-  const candidates = discovery.prepared
-    ? existing
-    : configured
-      ? [fallback, ...existing.filter((target) => target.storePath !== fallback.storePath)]
-      : existing;
+  const candidates = configured
+    ? [fallback, ...existing.filter((target) => target.storePath !== fallback.storePath)]
+    : existing;
   if (candidates.length === 0) {
     // Retired/manual agents require an existing discovered store; lookup never creates one.
     return {
@@ -458,9 +420,8 @@ export function resolveGatewaySessionStoreTargetWithStore(
 export function resolveGatewaySessionStoreTargetsReadOnly(params: {
   cfg: OpenClawConfig;
   targets: readonly { key: string; agentId?: string }[];
-  targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
 }): GatewaySessionStoreTargetWithStore[] {
-  const targetDiscoveryCache = params.targetDiscoveryCache ?? new Map();
+  const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
   const requests = params.targets.map((target) => {
     const lookup: GatewaySessionStoreLookupParams = {
       ...target,

--- a/src/gateway/session-utils.child-cache-retention.test-support.ts
+++ b/src/gateway/session-utils.child-cache-retention.test-support.ts
@@ -27,6 +27,10 @@ async function populate() {
   retired.push(new WeakRef(parent), new WeakRef(child));
   return listSessionsFromStoreAsync({
     cfg,
+    agentIdBySessionKey: new Map([
+      [parentKey, "main"],
+      [childKey, "main"],
+    ]),
     storePath: "retired",
     store: { [parentKey]: parent, [childKey]: child },
     modelCatalog: [],

--- a/src/gateway/session-utils.child-cache-retention.test-support.ts
+++ b/src/gateway/session-utils.child-cache-retention.test-support.ts
@@ -27,9 +27,9 @@ async function populate() {
   retired.push(new WeakRef(parent), new WeakRef(child));
   return listSessionsFromStoreAsync({
     cfg,
-    agentIdBySessionKey: new Map([
-      [parentKey, "main"],
-      [childKey, "main"],
+    targetsBySessionKey: new Map([
+      [parentKey, { agentId: "main", storeTarget: { agentId: "main", storePath: "retired" } }],
+      [childKey, { agentId: "main", storeTarget: { agentId: "main", storePath: "retired" } }],
     ]),
     storePath: "retired",
     store: { [parentKey]: parent, [childKey]: child },

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -19,12 +19,12 @@ import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { ensureProfileForEmail } from "../state/user-profiles.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import * as usageFormat from "../utils/usage-format.js";
+import { listSessionFixture } from "./session-list.test-support.js";
 import * as titleReader from "./session-transcript-title-reader.js";
 import { resolveEstimatedSessionCostUsd } from "./session-utils-core.js";
 import { resolveGatewaySessionThinkingProjectionInternal } from "./session-utils-model.js";
 import { buildSessionListRowMetadataContext } from "./session-utils-projection.js";
 import * as rowProjection from "./session-utils-row.js";
-import { listSessionsFromStoreAsync } from "./session-utils.js";
 
 /**
  * Regression smoke for the per-list rowContext resolver cache. The bug we are
@@ -74,7 +74,7 @@ describe("session list resolver cache", () => {
           });
         });
         try {
-          const result = await listSessionsFromStoreAsync({
+          const result = await listSessionFixture({
             cfg,
             storePath: path.join(stateDir, "sessions.json"),
             store,
@@ -310,7 +310,7 @@ describe("session list resolver cache", () => {
         expect(acpSelects).toBe(3);
 
         acpSelects = 0;
-        const result = await listSessionsFromStoreAsync({
+        const result = await listSessionFixture({
           cfg,
           storePath: path.join(stateDir, "agents", "default", "sessions", "sessions.json"),
           store: {
@@ -326,7 +326,7 @@ describe("session list resolver cache", () => {
           acpSelects = 0;
           const rows = vi.spyOn(rowProjection, "buildGatewaySessionRow");
           try {
-            const searched = await listSessionsFromStoreAsync({
+            const searched = await listSessionFixture({
               cfg,
               storePath: path.join(stateDir, "agents", "default", "sessions", "sessions.json"),
               store: Object.fromEntries(
@@ -397,7 +397,7 @@ describe("session list resolver cache", () => {
           })),
         );
       try {
-        const result = await listSessionsFromStoreAsync({
+        const result = await listSessionFixture({
           cfg,
           storePath,
           store,
@@ -419,7 +419,7 @@ describe("session list resolver cache", () => {
         });
 
         titleBatchSpy.mockClear();
-        await listSessionsFromStoreAsync({
+        await listSessionFixture({
           cfg,
           storePath,
           store,

--- a/src/gateway/session-utils.plugin-runtime.test.ts
+++ b/src/gateway/session-utils.plugin-runtime.test.ts
@@ -59,6 +59,7 @@ describe("gateway session list plugin runtime normalization", () => {
 
     const listed = await sessionUtils.listSessionsFromStoreAsync({
       cfg,
+      agentIdBySessionKey: new Map(Object.keys(store).map((key) => [key, "main"])),
       storePath: "",
       store,
       opts: {},
@@ -90,6 +91,7 @@ describe("gateway session list plugin runtime normalization", () => {
 
     const row = sessionUtils.buildGatewaySessionRow({
       cfg,
+      agentId: "main",
       storePath: "",
       store: {},
       key: "main",

--- a/src/gateway/session-utils.plugin-runtime.test.ts
+++ b/src/gateway/session-utils.plugin-runtime.test.ts
@@ -59,7 +59,12 @@ describe("gateway session list plugin runtime normalization", () => {
 
     const listed = await sessionUtils.listSessionsFromStoreAsync({
       cfg,
-      agentIdBySessionKey: new Map(Object.keys(store).map((key) => [key, "main"])),
+      targetsBySessionKey: new Map(
+        Object.keys(store).map((key) => [
+          key,
+          { agentId: "main", storeTarget: { agentId: "main", storePath: "" } },
+        ]),
+      ),
       storePath: "",
       store,
       opts: {},

--- a/src/gateway/session-utils.search.test.ts
+++ b/src/gateway/session-utils.search.test.ts
@@ -60,9 +60,11 @@ function selectSessionKeys(params: {
   now?: number;
 }): string[] {
   const now = params.now ?? Date.now();
+  const store = params.store ?? makeStore(now);
   return filterAndSortSessionEntries({
     cfg: params.cfg ?? baseCfg,
-    store: params.store ?? makeStore(now),
+    store,
+    agentIdBySessionKey: new Map(Object.keys(store).map((key) => [key, "main"])),
     opts: params.opts,
     now,
   }).map(([key]) => key);

--- a/src/gateway/session-utils.search.test.ts
+++ b/src/gateway/session-utils.search.test.ts
@@ -64,7 +64,12 @@ function selectSessionKeys(params: {
   return filterAndSortSessionEntries({
     cfg: params.cfg ?? baseCfg,
     store,
-    agentIdBySessionKey: new Map(Object.keys(store).map((key) => [key, "main"])),
+    targetsBySessionKey: new Map(
+      Object.keys(store).map((key) => [
+        key,
+        { agentId: "main", storeTarget: { agentId: "main", storePath: "" } },
+      ]),
+    ),
     opts: params.opts,
     now,
   }).map(([key]) => key);

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -76,10 +76,11 @@ const subagentRegistryReadMock = vi.hoisted(() => {
 
 vi.mock("../agents/subagents/registry/subagent-registry-read.js", () => subagentRegistryReadMock);
 
+import { listSessionFixture } from "./session-list.test-support.js";
 import {
   buildGatewaySessionInfo,
-  listSessionsFromStoreAsync,
   loadGatewaySessionEntryReadOnly,
+  loadGatewaySessionLifecycleSnapshot,
   loadGatewaySessionRow,
   loadSessionEntry,
 } from "./session-utils.js";
@@ -217,6 +218,42 @@ describe("single gateway session row child projections", () => {
     resetPluginRuntimeStateForTest();
     subagentRegistryReadMock.setSubagentRunsForTest([]);
     vi.clearAllMocks();
+  });
+
+  test("retains the loaded owner after a qualified main alias becomes global", async () => {
+    await withStateDirEnv("openclaw-single-row-global-owner-", async () => {
+      const cfg: OpenClawConfig = {
+        session: { scope: "global" },
+        agents: {
+          entries: {
+            main: { default: true, model: { primary: "openai/gpt-5.4" } },
+            research: { model: { primary: "openai/gpt-5.5" } },
+          },
+        },
+      };
+      setRuntimeConfigSnapshot(cfg, cfg);
+      await replaceSessionEntry(
+        { agentId: "research", sessionKey: "global" },
+        { sessionId: "research-main", updatedAt: 42 },
+      );
+      const key = "agent:research:main";
+      expect(loadGatewaySessionEntryReadOnly(key)).toMatchObject({
+        agentId: "research",
+        canonicalKey: "global",
+        entry: { sessionId: "research-main" },
+      });
+      expect.soft(loadGatewaySessionLifecycleSnapshot(key).row).toMatchObject({
+        key: "global",
+        sessionId: "research-main",
+        agentId: "research",
+        model: "gpt-5.5",
+      });
+      expect(loadGatewaySessionRow(key, { agentId: "research" })).toMatchObject({
+        key: "global",
+        agentId: "research",
+        model: "gpt-5.5",
+      });
+    });
   });
 
   test.each([undefined, false])(
@@ -449,7 +486,7 @@ describe("single gateway session row child projections", () => {
           },
         } as OpenClawConfig;
 
-        const asyncListed = await listSessionsFromStoreAsync({
+        const asyncListed = await listSessionFixture({
           cfg,
           storePath,
           store,

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -27,9 +27,9 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { listSessionFixture } from "./session-list.test-support.js";
 import { buildSingleRowStoreChildSessionsByKey } from "./session-utils-projection.js";
 import {
-  listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGatewayCore,
   resolveGatewayModelSupportsImages,
 } from "./session-utils.js";
@@ -64,7 +64,7 @@ describe("session list subagent metadata", () => {
   } as OpenClawConfig;
 
   test("searches channel-derived display names before row enrichment", async () => {
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {
@@ -108,7 +108,7 @@ describe("session list subagent metadata", () => {
     };
     const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
     try {
-      const result = await listSessionsFromStoreAsync({
+      const result = await listSessionFixture({
         cfg,
         storePath: "/tmp/sessions.json",
         store,
@@ -156,7 +156,7 @@ describe("session list subagent metadata", () => {
       startedAt: now - 4_000,
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store: { [childSessionKey]: entry },
@@ -218,7 +218,7 @@ describe("session list subagent metadata", () => {
     });
 
     const listForOwner = async (ownerSessionKey: string) =>
-      await listSessionsFromStoreAsync({
+      await listSessionFixture({
         cfg,
         storePath: "/tmp/sessions.json",
         store,
@@ -234,7 +234,7 @@ describe("session list subagent metadata", () => {
     ]);
     expect((await listForOwner(staleParentKey)).sessions).toEqual([]);
 
-    const all = await listSessionsFromStoreAsync({
+    const all = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -330,7 +330,7 @@ describe("session list subagent metadata", () => {
       model: "openai/gpt-5.4",
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -397,7 +397,7 @@ describe("session list subagent metadata", () => {
       model: "openai/gpt-5.4",
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -483,7 +483,7 @@ describe("session list subagent metadata", () => {
       startedAt: now - 1_500,
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -572,7 +572,7 @@ describe("session list subagent metadata", () => {
       startedAt: now - 1_500,
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -661,7 +661,7 @@ describe("session list subagent metadata", () => {
       startedAt: now - 1_500,
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -709,7 +709,7 @@ describe("session list subagent metadata", () => {
       startedAt: now - 1_500,
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -757,7 +757,7 @@ describe("session list subagent metadata", () => {
       startedAt: now - 1_500,
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -801,7 +801,7 @@ describe("session list subagent metadata", () => {
       sessionKey: "agent:main:subagent:followup",
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -854,7 +854,7 @@ describe("session list subagent metadata", () => {
       model: "openai/gpt-5.4",
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -913,7 +913,7 @@ describe("session list subagent metadata", () => {
         },
         async () => {
           saveSubagentRegistryToSqlite(canonicalSubagentRunFixtures(persistedRuns));
-          const result = await listSessionsFromStoreAsync({
+          const result = await listSessionFixture({
             cfg,
             storePath: "/tmp/sessions.json",
             store: {
@@ -1006,7 +1006,7 @@ describe("session list subagent metadata", () => {
         },
         async () => {
           saveSubagentRegistryToSqlite(canonicalSubagentRunFixtures(persistedRuns));
-          return await listSessionsFromStoreAsync({
+          return await listSessionFixture({
             cfg,
             storePath: "/tmp/sessions.json",
             store,
@@ -1041,7 +1041,7 @@ describe("session list subagent metadata", () => {
           OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_SQLITE: "1",
         },
         async () =>
-          await listSessionsFromStoreAsync({
+          await listSessionFixture({
             cfg,
             storePath: "/tmp/sessions.json",
             store: {
@@ -1078,7 +1078,7 @@ describe("session list subagent metadata", () => {
       } as SessionEntry,
     };
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1106,7 +1106,7 @@ describe("session list subagent metadata", () => {
       } as SessionEntry,
     };
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1136,7 +1136,7 @@ describe("session list subagent metadata", () => {
       } as SessionEntry,
     };
 
-    const all = await listSessionsFromStoreAsync({
+    const all = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1145,7 +1145,7 @@ describe("session list subagent metadata", () => {
     const main = all.sessions.find((session) => session.key === "agent:main:main");
     expect(main?.childSessions).toBeUndefined();
 
-    const filtered = await listSessionsFromStoreAsync({
+    const filtered = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1172,7 +1172,7 @@ describe("session list subagent metadata", () => {
       } as SessionEntry,
     };
 
-    const all = await listSessionsFromStoreAsync({
+    const all = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1181,7 +1181,7 @@ describe("session list subagent metadata", () => {
     const main = all.sessions.find((session) => session.key === "agent:main:main");
     expect(main?.childSessions).toBeUndefined();
 
-    const filtered = await listSessionsFromStoreAsync({
+    const filtered = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1220,7 +1220,7 @@ describe("session list subagent metadata", () => {
       outcome: { status: "ok" },
     });
 
-    const all = await listSessionsFromStoreAsync({
+    const all = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1229,7 +1229,7 @@ describe("session list subagent metadata", () => {
     const main = all.sessions.find((session) => session.key === "agent:main:main");
     expect(main?.childSessions).toBeUndefined();
 
-    const filtered = await listSessionsFromStoreAsync({
+    const filtered = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1286,7 +1286,7 @@ describe("session list subagent metadata", () => {
       startedAt: now - 900,
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1314,7 +1314,7 @@ describe("session list subagent metadata", () => {
       } as SessionEntry,
     };
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,
@@ -1355,7 +1355,7 @@ describe("session list subagent metadata", () => {
       model: "openai/gpt-5.4",
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store,

--- a/src/gateway/session-utils.telegram-recreate.test.ts
+++ b/src/gateway/session-utils.telegram-recreate.test.ts
@@ -18,7 +18,7 @@ import {
   deliveryContextFromSession,
   sessionDeliveryOrigin,
 } from "../utils/delivery-context.shared.js";
-import { listSessionsFromStoreAsync } from "./session-utils.js";
+import { listSessionFixture } from "./session-list.test-support.js";
 
 const TELEGRAM_DIRECT_KEY = "agent:main:telegram:direct:7463849194";
 
@@ -107,7 +107,7 @@ describe("Telegram direct session recreation after delete", () => {
       session: { ...cfg.session, store: storePath },
     } satisfies OpenClawConfig;
     const loaded = loadCombinedSessionStoreForGatewayCore(runtimeCfg, { agentId: "main" });
-    const listed = await listSessionsFromStoreAsync({
+    const listed = await listSessionFixture({
       cfg: runtimeCfg,
       storePath: loaded.storePath,
       store: loaded.store,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -38,9 +38,9 @@ import type { GatewayModelCatalogSnapshot } from "./server-model-catalog.types.j
 import { registerSessionAutomationSource } from "./session-automation-index.js";
 import { buildGatewaySessionEventFields } from "./session-event-payload.js";
 import { projectSessionActor } from "./session-identity-projection.js";
+import { buildSessionRowFixture, listSessionFixture } from "./session-list.test-support.js";
 import { resolveSessionStoreAgentId, resolveSessionStoreKey } from "./session-store-key.js";
 import { deriveSessionTitle } from "./session-utils-core.js";
-import { listSessionsFromStoreAsync } from "./session-utils-list.js";
 import {
   getSessionDefaults,
   projectSessionPatchResult,
@@ -124,6 +124,7 @@ test("projects a channel avatar route without exposing its media-store reference
 
   const row = buildGatewaySessionRowOwner({
     cfg,
+    agentId: "main",
     storePath: "",
     store: { [key]: entry },
     key,
@@ -154,6 +155,7 @@ test("projects a channel avatar route without exposing its media-store reference
   } satisfies SessionEntry;
   const replacedRow = buildGatewaySessionRowOwner({
     cfg,
+    agentId: "main",
     storePath: "",
     store: { [key]: replacedEntry },
     key,
@@ -265,7 +267,7 @@ function expectFields(value: unknown, expected: Record<string, unknown>): void {
 }
 
 function buildGatewaySessionRow(
-  params: Parameters<typeof buildGatewaySessionRowOwner>[0],
+  params: Parameters<typeof buildSessionRowFixture>[0],
 ): ReturnType<typeof buildGatewaySessionRowOwner> {
   const entry = params.entry ?? ({} as SessionEntry);
   const rowContext = buildSessionListRowMetadataContext({
@@ -274,7 +276,7 @@ function buildGatewaySessionRow(
   // Row projection tests do not own ACP persistence. Mark the supplied fixture
   // as already checked so each assertion does not open the ambient state DB.
   rowContext.acpSessionMetaByEntry.set(entry, undefined);
-  return buildGatewaySessionRowOwner({
+  return buildSessionRowFixture({
     ...params,
     entry,
     rowContext,
@@ -625,7 +627,7 @@ describe("gateway session utils", () => {
       ]),
     );
 
-    const listed = await listSessionsFromStoreAsync({
+    const listed = await listSessionFixture({
       cfg,
       storePath: "",
       store,
@@ -654,7 +656,7 @@ describe("gateway session utils", () => {
       ]),
     );
 
-    const listed = await listSessionsFromStoreAsync({
+    const listed = await listSessionFixture({
       cfg,
       storePath: "",
       store,
@@ -686,7 +688,7 @@ describe("gateway session utils", () => {
       },
     } satisfies Record<string, SessionEntry>;
 
-    const active = await listSessionsFromStoreAsync({ cfg, storePath: "", store, opts: {} });
+    const active = await listSessionFixture({ cfg, storePath: "", store, opts: {} });
     expect(active.sessions.map((session) => session.key)).toEqual(["pinned", "recent"]);
     expect(active.sessions[0]).toMatchObject({
       pinned: true,
@@ -694,7 +696,7 @@ describe("gateway session utils", () => {
       archived: false,
     });
 
-    const archived = await listSessionsFromStoreAsync({
+    const archived = await listSessionFixture({
       cfg,
       storePath: "",
       store,
@@ -710,7 +712,7 @@ describe("gateway session utils", () => {
       },
     ]);
 
-    const all = await listSessionsFromStoreAsync({
+    const all = await listSessionFixture({
       cfg,
       storePath: "",
       store,
@@ -732,7 +734,7 @@ describe("gateway session utils", () => {
       ]),
     );
 
-    const listed = await listSessionsFromStoreAsync({
+    const listed = await listSessionFixture({
       cfg,
       storePath: "",
       store,
@@ -765,7 +767,7 @@ describe("gateway session utils", () => {
       },
     };
 
-    const listed = await listSessionsFromStoreAsync({
+    const listed = await listSessionFixture({
       cfg,
       storePath: "",
       store,
@@ -798,7 +800,7 @@ describe("gateway session utils", () => {
       },
     };
 
-    const listed = await listSessionsFromStoreAsync({
+    const listed = await listSessionFixture({
       cfg,
       storePath: "",
       store,
@@ -823,7 +825,7 @@ describe("gateway session utils", () => {
       ]),
     );
 
-    const listed = await listSessionsFromStoreAsync({
+    const listed = await listSessionFixture({
       cfg,
       storePath: "",
       store,
@@ -1274,7 +1276,7 @@ describe("gateway session utils", () => {
 
     const historicalModel = vi.spyOn(sessionModelRefs, "resolveSessionModelIdentityRef");
     onTestFinished(() => historicalModel.mockRestore());
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "",
       store,
@@ -1319,7 +1321,7 @@ describe("gateway session utils", () => {
         compat: { supportedReasoningEfforts: ["low", "medium", "high"] },
       },
     ];
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "",
       modelCatalog,
@@ -1580,6 +1582,7 @@ describe("gateway session utils", () => {
       const readRow = (key: keyof typeof store) =>
         buildGatewaySessionRowOwner({
           cfg,
+          agentId: "main",
           storePath: "",
           store,
           key,
@@ -1590,7 +1593,7 @@ describe("gateway session utils", () => {
         });
       const nativeRow = readRow(nativeKey);
       expect(nativeRow).toMatchObject({ modelProvider: "openai", model: "gpt-5.6-luna" });
-      const matches = await listSessionsFromStoreAsync({
+      const matches = await listSessionFixture({
         cfg,
         storePath: "",
         store,
@@ -2421,6 +2424,7 @@ describe("gateway session utils", () => {
     const projectKind = (key: string, entry?: SessionEntry) =>
       buildGatewaySessionRow({
         cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
+        agentId: "main",
         storePath: "",
         store: {},
         key,
@@ -4563,7 +4567,7 @@ describe("session list selected model display", () => {
         store,
         opts: { includeDerivedTitles: true, includeLastMessage: true, limit: 11 },
       };
-      const listedPromise = listSessionsFromStoreAsync(params);
+      const listedPromise = listSessionFixture(params);
       let settled = false;
       void listedPromise.then(() => {
         settled = true;
@@ -4634,7 +4638,7 @@ describe("session list selected model display", () => {
         }
       }
 
-      const result = await listSessionsFromStoreAsync({
+      const result = await listSessionFixture({
         cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
         storePath,
         store,
@@ -4663,7 +4667,7 @@ describe("session list selected model display", () => {
       "agent:main:middle-b": { sessionId: "middle-b", updatedAt: now - 5_000 } as SessionEntry,
       "agent:main:newer": { sessionId: "newer", updatedAt: now - 1_000 } as SessionEntry,
     };
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
       storePath: "/tmp/sessions.json",
       store,
@@ -4680,7 +4684,7 @@ describe("session list selected model display", () => {
 
   test("keeps the scoped global row when filtering by agent", async () => {
     const now = Date.now();
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg: {
         ...createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
         agents: {
@@ -4709,7 +4713,7 @@ describe("session list selected model display", () => {
 
   test("searches a selected agent's global row in an ownerless explicit fleet", async () => {
     const now = Date.now();
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg: {
         agents: {
           ownership: "explicit",
@@ -4738,7 +4742,7 @@ describe("session list selected model display", () => {
 
   test("filters phantom agent store placeholder rows from session lists", async () => {
     const now = Date.now();
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
       storePath: "/tmp/sessions.json",
       store: {
@@ -4756,7 +4760,7 @@ describe("session list selected model display", () => {
       primary: "anthropic/claude-opus-4-6",
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {
@@ -4782,7 +4786,7 @@ describe("session list selected model display", () => {
       agentRuntime: { id: "claude-cli" },
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {
@@ -4815,7 +4819,7 @@ describe("session list selected model display", () => {
       agentRuntime: { id: "claude-cli" },
     });
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {
@@ -4853,7 +4857,7 @@ describe("session list selected model display", () => {
       },
     } as OpenClawConfig;
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {
@@ -4890,7 +4894,7 @@ describe("session list selected model display", () => {
       },
     } as OpenClawConfig;
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {
@@ -4916,7 +4920,7 @@ describe("session list selected model display", () => {
       },
     } as OpenClawConfig;
 
-    const result = await listSessionsFromStoreAsync({
+    const result = await listSessionFixture({
       cfg,
       storePath: "/tmp/sessions.json",
       store: {

--- a/src/gateway/sessions-resolve.test.ts
+++ b/src/gateway/sessions-resolve.test.ts
@@ -248,6 +248,10 @@ describe("resolveSessionKeyFromResolveParams", () => {
   ])("resolves %j from raw metadata without hydrating session rows", async (p) => {
     hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({
       storePath,
+      agentIdBySessionKey: new Map([
+        ["agent:main:noisy", "main"],
+        ["agent:main:target", "main"],
+      ]),
       store: {
         "agent:main:noisy": {
           sessionId: "sess-noisy",

--- a/src/gateway/sessions-resolve.test.ts
+++ b/src/gateway/sessions-resolve.test.ts
@@ -248,9 +248,9 @@ describe("resolveSessionKeyFromResolveParams", () => {
   ])("resolves %j from raw metadata without hydrating session rows", async (p) => {
     hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({
       storePath,
-      agentIdBySessionKey: new Map([
-        ["agent:main:noisy", "main"],
-        ["agent:main:target", "main"],
+      targetsBySessionKey: new Map([
+        ["agent:main:noisy", { agentId: "main", storeTarget: { agentId: "main", storePath } }],
+        ["agent:main:target", { agentId: "main", storeTarget: { agentId: "main", storePath } }],
       ]),
       store: {
         "agent:main:noisy": {
@@ -461,7 +461,12 @@ describe("resolveSessionKeyFromResolveParams", () => {
     hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({
       storePath,
       store,
-      agentIdBySessionKey: new Map(Object.keys(store).map((key) => [key, "main"])),
+      targetsBySessionKey: new Map(
+        Object.keys(store).map((key) => [
+          key,
+          { agentId: "main", storeTarget: { agentId: "main", storePath } },
+        ]),
+      ),
     });
     const result = await resolveSessionKeyFromResolveParams({
       cfg: {},
@@ -489,7 +494,9 @@ describe("resolveSessionKeyFromResolveParams", () => {
     hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({
       storePath,
       store: { global: { updatedAt: 1, displayName: "Work dashboard", boardFace: "dashboard" } },
-      agentIdBySessionKey: new Map([["global", "work"]]),
+      targetsBySessionKey: new Map([
+        ["global", { agentId: "work", storeTarget: { agentId: "work", storePath } }],
+      ]),
     });
     await expect(
       resolveSessionKeyFromResolveParams({
@@ -512,7 +519,9 @@ describe("resolveSessionKeyFromResolveParams", () => {
       hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({
         storePath,
         store: { [key]: { updatedAt: 1, displayName: "Room" } },
-        agentIdBySessionKey: new Map([[key, "main"]]),
+        targetsBySessionKey: new Map([
+          [key, { agentId: "main", storeTarget: { agentId: "main", storePath } }],
+        ]),
       });
       const result = await resolveSessionKeyFromResolveParams({
         cfg: {},
@@ -555,7 +564,12 @@ describe("resolveSessionKeyFromResolveParams", () => {
     hoisted.loadCombinedSessionStoreForGatewayMock.mockReturnValue({
       storePath,
       store,
-      agentIdBySessionKey: new Map(Object.keys(store).map((key) => [key, "main"])),
+      targetsBySessionKey: new Map(
+        Object.keys(store).map((key) => [
+          key,
+          { agentId: "main", storeTarget: { agentId: "main", storePath } },
+        ]),
+      ),
     });
     await expect(
       resolveSessionKeyFromResolveParams({

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -25,7 +25,7 @@ import { hasOperatorBoundary } from "./operator-role-policy.js";
 import type { GatewayClient } from "./server-methods/types.js";
 import { resolveRequestedSessionAgentId } from "./session-request-agent.js";
 import { prepareSessionSharing } from "./session-sharing.js";
-import { resolveSessionStoreAgentId, resolveSessionStoreKey } from "./session-store-key.js";
+import { resolveSessionStoreKey } from "./session-store-key.js";
 import type { SessionListRowContext } from "./session-utils-contracts.js";
 import { resolveGatewaySessionDisplayName } from "./session-utils-display.js";
 import { buildSessionListRowMetadataContext } from "./session-utils-projection.js";
@@ -452,7 +452,9 @@ export async function resolveSessionKeyFromResolveParams(params: {
     };
   }
 
-  const { store } = loadCombinedSessionStoreForGatewayCore(cfg, { agentId: p.agentId });
+  const { store, agentIdBySessionKey } = loadCombinedSessionStoreForGatewayCore(cfg, {
+    agentId: p.agentId,
+  });
   const now = Date.now();
   // Keep list-discovery snapshot semantics without hydrating display rows.
   let rowContext: SessionListRowContext | undefined;
@@ -493,10 +495,6 @@ export async function resolveSessionKeyFromResolveParams(params: {
   return {
     ok: true,
     key: labelKey,
-    agentId: normalizeAgentId(
-      parseAgentSessionKey(labelKey)?.agentId ??
-        p.agentId ??
-        resolveSessionStoreAgentId(cfg, labelKey),
-    ),
+    agentId: expectDefined(agentIdBySessionKey.get(labelKey), "label session agent"),
   };
 }

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -217,7 +217,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
     const exactKey = sameAgent
       ? resolveSessionStoreKey({ cfg, sessionKey: referenceKey, storeAgentId: p.agentId })
       : referenceKey;
-    const { store, agentIdBySessionKey } = loadCombinedSessionStoreForGatewayCore(cfg, {
+    const { store, targetsBySessionKey } = loadCombinedSessionStoreForGatewayCore(cfg, {
       agentId: p.agentId,
       configuredAgentsOnly: true,
       projection: "list",
@@ -238,7 +238,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
       sessionResolveCandidate(
         candidateKey,
         entry,
-        expectDefined(agentIdBySessionKey.get(candidateKey), "reference session agent"),
+        expectDefined(targetsBySessionKey.get(candidateKey), "reference session agent").agentId,
       );
     const exact = entries.find(
       ([candidateKey]) => normalizeSessionKeyPreservingOpaquePeerIds(candidateKey) === exactKey,
@@ -452,7 +452,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
     };
   }
 
-  const { store, agentIdBySessionKey } = loadCombinedSessionStoreForGatewayCore(cfg, {
+  const { store, targetsBySessionKey } = loadCombinedSessionStoreForGatewayCore(cfg, {
     agentId: p.agentId,
   });
   const now = Date.now();
@@ -495,6 +495,6 @@ export async function resolveSessionKeyFromResolveParams(params: {
   return {
     ok: true,
     key: labelKey,
-    agentId: expectDefined(agentIdBySessionKey.get(labelKey), "label session agent"),
+    agentId: expectDefined(targetsBySessionKey.get(labelKey), "label session agent").agentId,
   };
 }

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -1334,6 +1334,7 @@ describe("host-hook fixture plugin contract", () => {
 
     const row = buildGatewaySessionRow({
       cfg: config,
+      agentId: "main",
       storePath: "/tmp/sessions.json",
       store: {},
       key: "agent:main:main",
@@ -1401,6 +1402,7 @@ describe("host-hook fixture plugin contract", () => {
 
     const row = buildGatewaySessionRow({
       cfg: config,
+      agentId: "main",
       storePath: "/tmp/sessions.json",
       store: {},
       key: "agent:main:main",
@@ -1646,6 +1648,7 @@ describe("host-hook fixture plugin contract", () => {
     ]);
     const row = buildGatewaySessionRow({
       cfg: config,
+      agentId: "main",
       storePath: "/tmp/sessions.json",
       store: {},
       key: "agent:main:main",

--- a/src/sessions/session-state-events.ts
+++ b/src/sessions/session-state-events.ts
@@ -762,8 +762,8 @@ export function recordSessionGoalChanged(params: {
   summary: string;
 }): void {
   const watcherSessionKey = params.entry.spawnedBy ?? params.entry.parentSessionKey;
-  // Callers that own an explicit store agent must pass it: bare "global" keys
-  // parse to the default agent and would misattribute the event.
+  // Forward the resolved store agent: bare "global" does not encode an owner,
+  // so inferring it here would throw after the goal mutation has already committed.
   recordSessionStateEvent({
     sessionKey: params.sessionKey,
     sessionId: params.entry.sessionId,

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -11,6 +11,7 @@ import {
   clearEmbeddedPluginApprovalBroker,
   getEmbeddedPluginApprovalBroker,
 } from "../infra/embedded-plugin-approval-broker.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import { AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE } from "../sessions/agent-harness-session-key.js";
 import { notifyListeners } from "../shared/listeners.js";
@@ -84,6 +85,7 @@ const readChatHistoryPageMock = vi.fn(
   }),
 );
 type LoadSessionEntryMockResult = {
+  agentId: string;
   cfg: Record<string, unknown>;
   canonicalKey: string;
   storePath?: string;
@@ -91,8 +93,9 @@ type LoadSessionEntryMockResult = {
   entry?: Record<string, unknown>;
 };
 const loadSessionEntryMock = vi.fn(
-  (sessionKey: string, _opts?: { agentId?: string }): LoadSessionEntryMockResult => ({
+  (sessionKey: string, opts?: { agentId?: string }): LoadSessionEntryMockResult => ({
     cfg: {},
+    agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
     canonicalKey: sessionKey,
     storePath: "/tmp/openclaw-sessions.json",
     store: {},
@@ -262,7 +265,14 @@ vi.mock("../gateway/session-utils.js", () => ({
     primaryKey: key,
     target: { storeKeys: [key] },
   }),
-  resolveGatewaySessionStoreTargetWithStore: ({ key }: { key: string }) => ({
+  resolveGatewaySessionStoreTargetWithStore: ({
+    key,
+    agentId,
+  }: {
+    key: string;
+    agentId?: string;
+  }) => ({
+    agentId: agentId ?? parseAgentSessionKey(key)?.agentId ?? "main",
     canonicalKey: key,
     storeKeys: [key],
     storePath: "/tmp/openclaw-sessions.json",
@@ -335,6 +345,11 @@ function captureBackendEvents(backend: EmbeddedTuiBackendType) {
 function sendMainChat(backend: EmbeddedTuiBackendType, message: string, runId: string) {
   return backend.sendChat({ sessionKey: "agent:main:main", message, runId });
 }
+
+const selectedGlobalSessionCases = [
+  { input: { sessionKey: "global", agentId: "work" }, owner: "work" },
+  { input: { sessionKey: "agent:research:main" }, owner: "research" },
+];
 
 describe("EmbeddedTuiBackend", () => {
   const originalRuntimeLog = defaultRuntime.log;
@@ -428,8 +443,9 @@ describe("EmbeddedTuiBackend", () => {
     readChatHistoryPageMock.mockReset();
     readChatHistoryPageMock.mockResolvedValue({ messages: [] });
     loadSessionEntryMock.mockReset();
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
       cfg: {},
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
       canonicalKey: sessionKey,
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
@@ -1079,8 +1095,9 @@ describe("EmbeddedTuiBackend", () => {
     agentCommandFromIngressMock
       .mockReturnValueOnce(first.promise)
       .mockResolvedValueOnce({ payloads: [{ text: "second done" }], meta: {} });
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
       cfg: { messages: { queue: { mode: "followup" } } },
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
       canonicalKey: sessionKey,
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
@@ -1118,6 +1135,7 @@ describe("EmbeddedTuiBackend", () => {
   it("creates a local session entry before starting a goal", async () => {
     loadSessionEntryMock.mockReturnValueOnce({
       cfg: {},
+      agentId: "main",
       canonicalKey: "agent:main:main",
       storePath: "/tmp/openclaw-sessions.json",
     });
@@ -1135,6 +1153,7 @@ describe("EmbeddedTuiBackend", () => {
     });
     expect(createSessionGoalMock).toHaveBeenCalledWith({
       sessionKey: "agent:main:main",
+      agentId: "main",
       storePath: "/tmp/openclaw-sessions.json",
       objective: "Ship Goal",
       actor: { type: "human" },
@@ -1148,6 +1167,7 @@ describe("EmbeddedTuiBackend", () => {
   it("uses the selected agent when running local global goal commands", async () => {
     loadSessionEntryMock.mockReturnValueOnce({
       cfg: {},
+      agentId: "work",
       canonicalKey: "global",
       storePath: "/tmp/openclaw-work-sessions.json",
       entry: { sessionId: "session-work", updatedAt: embeddedEventTimestamp },
@@ -1170,33 +1190,65 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
-  it("runs local usage cost with the canonical session entry and selected agent", async () => {
-    const cfg = { session: { scope: "global" } };
-    const sessionEntry = { sessionId: "session-work", updatedAt: embeddedEventTimestamp };
-    loadSessionEntryMock.mockReturnValueOnce({
-      cfg,
-      canonicalKey: "global",
-      storePath: "/tmp/openclaw-work-sessions.json",
-      entry: sessionEntry,
-    });
-    const backend = new EmbeddedTuiBackend();
+  it.each(selectedGlobalSessionCases)(
+    "runs local usage cost with the stored owner: $input.sessionKey",
+    async ({ input, owner }) => {
+      const cfg = { session: { scope: "global" } };
+      const sessionEntry = { sessionId: `session-${owner}`, updatedAt: embeddedEventTimestamp };
+      loadSessionEntryMock.mockReturnValueOnce({
+        cfg,
+        agentId: owner,
+        canonicalKey: "global",
+        storePath: `/tmp/openclaw-${owner}-sessions.json`,
+        entry: sessionEntry,
+      });
+      const backend = new EmbeddedTuiBackend();
 
-    await expect(
-      backend.runUsageCostCommand({ sessionKey: "global", agentId: "work" }),
-    ).resolves.toEqual({
-      text: "💸 Usage cost\nSession $1.23",
-    });
+      await expect(backend.runUsageCostCommand(input)).resolves.toEqual({
+        text: "💸 Usage cost\nSession $1.23",
+      });
 
-    expect(loadSessionEntryMock).toHaveBeenCalledWith("global", { agentId: "work" });
-    expect(formatSessionUsageCostSummaryMock).toHaveBeenCalledWith({
-      cfg,
-      sessionKey: "global",
-      agentId: "work",
-      sessionEntry,
-      storePath: "/tmp/openclaw-work-sessions.json",
-    });
-    expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
-  });
+      expect(loadSessionEntryMock).toHaveBeenCalledWith(
+        input.sessionKey,
+        input.agentId ? { agentId: input.agentId } : undefined,
+      );
+      expect(formatSessionUsageCostSummaryMock).toHaveBeenCalledWith({
+        cfg,
+        sessionKey: "global",
+        agentId: owner,
+        sessionEntry,
+        storePath: `/tmp/openclaw-${owner}-sessions.json`,
+      });
+      expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(selectedGlobalSessionCases)(
+    "records local goal mutations with the stored owner: $input.sessionKey",
+    async ({ input, owner }) => {
+      const entry = { sessionId: `session-${owner}`, updatedAt: embeddedEventTimestamp };
+      const storePath = `/tmp/openclaw-${owner}-sessions.json`;
+      loadSessionEntryMock.mockReturnValueOnce({
+        cfg: { session: { scope: "global" } },
+        agentId: owner,
+        canonicalKey: "global",
+        storePath,
+        entry,
+      });
+      const backend = new EmbeddedTuiBackend();
+      await expect(
+        backend.runGoalCommand({ ...input, command: "/goal start Ship Goal" }),
+      ).resolves.toMatchObject({ text: "Goal started: Ship Goal" });
+      expect(createSessionGoalMock).toHaveBeenCalledWith({
+        sessionKey: "global",
+        storePath,
+        agentId: owner,
+        actor: { type: "human" },
+        objective: "Ship Goal",
+        fallbackEntry: entry,
+      });
+    },
+  );
 
   it("loads history thinking defaults from configured replace-mode models", async () => {
     loadSessionEntryMock.mockReturnValue({
@@ -1210,6 +1262,7 @@ describe("EmbeddedTuiBackend", () => {
           },
         },
       },
+      agentId: "main",
       canonicalKey: "agent:main:main",
       entry: {},
     });
@@ -1224,60 +1277,84 @@ describe("EmbeddedTuiBackend", () => {
     expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
   });
 
-  it("loads selected-agent global history from the selected agent store", async () => {
-    loadSessionEntryMock.mockReturnValue({
-      cfg: {},
-      canonicalKey: "global",
-      storePath: "/tmp/openclaw-work-sessions.json",
-      entry: { sessionId: "session-work-global" },
-    });
+  it.each(selectedGlobalSessionCases)(
+    "loads selected-agent global history from the selected agent store: $input.sessionKey",
+    async ({ input, owner }) => {
+      const entry = { sessionId: `session-${owner}-global` };
+      loadSessionEntryMock.mockReturnValue({
+        cfg: { session: { scope: "global" } },
+        agentId: owner,
+        canonicalKey: "global",
+        storePath: `/tmp/openclaw-${owner}-sessions.json`,
+        entry,
+      });
 
-    const backend = new EmbeddedTuiBackend();
+      const backend = new EmbeddedTuiBackend();
 
-    await expect(
-      backend.loadHistory({ sessionKey: "global", agentId: "work" }),
-    ).resolves.toMatchObject({
-      sessionKey: "global",
-      sessionId: "session-work-global",
-      messages: [],
-    });
-    expect(loadSessionEntryMock).toHaveBeenCalledWith("global", {
-      agentId: "work",
-      includeStoreChildEntries: true,
-    });
-  });
+      await expect(backend.loadHistory(input)).resolves.toMatchObject({
+        sessionKey: input.sessionKey,
+        sessionId: entry.sessionId,
+        sessionInfo: { key: "global", sessionId: entry.sessionId },
+        messages: [],
+      });
+      expect(loadSessionEntryMock).toHaveBeenCalledWith(input.sessionKey, {
+        ...(input.agentId ? { agentId: input.agentId } : {}),
+        includeStoreChildEntries: true,
+      });
+      expect(readChatHistoryPageMock).toHaveBeenCalledWith(
+        expect.objectContaining({ canonicalKey: "global", sessionAgentId: owner, entry }),
+      );
+      expect(buildGatewaySessionInfoMock).toHaveBeenCalledWith(
+        expect.objectContaining({ key: "global", agentId: owner, entry }),
+      );
+    },
+  );
 
-  it("keeps gateway subagent binding off for embedded /btw side questions", async () => {
-    // The embedded TUI runs the side question locally, so it must not borrow the
-    // active registry's subagent and node capabilities. Only gateway-hosted
-    // callers opt into allowGatewaySubagentBinding.
-    loadSessionEntryMock.mockReturnValue({
-      cfg: {},
-      canonicalKey: "global",
-      storePath: "/tmp/openclaw-btw-sessions.json",
-      store: {},
-      entry: { sessionId: "session-btw-local" },
-    });
-    runBtwSideQuestionMock.mockResolvedValueOnce({ text: "side done" });
+  it.each([{ input: { sessionKey: "global" }, owner: "main" }, ...selectedGlobalSessionCases])(
+    "keeps the selected owner and gateway subagent binding off for embedded /btw: $input.sessionKey ($owner)",
+    async ({ input, owner }) => {
+      // The embedded TUI runs the side question locally, so it must not borrow the
+      // active registry's subagent and node capabilities. Only gateway-hosted
+      // callers opt into allowGatewaySubagentBinding.
+      loadSessionEntryMock.mockReturnValue({
+        cfg: { session: { scope: "global" } },
+        agentId: owner,
+        canonicalKey: "global",
+        storePath: `/tmp/openclaw-${owner}-sessions.json`,
+        store: {},
+        entry: { sessionId: `session-${owner}-global` },
+      });
+      runBtwSideQuestionMock.mockResolvedValueOnce({ text: "side done" });
 
-    const backend = new EmbeddedTuiBackend();
-    backend.start();
-    await backend.sendChat({
-      sessionKey: "global",
-      message: "/btw local only",
-      runId: "run-btw-local",
-    });
-    await vi.waitFor(() => expect(runBtwSideQuestionMock).toHaveBeenCalledTimes(1));
-    await backend.stop();
-
-    expect(runBtwSideQuestionMock.mock.calls[0]?.[0]).not.toHaveProperty(
-      "allowGatewaySubagentBinding",
-    );
-  });
+      const backend = new EmbeddedTuiBackend();
+      backend.start();
+      try {
+        await backend.sendChat({
+          ...input,
+          message: "/btw local only",
+          runId: "run-btw-local",
+        });
+        await vi.waitFor(() => expect(runBtwSideQuestionMock).toHaveBeenCalledTimes(1));
+        expect(runBtwSideQuestionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sessionKey: "global",
+            agentId: owner,
+            agentDir: `/tmp/openclaw-agent-${owner}/agent`,
+          }),
+        );
+        expect(runBtwSideQuestionMock.mock.calls[0]?.[0]).not.toHaveProperty(
+          "allowGatewaySubagentBinding",
+        );
+      } finally {
+        await backend.stop();
+      }
+    },
+  );
 
   it("reports the newest matching non-BTW local run in embedded history", async () => {
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
       cfg: {},
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
       canonicalKey: sessionKey,
       storePath: "/tmp/openclaw-work-sessions.json",
       store: {},
@@ -1329,6 +1406,7 @@ describe("EmbeddedTuiBackend", () => {
   it("uses the canonical gateway projector for embedded TUI history reads", async () => {
     loadSessionEntryMock.mockReturnValue({
       cfg: {},
+      agentId: "main",
       canonicalKey: "agent:main:main",
       storePath: "/tmp/openclaw-sessions.json",
       entry: { sessionId: "sess-main" },
@@ -1357,6 +1435,7 @@ describe("EmbeddedTuiBackend", () => {
     const cfg = { agents: { list: [{ id: "main" }] } };
     loadSessionEntryMock.mockReturnValue({
       cfg,
+      agentId: "main",
       canonicalKey: "agent:main:main",
       storePath: "/tmp/openclaw-sessions.json",
       entry: { spawnedWorkspaceDir: "/tmp/openclaw-custom-workspace" },
@@ -1379,6 +1458,7 @@ describe("EmbeddedTuiBackend", () => {
     });
     loadSessionEntryMock.mockReturnValue({
       cfg: {},
+      agentId: "main",
       canonicalKey: "agent:main:main",
       storePath: "/tmp/openclaw-sessions.json",
       entry: {},
@@ -1400,6 +1480,7 @@ describe("EmbeddedTuiBackend", () => {
       .mockReturnValueOnce(undefined);
     loadSessionEntryMock.mockReturnValue({
       cfg: {},
+      agentId: "main",
       canonicalKey: "agent:main:main",
       entry: {},
     });
@@ -1425,6 +1506,7 @@ describe("EmbeddedTuiBackend", () => {
       });
     loadSessionEntryMock.mockReturnValue({
       cfg: {},
+      agentId: "main",
       canonicalKey: "agent:main:main",
       entry: {},
     });
@@ -1441,41 +1523,56 @@ describe("EmbeddedTuiBackend", () => {
     );
   });
 
-  it("passes selected-agent global scope into local chat turns", async () => {
-    agentCommandFromIngressMock.mockResolvedValueOnce({
-      payloads: [{ text: "done" }],
-      meta: {},
-    });
-
-    const backend = new EmbeddedTuiBackend();
-    backend.start();
-    try {
-      await backend.sendChat({
-        sessionKey: "global",
-        agentId: "work",
-        message: "hello",
-        runId: "run-global-work",
+  it.each(selectedGlobalSessionCases)(
+    "passes selected-agent global scope into local chat turns: $input.sessionKey",
+    async ({ input, owner }) => {
+      const entry = { sessionId: `session-${owner}-global` };
+      loadSessionEntryMock.mockReturnValue({
+        cfg: { session: { scope: "global" } },
+        agentId: owner,
+        canonicalKey: "global",
+        storePath: `/tmp/openclaw-${owner}-sessions.json`,
+        entry,
       });
-      await flushMicrotasks();
+      agentCommandFromIngressMock.mockResolvedValueOnce({
+        payloads: [{ text: "done" }],
+        meta: {},
+      });
 
-      expect(loadSessionEntryMock).toHaveBeenCalledWith("global", { agentId: "work" });
-      expect(agentCommandFromIngressMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          sessionKey: "global",
-          agentId: "work",
-          message: expect.stringContaining("hello"),
-        }),
-        expect.anything(),
-        expect.anything(),
-      );
-    } finally {
-      await backend.stop();
-    }
-  });
+      const backend = new EmbeddedTuiBackend();
+      backend.start();
+      try {
+        await backend.sendChat({
+          ...input,
+          message: "hello",
+          runId: "run-global-owner",
+        });
+        await vi.waitFor(() => expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1));
+
+        expect(loadSessionEntryMock).toHaveBeenCalledWith(
+          input.sessionKey,
+          input.agentId ? { agentId: input.agentId } : undefined,
+        );
+        expect(agentCommandFromIngressMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sessionKey: "global",
+            agentId: owner,
+            sessionId: entry.sessionId,
+            message: expect.stringContaining("hello"),
+          }),
+          expect.anything(),
+          expect.anything(),
+        );
+      } finally {
+        await backend.stop();
+      }
+    },
+  );
 
   it("stamps the selected global agent on chat, agent, and BTW envelopes", async () => {
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
       cfg: {},
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
       canonicalKey: sessionKey,
       storePath: "/tmp/openclaw-work-sessions.json",
       store: {},
@@ -1744,8 +1841,9 @@ describe("EmbeddedTuiBackend", () => {
       activeSignal = opts.abortSignal;
       return active.promise;
     });
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
       cfg: { messages: { queue: { mode: "followup" } } },
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
       canonicalKey: sessionKey,
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
@@ -1786,8 +1884,9 @@ describe("EmbeddedTuiBackend", () => {
         return active.promise;
       })
       .mockResolvedValueOnce({ payloads: [{ text: "the later turn completed" }], meta: {} });
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
       cfg: { messages: { queue: { mode: "followup" } } },
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
       canonicalKey: sessionKey,
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
@@ -1843,8 +1942,9 @@ describe("EmbeddedTuiBackend", () => {
     const first = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(first.promise);
     resolveActiveEmbeddedRunSessionIdMock.mockReturnValue("active-session");
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
       cfg: {},
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
       canonicalKey: sessionKey,
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
@@ -1910,8 +2010,9 @@ describe("EmbeddedTuiBackend", () => {
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(second.promise);
     resolveActiveEmbeddedRunSessionIdMock.mockReturnValue("active-session");
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
       cfg: {},
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
       canonicalKey: sessionKey,
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
@@ -1944,8 +2045,9 @@ describe("EmbeddedTuiBackend", () => {
     agentCommandFromIngressMock
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(second.promise);
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
       cfg: { messages: { queue: { mode: "steer" } } },
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
       canonicalKey: sessionKey,
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
@@ -1975,8 +2077,9 @@ describe("EmbeddedTuiBackend", () => {
     agentCommandFromIngressMock
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(collected.promise);
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
       cfg: { messages: { queue: { mode: "collect" } } },
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
       canonicalKey: sessionKey,
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
@@ -2026,13 +2129,16 @@ describe("EmbeddedTuiBackend", () => {
         .mockReturnValueOnce(collected.promise);
       let dropPolicy: "summarize" | "old" | "new" = "summarize";
       let cap = 1;
-      loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
-        cfg: { messages: { queue: { mode: "collect", cap, drop: dropPolicy } } },
-        canonicalKey: sessionKey,
-        storePath: "/tmp/openclaw-sessions.json",
-        store: {},
-        entry: { queueDebounceMs: 0 },
-      }));
+      loadSessionEntryMock.mockImplementation(
+        (sessionKey: string, opts?: { agentId?: string }) => ({
+          cfg: { messages: { queue: { mode: "collect", cap, drop: dropPolicy } } },
+          agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
+          canonicalKey: sessionKey,
+          storePath: "/tmp/openclaw-sessions.json",
+          store: {},
+          entry: { queueDebounceMs: 0 },
+        }),
+      );
 
       const backend = new EmbeddedTuiBackend();
       backend.start();
@@ -2086,10 +2192,11 @@ describe("EmbeddedTuiBackend", () => {
     agentCommandFromIngressMock
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(second.promise);
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
       cfg: {
         messages: { queue: { mode: "followup", cap: 1, drop: "new" } },
       },
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
       canonicalKey: sessionKey,
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
@@ -2129,8 +2236,9 @@ describe("EmbeddedTuiBackend", () => {
         return first.promise;
       })
       .mockResolvedValueOnce({ payloads: [{ text: "replacement done" }], meta: {} });
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
       cfg: { messages: { queue: { mode: "interrupt" } } },
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
       canonicalKey: sessionKey,
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
@@ -2157,8 +2265,9 @@ describe("EmbeddedTuiBackend", () => {
         return first.promise;
       })
       .mockResolvedValueOnce({ payloads: [{ text: "queue updated" }], meta: {} });
-    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
       cfg: {},
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
       canonicalKey: sessionKey,
       storePath: "/tmp/openclaw-sessions.json",
       store: {},
@@ -2933,27 +3042,53 @@ describe("EmbeddedTuiBackend", () => {
     await flushMicrotasks();
   });
 
-  it("scopes selected global patches to the selected agent", async () => {
-    const backend = new EmbeddedTuiBackend();
-
-    await backend.patchSession({
-      key: "global",
-      agentId: "work",
-      fastMode: true,
-    });
-
-    expect(projectSessionsPatchEntryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        storeKey: "global",
-        agentId: "work",
-        patch: expect.objectContaining({
+  it.each(selectedGlobalSessionCases)(
+    "scopes selected global patch policy and result to the stored owner: $input.sessionKey",
+    async ({ input, owner }) => {
+      const sessionUtils = await import("../gateway/session-utils.js");
+      const entry = { sessionId: `session-${owner}`, updatedAt: embeddedEventTimestamp };
+      const target = {
+        agentId: owner,
+        canonicalKey: "global",
+        storePath: `/tmp/openclaw-${owner}-sessions.json`,
+        storeKeys: ["global"],
+        store: { global: entry },
+      };
+      const resolveTarget = vi
+        .spyOn(sessionUtils, "resolveGatewaySessionStoreTargetWithStore")
+        .mockReturnValue(target);
+      const resolveCanonical = vi
+        .spyOn(sessionUtils, "resolveCanonicalGatewaySessionStoreKey")
+        .mockReturnValue({ target, primaryKey: "global", entry });
+      const resolveModel = vi.spyOn(sessionUtils, "resolveSessionModelRef");
+      projectSessionsPatchEntryMock.mockResolvedValueOnce({ ok: true, entry });
+      const backend = new EmbeddedTuiBackend();
+      const patch = {
+        key: input.sessionKey,
+        ...(input.agentId ? { agentId: input.agentId } : {}),
+        fastMode: true,
+      };
+      try {
+        await expect(backend.patchSession(patch)).resolves.toMatchObject({
+          ok: true,
           key: "global",
-          agentId: "work",
-          fastMode: true,
-        }),
-      }),
-    );
-  });
+          entry,
+        });
+        expect.soft(projectSessionsPatchEntryMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            storeKey: "global",
+            agentId: owner,
+            patch,
+          }),
+        );
+        expect.soft(resolveModel).toHaveBeenCalledWith(expect.anything(), entry, owner);
+      } finally {
+        resolveTarget.mockRestore();
+        resolveCanonical.mockRestore();
+        resolveModel.mockRestore();
+      }
+    },
+  );
 
   it("fails a queued local send when the previous finishing run does not settle", async () => {
     await withEnvAsync({ OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS: "5" }, async () => {
@@ -3001,13 +3136,16 @@ describe("EmbeddedTuiBackend", () => {
     await withEnvAsync({ OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS: "5" }, async () => {
       const active = deferred<EmbeddedAgentResult>();
       agentCommandFromIngressMock.mockReturnValueOnce(active.promise);
-      loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
-        cfg: { messages: { queue: { mode: "followup" } } },
-        canonicalKey: sessionKey,
-        storePath: "/tmp/openclaw-sessions.json",
-        store: {},
-        entry: { queueDebounceMs: 0 },
-      }));
+      loadSessionEntryMock.mockImplementation(
+        (sessionKey: string, opts?: { agentId?: string }) => ({
+          cfg: { messages: { queue: { mode: "followup" } } },
+          agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
+          canonicalKey: sessionKey,
+          storePath: "/tmp/openclaw-sessions.json",
+          store: {},
+          entry: { queueDebounceMs: 0 },
+        }),
+      );
       const backend = new EmbeddedTuiBackend();
       const events = captureBackendEvents(backend);
       backend.start();
@@ -3527,6 +3665,7 @@ describe("EmbeddedTuiBackend", () => {
   it("emits side-result events for local /btw runs", async () => {
     loadSessionEntryMock.mockReturnValueOnce({
       cfg: {},
+      agentId: "main",
       canonicalKey: "agent:main:main",
       storePath: "/tmp/openclaw-sessions.json",
       store: {
@@ -3597,6 +3736,7 @@ describe("EmbeddedTuiBackend", () => {
   it("emits side-result events for local /side alias runs", async () => {
     loadSessionEntryMock.mockReturnValueOnce({
       cfg: {},
+      agentId: "main",
       canonicalKey: "agent:main:main",
       storePath: "/tmp/openclaw-sessions.json",
       store: {
@@ -3746,6 +3886,7 @@ describe("EmbeddedTuiBackend", () => {
   it("keeps local BTW runs alive during a session-scoped abort", async () => {
     loadSessionEntryMock.mockReturnValue({
       cfg: {},
+      agentId: "main",
       canonicalKey: "agent:main:main",
       storePath: "/tmp/openclaw-sessions.json",
       store: {},

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -741,7 +741,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   async listSessions(opts?: Parameters<TuiBackend["listSessions"]>[0]): Promise<TuiSessionList> {
     await this.ready;
     const cfg = getRuntimeConfig();
-    const { storePath, store, agentIdBySessionKey } = loadCombinedSessionStoreForGatewayCore(cfg, {
+    const { storePath, store, targetsBySessionKey } = loadCombinedSessionStoreForGatewayCore(cfg, {
       agentId: opts?.agentId,
       projection: "list",
     });
@@ -749,7 +749,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       cfg,
       storePath,
       store,
-      agentIdBySessionKey,
+      targetsBySessionKey,
       opts: opts ?? {},
     })) as TuiSessionList;
   }

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -633,16 +633,18 @@ export class EmbeddedTuiBackend implements TuiBackend {
   async loadHistory(opts: { sessionKey: string; agentId?: string; limit?: number }) {
     await this.ready;
     const loadOptions = opts.agentId ? { agentId: opts.agentId } : undefined;
-    const { cfg, storePath, store, entry, canonicalKey } = loadGatewaySessionEntryReadOnly(
-      opts.sessionKey,
-      { ...loadOptions, includeStoreChildEntries: true },
-    );
-    const sessionId = entry?.sessionId;
-    const sessionAgentId = resolveSessionAgentId({
-      sessionKey: opts.sessionKey,
-      config: cfg,
-      agentId: opts.agentId,
+    const {
+      cfg,
+      agentId: sessionAgentId,
+      storePath,
+      store,
+      entry,
+      canonicalKey,
+    } = loadGatewaySessionEntryReadOnly(opts.sessionKey, {
+      ...loadOptions,
+      includeStoreChildEntries: true,
     });
+    const sessionId = entry?.sessionId;
     const runtimePluginsPrewarm = ensureEmbeddedHistoryRuntimePluginsLoaded({
       cfg,
       sessionAgentId,
@@ -714,7 +716,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       store,
       key: canonicalKey,
       entry,
-      agentId: opts.agentId,
+      agentId: sessionAgentId,
     });
     sessionInfo.thinkingLevel = thinkingLevel;
     sessionInfo.verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
@@ -739,7 +741,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   async listSessions(opts?: Parameters<TuiBackend["listSessions"]>[0]): Promise<TuiSessionList> {
     await this.ready;
     const cfg = getRuntimeConfig();
-    const { storePath, store } = loadCombinedSessionStoreForGatewayCore(cfg, {
+    const { storePath, store, agentIdBySessionKey } = loadCombinedSessionStoreForGatewayCore(cfg, {
       agentId: opts?.agentId,
       projection: "list",
     });
@@ -747,6 +749,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       cfg,
       storePath,
       store,
+      agentIdBySessionKey,
       opts: opts ?? {},
     })) as TuiSessionList;
   }
@@ -784,7 +787,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
           existingEntry,
           isLabelInUse,
           storeKey: primaryKey,
-          agentId: opts.agentId,
+          agentId: target.agentId,
           patch: opts,
           loadGatewayModelCatalog: () =>
             this.withRuntimePluginRegistry(() => loadEmbeddedTuiModelCatalog(cfg)),
@@ -794,12 +797,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       throw new Error(applied.error.message);
     }
 
-    const agentId = resolveSessionAgentId({
-      sessionKey: target.canonicalKey ?? opts.key,
-      config: cfg,
-      agentId: opts.agentId,
-    });
-    const resolved = resolveSessionModelRef(cfg, applied.entry, agentId);
+    const resolved = resolveSessionModelRef(cfg, applied.entry, target.agentId);
     return {
       ok: true as const,
       path: target.storePath,
@@ -868,18 +866,17 @@ export class EmbeddedTuiBackend implements TuiBackend {
     controller: AbortController;
   }) {
     const loadOptions = params.agentId ? { agentId: params.agentId } : undefined;
-    const { cfg, canonicalKey, storePath, store, entry } = loadSessionEntry(
-      params.sessionKey,
-      loadOptions,
-    );
+    const {
+      cfg,
+      agentId: sessionAgentId,
+      canonicalKey,
+      storePath,
+      store,
+      entry,
+    } = loadSessionEntry(params.sessionKey, loadOptions);
     if (!entry?.sessionId) {
       throw new Error("/btw requires an active session with existing context.");
     }
-    const sessionAgentId = resolveSessionAgentId({
-      sessionKey: canonicalKey,
-      config: cfg,
-      agentId: params.agentId,
-    });
     const resolvedModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
     const timeoutSeconds = timeoutSecondsFromMs(params.timeoutMs);
     const { runBtwSideQuestion } = await import("../agents/btw.js");
@@ -950,8 +947,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
   async runGoalCommand(opts: Parameters<NonNullable<TuiBackend["runGoalCommand"]>>[0]) {
     await this.ready;
     const loadOptions = opts.agentId ? { agentId: opts.agentId } : undefined;
-    const { canonicalKey, storePath, entry } = loadSessionEntry(opts.sessionKey, loadOptions);
-    const sessionKey = canonicalKey ?? opts.sessionKey;
+    const { agentId, canonicalKey, storePath, entry } = loadSessionEntry(
+      opts.sessionKey,
+      loadOptions,
+    );
     const parsed = parseGoalCommand(opts.command.trim());
     if (!parsed) {
       throw new Error("invalid goal command");
@@ -959,10 +958,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
     const result = await executeSessionGoalCommand({
       parsed,
-      sessionKey,
+      sessionKey: canonicalKey,
       storePath,
       fallbackEntry: entry ?? { sessionId: randomUUID(), updatedAt: Date.now() },
-      agentId: opts.agentId,
+      agentId,
     });
     return result.continuationPrompt
       ? { text: result.text, continuationPrompt: result.continuationPrompt }
@@ -971,7 +970,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
   async runUsageCostCommand(opts: Parameters<NonNullable<TuiBackend["runUsageCostCommand"]>>[0]) {
     await this.ready;
-    const { cfg, canonicalKey, storePath, entry } = loadSessionEntry(
+    const { cfg, agentId, canonicalKey, storePath, entry } = loadSessionEntry(
       opts.sessionKey,
       opts.agentId ? { agentId: opts.agentId } : undefined,
     );
@@ -980,8 +979,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
     return {
       text: await formatSessionUsageCostSummary({
         cfg,
-        sessionKey: canonicalKey ?? opts.sessionKey,
-        agentId: opts.agentId,
+        sessionKey: canonicalKey,
+        agentId,
         sessionEntry: entry,
         storePath,
       }),
@@ -1466,7 +1465,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
         return;
       }
       const loadOptions = params.agentId ? { agentId: params.agentId } : undefined;
-      const { canonicalKey, entry } = loadSessionEntry(params.sessionKey, loadOptions);
+      const { agentId, canonicalKey, entry } = loadSessionEntry(params.sessionKey, loadOptions);
       const result = await agentCommandFromIngress(
         {
           // The per-message timestamp prefix is applied at the single LLM
@@ -1475,7 +1474,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
           // bytes on the wire. See: https://github.com/openclaw/openclaw/issues/3658
           message,
           sessionKey: canonicalKey,
-          ...(params.agentId ? { agentId: params.agentId } : {}),
+          agentId,
           ...(entry?.sessionId ? { sessionId: entry.sessionId } : {}),
           thinking: params.thinking,
           deliver: params.deliver,


### PR DESCRIPTION
## What Problem This Solves

Global and unknown sessions can belong to a different agent than an aggregate view's default, and their logical agent can differ from the physical database owner. Discarding those facts caused wrong agent/model labels, missing model-search results, transcript or sharing errors, and cross-store board matches. Local qualified-session commands could also lose the agent when their key became `global`: goal creation could commit then throw before its event, and cost reporting could reject the selected store.

These consumers were found while validating #138930. This follow-up preserves the existing selection instead of reconstructing ownership downstream.

## Why This Change Was Made

The combined loader now records one per-row target containing the logical agent and concrete physical store. It captures already-resolved database facts at the existing discovery boundary, without a new filesystem scan. First-sentinel federation chooses the row and target together; filtering removes them together.

Model, identity and ACP projections use the logical agent. Transcript titles, fresh sharing and membership reads, and board inventory use the selected physical database. After projection yields, sharing rereads only that page's exact keys; it does not redirect through public aliases or substitute another store's equal sentinel. This removes the list-only discovery cache, repeated database resolution, and separate board-owner inference.

A typed, exclusive prepared-owner path carries the stored row's agent through runtime policy, implicit OpenAI routing, registered harness support and thinking metadata. Existing raw request selection still validates normally, and the real session key remains available to ACP/runtime context. No validation-skip flag or duplicated policy algorithm was added.

Snapshot, hover, chat-history, label lookup and embedded TUI callers retain their loader's owner. Local history, ordinary turns, side questions, model patches, goals and costs keep that owner through canonicalization.

**Production: 379 added / 412 removed, net −33 lines.** Tests/support: net +1015; docs: +2. Counts are verified against the submitted head. No config/env option, SQLite representation/schema/migration, protocol version or public SDK shape changes. The SDK wrapper still exposes only its established store/path result.

## User Impact

Lists and previews describe the stored conversation rather than the aggregate default. Shared, registered, suffixed, retired and incognito stores keep their existing discovery and inclusion rules. A board in another database cannot make the selected session match `hasBoard`. Visibility, membership and deleted-row checks remain fresh after awaits.

Public fixed-store mismatch requests still reject. Aggregate defaults, row ordering, first-sentinel selection, exact-key/short-ID/session-ID policies, and goal-status behavior remain unchanged. No provider or channel is hardcoded into the repair.

## Evidence

### Regression and runtime proof

The original aggregate probes reproduced research-owned rows labeled main and missing research-model search matches. Real Gateway WebSocket tests cover list/search/title, hover and label resolution. An unchanged standalone SQLite probe showed goal creation writing research's goal then throwing before an event, and cost reporting throwing an owner/store mismatch. Repaired goal creation succeeds with a research-owned event; cost output matches research's $1.23/123-token control, while main's $9/900-token control remains unchanged. No wrong-main event or wrong-total result is claimed.

The [ClawSweeper fixed-store finding](https://github.com/openclaw/openclaw/pull/138991#issuecomment-5551044276) is addressed across the full path. The new pre-edit handler reproduction first failed in runtime metadata's raw owner resolution, before reaching sharing. It now returns independently owned registered/suffixed rows while the public mismatch control still rejects. A separate failing board test proved that a later same-owner store's board could incorrectly match the first selected row; that now passes with the first-store control intact.

The focused seven-file cohort passed **314/314, zero skips**. It includes real shared-store title reads, deletion/draft/member-join/member-leave changes after projection, canonical-main shared aliases, and no substitution after the first selected sentinel disappears. The broader final cohort and completed full gates are recorded below.

### Original model-label before/after

These captures use the production Control UI with an actual isolated loopback Gateway and synthetic SQLite state; RPC responses were not mocked. Before is `d8e0a03186679a23cf30751d85f9e0219e129dcc`; after is the initial projection fix `a0a20646e122a942c928b99a996dc710c643b9d9`.

| Before: wrong model | After: stored agent's model |
| --- | --- |
| ![Research global session incorrectly displays gpt-5.4](https://github.com/user-attachments/assets/dd75ba95-9613-4e77-a11e-e1046d847380) | ![Research global session correctly displays gpt-5.5](https://github.com/user-attachments/assets/1291ec12-9b5e-4e2f-8d76-588b70ca2834) |

### Fixed-store real Gateway flow

The final physical-store candidate also passed the real All Agents → Filters → Unknown → session-details flow. Configured-only/unscoped and main/ops-scoped WebSocket controls return the expected originating rows/models. `chat.history` with global/main still rejects against the configured fixed owner ops. This uses explicit `auth:none`, private state/ports and no provider calls or operator Gateway. It is not token-auth/provider execution proof.

https://github.com/user-attachments/assets/a799268a-e6bd-4919-85ba-36d189b19886

![Registered main-owned session remains visible under a fixed ops store](https://github.com/user-attachments/assets/c33581c3-13b1-4bfb-b540-96d809cd3b87)

The six-second original recording and all PNGs were inspected. All 150 decoded video frames were accounted for, including 89 distinct images; content is synthetic-only. Captures came from candidate patch `39be0556…`; the subsequent tuple typing, unused type-export removal and fixture consolidation change no executable production behavior; the type-export removal was verified to emit identical JavaScript. This demonstrates list/detail rendering, not the separate hover endpoint.

### Validation

Final head: `f163237359c62a28d136da87cf50d446f717dca9`.

- Production types, all 16 canonical core-test type graphs, formatting, runtime import-cycle guard and type-inclusive Madge: passed.
- Full 59-path changed gate and architecture: passed; the complete changed gate finished with exit 0 in 548.794 seconds.
- Broader owner/caller and TUI cohorts: 1,264 owner/caller tests and 217 TUI tests passed, zero skips; the subsequently consolidated usage file passed its 27 tests again (overlapping, not added to the total).
- Fresh managed correction review: 10/10 packets completed, no actionable P0–P2 findings; this is static review of partitioned source/context, not independent execution of tests.
- Exact-head hosted CI: [run 33963859265](https://github.com/openclaw/openclaw/actions/runs/33963859265) completed successfully: 107 passed, 16 skipped, including the required `openclaw/ci-gate`.

Earlier failures remain recorded: hosted CI on a0 found three stale fixtures; assertions were preserved while producer facts were supplied and obsolete error expectations became explicit owner/result checks. New fixtures initially used an invalid physical-owner write scope, then failed to publish configuration through the shared fixture owner. Both were corrected through existing canonical helpers, not runtime workarounds. A full-order run also exposed an older incognito fixture's missing cleanup. One test tuple needed readonly literal typing; full validation also caught an unused type export and an expanded fixture exceeding its file-size limit. The type is now private, and repeated fixture setup was consolidated without a suppression or weaker checks. The first video attempt stopped before page/RPC creation because the private HOME could not locate the existing encoder; the retry reused it read-only and pinned private logging before imports. That first attempt may have touched the default shared log, which was neither inspected nor deleted; no operator database/configuration or saved credentials were used.

### Post-merge confirmation

Merged as `97d35e3faa3d3bb7557c9b4467342dae227fc7ce`. All 59 landed files match the reviewed head byte-for-byte; actual landed production delta remains −33. [Post-merge CI 33964591994](https://github.com/openclaw/openclaw/actions/runs/33964591994) also completed successfully: 58 passed, 16 skipped, without cancellation.

The unchanged real SQLite goal/cost probe passed again on clean landed main: goal creation returned success and recorded research/global’s event with no main event; qualified cost matched research’s $1.23 / 123 tokens while the main control remained $9.00 / 900 tokens. This directly calls the published backend methods with private state; it does not start the TUI/Gateway or execute a provider. Source/index/config/dependency guards passed and private state was removed.

## Separate Follow-ups

The retained literal-global/per-sender URL representation remains a separate decision; existing `~key/global` links are not reinterpreted. The pre-stable steering investigation did not establish wrong-agent injection and makes no authority changes here. A separate caller audit found existing admission fences before session-patch result projection. Raw residual-auto context forwarding is a pre-stable third-party contract risk, not a demonstrated bundled regression or a fix claimed here.
