### PR TITLE
fix(memory): rank indexed sessions by source activity

### DIFF
--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -149,6 +149,11 @@ original weight. `MEMORY.md`, `USER.md`, and undated files under `memory/`
 remain evergreen. Dated `YYYY-MM-DD.md` and `YYYY-MM-DD-<slug>.md` files decay
 at any depth, including session-memory notes and nested dreaming reports.
 
+Session transcript hits use the source activity timestamp captured during
+indexing. Retained transcript archives use their indexed file modification
+time. Individual message timestamps remain provenance metadata and do not
+determine the source's recency weight.
+
 ### MMR (diversity)
 
 Reduces redundant results. If five notes all mention the same router config,

--- a/extensions/memory-core/src/memory/hybrid.test.ts
+++ b/extensions/memory-core/src/memory/hybrid.test.ts
@@ -816,71 +816,53 @@ describe("memory hybrid helpers", () => {
     expect(merged[0]?.textScore).toBeCloseTo(1);
   });
 
-  it("preserves LIKE-fallback lexical ordering in hybrid selection (keyword-only)", async () => {
-    // Two LIKE-fallback body hits: both textScore = 0 (no BM25), no vector
-    // match, exactPathSpecificity = 0. Their weighted contentScore collapses to
-    // 0 for both, so they would tie by path without the lexical tie-break.
-    // The manager carries a boost-derived lexical score as `rankingScore`; the
-    // hybrid consumer must use it as an unweighted tie-break so the
-    // lexically-stronger hit ranks first regardless of path alphabetical order.
-    // See ClawSweeper P2 finding on #120603 / #115001.
-    //
-    // path alphabetical order (memory/aaa.md < memory/zzz.md) is intentionally
-    // the REVERSE of lexical strength, so a path-ordered tie would put aaa
-    // first while the lexical tie-break must put zzz first.
-    const keyword = [
-      {
-        id: "aaa",
-        path: "memory/aaa.md",
+  it.each([null, 0.5, -0.5])(
+    "preserves LIKE lexical ties and public confidence with vector score %s",
+    async (vectorScore) => {
+      const keyword = [
+        { id: "aaa", rankingScore: 0.2 },
+        { id: "zzz", rankingScore: 0.8 },
+      ].map(({ id, rankingScore }) => ({
+        id,
+        path: `memory/${id}.md`,
         startLine: 1,
         endLine: 1,
         source: "memory",
-        snippet: "weak substring overlap",
+        snippet: `${id} substring overlap`,
         textScore: 0,
         hasBodyMatch: true,
-        rankingScore: 0.2,
+        rankingScore,
         pathScore: 0,
         exactPathSpecificity: 0 as const,
-      },
-      {
-        id: "zzz",
-        path: "memory/zzz.md",
-        startLine: 1,
-        endLine: 1,
-        source: "memory",
-        snippet: "strong substring overlap with the query terms",
-        textScore: 0,
-        hasBodyMatch: true,
-        rankingScore: 0.8,
-        pathScore: 0,
-        exactPathSpecificity: 0 as const,
-      },
-    ];
-    const merged = await mergeHybridResults({
-      vectorWeight: 0.7,
-      textWeight: 0.3,
-      vector: [],
-      keyword,
-    });
+      }));
+      const merged = await mergeHybridResults({
+        vectorWeight: 0.7,
+        textWeight: 0.3,
+        vector: vectorScore === null ? [] : keyword.map((entry) => ({ ...entry, vectorScore })),
+        keyword,
+      });
 
-    // Both hits tie at contentScore = 0 (no vector, LIKE carries no weighted
-    // text signal), proving the ordering below comes from the lexical tie-break
-    // and not from a restored weighted text score.
-    expect(merged.map((entry) => entry.score)).toEqual([0, 0]);
-    // The internal lexicalRank signal must not leak into the public result.
-    expect(merged.every((entry) => !("lexicalRank" in entry))).toBe(true);
-
-    const selected = selectHybridSearchResults({
-      merged,
-      keyword,
-      maxResults: 2,
-      minScore: 0,
-    });
-
-    // Lexical tie-break: zzz (rankingScore 0.8) before aaa (rankingScore 0.2),
-    // NOT path alphabetical (aaa before zzz).
-    expect(selected.map((entry) => entry.path)).toEqual(["memory/zzz.md", "memory/aaa.md"]);
-  });
+      // LIKE strength breaks tied confidence without turning recall into a scored match.
+      expect(merged.map((entry) => entry.path)).toEqual(["memory/zzz.md", "memory/aaa.md"]);
+      expect(merged).toEqual([
+        expect.objectContaining({
+          score: (vectorScore ?? 0) * 0.7,
+          vectorScore: vectorScore ?? 0,
+          textScore: 0,
+        }),
+        expect.objectContaining({
+          score: (vectorScore ?? 0) * 0.7,
+          vectorScore: vectorScore ?? 0,
+          textScore: 0,
+        }),
+      ]);
+      expect(merged.every((entry) => !("lexicalRank" in entry) && !("rankingScore" in entry))).toBe(
+        true,
+      );
+      const selected = selectHybridSearchResults({ merged, keyword, maxResults: 2, minScore: 0 });
+      expect(selected).toEqual(vectorScore !== null && vectorScore < 0 ? [] : merged);
+    },
+  );
 
   const vectorResult = (id: string, path: string, vectorScore: number) => ({
     id,

--- a/extensions/memory-core/src/memory/hybrid.ts
+++ b/extensions/memory-core/src/memory/hybrid.ts
@@ -92,6 +92,7 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
   textWeight: number;
   isNonTextMediaPath?: (path: string) => boolean;
   workspaceDir?: string;
+  sessionSourceMtimes?: ReadonlyMap<string, number | undefined>;
   /** MMR configuration for diversity-aware re-ranking */
   mmr?: Partial<MMRConfig>;
   /** Temporal decay configuration for recency-aware scoring */
@@ -254,6 +255,7 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
     results: merged,
     temporalDecay: temporalDecayConfig,
     workspaceDir: params.workspaceDir,
+    sessionSourceMtimes: params.sessionSourceMtimes,
     nowMs: params.nowMs,
   });
   const rankable = applyProjectRanking(

--- a/extensions/memory-core/src/memory/hybrid.ts
+++ b/extensions/memory-core/src/memory/hybrid.ts
@@ -1,5 +1,4 @@
 import type { MemoryEntryProvenance } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
-// Memory Core plugin module implements hybrid behavior.
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { applyImportanceMultiplier } from "./importance.js";
 import { applyMMRToHybridResults, type MMRConfig, DEFAULT_MMR_CONFIG } from "./mmr.js";
@@ -212,41 +211,41 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
     const contentScore = dropMediaTextSignal
       ? entry.vectorScore
       : params.vectorWeight * entry.vectorScore + params.textWeight * keywordScore;
-    const hasWeightedContentRelevance = contentScore > 0;
-    // LIKE recall has no weighted BM25 score. Its lexical score only breaks
-    // ties between otherwise equal results.
+    // LIKE recall has no BM25 confidence. Weight its private ranking signal
+    // through the same passes, then restore public confidence before selection.
     const lexicalRank = entry.hasBodyMatch && entry.textScore === 0 ? entry.rankingScore : 0;
     // With decay enabled, reserve the lower half of an exact tier for path
     // identity and the upper half for content relevance. This lets recency beat
     // a stale cap-selected content hit. Otherwise retain the established score.
-    const weightedScore =
+    const rankingScore =
       entry.exactPathSpecificity > 0
         ? temporalDecayConfig.enabled
           ? scoreExactPathTieForTemporalDecay(contentScore)
-          : hasWeightedContentRelevance
+          : contentScore > 0
             ? contentScore
             : 1
-        : contentScore;
-    const result = {
-      path: entry.path,
-      startLine: entry.startLine,
-      endLine: entry.endLine,
-      score: weightedScore,
-      vectorScore: entry.vectorScore,
-      textScore: entry.textScore,
-      exactPathSpecificity: entry.exactPathSpecificity,
-      hasWeightedContentRelevance,
-      lexicalRank,
-      snippet: entry.snippet,
-      source: entry.source,
-      importance: entry.importance,
-      triggers: entry.triggers,
-      projectKey: entry.projectKey,
-    };
-    if (entry.provenance) {
-      Object.assign(result, { provenance: entry.provenance });
-    }
-    return result;
+        : contentScore === 0
+          ? lexicalRank
+          : contentScore;
+    return Object.assign(
+      {
+        path: entry.path,
+        startLine: entry.startLine,
+        endLine: entry.endLine,
+        score: rankingScore,
+        vectorScore: entry.vectorScore,
+        textScore: entry.textScore,
+        exactPathSpecificity: entry.exactPathSpecificity,
+        contentScore,
+        lexicalRank,
+        snippet: entry.snippet,
+        source: entry.source,
+        importance: entry.importance,
+        triggers: entry.triggers,
+        projectKey: entry.projectKey,
+      },
+      entry.provenance ? { provenance: entry.provenance } : {},
+    );
   });
 
   // Keep component scores as raw retrieval diagnostics. Temporal decay and MMR
