### PR TITLE
fix(cli): preserve command dispatch and structured errors

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -52,6 +52,10 @@ A named `--profile` replaces canonical state and config paths inherited from
 another profile, including a running Gateway service. Explicitly customized
 state directories and config paths remain unchanged.
 
+Use `--` to stop option parsing. Command words still dispatch after it: for example,
+`openclaw -- config get gateway.port` reads the configured port. A token such as
+`--help` after `--` is a positional argument.
+
 ## Output modes
 
 - ANSI colors and progress indicators render only in TTY sessions.

--- a/src/cli/argv-invocation.test.ts
+++ b/src/cli/argv-invocation.test.ts
@@ -1,6 +1,8 @@
 // Argv invocation tests cover CLI argv normalization before command dispatch.
+import { Command } from "commander";
 import { describe, expect, it } from "vitest";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
+import { getCommanderCommandPath } from "./program/commander-parse-facts.js";
 
 describe("argv-invocation", () => {
   it("resolves root help and empty command path", () => {
@@ -114,6 +116,39 @@ describe("argv-invocation", () => {
       resolveCliArgvInvocation(["node", "openclaw", "models", "--agent", "main", "status"])
         .commandPath,
     ).toEqual(["models", "status"]);
+  });
+
+  it.each([
+    ["config", ["--section", "model"], ["config"]],
+    ["config", ["--section", "get"], ["config"]],
+    ["config", ["--section=model", "get"], ["config", "get"]],
+    ["config", ["--", "get"], ["config", "get"]],
+    ["skills", ["--agent", "main", "verify"], ["skills", "verify"]],
+    ["skills", ["--agent=main", "verify"], ["skills", "verify"]],
+    ["skills", ["--agent", "verify"], ["skills"]],
+    ["skills", ["--json", "--agent", "main", "verify"], ["skills", "verify"]],
+    ["skills", ["--", "verify"], ["skills", "verify"]],
+  ])("matches Commander for %s %j", async (rootName, args, expectedPath) => {
+    const program = new Command().name("openclaw").enablePositionalOptions();
+    const root = program.command(rootName);
+    if (rootName === "config") {
+      root.option("--section <section>");
+    } else {
+      root.option("--agent <id>").option("--json");
+    }
+    const child = root.command(rootName === "config" ? "get" : "verify");
+    let parsedPath: string[] = [];
+    for (const command of [root, child]) {
+      command.action(() => {
+        parsedPath = getCommanderCommandPath(command);
+      });
+    }
+    const argv = ["node", "openclaw", rootName, ...args];
+
+    await program.parseAsync(argv);
+
+    expect(parsedPath).toEqual(expectedPath);
+    expect(resolveCliArgvInvocation(argv).commandPath).toEqual(parsedPath);
   });
 
   it.each(["cleanup", "status", "repair", "finalize", "wizard"])(

--- a/src/cli/argv-invocation.ts
+++ b/src/cli/argv-invocation.ts
@@ -5,6 +5,7 @@ import {
   isHelpOrVersionInvocation,
   isRootHelpInvocation,
 } from "./argv.js";
+import { resolveGatewayCatalogCommandPath } from "./gateway-run-argv.js";
 import { resolveParentAwareCommandPath } from "./parent-command-path.js";
 
 type CliArgvInvocation = {
@@ -19,7 +20,10 @@ type CliArgvInvocation = {
 export function resolveCliArgvInvocation(argv: string[]): CliArgvInvocation {
   return {
     argv,
-    commandPath: resolveParentAwareCommandPath(argv) ?? getCommandPathWithRootOptions(argv, 2),
+    commandPath:
+      resolveGatewayCatalogCommandPath(argv) ??
+      resolveParentAwareCommandPath(argv) ??
+      getCommandPathWithRootOptions(argv, 2),
     primary: getPrimaryCommand(argv),
     hasHelpOrVersion: isHelpOrVersionInvocation(argv),
     isRootHelpInvocation: isRootHelpInvocation(argv),

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -1,4 +1,5 @@
 // Argv tests cover CLI argument parsing helpers and platform-specific normalization.
+import { Command } from "commander";
 import { describe, expect, it } from "vitest";
 import {
   buildParseArgv,
@@ -284,6 +285,26 @@ describe("argv helpers", () => {
       expected: false,
     },
     {
+      name: "implicit root help command after terminator",
+      argv: ["node", "openclaw", "--", "help", "config"],
+      expected: true,
+    },
+    {
+      name: "implicit parent help command after terminator",
+      argv: ["node", "openclaw", "config", "--", "help"],
+      expected: true,
+    },
+    {
+      name: "literal root help-looking command",
+      argv: ["node", "openclaw", "--", "--help"],
+      expected: false,
+    },
+    {
+      name: "literal parent help-looking command",
+      argv: ["node", "openclaw", "--", "config", "--help"],
+      expected: false,
+    },
+    {
       name: "help flag after terminator",
       argv: ["node", "openclaw", "nodes", "invoke", "--", "--help"],
       expected: false,
@@ -364,6 +385,30 @@ describe("argv helpers", () => {
     },
   ])("detects help/version invocations: $name", ({ argv, expected }) => {
     expect(isHelpOrVersionInvocation(argv)).toBe(expected);
+  });
+
+  it.each([
+    { path: ["skills", "verify"], option: "tag" },
+    { path: ["skills", "verify"], option: "version" },
+    { path: ["models", "list"], option: "provider" },
+    { path: ["agent"], option: "message" },
+  ])("keeps actual help after a root-looking $option value on $path", async ({ path, option }) => {
+    const program = new Command()
+      .name("openclaw")
+      .enablePositionalOptions()
+      .option("--log-level <level>")
+      .exitOverride();
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} });
+    const leaf = path.reduce((parent, name) => parent.command(name), program);
+    leaf.option(`--${option} <value>`);
+    const argv = ["node", "openclaw", ...path, `--${option}`, "--log-level", "--help"];
+
+    await expect(program.parseAsync(argv)).rejects.toMatchObject({
+      code: "commander.helpDisplayed",
+      exitCode: 0,
+    });
+    expect(leaf.opts()[option]).toBe("--log-level");
+    expect(isHelpOrVersionInvocation(argv)).toBe(true);
   });
 
   it.each([

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -36,21 +36,27 @@ export function isHelpOrVersionInvocation(argv: string[]): boolean {
 
   const args = argv.slice(2);
   let sawCommandOption = false;
+  let literal = false;
   const positionals: string[] = [];
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
-    if (!arg || arg === FLAG_TERMINATOR) {
+    if (!arg) {
       break;
     }
-    const rootConsumed = consumeRootOptionToken(args, i);
+    if (!literal && arg === FLAG_TERMINATOR) {
+      literal = true;
+      continue;
+    }
+    // Command option roles are not registered yet; keep possible help flags visible.
+    const rootConsumed = literal ? 0 : consumeRootOptionToken(args, i);
     if (rootConsumed > 0) {
       i += rootConsumed - 1;
       continue;
     }
-    if (HELP_FLAGS.has(arg)) {
+    if (!literal && HELP_FLAGS.has(arg)) {
       return true;
     }
-    if (arg.startsWith("-")) {
+    if (!literal && arg.startsWith("-")) {
       sawCommandOption = true;
       continue;
     }

--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -141,6 +141,9 @@ describe("shouldSkipRespawnForArgv", () => {
     { argv: ["node", "openclaw", "gateway", "--port", "14720", "--bind", "loopback"] },
     { argv: ["node", "openclaw", "gateway", "run", "--port=14720", "--bind", "loopback"] },
     { argv: ["node", "openclaw", "gateway", "status"] },
+    { argv: ["node", "openclaw", "--", "gateway", "run"] },
+    { argv: ["node", "openclaw", "gateway", "--", "status"] },
+    { argv: ["node", "openclaw", "gateway", "--token", "test-token", "status"] },
     {
       argv: ["node", "openclaw", "--profile", "server", "gateway", "run", "--allow-unconfigured"],
     },
@@ -174,6 +177,7 @@ describe("shouldSkipStartupEnvironmentRespawnForArgv", () => {
     { argv: ["node", "openclaw", "hooks", "relay", "--relay-id", "relay-1"] },
     { argv: ["node", "openclaw", "gateway"] },
     { argv: ["node", "openclaw", "gateway", "run", "--port=14720"] },
+    { argv: ["node", "openclaw", "--", "gateway", "run"] },
   ] as const)("skips startup env respawn for argv %j", ({ argv }) => {
     expect(shouldSkipStartupEnvironmentRespawnForArgv([...argv]), argv.join(" ")).toBe(true);
   });
@@ -183,6 +187,8 @@ describe("shouldSkipStartupEnvironmentRespawnForArgv", () => {
     { argv: ["node", "openclaw", "terminal"] },
     { argv: ["node", "openclaw", "chat"] },
     { argv: ["node", "openclaw", "status"] },
+    { argv: ["node", "openclaw", "gateway", "--", "status"] },
+    { argv: ["node", "openclaw", "--", "gateway", "run", "--force"] },
   ] as const)("allows startup env respawn for argv %j", ({ argv }) => {
     expect(shouldSkipStartupEnvironmentRespawnForArgv([...argv]), argv.join(" ")).toBe(false);
   });

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -341,6 +341,10 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { ...PASSIVE_STARTUP_POLICY },
     route: { id: "models-status" },
   },
+  // Default-policy children must remain distinct from the passive parent action.
+  ...["refresh", "set", "set-image", "aliases", "fallbacks", "image-fallbacks", "scan"].map(
+    (subcommand): CliCommandCatalogEntry => ({ commandPath: ["models", subcommand] }),
+  ),
   { commandPath: ["models", "auth"], policy: { stateStoreGuard: "run" } },
   {
     commandPath: ["models", "accounts"],

--- a/src/cli/command-execution-startup.test.ts
+++ b/src/cli/command-execution-startup.test.ts
@@ -139,14 +139,14 @@ describe("command-execution-startup", () => {
 
   it("uses the resolved action command path for every execution startup decision", () => {
     const context = mod.resolveCliExecutionStartupContext({
-      argv: ["node", "openclaw", "gateway", "--token", "secret", "call", "health"],
-      commandPath: ["gateway", "call"],
+      argv: ["node", "openclaw", "acp", "--token", "client"],
+      commandPath: ["acp"],
       jsonOutputMode: false,
       env: {},
     });
 
-    expect(context.invocation.commandPath).toEqual(["gateway", "secret"]);
-    expect(context.commandPath).toEqual(["gateway", "call"]);
+    expect(context.commandPath).toEqual(["acp"]);
+    expect(context.startupPolicy.suppressDoctorStdout).toBe(true);
 
     expect(
       mod.resolveCliExecutionStartupContext({

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -637,6 +637,44 @@ describe("command-path-policy", () => {
     ).toBe("default");
   });
 
+  it.each(["refresh", "set", "set-image", "aliases", "fallbacks", "image-fallbacks", "scan"])(
+    "preserves default startup and proxy policy for models %s",
+    (subcommand) => {
+      expectResolvedPolicy(["models", subcommand], {});
+      for (const parentOptions of [[], ["--agent", "main"]]) {
+        expect(
+          resolveCliNetworkProxyPolicy([
+            "node",
+            "openclaw",
+            "models",
+            ...parentOptions,
+            subcommand,
+          ]),
+        ).toBe("default");
+      }
+    },
+  );
+
+  it.each([
+    { childPath: ["workshop", "list"] },
+    { childPath: ["library", "list"] },
+    { childPath: ["curator", "status"] },
+    { childPath: ["workshop"] },
+    { childPath: ["unknown"] },
+  ])("preserves the skills catalog proxy policy for $childPath", ({ childPath }) => {
+    for (const parentOptions of [[], ["--agent", "main"], ["--agent=main"]]) {
+      expect(
+        resolveCliNetworkProxyPolicy([
+          "node",
+          "openclaw",
+          "skills",
+          ...parentOptions,
+          ...childPath,
+        ]),
+      ).toBe("bypass");
+    }
+  });
+
   it("uses the longest catalog command path for deep network proxy overrides", async () => {
     const catalog: readonly CliCommandCatalogEntry[] = [
       { commandPath: ["nodes"], policy: { networkProxy: "bypass" } },

--- a/src/cli/command-path-policy.ts
+++ b/src/cli/command-path-policy.ts
@@ -42,12 +42,10 @@ function isCommandPathPrefix(commandPath: string[], pattern: readonly string[]):
 
 function resolveCliCatalogCommandPath(argv: string[]): string[] {
   // Gateway `run openclaw ...` argv needs catalog routing against the embedded command path.
-  const gatewayPath = resolveGatewayCatalogCommandPath(argv);
-  const parentPath = resolveParentAwareCommandPath(argv);
-  if (!gatewayPath && parentPath) {
-    return parentPath;
-  }
-  const tokens = gatewayPath ?? getCommandPathWithRootOptions(argv, argv.length);
+  const tokens =
+    resolveGatewayCatalogCommandPath(argv) ??
+    resolveParentAwareCommandPath(argv) ??
+    getCommandPathWithRootOptions(argv, argv.length);
   if (tokens.length === 0) {
     return [];
   }

--- a/src/cli/config-output-mode.ts
+++ b/src/cli/config-output-mode.ts
@@ -1,4 +1,4 @@
-import { consumeRootOptionToken, findRootCommandIndex } from "../infra/cli-root-options.js";
+import { resolveConfigParentCommandPath } from "./parent-command-path.js";
 
 function hasFlag(argv: readonly string[], flag: string): boolean {
   for (const arg of argv.slice(2)) {
@@ -12,38 +12,9 @@ function hasFlag(argv: readonly string[], flag: string): boolean {
   return false;
 }
 
-function resolveConfigSubcommand(argv: readonly string[]): string | null {
-  const rootIndex = findRootCommandIndex(argv);
-  if (rootIndex === null) {
-    return null;
-  }
-  for (let index = rootIndex + 1; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (!arg || arg === "--") {
-      return null;
-    }
-    const rootConsumed = consumeRootOptionToken(argv, index);
-    if (rootConsumed > 0) {
-      index += rootConsumed - 1;
-      continue;
-    }
-    if (arg === "--section") {
-      index += 1;
-      continue;
-    }
-    if (arg.startsWith("--section=")) {
-      continue;
-    }
-    if (!arg.startsWith("-")) {
-      return arg;
-    }
-  }
-  return null;
-}
-
 /** Config values, paths, and schemas reserve stdout for machine-consumed output. */
 export function isConfigMachineOutput(argv: readonly string[]): boolean {
-  const subcommand = resolveConfigSubcommand(argv);
+  const subcommand = resolveConfigParentCommandPath(argv)?.[1];
   return subcommand === "get" || subcommand === "file" || subcommand === "schema";
 }
 

--- a/src/cli/gateway-run-argv.ts
+++ b/src/cli/gateway-run-argv.ts
@@ -1,7 +1,8 @@
 // Fast-path argv parser for `openclaw gateway ...` without full Commander registration.
+import { WINDOWS_TASK_SUPERVISOR_FLAG } from "../daemon/windows-task-supervisor-contract.js";
 import {
-  consumeRootOptionToken,
-  findRootCommandIndex,
+  consumeRootCommandOptionToken,
+  getCommandArgsWithRootOptions,
   getCommandPositionalsWithRootOptions,
   isValueToken,
 } from "../infra/cli-root-options.js";
@@ -39,6 +40,7 @@ export function isForegroundGatewayRunArgv(argv: string[]): boolean {
     commandPath: ["gateway"],
     booleanFlags: [...GATEWAY_RUN_BOOLEAN_FLAGS],
     valueFlags: [...GATEWAY_RUN_VALUE_FLAGS],
+    mode: "command-path",
   });
   if (!positionals) {
     return false;
@@ -72,7 +74,7 @@ function consumeGatewayRunPreBootstrapOptionToken(
   args: ReadonlyArray<string>,
   index: number,
 ): number {
-  const rootConsumed = consumeRootOptionToken(args, index);
+  const rootConsumed = consumeRootCommandOptionToken(args, index);
   if (rootConsumed > 0) {
     return rootConsumed;
   }
@@ -82,8 +84,7 @@ function consumeGatewayRunPreBootstrapOptionToken(
   }
   const arg = args[index];
   if (arg && GATEWAY_RUN_VALUE_FLAGS.has(arg) && args[index + 1] !== undefined) {
-    // Commander will reject option-looking required values later. Consume them here so malformed
-    // input cannot accidentally enable a destructive flag before parsing reaches that error.
+    // Required values can look like flags; consume them before considering destructive options.
     return 2;
   }
   return 0;
@@ -110,43 +111,17 @@ export function consumeGatewayFastPathRootOptionToken(
   return 0;
 }
 
-function resolveGatewayCommandStart(argv: string[]): number | null {
-  const index = findRootCommandIndex(argv);
-  return index !== null && argv[index] === "gateway" ? index + 1 : null;
-}
-
 /** Resolve the gateway command path from raw argv without full Commander registration. */
 export function resolveGatewayCommandPath(argv: string[], depth = 2): string[] | null {
-  const startIndex = resolveGatewayCommandStart(argv);
-  if (startIndex === null) {
-    return null;
-  }
-  const commandPath = ["gateway"];
-  for (let index = startIndex; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (!arg || arg === "--") {
-      break;
-    }
-    const rootConsumed = consumeRootOptionToken(argv, index);
-    if (rootConsumed > 0) {
-      index += rootConsumed - 1;
-      continue;
-    }
-    const consumed = consumeGatewayRunOptionToken(argv, index);
-    if (consumed > 0) {
-      index += consumed - 1;
-      continue;
-    }
-    if (arg.startsWith("-")) {
-      continue;
-    }
-    commandPath.push(arg);
-    if (commandPath.length >= depth) {
-      return commandPath;
-    }
-  }
-
-  return commandPath;
+  const positionals = getCommandPositionalsWithRootOptions(argv, {
+    commandPath: ["gateway"],
+    // Supervisor commands use full parsing but still need Gateway startup selection.
+    booleanFlags: [...GATEWAY_RUN_BOOLEAN_FLAGS, WINDOWS_TASK_SUPERVISOR_FLAG],
+    valueFlags: [...GATEWAY_RUN_VALUE_FLAGS],
+    maxPositionals: depth - 1,
+    mode: "command-path",
+  });
+  return positionals ? ["gateway", ...positionals] : null;
 }
 
 /** Resolve the gateway command path used by catalog and startup-policy lookups. */
@@ -158,16 +133,19 @@ export function resolveGatewayCatalogCommandPath(argv: string[]): string[] | nul
 export function resolveGatewayRunPreBootstrapOptions(
   argv: string[],
 ): { force: boolean; reset: boolean } | null {
-  const startIndex = resolveGatewayCommandStart(argv);
-  if (startIndex === null) {
+  const args = getCommandArgsWithRootOptions(argv, {
+    commandPath: ["gateway"],
+    mode: "command-path",
+  });
+  if (!args) {
     return null;
   }
   let force = false;
   let reset = false;
   let sawRun = false;
 
-  for (let index = startIndex; index < argv.length; index += 1) {
-    const arg = argv[index];
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
     if (!arg || arg === "--") {
       break;
     }
@@ -175,7 +153,7 @@ export function resolveGatewayRunPreBootstrapOptions(
       sawRun = true;
       continue;
     }
-    const consumed = consumeGatewayRunPreBootstrapOptionToken(argv, index);
+    const consumed = consumeGatewayRunPreBootstrapOptionToken(args, index);
     if (consumed > 0) {
       if (arg === "--force") {
         force = true;
@@ -184,11 +162,6 @@ export function resolveGatewayRunPreBootstrapOptions(
       }
       index += consumed - 1;
       continue;
-    }
-    if (arg === "--force") {
-      force = true;
-    } else if (arg === "--reset") {
-      reset = true;
     }
     if (!arg.startsWith("-")) {
       return null;

--- a/src/cli/machine-output-argv.ts
+++ b/src/cli/machine-output-argv.ts
@@ -1,4 +1,6 @@
+import type { Command } from "commander";
 import { getRootOptionAwareCommandPath } from "../infra/cli-root-options.js";
+import { hasCommanderOptionToken } from "./program/commander-parse-facts.js";
 
 export type MachineOutputResolverParams = {
   argv: readonly string[];
@@ -22,8 +24,15 @@ export function getMachineOutputCommandPath(argv: readonly string[], depth: numb
   return getRootOptionAwareCommandPath(argv, depth);
 }
 
-/** Match a boolean or value option before the argv terminator, including `--flag=value`. */
-export function hasMachineOutputOption(argv: readonly string[], flag: string): boolean {
+/** Prefer registered option roles; early discovery falls back to literal option spellings. */
+export function hasMachineOutputOption(
+  argv: readonly string[],
+  flag: string,
+  command?: Command,
+): boolean {
+  if (command) {
+    return hasCommanderOptionToken(command, argv, new Set([flag]), "flag");
+  }
   for (const arg of argv.slice(2)) {
     if (arg === "--") {
       return false;

--- a/src/cli/models-output-mode.ts
+++ b/src/cli/models-output-mode.ts
@@ -1,20 +1,13 @@
 import type { Command } from "commander";
 import { hasMachineOutputOption } from "./machine-output-argv.js";
 import { resolveModelsParentCommandPath } from "./parent-command-path.js";
-import { hasCommanderOptionToken } from "./program/commander-parse-facts.js";
-
-function hasModelsOutputOption(argv: readonly string[], token: string, command?: Command): boolean {
-  return command
-    ? hasCommanderOptionToken(command, argv, new Set([token]), "flag")
-    : hasMachineOutputOption(argv, token);
-}
 
 /** Resolve the parent-command alias for `models status --json`. */
 export function isModelsStatusJsonOutput(argv: readonly string[], command?: Command): boolean {
   return (
-    hasModelsOutputOption(argv, "--json", command) ||
+    hasMachineOutputOption(argv, "--json", command) ||
     (resolveModelsParentCommandPath(argv)?.length === 1 &&
-      hasModelsOutputOption(argv, "--status-json", command))
+      hasMachineOutputOption(argv, "--status-json", command))
   );
 }
 
@@ -22,7 +15,7 @@ export function isModelsPlainMachineOutput(argv: readonly string[], command?: Co
   const commandPath = resolveModelsParentCommandPath(argv);
   return (
     commandPath !== null &&
-    (hasModelsOutputOption(argv, "--plain", command) ||
-      (commandPath.length === 1 && hasModelsOutputOption(argv, "--status-plain", command)))
+    (hasMachineOutputOption(argv, "--plain", command) ||
+      (commandPath.length === 1 && hasMachineOutputOption(argv, "--status-plain", command)))
   );
 }

--- a/src/cli/parent-command-path.ts
+++ b/src/cli/parent-command-path.ts
@@ -60,11 +60,21 @@ export function resolveModelsParentCommandPath(argv: readonly string[]): string[
   );
 }
 
+export function resolveConfigParentCommandPath(argv: readonly string[]): string[] | null {
+  return resolveParentCommandPath(argv, "config", [], ["--section"]);
+}
+
+export function resolveSkillsParentCommandPath(argv: readonly string[]): string[] | null {
+  return resolveParentCommandPath(argv, "skills", ["--json"], ["--agent"]);
+}
+
 /** Resolve the parent commands whose options may precede a child command. */
 export function resolveParentAwareCommandPath(argv: readonly string[]): string[] | null {
   return (
     resolveParentCommandPath(argv, "agent", AGENT_PARENT_BOOLEAN_FLAGS, AGENT_PARENT_VALUE_FLAGS) ??
     resolveModelsParentCommandPath(argv) ??
+    resolveConfigParentCommandPath(argv) ??
+    resolveSkillsParentCommandPath(argv) ??
     resolveParentCommandPath(argv, "channels", [], ["--agent"]) ??
     resolveParentCommandPath(argv, "update", UPDATE_PARENT_BOOLEAN_FLAGS, UPDATE_PARENT_VALUE_FLAGS)
   );

--- a/src/cli/program/action-reparse.test.ts
+++ b/src/cli/program/action-reparse.test.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
 import { reparseProgramFromActionCommand } from "./action-reparse.js";
+import { registerLazyCommand } from "./register-lazy-command.js";
 
 function setRawArgs(command: Command, rawArgs: string[]): void {
   (command as Command & { rawArgs: string[] }).rawArgs = rawArgs;
@@ -26,6 +27,31 @@ async function expectReparseArgv(params: {
 }
 
 describe("reparseProgramFromActionCommand", () => {
+  it.each([
+    { args: ["--", "config", "get", "--help"] },
+    { args: ["config", "--", "get", "--help"] },
+    { args: ["config", "get", "--", "--help"] },
+  ])("keeps literal flag-looking values through actual lazy reparse: $args", async ({ args }) => {
+    const program = new Command().name("openclaw").enablePositionalOptions();
+    const received: string[] = [];
+    registerLazyCommand({
+      program,
+      name: "config",
+      description: "Read config",
+      register: () => {
+        program
+          .command("config")
+          .command("get")
+          .argument("<path>")
+          .action((value: string) => {
+            received.push(value);
+          });
+      },
+    });
+    await program.parseAsync(["node", "openclaw", ...args]);
+    expect(received).toEqual(["--help"]);
+  });
+
   it("uses root raw args and reparses the root for nested lazy commands", async () => {
     const root = new Command().name("openclaw");
     setRawArgs(root, ["node", "openclaw", "workspaces", "audit", "export", "--since", "1"]);

--- a/src/cli/program/error-output.test.ts
+++ b/src/cli/program/error-output.test.ts
@@ -1,6 +1,7 @@
 // Error output tests cover program-level error display and exit messaging.
-import { CommanderError, InvalidArgumentError } from "commander";
+import { CommanderError, InvalidArgumentError, type Command } from "commander";
 import { describe, expect, it } from "vitest";
+import { isConfigMachineOutput } from "../config-output-mode.js";
 import { createCronOutputCommand, isCronMachineOutput } from "../cron-cli/output-mode.js";
 import { isDevicesMachineOutput } from "../devices-output-mode.js";
 import { ExpectedCliError, formatCliJsonFailure } from "../failure-output.js";
@@ -77,7 +78,18 @@ async function parseLazyGroupError(params: {
 }
 
 describe("formatCliParseErrorOutput", () => {
-  it.each([
+  it.each<{
+    name: string;
+    args: string[];
+    root: string;
+    alias?: string;
+    children: string[];
+    argument?: string;
+    requiredOption?: string;
+    valueOption?: string;
+    message: string;
+    machineOutput: (argv: readonly string[], command?: Command) => boolean;
+  }>([
     {
       name: "automation lookup",
       args: ["cron", "get"],
@@ -115,6 +127,52 @@ describe("formatCliParseErrorOutput", () => {
       message: 'Missing required argument "ref".',
       machineOutput: isSkillsMachineOutput,
     },
+    {
+      name: "skill verification after a parent terminator",
+      args: ["skills", "--", "verify"],
+      root: "skills",
+      children: ["verify"],
+      argument: "<ref>",
+      message: 'Missing required argument "ref".',
+      machineOutput: isSkillsMachineOutput,
+    },
+    {
+      name: "config read after a parent terminator",
+      args: ["config", "--", "get"],
+      root: "config",
+      children: ["get"],
+      argument: "<path>",
+      message: 'Missing required argument "path".',
+      machineOutput: isConfigMachineOutput,
+    },
+    {
+      name: "skill verification after a root terminator",
+      args: ["--", "skills", "verify"],
+      root: "skills",
+      children: ["verify"],
+      argument: "<ref>",
+      message: 'Missing required argument "ref".',
+      machineOutput: isSkillsMachineOutput,
+    },
+    {
+      name: "config read after a root terminator",
+      args: ["--", "config", "get"],
+      root: "config",
+      children: ["get"],
+      argument: "<path>",
+      message: 'Missing required argument "path".',
+      machineOutput: isConfigMachineOutput,
+    },
+    ...["version", "tag"].map((option) => ({
+      name: `skill verification with a card-looking ${option} value`,
+      args: ["skills", "verify", `--${option}`, "--card"],
+      root: "skills",
+      children: ["verify"],
+      argument: "<ref>",
+      valueOption: `--${option} <value>`,
+      message: 'Missing required argument "ref".',
+      machineOutput: isSkillsMachineOutput,
+    })),
     {
       name: "node invocation",
       args: ["nodes", "invoke"],
@@ -173,7 +231,9 @@ describe("formatCliParseErrorOutput", () => {
       if (testCase.alias) {
         root.alias(testCase.alias);
       }
-      setCommandJsonMode(root, "output", ({ argv }) => testCase.machineOutput(argv));
+      setCommandJsonMode(root, "output", ({ argv, command }) =>
+        testCase.machineOutput(argv, command),
+      );
 
       let command = root;
       for (const child of testCase.children) {
@@ -187,6 +247,9 @@ describe("formatCliParseErrorOutput", () => {
       }
       if (testCase.requiredOption) {
         command.requiredOption(testCase.requiredOption);
+      }
+      if (testCase.valueOption) {
+        command.option(testCase.valueOption).option("--card");
       }
       command.action(() => {});
 

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -184,6 +184,24 @@ describe("resolveGatewayRunPreBootstrapOptions", () => {
       resolveGatewayRunPreBootstrapOptions(["node", "openclaw", "gateway", "--token", "--force"]),
     ).toEqual({ force: false, reset: false });
   });
+
+  it.each([
+    { args: ["--", "gateway", "status"], commandPath: ["gateway", "status"] },
+    { args: ["gateway", "--", "status"], commandPath: ["gateway", "status"] },
+    { args: ["--", "gateway", "--force"], commandPath: ["gateway", "--force"] },
+    { args: ["--", "gateway", "run", "--reset"], commandPath: ["gateway", "run"] },
+    { args: ["gateway", "--", "run", "--force"], commandPath: ["gateway", "run"] },
+    { args: ["gateway", "run", "--", "--reset"], commandPath: ["gateway", "run"] },
+  ])(
+    "preserves literal gateway commands without enabling destructive flags: $args",
+    ({ args, commandPath }) => {
+      const argv = ["node", "openclaw", ...args];
+      expect(resolveGatewayCatalogCommandPath(argv)).toEqual(commandPath);
+      const options = resolveGatewayRunPreBootstrapOptions(argv);
+      expect(options?.force).not.toBe(true);
+      expect(options?.reset).not.toBe(true);
+    },
+  );
 });
 
 describe("rewriteUpdateFlagArgv", () => {
@@ -301,6 +319,22 @@ describe("shouldHandleBareRoot", () => {
     expect(shouldHandleBareRoot(["node", "openclaw", "--help"])).toBe(false);
     expect(shouldHandleBareRoot(["node", "openclaw", "-V"])).toBe(false);
     expect(shouldHandleBareRoot(["node", "openclaw", "status"])).toBe(false);
+  });
+
+  it.each([
+    { args: ["--", "config", "get", "gateway.mode"] },
+    { args: ["--profile", "work", "--", "config", "get", "gateway.mode"] },
+    { args: ["--", "--help"] },
+    { args: ["--", "config", "--help"] },
+    { args: ["--", "config", "unknown"] },
+  ])("does not start bare-root flows for literal commands: $args", ({ args }) => {
+    const argv = ["node", "openclaw", ...args];
+    expect(shouldHandleBareRoot(argv)).toBe(false);
+    expect(shouldUseRootHelpFastPath(argv)).toBe(false);
+  });
+
+  it("retains bare-root behavior for an otherwise empty terminator", () => {
+    expect(shouldHandleBareRoot(["node", "openclaw", "--"])).toBe(true);
   });
 });
 

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -576,7 +576,7 @@ export function registerSkillsCli(program: Command) {
     );
   const hasJsonOutput = (opts?: { json?: boolean }): boolean =>
     Boolean(opts?.json || skills.opts<{ json?: boolean }>().json);
-  setCommandJsonMode(skills, "output", ({ argv }) => isSkillsMachineOutput(argv));
+  setCommandJsonMode(skills, "output", ({ argv, command }) => isSkillsMachineOutput(argv, command));
   registerSkillsLibraryCli(skills);
 
   skills

--- a/src/cli/skills-output-mode.ts
+++ b/src/cli/skills-output-mode.ts
@@ -1,36 +1,11 @@
-import { consumeRootOptionToken, findRootCommandIndex } from "../infra/cli-root-options.js";
+import type { Command } from "commander";
 import { hasMachineOutputOption } from "./machine-output-argv.js";
-
-function resolveSkillsSubcommand(argv: readonly string[]): string | null {
-  const rootIndex = findRootCommandIndex(argv);
-  if (rootIndex === null) {
-    return null;
-  }
-  for (let index = rootIndex + 1; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (!arg || arg === "--") {
-      return null;
-    }
-    const rootConsumed = consumeRootOptionToken(argv, index);
-    if (rootConsumed > 0) {
-      index += rootConsumed - 1;
-      continue;
-    }
-    if (arg === "--agent") {
-      index += 1;
-      continue;
-    }
-    if (arg.startsWith("--agent=")) {
-      continue;
-    }
-    if (!arg.startsWith("-")) {
-      return arg;
-    }
-  }
-  return null;
-}
+import { resolveSkillsParentCommandPath } from "./parent-command-path.js";
 
 /** Skill verification emits JSON unless the caller explicitly requests the Markdown card. */
-export function isSkillsMachineOutput(argv: readonly string[]): boolean {
-  return resolveSkillsSubcommand(argv) === "verify" && !hasMachineOutputOption(argv, "--card");
+export function isSkillsMachineOutput(argv: readonly string[], command?: Command): boolean {
+  return (
+    resolveSkillsParentCommandPath(argv)?.[1] === "verify" &&
+    !hasMachineOutputOption(argv, "--card", command)
+  );
 }

--- a/src/infra/cli-root-options.test.ts
+++ b/src/infra/cli-root-options.test.ts
@@ -1,6 +1,12 @@
 // Covers root CLI option token parsing.
 import { describe, expect, it } from "vitest";
-import { consumeRootOptionToken, isValueToken } from "./cli-root-options.js";
+import {
+  consumeRootOptionToken,
+  getCommandArgsWithRootOptions,
+  getCommandPositionalsWithRootOptions,
+  getRootOptionAwareCommandPath,
+  isValueToken,
+} from "./cli-root-options.js";
 
 function expectValueTokenCases(
   cases: ReadonlyArray<{ value: string | undefined; expected: boolean }>,
@@ -44,5 +50,41 @@ describe("consumeRootOptionToken", () => {
     { args: [], index: 0, expected: 0 },
   ])("consumes %j at %d", ({ args, index, expected }) => {
     expect(consumeRootOptionToken(args, index)).toBe(expected);
+  });
+});
+
+describe("literal command discovery", () => {
+  it.each([
+    { args: ["--", "config", "get"], expected: ["config", "get"] },
+    { args: ["--profile", "work", "--", "config", "get"], expected: ["config", "get"] },
+    { args: ["--profile", "--", "config", "get"], expected: ["config", "get"] },
+    { args: ["--", "--help"], expected: ["--help"] },
+    { args: ["--", "config", "--help"], expected: ["config", "--help"] },
+    { args: ["--", "config", "unknown"], expected: ["config", "unknown"] },
+    { args: ["--"], expected: [] },
+    { args: ["status", "--", "ignored"], expected: ["status"] },
+  ])("discovers $args without promoting literal flags", ({ args, expected }) => {
+    expect(getRootOptionAwareCommandPath(["node", "openclaw", ...args], 2)).toEqual(expected);
+  });
+
+  it.each([
+    ["--", "channels", "add", "--channel", "example"],
+    ["channels", "--", "add", "--channel", "example"],
+    ["channels", "add", "--", "--channel", "example"],
+  ])("retains the literal boundary in a delegated argument tail: %j", (...args) => {
+    expect(
+      getCommandArgsWithRootOptions(["node", "openclaw", ...args], {
+        commandPath: ["channels", "add"],
+        mode: "command-path",
+      }),
+    ).toEqual(["--", "--channel", "example"]);
+  });
+
+  it("keeps literal root invocations out of conservative fast routes", () => {
+    expect(
+      getCommandPositionalsWithRootOptions(["node", "openclaw", "--", "config", "get"], {
+        commandPath: ["config", "get"],
+      }),
+    ).toBeNull();
   });
 });

--- a/src/infra/cli-root-options.ts
+++ b/src/infra/cli-root-options.ts
@@ -15,7 +15,7 @@ export function isValueToken(arg: string | undefined): boolean {
   return /^-\d+(?:\.\d+)?$/.test(arg);
 }
 
-/** Returns how many argv tokens a supported root option consumes at the given index. */
+/** Count root-option tokens conservatively for route matching. */
 export function consumeRootOptionToken(args: ReadonlyArray<string>, index: number): number {
   const arg = args[index];
   if (!arg) {
@@ -37,40 +37,35 @@ export function consumeRootOptionToken(args: ReadonlyArray<string>, index: numbe
   return 0;
 }
 
-/** Locate the root command after supported root options without loading CLI catalogs. */
-export function findRootCommandIndex(argv: readonly string[]): number | null {
-  for (let index = 2; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (!arg || arg === FLAG_TERMINATOR) {
-      return null;
-    }
-    const consumed = consumeRootOptionToken(argv, index);
-    if (consumed > 0) {
-      index += consumed - 1;
-      continue;
-    }
-    if (!arg.startsWith("-")) {
-      return index;
-    }
-  }
-  return null;
+/** Consume required root values by their Commander role before startup policy is selected. */
+export function consumeRootCommandOptionToken(args: readonly string[], index: number): number {
+  return consumeKnownOptionToken(args, index, ROOT_BOOLEAN_FLAGS, ROOT_VALUE_FLAGS, "command-path");
 }
 
 /** Read positional command tokens while accepting root options at any pre-terminator position. */
 export function getRootOptionAwareCommandPath(argv: readonly string[], depth: number): string[] {
   const args = argv.slice(2);
   const path: string[] = [];
+  let literal = false;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (!arg || arg === FLAG_TERMINATOR) {
+    if (!arg) {
       break;
     }
-    const consumed = consumeRootOptionToken(args, index);
+    if (!literal && arg === FLAG_TERMINATOR) {
+      // A leading terminator still leaves a command to discover; later operands belong to callers.
+      if (path.length > 0) {
+        break;
+      }
+      literal = true;
+      continue;
+    }
+    const consumed = literal ? 0 : consumeRootCommandOptionToken(args, index);
     if (consumed > 0) {
       index += consumed - 1;
       continue;
     }
-    if (arg.startsWith("-")) {
+    if (!literal && arg.startsWith("-")) {
       continue;
     }
     path.push(arg);
@@ -160,7 +155,11 @@ function parseCommandArgsWithRootOptions(
       literal = true;
       continue;
     }
-    const rootConsumed = literal ? 0 : consumeRootOptionToken(args, index);
+    const rootConsumed = literal
+      ? 0
+      : options.mode === "command-path"
+        ? consumeRootCommandOptionToken(args, index)
+        : consumeRootOptionToken(args, index);
     if (rootConsumed > 0) {
       index += rootConsumed - 1;
       continue;
@@ -185,7 +184,9 @@ function parseCommandArgsWithRootOptions(
       }
       commandIndex += 1;
       if (returnTail && commandIndex === options.commandPath.length) {
-        return args.slice(index + 1);
+        const tail = args.slice(index + 1);
+        // A downstream parser must not reactivate flags after an earlier literal boundary.
+        return literal ? [FLAG_TERMINATOR, ...tail] : tail;
       }
       continue;
     }


### PR DESCRIPTION
Closes #139053

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where config reads and skill verification lost their usual structured errors when a parent option or `--` preceded the child command. For example, `openclaw config -- get` and `openclaw skills -- verify` returned human-only missing-argument errors even though those commands normally own machine-readable output.

The same disagreement about argument roles also sent `openclaw -- config get gateway.mode` into the TUI and treated a value spelled `--card` in `skills verify --version --card` or `--tag --card` as a request for card output.

## Why This Change Was Made

Command discovery, startup selection, and output ownership now reuse the existing root/parent parser. Leading literal boundaries survive downstream parsing and lazy command dispatch, and the existing Commander token-role helper serves both models and skills output detection. This removes duplicate config, skills, root-index, Gateway-path, and models-output scanning paths.

Canonical command paths still pass through the catalog's longest-prefix policy lookup. Membership-only rows for seven existing model child roots preserve their default startup behavior, while nested skills commands retain their proxy bypass. Gateway foreground/respawn selection uses the same command-path owner; literal `--force` and `--reset` stay operands. Conservative execution routing still falls through to Commander when needed.

## User Impact

Parent option values remain values, commands still dispatch after `--`, and structured errors remain available where they are already the command's default. Actual `--card` retains human output, config set keeps parse-only `--json`, and literal `--help` stays an operand after a terminator. No flags, configuration fields, defaults, dependencies, schemas, or persistence contracts are added. Current main's SkillWorkshop storage ownership changes are preserved.

## Evidence

Full build and official CLI proof are complete. CI and the separate full-head source review are green at the current head.

Committed candidate: `3d752f9da95c90ead28774745659af521a406826`, based on current main `31903060a5d4a98ccd367aa6f15e66339a3ddcba`. The committed diff matches the final reviewed and checked tree.

Before production edits, real Commander comparisons and the actual `OpenClawCommand` error boundary reproduced the failures. The original built CLI also confirmed the leading-terminator TUI dispatch and card-shaped option-value failures. New root/tail, help, Gateway, lazy reparse, and respawn tests were captured failing before their repairs.

The current-main focused suite passed **529 tests across 12 files**. After the typecheck caught two test-declaration issues, both corrected files passed their **69-case boundary suite** without changing assertions or production behavior. Coverage includes root/parent/leaf terminators, literal help operands, required values spelled `--`, real card flags versus option values, Gateway destructive-option fencing, conservative route fallback, channels-add consumers, and complete model/startup policy dimensions.

Production: **105 added / 161 removed, net -56 lines**. Tests: **297 added / 8 removed, net +289**. Documentation: **+4**. No test-only production hooks were introduced.

Commander **15.0.0** was personally inspected in this checkout: `lib/command.js` child dispatch at line 1562, terminator handling at line 1789, and required-value consumption at line 1808. The launcher validates profile arguments before version handling: `--profile --version` returns a missing-value error, while `--profile work --version` succeeds. This preserves the existing validation owner.

Pinned oxfmt **0.65.0** and whitespace checks pass. Final P2 review and the independent source challenge are clean; the final full changed gate passes, including core/test types, changed-file lint, dead-export scans, storage/loader/security guards, and runtime import-cycle checks. A second review also caught a help-classification regression when a command-owned value resembled a root option before `--help`. Four real-Commander cases reproduced it before the early help policy was restored to its existing conservative owner. The corrected help/profile/container/entry/Gateway sweep passes **373 tests across nine files**.

The full `pnpm build` passed in **3m 14s**, including runtime bundles, declarations, plugin artifacts, Control UI budgets, and CLI bootstrap checks. `dist/build-info.json` records `4a7ad309e387ebbc553965991aca71f15bc13a00`. All 21 files in that built candidate are byte-for-byte identical at the current head; the successor only updates the existing startup-context test. Dependencies were installed into this checkout with the frozen lockfile; no shared install was reconciled.

**54/54 official dist CLI cases passed** through `node openclaw.mjs`, using temporary synthetic home/state/config. Stdout, stderr, and exit codes were captured and completely inspected. There was no source loader or output-suppression override. Machine-output commands produced only their raw value or JSON; requested help retained its ordinary help text.

| Actual command families | Observed result |
| --- | --- |
| Config get/file, six plain/parent/root-terminator/profile forms each | Exit 0, exact raw port/config path, empty stderr |
| Missing config path and skill reference, including root/parent terminators | Exit 1, JSON `cli_error` plus normal diagnostic on stderr |
| Skills verify with `--version --card` / `--tag --card`, with/without parent agent | Exit 1, default JSON missing-reference error; real `--card` keeps human output |
| Literal `--help` at root, parent, and leaf boundaries | Intended unknown-command, excess-argument, or unknown-config-path error; no TUI or help takeover |
| Gateway run with literal `--force --reset`, root/parent/leaf forms | Exit 1 parse error, no config rewrite, no listener |
| Skills Workshop list, with/without parent agent | Exit 0, empty proposals-manifest JSON despite unusable proxy CA |
| Models refresh and scan | Expected unreadable proxy CA failure, preserving their default proxy policy |
| Skills tag/version, models provider, and agent message values spelling `--log-level` before `--help` | Exit 0 help with empty stderr despite unusable proxy CA |
| Root profile/container validation and profiled version | Existing validation errors preserved; valid version identifies the candidate head |

All 54 cases left their synthetic config unchanged and no Gateway listener behind; the fixture was removed. Config reads also used the unusable proxy CA to prove their existing bypass. These runtime captures are attributed to `4a7ad309e387ebbc553965991aca71f15bc13a00` and remain applicable because all original candidate file blobs are unchanged. [Exact-head CI passed for `3d752f9da95c`](https://github.com/openclaw/openclaw/actions/runs/33977508865).

CI run 33975607691 caught an obsolete test assertion that expected Gateway token values to be misidentified as commands. The committed test-only correction updates the existing case to use valid `acp --token client` input and verifies that the authoritative ACP action path preserves protocol stdout. It no longer pins approximate parser output; negative-token and actual-client cases remain. The original 21 files and all production bytes are unchanged, preserving the completed build and 54-case runtime evidence. The corrected test was independently reviewed through P2; its 239-case focused suite and scoped changed-file gate pass. Fresh exact-head CI is green.

The separate final 22-file source review is clean at `3d752f9da95c90ead28774745659af521a406826`, with verified inheritance from the unchanged production candidate and fresh inspection of the test correction. CI preflight actually tested merge `170a152fac87923c4b8a9ea68bedd268b0f32e8b`, whose ordered parents are main `707edba619a6244fb6a465f9c4b01a856994a29c` and this exact PR head.

The latest completed ClawSweeper review at exact `3d752f9d` (16:49 UTC) accepts the 54-case runtime proof and has no patch/security finding. Its remaining environment limitation obtaining Commander 15.0.0 is addressed by actual pinned-source inspection by the owner, independent peers, and separate direct reviewer. No production behavior changed in the test-only successor, and no duplicate re-review request was posted.
