### PR TITLE
fix(browser): historical previews launch unwanted browsers

### DIFF
--- a/extensions/browser/src/browser/server-context.remote-tab-ops.harness.ts
+++ b/extensions/browser/src/browser/server-context.remote-tab-ops.harness.ts
@@ -123,7 +123,6 @@ export function createTestBrowserRouteContext(opts: { getState: () => BrowserSer
       profile,
       runtime,
       getCdpControlPolicy: () => resolveCdpControlPolicy(profile, state.resolved.ssrfPolicy),
-      ensureBrowserAvailable: async () => {},
       listTabs: tabOps.listTabs,
       openTab: tabOps.openTab,
     });

--- a/extensions/browser/src/browser/server-context.selection.ts
+++ b/extensions/browser/src/browser/server-context.selection.ts
@@ -31,7 +31,6 @@ type SelectionDeps = {
   profile: ResolvedBrowserProfile;
   runtime: ProfileRuntimeState;
   getCdpControlPolicy: () => SsrFPolicy | undefined;
-  ensureBrowserAvailable: (opts?: { headless?: boolean; signal?: AbortSignal }) => Promise<void>;
   listTabs: (options?: BrowserOperationOptions) => Promise<BrowserTab[]>;
   openTab: (url: string, options?: BrowserOperationOptions) => Promise<BrowserTab>;
 };
