### PR TITLE
refactor(gateway): share approval snapshot projection

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2825,7 +2825,7 @@ src/gateway/server-methods/agent-wait.ts	1
 src/gateway/server-methods/approval-publication.ts	4
 src/gateway/server-methods/approval-request-delivery.ts	1
 src/gateway/server-methods/approval-shared.ts	1
-src/gateway/server-methods/approval.ts	8
+src/gateway/server-methods/approval.ts	4
 src/gateway/server-methods/attachment-normalize.ts	1
 src/gateway/server-methods/base-hash.ts	1
 src/gateway/server-methods/channel-pairing.ts	3

--- a/src/gateway/server-methods/approval.ts
+++ b/src/gateway/server-methods/approval.ts
@@ -31,6 +31,7 @@ import {
   canResolveOperatorApproval,
   canReviewOperatorApproval,
 } from "../operator-approval-authorization.js";
+import { projectOperatorApprovalSnapshot } from "../operator-approval-snapshot.js";
 import {
   getOperatorApprovalDetailed,
   listTerminalOperatorApprovals,
@@ -61,24 +62,13 @@ function buildApprovalSnapshot(
   record: OperatorApprovalRecord,
   controlUiBasePath: string,
 ): ApprovalSnapshot | null {
-  const common = {
-    id: record.id,
-    status: record.status,
-    presentation: record.presentation,
-    urlPath: `${controlUiBasePath}/approve/${encodeURIComponent(record.id)}`,
-    createdAtMs: record.createdAtMs,
-    expiresAtMs: record.expiresAtMs,
-  };
-  if (record.status === "pending") {
-    return common as ApprovalSnapshot;
+  const snapshot = projectOperatorApprovalSnapshot(record, controlUiBasePath);
+  if (!snapshot || snapshot.status === "pending") {
+    return snapshot;
   }
-  if (record.resolvedAtMs === null || record.terminalReason === null) {
-    return null;
-  }
-  const terminal = {
-    ...common,
-    resolvedAtMs: record.resolvedAtMs,
-    reason: record.terminalReason,
+  // Terminal attribution belongs to RPC readers; session events omit it.
+  return {
+    ...snapshot,
     source: {
       ...(record.source.agentId ? { agentId: record.source.agentId } : {}),
       ...(record.source.sessionKey ? { sessionKey: record.source.sessionKey } : {}),
@@ -92,16 +82,6 @@ function buildApprovalSnapshot(
         }
       : {}),
   };
-  if (record.status === "allowed") {
-    if (record.decision !== "allow-once" && record.decision !== "allow-always") {
-      return null;
-    }
-    return { ...terminal, decision: record.decision } as ApprovalSnapshot;
-  }
-  if (record.status === "denied") {
-    return { ...terminal, decision: "deny" } as ApprovalSnapshot;
-  }
-  return terminal as ApprovalSnapshot;
 }
 
 function resolveApprovalResolver(client: GatewayClient | null): OperatorApprovalResolver {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Maintainers must keep approval lookup, history, resolution, and session-event snapshots consistent. This requested cleanup gives those surfaces one common set of pending/terminal validation and decision rules while preserving their different attribution fields.

## Why This Change Was Made

The RPC builder now uses the existing `projectOperatorApprovalSnapshot` and adds its terminal-only source/resolver attribution afterward. Session events continue using the unchanged common projection, which omits that attribution.

The two-file change removes 20 production lines (`+7/-27`). Its only other edit reduces the assertion baseline for the RPC module from eight to four, exactly matching the four removed casts. Tests are unchanged.

## User Impact

No user-visible behavior change. Approval statuses, decisions, URLs, terminal attribution, and session-event field omissions are preserved. Authorization, storage, and protocol contracts are unchanged.

## Evidence

Current head: `1623a031b55fa690284152592014d4b9d7356ac2`. `git range-diff` confirms an exact patch match to the original locally verified commit `657d816a26593cd68c92d562101b643101260b5b`, rebased onto repaired main `ff998e6df1d855e87df50a2ae0789f7a9759d694`.

- Historical local proof for the unchanged patch: the same **47** real-store handler/event tests passed before and after, covering attribution, complete event payloads, terminal states, invalid decisions, expiry, corruption, and competing resolutions.
- A source-extracted differential probe compared actual old/new builders over **7,200** combinations. Every decoded JSON result matched; the shared event projector is byte-identical. Some terminal RPC object-key insertion order changes without changing field values or omission semantics.
- The full local changed-file gate passed before the mechanical rebase, including production/core-test types, formatting, lint, ratchets, dependency/storage checks, and zero runtime import cycles.
- Fresh P2 autoreview and an independent source challenge were clean on the original patch. A separate read-only direct Codex review of the current exact head and repaired base found no actionable P0–P2 findings.
- **Current-head CI passed:** [run 33970796082](https://github.com/openclaw/openclaw/actions/runs/33970796082), including the successful [required `openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/33970796082/job/101320232271). Preflight tested merge `2c98b69ac4a242daaec078d7bfdcb49a582e5a83` with ordered parents `df78d38ccca76a823c712406dbef71d8f6a62534` and this PR head; the tested main ancestry includes `ff998e6`.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/139124#issuecomment-5552241003), reviewed September 5 at 13:55 UTC, lists no findings, security issues, or pre-merge actions. It reviewed the original head; the only subsequent change is the exact mechanical rebase, so no rank-up work remains.

<details>
<summary>Local verification commands (before the patch-preserving rebase)</summary>

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/gateway/server-methods/approval.test.ts src/gateway/operator-approval-session-events.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- src/gateway/server-methods/approval.ts config/assertion-safety-baseline.txt
git diff --check
```

</details>
