### PR TITLE
refactor(proxy-capture): consolidate typed cleanup queries

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3524,7 +3524,7 @@ src/projects/project-registry.ts	1
 src/provider-runtime/operation-retry.ts	3
 src/proxy-capture/env.ts	1
 src/proxy-capture/runtime.ts	10
-src/proxy-capture/store.sqlite.ts	16
+src/proxy-capture/store.sqlite.ts	4
 src/realtime-transcription/websocket-session.ts	2
 src/routing/binding-scope.ts	1
 src/runtime.ts	4

--- a/scripts/check-kysely-guardrails.mts
+++ b/scripts/check-kysely-guardrails.mts
@@ -127,7 +127,6 @@ const rawSqliteAllowPathGroups = {
     "src/infra/state-migrations.transcript-directives-archives.ts",
     "src/infra/state-migrations.transcript-directives.ts",
   ],
-  "shared database stores with direct DatabaseSync access": ["src/proxy-capture/store.sqlite.ts"],
   "session entry cache connection-local validity counters": [
     "src/config/sessions/session-accessor.sqlite-entry-cache.ts",
   ],
@@ -143,6 +142,7 @@ const rawSqliteAllowPathGroups = {
     "src/plugins/installed-plugin-index-store-write.ts",
     "src/plugins/installed-plugin-index-store.ts",
     "src/plugin-state/plugin-state-store.sqlite.ts",
+    "src/proxy-capture/store.sqlite.ts",
     "src/tasks/task-flow-registry.store.sqlite.ts",
     "src/tasks/task-registry.store.sqlite.ts",
   ],

--- a/src/proxy-capture/store.sqlite.test.ts
+++ b/src/proxy-capture/store.sqlite.test.ts
@@ -309,65 +309,83 @@ describe("DebugProxyCaptureStore", () => {
     expect(lease.store.isClosed).toBe(true);
   });
 
