### PR TITLE
fix(ui): keep Home context current after dock reconnection

### DIFF
--- a/ui/src/components/assistant-panel.test.ts
+++ b/ui/src/components/assistant-panel.test.ts
@@ -303,6 +303,16 @@ describe("assistant panel", () => {
       setGatewaySnapshot({ hello });
       await panel.updateComplete;
       expect(workContext()).toEqual(disconnectedContext);
+
+      provider.append(panel);
+      await panel.updateComplete;
+      request.mockResolvedValueOnce({
+        ...agents.state.agentsList,
+        agents: [{ id: "main" }, { id: "research", workspace: "/projects/reconnected" }],
+      });
+      await agents.refreshList();
+      await panel.updateComplete;
+      expect(workContext()?.workspace).toBe("/projects/reconnected");
     } finally {
       agents.dispose();
     }

--- a/ui/src/components/assistant-panel.ts
+++ b/ui/src/components/assistant-panel.ts
@@ -83,31 +83,35 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
     agentsList?: ApplicationContext["agents"]["state"]["agentsList"];
     hello?: ApplicationContext["gateway"]["snapshot"]["hello"];
   } = {};
-  private readonly subscriptions = new SubscriptionsController(this)
-    .watch(
-      () => this.store,
-      (store, notify) => store.subscribe(notify),
-    )
-    .watch(
-      () => this.context,
-      (context, notify) => subscribeChatWorkContext(context, notify),
-    )
-    .watch(
-      () => this.context?.agentSelection,
-      (selection, notify) => selection.subscribe(notify),
-    )
-    .watch(
-      () => this.context?.sessions,
-      (sessions, notify) => sessions.subscribe(notify),
-    )
-    .watch(
-      () => this.context?.agents,
-      (agents, notify) => agents.subscribe(notify),
-    )
-    .watch(
-      () => this.context?.gateway,
-      (gateway, notify) => gateway.subscribe(notify),
-    );
+
+  constructor() {
+    super();
+    void new SubscriptionsController(this)
+      .watch(
+        () => this.store,
+        (store, notify) => store.subscribe(notify),
+      )
+      .watch(
+        () => this.context,
+        (context, notify) => subscribeChatWorkContext(context, notify),
+      )
+      .watch(
+        () => this.context?.agentSelection,
+        (selection, notify) => selection.subscribe(notify),
+      )
+      .watch(
+        () => this.context?.sessions,
+        (sessions, notify) => sessions.subscribe(notify),
+      )
+      .watch(
+        () => this.context?.agents,
+        (agents, notify) => agents.subscribe(notify),
+      )
+      .watch(
+        () => this.context?.gateway,
+        (gateway, notify) => gateway.subscribe(notify),
+      );
+  }
 
   override connectedCallback(): void {
     super.connectedCallback();

--- a/ui/src/components/assistant-panel.ts
+++ b/ui/src/components/assistant-panel.ts
@@ -1,6 +1,6 @@
 import { consume } from "@lit/context";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
-import { html, nothing, type PropertyValues } from "lit";
+import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import "./openclaw-mascot.ts";
 import type { RouteId } from "../app-route-paths.ts";
@@ -24,6 +24,7 @@ import {
   resolveUiDefaultAgentId,
 } from "../lib/sessions/session-key.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
+import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
 import { CHAT_TRANSCRIPT_LOADING_CHANGED_EVENT } from "../pages/chat/chat-history-events.ts";
 import { buildHomeWorkContext, subscribeChatWorkContext } from "../pages/chat/chat-work-context.ts";
@@ -82,13 +83,34 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
     agentsList?: ApplicationContext["agents"]["state"]["agentsList"];
     hello?: ApplicationContext["gateway"]["snapshot"]["hello"];
   } = {};
-  private contextCleanup: (() => void) | null = null;
-  private subscribedStore: CustodianSessionStore | null = null;
-  private storeCleanup: (() => void) | null = null;
+  private readonly subscriptions = new SubscriptionsController(this)
+    .watch(
+      () => this.store,
+      (store, notify) => store.subscribe(notify),
+    )
+    .watch(
+      () => this.context,
+      (context, notify) => subscribeChatWorkContext(context, notify),
+    )
+    .watch(
+      () => this.context?.agentSelection,
+      (selection, notify) => selection.subscribe(notify),
+    )
+    .watch(
+      () => this.context?.sessions,
+      (sessions, notify) => sessions.subscribe(notify),
+    )
+    .watch(
+      () => this.context?.agents,
+      (agents, notify) => agents.subscribe(notify),
+    )
+    .watch(
+      () => this.context?.gateway,
+      (gateway, notify) => gateway.subscribe(notify),
+    );
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.subscribeToStore();
     document.addEventListener(CHAT_ROUTE_READY_EVENT, this.startHomeAfterPrimaryChat);
     document.addEventListener(
       CHAT_TRANSCRIPT_LOADING_CHANGED_EVENT,
@@ -110,33 +132,11 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
     window.removeEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.onToggleRequest);
     window.removeEventListener(HOME_PANEL_TOGGLE_EVENT, this.onToggleRequest);
     this.claimInput("page");
