### PR TITLE
fix(macos): start AI setup for externally managed Gateways

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
@@ -54,9 +54,9 @@ extension OnboardingView {
 
     func maybeStartAISetup(for pageIndex: Int) {
         guard pageIndex == aiPageIndex else { return }
-        // Local mode reaches this page only after the CLI/gateway install page,
-        // so the gateway is up before the first RPC.
-        guard state.connectionMode != .local || cliInstalled else { return }
+        // Only app-managed local installs need CLI activation; external attachments
+        // proceed through the existing route-bound Gateway probe.
+        guard !requiresLocalCLI || cliInstalled else { return }
         self.prepareSystemAgentHandoff()
         // A selected/reconnected Gateway may already have a configured default
         // agent. Check that route before setup tries to author inference.

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -6,6 +6,7 @@ import Foundation
 import ObjectiveC
 import Observation
 import OpenClawChatUI
+import OpenClawDiscovery
 import OpenClawProtocol
 import SwiftUI
 import Testing
@@ -788,6 +789,59 @@ private func setupAdmissionBusyResponse(id: String, confirmed: Bool = true) -> D
           "code":"UNAVAILABLE","message":"OpenClaw setup is already in progress; try again when it finishes.",
           "retryable":true\(details)}}
         """.utf8)
+}
+
+private enum OnboardingEntryError: Error {
+    case timedOut(String)
+}
+
+@MainActor
+private final class OnboardingEntryEvents {
+    var persistenceCalls = 0
+    var missingReplies = 0
+    var sawSnapshot = false
+    var healthFinished = false
+}
+
+@MainActor
+private func waitForOnboardingEntry(
+    _ description: String,
+    until condition: () async throws -> Bool) async throws
+{
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: .seconds(5))
+    while clock.now < deadline {
+        try Task.checkCancellation()
+        if try await condition() { return }
+        // Poll a concrete event/UI predicate; elapsed time is never ordering proof.
+        try await Task.sleep(for: .milliseconds(10))
+    }
+    throw OnboardingEntryError.timedOut(description)
+}
+
+@MainActor
+private func pressOnboardingEntryButton(_ title: String, in root: NSView) async throws {
+    _ = try await inspectAISetupAccessibility(root)
+    var matches: [AnyObject] = []
+    var visited = Set<ObjectIdentifier>()
+    func visit(_ element: AnyObject) {
+        guard visited.insert(ObjectIdentifier(element)).inserted else { return }
+        let text = [element.accessibilityLabel?(), element.accessibilityTitle?()]
+            .compactMap(\.self)
+        if element.accessibilityRole?() == .button,
+           element.isAccessibilityEnabled?() == true,
+           text.contains(where: { $0 == title || (title == "API Keys" && $0.contains(title)) })
+        {
+            matches.append(element)
+        }
+        for child in element.accessibilityChildren?() ?? [] {
+            visit(child as AnyObject)
+        }
+    }
+    visit(root)
+    try #require(matches.count == 1, "Expected one enabled mounted button: \(title)")
+    let button = try #require(matches.first)
+    try #require(button.accessibilityPerformPress?() == true, "AX press failed: \(title)")
 }
 
 private enum AISetupAccessibilityError: Error {
@@ -2844,6 +2898,219 @@ struct OnboardingAISetupTests {
         #expect(!model.pendingActivationVerification)
         #expect(model.selectedKind == "existing-model")
         #expect(OnboardingController.shared.busyReason == nil)
+    }
+
+    @Test(.timeLimit(.minutes(1)), arguments: [
+        "attach-only", "external-service", "unreadable",
+    ])
+    func `first mounted AI entry respects local installation ownership`(_ scenario: String) async throws {
+        try #require(!AppProfile.current.isActive, "Run this fixture in an unprofiled disposable test process")
+        let root = try makeTempDirForTests().resolvingSymlinksInPath()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try await TestIsolation.withIsolatedState(env: [
+            "HOME": root.path,
+            "CFFIXED_USER_HOME": root.path,
+            "OPENCLAW_STATE_DIR": root.appendingPathComponent("state").path,
+            "OPENCLAW_CONFIG_PATH": root.appendingPathComponent("openclaw.json").path,
+        ]) {
+            try #require(FileManager.default.homeDirectoryForCurrentUser.resolvingSymlinksInPath() == root)
+            let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingEntry"))
+            let oldGatewayID = GatewayDiscoveryPreferences.preferredStableID()
+            let oldRouteBinding = GatewayDiscoveryPreferences.preferredRouteBinding()
+            GatewayDiscoveryPreferences.setPreferredStableID(nil)
+            let marker = root.appendingPathComponent("disable-launchagent")
+            GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(marker)
+            GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
+            defer {
+                #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().allSatisfy {
+                    $0.first == "status"
+                })
+                GatewayDiscoveryPreferences.setPreferredStableID(oldGatewayID, routeBinding: oldRouteBinding)
+                GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(nil)
+                GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+                GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+            }
+            if scenario == "attach-only" { try Data().write(to: marker) }
+            let plist = GatewayLaunchAgentManager.plistURL(homeDirectory: root, profile: AppProfile(environment: [:]))
+            if scenario == "external-service" || scenario == "unreadable" {
+                try FileManager.default.createDirectory(
+                    at: plist.deletingLastPathComponent(),
+                    withIntermediateDirectories: true)
+                let data = scenario == "unreadable" ? Data("not a plist".utf8) : try PropertyListSerialization.data(
+                    fromPropertyList: ["ProgramArguments": ["/opt/fixture-openclaw/bin/openclaw", "gateway"]],
+                    format: .xml, options: 0)
+                try data.write(to: plist)
+            }
+            let blocked = scenario == "unreadable"
+            // Explicit artifacts take precedence over remembered ownership; leave the singleton untouched.
+            try #require(GatewayProcessManager.shared.installation == (blocked ? .unreadable : .external))
+            let artifacts = try [marker, plist].map { url in
+                try (url: url, data: FileManager.default.fileExists(atPath: url.path) ? Data(contentsOf: url) : nil)
+            }
+            defer {
+                for artifact in artifacts {
+                    #expect(FileManager.default.fileExists(atPath: artifact.url.path) == (artifact.data != nil))
+                    if let data = artifact.data {
+                        #expect((try? Data(contentsOf: artifact.url)) == data)
+                    }
+                }
+            }
+            let events = OnboardingEntryEvents()
+            let url = try #require(URL(string: "ws://127.0.0.1:49152"))
+            let harness = AISetupHarness(url: url) { task, request, _ in
+                switch request.method {
+                case "agents.list":
+                    task.emitReceiveSuccess(.data(missingConfiguredModelResponse(id: request.id)))
+                    await MainActor.run { events.missingReplies += 1 }
+                    return nil
+                case "openclaw.setup.detect":
+                    // Keep the existing provider fixture; remove automatic and prepare paths.
+                    let data = detectedSetupResponse(id: request.id, kind: "fixture", modelRef: "fixture/model")
+                    var response = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+                    var payload = try #require(response["payload"] as? [String: Any])
+                    payload["candidates"] = [] as [Any]
+                    payload["prepareOptions"] = [] as [Any]
+                    response["payload"] = payload
+                    return try JSONSerialization.data(withJSONObject: response)
+                default:
+                    Issue.record("Unexpected onboarding request: \(request.method)")
+                    return unavailableGatewayResponse(id: request.id)
+                }
+            }
+            // Consume the one physical hello BEFORE mounting. The view subsequently
+            // receives its ordinary replay; no fixture reconnect or retry occurs.
+            let pushes = await harness.gateway.subscribe()
+            let snapshotTask = Task { @MainActor in
+                for await delivery in pushes {
+                    guard !Task.isCancelled else { return }
+                    if delivery.isCurrent, case .snapshot = delivery.push {
+                        events.sawSnapshot = true
+                        return
+                    }
+                }
+            }
+            let warmup = Task { @MainActor in
+                defer { events.healthFinished = true }
+                _ = try await harness.gateway.request(
+                    method: "health", params: nil, timeoutMs: 1000, retryTransportFailures: false)
+            }
+            let state = AppState(preview: true)
+            state.onboardingSeen = false
+            state.connectionMode = .local
+            let view = harness.view(
+                state: state, defaults: defaults, routeIdentityProvider: { "local" },
+                configuredGatewayProbeTimeoutMs: 1000,
+                gatewaySelectionPersister: {
+                    events.persistenceCalls += 1
+                    return true
+                })
+            // These are reference objects, not later reads through an unmounted @State copy.
+            let model = view.aiSetup
+            let finishState = view.finishState
+            let probe = view.configuredGatewayProbe
+            let discovery = view.gatewayDiscovery
+            _ = AppKitTestSupport.application
+            var appeared = false
+            var disappeared = false
+            let hosting = NSHostingView(rootView: AnyView(EmptyView()))
+            hosting.frame = NSRect(x: 0, y: 0, width: 630, height: 900)
+            let window = NSWindow(contentRect: hosting.frame, styleMask: [.titled], backing: .buffered, defer: false)
+            window.isReleasedWhenClosed = false
+            @MainActor
+            func cleanup() async {
+                // Cleanup only: invalidate unstructured owner work before restoring fixtures.
+                probe.invalidate()
+                model.resetForGatewayChange(clearPendingHandoff: false)
+                hosting.rootView = AnyView(EmptyView())
+                hosting.layoutSubtreeIfNeeded()
+                window.orderOut(nil)
+                window.contentView = nil
+                window.close()
+                do {
+                    try await waitForOnboardingEntry("mounted view disappeared") { !appeared || disappeared }
+                } catch {
+                    Issue.record(error)
+                }
+                discovery.stop()
+                warmup.cancel()
+                snapshotTask.cancel()
+                await harness.gateway.shutdown()
+                _ = await warmup.result
+                await snapshotTask.value
+            }
+            do {
+                try await waitForOnboardingEntry("connected physical hello") {
+                    events.healthFinished && events.sawSnapshot
+                }
+                try await warmup.value
+                try #require(harness.session.snapshotMakeCount() == 1)
+                hosting.rootView = AnyView(view
+                    .onAppear { appeared = true }
+                    .onDisappear { disappeared = true })
+                window.contentView = hosting
+                window.orderFront(nil)
+                hosting.layoutSubtreeIfNeeded()
+                window.displayIfNeeded()
+                try await waitForOnboardingEntry("appearance and initial snapshot invoked, missing reply emitted") {
+                    events.persistenceCalls == 2 && events.missingReplies >= 1
+                }
+                try #require(appeared)
+                // Finish a read-only inspection before navigation. Its generation retires
+                // any late startup response that could otherwise mask the page-entry gate.
+                let inspection = try #require(view.probeConfiguredGatewayForDashboard(
+                    intent: .inspectOnly,
+                    knownVisible: true))
+                await inspection.value
+                try #require(events.persistenceCalls == 3)
+                try #require(await harness.recorder.snapshot().methods.allSatisfy { $0 == "agents.list" })
+                try #require(!isPending(defaults))
+                try #require(!model.connected && model.phase == .idle)
+                try await pressOnboardingEntryButton("Next", in: hosting)
+                try await waitForOnboardingEntry("connection page navigation committed") {
+                    let ax = try await inspectAISetupAccessibility(hosting)
+                    return ax.actions["Back"] == true && ax.actions["Next"] == true
+                }
+                try #require(events.persistenceCalls == 3)
+                try #require(await harness.recorder.snapshot().methods.allSatisfy { $0 == "agents.list" })
+                try await pressOnboardingEntryButton("Next", in: hosting)
+                if blocked {
+                    try await waitForOnboardingEntry("unreadable ownership retains CLI gate") {
+                        let ax = try await inspectAISetupAccessibility(hosting)
+                        return ax.actions["Next"] == false && ax.actions["Finish"] == nil &&
+                            ax.labels.contains(GatewayProcessManager.Installation.ownershipFailure)
+                    }
+                    #expect(events.persistenceCalls == 3)
+                } else {
+                    try await waitForOnboardingEntry("first AI entry emits openclaw.setup.detect") {
+                        await harness.recorder.snapshot().methods.contains("openclaw.setup.detect")
+                    }
+                    try await waitForOnboardingEntry("AI entry renders enabled manual setup with Finish gated") {
+                        let ax = try await inspectAISetupAccessibility(hosting)
+                        return ax.actions["Finish"] == false &&
+                            ax.actions.contains { $0.key.contains("API Keys") && $0.value }
+                    }
+                    try await pressOnboardingEntryButton("API Keys", in: hosting)
+                    try await waitForOnboardingEntry("API key provider form is actionable") {
+                        let ax = try await inspectAISetupAccessibility(hosting)
+                        return model.showManualEntry && ax.labels.contains("OpenAI API key") &&
+                            ax.actions["Finish"] == false
+                    }
+                    #expect(events.persistenceCalls == 4)
+                }
+                let methods = await harness.recorder.snapshot().methods
+                #expect(methods.filter { $0 == "openclaw.setup.detect" }.count == (blocked ? 0 : 1))
+                #expect(methods.allSatisfy { $0 == "agents.list" || $0 == "openclaw.setup.detect" })
+                #expect(harness.session.snapshotMakeCount() == 1)
+                #expect(!model.connected)
+                #expect(!finishState.didFinish)
+                #expect(!isPending(defaults))
+            } catch {
+                await cleanup()
+                throw error
+            }
+            await cleanup()
+        }
     }
 
     @Test func `implicit model label falls through verification to automatic setup`() async throws {

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -70,12 +70,16 @@ Where does the **Gateway** run?
   Local setup reuses a compatible CLI installation or uses the bundled installer
   to install `openclaw` and Node in a private managed runtime. It does not require
   a global npm, pnpm, or bun install.
+
+Attaching to an independently managed local Gateway skips CLI installation
+and proceeds to AI checks without taking over its CLI or service installation.
+See [Gateway on macOS](/platforms/mac/bundled-gateway#automatic-setup).
 </Step>
 <Step title="Connect your AI">
-  If the connected Gateway already has a configured agent model, the app
-  verifies it with a real completion before opening the normal dashboard.
-  A configured model name alone does not skip verification. Fresh or incomplete
-  Gateways continue through provider setup.
+If the connected Gateway already has a configured agent model, the app
+verifies it with a real completion before opening the normal dashboard.
+A configured model name alone does not skip verification. Fresh or incomplete
+Gateways continue through provider setup.
 
 Once the Gateway is ready, onboarding looks for AI access you already have:
 a Claude Code or Codex login, `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`, or a


### PR DESCRIPTION
Closes #139038 — native AI-page entry waits for CLI installation that external Gateway ownership deliberately skips.

Related: #138814 — activation-rejection recovery, already landed and preserved unchanged.

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer-editable branch.

</details>

## What Problem This Solves

Fixes an issue where native macOS users attaching to an independently managed local Gateway could reach **Connect your AI** without starting detection when the initial configured-model inspection had completed with no model. Installation is intentionally skipped for external ownership, but this entry path still waited for its CLI-installed flag.

The negative reproduction uses the real mounted native view with a controlled missing-model Gateway response. A fresh real current Gateway normally projects an implicit model and starts verification/detection before Next, masking the stale gate; that ordinary fresh flow was not observed to stall.

## Why This Change Was Made

Reuse the existing installation policy (`requiresLocalCLI`) for AI-page entry instead of a second all-local condition. The app still uses the same route-bound Gateway probe and does not manufacture CLI readiness, introduce a retry path, or take over an external installation.

Managed and unreadable local ownership remain gated. Named-profile listener-PID ownership, endpoint fencing, authentication, inference verification, and the activation-recovery logic from #138814 are unchanged.

## User Impact

External local attachments can enter AI setup after a missing-model preflight without relying on a reconnect or Retry. Install/ownership errors remain visible where the app actually owns local setup, and Finish remains blocked until inference is verified.

The [onboarding documentation](https://docs.openclaw.ai/start/onboarding) now explains the independent-attachment path and links the existing [Gateway ownership contract](https://docs.openclaw.ai/platforms/mac/bundled-gateway#automatic-setup).

## Evidence

- Production LOC: **+3/-3 (net 0)**. Tests: **+267/-0**. Docs: **+8/-4 (net +4)**. One existing setup gate changes; no new config/env option, protocol change, schema change, or migration.
- The mounted regression establishes one physical connection, completes read-only inspection before actual AX Next navigation, and checks one detection, actionable provider UI, Finish gating, unchanged service artifacts, and no daemon mutations. No production test seam was added.
- **Refreshed native red/green:** on current base `ea48ec72824dbe34b62837eea19658edb22694d0`, the final regression fails only the attach-only and external-service cases at missing first-entry `openclaw.setup.detect`; unreadable ownership remains gated. With the PR's production file, all three cases pass in 1.723 seconds. Production/test hashes match PR head `25a0a6b570bcf3aec05ee4245d209eb9cc3485d6`.
- **301 refreshed native tests passed:** 299 tests across the six onboarding/Gateway/endpoint suites in 51.932 seconds, plus two AppState isolation tests in a separate named-profile process. These ran on disposable macOS 26.5 with Xcode 26.5 / Swift 6.3.2 using fresh guest compilation and the repository's native test launcher.
- Recovery PR #138814's new probe-intent API is preserved. The regression awaits an explicit existing `inspectOnly` preflight so late startup results cannot hide the entry failure; it does not sleep to establish quiescence.
- Fresh independent pre-land Codex review through P2, including complete owner/sibling context and the capture-only failure described below: scoped-clean in both evidence partitions, with no actionable findings. The signed source-equivalent candidate build and strict signature verification passed; it retains base Git metadata because it was built before the commit and is not a release artifact.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33964807195) completed successfully, including both macOS Swift jobs and `openclaw/ci-gate`.

### Visual evidence and its limits

The controlled baseline image below shows the real mounted native view during a separate guest-only post-verdict observation hold. The baseline regression proves that the missing-model preflight was followed by no detection request; the still frame alone does not prove the missing request.

![Controlled native baseline: AI entry stays on the looking-for-AI presentation](https://github.com/user-attachments/assets/b361c018-1591-4fae-85b9-1efa820afe1a)

**Matched after-image limitation:** the candidate's observation-only replay exceeded the existing 60-second test limit and recorded a cleanup cancellation before a usable capture was obtained. The cause is not established, and this replay is not claimed as passing correctness proof. The temporary capture code was removed, the committed test hash restored, and the source explicitly recompiled/relinked; the unchanged three-case regression passed again. No assertion, timeout, or production behavior was relaxed. This documents the concrete visual-proof limitation requested by ClawSweeper; no real-Gateway control image is substituted as a matched after-image.

**Separate signed-app / real-Gateway control:** the candidate attached to its manually started loopback Gateway and ran `agents.list → openclaw.setup.verify → openclaw.setup.detect` before navigation. With no AI credentials, it showed an explicit verification error, local-model connection choices, a provider-sign-in section, and disabled Finish. This is a control, not the missing-model reproduction or a matched after-image. Repeated inspection requests during automated key/modal interaction stopped after explicit key release; the cause of that transient is not diagnosed.

![Signed candidate real-Gateway control: visible error and setup choices, Finish disabled](https://github.com/user-attachments/assets/ee95dfbf-a36e-4ae9-9703-69886680b7d9)

Native tests and OpenClaw UI run only in a separate disposable Mac. No operator Gateway, desktop state, or the activation-recovery task's VM is used. No real AI credential is required for this gate proof. No inference activation success is claimed.
