### PR TITLE
improve: reduce session navigation and name lookup work

### DIFF
--- a/src/agents/sessions/session-manager-codec.test.ts
+++ b/src/agents/sessions/session-manager-codec.test.ts
@@ -98,9 +98,11 @@ describe("session manager codec compatibility", () => {
         parentId: "invalid-model",
         message: { role: "user", content: "valid descendant" },
       },
+      { type: "session_info", id: "invalid-name", parentId: "after", name: 42 },
     ]);
 
     expect(manager.getEntries().map((entry) => entry.type)).toEqual(["message", "message"]);
+    expect(manager.getSessionName()).toBeUndefined();
     expect(manager.buildSessionContext()).toEqual({
       messages: [{ role: "user", content: "valid descendant" }],
       thinkingLevel: "off",
@@ -121,6 +123,31 @@ describe("session manager codec compatibility", () => {
       parseOpaqueLeafEntry({ type: "leaf", id: "leaf1", parentId: null, targetId: null }),
     ).toEqual({ id: "leaf1", parentId: null, targetId: null });
     expect(parseOpaqueLeafEntry({ type: "leaf", id: "leaf1", parentId: null })).toBeUndefined();
+  });
+
+  it("preserves the original parent fallback for an opaque compaction keep marker", () => {
+    const manager = SessionManager.fromEntries([
+      {
+        type: "session",
+        version: CURRENT_SESSION_VERSION,
+        id: "self-parent-compaction",
+        cwd: "/tmp",
+      },
+      { type: "future", id: "opaque-root", parentId: null },
+      {
+        type: "compaction",
+        id: "compaction",
+        parentId: "compaction",
+        summary: "summary",
+        firstKeptEntryId: "opaque-root",
+        tokensBefore: 1,
+      },
+    ]);
+
+    expect(manager.getEntry("compaction")).toMatchObject({
+      parentId: null,
+      firstKeptEntryId: "compaction",
+    });
   });
 });
 

