### PR TITLE
fix: preserve saved settings across delayed reads and reconnects

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3882,7 +3882,6 @@ ui/src/lib/chat/tool-cards.ts	2
 ui/src/lib/chat/tool-display.ts	1
 ui/src/lib/config-form-utils.ts	7
 ui/src/lib/config/config-draft-model.ts	5
-ui/src/lib/config/config-gateway-operations.ts	1
 ui/src/lib/cron/index.ts	13
 ui/src/lib/gateway-diagnostics.ts	3
 ui/src/lib/gateway-errors.ts	1

--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -771,21 +771,19 @@ suite.define(() => {
           },
         },
       });
-      await gateway.setMethodResponse(
-        "config.get",
-        configResponse(
-          {
-            "session-docs": {
-              enabled: false,
-              transport: "streamable-http",
-              url: "https://session.example.test/mcp",
-            },
+      const afterSessionAdd = configResponse(
+        {
+          "session-docs": {
+            enabled: false,
+            transport: "streamable-http",
+            url: "https://session.example.test/mcp",
           },
-          false,
-          "capability-menu-config-1",
-        ),
+        },
+        false,
+        "capability-menu-config-1",
       );
-      await gateway.resolveDeferred("config.patch", { ok: true });
+      await gateway.setMethodResponse("config.get", afterSessionAdd);
+      await gateway.resolveDeferred("config.patch", { ok: true, ...afterSessionAdd });
       await expect
         .poll(() => latestToolOverrides(gateway))
         .toEqual({ mcpServers: { "session-docs": true }, skills: { docs: false } });
@@ -822,22 +820,20 @@ suite.define(() => {
           },
         },
       });
-      await gateway.setMethodResponse(
-        "config.get",
-        configResponse(
-          {
-            "global-docs": { args: ["--stdio"], command: "docs-mcp" },
-            "session-docs": {
-              enabled: false,
-              transport: "streamable-http",
-              url: "https://session.example.test/mcp",
-            },
+      const afterEverywhereAdd = configResponse(
+        {
+          "global-docs": { args: ["--stdio"], command: "docs-mcp" },
+          "session-docs": {
+            enabled: false,
+            transport: "streamable-http",
+            url: "https://session.example.test/mcp",
           },
-          false,
-          "capability-menu-config-2",
-        ),
+        },
+        false,
+        "capability-menu-config-2",
       );
-      await gateway.resolveDeferred("config.patch", { ok: true });
+      await gateway.setMethodResponse("config.get", afterEverywhereAdd);
+      await gateway.resolveDeferred("config.patch", { ok: true, ...afterEverywhereAdd });
       await expect.poll(() => everywhereDialog.count()).toBe(0);
       expect(await gateway.getRequests("sessions.patch")).toHaveLength(sessionPatchCount);
 

--- a/ui/src/e2e/config-safe-write.e2e.test.ts
+++ b/ui/src/e2e/config-safe-write.e2e.test.ts
@@ -391,12 +391,13 @@ suite.define(() => {
         const patchedResponse = configResponse(patchedConfig, "snapshot-2", "snapshot-1");
         await gateway.setMethodResponse("config.get", patchedResponse);
         await gateway.resolveDeferred("config.patch", {
+          config: patchedConfig,
           hash: "snapshot-2",
           ok: true,
         });
         await expect
           .poll(async () => (await gateway.getRequests("config.get")).length)
-          .toBe(configGetsBeforePatch + 1);
+          .toBe(configGetsBeforePatch);
         await expect.poll(() => codeModeRow.textContent()).toContain("Default: Disabled");
         await expect.poll(() => labsLink.getAttribute("aria-current")).toBe("page");
         await capture(page, "00-labs-canonical-refresh.png", codeModeSwitch);

--- a/ui/src/e2e/curated-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/curated-settings-defaults.e2e.test.ts
@@ -242,11 +242,8 @@ suite.define(() => {
           });
         }
 
-        await gateway.setMethodResponse(
-          "config.get",
-          configResponse(afterThinkingReset, "curated-defaults-model-thinking-reset"),
-        );
         const modelSavesBefore = (await gateway.getRequests("config.patch")).length;
+        await gateway.deferNext("config.patch");
         await selectDefault(thinkingRow);
         expect(
           requestRaw(await gateway.waitForRequest("config.patch", { after: modelSavesBefore })),
@@ -260,14 +257,17 @@ suite.define(() => {
             },
           },
         });
+        const afterThinkingResponse = configResponse(
+          afterThinkingReset,
+          "curated-defaults-model-thinking-reset",
+        );
+        await gateway.setMethodResponse("config.get", afterThinkingResponse);
+        await gateway.resolveDeferred("config.patch", { ok: true, ...afterThinkingResponse });
         await expect
           .poll(() => page.getByRole("status").filter({ hasText: "Defaults saved" }).count())
           .toBeGreaterThan(0);
-        await gateway.setMethodResponse(
-          "config.get",
-          configResponse(afterModelResets, "curated-defaults-model-resets"),
-        );
         const fastModeSavesBefore = (await gateway.getRequests("config.patch")).length;
+        await gateway.deferNext("config.patch");
         await selectDefault(fastModeRow);
         expect(
           requestRaw(await gateway.waitForRequest("config.patch", { after: fastModeSavesBefore })),
@@ -281,6 +281,12 @@ suite.define(() => {
             },
           },
         });
+        const afterModelResponse = configResponse(
+          afterModelResets,
+          "curated-defaults-model-resets",
+        );
+        await gateway.setMethodResponse("config.get", afterModelResponse);
+        await gateway.resolveDeferred("config.patch", { ok: true, ...afterModelResponse });
         await expectDefaultInfo(thinkingRow, thinkingDefaultExplanation);
         await expectDefaultInfo(fastModeRow, fastModeDefaultExplanation);
         await expect

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -13,6 +13,7 @@ import {
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
   type ControlUiE2eServer,
+  type MockGatewayControls,
   type MockGatewayRequest,
 } from "../test-helpers/control-ui-e2e.ts";
 
@@ -44,6 +45,22 @@ function requestRaw(request: MockGatewayRequest): Record<string, unknown> {
     throw new Error("Expected config.patch params");
   }
   return JSON.parse(String((params as Record<string, unknown>).raw)) as Record<string, unknown>;
+}
+
+async function resolveConfigPatch(
+  gateway: MockGatewayControls,
+  config: Record<string, unknown>,
+  hash: string,
+) {
+  await gateway.setMethodResponse("config.get", {
+    config,
+    sourceConfig: config,
+    hash,
+    issues: [],
+    raw: JSON.stringify(config),
+    valid: true,
+  });
+  await gateway.resolveDeferred("config.patch", { ok: true, config, hash });
 }
 
 function providerConfig(value: string): { apiKey: string } {
@@ -564,7 +581,6 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
           raw: JSON.stringify(config),
           valid: true,
         },
-        "config.patch": { ok: true },
         "models.list": {
           cases: [
             {
@@ -662,6 +678,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       // The { after } cursor waits for and returns the save-triggered patch,
       // so a slow runner can't hand back an earlier config.patch stale.
       const patchCount = (await gateway.getRequests("config.patch")).length;
+      await gateway.deferNext("config.patch");
       await openaiCard.getByRole("button", { name: "Save" }).click();
       const keyPatch = requestRaw(
         await gateway.waitForRequest("config.patch", {
@@ -671,6 +688,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       expect(keyPatch).toEqual({
         models: { providers: { openai: providerConfig(openaiInputValue) } },
       });
+      await resolveConfigPatch(gateway, config, "model-providers-hash-key");
       await expect.poll(async () => openaiCard.textContent()).toContain("Secret saved.");
 
       await openaiCard.getByRole("button", { name: "Test connection" }).click();
@@ -689,14 +707,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
           },
         },
       };
-      await gateway.setMethodResponse("config.get", {
-        config: updatedDefaultsConfig,
-        sourceConfig: updatedDefaultsConfig,
-        hash: "model-providers-hash-defaults",
-        issues: [],
-        raw: JSON.stringify(updatedDefaultsConfig),
-        valid: true,
-      });
+      await gateway.deferNext("config.patch");
       await selectModelPicker(primary, "anthropic/claude-sonnet-4-5");
       expect(
         requestRaw(await gateway.waitForRequest("config.patch", { after: defaultPatchCount })),
@@ -710,6 +721,10 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
           },
         },
       });
+      await resolveConfigPatch(gateway, updatedDefaultsConfig, "model-providers-hash-defaults");
+      await expect
+        .poll(() => page.getByRole("status").filter({ hasText: "Defaults saved" }).count())
+        .toBeGreaterThan(0);
 
       const addSection = page.locator(".settings-section", {
         has: page.getByRole("heading", { name: "Add provider" }),
@@ -726,14 +741,6 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
           },
         },
       };