@@ -262,27 +261,28 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
     applyImportanceMultiplier(decayed),
     params.activeProjectKeys,
   ).map((entry) => {
-    // Specificity owns cross-tier precedence. Keep the decayed weighted score
-    // separately for within-tier ranking while exact public scores stay at 1.
-    const exactPathTieScore = entry.score;
+    // Exact tiers and recall-only LIKE hits keep their public confidence;
+    // their private ranking score still includes every weighting pass.
+    const rankingScore = entry.score;
     return Object.assign(entry, {
-      exactPathTieScore,
+      rankingScore,
       score:
         entry.exactPathSpecificity > 0
           ? projectScoreMultiplier(entry.projectKey, params.activeProjectKeys)
-          : entry.score,
+          : entry.contentScore === 0
+            ? 0
+            : entry.score,
     });
   });
+  const compareRankingScores = (a: (typeof rankable)[number], b: (typeof rankable)[number]) =>
+    b.rankingScore - a.rankingScore ||
+    b.lexicalRank - a.lexicalRank ||
+    a.path.localeCompare(b.path) ||
+    a.startLine - b.startLine ||
+    a.endLine - b.endLine;
   const nonExact = rankable
     .filter((entry) => entry.exactPathSpecificity === 0)
-    .toSorted(
-      (a, b) =>
-        b.score - a.score ||
-        b.lexicalRank - a.lexicalRank ||
-        a.path.localeCompare(b.path) ||
-        a.startLine - b.startLine ||
-        a.endLine - b.endLine,
-    );
+    .toSorted((a, b) => b.score - a.score || compareRankingScores(a, b));
 
   // Apply MMR re-ranking if enabled
   const mmrConfig = { ...DEFAULT_MMR_CONFIG, ...params.mmr };
