### PR TITLE
fix(config): guide exec policy migration repairs

### DIFF
--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -187,8 +187,20 @@ Example schema:
 | `auto`      | Use allowlist policy, run deterministic matches directly, and send approval misses through OpenClaw's native auto reviewer before falling back to a human approval route. |
 | `full`      | Run host exec without approval prompts.                                                                                                                                   |
 
-Doctor migrates the retired persisted `tools.exec.security` / `tools.exec.ask`
-pair to `tools.exec.mode`.
+Doctor migrates supported legacy `tools.exec.security` / `tools.exec.ask` pairs
+to `tools.exec.mode`. If a deploy script, template, or config generator still
+sends the old fields, `config patch` and Gateway `config.patch` reject the mixed
+policy without changing the file. Update that source in the same exec object
+named by the error, including `agents.entries.<agentId>.tools.exec` for an agent
+override. Replace `security` / `ask` with the suggested `mode` value when an exact
+equivalent exists. For example, `security: "full", ask: "off"` becomes `mode: "full"`.
+
+An incomplete pair needs an explicit choice of the intended policy before
+conversion. Pairs with `ask: "always"`, or `security: "full", ask: "on-miss"`,
+have no exact mode equivalent: retain both legacy fields and remove `mode` from
+that same object to keep their policy. Preserve other exec settings when replacing
+an object. Run `openclaw doctor --fix` for a saved file that still needs migration;
+running it again does not update a stale deployment source.
 
 ### `exec.security`
 

--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -13,7 +13,8 @@ const configRuntime = await import("../config/config.js");
 const { clearConfigCache } = configRuntime;
 const { REDACTED_SENTINEL } = await import("../config/redact-snapshot.js");
 const runtimeSchema = await import("../config/runtime-schema.js");
-const { runConfigGet, runConfigSet, runConfigUnset } = await import("./config-cli.js");
+const { runConfigGet, runConfigPatch, runConfigSet, runConfigUnset } =
+  await import("./config-cli.js");
 const { withConfigFileHarness } = useConfigCliIntegrationHarness();
 
 function installRuntimeSchemaReadHook(hook: () => void | Promise<void>): void {
@@ -125,6 +126,52 @@ describe("config cli integration", () => {
       },
     );
   });
