### PR TITLE
improve: reduce scheduling work in busy worker pools

### DIFF
--- a/src/infra/worker-task-pool.ts
+++ b/src/infra/worker-task-pool.ts
@@ -197,6 +197,8 @@ export class WorkerTaskPool<Input, Output> {
     if (task.slot) {
       this.fail(task.slot, error);
     } else {
+      // Only queued tasks lack a slot; dispatch and close remove their entries themselves.
+      this.queue.splice(this.queue.indexOf(task), 1);
       this.finish(task, error);
     }
   }
@@ -221,10 +223,6 @@ export class WorkerTaskPool<Input, Output> {
     task.done = true;
     clearTimeout(task.timer);
     task.options.signal?.removeEventListener("abort", task.abort);
-    const queuedIndex = this.queue.indexOf(task);
-    if (queuedIndex !== -1) {
-      this.queue.splice(queuedIndex, 1);
-    }
     // SAFETY: Only a validated successful reply reaches finish without an error and supplies Output.
     const complete = () => (error ? task.reject(error) : task.resolve(value as Output));
     const slot = task.slot;
@@ -235,7 +233,9 @@ export class WorkerTaskPool<Input, Output> {
         void this.retire(slot).then(complete);
         return;
       }
-      this.idle(slot);
+      if (!this.queue.length) {
+        this.idle(slot);
+      }
     }
     complete();
     this.dispatch();


### PR DESCRIPTION
## What Problem This Solves

Busy worker pools repeatedly allocate idle timers between consecutive queued tasks and scan the backlog after completed tasks have already left it. This adds avoidable scheduling work to Code Mode, compaction planning, and other pooled worker workloads. This is a maintainer-requested performance improvement.

## Why This Change Was Made

Keep queue removal with dispatch, queued cancellation, and close. A completing worker now enters its existing idle lifecycle only when no queued task is waiting, preserving the worker reference during immediate handoff. Cancellation, worker retirement, input release, and result validation retain their existing owners.

## User Impact

Queued work uses fewer short-lived timers while preserving FIFO settlement, cancellation, and idle process exit. No configuration or protocol changes. Production LOC: +5/-5 (net 0); no test-source changes.

## Evidence

- Before and after: 61 tests passed using `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/infra/worker-task-pool.test.ts src/agents/code-mode-worker-lifecycle.test.ts src/agents/compaction-planning-worker.test.ts`. These exercise real worker threads, queued cancellation, asynchronous preparation, retirement, input transfer/release, and headless process exit.
- Five independent pools per arm, each draining 5,001 tasks through one warm real worker: exact FIFO and worker reuse passed; parent `Timeout` creations fell from 5,001 to 1 in every sample. Mean wall time was 99.63 → 78.63 ms and process CPU 107.01 → 86.85 ms. Timings are descriptive sequential measurements on a shared host with instrumentation, not a whole-Gateway or retained-memory claim.
- Formatting and `git diff --check` passed. The changed-check plan selected core/coreTests; the broad local check was interrupted and is not claimed as passing. Required exact-head [CI 33965398157](https://github.com/openclaw/openclaw/actions/runs/33965398157) and [Workflow Sanity 33965345848](https://github.com/openclaw/openclaw/actions/runs/33965345848) passed. Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 139069` verified these hosted gates; Testbox was not applicable.
- Managed independent P2 autoreview: scoped-clean, no actionable findings. The committed source is checked against the frozen reviewed bytes.
- Compiled integration candidate `7428c4a5e850016e34336b382e345ef0017f71f4`, containing all 20 batch changes and this exact worker-owner blob, passed a real OpenAI run on `openai/gpt-5.6-luna`: 10 outer turns, 14 stages and 50 phases across Code Mode and tool-search profiles. Run B1 completed with stable identities, clean unforced shutdown, all 69 owned process identities absent, and both listeners/private runtimes cleared. The publisher verified the worker source is byte-identical to this PR. Verification identity SHA-256: `3e949e2dd485ab1da7ad1faeb707b9b7ff33062906e2af8b6fc7a9ff0343594c`. This proves compiled batch behavior, not isolated attribution or a final aggregate performance improvement; remaining controlled measurement arms are still running.