@@ -291,7 +291,7 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
       return entries;
     }
     return applyMMRToHybridResults(
-      entries.map((entry) => Object.assign(entry, { score: entry.exactPathTieScore })),
+      entries.map((entry) => Object.assign(entry, { score: entry.rankingScore })),
       mmrConfig,
     ).map((entry) =>
       Object.assign(entry, {
@@ -299,25 +299,15 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
       }),
     );
   };
-  const compareExactTieScores = (a: (typeof rankable)[number], b: (typeof rankable)[number]) =>
-    b.exactPathTieScore - a.exactPathTieScore ||
-    b.lexicalRank - a.lexicalRank ||
-    a.path.localeCompare(b.path) ||
-    a.startLine - b.startLine ||
-    a.endLine - b.endLine;
   const exact = ([3, 2, 1] as const).flatMap((specificity) => {
     const tier = rankable
       .filter((entry) => entry.exactPathSpecificity === specificity)
-      .toSorted(compareExactTieScores);
+      .toSorted(compareRankingScores);
     if (temporalDecayConfig.enabled) {
       return rerankExactGroup(tier);
     }
-    const contentBacked = tier.filter(
-      (entry) => entry.hasWeightedContentRelevance || entry.lexicalRank > 0,
-    );
-    const pathOnly = tier.filter(
-      (entry) => !entry.hasWeightedContentRelevance && entry.lexicalRank === 0,
-    );
+    const contentBacked = tier.filter((entry) => entry.contentScore > 0 || entry.lexicalRank > 0);
+    const pathOnly = tier.filter((entry) => !(entry.contentScore > 0) && entry.lexicalRank === 0);
     return rerankExactGroup(contentBacked).concat(rerankExactGroup(pathOnly));
   });
   const ranked = [
@@ -328,8 +318,8 @@ export async function mergeHybridResults<TSource extends HybridSource>(params: {
   return ranked.map(
     ({
       exactPathSpecificity: _exactPathSpecificity,
-      exactPathTieScore: _exactPathTieScore,
-      hasWeightedContentRelevance: _hasWeightedContentRelevance,
+      rankingScore: _rankingScore,
+      contentScore: _contentScore,
       lexicalRank: _lexicalRank,
       ...entry
     }) => entry,

--- a/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
+++ b/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
@@ -20,6 +20,7 @@ import {
   searchPathKeyword,
   type ExactPathSpecificity,
 } from "./manager-search.js";
+import { loadMemorySourceFileState } from "./manager-source-state.js";
 import { applyProjectRanking } from "./project-ranking.js";
 import { applyTemporalDecayToHybridResults } from "./temporal-decay.js";
 
@@ -200,6 +201,7 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
       results: decayInputs,
       temporalDecay: params.temporalDecay,
       workspaceDir: this.workspaceDir,
+      sessionSourceMtimes: this.loadSessionSourceMtimes(params.results),
     });
     const ranked = applyProjectRanking(
       this.rankKeywordOnlyResults(applyImportanceMultiplier(decayed), !appliesTemporalDecay),
@@ -207,6 +209,21 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
     );
     return this.toMemorySearchResults(
       this.selectScoredResults(ranked, params.maxResults, params.minScore, 0),
+    );
+  }
+
+  protected loadSessionSourceMtimes(
+    results: ReadonlyArray<Pick<MemorySearchResult, "path" | "source">>,
+  ): ReadonlyMap<string, number | undefined> | undefined {
+    const paths = results.filter((entry) => entry.source === "sessions").map((entry) => entry.path);
+    if (paths.length === 0) {
+      return undefined;
+    }
+    return new Map(
+      loadMemorySourceFileState({ db: this.db, source: "sessions", paths }).map((row) => [
+        row.path,
+        row.mtime,
+      ]),
     );
   }
 

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -1,4 +1,3 @@
-// Memory Core plugin module owns public search orchestration.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { classifyMemoryMultimodalPath } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
@@ -279,11 +278,11 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
         Math.max(1, Math.floor(maxResults * hybrid.candidateMultiplier)),
       );
 
