### PR TITLE
fix(agents): prevent stale options across provider runtimes

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1739,7 +1739,7 @@ src/agents/embedded-agent-runner/delivery-evidence.ts	11
 src/agents/embedded-agent-runner/direct-compaction-preparation.ts	1
 src/agents/embedded-agent-runner/empty-assistant-turn.ts	1
 src/agents/embedded-agent-runner/extensions.ts	1
-src/agents/embedded-agent-runner/extra-params.ts	10
+src/agents/embedded-agent-runner/extra-params.ts	9
 src/agents/embedded-agent-runner/google-prompt-cache.ts	5
 src/agents/embedded-agent-runner/history.ts	2
 src/agents/embedded-agent-runner/message-visibility.ts	13

--- a/src/agents/ai-transport-runtime-host.ts
+++ b/src/agents/ai-transport-runtime-host.ts
@@ -45,6 +45,7 @@ export function configureAiTransportRuntimeHost(): void {
         resolveProviderStreamFn({
           ...params,
           config: params.config as OpenClawConfig | undefined,
+          runtimeHandle: getModelProviderRuntimePluginHandle(params.context.model),
           context: {
             ...params.context,
             config: params.context.config as OpenClawConfig | undefined,
@@ -65,6 +66,7 @@ export function configureAiTransportRuntimeHost(): void {
         wrapProviderSimpleCompletionStreamFn({
           ...params,
           config: params.config as OpenClawConfig | undefined,
+          runtimeHandle: getModelProviderRuntimePluginHandle(params.context.model),
           context: {
             ...params.context,
             config: params.context.config as OpenClawConfig | undefined,

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -3,7 +3,10 @@ import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { Context, Model, SimpleStreamOptions } from "openclaw/plugin-sdk/llm";
 import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { testing as extraParamsTesting } from "./embedded-agent-runner/extra-params.test-support.js";
+import {
+  testing as extraParamsTesting,
+  type WrapProviderStreamFnParams,
+} from "./embedded-agent-runner/extra-params.test-support.js";
 
 vi.mock("../plugins/provider-hook-runtime.js", () => ({
   clearProviderRuntimePluginCacheForTest: vi.fn(),
@@ -11,9 +14,8 @@ vi.mock("../plugins/provider-hook-runtime.js", () => ({
     buildHookProviderCacheKey: () => "test-provider-hook-cache-key",
     clearProviderRuntimePluginCacheForTest: vi.fn(),
   },
-  prepareProviderExtraParams: () => undefined,
-  resolveProviderExtraParamsForTransport: () => undefined,
-  wrapProviderStreamFn: (params: { context: { streamFn?: StreamFn } }) => params.context.streamFn,
+  ensureProviderRuntimePluginHandle: vi.fn(),
+  getModelProviderRuntimePluginHandle: () => undefined,
 }));
 
 const ANTHROPIC_DEFAULT_BETAS = [
@@ -246,10 +248,6 @@ import {
   resolvePreparedExtraParams,
 } from "./embedded-agent-runner/extra-params.js";
 import { log } from "./embedded-agent-runner/logger.js";
-
-type WrapProviderStreamFnParams = Parameters<
-  typeof import("../plugins/provider-hook-runtime.js").wrapProviderStreamFn
->[0];
 
 function installFullProviderRuntimeDepsForTest() {
   // Install a test-only provider runtime that composes the same wrapper families
@@ -2230,7 +2228,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(hookContext?.workspaceDir).toBe("/tmp/workspace");
   });
 
-  it("keys prepared extra-param memoization by resolved model transport inputs", () => {
+  it("prepares extra params from each model's transport inputs", () => {
     const resolveProviderExtraParamsForTransport = vi.fn((params) => ({
       patch: {
         transportFamily: params.context.model?.api,
@@ -2303,7 +2301,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(differentModelHeadersParams.baseUrl).toBe("https://api-two.example/v1");
     expect(differentModelHeadersParams.headerAuth).toBe("two");
     expect(repeatedResponsesParams.transportFamily).toBe("openai-responses");
-    expect(resolveProviderExtraParamsForTransport).toHaveBeenCalledTimes(3);
+    expect(resolveProviderExtraParamsForTransport).toHaveBeenCalledTimes(4);
   });
 
   it("passes explicit settings transport to transport extra-param hooks", () => {

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -1050,6 +1050,10 @@ export async function loadCompactHooksHarness(options: { durableSession?: boolea
 
   vi.doMock("../runtime-plan/build.js", () => ({
     buildAgentRuntimePlan: buildAgentRuntimePlanMock,
+    resolvePreparedProviderRuntimeHandle: vi.fn(
+      ({ providerRuntimeHandle, provider, modelId, workspaceDir }: BuildAgentRuntimePlanParams) =>
+        providerRuntimeHandle ?? { provider, modelId, workspaceDir, prepared: true },
+    ),
   }));
 
   vi.doMock("../../plugins/memory-runtime.js", () => ({

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -348,6 +348,7 @@ function createCompactHooksRuntimePlan(params: BuildAgentRuntimePlanParams): Age
       ...(modelApi ? { modelApi } : {}),
       ...(params.resolvedTransport ? { transport: params.resolvedTransport } : {}),
     },
+    providerRuntimeHandle: params.providerRuntimeHandle,
     auth: {
       providerForAuth: params.provider,
       authProfileProviderForAuth: params.authProfileProvider ?? params.provider,

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -17,6 +17,7 @@ import {
 import { delegateCompactionToRuntime } from "../../context-engine/delegate.js";
 import type { ContextEngine } from "../../context-engine/types.js";
 import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { getModelProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 import {
   requireActivePluginRegistry,
   withPluginRegistrationContext,
@@ -3325,19 +3326,13 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
   it("carries the prepared provider reconciler into direct compaction", async () => {
     mockResolvedModel();
     const reconcile = vi.fn(async () => undefined);
-    const buildDefaultPlan = buildAgentRuntimePlanMock.getMockImplementation();
-    if (!buildDefaultPlan) {
-      throw new Error("Compaction runtime plan fixture is not configured");
-    }
-    buildAgentRuntimePlanMock.mockImplementation((params) => ({
-      ...buildDefaultPlan(params),
-      providerRuntimeHandle: {
-        provider: params.provider,
-        modelId: params.modelId,
-        workspaceDir: params.workspaceDir,
-        prepared: true,
-        plugin: { reconcileLocalService: reconcile },
-      },
+    const { resolvePreparedProviderRuntimeHandle } = await import("../runtime-plan/build.js");
+    vi.mocked(resolvePreparedProviderRuntimeHandle).mockImplementationOnce((params) => ({
+      provider: params.provider,
+      modelId: params.modelId,
+      workspaceDir: params.workspaceDir,
+      prepared: true,
+      plugin: { id: params.provider, label: "Fixture", auth: [], reconcileLocalService: reconcile },
     }));
 
     await expect(compactEmbeddedAgentSessionDirect(wrappedCompactionArgs())).resolves.toMatchObject(
@@ -3348,6 +3343,9 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       model: object;
     };
     expect(getModelProviderLocalServiceReconciler(streamRegistration.model)).toBe(reconcile);
+    expect(getModelProviderRuntimePluginHandle(streamRegistration.model)).toBe(
+      buildAgentRuntimePlanMock.mock.calls[0]?.[0].providerRuntimeHandle,
+    );
   });
 
   it("aborts in-flight compaction when the caller abort signal fires", async () => {

--- a/src/agents/embedded-agent-runner/compaction-session-agent.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-agent.ts
@@ -1,6 +1,7 @@
 import type { LlmRuntime } from "@openclaw/ai";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { getModelProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { resolveProviderTextTransforms } from "../../plugins/provider-runtime.js";
 import { wrapStreamFnTextTransforms } from "../plugin-text-transforms.js";
@@ -75,6 +76,7 @@ export async function prepareCompactionSessionAgent(params: {
     provider: params.provider,
     config: params.config,
     workspaceDir: params.effectiveWorkspace,
+    runtimeHandle: getModelProviderRuntimePluginHandle(params.effectiveModel),
   });
   if (providerTextTransforms) {
     params.session.agent.streamFn = wrapStreamFnTextTransforms({

--- a/src/agents/embedded-agent-runner/extra-params.lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.lifecycle.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { Model, SimpleStreamOptions } from "../../llm/types.js";
+import { createAssistantMessageEventStream } from "../../llm/utils/event-stream.js";
+import {
+  attachModelProviderRuntimePluginHandle,
+  type ProviderRuntimePluginHandle,
+} from "../../plugins/provider-hook-runtime.js";
+import type { ProviderPlugin } from "../../plugins/types.js";
+import { makeProviderModelFixture } from "../test-helpers/provider-model-fixture.js";
+import { applyExtraParamsToAgent, resolvePreparedExtraParams } from "./extra-params.js";
+
+describe("prepared provider extra-param lifecycle", () => {
+  it("uses each prepared owner for params and stream wrapping with shared config", () => {
+    const cfg = { agents: { defaults: { params: { temperature: 0.1 } } } };
+    const model = makeProviderModelFixture({
+      provider: "fixture-provider",
+      id: "fixture-model",
+      api: "fixture-api",
+      baseUrl: "https://fixture.invalid",
+    });
+    const observed: Array<SimpleStreamOptions | undefined> = [];
+    for (const owner of ["first", "replacement", "updated"]) {
+      if (owner === "updated") {
+        cfg.agents.defaults.params.temperature = 0.7;
+      }
+      const plugin: ProviderPlugin = {
+        id: model.provider,
+        label: "Fixture",
+        auth: [],
+        prepareExtraParams: ({ extraParams }) => ({ ...extraParams, owner }),
+        extraParamsForTransport: ({ extraParams }) => ({
+          patch: { preparedBy: extraParams.owner },
+        }),
+        wrapStreamFn:
+          ({ streamFn, extraParams }) =>
+          (requestModel, context, options) =>
+            streamFn!(requestModel, context, {
+              ...options,
+              headers: { owner, preparedBy: String(extraParams?.preparedBy) },
+            }),
+      };
+      const providerRuntimeHandle: ProviderRuntimePluginHandle = {
+        provider: model.provider,
+        modelId: model.id,
+        config: cfg,
+        plugin,
+      };
+      const preparedExtraParams = resolvePreparedExtraParams({
+        cfg,
+        provider: model.provider,
+        modelId: model.id,
+        providerRuntimeHandle,
+      });
+      const agent = {
+        streamFn: (_model: Model, _context: unknown, options?: SimpleStreamOptions) => {
+          observed.push(options);
+          return createAssistantMessageEventStream();
+        },
+      };
+      const preparedModel = attachModelProviderRuntimePluginHandle(model, providerRuntimeHandle);
+      applyExtraParamsToAgent(
+        agent,
+        cfg,
+        model.provider,
+        model.id,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        preparedModel,
+        undefined,
+        undefined,
+        { preparedExtraParams },
+      );
+      agent.streamFn(model, { messages: [] });
+    }
+    expect(
+      observed.map((options) => ({ temperature: options?.temperature, headers: options?.headers })),
+    ).toEqual([
+      { temperature: 0.1, headers: { owner: "first", preparedBy: "first" } },
+      { temperature: 0.1, headers: { owner: "replacement", preparedBy: "replacement" } },
+      { temperature: 0.7, headers: { owner: "updated", preparedBy: "updated" } },
+    ]);
+  });
+});

--- a/src/agents/embedded-agent-runner/extra-params.provider-runtime.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.provider-runtime.test.ts
@@ -120,7 +120,7 @@ describe("extra-params: provider runtime handoff", () => {
     },
   );
 
-  it("keeps provider-ready max stable through provider hooks and cache lookup", () => {
+  it("passes provider-ready max through preparation and stream wrapping", () => {
     const prepareProviderExtraParams = vi.fn(({ context }) => context.extraParams);
     const resolveProviderExtraParamsForTransport = vi.fn(() => undefined);
     const wrapProviderStreamFn = vi.fn(({ context }) => context.streamFn);
@@ -144,9 +144,9 @@ describe("extra-params: provider runtime handoff", () => {
       thinkingLevel: "max",
     });
 
-    expect(first).toBe(repeated);
-    expect(prepareProviderExtraParams).toHaveBeenCalledTimes(1);
-    expect(resolveProviderExtraParamsForTransport).toHaveBeenCalledTimes(1);
+    expect(first).toEqual(repeated);
+    expect(prepareProviderExtraParams).toHaveBeenCalledTimes(2);
+    expect(resolveProviderExtraParamsForTransport).toHaveBeenCalledTimes(2);
     expect(prepareProviderExtraParams).toHaveBeenCalledWith(
       expect.objectContaining({ context: expect.objectContaining({ thinkingLevel: "max" }) }),
     );

--- a/src/agents/embedded-agent-runner/extra-params.sampling.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.sampling.test.ts
@@ -291,7 +291,7 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     expect(callOptions?.responseFormat).toEqual(responseFormat);
   });
 
-  it("keeps request-scoped response_format out of prepared extra params cache", () => {
+  it("keeps request-scoped response_format out of prepared extra params", () => {
     const prepareProviderExtraParams = vi.fn((params) => ({
       ...params.context.extraParams,
       prepared: true,
@@ -328,14 +328,14 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
       },
     });
 
-    expect(prepareProviderExtraParams).toHaveBeenCalledTimes(1);
-    expect(first).toBe(second);
+    expect(prepareProviderExtraParams).toHaveBeenCalledTimes(2);
+    expect(first).toEqual(second);
     expect(first).not.toHaveProperty("response_format");
     expect(first).not.toHaveProperty("responseFormat");
     expect(first.temperature).toBe(0.4);
   });
 
-  it("keeps request-scoped stop out of prepared extra params cache", () => {
+  it("keeps request-scoped stop out of prepared extra params", () => {
     const prepareProviderExtraParams = vi.fn((params) => ({
       ...params.context.extraParams,
       prepared: true,
@@ -360,8 +360,8 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
       extraParamsOverride: { temperature: 0.4, stop: ["Assistant:", "\n\n"] },
     });
 
-    expect(prepareProviderExtraParams).toHaveBeenCalledTimes(1);
-    expect(first).toBe(second);
+    expect(prepareProviderExtraParams).toHaveBeenCalledTimes(2);
+    expect(first).toEqual(second);
     expect(first).not.toHaveProperty("stop");
     expect(first.temperature).toBe(0.4);
   });
@@ -485,7 +485,7 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     expect(callOptions?.presencePenalty).toBe(0.7);
   });
 
-  it("keeps dynamic fast mode overrides out of prepared extra params cache", () => {
+  it("preserves each request's dynamic fast mode override", () => {
     const prepareProviderExtraParams = vi.fn((params) => ({
       ...params.context.extraParams,
       prepared: true,

--- a/src/agents/embedded-agent-runner/extra-params.test-support.ts
+++ b/src/agents/embedded-agent-runner/extra-params.test-support.ts
@@ -1,39 +1,61 @@
 // Shared harness for extra-params wrapper tests.
+import { vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { Context, Model, SimpleStreamOptions } from "../../llm/types.js";
-import type {
-  prepareProviderExtraParams,
-  resolveProviderExtraParamsForTransport,
-  wrapProviderStreamFn,
-} from "../../plugins/provider-hook-runtime.js";
+import * as providerRuntime from "../../plugins/provider-hook-runtime.js";
+import type { ProviderPlugin } from "../../plugins/types.js";
 import type { StreamFn } from "../runtime/index.js";
 import { applyExtraParamsToAgent } from "./extra-params.js";
 import type { ProviderThinkLevel } from "./utils.js";
 
-type ExtraParamsTestApi = {
-  setProviderRuntimeDepsForTest(
-    deps:
-      | Partial<{
-          prepareProviderExtraParams: typeof prepareProviderExtraParams;
-          resolveProviderExtraParamsForTransport: typeof resolveProviderExtraParamsForTransport;
-          wrapProviderStreamFn: typeof wrapProviderStreamFn;
-        }>
-      | undefined,
-  ): void;
-  resetProviderRuntimeDepsForTest(): void;
+type ProviderHook<K extends keyof ProviderPlugin> = Extract<
+  ProviderPlugin[K],
+  (...args: never[]) => unknown
+>;
+type ProviderHookCall<K extends keyof ProviderPlugin> = {
+  provider: string;
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  context: Parameters<ProviderHook<K>>[0];
+};
+export type WrapProviderStreamFnParams = ProviderHookCall<"wrapStreamFn">;
+type ProviderRuntimeDeps = {
+  prepareProviderExtraParams: (
+    params: ProviderHookCall<"prepareExtraParams">,
+  ) => ReturnType<ProviderHook<"prepareExtraParams">>;
+  resolveProviderExtraParamsForTransport: (
+    params: ProviderHookCall<"extraParamsForTransport">,
+  ) => ReturnType<ProviderHook<"extraParamsForTransport">>;
+  wrapProviderStreamFn: (
+    params: WrapProviderStreamFnParams,
+  ) => ReturnType<ProviderHook<"wrapStreamFn">>;
 };
 
-function getTestApi(): ExtraParamsTestApi {
-  const api = (globalThis as Record<PropertyKey, unknown>)[
-    Symbol.for("openclaw.extraParamsTestApi")
-  ];
-  if (!api) {
-    throw new Error("extra params test API is unavailable");
-  }
-  return api as ExtraParamsTestApi;
-}
-
-export const testing = getTestApi();
+export const testing = {
+  setProviderRuntimeDepsForTest(deps: Partial<ProviderRuntimeDeps> = {}): void {
+    vi.spyOn(providerRuntime, "ensureProviderRuntimePluginHandle").mockImplementation((params) => {
+      if (params.runtimeHandle) {
+        return params.runtimeHandle;
+      }
+      return {
+        ...params,
+        plugin: {
+          id: params.provider,
+          label: params.provider,
+          auth: [],
+          prepareExtraParams: (context) =>
+            deps.prepareProviderExtraParams?.({ ...params, context }),
+          extraParamsForTransport: (context) =>
+            deps.resolveProviderExtraParamsForTransport?.({ ...params, context }),
+          wrapStreamFn: (context) => deps.wrapProviderStreamFn?.({ ...params, context }),
+        },
+      };
+    });
+  },
+  resetProviderRuntimeDepsForTest(): void {
+    vi.mocked(providerRuntime.ensureProviderRuntimePluginHandle).mockRestore();
+  },
+};
 
 type ExtraParamsCapture<TPayload extends Record<string, unknown>> = {
   headers?: Record<string, string>;

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -32,10 +32,9 @@ import {
   createThinkingOnlyFinalTextWrapper,
 } from "../../plugin-sdk/provider-stream-shared.js";
 import {
-  prepareProviderExtraParams as prepareProviderExtraParamsRuntime,
+  ensureProviderRuntimePluginHandle,
+  getModelProviderRuntimePluginHandle,
   type ProviderRuntimePluginHandle,
-  resolveProviderExtraParamsForTransport as resolveProviderExtraParamsForTransportRuntime,
-  wrapProviderStreamFn as wrapProviderStreamFnRuntime,
 } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { resolveModelExtraParamSources } from "../model-extra-params.js";
@@ -57,17 +56,6 @@ function requireBaseStreamFn(streamFn: StreamFn | undefined): StreamFn {
   return streamFn;
 }
 
-const defaultProviderRuntimeDeps = {
-  prepareProviderExtraParams: prepareProviderExtraParamsRuntime,
-  resolveProviderExtraParamsForTransport: resolveProviderExtraParamsForTransportRuntime,
-  wrapProviderStreamFn: wrapProviderStreamFnRuntime,
-};
-
-const providerRuntimeDeps = {
-  ...defaultProviderRuntimeDeps,
-};
-
-let preparedExtraParamsCache = new WeakMap<OpenClawConfig, Map<string, Record<string, unknown>>>();
 const REQUEST_SCOPED_EXTRA_PARAM_KEYS = new Set(["response_format", "responseFormat", "stop"]);
 const GPT_PARALLEL_TOOL_CALLS_APIS = new Set([
   "openai-completions",
@@ -81,37 +69,9 @@ function supportsGptParallelToolCallsPayload(api: unknown): boolean {
   return typeof api === "string" && GPT_PARALLEL_TOOL_CALLS_APIS.has(api);
 }
 
-const testing = {
-  setProviderRuntimeDepsForTest(
-    deps: Partial<typeof defaultProviderRuntimeDeps> | undefined,
-  ): void {
-    providerRuntimeDeps.prepareProviderExtraParams =
-      deps?.prepareProviderExtraParams ?? defaultProviderRuntimeDeps.prepareProviderExtraParams;
-    providerRuntimeDeps.resolveProviderExtraParamsForTransport =
-      deps?.resolveProviderExtraParamsForTransport ??
-      defaultProviderRuntimeDeps.resolveProviderExtraParamsForTransport;
-    providerRuntimeDeps.wrapProviderStreamFn =
-      deps?.wrapProviderStreamFn ?? defaultProviderRuntimeDeps.wrapProviderStreamFn;
-  },
-  resetProviderRuntimeDepsForTest(): void {
-    clearPreparedExtraParamsCache();
-    providerRuntimeDeps.prepareProviderExtraParams =
-      defaultProviderRuntimeDeps.prepareProviderExtraParams;
-    providerRuntimeDeps.resolveProviderExtraParamsForTransport =
-      defaultProviderRuntimeDeps.resolveProviderExtraParamsForTransport;
-    providerRuntimeDeps.wrapProviderStreamFn = defaultProviderRuntimeDeps.wrapProviderStreamFn;
-  },
-};
-
-if (process.env.VITEST || process.env.NODE_ENV === "test") {
-  (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.extraParamsTestApi")] = testing;
-}
-
 /**
  * Resolve provider-specific extra params from model config.
  * Used to pass through stream params like temperature/maxTokens.
- *
- * @internal Exported for testing only
  */
 export function resolveExtraParams(params: {
   cfg: OpenClawConfig | undefined;
@@ -204,61 +164,6 @@ function hasExplicitTransportSetting(settings: { transport?: unknown }): boolean
   return Object.hasOwn(settings, "transport");
 }
 
-function clearPreparedExtraParamsCache(): void {
-  preparedExtraParamsCache = new WeakMap();
-}
-
-function fingerprintPreparedExtraParamsModel(model?: ProviderRuntimeModel): unknown {
-  if (!model) {
-    return null;
-  }
-  return {
-    api: model.api,
-    provider: model.provider,
-    id: model.id,
-    name: model.name,
-    baseUrl: model.baseUrl,
-    reasoning: model.reasoning,
-    input: model.input,
-    cost: model.cost,
-    compat: Reflect.get(model, "compat") ?? null,
-    contextWindow: model.contextWindow,
-    contextTokens: model.contextTokens ?? null,
-    headers: Reflect.get(model, "headers") ?? null,
-    maxTokens: model.maxTokens,
-    maxTokensSource: model.maxTokensSource ?? null,
-    params: model.params ?? null,
-    requestTimeoutMs: model.requestTimeoutMs ?? null,
-  };
-}
-
-function resolvePreparedExtraParamsCacheKey(params: {
-  provider: string;
-  modelId: string;
-  agentDir?: string;
-  workspaceDir?: string;
-  extraParamsOverride?: Record<string, unknown>;
-  thinkingLevel?: ProviderThinkLevel;
-  agentId?: string;
-  resolvedExtraParams?: Record<string, unknown>;
-  model?: ProviderRuntimeModel;
-  resolvedTransport?: SupportedTransport;
-}): string {
-  return JSON.stringify({
-    provider: params.provider,
-    modelId: params.modelId,
-    agentId: params.agentId ?? "",
-    agentDir: params.agentDir ?? "",
-    workspaceDir: params.workspaceDir ?? "",
-    thinkingLevel: params.thinkingLevel ?? "",
-    resolvedTransport: params.resolvedTransport ?? "",
-    extraParamsOverride:
-      stripRequestScopedExtraParams(sanitizeExtraParamsRecord(params.extraParamsOverride)) ?? null,
-    resolvedExtraParams: params.resolvedExtraParams ?? null,
-    model: fingerprintPreparedExtraParamsModel(params.model),
-  });
-}
-
 export function resolvePreparedExtraParams(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
@@ -311,64 +216,36 @@ export function resolvePreparedExtraParams(params: {
   if (params.provider === "openrouter") {
     canonicalizeOpenRouterResponseCacheParams(merged, [resolvedExtraParams, override]);
   }
-  const cfg = params.cfg;
-  const cacheKey =
-    cfg && !hasFunctionExtraParamValue(params.extraParamsOverride)
-      ? resolvePreparedExtraParamsCacheKey(params)
-      : undefined;
-  if (cacheKey) {
-    const cached = preparedExtraParamsCache.get(cfg!)?.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
-  }
-  const prepared =
-    providerRuntimeDeps.prepareProviderExtraParams({
-      provider: params.provider,
-      config: params.cfg,
-      workspaceDir: params.workspaceDir,
-      runtimeHandle: params.providerRuntimeHandle,
-      context: {
-        config: params.cfg,
-        agentDir: params.agentDir,
-        workspaceDir: params.workspaceDir,
-        provider: params.provider,
-        modelId: params.modelId,
-        model: params.model,
-        extraParams: merged,
-        thinkingLevel: params.thinkingLevel,
-      },
-    }) ?? merged;
-  const transportPatch = providerRuntimeDeps.resolveProviderExtraParamsForTransport({
+  // Runtime plans memoize their own defaults. Results must not outlive the
+  // prepared provider or share mutable hook output with another attempt.
+  const { plugin } = ensureProviderRuntimePluginHandle({
     provider: params.provider,
+    modelId: params.modelId,
     config: params.cfg,
     workspaceDir: params.workspaceDir,
-    runtimeHandle: params.providerRuntimeHandle,
-    context: {
-      config: params.cfg,
-      agentDir: params.agentDir,
-      workspaceDir: params.workspaceDir,
-      provider: params.provider,
-      modelId: params.modelId,
-      extraParams: prepared,
-      thinkingLevel: params.thinkingLevel,
-      model: params.model,
-      transport: params.resolvedTransport ?? resolveSupportedTransport(prepared.transport),
-    },
+    runtimeHandle:
+      params.providerRuntimeHandle ?? getModelProviderRuntimePluginHandle(params.model),
+  });
+  const context = {
+    config: params.cfg,
+    agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
+    provider: params.provider,
+    modelId: params.modelId,
+    model: params.model,
+    thinkingLevel: params.thinkingLevel,
+  };
+  const prepared = plugin?.prepareExtraParams?.({ ...context, extraParams: merged }) ?? merged;
+  const transportPatch = plugin?.extraParamsForTransport?.({
+    ...context,
+    extraParams: prepared,
+    transport: params.resolvedTransport ?? resolveSupportedTransport(prepared.transport),
   })?.patch;
   const result = transportPatch ? { ...prepared, ...transportPatch } : prepared;
   canonicalizeMaxTokensParam({
     merged: result,
     sources: [prepared, transportPatch ?? undefined],
   });
-  if (cacheKey) {
-    let bucket = preparedExtraParamsCache.get(cfg!);
-    if (!bucket) {
-      bucket = new Map();
-      preparedExtraParamsCache.set(cfg!, bucket);
-    }
-    bucket.set(cacheKey, result);
-  }
   return result;
 }
 
@@ -404,9 +281,6 @@ function hasRequestScopedExtraParams(value: Record<string, unknown> | undefined)
   return [...REQUEST_SCOPED_EXTRA_PARAM_KEYS].some((key) => Object.hasOwn(value, key));
 }
 
-function hasFunctionExtraParamValue(value: Record<string, unknown> | undefined): boolean {
-  return Boolean(value && Object.values(value).some((item) => typeof item === "function"));
-}
 function shouldApplyDefaultOpenAIGptRuntimeParams(params: {
   provider: string;
   modelId: string;
@@ -1090,8 +964,6 @@ function isMiMoReasoningAsVisibleTextOpenAICompatibleModel(
 /**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also applies verified provider-specific request wrappers, such as OpenRouter attribution.
- *
- * @internal Exported for testing
  */
 export function applyExtraParamsToAgent(
   agent: { streamFn?: StreamFn },
@@ -1110,6 +982,13 @@ export function applyExtraParamsToAgent(
     nativeWebSearchPolicyContext?: NativeWebSearchToolPolicyParams;
   },
 ) {
+  const providerRuntimeHandle = ensureProviderRuntimePluginHandle({
+    provider,
+    modelId,
+    config: cfg,
+    workspaceDir,
+    runtimeHandle: getModelProviderRuntimePluginHandle(model),
+  });
   const resolvedExtraParams = resolveExtraParams({
     cfg,
     provider,
@@ -1138,6 +1017,7 @@ export function applyExtraParamsToAgent(
       resolvedExtraParams,
       model,
       resolvedTransport,
+      providerRuntimeHandle,
     });
   const wrapperContext: ApplyExtraParamsContext = {
     agent,
@@ -1163,11 +1043,8 @@ export function applyExtraParamsToAgent(
         ...options.nativeWebSearchPolicyContext,
       })
     : undefined;
-  const pluginWrappedStreamFn = providerRuntimeDeps.wrapProviderStreamFn({
-    provider,
-    config: cfg,
-    workspaceDir,
-    context: {
+  const pluginWrappedStreamFn =
+    providerRuntimeHandle.plugin?.wrapStreamFn?.({
       config: cfg,
       agentDir,
       workspaceDir,
@@ -1179,8 +1056,7 @@ export function applyExtraParamsToAgent(
       thinkingLevel,
       model,
       streamFn: providerStreamBase,
-    },
-  });
+    }) ?? undefined;
   agent.streamFn = pluginWrappedStreamFn ?? providerStreamBase;
   // Apply caller/config extra params outside provider defaults so explicit runtime
   // transport values can override provider-added defaults.

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -13,10 +13,7 @@ import {
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { resolveRuntimeOsLabel } from "../../infra/os-summary.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-registry-state.js";
-import {
-  attachModelProviderRuntimePluginHandle,
-  type ProviderRuntimePluginHandle,
-} from "../../plugins/provider-hook-runtime.js";
+import { attachModelProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 import { extractModelCompat } from "../../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { transformProviderSystemPrompt } from "../../plugins/provider-runtime.js";
@@ -57,7 +54,10 @@ import {
 import { supportsModelTools } from "../model-tool-support.js";
 import { resolveAgentPromptSurfaceForSessionKey } from "../prompt-surface.js";
 import { collectRuntimeChannelCapabilities } from "../runtime-capabilities.js";
-import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
+import {
+  buildAgentRuntimePlan,
+  resolvePreparedProviderRuntimeHandle,
+} from "../runtime-plan/build.js";
 import type { AgentRuntimePlan } from "../runtime-plan/types.js";
 import {
   resolveSessionPermissionExecMode,
@@ -246,7 +246,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       requestedTokenBudget: params.contextTokenBudget,
       fallbackTokenBudget: params.tokenBudget,
     });
-    const effectiveModelWithoutRuntimeHandle = applyAuthHeaderOverride(
+    const modelWithAuth = applyAuthHeaderOverride(
       applyLocalNoAuthHeaderOverride(
         contextTokenBudget < (runtimeModelWithContext.contextWindow ?? Infinity)
           ? { ...runtimeModelWithContext, contextWindow: contextTokenBudget }
@@ -259,14 +259,27 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       hasRuntimeAuthExchange ? null : apiKeyInfo,
       params.config,
     );
+    const providerRuntimeHandle = resolvePreparedProviderRuntimeHandle({
+      provider,
+      modelId,
+      config: params.config,
+      workspaceDir: effectiveWorkspace,
+      providerRuntimeHandle: params.runtimePlan?.providerRuntimeHandle,
+      metadataSnapshot: params.preparedModelRuntime.metadataSnapshot,
+    });
+    const effectiveModel = attachModelProviderRuntimePluginHandle(
+      modelWithAuth,
+      providerRuntimeHandle,
+    );
     const reuseFullRuntimePlan = params.runtimePlan?.auth === resolvedRuntimeAuthPlan;
     const preparedRuntimePlan =
       (reuseFullRuntimePlan ? params.runtimePlan : undefined) ??
       buildAgentRuntimePlan({
         provider,
         modelId,
-        model: effectiveModelWithoutRuntimeHandle,
-        modelApi: effectiveModelWithoutRuntimeHandle.api,
+        model: effectiveModel,
+        modelApi: effectiveModel.api,
+        providerRuntimeHandle,
         harnessId: preparedHarnessRuntime,
         harnessRuntime: preparedHarnessRuntime,
         authProfileMode: resolvedRuntimeAuthPlan.selectedAuthMode,
@@ -283,14 +296,6 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
     const runtimePlan = reuseFullRuntimePlan
       ? preparedRuntimePlan
       : { ...preparedRuntimePlan, auth: resolvedRuntimeAuthPlan };
-    const effectiveModel = runtimePlan.providerRuntimeHandle
-      ? attachModelProviderRuntimePluginHandle(
-          effectiveModelWithoutRuntimeHandle,
-          // SAFETY: runtime plans use canonical plugin handles; public types omit plugin internals.
-          runtimePlan.providerRuntimeHandle as ProviderRuntimePluginHandle,
-        )
-      : effectiveModelWithoutRuntimeHandle;
-
     const runAbortController = new AbortController();
     const spawnWorkspaceDir =
       effectiveCwd !== effectiveWorkspace

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -490,6 +490,7 @@ export async function prepareEmbeddedAttemptTransport(input: {
       cfg: attempt.config,
       provider: attempt.provider,
       modelId: attempt.modelId,
+      providerRuntimeHandle: input.getProviderRuntimeHandle(),
       extraParamsOverride: streamExtraParamsOverride,
       thinkingLevel: input.providerThinkingLevel,
       agentId: input.sessionAgentId,

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -14,7 +14,6 @@ import {
   getModelProviderRuntimePluginHandle,
   resolveProviderRuntimePluginHandle,
   type ProviderRuntimePluginHandle,
-  wrapProviderStreamFn,
 } from "../plugins/provider-hook-runtime.js";
 import { resolveProviderStreamFn } from "../plugins/provider-runtime.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
@@ -94,21 +93,14 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
   }
   const providerWrappedStreamFn =
     params.wrapProviderStream && runtimeHandle
-      ? (wrapProviderStreamFn({
-          provider: runtimeModel.provider,
+      ? (runtimeHandle.plugin?.wrapStreamFn?.({
           config: params.cfg,
+          agentDir: params.agentDir,
           workspaceDir: params.workspaceDir,
-          env: params.env,
-          runtimeHandle,
-          context: {
-            config: params.cfg,
-            agentDir: params.agentDir,
-            workspaceDir: params.workspaceDir,
-            provider: runtimeModel.provider,
-            modelId: runtimeModel.id,
-            model: runtimeModel,
-            streamFn,
-          },
+          provider: runtimeModel.provider,
+          modelId: runtimeModel.id,
+          model: runtimeModel,
+          streamFn,
         }) ?? streamFn)
       : streamFn;
   const preparedStreamFn = runtimeHandle

--- a/src/agents/runtime-plan/build.test.ts
+++ b/src/agents/runtime-plan/build.test.ts
@@ -4,7 +4,6 @@ import { createParameterFreeTool } from "openclaw/plugin-sdk/agent-runtime-test-
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetConfigRuntimeState } from "../../config/config.js";
 import {
-  prepareProviderExtraParams,
   resolveProviderFollowupFallbackRoute,
   resolveProviderRuntimePluginHandle,
   type ProviderRuntimePluginHandle,
@@ -26,14 +25,12 @@ vi.mock("../../plugins/provider-hook-runtime.js", () => ({
   ensureProviderRuntimePluginHandle: vi.fn(
     (params) => params.runtimeHandle ?? { provider: "openai" },
   ),
-  prepareProviderExtraParams: vi.fn(() => undefined),
+  getModelProviderRuntimePluginHandle: () => undefined,
   resolveProviderAuthProfileId: vi.fn(() => undefined),
-  resolveProviderExtraParamsForTransport: vi.fn(() => undefined),
   resolveProviderFollowupFallbackRoute: vi.fn(() => undefined),
   resolveProviderPluginsForHooks: vi.fn(() => []),
   resolveProviderRuntimePlugin: vi.fn(() => undefined),
   resolveProviderRuntimePluginHandle: vi.fn(() => ({ provider: "openai" })),
-  wrapProviderStreamFn: vi.fn(() => undefined),
 }));
 
 const gpt54Model = {
@@ -94,9 +91,19 @@ describe("AgentRuntimePlan", () => {
   it("defers default transport extra params until they are read", () => {
     // Extra params are lazy so plan construction stays cheap and provider hooks
     // only run if a transport path actually needs them.
-    const prepareProviderExtraParamsMock = vi.mocked(prepareProviderExtraParams);
-    prepareProviderExtraParamsMock.mockClear();
-
+    const prepareProviderExtraParamsMock = vi.fn(() => undefined);
+    const providerRuntimeHandle = {
+      provider: "openai",
+      modelId: gpt54Model.id,
+      workspaceDir: "/tmp/openclaw-runtime-plan",
+      prepared: true,
+      plugin: {
+        id: "openai",
+        label: "OpenAI",
+        auth: [],
+        prepareExtraParams: prepareProviderExtraParamsMock,
+      },
+    } satisfies ProviderRuntimePluginHandle & { modelId: string; prepared: true };
     const plan = buildAgentRuntimePlan({
       provider: "openai",
       modelId: "gpt-5.4",
@@ -104,6 +111,7 @@ describe("AgentRuntimePlan", () => {
       config: {},
       workspaceDir: "/tmp/openclaw-runtime-plan",
       model: gpt54Model,
+      providerRuntimeHandle,
     });
 
     expect(prepareProviderExtraParamsMock).not.toHaveBeenCalled();
@@ -114,6 +122,37 @@ describe("AgentRuntimePlan", () => {
     expect(prepareProviderExtraParamsMock).toHaveBeenCalledTimes(1);
     void plan.transport.extraParams;
     expect(prepareProviderExtraParamsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps prepared extra params within their provider generation and attempt", () => {
+    const config = { agents: { defaults: { params: { temperature: 0.1 } } } };
+    const buildPlan = (owner: string) => {
+      const providerRuntimeHandle = {
+        provider: "fixture-provider",
+        modelId: "fixture-model",
+        prepared: true,
+        plugin: {
+          id: "fixture-provider",
+          label: "Fixture",
+          auth: [],
+          prepareExtraParams: ({ extraParams }) => ({ ...extraParams, owner }),
+        },
+      } satisfies ProviderRuntimePluginHandle & { modelId: string; prepared: true };
+      return buildAgentRuntimePlan({
+        config,
+        provider: "fixture-provider",
+        modelId: "fixture-model",
+        providerRuntimeHandle,
+      });
+    };
+    const first = buildPlan("first");
+    expect(first.transport.extraParams).toEqual({ temperature: 0.1, owner: "first" });
+    const replacement = buildPlan("replacement");
+    expect(replacement.transport.extraParams).toEqual({ temperature: 0.1, owner: "replacement" });
+    config.agents.defaults.params.temperature = 0.7;
+    const updated = buildPlan("updated");
+    expect(updated.transport.extraParams).toEqual({ temperature: 0.7, owner: "updated" });
+    expect(first.transport.extraParams).toEqual({ temperature: 0.1, owner: "first" });
   });
 
   it("records resolved model, auth, transport, tool, delivery, and observability policy", () => {

--- a/src/agents/runtime-plan/build.ts
+++ b/src/agents/runtime-plan/build.ts
@@ -61,7 +61,7 @@ function resolvePreparedMetadataSnapshot(
   return params.metadataSnapshot as PluginMetadataSnapshot | undefined;
 }
 
-function resolvePreparedProviderRuntimeHandle(
+export function resolvePreparedProviderRuntimeHandle(
   params: RuntimePlanMetadataParams,
 ): ProviderRuntimePluginHandle & { modelId: string; prepared: true } {
   if (

--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -32,8 +32,6 @@ import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-s
 import { getPluginRuntimeGenerationRegistry } from "./runtime/generation-scope.js";
 import type {
   ProviderPlugin,
-  ProviderExtraParamsForTransportContext,
-  ProviderPrepareExtraParamsContext,
   ProviderResolveAuthProfileIdContext,
   ProviderFollowupFallbackRouteContext,
   ProviderFollowupFallbackRouteResult,
@@ -438,34 +436,6 @@ export function ensureProviderRuntimePluginHandle(
   return params.runtimeHandle;
 }
 
-export function prepareProviderExtraParams(params: {
-  provider: string;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  runtimeHandle?: ProviderRuntimePluginHandle;
-  context: ProviderPrepareExtraParamsContext;
-}) {
-  return (
-    ensureProviderRuntimePluginHandle(params).plugin?.prepareExtraParams?.(params.context) ??
-    undefined
-  );
-}
-
-export function resolveProviderExtraParamsForTransport(params: {
-  provider: string;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  runtimeHandle?: ProviderRuntimePluginHandle;
-  context: ProviderExtraParamsForTransportContext;
-}) {
-  return (
-    ensureProviderRuntimePluginHandle(params).plugin?.extraParamsForTransport?.(params.context) ??
-    undefined
-  );
-}
-
 export function resolveProviderAuthProfileId(params: {
   provider: string;
   config?: OpenClawConfig;
@@ -491,19 +461,6 @@ export function resolveProviderFollowupFallbackRoute(params: {
   return (
     ensureProviderRuntimePluginHandle(params).plugin?.followupFallbackRoute?.(params.context) ??
     undefined
-  );
-}
-
-export function wrapProviderStreamFn(params: {
-  provider: string;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  runtimeHandle?: ProviderRuntimePluginHandle;
-  context: ProviderWrapStreamFnContext;
-}) {
-  return (
-    ensureProviderRuntimePluginHandle(params).plugin?.wrapStreamFn?.(params.context) ?? undefined
   );
 }
 

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -1,5 +1,5 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import type { AgentMessage, StreamFn } from "openclaw/plugin-sdk/agent-core";
 /** Exercises provider runtime loading, ordering, and manifest-backed discovery paths. */
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -73,10 +73,10 @@ let normalizeProviderConfigWithPlugin: typeof import("./provider-runtime.js").no
 let normalizeProviderModelIdWithPlugin: typeof import("./provider-runtime.js").normalizeProviderModelIdWithPlugin;
 let applyProviderResolvedTransportWithPlugin: typeof import("./provider-runtime.js").applyProviderResolvedTransportWithPlugin;
 let normalizeProviderTransportWithPlugin: typeof import("./provider-runtime.js").normalizeProviderTransportWithPlugin;
-let prepareProviderExtraParams: typeof import("./provider-runtime.js").prepareProviderExtraParams;
+let resolvePreparedExtraParams: typeof import("../agents/embedded-agent-runner/extra-params.js").resolvePreparedExtraParams;
+let applyExtraParamsToAgent: typeof import("../agents/embedded-agent-runner/extra-params.js").applyExtraParamsToAgent;
 let resolveProviderAuthProfileId: typeof import("./provider-runtime.js").resolveProviderAuthProfileId;
 let resolveProviderConfigApiKeyWithPlugin: typeof import("./provider-runtime.js").resolveProviderConfigApiKeyWithPlugin;
-let resolveProviderExtraParamsForTransport: typeof import("./provider-runtime.js").resolveProviderExtraParamsForTransport;
 let resolveProviderFollowupFallbackRoute: typeof import("./provider-runtime.js").resolveProviderFollowupFallbackRoute;
 let resolveProviderStreamFn: typeof import("./provider-runtime.js").resolveProviderStreamFn;
 let resolveProviderTransportTurnStateWithPlugin: typeof import("./provider-runtime.js").resolveProviderTransportTurnStateWithPlugin;
@@ -103,7 +103,6 @@ let resolveProviderRuntimePlugin: typeof import("./provider-runtime.js").resolve
 let runProviderDynamicModel: typeof import("./provider-runtime.js").runProviderDynamicModel;
 let validateProviderReplayTurnsWithPlugin: typeof import("./provider-runtime.js").validateProviderReplayTurnsWithPlugin;
 let wrapProviderSimpleCompletionStreamFn: typeof import("./provider-runtime.js").wrapProviderSimpleCompletionStreamFn;
-let wrapProviderStreamFn: typeof import("./provider-runtime.js").wrapProviderStreamFn;
 let createEmptyPluginRegistry: typeof import("./registry-empty.js").createEmptyPluginRegistry;
 let resetPluginRuntimeStateForTest: typeof import("./runtime.js").resetPluginRuntimeStateForTest;
 let setActivePluginRegistry: typeof import("./runtime.js").setActivePluginRegistry;
@@ -331,10 +330,8 @@ describe("provider-runtime", () => {
       normalizeProviderConfigWithPlugin,
       normalizeProviderModelIdWithPlugin,
       normalizeProviderTransportWithPlugin,
-      prepareProviderExtraParams,
       resolveProviderAuthProfileId,
       resolveProviderConfigApiKeyWithPlugin,
-      resolveProviderExtraParamsForTransport,
       resolveProviderFollowupFallbackRoute,
       resolveProviderStreamFn,
       resolveProviderTransportTurnStateWithPlugin,
@@ -361,8 +358,9 @@ describe("provider-runtime", () => {
       runProviderDynamicModel,
       validateProviderReplayTurnsWithPlugin,
       wrapProviderSimpleCompletionStreamFn,
-      wrapProviderStreamFn,
     } = await import("./provider-runtime.js"));
+    ({ resolvePreparedExtraParams, applyExtraParamsToAgent } =
+      await import("../agents/embedded-agent-runner/extra-params.js"));
     ({ attachModelProviderRuntimePluginHandle, resolveProviderPluginsForHooks } =
       await import("./provider-hook-runtime.js"));
     await import("../agents/ai-transport-runtime-host.js");
@@ -632,12 +630,11 @@ describe("provider-runtime", () => {
     setActivePluginRegistry(registry, "startup-registry", "gateway-bindable", "/tmp/workspace");
 
     expect(
-      prepareProviderExtraParams({
+      resolvePreparedExtraParams({
+        cfg: undefined,
         provider: DEMO_PROVIDER_ID,
+        modelId: MODEL.id,
         workspaceDir: "/tmp/workspace",
-        context: createDemoRuntimeContext({
-          extraParams: {},
-        }),
       }),
     ).toEqual({
       fromActiveRegistry: true,
@@ -881,6 +878,9 @@ describe("provider-runtime", () => {
   });
 
   it("reuses the attempt-prepared provider handle at the model transport boundary", () => {
+    const streamFn = vi.fn();
+    const createStreamFn = vi.fn(() => streamFn);
+    const wrapSimpleCompletionStreamFn = vi.fn(() => streamFn);
     const resolveTransportTurnState = vi.fn(() => ({
       headers: { "x-demo-turn": "turn-1" },
     }));
@@ -889,6 +889,8 @@ describe("provider-runtime", () => {
       label: "Demo",
       auth: [],
       resolveTransportTurnState,
+      createStreamFn,
+      wrapSimpleCompletionStreamFn,
     };
     const model = attachModelProviderRuntimePluginHandle(MODEL, {
       provider: DEMO_PROVIDER_ID,
@@ -914,8 +916,43 @@ describe("provider-runtime", () => {
       }),
     ).toEqual({ headers: { "x-demo-turn": "turn-1" } });
     expect(resolveTransportTurnState).toHaveBeenCalledOnce();
+    expect(
+      getAiTransportHost().plugin.resolveProviderStream({
+        provider: DEMO_PROVIDER_ID,
+        allowRuntimePluginLoad: true,
+        context: createDemoResolvedModelContext({ model }),
+      }),
+    ).toBe(streamFn);
+    expect(
+      getAiTransportHost().plugin.wrapSimpleCompletionStream({
+        provider: DEMO_PROVIDER_ID,
+        context: createDemoResolvedModelContext({ model, streamFn }),
+      }),
+    ).toBe(streamFn);
+    expect(createStreamFn).toHaveBeenCalledOnce();
+    expect(wrapSimpleCompletionStreamFn).toHaveBeenCalledOnce();
     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
     expect(isPluginProvidersLoadInFlightMock).not.toHaveBeenCalled();
+  });
+
+  it("honors an explicit transport fallback owner over the model's attached handle", () => {
+    const streamFn = vi.fn();
+    registerLoadedProviders([
+      { id: "fallback", label: "Fallback", auth: [], createStreamFn: () => streamFn },
+    ]);
+    const model = attachModelProviderRuntimePluginHandle(MODEL, {
+      provider: DEMO_PROVIDER_ID,
+      modelId: MODEL.id,
+      plugin: { id: DEMO_PROVIDER_ID, label: "Demo", auth: [] },
+    });
+    expect(
+      getAiTransportHost().plugin.resolveProviderStream({
+        provider: "fallback",
+        allowRuntimePluginLoad: false,
+        context: createDemoResolvedModelContext({ model }),
+      }),
+    ).toBe(streamFn);
+    expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
 
   it("does not load runtime plugins for transport turn-state hooks when loading is disabled", () => {
@@ -1440,17 +1477,16 @@ describe("provider-runtime", () => {
     ]);
 
     expect(
-      resolveProviderExtraParamsForTransport({
+      resolvePreparedExtraParams({
+        cfg: undefined,
         provider: DEMO_PROVIDER_ID,
-        context: createDemoResolvedModelContext({
-          extraParams: { transport: "websocket" },
-          transport: "websocket" as const,
-        }),
+        modelId: MODEL.id,
+        model: MODEL,
+        extraParamsOverride: { transport: "websocket" },
       }),
     ).toEqual({
-      patch: {
-        providerTransportPatch: true,
-      },
+      transport: "websocket",
+      providerTransportPatch: true,
     });
     expectRecordFields(
       requireRecord(firstMockArg(extraParamsForTransport), "transport params context"),
@@ -1999,15 +2035,10 @@ describe("provider-runtime", () => {
       },
     ]);
 
-    expect(
-      wrapProviderStreamFn({
-        provider: "azure-openai-responses",
-        context: createDemoResolvedModelContext({
-          provider: "azure-openai-responses",
-          streamFn: wrappedStreamFn,
-        }),
-      }),
-    ).toBe(wrappedStreamFn);
+    const agent: { streamFn: StreamFn } = { streamFn: wrappedStreamFn };
+    applyExtraParamsToAgent(agent, undefined, "azure-openai-responses", MODEL.id);
+    void agent.streamFn(MODEL, { messages: [] });
+    expect(wrappedStreamFn).toHaveBeenCalledOnce();
   });
 
   it("resolves opt-in simple-completion stream wrappers", () => {
@@ -2083,15 +2114,12 @@ describe("provider-runtime", () => {
     });
 
     expect(
-      resolveProviderExtraParamsForTransport({
+      resolvePreparedExtraParams({
+        cfg: undefined,
         provider: "mock-openai",
-        context: createDemoRuntimeContext({
-          provider: "mock-openai",
-          modelId: "gpt-5.5",
-          extraParams: {},
-        }),
+        modelId: "gpt-5.5",
       }),
-    ).toBeUndefined();
+    ).toEqual({});
     expect(resolvePluginProvidersMock).toHaveBeenCalledOnce();
   });
 
@@ -2448,11 +2476,11 @@ describe("provider-runtime", () => {
     ).toBe("tagged");
 
     expect(
-      prepareProviderExtraParams({
+      resolvePreparedExtraParams({
+        cfg: undefined,
         provider: DEMO_PROVIDER_ID,
-        context: createDemoRuntimeContext({
-          extraParams: { temperature: 0.3 },
-        }),
+        modelId: MODEL.id,
+        extraParamsOverride: { temperature: 0.3 },
       }),
     ).toEqual({
       temperature: 0.3,
@@ -2564,14 +2592,19 @@ describe("provider-runtime", () => {
       },
     ]);
 
-    expect(
-      wrapProviderStreamFn({
-        provider: DEMO_PROVIDER_ID,
-        context: createDemoResolvedModelContext({
-          streamFn: vi.fn(),
-        }),
-      }),
-    ).toBeTypeOf("function");
+    const agent = { streamFn: vi.fn() };
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      DEMO_PROVIDER_ID,
+      MODEL.id,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      MODEL,
+    );
+    expect(agent.streamFn).toBeTypeOf("function");
 
     expect(
       normalizeProviderToolSchemasWithPlugin({

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -30,9 +30,7 @@ import type {
 } from "./plugin-metadata-snapshot.types.js";
 import { resolvePluginDiscoveryProvidersRuntime } from "./provider-discovery.runtime.js";
 import {
-  prepareProviderExtraParams,
   resolveProviderAuthProfileId,
-  resolveProviderExtraParamsForTransport,
   resolveProviderFollowupFallbackRoute,
   ensureProviderRuntimePluginHandle,
   resolveLoadedProviderRuntimePlugin,
@@ -41,7 +39,6 @@ import {
   resolveProviderRuntimePlugin,
   wrapProviderSimpleCompletionStreamFn,
   type ProviderRuntimePluginHandle,
-  wrapProviderStreamFn,
 } from "./provider-hook-runtime.js";
 import {
   resolveBundledProviderPolicySurface,
@@ -150,13 +147,10 @@ function hasConfiguredModelProvider(params: {
 }
 
 export {
-  prepareProviderExtraParams,
   resolveProviderAuthProfileId,
-  resolveProviderExtraParamsForTransport,
   resolveProviderFollowupFallbackRoute,
   resolveProviderRuntimePlugin,
   wrapProviderSimpleCompletionStreamFn,
-  wrapProviderStreamFn,
 };
 
 function resolveProviderPluginsForCatalogHooks(params: {
@@ -570,11 +564,13 @@ export function resolveProviderStreamFn(params: {
   allowRuntimePluginLoad?: boolean;
   context: ProviderCreateStreamFnContext;
 }) {
-  const plugin = params.runtimeHandle
-    ? ensureProviderRuntimePluginHandle(params).plugin
-    : params.allowRuntimePluginLoad === false
-      ? resolveLoadedProviderRuntimePlugin(params)
-      : resolveProviderRuntimePlugin(params);
+  // Transport families may explicitly ask for a different fallback owner.
+  const plugin =
+    params.runtimeHandle?.provider === params.provider
+      ? ensureProviderRuntimePluginHandle(params).plugin
+      : params.allowRuntimePluginLoad === false
+        ? resolveLoadedProviderRuntimePlugin(params)
+        : resolveProviderRuntimePlugin(params);
   return plugin?.createStreamFn?.(params.context) ?? undefined;
 }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers retain normal repository write access.

</details>

Related: #77700

## What Problem This Solves

Fixes an issue where later agent attempts could send stale provider options after their provider runtime changed or configuration defaults were updated. Stream setup could also select a different provider instance from the one that prepared the attempt.

## Why This Change Was Made

The process-wide extra-parameter cache used configuration identity and a model/options fingerprint, but omitted the prepared provider owner and current configuration-derived parameters. Runtime plans already memoize their defaults. Remove the duplicate global cache, its fingerprint machinery, three internal hook-forwarding functions, and the production-only test injection surface.

Resolve one prepared provider for parameter preparation, transport patches, and stream wrapping. Carry the model's prepared handle through regular streams, simple completions, and compaction. Explicit transport fallback providers retain precedence over a foreign model handle. Public `ProviderPlugin` hooks and configuration/storage contracts remain unchanged.

## User Impact

Each attempt uses its selected provider's options and stream hooks. Existing plans keep their lazily prepared defaults while replacement plans receive fresh parameters. Production LOC: **net -169**. Tests and test support: **+295 / -115 (net +180)**. No configuration keys, defaults, SDK types, or persistent data formats change.

## Evidence

- Original-order reproduction on `49ecde890905fa601cafc9cfbf6ea0cfe9aab824`: replacement providers reused the first owner's parameters, and an updated temperature remained `0.1` instead of `0.7`. The lifecycle regression fails on the original source. The same global cache is present in `v2026.9.1`.
- Focused provider/plan tests: **126 passed**. Provider-family and stream sibling tests: **293 passed**. Final provider/compaction suite: **209 passed** across six files. These suites overlap; counts are separate runs.
- `node scripts/check-changed.mjs`, final core and core-test typechecks, formatting, and `git diff --check` passed. Runtime import-cycle guard reported zero cycles. Independent Codex autoreview is scoped-clean through P2.
- `pnpm build` passed in **6m 1.4s**, rebuilding 90 local plugin packages and verifying 53 built control-plane modules with native `require`.
- Isolated actual HTTP/SSE transport proof sent four requests across three provider generations, including an older generation's simple completion. Observed owner headers were `first`, `replacement`, `updated`, then `replacement`; temperatures were `0.1`, `0.1`, and `0.7`. Plan preparation ran once per generation.
- One credentialed completion through the prepared runtime and real OpenAI plugin used **`gpt-5.6-luna` / Responses / SSE**, returned HTTP 200 and exactly `prepared-owner-ok`, and reported 13 input / 7 output tokens. The observed 539-byte request had `max_output_tokens: 128`, `parallel_tool_calls: true`, and zero tools.
- Built launcher proof: `node openclaw.mjs --version`; `node openclaw.mjs plugins inspect openai --runtime --json` returned `status: loaded` with provider `openai`. All live runs used isolated state that was verified removed; operator configuration and gateway state were untouched.

The integrated implementation preserves main's native-search policy, optional stream wrapping, and local-service reconciliation. The forwarding caller uses the prepared plugin directly. All 114 selected integration tests, full changed gates, independent P2 review, and five actual HTTP/SSE requests passed; the fifth request exercises wrapping without the agent extra-parameter wrapper.

Direct-compaction coverage now injects its reconciler at the prepared-handle boundary and verifies that the stream model and runtime plan receive the same handle. The former fixture minted an unrelated handle after preparation; the original reconciler assertion was retained and captured failing before the fixture correction. The complete compaction file and four sibling files pass **221 tests**, with full changed gates and clean independent P2 review. Additional actual HTTP/SSE proof observes `reconcile → completion` for both fresh and reused handles; rejected reconciliation issues no extra inference request. This final correction changes only tests/support (net −1), and all isolated proof state was removed. [Exact-head CI run 33988114819](https://github.com/openclaw/openclaw/actions/runs/33988114819) is green on attempt 2. Its first attempt failed in an unrelated PR-tooling revoked-admin fixture; the refusal cause remains unknown and one unchanged failed-job retry passed. No authorization checks, assertions, or timeouts changed.
