### PR TITLE
perf(gateway): skip unused HEAD reads for PR chips

### DIFF
--- a/src/gateway/control-ui-session-prs-landing.test.ts
+++ b/src/gateway/control-ui-session-prs-landing.test.ts
@@ -3,7 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as worktreeGit from "../agents/worktrees/git.js";
 import { resolveBranchLanding } from "./control-ui-session-prs-landing.js";
 
 const execFileAsync = promisify(execFile);
@@ -27,7 +28,30 @@ describe("resolveBranchLanding", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("resolves an unpublished branch without reading an unused HEAD", async () => {
+    const base = await sha("HEAD");
+    await git("checkout", "-b", "feature");
+    await fs.appendFile(path.join(root, "a.txt"), "two\n");
+    await git("commit", "-am", "unpublished work");
+    const runGit = vi.spyOn(worktreeGit, "runGit");
+
+    expect(
+      await resolveBranchLanding(root, {
+        branch: "feature",
+        defaultBranch: "main",
+        mergedHeads: [],
+      }),
+    ).toEqual({
+      pushedSha: null,
+      statsBase: base,
+      hasLandedPullRequest: false,
+      provenNewPushedWork: false,
+    });
+    expect(runGit).not.toHaveBeenCalledWith(root, ["rev-parse", "HEAD"]);
   });
 
   it("marks a squash-landed tip and bases stats on the merged head", async () => {

--- a/src/gateway/control-ui-session-prs-landing.ts
+++ b/src/gateway/control-ui-session-prs-landing.ts
@@ -95,7 +95,8 @@ export async function resolveBranchLanding(
     "--quiet",
     `refs/remotes/origin/${params.branch}`,
   ]);
-  const headSha = await gitOutput(root, ["rev-parse", "HEAD"]);
+  // HEAD is only used to compare landed PR heads; keep its read order when needed.
+  const headSha = params.mergedHeads.length ? await gitOutput(root, ["rev-parse", "HEAD"]) : null;
   // Only merges whose content reached this checkout's default branch prove
   // the tip landed there: a direct default-base merge, or a landing through
   // another branch (feature -> release -> main) whose merge commit is now


### PR DESCRIPTION
## What Problem This Solves

Refreshing Control UI PR chips for a branch with no merged PRs launches a Git process whose result is never used. On a busy Gateway, even asynchronous child-process APIs have a synchronous launch cost.

## Why This Change Was Made

The landing resolver now reads HEAD only when fetched merged heads need ancestry comparison. Every nonempty-head case retains its existing Git observation order, including heads later excluded from landing checks. Cache freshness, branch visibility, diff statistics, and Git safety options are unchanged.

## User Impact

One fewer Git process per uncached or forced landing lookup when there are no merged PR heads: the ordinary landing calculation goes from three Git commands to two. Returned branch facts remain identical. This does not claim to eliminate all process-launch latency or Gateway stalls.

## Evidence

- A real-Git regression in the existing landing fixture fails before the change on the unused HEAD invocation and passes afterward.
- The landing, PR-loader, and subscription suites pass: 62 tests across three files.
- Same-fixture owner comparison preserves all returned fields. Empty-head calls fall from three to two; nonempty release and merged-main controls preserve their complete Git argument order.
- Independent P2 review: no accepted or actionable findings.
- Qualified Crabbox 0.49.1 / Blacksmith Testbox: 62 tests pass on Linux with Node 24.19.0, Execa 10.0.1 and Git 2.52.0. This proves native behavior and call removal, not a Node 26.7 timing benchmark.
- Full local changed-scope gate passed: `node scripts/check-changed.mjs -- src/gateway/control-ui-session-prs-landing.ts src/gateway/control-ui-session-prs-landing.test.ts`.
- Linux proof used [this Testbox run](https://github.com/openclaw/openclaw/actions/runs/33970128790); the manual payload exited 0 and its environment was subsequently stopped. This is separate from PR CI.

Production: +2/-1 lines; tests: +25/-1 lines. The added comment records why necessary HEAD reads retain their original position. No dependency, configuration, schema, protocol, or visual change.
