### PR TITLE
fix: [Bug]: # L5 — Upstream-issue: model-fallback triggert niet bij zachte providerfout (definitief, 2026-09-03) (#138531)

### DIFF
--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -355,7 +355,7 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     expect(result).toBeNull();
   });
 
-  it("does not retry non-business transport error payloads", () => {
+  it("retries transient transport error payloads via the shared timeout lane (#138531)", () => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "custom",
       model: "llama-3.1",
@@ -372,7 +372,31 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
       },
     });
 
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      message: "custom/llama-3.1 ended with a provider error: HTTP 500: internal server error",
+      reason: "timeout",
+      code: "embedded_error_payload",
+      rawError: "HTTP 500: internal server error",
+    });
+  });
+
+  it("classifies generic isError 'LLM request failed.' payloads as timeout fallback (#138531)", () => {
+    const rawError = "LLM request failed.";
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "custom",
+      model: "llama-3.1",
+      result: {
+        payloads: [{ isError: true, text: rawError }],
+        meta: { durationMs: 42 },
+      },
+    });
+
+    expect(result).toEqual({
+      message: `custom/llama-3.1 ended with a provider error: ${rawError}`,
+      reason: "timeout",
+      code: "embedded_error_payload",
+      rawError,
+    });
   });
 
   it("keeps tool-authored incomplete summaries fallback-eligible", () => {

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -12,7 +12,7 @@ import type { EmbeddedAgentRunResult } from "./types.js";
 
 type ProviderErrorPayloadFailoverReason = Extract<
   FailoverReason,
-  "auth" | "auth_permanent" | "billing" | "rate_limit" | "server_error" | "overloaded"
+  "auth" | "auth_permanent" | "billing" | "rate_limit" | "server_error" | "overloaded" | "timeout"
 >;
 
 /**
@@ -179,6 +179,7 @@ function classifyProviderErrorPayloadReason(
     case "rate_limit":
     case "server_error":
     case "overloaded":
+    case "timeout":
       return failoverReason;
     default:
       return null;


### PR DESCRIPTION
## What Problem This Solves
Fixes #138531 — [Bug]: # L5 — Upstream-issue: model-fallback triggert niet bij zachte providerfout (definitief, 2026-09-03). Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree oc-138531).

Closes #138531