### PR TITLE
refactor(channels): simplify account configuration updates

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2212,7 +2212,7 @@ src/channels/plugins/bootstrap-registry.ts	4
 src/channels/plugins/bundled-setup-policy.ts	2
 src/channels/plugins/bundled.ts	4
 src/channels/plugins/chat-target-prefixes.ts	2
-src/channels/plugins/config-helpers.ts	14
+src/channels/plugins/config-helpers.ts	7
 src/channels/plugins/config-schema.ts	14
 src/channels/plugins/config-write-policy-shared.ts	1
 src/channels/plugins/config-writes.ts	1
@@ -2232,11 +2232,11 @@ src/channels/plugins/read-only.ts	6
 src/channels/plugins/registry.ts	1
 src/channels/plugins/session-thread-info-loaded.ts	1
 src/channels/plugins/setup-contract.ts	3
-src/channels/plugins/setup-helpers.ts	4
+src/channels/plugins/setup-helpers.ts	3
 src/channels/plugins/setup-promotion-helpers.ts	1
 src/channels/plugins/setup-promotion-keys.ts	1
 src/channels/plugins/setup-registry.ts	2
-src/channels/plugins/setup-wizard-helpers.ts	13
+src/channels/plugins/setup-wizard-helpers.ts	12
 src/channels/plugins/setup-wizard-proxy.ts	1
 src/channels/plugins/setup-wizard.ts	5
 src/channels/plugins/threading-helpers.ts	1
@@ -3295,7 +3295,7 @@ src/plugin-sdk/approval-auth-helpers.ts	1
 src/plugin-sdk/approval-handler-runtime.ts	1
 src/plugin-sdk/approval-native-helpers.ts	1
 src/plugin-sdk/approval-reaction-binding.ts	2
-src/plugin-sdk/channel-config-helpers.ts	24
+src/plugin-sdk/channel-config-helpers.ts	17
 src/plugin-sdk/channel-config-ui-hints.ts	1
 src/plugin-sdk/channel-entry-contract.ts	6
 src/plugin-sdk/channel-inbound.ts	2

--- a/src/channels/plugins/config-helpers.ts
+++ b/src/channels/plugins/config-helpers.ts
@@ -11,6 +11,53 @@ type ChannelSection = {
   enabled?: boolean;
 };
 
