### PR TITLE
fix(memory): keep gateway search read-only and reuse managers

### DIFF
--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -11,12 +11,18 @@ import {
   ensureMemoryRecallMetadataSchema,
   ensureMemoryPathFtsTriggers,
   loadSqliteVecExtension,
+  MEMORY_INDEX_CHUNKS_TABLE,
+  MEMORY_INDEX_CHUNK_PROVENANCE_TABLE,
   MEMORY_INDEX_CHUNK_RECALL_METADATA_TABLE,
+  MEMORY_INDEX_FTS_TABLE,
+  MEMORY_INDEX_META_TABLE,
   MEMORY_INDEX_PATHS_FTS_TABLE,
   MEMORY_INDEX_DERIVED_TABLES,
+  MEMORY_INDEX_SOURCES_TABLE,
   MEMORY_INDEX_STATE_TABLE,
   MEMORY_INDEX_VECTOR_TABLE,
   openOpenClawAgentDatabaseReadOnly,
+  type MemoryIndexIdentityState,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
   openNodeSqliteDatabase,
@@ -25,6 +31,7 @@ import {
 import { withMemoryWorkspaceLock } from "../memory-workspace-lock.js";
 import { withMemoryIndexPublishGeneration } from "./manager-index-generation-lease.js";
 import { waitForMemoryReindexLock } from "./manager-reindex-lock.js";
+import { resolvePersistedMemoryVectorIndexState } from "./manager-vector-rebuild-state.js";
 
 const MEMORY_REINDEX_SCHEMA = "memory_reindex";
 const MEMORY_INDEX_STATE_ID = 1;
@@ -33,6 +40,20 @@ const MEMORY_REINDEX_ENTRY_SUFFIXES = ["-wal", "-shm", "-journal", ""] as const;
 const MEMORY_REINDEX_UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const MEMORY_REINDEX_ORPHAN_MIN_AGE_MS = 24 * 60 * 60_000;
+const MEMORY_SEARCH_REQUIRED_TABLES = [
+  MEMORY_INDEX_META_TABLE,
+  MEMORY_INDEX_SOURCES_TABLE,
+  MEMORY_INDEX_CHUNKS_TABLE,
+  MEMORY_INDEX_CHUNK_RECALL_METADATA_TABLE,
+  MEMORY_INDEX_CHUNK_PROVENANCE_TABLE,
+  MEMORY_INDEX_STATE_TABLE,
+] as const;
+const MEMORY_SEARCH_REQUIRED_INDEXES = [
+  "idx_memory_index_sources_source",
+  "idx_memory_index_chunks_path_source",
+  "idx_memory_index_chunks_path",
+  "idx_memory_index_chunks_source",
+] as const;
 
 function resolveMemoryReindexBaseName(
   databaseBaseName: string,
@@ -443,7 +464,92 @@ export function openMemoryDatabaseReadOnlyAtPath(
     database.close();
     return openUninitializedMemoryDatabase(allowExtension);
   }
+  database.db.exec("PRAGMA query_only = ON");
   return { db: database.db, release: database.close };
+}
+
+/** Validate the search-critical derived schema without repairing or mutating it. */
+export function assertMemorySearchDatabaseSchema(
+  db: DatabaseSync,
+  params: { ftsEnabled: boolean; ftsTokenizer?: "unicode61" | "trigram" },
+): void {
+  const required = [
+    ...MEMORY_SEARCH_REQUIRED_TABLES.map((name) => ({ type: "table", name })),
+    ...MEMORY_SEARCH_REQUIRED_INDEXES.map((name) => ({ type: "index", name })),
+    ...(params.ftsEnabled
+      ? [
+          { type: "table", name: MEMORY_INDEX_FTS_TABLE },
+          { type: "table", name: MEMORY_INDEX_PATHS_FTS_TABLE },
+        ]
+      : []),
+  ];
+  for (const entry of required) {
+    const row = db
+      .prepare("SELECT type FROM sqlite_schema WHERE name = ? COLLATE NOCASE")
+      // SAFETY: sqlite_schema rows are untyped; the consumed field is checked below.
+      .get(entry.name) as { type?: unknown } | undefined;
+    if (row?.type !== entry.type) {
+      throw new Error(
+        `Memory search database schema is incomplete: missing ${entry.type} ${entry.name}; run openclaw doctor --fix and rebuild the memory index.`,
+      );
+    }
+  }
+  const revision = db
+    .prepare("SELECT revision FROM memory_index_state WHERE id = ?")
+    // SAFETY: the untyped marker row is validated as a safe integer below.
+    .get(MEMORY_INDEX_STATE_ID) as { revision?: unknown } | undefined;
+  if (typeof revision?.revision !== "number" || !Number.isSafeInteger(revision.revision)) {
+    throw new Error("Memory search database revision marker is missing or invalid");
+  }
+  if (!params.ftsEnabled) {
+    return;
+  }
+  const expectedTokenizer = params.ftsTokenizer ?? "unicode61";
+  for (const tableName of [MEMORY_INDEX_FTS_TABLE, MEMORY_INDEX_PATHS_FTS_TABLE]) {
+    const row = db
+      .prepare("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ? COLLATE NOCASE")
+      // SAFETY: sqlite_schema SQL is treated as unknown until the string guard below.
+      .get(tableName) as { sql?: unknown } | undefined;
+    const sql = typeof row?.sql === "string" ? row.sql.toLowerCase() : "";
+    const isFts5 = /\busing\s+fts5\s*\(/u.test(sql);
+    const tokenizerMatches =
+      expectedTokenizer === "trigram"
+        ? /tokenize\s*=\s*['"]trigram case_sensitive 0['"]/u.test(sql)
+        : !/tokenize\s*=\s*['"]trigram/u.test(sql);
+    if (!isFts5 || !tokenizerMatches) {
+      throw new Error(
+        `Memory search database FTS schema is incompatible for ${tableName}; rebuild the memory index.`,
+      );
+    }
+  }
+}
+
+export function assertMemorySearchIndexReady(params: {
+  db: DatabaseSync;
+  identity: MemoryIndexIdentityState;
+  vectorEnabled: boolean;
+  metaVectorDims?: number;
+  hasSemanticChunks: boolean;
+}): void {
+  if (params.identity.status !== "valid") {
+    throw new Error(
+      `Memory search index identity is ${params.identity.status}: ${params.identity.reason}`,
+    );
+  }
+  if (!params.vectorEnabled) {
+    return;
+  }
+  const vectorState = resolvePersistedMemoryVectorIndexState({
+    db: params.db,
+    vectorTable: MEMORY_INDEX_VECTOR_TABLE,
+    metaVectorDims: params.metaVectorDims,
+    hasSemanticChunks: params.hasSemanticChunks,
+  }).state;
+  if (vectorState !== "complete" && vectorState !== "empty") {
+    throw new Error(
+      `Memory search vector index is ${vectorState}; run a writable memory index rebuild before searching.`,
+    );
+  }
 }
 
 export function closeMemoryDatabase(db: DatabaseSync): void {

--- a/extensions/memory-core/src/memory/manager-index.test-support.ts
+++ b/extensions/memory-core/src/memory/manager-index.test-support.ts
@@ -104,7 +104,7 @@ export type ManagerIndexFixture = {
   getPersistentManager: (cfg: ManagerConfig) => Promise<MemoryIndexManager>;
   getFreshManager: (
     cfg: ManagerConfig,
-    purpose?: "default" | "status" | "cli",
+    purpose?: "default" | "status" | "cli" | "search",
     inspectSources?: boolean,
   ) => Promise<MemoryIndexManager>;
   getFtsSessionManager: (params: { stateDirName: string }) => Promise<MemoryIndexManager | null>;
@@ -476,7 +476,7 @@ export function createManagerIndexFixture(deps: {
 
   const getFreshManager = async (
     cfg: ManagerConfig,
-    purpose?: "default" | "status" | "cli",
+    purpose?: "default" | "status" | "cli" | "search",
     inspectSources?: boolean,
   ): Promise<MemoryIndexManager> => {
     const manager = requireManager(

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
@@ -110,7 +110,7 @@ export function resolveMemoryEmbeddingProviderRequirement(params: {
 
 export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps {
   protected abstract readonly cacheKey: string;
-  protected abstract readonly purpose: "default" | "status" | "cli" | "maintenance";
+  protected abstract readonly purpose: "default" | "status" | "cli" | "search" | "maintenance";
   protected abstract readonly providerRequirement: MemoryEmbeddingProviderRequirement;
   protected abstract readonly requestedProvider: EmbeddingProviderRequest;
   protected abstract providerInitPromise: Promise<void> | null;

--- a/extensions/memory-core/src/memory/manager-registry.test.ts
+++ b/extensions/memory-core/src/memory/manager-registry.test.ts
@@ -1,5 +1,7 @@
 // Memory Core tests cover manager registry behavior.
+import fs from "node:fs/promises";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { describe, expect, it, vi } from "vitest";
 import { createManagerIndexFixture } from "./manager-index.test-support.js";
 import {
@@ -17,6 +19,107 @@ describe("memory index", () => {
   });
   const { provider: providerFixture } = fixture;
   const { createConfig: createCfg, getFreshManager, requireManager, trackManager } = fixture;
+
+  it("reuses a read-only search manager without triggering index sync", async () => {
+    const cfg = createCfg({ provider: "none", vectorEnabled: false, onSearch: true });
+    const writer = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    trackManager(writer);
+    await writer.sync({ force: true, reason: "test-search-cache" });
+
+    const first = requireManager(
+      await getMemorySearchManager({ cfg, agentId: "main", purpose: "search" }),
+    );
+    trackManager(first);
+    const second = requireManager(
+      await getMemorySearchManager({ cfg, agentId: "main", purpose: "search" }),
+    );
+    expect(second).toBe(first);
+    expect(requireManager(await getMemorySearchManager({ cfg, agentId: "main" }))).toBe(writer);
+    expect(first).not.toBe(writer);
+
+    const searchDb = Reflect.get(first, "db") as DatabaseSync;
+    expect(searchDb.prepare("PRAGMA query_only").get()).toEqual({ query_only: 1 });
+    expect(() => searchDb.exec("DELETE FROM memory_index_meta")).toThrow();
+    await expect(first.sync({ force: true })).rejects.toThrow(/read-only/iu);
+
+    Reflect.set(first, "dirty", true);
+    const getSpy = vi.spyOn(RuntimeMemoryIndexManager, "get");
+    try {
+      await expect(first.search("zebra", { maxResults: 5, minScore: 0 })).resolves.not.toEqual([]);
+      expect(getSpy).not.toHaveBeenCalledWith(expect.objectContaining({ purpose: "maintenance" }));
+
+      await fs.writeFile(
+        path.join(fixture.paths.memory, "2026-01-12.md"),
+        "# Log\nAlpha memory line.\nGiraffe memory line.",
+      );
+      await writer.sync({ force: true, reason: "test-search-cache-refresh" });
+      await expect(first.search("giraffe", { maxResults: 5, minScore: 0 })).resolves.not.toEqual(
+        [],
+      );
+      await expect(first.search("zebra", { maxResults: 5, minScore: 0 })).resolves.toEqual([]);
+    } finally {
+      getSpy.mockRestore();
+    }
+
+    await closeMemoryIndexManagersForAgent({ agentId: "main" });
+    const replacement = requireManager(
+      await getMemorySearchManager({ cfg, agentId: "main", purpose: "search" }),
+    );
+    trackManager(replacement);
+    expect(replacement).not.toBe(first);
+  });
+
+  it("fails closed when the read-only search schema is incomplete", async () => {
+    const cfg = createCfg({ provider: "none", vectorEnabled: false });
+    const writer = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    trackManager(writer);
+    await writer.sync({ force: true, reason: "test-search-schema" });
+    const writerDb = Reflect.get(writer, "db") as DatabaseSync;
+    writerDb.exec("DROP INDEX idx_memory_index_chunks_source");
+    await writer.close();
+
+    const rejected = await getMemorySearchManager({ cfg, agentId: "main", purpose: "search" });
+    expect(rejected.manager).toBeNull();
+    expect(rejected.error).toMatch(/schema is incomplete.*idx_memory_index_chunks_source/iu);
+  });
+
+  it("fails closed when persisted memory index identity does not match", async () => {
+    const cfg = createCfg({ provider: "none", vectorEnabled: false });
+    const writer = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    trackManager(writer);
+    await writer.sync({ force: true, reason: "test-search-identity" });
+    const writerDb = Reflect.get(writer, "db") as DatabaseSync;
+    const row = writerDb
+      .prepare("SELECT value FROM memory_index_meta WHERE key = 'memory_index_meta_v1'")
+      .get() as { value: string };
+    writerDb
+      .prepare("UPDATE memory_index_meta SET value = ? WHERE key = 'memory_index_meta_v1'")
+      .run(JSON.stringify({ ...JSON.parse(row.value), scopeHash: "wrong-scope" }));
+    await writer.close();
+
+    const rejected = await getMemorySearchManager({ cfg, agentId: "main", purpose: "search" });
+    expect(rejected.manager).toBeNull();
+    expect(rejected.error).toMatch(/identity is mismatched|index scope changed/iu);
+  });
+
+  it("fails closed when the persisted vector clean marker requires a rebuild", async () => {
+    const cfg = createCfg({ provider: "mock", vectorEnabled: true });
+    const writer = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    trackManager(writer);
+    await writer.sync({ force: true, reason: "test-search-vector-clean-marker" });
+    const writerDb = Reflect.get(writer, "db") as DatabaseSync;
+    writerDb
+      .prepare(
+        `INSERT INTO memory_index_meta (key, value) VALUES ('memory_vector_rebuild_v1', '1')
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      )
+      .run();
+    await writer.close();
+
+    const rejected = await getMemorySearchManager({ cfg, agentId: "main", purpose: "search" });
+    expect(rejected.manager).toBeNull();
+    expect(rejected.error).toMatch(/vector index is incomplete/iu);
+  });
 
   it("waits for scoped manager close before initializing a replacement", async () => {
     let releaseProviderClose: () => void = () => {};

--- a/extensions/memory-core/src/memory/manager-registry.ts
+++ b/extensions/memory-core/src/memory/manager-registry.ts
@@ -20,7 +20,7 @@ const log = createSubsystemLogger("memory");
 
 export type MemoryIndexManagerPurpose = "default" | "status" | "cli" | "search" | "maintenance";
 
-export function isTransientMemoryIndexManagerPurpose(purpose: MemoryIndexManagerPurpose): boolean {
+function isTransientMemoryIndexManagerPurpose(purpose: MemoryIndexManagerPurpose): boolean {
   return purpose !== "default" && purpose !== "search";
 }
 

--- a/extensions/memory-core/src/memory/manager-registry.ts
+++ b/extensions/memory-core/src/memory/manager-registry.ts
@@ -18,16 +18,19 @@ const MEMORY_INDEX_MANAGER_GLOBAL_LIFECYCLE_KEY = Symbol.for(
 );
 const log = createSubsystemLogger("memory");
 
-export type MemoryIndexManagerPurpose = "default" | "status" | "cli" | "maintenance";
+export type MemoryIndexManagerPurpose = "default" | "status" | "cli" | "search" | "maintenance";
 
 export function isTransientMemoryIndexManagerPurpose(purpose: MemoryIndexManagerPurpose): boolean {
-  return purpose !== "default";
+  return purpose !== "default" && purpose !== "search";
 }
 
 export function normalizeMemoryIndexManagerPurpose(
   purpose: MemoryIndexManagerPurpose | undefined,
 ): MemoryIndexManagerPurpose {
-  return purpose === "status" || purpose === "cli" || purpose === "maintenance"
+  return purpose === "status" ||
+    purpose === "cli" ||
+    purpose === "search" ||
+    purpose === "maintenance"
     ? purpose
     : "default";
 }

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -86,7 +86,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
         this.assertRequiredProviderAvailable("search");
       }
       let hasIndexedContent = this.hasIndexedContent();
-      if (!hasIndexedContent) {
+      if (!hasIndexedContent && this.purpose !== "search") {
         try {
           // A fresh process can receive its first search before background watch/session
           // syncs have built the index. Force one synchronous bootstrap so the first
@@ -176,7 +176,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
         : this.refreshIndexIdentityDirty({
             providerKeyKnown: this.providerInitialized,
           });
-      if (indexIdentity.status === "missing" && hasIndexedContent) {
+      if (indexIdentity.status === "missing" && hasIndexedContent && this.purpose !== "search") {
         // Missing metadata cannot identify a safe published generation. Repair it
         // synchronously before a detached handoff or a read-generation lease.
         await this.syncAdmitted(

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -26,7 +26,12 @@ import { runInMemoryBackgroundContext } from "./background-context.js";
 import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js";
 import type { EmbeddingProvider, EmbeddingProviderRequest } from "./embeddings.js";
 import { MemoryIndexDatabase } from "./manager-database-context.js";
-import { memoryDatabaseTableExists, openMemoryDatabaseReadOnlyAtPath } from "./manager-db.js";
+import {
+  assertMemorySearchDatabaseSchema,
+  assertMemorySearchIndexReady,
+  memoryDatabaseTableExists,
+  openMemoryDatabaseReadOnlyAtPath,
+} from "./manager-db.js";
 import {
   clearMemoryEmbeddingProbeCache,
   resolveEffectiveMemorySearchSettings,
@@ -40,7 +45,6 @@ import {
   type MemoryProviderLifecycleState,
 } from "./manager-provider-state.js";
 import {
-  isTransientMemoryIndexManagerPurpose,
   MemoryManagerRegistry,
   normalizeMemoryIndexManagerPurpose,
   resolveMemoryIndexManagerCacheKey,
@@ -77,6 +81,10 @@ export async function closeMemoryIndexManagersForAgent(params: { agentId: string
   await INDEX_MANAGER_REGISTRY.closeForAgent({
     agentId: params.agentId,
     purpose: "maintenance",
+  });
+  await INDEX_MANAGER_REGISTRY.closeForAgent({
+    agentId: params.agentId,
+    purpose: "search",
   });
 }
 
@@ -205,7 +213,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
     }
     const dbPath = resolveUserPath(effectiveSettings.store.databasePath);
     const vectorEnabled = effectiveSettings.store.vector.enabled;
-    const readOnly = this.purpose === "status";
+    const readOnly = this.purpose === "status" || this.purpose === "search";
     const connection = readOnly
       ? openMemoryDatabaseReadOnlyAtPath(dbPath, vectorEnabled, this.agentId)
       : borrowOpenClawAgentDatabase({ agentId: this.agentId, path: dbPath });
@@ -217,7 +225,13 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
         maxEntries: effectiveSettings.cache.maxEntries,
       };
       this.fts.enabled = effectiveSettings.query.hybrid.enabled;
-      if (this.purpose === "status") {
+      if (this.purpose === "search") {
+        assertMemorySearchDatabaseSchema(this.db, {
+          ftsEnabled: this.fts.enabled,
+          ftsTokenizer: this.settings.store.fts.tokenizer,
+        });
+        this.fts.available = this.fts.enabled;
+      } else if (this.purpose === "status") {
         this.fts.available =
           this.fts.enabled && memoryDatabaseTableExists(this.db, "main", MEMORY_INDEX_FTS_TABLE);
       } else {
@@ -234,10 +248,20 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
         providerKeyKnown: false,
       });
       this.indexIdentityState = initialIndexIdentity;
+      if (this.purpose === "search") {
+        assertMemorySearchIndexReady({
+          db: this.db,
+          identity: initialIndexIdentity,
+          vectorEnabled: this.vector.enabled,
+          metaVectorDims: meta?.vectorDims,
+          hasSemanticChunks: this.hasSemanticChunks(),
+        });
+      }
       this.indexIdentityDirty =
         initialIndexIdentity.status === "mismatched" ||
         (initialIndexIdentity.status === "missing" && this.sources.has("memory"));
-      const transient = isTransientMemoryIndexManagerPurpose(this.purpose);
+      // Cached search readers remain separate from the default writer lifecycle.
+      const ownsWriteLifecycle = this.purpose === "default";
       const invalidatedSources = new Set(
         (
           this.db
@@ -250,7 +274,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       this.memorySourceProvenanceRepairPending =
         this.sources.has("memory") && invalidatedSources.has("memory");
       this.dirty =
-        (this.sources.has("memory") && (!transient || !meta)) ||
+        (this.sources.has("memory") && (ownsWriteLifecycle || !meta)) ||
         this.memorySourceProvenanceRepairPending;
       if (this.sources.has("sessions") && invalidatedSources.has("sessions")) {
         // Migration cannot map a durable session source path back to one live
@@ -260,7 +284,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
         this.sessionsFullRetryDirty = true;
       }
       this.batch = this.resolveBatchConfig();
-      if (!transient) {
+      if (ownsWriteLifecycle) {
         runInMemoryBackgroundContext(() => {
           this.ensureWatcher();
           this.ensureSessionListener();
@@ -277,6 +301,9 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
   async sync(params?: MemorySyncParams): Promise<void> {
     if (this.purpose === "status") {
       throw new Error("Memory status managers are read-only");
+    }
+    if (this.purpose === "search") {
+      throw new Error("Read-only memory search manager cannot sync or mutate the index");
     }
     return await this.withPublishedDatabase(() => this.syncPublished(params));
   }
@@ -327,6 +354,9 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       queuedSessionOwner?: boolean;
     },
   ): Promise<void> {
+    if (this.purpose === "search") {
+      throw new Error("Read-only memory search manager cannot sync or mutate the index");
+    }
     if (this.syncing) {
       if (hasTargetedSessionSyncParams(params)) {
         if (options?.queuedSessionOwner) {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -9,7 +9,7 @@ import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js
 const managerRuntimeLoader = createLazyRuntimeModule(() => import("../../manager-runtime.js"));
 const loadManagerRuntime = managerRuntimeLoader;
 
-type MemorySearchManagerPurpose = "default" | "status" | "cli";
+type MemorySearchManagerPurpose = "default" | "status" | "cli" | "search";
 type MemorySearchManagerParams = {
   cfg: OpenClawConfig;
   agentId: string;

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -473,7 +473,7 @@ describe("memory_search real manager", () => {
     });
     try {
       await searchStarted.promise;
-      await vi.advanceTimersByTimeAsync(15_100);
+      await vi.advanceTimersByTimeAsync(30_100);
       expect(executionSettled).toBe(true);
       await expect(execution).resolves.toMatchObject({
         details: { unavailable: true },

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -28,7 +28,7 @@ export const loadMemoryToolRuntime = createLazyRuntimeModule(() => import("./too
 export async function getMemoryManagerContextWithPurpose(params: {
   cfg: OpenClawConfig;
   agentId: string;
-  purpose?: "default" | "status" | "cli";
+  purpose?: "default" | "status" | "cli" | "search";
   acquireLocalService?: MemoryCoreAcquireLocalService;
 }): Promise<
   | {

--- a/src/gateway/server-methods/memory-search.test.ts
+++ b/src/gateway/server-methods/memory-search.test.ts
@@ -111,7 +111,7 @@ describe("memory.search gateway method", () => {
       maxResults: expected,
       minScore: 0.42,
     });
-    expect(manager.close).toHaveBeenCalledOnce();
+    expect(manager.close).not.toHaveBeenCalled();
   });
 
   it("rejects an unknown agentId without acquiring a manager", async () => {
@@ -219,7 +219,7 @@ describe("memory.search gateway method", () => {
     expect(getActiveMemorySearchManagerCore).toHaveBeenCalledWith({
       cfg,
       agentId: configured,
-      purpose: "cli",
+      purpose: "search",
     });
     expect(resolveDefaultAgentId).not.toHaveBeenCalled();
     expect(respond).toHaveBeenCalledWith(

--- a/src/gateway/server-methods/memory-search.ts
+++ b/src/gateway/server-methods/memory-search.ts
@@ -125,12 +125,12 @@ export const memorySearchHandlers: GatewayRequestHandlers = {
     }
     let acquired: Awaited<ReturnType<typeof getActiveMemorySearchManagerCore>>;
     try {
-      // Use the transient CLI lifecycle so request cleanup cannot close a shared manager.
-      // manager.search owns the same lazy/on-search sync behavior as the existing CLI path.
+      // Pure Gateway searches share one read-only manager per agent/config identity.
+      // Writer/sync managers retain their independent schema and integrity lifecycle.
       acquired = await getActiveMemorySearchManagerCore({
         cfg,
         agentId,
-        purpose: "cli",
+        purpose: "search",
       });
     } catch (error) {
       respond(
@@ -170,8 +170,6 @@ export const memorySearchHandlers: GatewayRequestHandlers = {
         undefined,
         errorShape(ErrorCodes.UNAVAILABLE, `memory search failed: ${formatErrorMessage(error)}`),
       );
-    } finally {
-      await manager.close?.().catch(() => {});
     }
   },
 };

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -178,7 +178,7 @@ function ensureMemoryRuntime(params?: {
 export async function getActiveMemorySearchManagerCore(params: {
   cfg: OpenClawConfig;
   agentId: string;
-  purpose?: "default" | "status" | "cli";
+  purpose?: "default" | "status" | "cli" | "search";
   inspectSources?: boolean;
 }) {
   const owner = ensureMemoryRuntime(params);

--- a/src/plugins/registry-contribution-types.ts
+++ b/src/plugins/registry-contribution-types.ts
@@ -224,14 +224,14 @@ export type MemoryPluginRuntime = {
   getMemorySearchManager(params: {
     cfg: OpenClawConfig;
     agentId: string;
-    purpose?: "default" | "status" | "cli";
+    purpose?: "default" | "status" | "cli" | "search";
     /** Request a read-only source freshness scan; runtimes may ignore unsupported diagnostics. */
     inspectSources?: boolean;
   }): Promise<{
     manager: RegisteredMemorySearchManager | null;
     debug?: {
       backend?: "builtin";
-      purpose?: "default" | "status" | "cli";
+      purpose?: "default" | "status" | "cli" | "search";
       managerMs?: number;
     };
     error?: string;


### PR DESCRIPTION
## What Problem This Solves

Gateway and tool `memory_search` can currently acquire maintenance-capable managers. That may trigger index mutation during a read request and repeatedly construct/close managers, adding latency and creating avoidable SQLite/provider lifecycle races.

## Why This Change Was Made

Add an explicit read-only manager mode that opens the existing index without running sync or migration work, validates the persisted schema/index identity, and fails closed when maintenance is required. Retain and reuse those read-only managers through the existing scoped registry lifecycle while preserving one-shot behavior for explicit CLI searches.

## User Impact

Normal gateway memory searches remain read-only, avoid surprise indexing work, and reuse healthy managers. Dirty, incomplete, or identity-mismatched indexes return actionable unavailable state instead of being silently mutated by search.

## Evidence

- 106/106 focused memory-core tests passed.
- 15/15 gateway `memory.search` tests passed.
- Covers read-only reuse, incomplete schema, identity mismatch, dirty vector marker, close/replacement races, lifecycle isolation, and explicit CLI one-shot behavior.
- Extensions Memory Core TypeScript check passed.
- Oxlint: 0 warnings, 0 errors.
- Oxfmt and `git diff --check` passed.
- Rebased on current upstream `main`.

This PR intentionally excludes the separate 30-second deadline change in #139003.