### PR TITLE
fix: retain proxy DNS checks with Undici security updates

### DIFF
--- a/.github/release/clawhub-cli/package-lock.json
+++ b/.github/release/clawhub-cli/package-lock.json
@@ -541,9 +541,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/.github/release/clawhub-cli/package.json
+++ b/.github/release/clawhub-cli/package.json
@@ -4,5 +4,10 @@
   "version": "1.0.0",
   "dependencies": {
     "clawhub": "0.23.3"
+  },
+  "overrides": {
+    "clawhub@0.23.3": {
+      "undici": "7.29.1"
+    }
   }
 }

--- a/.github/release/vercel-cli/package-lock.json
+++ b/.github/release/vercel-cli/package-lock.json
@@ -2264,9 +2264,9 @@
       "license": "MIT"
     },
     "node_modules/@vercel/sandbox/node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -4368,9 +4368,9 @@
       }
     },
     "node_modules/vercel/node_modules/@vercel/sandbox/node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -274,7 +274,8 @@ outbound policy after DNS resolution.
 <Note>
   If no HTTP(S) proxy env var is configured, or the target host is excluded by
   `NO_PROXY`, `web_fetch` falls back to the normal strict path with local DNS
-  pinning.
+  pinning. Hostname matching ignores case and a single trailing DNS dot in
+  either the URL or the `NO_PROXY` entry.
 </Note>
 
 ## Limits and safety

--- a/extensions/anthropic-vertex/package.json
+++ b/extensions/anthropic-vertex/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@anthropic-ai/vertex-sdk": "0.19.5",
     "google-auth-library": "10.9.1",
-    "undici": "8.10.0"
+    "undici": "8.10.2"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
     "@types/yargs-parser": "21.0.3",
-    "undici": "8.10.0"
+    "undici": "8.10.2"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -14,7 +14,7 @@
     "libopus-wasm": "0.2.0",
     "mdast-util-from-markdown": "2.0.3",
     "typebox": "1.3.18",
-    "undici": "8.10.0",
+    "undici": "8.10.2",
     "ws": "8.21.3",
     "zod": "4.4.3"
   },

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -14,7 +14,7 @@
     "@slack/web-api": "8.0.0",
     "get-east-asian-width": "1.6.0",
     "typebox": "1.3.18",
-    "undici": "7.29.0",
+    "undici": "7.29.1",
     "ws": "8.21.3",
     "zod": "4.4.3"
   },

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -9,7 +9,7 @@
     "@grammyjs/transformer-throttler": "1.2.1",
     "grammy": "1.46.0",
     "typebox": "1.3.18",
-    "undici": "8.10.0",
+    "undici": "8.10.2",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2154,7 +2154,7 @@
     "tslog": "4.11.0",
     "typebox": "1.3.18",
     "typescript": "6.0.3",
-    "undici": "8.10.0",
+    "undici": "8.10.2",
     "web-push": "3.6.7",
     "web-tree-sitter": "0.26.13",
     "ws": "8.21.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,7 @@ overrides:
   ip-address: 10.5.0
   mailparser@3.9.15>html-to-text: 10.0.1
   mailauth@5.0.2>nodemailer: 9.1.1
+  mailauth@5.0.2>undici: 8.10.2
   mailparser@3.9.15>nodemailer: 9.1.1
   minimatch: 10.2.6
   path-to-regexp: 8.4.2
@@ -206,7 +207,7 @@ importers:
         version: 0.8.1
       '@openclaw/proxyline':
         specifier: 0.3.7
-        version: 0.3.7(undici@8.10.0)
+        version: 0.3.7(undici@8.10.2)
       '@silvia-odwyer/photon-node':
         specifier: 0.3.4
         version: 0.3.4
@@ -337,8 +338,8 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
       undici:
-        specifier: 8.10.0
-        version: 8.10.0
+        specifier: 8.10.2
+        version: 8.10.2
       web-push:
         specifier: 3.6.7
         version: 3.6.7(supports-color@10.2.2)
@@ -652,8 +653,8 @@ importers:
         specifier: 10.9.1
         version: 10.9.1(supports-color@10.2.2)
       undici:
