### PR TITLE
fix(gateway): session group defaults show admin requirement instead of a Git error for outside-workspace folders

### DIFF
--- a/src/gateway/server-methods/worktrees.authorization.test.ts
+++ b/src/gateway/server-methods/worktrees.authorization.test.ts
@@ -97,7 +97,15 @@ describe("worktrees.create authorization", () => {
     expect(write.respond).toHaveBeenCalledWith(
       false,
       undefined,
-      expect.objectContaining({ code: "INVALID_REQUEST" }),
+      expect.objectContaining({
+        code: "FORBIDDEN",
+        message: "missing scope: operator.admin",
+        details: {
+          code: "MISSING_SCOPE",
+          missingScope: "operator.admin",
+          requiredScopes: ["operator.admin"],
+        },
+      }),
     );
 
     const admin = await dispatchCreate({

--- a/src/gateway/server-methods/worktrees.test.ts
+++ b/src/gateway/server-methods/worktrees.test.ts
@@ -150,7 +150,9 @@ describe("worktrees gateway methods", () => {
       includeRepositoryStatus: true,
     });
 
-    // Write scope cannot probe arbitrary host paths for branch names.
+    // Write scope cannot probe arbitrary host paths for branch names; the
+    // denial uses the shared structured missing-scope contract so clients can
+    // tell an authorization failure apart from a repository inspection failure.
     const denied = await call(
       handlers,
       "worktrees.branches",
@@ -158,7 +160,15 @@ describe("worktrees gateway methods", () => {
       { client: writeClient, context: emptyConfigContext },
     );
     expect(denied?.[0]).toBe(false);
-    expect(String((denied?.[2] as { message?: string })?.message)).toContain("operator.admin");
+    expect(denied?.[2]).toMatchObject({
+      code: "FORBIDDEN",
+      message: "missing scope: operator.admin",
+      details: {
+        code: "MISSING_SCOPE",
+        missingScope: "operator.admin",
+        requiredScopes: ["operator.admin"],
+      },
+    });
   });
 
   it("allows write-scoped branch listing for a subdirectory inside an agent workspace", async () => {
@@ -238,7 +248,14 @@ describe("worktrees gateway methods", () => {
         { client: writeClient, context: emptyConfigContext },
       );
       expect(denied?.[0]).toBe(false);
-      expect(String((denied?.[2] as { message?: string })?.message)).toContain("operator.admin");
+      expect(denied?.[2]).toMatchObject({
+        code: "FORBIDDEN",
+        details: {
+          code: "MISSING_SCOPE",
+          missingScope: "operator.admin",
+          requiredScopes: ["operator.admin"],
+        },
+      });
     } finally {
       removeProjectRegistry(project.id);
     }

--- a/src/gateway/server-methods/worktrees.ts
+++ b/src/gateway/server-methods/worktrees.ts
@@ -1,6 +1,7 @@
 import {
   ErrorCodes,
   errorShape,
+  missingScopeErrorShape,
   validateWorktreesBranchesParams,
   validateWorktreesCreateParams,
   validateWorktreesGcParams,
@@ -30,7 +31,6 @@ function invalidParams(respond: Parameters<GatewayRequestHandlers[string]>[0]["r
 }
 
 async function resolveAuthorizedRepoRoot(
-  method: string,
   repoRoot: string,
   opts: Parameters<GatewayRequestHandlers[string]>[0],
 ): Promise<string | undefined> {
@@ -47,13 +47,13 @@ async function resolveAuthorizedRepoRoot(
   if (authorizedRoot) {
     return authorizedRoot;
   }
+  // Shared structured missing-scope contract (same shape as fs.listDir and
+  // sessions.groups.update) so clients can distinguish an authorization denial
+  // from a repository inspection failure instead of parsing prose.
   opts.respond(
     false,
     undefined,
-    errorShape(
-      ErrorCodes.INVALID_REQUEST,
-      `${method} outside configured agent workspaces requires gateway scope: ${ADMIN_SCOPE}`,
-    ),
+    missingScopeErrorShape({ missingScope: ADMIN_SCOPE, requiredScopes: [ADMIN_SCOPE] }),
   );
   return undefined;
 }
@@ -73,7 +73,7 @@ export function createWorktreesHandlers(service: WorktreeService): GatewayReques
         invalidParams(respond);
         return;
       }
-      const repoRoot = await resolveAuthorizedRepoRoot("worktrees.create", params.repoRoot, opts);
+      const repoRoot = await resolveAuthorizedRepoRoot(params.repoRoot, opts);
       if (!repoRoot) {
         return;
       }
@@ -134,7 +134,7 @@ export function createWorktreesHandlers(service: WorktreeService): GatewayReques
         invalidParams(respond);
         return;
       }
-      const repoRoot = await resolveAuthorizedRepoRoot("worktrees.branches", params.repoRoot, opts);
+      const repoRoot = await resolveAuthorizedRepoRoot(params.repoRoot, opts);
       if (!repoRoot) {
         return;
       }

--- a/ui/src/components/session-group-defaults-dialog.ts
+++ b/ui/src/components/session-group-defaults-dialog.ts
@@ -38,7 +38,7 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
   return new Promise<void>((resolve) => {
     let cwd = options.defaults.cwd;
     let worktree = false;
-    let repositoryStatus: WorktreeRepositoryStatus | "checking" = "checking";
+    let repositoryStatus: WorktreeRepositoryStatus | "checking" | "restricted" = "checking";
     let repositoryRequestToken = 0;
     let submitting = false;
     let failure: string | null = null;
@@ -60,7 +60,7 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
 
     const handleSubmit = async (event: Event) => {
       event.preventDefault();
-      if (submitting || repositoryStatus === "checking" || repositoryStatus === "unavailable") {
+      if (submitting || (repositoryStatus !== "git" && repositoryStatus !== "not_git")) {
         return;
       }
       submitting = true;
@@ -121,12 +121,15 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
         }
         repositoryStatus = status;
         worktree = status === "git" && restoreSavedWorktree && options.defaults.worktree;
-      } catch {
+      } catch (error) {
         if (requestToken !== repositoryRequestToken) {
           return;
         }
-        repositoryStatus = "unavailable";
         worktree = false;
+        // A path-authorization denial is not a repository status: collapsing it
+        // into "couldn't verify Git" would present a retry that can never
+        // succeed while the connection still lacks the required operator scope.
+        repositoryStatus = readMissingScopeError(error) ? "restricted" : "unavailable";
       }
       paint();
     };
@@ -226,7 +229,13 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
         ? browserPathDraft.trim()
         : null;
       const environmentState =
-        repositoryStatus === "checking" ? "checking" : repositoryStatus === "git" ? "git" : "local";
+        repositoryStatus === "checking"
+          ? "checking"
+          : repositoryStatus === "git"
+            ? "git"
+            : repositoryStatus === "restricted"
+              ? "restricted"
+              : "local";
       const environmentOptions = [
         {
           value: "local",
@@ -436,9 +445,11 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
                                     ? nothing
                                     : html`<small
                                         >${
-                                          repositoryStatus === "unavailable"
-                                            ? t("newSession.gitCheckUnavailable")
-                                            : t("newSession.checkoutCurrentNote")
+                                          repositoryStatus === "restricted"
+                                            ? t("sessionsView.groupDefaultsRequiresAdmin")
+                                            : repositoryStatus === "unavailable"
+                                              ? t("newSession.gitCheckUnavailable")
+                                              : t("newSession.checkoutCurrentNote")
                                         }</small
                                       >`
                                 }
@@ -461,13 +472,14 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
                   ?disabled=${
                     submitting ||
                     repositoryStatus === "checking" ||
-                    repositoryStatus === "unavailable"
+                    repositoryStatus === "unavailable" ||
+                    repositoryStatus === "restricted"
                   }
                 >
                   ${t("common.save")}
                 </button>
                 ${
-                  repositoryStatus === "unavailable"
+                  repositoryStatus === "unavailable" || repositoryStatus === "restricted"
                     ? html`
                         <button
                           type="button"

--- a/ui/src/e2e/session-management.group-defaults.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-defaults.e2e.test.ts
@@ -252,6 +252,81 @@ suite.define(() => {
     },
   );
 
+  it("shows the admin requirement when probing an outside-workspace folder is denied", async () => {
+    const outsideCwd = "/home/peter/outside-project";
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([]),
+        "worktrees.branches": {
+          __mockError: {
+            code: "FORBIDDEN",
+            message: "missing scope: operator.admin",
+            details: {
+              code: "MISSING_SCOPE",
+              missingScope: "operator.admin",
+              requiredScopes: ["operator.admin"],
+            },
+          },
+        },
+      },
+      sessionGroups: ["Client work"],
+      sessionGroupDefaults: { "Client work": { cwd: outsideCwd, worktree: false } },
+      workspace: "/home/peter/openclaw",
+      workspaceGit: true,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const group = page.locator('[data-session-section="category:Client work"]');
+      await group.waitFor({ state: "visible", timeout: 10_000 });
+      await group.locator(".sidebar-recent-sessions__head").hover();
+      await group.getByRole("button", { name: "Group options for Client work" }).click();
+      await page.getByRole("menuitem", { name: "New session defaults" }).click();
+      const dialog = page.locator(
+        `openclaw-modal-dialog[label='New session defaults for "Client work"']`,
+      );
+      await dialog.waitFor({ state: "visible" });
+
+      const environment = dialog.locator("[data-session-group-environment]");
+      await expect
+        .poll(() => environment.getAttribute("data-session-group-environment"))
+        .toBe("restricted");
+      const save = dialog.getByRole("button", { name: "Save" });
+      await expect.poll(() => save.isDisabled()).toBe(true);
+      // The denial is an authorization problem, not a repository inspection failure.
+      await expect.poll(() => environment.textContent()).toContain("requires operator.admin");
+      await expect.poll(() => environment.textContent()).not.toContain("Couldn't verify Git");
+      expect(await gateway.getRequests("sessions.groups.update")).toHaveLength(0);
+
+      // Once the connection holds admin scope the same retry recovers and the
+      // saved Local default (worktree false) can be submitted unchanged.
+      await gateway.setMethodResponse("worktrees.branches", {
+        branches: [{ kind: "local", name: "main" }],
+        defaultBranch: "main",
+        repositoryStatus: "git",
+      });
+      await dialog.getByRole("button", { name: "Retry" }).click();
+      await expect
+        .poll(() => environment.getAttribute("data-session-group-environment"))
+        .toBe("git");
+      await expect.poll(() => save.isEnabled()).toBe(true);
+      await save.click();
+      expect((await gateway.waitForRequest("sessions.groups.update")).params).toMatchObject({
+        name: "Client work",
+        cwd: outsideCwd,
+        worktree: false,
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("omits the group category for a legacy Gateway", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1373,6 +1373,8 @@ export const en: TranslationMap & {
     groupDefaultsWorktree: "New worktree",
     groupDefaultsWorktreeHint: "Runs each session in an isolated Git worktree.",
     groupDefaultsFailed: "Could not save the group defaults.",
+    groupDefaultsRequiresAdmin:
+      "This folder is outside agent workspaces. Saving defaults for it requires operator.admin. Open Inbox, select Limited access, request admin, then approve in Devices.",
     groupDefaultsStale: "Gateway connection replaced before the defaults were saved. Try again.",
     renameGroupMenu: "Rename group",
     renameGroupTitle: 'Rename group "{group}"',


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #138955

## What Problem This Solves

- Fixes an issue where the Control UI "New session defaults" dialog for a custom session group reports a Git verification failure ("Couldn't verify Git for this folder. Choose it again to retry.") and disables Save when the selected working directory is outside the configured agent workspaces and the current connection lacks `operator.admin`.
- The dialog collapsed the Gateway's authorization denial for the `worktrees.branches` probe into a Git-availability problem, so retrying could never succeed without changing the connection's scope and the real cause (missing admin scope) was never shown.
- **Related:** #133700 fixed repository probing for implicit agent-workspace defaults; this report covers authorization failures for explicit outside-workspace folders being misclassified as Git failures.

## Why This Change Was Made

- **Intended outcome:** Gateway worktree-path denials now use the shared structured missing-scope error contract (the same `FORBIDDEN` + `MISSING_SCOPE` details shape `fs.listDir` and `sessions.groups.update` already emit), and the defaults dialog renders an actionable `operator.admin` requirement for outside-workspace paths instead of a Git-check failure. Save stays disabled while the probe is denied, preserving the existing protection for saved Worktree defaults; once the connection holds admin scope, Retry succeeds as before.
- **Out of scope:** No change to the independent authorization enforced by `sessions.groups.update`; no unconditional Save enablement; new-session page discovery behavior is unchanged.
- **Highest-risk area:** The dialog's repository-inspection state machine (Save gating and Retry for saved Worktree defaults are covered by existing browser tests).
- **How is that risk mitigated?** The existing "blocks saving a worktree default until repository inspection succeeds" e2e coverage still passes, and a new e2e case pins the restricted-state rendering plus recovery after the scope is granted.

## User Impact

- **Success criteria:** For an outside-workspace folder on a connection without `operator.admin`, the dialog explains that the folder requires `operator.admin` (with the existing request-admin guidance) instead of blaming Git, and Save remains disabled until the connection has the scope to verify and save; for a Local (non-worktree) folder that is authorized, saving still works.
- **What should reviewers focus on?** `src/gateway/server-methods/worktrees.ts` (`resolveAuthorizedRepoRoot` shared missing-scope error), `ui/src/components/session-group-defaults-dialog.ts` (restricted inspection state + copy), and the regression tests in `src/gateway/server-methods/worktrees.authorization.test.ts` / `worktrees.test.ts` and `ui/src/e2e/session-management.group-defaults.e2e.test.ts` ("shows the admin requirement when probing an outside-workspace folder is denied").

## Evidence

- **Real environment tested:** full recovery loop with no RPC mocks — a real Gateway process on the PR head (trusted-proxy auth on loopback) serving the real built Control UI bundle, driven in real Chromium. A real WebSocket proxy injects the trusted-proxy identity headers, so the browser pairs with the gateway's trusted-proxy `deviceAutoApprove` default scopes — `operator.read`, `operator.write`, `operator.approvals`, `operator.questions` — the exact issue scenario: `operator.write` without `operator.admin`. The admin approval comes from a second real WebSocket session over an admin identity calling `device.pair.approve` (the RPC the Devices page uses).
- **Exact steps or commands run after this patch:**
  1. Connect the Control UI with the limited identity; hello scopes are `[operator.approvals, operator.questions, operator.read, operator.write]` (no `operator.admin`).
  2. Custom group "Client work" → "New session defaults" → Browse → select the outside-workspace folder `/tmp/oc-scope-proof/outside-project`; the `worktrees.branches` probe is denied on the wire with the structured error and the dialog renders the restricted state with Save disabled and zero `sessions.groups.update` requests.
  3. Follow the dialog guidance: Inbox → System → Limited access → "Request admin" → pending request appears on the gateway.
  4. The admin identity approves the request (`device.pair.approve` → ok); the browser reconnects with the rotated device token and now holds `operator.admin`.
  5. Reopen the dialog → select the same folder → the probe now succeeds and the folder inspects as a normal non-Git directory (environment state `local`); Save submits and succeeds.
  6. Readback through the gateway RPC `sessions.groups.defaults` returns the saved default.
- **Evidence after fix:** wire-level, from the real run:
  ```json
  {
    "limitedScopes": ["operator.approvals", "operator.questions", "operator.read", "operator.write"],
    "probeRequest": { "method": "worktrees.branches", "params": { "repoRoot": "/tmp/oc-scope-proof/outside-project", "includeRepositoryStatus": true } },
    "probeDenial": {
      "code": "FORBIDDEN",
      "message": "missing scope: operator.admin",
      "details": { "code": "MISSING_SCOPE", "missingScope": "operator.admin", "requiredScopes": ["operator.admin"] }
    },
    "dialog": {
      "environmentState": "restricted",
      "copyShows": "requires operator.admin",
      "copyExcludes": "Couldn't verify Git",
      "saveDisabled": true,
      "updateRequestsBeforeGrant": 0
    },
    "adminApproval": { "method": "device.pair.approve", "ok": true },
    "reconnectedScopes": ["operator.admin", "operator.approvals", "operator.pairing", "operator.questions", "operator.read", "operator.write"],
    "afterGrant": { "environmentState": "local", "saveEnabled": true },
    "updateRequest": { "name": "Client work", "cwd": "/tmp/oc-scope-proof/outside-project", "worktree": false },
    "updateReply": { "ok": true },
    "readback": { "defaults": [{ "name": "Client work", "cwd": "/tmp/oc-scope-proof/outside-project", "worktree": false }] }
  }
  ```
- **Screenshots from the real run (real Chromium + real Gateway):**
  - Restricted dialog with the admin requirement instead of the Git error: [02-restricted-dialog.png](https://github.com/LiuwqGit/openclaw/releases/download/evidence-pr-131750/02-restricted-dialog.png)
  - Following the dialog guidance — Inbox → Limited access: [03-inbox-limited-access.png](https://github.com/LiuwqGit/openclaw/releases/download/evidence-pr-131750/03-inbox-limited-access.png), pending approval: [04-pending-admin-request.png](https://github.com/LiuwqGit/openclaw/releases/download/evidence-pr-131750/04-pending-admin-request.png)
  - After the admin approval (reconnected with `operator.admin`): [05-reconnected-admin.png](https://github.com/LiuwqGit/openclaw/releases/download/evidence-pr-131750/05-reconnected-admin.png), the same folder now authorized: [06-authorized-dialog.png](https://github.com/LiuwqGit/openclaw/releases/download/evidence-pr-131750/06-authorized-dialog.png)
  - Saved default: [07-saved.png](https://github.com/LiuwqGit/openclaw/releases/download/evidence-pr-131750/07-saved.png)
  - Full run log: [scope-proof-run.log](https://github.com/LiuwqGit/openclaw/releases/download/evidence-pr-131750/scope-proof-run.log); machine-readable evidence: [scope-proof-evidence.json](https://github.com/LiuwqGit/openclaw/releases/download/evidence-pr-131750/scope-proof-evidence.json)
- **Observed result after fix:** a write-scoped connection editing defaults for an outside-workspace folder sees the actual authorization requirement with the standard request-admin guidance instead of a misleading Git error, and after the admin grants the scope the same folder saves the Local default successfully; authorized Local saves and Worktree-default protection behave exactly as before.
- **Before evidence:** on the pre-patch dialog the same probe denial rendered `gitCheckUnavailable` ("Couldn't verify Git for this folder. Choose it again to retry.") with Save disabled and a Retry that cannot succeed while the scope is unchanged (source-verified on current main: the dialog mapped every rejected probe to unavailable).
- **Test suites run on the PR head (unchanged):**
  ```bash
  pnpm install --prefer-offline
  node scripts/run-vitest.mjs run src/gateway/server-methods/worktrees.test.ts \
    src/gateway/server-methods/worktrees.authorization.test.ts \
    src/gateway/server-methods/sessions-groups.test.ts
  node scripts/run-vitest.mjs run ui/src/components/app-sidebar.test.ts \
    ui/src/pages/new-session/draft-place-state.test.ts
  node scripts/run-vitest.mjs run ui/src/e2e/session-management.group-defaults.e2e.test.ts \
    ui/src/e2e/new-session-page.operator-scopes.e2e.test.ts \
    --config test/vitest/vitest.ui-e2e.config.ts
  pnpm tsgo:core && pnpm tsgo:ui
  pnpm ui:i18n:verify
  ```
- **What was not tested:** No live two-connection Gateway session over a real network was exercised; the trusted-proxy identity is injected by a local reverse WebSocket proxy (the same trust boundary a real reverse proxy provides, on loopback), and the admin approver is a direct WebSocket session rather than a second browser. `src/agents/worktrees/service-branches.test.ts` could not run locally because the host git (2.27) lacks `git init -b`/`git worktree list -z`; it runs on CI (no service code changed). CI lanes all green on the head (`openclaw/ci-gate`, `checks-node-compact-small-18/52`, and the full compact/UI/e2e matrix passed; all CI checks green).
- **Proof tier:** L2 (real Gateway + real built Control UI in real Chromium; wire-level diagnostics recorded in the run log)
- **Proof limitations:** The trusted-proxy topology is scripted locally (real gateway, real browser, real RPCs); the admin approval uses the same `device.pair.approve` RPC the Devices page calls rather than a second browser UI session. No external services involved.
- **Review state:** Rebased onto current main (CI all green); real-environment recovery evidence added; awaiting maintainer review
