### PR TITLE
fix(gateway): avoid crashes when an upgrading client disconnects

### DIFF
--- a/src/gateway/portals/portal-http-proxy.test.ts
+++ b/src/gateway/portals/portal-http-proxy.test.ts
@@ -1,3 +1,4 @@
+import { once } from "node:events";
 import {
   createServer,
   request,
@@ -9,6 +10,7 @@ import net, { type AddressInfo } from "node:net";
 import { duplexPair, type Duplex } from "node:stream";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { type RawData, WebSocket, WebSocketServer } from "ws";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { getFreePort } from "../../test-utils/ports.js";
 import type { PortalTarget } from "./portal-http-proxy.js";
 import { createGatewayPortalService, type GatewayPortalService } from "./portal-service.js";
@@ -596,6 +598,56 @@ describe("portal HTTP proxy", () => {
     releaseDial();
 
     expect(await response).toMatchObject({ status: 200, body: "worker /slow" });
+  });
+
+  it("contains browser socket errors while a worker WebSocket is attaching", async () => {
+    targetHandler = (_req, res) => res.end("still available");
+    const httpServers: Server[] = [];
+    const service = createGatewayPortalService({ httpBindHosts: ["127.0.0.1"], httpServers });
+    services.add(service);
+    const dialing = createDeferredCore();
+    const attachment = createDeferredCore<Duplex>();
+    let firstConnection = true;
+    const portal = await service.open({
+      targetPort,
+      target: workerTarget(async () => {
+        if (!firstConnection) {
+          return createWorkerStream(targetPort);
+        }
+        firstConnection = false;
+        dialing.resolve();
+        return await attachment.promise;
+      }, targetPort),
+    });
+    const upgrade = createDeferredCore<Duplex>();
+    httpServers[0]!.once("upgrade", (_req, socket) => upgrade.resolve(socket));
+    const browser = net.connect({ host: "127.0.0.1", port: portal.listenPort });
+    const [lateStream, peer] = createWorkerStreamPair();
+    let transport: Duplex | undefined;
+    try {
+      await once(browser, "connect");
+      browser.write(
+        `GET /hmr?${portal.tokenQuery} HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n`,
+      );
+      await dialing.promise;
+      transport = await upgrade.promise;
+      const reset = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+      expect(() => transport!.emit("error", reset)).not.toThrow();
+      expect(transport.destroyed).toBe(true);
+      const lateClosed = once(lateStream, "close");
+      attachment.resolve(lateStream);
+      await lateClosed;
+      expect(lateStream.destroyed).toBe(true);
+      expect(
+        await httpCall({ port: portal.listenPort, headers: { Cookie: portalAuthCookie(portal) } }),
+      ).toMatchObject({ status: 200, body: "still available" });
+    } finally {
+      attachment.resolve(lateStream);
+      browser.destroy();
+      transport?.destroy();
+      lateStream.destroy();
+      peer.destroy();
+    }
   });
 
   it.each([

--- a/src/gateway/portals/portal-http-proxy.ts
+++ b/src/gateway/portals/portal-http-proxy.ts
@@ -451,6 +451,8 @@ export function handlePortalProxyUpgrade(params: {
   upgradedSockets: Set<Duplex>;
 }): void {
   const { req, socket, head, target, upgradedSockets } = params;
+  // Node releases socket errors on upgrade; own them before replies or worker attachment.
+  socket.once("error", () => socket.destroy());
   const authorization = authorizePortalRequest(req, target);
   if (authorization.kind !== "authorized") {
     rejectPortalUpgrade(socket);
@@ -460,59 +462,45 @@ export function handlePortalProxyUpgrade(params: {
   const targetPort = target.target.kind === "local" ? target.target.port : target.target.remotePort;
   upgradedSockets.add(socket);
   socket.once("close", () => upgradedSockets.delete(socket));
-  void connectPortalTarget(target.target).then(
-    (targetSocket) => {
-      if (socket.destroyed) {
-        targetSocket.destroy();
-        return;
+  let responseStarted = false;
+  const closeUpgrade = () => {
+    if (target.target.kind === "worker" && !responseStarted && !socket.destroyed) {
+      if (!socket.writableEnded) {
+        respondUpgradeWaiting(socket, targetPort);
       }
-      upgradedSockets.add(targetSocket);
-      let responseStarted = false;
-      let waitingResponseSent = false;
-      const closeUpgrade = () => {
-        if (target.target.kind === "worker" && !responseStarted && !socket.destroyed) {
-          if (!waitingResponseSent) {
-            waitingResponseSent = true;
-            respondUpgradeWaiting(socket, targetPort);
-          }
-          return;
-        }
-        socket.destroy();
-      };
-      socket.once("close", () => targetSocket.destroy());
-      targetSocket.once("close", () => {
-        upgradedSockets.delete(targetSocket);
-        closeUpgrade();
+      return;
+    }
+    socket.destroy();
+  };
+  void connectPortalTarget(target.target).then((targetSocket) => {
+    if (socket.destroyed) {
+      targetSocket.destroy();
+      return;
+    }
+    upgradedSockets.add(targetSocket);
+    socket.once("close", () => targetSocket.destroy());
+    targetSocket.once("close", () => {
+      upgradedSockets.delete(targetSocket);
+      closeUpgrade();
+    });
+    targetSocket.once("end", closeUpgrade);
+    targetSocket.once("error", closeUpgrade);
+    const spliceUpgrade = () => {
+      forwardWebSocketResponse(targetSocket, socket, target.cookieNamespace, () => {
+        responseStarted = true;
       });
-      targetSocket.once("end", closeUpgrade);
-      socket.once("error", () => targetSocket.destroy());
-      targetSocket.once("error", closeUpgrade);
-      const spliceUpgrade = () => {
-        forwardWebSocketResponse(targetSocket, socket, target.cookieNamespace, () => {
-          responseStarted = true;
-        });
-        targetSocket.write(
-          websocketHeaders(req, targetPort, target.cookieNamespace, authorization.requestPath),
-        );
-        if (head.length > 0) {
-          targetSocket.write(head);
-        }
-        socket.pipe(targetSocket);
-      };
-      if (target.target.kind === "worker") {
-        spliceUpgrade();
-      } else {
-        targetSocket.once("connect", spliceUpgrade);
+      targetSocket.write(
+        websocketHeaders(req, targetPort, target.cookieNamespace, authorization.requestPath),
+      );
+      if (head.length > 0) {
+        targetSocket.write(head);
       }
-    },
-    () => {
-      if (!socket.destroyed) {
-        if (target.target.kind === "worker") {
-          respondUpgradeWaiting(socket, targetPort);
-        } else {
-          socket.destroy();
-        }
-      }
-    },
-  );
+      socket.pipe(targetSocket);
+    };
+    if (target.target.kind === "worker") {
+      spliceUpgrade();
+    } else {
+      targetSocket.once("connect", spliceUpgrade);
+    }
+  }, closeUpgrade);
 }

--- a/src/gateway/server-http-upgrades.ts
+++ b/src/gateway/server-http-upgrades.ts
@@ -222,6 +222,8 @@ export function attachGatewayUpgradeHandler(opts: {
   } = opts;
   const getResolvedAuth = opts.getResolvedAuth ?? (() => resolvedAuth);
   httpServer.on("upgrade", (req, socket, head) => {
+    // Node releases socket errors before routing can await a plugin or authenticate.
+    socket.once("error", () => socket.destroy());
     markGatewayIngressTransport(req, opts.ingressTransport ?? { kind: "ordinary" });
     const handleUpgrade = async () => {
       const configSnapshot = getRuntimeConfig();

--- a/src/gateway/server-http.rejection-transport.test.ts
+++ b/src/gateway/server-http.rejection-transport.test.ts
@@ -30,7 +30,7 @@ describe("Gateway closing connection admission", () => {
         return true;
       },
     });
-    const wss = new WebSocketServer({ noServer: true });
+    const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_PREAUTH_PAYLOAD_BYTES });
     attachGatewayUpgradeHandler({
       httpServer: server,
       wss,

--- a/src/gateway/server-http.rejection-transport.test.ts
+++ b/src/gateway/server-http.rejection-transport.test.ts
@@ -13,6 +13,72 @@ import { createPreauthConnectionBudget } from "./server/preauth-connection-budge
 vi.mock("../config/io.js", () => ({ getRuntimeConfig: () => ({}) }));
 
 describe("Gateway closing connection admission", () => {
+  it("contains browser socket errors while plugin upgrade routing is pending", async () => {
+    const routing = createDeferredCore<Duplex>();
+    const releaseRouting = createDeferredCore();
+    const routed = createDeferredCore();
+    const clients = new Set<never>();
+    const resolvedAuth = { mode: "none" as const, allowTailscale: false };
+    const server = createGatewayHttpServer({
+      clients,
+      controlUiEnabled: false,
+      controlUiBasePath: "",
+      resolvedAuth,
+      getRuntimeConfig: () => ({}),
+      handleHooksRequest: async (_req, res) => {
+        res.end("still available");
+        return true;
+      },
+    });
+    const wss = new WebSocketServer({ noServer: true });
+    attachGatewayUpgradeHandler({
+      httpServer: server,
+      wss,
+      clients,
+      resolvedAuth,
+      preauthConnectionBudget: createPreauthConnectionBudget(),
+      shouldEnforcePluginGatewayAuth: () => false,
+      handlePluginUpgrade: async (_req, socket) => {
+        routing.resolve(socket);
+        await releaseRouting.promise;
+        routed.resolve();
+        return true;
+      },
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("missing listener");
+    }
+    const browser = connect({ host: "127.0.0.1", port: address.port });
+    let transport: Duplex | undefined;
+    try {
+      await once(browser, "connect");
+      browser.write(
+        "GET /socket HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+      );
+      transport = await routing.promise;
+      const reset = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+      expect(() => transport!.emit("error", reset)).not.toThrow();
+      expect(transport.destroyed).toBe(true);
+      releaseRouting.resolve();
+      await routed.promise;
+      expect(await (await fetch(`http://127.0.0.1:${address.port}/next`)).text()).toBe(
+        "still available",
+      );
+    } finally {
+      releaseRouting.resolve();
+      browser.destroy();
+      transport?.destroy();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      wss.close();
+    }
+  });
+
   it.each([
     { route: "Gateway", queued: false },
     { route: "Gateway", queued: true },


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where a client disconnecting during WebSocket setup could crash the Gateway with an unhandled socket error. The gap affects portal worker attachment and asynchronous plugin/Gateway upgrade routing.

## Why This Change Was Made

Node removes its HTTP socket error listener before handing an upgrade to the application. Both upgrade entry points now own errors immediately, before waiting for routing or worker attachment. Existing close handling disposes connected and late-arriving target streams.

Portal failures share one finalizer and use the socket's completion state instead of a second waiting-response flag. This removes 10 net production lines. Authentication, routing, admission and protocol contracts are preserved.

## User Impact

A disconnected client closes its own upgrade without bringing down unrelated Gateway connections. Worker failures still produce one waiting response when possible, and later requests remain usable.

## Evidence

The two new regressions fail on unchanged source while 42 existing controls pass. The final 44 tests pass, covering portal/Gateway upgrade ownership, late stream cleanup, ordinary forwarding and subsequent healthy requests:

```sh
node scripts/run-vitest.mjs src/gateway/portals/portal-http-proxy.test.ts src/gateway/server-http.rejection-transport.test.ts
```

Real local TCP reset reproductions changed from process exit 1 to exit 0 on Node 24 and Node 26, with browser sockets, late worker streams and servers cleaned up. Root inspection of Node 24.19's built-in HTTP parser confirms listener removal before upgrade dispatch. These are real TCP and Gateway HTTP-server harness tests; no full remote worker deployment is claimed.

All 29 selected changed-check stages passed, including production/test types, lint, exports and architecture guards. A test Promise-executor lint issue was corrected before the final run. Fresh independent P2 review found no actionable issues. Production: +42/−52, net −10; tests: +118.

Final head `f11e1f9909fc73b6663b8c14d86edd02f35aadc5` passed [CI](https://github.com/openclaw/openclaw/actions/runs/33987925425) and [OpenGrep](https://github.com/openclaw/openclaw/actions/runs/33987925364), with no pending checks. The payload-limit fixture correction passed 16 affected tests, scoped lint and fresh independent review. The latest ClawSweeper review covers this exact head and has no before-merge items.