-        specifier: 8.10.0
-        version: 8.10.0
+        specifier: 8.10.2
+        version: 8.10.2
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -730,8 +731,8 @@ importers:
         specifier: 21.0.3
         version: 21.0.3
       undici:
-        specifier: 8.10.0
-        version: 8.10.0
+        specifier: 8.10.2
+        version: 8.10.2
 
   extensions/buzz:
     dependencies:
@@ -1014,8 +1015,8 @@ importers:
         specifier: 1.3.18
         version: 1.3.18
       undici:
-        specifier: 8.10.0
-        version: 8.10.0
+        specifier: 8.10.2
+        version: 8.10.2
       ws:
         specifier: 8.21.3
         version: 8.21.3
@@ -1944,10 +1945,10 @@ importers:
     dependencies:
       '@slack/bolt':
         specifier: 5.0.0
-        version: 5.0.0(@types/express@5.0.6)(supports-color@10.2.2)(undici@7.29.0)
+        version: 5.0.0(@types/express@5.0.6)(supports-color@10.2.2)(undici@7.29.1)
       '@slack/socket-mode':
         specifier: 3.0.0
-        version: 3.0.0(undici@7.29.0)
+        version: 3.0.0(undici@7.29.1)
       '@slack/types':
         specifier: 3.0.0
         version: 3.0.0
@@ -1961,8 +1962,8 @@ importers:
         specifier: 1.3.18
         version: 1.3.18
       undici:
-        specifier: 7.29.0
-        version: 7.29.0
+        specifier: 7.29.1
+        version: 7.29.1
       ws:
         specifier: 8.21.3
         version: 8.21.3
@@ -2047,8 +2048,8 @@ importers:
         specifier: 1.3.18
         version: 1.3.18
       undici:
-        specifier: 8.10.0
-        version: 8.10.0
+        specifier: 8.10.2
+        version: 8.10.2
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -9272,12 +9273,12 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.29.0:
-    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+  undici@7.29.1:
+    resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
     engines: {node: '>=20.18.1'}
 
-  undici@8.10.0:
-    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+  undici@8.10.2:
+    resolution: {integrity: sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==}
     engines: {node: '>=22.19.0'}
 
   unhomoglyph@1.0.6:
@@ -11466,9 +11467,9 @@ snapshots:
     dependencies:
       ghostty-web: 0.4.0
 
-  '@openclaw/proxyline@0.3.7(undici@8.10.0)':
+  '@openclaw/proxyline@0.3.7(undici@8.10.2)':
     dependencies:
-      undici: 8.10.0
+      undici: 8.10.2
 
   '@openclaw/uirouter@0.1.1': {}
 
@@ -12158,11 +12159,11 @@ snapshots:
     dependencies:
       escape-string-regexp: 5.0.0
 
-  '@slack/bolt@5.0.0(@types/express@5.0.6)(supports-color@10.2.2)(undici@7.29.0)':
+  '@slack/bolt@5.0.0(@types/express@5.0.6)(supports-color@10.2.2)(undici@7.29.1)':
     dependencies:
       '@slack/logger': 5.0.0
       '@slack/oauth': 4.0.0
-      '@slack/socket-mode': 3.0.0(undici@7.29.0)
+      '@slack/socket-mode': 3.0.0(undici@7.29.1)
       '@slack/types': 3.0.0
       '@slack/web-api': 8.0.0
       '@types/express': 5.0.6
@@ -12186,13 +12187,13 @@ snapshots:
       '@types/node': 26.2.0
       jsonwebtoken: 9.0.3
 
-  '@slack/socket-mode@3.0.0(undici@7.29.0)':
+  '@slack/socket-mode@3.0.0(undici@7.29.1)':
     dependencies:
       '@slack/logger': 5.0.0
       '@slack/web-api': 8.0.0
       '@types/node': 26.2.0
       eventemitter3: 5.0.4
-      undici: 7.29.0
+      undici: 7.29.1
 
   '@slack/types@3.0.0': {}
 
@@ -14737,7 +14738,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.29.0
+      undici: 7.29.1
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -15060,7 +15061,7 @@ snapshots:
       nodemailer: 9.1.1
       punycode.js: 2.3.1
       tldts: 7.4.10
