### PR TITLE
fix: [Bug]: CLI no-output watchdog kills the turn during Claude Code auto-compaction — the defer path counts tool calls but has no signal for an in-flight compaction (#138644)

### DIFF
--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -964,6 +964,41 @@ describe("plugin-owned CLI execution host boundary", () => {
     expect(received.map((event) => JSON.parse(event))).toHaveLength(3);
   });
 
+  it("defers the no-output watchdog while native compaction is active", async () => {
+    vi.useFakeTimers();
+    const { context } = await createExecution();
+    context.backendResolved.parseJsonlLifecycleEvent = (line) => {
+      const event = JSON.parse(line) as { status?: unknown; compact_result?: unknown };
+      if (event.status === "compacting") {
+        return { kind: "compaction", phase: "start" };
+      }
+      return event.compact_result === "success"
+        ? { kind: "compaction", phase: "end", completed: true }
+        : null;
+    };
+    const compactionFinished = createDeferred();
+    const received: string[] = [];
+    let completed = false;
+    const run = runPlugin(
+      context,
+      async function* () {
+        yield { type: "system", subtype: "status", status: "compacting" };
+        await compactionFinished.promise;
+        yield { compact_result: "success" };
+        yield SUCCESS_RESULT;
+      },
+      { noOutputTimeoutMs: 100, consumeStdout: received.push.bind(received) },
+    ).then((result) => {
+      completed = true;
+      return result;
+    });
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+    await vi.advanceTimersByTimeAsync(150);
+    expect(completed).toBe(false);
+    compactionFinished.resolve();
+    await expect(run).resolves.toMatchObject({ reason: "exit", timedOut: false });
+  });
+
   it("keeps the overall deadline authoritative while background work remains active", async () => {
     vi.useFakeTimers();
     const { context } = await createExecution({ timeoutMs: 150 });

--- a/src/agents/cli-runner/execute-plugin.ts
+++ b/src/agents/cli-runner/execute-plugin.ts
@@ -429,6 +429,7 @@ export async function executePluginOwnedProcess(params: {
   const outstanding = {
     approvals: 0,
     background: 0,
+    compacting: false,
     lastOutputAt: startedAt,
     observed: false,
     replayUnsafe: false,
@@ -467,6 +468,7 @@ export async function executePluginOwnedProcess(params: {
           observedActivity: outstanding.observed,
           activeToolCount: Math.max(params.activeToolCount?.() ?? 0, outstanding.approvals),
           backgroundTaskCount: outstanding.background,
+          ...(outstanding.compacting ? { compactionActive: true as const } : {}),
         },
         hasOutputText: false,
         useResume: params.useResume,
@@ -570,6 +572,8 @@ export async function executePluginOwnedProcess(params: {
         throw new Error("CLI plugin runtime emitted an invalid structured stream event.");
       }
       if (next.value.type === "result") {
+        // A terminal result ends the turn, so any in-flight compaction is over.
+        outstanding.compacting = false;
         terminalResult =
           terminalResult === "error" ||
           next.value.is_error === true ||
@@ -584,7 +588,25 @@ export async function executePluginOwnedProcess(params: {
       ) {
         outstanding.background = next.value.tasks.filter(isRecord).length;
       }
-      params.consumeStdout(`${JSON.stringify(next.value)}\n`);
+      const line = JSON.stringify(next.value);
+      try {
+        // Reuse the backend-owned lifecycle parser so native compaction phases
+        // (e.g. Claude auto-compaction) count as outstanding work. Projection
+        // must never fail a live turn; the timer reset below still applies.
+        const backend = params.context.backendResolved;
+        const lifecycle = backend.parseJsonlLifecycleEvent?.(line, {
+          backendId: backend.id,
+          backend: backend.config,
+        });
+        for (const event of lifecycle == null ? [] : Array.isArray(lifecycle) ? lifecycle : [lifecycle]) {
+          if (event.kind === "compaction") {
+            outstanding.compacting = event.phase === "start";
+          }
+        }
+      } catch {
+        // Ignore lifecycle projection failures; the event itself still counts as output.
+      }
+      params.consumeStdout(`${line}\n`);
       outstanding.observed = true;
       if (
         !(next.value.type === "system" && next.value.subtype === "init") &&

--- a/src/agents/cli-runner/no-output-timeout-policy.ts
+++ b/src/agents/cli-runner/no-output-timeout-policy.ts
@@ -20,7 +20,8 @@ export function resolveCliNoOutputTimeoutDecision(params: CliNoOutputTimeoutPoli
   error: FailoverError;
 } {
   const outstandingWork =
-    params.cliTimeout.activeToolCount + params.cliTimeout.backgroundTaskCount > 0;
+    params.cliTimeout.activeToolCount + params.cliTimeout.backgroundTaskCount > 0 ||
+    params.cliTimeout.compactionActive === true;
   const deferMs =
     outstandingWork && params.outstandingWorkGraceMs !== undefined
       ? Math.max(params.timeoutMs, params.outstandingWorkGraceMs) - params.quietDurationMs

--- a/src/agents/failover/error.ts
+++ b/src/agents/failover/error.ts
@@ -12,6 +12,8 @@ export type CliTimeoutContext = {
   observedActivity: boolean;
   activeToolCount: number;
   backgroundTaskCount: number;
+  /** Native context maintenance (e.g. Claude auto-compaction) in progress: silent but busy. */
+  compactionActive?: boolean;
 };
 
 export type FallbackAttemptRecord = {


### PR DESCRIPTION
## What Problem This Solves
Fixes #138644 — [Bug]: CLI no-output watchdog kills the turn during Claude Code auto-compaction — the defer path counts tool calls but has no signal for an in-flight compaction. Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree oc-138644).

Closes #138644