### PR TITLE
fix: [Bug]: openclaw doctor [--fix] silently blocks QQ and WeCom channel accounts; recovery requires manual channels.start RPCs (#138947)

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -4742,5 +4742,38 @@ describe("server-channels auto restart", () => {
 
     expect(manager.isHealthMonitorEnabled("discord", "")).toBe(true);
   });
+
+  it("re-drives a terminal reload handshake that never reached ready", async () => {
+    let starts = 0;
+    installTestRegistry(createTestPlugin({ startAccount: async ({ setStatus, abortSignal }) => {
+      starts += 1;
+      if (starts === 2) {
+        setStatus(channelBlockedPatch("session collision", { accountId: DEFAULT_ACCOUNT_ID }));
+        return;
+      }
+      setStatus(channelReadyPatch({ accountId: DEFAULT_ACCOUNT_ID }));
+      await new Promise<void>((resolve) => abortSignal.addEventListener("abort", () => resolve(), { once: true }));
+    }}));
+    const manager = createManager();
+    await manager.startChannels();
+    await manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, { manual: false, routeHandoff: true });
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID, { preserveManualStop: true, skipUnavailableAccounts: true });
+    await advanceTimersUntil(() => starts >= 3, "terminal handshake was not re-driven", { stepMs: 10, maxMs: 1_000 });
+    expect(manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]).toMatchObject({ lifecycle: "ready", terminalDisconnect: undefined });
+  });
+
+  it("still wedges a terminal disconnect with no healthy history", async () => {
+    let starts = 0;
+    installTestRegistry(createTestPlugin({ startAccount: async ({ setStatus }) => {
+      starts += 1;
+      setStatus(channelBlockedPatch("relink required", { accountId: DEFAULT_ACCOUNT_ID }));
+    }}));
+    const manager = createManager();
+    await manager.startChannels();
+    await flushMicrotasks(30);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(starts).toBe(1);
+    expect(manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]).toMatchObject({ lifecycle: "blocked", restartPending: false });
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -75,6 +75,12 @@ const RESTART_POLICY: BackoffPolicy = {
   factor: 2,
   jitter: 0.1,
 };
+// A replacement admitted for a recently-connected account that dies terminally
+// before its first ready most likely lost a restart race (for example a
+// hot-reload re-handshake colliding with the still-live external session),
+// not its credentials. Re-drive those through the bounded crash supervisor
+// instead of wedging blocked forever.
+const CHANNEL_TERMINAL_RETRY_HEALTHY_WINDOW_MS = 5 * 60_000;
 const MAX_RESTARTS = 10;
 const CHANNEL_STABLE_RUN_MS = RESTART_POLICY.maxMs;
 const CHANNEL_STOP_ABORT_TIMEOUT_MS = 5_000;
@@ -720,6 +726,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         const lifetime: ChannelAccountLifetime = { abort, capabilityLease };
         store.lifetimes.set(id, lifetime);
         let handedOffTask = false;
+        let taskReachedReady = false;
         const log = ensureChannelLog(channelId);
         let scopedChannelRuntime: {
           channelRuntime?: PluginRuntimeChannel;
@@ -904,6 +911,13 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             return;
           }
           let channelRunDurationMs: number | undefined;
+          const prevRuntimeForTerminalRetry = getRuntime(channelId, id);
+          const prevTerminalRetryable =
+            prevRuntimeForTerminalRetry.running === true ||
+            (typeof prevRuntimeForTerminalRetry.lastConnectedAt === "number" &&
+              Number.isFinite(prevRuntimeForTerminalRetry.lastConnectedAt) &&
+              Date.now() - prevRuntimeForTerminalRetry.lastConnectedAt <
+                CHANNEL_TERMINAL_RETRY_HEALTHY_WINDOW_MS);
           setRuntime(channelId, id, {
             accountId: id,
             enabled: true,
@@ -969,10 +983,14 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                   return withGatewayNativeApprovalRuntime(opts.getNativeApprovalRuntime?.(), () =>
                     startAccount({
                       ...accountContext,
-                      setStatus: (next) =>
-                        isCurrentTask()
+                      setStatus: (next) => {
+                        if (next.lifecycle === "ready") {
+                          taskReachedReady = true;
+                        }
+                        return isCurrentTask()
                           ? setRuntimeFromTaskStatus(channelId, id, next, abort.signal)
-                          : getRuntime(channelId, id),
+                          : getRuntime(channelId, id);
+                      },
                       invalidateDirectoryCache: () =>
                         resetDirectoryCache({ cfg, channel: channelId, accountId: id }),
                       ...(channelRuntimeForTask ? { channelRuntime: channelRuntimeForTask } : {}),
@@ -1054,18 +1072,26 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               if (getRuntime(channelId, id).terminalDisconnect) {
                 // Authentication/session termination wins over pending recovery.
                 // Leaving recovery state behind would restart a channel that needs user action.
-                recoveryStopTimedOut.delete(rKey);
-                recoveryStartRequested.delete(rKey);
-                restarts.delete(rKey);
-                setRuntime(channelId, id, {
-                  accountId: id,
-                  restartPending: false,
-                  reconnectAttempts: 0,
-                });
-                log.info?.(`[${id}] auto-restart skipped, terminal disconnect`);
-                return;
-              }
-              if (recoveryStopTimedOut.has(rKey)) {
+                // Exception: a replacement admitted for a recently-connected account
+                // that never reached ready most likely lost a restart race, so let
+                // the bounded crash supervisor below re-drive it instead of wedging.
+                if (prevTerminalRetryable && !taskReachedReady) {
+                  log.info?.(
+                    `[${id}] retrying terminal disconnect before first ready; last connection was recent`,
+                  );
+                } else {
+                  recoveryStopTimedOut.delete(rKey);
+                  recoveryStartRequested.delete(rKey);
+                  restarts.delete(rKey);
+                  setRuntime(channelId, id, {
+                    accountId: id,
+                    restartPending: false,
+                    reconnectAttempts: 0,
+                  });
+                  log.info?.(`[${id}] auto-restart skipped, terminal disconnect`);
+                  return;
+                }
+              } else if (recoveryStopTimedOut.has(rKey)) {
                 recoveryStopTimedOut.delete(rKey);
                 if (!recoveryStartRequested.delete(rKey)) {
                   setRuntime(channelId, id, {


### PR DESCRIPTION
## What Problem This Solves
Fixes #138947 — [Bug]: openclaw doctor [--fix] silently blocks QQ and WeCom channel accounts; recovery requires manual channels.start RPCs. Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree oc-138947).

Closes #138947