-      undici: 8.10.0
+      undici: 8.10.2
 
   mailparser@3.9.15:
     dependencies:
@@ -16901,9 +16902,9 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.29.0: {}
+  undici@7.29.1: {}
 
-  undici@8.10.0: {}
+  undici@8.10.2: {}
 
   unhomoglyph@1.0.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,9 @@ minimumReleaseAgeStrict: true
 
 # Trusted Codex runtimes are outside the dependency cooldown.
 minimumReleaseAgeExclude:
+  # GHSA-vp8m-p9jh-q5pm / GHSA-w293-vg96-wgc3 security fixes; remove after 2026-09-12.
+  - "undici@8.10.2"
+  - "undici@7.29.1"
   # GHSA-58mr-gqgx-xq4g / GHSA-qw65-cvwx-89v3 security fix; remove after 2026-09-09.
   - "fast-uri@4.1.4"
   # GHSA-2x7j-588g-ccc2 security fix; remove after 2026-09-08.
@@ -67,6 +70,8 @@ overrides:
   # Keep the cooled HTML converter security fix while Mailparser is rolled back.
   "mailparser@3.9.15>html-to-text": 10.0.1
   "mailauth@5.0.2>nodemailer": 9.1.1
+  # Mailauth pins vulnerable Undici; remove when its direct dependency is fixed.
+  "mailauth@5.0.2>undici": 8.10.2
   "mailparser@3.9.15>nodemailer": 9.1.1
   minimatch: 10.2.6
   path-to-regexp: 8.4.2

--- a/scripts/materialize-clawhub-cli.sh
+++ b/scripts/materialize-clawhub-cli.sh
@@ -8,7 +8,7 @@ github_output="${3:-}"
 
 package_json="${source_root}/package.json"
 package_lock="${source_root}/package-lock.json"
-expected_lock_sha256="adc9d3613a752dfe00597a8826f45fab82e7651478d16ba1bf5354369157fee9"
+expected_lock_sha256="30142b07c1167d030926f9dd3320a8b158aa59cbca5a56e05d949a50e6e2b3c6"
 expected_clawhub_integrity="sha512-VwM6FQrZVarFRDiEqG42npUeyCu/iLhPnpO+b7kKIGRXv+TA6Lb8pboHnIgT6cmjFEnW3j/pTbshWeDQMQ7QWQ=="
 test -f "${package_json}"
 test -f "${package_lock}"

--- a/scripts/materialize-vercel-cli.sh
+++ b/scripts/materialize-vercel-cli.sh
@@ -8,7 +8,7 @@ github_output="${3:-}"
 
 package_json="${source_root}/package.json"
 package_lock="${source_root}/package-lock.json"
-expected_lock_sha256="1184e89900b599f92cc40f45c034870ff13e0f1f02d4ae97486849362719362e"
+expected_lock_sha256="d9c34731737801bae70c8a807c617f758c30a3c07ea3edfb32550370eb55524d"
 expected_vercel_integrity="sha512-tQgKXmppJ/uoQZfX+HYAVIxWSUS6V6FMounEEpsHTUqlHyBI/aOATH9sKtkXXD1lQt/JsN4ocWymIGUPLRTxwA=="
 test -f "${package_json}"
 test -f "${package_lock}"

