### PR TITLE
fix(test): restore Gateway steering handshake coverage

### DIFF
--- a/test/gateway-steer-fifo.e2e.test.ts
+++ b/test/gateway-steer-fifo.e2e.test.ts
@@ -467,6 +467,7 @@ async function connectDiagnosticsClient(instance: OpenClawTestInstance): Promise
   });
   const gatewayUrl = new URL(instance.url);
   gatewayUrl.protocol = gatewayUrl.protocol === "wss:" ? "https:" : "http:";
+  // Both clients share a device identity; use the same canonical runtime metadata.
   const options: GatewayClientOptions = {
     url: instance.url,
     origin: gatewayUrl.origin,
@@ -482,7 +483,6 @@ async function connectDiagnosticsClient(instance: OpenClawTestInstance): Promise
       GATEWAY_CLIENT_CAPS.TASK_SUGGESTIONS,
       GATEWAY_CLIENT_CAPS.TOOL_EVENTS,
     ],
-    platform: process.platform,
     requestTimeoutMs: 30_000,
     onHelloOk: resolveHello,
     onConnectError: rejectHello,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where all five Gateway steering FIFO E2Es fail during the diagnostics handshake, before exercising steering. The diagnostics connection requests a metadata change for the device that the TUI connection just paired, producing `NOT_PAIRED` with `metadata-upgrade` in full release validation.

## Why This Change Was Made

Remove the fixture's explicit `process.platform` override. Both connections now use the Gateway client's canonical platform/device-family defaults for their shared device identity. The explicit override intentionally suppresses default family metadata for custom callers; it is inappropriate for this second ordinary client.

## User Impact

Restores release verification of terminal steering, FIFO ordering, and sequential-tool control points. Production behavior, browser Origin, credentials, scopes, pairing enforcement, and all existing steering assertions stay unchanged. No new tests or production seams are introduced.

## Evidence

- Exact release source `2542d48dc9c2a81beb6a9480f21bdec21dc0224a`: all five E2Es reproduced `NOT_PAIRED` / `metadata-upgrade` before the change; all five passed afterward against freshly built real Gateway processes and the existing mock Responses provider.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/gateway-steer-fifo.e2e.test.ts`: 5 passed.
- `node scripts/run-vitest.mjs src/gateway/client.test.ts src/gateway/server/ws-connection/connect-device-metadata.test.ts src/gateway/server/ws-connection/handshake-auth-helpers.test.ts`: 176 passed, including explicit metadata and rejection controls.
- `node scripts/check-changed.mjs -- test/gateway-steer-fifo.e2e.test.ts`: passed.
- All seven implicated fixture/client/pairing modules are byte-identical between that proved release source and this PR's main base `ff998e6df1d855e87df50a2ae0789f7a9759d694`.
- Fresh independent Codex review of the main forward-port: no actionable findings through P2.

Production delta: zero. Test/support delta: one explanatory comment added, one redundant metadata override removed.

The first hosted run exposed the unrelated missing prebuilt-UI readiness export in type checks and four tooling cases. After canonical #139123 landed, this branch was rebased with an identical patch and re-reviewed; the seven pairing/fixture owners remained unchanged.
