### PR TITLE
fix(sessions): reduce cold catalog listing delays

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2625,7 +2625,7 @@ src/config/sessions/session-accessor.sqlite-canonical-inventory.ts	1
 src/config/sessions/session-accessor.sqlite-checkpoint.ts	3
 src/config/sessions/session-accessor.sqlite-delta.ts	2
 src/config/sessions/session-accessor.sqlite-entry-availability.ts	1
-src/config/sessions/session-accessor.sqlite-entry-cache.ts	3
+src/config/sessions/session-accessor.sqlite-entry-cache.ts	2
 src/config/sessions/session-accessor.sqlite-entry.ts	1
 src/config/sessions/session-accessor.sqlite-history-events.ts	2
 src/config/sessions/session-accessor.sqlite-message-cut.ts	1

--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -238,6 +238,8 @@ describe("SQLite session entry cache", () => {
   ])("preserves list parsing for %s rows", (_name, entryJson, readable) => {
     const scope = createSessionScope("raw-list-projection");
     const database = openOpenClawAgentDatabase(scope);
+    // Raw runtime writes follow canonical admission; this case isolates subsequent JSON decoding.
+    listSessionEntriesCore(scope);
     database.db
       .prepare(
         "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, ?, ?, ?)",
@@ -357,6 +359,7 @@ describe("SQLite session entry cache", () => {
     const primary = openOpenClawAgentDatabase(scope);
     const first = listSessionEntriesCore({ ...scope, clone: false });
     const alternate = new DatabaseSync(primary.path, { readOnly: true });
+    const parse = vi.spyOn(JSON, "parse");
 
     try {
       parseSessionEntryCalls.mockClear();
@@ -366,7 +369,9 @@ describe("SQLite session entry cache", () => {
       );
       expect(alternateSnapshot.entries.get(scope.sessionKey)?.label).toBe("connection-identity");
       const alternateEntry = alternateSnapshot.entries.get(scope.sessionKey);
-      expect(parseSessionEntryCalls).toHaveBeenCalledOnce();
+      expect(
+        parse.mock.calls.filter(([json]) => json.includes('"sessionId":"connection-identity"')),
+      ).toHaveLength(1);
 
       parseSessionEntryCalls.mockClear();
       const second = listSessionEntriesCore({ ...scope, clone: false });
@@ -382,7 +387,11 @@ describe("SQLite session entry cache", () => {
 
       expect(alternateAgain.entries.get(scope.sessionKey)).toBe(alternateEntry);
       expect(parseSessionEntryCalls).not.toHaveBeenCalled();
+      expect(
+        parse.mock.calls.filter(([json]) => json.includes('"sessionId":"connection-identity"')),
+      ).toHaveLength(1);
     } finally {
+      parse.mockRestore();
       clearNodeSqliteKyselyCacheForDatabase(alternate);
       alternate.close();
     }

--- a/src/config/sessions/session-accessor.sqlite-entry-cache.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-cache.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 import { executeSqliteQuerySync, iterateSqliteQuerySync } from "../../infra/kysely-sync.js";
+import { readSqliteDataVersion } from "../../infra/node-sqlite.js";
 import {
   deferOpenClawAgentPostCommitPublication,
   type OpenClawAgentDatabase,
@@ -11,6 +12,10 @@ import {
 } from "./session-accessor.sqlite-participant-projection.js";
 import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
 import { parseSessionEntryJson, selectSessionEntryRows } from "./session-accessor.sqlite-status.js";
+import {
+  assertCanonicalSqliteSessionKeysCurrent,
+  type ValidatedSessionMetadata,
+} from "./session-canonical-key.js";
 import type { SessionEntry } from "./types.js";
 
 type SessionEntryCacheDatabase = Pick<OpenClawAgentDatabase, "agentId" | "db">;
@@ -42,14 +47,6 @@ type SqliteSessionEntryCacheWriteGeneration = {
 // every entry_json document.
 const sessionEntryCaches = new WeakMap<DatabaseSync, SqliteSessionEntryCache>();
 const sessionNodesGenerationTrackerSchemaVersions = new WeakMap<DatabaseSync, number>();
-
-function readDataVersion(database: DatabaseSync): number {
-  const row = database.prepare("PRAGMA data_version").get() as { data_version?: unknown };
-  if (typeof row.data_version !== "number") {
-    throw new Error("SQLite did not return a numeric PRAGMA data_version");
-  }
-  return row.data_version;
-}
 
 function ensureSessionNodesGenerationTracker(database: DatabaseSync): void {
   const schemaRow = database.prepare("PRAGMA schema_version").get() as {
@@ -95,7 +92,7 @@ function readSessionNodesGeneration(database: DatabaseSync): number {
 
 function readCacheValidityToken(database: DatabaseSync): SqliteSessionEntryCacheValidityToken {
   return {
-    dataVersion: readDataVersion(database),
+    dataVersion: readSqliteDataVersion(database),
     sessionNodesGeneration: readSessionNodesGeneration(database),
   };
 }
@@ -127,21 +124,26 @@ export function trackSessionEntryCacheWrite(
 function loadSessionEntrySnapshot(
   database: SessionEntryCacheDatabase,
   projection: "full" | "list" = "list",
+  prepared?: ValidatedSessionMetadata,
 ): SessionEntryCacheSnapshot {
-  const rows = iterateSqliteQuerySync(
-    database.db,
-    selectSessionEntryRows(database, projection).select("updated_at").orderBy("session_key"),
-  );
-  const parsedEntries = new Map<string, SessionEntry>();
-  const keys: string[] = [];
+  // Validation lends complete parsed facts only within this read. A concurrent external commit
+  // requires the ordinary fresh SELECT, never a stale snapshot stamped with its newer version.
+  const metadata =
+    prepared && prepared.dataVersion === readSqliteDataVersion(database.db) ? prepared : undefined;
+  const parsedEntries = metadata?.entries ?? new Map<string, SessionEntry>();
+  const keys = metadata?.keys ?? [];
   // Stream raw JSON so a full read never holds both serialized and parsed store-wide payloads.
-  for (const row of rows) {
-    keys.push(row.session_key);
-    const entry = parseSessionEntryJson(row, projection);
-    if (!entry) {
-      continue;
+  if (!metadata) {
+    for (const row of iterateSqliteQuerySync(
+      database.db,
+      selectSessionEntryRows(database, projection).select("updated_at").orderBy("session_key"),
+    )) {
+      keys.push(row.session_key);
+      const entry = parseSessionEntryJson(row, projection);
+      if (entry) {
+        parsedEntries.set(row.session_key, entry);
+      }
     }
-    parsedEntries.set(row.session_key, entry);
   }
   const entries = projectSqliteSessionParticipantsBatch(database.db, parsedEntries);
   return {
@@ -154,13 +156,18 @@ export function readSessionEntryCache(
   database: SessionEntryCacheDatabase,
   options: { cache: boolean; latest?: boolean; projection?: "full" | "list" },
 ): SessionEntryCacheSnapshot {
+  const prepared = assertCanonicalSqliteSessionKeysCurrent(
+    database,
+    undefined,
+    options.projection !== "full",
+  );
   if (
     !options.cache ||
     options.latest ||
     options.projection === "full" ||
     database.db.isTransaction
   ) {
-    return loadSessionEntrySnapshot(database, options.projection);
+    return loadSessionEntrySnapshot(database, options.projection, prepared);
   }
   const validityToken = readCacheValidityToken(database.db);
   const cached = sessionEntryCaches.get(database.db);
@@ -169,7 +176,7 @@ export function readSessionEntryCache(
   }
   // Only tracked publications identify changed rows. A generation gap can contain
   // same-timestamp or owner-only edits; updated_at cannot validate a partial reload.
-  const loaded = loadSessionEntrySnapshot(database);
+  const loaded = loadSessionEntrySnapshot(database, options.projection, prepared);
   const next = { ...loaded, validityToken };
   sessionEntryCaches.set(database.db, next);
   return next;

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -286,7 +286,6 @@ function listSqliteSessionEntriesFromDatabase(
   resolved: ResolvedSqliteScope,
   scope: SessionEntryListScope,
 ): SessionEntrySummary[] {
-  assertCanonicalSqliteSessionKeysCurrent(database);
   const projection = scope.projection ?? "full";
   const cache = !isIncognitoOpenClawAgentSqlitePath(database.path, {
     agentId: database.agentId,

--- a/src/config/sessions/session-canonical-key.test.ts
+++ b/src/config/sessions/session-canonical-key.test.ts
@@ -1,13 +1,26 @@
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { FIRST_USE_ADDITIVE_AGENT_COLUMN_DEFINITIONS } from "../../state/openclaw-agent-db-additive-columns.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { loadSessionEntryReadOnly, upsertSessionEntryCore } from "./session-accessor.js";
+import {
+  assignSessionOwner,
+  listSessionEntriesReadOnly,
+  loadSessionEntryReadOnly,
+  recordSessionParticipant,
+  replaceSessionEntrySync,
+  upsertSessionEntryCore,
+} from "./session-accessor.js";
 import { scanDoctorSessionEntriesStrict } from "./session-accessor.sqlite-canonical-inventory.js";
+import { readSessionEntryCache } from "./session-accessor.sqlite-entry-cache.js";
+import { ensureTranscriptSessionRoot } from "./session-accessor.sqlite-transcript-state.js";
+import { setCanonicalSqliteSessionMainKey } from "./session-canonical-key.js";
 import type { SessionEntry } from "./types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -28,6 +41,229 @@ function createScope() {
 }
 
 describe("cold canonical session validation", () => {
+  it("lists existing metadata without creating absent owner columns", () => {
+    const scope = createScope();
+    replaceSessionEntrySync(scope, { sessionId: "cold-key", updatedAt: 1, label: "existing" });
+    const database = openOpenClawAgentDatabase({ ...scope, path: scope.storePath });
+    for (const { columnName } of FIRST_USE_ADDITIVE_AGENT_COLUMN_DEFINITIONS) {
+      database.db.exec(`ALTER TABLE session_nodes DROP COLUMN ${columnName}`);
+    }
+    closeOpenClawAgentDatabasesForTest();
+    expect(listSessionEntriesReadOnly({ ...scope, projection: "list" })[0]?.entry).toEqual({
+      sessionId: "cold-key",
+      updatedAt: 1,
+      label: "existing",
+      delivery: { kind: "none" },
+    });
+    const readOnly = new DatabaseSync(scope.storePath, { readOnly: true });
+    try {
+      const names = new Set(
+        readOnly
+          .prepare("PRAGMA table_info(session_nodes)")
+          .all()
+          .map((row) => row.name),
+      );
+      expect(
+        FIRST_USE_ADDITIVE_AGENT_COLUMN_DEFINITIONS.every(
+          ({ columnName }) => !names.has(columnName),
+        ),
+      ).toBe(true);
+    } finally {
+      readOnly.close();
+    }
+  });
+
+  it.each([
+    '{"sessionId":null,"sessionId":"cold-key","updatedAt":1}',
+    '{"sessionId":"cold-key","updatedAt":1,"skillsSnapshot":{},"skillsSnapshot":{"prompt":"last","skills":[]}}',
+    `{"sessionId":"cold-key","updatedAt":1,"skillsSnapshot":{"prompt":${"[".repeat(1001)}0${"]".repeat(1001)},"skills":[]}}`,
+  ])("keeps source-JSON fallback semantics in the cold metadata handoff (%#)", (entryJson) => {
+    const scope = createScope();
+    replaceSessionEntrySync(scope, { sessionId: "cold-key", updatedAt: 1 });
+    const database = openOpenClawAgentDatabase({ ...scope, path: scope.storePath });
+    database.db
+      .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+      .run(entryJson, scope.sessionKey);
+    database.db
+      .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
+      .run(scope.sessionKey);
+    closeOpenClawAgentDatabasesForTest();
+    const rows = listSessionEntriesReadOnly({ ...scope, projection: "list" });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.entry).toEqual({ sessionId: "cold-key", updatedAt: 1 });
+  });
+
+  it("keeps timestamp-mismatched keys without strengthening Doctor validation", () => {
+    const scope = createScope();
+    replaceSessionEntrySync(scope, { sessionId: "cold-key", updatedAt: 1 });
+    const database = openOpenClawAgentDatabase({ ...scope, path: scope.storePath });
+    database.db
+      .prepare("UPDATE session_nodes SET updated_at = 2 WHERE session_key = ?")
+      .run(scope.sessionKey);
+    database.db
+      .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
+      .run(scope.sessionKey);
+    closeOpenClawAgentDatabasesForTest();
+    const held = openOpenClawAgentDatabase({ ...scope, path: scope.storePath });
+    expect(listSessionEntriesReadOnly({ ...scope, projection: "list" })).toEqual([]);
+    const cached = readSessionEntryCache(held, { cache: true });
+    expect(cached.keys).toEqual([scope.sessionKey]);
+    expect(cached.entries.size).toBe(0);
+    const doctor: SessionEntry[] = [];
+    expect(scanDoctorSessionEntriesStrict(scope, ({ entry }) => doctor.push(entry))).toBe(1);
+    expect(doctor[0]?.updatedAt).toBe(1);
+  });
+
+  it("reloads metadata when another connection commits during canonical validation", () => {
+    const scope = createScope();
+    const entry = { sessionId: "cold-key", updatedAt: 1, label: "before" };
+    replaceSessionEntrySync(scope, entry);
+    closeOpenClawAgentDatabasesForTest();
+    openOpenClawAgentDatabase({ ...scope, path: scope.storePath });
+    const writer = new DatabaseSync(scope.storePath);
+    const originalParse = JSON.parse;
+    let committed = false;
+    const parse = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+      const value = originalParse(text, reviver);
+      if (!committed && value?.sessionId === entry.sessionId && value?.label === "before") {
+        committed = true;
+        writer.exec("BEGIN IMMEDIATE");
+        writer
+          .prepare("UPDATE session_nodes SET entry_json = ?, label = 'after' WHERE session_key = ?")
+          .run(JSON.stringify({ ...entry, label: "after" }), scope.sessionKey);
+        writer
+          .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
+          .run(scope.sessionKey);
+        writer.exec("COMMIT");
+      }
+      return value;
+    });
+    try {
+      expect(listSessionEntriesReadOnly({ ...scope, projection: "list" })[0]?.entry.label).toBe(
+        "after",
+      );
+      expect(committed).toBe(true);
+      expect(listSessionEntriesReadOnly({ ...scope, projection: "list" })[0]?.entry.label).toBe(
+        "after",
+      );
+    } finally {
+      parse.mockRestore();
+      writer.close();
+    }
+  });
+
+  it("does not publish a partial snapshot after a later malformed row", () => {
+    const scope = createScope();
+    const otherKey = "agent:main:z-later";
+    replaceSessionEntrySync(scope, { sessionId: "cold-key", updatedAt: 1, label: "before" });
+    replaceSessionEntrySync(
+      { ...scope, sessionKey: otherKey },
+      { sessionId: "later", updatedAt: 1 },
+    );
+    const database = openOpenClawAgentDatabase({ ...scope, path: scope.storePath });
+    database.db
+      .prepare("UPDATE session_nodes SET entry_json = '{' WHERE session_key = ?")
+      .run(otherKey);
+    closeOpenClawAgentDatabasesForTest();
+    const held = openOpenClawAgentDatabase({ ...scope, path: scope.storePath });
+    expect(() => listSessionEntriesReadOnly({ ...scope, projection: "list" })).toThrow(
+      "openclaw doctor --fix",
+    );
+    expect(() => listSessionEntriesReadOnly({ ...scope, projection: "list" })).toThrow(
+      "openclaw doctor --fix",
+    );
+    for (const [key, id] of [
+      [scope.sessionKey, "cold-key"],
+      [otherKey, "later"],
+    ] as const) {
+      held.db
+        .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+        .run(JSON.stringify({ sessionId: id, updatedAt: 1, label: "repaired" }), key);
+      held.db.prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?").run(key);
+    }
+    expect(
+      listSessionEntriesReadOnly({ ...scope, projection: "list" }).map(({ entry }) => entry.label),
+    ).toEqual(["repaired", "repaired"]);
+  });
+
+  it("rejects the retired main alias on a cold listing", () => {
+    const scope = { ...createScope(), sessionKey: "agent:main:main" };
+    replaceSessionEntrySync(scope, { sessionId: "main-alias", updatedAt: 1 });
+    const database = openOpenClawAgentDatabase({ ...scope, path: scope.storePath });
+    setCanonicalSqliteSessionMainKey(database, "custom");
+    closeOpenClawAgentDatabasesForTest();
+    expect(() => listSessionEntriesReadOnly({ ...scope, projection: "list" })).toThrow(
+      "openclaw doctor --fix",
+    );
+  });
+
+  it.each([false, true])(
+    "decodes cold list metadata once and preserves projected values (retained handle: %s)",
+    (retained) => {
+      const scope = createScope();
+      const sourceOwner = { actor: { type: "agent" as const, id: "json-owner" } };
+      replaceSessionEntrySync(scope, {
+        sessionId: "cold-key",
+        updatedAt: 1,
+        owner: sourceOwner,
+        skillsSnapshot: { prompt: "saved prompt".repeat(4096), skills: [] },
+      });
+      assignSessionOwner(scope, {
+        owner: { type: "agent", id: "column-owner" },
+        assignedBy: { type: "agent", id: "assigner" },
+        assignedAt: 2,
+      });
+      recordSessionParticipant(scope, {
+        identity: { type: "profile", id: "participant" },
+        promptedAt: 3,
+      });
+      const placeholderKey = "agent:main:retained";
+      runOpenClawAgentWriteTransaction((database) => {
+        ensureTranscriptSessionRoot(
+          database,
+          { ...scope, sessionKey: placeholderKey, sessionId: "retained" },
+          4,
+        );
+      }, scope);
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      const database = retained
+        ? openOpenClawAgentDatabase({ ...scope, path: scope.storePath })
+        : undefined;
+      const parse = vi.spyOn(JSON, "parse");
+      try {
+        const rows = listSessionEntriesReadOnly({ ...scope, projection: "list", clone: false });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.entry).toMatchObject({
+          sessionId: "cold-key",
+          owner: {
+            actor: { type: "agent", id: "column-owner" },
+            assignedBy: { type: "agent", id: "assigner" },
+            assignedAt: 2,
+          },
+          participants: [{ identity: { type: "profile", id: "participant" } }],
+          participantCount: 1,
+        });
+        expect(rows[0]?.entry.skillsSnapshot).toBeUndefined();
+        expect(
+          parse.mock.calls.filter(([value]) => value.includes('"sessionId":"cold-key"')),
+        ).toHaveLength(1);
+        if (database) {
+          const cached = readSessionEntryCache(database, { cache: true });
+          expect(cached.keys).toEqual([scope.sessionKey, placeholderKey]);
+          expect(cached.entries.has(placeholderKey)).toBe(false);
+          expect(cached.entries.get(scope.sessionKey)).toBe(rows[0]?.entry);
+        }
+      } finally {
+        parse.mockRestore();
+      }
+      const doctor: SessionEntry[] = [];
+      expect(scanDoctorSessionEntriesStrict(scope, ({ entry }) => doctor.push(entry))).toBe(1);
+      expect(doctor[0]?.owner).toBeUndefined();
+      expect(doctor[0]?.skillsSnapshot?.prompt).toBe("saved prompt".repeat(4096));
+    },
+  );
+
   it("omits saved prompts before decoding keys but retains them for Doctor", async () => {
     const scope = createScope();
     const prompt = "synthetic saved prompt ".repeat(8192);

--- a/src/config/sessions/session-canonical-key.ts
+++ b/src/config/sessions/session-canonical-key.ts
@@ -5,6 +5,7 @@ import {
   getNodeSqliteKysely,
   iterateSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
+import { readSqliteDataVersion } from "../../infra/node-sqlite.js";
 import {
   normalizeAgentId,
   normalizeMainKey,
@@ -16,6 +17,10 @@ import {
 } from "../../state/openclaw-agent-db-contract.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import {
+  hasSqliteSessionOwnerColumns,
+  projectSqliteSessionOwner,
+} from "./session-accessor.sqlite-owner-projection.js";
 import { sessionEntryMetadataJson } from "./session-accessor.sqlite-status.js";
 import { parseSqliteSessionEntryRecord } from "./session-entry-json.js";
 import { projectCanonicalSessionEntryShape } from "./store-entry-shape.js";
@@ -31,6 +36,13 @@ type CanonicalSessionDatabase = Pick<
   "schema_meta" | "session_key_contract" | "session_nodes" | "session_windows"
 >;
 const validatedDatabases = new WeakSet<DatabaseSync>();
+
+type CanonicalSessionMetadata = {
+  entries: Map<string, SessionEntry>;
+  keys: string[];
+};
+
+export type ValidatedSessionMetadata = CanonicalSessionMetadata & { dataVersion: number };
 
 class SessionCanonicalKeyMigrationRequiredError extends Error {
   readonly code = "SESSION_CANONICAL_KEY_MIGRATION_REQUIRED";
@@ -126,6 +138,7 @@ export function scanCanonicalSqliteSessionEntries(
   database: { agentId: string; db: DatabaseSync },
   visit?: (summary: { entry: SessionEntry; sessionKey: string }) => void,
   mainKey?: string,
+  metadata?: CanonicalSessionMetadata,
 ): number {
   // This connection validates once. External direct-SQLite edits surface at the next
   // process start, not the next topology change; doctor owns live repair.
@@ -156,8 +169,20 @@ export function scanCanonicalSqliteSessionEntries(
       ])
       // Key validation needs metadata; Doctor visitors still own complete saved entries.
       .select(visit ? "session_nodes.entry_json" : sessionEntryMetadataJson)
+      .$if(Boolean(metadata), (query) => query.select("session_nodes.updated_at"))
+      .$if(Boolean(metadata) && hasSqliteSessionOwnerColumns(database.db), (query) =>
+        query.select([
+          "session_nodes.owner_actor_type",
+          "session_nodes.owner_actor_id",
+          "session_nodes.owner_assigned_by_type",
+          "session_nodes.owner_assigned_by_id",
+          "session_nodes.owner_assigned_at",
+        ]),
+      )
       .orderBy("session_nodes.session_key"),
   )) {
+    // Retained windows have no entry, but their keys remain part of a listing snapshot.
+    metadata?.keys.push(row.session_key);
     if (
       row.entry_json === "{}" &&
       row.entry_valid === -1 &&
@@ -165,7 +190,13 @@ export function scanCanonicalSqliteSessionEntries(
     ) {
       continue;
     }
-    const record = row.entry_valid === 1 ? parseSqliteSessionEntryRecord(row) : null;
+    const record =
+      row.entry_valid === 1
+        ? parseSqliteSessionEntryRecord({
+            entry_json: row.entry_json,
+            current_session_id: row.current_session_id,
+          })
+        : null;
     if (!record) {
       throw canonicalSessionKeyMigrationRequiredError(
         `invalid persisted session row requires repair for ${row.session_key}`,
@@ -220,6 +251,12 @@ export function scanCanonicalSqliteSessionEntries(
         );
       }
     }
+    if (metadata && record.updatedAt === row.updated_at) {
+      // List decoding also checks the row timestamp and strips SQL-fallback prompt payloads;
+      // neither rule belongs to canonical validation or Doctor's complete-entry visitor.
+      const { skillsSnapshot: _skills, systemPromptReport: _report, ...listEntry } = entry;
+      metadata.entries.set(row.session_key, projectSqliteSessionOwner(listEntry, row));
+    }
     visit?.({ entry, sessionKey: row.session_key });
     count += 1;
   }
@@ -230,10 +267,16 @@ export function scanCanonicalSqliteSessionEntries(
 export function assertCanonicalSqliteSessionKeysCurrent(
   database: { agentId: string; db: DatabaseSync },
   mainKey?: string,
-): void {
-  if (!validatedDatabases.has(database.db)) {
-    scanCanonicalSqliteSessionEntries(database, undefined, mainKey);
+  collectMetadata = false,
+): ValidatedSessionMetadata | undefined {
+  if (validatedDatabases.has(database.db)) {
+    return undefined;
   }
+  const metadata: ValidatedSessionMetadata | undefined = collectMetadata
+    ? { dataVersion: readSqliteDataVersion(database.db), entries: new Map(), keys: [] }
+    : undefined;
+  scanCanonicalSqliteSessionEntries(database, undefined, mainKey, metadata);
+  return metadata;
 }
 
 export function setCanonicalSqliteSessionMainKey(

--- a/src/infra/node-sqlite.ts
+++ b/src/infra/node-sqlite.ts
@@ -113,6 +113,16 @@ export function openNodeSqliteDatabase(
     : new sqlite.DatabaseSync(resolvedLocation, options);
 }
 
+/** Compare versions only across reads on the same connection. */
+export function readSqliteDataVersion(database: import("node:sqlite").DatabaseSync): number {
+  // SAFETY: SQLite names this PRAGMA's column data_version; its numeric value is checked below.
+  const row = database.prepare("PRAGMA data_version").get() as { data_version?: unknown };
+  if (typeof row.data_version !== "number") {
+    throw new Error("SQLite did not return a numeric PRAGMA data_version");
+  }
+  return row.data_version;
+}
+
 /** Hold a raw exclusive transaction until release for cross-process coordination. */
 export function tryAcquireExclusiveSqliteCoordinator(
   location: string,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators opening or refreshing session catalogs wait unnecessarily for locally stored metadata when database handles are cold. Large inventories amplify that delay.

## Why This Change Was Made

Reuse the metadata already parsed by canonical-key validation during the same listing read. The cache checks SQLite’s connection-local data version before consuming those complete facts and uses its existing fresh SELECT if an external commit intervened.

Retained-window keys, timestamp filtering, owner and participant projection, Doctor’s full entries, cache invalidation and fresh delivery privacy keep their existing contracts. No schema, migration, configuration, RPC, cache lifetime or retained-handle policy changes. Production LOC is +87/-28 (net +59); tests are +247/-2. The assertion baseline decreases one existing allowance from 3 to 2.

## User Impact

Cold metadata listings, including `sessions.catalog.list`, perform less synchronous work. The large-inventory proof showed roughly 31–33% shorter cold handler times. Warm full-page reads showed a modest measured increase, recorded below; this is not a universal speedup claim.

## Evidence

Linux Node 24.19.0 / SQLite 3.53.3 proof used the actual Gateway request router, synthetic authenticated connect metadata and real SQLite. All 864 final response digests and row, enumeration and progress counts matched between variants in each timing/SQL-diagnostic matrix. The matrix covers small/large inventories, sparse/full pages, temporary/held handles, native/adopted rows and progress/final delivery. A separate privacy control held provider planning fixed while a draft transition removed the progress row and restoration returned the final row. No WebSocket handshake or live provider call is claimed.

For two agents with 5,000 stored entries each and eight adopted hosts, handler elapsed medians were:

| Read condition | Before | After |
| --- | ---: | ---: |
| Temporary handles, 16 returned rows | 431.6 ms | 289.0 ms |
| Temporary handles, 5,000 returned rows | 538.4 ms | 369.9 ms |
| Warm retained handles, fresh catalog enumeration, 5,000 rows | 90.1 ms | 91.5 ms |
| Warm retained handles, cached catalog enumeration, 5,000 rows | 29.8 ms | 30.3 ms |

Cold cells use three miss/hit pairs. Warm cells use 60 observations per variant across two processes in ABBA order. The final large warm full-page median with fresh enumeration increased 1.6%; an earlier run measured 3.4%. The immediately repeated cached-enumeration request increased from 29.77 to 30.30 ms (1.8%). Both are retained, with no causal explanation inferred. Separate SQL diagnostics showed 11 metadata scans returning 55,000 rows versus 22 scans returning 110,000 rows in the large sparse cold case.

All 159 focused owner/sibling tests, focused typed lint, cycle checks and the complete unchanged changed-file gate passed. The original implementation failed both decode-once regressions. The full gate took 956.1 seconds; all observed process groups closed, source inventories stayed unchanged and the test lease is completed. Earlier assertion bookkeeping, fixture typing and lint failures were corrected and retained with the refused finished-lease reuse attempt.

The source proof used [base e55f25b](https://github.com/openclaw/openclaw/commit/e55f25b15ea61ab26ef9079b9afa279155689b50) plus this change. Rebasing onto current main preserved all six runtime/test postimages and merged only the strict assertion-count decrement into its updated baseline. Independent P2 review is clean. [Fresh exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33971634072) passed for `dc3abd02ce8fc494557bd723a9b57d02a9d552db` and the current dependency graph; CodeQL also passed.
