### PR TITLE
fix(ci): prepare Watch toolchain for frozen release sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4842,7 +4842,8 @@ jobs:
 
       - &install_watch_rust_toolchain
         name: Install Watch Rust toolchain
-        if: env.HISTORICAL_TARGET != 'true'
+        # Frozen release sources can include Watch RTC even when they use compatibility CI.
+        if: env.HISTORICAL_TARGET != 'true' || hashFiles('apps/shared/OpenClawWatchRTC/Cargo.toml') != ''
         run: |
           set -euo pipefail
           export PATH="$HOME/.cargo/bin:$PATH"
@@ -4851,7 +4852,7 @@ jobs:
           rustup toolchain install "$watch_toolchain" --profile minimal --component rust-src
 
       - name: Test Watch RTC engine
-        if: matrix.phase == 'tests' && env.HISTORICAL_TARGET != 'true'
+        if: matrix.phase == 'tests' && (env.HISTORICAL_TARGET != 'true' || hashFiles('apps/shared/OpenClawWatchRTC/Cargo.toml') != '')
         working-directory: apps/shared/OpenClawWatchRTC
         run: |
           set -euo pipefail

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -131,6 +131,7 @@ function evaluateWorkflowExpression(
     dispatchId?: string;
     draft?: boolean;
     eventName: "pull_request" | "push" | "workflow_dispatch" | "repository_dispatch" | "schedule";
+    env?: Record<string, string>;
     frozenTarget?: boolean;
     fileHashes?: Record<string, string>;
     headRepository?: string;
@@ -222,6 +223,7 @@ function evaluateWorkflowExpression(
       target_ref: context.targetRef ?? "",
       use_github_hosted_runners: context.useGithubHostedRunners ?? false,
     },
+    env: context.env ?? {},
     matrix: context.matrix ?? {},
     runner: { environment: context.runnerEnvironment ?? "" },
     steps: context.steps ?? {},
@@ -9238,6 +9240,37 @@ server.listen(0, "127.0.0.1", () => {
       expect(existsSync(marker)).toBe(testCase.helperPresent);
     },
   );
+
+  it.each([
+    { historical: false, hasWatchRtc: true, expected: true },
+    { historical: false, hasWatchRtc: false, expected: true },
+    { historical: true, hasWatchRtc: true, expected: true },
+    { historical: true, hasWatchRtc: false, expected: false },
+  ])("prepares Watch RTC by source capability: %j", ({ historical, hasWatchRtc, expected }) => {
+    const workflow = readCiWorkflow();
+    for (const jobName of ["ios-build", "ios-screenshot-shard"]) {
+      const install = workflow.jobs[jobName].steps.find(
+        (step: WorkflowStep) => step.name === "Install Watch Rust toolchain",
+      );
+      const engine = workflow.jobs["ios-build"].steps.find(
+        (step: WorkflowStep) => step.name === "Test Watch RTC engine",
+      );
+      for (const phase of ["tests", "release"]) {
+        const context: Parameters<typeof evaluateWorkflowExpression>[1] = {
+          eventName: "workflow_dispatch",
+          repository: "openclaw/openclaw",
+          runAttempt: 1,
+          env: { HISTORICAL_TARGET: String(historical) },
+          matrix: { phase },
+          fileHashes: hasWatchRtc ? { "apps/shared/OpenClawWatchRTC/Cargo.toml": "present" } : {},
+        };
+        expect(evaluateWorkflowExpression(`\${{ ${install.if} }}`, context)).toBe(expected);
+        expect(evaluateWorkflowExpression(`\${{ ${engine.if} }}`, context)).toBe(
+          expected && phase === "tests",
+        );
+      }
+    }
+  });
 
   it("retries macOS release builds only when Sparkle metadata is incomplete", () => {
     const workflow = readCiWorkflow();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where frozen release validation skips the Rust prerequisite for sources that already contain standalone Watch voice, then fails during the iOS Watch WebRTC build. Full Release Validation [33966876950](https://github.com/openclaw/openclaw/actions/runs/33966876950) exposed this on the 2026.9.2 candidate.

## Why This Change Was Made

The compatibility-target flag means source and workflow revisions differ; it does not mean Watch RTC is absent. The shared prerequisite now checks the source-owned Cargo manifest, and the engine test uses the same capability condition. Current targets retain their existing fail-closed behavior. Truly older frozen targets without Watch RTC still skip the unavailable prerequisite.

## User Impact

Release maintainers can validate newer frozen sources with the required Watch build toolchain. No app behavior, native code, runner allocation, concurrency, or publication policy changes.

## Evidence

- The original iOS job skipped both the Rust install and engine test. The historical-source/present-module regression case fails before the repair and passes afterward; the guard covers current and historical targets, module presence/absence, test/release phases, and the shared screenshot prerequisite.
- The unchanged native build script rejects the missing pinned toolchain. After running the existing install step, the Watch simulator build produces arm64 and x86_64 archives, and all 12 RTC engine tests pass (Xcode 27). Xcode 26.6 is unavailable locally; the canonical iOS CI lane remains the platform proof.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts`: 441 passed, 2 skipped. `node --import tsx scripts/check-workflows.mts`: passed with task-local actionlint 1.7.12 and Python 3.12 (the default macOS Python 3.9 cannot install the pinned pre-commit version). Formatting and diff checks pass; independent review is clean through P2.
- The first CI run exposed the unrelated main Control UI import conflict after #138964. This branch is now rebased onto the canonical repair #139123; the Apple patch is byte-equivalent by stable patch ID. The full changed gate now passes, including root test types; all four Watch condition cases, the canonical workflow checker, and fresh independent P2 review pass after rebase. Exact-head CI remains the landing gate.
- Product runtime delta: 0. Workflow: +3/-2 (one explanatory comment); tests: +33/-0. No compatibility path or build-script fallback was introduced.
