### PR TITLE
improve: keep small lint checks fast with assertion baseline edits

### DIFF
--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -125,12 +125,12 @@ const LINTABLE_CORE_PATH_RE = /^(?:src|ui|packages)\/.+\.[cm]?[jt]sx?$/u;
 const LINTABLE_EXTENSION_PATH_RE = /^extensions\/[^/]+\/.+\.[cm]?[jt]sx?$/u;
 const LINTABLE_SCRIPT_PATH_RE = /^scripts\/.+\.[cm]?[jt]sx?$/u;
 const LINTABLE_UI_STYLE_PATH_RE = /^ui\/(?:src\/.+\.(?:css|ts)|public\/themes\/[^/]+\.css)$/u;
-const MARKDOWN_LINT_OPTIMIZATION_NEUTRAL_PATH_RE = /^(?:docs\/|README\.md$|.*\.mdx?$)/u;
+// The assertion baseline is checked by its ratchet, not consumed by Oxlint.
+const LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
+  /^(?:docs\/|README\.md$|.*\.mdx?$|config\/assertion-safety-baseline\.txt$)/u;
 const CORE_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
   /^(?:scripts|test\/scripts)\/|^\.github\/workflows\/ci\.yml$|^ui\/(?:src\/.+|public\/themes\/[^/]+)\.css$/u;