-    this.contextCleanup?.();
-    this.contextCleanup = null;
-    this.storeCleanup?.();
-    this.storeCleanup = null;
-    this.subscribedStore = null;
     super.disconnectedCallback();
   }
 
-  override willUpdate(changed: PropertyValues): void {
+  override willUpdate(): void {
     const wasOpen = this.dockLayout.open;
-    if (changed.has("context") && this.context) {
-      this.contextCleanup?.();
-      const cleanups = [
-        subscribeChatWorkContext(this.context, () => this.requestUpdate()),
-        // The sidebar switcher owns agent choice; the dock follows it.
-        this.context.agentSelection.subscribe(() => this.requestUpdate()),
-        // Snapshot changes need not change route facts; keep the open Home reference current.
-        this.context.sessions.subscribe(() => this.requestUpdate()),
-        this.context.agents.subscribe(() => this.requestUpdate()),
-        this.context.gateway.subscribe(() => this.requestUpdate()),
-      ];
-      this.contextCleanup = () => {
-        for (const cleanup of cleanups) {
-          cleanup();
-        }
-      };
-    }
     const scope = this.context?.gateway.connection.gatewayUrl ?? "";
     if (scope !== this.targetScope) {
       this.targetScope = scope;
@@ -157,9 +157,6 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
         agentsList: this.context.agents.state.agentsList ?? this.homeDefaults.agentsList,
         hello: this.context.gateway.snapshot.hello,
       };
-    }
-    if (changed.has("store")) {
-      this.subscribeToStore();
     }
     this.dockLayout.setSuppressed(this.suppressed);
     if (
@@ -325,15 +322,6 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
         }
       }
     }
