### PR TITLE
refactor(matrix): keep Doctor metadata loading independent of client storage

### DIFF
--- a/extensions/matrix/doctor-contract-api.import.test.ts
+++ b/extensions/matrix/doctor-contract-api.import.test.ts
@@ -12,6 +12,9 @@ vi.mock("fake-indexeddb", () => {
 vi.mock("openclaw/plugin-sdk/doctor-repair-runtime", () => {
   throw new Error("Schema repair runtime loaded without an account database");
 });
+vi.mock("./src/matrix/client/storage.js", () => {
+  throw new Error("Client storage loaded by an absent-state Doctor migration");
+});
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -30,6 +33,7 @@ it("completes absent legacy-state checks without loading client runtimes", async
   };
   for (const id of [
     "matrix-account-sqlite-schema",
+    "matrix-storage-meta-json-to-plugin-state",
     "matrix-sync-cache-json-to-plugin-state",
     "matrix-legacy-crypto-migration-json-to-plugin-state",
   ]) {

--- a/extensions/matrix/doctor-contract-api.test.ts
+++ b/extensions/matrix/doctor-contract-api.test.ts
@@ -24,7 +24,7 @@ import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runt
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 import { SqliteBackedMatrixSyncStore } from "./src/matrix/client/file-sync-store.js";
-import { openMatrixStorageMetaStoreOptions } from "./src/matrix/client/storage.js";
+import { openMatrixStorageMetaStoreOptions } from "./src/matrix/client/storage-metadata.js";
 import {
   MATRIX_IDB_SNAPSHOT_FILENAME,
   MATRIX_RECOVERY_KEY_FILENAME,

--- a/extensions/matrix/doctor-contract-api.ts
+++ b/extensions/matrix/doctor-contract-api.ts
@@ -19,7 +19,7 @@ import {
   openMatrixStorageMetaStoreOptions,
   writeMatrixStorageMetaStateToStore,
   type MatrixStorageMetadata,
-} from "./src/matrix/client/storage.js";
+} from "./src/matrix/client/storage-metadata.js";
 import {
   hasMatrixSyncCacheStateInStore,
   openMatrixSyncCacheStoreOptions,

--- a/extensions/matrix/src/matrix/client/file-sync-store.test.ts
+++ b/extensions/matrix/src/matrix/client/file-sync-store.test.ts
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getMatrixRuntime } from "../../runtime.js";
 import { installMatrixTestRuntime } from "../../test-runtime.js";
 import { SqliteBackedMatrixSyncStore } from "./file-sync-store.js";
-import { openMatrixStorageMetaStoreOptions } from "./storage.js";
+import { openMatrixStorageMetaStoreOptions } from "./storage-metadata.js";
 import { openMatrixSyncCacheStoreOptions, type MatrixSyncCacheRecord } from "./sync-cache-state.js";
 
 function createSyncResponse(nextBatch: string): ISyncResponse {

--- a/extensions/matrix/src/matrix/client/storage-metadata.ts
+++ b/extensions/matrix/src/matrix/client/storage-metadata.ts
@@ -1,0 +1,68 @@
+// Metadata contract shared by Doctor migrations and client storage selection.
+import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveMatrixSqliteStateEnv } from "../sqlite-state.js";
+
+const STORAGE_META_NAMESPACE = "storage-meta";
+export const STORAGE_META_STATE_KEY = "current";
+const STORAGE_META_MAX_ENTRIES = 10;
+
+export type MatrixStorageMetadata = {
+  homeserver?: string;
+  userId?: string;
+  accountId?: string;
+  accessTokenHash?: string;
+  deviceId?: string | null;
+  currentTokenStateClaimed?: boolean;
+  createdAt?: string;
+};
+
+export function openMatrixStorageMetaStoreOptions(storageRootDir: string) {
+  return {
+    namespace: STORAGE_META_NAMESPACE,
+    maxEntries: STORAGE_META_MAX_ENTRIES,
+    env: resolveMatrixSqliteStateEnv({ stateDir: storageRootDir }),
+  };
+}
+
+export function normalizeMatrixStorageMetadata(value: unknown): MatrixStorageMetadata | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const metadata: MatrixStorageMetadata = {};
+  if (typeof value.homeserver === "string" && value.homeserver.trim()) {
+    metadata.homeserver = value.homeserver.trim();
+  }
+  if (typeof value.userId === "string" && value.userId.trim()) {
+    metadata.userId = value.userId.trim();
+  }
+  if (typeof value.accountId === "string" && value.accountId.trim()) {
+    metadata.accountId = value.accountId.trim();
+  }
+  if (typeof value.accessTokenHash === "string" && value.accessTokenHash.trim()) {
+    metadata.accessTokenHash = value.accessTokenHash.trim();
+  }
+  if (typeof value.deviceId === "string" && value.deviceId.trim()) {
+    metadata.deviceId = value.deviceId.trim();
+  }
+  if (value.currentTokenStateClaimed === true) {
+    metadata.currentTokenStateClaimed = true;
+  }
+  if (typeof value.createdAt === "string" && value.createdAt.trim()) {
+    metadata.createdAt = value.createdAt.trim();
+  }
+  return Object.keys(metadata).length > 0 ? metadata : null;
+}
+
+export async function hasMatrixStorageMetaStateInStore(params: {
+  store: Pick<PluginStateKeyedStore<MatrixStorageMetadata>, "lookup">;
+}): Promise<boolean> {
+  return normalizeMatrixStorageMetadata(await params.store.lookup(STORAGE_META_STATE_KEY)) !== null;
+}
+
+export async function writeMatrixStorageMetaStateToStore(params: {
+  payload: MatrixStorageMetadata;
+  store: Pick<PluginStateKeyedStore<MatrixStorageMetadata>, "register">;
+}): Promise<void> {
+  await params.store.register(STORAGE_META_STATE_KEY, params.payload);
+}

--- a/extensions/matrix/src/matrix/client/storage.test.ts
+++ b/extensions/matrix/src/matrix/client/storage.test.ts
@@ -10,10 +10,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveMatrixAccountStorageRoot } from "../../storage-paths.js";
 import { installMatrixTestRuntime } from "../../test-runtime.js";
 import { SqliteBackedMatrixSyncStore } from "./file-sync-store.js";
+import { openMatrixStorageMetaStoreOptions } from "./storage-metadata.js";
 import {
   claimCurrentTokenStorageState,
   maybeMigrateLegacyStorage,
-  openMatrixStorageMetaStoreOptions,
   recordCurrentStorageMetaDeviceId,
   repairCurrentTokenStorageMetaDeviceId,
   resolveMatrixStateFilePath,

--- a/extensions/matrix/src/matrix/client/storage.ts
+++ b/extensions/matrix/src/matrix/client/storage.ts
@@ -4,11 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { loadJsonFile } from "openclaw/plugin-sdk/json-store";
-import type {
-  PluginStateKeyedStore,
-  PluginStateSyncKeyedStore,
-} from "openclaw/plugin-sdk/plugin-state-runtime";
-import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getMatrixRuntime } from "../../runtime.js";
 import { resolveMatrixAccountStorageRoot } from "../../storage-paths.js";
 import {
@@ -19,15 +15,17 @@ import {
   migrateLegacyMatrixRecoveryKeyFileToStore,
   scoreMatrixCryptoStateInStore,
 } from "../crypto-state-store.js";
-import { resolveMatrixSqliteStateEnv } from "../sqlite-state.js";
+import {
+  normalizeMatrixStorageMetadata,
+  openMatrixStorageMetaStoreOptions,
+  STORAGE_META_STATE_KEY,
+  type MatrixStorageMetadata,
+} from "./storage-metadata.js";
 import type { MatrixAuth, MatrixStoragePaths } from "./types.js";
 
 const DEFAULT_ACCOUNT_KEY = "default";
 const STORAGE_META_FILENAME = "storage-meta.json";
 const THREAD_BINDINGS_FILENAME = "thread-bindings.json";
-const STORAGE_META_NAMESPACE = "storage-meta";
-const STORAGE_META_STATE_KEY = "current";
-const STORAGE_META_MAX_ENTRIES = 10;
 type LegacyMoveRecord = {
   sourcePath: string;
   targetPath: string;
@@ -38,24 +36,6 @@ type LegacyArchiveRecord = {
   sourcePath: string;
   label: string;
 };
-
-export type MatrixStorageMetadata = {
-  homeserver?: string;
-  userId?: string;
-  accountId?: string;
-  accessTokenHash?: string;
-  deviceId?: string | null;
-  currentTokenStateClaimed?: boolean;
-  createdAt?: string;
-};
-
-export function openMatrixStorageMetaStoreOptions(storageRootDir: string) {
-  return {
-    namespace: STORAGE_META_NAMESPACE,
-    maxEntries: STORAGE_META_MAX_ENTRIES,
-    env: resolveMatrixSqliteStateEnv({ stateDir: storageRootDir }),
-  };
-}
 
 function openStorageMetaStore(rootDir: string): PluginStateSyncKeyedStore<MatrixStorageMetadata> {
   return getMatrixRuntime().state.openSyncKeyedStore<MatrixStorageMetadata>(
@@ -107,48 +87,6 @@ type PopulatedMatrixStorageRoot = {
   score: number;
   mtimeMs: number;
 };
-
-export function normalizeMatrixStorageMetadata(value: unknown): MatrixStorageMetadata | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-  const metadata: MatrixStorageMetadata = {};
-  if (typeof value.homeserver === "string" && value.homeserver.trim()) {
-    metadata.homeserver = value.homeserver.trim();
-  }
-  if (typeof value.userId === "string" && value.userId.trim()) {
-    metadata.userId = value.userId.trim();
-  }
-  if (typeof value.accountId === "string" && value.accountId.trim()) {
-    metadata.accountId = value.accountId.trim();
-  }
-  if (typeof value.accessTokenHash === "string" && value.accessTokenHash.trim()) {
-    metadata.accessTokenHash = value.accessTokenHash.trim();
-  }
-  if (typeof value.deviceId === "string" && value.deviceId.trim()) {
-    metadata.deviceId = value.deviceId.trim();
-  }
-  if (value.currentTokenStateClaimed === true) {
-    metadata.currentTokenStateClaimed = true;
-  }
-  if (typeof value.createdAt === "string" && value.createdAt.trim()) {
-    metadata.createdAt = value.createdAt.trim();
-  }
-  return Object.keys(metadata).length > 0 ? metadata : null;
-}
-
-export async function hasMatrixStorageMetaStateInStore(params: {
-  store: Pick<PluginStateKeyedStore<MatrixStorageMetadata>, "lookup">;
-}): Promise<boolean> {
-  return normalizeMatrixStorageMetadata(await params.store.lookup(STORAGE_META_STATE_KEY)) !== null;
-}
-
-export async function writeMatrixStorageMetaStateToStore(params: {
-  payload: MatrixStorageMetadata;
-  store: Pick<PluginStateKeyedStore<MatrixStorageMetadata>, "register">;
-}): Promise<void> {
-  await params.store.register(STORAGE_META_STATE_KEY, params.payload);
-}
 
 function readStoredRootMetadata(rootDir: string): MatrixStorageMetadata {
   if (fs.existsSync(path.join(rootDir, "state", "openclaw.sqlite"))) {

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
@@ -20,7 +20,7 @@ import type { DatabaseSync } from "node:sqlite";
 import type { PersistentDedupeEntry } from "openclaw/plugin-sdk/persistent-dedupe";
 import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { normalizeMatrixStorageMetadata } from "../client/storage.js";
+import { normalizeMatrixStorageMetadata } from "../client/storage-metadata.js";
 
 const LEGACY_SQLITE_NAMESPACE = "inbound-dedupe";
 const LEGACY_MARKERS_NAMESPACE = "inbound-dedupe-migrations";

--- a/extensions/matrix/test-api.ts
+++ b/extensions/matrix/test-api.ts
@@ -7,8 +7,8 @@ export {
 export {
   normalizeMatrixStorageMetadata,
   openMatrixStorageMetaStoreOptions,
-} from "./src/matrix/client/storage.js";
-export type { MatrixStorageMetadata } from "./src/matrix/client/storage.js";
+} from "./src/matrix/client/storage-metadata.js";
+export type { MatrixStorageMetadata } from "./src/matrix/client/storage-metadata.js";
 export type {
   EncryptedFile,
   MatrixDeviceVerificationStatus,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Matrix Doctor metadata checks and migrations pull in the client-storage dependency graph even when there is no legacy Matrix state to migrate. Metadata discovery should not need the client storage, crypto, or IndexedDB initialization paths merely to determine that there is nothing to do.

## Why This Change Was Made

Move the existing metadata normalization and SQLite-store helpers into one private `storage-metadata.ts` owner, then have Doctor, inbound-dedupe migration, and client storage use it directly. The helper bodies and storage contract stay unchanged; client root selection, claims, sync persistence, and runtime initialization stay with their existing owners, with no compatibility facade or new cache.

## User Impact

No intentional change to Matrix configuration, stored data, migration results, or account ownership. Doctor keeps the same canonical-state precedence and write-before-archive behavior while metadata-only discovery avoids an unnecessary client dependency. There is no new setting, schema, dependency, or setup step.

## Evidence

Validation used base `db0779d4dcb81b465b3e24c01cf384dc871f7872` plus the exact source now committed as `9f224385f4f82f1da4cf9d8ee954b868ad04021d`. The nine-path change is production **77 additions / 71 removals (+6)** and tests/support **9 additions / 5 removals (+4)**. Most production lines move unchanged; the small remainder establishes the shared private owner and its imports. Test growth extends the existing absent-state import-fault coverage rather than adding cache-count or placement assertions.

The same seven whole test files produced **53 passes and one intentional import-fault failure before**, then **54 passes after**. Every case identity and within-file order matched. The baseline failure is the injected client-storage import fault, not a claim that an ordinary Matrix installation crashes.

<details>
<summary>Complete whole-file test inventory</summary>

Paths below are under `extensions/matrix/`.

| Whole file | Before | Candidate |
|---|---:|---:|
| `doctor-contract-api.import.test.ts` | 0 pass + 1 expected failure | 1 pass |
| `doctor-contract-api.capacity.test.ts` | 2 pass | 2 pass |
| `doctor-contract-api.credentials.test.ts` | 3 pass | 3 pass |
| `doctor-contract-api.test.ts` | 15 pass | 15 pass |
| `src/matrix/client/file-sync-store.test.ts` | 13 pass | 13 pass |
| `src/matrix/client/storage.test.ts` | 19 pass | 19 pass |
| `doctor-contract-api.account-state.test.ts` | 1 pass | 1 pass |

</details>

The ordinary changed gate passed **all 26 stages**, including the real Doctor declaration/closure checks and both targeted lint stages. An earlier nested-checkout gate stopped after 20 stages because artifact preparation resolved `qrcode` from its ancestor checkout. That failed attempt remains recorded; the unchanged candidate subsequently passed in an independent ordinary checkout outside that ancestor. No guard, compiler, dependency, or test was weakened.

The normal full build passed, including external plugin output, bootstrap/Doctor closure checks, public SDK checks, and UI checks. Its dependency direct-eval, worker-deploy sourcemap, browser externalization, and plugin-timing warnings remain recorded. The emitted Matrix Doctor and client-storage chunks both reference the extracted metadata owner; Matrix's external build emits no source maps, so correspondence uses the actual compiled files/import edges, with exact source-map matches only for the mapped core owners.

The initial built import smoke checked all seven migration descriptors. A separate **populated built-consumer proof** then invoked the real exported `autoMigrateLegacyPluginDoctorState` twice through ordinary plugin discovery, context, and maintenance ownership in isolated synthetic state:

- First invocation imported all seven normalized metadata fields and archived the exact original 265-byte file; both expected changes were returned, with no warnings.
- Second invocation returned no changes and no warnings. Canonical metadata remained unchanged, and the ordinary inbound empty-scan completion row was present.
- An independent read-only SQLite audit verified the exact metadata and completion rows, unchanged database bytes during audit, archive equality, and canonical store closure. The native child and observed adapter were gone afterward.

This exercises the moved helpers through the built Doctor consumer, not only descriptor imports. It used no Matrix account or provider credential. It does **not** establish live Matrix messaging, a packed-plugin installation, current-main runtime behavior, or Gateway speedup. The managed Codex review completed five scoped passes with no actionable P0–P2 findings; those evidence limits remain explicit.

The fixed **12-host source-import/context study** used Node 26.8.1, two observations per variant and row, with baseline-first AB and candidate-first BA ordering. All import/context/migration outcome checks passed. Operation times are below in milliseconds, before → candidate:

| Complete source operation | AB | BA |
|---|---:|---:|
| M01: Doctor source import | 215.377 → 192.490 (-10.63%) | 203.947 → 194.723 (-4.52%) |
| M02: Doctor + real context + absent-state detection/migration | 2405.672 → 2145.711 (-10.81%) | 2134.909 → 2287.299 (+7.14%) |
| M03: Client-storage source import (control) | 101.325 → 101.443 (+0.12%) | 102.024 → 100.187 (-1.80%) |

These are source/TSX measurements, separate from the built behavior proof. All **60 comparisons, including 20 adverse results**, are retained. The wider Doctor/context operation regressed in BA; sampled peak RSS also increased in three comparisons. Numerical acceptance was deliberately **null**, with no threshold or overall performance pass. Two observations cannot establish significance, tail latency, retained allocation, or a general startup improvement. External envelopes include observation/join latency and are not target or native-process times.

<details>
<summary>All 20 adverse comparisons (positive means candidate increased)</summary>

| Row/order | Metric | Absolute increase | Relative increase |
|---|---|---:|---:|
| M01 AB | RSS before operation | +49,152 B | +0.0580% |
| M01 AB | RSS after operation | +2,998,272 B | +1.9583% |
| M01 AB | Sampled tree peak RSS | +3,227,648 B | +2.4187% |
| M02 AB | Approx. Node-to-entry | +0.215374 ms | +0.3407% |
| M02 AB | Native user CPU | +51.695000 ms | +1.6735% |
| M02 AB | Native system CPU | +2.797000 ms | +0.4424% |
| M02 BA | Operation | +152.390167 ms | +7.1380% |
| M02 BA | RSS before operation | +245,760 B | +0.2901% |
| M02 BA | Native wall | +149.413959 ms | +6.6789% |
| M02 BA | External observation envelope | +163.000000 ms | +6.8229% |
| M02 BA | Sampled tree peak RSS | +2,818,048 B | +0.5770% |
| M02 BA | Native user CPU | +162.095000 ms | +5.1912% |
| M02 BA | Native system CPU | +58.084000 ms | +9.3005% |
| M03 AB | Operation | +0.117708 ms | +0.1162% |
| M03 AB | RSS before operation | +32,768 B | +0.0387% |
| M03 AB | RSS after operation | +3,325,952 B | +2.7314% |
| M03 AB | External observation envelope | +15.000000 ms | +4.4118% |
| M03 AB | Sampled tree peak RSS | +5,832,704 B | +4.3452% |
| M03 AB | Native user CPU | +0.011000 ms | +0.0044% |
| M03 BA | RSS after operation | +180,224 B | +0.1449% |

</details>

Source-only comparison with main `4cb260cd132f1315fccecc8c9dcb765d3ccd1f28` found the eight existing changed files still byte-identical to the tested baseline and the extracted module still absent. Of 83 selected owner/caller/test/build/docs paths, only root package/lock/workspace files differed, including newer pnpm and undici bindings. This supports source composition without extending the old runtime or numerical claims to those newer dependencies.
