### PR TITLE
refactor(claws): type MCP provenance queries

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2259,7 +2259,7 @@ src/claws/cron.ts	13
 src/claws/doctor.ts	2
 src/claws/export.ts	8
 src/claws/lifecycle-delete-support.ts	5
-src/claws/mcp.ts	4
+src/claws/mcp.ts	1
 src/claws/openclaw-profile.ts	1
 src/claws/package-update.ts	1
 src/claws/packages.ts	1

--- a/src/claws/mcp-update.test.ts
+++ b/src/claws/mcp-update.test.ts
@@ -273,6 +273,7 @@ describe("applyClawMcpUpdate", () => {
       independentOwner: true,
     };
     upsertClawMcpServerRef(independent, stateOptions);
+    upsertClawMcpServerRef({ ...independent, createdAtMs: 99 }, stateOptions);
 
     const execution = await applyClawMcpUpdate(
       plan([

--- a/src/claws/mcp.ts
+++ b/src/claws/mcp.ts
@@ -1,10 +1,19 @@
 import { createHash } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
 import { coerceErrorMessage, stableStringify } from "@openclaw/normalization-core";
+import type { Selectable } from "kysely";
 import { setConfiguredMcpServer } from "../agents/mcp-config-mutation.js";
 import { withClawMcpLifecycleLease } from "../agents/mcp-lifecycle-lease.js";
 import { canonicalizeConfiguredMcpServer } from "../config/mcp-config-normalize.js";
 import { listConfiguredMcpServers } from "../config/mcp-config.js";
+import {
+  compileSqliteQueryBindings,
+  executeSqliteQuerySync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
 import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import type { DB } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -29,19 +38,42 @@ export type PersistedClawMcpServerRef = {
   updatedAtMs: number;
 };
 
-type McpRefRow = {
-  schema_version: string;
-  agent_id: string;
-  name: string;
-  config_digest: string;
-  relationship: PersistedClawMcpServerRef["relationship"];
-  origin: PersistedClawMcpServerRef["origin"];
-  independent_owner: number | bigint;
-  status: PersistedClawMcpServerRef["status"];
-  error: string | null;
-  created_at_ms: number | bigint;
-  updated_at_ms: number | bigint;
-};
+type McpDatabase = Pick<DB, "claw_mcp_server_refs">;
+type McpRefRow = Selectable<DB["claw_mcp_server_refs"]>;
+
+function selectMcpRefs(db: DatabaseSync) {
+  return getNodeSqliteKysely<McpDatabase>(db)
+    .selectFrom("claw_mcp_server_refs")
+    .select([
+      "schema_version",
+      "agent_id",
+      "name",
+      "config_digest",
+      "relationship",
+      "origin",
+      "independent_owner",
+      "status",
+      "error",
+      "created_at_ms",
+      "updated_at_ms",
+    ]);
+}
+
+function refToRow(ref: PersistedClawMcpServerRef): McpRefRow {
+  return {
+    agent_id: ref.agentId,
+    name: ref.name,
+    schema_version: ref.schemaVersion,
+    config_digest: ref.configDigest,
+    relationship: ref.relationship,
+    origin: ref.origin,
+    independent_owner: ref.independentOwner ? 1 : 0,
+    status: ref.status,
+    error: ref.error ?? null,
+    created_at_ms: ref.createdAtMs,
+    updated_at_ms: ref.updatedAtMs,
+  };
+}
 
 export class ClawMcpInstallError extends Error {
   constructor(
@@ -65,10 +97,13 @@ function rowToRef(row: McpRefRow): PersistedClawMcpServerRef {
     agentId: row.agent_id,
     name: row.name,
     configDigest: row.config_digest,
-    relationship: row.relationship,
-    origin: row.origin,
+    // SAFETY: The canonical table constrains relationship to these two values.
+    relationship: row.relationship as PersistedClawMcpServerRef["relationship"],
+    // SAFETY: The canonical table constrains origin to these two values.
+    origin: row.origin as PersistedClawMcpServerRef["origin"],
     independentOwner: sqliteNumber(row.independent_owner) === 1,
-    status: row.status,
+    // SAFETY: Existing inventory exposes stored status without additional validation.
+    status: row.status as PersistedClawMcpServerRef["status"],
     ...(row.error ? { error: row.error } : {}),
     createdAtMs: sqliteNumber(row.created_at_ms),
     updatedAtMs: sqliteNumber(row.updated_at_ms),
@@ -90,15 +125,25 @@ function persistPendingRef(
   const nowMs = options.nowMs ?? Date.now();
   const configDigest = digestClawMcpServer(server);
   const database = openOpenClawStateDatabase(options);
-  const existing = database.db /* sqlite-allow-raw: read one Claw MCP ownership row. */
-    .prepare(
-      `SELECT schema_version, agent_id, name, config_digest, relationship, origin,
-              independent_owner, status, error,
-              created_at_ms, updated_at_ms
-         FROM claw_mcp_server_refs
-        WHERE agent_id = ? AND name = ?`,
-    )
-    .get(plan.agent.finalId, name) as McpRefRow | undefined;
+  const { compiled, bind } = compileSqliteQueryBindings<{ agentId: string; name: string }>(
+    (parameter) =>
+      selectMcpRefs(database.db)
+        .where(
+          "agent_id",
+          "=",
+          parameter((value) => value.agentId),
+        )
+        .where(
+          "name",
+          "=",
+          parameter((value) => value.name),
+        ),
+  );
+  const existing =
+    database.db /* sqlite-allow-raw: preserve native point-read errors outside the write transaction. */
+      .prepare(compiled.sql)
+      // SAFETY: The canonical table and explicit projection provide this generated row shape.
+      .get(...bind({ agentId: plan.agent.finalId, name })) as McpRefRow | undefined;
   if (existing) {
     const ref = rowToRef(existing);
     if (ref.configDigest !== configDigest || ref.status === "failed") {
@@ -121,30 +166,10 @@ function persistPendingRef(
     updatedAtMs: nowMs,
   };
   runOpenClawStateWriteTransaction(({ db }) => {
-    db /* sqlite-allow-raw: persist one pending Claw MCP ownership row. */
-      .prepare(
-        `INSERT INTO claw_mcp_server_refs (
-         agent_id, name, schema_version, config_digest, relationship, origin,
-         independent_owner, status, error,
-         created_at_ms, updated_at_ms
-       ) VALUES (
-         @agent_id, @name, @schema_version, @config_digest, @relationship, @origin,
-         @independent_owner, @status, NULL,
-         @created_at_ms, @updated_at_ms
-       )`,
-      )
-      .run({
-        agent_id: ref.agentId,
-        name: ref.name,
-        schema_version: ref.schemaVersion,
-        config_digest: ref.configDigest,
-        relationship: ref.relationship,
-        origin: ref.origin,
-        independent_owner: ref.independentOwner ? 1 : 0,
-        status: ref.status,
-        created_at_ms: nowMs,
-        updated_at_ms: nowMs,
-      });
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<McpDatabase>(db).insertInto("claw_mcp_server_refs").values(refToRow(ref)),
+    );
   }, options);
   return { ref, existing: false };
 }
@@ -156,19 +181,18 @@ function updateRef(
 ): PersistedClawMcpServerRef {
   const updated = { ...ref, ...update, updatedAtMs: options.nowMs ?? Date.now() };
   runOpenClawStateWriteTransaction(({ db }) => {
-    db /* sqlite-allow-raw: update one Claw MCP ownership row after config write. */
-      .prepare(
-        `UPDATE claw_mcp_server_refs
-          SET status = @status, error = @error, updated_at_ms = @updated_at_ms
-        WHERE agent_id = @agent_id AND name = @name`,
-      )
-      .run({
-        agent_id: ref.agentId,
-        name: ref.name,
-        status: update.status,
-        error: update.error ?? null,
-        updated_at_ms: updated.updatedAtMs,
-      });
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<McpDatabase>(db)
+        .updateTable("claw_mcp_server_refs")
+        .set({
+          status: update.status,
+          error: update.error ?? null,
+          updated_at_ms: updated.updatedAtMs,
+        })
+        .where("agent_id", "=", ref.agentId)
+        .where("name", "=", ref.name),
+    );
   }, options);
   return updated;
 }
@@ -307,25 +331,24 @@ export function readClawMcpServerRefs(
   agentId: string,
   options: OpenClawStateDatabaseOptions = {},
 ): PersistedClawMcpServerRef[] {
-  const database = openOpenClawStateDatabase(options);
-  if (
-    options.readOnly &&
-    !database.db /* sqlite-allow-raw: read-only Claw MCP table-existence probe. */
-      .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'claw_mcp_server_refs'")
-      .get()
-  ) {
+  const { db } = openOpenClawStateDatabase(options);
+  if (options.readOnly && !tableExists(db, "claw_mcp_server_refs")) {
     return [];
   }
-  const rows = database.db /* sqlite-allow-raw: read Claw MCP refs for one agent. */
-    .prepare(
-      `SELECT schema_version, agent_id, name, config_digest, relationship, origin,
-              independent_owner, status, error,
-              created_at_ms, updated_at_ms
-         FROM claw_mcp_server_refs
-        WHERE agent_id = ?
-        ORDER BY name`,
-    )
-    .all(agentId) as McpRefRow[];
+  const { compiled, bind } = compileSqliteQueryBindings<string>((parameter) =>
+    selectMcpRefs(db)
+      .where(
+        "agent_id",
+        "=",
+        parameter((value) => value),
+      )
+      .orderBy("name"),
+  );
+  const rows =
+    db /* sqlite-allow-raw: preserve native full-agent inventory errors without a write transaction. */
+      .prepare(compiled.sql)
+      // SAFETY: The canonical table and explicit projection provide this generated row shape.
+      .all(...bind(agentId)) as McpRefRow[];
   return rows.map(rowToRef);
 }
 
@@ -333,25 +356,24 @@ export function readClawMcpServerRefsByName(
   name: string,
   options: OpenClawStateDatabaseOptions = {},
 ): PersistedClawMcpServerRef[] {
-  const database = openOpenClawStateDatabase(options);
-  if (
-    options.readOnly &&
-    !database.db /* sqlite-allow-raw: read-only Claw MCP table-existence probe. */
-      .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'claw_mcp_server_refs'")
-      .get()
-  ) {
+  const { db } = openOpenClawStateDatabase(options);
+  if (options.readOnly && !tableExists(db, "claw_mcp_server_refs")) {
     return [];
   }
-  const rows = database.db /* sqlite-allow-raw: read sibling Claw MCP refs by server name. */
-    .prepare(
-      `SELECT schema_version, agent_id, name, config_digest, relationship, origin,
-              independent_owner, status, error,
-              created_at_ms, updated_at_ms
-         FROM claw_mcp_server_refs
-        WHERE name = ?
-        ORDER BY agent_id`,
-    )
-    .all(name) as McpRefRow[];
+  const { compiled, bind } = compileSqliteQueryBindings<string>((parameter) =>
+    selectMcpRefs(db)
+      .where(
+        "name",
+        "=",
+        parameter((value) => value),
+      )
+      .orderBy("agent_id"),
+  );
+  const rows =
+    db /* sqlite-allow-raw: preserve native sibling-inventory errors without a write transaction. */
+      .prepare(compiled.sql)
+      // SAFETY: The canonical table and explicit projection provide this generated row shape.
+      .all(...bind(name)) as McpRefRow[];
   return rows.map(rowToRef);
 }
 
@@ -445,9 +467,13 @@ export function deleteClawMcpServerRef(
   options: OpenClawStateDatabaseOptions = {},
 ): void {
   runOpenClawStateWriteTransaction(({ db }) => {
-    db /* sqlite-allow-raw: delete one released Claw MCP ownership row. */
-      .prepare("DELETE FROM claw_mcp_server_refs WHERE agent_id = ? AND name = ?")
-      .run(agentId, name);
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<McpDatabase>(db)
+        .deleteFrom("claw_mcp_server_refs")
+        .where("agent_id", "=", agentId)
+        .where("name", "=", name),
+    );
   }, options);
 }
 
@@ -456,39 +482,24 @@ export function upsertClawMcpServerRef(
   options: OpenClawStateDatabaseOptions = {},
 ): void {
   runOpenClawStateWriteTransaction(({ db }) => {
-    db /* sqlite-allow-raw: Claw MCP lifecycle provenance write. */
-      .prepare(
-        `INSERT INTO claw_mcp_server_refs (
-         agent_id, name, schema_version, config_digest, relationship, origin,
-         independent_owner, status, error,
-         created_at_ms, updated_at_ms
-       ) VALUES (
-         @agent_id, @name, @schema_version, @config_digest, @relationship, @origin,
-         @independent_owner, @status, @error,
-         @created_at_ms, @updated_at_ms
-       )
-       ON CONFLICT(agent_id, name) DO UPDATE SET
-         schema_version = excluded.schema_version,
-         config_digest = excluded.config_digest,
-         relationship = excluded.relationship,
-         origin = excluded.origin,
-         independent_owner = excluded.independent_owner,
-         status = excluded.status,
-         error = excluded.error,
-         updated_at_ms = excluded.updated_at_ms`,
-      )
-      .run({
-        agent_id: ref.agentId,
-        name: ref.name,
-        schema_version: ref.schemaVersion,
-        config_digest: ref.configDigest,
-        relationship: ref.relationship,
-        origin: ref.origin,
-        independent_owner: ref.independentOwner ? 1 : 0,
-        status: ref.status,
-        error: ref.error ?? null,
-        created_at_ms: ref.createdAtMs,
-        updated_at_ms: ref.updatedAtMs,
-      });
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<McpDatabase>(db)
+        .insertInto("claw_mcp_server_refs")
+        .values(refToRow(ref))
+        .onConflict((conflict) =>
+          conflict.columns(["agent_id", "name"]).doUpdateSet((eb) => ({
+            schema_version: eb.ref("excluded.schema_version"),
+            config_digest: eb.ref("excluded.config_digest"),
+            relationship: eb.ref("excluded.relationship"),
+            origin: eb.ref("excluded.origin"),
+            independent_owner: eb.ref("excluded.independent_owner"),
+            status: eb.ref("excluded.status"),
+            error: eb.ref("excluded.error"),
+            // Existing claims retain their original creation timestamp through updates and undo.
+            updated_at_ms: eb.ref("excluded.updated_at_ms"),
+          })),
+        ),
+    );
   }, options);
 }


### PR DESCRIPTION
## What Problem This Solves

Claw MCP ownership maintained seven ordinary SQL statements, repeated row projections, and duplicate schema probes beside the shared typed database layer. This made installation, sharing, update, and removal harder to maintain consistently.

## Why This Change Was Made

Use the generated table type and existing Kysely helpers, with one projection and one row encoder. The three reads retain native execution and error ownership; writes retain their synchronous transaction boundaries. Updates and rollback preserve the original creation timestamp and all existing ownership fields.

The production delta is +144/-133, net +11. Those lines provide the shared typed projection and bindings while retaining the native read contract. Tests add one line to an existing real rollback case; the assertion allowance shrinks from four to one. No schema, stored format, configuration, retention, or authority policy changes.

## User Impact

No intended behavior change. Claw MCP installation, shared ownership, update, export, and removal keep their existing results while using the canonical database helpers.

## Evidence

- All 93 focused tests across eight files passed, along with the full changed gate and Kysely guard.
- Paired actual SQLite owner runs passed seven phases and a fresh-process reopen: full row values, opaque bindings, native read failures, sharing and adoption, failed completion and reconciliation, ignored zero-row writes, rollback, and borrowed handle lifetime remained equal.
- Eleven real CLI commands passed before and after, including add/update/export, consent refusal, removal, and fresh status. The canonical MCP configuration owner retained an unrelated server, edited workspace file, and sibling workspace.
- The final CLI run used regular-file stdout/stderr redirection. An earlier pipe-capture run passed its first ten commands but truncated the final missing-status JSON to 512 of 514 bytes. That unchanged output/exit path remains a named follow-up; this PR does not claim to repair it.
- Independent Codex review completed four passes with no P0–P2 findings. Direct installed Kysely and Node SQLite contracts were inspected.