--- a/src/agents/sessions/session-manager-core.ts
+++ b/src/agents/sessions/session-manager-core.ts
@@ -210,7 +210,6 @@ export class SessionManagerCore extends SessionEntryNavigation<SessionEntry> {
   }
 
   protected override normalizeEntryParent(entry: SessionEntry): SessionEntry {
-    const parentId = this.resolveEntryParentId(entry);
     let normalized = super.normalizeEntryParent(entry);
     const boundedFirstKept = this.boundedFirstKeptById.get(normalized.id);
     if (
@@ -233,7 +232,7 @@ export class SessionManagerCore extends SessionEntryNavigation<SessionEntry> {
           normalized.parentId,
         ) ??
         this.findFirstCanonicalDescendant(normalized.firstKeptEntryId) ??
-        parentId;
+        this.resolveEntryParentId(entry);
       if (firstKeptEntryId && firstKeptEntryId !== normalized.firstKeptEntryId) {
         normalized = { ...normalized, firstKeptEntryId };
       }

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -290,11 +290,11 @@ export class SessionManagerEntries extends SessionManagerPersistence {
   }
 
   getSessionName(): string | undefined {
-    const entry = this.fileEntries.findLast(
+    const sessionInfo = this.fileEntries.findLast(
       (entry): entry is SessionInfoEntry =>
         entry.type === "session_info" && this.byId.has(entry.id),
     );
-    return entry?.name?.trim() || undefined;
+    return sessionInfo?.name?.trim() || undefined;
   }
 
   appendCustomMessageEntry(

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -290,12 +290,11 @@ export class SessionManagerEntries extends SessionManagerPersistence {
   }
 
   getSessionName(): string | undefined {
-    for (const entry of this.getEntries().toReversed()) {
-      if (entry.type === "session_info") {
-        return entry.name?.trim() || undefined;
-      }
-    }
-    return undefined;
+    const entry = this.fileEntries.findLast(
+      (entry): entry is SessionInfoEntry =>
+        entry.type === "session_info" && this.byId.has(entry.id),
+    );
+    return entry?.name?.trim() || undefined;
   }
 
   appendCustomMessageEntry(

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -720,12 +720,31 @@ describe("SessionManager.open", () => {
     ).toMatchObject([{ content: "root" }, { content: "side middle" }, { content: "side leaf" }]);
   });
 
-  it("normalizes session names to one line", () => {
+  it.each([
+    { label: "missing", names: [], expected: undefined, rewind: false },
+    {
+      label: "single-line normalized",
+      names: ["  first\nsecond\r\nthird  "],
+      expected: "first second third",
+      rewind: false,
+    },
+    { label: "cleared", names: ["old name", "  "], expected: undefined, rewind: false },
+    {
+      label: "off-branch latest",
+      names: ["old name", "latest name"],
+      expected: "latest name",
+      rewind: true,
+    },
+  ])("reads $label session names", ({ names, expected, rewind }) => {
     const manager = SessionManager.inMemory();
-
-    manager.appendSessionInfo("  first\nsecond\r\nthird  ");
-
-    expect(manager.getSessionName()).toBe("first second third");
+    const root = manager.appendMessage({ role: "user", content: "root", timestamp: 1 });
+    for (const name of names) {
+      manager.appendSessionInfo(name);
+    }
+    if (rewind) {
+      manager.branch(root);
+    }
+    expect(manager.getSessionName()).toBe(expected);
   });
 
   it("ignores opaque SQLite rows while resolving the session cwd", async () => {


### PR DESCRIPTION
## What Problem This Solves

Session navigation resolves parent ancestry twice for ordinary entries, and reading a session name materializes and normalizes the full transcript before reversing it. Long session histories therefore do unnecessary allocation work for these routine reads. This is a maintainer-requested performance improvement.

## Why This Change Was Made

Resolve the original entry's parent only when the compaction/reset fallback needs it. Read the last indexed name record directly in file order, preserving blank-name clearing, names outside the selected branch and rejection of invalid legacy metadata. The existing shared navigation and transcript owners remain canonical.

## User Impact

Session branch and display-name reads avoid redundant work while returning the same results. No storage, schema, configuration or protocol changes. Production LOC: +6/-8 (net -2); tests: +51/-5 (net +46).

## Evidence

- `node scripts/run-vitest.mjs src/agents/sessions/session-manager.test.ts src/agents/sessions/session-manager-codec.test.ts src/agents/embedded-agent-runner/transcript-file-state.test.ts`: 64 tests passed before and 68 after. Added cases preserve missing/normalized/cleared/off-branch names, rejected legacy metadata and original-parent fallback for opaque compaction markers. These are preservation tests for a behavior-neutral refactor.
- Actual `SessionManager.fromEntries` benchmark: 20,000 linked synthetic user entries plus a trailing name, five warmups and forty measured reads. Three fresh processes per arm/workload; all twelve output hashes match. Construction/import are excluded from timing.
- Median branch sampled allocation: 304.73 → 187.64 MiB (-38.42%); wall 131.10 → 90.87 ms. Median name sampled allocation: 267.28 → 0.042 MiB; wall 133.55 → 0.087 ms. Candidate name timing approaches instrumentation overhead. Arms were sequential on a shared host, allocation sampling includes collected objects and RSS was mixed; these are synthetic owner-operation results, not retained-memory, whole-Gateway RSS or provider-latency proof.
- Formatting, `git diff --check` and changed-check classification passed. Exact-head CI [33967458478](https://github.com/openclaw/openclaw/actions/runs/33967458478), including the required `openclaw/ci-gate`, and Workflow Sanity [33967458513](https://github.com/openclaw/openclaw/actions/runs/33967458513) passed. Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 139080` verified those hosted gates; Testbox was not applicable for this scope.
- Managed independent P2 review was scoped-clean with zero findings, and all four committed files are verified against its frozen source hashes. No full build, standalone Gateway or model-provider run is claimed.

CI follow-up: the first head hit `eslint(no-shadow)` because the selected name record and `findLast` callback both used `entry`. The follow-up renames only the outer result and its return reference to `sessionInfo`. Targeted lint failed before and passed after, five detached-session outputs are byte-identical, the four name tests pass, and fresh managed P2 review is scoped-clean. No predicate, selection, source ordering, tests or storage behavior changed. Original allocation measurements remain historical for the same algorithm; no new performance result is claimed for this binding rename. Corrected head `5486ac464242a8ecc14fbd78149110862a589ec9` passed the fresh exact-head CI and native gates linked above. The latest ClawSweeper review reports no findings or pre-merge moves.
