### PR TITLE
fix(memory): split batches rejected by explicit provider size limits

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
@@ -132,6 +132,10 @@ describe("memory embedding batch retry boundary", () => {
         `Embeddings API input limit exceeded: max 10, got ${count}. Request id: fixture-000597000`,
     ],
     ["an explicit maximum input length", () => "embeddings max input length is 10"],
+    [
+      "an explicit maximum batch size",
+      () => "batch size is invalid, it should not be larger than 10",
+    ],
   ])(
     "splits provider errors with %s without retrying oversized requests",
     async (_label, error) => {

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -214,6 +214,7 @@ describe("memory embedding policy", () => {
     for (const message of [
       "Embeddings API input limit exceeded: max 10, got 33. Request id: fixture-000597000",
       "embeddings max input length is 16",
+      "batch size is invalid, it should not be larger than 20",
     ]) {
       expect(isSplittableMemoryEmbeddingBatchError(message)).toBe(true);
       expect(isRetryableMemoryEmbeddingError(message)).toBe(false);
@@ -223,6 +224,9 @@ describe("memory embedding policy", () => {
       "embedding input exceeds maximum token length 4096",
       "embeddings max input length is unknown",
       "Embeddings API input limit exceeded",
+      "batch size is invalid, it should not be larger than unknown",
+      "batch size is invalid, it should not be smaller than 20",
+      "input size is invalid, it should not be larger than 20",
       'HTTP 400: {"code":"InvalidParameter","param":"input","message":"input must be a string"}',
     ]) {
       expect(isSplittableMemoryEmbeddingBatchError(message)).toBe(false);

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -55,7 +55,7 @@ const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
   /(fetch failed|other side closed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|UND_ERR_|socket hang up|socket terminated|network error|read ECONN|timed out|connection (?:reset|refused|aborted|timed out)|EHOSTUNREACH|ENETUNREACH|ECONNABORTED|EAI_AGAIN)/i;
 
 const SPLITTABLE_MEMORY_EMBEDDING_BATCH_ERROR_RE =
-  /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted)|\bembeddings (?:api input limit exceeded:\s*max\s+\d+\s*,\s*got\s+\d+|max input length is\s+\d+)\b)/i;
+  /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted)|\bbatch size is invalid,\s*it should not be larger than\s+\d+\b|\bembeddings (?:api input limit exceeded:\s*max\s+\d+\s*,\s*got\s+\d+|max input length is\s+\d+)\b)/i;
 
 export function isSplittableMemoryEmbeddingBatchError(message: string): boolean {
   return SPLITTABLE_MEMORY_EMBEDDING_BATCH_ERROR_RE.test(message);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users of OpenAI-compatible embedding providers would see memory indexing fail permanently when the provider rejected an oversized item batch with an explicit numeric maximum.

## Why This Change Was Made

Recognize the provider-neutral error form `batch size is invalid, it should not be larger than <N>` and route it through the existing recursive batch splitter. Nonnumeric limits, minimum-size errors, input-size errors, and generic 400 validation failures remain unsplittable.

## User Impact

Memory indexing can recover automatically when a compatible embedding service reports an explicit maximum batch item count, without provider-specific configuration.

## Evidence

- Focused extension-memory Vitest: 24/24 passed
- Verified recursive splitting of 33 inputs until each request was at or below the reported limit
- Verified four neighboring validation errors remain unsplittable
- Oxlint: 0 warnings / 0 errors
- Oxfmt and `git diff --check`: passed
