### PR TITLE
fix(memory): concurrent syncs time out during slow embeddings

### DIFF
--- a/extensions/memory-core/src/memory/manager-reindex-lock.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-lock.ts
@@ -5,6 +5,7 @@ import {
 } from "./manager-sqlite-lease.js";
 
 export type MemoryReindexLockHandle = MemorySqliteLeaseHandle;
+export type MemoryReindexLockMode = "shared" | "exclusive";
 
 const REINDEX_LOCK_WAIT_TIMEOUT_MS = 2_000;
 const REINDEX_LOCK_RETRY_DELAY_MS = 25;
@@ -26,26 +27,46 @@ function createMemoryReindexBusyError(lockPath: string): Error & { code: string 
   );
 }
 
-/** Try to acquire the build lock without locking readers of the live agent database. */
-function tryAcquireMemoryReindexLock(dbPath: string): MemoryReindexLockHandle | undefined {
-  return tryAcquireMemorySqliteLease(resolveMemoryReindexLockPath(dbPath), "exclusive");
+/** Try to acquire the sync/reindex coordination lock without locking the live agent database. */
+function tryAcquireMemoryReindexLock(
+  dbPath: string,
+  mode: MemoryReindexLockMode,
+): MemoryReindexLockHandle | undefined {
+  return tryAcquireMemorySqliteLease(resolveMemoryReindexLockPath(dbPath), mode);
 }
 
-/** Wait asynchronously for the exclusive build lock without blocking the Node event loop. */
-export async function waitForMemoryReindexLock(dbPath: string): Promise<MemoryReindexLockHandle> {
+/** Wait asynchronously for the sync/reindex lock without blocking the Node event loop. */
+export async function waitForMemoryReindexLock(
+  dbPath: string,
+  mode: MemoryReindexLockMode = "exclusive",
+): Promise<MemoryReindexLockHandle> {
   const lockPath = resolveMemoryReindexLockPath(dbPath);
   const deadline = Date.now() + REINDEX_LOCK_WAIT_TIMEOUT_MS;
   do {
-    const lock = tryAcquireMemoryReindexLock(dbPath);
+    const lock = tryAcquireMemoryReindexLock(dbPath, mode);
     if (lock) {
       return lock;
     }
     await sleepAsync(REINDEX_LOCK_RETRY_DELAY_MS);
   } while (Date.now() < deadline);
 
-  const finalLock = tryAcquireMemoryReindexLock(dbPath);
+  const finalLock = tryAcquireMemoryReindexLock(dbPath, mode);
   if (finalLock) {
     return finalLock;
   }
   throw createMemoryReindexBusyError(lockPath);
+}
+
+/** Run one operation under the requested coordination mode and always release its lease. */
+export async function withMemoryReindexLock<T>(
+  dbPath: string,
+  mode: MemoryReindexLockMode,
+  run: () => Promise<T>,
+): Promise<T> {
+  const lock = await waitForMemoryReindexLock(dbPath, mode);
+  try {
+    return await run();
+  } finally {
+    lock.release();
+  }
 }

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -36,6 +36,7 @@ import {
   resolveFallbackCurrentProviderId,
   resolveMemoryFallbackProviderRequest,
 } from "./manager-provider-state.js";
+import { withMemoryReindexLock } from "./manager-reindex-lock.js";
 import {
   MEMORY_INDEX_PROVENANCE_VERSION,
   resolveConfiguredScopeHash,
@@ -157,6 +158,7 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
   protected async runSync(params?: MemorySyncParams) {
     const hasTargetSessionRequest = this.hasRequestedTargetSessionSync(params);
     let needsFullReindex = Boolean(params?.force && !hasTargetSessionRequest);
+    let cachePrunedUnderLock = false;
     try {
       // An unavailable configured provider must not replace semantic vectors
       // with FTS-only rows; fresh and already-FTS-only indexes remain safe.
@@ -273,26 +275,33 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
         return;
       }
       if (!needsFullSessionReindex) {
-        const targetedSessionSync = await runMemoryTargetedSessionSync({
-          hasSessionSource: this.sources.has("sessions"),
-          targetArchiveFiles,
-          reason: params?.reason,
-          progress: progress ?? undefined,
-          sessionsFullRetryDirty: this.sessionsFullRetryDirty,
-          sessionsReconcileDirty: this.sessionsReconcileDirty,
-          sessionsDirtyFiles: this.sessionsDirtyFiles,
-          syncArchiveFiles: async (targetedParams) => {
-            await this.syncArchiveFiles({
-              ...targetedParams,
-              corpusEntries: targetSessionSync?.corpusEntries,
-            });
-          },
-          shouldFallbackOnError: (err) => this.shouldFallbackOnError(err),
-          activateFallbackProvider: async (reason) => {
-            this.endSyncProviderGeneration();
-            return await this.activateFallbackProvider(reason);
-          },
-        });
+        // Targeted updates share coordination with other incremental writers,
+        // while reset and full reindex still require exclusive admission.
+        const targetedSessionSync = await withMemoryReindexLock(
+          resolveUserPath(this.settings.store.databasePath),
+          "shared",
+          async () =>
+            await runMemoryTargetedSessionSync({
+              hasSessionSource: this.sources.has("sessions"),
+              targetArchiveFiles,
+              reason: params?.reason,
+              progress: progress ?? undefined,
+              sessionsFullRetryDirty: this.sessionsFullRetryDirty,
+              sessionsReconcileDirty: this.sessionsReconcileDirty,
+              sessionsDirtyFiles: this.sessionsDirtyFiles,
+              syncArchiveFiles: async (targetedParams) => {
+                await this.syncArchiveFiles({
+                  ...targetedParams,
+                  corpusEntries: targetSessionSync?.corpusEntries,
+                });
+              },
+              shouldFallbackOnError: (err) => this.shouldFallbackOnError(err),
+              activateFallbackProvider: async (reason) => {
+                this.endSyncProviderGeneration();
+                return await this.activateFallbackProvider(reason);
+              },
+            }),
+        );
         if (targetedSessionSync.handled) {
           this.sessionsDirty = targetedSessionSync.sessionsDirty;
           if (targetedSessionSync.failure) {
@@ -301,84 +310,104 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
           return;
         }
       }
-      try {
-        if (needsFullReindex) {
-          await this.runInPlaceReindex({
-            reason: params?.reason,
-            force: params?.force,
-            progress: progress ?? undefined,
-          });
-          return;
-        }
+      // Embedding work may be slow, so only true shadow rebuilds own the
+      // exclusive lease. Shared incremental leases still prevent reset from
+      // overtaking writes without excluding other incremental generations.
+      await withMemoryReindexLock(
+        resolveUserPath(this.settings.store.databasePath),
+        needsFullReindex ? "exclusive" : "shared",
+        async () => {
+          try {
+            if (needsFullReindex) {
+              await this.runInPlaceReindex({
+                reason: params?.reason,
+                force: params?.force,
+                progress: progress ?? undefined,
+              });
+              return;
+            }
 
-        const shouldSyncMemory = this.sources.has("memory") && this.dirty;
-        const shouldSyncSessions = this.shouldSyncSessions(params, needsFullReindex);
+            const shouldSyncMemory = this.sources.has("memory") && this.dirty;
+            const shouldSyncSessions = this.shouldSyncSessions(params, needsFullReindex);
 
-        if (this.shouldDeferSourceWideBatch()) {
-          await this.executeSourceWideSync({
-            shouldSyncMemory,
-            shouldSyncSessions,
-            needsFullReindex,
-            needsFullSessionReindex,
-            targetArchiveFiles: targetArchiveFiles ? Array.from(targetArchiveFiles) : undefined,
-            progress: progress ?? undefined,
-          });
-          if (shouldSyncMemory) {
-            this.clearMemoryRetryState();
-          }
-          if (shouldSyncSessions) {
-            this.clearSessionRetryState();
-          } else {
-            this.refreshSessionDirtyFlag();
-          }
-        } else {
-          if (shouldSyncMemory) {
-            await this.syncMemoryFiles({ needsFullReindex, progress: progress ?? undefined });
-            this.clearMemoryRetryState();
-          }
+            if (this.shouldDeferSourceWideBatch()) {
+              await this.executeSourceWideSync({
+                shouldSyncMemory,
+                shouldSyncSessions,
+                needsFullReindex,
+                needsFullSessionReindex,
+                targetArchiveFiles: targetArchiveFiles ? Array.from(targetArchiveFiles) : undefined,
+                progress: progress ?? undefined,
+              });
+              if (shouldSyncMemory) {
+                this.clearMemoryRetryState();
+              }
+              if (shouldSyncSessions) {
+                this.clearSessionRetryState();
+              } else {
+                this.refreshSessionDirtyFlag();
+              }
+            } else {
+              if (shouldSyncMemory) {
+                await this.syncMemoryFiles({ needsFullReindex, progress: progress ?? undefined });
+                this.clearMemoryRetryState();
+              }
 
-          if (shouldSyncSessions) {
-            await this.syncArchiveFiles({
-              needsFullReindex: needsFullSessionReindex,
-              targetArchiveFiles: targetArchiveFiles ? Array.from(targetArchiveFiles) : undefined,
-              progress: progress ?? undefined,
-            });
-            this.clearSessionRetryState();
-          } else {
-            this.refreshSessionDirtyFlag();
+              if (shouldSyncSessions) {
+                await this.syncArchiveFiles({
+                  needsFullReindex: needsFullSessionReindex,
+                  targetArchiveFiles: targetArchiveFiles
+                    ? Array.from(targetArchiveFiles)
+                    : undefined,
+                  progress: progress ?? undefined,
+                });
+                this.clearSessionRetryState();
+              } else {
+                this.refreshSessionDirtyFlag();
+              }
+            }
+          } catch (err) {
+            const reason = formatErrorMessage(err);
+            const shouldFallback = this.shouldFallbackOnError(err);
+            if (shouldFallback) {
+              // A failed generation cannot wait on its own sync lease while activating fallback.
+              this.endSyncProviderGeneration();
+            }
+            const activated = shouldFallback && (await this.activateFallbackProvider(reason));
+            if (activated) {
+              if (needsFullReindex && !hasTargetArchiveFiles) {
+                this.beginSyncProviderGeneration();
+                await this.runInPlaceReindex({
+                  reason: params?.reason ?? "fallback",
+                  force: true,
+                  progress: progress ?? undefined,
+                });
+              }
+              return;
+            }
+            if (!this.provider && this.fts.enabled && this.shouldFallbackOnError(err)) {
+              this.syncOutcomes.recordActiveFailure(err);
+              log.warn(`memory embeddings unavailable; leaving memory index dirty: ${reason}`);
+              return;
+            }
+            throw err;
+          } finally {
+            if (!needsFullReindex) {
+              this.pruneEmbeddingCacheIfNeeded();
+              cachePrunedUnderLock = true;
+            }
           }
-        }
-      } catch (err) {
-        const reason = formatErrorMessage(err);
-        const shouldFallback = this.shouldFallbackOnError(err);
-        if (shouldFallback) {
-          // A failed generation cannot wait on its own sync lease while activating fallback.
-          this.endSyncProviderGeneration();
-        }
-        const activated = shouldFallback && (await this.activateFallbackProvider(reason));
-        if (activated) {
-          if (needsFullReindex && !hasTargetArchiveFiles) {
-            this.beginSyncProviderGeneration();
-            await this.runInPlaceReindex({
-              reason: params?.reason ?? "fallback",
-              force: true,
-              progress: progress ?? undefined,
-            });
-          }
-          return;
-        }
-        if (!this.provider && this.fts.enabled && this.shouldFallbackOnError(err)) {
-          this.syncOutcomes.recordActiveFailure(err);
-          log.warn(`memory embeddings unavailable; leaving memory index dirty: ${reason}`);
-          return;
-        }
-        throw err;
-      }
+        },
+      );
     } finally {
       // Ordinary sync exits retain live cleanup, including preflight/no-op exits.
       // Full rebuild failures (including forced preflight) leave the primary alone.
-      if (!needsFullReindex) {
-        this.pruneEmbeddingCacheIfNeeded();
+      if (!needsFullReindex && !cachePrunedUnderLock) {
+        await withMemoryReindexLock(
+          resolveUserPath(this.settings.store.databasePath),
+          "shared",
+          async () => this.pruneEmbeddingCacheIfNeeded(),
+        );
       }
     }
   }

--- a/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
@@ -14,6 +14,7 @@ import type { EmbeddingProvider } from "./embeddings.js";
 import { resetMemoryDatabase } from "./manager-db.js";
 import { waitForMemoryReindexLock } from "./manager-reindex-lock.js";
 import type { MemoryIndexMeta } from "./manager-reindex-state.js";
+import { tryAcquireMemorySqliteLease } from "./manager-sqlite-lease.js";
 import type { MemoryIndexManager } from "./manager.js";
 import { isolateMemoryManagerTestConfig } from "./test-config-helpers.js";
 
@@ -334,6 +335,10 @@ describe("memory manager reindex recovery", () => {
     expect(harness.db.prepare("SELECT text FROM memory_index_chunks").get()).toEqual({
       text: "incremental beta",
     });
+    const releasedLock = await waitForMemoryReindexLock(
+      resolveOpenClawAgentSqlitePath({ agentId: "main" }),
+    );
+    releasedLock.release();
   });
 
   it("rejects a full reindex while another process owns the build lock", async () => {
@@ -381,6 +386,18 @@ describe("memory manager reindex recovery", () => {
     const activeSync = memoryManager.sync({ reason: "session-delta" });
     try {
       await embeddingStarted;
+      const shadowPrefix = `${path.basename(databasePath)}.memory-reindex-`;
+      expect(
+        (await fs.readdir(path.dirname(databasePath))).some((name) =>
+          name.startsWith(shadowPrefix),
+        ),
+      ).toBe(false);
+      const concurrentIncremental = tryAcquireMemorySqliteLease(
+        `${databasePath}.reindex-lock.sqlite`,
+        "shared",
+      );
+      expect(concurrentIncremental).toBeDefined();
+      concurrentIncremental?.release();
       await expect(reset()).rejects.toMatchObject({ code: "SQLITE_BUSY" });
       expect(harness.db.prepare("SELECT text FROM memory_index_chunks").all()).toEqual([
         { text: "published alpha" },

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -46,7 +46,6 @@ import {
   resolveMemoryIndexManagerCacheKey,
   type MemoryIndexManagerPurpose,
 } from "./manager-registry.js";
-import { waitForMemoryReindexLock } from "./manager-reindex-lock.js";
 import { runMemorySearchMaintenance } from "./manager-search-maintenance.js";
 import { MemorySearchOrchestration } from "./manager-search-orchestration.js";
 import {
@@ -388,20 +387,11 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       }
 
       const runGeneration = async (keywordOnly: boolean) => {
-        // Reset must not overtake embeddings awaiting their final incremental writes.
-        // All sync generations own the existing maintenance lease through cleanup.
-        const lock = await waitForMemoryReindexLock(
-          resolveUserPath(this.settings.store.databasePath),
-        );
+        this.beginSyncProviderGeneration({ forceFtsOnly: keywordOnly });
         try {
-          this.beginSyncProviderGeneration({ forceFtsOnly: keywordOnly });
-          try {
-            await this.runSync(params);
-          } finally {
-            this.endSyncProviderGeneration();
-          }
+          await this.runSync(params);
         } finally {
-          lock.release();
+          this.endSyncProviderGeneration();
         }
       };
       try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where concurrent incremental memory syncs could fail with `SQLITE_BUSY` when another sync was waiting on slow embedding work. Incremental generations held the exclusive reindex coordination lease even though they did not build or publish a shadow index.

## Why This Change Was Made

Use shared coordination leases for incremental and targeted-session syncs, while reserving the exclusive lease for full shadow rebuilds and reset. SQLite continues to serialize live database writes, and the coordination lease still prevents reset or full reindex from overtaking active incremental generations.

## User Impact

Independent incremental syncs no longer block each other for the full duration of provider work. Full reindex and reset retain exclusive safety, and all success and failure paths release their lease.

## Evidence

- 86/86 focused memory-core tests passed across reindex recovery, FTS-only reindex, session reindex, revision state, and search orchestration.
- Rebased on current upstream and reran the 17/17 reindex recovery suite.
- Concurrency coverage verifies a second shared incremental lease can enter while reset remains blocked.
- Extensions TypeScript check passed.
- Oxlint: 0 warnings, 0 errors.
- Oxfmt and `git diff --check` passed.
