### PR TITLE
test(agents): lock fenced session-db purge regression Closes #138676

### DIFF
--- a/src/state/agent-deletion-cleanup.test.ts
+++ b/src/state/agent-deletion-cleanup.test.ts
@@ -7,6 +7,7 @@ import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
 import { purgeAgentSessionStoreEntries } from "../config/sessions/cleanup-service.js";
 import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import { replaceSessionEntrySync } from "../config/sessions/session-accessor.sqlite-entry.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import * as integrityWorker from "../infra/sqlite-integrity-worker.js";
 import { assertNoOpenClawAgentDatabaseLeases } from "./openclaw-agent-db-lease.js";
@@ -361,6 +362,27 @@ describe("agent deletion database cleanup authority", () => {
       if (cold) {
         expect(getOpenClawAgentDatabaseIfOpen(sharedOptions)).toBeUndefined();
       }
+    },
+  );
+
+  it.each([false, true])(
+    "purges the deleted agent's own default fenced store under its journal cleanup authority (scope: %s)",
+    async (scoped) => {
+      const f = fixture();
+      const cfg = {
+        agents: { ownership: "explicit", entries: { worker: {}, kept: {} } },
+      } satisfies OpenClawConfig;
+      const deletion = f.begin();
+      // The default (agent-fenced) store lives beneath the agent directory the journal
+      // itself fences. Without the deletion cleanup authority the purge open is rejected
+      // (#138676); with it the same open is admitted and only the target rows are removed.
+      const purgeFailed = await purgeAgentSessionStoreEntries(cfg, "worker", {
+        env: f.options.env,
+        ...(scoped ? { runDatabaseCleanup: deletion.runDatabaseCleanup } : {}),
+      });
+      expect(purgeFailed).toBe(!scoped);
+      expect(f.read()).toBe(scoped ? undefined : "before");
+      deletion.rollback();
     },
   );
 });


### PR DESCRIPTION
## What Problem This Solves
Regression coverage for #138676 — fix: agent deletion cannot purge its fenced session database. The core fix already landed on main via #138693 (cf127a39cb9); this PR adds the missing fenced-default-store coverage so the issue scenario stays locked.

## Evidence
- New it.each([false,true]) cases: no cleanup scope → purge rejected (fence by design); cleanup scope → fenced session db purged.
- agent-deletion-cleanup.test.ts + cleanup-service.agent-purge.test.ts: 23/23 pass.
- Verified empirically: pre-#138693 baseline fails the scenario; current main passes.

Related to #138676