### PR TITLE
fix: WhatsApp group session gets a duplicate `direct`-kind conversation row (same peer_id as the group JID), causing UNIQUE constraint failures (#137781)

### DIFF
--- a/src/config/sessions/conversation-identity.test.ts
+++ b/src/config/sessions/conversation-identity.test.ts
@@ -301,4 +301,24 @@ describe("conversation identity", () => {
     expect(persisted?.deliveryTarget).toBe("channel:ops-room");
     expect(live?.parentConversationRef).toBeUndefined();
   });
+
+  it("treats a whatsapp @g.us peer as group even when kind arrives as direct", () => {
+    const direct = buildConversationIdentity({
+      channel: "whatsapp",
+      accountId: "default",
+      kind: "direct",
+      peerId: "120363429459936309@g.us",
+      deliveryTarget: "120363429459936309@g.us",
+    });
+    const group = buildConversationIdentity({
+      channel: "whatsapp",
+      accountId: "default",
+      kind: "group",
+      peerId: "120363429459936309@g.us",
+      deliveryTarget: "120363429459936309@g.us",
+    });
+
+    expect(direct?.kind).toBe("group");
+    expect(direct?.conversationRef).toBe(group?.conversationRef);
+  });
 });

--- a/src/config/sessions/conversation-identity.ts
+++ b/src/config/sessions/conversation-identity.ts
@@ -111,6 +111,10 @@ export function buildConversationIdentity(params: {
   if (!peerId) {
     return null;
   }
+  // ponytail: whatsapp @g.us ids are always groups; dashboard sends without the
+  // inbound group flag would otherwise mint a duplicate direct row for the group.
+  const kind =
+    channel === "whatsapp" && peerId.toLowerCase().endsWith("@g.us") ? "group" : params.kind;
   // A normalized peer id identifies a conversation but is not necessarily a
   // routable transport address. Exact-address tools require authoritative egress facts.
   const deliveryTarget = normalizeText(params.deliveryTarget);
@@ -125,7 +129,7 @@ export function buildConversationIdentity(params: {
       : buildConversationRef({
           channel,
           accountId,
-          kind: params.kind,
+          kind,
           peerId: normalizeConversationPeerId(channel, rawParent),
         })
     : undefined;
@@ -134,14 +138,14 @@ export function buildConversationIdentity(params: {
     conversationRef: buildConversationRef({
       channel,
       accountId,
-      kind: params.kind,
+      kind,
       peerId,
       parentConversationRef,
       threadId,
     }),
     channel,
     accountId,
-    kind: params.kind,
+    kind,
     peerId,
     deliveryTarget,
     ...(parentConversationRef ? { parentConversationRef } : {}),


### PR DESCRIPTION
## What Problem This Solves
Fixes #137781 — WhatsApp group session gets a duplicate `direct`-kind conversation row (same peer_id as the group JID), causing UNIQUE constraint failures. Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree oc-137781).

Closes #137781