+
+  it.each(["root", "agent"])(
+    "repairs a stale deployment patch at %s scope without changing policy",
+    async (scope) => {
+      const configForExec = (exec: Record<string, string>) =>
+        scope === "root"
+          ? { tools: { exec } }
+          : { agents: { entries: { worker: { tools: { exec } } } } };
+      const migrated = configForExec({ mode: "ask" });
+      const migratedRaw = JSON.stringify(migrated) + "\n";
+      await withConfigFileHarness(
+        "openclaw-config-cli-patch-exec-mode-migrated-",
+        migratedRaw,
+        async ({ configPath, tempDir }) => {
+          const patchPath = path.join(tempDir, "patch.json5");
+          fs.writeFileSync(
+            patchPath,
+            JSON.stringify(configForExec({ security: "allowlist", ask: "on-miss" })),
+          );
+          const output = createTestRuntime();
+
+          await expect(
+            runConfigPatch({ cliOptions: { file: patchPath }, runtime: output.runtime }),
+          ).rejects.toThrow("__exit__:1");
+
+          expect(fs.readFileSync(configPath, "utf8")).toBe(migratedRaw);
+          const errors = output.errors.join("\n");
+          expect(errors).toContain(
+            scope === "root" ? "tools.exec.mode:" : "agents.entries.worker.tools.exec.mode:",
+          );
+          expect(errors).toContain('Replace security/ask with mode="ask"');
+          expect(errors).toContain("at this scope");
+
+          fs.writeFileSync(
+            patchPath,
+            JSON.stringify({ ...migrated, messages: { ackReaction: "✅" } }),
+          );
+          await runConfigPatch({ cliOptions: { file: patchPath }, runtime: output.runtime });
+          expect(JSON5.parse(fs.readFileSync(configPath, "utf8"))).toMatchObject({
+            ...migrated,
+            messages: { ackReaction: "✅" },
+          });
+        },
+      );
+    },
+  );
 
   it("conflicts when a top-level include changes after config set starts", async () => {
     await withConfigFileHarness(

--- a/src/cli/exec-policy-cli.ts
+++ b/src/cli/exec-policy-cli.ts
@@ -20,7 +20,7 @@ import {
   normalizeExecSecurity,
   normalizeExecTarget,
   readExecApprovalsSnapshot,
-  resolveExecModeFromPolicy,
+  resolveExactExecModeFromPolicy,
   resolveExecModePolicy,
   resolveExecApprovalsFromFile,
   restoreExecApprovalsSnapshotLocked,
@@ -190,14 +190,15 @@ function applyConfigExecPolicy(draft: Record<string, unknown>, policy: ExecPolic
     });
     const security = policy.security ?? currentPolicy.security;
     const ask = policy.ask ?? currentPolicy.ask;
-    if (ask === "always" || (security === "full" && ask === "on-miss")) {
+    const mode = resolveExactExecModeFromPolicy({ security, ask });
+    if (mode) {
+      root.tools.exec.mode = mode;
+      delete root.tools.exec.security;
+      delete root.tools.exec.ask;
+    } else {
       delete root.tools.exec.mode;
       root.tools.exec.security = security;
       root.tools.exec.ask = ask;
-    } else {
-      root.tools.exec.mode = resolveExecModeFromPolicy({ security, ask });
-      delete root.tools.exec.security;
-      delete root.tools.exec.ask;
     }
   }
 }

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.tier-eval.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.tier-eval.ts
@@ -1,5 +1,6 @@
 // Tier-eval config compatibility migration and its scoped traversal helpers.
 import { ensureRecord, getRecord } from "../../../config/legacy.shared.js";
+import { resolveExactExecModeFromPolicy } from "../../../infra/exec-approvals-core.js";
 import {
   deleteRetiredPath,
   visitAgentConfigScopes,
@@ -93,31 +94,28 @@ function migrateExecMode(
     delete exec.ask;
     return;
   }
-  const securityValid =
-    exec.security === "deny" || exec.security === "allowlist" || exec.security === "full";
-  const askValid = exec.ask === "on-miss" || exec.ask === "always" || exec.ask === "off";
+  const ownSecurity =
+    exec.security === "deny" || exec.security === "allowlist" || exec.security === "full"
+      ? exec.security
+      : undefined;
+  const ownAsk =
+    exec.ask === "on-miss" || exec.ask === "always" || exec.ask === "off" ? exec.ask : undefined;
   if (
-    (Object.hasOwn(exec, "security") && !securityValid) ||
-    (Object.hasOwn(exec, "ask") && !askValid)
+    (Object.hasOwn(exec, "security") && !ownSecurity) ||
+    (Object.hasOwn(exec, "ask") && !ownAsk)
   ) {
     return;
   }
-  const security = securityValid ? exec.security : inheritedPolicy?.security;
-  const ask = askValid ? exec.ask : inheritedPolicy?.ask;
+  const security = ownSecurity ?? inheritedPolicy?.security;
+  const ask = ownAsk ?? inheritedPolicy?.ask;
   if (!security || !ask) {
     return;
   }
-  if (ask === "always" || (security === "full" && ask === "on-miss")) {
+  const mode = resolveExactExecModeFromPolicy({ security, ask });
+  if (!mode) {
     return;
   }
-  exec.mode =
-    security === "deny"
-      ? "deny"
-      : security === "allowlist" && ask === "off"
-        ? "allowlist"
-        : security === "full"
-          ? "full"
-          : "ask";
+  exec.mode = mode;
   changes.push(`Moved ${path}.tools.exec.security/ask → ${path}.tools.exec.mode.`);
   delete exec.security;
   delete exec.ask;

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1031,33 +1031,42 @@ describe("config schema", () => {
     expect(config.agents?.entries?.main?.tools?.exec?.reviewer?.model).toBe("openai/gpt-5.5");
   });
 
-  it("rejects mixed normalized and legacy exec policy config", () => {
-    expect(
-      ToolsSchema.safeParse({
-        exec: {
-          mode: "auto",
-          ask: "always",
-        },
-      }).success,
-    ).toBe(false);
-
-    expect(
-      OpenClawSchema.safeParse({
-        agents: {
-          list: [
-            {
-              id: "main",
-              tools: {
-                exec: {
-                  mode: "full",
-                  security: "deny",
-                },
-              },
-            },
-          ],
-        },
-      }).success,
-    ).toBe(false);
+  it.each([
+    { policy: { security: "full", ask: "off" }, hint: 'Replace security/ask with mode="full"' },
+    {
+      policy: { security: "allowlist", ask: "on-miss" },
+      hint: 'Replace security/ask with mode="ask"',
+    },
+    { policy: { security: "full", ask: "on-miss" }, hint: "no exact mode equivalent" },
+    { policy: { security: "allowlist", ask: "always" }, hint: "no exact mode equivalent" },
+    { policy: { security: "deny" }, hint: "legacy policy is incomplete" },
+    { policy: { ask: "off" }, hint: "legacy policy is incomplete" },
+  ])("rejects mixed exec policy with accurate repair guidance: $policy", ({ policy, hint }) => {
+    for (const scope of ["root", "agent"]) {
+      const exec = { mode: "auto", ...policy };
+      const result = OpenClawSchema.safeParse(
+        scope === "root"
+          ? { tools: { exec } }
+          : { agents: { entries: { worker: { tools: { exec } } } } },
+      );
+      expect(result.success).toBe(false);
+      expect(result.error?.issues).toEqual([
+        expect.objectContaining({
+          path:
+            scope === "root"
+              ? ["tools", "exec", "mode"]
+              : ["agents", "entries", "worker", "tools", "exec", "mode"],
+          message: expect.stringContaining(hint),
+        }),
+      ]);
+      const message = result.error?.issues[0]?.message;
+      expect(message).toContain("same exec object");
+      expect(message).toContain("deploy script, template, or patch at this scope");
+      expect(message).toContain('run "openclaw doctor --fix"');
+      if (!hint.startsWith("Replace")) {
+        expect(message).not.toContain("the equivalent of");
+      }
+    }
   });
 
   it("accepts the update_plan tool switch in the runtime zod schema", () => {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -11,6 +11,11 @@ import { splitSandboxBindSpec } from "../agents/sandbox/bind-spec.js";
 import { isSandboxHostPathAbsolute } from "../agents/sandbox/host-paths.js";
 import { getBlockedNetworkModeReason } from "../agents/sandbox/network-mode.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
+import {
+  resolveExactExecModeFromPolicy,
+  type ExecAsk,
+  type ExecSecurity,
+} from "../infra/exec-approvals-core.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { MANAGED_GITHUB_PROFILE_ID_PATTERN } from "./github-identity-profile-id.js";
 import { LEGACY_WEB_SEARCH_PROVIDER_CONFIG_KEYS } from "./web-search-legacy-provider-keys.js";
@@ -540,16 +545,27 @@ const ToolExecBaseShape = {
 } as const;
 
 function addExecPolicyModeConflictIssue(
-  value: { mode?: unknown; security?: unknown; ask?: unknown },
+  value: { mode?: unknown; security?: ExecSecurity; ask?: ExecAsk },
   ctx: z.RefinementCtx,
 ): void {
   if (value.mode === undefined || (value.security === undefined && value.ask === undefined)) {
     return;
   }
+  // The issue path identifies root or agent scope; repair that same object without
+  // inferring missing policy values or using the lossy display-mode projection.
+  const exactMode =
+    value.security !== undefined && value.ask !== undefined
+      ? resolveExactExecModeFromPolicy({ security: value.security, ask: value.ask })
+      : null;
+  const repair = exactMode
+    ? `Replace security/ask with mode="${exactMode}" (the equivalent of security="${value.security}" + ask="${value.ask}").`
+    : value.security !== undefined && value.ask !== undefined
+      ? "This security/ask pair has no exact mode equivalent. To keep this policy, retain both legacy fields and remove mode."
+      : "The legacy policy is incomplete. Choose the intended security and ask values before converting; no mode equivalent can be inferred.";
   ctx.addIssue({
     code: z.ZodIssueCode.custom,
     path: ["mode"],
-    message: "tools.exec.mode cannot be combined with tools.exec.security or tools.exec.ask",
+    message: `mode cannot be combined with security or ask in the same exec object. Update the deploy script, template, or patch at this scope. ${repair} Doctor migrates supported legacy policies to mode; run "openclaw doctor --fix" only when the saved file still needs migration.`,
   });
 }
 

--- a/src/infra/exec-approvals-core.ts
+++ b/src/infra/exec-approvals-core.ts
@@ -101,6 +101,18 @@ export function resolveExecModeFromPolicy(params: {
   return "ask";
 }
 
+// Migration, policy writes, and repair hints must preserve policies that the
+// display-mode projection cannot express: always-ask and full/on-miss.
+export function resolveExactExecModeFromPolicy(params: {
+  security: ExecSecurity;
+  ask: ExecAsk;
+}): ExecMode | null {
+  if (params.ask === "always" || (params.security === "full" && params.ask === "on-miss")) {
+    return null;
+  }
+  return resolveExecModeFromPolicy(params);
+}
+
 export function resolveExecPolicyForMode(mode: ExecMode): {
   security: ExecSecurity;
   ask: ExecAsk;

--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -30,6 +30,7 @@ let normalizeExecApprovalUnavailableDecisions: typeof import("./exec-approvals.j
 let resolveExecApprovalUnavailableDecisions: typeof import("./exec-approvals.js").resolveExecApprovalUnavailableDecisions;
 let resolveExecApprovalRequestAllowedDecisions: typeof import("./exec-approvals.js").resolveExecApprovalRequestAllowedDecisions;
 let resolveExecModeFromPolicy: typeof import("./exec-approvals.js").resolveExecModeFromPolicy;
+let resolveExactExecModeFromPolicy: typeof import("./exec-approvals.js").resolveExactExecModeFromPolicy;
 let resolveExecModePolicy: typeof import("./exec-approvals.js").resolveExecModePolicy;
 let resolveExecPolicyForMode: typeof import("./exec-approvals.js").resolveExecPolicyForMode;
 
@@ -59,6 +60,7 @@ async function loadActualExecApprovalModules(): Promise<void> {
   resolveExecApprovalRequestAllowedDecisions =
     execApprovals.resolveExecApprovalRequestAllowedDecisions;
   resolveExecModeFromPolicy = execApprovals.resolveExecModeFromPolicy;
+  resolveExactExecModeFromPolicy = execApprovals.resolveExactExecModeFromPolicy;
   resolveExecModePolicy = execApprovals.resolveExecModePolicy;
   resolveExecPolicyForMode = execApprovals.resolveExecPolicyForMode;
 }
@@ -191,6 +193,21 @@ describe("exec approvals policy helpers", () => {
     { security: "full" as const, ask: "always" as const, expected: "ask" as const },
   ])("derives normalized exec mode from legacy policy %j", ({ security, ask, expected }) => {
     expect(resolveExecModeFromPolicy({ security, ask })).toBe(expected);
+  });
+
+  it.each([
+    { security: "deny" as const, ask: "off" as const, expected: "deny" as const },
+    { security: "deny" as const, ask: "on-miss" as const, expected: "deny" as const },
+    { security: "allowlist" as const, ask: "off" as const, expected: "allowlist" as const },
+    { security: "allowlist" as const, ask: "on-miss" as const, expected: "ask" as const },
+    { security: "full" as const, ask: "off" as const, expected: "full" as const },
+    // Only the retired pair can express these postures; migration and hints must not widen them.
+    { security: "full" as const, ask: "on-miss" as const, expected: null },
+    { security: "deny" as const, ask: "always" as const, expected: null },
+    { security: "allowlist" as const, ask: "always" as const, expected: null },
+    { security: "full" as const, ask: "always" as const, expected: null },
+  ])("resolves the exact exec mode for legacy policy %j", ({ security, ask, expected }) => {
+    expect(resolveExactExecModeFromPolicy({ security, ask })).toBe(expected);
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Fixes #137357. After Doctor converts an execution policy to `mode`, a deployment source that still writes `security` and `ask` gets a generic conflict error. Every redeploy fails until the source is corrected.

## Why This Change Was Made

Keep the strict refusal and make its repair accurate. Shared config validation tells the operator to update the script, template, or patch in the same execution-policy object identified by the issue path. It suggests an exact `mode` only for a complete representable pair. Incomplete policies require an explicit choice; nonrepresentable pairs keep their legacy fields without `mode`.

Doctor, `exec-policy set`, and the diagnostic now share the existing exact-conversion rule. The separate display projection remains unchanged. This removes Doctor's duplicate mapping and keeps policy meaning at its existing owner.

## User Impact

- Root and per-agent deployment sources get guidance for their own scope.
- Rejected CLI and Gateway writes leave saved configuration bytes unchanged.
- Updating a representable source to the suggested mode lets deployment finish.
- Zero new settings, changed defaults, accepted-shape changes, or migration-policy changes. Existing partial/inherited policies and nonrepresentable legacy policies retain their behavior.

The previous review's config-compatibility checkpoint is addressed by the shared mapping tests, Doctor/CLI coverage, and real preserved-policy proofs below. The reporter's actionable-refusal option is retained; no automatic legacy-write normalization is added.

## Evidence

Baseline: `31903060a5d4a98ccd367aa6f15e66339a3ddcba`.
Candidate: `ee46b20d1eb6847cdf413afb5ba5aca64b2d629d`.
Both runtimes were built from their identified source in an isolated, secretless environment.

| Scenario | Baseline | Candidate |
| --- | --- | --- |
| Real `config set --replace` → `doctor --fix --yes --non-interactive` → stale `config patch --stdin` | Generic error, exit 1, unchanged bytes | Exact repair guidance, exit 1, unchanged bytes |
| Follow the suggested repair and finish the deployment update | No suggested repair | Canonical policy and deployment setting saved successfully |
| Real Gateway `config.patch`, root and agent scope | Generic structured `INVALID_REQUEST` | Correct scoped issue, unchanged bytes, corrected patch accepted |
| Partial and nonrepresentable legacy writes | Strict refusal retained | No invented mode equivalent; complete always-ask policy remains usable through Doctor |

Validation:

```sh
node scripts/run-vitest.mjs src/config/schema.test.ts src/cli/config-cli.integration.test.ts src/cli/exec-policy-cli.test.ts src/infra/exec-approvals-policy.test.ts src/commands/doctor/shared/legacy-config-migrations.runtime.retired.test.ts
# 300 tests passed

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cli/config-cli.integration.test.ts src/cli/exec-policy-cli.ts src/commands/doctor/shared/legacy-config-migrations.runtime.tier-eval.ts src/config/schema.test.ts src/config/zod-schema.agent-runtime.ts src/infra/exec-approvals-core.ts src/infra/exec-approvals-policy.test.ts
# Zero warnings or errors
```

All six schema regression cases and both CLI recovery cases fail on pre-fix production because the guidance is missing. The CLI tests then follow the repair to a successful write. Formatting, max-lines and assertion-safety checks, and `git diff --check` pass. Documentation now explains exact, incomplete, and nonrepresentable cases.

Production: +27 lines; tests: +73; docs: +12. The production growth supplies conditional recovery guidance and the shared exact conversion boundary for three real callers; no new compatibility writer or configuration surface is introduced.

Original contribution by @ylcn91; reported by @technicalpickles. AI-assisted repair and verification.

Additional real per-agent proof ran `config set` → Doctor → rejected stale patch → corrected deployment and compared requested/effective security, ask, host, and fallback policy before and after: unchanged.

Named follow-up from baseline fixture setup: investigate `config.patch` normalization of legacy per-agent `default` markers, which produced a separate `agents.ownership` error. The execution-policy proof uses the supported explicit roster and does not change roster behavior. Doctor's optional UI rebuild also reported a build-identity mismatch in the runtime-only fixture; no Control UI behavior is claimed here.