-  }
-
-  private subscribeToStore(): void {
-    if (!this.isConnected || this.subscribedStore === this.store) {
-      return;
-    }
-    this.storeCleanup?.();
-    this.subscribedStore = this.store;
-    this.storeCleanup = this.store.subscribe(() => this.requestUpdate());
   }
 
   private openHomePage(): void {

--- a/ui/src/e2e/assistant-panel-context.e2e.test.ts
+++ b/ui/src/e2e/assistant-panel-context.e2e.test.ts
@@ -103,7 +103,7 @@ suite.define(() => {
     },
   );
 
-  it("refreshes open Home context after a roster-only title update", async () => {
+  it("refreshes reconnected Home context after a roster-only title update", async () => {
     const proofDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()
       ? suite.artifactDir
       : undefined;
@@ -148,6 +148,14 @@ suite.define(() => {
           await page.screenshot({ path: path.join(proofDir, "01-initial-context.png") });
         }
 
+        await panel.evaluate(async (element) => {
+          const parent = element.parentElement!;
+          const next = element.nextSibling;
+          element.remove();
+          parent.insertBefore(element, next);
+          await (element as HTMLElement & { updateComplete: Promise<boolean> }).updateComplete;
+        });
+
         const renamed = { ...work, label: "Renamed workspace", updatedAt: Date.now() + 1 };
         const list: SessionsListResult = {
           ts: Date.now(),
@@ -165,10 +173,10 @@ suite.define(() => {
         const row = page.locator(`.sidebar-recent-session[data-session-key="${work.key}"]`);
         // Confirm the roster and shell observed the update without changing the route or pane.
         await expect.poll(() => row.textContent()).toContain(renamed.label);
-        await expect.poll(() => reference.textContent()).toContain('"title":"Renamed workspace"');
         if (proofDir) {
           await page.screenshot({ path: path.join(proofDir, "02-renamed-context.png") });
         }
+        await expect.poll(() => reference.textContent()).toContain('"title":"Renamed workspace"');
 
         const composer = panel.locator(".agent-chat__composer-combobox textarea");
         await composer.fill("Review the current work");

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -37,32 +37,36 @@ export class CustodianPage extends OpenClawLightDomElement {
   private historyClient: GatewayBrowserClient | null = null;
   private historyRequestEpoch = 0;
   private channelsSource: ApplicationContext["channels"] | null = null;
-  private readonly subscriptions = new SubscriptionsController(this)
-    .watch(
-      () => this.store,
-      (store, notify) => {
-        const cleanup = store.subscribe(notify);
-        void store.refreshTranscriptIfIdle();
-        return cleanup;
-      },
-    )
-    .effect(
-      () => this.context?.channels,
-      (channels) => {
-        this.channelsSource = channels;
-        const stop = channels.subscribe(() => {
+
+  constructor() {
+    super();
+    void new SubscriptionsController(this)
+      .watch(
+        () => this.store,
+        (store, notify) => {
+          const cleanup = store.subscribe(notify);
+          void store.refreshTranscriptIfIdle();
+          return cleanup;
+        },
+      )
+      .effect(
+        () => this.context?.channels,
+        (channels) => {
+          this.channelsSource = channels;
+          const stop = channels.subscribe(() => {
+            this.ensureOnboardingChannelStatus();
+            this.requestUpdate();
+          });
           this.ensureOnboardingChannelStatus();
-          this.requestUpdate();
-        });
-        this.ensureOnboardingChannelStatus();
-        return () => {
-          stop();
-          if (this.channelsSource === channels) {
-            this.channelsSource = null;
-          }
-        };
-      },
-    );
+          return () => {
+            stop();
+            if (this.channelsSource === channels) {
+              this.channelsSource = null;
+            }
+          };
+        },
+      );
+  }
 
   protected override async getUpdateComplete(): Promise<boolean> {
     const complete = await super.getUpdateComplete();

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -1,6 +1,6 @@
 import { consume } from "@lit/context";
 import type { SystemChangeEntry, SystemChangesListResult } from "@openclaw/gateway-protocol";
-import { html, nothing, type PropertyValues } from "lit";
+import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
@@ -36,39 +36,33 @@ export class CustodianPage extends OpenClawLightDomElement {
   private historyLoaded = false;
   private historyClient: GatewayBrowserClient | null = null;
   private historyRequestEpoch = 0;
-  private subscribedStore: CustodianSessionStore | null = null;
-  private storeCleanup: (() => void) | null = null;
   private channelsSource: ApplicationContext["channels"] | null = null;
-  private readonly subscriptions = new SubscriptionsController(this).effect(
-    () => this.context?.channels,
-    (channels) => {
-      this.channelsSource = channels;
-      const stop = channels.subscribe(() => {
+  private readonly subscriptions = new SubscriptionsController(this)
+    .watch(
+      () => this.store,
+      (store, notify) => {
+        const cleanup = store.subscribe(notify);
+        void store.refreshTranscriptIfIdle();
+        return cleanup;
+      },
+    )
+    .effect(
+      () => this.context?.channels,
+      (channels) => {
+        this.channelsSource = channels;
+        const stop = channels.subscribe(() => {
+          this.ensureOnboardingChannelStatus();
+          this.requestUpdate();
+        });
         this.ensureOnboardingChannelStatus();
-        this.requestUpdate();
-      });
-      this.ensureOnboardingChannelStatus();
-      return () => {
-        stop();
-        if (this.channelsSource === channels) {
-          this.channelsSource = null;
-        }
-      };
-    },
-  );
-
-  override connectedCallback(): void {
-    super.connectedCallback();
-    this.subscribeToStore();
-  }
-
-  override disconnectedCallback(): void {
-    this.storeCleanup?.();
-    this.storeCleanup = null;
-    this.subscribedStore = null;
-    this.subscriptions.clear();
-    super.disconnectedCallback();
-  }
+        return () => {
+          stop();
+          if (this.channelsSource === channels) {
+            this.channelsSource = null;
+          }
+        };
+      },
+    );
 
   protected override async getUpdateComplete(): Promise<boolean> {
     const complete = await super.getUpdateComplete();
@@ -79,10 +73,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     return complete;
   }
 
-  override willUpdate(changedProperties: PropertyValues): void {
-    if (changedProperties.has("store")) {
-      this.subscribeToStore();
-    }
+  override willUpdate(): void {
     this.synchronizeHistoryClient();
     this.ensureOnboardingChannelStatus();
   }
@@ -102,16 +93,6 @@ export class CustodianPage extends OpenClawLightDomElement {
       return;
     }
     void channels.refresh(false);
-  }
-
-  private subscribeToStore(): void {
-    if (!this.isConnected || this.subscribedStore === this.store) {
-      return;
-    }
-    this.storeCleanup?.();
-    this.subscribedStore = this.store;
-    this.storeCleanup = this.store.subscribe(() => this.requestUpdate());
-    void this.store.refreshTranscriptIfIdle();
   }
 
   private synchronizeHistoryClient(): void {

--- a/ui/src/pages/custodian/custodian-surface.ts
+++ b/ui/src/pages/custodian/custodian-surface.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import { property } from "lit/decorators.js";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { controlUiPublicAssetPath } from "../../app/public-assets.ts";
@@ -11,6 +11,7 @@ import { renderPanelRefreshStatus } from "../../components/panel-refresh-status.
 import "../../components/openclaw-mascot.ts";
 import { t } from "../../i18n/index.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
+import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import "../../styles/chat/grouped.css";
 import "../../styles/chat/layout.css";
 import "../../styles/chat/message-layout.css";
@@ -38,25 +39,16 @@ class CustodianSurface extends OpenClawLightDomElement {
   @property({ attribute: false }) compact = false;
   @property({ attribute: false }) historyContent: TemplateResult | typeof nothing = nothing;
 
-  private subscribedStore: CustodianSessionStore | null = null;
-  private storeCleanup: (() => void) | null = null;
-  private alertCleanup: (() => void) | null = null;
+  private readonly subscriptions = new SubscriptionsController(this)
+    .watch(
+      () => this.store,
+      (store, notify) => store.subscribe(notify),
+    )
+    .watch(
+      () => custodianAlertStore,
+      (alerts, notify) => alerts.subscribe(notify),
+    );
   private lastMessageId: number | null = null;
-
-  override connectedCallback(): void {
-    super.connectedCallback();
-    this.subscribeToStore();
-    this.alertCleanup = custodianAlertStore.subscribe(() => this.requestUpdate());
-  }
-
-  override disconnectedCallback(): void {
-    this.storeCleanup?.();
-    this.storeCleanup = null;
-    this.alertCleanup?.();
-    this.alertCleanup = null;
-    this.subscribedStore = null;
-    super.disconnectedCallback();
-  }
 
   protected override async getUpdateComplete(): Promise<boolean> {
     const complete = await super.getUpdateComplete();
@@ -70,10 +62,7 @@ class CustodianSurface extends OpenClawLightDomElement {
     return complete;
   }
 
-  override willUpdate(changedProperties: PropertyValues): void {
-    if (changedProperties.has("store")) {
-      this.subscribeToStore();
-    }
+  override willUpdate(): void {
     this.store.connect(this.context, sessionVariant(this.onboarding, this.newAgentIntent));
   }
 
@@ -93,15 +82,6 @@ class CustodianSurface extends OpenClawLightDomElement {
         lastMessage.scrollIntoView?.({ block: "nearest" });
       }
     }
-  }
-
-  private subscribeToStore(): void {
-    if (!this.isConnected || this.subscribedStore === this.store) {
-      return;
-    }
-    this.storeCleanup?.();
-    this.subscribedStore = this.store;
-    this.storeCleanup = this.store.subscribe(() => this.requestUpdate());
   }
 
   private handleComposerKeydown(event: KeyboardEvent): void {

--- a/ui/src/pages/custodian/custodian-surface.ts
+++ b/ui/src/pages/custodian/custodian-surface.ts
@@ -39,16 +39,20 @@ class CustodianSurface extends OpenClawLightDomElement {
   @property({ attribute: false }) compact = false;
   @property({ attribute: false }) historyContent: TemplateResult | typeof nothing = nothing;
 
-  private readonly subscriptions = new SubscriptionsController(this)
-    .watch(
-      () => this.store,
-      (store, notify) => store.subscribe(notify),
-    )
-    .watch(
-      () => custodianAlertStore,
-      (alerts, notify) => alerts.subscribe(notify),
-    );
   private lastMessageId: number | null = null;
+
+  constructor() {
+    super();
+    void new SubscriptionsController(this)
+      .watch(
+        () => this.store,
+        (store, notify) => store.subscribe(notify),
+      )
+      .watch(
+        () => custodianAlertStore,
+        (alerts, notify) => alerts.subscribe(notify),
+      );
+  }
 
   protected override async getUpdateComplete(): Promise<boolean> {
     const complete = await super.getUpdateComplete();


### PR DESCRIPTION
Closes #139054

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Repairs a latent lifecycle bug: after the same Home panel is detached and reattached with the same context, subsequent roster updates can leave its displayed working reference stale. Direct component and bundled-browser tests reproduce this sequence. An ordinary current UI action that triggers the same-node reattachment has not been established.

## Why This Change Was Made

Home removed its context subscriptions on disconnect and restored them only when the context object changed. Reconnecting to the same context therefore left its listeners inactive. Home and both Ask OpenClaw presentations now use the existing subscription lifecycle controller, removing three duplicate store-subscription loops and the separate context cleanup path.

The conversation store remains the shared owner across the page and dock. The page still refreshes idle history once per subscription, and the dock still refreshes it only when shown. This removes 39 production lines; the existing regression tests grow by 18 lines. No configuration, database, or protocol changes.

## User Impact

Reattached Home panels keep their working reference current, and all three presentations share the established subscription lifecycle owner. This is a latent lifecycle repair and deduplication under the maintainer cleanup request, with existing Home and Ask OpenClaw behavior covered by regression tests.

## Evidence

Both directly exercised lifecycle regressions failed before the production change and pass after it:

- The component test reattaches the same Home panel and refreshes the agent roster; the new workspace now replaces the old workspace.
- The bundled Chromium flow reattaches the same dock, renames the current session through a Gateway event, verifies the sidebar and Home title agree, and sends a message containing the updated title.

Before the fix, component and browser tests reproduced stale displayed context after explicit DOM detachment/reattachment. Stale-send impact is source-backed inference because the send path consumes the same cached reference; no pre-fix stale send was observed. After the fix, the browser test also verifies that the next message carries the updated title. This is bundled Chromium proof with a synthetic Gateway WebSocket, not real-Gateway transport proof or an observed ordinary-user regression.

![Before: Home retains the old workspace title](https://github.com/user-attachments/assets/53436cd1-b3d8-4557-bf30-3c0b4c4363c8)

![After: Home follows the renamed workspace](https://github.com/user-attachments/assets/9f377664-5cc5-46b6-9503-330a4d544edb)

All 125 focused component, Custodian lifecycle, history, onboarding, nudge, transcript-status, alert-store, and subscription-controller tests pass. The five alert-store cases cover once-per-presentation delivery, rearming recurring incidents, listener updates, retired authority, and visible alerts without unavailable chat sends. All five bundled Home/Ask OpenClaw E2E scenarios pass, including saved workspace/dashboard layouts, palette opening, and history restoration after reload. Fresh Codex autoreview found no actionable P0–P2 findings. The declared Oxfmt 0.65.0 formatting check passes.

<details>
<summary>Focused verification commands</summary>

```sh
pnpm tsgo:ui
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run ui/src/components/assistant-panel.test.ts ui/src/pages/custodian/custodian-page.test.ts ui/src/pages/custodian/custodian-page.history.test.ts ui/src/pages/custodian/custodian-page.channel-onboarding.test.ts ui/src/pages/custodian/custodian-page.nudges.test.ts ui/src/pages/custodian/custodian-page.session-lifecycle.test.ts ui/src/pages/custodian/custodian-transcript-status.test.ts ui/src/pages/custodian/custodian-alert-store.test.ts ui/src/lit/subscriptions-controller.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/assistant-panel-context.e2e.test.ts ui/src/e2e/custodian-panel-toggle.e2e.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- ui/src/components/assistant-panel.ts ui/src/pages/custodian/custodian-page.ts ui/src/pages/custodian/custodian-surface.ts ui/src/components/assistant-panel.test.ts ui/src/e2e/assistant-panel-context.e2e.test.ts
pnpm build
```

</details>

The native checkout now has its own frozen dependencies. Its pinned UI typecheck reproduced the three unread controller fields reported by review; replacing them with the existing constructor-registration pattern makes `pnpm tsgo:ui` pass. All 125 focused unit tests and five bundled-browser scenarios also pass after that correction. The full changed gate and complete build pass in that checkout. Fresh P2 autoreview of the complete candidate and a separate direct read-only review of the final pushed head are clean. [CI run 33966375794](https://github.com/openclaw/openclaw/actions/runs/33966375794) passed on the exact final head.

Validated final head: `9a1d2de908ccf22d88559c22826c032a521cabe0`. The final ClawSweeper review explicitly resolves the constructor/type finding and reports no new actionable correctness findings. Its remaining reviewer-access questions are covered by direct maintainer inspection of the pinned Lit lifecycle source and the complete before/after captures. The existing uploaded after screenshot remains equivalent for the asserted renamed-context state.
