### PR TITLE
fix: [Bug]: Interrupted transcript rewrite makes stale history the active conversation (#138965)

### DIFF
--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -418,4 +418,74 @@ describe("rewriteTranscriptEntriesInSessionManager", () => {
       }
     },
   );
+
+  it("restores the durable leaf across reopen when replay is interrupted", async () => {
+    // An in-memory branch()/resetLeaf() rollback is lost on reopen: the
+    // partial suffix would become the active conversation. The rollback must
+    // persist a leaf control pointing at the last complete branch.
+    const dir = tempDirs.make("openclaw-transcript-rewrite-interrupt-");
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "interrupt-rewrite-leaf";
+    const sessionKey = "agent:main:test";
+    const target = {
+      agentId: "main",
+      sessionId,
+      sessionKey,
+      storePath,
+    };
+    await replaceSessionEntry({ sessionKey, storePath }, {
+      sessionFile: formatSqliteSessionFileMarker({
+        agentId: "main",
+        sessionId,
+        storePath,
+      }),
+      sessionId,
+      updatedAt: 10,
+    } as SessionEntry);
+    const sessionManager = SessionManager.open(target, dir);
+    appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: "run tool", timestamp: 1 }),
+      asAppendMessage(createToolResultReplacement("exec", "before rewrite", 2)),
+      asAppendMessage({
+        role: "assistant",
+        content: createTextContent("summarized"),
+        timestamp: 3,
+      }),
+    ]);
+    const savedLeafId = sessionManager.getLeafId();
+    const rewriteTarget = sessionManager.getBranch()[1];
+    if (rewriteTarget?.type !== "message") {
+      throw new Error("expected a persisted rewrite target");
+    }
+    // Fail the second replay append to simulate an interrupted rewrite.
+    const { getRawSessionAppendMessage, setRawSessionAppendMessage } =
+      await import("../session-raw-append-message.js");
+    const rawAppend = getRawSessionAppendMessage(sessionManager);
+    let replayAppends = 0;
+    setRawSessionAppendMessage(sessionManager, (message) => {
+      replayAppends += 1;
+      if (replayAppends > 1) {
+        throw new Error("injected replay failure");
+      }
+      return rawAppend(message);
+    });
+
+    expect(() =>
+      rewriteTranscriptEntriesInSessionManager({
+        sessionManager,
+        replacements: [
+          {
+            entryId: rewriteTarget.id,
+            message: createToolResultReplacement("exec", "[runtime rewrite]", 2),
+          },
+        ],
+      }),
+    ).toThrow("injected replay failure");
+    expect(sessionManager.getLeafId()).toBe(savedLeafId);
+    const reopened = SessionManager.open(target, dir);
+    expect(reopened.getLeafId()).toBe(savedLeafId);
+    expect(reopened.getBranch().map((entry) => entry.id)).toEqual(
+      sessionManager.getBranch().map((entry) => entry.id),
+    );
+  });
 });

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -180,6 +180,12 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
     };
   }
 
+  // Fail closed: an interrupted replay must leave the last complete branch active.
+  // ponytail: persists one leaf control restoring the pre-rewrite selection;
+  // partial rows stay stored but unreachable, delete nothing.
+  const savedLeafId = params.sessionManager.getLeafId();
+  const savedAppendParentId = params.sessionManager.getAppendParentId();
+  const savedAppendMode = params.sessionManager.getAppendMode();
   if (!firstMatchedEntry.parentId) {
     params.sessionManager.resetLeaf();
   } else {
@@ -194,24 +200,36 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
     rawAppendMessage(message, { idempotencyLookup: "caller-checked" });
   const rewrittenEntryIds = new Map<string, string>();
   // Every re-appended message follows the rewritten prefix, so its prefix-bound checkpoint is stale.
-  for (const entry of branch.slice(firstMatchedIndex)) {
-    const replacement = entry.type === "message" ? replacementsById.get(entry.id) : undefined;
-    const newEntryId =
-      replacement === undefined
-        ? appendBranchEntry({
-            sessionManager: params.sessionManager,
-            entry,
-            rewrittenEntryIds,
-            appendMessage,
-          })
-        : appendMessage(
-            (params.preserveReplacementCompactionReplay
-              ? replacement
-              : stripStalePrefixReplay(replacement)) as Parameters<
-              typeof params.sessionManager.appendMessage
-            >[0],
-          );
-    rewrittenEntryIds.set(entry.id, newEntryId);
+  try {
+    for (const entry of branch.slice(firstMatchedIndex)) {
+      const replacement = entry.type === "message" ? replacementsById.get(entry.id) : undefined;
+      const newEntryId =
+        replacement === undefined
+          ? appendBranchEntry({
+              sessionManager: params.sessionManager,
+              entry,
+              rewrittenEntryIds,
+              appendMessage,
+            })
+          : appendMessage(
+              (params.preserveReplacementCompactionReplay
+                ? replacement
+                : stripStalePrefixReplay(replacement)) as Parameters<
+                typeof params.sessionManager.appendMessage
+              >[0],
+            );
+      rewrittenEntryIds.set(entry.id, newEntryId);
+    }
+  } catch (error) {
+    // branch()/resetLeaf() move only the in-memory pointer: with no further
+    // writes the partial suffix would still win after reopen. Persist the
+    // restored selection so the last complete branch stays active on restart.
+    params.sessionManager.appendLeafControl({
+      targetId: savedLeafId,
+      appendParentId: savedAppendParentId,
+      ...(savedAppendMode === undefined ? {} : { appendMode: savedAppendMode }),
+    });
+    throw error;
   }
 
   return {


### PR DESCRIPTION
## What Problem This Solves
Fixes #138965 — [Bug]: Interrupted transcript rewrite makes stale history the active conversation. Minimal diff, single shared guard, no new deps.

## Evidence
- P1 follow-up (ClawSweeper 2026-09-05 review): the `catch` rollback used `branch()/resetLeaf()`, which move only the in-memory pointer — after reopen the partial suffix still won. Rollback now persists a leaf control (`appendLeafControl`) restoring the pre-rewrite leaf/append-parent/mode, so the last complete branch stays active across restarts. Partial rows stay stored but unreachable; nothing deleted.
- Red/green proof, new test `restores the durable leaf across reopen when replay is interrupted` (injected 2nd-append failure on a persisted session):
  - Before fix: `reopened.getLeafId()` = partial replay row, expected saved leaf → AssertionError (reproduces the finding).
  - After fix: `Test Files 1 passed (1) / Tests 1 passed (1)`.
- In-memory rewrite suite: 5/5 pass. SQLite rewrite assertions: no assertion failures (this sandbox shows Windows-only EPERM temp-dir cleanup flakes on all persisted tests, incl. 3 pre-existing ones; Linux CI unaffected).
- Known limitation (out of scope for this diff): a process kill mid-replay bypasses any `catch`; fully atomic publish (stage suffix, then commit selection) needs a storage-owner redesign.

Closes #138965
