### PR TITLE
improve: reduce temporary allocation when assembling PNGs

### DIFF
--- a/src/media/png-encode.ts
+++ b/src/media/png-encode.ts
@@ -1,15 +1,14 @@
 // PNG encode helpers build small PNG files without external image dependencies.
 import { crc32, deflateSync } from "node:zlib";
 
-/** Create a PNG chunk with type, data, and CRC. */
-function pngChunk(type: string, data: Buffer): Buffer {
-  const typeBuf = Buffer.from(type, "ascii");
-  const len = Buffer.alloc(4);
-  len.writeUInt32BE(data.length, 0);
-  const crc = crc32(data, crc32(typeBuf));
+/** Keep chunk parts separate so final assembly copies compressed data only once. */
+function pngChunkParts(type: string, data: Buffer): Buffer[] {
+  const header = Buffer.alloc(8);
+  header.writeUInt32BE(data.length, 0);
+  header.write(type, 4, "ascii");
   const crcBuf = Buffer.alloc(4);
-  crcBuf.writeUInt32BE(crc, 0);
-  return Buffer.concat([len, typeBuf, data, crcBuf]);
+  crcBuf.writeUInt32BE(crc32(data, crc32(header.subarray(4))), 0);
+  return [header, data, crcBuf];
 }
 
 /**
@@ -62,9 +61,9 @@ function encodePng(buffer: Buffer, width: number, height: number, channels: 3 | 
 
   return Buffer.concat([
     signature,
-    pngChunk("IHDR", ihdr),
-    pngChunk("IDAT", compressed),
-    pngChunk("IEND", Buffer.alloc(0)),
+    ...pngChunkParts("IHDR", ihdr),
+    ...pngChunkParts("IDAT", compressed),
+    ...pngChunkParts("IEND", Buffer.alloc(0)),
   ]);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Generating context-map PNGs and RGB/RGBA fixtures allocates complete intermediate chunks, then copies their payloads again during final PNG assembly. This is a maintainer-requested reduction in avoidable image-encoding allocation.

## Why This Change Was Made

Keep each private chunk's length/type header, payload, and incremental CRC separate until the existing final concatenation. The encoder still emits the same IHDR, IDAT, and IEND bytes with the same scanlines and zlib compression.

## User Impact

PNG assembly allocates fewer temporary buffers while preserving exact image bytes. No API, media policy, dependency, or configuration changes. Production LOC: +10/-11 (net -1); no test-source changes.

## Evidence

- Six synthetic cases cover tiny, compressible, and high-entropy RGB/RGBA. Every output matches the pre-edit PNG byte for byte. Independent decoding verifies dimensions, color type, chunk order, CRCs, inflated scanline filters, and all pixel bytes.
- Instrumented public `Buffer.concat` results remove exactly three concatenations and `(PNG length - 8)` allocated bytes per image. For the 1,049,476-byte high-entropy RGBA PNG, counted concat allocation falls from 3,148,363 to 2,098,895 bytes. This counts concat allocations only, not all heap allocation.
- Uninstrumented timing in the initial sequential pair did not improve; all candidate timings increased, including compressible RGBA from 202.55 to 270.70 ms per batch. RSS was mixed. This PR claims lower assembly allocation, not faster encoding, retained-memory savings, or a whole-Gateway improvement.
- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-context-report.test.ts`: 20 tests passed, including the real context-map rendering path and decoded image checks.
- `node scripts/check-changed.mjs -- src/media/png-encode.ts`, direct-file formatting, and `git diff --check` passed.
- Managed independent P2 autoreview: scoped-clean, no actionable findings; source bytes match the frozen measured/reviewed candidate. Exact-head CI [33965446300](https://github.com/openclaw/openclaw/actions/runs/33965446300) and Workflow Sanity [33965408744](https://github.com/openclaw/openclaw/actions/runs/33965408744) passed. The required `openclaw/ci-gate` is SUCCESS. No standalone live Gateway/provider claim is made; the real context-map renderer and byte/decode fixtures prove this unchanged helper contract.

Pre-merge verification: `scripts/pr review-init 139070`, native main/PR checkout inspection, `review-artifacts-init`, `review-validate-artifacts`, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 139070` passed. Native hosted verification retained exact head `4f9d6e19638db4abcc493c62d612afd55336bfc5` without rebase or source changes. The complete [ClawSweeper review](https://github.com/openclaw/openclaw/pull/139070#issuecomment-5551780115) has no findings or before-merge requests.