+/** Replace one section; undefined removes it and prunes an empty channels object. */
+export function writeChannelSection(
+  cfg: OpenClawConfig,
+  channelKey: string,
+  section: Record<string, unknown> | undefined,
+): OpenClawConfig {
+  if (section !== undefined) {
+    return { ...cfg, channels: { ...cfg.channels, [channelKey]: section } };
+  }
+  const channels = { ...cfg.channels };
+  delete channels[channelKey];
+  const next = { ...cfg };
+  if (Object.keys(channels).length > 0) {
+    next.channels = channels;
+  } else {
+    delete next.channels;
+  }
+  return next;
+}
+
+export function setTopLevelChannelEnabledInConfigSection(params: {
+  cfg: OpenClawConfig;
+  sectionKey: string;
+  enabled: boolean;
+}): OpenClawConfig {
+  return writeChannelSection(params.cfg, params.sectionKey, {
+    ...params.cfg.channels?.[params.sectionKey],
+    enabled: params.enabled,
+  });
+}
+
+export function clearTopLevelChannelConfigFields(params: {
+  cfg: OpenClawConfig;
+  sectionKey: string;
+  clearBaseFields: string[];
+}): OpenClawConfig {
+  const section = params.cfg.channels?.[params.sectionKey];
+  if (!section) {
+    return params.cfg;
+  }
+  const nextSection = { ...section };
+  for (const field of params.clearBaseFields) {
+    delete nextSection[field];
+  }
+  return writeChannelSection(params.cfg, params.sectionKey, nextSection);
+}
+
 function isConfiguredSecretValue(value: unknown): boolean {
   if (typeof value === "string") {
     return value.trim().length > 0;
@@ -34,36 +81,18 @@ export function setAccountEnabledInConfigSection(params: {
   const hasAccounts = Boolean(base?.accounts);
   if (params.allowTopLevel && accountKey === DEFAULT_ACCOUNT_ID && !hasAccounts) {
     // Legacy single-account sections store enabled at the channel root until accounts exist.
-    return {
-      ...params.cfg,
-      channels: {
-        ...params.cfg.channels,
-        [params.sectionKey]: {
-          ...base,
-          enabled: params.enabled,
-        },
-      },
-    } as OpenClawConfig;
+    return setTopLevelChannelEnabledInConfigSection(params);
   }
 
   const baseAccounts = base?.accounts ?? {};
   const existing = baseAccounts[accountKey] ?? {};
-  return {
-    ...params.cfg,
-    channels: {
-      ...params.cfg.channels,
-      [params.sectionKey]: {
-        ...base,
-        accounts: {
-          ...baseAccounts,
-          [accountKey]: {
-            ...existing,
-            enabled: params.enabled,
-          },
-        },
-      },
+  return writeChannelSection(params.cfg, params.sectionKey, {
+    ...base,
+    accounts: {
+      ...baseAccounts,
+      [accountKey]: { ...existing, enabled: params.enabled },
     },
-  } as OpenClawConfig;
+  });
 }
 
 /**
@@ -82,27 +111,14 @@ export function deleteAccountFromConfigSection(params: {
     return params.cfg;
   }
 
-  const baseAccounts =
-    base.accounts && typeof base.accounts === "object" ? { ...base.accounts } : undefined;
-
-  if (accountKey !== DEFAULT_ACCOUNT_ID) {
-    const accounts = baseAccounts ? { ...baseAccounts } : {};
-    delete accounts[accountKey];
-    return {
-      ...params.cfg,
-      channels: {
-        ...params.cfg.channels,
-        [params.sectionKey]: {
-          ...base,
-          accounts: Object.keys(accounts).length ? accounts : undefined,
-        },
-      },
-    } as OpenClawConfig;
+  const accounts = base.accounts && typeof base.accounts === "object" ? { ...base.accounts } : {};
+  if (accountKey === DEFAULT_ACCOUNT_ID && Object.keys(accounts).length === 0) {
+    return writeChannelSection(params.cfg, params.sectionKey, undefined);
   }
 
-  if (baseAccounts && Object.keys(baseAccounts).length > 0) {
-    delete baseAccounts[accountKey];
-    const baseRecord = { ...(base as Record<string, unknown>) };
+  delete accounts[accountKey];
+  const baseRecord = { ...(base as Record<string, unknown>) };
+  if (accountKey === DEFAULT_ACCOUNT_ID) {
     // Deleting the default account can also clear root-level credential fields that represented
     // the legacy default account.
     for (const field of params.clearBaseFields ?? []) {
@@ -110,27 +126,11 @@ export function deleteAccountFromConfigSection(params: {
         baseRecord[field] = undefined;
       }
     }
-    return {
-      ...params.cfg,
-      channels: {
-        ...params.cfg.channels,
-        [params.sectionKey]: {
-          ...baseRecord,
-          accounts: Object.keys(baseAccounts).length ? baseAccounts : undefined,
-        },
-      },
-    } as OpenClawConfig;
   }
-
-  const nextChannels = { ...params.cfg.channels } as Record<string, unknown>;
-  delete nextChannels[params.sectionKey];
-  const nextCfg = { ...params.cfg } as OpenClawConfig;
-  if (Object.keys(nextChannels).length > 0) {
-    nextCfg.channels = nextChannels as OpenClawConfig["channels"];
-  } else {
-    delete nextCfg.channels;
-  }
-  return nextCfg;
+  return writeChannelSection(params.cfg, params.sectionKey, {
+    ...baseRecord,
+    accounts: Object.keys(accounts).length ? accounts : undefined,
+  });
 }
 
 /**
@@ -231,17 +231,10 @@ export function clearAccountFieldsFromConfigSection(params: {
       delete nextSection.accounts;
     }
   }
-  const nextChannels = { ...params.cfg.channels };
-  if (Object.keys(nextSection).length > 0) {
-    nextChannels[params.sectionKey] = nextSection;
-  } else {
-    delete nextChannels[params.sectionKey];
-  }
-  const nextConfig = { ...params.cfg };
-  if (Object.keys(nextChannels).length > 0) {
-    nextConfig.channels = nextChannels;
-  } else {
-    delete nextConfig.channels;
-  }
+  const nextConfig = writeChannelSection(
+    params.cfg,
+    params.sectionKey,
+    Object.keys(nextSection).length > 0 ? nextSection : undefined,
+  );
   return { nextConfig, changed: true, cleared: clearedRoot || accountCleanup.cleared };
 }

--- a/src/channels/plugins/setup-helpers.ts
+++ b/src/channels/plugins/setup-helpers.ts
@@ -5,6 +5,7 @@
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
+import { writeChannelSection } from "./config-helpers.js";
 import { resolveSingleAccountPromotion } from "./setup-promotion-helpers.js";
 import type { ChannelSetupAdapter } from "./types.adapters.js";
 import type { ChannelSetupInput } from "./types.core.js";
@@ -21,14 +22,6 @@ function getChannelSection(
 ): ChannelSectionBase | undefined {
   const section = (cfg.channels as Record<string, unknown> | undefined)?.[channelKey];
   return section && typeof section === "object" ? (section as ChannelSectionBase) : undefined;
-}
-
-function writeChannelSection(
-  cfg: OpenClawConfig,
-  channelKey: string,
-  section: ChannelSectionBase,
-): OpenClawConfig {
-  return { ...cfg, channels: { ...cfg.channels, [channelKey]: section } } as OpenClawConfig;
 }
 
 export function applyAccountNameToChannelSection(params: {

--- a/src/channels/plugins/setup-wizard-helpers.ts
+++ b/src/channels/plugins/setup-wizard-helpers.ts
@@ -15,6 +15,7 @@ import { resolveSecretInputModeForEnvSelection } from "../../plugins/provider-au
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
+import { setTopLevelChannelEnabledInConfigSection, writeChannelSection } from "./config-helpers.js";
 import {
   moveSingleAccountChannelSectionToDefaultAccount,
   patchScopedAccountConfig,
@@ -267,17 +268,11 @@ export function patchTopLevelChannelConfigSection(params: {
   for (const field of params.clearFields ?? []) {
     delete channelConfig[field];
   }
-  return {
-    ...params.cfg,
-    channels: {
-      ...params.cfg.channels,
-      [params.channel]: {
-        ...channelConfig,
-        ...(params.enabled ? { enabled: true } : {}),
-        ...params.patch,
-      },
-    },
-  };
+  return writeChannelSection(params.cfg, params.channel, {
+    ...channelConfig,
+    ...(params.enabled ? { enabled: true } : {}),
+    ...params.patch,
+  });
 }
 
 function setTopLevelChannelAllowFrom(params: {
@@ -549,17 +544,7 @@ export function setSetupChannelEnabled(
   channel: string,
   enabled: boolean,
 ): OpenClawConfig {
-  const channelConfig = (cfg.channels?.[channel] as Record<string, unknown> | undefined) ?? {};
-  return {
-    ...cfg,
-    channels: {
-      ...cfg.channels,
-      [channel]: {
-        ...channelConfig,
-        enabled,
-      },
-    },
-  };
+  return setTopLevelChannelEnabledInConfigSection({ cfg, sectionKey: channel, enabled });
 }
 
 function patchConfigForScopedAccount(params: {

--- a/src/plugin-sdk/channel-config-helpers.ts
+++ b/src/plugin-sdk/channel-config-helpers.ts
@@ -7,8 +7,11 @@
  */
 import { normalizeStringEntries } from "../../packages/normalization-core/src/string-normalization.js";
 import {
+  clearTopLevelChannelConfigFields,
   deleteAccountFromConfigSection as deleteAccountFromConfigSectionInSection,
   setAccountEnabledInConfigSection as setAccountEnabledInConfigSectionInSection,
+  setTopLevelChannelEnabledInConfigSection,
+  writeChannelSection,
 } from "../channels/plugins/config-helpers.js";
 import {
   resolveChannelConfigWritesShared,
@@ -322,61 +325,6 @@ export function createScopedChannelConfigAdapter<
   });
 }
 
-function setTopLevelChannelEnabledInConfigSection<Config extends OpenClawConfig>(params: {
-  cfg: Config;
-  sectionKey: string;
-  enabled: boolean;
-}): Config {
-  const section = params.cfg.channels?.[params.sectionKey] as Record<string, unknown> | undefined;
-  return {
-    ...params.cfg,
-    channels: {
-      ...params.cfg.channels,
-      [params.sectionKey]: {
-        ...section,
-        enabled: params.enabled,
-      },
-    },
-  } as Config;
-}
-
-function removeTopLevelChannelConfigSection<Config extends OpenClawConfig>(params: {
-  cfg: Config;
-  sectionKey: string;
-}): Config {
-  const nextChannels = { ...params.cfg.channels } as Record<string, unknown>;
-  delete nextChannels[params.sectionKey];
-  const nextCfg = { ...params.cfg };
-  if (Object.keys(nextChannels).length > 0) {
-    nextCfg.channels = nextChannels as Config["channels"];
-  } else {
-    delete nextCfg.channels;
-  }
-  return nextCfg;
-}
-
-function clearTopLevelChannelConfigFields<Config extends OpenClawConfig>(params: {
-  cfg: Config;
-  sectionKey: string;
-  clearBaseFields: string[];
-}): Config {
-  const section = params.cfg.channels?.[params.sectionKey] as Record<string, unknown> | undefined;
-  if (!section) {
-    return params.cfg;
-  }
-  const nextSection = { ...section };
-  for (const field of params.clearBaseFields) {
-    delete nextSection[field];
-  }
-  return {
-    ...params.cfg,
-    channels: {
-      ...params.cfg.channels,
-      [params.sectionKey]: nextSection,
-    },
-  } as Config;
-}
-
 /** Build CRUD/config helpers for top-level single-account channels. */
 export function createTopLevelChannelConfigBase<
   ResolvedAccount,
@@ -425,10 +373,7 @@ export function createTopLevelChannelConfigBase<
             sectionKey: params.sectionKey,
             clearBaseFields: params.clearBaseFields ?? [],
           })
