### PR TITLE
fix(ui): keep stopped historical browser panels on Start

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -169,6 +169,11 @@ blocked it or its address could not be verified. Select another tab, enter an
 allowed address, or refresh after a temporary lookup failure. Blocked URLs stay
 hidden; displaying a tab title does not grant access to its contents.
 
+Following a historical tab never starts a stopped managed browser: a fresh
+launch cannot contain that tab. The panel shows **Start browser** instead, and
+preview cards keep their title and URL without a thumbnail until the browser
+is running again.
+
 ## Configuration
 
 Browser settings live in `~/.openclaw/openclaw.json`.
@@ -471,6 +476,9 @@ instead, and remote CDP profiles use the browser behind `cdpUrl`.
 ## Local vs remote control
 
 - **Local control (default):** the Gateway starts the loopback control service and can launch a local browser.
+  Only targetless actions (`open`, `navigate`, `openclaw browser start`) launch it. Actions that name a
+  tab by `targetId`, tab id, or label never start a stopped browser, because a new browser cannot
+  contain that tab; they fail with `Browser profile "<name>" is not running` until it is started.
 - **Remote control (node host):** run a node host on the machine that has the browser; the Gateway proxies browser actions to it.
 - **Remote CDP:** set `browser.profiles.<name>.cdpUrl` (or `browser.cdpUrl`) to
   attach to a remote Chromium-based browser. In this case, OpenClaw will not launch a local browser.

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -171,8 +171,8 @@ hidden; displaying a tab title does not grant access to its contents.
 
 Following a historical tab never starts a stopped managed browser: a fresh
 launch cannot contain that tab. The panel shows **Start browser** instead, and
-preview cards keep their title and URL without a thumbnail until the browser
-is running again.
+preview cards keep their title and URL without a thumbnail when that target
+is unavailable. Click **Start browser** to launch the browser and show its current tabs.
 
 ## Configuration
 
@@ -476,9 +476,9 @@ instead, and remote CDP profiles use the browser behind `cdpUrl`.
 ## Local vs remote control
 
 - **Local control (default):** the Gateway starts the loopback control service and can launch a local browser.
-  Only targetless actions (`open`, `navigate`, `openclaw browser start`) launch it. Actions that name a
+  Targetless actions can launch it (for example, `open`, `navigate`, or `openclaw browser start`). Actions that name a
   tab by `targetId`, tab id, or label never start a stopped browser, because a new browser cannot
