### PR TITLE
fix(gateway): expose agent hook completion outcomes

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2921,7 +2921,6 @@ src/gateway/server.auth.control-ui.pairing.suite.ts	6
 src/gateway/server.auth.control-ui.trusted-proxy.suite.ts	5
 src/gateway/server.auth.default-token.suite.ts	10
 src/gateway/server.auth.modes.suite.ts	1
-src/gateway/server/hooks-request-handler.ts	4
 src/gateway/server/http-listen.ts	1
 src/gateway/server/plugins-http/route-capability.ts	1
 src/gateway/server/ws-connection-diagnostics.ts	3

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -702,6 +702,34 @@ mean the model finished, a tool succeeded, or a message was delivered. A single
 agent request can wait up to 15 seconds for admission; the model runtime may still
 be preparing when the response arrives.
 
+For callers that need the terminal execution and delivery facts in the same
+request, add `"waitForCompletion": true` to the direct `/hooks/agent` payload.
+The response stays open after admission and returns HTTP `200` when the admitted
+run settles:
+
+```json
+{
+  "ok": true,
+  "runId": "<hook-request-run-id>",
+  "completion": {
+    "status": "ok",
+    "replyDisposition": "silent",
+    "delivered": false,
+    "deliveryAttempted": true,
+    "deliverySuppressionReason": "silent"
+  }
+}
+```
+
+`replyDisposition` records whether the model's terminal reply was `visible`,
+`silent`, or `empty`, without exposing its text. Post-admission execution or
+delivery failures are terminal data in `completion`, not retryable HTTP
+failures. `deliveryError`, when present, is the fixed categorical value
+`"delivery-failed"`; provider, runtime, model, target, session, and diagnostic
+details remain private. The response never includes model output or summaries.
+Use an idempotency key so a lost response can replay the same admitted run and
+completion result without dispatching again.
+
 In `openclaw logs --follow`, search for `hook agent run completed` and the exact HTTP
 `runId`. Runs with `status=ok` and no explicit delivery error log at info level;
 all non-ok statuses (including skipped runs), thrown errors, and explicit delivery

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1167,7 +1167,7 @@ plugin does enforce it.
 | Endpoint             | Payload and result                                                                                                                                                                                                                                                                                                                                                                                     |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `POST /hooks/wake`   | Required nonempty `text`; optional `mode` (`"now"` default or `"next-heartbeat"`), `agentId`, `sessionKey`. Returns `200 { ok: true, mode, eventOutcome }`; `eventOutcome` is `"queued"` when the queue accepts the wake or `"coalesced"` when the same wake is already the queue's most recent pending event. `now` requests a heartbeat in either case; the result does not prove the heartbeat ran. |