-        : removeTopLevelChannelConfigSection({
-            cfg: cfg as Config,
-            sectionKey: params.sectionKey,
-          });
+        : writeChannelSection(cfg, params.sectionKey, undefined);
     },
   };
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Maintaining channel setup, enable/disable, and account removal required keeping repeated config-write implementations aligned. The same immutable section replacement and empty-section cleanup lived in setup, wizard, account, and SDK helpers.

## Why This Change Was Made

The existing `config-helpers` owner now handles immutable section writes and pruning. Setup and SDK adapters retain their account-placement, credential-clearing, normalization, and lifecycle policies, while duplicated write paths are removed. Account deletion shares one final write for named and default accounts.

Production changes are **+83/-167 = -84 lines**. Tests are unchanged. The generated assertion baseline records **17 fewer type assertions**. SDK factory callback capture and lightweight accessor resolution remain unchanged; no new public SDK export or config/schema/default surface is introduced.

## User Impact

No intended user-visible behavior change. Channel setup, default and named accounts, disabling, deletion, and logout credential clearing retain their existing behavior. Empty sections versus removed sections, fields assigned `undefined` versus deleted keys, and no-op config identity remain deliberate policy distinctions.

## Evidence

- A before/after differential run matched **19,128 cases** exactly, including object key order, explicit `undefined`, structural sharing, no-op identity, and input immutability. Both runs produced aggregate `da0b6f543be0baf2f2fa8eacfaa5bd8ddeeb0ae6f51ffc4c426191acd3c1eb56`.
- **527 tests passed** across the four shared owners and representative Matrix, Slack, LINE, Feishu, Tlon, and Synology plugin callers.
- The canonical `cli-channel-picker` producer passed through a real PTY and isolated home. It selected Telegram, persisted the synthetic token, enabled the plugin/channel, retained the default group mention gate, and recorded configure metadata. Its temporary home was removed.
- Independent Codex review found no actionable P0–P2 defect in the selected source scope.