-      // FTS-only mode: no embedding provider available
-      if (embeddingBootstrapKeywordOnly || !this.provider) {
+      // Reply-path lexical recall skips query embedding and the semantic provider lease.
+      if (embeddingBootstrapKeywordOnly || !this.provider || opts?.lexicalOnly) {
         this.assertRequiredProviderAvailable("search");
         if (!this.fts.enabled || !this.fts.available) {
-          log.warn("memory search: no provider and FTS unavailable");
+          log.warn("memory search: keyword-only search has no available FTS index");
           return [];
         }
 
@@ -336,17 +335,6 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
       const releaseSemanticProvider = this.acquireProviderUse(semanticProvider);
       try {
         keywordResults = await loadKeywordResults();
-        // lexicalOnly is a reply-path contract: no query embedding, no vector
-        // search, no network. Callers accept keyword-only recall quality.
-        if (opts?.lexicalOnly) {
-          return await this.finalizeKeywordOnlyResults({
-            results: keywordResults,
-            temporalDecay: hybrid.temporalDecay,
-            maxResults,
-            minScore,
-            activeProjectKeys: opts?.activeProjectKeys,
-          });
-        }
         try {
           queryVec = await this.embedQueryWithRetry(
             cleaned,
@@ -449,9 +437,12 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
           results: vectorResults,
           temporalDecay: hybrid.temporalDecay,
           workspaceDir: this.workspaceDir,
+          sessionSourceMtimes: this.loadSessionSourceMtimes(vectorResults),
         });
+        // Decay and importance can reverse the order returned by vector retrieval.
         return applyProjectRanking(applyImportanceMultiplier(decayed), opts?.activeProjectKeys)
           .filter((entry) => entry.score >= minScore)
+          .toSorted((left, right) => right.score - left.score)
           .slice(0, maxResults);
       }
 
@@ -571,6 +562,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
       temporalDecay: params.temporalDecay,
       activeProjectKeys: params.activeProjectKeys,
       workspaceDir: this.workspaceDir,
+      sessionSourceMtimes: this.loadSessionSourceMtimes([...params.vector, ...params.keyword]),
     });
   }
 }

