### PR TITLE
fix: unblock session updates during archived worktree restore

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
@@ -102,58 +102,64 @@ async function restoreArchivedDispatchSession(params: {
   }
   const snapshotSessionId = entry.sessionId;
   const snapshotArchivedAt = entry.archivedAt;
-  // Admission must see the current owner: a rebound, re-archive, or unsafe placement stays untouched.
-  let assertCommitAllowed: (() => void) | undefined;
+  const canRestore = (currentEntry: SessionEntry) => {
+    if (
+      currentEntry.sessionId !== snapshotSessionId ||
+      currentEntry.archivedAt !== snapshotArchivedAt ||
+      isRestartRecoveryTombstone(currentEntry)
+    ) {
+      return false;
+    }
+    try {
+      const placement = currentEntry.sessionId
+        ? placementContext.workerSessionPlacementService
+            ?.getMany([currentEntry.sessionId])
+            .get(currentEntry.sessionId)
+        : undefined;
+      return !resolveWorkerPlacementArchiveRestoreError({
+        context: placementContext,
+        key: sessionKey,
+        placement,
+      });
+    } catch {
+      return false;
+    }
+  };
   return await runExclusiveSessionLifecycleMutation({
     scope: storePath,
     identities: [sessionKey, snapshotSessionId],
-    run: async () =>
-      (await patchSessionEntryCore(
-        { sessionKey, storePath },
-        async (currentEntry) => {
-          if (
-            currentEntry.sessionId !== snapshotSessionId ||
-            currentEntry.archivedAt !== snapshotArchivedAt ||
-            isRestartRecoveryTombstone(currentEntry)
-          ) {
-            return null;
-          }
-          try {
-            const placement = currentEntry.sessionId
-              ? placementContext.workerSessionPlacementService
-                  ?.getMany([currentEntry.sessionId])
-                  .get(currentEntry.sessionId)
-              : undefined;
-            if (
-              resolveWorkerPlacementArchiveRestoreError({
-                context: placementContext,
-                key: sessionKey,
-                placement,
-              })
-            ) {
-              return null;
-            }
-          } catch {
-            return null;
-          }
-          if (currentEntry.worktree) {
-            const { synchronizeSessionWorktreeArchive } =
-              await import("../../sessions/session-worktree-lifecycle.js");
-            assertCommitAllowed = prepareSessionWorkerPlacementMutationCheck({
-              context: placementContext,
-              sessionId: currentEntry.sessionId,
-            });
-            await synchronizeSessionWorktreeArchive({
-              archived: false,
-              entry: currentEntry,
-              scope: { sessionKey, storePath },
-              commitGuard: assertCommitAllowed,
-            });
-          }
-          return { archivedAt: undefined, archivedBy: undefined, archiveReason: undefined };
-        },
-        { assertCommitAllowed: () => assertCommitAllowed?.() },
-      )) ?? undefined,
+    run: async () => {
+      const scope = { sessionKey, storePath };
+      const currentEntry = loadSessionStoreEntry(scope);
+      if (!currentEntry || !canRestore(currentEntry)) {
+        return currentEntry;
+      }
+      let assertCommitAllowed: (() => void) | undefined;
+      if (currentEntry.worktree) {
+        const { synchronizeSessionWorktreeArchive } =
+          await import("../../sessions/session-worktree-lifecycle.js");
+        // Keep the target fenced through Git/allocation waits without retaining the agent writer.
+        assertCommitAllowed = await synchronizeSessionWorktreeArchive({
+          archived: false,
+          entry: currentEntry,
+          scope,
+          commitGuard: prepareSessionWorkerPlacementMutationCheck({
+            context: placementContext,
+            sessionId: currentEntry.sessionId,
+          }),
+        });
+      }
+      const updatedEntry = await patchSessionEntryCore(
+        scope,
+        (current) =>
+          canRestore(current)
+            ? { archivedAt: undefined, archivedBy: undefined, archiveReason: undefined }
+            : null,
+        // The writer may have waited; revalidate the prepared binding at the actual commit edge.
+        { assertCommitAllowed },
+      );
+      return updatedEntry ?? undefined;
+    },
   });
 }
 

--- a/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
@@ -16,8 +16,16 @@ import {
 } from "../agents/worktrees/run-lease.js";
 import { managedWorktrees, WorktreeSnapshotError } from "../agents/worktrees/service.js";
 import { loadSessionEntry, patchSessionEntryCore } from "../config/sessions/session-accessor.js";
