### PR TITLE
improve: reduce temporary allocation in HTTP response streaming

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2795,7 +2795,7 @@ src/gateway/node-pairing-ssh-verify.ts	1
 src/gateway/node-registry-private.ts	1
 src/gateway/node-registry.ts	5
 src/gateway/openai-agent-run-usage.ts	1
-src/gateway/openai-http.ts	29
+src/gateway/openai-http.ts	28
 src/gateway/openresponses-http.ts	4
 src/gateway/operator-approval-snapshot.ts	4
 src/gateway/operator-approval-store.ts	8

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2998,10 +2998,17 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(repeatedContent).toBe("hihi");
       }
 
-      {
+      for (const { payloads, expected } of [
+        { payloads: [{ text: "hello" }], expected: "hello" },
+        { payloads: [{ text: "" }, {}], expected: "No response from OpenClaw." },
+        {
+          payloads: [{ text: "First." }, {}, { text: "" }, { text: "Second." }],
+          expected: "First.\n\nSecond.",
+        },
+      ]) {
         agentCommandMock.mockClear();
         agentCommandMock.mockResolvedValueOnce({
-          payloads: [{ text: "hello" }],
+          payloads,
         } as never);
 
         const fallbackRes = await postChatCompletions(port, {
@@ -3012,7 +3019,14 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(fallbackRes.status).toBe(200);
         const fallbackText = await fallbackRes.text();
         expect(fallbackText).toContain("[DONE]");
-        expect(fallbackText).toContain("hello");
+        const fallbackContent = parseSseDataLines(fallbackText)
+          .filter((data) => data !== "[DONE]")
+          .flatMap((data) => {
+            const chunk = JSON.parse(data) as { choices?: Array<{ delta?: { content?: string } }> };
+            return chunk.choices?.map((choice) => choice.delta?.content ?? "") ?? [];
+          })
+          .join("");
+        expect(fallbackContent).toBe(expected);
       }
 
       {
@@ -3323,70 +3337,69 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
   });
 
   it.each([
-    { astral: "😀", boundary: 255 },
-    { astral: "𐐷", boundary: 511 },
-  ])(
-    "keeps streamed tool-call arguments well-formed ($astral at UTF-16 boundary $boundary)",
-    async ({ astral, boundary }) => {
-      const argumentPrefix = '{"value":"';
-      const value = `${"a".repeat(boundary - argumentPrefix.length)}${astral}tail`;
-      const expectedArguments = JSON.stringify({ value });
-      expect(expectedArguments.indexOf(astral)).toBe(boundary);
+    { name: "empty arguments", expectedArguments: "" },
+    ...[
+      { astral: "😀", boundary: 255 },
+      { astral: "𐐷", boundary: 511 },
+    ].map(({ astral, boundary }) => ({
+      name: `${astral} at UTF-16 boundary ${boundary}`,
+      expectedArguments: JSON.stringify({
+        value: `${"a".repeat(boundary - '{"value":"'.length)}${astral}tail`,
+      }),
+    })),
+  ])("keeps streamed tool-call arguments well-formed ($name)", async ({ expectedArguments }) => {
+    agentCommandMock.mockClear();
+    agentCommandMock.mockResolvedValueOnce({
+      payloads: [{ text: "Calling the tool." }],
+      meta: {
+        stopReason: "tool_calls",
+        pendingToolCalls: [
+          {
+            id: "call_1",
+            name: "read_value",
+            arguments: expectedArguments,
+          },
+        ],
+      },
+    } as never);
 
-      agentCommandMock.mockClear();
-      agentCommandMock.mockResolvedValueOnce({
-        payloads: [{ text: "Calling the tool." }],
-        meta: {
-          stopReason: "tool_calls",
-          pendingToolCalls: [
-            {
-              id: "call_1",
-              name: "read_value",
-              arguments: expectedArguments,
-            },
-          ],
-        },
-      } as never);
+    const res = await postChatCompletions(enabledPort, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "read the value" }],
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
 
-      const res = await postChatCompletions(enabledPort, {
-        stream: true,
-        model: "openclaw",
-        messages: [{ role: "user", content: "read the value" }],
-      });
-      expect(res.status).toBe(200);
-      expect(res.headers.get("content-type")).toContain("text/event-stream");
+    const data = parseSseDataLines(await res.text());
+    expect(data.at(-1)).toBe("[DONE]");
 
-      const data = parseSseDataLines(await res.text());
-      expect(data.at(-1)).toBe("[DONE]");
+    const chunks = data
+      .filter((line) => line !== "[DONE]")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const choices = chunks.flatMap(
+      (chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [],
+    );
+    const argumentDeltas = choices
+      .flatMap((choice) => {
+        const delta = choice.delta as Record<string, unknown> | undefined;
+        return (delta?.tool_calls as Array<Record<string, unknown>> | undefined) ?? [];
+      })
+      .map((toolCall) => {
+        const toolFunction = toolCall.function as Record<string, unknown> | undefined;
+        return toolFunction?.arguments;
+      })
+      .filter((argumentsDelta): argumentsDelta is string => typeof argumentsDelta === "string");
 
-      const chunks = data
-        .filter((line) => line !== "[DONE]")
-        .map((line) => JSON.parse(line) as Record<string, unknown>);
-      const choices = chunks.flatMap(
-        (chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [],
+    expect(argumentDeltas.length).toBeGreaterThan(1);
+    for (const argumentsDelta of argumentDeltas) {
+      expect(new TextDecoder().decode(new TextEncoder().encode(argumentsDelta))).toBe(
+        argumentsDelta,
       );
-      const argumentDeltas = choices
-        .flatMap((choice) => {
-          const delta = choice.delta as Record<string, unknown> | undefined;
-          return (delta?.tool_calls as Array<Record<string, unknown>> | undefined) ?? [];
-        })
-        .map((toolCall) => {
-          const toolFunction = toolCall.function as Record<string, unknown> | undefined;
-          return toolFunction?.arguments;
-        })
-        .filter((argumentsDelta): argumentsDelta is string => typeof argumentsDelta === "string");
-
-      expect(argumentDeltas.length).toBeGreaterThan(1);
-      for (const argumentsDelta of argumentDeltas) {
-        expect(new TextDecoder().decode(new TextEncoder().encode(argumentsDelta))).toBe(
-          argumentsDelta,
-        );
-      }
-      expect(argumentDeltas.join("")).toBe(expectedArguments);
-      expect(JSON.parse(argumentDeltas.join(""))).toEqual({ value });
-      expect(choices.some((choice) => choice.finish_reason === "tool_calls")).toBe(true);
-    },
-  );
+    }
+    expect(argumentDeltas.join("")).toBe(expectedArguments);
+    expect(choices.some((choice) => choice.finish_reason === "tool_calls")).toBe(true);
+  });
 
   it(
     "sends an initial SSE chunk before a streaming agent run settles",

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -336,24 +336,6 @@ function writeAssistantFinishChunk(
   });
 }
 
-function splitArgumentsForStreaming(argumentsValue: string): string[] {
-  if (!argumentsValue) {
-    return [""];
-  }
-  const chunkSize = 256;
-  const chunks: string[] = [];
-  for (let start = 0; start < argumentsValue.length;) {
-    const end = avoidTrailingHighSurrogateBreak(
-      argumentsValue,
-      start,
-      Math.min(start + chunkSize, argumentsValue.length),
-    );
-    chunks.push(argumentsValue.slice(start, end));
-    start = end;
-  }
-  return chunks.length > 0 ? chunks : [""];
-}
-
 function writeAssistantToolCallsIncrementalChunks(
   res: ServerResponse,
   params: ChatCompletionStreamIdentity & {
@@ -380,7 +362,14 @@ function writeAssistantToolCallsIncrementalChunks(
       ],
     });
 
-    for (const argsDelta of splitArgumentsForStreaming(call.arguments)) {
+    // Empty arguments still produce a delta after the tool identity frame.
+    let start = 0;
+    do {
+      const end = avoidTrailingHighSurrogateBreak(
+        call.arguments,
+        start,
+        Math.min(start + 256, call.arguments.length),
+      );
       writeChatCompletionChunk(res, params, {
         choices: [
           {
@@ -389,7 +378,7 @@ function writeAssistantToolCallsIncrementalChunks(
               tool_calls: [
                 {
                   index,
-                  function: { arguments: argsDelta },
+                  function: { arguments: call.arguments.slice(start, end) },
                 },
               ],
             },
@@ -397,7 +386,8 @@ function writeAssistantToolCallsIncrementalChunks(
           },
         ],
       });
-    }
+      start = end;
+    } while (start < call.arguments.length);
   }
 }
 
