### PR TITLE
improve: reuse encoded properties in Gateway broadcasts

### DIFF
--- a/src/gateway/server-broadcast.serialization.test.ts
+++ b/src/gateway/server-broadcast.serialization.test.ts
@@ -79,6 +79,38 @@ afterEach(() => {
 });
 
 describe("broadcast serialization failures", () => {
+  it.each([
+    ["undefined", undefined],
+    ["function", () => "omitted"],
+    ["symbol", Symbol("omitted")],
+    ["escaped values", { text: '"🦞"\n\\\ud800', items: [undefined, Symbol("omitted")] }],
+    ["date", new Date("2026-01-01T00:00:00Z")],
+    [
+      "inherited toJSON",
+      new (class {
+        toJSON(key: string) {
+          return `field:${key}`;
+        }
+      })(),
+    ],
+    ["omitted toJSON", { toJSON: () => undefined }],
+  ])("preserves complete envelope bytes for %s payloads", (_name, payload) => {
+    const peer = makeClient("json-reader");
+    const { broadcast } = createGatewayBroadcaster({
+      clients: new GatewayClientRegistry([peer.client]),
+    });
+    const stateVersion = {
+      presence: 7,
+      toJSON: (key: string) => ({ presence: key.length }),
+    };
+
+    broadcast("skills.changed", payload, { stateVersion });
+
+    expect(peer.socket.send.mock.calls[0]?.[0]).toBe(
+      JSON.stringify({ type: "event", event: "skills.changed", payload, seq: 1, stateVersion }),
+    );
+  });
+
   it("delivers public suspension state to connected operators without read scope", () => {
     const peer = makeClient("suspension-viewer");
     peer.client.connect.scopes = [];

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -127,12 +127,10 @@ const SESSION_SUBSCRIPTION_EVENTS = new Set([
 ]);
 
 function serializeFrameField(name: "payload" | "stateVersion", value: unknown): string {
-  // Serialize one field through JSON.stringify so embedded values keep JSON
-  // escaping, then splice it into the shared per-client frame body.
+  // Keep the wrapper for toJSON's property key and reuse its serialized field.
+  // Only splice wrappers that still start with that field after inherited toJSON.
   const fieldJSON = JSON.stringify({ [name]: value });
-  const keyJSON = JSON.stringify(name);
-  const prefix = `{${keyJSON}:`;
-  return fieldJSON.startsWith(prefix) ? `,${keyJSON}:${fieldJSON.slice(prefix.length, -1)}` : "";
+  return fieldJSON.startsWith(`{"${name}":`) ? `,${fieldJSON.slice(1, -1)}` : "";
 }
 
 function resolveBroadcastSessionScope(


### PR DESCRIPTION
## What Problem This Solves

Gateway broadcast serialization encodes a complete property, then serializes its already-known name again and removes/rebuilds the same key prefix. This creates unnecessary work for payload and state-version fields. This is a maintainer-requested allocation improvement.

## Why This Change Was Made

Reuse the complete encoded property after the existing prefix check. Keep the JSON wrapper because `toJSON` receives the property key and an inherited hook can replace the wrapper. Both private field names are fixed ASCII identifiers. The [ECMAScript serialization contract](https://tc39.es/ecma262/2025/multipage/structured-data.html#sec-serializejsonproperty) and actual boundary fixtures confirm why these semantics remain necessary.

## User Impact

Broadcast fields avoid repeated key encoding while preserving exact frame bytes, omission/error behavior, recipient filtering, presence projection, per-client sequence handling and slow-consumer ownership. No protocol, dependency, configuration or event-access policy changes. Production LOC: +3/-5 (net -2); tests: +32/-0.

## Evidence

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-broadcast.serialization.test.ts src/gateway/server-broadcast.live-text.test.ts src/gateway/server-broadcast.transport.test.ts` passed 46 tests before and 53 after. Existing cases include real compressed WebSocket failure, healthy peer ordering, cancellation/retirement, recipient projection and complete-frame byte limits at/over the boundary.
- Seven added complete-envelope cases cover omitted undefined/functions/symbols, escaping, dates and own/inherited `toJSON`. They use the existing broadcaster/socket boundary and characterize preserved behavior.
- Actual broadcaster captures match byte for byte across 21 scenarios, including the field key received by `toJSON`, cycles/BigInt/throwing hooks, zero eligible recipients and inherited wrapper replacement. Isolated prototype experiments restore the prototype after each case and are kept out of the maintained parallel test suite. The prefix guard remains essential for those replacements.
- Five alternating baseline/candidate process pairs extracted the actual private helper with TypeScript annotations erased, preserving its body. Each used 50,000 warmups and 400,000 measured calls over four representative field shapes. Every checksum matched. Median total sampled allocation fell 140,913,800 → 108,983,704 bytes (-22.66%); median time 87.2115 → 76.3824 ms (-12.42%). Sampling includes collected objects and compiler attribution can shift; these are focused field-owner measurements, not retained memory, Gateway RSS or throughput proof.
- The pinned `ws` 8.21.3 send/buffering implementation, protocol schema, callers and typed Codex sibling transport were inspected. Formatting, diff checks and managed independent P2 review passed; both committed source hashes match the reviewed freeze. Exact-head hosted CI and native preparation remain pending.

Named follow-up: `docs/gateway/protocol.md` still lists presence among unrestricted status events, whereas the existing `READ_SCOPE` guard and `docs/concepts/presence.md` require read access. That pre-existing documentation mismatch needs a separate correction; this serialization patch preserves the current access policy.

Data-model compatibility review: the serialized value here is a transient WebSocket EventFrame, not a persistent store or schema. The EventFrame schema and protocol version are unchanged. All 21 actual broadcaster boundary cases retain identical complete frame bytes (SHA-256 `115226a75cfb72064624a5b0b3a3277d6f624b9b93ff1870b44e638179af2ee2`), including optional fields, escaping, root/property toJSON and exceptions. Existing clients therefore receive the same envelope; no data migration or upgrade action exists. This addresses the latest ClawSweeper pre-merge compatibility request; no code/security findings or separate rank-up moves remain. Exact-head CI run 33971849507 passed.
