### PR TITLE
fix(test): keep provider teardown deadline tests from wedging their shard

### DIFF
--- a/src/gateway/worker-environments/provider-destroy-timeout.test.ts
+++ b/src/gateway/worker-environments/provider-destroy-timeout.test.ts
@@ -1,19 +1,21 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { racePromiseWithAbortSignal } from "../../infra/abort-signal.js";
 import * as support from "./service.test-support.js";
 
 describe("worker provider teardown deadlines", () => {
   support.setupWorkerEnvironmentServiceSuite();
 
-  it.each(["destroy", "bootstrap-failure"] as const)(
+  it.for(["destroy", "bootstrap-failure"] as const)(
     "allows provider-owned checkpointing beyond five minutes during %s",
-    async (entrance) => {
+    async (entrance, { signal }) => {
       const started = createDeferred();
       const finish = createDeferred();
       const destroy = vi.fn(async () => {
         started.resolve();
-        await finish.promise;
+        // A test timeout does not unwind finally; release provider ownership on cancellation.
+        await racePromiseWithAbortSignal(finish.promise, signal);
       });
       const resolveDestroyTimeoutMs = vi.fn(() => 10 * 60_000);
       if (entrance === "destroy") {
@@ -43,7 +45,7 @@ describe("worker provider teardown deadlines", () => {
         },
       );
       try {
-        await started.promise;
+        await support.waitForFast(() => started.promise);
         await vi.advanceTimersByTimeAsync(5 * 60_000 + 1);
         expect(settled).toBe(false);
         finish.resolve();
@@ -63,6 +65,7 @@ describe("worker provider teardown deadlines", () => {
         }
       } finally {
         finish.resolve();
+        vi.useRealTimers();
         await operation;
       }
     },
@@ -123,14 +126,16 @@ describe("worker provider teardown deadlines", () => {
     },
   );
 
-  it("keeps timed-out teardown queued and rejects a stale owner before retry side effects", async () => {
+  it("keeps timed-out teardown queued and rejects a stale owner before retry side effects", async ({
+    signal,
+  }) => {
     const initial = support.seedReady("timed-out-destroy");
     const started = createDeferred();
     const finish = createDeferred();
     const resolveDestroyTimeoutMs = vi.fn(() => 20);
     const destroy = vi.fn(async () => {
       started.resolve();
-      await finish.promise;
+      await racePromiseWithAbortSignal(finish.promise, signal);
     });
     const service = support.createService(
       support.createProvider({ destroy, resolveDestroyTimeoutMs }),
@@ -139,7 +144,7 @@ describe("worker provider teardown deadlines", () => {
     const first = service.destroy(initial.environmentId).catch((error: unknown) => error);
     let second: Promise<unknown> | undefined;
     try {
-      await started.promise;
+      await support.waitForFast(() => started.promise);
       await vi.advanceTimersByTimeAsync(21);
       expect(await first).toMatchObject({ code: "provider_failure" });
       expect(support.testState.store.get(initial.environmentId)?.lastError).toBe(
@@ -163,6 +168,7 @@ describe("worker provider teardown deadlines", () => {
       expect(destroy).toHaveBeenCalledOnce();
     } finally {
       finish.resolve();
+      vi.useRealTimers();
       await first;
       await second;
     }

--- a/src/gateway/worker-environments/service.test-support.ts
+++ b/src/gateway/worker-environments/service.test-support.ts
@@ -151,8 +151,9 @@ export function setupWorkerEnvironmentServiceSuite() {
   });
 
   afterEach(async () => {
-    await testState.service?.stop();
+    // Shutdown may schedule cleanup after a test leaves fake timers installed.
     vi.useRealTimers();
+    await testState.service?.stop();
     closeOpenClawStateDatabaseForTest();
     await fs.rm(testState.root, { recursive: true, force: true });
   });


### PR DESCRIPTION
## What Problem This Solves

`src/gateway/worker-environments/provider-destroy-timeout.test.ts` ("allows provider-owned checkpointing beyond five minutes during destroy/bootstrap-failure") failed four times on main CI today (runs [33959274889](https://github.com/openclaw/openclaw/actions/runs/33959274889), [33960371295](https://github.com/openclaw/openclaw/actions/runs/33960371295), [33961192294](https://github.com/openclaw/openclaw/actions/runs/33961192294), [33962562919](https://github.com/openclaw/openclaw/actions/runs/33962562919)), each time as a 120s test timeout followed by a 180s hook timeout that wedged the whole shard.

## Why This Change Was Made

Two lifetime defects amplified any slow turn into a shard wedge:

1. The provider mock awaited an unresolved `finish.promise` whose only release was the test body's `finally`. Vitest's watchdog aborts the test context but does not unwind a suspended async body, so a timed-out test kept the provider held — and `afterEach`'s `service.stop()` correctly joined it while fake timers were still installed, hanging the hook too.
2. `await started.promise` waited for mock readiness without advancing fake timers, so any chain progress that requires a timer turn deadlocks permanently.

The fix awaits mock readiness through the existing timer-aware `waitForFast`, races held mocks against the test cancellation signal (`racePromiseWithAbortSignal`), and restores real timers before draining operations and before `service.stop()` in the shared fixture. All assertions and the five-minute checkpointing semantics are unchanged; production code is untouched.

## User Impact

No user-facing change — test robustness only. Main CI stops losing the `checks-node-compact-large-1` shard to this wedge.

## Evidence

- Synthetic fault injection reproduces the exact CI signature on the original code (test timeout + hook timeout) and passes with the fix: a zero-delay timer inserted before mock readiness deadlocks the original and passes with `waitForFast`; a suspended test cancellation wedges the original hooks and unwinds cleanly with the patch.
- 30/30 local file invocations pass (300 cases), including five under extra CPU load.
- Linux CI-shard replay on Blacksmith Testbox (`tbx_01m1rr5m48gzwx01nhhk44es9w`): the exact gateway-core-3 file set, 182 files / 3,397 tests passed.
- Honest limit: the *initiating* CI stall was not reproduced naturally, so this is hardening against the observed failure mode, not a proven root-cause elimination. The synthetic probes cover precisely the two mechanisms that produce the observed signature. If the stall recurs, the follow-up is phase-boundary instrumentation in the non-isolated worker (recorded in the investigation notes).

## Checklist

- [x] Tests updated/added
- [x] No production code changed
