### PR TITLE
fix(plugins): git update aborts with build-dirty when NODE_ENV=production rebuilds the workboard Control UI

### DIFF
--- a/src/cli/plugins-control-ui-build.test.ts
+++ b/src/cli/plugins-control-ui-build.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
 import {
   createPluginImportFixture,
   unresolvedPluginImportCases,
@@ -106,6 +107,49 @@ describe("native plugin browser builds", () => {
     expect(built.asDateTimestampMs("0")).toBeUndefined();
     expect(built.asDateTimestampMs(Number.POSITIVE_INFINITY)).toBeUndefined();
     expect(built.truncateUtf16Safe("A😀B", 2)).toBe("A");
+  });
+
+  it("bundles SDK source instead of stale dist under NODE_ENV=production", async () => {
+    const project = await fixture();
+    const sdkRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-build-sdk-"));
+    directories.push(sdkRoot);
+    await Promise.all(
+      ["src/plugin-sdk", "dist/plugin-sdk", "extensions"].map((dir) =>
+        fs.mkdir(path.join(sdkRoot, dir), { recursive: true }),
+      ),
+    );
+    await fs.writeFile(
+      path.join(sdkRoot, "package.json"),
+      JSON.stringify({
+        name: "openclaw",
+        type: "module",
+        bin: { openclaw: "openclaw.mjs" },
+        exports: { "./plugin-sdk/control-ui": { default: "./dist/plugin-sdk/control-ui.js" } },
+      }),
+    );
+    await fs.writeFile(
+      path.join(sdkRoot, "src/plugin-sdk/control-ui.ts"),
+      'export const origin = "source";',
+    );
+    await fs.writeFile(
+      path.join(sdkRoot, "dist/plugin-sdk/control-ui.js"),
+      'export const origin = "stale dist";',
+    );
+    await fs.writeFile(
+      path.join(project.rootDir, project.source),
+      'export { origin } from "openclaw/plugin-sdk/control-ui";',
+    );
+    const build = (nodeEnv: string | undefined) =>
+      withEnvAsync({ NODE_ENV: nodeEnv, OPENCLAW_DEV_SOURCE_ROOT: sdkRoot }, () =>
+        buildPluginControlUi(project),
+      );
+
+    const development = await build(undefined);
+    const production = await build("production");
+
+    expect(production).toEqual(development);
+    const built = await import(pathToFileURL(path.join(project.rootDir, production.entry)).href);
+    expect(built.origin).toBe("source");
   });
 
   it.each(unresolvedPluginImportCases)(

--- a/src/cli/plugins-control-ui-build.ts
+++ b/src/cli/plugins-control-ui-build.ts
@@ -47,7 +47,11 @@ export async function buildPluginControlUi(params: {
     tsconfigRaw: {
       compilerOptions: { experimentalDecorators: true, useDefineForClassFields: false },
     },
-    alias: buildPluginLoaderAliasMap(entry, process.argv[1], import.meta.url),
+    // Browser bundles embed the host SDK and workspace packages, so resolve them
+    // from source whenever a source checkout is present. NODE_ENV=production would
+    // otherwise prefer compiled dist left behind by an earlier build, and stale
+    // bytes change the content hash that openclaw.plugin.json commits.
+    alias: buildPluginLoaderAliasMap(entry, process.argv[1], import.meta.url, "src"),
   });
   if (
     files.some((file) => file.contents.length > CONTROL_UI_PLUGIN_MAX_ASSET_BYTES) ||


### PR DESCRIPTION
Closes #138684.

## What Problem This Solves

Fixes Git-checkout updates that stop the Gateway and then abort with `build-dirty` because building the workboard Control UI changes its tracked plugin manifest. The rollback build can hit the same problem and leave the service stopped with `rollback-checkout-dirty`.

## Why This Change Was Made

Browser asset builds now use the existing source-first SDK and workspace alias resolution. Under `NODE_ENV=production`, automatic resolution preferred existing compiled output; compiling those inputs produces different bundle bytes and manifest hashes, even when the source revision has not changed. Old compiled output can also embed stale code.

The repair belongs in the asset producer. The updater's clean-check guard remains intact, and packaged installations still fall back to compiled files when source is unavailable. Runtime loader preferences are unchanged.

## User Impact

Production-mode Git-checkout builds use the checked-out sources consistently, preventing this generated-manifest failure during forward updates and rollback builds.

Thanks @ylcn91. The contributor's commit and authorship are preserved through rebase.

## Evidence

Baseline: `6aa09cbadb594c3d46d5bd49a28c514df1b256b0`. Reviewed and pushed head: `2f5d6f00ab6d899feb2bb82f4ca8ce2727f85a45`.

- Reproduced on main: `NODE_ENV=production pnpm build` succeeded with a clean tree. A subsequent `NODE_ENV=production pnpm plugins:assets:build --plugin workboard` changed the tracked manifest hash from `045246ad…` to `072f0b70…`. Rebuilding with `NODE_ENV` unset restored the committed hash and clean tree. No source transition was required.
- Isolated Linux, Node 24.19.0, pnpm 12.3.4: `pnpm check:changed --base 6aa09cbadb5` passed. Focused browser-builder, authoring-command, and SDK-alias suites passed: **113 passed, 1 skipped**.
- Red/green: the new stale-dist regression failed against main's production builder with different development/production hashes, then passed with the candidate restored.
- `NODE_ENV=production pnpm plugins:assets:check` passed; generated plugin assets match committed bytes.
- Actual compiled-package comparison: after generating workspace package output with the canonical build, main's producer changed the real workboard manifest to `b695b7a3…`. Restoring only the candidate builder and rebuilding in the same production environment restored `045246ad…` and a clean tracked checkout.
- Independent Codex P2 review: scoped-clean. The installed esbuild declarations independently confirm the existing `alias?: Record<string, string>` contract; this change only selects the existing source-first resolver mode.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/34148756205. Final exact-head verification is green: 132 successful checks, 42 skipped, and 1 neutral; no pending or failed checks.

The build boundary is exercised directly. A complete live managed-Gateway update/rollback cycle was not run; its unchanged dirty-check and recovery paths were inspected.