-| `POST /hooks/agent`  | [Agent payload](/gateway/configuration-reference#hook-agent-payload). Returns `200 { ok: true, runId }` after session/global placement admission, not completion.                                                                                                                                                                                                                                      |
+| `POST /hooks/agent`  | [Agent payload](/gateway/configuration-reference#hook-agent-payload). By default returns `200 { ok: true, runId }` after session/global placement admission. With `waitForCompletion: true`, waits for the admitted run and adds bounded terminal execution/delivery facts in `completion`.                                                                                                            |
 | `POST /hooks/<name>` | First matching mapping produces wake/agent actions. No matching mapping returns `404`; no actions returns `204`. Agent fan-out has the [batch response contract](/gateway/configuration-reference#hook-retries-and-fan-out).                                                                                                                                                                           |
 
 The direct `/wake` and `/agent` endpoints take precedence over mappings with
@@ -1195,22 +1195,23 @@ or channel delivery. See [hook verification](/automation/cron-jobs#verify-and-tr
 
 ### Hook agent payload
 
-| Field            | Default                  | Contract                                                                                                                                                                                                                                                     |
-| ---------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `message`        | required                 | Nonempty agent input text; external content is safety-wrapped.                                                                                                                                                                                               |
-| `name`           | `"Hook"`                 | Hook label used in logs/completion events.                                                                                                                                                                                                                   |
-| `agentId`        | resolved owner           | Must name a configured agent when supplied directly. Required when no implicit/retained owner can be resolved.                                                                                                                                               |
-| `sessionKey`     | default/generated key    | Subject to caller-key opt-in and prefix policy.                                                                                                                                                                                                              |
-| `sessionMode`    | `"isolated"`             | `"isolated"` creates a fresh run session; `"persistent"` reuses the resolved session.                                                                                                                                                                        |
-| `idempotencyKey` | unset                    | Optional replay key; headers take precedence. See retries below.                                                                                                                                                                                             |
-| `wakeMode`       | `"now"`                  | `"now"` or `"next-heartbeat"`; controls waking for completion events, not whether the agent is dispatched immediately.                                                                                                                                       |
-| `deliver`        | `true`                   | Only `false` opts out. With no direct destination, successful output can become a main-session completion event. `false` logs successful completion without an announcement and ignores destination fields. Non-ok execution results produce a status event. |
-| `channel`        | none for direct delivery | Registered concrete channel id; must be paired with `to`. Direct `/agent` cannot use `"last"`.                                                                                                                                                               |
-| `to`             | unset                    | Nonempty recipient for direct announce delivery, paired with `channel`.                                                                                                                                                                                      |
-| `accountId`      | channel default          | Selects a configured, enabled account; requires `channel` and `to`. Unknown, disabled, or invalid selections return `400` before dispatch.                                                                                                                   |
-| `model`          | agent/model defaults     | Model id or alias override, subject to model availability and allowlist policy.                                                                                                                                                                              |
-| `thinking`       | agent/model defaults     | Thinking override for the run.                                                                                                                                                                                                                               |
-| `timeoutSeconds` | agent timeout            | Positive numeric turn-timeout override; direct payload values are floored to whole seconds. Invalid/nonpositive values are ignored.                                                                                                                          |
+| Field               | Default                  | Contract                                                                                                                                                                                                                                                     |
+| ------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `message`           | required                 | Nonempty agent input text; external content is safety-wrapped.                                                                                                                                                                                               |
+| `name`              | `"Hook"`                 | Hook label used in logs/completion events.                                                                                                                                                                                                                   |
+| `agentId`           | resolved owner           | Must name a configured agent when supplied directly. Required when no implicit/retained owner can be resolved.                                                                                                                                               |
+| `sessionKey`        | default/generated key    | Subject to caller-key opt-in and prefix policy.                                                                                                                                                                                                              |
+| `sessionMode`       | `"isolated"`             | `"isolated"` creates a fresh run session; `"persistent"` reuses the resolved session.                                                                                                                                                                        |
+| `idempotencyKey`    | unset                    | Optional replay key; headers take precedence. See retries below.                                                                                                                                                                                             |
+| `waitForCompletion` | `false`                  | Direct `/agent` only. When `true`, keep the HTTP response open after admission and return `completion` with `status` plus available delivery facts. Mappings and fan-out remain admission-only.                                                              |
+| `wakeMode`          | `"now"`                  | `"now"` or `"next-heartbeat"`; controls waking for completion events, not whether the agent is dispatched immediately.                                                                                                                                       |
+| `deliver`           | `true`                   | Only `false` opts out. With no direct destination, successful output can become a main-session completion event. `false` logs successful completion without an announcement and ignores destination fields. Non-ok execution results produce a status event. |
+| `channel`           | none for direct delivery | Registered concrete channel id; must be paired with `to`. Direct `/agent` cannot use `"last"`.                                                                                                                                                               |
+| `to`                | unset                    | Nonempty recipient for direct announce delivery, paired with `channel`.                                                                                                                                                                                      |
+| `accountId`         | channel default          | Selects a configured, enabled account; requires `channel` and `to`. Unknown, disabled, or invalid selections return `400` before dispatch.                                                                                                                   |
+| `model`             | agent/model defaults     | Model id or alias override, subject to model availability and allowlist policy.                                                                                                                                                                              |
+| `thinking`          | agent/model defaults     | Thinking override for the run.                                                                                                                                                                                                                               |
+| `timeoutSeconds`    | agent timeout            | Positive numeric turn-timeout override; direct payload values are floored to whole seconds. Invalid/nonpositive values are ignored.                                                                                                                          |
 
 Omitting all destination fields runs without a direct announce destination.
 Supplying only part of a destination fails with `400` while delivery is enabled.
@@ -1298,9 +1299,24 @@ Agent replay keys resolve in this order: `Idempotency-Key`,
 `X-OpenClaw-Idempotency-Key`, then payload `idempotencyKey`. Only trimmed nonempty
 strings of at most 256 characters are used. The same key replays only for the
 same token, path, and resolved dispatch fields; changing the message or routing
-can create a new run. Completed admission replay entries expire after 5 minutes
-and are bounded to 1,000 entries in memory. Restart clears them. Failed admissions
-remain retryable; a replayed `200` is not a fresh execution or a completion check.
+can create a new run. Pending admissions and admitted runs with unresolved
+completion are retained without TTL or size eviction. After terminal completion
+settles, its replay entry expires after 5 minutes and counts toward the 1,000
+terminal-entry memory bound. Restart clears all replay state. Failed admissions
+remain retryable. Direct retries may change `waitForCompletion` without changing
+dispatch identity: admission-only callers replay the `runId`, while waiting
+callers share the same completion promise and replay its terminal result.
+
+When requested, `completion.status` is `ok`, `error`, or `skipped`, and
+`replyDisposition` is `visible`, `silent`, or `empty`. This disposition exposes
+only whether a terminal model reply existed, never its text. The optional
+delivery fields are `delivered`, `deliveryAttempted`, `deliveryError`, and
+`deliverySuppressionReason` (`empty`, `silent`, `heartbeat`, or
+`channel_transform`). Missing delivery fields remain unknown. Post-admission
+failures still return HTTP `200`; only admission failures use the non-2xx
+statuses above. `deliveryError`, when present, is the fixed categorical value
+`"delivery-failed"`. Provider, runtime, model, target, session, diagnostic,
+output, and summary details are never returned.
 
 For `forEach`, templates/transforms see the original payload with the chosen
 array replaced by `[currentItem]`. Missing, empty, or non-array values produce no

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -5,6 +5,10 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { hasAcceptedSessionSpawn } from "../../agents/accepted-session-spawn.js";
+import {
+  buildAgentRunTerminalReplySnapshot,
+  normalizeAgentRunTerminalReplySnapshot,
+} from "../../agents/agent-run-terminal-reply.js";
 import { resolveAuthoredModelContextTokens } from "../../agents/context-resolution.js";
 import { hasCommittedMessagingToolDeliveryEvidence } from "../../agents/embedded-agent-runner/delivery-evidence.js";
 import { hasIntentionalTerminalCompletion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
@@ -64,6 +68,14 @@ export async function finalizeCronRun(params: {
 }): Promise<RunCronAgentTurnResult> {
   const { prepared, execution } = params;
   const finalRunResult = execution.runResult;
+  const replyDisposition = (
+    normalizeAgentRunTerminalReplySnapshot(finalRunResult.meta?.terminalReply) ??
+    buildAgentRunTerminalReplySnapshot({
+      visibleText: finalRunResult.meta?.finalAssistantVisibleText,
+      rawText: finalRunResult.meta?.finalAssistantRawText,
+      terminalReplyKind: finalRunResult.meta?.terminalReplyKind,
+    })
+  ).disposition;
   const payloads = finalRunResult.payloads ?? [];
   const cleanupRunSession = async (reason: string) => {
     await cleanupCronRunSessionAfterRun({
@@ -285,6 +297,7 @@ export async function finalizeCronRun(params: {
     return prepared.withRunSession({
       status: "error",
       error: params.abortReason(),
+      replyDisposition,
       diagnostics: mergeCronRunDiagnostics(
         prepared.preflightDiagnostics,
         createCronRunDiagnosticsFromAgentResult(finalRunResult, { finalStatus: "error" }),
@@ -311,6 +324,7 @@ export async function finalizeCronRun(params: {
     return prepared.withRunSession({
       status: "error",
       error,
+      replyDisposition,
       diagnostics: mergeCronRunDiagnostics(
         prepared.preflightDiagnostics,
         createCronRunDiagnosticsFromAgentResult(finalRunResult, { finalStatus: "error" }),
@@ -357,6 +371,7 @@ export async function finalizeCronRun(params: {
         : {}),
       summary,
       outputText,
+      replyDisposition,
       deliveryState: result?.deliveryState,
       delivered: result?.delivered,
       deliveryAttempted: result?.deliveryAttempted,
@@ -450,6 +465,7 @@ export async function finalizeCronRun(params: {
       error,
       summary: error,
       outputText: error,
+      replyDisposition,
       delivered: false,
       deliveryAttempted: false,
       diagnostics: mergeCronRunDiagnostics(
@@ -538,6 +554,7 @@ export async function finalizeCronRun(params: {
       (deliveryResult.result.status === "error" ? deliveryResult.result.error : undefined);
     const resultWithDeliveryMeta: RunCronAgentTurnResult = {
       ...deliveryResult.result,
+      replyDisposition,
       deliveryState: deliveryResult.deliveryState,
       delivered: deliveryResult.result.delivered ?? deliveryResult.delivered,
       deliveryAttempted:

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -492,6 +492,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(result.error).toBeUndefined();
     expect(result.summary).toBe("Final cron report from the agent.");
     expect(result.outputText).toBe("Final cron report from the agent.");
+    expect(result.replyDisposition).toBe("visible");
     expect(resolveCronPayloadOutcomeMock).toHaveBeenCalledWith(
       expect.objectContaining({
         finalAssistantVisibleText: "Final cron report from the agent.",
@@ -502,6 +503,31 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       deliveryRequested: false,
       deliveryPayloads: [{ text: "Final cron report from the agent." }],
     });
+  });
+
+  it("records an exact NO_REPLY as a silent bare no-deliver result", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: false,
+      mode: "none",
+    });
+    runEmbeddedAgentMock.mockResolvedValue({
+      payloads: [{ text: "NO_REPLY" }],
+      meta: {
+        finalAssistantVisibleText: "NO_REPLY",
+        finalAssistantRawText: "NO_REPLY",
+        agentMeta: { usage: { input: 10, output: 20 } },
+      },
+    });
+
+    const result = await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob({ mode: "none" }),
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.replyDisposition).toBe("silent");
+    expect(result.delivered).toBe(false);
   });
 
   it('suppresses automatic exec completion notifications when delivery.mode is "none"', async () => {
@@ -613,11 +639,17 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       accountId: undefined,
       error: undefined,
     });
-    runEmbeddedAgentMock.mockResolvedValue(
-      makeMessageToolRunResult([
-        { tool: "message", provider: "topicchat", to: "room#42", threadId: "42" },
-      ]),
-    );
+    const embeddedResult = makeMessageToolRunResult([
+      { tool: "message", provider: "topicchat", to: "room#42", threadId: "42" },
+    ]);
+    runEmbeddedAgentMock.mockResolvedValue({
+      ...embeddedResult,
+      meta: {
+        ...embeddedResult.meta,
+        finalAssistantVisibleText: "NO_REPLY",
+        finalAssistantRawText: "NO_REPLY",
+      },
+    });
 
     const result = await runCronIsolatedAgentTurn({
       ...makeParams(),
@@ -646,6 +678,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     });
     expect(result.delivered).toBe(true);
     expect(result.deliveryAttempted).toBe(true);
+    expect(result.replyDisposition).toBe("silent");
     expectDeliveryFields(result.delivery, {
       intended: { channel: "topicchat", to: "room#42", threadId: 42, source: "explicit" },
       messageToolSentTo: [{ channel: "topicchat", to: "room#42", threadId: "42" }],

--- a/src/cron/isolated-agent/run.types.ts
+++ b/src/cron/isolated-agent/run.types.ts
@@ -1,3 +1,4 @@
+import type { AgentRunTerminalReplySnapshot } from "../../agents/agent-run-terminal-reply.js";
 import type { NormalizeReplySkipReason } from "../../auto-reply/reply/normalize-reply-skip-reason.js";
 /** Result types returned by isolated cron agent runs. */
 import type {
@@ -19,6 +20,8 @@ export type RunCronAgentTurnResult = {
   deliveryState?: CronResolvedDeliveryState;
   /** Last non-empty agent text output (not truncated). */
   outputText?: string;
+  /** Terminal model-reply fact without exposing reply text. */
+  replyDisposition?: AgentRunTerminalReplySnapshot["disposition"];
   /** Confirmed target delivery, including matching message-tool sends; unknown is omitted. */
   delivered?: boolean;
   /**

--- a/src/gateway/hooks.types.ts
+++ b/src/gateway/hooks.types.ts
@@ -1,8 +1,28 @@
 // Gateway hook payload type aliases.
 // Keeps hook-facing channel ids on public plugin channel contracts.
+import type { NormalizeReplySkipReason } from "../auto-reply/reply/normalize-reply-skip-reason.js";
 import type { ChannelId } from "../channels/plugins/types.public.js";
 
 // Gateway hooks use public channel ids so hook payloads stay aligned with plugin
 // channel contracts instead of internal runtime ids.
 /** Public channel id type carried by gateway hook payloads. */
 export type HookMessageChannel = ChannelId;
+
+export type HookAgentCompletion = {
+  status: "ok" | "error" | "skipped";
+  replyDisposition: "visible" | "silent" | "empty";
+  delivered?: boolean;
+  deliveryAttempted?: boolean;
+  deliveryError?: "delivery-failed";
+  deliverySuppressionReason?: NormalizeReplySkipReason;
+};
+
+export type HookAgentDispatchSuccess = {
+  ok: true;
+  runId: string;
+  completion: Promise<HookAgentCompletion>;
+};
+
+export type HookAgentDispatchResult =
+  | HookAgentDispatchSuccess
+  | { ok: false; statusCode: 400 | 409 | 502 | 503; error: string; runId?: string };

--- a/src/gateway/server-http.hooks-delivery.test.ts
+++ b/src/gateway/server-http.hooks-delivery.test.ts
@@ -41,6 +41,7 @@ function createDeliveryHandler(params?: {
   const dispatchAgentHook = vi.fn((_value: HookAgentDispatchPayload) => ({
     ok: true as const,
     runId: "run-1",
+    completion: Promise.resolve({ status: "ok" as const, replyDisposition: "empty" as const }),
   }));
   const canonicalConfig = createHooksConfig();
   const hooksConfig = {

--- a/src/gateway/server-http.hooks-request-timeout.test.ts
+++ b/src/gateway/server-http.hooks-request-timeout.test.ts
@@ -39,7 +39,11 @@ describe("createHooksRequestHandler timeout status mapping", () => {
   test("returns 408 for request body timeout", async () => {
     readJsonBodyMock.mockResolvedValue({ ok: false, error: "request body timeout" });
     const dispatchWakeHook = vi.fn(() => ({ eventOutcome: "queued" as const }));
-    const dispatchAgentHook = vi.fn(() => ({ ok: true as const, runId: "run-1" }));
+    const dispatchAgentHook = vi.fn(() => ({
+      ok: true as const,
+      runId: "run-1",
+      completion: Promise.resolve({ status: "ok" as const, replyDisposition: "empty" as const }),
+    }));
     const handler = createHooksHandler({ dispatchWakeHook, dispatchAgentHook });
     const tasks: Promise<boolean>[] = [];
     const server = createServer((req, res) => {

--- a/src/gateway/server-http.test-harness.ts
+++ b/src/gateway/server-http.test-harness.ts
@@ -229,7 +229,13 @@ export function createHooksHandler(
     } as unknown as ReturnType<typeof createSubsystemLogger>,
     getClientIpConfig: options.getClientIpConfig,
     dispatchWakeHook: options.dispatchWakeHook ?? (() => ({ eventOutcome: "queued" })),
-    dispatchAgentHook: options.dispatchAgentHook ?? (() => ({ ok: true, runId: "run-1" })),
+    dispatchAgentHook:
+      options.dispatchAgentHook ??
+      (() => ({
+        ok: true,
+        runId: "run-1",
+        completion: Promise.resolve({ status: "ok", replyDisposition: "empty" }),
+      })),
   });
 }
 

--- a/src/gateway/server/hooks-request-handler.fanout.test.ts
+++ b/src/gateway/server/hooks-request-handler.fanout.test.ts
@@ -9,15 +9,22 @@ import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveHookMappings } from "../hooks-mapping.js";
 import { createHooksConfig } from "../hooks-test-helpers.js";
 import type { HookAgentDispatchPayload, HooksConfigResolved } from "../hooks.js";
+import type { HookAgentCompletion, HookAgentDispatchResult } from "../hooks.types.js";
+import { DEDUPE_MAX, DEDUPE_TTL_MS } from "../server-constants.js";
 import { createHookRequest, createResponse } from "../server-http.test-harness.js";
-import {
-  createHooksRequestHandler,
-  type HookAgentDispatchResult,
-} from "./hooks-request-handler.js";
+import { createHooksRequestHandler } from "./hooks-request-handler.js";
 
 const { readJsonBodyMock } = vi.hoisted(() => ({
   readJsonBodyMock: vi.fn(),
 }));
+
+function completedDispatch(runId: string): HookAgentDispatchResult {
+  return {
+    ok: true,
+    runId,
+    completion: Promise.resolve({ status: "ok", replyDisposition: "empty" }),
+  };
+}
 
 vi.mock("../hooks.js", async () => {
   const actual = await vi.importActual<typeof import("../hooks.js")>("../hooks.js");
@@ -57,10 +64,7 @@ function createFanOutHandler(params?: {
   );
   const dispatchAgentHook = vi.fn(
     params?.dispatchAgentHook ??
-      ((value: HookAgentDispatchPayload) => ({
-        ok: true as const,
-        runId: `run:${value.sessionKey}`,
-      })),
+      ((value: HookAgentDispatchPayload) => completedDispatch(`run:${value.sessionKey}`)),
   );
   const logHooks = {
     warn: vi.fn(),
@@ -152,7 +156,7 @@ describe("hook fan-out dispatch", () => {
         if (failM2 && value.sessionKey === "hook:gmail:m2") {
           return { ok: false as const, statusCode: 502 as const, error: "admission failed" };
         }
-        return { ok: true as const, runId: `run:${value.sessionKey}` };
+        return completedDispatch(`run:${value.sessionKey}`);
       },
     });
     const payload = { messages: [gmailMessage("m1"), gmailMessage("m2"), gmailMessage("m3")] };
@@ -185,7 +189,7 @@ describe("hook fan-out dispatch", () => {
       dispatchAgentHook: (value) =>
         value.sessionKey === "hook:gmail:slow"
           ? hang
-          : { ok: true as const, runId: `run:${value.sessionKey}` },
+          : completedDispatch(`run:${value.sessionKey}`),
     });
     const payload = { messages: [gmailMessage("fast"), gmailMessage("slow")] };
 
@@ -197,7 +201,7 @@ describe("hook fan-out dispatch", () => {
 
     // The pending admission settles in the background; the redelivered batch
     // replays both items without a duplicate dispatch.
-    releaseHang({ ok: true, runId: "run:hook:gmail:slow" });
+    releaseHang(completedDispatch("run:hook:gmail:slow"));
     const retryResponse = await postGmailPayload(handler, payload);
     expect(retryResponse.res.statusCode).toBe(200);
     expect(dispatchAgentHook).toHaveBeenCalledTimes(2);
@@ -209,7 +213,7 @@ describe("hook fan-out dispatch", () => {
     // both instead of dispatching a third run.
     let runSeq = 0;
     const { handler, dispatchAgentHook } = createFanOutHandler({
-      dispatchAgentHook: () => ({ ok: true as const, runId: `run-${runSeq++}` }),
+      dispatchAgentHook: () => completedDispatch(`run-${runSeq++}`),
     });
     const payload = { messages: [gmailMessage("twin"), gmailMessage("twin")] };
 
@@ -380,5 +384,252 @@ describe("hook fan-out dispatch", () => {
     const response = createResponse();
     await handler(req, response.res);
     expect(readJsonBodyMock).toHaveBeenLastCalledWith(expect.anything(), canonical.maxBodyBytes);
+  });
+
+  test("waits for direct agent completion when explicitly requested", async () => {
+    let resolveCompletion!: (value: {
+      status: "ok";
+      replyDisposition: "silent";
+      delivered: boolean;
+      deliveryAttempted: boolean;
+    }) => void;
+    const completion = new Promise<{
+      status: "ok";
+      replyDisposition: "silent";
+      delivered: boolean;
+      deliveryAttempted: boolean;
+    }>((resolve) => {
+      resolveCompletion = resolve;
+    });
+    const { handler, dispatchAgentHook } = createFanOutHandler({
+      hooksConfig: createHooksConfig(),
+      dispatchAgentHook: () => ({ ok: true, runId: "run:direct", completion }),
+    });
+    readJsonBodyMock.mockResolvedValueOnce({
+      ok: true,
+      value: { message: "direct", waitForCompletion: true },
+    });
+    const req = createHookRequest({ url: "/hooks/agent" });
+    const response = createResponse();
+
+    const handling = handler(req, response.res);
+    await vi.waitFor(() => expect(dispatchAgentHook).toHaveBeenCalledTimes(1));
+    expect(response.getBody()).toBe("");
+
+    resolveCompletion({
+      status: "ok",
+      replyDisposition: "silent",
+      delivered: true,
+      deliveryAttempted: true,
+    });
+    await handling;
+    expect(JSON.parse(response.getBody())).toEqual({
+      ok: true,
+      runId: "run:direct",
+      completion: {
+        status: "ok",
+        replyDisposition: "silent",
+        delivered: true,
+        deliveryAttempted: true,
+      },
+    });
+  });
+
+  test("keeps direct completion observation outside dispatch identity", async () => {
+    let resolveAdmission!: (value: HookAgentDispatchResult) => void;
+    const admission = new Promise<HookAgentDispatchResult>((resolve) => {
+      resolveAdmission = resolve;
+    });
+    let resolveCompletion!: (value: {
+      status: "ok";
+      replyDisposition: "silent";
+      delivered: boolean;
+    }) => void;
+    const completion = new Promise<{
+      status: "ok";
+      replyDisposition: "silent";
+      delivered: boolean;
+    }>((resolve) => {
+      resolveCompletion = resolve;
+    });
+    const { handler, dispatchAgentHook } = createFanOutHandler({
+      hooksConfig: createHooksConfig(),
+      dispatchAgentHook: () => admission,
+    });
+    const startRequest = (waitForCompletion: boolean) => {
+      readJsonBodyMock.mockResolvedValueOnce({
+        ok: true,
+        value: {
+          message: "direct",
+          idempotencyKey: "shared-request",
+          waitForCompletion,
+        },
+      });
+      const req = createHookRequest({ url: "/hooks/agent" });
+      const response = createResponse();
+      return { response, handling: handler(req, response.res) };
+    };
+
+    const admittedOnly = startRequest(false);
+    const waiting = startRequest(true);
+    await vi.waitFor(() => expect(dispatchAgentHook).toHaveBeenCalledTimes(1));
+
+    resolveAdmission({ ok: true, runId: "run:shared", completion });
+    await admittedOnly.handling;
+    expect(JSON.parse(admittedOnly.response.getBody())).toEqual({
+      ok: true,
+      runId: "run:shared",
+    });
+    expect(waiting.response.getBody()).toBe("");
+
+    resolveCompletion({ status: "ok", replyDisposition: "silent", delivered: true });
+    await waiting.handling;
+    expect(JSON.parse(waiting.response.getBody())).toEqual({
+      ok: true,
+      runId: "run:shared",
+      completion: { status: "ok", replyDisposition: "silent", delivered: true },
+    });
+
+    const replay = startRequest(true);
+    await replay.handling;
+    expect(JSON.parse(replay.response.getBody())).toEqual({
+      ok: true,
+      runId: "run:shared",
+      completion: { status: "ok", replyDisposition: "silent", delivered: true },
+    });
+    expect(dispatchAgentHook).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps an active admitted replay owner under terminal cache pressure", async () => {
+    let resolveActiveCompletion!: (value: HookAgentCompletion) => void;
+    const activeCompletion = new Promise<HookAgentCompletion>((resolve) => {
+      resolveActiveCompletion = resolve;
+    });
+    let activeDispatches = 0;
+    const { handler, dispatchAgentHook } = createFanOutHandler({
+      hooksConfig: createHooksConfig(),
+      dispatchAgentHook: (value) => {
+        if (value.idempotencyKey === "active-owner") {
+          activeDispatches += 1;
+          return { ok: true, runId: "run:active", completion: activeCompletion };
+        }
+        return completedDispatch(`run:${value.idempotencyKey}`);
+      },
+    });
+    const startRequest = (idempotencyKey: string, waitForCompletion = false) => {
+      readJsonBodyMock.mockResolvedValueOnce({
+        ok: true,
+        value: { message: "direct", idempotencyKey, waitForCompletion },
+      });
+      const req = createHookRequest({ url: "/hooks/agent" });
+      const response = createResponse();
+      return { response, handling: handler(req, response.res) };
+    };
+
+    await startRequest("active-owner").handling;
+
+    for (let index = 0; index < DEDUPE_MAX; index += 1) {
+      await startRequest(`pressure-${index}`).handling;
+    }
+    await Promise.resolve();
+
+    const replay = startRequest("active-owner", true);
+    await Promise.resolve();
+    expect(replay.response.getBody()).toBe("");
+    expect(activeDispatches).toBe(1);
+    resolveActiveCompletion({ status: "ok", replyDisposition: "silent" });
+    await replay.handling;
+
+    expect(JSON.parse(replay.response.getBody())).toEqual({
+      ok: true,
+      runId: "run:active",
+      completion: { status: "ok", replyDisposition: "silent" },
+    });
+    expect(dispatchAgentHook).toHaveBeenCalledTimes(DEDUPE_MAX + 1);
+  });
+
+  test("starts replay TTL when active completion settles", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-05T00:00:00.000Z"));
+    try {
+      let resolveCompletion!: (value: HookAgentCompletion) => void;
+      const completion = new Promise<HookAgentCompletion>((resolve) => {
+        resolveCompletion = resolve;
+      });
+      let dispatches = 0;
+      const { handler } = createFanOutHandler({
+        hooksConfig: createHooksConfig(),
+        dispatchAgentHook: () => {
+          dispatches += 1;
+          return dispatches === 1
+            ? { ok: true, runId: "run:active", completion }
+            : completedDispatch("run:duplicate");
+        },
+      });
+      const startRequest = () => {
+        readJsonBodyMock.mockResolvedValueOnce({
+          ok: true,
+          value: { message: "direct", idempotencyKey: "delayed-admission" },
+        });
+        const req = createHookRequest({ url: "/hooks/agent" });
+        const response = createResponse();
+        return { response, handling: handler(req, response.res) };
+      };
+
+      await startRequest().handling;
+
+      await vi.advanceTimersByTimeAsync(DEDUPE_TTL_MS + 1);
+      const activeReplay = startRequest();
+      await activeReplay.handling;
+      expect(JSON.parse(activeReplay.response.getBody())).toEqual({
+        ok: true,
+        runId: "run:active",
+      });
+      expect(dispatches).toBe(1);
+
+      resolveCompletion({ status: "ok", replyDisposition: "empty" });
+      await vi.advanceTimersByTimeAsync(0);
+
+      await vi.advanceTimersByTimeAsync(DEDUPE_TTL_MS);
+      const terminalReplay = startRequest();
+      await terminalReplay.handling;
+      expect(JSON.parse(terminalReplay.response.getBody())).toEqual({
+        ok: true,
+        runId: "run:active",
+      });
+      expect(dispatches).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const expired = startRequest();
+      await expired.handling;
+      expect(JSON.parse(expired.response.getBody())).toEqual({
+        ok: true,
+        runId: "run:duplicate",
+      });
+      expect(dispatches).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("rejects non-boolean direct completion observation", async () => {
+    const { handler, dispatchAgentHook } = createFanOutHandler({
+      hooksConfig: createHooksConfig(),
+    });
+    readJsonBodyMock.mockResolvedValueOnce({
+      ok: true,
+      value: { message: "direct", waitForCompletion: "yes" },
+    });
+    const req = createHookRequest({ url: "/hooks/agent" });
+    const response = createResponse();
+
+    await handler(req, response.res);
+
+    expect(response.res.statusCode).toBe(400);
+    expect(JSON.parse(response.getBody())).toEqual({
+      ok: false,
+      error: "waitForCompletion must be boolean",
+    });
+    expect(dispatchAgentHook).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server/hooks-request-handler.ts
+++ b/src/gateway/server/hooks-request-handler.ts
@@ -1,8 +1,7 @@
-// Hook request handler validates hook tokens, applies mappings, dedupes requests, and dispatches wake or agent work.
 import { createHash } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import { sendHttpRequestRejection } from "../../infra/http-request-lifecycle.js";
-import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveHookExternalContentSource as resolveHookExternalContentSourceFromSession } from "../../security/external-content.js";
 import { safeEqualSecret } from "../../security/secret-equal.js";
@@ -35,12 +34,15 @@ import {
   resolveHookPathBodyLimit,
   resolveHookSessionKey,
 } from "../hooks.js";
+import type {
+  HookAgentCompletion,
+  HookAgentDispatchResult,
+  HookAgentDispatchSuccess,
+} from "../hooks.types.js";
 import { sendJson } from "../http-common.js";
 import { readPreparedGatewayIngressAttribution } from "../ingress-attribution.js";
 import { resolveRequestClientIpFromHeaders } from "../net.js";
 import { DEDUPE_MAX, DEDUPE_TTL_MS } from "../server-constants.js";
-
-type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
 const HOOK_AUTH_FAILURE_LIMIT = 20;
 const HOOK_AUTH_FAILURE_WINDOW_MS = 60_000;
@@ -55,6 +57,8 @@ const HOOK_FAN_OUT_RESPONSE_DEADLINE_MS = 8_000;
 // Marker for replay keys derived from item content when the producer supplies
 // no idempotency key; item identity lives in the dispatch-scope fingerprint.
 const HOOK_FAN_OUT_DERIVED_IDEMPOTENCY = "hook-fanout-item";
+
+const hashReplay = (value: string) => createHash("sha256").update(value, "utf8").digest("hex");
 
 const FAN_OUT_PENDING = Symbol("hook-fanout-pending");
 type FanOutSettled = HookAgentDispatchResult | typeof FAN_OUT_PENDING;
@@ -86,23 +90,11 @@ async function settleFanOutDispatches(
   }
 }
 
-function sendAgentResult(
-  res: ServerResponse,
-  result: HookAgentDispatchResult & Partial<WakeResult>,
-) {
-  if (result.ok) {
-    sendJson(res, 200, result);
-    return;
-  }
-  const { statusCode, ...body } = result;
-  sendJson(res, statusCode, body);
-}
-
 function sendFanOutResult(res: ServerResponse, settled: FanOutSettled[], wake?: WakeResult) {
   const first = settled[0];
   if (settled.length === 1 && first !== undefined && first !== FAN_OUT_PENDING) {
     // Single-item batches keep the exact single-dispatch response shape.
-    sendAgentResult(res, { ...first, ...wake });
+    void sendAgentResult(res, first, wake);
     return;
   }
   const runIds: string[] = [];
@@ -153,14 +145,31 @@ type HookDispatchers = {
   ) => HookAgentDispatchResult | Promise<HookAgentDispatchResult>;
 };
 
-export type HookAgentDispatchResult =
-  | { ok: true; runId: string }
-  | { ok: false; statusCode: 400 | 409 | 502 | 503; error: string; runId?: string };
+function sendAgentResult(
+  res: ServerResponse,
+  result: HookAgentDispatchResult,
+  extra?: Partial<WakeResult>,
+  waitForCompletion = false,
+): void | Promise<void> {
+  if (!result.ok) {
+    const { statusCode, ...body } = result;
+    sendJson(res, statusCode, { ...body, ...extra });
+    return;
+  }
+  const send = (completion?: HookAgentCompletion) =>
+    sendJson(res, 200, {
+      ok: true,
+      runId: result.runId,
+      ...extra,
+      ...(completion ? { completion } : {}),
+    });
+  return waitForCompletion ? result.completion.then(send) : send();
+}
 
-type HookReplayEntry = {
-  ts: number;
-  runId: string;
-};
+type HookReplayEntry =
+  | { state: "pending"; dispatch: Promise<HookAgentDispatchResult> }
+  | { state: "active"; dispatch: HookAgentDispatchSuccess }
+  | { state: "terminal"; ts: number; dispatch: HookAgentDispatchSuccess };
 
 type HookReplayScope = {
   pathKey: string;
@@ -181,7 +190,7 @@ export function createHooksRequestHandler(
     getHooksConfig: () => HooksConfigResolved | null;
     bindHost: string;
     port: number;
-    logHooks: SubsystemLogger;
+    logHooks: ReturnType<typeof createSubsystemLogger>;
     getClientIpConfig?: () => HookClientIpConfig;
     fanoutResponseDeadlineMs?: number;
   } & HookDispatchers,
@@ -190,7 +199,6 @@ export function createHooksRequestHandler(
   const fanoutResponseDeadlineMs =
     opts.fanoutResponseDeadlineMs ?? HOOK_FAN_OUT_RESPONSE_DEADLINE_MS;
   const hookReplayCache = new Map<string, HookReplayEntry>();
-  const pendingHookReplays = new Map<string, Promise<HookAgentDispatchResult>>();
   const hookAuthLimiter = createAuthRateLimiter({
     maxAttempts: HOOK_AUTH_FAILURE_LIMIT,
     windowMs: HOOK_AUTH_FAILURE_WINDOW_MS,
@@ -216,13 +224,15 @@ export function createHooksRequestHandler(
   };
 
   const pruneHookReplayCache = (now: number) => {
-    const cutoff = now - DEDUPE_TTL_MS;
     for (const [key, entry] of hookReplayCache) {
-      if (entry.ts < cutoff) {
+      if (entry.state === "terminal" && entry.ts < now - DEDUPE_TTL_MS) {
         hookReplayCache.delete(key);
       }
     }
-    pruneMapToMaxSize(hookReplayCache, DEDUPE_MAX);
+    const terminal = [...hookReplayCache].filter(([, entry]) => entry.state === "terminal");
+    for (const [key] of terminal.slice(0, Math.max(0, terminal.length - DEDUPE_MAX))) {
+      hookReplayCache.delete(key);
+    }
   };
 
   const buildHookReplayCacheKey = (params: HookReplayScope): string | undefined => {
@@ -230,86 +240,72 @@ export function createHooksRequestHandler(
     if (!idem) {
       return undefined;
     }
-    const tokenFingerprint = createHash("sha256")
-      .update(params.token ?? "", "utf8")
-      .digest("hex");
-    const idempotencyFingerprint = createHash("sha256").update(idem, "utf8").digest("hex");
-    const scopeFingerprint = createHash("sha256")
-      .update(
-        JSON.stringify({
-          pathKey: params.pathKey,
-          dispatchScope: params.dispatchScope,
-        }),
-        "utf8",
-      )
-      .digest("hex");
-    return `${tokenFingerprint}:${scopeFingerprint}:${idempotencyFingerprint}`;
+    const scope = JSON.stringify({
+      pathKey: params.pathKey,
+      dispatchScope: params.dispatchScope,
+    });
+    return `${hashReplay(params.token ?? "")}:${hashReplay(scope)}:${hashReplay(idem)}`;
   };
 
-  const resolveCachedHookRunId = (key: string | undefined, now: number): string | undefined => {
+  const resolveHookReplay = (key: string | undefined) => {
     if (!key) {
       return undefined;
     }
-    pruneHookReplayCache(now);
+    pruneHookReplayCache(Date.now());
     const cached = hookReplayCache.get(key);
     if (!cached) {
       return undefined;
     }
-    hookReplayCache.delete(key);
-    hookReplayCache.set(key, cached);
-    return cached.runId;
-  };
-
-  const rememberHookRunId = (key: string | undefined, runId: string, now: number) => {
-    if (!key) {
-      return;
+    if (cached.state === "terminal") {
+      hookReplayCache.delete(key);
+      hookReplayCache.set(key, cached);
     }
-    hookReplayCache.delete(key);
-    hookReplayCache.set(key, { ts: now, runId });
-    pruneHookReplayCache(now);
-  };
-
-  const resolveHookReplay = (
-    key: string | undefined,
-    now: number,
-  ): HookAgentDispatchResult | Promise<HookAgentDispatchResult> | undefined => {
-    if (!key) {
-      return undefined;
-    }
-    const cachedRunId = resolveCachedHookRunId(key, now);
-    if (cachedRunId) {
-      return { ok: true, runId: cachedRunId };
-    }
-    return pendingHookReplays.get(key);
+    return cached.dispatch;
   };
 
   const dispatchAgentHookWithReplay = (
     key: string | undefined,
-    now: number,
     dispatch: () => HookAgentDispatchResult | Promise<HookAgentDispatchResult>,
   ): HookAgentDispatchResult | Promise<HookAgentDispatchResult> => {
     if (!key) {
       return dispatch();
     }
-    const existing = resolveHookReplay(key, now);
+    const existing = resolveHookReplay(key);
     if (existing) {
       return existing;
     }
     const pending = Promise.resolve()
       .then(dispatch)
       .then((result) => {
-        if (result.ok) {
-          rememberHookRunId(key, result.runId, now);
+        const current = hookReplayCache.get(key);
+        if (current?.state === "pending" && current.dispatch === pending) {
+          if (result.ok) {
+            const active = { state: "active", dispatch: result } as const;
+            hookReplayCache.set(key, active);
+            const settle = () => {
+              if (hookReplayCache.get(key) !== active) {
+                return;
+              }
+              const terminal = { state: "terminal", ts: Date.now(), dispatch: result } as const;
+              hookReplayCache.delete(key);
+              hookReplayCache.set(key, terminal);
+              pruneHookReplayCache(terminal.ts);
+            };
+            void result.completion.then(settle, settle);
+          } else {
+            hookReplayCache.delete(key);
+          }
         }
         return result;
       })
-      .finally(() => {
-        // Failed admission stays retryable; identity guards against deleting a newer replay.
-        if (pendingHookReplays.get(key) === pending) {
-          pendingHookReplays.delete(key);
+      .catch((err: unknown) => {
+        const current = hookReplayCache.get(key);
+        if (current?.state === "pending" && current.dispatch === pending) {
+          hookReplayCache.delete(key);
         }
+        throw err;
       });
-    pendingHookReplays.set(key, pending);
+    hookReplayCache.set(key, { state: "pending", dispatch: pending });
     return pending;
   };
 
@@ -391,13 +387,9 @@ export function createHooksRequestHandler(
       return true;
     }
 
-    const payload = typeof body.value === "object" && body.value !== null ? body.value : {};
+    const payload = asRecord(body.value);
     const headers = normalizeHookHeaders(req);
-    const idempotencyKey = resolveHookIdempotencyKey({
-      payload: payload as Record<string, unknown>,
-      headers,
-    });
-    const now = Date.now();
+    const idempotencyKey = resolveHookIdempotencyKey({ payload, headers });
     // Later mapped validation errors must report any wake outcome that already occurred.
     let wakeResult: WakeResult | undefined;
     const sendHookError = (error: string) =>
@@ -463,7 +455,7 @@ export function createHooksRequestHandler(
     };
 
     if (subPath === "wake") {
-      const normalized = normalizeWakePayload(payload as Record<string, unknown>);
+      const normalized = normalizeWakePayload(payload);
       if (!normalized.ok) {
         sendJson(res, 400, { ok: false, error: normalized.error });
         return true;
@@ -481,7 +473,12 @@ export function createHooksRequestHandler(
     }
 
     if (subPath === "agent") {
-      const normalized = normalizeAgentPayload(payload as Record<string, unknown>);
+      const waitForCompletion = payload.waitForCompletion;
+      if (waitForCompletion !== undefined && typeof waitForCompletion !== "boolean") {
+        sendJson(res, 400, { ok: false, error: "waitForCompletion must be boolean" });
+        return true;
+      }
+      const normalized = normalizeAgentPayload(payload);
       if (!normalized.ok) {
         sendJson(res, 400, { ok: false, error: normalized.error });
         return true;
@@ -538,9 +535,9 @@ export function createHooksRequestHandler(
           timeoutSeconds: normalized.value.timeoutSeconds ?? null,
         },
       });
-      const replay = resolveHookReplay(replayKey, now);
+      const replay = resolveHookReplay(replayKey);
       if (replay) {
-        sendAgentResult(res, await replay);
+        await sendAgentResult(res, await replay, undefined, waitForCompletion === true);
         return true;
       }
       const dispatchSessionKey = resolveDispatchSessionKeyOrRespond(
@@ -550,7 +547,7 @@ export function createHooksRequestHandler(
       if (dispatchSessionKey === null) {
         return true;
       }
-      const dispatched = await dispatchAgentHookWithReplay(replayKey, now, () =>
+      const dispatched = await dispatchAgentHookWithReplay(replayKey, () =>
         dispatchAgentHook({
           ...normalized.value,
           effectiveAgentId: target.effectiveAgentId,
@@ -561,14 +558,14 @@ export function createHooksRequestHandler(
           externalContentSource: "webhook",
         }),
       );
-      sendAgentResult(res, dispatched);
+      await sendAgentResult(res, dispatched, undefined, waitForCompletion === true);
       return true;
     }
 
     if (hooksConfig.mappings.length > 0) {
       try {
         const mapped = await applyHookMappings(hooksConfig.mappings, {
-          payload: payload as Record<string, unknown>,
+          payload,
           headers,
           url,
           path: subPath,
@@ -673,7 +670,7 @@ export function createHooksRequestHandler(
               dispatchScope,
             });
             return () =>
-              dispatchAgentHookWithReplay(replayKey, now, () =>
+              dispatchAgentHookWithReplay(replayKey, () =>
                 dispatchAgentHook({
                   message: action.message,
                   name: action.name ?? "Hook",
@@ -743,7 +740,7 @@ export function createHooksRequestHandler(
           if (!mapped.fanout) {
             // Non-fanout mappings produce exactly one action.
             const dispatched = await dispatches[0]!();
-            sendAgentResult(res, { ...dispatched, ...wakeResult });
+            void sendAgentResult(res, dispatched, wakeResult);
             return true;
           }
           const settled = await settleFanOutDispatches(

--- a/src/gateway/server/hooks.background-admission.test.ts
+++ b/src/gateway/server/hooks.background-admission.test.ts
@@ -5,7 +5,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
 import { setTimeout as delay } from "node:timers/promises";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveHooksConfig } from "../hooks.js";
 
@@ -88,6 +88,10 @@ async function post(
 }
 
 describe("hook background admission", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("admits slow fan-out items past the bounded deadline instead of canceling them", async () => {
     mocks.getRuntimeConfig.mockReturnValue(config);
     // Execution starts well after the 20ms bounded admission deadline,
@@ -136,5 +140,214 @@ describe("hook background admission", () => {
     // The canceled run must not proceed after the 503.
     await delay(80);
     expect(sawAbort).toBe(true);
+  });
+
+  it.each([
+    { deliverySuppressionReason: "empty", replyDisposition: "empty" },
+    { deliverySuppressionReason: "silent", replyDisposition: "silent" },
+    { deliverySuppressionReason: "heartbeat", replyDisposition: "empty" },
+    { deliverySuppressionReason: "channel_transform", replyDisposition: "visible" },
+  ] as const)(
+    "returns the $deliverySuppressionReason terminal suppression reason to an explicit waiter",
+    async ({ deliverySuppressionReason, replyDisposition }) => {
+      mocks.getRuntimeConfig.mockReturnValue(config);
+      mocks.runCronIsolatedAgentTurn.mockImplementationOnce(
+        async (params: { onExecutionStarted?: () => void }) => {
+          params.onExecutionStarted?.();
+          return {
+            status: "ok" as const,
+            delivered: false,
+            deliveryAttempted: true,
+            deliverySuppressionReason,
+            replyDisposition,
+            outputText: "private output",
+            summary: "private summary",
+            sessionId: "private-session",
+            sessionKey: "private-session-key",
+          };
+        },
+      );
+      const handler = createHandler(100);
+
+      const response = await post(handler, "/hooks/agent", {
+        message: "Direct",
+        name: "Observed",
+        waitForCompletion: true,
+      });
+
+      expect(response.res.statusCode).toBe(200);
+      expect(JSON.parse(response.body())).toEqual({
+        ok: true,
+        runId: expect.any(String),
+        completion: {
+          status: "ok",
+          replyDisposition,
+          delivered: false,
+          deliveryAttempted: true,
+          deliverySuppressionReason,
+        },
+      });
+    },
+  );
+
+  it("returns categorical delivery failure without private run data", async () => {
+    mocks.getRuntimeConfig.mockReturnValue(config);
+    const secret = "fake-secret-value-that-must-not-leak";
+    mocks.runCronIsolatedAgentTurn.mockImplementationOnce(
+      async (params: { onExecutionStarted?: () => void }) => {
+        params.onExecutionStarted?.();
+        return {
+          status: "ok" as const,
+          replyDisposition: "visible" as const,
+          delivered: false,
+          deliveryAttempted: true,
+          deliveryError: `line\nAuthorization: Bearer ${secret}\n${"x".repeat(600)} tail`,
+          outputText: "private output",
+          summary: "private summary",
+          sessionId: "private-session",
+          sessionKey: "private-session-key",
+        };
+      },
+    );
+    const handler = createHandler(100);
+
+    const response = await post(handler, "/hooks/agent", {
+      message: "Direct",
+      name: "Observed",
+      waitForCompletion: true,
+    });
+
+    const body = JSON.parse(response.body()) as {
+      completion: { deliveryError: string };
+    };
+    expect(response.res.statusCode).toBe(200);
+    expect(body).toMatchObject({
+      completion: {
+        status: "ok",
+        replyDisposition: "visible",
+        delivered: false,
+        deliveryAttempted: true,
+        deliveryError: "delivery-failed",
+      },
+    });
+    expect(JSON.stringify(body)).not.toMatch(
+      /Authorization|fake-secret-value|private output|private summary|private-session|x{20}/,
+    );
+  });
+
+  it("preserves an attempted delivery with unknown acknowledgment", async () => {
+    mocks.getRuntimeConfig.mockReturnValue(config);
+    mocks.runCronIsolatedAgentTurn.mockImplementationOnce(
+      async (params: { onExecutionStarted?: () => void }) => {
+        params.onExecutionStarted?.();
+        return {
+          status: "ok" as const,
+          replyDisposition: "empty" as const,
+          delivered: false,
+          deliveryAttempted: true,
+        };
+      },
+    );
+    const handler = createHandler(100);
+
+    const response = await post(handler, "/hooks/agent", {
+      message: "Direct",
+      name: "Observed",
+      waitForCompletion: true,
+    });
+
+    expect(JSON.parse(response.body())).toEqual({
+      ok: true,
+      runId: expect.any(String),
+      completion: {
+        status: "ok",
+        replyDisposition: "empty",
+        delivered: false,
+        deliveryAttempted: true,
+      },
+    });
+  });
+
+  it("settles an admitted waiter when the isolated runner throws", async () => {
+    mocks.getRuntimeConfig.mockReturnValue(config);
+    mocks.runCronIsolatedAgentTurn.mockImplementationOnce(
+      async (params: { onExecutionStarted?: () => void }) => {
+        params.onExecutionStarted?.();
+        throw new Error("private execution diagnostic");
+      },
+    );
+    const handler = createHandler(100);
+
+    const response = await post(handler, "/hooks/agent", {
+      message: "Direct",
+      name: "Observed",
+      waitForCompletion: true,
+    });
+
+    expect(response.res.statusCode).toBe(200);
+    expect(JSON.parse(response.body())).toEqual({
+      ok: true,
+      runId: expect.any(String),
+      completion: { status: "error", replyDisposition: "empty" },
+    });
+  });
+
+  it.each([
+    {
+      name: "verified message-tool delivery",
+      result: {
+        status: "ok" as const,
+        replyDisposition: "silent" as const,
+        delivered: true,
+        deliveryAttempted: true,
+      },
+    },
+    {
+      name: "silent model reply",
+      result: {
+        status: "ok" as const,
+        replyDisposition: "silent" as const,
+        delivered: false,
+        deliveryAttempted: false,
+      },
+    },
+    {
+      name: "private visible model reply",
+      result: {
+        status: "ok" as const,
+        replyDisposition: "visible" as const,
+        delivered: false,
+        deliveryAttempted: false,
+        outputText: "private visible final",
+      },
+    },
+  ])("returns bounded evidence for deliver:false + $name", async ({ result }) => {
+    mocks.getRuntimeConfig.mockReturnValue(config);
+    mocks.runCronIsolatedAgentTurn.mockImplementationOnce(
+      async (params: { onExecutionStarted?: () => void }) => {
+        params.onExecutionStarted?.();
+        return result;
+      },
+    );
+    const handler = createHandler(100);
+
+    const response = await post(handler, "/hooks/agent", {
+      message: "Direct",
+      name: "Observed",
+      deliver: false,
+      waitForCompletion: true,
+    });
+
+    expect(response.res.statusCode).toBe(200);
+    const body = JSON.parse(response.body()) as {
+      completion: Record<string, unknown>;
+    };
+    expect(body.completion).toMatchObject({
+      status: result.status,
+      replyDisposition: result.replyDisposition,
+      delivered: result.delivered,
+      deliveryAttempted: result.deliveryAttempted,
+    });
+    expect(JSON.stringify(body)).not.toContain("private visible final");
   });
 });

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -32,22 +32,20 @@ import type { PluginRuntime } from "../../plugins/runtime/types.js";
 import { runWithGatewayIndependentRootWorkContinuation } from "../../process/gateway-work-admission.js";
 import { CommandLane } from "../../process/lanes.js";
 import { isUnscopedSessionKeySentinel, toAgentStoreSessionKey } from "../../routing/session-key.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import {
   type HookAgentDispatchPayload,
   type HooksConfigResolved,
   normalizeHookDispatchSessionKey,
 } from "../hooks.js";
+import type { HookAgentCompletion, HookAgentDispatchResult } from "../hooks.types.js";
 import {
   fenceScheduledGatewayContextResolver,
   runWithScheduledGatewayContext,
 } from "../scheduled-run-gateway-context.js";
 import { DEDUPE_MAX, DEDUPE_TTL_MS } from "../server-constants.js";
 import type { GatewayRequestContext } from "../server-methods/types.js";
-import {
-  createHooksRequestHandler,
-  type HookAgentDispatchResult,
-  type HookClientIpConfig,
-} from "./hooks-request-handler.js";
+import { createHooksRequestHandler, type HookClientIpConfig } from "./hooks-request-handler.js";
 
 /**
  * Gateway hook HTTP handler factory.
@@ -301,6 +299,7 @@ export function createGatewayHookDispatcher(params: {
     const safeName = sanitizeHookConsoleValue(value.name) ?? "Hook";
     const jobId = randomUUID();
     const runId = randomUUID();
+    const completion = createDeferredCore<HookAgentCompletion>();
     const logContext = sanitizeHookLogMetadata({
       runId,
       jobId,
@@ -333,6 +332,18 @@ export function createGatewayHookDispatcher(params: {
       // A delivery error is separate from execution status; missing acknowledgments are not failures.
       const level = result.status !== "ok" || result.deliveryError ? "warn" : "info";
       logHooks[level](message, meta);
+      return {
+        status: result.status,
+        replyDisposition: result.replyDisposition ?? "empty",
+        ...(result.delivered !== undefined ? { delivered: result.delivered } : {}),
+        ...(result.deliveryAttempted !== undefined
+          ? { deliveryAttempted: result.deliveryAttempted }
+          : {}),
+        ...(result.deliveryError ? { deliveryError: "delivery-failed" as const } : {}),
+        ...(result.deliverySuppressionReason
+          ? { deliverySuppressionReason: result.deliverySuppressionReason }
+          : {}),
+      };
     };
     const nowMs = resolveDateTimestampMs(Date.now());
     const job: CronJob = {
@@ -373,7 +384,7 @@ export function createGatewayHookDispatcher(params: {
       return undefined;
     };
     const reportHookFailure = (err: unknown) => {
-      logHookRunTerminal({ status: "error", error: String(err) });
+      completion.resolve(logHookRunTerminal({ status: "error", error: String(err) }));
       const eventTarget =
         hookEventTarget ??
         resolveHookEventTarget({
@@ -458,7 +469,7 @@ export function createGatewayHookDispatcher(params: {
     const startupAbortController = new AbortController();
     const settleSuccessfulAdmission = () => {
       startupAbortController.signal.throwIfAborted();
-      settleAdmission({ ok: true, runId });
+      settleAdmission({ ok: true, runId, completion: completion.promise });
     };
     // Background admission (fan-out items) skips the start deadline: the
     // producer's redelivery plus the replay cache own retry semantics, and a
@@ -564,7 +575,7 @@ export function createGatewayHookDispatcher(params: {
             if (!admissionSettled) {
               settleAdmission(
                 result.status === "ok" || result.executionStarted === true
-                  ? { ok: true, runId }
+                  ? { ok: true, runId, completion: completion.promise }
                   : createHookAdmissionFailure({
                       runId,
                       disposition: result.admissionDisposition,
@@ -574,7 +585,7 @@ export function createGatewayHookDispatcher(params: {
             const prefix =
               result.status === "ok" ? `Hook ${safeName}` : `Hook ${safeName} (${result.status})`;
             const shouldAnnounce = shouldAnnounceHookRunResult({ deliver: value.deliver, result });
-            logHookRunTerminal(result);
+            completion.resolve(logHookRunTerminal(result));
             if (shouldAnnounce) {
               const eventSessionKey = eventTarget.eventSessionKey;
               const isGlobalEvent = isUnscopedSessionKeySentinel(eventSessionKey);
@@ -675,7 +686,7 @@ export function createGatewayHookDispatcher(params: {
         },
         pluginId,
       );
-      return result.ok ? result : { ok: false, reason: result.error };
+      return result.ok ? { ok: true, runId: result.runId } : { ok: false, reason: result.error };
     };
     const idempotencyKey = normalizeOptionalString(value.idempotencyKey);
     if (!idempotencyKey) {

--- a/test/gateway-hook-concurrency.e2e.test.ts
+++ b/test/gateway-hook-concurrency.e2e.test.ts
@@ -31,6 +31,7 @@ type HeldModelServer = {
   close: () => Promise<void>;
   hold: () => void;
   peak: () => number;
+  queueReply: (text: string) => void;
   release: (index: number) => void;
   releaseAll: () => void;
   requestBody: (index: number) => string | undefined;
@@ -47,6 +48,50 @@ afterEach(async () => {
 });
 
 describe("Gateway hook concurrency", () => {
+  it(
+    "returns bounded reply disposition from real stub-model hook turns",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const modelServer = await startHeldModelServer();
+      modelServers.push(modelServer);
+      const instance = await createOpenClawTestInstance({
+        name: "gateway-hook-completion",
+        config: createTestConfig(modelServer.url),
+        env: { OPENCLAW_SKIP_CRON: undefined, OPENCLAW_SKIP_PROVIDERS: undefined },
+      });
+      instances.push(instance);
+      await instance.startGateway();
+      await warmGatewayHook(instance, modelServer);
+
+      const privateVisibleReply = "private visible hook completion";
+      modelServer.queueReply(privateVisibleReply);
+      const visible = await postObservedHook(instance, "visible");
+      expect(visible.status, visible.body).toBe(200);
+      expect(JSON.parse(visible.body)).toMatchObject({
+        ok: true,
+        runId: expect.any(String),
+        completion: {
+          status: "ok",
+          replyDisposition: "visible",
+        },
+      });
+      expect(visible.body).not.toContain(privateVisibleReply);
+
+      modelServer.queueReply("NO_REPLY");
+      const silent = await postObservedHook(instance, "silent");
+      expect(silent.status, silent.body).toBe(200);
+      expect(JSON.parse(silent.body)).toMatchObject({
+        ok: true,
+        runId: expect.any(String),
+        completion: {
+          status: "ok",
+          replyDisposition: "silent",
+        },
+      });
+      expect(silent.body).not.toContain("NO_REPLY");
+    },
+  );
+
   it(
     "bounds hooks and admits an older cron turn before a later hook",
     { timeout: TEST_TIMEOUT_MS },
@@ -308,9 +353,33 @@ async function postHook(instance: OpenClawTestInstance, index: number): Promise<
   };
 }
 
+async function postObservedHook(instance: OpenClawTestInstance, id: string): Promise<HookResponse> {
+  const response = await fetch(`http://127.0.0.1:${instance.port}/hooks/agent`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${instance.hookToken}`,
+      "Content-Type": "application/json",
+      "Idempotency-Key": `hook-completion-${id}`,
+    },
+    body: JSON.stringify({
+      message: `hook completion request ${id}`,
+      name: `Hook completion ${id}`,
+      sessionKey: `hook:completion:${id}`,
+      sessionMode: "persistent",
+      deliver: false,
+      waitForCompletion: true,
+    }),
+  });
+  return {
+    body: await response.text(),
+    status: response.status,
+  };
+}
+
 async function startHeldModelServer(): Promise<HeldModelServer> {
   const releases: Deferred[] = [];
   const requestBodies: string[] = [];
+  const replyTexts = new Map<number, string>();
   let holdRequests = false;
   let active = 0;
   let peak = 0;
@@ -354,7 +423,7 @@ async function startHeldModelServer(): Promise<HeldModelServer> {
     try {
       await release.promise;
       if (!response.destroyed) {
-        writeModelResponse(response, index);
+        writeModelResponse(response, index, replyTexts.get(index));
       }
     } finally {
       active -= 1;
@@ -382,6 +451,9 @@ async function startHeldModelServer(): Promise<HeldModelServer> {
       holdRequests = true;
     },
     peak: () => peak,
+    queueReply: (text) => {
+      replyTexts.set(requestCount, text);
+    },
     release: (index) => {
       releases[index]?.resolve();
     },
@@ -439,8 +511,8 @@ async function delay(ms: number): Promise<void> {
   });
 }
 
-function writeModelResponse(response: ServerResponse, sequence: number): void {
-  const text = `hook concurrency response ${sequence}`;
+function writeModelResponse(response: ServerResponse, sequence: number, replyText?: string): void {
+  const text = replyText ?? `hook concurrency response ${sequence}`;
   const message = {
     type: "message",
     id: `hook-concurrency-message-${sequence}`,


### PR DESCRIPTION
Fixes #139154

## What Problem This Solves

Fixes an issue where direct agent-hook callers could observe admission but could not tell whether the run delivered a message, intentionally replied `NO_REPLY`, produced an undelivered private reply, or failed after admission.

## Why This Change Was Made

Adds an opt-in `waitForCompletion: true` contract for direct `/hooks/agent` calls. The response carries only bounded owner-authored execution, reply-disposition, and delivery facts. Default calls, mappings, and fan-out remain admission-only.

Replay ownership is one canonical `pending -> active -> terminal` state machine. Pending and active runs cannot be evicted; terminal results receive the existing TTL/LRU policy and replay the same run and completion.

## User Impact

Automation can distinguish visible output, exact intentional silence, verified delivery, suppression, and delivery failure without receiving model text, target/session identifiers, or provider diagnostics.

## Evidence

- Real behavior: `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs test/gateway-hook-concurrency.e2e.test.ts -t "returns bounded reply disposition from real stub-model hook turns"`
- Observed: real Gateway returned `replyDisposition: "visible"` for a private visible reply and `"silent"` for exact `NO_REPLY`; neither reply text appeared in the HTTP body.
- Result: 1 selected test passed; 1 filtered skip.
- Focused Gateway hook suites: 27/27 passed.
- Cron message-tool policy suite: 60/60 passed.
- Build, format, lint, and diff checks passed.
- Independent committed-branch Codex review: no actionable P0-P2 findings.

### Repair Scope

- Root cause: hook admission discarded the terminal outcome owned by the isolated agent-run finalizer.
- Architectural owner: cron finalization records reply/delivery facts; the Gateway hook boundary sanitizes and exposes only the bounded public projection.
- Canonical fix: one opt-in direct-hook completion response and one replay owner state machine.
- Sibling coverage: admission-only direct calls, mapped hooks, fan-out, failed admission retry, delayed admission, active-run TTL/LRU pressure, and terminal replay.
- Production LOC: +146/-95, net +51. The growth is the public completion contract and replay ownership needed to keep active idempotent runs non-evictable.
- Tests/support: +597/-22. Docs: +64/-20.

### Limits

The real-behavior proof used a loopback stub model provider. It did not perform live Discord delivery.
