### PR TITLE
improve: reduce temporary allocation in Gateway request tracking

### DIFF
--- a/packages/gateway-client/src/pending-request.ts
+++ b/packages/gateway-client/src/pending-request.ts
@@ -46,7 +46,7 @@ type GatewayPendingRequestsOptions = {
 
 /** Owns request deadlines, correlation, settlement, and generation-scoped IDs. */
 export class GatewayPendingRequests {
-  private readonly pending = new Map<string, GatewayPendingRequest>();
+  private pending = new Map<string, GatewayPendingRequest>();
   private requestSequence = 0;
 
   constructor(private readonly opts: GatewayPendingRequestsOptions) {}
@@ -56,7 +56,12 @@ export class GatewayPendingRequests {
   }
 
   get hasUnboundedPending(): boolean {
-    return [...this.pending.values()].some((pending) => pending.unbounded);
+    for (const pending of this.pending.values()) {
+      if (pending.unbounded) {
+        return true;
+      }
+    }
+    return false;
   }
 
   request<T>(
@@ -180,8 +185,8 @@ export class GatewayPendingRequests {
   }
 
   flush(error: Error): void {
-    const retired = [...this.pending];
-    this.pending.clear();
+    const retired = this.pending;
+    this.pending = new Map();
     // Timing observers can reconnect synchronously, so detach the entire old
     // generation and reset its sequence before running any caller-owned code.
     this.requestSequence = 0;
@@ -205,21 +210,15 @@ export class GatewayPendingRequests {
   ): void {
     const endedAtMs = this.opts.nowMs();
     try {
-      const onTiming = this.opts.onTiming;
-      if (onTiming === undefined || onTiming === null) {
-        return;
-      }
-      Reflect.apply(onTiming, this.opts, [
-        {
-          id,
-          method: pending.method,
-          ok,
-          durationMs: Math.max(0, endedAtMs - pending.startedAtMs),
-          startedAtMs: pending.startedAtMs,
-          endedAtMs,
-          errorCode,
-        },
-      ]);
+      this.opts.onTiming?.({
+        id,
+        method: pending.method,
+        ok,
+        durationMs: Math.max(0, endedAtMs - pending.startedAtMs),
+        startedAtMs: pending.startedAtMs,
+        endedAtMs,
+        errorCode,
+      });
     } catch (error) {
       this.opts.onCallbackError?.("request timing", error);
     }


### PR DESCRIPTION
## What Problem This Solves

Gateway clients allocate temporary request collections during connection shutdown and watchdog queries, plus an argument array for each timing notification. Large outstanding-request cohorts amplify that avoidable work. This is a maintainer-requested allocation improvement.

## Why This Change Was Made

Detach the retired request map before callbacks run, iterate pending values directly for the watchdog, and invoke the timing callback through its existing optional method boundary. Generation reset, replacement requests started from timing observers, deadlines, correlation, and callback error handling keep their current behavior.

## User Impact

Browser and Node clients use less transient allocation when retiring large request cohorts or checking unbounded requests. Empty flushes now allocate a new empty map: a small-cohort tradeoff for retiring an entire generation without a staging array. No wire protocol, timeout defaults, auth, or persistence changes. Production LOC: +18/-19 (net -1); no test-source changes.

## Evidence

- Before and after: `node scripts/run-vitest.mjs packages/gateway-client/src/pending-request.test.ts packages/gateway-client/src/protocol-client.request.test.ts packages/gateway-client/src/client.watchdog.test.ts` passed all 55 tests. Coverage includes nested flush, replacement generations, accepted/final replies, late-response isolation, abort/send failure, timing receiver/accessor errors, and finite/unbounded watchdog behavior. The suite includes synthetic local WebSocket servers.
- One source-bound baseline/candidate pair, Node 26.8.1, V8 allocation sampling at 512 bytes including collected objects: retiring 10,000 requests fell from 4,091,592 to 3,279,736 sampled bytes without timing callbacks (-19.84%), and 4,951,664 to 4,102,456 with timing callbacks (-17.15%).
- 1,000 watchdog queries with the first of 10,000 pending requests unbounded fell from 80,142,784 to 85,192 sampled bytes. This deliberately measures early exit; finite-only or late-unbounded scans remain linear without building the array. The 20,000-settlement no-timing control was effectively unchanged (+0.50%), and small cohorts vary in both directions.
- All fixture requests settled, timing counts matched, and pending state ended empty. Samples include inspector/assertion overhead; no statistical, retained-heap, RSS, idle-memory, or whole-Gateway improvement is claimed.
- `node scripts/check-changed.mjs -- packages/gateway-client/src/pending-request.ts`, formatting, and `git diff --check` passed. Managed independent P2 autoreview was scoped-clean with no actionable findings, and frozen source hashes match the committed candidate.
- Exact-head CI [33965558718](https://github.com/openclaw/openclaw/actions/runs/33965558718) and Workflow Sanity [33965500590](https://github.com/openclaw/openclaw/actions/runs/33965500590) passed; the required `openclaw/ci-gate` is SUCCESS. No live Gateway/provider claim is made; the existing real WebSocket fixture and request-lifecycle tests exercise the unchanged owner contract.

Pre-merge verification: native `scripts/pr review-init 139073`, main/PR source inspection, artifact initialization/validation, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 139073` passed. Prepared head remains `8bc10dc5e8a59b1a6a64f1fac8f9b7d0313d2060`, identical to reviewed source, without rebase or source changes. The latest complete ClawSweeper review (2026-09-05 12:22:47 UTC) has no findings or before-merge requests.