-const EXTENSION_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
-  /^(?:test\/scripts\/|\.github\/workflows\/ci\.yml$)/u;
-const SCRIPT_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
+const TOOLING_LINT_OPTIMIZATION_NEUTRAL_PATH_RE =
   /^(?:test\/scripts\/|\.github\/workflows\/ci\.yml$)/u;
 const ANDROID_VERSION_SYNC_PATHS = new Set([
   "apps/android/CHANGELOG.md",
@@ -868,7 +868,7 @@ export function createChangedCheckPlan(
       return (
         (surface === "source" || surface === "package" || surface === "ui") &&
         !CORE_LINT_OPTIMIZATION_NEUTRAL_PATH_RE.test(changedPath) &&
-        !MARKDOWN_LINT_OPTIMIZATION_NEUTRAL_PATH_RE.test(changedPath)
+        !LINT_OPTIMIZATION_NEUTRAL_PATH_RE.test(changedPath)
       );
     });
     addTargetedLint(
@@ -1029,7 +1029,7 @@ export function createTargetedExtensionLintCommand(
     env,
     label: "extension",
     lintablePathRe: LINTABLE_EXTENSION_PATH_RE,
-    neutralPathRe: EXTENSION_LINT_OPTIMIZATION_NEUTRAL_PATH_RE,
+    neutralPathRe: TOOLING_LINT_OPTIMIZATION_NEUTRAL_PATH_RE,
     paths,
     tsconfig: EXTENSIONS_OXLINT_TS_CONFIG,
     ...options,
@@ -1045,7 +1045,7 @@ export function createTargetedScriptLintCommand(
     env,
     label: "script",
     lintablePathRe: LINTABLE_SCRIPT_PATH_RE,
-    neutralPathRe: SCRIPT_LINT_OPTIMIZATION_NEUTRAL_PATH_RE,
+    neutralPathRe: TOOLING_LINT_OPTIMIZATION_NEUTRAL_PATH_RE,
     paths,
     tsconfig: SCRIPTS_OXLINT_TS_CONFIG,
     ...options,
@@ -1070,7 +1070,7 @@ function createTargetedOxlintCommand({
         !LINTABLE_SCRIPT_PATH_RE.test(changedPath) &&
         !getChangedPathFacts(changedPath).isRootTestSource &&
         !neutralPathRe.test(changedPath) &&
-        !MARKDOWN_LINT_OPTIMIZATION_NEUTRAL_PATH_RE.test(changedPath),
+        !LINT_OPTIMIZATION_NEUTRAL_PATH_RE.test(changedPath),
     )
   ) {
     return null;

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -1344,6 +1344,7 @@ describe("scripts/changed-lanes", () => {
 
   it("targets mixed core, extension, script, and root test lint without full-owner fan-out", () => {
     const result = detectChangedLanes([
+      "config/assertion-safety-baseline.txt",
       "src/gateway/node-registry.ts",
       "extensions/lmstudio/src/models.fetch.ts",
       "scripts/check-changed.mjs",
@@ -1392,6 +1393,7 @@ describe("scripts/changed-lanes", () => {
       ]),
     );
     const commandNames = plan.commands.map((command) => command.args[0]);
+    expect(commandNames).toContain("check:assertion-safety");
     for (const fullLane of ["lint:core", "lint:extensions", "lint:scripts"]) {
       expect(commandNames).not.toContain(fullLane);
     }
@@ -1689,6 +1691,7 @@ describe("scripts/changed-lanes", () => {
     expect(
       createTargetedCoreLintCommand(
         [
+          "config/assertion-safety-baseline.txt",
           "config/tsconfig/oxlint.core.json",
           "packages/normalization-core/src/string-normalization.ts",
         ],
@@ -1703,6 +1706,7 @@ describe("scripts/changed-lanes", () => {
       name: "targets small core lint diffs",
       create: createTargetedCoreLintCommand,
       targets: [
+        "config/assertion-safety-baseline.txt",
         ".github/workflows/ci.yml",
         "scripts/check-changed.mjs",
         "src/agents/auth-profiles/usage.ts",
@@ -1717,7 +1721,11 @@ describe("scripts/changed-lanes", () => {
     {
       name: "targets small extension lint diffs",
       create: createTargetedExtensionLintCommand,
-      targets: ["extensions/lmstudio/src/model-reasoning.ts", "docs/help/testing.md"],
+      targets: [
+        "config/assertion-safety-baseline.txt",
+        "extensions/lmstudio/src/model-reasoning.ts",
+        "docs/help/testing.md",
+      ],
       expected: {
         name: "lint extension changed file",
         tsconfig: "extensions/tsconfig.json",
@@ -1727,7 +1735,11 @@ describe("scripts/changed-lanes", () => {
     {
       name: "targets small script lint diffs",
       create: createTargetedScriptLintCommand,
-      targets: ["scripts/check-changed.mjs", "test/scripts/changed-lanes.test.ts"],
+      targets: [
+        "config/assertion-safety-baseline.txt",
+        "scripts/check-changed.mjs",
+        "test/scripts/changed-lanes.test.ts",
+      ],
       expected: {
         name: "lint script changed file",
         tsconfig: "config/tsconfig/oxlint.scripts.json",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers changing the assertion-safety baseline alongside a small source edit would trigger full-owner lint instead of linting the changed files. A representative three-file core edit plus its baseline change exceeded a 16 GiB memory limit in the full-core lint command.

## Why This Change Was Made

The assertion baseline is ratchet data, not an Oxlint configuration input. Treat its exact path as neutral when selecting targeted core, plugin, and script lint. The assertion-safety ratchet still runs, and real configuration changes, deleted paths, broad changes, and baseline-only changes retain their existing checks.

The shared selection owner also replaces two identical tooling-neutral patterns with one. Production/tooling LOC is neutral (8 added / 8 deleted); existing test coverage grows by 12 lines. No new dependency, configuration option, runtime cache, or Gateway behavior changes.

## User Impact

Small source changes can retain targeted lint when their assertion baseline changes too, avoiding unnecessary full-repository work without weakening assertion checks or the real lint-configuration fallbacks.

## Evidence

- The same complete `test/scripts/changed-lanes.test.ts` suite ran on both owners: the old owner had 4 expected failures and 312 passes; the candidate passed all 316 tests. The affected cases cover mixed core/plugin/script selection, each targeted owner, and a real configuration companion that must still fall back.
- `node scripts/check-changed.mjs --timed --base HEAD -- scripts/check-changed.mts test/scripts/changed-lanes.test.ts` passed all 22 local checks before commit. An initial adapter incorrectly set `CI=1` locally and failed looking for Corepack; using the actual local pnpm route fixed that setup error without changing code, checks, dependencies, or limits.
- A real check-plan comparison for three provider-attribution source/test paths plus `config/assertion-safety-baseline.txt` changed only full-core lint to the maintained targeted command. The assertion ratchet and all other selected commands remained unchanged.
- One operational before/after comparison used identical source files and resource limits. `pnpm lint:core` was stopped at the 16 GiB descendant-RSS limit after 54.575 seconds; targeted lint on the three files finished in 16.359 seconds, peaked at 8.627 GB sampled descendant RSS, and reported zero warnings or errors. The baseline is censored and order was not reversed: these are observed command outcomes, not an exact percentage speedup or Gateway latency claim.
- Independent source review and isolated Codex autoreview found no actionable P0–P2 findings.
