### PR TITLE
fix: smooth focused dashboard loading

### DIFF
--- a/docs/web/dashboard-architecture.md
+++ b/docs/web/dashboard-architecture.md
@@ -234,10 +234,17 @@ access nor the proxy's origin. Inline views adopt only the wrapper's private
 prompt channel; dashboard views initialize their separate ticket-bound bridge.
 
 The shared loader fetches board HTML while the sandbox proxy starts, then
-delivers it only after that exact proxy reports ready. Mounted widgets retain
-their loaded document across presentation changes and ticket renewal. Inline
-views share concurrent reads of the same document only within one client and
-connection generation; each view still owns its own sandbox and prompt channel.
+delivers it only after that exact proxy reports ready. Dashboard widgets keep a
+themed loading placeholder until the proxy confirms that the current inner
+document has loaded. This rendering signal is separate from HTML delivery and
+bridge initialization, so an empty widget can finish loading without reporting
+a positive content height. Focused dashboard routes reuse an already resolved
+session key and agent owner to avoid a second session lookup.
+
+Mounted widgets retain their loaded document across presentation changes and
+ticket renewal. Inline views share concurrent reads of the same document only
+within one client and connection generation; each view still owns its own sandbox
+and prompt channel.
 Managed `[embed ref="..."]` previews use that authenticated path whenever their
 effective sandbox policy permits scripts, including the default with no explicit
 sandbox field. Explicit strict previews remain script-free.

