### PR TITLE
refactor(plugins): share manifest capability families

### DIFF
--- a/src/plugins/capability-summary.ts
+++ b/src/plugins/capability-summary.ts
@@ -22,43 +22,9 @@ import {
 } from "./hook-policy-decisions.js";
 import type { InstalledPluginInstallRecordInfo } from "./installed-plugin-index-types.js";
 import type { InstalledPluginPackageOwnership } from "./installed-plugin-package-ownership.js";
+import { PLUGIN_MANIFEST_CONTRACT_KEYS } from "./manifest-contract-keys.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
-import type { PluginManifestContracts } from "./manifest-types.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
-
-const MANIFEST_CONTRACT_FAMILIES = [
-  "embeddedExtensionFactories",
-  "agentToolResultMiddleware",
-  "trustedToolPolicies",
-  "externalAuthProviders",
-  "embeddingProviders",
-  "speechProviders",
-  "realtimeTranscriptionProviders",
-  "realtimeVoiceProviders",
-  "mediaUnderstandingProviders",
-  "transcriptSourceProviders",
-  "documentExtractors",
-  "imageGenerationProviders",
-  "videoGenerationProviders",
-  "musicGenerationProviders",
-  "webContentExtractors",
-  "webFetchProviders",
-  "webSearchProviders",
-  "workerProviders",
-  "usageProviders",
-  "migrationProviders",
-  "gatewayMethodDispatch",
-  "tools",
-] as const satisfies readonly (keyof PluginManifestContracts)[];
-
-type MissingManifestContractFamilies = Exclude<
-  keyof PluginManifestContracts,
-  (typeof MANIFEST_CONTRACT_FAMILIES)[number]
->;
-
-const REVIEWED_MANIFEST_CONTRACT_FAMILIES: MissingManifestContractFamilies extends never
-  ? typeof MANIFEST_CONTRACT_FAMILIES
-  : never = MANIFEST_CONTRACT_FAMILIES;
 
 type PluginCapabilityManifest = {
   channels?: readonly string[];
@@ -206,7 +172,7 @@ export function buildPluginCapabilitySummary(params: {
       ].toSorted(),
       contracts: [
         ...new Set(
-          REVIEWED_MANIFEST_CONTRACT_FAMILIES.flatMap((family) =>
+          PLUGIN_MANIFEST_CONTRACT_KEYS.flatMap((family) =>
             (manifest.contracts?.[family] ?? []).map((id) => `${family}: ${id}`),
           ),
         ),

--- a/src/plugins/manifest-capability-normalizers.ts
+++ b/src/plugins/manifest-capability-normalizers.ts
@@ -2,6 +2,7 @@ import { normalizeOptionalString } from "../../packages/normalization-core/src/s
 import { normalizeTrimmedStringList } from "../../packages/normalization-core/src/string-normalization.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { isRecord } from "../utils.js";
+import { PLUGIN_MANIFEST_CONTRACT_KEYS } from "./manifest-contract-keys.js";
 import type {
   PluginManifestCapabilityProviderAuthSignal,
   PluginManifestCapabilityProviderConfigSignal,
@@ -350,37 +351,12 @@ export function normalizeManifestCatalog(value: unknown): PluginManifestCatalog 
   };
 }
 
-const MANIFEST_CONTRACT_KEYS = [
-  "embeddedExtensionFactories",
-  "agentToolResultMiddleware",
-  "trustedToolPolicies",
-  "externalAuthProviders",
-  "embeddingProviders",
-  "speechProviders",
-  "realtimeTranscriptionProviders",
-  "realtimeVoiceProviders",
-  "mediaUnderstandingProviders",
-  "transcriptSourceProviders",
-  "documentExtractors",
-  "imageGenerationProviders",
-  "videoGenerationProviders",
-  "musicGenerationProviders",
-  "webContentExtractors",
-  "webFetchProviders",
-  "webSearchProviders",
-  "workerProviders",
-  "usageProviders",
-  "migrationProviders",
-  "gatewayMethodDispatch",
-  "tools",
-] as const satisfies readonly (keyof PluginManifestContracts)[];
-
 export function normalizeManifestContracts(value: unknown): PluginManifestContracts | undefined {
   if (!isRecord(value)) {
     return undefined;
   }
   const contracts: PluginManifestContracts = {};
-  for (const key of MANIFEST_CONTRACT_KEYS) {
+  for (const key of PLUGIN_MANIFEST_CONTRACT_KEYS) {
     const entries = normalizeTrimmedStringList(value[key]);
     if (entries.length > 0) {
       contracts[key] = entries;

--- a/src/plugins/manifest-contract-keys.ts
+++ b/src/plugins/manifest-contract-keys.ts
@@ -1,0 +1,36 @@
+import type { PluginManifestContracts } from "./manifest-types.js";
+
+const MANIFEST_CONTRACT_KEYS = [
+  "embeddedExtensionFactories",
+  "agentToolResultMiddleware",
+  "trustedToolPolicies",
+  "externalAuthProviders",
+  "embeddingProviders",
+  "speechProviders",
+  "realtimeTranscriptionProviders",
+  "realtimeVoiceProviders",
+  "mediaUnderstandingProviders",
+  "transcriptSourceProviders",
+  "documentExtractors",
+  "imageGenerationProviders",
+  "videoGenerationProviders",
+  "musicGenerationProviders",
+  "webContentExtractors",
+  "webFetchProviders",
+  "webSearchProviders",
+  "workerProviders",
+  "usageProviders",
+  "migrationProviders",
+  "gatewayMethodDispatch",
+  "tools",
+] as const satisfies readonly (keyof PluginManifestContracts)[];
+
+type MissingManifestContractKeys = Exclude<
+  keyof PluginManifestContracts,
+  (typeof MANIFEST_CONTRACT_KEYS)[number]
+>;
+
+// Parsing, catalog overlays, and capability consent must account for the same families.
+export const PLUGIN_MANIFEST_CONTRACT_KEYS: MissingManifestContractKeys extends never
+  ? typeof MANIFEST_CONTRACT_KEYS
+  : never = MANIFEST_CONTRACT_KEYS;

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -28,6 +28,7 @@ import {
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
 import { resolveInstalledPluginIndexStorePath } from "./installed-plugin-index-store-path.js";
+import { PLUGIN_MANIFEST_CONTRACT_KEYS } from "./manifest-contract-keys.js";
 import { recordPluginManifestInstallOwner } from "./manifest-install-owner.js";
 import type {
   BundledChannelConfigCollector,
@@ -304,30 +305,7 @@ function mergeManifestContracts(
     return manifestContracts;
   }
   const contracts: PluginManifestContracts = {};
-  for (const key of [
-    "embeddedExtensionFactories",
-    "agentToolResultMiddleware",
-    "trustedToolPolicies",
-    "externalAuthProviders",
-    "embeddingProviders",
-    "speechProviders",
-    "realtimeTranscriptionProviders",
-    "realtimeVoiceProviders",
-    "mediaUnderstandingProviders",
-    "transcriptSourceProviders",
-    "documentExtractors",
-    "imageGenerationProviders",
-    "videoGenerationProviders",
-    "musicGenerationProviders",
-    "webContentExtractors",
-    "webFetchProviders",
-    "webSearchProviders",
-    "workerProviders",
-    "usageProviders",
-    "migrationProviders",
-    "gatewayMethodDispatch",
-    "tools",
-  ] as const) {
+  for (const key of PLUGIN_MANIFEST_CONTRACT_KEYS) {
     const merged = mergeContractLists(manifestContracts?.[key], catalogContracts[key]);
     if (merged) {
       contracts[key] = merged;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Plugin maintainers must currently update three separate capability-family inventories to keep manifest parsing, official catalog supplementation, and capability consent aligned. The inventories contain the same 22 families, but only the consent inventory checks that every declared family is accounted for.

## Why This Change Was Made

One internal, exhaustively checked tuple now supplies all three consumers. It preserves every family and its order while removing the duplicate lists; the shared module has only a type import, so metadata discovery stays independent of plugin runtime loading.

The manifest type and its field documentation remain the independent contract. The runtime eligibility subset and public Plugin SDK exports are unchanged. Production LOC: **+42/-86, net -44**; no test, generated, or dependency changes.

## User Impact

No user-visible behavior changes. Parsing, catalog overlays, consent summaries, and acceptance hashes keep their current behavior, with one place to maintain the supported capability families.

## Evidence

- Before and after: `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/plugins/capability-summary.test.ts src/plugins/manifest-registry.test.ts` — **126 tests pass**. Coverage includes every reviewed contract family, actual manifest normalization, and supplemental official-catalog contracts.
- Formatting, `git diff --check`, and targeted core lint pass.
- Fresh independent Codex autoreview through P2 reports scoped-clean. It checked all key values/order, the readonly tuple and exhaustive type check, unknown-key filtering, and metadata-only loading.
- The full changed-check pipeline now passes in the native PR checkout after a checkout-owned dependency install, including production/test typechecks, lint, unused exports, and import-cycle checks. The initial shared-install guard was preserved.
- `pnpm build` passes locally in that native checkout; no ineffective dynamic-import warnings were emitted.
- Exact-head [CI run 33963993520](https://github.com/openclaw/openclaw/actions/runs/33963993520) passes, including the required `openclaw/ci-gate`.
- Separate read-only Codex review of `ee882077ff64b2475113a2b7452c3894d34c7310` found no actionable P0–P2 findings.

Compatibility review requested by ClawSweeper: **0 config/default fields added, changed, or removed**. All 22 capability families and their order, unknown-key filtering, catalog merge ordering, consent hash inputs, public types, and SDK exports remain unchanged. Existing configurations and upgrades keep the same behavior; no migration is needed.

Validated head: `ee882077ff64b2475113a2b7452c3894d34c7310`.
