### PR TITLE
fix(ui): keep Refresh stable during background session updates

### DIFF
--- a/ui/src/e2e/session-roster-event-scope.e2e.test.ts
+++ b/ui/src/e2e/session-roster-event-scope.e2e.test.ts
@@ -34,14 +34,15 @@ suite.define(() => {
       await gateway.waitForRequest("sessions.subscribe");
       await page.waitForTimeout(1_200);
 
-      await gateway.deferNext("sessions.list");
-      const before = (await gateway.getRequests("sessions.list")).length;
+      const pageQuery = { includeUnknown: false };
+      await gateway.deferNext("sessions.list", pageQuery);
+      const before = (await gateway.getRequests("sessions.list", pageQuery)).length;
       await gateway.emitGatewayEvent("sessions.changed", {
         sessionKey: key,
         reason: "update",
         updatedAt: 2,
       });
-      await gateway.waitForRequest("sessions.list", { after: before });
+      await gateway.waitForRequest("sessions.list", { after: before, match: pageQuery });
       heldRequest = true;
       await page.waitForTimeout(50);
       await captureUiProof(suite, page, "sessions-background-refresh.png");

--- a/ui/src/e2e/session-roster-event-scope.e2e.test.ts
+++ b/ui/src/e2e/session-roster-event-scope.e2e.test.ts
@@ -13,6 +13,49 @@ import {
 const suite = createSessionManagementE2eSuite();
 
 suite.define(() => {
+  it("keeps the page Refresh control stable during background roster reads", async () => {
+    const key = "agent:main:background-refresh";
+    const row = sessionRow(key, "Background refresh", 1);
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: { "sessions.list": sessionsListResponse([row]) },
+      sessionKey: key,
+    });
+    let heldRequest = false;
+    try {
+      await page.goto(`${suite.server.baseUrl}sessions`);
+      const refresh = page.locator(".settings-section__actions .btn").last();
+      await expect.poll(async () => (await refresh.textContent())?.trim()).toBe("Refresh");
+      await gateway.waitForRequest("sessions.subscribe");
+      await page.waitForTimeout(1_200);
+
+      await gateway.deferNext("sessions.list");
+      const before = (await gateway.getRequests("sessions.list")).length;
+      await gateway.emitGatewayEvent("sessions.changed", {
+        sessionKey: key,
+        reason: "update",
+        updatedAt: 2,
+      });
+      await gateway.waitForRequest("sessions.list", { after: before });
+      heldRequest = true;
+      await page.waitForTimeout(50);
+      await captureUiProof(suite, page, "sessions-background-refresh.png");
+
+      expect((await refresh.textContent())?.trim()).toBe("Refresh");
+      expect(await refresh.isEnabled()).toBe(true);
+    } finally {
+      if (heldRequest) {
+        await gateway.resolveDeferred("sessions.list");
+      }
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("keeps the selected roster quiet during other agents' activity and refreshes its own changes", async () => {
     const key = "agent:main:weekly-report";
     const row = sessionRow(key, "Weekly report", 1);

--- a/ui/src/pages/sessions/sessions-page.roster.test.ts
+++ b/ui/src/pages/sessions/sessions-page.roster.test.ts
@@ -426,8 +426,15 @@ describe("sessions page managed roster", () => {
       throw new Error("Expected a managed query subscription");
     }
 
+    const refresh = [...page.querySelectorAll<HTMLButtonElement>("button.btn")].find(
+      (button) => button.textContent?.trim() === "Refresh",
+    );
     managed.publish(query, { result, agentId: "main", loading: true, error: null });
+    await page.updateComplete;
     expect(page.loading).toBe(true);
+    expect(page.refreshing).toBe(false);
+    expect(refresh?.textContent?.trim()).toBe("Refresh");
+    expect(refresh?.disabled).toBe(false);
     expect(page.result?.sessions.map((row) => row.key)).toEqual(["last-good"]);
 
     managed.publish(query, {
@@ -439,6 +446,36 @@ describe("sessions page managed roster", () => {
     expect(page.loading).toBe(false);
     expect(page.error).toBe("managed refresh failed");
     expect(page.result?.sessions.map((row) => row.key)).toEqual(["last-good"]);
+  });
+
+  it("shows loading while the page owns an explicit refresh", async () => {
+    const request = deferred<void>();
+    const managed = createManagedSessions({
+      refreshList: vi.fn(() => request.promise),
+    });
+    const context = createContext(
+      createGateway({} as GatewayBrowserClient).gateway,
+      managed.sessions,
+    );
+    const result = { count: 1, sessions: [{ key: "current" }] } as SessionsListResult;
+    const page = await createRenderedPage(context, result);
+
+    const refresh = [...page.querySelectorAll<HTMLButtonElement>("button.btn")].find(
+      (button) => button.textContent?.trim() === "Refresh",
+    );
+    refresh?.click();
+
+    await vi.waitFor(() => expect(managed.sessions.refreshList).toHaveBeenCalledOnce());
+    await page.updateComplete;
+    expect(page.refreshing).toBe(true);
+    expect(refresh?.textContent?.trim()).toBe("Loading…");
+    expect(refresh?.disabled).toBe(true);
+
+    request.resolve();
+    await vi.waitFor(() => expect(page.refreshing).toBe(false));
+    await page.updateComplete;
+    expect(refresh?.textContent?.trim()).toBe("Refresh");
+    expect(refresh?.disabled).toBe(false);
   });
 
   it("reconciles checkpoint caches only when the managed result pointer changes", async () => {

--- a/ui/src/pages/sessions/sessions-page.test-support.ts
+++ b/ui/src/pages/sessions/sessions-page.test-support.ts
@@ -25,6 +25,7 @@ export type TestSessionsPage = HTMLElement & {
   result: SessionsListResult | null;
   error: string | null;
   loading: boolean;
+  refreshing: boolean;
   statusFilter: "active" | "archived" | "all";
   selectedKeys: Set<string>;
   sessionMenu: { key: string; x: number; y: number } | null;

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -113,6 +113,7 @@ class SessionsPage extends OpenClawLightDomElement {
 
   @state() private result: SessionsListResult | null = null;
   @state() private loading = false;
+  @state() private refreshing = false;
   @state() private error: string | null = null;
   @state() private activeMinutes = "";
   @state() private limit = String(SESSIONS_PAGE_DEFAULT_LIMIT);
@@ -291,6 +292,7 @@ class SessionsPage extends OpenClawLightDomElement {
     this.resetTranscriptSearchState(this.transcriptSearchQuery);
     this.resetCheckpointTask();
     this.loading = false;
+    this.refreshing = false;
     this.checkpointBusyKey = null;
     this.sessionMutationPending = false;
     this.closeSessionMenu();
@@ -300,6 +302,7 @@ class SessionsPage extends OpenClawLightDomElement {
     this.result = null;
     this.error = null;
     this.loading = false;
+    this.refreshing = false;
     this.resetTranscriptSearchState("");
     this.selectedKeys = new Set();
     this.expandedSessionKey = null;
@@ -567,9 +570,11 @@ class SessionsPage extends OpenClawLightDomElement {
         return;
       }
       this.listRequest = undefined;
+      this.refreshing = false;
       this.bindSessionList();
     });
     this.listRequest = pending;
+    this.refreshing = true;
     start(binding.sessions.refreshList({ ...binding.query, ...options }));
     return pending;
   }
@@ -1595,6 +1600,7 @@ class SessionsPage extends OpenClawLightDomElement {
       ${renderSettingsWorkspace(
         renderSessions({
           loading: this.loading,
+          refreshing: this.refreshing,
           result: this.result,
           error: this.error,
           activeMinutes: this.activeMinutes,

--- a/ui/src/pages/sessions/view.test.ts
+++ b/ui/src/pages/sessions/view.test.ts
@@ -32,6 +32,7 @@ function buildMultiResult(sessions: SessionsListResult["sessions"]): SessionsLis
 function buildProps(result: SessionsListResult): SessionsProps {
   return {
     loading: false,
+    refreshing: false,
     agentId: "main",
     mainKey: "main",
     result,

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -76,6 +76,7 @@ type TranscriptSearchState =
 
 export type SessionsProps = {
   loading: boolean;
+  refreshing: boolean;
   result: SessionsListResult | null;
   error: string | null;
   activeMinutes: string;
@@ -1019,8 +1020,8 @@ export function renderSessions(props: SessionsProps) {
           `
         : nothing
     }
-    <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
-      ${props.loading ? t("common.loading") : t("common.refresh")}
+    <button class="btn" ?disabled=${props.refreshing} @click=${props.onRefresh}>
+      ${props.refreshing ? t("common.loading") : t("common.refresh")}
     </button>
   `;
   const children = [


### PR DESCRIPTION
Related: #138988

## What Problem This Solves

Fixes an issue where users viewing the Sessions page would see the manual Refresh button switch to Loading and become disabled whenever background session activity refreshed the roster.

## Why This Change Was Made

The Sessions page now tracks requests it initiates separately from the managed roster's background loading state. Background refreshes still update rows and retain the existing loading protections for roster operations, while only a page-owned request changes the manual Refresh control. Request scheduling, query ownership, and coalescing are intentionally unchanged.

## User Impact

The Refresh button remains stable and usable while session events update the roster in the background. Clicking Refresh still immediately shows Loading and disables the control until that request completes.

## Evidence

- The focused regression fails on the previous behavior when a managed background refresh publishes `loading: true`; it passes after the fix and verifies that an explicit Refresh still shows Loading.
- Maintainer validation after rebase: 73 focused unit tests and 2 Chromium/mock-Gateway browser scenarios passed; the UI bundle built successfully.
- Real Chromium with the bundled Control UI and mock Gateway protocol: 2 scenarios passed. The background regression now consistently selects the Sessions-page query (`includeUnknown: false`) for request deferral, counting, and waiting. Restoring the original loading binding fails with `Loading…` instead of `Refresh`; restoring the fix passes both scenarios.
- `node scripts/check-changed.mjs --base upstream/main`: passed all selected repository gates, including formatting, typechecks, dead exports, lint, and runtime import cycles.
- Maintainer review: fresh local autoreview and ClawSweeper review found no blocking findings in the Refresh change. The original button-binding regression was independently reproduced and verified fixed.

### Real-Gateway visual proof

Disposable loopback Gateways used synthetic session data only. Exact upstream main `41651036f27f672e17dfb0f2b81aa084f7715805` is compared with PR head `02630a3e77a978678786d3eb3698bb212b0b1c16`. The isolated browser delayed resolution of the real `sessions.list` response by 1.5 seconds so the transient state remained capturable; no Gateway response or roster payload was mocked. [Proof manifest](https://github.com/PollyBot13/openclaw/tree/proof-139023)

The displayed images are matching 942×480 crops of those existing captures, focused on the Sessions area to exclude the Discord invitation card as required by `ui/AGENTS.md`. No new runtime capture or image content alteration was performed.

Upstream main: background refresh incorrectly takes over the manual control:

![Upstream main background refresh shows Loading](https://github.com/user-attachments/assets/03c24813-8ccb-4ec8-9189-f46ba73da25e)

PR head: the same background refresh keeps the manual control stable:

![PR background refresh keeps Refresh enabled](https://github.com/user-attachments/assets/054568ad-380b-4014-8388-63b67567cd55)

PR head positive control: an explicit manual refresh shows progress, then completes:

![PR manual refresh shows Loading](https://github.com/user-attachments/assets/fbc8f51f-eb8f-4961-b040-e14924a6d605)

![PR manual refresh returns to Refresh](https://github.com/user-attachments/assets/f64d2cb2-2d31-4598-99dc-df1225f89b29)

AI-assisted: yes.

### Landing CI repairs

Two unrelated CI blockers are now repaired on main through [PR #123864](https://github.com/openclaw/openclaw/pull/123864): the setup-activation fixture retains its prepared provider generation, and the New Session-only shuffle icon lives with its deferred consumer instead of the eager icon registry. Real credential assertions, icon SVG output, and all timeout/performance limits remain unchanged.

This PR is rebased onto main `1c1f85474f5b11b281ab446d568b86a329dee22c`. Both original Refresh commits are patch-identical; the duplicate fixture commit was dropped because it is upstream. The net PR remains the original six-file Refresh repair.

Controlled bundle verification on candidate `19459bcfbf758745747054cf5fbeaeb8f6317786` passes: 352,894 B startup gzip across 8 requests, against the unchanged 353,107 B limit (213 B headroom). The earlier failed merge build measured 353,123 B. The current measurement includes all intervening main changes, not only the icon relocation. Rebased regression proof passes 73 Sessions unit tests, 9 onboarding tests, and both bundled Chromium/mock-Gateway scenarios.