--- a/extensions/memory-core/src/memory/manager-temporal-ranking.test.ts
+++ b/extensions/memory-core/src/memory/manager-temporal-ranking.test.ts
@@ -24,6 +24,7 @@ describe("memory source temporal ranking", () => {
       lexicalOnly: false,
       archived: false,
       ftsUnavailable: false,
+      zeroScoreLike: false,
     },
     {
       name: "lexical recall",
@@ -31,6 +32,7 @@ describe("memory source temporal ranking", () => {
       lexicalOnly: true,
       archived: false,
       ftsUnavailable: false,
+      zeroScoreLike: false,
     },
     {
       name: "hybrid",
@@ -38,6 +40,7 @@ describe("memory source temporal ranking", () => {
       lexicalOnly: false,
       archived: false,
       ftsUnavailable: false,
+      zeroScoreLike: false,
     },
     {
       name: "retained archives",
@@ -45,6 +48,7 @@ describe("memory source temporal ranking", () => {
       lexicalOnly: false,
       archived: true,
       ftsUnavailable: false,
+      zeroScoreLike: false,
     },
     {
       name: "FTS unavailable",
@@ -52,10 +56,19 @@ describe("memory source temporal ranking", () => {
       lexicalOnly: false,
       archived: false,
       ftsUnavailable: true,
+      zeroScoreLike: false,
+    },
+    {
+      name: "LIKE-only hybrid",
+      provider: "openai",
+      lexicalOnly: false,
+      archived: false,
+      ftsUnavailable: false,
+      zeroScoreLike: true,
     },
   ])(
     "decays SQLite session hits by recorded source activity through $name",
-    async ({ provider, lexicalOnly, archived, ftsUnavailable }) => {
+    async ({ provider, lexicalOnly, archived, ftsUnavailable, zeroScoreLike }) => {
       fixture.provider.forceNoProvider = provider === "none";
       const cfg = fixture.createConfig({
         provider,
@@ -63,6 +76,7 @@ describe("memory source temporal ranking", () => {
         sessionMemory: true,
         minScore: 0,
         vectorEnabled: false,
+        ftsTokenizer: zeroScoreLike ? "trigram" : "unicode61",
       });
       const now = Date.now();
       const oldSession = {
@@ -81,7 +95,9 @@ describe("memory source temporal ranking", () => {
           messages: [
             {
               role: "user",
-              content: "Alpha cobalt orchid tidepool preference.",
+              content: zeroScoreLike
+                ? "记忆 彩色 潮池 偏好。"
+                : "Alpha cobalt orchid tidepool preference.",
               timestamp: now - 60 * DAY_MS,
             },
           ],
@@ -145,7 +161,7 @@ describe("memory source temporal ranking", () => {
         minScore: 0,
         lexicalOnly,
       };
-      const query = "alpha cobalt orchid tidepool preference";
+      const query = zeroScoreLike ? "记忆" : "alpha cobalt orchid tidepool preference";
       const search = () => manager.search(query, { ...searchOptions, sources: ["sessions"] });
       const expectSourceRecency = (results: MemorySearchResult[]) => {
         const old = results.find((entry) => entry.path === `sessions/main/${oldSession.fileName}`);
@@ -157,7 +173,14 @@ describe("memory source temporal ranking", () => {
         if (!old || !fresh) {
           throw new Error("Expected both indexed session sources");
         }
-        expect(old.score / fresh.score).toBeCloseTo(Math.SQRT1_2, 5);
+        if (zeroScoreLike) {
+          expect(results).toEqual([
+            expect.objectContaining({ score: 0, vectorScore: 0, textScore: 0 }),
+            expect.objectContaining({ score: 0, vectorScore: 0, textScore: 0 }),
+          ]);
+        } else {
+          expect(old.score / fresh.score).toBeCloseTo(Math.SQRT1_2, 5);
+        }
         expect(results[0]?.path).toBe(fresh.path);
         expect(results.every((entry) => entry.provenance?.observedAt === now - 60 * DAY_MS)).toBe(
           true,

--- a/extensions/memory-core/src/memory/manager-temporal-ranking.test.ts
+++ b/extensions/memory-core/src/memory/manager-temporal-ranking.test.ts
@@ -1,0 +1,198 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { deleteSessionEntry, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { openOpenClawAgentDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
+import { describe, expect, it } from "vitest";
+import { createMemorySearchTool } from "../tools.js";
+import { createManagerIndexFixture } from "./manager-index.test-support.js";
+
+const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+describe("memory source temporal ranking", () => {
+  const fixture = createManagerIndexFixture({
+    getMemorySearchManager,
+    closeAllMemorySearchManagers,
+  });
+
+  it.each([
+    {
+      name: "keyword-only",
+      provider: "none",
+      lexicalOnly: false,
+      archived: false,
+      ftsUnavailable: false,
+    },
+    {
+      name: "lexical recall",
+      provider: "openai",
+      lexicalOnly: true,
+      archived: false,
+      ftsUnavailable: false,
+    },
+    {
+      name: "hybrid",
+      provider: "openai",
+      lexicalOnly: false,
+      archived: false,
+      ftsUnavailable: false,
+    },
+    {
+      name: "retained archives",
+      provider: "none",
+      lexicalOnly: false,
+      archived: true,
+      ftsUnavailable: false,
+    },
+    {
+      name: "FTS unavailable",
+      provider: "openai",
+      lexicalOnly: false,
+      archived: false,
+      ftsUnavailable: true,
+    },
+  ])(
+    "decays SQLite session hits by recorded source activity through $name",
+    async ({ provider, lexicalOnly, archived, ftsUnavailable }) => {
+      fixture.provider.forceNoProvider = provider === "none";
+      const cfg = fixture.createConfig({
+        provider,
+        sources: ["sessions"],
+        sessionMemory: true,
+        minScore: 0,
+        vectorEnabled: false,
+      });
+      const now = Date.now();
+      const oldSession = {
+        sessionId: "a-old",
+        updatedAt: now - 15 * DAY_MS,
+        fileName: "a-old.jsonl",
+      };
+      const freshSession = { sessionId: "z-fresh", updatedAt: now, fileName: "z-fresh.jsonl" };
+      const sessions = [oldSession, freshSession];
+      const storePath = path.join(resolveSessionTranscriptsDirForAgent("main"), "sessions.json");
+      for (const session of sessions) {
+        const sessionKey = `agent:main:memory:${session.sessionId}`;
+        await fixture.seedSessionTranscript({
+          sessionId: session.sessionId,
+          sessionKey,
+          messages: [
+            {
+              role: "user",
+              content: "Alpha cobalt orchid tidepool preference.",
+              timestamp: now - 60 * DAY_MS,
+            },
+          ],
+        });
+        await upsertSessionEntry({
+          agentId: "main",
+          sessionKey,
+          storePath,
+          entry: { sessionId: session.sessionId, updatedAt: session.updatedAt },
+        });
+        if (archived) {
+          await deleteSessionEntry({
+            agentId: "main",
+            sessionKey,
+            storePath,
+            archiveTranscript: true,
+          });
+          const files = await fs.readdir(path.dirname(storePath));
+          const archiveName = files.find((name) =>
+            name.startsWith(`${session.sessionId}.jsonl.deleted.`),
+          );
+          if (!archiveName) {
+            throw new Error("Expected retained session archive");
+          }
+          const archivePath = path.join(path.dirname(storePath), archiveName);
+          const activity = new Date(session.updatedAt);
+          await fs.utimes(archivePath, activity, activity);
+          session.fileName = archiveName;
+          session.updatedAt = (await fs.stat(archivePath)).mtimeMs;
+        }
+      }
+      let manager = await fixture.getFreshManager(cfg);
+      await manager.sync({ reason: "test", force: true });
+      const sourceRows = openOpenClawAgentDatabase({ agentId: "main" })
+        .db.prepare(
+          "SELECT path, mtime FROM memory_index_sources WHERE source = 'sessions' ORDER BY path",
+        )
+        .all();
+      expect(sourceRows).toEqual(
+        sessions.map((session) => ({
+          path: `sessions/main/${session.fileName}`,
+          mtime: session.updatedAt,
+        })),
+      );
+      await expect(fs.stat(path.join(fixture.paths.workspace, "sessions"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      if (ftsUnavailable) {
+        await manager.close();
+        openOpenClawAgentDatabase({ agentId: "main" }).db.exec(`
+          DROP TABLE memory_index_chunks_fts;
+          CREATE VIEW memory_index_chunks_fts AS
+            SELECT text, id, path, source, model, start_line, end_line FROM memory_index_chunks;
+        `);
+        manager = await fixture.getFreshManager(cfg, "cli");
+        expect(manager.status().fts).toMatchObject({ enabled: true, available: false });
+      }
+
+      const searchOptions = {
+        maxResults: 2,
+        minScore: 0,
+        lexicalOnly,
+      };
+      const query = "alpha cobalt orchid tidepool preference";
+      const search = () => manager.search(query, { ...searchOptions, sources: ["sessions"] });
+      const expectSourceRecency = (results: MemorySearchResult[]) => {
+        const old = results.find((entry) => entry.path === `sessions/main/${oldSession.fileName}`);
+        const fresh = results.find(
+          (entry) => entry.path === `sessions/main/${freshSession.fileName}`,
+        );
+        expect(old).toBeDefined();
+        expect(fresh).toBeDefined();
+        if (!old || !fresh) {
+          throw new Error("Expected both indexed session sources");
+        }
+        expect(old.score / fresh.score).toBeCloseTo(Math.SQRT1_2, 5);
+        expect(results[0]?.path).toBe(fresh.path);
+        expect(results.every((entry) => entry.provenance?.observedAt === now - 60 * DAY_MS)).toBe(
+          true,
+        );
+      };
+      expectSourceRecency(await search());
+      expect(fixture.provider.embedQueryCalls).toBe(provider === "none" || lexicalOnly ? 0 : 1);
+      expect(
+        (await manager.search(query, { ...searchOptions, maxResults: 1, sources: ["sessions"] }))[0]
+          ?.path,
+      ).toBe(`sessions/main/${freshSession.fileName}`);
+
+      if (!lexicalOnly && !archived) {
+        const tool = createMemorySearchTool({
+          config: cfg,
+          agentId: "main",
+          agentSessionKey: "agent:main:memory:z-fresh",
+        });
+        if (!tool) {
+          throw new Error("Expected memory_search tool");
+        }
+        const result = await tool.execute("source-recency", {
+          query,
+          corpus: "sessions",
+          maxResults: 2,
+          minScore: 0,
+        });
+        expectSourceRecency((result.details as { results: MemorySearchResult[] }).results);
+      }
+
+      // A decoy is deliberately outside the canonical source; it must not become its timestamp owner.
+      const decoyPath = path.join(fixture.paths.workspace, "sessions", "main", oldSession.fileName);
+      await fs.mkdir(path.dirname(decoyPath), { recursive: true });
+      await fs.writeFile(decoyPath, "not the indexed transcript");
+      expectSourceRecency(await search());
+    },
+  );
+});

--- a/extensions/memory-core/src/memory/temporal-decay.test.ts
+++ b/extensions/memory-core/src/memory/temporal-decay.test.ts
@@ -203,21 +203,33 @@ describe("temporal decay", () => {
     expect(byPath.get("memory/2000-01-01.md")?.score ?? 1).toBeLessThan(0.001);
   });
 
-  it("uses file mtime fallback for non-memory sources", async () => {
+  it("uses file mtime for additional memory files", async () => {
     const dir = await createTempWorkspace("openclaw-temporal-decay-");
-    const sessionPath = path.join(dir, "sessions", "thread.jsonl");
-    await fs.mkdir(path.dirname(sessionPath), { recursive: true });
-    await fs.writeFile(sessionPath, "{}\n");
+    const filePath = path.join(dir, "notes", "topic.md");
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "notes\n");
     const oldMtime = new Date(NOW_MS - 30 * DAY_MS);
-    await fs.utimes(sessionPath, oldMtime, oldMtime);
+    await fs.utimes(filePath, oldMtime, oldMtime);
 
     const decayed = await applyTemporalDecayToHybridResults({
-      results: [{ path: "sessions/thread.jsonl", score: 1, source: "sessions" }],
+      results: [{ path: "notes/topic.md", score: 1, source: "memory" }],
       workspaceDir: dir,
       temporalDecay: { enabled: true, halfLifeDays: 30 },
       nowMs: NOW_MS,
     });
 
     expect(decayed[0]?.score).toBeCloseTo(0.5, 2);
+  });
+
+  it("leaves session timestamps unknown when their indexed source is missing", async () => {
+    const entry = { path: "sessions/main/missing.jsonl", score: 1, source: "sessions" };
+    expect(
+      await applyTemporalDecayToHybridResults({
+        results: [entry],
+        temporalDecay: { enabled: true, halfLifeDays: 30 },
+        sessionSourceMtimes: new Map(),
+        nowMs: NOW_MS,
+      }),
+    ).toEqual([entry]);
   });
 });

--- a/extensions/memory-core/src/memory/temporal-decay.ts
+++ b/extensions/memory-core/src/memory/temporal-decay.ts
@@ -1,4 +1,3 @@
-// Memory Core plugin module implements temporal decay behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -15,31 +14,17 @@ export const DEFAULT_TEMPORAL_DECAY_CONFIG: TemporalDecayConfig = {
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(?:[^/]+\/)*(\d{4})-(\d{2})-(\d{2})(?:-[^/]+)?\.md$/;
 
-function toDecayLambda(halfLifeDays: number): number {
-  if (!Number.isFinite(halfLifeDays) || halfLifeDays <= 0) {
-    return 0;
-  }
-  return Math.LN2 / halfLifeDays;
-}
-
-function calculateTemporalDecayMultiplier(params: {
-  ageInDays: number;
-  halfLifeDays: number;
-}): number {
-  const lambda = toDecayLambda(params.halfLifeDays);
-  const clampedAge = Math.max(0, params.ageInDays);
-  if (lambda <= 0 || !Number.isFinite(clampedAge)) {
-    return 1;
-  }
-  return Math.exp(-lambda * clampedAge);
-}
-
 function applyTemporalDecayToScore(params: {
   score: number;
   ageInDays: number;
   halfLifeDays: number;
 }): number {
-  return params.score * calculateTemporalDecayMultiplier(params);
+  const { halfLifeDays } = params;
+  const clampedAge = Math.max(0, params.ageInDays);
+  if (!Number.isFinite(halfLifeDays) || halfLifeDays <= 0 || !Number.isFinite(clampedAge)) {
+    return params.score;
+  }
+  return params.score * Math.exp(-(Math.LN2 / halfLifeDays) * clampedAge);
 }
 
 function parseMemoryDateFromPath(filePath: string): Date | null {
@@ -84,7 +69,14 @@ async function extractTimestamp(params: {
   filePath: string;
   source?: string;
   workspaceDir?: string;
+  sessionSourceMtimes?: ReadonlyMap<string, number | undefined>;
 }): Promise<Date | null> {
+  if (params.source === "sessions") {
+    // Session paths are logical SQLite identities, not workspace files. Ranking
+    // uses the indexed source activity, never a same-named filesystem artifact.
+    const mtime = params.sessionSourceMtimes?.get(params.filePath);
+    return mtime !== undefined && Number.isFinite(mtime) ? new Date(mtime) : null;
+  }
   const fromPath = parseMemoryDateFromPath(params.filePath);
   if (fromPath) {
     return fromPath;
@@ -114,17 +106,13 @@ async function extractTimestamp(params: {
   }
 }
 
-function ageInDaysFromTimestamp(timestamp: Date, nowMs: number): number {
-  const ageMs = Math.max(0, nowMs - timestamp.getTime());
-  return ageMs / DAY_MS;
-}
-
 export async function applyTemporalDecayToHybridResults<
   T extends { path: string; score: number; source: string },
 >(params: {
   results: T[];
   temporalDecay?: Partial<TemporalDecayConfig>;
   workspaceDir?: string;
+  sessionSourceMtimes?: ReadonlyMap<string, number | undefined>;
   nowMs?: number;
 }): Promise<T[]> {
   const config = { ...DEFAULT_TEMPORAL_DECAY_CONFIG, ...params.temporalDecay };
@@ -144,6 +132,7 @@ export async function applyTemporalDecayToHybridResults<
           filePath: entry.path,
           source: entry.source,
           workspaceDir: params.workspaceDir,
+          sessionSourceMtimes: params.sessionSourceMtimes,
         });
         timestampPromiseCache.set(cacheKey, timestampPromise);
       }
@@ -155,7 +144,7 @@ export async function applyTemporalDecayToHybridResults<
 
       const decayedScore = applyTemporalDecayToScore({
         score: entry.score,
-        ageInDays: ageInDaysFromTimestamp(timestamp, nowMs),
+        ageInDays: (nowMs - timestamp.getTime()) / DAY_MS,
         halfLifeDays: config.halfLifeDays,
       });
 

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -299,10 +299,12 @@ describe("memory_search real manager", () => {
       minScore: 0,
       sources: ["sessions"],
     });
-    expect(ranked.slice(0, 2).map((hit) => hit.path)).toEqual([
-      expect.stringContaining("hidden-a"),
-      expect.stringContaining("hidden-b"),
-    ]);
+    expect(
+      ranked
+        .slice(0, 2)
+        .map((hit) => hit.path)
+        .toSorted(),
+    ).toEqual([expect.stringContaining("hidden-a"), expect.stringContaining("hidden-b")]);
     fixture.provider.embedQueryCalls = 0;
     fixture.provider.embeddedQueryTexts = [];
 
@@ -335,7 +337,7 @@ describe("memory_search real manager", () => {
       };
     };
 
-    expect(details.results.map((hit) => hit.snippet)).toEqual([
+    expect(details.results.map((hit) => hit.snippet).toSorted()).toEqual([
       expect.stringContaining("visible private a"),
       expect.stringContaining("visible private b"),
     ]);


### PR DESCRIPTION
Closes #139094

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users searching indexed conversations would receive stale or incorrectly ordered recall results. Session recency could be lost, vector fallback could limit results before sorting their final scores, and short CJK substring matches could select an older session despite having its indexed activity timestamp.

This affects Memory Core retrieval through `memory_search`, including keyword-only, lexical, hybrid and FTS-unavailable vector paths. The built-in manager already enables recency weighting with a 30-day half-life; there is no new operator toggle.

## Why This Change Was Made

Ranking now reads existing indexed source activity instead of trying to reconstruct a workspace filename for logical SQLite-backed session paths. The existing ranking pipeline applies that activity before selection, shares lexical finalization, and uses one tie-break comparator across exact and ordinary hybrid results.

Recall-only LIKE matches retain zero public confidence: their private ranking signal receives recency, importance and project weighting without turning substring recall into a scored semantic match. Positive and negative weighted confidence, raw retrieval diagnostics, exact-path precedence and message provenance remain intact.

## User Impact

Indexed conversations and retained archives receive the expected recency weighting. Limited result windows select the correct final-ranked match, and unrelated workspace files cannot supply a session timestamp. Extra-memory file mtime behavior, evergreen exemptions and provider availability requirements are preserved.

The change removes **10 production lines** overall: 88 added, 98 removed. Tests add 217 net lines; documentation adds five. No schema, migration, index layout, retention, configuration, SDK, public result shape, stored representation or embedding transport changes are introduced.

## Evidence

Three failures were reproduced before their respective repairs using actual SQLite/session owners:

- Identical session content with source activity 15 days apart produced an old/fresh score ratio of **1**, rather than **sqrt(0.5) ≈ 0.70710678**. Keyword-only, configured-provider lexical and hybrid search now produce the expected ratio while retaining the original message provenance timestamps. The fixture independently verifies persisted activity and the absence of any workspace transcript file.
- A colliding view in the temporary database makes the actual FTS initializer report unavailable. Even with correct decayed scores, vector fallback previously returned the old session first. Sorting final scores before truncation now makes `maxResults=1` select the fresh session. No private availability override or unsupported hybrid-disable setting is used.
- A supported trigram query `记忆` uses LIKE retrieval for two identical session transcripts. The existing API-shaped embedding fixture returns a valid all-zero vector, so both results retain public `score=0`, `vectorScore=0` and `textScore=0`. Before repair, their private lexical tie-break bypassed decay and selected `sessions/main/a-old.jsonl`; afterward the manager and real `memory_search` tool select `sessions/main/z-fresh.jsonl`, including a one-result window. This connected gap predates the PR; the confidence contract is intentionally preserved.

The expanded affected suite passed **80 tests across six files**, covering the six-mode source-recency regression, actual archive lifecycle, workspace decoys, real tool execution, provenance, KNN/scan retrieval, exact-path/MMR ranking, cancellation, visibility and search-generation lifetimes. The existing LIKE helper fixture now covers absent, positive and negative vector confidence, including negative-score exclusion.

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  extensions/memory-core/src/memory/manager-temporal-ranking.test.ts \
  extensions/memory-core/src/memory/temporal-decay.test.ts \
  extensions/memory-core/src/memory/hybrid.test.ts \
  extensions/memory-core/src/memory/manager-search-provenance.test.ts \
  extensions/memory-core/src/memory/manager-search-orchestration.test.ts \
  extensions/memory-core/src/tools.real-manager.test.ts
```

The full changed-file check passed, including formatting, production/test typechecking and declaration containment, doctor contracts, plugin boundaries, lint, dependency/coercion/deprecation/dead-export guards, database-first storage checks and zero runtime import cycles. A final mechanical consolidation then shared the identical tie-break comparator; **all 35 manager/hybrid tests and targeted type-aware lint passed again** on that final source. `git diff --check` passed. The full gate is attributed to the immediately preceding comparator-equivalent snapshot, rather than claimed as a repeated final run.

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- \
  docs/concepts/memory-search.md \
  extensions/memory-core/src/memory/hybrid.test.ts \
  extensions/memory-core/src/memory/hybrid.ts \
  extensions/memory-core/src/memory/manager-keyword-retrieval.ts \
  extensions/memory-core/src/memory/manager-search-orchestration.ts \
  extensions/memory-core/src/memory/manager-temporal-ranking.test.ts \
  extensions/memory-core/src/memory/temporal-decay.test.ts \
  extensions/memory-core/src/memory/temporal-decay.ts \
  extensions/memory-core/src/tools.real-manager.test.ts
```

The source lookup runs under the search-generation lease, constrained to session results and retained candidate paths through one bound JSON set. Current caps allow at most 800 candidate references / 600 distinct paths, with at most one returned row per unique path/source. Memory-only results skip the lookup. No per-hit query or session-history enumeration is added.

For the ClawSweeper data-model proof request: no persistent transition is introduced, so a migration/format-transition test is inapplicable. The unchanged shipped schema already defines `mtime REAL NOT NULL` and `UNIQUE(path, source)`; the existing writer and parameterized reader retain those representations. The regressions verify those stored values before search. No compatibility shim or schema workaround is needed.

Validation used a task-local frozen dependency install, Node 26.8.1 and pinned pnpm 12.3.4; lockfile supply-chain policies and applicable package lifecycle checks passed. Final staged autoreview is scoped-clean through P2, and the root/peer source challenges found no remaining semantic defect. [CI run 33973263252](https://github.com/openclaw/openclaw/actions/runs/33973263252) passed for committed head `685a9be80176f6a21193fcc1de36ead6b14a2e21` (79 successful jobs, 16 skipped). The separate direct read-only review initially raised an MMR P2, then withdrew it after source/history/documentation review: LIKE strength is a shipped tie-break rather than MMR confidence, equal confidence and similarity retain recency order at every selection round, and the proposed example changed diversity. The original report is preserved with that disposition; no accepted findings remain through P2, and no code or tests changed for the adjudication. Earlier green CI at `1852e6f` predates the added LIKE repair and is not claimed as proof of this final candidate.

**Proof boundary:** deterministic local tests invoke the real tool and SQLite/session/archive owners with fixture embeddings. A booted Gateway/browser, live external embedding endpoint and remote installation were not exercised. Embedding transport and Gateway ingress are unchanged. Exact-head CI passed; native landing validation remains under maintainer ownership.
