### PR TITLE
refactor(sqlite): share reliability proof lifecycle

### DIFF
--- a/scripts/lib/sqlite-reliability-compaction.ts
+++ b/scripts/lib/sqlite-reliability-compaction.ts
@@ -5,24 +5,29 @@ import { fileURLToPath } from "node:url";
 import type { SnapshotDatabaseIdentity } from "../../src/snapshot/snapshot-provider.js";
 import {
   assertSameCompactionPayload,
+  assertSameReliabilityState,
   formatReliabilityStderr,
   type CompactionPayloadProof,
   type ReliabilityReport,
   type ReliabilityStateProof,
 } from "./sqlite-reliability-contract.js";
+import {
+  assertReliabilityForcedExit,
+  waitForReliabilityWorkerExit,
+} from "./sqlite-reliability-process.js";
 
 type CompactionTarget = {
   identity: SnapshotDatabaseIdentity;
   path: string;
 };
 
-type CompactionExit = ReliabilityReport["maintenanceProof"]["vacuumInterruption"]["exit"];
-
 const COMPACTION_WORKER_PATH = fileURLToPath(
   new URL("./sqlite-reliability-compaction-worker.ts", import.meta.url),
 );
 const COMPACTION_TIMEOUT_MS = 120_000;
 const MIN_ACTIVE_SIDECAR_BYTES = 1024 * 1024;
+const WORKER_EXIT_TIMEOUT_MESSAGE =
+  "SQLite compaction worker did not exit after forced termination.";
 
 function fileSize(filePath: string): number {
   try {
@@ -32,22 +37,6 @@ function fileSize(filePath: string): number {
       return 0;
     }
     throw error;
-  }
-}
-
-function assertSameState(
-  actual: ReliabilityStateProof,
-  expected: ReliabilityStateProof,
-  label: string,
-): void {
-  if (
-    actual.batches !== expected.batches ||
-    actual.rows !== expected.rows ||
-    actual.sha256 !== expected.sha256
-  ) {
-    throw new Error(
-      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
-    );
   }
 }
 
@@ -108,33 +97,6 @@ async function waitForWorkerReady(params: {
   });
 }
 
