### PR TITLE
fix(sqlite): retain malformed database diagnostics

### DIFF
--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -11,6 +11,7 @@ import {
   TELEGRAM_TEST_TIMINGS,
   createBotHandler,
   createBotHandlerWithOptions,
+  holdTelegramMediaTimeouts,
   mockTelegramFileDownload,
   mockTelegramPngDownload,
   watchTelegramFetch,
@@ -583,12 +584,7 @@ describe("telegram media groups", () => {
       const runtimeError = vi.fn();
       const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
       const fetchSpy = mockTelegramPngDownload();
-      let nextTimerHandle = 1;
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
-        const handle = nextTimerHandle;
-        nextTimerHandle += 1;
-        return handle as unknown as ReturnType<typeof setTimeout>;
-      });
+      const setTimeoutSpy = holdTelegramMediaTimeouts(TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs);
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 
       try {
@@ -693,12 +689,7 @@ describe("telegram media groups", () => {
       const runtimeError = vi.fn();
       const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
       const fetchSpy = mockTelegramPngDownload();
-      let nextTimerHandle = 1;
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
-        const handle = nextTimerHandle;
-        nextTimerHandle += 1;
-        return handle as unknown as ReturnType<typeof setTimeout>;
-      });
+      const setTimeoutSpy = holdTelegramMediaTimeouts(TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs);
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
       const savedPaths = [
         "/tmp/media/inbound/album-context-1.png",
@@ -792,12 +783,7 @@ describe("telegram media groups", () => {
     async () => {
       const runtimeError = vi.fn();
       const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
-      let nextTimerHandle = 1;
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
-        const handle = nextTimerHandle;
-        nextTimerHandle += 1;
-        return handle as unknown as ReturnType<typeof setTimeout>;
-      });
+      const setTimeoutSpy = holdTelegramMediaTimeouts(TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs);
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
       const savedPaths = [
         "/tmp/media/inbound/album-partial-2.png",
@@ -922,12 +908,7 @@ describe("telegram media groups", () => {
       const runtimeError = vi.fn();
       const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
       const fetchSpy = mockTelegramPngDownload();
-      let nextTimerHandle = 1;
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
-        const handle = nextTimerHandle;
-        nextTimerHandle += 1;
-        return handle as unknown as ReturnType<typeof setTimeout>;
-      });
+      const setTimeoutSpy = holdTelegramMediaTimeouts(TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs);
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 
       try {

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -8,6 +8,7 @@ import {
   TELEGRAM_TEST_TIMINGS,
   cacheStickerSpy,
   createBotHandlerWithOptions,
+  holdTelegramMediaTimeouts,
   describeStickerImageSpy,
   getCachedStickerSpy,
 } from "./bot.media.test-utils.js";
@@ -404,12 +405,7 @@ describe("telegram text fragments", () => {
 
       const runtimeError = vi.fn();
       const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
-      let nextTimerHandle = 1;
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
-        const handle = nextTimerHandle;
-        nextTimerHandle += 1;
-        return handle as unknown as ReturnType<typeof setTimeout>;
-      });
+      const setTimeoutSpy = holdTelegramMediaTimeouts(TELEGRAM_TEST_TIMINGS.textFragmentGapMs);
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
       const part1 = "A".repeat(4050);
       const part2 = "B".repeat(50);
@@ -480,12 +476,7 @@ describe("telegram text fragments", () => {
 
       const runtimeError = vi.fn();
       const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
-      let nextTimerHandle = 1;
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
-        const handle = nextTimerHandle;
-        nextTimerHandle += 1;
-        return handle as unknown as ReturnType<typeof setTimeout>;
-      });
+      const setTimeoutSpy = holdTelegramMediaTimeouts(TELEGRAM_TEST_TIMINGS.textFragmentGapMs);
       const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 
       try {

--- a/extensions/telegram/src/bot.media.test-utils.ts
+++ b/extensions/telegram/src/bot.media.test-utils.ts
@@ -1,4 +1,5 @@
 // Telegram helper module supports bot.media utils behavior.
+import { clearTimeout as cancelTimeout, setTimeout as scheduleTimeout } from "node:timers";
 import * as ssrf from "openclaw/plugin-sdk/ssrf-runtime";
 import { afterEach, beforeAll, beforeEach, expect, vi, type Mock } from "vitest";
 import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
@@ -18,6 +19,18 @@ export const TELEGRAM_TEST_TIMINGS = {
   mediaGroupFlushMs: 20,
   textFragmentGapMs: 30,
 } as const;
+
+export function holdTelegramMediaTimeouts(delayMs: number) {
+  return vi.spyOn(globalThis, "setTimeout").mockImplementation((callback, delay, ...args) => {
+    const handle = scheduleTimeout(callback, delay, ...args);
+    // Only media deadlines are flushed manually; worker timers keep their
+    // native scheduling and handles, including ref/unref lifecycle methods.
+    if (delay === delayMs) {
+      cancelTimeout(handle);
+    }
+    return handle;
+  });
+}
 
 let createTelegramBotRef: typeof import("./bot.js").createTelegramBot;
 let replySpyRef: ReturnType<typeof vi.fn>;

--- a/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
@@ -543,7 +543,7 @@ describe("runEmbeddedAgent provider fault sequences", () => {
     });
   });
 
-  it("persists long-TTL billing cooldown and surfaces billing copy for 402", async () => {
+  it("persists a ten-minute initial billing disable and surfaces billing copy for 402", async () => {
     await withScenarioWorkspace(async ({ agentDir, workspaceDir }) => {
       writeProfiles(agentDir, { openai: 1 });
       const observations: AttemptObservation[] = [];
@@ -568,7 +568,10 @@ describe("runEmbeddedAgent provider fault sequences", () => {
       expect(usageStats["openai:p1"]?.disabledReason).toBe("billing");
       expect(usageStats["openai:p1"]?.failureCounts?.billing).toBe(1);
       expect(usageStats["openai:p1"]?.disabledUntil).toBeGreaterThanOrEqual(
-        startedAt + 5 * 60 * 60 * 1_000,
+        startedAt + 10 * 60 * 1_000,
+      );
+      expect(usageStats["openai:p1"]?.disabledUntil).toBeLessThanOrEqual(
+        Date.now() + 10 * 60 * 1_000,
       );
       expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
     });

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -360,6 +360,33 @@ describe("prepareSqliteReadOnlyLocation", () => {
     expect(fs.readdirSync(path.join(cacheRoot, "openclaw"))).toEqual([]);
   });
 
+  it.each([
+    { mode: "async", prepare: prepareSqliteReadOnlyLocationInProcess },
+    { mode: "sync", prepare: prepareSqliteReadOnlyLocationSyncInProcess },
+  ])("preserves malformed header diagnostics during $mode inspection", async ({ prepare }) => {
+    const databasePath = createTempDatabasePath();
+    fs.writeFileSync(databasePath, "not a sqlite database");
+    const before = readFamily(databasePath);
+    let prepared: Awaited<ReturnType<typeof prepare>> | undefined;
+    try {
+      await expect(
+        (async () => {
+          prepared = await prepare(databasePath);
+          const sqlite = requireNodeSqlite();
+          const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
+          try {
+            snapshot.prepare("PRAGMA user_version;").get();
+          } finally {
+            snapshot.close();
+          }
+        })(),
+      ).rejects.toThrow("file is not a database");
+    } finally {
+      prepared?.cleanup();
+    }
+    expect(readFamily(databasePath)).toEqual(before);
+  });
+
   it("preserves source corruption without reporting a snapshot staging quota failure", async () => {
     const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-corrupt-source-");
     const sqlite = requireNodeSqlite();

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -348,7 +348,7 @@ function recoverPrivateRollbackCopy(snapshotPath: string): void {
 
 function createStableReadOnlyCopyInTempDirectory(
   pathname: string,
-  journalMode: Exclude<SourceJournalMode, "unknown">,
+  journalMode: SourceJournalMode,
   existingTempDir?: string,
   stagingRoot = existingTempDir
     ? path.dirname(existingTempDir)
@@ -577,13 +577,9 @@ export function prepareSqliteReadOnlyLocationSyncInProcess(
       lastChange = error;
       continue;
     }
-    if (journalMode === "unknown") {
-      lastChange = new SqliteSourceChangedError(
-        `SQLite journal mode is unavailable while copying: ${canonicalPath}`,
-      );
-      continue;
-    }
     try {
+      // Stable malformed bytes still belong to SQLite's diagnostic path. The
+      // private copy checks bytes, sidecars, and mode before a reader opens it.
       return createStableReadOnlyCopyInTempDirectory(
         canonicalPath,
         journalMode,


### PR DESCRIPTION
## What Problem This Solves

Doctor reported that an unreadable SQLite file “did not stabilize” even when its malformed bytes were unchanged. The synchronous snapshot preparer classified every unknown header as concurrent source mutation, so SQLite never got to provide the actual corruption diagnostic.

Gateway E2E fixtures also replaced every Node timeout with numeric handles, stranding real worker completions at `Timeout.unref()`, and retained a five-hour billing expectation after #136364 intentionally changed the initial disable window to ten minutes.

## Why This Change Was Made

Keep stable malformed bytes on the existing private-copy path and let the SQLite reader diagnose them. The copy still checks source identity, repeated bytes, sidecars, and journal mode; actual source changes continue to retry. The source database and its sidecars remain untouched. Main's cancellable worker and staging-directory ownership from #138986 are preserved.

The six affected Telegram album/fragment cases share a test-only timer helper that holds only their media deadline for explicit flushing while retaining native Node handles and all other timer scheduling. The billing E2E checks both lower and upper bounds around the documented ten-minute initial disable. No Doctor assertion is relaxed.

## User Impact

Unreadable-database recovery messages retain the concrete SQLite error instead of blaming nonexistent concurrent writes. Existing refusal, recovery guidance, and data preservation remain enforced. The timer and billing changes repair test contracts; they do not change Telegram delivery or billing policy.

## Evidence

- The original three Gateway E2E files reproduced three assertion failures and two unhandled worker-timer errors on the frozen release source. The downloads sibling separately reproduced four unhandled timer errors with all 15 assertions passing.
- The added malformed-header owner matrix failed on the original synchronous path while the asynchronous control passed. Both paths now preserve the original file family and report the SQLite error.
- Linux Node 24.20.0: all 86 SQLite/worker owner tests passed, including the live-WAL POSIX-lock regression, concurrent WAL/MEMORY writes, private rollback recovery, sidecar preservation, staging failures, and cleanup. [Testbox source workflow](https://github.com/openclaw/openclaw/actions/runs/33969005475).
- Final combined Doctor, provider-fault, Telegram fragment, and Telegram download E2Es: 36/36 passed with zero unhandled errors. The canonical product build passed; the final test-only helper replay reused those exact unchanged product bytes through the documented prebuilt-dist contract.
- Current-main integration: two malformed-header cases and three worker-cancellation cases passed. The only context adaptation retains the existing staging-root arguments.
- Independent managed review cleared all six files through P2 with no accepted findings. The full six-file Linux changed gate passed, including all routed type graphs, declaration boundaries, lint, dead exports, import cycles, and ownership guards. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33970351886) passed112 jobs with15 skips on `3f450a25d3d4bcc68d1117f20d18700a1cb9383c`.

Focused commands:

```sh
node scripts/run-vitest.mjs src/infra/sqlite-readonly-location.test.ts src/infra/sqlite-readonly-location.worker.test.ts src/infra/worker-task-pool.test.ts
node scripts/run-vitest.mjs src/commands/doctor.refuses-newer-database-schemas.e2e.test.ts src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
node scripts/check-changed.mjs -- extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts extensions/telegram/src/bot.media.test-utils.ts src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts src/infra/sqlite-readonly-location.test.ts src/infra/sqlite-readonly-location.ts
```

Production: +3/−7 lines, net −4. Tests/support: +53/−38, net +15. No schema, persistence-policy, configuration, or public API change. Existing database-recovery and billing documentation remains accurate; #136364 supplies the billing policy and contributor provenance.