@@ -40,7 +39,6 @@ type SelectionOps = {
   ensureTabAvailable: (
     targetId?: string,
     options?: EnsureTabAvailableOptions,
-    browserAlreadyEnsured?: boolean,
   ) => Promise<BrowserTab>;
   focusTab: (targetId: string, options?: BrowserTabTargetOptions) => Promise<void>;
   closeTab: (targetId: string, options?: BrowserTabTargetOptions) => Promise<string>;
@@ -75,7 +73,6 @@ export function createProfileSelectionOps({
   profile,
   runtime,
   getCdpControlPolicy,
-  ensureBrowserAvailable,
   listTabs,
   openTab,
 }: SelectionDeps): SelectionOps {
@@ -85,12 +82,7 @@ export function createProfileSelectionOps({
   const ensureTabAvailable = async (
     targetId?: string,
     options?: EnsureTabAvailableOptions,
-    browserAlreadyEnsured = false,
   ): Promise<BrowserTab> => {
-    options?.signal?.throwIfAborted();
-    if (!browserAlreadyEnsured) {
-      await ensureBrowserAvailable({ signal: options?.signal });
-    }
     options?.signal?.throwIfAborted();
     let lastNonEmptyTabs: BrowserTab[] = [];
     let lastListError: unknown;
@@ -114,6 +106,9 @@ export function createProfileSelectionOps({
     };
 
     const openWhenConfirmedEmpty = async (tabs: BrowserTab[]): Promise<void> => {
+      if (targetId !== undefined) {
+        return;
+      }
       if (!openedTab && sawSuccessfulList && lastNonEmptyTabs.length === 0 && tabs.length === 0) {
         openedTab = await openTab("about:blank", options);
       }

--- a/extensions/browser/src/browser/server-context.tab-discovery-poll-abort.test.ts
+++ b/extensions/browser/src/browser/server-context.tab-discovery-poll-abort.test.ts
@@ -61,7 +61,6 @@ describe("browser tab discovery poll abort", () => {
       profile: runtime.profile,
       runtime,
       getCdpControlPolicy: () => undefined,
-      ensureBrowserAvailable: async () => {},
       listTabs,
       openTab: async () => tabWithoutWsUrl,
     });
@@ -98,7 +97,6 @@ describe("browser tab discovery poll abort", () => {
       profile: runtime.profile,
       runtime,
       getCdpControlPolicy: () => undefined,
-      ensureBrowserAvailable: async () => {},
       listTabs,
       openTab: async () => tab,
     });

--- a/extensions/browser/src/browser/server-context.ts
+++ b/extensions/browser/src/browser/server-context.ts
@@ -125,7 +125,6 @@ function createProfileContext(
     profile,
     runtime: profileState,
     getCdpControlPolicy: () => resolveCdpControlPolicy(profile, state().resolved.ssrfPolicy),
-    ensureBrowserAvailable: rawAvailability.ensureBrowserAvailable,
     listTabs: rawTabOps.listTabs,
     openTab: rawTabOps.openTab,
   });
@@ -158,12 +157,18 @@ function createProfileContext(
     profile,
     ensureBrowserAvailable,
     ensureTabAvailable: async (targetId, options) => {
-      await ensureBrowserAvailable({ signal: options?.signal });
-      return await withLease(
-        options?.signal,
-        async (signal) =>
-          await rawSelection.ensureTabAvailable(targetId, { ...options, signal }, true),
-      );
+      if (targetId === undefined) {
+        await ensureBrowserAvailable({ signal: options?.signal });
+      }
+      return await withLease(options?.signal, async (signal) => {
+        // Explicit targets can come from history; lookup must not launch or restart a browser.
+        if (targetId !== undefined && !(await rawAvailability.isReachable(undefined, { signal }))) {
+          throw new BrowserProfileUnavailableError(
+            `Browser profile "${profile.name}" is not running. Start the browser or open a new tab, then select a current target.`,
+          );
+        }
+        return await rawSelection.ensureTabAvailable(targetId, { ...options, signal });
+      });
     },
     isHttpReachable: async (timeoutMs, callerSignal) =>
       await withLease(

--- a/extensions/browser/src/browser/server.control-server.test-harness.ts
+++ b/extensions/browser/src/browser/server.control-server.test-harness.ts
@@ -392,6 +392,7 @@ const chromeMcpMocks = vi.hoisted(() => ({
   clickChromeMcpElement: vi.fn(async () => {}),
   closeChromeMcpSession: vi.fn(async () => true),
   closeChromeMcpTab: vi.fn(async () => {}),
+  countChromeMcpTabs: vi.fn(async () => 1),
   dragChromeMcpElement: vi.fn(async () => {}),
   ensureChromeMcpAvailable: vi.fn(async () => {}),
   evaluateChromeMcpScript: vi.fn(async () => true),

--- a/extensions/browser/src/browser/server.historical-target.test.ts
+++ b/extensions/browser/src/browser/server.historical-target.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getBrowserControlServerBaseUrl,
+  getCdpMocks,
+  installBrowserControlServerHooks,
+  makeResponse,
+  setBrowserControlServerReachable,
+  startBrowserControlServerFromConfig,
+} from "./server.control-server.test-harness.js";
+import { getBrowserTestFetch } from "./test-support/fetch.js";
+
+const { launchOpenClawChrome, stopOpenClawChrome } = await import("./chrome.js");
+
+describe("browser control server historical targets", () => {
+  installBrowserControlServerHooks();
+
+  async function request(path: string, body?: unknown) {
+    return await getBrowserTestFetch()(
+      `${getBrowserControlServerBaseUrl()}${path}`,
+      body === undefined
+        ? undefined
+        : {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          },
+    );
+  }
+
+  it("does not start a stopped browser for a historical screenshot", async () => {
+    await startBrowserControlServerFromConfig();
+    vi.mocked(launchOpenClawChrome).mockClear();
+
+    const response = await request("/screenshot", { targetId: "closed-historical-tab" });
+
+    expect(launchOpenClawChrome).not.toHaveBeenCalled();
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: expect.stringContaining("not running") });
+    expect(await (await request("/tabs")).json()).toMatchObject({ running: false, tabs: [] });
+  });
+
+  it.each([false, true])(
+    "does not create a tab or stop a running browser for a missing target (empty: %s)",
+    async (empty) => {
+      await startBrowserControlServerFromConfig();
+      setBrowserControlServerReachable(true);
+      vi.mocked(launchOpenClawChrome).mockClear();
+      vi.mocked(stopOpenClawChrome).mockClear();
+      const fetchCdp = globalThis.fetch;
+      const tabRequests: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+          const url = input instanceof Request ? input.url : input.toString();
+          tabRequests.push(url);
+          return empty && url.includes("/json/list")
+            ? makeResponse([])
+            : await fetchCdp(input, init);
+        }),
+      );
+
+      const response = await request("/screenshot", { targetId: "closed-historical-tab" });
+
+      expect(getCdpMocks().createTargetViaCdp).not.toHaveBeenCalled();
+      expect(response.status).toBe(404);
+      expect(await response.json()).toMatchObject({ error: expect.stringContaining("not found") });
+      expect(launchOpenClawChrome).not.toHaveBeenCalled();
+      expect(stopOpenClawChrome).not.toHaveBeenCalled();
+      expect(tabRequests.some((url) => url.includes("/json/new"))).toBe(false);
+      expect(await (await request("/tabs")).json()).toMatchObject({
+        running: true,
+        tabs: empty
+          ? []
+          : expect.arrayContaining([expect.objectContaining({ targetId: "abcd1234" })]),
+      });
+    },
+  );
+
+  it.each(["abcd1234", "t1", "abcd"])("still resolves a live target %s", async (targetId) => {
+    await startBrowserControlServerFromConfig();
+    setBrowserControlServerReachable(true);
+
+    const response = await request(`/snapshot?targetId=${targetId}&format=ai`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ targetId: "abcd1234" });
+  });
+
+  it.each([
+    { path: "/start", body: {} },
+    { path: "/tabs/open", body: { url: "about:blank" } },
+    { path: "/snapshot?format=ai", body: undefined },
+  ])("preserves intentional startup through $path", async ({ path, body }) => {
+    await startBrowserControlServerFromConfig();
+    vi.mocked(launchOpenClawChrome).mockClear();
+    getCdpMocks().createTargetViaCdp.mockResolvedValue({
+      targetId: "abcd1234",
+      finalUrl: "https://example.com",
+    });
+
+    const response = await request(path, body);
+
+    expect(response.status).toBe(200);
+    expect(launchOpenClawChrome).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Opening a chat with an old browser result could start a stopped managed browser, fail to find its tab, and leave the new browser running. Reconnecting could repeat it.

## Why This Change Was Made

Explicit tab references now use the browser owner’s non-starting reachability check. A missing explicit target cannot create a blank tab. Targetless operations and explicit Start/Open retain startup behavior.

## User Impact

Historical cards stay static while the browser is stopped. Live previews still work, stale targets do not stop running browsers, and users can start or open tabs explicitly.

## Evidence

Real built Control UI, Gateway, and headed-browser checks reproduced unwanted launches before repair. Afterward, history and reconnect kept the browser stopped; live thumbnails and explicit Start/Open worked, and stale targets preserved running tabs. Both regressions failed before the fix; 149 focused browser tests passed. Platform-specific alternate-browser behavior was not independently tested.

Closes #138999. Thanks @Pondsi for the report and repeated-failure evidence.
