### PR TITLE
fix(gateway): prevent queued startup work after shutdown begins

### DIFF
--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -3522,6 +3522,176 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(hoisted.startGmailWatcherWithLogs).not.toHaveBeenCalled();
   });
 
+  it.each(["direct close", "restart drain"] as const)(
+    "retires queued producers during %s before received work permits sidecar cleanup",
+    async (boundary) => {
+      vi.useFakeTimers();
+      const postReadyWork = createDeferred();
+      const received = createDeferred();
+      const connectionWork = new GatewayConnectionWork();
+      const events: string[] = [];
+      const cleanupOwner = {
+        stop: vi.fn(() => {
+          events.push("cleanup");
+        }),
+      };
+      const config: OpenClawConfig = {
+        hooks: {
+          enabled: true,
+          internal: { enabled: false },
+          gmail: { account: "fixture@example.test", model: "openai/gpt-5.4" },
+        },
+        transcripts: {
+          autoStart: [{ providerId: "discord-voice", guildId: "g", channelId: "c" }],
+        },
+      };
+      hoisted.hasInternalHookListeners.mockReturnValueOnce(true);
+      hoisted.resolveHooksGmailModel.mockReturnValueOnce({ provider: "openai", model: "gpt-5.4" });
+      const trackStartupWork: PostAttachParams["trackStartupWork"] = (run) => {
+        const operation = Promise.resolve().then(() => run(connectionWork.signal));
+        return connectionWork.track(() => operation);
+      };
+      const params = createPostAttachParams({
+        cfgAtStart: config,
+        gatewayPluginConfigAtStart: config,
+        sidecarStartup: "defer",
+        isClosing: () => connectionWork.isClosing,
+        waitForPostReadyWork: () => postReadyWork.promise,
+        trackStartupWork,
+      });
+      const runtime = await startGatewayPostAttachRuntime(
+        params,
+        createPostAttachRuntimeDeps({ startGatewaySidecars }),
+      );
+      let closing: Promise<void> | undefined;
+      try {
+        await vi.advanceTimersByTimeAsync(100);
+        await runtime.startupSettled;
+        adoptSidecars(publishedGatewayLifetimeSidecars, [cleanupOwner]);
+        void connectionWork.track(async () => {
+          events.push("received");
+          await received.promise;
+          events.push("received-completed");
+        });
+        connectionWork.beginClose();
+        if (boundary === "restart drain") {
+          markGatewayRestartDraining();
+        }
+        await runtime.stopGatewayUpdateCheck();
+        closing = connectionWork.drain().then(async () => {
+          events.push("drained");
+          await stopTrackedSidecars(publishedGatewayLifetimeSidecars);
+          await stopTrackedSidecars(publishedPostReadySidecars);
+        });
+        postReadyWork.resolve();
+        await vi.advanceTimersByTimeAsync(1_000);
+        await vi.dynamicImportSettled();
+
+        expect.soft(hoisted.startGmailWatcherWithLogs).not.toHaveBeenCalled();
+        expect.soft(hoisted.loadModelCatalog).not.toHaveBeenCalled();
+        expect.soft(hoisted.transcriptsAutoStartService.start).not.toHaveBeenCalled();
+        expect.soft(hoisted.triggerInternalHook).not.toHaveBeenCalled();
+        expect.soft(params.log.warn).not.toHaveBeenCalled();
+        expect.soft(params.logHooks.warn).not.toHaveBeenCalled();
+        expect(events).toEqual(["received"]);
+        expect(cleanupOwner.stop).not.toHaveBeenCalled();
+
+        received.resolve();
+        await closing;
+        expect(events).toEqual(["received", "received-completed", "drained", "cleanup"]);
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+      } finally {
+        postReadyWork.resolve();
+        received.resolve();
+        await runtime.startupSettled;
+        await closing;
+        await runtime.stopGatewayUpdateCheck();
+        await stopTrackedSidecars(publishedGatewayLifetimeSidecars);
+        await stopTrackedSidecars(publishedPostReadySidecars);
+        await connectionWork.drain();
+      }
+    },
+  );
+
+  it("rechecks a queued Control UI producer after suspension admission resumes", async () => {
+    vi.useFakeTimers();
+    const suspension = tryBeginGatewaySuspendAdmission(() => {});
+    expect(suspension?.commit()).toBe(true);
+    const postReadyWork = createDeferred();
+    let closing = false;
+    const startAssets = vi.fn(async () => {});
+    const stopAssets = vi.fn(async () => {});
+    const runtime = await startGatewayPostAttachRuntime(
+      createPostAttachParams({
+        sidecarStartup: "defer",
+        isClosing: () => closing,
+        waitForPostReadyWork: () => postReadyWork.promise,
+        controlUiRootLifecycle: {
+          state: { kind: "preparing" },
+          setEnabled: vi.fn(),
+          start: startAssets,
+          stop: stopAssets,
+        },
+      }),
+      createPostAttachRuntimeDeps(),
+    );
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      expect(startAssets).not.toHaveBeenCalled();
+      closing = true;
+      suspension?.release();
+      await vi.advanceTimersByTimeAsync(100);
+      await runtime.startupSettled;
+      expect(startAssets).not.toHaveBeenCalled();
+      expect(stopAssets).not.toHaveBeenCalled();
+    } finally {
+      suspension?.release();
+      postReadyWork.resolve();
+      await vi.advanceTimersByTimeAsync(100);
+      await runtime.startupSettled;
+      await runtime.stopGatewayUpdateCheck();
+      await stopTrackedSidecars(publishedGatewayLifetimeSidecars);
+    }
+    expect(stopAssets).toHaveBeenCalledOnce();
+  });
+
+  it("reports an admitted startup hook failure during close before its sidecar stops", async () => {
+    vi.useFakeTimers();
+    const hook = createDeferred();
+    const failure = new Error("admitted startup hook failed");
+    let closing = false;
+    hoisted.hasInternalHookListeners.mockReturnValueOnce(true);
+    hoisted.triggerInternalHook.mockReturnValueOnce(hook.promise);
+    const params = createPostAttachParams();
+    const result = await startGatewaySidecars({
+      cfg: params.cfgAtStart,
+      pluginRegistry: params.pluginRegistry,
+      defaultWorkspaceDir: params.defaultWorkspaceDir,
+      deps: params.deps,
+      startChannels: params.startChannels,
+      shouldCreatePostReadySidecars: () => !closing,
+      log: params.log,
+      logHooks: params.logHooks,
+      logChannels: params.logChannels,
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(250);
+      expect(hoisted.triggerInternalHook).toHaveBeenCalledOnce();
+      closing = true;
+      hook.reject(failure);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(params.logHooks.warn).toHaveBeenCalledExactlyOnceWith(
+        `gateway startup hook failed: ${String(failure)}`,
+      );
+    } finally {
+      hook.resolve();
+      await Promise.allSettled([hook.promise]);
+      for (const sidecar of result.postReadySidecars) {
+        await stopTrackedSidecar(sidecar);
+      }
+    }
+  });
+
   it("logs post-ready Gmail watcher failures without delaying sidecar readiness", async () => {
     const log = { warn: vi.fn() };
     hoisted.startGmailWatcherWithLogs.mockRejectedValueOnce(new Error("boom"));
@@ -3586,60 +3756,71 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(hoisted.startGmailWatcherWithLogs).not.toHaveBeenCalled();
   });
 
-  it("cancels a post-ready Gmail watcher after the immediate enters", async () => {
-    let releaseImport: (() => void) | undefined;
-    vi.doMock("../hooks/gmail-watcher-lifecycle.js", async () => {
-      await new Promise<void>((resolve) => {
-        releaseImport = resolve;
+  it.each(["sidecar stop", "close prelude"] as const)(
+    "cancels a post-ready Gmail watcher after the immediate enters through %s",
+    async (boundary) => {
+      let releaseImport: (() => void) | undefined;
+      let closing = false;
+      vi.doMock("../hooks/gmail-watcher-lifecycle.js", async () => {
+        await new Promise<void>((resolve) => {
+          releaseImport = resolve;
+        });
+        return {
+          startGmailWatcherWithLogs: hoisted.startGmailWatcherWithLogs,
+        };
       });
-      return {
-        startGmailWatcherWithLogs: hoisted.startGmailWatcherWithLogs,
-      };
-    });
-    vi.resetModules();
-    try {
-      const { startGatewaySidecars: startGatewaySidecarsWithDelayedImport } =
-        await import("./server-startup-post-attach.js");
-
-      const result = adoptPostReadyResult(
-        await startGatewaySidecarsWithDelayedImport({
-          cfg: {
-            hooks: { enabled: true, internal: { enabled: false }, gmail: { account: "me" } },
-          } as never,
-          pluginRegistry: createPostAttachParams().pluginRegistry,
-          defaultWorkspaceDir: "/tmp/openclaw-workspace",
-          deps: {} as never,
-          startChannels: vi.fn(async () => {}),
-          log: { warn: vi.fn() },
-          logHooks: {
-            info: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-          },
-          logChannels: {
-            info: vi.fn(),
-            error: vi.fn(),
-          },
-        }),
-      );
-
-      await waitForGatewayTestState(() => {
-        expect(releaseImport).toBeDefined();
-      });
-      for (const sidecar of result.postReadySidecars) {
-        await stopTrackedSidecar(sidecar);
-      }
-      releaseImport?.();
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-
-      expect(hoisted.startGmailWatcherWithLogs).not.toHaveBeenCalled();
-    } finally {
-      vi.doUnmock("../hooks/gmail-watcher-lifecycle.js");
       vi.resetModules();
-    }
-  });
+      try {
+        const { startGatewaySidecars: startGatewaySidecarsWithDelayedImport } =
+          await import("./server-startup-post-attach.js");
+
+        const result = adoptPostReadyResult(
+          await startGatewaySidecarsWithDelayedImport({
+            cfg: {
+              hooks: { enabled: true, internal: { enabled: false }, gmail: { account: "me" } },
+            } as never,
+            pluginRegistry: createPostAttachParams().pluginRegistry,
+            defaultWorkspaceDir: "/tmp/openclaw-workspace",
+            deps: {} as never,
+            startChannels: vi.fn(async () => {}),
+            shouldCreatePostReadySidecars: () => !closing,
+            log: { warn: vi.fn() },
+            logHooks: {
+              info: vi.fn(),
+              warn: vi.fn(),
+              error: vi.fn(),
+            },
+            logChannels: {
+              info: vi.fn(),
+              error: vi.fn(),
+            },
+          }),
+        );
+
+        await waitForGatewayTestState(() => {
+          expect(releaseImport).toBeDefined();
+        });
+        if (boundary === "sidecar stop") {
+          for (const sidecar of result.postReadySidecars) {
+            await stopTrackedSidecar(sidecar);
+          }
+        } else {
+          closing = true;
+        }
+        releaseImport?.();
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+
+        expect(hoisted.startGmailWatcherWithLogs).not.toHaveBeenCalled();
+      } finally {
+        releaseImport?.();
+        await vi.dynamicImportSettled();
+        vi.doUnmock("../hooks/gmail-watcher-lifecycle.js");
+        vi.resetModules();
+      }
+    },
+  );
 
   it("runs Gmail model validation after sidecars are ready", async () => {
     hoisted.resolveHooksGmailModel.mockReturnValueOnce({
@@ -4258,6 +4439,96 @@ describe("startGatewayPostAttachRuntime", () => {
       ],
     });
   });
+
+  it.each(["suspension", "backend readiness", "manager import", "reconciliation"] as const)(
+    "retires unstarted ACP reconciliation when close wins during %s",
+    async (boundary) => {
+      const managerModule = await import("../acp/control-plane/manager.js");
+      const importEntered = createDeferred();
+      const releaseImport = createDeferred();
+      const scan = createDeferred<{ checked: number; resolved: number; failed: number }>();
+      let closing = false;
+      let healthy = boundary !== "backend readiness";
+      const suspension =
+        boundary === "suspension" ? tryBeginGatewaySuspendAdmission(() => {}) : undefined;
+      if (suspension) {
+        expect(suspension.commit()).toBe(true);
+      }
+      hoisted.getAcpRuntimeBackend.mockImplementation((id?: string) => ({
+        id: id ?? "acpx",
+        runtime: {},
+        healthy: () => healthy,
+      }));
+      if (boundary === "reconciliation") {
+        hoisted.reconcilePendingSessionIdentities.mockReturnValueOnce(scan.promise);
+      }
+      if (boundary !== "manager import") {
+        releaseImport.resolve();
+      }
+      const params = createPostAttachParams();
+      vi.resetModules();
+      try {
+        const { startGatewaySidecars: startFreshGatewaySidecars } =
+          await import("./server-startup-post-attach.js");
+        vi.doMock("../acp/control-plane/manager.js", async () => {
+          importEntered.resolve();
+          await releaseImport.promise;
+          return managerModule;
+        });
+        adoptPostReadyResult(
+          await startFreshGatewaySidecars({
+            cfg: { ...params.cfgAtStart, acp: { enabled: true, backend: "acpx" } },
+            pluginRegistry: params.pluginRegistry,
+            defaultWorkspaceDir: params.defaultWorkspaceDir,
+            deps: params.deps,
+            startChannels: params.startChannels,
+            shouldCreatePostReadySidecars: () => !closing,
+            log: params.log,
+            logHooks: params.logHooks,
+            logChannels: params.logChannels,
+          }),
+        );
+        if (boundary === "backend readiness") {
+          await waitForGatewayTestState(() =>
+            expect(hoisted.getAcpRuntimeBackend).toHaveBeenCalledWith("acpx"),
+          );
+        } else if (boundary === "manager import") {
+          await importEntered.promise;
+        } else if (boundary === "reconciliation") {
+          await waitForGatewayTestState(() =>
+            expect(hoisted.reconcilePendingSessionIdentities).toHaveBeenCalledOnce(),
+          );
+        }
+        closing = true;
+        suspension?.release();
+        healthy = true;
+        releaseImport.resolve();
+        if (boundary === "reconciliation") {
+          expect(getActiveGatewayRootWorkCount()).toBe(1);
+        }
+        scan.resolve({ checked: 0, resolved: 0, failed: 0 });
+        await vi.dynamicImportSettled();
+        await waitForGatewayTestState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+        if (boundary === "reconciliation") {
+          expect(hoisted.reconcilePendingSessionIdentities).toHaveBeenCalledOnce();
+        } else {
+          expect(hoisted.reconcilePendingSessionIdentities).not.toHaveBeenCalled();
+        }
+        expect(params.log.warn).not.toHaveBeenCalled();
+      } finally {
+        closing = true;
+        healthy = true;
+        suspension?.release();
+        releaseImport.resolve();
+        scan.resolve({ checked: 0, resolved: 0, failed: 0 });
+        await vi.dynamicImportSettled();
+        await waitForGatewayTestState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+        await stopTrackedSidecars(publishedPostReadySidecars);
+        vi.doMock("../acp/control-plane/manager.js", () => managerModule);
+        vi.resetModules();
+      }
+    },
+  );
 
   it.each([
     { label: "before restart-sentinel refresh starts", closeAfterRefreshStarts: false },

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -259,17 +259,22 @@ function schedulePostReadySidecarTask(params: {
   run: (isStopped: () => boolean, signal: AbortSignal) => Awaitable<void>;
   stop?: () => Awaitable<void>;
   waitForPostReadyWork?: () => Promise<void>;
+  shouldRun?: () => boolean;
 }): GatewayPostReadySidecarHandle {
-  let stopped = false;
   const abortController = new AbortController();
-  const isStopped = () => stopped;
+  // Closing retires producers before received work permits sidecar teardown.
+  const isStopped = () => abortController.signal.aborted || params.shouldRun?.() === false;
   const handle = setImmediate(() => {
     void (async () => {
       await params.waitForPostReadyWork?.();
       if (isStopped()) {
         return;
       }
+      // Suspension can defer admission, so eligibility must be checked again inside it.
       await runWithGatewayIndependentRootWorkAdmission(async () => {
+        if (isStopped()) {
+          return;
+        }
         await measureStartup(params.startupTrace, params.name, () =>
           params.run(isStopped, abortController.signal),
         );
@@ -283,7 +288,6 @@ function schedulePostReadySidecarTask(params: {
     stop: async () => {
       // Sidecars get both a synchronous stopped predicate and an AbortSignal so
       // lazy imports and long-running watchers can cooperate with shutdown.
-      stopped = true;
       abortController.abort();
       clearImmediate(handle);
       await params.stop?.();
@@ -296,19 +300,24 @@ function scheduleGatewayGenerationTimer(params: {
   origin: string;
   run: (isStopped: () => boolean) => Awaitable<void>;
   onError: (err: unknown) => void;
+  shouldRun?: () => boolean;
 }): GatewayPostReadySidecarHandle {
   let stopped = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const isStopped = () => stopped;
+  const isStopped = () => stopped || params.shouldRun?.() === false;
   timer = setTimeout(() => {
     timer = undefined;
     if (isStopped()) {
       return;
     }
     void runWithGatewayIndependentRootWorkAdmission(async () => {
+      if (isStopped()) {
+        return;
+      }
       await params.run(isStopped);
     }, params.origin).catch((err: unknown) => {
-      if (!isStopped()) {
+      // Closing must not hide errors from callbacks already admitted before it.
+      if (!stopped) {
         params.onError(err);
       }
     });
@@ -328,10 +337,12 @@ function scheduleGatewayGenerationTimer(params: {
 function scheduleRestartSentinelWakeAfterReady(params: {
   deps: CliDeps;
   log: { warn: (msg: string) => void };
+  shouldRun?: () => boolean;
 }): GatewayPostReadySidecarHandle {
   return scheduleGatewayGenerationTimer({
     delayMs: 750,
     origin: "restart-sentinel:wake",
+    shouldRun: params.shouldRun,
     run: async (isStopped) => {
       const { scheduleRestartSentinelWake } = await loadGatewayRestartSentinelModule();
       if (isStopped()) {
@@ -348,6 +359,7 @@ function scheduleTranscriptsAutoStartSidecar(params: {
   startupTrace?: GatewayStartupTrace;
   log: { warn: (msg: string) => void };
   waitForPostReadyWork?: () => Promise<void>;
+  shouldRun?: () => boolean;
 }): GatewayPostReadySidecarHandle {
   let stopTranscriptsAutoStart: (() => Promise<void>) | undefined;
   return schedulePostReadySidecarTask({
@@ -355,6 +367,7 @@ function scheduleTranscriptsAutoStartSidecar(params: {
     name: "sidecars.transcripts-auto-start",
     log: params.log,
     waitForPostReadyWork: params.waitForPostReadyWork,
+    shouldRun: params.shouldRun,
     run: async (isStopped) => {
       const { createTranscriptsAutoStartService } =
         await import("../agents/tools/transcripts-tool.js");
@@ -832,6 +845,7 @@ export async function startGatewaySidecars(params: {
       scheduleGatewayGenerationTimer({
         delayMs: 250,
         origin: "hooks:gateway-startup",
+        shouldRun: params.shouldCreatePostReadySidecars,
         run: async (isStopped) => {
           const { createInternalHookEvent, triggerInternalHook } = await loadInternalHooksModule();
           if (isStopped()) {
@@ -851,6 +865,9 @@ export async function startGatewaySidecars(params: {
 
   if (params.cfg.acp?.enabled) {
     void runWithGatewayIndependentRootWorkAdmission(async () => {
+      if (params.shouldCreatePostReadySidecars?.() === false) {
+        return;
+      }
       const ready = await measureStartup(params.startupTrace, "sidecars.acp.runtime-ready", () =>
         waitForAcpRuntimeBackendReady({ backendId: params.cfg.acp?.backend }),
       );
@@ -858,12 +875,18 @@ export async function startGatewaySidecars(params: {
         ["readyCount", ready ? 1 : 0],
         ["backend", params.cfg.acp?.backend ?? "default"],
       ]);
+      if (params.shouldCreatePostReadySidecars?.() === false) {
+        return;
+      }
       await measureStartup(params.startupTrace, "sidecars.acp.identity-reconcile", async () => {
         const [{ getAcpSessionManager }, { ACP_SESSION_IDENTITY_RENDERER_VERSION }] =
           await Promise.all([
             import("../acp/control-plane/manager.js"),
             import("@openclaw/acp-core/runtime/session-identifiers"),
           ]);
+        if (params.shouldCreatePostReadySidecars?.() === false) {
+          return;
+        }
         const result = await getAcpSessionManager().reconcilePendingSessionIdentities({
           cfg: params.cfg,
         });
@@ -886,6 +909,7 @@ export async function startGatewaySidecars(params: {
       name: "sidecars.restart-sentinel",
       log: params.log,
       waitForPostReadyWork: params.waitForPostReadyWork,
+      shouldRun: params.shouldCreatePostReadySidecars,
       run: async (isStopped) => {
         if (!shouldCheckRestartSentinel() || isStopped()) {
           return;
@@ -896,6 +920,7 @@ export async function startGatewaySidecars(params: {
         restartSentinelWake = scheduleRestartSentinelWakeAfterReady({
           deps: params.deps,
           log: params.log,
+          shouldRun: params.shouldCreatePostReadySidecars,
         });
       },
       stop: async () => {
@@ -911,6 +936,7 @@ export async function startGatewaySidecars(params: {
         name: "sidecars.gmail-watch",
         log: params.log,
         waitForPostReadyWork: params.waitForPostReadyWork,
+        shouldRun: params.shouldCreatePostReadySidecars,
         run: async (isStopped, signal) => {
           const { startGmailWatcherWithLogs } = await import("../hooks/gmail-watcher-lifecycle.js");
           if (isStopped()) {
@@ -933,6 +959,7 @@ export async function startGatewaySidecars(params: {
         name: "sidecars.gmail-model",
         log: params.log,
         waitForPostReadyWork: params.waitForPostReadyWork,
+        shouldRun: params.shouldCreatePostReadySidecars,
         run: async (isStopped) => {
           const [
             { DEFAULT_MODEL, DEFAULT_PROVIDER },
@@ -963,6 +990,9 @@ export async function startGatewaySidecars(params: {
               providerDiscoveryProviderIds: [hooksModelRef.provider],
               scopedLiveProviderDiscovery: true,
             });
+            if (isStopped()) {
+              return;
+            }
             const status = getModelRefStatus({
               cfg: params.cfg,
               catalog,
@@ -1245,6 +1275,7 @@ export async function startGatewayPostAttachRuntime(
           name: "sidecars.control-ui-assets",
           startupTrace: params.startupTrace,
           log: params.log,
+          shouldRun: () => params.isClosing?.() !== true,
           run: controlUiRootLifecycle.start,
           stop: controlUiRootLifecycle.stop,
         })
@@ -1562,6 +1593,7 @@ export async function startGatewayPostAttachRuntime(
                 startupTrace: params.startupTrace,
                 log: params.log,
                 waitForPostReadyWork: params.waitForPostReadyWork,
+                shouldRun: () => params.isClosing?.() !== true,
               }),
             );
           }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where stopping or restarting a newly started Gateway could still start queued background work or emit avoidable startup-failure warnings after local shutdown began, while existing requests were finishing. A callback paused for admission, a module import, or ACP backend readiness could resume into the closing Gateway.

## Why This Change Was Made

The post-ready producer owner now carries the Gateway's existing live closing predicate through scheduling, admitted callback entry, and asynchronous import/catalog boundaries, preventing unstarted producers from entering after close wins. Cleanup remains with its existing lifecycle owner after received work drains; already-entered work stays owned, and real errors from admitted callbacks remain visible.

## User Impact

Queued Gmail watcher/model validation, transcript auto-start, internal startup hooks, restart wake, and Control UI preparation respect local Gateway closing state. ACP identity reconciliation does not begin when close wins during admission, backend readiness, or manager loading; a scan that has already entered retains its existing completion behavior.

There are no config, protocol, database, timeout, or teardown-order changes. This does not change the earlier process-manager restart-drain-only interval or promise to cancel every operation already in progress.

## Evidence

- **Controlled failures before the repair:** the original 111-case owner run had 107 passes and four expected failures: queued producers during direct close; queued warnings during restart drain after local close; a Control UI callback parked behind suspension; and Gmail startup resuming from an import after close prelude. The intermediate producer repair passed all 111 owner cases and 83 sibling cases.
- **ACP boundary proof:** the added cases against that intermediate owner produced three expected failures—suspended admission, backend readiness, and manager import. The already-entered reconciliation control passed. The final candidate passed the identical 115 owner cases and 87 cases across nine whole sibling files, preserving the earlier 83 sibling identities and per-file order. Original failures remain retained.
- **Normal validation:** all 29 selected changed-gate stages and the normal mapped build passed. Build evidence retains dependency-eval, worker `SOURCEMAP_BROKEN`, and browser `node:path` warnings; these are not described as warning-free results. Managed Codex review returned seven scoped passes with no actionable P0–P2 findings; the reviewer did not execute project code.
- **Ordinary built smoke:** one real built Gateway completed readiness, then `health({probe:false})`, `status`, `tts.providers`, and `plugins.list` in that order, followed by normal SIGTERM shutdown. Full decoded results and initial refusal/503/pre-ready-timeout observations were retained. The smoke recorded 22 INFO messages without warnings/errors; root verified all eight observed PIDs, four groups, and the listener closed. It does not reproduce the controlled close races or establish real-provider/ACP/channel race behavior. The zero-session status was a point-in-time observation before later background bindings, and none of the recorded durations is a latency comparison.

Production is **+37/−5, net +32 lines**; tests are **+321/−50, net +271 lines**. The production growth propagates an existing lifecycle fact into previously unguarded producer boundaries, including ACP's distinct dispatch path, without adding a new cancellation framework. The immediate scheduler also removes its duplicate stopped flag; timer error handling preserves the distinction between actual stop and an admitted callback failing during close.

Candidate commit `cb4ccc8d50a887df0201860d38e2f67c27ac11f6` preserves the exact reviewed and tested patch against base `17b0c435dd5b341d645703c04354706a1c7f9a55`. A source-only comparison with current main `4cb260cd132f1315fccecc8c9dcb765d3ccd1f28` found both touched baseline files unchanged and all 53 selected contracts identical to the context supplied to review. The eight accounted-for context changes include host lifecycle types, prepared session facts, ACP initialization cleanup, transcript retry identity, and update-notice ownership. This is not current-main runtime or CI proof. Full source, failures, closures, gate/build logs, and built-smoke readback remain under the retained `post-ready-producer-fence` evidence family.