+import {
+  resolveSqliteScope,
+  runExclusiveSqliteSessionWrite,
+  toDatabaseOptions,
+} from "../config/sessions/session-accessor.sqlite-scope.js";
+import { SQLITE_SESSION_WRITER_QUEUES } from "../config/sessions/store-writer-state.js";
 import { isSessionLifecycleMutationActive } from "../sessions/session-lifecycle-admission.js";
 import { listSessionStateEventsSince } from "../sessions/session-state-events.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { testState, writeSessionStore } from "./test-helpers.js";
@@ -99,20 +107,47 @@ test.each(["none", "restore-failed", "placement-changed"] as const)(
         : undefined;
     const worktreeLifecycle = await import("../sessions/session-worktree-lifecycle.js");
     const synchronize = worktreeLifecycle.synchronizeSessionWorktreeArchive;
+    const sqliteScope = resolveSqliteScope({ storePath, sessionKey: key });
+    const writerQueuePath = resolveOpenClawAgentSqlitePath(toDatabaseOptions(sqliteScope));
+    const writerStarted = createDeferredCore();
+    const releaseWriter = createDeferredCore();
+    let heldWriter: Promise<void> | undefined;
+    let admission: ReturnType<typeof coordinator.ensureDispatchReplyOperation> | undefined;
     const placementChange = placements
       ? vi
           .spyOn(worktreeLifecycle, "synchronizeSessionWorktreeArchive")
           .mockImplementationOnce(async (params) => {
-            await synchronize(params);
-            // Another durable owner can advance after filesystem preparation has returned.
-            placements.startDispatch({ sessionId, sessionKey: key, agentId: "main" });
+            const assertCurrent = await synchronize(params);
+            heldWriter = runExclusiveSqliteSessionWrite(sqliteScope, async () => {
+              writerStarted.resolve();
+              await releaseWriter.promise;
+            });
+            await writerStarted.promise;
+            return assertCurrent;
           })
       : undefined;
     try {
-      const admission = coordinator.ensureDispatchReplyOperation("pre_dispatch");
+      admission = coordinator.ensureDispatchReplyOperation("pre_dispatch");
+      void admission.catch(() => {});
       if (failure === "placement-changed") {
+        // Advance placement only after the restored session waits behind a real SQLite writer.
+        await Promise.race([writerStarted.promise, admission]);
+        expect(heldWriter).toBeDefined();
+        await vi.waitFor(() => {
+          expect(SQLITE_SESSION_WRITER_QUEUES.get(writerQueuePath)?.pending.length).toBe(1);
+        });
+        expect(isSessionLifecycleMutationActive(storePath, [key, sessionId])).toBe(true);
+        placements!.startDispatch({ sessionId, sessionKey: key, agentId: "main" });
+        // A stopped replacement is eligible, but cannot reuse preparation owned by the prior placement.
+        placements!.fail({ sessionId, expectedGeneration: 1, recoveryError: "preparation failed" });
+        releaseWriter.resolve();
+        await heldWriter;
         await expect(admission).rejects.toThrow("changed before mutation");
-        expect(placements?.get(sessionId)).toMatchObject({ state: "requested", generation: 1 });
+        expect(placements?.get(sessionId)).toMatchObject({
+          state: "failed",
+          generation: 2,
+          environmentId: null,
+        });
         expect(loadSessionEntry({ storePath, sessionKey: key })?.archivedAt).toBe(1);
         await expect(fs.readFile(path.join(worktree.path, "draft.txt"), "utf8")).resolves.toBe(
           "inbound restore keeps work\n",
@@ -132,10 +167,14 @@ test.each(["none", "restore-failed", "placement-changed"] as const)(
         transcript,
       );
     } finally {
+      releaseWriter.resolve();
+      await heldWriter;
+      await admission?.catch(() => {});
       placementChange?.mockRestore();
       restore?.mockRestore();
       coordinator.completeDispatchReplyOperation();
       await coordinator.releasePreDispatchLifecycleAdmission();
+      expect(isSessionLifecycleMutationActive(storePath, [key, sessionId])).toBe(false);
     }
   },
 );

--- a/src/gateway/server.sessions.inbound-worktree-writer.test.ts
+++ b/src/gateway/server.sessions.inbound-worktree-writer.test.ts
@@ -1,0 +1,156 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, onTestFinished, test, vi } from "vitest";
+import { managedWorktrees } from "../agents/worktrees/service.js";
+import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { isSessionLifecycleMutationActive } from "../sessions/session-lifecycle-admission.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { withOpenClawStateLease } from "../state/openclaw-state-lease.js";
+import {
+  directSessionReq,
+  loadSeededTranscriptEvents,
+} from "./test/server-sessions.test-helpers.js";
+import { setupGatewaySessionsWorktreeTestHarness } from "./test/server-sessions.worktree-fixture.js";
+
+const { createArchiveWorktreeFixture } = setupGatewaySessionsWorktreeTestHarness();
+
+test.each([false, true])(
+  "inbound restore releases unrelated session writes while allocation waits (checkout already restored=%s)",
+  async (alreadyRestored) => {
+    const fixture = await createArchiveWorktreeFixture();
+    const { key, sessionId, storePath, worktree, workspace } = fixture;
+    const peer = await directSessionReq<{ key: string }>("sessions.create", { agentId: "main" });
+    expect(peer.ok).toBe(true);
+    const peerKey = peer.payload!.key;
+    expect(peerKey).toMatch(/^agent:main:/);
+    expect(loadSessionEntry({ storePath, sessionKey: peerKey })).toBeDefined();
+    await fs.writeFile(path.join(worktree.path, "draft.txt"), "inbound restore preserves work\n");
+    expect(
+      await directSessionReq("sessions.patch", {
+        key,
+        expectedSessionId: sessionId,
+        archived: true,
+      }),
+    ).toMatchObject({ ok: true });
+    if (alreadyRestored) {
+      await managedWorktrees.restore({ id: worktree.id });
+    }
+    const [
+      { createDispatchReplyOperationCoordinator },
+      { createReplyDispatcher },
+      { buildTestCtx },
+    ] = await Promise.all([
+      import("../auto-reply/reply/dispatch-from-config.lifecycle.js"),
+      import("../auto-reply/reply/reply-dispatcher.js"),
+      import("../auto-reply/reply/test-ctx.js"),
+    ]);
+    const transcript = await loadSeededTranscriptEvents(fixture.transcriptScope);
+    const dispatcher = createReplyDispatcher({ deliver: async () => {} });
+    onTestFinished(async () => {
+      dispatcher.markComplete();
+      await dispatcher.waitForIdle();
+    });
+    const coordinator = createDispatchReplyOperationCoordinator({
+      agentId: "main",
+      cfg: { agents: { defaults: { workspace } } },
+      ctx: buildTestCtx({
+        SessionKey: key,
+        Body: "Continue this task",
+        CommandSource: undefined,
+        InboundAccessAuthorized: true,
+        InboundEventKind: "user_request",
+        InputProvenance: { kind: "external_user", sourceChannel: "discord" },
+      }),
+      dispatcher,
+      dispatchOperationSessionKey: key,
+      operationSessionStoreEntry: {
+        storePath,
+        entry: loadSessionEntry({ storePath, sessionKey: key }),
+      },
+      sessionWorkerPlacementContext: {},
+      resolveOperationExpectedSessionId: () => sessionId,
+    });
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    const restoreEntered = createDeferredCore();
+    const allocation = withOpenClawStateLease(
+      {
+        scope: "core:managed-worktrees:create",
+        key: "capacity",
+        database: { scope: "shared" },
+        leaseMs: 60_000,
+        waitMs: 5_000,
+      },
+      async () => {
+        entered.resolve();
+        await release.promise;
+      },
+    );
+    const originalRestore = managedWorktrees.restore.bind(managedWorktrees);
+    const restore = vi.spyOn(managedWorktrees, "restore").mockImplementation((params) => {
+      restoreEntered.resolve();
+      return originalRestore(params);
+    });
+    let admission: ReturnType<typeof coordinator.ensureDispatchReplyOperation> | undefined;
+    let independent: ReturnType<typeof directSessionReq> | undefined;
+    let admissionDone = false;
+    let independentDone = false;
+    let blockedIndependent: Error | undefined;
+    try {
+      await Promise.race([entered.promise, allocation]);
+      admission = coordinator.ensureDispatchReplyOperation("pre_dispatch").then((result) => {
+        admissionDone = true;
+        return result;
+      });
+      if (alreadyRestored) {
+        await expect(admission).resolves.toEqual({ status: "ready" });
+        expect(restore).not.toHaveBeenCalled();
+      } else {
+        await Promise.race([restoreEntered.promise, admission]);
+        expect(restore).toHaveBeenCalledOnce();
+        expect(isSessionLifecycleMutationActive(storePath, [key, sessionId])).toBe(true);
+      }
+      independent = directSessionReq("sessions.patch", {
+        key: peerKey,
+        label: "Independent inbound peer",
+      }).then((result) => {
+        independentDone = true;
+        return result;
+      });
+      // Release the real allocation lease even when the pre-fix writer blocks this assertion.
+      await vi
+        .waitFor(() => expect(independentDone).toBe(true))
+        .catch((error: unknown) => {
+          blockedIndependent = error instanceof Error ? error : new Error(String(error));
+        });
+      if (!alreadyRestored) {
+        expect(admissionDone).toBe(false);
+        expect(isSessionLifecycleMutationActive(storePath, [key, sessionId])).toBe(true);
+        expect(loadSessionEntry({ storePath, sessionKey: key })?.archivedAt).toEqual(
+          expect.any(Number),
+        );
+        await expect(fs.access(worktree.path)).rejects.toThrow();
+      }
+    } finally {
+      release.resolve();
+      await Promise.allSettled([allocation, admission, independent]);
+      restore.mockRestore();
+      coordinator.completeDispatchReplyOperation();
+      await coordinator.releasePreDispatchLifecycleAdmission();
+    }
+    await allocation;
+    await expect(admission).resolves.toEqual({ status: "ready" });
+    expect(await independent).toMatchObject({ ok: true });
+    expect(loadSessionEntry({ storePath, sessionKey: peerKey })?.label).toBe(
+      "Independent inbound peer",
+    );
+    expect(loadSessionEntry({ storePath, sessionKey: key })?.archivedAt).toBeUndefined();
+    await expect(fs.readFile(path.join(worktree.path, "draft.txt"), "utf8")).resolves.toBe(
+      "inbound restore preserves work\n",
+    );
+    await expect(loadSeededTranscriptEvents(fixture.transcriptScope)).resolves.toEqual(transcript);
+    if (blockedIndependent) {
+      throw blockedIndependent;
+    }
+  },
+);