--- a/src/infra/net/proxy-env.test.ts
+++ b/src/infra/net/proxy-env.test.ts
@@ -356,6 +356,23 @@ describe("matchesNoProxy", () => {
 
 describe("shouldUseEnvHttpProxyForUrl", () => {
   it.each([
+    ["https://api.example./v1", "example", false],
+    ["https://api.example/v1", "example.", false],
+    ["https://api.example.:8443/v1", "*.example.:8443", false],
+    ["https://api.example.:8443/v1", "*.example.:443", true],
+    ["https://notexample./v1", "example.", true],
+    ["https://api.example../v1", "example", true],
+    ["https://api.example./v1", ".", true],
+  ])("keeps NO_PROXY DNS-dot routing aligned for %s and %s", (url, noProxy, expected) => {
+    expect(
+      shouldUseEnvHttpProxyForUrl(url, {
+        HTTPS_PROXY: "http://proxy.test:8080",
+        NO_PROXY: noProxy,
+      }),
+    ).toBe(expected);
+  });
+
+  it.each([
     {
       name: "uses HTTPS_PROXY for https URLs",
       url: "https://api.example.com/v1",

--- a/src/infra/net/proxy-env.ts
+++ b/src/infra/net/proxy-env.ts
@@ -126,6 +126,7 @@ export function shouldUseEnvHttpProxyForUrl(
  * (`undici/lib/dispatcher/env-http-proxy-agent.js`):
  * - Entries separated by commas OR whitespace (undici splits on `/[,\s]/`)
  * - Case-insensitive
+ * - A single trailing DNS dot is ignored in both hosts and entries
  * - Lower-case `no_proxy` shadows upper-case `NO_PROXY`, including blank values
  * - Empty or missing → no bypass
  * - Bare `*` value → bypass everything
@@ -160,7 +161,11 @@ export function matchesNoProxy(targetUrl: string, env: NodeJS.ProcessEnv = proce
     return false;
   }
 
-  const targetHost = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  // Keep the eligibility gate aligned with Undici so direct bypasses retain DNS pinning.
+  const targetHost = parsed.hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/^(.+)\.$/, "$1");
   if (!targetHost) {
     return false;
   }
@@ -217,7 +222,7 @@ export function matchesNoProxy(targetUrl: string, env: NodeJS.ProcessEnv = proce
     // Mirror undici: strip optional leading `*` followed by `.` so both
     // `.example.com` and `*.example.com` normalize to `example.com`. That also
     // means apex hosts still match those entries after normalization.
-    const normalizedEntry = entryHost.replace(/^\*\./, "").replace(/^\./, "");
+    const normalizedEntry = entryHost.replace(/^\*?\./, "").replace(/^(.+)\.$/, "$1");
     if (!normalizedEntry || normalizedEntry === "*") {
       continue;
     }

--- a/test/scripts/plugin-clawhub-new-workflow.test.ts
+++ b/test/scripts/plugin-clawhub-new-workflow.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
@@ -38,9 +39,8 @@ const materializerSource = readFileSync("scripts/materialize-clawhub-cli.sh", "u
 const clawhubCliPackage = JSON.parse(
   readFileSync(".github/release/clawhub-cli/package.json", "utf8"),
 ) as { dependencies?: Record<string, string> };
-const clawhubCliLock = JSON.parse(
-  readFileSync(".github/release/clawhub-cli/package-lock.json", "utf8"),
-) as {
+const clawhubCliLockBytes = readFileSync(".github/release/clawhub-cli/package-lock.json");
+const clawhubCliLock = JSON.parse(clawhubCliLockBytes.toString("utf8")) as {
   packages?: Record<string, { integrity?: string; version?: string }>;
 };
 
@@ -349,9 +349,8 @@ describe("Plugin ClawHub New workflow", () => {
     expect(materializerSource).not.toContain('--prefix "${destination}"');
     expect(materializerSource).toContain("--ignore-scripts");
     expect(materializerSource).toContain("--omit=dev");
-    expect(materializerSource).toContain(
-      "adc9d3613a752dfe00597a8826f45fab82e7651478d16ba1bf5354369157fee9",
-    );
+    const lockSha256 = createHash("sha256").update(clawhubCliLockBytes).digest("hex");
+    expect(materializerSource).toContain(`expected_lock_sha256="${lockSha256}"`);
     expect(materializerSource).toContain("lock_sha256=");
     expect(materializerSource).toContain("integrity=${clawhub_integrity}");
     expect(materializerSource).toContain("cli=${clawhub_cli}");

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -358,7 +358,9 @@ describe("parseReleaseVerifyBetaArgs", () => {
 describe("validateClawHubBootstrapEvidence", () => {
   const clawhubToolchainIntegrity =
     "sha512-VwM6FQrZVarFRDiEqG42npUeyCu/iLhPnpO+b7kKIGRXv+TA6Lb8pboHnIgT6cmjFEnW3j/pTbshWeDQMQ7QWQ==";
-  const clawhubToolchainSha256 = "adc9d3613a752dfe00597a8826f45fab82e7651478d16ba1bf5354369157fee9";
+  const clawhubToolchainSha256 = sha256(
+    readFileSync(".github/release/clawhub-cli/package-lock.json"),
+  );
   const clawhubToolchainVersion = "0.23.3";
   const releaseSha = "a".repeat(40);
   const workflowSha = "b".repeat(40);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release verification is blocked by vulnerable Undici versions in the product and the pinned ClawHub/Vercel release tools. The affected versions can drop custom TLS rejection callbacks and mix responses across origins when sharing cache or deduplication interceptors.

Related: [GHSA-w293-vg96-wgc3](https://github.com/nodejs/undici/security/advisories/GHSA-w293-vg96-wgc3), [GHSA-vp8m-p9jh-q5pm](https://github.com/nodejs/undici/security/advisories/GHSA-vp8m-p9jh-q5pm), and [Full Release Validation 33936309800](https://github.com/openclaw/openclaw/actions/runs/33936309800).

## Why This Change Was Made

Upgrade the existing Undici 8 and 7 dependency families to 8.10.2 and 7.29.1, preserving package ownership and major versions. Mailauth and ClawHub still pin vulnerable versions exactly, so their overrides are narrowly scoped to those owning versions. The two exact pnpm cooldown exceptions are maintainer-approved and marked for removal after September 12. Both release-tool locks and their materializer digest pins move together; the historical 2026.9.1 accepted-risk record stays unchanged.

Undici 8.10.2 also treats a trailing DNS dot as equivalent when matching NO_PROXY. Update OpenClaw's shared matcher to adopt that upstream behavior. Guarded-fetch eligibility and OpenClaw's env dispatcher already use this same matcher, so both continue to agree; matched direct requests retain local DNS pinning. Existing port, domain-boundary, IPv6, CIDR, and wildcard rules remain covered.

## User Impact

Operators receive the upstream TLS and cross-origin isolation fixes. NO_PROXY entries match DNS-equivalent dotted hostnames while retaining the guarded fetch path's DNS checks. No new configuration options are introduced.

## Evidence

- Registry-integrity-verified old/fixed tarballs and actual installed packages reproduce the TLS callback and cross-origin cache/dedup defects, then prove the upstream repairs over local HTTP/TLS servers. All 12 old/fixed observations pass on Node 26 and Node 24.20.0. The installed fixed files match the verified tarballs across ten dependency consumers.
- The two DNS-dot eligibility regressions fail on the original matcher. The combined source/toolchain suite passes **277 tests across eight files**, including SSRF guard/dispatcher coverage and rejection of mismatched release evidence. A further **109 transport tests across five files** pass on Node 24.20.0 for shared Undici, Slack, Discord REST, and Telegram (386 tests total).
- Both release materializers first reject the changed locks with stale digest pins; with matching pins, real `npm ci --ignore-scripts` succeeds for ClawHub 0.23.3 and Vercel 59.5.0. Current-toolchain test fixtures now derive their digest from the committed lock bytes; deliberately mismatched evidence remains rejected.
- `pnpm deps:vuln:gate` passes with **0 hard blockers across 2,043 package versions and three independent lock graphs**. Public upstream coverage is explicitly partial (26/1,023 repositories, including an Undici rate limit); this is not comprehensive vulnerability clearance. Both targeted advisories were separately re-read successfully from the official Undici repository API and explicitly name 8.10.2/7.29.1 as patched versions; their ranges and the preserved direct reproduction independently establish the targeted fixes. Two pre-existing qs advisories remain a separate follow-up.
- Fresh isolated Codex review is scoped-clean through P2. `pnpm build` passes, including the 90 plugin builds, SDK checks, and UI asset budgets. `node scripts/check-changed.mjs` passes the prescribed dependency-lock, typecheck, lint, dead-export, and runtime-cycle gates.

Production matcher delta is +5 lines, including formatting and the DNS-pinning invariant comment; no new helper or fallback path. The remaining changes are dependency metadata, exact toolchain digest updates, tests, and one documentation sentence.
