### PR TITLE
docs(cli): document system Gateway port and password options

### DIFF
--- a/docs/cli/system.md
+++ b/docs/cli/system.md
@@ -14,13 +14,15 @@ heartbeats, and view presence.
 
 All `system` subcommands use Gateway RPC and accept the shared client flags:
 
-| Flag              | Default                              | Description                                                                                                                                                                                            |
-| ----------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--url <url>`     | `gateway.remote.url` when configured | Gateway WebSocket URL.                                                                                                                                                                                 |
-| `--token <token>` | none                                 | Gateway token (if required).                                                                                                                                                                           |
-| `--timeout <ms>`  | `30000`                              | RPC timeout in milliseconds.                                                                                                                                                                           |
-| `--expect-final`  | off                                  | Wait for final response (agent).                                                                                                                                                                       |
-| `--json`          | off                                  | Output JSON. `heartbeat last/enable/disable` and `system presence` always print the raw RPC JSON payload regardless of this flag; `system event` uses it to switch between JSON and a plain `ok` line. |
+| Flag                    | Default                              | Description                                                                                                                                                                                            |
+| ----------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--url <url>`           | `gateway.remote.url` when configured | Gateway WebSocket URL.                                                                                                                                                                                 |
+| `--port <port>`         | none                                 | Local Gateway port.                                                                                                                                                                                    |
+| `--token <token>`       | none                                 | Gateway token (if required).                                                                                                                                                                           |
+| `--password <password>` | none                                 | Gateway password (if required).                                                                                                                                                                        |
+| `--timeout <ms>`        | `30000`                              | RPC timeout in milliseconds.                                                                                                                                                                           |
+| `--expect-final`        | off                                  | Wait for final response (agent).                                                                                                                                                                       |
+| `--json`                | off                                  | Output JSON. `heartbeat last/enable/disable` and `system presence` always print the raw RPC JSON payload regardless of this flag; `system event` uses it to switch between JSON and a plain `ok` line. |
 
 ## Common commands
 


### PR DESCRIPTION
## What Problem This Solves

The `openclaw system` reference promises to list the shared Gateway client flags but omits `--port` and `--password`.

## Why This Change Was Made

Add the two existing options to the shared table: the local Gateway port and the Gateway password when required. Neither option has an explicit registration default. Preserve the other flags, the detailed JSON behavior, and the existing command sections.

## User Impact

Operators can find all shared connection options in the system reference. CLI behavior, authentication, transport, and configuration do not change.

## Evidence

- Traced the shared option helper through `event`, `heartbeat last`, `heartbeat enable`, `heartbeat disable`, and `presence`.
- Generated the baseline and candidate with the official documentation publisher and renderer.
- Browser proof confirms the original omission, both added rows, and preservation of the full reference.
- Native documentation checks, the commit hook, exact-head review, and hosted CI provide the finishing gates.
- No Gateway command or credential was used.

Thanks to @qingminglong for the original contribution.
