### PR TITLE
fix(sessions): avoid cross-agent global initialization blocks

### DIFF
--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -32,6 +32,7 @@ import {
   loadTranscriptEvents,
   onSessionIdentityMutation,
   replaceSessionEntrySync,
+  resolveSessionEntryAccessTarget,
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
 import {
@@ -6104,6 +6105,59 @@ test("sessions.get reads selected global messages from the requested agent store
     const renderedMessages = JSON.stringify(result.payload?.messages ?? []);
     expect(renderedMessages).toContain("work global");
     expect(renderedMessages).not.toContain("main global");
+  } finally {
+    testState.sessionStorePath = undefined;
+    testState.sessionConfig = undefined;
+    testState.agentsConfig = undefined;
+  }
+});
+
+test("sessions.create checks selected global initialization in the requested agent store", async () => {
+  const { mainStorePath, workStorePath } = await createSelectedGlobalSessionStore();
+  try {
+    await writeSessionStore({
+      storePath: mainStorePath,
+      entries: {
+        global: sessionStoreEntry("sess-main-initializing", { initializationPending: true }),
+      },
+    });
+
+    const created = await directSessionReq<{ key?: string }>("sessions.create", {
+      key: "global",
+      agentId: "work",
+    });
+
+    expect(created.ok, JSON.stringify(created)).toBe(true);
+    expect(created.payload).toMatchObject({ key: "global" });
+    expect(
+      loadSessionEntry({ agentId: "work", sessionKey: "global", storePath: workStorePath }),
+    ).toBeDefined();
+    expect(
+      loadSessionEntry({ agentId: "main", sessionKey: "global", storePath: mainStorePath }),
+    ).toMatchObject({ sessionId: "sess-main-initializing", initializationPending: true });
+
+    await writeSessionStore({
+      storePath: workStorePath,
+      agentId: "work",
+      entries: {
+        global: sessionStoreEntry("sess-work-initializing", { initializationPending: true }),
+      },
+    });
+    expect(
+      resolveSessionEntryAccessTarget({
+        cfg: getRuntimeConfig(),
+        sessionKey: "global",
+        agentId: "work",
+      }).entry,
+    ).toMatchObject({ sessionId: "sess-work-initializing", initializationPending: true });
+    const blocked = await directSessionReq("sessions.create", { key: "global", agentId: "work" });
+    expect(blocked).toMatchObject({
+      ok: false,
+      error: {
+        code: "UNAVAILABLE",
+        message: "Session global is still initializing; retry creation later.",
+      },
+    });
   } finally {
     testState.sessionStorePath = undefined;
     testState.sessionConfig = undefined;

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -711,6 +711,7 @@ export async function createGatewaySession(params: {
     const pendingEntry = resolveSessionEntryAccessTarget({
       cfg: params.cfg,
       sessionKey: creationTarget.canonicalKey,
+      agentId: creationTarget.agentId,
     }).entry;
     if (pendingEntry?.initializationPending === true) {
       return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users creating an agent-selected global session receive “still initializing” when a different agent's independent global session is pending.

## Why This Change Was Made

The creation service now passes its already-resolved agent to the existing initialization lookup. The preflight reads the same owner as the lifecycle lock, transcript writer, and finalization path. The early deadlock-prevention check and later in-lock race check both remain.

## User Impact

With separate agent session stores, one agent's initialization no longer blocks another agent's global session. The requested agent's own pending initialization still rejects creation. Fixed-store ownership, canonical keys, parent lookup, events, and task dispatch retain their existing boundaries. There are no schema, configuration, migration, or protocol changes.

## Evidence

Real Gateway proof used a compiled Gateway, an authenticated WebSocket client, and the actual `sessions.create` RPC. Two agents used separate physical SQLite stores. The existing session-store owner seeded and inspected the fixture; it did not replace the RPC under test.

| Scenario | Current main `5eb472e9060394f2fcee2e8b7d2dd61774d9feb1` | Merged candidate `fdfe89454a23787762c7d8cbee68447ff2908b59` |
| --- | --- | --- |
| Only `main/global` pending; create `work/global` | `UNAVAILABLE`: still initializing | Creation succeeds in the work agent's physical store |
| Requested `work/global` pending | `UNAVAILABLE` | `UNAVAILABLE`; same-agent fence remains |
| Inspect main store after work request | Pending main row unchanged | Pending main row unchanged |

The same-agent control also confirmed that rejection left both physical stores unchanged. No provider or external channel was needed for this empty-session creation flow. Fixture credentials and private machine details are redacted.

- Regression red: baseline production plus the new regression test failed at the cross-agent create assertion with the observed `UNAVAILABLE` response.
- Candidate: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts --testNamePattern 'global|initializ'` — **13 passed**, including selected-agent writes/events, parents, transcript reads, initial task dispatch, and sentinel handling.
- Runtime proof: `node --import ./scripts/tsx.mjs scripts/build-all.mts qaRuntime`, then `node proof-rpc.mjs baseline` / `node proof-rpc.mjs candidate` with the same retained harness.
- Exact `oxfmt@0.65.0 --check` and `git diff --check` passed.
- Exact merged-head [CI run 33970415633](https://github.com/openclaw/openclaw/actions/runs/33970415633) passed all 139 jobs.
- Exact merged-head autoreview at `fdfe89454a23787762c7d8cbee68447ff2908b59`: scoped clean, no actionable P0-P2 findings, confidence 0.96.
- Production **+1** argument line; tests **+54**. No new branch, lock, parser, state owner, or fallback. Removing either existing check would lose its distinct timing guarantee.

The one-line contributor repair was merged as `834c7c0487ebbd99f58ec34ed17ce73e2aa83fe5`.

<details>
<summary>Redacted Gateway wire replies</summary>

```json
{
  "baseline_cross_agent": {
    "ok": false,
    "error": {
      "code": "UNAVAILABLE",
      "message": "Session global is still initializing; retry creation later."
    }
  },
  "candidate_cross_agent": {
    "ok": true,
    "payload": {
      "ok": true,
      "key": "global",
      "runStarted": false
    }
  },
  "candidate_same_agent": {
    "ok": false,
    "error": {
      "code": "UNAVAILABLE",
      "message": "Session global is still initializing; retry creation later."
    }
  }
}
```

Fixture tokens, model metadata, session identifiers, and machine paths are redacted.

</details>
