### PR TITLE
improve: normalize installed channel metadata once

### DIFF
--- a/src/agents/embedded-agent-runner/model.static-catalog.prepared.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.prepared.test.ts
@@ -34,7 +34,8 @@ vi.mock("../../plugins/manifest-registry.js", () => ({
   loadPluginManifestRegistryCore: mocks.loadPluginManifestRegistryCore,
 }));
 
-vi.mock("../../plugins/manifest.js", () => ({
+vi.mock("../../plugins/manifest.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../plugins/manifest.js")>()),
   loadPluginManifest: vi.fn(),
 }));
 

--- a/src/plugins/bundled-sources.test.ts
+++ b/src/plugins/bundled-sources.test.ts
@@ -25,7 +25,8 @@ vi.mock("./discovery.js", () => ({
   discoverOpenClawPlugins: (...args: unknown[]) => discoverOpenClawPluginsMock(...args),
 }));
 
-vi.mock("./manifest.js", () => ({
+vi.mock("./manifest.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./manifest.js")>()),
   loadPluginManifest: (...args: unknown[]) => loadPluginManifestMock(...args),
 }));
 

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -140,23 +140,18 @@ function normalizePackageChannelConfiguredState(
   if (!isRecord(configuredState)) {
     return undefined;
   }
-  const env = isRecord(configuredState.env)
-    ? {
-        ...(normalizeOptionalTrimmedStringList(configuredState.env.allOf)?.length
-          ? { allOf: normalizeOptionalTrimmedStringList(configuredState.env.allOf) }
-          : {}),
-        ...(normalizeOptionalTrimmedStringList(configuredState.env.anyOf)?.length
-          ? { anyOf: normalizeOptionalTrimmedStringList(configuredState.env.anyOf) }
-          : {}),
-      }
-    : undefined;
+  const rawEnv = isRecord(configuredState.env) ? configuredState.env : undefined;
+  const allOf = rawEnv ? normalizeOptionalTrimmedStringList(rawEnv.allOf) : undefined;
+  const anyOf = rawEnv ? normalizeOptionalTrimmedStringList(rawEnv.anyOf) : undefined;
+  const env =
+    allOf || anyOf ? { ...(allOf ? { allOf } : {}), ...(anyOf ? { anyOf } : {}) } : undefined;
   const specifier = normalizeOptionalString(configuredState.specifier);
   const exportName = normalizeOptionalString(configuredState.exportName);
-  return specifier || exportName || (env && Object.keys(env).length > 0)
+  return specifier || exportName || env
     ? {
         ...(specifier ? { specifier } : {}),
         ...(exportName ? { exportName } : {}),
-        ...(env && Object.keys(env).length > 0 ? { env } : {}),
+        ...(env ? { env } : {}),
       }
     : undefined;
 }
@@ -322,6 +317,16 @@ function normalizePackageChannelSetup(setup: unknown): PluginPackageChannel["set
   return { fields };
 }
 
+const PACKAGE_CHANNEL_NORMALIZERS = [
+  ["exposure", normalizePackageChannelExposure],
+  ["commands", normalizeManifestChannelCommandDefaults],
+  ["configuredState", normalizePackageChannelConfiguredState],
+  ["persistedAuthState", normalizePackageChannelPersistedAuthState],
+  ["doctorCapabilities", normalizePackageChannelDoctorCapabilities],
+  ["setup", normalizePackageChannelSetup],
+  ["cliAddOptions", normalizePackageChannelCliOptions],
+] as const;
+
 function normalizePersistedPackageChannel(value: unknown): PluginPackageChannel | undefined {
   if (!isRecord(value)) {
     return undefined;
@@ -372,15 +377,7 @@ function normalizePersistedPackageChannel(value: unknown): PluginPackageChannel 
       channel[key] = value[key];
     }
   }