@@ -718,18 +708,6 @@ function buildAgentPrompt(
 }
 
 function resolveAgentResponseText(result: unknown): string {
-  const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
-  if (!Array.isArray(payloads) || payloads.length === 0) {
-    return "No response from OpenClaw.";
-  }
-  const content = payloads
-    .map((p) => (typeof p.text === "string" ? p.text : ""))
-    .filter(Boolean)
-    .join("\n\n");
-  return content || "No response from OpenClaw.";
-}
-
-function resolveAgentResponseCommentary(result: unknown): string {
   const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
   if (!Array.isArray(payloads) || payloads.length === 0) {
     return "";
@@ -1103,7 +1081,7 @@ export async function handleOpenAiHttpRequest(
       }
 
       if (stopReason === "tool_calls" && pendingToolCalls && pendingToolCalls.length > 0) {
-        const commentary = resolveAgentResponseCommentary(result);
+        const commentary = resolveAgentResponseText(result);
         sendJson(res, 200, {
           id: runId,
           object: "chat.completion",
@@ -1128,7 +1106,7 @@ export async function handleOpenAiHttpRequest(
         });
         return true;
       }
-      const content = resolveAgentResponseText(result);
+      const content = resolveAgentResponseText(result) || "No response from OpenClaw.";
 
       sendJson(res, 200, {
         id: runId,
@@ -1391,7 +1369,7 @@ export async function handleOpenAiHttpRequest(
         if (!sawAssistantDelta) {
           // Final payloads own held prose; snapshots may replace provisional deltas.
           const commentary =
-            resolveAgentResponseCommentary(result) ||
+            resolveAgentResponseText(result) ||
             streamedAssistantText ||
             bufferedReplaceableAssistantContent;
           if (commentary) {
@@ -1412,9 +1390,8 @@ export async function handleOpenAiHttpRequest(
 
       if (!sawAssistantDelta) {
         const content =
-          resolveAgentResponseCommentary(result) ||
-          bufferedReplaceableAssistantContent ||
           resolveAgentResponseText(result) ||
+          bufferedReplaceableAssistantContent ||
           "No response from OpenClaw.";
 
         sawAssistantDelta = true;


### PR DESCRIPTION
## What Problem This Solves

The OpenAI-compatible HTTP endpoint materializes all tool-argument fragments before writing them and repeats payload-text projection when a streaming run produces no deltas. Large tool arguments and text-empty result cohorts make those transient allocations more noticeable. This is a maintainer-requested performance improvement.

## Why This Change Was Made

Write each argument slice directly through the existing SSE writer using the existing surrogate-safe boundary helper, preserving the initial identity frame and the empty argument frame. Consolidate the private payload projection while keeping ordinary missing-response placeholders with their callers and tool commentary allowed to stay empty.

## User Impact

The endpoint creates fewer temporary strings/arrays while emitting the same HTTP response bytes. Tool order, Unicode boundaries, finalized-commentary precedence, cancellation, terminal frames and usage stay unchanged. Production LOC: +15/-38 (net -23); tests: +76/-63 (net +13, including formatter reflow). No protocol, configuration, storage, dependency, or backpressure change.

## Evidence

- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/gateway/openai-http.test.ts`: 69 tests passed before, 70 after. These start an actual HTTP Gateway server with a mocked agent and exercise SDK decoding, cancellation, terminal/usage behavior, tool calls and finalized output. The extended table covers empty tool arguments and empty/mixed fallback payloads.
- Source-extracted owner benchmark: six wire fixtures (including empty, multiple, large and two astral-boundary arguments) have identical frame counts, byte counts and SHA-256 hashes before/after. Five fallback fixtures also match. The unchanged UTF-16 helper is included in extraction; the full HTTP suite separately covers endpoint lifecycle.
- Ten writes of a synthetic 4 MiB argument: sampled allocation 160,093,392 → 154,486,240 bytes (-3.50%). For 3,000 projections of 4,096 text-empty payloads: 197,433,136 → 98,751,616 bytes (-49.98%). Median first-argument-frame extra heap after requested GC: 706,232 → 1,000 bytes. These are large synthetic owner workloads in one sequential pair on a shared host, not a default-workload, whole-Gateway, idle-memory, RSS or latency claim.
- Formatting and `git diff --check` passed. Changed-check dry run selected core/coreTests; full type/lint/guards passed through the exact corrected-head CI and native hosted verification.
- Managed independent P2 autoreview completed scoped-clean with zero findings. Both files match the frozen measured/tested/reviewed hashes. No live model-provider request is claimed; HTTP wire behavior is proved with the existing real server fixtures.

CI follow-up: the first run correctly required shrinking the assertion baseline after the duplicate projection helper was deleted (`openai-http.ts: 28 < 29`). The sole bookkeeping follow-up changes that row from 29 to 28. The exact checker failed before and passed after (4,044 files, 12,219 assertions), and fresh managed P2 review was scoped-clean. No runtime/test bytes, unrelated baseline rows, checker policy or suppressions changed. Updated head `b0e93da0fc2216d329ff0656a9eaa44c1103369d` passed [CI 33966977873](https://github.com/openclaw/openclaw/actions/runs/33966977873) and [Workflow Sanity 33966977870](https://github.com/openclaw/openclaw/actions/runs/33966977870). Required `openclaw/ci-gate` is SUCCESS; the failed earlier aggregate was not reused.

Pre-merge verification: regenerated native review artifacts for the corrected head, `review-validate-artifacts`, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 139077` passed without rebase or runtime changes. The full [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/139077#issuecomment-5551875475) covers the corrected head and has no findings or before-merge requests.
