### PR TITLE
fix(ci): isolate node routing evidence from login-shell HOME

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-node-exec-routing.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-exec-routing.e2e.test.ts
@@ -45,13 +45,14 @@ it(
     const children: CapturedChild[] = [];
     const canvasClients: GatewayClient[] = [];
     const probe = path.join(root, "probe.mjs");
+    // Login-shell profiles can reset HOME; keep effects in the node fixture's owned home.
     await fs.writeFile(
       probe,
       [
         'import fs from "node:fs";',
-        'import os from "node:os";',
         'import path from "node:path";',
-        "const home = os.homedir();",
+        "const home = process.env.OPENCLAW_HOME;",
+        'if (!home) throw new Error("Node fixture omitted OPENCLAW_HOME");',
         "const marker = process.argv[2];",
         'fs.appendFileSync(path.join(home, "exec-proof.txt"), `${marker}\\n`);',
         "console.log(JSON.stringify({ home, marker }));",


### PR DESCRIPTION
Related: #131767

## What Problem This Solves

Resolves a node-routing E2E failure on Linux runners whose login profile rewrites `HOME`. The selected node executed the right command, but the probe wrote its evidence into the runner account's home and failed its isolated-directory assertion.

## Why This Change Was Made

Use the node fixture's existing, mandatory `OPENCLAW_HOME` for probe output and file effects. Linux node commands intentionally use a login shell; its startup profile owns `HOME`. The command still receives only the shared probe path and marker, so the selected node's inherited environment determines the evidence directory. Every node-selection, per-node effect, ambiguity, offline rejection, and nonexecution assertion remains unchanged.

## User Impact

No production behavior changes. Node-routing verification remains isolated from the runner's account home and continues to prove that commands execute only on an eligible selected node.

## Evidence

- On the original failing Blacksmith environment, direct Node and non-login `sh` preserved the synthetic home; login `sh` changed `HOME` to `/home/runner` while preserving the fixture's `OPENCLAW_HOME`. The runner login profile explicitly assigns `HOME`.
- Fresh Blacksmith Testbox `tbx_01m1rzpawk3ry1cbe0f6e4d1nh`: unchanged case reproduced the exact failure; the repaired full case passed on the same machine, including two executable nodes, a canvas-only node, and ambiguous/offline target refusal.
- Command: `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/gateway-node-exec-routing.e2e.test.ts --maxWorkers=1 --no-file-parallelism`.
- Canonical E2E preparation retained; no prebuilt/skip flags, shell-policy changes, retries, or weaker assertions.
- Independent managed review through P2 found no actionable findings.
- The full classified changed gate passed on the separate proof checkout (exit 0), including test-root TypeScript, lint, dependency/boundary guards and dead-code scans. [Exact PR-head CI](https://github.com/openclaw/openclaw/actions/runs/33972700030) is green on `6408a3e6b4975858baad3d93626ca276c344311f`.
- One test file, +3/−2; production and tooling unchanged.

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/139153#issuecomment-5552609037) covers the exact head and reports no findings or pre-merge actions.
