### PR TITLE
fix(claws): compare cron definitions without response metadata

### DIFF
--- a/src/claws/cron-update.test.ts
+++ b/src/claws/cron-update.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { cronJobReadView } from "../cron/job-read-view.js";
 import { normalizeCronJobCreate } from "../cron/normalize.js";
 import { applyClawCronUpdate } from "./cron-update.js";
 import {
@@ -48,13 +49,13 @@ function cronReadView(agentId: string, value: PersistedClawCronRef) {
   if (!normalized || !value.schedulerJobId) {
     throw new Error("expected complete cron provenance");
   }
-  return {
+  return cronJobReadView({
     ...normalized,
     id: value.schedulerJobId,
     createdAtMs: 1,
     updatedAtMs: 1,
-    state: {},
-  };
+    state: { nextRunAtMs: 100, lastRunAtMs: 50, lastStatus: "ok" },
+  });
 }
 
 function plan(actions: ClawUpdatePlan["actions"]): ClawUpdatePlan {

--- a/src/claws/cron.test.ts
+++ b/src/claws/cron.test.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { validateCronAddParams } from "../../packages/gateway-protocol/src/index.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { cronJobReadView } from "../cron/job-read-view.js";
 import { normalizeCronJobCreate } from "../cron/normalize.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -9,6 +10,7 @@ import {
 } from "../state/openclaw-state-db.js";
 import {
   clawCronGatewayInput,
+  clawCronGatewayJobMatchesRef,
   deleteClawCronRef,
   installClawCronJobs,
   markClawCronRefRemoved,
@@ -69,13 +71,25 @@ function listedCronJob(
   if (!normalized) {
     throw new Error("expected normalized cron job");
   }
-  return {
+  return cronJobReadView({
     ...normalized,
     id,
     createdAtMs: 1,
     updatedAtMs: 1,
-    state: {},
-  };
+    state: {
+      nextRunAtMs: 100,
+      lastRunAtMs: 50,
+      lastStatus: "error",
+      lastError: "Synthetic run error",
+      lastDelivered: false,
+      lastDeliveryStatus: "not-delivered",
+      lastDeliveryError: "Synthetic delivery error",
+      deliverySuppressionReason: "channel_transform",
+      lastFailureNotificationDelivered: false,
+      lastFailureNotificationDeliveryStatus: "not-delivered",
+      lastFailureNotificationDeliveryError: "Synthetic notification error",
+    },
+  });
 }
 
 describe("installClawCronJobs", () => {
@@ -177,7 +191,45 @@ describe("installClawCronJobs", () => {
     ]);
   });
 
-  it("rejects a same-key scheduler job whose declaration drifted", async () => {
+  it("reconciles an unchanged completed job from a status-rich Gateway view", async () => {
+    const current = await fixture();
+    const refs = await installClawCronJobs(current.plan, {
+      env: current.env,
+      gateway: { add: async () => ({ id: "scheduler-123" }) },
+    });
+    const view = listedCronJob("worker-two", refs[0]!, "scheduler-123");
+    const before = structuredClone(view);
+    const add = vi.fn();
+
+    await expect(
+      installClawCronJobs(current.plan, {
+        env: current.env,
+        gateway: { add, list: async () => ({ jobs: [view] }) },
+      }),
+    ).resolves.toEqual(refs);
+    expect(add).not.toHaveBeenCalled();
+    expect(view).toEqual(before);
+    for (const invalid of [
+      null,
+      false,
+      "job",
+      {},
+      { ...view, state: undefined },
+      { ...view, id: undefined },
+      { ...view, schedule: undefined },
+      { ...view, payload: { kind: "invalid" } },
+    ]) {
+      expect(clawCronGatewayJobMatchesRef("worker-two", refs[0]!, invalid)).toBe(false);
+    }
+  });
+
+  it.each([
+    {
+      name: "message",
+      patch: { payload: { kind: "agentTurn", message: "Different declaration" } },
+    },
+    { name: "unknown definition field", patch: { operatorSetting: { mode: "changed" } } },
+  ])("rejects a same-key scheduler job with drifted $name", async ({ patch }) => {
     const current = await fixture();
     await installClawCronJobs(current.plan, {
       env: current.env,
@@ -185,7 +237,7 @@ describe("installClawCronJobs", () => {
     });
     const [ref] = readClawCronRefs("worker-two", { env: current.env });
     const drifted = listedCronJob("worker-two", ref!, "scheduler-123");
-    drifted.payload = { kind: "agentTurn", message: "Different declaration" };
+    Object.assign(drifted, patch);
     const add = vi.fn();
 
     await expect(

--- a/src/claws/cron.ts
+++ b/src/claws/cron.ts
@@ -2,6 +2,7 @@ import type { SQLInputValue } from "node:sqlite";
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
 import type { Selectable } from "kysely";
 import { resolveCronJobConfigRevision } from "../cron/config-revision.js";
+import { cronJobDefinitionFromReadView } from "../cron/job-read-view.js";
 import { normalizeCronJobCreate } from "../cron/normalize.js";
 import { createTrustedCronScheduledToolPolicy } from "../cron/scheduled-tool-policy.js";
 import { applyDefaultCronToolsAllow } from "../cron/tools-allow.js";
@@ -250,7 +251,7 @@ export function clawCronGatewayJobMatchesRef(
   if (!value || typeof value !== "object") {
     return false;
   }
-  const live = value as Partial<CronJob>;
+  const live = cronJobDefinitionFromReadView(value as Partial<CronJob>);
   const expected = normalizeCronJobCreate(clawCronGatewayInput(agentId, ref));
   if (
     !expected ||

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { cronJobReadView } from "../cron/job-read-view.js";
 import { normalizeCronJobCreate } from "../cron/normalize.js";
 import { upsertCronJobRow } from "../cron/store/row-codec.js";
 import type { CronStoredJob } from "../cron/types.js";
@@ -15,7 +16,7 @@ import {
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { applyClawAddPlan } from "./add.js";
-import { markClawCronRefRemoved, readClawCronRefs } from "./cron.js";
+import { clawCronGatewayInput, markClawCronRefRemoved, readClawCronRefs } from "./cron.js";
 import { withClawAgentConfigRemoval } from "./lifecycle-config-removal.js";
 import { applyClawRemovePlan, buildClawRemovePlan, readClawStatus } from "./lifecycle-state.js";
 import { buildClawAddPlan } from "./lifecycle.js";
@@ -33,39 +34,17 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const packageIntegrity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
 function cronReadView(agentId: string, ref: ReturnType<typeof readClawCronRefs>[number]) {
-  const job = ref.job;
-  const normalized = normalizeCronJobCreate({
-    name: job.name ?? job.id,
-    declarationKey: ref.declarationKey,
-    ...(job.name ? { displayName: job.name } : {}),
-    owner: { agentId },
-    enabled: true,
-    agentId,
-    schedule: {
-      kind: "cron",
-      expr: job.schedule.cron,
-      ...(job.schedule.timezone ? { tz: job.schedule.timezone } : {}),
-    },
-    sessionTarget: job.session === "main" ? `session:agent:${agentId}:main` : job.session,
-    wakeMode: "now",
-    payload: { kind: "agentTurn", message: job.message },
-    delivery: job.delivery
-      ? {
-          mode: job.delivery.mode,
-          ...(job.delivery.channel ? { channel: job.delivery.channel } : {}),
-        }
-      : { mode: "none" },
-  });
+  const normalized = normalizeCronJobCreate(clawCronGatewayInput(agentId, ref));
   if (!normalized || !ref.schedulerJobId) {
     throw new Error("expected complete cron provenance");
   }
-  return {
+  return cronJobReadView({
     ...normalized,
     id: ref.schedulerJobId,
     createdAtMs: 1,
     updatedAtMs: 1,
-    state: {},
-  };
+    state: { nextRunAtMs: 100, lastRunAtMs: 50, lastStatus: "ok" },
+  });
 }
 
 function seedAttachedCronJob(

--- a/src/cron/job-read-view.ts
+++ b/src/cron/job-read-view.ts
@@ -1,0 +1,43 @@
+import { resolveCronJobConfigRevision } from "./config-revision.js";
+import { toPublicCronJob } from "./public-job.js";
+import type { CronJob } from "./types.js";
+
+export function cronJobReadView(job: CronJob) {
+  const publicJob = toPublicCronJob(job);
+  return {
+    ...publicJob,
+    configRevision: resolveCronJobConfigRevision(job),
+    nextRunAtMs: job.state.nextRunAtMs,
+    lastRunAtMs: job.state.lastRunAtMs,
+    lastRunStatus: job.state.lastRunStatus ?? job.state.lastStatus,
+    lastRunError: job.state.lastError,
+    lastDelivered: job.state.lastDelivered,
+    lastDeliveryStatus: job.state.lastDeliveryStatus,
+    lastDeliveryError: job.state.lastDeliveryError,
+    deliverySuppressionReason: job.state.deliverySuppressionReason,
+    lastFailureNotificationDelivered: job.state.lastFailureNotificationDelivered,
+    lastFailureNotificationDeliveryStatus: job.state.lastFailureNotificationDeliveryStatus,
+    lastFailureNotificationDeliveryError: job.state.lastFailureNotificationDeliveryError,
+  };
+}
+
+// Strip only metadata added by the public read view, never unknown definition fields.
+// Stored revisions and privacy projection have separate owners and stay unchanged.
+export function cronJobDefinitionFromReadView(view: Partial<ReturnType<typeof cronJobReadView>>) {
+  const {
+    configRevision: _configRevision,
+    nextRunAtMs: _nextRunAtMs,
+    lastRunAtMs: _lastRunAtMs,
+    lastRunStatus: _lastRunStatus,
+    lastRunError: _lastRunError,
+    lastDelivered: _lastDelivered,
+    lastDeliveryStatus: _lastDeliveryStatus,
+    lastDeliveryError: _lastDeliveryError,
+    deliverySuppressionReason: _deliverySuppressionReason,
+    lastFailureNotificationDelivered: _lastFailureNotificationDelivered,
+    lastFailureNotificationDeliveryStatus: _lastFailureNotificationDeliveryStatus,
+    lastFailureNotificationDeliveryError: _lastFailureNotificationDeliveryError,
+    ...definition
+  } = view;
+  return definition;
+}

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -31,8 +31,8 @@ import {
   resolveCronDeliveryPreviews,
 } from "../../cron/delivery-preview.js";
 import { assertCronDeliveryInputNonBlankFields } from "../../cron/delivery-target-validation.js";
+import { cronJobReadView } from "../../cron/job-read-view.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "../../cron/normalize.js";
-import { toPublicCronJob } from "../../cron/public-job.js";
 import type { CronRuntimeAuthority } from "../../cron/runtime-authority.js";
 import { CRON_JOB_SCRATCH_MAX_BYTES } from "../../cron/scratch-contract.js";
 import { resolveFailureAlert } from "../../cron/service/failure-alerts.js";
@@ -193,25 +193,6 @@ function publicCronScratch(
     content: scratch.content,
     revision: scratch.revision,
     updatedAtMs: scratch.updatedAtMs,
-  };
-}
-
-function cronJobReadView(job: CronJob) {
-  const publicJob = toPublicCronJob(job);
-  return {
-    ...publicJob,
-    configRevision: resolveCronJobConfigRevision(job),
-    nextRunAtMs: job.state.nextRunAtMs,
-    lastRunAtMs: job.state.lastRunAtMs,
-    lastRunStatus: job.state.lastRunStatus ?? job.state.lastStatus,
-    lastRunError: job.state.lastError,
-    lastDelivered: job.state.lastDelivered,
-    lastDeliveryStatus: job.state.lastDeliveryStatus,
-    lastDeliveryError: job.state.lastDeliveryError,
-    deliverySuppressionReason: job.state.deliverySuppressionReason,
-    lastFailureNotificationDelivered: job.state.lastFailureNotificationDelivered,
-    lastFailureNotificationDeliveryStatus: job.state.lastFailureNotificationDeliveryStatus,
-    lastFailureNotificationDeliveryError: job.state.lastFailureNotificationDeliveryError,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Claw updates, removal, and completed-install reconciliation can reject unchanged scheduled jobs as “changed after planning.” The real Gateway response includes a revision token and flattened run/delivery status, while the comparison incorrectly hashes those response fields as part of the stored definition.

## Why This Change Was Made

Move the unchanged read-view producer into the cron owner and co-locate the projection that removes exactly its declared response metadata. The shared Claw matcher uses that projection once. Arbitrary definition fields remain hash-significant; stored revisions, codecs, private-field redaction, API output, CAS, and lifecycle ordering stay unchanged. Existing consumer fixtures now use the actual producer.

## User Impact

An unchanged scheduled job can be reconciled and updated using the normal Claw flow. Actual operator edits still stop Claw mutation. The separate system-monitor removal policy is unchanged.

## Evidence

- Before the fix, realistic Gateway fixtures caused seven existing update/removal failures and one completed-install reconciliation failure.
- Focused consumer/revision/privacy tests: 58 passed; corrected closed-enum fixture: 13 passed. Gateway validation and CAS: 248 passed.
- Native SQLite proof: rich views fail before/pass after; eight definition drifts rejected; unknown fields preserved; private creator removed; exact rows and revisions retained after physical close/reopen.
- Final full changed gate: exit 0. One qaRuntime build: 48.7 seconds. Actual CLI add/consented update/status/offline reopen/Gateway restart passed; an ordinary operator edit was refused by the next Claw mutation and exact job/provenance rows were preserved. All owned processes joined; synthetic state removed.
- Independent Codex review completed five passes with no P0–P2 findings. The native and live controllers retained source hashes, and the Gateway producer moved unchanged.

Production +25 lines (including the moved producer; inverse boundary is the justified growth); tests +32 lines. No schema/config/protocol changes. Failed attempts are retained in the local evidence pack.
