### PR TITLE
refactor(sessions): remove unused timeout field

### DIFF
--- a/src/sessions/conversation-turns.ts
+++ b/src/sessions/conversation-turns.ts
@@ -24,7 +24,6 @@ type PendingConversationTurn = {
   outboundMessageId?: string;
   correlationReady: Promise<void>;
   markCorrelationReady: () => void;
-  stopTimeout: () => void;
   claimed: boolean;
   settle: (reply: ConversationTurnReply | undefined) => void;
 };
@@ -128,7 +127,6 @@ export function registerPendingConversationTurn(params: {
     createdAt,
     correlationReady,
     markCorrelationReady,
-    stopTimeout,
     claimed: false,
     settle,
   };


### PR DESCRIPTION
## What Problem This Solves

Pending conversation turn records carried a private timeout callback that was never read from the record, making the internal state shape larger and misleading about its ownership.

## Why This Change Was Made

Remove only the unused record field and assignment. The lexical timeout callback remains owned and invoked by `settle()`, so timeout, cancellation, abort, claim, and cleanup behavior is unchanged.

## User Impact

No user-visible behavior changes. This is a small internal cleanup.

## Evidence

- `node scripts/run-vitest.mjs src/sessions/conversation-turns.test.ts` (14 tests passed)
- `node_modules/.bin/oxfmt --check src/sessions/conversation-turns.ts`
- `git diff --check`
- Independent audit and actual-diff review confirmed the patch removes only the write-only field.
