### PR TITLE
fix(android): keep workspace previews open when sharing fails

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -433,6 +433,7 @@
     {"id":"native.android.aaab13cc0ab5153c","source":"Could not save wake words","surface":"android","sites":[{"kind":"ui-call","path":"apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt"}]},
     {"id":"native.android.f6f0f4e6491e711a","source":"Could not save widget image","surface":"android","sites":[{"kind":"ui-call","path":"apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt"}]},
     {"id":"native.android.2525b1650cf92f0c","source":"Could not search ClawHub skills.","surface":"android","sites":[{"kind":"ui-call","path":"apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt"}]},
+    {"id":"native.android.d3f266a0285fea61","source":"Could not share file","surface":"android","sites":[{"kind":"ui-call","path":"apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt"}]},
     {"id":"native.android.1b79f48e2b7bad07","source":"Could not stage an attachment for sending.","surface":"android","sites":[{"kind":"ui-call","path":"apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt"}]},
     {"id":"native.android.2e28f34529493a97","source":"Could not start the camera. Choose a QR image from gallery or enter the setup code manually.","surface":"android","sites":[{"kind":"ui-call","path":"apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt"}]},
     {"id":"native.android.495d785a90ecdad4","source":"Could not test connection","surface":"android","sites":[{"kind":"ui-call","path":"apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt"}]},

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
@@ -14,6 +14,7 @@ import android.content.Context
 import android.content.Intent
 import android.text.format.Formatter
 import android.util.Base64
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -432,23 +433,24 @@ private fun shareWorkspaceFile(
 ) {
   // A FileProvider grant can outlive the share sheet. Unique directories keep
   // a later same-basename export from replacing bytes behind an older grant.
-  val directory = File(context.cacheDir, "workspace-files/${UUID.randomUUID()}").apply { mkdirs() }
-  // Server names are plain basenames; keep the guard so a hostile gateway
-  // cannot steer the temp write outside the export directory.
-  val safeName = file.name.substringAfterLast('/').ifEmpty { "file" }
-  val target = File(directory, safeName)
-  if (file.isBase64) {
-    val bytes = runCatching { Base64.decode(file.content, Base64.DEFAULT) }.getOrNull() ?: return
-    target.writeBytes(bytes)
-  } else {
-    target.writeText(file.content)
+  val directory = File(context.cacheDir, "workspace-files/${UUID.randomUUID()}")
+  try {
+    directory.mkdirs()
+    // Server names are plain basenames; keep the guard so a hostile gateway
+    // cannot steer the temp write outside the export directory.
+    val target = File(directory, file.name.substringAfterLast('/').ifEmpty { "file" })
+    target.writeBytes(if (file.isBase64) Base64.decode(file.content, Base64.DEFAULT) else file.content.toByteArray())
+    val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", target)
+    val send =
+      Intent(Intent.ACTION_SEND).apply {
+        type = file.mimeType.ifEmpty { "application/octet-stream" }
+        putExtra(Intent.EXTRA_STREAM, uri)
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+      }
+    context.startActivity(Intent.createChooser(send, file.name))
+  } catch (_: Exception) {
+    // Only this unpublished attempt is disposable; older URI grants still own their files.
+    runCatching { directory.deleteRecursively() }
+    Toast.makeText(context, nativeString("Could not share file"), Toast.LENGTH_SHORT).show()
   }
-  val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", target)
-  val send =
-    Intent(Intent.ACTION_SEND).apply {
-      type = file.mimeType.ifEmpty { "application/octet-stream" }
-      putExtra(Intent.EXTRA_STREAM, uri)
-      addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-    }
-  context.startActivity(Intent.createChooser(send, file.name))
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/WorkspaceFilesShareLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/WorkspaceFilesShareLayoutTest.kt
@@ -1,0 +1,459 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.NodeApp
+import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.SecurePrefs
+import ai.openclaw.app.closeNodeRuntimeTestFixture
+import ai.openclaw.app.gateway.GatewayEndpoint
+import ai.openclaw.app.ui.design.ClawDesignTheme
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.graphics.Bitmap
+import android.net.Uri
+import android.util.Base64
+import androidx.activity.compose.LocalActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStore
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExternalResource
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowContentResolver
+import org.robolectric.shadows.ShadowToast
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.net.InetAddress
+import java.util.UUID
+
+private const val FILE_NAME = "notes.txt"
+private const val FIRST_BODY = "First workspace export.\n"
+private const val SECOND_BODY = "Second workspace export.\n"
+private const val SHARE_FAILURE = "Could not share file"
+private const val READY_TIMEOUT_MS = 10_000L
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "en-rUS-w360dp-h800dp-420dpi")
+class WorkspaceFilesShareLayoutTest {
+  private val composeRule = createComposeRule()
+
+  // Dispose the real screen before joining runtime/socket cleanup, including after the expected red.
+  @get:Rule
+  val fixtureRules: RuleChain =
+    RuleChain
+      .outerRule(
+        object : ExternalResource() {
+          override fun after() = tearDown()
+        },
+      ).around(composeRule)
+
+  private lateinit var app: NodeApp
+  private lateinit var runtime: NodeRuntime
+  private lateinit var activity: Activity
+  private lateinit var gateway: WorkspaceFilesGateway
+  private lateinit var blockedCache: File
+  private lateinit var exportRoot: File
+  private val models = ViewModelStore()
+  private var previousRuntime: NodeRuntime? = null
+  private var originalExportChildren = emptySet<File>()
+  private var exportRootExisted = false
+  private var exportSnapshotReady = false
+
+  @Volatile private var blockCache = false
+  private var failLaunch = false
+
+  @Before
+  fun setUp() {
+    app = RuntimeEnvironment.getApplication() as NodeApp
+    previousRuntime = app.peekRuntime()
+    blockedCache = File.createTempFile("workspace-share-obstruction-", ".tmp", app.cacheDir)
+    exportRoot = File(app.cacheDir, "workspace-files")
+    check(!exportRoot.exists() || exportRoot.isDirectory)
+    exportRootExisted = exportRoot.exists()
+    originalExportChildren = exportRoot.listFiles().orEmpty().toSet()
+    exportSnapshotReady = true
+    // Load the manifest provider, not a registered byte-stream substitute.
+    assertTrue(ShadowContentResolver.getProvider(Uri.parse("content://${app.packageName}.fileprovider")) is FileProvider)
+    ShadowToast.reset()
+    gateway = WorkspaceFilesGateway()
+    val prefs = SecurePrefs(app, app.getSharedPreferences("workspace-share-${UUID.randomUUID()}", Context.MODE_PRIVATE))
+    prefs.setManualTls(false)
+    prefs.saveGatewayCredentials(gateway.endpoint.stableId, token = "synthetic-workspace-share-proof")
+    runtime = NodeRuntime(app, prefs)
+    bindRuntime(runtime)
+    val model = MainViewModel(app, prefs, SavedStateHandle())
+    models.put("workspace", model)
+    model.setForeground(true)
+    composeRule.setContent {
+      activity = requireNotNull(LocalActivity.current)
+      val context =
+        remember(activity) {
+          object : ContextWrapper(activity) {
+            // Only the selected action's local storage is faulted; fetch/runtime use the normal app.
+            override fun getCacheDir(): File = if (blockCache) blockedCache else super.getCacheDir()
+
+            override fun startActivity(intent: Intent) {
+              if (failLaunch) throw ActivityNotFoundException("Synthetic chooser failure")
+              super.startActivity(intent)
+            }
+          }
+        }
+      CompositionLocalProvider(LocalContext provides context) {
+        ClawDesignTheme {
+          Box(Modifier.size(360.dp, 800.dp).clipToBounds()) {
+            WorkspaceFilesScreen(viewModel = model, onBack = {})
+          }
+        }
+      }
+    }
+    composeRule.runOnIdle { model.connect(gateway.endpoint) }
+    openPreview(FIRST_BODY)
+    assertNull(shadowOf(activity).nextStartedActivity)
+  }
+
+  @Test
+  fun cacheFailureReportsOutcomeWithoutLaunchingChooserOrLosingPreview() {
+    assertTrue(blockedCache.isFile)
+    blockCache = true
+    ShadowToast.reset()
+
+    share()
+
+    awaitShareFailure()
+    assertTrue(blockedCache.isFile)
+    assertNull(shadowOf(activity).nextStartedActivity)
+    composeRule.onNodeWithText(FIRST_BODY.trimEnd()).assertIsDisplayed()
+    composeRule.onNodeWithContentDescription("Share file").assertIsEnabled()
+    composeRule.onNodeWithContentDescription("Back").performClick()
+    awaitFileRow()
+  }
+
+  @Test
+  fun aLaterSameNameExportDoesNotReplaceBytesBehindTheFirstUri() {
+    val first = shareUri()
+    assertArrayEquals(FIRST_BODY.toByteArray(), readExport(first))
+
+    composeRule.onNodeWithContentDescription("Back").performClick()
+    gateway.body = SECOND_BODY
+    openPreview(SECOND_BODY)
+    val second = shareUri()
+
+    assertArrayEquals(SECOND_BODY.toByteArray(), readExport(second))
+    assertArrayEquals(FIRST_BODY.toByteArray(), readExport(first))
+  }
+
+  @Test
+  fun chooserFailureRemovesOnlyItsUnpublishedAttempt() {
+    val first = shareUri()
+    val published = exportRoot.listFiles().orEmpty().toSet()
+    failLaunch = true
+
+    share()
+
+    awaitShareFailure()
+    assertNull(shadowOf(activity).nextStartedActivity)
+    assertEquals(published, exportRoot.listFiles().orEmpty().toSet())
+    assertArrayEquals(FIRST_BODY.toByteArray(), readExport(first))
+    composeRule.onNodeWithText(FIRST_BODY.trimEnd()).assertIsDisplayed()
+  }
+
+  @Test
+  fun sharesExactImageBytesAndReportsInvalidBase64WithoutLeavingAnAttempt() {
+    val bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+    val bytes =
+      ByteArrayOutputStream().use { output ->
+        assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output))
+        output.toByteArray()
+      }
+    bitmap.recycle()
+    gateway.name = "pixel.png"
+    gateway.mimeType = "image/png"
+    gateway.encoding = "base64"
+    gateway.body = Base64.encodeToString(bytes, Base64.NO_WRAP)
+    composeRule.onNodeWithContentDescription("Back").performClick()
+    openPreview()
+    val first = shareUri("image/png")
+    assertArrayEquals(bytes, readExport(first))
+    val published = exportRoot.listFiles().orEmpty().toSet()
+
+    composeRule.onNodeWithContentDescription("Back").performClick()
+    gateway.body = "A"
+    openPreview()
+    share()
+
+    awaitShareFailure()
+    assertNull(shadowOf(activity).nextStartedActivity)
+    assertEquals(published, exportRoot.listFiles().orEmpty().toSet())
+    assertArrayEquals(bytes, readExport(first))
+  }
+
+  private fun openPreview(body: String? = null) {
+    awaitFileRow()
+    composeRule.onNode(hasText(gateway.name) and hasClickAction()).performClick()
+    composeRule.waitUntil(READY_TIMEOUT_MS) {
+      composeRule.onAllNodes(hasContentDescription("Share file")).fetchSemanticsNodes().isNotEmpty()
+    }
+    if (body != null) composeRule.onNodeWithText(body.trimEnd()).assertIsDisplayed()
+    composeRule.onNodeWithContentDescription("Share file").assertIsDisplayed().assertIsEnabled()
+  }
+
+  private fun awaitFileRow() {
+    composeRule.waitUntil(READY_TIMEOUT_MS) {
+      composeRule.onAllNodes(hasText(gateway.name) and hasClickAction()).fetchSemanticsNodes().isNotEmpty()
+    }
+  }
+
+  private fun share() {
+    composeRule
+      .onNodeWithContentDescription("Share file")
+      .assertIsDisplayed()
+      .assertIsEnabled()
+      .performClick()
+  }
+
+  private fun awaitShareFailure() {
+    // The outcome may be a shown Toast or visible screen text; the test does not require a layout.
+    composeRule.waitUntil(READY_TIMEOUT_MS) {
+      ShadowToast.getTextOfLatestToast() == SHARE_FAILURE ||
+        composeRule.onAllNodesWithText(SHARE_FAILURE).fetchSemanticsNodes().isNotEmpty()
+    }
+    if (ShadowToast.getTextOfLatestToast() != SHARE_FAILURE) {
+      composeRule.onNodeWithText(SHARE_FAILURE).assertIsDisplayed()
+    }
+  }
+
+  private fun shareUri(mimeType: String = "text/plain"): Uri {
+    share()
+    var chooser: Intent? = null
+    composeRule.waitUntil(READY_TIMEOUT_MS) {
+      chooser = shadowOf(activity).nextStartedActivity
+      chooser != null
+    }
+    val selected = requireNotNull(chooser)
+    assertEquals(Intent.ACTION_CHOOSER, selected.action)
+    val send = requireNotNull(selected.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java))
+    assertEquals(Intent.ACTION_SEND, send.action)
+    assertEquals(mimeType, send.type)
+    assertTrue(send.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+    return requireNotNull(send.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)).also {
+      assertEquals("content", it.scheme)
+    }
+  }
+
+  private fun readExport(uri: Uri): ByteArray = requireNotNull(app.contentResolver.openInputStream(uri)).use { it.readBytes() }
+
+  private fun bindRuntime(value: NodeRuntime?) {
+    NodeApp::class.java
+      .getDeclaredField("runtimeInstance")
+      .apply { isAccessible = true }
+      .set(app, value)
+  }
+
+  private fun tearDown() {
+    try {
+      models.clear()
+    } finally {
+      try {
+        if (::runtime.isInitialized) closeNodeRuntimeTestFixture(runtime)
+      } finally {
+        try {
+          if (::app.isInitialized) bindRuntime(previousRuntime)
+        } finally {
+          try {
+            if (::gateway.isInitialized) gateway.close()
+          } finally {
+            if (::blockedCache.isInitialized) assertTrue(blockedCache.delete())
+            if (exportSnapshotReady) {
+              exportRoot.listFiles().orEmpty().filterNot(originalExportChildren::contains).forEach {
+                assertTrue(it.deleteRecursively())
+              }
+              if (!exportRootExisted && exportRoot.exists()) assertTrue(exportRoot.delete())
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+private class WorkspaceFilesGateway : AutoCloseable {
+  private val json = Json { ignoreUnknownKeys = true }
+  private val server = MockWebServer()
+
+  @Volatile var body = FIRST_BODY
+
+  @Volatile var name = FILE_NAME
+
+  @Volatile var mimeType = "text/plain"
+
+  @Volatile var encoding = "utf8"
+  val endpoint: GatewayEndpoint
+
+  init {
+    server.dispatcher =
+      object : Dispatcher() {
+        override fun dispatch(request: RecordedRequest): MockResponse =
+          if (request.getHeader("Upgrade").equals("websocket", ignoreCase = true)) {
+            MockResponse().withWebSocketUpgrade(listener())
+          } else {
+            MockResponse().setResponseCode(404)
+          }
+      }
+    server.start(InetAddress.getByName("127.0.0.1"), 0)
+    endpoint = GatewayEndpoint.manual("127.0.0.1", server.port)
+  }
+
+  private fun listener() =
+    object : WebSocketListener() {
+      override fun onOpen(
+        webSocket: WebSocket,
+        response: Response,
+      ) {
+        webSocket.send("""{"type":"event","event":"connect.challenge","payload":{"nonce":"workspace-share-proof","ts":1700000000123}}""")
+      }
+
+      override fun onMessage(
+        webSocket: WebSocket,
+        text: String,
+      ) {
+        val frame = json.parseToJsonElement(text).jsonObject
+        if (frame["type"]?.jsonPrimitive?.content != "req") return
+        val id = frame.getValue("id")
+        val method = frame["method"]?.jsonPrimitive?.content
+        val params = frame["params"] as? JsonObject ?: JsonObject(emptyMap())
+        val content = body
+        val payload: JsonElement? =
+          when (method) {
+            "connect" -> {
+              val role = params.getValue("role").jsonPrimitive.content
+              json.parseToJsonElement(
+                """{"type":"hello-ok","protocol":3,"server":{"host":"workspace-share-proof","version":"proof"},"features":{"methods":["agents.workspace.list","agents.workspace.get","chat.history","chat.metadata","health","sessions.list"],"events":[]},"auth":{"role":"$role","scopes":${if (role == "operator") "[\"operator.read\",\"operator.write\"]" else "[]"}},"snapshot":{"sessionDefaults":{"mainSessionKey":"agent:main:main"}}}""",
+              )
+            }
+
+            "agents.workspace.list" -> {
+              if (params["agentId"]?.jsonPrimitive?.content == "main" &&
+                params["path"]
+                  ?.jsonPrimitive
+                  ?.content
+                  .orEmpty()
+                  .isEmpty()
+              ) {
+                json.parseToJsonElement("""{"agentId":"main","workspace":"/synthetic-workspace","path":"","parentPath":null,"entries":[{"path":"$name","name":"$name","kind":"file","size":${content.toByteArray().size},"updatedAtMs":1}],"totalEntries":1,"offset":0}""")
+              } else {
+                null
+              }
+            }
+
+            "agents.workspace.get" -> {
+              if (params["agentId"]?.jsonPrimitive?.content == "main" && params["path"]?.jsonPrimitive?.content == name) {
+                buildJsonObject {
+                  put("agentId", JsonPrimitive("main"))
+                  put("workspace", JsonPrimitive("/synthetic-workspace"))
+                  put(
+                    "file",
+                    buildJsonObject {
+                      put("path", JsonPrimitive(name))
+                      put("name", JsonPrimitive(name))
+                      put("size", JsonPrimitive(content.toByteArray().size))
+                      put("updatedAtMs", JsonPrimitive(1))
+                      put("mimeType", JsonPrimitive(mimeType))
+                      put("encoding", JsonPrimitive(encoding))
+                      put("content", JsonPrimitive(content))
+                    },
+                  )
+                }
+              } else {
+                null
+              }
+            }
+
+            "chat.history" -> {
+              json.parseToJsonElement("""{"sessionId":"workspace-share-chat","messages":[]}""")
+            }
+
+            "chat.metadata" -> {
+              json.parseToJsonElement("""{"commands":[],"models":[]}""")
+            }
+
+            "sessions.list" -> {
+              json.parseToJsonElement("""{"sessions":[]}""")
+            }
+
+            "health", "sessions.subscribe", "sessions.messages.subscribe" -> {
+              JsonObject(emptyMap())
+            }
+
+            else -> {
+              null
+            }
+          }
+        webSocket.send(
+          buildJsonObject {
+            put("type", JsonPrimitive("res"))
+            put("id", id)
+            put("ok", JsonPrimitive(payload != null))
+            if (payload != null) {
+              put("payload", payload)
+            } else {
+              put(
+                "error",
+                buildJsonObject {
+                  put("code", JsonPrimitive("INVALID_REQUEST"))
+                  put("message", JsonPrimitive("Workspace share fixture does not implement this request: $method"))
+                },
+              )
+            }
+          }.toString(),
+        )
+      }
+    }
+
+  override fun close() = server.shutdown()
+}

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -384,6 +384,8 @@ Camera commands (foreground only; permission-gated): `camera.snap` (jpg), `camer
 
 Open **Work** from the sidebar's **Pages** menu to find the **Files** card. It browses the active agent's workspace through the read-only `agents.workspace.list` / `agents.workspace.get` gateway RPCs: directory drill-down, text and image previews, and export through the Android share sheet. There are no write operations, and previews are size-capped by the gateway.
 
+If the app cannot prepare a file or open the share sheet, it shows **Could not share file** and keeps the preview open so you can retry or go back.
+
 ## Review command approvals
 
 An operator connection with `operator.admin`, or a paired


### PR DESCRIPTION
Related: #127434 — this fixes Android failure handling and unpublished-attempt cleanup only. Successful-share retention policy and iOS remain separate follow-ups; this does not close that issue.

The source branch is in `openclaw/openclaw`, not a contributor fork.

## What Problem This Solves

Fixes an issue where users sharing a previewed workspace file could lose the preview or receive no useful error when Android could not prepare the export or open the share sheet.

## Why This Change Was Made

The Workspace Files share action now handles preparation and chooser failures together, removes only the unpublished attempt, and reports “Could not share file.” Previously published copies remain untouched so a failed or later same-name export cannot invalidate earlier URI grants. Successful-share expiry is intentionally unchanged.

## User Impact

A failed share leaves the preview available to retry or go back, with a visible error instead of an unexplained outcome. Successful text and image sharing retains its existing behavior.

## Evidence

- **Before, installed:** from a loaded short-text preview, one Share action with an owned obstruction at the export-cache path was followed by the Android launcher. The negative run remained failed. No fatal stack or process-death evidence was captured, so neither is claimed.
- **After, installed:** the same obstruction produced the normal-duration “Could not share file” toast while retaining the preview. Removing the obstruction allowed retry from that preview. Two same-name text exports and a PNG then reached a separately signed, distinct-UID receiver through the real Android share sheet and an isolated real Gateway. The same receiver Activity reread all previously granted URIs on each delivery: histories of one, two, and three files retained their exact bytes and hashes.
- **Regression tests:** all 28 focused tests passed across Play and third-party debug flavors, covering the Compose Share action, workspace parsing, and the existing export sibling. Malformed Base64 and chooser exceptions are unit-test coverage, not additional installed scenarios.
- Both isolated proof lifetimes completed cleanup, including the owned obstruction, native/Gateway processes, and lease stop.

The before APK is qualified against the identical Workspace Files owner preimage for this short-file case—not as whole-APK equivalence or an exact-parent upgrade comparison.

| Before: launcher after failed Share | After: preview retained with visible error |
| --- | --- |
| ![Launcher after one obstructed workspace Share](https://github.com/user-attachments/assets/96012bd7-5be2-4970-99cd-c2722247cd60) | ![Workspace preview retained with Could not share file](https://github.com/user-attachments/assets/306843fa-4441-4808-b3b4-b69b1a8e3670) |

These are inspected original frames from synthetic-only, isolated API 36 guests.

Production Kotlin is +20/-18 (net +2): one canonical exception/cleanup boundary replaces the duplicate writes and silent Base64 return. The small growth provides the missing user-visible failure outcome. Tests add 459 lines across four real-screen cases; native-source inventory adds one entry and docs add two lines. No new dependency, configuration, permission, schema, migration, retention policy, or public protocol is introduced.

All 15 local changed-file checks passed; Codex P2 review found no actionable findings. The complete current-main Workspace Files owner was byte-identical to the reviewed preimage at `9e75cf16f06b`. Exact-head hosted [CI33970826355](https://github.com/openclaw/openclaw/actions/runs/33970826355) completed successfully, including both phone-flavor tests, Wear tests, APK builds, Android lint, and the required CI gate.


### Review disposition

The exact-head review published at 14:41 UTC reports no introduced correctness or security finding. Its remaining note is reviewer-side DNS preventing source/image downloads. The maintainer directly inspected matching AndroidX Core 1.19.0 FileProvider source and bytecode for cache-root canonicalization, URI generation and file opening, Kotlin write behavior, and the original installed captures. The distinct-UID receiver read all three exports through actual Android grants. Those observations cover the dependency and image checks; no indefinite-grant, fatal-stack, or successful-retention-policy claim is made. The repair remains at the existing Share owner, and #127434 remains separate.
