### PR TITLE
refactor: simplify outbound message execution context

### DIFF
--- a/src/infra/outbound/message-action-execution.thread-reply.test.ts
+++ b/src/infra/outbound/message-action-execution.thread-reply.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
 import { annotateSourceDelivery } from "./message-action-execution.js";
 
 const actionParams = {
@@ -26,11 +27,13 @@ const input = {
 
 const annotationParams = {
   cfg: {},
-  actionParams,
+  params: actionParams,
   channel: "testchat" as const,
   accountId: "default",
   input,
-  replyToIsExplicit: false,
+  dryRun: false,
+  channelPlugin: createChannelTestPluginBase({ id: "testchat" }),
+  mediaAccess: { localRoots: [] },
 };
 
 describe("annotateSourceDelivery thread replies", () => {
@@ -45,6 +48,7 @@ describe("annotateSourceDelivery thread replies", () => {
         dryRun: false,
       },
       annotationParams,
+      false,
     );
 
     expect(result.payload).toMatchObject({ sourceReplyRoute: "current-source" });
@@ -66,6 +70,7 @@ describe("annotateSourceDelivery thread replies", () => {
         dryRun: false,
       },
       annotationParams,
+      false,
     );
 
     expect(result.payload).toMatchObject({ sourceReplyRoute: "current-source" });
@@ -83,6 +88,7 @@ describe("annotateSourceDelivery thread replies", () => {
         dryRun: false,
       },
       annotationParams,
+      false,
     );
 
     expect(result.payload).not.toHaveProperty("sourceReplyRoute");

--- a/src/infra/outbound/message-action-execution.ts
+++ b/src/infra/outbound/message-action-execution.ts
@@ -14,7 +14,6 @@ import { dispatchChannelMessageAction } from "../../channels/plugins/message-act
 import type {
   ChannelId,
   ChannelMessageActionName,
-  ChannelPlugin,
   ChannelThreadingToolContext,
 } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -29,7 +28,6 @@ import { formatErrorMessage } from "../errors.js";
 import { throwIfAborted } from "./abort.js";
 import type {
   MessageActionGateway,
-  MessageActionInput,
   MessageActionResult,
   ResolvedActionContext,
 } from "./message-action-contracts.js";
@@ -59,35 +57,28 @@ const loadMessageActionGatewayRuntime = createLazyRuntimeModule(
 
 export function annotateSourceDelivery<T extends MessageActionResult>(
   result: T,
-  params: {
-    cfg: OpenClawConfig;
-    actionParams: Record<string, unknown>;
-    channel: ChannelId;
-    accountId?: string | null;
-    input: MessageActionInput;
-    agentId?: string;
-    replyToIsExplicit: boolean;
-  },
+  ctx: ResolvedActionContext,
+  replyToIsExplicit: boolean,
 ): T {
   // Current-source identity comes from the authorized route and delivery receipt,
   // not the reply mode; automatic runs also use this marker to avoid false fallbacks.
-  const authorization = params.input.messageActionAuthorization;
+  const authorization = ctx.input.messageActionAuthorization;
   if (result.kind === "broadcast" || !authorization?.toolContext) {
     return result;
   }
   const mirrorParams = {
     action: result.action,
-    channel: params.channel,
-    actionParams: params.actionParams,
-    cfg: params.cfg,
-    accountId: params.accountId,
-    currentAccountId: authorization.requesterAccountId ?? params.input.defaultAccountId,
-    sessionKey: params.input.sessionKey,
-    sessionId: params.input.sessionId,
-    agentId: params.agentId,
+    channel: ctx.channel,
+    actionParams: ctx.params,
+    cfg: ctx.cfg,
+    accountId: ctx.accountId,
+    currentAccountId: authorization.requesterAccountId ?? ctx.input.defaultAccountId,
+    sessionKey: ctx.input.sessionKey,
+    sessionId: ctx.input.sessionId,
+    agentId: ctx.agentId,
     toolContext: authorization.toolContext,
     deliveredPayload: result.payload,
-    replyToIsExplicit: params.replyToIsExplicit,
+    replyToIsExplicit,
   };
   if (!isDeliveredCurrentSourceReply(mirrorParams)) {
     return result;
@@ -286,62 +277,55 @@ export async function applyMessageCrossContextMarker(params: {
   });
 }
 
-export async function executeGatewayAction(params: {
-  cfg: OpenClawConfig;
-  params: Record<string, unknown>;
-  channel: ChannelId;
-  channelPlugin?: ChannelPlugin;
-  action: ChannelMessageActionName;
-  reply?: OutboundReplyFacts;
-  accountId?: string | null;
-  dryRun: boolean;
-  gateway?: MessageActionGateway;
-  input: MessageActionInput;
-  agentId?: string;
-  result: (payload: unknown) => MessageActionResult;
-}): Promise<MessageActionResult | null> {
-  if (params.dryRun || !params.gateway) {
+export async function executeGatewayAction(
+  ctx: ResolvedActionContext,
+  params: {
+    action: ChannelMessageActionName;
+    reply?: OutboundReplyFacts;
+    result: (payload: unknown) => MessageActionResult;
+  },
+): Promise<MessageActionResult | null> {
+  if (ctx.dryRun || !ctx.gateway) {
     return null;
   }
-  if (!params.channelPlugin?.actions?.handleAction) {
+  if (!ctx.channelPlugin?.actions?.handleAction) {
     return null;
   }
   const executionMode =
-    params.channelPlugin.actions.resolveExecutionMode?.({ action: params.action }) ?? "local";
+    ctx.channelPlugin.actions.resolveExecutionMode?.({ action: params.action }) ?? "local";
   if (executionMode !== "gateway") {
     return null;
   }
   const conversationReadOrigin = normalizeConversationReadInvocationOrigin(
-    params.input.conversationReadOrigin,
+    ctx.input.conversationReadOrigin,
   );
   const idempotencyKey = await resolveGatewayActionIdempotencyKey(
-    normalizeOptionalString(params.params.idempotencyKey),
+    normalizeOptionalString(ctx.params.idempotencyKey),
   );
   const callerOwnsTerminalReceipt =
-    params.gateway.terminalSourceReplyReceiptOwner === "caller" &&
-    params.input.sourceReplyFinal === true;
+    ctx.gateway.terminalSourceReplyReceiptOwner === "caller" && ctx.input.sourceReplyFinal === true;
   // Resolve local capability/auth preflight before arming a durable send intent.
   // A failure here proves the RPC never reached the gateway.
-  const agentRuntimeIdentityToken = await params.gateway.resolveAgentRuntimeIdentityToken?.({
-    sourceReplyFinal: params.input.sourceReplyFinal,
-    sourceReplyToolCallId: params.input.sourceReplyToolCallId,
+  const agentRuntimeIdentityToken = await ctx.gateway.resolveAgentRuntimeIdentityToken?.({
+    sourceReplyFinal: ctx.input.sourceReplyFinal,
+    sourceReplyToolCallId: ctx.input.sourceReplyToolCallId,
   });
   const sourceReplyMirror = {
     action: params.action,
-    channel: params.channel,
-    actionParams: params.params,
-    cfg: params.cfg,
-    accountId: params.accountId,
+    channel: ctx.channel,
+    actionParams: ctx.params,
+    cfg: ctx.cfg,
+    accountId: ctx.accountId,
     currentAccountId:
-      params.input.messageActionAuthorization?.requesterAccountId ?? params.input.defaultAccountId,
-    sessionKey: params.input.sourceReplySessionKey ?? params.input.sessionKey,
-    sessionId: params.input.sessionId,
-    agentId: params.agentId,
-    toolContext: params.input.messageActionAuthorization?.toolContext,
+      ctx.input.messageActionAuthorization?.requesterAccountId ?? ctx.input.defaultAccountId,
+    sessionKey: ctx.input.sourceReplySessionKey ?? ctx.input.sessionKey,
+    sessionId: ctx.input.sessionId,
+    agentId: ctx.agentId,
+    toolContext: ctx.input.messageActionAuthorization?.toolContext,
     replyToIsExplicit: params.reply?.source === "explicit",
     idempotencyKey,
-    sourceReplyFinal: params.input.sourceReplyFinal,
-    toolCallId: params.input.sourceReplyToolCallId,
+    sourceReplyFinal: ctx.input.sourceReplyFinal,
+    toolCallId: ctx.input.sourceReplyToolCallId,
   };
   const terminalDeliveryStart = callerOwnsTerminalReceipt
     ? await beginTerminalSourceReplyDelivery(sourceReplyMirror)
@@ -354,23 +338,23 @@ export async function executeGatewayAction(params: {
   let payload: unknown;
   try {
     payload = await callGatewayMessageAction<unknown>({
-      gateway: params.gateway,
-      abortSignal: params.input.abortSignal,
+      gateway: ctx.gateway,
+      abortSignal: ctx.input.abortSignal,
       agentRuntimeIdentityToken,
       onUnknownDeliveryOutcome: () => {
         hadUnknownDeliveryOutcome = true;
       },
       actionParams: {
-        channel: params.channel,
+        channel: ctx.channel,
         action: params.action,
-        params: params.params,
+        params: ctx.params,
         ...(params.reply ? { reply: params.reply } : {}),
-        accountId: params.accountId ?? undefined,
-        senderIsOwner: params.input.senderIsOwner,
-        sessionKey: params.input.sessionKey,
-        sessionId: params.input.sessionId,
-        inboundTurnKind: params.input.inboundEventKind,
-        agentId: params.agentId,
+        accountId: ctx.accountId ?? undefined,
+        senderIsOwner: ctx.input.senderIsOwner,
+        sessionKey: ctx.input.sessionKey,
+        sessionId: ctx.input.sessionId,
+        inboundTurnKind: ctx.input.inboundEventKind,
+        agentId: ctx.agentId,
         ...(conversationReadOrigin === "direct-operator" ? { conversationReadOrigin } : {}),
         idempotencyKey,
       },
@@ -397,8 +381,8 @@ export async function executeGatewayAction(params: {
       // The pre-send intent remains durable. Return the provider result so the
       // model cannot retry an external effect with an unknown outcome.
       log.warn("Terminal source reply receipt reconciliation failed.", {
-        channel: params.channel,
-        sessionKey: params.input.sessionKey,
+        channel: ctx.channel,
+        sessionKey: ctx.input.sessionKey,
         error: formatErrorMessage(error),
       });
     }
@@ -407,18 +391,8 @@ export async function executeGatewayAction(params: {
 }
 
 export async function executeMessagePoll(ctx: ResolvedActionContext): Promise<MessageActionResult> {
-  const {
-    cfg,
-    params,
-    channel,
-    channelPlugin,
-    accountId,
-    dryRun,
-    gateway,
-    input,
-    agentId,
-    abortSignal,
-  } = ctx;
+  const { cfg, params, channel, channelPlugin, accountId, dryRun, input, agentId, abortSignal } =
+    ctx;
   throwIfAborted(abortSignal);
   const action: ChannelMessageActionName = "poll";
   const to = readToolStringParam(params, "to", { required: true });
@@ -446,17 +420,8 @@ export async function executeMessagePoll(ctx: ResolvedActionContext): Promise<Me
     preferPresentation: false,
   });
 
-  const gatewayPluginAction = await executeGatewayAction({
-    cfg,
-    params,
-    channel,
-    channelPlugin,
+  const gatewayPluginAction = await executeGatewayAction(ctx, {
     action,
-    accountId,
-    dryRun,
-    gateway,
-    input,
-    agentId,
     result: (payload) => ({
       kind: "poll",
       channel,
@@ -469,37 +434,27 @@ export async function executeMessagePoll(ctx: ResolvedActionContext): Promise<Me
   });
   const pollReplyToIsExplicit = Boolean(readToolStringParam(params, "replyTo"));
   if (gatewayPluginAction) {
-    return annotateSourceDelivery(gatewayPluginAction, {
-      cfg,
-      actionParams: params,
-      channel,
-      accountId,
-      input,
-      agentId,
-      replyToIsExplicit: pollReplyToIsExplicit,
-    });
+    return annotateSourceDelivery(gatewayPluginAction, ctx, pollReplyToIsExplicit);
   }
 
   const poll = await executePollAction({
     ctx: {
-      cfg,
-      channel,
-      plugin: channelPlugin,
-      params,
-      idempotencyKey: ctx.idempotencyKey,
-      accountId: accountId ?? undefined,
-      agentId,
-      requesterAccountId: input.requesterAccountId ?? undefined,
-      requesterSenderId: input.requesterSenderId ?? undefined,
-      conversationReadOrigin: normalizeConversationReadInvocationOrigin(
-        input.conversationReadOrigin,
-      ),
-      sessionKey: input.sessionKey,
-      sessionId: input.sessionId,
-      inboundEventKind: input.inboundEventKind,
-      gateway,
-      toolContext: input.toolContext,
-      dryRun,
+      ...ctx,
+      // Poll actions expose requester IDs and turn context, without send-only
+      // authority or media grants. Preserve that plugin boundary independently.
+      mediaAccess: undefined,
+      input: {
+        cfg,
+        action,
+        params,
+        requesterAccountId: input.requesterAccountId,
+        requesterSenderId: input.requesterSenderId,
+        conversationReadOrigin: input.conversationReadOrigin,
+        sessionKey: input.sessionKey,
+        sessionId: input.sessionId,
+        inboundEventKind: input.inboundEventKind,
+        toolContext: input.toolContext,
+      },
       silent: silent ?? undefined,
     },
     resolveCorePoll: () => {
@@ -539,15 +494,8 @@ export async function executeMessagePoll(ctx: ResolvedActionContext): Promise<Me
       pollResult: poll.pollResult,
       dryRun,
     },
-    {
-      cfg,
-      actionParams: params,
-      channel,
-      accountId,
-      input,
-      agentId,
-      replyToIsExplicit: pollReplyToIsExplicit,
-    },
+    ctx,
+    pollReplyToIsExplicit,
   );
 }
 
@@ -612,17 +560,8 @@ export async function executeMessagePlugin(
     });
   }
 
-  const gatewayPluginAction = await executeGatewayAction({
-    cfg,
-    params,
-    channel,
-    channelPlugin,
+  const gatewayPluginAction = await executeGatewayAction(ctx, {
     action,
-    accountId,
-    dryRun,
-    gateway,
-    input,
-    agentId,
     result: (payload) => ({
       kind: "action",
       channel,
@@ -635,15 +574,7 @@ export async function executeMessagePlugin(
   const replyToIsExplicit = Boolean(readToolStringParam(params, "replyTo"));
   if (gatewayPluginAction) {
     // Gateway-owned actions must execute where the live channel runtime exists.
-    return annotateSourceDelivery(gatewayPluginAction, {
-      cfg,
-      actionParams: params,
-      channel,
-      accountId,
-      input,
-      agentId,
-      replyToIsExplicit,
-    });
+    return annotateSourceDelivery(gatewayPluginAction, ctx, replyToIsExplicit);
   }
 
   const authorization = input.messageActionAuthorization;
@@ -687,14 +618,7 @@ export async function executeMessagePlugin(
       toolResult: handled,
       dryRun,
     },
-    {
-      cfg,
-      actionParams: params,
-      channel,
-      accountId,
-      input,
-      agentId,
-      replyToIsExplicit,
-    },
+    ctx,
+    replyToIsExplicit,
   );
 }

--- a/src/infra/outbound/message-action-gateway.test.ts
+++ b/src/infra/outbound/message-action-gateway.test.ts
@@ -514,13 +514,13 @@ describe("runMessageAction plugin dispatch", () => {
 
       expect(mocks.callGatewayLeastPrivilege).not.toHaveBeenCalled();
       const executeCall = readMockCallArg(mocks.executeSendAction, "execute send call");
+      const context = readRecordField(executeCall, "ctx", "execute send context");
       expectRecordFields(
-        readRecordField(executeCall, "ctx", "execute send context"),
+        readRecordField(context, "input", "message action input"),
         {
-          forceCoreDelivery: true,
           requireQueuePersistence: true,
         },
-        "execute send context",
+        "message action input",
       );
       expectRecordFields(result, { handledBy: "core" }, "result");
     });

--- a/src/infra/outbound/message-action-runner.test-helpers.ts
+++ b/src/infra/outbound/message-action-runner.test-helpers.ts
@@ -4,7 +4,6 @@ import { vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
 import type {
-  ChannelMessageActionContext,
   ChannelMessageActionName,
   ChannelPlugin,
 } from "../../channels/plugins/types.public.js";
@@ -263,20 +262,7 @@ export function createPollForwardingPlugin(params: {
 
 async function executePluginAction(params: {
   action: "send" | "poll";
-  ctx: Pick<
-    ChannelMessageActionContext,
-    | "channel"
-    | "cfg"
-    | "params"
-    | "mediaAccess"
-    | "accountId"
-    | "gateway"
-    | "toolContext"
-    | "inboundEventKind"
-  > & {
-    dryRun: boolean;
-    agentId?: string;
-  };
+  ctx: Parameters<typeof import("./outbound-send-service.js").executeSendAction>[0]["ctx"];
 }) {
   const handled = await dispatchChannelMessageAction({
     channel: params.ctx.channel,
@@ -291,8 +277,8 @@ async function executePluginAction(params: {
         : undefined,
     accountId: params.ctx.accountId ?? undefined,
     gateway: params.ctx.gateway,
-    toolContext: params.ctx.toolContext,
-    inboundEventKind: params.ctx.inboundEventKind,
+    toolContext: params.ctx.input.toolContext,
+    inboundEventKind: params.ctx.input.inboundEventKind,
     dryRun: params.ctx.dryRun,
     agentId: params.ctx.agentId,
   });

--- a/src/infra/outbound/message-action-send.media.test.ts
+++ b/src/infra/outbound/message-action-send.media.test.ts
@@ -142,7 +142,7 @@ describe("runMessageAction media behavior", () => {
     expect(requireRecord(sendArgs.ctx).idempotencyKey).toBe(
       "run-1:message-tool:send-1:fingerprint",
     );
-    expect(requireRecord(sendArgs.ctx).plugin).toBe(workspacePlugin);
+    expect(requireRecord(sendArgs.ctx).channelPlugin).toBe(workspacePlugin);
     expect(channelResolutionMocks.resolveOutboundChannelPlugin).toHaveBeenCalledTimes(1);
   });
 

--- a/src/infra/outbound/message-action-send.ts
+++ b/src/infra/outbound/message-action-send.ts
@@ -10,7 +10,6 @@ import {
 } from "../../auto-reply/reply-payload.js";
 import { resolveResponsePrefixTemplate } from "../../auto-reply/reply/response-prefix-template.js";
 import { normalizeOutboundLocation } from "../../channels/location.js";
-import { normalizeConversationReadInvocationOrigin } from "../../channels/plugins/conversation-read-origin.js";
 import type { ChannelId, ChannelMessageActionName } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -529,18 +528,9 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
   // outbound adapter; credentials and account selection may exist only remotely.
   const gatewayPluginAction = requiresCoreDelivery
     ? null
-    : await executeGatewayAction({
-        cfg,
-        params,
-        channel,
-        channelPlugin,
+    : await executeGatewayAction(ctx, {
         action,
         reply,
-        accountId,
-        dryRun,
-        gateway,
-        input,
-        agentId,
         result: (payload) => ({
           kind: "send",
           channel,
@@ -555,15 +545,8 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
     await commitOutboundSessionRoute();
     return annotateSourceDelivery(
       withSendNormalization(gatewayPluginAction, sendPayload.normalization),
-      {
-        cfg,
-        actionParams: params,
-        channel,
-        accountId,
-        input,
-        agentId,
-        replyToIsExplicit: reply?.source === "explicit",
-      },
+      ctx,
+      reply?.source === "explicit",
     );
   }
 
@@ -585,54 +568,14 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
 
   const send = await executeSendAction({
     ctx: {
-      cfg,
-      channel,
-      plugin: channelPlugin,
-      params,
-      idempotencyKey: ctx.idempotencyKey,
-      agentId,
-      sessionKey: input.sessionKey,
-      requesterAccountId: input.requesterAccountId ?? undefined,
-      requesterSenderId: input.requesterSenderId ?? undefined,
-      requesterSenderName: input.requesterSenderName ?? undefined,
-      requesterSenderUsername: input.requesterSenderUsername ?? undefined,
-      requesterSenderE164: input.requesterSenderE164 ?? undefined,
-      senderIsOwner: input.senderIsOwner,
-      conversationReadOrigin: normalizeConversationReadInvocationOrigin(
-        input.conversationReadOrigin,
-      ),
+      ...ctx,
       mediaAccess,
-      accountId: accountId ?? undefined,
       conversationType: outboundRoute?.chatType,
-      sessionId: input.sessionId,
-      runId: input.runId,
-      executionIdentityToken: input.executionIdentityToken,
-      inboundEventKind: input.inboundEventKind,
-      gateway,
-      toolContext: input.toolContext,
-      deps: input.deps,
-      dryRun,
-      preparedMessageId: input.preparedMessageId,
-      gatewayOwnedDelivery: input.gatewayOwnedDelivery,
-      forceCoreDelivery: requiresCoreDelivery,
-      requireQueuePersistence: input.requireQueuePersistence,
-      deliveryIntentId: input.deliveryIntentId,
-      deliveryCompletion: input.deliveryCompletion,
       // Model-authored sends get the failure back and resend it themselves; every
       // other caller only reports the error, so recovery keeps its replay right.
       deliveryRetryOwner: input.actionOrigin === "message-tool" ? "caller" : undefined,
-      onDeliveryIntent: input.onDeliveryIntent,
-      onPlatformSendDispatch: input.onPlatformSendDispatch,
-      skipQueue: input.skipQueue,
-      onDeliveryAttempt: input.onDeliveryAttempt,
-      // Identified platform evidence is the first success proof on the core
-      // path; commit the route here so the transcript mirror (which runs later
-      // in the same delivery) can resolve a just-created session entry.
-      onDeliveryResult: async (result) => {
-        await commitOutboundSessionRoute();
-        await input.onDeliveryResult?.(result);
-      },
-      onPluginSendAccepted: commitOutboundSessionRoute,
+      // Both delivery paths must commit a first-contact route before mirroring.
+      onSendAccepted: commitOutboundSessionRoute,
       mirror:
         !dryRun && input.transcriptMirror
           ? {
@@ -649,7 +592,6 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
                 idempotencyKey: normalizeOptionalString(params.idempotencyKey) ?? undefined,
               }
             : undefined,
-      abortSignal,
       silent: sendPayload.silent ?? undefined,
     },
     to,
@@ -688,13 +630,9 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
     sendResult: send.sendResult,
     dryRun,
   };
-  return annotateSourceDelivery(withSendNormalization(result, sendPayload.normalization), {
-    cfg,
-    actionParams: params,
-    channel,
-    accountId,
-    input,
-    agentId,
-    replyToIsExplicit: reply?.source === "explicit",
-  });
+  return annotateSourceDelivery(
+    withSendNormalization(result, sendPayload.normalization),
+    ctx,
+    reply?.source === "explicit",
+  );
 }

--- a/src/infra/outbound/outbound-send-service.test.ts
+++ b/src/infra/outbound/outbound-send-service.test.ts
@@ -113,6 +113,24 @@ vi.mock("../../config/sessions.js", () => ({
 type OutboundSendServiceModule = typeof import("./outbound-send-service.js");
 type ExecuteSendInput = Parameters<OutboundSendServiceModule["executeSendAction"]>[0];
 type ExecuteSendContext = ExecuteSendInput["ctx"];
+type ContextOverrides = Omit<Partial<ExecuteSendContext>, "input"> & {
+  input?: Partial<ExecuteSendContext["input"]>;
+};
+
+function createContext(overrides: ContextOverrides): ExecuteSendContext {
+  const { input, ...ctx } = overrides;
+  const cfg = ctx.cfg ?? {};
+  const params = ctx.params ?? {};
+  return {
+    channelPlugin: defaultPlugin,
+    channel: "demo-outbound",
+    dryRun: false,
+    ...ctx,
+    cfg,
+    params,
+    input: { cfg, action: "send", params, ...input },
+  };
+}
 
 let executePollAction: OutboundSendServiceModule["executePollAction"];
 let executeSendAction: OutboundSendServiceModule["executeSendAction"];
@@ -193,38 +211,31 @@ describe("executeSendAction", () => {
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
 
     await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
+      ctx: createContext({
         params: { to: "channel:123", message: "hello" },
-        dryRun: false,
         mirror: {
           sessionKey: "agent:main:demo-outbound:channel:123",
           ...params.mirror,
         },
-      },
+      }),
       to: "channel:123",
       message: "hello",
       mediaUrls: params.mediaUrls,
     });
   }
 
-  function createPluginMediaSendContext(
-    overrides: Partial<ExecuteSendContext>,
-  ): ExecuteSendContext {
-    return {
-      plugin: defaultPlugin,
-      cfg: {},
-      channel: "demo-outbound",
+  function createPluginMediaSendContext(overrides: ContextOverrides): ExecuteSendContext {
+    return createContext({
       params: { media: "/tmp/host.png" },
-      sessionKey: "agent:main:directchat:group:ops",
-      dryRun: false,
       ...overrides,
-    } as ExecuteSendContext;
+      input: {
+        sessionKey: "agent:main:directchat:group:ops",
+        ...overrides.input,
+      },
+    });
   }
 
-  async function executePluginMediaSend(ctx: Partial<ExecuteSendContext>) {
+  async function executePluginMediaSend(ctx: ContextOverrides) {
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
 
     await executeSendAction({
@@ -260,14 +271,9 @@ describe("executeSendAction", () => {
     });
 
     await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
-        params: {},
+      ctx: createContext({
         agentId: "work",
-        dryRun: false,
-      },
+      }),
       to: "channel:123",
       message: "hello",
     });
@@ -300,13 +306,9 @@ describe("executeSendAction", () => {
     });
 
     const result = await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
+      ctx: createContext({
         params: { to: "channel:123", message: "hello" },
-        dryRun: false,
-      },
+      }),
       to: "channel:123",
       message: "hello",
     });
@@ -316,27 +318,36 @@ describe("executeSendAction", () => {
 
   it("makes required queue persistence force core delivery and lifecycle callbacks", async () => {
     const onDeliveryIntent = vi.fn();
-    const onDeliveryResult = vi.fn();
+    const order: string[] = [];
+    const onSendAccepted = vi.fn(async () => {
+      order.push("route");
+    });
+    const onDeliveryResult = vi.fn(async () => {
+      order.push("receipt");
+    });
+    const evidence = { channel: "demo-outbound", messageId: "sent-1" };
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
-    mocks.sendMessage.mockResolvedValue({
-      channel: "demo-outbound",
-      to: "channel:123",
-      via: "direct",
-      mediaUrl: null,
-      deliveryStatus: "sent",
+    mocks.sendMessage.mockImplementationOnce(async (params) => {
+      await params.onDeliveryResult(evidence);
+      return {
+        channel: "demo-outbound",
+        to: "channel:123",
+        via: "direct",
+        mediaUrl: null,
+        deliveryStatus: "sent",
+      };
     });
 
     await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
+      ctx: createContext({
         params: { to: "channel:123", message: "hello" },
-        dryRun: false,
-        requireQueuePersistence: true,
-        onDeliveryIntent,
-        onDeliveryResult,
-      },
+        onSendAccepted,
+        input: {
+          requireQueuePersistence: true,
+          onDeliveryResult,
+          onDeliveryIntent,
+        },
+      }),
       to: "channel:123",
       message: "hello",
     });
@@ -346,8 +357,9 @@ describe("executeSendAction", () => {
       queuePolicy: "required",
       requireUnknownSendReconciliation: false,
       onDeliveryIntent,
-      onDeliveryResult,
     });
+    expect(order).toEqual(["route", "receipt"]);
+    expect(onDeliveryResult).toHaveBeenCalledWith(evidence);
   });
 
   it("forwards requesterSenderId to sendMessage on core outbound path", async () => {
@@ -360,15 +372,12 @@ describe("executeSendAction", () => {
     });
 
     await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
-        params: {},
-        sessionKey: "agent:main:directchat:group:ops",
-        requesterSenderId: "attacker",
-        dryRun: false,
-      },
+      ctx: createContext({
+        input: {
+          sessionKey: "agent:main:directchat:group:ops",
+          requesterSenderId: "attacker",
+        },
+      }),
       to: "channel:123",
       message: "hello",
     });
@@ -388,17 +397,14 @@ describe("executeSendAction", () => {
     });
 
     await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
-        params: {},
-        sessionKey: "agent:main:directchat:group:ops",
-        requesterSenderName: "Alice",
-        requesterSenderUsername: "alice_u",
-        requesterSenderE164: "+15551234567",
-        dryRun: false,
-      },
+      ctx: createContext({
+        input: {
+          sessionKey: "agent:main:directchat:group:ops",
+          requesterSenderName: "Alice",
+          requesterSenderUsername: "alice_u",
+          requesterSenderE164: "+15551234567",
+        },
+      }),
       to: "channel:123",
       message: "hello",
     });
@@ -420,18 +426,15 @@ describe("executeSendAction", () => {
     });
 
     await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
-        params: {},
-        sessionKey: "agent:main:directchat:group:ops",
+      ctx: createContext({
         conversationType: "channel",
-        requesterAccountId: "source-account",
-        requesterSenderId: "attacker",
         accountId: "destination-account",
-        dryRun: false,
-      },
+        input: {
+          sessionKey: "agent:main:directchat:group:ops",
+          requesterAccountId: "source-account",
+          requesterSenderId: "attacker",
+        },
+      }),
       to: "channel:123",
       message: "hello",
     });
@@ -446,9 +449,7 @@ describe("executeSendAction", () => {
   });
 
   it("forwards requesterSenderId into outbound media access resolution", async () => {
-    await executePluginMediaSend({
-      requesterSenderId: "attacker",
-    });
+    await executePluginMediaSend({ input: { requesterSenderId: "attacker" } });
 
     expectSingleCallFields(mocks.resolveAgentScopedOutboundMediaAccess, {
       requesterSenderId: "attacker",
@@ -457,9 +458,11 @@ describe("executeSendAction", () => {
 
   it("forwards non-id requester sender fields into outbound media access resolution", async () => {
     await executePluginMediaSend({
-      requesterSenderName: "Alice",
-      requesterSenderUsername: "alice_u",
-      requesterSenderE164: "+15551234567",
+      input: {
+        requesterSenderName: "Alice",
+        requesterSenderUsername: "alice_u",
+        requesterSenderE164: "+15551234567",
+      },
     });
 
     expectSingleCallFields(mocks.resolveAgentScopedOutboundMediaAccess, {
@@ -470,9 +473,7 @@ describe("executeSendAction", () => {
   });
 
   it("keeps requester session channel authoritative for media policy", async () => {
-    await executePluginMediaSend({
-      requesterSenderId: "attacker",
-    });
+    await executePluginMediaSend({ input: { requesterSenderId: "attacker" } });
 
     expectSingleCallFields(mocks.resolveAgentScopedOutboundMediaAccess, {
       sessionKey: "agent:main:directchat:group:ops",
@@ -482,9 +483,8 @@ describe("executeSendAction", () => {
 
   it("uses requester account for media policy when session context is present", async () => {
     await executePluginMediaSend({
-      requesterAccountId: "source-account",
-      requesterSenderId: "attacker",
       accountId: "destination-account",
+      input: { requesterAccountId: "source-account", requesterSenderId: "attacker" },
     });
 
     expectSingleCallFields(mocks.resolveAgentScopedOutboundMediaAccess, {
@@ -495,8 +495,8 @@ describe("executeSendAction", () => {
 
   it("falls back to destination account for media policy when requester account is missing", async () => {
     await executePluginMediaSend({
-      requesterSenderId: "attacker",
       accountId: "destination-account",
+      input: { requesterSenderId: "attacker" },
     });
 
     expectSingleCallFields(mocks.resolveAgentScopedOutboundMediaAccess, {
@@ -515,16 +515,13 @@ describe("executeSendAction", () => {
     });
 
     await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
-        params: {},
-        sessionKey: "agent:main:directchat:group:ops",
-        requesterSenderId: "attacker",
+      ctx: createContext({
         accountId: "destination-account",
-        dryRun: false,
-      },
+        input: {
+          sessionKey: "agent:main:directchat:group:ops",
+          requesterSenderId: "attacker",
+        },
+      }),
       to: "channel:123",
       message: "hello",
     });
@@ -555,18 +552,18 @@ describe("executeSendAction", () => {
     });
 
     const result = await executeSendAction({
-      ctx: {
-        plugin,
-        cfg: {},
+      ctx: createContext({
+        channelPlugin: plugin,
         channel: "discord",
         params: { to: "channel:123", presentation },
-        runId: "run-presentation-delivery",
-        dryRun: false,
         mirror: {
           sessionKey: "agent:main:discord:channel:123",
           agentId: "main",
         },
-      },
+        input: {
+          runId: "run-presentation-delivery",
+        },
+      }),
       to: "channel:123",
       message: "",
       payload: { text: "", presentation },
@@ -613,13 +610,11 @@ describe("executeSendAction", () => {
     });
 
     await executeSendAction({
-      ctx: {
-        plugin,
-        cfg: {},
+      ctx: createContext({
+        channelPlugin: plugin,
         channel: "discord",
         params: { to: "channel:123", message: "Deployment trend", presentation },
-        dryRun: false,
-      },
+      }),
       to: "channel:123",
       message: "Deployment trend",
       payload: { text: "Deployment trend", presentation },
@@ -653,18 +648,16 @@ describe("executeSendAction", () => {
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
 
     const result = await executeSendAction({
-      ctx: {
-        plugin,
-        cfg: {},
+      ctx: createContext({
+        channelPlugin: plugin,
         channel: "discord",
         params: { to: "channel:123", components: nativeComponents, presentation },
-        dryRun: false,
         mirror: {
           sessionKey: "agent:main:discord:channel:123",
           agentId: "main",
           text: "Summary",
         },
-      },
+      }),
       to: "channel:123",
       message: "Summary",
       payload: { text: "Summary", presentation },
@@ -718,13 +711,11 @@ describe("executeSendAction", () => {
     });
 
     await executeSendAction({
-      ctx: {
-        plugin,
-        cfg: {},
+      ctx: createContext({
+        channelPlugin: plugin,
         channel: "whatsapp",
         params: { to: "+15551234567", message: "Deployment trend", presentation },
-        dryRun: false,
-      },
+      }),
       to: "+15551234567",
       message: "Deployment trend",
       payload: { text: "Deployment trend", presentation },
@@ -761,13 +752,11 @@ describe("executeSendAction", () => {
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
 
     const result = await executeSendAction({
-      ctx: {
-        plugin,
-        cfg: {},
+      ctx: createContext({
+        channelPlugin: plugin,
         channel: "discord",
         params: { to: "channel:123", presentation },
-        dryRun: false,
-      },
+      }),
       to: "channel:123",
       message: "",
       payload: { text: "", presentation },
@@ -786,13 +775,9 @@ describe("executeSendAction", () => {
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
 
     const result = await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
+      ctx: createContext({
         params: { to: "channel:123", message: "hello" },
-        dryRun: false,
-      },
+      }),
       to: "channel:123",
       message: "hello",
       payload: { text: "hello" },
@@ -840,13 +825,11 @@ describe("executeSendAction", () => {
 
     const components = () => [];
     const result = await executeSendAction({
-      ctx: {
-        plugin,
-        cfg: {},
+      ctx: createContext({
+        channelPlugin: plugin,
         channel: "discord",
         params: { to: "channel:123", message: "hello", components, replyTo: reply.replyToId },
-        dryRun: false,
-      },
+      }),
       to: "channel:123",
       message: "hello",
       reply,
@@ -866,13 +849,7 @@ describe("executeSendAction", () => {
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("poll-plugin"));
 
     const result = await executePollAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
-        params: {},
-        dryRun: false,
-      },
+      ctx: createContext({}),
       resolveCorePoll: () => ({
         to: "channel:123",
         question: "Lunch?",
@@ -892,18 +869,14 @@ describe("executeSendAction", () => {
     });
 
     const result = await executePollAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
+      ctx: createContext({
         params: {
           pollQuestion: "Lunch?",
           pollOption: ["Pizza", "Sushi"],
           pollDurationSeconds: 90,
           pollPublic: true,
         },
-        dryRun: false,
-      },
+      }),
       resolveCorePoll,
     });
 
@@ -916,14 +889,10 @@ describe("executeSendAction", () => {
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
 
     await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
+      ctx: createContext({
         params: { to: "channel:123", message: "hello" },
         agentId: "agent-1",
-        dryRun: false,
-      },
+      }),
       to: "channel:123",
       message: "hello",
     });
@@ -943,18 +912,14 @@ describe("executeSendAction", () => {
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
 
     await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
+      ctx: createContext({
         params: {
           to: "channel:123",
           message: "hello",
           media: "/Users/peter/Pictures/photo.png",
         },
         agentId: "agent-1",
-        dryRun: false,
-      },
+      }),
       to: "channel:123",
       message: "hello",
       mediaUrl: "/Users/peter/Pictures/photo.png",
@@ -971,10 +936,7 @@ describe("executeSendAction", () => {
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
 
     await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
+      ctx: createContext({
         params: {
           to: "channel:123",
           message: "hello",
@@ -982,8 +944,7 @@ describe("executeSendAction", () => {
           attachments: [{ filePath: "/workspace/Documents/report.md" }],
         },
         agentId: "agent-1",
-        dryRun: false,
-      },
+      }),
       to: "channel:123",
       message: "hello",
       mediaUrls: ["/workspace/Pictures/chart.png"],
@@ -1001,10 +962,7 @@ describe("executeSendAction", () => {
     mocks.dispatchChannelMessageAction.mockResolvedValue(pluginActionResult("msg-plugin"));
 
     await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
+      ctx: createContext({
         params: {
           to: "channel:123",
           message: "hello",
@@ -1015,8 +973,7 @@ describe("executeSendAction", () => {
           readFile: explicitReadFile,
         },
         agentId: "agent-1",
-        dryRun: false,
-      },
+      }),
       to: "channel:123",
       message: "hello",
       mediaUrls: ["/workspace/Pictures/chart.png"],
@@ -1076,10 +1033,7 @@ describe("executeSendAction", () => {
     });
 
     await executeSendAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
+      ctx: createContext({
         params: { to: "channel:123", message: "hello" },
         idempotencyKey: "stable-send-key",
         dryRun: true,
@@ -1091,7 +1045,7 @@ describe("executeSendAction", () => {
           clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
           mode: GATEWAY_CLIENT_MODES.BACKEND,
         },
-      },
+      }),
       to: "channel:123",
       message: "hello",
     });
@@ -1136,16 +1090,16 @@ describe("executeSendAction", () => {
     });
 
     await executeSendAction({
-      ctx: {
-        plugin,
-        cfg: {},
+      ctx: createContext({
+        channelPlugin: plugin,
         channel: "discord",
         params: { to: "channel:123", message: "hello" },
-        dryRun: false,
-        sessionKey: "discord-session",
-        inboundEventKind: "room_event",
-        conversationReadOrigin: "delegated",
-      },
+        input: {
+          sessionKey: "discord-session",
+          inboundEventKind: "room_event",
+          conversationReadOrigin: "delegated",
+        },
+      }),
       to: "channel:123",
       message: "hello",
       payload: { text: "hello", presentation },
@@ -1200,13 +1154,11 @@ describe("executeSendAction", () => {
     });
 
     await executeSendAction({
-      ctx: {
-        plugin,
-        cfg: {},
+      ctx: createContext({
+        channelPlugin: plugin,
         channel: "discord",
         params: { to: "channel:123", message: "hello" },
-        dryRun: false,
-      },
+      }),
       to: "channel:123",
       message: "hello",
       bestEffort: false,
@@ -1232,16 +1184,13 @@ describe("executeSendAction", () => {
     });
 
     await executePollAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
-        params: {},
+      ctx: createContext({
         accountId: "acc-1",
-        sessionKey: "agent:main:demo-outbound:channel:123",
-        inboundEventKind: "room_event",
-        dryRun: false,
-      },
+        input: {
+          sessionKey: "agent:main:demo-outbound:channel:123",
+          inboundEventKind: "room_event",
+        },
+      }),
       resolveCorePoll: () => ({
         to: "channel:123",
         question: "Lunch?",
@@ -1283,11 +1232,7 @@ describe("executeSendAction", () => {
     });
 
     await executePollAction({
-      ctx: {
-        plugin: defaultPlugin,
-        cfg: {},
-        channel: "demo-outbound",
-        params: {},
+      ctx: createContext({
         idempotencyKey: "stable-poll-key",
         dryRun: true,
         silent: true,
@@ -1298,7 +1243,7 @@ describe("executeSendAction", () => {
           clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
           mode: GATEWAY_CLIENT_MODES.BACKEND,
         },
-      },
+      }),
       resolveCorePoll: () => ({
         to: "channel:123",
         question: "Lunch?",

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -1,37 +1,29 @@
 // Outbound send service chooses plugin-handled message actions or the core
 // message/poll path while preserving media policy and transcript mirrors.
 import type { AgentToolResult } from "../../agents/runtime/index.js";
-import type { ExecutionIdentityAdmissionToken } from "../../audit/execution-identity-admission.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ChatType } from "../../channels/chat-type.js";
-import type { InboundEventKind } from "../../channels/inbound-event/kind.js";
-import type { DurableMessageSendIntent, OutboundReplyFacts } from "../../channels/message/types.js";
-import type { ConversationReadInvocationOrigin } from "../../channels/plugins/conversation-read-origin.js";
+import type { OutboundReplyFacts } from "../../channels/message/types.js";
+import { normalizeConversationReadInvocationOrigin } from "../../channels/plugins/conversation-read-origin.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
 import type {
-  ChannelId,
   ChannelMessageActionContext,
   ChannelOutboundAdapter,
-  ChannelPlugin,
-  ChannelThreadingToolContext,
 } from "../../channels/plugins/types.public.js";
 import { appendAssistantMessageToSessionTranscript } from "../../config/sessions.js";
 import { getOwnedSessionTranscriptWriterFence } from "../../config/sessions/transcript-write-context.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   normalizeMessagePresentation,
   renderMessagePresentationFallbackText,
 } from "../../interactive/payload.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import type { OutboundMediaAccess, OutboundMediaReadFile } from "../../media/load-options.js";
+import type { OutboundMediaAccess } from "../../media/load-options.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
 import { formatErrorMessage } from "../errors.js";
 import { throwIfAborted } from "./abort.js";
-import type { OutboundDeliveryResult } from "./deliver-types.js";
-import type { NormalizedOutboundPayload, OutboundSendDeps } from "./deliver.js";
-import type { DurableDeliveryCompletion } from "./delivery-completion.js";
-import type { MessageActionGateway } from "./message-action-contracts.js";
+import type { NormalizedOutboundPayload } from "./deliver.js";
+import type { ResolvedActionContext } from "./message-action-contracts.js";
 import { collectActionMediaSourceHints } from "./message-action-params.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
 import { sendMessage, sendPoll } from "./message.js";
@@ -39,65 +31,15 @@ import type { OutboundMirror } from "./mirror.js";
 
 const log = createSubsystemLogger("outbound/send-service");
 
-/** Shared execution context for message-tool send and poll actions. */
-type OutboundSendContext = {
-  cfg: OpenClawConfig;
-  channel: ChannelId;
-  plugin: ChannelPlugin;
-  params: Record<string, unknown>;
-  idempotencyKey?: string;
-  /** Active agent id for per-agent outbound media root scoping. */
-  agentId?: string;
-  sessionKey?: string;
-  requesterAccountId?: string;
-  requesterSenderId?: string;
-  requesterSenderName?: string;
-  requesterSenderUsername?: string;
-  requesterSenderE164?: string;
-  senderIsOwner?: boolean;
-  conversationReadOrigin?: ConversationReadInvocationOrigin;
+type OutboundSendContext = Omit<ResolvedActionContext, "mediaAccess"> & {
   mediaAccess?: OutboundMediaAccess;
-  mediaReadFile?: OutboundMediaReadFile;
-  accountId?: string | null;
-  /** Known destination conversation kind prepared by the caller. */
   conversationType?: ChatType;
-  sessionId?: string;
-  runId?: string;
-  executionIdentityToken?: ExecutionIdentityAdmissionToken;
-  inboundEventKind?: InboundEventKind;
-  gateway?: MessageActionGateway;
-  toolContext?: ChannelThreadingToolContext;
-  deps?: OutboundSendDeps;
-  dryRun: boolean;
   mirror?: OutboundMirror;
-  abortSignal?: AbortSignal;
   silent?: boolean;
-  /** Channel-valid id reserved before a correlated conversation turn is sent. */
-  preparedMessageId?: string;
-  /** The Gateway owns this call and may use its active gateway-mode adapter directly. */
-  gatewayOwnedDelivery?: boolean;
-  /** Bypass provider-native actions so core durable delivery owns the send. */
-  forceCoreDelivery?: boolean;
-  /** Fail before platform I/O unless the core delivery queue persisted the intent. */
-  requireQueuePersistence?: boolean;
-  /** Stable producer id for idempotent durable queue creation. */
-  deliveryIntentId?: string;
-  /** Serializable owner state finalized by live send or recovery. */
-  deliveryCompletion?: DurableDeliveryCompletion;
   /** The caller resends proven-not-sent payloads itself, so recovery must not. */
   deliveryRetryOwner?: "caller";
-  /** Runs after queue persistence and before platform I/O. */
-  onDeliveryIntent?: (intent: DurableMessageSendIntent) => void;
-  /** Revalidates authority once per durable queue execution, before adapter fanout. */
-  onDeliveryAttempt?: () => Promise<void>;
-  /** Runs on identified platform evidence before queue acknowledgement. */
-  onDeliveryResult?: (result: OutboundDeliveryResult) => Promise<void> | void;
-  /** Revalidates caller authority immediately before recipient-visible I/O. */
-  onPlatformSendDispatch?: () => Promise<void>;
-  /** Keep ephemeral-authority sends out of replayable recovery. */
-  skipQueue?: boolean;
-  /** Runs once a plugin action accepted the send, before transcript mirroring. */
-  onPluginSendAccepted?: () => Promise<void>;
+  /** Commits the route after platform evidence, before either delivery mirror. */
+  onSendAccepted?: () => Promise<void>;
 };
 
 type PluginHandledResult = {
@@ -153,12 +95,12 @@ async function sendCoreMessage(params: {
     content: params.message,
     ...(params.payloads ? { payloads: params.payloads } : {}),
     agentId: params.ctx.agentId,
-    requesterSessionKey: params.ctx.sessionKey,
-    requesterAccountId: params.ctx.requesterAccountId ?? params.ctx.accountId ?? undefined,
-    requesterSenderId: params.ctx.requesterSenderId,
-    requesterSenderName: params.ctx.requesterSenderName,
-    requesterSenderUsername: params.ctx.requesterSenderUsername,
-    requesterSenderE164: params.ctx.requesterSenderE164,
+    requesterSessionKey: params.ctx.input.sessionKey,
+    requesterAccountId: params.ctx.input.requesterAccountId ?? params.ctx.accountId ?? undefined,
+    requesterSenderId: params.ctx.input.requesterSenderId ?? undefined,
+    requesterSenderName: params.ctx.input.requesterSenderName ?? undefined,
+    requesterSenderUsername: params.ctx.input.requesterSenderUsername ?? undefined,
+    requesterSenderE164: params.ctx.input.requesterSenderE164 ?? undefined,
     mediaUrl: params.mediaUrl || undefined,
     mediaUrls: params.mediaUrls,
     buffer: params.buffer,
@@ -168,7 +110,9 @@ async function sendCoreMessage(params: {
     channel: params.ctx.channel || undefined,
     accountId: params.ctx.accountId ?? undefined,
     conversationType: params.ctx.conversationType,
-    conversationReadOrigin: params.ctx.conversationReadOrigin,
+    conversationReadOrigin: normalizeConversationReadInvocationOrigin(
+      params.ctx.input.conversationReadOrigin,
+    ),
     reply: params.reply,
     threadId: params.threadId,
     gifPlayback: params.gifPlayback,
@@ -176,27 +120,30 @@ async function sendCoreMessage(params: {
     dryRun: params.ctx.dryRun,
     bestEffort: params.bestEffort ?? undefined,
     queuePolicy: params.queuePolicy,
-    deps: params.ctx.deps,
+    deps: params.ctx.input.deps,
     gateway: params.ctx.gateway,
     idempotencyKey: params.ctx.idempotencyKey,
-    runId: params.ctx.runId,
-    executionIdentityToken: params.ctx.executionIdentityToken,
+    runId: params.ctx.input.runId,
+    executionIdentityToken: params.ctx.input.executionIdentityToken,
     mirror: params.ctx.mirror,
     abortSignal: params.ctx.abortSignal,
     silent: params.ctx.silent,
     mediaAccess: params.ctx.mediaAccess,
-    preparedMessageId: params.ctx.preparedMessageId,
-    preparedPlugin: params.ctx.plugin,
-    gatewayOwnedDelivery: params.ctx.gatewayOwnedDelivery,
-    deliveryIntentId: params.ctx.deliveryIntentId,
-    deliveryCompletion: params.ctx.deliveryCompletion,
+    preparedMessageId: params.ctx.input.preparedMessageId,
+    preparedPlugin: params.ctx.channelPlugin,
+    gatewayOwnedDelivery: params.ctx.input.gatewayOwnedDelivery,
+    deliveryIntentId: params.ctx.input.deliveryIntentId,
+    deliveryCompletion: params.ctx.input.deliveryCompletion,
     deliveryRetryOwner: params.ctx.deliveryRetryOwner,
-    requireUnknownSendReconciliation: params.ctx.requireQueuePersistence ? false : undefined,
-    onDeliveryIntent: params.ctx.onDeliveryIntent,
-    onDeliveryAttempt: params.ctx.onDeliveryAttempt,
-    onDeliveryResult: params.ctx.onDeliveryResult,
-    onPlatformSendDispatch: params.ctx.onPlatformSendDispatch,
-    skipQueue: params.ctx.skipQueue,
+    requireUnknownSendReconciliation: params.ctx.input.requireQueuePersistence ? false : undefined,
+    onDeliveryIntent: params.ctx.input.onDeliveryIntent,
+    onDeliveryAttempt: params.ctx.input.onDeliveryAttempt,
+    onDeliveryResult: async (evidence) => {
+      await params.ctx.onSendAccepted?.();
+      await params.ctx.input.onDeliveryResult?.(evidence);
+    },
+    onPlatformSendDispatch: params.ctx.input.onPlatformSendDispatch,
+    skipQueue: params.ctx.input.skipQueue,
     onDeliveredPayload: (payload) => deliveredPayloads.push(payload),
   });
   const deliveredText =
@@ -232,18 +179,17 @@ async function tryHandleWithPluginAction(params: {
     mediaSources: collectActionMediaSourceHints(params.ctx.params, undefined, {
       structuredAttachments: params.action === "send" ? "all" : undefined,
     }),
-    sessionKey: params.ctx.sessionKey,
-    messageProvider: params.ctx.sessionKey ? undefined : params.ctx.channel,
+    sessionKey: params.ctx.input.sessionKey,
+    messageProvider: params.ctx.input.sessionKey ? undefined : params.ctx.channel,
     accountId:
-      (params.ctx.sessionKey
-        ? (params.ctx.requesterAccountId ?? params.ctx.accountId)
+      (params.ctx.input.sessionKey
+        ? (params.ctx.input.requesterAccountId ?? params.ctx.accountId)
         : params.ctx.accountId) ?? undefined,
-    requesterSenderId: params.ctx.requesterSenderId,
-    requesterSenderName: params.ctx.requesterSenderName,
-    requesterSenderUsername: params.ctx.requesterSenderUsername,
-    requesterSenderE164: params.ctx.requesterSenderE164,
+    requesterSenderId: params.ctx.input.requesterSenderId ?? undefined,
+    requesterSenderName: params.ctx.input.requesterSenderName ?? undefined,
+    requesterSenderUsername: params.ctx.input.requesterSenderUsername ?? undefined,
+    requesterSenderE164: params.ctx.input.requesterSenderE164 ?? undefined,
     mediaAccess: params.ctx.mediaAccess,
-    mediaReadFile: params.ctx.mediaReadFile,
   });
   const handled = await dispatchChannelMessageAction(
     createChannelActionContext({
@@ -278,19 +224,21 @@ function createChannelActionContext(params: {
     params: params.ctx.params,
     ...(params.reply ? { reply: params.reply } : {}),
     ...(mediaAccess ? { mediaAccess } : {}),
-    mediaLocalRoots: mediaAccess?.localRoots ?? params.ctx.mediaAccess?.localRoots,
-    mediaReadFile: mediaAccess?.readFile ?? params.ctx.mediaReadFile,
+    mediaLocalRoots: mediaAccess?.localRoots,
+    mediaReadFile: mediaAccess?.readFile,
     accountId: params.ctx.accountId ?? undefined,
-    requesterAccountId: params.ctx.requesterAccountId,
-    requesterSenderId: params.ctx.requesterSenderId,
-    senderIsOwner: params.ctx.senderIsOwner,
-    conversationReadOrigin: params.ctx.conversationReadOrigin,
-    sessionKey: params.ctx.sessionKey,
-    sessionId: params.ctx.sessionId,
-    inboundEventKind: params.ctx.inboundEventKind,
+    requesterAccountId: params.ctx.input.requesterAccountId ?? undefined,
+    requesterSenderId: params.ctx.input.requesterSenderId ?? undefined,
+    senderIsOwner: params.ctx.input.senderIsOwner,
+    conversationReadOrigin: normalizeConversationReadInvocationOrigin(
+      params.ctx.input.conversationReadOrigin,
+    ),
+    sessionKey: params.ctx.input.sessionKey,
+    sessionId: params.ctx.input.sessionId,
+    inboundEventKind: params.ctx.input.inboundEventKind,
     agentId: params.ctx.agentId,
     gateway: params.ctx.gateway,
-    toolContext: params.ctx.toolContext,
+    toolContext: params.ctx.input.toolContext,
     dryRun: params.ctx.dryRun,
   };
 }
@@ -307,7 +255,7 @@ async function preparePluginSendPayload(params: {
   reply?: OutboundReplyFacts;
   threadId?: string | number;
 }): Promise<PluginSendPayloadPreparation> {
-  const plugin = params.ctx.plugin;
+  const plugin = params.ctx.channelPlugin;
   if (!plugin?.outbound) {
     return { kind: "unavailable" };
   }
@@ -361,11 +309,14 @@ export async function executeSendAction(params: {
     audioAsVoice: params.asVoice === true,
   };
   const queuePolicy =
-    params.bestEffort === false || params.ctx.requireQueuePersistence ? "required" : "best_effort";
+    params.bestEffort === false || params.ctx.input.requireQueuePersistence
+      ? "required"
+      : "best_effort";
   // Queue persistence cannot be guaranteed by provider-native action handlers.
   // Treat the guarantee as forcing the one core path at every dispatch gate.
   const requiresCoreDelivery =
-    params.ctx.forceCoreDelivery === true || params.ctx.requireQueuePersistence === true;
+    params.ctx.input.forceCoreDelivery === true ||
+    params.ctx.input.requireQueuePersistence === true;
   const pluginPreparation = requiresCoreDelivery
     ? ({ kind: "unavailable" } as const)
     : await preparePluginSendPayload({
@@ -375,7 +326,7 @@ export async function executeSendAction(params: {
         reply: params.reply,
         threadId: params.threadId,
       });
-  const channelPlugin = params.ctx.plugin;
+  const channelPlugin = params.ctx.channelPlugin;
   const presentation = normalizeMessagePresentation(defaultPayload.presentation);
   const corePayload = requiresCoreDelivery
     ? defaultPayload
@@ -386,102 +337,84 @@ export async function executeSendAction(params: {
           hasCorePresentationDelivery(channelPlugin?.outbound)
         ? defaultPayload
         : null;
-  if (corePayload) {
-    throwIfAborted(params.ctx.abortSignal);
-    const corePresentation = normalizeMessagePresentation(corePayload.presentation);
-    const message =
-      corePresentation && channelPlugin?.outbound?.deliveryMode === "gateway"
-        ? materializeMessagePresentationFallback({
-            payload: corePayload,
-            text: params.message,
-          })
-        : params.message;
-    // Prepared payloads and portable presentations need core delivery so queueing,
-    // presentation rendering/adaptation, hooks, and mirrors stay uniform. The legacy
-    // gateway `send` method accepts text/media only, so materialize its fallback here.
-    const delivery = await sendCoreMessage({
-      ...params,
-      message,
-      queuePolicy,
-      payloads: [corePayload],
-    });
-
-    return {
-      handledBy: "core",
-      payload: delivery.result,
-      ...(delivery.deliveredText ? { deliveredText: delivery.deliveredText } : {}),
-      sendResult: delivery.result,
-    };
-  }
-
-  const pluginMessage = presentation
-    ? materializeMessagePresentationFallback({ payload: defaultPayload, text: params.message })
-    : params.message;
-  const pluginCtx =
-    pluginMessage === params.message
-      ? params.ctx
-      : {
-          ...params.ctx,
-          params: { ...params.ctx.params, message: pluginMessage },
-        };
-  const pluginHandled = requiresCoreDelivery
-    ? null
-    : await tryHandleWithPluginAction({
-        ctx: pluginCtx,
-        action: "send",
-        reply: params.reply,
-        onHandled: async () => {
-          // The accepted-send commit must precede the transcript mirror below:
-          // first-contact outbound routes create their session row in it.
-          await params.ctx.onPluginSendAccepted?.();
-          if (!params.ctx.mirror) {
-            return;
-          }
-          const materializedPresentationFallback = pluginMessage !== params.message;
-          const mirrorText = materializedPresentationFallback
-            ? pluginMessage
-            : params.ctx.mirror.text?.trim() || pluginMessage;
-          const mirrorMediaUrls =
-            params.ctx.mirror.mediaUrls ??
-            params.mediaUrls ??
-            (params.mediaUrl ? [params.mediaUrl] : undefined);
-          try {
-            const writerFence = getOwnedSessionTranscriptWriterFence({
-              sessionKey: params.ctx.mirror.sessionKey,
-            });
-            const mirrorResult = await appendAssistantMessageToSessionTranscript({
-              agentId: params.ctx.mirror.agentId,
-              sessionKey: params.ctx.mirror.sessionKey,
-              expectedSessionId: params.ctx.mirror.expectedSessionId,
-              ...(writerFence?.expectedLifecycleRevision !== undefined
-                ? { expectedLifecycleRevision: writerFence.expectedLifecycleRevision }
-                : {}),
-              ...(writerFence ? { expectedWriterRunId: writerFence.expectedWriterRunId } : {}),
-              text: mirrorText,
-              mediaUrls: mirrorMediaUrls,
-              idempotencyKey: params.ctx.mirror.idempotencyKey,
-              deliveryMirror: params.ctx.mirror.deliveryMirror,
-              config: params.ctx.cfg,
-            });
-            if (!mirrorResult.ok) {
-              log.warn(
-                `failed to mirror plugin-handled delivery; channel send already succeeded: ${mirrorResult.reason}`,
-              );
-            }
-          } catch (error) {
+  if (!corePayload) {
+    const pluginMessage = presentation
+      ? materializeMessagePresentationFallback({ payload: defaultPayload, text: params.message })
+      : params.message;
+    const pluginCtx =
+      pluginMessage === params.message
+        ? params.ctx
+        : {
+            ...params.ctx,
+            params: { ...params.ctx.params, message: pluginMessage },
+          };
+    const pluginHandled = await tryHandleWithPluginAction({
+      ctx: pluginCtx,
+      action: "send",
+      reply: params.reply,
+      onHandled: async () => {
+        // The accepted-send commit must precede the transcript mirror below:
+        // first-contact outbound routes create their session row in it.
+        await params.ctx.onSendAccepted?.();
+        if (!params.ctx.mirror) {
+          return;
+        }
+        const materializedPresentationFallback = pluginMessage !== params.message;
+        const mirrorText = materializedPresentationFallback
+          ? pluginMessage
+          : params.ctx.mirror.text?.trim() || pluginMessage;
+        const mirrorMediaUrls =
+          params.ctx.mirror.mediaUrls ??
+          params.mediaUrls ??
+          (params.mediaUrl ? [params.mediaUrl] : undefined);
+        try {
+          const writerFence = getOwnedSessionTranscriptWriterFence({
+            sessionKey: params.ctx.mirror.sessionKey,
+          });
+          const mirrorResult = await appendAssistantMessageToSessionTranscript({
+            agentId: params.ctx.mirror.agentId,
+            sessionKey: params.ctx.mirror.sessionKey,
+            expectedSessionId: params.ctx.mirror.expectedSessionId,
+            ...(writerFence?.expectedLifecycleRevision !== undefined
+              ? { expectedLifecycleRevision: writerFence.expectedLifecycleRevision }
+              : {}),
+            ...(writerFence ? { expectedWriterRunId: writerFence.expectedWriterRunId } : {}),
+            text: mirrorText,
+            mediaUrls: mirrorMediaUrls,
+            idempotencyKey: params.ctx.mirror.idempotencyKey,
+            deliveryMirror: params.ctx.mirror.deliveryMirror,
+            config: params.ctx.cfg,
+          });
+          if (!mirrorResult.ok) {
             log.warn(
-              `failed to mirror plugin-handled delivery; channel send already succeeded: ${formatErrorMessage(error)}`,
+              `failed to mirror plugin-handled delivery; channel send already succeeded: ${mirrorResult.reason}`,
             );
           }
-        },
-      });
-  if (pluginHandled) {
-    return pluginHandled;
+        } catch (error) {
+          log.warn(
+            `failed to mirror plugin-handled delivery; channel send already succeeded: ${formatErrorMessage(error)}`,
+          );
+        }
+      },
+    });
+    if (pluginHandled) {
+      return pluginHandled;
+    }
   }
 
   throwIfAborted(params.ctx.abortSignal);
+  // Prepared payloads and presentations share core queueing, hooks, and mirrors.
+  // The legacy gateway send RPC accepts text/media, so materialize its fallback.
+  const message =
+    corePayload &&
+    normalizeMessagePresentation(corePayload.presentation) &&
+    channelPlugin?.outbound?.deliveryMode === "gateway"
+      ? materializeMessagePresentationFallback({ payload: corePayload, text: params.message })
+      : params.message;
   const delivery = await sendCoreMessage({
     ...params,
+    message,
+    ...(corePayload ? { payloads: [corePayload] } : {}),
     queuePolicy,
   });
 
@@ -539,9 +472,9 @@ export async function executePollAction(params: {
     dryRun: params.ctx.dryRun,
     gateway: params.ctx.gateway,
     idempotencyKey: params.ctx.idempotencyKey,
-    preparedPlugin: params.ctx.plugin,
-    sessionKey: params.ctx.sessionKey,
-    inboundEventKind: params.ctx.inboundEventKind,
+    preparedPlugin: params.ctx.channelPlugin,
+    sessionKey: params.ctx.input.sessionKey,
+    inboundEventKind: params.ctx.input.inboundEventKind,
   });
 
   return {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Outbound message handling repeatedly copied the same resolved delivery context into separate private shapes. Send, poll, plugin dispatch, and source-delivery annotation had to keep these projections synchronized, while core send maintained two equivalent execution paths.

## Why This Change Was Made

Carry the resolved action context through internal execution and use one core-send path. Keep the explicit plugin and Gateway request projections at their existing boundaries. Native and core acceptance share the same route-commit callback, preserving route-before-receipt and mirror ordering.

Production changes are **+223/-428 = -205 lines**; tests and support are **-63 lines**. The public message-action input, plugin SDK, protocol, config, and storage formats are unchanged. Poll deliberately retains its narrower requester and media context. Retry ownership, required queue persistence, scoped media reads, cancellation, dry runs, and mirror destinations retain their existing policies.

## User Impact

No intended behavior change. Operators can send messages, create polls, and invoke plugin actions through the same interfaces.

## Evidence

- The baseline's 612 tests across 35 files passed. Candidate coverage passed across the same owners and channel boundaries, including all 96 channel cases. Two internal-context assertions were updated after the refactor and their 16-test files passed.
- One broad candidate run hit a producer-lease expiry after an 80.9-second cold account-routing case. The entire 26-test file then passed in original order on both baseline and candidate, without source or timeout changes. Lease/renewal/acknowledgement code is unchanged; the original failure lacks sufficient row/clock evidence to prove its cause.
- A 14-case process differential executed actual send/poll/plugin entry points and queue, session, transcript, media, and action-dispatch owners against a synthetic transport. Baseline and candidate observations were identical, including request whitelists, null normalization, media readers, dry runs, cancellation, authority rejection, and mirroring.
- Full changed checks passed. Independent Codex P0–P2 review and an additional owner-boundary review found no actionable findings.

Built Gateway QA completed on an isolated Linux Testbox with Node 24.19.0, a mock OpenAI provider, and the QA channel. Both `a2a-message-tool-mirror-dedupe` and `thread-reply-current-source-delivery` passed. All 38,074 tracked source files matched the frozen local candidate before and after the run. [Gateway proof run](https://github.com/openclaw/openclaw/actions/runs/33967274051).

```json
{"verdict":"PASS","processDifferentialCases":14,"gatewayScenarios":["a2a-message-tool-mirror-dedupe","thread-reply-current-source-delivery"],"sourceIdentityUnchanged":true}
```

CI refresh: rebased onto current main after the prebuilt UI admission import was repaired in #139123. All three production owner hashes still match the live proof. An unchanged Gateway event-loop recovery assertion failed once in CI and passed on the focused rerun; no assertion or timeout was changed.
