### PR TITLE
fix: Internal context block (<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>) leaks into visible Telegram message text (#137927)

### DIFF
--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -2074,6 +2074,17 @@ describe("draft stream initial message debounce", () => {
 
       expectPreviewSend(api, "Hi");
     });
+
+    it("strips leaked internal runtime context from streamed previews (#137927)", async () => {
+      const api = createMockDraftApi();
+      const stream = createDraftStream(api);
+      stream.update(
+        "OpenClaw runtime context for the active user request in this turn. Do not reply to or describe this context. Use it to continue answering the active user request now. Do not wait for another message.\nThis context is runtime-generated, not user-authored. Keep internal details private.\n\n<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nsecret session replay\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>\n\nVisible answer.",
+      );
+      await stream.flush();
+      expectPreviewSend(api, "Visible answer.");
+      expect(requireSendMessageCallText(api, 0)).not.toContain("OPENCLAW_INTERNAL_CONTEXT");
+    });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -2,6 +2,7 @@ import type { Bot } from "grammy";
 import type { Message } from "grammy/types";
 import {
   createFinalizableDraftStreamControlsForState,
+  stripInternalRuntimeContext,
   takeMessageIdAfterStop,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { MarkdownTableMode, ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
@@ -587,9 +588,14 @@ export function createTelegramDraftStream(params: {
       // last delivered draft. Counting the consumed slot as a flush is intentional.
       return true;
     }
+    // Streaming edits bypass the delivery funnel's scaffolding strip (#137927):
+    // a model echo of the runtime-context block would stay visible here and be
+    // finalizable into the durable message. Strip at this one transport
+    // boundary; marker-free text passes through unchanged.
+    const sanitizedText = stripInternalRuntimeContext(text);
     if (isLazy) {
       lastRequestedPreview = undefined;
-      lastRequestedText = text;
+      lastRequestedText = sanitizedText;
     }
     if (streamState.stopped && !streamState.final) {
       return false;
@@ -600,7 +606,7 @@ export function createTelegramDraftStream(params: {
     if (!streamState.final && Date.now() < suspendedUntilMs) {
       return false;
     }
-    const trimmed = text.trimEnd();
+    const trimmed = sanitizedText.trimEnd();
     if (!trimmed) {
       return false;
     }

--- a/src/plugin-sdk/channel-outbound.ts
+++ b/src/plugin-sdk/channel-outbound.ts
@@ -79,6 +79,9 @@ export {
   createOutboundPayloadPlan,
   projectOutboundPayloadPlanForDelivery,
 } from "../infra/outbound/payloads.js";
+// Streaming previews edit messages outside the delivery funnel, so stream
+// transports strip leaked runtime-context blocks with this shared helper.
+export { stripInternalRuntimeContext } from "../agents/internal-runtime-context.js";
 export { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 export type { OutboundSessionContext } from "../infra/outbound/session-context.js";
 export type { OutboundDeliveryFormattingOptions } from "../infra/outbound/formatting.js";


### PR DESCRIPTION
## What Problem This Solves
Fixes #137927 — Internal context block (<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>) leaks into visible Telegram message text. Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree oc-137927).

Closes #137927