### PR TITLE
fix: qualify reviewed hardware probes in release checks

### DIFF
--- a/scripts/lib/plugin-npm-security-scan.mts
+++ b/scripts/lib/plugin-npm-security-scan.mts
@@ -96,7 +96,7 @@ const MAX_SCANNABLE_TOTAL_BYTES_PER_PACKAGE = 64 * 1024 * 1024;
 const PACKAGE_SCAN_CONCURRENCY = 4;
 const CANONICAL_NPM_PACKAGE_NAME = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u;
 
-const CURRENT_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS = new Map<string, number>([
+const RELEASE_2026_9_1_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/acpx:dangerous-exec:src/codex-auth-bridge.ts", 1],
   ["@openclaw/acpx:dangerous-exec:src/runtime-internals/mcp-proxy.mjs", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
@@ -108,6 +108,11 @@ const CURRENT_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS = new Map<string, number>(
   ["@openclaw/raft:dangerous-exec:src/gateway.ts", 1],
   ["@openclaw/signal:dangerous-exec:src/daemon.ts", 1],
   ["@openclaw/voice-call:dangerous-exec:src/tunnel.ts", 1],
+]);
+
+const CURRENT_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS = new Map<string, number>([
+  ...RELEASE_2026_9_1_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS,
+  ["@openclaw/llama-cpp-provider:dangerous-exec:src/hardware.ts", 1],
 ]);
 
 type ReviewedReleaseLayout = {
@@ -199,7 +204,14 @@ const FROZEN_EXTENDED_STABLE_2026_6_33_LAYOUT = {
 };
 
 const FROZEN_RELEASE_SECURITY_INVENTORY_POLICIES = new Map<string, PluginSecurityInventoryPolicy>([
-  ["release/2026.9.1", CURRENT_SECURITY_INVENTORY_POLICY],
+  [
+    "release/2026.9.1",
+    {
+      ...CURRENT_SECURITY_INVENTORY_POLICY,
+      requiredSourceFindingCounts: RELEASE_2026_9_1_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS,
+    },
+  ],
+  ["release/2026.9.2", CURRENT_SECURITY_INVENTORY_POLICY],
   [
     "extended-stable/2026.6.33",
     {

--- a/test/scripts/plugin-npm-security-scan.test.ts
+++ b/test/scripts/plugin-npm-security-scan.test.ts
@@ -218,7 +218,8 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
     expect(resolveReviewedSourceLayout(current)?.id).toBe("current");
     expect(resolveReviewedSourceLayout(current, "release/2026.9.1")?.id).toBe("current");
     expect(resolveReviewedSourceLayout(frozenLegacy, "release/2026.9.1")).toBeUndefined();
-    expect(resolveReviewedSourceLayout(current, "release/2026.9.2")).toBeUndefined();
+    expect(resolveReviewedSourceLayout(current, "release/2026.9.2")?.id).toBe("current");
+    expect(resolveReviewedSourceLayout(current, "release/2026.9.3")).toBeUndefined();
     expect(resolveReviewedSourceLayout(frozenLegacy)).toBeUndefined();
     expect(resolveReviewedSourceLayout(frozenLegacy, "extended-stable/2026.6.33")?.id).toBe(
       "extended-stable-2026.6.33",
@@ -259,6 +260,54 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
       }),
     ).toMatchObject({ layout: null, status: "fail" });
   });
+
+  it.each([1, 2])(
+    "reviews exactly one current hardware probe, preserving frozen policy: %s",
+    async (count) => {
+      const packageName = "@openclaw/llama-cpp-provider";
+      const hardwareKey = `${packageName}:dangerous-exec:src/hardware.ts`;
+      const installerKey = `${packageName}:dangerous-exec:src/llama-server-install.ts`;
+      const probe =
+        'import { execFile } from "node:child_process";\nexecFile("/usr/bin/vm_stat", []);\n';
+      const artifact = writePluginArtifact({
+        extensionId: "llama-cpp",
+        files: {
+          "src/hardware.ts": probe + (count === 2 ? 'execFile("/bin/df", ["-P", "/tmp"]);\n' : ""),
+          "src/llama-server-install.ts": probe,
+        },
+        packageName,
+      });
+      const current = await scanPublishablePluginPackages([artifact.artifact]);
+      expect(current.scanErrors).toEqual([]);
+      expect(current.packageResults[0]?.unexpectedCriticalFindings).toEqual([]);
+      expect(current.packageResults[0]?.reviewedCriticalFindings).toEqual([
+        ...Array.from({ length: count }, () => hardwareKey),
+        installerKey,
+      ]);
+      const currentReport = buildPluginNpmSecurityScanReport({
+        candidateSha: CANDIDATE_SHA,
+        packageResults: [
+          ...current.packageResults,
+          syntheticResult("@openclaw/codex", { reviewedCriticalFindings: currentLayoutFindings() }),
+        ],
+        toolingSha: TOOLING_SHA,
+      });
+      const packageErrors = currentReport.errors.filter((error) =>
+        error.startsWith(`${packageName}:`),
+      );
+      expect(packageErrors).toEqual(
+        count === 1 ? [] : [expect.stringContaining("reviewed critical inventory mismatch")],
+      );
+
+      const frozen = await scanPublishablePluginPackages([artifact.artifact], "release/2026.9.1");
+      expect(frozen.scanErrors).toEqual([]);
+      expect(frozen.packageResults[0]?.reviewedCriticalFindings).toEqual([installerKey]);
+      expect(frozen.packageResults[0]?.unexpectedCriticalFindings).toHaveLength(count);
+      expect(frozen.packageResults[0]?.unexpectedCriticalFindings).toEqual(
+        expect.arrayContaining([{ line: 2, path: "src/hardware.ts", ruleId: "dangerous-exec" }]),
+      );
+    },
+  );
 
   it("scans checked-in malicious code without running candidate hooks or helpers", async () => {
     const candidateRoot = tempDirs.make("openclaw-plugin-security-inert-pack-");


### PR DESCRIPTION
## What Problem This Solves

Release qualification rejects the reviewed llama.cpp hardware probe as an unexpected critical finding. The trusted scanner on main also lacks the exact `release/2026.9.2` context registration already present in the approved release preparation, so that release cannot select its inventory.

## Why This Change Was Made

Record the explicitly approved `@openclaw/llama-cpp-provider:dangerous-exec:src/hardware.ts` finding with required count **1**, and register only `release/2026.9.2` against the current policy. Preserve `release/2026.9.1`'s existing required counts separately; its frozen source predates the hardware detector. Extended-stable counts, optional packed findings, layout discrimination, unknown-context rejection, and scanner rules remain unchanged.

The detector added in #138464 uses one private `execFile` wrapper for fixed read-only hardware commands. Arguments are passed separately, with a 3-second timeout, 64 KiB output limit and cancellation. Direct Node runtime inspection confirmed the default `shell: false`; the detector is called during setup, not inference. This change records the reviewed finding without rewriting runtime code to evade detection.

## User Impact

Current and 2026.9.2 release checks can qualify the reviewed hardware probe. Additional execution findings still fail the exact-count inventory check. The frozen 2026.9.1 policy remains unchanged, and unregistered release contexts continue to fail closed.

## Evidence

- Both new public scanner cases failed before the approved inventory update. A separate exact-9.2 layout regression failed before the registration was restored. The final scanner and hardware suites pass **31 tests**, and the complete changed-file gate passes.
- Rescanned the same **90** retained supplemental inert plugin packages from source/tooling `2329399cf6a9a2ca0c19d6c620b713a2768f9125`, verifying every tarball hash before and after. Before: **58 findings, 50 reviewed critical findings, one unexpected hardware finding**. After: **58 findings, 51 reviewed, zero unexpected**, passing for both current and `release/2026.9.2`.
- Every package result remains identical except that single hardware finding moving into the reviewed inventory. Frozen-9.1 reports are identical before/after apart from the declared tooling revision: they continue to reject the post-release hardware file in these newer inputs. Frozen source `ad6fe23aecb9b833d68139b0ddc9f239b894d2f1` has no `hardware.ts`. `release/2026.9.3` remains rejected.
- The exact 9.2 context registration was inspected in approved release source `b88b7fb691745c0e809732f0729f239f2b91c8b4`; there is no broad release-ref fallback.

This proof covers supplemental inert checked-in npm input, not final built publication bytes. Product runtime changes: **0**. Tooling: **+12 net lines**, principally separating the frozen map; tests: **+49 net lines**. Fresh managed P2 review found no actionable findings.
