### PR TITLE
test(update): exercise repair through native built runtime

### DIFF
--- a/src/infra/update-repair-agent.e2e.test.ts
+++ b/src/infra/update-repair-agent.e2e.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import type { ServerResponse } from "node:http";
 import path from "node:path";
 import { text as readText } from "node:stream/consumers";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   writeOpenAiResponsesSse,
   writeOpenAiResponsesText,
@@ -11,6 +11,15 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withServer } from "../plugin-sdk/test-helpers/http-test-server.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { runUpdateRepairLoop } from "./update-repair-agent.js";
+
+// Exercise the built runtime through Node's loader; Vitest's source-module graph
+// stalls inside agent command execution before the synthetic provider is called.
+vi.mock("./update-repair-agent.runtime.js", async () => {
+  const { createRequire } = await import("node:module");
+  return createRequire(import.meta.url)(
+    "../../dist/update-repair-agent.runtime.js",
+  ) as typeof import("./update-repair-agent.runtime.js");
+});
 
 type ModelRequest = {
   model?: string;


### PR DESCRIPTION
## What Problem This Solves

Resolves an update-repair E2E timeout during full release validation. The source Vitest execution path stalled inside agent-command invocation, while the exact CI-built runtime completed the same synthetic provider and host-exec scenario in 5.4 seconds.

## Why This Change Was Made

Load the existing built runtime facade through Node's native loader. The test still exercises the source repair loop and real HTTP/provider/tool execution, with its original deadlines, two-tool budget, pinned-state marker, and filesystem escape assertions. The normal E2E build prerequisite supplies the facade; no production export or fallback was added.

## User Impact

Test-only change; production behavior is unchanged. Release validation now exercises the built repair runtime instead of stalling in the source test-runner path.

## Evidence

- Original [Gateway 3/4 failure](https://github.com/openclaw/openclaw/actions/runs/33966906376/job/101309574256): 120-second timeout, reported 476 seconds. Fresh Linux isolated reproduction also failed, without Telegram tests or timer errors.
- Exact original CI-built runtime: passed in 5.4 seconds, four synthetic HTTP requests, two real tools, correct target marker, and rejected filesystem escape. Revised E2E: passed in 3.8 seconds.
- Replayed all 59 original files with two workers and original source-size ordering, alongside the separately reviewed Telegram timer repair. Update-repair passed in 4.7 seconds and no unhandled errors remained. The overall replay was **not green**: 396 tests passed, one separate node-routing HOME assertion failed, and five were skipped. A shell probe traced that mismatch to the runner login profile overriding HOME; it is handled separately.
- Full changed-file gate passed with contained Linux dependencies. Independent managed review found no actionable P0–P2 findings. Production LOC delta: zero; test delta: +10/-1.
- Fresh-main inspection: the repair test, loop, runtime, inference owner, and agent-exec preimages match the verified release source. Adjacent post-turn maintenance changes were inspected; exact-head PR CI follows.

The specific downstream reason for the source Vitest stall remains unproven; this change does not claim a production timeout or plugin-loading repair.
