### PR TITLE
fix(ci): restore prebuilt UI test admission

### DIFF
--- a/test/vitest/vitest.ui-e2e-prebuilt.global-setup.ts
+++ b/test/vitest/vitest.ui-e2e-prebuilt.global-setup.ts
@@ -13,7 +13,7 @@ import {
   resolveBuildRequirement,
   resolveRuntimePostBuildRequirement,
 } from "../../scripts/run-node.mts";
-import { isControlUiStartupAssetsReady } from "../../src/infra/control-ui-assets.ts";
+import { inspectControlUiRootAssets } from "../../src/infra/control-ui-assets.ts";
 
 declare module "vitest" {
   export interface ProvidedContext {
@@ -71,7 +71,7 @@ export function assertPrebuiltUiE2eRuntime(repoRoot: string): string {
     fail(runtime.reason);
   }
   const uiRoot = path.join(distRoot, "control-ui");
-  if (!isControlUiStartupAssetsReady(uiRoot)) {
+  if (inspectControlUiRootAssets(uiRoot).kind !== "ready") {
     fail("canonical Control UI assets are not ready");
   }
   const digest = createHash("sha256").update(head);


### PR DESCRIPTION
Related: #139081 (prepared real-Gateway parallel test setup), #138964 (canonical Control UI startup asset health).

## What Problem This Solves

Resolves a problem where the prepared real-Gateway UI test lane fails before starting tests after the startup asset-health refactor. The same stale import also fails the root test typecheck with TS2305.

## Why This Change Was Made

Use the current read-only Control UI root inspector and require its `ready` result. This preserves the removed helper’s completeness check while keeping Git/build-stamp freshness, required-output validation, and teardown generation checks with their existing owners.

## User Impact

Maintainers can run the prepared real-Gateway verification lane again. No product runtime or visual behavior changes.

## Evidence

- Before: the native root test typecheck fails with TS2305 on the removed export; the existing prebuilt fixture suite has four failures caused by the missing function.
- After: `node scripts/run-vitest.mjs test/vitest-ui-e2e-prebuilt.test.ts src/infra/control-ui-assets.test.ts` passes all 49 tests, including real Git/filesystem admission and native Vitest teardown outcomes.
- `node scripts/check-changed.mjs -- test/vitest/vitest.ui-e2e-prebuilt.global-setup.ts` passes, including the native root test typecheck and relevant lint/format guards.
- Independent Codex autoreview is clean through P2. Production delta is zero; test support changes two lines in and two out.

The successful CI artifact step remains the preparation owner. This repair preserves the existing UI completeness contract; it does not add a separate UI-to-HEAD identity attestation. Exact-head hosted CI is pending publication.