--- a/src/agents/sandbox-host.ts
+++ b/src/agents/sandbox-host.ts
@@ -265,6 +265,14 @@ export function buildSandboxHostProxyHtml(csp?: SandboxHostCsp): string {
           // Replace the browsing context so a superseded document cannot race
           // the new wrapper's first private bridge-port offer.
           const nextInner = createInner();
+          nextInner.addEventListener("load", () => {
+            if (inner !== nextInner || typeof params.renderId !== "string") return;
+            window.parent.postMessage({
+              jsonrpc: "2.0",
+              method: "ui/notifications/sandbox-resource-loaded",
+              params: { renderId: params.renderId },
+            }, hostOrigin);
+          }, { once: true });
           widgetPortsOffered.clear();
           nextInner.srcdoc = guardedHtml;
           inner.replaceWith(nextInner);

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -433,6 +433,11 @@ export class OpenClawApp extends OpenClawLightDomElement {
       <openclaw-board-document
         .gatewaySnapshot=${gatewaySnapshot}
         .sessionKey=${route.data.sessionKey}
+        .preparedSession=${
+          route.data.agentId
+            ? { sessionKey: route.data.sessionKey, agentId: route.data.agentId }
+            : null
+        }
         .onDocumentClose=${
           isNativeWebChromeHost() ? null : () => this.closeDocument(this.context?.basePath ?? "")
         }

--- a/ui/src/components/board/board-document.ts
+++ b/ui/src/components/board/board-document.ts
@@ -23,6 +23,7 @@ import {
   isGatewayMethodAdvertised,
 } from "../../lib/gateway-methods.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
+import { renderPanelLoadingSkeleton } from "../panel-loading-skeleton.ts";
 import "../../styles/board-document.css";
 import "./board-view.ts";
 
@@ -261,9 +262,7 @@ export class OpenClawBoardDocument extends OpenClawLightDomElement {
 
   private renderState() {
     if (this.documentState === "loading") {
-      return html`<div class="board-document__state" role="status" aria-live="polite">
-        ${t("common.loading")}
-      </div>`;
+      return renderPanelLoadingSkeleton("discussion", t("common.loading"));
     }
     if (this.documentState === "missing-session") {
       return html`<div class="board-document__state" role="status">

--- a/ui/src/components/board/board-widget-frame.ts
+++ b/ui/src/components/board/board-widget-frame.ts
@@ -1,4 +1,4 @@
-import { html, type TemplateResult } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import type { BoardWidget } from "../../lib/board/types.ts";
@@ -9,6 +9,7 @@ import { formatUiError } from "../../lib/format-error.ts";
 import { isLoopbackHostname } from "../../lib/gateway-locality.ts";
 import { generateUUID } from "../../lib/uuid.ts";
 import { installWidgetThemeObserver, postWidgetTheme } from "../../lib/widget-theme.ts";
+import { renderPanelLoadingSkeleton } from "../panel-loading-skeleton.ts";
 import { resolveGatewayHttpOrigin, resolveSandboxHostUrl } from "../sandbox-host.ts";
 
 // Keep in sync with the identical literal in chat widget-card.ts: a shared
@@ -147,6 +148,8 @@ export class BoardWidgetFrameLifecycle {
   private visibilityListening = false;
   private sandboxOrigin = "";
   private sandboxHost: BoardWidgetSandboxHost | null = null;
+  private contentVisible = false;
+  private revealFrame = 0;
   private readonly ticketRefresh = new BoardWidgetTicketRefresh(
     () => this.host.widget()?.viewTicket,
     () => this.host.active() && !documentHidden(),
@@ -167,6 +170,7 @@ export class BoardWidgetFrameLifecycle {
   }
 
   disconnect(): void {
+    this.resetPresentation();
     this.stopWork();
     if (this.messageListening) {
       window.removeEventListener("message", this.handleWindowMessage);
@@ -243,8 +247,15 @@ export class BoardWidgetFrameLifecycle {
       // Never grant popups: host.open handles user-clicked links so ungranted
       // widgets cannot escape network containment through navigation.
       return html`
+        ${
+          this.contentVisible
+            ? nothing
+            : renderPanelLoadingSkeleton("discussion", t("common.loading"), false, true)
+        }
         <iframe
           class="board-widget__frame"
+          style=${this.contentVisible ? "" : "opacity: 0"}
+          ?inert=${!this.contentVisible}
           sandbox="allow-scripts allow-same-origin allow-forms"
           referrerpolicy="origin"
           loading="eager"
@@ -294,11 +305,33 @@ export class BoardWidgetFrameLifecycle {
   }
 
   private resetFailures(notify = true): void {
+    this.resetPresentation();
     this.frameProbeGeneration += 1;
     this.frameFailureKey = "";
     this.frameRefreshAttempts = 0;
     this.setError("", notify);
     this.sandboxHost?.reset();
+  }
+
+  private resetPresentation(): void {
+    window.cancelAnimationFrame(this.revealFrame);
+    this.revealFrame = 0;
+    this.contentVisible = false;
+  }
+
+  private revealContent(): void {
+    if (this.contentVisible || this.revealFrame) {
+      return;
+    }
+    // Apply the reported height before revealing the cross-origin frame; its
+    // compositor needs a paint opportunity at the final size to avoid a white flash.
+    this.revealFrame = window.requestAnimationFrame(() => {
+      this.revealFrame = window.requestAnimationFrame(() => {
+        this.revealFrame = 0;
+        this.contentVisible = true;
+        this.host.requestUpdate();
+      });
+    });
   }
 
   private refreshFailedFrame(widget: BoardWidget): void {
@@ -431,9 +464,15 @@ export class BoardWidgetFrameLifecycle {
       onUnauthorized: (currentWidget) => this.refreshFailedFrame(currentWidget),
       onReadyTimeout: () => this.refreshFailedFrame(widget),
       onLoaded: () => {
+        this.resetPresentation();
         this.frameFailureKey = "";
         this.frameRefreshAttempts = 0;
+        this.setError("", false);
+        this.host.requestUpdate();
+      },
+      onRendered: () => {
         this.setError("");
+        this.revealContent();
       },
       onError: (error) => {
         this.setError(formatUiError(error));

--- a/ui/src/components/canvas-widget-view.test.ts
+++ b/ui/src/components/canvas-widget-view.test.ts
@@ -101,7 +101,7 @@ describe("Canvas widget view", () => {
     expect(post).toHaveBeenCalledWith(
       expect.objectContaining({
         method: "ui/notifications/sandbox-resource-ready",
-        params: { html: documentView.html },
+        params: { html: documentView.html, renderId: expect.any(String) },
       }),
       "http://gateway.example:8444",
     );

--- a/ui/src/e2e/dashboard-fullscreen.e2e.test.ts
+++ b/ui/src/e2e/dashboard-fullscreen.e2e.test.ts
@@ -478,7 +478,7 @@ suite.define(() => {
           await gateway.setMethodResponse("board.get", {
             ...widgetSnapshot,
             revision: 2,
-            widgets: widgetSnapshot.widgets.map((widget) => ({ ...widget, revision: 2 })),
+            widgets: [{ ...widgetSnapshot.widgets[0], revision: 2 }],
           });
           await gateway.emitGatewayEvent("board.changed", { sessionKey, widget: "long-dashboard" });
           const replacement = page.frameLocator(".board-widget__frame").frameLocator("iframe");

--- a/ui/src/e2e/dashboard-fullscreen.e2e.test.ts
+++ b/ui/src/e2e/dashboard-fullscreen.e2e.test.ts
@@ -163,11 +163,14 @@ suite.define(() => {
       await document.locator("openclaw-board-view").waitFor();
 
       expect(await gateway.getRequests("sessions.resolve")).toHaveLength(1);
-      expect(await gateway.getRequests("sessions.describe")).toHaveLength(1);
+      expect(await gateway.getRequests("sessions.describe")).toHaveLength(0);
       expect(await gateway.getRequests("sessions.list")).toHaveLength(initialSessionListCount);
       expect(await page.locator("openclaw-app-shell").count()).toBe(0);
       expect(await page.locator(".agent-chat").count()).toBe(0);
-      expect((await gateway.getRequests("board.get"))[0]?.params).toEqual({ sessionKey });
+      expect((await gateway.getRequests("board.get"))[0]?.params).toEqual({
+        sessionKey,
+        agentId: "main",
+      });
       await document.getByRole("tab", { name: "Research" }).waitFor();
       const widget = document.locator('[data-widget-name="status"]');
       await widget.waitFor();
@@ -182,6 +185,7 @@ suite.define(() => {
       const grant = await gateway.waitForRequest("board.widget.grant");
       expect(grant.params).toEqual({
         sessionKey,
+        agentId: "main",
         name: "permissions",
         decision: "rejected",
         revision: 1,
@@ -265,7 +269,7 @@ suite.define(() => {
           viewport: { width: 393, height: 852 },
         },
         async ({ context, page }) => {
-          const widgetDocument = buildWidgetDocument(
+          let widgetDocument = buildWidgetDocument(
             "Nightly disk cleanup",
             `<style>
             .local-scroll{height:120px;overflow-y:auto}.local-row{height:40px}
@@ -282,14 +286,43 @@ suite.define(() => {
           ).join("")}</main>`,
           );
           const widgetUrl = `${suite.server.baseUrl}__widget/long-dashboard`;
+          const widgetSnapshot = {
+            ...boardSnapshot,
+            widgets: [
+              {
+                name: "long-dashboard",
+                tabId: "main",
+                title: "Nightly disk cleanup",
+                contentKind: "html",
+                sizeW: 12,
+                sizeH: 6,
+                position: 0,
+                grantState: "none",
+                revision: 1,
+                frameUrl: widgetUrl,
+                instanceId: "long-dashboard-instance",
+                viewTicket: "long-dashboard-ticket",
+                viewTicketTtlMs: 1_200_000,
+                viewGeneration: "long-dashboard-generation",
+                sandboxUrl: SANDBOX_HOST_PATH,
+                sandboxPort,
+                sandboxOrigin: `http://127.0.0.1:${sandboxPort}`,
+              },
+            ],
+          };
+          let releaseDocument!: () => void;
+          const documentGate = new Promise<void>((resolve) => {
+            releaseDocument = resolve;
+          });
           await page.route(widgetUrl, async (route) => {
+            await documentGate;
             await route.fulfill({
               body: widgetDocument,
               contentType: "text/html; charset=utf-8",
               status: 200,
             });
           });
-          await installMockGateway(page, {
+          const gateway = await installMockGateway(page, {
             sessionKey,
             featureMethods: ["board.get"],
             methodResponses: {
@@ -301,30 +334,7 @@ suite.define(() => {
                 boardFace: sessionRow.boardFace,
               },
               "sessions.describe": { session: sessionRow },
-              "board.get": {
-                ...boardSnapshot,
-                widgets: [
-                  {
-                    name: "long-dashboard",
-                    tabId: "main",
-                    title: "Nightly disk cleanup",
-                    contentKind: "html",
-                    sizeW: 12,
-                    sizeH: 6,
-                    position: 0,
-                    grantState: "none",
-                    revision: 1,
-                    frameUrl: widgetUrl,
-                    instanceId: "long-dashboard-instance",
-                    viewTicket: "long-dashboard-ticket",
-                    viewTicketTtlMs: 1_200_000,
-                    viewGeneration: "long-dashboard-generation",
-                    sandboxUrl: SANDBOX_HOST_PATH,
-                    sandboxPort,
-                    sandboxOrigin: `http://127.0.0.1:${sandboxPort}`,
-                  },
-                ],
-              },
+              "board.get": widgetSnapshot,
             },
           });
 
@@ -334,15 +344,31 @@ suite.define(() => {
             '.board-widget[data-widget-name="long-dashboard"] .board-widget__frame',
           );
           await frame.waitFor();
+          try {
+            await expect
+              .poll(() =>
+                page
+                  .frames()
+                  .some((candidate) => candidate.parentFrame()?.url().includes(SANDBOX_HOST_PATH)),
+              )
+              .toBe(true);
+            await page.screenshot({ path: `${suite.artifactDir}/dashboard-loading.png` });
+            expect(await frame.evaluate((element) => getComputedStyle(element).opacity)).toBe("0");
+            expect(await frame.getAttribute("inert")).toBe("");
+            await board.getByRole("status", { name: "Loading…", exact: true }).waitFor();
+          } finally {
+            releaseDocument();
+          }
+          await expect
+            .poll(() => frame.evaluate((element) => getComputedStyle(element).opacity))
+            .toBe("1");
+          expect(await frame.getAttribute("inert")).toBeNull();
+          expect(await board.getByRole("status", { name: "Loading…", exact: true }).count()).toBe(
+            0,
+          );
+          await page.screenshot({ path: `${suite.artifactDir}/dashboard-ready.png` });
           await expect
             .poll(() => board.evaluate((element) => element.scrollHeight > element.clientHeight))
-            .toBe(true);
-          await expect
-            .poll(() =>
-              page
-                .frames()
-                .some((candidate) => candidate.parentFrame()?.url().includes(SANDBOX_HOST_PATH)),
-            )
             .toBe(true);
           const embeddedFrame = page
             .frames()
@@ -443,6 +469,44 @@ suite.define(() => {
           expect(finalRowBox.y + finalRowBox.height).toBeLessThanOrEqual(
             finalBoardBox.y + finalBoardBox.height + 1,
           );
+
+          widgetDocument = buildWidgetDocument(
+            "Cleanup controls",
+            `<button style="position:fixed;top:24px;left:24px"
+              onclick="this.textContent='Cleanup requested'">Run cleanup</button>`,
+          );
+          await gateway.setMethodResponse("board.get", {
+            ...widgetSnapshot,
+            revision: 2,
+            widgets: widgetSnapshot.widgets.map((widget) => ({ ...widget, revision: 2 })),
+          });
+          await gateway.emitGatewayEvent("board.changed", { sessionKey, widget: "long-dashboard" });
+          const replacement = page.frameLocator(".board-widget__frame").frameLocator("iframe");
+          const cleanup = replacement.getByRole("button", { name: "Run cleanup", exact: true });
+          await cleanup.waitFor();
+          expect(
+            await replacement.locator("body").evaluate((body) => {
+              if (!(body instanceof HTMLElement)) {
+                throw new Error("Widget body is not an HTML element");
+              }
+              return Math.max(
+                body.scrollHeight,
+                body.offsetHeight,
+                body.getBoundingClientRect().height,
+              );
+            }),
+          ).toBe(0);
+          await expect
+            .poll(() => frame.evaluate((element) => getComputedStyle(element).opacity))
+            .toBe("1");
+          expect(await board.getByRole("status", { name: "Loading…", exact: true }).count()).toBe(
+            0,
+          );
+          await cleanup.click();
+          await replacement
+            .getByRole("button", { name: "Cleanup requested", exact: true })
+            .waitFor();
+          await page.screenshot({ path: `${suite.artifactDir}/dashboard-fixed-controls.png` });
         },
       );
     } finally {

--- a/ui/src/lib/board/widget-sandbox-host.test.ts
+++ b/ui/src/lib/board/widget-sandbox-host.test.ts
@@ -104,6 +104,7 @@ describe("BoardWidgetSandboxHost", () => {
     const fetchMock = vi.fn(async () => new Response("<!doctype html><p>weather</p>"));
     vi.stubGlobal("fetch", fetchMock);
     const onLoaded = vi.fn();
+    const onRendered = vi.fn();
     const host = new BoardWidgetSandboxHost({
       frame,
       widget: widget(),
@@ -118,6 +119,7 @@ describe("BoardWidgetSandboxHost", () => {
       onUnauthorized: vi.fn(),
       onReadyTimeout: vi.fn(),
       onLoaded,
+      onRendered,
       onError: vi.fn(),
     });
 
@@ -135,10 +137,35 @@ describe("BoardWidgetSandboxHost", () => {
     expect(postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         method: "ui/notifications/sandbox-resource-ready",
-        params: { html: "<!doctype html><p>weather</p>" },
+        params: { html: "<!doctype html><p>weather</p>", renderId: expect.any(String) },
       }),
       "https://sandbox.example",
     );
+    expect(onRendered).not.toHaveBeenCalled();
+    const { renderId } = postMessage.mock.calls[0]![0].params as { renderId: string };
+    const rendered = (
+      id: string,
+      source = frame.contentWindow,
+      origin = "https://sandbox.example",
+    ) =>
+      host.handleMessage(
+        new MessageEvent("message", {
+          source,
+          origin,
+          data: { method: "ui/notifications/sandbox-resource-loaded", params: { renderId: id } },
+        }),
+      );
+    rendered("stale-document");
+    rendered(renderId, window);
+    rendered(renderId, frame.contentWindow, "https://other.example");
+    expect(onRendered).not.toHaveBeenCalled();
+    rendered(renderId);
+    rendered(renderId);
+    expect(onRendered).toHaveBeenCalledOnce();
+    host.reset();
+    rendered(renderId);
+    expect(onRendered).toHaveBeenCalledOnce();
+    host.dispose();
   });
 
   it("delivers passive preview HTML without accepting its capability bridge", async () => {

--- a/ui/src/lib/board/widget-sandbox-host.timeout.test.ts
+++ b/ui/src/lib/board/widget-sandbox-host.timeout.test.ts
@@ -19,7 +19,7 @@ function widget(viewGeneration = "a".repeat(32)): BoardWidget {
   };
 }
 
-function createHost() {
+function createHost(waitForRender = false) {
   const frame = document.createElement("iframe");
   document.body.append(frame);
   const onLoadFailed = vi.fn();
@@ -37,6 +37,7 @@ function createHost() {
     onUnauthorized: vi.fn(),
     onReadyTimeout: vi.fn(),
     onLoaded,
+    onRendered: waitForRender ? vi.fn() : undefined,
     onError: vi.fn(),
   };
   const host = new BoardWidgetSandboxHost(options);
@@ -60,40 +61,53 @@ afterEach(() => {
 });
 
 describe("BoardWidgetSandboxHost document timeout", () => {
-  it.each(["headers", "body"] as const)("times out stalled %s delivery", async (phase) => {
-    vi.useFakeTimers();
-    vi.stubGlobal(
-      "fetch",
-      vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
-        const signal = init?.signal;
-        if (phase === "headers") {
-          return new Promise<Response>((_resolve, reject) => {
-            signal?.addEventListener("abort", () => reject(new Error("request aborted")));
-          });
-        }
-        return Promise.resolve(
-          new Response(
-            new ReadableStream({
-              start(controller) {
-                controller.enqueue(new TextEncoder().encode("<!doctype html>"));
-                signal?.addEventListener("abort", () =>
-                  controller.error(new Error("body aborted")),
-                );
-              },
-            }),
-          ),
+  it.each(["headers", "body", "render"] as const)(
+    "times out stalled %s delivery",
+    async (phase) => {
+      vi.useFakeTimers();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+          if (phase === "render") {
+            return Promise.resolve(new Response("<!doctype html><p>Waiting for a resource</p>"));
+          }
+          const signal = init?.signal;
+          if (phase === "headers") {
+            return new Promise<Response>((_resolve, reject) => {
+              signal?.addEventListener("abort", () => reject(new Error("request aborted")));
+            });
+          }
+          return Promise.resolve(
+            new Response(
+              new ReadableStream({
+                start(controller) {
+                  controller.enqueue(new TextEncoder().encode("<!doctype html>"));
+                  signal?.addEventListener("abort", () =>
+                    controller.error(new Error("body aborted")),
+                  );
+                },
+              }),
+            ),
+          );
+        }),
+      );
+      const { host, onLoadFailed, onLoaded, options } = createHost(phase === "render");
+
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      if (phase === "render") {
+        expect(onLoadFailed).not.toHaveBeenCalled();
+        expect(options.onError).toHaveBeenCalledWith(
+          expect.objectContaining({ message: expect.stringContaining("did not finish loading") }),
         );
-      }),
-    );
-    const { host, onLoadFailed, onLoaded } = createHost();
-
-    await vi.advanceTimersByTimeAsync(10_000);
-
-    expect(onLoadFailed).toHaveBeenCalledWith(widget());
-    expect(onLoadFailed).toHaveBeenCalledOnce();
-    expect(onLoaded).not.toHaveBeenCalled();
-    host.dispose();
-  });
+      } else {
+        expect(onLoadFailed).toHaveBeenCalledWith(widget());
+        expect(onLoadFailed).toHaveBeenCalledOnce();
+      }
+      expect(onLoaded).toHaveBeenCalledTimes(phase === "render" ? 1 : 0);
+      host.dispose();
+    },
+  );
 
   it.each(["generation", "client"] as const)(
     "keeps a replacement document after a %s change cancels a stalled load",

--- a/ui/src/lib/board/widget-sandbox-host.ts
+++ b/ui/src/lib/board/widget-sandbox-host.ts
@@ -1,5 +1,5 @@
 import { formatUiError } from "../format-error.ts";
-import { WidgetSandboxHost } from "../widget-sandbox-host.ts";
+import { WidgetRenderTimeoutError, WidgetSandboxHost } from "../widget-sandbox-host.ts";
 import type { BoardWidget } from "./types.ts";
 import type { BoardWidgetFrameUrl } from "./view-types.ts";
 import {
@@ -24,6 +24,7 @@ type BoardWidgetSandboxHostOptions = {
   onUnauthorized: (widget: BoardWidget) => void;
   onReadyTimeout: () => void;
   onLoaded: () => void;
+  onRendered?: () => void;
   onError: (error: unknown) => void;
 };
 
@@ -325,7 +326,12 @@ export class BoardWidgetSandboxHost {
         this.options.onLoaded();
         this.postHostInit();
       },
+      onRendered: options.onRendered ? () => this.options.onRendered?.() : undefined,
       onError: (error) => {
+        if (error instanceof WidgetRenderTimeoutError) {
+          this.options.onError(error);
+          return;
+        }
         if (error instanceof WidgetDocumentError) {
           if (error.kind === "unauthorized") {
             this.options.onUnauthorized(this.options.widget);

--- a/ui/src/lib/widget-sandbox-host.ts
+++ b/ui/src/lib/widget-sandbox-host.ts
@@ -1,6 +1,8 @@
 import { toStringifiedError } from "@openclaw/normalization-core";
+import { generateUUID } from "./uuid.ts";
 
 export const WIDGET_LOAD_TIMEOUT_MS = 10_000;
+export class WidgetRenderTimeoutError extends Error {}
 
 type WidgetSandboxHostOptions = {
   frame: HTMLIFrameElement;
@@ -9,6 +11,7 @@ type WidgetSandboxHostOptions = {
   documentKey: string;
   loadDocument: (signal: AbortSignal) => Promise<string>;
   onLoaded: () => void;
+  onRendered?: () => void;
   onError: (error: unknown) => void;
   onReadyTimeout: () => void;
 };
@@ -19,6 +22,7 @@ export class WidgetSandboxHost {
   private proxyReady = false;
   private readyTimer: number | null = null;
   private loadedDocumentKey: string | null = null;
+  private renderId: string | null = null;
   private pendingDocument: { key: string; html: string } | null = null;
   private activeLoad: { key: string; controller: AbortController; timeout: number } | null = null;
 
@@ -70,6 +74,8 @@ export class WidgetSandboxHost {
 
   reset(): void {
     this.cancelLoad();
+    this.clearReadyTimeout();
+    this.renderId = null;
     this.loadedDocumentKey = null;
     this.pendingDocument = null;
   }
@@ -82,9 +88,18 @@ export class WidgetSandboxHost {
   }
 
   handleMessage(event: MessageEvent): void {
+    if (event.source !== this.frame.contentWindow || event.origin !== this.options.sandboxOrigin) {
+      return;
+    }
+    if (event.data?.method === "ui/notifications/sandbox-resource-loaded") {
+      if (this.renderId && event.data?.params?.renderId === this.renderId) {
+        this.clearReadyTimeout();
+        this.renderId = null;
+        this.options.onRendered?.();
+      }
+      return;
+    }
     if (
-      event.source !== this.frame.contentWindow ||
-      event.origin !== this.options.sandboxOrigin ||
       event.data?.method !== "ui/notifications/sandbox-proxy-ready" ||
       event.data?.params?.sandboxUrl !== this.options.sandboxUrl
     ) {
@@ -121,13 +136,22 @@ export class WidgetSandboxHost {
   }
 
   private scheduleReadyTimeout(): void {
-    if (this.proxyReady || this.readyTimer !== null) {
+    if (
+      (this.proxyReady && (!this.renderId || !this.options.onRendered)) ||
+      this.readyTimer !== null
+    ) {
       return;
     }
     this.readyTimer = window.setTimeout(() => {
       this.readyTimer = null;
       if (this.active && !this.proxyReady && this.frame.isConnected) {
         this.retrySandboxFrame();
+      } else if (this.active && this.renderId && this.frame.isConnected) {
+        this.options.onError(
+          new WidgetRenderTimeoutError(
+            "Widget content did not finish loading. Reload the dashboard to try again.",
+          ),
+        );
       }
     }, WIDGET_LOAD_TIMEOUT_MS);
   }
@@ -202,11 +226,13 @@ export class WidgetSandboxHost {
     if (!this.active || !this.proxyReady || !document || !this.frame.isConnected) {
       return;
     }
+    this.renderId = generateUUID();
+    this.scheduleReadyTimeout();
     this.frame.contentWindow?.postMessage(
       {
         jsonrpc: "2.0",
         method: "ui/notifications/sandbox-resource-ready",
-        params: { html: document.html },
+        params: { html: document.html, renderId: this.renderId },
       },
       this.options.sandboxOrigin,
     );

--- a/ui/src/pages/chat/route-loader-short-resolve.ts
+++ b/ui/src/pages/chat/route-loader-short-resolve.ts
@@ -11,7 +11,10 @@ import {
 import type { ChatHistoryResult } from "./chat-history-snapshot.ts";
 import type { SessionRouteContext as ApplicationContext } from "./route-loader-context.ts";
 import { prepareChatRouteStartup } from "./route-startup.ts";
-export type SessionRoutePresentation = Pick<GatewaySessionRow, "key" | "displayName" | "boardFace">;
+export type SessionRoutePresentation = Pick<
+  GatewaySessionRow,
+  "key" | "agentId" | "displayName" | "boardFace"
+>;
 
 export type SessionReferenceResolution =
   | { kind: "not-found" }

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -234,6 +234,7 @@ function resolvedSessionRouteData(params: {
   return {
     kind: "session",
     sessionKey: params.row.key,
+    ...(params.row.agentId ? { agentId: params.row.agentId } : {}),
     ...sessionRouteHints(params.location),
     face,
     ...(params.shortId && params.shortId.length > 8 ? { shortId: params.shortId } : {}),

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -472,6 +472,8 @@ export async function loadChatRoute(
     return {
       kind: "session",
       sessionKey: cached.sessionKey,
+      // The connection-bound handoff has already validated this agent scope.
+      agentId: target.agentId,
       ...sessionRouteHints(routeLocation),
       face,
       ...(target.shortId.length > 8 ? { shortId: target.shortId } : {}),

--- a/ui/src/pages/chat/route-resolution-handoff.test.ts
+++ b/ui/src/pages/chat/route-resolution-handoff.test.ts
@@ -37,6 +37,7 @@ describe("session route navigation handoffs", () => {
       expect(loaded).toMatchObject({
         kind: "session",
         sessionKey: storedRow.key,
+        agentId: "roboclaw",
         canonicalLocation: {
           // Canonicalizes to the same short reference every other surface links to.
           pathname: `/${face}/roboclaw/default-mode-with-rare-surprises-12345678`,
@@ -47,7 +48,12 @@ describe("session route navigation handoffs", () => {
       }
       await expect(
         loadChatRoute(context, loaded.canonicalLocation, face, new AbortController().signal),
-      ).resolves.toMatchObject({ kind: "session", sessionKey: storedRow.key, face });
+      ).resolves.toMatchObject({
+        kind: "session",
+        sessionKey: storedRow.key,
+        agentId: "roboclaw",
+        face,
+      });
       expect(request).toHaveBeenCalledExactlyOnceWith("sessions.resolve", {
         reference: {
           key: "agent:roboclaw:default-mode-with-rare-surprises",

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -248,7 +248,12 @@ describe("gateway-backed session route resolution", () => {
         new AbortController().signal,
       );
 
-      expect(loaded).toMatchObject({ kind: "session", sessionKey: storedRow.key, face });
+      expect(loaded).toMatchObject({
+        kind: "session",
+        sessionKey: storedRow.key,
+        agentId: "roboclaw",
+        face,
+      });
       expect(loaded).not.toHaveProperty("canonicalLocation");
     }
   });
@@ -728,7 +733,11 @@ describe("gateway-backed session route resolution", () => {
   });
 
   it("resolves a cached literal without a gateway round-trip", async () => {
-    const literal = row({ key: "agent:roboclaw:standup", displayName: "Standup" });
+    const literal = row({
+      key: "agent:roboclaw:standup",
+      agentId: "roboclaw",
+      displayName: "Standup",
+    });
     const { context, list, request } = contextFor({ ok: false }, [literal]);
     const loaded = await loadChatRoute(
       context,
@@ -737,7 +746,11 @@ describe("gateway-backed session route resolution", () => {
       new AbortController().signal,
     );
 
-    expect(loaded).toMatchObject({ kind: "session", sessionKey: literal.key });
+    expect(loaded).toMatchObject({
+      kind: "session",
+      sessionKey: literal.key,
+      agentId: "roboclaw",
+    });
     expect(request).not.toHaveBeenCalled();
     expect(list).not.toHaveBeenCalled();
   });

--- a/ui/src/pages/chat/route.test.ts
+++ b/ui/src/pages/chat/route.test.ts
@@ -68,6 +68,7 @@ describe("loadChatRoute", () => {
     expect(redirected).toEqual({
       kind: "session",
       sessionKey,
+      agentId: "main",
       draft: "ship",
       face: "chat",
       canonicalLocation: {
@@ -89,7 +90,13 @@ describe("loadChatRoute", () => {
         "chat",
         signal,
       ),
-    ).resolves.toEqual({ kind: "session", sessionKey, draft: "ship", face: "chat" });
+    ).resolves.toEqual({
+      kind: "session",
+      sessionKey,
+      agentId: "main",
+      draft: "ship",
+      face: "chat",
+    });
     expect(list).not.toHaveBeenCalled();
     expect(request).toHaveBeenCalledOnce();
   });
@@ -131,6 +138,7 @@ describe("loadChatRoute", () => {
     ).resolves.toEqual({
       kind: "session",
       sessionKey: target.key,
+      agentId: "main",
       draft: undefined,
       face: "chat",
       shortId: "123456780a",
@@ -199,6 +207,7 @@ describe("loadChatRoute", () => {
       ).resolves.toEqual({
         kind: "session",
         sessionKey: expectedRow?.key,
+        agentId: candidate.agentId,
         draft: "ship",
         focusComposer: true,
         face: "dashboard",


### PR DESCRIPTION
Closes #139072
Related: #138860, #139055

## What Problem This Solves

Fixes an issue where focused dashboards show plain loading text, flash an empty white iframe, and visibly jump from the saved widget size to the content height. The focused route also repeats session discovery before requesting its board.

## Why This Change Was Made

Use the existing themed, reduced-motion-aware loading skeleton until the trusted sandbox reports that its current inner document has loaded. A fresh render ID distinguishes replacements and stale receipts; sizing and capability-bridge initialization retain their existing owners. Reveal follows a paint opportunity at the measured size, and the hidden frame is inert. Empty and fixed-position widgets also complete; a stalled document ends in the existing visible error surface instead of an endless refresh cycle. Standard MCP App resource requests without a render ID keep their existing notification flow.

The focused document reuses the resolved session key and agent owner through its existing prepared-session path, removing one serial sessions.describe request. Canonical reloads also retain the validated agent scope through the existing connection-bound navigation handoff. Unresolved routes keep their discovery path.

## User Impact

Dashboard loading stays themed and animated until the widget can be shown at its measured size. Keyboard focus cannot enter the hidden frame. Existing scrolling, grants, updates, and interaction remain available. Resolved focus links make one fewer serial RPC.

## Evidence

A live Chromium filmstrip reproduced loading text at 1.047 s, a white iframe around 2.403–2.772 s, and the expanded widget at 2.794 s. A second live attempt stalled while connecting, before dashboard data arrived, so no production latency improvement is claimed.

Controlled production-bundle runs used the same synthetic widget, 150 ms simulated RPC delay and 200 ms HTML delay. Each set had one warm-up and five measured loads; every loaded widget's Details button worked.

| Measurement | Baseline | Candidate round 1 | Candidate round 2 |
| --- | ---: | ---: | ---: |
| Median visible-widget time | 665 ms | 529 ms | 892 ms |
| Median unfinished-frame exposure | 357 ms | 0 ms | 0 ms |
| Visible widget-content height changes during startup | 1 | 0 | 0 |
| Extra sessions.describe requests | 1 | 0 | 0 |

Host contention produced substantial outliers, including a 6.13 s candidate load. Wall-clock speed is inconclusive; the eliminated RPC and visual transition improvements are consistent across all measured runs.

The existing fullscreen browser scenario now holds HTML delivery to verify loading, then checks mobile wheel/touch scrolling and replaces the document with zero-height fixed-position controls that remain clickable. The original code fails both the no-extra-describe and hidden-unfinished-frame expectations. Initial hosted CI exposed a no-map-spread lint error in the test fixture and an integration gap with the newly landed canonical-navigation handoff (#139055). Both are repaired; all 54 focused route/handoff cases and targeted lint pass, preserving the one-resolver path and agent scope. Focused route, board, shared sandbox, Canvas sibling, cancellation, timeout, source/origin, and stale-receipt tests pass; independent review covers the final candidate through P2.

No configuration, database, dependency, or Gateway protocol-version change. The sandbox render receipt is additive and presentation-only. Production delta is +89 lines; tests +133; docs +7. Production growth is for the missing document-render lifecycle and accessible loading presentation; it reuses the existing skeleton, prepared-session path, and timeout owner.

Before: the pending widget is blank.

![Before: blank pending dashboard widget](https://github.com/user-attachments/assets/a1b7fe76-c73f-42bb-af81-45621405c861)

After: the same pending widget uses the themed loading skeleton.

![After: themed dashboard loading skeleton](https://github.com/user-attachments/assets/25abd999-2b41-4db9-83f5-0c1555981d6e)
