### PR TITLE
fix(claws): wait for agents before cron setup

### DIFF
--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -243,7 +243,9 @@ Cron jobs declare scheduled work for the new agent:
 ```
 
 Claws use the existing Gateway scheduler and bind created jobs to the new
-agent. Preview, provenance, status, and removal cover those jobs without
+agent. Before creating jobs during add or update, Claws wait for the target
+agent to appear in the Gateway's applied configuration. Preview, provenance,
+status, and removal cover those jobs without
 changing the behavior of ordinary cron commands. Removal rereads the live job
 through the Gateway and preserves it when its owned definition changed after
 planning.

--- a/src/claws/cron-update.test.ts
+++ b/src/claws/cron-update.test.ts
@@ -1,14 +1,25 @@
-import { describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { cronJobReadView } from "../cron/job-read-view.js";
 import { normalizeCronJobCreate } from "../cron/normalize.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { applyClawCronUpdate } from "./cron-update.js";
 import {
   CLAW_CRON_REF_SCHEMA_VERSION,
   clawCronGatewayInput,
+  readClawCronRefs,
+  upsertClawCronRef,
   type PersistedClawCronRef,
 } from "./cron.js";
 import { CLAW_OUTPUT_STABILITY, type ClawCronJob, type ClawManifest } from "./types.js";
 import { CLAW_UPDATE_PLAN_SCHEMA_VERSION, type ClawUpdatePlan } from "./update-plan.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(closeOpenClawStateDatabaseForTest);
 
 const oldDaily: ClawCronJob = {
   id: "daily",
@@ -101,8 +112,140 @@ function manifest(): ClawManifest {
 }
 
 describe("applyClawCronUpdate", () => {
+  it.each(["add", "change"] as const)(
+    "preserves ownership before a failed readiness wait and permits %s retry",
+    async (action) => {
+      const env = { OPENCLAW_STATE_DIR: join(tempDirs.make("openclaw-cron-readiness-"), "state") };
+      const previous = ref(oldDaily, "scheduler-daily");
+      if (action === "change") {
+        upsertClawCronRef(previous, { env });
+      }
+      readClawCronRefs("worker", { env });
+      const database = openOpenClawStateDatabase({ env });
+      const rows = () =>
+        JSON.stringify(
+          database.db.prepare("SELECT * FROM claw_cron_refs ORDER BY agent_id, manifest_id").all(),
+        );
+      const before = rows();
+      const order: string[] = [];
+      const waitUntilAgentAvailable = vi.fn(async () => {
+        order.push("wait");
+      });
+      waitUntilAgentAvailable.mockImplementationOnce(async () => {
+        order.push("wait");
+        throw new Error("agent not ready");
+      });
+      const add = vi.fn(async () => ({ id: "scheduler-daily" }));
+      const remove = vi.fn();
+      const options = {
+        env,
+        cronGateway: {
+          add,
+          remove,
+          waitUntilAgentAvailable,
+          get: async () => {
+            order.push("get");
+            return cronReadView("worker", previous);
+          },
+        },
+      };
+      const updatePlan = plan([
+        {
+          kind: "cronJob",
+          id: "daily",
+          action,
+          target: "claw:worker:daily",
+          blocked: false,
+          reason: "target declaration",
+        },
+      ]);
+
+      await expect(applyClawCronUpdate(updatePlan, manifest(), options)).rejects.toMatchObject({
+        message: "agent not ready",
+        partial: false,
+      });
+      expect(order).toEqual(action === "change" ? ["get", "wait"] : ["wait"]);
+      expect(add).not.toHaveBeenCalled();
+      expect(remove).not.toHaveBeenCalled();
+      expect(rows()).toBe(before);
+
+      await expect(applyClawCronUpdate(updatePlan, manifest(), options)).resolves.toMatchObject({
+        appliedIds: ["daily"],
+      });
+      expect(add).toHaveBeenCalledOnce();
+      expect(readClawCronRefs("worker", { env })).toMatchObject([
+        {
+          manifestId: "daily",
+          status: "complete",
+          schedulerJobId: "scheduler-daily",
+          job: newDaily,
+        },
+      ]);
+    },
+  );
+
+  it("compensates an earlier removal when later readiness fails without introducing a pending addition", async () => {
+    const env = {
+      OPENCLAW_STATE_DIR: join(tempDirs.make("openclaw-cron-readiness-undo-"), "state"),
+    };
+    const previous = ref(legacy, "scheduler-legacy");
+    upsertClawCronRef(previous, { env });
+    const waitUntilAgentAvailable = vi
+      .fn(async () => undefined)
+      .mockRejectedValueOnce(new Error("agent not ready"));
+    const add = vi.fn(async () => ({ id: "scheduler-restored" }));
+    const remove = vi.fn();
+
+    await expect(
+      applyClawCronUpdate(
+        plan([
+          {
+            kind: "cronJob",
+            id: "legacy",
+            action: "remove",
+            target: "scheduler-legacy",
+            blocked: false,
+            reason: "removed",
+          },
+          {
+            kind: "cronJob",
+            id: "weekly",
+            action: "add",
+            target: "claw:worker:weekly",
+            blocked: false,
+            reason: "added",
+          },
+        ]),
+        manifest(),
+        {
+          env,
+          nowMs: 20,
+          cronGateway: {
+            add,
+            remove,
+            get: async () => cronReadView("worker", previous),
+            waitUntilAgentAvailable,
+          },
+        },
+      ),
+    ).rejects.toMatchObject({ message: "agent not ready", partial: false });
+
+    expect(remove).toHaveBeenCalledExactlyOnceWith("scheduler-legacy");
+    expect(waitUntilAgentAvailable).toHaveBeenCalledTimes(2);
+    expect(add).toHaveBeenCalledExactlyOnceWith(clawCronGatewayInput("worker", previous));
+    expect(readClawCronRefs("worker", { env })).toEqual([
+      { ...previous, schedulerJobId: "scheduler-restored", updatedAtMs: 20 },
+    ]);
+  });
+
   it("converges changes and reverses add, change, and remove operations", async () => {
+    let agentAvailable = false;
+    const waitUntilAgentAvailable = vi.fn(async (agentId: string) => {
+      expect(agentId).toBe("worker");
+      agentAvailable = true;
+    });
     const add = vi.fn(async (input: Record<string, unknown>) => {
+      expect(agentAvailable).toBe(true);
       const key = input.declarationKey;
       if (key === "claw:worker:daily") {
         return { id: "scheduler-daily" };
@@ -147,6 +290,7 @@ describe("applyClawCronUpdate", () => {
       {
         cronGateway: {
           add,
+          waitUntilAgentAvailable,
           get: async (id) =>
             cronReadView(
               "worker",
@@ -172,6 +316,49 @@ describe("applyClawCronUpdate", () => {
     expect(add).toHaveBeenCalledTimes(4);
     expect(upsertRef).toHaveBeenCalledTimes(7);
     expect(deleteRef).toHaveBeenCalledTimes(2);
+    expect(waitUntilAgentAvailable).toHaveBeenCalledOnce();
+  });
+
+  it("removes without waiting and checks availability before compensating add", async () => {
+    const previous = ref(legacy, "scheduler-legacy");
+    const waitUntilAgentAvailable = vi.fn(async () => undefined);
+    const add = vi.fn(async () => {
+      expect(waitUntilAgentAvailable).toHaveBeenCalledWith("worker");
+      return { id: "scheduler-restored" };
+    });
+    const upsertRef = vi.fn();
+    const execution = await applyClawCronUpdate(
+      plan([
+        {
+          kind: "cronJob",
+          id: "legacy",
+          action: "remove",
+          target: "scheduler-legacy",
+          blocked: false,
+          reason: "removed",
+        },
+      ]),
+      manifest(),
+      {
+        cronGateway: {
+          add,
+          get: async () => cronReadView("worker", previous),
+          remove: vi.fn(),
+          waitUntilAgentAvailable,
+        },
+        readRefs: () => [previous],
+        upsertRef,
+        deleteRef: vi.fn(),
+      },
+    );
+    expect(execution.appliedIds).toEqual(["legacy"]);
+    expect(waitUntilAgentAvailable).not.toHaveBeenCalled();
+    await execution.rollback();
+    expect(add).toHaveBeenCalledOnce();
+    expect(upsertRef).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: "complete", schedulerJobId: "scheduler-restored" }),
+      expect.any(Object),
+    );
   });
 
   it("removes a non-converged replacement and fails closed", async () => {

--- a/src/claws/cron-update.ts
+++ b/src/claws/cron-update.ts
@@ -89,8 +89,16 @@ export async function applyClawCronUpdate(
   const undo: Array<() => Promise<void>> = [];
   const appliedIds: string[] = [];
   const nowMs = options.nowMs ?? Date.now();
+  let agentAvailable = false;
 
+  const waitForAgent = async () => {
+    if (!agentAvailable) {
+      await gateway.waitUntilAgentAvailable?.(updatePlan.agentId);
+      agentAvailable = true;
+    }
+  };
   const add = async (ref: PersistedClawCronRef): Promise<string> => {
+    await waitForAgent();
     let raw: unknown;
     try {
       raw = await gateway.add(clawCronGatewayInput(updatePlan.agentId, ref));
@@ -153,6 +161,8 @@ export async function applyClawCronUpdate(
           `Target cron declaration ${JSON.stringify(action.id)} is missing.`,
         );
       }
+      // A readiness failure must leave this declaration's ownership untouched.
+      await waitForAgent();
       const pending = targetRef({ agentId: updatePlan.agentId, job, previous, nowMs });
       upsertRef(pending, options);
       const schedulerJobId = await add(pending);

--- a/src/claws/update-apply.test-helpers.ts
+++ b/src/claws/update-apply.test-helpers.ts
@@ -1,0 +1,103 @@
+import type { PersistedClawInstall } from "./provenance.js";
+import type { ClawAddPlan, ClawManifest, ClawSourceIdentity } from "./types.js";
+import type { ClawUpdatePlan } from "./update-plan.js";
+
+export const source: ClawSourceIdentity = {
+  kind: "package",
+  name: "@acme/worker",
+  version: "2.0.0",
+  packageRoot: "/tmp/target",
+  manifestPath: "/tmp/target/openclaw.claw.json",
+  integrityKind: "artifact",
+  integrity: "sha256:target",
+  byteLength: 1,
+};
+export const manifest: ClawManifest = {
+  schemaVersion: 1,
+  agent: { id: "worker", name: "Worker v2" },
+  workspace: { bootstrapFiles: {}, files: [] },
+  packages: [],
+  mcpServers: {},
+  cronJobs: [],
+};
+export const install: PersistedClawInstall = {
+  schemaVersion: "openclaw.clawInstallRecord.v1",
+  claw: { ...source, version: "1.0.0", integrity: "sha256:current" },
+  manifestSchemaVersion: 1,
+  planIntegrity: "sha256:current-add-plan",
+  agentId: "worker",
+  workspace: "/tmp/workspace-worker",
+  agentConfigDigest: "sha256:current-agent",
+  agentOwnedPaths: ['agents.entries["worker"]'],
+  status: "complete",
+  addedAtMs: 1,
+  updatedAtMs: 1,
+};
+export const addPlan: ClawAddPlan = {
+  schemaVersion: "openclaw.clawAddPlan.v1",
+  stability: "experimental",
+  dryRun: true,
+  mutationAllowed: false,
+  manifestSchemaVersion: 1,
+  planIntegrity: "sha256:target-add-plan",
+  claw: source,
+  agent: {
+    requestedId: "worker",
+    finalId: "worker",
+    workspace: "/tmp/workspace-worker",
+    config: { id: "worker", name: "Worker v2", workspace: "/tmp/workspace-worker" },
+  },
+  summary: {
+    totalActions: 1,
+    agentActions: 1,
+    workspaceActions: 0,
+    packageActions: 0,
+    mcpServerActions: 0,
+    cronJobActions: 0,
+    blockedActions: 0,
+    capabilityEscalations: 0,
+  },
+  actions: [],
+  capabilityChanges: [],
+  blockers: [],
+  diagnostics: [],
+  readiness: { ready: true, requirements: [] },
+};
+
+export function plan(actions: ClawUpdatePlan["actions"]): ClawUpdatePlan {
+  return {
+    schemaVersion: "openclaw.clawUpdatePlan.v1",
+    stability: "experimental",
+    dryRun: true,
+    mutationAllowed: false,
+    planIntegrity: "sha256:update-plan",
+    found: true,
+    agentId: "worker",
+    currentClaw: { name: "@acme/worker", version: "1.0.0", integrity: "sha256:current" },
+    targetClaw: { name: "@acme/worker", version: "2.0.0", integrity: "sha256:target" },
+    summary: {
+      totalActions: actions.length,
+      added: 0,
+      changed: actions.filter((action) => action.action === "change").length,
+      removed: 0,
+      released: 0,
+      unchanged: actions.filter((action) => action.action === "unchanged").length,
+      manual: 0,
+      blocked: actions.filter((action) => action.blocked).length,
+      capabilityChanges: 0,
+      capabilityEscalations: 0,
+    },
+    actions,
+    capabilityChanges: [],
+    readiness: { ready: true, requirements: [] },
+    blockers: [],
+    diagnostics: [],
+  };
+}
+
+export function consent(updatePlan: ClawUpdatePlan) {
+  return {
+    sourceMcpServers: {},
+    consentPlanIntegrity: updatePlan.planIntegrity,
+  };
+}

--- a/src/claws/update-apply.test.ts
+++ b/src/claws/update-apply.test.ts
@@ -1,127 +1,22 @@
+import { createHash } from "node:crypto";
 import { join } from "node:path";
+import { stableStringify } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { ClawCronUpdateError } from "./cron-update.js";
+import { readClawCronRefs } from "./cron.js";
 import type { buildClawAddPlan } from "./lifecycle.js";
 import { ClawPackageUpdateError } from "./package-update.js";
-import {
-  persistClawInstallRecord,
-  readClawInstallRecord,
-  type PersistedClawInstall,
-} from "./provenance.js";
-import type {
-  ClawAddPlan,
-  ClawManifest,
-  ClawOpenClawProfile,
-  ClawSourceIdentity,
-} from "./types.js";
+import { persistClawInstallRecord, readClawInstallRecord } from "./provenance.js";
+import type { ClawAddPlan, ClawManifest, ClawOpenClawProfile } from "./types.js";
 import { applyClawUpdatePlan } from "./update-apply.js";
+import { addPlan, consent, install, manifest, plan, source } from "./update-apply.test-helpers.js";
 import type { ClawUpdatePlan } from "./update-plan.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(closeOpenClawStateDatabaseForTest);
-
-const source: ClawSourceIdentity = {
-  kind: "package",
-  name: "@acme/worker",
-  version: "2.0.0",
-  packageRoot: "/tmp/target",
-  manifestPath: "/tmp/target/openclaw.claw.json",
-  integrityKind: "artifact",
-  integrity: "sha256:target",
-  byteLength: 1,
-};
-const manifest: ClawManifest = {
-  schemaVersion: 1,
-  agent: { id: "worker", name: "Worker v2" },
-  workspace: { bootstrapFiles: {}, files: [] },
-  packages: [],
-  mcpServers: {},
-  cronJobs: [],
-};
-const install: PersistedClawInstall = {
-  schemaVersion: "openclaw.clawInstallRecord.v1",
-  claw: { ...source, version: "1.0.0", integrity: "sha256:current" },
-  manifestSchemaVersion: 1,
-  planIntegrity: "sha256:current-add-plan",
-  agentId: "worker",
-  workspace: "/tmp/workspace-worker",
-  agentConfigDigest: "sha256:current-agent",
-  agentOwnedPaths: ['agents.entries["worker"]'],
-  status: "complete",
-  addedAtMs: 1,
-  updatedAtMs: 1,
-};
-const addPlan: ClawAddPlan = {
-  schemaVersion: "openclaw.clawAddPlan.v1",
-  stability: "experimental",
-  dryRun: true,
-  mutationAllowed: false,
-  manifestSchemaVersion: 1,
-  planIntegrity: "sha256:target-add-plan",
-  claw: source,
-  agent: {
-    requestedId: "worker",
-    finalId: "worker",
-    workspace: "/tmp/workspace-worker",
-    config: { id: "worker", name: "Worker v2", workspace: "/tmp/workspace-worker" },
-  },
-  summary: {
-    totalActions: 1,
-    agentActions: 1,
-    workspaceActions: 0,
-    packageActions: 0,
-    mcpServerActions: 0,
-    cronJobActions: 0,
-    blockedActions: 0,
-    capabilityEscalations: 0,
-  },
-  actions: [],
-  capabilityChanges: [],
-  blockers: [],
-  diagnostics: [],
-  readiness: { ready: true, requirements: [] },
-};
-
-function plan(actions: ClawUpdatePlan["actions"]): ClawUpdatePlan {
-  return {
-    schemaVersion: "openclaw.clawUpdatePlan.v1",
-    stability: "experimental",
-    dryRun: true,
-    mutationAllowed: false,
-    planIntegrity: "sha256:update-plan",
-    found: true,
-    agentId: "worker",
-    currentClaw: { name: "@acme/worker", version: "1.0.0", integrity: "sha256:current" },
-    targetClaw: { name: "@acme/worker", version: "2.0.0", integrity: "sha256:target" },
-    summary: {
-      totalActions: actions.length,
-      added: 0,
-      changed: actions.filter((action) => action.action === "change").length,
-      removed: 0,
-      released: 0,
-      unchanged: actions.filter((action) => action.action === "unchanged").length,
-      manual: 0,
-      blocked: actions.filter((action) => action.blocked).length,
-      capabilityChanges: 0,
-      capabilityEscalations: 0,
-    },
-    actions,
-    capabilityChanges: [],
-    readiness: { ready: true, requirements: [] },
-    blockers: [],
-    diagnostics: [],
-  };
-}
-
-function consent(updatePlan: ClawUpdatePlan) {
-  return {
-    sourceMcpServers: {},
-    consentPlanIntegrity: updatePlan.planIntegrity,
-  };
-}
 
 describe("applyClawUpdatePlan", () => {
   it("rejects consent that does not match the preview before rebuilding", async () => {
@@ -258,6 +153,15 @@ describe("applyClawUpdatePlan", () => {
   });
 
   it("activates cron only after owned state and agent updates succeed", async () => {
+    const env = {
+      OPENCLAW_STATE_DIR: join(tempDirs.make("openclaw-claw-update-roster-"), "state"),
+    };
+    const job: ClawManifest["cronJobs"][number] = {
+      id: "daily",
+      schedule: { cron: "0 9 * * *", timezone: "UTC" },
+      session: "main",
+      message: "Daily report",
+    };
     const updatePlan = plan([
       {
         kind: "agent",
@@ -267,15 +171,26 @@ describe("applyClawUpdatePlan", () => {
         blocked: false,
         reason: "restore agent",
       },
+      {
+        kind: "cronJob",
+        id: job.id,
+        action: "add",
+        target: "claw:worker:daily",
+        blocked: false,
+        reason: "target adds cron job",
+      },
     ]);
     const order: string[] = [];
     let config: OpenClawConfig = { agents: { entries: {} } };
+    let runtimeConfig = config;
+    const runtimeApplied = createDeferred();
 
-    await applyClawUpdatePlan(
+    const update = applyClawUpdatePlan(
       updatePlan,
-      { targetManifest: manifest, targetSource: source },
+      { targetManifest: { ...manifest, cronJobs: [job] }, targetSource: source },
       {
         config,
+        env,
         ...consent(updatePlan),
         rebuildPlan: vi.fn(async () => updatePlan),
         buildAddPlan: vi.fn(async () => addPlan),
@@ -288,18 +203,31 @@ describe("applyClawUpdatePlan", () => {
           order.push("mcp");
           return { appliedNames: [], rollback: vi.fn(async () => undefined) };
         }),
-        applyPackage: vi.fn(async () => {
-          order.push("package");
-          return { appliedIds: [], rollback: vi.fn(async () => undefined) };
-        }),
         commitConfig: async (transform) => {
           order.push("agent");
           config = transform(config);
+          setImmediate(() => {
+            runtimeConfig = config;
+            order.push("runtime");
+            runtimeApplied.resolve();
+          });
         },
-        applyCron: vi.fn(async () => {
-          order.push("cron");
-          return { appliedIds: [], rollback: vi.fn(async () => undefined) };
-        }),
+        cronGateway: {
+          waitUntilAgentAvailable: async (agentId) => {
+            expect(agentId).toBe("worker");
+            order.push("wait");
+            await runtimeApplied.promise;
+          },
+          add: async () => {
+            if (!runtimeConfig.agents?.entries?.worker) {
+              throw new Error("cron job agent is unavailable: worker");
+            }
+            order.push("cron");
+            return { id: "scheduler-daily" };
+          },
+          get: vi.fn(),
+          remove: vi.fn(),
+        },
         persistInstall: vi.fn(() => {
           order.push("provenance");
           return { ...install, claw: source };
@@ -307,7 +235,15 @@ describe("applyClawUpdatePlan", () => {
       },
     );
 
-    expect(order).toEqual(["workspace", "mcp", "agent", "cron", "provenance"]);
+    try {
+      await expect(update).resolves.toMatchObject({ status: "complete" });
+    } finally {
+      await runtimeApplied.promise;
+    }
+    expect(order).toEqual(["workspace", "mcp", "agent", "wait", "runtime", "cron", "provenance"]);
+    expect(readClawCronRefs("worker", { env })).toMatchObject([
+      { manifestId: job.id, schedulerJobId: "scheduler-daily", status: "complete" },
+    ]);
   });
 
   it("realizes new plugin requirements before workspace mutation and retains them on failure", async () => {
@@ -397,86 +333,116 @@ describe("applyClawUpdatePlan", () => {
     expect(requirementRollback).not.toHaveBeenCalled();
   });
 
-  it("preserves cron prerequisites when the gateway mutation outcome is uncertain", async () => {
-    const root = tempDirs.make("openclaw-claw-update-apply-");
-    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
-    const currentAddPlan: ClawAddPlan = {
-      ...addPlan,
-      claw: install.claw,
-      planIntegrity: install.planIntegrity,
-      agent: {
-        ...addPlan.agent,
-        config: { id: "worker", name: "Worker", workspace: addPlan.agent.workspace },
-      },
-    };
-    const currentRecord = persistClawInstallRecord(currentAddPlan, { env, nowMs: 1 });
-    const updatePlan = plan([
-      {
-        kind: "agent",
-        id: "worker",
-        action: "change",
-        target: 'agents.entries["worker"]',
-        blocked: false,
-        reason: "restore agent",
-      },
-      {
-        kind: "cronJob",
-        id: "heartbeat",
-        action: "add",
-        target: "cronJobs.heartbeat",
-        blocked: false,
-        reason: "target adds cron job",
-      },
-    ]);
-    let config: OpenClawConfig = { agents: { entries: {} } };
-    const workspaceRollback = vi.fn(async () => undefined);
-    const mcpRollback = vi.fn(async () => undefined);
-    const packageRollback = vi.fn(async () => undefined);
-
-    await expect(
-      applyClawUpdatePlan(
-        updatePlan,
-        { targetManifest: manifest, targetSource: source },
-        {
-          config,
-          env,
-          ...consent(updatePlan),
-          rebuildPlan: vi.fn(async () => updatePlan),
-          buildAddPlan: vi.fn(async () => addPlan),
-          applyWorkspace: vi.fn(async () => ({
-            appliedPaths: [],
-            rollback: workspaceRollback,
-          })),
-          applyMcp: vi.fn(async () => ({ appliedNames: [], rollback: mcpRollback })),
-          applyPackage: vi.fn(async () => ({
-            appliedIds: [],
-            rollback: packageRollback,
-          })),
-          commitConfig: async (transform) => {
-            config = transform(config);
-          },
-          applyCron: vi.fn(async () => {
-            throw new ClawCronUpdateError("cron transport closed", true);
-          }),
+  it.each(["readiness", "mutation"] as const)(
+    "rolls back known failures and preserves uncertain cron prerequisites: %s",
+    async (failure) => {
+      const root = tempDirs.make("openclaw-claw-update-apply-");
+      const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+      const currentAddPlan: ClawAddPlan = {
+        ...addPlan,
+        claw: install.claw,
+        planIntegrity: install.planIntegrity,
+        agent: {
+          ...addPlan.agent,
+          config: { id: "worker", name: "Worker", workspace: addPlan.agent.workspace },
         },
-      ),
-    ).rejects.toMatchObject({ code: "update_partial" });
+      };
+      const currentRecord = persistClawInstallRecord(currentAddPlan, { env, nowMs: 1 });
+      const updatePlan = plan([
+        {
+          kind: "agent",
+          id: "worker",
+          action: "change",
+          target: 'agents.entries["worker"]',
+          blocked: false,
+          reason: "restore agent",
+        },
+        {
+          kind: "cronJob",
+          id: "heartbeat",
+          action: "add",
+          target: "cronJobs.heartbeat",
+          blocked: false,
+          reason: "target adds cron job",
+        },
+      ]);
+      let config: OpenClawConfig = { agents: { entries: {} } };
+      const workspaceRollback = vi.fn(async () => undefined);
+      const mcpRollback = vi.fn(async () => undefined);
 
-    const partialRecord = readClawInstallRecord("worker", { env });
-    expect(config.agents?.entries?.worker).toEqual({
-      name: "Worker v2",
-      workspace: "/tmp/workspace-worker",
-    });
-    expect(partialRecord).toMatchObject({
-      claw: { version: "2.0.0", integrity: "sha256:target" },
-      planIntegrity: addPlan.planIntegrity,
-      status: "partial",
-    });
-    expect(partialRecord?.agentConfigDigest).not.toBe(currentRecord.agentConfigDigest);
-    expect(packageRollback).not.toHaveBeenCalled();
-    expect(mcpRollback).not.toHaveBeenCalled();
-    expect(workspaceRollback).not.toHaveBeenCalled();
-  });
+      const add = vi.fn(async () => {
+        throw new Error("cron transport closed");
+      });
+      const job: ClawManifest["cronJobs"][number] = {
+        id: "heartbeat",
+        schedule: { cron: "0 9 * * *", timezone: "UTC" },
+        session: "main",
+        message: "Heartbeat",
+      };
+      await expect(
+        applyClawUpdatePlan(
+          updatePlan,
+          { targetManifest: { ...manifest, cronJobs: [job] }, targetSource: source },
+          {
+            config,
+            env,
+            ...consent(updatePlan),
+            rebuildPlan: vi.fn(async () => updatePlan),
+            buildAddPlan: vi.fn(async () => addPlan),
+            applyWorkspace: vi.fn(async () => ({
+              appliedPaths: [],
+              rollback: workspaceRollback,
+            })),
+            applyMcp: vi.fn(async () => ({ appliedNames: [], rollback: mcpRollback })),
+            commitConfig: async (transform) => {
+              config = transform(config);
+            },
+            cronGateway: {
+              add,
+              get: vi.fn(),
+              remove: vi.fn(),
+              waitUntilAgentAvailable: async () => {
+                expect(readClawCronRefs("worker", { env })).toEqual([]);
+                if (failure === "readiness") {
+                  throw new Error("agent not ready");
+                }
+              },
+            },
+          },
+        ),
+      ).rejects.toMatchObject({
+        code: failure === "mutation" ? "update_partial" : "cron_update_failed",
+      });
+
+      if (failure === "readiness") {
+        expect(readClawCronRefs("worker", { env })).toEqual([]);
+        expect(add).not.toHaveBeenCalled();
+        expect(config.agents?.entries?.worker).toBeUndefined();
+        expect(readClawInstallRecord("worker", { env })).toEqual(currentRecord);
+        expect(mcpRollback).toHaveBeenCalledOnce();
+        expect(workspaceRollback).toHaveBeenCalledOnce();
+        return;
+      }
+      expect(readClawCronRefs("worker", { env })).toMatchObject([
+        { status: "pending", manifestId: "heartbeat" },
+      ]);
+      expect(add).toHaveBeenCalledOnce();
+
+      const partialRecord = readClawInstallRecord("worker", { env });
+      expect(config.agents?.entries?.worker).toEqual({
+        name: "Worker v2",
+        workspace: "/tmp/workspace-worker",
+      });
+      expect(partialRecord).toMatchObject({
+        claw: { version: "2.0.0", integrity: "sha256:target" },
+        planIntegrity: addPlan.planIntegrity,
+        status: "partial",
+      });
+      expect(partialRecord?.agentConfigDigest).not.toBe(currentRecord.agentConfigDigest);
+      expect(mcpRollback).not.toHaveBeenCalled();
+      expect(workspaceRollback).not.toHaveBeenCalled();
+    },
+  );
 
   it("stops before agent mutation when a package update fails", async () => {
     const targetPackage = {
@@ -1034,5 +1000,3 @@ describe("applyClawUpdatePlan", () => {
     ).rejects.toMatchObject({ code: "update_blocked" });
   });
 });
-import { createHash } from "node:crypto";
-import { stableStringify } from "@openclaw/normalization-core";

--- a/src/cli/claws-cli.gateway-readiness.test.ts
+++ b/src/cli/claws-cli.gateway-readiness.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ callGatewayFromCli: vi.fn(), sleep: vi.fn() }));
+vi.mock("./gateway-rpc.js", () => ({ callGatewayFromCli: mocks.callGatewayFromCli }));
+vi.mock("../utils/sleep.js", () => ({ sleep: mocks.sleep }));
+const { waitUntilGatewayAgentAvailable } = await import("./claws-cli.gateway-readiness.js");
+
+beforeEach(() => {
+  mocks.callGatewayFromCli.mockReset();
+  mocks.sleep.mockReset().mockResolvedValue(undefined);
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("Claw Gateway agent readiness", () => {
+  it("accepts an already-applied Gateway config revision", async () => {
+    mocks.callGatewayFromCli.mockResolvedValue({
+      config: { agents: { entries: { worker: {} } } },
+      configRevisionHash: "revision-new",
+      appliedConfigHash: "revision-new",
+    });
+
+    await expect(waitUntilGatewayAgentAvailable("worker")).resolves.toBeUndefined();
+
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledOnce();
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledWith("config.get", { timeout: "5000" }, {});
+    expect(mocks.sleep).not.toHaveBeenCalled();
+  });
+
+  it("waits for the requested agent in an applied revision after a cached response", async () => {
+    mocks.callGatewayFromCli
+      .mockResolvedValueOnce({
+        config: { agents: { entries: { other: {} } } },
+        configRevisionHash: "revision-old",
+        appliedConfigHash: "revision-old",
+      })
+      .mockResolvedValueOnce({
+        config: { agents: { entries: { worker: {} } } },
+        configRevisionHash: "revision-new",
+        appliedConfigHash: "revision-old",
+      })
+      .mockResolvedValueOnce({
+        config: { agents: { entries: { worker: {} } } },
+        configRevisionHash: "revision-new",
+        appliedConfigHash: "revision-new",
+      });
+
+    await expect(waitUntilGatewayAgentAvailable("worker")).resolves.toBeUndefined();
+
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledTimes(3);
+    expect(mocks.sleep).toHaveBeenCalledTimes(2);
+    expect(mocks.sleep).toHaveBeenCalledWith(100);
+  });
+
+  it("reports the last Gateway error after the reload deadline", async () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(15_000);
+    mocks.callGatewayFromCli.mockRejectedValue(new Error("gateway unavailable"));
+
+    await expect(waitUntilGatewayAgentAvailable("worker")).rejects.toThrow(
+      "Gateway did not apply the Claw agent configuration in time: gateway unavailable",
+    );
+
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledOnce();
+    expect(mocks.sleep).toHaveBeenCalledOnce();
+  });
+});

--- a/src/cli/claws-cli.gateway-readiness.ts
+++ b/src/cli/claws-cli.gateway-readiness.ts
@@ -1,19 +1,23 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { sleep } from "../utils/sleep.js";
 import { callGatewayFromCli } from "./gateway-rpc.js";
 
 const CLAW_AGENT_RELOAD_TIMEOUT_MS = 15_000;
 const CLAW_AGENT_RELOAD_POLL_MS = 100;
 
-export async function waitUntilGatewayConfigApplied(): Promise<void> {
+export async function waitUntilGatewayAgentAvailable(agentId: string): Promise<void> {
   const deadline = Date.now() + CLAW_AGENT_RELOAD_TIMEOUT_MS;
   let lastError: unknown;
   while (Date.now() < deadline) {
     try {
       const response = (await callGatewayFromCli("config.get", { timeout: "5000" }, {})) as {
+        config?: OpenClawConfig;
         configRevisionHash?: unknown;
         appliedConfigHash?: unknown;
       };
+      // Matching tokens can describe a cached roster from before this agent was added.
       if (
+        Object.hasOwn(response.config?.agents?.entries ?? {}, agentId) &&
         typeof response.configRevisionHash === "string" &&
         response.configRevisionHash === response.appliedConfigHash
       ) {

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -63,7 +63,7 @@ import {
   formatClawDiagnostics,
   logClawExperimentalWarning,
 } from "./claws-cli-output.js";
-import { waitUntilGatewayConfigApplied } from "./claws-cli.gateway-readiness.js";
+import { waitUntilGatewayAgentAvailable } from "./claws-cli.gateway-readiness.js";
 import type {
   ClawsAddOptions,
   ClawsExportOptions,
@@ -476,7 +476,7 @@ export async function runClawsAddCommand(
         add: async (input) => await callGatewayFromCli("cron.add", {}, input),
         list: async (agentId) =>
           await listCronJobsFromGateway({}, { agentId, includeDisabled: true }),
-        waitUntilAgentAvailable: async () => await waitUntilGatewayConfigApplied(),
+        waitUntilAgentAvailable: waitUntilGatewayAgentAvailable,
       },
     });
   } catch (error) {

--- a/src/cli/claws-cli.test.ts
+++ b/src/cli/claws-cli.test.ts
@@ -111,7 +111,6 @@ vi.mock("../claws/update-apply.js", async () => ({
 }));
 
 const { registerClawsCli } = await import("./claws-cli.js");
-const { waitUntilGatewayConfigApplied } = await import("./claws-cli.gateway-readiness.js");
 const { runClawsAddCommand } = await import("./claws-cli.runtime.js");
 const { ClawUpdateMutationError } = await import("../claws/update-apply.js");
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -326,49 +325,6 @@ describe("claws cli", () => {
     );
   });
 
-  it("accepts an already-applied Gateway config revision", async () => {
-    mocks.callGatewayFromCli.mockResolvedValue({
-      configRevisionHash: "revision-new",
-      appliedConfigHash: "revision-new",
-    });
-
-    await expect(waitUntilGatewayConfigApplied()).resolves.toBeUndefined();
-
-    expect(mocks.callGatewayFromCli).toHaveBeenCalledOnce();
-    expect(mocks.callGatewayFromCli).toHaveBeenCalledWith("config.get", { timeout: "5000" }, {});
-    expect(mocks.sleep).not.toHaveBeenCalled();
-  });
-
-  it("retries until the Gateway applies the persisted config revision", async () => {
-    mocks.callGatewayFromCli
-      .mockResolvedValueOnce({
-        configRevisionHash: "revision-new",
-        appliedConfigHash: "revision-old",
-      })
-      .mockResolvedValueOnce({
-        configRevisionHash: "revision-new",
-        appliedConfigHash: "revision-new",
-      });
-
-    await expect(waitUntilGatewayConfigApplied()).resolves.toBeUndefined();
-
-    expect(mocks.callGatewayFromCli).toHaveBeenCalledTimes(2);
-    expect(mocks.sleep).toHaveBeenCalledOnce();
-    expect(mocks.sleep).toHaveBeenCalledWith(100);
-  });
-
-  it("reports the last Gateway error after the reload deadline", async () => {
-    vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(15_000);
-    mocks.callGatewayFromCli.mockRejectedValue(new Error("gateway unavailable"));
-
-    await expect(waitUntilGatewayConfigApplied()).rejects.toThrow(
-      "Gateway did not apply the Claw agent configuration in time: gateway unavailable",
-    );
-
-    expect(mocks.callGatewayFromCli).toHaveBeenCalledOnce();
-    expect(mocks.sleep).toHaveBeenCalledOnce();
-  });
-
   it("prints versioned experimental JSON for a development manifest", async () => {
     const manifestPath = await writeManifest();
 
@@ -521,6 +477,16 @@ describe("claws cli", () => {
     );
     expect(mocks.logs).toContain("Added agent: demo-agent");
     expect(mocks.logs.some((line) => line.startsWith("Workspace: "))).toBe(true);
+    mocks.callGatewayFromCli.mockResolvedValue({
+      config: { agents: { entries: { "demo-agent": {} } } },
+      configRevisionHash: "applied",
+      appliedConfigHash: "applied",
+    });
+    vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(1).mockReturnValue(20_000);
+    const [, options] = mocks.applyClawAddPlan.mock.calls[0]!;
+    await expect(
+      options.cronGateway.waitUntilAgentAvailable(plan.agent.finalId),
+    ).resolves.toBeUndefined();
   });
 
   it("resumes consented add with the matching in-flight workspace on disk", async () => {
@@ -992,6 +958,16 @@ describe("claws cli", () => {
       status: "complete",
       agentId: "demo-agent",
     });
+    mocks.callGatewayFromCli.mockResolvedValue({
+      config: { agents: { entries: { "demo-agent": {} } } },
+      configRevisionHash: "applied",
+      appliedConfigHash: "applied",
+    });
+    vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(1).mockReturnValue(20_000);
+    const [plan, , options] = mocks.applyClawUpdatePlan.mock.calls[0]!;
+    await expect(
+      options.cronGateway.waitUntilAgentAvailable(plan.agentId),
+    ).resolves.toBeUndefined();
   });
 
   it("reports uncertain update mutations as partial JSON", async () => {

--- a/src/cli/claws-update-cli.runtime.ts
+++ b/src/cli/claws-update-cli.runtime.ts
@@ -18,6 +18,7 @@ import {
   logClawExperimentalWarning,
   logClawUpdatePlanSummary,
 } from "./claws-cli-output.js";
+import { waitUntilGatewayAgentAvailable } from "./claws-cli.gateway-readiness.js";
 import type { ClawsUpdateOptions } from "./claws-cli.js";
 import { callGatewayFromCli } from "./gateway-rpc.js";
 
@@ -182,6 +183,7 @@ export async function runClawsUpdateCommand(
         packagePreflight: preflightClawPackage,
         runtime: opts.json ? { ...runtime, log: () => undefined } : runtime,
         cronGateway: {
+          waitUntilAgentAvailable: waitUntilGatewayAgentAvailable,
           add: async (input) => await callGatewayFromCli("cron.add", {}, input),
           get: async (id) => await callGatewayFromCli("cron.get", {}, { id }),
           remove: async (id) => await callGatewayFromCli("cron.remove", {}, { id }),


### PR DESCRIPTION
## What Problem This Solves

Claw cron setup could run after the Gateway reported an applied configuration but before that configuration contained the requested agent. A first installation could fail, and an update readiness failure could leave pending cron ownership despite making no scheduler change.

## Why This Change Was Made

Both CLI paths pass the requested agent ID into the existing readiness check. Cron additions wait for an applied Gateway snapshot containing that agent. Updates finish this wait before persisting pending ownership; successful readiness is reused by forward and compensating additions.

Validation, consent, revision checks, uncertain-mutation recovery and removal behavior retain their existing owners. No schema, stored format, configuration option, retention or scheduler policy changes. Production grows by 16 lines; tests by 295; docs by 2.

## Evidence

- The original owner regressions and focused tests passed, followed by 153 tests and the full changed-file gate on the read-view integration. The current composed source passed another 175 tests covering readiness/cron, Gateway pending requests, asynchronous database preflight, snapshot cancellation and the run loop. The entire readiness patch is byte-identical across the mechanical rebase.
- A real built CLI/Gateway flow passed 25 invocations and four fresh reopen/status processes. A cached roster becomes ready with the requested agent, and the first add attempt succeeds. Lost-response recovery preserves the same job and returns no stale error.
- Actual update-add and update-change readiness timeouts each made zero scheduler mutations and left all Claw rows unchanged. Retrying the same consented plan completed successfully; existing scheduler identity and creation time were preserved.
- Two Gateway process generations, an in-process restart and eight additional CLI calls preserved stored rows. Observed SQLite snapshot directories were absent after ready CLI verification and joined shutdown. All owned processes exited, and the port could be rebound. Scheduler execution and real providers were disabled in these synthetic fixtures.
- Independent review of the complete composed source and proof returned 23 clean P0–P2 reports. Current proof used Node 24.20.0 and the repository-pinned pnpm 12.3.4 without changing dependency policies.

The readiness contract establishes agent presence in an applied snapshot; it does not add per-operation configuration identity for an already-present agent. Snapshot cleanup was checked after ready CLI verification, not atomically before the first readiness response. Two early probe-comparison mistakes are retained with corrected native/JSON and Jiti-cache scoping; production and build artifacts stayed unchanged.
