### PR TITLE
fix(memory): embeddings fail when providers reject oversized batches

### DIFF
--- a/extensions/memory-core/src/memory/generic-embedding-provider.integration.test.ts
+++ b/extensions/memory-core/src/memory/generic-embedding-provider.integration.test.ts
@@ -8,7 +8,8 @@ import {
   restoreRegisteredEmbeddingProviders,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createEmbeddingProvider } from "./embeddings.js";
+import { createEmbeddingProvider, type EmbeddingProvider } from "./embeddings.js";
+import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
 
 type CapturedRequest = {
   method: string | undefined;
@@ -34,7 +35,7 @@ async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknow
   return JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
 }
 
-async function startEmbeddingServer(): Promise<TestServer> {
+async function startEmbeddingServer(options?: { maxBatchItems?: number }): Promise<TestServer> {
   const requests: CapturedRequest[] = [];
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
     void (async () => {
@@ -48,6 +49,18 @@ async function startEmbeddingServer(): Promise<TestServer> {
         });
         const input = body.input;
         const texts = Array.isArray(input) ? input : [input];
+        if (options?.maxBatchItems && texts.length > options.maxBatchItems) {
+          res.writeHead(400, { "content-type": "application/json" });
+          res.end(
+            JSON.stringify({
+              error: {
+                code: "InvalidParameter",
+                message: `batch size is invalid, it should not be larger than ${options.maxBatchItems}`,
+              },
+            }),
+          );
+          return;
+        }
         res.writeHead(200, { "content-type": "application/json" });
         res.end(
           JSON.stringify({
@@ -86,6 +99,18 @@ async function startEmbeddingServer(): Promise<TestServer> {
   };
   servers.push(testServer);
   return testServer;
+}
+
+function createEmbeddingBatchRetryHarness(provider: EmbeddingProvider) {
+  return Object.assign(Object.create(MemoryManagerEmbeddingOps.prototype), {
+    provider,
+    resolveEmbeddingTimeout: () => 60_000,
+    markLocalEmbeddingProviderDegraded: () => {},
+    waitForEmbeddingRetry: async () => {},
+    withProviderUse: async <T>(_provider: EmbeddingProvider, run: () => Promise<T>) => await run(),
+  }) as {
+    embedBatchWithRetry: (texts: string[]) => Promise<number[][]>;
+  };
 }
 
 function createMemoryEmbeddingOptions(overrides?: {
@@ -215,6 +240,22 @@ describe("memory-core generic embedding provider contract", () => {
       dimensions: 3,
       input_type: "document",
     });
+  });
+
+  it("splits an explicit provider item-limit rejection through the real HTTP client", async () => {
+    const server = await startEmbeddingServer({ maxBatchItems: 10 });
+    const result = await createEmbeddingProvider(
+      createMemoryEmbeddingOptions({ baseUrl: server.baseUrl }),
+    );
+    expect(result.provider).not.toBeNull();
+
+    const items = Array.from({ length: 33 }, (_, index) => `item-${index}`);
+    const manager = createEmbeddingBatchRetryHarness(result.provider!);
+
+    await expect(manager.embedBatchWithRetry(items)).resolves.toHaveLength(33);
+    expect(server.requests.map((request) => (request.body.input as unknown[]).length)).toEqual([
+      33, 17, 9, 8, 16, 8, 8,
+    ]);
   });
 
   it("does not make generic embedding providers memory auto-selection candidates", async () => {

--- a/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
@@ -132,6 +132,10 @@ describe("memory embedding batch retry boundary", () => {
         `Embeddings API input limit exceeded: max 10, got ${count}. Request id: fixture-000597000`,
     ],
     ["an explicit maximum input length", () => "embeddings max input length is 10"],
+    [
+      "an explicit maximum batch size",
+      () => "batch size is invalid, it should not be larger than 10",
+    ],
   ])(
     "splits provider errors with %s without retrying oversized requests",
     async (_label, error) => {

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -214,6 +214,7 @@ describe("memory embedding policy", () => {
     for (const message of [
       "Embeddings API input limit exceeded: max 10, got 33. Request id: fixture-000597000",
       "embeddings max input length is 16",
+      "batch size is invalid, it should not be larger than 20",
     ]) {
       expect(isSplittableMemoryEmbeddingBatchError(message)).toBe(true);
       expect(isRetryableMemoryEmbeddingError(message)).toBe(false);
@@ -223,6 +224,9 @@ describe("memory embedding policy", () => {
       "embedding input exceeds maximum token length 4096",
       "embeddings max input length is unknown",
       "Embeddings API input limit exceeded",
+      "batch size is invalid, it should not be larger than unknown",
+      "batch size is invalid, it should not be smaller than 20",
+      "input size is invalid, it should not be larger than 20",
       'HTTP 400: {"code":"InvalidParameter","param":"input","message":"input must be a string"}',
     ]) {
       expect(isSplittableMemoryEmbeddingBatchError(message)).toBe(false);

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -55,7 +55,7 @@ const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
   /(fetch failed|other side closed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|UND_ERR_|socket hang up|socket terminated|network error|read ECONN|timed out|connection (?:reset|refused|aborted|timed out)|EHOSTUNREACH|ENETUNREACH|ECONNABORTED|EAI_AGAIN)/i;
 
 const SPLITTABLE_MEMORY_EMBEDDING_BATCH_ERROR_RE =
-  /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted)|\bembeddings (?:api input limit exceeded:\s*max\s+\d+\s*,\s*got\s+\d+|max input length is\s+\d+)\b)/i;
+  /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted)|\bbatch size is invalid,\s*it should not be larger than\s+\d+\b|\bembeddings (?:api input limit exceeded:\s*max\s+\d+\s*,\s*got\s+\d+|max input length is\s+\d+)\b)/i;
 
 export function isSplittableMemoryEmbeddingBatchError(message: string): boolean {
   return SPLITTABLE_MEMORY_EMBEDDING_BATCH_ERROR_RE.test(message);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users of OpenAI-compatible embedding providers could not index memory when a provider rejected an oversized item batch with an explicit numeric maximum. The request failed permanently instead of being split into smaller batches.

## Why This Change Was Made

Recognize the provider-neutral error form `batch size is invalid, it should not be larger than <N>` and route it through the existing recursive batch splitter. The classifier requires an explicit numeric maximum and does not depend on a provider name.

## User Impact

Memory indexing now automatically recovers from this explicit provider batch-size limit instead of failing with HTTP 400. Other input-validation errors remain permanent and are not retried or split.

## Evidence

- Focused extension-memory Vitest: 24/24 passed.
- Verified recursive splitting of 33 inputs until every request is at or below the provider limit.
- Negative cases remain unsplittable: unknown maximum, minimum-size wording, input-size wording, and generic input validation.
- Oxlint: 0 warnings, 0 errors.
- Oxfmt and `git diff --check` passed.
