### PR TITLE
improve(skills): avoid repeated archive reads during ZIP imports

### DIFF
--- a/src/skills/library/import.ts
+++ b/src/skills/library/import.ts
@@ -32,6 +32,7 @@ import {
   requireSkillLibraryEntry,
   requireSkillLibraryProfile,
   requireSkillLibraryUpload,
+  requireSkillLibraryUploadMetadata,
   selectSkillLibraryOwner,
   skillLibraryDb,
   type SkillLibraryAuthority,
@@ -230,7 +231,12 @@ export async function uploadSkillLibrary(
           receipt: await publishDirectory(
             {
               ...authority,
-              assertCurrent: readOwned,
+              assertCurrent: () =>
+                requireSkillLibraryUploadMetadata(
+                  openOpenClawStateDatabase(options).db,
+                  params.uploadId,
+                  authority,
+                ),
             },
             upload.slug,
             rootDir,

--- a/src/skills/library/service.test.ts
+++ b/src/skills/library/service.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { constants } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SKILL_LIBRARY_MAX_FILE_BYTES } from "../../../packages/gateway-protocol/src/schema/skill-library.js";
+import { trackSqliteStatementExecutions } from "../../../test/helpers/sqlite-statement-execution-counter.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { tableExists } from "../../state/openclaw-state-db-schema-helpers.js";
 import {
@@ -539,11 +540,23 @@ describe("library admission and imports", () => {
       await expect(
         uploadSkillLibrary(bob, { action: "commit", uploadId: begun.uploadId }, options),
       ).rejects.toMatchObject({ code: "NOT_FOUND" });
+      const archiveReads = trackSqliteStatementExecutions(
+        openOpenClawStateDatabase(options).db,
+        ["archive"],
+        (sql) =>
+          sql.startsWith("select ") &&
+          sql.includes('from "skill_library_uploads"') &&
+          /\*|"archive_blob"/u.test(sql)
+            ? "archive"
+            : null,
+      );
       const saved = await uploadSkillLibrary(
         alice,
         { action: "commit", uploadId: begun.uploadId },
         options,
-      );
+      ).finally(archiveReads.restore);
+      // Publication guards must not reload the archive after the extraction snapshot.
+      expect(archiveReads.rowCounts.archive).toBe(1);
       if (!("entry" in saved)) {
         throw new Error("Expected publication receipt");
       }

--- a/src/skills/library/service.ts
+++ b/src/skills/library/service.ts
@@ -39,7 +39,7 @@ import {
   recordSkillLibraryEvent,
   requireSkillLibraryEntry,
   requireSkillLibraryProfile,
-  requireSkillLibraryUpload,
+  requireSkillLibraryUploadMetadata,
   resolveSkillLibraryActor,
   selectSkillLibraryRevision,
   selectSkillLibraryRevisionMetadata,
@@ -282,7 +282,7 @@ export async function saveSkillLibrary(
       ({ db }) => {
         const actor = requireSkillLibraryProfile(db, authority);
         if (uploadId) {
-          const upload = requireSkillLibraryUpload(db, uploadId, authority);
+          const upload = requireSkillLibraryUploadMetadata(db, uploadId, authority);
           if (upload.slug !== params.slug) {
             throw new SkillLibraryError(
               "NOT_FOUND",

--- a/src/skills/library/store.ts
+++ b/src/skills/library/store.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
+import type { SelectQueryBuilder } from "kysely";
 import type { SkillLibraryEntry } from "../../../packages/gateway-protocol/src/schema/skill-library.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { authorizeOperatorScopesForRequiredScope } from "../../gateway/method-scopes.js";
@@ -129,19 +130,16 @@ export function requireSkillLibraryProfile(
   return actor.profileId;
 }
 
-export function requireSkillLibraryUpload(
+function requireSelectedSkillLibraryUpload<
+  T extends Pick<SkillLibraryDatabase["skill_library_uploads"], "owner_profile_id" | "expires_at">,
+>(
   db: DatabaseSync,
   uploadId: string,
   authority: SkillLibraryAuthority,
+  query: SelectQueryBuilder<SkillLibraryDatabase, "skill_library_uploads", T>,
 ) {
   const actor = requireSkillLibraryProfile(db, authority);
-  const upload = executeSqliteQueryTakeFirstSync(
-    db,
-    skillLibraryDb(db)
-      .selectFrom("skill_library_uploads")
-      .selectAll()
-      .where("upload_id", "=", uploadId),
-  );
+  const upload = executeSqliteQueryTakeFirstSync(db, query.where("upload_id", "=", uploadId));
   if (
     !upload ||
     upload.expires_at <= Date.now() ||
@@ -153,6 +151,34 @@ export function requireSkillLibraryUpload(
     );
   }
   return upload;
+}
+
+export function requireSkillLibraryUpload(
+  db: DatabaseSync,
+  uploadId: string,
+  authority: SkillLibraryAuthority,
+) {
+  return requireSelectedSkillLibraryUpload(
+    db,
+    uploadId,
+    authority,
+    skillLibraryDb(db).selectFrom("skill_library_uploads").selectAll(),
+  );
+}
+
+export function requireSkillLibraryUploadMetadata(
+  db: DatabaseSync,
+  uploadId: string,
+  authority: SkillLibraryAuthority,
+) {
+  return requireSelectedSkillLibraryUpload(
+    db,
+    uploadId,
+    authority,
+    skillLibraryDb(db)
+      .selectFrom("skill_library_uploads")
+      .select(["owner_profile_id", "expires_at", "slug", "published_skill_id"]),
+  );
 }
 
 export function selectSkillLibraryRow(


### PR DESCRIPTION
## What Problem This Solves

ZIP imports repeatedly loaded the complete archive while rechecking publication authorization. An 8 MiB upload materialized 56 MiB of archive rows during commit, including 32 MiB inside the SQLite write transaction.

## Why This Change Was Made

The existing upload authorization policy now serves full and four-field metadata projections. Publication guards and slug/receipt checks use metadata; chunk handling, the initial byte snapshot and completed-receipt replay keep their full reads. Every authority callback, query, ownership/expiry check and publication boundary remains in place.

## User Impact

ZIP imports avoid six unused archive copies during commit. Schema, retained data, quotas, errors, receipt replay and published artifact bytes are unchanged. Production delta: +32 lines for the shared typed projection boundary; tests: +13 lines in the existing ZIP owner test.

## Evidence

Node 24.20.0 with real SQLite:

| Commit scenario | Archive bytes selected | Inside write transaction | Queries / authority callbacks |
| --- | --- | --- | --- |
| One 8 MiB upload | 56 → 8 MiB | 32 → 0 MiB | 30 / 7, unchanged |
| Two concurrent commits | 112 → 16 MiB | 64 → 0 MiB | 59 / 14, unchanged |

All 13 baseline/candidate scenarios passed, including wrong/missing owner, expiry and authority loss after the byte snapshot, late slug change, profile merge, concurrent commit and removed-skill replay. The actual metadata reader also passed with native SQLite authorization denying archive-column access.

The existing ZIP import regression test fails on the old code with `expected 7 to be 1` and passes on the candidate. All 54 focused tests across library, persistence/crash, Gateway, authoring and CLI owners passed, followed by the full changed-code gate.

A real isolated Gateway accepted a two-chunk ZIP upload, published and read its 320 KiB binary file and executable flag, replayed the receipt, restarted, then returned the identical receipt and artifact. Raw application RPC frames were retained. Fresh SQLite readback after shutdown found one upload, entry, revision and event with the exact retained archive hash. Both owned Gateway processes and ports were closed. Intentional shutdown canceled the background Control UI build and deferred maintenance; the RPC flow and clean shutdown passed.

Byte counts measure payloads selected into native rows, not peak RSS or elapsed-time speedup. Completed receipt replay intentionally retains one full archive read and its existing single-row snapshot.

Independent Codex review completed nine passes with no P0–P2 findings. Direct installed dependency contracts were inspected.
