### PR TITLE
improve: classify package script changes once

### DIFF
--- a/scripts/changed-lanes.mts
+++ b/scripts/changed-lanes.mts
@@ -512,55 +512,37 @@ export function listStagedChangedPaths(cwd = process.cwd()) {
 function classifyPackageJsonChangeFromGit(params: PackageJsonGitParams) {
   try {
     const { before, after } = readPackageJsonBeforeAfter(params);
-    if (isLiveDockerPackageScriptOnlyChange(before, after)) {
-      return "liveDockerTooling";
-    }
-    return isPackageScriptOnlyChange(before, after) ? "tooling" : null;
+    return classifyPackageJsonScriptChange(before, after);
   } catch {
     return null;
   }
 }
 
-/**
- * Checks whether package scripts changed only live Docker script entries.
- * @internal Directly tested script implementation detail.
- */
-export function isLiveDockerPackageScriptOnlyChange(before: string, after: string): boolean {
+function classifyPackageJsonScriptChange(
+  before: string,
+  after: string,
+): "liveDockerTooling" | "tooling" | null {
   const beforePackage = parsePackageJson(before);
   const afterPackage = parsePackageJson(after);
   if (!beforePackage || !afterPackage) {
-    return false;
+    return null;
   }
-  const beforeAllowed = extractLiveDockerPackageScripts(beforePackage);
-  const afterAllowed = extractLiveDockerPackageScripts(afterPackage);
-  const beforeStripped = stripLiveDockerPackageScripts(beforePackage);
-  const afterStripped = stripLiveDockerPackageScripts(afterPackage);
-
-  return (
-    stableStringify(beforeStripped) === stableStringify(afterStripped) &&
-    stableStringify(beforeAllowed) !== stableStringify(afterAllowed)
-  );
-}
-
-/**
- * Checks whether package.json changes are limited to scripts.
- * @internal Directly tested script implementation detail.
- */
-export function isPackageScriptOnlyChange(before: string, after: string): boolean {
-  const beforePackage = parsePackageJson(before);
-  const afterPackage = parsePackageJson(after);
-  if (!beforePackage || !afterPackage) {
-    return false;
+  const { scripts: beforeScripts, ...beforeMetadata } = beforePackage;
+  const { scripts: afterScripts, ...afterMetadata } = afterPackage;
+  if (
+    stableStringify(beforeMetadata) !== stableStringify(afterMetadata) ||
+    stableStringify(isRecord(beforeScripts) ? beforeScripts : {}) ===
+      stableStringify(isRecord(afterScripts) ? afterScripts : {})
+  ) {
+    return null;
   }
-  const beforeScripts = extractPackageScripts(beforePackage);
-  const afterScripts = extractPackageScripts(afterPackage);
-  const beforeStripped = stripPackageScripts(beforePackage);
-  const afterStripped = stripPackageScripts(afterPackage);
-
-  return (
-    stableStringify(beforeStripped) === stableStringify(afterStripped) &&
-    stableStringify(beforeScripts) !== stableStringify(afterScripts)
-  );
+  // Coercing missing/non-record scripts to {} must not grant the narrower live-Docker lane.
+  return isRecord(beforeScripts) &&
+    isRecord(afterScripts) &&
+    stableStringify(withoutLiveDockerScripts(beforeScripts)) ===
+      stableStringify(withoutLiveDockerScripts(afterScripts))
+    ? "liveDockerTooling"
+    : "tooling";
 }
 
 function parsePackageJson(value: string) {
@@ -596,39 +578,10 @@ function readGitText(ref: string, filePath: string) {
   });
 }
 
-function extractLiveDockerPackageScripts(packageJson: Record<string, unknown>) {
-  const scripts = packageJson.scripts;
-  if (!isRecord(scripts)) {
-    return {};
-  }
+function withoutLiveDockerScripts(scripts: Record<string, unknown>) {
   return Object.fromEntries(
-    Object.entries(scripts).filter(([name]) => LIVE_DOCKER_PACKAGE_SCRIPT_RE.test(name)),
+    Object.entries(scripts).filter(([name]) => !LIVE_DOCKER_PACKAGE_SCRIPT_RE.test(name)),
   );
-}
-
-function stripLiveDockerPackageScripts(packageJson: Record<string, unknown>) {
-  const clone = structuredClone(packageJson);
-  const scripts = clone.scripts;
-  if (!isRecord(scripts)) {
-    return clone;
-  }
-  for (const name of Object.keys(scripts)) {
-    if (LIVE_DOCKER_PACKAGE_SCRIPT_RE.test(name)) {
-      delete scripts[name];
-    }
-  }
-  return clone;
-}
-
-function extractPackageScripts(packageJson: Record<string, unknown>) {
-  const scripts = packageJson.scripts;
-  return isRecord(scripts) ? scripts : {};
-}
-
-function stripPackageScripts(packageJson: Record<string, unknown>) {
-  const clone = structuredClone(packageJson);
-  delete clone.scripts;
-  return clone;
 }
 
 /**

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -20,8 +20,6 @@ import {
   detectChangedLanesForPaths,
   hasDeadcodeScannedSource,
   isChangedLaneTestPath,
-  isLiveDockerPackageScriptOnlyChange,
-  isPackageScriptOnlyChange,
   listChangedPathsFromGit,
   listStagedChangedPaths,
 } from "../../scripts/changed-lanes.mts";
@@ -107,14 +105,8 @@ function expectLanes(
   expect(lanes).toEqual({ ...createEmptyChangedLanes(), ...expected });
 }
 
-function parseChangedLaneOutput(output: string): {
-  paths: string[];
-  lanes: ReturnType<typeof createEmptyChangedLanes>;
-} {
-  return JSON.parse(output) as {
-    paths: string[];
-    lanes: ReturnType<typeof createEmptyChangedLanes>;
-  };
+function parseChangedLaneOutput(output: string): ReturnType<typeof detectChangedLanes> {
+  return JSON.parse(output) as ReturnType<typeof detectChangedLanes>;
 }
 
 function runChangedLanesCli(cwd: string, args: string[]) {
@@ -353,14 +345,14 @@ function createSyntheticMergeRepo(prefix: string): { dir: string; staleBase: str
 
 function classifyPackageJsonChange(
   prefix: string,
-  before: Record<string, unknown>,
-  after: Record<string, unknown>,
+  before: Record<string, unknown> | string,
+  after: Record<string, unknown> | string,
 ) {
   const dir = makeTempRepoRoot(tempDirs, prefix);
   git(dir, ["init", "-q", "--initial-branch=main"]);
-  writeRepoFile(dir, "package.json", prettyJson(before));
+  writeRepoFile(dir, "package.json", typeof before === "string" ? before : prettyJson(before));
   commitAll(dir, "initial");
-  writeRepoFile(dir, "package.json", prettyJson(after));
+  writeRepoFile(dir, "package.json", typeof after === "string" ? after : prettyJson(after));
 
   const output = execFileSync(
     process.execPath,
@@ -2207,121 +2199,115 @@ describe("scripts/changed-lanes", () => {
     expect(schedulerDryRun?.env?.OPENCLAW_DOCKER_ALL_LIVE_MODE).toBe("only");
   });
 
-  it("routes live Docker package script-only changes through the focused gate", () => {
-    const before = prettyJson({
-      name: "fixture",
-      scripts: { "test:docker:all": "node scripts/test-docker-all.mjs" },
-      dependencies: { leftpad: "1.0.0" },
-    });
-    const after = prettyJson({
-      name: "fixture",
-      scripts: {
-        "test:docker:all": "node scripts/test-docker-all.mjs",
-        "test:docker:live-acp-bind:droid":
-          "OPENCLAW_LIVE_ACP_BIND_AGENT=droid bash scripts/test-live-acp-bind-docker.sh",
-      },
-      dependencies: { leftpad: "1.0.0" },
-    });
-
-    expect(isLiveDockerPackageScriptOnlyChange(before, after)).toBe(true);
-
-    const result = detectChangedLanes(["package.json"], {
-      packageJsonChangeKind: "liveDockerTooling",
-    });
-    const plan = createChangedCheckPlan(result);
-
-    expectLanes(result.lanes, {
-      liveDockerTooling: true,
-    });
-    expect(plan.commands.map((command) => command.name)).toContain("live Docker scheduler dry run");
-  });
-
   it.each([
     {
-      name: "classifies live Docker package script changes from the git diff",
-      prefix: "openclaw-live-docker-package-",
-      before: {
-        name: "fixture",
-        scripts: { "test:docker:all": "node scripts/test-docker-all.mjs" },
-      },
+      name: "live Docker scripts",
+      before: { scripts: { "test:docker:all": "node scripts/test-docker-all.mjs" } },
       after: {
-        name: "fixture",
         scripts: {
           "test:docker:all": "node scripts/test-docker-all.mjs",
-          "test:docker:live-acp-bind:droid":
-            "OPENCLAW_LIVE_ACP_BIND_AGENT=droid bash scripts/test-live-acp-bind-docker.sh",
+          "test:docker:live-acp-bind:droid": "bash scripts/test-live-acp-bind-docker.sh",
         },
       },
       expected: { liveDockerTooling: true },
     },
     {
-      name: "classifies normal package script changes from the git diff",
-      prefix: "openclaw-package-scripts-",
-      before: {
-        name: "fixture",
-        scripts: { test: "node --import tsx scripts/test-projects.mts" },
-        dependencies: { leftpad: "1.0.0" },
-      },
+      name: "ordinary scripts with unchanged dependencies",
+      before: { scripts: { test: "node test.js" }, dependencies: { leftpad: "1.0.0" } },
       after: {
-        name: "fixture",
-        scripts: {
-          test: "node --import tsx scripts/test-projects.mts",
-          "test:profile": "node scripts/profile-tests.mjs",
-        },
+        scripts: { test: "node test.js", "test:profile": "node scripts/profile-tests.mjs" },
         dependencies: { leftpad: "1.0.0" },
       },
       expected: { tooling: true },
     },
-  ])("$name", ({ prefix, before, after, expected }) => {
-    const result = classifyPackageJsonChange(prefix, before, after);
-
-    expect(result.paths).toEqual(["package.json"]);
-    expectLanes(result.lanes, expected);
-  });
-
-  it("keeps non-script package changes off the live Docker focused gate", () => {
-    const before = prettyJson({
-      name: "fixture",
-      scripts: {},
-      dependencies: { leftpad: "1.0.0" },
-    });
-    const after = prettyJson({
-      name: "fixture",
-      scripts: {
-        "test:docker:live-acp-bind:droid":
-          "OPENCLAW_LIVE_ACP_BIND_AGENT=droid bash scripts/test-live-acp-bind-docker.sh",
+    {
+      name: "live and ordinary scripts together",
+      before: { scripts: {} },
+      after: { scripts: { "test:docker:live-models": "bash live.sh", test: "node test.js" } },
+      expected: { tooling: true },
+    },
+    {
+      name: "live scripts alongside a dependency change",
+      before: { scripts: {}, dependencies: { leftpad: "1.0.0" } },
+      after: {
+        scripts: { "test:docker:live-models": "bash live.sh" },
+        dependencies: { leftpad: "1.0.1" },
       },
-      dependencies: { leftpad: "1.0.1" },
-    });
+      expected: { releaseMetadata: true },
+    },
+    {
+      name: "empty scripts become live scripts",
+      before: { scripts: {} },
+      after: { scripts: { "test:docker:live-models": "bash live.sh" } },
+      expected: { liveDockerTooling: true },
+    },
+    {
+      name: "removal of the last live script",
+      before: { scripts: { "test:docker:live-models": "bash live.sh" } },
+      after: { scripts: {} },
+      expected: { liveDockerTooling: true },
+    },
+    ...[
+      { name: "absent scripts", before: {} },
+      { name: "null scripts", before: { scripts: null } },
+      { name: "array scripts", before: { scripts: [] } },
+      { name: "scalar scripts", before: { scripts: false } },
+    ].map(({ name, before }) => ({
+      name: `${name} become live scripts`,
+      before,
+      after: { scripts: { "test:docker:live-models": "bash live.sh" } },
+      expected: { tooling: true },
+    })),
+    {
+      name: "removal of the scripts property",
+      before: { scripts: { "test:docker:live-models": "bash live.sh" } },
+      after: {},
+      expected: { tooling: true },
+    },
+    {
+      name: "equivalent empty scripts",
+      before: { scripts: null },
+      after: { scripts: {} },
+      expected: { releaseMetadata: true },
+    },
+    {
+      name: "JSON formatting and key order only",
+      before: '{"scripts":{"test":"node test.js"},"name":"fixture"}',
+      after: { name: "fixture", scripts: { test: "node test.js" } },
+      expected: { releaseMetadata: true },
+    },
+    {
+      name: "non-record package root",
+      before: { scripts: { test: "node test.js" } },
+      after: "[]",
+      expected: { releaseMetadata: true },
+    },
+    {
+      name: "invalid package JSON",
+      before: { scripts: {} },
+      after: '{"scripts":',
+      expected: { releaseMetadata: true },
+    },
+  ])(
+    "classifies $name through the Git CLI and changed-check plan",
+    ({ before, after, expected }) => {
+      const result = classifyPackageJsonChange("openclaw-package-scripts-", before, after);
+      const plan = createChangedCheckPlan(result);
 
-    expect(isLiveDockerPackageScriptOnlyChange(before, after)).toBe(false);
-  });
-
-  it("routes package script-only changes through the tooling gate", () => {
-    const before = prettyJson({
-      name: "fixture",
-      scripts: { test: "node test.js" },
-      dependencies: { leftpad: "1.0.0" },
-    });
-    const after = prettyJson({
-      name: "fixture",
-      scripts: { test: "node test.js", "test:profile": "node scripts/profile-tests.mjs" },
-      dependencies: { leftpad: "1.0.0" },
-    });
-
-    expect(isPackageScriptOnlyChange(before, after)).toBe(true);
-
-    const result = detectChangedLanes(["package.json"], {
-      packageJsonChangeKind: "tooling",
-    });
-    const plan = createChangedCheckPlan(result);
-
-    expectLanes(result.lanes, {
-      tooling: true,
-    });
-    expect(plan.commands.map((command) => command.args[0])).toContain("lint:scripts");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("tsgo:all");
-  });
+      expect(result.paths).toEqual(["package.json"]);
+      expectLanes(result.lanes, expected);
+      expect(
+        plan.commands.some((command) => command.name === "live Docker scheduler dry run"),
+      ).toBe(result.lanes.liveDockerTooling);
+      if (result.lanes.tooling) {
+        expect(plan.commands.map((command) => command.args[0])).toContain("lint:scripts");
+        expect(plan.commands.map((command) => command.args[0])).not.toContain("tsgo:all");
+      }
+      if (result.lanes.releaseMetadata) {
+        expect(plan.commands.map((command) => command.name)).toContain("release metadata guard");
+      }
+    },
+  );
 
   it("keeps release metadata commits off the full changed gate", () => {
     const result = detectChangedLanes([


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Choosing the appropriate checks for package-script edits does avoidable work before local verification begins.

## Why This Change Was Made

Use one private classifier to parse each package once, compare its non-script metadata once, and select the existing live-Docker, ordinary-tooling or fallback classification. This removes two test-only exports, duplicate projections and deep clones while preserving the distinction between missing/non-record scripts and an empty scripts record; Git selection, error handling and the downstream release-metadata guard stay unchanged.

Production code shrinks by **47 lines** (23 added, 70 removed). Tests shrink by **14 lines** (98 added, 112 removed) while moving the old predicate assertions into **15 real Git CLI and check-plan cases**. The broader CLI coverage adds executions; fewer test lines do not imply faster tests.

## User Impact

Developers receive the same check plans from a smaller classifier. Measured gains apply to the package-classification component and vary by input and execution order. This PR does not claim a Gateway speedup or faster complete CLI launches.

## Evidence

- The same complete changed-lanes suite passed **326/326 cases before and 326/326 after**, including all 15 package-script CLI cases, on macOS with Node 26.8.1 and Vitest 4.1.11. Cases cover live/ordinary/mixed changes, missing/non-record/empty scripts, removal, metadata drift and malformed JSON. The CLI facade, real synthetic Git repositories and check-plan owner are exercised. Functional-run durations are not benchmark evidence.
- The normal **21-stage changed-file gate** passed once, including script/root-test typechecks, targeted lint, formatting and maintained guards. No test, gate or measurement was retried to obtain a better result.
- Independent source reviews informed the cleanup; both managed review chunks found no actionable P0–P2 findings.
- A fixed before/candidate/candidate/before cohort measured the complete exported `detectChangedLanesForPaths` operation with real staged HEAD/index reads: **592 calls including proof, 256 batch means and 106 comparisons**. Complete outputs, key order, input preservation and fresh returned ownership were checked. All **40 adverse comparisons** were retained and the arithmetic was independently checked. No numerical acceptance threshold was prescribed.

Median component changes, kept separate for the two execution orders:

| Input | Forward | Reverse |
| --- | ---: | ---: |
| Ordinary script edit | −8.27% (−1.93 ms) | −8.97% (−2.10 ms) |
| Live-Docker script edit | **+2.75% (+0.59 ms)** | −2.93% (−0.64 ms) |
| Metadata-only edit | −18.26% (−4.62 ms) | −11.06% (−2.53 ms) |
| No-package control | +8.08% (+62 ns) | −4.05% (−31 ns) |

The live-Docker row classifies an inert script name; it executes no Docker task or provider request. The unchanged control's means and p95 worsened in both orders. Forward metadata individual maximum worsened **37.83%**, and its batch p95 worsened **2.94%**. Batch p95 is the maximum of 16 batch means, a coarse observation distinct from individual-call tails.

Whole native-host time improved **8.06%** forward but worsened **33.00%** in reverse. The reverse candidate's fixture setup was **1.172 seconds slower**; that observation remains included without an inferred cause or exclusion. Imports also slowed in both orders. Sampled tree peak RSS fell **14.56% / 16.63%**, while several heap snapshots worsened, so no universal memory or startup improvement is claimed. Host setup/import/validation, component calls and external dispatch-to-join durations remain distinct measurements. The functional and numerical evidence is local; it does not establish Linux CI results.