-async function waitForChildExit(child: ChildProcess): Promise<CompactionExit> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return { code: child.exitCode, signal: child.signalCode };
-  }
-  return await new Promise<CompactionExit>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      cleanup();
-      reject(new Error("SQLite compaction worker did not exit after forced termination."));
-    }, 30_000);
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      cleanup();
-      resolve({ code, signal });
-    };
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
-    const cleanup = () => {
-      clearTimeout(timeout);
-      child.off("exit", onExit);
-      child.off("error", onError);
-    };
-    child.on("exit", onExit);
-    child.on("error", onError);
-  });
-}
-
 async function waitForActiveVacuum(params: {
   child: ChildProcess;
   databasePath: string;
@@ -157,23 +119,6 @@ async function waitForActiveVacuum(params: {
   throw new Error(
     `SQLite compaction did not produce ${MIN_ACTIVE_SIDECAR_BYTES} bytes of active journal evidence within 120 seconds.`,
   );
-}
-
-function assertForcedExit(exit: CompactionExit): void {
-  if (exit.code === 0) {
-    throw new Error("SQLite compaction worker exited cleanly before forced termination.");
-  }
-  if (process.platform === "win32") {
-    if (exit.code === null && exit.signal === null) {
-      throw new Error("SQLite compaction worker reported no forced Windows exit.");
-    }
-    return;
-  }
-  if (exit.signal !== "SIGKILL") {
-    throw new Error(
-      `SQLite compaction worker exited without SIGKILL: code=${String(exit.code)} signal=${String(exit.signal)}`,
-    );
-  }
 }
 
 export async function runVacuumInterruptionProof(params: {
@@ -208,11 +153,11 @@ export async function runVacuumInterruptionProof(params: {
     if (!child.kill("SIGKILL")) {
       throw new Error("SQLite compaction worker exited before the crash signal was delivered.");
     }
-    const exit = await waitForChildExit(child);
-    assertForcedExit(exit);
+    const exit = await waitForReliabilityWorkerExit(child, WORKER_EXIT_TIMEOUT_MESSAGE);
+    assertReliabilityForcedExit(exit, "SQLite compaction worker");
 
     const stateAfterRecovery = params.recoverAndVerifyDatabase();
-    assertSameState(stateAfterRecovery, params.expectedState, "vacuum crash recovery");
+    assertSameReliabilityState(stateAfterRecovery, params.expectedState, "vacuum crash recovery");
     const autoVacuumAfterRecovery = params.readAutoVacuum();
     if (autoVacuumAfterRecovery !== params.expectedAutoVacuum) {
       throw new Error(
@@ -248,7 +193,7 @@ export async function runVacuumInterruptionProof(params: {
   } finally {
     if (child.exitCode === null && child.signalCode === null) {
       child.kill("SIGKILL");
-      await waitForChildExit(child).catch(() => undefined);
+      await waitForReliabilityWorkerExit(child, WORKER_EXIT_TIMEOUT_MESSAGE).catch(() => undefined);
     }
   }
 }

--- a/scripts/lib/sqlite-reliability-contract.ts
+++ b/scripts/lib/sqlite-reliability-contract.ts
@@ -43,6 +43,22 @@ export type ReliabilityStateProof = {
   sha256: string;
 };
 
+export function assertSameReliabilityState(
+  actual: ReliabilityStateProof,
+  expected: ReliabilityStateProof,
+  label: string,
+): void {
+  if (
+    actual.batches !== expected.batches ||
+    actual.rows !== expected.rows ||
+    actual.sha256 !== expected.sha256
+  ) {
+    throw new Error(
+      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
+    );
+  }
+}
+
 export function formatReliabilityStderr(stderr: string): string {
   const text = stderr.trim();
   return text ? ` stderr=${JSON.stringify(text)}` : "";

--- a/scripts/lib/sqlite-reliability-index-repair.ts
+++ b/scripts/lib/sqlite-reliability-index-repair.ts
@@ -15,6 +15,10 @@ import {
   type IndexRepairJournalMode,
   type ReliabilityReport,
 } from "./sqlite-reliability-contract.js";
+import {
+  assertReliabilityForcedExit,
+  waitForReliabilityWorkerExit,
+} from "./sqlite-reliability-process.js";
 
 type IndexRepairProof = ReliabilityReport["indexRepairInterruptionProof"]["rollbackJournal"];
 
@@ -23,8 +27,6 @@ type IndexRepairState = {
   sha256: string;
 };
 
-type WorkerExit = IndexRepairProof["exit"];
-
 const INDEX_REPAIR_WORKER_PATH = fileURLToPath(
   new URL("./sqlite-reliability-index-repair-worker.ts", import.meta.url),
 );
@@ -32,6 +34,8 @@ const INDEX_REPAIR_WORKER_PATH = fileURLToPath(
 // before the worker reports its explicit crash point.
 const INDEX_REPAIR_ROWS = 16_384;
 const INDEX_REPAIR_TIMEOUT_MS = 30_000;
+const WORKER_EXIT_TIMEOUT_MESSAGE =
+  "SQLite index repair worker did not exit after forced termination.";
 
 function fileSize(filePath: string): number {
   try {
@@ -189,50 +193,6 @@ async function waitForActiveTransaction(params: {
   );
 }
 
-async function waitForChildExit(child: ChildProcess): Promise<WorkerExit> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return { code: child.exitCode, signal: child.signalCode };
-  }
-  return await new Promise<WorkerExit>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      cleanup();
-      reject(new Error("SQLite index repair worker did not exit after forced termination."));
-    }, INDEX_REPAIR_TIMEOUT_MS);
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      cleanup();
-      resolve({ code, signal });
-    };
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
-    const cleanup = () => {
-      clearTimeout(timeout);
-      child.off("exit", onExit);
-      child.off("error", onError);
-    };
-    child.on("exit", onExit);
-    child.on("error", onError);
-  });
-}
-
-function assertForcedExit(exit: WorkerExit): void {
-  if (exit.code === 0) {
-    throw new Error("SQLite index repair worker exited cleanly before forced termination.");
-  }
-  if (process.platform === "win32") {
-    if (exit.code === null && exit.signal === null) {
-      throw new Error("SQLite index repair worker reported no forced Windows exit.");
-    }
-    return;
-  }
-  if (exit.signal !== "SIGKILL") {
-    throw new Error(
-      `SQLite index repair worker exited without SIGKILL: code=${String(exit.code)} signal=${String(exit.signal)}`,
-    );
-  }
-}
-
 function recoverAndRepair(databasePath: string, expectedState: IndexRepairState): string[] {
   const database = openNodeSqliteDatabase(databasePath);
   try {
@@ -307,8 +267,8 @@ async function runJournalModeProof(params: {
     if (!child.kill("SIGKILL")) {
       throw new Error("SQLite index repair worker exited before the crash signal was delivered.");
     }
-    const exit = await waitForChildExit(child);
-    assertForcedExit(exit);
+    const exit = await waitForReliabilityWorkerExit(child, WORKER_EXIT_TIMEOUT_MESSAGE);
+    assertReliabilityForcedExit(exit, "SQLite index repair worker");
     const repairedIndexes = recoverAndRepair(params.databasePath, expectedState);
     return {
       exit,
@@ -321,7 +281,7 @@ async function runJournalModeProof(params: {
   } finally {
     if (child.exitCode === null && child.signalCode === null) {
       child.kill("SIGKILL");
-      await waitForChildExit(child).catch(() => undefined);
+      await waitForReliabilityWorkerExit(child, WORKER_EXIT_TIMEOUT_MESSAGE).catch(() => undefined);
     }
   }
 }

--- a/scripts/lib/sqlite-reliability-process.ts
+++ b/scripts/lib/sqlite-reliability-process.ts
@@ -1,0 +1,58 @@
+import type { ChildProcess } from "node:child_process";
+
+export type ReliabilityWorkerExit = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+};
+
+export async function waitForReliabilityWorkerExit(
+  child: ChildProcess,
+  timeoutMessage: string,
+): Promise<ReliabilityWorkerExit> {
+  // A crash probe can reach this wait after exit was recorded; do not wait for a second event.
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+  return await new Promise<ReliabilityWorkerExit>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(timeoutMessage));
+    }, 30_000);
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      resolve({ code, signal });
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    child.on("exit", onExit);
+    child.on("error", onError);
+  });
+}
+
+export function assertReliabilityForcedExit(
+  exit: ReliabilityWorkerExit,
+  workerLabel: string,
+): void {
+  if (exit.code === 0) {
+    throw new Error(`${workerLabel} exited cleanly before forced termination.`);
+  }
+  // Windows can record a forced termination as an exit code instead of a POSIX signal.
+  if (process.platform === "win32") {
+    if (exit.code === null && exit.signal === null) {
+      throw new Error(`${workerLabel} reported no forced Windows exit.`);
+    }
+    return;
+  }
+  if (exit.signal !== "SIGKILL") {
+    throw new Error(
+      `${workerLabel} exited without SIGKILL: code=${String(exit.code)} signal=${String(exit.signal)}`,
+    );
+  }
+}

--- a/scripts/lib/sqlite-reliability-publication.ts
+++ b/scripts/lib/sqlite-reliability-publication.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import { createVerifiedSqliteSnapshot } from "../../src/infra/sqlite-snapshot.js";
-import type { ReliabilityReport, ReliabilityStateProof } from "./sqlite-reliability-contract.js";
+import {
+  assertSameReliabilityState,
+  type ReliabilityReport,
+  type ReliabilityStateProof,
+} from "./sqlite-reliability-contract.js";
 
 type PublicationCrashPoint = "after-publish" | "before-publish";
 type PublicationExit = ReliabilityReport["publicationInterruptionProof"]["beforePublish"]["exit"];
@@ -22,22 +26,6 @@ const PUBLICATION_WORKER_PATH = fileURLToPath(
   new URL("./sqlite-reliability-publication-worker.ts", import.meta.url),
 );
 const CRASH_POINT_TIMEOUT_MS = 120_000;
-
-function assertSameState(
-  actual: ReliabilityStateProof,
-  expected: ReliabilityStateProof,
-  label: string,
-): void {
-  if (
-    actual.batches !== expected.batches ||
-    actual.rows !== expected.rows ||
-    actual.sha256 !== expected.sha256
-  ) {
-    throw new Error(
-      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
-    );
-  }
-}
 
 function assertNoSqliteSidecars(targetPath: string): void {
   for (const suffix of ["-journal", "-shm", "-wal"]) {
@@ -132,12 +120,12 @@ async function runCrashPoint(params: {
     }
 
     const sourceState = params.verifyDatabase(params.sourcePath);
-    assertSameState(sourceState, params.expectedState, `${params.crashPoint} source`);
+    assertSameReliabilityState(sourceState, params.expectedState, `${params.crashPoint} source`);
     let targetState: ReliabilityStateProof | null = null;
     if (targetVisibleAfterCrash) {
       assertNoSqliteSidecars(targetPath);
       targetState = params.verifyDatabase(targetPath);
-      assertSameState(targetState, params.expectedState, `${params.crashPoint} target`);
+      assertSameReliabilityState(targetState, params.expectedState, `${params.crashPoint} target`);
     }
 
     if (params.crashPoint === "before-publish") {
@@ -147,7 +135,7 @@ async function runCrashPoint(params: {
       });
       assertNoSqliteSidecars(targetPath);
       const retryState = params.verifyDatabase(targetPath);
-      assertSameState(retryState, params.expectedState, `${params.crashPoint} retry`);
+      assertSameReliabilityState(retryState, params.expectedState, `${params.crashPoint} retry`);
     } else {
       const targetHash = hashFile(targetPath);
       let retryError: unknown;
@@ -169,7 +157,11 @@ async function runCrashPoint(params: {
         throw new Error("SQLite retry changed the already-published target.");
       }
       const preservedState = params.verifyDatabase(targetPath);
-      assertSameState(preservedState, params.expectedState, `${params.crashPoint} retry`);
+      assertSameReliabilityState(
+        preservedState,
+        params.expectedState,
+        `${params.crashPoint} retry`,
+      );
     }
     for (const entry of crashStagingEntries) {
       if (!fs.existsSync(path.join(params.scratchPath, entry))) {

--- a/scripts/lib/sqlite-reliability-repository.ts
+++ b/scripts/lib/sqlite-reliability-repository.ts
@@ -10,11 +10,16 @@ import {
 } from "../../src/snapshot/snapshot-provider.js";
 import {
   assertSameCompactionPayload,
+  assertSameReliabilityState,
   formatReliabilityStderr,
   type CompactionPayloadProof,
   type ReliabilityReport,
   type ReliabilityStateProof,
 } from "./sqlite-reliability-contract.js";
+import {
+  assertReliabilityForcedExit,
+  waitForReliabilityWorkerExit,
+} from "./sqlite-reliability-process.js";
 
 type RepositoryCrashPoint = "after-commit" | "before-pending" | "pending";
 type RepositoryExit =
@@ -34,22 +39,8 @@ const REPOSITORY_WORKER_PATH = fileURLToPath(
   new URL("./sqlite-reliability-repository-worker.ts", import.meta.url),
 );
 const REPOSITORY_TIMEOUT_MS = 120_000;
-
-function assertSameState(
-  actual: ReliabilityStateProof,
-  expected: ReliabilityStateProof,
-  label: string,
-): void {
-  if (
-    actual.batches !== expected.batches ||
-    actual.rows !== expected.rows ||
-    actual.sha256 !== expected.sha256
-  ) {
-    throw new Error(
-      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
-    );
-  }
-}
+const WORKER_EXIT_TIMEOUT_MESSAGE =
+  "SQLite repository worker did not exit after forced termination.";
 
 async function waitForCrashPoint(params: {
   child: ChildProcess;
@@ -96,50 +87,6 @@ async function waitForCrashPoint(params: {
   });
 }
 
-async function waitForChildExit(child: ChildProcess): Promise<RepositoryExit> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return { code: child.exitCode, signal: child.signalCode };
-  }
-  return await new Promise<RepositoryExit>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      cleanup();
-      reject(new Error("SQLite repository worker did not exit after forced termination."));
-    }, 30_000);
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      cleanup();
-      resolve({ code, signal });
-    };
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
-    const cleanup = () => {
-      clearTimeout(timeout);
-      child.off("exit", onExit);
-      child.off("error", onError);
-    };
-    child.on("exit", onExit);
-    child.on("error", onError);
-  });
-}
-
-function assertForcedExit(exit: RepositoryExit): void {
-  if (exit.code === 0) {
-    throw new Error("SQLite repository worker exited cleanly before forced termination.");
-  }
-  if (process.platform === "win32") {
-    if (exit.code === null && exit.signal === null) {
-      throw new Error("SQLite repository worker reported no forced Windows exit.");
-    }
-    return;
-  }
-  if (exit.signal !== "SIGKILL") {
-    throw new Error(
-      `SQLite repository worker exited without SIGKILL: code=${String(exit.code)} signal=${String(exit.signal)}`,
-    );
-  }
-}
-
 async function verifySnapshot(params: {
   expectedPayload: CompactionPayloadProof;
   expectedState: ReliabilityStateProof;
@@ -150,7 +97,7 @@ async function verifySnapshot(params: {
 }): Promise<void> {
   await params.provider.verify(params.snapshot.ref);
   const artifactPath = path.join(params.snapshot.ref.path, SNAPSHOT_SQLITE_FILENAME);
-  assertSameState(params.verifyState(artifactPath), params.expectedState, artifactPath);
+  assertSameReliabilityState(params.verifyState(artifactPath), params.expectedState, artifactPath);
   assertSameCompactionPayload(
     params.verifyPayload(artifactPath),
     params.expectedPayload,
@@ -212,8 +159,8 @@ async function runCrashPoint(params: {
         `SQLite repository worker exited before the ${params.crashPoint} crash signal was delivered.`,
       );
     }
-    const exit = await waitForChildExit(child);
-    assertForcedExit(exit);
+    const exit = await waitForReliabilityWorkerExit(child, WORKER_EXIT_TIMEOUT_MESSAGE);
+    assertReliabilityForcedExit(exit, "SQLite repository worker");
 
     const createdEntries = listRepositoryEntries(params.repositoryPath).filter(
       (entry) => !entriesBefore.has(entry),
@@ -233,7 +180,7 @@ async function runCrashPoint(params: {
     }
 
     const sourceState = params.verifyState(params.sourcePath);
-    assertSameState(sourceState, params.expectedState, `${params.crashPoint} source`);
+    assertSameReliabilityState(sourceState, params.expectedState, `${params.crashPoint} source`);
     const sourcePayload = params.verifyPayload(params.sourcePath);
     assertSameCompactionPayload(
       sourcePayload,
@@ -287,7 +234,7 @@ async function runCrashPoint(params: {
   } finally {
     if (child.exitCode === null && child.signalCode === null) {
       child.kill("SIGKILL");
-      await waitForChildExit(child).catch(() => undefined);
+      await waitForReliabilityWorkerExit(child, WORKER_EXIT_TIMEOUT_MESSAGE).catch(() => undefined);
     }
   }
 }

--- a/scripts/lib/sqlite-reliability-restore.ts
+++ b/scripts/lib/sqlite-reliability-restore.ts
@@ -6,11 +6,16 @@ import { fileURLToPath } from "node:url";
 import { createLocalSqliteSnapshotProvider } from "../../src/snapshot/local-repository.js";
 import {
   assertSameCompactionPayload,
+  assertSameReliabilityState,
   formatReliabilityStderr,
   type CompactionPayloadProof,
   type ReliabilityReport,
   type ReliabilityStateProof,
 } from "./sqlite-reliability-contract.js";
+import {
+  assertReliabilityForcedExit,
+  waitForReliabilityWorkerExit,
+} from "./sqlite-reliability-process.js";
 
 type RestoreCrashPoint = "after-publish" | "before-publish";
 type RestoreExit =
@@ -33,25 +38,10 @@ const RESTORE_WORKER_PATH = fileURLToPath(
 );
 const RESTORE_TIMEOUT_MS = 120_000;
 const MIN_STAGED_RESTORE_BYTES = 1024 * 1024;
+const WORKER_EXIT_TIMEOUT_MESSAGE = "SQLite restore worker did not exit after forced termination.";
 
 function hashFile(filePath: string): string {
   return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
-}
-
-function assertSameState(
-  actual: ReliabilityStateProof,
-  expected: ReliabilityStateProof,
-  label: string,
-): void {
-  if (
-    actual.batches !== expected.batches ||
-    actual.rows !== expected.rows ||
-    actual.sha256 !== expected.sha256
-  ) {
-    throw new Error(
-      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
-    );
-  }
 }
 
 function assertNoSqliteSidecars(targetPath: string): void {
@@ -125,50 +115,6 @@ async function waitForWorkerReady(params: {
     params.child.on("error", onError);
     params.child.on("exit", onExit);
   });
-}
-
-async function waitForChildExit(child: ChildProcess): Promise<RestoreExit> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return { code: child.exitCode, signal: child.signalCode };
-  }
-  return await new Promise<RestoreExit>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      cleanup();
-      reject(new Error("SQLite restore worker did not exit after forced termination."));
-    }, 30_000);
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      cleanup();
-      resolve({ code, signal });
-    };
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
-    const cleanup = () => {
-      clearTimeout(timeout);
-      child.off("exit", onExit);
-      child.off("error", onError);
-    };
-    child.on("exit", onExit);
-    child.on("error", onError);
-  });
-}
-
-function assertForcedExit(exit: RestoreExit): void {
-  if (exit.code === 0) {
-    throw new Error("SQLite restore worker exited cleanly before forced termination.");
-  }
-  if (process.platform === "win32") {
-    if (exit.code === null && exit.signal === null) {
-      throw new Error("SQLite restore worker reported no forced Windows exit.");
-    }
-    return;
-  }
-  if (exit.signal !== "SIGKILL") {
-    throw new Error(
-      `SQLite restore worker exited without SIGKILL: code=${String(exit.code)} signal=${String(exit.signal)}`,
-    );
-  }
 }
 
 async function waitForCrashPoint(params: {
@@ -299,8 +245,8 @@ async function runCrashPoint(params: {
         `SQLite restore worker exited before the ${params.crashPoint} crash signal was delivered.`,
       );
     }
-    const exit = await waitForChildExit(child);
-    assertForcedExit(exit);
+    const exit = await waitForReliabilityWorkerExit(child, WORKER_EXIT_TIMEOUT_MESSAGE);
+    assertReliabilityForcedExit(exit, "SQLite restore worker");
 
     crashStagingEntries = listRestoreStagingEntries(params.scratchPath);
     if (!crashStagingEntries.some((entry) => entry.startsWith(".tmp-restore-"))) {
@@ -351,7 +297,11 @@ async function runCrashPoint(params: {
 
     assertNoSqliteSidecars(targetPath);
     const stateAfterRecovery = params.verifyState(targetPath);
-    assertSameState(stateAfterRecovery, params.expectedState, `${params.crashPoint} restore`);
+    assertSameReliabilityState(
+      stateAfterRecovery,
+      params.expectedState,
+      `${params.crashPoint} restore`,
+    );
     const payloadAfterRecovery = params.verifyPayload(targetPath);
     assertSameCompactionPayload(
       payloadAfterRecovery,
@@ -384,7 +334,7 @@ async function runCrashPoint(params: {
   } finally {
     if (child.exitCode === null && child.signalCode === null) {
       child.kill("SIGKILL");
-      await waitForChildExit(child).catch(() => undefined);
+      await waitForReliabilityWorkerExit(child, WORKER_EXIT_TIMEOUT_MESSAGE).catch(() => undefined);
     }
     fs.rmSync(targetPath, { force: true });
     for (const entry of listRestoreStagingEntries(params.scratchPath)) {

--- a/scripts/lib/sqlite-reliability-runner.ts
+++ b/scripts/lib/sqlite-reliability-runner.ts
@@ -20,6 +20,7 @@ import {
 } from "../../src/state/openclaw-state-db.js";
 import { runVacuumInterruptionProof } from "./sqlite-reliability-compaction.js";
 import {
+  assertSameReliabilityState,
   COMMITTED_WAL_SENTINEL,
   PROFILES,
   STRESS_TABLE_SQL,
@@ -28,6 +29,7 @@ import {
   type ReliabilityStateProof,
 } from "./sqlite-reliability-contract.js";
 import { runIndexRepairInterruptionProof } from "./sqlite-reliability-index-repair.js";
+import type { ReliabilityWorkerExit } from "./sqlite-reliability-process.js";
 import { runPublicationInterruptionProof } from "./sqlite-reliability-publication.js";
 import { runRepositoryInterruptionProof } from "./sqlite-reliability-repository.js";
 import { runRestoreInterruptionProof } from "./sqlite-reliability-restore.js";
@@ -39,7 +41,6 @@ import {
   terminateWriter,
   waitForWriterMessage,
   type WriterHandle,
-  type WriterExit,
 } from "./sqlite-reliability-writer.js";
 
 type TargetDatabase = {
@@ -204,22 +205,6 @@ function readReliabilityState(database: DatabaseSync, rowsPerBatch: number): Rel
     rows,
     sha256: hash.digest("hex"),
   };
-}
-
-function assertSameReliabilityState(
-  actual: ReliabilityStateProof,
-  expected: ReliabilityStateProof,
-  label: string,
-): void {
-  if (
-    actual.batches !== expected.batches ||
-    actual.rows !== expected.rows ||
-    actual.sha256 !== expected.sha256
-  ) {
-    throw new Error(
-      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
-    );
-  }
 }
 
 function verifyRestoredDatabase(params: {
@@ -724,7 +709,7 @@ export async function runReliabilityStress(options: CliOptions): Promise<Reliabi
       rowsPerBatch: profile.rowsPerBatch,
       uncommittedBatch: partial.batch,
     });
-    let crashExit: WriterExit | undefined;
+    let crashExit: ReliabilityWorkerExit | undefined;
     let stateAfterRecovery: ReliabilityStateProof | undefined;
     const metrics: IterationMetric[] = [];
     for (let iteration = 0; iteration < profile.iterations; iteration += 1) {

--- a/scripts/lib/sqlite-reliability-writer.ts
+++ b/scripts/lib/sqlite-reliability-writer.ts
@@ -8,6 +8,10 @@ import {
   STRESS_TABLE_SQL,
   type ProfileConfig,
 } from "./sqlite-reliability-contract.js";
+import {
+  waitForReliabilityWorkerExit,
+  type ReliabilityWorkerExit,
+} from "./sqlite-reliability-process.js";
 
 type WriterReadyMessage = {
   kind: "ready";
@@ -50,12 +54,9 @@ export type WriterHandle = {
   stopped: boolean;
 };
 
-export type WriterExit = {
-  code: number | null;
-  signal: NodeJS.Signals | null;
-};
-
 const WRITER_MESSAGE_TIMEOUT_MS = 30_000;
+const WORKER_EXIT_TIMEOUT_MESSAGE =
+  "SQLite reliability writer did not exit after termination was requested.";
 
 export function startWriter(databasePath: string, profile: ProfileConfig): WriterHandle {
   const child = fork(
@@ -141,46 +142,19 @@ export async function stopWriter(writer: WriterHandle): Promise<WriterResultMess
   const result = await waitForWriterMessage(writer, "result", () => {
     writer.child.send?.({ kind: "stop" });
   });
-  await waitForChildExit(writer.child);
+  await waitForReliabilityWorkerExit(writer.child, WORKER_EXIT_TIMEOUT_MESSAGE);
   writer.stopped = true;
   return result;
 }
 
-async function waitForChildExit(child: ChildProcess): Promise<WriterExit> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return { code: child.exitCode, signal: child.signalCode };
-  }
-  return await new Promise<WriterExit>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      cleanup();
-      reject(new Error("SQLite reliability writer did not exit after termination was requested."));
-    }, WRITER_MESSAGE_TIMEOUT_MS);
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      cleanup();
-      resolve({ code, signal });
-    };
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
-    const cleanup = () => {
-      clearTimeout(timeout);
-      child.off("exit", onExit);
-      child.off("error", onError);
-    };
-    child.on("exit", onExit);
-    child.on("error", onError);
-  });
-}
-
-export async function crashWriter(writer: WriterHandle): Promise<WriterExit> {
+export async function crashWriter(writer: WriterHandle): Promise<ReliabilityWorkerExit> {
   if (writer.stopped) {
     throw new Error("SQLite reliability writer was already stopped.");
   }
   if (!writer.child.kill("SIGKILL")) {
     throw new Error("SQLite reliability writer exited before the crash signal was delivered.");
   }
-  const exit = await waitForChildExit(writer.child);
+  const exit = await waitForReliabilityWorkerExit(writer.child, WORKER_EXIT_TIMEOUT_MESSAGE);
   writer.stopped = true;
   return exit;
 }
@@ -191,7 +165,9 @@ export async function terminateWriter(writer: WriterHandle): Promise<void> {
     return;
   }
   writer.child.kill();
-  await waitForChildExit(writer.child).catch(() => undefined);
+  await waitForReliabilityWorkerExit(writer.child, WORKER_EXIT_TIMEOUT_MESSAGE).catch(
+    () => undefined,
+  );
   writer.stopped = true;
 }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Maintainer-requested cleanup of the SQLite reliability proof workflow: worker-exit handling and state-preservation checks were repeated across its crash scenarios, making consistent maintenance require several identical edits.

## Why This Change Was Made

One reliability process module now owns the shared exit wait and forced-exit validation, while the existing reliability contract owns state equality. This removes five copied exit waiters, four copied forced-exit checks, and the repeated state assertions without changing the scenario-specific message barriers or filesystem evidence checks.

The existing 30-second exit deadline, recorded-exit handling, listener cleanup, worker-specific error messages, Windows exit-code handling, and POSIX SIGKILL requirement are preserved. Tooling changes total **+148/-319 lines, a net reduction of 171** across nine files; product runtime and test LOC are unchanged.

## User Impact

No user-visible behavior change. Developers maintain one implementation of these shared reliability checks while retaining the existing real crash, recovery, retry, and artifact-preservation coverage. Database schemas, storage behavior, fixture sizes, command arguments, and report shapes are unchanged.

## Evidence

Validated candidate: `1b39d5c1b3f9ce75b9ab8c9ef58ec03d09a34cb6`.

- Before and after the refactor, `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs test/scripts/bench-sqlite-reliability.test.ts` passed **7/7 tests**. This includes the actual global SQLite CLI smoke flow across all crash/recovery scenarios and the real writer IPC-disconnect check.
- `TSX_DISABLE_CACHE=1 node --import tsx scripts/bench-sqlite-reliability.ts --profile smoke --agent tooling-proof` also passed on macOS arm64, Node 26.8.1: five verified restores, two concurrent restores, and verified crash recovery, publication, repository, restore, index-repair, WAL-sentinel, VACUUM, and post-compaction proof markers. Its temporary state was removed afterward.
- Formatting, `git diff --check`, targeted oxlint on all nine files, coercion declarations, Docker E2E package/catalog boundaries, and the raw-http2 boundary guard passed.
- In the native PR checkout with its own installed dependencies, `GOMAXPROCS=2 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- <the nine changed files>` passed **all 17 selected checks**, including script typecheck. The earlier shared-dependency path restriction is resolved. The focused reliability suite was also rerun there and passed **7/7**.
- Fresh Codex autoreview through P2, a separate source challenge, and a read-only review of this exact committed head found no actionable issues. [Exact-head CI 33964474759](https://github.com/openclaw/openclaw/actions/runs/33964474759) completed successfully, including `openclaw/ci-gate`. Native prepare/merge checks remain pending.

The existing VACUUM stabilization PR #122612 changes fixture sizing; this refactor leaves that surface untouched.


**ClawSweeper before-merge item — data-model compatibility:** The request for a new migration/upgrade exercise is skipped as inapplicable. This PR changes no persisted data model. Exact base-to-head comparison confirms that all 53 SQLite `.exec()`/`.prepare()` call expressions and all 13 reliability-contract type/constant declarations are unchanged; no product-runtime, schema, or migration source changed, and worker-side database logic is unchanged. The existing-state-reuse smoke also passes. The review’s generated SQLite-table warning does not correspond to a schema change in this diff.
