### PR TITLE
fix(ci): unblock Docker smoke tests on current runtimes

### DIFF
--- a/scripts/test-live-acp-bind-docker.sh
+++ b/scripts/test-live-acp-bind-docker.sh
@@ -123,21 +123,12 @@ case "$agent" in
       unset ANTHROPIC_AUTH_TOKEN
       unset ANTHROPIC_OAUTH_TOKEN
     fi
-    claude_code_version="$(
-      node -e 'const path = require("node:path"); const packagePath = path.join(path.dirname(require.resolve("@anthropic-ai/claude-agent-sdk")), "package.json"); process.stdout.write(require(packagePath).claudeCodeVersion);'
-    )"
-    claude_package_json="$NPM_CONFIG_PREFIX/lib/node_modules/@anthropic-ai/claude-code/package.json"
     real_claude="$NPM_CONFIG_PREFIX/bin/claude-real"
-    installed_claude_code_version=""
-    if [ -f "$claude_package_json" ]; then
-      installed_claude_code_version="$(
-        node -e 'process.stdout.write(require(process.argv[1]).version);' \
-          "$claude_package_json" 2>/dev/null || true
-      )"
-    fi
-    if [ "$installed_claude_code_version" != "$claude_code_version" ]; then
-      rm -f "$NPM_CONFIG_PREFIX/bin/claude" "$real_claude"
-      run_setup_command npm install -g "@anthropic-ai/claude-code@$claude_code_version"
+    if [ ! -x "$real_claude" ]; then
+      # Claude owns its executable; the retired Agent SDK no longer pins its version.
+      openclaw_live_prepare_cli_backend \
+        "$NPM_CONFIG_PREFIX/bin/claude" "@anthropic-ai/claude-code" \
+        "$OPENCLAW_LIVE_ACP_BIND_SETUP_TIMEOUT_SECONDS"
     fi
     if [ ! -x "$real_claude" ] && [ -x "$NPM_CONFIG_PREFIX/bin/claude" ]; then
       mv "$NPM_CONFIG_PREFIX/bin/claude" "$real_claude"
@@ -162,7 +153,7 @@ WRAP
       chmod +x "$NPM_CONFIG_PREFIX/bin/claude"
     fi
     export CLAUDE_CODE_EXECUTABLE="$NPM_CONFIG_PREFIX/bin/claude"
-    echo "Using Claude Code $claude_code_version declared by the installed Claude Agent SDK"
+    echo "Using installed Claude Code CLI"
     claude --version
     claude auth status || true
     ;;

--- a/scripts/test-live-acp-bind-docker.sh
+++ b/scripts/test-live-acp-bind-docker.sh
@@ -123,12 +123,22 @@ case "$agent" in
       unset ANTHROPIC_AUTH_TOKEN
       unset ANTHROPIC_OAUTH_TOKEN
     fi
+    # Resolve through ACPX so pnpm cannot select an unrelated root or hoisted SDK.
+    claude_code_version="$(
+      node -e 'const path = require("node:path"); const { createRequire } = require("node:module"); const acpxRequire = createRequire(path.resolve("extensions/acpx/package.json")); const adapterPackagePath = acpxRequire.resolve("@agentclientprotocol/claude-agent-acp/package.json"); const adapterRequire = createRequire(adapterPackagePath); const sdkEntry = adapterRequire.resolve("@anthropic-ai/claude-agent-sdk"); const packagePath = path.join(path.dirname(sdkEntry), "package.json"); process.stdout.write(require(packagePath).claudeCodeVersion);'
+    )"
+    claude_package_json="$NPM_CONFIG_PREFIX/lib/node_modules/@anthropic-ai/claude-code/package.json"
     real_claude="$NPM_CONFIG_PREFIX/bin/claude-real"
-    if [ ! -x "$real_claude" ]; then
-      # Claude owns its executable; the retired Agent SDK no longer pins its version.
-      openclaw_live_prepare_cli_backend \
-        "$NPM_CONFIG_PREFIX/bin/claude" "@anthropic-ai/claude-code" \
-        "$OPENCLAW_LIVE_ACP_BIND_SETUP_TIMEOUT_SECONDS"
+    installed_claude_code_version=""
+    if [ -f "$claude_package_json" ]; then
+      installed_claude_code_version="$(
+        node -e 'process.stdout.write(require(process.argv[1]).version);' \
+          "$claude_package_json" 2>/dev/null || true
+      )"
+    fi
+    if [ "$installed_claude_code_version" != "$claude_code_version" ]; then
+      rm -f "$NPM_CONFIG_PREFIX/bin/claude" "$real_claude"
+      run_setup_command npm install -g "@anthropic-ai/claude-code@$claude_code_version"
     fi
     if [ ! -x "$real_claude" ] && [ -x "$NPM_CONFIG_PREFIX/bin/claude" ]; then
       mv "$NPM_CONFIG_PREFIX/bin/claude" "$real_claude"
