### PR TITLE
fix: fence pending child spawns with parent authority

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -168,16 +168,30 @@ export class AcpSessionManager {
     runtime: AcpRuntime;
     handle: AcpRuntimeHandle;
     meta: SessionAcpMeta;
+    sessionEntry: SessionEntry;
+    closeRuntimeOnFailure: () => Promise<void>;
   }> {
     const target = resolveAcpSessionTarget(input);
     return await this.withSessionActor(target, async () => {
-      return await runManagerInitializeSession({
+      const initialized = await runManagerInitializeSession({
         input,
         ...target,
         deps: this.deps,
         runtimeHandles: this.runtimeHandles,
         writeSessionMeta: this.writeSessionMeta.bind(this),
       });
+      return {
+        ...initialized,
+        // Deletion and shutdown may have already released this exact handle.
+        closeRuntimeOnFailure: () =>
+          this.withSessionActor(target, () =>
+            this.runtimeHandles.close({
+              ...target,
+              reason: "spawn-failed",
+              expectedHandle: initialized.handle,
+            }),
+          ),
+      };
     });
   }
 
@@ -468,6 +482,7 @@ export class AcpSessionManager {
   }
 
   private async writeSessionMeta(params: {
+    assertCommitAllowed?: () => void;
     cfg: OpenClawConfig;
     sessionKey: string;
     agentId: string;
@@ -485,6 +500,7 @@ export class AcpSessionManager {
         sessionKey: params.sessionKey,
         agentId: params.agentId,
         mutate: params.mutate,
+        assertCommitAllowed: params.assertCommitAllowed,
         ...(params.skipMaintenance === true ? { skipMaintenance: true } : {}),
         ...(params.takeCacheOwnership === true ? { takeCacheOwnership: true } : {}),
       });

--- a/src/acp/control-plane/manager.initialize-session.ts
+++ b/src/acp/control-plane/manager.initialize-session.ts
@@ -39,6 +39,7 @@ export async function runManagerInitializeSession(params: {
   runtime: AcpRuntime;
   handle: AcpRuntimeHandle;
   meta: SessionAcpMeta;
+  sessionEntry: SessionEntry;
 }> {
   const { input, sessionKey, agentId } = params;
   const backend = params.deps.requireRuntimeBackend(input.backendId || input.cfg.acp?.backend);
@@ -53,6 +54,7 @@ export async function runManagerInitializeSession(params: {
   const requestedModel = initialRuntimeOptions.model;
   const requestedThinking = initialRuntimeOptions.thinking;
   const previousMeta = params.deps.loadSessionEntry({ cfg: input.cfg, sessionKey, agentId })?.acp;
+  input.assertActive?.();
   const ensured = await withAcpRuntimeErrorBoundary({
     run: async () =>
       await runtime.ensureSession({
@@ -122,6 +124,7 @@ export async function runManagerInitializeSession(params: {
     runtime,
     handle,
     writeSessionMeta: params.writeSessionMeta,
+    assertCommitAllowed: input.assertActive,
   });
   if (!persisted?.acp) {
     throw new AcpRuntimeError(
@@ -142,6 +145,7 @@ export async function runManagerInitializeSession(params: {
     runtime,
     handle,
     meta,
+    sessionEntry: persisted,
   };
 }
 
@@ -157,6 +161,7 @@ function resolveEffectiveSessionModel(params: {
 }
 
 async function persistInitializedSessionMeta(params: {
+  assertCommitAllowed?: () => void;
   cfg: OpenClawConfig;
   sessionKey: string;
   agentId: string;
@@ -172,6 +177,7 @@ async function persistInitializedSessionMeta(params: {
       agentId: params.agentId,
       mutate: () => params.meta,
       failOnError: true,
+      assertCommitAllowed: params.assertCommitAllowed,
     });
     if (persisted?.acp) {
       return persisted;

--- a/src/acp/control-plane/manager.runtime-handle-cache.ts
+++ b/src/acp/control-plane/manager.runtime-handle-cache.ts
@@ -55,9 +55,11 @@ export class ManagerRuntimeHandleCache {
   }
 
   /** Closes and removes one cached runtime handle when present. */
-  async close(params: AcpSessionTarget & { reason: string }): Promise<void> {
+  async close(
+    params: AcpSessionTarget & { reason: string; expectedHandle?: AcpRuntimeHandle },
+  ): Promise<void> {
     const cached = this.get(params);
-    if (!cached) {
+    if (!cached || (params.expectedHandle && cached.handle !== params.expectedHandle)) {
       return;
     }
     try {
@@ -66,6 +68,9 @@ export class ManagerRuntimeHandleCache {
         reason: params.reason,
       });
     } catch (error) {
+      if (params.expectedHandle && isAcpOwnerRepairRequired(error)) {
+        throw error;
+      }
       logVerbose(
         `acp-manager: cached runtime close failed for ${params.sessionKey}: ${String(error)}`,
       );

--- a/src/acp/control-plane/manager.types.ts
+++ b/src/acp/control-plane/manager.types.ts
@@ -50,6 +50,8 @@ export type AcpSessionResolution =
 
 /** Input required to create or resume an ACP runtime session. */
 export type AcpInitializeSessionInput = {
+  /** Ephemeral source authority; rechecked after queued work and before publication. */
+  assertActive?: () => void;
   cfg: OpenClawConfig;
   sessionKey: string;
   agentId?: string;
@@ -173,6 +175,7 @@ export type AcpSessionManagerDeps = {
 };
 
 export type WriteManagerSessionMeta = (params: {
+  assertCommitAllowed?: () => void;
   cfg: OpenClawConfig;
   sessionKey: string;
   agentId: string;

--- a/src/acp/control-plane/spawn.test.ts
+++ b/src/acp/control-plane/spawn.test.ts
@@ -1,0 +1,588 @@
+import type { AcpRuntime } from "@openclaw/acp-core/runtime/types";
+import { afterEach, beforeAll, describe, expect, it, vi, type MockInstance } from "vitest";
+import { withGatewayToolCallerIdentity } from "../../agents/tools/gateway-caller-context.js";
+import { callInProcessGatewayTool } from "../../agents/tools/in-process-gateway.js";
+import type { CliDeps } from "../../cli/deps.types.js";
+import {
+  loadSessionEntry,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import * as gatewayCall from "../../gateway/call.js";
+import { withLocalGatewayRequestScope } from "../../gateway/local-request-context.js";
+import { createGatewayMethodRegistry } from "../../gateway/methods/registry.js";
+import { createLazyCoreHandlers } from "../../gateway/server-methods/lazy-core-handlers.js";
+import { sessionDeleteHandlers } from "../../gateway/server-methods/sessions-delete.js";
+import { withOperatorToolGatewayAuthority } from "../../gateway/server-plugin-in-process-dispatch.js";
+import { GatewayRequestEntryLifetime } from "../../gateway/server-request-entry.js";
+import {
+  getSessionBindingService,
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  type SessionBindingAdapter,
+  type SessionBindingRecord,
+} from "../../infra/outbound/session-binding-service.js";
+import {
+  getPluginRuntimeGatewayRequestScope,
+  withPluginRuntimeGatewayRequestScope,
+} from "../../plugins/runtime/gateway-request-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { ensureGatewayOwnerProfile } from "../../state/user-profiles.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { registerAcpRuntimeBackend, unregisterAcpRuntimeBackend } from "../runtime/registry.js";
+import { AcpSessionManager, getAcpSessionManager, testing as managerTesting } from "./manager.js";
+import { disposeAcpSessionManagerInstance } from "./manager.lifecycle.js";
+import { DEFAULT_DEPS } from "./manager.types.js";
+import { cleanupFailedAcpSpawn } from "./spawn.js";
+
+const backendId = "provisional-cleanup-fixture";
+const agentId = "main";
+const sessionKey = "agent:main:acp:provisional-cleanup";
+type Initialized = Awaited<
+  ReturnType<ReturnType<typeof getAcpSessionManager>["initializeSession"]>
+>;
+
+// This fixture opens no browser; browser ownership has its own lifecycle tests.
+vi.mock("../../browser-lifecycle-cleanup.js", () => ({
+  cleanupBrowserSessionsForLifecycleEnd: async () => {},
+}));
+
+beforeAll(async () => {
+  // Prepare the real lazy cleanup graph outside request deadlines. Vitest source
+  // transformation is not part of the running Gateway's ten-second RPC budget.
+  await Promise.all([
+    import("../../gateway/server-methods/sessions-delete.js"),
+    import("../../gateway/server-methods/sessions.runtime.js"),
+    import("../../agents/embedded-agent.js"),
+    import("../../agents/agent-bundle-mcp-tools.js"),
+    import("../../agents/bash-process-registry.js"),
+  ]);
+});
+afterEach(() => vi.restoreAllMocks());
+
+async function withCleanupFixture(
+  run: (fixture: {
+    cfg: OpenClawConfig;
+    manager: ReturnType<typeof getAcpSessionManager>;
+    runtime: AcpRuntime;
+    initialize: () => Promise<Initialized>;
+    cleanup: (initialized: Initialized) => Promise<void>;
+    close: ReturnType<typeof vi.fn<AcpRuntime["close"]>>;
+    ensureSession: ReturnType<typeof vi.fn<AcpRuntime["ensureSession"]>>;
+    prepareFreshSession: ReturnType<typeof vi.fn<NonNullable<AcpRuntime["prepareFreshSession"]>>>;
+    socket: MockInstance<typeof gatewayCall.callGateway>;
+    bindings: Map<string, SessionBindingRecord>;
+    bind: ReturnType<typeof vi.fn<NonNullable<SessionBindingAdapter["bind"]>>>;
+  }) => Promise<void>,
+) {
+  return await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+    const cfg: OpenClawConfig = {
+      acp: { enabled: true, backend: backendId, allowedAgents: [agentId] },
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId } },
+        entries: { main: { workspace: state.workspaceDir } },
+      },
+      channels: { discord: { threadBindings: { enabled: true } } },
+    };
+    await state.writeConfig(cfg);
+    const close = vi.fn<AcpRuntime["close"]>(async () => {});
+    const ensureSession = vi.fn<AcpRuntime["ensureSession"]>(async (input) => ({
+      agentId: input.agentId,
+      sessionKey: input.sessionKey,
+      backend: backendId,
+      runtimeSessionName: input.sessionKey,
+      backendSessionId: `runtime:${input.sessionKey}`,
+    }));
+    const prepareFreshSession = vi.fn<NonNullable<AcpRuntime["prepareFreshSession"]>>(
+      async () => {},
+    );
+    const runtime: AcpRuntime = {
+      ownerAwareSessions: 1,
+      ensureSession,
+      close,
+      prepareFreshSession,
+      async cancel() {},
+      runTurn() {
+        throw new Error("No provider turn belongs in this cleanup fixture");
+      },
+    };
+    const bindings = new Map<string, SessionBindingRecord>();
+    const bind = vi.fn<NonNullable<SessionBindingAdapter["bind"]>>(async (input) => {
+      const binding: SessionBindingRecord = {
+        bindingId: `binding:${input.targetSessionKey}`,
+        targetSessionKey: input.targetSessionKey,
+        targetKind: input.targetKind,
+        conversation: input.conversation,
+        status: "active",
+        boundAt: Date.now(),
+        metadata: input.metadata,
+      };
+      bindings.set(input.targetSessionKey, binding);
+      return binding;
+    });
+    const adapter: SessionBindingAdapter = {
+      channel: "discord",
+      accountId: "default",
+      capabilities: {
+        placements: ["current", "child"],
+        bindSupported: true,
+        unbindSupported: true,
+      },
+      bind,
+      listBySession: (key) => (bindings.has(key) ? [bindings.get(key)!] : []),
+      resolveByConversation: () => null,
+      unbind: async (input) => {
+        const removed = [...bindings.values()].filter(
+          (record) => record.targetSessionKey === input.targetSessionKey,
+        );
+        for (const record of removed) {
+          bindings.delete(record.targetSessionKey);
+        }
+        return removed;
+      },
+    };
+    registerSessionBindingAdapter(adapter);
+    registerAcpRuntimeBackend({ id: backendId, runtime });
+    managerTesting.resetAcpSessionManagerForTests();
+    const manager = getAcpSessionManager();
+    const socket = vi
+      .spyOn(gatewayCall, "callGateway")
+      .mockRejectedValue(new Error("Raw WebSocket transport is unavailable"));
+    try {
+      await withLocalGatewayRequestScope({ deps: {} as CliDeps, getRuntimeConfig: () => cfg }, () =>
+        run({
+          cfg,
+          manager,
+          runtime,
+          close,
+          ensureSession,
+          prepareFreshSession,
+          socket,
+          bindings,
+          bind,
+          initialize: () =>
+            manager.initializeSession({
+              cfg,
+              sessionKey,
+              agentId,
+              agent: agentId,
+              mode: "persistent",
+            }),
+          cleanup: (initialized) =>
+            cleanupFailedAcpSpawn({
+              cfg,
+              sessionKey,
+              agentId,
+              sessionEntry: initialized.sessionEntry,
+              deleteTranscript: true,
+              closeRuntimeOnFailure: initialized.closeRuntimeOnFailure,
+            }),
+        }),
+      );
+    } finally {
+      await disposeAcpSessionManagerInstance(manager, "fixture-cleanup");
+      managerTesting.resetAcpSessionManagerForTests();
+      unregisterAcpRuntimeBackend(backendId);
+      unregisterSessionBindingAdapter({ channel: "discord", accountId: "default", adapter });
+    }
+  });
+}
+
+describe("failed ACP provisional cleanup", () => {
+  it.each(["live Gateway", "retired Gateway", "expired operator"] as const)(
+    "retains local resource cleanup after %s ownership",
+    async (owner) => {
+      await withCleanupFixture(
+        async ({ initialize, cleanup, close, ensureSession, socket, manager }) => {
+          const scope = getPluginRuntimeGatewayRequestScope();
+          if (!scope?.context) {
+            throw new Error("Expected the local Gateway owner");
+          }
+          const initialized = await initialize();
+          const before = loadSessionEntry({ sessionKey, agentId });
+          let current = true;
+          const resolveGatewayContext = () => (current ? scope.context : undefined);
+          await withPluginRuntimeGatewayRequestScope({ ...scope, resolveGatewayContext }, () =>
+            withGatewayToolCallerIdentity(
+              {
+                agentId,
+                sessionKey: "agent:main:main",
+                operationalRunInstance: { instanceId: "parent-instance", runId: "parent-run" },
+                receiptAuthority: () => false,
+                gatewayContextResolver: resolveGatewayContext,
+              },
+              async () => {
+                if (owner === "expired operator") {
+                  const profile = ensureGatewayOwnerProfile("Cleanup owner");
+                  const release = createDeferredCore();
+                  let late: Promise<void> | undefined;
+                  await withOperatorToolGatewayAuthority(
+                    {
+                      authenticatedUserProfile: {
+                        profileId: profile.id,
+                        displayName: profile.displayName,
+                        hasAvatar: false,
+                        updatedAt: profile.updatedAt,
+                      },
+                      scopes: ["operator.admin"],
+                    },
+                    async () => {
+                      late = release.promise.then(() => cleanup(initialized));
+                    },
+                  );
+                  release.resolve();
+                  await late;
+                } else {
+                  current = owner !== "retired Gateway";
+                  await cleanup(initialized);
+                }
+              },
+            ),
+          );
+          expect(loadSessionEntry({ sessionKey, agentId })).toEqual(
+            owner === "live Gateway" ? undefined : before,
+          );
+          expect(close).toHaveBeenCalledOnce();
+          expect(ensureSession).toHaveBeenCalledOnce();
+          expect(socket).not.toHaveBeenCalled();
+          await initialized.closeRuntimeOnFailure();
+          await disposeAcpSessionManagerInstance(manager, "repeat-disposal");
+          expect(close).toHaveBeenCalledOnce();
+        },
+      );
+    },
+  );
+
+  it("releases the original handle when Gateway retirement during lazy preparation prevents admission", async () => {
+    await withCleanupFixture(async ({ initialize, cleanup, close, ensureSession, socket }) => {
+      const scope = getPluginRuntimeGatewayRequestScope();
+      if (!scope?.context) {
+        throw new Error("Expected local Gateway owner");
+      }
+      const initialized = await initialize();
+      const before = loadSessionEntry({ sessionKey, agentId });
+      const entered = createDeferredCore();
+      const release = createDeferredCore();
+      const deletion = vi.fn(sessionDeleteHandlers["sessions.delete"]!);
+      const lazy = createLazyCoreHandlers({
+        methods: ["sessions.delete"],
+        loadHandlers: async () => {
+          entered.resolve();
+          await release.promise;
+          return { "sessions.delete": deletion };
+        },
+      });
+      const registry = createGatewayMethodRegistry([
+        {
+          name: "sessions.delete",
+          owner: { kind: "core", area: "sessions" },
+          scope: "operator.admin",
+          handler: lazy["sessions.delete"]!,
+        },
+      ]);
+      const lifetime = new GatewayRequestEntryLifetime();
+      const context = {
+        ...scope.context,
+        requestEntryLifetime: lifetime,
+        getGatewayMethodRegistry: () => registry,
+      };
+      let current = true;
+      await withPluginRuntimeGatewayRequestScope(
+        { ...scope, context, resolveGatewayContext: () => (current ? context : undefined) },
+        async () => {
+          const cleaning = cleanup(initialized);
+          try {
+            await entered.promise;
+            current = false;
+            lifetime.beginClose();
+          } finally {
+            release.resolve();
+          }
+          await cleaning;
+          await lifetime.sealAndJoin();
+          expect(deletion).not.toHaveBeenCalled();
+          expect(close).toHaveBeenCalledOnce();
+          expect(close).toHaveBeenCalledWith({
+            handle: initialized.handle,
+            reason: "spawn-failed",
+          });
+          expect(ensureSession).toHaveBeenCalledOnce();
+          expect(loadSessionEntry({ sessionKey, agentId })).toEqual(before);
+          expect(socket).not.toHaveBeenCalled();
+        },
+      );
+    });
+  });
+
+  it.each(["before admission", "after admission"] as const)(
+    "does not repeat resource cleanup after a deadline %s",
+    async (boundary) => {
+      await withCleanupFixture(async ({ initialize, cleanup, close, ensureSession, socket }) => {
+        const scope = getPluginRuntimeGatewayRequestScope();
+        if (!scope?.context) {
+          throw new Error("Expected local Gateway owner");
+        }
+        const initialized = await initialize();
+        const before = loadSessionEntry({ sessionKey, agentId });
+        const entered = createDeferredCore();
+        const release = createDeferredCore();
+        const deletion = vi.fn(sessionDeleteHandlers["sessions.delete"]!);
+        const lazy = createLazyCoreHandlers({
+          methods: ["sessions.delete"],
+          loadHandlers: async () => {
+            if (boundary === "before admission") {
+              entered.resolve();
+              await release.promise;
+            }
+            return { "sessions.delete": deletion };
+          },
+        });
+        if (boundary === "after admission") {
+          close.mockImplementationOnce(async () => {
+            entered.resolve();
+            await release.promise;
+          });
+        }
+        const registry = createGatewayMethodRegistry([
+          {
+            name: "sessions.delete",
+            owner: { kind: "core", area: "sessions" },
+            scope: "operator.admin",
+            handler: lazy["sessions.delete"]!,
+          },
+        ]);
+        const executions: Promise<unknown>[] = [];
+        const context = {
+          ...scope.context,
+          getGatewayMethodRegistry: () => registry,
+          trackExecution: <T>(work: () => T | Promise<T>) => {
+            const tracked = scope.context!.trackExecution(work);
+            executions.push(tracked);
+            return tracked;
+          },
+        };
+        const retainedRelease = vi.fn(initialized.closeRuntimeOnFailure);
+        await withPluginRuntimeGatewayRequestScope(
+          { ...scope, context, resolveGatewayContext: () => context },
+          async () => {
+            vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+            const cleaning = cleanup({ ...initialized, closeRuntimeOnFailure: retainedRelease });
+            try {
+              await entered.promise;
+              await vi.advanceTimersByTimeAsync(10_001);
+              await cleaning;
+              expect(retainedRelease).toHaveBeenCalledTimes(
+                boundary === "before admission" ? 1 : 0,
+              );
+              expect(close).toHaveBeenCalledOnce();
+            } finally {
+              vi.useRealTimers();
+              release.resolve();
+              await cleaning;
+              await Promise.allSettled(executions);
+            }
+            expect(deletion).toHaveBeenCalledTimes(boundary === "before admission" ? 0 : 1);
+            expect(loadSessionEntry({ sessionKey, agentId })).toEqual(
+              boundary === "before admission" ? before : undefined,
+            );
+            expect(close).toHaveBeenCalledOnce();
+            expect(ensureSession).toHaveBeenCalledOnce();
+            expect(socket).not.toHaveBeenCalled();
+          },
+        );
+      });
+    },
+  );
+
+  it("deletes the provisional shell after the initializer owns metadata-failure release", async () => {
+    await withCleanupFixture(async ({ cfg, close, ensureSession, socket }) => {
+      const shell = await upsertSessionEntryCore(
+        { sessionKey, agentId },
+        { sessionId: "metadata-failure-shell", updatedAt: Date.now() },
+      );
+      if (!shell) {
+        throw new Error("Expected provisional shell");
+      }
+      const manager = new AcpSessionManager({
+        ...DEFAULT_DEPS,
+        upsertSessionMeta: async () => {
+          throw new Error("metadata write refused");
+        },
+      });
+      try {
+        await expect(
+          manager.initializeSession({
+            cfg,
+            sessionKey,
+            agentId,
+            agent: agentId,
+            mode: "persistent",
+          }),
+        ).rejects.toThrow("metadata write refused");
+        expect(close).toHaveBeenCalledExactlyOnceWith({
+          handle: expect.objectContaining({ sessionKey }),
+          reason: "init-meta-failed",
+        });
+        await cleanupFailedAcpSpawn({
+          cfg,
+          sessionKey,
+          agentId,
+          sessionEntry: shell,
+          deleteTranscript: true,
+        });
+        expect(loadSessionEntry({ sessionKey, agentId })).toBeUndefined();
+        expect(ensureSession).toHaveBeenCalledOnce();
+        expect(close).toHaveBeenCalledOnce();
+        expect(socket).not.toHaveBeenCalled();
+      } finally {
+        await disposeAcpSessionManagerInstance(manager, "fixture-cleanup");
+      }
+    });
+  });
+
+  it("uses pending-identity prepare-fresh cleanup without rehydrating or forcing a close", async () => {
+    await withCleanupFixture(
+      async ({ ensureSession, initialize, cleanup, close, prepareFreshSession, manager }) => {
+        ensureSession.mockImplementationOnce(async (input) => ({
+          sessionKey: input.sessionKey,
+          agentId: input.agentId,
+          backend: backendId,
+          runtimeSessionName: input.sessionKey,
+        }));
+        const initialized = await initialize();
+        await cleanup(initialized);
+        expect(loadSessionEntry({ sessionKey, agentId })).toBeUndefined();
+        expect(ensureSession).toHaveBeenCalledOnce();
+        expect(close).not.toHaveBeenCalled();
+        expect(prepareFreshSession).toHaveBeenCalledOnce();
+        await initialized.closeRuntimeOnFailure();
+        expect(close).not.toHaveBeenCalled();
+        expect(manager.getObservabilitySnapshot().runtimeCache.activeSessions).toBe(0);
+      },
+    );
+  });
+
+  it.each(["replace", "reset"] as const)(
+    "keeps a %s successor and its binding untouched by stale cleanup",
+    async (mutation) => {
+      await withCleanupFixture(
+        async ({ initialize, cleanup, close, ensureSession, bindings, socket }) => {
+          const original = await initialize();
+          await callInProcessGatewayTool(
+            mutation === "replace" ? "sessions.delete" : "sessions.reset",
+            { key: sessionKey, agentId },
+          );
+          const successor = await initialize();
+          if (mutation === "replace") {
+            expect(successor.sessionEntry.sessionId).not.toBe(original.sessionEntry.sessionId);
+          } else {
+            expect(successor.sessionEntry.sessionId).toBe(original.sessionEntry.sessionId);
+            expect(successor.sessionEntry.lifecycleRevision).not.toBe(
+              original.sessionEntry.lifecycleRevision,
+            );
+          }
+          const binding = await getSessionBindingService().bind({
+            targetSessionKey: sessionKey,
+            targetKind: "session",
+            placement: "current",
+            conversation: {
+              channel: "discord",
+              accountId: "default",
+              conversationId: "successor-thread",
+            },
+          });
+          const before = loadSessionEntry({ sessionKey, agentId });
+          close.mockClear();
+          ensureSession.mockClear();
+          await cleanup(original);
+          expect(loadSessionEntry({ sessionKey, agentId })).toEqual(before);
+          expect(bindings.get(sessionKey)).toEqual(binding);
+          expect(close).not.toHaveBeenCalled();
+          expect(ensureSession).not.toHaveBeenCalled();
+          expect(socket).not.toHaveBeenCalled();
+        },
+      );
+    },
+  );
+
+  it("releases an initialization that finishes after its Gateway and manager retire", async () => {
+    await withCleanupFixture(
+      async ({ manager, initialize, cleanup, ensureSession, close, socket }) => {
+        const scope = getPluginRuntimeGatewayRequestScope();
+        if (!scope?.context) {
+          throw new Error("Expected local Gateway owner");
+        }
+        let current = true;
+        const entered = createDeferredCore();
+        const release = createDeferredCore();
+        const originalEnsure = ensureSession.getMockImplementation()!;
+        ensureSession.mockImplementationOnce(async (input) => {
+          entered.resolve();
+          await release.promise;
+          return await originalEnsure(input);
+        });
+        await withPluginRuntimeGatewayRequestScope(
+          { ...scope, resolveGatewayContext: () => (current ? scope.context : undefined) },
+          async () => {
+            const initializing = initialize();
+            try {
+              await entered.promise;
+              current = false;
+              await disposeAcpSessionManagerInstance(manager, "gateway-shutdown");
+              expect(close).not.toHaveBeenCalled();
+            } finally {
+              release.resolve();
+            }
+            const initialized = await initializing;
+            await cleanup(initialized);
+            expect(close).toHaveBeenCalledOnce();
+            expect(ensureSession).toHaveBeenCalledOnce();
+            expect(socket).not.toHaveBeenCalled();
+            expect(manager.getObservabilitySnapshot().runtimeCache.activeSessions).toBe(0);
+          },
+        );
+      },
+    );
+  });
+
+  it("does not release a newer handle through a retained initialization callback", async () => {
+    await withCleanupFixture(async ({ manager, initialize, close }) => {
+      const original = await initialize();
+      const successor = await initialize();
+      expect(successor.handle).not.toBe(original.handle);
+      await original.closeRuntimeOnFailure();
+      expect(close).not.toHaveBeenCalled();
+      await disposeAcpSessionManagerInstance(manager, "gateway-shutdown");
+      await successor.closeRuntimeOnFailure();
+      expect(close).toHaveBeenCalledOnce();
+      expect(close).toHaveBeenCalledWith({ handle: successor.handle, reason: "gateway-shutdown" });
+    });
+  });
+
+  it("rolls back a refused /acp conversation binding through the local session owner", async () => {
+    const { handleAcpCommand } = await import("../../auto-reply/reply/commands-acp.js");
+    const { buildCommandTestParams } =
+      await import("../../auto-reply/reply/commands.test-harness.js");
+    await withCleanupFixture(async ({ cfg, bind, ensureSession, close, socket }) => {
+      bind.mockRejectedValueOnce(new Error("Conversation binding refused"));
+      const params = buildCommandTestParams("/acp spawn main --bind here", cfg, {
+        Provider: "discord",
+        Surface: "discord",
+        OriginatingChannel: "discord",
+        OriginatingTo: "channel:fixture-room",
+        SenderId: "fixture-owner",
+        AccountId: "default",
+      });
+      params.command.senderIsOwner = true;
+      const result = await handleAcpCommand(params, true);
+      expect(result?.reply?.text).toContain("Conversation binding refused");
+      expect(bind).toHaveBeenCalledOnce();
+      expect(ensureSession).toHaveBeenCalledOnce();
+      const childKey = ensureSession.mock.calls[0]![0].sessionKey;
+      expect(loadSessionEntry({ sessionKey: childKey, agentId })).toBeUndefined();
+      expect(close).toHaveBeenCalledOnce();
+      expect(socket).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/acp/control-plane/spawn.ts
+++ b/src/acp/control-plane/spawn.ts
@@ -1,90 +1,100 @@
 /** Cleanup helpers for failed ACP spawn flows. */
+import {
+  callInProcessGatewayTool,
+  getInProcessGatewayToolContext,
+  runWithGatewayToolCleanupContext,
+} from "../../agents/tools/in-process-gateway.js";
+import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
+import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { callGateway } from "../../gateway/call.js";
 import { logVerbose } from "../../globals.js";
-import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
-import { getAcpSessionManager } from "./manager.js";
+import { runExclusiveSessionLifecycleMutation } from "../../sessions/session-lifecycle-admission.js";
 import { isAcpOwnerRepairRequired } from "./manager.runtime-owner.js";
 
-/** Minimal runtime handle needed to close a just-created session during failed spawn cleanup. */
-export type AcpSpawnRuntimeCloseHandle = {
-  runtime: {
-    close: (params: {
-      handle: { sessionKey: string; backend: string; runtimeSessionName: string };
-      reason: string;
-    }) => Promise<void>;
-  };
-  handle: { sessionKey: string; backend: string; runtimeSessionName: string };
-};
-
-/** Best-effort cleanup for partially created ACP sessions, bindings, and transcripts. */
+/** Roll back only the provisional session owned by this failed spawn. */
 export async function cleanupFailedAcpSpawn(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
-  agentId?: string;
-  shouldDeleteSession: boolean;
+  agentId: string;
+  sessionEntry?: SessionEntry;
   deleteTranscript: boolean;
-  runtimeCloseHandle?: AcpSpawnRuntimeCloseHandle;
+  closeRuntimeOnFailure?: () => Promise<void>;
 }): Promise<void> {
-  if (params.runtimeCloseHandle) {
-    await params.runtimeCloseHandle.runtime
-      .close({
-        handle: params.runtimeCloseHandle.handle,
-        reason: "spawn-failed",
-      })
-      .catch((err: unknown) => {
-        if (isAcpOwnerRepairRequired(err)) {
-          throw err;
-        }
-        logVerbose(
-          `acp-spawn: runtime cleanup close failed for ${params.sessionKey}: ${String(err)}`,
-        );
-      });
-  }
-
-  const acpManager = getAcpSessionManager();
-  await acpManager
-    .closeSession({
-      cfg: params.cfg,
-      sessionKey: params.sessionKey,
-      agentId: params.agentId,
-      reason: "spawn-failed",
-      allowBackendUnavailable: true,
-      requireAcpSession: false,
-    })
-    .catch((err: unknown) => {
-      if (isAcpOwnerRepairRequired(err)) {
-        throw err;
-      }
-      logVerbose(
-        `acp-spawn: manager cleanup close failed for ${params.sessionKey}: ${String(err)}`,
-      );
-    });
-
-  await getSessionBindingService()
-    .unbind({
-      targetSessionKey: params.sessionKey,
-      reason: "spawn-failed",
-    })
-    .catch((err: unknown) => {
-      logVerbose(
-        `acp-spawn: binding cleanup unbind failed for ${params.sessionKey}: ${String(err)}`,
-      );
-    });
-
-  if (!params.shouldDeleteSession) {
+  if (!params.sessionEntry) {
     return;
   }
-  await callGateway({
-    method: "sessions.delete",
-    params: {
-      key: params.sessionKey,
-      agentId: params.agentId,
-      deleteTranscript: params.deleteTranscript,
-      emitLifecycleHooks: false,
-    },
-    timeoutMs: 10_000,
-  }).catch(() => {
-    // Best-effort cleanup only.
+  const { sessionId, lifecycleRevision } = params.sessionEntry;
+  const storePath = resolveSessionStorePathCore(params.cfg.session?.store, {
+    agentId: params.agentId,
   });
+  const assertCurrent = () => {
+    const current = loadSessionEntry({
+      storePath,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      clone: false,
+    });
+    if (current?.sessionId !== sessionId || current?.lifecycleRevision !== lifecycleRevision) {
+      throw new Error(`ACP provisional session ${params.sessionKey} changed before cleanup.`);
+    }
+  };
+  let deletionStarted = false;
+  const cancellation = new AbortController();
+  try {
+    await runWithGatewayToolCleanupContext(async () => {
+      assertCurrent();
+      const context = getInProcessGatewayToolContext();
+      if (!context) {
+        throw new Error("ACP provisional cleanup Gateway is unavailable.");
+      }
+      await callInProcessGatewayTool(
+        "sessions.delete",
+        {
+          key: params.sessionKey,
+          agentId: params.agentId,
+          expectedSessionId: sessionId,
+          ...(lifecycleRevision ? { expectedLifecycleRevision: lifecycleRevision } : {}),
+          deleteTranscript: params.deleteTranscript,
+          emitLifecycleHooks: false,
+        },
+        // New /acp rows can have no revision yet. The private guard preserves
+        // exact absence as well as recorded revisions throughout deletion.
+        {
+          sessionMutationCommitGuard: () => {
+            cancellation.signal.throwIfAborted();
+            context.requestEntryLifetime?.signal.throwIfAborted();
+            assertCurrent();
+            // The router calls this after lazy preparation, before handler entry.
+            deletionStarted = true;
+          },
+          signal: cancellation.signal,
+          timeoutMs: 10_000,
+        },
+      );
+    });
+  } catch (error) {
+    // A retired owner cannot dispatch cleanup. Retain its existing local handle
+    // release, but never repeat a close after canonical deletion has started.
+    if (!deletionStarted) {
+      // A timed-out preparation may still settle; fence its late handler entry.
+      cancellation.abort(error);
+    }
+    if (!deletionStarted && params.closeRuntimeOnFailure) {
+      await runExclusiveSessionLifecycleMutation({
+        scope: storePath,
+        identities: [params.sessionKey, sessionId],
+        run: async () => {
+          assertCurrent();
+          await params.closeRuntimeOnFailure!();
+        },
+      }).catch((releaseError: unknown) => {
+        if (isAcpOwnerRepairRequired(releaseError)) {
+          throw releaseError;
+        }
+        logVerbose(`acp-spawn: provisional runtime cleanup failed: ${String(releaseError)}`);
+      });
+    }
+    logVerbose(`acp-spawn: provisional session cleanup failed: ${String(error)}`);
+  }
 }

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -518,6 +518,7 @@ function sessionStoreUpdateOptions(params: {
 }
 
 export async function upsertAcpSessionMeta(params: {
+  assertCommitAllowed?: () => void;
   sessionKey: string;
   agentId?: string;
   cfg?: OpenClawConfig;
@@ -592,11 +593,13 @@ export async function upsertAcpSessionMeta(params: {
           {
             ...sessionStoreUpdateOptions({ ...params, sessionKey: storageSessionKey }),
             replaceEntry: true,
+            assertCommitAllowed: params.assertCommitAllowed,
           },
         )
       : null;
     runOpenClawStateWriteTransaction(
       (database) => {
+        params.assertCommitAllowed?.();
         const sessionKeysToDelete = new Set([databaseSessionKey]);
         if (currentRowKey) {
           sessionKeysToDelete.add(currentRowKey);
@@ -641,6 +644,7 @@ export async function upsertAcpSessionMeta(params: {
       ...sessionStoreUpdateOptions({ ...params, sessionKey: storageSessionKey }),
       fallbackEntry: preparedEntry,
       replaceEntry: true,
+      assertCommitAllowed: params.assertCommitAllowed,
     },
   );
   if (!persisted) {
@@ -653,6 +657,8 @@ export async function upsertAcpSessionMeta(params: {
   });
   runOpenClawStateWriteTransaction(
     (database) => {
+      // The entry patch and legacy cleanup await before this authoritative publication.
+      params.assertCommitAllowed?.();
       const persistedDatabaseSessionKey = buildAcpDatabaseSessionKey(
         persisted.sessionKey,
         storeEntry.agentId,

--- a/src/agents/spawn-pipeline.ts
+++ b/src/agents/spawn-pipeline.ts
@@ -40,6 +40,7 @@ export function summarizeSpawnError(error: unknown): string {
 
 type SpawnPipelineParams<TState> = {
   adapter: SpawnBackendAdapter<TState>;
+  assertActive?: () => void;
   admissionReservation?: { release: () => void };
   buildRegistration: (state: TState, runId: string) => RegisterSubagentRunInput;
   hookRunner?: SubagentLifecycleHookRunner | null;
@@ -53,64 +54,52 @@ type SpawnPipelineParams<TState> = {
 export async function runSpawnPipeline<TState>(
   params: SpawnPipelineParams<TState>,
 ): Promise<SpawnPipelineResult<TState>> {
+  let phase: SpawnPipelinePhase = "initialize";
+  let state: TState | undefined;
+  let runId: string | undefined;
   try {
-    return await executeSpawnPipeline(params);
+    let registration: RegisterSubagentRunInput;
+    try {
+      params.assertActive?.();
+      state = await params.adapter.initialize();
+      // Retain initialization's rollback handle before checking a parent that
+      // may have closed while the backend was preparing its child.
+      phase = "dispatch";
+      params.assertActive?.();
+      ({ runId } = await params.adapter.dispatchTurn(state));
+      phase = "register";
+      params.assertActive?.();
+      // Construction and registration transfer ownership without an interleaving await.
+      registration = params.buildRegistration(state, runId);
+      registerSubagentRun(registration);
+      // Registry insertion takes ownership synchronously; keeping the slot would double-count it.
+      params.admissionReservation?.release();
+    } catch (error) {
+      await params.adapter.cleanupOnFailure({ phase, state, error });
+      return { ok: false, phase, state, runId, error };
+    }
+
+    if (params.hookRunner?.hasHooks("subagent_progress")) {
+      try {
+        await params.hookRunner.runSubagentProgress(
+          {
+            phase: "started",
+            runId,
+            childSessionKey: registration.childSessionKey,
+            requester: params.progressOrigin,
+          },
+          {
+            runId,
+            childSessionKey: registration.childSessionKey,
+            requesterSessionKey: params.progressSessionKey,
+          },
+        );
+      } catch {
+        // Presentation hooks are best-effort after the run is durably registered.
+      }
+    }
+    return { ok: true, state, runId };
   } finally {
     params.admissionReservation?.release();
   }
-}
-
-async function executeSpawnPipeline<TState>(
-  params: SpawnPipelineParams<TState>,
-): Promise<SpawnPipelineResult<TState>> {
-  let state: TState;
-  try {
-    state = await params.adapter.initialize();
-  } catch (error) {
-    await params.adapter.cleanupOnFailure({ phase: "initialize", error });
-    return { ok: false, phase: "initialize", error };
-  }
-
-  let runId: string;
-  try {
-    ({ runId } = await params.adapter.dispatchTurn(state));
-  } catch (error) {
-    await params.adapter.cleanupOnFailure({ phase: "dispatch", state, error });
-    return { ok: false, phase: "dispatch", state, error };
-  }
-
-  let registration: RegisterSubagentRunInput;
-  try {
-    // Keep construction and registration in one synchronous section so callers
-    // can revalidate shared admission state without an interleaving await.
-    registration = params.buildRegistration(state, runId);
-    registerSubagentRun(registration);
-    // Registry insertion takes ownership synchronously; keeping the slot would double-count it.
-    params.admissionReservation?.release();
-  } catch (error) {
-    await params.adapter.cleanupOnFailure({ phase: "register", state, error });
-    return { ok: false, phase: "register", state, runId, error };
-  }
-
-  if (params.hookRunner?.hasHooks("subagent_progress")) {
-    try {
-      await params.hookRunner.runSubagentProgress(
-        {
-          phase: "started",
-          runId,
-          childSessionKey: registration.childSessionKey,
-          requester: params.progressOrigin,
-        },
-        {
-          runId,
-          childSessionKey: registration.childSessionKey,
-          requesterSessionKey: params.progressSessionKey,
-        },
-      );
-    } catch {
-      // Presentation hooks are best-effort after the run is durably registered.
-    }
-  }
-
-  return { ok: true, state, runId };
 }

--- a/src/agents/subagents/spawn/acp-spawn-gateway.ts
+++ b/src/agents/subagents/spawn/acp-spawn-gateway.ts
@@ -9,6 +9,7 @@ import {
 import { callSubagentGateway } from "./subagent-spawn-gateway.js";
 
 export async function launchAcpChildThroughGateway(params: {
+  assertDispatchCurrent?: () => void;
   attachments?: unknown[];
   childIdem: string;
   deliveryPlan: AcpSpawnBootstrapDeliveryPlan;
@@ -25,6 +26,7 @@ export async function launchAcpChildThroughGateway(params: {
     withSubagentGatewayExecutionIdentity(
       {
         method: "agent",
+        assertDispatchCurrent: params.assertDispatchCurrent,
         params: {
           message: params.task,
           sessionKey: params.sessionKey,

--- a/src/agents/subagents/spawn/acp-spawn-runtime.ts
+++ b/src/agents/subagents/spawn/acp-spawn-runtime.ts
@@ -6,7 +6,6 @@ import {
 import type { AcpRuntimeSessionMode } from "@openclaw/acp-core/runtime/types";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { getAcpSessionManager } from "../../../acp/control-plane/manager.js";
-import type { AcpSpawnRuntimeCloseHandle } from "../../../acp/control-plane/spawn.js";
 import { formatThinkingLevels } from "../../../auto-reply/thinking.js";
 import {
   resolveThreadBindingIntroText,
@@ -69,7 +68,6 @@ type AcpSpawnInitializedSession = Awaited<
 
 export type AcpSpawnInitializedRuntime = {
   initialized: AcpSpawnInitializedSession;
-  runtimeCloseHandle: AcpSpawnRuntimeCloseHandle;
   sessionId?: string;
   sessionEntry: SessionEntry | undefined;
   storePath: string;
@@ -153,6 +151,7 @@ export function resolveAcpSpawnRuntimeOptions(params: {
 }
 
 export async function initializeAcpSpawnRuntime(params: {
+  assertActive?: () => void;
   cfg: OpenClawConfig;
   sessionKey: string;
   targetAgentId: string;
@@ -163,6 +162,7 @@ export async function initializeAcpSpawnRuntime(params: {
   modelExplicit?: boolean;
   cwd?: string;
 }): Promise<AcpSpawnInitializedRuntime> {
+  params.assertActive?.();
   const storePath = resolveSessionStorePathCore(params.cfg.session?.store, {
     agentId: params.targetAgentId,
   });
@@ -185,6 +185,7 @@ export async function initializeAcpSpawnRuntime(params: {
   }
 
   const initialized = await getAcpSessionManager().initializeSession({
+    assertActive: params.assertActive,
     cfg: params.cfg,
     sessionKey: params.sessionKey,
     agentId: params.targetAgentId,
@@ -199,10 +200,6 @@ export async function initializeAcpSpawnRuntime(params: {
 
   return {
     initialized,
-    runtimeCloseHandle: {
-      runtime: initialized.runtime,
-      handle: initialized.handle,
-    },
     sessionId,
     sessionEntry,
     storePath,
@@ -210,6 +207,7 @@ export async function initializeAcpSpawnRuntime(params: {
 }
 
 export async function bindPreparedAcpThread(params: {
+  assertActive?: () => void;
   cfg: OpenClawConfig;
   sessionKey: string;
   targetAgentId: string;
@@ -261,6 +259,7 @@ export async function bindPreparedAcpThread(params: {
       }),
     },
   });
+  params.assertActive?.();
   if (!binding.conversation.conversationId) {
     throw new Error(
       params.preparedBinding.placement === "child"

--- a/src/agents/subagents/spawn/acp-spawn.authority.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.authority.test.ts
@@ -1,0 +1,483 @@
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AcpRuntime } from "@openclaw/acp-core/runtime/types";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import {
+  getAcpSessionManager,
+  testing as managerTesting,
+} from "../../../acp/control-plane/manager.js";
+import { disposeAcpSessionManagerInstance } from "../../../acp/control-plane/manager.lifecycle.js";
+import { SessionActorQueue } from "../../../acp/control-plane/session-actor-queue.js";
+import {
+  registerAcpRuntimeBackend,
+  unregisterAcpRuntimeBackend,
+} from "../../../acp/runtime/registry.js";
+import type { CliDeps } from "../../../cli/deps.types.js";
+import {
+  clearConfigCache,
+  clearRuntimeConfigSnapshot,
+  getRuntimeConfig,
+} from "../../../config/config.js";
+import { loadSessionEntry } from "../../../config/sessions/session-accessor.js";
+import * as sessionAccessor from "../../../config/sessions/session-accessor.js";
+import * as gatewayCall from "../../../gateway/call.js";
+import { registerChatAbortController } from "../../../gateway/chat-abort.js";
+import { withLocalGatewayRequestScope } from "../../../gateway/local-request-context.js";
+import { handleChatAbortRequest } from "../../../gateway/server-methods/chat-abort-handler.js";
+import { createSyntheticPluginRuntimeClient } from "../../../gateway/server-plugin-runtime-client.js";
+import {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  type SessionBindingAdapter,
+} from "../../../infra/outbound/session-binding-service.js";
+import { flushLogger, resetLogger } from "../../../logging/logger.js";
+import {
+  bindGatewayContextResolver,
+  getPluginRuntimeGatewayRequestScope,
+  withPluginRuntimeGatewayRequestScope,
+} from "../../../plugins/runtime/gateway-request-scope.js";
+import { AsyncWorkScope } from "../../../shared/async-work-scope.js";
+import { resetTaskRegistryForTests } from "../../../tasks/task-registry.test-support.js";
+import { captureEnv, setTestEnvValue } from "../../../test-utils/env.js";
+import { cleanupSessionStateForTest } from "../../../test-utils/session-state-cleanup.js";
+import {
+  createOperationalRunInstanceRef,
+  getAdmittedRunDelegatedAuthority,
+  prepareAgentRunAdmission,
+} from "../../admitted-run-context.js";
+import { copyAgentToolMetadata } from "../../agent-tool-metadata.js";
+import { finalizeAgentTools } from "../../agent-tools.finalize.js";
+import type { AnyAgentTool } from "../../agent-tools.types.js";
+import {
+  createAdmittedGatewayToolCallerIdentity,
+  withGatewayToolCallerIdentity,
+} from "../../tools/gateway-caller-context.js";
+import { createSessionsSpawnTool } from "../../tools/sessions-spawn-tool.js";
+import { subagentRuns } from "../registry/subagent-registry-memory.js";
+import {
+  settleSubagentRegistryPersistenceWork,
+  writeSubagentSessionEntry,
+} from "../registry/subagent-registry.persistence.test-support.js";
+import {
+  resetSubagentRegistryForTests,
+  testing as registryTesting,
+} from "../registry/subagent-registry.test-helpers.js";
+import * as acpSpawnRuntime from "./acp-spawn-runtime.js";
+import { setSubagentSpawnDepsForTest } from "./subagent-spawn-deps.js";
+
+const parentSessionKey = "agent:main:main";
+const parentRunId = "acp-spawn-parent";
+const backendId = "spawn-authority-fixture";
+const env = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_CONFIG_PATH"]);
+let stateDir = "";
+
+beforeAll(async () => {
+  // Prepare the real cleanup graph before the RPC deadline starts; source
+  // transformation is not part of the running Gateway's cleanup budget.
+  await Promise.all([
+    import("../../../gateway/server-methods/sessions-delete.js"),
+    import("../../../gateway/server-methods/sessions.runtime.js"),
+    import("../../embedded-agent.js"),
+    import("../../agent-bundle-mcp-tools.js"),
+    import("../../bash-process-registry.js"),
+  ]);
+});
+
+beforeEach(async () => {
+  stateDir = await realpath(await mkdtemp(path.join(os.tmpdir(), "openclaw-acp-authority-")));
+  setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+  setTestEnvValue("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
+  await writeFile(
+    path.join(stateDir, "openclaw.json"),
+    JSON.stringify({
+      logging: { audit: { enabled: false } },
+      acp: { enabled: true, backend: backendId, allowedAgents: ["fixture"] },
+      agents: {
+        ownership: "explicit",
+        defaults: { workspace: stateDir },
+        entries: { main: { workspace: stateDir }, fixture: { workspace: stateDir } },
+      },
+    }),
+  );
+  clearConfigCache();
+  clearRuntimeConfigSnapshot();
+  managerTesting.resetAcpSessionManagerForTests();
+  resetSubagentRegistryForTests({ persist: false });
+  resetTaskRegistryForTests({ persist: false });
+  registryTesting.setDepsForTest({
+    loadAgentRuntimePluginRegistryHandle: () => undefined,
+    callGateway: async (request) => {
+      if (request.method !== "agent.wait") {
+        throw new Error(`Unexpected registry RPC ${request.method}`);
+      }
+      return await new Promise<never>(() => {});
+    },
+  });
+});
+
+afterEach(async () => {
+  try {
+    await disposeAcpSessionManagerInstance(getAcpSessionManager(), "test-cleanup");
+    managerTesting.resetAcpSessionManagerForTests();
+    unregisterAcpRuntimeBackend(backendId);
+    await settleSubagentRegistryPersistenceWork();
+    resetSubagentRegistryForTests({ persist: false });
+    resetTaskRegistryForTests({ persist: false });
+    await cleanupSessionStateForTest({ stateDir });
+  } finally {
+    registryTesting.setDepsForTest();
+    setSubagentSpawnDepsForTest();
+    vi.restoreAllMocks();
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+    try {
+      await flushLogger();
+      resetLogger();
+    } finally {
+      env.restore();
+    }
+  }
+  await rm(stateDir, { recursive: true, force: true });
+});
+
+describe("pending ACP spawn authority", () => {
+  it.each([
+    ["runtime", "abort"],
+    ["runtime", "admission close"],
+    ["runtime", "live"],
+    ["row", "admission close"],
+    ["transcript", "admission close"],
+    ["thread", "admission close"],
+    ["thread", "live"],
+    ["actor", "admission close"],
+    ["metadata", "admission close"],
+    ["initialized", "admission close"],
+  ] as const)(
+    "transfers initialized ACP work only from its live parent: %s / %s",
+    async (stage, closure) => {
+      const cfg = getRuntimeConfig();
+      await writeSubagentSessionEntry({
+        stateDir,
+        agentId: "main",
+        sessionKey: parentSessionKey,
+        defaultSessionId: "parent-session",
+      });
+      const context = withLocalGatewayRequestScope(
+        { deps: {} as CliDeps, getRuntimeConfig: () => cfg },
+        () => getPluginRuntimeGatewayRequestScope()!.context!,
+      );
+      const work = new AsyncWorkScope();
+      const trackExecution = context.trackExecution;
+      context.trackExecution = (run) => work.track(() => trackExecution(run));
+      const admission = prepareAgentRunAdmission({
+        cfg,
+        operationalRunInstance: createOperationalRunInstanceRef(parentRunId),
+        facts: {
+          runId: parentRunId,
+          agentId: "main",
+          ingress: { kind: "system", boundary: "acp-authority-test", state: "present" },
+        },
+      });
+      const parent = registerChatAbortController({
+        chatAbortControllers: context.chatAbortControllers,
+        runId: parentRunId,
+        sessionKey: parentSessionKey,
+        sessionId: "parent-session",
+        agentId: "main",
+        ownerConnId: "owner-connection",
+        timeoutMs: 60_000,
+        operationalRunInstance: admission.operationalRunInstance,
+      });
+      const admitted = await admission.admit("embedded");
+      bindGatewayContextResolver(admitted, () => context);
+      parent.bindAgentRunDelegatedAuthority(getAdmittedRunDelegatedAuthority(admitted)!);
+      expect(admitted.executionIdentityToken).toBeUndefined();
+      const entered = createDeferred<string>();
+      const release = createDeferred();
+      const pause = async (sessionKey: string) => {
+        entered.resolve(sessionKey);
+        await release.promise;
+      };
+      let childKey: string | undefined;
+      const upsert = sessionAccessor.upsertSessionEntryCore;
+      vi.spyOn(sessionAccessor, "upsertSessionEntryCore").mockImplementation(async (...args) => {
+        const entry = await upsert(...args);
+        childKey = args[0].sessionKey;
+        if (stage === "row") {
+          await pause(childKey);
+        }
+        return entry;
+      });
+      if (stage === "transcript") {
+        const resolve = sessionAccessor.resolveSessionTranscriptRuntimeTarget;
+        vi.spyOn(sessionAccessor, "resolveSessionTranscriptRuntimeTarget").mockImplementation(
+          async (...args) => {
+            const target = await resolve(...args);
+            await pause(target.sessionKey);
+            return target;
+          },
+        );
+      } else if (stage === "actor") {
+        const run = vi.spyOn(SessionActorQueue.prototype, "run");
+        run.mockImplementationOnce(function (this: SessionActorQueue, key, op) {
+          run.mockRestore();
+          return this.run(key, async () => {
+            if (!childKey) {
+              throw new Error("ACP actor started before its child entry existed");
+            }
+            await pause(childKey);
+            return await op();
+          });
+        });
+      } else if (stage === "initialized" || stage === "metadata") {
+        const initialize = acpSpawnRuntime.initializeAcpSpawnRuntime;
+        vi.spyOn(acpSpawnRuntime, "initializeAcpSpawnRuntime").mockImplementationOnce(
+          async (params) => {
+            const initialized = await initialize(params);
+            if (stage === "initialized") {
+              await pause(params.sessionKey);
+            } else if (!getAdmittedRunDelegatedAuthority(admitted)) {
+              lateMetadata(initialized.initialized.meta);
+            }
+            return initialized;
+          },
+        );
+      }
+      const lateMetadata = vi.fn();
+      if (stage === "metadata") {
+        const patch = sessionAccessor.patchSessionEntryWithKey;
+        let held = false;
+        vi.spyOn(sessionAccessor, "patchSessionEntryWithKey").mockImplementation(
+          async (...args) => {
+            const patched = await patch(...args);
+            if (!held && ensuredSessions.length > 0 && childKey) {
+              held = true;
+              await pause(childKey);
+            }
+            return patched;
+          },
+        );
+      }
+      const bindThread = vi.fn<NonNullable<SessionBindingAdapter["bind"]>>(async (input) => ({
+        bindingId: "default:child-thread",
+        targetSessionKey: input.targetSessionKey,
+        targetKind: "session",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: "child-thread",
+          parentConversationId: "parent-channel",
+        },
+        status: "active",
+        boundAt: Date.now(),
+        metadata: input.metadata,
+      }));
+      const bindingAdapter: SessionBindingAdapter = {
+        channel: "discord",
+        accountId: "default",
+        capabilities: { placements: ["child"], bindSupported: true, unbindSupported: true },
+        bind: bindThread,
+        listBySession: () => [],
+        resolveByConversation: () => null,
+        unbind: async () => [],
+      };
+      if (stage === "thread") {
+        registerSessionBindingAdapter(bindingAdapter);
+      }
+      const pausesRuntime = stage === "runtime" || stage === "thread";
+      const initializesRuntime = pausesRuntime || stage === "metadata" || stage === "initialized";
+      const ensuredSessions: string[] = [];
+      const closeRuntime = vi.fn(async () => {});
+      const runtime: AcpRuntime = {
+        ownerAwareSessions: 1,
+        async ensureSession(input) {
+          ensuredSessions.push(input.sessionKey);
+          if (pausesRuntime) {
+            await pause(input.sessionKey);
+          }
+          return {
+            sessionKey: input.sessionKey,
+            agentId: input.agentId,
+            backend: backendId,
+            runtimeSessionName: input.sessionKey,
+            backendSessionId: `fixture:${input.sessionKey}`,
+          };
+        },
+        runTurn() {
+          throw new Error("No external harness turn belongs in this boundary test");
+        },
+        async cancel() {},
+        close: closeRuntime,
+      };
+      registerAcpRuntimeBackend({ id: backendId, runtime });
+      const dispatch = vi.fn();
+      setSubagentSpawnDepsForTest({
+        dispatchGatewayMethodInProcess: async <T>(
+          method: string,
+          params: Record<string, unknown>,
+        ) => {
+          if (method !== "agent") {
+            throw new Error(`Unexpected spawn RPC ${method}`);
+          }
+          dispatch(params);
+          return { runId: params.idempotencyKey, status: "accepted" } as T;
+        },
+      });
+      const socket = vi
+        .spyOn(gatewayCall, "callGateway")
+        .mockRejectedValue(new Error("Raw WebSocket transport is unavailable"));
+      const source = createSessionsSpawnTool({
+        config: cfg,
+        agentSessionKey: parentSessionKey,
+        requesterRunId: parentRunId,
+        requesterTurnRunId: parentRunId,
+        ...(stage === "thread"
+          ? {
+              agentChannel: "discord",
+              agentAccountId: "default",
+              agentTo: "channel:parent-channel",
+            }
+          : {}),
+      });
+      let forwarded: Promise<unknown> | undefined;
+      const observed: AnyAgentTool = copyAgentToolMetadata(source, {
+        ...source,
+        execute: (...args) => {
+          const pending = source.execute!(...args);
+          forwarded = pending.then(
+            (result) => result,
+            (error: unknown) => error,
+          );
+          return pending;
+        },
+      });
+      const [tool] = finalizeAgentTools({
+        tools: [observed],
+        hookContext: {
+          config: cfg,
+          agentId: "main",
+          sessionKey: parentSessionKey,
+          runId: parentRunId,
+        },
+        abortSignal: parent.controller.signal,
+      });
+      const wrapped = withPluginRuntimeGatewayRequestScope(
+        { context, isWebchatConnect: () => false },
+        () =>
+          withGatewayToolCallerIdentity(
+            createAdmittedGatewayToolCallerIdentity({
+              admittedRunContext: admitted,
+              agentId: "main",
+              sessionKey: parentSessionKey,
+            }),
+            () =>
+              tool!.execute!("pending-acp", {
+                task: "bounded child",
+                runtime: "acp",
+                agentId: "fixture",
+                mode: "run",
+                expectsCompletionMessage: false,
+                ...(stage === "thread" ? { thread: true } : {}),
+              }),
+          ),
+      );
+      const wrappedOutcome = wrapped.then(
+        (result) => result,
+        (error: unknown) => error,
+      );
+      try {
+        const childSessionKey = await Promise.race([
+          entered.promise,
+          wrapped.then(() => {
+            throw new Error("ACP spawn settled before runtime initialization");
+          }),
+        ]);
+        expect(subagentRuns.size).toBe(0);
+        expect(loadSessionEntry({ sessionKey: childSessionKey, agentId: "fixture" })).toBeDefined();
+        if (closure === "abort") {
+          const reply = vi.fn();
+          const request = { sessionKey: parentSessionKey, runId: parentRunId };
+          await handleChatAbortRequest({
+            req: { type: "req", id: "abort-parent", method: "chat.abort", params: request },
+            params: request,
+            context,
+            respond: reply,
+            client: { ...createSyntheticPluginRuntimeClient(), connId: "owner-connection" },
+            isWebchatConnect: () => false,
+          });
+          expect(reply).toHaveBeenCalledWith(true, {
+            ok: true,
+            aborted: true,
+            runIds: [parentRunId],
+          });
+          expect(await wrappedOutcome).toBeInstanceOf(Error);
+        } else if (closure === "admission close") {
+          admission.close();
+          expect(parent.controller.signal.aborted).toBe(false);
+        }
+        expect(getAdmittedRunDelegatedAuthority(admitted) !== undefined).toBe(closure === "live");
+        release.resolve();
+        const result = await forwarded;
+        const sourceBoundary = {
+          entry: loadSessionEntry({ sessionKey: childSessionKey, agentId: "fixture" }),
+          closes: closeRuntime.mock.calls.length,
+        };
+        await wrappedOutcome;
+        await work.drain();
+        expect
+          .soft(lateMetadata, "closed parent must not publish ACP metadata after async planning")
+          .not.toHaveBeenCalled();
+        expect
+          .soft(
+            ensuredSessions,
+            "only live initialization may ensure once; cleanup must not reopen",
+          )
+          .toEqual(initializesRuntime ? [childSessionKey] : []);
+        expect
+          .soft(bindThread, "a closed parent must not create an external thread")
+          .toHaveBeenCalledTimes(stage === "thread" && closure === "live" ? 1 : 0);
+        if (closure === "live") {
+          expect(result).toMatchObject({ details: { status: "accepted", childSessionKey } });
+          expect(dispatch).toHaveBeenCalledOnce();
+          expect(subagentRuns.size).toBe(1);
+          expect(closeRuntime).not.toHaveBeenCalled();
+        } else {
+          expect
+            .soft(dispatch, "closed parent must never dispatch new ACP work")
+            .not.toHaveBeenCalled();
+          expect.soft(subagentRuns.size, "closed parent must never register runnable work").toBe(0);
+          expect.soft(socket).not.toHaveBeenCalled();
+          expect
+            .soft(sourceBoundary.entry, "cleanup completes before spawn returns")
+            .toBeUndefined();
+          expect
+            .soft(sourceBoundary.closes, "runtime closes before spawn returns")
+            .toBe(initializesRuntime ? 1 : 0);
+          expect
+            .soft(loadSessionEntry({ sessionKey: childSessionKey, agentId: "fixture" }))
+            .toBeUndefined();
+          expect
+            .soft(closeRuntime, "cleanup only disposes the runtime this spawn created")
+            .toHaveBeenCalledTimes(initializesRuntime ? 1 : 0);
+          expect.soft(result).toMatchObject({ details: { status: "error" } });
+        }
+      } finally {
+        release.resolve();
+        await forwarded;
+        await wrappedOutcome;
+        admission.close();
+        parent.cleanup();
+        await work.drain();
+        if (stage === "thread") {
+          unregisterSessionBindingAdapter({
+            channel: "discord",
+            accountId: "default",
+            adapter: bindingAdapter,
+          });
+        }
+      }
+    },
+  );
+});

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -90,6 +90,7 @@ const hoisted = vi.hoisted(() => {
     return normalized || null;
   });
   const cleanupFailedAcpSpawnMock = vi.fn();
+  const closeRuntimeOnFailureMock = vi.fn();
   const registerSubagentRunMock = vi.fn();
   const countActiveRunsForSessionMock = vi.fn();
   const getSubagentRunByChildSessionKeyMock = vi.fn();
@@ -182,6 +183,7 @@ const hoisted = vi.hoisted(() => {
     areHeartbeatsEnabledMock,
     normalizeChannelIdMock,
     cleanupFailedAcpSpawnMock,
+    closeRuntimeOnFailureMock,
     registerSubagentRunMock,
     countActiveRunsForSessionMock,
     getSubagentRunByChildSessionKeyMock,
@@ -710,6 +712,7 @@ describe("spawnAcpDirect", () => {
     replaceSpawnConfig(createDefaultSpawnConfig());
     hoisted.areHeartbeatsEnabledMock.mockReset().mockReturnValue(true);
     hoisted.cleanupFailedAcpSpawnMock.mockReset().mockResolvedValue(undefined);
+    hoisted.closeRuntimeOnFailureMock.mockReset().mockResolvedValue(undefined);
     hoisted.registerSubagentRunMock.mockReset();
     hoisted.countActiveRunsForSessionMock.mockReset().mockReturnValue(0);
     hoisted.getSubagentRunByChildSessionKeyMock.mockReset().mockReturnValue(null);
@@ -751,6 +754,7 @@ describe("spawnAcpDirect", () => {
       const runtimeSessionName = `${args.sessionKey}:runtime`;
       const cwd = typeof args.cwd === "string" ? args.cwd : undefined;
       return {
+        closeRuntimeOnFailure: hoisted.closeRuntimeOnFailureMock,
         runtime: {
           close: vi.fn().mockResolvedValue(undefined),
         },
@@ -3807,11 +3811,8 @@ describe("spawnAcpDirect", () => {
     expect(relayHandle.notifyStarted).not.toHaveBeenCalled();
     expect(hoisted.cleanupFailedAcpSpawnMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        runtimeCloseHandle: expect.objectContaining({
-          handle: expect.objectContaining({
-            backend: "acpx",
-          }),
-        }),
+        sessionEntry: expect.objectContaining({ sessionId: expect.any(String) }),
+        closeRuntimeOnFailure: hoisted.closeRuntimeOnFailureMock,
       }),
     );
   });

--- a/src/agents/subagents/spawn/acp-spawn.ts
+++ b/src/agents/subagents/spawn/acp-spawn.ts
@@ -2,7 +2,6 @@
 import crypto from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { AcpTurnAttachment } from "../../../acp/control-plane/manager.types.js";
-import type { AcpSpawnRuntimeCloseHandle } from "../../../acp/control-plane/spawn.js";
 import { cleanupFailedAcpSpawn } from "../../../acp/control-plane/spawn.js";
 import { isAcpEnabledByPolicy, resolveAcpAgentPolicyError } from "../../../acp/policy.js";
 import { isExecutionIdentityCollectionEnabled } from "../../../audit/audit-config.js";
@@ -122,6 +121,7 @@ type SpawnAcpParams = {
 };
 
 type SpawnAcpContext = {
+  assertActive?: () => void;
   agentSessionKey?: string;
   requesterTurnRunId?: string;
   completionOwnerKey?: string;
@@ -393,9 +393,8 @@ export async function spawnAcpDirect(
     preparedBinding = prepared.binding;
   }
 
-  let sessionCreated = false;
   let childCreationEntry: SessionEntry | undefined;
-  let initializedRuntime: AcpSpawnRuntimeCloseHandle | undefined;
+  let closeRuntimeOnFailure: (() => Promise<void>) | undefined;
   const childIdem = crypto.randomUUID();
   const parentAgentId = parentSessionKey
     ? resolveAgentIdFromSessionKey(parentSessionKey, requesterAgentId)
@@ -470,9 +469,10 @@ export async function spawnAcpDirect(
             ...inheritedToolDenyPatch(ctx.inheritedToolDenylist),
             ...(params.label ? { label: params.label } : {}),
           },
+          { assertCommitAllowed: ctx.assertActive },
         )) ?? undefined;
-      sessionCreated = true;
       const initializedSession = await initializeAcpSpawnRuntime({
+        assertActive: ctx.assertActive,
         cfg,
         sessionKey,
         targetAgentId,
@@ -483,10 +483,12 @@ export async function spawnAcpDirect(
         modelExplicit: runtimeOptionsResult.modelExplicit,
         cwd: runtimeCwd,
       });
-      initializedRuntime = initializedSession.runtimeCloseHandle;
+      closeRuntimeOnFailure = initializedSession.initialized.closeRuntimeOnFailure;
+      ctx.assertActive?.();
       const binding = preparedBinding
         ? (
             await bindPreparedAcpThread({
+              assertActive: ctx.assertActive,
               cfg,
               sessionKey,
               targetAgentId,
@@ -539,6 +541,7 @@ export async function spawnAcpDirect(
           : undefined;
       state.parentRelay = startParentRelay(childIdem);
       const response = await launchAcpChildThroughGateway({
+        assertDispatchCurrent: ctx.assertActive,
         task: params.task,
         sessionKey,
         deliveryPlan: state.deliveryPlan,
@@ -578,9 +581,9 @@ export async function spawnAcpDirect(
         cfg,
         sessionKey,
         agentId: targetAgentId,
-        shouldDeleteSession: sessionCreated,
+        sessionEntry: childCreationEntry,
         deleteTranscript: true,
-        runtimeCloseHandle: initializedRuntime,
+        closeRuntimeOnFailure,
       });
     },
   };
@@ -598,6 +601,7 @@ export async function spawnAcpDirect(
   let expectsCompletionMessage = false;
   const pipelineResult = await runSpawnPipeline({
     adapter,
+    assertActive: ctx.assertActive,
     admissionReservation,
     hookRunner: getGlobalHookRunner(),
     progressOrigin,

--- a/src/agents/subagents/spawn/subagent-attachments.ts
+++ b/src/agents/subagents/spawn/subagent-attachments.ts
@@ -314,6 +314,7 @@ export function resolveAcpSessionsSpawnImageAttachments(params: {
 }
 
 export async function materializeSubagentAttachments(params: {
+  assertActive?: () => void;
   config: OpenClawConfig;
   targetAgentId: string;
   workspaceDir?: string;
@@ -346,7 +347,11 @@ export async function materializeSubagentAttachments(params: {
       relDir,
       prepared.attachments.map((attachment) => attachment.name),
     );
+    // Keep cancellation inside staging so an awaited operation cannot start
+    // the next write after closure or leave its directory outside cleanup.
+    params.assertActive?.();
     await fs.mkdir(absDir, { recursive: true, mode: 0o700 });
+    params.assertActive?.();
     const store = privateFileStore(absDir);
 
     const files: SubagentAttachmentReceiptFile[] = [];
@@ -365,6 +370,7 @@ export async function materializeSubagentAttachments(params: {
       totalBytes: prepared.totalBytes,
       files,
     };
+    params.assertActive?.();
     await store.writeJson(".manifest.json", manifest, { trailingNewline: true });
 
     return {

--- a/src/agents/subagents/spawn/subagent-spawn-context.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-context.ts
@@ -27,6 +27,7 @@ type PreparedSpawnContext =
   | { status: "error"; error: string };
 
 export async function prepareSubagentSessionContext(params: {
+  assertActive?: () => void;
   cfg: OpenClawConfig;
   contextMode: SpawnSubagentContextMode;
   requesterAgentId: string;
@@ -56,6 +57,7 @@ export async function prepareSubagentSessionContext(params: {
     }
 
     const forkedResult = await getSubagentSpawnDeps().forkSessionEntryFromParent({
+      commitGuard: params.assertActive,
       storePath: childTarget.storePath,
       parentSessionKey: parentTarget.canonicalKey,
       parentStoreKeys: parentTarget.storeKeys,
@@ -101,6 +103,7 @@ export async function prepareSubagentSessionContext(params: {
 }
 
 export async function prepareContextEngineSubagentSpawn(params: {
+  assertActive?: () => void;
   cfg: OpenClawConfig;
   context: PreparedSpawnContext & { status: "ok" };
   requesterInternalKey: string;
@@ -113,6 +116,9 @@ export async function prepareContextEngineSubagentSpawn(params: {
     const deps = getSubagentSpawnDeps();
     deps.ensureContextEnginesInitialized();
     const engine = await deps.resolveContextEngine(params.cfg);
+    // Resolution may outlive the caller. Returned preparation must still reach
+    // the pipeline rollback owner before its next authority check.
+    params.assertActive?.();
     const preparation = await engine.prepareSubagentSpawn?.({
       parentSessionKey: params.requesterInternalKey,
       childSessionKey: params.childSessionKey,

--- a/src/agents/subagents/spawn/subagent-spawn-gateway.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-gateway.ts
@@ -92,6 +92,7 @@ async function callSubagentGatewayWithDispatchMode(
     const isChildRunLaunch = request.method === "agent";
     const forceSyntheticClient = isChildRunLaunch || scopes != null;
     const dispatch = async (workerIdentity?: WorkerTurnExecutionIdentity) => {
+      request.assertDispatchCurrent?.();
       const operationalRunInstance = gatewayCaller?.workerTurnClaim
         ? workerIdentity?.operationalRunInstance
         : gatewayCaller?.operationalRunInstance;
@@ -121,6 +122,7 @@ async function callSubagentGatewayWithDispatchMode(
         withInProcessAgentRuntimeIdentity(
           {
             expectFinal: request.expectFinal,
+            sessionMutationCommitGuard: request.assertDispatchCurrent,
             ...(allowModelOverride ? { allowSyntheticModelOverride: true } : {}),
             ...(options?.agentRunTracking ? { agentRunTracking: options.agentRunTracking } : {}),
             ...(gatewayContextResolver ? { resolveGatewayContext: gatewayContextResolver } : {}),
@@ -150,8 +152,9 @@ async function callSubagentGatewayWithDispatchMode(
       : await dispatch();
     return { response, dispatchMode: "in_process" };
   }
-  const dispatchAgentRequest = (timeoutMs?: number | null) =>
-    sessionSpawnContext && gatewayCaller?.operationalRunInstance
+  const dispatchAgentRequest = (timeoutMs?: number | null) => {
+    request.assertDispatchCurrent?.();
+    return sessionSpawnContext && gatewayCaller?.operationalRunInstance
       ? runWithGatewaySessionSpawnContext(sessionSpawnContext, () =>
           runWithGatewaySessionSpawnParentExecutionIdentity(parentExecutionIdentityToken, () =>
             callGatewayTool(
@@ -162,11 +165,21 @@ async function callSubagentGatewayWithDispatchMode(
                 expectFinal: request.expectFinal,
                 scopes,
                 requireAgentRuntimeIdentity: true,
+                ...(request.assertDispatchCurrent
+                  ? {
+                      dispatchAuthority: {
+                        version: 2,
+                        kind: "source-bound",
+                        assertCurrent: request.assertDispatchCurrent,
+                      },
+                    }
+                  : {}),
               },
             ),
           ),
         )
       : deps.callGateway(typeof timeoutMs === "number" ? { ...request, timeoutMs } : request);
+  };
   // Only agent launches have an idempotency key backed by authoritative Gateway state.
   // Other methods must not repeat after a transport-ambiguous failure.
   const response =

--- a/src/agents/subagents/spawn/subagent-spawn-session-patch.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-session-patch.ts
@@ -235,33 +235,3 @@ export async function createInitialSubagentSession(params: {
     return { status: "error", error: `child session patch failed: ${message}` };
   }
 }
-
-export async function persistInitialChildSessionRuntimeModel(params: {
-  cfg: OpenClawConfig;
-  childSessionKey: string;
-  resolvedModel?: string;
-}): Promise<string | undefined> {
-  const { provider, model } = splitModelRef(params.resolvedModel);
-  if (!model) {
-    return undefined;
-  }
-  try {
-    const target = resolveGatewaySessionStoreTarget({
-      cfg: params.cfg,
-      key: params.childSessionKey,
-    });
-    await upsertSessionEntryCore(
-      {
-        storePath: target.storePath,
-        sessionKey: target.canonicalKey,
-      },
-      {
-        model,
-        ...(provider ? { modelProvider: provider } : {}),
-      },
-    );
-    return undefined;
-  } catch (err) {
-    return err instanceof Error ? err.message : typeof err === "string" ? err : "error";
-  }
-}

--- a/src/agents/subagents/spawn/subagent-spawn-thread-binding.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-thread-binding.ts
@@ -15,6 +15,7 @@ import { getSessionBindingService } from "./subagent-spawn.runtime.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 
 export async function bindThreadForSubagentSpawn(params: {
+  assertActive?: () => void;
   cfg: OpenClawConfig;
   childSessionKey: string;
   agentId: string;
@@ -53,6 +54,7 @@ export async function bindThreadForSubagentSpawn(params: {
   }
 
   try {
+    params.assertActive?.();
     const binding = await getSessionBindingService().bind({
       targetSessionKey: params.childSessionKey,
       targetKind: "subagent",

--- a/src/agents/subagents/spawn/subagent-spawn.authority.test-support.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.authority.test-support.ts
@@ -1,0 +1,305 @@
+// Shared isolated ownership fixtures and real preparation adapters for native authority tests.
+import { promises as fs } from "node:fs";
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, vi } from "vitest";
+import {
+  clearConfigCache,
+  clearRuntimeConfigSnapshot,
+  getRuntimeConfig,
+} from "../../../config/config.js";
+import { registerChatAbortController } from "../../../gateway/chat-abort.js";
+import { createChatAbortContext } from "../../../gateway/server-methods/chat.abort.test-helpers.js";
+import type { GatewayRequestContext } from "../../../gateway/server-methods/types.js";
+import {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  type SessionBindingAdapter,
+  type SessionBindingRecord,
+} from "../../../infra/outbound/session-binding-service.js";
+import * as privateStores from "../../../infra/private-file-store.js";
+import { flushLogger, resetLogger } from "../../../logging/logger.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../../../plugins/runtime.js";
+import { bindGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
+import { resetTaskFlowRegistryForTests } from "../../../tasks/task-flow-registry.test-support.js";
+import * as taskControlRuntime from "../../../tasks/task-registry-control.runtime.js";
+import {
+  resetTaskRegistryForTests,
+  setTaskRegistryControlRuntimeForTests,
+  resetTaskRegistryControlRuntimeForTests,
+} from "../../../tasks/task-registry.test-support.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../../test-utils/channel-plugins.js";
+import { captureEnv, setTestEnvValue } from "../../../test-utils/env.js";
+import { cleanupSessionStateForTest } from "../../../test-utils/session-state-cleanup.js";
+import {
+  createOperationalRunInstanceRef,
+  getAdmittedRunDelegatedAuthority,
+  prepareAgentRunAdmission,
+} from "../../admitted-run-context.js";
+import {
+  settleSubagentRegistryPersistenceWork,
+  writeSubagentSessionEntry,
+} from "../registry/subagent-registry.persistence.test-support.js";
+import {
+  resetSubagentRegistryForTests,
+  testing as registryTesting,
+} from "../registry/subagent-registry.test-helpers.js";
+import { testing as schedulerTesting } from "../swarm/swarm-scheduler.test-support.js";
+import { testing as spawnTesting } from "./subagent-spawn.test-support.js";
+
+export function installSpawnThreadBindingFixture(
+  onBound?: (binding: SessionBindingRecord) => Promise<void>,
+) {
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "matrix",
+        source: "test",
+        plugin: {
+          ...createChannelTestPluginBase({ id: "matrix" }),
+          conversationBindings: { defaultTopLevelPlacement: "child" },
+        },
+      },
+    ]),
+  );
+  const bindings: SessionBindingRecord[] = [];
+  const bind = vi.fn<NonNullable<SessionBindingAdapter["bind"]>>(async (input) => {
+    const binding: SessionBindingRecord = {
+      bindingId: "synthetic-thread",
+      targetSessionKey: input.targetSessionKey,
+      targetKind: input.targetKind,
+      status: "active",
+      boundAt: Date.now(),
+      conversation: {
+        ...input.conversation,
+        conversationId: "child-thread",
+        parentConversationId: "parent",
+      },
+    };
+    bindings.push(binding);
+    await onBound?.(binding);
+    return binding;
+  });
+  const adapter: SessionBindingAdapter = {
+    channel: "matrix",
+    accountId: "default",
+    bind,
+    capabilities: { placements: ["child"] },
+    listBySession: (key) => bindings.filter((binding) => binding.targetSessionKey === key),
+    resolveByConversation: (ref) =>
+      bindings.find((binding) => binding.conversation.conversationId === ref.conversationId) ??
+      null,
+    unbind: async (input) => {
+      const removed = bindings.filter(
+        (binding) =>
+          input.targetSessionKey === binding.targetSessionKey ||
+          input.bindingId === binding.bindingId,
+      );
+      for (const binding of removed) {
+        bindings.splice(bindings.indexOf(binding), 1);
+      }
+      return removed;
+    },
+  };
+  registerSessionBindingAdapter(adapter);
+  return {
+    bind,
+    bindings,
+    unregister: () =>
+      unregisterSessionBindingAdapter({
+        channel: adapter.channel,
+        accountId: adapter.accountId,
+        adapter,
+      }),
+  };
+}
+
+export function installSpawnAttachmentFixture(params: {
+  stateDir: string;
+  admitted: Parameters<typeof getAdmittedRunDelegatedAuthority>[0];
+  pauseAt?: "directory" | "files";
+  entered: () => void;
+  release: Promise<void>;
+}) {
+  const root = path.join(params.stateDir, ".openclaw", "attachments");
+  const lateWrites: string[] = [];
+  const attachmentDirs: string[] = [];
+  const mkdir = fs.mkdir;
+  const mkdirSpy = vi.spyOn(fs, "mkdir").mockImplementation(async (...args) => {
+    const result = await mkdir(...args);
+    if (typeof args[0] === "string" && path.dirname(args[0]) === root) {
+      attachmentDirs.push(args[0]);
+      if (!getAdmittedRunDelegatedAuthority(params.admitted)) {
+        lateWrites.push("directory");
+      }
+      if (params.pauseAt === "directory") {
+        params.entered();
+        await params.release;
+      }
+    }
+    return result;
+  });
+  const createStore = privateStores.privateFileStore;
+  const storeSpy = vi.spyOn(privateStores, "privateFileStore").mockImplementation((rootDir) => {
+    const store = createStore(rootDir);
+    if (path.dirname(rootDir) !== root) {
+      return store;
+    }
+    return {
+      ...store,
+      writeText: async (...args) => {
+        if (!getAdmittedRunDelegatedAuthority(params.admitted)) {
+          lateWrites.push("content");
+        }
+        const result = await store.writeText(...args);
+        expect(await fs.readFile(path.join(rootDir, args[0]), "utf8")).toBe("synthetic attachment");
+        if (params.pauseAt === "files") {
+          params.entered();
+          await params.release;
+        }
+        return result;
+      },
+      writeJson: async (...args) => {
+        if (!getAdmittedRunDelegatedAuthority(params.admitted)) {
+          lateWrites.push("manifest");
+        }
+        return await store.writeJson(...args);
+      },
+    };
+  });
+  return {
+    lateWrites,
+    attachmentDirs,
+    restore: () => {
+      mkdirSpy.mockRestore();
+      storeSpy.mockRestore();
+    },
+  };
+}
+
+export function installSpawnAuthorityFixture() {
+  const parentSessionKey = "agent:main:main";
+  const parentRunId = "pending-spawn-parent";
+  const groupId = "pending-spawn";
+  const env = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_CONFIG_PATH"]);
+  let stateDir = "";
+  let pluginSnapshot: ReturnType<typeof captureActivePluginRegistrySnapshot>;
+
+  beforeEach(async () => {
+    pluginSnapshot = captureActivePluginRegistrySnapshot();
+    stateDir = await realpath(await mkdtemp(path.join(os.tmpdir(), "openclaw-spawn-authority-")));
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
+    await writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        logging: { audit: { enabled: false } },
+        tools: {
+          swarm: { enabled: true, maxConcurrent: 1 },
+          sessions_spawn: { attachments: { enabled: true } },
+        },
+        agents: {
+          defaults: { workspace: stateDir, model: { primary: "openai/gpt-5.4" } },
+          entries: { main: { workspace: stateDir } },
+        },
+      }),
+    );
+    clearConfigCache();
+    clearRuntimeConfigSnapshot();
+    resetSubagentRegistryForTests({ persist: false });
+    resetTaskRegistryForTests({ persist: false });
+    resetTaskFlowRegistryForTests({ persist: false });
+    // The source test supplies the real ESM owner through the existing CJS runtime seam.
+    setTaskRegistryControlRuntimeForTests(taskControlRuntime);
+    registryTesting.setDepsForTest({
+      loadAgentRuntimePluginRegistryHandle: () => undefined,
+      callGateway: async (request) => {
+        if (request.method !== "agent.wait") {
+          throw new Error(`Unexpected registry RPC ${request.method}`);
+        }
+        return await new Promise<never>(() => {});
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await settleSubagentRegistryPersistenceWork();
+    resetSubagentRegistryForTests({ persist: false });
+    resetTaskRegistryForTests({ persist: false });
+    resetTaskFlowRegistryForTests({ persist: false });
+    schedulerTesting.reset();
+    resetTaskRegistryControlRuntimeForTests();
+    await cleanupSessionStateForTest({ stateDir });
+    registryTesting.setDepsForTest();
+    spawnTesting.setDepsForTest();
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+    await flushLogger();
+    resetLogger();
+    await rm(stateDir, { recursive: true, force: true });
+    restoreActivePluginRegistrySnapshot(pluginSnapshot);
+    env.restore();
+  });
+
+  async function createBoundParent(runtime: "embedded" | "plugin-harness" = "embedded") {
+    const cfg = getRuntimeConfig();
+    const storePath = await writeSubagentSessionEntry({
+      stateDir,
+      agentId: "main",
+      sessionKey: parentSessionKey,
+      defaultSessionId: "parent-session",
+    });
+    const context = createChatAbortContext({
+      getRuntimeConfig: () => cfg,
+      getSessionEventSubscriberConnIds: () => new Set(),
+      broadcastToConnIds: vi.fn(),
+    });
+    const admission = prepareAgentRunAdmission({
+      cfg,
+      operationalRunInstance: createOperationalRunInstanceRef(parentRunId),
+      facts: {
+        runId: parentRunId,
+        agentId: "main",
+        ingress: { kind: "system", boundary: "spawn-authority-test", state: "present" },
+      },
+    });
+    const parent = registerChatAbortController({
+      chatAbortControllers: context.chatAbortControllers,
+      runId: parentRunId,
+      sessionKey: parentSessionKey,
+      sessionId: "parent-session",
+      agentId: "main",
+      ownerConnId: "owner-connection",
+      timeoutMs: 60_000,
+      operationalRunInstance: admission.operationalRunInstance,
+    });
+    const admitted = await admission.admit(runtime);
+    // Match agent-run-execution-phase: bind the admitted owner before tools run.
+    bindGatewayContextResolver(admitted, () => context as unknown as GatewayRequestContext);
+    const authority = getAdmittedRunDelegatedAuthority(admitted)!;
+    parent.bindAgentRunDelegatedAuthority(authority);
+    expect(parent.entry?.operationalRunInstance).toBe(admitted.operationalRunInstance);
+    expect(parent.entry?.agentRunDelegatedAuthority).toBe(authority);
+    expect(admitted.executionIdentityToken).toBeUndefined();
+
+    return { cfg, storePath, context, admission, parent, admitted, authority };
+  }
+
+  return {
+    parentSessionKey,
+    parentRunId,
+    groupId,
+    createBoundParent,
+    get stateDir() {
+      return stateDir;
+    },
+  };
+}

--- a/src/agents/subagents/spawn/subagent-spawn.authority.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.authority.test.ts
@@ -1,8 +1,7 @@
-/** Pending native spawn must transfer only live invocation authority to the child owner. */
-import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
+/** Registered native children retain their own lifecycle after spawn handoff. */
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import {
   clearConfigCache,
@@ -11,24 +10,14 @@ import {
 } from "../../../config/config.js";
 import { loadSessionEntry } from "../../../config/sessions/session-accessor.js";
 import { LegacyContextEngine } from "../../../context-engine/legacy.js";
-import { registerChatAbortController } from "../../../gateway/chat-abort.js";
 import { handleChatAbortRequest } from "../../../gateway/server-methods/chat-abort-handler.js";
-import {
-  createChatAbortContext,
-  invokeChatAbortHandler,
-} from "../../../gateway/server-methods/chat.abort.test-helpers.js";
-import { sessionDeleteHandlers } from "../../../gateway/server-methods/sessions-delete.js";
+import { invokeChatAbortHandler } from "../../../gateway/server-methods/chat.abort.test-helpers.js";
 import type { GatewayRequestContext } from "../../../gateway/server-methods/types.js";
-import { createSyntheticPluginRuntimeClient } from "../../../gateway/server-plugin-runtime-client.js";
 import { emitAgentEvent } from "../../../infra/agent-events.js";
 import {
-  claimAgentRunDelegatedAuthority,
   clearAgentRunContext,
   registerAgentRunContext,
-  releaseAgentRunDelegatedAuthority,
-  rotateAgentRunRegistryLifecycleGeneration,
 } from "../../../infra/agent-run-registry.js";
-import { flushLogger, resetLogger } from "../../../logging/logger.js";
 import {
   bindGatewayContextResolver,
   withPluginRuntimeGatewayRequestScope,
@@ -37,27 +26,16 @@ import {
   beginSessionWorkAdmission,
   consumeSessionWorkAdmissionHandoff,
 } from "../../../sessions/session-lifecycle-admission.js";
-import { resetTaskFlowRegistryForTests } from "../../../tasks/task-flow-registry.test-support.js";
-import * as taskControlRuntime from "../../../tasks/task-registry-control.runtime.js";
 import { cancelTaskById, findTaskByRunId, getTaskById } from "../../../tasks/task-registry.js";
 import { configureTaskRegistryRuntime } from "../../../tasks/task-registry.store.js";
-import {
-  resetTaskRegistryForTests,
-  setTaskRegistryControlRuntimeForTests,
-  resetTaskRegistryControlRuntimeForTests,
-} from "../../../tasks/task-registry.test-support.js";
-import { captureEnv, setTestEnvValue } from "../../../test-utils/env.js";
-import { cleanupSessionStateForTest } from "../../../test-utils/session-state-cleanup.js";
 import {
   createOperationalRunInstanceRef,
   getAdmittedRunDelegatedAuthority,
   prepareAgentRunAdmission,
 } from "../../admitted-run-context.js";
-import { finalizeAgentToolAvailability } from "../../agent-tool-availability.js";
 import { copyAgentToolMetadata } from "../../agent-tool-metadata.js";
 import { finalizeAgentTools } from "../../agent-tools.finalize.js";
 import type { AnyAgentTool } from "../../agent-tools.types.js";
-import { createAgentHarnessHostCapabilities } from "../../harness/host-capability.js";
 import { createAgentsWaitTool } from "../../tools/agents-wait-tool.js";
 import {
   createAdmittedGatewayToolCallerIdentity,
@@ -70,112 +48,13 @@ import {
   settleSubagentRegistryPersistenceWork,
   writeSubagentSessionEntry,
 } from "../registry/subagent-registry.persistence.test-support.js";
-import {
-  resetSubagentRegistryForTests,
-  testing as registryTesting,
-} from "../registry/subagent-registry.test-helpers.js";
 import { enqueueSwarmRun, releaseSwarmRun } from "../swarm/swarm-scheduler.js";
-import { testing as schedulerTesting } from "../swarm/swarm-scheduler.test-support.js";
+import { installSpawnAuthorityFixture } from "./subagent-spawn.authority.test-support.js";
 import { spawnSubagentDirect } from "./subagent-spawn.js";
 import { testing as spawnTesting } from "./subagent-spawn.test-support.js";
 
-const parentSessionKey = "agent:main:main";
-const parentRunId = "pending-spawn-parent";
-const groupId = "pending-spawn";
-const env = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_CONFIG_PATH"]);
-let stateDir = "";
-
-beforeEach(async () => {
-  stateDir = await realpath(await mkdtemp(path.join(os.tmpdir(), "openclaw-spawn-authority-")));
-  setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
-  setTestEnvValue("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
-  await writeFile(
-    path.join(stateDir, "openclaw.json"),
-    JSON.stringify({
-      logging: { audit: { enabled: false } },
-      tools: { swarm: { enabled: true, maxConcurrent: 1 } },
-      agents: { defaults: { workspace: stateDir }, entries: { main: { workspace: stateDir } } },
-    }),
-  );
-  clearConfigCache();
-  clearRuntimeConfigSnapshot();
-  resetSubagentRegistryForTests({ persist: false });
-  resetTaskRegistryForTests({ persist: false });
-  resetTaskFlowRegistryForTests({ persist: false });
-  // The source test supplies the real ESM owner through the existing CJS runtime seam.
-  setTaskRegistryControlRuntimeForTests(taskControlRuntime);
-  registryTesting.setDepsForTest({
-    loadAgentRuntimePluginRegistryHandle: () => undefined,
-    callGateway: async (request) => {
-      if (request.method !== "agent.wait") {
-        throw new Error(`Unexpected registry RPC ${request.method}`);
-      }
-      return await new Promise<never>(() => {});
-    },
-  });
-});
-
-afterEach(async () => {
-  await settleSubagentRegistryPersistenceWork();
-  resetSubagentRegistryForTests({ persist: false });
-  resetTaskRegistryForTests({ persist: false });
-  resetTaskFlowRegistryForTests({ persist: false });
-  schedulerTesting.reset();
-  resetTaskRegistryControlRuntimeForTests();
-  await cleanupSessionStateForTest({ stateDir });
-  registryTesting.setDepsForTest();
-  spawnTesting.setDepsForTest();
-  clearRuntimeConfigSnapshot();
-  clearConfigCache();
-  await flushLogger();
-  resetLogger();
-  await rm(stateDir, { recursive: true, force: true });
-  env.restore();
-});
-
-async function createBoundParent(runtime: "embedded" | "plugin-harness" = "embedded") {
-  const cfg = getRuntimeConfig();
-  const storePath = await writeSubagentSessionEntry({
-    stateDir,
-    agentId: "main",
-    sessionKey: parentSessionKey,
-    defaultSessionId: "parent-session",
-  });
-  const context = createChatAbortContext({
-    getRuntimeConfig: () => cfg,
-    getSessionEventSubscriberConnIds: () => new Set(),
-    broadcastToConnIds: vi.fn(),
-  });
-  const admission = prepareAgentRunAdmission({
-    cfg,
-    operationalRunInstance: createOperationalRunInstanceRef(parentRunId),
-    facts: {
-      runId: parentRunId,
-      agentId: "main",
-      ingress: { kind: "system", boundary: "spawn-authority-test", state: "present" },
-    },
-  });
-  const parent = registerChatAbortController({
-    chatAbortControllers: context.chatAbortControllers,
-    runId: parentRunId,
-    sessionKey: parentSessionKey,
-    sessionId: "parent-session",
-    agentId: "main",
-    ownerConnId: "owner-connection",
-    timeoutMs: 60_000,
-    operationalRunInstance: admission.operationalRunInstance,
-  });
-  const admitted = await admission.admit(runtime);
-  // Match agent-run-execution-phase: bind the admitted owner before tools run.
-  bindGatewayContextResolver(admitted, () => context as unknown as GatewayRequestContext);
-  const authority = getAdmittedRunDelegatedAuthority(admitted)!;
-  parent.bindAgentRunDelegatedAuthority(authority);
-  expect(parent.entry?.operationalRunInstance).toBe(admitted.operationalRunInstance);
-  expect(parent.entry?.agentRunDelegatedAuthority).toBe(authority);
-  expect(admitted.executionIdentityToken).toBeUndefined();
-
-  return { cfg, storePath, context, admission, parent, admitted, authority };
-}
+const fixture = installSpawnAuthorityFixture();
+const { parentSessionKey, parentRunId, groupId, createBoundParent } = fixture;
 
 describe("pending spawn invocation authority", () => {
   it.each(["sibling", "nested sibling"] as const)(
@@ -183,7 +62,7 @@ describe("pending spawn invocation authority", () => {
     async (slowBranch) => {
       const originalConfig = getRuntimeConfig();
       await writeFile(
-        path.join(stateDir, "openclaw.json"),
+        path.join(fixture.stateDir, "openclaw.json"),
         JSON.stringify({
           ...originalConfig,
           agents: {
@@ -204,7 +83,7 @@ describe("pending spawn invocation authority", () => {
       const slowId = slowBranch === "sibling" ? "a" : "d";
       for (const id of ids) {
         await writeSubagentSessionEntry({
-          stateDir,
+          stateDir: fixture.stateDir,
           agentId: "main",
           sessionKey: key(id),
           defaultSessionId: `${id}-session`,
@@ -403,267 +282,6 @@ describe("pending spawn invocation authority", () => {
       }
     },
   );
-
-  it.each([
-    "native abort",
-    "native acceptance",
-    "native call signal",
-    "native construction signal",
-    "native claim loss",
-    "native replacement",
-    "native lifecycle rotation",
-    "native admission close",
-    "projected close",
-    "projected claim loss",
-  ])("rolls back an untransferred native spawn: %s", async (closure) => {
-    const { cfg, storePath, context, admission, parent, admitted, authority } =
-      await createBoundParent(closure.startsWith("projected") ? "plugin-harness" : "embedded");
-    const acceptedGate = createDeferred();
-    const acceptedEntered = createDeferred();
-    let childController: ReturnType<typeof registerChatAbortController> | undefined;
-    const entered = createDeferred<string>();
-    const release = createDeferred();
-    const rollback = vi.fn(async () => {});
-    const agentDispatch = vi.fn();
-    const deleted: string[] = [];
-    spawnTesting.setDepsForTest({
-      resolveContextEngine: async () =>
-        Object.assign(new LegacyContextEngine(), {
-          prepareSubagentSpawn: async ({ childSessionKey }: { childSessionKey: string }) => {
-            entered.resolve(childSessionKey);
-            await release.promise;
-            return { rollback };
-          },
-        }),
-      dispatchGatewayMethodInProcess: async <T>(
-        method: string,
-        params: Record<string, unknown>,
-      ) => {
-        if (method === "agent") {
-          agentDispatch(params);
-          if (closure === "native acceptance") {
-            const childSessionKey = params.sessionKey as string;
-            const child = loadSessionEntry({ storePath, sessionKey: childSessionKey })!;
-            childController = registerChatAbortController({
-              chatAbortControllers: context.chatAbortControllers,
-              runId: params.idempotencyKey as string,
-              sessionKey: childSessionKey,
-              sessionId: child.sessionId,
-              agentId: "main",
-              timeoutMs: 60_000,
-            });
-            acceptedEntered.resolve();
-            await acceptedGate.promise;
-          }
-          return { runId: params.idempotencyKey, status: "accepted" } as T;
-        }
-        if (method === "chat.abort") {
-          const respond = await invokeChatAbortHandler({
-            handler: handleChatAbortRequest,
-            context,
-            request: params as { sessionKey: string; runId: string },
-            client: createSyntheticPluginRuntimeClient(),
-          });
-          expect(respond).toHaveBeenCalledWith(
-            true,
-            expect.objectContaining({ aborted: true, runIds: [params.runId] }),
-          );
-          return respond.mock.calls[0]![1] as T;
-        }
-        if (method !== "sessions.delete") {
-          throw new Error(`Unexpected spawn RPC ${method}`);
-        }
-        let payload: unknown;
-        await sessionDeleteHandlers["sessions.delete"]!({
-          req: {} as never,
-          params,
-          context: context as unknown as GatewayRequestContext,
-          client: createSyntheticPluginRuntimeClient(),
-          isWebchatConnect: () => false,
-          respond: (ok, result, error) => {
-            if (!ok) {
-              throw new Error(error?.message ?? "delete failed");
-            }
-            payload = result;
-          },
-        });
-        deleted.push(params.key as string);
-        return payload as T;
-      },
-    });
-    const invocationAbort = new AbortController();
-    let replacementAuthority: ReturnType<typeof claimAgentRunDelegatedAuthority> | undefined;
-    const host = closure.startsWith("projected")
-      ? createAgentHarnessHostCapabilities({
-          attempt: {
-            admittedRunContext: admitted,
-            runId: parentRunId,
-            config: cfg,
-            agentId: "main",
-            sessionKey: parentSessionKey,
-            abortSignal: parent.controller.signal,
-          },
-          pluginId: "test-harness",
-        })
-      : undefined;
-    const source = createSessionsSpawnTool({
-      config: cfg,
-      agentSessionKey: parentSessionKey,
-      requesterRunId: parentRunId,
-      requesterTurnRunId: parentRunId,
-      signal: closure === "native construction signal" ? invocationAbort.signal : undefined,
-    });
-    let forwarded: Promise<unknown> | undefined;
-    const observed: AnyAgentTool = copyAgentToolMetadata(source, {
-      ...source,
-      execute: (...args) => {
-        const pending = source.execute!(...args);
-        // Observe, but still forward the real source promise through the native wrappers.
-        forwarded = pending.then(
-          (result) => result,
-          (error: unknown) => error,
-        );
-        return pending;
-      },
-    });
-    const wait = createAgentsWaitTool({
-      config: cfg,
-      agentSessionKey: parentSessionKey,
-      agentId: "main",
-    });
-    const tools = [observed, wait];
-    const [tool] = host
-      ? finalizeAgentToolAvailability(host.capabilities.bindToolSurface(tools))
-      : finalizeAgentTools({
-          tools,
-          hookContext: {
-            config: cfg,
-            agentId: "main",
-            sessionKey: parentSessionKey,
-            runId: parentRunId,
-          },
-          abortSignal: parent.controller.signal,
-        });
-    const caller = createAdmittedGatewayToolCallerIdentity({
-      admittedRunContext: admitted,
-      agentId: "main",
-      sessionKey: parentSessionKey,
-    });
-    const wrapped = withPluginRuntimeGatewayRequestScope(
-      { context: context as unknown as GatewayRequestContext, isWebchatConnect: () => false },
-      () =>
-        withGatewayToolCallerIdentity(caller, () =>
-          tool!.execute!(
-            "spawn-pending",
-            {
-              task: "bounded child",
-              collect: closure !== "native acceptance",
-              context: "isolated",
-              groupId: closure === "native acceptance" ? undefined : groupId,
-            },
-            closure === "native call signal" ? invocationAbort.signal : undefined,
-          ),
-        ),
-    );
-    const wrappedOutcome = wrapped.then(
-      (result) => result,
-      (error: unknown) => error,
-    );
-    try {
-      // A rejected spawn never enters preparation; report it instead of waiting for the test timeout.
-      const childSessionKey = await Promise.race([
-        entered.promise,
-        wrapped.then(() => {
-          throw new Error("Spawn settled before entering context preparation");
-        }),
-      ]);
-      expect(subagentRuns.size, "no ownership transfer before preparation resolves").toBe(0);
-      expect(loadSessionEntry({ storePath, sessionKey: childSessionKey })).toBeDefined();
-      if (closure === "native acceptance") {
-        release.resolve();
-        await acceptedEntered.promise;
-        expect(subagentRuns.size, "accepted local run still awaits source registration").toBe(0);
-        expect(childController?.controller.signal.aborted).toBe(false);
-      }
-      if (closure === "native abort" || closure === "native acceptance") {
-        const reply = await invokeChatAbortHandler({
-          handler: handleChatAbortRequest,
-          context,
-          request: { sessionKey: parentSessionKey, runId: parentRunId },
-          client: {
-            connId: "owner-connection",
-            connect: { scopes: ["operator.read", "operator.write"] },
-          },
-        });
-        expect(reply).toHaveBeenCalledWith(true, {
-          ok: true,
-          aborted: true,
-          runIds: [parentRunId],
-        });
-        expect(parent.controller.signal.aborted).toBe(true);
-        expect(getAdmittedRunDelegatedAuthority(admitted)).toBeUndefined();
-        expect(await wrappedOutcome).toBeInstanceOf(Error);
-      } else {
-        if (closure.endsWith("claim loss")) {
-          releaseAgentRunDelegatedAuthority(authority);
-        } else if (closure.endsWith("replacement")) {
-          replacementAuthority = claimAgentRunDelegatedAuthority(
-            createOperationalRunInstanceRef(parentRunId),
-          );
-        } else if (closure.endsWith("lifecycle rotation")) {
-          rotateAgentRunRegistryLifecycleGeneration();
-        } else if (closure === "projected close") {
-          host!.close();
-        } else if (closure.endsWith("signal")) {
-          invocationAbort.abort();
-        } else {
-          admission.close();
-        }
-        expect(
-          parent.controller.signal.aborted,
-          "claim/capability closure is independent of parent signal",
-        ).toBe(false);
-      }
-      release.resolve();
-      acceptedGate.resolve();
-      await forwarded;
-      if (closure === "native acceptance") {
-        expect(agentDispatch).toHaveBeenCalledOnce();
-        expect(
-          childController?.controller.signal.aborted,
-          "exact accepted local child aborted before deletion",
-        ).toBe(true);
-      } else {
-        expect(agentDispatch, "cancelled source never dispatches a child").not.toHaveBeenCalled();
-      }
-      expect(subagentRuns.size, "cancelled source never registers runnable work").toBe(0);
-      expect(rollback).toHaveBeenCalledOnce();
-      expect(deleted).toEqual([childSessionKey]);
-      expect(loadSessionEntry({ storePath, sessionKey: childSessionKey })).toBeUndefined();
-      const survivor = vi.fn(async () => {});
-      enqueueSwarmRun({
-        groupId: JSON.stringify(["main", parentSessionKey, groupId]),
-        runId: "surviving-reservation",
-        maxConcurrent: 1,
-        activeRunIds: [],
-        start: survivor,
-        onStartFailure: () => true,
-      });
-      await vi.waitFor(() => expect(survivor).toHaveBeenCalledOnce());
-    } finally {
-      release.resolve();
-      acceptedGate.resolve();
-      await forwarded;
-      childController?.cleanup();
-      await wrappedOutcome;
-      host?.close();
-      if (replacementAuthority) {
-        releaseAgentRunDelegatedAuthority(replacementAuthority);
-      }
-      admission.close();
-      parent.cleanup();
-    }
-  });
 
   it.each(["complete", "abort", "abort during registration"])(
     "preserves child ownership when the parent closes after registration: %s",

--- a/src/agents/subagents/spawn/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.model-session.test.ts
@@ -84,7 +84,6 @@ describe("spawnSubagentDirect runtime model persistence", () => {
     expect(result.modelApplied).toBe(true);
     expect(result.resolvedModel).toBe("openai/gpt-5.4");
     expect(result.resolvedProvider).toBe("openai");
-    expect(updateSessionStoreMock).toHaveBeenCalledTimes(2);
     expectPersistedRuntimeModel({
       persistedStore,
       sessionKey: /^agent:main:subagent:/,

--- a/src/agents/subagents/spawn/subagent-spawn.preparation-authority.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.preparation-authority.test.ts
@@ -1,0 +1,631 @@
+/** Pending native preparation must transfer only live invocation authority to the child owner. */
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { forkSessionEntryFromParent } from "../../../auto-reply/reply/session-fork.js";
+import {
+  listSessionChildEntriesReadOnly,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  replaceTranscriptEvents,
+} from "../../../config/sessions/session-accessor.js";
+import {
+  resolveSqliteStoreScope,
+  runExclusiveSqliteSessionWrite,
+} from "../../../config/sessions/session-accessor.sqlite-scope.js";
+import { LegacyContextEngine } from "../../../context-engine/legacy.js";
+import { registerChatAbortController } from "../../../gateway/chat-abort.js";
+import { handleChatAbortRequest } from "../../../gateway/server-methods/chat-abort-handler.js";
+import { invokeChatAbortHandler } from "../../../gateway/server-methods/chat.abort.test-helpers.js";
+import { sessionDeleteHandlers } from "../../../gateway/server-methods/sessions-delete.js";
+import type { GatewayRequestContext } from "../../../gateway/server-methods/types.js";
+import { createSyntheticPluginRuntimeClient } from "../../../gateway/server-plugin-runtime-client.js";
+import {
+  claimAgentRunDelegatedAuthority,
+  releaseAgentRunDelegatedAuthority,
+  rotateAgentRunRegistryLifecycleGeneration,
+} from "../../../infra/agent-run-registry.js";
+import { withPluginRuntimeGatewayRequestScope } from "../../../plugins/runtime/gateway-request-scope.js";
+import {
+  createOperationalRunInstanceRef,
+  getAdmittedRunDelegatedAuthority,
+} from "../../admitted-run-context.js";
+import { finalizeAgentToolAvailability } from "../../agent-tool-availability.js";
+import { copyAgentToolMetadata } from "../../agent-tool-metadata.js";
+import { finalizeAgentTools } from "../../agent-tools.finalize.js";
+import type { AnyAgentTool } from "../../agent-tools.types.js";
+import { createAgentHarnessHostCapabilities } from "../../harness/host-capability.js";
+import { createAgentsWaitTool } from "../../tools/agents-wait-tool.js";
+import {
+  createAdmittedGatewayToolCallerIdentity,
+  withGatewayToolCallerIdentity,
+} from "../../tools/gateway-caller-context.js";
+import { createSessionsSpawnTool } from "../../tools/sessions-spawn-tool.js";
+import { subagentRuns } from "../registry/subagent-registry-memory.js";
+import { enqueueSwarmRun } from "../swarm/swarm-scheduler.js";
+import {
+  installSpawnAuthorityFixture,
+  installSpawnThreadBindingFixture,
+  installSpawnAttachmentFixture,
+} from "./subagent-spawn.authority.test-support.js";
+import { testing as spawnTesting } from "./subagent-spawn.test-support.js";
+
+const fixture = installSpawnAuthorityFixture();
+const { parentSessionKey, parentRunId, groupId, createBoundParent } = fixture;
+
+describe("pending spawn preparation authority", () => {
+  it.each(["closed", "live"])(
+    "checks parent authority after queued fork preparation: %s",
+    async (closure) => {
+      const bindingFixture = installSpawnThreadBindingFixture();
+      const { cfg, storePath, context, admission, parent, admitted } = await createBoundParent();
+      await replaceTranscriptEvents(
+        { agentId: "main", sessionId: "parent-session", sessionKey: parentSessionKey, storePath },
+        [
+          {
+            type: "session",
+            version: 3,
+            id: "parent-session",
+            timestamp: "2026-09-05T00:00:00Z",
+            cwd: fixture.stateDir,
+          },
+          {
+            type: "message",
+            id: "parent-message",
+            parentId: null,
+            timestamp: "2026-09-05T00:00:01Z",
+            message: { role: "user", content: "synthetic parent context" },
+          },
+          {
+            type: "message",
+            id: "parent-answer",
+            parentId: "parent-message",
+            timestamp: "2026-09-05T00:00:02Z",
+            message: {
+              role: "assistant",
+              content: "synthetic completed reply",
+              stopReason: "stop",
+            },
+          },
+        ],
+      );
+      const writerEntered = createDeferred();
+      const releaseWriter = createDeferred();
+      const forkQueued = createDeferred<{ childSessionKey: string; initialSessionId: string }>();
+      const forkSettled = createDeferred<
+        Awaited<ReturnType<typeof forkSessionEntryFromParent>> | Error
+      >();
+      const inspected = createDeferred();
+      let blocker: Promise<void> | undefined;
+      const dispatch = vi.fn();
+      const deleted: string[] = [];
+      spawnTesting.setDepsForTest({
+        forkSessionEntryFromParent: async (params) => {
+          // Hold a genuine preceding database writer, then enqueue the real fork owner.
+          blocker = runExclusiveSqliteSessionWrite(resolveSqliteStoreScope(storePath), async () => {
+            writerEntered.resolve();
+            await releaseWriter.promise;
+          });
+          await writerEntered.promise;
+          const initial = loadSessionEntry({ storePath, sessionKey: params.sessionKey })!;
+          const pending = forkSessionEntryFromParent(params);
+          forkQueued.resolve({
+            childSessionKey: params.sessionKey,
+            initialSessionId: initial.sessionId,
+          });
+          try {
+            const result = await pending;
+            forkSettled.resolve(result);
+            await inspected.promise;
+            return result;
+          } catch (error) {
+            forkSettled.resolve(error instanceof Error ? error : new Error(String(error)));
+            await inspected.promise;
+            throw error;
+          }
+        },
+        resolveContextEngine: async () => new LegacyContextEngine(),
+        dispatchGatewayMethodInProcess: async <T>(
+          method: string,
+          params: Record<string, unknown>,
+        ) => {
+          if (method === "agent") {
+            dispatch(params);
+            return { runId: params.idempotencyKey, status: "accepted" } as T;
+          }
+          if (method !== "sessions.delete") {
+            throw new Error(`Unexpected spawn RPC ${method}`);
+          }
+          let payload: unknown;
+          await sessionDeleteHandlers["sessions.delete"]!({
+            req: {} as never,
+            params,
+            context: context as unknown as GatewayRequestContext,
+            client: createSyntheticPluginRuntimeClient(),
+            isWebchatConnect: () => false,
+            respond: (ok, result, error) => {
+              if (!ok) {
+                throw new Error(error?.message ?? "delete failed");
+              }
+              payload = result;
+            },
+          });
+          deleted.push(params.key as string);
+          return payload as T;
+        },
+      });
+      const [tool] = finalizeAgentTools({
+        tools: [
+          createSessionsSpawnTool({
+            config: cfg,
+            agentSessionKey: parentSessionKey,
+            requesterRunId: parentRunId,
+            requesterTurnRunId: parentRunId,
+            agentChannel: "matrix",
+            agentAccountId: "default",
+            agentTo: "room:parent",
+          }),
+        ],
+        hookContext: {
+          config: cfg,
+          agentId: "main",
+          sessionKey: parentSessionKey,
+          runId: parentRunId,
+        },
+        abortSignal: parent.controller.signal,
+      });
+      const pending = withPluginRuntimeGatewayRequestScope(
+        { context: context as unknown as GatewayRequestContext, isWebchatConnect: () => false },
+        () =>
+          withGatewayToolCallerIdentity(
+            createAdmittedGatewayToolCallerIdentity({
+              admittedRunContext: admitted,
+              agentId: "main",
+              sessionKey: parentSessionKey,
+            }),
+            () =>
+              tool!.execute!("spawn-fork-queued", {
+                task: "bounded fork",
+                context: "fork",
+                thread: true,
+                mode: "run",
+                attachments: [{ name: "synthetic.txt", content: "synthetic attachment" }],
+                expectsCompletionMessage: false,
+              }),
+          ),
+      ).then(
+        (value) => value,
+        (error: unknown) => error,
+      );
+      try {
+        const { childSessionKey, initialSessionId } = await Promise.race([
+          forkQueued.promise,
+          pending.then((result) => {
+            throw new Error(`Spawn settled before fork queue: ${JSON.stringify(result)}`);
+          }),
+        ]);
+        expect(subagentRuns.size).toBe(0);
+        expect(loadSessionEntry({ storePath, sessionKey: childSessionKey })).toMatchObject({
+          model: "gpt-5.4",
+          modelProvider: "openai",
+          modelOverride: "gpt-5.4",
+          providerOverride: "openai",
+        });
+        if (closure === "closed") {
+          admission.close();
+          expect(parent.controller.signal.aborted).toBe(false);
+          expect(getAdmittedRunDelegatedAuthority(admitted)).toBeUndefined();
+        }
+        releaseWriter.resolve();
+        const result = await forkSettled.promise;
+        const entry = loadSessionEntry({ storePath, sessionKey: childSessionKey })!;
+        const transcript = await loadTranscriptEvents({
+          agentId: "main",
+          sessionId: entry.sessionId,
+          sessionKey: childSessionKey,
+          storePath,
+        });
+        if (closure === "closed") {
+          expect
+            .soft(entry.sessionId, "closed parent must not replace the provisional child identity")
+            .toBe(initialSessionId);
+          expect
+            .soft(transcript, "closed parent must not copy its transcript after writer queue wait")
+            .toEqual([]);
+          expect.soft(result).toBeInstanceOf(Error);
+        } else {
+          expect(result).toMatchObject({ status: "forked" });
+          expect(entry.sessionId).not.toBe(initialSessionId);
+          expect(entry).toMatchObject({ model: "gpt-5.4", modelProvider: "openai" });
+          expect(transcript).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                type: "message",
+                message: { role: "user", content: "synthetic parent context" },
+              }),
+            ]),
+          );
+        }
+        inspected.resolve();
+        const outcome = await pending;
+        if (closure === "closed") {
+          expect(outcome).toMatchObject({ details: { status: "error" } });
+          expect(dispatch).not.toHaveBeenCalled();
+          expect(subagentRuns.size).toBe(0);
+          expect(deleted).toEqual([childSessionKey]);
+          expect(loadSessionEntry({ storePath, sessionKey: childSessionKey })).toBeUndefined();
+        } else {
+          expect(outcome).toMatchObject({ details: { status: "accepted" } });
+          expect(dispatch).toHaveBeenCalledOnce();
+          expect(bindingFixture.bind).toHaveBeenCalledOnce();
+          const details = (outcome as { details: { attachments: { relDir: string } } }).details;
+          expect(
+            await fs.readFile(
+              path.join(fixture.stateDir, details.attachments.relDir, "synthetic.txt"),
+              "utf8",
+            ),
+          ).toBe("synthetic attachment");
+        }
+      } finally {
+        releaseWriter.resolve();
+        inspected.resolve();
+        await blocker;
+        await pending;
+        admission.close();
+        parent.cleanup();
+        bindingFixture.unregister();
+      }
+    },
+  );
+
+  it.each([
+    "native engine resolution",
+    "native thread binding",
+    "native attachment staging",
+    "native attachment directory",
+    "native attachment files",
+    "native abort",
+    "native acceptance",
+    "native call signal",
+    "native construction signal",
+    "native claim loss",
+    "native replacement",
+    "native lifecycle rotation",
+    "native admission close",
+    "projected close",
+    "projected claim loss",
+  ])("rolls back an untransferred native spawn: %s", async (closure) => {
+    const entered = createDeferred<string>();
+    const release = createDeferred();
+    const hasThread =
+      closure === "native thread binding" || closure === "native attachment staging";
+    const hasAttachments = closure.startsWith("native attachment");
+    const bindingFixture = hasThread
+      ? installSpawnThreadBindingFixture(async (binding) => {
+          if (closure === "native attachment staging") {
+            entered.resolve(binding.targetSessionKey);
+            await release.promise;
+          }
+        })
+      : undefined;
+    const { cfg, storePath, context, admission, parent, admitted, authority } =
+      await createBoundParent(closure.startsWith("projected") ? "plugin-harness" : "embedded");
+    if (closure === "native thread binding") {
+      await replaceTranscriptEvents(
+        { agentId: "main", sessionId: "parent-session", sessionKey: parentSessionKey, storePath },
+        [
+          {
+            type: "session",
+            version: 3,
+            id: "parent-session",
+            timestamp: "2026-09-05T00:00:00Z",
+            cwd: fixture.stateDir,
+          },
+        ],
+      );
+    }
+    const readChildKey = () =>
+      listSessionChildEntriesReadOnly({ storePath, sessionKey: parentSessionKey })[0]!.sessionKey;
+    const attachmentFixture = hasAttachments
+      ? installSpawnAttachmentFixture({
+          stateDir: fixture.stateDir,
+          admitted,
+          pauseAt:
+            closure === "native attachment directory"
+              ? "directory"
+              : closure === "native attachment files"
+                ? "files"
+                : undefined,
+          entered: () => entered.resolve(readChildKey()),
+          release: release.promise,
+        })
+      : undefined;
+    const acceptedGate = createDeferred();
+    const acceptedEntered = createDeferred();
+    let childController: ReturnType<typeof registerChatAbortController> | undefined;
+    const rollback = vi.fn(async () => {});
+    const prepare = vi.fn(async ({ childSessionKey }: { childSessionKey: string }) => {
+      entered.resolve(childSessionKey);
+      await release.promise;
+      return { rollback };
+    });
+    const agentDispatch = vi.fn();
+    const deleted: string[] = [];
+    spawnTesting.setDepsForTest({
+      forkSessionEntryFromParent: async (params) => {
+        const result = await forkSessionEntryFromParent(params);
+        if (closure === "native thread binding") {
+          entered.resolve(params.sessionKey);
+          await release.promise;
+        }
+        return result;
+      },
+      resolveContextEngine: async () => {
+        if (closure === "native engine resolution") {
+          entered.resolve(readChildKey());
+          await release.promise;
+        }
+        return Object.assign(new LegacyContextEngine(), { prepareSubagentSpawn: prepare });
+      },
+      dispatchGatewayMethodInProcess: async <T>(
+        method: string,
+        params: Record<string, unknown>,
+      ) => {
+        if (method === "agent") {
+          agentDispatch(params);
+          if (closure === "native acceptance") {
+            const childSessionKey = params.sessionKey as string;
+            const child = loadSessionEntry({ storePath, sessionKey: childSessionKey })!;
+            childController = registerChatAbortController({
+              chatAbortControllers: context.chatAbortControllers,
+              runId: params.idempotencyKey as string,
+              sessionKey: childSessionKey,
+              sessionId: child.sessionId,
+              agentId: "main",
+              timeoutMs: 60_000,
+            });
+            acceptedEntered.resolve();
+            await acceptedGate.promise;
+          }
+          return { runId: params.idempotencyKey, status: "accepted" } as T;
+        }
+        if (method === "chat.abort") {
+          const respond = await invokeChatAbortHandler({
+            handler: handleChatAbortRequest,
+            context,
+            request: params as { sessionKey: string; runId: string },
+            client: createSyntheticPluginRuntimeClient(),
+          });
+          expect(respond).toHaveBeenCalledWith(
+            true,
+            expect.objectContaining({ aborted: true, runIds: [params.runId] }),
+          );
+          return respond.mock.calls[0]![1] as T;
+        }
+        if (method !== "sessions.delete") {
+          throw new Error(`Unexpected spawn RPC ${method}`);
+        }
+        let payload: unknown;
+        await sessionDeleteHandlers["sessions.delete"]!({
+          req: {} as never,
+          params,
+          context: context as unknown as GatewayRequestContext,
+          client: createSyntheticPluginRuntimeClient(),
+          isWebchatConnect: () => false,
+          respond: (ok, result, error) => {
+            if (!ok) {
+              throw new Error(error?.message ?? "delete failed");
+            }
+            payload = result;
+          },
+        });
+        deleted.push(params.key as string);
+        return payload as T;
+      },
+    });
+    const invocationAbort = new AbortController();
+    let replacementAuthority: ReturnType<typeof claimAgentRunDelegatedAuthority> | undefined;
+    const host = closure.startsWith("projected")
+      ? createAgentHarnessHostCapabilities({
+          attempt: {
+            admittedRunContext: admitted,
+            runId: parentRunId,
+            config: cfg,
+            agentId: "main",
+            sessionKey: parentSessionKey,
+            abortSignal: parent.controller.signal,
+          },
+          pluginId: "test-harness",
+        })
+      : undefined;
+    const source = createSessionsSpawnTool({
+      config: cfg,
+      agentSessionKey: parentSessionKey,
+      requesterRunId: parentRunId,
+      requesterTurnRunId: parentRunId,
+      agentChannel: hasThread ? "matrix" : undefined,
+      agentAccountId: hasThread ? "default" : undefined,
+      agentTo: hasThread ? "room:parent" : undefined,
+      signal: closure === "native construction signal" ? invocationAbort.signal : undefined,
+    });
+    let forwarded: Promise<unknown> | undefined;
+    const observed: AnyAgentTool = copyAgentToolMetadata(source, {
+      ...source,
+      execute: (...args) => {
+        const pending = source.execute!(...args);
+        // Observe, but still forward the real source promise through the native wrappers.
+        forwarded = pending.then(
+          (result) => result,
+          (error: unknown) => error,
+        );
+        return pending;
+      },
+    });
+    const wait = createAgentsWaitTool({
+      config: cfg,
+      agentSessionKey: parentSessionKey,
+      agentId: "main",
+    });
+    const tools = [observed, wait];
+    const [tool] = host
+      ? finalizeAgentToolAvailability(host.capabilities.bindToolSurface(tools))
+      : finalizeAgentTools({
+          tools,
+          hookContext: {
+            config: cfg,
+            agentId: "main",
+            sessionKey: parentSessionKey,
+            runId: parentRunId,
+          },
+          abortSignal: parent.controller.signal,
+        });
+    const caller = createAdmittedGatewayToolCallerIdentity({
+      admittedRunContext: admitted,
+      agentId: "main",
+      sessionKey: parentSessionKey,
+    });
+    const wrapped = withPluginRuntimeGatewayRequestScope(
+      { context: context as unknown as GatewayRequestContext, isWebchatConnect: () => false },
+      () =>
+        withGatewayToolCallerIdentity(caller, () =>
+          tool!.execute!(
+            "spawn-pending",
+            {
+              task: "bounded child",
+              collect: closure !== "native acceptance" && !hasThread,
+              thread: hasThread,
+              context: closure === "native thread binding" ? "fork" : "isolated",
+              attachments: hasAttachments
+                ? [{ name: "synthetic.txt", content: "synthetic attachment" }]
+                : undefined,
+              groupId: closure === "native acceptance" || hasThread ? undefined : groupId,
+            },
+            closure === "native call signal" ? invocationAbort.signal : undefined,
+          ),
+        ),
+    );
+    const wrappedOutcome = wrapped.then(
+      (result) => result,
+      (error: unknown) => error,
+    );
+    try {
+      // A rejected spawn never enters preparation; report it instead of waiting for the test timeout.
+      const childSessionKey = await Promise.race([
+        entered.promise,
+        wrapped.then(() => {
+          throw new Error("Spawn settled before entering context preparation");
+        }),
+      ]);
+      expect(subagentRuns.size, "no ownership transfer before preparation resolves").toBe(0);
+      expect(loadSessionEntry({ storePath, sessionKey: childSessionKey })).toBeDefined();
+      if (closure === "native acceptance") {
+        release.resolve();
+        await acceptedEntered.promise;
+        expect(subagentRuns.size, "accepted local run still awaits source registration").toBe(0);
+        expect(childController?.controller.signal.aborted).toBe(false);
+      }
+      if (closure === "native abort" || closure === "native acceptance") {
+        const reply = await invokeChatAbortHandler({
+          handler: handleChatAbortRequest,
+          context,
+          request: { sessionKey: parentSessionKey, runId: parentRunId },
+          client: {
+            connId: "owner-connection",
+            connect: { scopes: ["operator.read", "operator.write"] },
+          },
+        });
+        expect(reply).toHaveBeenCalledWith(true, {
+          ok: true,
+          aborted: true,
+          runIds: [parentRunId],
+        });
+        expect(parent.controller.signal.aborted).toBe(true);
+        expect(getAdmittedRunDelegatedAuthority(admitted)).toBeUndefined();
+        expect(await wrappedOutcome).toBeInstanceOf(Error);
+      } else {
+        if (closure.endsWith("claim loss")) {
+          releaseAgentRunDelegatedAuthority(authority);
+        } else if (closure.endsWith("replacement")) {
+          replacementAuthority = claimAgentRunDelegatedAuthority(
+            createOperationalRunInstanceRef(parentRunId),
+          );
+        } else if (closure.endsWith("lifecycle rotation")) {
+          rotateAgentRunRegistryLifecycleGeneration();
+        } else if (closure === "projected close") {
+          host!.close();
+        } else if (closure.endsWith("signal")) {
+          invocationAbort.abort();
+        } else {
+          admission.close();
+        }
+        expect(
+          parent.controller.signal.aborted,
+          "claim/capability closure is independent of parent signal",
+        ).toBe(false);
+      }
+      release.resolve();
+      acceptedGate.resolve();
+      await forwarded;
+      if (closure === "native acceptance") {
+        expect(agentDispatch).toHaveBeenCalledOnce();
+        expect(
+          childController?.controller.signal.aborted,
+          "exact accepted local child aborted before deletion",
+        ).toBe(true);
+      } else {
+        expect(agentDispatch, "cancelled source never dispatches a child").not.toHaveBeenCalled();
+      }
+      expect(subagentRuns.size, "cancelled source never registers runnable work").toBe(0);
+      const closedBeforePreparation =
+        closure === "native engine resolution" || hasThread || hasAttachments;
+      if (closedBeforePreparation) {
+        expect
+          .soft(prepare, "closed source must not start context engine preparation")
+          .not.toHaveBeenCalled();
+        expect.soft(rollback).not.toHaveBeenCalled();
+      } else {
+        expect(rollback).toHaveBeenCalledOnce();
+      }
+      if (closure === "native thread binding") {
+        expect.soft(bindingFixture!.bind).not.toHaveBeenCalled();
+      }
+      if (closure === "native attachment staging") {
+        expect(bindingFixture!.bind).toHaveBeenCalledOnce();
+      }
+      expect
+        .soft(attachmentFixture?.lateWrites ?? [], "no new attachment write after parent closure")
+        .toEqual([]);
+      expect(bindingFixture?.bindings ?? []).toEqual([]);
+      for (const directory of attachmentFixture?.attachmentDirs ?? []) {
+        await expect(fs.stat(directory)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+      expect(deleted).toEqual([childSessionKey]);
+      expect(loadSessionEntry({ storePath, sessionKey: childSessionKey })).toBeUndefined();
+      const survivor = vi.fn(async () => {});
+      enqueueSwarmRun({
+        groupId: JSON.stringify(["main", parentSessionKey, groupId]),
+        runId: "surviving-reservation",
+        maxConcurrent: 1,
+        activeRunIds: [],
+        start: survivor,
+        onStartFailure: () => true,
+      });
+      await vi.waitFor(() => expect(survivor).toHaveBeenCalledOnce());
+    } finally {
+      release.resolve();
+      acceptedGate.resolve();
+      await forwarded;
+      childController?.cleanup();
+      await wrappedOutcome;
+      host?.close();
+      if (replacementAuthority) {
+        releaseAgentRunDelegatedAuthority(replacementAuthority);
+      }
+      admission.close();
+      parent.cleanup();
+      attachmentFixture?.restore();
+      bindingFixture?.unregister();
+    }
+  });
+});

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -1539,7 +1539,7 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(result.childSessionKey).toMatch(/^agent:main:subagent:/);
 
     const childSessionKey = result.childSessionKey as string;
-    expect(hoisted.updateSessionStoreMock).toHaveBeenCalledTimes(2);
+    expect(hoisted.updateSessionStoreMock).toHaveBeenCalledOnce();
     expect(persistedStore?.[childSessionKey]).toMatchObject({
       sessionId: expect.any(String),
       lifecycleRevision: expect.any(String),

--- a/src/agents/subagents/spawn/subagent-spawn.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.ts
@@ -61,10 +61,7 @@ import { callNativeSubagentGateway, readGatewayRunId } from "./subagent-spawn-ga
 import { buildSubagentLaunchRequest } from "./subagent-spawn-launch-request.js";
 import { createSubagentSpawnLifecycleEmitter } from "./subagent-spawn-lifecycle.js";
 import { resolveSubagentSpawnRequest } from "./subagent-spawn-request.js";
-import {
-  createInitialSubagentSession,
-  persistInitialChildSessionRuntimeModel,
-} from "./subagent-spawn-session-patch.js";
+import { createInitialSubagentSession } from "./subagent-spawn-session-patch.js";
 import { bindThreadForSubagentSpawn } from "./subagent-spawn-thread-binding.js";
 import { emitSessionLifecycleEvent, mergeDeliveryContext } from "./subagent-spawn.runtime.js";
 import { buildSubagentSpawnEnvelope } from "./subagent-system-prompt.js";
@@ -129,7 +126,6 @@ export async function spawnSubagentDirect(
     },
     childIdem,
   } = requestResolution.resolved;
-  let modelApplied = false;
   let threadBindingReady = false;
   let hasBoundThreadDeliveryOrigin = false;
   let childRunId: string = childIdem;
@@ -204,6 +200,7 @@ export async function spawnSubagentDirect(
         ...provisionalSessionIdentity,
       });
     const preparedSpawnContext = await prepareSubagentSessionContext({
+      assertActive,
       cfg,
       contextMode,
       requesterAgentId,
@@ -228,24 +225,9 @@ export async function spawnSubagentDirect(
         expectedLifecycleRevision: childEntry.lifecycleRevision,
       };
     }
-    if (resolvedModel) {
-      const runtimeModelPersistError = await persistInitialChildSessionRuntimeModel({
-        cfg,
-        childSessionKey,
-        resolvedModel,
-      });
-      if (runtimeModelPersistError) {
-        await cleanupCreatedSession();
-        return {
-          status: "error",
-          error: runtimeModelPersistError,
-          childSessionKey,
-        };
-      }
-      modelApplied = true;
-    }
     if (requestThreadBinding) {
       const bindResult = await bindThreadForSubagentSpawn({
+        assertActive,
         cfg,
         childSessionKey,
         agentId: targetAgentId,
@@ -312,6 +294,7 @@ export async function spawnSubagentDirect(
     let attachmentRootDir: string | undefined;
 
     const materializedAttachments = await materializeSubagentAttachments({
+      assertActive,
       config: cfg,
       targetAgentId,
       workspaceDir: spawnedCwd ?? spawnedWorkspaceDir,
@@ -370,11 +353,12 @@ export async function spawnSubagentDirect(
       requesterSessionKey: requesterInternalKey,
       agentId: targetAgentId,
     });
-    const launchChildRun = async () =>
+    const launchChildRun = async (assertDispatchCurrent?: () => void) =>
       await callNativeSubagentGateway(
         withSubagentGatewayExecutionIdentity(
           {
             method: "agent",
+            assertDispatchCurrent,
             params: childLaunch.request,
             timeoutMs: childLaunch.timeoutMs,
           },
@@ -431,6 +415,7 @@ export async function spawnSubagentDirect(
           params.lightContext && preparedSpawnContext.mode === "isolated"
             ? ({ status: "ok", preparation: undefined } as const)
             : await prepareContextEngineSubagentSpawn({
+                assertActive,
                 cfg,
                 context: preparedSpawnContext,
                 requesterInternalKey,
@@ -443,13 +428,10 @@ export async function spawnSubagentDirect(
         return { contextEnginePreparation: result.preparation };
       },
       async dispatchTurn() {
-        // Initialize returned its rollback handle. Refusal here follows dispatch
-        // cleanup instead of losing that handle through initialize failure.
-        assertActive?.();
         if (params.collect) {
           return { runId: childIdem };
         }
-        const launch = await launchChildRun();
+        const launch = await launchChildRun(assertActive);
         taskRowOwnership = launch.taskRowOwnership;
         acceptedChildRunId = readGatewayRunId(launch.response) ?? childIdem;
         recordSessionParticipantBestEffort({
@@ -519,11 +501,11 @@ export async function spawnSubagentDirect(
     };
     const pipelineResult = await runSpawnPipeline({
       adapter,
+      assertActive,
       admissionReservation,
       progressOrigin,
       progressSessionKey: requesterInternalKey,
       buildRegistration: (_state, runId) => {
-        assertActive?.();
         if (params.collect) {
           const latestAdmission = resolveAdmission();
           if (!latestAdmission.ok) {
@@ -697,7 +679,7 @@ export async function spawnSubagentDirect(
         [envelope.acceptedNote, preparedSpawnContext.forkFallbackNote].filter(Boolean).join(" ") ||
         undefined,
       ...resolvedModelMetadata,
-      modelApplied: resolvedModel ? modelApplied : undefined,
+      modelApplied: plan.modelApplied || undefined,
       attachments: attachmentsReceipt,
     };
   } finally {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -579,6 +579,7 @@ export function createSessionsSpawnTool(
           },
           withParentExecutionIdentity(
             {
+              assertActive,
               agentSessionKey: opts?.agentSessionKey,
               requesterTurnRunId: opts?.requesterTurnRunId,
               completionOwnerKey: opts?.completionOwnerKey,

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -19,6 +19,8 @@ import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 
 const hoisted = vi.hoisted(() => {
   const callGatewayMock = vi.fn();
+  const cleanupFailedAcpSpawnMock = vi.fn();
+  const closeRuntimeOnFailureMock = vi.fn();
   const requireAcpRuntimeBackendMock = vi.fn();
   const getAcpRuntimeBackendMock = vi.fn();
   const listAcpSessionEntriesMock = vi.fn();
@@ -44,6 +46,8 @@ const hoisted = vi.hoisted(() => {
   const doctorMock = vi.fn();
   return {
     callGatewayMock,
+    cleanupFailedAcpSpawnMock,
+    closeRuntimeOnFailureMock,
     requireAcpRuntimeBackendMock,
     getAcpRuntimeBackendMock,
     listAcpSessionEntriesMock,
@@ -91,6 +95,10 @@ function createAcpCommandSessionBindingService() {
     unbind: (input: unknown) => hoisted.sessionBindingUnbindMock(input),
   };
 }
+
+vi.mock("../../acp/control-plane/spawn.js", () => ({
+  cleanupFailedAcpSpawn: (args: unknown) => hoisted.cleanupFailedAcpSpawnMock(args),
+}));
 
 vi.mock("../../gateway/call.js", () => ({
   callGateway: (args: unknown) => hoisted.callGatewayMock(args),
@@ -682,10 +690,6 @@ function gatewayRequests(): Array<Record<string, unknown>> {
   return hoisted.callGatewayMock.mock.calls.map((call) => call[0] as Record<string, unknown>);
 }
 
-function expectGatewayMethodCalled(method: string): void {
-  expect(gatewayRequests().some((request) => request.method === method)).toBe(true);
-}
-
 function expectGatewayMethodNotCalled(method: string): void {
   expect(gatewayRequests().some((request) => request.method === method)).toBe(false);
 }
@@ -907,6 +911,8 @@ describe("/acp command", () => {
     configureInMemoryTaskRegistryStoreForTests();
     hoisted.listAcpSessionEntriesMock.mockReset().mockResolvedValue([]);
     hoisted.callGatewayMock.mockReset().mockResolvedValue({ ok: true });
+    hoisted.cleanupFailedAcpSpawnMock.mockReset().mockResolvedValue(undefined);
+    hoisted.closeRuntimeOnFailureMock.mockReset().mockResolvedValue(undefined);
     hoisted.readAcpSessionEntryMock.mockReset().mockReturnValue(null);
     hoisted.upsertAcpSessionMetaMock.mockReset().mockResolvedValue({
       sessionId: "session-1",
@@ -1024,11 +1030,13 @@ describe("/acp command", () => {
               }
             : {}),
         };
-        await hoisted.upsertAcpSessionMetaMock({
+        const sessionEntry = await hoisted.upsertAcpSessionMetaMock({
           sessionKey: input.sessionKey,
           mutate: () => meta,
         });
         return {
+          sessionEntry,
+          closeRuntimeOnFailure: hoisted.closeRuntimeOnFailureMock,
           runtime: backend.runtime,
           handle: {
             backend: meta.backend,
@@ -1622,8 +1630,14 @@ describe("/acp command", () => {
     const result = await runDiscordAcpCommand("/acp spawn codex", cfg);
 
     expect(result?.reply?.text).toContain("spawnSessions=true");
-    expect(hoisted.closeMock).toHaveBeenCalledTimes(2);
-    expectGatewayMethodCalled("sessions.delete");
+    expect(hoisted.cleanupFailedAcpSpawnMock).toHaveBeenCalledExactlyOnceWith({
+      cfg,
+      sessionKey: expect.stringContaining("agent:codex:acp:"),
+      agentId: "codex",
+      sessionEntry: expect.objectContaining({ sessionId: "session-1" }),
+      deleteTranscript: false,
+      closeRuntimeOnFailure: hoisted.closeRuntimeOnFailureMock,
+    });
     expectGatewayMethodNotCalled("sessions.patch");
   });
 

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -5,10 +5,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getAcpSessionManager } from "../../../acp/control-plane/manager.js";
 import type { AcpSessionTarget } from "../../../acp/control-plane/manager.types.js";
 import { resolveAcpSessionResolutionError } from "../../../acp/control-plane/manager.utils.js";
-import {
-  cleanupFailedAcpSpawn,
-  type AcpSpawnRuntimeCloseHandle,
-} from "../../../acp/control-plane/spawn.js";
+import { cleanupFailedAcpSpawn } from "../../../acp/control-plane/spawn.js";
 import {
   isAcpEnabledByPolicy,
   resolveAcpAgentPolicyError,
@@ -31,7 +28,7 @@ import {
   type ChannelAdmissionEvidence,
 } from "../../../channels/message-access/admission-evidence.js";
 import { updateSessionEntry } from "../../../config/sessions/session-accessor.js";
-import type { SessionAcpMeta } from "../../../config/sessions/types.js";
+import type { SessionAcpMeta, SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
@@ -52,23 +49,6 @@ import {
   withAcpCommandErrorBoundary,
 } from "./shared.js";
 import { resolveAcpTargetSessionKey } from "./targets.js";
-async function cleanupFailedSpawn(params: {
-  cfg: OpenClawConfig;
-  sessionKey: string;
-  agentId: string;
-  shouldDeleteSession: boolean;
-  initializedRuntime?: AcpSpawnRuntimeCloseHandle;
-}) {
-  await cleanupFailedAcpSpawn({
-    cfg: params.cfg,
-    sessionKey: params.sessionKey,
-    agentId: params.agentId,
-    shouldDeleteSession: params.shouldDeleteSession,
-    deleteTranscript: false,
-    runtimeCloseHandle: params.initializedRuntime,
-  });
-}
-
 async function persistSpawnedSessionLabel(params: {
   commandParams: HandleCommandsParams;
   sessionKey: string;
@@ -172,7 +152,8 @@ export async function handleAcpSpawnAction(
 
   let initializedBackend;
   let initializedMeta: SessionAcpMeta | undefined;
-  let initializedRuntime: AcpSpawnRuntimeCloseHandle | undefined;
+  let sessionEntry: SessionEntry;
+  let closeRuntimeOnFailure: () => Promise<void>;
   try {
     const initialized = await acpManager.initializeSession({
       cfg: params.cfg,
@@ -182,10 +163,8 @@ export async function handleAcpSpawnAction(
       mode: spawn.mode,
       cwd: runtimeCwd,
     });
-    initializedRuntime = {
-      runtime: initialized.runtime,
-      handle: initialized.handle,
-    };
+    sessionEntry = initialized.sessionEntry;
+    closeRuntimeOnFailure = initialized.closeRuntimeOnFailure;
     initializedBackend = initialized.handle.backend || initialized.meta.backend;
     initializedMeta = initialized.meta;
   } catch (err) {
@@ -214,12 +193,13 @@ export async function handleAcpSpawnAction(
       sessionMeta: initializedMeta,
     });
     if (!result.ok) {
-      await cleanupFailedSpawn({
+      await cleanupFailedAcpSpawn({
         cfg: params.cfg,
         sessionKey,
         agentId: spawn.agentId,
-        shouldDeleteSession: true,
-        initializedRuntime,
+        sessionEntry,
+        deleteTranscript: false,
+        closeRuntimeOnFailure,
       });
       return commandReply(`⚠️ ${result.error}`);
     }
@@ -234,12 +214,13 @@ export async function handleAcpSpawnAction(
       label: spawn.label,
     });
   } catch (err) {
-    await cleanupFailedSpawn({
+    await cleanupFailedAcpSpawn({
       cfg: params.cfg,
       sessionKey,
       agentId: spawn.agentId,
-      shouldDeleteSession: true,
-      initializedRuntime,
+      sessionEntry,
+      deleteTranscript: false,
+      closeRuntimeOnFailure,
     });
     const message = formatErrorMessage(err);
     return commandReply(`⚠️ ACP spawn failed: ${message}`);

--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -169,6 +169,7 @@ export async function forkSessionEntryFromParent(
   const storePath = resolveParentForkStorePath(params);
   return await forkSessionEntryFromParentTarget({
     agentId: params.agentId,
+    commitGuard: params.commitGuard,
     decisionSkipPatch: params.decisionSkipPatch,
     fallbackEntry: params.fallbackEntry,
     parentTarget: normalizeForkTarget({

--- a/src/config/sessions/session-accessor.parent-fork.test.ts
+++ b/src/config/sessions/session-accessor.parent-fork.test.ts
@@ -72,6 +72,45 @@ afterEach(async () => {
 });
 
 describe("forkSessionFromParentTranscript", () => {
+  it.each(["existing-entry", "decision-skip"])(
+    "checks authority before applying a %s child patch",
+    async (reason) => {
+      const root = await makeRoot("openclaw-parent-fork-skip-guard-");
+      const storePath = path.join(root, "sessions.json");
+      const parentKey = "agent:main:main";
+      const childKey = "agent:main:child";
+      await replaceSessionEntry(
+        { sessionKey: parentKey, storePath },
+        {
+          sessionId: "parent-guarded",
+          updatedAt: 1,
+          totalTokens: 200_000,
+          totalTokensFresh: true,
+          totalTokensVersion: 1,
+        },
+      );
+      await replaceSessionEntry(
+        { sessionKey: childKey, storePath },
+        { sessionId: "child-guarded", updatedAt: 1, label: "original" },
+      );
+      const original = loadSessionEntry({ sessionKey: childKey, storePath });
+      await expect(
+        forkSessionEntryFromParentTarget({
+          storePath,
+          parentTarget: { canonicalKey: parentKey, storeKeys: [parentKey] },
+          sessionTarget: { canonicalKey: childKey, storeKeys: [childKey] },
+          skipForkWhen: () => reason === "existing-entry",
+          skipPatch: () => ({ label: "unauthorized" }),
+          decisionSkipPatch: () => ({ label: "unauthorized" }),
+          commitGuard: () => {
+            throw new Error("parent authority closed");
+          },
+        }),
+      ).rejects.toThrow("parent authority closed");
+      expect(loadSessionEntry({ sessionKey: childKey, storePath })).toEqual(original);
+    },
+  );
+
   it("checks authority inside same- and cross-database transcript commits", async () => {
     const root = await makeRoot("openclaw-parent-fork-guard-");
     const storePath = path.join(root, "sessions.json");

--- a/src/config/sessions/session-accessor.sqlite-parent-session.ts
+++ b/src/config/sessions/session-accessor.sqlite-parent-session.ts
@@ -148,6 +148,7 @@ export async function forkSessionEntryFromParentTarget(
 
       if (params.skipForkWhen?.(cloneSessionEntry(base))) {
         const sessionEntry = persistSqliteParentForkSkipPatch({
+          commitGuard: params.commitGuard,
           entry: base,
           sessionKey: sessionTarget.canonicalKey,
           patch: params.skipPatch?.(cloneSessionEntry(base)),
@@ -179,6 +180,7 @@ export async function forkSessionEntryFromParentTarget(
           parentEntry: cloneSessionEntry(parent.entry),
         });
         const sessionEntry = persistSqliteParentForkSkipPatch({
+          commitGuard: params.commitGuard,
           entry: base,
           sessionKey: sessionTarget.canonicalKey,
           patch,
@@ -197,6 +199,8 @@ export async function forkSessionEntryFromParentTarget(
       let previousIdentity = new Map<string, SessionEntry>();
       let currentIdentity = new Map<string, SessionEntry>();
       runOpenClawAgentWriteTransaction((writeDatabase) => {
+        // Parent authority can close while this fork waits behind another writer.
+        params.commitGuard?.();
         const freshParent = resolveLifecyclePrimaryEntry(writeDatabase, parentTarget)?.entry;
         if (!freshParent?.sessionId) {
           result = { status: "missing-parent" };
@@ -264,6 +268,7 @@ export async function forkSessionEntryFromParentTarget(
 }
 
 function persistSqliteParentForkSkipPatch(params: {
+  commitGuard?: () => void;
   entry: SessionEntry;
   sessionKey: string;
   patch: Partial<SessionEntry> | null | undefined;
@@ -281,6 +286,7 @@ function persistSqliteParentForkSkipPatch(params: {
   let previousIdentity = new Map<string, SessionEntry>();
   let currentIdentity = new Map<string, SessionEntry>();
   runOpenClawAgentWriteTransaction((database) => {
+    params.commitGuard?.();
     previousIdentity = readSessionIdentitySnapshot(database, [params.sessionKey]);
     writeSessionEntry(database, params.sessionKey, next, {
       previousEntry: params.entry,

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -686,6 +686,7 @@ export type ForkSessionEntryFromParentTargetResult =
 
 export type ForkSessionEntryFromParentTargetParams = {
   agentId?: string;
+  commitGuard?: () => void;
   decisionSkipPatch?: (params: {
     decision: Extract<SessionParentForkDecision, { status: "skip" }>;
     entry: SessionEntry;

--- a/src/gateway/agent-turn/agent-admission-controller.ts
+++ b/src/gateway/agent-turn/agent-admission-controller.ts
@@ -27,6 +27,7 @@ import {
 import type { AgentTurnContext, AgentTurnIo } from "./types.js";
 
 export function createAgentAdmissionController(params: {
+  assertAdmissionCurrent?: () => void;
   cfg: OpenClawConfig;
   runId: string;
   lifecycleGeneration: string;
@@ -71,6 +72,7 @@ export function createAgentAdmissionController(params: {
   };
 
   const assertAllowed = (commitOutcome = true) => {
+    params.assertAdmissionCurrent?.();
     const resolvedSessionKey = params.getResolvedSessionKey();
     const requestedSessionKey = params.getRequestedSessionKey();
     const latest = readGatewayDedupeEntry({

--- a/src/gateway/agent-turn/agent-run-admission-phase.ts
+++ b/src/gateway/agent-turn/agent-run-admission-phase.ts
@@ -93,6 +93,7 @@ export type PreparedAgentRunDispatch = {
 };
 
 export async function prepareAgentRunDispatch(params: {
+  assertAdmissionCurrent?: () => void;
   promptedAt: number;
   request: AgentRunRequest;
   cfg: OpenClawConfig;
@@ -556,10 +557,12 @@ export async function prepareAgentRunDispatch(params: {
       return rejectPreaccept(errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
     }
   }
+  let assertInputAdmissionCurrent = params.assertAdmissionCurrent;
   let userTurn: PreparedAgentRunUserTurn;
   try {
     userTurn = await prepareAgentRunUserTurn({
       assertCurrent: () => {
+        assertInputAdmissionCurrent?.();
         assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration);
         activeRunAbort.controller.signal.throwIfAborted();
         const entry = params.context.chatAbortControllers.get(params.runId);
@@ -631,6 +634,9 @@ export async function prepareAgentRunDispatch(params: {
       },
     },
   });
+  // Pending input outlives admission; only the child controller and lifecycle
+  // may reject its execution after this synchronous ownership transfer.
+  assertInputAdmissionCurrent = undefined;
   params.io.emitAcceptance([true, accepted, undefined], { runId: params.runId });
   const participant = resolveGatewayInputParticipant(params.client, params.inputProvenance);
   if (

--- a/src/gateway/agent-turn/agent-session-persist.ts
+++ b/src/gateway/agent-turn/agent-session-persist.ts
@@ -83,6 +83,7 @@ type AgentSessionPersistResult = {
 };
 
 export async function persistAgentSessionPhase(params: {
+  assertAdmissionCurrent?: () => void;
   request: AgentRunRequest;
   cfg: OpenClawConfig;
   storePath: string;
@@ -418,6 +419,7 @@ export async function persistAgentSessionPhase(params: {
             takeCacheOwnership: true,
             maintenanceConfig: params.maintenanceConfig,
             assertCommitAllowed: () => {
+              params.assertAdmissionCurrent?.();
               if (createdNewEntry) {
                 assertPreparedSkillLibrarySelection(params.creation.skillLibrarySelections);
               }

--- a/src/gateway/agent-turn/agent-turn-service.ts
+++ b/src/gateway/agent-turn/agent-turn-service.ts
@@ -37,6 +37,7 @@ import { persistAgentSessionPhase } from "./agent-session-persist.js";
 import type { AgentTurnIo, AgentTurnPrincipal } from "./types.js";
 
 type AgentTurnStartRequest = {
+  assertAdmissionCurrent?: () => void;
   preflight: AgentRequestPreflight;
   principal: AgentTurnPrincipal | null;
   io: AgentTurnIo;
@@ -88,12 +89,14 @@ export function createAgentTurnService(
   assertContextCurrent?: () => void,
 ) {
   const startTurn = async ({
+    assertAdmissionCurrent,
     preflight,
     principal,
     io,
     onRunObserved,
   }: AgentTurnStartRequest): Promise<void> => {
     const promptedAt = Date.now();
+    assertAdmissionCurrent?.();
     if (replayAgentTurnIfCached({ preflight, context, io })) {
       return;
     }
@@ -144,9 +147,6 @@ export function createAgentTurnService(
       context,
       io,
     });
-    const reservePreAcceptedAgentDedupe = dedupeLifecycle.reserve;
-    const clearUnacceptedAgentDedupe = dedupeLifecycle.clearUnaccepted;
-    const abortForLifecycleRotation = dedupeLifecycle.abortForLifecycleRotation;
     const routing = await prepareAgentRequestRouting({
       request,
       cfg,
@@ -157,8 +157,8 @@ export function createAgentTurnService(
       agentDedupeKeys,
       context,
       respond,
-      reserveDedupe: reservePreAcceptedAgentDedupe,
-      clearDedupe: clearUnacceptedAgentDedupe,
+      reserveDedupe: dedupeLifecycle.reserve,
+      clearDedupe: dedupeLifecycle.clearUnaccepted,
     });
     if (!routing) {
       return;
@@ -186,8 +186,8 @@ export function createAgentTurnService(
       lifecycleGeneration,
       context,
     });
-    const releaseCronContinuationClaimWithRecovery = cronContinuation.releaseWithRecovery;
     try {
+      assertAdmissionCurrent?.();
       const content = await prepareAgentContentPhase({
         request,
         cfg,
@@ -211,6 +211,7 @@ export function createAgentTurnService(
         return;
       }
       preparedOffloadedRefs = content.offloadedRefs;
+      assertAdmissionCurrent?.();
       agentId = content.agentId;
       requestedSessionKey = content.requestedSessionKey;
       // Participation is authorized below against the canonical session the run
@@ -249,6 +250,7 @@ export function createAgentTurnService(
       let resolvedStorePath: string | undefined;
       let admittedSessionId = resolvedSessionId ?? runId;
       const admissionController = createAgentAdmissionController({
+        assertAdmissionCurrent,
         cfg,
         runId,
         lifecycleGeneration,
@@ -273,12 +275,9 @@ export function createAgentTurnService(
           admittedSessionId = sessionId;
         },
       });
-      const admissionAgentId = admissionController.admissionAgentId;
-      const assertGatewayWorkAdmissionAllowed = admissionController.assertAllowed;
-      const acquireGatewayWorkAdmission = admissionController.acquire;
-      const respondToGatewayAdmissionOutcome = admissionController.respondToOutcome;
       releaseGatewayAdmission = admissionController.release;
       const resetPhase = await runAgentResetPhase({
+        assertAdmissionCurrent,
         request,
         cfg,
         requestedSessionKey,
@@ -293,7 +292,7 @@ export function createAgentTurnService(
         client: principal,
         context,
         respond,
-        abortForLifecycleRotation,
+        abortForLifecycleRotation: dedupeLifecycle.abortForLifecycleRotation,
         setCommittedResetCompletion: dedupeLifecycle.setCommittedResetCompletion,
       });
       requestedSessionKey = resetPhase.requestedSessionKey;
@@ -329,14 +328,14 @@ export function createAgentTurnService(
           cfg: cfgLocal,
           storePath,
           entry,
-          canonicalKey,
+          canonicalKey: canonicalSessionKey,
           storeKeys,
           maintenanceConfig: sessionMaintenanceConfig,
-          canonicalSessionAgentId,
+          canonicalSessionAgentId: sessionAgentId,
           resetPolicy,
           now,
           visibleRequest,
-          mainSessionKey: mainSessionKeyForRequest,
+          mainSessionKey,
           isSystemGatewayRun,
           sessionId,
           touchInteraction,
@@ -351,13 +350,13 @@ export function createAgentTurnService(
           authorizeGatewaySessionCreation({
             cfg: cfgLocal,
             client: principal,
-            agentId: canonicalSessionAgentId,
+            agentId: sessionAgentId,
           }) ??
           authorizeResolvedSessionMutation({
             cfg: cfgLocal,
             client: principal,
-            sessionKey: canonicalKey,
-            agentId: canonicalSessionAgentId,
+            sessionKey: canonicalSessionKey,
+            agentId: sessionAgentId,
           });
         if (sessionAuthorizationError) {
           io.emitAcceptance([false, undefined, sessionAuthorizationError]);
@@ -368,7 +367,6 @@ export function createAgentTurnService(
         sessionPersistedBeforeGatewayAdmission =
           preparedSession.sessionPersistedBeforeGatewayAdmission;
         isNewSession = preparedSession.isNewSession;
-        const sessionAgent = canonicalSessionAgentId;
         const requestDeliveryHint = normalizeDeliveryContext({
           channel: recipientChannel?.trim(),
           to,
@@ -383,8 +381,8 @@ export function createAgentTurnService(
             freshEntry,
             initialEntry: entry,
             cfg: cfgLocal,
-            sessionAgentId: sessionAgent,
-            canonicalSessionKey: canonicalKey,
+            sessionAgentId,
+            canonicalSessionKey,
             storePath,
             normalizedSpawned,
             requestDeliveryHint,
@@ -410,13 +408,10 @@ export function createAgentTurnService(
         sessionEntry = mergeSessionEntry(entry, patchBuild.patch);
         resolvedSessionId = sessionEntry?.sessionId ?? sessionId;
         admittedSessionId = resolvedSessionId ?? runId;
-        const canonicalSessionKey = canonicalKey;
         resolvedSessionKey = canonicalSessionKey;
-        const sessionAgentId = canonicalSessionAgentId;
         resolvedSessionAgentId = sessionAgentId;
-        const mainSessionKey = mainSessionKeyForRequest;
         try {
-          await acquireGatewayWorkAdmission(storePath ?? `agent:${sessionAgentId}`);
+          await admissionController.acquire(storePath ?? `agent:${sessionAgentId}`);
         } catch (err) {
           io.emitAcceptance([
             false,
@@ -425,10 +420,11 @@ export function createAgentTurnService(
           ]);
           return;
         }
-        if (respondToGatewayAdmissionOutcome()) {
+        if (admissionController.respondToOutcome()) {
           return;
         }
         const persistedSession = await persistAgentSessionPhase({
+          assertAdmissionCurrent,
           request,
           cfg: cfgLocal,
           storePath,
@@ -465,9 +461,9 @@ export function createAgentTurnService(
           bestEffortDeliver,
           expectedSession,
           maintenanceConfig: sessionMaintenanceConfig,
-          abortForLifecycleRotation,
-          assertGatewayWorkAdmissionAllowed,
-          respondToGatewayAdmissionOutcome,
+          abortForLifecycleRotation: dedupeLifecycle.abortForLifecycleRotation,
+          assertGatewayWorkAdmissionAllowed: admissionController.assertAllowed,
+          respondToGatewayAdmissionOutcome: admissionController.respondToOutcome,
           updateAdmissionState: (state) => {
             resolvedSessionId = state.resolvedSessionId;
             admittedSessionId = state.admittedSessionId;
@@ -528,6 +524,7 @@ export function createAgentTurnService(
       const { activeSessionAgentId } = delivery;
 
       const preparedDispatch = await prepareAgentRunDispatch({
+        assertAdmissionCurrent,
         promptedAt,
         request,
         cfg,
@@ -568,12 +565,12 @@ export function createAgentTurnService(
         context,
         client: principal,
         io,
-        abortForLifecycleRotation,
-        acquireGatewayWorkAdmission,
-        assertGatewayWorkAdmissionAllowed,
+        abortForLifecycleRotation: dedupeLifecycle.abortForLifecycleRotation,
+        acquireGatewayWorkAdmission: admissionController.acquire,
+        assertGatewayWorkAdmissionAllowed: admissionController.assertAllowed,
         hasGatewayAdmissionOutcome: admissionController.hasOutcome,
-        respondToGatewayAdmissionOutcome,
-        admissionAgentId,
+        respondToGatewayAdmissionOutcome: admissionController.respondToOutcome,
+        admissionAgentId: admissionController.admissionAgentId,
         getGatewayWorkAdmission: admissionController.getAdmission,
         setAdmittedRunAbort: admissionController.setAdmittedRunAbort,
         getAdmittedRunAbort: admissionController.getAdmittedRunAbort,
@@ -631,7 +628,7 @@ export function createAgentTurnService(
             client: principal,
             context,
             io,
-            releaseCronContinuationClaimWithRecovery,
+            releaseCronContinuationClaimWithRecovery: cronContinuation.releaseWithRecovery,
           }),
         )
         .catch((error: unknown) =>
@@ -650,7 +647,7 @@ export function createAgentTurnService(
               releaseGatewayAdmission();
             } finally {
               try {
-                await releaseCronContinuationClaimWithRecovery();
+                await cronContinuation.releaseWithRecovery();
               } finally {
                 scheduleMainSessionRecoveryPendingTarget(pendingRecovery);
               }
@@ -659,7 +656,7 @@ export function createAgentTurnService(
         }
       } finally {
         await discardPreparedInboundMedia(preparedOffloadedRefs);
-        clearUnacceptedAgentDedupe();
+        dedupeLifecycle.clearUnaccepted();
       }
     }
   };

--- a/src/gateway/agent-turn/internal-facade.test.ts
+++ b/src/gateway/agent-turn/internal-facade.test.ts
@@ -7,9 +7,11 @@ import { createSyntheticPluginRuntimeClient } from "../server-plugin-runtime-cli
 import { createInternalAgentTurnFacade } from "./internal-facade.js";
 
 const startTurn = vi.hoisted(() => vi.fn());
+const authorize = vi.hoisted(() => vi.fn(async () => ({ error: null })));
+const envelope = vi.hoisted(() => vi.fn(async (run: () => Promise<unknown>) => await run()));
 
 vi.mock("../server-methods.js", () => ({
-  authorizeGatewayRequestPreDispatch: async () => ({ error: null }),
+  authorizeGatewayRequestPreDispatch: authorize,
   createRequestGatewayMethodRegistry: () => ({
     isControlPlaneWrite: () => false,
   }),
@@ -17,7 +19,7 @@ vi.mock("../server-methods.js", () => ({
     _method: string,
     _client: unknown,
     run: () => Promise<unknown>,
-  ) => await run(),
+  ) => await envelope(run),
 }));
 
 vi.mock("./agent-request-preflight.js", () => ({
@@ -56,14 +58,60 @@ function createFacade(context = createContext()) {
 describe("createInternalAgentTurnFacade", () => {
   beforeEach(() => {
     startTurn.mockReset();
+    authorize.mockReset().mockResolvedValue({ error: null });
+    envelope.mockReset().mockImplementation(async (run) => await run());
   });
 
+  it.each(["authorization", "envelope"] as const)(
+    "rejects a source closed during %s before starting a turn",
+    async (boundary) => {
+      let current = true;
+      const assertAdmissionCurrent = () => {
+        if (!current) {
+          throw new Error("source closed");
+        }
+      };
+      if (boundary === "authorization") {
+        authorize.mockImplementationOnce(async () => {
+          await Promise.resolve();
+          current = false;
+          return { error: null };
+        });
+      } else {
+        envelope.mockImplementationOnce(async (run) => {
+          await Promise.resolve();
+          current = false;
+          return await run();
+        });
+      }
+      startTurn.mockImplementation(async ({ io }) => {
+        io.emitAcceptance([true, { runId: "stale-source", status: "accepted" }, undefined]);
+      });
+
+      await expect(
+        createFacade().dispatchRaw(
+          { message: "test", idempotencyKey: "stale-source" },
+          { assertAdmissionCurrent },
+        ),
+      ).rejects.toThrow("source closed");
+      expect(startTurn).not.toHaveBeenCalled();
+    },
+  );
+
   it("preserves accepted/final ordering and acceptance metadata without frames", async () => {
+    let sourceCurrent = true;
+    const assertAdmissionCurrent = vi.fn(() => {
+      if (!sourceCurrent) {
+        throw new Error("source closed");
+      }
+    });
     let emitFinal!: () => void;
     const finalGate = new Promise<void>((resolve) => {
       emitFinal = resolve;
     });
-    startTurn.mockImplementation(async ({ io }) => {
+    startTurn.mockImplementation(async ({ io, assertAdmissionCurrent: admissionGuard }) => {
+      expect(admissionGuard).toBe(assertAdmissionCurrent);
+      admissionGuard();
       io.emitAcceptance([true, { runId: "run-1", status: "accepted" }, undefined], {
         runId: "run-1",
       });
@@ -77,7 +125,7 @@ describe("createInternalAgentTurnFacade", () => {
 
     const result = createFacade().dispatchRaw(
       { message: "test", idempotencyKey: "run-1" },
-      { expectFinal: true, onAccepted },
+      { expectFinal: true, onAccepted, assertAdmissionCurrent },
     );
     await vi.waitFor(() =>
       expect(onAccepted).toHaveBeenCalledWith({
@@ -85,6 +133,8 @@ describe("createInternalAgentTurnFacade", () => {
         status: "accepted",
       }),
     );
+    sourceCurrent = false;
+    const checksAtAcceptance = assertAdmissionCurrent.mock.calls.length;
     emitFinal();
 
     await expect(result).resolves.toEqual({
@@ -93,6 +143,7 @@ describe("createInternalAgentTurnFacade", () => {
       error: undefined,
       meta: { runId: "run-1", terminal: true },
     });
+    expect(assertAdmissionCurrent).toHaveBeenCalledTimes(checksAtAcceptance);
   });
 
   it("preserves post-acceptance Error identity", async () => {

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -55,6 +55,7 @@ export function createInternalAgentTurnFacade(
   ): Promise<GatewayMethodDispatchResponse> => {
     const method = "agent";
     throwIfGatewayDispatchAborted(method, dispatchOptions.signal);
+    dispatchOptions.assertAdmissionCurrent?.();
     options.assertContextCurrent?.();
     const context = options.getContext();
     const entry = context.requestEntryLifetime?.enter({
@@ -80,6 +81,7 @@ export function createInternalAgentTurnFacade(
         return { ok: false, error: validationError };
       }
       options.assertContextCurrent?.();
+      dispatchOptions.assertAdmissionCurrent?.();
       let acceptance: GatewayMethodDispatchResponse | undefined;
       let final: GatewayMethodDispatchResponse | undefined;
       let resolveAcceptance: ((response: GatewayMethodDispatchResponse) => void) | undefined;
@@ -166,6 +168,7 @@ export function createInternalAgentTurnFacade(
           options.client,
           async () => {
             entry?.assertOpen();
+            dispatchOptions.assertAdmissionCurrent?.();
             entry?.release();
             const principal = captureAgentTurnPrincipal(options.client);
             const preflight = prepareAgentRequestPreflight({
@@ -184,7 +187,13 @@ export function createInternalAgentTurnFacade(
             await createAgentTurnService(
               { context, isWebchatConnect },
               options.assertContextCurrent,
-            ).startTurn({ preflight, principal, io, onRunObserved });
+            ).startTurn({
+              preflight,
+              principal,
+              io,
+              onRunObserved,
+              assertAdmissionCurrent: dispatchOptions.assertAdmissionCurrent,
+            });
           },
           {
             context,

--- a/src/gateway/agent-turn/internal-facade.types.ts
+++ b/src/gateway/agent-turn/internal-facade.types.ts
@@ -12,6 +12,8 @@ export type InternalAgentTurnPrincipalOptions = {
 };
 
 export type InternalAgentTurnDispatchOptions = {
+  // The source owns admission only; accepted children execute under their own lifetime.
+  assertAdmissionCurrent?: () => void;
   cancelOnDeadline?: boolean;
   expectFinal?: boolean;
   onAccepted?: (payload: unknown) => void;

--- a/src/gateway/server-methods/agent-reset-phase.ts
+++ b/src/gateway/server-methods/agent-reset-phase.ts
@@ -45,6 +45,7 @@ type AgentResetPhaseResult = {
 };
 
 export async function runAgentResetPhase(params: {
+  assertAdmissionCurrent?: () => void;
   request: AgentRunRequest;
   cfg: OpenClawConfig;
   requestedSessionKey?: string;
@@ -110,6 +111,7 @@ export async function runAgentResetPhase(params: {
         ? { operatorRoleActor: params.client.internal.operatorRoleActor }
         : {}),
       assertCurrent: () => {
+        params.assertAdmissionCurrent?.();
         assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration);
         assertPreparedSkillLibrarySelection(creation.skillLibrarySelections);
       },

--- a/src/gateway/server-methods/agent-run-handler.ts
+++ b/src/gateway/server-methods/agent-run-handler.ts
@@ -13,7 +13,9 @@ export const agentRunHandler: GatewayRequestHandlers["agent"] = async ({
   context,
   client,
   isWebchatConnect,
+  sessionMutationCommitGuard,
 }) => {
+  sessionMutationCommitGuard?.();
   const io = createAgentTurnIo(respond);
   if (
     !assertValidParams(params, validateAgentParams, "agent", (ok, payload, error, meta) =>
@@ -33,6 +35,7 @@ export const agentRunHandler: GatewayRequestHandlers["agent"] = async ({
     registerToolEventRecipient: context.registerToolEventRecipient,
   });
   await createAgentTurnService({ context, isWebchatConnect }).startTurn({
+    assertAdmissionCurrent: sessionMutationCommitGuard,
     preflight,
     principal,
     io,

--- a/src/gateway/server-plugin-in-process-dispatch.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.ts
@@ -442,6 +442,7 @@ export async function dispatchGatewayMethodInProcess<T>(
       });
       return method === "agent"
         ? await facade.dispatch<T>(params as AgentRunRequest, {
+            assertAdmissionCurrent: options?.sessionMutationCommitGuard,
             cancelOnDeadline: options?.cancelOnDeadline,
             expectFinal: options?.expectFinal,
             onAccepted: options?.onAccepted,

--- a/src/gateway/server.agent-input-authority.test.ts
+++ b/src/gateway/server.agent-input-authority.test.ts
@@ -1,0 +1,243 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  createOperationalRunInstanceRef,
+  prepareAgentRunAdmission,
+} from "../agents/admitted-run-context.js";
+import { captureAgentToolSourceExecutionGuard } from "../agents/agent-tool-source-execution-guard.js";
+import {
+  createAdmittedGatewayToolCallerIdentity,
+  withGatewayToolCallerIdentity,
+} from "../agents/tools/gateway-caller-context.js";
+import * as sessionAccessor from "../config/sessions/session-accessor.js";
+import { listSessionPendingInputs } from "../config/sessions/session-accessor.pending-inputs.js";
+import {
+  resolveSqliteStoreScope,
+  runExclusiveSqliteSessionWrite,
+} from "../config/sessions/session-accessor.sqlite-scope.js";
+import { registerInternalHook, unregisterInternalHook } from "../hooks/internal-hooks.js";
+import { dispatchGatewayMethodInProcess } from "./server-plugins.js";
+import { startGatewayServerHarness, type GatewayServerHarness } from "./server.e2e-ws-harness.js";
+import { loadSessionEntry } from "./session-utils.js";
+import { installGatewayTestHooks, prepareGatewayReplyRuntimeForTest } from "./test-helpers.js";
+
+describe("spawn input ownership transfer", () => {
+  let harness: GatewayServerHarness;
+  let kernel: Awaited<ReturnType<(typeof import("./server-kernel.js"))["createGatewayKernel"]>>;
+  installGatewayTestHooks({
+    scope: "suite",
+    setup: async () => {
+      const module = await import("./server-kernel.js");
+      const create = module.createGatewayKernel;
+      const capture = vi
+        .spyOn(module, "createGatewayKernel")
+        .mockImplementation(async (...args) => {
+          kernel = await create(...args);
+          return kernel;
+        });
+      try {
+        harness = await startGatewayServerHarness();
+      } finally {
+        capture.mockRestore();
+      }
+    },
+    cleanup: async () => {
+      await harness?.close();
+    },
+  });
+
+  it.for([
+    "before staging",
+    "after acceptance",
+    "child abort",
+    "before reset",
+    "live reset",
+  ] as const)("keeps input authority at its current owner: %s", async (boundary, { signal }) => {
+    await prepareGatewayReplyRuntimeForTest();
+    const context = kernel.gatewayRequestContext;
+    const cfg = context.getRuntimeConfig();
+    const runId = randomUUID();
+    const parentKey = `agent:main:parent:${runId}`;
+    const childKey = `agent:main:subagent:${runId}`;
+    const sessionId = `child-${runId}`;
+    await sessionAccessor.upsertSessionEntryCore(
+      { agentId: "main", sessionKey: childKey },
+      { sessionId, updatedAt: Date.now() },
+    );
+    const loaded = loadSessionEntry(childKey, { agentId: "main" });
+    const admission = prepareAgentRunAdmission({
+      cfg,
+      operationalRunInstance: createOperationalRunInstanceRef(`parent-${runId}`),
+      facts: {
+        runId: `parent-${runId}`,
+        agentId: "main",
+        ingress: { kind: "system", boundary: "spawn-input-proof", state: "present" },
+      },
+    });
+    const admitted = await admission.admit("embedded");
+    const guard = await withGatewayToolCallerIdentity(
+      createAdmittedGatewayToolCallerIdentity({
+        admittedRunContext: admitted,
+        agentId: "main",
+        sessionKey: parentKey,
+      }),
+      () => captureAgentToolSourceExecutionGuard(),
+    );
+    if (boundary === "before reset" || boundary === "live reset") {
+      const before = loadSessionEntry(childKey, { agentId: "main" }).entry;
+      let hookCalls = 0;
+      const onReset = (event: import("../hooks/internal-hooks.js").InternalHookEvent) => {
+        if (event.sessionKey !== childKey) {
+          return;
+        }
+        hookCalls++;
+        if (boundary === "before reset") {
+          admission.close();
+        }
+      };
+      registerInternalHook("command:new", onReset);
+      try {
+        const reset = dispatchGatewayMethodInProcess(
+          "agent",
+          { message: "/new", sessionKey: childKey, idempotencyKey: runId },
+          {
+            forceSyntheticClient: true,
+            syntheticScopes: ["operator.admin"],
+            resolveGatewayContext: () => context,
+            sessionMutationCommitGuard: guard,
+          },
+        );
+        if (boundary === "before reset") {
+          await expect(reset).rejects.toThrow("tool invocation authority is no longer active");
+          expect(loadSessionEntry(childKey, { agentId: "main" }).entry).toEqual(before);
+        } else {
+          await expect(reset).resolves.toMatchObject({ status: "ok", summary: "completed" });
+          const after = loadSessionEntry(childKey, { agentId: "main" }).entry;
+          expect(after?.sessionId).toBe(sessionId);
+          expect(after?.lifecycleRevision).not.toBe(before?.lifecycleRevision);
+        }
+        expect(hookCalls).toBe(1);
+      } finally {
+        unregisterInternalHook("command:new", onReset);
+        admission.close();
+      }
+      return;
+    }
+    const staged = createDeferred();
+    const releaseWriter = createDeferred();
+    const releaseExecution = createDeferred();
+    const executionEntered = createDeferred();
+    const release = () => {
+      releaseWriter.resolve();
+      releaseExecution.resolve();
+    };
+    signal.addEventListener("abort", release, { once: true });
+    let writer: Promise<unknown> | undefined;
+    let execution: Promise<void> | undefined;
+    let prepared:
+      | import("./agent-turn/agent-run-admission-phase.js").PreparedAgentRunDispatch
+      | undefined;
+    const executionModule = await import("./agent-turn/agent-run-execution-phase.js");
+    const execute = executionModule.startAgentRunExecution;
+    const executionSpy = vi
+      .spyOn(executionModule, "startAgentRunExecution")
+      .mockImplementationOnce((params) => {
+        prepared = params.prepared;
+        executionEntered.resolve();
+        execution = releaseExecution.promise.then(() => execute(params));
+        return execution;
+      });
+    const stage = sessionAccessor.stageSessionPendingInput;
+    const stageSpy = vi
+      .spyOn(sessionAccessor, "stageSessionPendingInput")
+      .mockImplementationOnce(async (...args) => {
+        if (boundary === "before staging") {
+          const entered = createDeferred();
+          writer = runExclusiveSqliteSessionWrite(
+            resolveSqliteStoreScope(loaded.storePath, { agentId: "main" }),
+            async () => {
+              entered.resolve();
+              await releaseWriter.promise;
+            },
+          );
+          await entered.promise;
+        }
+        const pending = stage(...args);
+        staged.resolve();
+        return await pending;
+      });
+    let dispatch: Promise<unknown> | undefined;
+    try {
+      dispatch = dispatchGatewayMethodInProcess(
+        "agent",
+        { message: "synthetic staged child input", sessionKey: childKey, idempotencyKey: runId },
+        {
+          forceSyntheticClient: true,
+          resolveGatewayContext: () => context,
+          sessionMutationCommitGuard: guard,
+        },
+      );
+      const outcome = dispatch.then(
+        (value) => ({ value }),
+        (error: unknown) => ({ error }),
+      );
+      await Promise.race([
+        staged.promise,
+        outcome.then((value) => {
+          if ("error" in value) {
+            throw value.error;
+          }
+          throw new Error(`Dispatch ended before staging: ${JSON.stringify(value)}`);
+        }),
+      ]);
+      if (boundary === "before staging") {
+        admission.close();
+        releaseWriter.resolve();
+        expect(await outcome).toHaveProperty(
+          "error.message",
+          "tool invocation authority is no longer active",
+        );
+        expect(prepared).toBeUndefined();
+        expect(
+          listSessionPendingInputs({
+            agentId: "main",
+            sessionKey: childKey,
+            sessionId,
+            storePath: loaded.storePath,
+          }).total,
+        ).toBe(0);
+      } else {
+        expect(await outcome).toHaveProperty("value.status", "accepted");
+        await executionEntered.promise;
+        const recorder = prepared!.userTurn.recorder!;
+        expect(recorder.getPendingInputMessage?.()).toBeDefined();
+        admission.close();
+        expect(() => guard()).toThrow("tool invocation authority is no longer active");
+        if (boundary === "child abort") {
+          prepared!.activeRunAbort.controller.abort(new Error("child stopped"));
+          expect(() => recorder.withPendingInput!(() => undefined)).toThrow("child stopped");
+        } else {
+          const persisted = await recorder.withPendingInput!(() => recorder.persistApproved());
+          expect(persisted?.appended).toBe(true);
+          expect(persisted?.message.content).toBe("synthetic staged child input");
+          expect(
+            listSessionPendingInputs({
+              agentId: "main",
+              sessionKey: childKey,
+              sessionId,
+              storePath: loaded.storePath,
+            }).total,
+          ).toBe(0);
+        }
+      }
+    } finally {
+      release();
+      await Promise.allSettled([writer, dispatch, execution]);
+      admission.close();
+      stageSpy.mockRestore();
+      executionSpy.mockRestore();
+      signal.removeEventListener("abort", release);
+    }
+  });
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

Closes #139001

## What Problem This Solves

Fixes an issue where stopping a parent while `sessions_spawn` was preparing a child could still let that pending operation create session state or start a child later. ACP preparation also split failure cleanup across several owners, so a refusal could leave a provisional session or close a successor's runtime. The reproduction holds the real Gateway facade before admission, closes the exact parent invocation, and then releases the request.

## Why This Change Was Made

Carry the existing private source-invocation assertion through both ACP and native preparation to the owner of each asynchronous mutation and final Gateway admission. Recheck after actor queues, hooks, authorization, facade creation and work admission; check immediately before authoritative session and fork writes. The canonical Gateway clears the source callback after accepting the child. An accepted child's later execution remains independent of ordinary parent completion, while explicit cancellation keeps its existing cascade.

The shared spawn pipeline now retains prepared resources before checking authority and transfers ownership once. ACP failures use canonical `sessions.delete` to drain work, release the runtime, delete the provisional row and metadata, and unbind the session. A dispatch refused before entering that owner releases only the exact cached runtime captured by the failed initialization. Session ID, lifecycle revision, and handle identity protect replacements; a cleanup deadline fences late entry. `/acp` uses the same cleanup owner. Native preparation removes a redundant model write and fences queued forks, attachments and thread binding at their existing owners.

No configuration option, environment variable, public RPC field, protocol-version bump, dependency, SQLite schema, migration or stored representation changes. The callback is private, ephemeral authority from the original invocation, not a copied token, diagnostic execution identity or inferred session ownership.

## User Impact

Stopping a parent while child creation is still pending prevents that stale operation from starting a new child. Refused ACP spawns remove their own provisional resources without affecting a replacement session. Children already accepted by the Gateway continue normally when their parent completes.

## Evidence

Original 41-file qualification commit: `242f507683da94d8f2b3b83a1b1b4a69a7ae05d4`, tree `ec799c29b5a86048dece4ef0fc27b981ab75a7cb`. The commit tree exactly matches the independently tested Linux candidate.

- Full `pnpm build` passed in 765.1 seconds, including declarations, all 90 plugin builds, runtime packaging and the Control UI. All 41 changed source hashes stayed unchanged and all 86 observed build processes exited. The first attempt was interrupted by an incorrectly short 360-second outer orchestration budget during plugin assembly, after all six declaration passes had completed; it remains a failed attempt. The completion run used a 900-second whole-build budget with the same 120-second no-output guard and unchanged native build supervision.
- The original held-admission reproduction accepted the child after parent closure. The repaired real finalized tool path rejects it, never runs its backend or registers a runnable child, removes the provisional row, and initializes/closes its runtime exactly once. A live control accepts the child, closes the parent, then executes one real synthetic ACP backend turn to a visible successful terminal result and releases the exact accepted controller.
- The final isolated Gateway run completed in 49.23 seconds on the final 41-file candidate. All four final archive/delete requests succeeded using the existing UI/CLI archive request options. Provisional ACP cleanup retains its separate ten-second deadline. Original source promises and actual Gateway execution/deletion work were joined before teardown; all eleven owned processes exited and every source hash stayed unchanged. No external provider call is claimed.
- Dedicated Linux qualification passed **71 fresh tests**: 23 ACP cleanup/authority, 35 native preparation/registration/fork, and 13 Gateway input/reset/facade. Four earlier cleanup-caller regressions retain exact source binding; their 164 intentionally unselected neighbors are not counted. All native report attempts completed successfully, source hashes stayed unchanged, and owned processes exited. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33958949935).
- All 41 changed files passed type-aware lint. The database-first guard passed. One composed TypeScript program passed with 10,894 inputs, including every changed source/test/support root and 13 ambient roots. Earlier dead-code, schema and six architecture guards remain bound to their named inputs. The final six-command Linux batch completed in 164.11 seconds with its original per-command watchdogs; the lease was stopped and independently verified completed.
- Independent full production review completed three passes without actionable findings; the fixture correction received a separate clean review. A final clean review covers the six-path alias/test cleanup; the other 29 production files retain the original reviewed bytes. All 23 native cases and shared fixture behavior are preserved by an independent syntax-tree comparison. Focused regressions cover replacement identity, queued fork commits, cancelled preparation, accepted-child lifetime, and canonical cleanup shared by `/acp` and spawning.

The follow-up commit `3b4410e71868463d3b9829296e84627514c805e7` changes only one existing test assertion. Hosted CI on the original head found that the success test still expected two store writes after the duplicate model write was removed. It now requires exactly one write and retains all model, ownership, registry, lifecycle and before-dispatch assertions. Both complete spawn/model test files pass: 88 tests with 8,346 captured compiler inputs. Type checking passes with 10,866 inputs; changed-file format and type-aware lint pass, and an independent P2 review found no issue. All original 41 candidate files remain byte-identical, so their build, Linux and Gateway evidence retains its original source binding. The final diff spans 42 files.

Earlier local attempts remain excluded from the passing results: cold imports exceeded bounded supervisors, and an incomplete fixture failed to join asynchronous cleanup. A later probe's stale literal config getter also caused deliberate runtime-cache invalidation after normal config startup; the final probe uses the canonical config reader and ordinary preparation before simulating an already-running parent. It records every cache predicate and retains explicit one-initialize/one-close assertions rather than changing runtime cache policy or backend handle fields.

## ClawSweeper disposition

The latest completed September 5, 11:04 UTC review at `3b4410e71868463d3b9829296e84627514c805e7` found no introduced code or security defect, accepted the actual Gateway proof, and explicitly says the earlier generic migration warning does not apply. Its rendered compatibility checklist still names `manager.initialize-session.ts` and `session-meta.ts`. **Disposition: no migration applies because the serialized contract is unchanged.** The added `assertCommitAllowed` callback is an in-memory commit option, and `sessionEntry` returns the existing persisted entry to the runtime owner; neither adds a stored field.

Compared with base `723731b5f7ad58e3bc0fd818b74d049563e3a2d0`, the complete ACP metadata types, SessionEntry types, canonical state schema, Kysely generator, ACP key/store resolution and embedded-metadata cleanup files are byte-identical. The existing metadata constructor is also identical. The first 16,368 bytes of `session-meta.ts`, containing all row readers, serialization, row upsert and migration functions before the guarded upsert, are byte-identical. The callback is forwarded separately to session commit options and invoked before the existing authoritative writes. This is source-contract compatibility evidence; no older-reader execution or new migration is claimed. The final follow-up changes only the stale test assertion described above.

Exact-head [CI run 33961838700](https://github.com/openclaw/openclaw/actions/runs/33961838700) completed successfully: 108 successful jobs, 16 skipped, no failures or cancellations.

## Scope and follow-up

Production changes span 30 files, **+311/-278, net +33**. Tests/support span 12 files, **+2,381/-409, net +1,972**, including a mechanical suite split with all original cases preserved. The growth carries one existing closure through distinct mutation/admission boundaries and records exact cached-resource identity. Removing the duplicate native model write and split failure paths absorbs most of it; removing the remaining checks would skip genuinely separate awaited boundaries or tie accepted-child lifetime to its parent. The final service cleanup removes twelve redundant aliases while making the existing owners explicit at each call.

The first final-v5 probe imposed a custom ten-second limit on auxiliary archive deletion and failed when the accepted session’s actual deletion finished after 13.8 seconds. That failed receipt remains failed. Source inspection established that normal UI/CLI archive deletion uses the shared ten-minute request contract; the final probe imports those exact options. Its outer 120-second no-output and 360-second total watchdogs remain unchanged, as do all refused-spawn assertions and the production provisional-cleanup timeout. No product timeout was increased; the internal breakdown of that earlier 13.8 seconds is not attributed without measurements.

The exact failing interval is a private facade-admission barrier with no ordinary UI control or visible checkpoint. A browser screenshot cannot establish whether admission occurred while that barrier was held. The real tool/Gateway proof therefore records admission, controller, session-row and runtime events directly; no before/after UI media is claimed. Earlier loopback HTTP operator proof covers refusal and disconnect lifetime only, and is not substituted for final child-admission proof.

A separate unproven follow-up is whether repeated cold standalone persistent ACP commands in one process retain a pre-activation config object and unnecessarily replace a handle on the next command. No supported long-lived caller or user-visible failure was established, and this repair does not alter the cache's configuration invalidation contract.

Existing embedded ACP metadata cleanup remains unchanged; moving all remaining legacy compatibility work into its migration owner is separate storage-design work.

The ClawSweeper render retains a generic data-model checkbox despite its technical review explicitly finding no stored-data change; that review-rendering mismatch is a separate follow-up. The compatibility disposition above addresses it for this PR.
