### PR TITLE
fix(sqlite): release cached statement with its database owner

### DIFF
--- a/src/state/openclaw-state-db-cache.retention.test.ts
+++ b/src/state/openclaw-state-db-cache.retention.test.ts
@@ -1,0 +1,60 @@
+import { spawnSync } from "node:child_process";
+import { afterEach, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+it("releases closed shared database wrappers after path and global retirement", () => {
+  const stateDir = tempDirs.make("openclaw-state-retention-");
+  const moduleUrl = new URL("./openclaw-state-db.ts", import.meta.url).href;
+  const script = `
+    import assert from "node:assert/strict";
+    import {
+      closeOpenClawStateDatabase,
+      closeOpenClawStateDatabaseByPath,
+      openOpenClawStateDatabase,
+    } from ${JSON.stringify(moduleUrl)};
+
+    function retire(byPath) {
+      const owner = openOpenClawStateDatabase();
+      const ref = new WeakRef(owner.db);
+      for (let i = 0; i < 3; i++) {
+        assert.equal(openOpenClawStateDatabase(), owner);
+      }
+      if (byPath) {
+        assert.equal(closeOpenClawStateDatabaseByPath(owner.path), true);
+      } else {
+        closeOpenClawStateDatabase();
+      }
+      assert.equal(owner.db.isOpen, false);
+      return ref;
+    }
+    const refs = [retire(true), retire(false)];
+    for (let i = 0; i < 30; i++) {
+      await new Promise(setImmediate);
+      globalThis.gc();
+    }
+    process.stdout.write(JSON.stringify(refs.map(ref => ref.deref() === undefined)));
+  `;
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--disable-warning=ExperimentalWarning",
+      "--expose-gc",
+      "--import",
+      "tsx",
+      "--input-type=module",
+      "--eval",
+      script,
+    ],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      encoding: "utf8",
+      timeout: 20_000,
+    },
+  );
+  expect(result.stderr).toBe("");
+  expect(result.status).toBe(0);
+  expect(JSON.parse(result.stdout)).toEqual([true, true]);
+});

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -14,8 +14,10 @@ import { createOpenClawDatabaseVerificationError } from "./openclaw-state-db-mai
 import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 
 const cachedDatabases = new Map<string, OpenClawStateDatabase>();
+// Statements retain their native database; key by the plain lifecycle owner so
+// removing that owner releases the statement instead of rooting its own weak key.
 const cachedDataVersionStatements = new WeakMap<
-  DatabaseSync,
+  OpenClawStateDatabase,
   ReturnType<DatabaseSync["prepare"]>
 >();
 const cachedDataVersions = new WeakMap<DatabaseSync, number>();
@@ -31,10 +33,10 @@ function notifyOpenClawStateDatabaseLifecycle(event: OpenClawStateDatabaseLifecy
   }
 }
 
-function readSqliteDataVersion(database: DatabaseSync): number {
+function readSqliteDataVersion(database: OpenClawStateDatabase): number {
   let statement = cachedDataVersionStatements.get(database);
   if (!statement) {
-    statement = database /* sqlite-allow-raw -- Connection-local schema compatibility counter. */
+    statement = database.db /* sqlite-allow-raw -- Connection-local schema compatibility counter. */
       .prepare("PRAGMA data_version");
     cachedDataVersionStatements.set(database, statement);
   }
@@ -114,7 +116,7 @@ const terminalOpenLatch = createSqliteTerminalOpenLatch({
 /** Publish a fully opened handle and bind query corruption to its exact cache owner. */
 function publishOpenClawStateDatabase(database: OpenClawStateDatabase): OpenClawStateDatabase {
   const { db, path: pathname } = database;
-  cachedDataVersions.set(db, readSqliteDataVersion(db));
+  cachedDataVersions.set(db, readSqliteDataVersion(database));
   cachedDatabases.set(pathname, database);
   notifyOpenClawStateDatabaseLifecycle({ kind: "opened", database });
   registerNodeSqliteKyselyQueryErrorHandler(db, (error) => {
@@ -139,7 +141,7 @@ function getOpenClawStateDatabaseRuntimeFailure(pathname: string): Error | undef
     return undefined;
   }
   try {
-    const dataVersion = readSqliteDataVersion(cached.db);
+    const dataVersion = readSqliteDataVersion(cached);
     if (cachedDataVersions.get(cached.db) === dataVersion) {
       return undefined;
     }


### PR DESCRIPTION
## Summary

Closed shared-state database wrappers remained reachable through the cached `PRAGMA data_version` statement. The WeakMap used the native database as its key, while Node's statement wrapper itself retained that database—even after SQLite finalized the statement during close.

Key the statement by the existing plain database-owner record. Retiring that owner now releases the cached statement and native wrapper. Warm reads still reuse one prepared statement, and the existing close, failure, eviction, schema-fence, and external-commit behavior stays with the same lifecycle owner. No schema, stored representation, configuration, or retention change.

## Validation

- The new public-opener regression fails on the baseline for both path-specific and global close, and passes with the fix.
- 44 focused tests and the full changed-file gate pass. Independent review found no P0–P2 findings.
- Seven actual-source native lifecycle scenarios compare baseline and candidate: path/global close, stale retirement, eviction, newer-schema rejection, native-close failure/retry, and maintenance-close failure/retry. All non-GC observations match; collected database and statement wrappers change from 0/7 to 7/7. Warm reuse, compatible external commits, latched error identity, integrity, and foreign-key checks pass.
- A real built Gateway completed two startup/shutdown cycles, actual `tasks.list` RPCs, a nonempty four-flow CLI inventory, and exact fresh-process database readback after restart. Owned processes and synthetic state were cleaned up.

The live harness initially required every observed handle to receive an explicit close. The extra handle was traced to the existing terminal boot-outcome write after server close and immediately before process exit; the final proof records this lifecycle without forcing Gateway GC or adding closes. Native wrapper reachability is measured separately. No file-descriptor, RSS, heap-size, or latency improvement is claimed.

Production: +7/-5 (net +2, the explanatory comment); tests: +60. The fix replaces the cache key and its callers rather than adding another cleanup path.