-  it.each(["deleteSessions", "purgeAll"] as const)(
-    "rolls back path-based %s when session deletion fails",
-    (operation) => {
-      const root = makeTempDir(cleanupDirs, "openclaw-proxy-capture-rollback-");
-      const dbPath = path.join(root, "capture.sqlite");
-      const blobDir = path.join(root, "blobs");
-      const lease = acquireDebugProxyCaptureStore(dbPath, blobDir);
-      const sessionId = "path-based-rollback-session";
+  it.each([
+    ["path", "deleteSessions", "capture_sessions"],
+    ["path", "purgeAll", "capture_sessions"],
+    ["shared", "deleteSessions", "capture_sessions"],
+    ["shared", "purgeAll", "capture_sessions"],
+    ["shared", "deleteSessions", "capture_blobs"],
+    ["shared", "purgeAll", "capture_blobs"],
+  ] as const)("rolls back %s %s when %s deletion fails", (kind, operation, deniedTable) => {
+    const root = makeTempDir(cleanupDirs, "openclaw-proxy-capture-rollback-");
+    const dbPath = path.join(root, "capture.sqlite");
+    const blobDir = path.join(root, "blobs");
+    const lease =
+      kind === "path"
+        ? acquireDebugProxyCaptureStore(dbPath, blobDir)
+        : acquireDebugProxyCaptureStore({ env: { OPENCLAW_STATE_DIR: root } });
+    const sessionId = "rollback-session";
 
-      try {
-        lease.store.upsertSession({
-          id: sessionId,
-          startedAt: 1,
-          mode: "sdk",
-          sourceScope: "openclaw",
-          sourceProcess: "plugin",
-          dbPath,
-          blobDir,
-        });
-        const blob = lease.store.persistPayload(Buffer.from("rollback payload"), "text/plain");
-        lease.store.recordEvent({
-          sessionId,
-          ts: 2,
-          sourceScope: "openclaw",
-          sourceProcess: "plugin",
-          protocol: "https",
-          direction: "outbound",
-          kind: "request",
-          flowId: "path-based-rollback-flow",
-          dataBlobId: blob.blobId,
-          dataSha256: blob.sha256,
-        });
+    try {
+      lease.store.upsertSession({
+        id: sessionId,
+        startedAt: 1,
+        mode: "sdk",
+        sourceScope: "openclaw",
+        sourceProcess: "plugin",
+        dbPath,
+        blobDir,
+      });
+      const blob = lease.store.persistPayload(Buffer.from("rollback payload"), "text/plain");
+      const blobPath = path.join(blobDir, `${blob.blobId}.bin.gz`);
+      lease.store.recordEvent({
+        sessionId,
+        ts: 2,
+        sourceScope: "openclaw",
+        sourceProcess: "plugin",
+        protocol: "https",
+        direction: "outbound",
+        kind: "request",
+        flowId: "path-based-rollback-flow",
+        dataBlobId: blob.blobId,
+        dataSha256: blob.sha256,
+      });
 
-        const cleanup = () =>
-          operation === "deleteSessions"
-            ? lease.store.deleteSessions([sessionId])
-            : lease.store.purgeAll();
-        lease.store.db.setAuthorizer((action, table) =>
-          action === constants.SQLITE_DELETE && table === "capture_sessions"
-            ? constants.SQLITE_DENY
-            : constants.SQLITE_OK,
-        );
+      const cleanup = () =>
+        operation === "deleteSessions"
+          ? lease.store.deleteSessions([sessionId])
+          : lease.store.purgeAll();
+      lease.store.db.setAuthorizer((action, table) =>
+        action === constants.SQLITE_DELETE && table === deniedTable
+          ? constants.SQLITE_DENY
+          : constants.SQLITE_OK,
+      );
 
-        expect(cleanup).toThrow(/not authorized/u);
-        lease.store.db.setAuthorizer(null);
-        expect(lease.store.listSessions()).toHaveLength(1);
-        expect(lease.store.getSessionEvents(sessionId)).toHaveLength(1);
-        expect(fs.existsSync(blob.path)).toBe(true);
-
-        expect(cleanup()).toEqual({ sessions: 1, events: 1, blobs: 1 });
-        expect(lease.store.listSessions()).toEqual([]);
-        expect(lease.store.getSessionEvents(sessionId)).toEqual([]);
-        expect(fs.existsSync(blob.path)).toBe(false);
-      } finally {
-        lease.store.db.setAuthorizer(null);
-        lease.release();
+      if (deniedTable === "capture_blobs" && operation === "deleteSessions") {
+        expect(() => lease.store.deleteSessions(["missing"])).toThrow(/not authorized/u);
       }
-    },
-  );
+      expect(cleanup).toThrow(/not authorized/u);
+      lease.store.db.setAuthorizer(null);
+      expect(lease.store.listSessions()).toHaveLength(1);
+      expect(lease.store.getSessionEvents(sessionId)).toHaveLength(1);
+      expect(lease.store.readBlob(blob.blobId)).toBe("rollback payload");
+      if (kind === "path") {
+        expect(fs.existsSync(blobPath)).toBe(true);
+      }
+
+      expect(cleanup()).toEqual({ sessions: 1, events: 1, blobs: 1 });
+      expect(lease.store.listSessions()).toEqual([]);
+      expect(lease.store.getSessionEvents(sessionId)).toEqual([]);
+      expect(lease.store.readBlob(blob.blobId)).toBeNull();
+      if (kind === "path") {
+        expect(fs.existsSync(blobPath)).toBe(false);
+      }
+      expect(cleanup()).toEqual({ sessions: 0, events: 0, blobs: 0 });
+    } finally {
+      lease.store.db.setAuthorizer(null);
+      lease.release();
+    }
+  });
 
   it("uses rollback journaling for captures on NFS-backed volumes", () => {
     vi.spyOn(fs, "statfsSync").mockReturnValue({
@@ -727,50 +745,66 @@ describe("DebugProxyCaptureStore", () => {
     });
   });
 
-  it("keeps shared blobs when deleting one of multiple referencing sessions", () => {
-    const store = makeStore();
-    const sharedPayload = persistEventPayload(store, {
-      data: '{"shared":true}',
-      contentType: "application/json",
-    });
+  it.each(["shared", "path"] as const)("preserves %s blob custody and cleanup counts", (kind) => {
+    const env = makeStateEnv("openclaw-proxy-capture-cleanup-");
+    const blobDir = path.join(env.OPENCLAW_STATE_DIR!, "blobs");
+    const store =
+      kind === "shared"
+        ? new DebugProxyCaptureStore({ env })
+        : new DebugProxyCaptureStore(path.join(env.OPENCLAW_STATE_DIR!, "capture.sqlite"), blobDir);
+    try {
+      const sharedPayload = persistEventPayload(store, {
+        data: '{"shared":true}',
+        contentType: "application/json",
+      });
 
-    for (const sessionId of ["session-a", "session-b"]) {
-      store.upsertSession({
-        id: sessionId,
-        startedAt: Date.now(),
-        mode: "proxy-run",
-        sourceScope: "openclaw",
-        sourceProcess: "openclaw",
+      for (const sessionId of ["session-a", "session-b"]) {
+        store.upsertSession({
+          id: sessionId,
+          startedAt: Date.now(),
+          mode: "proxy-run",
+          sourceScope: "openclaw",
+          sourceProcess: "openclaw",
+        });
+        store.recordEvent({
+          sessionId,
+          ts: Date.now(),
+          sourceScope: "openclaw",
+          sourceProcess: "openclaw",
+          protocol: "https",
+          direction: "outbound",
+          kind: "request",
+          flowId: `flow-${sessionId}`,
+          method: "POST",
+          host: "api.example.com",
+          path: "/v1/shared",
+          ...sharedPayload,
+        });
+      }
+
+      const result = store.deleteSessions([" session-a ", "session-a", "", " "]);
+
+      expect(result).toEqual({ sessions: 1, events: 1, blobs: 0 });
+      expect(store.readBlob(sharedPayload.dataBlobId ?? "")).toContain('"shared":true');
+      expect(store.listSessions(10).map((session) => session.id)).toEqual(["session-b"]);
+
+      expect(store.deleteSessions(["session-b"])).toEqual({
+        sessions: 1,
+        events: 1,
+        blobs: 1,
       });
-      store.recordEvent({
-        sessionId,
-        ts: Date.now(),
-        sourceScope: "openclaw",
-        sourceProcess: "openclaw",
-        protocol: "https",
-        direction: "outbound",
-        kind: "request",
-        flowId: `flow-${sessionId}`,
-        method: "POST",
-        host: "api.example.com",
-        path: "/v1/shared",
-        ...sharedPayload,
-      });
+      expect(store.readBlob(sharedPayload.dataBlobId ?? "")).toBeNull();
+      store.persistPayload(Buffer.from("unreferenced capture"));
+      if (kind === "path") {
+        fs.writeFileSync(path.join(blobDir, "extra-artifact.txt"), "capture artifact");
+      }
+      expect(store.purgeAll()).toEqual({ sessions: 0, events: 0, blobs: kind === "path" ? 2 : 1 });
+      if (kind === "path") {
+        expect(fs.readdirSync(blobDir)).toEqual([]);
+      }
+      expect(store.purgeAll()).toEqual({ sessions: 0, events: 0, blobs: 0 });
+    } finally {
+      store.close();
     }
-
-    const result = store.deleteSessions(["session-a"]);
-
-    expect(result.sessions).toBe(1);
-    expect(result.events).toBe(1);
-    expect(result.blobs).toBe(0);
-    expect(store.readBlob(sharedPayload.dataBlobId ?? "")).toContain('"shared":true');
-    expect(store.listSessions(10).map((session) => session.id)).toEqual(["session-b"]);
-
-    expect(store.deleteSessions(["session-b"])).toEqual({
-      sessions: 1,
-      events: 1,
-      blobs: 1,
-    });
-    expect(store.readBlob(sharedPayload.dataBlobId ?? "")).toBeNull();
   });
 });

--- a/src/proxy-capture/store.sqlite.ts
+++ b/src/proxy-capture/store.sqlite.ts
@@ -5,6 +5,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { StringDecoder } from "node:string_decoder";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
+import type { InferResult } from "kysely";
 import { sha256Hex } from "../infra/crypto-digest.js";
 import { compileSqliteQueryBindings, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
@@ -493,18 +494,16 @@ class DebugProxyCaptureStoreImpl {
   }
 
   purgeAll(): { sessions: number; events: number; blobs: number } {
+    const kysely = getNodeSqliteKysely<CaptureDatabase>(this.db);
+    const metadataDeletes = [
+      kysely.deleteFrom("capture_events").compile().sql,
+      kysely.deleteFrom("capture_sessions").compile().sql,
+    ];
     if (this.pathBased) {
-      const sessionCount =
-        (
-          this.db.prepare(`SELECT COUNT(*) AS count FROM capture_sessions`).get() as {
-            count: number;
-          }
-        ).count ?? 0;
-      const eventCount =
-        (this.db.prepare(`SELECT COUNT(*) AS count FROM capture_events`).get() as { count: number })
-          .count ?? 0;
+      const sessionCount = this.countCaptureRows("capture_sessions");
+      const eventCount = this.countCaptureRows("capture_events");
       runSqliteImmediateTransactionSync(this.db, () => {
-        this.db.exec(`DELETE FROM capture_events; DELETE FROM capture_sessions;`);
+        this.db.exec(metadataDeletes.join(";") + ";");
       });
       let blobs = 0;
       if (fs.existsSync(this.pathBased.blobDir)) {
@@ -516,20 +515,11 @@ class DebugProxyCaptureStoreImpl {
       return { sessions: sessionCount, events: eventCount, blobs };
     }
     return runSharedDebugProxyCaptureWrite(this, () => {
-      const sessionCount =
-        (
-          this.db.prepare(`SELECT COUNT(*) AS count FROM capture_sessions`).get() as {
-            count: number;
-          }
-        ).count ?? 0;
-      const eventCount =
-        (this.db.prepare(`SELECT COUNT(*) AS count FROM capture_events`).get() as { count: number })
-          .count ?? 0;
-      const blobCount =
-        (this.db.prepare(`SELECT COUNT(*) AS count FROM capture_blobs`).get() as { count: number })
-          .count ?? 0;
+      const sessionCount = this.countCaptureRows("capture_sessions");
+      const eventCount = this.countCaptureRows("capture_events");
+      const blobCount = this.countCaptureRows("capture_blobs");
       this.db.exec(
-        `DELETE FROM capture_events; DELETE FROM capture_sessions; DELETE FROM capture_blobs;`,
+        [...metadataDeletes, kysely.deleteFrom("capture_blobs").compile().sql].join(";") + ";",
       );
       return { sessions: sessionCount, events: eventCount, blobs: blobCount };
     });
@@ -544,69 +534,29 @@ class DebugProxyCaptureStoreImpl {
       return this.deletePathBasedSessions(uniqueSessionIds);
     }
     return runSharedDebugProxyCaptureWrite(this, () => {
-      const placeholders = uniqueSessionIds.map(() => "?").join(", ");
-      const blobRows = this.db
-        .prepare(
-          `SELECT DISTINCT data_blob_id AS blobId
-           FROM capture_events
-           WHERE session_id IN (${placeholders})
-             AND data_blob_id IS NOT NULL`,
-        )
-        .all(...uniqueSessionIds) as Array<{ blobId?: string | null }>;
-      const eventCount =
-        (
-          this.db
-            .prepare(
-              `SELECT COUNT(*) AS count
-               FROM capture_events
-               WHERE session_id IN (${placeholders})`,
-            )
-            .get(...uniqueSessionIds) as { count: number }
-        ).count ?? 0;
-      const sessionCount =
-        (
-          this.db
-            .prepare(
-              `SELECT COUNT(*) AS count
-               FROM capture_sessions
-               WHERE id IN (${placeholders})`,
-            )
-            .get(...uniqueSessionIds) as { count: number }
-        ).count ?? 0;
-      this.db
-        .prepare(`DELETE FROM capture_events WHERE session_id IN (${placeholders})`)
-        .run(...uniqueSessionIds);
-      this.db
-        .prepare(`DELETE FROM capture_sessions WHERE id IN (${placeholders})`)
-        .run(...uniqueSessionIds);
+      const { blobRows, eventCount, sessionCount } = this.readSessionDeletionRows(uniqueSessionIds);
+      this.deleteSessionMetadata(uniqueSessionIds);
       const candidateBlobIds = blobRows
         .map((row) => row.blobId?.trim())
         .filter((blobId): blobId is string => Boolean(blobId));
-      const remainingBlobRefs =
-        // Shared blobs are deleted only when no surviving event references them.
-        candidateBlobIds.length > 0
-          ? new Set(
-              (
-                this.db
-                  .prepare(
-                    `SELECT DISTINCT data_blob_id AS blobId
-                     FROM capture_events
-                     WHERE data_blob_id IN (${candidateBlobIds.map(() => "?").join(", ")})
-                       AND data_blob_id IS NOT NULL`,
-                  )
-                  .all(...candidateBlobIds) as Array<{ blobId?: string | null }>
-              )
-                .map((row) => row.blobId?.trim())
-                .filter((blobId): blobId is string => Boolean(blobId)),
-            )
-          : new Set<string>();
+      const remainingBlobRefs = this.findRemainingBlobReferences(candidateBlobIds);
+      const { compiled, bind } = compileSqliteQueryBindings<string>((parameter) =>
+        getNodeSqliteKysely<CaptureDatabase>(this.db)
+          .deleteFrom("capture_blobs")
+          .where(
+            "blob_id",
+            "=",
+            parameter((blobId) => blobId),
+          ),
+      );
       let blobs = 0;
-      const deleteBlob = this.db.prepare(`DELETE FROM capture_blobs WHERE blob_id = ?`);
+      // Prepare even without victims so native authorization failures still roll back metadata.
+      const deleteBlob = this.db.prepare(compiled.sql);
       for (const blobId of candidateBlobIds) {
         if (remainingBlobRefs.has(blobId)) {
           continue;
         }
-        const result = deleteBlob.run(blobId);
+        const result = deleteBlob.run(...bind(blobId));
         if (Number(result.changes) > 0) {
           blobs += 1;
         }
@@ -624,63 +574,13 @@ class DebugProxyCaptureStoreImpl {
     if (!pathBased) {
       throw new Error("path-based debug proxy capture store is unavailable");
     }
-    const placeholders = sessionIds.map(() => "?").join(", ");
-    const blobRows = this.db
-      .prepare(
-        `SELECT DISTINCT data_blob_id AS blobId
-         FROM capture_events
-         WHERE session_id IN (${placeholders})
-           AND data_blob_id IS NOT NULL`,
-      )
-      .all(...sessionIds) as Array<{ blobId?: string | null }>;
-    const eventCount =
-      (
-        this.db
-          .prepare(
-            `SELECT COUNT(*) AS count
-             FROM capture_events
-             WHERE session_id IN (${placeholders})`,
-          )
-          .get(...sessionIds) as { count: number }
-      ).count ?? 0;
-    const sessionCount =
-      (
-        this.db
-          .prepare(
-            `SELECT COUNT(*) AS count
-             FROM capture_sessions
-             WHERE id IN (${placeholders})`,
-          )
-          .get(...sessionIds) as { count: number }
-      ).count ?? 0;
-    runSqliteImmediateTransactionSync(this.db, () => {
-      this.db
-        .prepare(`DELETE FROM capture_events WHERE session_id IN (${placeholders})`)
-        .run(...sessionIds);
-      this.db
-        .prepare(`DELETE FROM capture_sessions WHERE id IN (${placeholders})`)
-        .run(...sessionIds);
-    });
+    const { blobRows, eventCount, sessionCount } = this.readSessionDeletionRows(sessionIds);
+    runSqliteImmediateTransactionSync(this.db, () => this.deleteSessionMetadata(sessionIds));
+    // Legacy files are removed only after metadata commits; file failures do not roll it back.
     const candidateBlobIds = blobRows
       .map((row) => row.blobId?.trim())
       .filter((blobId): blobId is string => Boolean(blobId));
-    const remainingBlobRefs =
-      candidateBlobIds.length > 0
-        ? new Set(
-            (
-              this.db
-                .prepare(
-                  `SELECT DISTINCT data_blob_id AS blobId
-                   FROM capture_events
-                   WHERE data_blob_id IN (${candidateBlobIds.map(() => "?").join(", ")})
-                     AND data_blob_id IS NOT NULL`,
-                )
-                .all(...candidateBlobIds) as Array<{ blobId?: string | null }>
-            )
-              .map((row) => row.blobId?.trim())
-              .filter((blobId): blobId is string => Boolean(blobId)),
-          )
-        : new Set<string>();
+    const remainingBlobRefs = this.findRemainingBlobReferences(candidateBlobIds);
     let blobs = 0;
     for (const blobId of candidateBlobIds) {
       if (remainingBlobRefs.has(blobId)) {
@@ -693,6 +593,75 @@ class DebugProxyCaptureStoreImpl {
       }
     }
     return { sessions: sessionCount, events: eventCount, blobs };
+  }
+
+  // Native statements leave corruption recovery with the shared write owner or legacy caller.
+  private countCaptureRows(table: keyof CaptureDatabase): number {
+    const query = getNodeSqliteKysely<CaptureDatabase>(this.db)
+      .selectFrom(table)
+      .select((eb) => eb.fn.countAll<number>().as("count"));
+    const row = this.db.prepare(query.compile().sql).get() as InferResult<typeof query>[number]; // SAFETY: COUNT(*) always returns the generated numeric count projection.
+    return row.count ?? 0;
+  }
+
+  private readSessionDeletionRows(sessionIds: string[]) {
+    const kysely = getNodeSqliteKysely<CaptureDatabase>(this.db);
+    const events = kysely.selectFrom("capture_events").where("session_id", "in", sessionIds);
+    // DISTINCT precedes trimming: colliding trimmed IDs retain separate cleanup attempts.
+    const blobs = compileSqliteQueryBindings(() =>
+      events.select("data_blob_id as blobId").distinct().where("data_blob_id", "is not", null),
+    );
+    const blobRows = this.db
+      .prepare(blobs.compiled.sql)
+      .all(...blobs.bind(undefined)) as InferResult<typeof blobs.compiled>; // SAFETY: Native rows follow the generated nullable blob-id projection.
+    const eventQuery = compileSqliteQueryBindings(() =>
+      events.select((eb) => eb.fn.countAll<number>().as("count")),
+    );
+    const eventRow = this.db
+      .prepare(eventQuery.compiled.sql)
+      .get(...eventQuery.bind(undefined)) as InferResult<typeof eventQuery.compiled>[number]; // SAFETY: COUNT(*) always returns the generated numeric count projection.
+    const sessionQuery = compileSqliteQueryBindings(() =>
+      kysely
+        .selectFrom("capture_sessions")
+        .select((eb) => eb.fn.countAll<number>().as("count"))
+        .where("id", "in", sessionIds),
+    );
+    const sessionRow = this.db
+      .prepare(sessionQuery.compiled.sql)
+      .get(...sessionQuery.bind(undefined)) as InferResult<typeof sessionQuery.compiled>[number]; // SAFETY: COUNT(*) always returns the generated numeric count projection.
+    return { blobRows, eventCount: eventRow.count ?? 0, sessionCount: sessionRow.count ?? 0 };
+  }
+
+  private deleteSessionMetadata(sessionIds: string[]): void {
+    const kysely = getNodeSqliteKysely<CaptureDatabase>(this.db);
+    const events = compileSqliteQueryBindings(() =>
+      kysely.deleteFrom("capture_events").where("session_id", "in", sessionIds),
+    );
+    this.db.prepare(events.compiled.sql).run(...events.bind(undefined));
+    const sessions = compileSqliteQueryBindings(() =>
+      kysely.deleteFrom("capture_sessions").where("id", "in", sessionIds),
+    );
+    this.db.prepare(sessions.compiled.sql).run(...sessions.bind(undefined));
+  }
+
+  private findRemainingBlobReferences(candidateBlobIds: string[]): Set<string> {
+    if (candidateBlobIds.length === 0) {
+      return new Set();
+    }
+    const { compiled, bind } = compileSqliteQueryBindings(() =>
+      getNodeSqliteKysely<CaptureDatabase>(this.db)
+        .selectFrom("capture_events")
+        .select("data_blob_id as blobId")
+        .distinct()
+        .where("data_blob_id", "in", candidateBlobIds)
+        .where("data_blob_id", "is not", null),
+    );
+    const rows = this.db.prepare(compiled.sql).all(...bind(undefined)) as InferResult<
+      typeof compiled
+    >; // SAFETY: Native rows follow the generated nullable blob-id projection.
+    return new Set(
+      rows.map((row) => row.blobId?.trim()).filter((blobId): blobId is string => Boolean(blobId)),
+    );
   }
 }
 


### PR DESCRIPTION
# refactor(proxy-capture): consolidate typed cleanup queries

## What Problem This Solves

Capture deletion and purge duplicated handwritten selection, count and surviving-blob queries across the shared database and shipped path-based SDK constructor. Cleanup now uses four private, capture-specific query helpers in the existing persistence owner, removing 31 production lines while preserving both storage modes.

## Why This Change Was Made

Both orchestration paths keep their existing transaction, native statement and filesystem boundaries. Shared payload removal remains atomic with metadata deletion; legacy files are removed after metadata commits. Purge still uses one native exec in its original delete order. Raw DISTINCT stays before JavaScript trimming, duplicate trimmed candidates stay intact, and the shared blob DELETE is prepared even when there are no victims.

The diagnostic-reader cleanup is already on the integration base. All ordinary capture query SQL is now generated with Kysely, so the existing guard allowlist entry moves to the Kysely-backed native-boundary reason group. Its allowed path set does not change. The assertion baseline shrinks from 16 to 4. No schema, stored representation, migration, config, public API, retention, concurrency or recovery policy changes.

## User Impact

No intended behavior change. QA and CLI cleanup retain exact counts, blob custody, rollback/retry, native errors and legacy filesystem effects. This prepares the current SQLite persistence owner for future work without enabling another database.

## Evidence

- 55 focused tests passed: 25 native store, 11 historical reader and 19 CLI tests. The two deletion regression fixtures and every unchanged main test remain intact after composition.
- Paired actual-code baseline/candidate probes passed 24 delete/purge cases, 84 diagnostic preset/scope queries and 15 read-corruption cases. Results also match the original pre-refactor baselines. Native preparation/transaction order, errors, rows, BLOB bytes, legacy files, rollback/retry, parameter-limit refusal and close/reopen behavior are preserved.
- Real loopback QA served 71 capture HTTP requests; 24 fresh built CLI processes exercised the actual command envelopes, reads and purge. Physical reopen, writable state, payload bytes, shared leases and borrowed-handle lifetime passed. Schema/user_version stayed unchanged and all synthetic fixtures were removed.
- The native runtime was Node 24.20.0 / SQLite 3.53.4 with Kysely 0.29.5. The newly pinned pnpm 12.3.4 was provisioned through the repository installer's isolated npm fallback and its installed native binary verified against registry/tarball integrity. The frozen install kept workspace dependency cooldown and lifecycle policy unchanged. The exact-head CLI build completed in 52.6 seconds.
- Full changed-file validation and the explicit Kysely guard are recorded in the final review manifest. The temporary-directory audit emits only a warning for the reused rollback fixture helper; test and native fixture cleanup passed.

Production is 101 additions / 132 removals (net -31); tests are 129 additions / 95 removals (net +34). Both ratchet and guard metadata changes are net zero. Query count/scan and native parameter limits are unchanged; this does not claim O(1) cleanup or improved throughput.

Independent review of the composed source and complete current proof returned eleven clean P0–P2 reports.
