### PR TITLE
refactor(media): consolidate load and playback options

### DIFF
--- a/src/media/load-options.ts
+++ b/src/media/load-options.ts
@@ -86,31 +86,16 @@ export function buildOutboundMediaLoadOptions(
   const workspaceDir = mediaAccess?.workspaceDir ?? params.workspaceDir;
   const readFile = mediaAccess?.readFile ?? params.mediaReadFile;
   const localRoots = mediaAccess?.localRoots ?? explicitLocalRoots;
-  if (readFile) {
-    // Host reads must declare a root boundary so local file access cannot silently widen.
-    if (!localRoots) {
-      throw new Error(
-        'Host media read requires explicit localRoots. Pass mediaAccess.localRoots or opt in with localRoots: "any".',
-      );
-    }
-    return {
-      ...(params.maxBytes !== undefined ? { maxBytes: params.maxBytes } : {}),
-      localRoots,
-      readFile,
-      ...(params.fetchImpl ? { fetchImpl: params.fetchImpl } : {}),
-      ...(params.proxyUrl ? { proxyUrl: params.proxyUrl } : {}),
-      ...(params.requestInit ? { requestInit: params.requestInit } : {}),
-      ...(params.trustExplicitProxyDns !== undefined
-        ? { trustExplicitProxyDns: params.trustExplicitProxyDns }
-        : {}),
-      hostReadCapability: true,
-      ...(params.optimizeImages !== undefined ? { optimizeImages: params.optimizeImages } : {}),
-      ...(workspaceDir ? { workspaceDir } : {}),
-    };
+  // Host reads must declare a root boundary so local file access cannot silently widen.
+  if (readFile && !localRoots) {
+    throw new Error(
+      'Host media read requires explicit localRoots. Pass mediaAccess.localRoots or opt in with localRoots: "any".',
+    );
   }
   return {
     ...(params.maxBytes !== undefined ? { maxBytes: params.maxBytes } : {}),
     ...(localRoots ? { localRoots } : {}),
+    ...(readFile ? { readFile, hostReadCapability: true } : {}),
     ...(params.proxyUrl ? { proxyUrl: params.proxyUrl } : {}),
     ...(params.fetchImpl ? { fetchImpl: params.fetchImpl } : {}),
     ...(params.requestInit ? { requestInit: params.requestInit } : {}),

--- a/src/media/playback-transcode.ts
+++ b/src/media/playback-transcode.ts
@@ -437,7 +437,12 @@ function buildPlaybackFfmpegArgs(params: {
   outputPath: string;
   videoStreamIndex?: number;
 }): string[] {
-  const common = [
+  const audioOnly = params.kind === "audio";
+  const primaryStreamIndex = audioOnly ? params.audioStreamIndex : params.videoStreamIndex;
+  if (primaryStreamIndex === undefined) {
+    throw new Error(`Playback ${audioOnly ? "audio" : "video"} stream is missing`);
+  }
+  return [
     "-hide_banner",
     "-loglevel",
     "error",
@@ -460,53 +465,28 @@ function buildPlaybackFfmpegArgs(params: {
     "-1",
     "-map_chapters",
     "-1",
-  ];
-  if (params.kind === "audio") {
-    if (params.audioStreamIndex === undefined) {
-      throw new Error("Playback audio stream is missing");
-    }
-    return [
-      ...common,
-      "-map",
-      `0:${params.audioStreamIndex}`,
-      "-vn",
-      "-sn",
-      "-dn",
-      "-t",
-      String(PLAYBACK_TRANSCODE_MAX_DURATION_SECS),
-      "-c:a",
-      "aac",
-      "-b:a",
-      "128k",
-      "-movflags",
-      "+faststart",
-      "-f",
-      "ipod",
-      "-fs",
-      String(params.maxOutputBytes + 1),
-      params.outputPath,
-    ];
-  }
-  if (params.videoStreamIndex === undefined) {
-    throw new Error("Playback video stream is missing");
-  }
-  return [
-    ...common,
     "-map",
-    `0:${params.videoStreamIndex}`,
-    ...(params.audioStreamIndex === undefined ? [] : ["-map", `0:${params.audioStreamIndex}`]),
+    `0:${primaryStreamIndex}`,
+    ...(!audioOnly && params.audioStreamIndex !== undefined
+      ? ["-map", `0:${params.audioStreamIndex}`]
+      : []),
+    ...(audioOnly ? ["-vn"] : []),
     "-sn",
     "-dn",
     "-t",
     String(PLAYBACK_TRANSCODE_MAX_DURATION_SECS),
-    "-vf",
-    "scale=w='min(1920,iw)':h='min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2",
-    "-c:v",
-    "libx264",
-    "-threads",
-    String(PLAYBACK_TRANSCODE_THREADS),
-    "-pix_fmt",
-    "yuv420p",
+    ...(audioOnly
+      ? []
+      : [
+          "-vf",
+          "scale=w='min(1920,iw)':h='min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2",
+          "-c:v",
+          "libx264",
+          "-threads",
+          String(PLAYBACK_TRANSCODE_THREADS),
+          "-pix_fmt",
+          "yuv420p",
+        ]),
     "-c:a",
     "aac",
     "-b:a",
@@ -514,7 +494,7 @@ function buildPlaybackFfmpegArgs(params: {
     "-movflags",
     "+faststart",
     "-f",
-    "mp4",
+    audioOnly ? "ipod" : "mp4",
     "-fs",
     String(params.maxOutputBytes + 1),
     params.outputPath,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Reduces the maintenance cost of keeping media delivery and cross-client playback settings consistent across host-provided file readers, audio files, and videos.

## Why This Change Was Made

Builds outbound loader options once after the existing host-root validation, and constructs one complete FFmpeg argument list with explicit audio/video differences. The consolidation stays in the existing media owners and removes the now-unused intermediate argument array.

Option precedence, host-read capability gating, error messages, selected stream order, FFmpeg flag order, codec and muxer choices, byte/duration limits, and final output validation are preserved. Host-reader option property insertion order changes; inspected consumers read named fields, and the SDK exposes an options record without an enumeration-order contract.

## User Impact

No user-visible behavior change. Media loading and playback retain their existing access checks, formats, limits, and failure behavior. No SDK types, configuration, defaults, dependencies, storage, imports, or tests change.

## Evidence

Candidate: `34d2c9af02b1bcd12c87da88f48c7e72c9368806`, based on `ff998e6df1d855e87df50a2ae0789f7a9759d694`.

The rebase preserves the exact patch (`git range-diff` reports `=`), both changed-file hashes, and the relevant caller, callee, test, and documentation source bytes. The local execution evidence below used the original base `4cb260cd132f1315fccecc8c9dcb765d3ccd1f28`; it is not presented as a fresh run on the rebased base.

Scope: `src/media/load-options.ts` and `src/media/playback-transcode.ts`; production **+30 / −65 = −35 lines**, tests/test support **0**.

| Source stage | Validation |
| --- | --- |
| Before the final single-use prefix-array fold | **239 tests passed across seven files.** The complete selected changed gate finished without errors, including core and core-test typechecks, formatting/lint, export scans, media guards, and import-cycle checks. |
| Final source, after that fold, before rebase | **504** option/error comparisons and **72** exact FFmpeg argument/error comparisons against the original frozen base passed. **Three real FFmpeg 9.0.1 pairs** passed: audio→AAC/M4A, silent video→H.264 MP4, and video with audio→H.264/AAC MP4. Paired FFprobe results matched for codecs, stream order, dimensions, pixel format, duration, and output size. Formatting, `git diff --check`, and targeted lint passed again. |
| Final source review | Refreshed P2 autoreview and independent source review were scoped-clean, with no accepted/actionable findings. The committed files retain the reviewed source hashes. |
| Exact rebased-head review | A separate fresh read-only Codex review of `34d2c9af02b1bcd12c87da88f48c7e72c9368806`, with validated review execution settings, was scoped-clean through P2. Committed and working-copy hashes matched at review start and completion. |
| Hosted CI | [Run 33970800979](https://github.com/openclaw/openclaw/actions/runs/33970800979) **completed successfully** on the rebased head: **106 checks passed, 17 skipped**, including [the successful required CI gate](https://github.com/openclaw/openclaw/actions/runs/33970800979/job/101320520945). Preflight verified tested merge `f0eb1ae3fa9a83cd133874d0995b9f10ece11c29`: PR head `34d2c9af02b1bcd12c87da88f48c7e72c9368806` over main parent `df78d38ccca76a823c712406dbef71d8f6a62534`, which includes `ff998e6df1d855e87df50a2ae0789f7a9759d694`. |

Focused suite and changed-gate commands:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 GOMAXPROCS=2 node scripts/run-vitest.mjs \
  src/media/load-options.test.ts src/media/outbound-attachment.test.ts \
  src/media/web-media.test.ts src/media/playback-transcode.test.ts \
  src/media/media-probe.test.ts src/media/ffmpeg-exec.test.ts \
  src/media/store.playback-cache.test.ts

OPENCLAW_VITEST_MAX_WORKERS=2 GOMAXPROCS=2 node scripts/check-changed.mjs -- \
  src/media/load-options.ts src/media/playback-transcode.ts

GOMAXPROCS=2 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
  src/media/load-options.ts src/media/playback-transcode.ts
```

The differential probe reads the actual candidate functions and frozen Git source; the codec runs use synthetic local fixtures. This is argument-generation and real-codec proof, without claiming a new live-channel, Gateway UI, or full product-build run. Existing owner tests remain unchanged because this refactor introduces no new behavior contract.

ClawSweeper follow-through for the [September 5, 13:55 UTC review of the identical pre-rebase patch](https://github.com/openclaw/openclaw/pull/139127#issuecomment-5552233074):

- **Independent FFmpeg contract:** covered by direct inspection of the installed upstream FFmpeg manuals and the [official CLI documentation](https://ffmpeg.org/ffmpeg.html), in addition to the exact-argument comparisons and paired real-codec runs. The inspected contracts cover positional input/output options, explicit stream mapping order, `ipod` versus `mp4`, `+faststart`, and `-fs` overshoot. The existing post-conversion size validation remains unchanged.
- **Data-model compatibility:** not applicable. `load-options.ts` constructs an in-memory loader options record, including a reader callback. This diff changes no persisted data shape, schema, configuration key, serializer, or migration. Its existing public option values and precedence remain covered by source review and the 504 structural comparisons. No migration is required.
