### PR TITLE
refactor(talk): centralize typed voice session queries

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3678,8 +3678,8 @@ src/talk/agent-consult-tool.ts	2
 src/talk/agent-run-control-shared.ts	4
 src/talk/client-voice-confirmation.ts	2
 src/talk/client-voice-mutation-digest-owner.ts	1
-src/talk/client-voice-session-store.ts	3
-src/talk/client-voice-session.ts	3
+src/talk/client-voice-session-store.ts	1
+src/talk/client-voice-session.ts	1
 src/talk/consult-question.ts	2
 src/talk/exact-speech-protocol.ts	1
 src/talk/provider-internal.ts	2

--- a/src/talk/client-voice-session-store.test.ts
+++ b/src/talk/client-voice-session-store.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createTempHomeEnv } from "../test-utils/temp-home.js";
+import {
   parseStoredVoiceSessionRecord,
+  readVoiceSessionRecordInTransaction,
   VOICE_SESSION_RECORD_VERSION,
+  writeVoiceSessionRecordInTransaction,
 } from "./client-voice-session-store.js";
 import { VOICE_TRANSCRIPT_MAX_UNRESOLVED } from "./voice-transcript.js";
 
@@ -22,6 +31,55 @@ function storedRecord(transcriptFailureKeys: unknown): string {
 }
 
 describe("client voice session store", () => {
+  it("preserves cache custody columns across rejected updates and a successful retry", async () => {
+    const home = await createTempHomeEnv("openclaw-voice-store-");
+    const scope = "talk-client-voice-sessions";
+    try {
+      const database = openOpenClawAgentDatabase({ agentId: "main" });
+      const original = parseStoredVoiceSessionRecord(storedRecord([]));
+      if (!original) {
+        throw new Error("expected a valid voice record");
+      }
+      const write = (updatedAt: number) =>
+        runOpenClawAgentWriteTransaction(
+          (owner) => writeVoiceSessionRecordInTransaction(owner, { ...original, updatedAt }),
+          { agentId: "main" },
+        );
+      write(1);
+      database.db
+        .prepare("UPDATE cache_entries SET blob = ?, expires_at = ? WHERE scope = ? AND key = ?")
+        .run(Buffer.from([0, 255, 4]), 123, scope, original.voiceSessionId);
+      const read = () =>
+        database.db
+          .prepare(
+            "SELECT value_json, hex(blob) AS blob, expires_at FROM cache_entries WHERE scope = ? AND key = ?",
+          )
+          .get(scope, original.voiceSessionId);
+      const before = read();
+      database.db.exec(`CREATE TEMP TRIGGER reject_voice_update BEFORE UPDATE ON main.cache_entries
+        WHEN NEW.scope = 'talk-client-voice-sessions' AND NEW.updated_at = 2
+        BEGIN SELECT RAISE(ABORT, 'synthetic voice update failure'); END`);
+      expect(() => write(2)).toThrow("synthetic voice update failure");
+      expect(database.db.isTransaction).toBe(false);
+      expect(read()).toEqual(before);
+      database.db.exec("DROP TRIGGER reject_voice_update");
+      write(3);
+      expect(read()).toEqual({
+        value_json: JSON.stringify({ ...original, updatedAt: 3 }),
+        blob: "00FF04",
+        expires_at: 123,
+      });
+      expect(readVoiceSessionRecordInTransaction(database, original.voiceSessionId)).toEqual({
+        ...original,
+        updatedAt: 3,
+      });
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      await home.restore();
+    }
+  });
+
   it("defaults unresolved transcript failures for existing records", () => {
     expect(
       parseStoredVoiceSessionRecord(

--- a/src/talk/client-voice-session-store.ts
+++ b/src/talk/client-voice-session-store.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 /** SQLite-backed persistence for durable per-agent Talk voice-call records. */
+import { compileSqliteQueryBindings, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
 import {
   openOpenClawAgentDatabase,
   type OpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
 import { VOICE_TRANSCRIPT_MAX_UNRESOLVED } from "./voice-transcript.js";
 
-export const VOICE_SESSION_CACHE_SCOPE = "talk-client-voice-sessions";
+const VOICE_SESSION_CACHE_SCOPE = "talk-client-voice-sessions";
 export const VOICE_SESSION_RECORD_VERSION = 1;
 export const VOICE_SESSION_STALE_AFTER_MS = 6 * 60 * 60_000;
 
@@ -123,41 +125,69 @@ export function readVoiceSessionRecord(
   agentId: string,
   voiceSessionId: string,
 ): ClientVoiceSessionRecord | undefined {
-  const database = openOpenClawAgentDatabase({ agentId });
-  const row = database.db
-    .prepare("SELECT value_json FROM cache_entries WHERE scope = ? AND key = ?")
-    .get(VOICE_SESSION_CACHE_SCOPE, voiceSessionId) as { value_json?: unknown } | undefined;
-  return parseStoredVoiceSessionRecord(row?.value_json);
+  return readVoiceSessionRecordInTransaction(
+    openOpenClawAgentDatabase({ agentId }),
+    voiceSessionId,
+  );
+}
+
+function voiceSessionRowsQuery(database: OpenClawAgentDatabase) {
+  return getNodeSqliteKysely<Pick<OpenClawAgentKyselyDatabase, "cache_entries">>(database.db)
+    .selectFrom("cache_entries")
+    .select("value_json")
+    .where("scope", "=", VOICE_SESSION_CACHE_SCOPE);
 }
 
 export function readVoiceSessionRecordInTransaction(
   database: OpenClawAgentDatabase,
   voiceSessionId: string,
 ): ClientVoiceSessionRecord | undefined {
-  const row = database.db
-    .prepare("SELECT value_json FROM cache_entries WHERE scope = ? AND key = ?")
-    .get(VOICE_SESSION_CACHE_SCOPE, voiceSessionId) as { value_json?: unknown } | undefined;
+  const { compiled, bind } = compileSqliteQueryBindings<void>(() =>
+    voiceSessionRowsQuery(database).where("key", "=", voiceSessionId),
+  );
+  const row = /* sqlite-allow-raw: Compiled SQL keeps native get error ownership. */ database.db
+    .prepare(compiled.sql)
+    .get(...bind());
   return parseStoredVoiceSessionRecord(row?.value_json);
+}
+
+export function readVoiceSessionRecordRows(agentId: string, updatedBefore?: number) {
+  const database = openOpenClawAgentDatabase({ agentId });
+  const query = voiceSessionRowsQuery(database);
+  const { compiled, bind } = compileSqliteQueryBindings<void>(() =>
+    updatedBefore === undefined
+      ? query.orderBy("updated_at", "desc")
+      : query.where("updated_at", "<=", updatedBefore),
+  );
+  return /* sqlite-allow-raw: Compiled SQL snapshots recovery candidates before awaits. */ database.db
+    .prepare(compiled.sql)
+    .all(...bind());
 }
 
 export function writeVoiceSessionRecordInTransaction(
   database: OpenClawAgentDatabase,
   record: ClientVoiceSessionRecord,
 ): void {
-  database.db
-    .prepare(
-      `INSERT INTO cache_entries (scope, key, value_json, blob, expires_at, updated_at)
-       VALUES (?, ?, ?, NULL, NULL, ?)
-       ON CONFLICT(scope, key) DO UPDATE SET
-         value_json = excluded.value_json,
-         updated_at = excluded.updated_at`,
-    )
-    .run(
-      VOICE_SESSION_CACHE_SCOPE,
-      record.voiceSessionId,
-      JSON.stringify(record),
-      record.updatedAt,
-    );
+  const { compiled, bind } = compileSqliteQueryBindings<ClientVoiceSessionRecord>((p) =>
+    getNodeSqliteKysely<Pick<OpenClawAgentKyselyDatabase, "cache_entries">>(database.db)
+      .insertInto("cache_entries")
+      .values({
+        scope: VOICE_SESSION_CACHE_SCOPE,
+        key: p((value) => value.voiceSessionId),
+        value_json: p((value) => JSON.stringify(value)),
+        blob: null,
+        expires_at: null,
+        updated_at: p((value) => value.updatedAt),
+      })
+      .onConflict((conflict) =>
+        conflict.columns(["scope", "key"]).doUpdateSet((eb) => ({
+          value_json: eb.ref("excluded.value_json"),
+          updated_at: eb.ref("excluded.updated_at"),
+        })),
+      ),
+  );
+  // sqlite-allow-raw: Compiled SQL preserves native preparation before JSON evaluation.
+  database.db.prepare(compiled.sql).run(...bind(record));
 }
 
 export function assertVoiceSessionOwnership(

--- a/src/talk/client-voice-session.ts
+++ b/src/talk/client-voice-session.ts
@@ -14,10 +14,7 @@ import {
   onTrustedToolExecutionEvent,
   type TrustedToolExecutionEvent,
 } from "../infra/diagnostic-events.js";
-import {
-  openOpenClawAgentDatabase,
-  runOpenClawAgentWriteTransaction,
-} from "../state/openclaw-agent-db.js";
+import { runOpenClawAgentWriteTransaction } from "../state/openclaw-agent-db.js";
 import {
   deactivateClientVoiceConfirmationSession,
   noteClientVoiceConfirmationUtterance,
@@ -37,7 +34,7 @@ import {
   parseStoredVoiceSessionRecord as parseStoredRecord,
   readVoiceSessionRecord as readRecord,
   readVoiceSessionRecordInTransaction as readRecordInTransaction,
-  VOICE_SESSION_CACHE_SCOPE as CACHE_SCOPE,
+  readVoiceSessionRecordRows,
   VOICE_SESSION_RECORD_VERSION as RECORD_VERSION,
   VOICE_SESSION_STALE_AFTER_MS as STALE_AFTER_MS,
   writeVoiceSessionRecordInTransaction as writeRecordInTransaction,
@@ -396,15 +393,12 @@ export function resolveClientVoiceSessionOrigin(params: {
   return record.origin;
 }
 
-/** Resolve the newest open client-owned call for legacy tool-call clients. */
+/** Resolve the unique open client-owned call for legacy tool-call clients. */
 export function resolveOpenClientVoiceSessionId(params: {
   agentId: string;
   sessionKey: string;
 }): string | undefined {
-  const database = openOpenClawAgentDatabase({ agentId: params.agentId });
-  const rows = database.db
-    .prepare("SELECT value_json FROM cache_entries WHERE scope = ? ORDER BY updated_at DESC")
-    .all(CACHE_SCOPE) as Array<{ value_json?: unknown }>;
+  const rows = readVoiceSessionRecordRows(params.agentId);
   let match: string | undefined;
   for (const row of rows) {
     const record = parseStoredRecord(row.value_json);
@@ -713,10 +707,7 @@ export async function closeStaleClientVoiceSessions(params: {
   // A new voice session remains a retry point, but channel I/O is detached so a
   // stalled adapter cannot block stale-session recovery.
   mutationDigestDeliveryOwner.retryAgent(params.agentId, params.config);
-  const database = openOpenClawAgentDatabase({ agentId: params.agentId });
-  const rows = database.db
-    .prepare("SELECT value_json FROM cache_entries WHERE scope = ? AND updated_at <= ?")
-    .all(CACHE_SCOPE, now - STALE_AFTER_MS) as Array<{ value_json?: unknown }>;
+  const rows = readVoiceSessionRecordRows(params.agentId, now - STALE_AFTER_MS);
   const stale = rows.flatMap((row) => {
     const record = parseStoredRecord(row.value_json);
     return record &&


### PR DESCRIPTION
## What Problem This Solves

Talk voice sessions constructed the same cache queries in both the lifecycle module and the persistence module. Point reads were duplicated, and recovery code owned its own SQL and row assertions.

## Why This Change Was Made

Keep all five ordinary queries in the existing Talk store, using the generated agent-database types and shared Kysely compile/bind helpers. The lifecycle code now asks the store for its records. Native `get`, eager `all`, and `run` execution retain the existing database/error owner and supplied transaction handle.

The UPSERT still updates only JSON and update time, preserving blob/expiry columns. Native preparation still precedes payload getters and JSON serialization. Recovery takes its full candidate snapshot before asynchronous work; the legacy lookup still requires a unique open session. Production: +58/-37 (net +21); tests: +58; four row assertions removed. No schema, config, public API, retention, or PostgreSQL change.

## Evidence

- 74 focused tests, a final seven-test store run, full changed-file gate, and Kysely guard passed. Independent review found no P0–P2 findings.
- Nine actual-owner baseline/candidate scenarios match: a 70,230-byte record, blob/expiry custody, preparation/binding order, rejected write rollback and retry, authorizer denial, agent isolation, malformed records, ambiguous lookup, and stale-snapshot boundaries. Three agent databases reopen with matching rows and valid integrity checks.
- A real built Gateway stored exactly two transcript messages from three requests, preserved duplicate/close idempotency, and retained exact voice JSON and transcript rows after restart. A post-close append returned the expected structured refusal without a durable change. Owned processes, homes, and ports were cleaned up.

Two early Gateway harness failures involved native row prototypes and JSON-mode error output; both are retained with their cleanup receipts. Only those task-local comparisons were corrected. The single runtime build was reused after comment-only guard annotations were proved to emit identical JavaScript; all 5,597 recorded build hashes remained unchanged. No external voice provider, audio transport, or performance claim.
