### PR TITLE
fix(test): use current Control UI asset readiness inspector

### DIFF
--- a/test/vitest-ui-e2e-prebuilt.test.ts
+++ b/test/vitest-ui-e2e-prebuilt.test.ts
@@ -56,9 +56,13 @@ beforeEach(() => {
   ]) {
     write(file);
   }
-  write("dist/control-ui/index.html", '<script src="./assets/entry.js"></script>');
+  write(
+    "dist/control-ui/index.html",
+    '<script src="./assets/entry.js"></script><link rel="stylesheet" href="./assets/style.css">',
+  );
   write("dist/control-ui/assets/entry.js");
-  write("dist/control-ui/asset-manifest.json", '{"assets":["assets/entry.js"]}');
+  write("dist/control-ui/assets/style.css");
+  write("dist/control-ui/asset-manifest.json", '{"assets":["assets/entry.js","assets/style.css"]}');
   writeBuildStamp({ cwd: root });
   writeRuntimePostBuildStamp({ cwd: root });
 });
@@ -91,6 +95,12 @@ it.each([
     reason: "missing_runtime_postbuild_output",
   },
   { name: "incomplete UI", remove: "dist/control-ui/assets/entry.js", reason: "Control UI assets" },
+  { name: "missing UI index", remove: "dist/control-ui/index.html", reason: "Control UI assets" },
+  {
+    name: "incomplete UI CSS",
+    remove: "dist/control-ui/assets/style.css",
+    reason: "Control UI assets",
+  },
 ])("rejects $name without repairing it", ({ remove, reason }) => {
   const target = path.join(root, remove);
   fs.rmSync(target, { recursive: true, force: true });

--- a/test/vitest/vitest.ui-e2e-prebuilt.global-setup.ts
+++ b/test/vitest/vitest.ui-e2e-prebuilt.global-setup.ts
@@ -13,7 +13,7 @@ import {
   resolveBuildRequirement,
   resolveRuntimePostBuildRequirement,
 } from "../../scripts/run-node.mts";
-import { isControlUiStartupAssetsReady } from "../../src/infra/control-ui-assets.ts";
+import { inspectControlUiRootAssets } from "../../src/infra/control-ui-assets.ts";
 
 declare module "vitest" {
   export interface ProvidedContext {
@@ -71,7 +71,7 @@ export function assertPrebuiltUiE2eRuntime(repoRoot: string): string {
     fail(runtime.reason);
   }
   const uiRoot = path.join(distRoot, "control-ui");
-  if (!isControlUiStartupAssetsReady(uiRoot)) {
+  if (inspectControlUiRootAssets(uiRoot).kind !== "ready") {
     fail("canonical Control UI assets are not ready");
   }
   const digest = createHash("sha256").update(head);


### PR DESCRIPTION
Closes #139128

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where the prebuilt Control UI E2E admission hook fails before testing an otherwise ready build, while the root test typecheck fails with TS2305. The mismatch is present on current main and surfaced in [CI run 33968652873](https://github.com/openclaw/openclaw/actions/runs/33968652873) for unrelated memory work.

## Why This Change Was Made

The prebuilt harness added by #139081 (parallel prepared real-Gateway suites) calls the boolean API replaced by #138964 (canonical Control UI asset health). It now uses the existing synchronous root-health inspector and its `ready` result, preserving the selected asset root, rejection messages, immutable-generation checks, and teardown outcome.

The existing no-repair table additionally covers a missing UI index and referenced stylesheet. The harness change is two lines with no net growth; tests add 10 net lines.

## User Impact

Unblocks maintainer and CI validation of prepared Control UI artifacts. This is a test-harness integration repair, with no product runtime change.

## Evidence

Before the harness edit, the current-main harness suite reproduced exactly four failures and nine passes: ready admission, incomplete UI, and both native CLI teardown cases failed with `isControlUiStartupAssetsReady is not a function`. The existing CI log independently records TS2305 at the same import. Both newly added asset-rejection rows also failed before the repair.

After the repair, **all 15 harness cases and 36 canonical asset-owner cases pass (51 total)**. This includes the real Vitest subprocess proof that successful teardown preserves exit 0 and generation drift forces exit 1. Missing index, JavaScript, and CSS assets retain the canonical readiness error and remain missing after rejection.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run test/vitest-ui-e2e-prebuilt.test.ts src/infra/control-ui-assets.test.ts
```

Fresh P2 Codex autoreview is clean. No obsolete helper references remain in source, tests, scripts, or UI. Targeted live searches found no open duplicate repair. The complete classified testRoot/tooling changed gate passes with checkout-owned frozen dependencies, including root test typechecking and full scripts/test lint. The 51 focused tests also pass against that contained install. No full build is needed for this harness-only change.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- test/vitest/vitest.ui-e2e-prebuilt.global-setup.ts test/vitest-ui-e2e-prebuilt.test.ts
```
