### PR TITLE
improve: reduce code-heavy reply restoration work

### DIFF
--- a/src/shared/text/text-projection.test.ts
+++ b/src/shared/text/text-projection.test.ts
@@ -121,6 +121,18 @@ describe("duplicate paragraphs", () => {
     { text: "repeat\n\n    repeat\n\nrepeat", expected: "repeat\n\n    repeat\n\nrepeat" },
     { text: "Run `x`.\n\nRun `x`.", expected: "Run `x`." },
     {
+      text: "Same `x`.\n\nSame `x`.\n\nOther `x`.\n\nOther `x`.",
+      expected: "Same `x`.\n\nOther `x`.",
+    },
+    {
+      text: "repeat\n\nrepeat\n\n```text\n$$ $& $` $'\n```\n\n```text\n$$ $& $` $'\n```",
+      expected: "repeat\n\n```text\n$$ $& $` $'\n```\n\n```text\n$$ $& $` $'\n```",
+    },
+    {
+      text: "\0\0\0\n\nrepeat\n\nrepeat\n\nUse `x`\u0000`y` and `x`.",
+      expected: "\0\0\0\n\nrepeat\n\nUse `x`\u0000`y` and `x`.",
+    },
+    {
       text: 'repeat\n\nrepeat\n\n```js\nfunction replacement() {\n\n  return "$$ $& $` $\'";\n}\n```',
       expected: 'repeat\n\n```js\nfunction replacement() {\n\n  return "$$ $& $` $\'";\n}\n```',
     },

--- a/src/shared/text/text-projection.ts
+++ b/src/shared/text/text-projection.ts
@@ -1,3 +1,4 @@
+import { expectDefined } from "@openclaw/normalization-core/expect";
 import { escapeRegExp } from "../regexp.js";
 import { findCodeRegions } from "./code-regions.js";
 
@@ -175,27 +176,24 @@ function collapseDuplicateParagraphs(text: string): string {
     marker += "\0";
   }
   const inlineTokens = new Map<string, string>();
-  const protectedRegions = regions.map((region, index) => {
+  let masked = "";
+  let cursor = 0;
+  const protectedText = regions.map((region, index) => {
     const source = text.slice(region.start, region.end);
     let token = `${marker}${index}${marker}`;
     if (!region.block) {
       token = inlineTokens.get(source) ?? token;
       inlineTokens.set(source, token);
     }
-    return { region, token };
-  });
-  let masked = "";
-  let cursor = 0;
-  for (const { region, token } of protectedRegions) {
     masked += text.slice(cursor, region.start) + token;
     cursor = region.end;
-  }
-  let projected = collapsePlainDuplicateParagraphs(masked + text.slice(cursor));
-  for (const { region, token } of protectedRegions) {
-    // Replacement-string dollar sequences must remain literal inside code.
-    projected = projected.replace(token, () => text.slice(region.start, region.end));
-  }
-  return projected;
+    return source;
+  });
+  // Only our indexed tokens contain the marker; a callback preserves literal dollar sequences.
+  return collapsePlainDuplicateParagraphs(masked + text.slice(cursor)).replace(
+    new RegExp(`${marker}(\\d+)${marker}`, "g"),
+    (_token, index: string) => expectDefined(protectedText[Number(index)], "protected code text"),
+  );
 }
 
 function createDuplicateParagraphProjector(protectCode = true): TextProjector {

--- a/src/shared/text/text-projection.ts
+++ b/src/shared/text/text-projection.ts
@@ -1,4 +1,4 @@
-import { expectDefined } from "@openclaw/normalization-core/expect";
+import { expectDefined } from "@openclaw/normalization-core";
 import { escapeRegExp } from "../regexp.js";
 import { findCodeRegions } from "./code-regions.js";
 


### PR DESCRIPTION
## What Problem This Solves

Replies containing many protected code regions repeatedly search and rebuild the entire reply while restoring code after duplicate-paragraph removal. This is a maintainer-requested reduction in transient allocation and restoration work.

## Why This Change Was Made

Collect exact protected code bytes during masking and restore indexed placeholders in one global callback. Existing collision-free NUL markers, shared inline-code IDs, distinct block IDs, literal dollar sequences, duplicate decisions, and streaming lifecycle are preserved.

## User Impact

Code-heavy replies require less work during duplicate-paragraph cleanup while producing the same delivered text. No parser, provider, configuration, protocol, or storage changes. Production LOC: +11/-13 (net -2); tests: +12/-0.

## Evidence

- Synthetic batch fixtures and 155 streaming partitions passed before and after. All nine cohort output hashes match. Added cases extend the existing exact-output/every-partition table for repeated inline IDs, adjacent fenced blocks with dollar sequences, and source NULs; they protect preserved behavior and also pass the baseline.
- `node scripts/run-vitest.mjs src/shared/text/text-projection.test.ts src/agents/embedded-agent-helpers.sanitizeuserfacingtext.duplicateblocks.test.ts`: 36 tests passed. Formatting and `git diff --check` passed. Changed-check classification selected core/coreTests; full type/lint/guard proof comes from the now-successful exact repaired-head CI.
- Approximate V8 allocation samples, six transformations per cohort: 1,024 inline regions fell from 464,062,576 to 294,455,464 sampled bytes (-36.55%); 1,024 fenced regions fell from 565,813,768 to 397,092,920 (-29.82%). Samples include collected objects and do not prove retained-memory savings.
- Initial instrumented timings were slower, so a separate same-process, uninstrumented baseline/candidate/candidate/baseline comparison tested that risk. At 4,096 regions, mean wall time changed 1,057.23 → 847.94 ms for inline code and 1,602.50 → 1,000.28 ms for fences; CPU changed -12.85% and -28.76%. Output hashes matched. Only two observations per arm on a shared host: descriptive evidence, not statistical significance or a whole-Gateway speed claim.
- Managed independent P2 autoreview was scoped-clean with no actionable findings. Both committed files match frozen reviewed hashes. No live Gateway/provider run was performed in this lane; the existing actual byte/stream boundary fixtures prove this helper contract.

CI follow-up: the first head failed the actual Control UI build because the new `/expect` subpath met the browser alias for the package root, producing `index.ts/expect` (ENOTDIR). The follow-up imports the identical guard from the already-supported package root. The exact UI Vite build failed before this one-line fix and passed afterward (3,234 modules, 406 assets); 36 focused tests, all 155 stream partitions and all nine prior output hashes also passed. Source after the import line is byte-identical to the measured implementation. Fresh managed P2 review included the browser alias contract and returned scoped-clean. Updated head `ec285cdfc6a195002c43b919a6224c276b73c1b2` passed [CI 33966304919](https://github.com/openclaw/openclaw/actions/runs/33966304919) and [Workflow Sanity 33966304951](https://github.com/openclaw/openclaw/actions/runs/33966304951); the required `openclaw/ci-gate` is SUCCESS. Prior-head failing CI was not reused.

Pre-merge verification: regenerated native review artifacts for the repaired head, `review-validate-artifacts`, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 139074` passed without rebase or source changes. The full [ClawSweeper review](https://github.com/openclaw/openclaw/pull/139074#issuecomment-5551884113) covers the repaired head and has no findings or before-merge requests.
