### PR TITLE
improve: reduce overhead when batching inbound conversations

### DIFF
--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -347,13 +347,6 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     buffer.timeout.unref?.();
   };
 
-  const canTrackKey = (key: string) => {
-    if (buffers.has(key) || keyChains.has(key)) {
-      return true;
-    }
-    return new Set([...buffers.keys(), ...keyChains.keys()]).size < maxTrackedKeys;
-  };
-
   const enqueue = async (item: T) => {
     const key = params.buildKey(item);
     const debounceMs = resolveDebounceMs(item);
@@ -403,7 +396,9 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       scheduleFlush(key, existing);
       return;
     }
-    if (!canTrackKey(key)) {
+    // Buffers reserve a chain before insertion and release it only after removal,
+    // so chain keys already cover every tracked debounce key.
+    if (!(keyChains.has(key) || keyChains.size < maxTrackedKeys)) {
       // When the debounce map is saturated, fall back to immediate keyed work
       // instead of buffering, but still preserve same-key ordering.
       const generation = resolveKeyGeneration(key);


### PR DESCRIPTION
## What Problem This Solves

Configured inbound debounce rebuilds a union of buffered and queued conversation keys whenever it admits a new key. Many concurrent conversations amplify that unnecessary work. This is a maintainer-requested performance improvement for configured debounce; general inbound debounce remains disabled by default.

## Why This Change Was Made

Use the existing queue map as the accounting owner. Buffers reserve a queue entry before insertion and remove the buffer before releasing that reservation, so buffered keys are already included. Same-key admission at saturation, fallback ordering, timing, cancellation and lifecycle callbacks keep their existing behavior.

## User Impact

Operators using inbound batching across many conversation keys avoid repeated temporary key sets. No new cache, settings, SDK, protocol or storage behavior. Production LOC: +3/-8 (net -5); no test-source changes.

## Evidence

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/inbound.test.ts src/channels/inbound-debounce-policy.test.ts`: all 65 tests passed before and after. Existing cases cover queued cancellation, separate admission/completion, drain tracking, saturation, same-key ordering and accounting across buffered/active-only keys.
- Actual owner benchmark with three warmups and nine measured rounds per workload asserts every input is delivered or canceled exactly once. At 2,048 distinct configured keys, median admission wall time changed 64.018 → 2.130 ms and process CPU 70.440 → 4.260 ms. Including cleanup, per-sample totals changed 65.600 → 4.429 ms wall and 73.226 → 7.206 ms CPU.
- Cleanup alone became slower; same-key and default-disabled controls did not establish a gain. Arms ran sequentially on a shared host. These are descriptive synthetic admission results, not statistical significance, allocation-byte sampling, retained-heap, RSS, Gateway, provider or live-channel performance proof.
- Source lifecycle inspection and untimed edge cases preserve the original less-than predicate, including NaN/Infinity behavior. No timer refresh redesign or new queue abstraction was added.
- Formatting, `git diff --check` and changed-check classification passed. Managed independent P2 review was scoped-clean with zero findings; frozen source hashes remain exact. Exact-head [CI 33968551596](https://github.com/openclaw/openclaw/actions/runs/33968551596), including required `openclaw/ci-gate`, and [Workflow Sanity 33968182273](https://github.com/openclaw/openclaw/actions/runs/33968182273) passed. Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 139104` verified these hosted gates; Testbox was not applicable. The latest completed ClawSweeper review reports no findings or pre-merge moves.
