### PR TITLE
fix(memory): keep curated annotation indexing linear

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -248,6 +248,49 @@ describe("memory index", () => {
     }
   });
 
+  it.each(["none", "openai"])(
+    "indexes incomplete and mixed annotations promptly with provider %s",
+    async (provider) => {
+      await fs.writeFile(
+        path.join(fixture.paths.workspace, "MEMORY.md"),
+        [
+          "- Alpha mixed. <!--trigger: alpha --><!-- note --> prose <!--importance: 3 --><!--project: alpha-key -->",
+          "- Beta nontrailing. <!--trigger: ignored --> ordinary text",
+          "- Gamma nested. <!--trigger: <!--project: gamma-key -->",
+          `- Incomplete. <!--trigger:${"--><!--project:".repeat(26)}X`,
+        ].join("\n"),
+      );
+      const manager = await getFreshManager(createCfg({ provider }));
+      try {
+        const started = performance.now();
+        await manager.sync({ reason: "test", force: true });
+        expect(performance.now() - started).toBeLessThan(3_000);
+        const db = Reflect.get(manager, "db") as DatabaseSync;
+        expect(
+          db
+            .prepare(
+              `SELECT metadata.triggers, metadata.importance, metadata.project_key AS projectKey
+               FROM memory_index_chunks AS chunk
+               JOIN memory_index_chunk_recall_metadata AS metadata ON metadata.chunk_id = chunk.id
+               WHERE chunk.path = 'MEMORY.md' ORDER BY chunk.start_line`,
+            )
+            .all(),
+        ).toEqual([
+          { triggers: "alpha", importance: 3, projectKey: "alpha-key" },
+          { triggers: null, importance: null, projectKey: null },
+          { triggers: "<!--project: gamma-key", importance: null, projectKey: "gamma-key" },
+          { triggers: null, importance: null, projectKey: INVALID_PROJECT_ANNOTATION_KEY },
+        ]);
+        expect(await manager.search("Alpha mixed", { lexicalOnly: true, minScore: 0 })).toEqual(
+          expect.arrayContaining([expect.objectContaining({ path: "MEMORY.md" })]),
+        );
+        expect(providerFixture.embedBatchCalls > 0).toBe(provider !== "none");
+      } finally {
+        await manager.close();
+      }
+    },
+  );
+
   it("round-trips mixed-case project keys through indexed recall consumers", async () => {
     const projectKey = "github.com/OpenClaw/OpenClaw";
     await fs.writeFile(

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
+import { extractCuratedEntryRecallMetadata } from "openclaw/plugin-sdk/memory-core-host-engine-curated";
 import {
   enforceEmbeddingMaxInputTokens,
   hasNonTextEmbeddingParts,
@@ -14,9 +15,7 @@ import {
   buildFileEntry,
   buildMultimodalChunkForIndexing,
   chunkMarkdown,
-  extractProjectKeysFromCuratedEntry,
   hashText,
-  INVALID_PROJECT_ANNOTATION_KEY,
   MEMORY_EMBEDDING_CACHE_TABLE,
   MEMORY_INDEX_CHUNK_PROVENANCE_TABLE,
   MEMORY_INDEX_CHUNK_RECALL_METADATA_TABLE,
@@ -112,69 +111,6 @@ type PreparedMemoryIndexEntry = {
   chunks: IndexedMemoryChunk[];
   structuredInputBytes?: number;
 };
-
-function resolveChunkRecallMetadata(params: {
-  curatedRoot: boolean;
-  projectScopeEligible: boolean;
-  sourceLines: string[];
-  chunk: MemoryChunk;
-}): Pick<IndexedMemoryChunk, "importance" | "triggers" | "projectKey"> {
-  if (!params.curatedRoot && !params.projectScopeEligible) {
-    return { importance: null, triggers: null, projectKey: null };
-  }
-
-  const phrases = new Set<string>();
-  let importance: number | null = null;
-  const annotationStartLine = params.chunk.entryStartLine ?? params.chunk.startLine;
-  const annotationEndLine = params.chunk.entryEndLine ?? params.chunk.endLine;
-  const annotationLines = params.sourceLines.slice(annotationStartLine - 1, annotationEndLine);
-  const projectAnnotations = params.projectScopeEligible
-    ? extractProjectKeysFromCuratedEntry(annotationLines.join("\n"))
-    : { annotated: false, valid: true, keys: [] };
-  for (const line of params.curatedRoot ? annotationLines : []) {
-    const annotationSuffix = line.match(
-      /(?:\s*<!--\s*(?:trigger|importance|project)\s*:[\s\S]*?-->\s*)+$/iu,
-    )?.[0];
-    if (!annotationSuffix) {
-      continue;
-    }
-    for (const match of annotationSuffix.matchAll(
-      /<!--\s*(trigger|importance|project)\s*:\s*([\s\S]*?)\s*-->/giu,
-    )) {
-      const kind = match[1]?.toLowerCase();
-      const value = match[2]?.trim() ?? "";
-      if (kind === "trigger") {
-        for (const phrase of value.split(/[,;]/u).map((entry) => entry.trim())) {
-          if (phrase) {
-            phrases.add(phrase);
-          }
-        }
-        continue;
-      }
-      if (kind === "importance" && /^\d+$/u.test(value)) {
-        const parsed = Number.parseInt(value, 10);
-        if (parsed >= 1 && parsed <= 10) {
-          importance = Math.max(importance ?? parsed, parsed);
-        }
-      }
-    }
-  }
-
-  // Missing annotations intentionally stay NULL: pre-annotation indexes keep
-  // neutral ranking and never become trigger candidates after a reindex.
-  return {
-    importance,
-    triggers: phrases.size > 0 ? [...phrases].join("; ") : null,
-    // Invalid annotations remain scoped but unsatisfiable; treating them as NULL
-    // would make malformed project memory global and leak it into every project.
-    projectKey:
-      projectAnnotations.annotated && !projectAnnotations.valid
-        ? INVALID_PROJECT_ANNOTATION_KEY
-        : projectAnnotations.keys.length > 0
-          ? projectAnnotations.keys.join("; ")
-          : null,
-  };
-}
 
 // Retry attempts are host control state. Provider-thrown values stay opaque so
 // they cannot override the counter or break accounting when they are immutable.
@@ -1043,6 +979,12 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           pathClassification.originClass,
         );
       }
+      // Fragments inherit one entry's metadata; parse each source span once,
+      // not once per fragment of a long line or oversized entry.
+      const recallMetadata = new Map<
+        string,
+        ReturnType<typeof extractCuratedEntryRecallMetadata>
+      >();
       const chunks = (
         generation?.kind === "semantic"
           ? enforceEmbeddingMaxInputTokens(
@@ -1051,18 +993,22 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
               EMBEDDING_BATCH_MAX_TOKENS,
             )
           : baseChunks
-      ).map((chunk): IndexedMemoryChunk =>
-        Object.assign(
-          chunk,
-          resolveChunkRecallMetadata({
+      ).map((chunk): IndexedMemoryChunk => {
+        const start = chunk.entryStartLine ?? chunk.startLine;
+        const end = chunk.entryEndLine ?? chunk.endLine;
+        const span = `${start}:${end}`;
+        let metadata = recallMetadata.get(span);
+        if (!metadata) {
+          metadata = extractCuratedEntryRecallMetadata({
             curatedRoot: pathClassification.curatedRoot,
             projectScopeEligible:
               options.source === "memory" && normalizedEntryPath.toUpperCase() !== "USER.MD",
-            sourceLines,
-            chunk,
-          }),
-        ),
-      );
+            sourceLines: sourceLines.slice(start - 1, end),
+          });
+          recallMetadata.set(span, metadata);
+        }
+        return Object.assign(chunk, metadata);
+      });
       if (options.source === "sessions" && "lineMap" in entry) {
         remapChunkLines(chunks, entry.lineMap);
       }

--- a/packages/memory-host-sdk/src/host/curated-annotations.test.ts
+++ b/packages/memory-host-sdk/src/host/curated-annotations.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractCuratedEntryRecallMetadata,
+  extractProjectKeysFromCuratedEntry,
+  stripMemoryAnnotationCarriers,
+} from "./curated-annotations.js";
+
+describe("curated annotation grammar", () => {
+  it.each([
+    ["<!--\n trigger: x -->", ""],
+    ["<!--trigger\n: x -->", ""],
+    ["<!--trigger:\n x -->", "<!--trigger:\n x -->"],
+    ["<!--trigger:\n<!--importance: 7 -->", "<!--trigger:\n"],
+    ["<!--trigger:x <!--\nimportance:7 -->", "<!--trigger:x"],
+    ["text <!--note: visible -->", "text <!--note: visible -->"],
+    ["a \t<!--trigger: x -->\r\nb \tX", "a\r\nb \tX"],
+  ])("strips carriers without changing the grammar of %j", (input, expected) => {
+    expect(stripMemoryAnnotationCarriers(input)).toBe(expected);
+  });
+
+  it.each([
+    ["<!-- trigger: <!-- project: alpha -->", true, ["alpha"], 1, 1],
+    ["<!-- project: outer <!-- project: inner -->", false, [], 1, 0],
+    ["<!--project: a;\n b -->", true, ["a", "b"], 2, 2],
+    ["<!--project: a; a -->", true, ["a"], 2, 2],
+    ["<!--project: \n a\n -->", true, ["a"], 1, 1],
+    ["<!--project: a\n b -->", false, [], 1, 0],
+    ["<!--project: a --> <!--project:", false, ["a"], 1, 1],
+  ])("preserves project scope for %j", (input, valid, keys, rawCount, validCount) => {
+    expect(extractProjectKeysFromCuratedEntry(input)).toEqual({
+      annotated: true,
+      valid,
+      keys,
+      rawCount,
+      validCount,
+    });
+  });
+
+  it("preserves suffix selection, value validation, and ordered trigger deduplication", () => {
+    expect(
+      extractCuratedEntryRecallMetadata({
+        curatedRoot: true,
+        projectScopeEligible: true,
+        sourceLines: [
+          "body <!--TRIGGER: alpha, beta; alpha --> prose <!-- note --><!--importance: 03 -->",
+          "<!--trigger: ignored --> trailing text",
+          "<!--importance: 11 --><!--importance: 8 --><!--importance: 2.5 -->",
+          "<!--trigger: gamma --><!--project: GitHub.com/Owner/Repo -->",
+        ],
+      }),
+    ).toEqual({
+      triggers: "alpha; beta; gamma",
+      importance: 8,
+      projectKey: "github.com/Owner/Repo",
+    });
+  });
+
+  it("keeps long unfinished carriers unchanged and invalid project markers scoped", () => {
+    const openers = "<!--project:".repeat(20_000);
+    const spaces = `<!--project:${" ".repeat(20_000)}X`;
+    const started = performance.now();
+    for (const input of [openers, spaces]) {
+      expect(stripMemoryAnnotationCarriers(input)).toBe(input);
+      expect(extractProjectKeysFromCuratedEntry(input)).toEqual({
+        annotated: true,
+        valid: false,
+        keys: [],
+        rawCount: 0,
+        validCount: 0,
+      });
+    }
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+});

--- a/packages/memory-host-sdk/src/host/curated-annotations.ts
+++ b/packages/memory-host-sdk/src/host/curated-annotations.ts
@@ -1,17 +1,59 @@
 // Pure curated-memory annotation parsing shared by runtime and doctor paths.
 export const INVALID_PROJECT_ANNOTATION_KEY = "!invalid-project-annotation";
 
-// Carrier syntax is line-scoped like recall metadata parsing. Never cross a
-// newline from an unterminated marker into the next entry's valid annotation.
-const MEMORY_ANNOTATION_CARRIER_RE = /<!--\s*(?:trigger|importance|project)\s*:[^\r\n]*?-->/giu;
+function* scanMemoryAnnotations(text: string, marker: RegExp, lineScoped = false) {
+  let closing = -1;
+  let newline = -1;
+  const lineBreak = /[\r\n]/gu;
+  for (let match = marker.exec(text); match; match = marker.exec(text)) {
+    const valueStart = marker.lastIndex;
+    // Failed carriers can contain later openers. Reuse forward-only delimiter
+    // positions so those openers never rescan the same unterminated suffix.
+    if (closing < valueStart) {
+      closing = text.indexOf("-->", valueStart);
+      if (closing < 0) {
+        return;
+      }
+    }
+    if (lineScoped) {
+      if (newline < valueStart) {
+        lineBreak.lastIndex = valueStart;
+        newline = lineBreak.exec(text)?.index ?? text.length;
+      }
+      if (newline < closing) {
+        continue;
+      }
+    }
+    yield {
+      start: match.index,
+      end: closing + 3,
+      kind: match[1]?.toLowerCase(),
+      value: text.slice(valueStart, closing).trim(),
+    };
+    marker.lastIndex = closing + 3;
+  }
+}
 
 export function stripMemoryAnnotationCarriers(text: string): string {
-  let stripped = false;
-  const withoutCarriers = text.replace(MEMORY_ANNOTATION_CARRIER_RE, () => {
-    stripped = true;
-    return "";
+  const parts: string[] = [];
+  let cursor = 0;
+  // Only the body is line-scoped; preserve the existing whitespace-prefix grammar.
+  for (const annotation of scanMemoryAnnotations(
+    text,
+    /<!--\s*(trigger|importance|project)\s*:/giu,
+    true,
+  )) {
+    parts.push(text.slice(cursor, annotation.start));
+    cursor = annotation.end;
+  }
+  if (cursor === 0) {
+    return text;
+  }
+  parts.push(text.slice(cursor));
+  return parts.join("").replace(/[ \t]+/gu, (space, offset, source: string) => {
+    const end = offset + space.length;
+    return end === source.length || /[\r\n\u2028\u2029]/u.test(source.charAt(end)) ? "" : space;
   });
-  return stripped ? withoutCarriers.replace(/[ \t]+(?=\r?$)/gmu, "") : text;
 }
 
 export type CuratedProjectAnnotations = {
@@ -46,9 +88,11 @@ export function extractProjectKeysFromCuratedEntry(text: string): CuratedProject
   let parsedCount = 0;
   let rawCount = 0;
   let validCount = 0;
-  for (const match of text.matchAll(/<!--\s*project\s*:\s*([\s\S]*?)\s*-->/giu)) {
+  // Projects are scanned independently: a project marker inside another
+  // annotation still scopes the entry, and nested project markers stay invalid.
+  for (const annotation of scanMemoryAnnotations(text, /<!--\s*(project)\s*:/giu)) {
     parsedCount += 1;
-    for (const rawKey of (match[1] ?? "").split(";")) {
+    for (const rawKey of annotation.value.split(";")) {
       rawCount += 1;
       const key = normalizeProjectAnnotationKey(rawKey);
       if (key) {
@@ -64,5 +108,53 @@ export function extractProjectKeysFromCuratedEntry(text: string): CuratedProject
     keys: [...keys],
     rawCount,
     validCount,
+  };
+}
+
+export function extractCuratedEntryRecallMetadata(params: {
+  sourceLines: string[];
+  curatedRoot: boolean;
+  projectScopeEligible: boolean;
+}): { importance: number | null; triggers: string | null; projectKey: string | null } {
+  const phrases = new Set<string>();
+  let importance: number | null = null;
+  const projectAnnotations = params.projectScopeEligible
+    ? extractProjectKeysFromCuratedEntry(params.sourceLines.join("\n"))
+    : { annotated: false, valid: true, keys: [] };
+  for (const line of params.curatedRoot ? params.sourceLines : []) {
+    // The original suffix may span intervening text or ordinary comments.
+    // Its only additional constraint is a closing marker at the end of the line.
+    if (!line.trimEnd().endsWith("-->")) {
+      continue;
+    }
+    for (const { kind, value } of scanMemoryAnnotations(
+      line,
+      /<!--\s*(trigger|importance|project)\s*:/giu,
+    )) {
+      if (kind === "trigger") {
+        for (const phrase of value.split(/[,;]/u).map((entry) => entry.trim())) {
+          if (phrase) {
+            phrases.add(phrase);
+          }
+        }
+      } else if (kind === "importance" && /^\d+$/u.test(value)) {
+        const parsed = Number.parseInt(value, 10);
+        if (parsed >= 1 && parsed <= 10) {
+          importance = Math.max(importance ?? parsed, parsed);
+        }
+      }
+    }
+  }
+  // Missing annotations retain neutral ranking and never become trigger candidates.
+  return {
+    importance,
+    triggers: phrases.size > 0 ? [...phrases].join("; ") : null,
+    // Invalid project metadata must not turn a scoped entry into global memory.
+    projectKey:
+      projectAnnotations.annotated && !projectAnnotations.valid
+        ? INVALID_PROJECT_ANNOTATION_KEY
+        : projectAnnotations.keys.length > 0
+          ? projectAnnotations.keys.join("; ")
+          : null,
   };
 }

--- a/src/plugin-sdk/memory-core-host-engine-curated.ts
+++ b/src/plugin-sdk/memory-core-host-engine-curated.ts
@@ -1,5 +1,6 @@
 // Focused curated-memory annotation helpers for doctor and promotion paths.
 export {
+  extractCuratedEntryRecallMetadata,
   extractProjectKeysFromCuratedEntry,
   type CuratedProjectAnnotations,
 } from "../../packages/memory-host-sdk/src/host/curated-annotations.js";


### PR DESCRIPTION
Fixes #138994.

## What Problem This Solves

A short incomplete annotation in `MEMORY.md` can block memory indexing for seconds. The original repeated suffix expression explores many ways to divide comments before rejecting an incomplete final marker.

The initial repair removed exponential backtracking but retained quadratic work and changed recall metadata when ordinary comments appeared between annotations.

## Why This Change Was Made

Use the existing curated-annotation owner for one forward-only scanner shared by carrier stripping, project extraction, and recall metadata parsing. Reuse metadata for fragments with the same source span.

Keep the existing grammar:

- Trailing recall metadata can span intervening ordinary comments and text.
- Trigger phrases retain their order and deduplication; importance retains the largest valid value from 1 through 10.
- Project extraction stays independent, including project markers nested inside other annotation payloads.
- Incomplete and invalid project annotations remain scoped but unsatisfiable.
- Existing multiline-prefix and line-scoped carrier-body behavior stays unchanged.

This removes the manager-owned parser and the proposed test-only matcher export. No configuration, schema, migration, or stored representation changes.

## User Impact

Curated memory indexing stays responsive with incomplete or long annotation-shaped input in both keyword-only and semantic modes. Reindexing preserves existing recall metadata and project isolation.

Thanks @lzhan011 for the report, initial repair, and short reproduction.

## Evidence

Baseline: `49ecde890905fa601cafc9cfbf6ea0cfe9aab824`.
Verified candidate: `4e2ad3d06424b17f769df6b2724d7d7250e16b92`.

### Real indexing

Ran the built CLI against isolated workspaces and databases:

```sh
node openclaw.mjs memory index --force --verbose
```

The reported 403-byte payload was placed inside a 432-byte curated entry. On main, the command took 25.38 seconds and the event loop stalled for 20.19 seconds. The baseline control had a 1.62-second startup delay.

On the candidate, the same keyword-only witness took 5.01 seconds including startup, with maximum event-loop delay 1.54 seconds. A 300 KB version took 4.99 seconds. Valid mixed-comment metadata remained intact.

Separate runs used deliberately unfinished project openers:

| Input | Keyword-only command | Semantic command | Embedding requests |
|---|---:|---:|---:|
| 120 KB | 4.78 s | 5.40 s | 38 |
| 240 KB | 4.88 s | 5.53 s | 76 |
| 480 KB | 5.03 s | 5.79 s | 151 |
| 960 KB | 5.08 s | 6.06 s | 301 |

These times include CLI startup. Semantic runs used a local deterministic HTTP embedding endpoint through the real provider, chunking, indexing, and SQLite publication path. They are not live external-provider tests. Embedding requests increased with input size; repeated identical fragments naturally share persisted chunk identities.

Both modes also passed valid trigger/importance/project controls, nontrailing-annotation controls, the original witness, and a 160 KB incomplete whitespace tail. Stored metadata and embedding rows were inspected.

### Regression and compatibility

- New indexing regression fails on baseline in both modes: 3.80/3.88 seconds against a 3-second bound.
- Candidate: 16 shared-owner grammar tests and all 72 index tests pass; the new cases take about 0.11 seconds each.
- 50,000 bounded generated cases match baseline carrier stripping, project extraction, and all recall/project eligibility combinations.
- Shared-owner incomplete-input medians across seven samples: 120 KB 0.90 ms; 240 KB 1.85 ms; 480 KB 3.13 ms; 960 KB 8.78 ms; 1.92 MB 18.76 ms.
- Existing invalid-project isolation, curated/daily/user eligibility, search, and oversized-fragment inheritance tests pass.
- Exact pinned formatter, type-aware lint for both changed lanes, runtime build, and independent code review pass.

The runtime build used the baseline source archive plus the candidate's committed files, with source digests checked after commit. Baseline dependency build artifacts were reused; the runtime was rebuilt from the repaired source. The runtime-only build's inherited version metadata is not used as candidate identity.

### Diff accounting

- Production: +123 / -84, net +39.
- Tests: +117 / -0.
- Much of the parser moved to its existing owner. Remaining growth implements a shared forward-only scanner and per-source-span reuse. A shorter suffix-only regex change leaves the other incomplete-input scans and repeated-fragment work unresolved.

The existing review's mixed-comment, whitespace, long-input, real-indexing, and compatibility requests are covered above.
