### PR TITLE
test(update): isolate campaign RPC ledger state

### DIFF
--- a/src/gateway/server-methods/update-run-campaign.test.ts
+++ b/src/gateway/server-methods/update-run-campaign.test.ts
@@ -1,6 +1,6 @@
 // update.run campaign tests cover failure release and concurrent campaign ownership.
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateScheduleState } from "../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -8,6 +8,16 @@ import type { RespawnSupervisor } from "../../infra/supervisor-markers.js";
 import type { UpdateCampaignController } from "../../infra/update-campaign.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { withEnvAsync } from "../../test-utils/env.js";
+import { createTempHomeEnv, type TempHomeEnv } from "../../test-utils/temp-home.js";
+
+let ledgerHome: TempHomeEnv | undefined;
+beforeEach(async () => {
+  ledgerHome = await createTempHomeEnv("openclaw-update-campaign-rpc-");
+});
+afterEach(async () => {
+  await ledgerHome?.restore();
+  ledgerHome = undefined;
+});
 
 let currentCampaignId: string | undefined;
 let updateSchedule: UpdateScheduleState | null;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full release verification fails the Gateway update-status test after campaign RPC tests have run in the same worker.

## Why This Change Was Made

The campaign fixture invokes the real update-run ledger but did not own an isolated state directory. An active `campaign-1` row survived into the later status test. Reuse the existing temporary-home lifecycle at the producing fixture, as the other update RPC suites already do, and await cleanup before restoring the environment.

## User Impact

No product behavior changes. Release verification retains its strict status assertions without sharing campaign records between tests.

## Evidence

- Original ordered campaign/status reproduction: 35 passed, 1 failed with the same leaked active/last run as [full release CI](https://github.com/openclaw/openclaw/actions/runs/33966901455/job/101308702287).
- Same command after repair: all 36 passed. Related update, owner, campaign, effective-channel, and status suites: all 89 passed.
- Full changed-file gate and independent review through P2 passed.
- Existing assertions unchanged; no added production seam. Production delta: 0. Test fixture delta: +11/-1.
- Relevant fixture, ledger, and cleanup owners are byte-identical between the release reproduction and this main-based patch.

```sh
node scripts/run-vitest.mjs src/gateway/server-methods/update-run-campaign.test.ts src/gateway/server-methods/update-effective-channel.test.ts --maxWorkers=1 --no-file-parallelism
```