@@ -153,7 +163,7 @@ WRAP
       chmod +x "$NPM_CONFIG_PREFIX/bin/claude"
     fi
     export CLAUDE_CODE_EXECUTABLE="$NPM_CONFIG_PREFIX/bin/claude"
-    echo "Using installed Claude Code CLI"
+    echo "Using Claude Code $claude_code_version declared by the ACPX-owned Claude Agent SDK"
     claude --version
     claude auth status || true
     ;;

--- a/test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts
+++ b/test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts
@@ -7,7 +7,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import {
   disposeAllSessionMcpRuntimes,
-  getOrCreateSessionMcpRuntime,
+  acquireSessionMcpRuntime,
 } from "../../../../dist/agents/agent-bundle-mcp-manager-api.js";
 import { materializeBundleMcpToolsForRun } from "../../../../dist/agents/agent-bundle-mcp-materialize.js";
 import { resolveConversationCapabilityProfile } from "../../../../dist/agents/conversation-capability-profile.js";
@@ -112,14 +112,15 @@ async function main() {
     },
   };
 
+  let materialized: Awaited<ReturnType<typeof materializeBundleMcpToolsForRun>> | undefined;
   try {
-    const runtime = await getOrCreateSessionMcpRuntime({
+    const acquisition = await acquireSessionMcpRuntime({
       sessionId: `docker-agent-bundle-mcp-${randomUUID()}`,
       sessionKey: "agent:main:docker-agent-bundle-mcp",
       workspaceDir: probeDir,
       cfg,
     });
-    const materialized = await materializeBundleMcpToolsForRun({ runtime });
+    materialized = await materializeBundleMcpToolsForRun(acquisition);
     const probeTool = materialized.tools.find((tool) => tool.name === "dockerProbe__docker_probe");
     assert(probeTool, "expected dockerProbe__docker_probe to materialize");
     assert(
@@ -228,7 +229,11 @@ async function main() {
       ) + "\n",
     );
   } finally {
-    await disposeAllSessionMcpRuntimes();
+    try {
+      await materialized?.dispose();
+    } finally {
+      await disposeAllSessionMcpRuntimes();
+    }
   }
 }
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -7189,9 +7189,6 @@ describe("package artifact reuse", () => {
     expect(readFileSync("scripts/test-live-acp-bind-docker.sh", "utf8")).toContain(
       '"live ACP bind setup"',
     );
-    expect(readFileSync("scripts/test-live-acp-bind-docker.sh", "utf8")).toContain(
-      'run_setup_command npm install -g "@anthropic-ai/claude-code@$claude_code_version"',
-    );
     const acpBindScript = readFileSync("scripts/test-live-acp-bind-docker.sh", "utf8");
     expect(acpBindScript).toContain(
       "OPENCLAW_LIVE_ACP_BIND_CLAUDE_AUTH must be one of: auto, api-key, subscription.",

--- a/test/scripts/test-live-acp-bind-docker.test.ts
+++ b/test/scripts/test-live-acp-bind-docker.test.ts
@@ -6,65 +6,126 @@ import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
 const script = readFileSync("scripts/test-live-acp-bind-docker.sh", "utf8");
-const setup = script
-  .split("read -r -d '' LIVE_TEST_CMD <<'EOF' || true\n")[1]!
-  .split('tmp_dir="$(mktemp -d)"')[0]!;
+const setupStart = "read -r -d '' LIVE_TEST_CMD <<'EOF' || true\n";
+const setupEnd = 'tmp_dir="$(mktemp -d)"';
+const setupParts = script.split(setupStart);
+expect(setupParts).toHaveLength(2);
+const setupEndParts = setupParts[1]!.split(setupEnd);
+expect(setupEndParts).toHaveLength(2);
+const setup = setupEndParts[0]!;
 
 it.each([
-  { existing: "claude", mode: "subscription", key: "unset" },
-  { existing: "claude-real", mode: "api-key", key: "fixture-key" },
-  { existing: undefined, mode: "subscription", key: "unset" },
-])("prepares $mode Claude from $existing without the retired SDK", ({ existing, mode, key }) => {
-  const home = createTempDir("openclaw-acp-claude-setup-");
-  const bin = path.join(home, "bin");
-  const prefix = path.join(home, "npm");
-  const installedBin = path.join(prefix, "bin");
-  const calls = path.join(home, "calls");
-  const installs = path.join(home, "installs");
-  const fixture = path.join(home, "claude-fixture");
-  mkdirSync(bin);
-  mkdirSync(installedBin, { recursive: true });
-  const executable =
-    '#!/bin/sh\nprintf "%s:%s\\n" "$*" "${ANTHROPIC_API_KEY-unset}" >> "$TEST_CALLS"\nprintf "9.1.0 (Claude Code)\\n"\n';
-  writeFileSync(fixture, executable, { mode: 0o755 });
-  if (existing) {
-    writeFileSync(path.join(installedBin, existing), executable, { mode: 0o755 });
-  }
-  writeFileSync(
-    path.join(bin, "npm"),
-    '#!/bin/sh\nprintf "%s\\n" "$*" >> "$TEST_INSTALLS"\ncp "$TEST_CLAUDE_FIXTURE" "$NPM_CONFIG_PREFIX/bin/claude"\n',
-    { mode: 0o755 },
-  );
-  writeFileSync(
-    path.join(bin, "timeout"),
-    '#!/bin/sh\ncase "$1" in --kill-after=*) shift;; esac\nshift\nexec "$@"\n',
-    { mode: 0o755 },
-  );
-  const result = spawnSync("bash", ["-c", setup], {
-    cwd: home,
-    encoding: "utf8",
-    env: {
-      HOME: home,
-      PATH: `${bin}:${path.dirname(process.execPath)}:/usr/bin:/bin`,
-      NPM_CONFIG_PREFIX: prefix,
-      OPENCLAW_LIVE_DOCKER_SCRIPTS_DIR: path.resolve("scripts"),
-      OPENCLAW_DOCKER_AUTH_PRESTAGED: "1",
-      OPENCLAW_LIVE_ACP_BIND_AGENT: "claude",
-      OPENCLAW_LIVE_ACP_BIND_CLAUDE_AUTH: mode,
-      OPENCLAW_LIVE_ACP_BIND_SETUP_TIMEOUT_SECONDS: "180",
-      ANTHROPIC_API_KEY: "ambient-fixture-key",
-      OPENCLAW_LIVE_ACP_BIND_ANTHROPIC_API_KEY: "fixture-key",
-      TEST_CALLS: calls,
-      TEST_INSTALLS: installs,
-      TEST_CLAUDE_FIXTURE: fixture,
-    },
-  });
-  expect(result.status, result.stderr).toBe(0);
-  expect(result.stdout).toContain("9.1.0 (Claude Code)");
-  expect(readFileSync(calls, "utf8")).toBe(`--version:${key}\nauth status:${key}\n`);
-  expect(readFileSync(path.join(installedBin, "claude-real"), "utf8")).toBe(executable);
-  expect(existsSync(installs)).toBe(existing === undefined);
-  if (!existing) {
-    expect(readFileSync(installs, "utf8")).toBe("install -g @anthropic-ai/claude-code\n");
-  }
-});
+  {
+    existing: "claude",
+    installedVersion: "9.1.0",
+    mode: "subscription",
+    key: "unset",
+    installs: false,
+  },
+  {
+    existing: "claude-real",
+    installedVersion: "9.1.0",
+    mode: "api-key",
+    key: "fixture-key",
+    installs: false,
+  },
+  {
+    existing: undefined,
+    installedVersion: undefined,
+    mode: "subscription",
+    key: "unset",
+    installs: true,
+  },
+  {
+    existing: "claude-real",
+    installedVersion: "9.0.0",
+    mode: "api-key",
+    key: "fixture-key",
+    installs: true,
+  },
+])(
+  "prepares $mode Claude from $existing at installed version $installedVersion",
+  ({ existing, installedVersion, mode, key, installs: shouldInstall }) => {
+    const home = createTempDir("openclaw-acp-claude-setup-");
+    const bin = path.join(home, "bin");
+    const prefix = path.join(home, "npm");
+    const installedBin = path.join(prefix, "bin");
+    const calls = path.join(home, "calls");
+    const installs = path.join(home, "installs");
+    const fixture = path.join(home, "claude-fixture");
+    const acpxDir = path.join(home, "extensions", "acpx");
+    const adapterDir = path.join(
+      acpxDir,
+      "node_modules",
+      "@agentclientprotocol",
+      "claude-agent-acp",
+    );
+    const sdkDir = path.join(adapterDir, "node_modules", "@anthropic-ai", "claude-agent-sdk");
+    mkdirSync(bin);
+    mkdirSync(installedBin, { recursive: true });
+    mkdirSync(sdkDir, { recursive: true });
+    writeFileSync(path.join(acpxDir, "package.json"), '{"name":"@openclaw/acpx"}\n');
+    writeFileSync(
+      path.join(adapterDir, "package.json"),
+      '{"name":"@agentclientprotocol/claude-agent-acp"}\n',
+    );
+    writeFileSync(
+      path.join(sdkDir, "package.json"),
+      '{"name":"@anthropic-ai/claude-agent-sdk","exports":{".":"./sdk.mjs"},"claudeCodeVersion":"9.1.0"}\n',
+    );
+    writeFileSync(path.join(sdkDir, "sdk.mjs"), "export {};\n");
+    const executable =
+      '#!/bin/sh\nprintf "%s:%s\\n" "$*" "${ANTHROPIC_API_KEY-unset}" >> "$TEST_CALLS"\nprintf "9.1.0 (Claude Code)\\n"\n';
+    writeFileSync(fixture, executable, { mode: 0o755 });
+    if (existing) {
+      writeFileSync(path.join(installedBin, existing), executable, { mode: 0o755 });
+    }
+    if (installedVersion) {
+      const packageDir = path.join(prefix, "lib", "node_modules", "@anthropic-ai", "claude-code");
+      mkdirSync(packageDir, { recursive: true });
+      writeFileSync(
+        path.join(packageDir, "package.json"),
+        `${JSON.stringify({ version: installedVersion })}\n`,
+      );
+    }
+    writeFileSync(
+      path.join(bin, "npm"),
+      '#!/bin/sh\nprintf "%s\\n" "$*" >> "$TEST_INSTALLS"\ncp "$TEST_CLAUDE_FIXTURE" "$NPM_CONFIG_PREFIX/bin/claude"\n',
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      path.join(bin, "timeout"),
+      '#!/bin/sh\ncase "$1" in --kill-after=*) shift;; esac\nshift\nexec "$@"\n',
+      { mode: 0o755 },
+    );
+    const result = spawnSync("bash", ["-c", setup], {
+      cwd: home,
+      encoding: "utf8",
+      env: {
+        HOME: home,
+        PATH: `${bin}:${path.dirname(process.execPath)}:/usr/bin:/bin`,
+        NPM_CONFIG_PREFIX: prefix,
+        OPENCLAW_LIVE_DOCKER_SCRIPTS_DIR: path.resolve("scripts"),
+        OPENCLAW_DOCKER_AUTH_PRESTAGED: "1",
+        OPENCLAW_LIVE_ACP_BIND_AGENT: "claude",
+        OPENCLAW_LIVE_ACP_BIND_CLAUDE_AUTH: mode,
+        OPENCLAW_LIVE_ACP_BIND_SETUP_TIMEOUT_SECONDS: "180",
+        ANTHROPIC_API_KEY: "ambient-fixture-key",
+        OPENCLAW_LIVE_ACP_BIND_ANTHROPIC_API_KEY: "fixture-key",
+        TEST_CALLS: calls,
+        TEST_INSTALLS: installs,
+        TEST_CLAUDE_FIXTURE: fixture,
+      },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(
+      "Using Claude Code 9.1.0 declared by the ACPX-owned Claude Agent SDK",
+    );
+    expect(readFileSync(calls, "utf8")).toBe(`--version:${key}\nauth status:${key}\n`);
+    expect(readFileSync(path.join(installedBin, "claude-real"), "utf8")).toBe(executable);
+    expect(existsSync(installs)).toBe(shouldInstall);
+    if (shouldInstall) {
+      expect(readFileSync(installs, "utf8")).toBe("install -g @anthropic-ai/claude-code@9.1.0\n");
+    }
+  },
+);

--- a/test/scripts/test-live-acp-bind-docker.test.ts
+++ b/test/scripts/test-live-acp-bind-docker.test.ts
@@ -1,0 +1,70 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+const script = readFileSync("scripts/test-live-acp-bind-docker.sh", "utf8");
+const setup = script
+  .split("read -r -d '' LIVE_TEST_CMD <<'EOF' || true\n")[1]!
+  .split('tmp_dir="$(mktemp -d)"')[0]!;
+
+it.each([
+  { existing: "claude", mode: "subscription", key: "unset" },
+  { existing: "claude-real", mode: "api-key", key: "fixture-key" },
+  { existing: undefined, mode: "subscription", key: "unset" },
+])("prepares $mode Claude from $existing without the retired SDK", ({ existing, mode, key }) => {
+  const home = createTempDir("openclaw-acp-claude-setup-");
+  const bin = path.join(home, "bin");
+  const prefix = path.join(home, "npm");
+  const installedBin = path.join(prefix, "bin");
+  const calls = path.join(home, "calls");
+  const installs = path.join(home, "installs");
+  const fixture = path.join(home, "claude-fixture");
+  mkdirSync(bin);
+  mkdirSync(installedBin, { recursive: true });
+  const executable =
+    '#!/bin/sh\nprintf "%s:%s\\n" "$*" "${ANTHROPIC_API_KEY-unset}" >> "$TEST_CALLS"\nprintf "9.1.0 (Claude Code)\\n"\n';
+  writeFileSync(fixture, executable, { mode: 0o755 });
+  if (existing) {
+    writeFileSync(path.join(installedBin, existing), executable, { mode: 0o755 });
+  }
+  writeFileSync(
+    path.join(bin, "npm"),
+    '#!/bin/sh\nprintf "%s\\n" "$*" >> "$TEST_INSTALLS"\ncp "$TEST_CLAUDE_FIXTURE" "$NPM_CONFIG_PREFIX/bin/claude"\n',
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    path.join(bin, "timeout"),
+    '#!/bin/sh\ncase "$1" in --kill-after=*) shift;; esac\nshift\nexec "$@"\n',
+    { mode: 0o755 },
+  );
+  const result = spawnSync("bash", ["-c", setup], {
+    cwd: home,
+    encoding: "utf8",
+    env: {
+      HOME: home,
+      PATH: `${bin}:${path.dirname(process.execPath)}:/usr/bin:/bin`,
+      NPM_CONFIG_PREFIX: prefix,
+      OPENCLAW_LIVE_DOCKER_SCRIPTS_DIR: path.resolve("scripts"),
+      OPENCLAW_DOCKER_AUTH_PRESTAGED: "1",
+      OPENCLAW_LIVE_ACP_BIND_AGENT: "claude",
+      OPENCLAW_LIVE_ACP_BIND_CLAUDE_AUTH: mode,
+      OPENCLAW_LIVE_ACP_BIND_SETUP_TIMEOUT_SECONDS: "180",
+      ANTHROPIC_API_KEY: "ambient-fixture-key",
+      OPENCLAW_LIVE_ACP_BIND_ANTHROPIC_API_KEY: "fixture-key",
+      TEST_CALLS: calls,
+      TEST_INSTALLS: installs,
+      TEST_CLAUDE_FIXTURE: fixture,
+    },
+  });
+  expect(result.status, result.stderr).toBe(0);
+  expect(result.stdout).toContain("9.1.0 (Claude Code)");
+  expect(readFileSync(calls, "utf8")).toBe(`--version:${key}\nauth status:${key}\n`);
+  expect(readFileSync(path.join(installedBin, "claude-real"), "utf8")).toBe(executable);
+  expect(existsSync(installs)).toBe(existing === undefined);
+  if (!existing) {
+    expect(readFileSync(installs, "utf8")).toBe("install -g @anthropic-ai/claude-code\n");
+  }
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves two pre-test failures in Full Release Validation:

- The Claude ACP Docker bootstrap resolved `@anthropic-ai/claude-agent-sdk` from the repository root. The SDK is owned by the bundled ACPX adapter and pnpm does not guarantee a root or hoisted copy, so the scenario failed before starting Claude.
- The packaged MCP tool smoke imported the retired `getOrCreateSessionMcpRuntime` API instead of participating in the current lease lifecycle.

Observed in [Full Release Validation 33966876950](https://github.com/openclaw/openclaw/actions/runs/33966876950), jobs 101309834193 and 101310400630.

## Why This Change Was Made

Claude setup now resolves the installed `@agentclientprotocol/claude-agent-acp` package through `extensions/acpx`, then resolves that adapter's own Agent SDK and installs the exact `claudeCodeVersion` it declares. Existing matching installs are retained; missing or stale installs are replaced. Subscription and API-key isolation remain unchanged.

The MCP smoke now acquires the canonical session runtime lease, transfers it to tool materialization, disposes the materialized runtime first, and retains global teardown as the final safety boundary.

The focused Bash test executes the actual setup fragment across matching, missing, and stale Claude installs. The duplicate package source-string assertion was removed because it coupled release acceptance to implementation text while the executable regression now proves the contract.

## User Impact

Release validation reaches the intended ACP and MCP behavior checks again. Product runtime, authentication policy, provider configuration, timeouts, and runtime dependencies are unchanged.

- Product runtime: `0`
- Release tooling: `+3/-2` (`+1` net)
- Tests and scenario support: `+140/-7` (`+133` net)

## Evidence

- Pre-fix reproduction: all four new Claude bootstrap cases fail with `Cannot find module '@anthropic-ai/claude-agent-sdk'` because the old setup resolves from the wrong dependency owner.
- Exact-head focused proof: 33 ACP and MCP owner tests pass across three Vitest shards; the relevant package-acceptance contract passes 1/1 with 399 unrelated tests skipped.
- Broader local Docker tooling proof: 274 tests pass, 2 skipped.
- The four-file changed gate passes conflict, attribution, registry, boundary, dependency, format, patch, temp-report, and core-graph checks. Local test typechecking then stops before branch code because the required worktree `node_modules` symlink escapes the checkout; hosted exact-head CI owns that proof.
- Crabbox/Testbox run [33971178058](https://github.com/openclaw/openclaw/actions/runs/33971178058) completed with wrapper exit 0 after verifying source `970df347840199f8cbc70aa9761e936343e1a8ce`, package build/tarball integrity, and real in-container MCP tool/App output. The backing action may appear cancelled because delegated cleanup stops the one-shot runner; the Crabbox wrapper receipt is the run result.
- The earlier exact-head CI install failure in run [33970770540](https://github.com/openclaw/openclaw/actions/runs/33970770540), job 101318831232, was upstream infrastructure fallout: `@matrix-org/matrix-sdk-crypto-nodejs@0.6.6` hit `ECONNRESET`, then its installer threw `ReferenceError: err is not defined`. No unchanged full rerun was requested.
- Independent autoreview: scoped-clean through P2 with 0.96 confidence.

## Dependency and Runtime Contracts

- `@agentclientprotocol/claude-agent-acp@0.70.0` owns `@anthropic-ai/claude-agent-sdk@0.3.232`, whose `claudeCodeVersion` is `2.1.232`.
- The adapter honors `CLAUDE_CODE_EXECUTABLE` and passes it as `pathToClaudeCodeExecutable`; the harness continues to provide that explicit wrapper.

## ClawSweeper Follow-Through

The previous review found no patch defect but requested upstream Claude executable-contract verification or explicit acceptance of scoped proof. That move is complete through direct installed adapter/SDK inspection, the executable bootstrap regression, and the Crabbox/Testbox Docker run. A fresh review was requested because the branch behavior changed after the previous reviewed head.

## Final maintainer validation

Independent verification of head `a16fda56b279af33048a99687d4b703cba16a697` passed all 24 bootstrap/CLI/staging tests, including four ACP cases, and the complete four-file changed gate with a private frozen dependency install. Fresh independent review is scoped-clean through P2. [Exact-head CI 33971520759](https://github.com/openclaw/openclaw/actions/runs/33971520759) completed successfully: 77 successful jobs and 17 skipped.

The earlier transport-failed run received one failed-job retry; that retry was superseded by this reviewed head before dependency setup. No full unchanged CI rerun or source workaround was used. The scoped harness validation is accepted for landing; full authenticated Docker/provider qualification remains part of release validation. Thanks @vincentkoc for preserving the adapter-owned CLI pin and extending the executable coverage.
