### PR TITLE
refactor(tasks): share eager flow snapshot construction

### DIFF
--- a/src/tasks/task-flow-registry.store.sqlite.ts
+++ b/src/tasks/task-flow-registry.store.sqlite.ts
@@ -168,7 +168,7 @@ function pruneFlowsNotInSnapshot(params: { db: DatabaseSync; ids: readonly strin
   params.db.exec(`DELETE FROM ${tempTableName}`);
 }
 
-function selectFlowRows(db: DatabaseSync): FlowRegistryRow[] {
+function readTaskFlowRegistrySnapshot(db: DatabaseSync): TaskFlowRegistryStoreSnapshot {
   const query = getFlowRegistryKysely(db)
     .selectFrom("flow_runs")
     .select([
@@ -194,7 +194,12 @@ function selectFlowRows(db: DatabaseSync): FlowRegistryRow[] {
     ])
     .orderBy("created_at", "asc")
     .orderBy("flow_id", "asc");
-  return executeSqliteQuerySync(db, query).rows;
+  const flows = new Map<string, TaskFlowRecord>();
+  // Finish native reads before decoding so SQLite errors retain precedence.
+  for (const row of executeSqliteQuerySync(db, query).rows) {
+    flows.set(row.flow_id, rowToFlowRecord(row));
+  }
+  return { flows };
 }
 
 export function upsertTaskFlowRowInDatabase(db: DatabaseSync, row: BoundTaskFlowRecord): void {
@@ -259,22 +264,15 @@ function withWriteTransaction(write: (database: FlowRegistryDatabase) => void) {
 }
 
 export function loadTaskFlowRegistryStateFromSqlite(): TaskFlowRegistryStoreSnapshot {
-  const { db } = openFlowRegistryDatabase();
-  const rows = selectFlowRows(db);
-  return {
-    flows: new Map(rows.map((row) => [row.flow_id, rowToFlowRecord(row)])),
-  };
+  return readTaskFlowRegistrySnapshot(openFlowRegistryDatabase().db);
 }
 
 /** Loads task flows without creating or migrating shared state. */
 export function loadTaskFlowRegistryStateFromSqliteReadOnly(): TaskFlowRegistryStoreSnapshot {
   return (
-    withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
-      const rows = selectFlowRows(db);
-      return {
-        flows: new Map(rows.map((row) => [row.flow_id, rowToFlowRecord(row)])),
-      };
-    }) ?? { flows: new Map() }
+    withExistingOpenClawStateDatabaseReadOnly(({ db }) => readTaskFlowRegistrySnapshot(db)) ?? {
+      flows: new Map(),
+    }
   );
 }
 

--- a/src/tasks/task-flow-registry.store.test.ts
+++ b/src/tasks/task-flow-registry.store.test.ts
@@ -201,6 +201,9 @@ describe("task-flow-registry store runtime", () => {
       expect(() => loadTaskFlowRegistryStateFromSqlite()).toThrow(
         "Invalid persisted task flow status",
       );
+      expect(() => loadTaskFlowRegistryStateFromSqliteReadOnly()).toThrow(
+        "Invalid persisted task flow status",
+      );
     });
   });
 
@@ -327,6 +330,7 @@ describe("task-flow-registry store runtime", () => {
       expect(restored.flows.size).toBe(1_100);
       expect(restored.flows.has("flow-large-0")).toBe(false);
       expect(restored.flows.has("flow-large-1199")).toBe(true);
+      expect(loadTaskFlowRegistryStateFromSqliteReadOnly()).toEqual(restored);
       expect(
         openOpenClawStateDatabase()
           .db.prepare(


### PR DESCRIPTION
## What Problem This Solves

Task-flow restore and Doctor's read-only inventory separately converted the same SQLite rows into maps, allocating an intermediate tuple array for every flow.

## Why This Change Was Made

Share one eager snapshot builder in the existing SQLite owner. It completes the same ordered native query before decoding rows into the final map. This preserves native error precedence and query-error notification while keeping the writable and non-creating read-only connection lifetimes separate.

Production decreases by two lines; four test lines extend two existing cases. No schema, stored format, decoding, retention, query projection, or transaction change.

## User Impact

Task-flow restore and Doctor retain the same records, ordering, errors, and recovery guidance with less duplicated snapshot construction. No measured latency or heap-size improvement is claimed.

## Evidence

- All 33 focused store, registry, and Doctor tests passed, as did the full changed gate.
- Actual exported baseline and candidate loaders produced 61 equal observations each, including rich and malformed JSON, absent databases, borrowed and fresh readers, transaction visibility, enum errors, native integer-error precedence, complete observer publication, and latched restore failures.
- Two real built Gateway processes, task-list commands, and Doctor runs returned identical results across restart. Six native query traces read all four synthetic flows; fresh SQLite readbacks matched the seed, integrity checks passed, and foreign-key checks were empty. Doctor reported the same two expected recovery warnings and exit code 1. All owned state and processes were cleaned up.
- A fixture-only raw verification failure on an intentionally oversized integer was preserved and corrected with bigint reads in that verification helper; production number decoding was unchanged.
- Independent Codex review completed four passes with no P0–P2 findings. Lazy decoding was rejected because it would change which error callers receive and skip the existing query-error notification.
