### PR TITLE
refactor(reply): share dispatch hook invocation

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.acp-tail.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-tail.ts
@@ -1,9 +1,5 @@
-import { runWithDispatchAbortSignal } from "./dispatch-from-config.abort.js";
-import {
-  admittedSessionSettingsRestrictRuntime,
-  createReplyDispatchEvent,
-} from "./dispatch-from-config.events.js";
 import type { PrepareDispatchExecutionReadyState } from "./dispatch-from-config.prepare-execution.js";
+import { runReplyDispatchHook } from "./dispatch-from-config.reply-dispatch-hook.js";
 import type { DispatchFromConfigResult } from "./dispatch-from-config.types.js";
 
 export async function handleAcpDispatchTailAfterReset(
@@ -15,60 +11,10 @@ export async function handleAcpDispatchTailAfterReset(
   // Command handling prepared a trailing prompt after ACP in-place reset.
   // Route that tail through ACP now (same turn) instead of embedded dispatch.
   state.ctx.AcpDispatchTailAfterReset = false;
-  const hookRunner = state.hookRunner;
-  if (admittedSessionSettingsRestrictRuntime(state.params.replyOptions?.admittedSessionSettings)) {
-    return undefined;
-  }
-  if (!hookRunner?.hasHooks("reply_dispatch", { dispatchKind: state.dispatchKind })) {
-    return undefined;
-  }
-  const tailDispatchResult = await state.runWithDispatchLifecycleAdmission(
-    async () =>
-      await runWithDispatchAbortSignal(
-        state.getDispatchAbortSignal(),
-        () =>
-          hookRunner.runReplyDispatch(
-            createReplyDispatchEvent({
-              ctx: state.ctx,
-              runId: state.params.replyOptions?.runId,
-              sessionKey: state.acpDispatchSessionKey,
-              toolsAllow: state.params.replyOptions?.toolsAllow,
-              images: state.params.replyOptions?.images,
-              inboundAudio: state.inboundAudio,
-              sessionTtsAuto: state.sessionTtsAuto,
-              ttsChannel: state.deliveryChannel,
-              suppressUserDelivery: state.suppressHookUserDelivery,
-              suppressReplyLifecycle: state.suppressHookReplyLifecycle,
-              sourceReplyDeliveryMode: state.sourceReplyDeliveryMode,
-              shouldRouteToOriginating: state.shouldRouteToOriginating,
-              originatingChannel: state.routeReplyChannel,
-              originatingTo: state.routeReplyTo,
-              originatingAccountId: state.replyContextAccountId,
-              originatingThreadId: state.routeReplyThreadId,
-              originatingChatType: state.replyRoute.chatType,
-              shouldSendToolSummaries: state.shouldSendToolSummaries,
-              shouldSendFullToolDetails: state.shouldEmitFullVerboseProgress(),
-              sendPolicy: state.sendPolicy,
-              isTailDispatch: true,
-            }),
-            {
-              cfg: state.cfg,
-              dispatchKind: state.dispatchKind,
-              dispatcher: state.dispatchHookDispatcher,
-              abortSignal:
-                state.getPreDispatchAbortSignal() ?? state.params.replyOptions?.abortSignal,
-              onReplyStart: state.params.replyOptions?.onReplyStart,
-              onAgentRunStart: state.params.replyOptions?.onAgentRunStart,
-              userTurnTranscriptRecorder: state.params.replyOptions?.userTurnTranscriptRecorder,
-              prepareAssistantTranscriptMessage:
-                state.params.replyOptions?.prepareAssistantTranscriptMessage,
-              recordProcessed: state.recordProcessed,
-              markIdle: state.markIdle,
-            },
-          ),
-        state.trackDispatchLifecycleWork,
-      ),
-  );
+  const tailDispatchResult = await runReplyDispatchHook(state, {
+    shouldSendToolSummaries: state.shouldSendToolSummaries,
+    isTailDispatch: true,
+  });
   if (!tailDispatchResult?.handled) {
     return undefined;
   }

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch-hook.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch-hook.ts
@@ -4,10 +4,10 @@ import type { PrepareDispatchOperationReadyState } from "./dispatch-from-config.
 import { runtimeTakeoverHooksAllowed } from "./dispatch-from-config.restricted-runtime.js";
 import type { DispatchFromConfigResult } from "./dispatch-from-config.types.js";
 
-export async function runReplyDispatchTakeover(
+export function runReplyDispatchHook(
   state: PrepareDispatchOperationReadyState,
-  shouldSendToolSummaries: () => boolean,
-): Promise<{ status: "complete"; result: DispatchFromConfigResult } | undefined> {
+  options: { shouldSendToolSummaries: () => boolean; isTailDispatch?: true },
+) {
   const { hookRunner, params } = state;
   if (
     !runtimeTakeoverHooksAllowed(params.replyOptions?.admittedSessionSettings) ||
@@ -15,11 +15,14 @@ export async function runReplyDispatchTakeover(
   ) {
     return undefined;
   }
-  const result = await state.traceReplyPhase("reply.reply_dispatch_hooks", () =>
+  const run = () =>
     state.runWithDispatchLifecycleAdmission(
       async () =>
         await runWithDispatchAbortSignal(
-          state.getPreDispatchAbortSignal(),
+          // Reset tails have entered dispatch admission; initial takeover still owns the pre-dispatch lease.
+          options.isTailDispatch
+            ? state.getDispatchAbortSignal()
+            : state.getPreDispatchAbortSignal(),
           () =>
             hookRunner.runReplyDispatch(
               createReplyDispatchEvent({
@@ -40,9 +43,10 @@ export async function runReplyDispatchTakeover(
                 originatingAccountId: state.replyContextAccountId,
                 originatingThreadId: state.routeReplyThreadId,
                 originatingChatType: state.replyRoute.chatType,
-                shouldSendToolSummaries,
+                shouldSendToolSummaries: options.shouldSendToolSummaries,
                 shouldSendFullToolDetails: state.shouldEmitFullVerboseProgress(),
                 sendPolicy: state.sendPolicy,
+                ...(options.isTailDispatch ? { isTailDispatch: true } : {}),
               }),
               {
                 cfg: state.cfg,
@@ -60,8 +64,15 @@ export async function runReplyDispatchTakeover(
             ),
           state.trackDispatchLifecycleWork,
         ),
-    ),
-  );
+    );
+  return options.isTailDispatch ? run() : state.traceReplyPhase("reply.reply_dispatch_hooks", run);
+}
+
+export async function runReplyDispatchTakeover(
+  state: PrepareDispatchOperationReadyState,
+  shouldSendToolSummaries: () => boolean,
+): Promise<{ status: "complete"; result: DispatchFromConfigResult } | undefined> {
+  const result = await runReplyDispatchHook(state, { shouldSendToolSummaries });
   if (!result?.handled) {
     return undefined;
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can update this branch.

</details>

## What Problem This Solves

Plugin reply takeover and the trailing prompt after an ACP reset duplicated the same host routing, delivery-policy, and transcript-callback wiring. Every change to that contract required updating both paths, creating avoidable maintenance work and a risk of inconsistent replies. This is a maintainer-requested refactor of that shared boundary.

## Why This Change Was Made

Both paths now use one invocation owner for eligibility checks, event/context construction, and lifecycle tracking. Event construction remains inside the abort callback, and tool-summary visibility remains a live getter. Initial takeover retains its pre-dispatch cancellation and trace; the ACP reset tail retains its dispatch cancellation, marker clearing, and completion/session-metadata accounting.

The two settlement wrappers remain separate because they own different lifecycle facts. Sharing only the field projection would leave the same eligibility and invocation policy duplicated. The change removes 43 production lines net (+24/−67), with no test changes or additional module.

## User Impact

No user-visible behavior change is intended. Existing plugin takeover, reset-tail replies, cancellation, source routing, and transcript ownership are preserved. Future changes to the shared hook contract have one implementation to update.

## Evidence

Head: `fb48a3472aba9ff05d2f8cf3260d0978b5ef570f`. Base inspected: `242717822e2c9641b71bff9d71c8643a3ab48063`. Both original invocation modules match stable `v2026.9.1`. Production delta: +24/−67, net **−43**; tests unchanged.

- **191 tests pass before and after**, across four existing dispatch suites. Coverage includes handled/unhandled hooks, restricted runtime rejection, routed ACP targets/reset tails, live tool-summary visibility, source-owned cancellation, transcript/run callback ownership and suppression of late sends.
- Targeted formatting, `git diff --check`, focused lint and deslop pass. Fresh Codex autoreview, a separate read-only Codex review of this exact head, and an independent source challenge found no actionable P0–P2 defects.
- **Exact-head CI passes:** [CI run 33964214913, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33964214913) completed successfully on this head: 106 successful jobs and 17 skipped jobs. Build artifacts, production/core/test types, lint, architecture/boundaries and `openclaw/ci-gate` all passed.
- [ClawSweeper's exact-head review](https://github.com/openclaw/openclaw/pull/139052#issuecomment-5551600820), reviewed September 5 at 11:53 UTC, found no correctness/security issues and lists **Before merge: None**. There is no Rank-up moves list or outstanding move to address.

The earlier local typecheck stopped at the declaration guard because the development worktree shared dependencies through a symlink. The hosted type/build checks above supply successful exact-head evidence. The full local changed check also completed successfully in the native PR checkout with its own dependencies. No separate local build is needed: this extraction adds no module, lazy or bundled import boundary, and exact-head CI build artifacts passed.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts \
  src/auto-reply/reply/dispatch-from-config.reply-dispatch-scope.test.ts \
  src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts \
  src/auto-reply/reply/dispatch-from-config.test.ts

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
  src/auto-reply/reply/dispatch-from-config.acp-tail.ts \
  src/auto-reply/reply/dispatch-from-config.reply-dispatch-hook.ts

node scripts/check-changed.mjs -- \
  src/auto-reply/reply/dispatch-from-config.acp-tail.ts \
  src/auto-reply/reply/dispatch-from-config.reply-dispatch-hook.ts
```

Proof covers deterministic dispatch boundaries and hosted integration checks. No visual behavior or provider protocol is changed; no live-provider or browser proof is claimed.