-  for (const [key, normalize] of [
-    ["exposure", normalizePackageChannelExposure],
-    ["commands", normalizeManifestChannelCommandDefaults],
-    ["configuredState", normalizePackageChannelConfiguredState],
-    ["persistedAuthState", normalizePackageChannelPersistedAuthState],
-    ["doctorCapabilities", normalizePackageChannelDoctorCapabilities],
-    ["setup", normalizePackageChannelSetup],
-    ["cliAddOptions", normalizePackageChannelCliOptions],
-  ] as const) {
+  for (const [key, normalize] of PACKAGE_CHANNEL_NORMALIZERS) {
     const normalized = normalize(value[key]);
     if (normalized) {
       Object.assign(channel, { [key]: normalized });


### PR DESCRIPTION
## What Problem This Solves

Installed channel metadata normalization repeats work for each nonempty configured-state environment list and reconstructs the same normalizer table for each channel. This adds avoidable work to prepared plugin-registry discovery.

## Why This Change Was Made

Normalize each environment list once, reuse the existing undefined-for-empty contract, and keep the seven stable normalizer functions in one private module-level table. Output omission, field/list order, duplicates, and fresh-array ownership remain unchanged. Prepared metadata bypasses remain intact; the table holds no request data.

This removes three production lines (18 added / 21 deleted). Two test mocks now preserve real manifest exports while overriding only file loading (4 test lines added / 2 deleted); their assertions are unchanged. No configuration, public API, persistence semantics, or cache lifetime is added.

## User Impact

Installed channel discovery does less duplicate normalization while returning the same metadata. The measured improvement is small and local; this PR does not claim faster model responses or lower whole-Gateway startup time.

## Evidence

- Both variants passed the same 34 tests across three complete suites. The candidate passed all 28 maintained changed checks and the normal mapped build.
- One fixed before/candidate/candidate/before cohort measured the complete exported prepared-registry operation: 3,192 calls including proofs and 384 measured batch means. One-channel median improved 4.35% / 3.18% in the two orders (about 0.47 / 0.32 microseconds per call); eight mixed channels improved 3.40% / 11.20% (about 1.41 / 4.90 microseconds).
- Adverse results are retained: one-channel batch p95 worsened 10.02% / 1.64%; eight-channel p95 improved 28.64% / 9.88%. These p95 values are maxima of 16 batch means, not individual-call tails. Whole-host time, heap/RSS, imports, and unchanged controls were mixed; no overall memory or startup improvement is claimed. All 276 comparisons, including 108 adverse observations, were retained rather than filtered.
- Full serialized correctness envelopes checked output values/order, omission, diagnostics identity, reused records and independent normalized arrays. Ordinary package/persisted JSON is the input contract; arbitrary effectful getters or custom array species are not claimed equivalent.
- A built development Gateway using real OpenAI completed four fixed tasks: remember a synthetic fact, join three fixture files, recall the fact in the same session, and fetch the public Node performance documentation. All final outputs and tool activity were checked; the CPU profile sampled the emitted changed owner. This is candidate behavior proof, not a paired Gateway speed measurement or channel-delivery test. The isolated Gateway was stopped and its task credentials were removed.
- Independent source/evidence reviews and both partitioned Codex autoreview passes found no actionable P0–P2 findings. The normal build's existing worker source-map and bundler warnings remain recorded; they were not treated as clean output.

## CI Follow-through

The [initial CI run](https://github.com/openclaw/openclaw/actions/runs/33963960076/job/101300690466) caught a related fixture failure: the prepared-catalog test replaced the entire manifest module with only a loader mock, so the hoisted normalizer table could not read the real command normalizer. Local reproduction confirmed that failure and the same problem in the bundled-source fixture. Both fixtures now use the existing adjacent suites’ partial-mock pattern; production code and assertions are unchanged.

All 44 tests in the four complete affected/adjacent suites pass after the repair, followed by all 29 selected changed checks, including production/test typechecks and typed lint. A fresh independent Codex review of the repair found no actionable P0–P2 findings. The original failed CI and local reproductions are retained; the new head must still pass CI before landing. The earlier component timings, mapped build and real Gateway tasks apply to identical production bytes, not a newly measured test change.