The completed candidate private-QA build was bound to SHA-256 digests of the reviewed source. A synthetic local harness used the public QA runtime APIs, the real Matrix plugin, an ephemeral Gateway, a mock model provider, and Crabline's Matrix server. It started with the account disabled and config credentials absent, then ran real CLI add, PTY disable, re-add, and delete commands. Two required marker replies arrived; disabling preserved credentials, reported a stopped runtime, and produced no outbound message during the disabled observation window. The queued inbound message was delivered after re-enabling. Deleting removed the Matrix section.

```json
{"verdict":"PASS","cliAddAndReAdd":2,"requiredMatrixReplies":2,"disablePreservedConfig":true,"noOutboundWhileDisabled":true,"deleteRemovedSection":true,"cleanup":{"process":"confirmed-stopped","errors":[],"recordedPidsGone":true,"portsClosed":true}}
```

The complete five-file changed gate passed, including core/test/plugin type checks, core/plugin/script lint, SDK export and boundary checks, dead exports, state/schema guards, and zero runtime import cycles.

Named follow-up: **Matrix duplicate accepted delivery during CLI account deletion**. The recorder accepted the restored marker twice in the same room: event 67 at 12:54:00.779 UTC used transaction `m1788612840778.3`; event 76 at 12:54:05.952 UTC used `oc_32ee-EPtjZPtrPUmaxIThZWrUvpi2gTIaix2iggsW3Q`. Crabline keys Matrix idempotency by room/event type/transaction ID, so these were two accepted timeline events, not one replayed transaction. The ordinary-send and durable-queue owners are unchanged by this refactor. Their acknowledgment and recovery ordering is being investigated separately; the config proof above does not establish exactly-once delivery.
