### PR TITLE
fix(sessions): make input relocation transaction-safe

### DIFF
--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -9,6 +9,7 @@ import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js"
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
 import {
   appendTranscriptMessage,
+  appendTranscriptMessageSync,
   loadTranscriptEvents,
   readActiveTranscriptEntryAnchor,
   replaceSessionEntry,
@@ -193,9 +194,25 @@ describe("rewriteTranscriptEntriesInSessionManager", () => {
         }),
         "pending input receipt",
       );
+      const sources = [source];
+      if (collected) {
+        sources.push(
+          requireValue(
+            await stageSessionPendingInput(target, {
+              runId: "admitted-rewrite-second",
+              message: {
+                ...message,
+                idempotencyKey: "admitted-rewrite-second:user",
+              },
+              assertCurrent: () => {},
+            }),
+            "second pending input receipt",
+          ),
+        );
+      }
       const receipt = collected
         ? requireValue(
-            bindSessionPendingInputSources([source], {
+            bindSessionPendingInputSources(sources, {
               ...message,
               idempotencyKey: "collected-rewrite:user",
             }),
@@ -221,6 +238,12 @@ describe("rewriteTranscriptEntriesInSessionManager", () => {
             }),
           );
           expect(rewritten.changed).toBe(true);
+          expect(
+            receipt.run(() => appendTranscriptMessageSync(target, { message: receipt.message })),
+          ).toMatchObject({
+            ok: true,
+            value: { appended: false },
+          });
           await waitForSessionTranscriptProjection(target);
           const reopened = SessionManager.open(target, directory);
           const activeUsers = reopened

--- a/src/config/sessions/session-accessor.pending-inputs.test.ts
+++ b/src/config/sessions/session-accessor.pending-inputs.test.ts
@@ -8,12 +8,14 @@ import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-trans
 import type { PersistedUserTurnMessage } from "../../sessions/user-turn-transcript.types.js";
 import {
   closeOpenClawAgentDatabasesForTest,
+  deferOpenClawAgentPostCommitPublication,
   openOpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
 import {
   appendTranscriptMessage,
   appendTranscriptMessageSync,
+  appendTranscriptEventSync,
   deleteSessionEntryLifecycle,
   loadTranscriptEvents,
   readActiveTranscriptEntryAnchor,
@@ -53,6 +55,12 @@ describe("accepted input custody", () => {
     timestamp: 100,
     idempotencyKey: `${runId}:user`,
   });
+  const readEventId = (event: unknown) => {
+    if (!event || typeof event !== "object" || !("id" in event)) {
+      return undefined;
+    }
+    return typeof event.id === "string" ? event.id : undefined;
+  };
   const stage = async (
     runId: string,
     options: Partial<Parameters<typeof stageSessionPendingInput>[1]> = {},
@@ -198,6 +206,146 @@ describe("accepted input custody", () => {
         appendTranscriptMessage(scope(), { message: receipt.message }),
       ),
     ).rejects.toThrow("conflicts with the admitted message");
+  });
+
+  it("publishes committed relocation before fallible post-commit observers", async () => {
+    const receipt = await stage("relocation-observer");
+    await promote(receipt);
+    const appendCopy = (sourceInputId: string, eventId: string) =>
+      withSessionPendingInputRelocation(sourceInputId, receipt.message, () =>
+        appendTranscriptMessageSync(scope(), {
+          eventId,
+          idempotencyLookup: "caller-checked",
+          message: receipt.message,
+          parentId: null,
+        }),
+      );
+
+    expect(() =>
+      runOpenClawAgentWriteTransaction(
+        (current) => {
+          deferOpenClawAgentPostCommitPublication(current, () => {
+            throw new Error("injected observer failure");
+          });
+          receipt.run(() => appendCopy(receipt.inputId, "relocated-before-observer"));
+        },
+        toDatabaseOptions(resolveSqliteScope(scope())),
+      ),
+    ).toThrow("injected observer failure");
+
+    expect(() =>
+      receipt.run(() => appendCopy(receipt.inputId, "stale-source-after-observer")),
+    ).toThrow("does not match");
+    expect(
+      receipt.run(() => appendTranscriptMessageSync(scope(), { message: receipt.message })),
+    ).toMatchObject({ ok: true, value: { appended: false } });
+  });
+
+  it("stages repeated relocation through savepoints and restores it on rollback", async () => {
+    const receipt = await stage("relocation-savepoints");
+    await promote(receipt);
+    const databaseOptions = toDatabaseOptions(resolveSqliteScope(scope()));
+    const appendCopy = (sourceInputId: string, eventId: string) =>
+      withSessionPendingInputRelocation(sourceInputId, receipt.message, () =>
+        appendTranscriptMessageSync(scope(), {
+          eventId,
+          idempotencyLookup: "caller-checked",
+          message: receipt.message,
+          parentId: null,
+        }),
+      );
+
+    expect(() =>
+      runOpenClawAgentWriteTransaction(() => {
+        receipt.run(() => appendCopy(receipt.inputId, "rolled-back-outer"));
+        throw new Error("outer rollback");
+      }, databaseOptions),
+    ).toThrow("outer rollback");
+
+    runOpenClawAgentWriteTransaction(() => {
+      receipt.run(() => {
+        expect(appendCopy(receipt.inputId, "first-savepoint-copy")).toMatchObject({
+          ok: true,
+          value: { appended: true, messageId: "first-savepoint-copy" },
+        });
+        expect(() =>
+          runOpenClawAgentWriteTransaction(() => {
+            appendCopy("first-savepoint-copy", "rolled-back-savepoint");
+            throw new Error("savepoint rollback");
+          }, databaseOptions),
+        ).toThrow("savepoint rollback");
+        expect(appendCopy("first-savepoint-copy", "final-savepoint-copy")).toMatchObject({
+          ok: true,
+          value: { appended: true, messageId: "final-savepoint-copy" },
+        });
+      });
+    }, databaseOptions);
+
+    expect((await loadTranscriptEvents(scope())).map(readEventId)).not.toContain(
+      "rolled-back-outer",
+    );
+    expect((await loadTranscriptEvents(scope())).map(readEventId)).not.toContain(
+      "rolled-back-savepoint",
+    );
+    expect(() =>
+      receipt.run(() => appendCopy("first-savepoint-copy", "stale-savepoint-source")),
+    ).toThrow("does not match");
+    expect(
+      receipt.run(() => appendTranscriptMessageSync(scope(), { message: receipt.message })),
+    ).toMatchObject({ ok: true, value: { appended: false } });
+  });
+
+  it("does not use a dirty projection to excuse an inactive admitted user", async () => {
+    const receipt = await stage("dirty-off-path");
+    await promote(receipt);
+    expect(
+      appendTranscriptMessageSync(scope(), {
+        eventId: "other-root",
+        message: message("other-root"),
+        parentId: null,
+      }),
+    ).toMatchObject({ ok: true, value: { appended: true, messageId: "other-root" } });
+
+    expect(() =>
+      receipt.run(() => appendTranscriptMessageSync(scope(), { message: receipt.message })),
+    ).toThrow("no longer active");
+  });
+
+  it("rejects a split-cursor replay before and after projection reconciliation", async () => {
+    const visible = await appendTranscriptMessage(scope(), {
+      message: message("visible", "Visible history"),
+    });
+    const receipt = await stage("split-cursor");
+    await promote(receipt);
+    expect(
+      appendTranscriptEventSync(scope(), {
+        type: "leaf",
+        id: "select-visible",
+        parentId: receipt.inputId,
+        targetId: visible?.messageId ?? null,
+        appendParentId: receipt.inputId,
+        appendMode: "side",
+      }),
+    ).toMatchObject({ ok: true, value: true });
+    expect(
+      appendTranscriptMessageSync(scope(), {
+        eventId: "continued",
+        message: message("continued", "Continued visible history"),
+        parentId: receipt.inputId,
+      }),
+    ).toMatchObject({ ok: true, value: { appended: true, messageId: "continued" } });
+
+    const replay = () =>
+      receipt.run(() => appendTranscriptMessageSync(scope(), { message: receipt.message }));
+    expect(
+      readActiveTranscriptEntryAnchor({ ...scope(), entryId: receipt.inputId }),
+    ).toBeUndefined();
+    expect(replay).toThrow("no longer active");
+    await waitForSessionTranscriptProjection(scope());
+    expect(
+      readActiveTranscriptEntryAnchor({ ...scope(), entryId: receipt.inputId }),
+    ).toBeUndefined();
+    expect(replay).toThrow("no longer active");
   });
 
   it("promotes a queued input with its own custody after another receipt releases the writer", async () => {

--- a/src/config/sessions/session-accessor.sqlite-pending-inputs.ts
+++ b/src/config/sessions/session-accessor.sqlite-pending-inputs.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import type { DatabaseSync } from "node:sqlite";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { Selectable } from "kysely";
 import {
@@ -9,6 +10,7 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
 } from "../../infra/kysely-sync.js";
+import { stageSqliteTransactionState } from "../../infra/sqlite-post-commit.js";
 import type { PersistedUserTurnMessage } from "../../sessions/user-turn-transcript.types.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import type { SessionPendingInputs } from "../../state/openclaw-agent-db.generated.js";
@@ -59,6 +61,7 @@ const owners = resolveGlobalSingleton(Symbol.for("openclaw.sessionPendingInputOw
     owner: SessionPendingInputOwner;
     sourceInputId: string;
   }>(),
+  transactionRelocations: new WeakMap<DatabaseSync, Map<SessionPendingInputOwner, string>>(),
 }));
 
 registerAgentEventLifecycleRotationHandler("session-pending-inputs", () => {
@@ -129,7 +132,7 @@ export function withSessionPendingInputRelocation<T>(
     return append();
   }
   assertPendingInputOwnerCurrent(owner);
-  if (owner.transcriptInputId !== sourceInputId || JSON.stringify(message) !== owner.messageJson) {
+  if (JSON.stringify(message) !== owner.messageJson) {
     throw new Error("Pending input relocation does not match its admitted transcript entry");
   }
   return owners.relocation.run({ owner, sourceInputId }, append);
@@ -215,7 +218,7 @@ export type SessionPendingInputAppend = {
   message: PersistedUserTurnMessage;
   alreadyPromoted: boolean;
   sourceInputIds?: readonly string[];
-  commitRelocation?: (destinationInputId: string) => void;
+  stageRelocation?: (destinationInputId: string) => void;
 };
 
 /** The private call-path owner, not a copied id or durable row, permits promotion. */
@@ -250,11 +253,46 @@ export function resolveSessionPendingInputAppend(
     throw new Error("Pending input cannot be appended outside its admitted turn");
   }
   const relocation = owners.relocation.getStore();
-  const relocationCommit =
-    relocation?.owner === owner && relocation.sourceInputId === owner.transcriptInputId
+  const transactionRelocations = owners.transactionRelocations.get(database.db);
+  const transcriptInputId = transactionRelocations?.get(owner) ?? owner.transcriptInputId;
+  if (relocation?.owner === owner && relocation.sourceInputId !== transcriptInputId) {
+    throw new Error("Pending input relocation does not match its admitted transcript entry");
+  }
+  const stageRelocation =
+    relocation?.owner === owner
       ? (destinationInputId: string) => {
-          if (owner.transcriptInputId === relocation.sourceInputId) {
-            owner.transcriptInputId = destinationInputId;
+          let staged = owners.transactionRelocations.get(database.db);
+          const hadPrevious = staged?.has(owner) ?? false;
+          const previous = staged?.get(owner);
+          if (
+            !stageSqliteTransactionState(database.db, {
+              stage: () => {
+                staged ??= new Map();
+                owners.transactionRelocations.set(database.db, staged);
+                staged.set(owner, destinationInputId);
+              },
+              rollback: () => {
+                if (hadPrevious && previous !== undefined) {
+                  staged?.set(owner, previous);
+                } else {
+                  staged?.delete(owner);
+                }
+                if (staged?.size === 0) {
+                  owners.transactionRelocations.delete(database.db);
+                }
+              },
+              commit: () => {
+                owner.transcriptInputId = destinationInputId;
+                if (staged?.get(owner) === destinationInputId) {
+                  staged.delete(owner);
+                }
+                if (staged?.size === 0) {
+                  owners.transactionRelocations.delete(database.db);
+                }
+              },
+            })
+          ) {
+            throw new Error("Pending input relocation requires a transcript write transaction");
           }
         }
       : undefined;
@@ -294,11 +332,11 @@ export function resolveSessionPendingInputAppend(
       assertPendingInputOwnerCurrent(owner);
     }
     return {
-      inputId: owner.transcriptInputId,
+      inputId: transcriptInputId,
       message: parseSessionPendingInputMessage(owner.messageJson),
       alreadyPromoted,
       sourceInputIds: sources.map((source) => source.input_id),
-      ...(alreadyPromoted && relocationCommit ? { commitRelocation: relocationCommit } : {}),
+      ...(alreadyPromoted && stageRelocation ? { stageRelocation } : {}),
     };
   }
   // Terminal mirroring may replay a consumed input after cancellation. The caller
@@ -307,10 +345,10 @@ export function resolveSessionPendingInputAppend(
     assertPendingInputOwnerCurrent(owner);
   }
   return {
-    inputId: owner.transcriptInputId,
+    inputId: transcriptInputId,
     message: parseSessionPendingInputMessage(row?.message_json ?? owner.messageJson),
     alreadyPromoted: !row,
-    ...(!row && relocationCommit ? { commitRelocation: relocationCommit } : {}),
+    ...(!row && stageRelocation ? { stageRelocation } : {}),
   };
 }
 

--- a/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
@@ -2,10 +2,7 @@ import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import {
-  deferOpenClawAgentPostCommitPublication,
-  type OpenClawAgentDatabase,
-} from "../../state/openclaw-agent-db.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type {
   TranscriptMessageAppendOptions,
   TranscriptMessageAppendResult,
@@ -18,7 +15,10 @@ import {
 import { readTranscriptIdentityByEventId } from "./session-accessor.sqlite-read.js";
 import type { ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
 import { readActiveTranscriptEntryAnchorInTransaction } from "./session-accessor.sqlite-transcript-anchor.js";
-import { resolveTranscriptMessageAppendParent } from "./session-accessor.sqlite-transcript-parent.js";
+import {
+  isTranscriptEntryOnActivePathInTransaction,
+  resolveTranscriptMessageAppendParent,
+} from "./session-accessor.sqlite-transcript-parent.js";
 import {
   appendTranscriptEventInTransaction,
   ensureTranscriptHeader,
@@ -82,7 +82,10 @@ export function appendTranscriptMessageInTransaction<TMessage>(
       }
       // A consumed receipt permits terminal mirroring only while its exact user
       // remains on the active path; it cannot revive a replaced transcript branch.
-      if (!anchor) {
+      if (
+        !anchor &&
+        !isTranscriptEntryOnActivePathInTransaction(database, resolved.sessionId, found.messageId)
+      ) {
         throw new Error("Pending input is no longer active in its admitted transcript");
       }
       consumeSessionPendingInput(database, pending);
@@ -116,7 +119,7 @@ export function appendTranscriptMessageInTransaction<TMessage>(
     }
   }
 
-  if (pending?.alreadyPromoted && !pending.commitRelocation) {
+  if (pending?.alreadyPromoted && !pending.stageRelocation) {
     const committed = readTranscriptMessageByEventId(database, resolved, pending.inputId);
     if (!committed) {
       throw new Error("Pending input custody ended before transcript promotion");
@@ -190,14 +193,8 @@ export function appendTranscriptMessageInTransaction<TMessage>(
   const persistedMessage = (JSON.parse(appended) as typeof event).message;
   const anchor = readAnchor({ message: persistedMessage, messageId });
   if (pending) {
-    if (pending.commitRelocation) {
-      if (
-        !deferOpenClawAgentPostCommitPublication(database, () =>
-          pending.commitRelocation?.(messageId),
-        )
-      ) {
-        throw new Error("Pending input relocation requires a transcript write transaction");
-      }
+    if (pending.stageRelocation) {
+      pending.stageRelocation(messageId);
     } else {
       consumeSessionPendingInput(database, pending);
     }

--- a/src/config/sessions/session-accessor.sqlite-transcript-parent.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-parent.test.ts
@@ -10,7 +10,10 @@ import {
   upsertSessionEntryCore,
   type TranscriptEvent,
 } from "./session-accessor.js";
-import { resolveTranscriptMessageAppendParent } from "./session-accessor.sqlite-transcript-parent.js";
+import {
+  isTranscriptEntryOnActivePathInTransaction,
+  resolveTranscriptMessageAppendParent,
+} from "./session-accessor.sqlite-transcript-parent.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -125,5 +128,59 @@ describe("SQLite transcript append ancestry", () => {
         }),
       ),
     ).toBe("root");
+  });
+
+  it("checks active ancestry directly without adopting another branch", async () => {
+    const { database, scope } = await createTranscript([
+      message("active-root", null),
+      message("active-tail", "active-root"),
+      message("other-root", null),
+      {
+        type: "leaf",
+        id: "select-active",
+        parentId: "other-root",
+        targetId: "active-tail",
+        appendParentId: "active-tail",
+      },
+    ]);
+
+    expect(
+      isTranscriptEntryOnActivePathInTransaction(database, scope.sessionId, "active-root"),
+    ).toBe(true);
+    expect(
+      isTranscriptEntryOnActivePathInTransaction(database, scope.sessionId, "active-tail"),
+    ).toBe(true);
+    expect(
+      isTranscriptEntryOnActivePathInTransaction(database, scope.sessionId, "other-root"),
+    ).toBe(false);
+    expect(isTranscriptEntryOnActivePathInTransaction(database, scope.sessionId, "missing")).toBe(
+      false,
+    );
+  });
+
+  it("checks selected visible ancestry instead of a disjoint append cursor", async () => {
+    const { database, scope } = await createTranscript([
+      message("visible", null),
+      message("hidden-user", "visible"),
+      {
+        type: "leaf",
+        id: "select-visible",
+        parentId: "hidden-user",
+        targetId: "visible",
+        appendParentId: "hidden-user",
+        appendMode: "side",
+      },
+      message("continued", "hidden-user"),
+    ]);
+
+    expect(isTranscriptEntryOnActivePathInTransaction(database, scope.sessionId, "visible")).toBe(
+      true,
+    );
+    expect(
+      isTranscriptEntryOnActivePathInTransaction(database, scope.sessionId, "hidden-user"),
+    ).toBe(false);
+    expect(isTranscriptEntryOnActivePathInTransaction(database, scope.sessionId, "continued")).toBe(
+      true,
+    );
   });
 });

--- a/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
@@ -12,7 +12,10 @@ import {
   isSessionTranscriptLeafControl,
   parseSessionTranscriptTreeEntry,
 } from "./transcript-tree.js";
-import { resolveVisibleTranscriptAppendParentId } from "./transcript-visible-events.js";
+import {
+  isTranscriptEntryOnVisiblePath,
+  resolveVisibleTranscriptAppendParentId,
+} from "./transcript-visible-events.js";
 
 export function resolveTranscriptMessageAppendParent<TMessage>(
   database: OpenClawAgentDatabase,
@@ -27,6 +30,30 @@ export function resolveTranscriptMessageAppendParent<TMessage>(
     return options.parentId;
   }
 
+  // Active appends rebase only along known ancestry; deliberate branches keep their parent.
+  return transcriptEntryIsAncestor(database, sessionId, tailId, options.parentId)
+    ? tailId
+    : options.parentId;
+}
+
+/** Checks the durable tree directly when the materialized active-path projection is dirty. */
+export function isTranscriptEntryOnActivePathInTransaction(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  entryId: string,
+): boolean {
+  return isTranscriptEntryOnVisiblePath(
+    readTranscriptNavigationEvents(database, sessionId),
+    entryId,
+  );
+}
+
+function transcriptEntryIsAncestor(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  leafId: string,
+  candidateId: string | null,
+): boolean {
   const db = getSessionKysely(database.db);
   // UNION visits each parent once, so cycles terminate without a transcript-wide count.
   // Keep dangling and null parents in the walk: they can be the requested ancestor.
@@ -38,7 +65,7 @@ export function resolveTranscriptMessageAppendParent<TMessage>(
           .selectFrom("transcript_event_identities")
           .select("parent_id")
           .where("session_id", "=", sessionId)
-          .where("event_id", "=", tailId)
+          .where("event_id", "=", leafId)
           .union(
             query
               .selectFrom("transcript_event_identities as ti")
@@ -49,11 +76,10 @@ export function resolveTranscriptMessageAppendParent<TMessage>(
       )
       .selectFrom("transcript_ancestors")
       .select("parent_id")
-      .where("parent_id", options.parentId === null ? "is" : "=", options.parentId)
+      .where("parent_id", candidateId === null ? "is" : "=", candidateId)
       .limit(1),
   );
-  // Active appends rebase only along known ancestry; deliberate branches keep their parent.
-  return ancestor?.parent_id === options.parentId ? tailId : options.parentId;
+  return ancestor?.parent_id === candidateId;
 }
 
 function readActiveTranscriptAppendParentId(
@@ -80,19 +106,7 @@ function readActiveTranscriptAppendParentId(
     return null;
   }
   const resolveFromNavigation = () =>
-    resolveVisibleTranscriptAppendParentId(
-      Array.from(
-        iterateSqliteQuerySync(
-          database.db,
-          db
-            .selectFrom("transcript_events")
-            .select((eb) => projectTranscriptNavigationSql(eb.ref("event_json")).as("event_json"))
-            .where("session_id", "=", sessionId)
-            .orderBy("seq", "asc"),
-        ),
-        (row) => JSON.parse(row.event_json) as unknown,
-      ),
-    );
+    resolveVisibleTranscriptAppendParentId(readTranscriptNavigationEvents(database, sessionId));
   try {
     const event = JSON.parse(latest.event_json) as unknown;
     const treeEntry = parseSessionTranscriptTreeEntry(event);
@@ -113,6 +127,24 @@ function readActiveTranscriptAppendParentId(
     // Fall through to the tolerant full-tree resolver.
   }
   return resolveFromNavigation();
+}
+
+function readTranscriptNavigationEvents(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): unknown[] {
+  const db = getSessionKysely(database.db);
+  return Array.from(
+    iterateSqliteQuerySync(
+      database.db,
+      db
+        .selectFrom("transcript_events")
+        .select((eb) => projectTranscriptNavigationSql(eb.ref("event_json")).as("event_json"))
+        .where("session_id", "=", sessionId)
+        .orderBy("seq", "asc"),
+    ),
+    (row) => JSON.parse(row.event_json) as unknown,
+  );
 }
 
 function transcriptTreeReferenceExists(

--- a/src/config/sessions/transcript-visible-events.ts
+++ b/src/config/sessions/transcript-visible-events.ts
@@ -37,3 +37,14 @@ export function selectVisibleTranscriptEvents<T>(events: readonly T[]): T[] {
 export function resolveVisibleTranscriptAppendParentId(events: readonly unknown[]): string | null {
   return scanSessionTranscriptTree(events).appendParentId;
 }
+
+/** Checks membership in the normalized selected path, not raw storage ancestry. */
+export function isTranscriptEntryOnVisiblePath(
+  events: readonly unknown[],
+  entryId: string,
+): boolean {
+  const tree = scanSessionTranscriptTree(events);
+  return selectSessionTranscriptTreePathNodes(tree, tree.leafId).some(
+    (node) => node.id === entryId,
+  );
+}

--- a/src/infra/sqlite-post-commit.ts
+++ b/src/infra/sqlite-post-commit.ts
@@ -6,6 +6,10 @@ const pendingPublications = resolveGlobalSingleton(
   Symbol.for("openclaw.sqlitePostCommitPublications"),
   () => new WeakMap<DatabaseSync, Array<() => void>>(),
 );
+const pendingTransactionState = resolveGlobalSingleton(
+  Symbol.for("openclaw.sqliteTransactionState"),
+  () => new WeakMap<DatabaseSync, Array<{ commit: () => void; rollback: () => void }>>(),
+);
 
 /** Publications are non-throwing observers, never part of a durable transaction's result. */
 export function deferSqlitePostCommitPublication(db: DatabaseSync, publish: () => void): boolean {
@@ -17,27 +21,55 @@ export function deferSqlitePostCommitPublication(db: DatabaseSync, publish: () =
   return true;
 }
 
-/** Nested rollback discards its observers; successful savepoints wait for the outer commit. */
+/**
+ * Stage private transaction-local state that publishes before fallible observers.
+ * Stage, rollback, and commit callbacks must not throw.
+ */
+export function stageSqliteTransactionState(
+  db: DatabaseSync,
+  state: { stage: () => void; rollback: () => void; commit: () => void },
+): boolean {
+  const pending = pendingTransactionState.get(db);
+  if (!pending) {
+    return false;
+  }
+  state.stage();
+  pending.push({ commit: state.commit, rollback: state.rollback });
+  return true;
+}
+
+/** Nested rollback restores staged state and discards observers; savepoints wait for outer commit. */
 export function withSqlitePostCommitPublications<T>(db: DatabaseSync, transaction: () => T): T {
   const nested = db.isTransaction;
-  const pending = nested ? pendingPublications.get(db) : [];
-  const start = pending?.length ?? 0;
-  if (!nested && pending) {
-    pendingPublications.set(db, pending);
+  const publications = nested ? pendingPublications.get(db) : [];
+  const transactionState = nested ? pendingTransactionState.get(db) : [];
+  const publicationStart = publications?.length ?? 0;
+  const stateStart = transactionState?.length ?? 0;
+  if (!nested && publications && transactionState) {
+    pendingPublications.set(db, publications);
+    pendingTransactionState.set(db, transactionState);
   }
   let result: T;
   try {
     result = transaction();
   } catch (error) {
-    pending?.splice(start);
+    publications?.splice(publicationStart);
+    const rolledBackState = transactionState?.splice(stateStart) ?? [];
+    for (const state of rolledBackState.toReversed()) {
+      state.rollback();
+    }
     throw error;
   } finally {
     if (!nested) {
       pendingPublications.delete(db);
+      pendingTransactionState.delete(db);
     }
   }
   if (!nested) {
-    for (const publish of pending ?? []) {
+    for (const state of transactionState ?? []) {
+      state.commit();
+    }
+    for (const publish of publications ?? []) {
       publish();
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #138967. That change authorizes transcript rewrites before appending the exact admitted user copy, but two commit-boundary gaps remain:

- immediate replay can fail while the materialized active-path projection is dirty
- an earlier throwing post-commit observer can skip relocation publication after SQLite has committed

This change keeps relocation transaction-local through nested savepoints, publishes the final binding before fallible observers, and checks the selected visible transcript ancestry when the materialized projection is dirty. It deliberately ignores a divergent physical append cursor. Receipt IDs, approved message bytes, source consumption IDs, session scope, and lifecycle authority remain unchanged.

## Proof

- Current-base red: 7 focused failures on `cd4504de2d`, including all four direct/collected and context-visible/context-excluded rewrite variants plus direct and replay split-cursor cases
- Patched focused suites: 64 tests passed
- Adjacent rewrite, compaction, pending-input, worker-commit, deletion, and lifecycle suites: 171 tests passed
- Strict source-blind behavior contract: 64 tests passed twice
- `node scripts/check-changed.mjs -- <8 changed files>`
- Autoreview: no P0-P2 findings

The original production trigger remains unproven. This PR addresses the reproduced custody and commit-order failures with synthetic fixtures only.