-      await gateway.setMethodResponse("config.get", {
-        config: savedConfig,
-        sourceConfig: savedConfig,
-        hash: "model-providers-hash-2",
-        issues: [],
-        raw: JSON.stringify(savedConfig),
-        valid: true,
-      });
       await gateway.setMethodResponse("models.authStatus", {
         ts: NOW,
         providerCapabilities: [
@@ -765,12 +772,14 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
         ],
       });
       const addPatchCount = (await gateway.getRequests("config.patch")).length;
+      await gateway.deferNext("config.patch");
       await addSection.getByRole("button", { name: "Save provider" }).click();
       expect(
         requestRaw(await gateway.waitForRequest("config.patch", { after: addPatchCount })),
       ).toEqual({
         models: { providers: { google: providerConfig(googleInputValue) } },
       });
+      await resolveConfigPatch(gateway, savedConfig, "model-providers-hash-2");
       await page.locator('[data-provider-id="google"]').waitFor();
 
       if (recordVisuals) {
@@ -952,17 +961,11 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
       const savedConfig = {
         agents: { defaults: { model: "openai/saved-model" } },
       };
-      await gateway.setMethodResponse("config.get", {
-        config: savedConfig,
-        sourceConfig: savedConfig,
-        hash: "model-providers-reconnect-saved",
-        issues: [],
-        raw: JSON.stringify(savedConfig),
-        valid: true,
-      });
       const savedPatchCount = (await gateway.getRequests("config.patch")).length;
+      await gateway.deferNext("config.patch");
       await selectModelPicker(primary, "openai/saved-model");
       await gateway.waitForRequest("config.patch", { after: savedPatchCount });
+      await resolveConfigPatch(gateway, savedConfig, "model-providers-reconnect-saved");
       await expect
         .poll(async () => page.getByRole("status").filter({ hasText: "Defaults saved" }).count())
         .toBeGreaterThan(0);

--- a/ui/src/e2e/skill-workshop-self-learning.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-self-learning.e2e.test.ts
@@ -134,8 +134,9 @@ describeControlUiE2e("Skill Workshop self-learning config recovery mocked Gatewa
       );
       expect(replayedPatch.baseHash).toBe("hash-current");
 
-      await gateway.setMethodResponse("config.get", configSnapshot(true, "hash-enabled"));
-      await gateway.resolveDeferred("config.patch", { ok: true });
+      const enabledSnapshot = configSnapshot(true, "hash-enabled");
+      await gateway.setMethodResponse("config.get", enabledSnapshot);
+      await gateway.resolveDeferred("config.patch", { ok: true, ...enabledSnapshot });
 
       const toggle = page.getByLabel("Toggle autonomous self-learning", { exact: true });
       await expect.poll(() => toggle.isChecked()).toBe(true);

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -328,13 +328,13 @@ export function serializeFormForSubmit(state: RuntimeConfigState): string {
 export function adoptConfigSetAck(
   state: RuntimeConfigState,
   submittedRaw: string,
-  ackHash: string | null,
+  ackHash: string,
 ) {
   const parsed = parseConfigRawDraft(submittedRaw);
   state.configSnapshot = {
     ...state.configSnapshot,
     raw: submittedRaw,
-    hash: ackHash ?? state.configSnapshot?.hash ?? null,
+    hash: ackHash,
     valid: true,
     issues: [],
     ...(parsed ? { config: parsed, sourceConfig: parsed } : {}),
@@ -353,19 +353,6 @@ export function adoptConfigSetAck(
     if (parsed) {
       state.configForm = cloneConfigObject(parsed);
     }
-  }
-}
-
-// Legacy hashless ack: when the follow-up reload returns exactly the submitted
-// bytes, rebase a preserved dirty draft onto that authoritative hash. Foreign
-// content matches neither and stays fail-closed.
-export function reconcileHashlessWriteReload(state: RuntimeConfigState, submittedRaw: string) {
-  if (state.configSnapshot?.raw !== submittedRaw) {
-    return;
-  }
-  const hash = state.configSnapshot.hash ?? null;
-  if (state.configFormDirty) {
-    state.configDraftBaseHash = hash ?? state.configDraftBaseHash;
   }
 }
 

--- a/ui/src/lib/config/config-gateway-operations.test.ts
+++ b/ui/src/lib/config/config-gateway-operations.test.ts
@@ -7,7 +7,6 @@ import {
   deferred,
   createGatewayHarness,
   createConfigServerMock,
-  createDeferredSetServerMock,
   createConfigCapabilityHarness,
 } from "./config-test-harness.ts";
 import { createRuntimeConfigCapability } from "./runtime-config-capability.ts";
@@ -117,10 +116,12 @@ describe("config gateway operations", () => {
     const reloadGate = deferred<unknown>();
     deferReload = reloadGate;
     runtimeConfig.patchForm(["count"], 2);
-    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+    const save = runtimeConfig.save();
+    await vi.advanceTimersByTimeAsync(0);
     // config.set acked; the post-save reload is held open while a new edit lands.
     runtimeConfig.patchForm(["count"], 3);
     reloadGate.resolve({});
+    await expect(save).resolves.toBe(true);
     await vi.advanceTimersByTimeAsync(0);
 
     expect(runtimeConfig.state.configFormDirty).toBe(true);
@@ -162,7 +163,8 @@ describe("config gateway operations", () => {
 
     failReloads = true;
     first.runtimeConfig.patchForm(["count"], 2);
-    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+    await expect(first.runtimeConfig.save()).resolves.toBe(true);
+    expect(first.runtimeConfig.state.lastError).toContain("gateway went away");
 
     expect(first.runtimeConfig.state.configNeedsApply).toBe(true);
     first.runtimeConfig.dispose();
@@ -267,11 +269,10 @@ describe("config gateway operations", () => {
     runtimeConfig.dispose();
   });
 
-  it("keeps a revert made during the cosmetic reload dirty and saves it", async () => {
+  it("saves a revert made after acknowledgement on the new base", async () => {
     vi.useFakeTimers();
     let hashCounter = 1;
     let storedRaw = '{\n  "count": 1\n}\n';
-    let deferReload: ReturnType<typeof deferred<unknown>> | null = null;
     const submissions: Array<{ raw: string; baseHash: string }> = [];
     const request = vi.fn((method: string, params?: unknown) => {
       if (method === "config.get") {
@@ -282,11 +283,6 @@ describe("config gateway operations", () => {
           valid: true,
           issues: [],
         };
-        if (deferReload) {
-          const pending = deferReload;
-          deferReload = null;
-          return pending.promise.then(() => response);
-        }
         return Promise.resolve(response);
       }
       if (method === "config.set") {
@@ -303,17 +299,14 @@ describe("config gateway operations", () => {
     );
     await runtimeConfig.ensureLoaded();
 
-    const reloadGate = deferred<unknown>();
-    deferReload = reloadGate;
     runtimeConfig.patchForm(["count"], 2);
     await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
     expect(submissions).toHaveLength(1);
 
     // The ack already rebased the originals onto the submitted bytes, so a
-    // revert during the still-pending reload compares dirty and reschedules.
+    // revert to the previous value compares dirty and reschedules.
     runtimeConfig.patchForm(["count"], 1);
     expect(runtimeConfig.state.configFormDirty).toBe(true);
-    reloadGate.resolve({});
     await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
 
     expect(submissions).toHaveLength(2);
@@ -425,125 +418,65 @@ describe("config gateway operations", () => {
     runtimeConfig.dispose();
   });
 
-  it("orders a patch acknowledgement after an older in-flight config load", async () => {
-    const staleLoad = deferred<ConfigSnapshot>();
-    let getCalls = 0;
-    const request = vi.fn(async (method: string) => {
-      if (method === "config.get") {
-        getCalls += 1;
-        if (getCalls === 2) {
-          return staleLoad.promise;
+  it.each(["autosave", "patch"] as const)(
+    "orders a %s acknowledgement after an older in-flight config load",
+    async (operation) => {
+      vi.useFakeTimers();
+      const staleLoad = deferred<ConfigSnapshot>();
+      let getCalls = 0;
+      const request = vi.fn(async (method: string) => {
+        if (method === "config.get") {
+          getCalls += 1;
+          if (getCalls === 2) {
+            return staleLoad.promise;
+          }
+          return {
+            config: { count: 1 },
+            raw: '{"count":1}',
+            hash: "hash-1",
+            valid: true,
+            issues: [],
+          };
         }
-        return {
-          config: { count: 1 },
-          raw: '{"count":1}',
-          hash: "hash-1",
-          valid: true,
-          issues: [],
-        };
-      }
-      if (method === "config.patch") {
-        return { config: { count: 1, patched: true }, hash: "hash-2" };
-      }
-      return {};
-    });
-    const { runtimeConfig } = createConfigCapabilityHarness(
-      request as GatewayBrowserClient["request"],
-    );
-    await runtimeConfig.ensureLoaded();
-
-    const staleRefresh = runtimeConfig.refresh();
-    await vi.waitFor(() => expect(getCalls).toBe(2));
-    await expect(
-      runtimeConfig.patch({ raw: { patched: true }, note: "ordered patch test" }),
-    ).resolves.toBe(true);
-    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
-
-    staleLoad.resolve({
-      config: { count: 999 },
-      raw: '{"count":999}',
-      hash: "stale-hash",
-      valid: true,
-      issues: [],
-    });
-    await staleRefresh;
-    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
-    expect(runtimeConfig.state.configForm).toEqual({ count: 1, patched: true });
-    runtimeConfig.dispose();
-  });
-
-  it("refreshes hash-only patch acknowledgements before publishing their revision", async () => {
-    let storedConfig: Record<string, unknown> = { count: 1 };
-    let hash = "hash-1";
-    let getCalls = 0;
-    const request = vi.fn(async (method: string) => {
-      if (method === "config.get") {
-        getCalls += 1;
-        return {
-          config: storedConfig,
-          raw: JSON.stringify(storedConfig),
-          hash,
-          valid: true,
-          issues: [],
-        };
-      }
-      if (method === "config.patch") {
-        storedConfig = { count: 1, patched: true };
-        hash = "hash-2";
-        return { hash };
-      }
-      return {};
-    });
-    const { runtimeConfig } = createConfigCapabilityHarness(
-      request as GatewayBrowserClient["request"],
-    );
-    await runtimeConfig.ensureLoaded();
-
-    await expect(
-      runtimeConfig.patch({ raw: { patched: true }, note: "hash-only patch test" }),
-    ).resolves.toBe(true);
-
-    expect(getCalls).toBe(2);
-    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
-    expect(runtimeConfig.state.configForm).toEqual({ count: 1, patched: true });
-    runtimeConfig.dispose();
-  });
-
-  it("records a committed hash-only patch when its acknowledgement refresh fails", async () => {
-    let getCalls = 0;
-    const request = vi.fn(async (method: string) => {
-      if (method === "config.get") {
-        getCalls += 1;
-        if (getCalls > 1) {
-          throw new Error("refresh unavailable");
+        if (method === "config.patch" || method === "config.set") {
+          return { config: { count: 1, patched: true }, hash: "hash-2" };
         }
-        return {
-          config: { count: 1 },
-          raw: '{"count":1}',
-          hash: "hash-1",
-          valid: true,
-          issues: [],
-        };
-      }
-      if (method === "config.patch") {
-        return { hash: "hash-2" };
-      }
-      return {};
-    });
-    const { runtimeConfig } = createConfigCapabilityHarness(
-      request as GatewayBrowserClient["request"],
-    );
-    await runtimeConfig.ensureLoaded();
+        return {};
+      });
+      const { runtimeConfig } = createConfigCapabilityHarness(
+        request as GatewayBrowserClient["request"],
+      );
+      await runtimeConfig.ensureLoaded();
 
-    await expect(
-      runtimeConfig.patch({ raw: { patched: true }, note: "hash-only refresh failure" }),
-    ).resolves.toBe(false);
+      const staleRefresh = runtimeConfig.refresh();
+      expect(getCalls).toBe(2);
+      if (operation === "autosave") {
+        runtimeConfig.patchForm(["patched"], true);
+        await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+      } else {
+        await expect(
+          runtimeConfig.patch({ raw: { patched: true }, note: "ordered patch test" }),
+        ).resolves.toBe(true);
+      }
+      expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
 
-    expect(runtimeConfig.state.configNeedsApply).toBe(true);
-    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-1");
-    expect(runtimeConfig.state.lastError).toContain("refresh unavailable");
-    runtimeConfig.dispose();
-  });
+      staleLoad.resolve({
+        config: { count: 1 },
+        raw: '{"count":1}',
+        hash: "hash-1",
+        valid: true,
+        issues: [],
+      });
+      await staleRefresh;
+      expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
+      expect(runtimeConfig.state.configForm).toEqual({ count: 1, patched: true });
+      // A refresh requested after the ack still owns its new snapshot.
+      await runtimeConfig.refresh();
+      expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-1");
+      expect(runtimeConfig.state.configForm).toEqual({ count: 1 });
+      runtimeConfig.dispose();
+    },
+  );
 
   it("refreshes applied revision truth after config.patch", async () => {
     vi.useFakeTimers();
@@ -562,7 +495,7 @@ describe("config gateway operations", () => {
           issues: [],
         };
       }
-      return method === "config.patch" ? { hash: "hash-2" } : {};
+      return method === "config.patch" ? { config: { count: 2 }, hash: "hash-2" } : {};
     });
     const { runtimeConfig } = createConfigCapabilityHarness(
       request as GatewayBrowserClient["request"],
@@ -577,47 +510,6 @@ describe("config gateway operations", () => {
     await vi.advanceTimersByTimeAsync(250);
     expect(runtimeConfig.state.configNeedsApply).toBe(false);
     expect(runtimeConfig.state.configSnapshot?.configRevisionHash).toBe("revision-2");
-    runtimeConfig.dispose();
-  });
-
-  it("rebases trailing edits after a hashless ack so the trailing save does not self-conflict", async () => {
-    vi.useFakeTimers();
-    const { request, submissions, firstSet } = createDeferredSetServerMock({ legacyAck: true });
-    const { runtimeConfig } = createConfigCapabilityHarness(
-      request as GatewayBrowserClient["request"],
-    );
-    await runtimeConfig.ensureLoaded();
-
-    runtimeConfig.patchForm(["count"], 2);
-    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
-    expect(submissions).toHaveLength(1);
-
-    // Edit while the hashless save is in flight: the follow-up reload must
-    // rebase the surviving draft onto the fetched post-write hash, or the
-    // trailing save conflicts with the write that just succeeded.
-    runtimeConfig.patchForm(["count"], 3);
-    firstSet.resolve({});
-    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
-
-    expect(submissions).toHaveLength(2);
-    expect(submissions[1]).toEqual({ raw: '{\n  "count": 3\n}\n', baseHash: "hash-2" });
-    runtimeConfig.dispose();
-  });
-
-  it("keeps process-local needsApply after a legacy hashless ack reload", async () => {
-    vi.useFakeTimers();
-    const { request, firstSet, submissions } = createDeferredSetServerMock({ legacyAck: true });
-    const { runtimeConfig } = createConfigCapabilityHarness(
-      request as GatewayBrowserClient["request"],
-    );
-    await runtimeConfig.ensureLoaded();
-
-    runtimeConfig.patchForm(["count"], 2);
-    firstSet.resolve({});
-    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
-
-    expect(submissions).toHaveLength(1);
-    expect(runtimeConfig.state.configNeedsApply).toBe(true);
     runtimeConfig.dispose();
   });
 

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -1,5 +1,4 @@
 import { ErrorCodes } from "@openclaw/gateway-client/browser";
-import { asNullableRecord as asConfigRecord } from "@openclaw/normalization-core/record-coerce";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ConfigSchemaResponse, ConfigSnapshot } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
@@ -12,7 +11,6 @@ import {
   applyConfigSnapshot,
   clearConfigDraftTracking,
   formatConfigMutationError,
-  reconcileHashlessWriteReload,
   serializeFormForSubmit,
 } from "./config-draft-model.ts";
 import {
@@ -62,11 +60,6 @@ export async function refreshDraft(
   reconcileAppliedRefresh();
 }
 
-function readAckHash(ack: unknown): string | null {
-  const hash = (ack as { hash?: unknown } | null | undefined)?.hash;
-  return typeof hash === "string" && hash.length > 0 ? hash : null;
-}
-
 /**
  * Gateway contract: requireConfigBaseHash in
  * src/gateway/server-methods/config.ts rejects writes whose baseHash no
@@ -99,11 +92,11 @@ export type ConfigPatchBuildResult = { options: ConfigPatchOptions } | { error: 
 export type ConfigPatchBuilder = (
   config: Readonly<Record<string, unknown>>,
 ) => ConfigPatchBuildResult;
-type ConfigPatchAck = {
-  config?: unknown;
-  hash?: unknown;
-  noop?: boolean;
-};
+// Gateway commitGatewayConfigWrite returns persisted hashes; only a no-op patch omits one.
+type ConfigPatchAck = { config: Record<string, unknown> } & (
+  | { noop: true }
+  | { noop?: false; hash: string }
+);
 
 export type RuntimeConfigExternalMutationResult<T> =
   | {
@@ -313,94 +306,87 @@ function applyConfigSchema(state: RuntimeConfigState, res: ConfigSchemaResponse)
   state.configSchemaVersion = res.version ?? null;
 }
 
-type ConfigSubmitMethod = "config.set" | "config.apply";
-type ConfigSubmitBusyKey = "configSaving" | "configApplying";
+export type ConfigSubmission = { raw: string; ackHash: string | null };
+export type ConfigSubmissionObserver = (submission: ConfigSubmission) => void;
 
-async function submitConfigChange(
+export async function submitConfigDraft(
   state: RuntimeConfigState,
-  method: ConfigSubmitMethod,
-  busyKey: ConfigSubmitBusyKey,
-  extraParams: Record<string, unknown> = {},
-  onSubmitted?: (info: { raw: string; ackHash: string | null }) => void,
+  mode: "auto" | "save" | "apply",
+  onSubmitted?: ConfigSubmissionObserver,
   canDispatch: () => boolean = () => true,
 ): Promise<boolean> {
   const client = state.client;
-  if (!client || !state.connected) {
+  const canSubmitDraft = () =>
+    mode !== "auto" || (state.configFormDirty && state.configFormMode === "form");
+  if (!client || !state.connected || !canSubmitDraft()) {
     return false;
   }
   const connectionEpoch = currentConfigConnectionEpoch(state);
   const isCurrent = () => isCurrentConfigConnection(state, client, connectionEpoch);
-  // Claim busy before any await so a second click cannot slip past the busy
-  // state while a JSON5 original parse settles; finally releases it.
-  state[busyKey] = true;
-  state.lastError = null;
-  state.chatError = null;
+  const busyKey = mode === "auto" ? null : mode === "apply" ? "configApplying" : "configSaving";
+  // Manual writes claim busy before parsing; autosave leaves editors interactive.
+  if (busyKey) {
+    state[busyKey] = true;
+    state.lastError = null;
+    state.chatError = null;
+  }
   let submittedFormRaw: string | null = null;
   try {
     if (state.configRawOriginalParsePending) {
-      // JSON5 originals parse asynchronously on first load; sanitize needs them.
+      // JSON5 originals load lazily; capture the submitted bytes only afterward.
       await state.configRawOriginalParsePending;
-      if (!isCurrent()) {
-        return false;
-      }
+    }
+    if (!isCurrent() || !canSubmitDraft()) {
+      return false;
     }
     const raw = serializeFormForSubmit(state);
-    // The serialized candidate includes schema coercion; a live draft can
-    // change while the request is pending, so never infer from it afterward.
     submittedFormRaw = state.configFormMode === "form" ? raw : null;
     const baseHash = state.configDraftBaseHash ?? state.configSnapshot?.hash;
     if (!baseHash) {
       state.lastError = "Config hash missing; reload and retry.";
+      if (mode === "auto") {
+        state.configAutoSaveStatus = "error";
+      }
       return false;
     }
-    if (!isCurrent() || !canDispatch()) {
+    if (!canDispatch()) {
       return false;
     }
-    // Dispatch-phase report (ackHash null): if the connection dies before the
-    // ack arrives, reconnect reconciliation still needs the submitted bytes
-    // to recognize its own committed write. The post-ack report below
-    // overwrites this with the real hash.
+    if (mode === "auto") {
+      state.configAutoSaveStatus = "saving";
+      state.lastError = null;
+      state.chatError = null;
+    }
+    // Dispatch bytes let reconnect recognize a committed write whose ack was lost.
     onSubmitted?.({ raw, ackHash: null });
-    const ack = await client.request(method, { raw, baseHash, ...extraParams });
-    // The gateway acks writes with the persisted snapshot hash. Adopt it as
-    // the new draft base; config.get remains the source of applied revision truth.
-    const ackHash = readAckHash(ack);
-    // Reported before the epoch check: dispose-chained teardown flushes need
-    // this flight's own submission even though state mutation may be blocked.
-    onSubmitted?.({ raw, ackHash });
+    const ack = await client.request<{ hash: string }>(
+      mode === "apply" ? "config.apply" : "config.set",
+      { raw, baseHash, ...(mode === "apply" ? { sessionKey: state.applySessionKey } : {}) },
+    );
+    // Report before the epoch fence: teardown can flush against this flight's ack.
+    onSubmitted?.({ raw, ackHash: ack.hash });
     if (!isCurrent()) {
       return false;
     }
-    // Same bytes-vs-submission rule as autosave: an edit made while this
-    // manual write was in flight must stay dirty (its autosave deferred into
-    // a trailing run), or adoption would snap the draft back to the older
-    // submitted bytes and silently discard the newer edit.
-    if (serializeFormForSubmit(state) === raw) {
-      state.configFormDirty = false;
+    // Compare before adoption: edits and reverts made in flight retain their intent.
+    state.configFormDirty = serializeFormForSubmit(state) !== raw;
+    if (!state.configFormDirty) {
       clearConfigDraftTracking(state);
-    } else {
-      state.configFormDirty = true;
     }
-    adoptConfigSetAck(state, raw, ackHash);
-    if (method === "config.apply") {
-      // Older gateways omit appliedConfigHash, so keep the former process-local
-      // behavior. New gateways replace this optimistic value on config.get.
-      state.configNeedsApply = false;
+    adoptConfigSetAck(state, raw, ack.hash);
+    state.configNeedsApply = mode !== "apply";
+    if (mode === "apply") {
       state.configAutoSaveStatus = "idle";
-    } else {
-      state.configNeedsApply = true;
     }
-    // Best-effort UI refresh; correctness no longer depends on it.
-    await loadConfig(state);
-    if (!isCurrent()) {
-      return false;
+    // Manual writes refresh resolved values and applied revision truth. Autosave
+    // already has its authoritative hash and must not lock editors with a reload.
+    if (mode !== "auto") {
+      await loadConfig(state);
+      if (!isCurrent()) {
+        return false;
+      }
     }
-    if (!ackHash) {
-      reconcileHashlessWriteReload(state, raw);
-    }
-    if (method === "config.set") {
-      // "Saved" would lie next to a draft the user re-dirtied during the
-      // reload; the rescheduled save reports its own completion.
+    if (mode !== "apply") {
       state.configAutoSaveStatus = state.configFormDirty ? "idle" : "saved";
     }
     return true;
@@ -408,15 +394,14 @@ async function submitConfigChange(
     if (isCurrent()) {
       state.lastError = formatConfigMutationError(err, submittedFormRaw);
       if (isConfigBaseHashConflictError(err)) {
-        // Applies conflict the same way saves do so the UI offers Reload.
         state.configAutoSaveStatus = "conflict";
-      } else if (method === "config.set") {
+      } else if (mode !== "apply") {
         state.configAutoSaveStatus = "error";
       }
     }
     return false;
   } finally {
-    if (isCurrent()) {
+    if (busyKey && isCurrent()) {
       state[busyKey] = false;
     }
   }
@@ -445,122 +430,10 @@ export function teardownFlushConfigDraft(
   void client.request("config.set", { raw, baseHash }).catch(() => undefined);
 }
 
-/**
- * Auto-save submission for debounced form edits. Unlike the manual
- * `submitConfigChange` path it never raises `configSaving` (editors must stay
- * interactive while typing) and it only clears the dirty flag when the draft
- * still matches the submitted bytes — edits made while the request was in
- * flight stay dirty so the trailing save picks them up.
- */
-export async function autoSaveConfig(
-  state: RuntimeConfigState,
-  onAck?: (ackHash: string | null) => void,
-  canDispatch: () => boolean = () => true,
-): Promise<boolean> {
-  const client = state.client;
-  if (!client || !state.connected || !state.configFormDirty || state.configFormMode !== "form") {
-    return false;
-  }
-  const connectionEpoch = currentConfigConnectionEpoch(state);
-  const isCurrent = () => isCurrentConfigConnection(state, client, connectionEpoch);
-  if (state.configRawOriginalParsePending) {
-    // JSON5 originals parse asynchronously on first load; sanitize needs them.
-    // Await only when pending: teardown flushes rely on a synchronous prefix.
-    // Entry stays serialized across this await: runAutoSave's synchronous
-    // in-flight check folds concurrent triggers into one trailing save.
-    await state.configRawOriginalParsePending;
-    if (!isCurrent() || !state.configFormDirty || state.configFormMode !== "form") {
-      return false;
-    }
-  }
-  const submittedRaw = serializeFormForSubmit(state);
-  const baseHash = state.configDraftBaseHash ?? state.configSnapshot?.hash;
-  if (!baseHash) {
-    state.configAutoSaveStatus = "error";
-    state.lastError = "Config hash missing; reload and retry.";
-    return false;
-  }
-  if (!isCurrent() || !canDispatch()) {
-    return false;
-  }
-  state.configAutoSaveStatus = "saving";
-  state.lastError = null;
-  state.chatError = null;
-  try {
-    const ack = await client.request("config.set", { raw: submittedRaw, baseHash });
-    // The gateway acks with the persisted snapshot hash. Applied revision
-    // truth arrives on config.get.
-    const ackHash = readAckHash(ack);
-    // Reported before the epoch check: dispose-chained teardown flushes need
-    // this flight's own ack even though state mutation below is blocked.
-    onAck?.(ackHash);
-    if (!isCurrent()) {
-      return false;
-    }
-    state.configNeedsApply = true;
-    // The submitted bytes are now the authoritative original: a draft that no
-    // longer matches them (mid-flight edits, or a revert back to the pre-save
-    // value) stays dirty so the trailing save runs. Computed before adoption
-    // so the comparison sees the pre-save snapshot for reverted-clean drafts.
-    const drained = serializeFormForSubmit(state) === submittedRaw;
-    if (drained) {
-      state.configFormDirty = false;
-      clearConfigDraftTracking(state);
-    } else {
-      state.configFormDirty = true;
-    }
-    adoptConfigSetAck(state, submittedRaw, ackHash);
-    if (!ackHash) {
-      // Only a hashless ack needs a reload to re-derive the snapshot. With a
-      // hash the adopted snapshot IS authoritative, and reloading here would
-      // flash configLoading and lock the editors between keystrokes.
-      await loadConfig(state);
-      if (!isCurrent()) {
-        return false;
-      }
-      reconcileHashlessWriteReload(state, submittedRaw);
-    }
-    // "Saved" would lie next to a still-dirty draft (edits during the
-    // request or reload); the trailing save reports its own completion.
-    state.configAutoSaveStatus = state.configFormDirty ? "idle" : "saved";
-    return true;
-  } catch (err) {
-    if (isCurrent()) {
-      state.lastError = formatConfigMutationError(err, submittedRaw);
-      state.configAutoSaveStatus = isConfigBaseHashConflictError(err) ? "conflict" : "error";
-    }
-    return false;
-  }
-}
-
-export async function saveConfig(
-  state: RuntimeConfigState,
-  onSubmitted?: (info: { raw: string; ackHash: string | null }) => void,
-  canDispatch?: () => boolean,
-): Promise<boolean> {
-  return submitConfigChange(state, "config.set", "configSaving", {}, onSubmitted, canDispatch);
-}
-
-export async function applyConfig(
-  state: RuntimeConfigState,
-  canDispatch?: () => boolean,
-): Promise<boolean> {
-  return submitConfigChange(
-    state,
-    "config.apply",
-    "configApplying",
-    {
-      sessionKey: state.applySessionKey,
-    },
-    undefined,
-    canDispatch,
-  );
-}
-
 export async function patchConfig(
   state: RuntimeConfigState,
   options: ConfigPatchOptions,
-  onAck?: (ack: ConfigPatchAck, snapshotAtDispatch: ConfigSnapshot) => Promise<void> | void,
+  onAck?: (ack: ConfigPatchAck, snapshotAtDispatch: ConfigSnapshot) => void,
 ): Promise<boolean> {
   const client = state.client;
   const currentSnapshot = state.configSnapshot;
@@ -593,20 +466,9 @@ export async function patchConfig(
     if (!isCurrentConfigConnection(state, client, connectionEpoch)) {
       return false;
     }
-    const committed = ack.noop !== true;
-    if (committed) {
-      // The patch is committed once the gateway acknowledges it. Preserve
-      // that fact even if a legacy hash-only ack requires a fallible refresh.
-      state.configNeedsApply = true;
-    }
-    await onAck?.(ack, currentSnapshot);
-    if (!isCurrentConfigConnection(state, client, connectionEpoch)) {
-      return false;
-    }
-    if (committed) {
-      // A successful acknowledgement refresh may publish the previous
-      // applied revision. Keep the existing immediate apply-needed signal;
-      // reconcileAppliedRefresh replaces it with authoritative process truth.
+    onAck?.(ack, currentSnapshot);
+    if (ack.noop !== true) {
+      // The commit is authoritative; polling config.get reconciles applied truth.
       state.configNeedsApply = true;
     }
     // A patch acknowledges only its own intent; it cannot reconcile a separate
@@ -634,19 +496,14 @@ export function adoptConfigPatchAck(
   ack: ConfigPatchAck,
   snapshotAtDispatch: ConfigSnapshot,
 ) {
-  const ackConfig = asConfigRecord(ack.config);
-  const ackHash = readAckHash(ack);
-  if (!ackConfig) {
-    return;
-  }
   const currentSnapshot = state.configSnapshot ?? snapshotAtDispatch;
   const raw =
-    ack.noop === true ? (currentSnapshot.raw ?? state.configRaw) : serializeConfigForm(ackConfig);
+    ack.noop === true ? (currentSnapshot.raw ?? state.configRaw) : serializeConfigForm(ack.config);
   applyConfigSnapshot(state, {
     ...currentSnapshot,
-    config: ackConfig,
-    sourceConfig: ackConfig,
-    hash: ackHash ?? currentSnapshot.hash ?? null,
+    config: ack.config,
+    sourceConfig: ack.config,
+    hash: ack.noop === true ? currentSnapshot.hash : ack.hash,
     raw,
     valid: true,
     issues: [],

--- a/ui/src/lib/config/config-patch-coordinator.ts
+++ b/ui/src/lib/config/config-patch-coordinator.ts
@@ -1,4 +1,3 @@
-import { asNullableRecord as asConfigRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   adoptConfigPatchAck,
   patchConfig,
@@ -7,15 +6,13 @@ import {
 import {
   currentConfigConnectionEpoch,
   isCurrentConfigConnection,
-  nextRequestVersion,
   type RuntimeConfigState,
 } from "./config-state-model.ts";
 
 export function createConfigPatchCoordinator(options: {
   state: RuntimeConfigState;
   dispatch: (task: () => Promise<boolean>) => Promise<boolean>;
-  refresh: () => Promise<boolean>;
-  resetConfigLoad: () => void;
+  invalidateConfigLoad: () => void;
   cancelAppliedRefresh: () => void;
   reconcileAppliedRefresh: () => void;
   reconcileDraft: () => void;
@@ -44,29 +41,10 @@ export function createConfigPatchCoordinator(options: {
           if (!client || !state.configSnapshot || resolved.options.canDispatch?.() === false) {
             return false;
           }
-          const patched = await patchConfig(
-            state,
-            resolved.options,
-            async (ack, snapshotAtDispatch) => {
-              // The ack is newer than every config.get that began before it.
-              // Invalidate those loads before publishing the acknowledged revision.
-              options.resetConfigLoad();
-              nextRequestVersion(state, "config");
-              state.configLoading = false;
-              if (asConfigRecord(ack.config)) {
-                adoptConfigPatchAck(state, ack, snapshotAtDispatch);
-                return;
-              }
-              // A hash-only acknowledgement needs an authoritative document before
-              // its revision can become the base of another write.
-              if (!(await options.refresh())) {
-                throw new Error(
-                  state.lastError ??
-                    "The configuration patch completed, but its authoritative refresh failed.",
-                );
-              }
-            },
-          );
+          const patched = await patchConfig(state, resolved.options, (ack, snapshotAtDispatch) => {
+            options.invalidateConfigLoad();
+            adoptConfigPatchAck(state, ack, snapshotAtDispatch);
+          });
           if (isCurrentConfigConnection(state, client, epoch)) {
             failedPatch = patched ? null : resolveOptions;
             if (patched) {

--- a/ui/src/lib/config/config-test-harness.ts
+++ b/ui/src/lib/config/config-test-harness.ts
@@ -99,7 +99,7 @@ export function createConfigServerMock() {
  * createConfigServerMock variant whose FIRST config.set stays pending until
  * `firstSet` resolves — for exercising mid-flight edits/reverts/teardown.
  */
-export function createDeferredSetServerMock(options: { legacyAck?: boolean } = {}) {
+export function createDeferredSetServerMock() {
   const firstSet = deferred<unknown>();
   let hashCounter = 1;
   let storedRaw = '{\n  "count": 1\n}\n';
@@ -120,7 +120,7 @@ export function createDeferredSetServerMock(options: { legacyAck?: boolean } = {
       submissions.push({ raw, baseHash });
       storedRaw = raw;
       hashCounter += 1;
-      const ack = options.legacyAck ? {} : { hash: `hash-${hashCounter}` };
+      const ack = { hash: `hash-${hashCounter}` };
       return submissions.length === 1 ? firstSet.promise.then(() => ack) : Promise.resolve(ack);
     }
     if (method === "config.apply") {

--- a/ui/src/lib/config/config-write-coordinator.test.ts
+++ b/ui/src/lib/config/config-write-coordinator.test.ts
@@ -134,7 +134,7 @@ describe("config write coordinator", () => {
     expect(runtimeConfig.state.configFormDirty).toBe(false);
     expect(runtimeConfig.state.configAutoSaveStatus).toBe("saved");
     expect(runtimeConfig.state.configNeedsApply).toBe(true);
-    // The post-save reload rebased the clean draft onto the new hash.
+    // The acknowledgement rebased the clean draft onto the new hash.
     expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
     runtimeConfig.dispose();
   });
@@ -309,9 +309,9 @@ describe("config write coordinator", () => {
     runtimeConfig.dispose();
   });
 
-  it("skips the teardown flush when the settled flight acked without a hash", async () => {
+  it("skips the teardown flush when the pending save fails", async () => {
     vi.useFakeTimers();
-    const { request, submissions, firstSet } = createDeferredSetServerMock({ legacyAck: true });
+    const { request, submissions, firstSet } = createDeferredSetServerMock();
     const { runtimeConfig } = createConfigCapabilityHarness(
       request as GatewayBrowserClient["request"],
     );
@@ -325,7 +325,7 @@ describe("config write coordinator", () => {
     // final flush; failing closed beats clobbering a foreign write.
     runtimeConfig.patchForm(["count"], 3);
     runtimeConfig.dispose();
-    firstSet.resolve({});
+    firstSet.reject(new Error("write unavailable"));
     await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
     expect(submissions).toHaveLength(1);
   });
@@ -429,7 +429,7 @@ describe("config write coordinator", () => {
     });
     await vi.advanceTimersByTimeAsync(0);
     expect(drained).toBe(false);
-    patchGate.resolve({});
+    patchGate.resolve({ config: { count: 5 }, hash: "hash-2" });
     await vi.advanceTimersByTimeAsync(0);
     await drainPromise;
     await expect(patchPromise).resolves.toBe(true);
@@ -1015,7 +1015,7 @@ describe("config write coordinator", () => {
       if (method === "config.set" || method === "config.patch") {
         order.push(method);
         hashCounter += 1;
-        return Promise.resolve({ hash: `hash-${hashCounter}` });
+        return Promise.resolve({ config: { count: 2, other: true }, hash: `hash-${hashCounter}` });
       }
       return Promise.resolve({});
     });

--- a/ui/src/lib/config/config-write-coordinator.ts
+++ b/ui/src/lib/config/config-write-coordinator.ts
@@ -11,12 +11,12 @@ import {
   updateConfigRawValue,
 } from "./config-draft-model.ts";
 import {
-  applyConfig,
-  autoSaveConfig,
   executeConfigExternalMutation,
   loadConfig,
   refreshDraft,
-  saveConfig,
+  submitConfigDraft,
+  type ConfigSubmission,
+  type ConfigSubmissionObserver,
   teardownFlushConfigDraft,
   type ConfigWriteCoordinator,
   type ConfigMethod,
@@ -28,6 +28,7 @@ import {
   currentConfigConnectionEpoch,
   invalidateConfigConnection,
   isCurrentConfigConnection,
+  nextRequestVersion,
   resolveEditableSnapshotConfig,
   type RuntimeConfigGateway,
   type RuntimeConfigState,
@@ -56,6 +57,8 @@ type ConfigWriteCoordinatorContext = {
   isDisposed: () => boolean;
 };
 
+type ConfigWriteFlight = { promise: Promise<unknown>; submission: ConfigSubmission | null };
+
 export function createConfigWriteCoordinator({
   state,
   gateway,
@@ -73,13 +76,10 @@ export function createConfigWriteCoordinator({
   isDisposed,
 }: ConfigWriteCoordinatorContext): ConfigWriteCoordinator {
   let autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
-  let autoSaveInFlight: Promise<unknown> | null = null;
+  let inFlight: ConfigWriteFlight | null = null;
   let autoSaveTrailing = false;
   let autoSaveDraftConnection: { client: GatewayBrowserClient; epoch: number } | null = null;
   let autoSaveRequiresExplicitSubmit = false;
-  let lastFlightSubmittedRaw: string | null = null;
-  let lastFlightAckHash: string | null = null;
-  let manualSubmitInFlight: Promise<unknown> | null = null;
   // A write interrupted by a connection change may or may not have committed;
   // remembered across the disconnect so the reconnect can reconcile against a
   // fresh snapshot before autosave resumes.
@@ -104,10 +104,6 @@ export function createConfigWriteCoordinator({
   let writesSuspended = false;
   let writesResumed: (() => void) | null = null;
   let writesResumedPromise: Promise<void> = Promise.resolve();
-  // Submission info of the pending manual SAVE (applies never register:
-  // a post-apply write is meaningless while the gateway restarts, so the
-  // teardown flush fail-closes on them).
-  let manualFlightInfo: { raw: string; ackHash: string | null } | null = null;
   const canDispatchConfigMutation = (method: ConfigMethod): boolean => {
     const allowed = canCallConfigMethod(method);
     if (!allowed && state.connected) {
@@ -162,8 +158,7 @@ export function createConfigWriteCoordinator({
       state.configAutoSaveStatus = "idle";
     }
   };
-  // A stale base or a previous connection needs explicit recovery, including
-  // trailing and teardown saves that do not pass through the debounce scheduler.
+  // Stale bases and previous connections require explicit recovery, including teardown.
   const canAutoSaveDraft = () =>
     state.configAutoSaveStatus !== "conflict" &&
     !autoSaveRequiresExplicitSubmit &&
@@ -173,7 +168,7 @@ export function createConfigWriteCoordinator({
   const reconcileAutoSaveDraftConnection = () => {
     if (state.configFormDirty) {
       captureAutoSaveDraftConnection();
-    } else if (autoSaveInFlight === null && manualSubmitInFlight === null) {
+    } else if (inFlight === null) {
       clearAutoSaveDraftConnection();
     }
   };
@@ -183,6 +178,53 @@ export function createConfigWriteCoordinator({
       autoSaveTimer = null;
     }
     autoSaveTrailing = false;
+  };
+  const invalidateConfigLoad = () => {
+    resetConfigLoad();
+    nextRequestVersion(state, "config");
+    state.configLoading = false;
+  };
+  const trackWrite = <T>(
+    task: (onSubmitted: ConfigSubmissionObserver) => Promise<T>,
+    auto = false,
+  ): Promise<T> => {
+    const flight: ConfigWriteFlight = { promise: Promise.resolve(), submission: null };
+    const submit = task((submission) => {
+      flight.submission = submission;
+      // Keep the ack for teardown, but only a live flight may retire older loads.
+      if (submission.ackHash && !isDisposed() && inFlight === flight) {
+        invalidateConfigLoad();
+      }
+    });
+    flight.promise = submit
+      .catch(() => false)
+      .then((saved) => {
+        // Disconnect deregisters the flight; its late completion must not steal
+        // the replacement connection's registration or trailing save.
+        if (inFlight !== flight) {
+          return;
+        }
+        inFlight = null;
+        // Explicit operations own recovery status; a failed patch must keep its Retry action.
+        if (auto) {
+          reconcileAutoSaveDraftConnection();
+        }
+        const wantsTrailing =
+          autoSaveTrailing ||
+          (auto &&
+            saved &&
+            state.configFormDirty &&
+            state.configFormMode === "form" &&
+            autoSaveTimer === null);
+        autoSaveTrailing = false;
+        if (wantsTrailing && !isDisposed()) {
+          runAutoSave();
+        } else {
+          reconcileAppliedRefresh();
+        }
+      });
+    inFlight = flight;
+    return submit;
   };
   const runAutoSave = () => {
     if (
@@ -194,60 +236,25 @@ export function createConfigWriteCoordinator({
     ) {
       return;
     }
-    if (autoSaveInFlight ?? manualSubmitInFlight) {
-      // Exactly one trailing save catches edits made while a write (auto or
-      // manual — a concurrent config.set would race the same base hash) is
-      // in flight; further edits fold into that same trailing run.
+    if (inFlight) {
+      // Edits during any write fold into one trailing autosave on its new base.
       autoSaveTrailing = true;
       return;
     }
     cancelAppliedRefresh();
-    // Captured for teardown: dispose compares the latest draft against the
-    // in-flight submission to decide whether a final flush is needed, and the
-    // flush may only CAS against this flight's own ack hash.
-    lastFlightSubmittedRaw = serializeFormForSubmit(state);
-    lastFlightAckHash = null;
-    const flight = run(() =>
-      autoSaveConfig(
-        state,
-        (ackHash) => {
-          lastFlightAckHash = ackHash;
-        },
-        () => {
-          if (!canCallConfigMethod("config.set")) {
-            return false;
-          }
-          patches.clear();
-          return true;
-        },
-      ),
-    )
-      .catch(() => false)
-      .then((saved) => {
-        // A connection change deregisters flights; a stale completion must
-        // not clear a NEW flight's registration or steal its trailing state.
-        if (autoSaveInFlight !== flight) {
-          return;
-        }
-        autoSaveInFlight = null;
-        reconcileAutoSaveDraftConnection();
-        // One trailing save catches edits (or reverts back to the pre-save
-        // value) made while the request was in flight. A still-armed debounce
-        // timer owns its own save, and failed flights never self-retry.
-        const wantsTrailing =
-          autoSaveTrailing ||
-          (saved &&
-            state.configFormDirty &&
-            state.configFormMode === "form" &&
-            autoSaveTimer === null);
-        autoSaveTrailing = false;
-        if (wantsTrailing && !isDisposed()) {
-          runAutoSave();
-        } else {
-          reconcileAppliedRefresh();
-        }
-      });
-    autoSaveInFlight = flight;
+    void trackWrite(
+      (onSubmitted) =>
+        run(() =>
+          submitConfigDraft(state, "auto", onSubmitted, () => {
+            if (!canCallConfigMethod("config.set")) {
+              return false;
+            }
+            patches.clear();
+            return true;
+          }),
+        ),
+      true,
+    ).catch(() => undefined);
   };
   const flushScheduledAutoSave = () => {
     if (!autoSaveTimer) {
@@ -292,14 +299,14 @@ export function createConfigWriteCoordinator({
       if (flushScheduledDraft) {
         flushScheduledAutoSave();
       }
-      const flight = autoSaveInFlight ?? manualSubmitInFlight;
+      const flight = inFlight;
       if (!flight) {
         return;
       }
       // Race the connection wake: a disconnect deregisters in-flight writes,
       // and a drain already awaiting one resumes from that deregistration
       // instead of depending on the transport's close-time rejection order.
-      await Promise.race([flight, connectionWakePromise]);
+      await Promise.race([flight.promise, connectionWakePromise]);
       if (isDisposed()) {
         return;
       }
@@ -317,7 +324,7 @@ export function createConfigWriteCoordinator({
   // cannot trail the just-discarded bytes back to disk.
   const drainWritesForDiscard = async (): Promise<void> => {
     cancelScheduledAutoSave();
-    if (autoSaveInFlight ?? manualSubmitInFlight) {
+    if (inFlight) {
       suppressAutoSave = true;
       try {
         await drainPendingWrites();
@@ -332,7 +339,7 @@ export function createConfigWriteCoordinator({
   // finish draining and dispatch against the same base hash.
   let explicitOpQueue: Promise<unknown> | null = null;
   const afterPendingWritesSettled = <T>(
-    task: () => Promise<T>,
+    task: (onSubmitted: ConfigSubmissionObserver) => Promise<T>,
     unavailable: T,
     options: { flushScheduledDraft?: boolean; canDispatch?: () => boolean } = {},
   ): Promise<T> => {
@@ -352,7 +359,7 @@ export function createConfigWriteCoordinator({
       run(async () => {
         // Drain before the explicit op — otherwise an apply could race a
         // pending config.set on the same base hash into a CAS failure.
-        if (autoSaveInFlight ?? manualSubmitInFlight) {
+        if (inFlight) {
           await drainPendingWrites(options.flushScheduledDraft);
         }
         // The updater may have started while we drained; suspension must be a
@@ -368,26 +375,7 @@ export function createConfigWriteCoordinator({
         if (options.canDispatch && !options.canDispatch()) {
           return unavailable;
         }
-        manualFlightInfo = null;
-        const submit = task();
-        const settled = submit
-          .catch(() => unavailable)
-          .then(() => {
-            if (manualSubmitInFlight !== settled) {
-              return;
-            }
-            manualSubmitInFlight = null;
-            // Edits made during the manual flight deferred their autosave
-            // (runAutoSave treats manual flights as active writes); give them
-            // their one trailing run. runAutoSave self-guards suspension.
-            const wantsTrailing = autoSaveTrailing;
-            autoSaveTrailing = false;
-            if (wantsTrailing) {
-              runAutoSave();
-            }
-          });
-        manualSubmitInFlight = settled;
-        return await submit;
+        return await trackWrite(task);
       });
     const queued = explicitOpQueue ? explicitOpQueue.then(start) : start();
     const tail: Promise<unknown> = queued
@@ -408,8 +396,7 @@ export function createConfigWriteCoordinator({
     state.applySessionKey = snapshot.sessionKey;
     if (clientChanged || connectionChanged) {
       patches.clear();
-      const draftBelongsToPreviousConnection =
-        state.configFormDirty || autoSaveInFlight !== null || manualSubmitInFlight !== null;
+      const draftBelongsToPreviousConnection = state.configFormDirty || inFlight !== null;
       resetLoads();
       // A dead prior-connection flight must not keep the reconnected owner's
       // explicit-operation FIFO waiting forever.
@@ -427,7 +414,7 @@ export function createConfigWriteCoordinator({
         // normal while every subsequent edit silently never saves.
         pauseAutoSaveDraftConnection();
       }
-      if (autoSaveInFlight !== null || manualSubmitInFlight !== null) {
+      if (inFlight !== null) {
         // The epoch guard already blocks these flights from mutating state;
         // deregistering releases drain barriers and the trailing-save chain
         // promptly instead of waiting on the transport's close-time
@@ -435,10 +422,8 @@ export function createConfigWriteCoordinator({
         // requests on socket close, so nothing here can hang forever).
         // Remember the uncertain submission for reconnect reconciliation.
         hasInterruptedWrite = true;
-        interruptedWriteRaw =
-          autoSaveInFlight !== null ? lastFlightSubmittedRaw : (manualFlightInfo?.raw ?? null);
-        autoSaveInFlight = null;
-        manualSubmitInFlight = null;
+        interruptedWriteRaw = inFlight.submission?.raw ?? null;
+        inFlight = null;
         autoSaveTrailing = false;
       }
       // Re-arm before waking so a resumed drain that loops again races the
@@ -523,20 +508,13 @@ export function createConfigWriteCoordinator({
 
   const patches = createConfigPatchCoordinator({
     state,
-    // Patch errors replace display status; the reconnect latch still owns
-    // whether a surviving draft requires the explicit Save action.
     reconcileDraft: reconcileAutoSaveDraftConnection,
     dispatch: (task) =>
       afterPendingWritesSettled(task, false, {
         flushScheduledDraft: true,
         canDispatch: () => canDispatchConfigMutation("config.patch"),
       }),
-    refresh: () => {
-      const refresh = run(() => loadConfig(state));
-      void trackLoad("config", refresh);
-      return refresh;
-    },
-    resetConfigLoad,
+    invalidateConfigLoad,
     cancelAppliedRefresh,
     reconcileAppliedRefresh,
     scheduleAutoSave,
@@ -621,19 +599,18 @@ export function createConfigWriteCoordinator({
       return !canDispatch()
         ? Promise.resolve(false)
         : afterPendingWritesSettled(
-            async () => {
-              const client = state.client;
-              const epoch = currentConfigConnectionEpoch(state);
+            async (onSubmitted) => {
               bindDraftToExplicitSubmit();
               cancelAppliedRefresh();
               try {
-                const saved = await saveConfig(
+                const saved = await submitConfigDraft(
                   state,
-                  (info) => {
-                    if (client && isCurrentConfigConnection(state, client, epoch)) {
+                  "save",
+                  (submission) => {
+                    if (submission.ackHash === null) {
                       patches.clear();
                     }
-                    manualFlightInfo = info;
+                    onSubmitted(submission);
                   },
                   canDispatch,
                 );
@@ -666,7 +643,7 @@ export function createConfigWriteCoordinator({
                 return false;
               }
               try {
-                const applied = await applyConfig(state, () => {
+                const applied = await submitConfigDraft(state, "apply", undefined, () => {
                   if (!canDispatchConfigMutation("config.apply")) {
                     return false;
                   }
@@ -787,23 +764,17 @@ export function createConfigWriteCoordinator({
         !writesSuspended &&
         canAutoSaveDraft() &&
         canCallConfigMethod("config.set");
-      const autoFlight = autoSaveInFlight;
-      const pendingFlight = autoFlight ?? manualSubmitInFlight;
+      const pendingFlight = inFlight;
       cancelScheduledAutoSave();
       disposeAppliedRefresh();
       if (canFlush && pendingFlight) {
-        void pendingFlight.then(() => {
+        void pendingFlight.promise.then(() => {
           // The settled flight could not update dirty/base state past the
           // epoch guard; a draft whose bytes differ from that submission is a
           // newer edit and gets exactly one chained final save — never a
-          // parallel one. Auto flights report via lastFlight*, manual saves
-          // via manualFlightInfo; applies never register info (a post-apply
-          // write is meaningless while the gateway restarts), and without the
-          // flight's own ack hash there is no CAS base we can trust — both
-          // fail closed rather than risk clobbering a foreign write.
-          const submitted = autoFlight
-            ? { raw: lastFlightSubmittedRaw, ackHash: lastFlightAckHash }
-            : manualFlightInfo;
+          // parallel one. Applies and external mutations never register submission
+          // info: only this save's own ack is a safe CAS base for a final flush.
+          const submitted = pendingFlight.submission;
           const ackHash = submitted?.ackHash ?? null;
           const submittedRaw = submitted?.raw ?? null;
           // Bytes-vs-submission is the only trustworthy signal here: the
@@ -817,7 +788,7 @@ export function createConfigWriteCoordinator({
           }
         });
       } else if (canFlush && state.configFormDirty) {
-        void autoSaveConfig(state, undefined, () => canCallConfigMethod("config.set"));
+        void submitConfigDraft(state, "auto", undefined, () => canCallConfigMethod("config.set"));
       }
       invalidateConfigConnection(state);
       state.connected = false;

--- a/ui/src/lib/config/config-write-recovery.test.ts
+++ b/ui/src/lib/config/config-write-recovery.test.ts
@@ -103,6 +103,36 @@ function createRecoveryHarness(
 }
 
 describe("config write recovery", () => {
+  it("reconciles the bytes dispatched after original-config parsing settles", async () => {
+    vi.useFakeTimers();
+    const harness = createRecoveryHarness();
+    const { runtimeConfig, submissions } = harness;
+    const parsing = deferred<void>();
+    try {
+      await runtimeConfig.ensureLoaded();
+      runtimeConfig.state.configRawOriginalParsePending = parsing.promise;
+      runtimeConfig.patchForm(nodePath, "before-parse");
+      await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+      expect(submissions).toHaveLength(0);
+
+      runtimeConfig.patchForm(nodePath, "dispatched");
+      parsing.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(submissions).toEqual([{ raw: rawForNode("dispatched"), baseHash: "before" }]);
+
+      runtimeConfig.patchForm(nodePath, "newer");
+      await harness.reconnect();
+      expect(runtimeConfig.state.configDraftBaseHash).toBe("own-commit");
+      expect(runtimeConfig.state.configForm).toEqual(nodeConfig("newer"));
+      expect(runtimeConfig.state.configAutoSaveStatus).toBe("paused");
+      await expect(runtimeConfig.save()).resolves.toBe(true);
+      expect(submissions[1]).toEqual({ raw: rawForNode("newer"), baseHash: "own-commit" });
+    } finally {
+      parsing.resolve();
+      harness.dispose();
+    }
+  });
+
   it("retains pending plugin allowlist ownership without removing authored entries", async () => {
     vi.useFakeTimers();
     const harness = createRecoveryHarness(

--- a/ui/src/lib/config/runtime-config-capability.test.ts
+++ b/ui/src/lib/config/runtime-config-capability.test.ts
@@ -417,7 +417,7 @@ describe("runtime config capability", () => {
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(getCount).toBe(2);
-    patchGate.resolve({ hash: "hash-2" });
+    patchGate.resolve({ config: { count: 2 }, hash: "hash-2" });
     await vi.advanceTimersByTimeAsync(0);
     await expect(patchPromise).resolves.toBe(true);
     runtimeConfig.dispose();
@@ -689,7 +689,10 @@ describe("runtime config capability", () => {
       if (method === "config.set") {
         return deadSet.promise;
       }
-      return Promise.resolve({});
+      return Promise.resolve({
+        config: { count: 1, ui: { prefs: { themeMode: "dark" } } },
+        hash: "hash-2",
+      });
     });
     const { runtimeConfig, publish } = createConfigCapabilityHarness(
       request as GatewayBrowserClient["request"],
@@ -737,7 +740,7 @@ describe("runtime config capability", () => {
     await vi.waitFor(() => expect(patchCalls).toBe(1));
     publish(false);
     publish(true);
-    firstPatch.resolve({});
+    firstPatch.resolve({ config: { count: 1 }, noop: true });
 
     await expect(stalePatch).resolves.toBe(false);
     await expect(staleSet).resolves.toBe(false);
@@ -776,7 +779,7 @@ describe("runtime config capability", () => {
       auth: { role: "operator", scopes: ["operator.read"] },
       features: { methods: ["config.get", "config.patch", "config.set"] },
     } as GatewayHelloOk);
-    firstPatch.resolve({});
+    firstPatch.resolve({ config: { count: 1 }, noop: true });
 
     await patch;
     await expect(save).resolves.toBe(false);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the same repository; maintainers retain repository branch access.

</details>

## What Problem This Solves

Fixes an issue where users editing Control UI settings during an autosave could recover onto the wrong saved revision after a lost acknowledgement. It also fixes an older refresh response replacing a setting that the Gateway had already acknowledged as saved.

## Why This Change Was Made

Autosave and explicit Save/Apply now share one draft submission executor and one current-flight record. The record captures the bytes actually dispatched after parsing, retains acknowledgement metadata for teardown, and prevents a replaced connection's completion from changing the current flight. Successful live save acknowledgements retire older config loads before adopting the saved revision. The existing patch coordinator retains failed-patch retry and reconnect/conflict status; shared flight settlement leaves explicit operations in charge of that recovery state.

The change removes duplicate save bookkeeping and unsupported hashless-success reload paths. Current and stable `v2026.9.1` Gateway write producers return a persisted hash or fail; the supported no-op `config.patch` response remains hashless and preserves its existing draft/hash behavior. UI and Gateway ship together. No configuration keys, defaults, persistence formats, protocol fields, or operator steps change. Production code is **207 lines smaller**; tests/test support are **68 lines smaller**, and the assertion baseline loses one obsolete entry.

## User Impact

Settings keep edits made during an in-flight save, recover a lost acknowledgement using the submitted content, and retain the acknowledged value when an older refresh arrives late. Raw Save, Apply, autosave, explicit reload, compare-and-swap conflicts, reconnect pause, FIFO writes, and teardown retain their existing behavior.

## Evidence

- Two regressions were captured failing on the original code: edits while original-config parsing is pending followed by lost-ack recovery, and an ordinary refresh returning after autosave acknowledgement. The latter also failed on the initial consolidation; the shared acknowledgement boundary now fixes it. The patch sibling and a later deliberate refresh remain covered.
- `node scripts/run-vitest.mjs ui/src/lib/config`: **161 tests passed across 9 files** on the initial candidate. Baseline owner suite: 163 passed; removed cases solely modeled unsupported acknowledgement shapes.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/config-safe-write.e2e.test.ts ui/src/e2e/config-quick-thinking-persistence.e2e.test.ts`: **12 Chromium E2Es passed**, including conflict, Apply, reconnect, Raw revert, lost acknowledgement, exact large identifiers, and quick-thinking persistence.
- Full baseline `pnpm build`, final `pnpm ui:build`, and explicit changed-path checks passed, including UI/core-test typechecks, formatting, assertion guard, dead exports, i18n and applicable lint. Independent Codex review found no actionable P0–P2 issue; a separate owner-boundary review closed the stale-load finding after examining both failing runs and the final fix.
- **Real isolated Gateway + built UI, before and after the initial consolidation:** opened the normal dashboard handoff in Chromium; changed Ack Reaction Emoji through the form; saved a different value through Raw; toggled Code Mode through its real patch action; independently checked persisted config through the CLI. Both runs returned hash-bearing set/patch acknowledgements, and the deliberate no-op patch returned config with no hash. The initial candidate separately passed normal CLI `config.apply` on a settled hot snapshot and confirmed the applied revision. Served document and asset hashes distinguish the baseline and candidate builds.

The hot-reloaded setting correctly had no UI Apply button on either build. UI Apply success is covered by the bundled browser harness; the real successful Apply call above is separate CLI protocol proof. A baseline attempt using a restart-required diagnostics setting remained pending while the normal Gateway deferred restart behind active requests. That existing Gateway restart/apply lifecycle case is a named follow-up, not claimed as passing live UI proof or repaired here.

All screenshots below were fully inspected and contain only synthetic isolated settings. They show the existing presentation preserved by the refactor.

| Real Gateway form autosave before | Real Gateway form autosave after |
| --- | --- |
| ![Before: synthetic Ack Reaction Emoji autosaved](https://github.com/user-attachments/assets/d595a24b-6e01-4b66-bb3e-32f7b7f5de1c) | ![After: synthetic Ack Reaction Emoji autosaved](https://github.com/user-attachments/assets/c40550f3-4778-4a07-8a85-d9725de97590) |

Successful browser fixtures return the actual config/hash patch acknowledgement. Their 19 affected cases and 23 sibling cases passed during fixture correction, alongside 185 focused unit tests and isolated real-Gateway proof. No synthetic hashless-success compatibility was restored.

Current integration with main's Appearance retry owner passes **172 configuration tests across 10 files**, **20 Chromium cases across guarded writes, quick-thinking persistence, and Appearance defaults**, and the UI production build/performance gates. The existing paused-draft patch-recovery test caught a settlement interaction before publication: shared cleanup must not replace a failed patch's error/Retry state with the retained draft's pause status. The repair keeps that transition at the explicit-operation owner, and the unchanged ordered test now passes. Independent Codex P2 review is clean. Full changed gates and exact-head [CI run 33987684816](https://github.com/openclaw/openclaw/actions/runs/33987684816) pass. The complete source-frozen build passed in 13m 23s. Refreshed real-Gateway proof on head `59240b7` again passed form autosave, Raw Save, patch/no-op patch and separate CLI Apply with persisted revision readback; all three new synthetic captures were inspected and the owned Gateway was cleaned up.
