### PR TITLE
refactor(proxy-capture): centralize typed diagnostic queries

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3526,7 +3526,7 @@ src/projects/project-registry.ts	1
 src/provider-runtime/operation-retry.ts	3
 src/proxy-capture/env.ts	1
 src/proxy-capture/runtime.ts	10
-src/proxy-capture/store.sqlite.ts	23
+src/proxy-capture/store.sqlite.ts	16
 src/realtime-transcription/websocket-session.ts	2
 src/routing/binding-scope.ts	1
 src/runtime.ts	4

--- a/src/proxy-capture/store-readonly.ts
+++ b/src/proxy-capture/store-readonly.ts
@@ -1,5 +1,6 @@
 import { gunzipSync } from "node:zlib";
 import { normalizeNullableString as normalizeObservedValue } from "@openclaw/normalization-core/string-coerce";
+import type { Compilable, InferResult } from "kysely";
 import {
   compileSqliteQueryBindings,
   executeSqliteQuerySync,
@@ -8,11 +9,16 @@ import {
 } from "../infra/kysely-sync.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
-import type { CaptureObservedDimension, CaptureSessionCoverageSummary } from "./types.js";
+import type {
+  CaptureObservedDimension,
+  CaptureQueryPreset,
+  CaptureQueryRow,
+  CaptureSessionCoverageSummary,
+} from "./types.js";
 
 type DebugProxyCaptureDatabase = Pick<
   OpenClawStateKyselyDatabase,
-  "capture_events" | "capture_blobs"
+  "capture_sessions" | "capture_events" | "capture_blobs"
 >;
 type NodeSqliteDatabase = Parameters<typeof getNodeSqliteKysely>[0];
 
@@ -20,6 +26,137 @@ export type DebugProxyCaptureReader = {
   getSessionEvents(sessionId: string, limit?: number): Array<Record<string, unknown>>;
   readBlob(blobId: string): string | null;
 };
+
+export function listDebugProxyCaptureSessions(db: NodeSqliteDatabase, limit = 50) {
+  const query = getNodeSqliteKysely<DebugProxyCaptureDatabase>(db)
+    .selectFrom("capture_sessions as s")
+    .leftJoin("capture_events as e", "e.session_id", "s.id")
+    .select([
+      "s.id",
+      "s.started_at as startedAt",
+      "s.ended_at as endedAt",
+      "s.mode",
+      "s.source_process as sourceProcess",
+      "s.proxy_url as proxyUrl",
+    ])
+    .select((eb) => eb.fn.count<number>("e.id").as("eventCount"))
+    .groupBy("s.id")
+    .orderBy("s.started_at", "desc")
+    .limit(limit);
+  const { compiled, bind } = compileSqliteQueryBindings(() => query);
+  // Native reads retain the store's failure ownership without evicting its borrowed DB.
+  return db /* sqlite-allow-raw -- Execute Kysely SQL with native failure ownership. */
+    .prepare(compiled.sql)
+    .all(...bind(undefined)) as InferResult<typeof query>; // SAFETY: Native columns follow this generated projection.
+}
+
+export function findDebugProxyCaptureBlobReference(
+  db: NodeSqliteDatabase,
+  blobId: string,
+): string | null {
+  const query = getNodeSqliteKysely<DebugProxyCaptureDatabase>(db)
+    .selectFrom("capture_events")
+    .select("data_blob_id as blobId")
+    .where("data_blob_id", "=", blobId)
+    .limit(1);
+  const { compiled, bind } = compileSqliteQueryBindings(() => query);
+  const row = db /* sqlite-allow-raw -- Execute Kysely SQL with native failure ownership. */
+    .prepare(compiled.sql)
+    .get(...bind(undefined)) as InferResult<typeof query>[number] | undefined; // SAFETY: Native lookup returns the selected nullable text column.
+  return row?.blobId || null;
+}
+
+export function queryDebugProxyCapturePreset(
+  db: NodeSqliteDatabase,
+  preset: CaptureQueryPreset,
+  sessionId?: string,
+): CaptureQueryRow[] {
+  const kysely = getNodeSqliteKysely<DebugProxyCaptureDatabase>(db);
+  let events = kysely.selectFrom("capture_events");
+  if (sessionId) {
+    events = events.where("session_id", "=", sessionId);
+  }
+  const locations = events.select(["host", "path"]);
+  const count = kysely.fn.countAll<number>();
+  let query: Compilable<CaptureQueryRow>;
+  // Aggregate in SQLite so diagnostics do not hydrate whole capture sessions.
+  switch (preset) {
+    case "double-sends":
+      query = locations
+        .select(["method", count.as("duplicateCount")])
+        .where("kind", "=", "request")
+        .groupBy(["host", "path", "method", "data_sha256"])
+        .having(count, ">", 1)
+        .orderBy("duplicateCount", "desc")
+        .orderBy("host", "asc");
+      break;
+    case "retry-storms":
+      query = locations
+        .select(count.as("errorCount"))
+        .where("kind", "=", "response")
+        .where("status", ">=", 429)
+        .groupBy(["host", "path"])
+        .having(count, ">", 1)
+        .orderBy("errorCount", "desc")
+        .orderBy("host", "asc");
+      break;
+    case "cache-busting":
+      query = locations
+        .select(count.as("variantCount"))
+        .where("kind", "=", "request")
+        .where((eb) =>
+          eb.or([
+            eb("path", "like", "%?%"),
+            eb("headers_json", "like", "%cache-control%"),
+            eb("headers_json", "like", "%pragma%"),
+          ]),
+        )
+        .groupBy(["host", "path"])
+        .orderBy("variantCount", "desc")
+        .orderBy("host", "asc");
+      break;
+    case "ws-duplicate-frames":
+      query = locations
+        .select(count.as("duplicateFrames"))
+        .where("kind", "=", "ws-frame")
+        .where("direction", "=", "outbound")
+        .groupBy(["host", "path", "data_sha256"])
+        .having(count, ">", 1)
+        .orderBy("duplicateFrames", "desc")
+        .orderBy("host", "asc");
+      break;
+    case "missing-ack":
+      query = events
+        .select(["flow_id as flowId", "host", "path", count.as("outboundFrames")])
+        .where("kind", "=", "ws-frame")
+        .where("direction", "=", "outbound")
+        .where(
+          "flow_id",
+          "not in",
+          events
+            .select("flow_id")
+            .where("kind", "=", "ws-frame")
+            .where("direction", "=", "inbound"),
+        )
+        .groupBy(["flow_id", "host", "path"])
+        .orderBy("outboundFrames", "desc");
+      break;
+    case "error-bursts":
+      query = locations
+        .select(count.as("errorCount"))
+        .where("kind", "=", "error")
+        .groupBy(["host", "path"])
+        .orderBy("errorCount", "desc")
+        .orderBy("host", "asc");
+      break;
+    default:
+      return [];
+  }
+  const { compiled, bind } = compileSqliteQueryBindings(() => query);
+  return db /* sqlite-allow-raw -- Execute Kysely SQL with native failure ownership. */
+    .prepare(compiled.sql)
+    .all(...bind(undefined)) as CaptureQueryRow[]; // SAFETY: Each typed preset selects only text, count, or nullable columns.
+}
 
 export function readDebugProxyCaptureSessionEvents(
   db: NodeSqliteDatabase,

--- a/src/proxy-capture/store.sqlite.test.ts
+++ b/src/proxy-capture/store.sqlite.test.ts
@@ -15,6 +15,7 @@ import {
   getDebugProxyCaptureStore,
   persistEventPayload,
 } from "./store.sqlite.js";
+import type { CaptureEventRecord, CaptureQueryPreset } from "./types.js";
 
 const cleanupDirs: string[] = [];
 
@@ -487,7 +488,7 @@ describe("DebugProxyCaptureStore", () => {
     expect(store.isClosed).toBe(true);
   });
 
-  it("stores sessions, blobs, and duplicate-send query results", () => {
+  it("stores sessions and deduplicates complete payloads", () => {
     const store = makeStore();
     store.upsertSession({
       id: "session-1",
@@ -525,30 +526,130 @@ describe("DebugProxyCaptureStore", () => {
       path: "/v1/send",
       ...firstPayload,
     });
-    store.recordEvent({
-      sessionId: "session-1",
-      ts: 2,
-      sourceScope: "openclaw",
-      sourceProcess: "openclaw",
-      protocol: "https",
-      direction: "outbound",
-      kind: "request",
-      flowId: "flow-2",
-      method: "POST",
-      host: "api.example.com",
-      path: "/v1/send",
-      ...firstPayload,
-    });
-
     expect(store.listSessions(10)).toHaveLength(1);
-    const duplicateRows = store.queryPreset("double-sends", "session-1");
-    expect(duplicateRows).toHaveLength(1);
-    expect(duplicateRows[0]?.host).toBe("api.example.com");
-    expect(duplicateRows[0]?.path).toBe("/v1/send");
-    expect(duplicateRows[0]?.method).toBe("POST");
-    expect(duplicateRows[0]?.duplicateCount).toBe(2);
     expect(store.readBlob(firstPayload.dataBlobId ?? "")).toContain('"ok":true');
   });
+
+  it.each(["shared", "path"] as const)(
+    "preserves %s diagnostic grouping, session scope, and native read retries",
+    (kind) => {
+      const env = makeStateEnv("openclaw-proxy-capture-diagnostics-");
+      const store =
+        kind === "shared"
+          ? new DebugProxyCaptureStore({ env })
+          : new DebugProxyCaptureStore(
+              path.join(env.OPENCLAW_STATE_DIR!, "capture.sqlite"),
+              path.join(env.OPENCLAW_STATE_DIR!, "blobs"),
+            );
+      const record = (overrides: Partial<CaptureEventRecord>) =>
+        store.recordEvent({
+          sessionId: "captured",
+          ts: 1,
+          sourceScope: "openclaw",
+          sourceProcess: "test",
+          protocol: "https",
+          direction: "outbound",
+          kind: "request",
+          flowId: "cross-session",
+          host: "api.example",
+          path: "/send",
+          method: "POST",
+          ...overrides,
+        });
+      try {
+        for (const [index, id] of ["captured", "other", "empty"].entries()) {
+          store.upsertSession({
+            id,
+            startedAt: index,
+            mode: "test",
+            sourceScope: "openclaw",
+            sourceProcess: "test",
+          });
+        }
+        for (const eventKind of ["request", "ws-frame"] as const) {
+          for (const dataSha256 of ["first", "second"]) {
+            record({ kind: eventKind, dataSha256 });
+            record({ kind: eventKind, dataSha256 });
+          }
+        }
+        for (const status of [428, 429, 500]) {
+          record({ kind: "response", direction: "inbound", status });
+        }
+        record({ path: "/cache?variant" });
+        record({ path: "/cache", headersJson: "CACHE-CONTROL" });
+        record({ path: "/pragma", headersJson: "pragma" });
+        record({ sessionId: "other", kind: "ws-frame", direction: "inbound" });
+        record({ kind: "error", host: undefined, path: undefined });
+        const presets: CaptureQueryPreset[] = [
+          "double-sends",
+          "retry-storms",
+          "cache-busting",
+          "ws-duplicate-frames",
+          "missing-ack",
+          "error-bursts",
+        ];
+        const location = { host: "api.example", path: "/send" };
+        const results = Object.fromEntries(
+          presets.map((preset) => [preset, store.queryPreset(preset, "captured")]),
+        );
+        expect(results).toEqual({
+          "double-sends": [
+            { ...location, method: "POST", duplicateCount: 2 },
+            { ...location, method: "POST", duplicateCount: 2 },
+          ],
+          "retry-storms": [{ ...location, errorCount: 2 }],
+          "cache-busting": expect.arrayContaining([
+            { host: "api.example", path: "/cache", variantCount: 1 },
+            { host: "api.example", path: "/cache?variant", variantCount: 1 },
+            { host: "api.example", path: "/pragma", variantCount: 1 },
+          ]),
+          "ws-duplicate-frames": [
+            { ...location, duplicateFrames: 2 },
+            { ...location, duplicateFrames: 2 },
+          ],
+          "missing-ack": [{ flowId: "cross-session", ...location, outboundFrames: 4 }],
+          "error-bursts": [{ host: null, path: null, errorCount: 1 }],
+        });
+        expect(results["cache-busting"]).toHaveLength(3);
+        expect(store.queryPreset("missing-ack")).toEqual([]);
+        expect(store.queryPreset("missing-ack", "")).toEqual([]);
+        expect(store.queryPreset("error-bursts", " captured ")).toEqual([]);
+        expect(store.listSessions(1)).toEqual([
+          {
+            id: "empty",
+            startedAt: 2,
+            endedAt: null,
+            mode: "test",
+            sourceProcess: "test",
+            proxyUrl: null,
+            eventCount: 0,
+          },
+        ]);
+        expect(store.listSessions(0)).toEqual([]);
+        expect(store.listSessions(-1)).toHaveLength(3);
+
+        store.db.setAuthorizer((action, table) =>
+          action === constants.SQLITE_READ && table === "capture_events"
+            ? constants.SQLITE_DENY
+            : constants.SQLITE_OK,
+        );
+        for (const preset of presets) {
+          expect(() => store.queryPreset(preset, "captured")).toThrow(/prohibited/u);
+        }
+        expect(() => store.listSessions()).toThrow(/prohibited/u);
+        expect(store.db.isOpen).toBe(true);
+        store.db.setAuthorizer(null);
+        expect(
+          Object.fromEntries(
+            presets.map((preset) => [preset, store.queryPreset(preset, "captured")]),
+          ),
+        ).toEqual(results);
+      } finally {
+        store.db.setAuthorizer(null);
+        store.close();
+      }
+    },
+  );
 
   it("keeps byte-limited UTF-8 previews on a complete character boundary", () => {
     const store = makeStore();

--- a/src/proxy-capture/store.sqlite.ts
+++ b/src/proxy-capture/store.sqlite.ts
@@ -24,6 +24,9 @@ import {
   type OpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import {
+  findDebugProxyCaptureBlobReference,
+  listDebugProxyCaptureSessions,
+  queryDebugProxyCapturePreset,
   readDebugProxyCaptureBlob,
   readDebugProxyCaptureSessionEvents,
   summarizeDebugProxyCaptureSessionCoverage,
@@ -459,23 +462,8 @@ class DebugProxyCaptureStoreImpl {
   }
 
   listSessions(limit = 50): CaptureSessionSummary[] {
-    return this.db
-      .prepare(
-        `SELECT
-           s.id,
-           s.started_at AS startedAt,
-           s.ended_at AS endedAt,
-           s.mode,
-           s.source_process AS sourceProcess,
-           s.proxy_url AS proxyUrl,
-           COUNT(e.id) AS eventCount
-         FROM capture_sessions s
-         LEFT JOIN capture_events e ON e.session_id = s.id
-         GROUP BY s.id
-         ORDER BY s.started_at DESC
-         LIMIT ?`,
-      )
-      .all(limit) as CaptureSessionSummary[];
+    // The shipped SDK type omits null, but callers receive native nullable fields.
+    return listDebugProxyCaptureSessions(this.db, limit) as CaptureSessionSummary[];
   }
 
   getSessionEvents(sessionId: string, limit = 500): Array<Record<string, unknown>> {
@@ -488,13 +476,11 @@ class DebugProxyCaptureStoreImpl {
 
   readBlob(blobId: string): string | null {
     if (this.pathBased) {
-      const legacyRow = this.db
-        .prepare(`SELECT data_blob_id AS blobId FROM capture_events WHERE data_blob_id = ? LIMIT 1`)
-        .get(blobId) as { blobId?: string } | undefined;
-      if (!legacyRow?.blobId) {
+      const legacyBlobId = findDebugProxyCaptureBlobReference(this.db, blobId);
+      if (!legacyBlobId) {
         return null;
       }
-      const blobPath = path.join(this.pathBased.blobDir, `${legacyRow.blobId}.bin.gz`);
+      const blobPath = path.join(this.pathBased.blobDir, `${legacyBlobId}.bin.gz`);
       return fs.existsSync(blobPath)
         ? gunzipSync(fs.readFileSync(blobPath)).toString("utf8")
         : null;
@@ -503,83 +489,7 @@ class DebugProxyCaptureStoreImpl {
   }
 
   queryPreset(preset: CaptureQueryPreset, sessionId?: string): CaptureQueryRow[] {
-    const sessionWhere = sessionId ? "AND session_id = ?" : "";
-    const args = sessionId ? [sessionId] : [];
-    switch (preset) {
-      // Presets are intentionally SQL-only summaries so the CLI can query large
-      // capture sessions without loading every event into memory.
-      case "double-sends":
-        return this.db
-          .prepare(
-            `SELECT host, path, method, COUNT(*) AS duplicateCount
-             FROM capture_events
-             WHERE kind = 'request' ${sessionWhere}
-             GROUP BY host, path, method, data_sha256
-             HAVING COUNT(*) > 1
-             ORDER BY duplicateCount DESC, host ASC`,
-          )
-          .all(...args) as CaptureQueryRow[];
-      case "retry-storms":
-        return this.db
-          .prepare(
-            `SELECT host, path, COUNT(*) AS errorCount
-             FROM capture_events
-             WHERE kind = 'response' AND status >= 429 ${sessionWhere}
-             GROUP BY host, path
-             HAVING COUNT(*) > 1
-             ORDER BY errorCount DESC, host ASC`,
-          )
-          .all(...args) as CaptureQueryRow[];
-      case "cache-busting":
-        return this.db
-          .prepare(
-            `SELECT host, path, COUNT(*) AS variantCount
-             FROM capture_events
-             WHERE kind = 'request'
-               AND (path LIKE '%?%' OR headers_json LIKE '%cache-control%' OR headers_json LIKE '%pragma%')
-               ${sessionWhere}
-             GROUP BY host, path
-             ORDER BY variantCount DESC, host ASC`,
-          )
-          .all(...args) as CaptureQueryRow[];
-      case "ws-duplicate-frames":
-        return this.db
-          .prepare(
-            `SELECT host, path, COUNT(*) AS duplicateFrames
-             FROM capture_events
-             WHERE kind = 'ws-frame' AND direction = 'outbound' ${sessionWhere}
-             GROUP BY host, path, data_sha256
-             HAVING COUNT(*) > 1
-             ORDER BY duplicateFrames DESC, host ASC`,
-          )
-          .all(...args) as CaptureQueryRow[];
-      case "missing-ack":
-        return this.db
-          .prepare(
-            `SELECT flow_id AS flowId, host, path, COUNT(*) AS outboundFrames
-             FROM capture_events
-             WHERE kind = 'ws-frame' AND direction = 'outbound' ${sessionWhere}
-               AND flow_id NOT IN (
-                 SELECT flow_id FROM capture_events
-                 WHERE kind = 'ws-frame' AND direction = 'inbound' ${sessionId ? "AND session_id = ?" : ""}
-               )
-             GROUP BY flow_id, host, path
-             ORDER BY outboundFrames DESC`,
-          )
-          .all(...(sessionId ? [sessionId, sessionId] : [])) as CaptureQueryRow[];
-      case "error-bursts":
-        return this.db
-          .prepare(
-            `SELECT host, path, COUNT(*) AS errorCount
-             FROM capture_events
-             WHERE kind = 'error' ${sessionWhere}
-             GROUP BY host, path
-             ORDER BY errorCount DESC, host ASC`,
-          )
-          .all(...args) as CaptureQueryRow[];
-      default:
-        return [];
-    }
+    return queryDebugProxyCapturePreset(this.db, preset, sessionId);
   }
 
   purgeAll(): { sessions: number; events: number; blobs: number } {


### PR DESCRIPTION
## What Problem This Solves

Capture session lists, diagnostic presets and legacy blob lookup maintained handwritten SQL and positional bindings in the write store while related reads already had a typed owner. The missing-ack query also repeated its optional session filter across outer and inner SQL.

## Why This Change Was Made

Move these queries into the existing capture read owner using generated Kysely types. Six preset execution paths become one; a shared filtered event query keeps both sides of missing-ack scoped together. Explicit preset branches retain their grouping, counts, thresholds, aliases and order. The store delegates while retaining legacy file handling and both constructor contracts.

Native call-local get/all execution remains because the generic query executor would change corruption recovery and borrowed database lifetime. The public standalone reader and schema are unchanged. Session summaries retain native null fields despite the existing optional-only SDK type; correcting that public type is a separate compatibility decision.

Production grows by 47 lines to express the typed projection/owner boundary while removing repeated SQL fragments and bindings. A descriptor framework or new executor/cache would add concepts solely to reduce line count, so the domain branches remain explicit. Tests grow by 101 lines, consolidating the older duplicate-send checks into broader constructor-paired coverage; the removed assertion baseline shrinks from 23 to 16.

## User Impact

Capture diagnostics keep their current results and output shapes. Empty sessions still count zero events; nullable labels and separate hash groups remain intact; scoped missing-ack results are not suppressed by another session. Legacy blob files still require an event reference. This changes query ownership without enabling another database or changing data, cleanup, retention or recovery policy.

## Evidence

- 50 focused tests passed: native store20, historical standalone reader11, CLI19. After final test-only cleanup, all 31 store/reader tests passed again. Full changed gate and explicit Kysely guard passed.
- Native baseline/candidate comparison passed 84 preset/scope cases across both constructors, zero/negative/invalid limits, native get/all execution, authorization refusal/retry, payload custody and fresh reopen. Fifteen real corrupt-table cases retained identical errors and open-handle ownership.
- Actual loopback QA HTTP served 55 requests covering all six presets, scoped/unscoped/trimmed/missing inputs, sessions/nulls, blobs, event/coverage siblings, refusal/retry and unchanged capture state.
- Eighteen fresh real source-entry CLI processes preserved JSON wrappers and bare arrays, scope handling, unknown-preset behavior and blob bytes. Fresh database reopen matched. All synthetic state and processes were cleaned up; no external provider was involved.
- The changed gate required SAFETY comments for native projections and then identified a test-local shadowed name. The comments, exact shrinking assertion baseline and local rename were applied; the final gate passed. Live runtime source equivalence across those comments is recorded, and native proof repeated on final source.

Independent Codex review completed nine passes with no P0–P2 findings. Direct installed Kysely and Node SQLite contracts were inspected.
