### PR TITLE
fix(memory): gateway search times out before remote embeddings finish

### DIFF
--- a/extensions/memory-core/src/memory-get-corpus.test.ts
+++ b/extensions/memory-core/src/memory-get-corpus.test.ts
@@ -316,7 +316,7 @@ describe("memory_get corpus outcomes", () => {
       path: lookup,
       corpus: "all",
     });
-    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.advanceTimersByTimeAsync(30_000);
 
     await expect(pending).resolves.toMatchObject({
       details: {
@@ -326,7 +326,7 @@ describe("memory_get corpus outcomes", () => {
           {
             corpus: "wiki",
             outcome: "unavailable",
-            error: "memory_get timed out after 15s",
+            error: "memory_get timed out after 30s",
           },
         ],
       },

--- a/extensions/memory-core/src/memory/search-deadline.test.ts
+++ b/extensions/memory-core/src/memory/search-deadline.test.ts
@@ -1,9 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { isMemorySearchDeadlineError, runMemorySearchWithDeadline } from "./search-deadline.js";
+import {
+  DEFAULT_MEMORY_SEARCH_TIMEOUT_MS,
+  isMemorySearchDeadlineError,
+  runMemorySearchWithDeadline,
+} from "./search-deadline.js";
 
 describe("runMemorySearchWithDeadline", () => {
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("allows the default memory_search envelope thirty seconds", () => {
+    expect(DEFAULT_MEMORY_SEARCH_TIMEOUT_MS).toBe(30_000);
   });
 
   it("clears its timer and parent abort listener after success", async () => {

--- a/extensions/memory-core/src/memory/search-deadline.ts
+++ b/extensions/memory-core/src/memory/search-deadline.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_MEMORY_SEARCH_TIMEOUT_MS = 15_000;
+export const DEFAULT_MEMORY_SEARCH_TIMEOUT_MS = 30_000;
 export function resolveMemorySearchAbortError(signal: AbortSignal): Error {
   const { reason } = signal;
   if (reason instanceof Error) {

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -637,7 +637,7 @@ describe("memory tools", () => {
         query: "alpha",
         corpus: "all",
       });
-      await vi.advanceTimersByTimeAsync(15_000);
+      await vi.advanceTimersByTimeAsync(30_000);
       const stalledAllResult = await stalledAllResultPromise;
       expect(stalledAllResult.details).toMatchObject({
         results: [{ corpus: "memory", path: "MEMORY.md" }],
@@ -646,7 +646,7 @@ describe("memory tools", () => {
           {
             corpus: "wiki",
             outcome: "unavailable",
-            error: "memory_search timed out after 15s",
+            error: "memory_search timed out after 30s",
           },
         ],
         warning: expect.stringContaining("Wiki corpus unavailable"),
@@ -738,7 +738,7 @@ describe("memory tools", () => {
         query: "alpha",
         corpus: "all",
       });
-      await vi.advanceTimersByTimeAsync(15_000);
+      await vi.advanceTimersByTimeAsync(30_000);
       const stalledAllResult = await stalledAllResultPromise;
       expect(stalledAllResult.details).toMatchObject({
         results: [{ corpus: "wiki", path: "entities/alpha.md" }],
@@ -746,7 +746,7 @@ describe("memory tools", () => {
           {
             corpus: "memory",
             outcome: "unavailable",
-            error: "memory_search timed out after 15s",
+            error: "memory_search timed out after 30s",
           },
           { corpus: "wiki", outcome: "ok" },
         ],
@@ -769,12 +769,12 @@ describe("memory tools", () => {
         {
           corpus: "memory",
           outcome: "unavailable",
-          error: "memory_search timed out after 15s",
+          error: "memory_search timed out after 30s",
         },
         { corpus: "wiki", outcome: "ok" },
       ]);
       expect(details.warning).toContain("Memory corpus unavailable");
-      expect(details.warning).toContain("memory_search timed out after 15s");
+      expect(details.warning).toContain("memory_search timed out after 30s");
       expect(searchCalls).toBe(1);
     } finally {
       vi.useRealTimers();

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -473,7 +473,7 @@ describe("memory_search real manager", () => {
     });
     try {
       await searchStarted.promise;
-      await vi.advanceTimersByTimeAsync(15_100);
+      await vi.advanceTimersByTimeAsync(30_100);
       expect(executionSettled).toBe(true);
       await expect(execution).resolves.toMatchObject({
         details: { unavailable: true },

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -352,11 +352,11 @@ describe("memory_search unavailable payloads", () => {
       const tool = createMemorySearchToolOrThrow();
 
       const resultPromise = tool.execute("search-timeout", { query: "hello" });
-      await vi.advanceTimersByTimeAsync(15_000);
+      await vi.advanceTimersByTimeAsync(30_000);
 
       const result = await resultPromise;
       expectUnavailableMemorySearchDetails(result.details, {
-        error: "memory_search timed out after 15s",
+        error: "memory_search timed out after 30s",
         warning: "Memory search did not finish within its time limit.",
         action:
           "Retry memory_search after a short wait: a memory-corpus timeout pauses retries for up to a minute. If memory-corpus timeouts persist, run: openclaw memory status --deep --agent main, and rebuild with openclaw memory index --force --agent main only if it reports the index dirty or incomplete",
@@ -365,7 +365,7 @@ describe("memory_search unavailable payloads", () => {
       expect(searchSignal?.aborted).toBe(true);
       const cooldownResult = await tool.execute("search-cooldown", { query: "hello again" });
       expectUnavailableMemorySearchDetails(cooldownResult.details, {
-        error: "memory_search timed out after 15s",
+        error: "memory_search timed out after 30s",
         warning: "Memory search did not finish within its time limit.",
         action:
           "Retry memory_search after a short wait: a memory-corpus timeout pauses retries for up to a minute. If memory-corpus timeouts persist, run: openclaw memory status --deep --agent main, and rebuild with openclaw memory index --force --agent main only if it reports the index dirty or incomplete",
@@ -405,11 +405,11 @@ describe("memory_search unavailable payloads", () => {
       const tool = createMemorySearchToolOrThrow();
 
       const resultPromise = tool.execute("abort-aware-timeout", { query: "hello" });
-      await vi.advanceTimersByTimeAsync(15_000);
+      await vi.advanceTimersByTimeAsync(30_000);
 
       const result = await resultPromise;
       expectUnavailableMemorySearchDetails(result.details, {
-        error: "memory_search timed out after 15s",
+        error: "memory_search timed out after 30s",
         warning: "Memory search did not finish within its time limit.",
         action:
           "Retry memory_search after a short wait: a memory-corpus timeout pauses retries for up to a minute. If memory-corpus timeouts persist, run: openclaw memory status --deep --agent main, and rebuild with openclaw memory index --force --agent main only if it reports the index dirty or incomplete",


### PR DESCRIPTION
## What Problem This Solves

Gateway `memory_search` currently aborts after 15 seconds, while remote embedding requests and their retry envelope can legitimately take longer. This makes otherwise healthy searches fail at the outer deadline before the provider operation can complete.

## Why This Change Was Made

Raise only the existing gateway memory-search deadline from 15 seconds to 30 seconds. The abort propagation, stable deadline error, timer cleanup, and provider-level timeout behavior remain unchanged.

## User Impact

Remote-backed memory searches get enough time to complete without removing the bounded request deadline or changing retry policy.

## Evidence

- Added a focused assertion for the 30-second default.
- `search-deadline.test.ts`: 8/8 tests passed.
- Oxlint: 0 warnings, 0 errors.
- Oxfmt and `git diff --check` passed.
- Rebased on current upstream `main`.