### PR TITLE
fix(matrix): stop SDK test clients before tearing down runtime

### DIFF
--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -441,7 +441,23 @@ vi.mock("matrix-js-sdk/lib/matrix.js", async () => {
 
 const { encodeRecoveryKey } = await import("matrix-js-sdk/lib/crypto-api/recovery-key.js");
 const { DecryptionFailureCode } = await import("matrix-js-sdk/lib/crypto-api/index.js");
-const { MatrixClient } = await import("./sdk.js");
+const { MatrixClient: BaseMatrixClient } = await import("./sdk.js");
+const startedClients = new Set<InstanceType<typeof BaseMatrixClient>>();
+
+class MatrixClient extends BaseMatrixClient {
+  protected override registerBridge(): void {
+    super.registerBridge();
+    startedClients.add(this);
+  }
+}
+
+async function stopStartedClients(): Promise<void> {
+  const clients = [...startedClients];
+  startedClients.clear();
+  // Retire the client owner before mocks or state disappear; its periodic
+  // persistence must not run against the next test's runtime or deleted home.
+  await Promise.all(clients.map((client) => client.stopWithoutPersist()));
+}
 
 function makeCryptoApi(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -490,7 +506,8 @@ describe("MatrixClient request hardening", () => {
     clearTestUndiciRuntimeDepsOverride();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await stopStartedClients();
     vi.useRealTimers();
     vi.unstubAllGlobals();
     clearTestUndiciRuntimeDepsOverride();
@@ -1876,7 +1893,8 @@ describe("MatrixClient event bridge", () => {
     lastCreateClientOpts = null;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await stopStartedClients();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -2650,7 +2668,8 @@ describe("MatrixClient crypto bootstrapping", () => {
     lastCreateClientOpts = null;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await stopStartedClients();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where plugin CI could finish all Matrix assertions and then fail during worker teardown. In [the release validation shard](https://github.com/openclaw/openclaw/actions/runs/33966876950/job/101308730190), clients left alive by SDK tests attempted periodic crypto persistence after their test runtime and temporary home had been removed. Those late logs overlapped Vitest's console RPC shutdown.

## Why This Change Was Made

The SDK fixture now tracks clients at their existing bridge-registration lifecycle boundary and awaits `stopWithoutPersist()` before each suite resets mocks, timers, and runtime state. That existing shutdown owner clears periodic persistence, aborts and joins an in-flight write, and stops the client. Production code and Vitest remain unchanged.

The shared boundary covers both public `start()` and crypto control-plane startup, including startup failures. Tracking only `start()` would miss the latter. Stopping every constructed client would instead extend the fixture's mocked SDK contract: never-started mocks report a syncing state but have no registered bridge to deliver their stop event. Tracking acquired lifecycles avoids that unrelated mock redesign.

## User Impact

No runtime, configuration, or public API behavior changes. Release verification no longer retains SDK fixture persistence writers after their owning tests finish. Production LOC: +0/-0; tests: +23/-4.

## Evidence

- Linux Testbox, Node 24.20.0, frozen dependencies: the existing 147 SDK tests passed before and after. Passive observation of native 60-second persistence intervals found **43 created / 2 cleared / 41 unjoined before**, and **43 created / 43 cleared / 0 unjoined after**. The independent resource-invariant check failed before and passed after; the observer retained native handles and callbacks.
- The original 21-plugin shard command, target set, ordering, two parallel groups, four workers, and 8 GiB worker heap budget were preserved. **4,417 tests in 332 files passed after the fix, exit 0**, without late Matrix runtime warnings or teardown RPC errors. The unchanged run also passed its assertions; it completed its Matrix group sooner and did not repeat the timing-dependent RPC failure. The reproduced defect is the leaked fixture lifecycle, rather than a claim that every framework teardown error has the same cause.
- `node scripts/check-changed.mjs --base HEAD -- extensions/matrix/src/matrix/sdk.test.ts` passed with private frozen Testbox dependencies: all guards, extension typecheck, dead-export scans, and lint; exit 0.
- Independent managed Codex P0–P2 review: no findings. Source inspection covered the SDK fixture, client lifecycle/crypto control-plane, sync quiescence, persistence, logger, reaction-event callers, and installed Matrix SDK/Vitest RPC and console contracts.

The real-timer resource proof exercises the existing fixture clients with a mocked Matrix SDK, not an authenticated homeserver. No extra assertion-only test was added: the existing suite plus failing/passing passive lifecycle evidence directly demonstrates cleanup. Exact historical introduction is unknown; the release failure and the producer-side leak are verified independently.
