### PR TITLE
fix(sessions): release writer during worktree restoration

### DIFF
--- a/src/gateway/server-methods.authorization.test.ts
+++ b/src/gateway/server-methods.authorization.test.ts
@@ -293,14 +293,8 @@ describe("gateway method authorization", () => {
         },
       );
 
-      let continueHandler = () => {};
-      const handlerCanContinue = new Promise<void>((resolve) => {
-        continueHandler = resolve;
-      });
-      let markHandlerStarted = () => {};
-      const handlerStarted = new Promise<void>((resolve) => {
-        markHandlerStarted = resolve;
-      });
+      const handlerCanContinue = createDeferredCore();
+      const handlerStarted = createDeferredCore();
       const patchHandler = sessionMutationHandlers["sessions.patch"];
       if (!patchHandler) {
         throw new Error("sessions.patch handler is not registered");
@@ -342,14 +336,14 @@ describe("gateway method authorization", () => {
         } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"],
         extraHandlers: {
           "sessions.patch": async (options) => {
-            markHandlerStarted();
-            await handlerCanContinue;
+            handlerStarted.resolve();
+            await handlerCanContinue.promise;
             await patchHandler(options);
           },
         },
       });
 
-      await handlerStarted;
+      await handlerStarted.promise;
       await upsertSessionEntryCore(
         { agentId: "main", sessionKey },
         {
@@ -363,7 +357,7 @@ describe("gateway method authorization", () => {
       await patchSessionEntryCore({ agentId: "main", sessionKey }, () => ({
         visibility: "draft",
       }));
-      continueHandler();
+      handlerCanContinue.resolve();
       await request;
 
       expect(respond).toHaveBeenCalledWith(
@@ -599,12 +593,10 @@ describe("sessions.patchMany orchestration", () => {
           { sessionId: `session-label-race-${index}`, updatedAt: 1 },
         );
       }
-      const guardOrder: string[] = [];
       const assertCurrent = vi.fn(() => {
         throw new Error("outer all-target guard must not be delegated");
       });
       const assertTargetCurrent = vi.fn(({ sessionKey }: { sessionKey: string }) => {
-        guardOrder.push(sessionKey);
         if (sessionKey === sessionKeys[0]) {
           throw new SessionMutationAuthorizationChangedError({
             code: "INVALID_REQUEST",
@@ -625,7 +617,9 @@ describe("sessions.patchMany orchestration", () => {
       } as never);
 
       expect(assertCurrent).not.toHaveBeenCalled();
-      expect(guardOrder).toEqual(sessionKeys);
+      expect([
+        ...new Set(assertTargetCurrent.mock.calls.map(([target]) => target.sessionKey)),
+      ]).toEqual(sessionKeys);
       expect(respond).toHaveBeenCalledWith(
         true,
         {
@@ -903,7 +897,9 @@ describe("sessions.patchMany orchestration", () => {
       } as never);
 
       expect(assertCurrent).not.toHaveBeenCalled();
-      expect(assertTargetCurrent).toHaveBeenCalledTimes(3);
+      expect([
+        ...new Set(assertTargetCurrent.mock.calls.map(([target]) => target.sessionKey)),
+      ]).toEqual([0, 1, 2].map((index) => `agent:main:race-${index}`));
       expect(respond).toHaveBeenCalledWith(
         true,
         {

--- a/src/gateway/server-methods/sessions-mutations.owner.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.owner.test.ts
@@ -97,6 +97,59 @@ async function invoke(params: {
 }
 
 describe("sessions.patch", () => {
+  it.each(["thinking", "context", "both"] as const)(
+    "persists %s preference clears with an agent model rollback marker",
+    async (field) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+        const sessionKey = "agent:main:rollback-preferences";
+        const scope = { agentId: "main", env: state.env, sessionKey };
+        await upsertSessionEntryCore(scope, {
+          sessionId: "rollback-preferences",
+          updatedAt: 1,
+          providerOverride: "anthropic",
+          modelOverride: "claude-sonnet-4-6",
+          thinkingLevel: "high",
+          contextWindow: "extended",
+          modelFallback: {
+            prevProvider: "openai",
+            prevModel: "gpt-5.4",
+            prevThinkingLevel: "high",
+            prevContextWindow: "extended",
+            ts: 1,
+            source: "agent-patch",
+          },
+        });
+        const respond = vi.fn();
+        await sessionMutationHandlers["sessions.patch"]!({
+          params: {
+            key: sessionKey,
+            ...(field !== "context" ? { thinkingLevel: null } : {}),
+            ...(field !== "thinking" ? { contextWindow: null } : {}),
+          },
+          client: client(),
+          context: context({}),
+          respond,
+        } as never);
+        expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+        const entry = loadSessionEntry(scope);
+        expect(entry?.thinkingLevel).toBe(field === "context" ? "high" : undefined);
+        expect(entry?.contextWindow).toBe(field === "thinking" ? "extended" : undefined);
+        expect(entry?.modelFallback).toMatchObject({
+          prevProvider: "openai",
+          prevModel: "gpt-5.4",
+          ts: 1,
+          source: "agent-patch",
+        });
+        expect(entry?.modelFallback?.prevThinkingLevel).toBe(
+          field === "context" ? "high" : undefined,
+        );
+        expect(entry?.modelFallback?.prevContextWindow).toBe(
+          field === "thinking" ? "extended" : undefined,
+        );
+      });
+    },
+  );
+
   it("publishes saved settings when applying permissions to the active run fails", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
       const sessionKey = "agent:main:failed-permission-update";

--- a/src/gateway/server-methods/sessions-mutations.ts
+++ b/src/gateway/server-methods/sessions-mutations.ts
@@ -4,6 +4,7 @@ import {
   ErrorCodes,
   errorShape,
   missingScopeErrorShape,
+  type SessionsPatchManyResult,
   validateSessionsAssignOwnerParams,
   validateSessionsPatchManyParams,
   validateSessionsPatchParams,
@@ -27,10 +28,13 @@ import {
 } from "../session-sharing.js";
 import { resolveStoredSessionKeyForAgentStore } from "../session-store-key.js";
 import type { SessionActorProfileIdentity } from "../session-utils-contracts.js";
+import { projectSessionPatchResult } from "../session-utils-model.js";
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
-import { executeSessionPatch, executeSessionPatchMany } from "./sessions-patch-engine.js";
+import { executeSessionPatchMutations } from "./sessions-patch-engine.js";
+import { createCommitGuard } from "./sessions-patch-errors.js";
+import { sessionPatchTargetIdentity } from "./sessions-patch-expectations.js";
 import { loadSessionsRuntimeModule, requireSessionKey } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -61,18 +65,34 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const executed = await executeSessionPatchMany({
+    const targets = params.targets;
+    const executed = await executeSessionPatchMutations({
       client,
       context,
       patch: params.patch,
-      sessionMutationAuthorization,
-      targets: params.targets,
+      targets: targets.map((target) => ({
+        ...target,
+        commitGuard: createCommitGuard(target.key.trim(), () =>
+          sessionMutationAuthorization?.assertTargetCurrent({
+            sessionKey: target.key.trim(),
+            ...(target.agentId ? { agentId: target.agentId } : {}),
+          }),
+        ),
+      })),
     });
     if (!executed.ok) {
       respond(false, undefined, executed.error);
       return;
     }
-    respond(true, { outcomes: executed.outcomes }, undefined);
+    const outcomes: SessionsPatchManyResult["outcomes"] = [];
+    for (const [index, outcome] of executed.outcomes.entries()) {
+      const target = targets[index]!;
+      const identity = { key: target.key, ...(target.agentId ? { agentId: target.agentId } : {}) };
+      outcomes.push(
+        outcome.ok ? { ok: true, ...identity } : { ok: false, ...identity, error: outcome.error },
+      );
+    }
+    respond(true, { outcomes }, undefined);
   },
   "sessions.patch": async ({ params, respond, context, client, sessionMutationAuthorization }) => {
     if (!assertValidParams(params, validateSessionsPatchParams, "sessions.patch", respond)) {
@@ -91,17 +111,39 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
     if (!key) {
       return;
     }
-    const executed = await executeSessionPatch({
+    const patch = { ...params, key };
+    const target = sessionPatchTargetIdentity(patch);
+    const executed = await executeSessionPatchMutations({
       client,
       context,
-      patch: { ...params, key },
-      sessionMutationAuthorization,
+      patch,
+      targets: [
+        {
+          ...target,
+          commitGuard: createCommitGuard(target.key, sessionMutationAuthorization?.assertCurrent),
+        },
+      ],
     });
     if (!executed.ok) {
       respond(false, undefined, executed.error);
       return;
     }
-    respond(true, executed.result, undefined);
+    const outcome = executed.outcomes[0]!;
+    if (!outcome.ok) {
+      respond(false, undefined, outcome.error);
+      return;
+    }
+    const prepared = executed.preparedByIndex[0]!;
+    respond(
+      true,
+      projectSessionPatchResult({
+        ...prepared,
+        cfg: executed.cfg,
+        entry: outcome.entry,
+        modelCatalog: await executed.catalogs.available(prepared.targetAgentId),
+      }),
+      undefined,
+    );
   },
   "sessions.assignOwner": async ({ params, respond, context, client }) => {
     if (

--- a/src/gateway/server-methods/sessions-patch-archive.ts
+++ b/src/gateway/server-methods/sessions-patch-archive.ts
@@ -351,11 +351,10 @@ export async function prepareSessionPatchWorktreeTransition(params: {
       scope: params.scope,
       commitGuard,
     });
-  if (!params.archived) {
-    await synchronize(params.entry);
-  }
+  // Carry the exact restored binding through the later metadata commit.
+  const assertCommitAllowed = params.archived ? commitGuard : await synchronize(params.entry);
   return {
-    assertCommitAllowed: commitGuard,
+    assertCommitAllowed,
     afterCommit: params.archived
       ? async (entry) => {
           try {

--- a/src/gateway/server-methods/sessions-patch-engine.ts
+++ b/src/gateway/server-methods/sessions-patch-engine.ts
@@ -1,10 +1,13 @@
 import type {
   ErrorShape,
-  SessionsPatchManyResult,
   SessionsPatchParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { isInternalSessionEffectsKey } from "../../config/sessions/internal-session-key.js";
+import {
+  assertLifecycleTargetSnapshotUnchanged,
+  type SqliteLifecycleTargetSnapshot,
+} from "../../config/sessions/session-accessor.sqlite-entry-equality.js";
 import {
   applySessionEntryCanonicalReplacements,
   type SessionEntryCanonicalReplacement,
@@ -18,12 +21,11 @@ import { authorizeGatewaySessionCreation, resolveCreatorSandbox } from "../opera
 import { ADMIN_SCOPE } from "../operator-scopes.js";
 import { resolvePluginSessionOwnershipError } from "../session-plugin-ownership.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
-import { projectSessionPatchResult } from "../session-utils-model.js";
+import { SessionMutationAuthorizationChangedError } from "../session-sharing.js";
 import {
   resolveCanonicalGatewaySessionStoreKey,
   resolveCanonicalSessionEntryFromStoreKeys,
   resolveGatewaySessionStoreTargetWithStore,
-  type SessionsPatchResult,
 } from "../session-utils.js";
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
 import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
@@ -42,7 +44,6 @@ import {
 } from "./sessions-patch-catalog-preparation.js";
 import { publishSessionPatchEffects } from "./sessions-patch-effects.js";
 import {
-  createCommitGuard,
   invalidSessionPatchOutcome,
   sessionChangedError,
   unexpectedPatchError,
@@ -50,11 +51,7 @@ import {
 import * as sessionPatchExpectations from "./sessions-patch-expectations.js";
 import type { ActiveSessionPermissionChange } from "./sessions-patch-permissions.runtime.js";
 import { resolveSessionWorkerPlacementPatchError } from "./sessions-shared.js";
-import type {
-  GatewayClient,
-  GatewayRequestContext,
-  SessionMutationAuthorization,
-} from "./types.js";
+import type { GatewayClient, GatewayRequestContext } from "./types.js";
 import { preparePersonalModelSelection } from "./users-model-account-access.js";
 
 type PatchTargetIdentity = sessionUnreadAck.SessionPatchTargetIdentity;
@@ -75,6 +72,12 @@ type MutationOutcome =
   | { ok: true; applied: boolean; entry: SessionEntry; cleanupError?: ErrorShape }
   | { ok: false; error: ErrorShape };
 
+type WorktreeTransition = Awaited<ReturnType<typeof prepareSessionPatchWorktreeTransition>>;
+type GroupMutationOperation = {
+  replacements?: SessionEntryCanonicalReplacement[];
+  result: GroupMutationResult;
+};
+
 type GroupMutationResult =
   | { kind: "model-catalog" }
   | { kind: "complete"; outcomes: MutationOutcome[] };
@@ -89,7 +92,7 @@ type MutationCoreResult =
       catalogs: ReturnType<typeof createSessionPatchCatalogPreparation>;
     };
 
-async function executeSessionPatchMutations(params: {
+export async function executeSessionPatchMutations(params: {
   client: GatewayClient | null;
   context: GatewayRequestContext;
   patch: Omit<SessionsPatchParams, keyof PatchTargetIdentity>;
@@ -319,264 +322,277 @@ async function executeSessionPatchMutations(params: {
                   ...target.initialStoreKeys,
                 ]);
                 const requestedLabel = parseSessionLabel(first.fullPatch.label);
-                const worktreeTransitions = new Map<
-                  number,
-                  Awaited<ReturnType<typeof prepareSessionPatchWorktreeTransition>>
-                >();
-                const applyGroup = (catalogPreparation?: SessionPatchCatalogResult) =>
-                  applySessionEntryCanonicalReplacements<GroupMutationResult>({
-                    assertCommitAllowed: () => {
-                      // Fresh selections remain human-owned through the final commit;
-                      // existing session pins are intentionally not rebound to the caller.
-                      personalModelSelection?.assertCurrent();
-                      for (const transition of worktreeTransitions.values()) {
-                        transition.assertCommitAllowed();
+                const worktreeTransitions = new Map<number, WorktreeTransition>();
+                const commitGuards = new Set<() => ErrorShape | undefined>();
+                const projectGroup = async (
+                  entries: SqliteLifecycleTargetSnapshot,
+                  catalogPreparation?: SessionPatchCatalogResult,
+                ): Promise<GroupMutationOperation> => {
+                  const workingStore = Object.fromEntries(
+                    entries.flatMap(({ entry, sessionKey }) =>
+                      isInternalSessionEffectsKey(sessionKey) ? [] : [[sessionKey, entry] as const],
+                    ),
+                  );
+                  const labelOwners = new SessionLabelOwnerIndex(workingStore);
+                  const replacements: SessionEntryCanonicalReplacement[] = [];
+                  const projectedOutcomes: MutationOutcome[] = [];
+                  for (const target of group) {
+                    try {
+                      // Preflight facts can stale behind the writer queue; resolve this snapshot
+                      // again so a new legacy alias is rejected rather than promoted or deleted.
+                      const {
+                        entry: existingEntry,
+                        primaryKey,
+                        target: currentTarget,
+                      } = resolveCanonicalGatewaySessionStoreKey({
+                        cfg,
+                        key: target.key,
+                        store: workingStore,
+                        ...(target.requestedAgentId ? { agentId: target.requestedAgentId } : {}),
+                      });
+                      const creationError =
+                        !existingEntry &&
+                        authorizeGatewaySessionCreation({
+                          cfg,
+                          client,
+                          agentId: target.targetAgentId,
+                        });
+                      if (creationError) {
+                        projectedOutcomes.push({ ok: false, error: creationError });
+                        continue;
                       }
-                    },
-                    agentId: first.targetAgentId,
-                    sessionKeys: selectedSessionKeys,
-                    ...(requestedLabel.ok ? { includeLabelOwners: requestedLabel.label } : {}),
-                    storePath: first.storePath,
-                    skipMaintenance: true,
-                    update: async (entries) => {
-                      const workingStore = Object.fromEntries(
-                        entries.flatMap(({ entry, sessionKey }) =>
-                          isInternalSessionEffectsKey(sessionKey)
-                            ? []
-                            : [[sessionKey, entry] as const],
-                        ),
-                      );
-                      const labelOwners = new SessionLabelOwnerIndex(workingStore);
-                      const replacements: SessionEntryCanonicalReplacement[] = [];
-                      const projectedOutcomes: MutationOutcome[] = [];
-                      for (const target of group) {
-                        try {
-                          // Preflight facts can stale behind the writer queue; resolve this snapshot
-                          // again so a new legacy alias is rejected rather than promoted or deleted.
-                          const {
-                            entry: existingEntry,
-                            primaryKey,
-                            target: currentTarget,
-                          } = resolveCanonicalGatewaySessionStoreKey({
-                            cfg,
-                            key: target.key,
-                            store: workingStore,
-                            ...(target.requestedAgentId
-                              ? { agentId: target.requestedAgentId }
-                              : {}),
-                          });
-                          const creationError =
-                            !existingEntry &&
-                            authorizeGatewaySessionCreation({
-                              cfg,
-                              client,
-                              agentId: target.targetAgentId,
-                            });
-                          if (creationError) {
-                            projectedOutcomes.push({ ok: false, error: creationError });
-                            continue;
-                          }
-                          const candidateKeys = currentTarget.storeKeys;
-                          const ownershipError = resolvePluginSessionOwnershipError({
-                            action: "patch",
-                            entry: existingEntry,
-                            key: primaryKey,
-                            pluginOwnerId,
-                          });
-                          if (ownershipError) {
-                            projectedOutcomes.push({ ok: false, error: ownershipError });
-                            continue;
-                          }
-                          // Compare tool policy only inside the serialized writer snapshot. A
-                          // preflight comparison can stale behind another queued restriction.
-                          const expectedSessionChanged =
-                            (target.fullPatch.expectedSessionId !== undefined &&
-                              existingEntry?.sessionId !== target.fullPatch.expectedSessionId) ||
-                            (target.fullPatch.expectedLifecycleRevision !== undefined &&
-                              existingEntry?.lifecycleRevision !==
-                                target.fullPatch.expectedLifecycleRevision) ||
-                            sessionPatchExpectations.sessionPatchExpectationsChanged(
-                              existingEntry,
-                              target.fullPatch,
-                            );
-                          const lifecycleEntryRemoved =
-                            target.initialEntry !== undefined && existingEntry === undefined;
-                          const archiveTargetChanged =
-                            target.fullPatch.archived === true &&
-                            (target.initialEntry === undefined
-                              ? existingEntry !== undefined
-                              : existingEntry !== undefined &&
-                                (existingEntry.sessionId !== target.initialEntry.sessionId ||
-                                  existingEntry.lifecycleRevision !==
-                                    target.initialEntry.lifecycleRevision));
-                          if (
-                            expectedSessionChanged ||
-                            lifecycleEntryRemoved ||
-                            archiveTargetChanged
-                          ) {
-                            projectedOutcomes.push({
-                              ok: false,
-                              error: sessionChangedError(target.key),
-                            });
-                            continue;
-                          }
-                          if (target.fullPatch.archived === true) {
-                            const archiveError = validateSessionPatchArchiveProjection({
-                              cfg,
-                              existingEntry,
-                              fullPatch: target.fullPatch,
-                              key: target.key,
-                              ...(pluginOwnerId ? { pluginOwnerId } : {}),
-                              preparation: target.archivePreparation!,
-                              primaryKey,
-                            });
-                            if (archiveError) {
-                              projectedOutcomes.push({ ok: false, error: archiveError });
-                              continue;
-                            }
-                          }
-                          const unreadAck = resolveSessionUnreadAck(
-                            existingEntry,
-                            target.fullPatch,
-                          );
-                          if (unreadAck.kind === "missing") {
-                            projectedOutcomes.push({
-                              ok: false,
-                              error: sessionChangedError(target.key),
-                            });
-                            continue;
-                          }
-                          if (unreadAck.kind === "stale") {
-                            const authorizationFailure =
-                              params.targets[target.index]!.commitGuard();
-                            if (authorizationFailure) {
-                              projectedOutcomes.push({ ok: false, error: authorizationFailure });
-                              continue;
-                            }
-                            // A newer explicit marker owns the session until a later activation.
-                            projectedOutcomes.push({
-                              ok: true,
-                              applied: false,
-                              entry: unreadAck.entry,
-                            });
-                            continue;
-                          }
-                          const projection = await catalogs.project({
-                            agentId: target.targetAgentId,
-                            // Multi-target groups retain ordered effects and label claims.
-                            mode: group.length === 1 ? "prepare" : "ordered",
-                            catalog: catalogPreparation,
-                            projection: {
-                              cfg,
-                              creation,
-                              existingEntry,
-                              isLabelInUse: (label) =>
-                                labelOwners.isLabelInUse(label, candidateKeys),
-                              storeKey: primaryKey,
-                              agentId: target.requestedAgentId,
-                              patch: target.fullPatch,
-                              archivedBy: archiveActor,
-                              personalModelSelection,
-                            },
-                          });
-                          if (projection.kind === "model-catalog") {
-                            // No replacements or runtime effects exist yet. Release this
-                            // writer snapshot; completed preparation must use fresh rows.
-                            return { result: projection };
-                          }
-                          const projected = projection.result;
-                          if (!projected.ok) {
-                            projectedOutcomes.push(projected);
-                            continue;
-                          }
-                          const placementPatchError = resolveSessionWorkerPlacementPatchError({
-                            agentId: target.targetAgentId,
-                            cfg,
-                            context: params.context,
-                            entry: projected.entry,
-                            key: target.key,
-                            patch: target.fullPatch,
-                            sessionKey: primaryKey,
-                            validateModelRuntime: true,
-                          });
-                          if (placementPatchError) {
-                            projectedOutcomes.push(invalidSessionPatchOutcome(placementPatchError));
-                            continue;
-                          }
-                          const authorizationFailure = params.targets[target.index]!.commitGuard();
-                          if (authorizationFailure) {
-                            projectedOutcomes.push({ ok: false, error: authorizationFailure });
-                            continue;
-                          }
-                          if (
-                            existingEntry?.worktree &&
-                            typeof target.fullPatch.archived === "boolean"
-                          ) {
-                            const transition = await prepareSessionPatchWorktreeTransition({
-                              archived: target.fullPatch.archived,
-                              entry: existingEntry,
-                              context: params.context,
-                              scope: {
-                                agentId: target.targetAgentId,
-                                sessionKey: primaryKey,
-                                storePath: target.storePath,
-                              },
-                              authorize: params.targets[target.index]!.commitGuard,
-                              preparation: target.archivePreparation,
-                            });
-                            worktreeTransitions.set(target.index, transition);
-                          }
-                          if (permissionRuntime && existingEntry?.sessionId) {
-                            const permission =
-                              permissionRuntime.prepareSessionPatchPermissionChange({
-                                context: params.context,
-                                sessionId: existingEntry.sessionId,
-                                sessionKey: target.canonicalKey,
-                                agentId: target.targetAgentId,
-                                assertCurrent: params.targets[target.index]!.commitGuard,
-                              });
-                            if (!permission.ok) {
-                              projectedOutcomes.push(permission);
-                              continue;
-                            }
-                            target.permissionChange = permission.change;
-                          }
-                          const previousSessionKeys = candidateKeys.filter(
-                            (sessionKey) => sessionKey !== primaryKey && workingStore[sessionKey],
-                          );
-                          replacements.push({
-                            entry: projected.entry,
-                            previousSessionKeys,
-                            sessionKey: primaryKey,
-                          });
-                          const cloned = labelOwners.replaceEntry(
-                            candidateKeys,
-                            primaryKey,
-                            projected.entry,
-                          );
-                          projectedOutcomes.push({ ok: true, applied: true, entry: cloned });
-                        } catch (error) {
-                          projectedOutcomes.push({
-                            ok: false,
-                            error: unexpectedPatchError(target.key, error),
-                          });
+                      const candidateKeys = currentTarget.storeKeys;
+                      const ownershipError = resolvePluginSessionOwnershipError({
+                        action: "patch",
+                        entry: existingEntry,
+                        key: primaryKey,
+                        pluginOwnerId,
+                      });
+                      if (ownershipError) {
+                        projectedOutcomes.push({ ok: false, error: ownershipError });
+                        continue;
+                      }
+                      // Compare tool policy against the captured snapshot; the final
+                      // commit rejects a selection changed during preparation.
+                      const expectedSessionChanged =
+                        (target.fullPatch.expectedSessionId !== undefined &&
+                          existingEntry?.sessionId !== target.fullPatch.expectedSessionId) ||
+                        (target.fullPatch.expectedLifecycleRevision !== undefined &&
+                          existingEntry?.lifecycleRevision !==
+                            target.fullPatch.expectedLifecycleRevision) ||
+                        sessionPatchExpectations.sessionPatchExpectationsChanged(
+                          existingEntry,
+                          target.fullPatch,
+                        );
+                      const lifecycleEntryRemoved =
+                        target.initialEntry !== undefined && existingEntry === undefined;
+                      const archiveTargetChanged =
+                        target.fullPatch.archived === true &&
+                        (target.initialEntry === undefined
+                          ? existingEntry !== undefined
+                          : existingEntry !== undefined &&
+                            (existingEntry.sessionId !== target.initialEntry.sessionId ||
+                              existingEntry.lifecycleRevision !==
+                                target.initialEntry.lifecycleRevision));
+                      if (expectedSessionChanged || lifecycleEntryRemoved || archiveTargetChanged) {
+                        projectedOutcomes.push({
+                          ok: false,
+                          error: sessionChangedError(target.key),
+                        });
+                        continue;
+                      }
+                      if (target.fullPatch.archived === true) {
+                        const archiveError = validateSessionPatchArchiveProjection({
+                          cfg,
+                          existingEntry,
+                          fullPatch: target.fullPatch,
+                          key: target.key,
+                          ...(pluginOwnerId ? { pluginOwnerId } : {}),
+                          preparation: target.archivePreparation!,
+                          primaryKey,
+                        });
+                        if (archiveError) {
+                          projectedOutcomes.push({ ok: false, error: archiveError });
+                          continue;
                         }
                       }
-                      return {
-                        replacements,
-                        result: { kind: "complete", outcomes: projectedOutcomes },
-                      };
-                    },
+                      const unreadAck = resolveSessionUnreadAck(existingEntry, target.fullPatch);
+                      if (unreadAck.kind === "missing") {
+                        projectedOutcomes.push({
+                          ok: false,
+                          error: sessionChangedError(target.key),
+                        });
+                        continue;
+                      }
+                      if (unreadAck.kind === "stale") {
+                        const authorizationFailure = params.targets[target.index]!.commitGuard();
+                        if (authorizationFailure) {
+                          projectedOutcomes.push({ ok: false, error: authorizationFailure });
+                          continue;
+                        }
+                        // A newer explicit marker owns the session until a later activation.
+                        projectedOutcomes.push({
+                          ok: true,
+                          applied: false,
+                          entry: unreadAck.entry,
+                        });
+                        continue;
+                      }
+                      const projection = await catalogs.project({
+                        agentId: target.targetAgentId,
+                        // Multi-target groups retain ordered effects and label claims.
+                        mode: group.length === 1 ? "prepare" : "ordered",
+                        catalog: catalogPreparation,
+                        projection: {
+                          cfg,
+                          creation,
+                          existingEntry,
+                          isLabelInUse: (label) => labelOwners.isLabelInUse(label, candidateKeys),
+                          storeKey: primaryKey,
+                          agentId: target.requestedAgentId,
+                          patch: target.fullPatch,
+                          archivedBy: archiveActor,
+                          personalModelSelection,
+                        },
+                      });
+                      if (projection.kind === "model-catalog") {
+                        // No replacements or runtime effects exist yet. Release this
+                        // writer snapshot; completed preparation must use fresh rows.
+                        return { result: projection };
+                      }
+                      const projected = projection.result;
+                      if (!projected.ok) {
+                        projectedOutcomes.push(projected);
+                        continue;
+                      }
+                      const placementPatchError = resolveSessionWorkerPlacementPatchError({
+                        agentId: target.targetAgentId,
+                        cfg,
+                        context: params.context,
+                        entry: projected.entry,
+                        key: target.key,
+                        patch: target.fullPatch,
+                        sessionKey: primaryKey,
+                        validateModelRuntime: true,
+                      });
+                      if (placementPatchError) {
+                        projectedOutcomes.push(invalidSessionPatchOutcome(placementPatchError));
+                        continue;
+                      }
+                      const authorizationFailure = params.targets[target.index]!.commitGuard();
+                      if (authorizationFailure) {
+                        projectedOutcomes.push({ ok: false, error: authorizationFailure });
+                        continue;
+                      }
+                      if (
+                        existingEntry?.worktree &&
+                        typeof target.fullPatch.archived === "boolean"
+                      ) {
+                        const transition = await prepareSessionPatchWorktreeTransition({
+                          archived: target.fullPatch.archived,
+                          entry: existingEntry,
+                          context: params.context,
+                          scope: {
+                            agentId: target.targetAgentId,
+                            sessionKey: primaryKey,
+                            storePath: target.storePath,
+                          },
+                          authorize: params.targets[target.index]!.commitGuard,
+                          preparation: target.archivePreparation,
+                        });
+                        worktreeTransitions.set(target.index, transition);
+                      }
+                      if (permissionRuntime && existingEntry?.sessionId) {
+                        const permission = permissionRuntime.prepareSessionPatchPermissionChange({
+                          context: params.context,
+                          sessionId: existingEntry.sessionId,
+                          sessionKey: target.canonicalKey,
+                          agentId: target.targetAgentId,
+                          assertCurrent: params.targets[target.index]!.commitGuard,
+                        });
+                        if (!permission.ok) {
+                          projectedOutcomes.push(permission);
+                          continue;
+                        }
+                        target.permissionChange = permission.change;
+                      }
+                      const previousSessionKeys = candidateKeys.filter(
+                        (sessionKey) => sessionKey !== primaryKey && workingStore[sessionKey],
+                      );
+                      commitGuards.add(params.targets[target.index]!.commitGuard);
+                      replacements.push({
+                        entry: projected.entry,
+                        previousSessionKeys,
+                        sessionKey: primaryKey,
+                      });
+                      const cloned = labelOwners.replaceEntry(
+                        candidateKeys,
+                        primaryKey,
+                        projected.entry,
+                      );
+                      projectedOutcomes.push({ ok: true, applied: true, entry: cloned });
+                    } catch (error) {
+                      projectedOutcomes.push({
+                        ok: false,
+                        error: unexpectedPatchError(target.key, error),
+                      });
+                    }
+                  }
+                  return {
+                    replacements,
+                    result: { kind: "complete", outcomes: projectedOutcomes },
+                  };
+                };
+                const groupStore = {
+                  assertCommitAllowed: () => {
+                    // Fresh selections remain human-owned through the final commit;
+                    // existing session pins are intentionally not rebound to the caller.
+                    personalModelSelection?.assertCurrent();
+                    for (const guard of commitGuards) {
+                      const error = guard();
+                      if (error) {
+                        throw new SessionMutationAuthorizationChangedError(error);
+                      }
+                    }
+                    for (const transition of worktreeTransitions.values()) {
+                      transition.assertCommitAllowed();
+                    }
+                  },
+                  agentId: first.targetAgentId,
+                  sessionKeys: selectedSessionKeys,
+                  ...(requestedLabel.ok ? { includeLabelOwners: requestedLabel.label } : {}),
+                  storePath: first.storePath,
+                  skipMaintenance: true,
+                };
+                const readGroup = () =>
+                  applySessionEntryCanonicalReplacements({
+                    ...groupStore,
+                    update: (entries) => ({ result: entries }),
                   });
-                let groupResult = await applyGroup();
-                if (groupResult.kind === "model-catalog") {
+                let snapshot = await readGroup();
+                // Preserve ordered label and runtime decisions without holding the
+                // agent writer across catalog, allocation, or filesystem preparation.
+                let operation = await projectGroup(snapshot);
+                if (operation.result.kind === "model-catalog") {
                   const catalog = await catalogs.prepare(first.targetAgentId);
-                  groupResult = await applyGroup(catalog);
+                  snapshot = await readGroup();
+                  operation = await projectGroup(snapshot, catalog);
                 }
-                if (groupResult.kind !== "complete") {
+                const { replacements, result } = operation;
+                if (result.kind !== "complete") {
                   throw new Error("Session patch catalog preparation did not complete");
                 }
-                const groupOutcomes = groupResult.outcomes;
+                const groupOutcomes = replacements?.length
+                  ? await applySessionEntryCanonicalReplacements({
+                      ...groupStore,
+                      update: (entries) => {
+                        // Async preparation owns detached rows, not permission to overwrite
+                        // a changed target, alias, or requested-label owner.
+                        assertLifecycleTargetSnapshotUnchanged(snapshot, entries, "session patch");
+                        return { replacements, result: result.outcomes };
+                      },
+                    })
+                  : result.outcomes;
                 for (const [groupIndex, target] of group.entries()) {
                   const outcome = groupOutcomes[groupIndex]!;
                   outcomes[target.index] = outcome;
@@ -643,91 +659,5 @@ async function executeSessionPatchMutations(params: {
     ) as MutationOutcome[],
     preparedByIndex,
     catalogs,
-  };
-}
-
-export async function executeSessionPatchMany(params: {
-  client: GatewayClient | null;
-  context: GatewayRequestContext;
-  patch: Omit<SessionsPatchParams, keyof PatchTargetIdentity>;
-  sessionMutationAuthorization?: SessionMutationAuthorization;
-  targets: readonly PatchTargetIdentity[];
-}): Promise<
-  { ok: false; error: ErrorShape } | { ok: true; outcomes: SessionsPatchManyResult["outcomes"] }
-> {
-  const executed = await executeSessionPatchMutations({
-    client: params.client,
-    context: params.context,
-    patch: params.patch,
-    targets: params.targets.map((target) => ({
-      ...target,
-      commitGuard: createCommitGuard(target.key.trim(), () =>
-        params.sessionMutationAuthorization?.assertTargetCurrent({
-          sessionKey: target.key.trim(),
-          ...(target.agentId ? { agentId: target.agentId } : {}),
-        }),
-      ),
-    })),
-  });
-  if (!executed.ok) {
-    return executed;
-  }
-  const outcomes: SessionsPatchManyResult["outcomes"] = [];
-  for (const [index, outcome] of executed.outcomes.entries()) {
-    const target = params.targets[index]!;
-    if (outcome.ok) {
-      outcomes.push(
-        target.agentId
-          ? { ok: true, key: target.key, agentId: target.agentId }
-          : { ok: true, key: target.key },
-      );
-      continue;
-    }
-    outcomes.push(
-      target.agentId
-        ? { ok: false, key: target.key, agentId: target.agentId, error: outcome.error }
-        : { ok: false, key: target.key, error: outcome.error },
-    );
-  }
-  return { ok: true, outcomes };
-}
-
-export async function executeSessionPatch(params: {
-  client: GatewayClient | null;
-  context: GatewayRequestContext;
-  patch: SessionsPatchParams;
-  sessionMutationAuthorization?: SessionMutationAuthorization;
-}): Promise<{ ok: false; error: ErrorShape } | { ok: true; result: SessionsPatchResult }> {
-  const target = sessionPatchExpectations.sessionPatchTargetIdentity(params.patch);
-  const executed = await executeSessionPatchMutations({
-    client: params.client,
-    context: params.context,
-    patch: params.patch,
-    targets: [
-      {
-        ...target,
-        commitGuard: createCommitGuard(
-          target.key,
-          params.sessionMutationAuthorization?.assertCurrent,
-        ),
-      },
-    ],
-  });
-  if (!executed.ok) {
-    return executed;
-  }
-  const outcome = executed.outcomes[0]!;
-  if (!outcome.ok) {
-    return outcome;
-  }
-  const prepared = executed.preparedByIndex[0]!;
-  return {
-    ok: true,
-    result: projectSessionPatchResult({
-      ...prepared,
-      cfg: executed.cfg,
-      entry: outcome.entry,
-      modelCatalog: await executed.catalogs.available(prepared.targetAgentId),
-    }),
   };
 }

--- a/src/gateway/server.sessions.archive-worktree-lifecycle.test.ts
+++ b/src/gateway/server.sessions.archive-worktree-lifecycle.test.ts
@@ -4,7 +4,16 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { expect, onTestFinished, test, vi } from "vitest";
-import type { SessionsPatchManyResult } from "../../packages/gateway-protocol/src/index.js";
+import {
+  ErrorCodes,
+  errorShape,
+  type SessionsPatchManyResult,
+} from "../../packages/gateway-protocol/src/index.js";
+import {
+  clearActiveEmbeddedRun,
+  setActiveEmbeddedRun,
+} from "../agents/embedded-agent-runner/runs.js";
+import { createEmbeddedRunHandle } from "../agents/embedded-agent-runner/runs.test-support.js";
 import { getRegistryWorktree } from "../agents/worktrees/registry.js";
 import { acquireWorktreeRunLease } from "../agents/worktrees/run-lease.js";
 import {
@@ -16,11 +25,17 @@ import {
   applySessionEntryLifecycleMutation,
   loadSessionEntry,
   patchSessionEntryCore,
+  recordSessionParticipant,
 } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
+import { withOpenClawStateLease } from "../state/openclaw-state-lease.js";
 import { flushPendingSessionsChangedEvents } from "./server-methods/session-change-event.js";
+import { worktreesHandlers } from "./server-methods/worktrees.js";
+import { isSessionPermissionChangePending } from "./session-permission-change.js";
+import { SessionMutationAuthorizationChangedError } from "./session-sharing.js";
+import { embeddedRunMock } from "./test-helpers.runtime-state.js";
 import {
   directSessionReq,
   loadSeededTranscriptEvents,
@@ -30,6 +45,412 @@ import { setupGatewaySessionsWorktreeTestHarness } from "./test/server-sessions.
 
 const { createArchiveWorktreeFixture } = setupGatewaySessionsWorktreeTestHarness();
 const execFileAsync = promisify(execFile);
+
+test.each([
+  ["sessions.patch", true],
+  ["sessions.patch", false],
+  ["sessions.patchMany", true],
+  ["sessions.patchMany", false],
+] as const)(
+  "%s releases unrelated session writes while worktree allocation waits (archived=%s)",
+  async (method, archived) => {
+    const { key, sessionId, storePath, worktree } = await createArchiveWorktreeFixture();
+    const peer = await directSessionReq<{ key: string; sessionId: string }>("sessions.create", {
+      agentId: "main",
+    });
+    expect(peer.ok).toBe(true);
+    const batchPeer =
+      method === "sessions.patchMany"
+        ? await directSessionReq<{ key: string; sessionId: string }>("sessions.create", {
+            agentId: "main",
+          })
+        : undefined;
+    if (batchPeer) {
+      expect(batchPeer.ok).toBe(true);
+    }
+    await fs.writeFile(path.join(worktree.path, "draft.txt"), "preserved work\n");
+    if (!archived) {
+      expect(
+        await directSessionReq("sessions.patch", {
+          key,
+          expectedSessionId: sessionId,
+          archived: true,
+        }),
+      ).toMatchObject({ ok: true });
+    }
+
+    const entered = createDeferredCore();
+    const release = createDeferredCore();
+    const operationEntered = createDeferredCore();
+    // The same capacity lease serializes real worktree create, remove, and restore operations.
+    const allocation = withOpenClawStateLease(
+      {
+        scope: "core:managed-worktrees:create",
+        key: "capacity",
+        database: { scope: "shared" },
+        leaseMs: 60_000,
+        waitMs: 5_000,
+      },
+      async () => {
+        entered.resolve();
+        await release.promise;
+      },
+    );
+    const originalRemove = managedWorktrees.remove.bind(managedWorktrees);
+    const originalRestore = managedWorktrees.restore.bind(managedWorktrees);
+    const remove = vi.spyOn(managedWorktrees, "remove").mockImplementation((params) => {
+      operationEntered.resolve();
+      return originalRemove(params);
+    });
+    const restore = vi.spyOn(managedWorktrees, "restore").mockImplementation((params) => {
+      operationEntered.resolve();
+      return originalRestore(params);
+    });
+    let mutation: ReturnType<typeof directSessionReq> | undefined;
+    let independent: ReturnType<typeof directSessionReq> | undefined;
+    let successor: ReturnType<typeof directSessionReq> | undefined;
+    let independentDone = false;
+    let successorDone = false;
+    let independentCheck: Promise<void> | undefined;
+    try {
+      await Promise.race([entered.promise, allocation]);
+      mutation = directSessionReq(
+        method,
+        method === "sessions.patch"
+          ? { key, expectedSessionId: sessionId, archived }
+          : {
+              targets: [
+                { key, expectedSessionId: sessionId },
+                { key: batchPeer!.payload!.key, expectedSessionId: batchPeer!.payload!.sessionId },
+              ],
+              patch: { archived },
+            },
+      );
+      await Promise.race([operationEntered.promise, mutation]);
+      expect(archived ? remove : restore).toHaveBeenCalledOnce();
+      successor = directSessionReq("sessions.patch", { key, label: "Same session" }).then(
+        (result) => {
+          successorDone = true;
+          return result;
+        },
+      );
+      independent = directSessionReq("sessions.patch", {
+        key: peer.payload!.key,
+        label: "Independent session",
+      }).then((result) => {
+        independentDone = true;
+        return result;
+      });
+      independentCheck = vi.waitFor(() => expect(independentDone).toBe(true));
+      // Preserve the assertion until the lease and all pending writes are released.
+      await independentCheck.catch(() => undefined);
+      expect(successorDone).toBe(false);
+      expect(loadSessionEntry({ storePath, sessionKey: key })?.archivedAt).toEqual(
+        expect.any(Number),
+      );
+    } finally {
+      release.resolve();
+      await Promise.allSettled([allocation, mutation, independent, successor]);
+      remove.mockRestore();
+      restore.mockRestore();
+    }
+    await allocation;
+    expect(await mutation).toMatchObject(
+      method === "sessions.patch"
+        ? { ok: true }
+        : { ok: true, payload: { outcomes: [{ ok: true }, { ok: true }] } },
+    );
+    expect(await independent).toMatchObject({ ok: true });
+    expect(await successor).toMatchObject({ ok: true });
+    expect(loadSessionEntry({ storePath, sessionKey: peer.payload!.key })?.label).toBe(
+      "Independent session",
+    );
+    const entry = loadSessionEntry({ storePath, sessionKey: key });
+    expect(entry?.label).toBe("Same session");
+    if (archived) {
+      expect(entry?.archivedAt).toEqual(expect.any(Number));
+      await expect(fs.access(worktree.path)).rejects.toThrow();
+    } else {
+      expect(entry?.archivedAt).toBeUndefined();
+      await expect(fs.readFile(path.join(worktree.path, "draft.txt"), "utf8")).resolves.toBe(
+        "preserved work\n",
+      );
+    }
+    await independentCheck;
+  },
+);
+
+test("sessions.patchMany leaves a failed restore's label available to a later target", async () => {
+  const { key, sessionId, storePath, worktree } = await createArchiveWorktreeFixture();
+  const peer = await directSessionReq<{ key: string; sessionId: string }>("sessions.create", {
+    agentId: "main",
+  });
+  expect(peer.ok).toBe(true);
+  expect(
+    await directSessionReq("sessions.patch", { key, expectedSessionId: sessionId, archived: true }),
+  ).toMatchObject({
+    ok: true,
+  });
+  const restore = vi
+    .spyOn(managedWorktrees, "restore")
+    .mockRejectedValueOnce(new Error("checkout unavailable"));
+  try {
+    const result = await directSessionReq<SessionsPatchManyResult>("sessions.patchMany", {
+      targets: [
+        { key, expectedSessionId: sessionId },
+        { key: peer.payload!.key, expectedSessionId: peer.payload!.sessionId },
+      ],
+      patch: { archived: false, label: "Available label" },
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      payload: { outcomes: [{ ok: false, error: { code: "UNAVAILABLE" } }, { ok: true }] },
+    });
+    expect(loadSessionEntry({ storePath, sessionKey: key })?.archivedAt).toEqual(
+      expect.any(Number),
+    );
+    expect(loadSessionEntry({ storePath, sessionKey: key })?.label).not.toBe("Available label");
+    expect(loadSessionEntry({ storePath, sessionKey: peer.payload!.key })?.label).toBe(
+      "Available label",
+    );
+    await expect(fs.access(worktree.path)).rejects.toThrow();
+  } finally {
+    restore.mockRestore();
+  }
+});
+
+test.each(["identity", "label-owner", "participants", "removed"] as const)(
+  "sessions.patch preserves owner contracts after %s changes during restoration",
+  async (change) => {
+    const { key, sessionId, storePath, worktree } = await createArchiveWorktreeFixture();
+    const scope = { storePath, sessionKey: key };
+    const peer = await directSessionReq<{ key: string }>("sessions.create", { agentId: "main" });
+    expect(peer.ok).toBe(true);
+    expect(
+      await directSessionReq("sessions.patch", {
+        key,
+        expectedSessionId: sessionId,
+        archived: true,
+      }),
+    ).toMatchObject({ ok: true });
+    const originalRestore = managedWorktrees.restore.bind(managedWorktrees);
+    const restore = vi.spyOn(managedWorktrees, "restore").mockImplementationOnce(async (params) => {
+      const restored = await originalRestore(params);
+      // Another supported owner can act after allocation/Git completes, before metadata commits.
+      if (change === "identity") {
+        await patchSessionEntryCore(scope, () => ({ sessionId: "replacement-session" }), {
+          skipMaintenance: true,
+        });
+      } else if (change === "label-owner") {
+        expect(
+          await directSessionReq("sessions.patch", {
+            key: peer.payload!.key,
+            label: "Requested label",
+          }),
+        ).toMatchObject({ ok: true });
+      } else if (change === "participants") {
+        expect(
+          recordSessionParticipant(scope, {
+            identity: { type: "agent", id: "participant-agent" },
+            promptedAt: 100,
+          }),
+        ).toBe("inserted");
+      } else {
+        const respond = vi.fn();
+        await worktreesHandlers["worktrees.remove"]!({
+          params: { id: worktree.id },
+          respond,
+        } as never);
+        expect(respond).toHaveBeenCalledWith(
+          true,
+          expect.objectContaining({ removed: true }),
+          undefined,
+        );
+      }
+      return restored;
+    });
+    try {
+      const result = await directSessionReq("sessions.patch", {
+        key,
+        expectedSessionId: sessionId,
+        archived: false,
+        label: "Requested label",
+      });
+      const entry = loadSessionEntry(scope);
+      if (change === "participants" || change === "removed") {
+        expect(result.ok).toBe(true);
+        expect(entry?.archivedAt).toBeUndefined();
+        if (change === "participants") {
+          expect(entry?.participantCount).toBe(1);
+        }
+      } else {
+        expect(result.ok).toBe(false);
+        expect(entry?.archivedAt).toEqual(expect.any(Number));
+        expect(entry?.label).not.toBe("Requested label");
+      }
+      if (change === "identity") {
+        expect(entry?.sessionId).toBe("replacement-session");
+      }
+      if (change === "label-owner") {
+        expect(loadSessionEntry({ storePath, sessionKey: peer.payload!.key })?.label).toBe(
+          "Requested label",
+        );
+      }
+      if (change === "removed") {
+        // Manual checkout removal deliberately leaves conversation metadata and binding intact.
+        expect(entry?.worktree?.id).toBe(worktree.id);
+        expect(getRegistryWorktree(process.env, worktree.id)).toMatchObject({
+          removedAt: expect.any(Number),
+          snapshotRef: expect.any(String),
+        });
+        await expect(fs.access(worktree.path)).rejects.toThrow();
+      } else {
+        await expect(fs.access(worktree.path)).resolves.toBeUndefined();
+      }
+    } finally {
+      restore.mockRestore();
+    }
+  },
+);
+
+test.each(["accepted", "revoked", "replacement"] as const)(
+  "sessions.patchMany retains the earlier permission owner across a later restore (%s)",
+  async (scenario) => {
+    const { key, sessionId, storePath, worktree } = await createArchiveWorktreeFixture();
+    const created = await directSessionReq<{ key: string; sessionId: string }>("sessions.create", {
+      agentId: "main",
+    });
+    expect(created.ok).toBe(true);
+    const earlier = created.payload!;
+    const earlierScope = { storePath, sessionKey: earlier.key };
+    await patchSessionEntryCore(earlierScope, () => ({ permissionMode: "guarded" }), {
+      skipMaintenance: true,
+    });
+    expect(
+      await directSessionReq("sessions.patch", {
+        key,
+        expectedSessionId: sessionId,
+        archived: true,
+      }),
+    ).toMatchObject({ ok: true });
+    const originalApply = vi.fn(async (_mode: string | null, revoke: () => void) => {
+      revoke();
+      return true;
+    });
+    const originalAbort = vi.fn();
+    const original = {
+      ...createEmbeddedRunHandle({ abort: originalAbort }),
+      applyPermissionMode: originalApply,
+    };
+    const successorApply = vi.fn(async () => true);
+    const successorAbort = vi.fn();
+    const successor = {
+      ...createEmbeddedRunHandle({ abort: successorAbort }),
+      applyPermissionMode: successorApply,
+    };
+    setActiveEmbeddedRun(earlier.sessionId, original, earlier.key);
+    embeddedRunMock.activeIds.add(earlier.sessionId);
+    const reached = createDeferredCore();
+    const release = createDeferredCore();
+    const originalRestore = managedWorktrees.restore.bind(managedWorktrees);
+    const restore = vi.spyOn(managedWorktrees, "restore").mockImplementationOnce(async (params) => {
+      const result = await originalRestore(params);
+      reached.resolve();
+      await release.promise;
+      return result;
+    });
+    let revoked = false;
+    const pending = directSessionReq<SessionsPatchManyResult>(
+      "sessions.patchMany",
+      {
+        targets: [
+          { key: earlier.key, expectedSessionId: earlier.sessionId },
+          { key, expectedSessionId: sessionId },
+        ],
+        patch: { archived: false, permissionMode: "read-only" },
+      },
+      {
+        // Exercise the handler's supplied live-authority contract independently of row equality.
+        sessionMutationAuthorization: {
+          assertCurrent() {},
+          assertTargetCurrent({ sessionKey }) {
+            if (revoked && sessionKey === earlier.key) {
+              throw new SessionMutationAuthorizationChangedError(
+                errorShape(ErrorCodes.FORBIDDEN, "Earlier target authority revoked"),
+              );
+            }
+          },
+        },
+      },
+    );
+    try {
+      await Promise.race([reached.promise, pending]);
+      expect(restore).toHaveBeenCalledOnce();
+      expect(isSessionPermissionChangePending(earlier.sessionId)).toBe(true);
+      expect(originalApply).not.toHaveBeenCalled();
+      expect(loadSessionEntry(earlierScope)?.permissionMode).toBe("guarded");
+      expect(loadSessionEntry({ storePath, sessionKey: key })?.archivedAt).toEqual(
+        expect.any(Number),
+      );
+      if (scenario === "revoked") {
+        revoked = true;
+      }
+      if (scenario === "replacement") {
+        setActiveEmbeddedRun(earlier.sessionId, successor, earlier.key);
+      }
+      release.resolve();
+      const result = await pending;
+      if (scenario === "revoked") {
+        expect(result).toMatchObject({
+          ok: true,
+          payload: {
+            outcomes: [
+              { ok: false, error: { code: "FORBIDDEN" } },
+              { ok: false, error: { code: "FORBIDDEN" } },
+            ],
+          },
+        });
+        expect(loadSessionEntry(earlierScope)?.permissionMode).toBe("guarded");
+        expect(loadSessionEntry({ storePath, sessionKey: key })?.archivedAt).toEqual(
+          expect.any(Number),
+        );
+      } else {
+        expect(result).toMatchObject({
+          ok: true,
+          payload: {
+            outcomes: [
+              scenario === "accepted"
+                ? { ok: true }
+                : {
+                    ok: false,
+                    error: {
+                      code: "UNAVAILABLE",
+                      message: expect.stringContaining("Permissions were saved"),
+                    },
+                  },
+              { ok: true },
+            ],
+          },
+        });
+        expect(loadSessionEntry(earlierScope)?.permissionMode).toBe("read-only");
+        expect(loadSessionEntry({ storePath, sessionKey: key })?.archivedAt).toBeUndefined();
+      }
+      expect(originalApply).toHaveBeenCalledTimes(scenario === "accepted" ? 1 : 0);
+      expect(originalAbort).not.toHaveBeenCalled();
+      expect(successorApply).not.toHaveBeenCalled();
+      expect(successorAbort).not.toHaveBeenCalled();
+      expect(isSessionPermissionChangePending(earlier.sessionId)).toBe(false);
+      await expect(fs.access(worktree.path)).resolves.toBeUndefined();
+    } finally {
+      release.resolve();
+      await Promise.allSettled([pending]);
+      restore.mockRestore();
+      clearActiveEmbeddedRun(earlier.sessionId, original, earlier.key);
+      clearActiveEmbeddedRun(earlier.sessionId, successor, earlier.key);
+      embeddedRunMock.activeIds.delete(earlier.sessionId);
+    }
+  },
+);
 
 test.each([
   ["sessions.patch", false, false],

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -3,7 +3,6 @@ export { resolveSessionStoreKey } from "./session-store-key.js";
 export type {
   GatewaySessionRow,
   SessionsListResult,
-  SessionsPatchResult,
   SessionsPreviewEntry,
   SessionsPreviewResult,
 } from "./session-utils.types.js";

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -1108,6 +1108,8 @@ describe("gateway sessions patch", () => {
         },
       } as SessionEntry,
     };
+    const input = store[MAIN_SESSION_KEY]!;
+    const before = structuredClone(input);
     const entry = expectPatchOk(
       await runPatch({ store, patch: { key: MAIN_SESSION_KEY, thinkingLevel: "low" } }),
     );
@@ -1121,6 +1123,7 @@ describe("gateway sessions patch", () => {
       ts: 1,
       source: "agent-patch",
     });
+    expect(input).toEqual(before);
   });
 
   test("clears the marker thinkingLevel restore when the user clears thinkingLevel", async () => {
@@ -1136,13 +1139,50 @@ describe("gateway sessions patch", () => {
         },
       } as SessionEntry,
     };
+    const input = store[MAIN_SESSION_KEY]!;
+    const before = structuredClone(input);
     const entry = expectPatchOk(
       await runPatch({ store, patch: { key: MAIN_SESSION_KEY, thinkingLevel: null } }),
     );
     expect(entry.thinkingLevel).toBeUndefined();
     expect(entry.modelFallback?.prevThinkingLevel).toBeUndefined();
     expect(entry.modelFallback?.prevModel).toBe(OPENAI_GPT_ID);
+    expect(input).toEqual(before);
   });
+
+  test.each([false, true])(
+    "projects context rollback metadata without mutating its input (clear thinking=%s)",
+    async (clearThinking) => {
+      const store = mainStoreEntry({
+        thinkingLevel: "high",
+        contextWindow: "extended",
+        modelFallback: {
+          prevModel: OPENAI_GPT_ID,
+          prevProvider: "openai",
+          prevThinkingLevel: "high",
+          prevContextWindow: "extended",
+          ts: 1,
+          source: "agent-patch",
+        },
+      });
+      const input = store[MAIN_SESSION_KEY]!;
+      const before = structuredClone(input);
+      const entry = expectPatchOk(
+        await runPatch({
+          store,
+          patch: {
+            key: MAIN_SESSION_KEY,
+            contextWindow: null,
+            ...(clearThinking ? { thinkingLevel: null } : {}),
+          },
+        }),
+      );
+      expect(entry.contextWindow).toBeUndefined();
+      expect(entry.modelFallback?.prevContextWindow).toBeUndefined();
+      expect(entry.modelFallback?.prevThinkingLevel).toBe(clearThinking ? undefined : "high");
+      expect(input).toEqual(before);
+    },
+  );
 
   test("clears pending live model switches for model reset patches", async () => {
     const store = mainStoreEntry({

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -681,22 +681,18 @@ function* projectSessionPatchSteps(
     return invalid(contextWindowPatch.error);
   }
 
-  // A thinkingLevel change made on its own (no model switch) never touches the
-  // agent-patch revert marker, so realign its restore target with the user's
-  // newer choice; otherwise a later model-failure revert clobbers it.
+  // Independent preference changes must survive a later model rollback. Copy
+  // the marker so previews and prepared patches keep their input snapshot intact.
   if (
-    "thinkingLevel" in patch &&
+    next.modelFallback?.source === "agent-patch" &&
     !("model" in patch) &&
-    next.modelFallback?.source === "agent-patch"
+    ("thinkingLevel" in patch || "contextWindow" in patch)
   ) {
-    next.modelFallback.prevThinkingLevel = next.thinkingLevel;
-  }
-  if (
-    "contextWindow" in patch &&
-    !("model" in patch) &&
-    next.modelFallback?.source === "agent-patch"
-  ) {
-    next.modelFallback.prevContextWindow = next.contextWindow;
+    next.modelFallback = {
+      ...next.modelFallback,
+      ...("thinkingLevel" in patch ? { prevThinkingLevel: next.thinkingLevel } : {}),
+      ...("contextWindow" in patch ? { prevContextWindow: next.contextWindow } : {}),
+    };
   }
 
   if ("sendPolicy" in patch) {


### PR DESCRIPTION
## What Problem This Solves

Restoring an archived worktree session could block settings updates to unrelated sessions on the same agent while allocation or Git work was pending.

## Why This Change Was Made

The patch owner now captures one canonical snapshot, prepares the ordered batch outside the physical SQLite writer, and performs one guarded replacement. The existing session lifecycle fence still serializes same-session changes; the final commit rechecks targets, aliases, label owners and authority while preserving independent participant updates.

A related projector fix copies the small model rollback marker before changing standalone thinking/context preferences. Its previous shallow-copy mutation could invalidate the prepared input snapshot. Redundant single/batch response adapters and their unused type export are removed. Authorization tests verify target order and persisted outcomes while permitting final revalidation. Production is net **−34 lines**, with no schema, dependency, configuration or public protocol change.

## User Impact

Other sessions can save settings while restoration waits. Batch ordering, failed-target label availability, permission-owner binding and archive cleanup remain intact. Concurrent changes to a selected target reject the stale patch instead of being overwritten.

## Evidence

- **Focused proof passed:** a six-suite 172-test run and a separate 48-test authorization/worktree run, covering real SQLite/Git/allocation behavior, target and label changes, participant merging, catalog preparation, permission revocation/replacement and projector input purity. The original owner fails both held-allocation restore regressions.
- **Built Gateway + authenticated WebSocket comparison:** candidate peer writes complete while allocation is held; the rebuilt baseline stays blocked in both single and batch cases. Both variants verify final files, metadata, ordered partial results and preference clears. The candidate also passes a real QA-channel inbound restore through the built private-QA plugins and mock provider. Both fixture states and all owned processes were cleaned up.
- Final canonical changed-file gate, private-QA full build and independent P0–P2 review passed. The build/wire proof uses isolated Linux Crabbox state; it is not a production latency benchmark or an installed npm-package claim.

The raw parent diff of 8e4eb78fa20b12a700cb60507fd15442b4c1c018 added restoration inside the existing replacement updater. This builds on the shared restore guard landed in #139051.