-  contain that tab; they fail with `Browser profile "<name>" is not running` until it is started.
+  contain that tab; start the browser or open a new tab, then select a current target.
 - **Remote control (node host):** run a node host on the machine that has the browser; the Gateway proxies browser actions to it.
 - **Remote CDP:** set `browser.profiles.<name>.cdpUrl` (or `browser.cdpUrl`) to
   attach to a remote Chromium-based browser. In this case, OpenClaw will not launch a local browser.

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -546,7 +546,7 @@ export class BrowserPanelController implements ReactiveController {
     const previous = { targetId: this.activeTargetId, view: this.view };
     this.invalidateViewOperations();
     const epoch = this.operations.epoch;
-    this.setState("activeTargetId", targetId);
+    this.setState("activeTargetId", route ? null : targetId);
     this.setState("view", null);
     this.exitCaptureModes();
     if (!route && this.clearUnavailableView()) {

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -554,15 +554,10 @@ export class BrowserPanelController implements ReactiveController {
     }
     const focused = await this.runAction(async (actionClient) => {
       if (route) {
-        // Listing is safe for blocked tabs; focus is not. Resolve the alias and
-        // current access observation before attempting to activate the target.
+        // Listing can observe stopped or blocked tabs; focus needs a running,
+        // accessible tab. A historical target cannot survive a browser restart.
         await this.refreshTabsOnly(actionClient, () => this.operations.isLive(epoch, actionClient));
-        if (!this.operations.isLive(epoch, actionClient)) {
-          return;
-        }
-        // A stopped browser cannot hold a historical tab. Keep the Start affordance
-        // instead of reporting the doomed focus request as an error.
-        if (this.running === false) {
+        if (!this.operations.isLive(epoch, actionClient) || this.running === false) {
           return;
         }
         const selected = this.tabs.find((tab) => tab.id === targetId || tab.targetId === targetId);

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -557,11 +557,11 @@ export class BrowserPanelController implements ReactiveController {
         // Listing can observe stopped or blocked tabs; focus needs a running,
         // accessible tab. A historical target cannot survive a browser restart.
         await this.refreshTabsOnly(actionClient, () => this.operations.isLive(epoch, actionClient));
-        if (!this.operations.isLive(epoch, actionClient) || this.running === false) {
+        if (!this.operations.isLive(epoch, actionClient)) {
           return;
         }
         const selected = this.tabs.find((tab) => tab.id === targetId || tab.targetId === targetId);
-        this.setState("activeTargetId", selected?.id ?? targetId);
+        this.setState("activeTargetId", this.running === false ? null : (selected?.id ?? targetId));
         if (this.clearUnavailableView()) {
           return;
         }

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -560,6 +560,11 @@ export class BrowserPanelController implements ReactiveController {
         if (!this.operations.isLive(epoch, actionClient)) {
           return;
         }
+        // A stopped browser cannot hold a historical tab. Keep the Start affordance
+        // instead of reporting the doomed focus request as an error.
+        if (this.running === false) {
+          return;
+        }
         const selected = this.tabs.find((tab) => tab.id === targetId || tab.targetId === targetId);
         this.setState("activeTargetId", selected?.id ?? targetId);
         if (this.clearUnavailableView()) {

--- a/ui/src/components/browser/browser-panel-route.test.ts
+++ b/ui/src/components/browser/browser-panel-route.test.ts
@@ -219,7 +219,7 @@ describe("browser panel route handoff", () => {
 
   it("leaves a stopped browser on its Start affordance instead of focusing a historical tab", async () => {
     let running = false;
-    const routedRefresh = createDeferred<void>();
+    const routedRefresh = createDeferred();
     let pauseRefresh = false;
     const gateway = createBrowserClient(async (request) => {
       if (request.path === "/tabs") {

--- a/ui/src/components/browser/browser-panel-route.test.ts
+++ b/ui/src/components/browser/browser-panel-route.test.ts
@@ -219,8 +219,13 @@ describe("browser panel route handoff", () => {
 
   it("leaves a stopped browser on its Start affordance instead of focusing a historical tab", async () => {
     let running = false;
+    const routedRefresh = createDeferred<void>();
+    let pauseRefresh = false;
     const gateway = createBrowserClient(async (request) => {
       if (request.path === "/tabs") {
+        if (pauseRefresh) {
+          await routedRefresh.promise;
+        }
         return running
           ? {
               running: true,
@@ -256,6 +261,16 @@ describe("browser panel route handoff", () => {
       'button[aria-label="Reload"]',
     );
     expect(reload?.disabled).toBe(true);
+
+    pauseRefresh = true;
+    chooseCard(panel, { ...hostTab, targetId: "dead-target" });
+    try {
+      await panel.updateComplete;
+      expect(reload?.disabled).toBe(true);
+    } finally {
+      routedRefresh.resolve();
+    }
+    await flushBrowserResponses();
 
     start?.click();
     await waitForFast(() => expect(pageTitle(panel)).toBe("managed"));

--- a/ui/src/components/browser/browser-panel-route.test.ts
+++ b/ui/src/components/browser/browser-panel-route.test.ts
@@ -252,6 +252,10 @@ describe("browser panel route handoff", () => {
     expect(controllerFor(panel).errorText).toBeNull();
     const start = panel.shadowRoot?.querySelector<HTMLButtonElement>(".bp-btn");
     expect(start?.textContent?.trim()).toBe("Start browser");
+    const reload = panel.shadowRoot?.querySelector<HTMLButtonElement>(
+      'button[aria-label="Reload"]',
+    );
+    expect(reload?.disabled).toBe(true);
 
     start?.click();
     await waitForFast(() => expect(pageTitle(panel)).toBe("managed"));

--- a/ui/src/components/browser/browser-panel-route.test.ts
+++ b/ui/src/components/browser/browser-panel-route.test.ts
@@ -217,6 +217,48 @@ describe("browser panel route handoff", () => {
     expect(pageTitle(panel)).toBe("work");
   });
 
+  it("leaves a stopped browser on its Start affordance instead of focusing a historical tab", async () => {
+    let running = false;
+    const gateway = createBrowserClient(async (request) => {
+      if (request.path === "/tabs") {
+        return running
+          ? {
+              running: true,
+              tabs: [createBrowserPanelTestTab("t1", "https://managed.example/", "managed")],
+            }
+          : { running: false, tabs: [] };
+      }
+      if (request.path === "/start") {
+        running = true;
+        return { ok: true };
+      }
+      if (request.path === "/screenshot") {
+        return { path: "/fresh.png", targetId: "raw-t1", url: "https://managed.example/" };
+      }
+      if (request.path === "/act") {
+        return createBrowserPanelTestMetrics("https://managed.example/", "managed");
+      }
+      return { ok: true };
+    });
+    const panel = await mountPanel(gateway.client, false);
+    panel.preferredTab = { tab: { ...hostTab, targetId: "dead-target" }, revision: "stale" };
+    panel.presented = true;
+    await waitForFast(() => expect(controllerFor(panel).running).toBe(false));
+    await panel.updateComplete;
+
+    const paths = () =>
+      gateway.request.mock.calls.map(([, value]) => (value as BrowserRequestEnvelope).path);
+    expect(paths()).toEqual(["/tabs"]);
+    expect(controllerFor(panel).errorText).toBeNull();
+    const start = panel.shadowRoot?.querySelector<HTMLButtonElement>(".bp-btn");
+    expect(start?.textContent?.trim()).toBe("Start browser");
+
+    start?.click();
+    await waitForFast(() => expect(pageTitle(panel)).toBe("managed"));
+    expect(paths()).toEqual(expect.arrayContaining(["/start", "/screenshot"]));
+    expect(paths()).not.toContain("/tabs/focus");
+  });
+
   it("keeps a raw target selection when its stable tab alias is not the first tab", async () => {
     const gateway = browserGateway();
     const panel = await mountPanel(gateway.client, false);


### PR DESCRIPTION
Related: #138999. Follow-up to #139064. The running-browser passive-focus change in #134480 remains separate.

## What Problem This Solves

Opening historical browser results while the managed browser is stopped showed `Browser request failed: browser not running` above **Start browser**. The panel tried to focus an old target after `/tabs` had already reported `running: false`.

## Why This Change Was Made

The selection owner now keeps routed targets unselected until the tab snapshot arrives, and leaves no selected target when the browser is stopped. The existing no-target path skips focus and capture, and Reload stays disabled. The existing Start action launches the browser and refreshes its current tabs.

This also covers selecting the same historical card while its next tab snapshot is pending. Historical title/URL remain visible. No configuration, storage, protocol, or plugin SDK change.

## User Impact

Stopped historical sessions show the normal **Start browser** state without a red error. Explicit Start and valid running-tab focus, screenshots, and thumbnails still work.

## Evidence

Real Linux Control UI, Gateway, and managed Chromium; no mocked Gateway or browser responses. A transparent observer recorded browser request/response traffic.

- Baseline: `a4514a0aff9de7bd299f70d821398df606df1a4f`. `/tabs` returned stopped, followed by failed `/tabs/focus` and the visible red note.
- Candidate: `2f045f307099833ebc5b843f5ca29a7e837c19f1`. Stopped history and repeated card selection sent no focus/capture after the stopped snapshot. Reload stayed disabled, including during the pending snapshot.
- Clicking Start launched Chromium and populated the panel. A valid historical tab then focused and captured successfully, with a live thumbnail. A fresh client after browser stop returned to clean Start without launching Chromium.
- The card's independent thumbnail attempt can precede the stopped snapshot; this change does not suppress that separate metadata-preview path.

| Current main | Repaired |
| --- | --- |
| ![Stopped history shows a red focus error](https://github.com/user-attachments/assets/05273162-b9b0-4473-8f0b-b4f8c25e6c93) | ![Stopped history shows clean Start with Reload disabled](https://github.com/user-attachments/assets/4c1da4c8-8446-4c87-81d2-a2255b7926d6) |

Additional inspected captures: [explicit Start](https://github.com/user-attachments/assets/28d6e23f-bc38-46bb-9524-2ebb38ca2716), [running tab and thumbnail](https://github.com/user-attachments/assets/7cccc5bc-7b00-4824-827e-a24f4b0aa519), [fresh-client reconnect](https://github.com/user-attachments/assets/26e37209-16a8-450d-9e0e-f72c676e4d25).

Validation:

- `node scripts/run-vitest.mjs ui/src/components/browser ui/src/lib/chat/browser-tab-preview.test.ts ui/src/pages/chat/components/browser-tab-card.test.ts` — 127 tests passed; the final test-only cleanup reran all 13 route tests.
- The regression failed on current main for extra focus/capture requests. Intermediate candidates also failed the added stopped and pending Reload assertions before their owner-state repairs.
- Pinned formatting, scoped type-aware lint, source ratchets, `git diff --check`, and the combined `pnpm build ciArtifacts` passed.
- [CI for the published head](https://github.com/openclaw/openclaw/actions/runs/33970832010).

Production +4/-4 (net 0); tests +61; docs +8. Contributor intent and ancestry retained.

Proof scope: real managed-browser flow on Linux; host/node route siblings have deterministic test coverage. A separate running-tab capture-cancellation timeout occurred during overlapping refresh/stale-card testing; its capture path is unchanged here and is retained as a follow-up, not claimed fixed by this PR.