--- a/src/sessions/session-worktree-lifecycle.ts
+++ b/src/sessions/session-worktree-lifecycle.ts
@@ -103,11 +103,11 @@ export async function synchronizeSessionWorktreeArchive(params: {
   entry: SessionEntry;
   scope: SessionAccessScope;
   commitGuard?: () => void;
-}): Promise<void> {
+}): Promise<() => void> {
   const { entry, scope } = params;
   const id = entry.worktree?.id;
   if (!id) {
-    return;
+    return () => params.commitGuard?.();
   }
   const assertCurrent = () => {
     params.commitGuard?.();
@@ -189,6 +189,7 @@ export async function synchronizeSessionWorktreeArchive(params: {
     }
   }
   assertCurrent();
+  return assertCurrent;
 }
 
 /** Maintenance commits archive metadata first; its released writer lane must never retain Git work. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where resuming an archived conversation could delay unrelated conversation updates for the same agent while its saved worktree waited for Git or allocation capacity.

## Why This Change Was Made

The inbound lifecycle owner now prepares the worktree before acquiring the agent's session writer. It keeps the target session fenced throughout, then rechecks the current entry and the prepared worktree/placement ownership at the actual metadata commit. The shared worktree helper returns its existing guard instead of duplicating ownership checks.

## User Impact

Unrelated conversation updates can finish while restoration waits. The resumed conversation opens only after its saved work is restored, and an ownership change rejects stale preparation. Existing administrator worktree-removal behavior is preserved.

## Evidence

- Linux regression with the actual managed-worktree service, allocation lease, Gateway session handlers, and pre-dispatch coordinator: the unchanged owner blocks an unrelated same-agent update; the candidate lets it finish before allocation is released. The already-restored checkout control passes both versions.
- The existing placement regression now changes the real placement after restoration, while the final physical writer is queued. The candidate rejects the changed owner; a private negative control that moves the guard before writer acquisition incorrectly admits the operation.
- Saved checkout files, transcript contents, archive metadata, and lifecycle cleanup are checked across restoration success, failure, and ownership change.
- 296 owner/sibling tests passed. After the final test-only compatibility correction, all 13 affected Gateway cases and the negative control passed their expected outcomes. The full changed-file gate and build passed on Linux Node 24.19.0 with the frozen dependency lock.
- Independent review found no actionable P0–P2 findings. Earlier test lint/type errors were corrected and the full gate rerun; no check was waived.
- Production: +58/-51 (net +7); tests: +200/-5 (net +195). The production growth carries the prepared guard across the released writer and reuses one eligibility predicate at both owner boundaries. No schema, index, public API, or configuration change.

The proof uses isolated Linux handlers and real filesystem/state owners. It does not claim a real external-channel delivery or attribute a historical production event-loop pause.
