### PR TITLE
perf(agents): reduce repeated tool-result budgeting

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -805,6 +805,13 @@ type ToolResultReplacement = {
   message: AgentMessage;
 };
 
+type MeasuredToolResultBranchEntry = {
+  readonly entry: ToolResultBranchEntry;
+  readonly textLength: number;
+};
+
+type MeasuredToolResultReplacement = Readonly<ToolResultReplacement & { textLength: number }>;
+
 function getToolResultProjectionBaseKey(message: AgentMessage): string | undefined {
   if (message.role !== "toolResult") {
     return undefined;
@@ -1107,15 +1114,15 @@ function toolResultTextMatches(left: string[], right: string[]): boolean {
 }
 
 function buildAggregateToolResultReplacements(params: {
-  branch: ToolResultBranchEntry[];
+  branch: MeasuredToolResultBranchEntry[];
   spillSourceBranch?: ToolResultBranchEntry[];
   aggregateBudgetChars: number;
   minKeepChars?: number;
   protectedEntryIds?: Set<string>;
-}): { replacements: ToolResultReplacement[]; pressureExceeded: boolean } {
+}): { replacements: MeasuredToolResultReplacement[]; pressureExceeded: boolean } {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
   const candidates = params.branch
-    .flatMap((entry, index) => {
+    .flatMap(({ entry, textLength }, index) => {
       const message = entry.message;
       return entry.type === "message" && message?.role === "toolResult"
         ? [
@@ -1123,7 +1130,7 @@ function buildAggregateToolResultReplacements(params: {
               entryId: entry.id,
               message,
               spillSourceMessage: params.spillSourceBranch?.[index]?.message ?? message,
-              textLength: getToolResultTextBudget(message),
+              textLength,
               aggregateEligible: entry.aggregateEligible !== false,
               protectedByTrailingBatch: params.protectedEntryIds?.has(entry.id) ?? false,
             },
@@ -1149,7 +1156,7 @@ function buildAggregateToolResultReplacements(params: {
   }
 
   let remainingReduction = totalChars - params.aggregateBudgetChars;
-  const replacements = new Map<string, ToolResultReplacement>();
+  const replacements = new Map<string, MeasuredToolResultReplacement>();
   // Frozen prompt bytes are immutable. Recover only from unsent tail results;
   // allow budget overflow when frozen history alone exceeds the aggregate cap.
   const recoveryCandidates = candidates.filter(
@@ -1162,8 +1169,8 @@ function buildAggregateToolResultReplacements(params: {
       if (remainingReduction <= 0) {
         break;
       }
-      const baseMessage = replacements.get(candidate.entryId)?.message ?? candidate.message;
-      const baseTextLength = getToolResultTextBudget(baseMessage);
+      const baseTextLength =
+        replacements.get(candidate.entryId)?.textLength ?? candidate.textLength;
       if (!clear && baseTextLength <= minTruncatedTextChars) {
         continue;
       }
@@ -1192,11 +1199,17 @@ function buildAggregateToolResultReplacements(params: {
           suffix,
         });
       }
-      const actualReduction = Math.max(0, baseTextLength - getToolResultTextBudget(message));
+      const textLength =
+        message === candidate.message ? candidate.textLength : getToolResultTextBudget(message);
+      const actualReduction = Math.max(0, baseTextLength - textLength);
       if (actualReduction <= 0 && (!clear || !spillMarkers)) {
         continue;
       }
-      replacements.set(candidate.entryId, { entryId: candidate.entryId, message });
+      replacements.set(candidate.entryId, {
+        entryId: candidate.entryId,
+        message,
+        textLength,
+      });
       remainingReduction -= actualReduction;
     }
   }
@@ -1265,24 +1278,25 @@ function clearToolResultText(
 }
 
 function applyToolResultReplacementsToBranch(
-  branch: ToolResultBranchEntry[],
-  replacements: ToolResultReplacement[],
-): { branch: ToolResultBranchEntry[]; reducedChars: number } {
+  branch: MeasuredToolResultBranchEntry[],
+  replacements: MeasuredToolResultReplacement[],
+): { branch: MeasuredToolResultBranchEntry[]; reducedChars: number } {
   if (replacements.length === 0) {
     return { branch, reducedChars: 0 };
   }
-  const replacementsById = new Map(replacements.map(({ entryId, message }) => [entryId, message]));
+  const replacementsById = new Map(replacements.map((item) => [item.entryId, item]));
   let reducedChars = 0;
-  const nextBranch = branch.map((entry) => {
-    const message = replacementsById.get(entry.id);
-    if (!message || entry.type !== "message" || !entry.message) {
-      return entry;
+  const nextBranch = branch.map((measured) => {
+    const { entry, textLength } = measured;
+    const replacement = replacementsById.get(entry.id);
+    if (!replacement || entry.type !== "message" || !entry.message) {
+      return measured;
     }
-    reducedChars += Math.max(
-      0,
-      getToolResultTextBudget(entry.message) - getToolResultTextBudget(message),
-    );
-    return { ...entry, message };
+    reducedChars += Math.max(0, textLength - replacement.textLength);
+    return {
+      entry: { ...entry, message: replacement.message },
+      textLength: replacement.textLength,
+    };
   });
   return { branch: nextBranch, reducedChars };
 }
@@ -1301,35 +1315,60 @@ function buildToolResultReplacementPlan(params: {
   aggregatePressureExceeded: boolean;
   oversizedReducibleChars: number;
   aggregateReducibleChars: number;
+  toolResultCount: number;
+  totalToolResultChars: number;
 } {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
   const protectedEntryIds = params.protectTrailingToolResults
     ? getTrailingToolResultEntryIds(params.branch)
     : undefined;
-  const oversizedReplacements = params.branch.flatMap((entry): ToolResultReplacement[] => {
-    const message = entry.message;
-    if (
-      entry.type !== "message" ||
-      message?.role !== "toolResult" ||
-      getToolResultTextBudget(message) <= params.maxChars
-    ) {
-      return [];
+  let toolResultCount = 0;
+  let totalToolResultChars = 0;
+  // Measurements belong to this synchronous plan, never to mutable messages or
+  // session projection state. Replacement producers supply the next measurement.
+  const measuredBranch = params.branch.map((entry): MeasuredToolResultBranchEntry => {
+    const textLength =
+      entry.type === "message" && entry.message ? getToolResultTextBudget(entry.message) : 0;
+    if (textLength > 0) {
+      toolResultCount += 1;
+      totalToolResultChars += textLength;
     }
-    const suffix = resolveAggregateElisionMarkers(message)?.truncationSuffix;
-    const maxChars = Math.max(params.maxChars, suffix ? estimateToolResultTextChars(suffix(1)) : 0);
-    return [
-      {
-        entryId: entry.id,
-        message: truncateToolResultMessage(message, maxChars, {
-          minKeepChars: protectedEntryIds?.has(entry.id)
-            ? Math.max(minKeepChars, MIN_KEEP_CHARS)
-            : minKeepChars,
-          ...(suffix ? { suffix } : {}),
-        }),
-      },
-    ];
+    return { entry, textLength };
   });
-  const oversizedPhase = applyToolResultReplacementsToBranch(params.branch, oversizedReplacements);
+  const oversizedReplacements = measuredBranch.flatMap(
+    ({ entry, textLength }): MeasuredToolResultReplacement[] => {
+      const message = entry.message;
+      if (
+        entry.type !== "message" ||
+        message?.role !== "toolResult" ||
+        textLength <= params.maxChars
+      ) {
+        return [];
+      }
+      const suffix = resolveAggregateElisionMarkers(message)?.truncationSuffix;
+      const maxChars = Math.max(
+        params.maxChars,
+        suffix ? estimateToolResultTextChars(suffix(1)) : 0,
+      );
+      const replacementMessage = truncateToolResultMessage(message, maxChars, {
+        minKeepChars: protectedEntryIds?.has(entry.id)
+          ? Math.max(minKeepChars, MIN_KEEP_CHARS)
+          : minKeepChars,
+        ...(suffix ? { suffix } : {}),
+      });
+      return [
+        {
+          entryId: entry.id,
+          message: replacementMessage,
+          textLength:
+            replacementMessage === message
+              ? textLength
+              : getToolResultTextBudget(replacementMessage),
+        },
+      ];
+    },
+  );
+  const oversizedPhase = applyToolResultReplacementsToBranch(measuredBranch, oversizedReplacements);
   const aggregatePlan = buildAggregateToolResultReplacements({
     branch: oversizedPhase.branch,
     spillSourceBranch: params.branch,
@@ -1343,13 +1382,20 @@ function buildToolResultReplacementPlan(params: {
   );
 
   return {
-    branch: aggregatePhase.branch,
-    replacements: [...oversizedReplacements, ...aggregatePlan.replacements],
+    branch:
+      aggregatePhase.branch === measuredBranch
+        ? params.branch
+        : aggregatePhase.branch.map(({ entry }) => entry),
+    replacements: [...oversizedReplacements, ...aggregatePlan.replacements].map(
+      ({ entryId, message }) => ({ entryId, message }),
+    ),
     oversizedReplacementCount: oversizedReplacements.length,
     aggregateReplacementCount: aggregatePlan.replacements.length,
     aggregatePressureExceeded: aggregatePlan.pressureExceeded,
     oversizedReducibleChars: oversizedPhase.reducedChars,
     aggregateReducibleChars: aggregatePhase.reducedChars,
+    toolResultCount,
+    totalToolResultChars,
   };
 }
 
@@ -1412,19 +1458,6 @@ export function estimateToolResultReductionPotential(params: {
   const { maxChars, aggregateBudgetChars } = resolveToolResultBudgets(params);
   const branch = buildToolResultPlanningBranch(params.messages);
 
-  let toolResultCount = 0;
-  let totalToolResultChars = 0;
-  for (const { message: msg } of branch) {
-    if (msg.role !== "toolResult") {
-      continue;
-    }
-    const textLength = getToolResultTextBudget(msg);
-    if (textLength <= 0) {
-      continue;
-    }
-    toolResultCount += 1;
-    totalToolResultChars += textLength;
-  }
   const plan = buildToolResultReplacementPlan({
     branch,
     maxChars,
@@ -1436,8 +1469,8 @@ export function estimateToolResultReductionPotential(params: {
   return {
     maxChars,
     aggregateBudgetChars,
-    toolResultCount,
-    totalToolResultChars,
+    toolResultCount: plan.toolResultCount,
+    totalToolResultChars: plan.totalToolResultChars,
     oversizedCount: plan.oversizedReplacementCount,
     oversizedReducibleChars: plan.oversizedReducibleChars,
     aggregateReducibleChars: plan.aggregateReducibleChars,


### PR DESCRIPTION
## What Problem This Solves

Tool-heavy histories spend unnecessary synchronous work preparing prompts and estimating whether tool-result truncation can avoid compaction. Even when every result fits, the same text is measured twice during projection and three times during reduction estimation.

## Why This Change Was Made

The replacement planner now measures each input once and carries that fact through its oversized and aggregate phases. Producers measure replacement messages once; application consumes those measurements. The reduction estimator reuses the planner's original totals.

Measurements are private to one synchronous plan. Returned messages, replacement descriptors, projection state, truncation policies and persisted data retain their existing shapes and behavior. This avoids a cache attached to mutable messages or shared across calls. Production delta: +94/-61 (net +33), for the explicit measurement ownership and boundary conversion; tests are unchanged.

## User Impact

Less CPU work during tool-result projection and recovery planning, particularly for CJK-heavy results. Truncation output, frozen prompt prefixes, trailing-result protection, spill references and recovery counters are preserved.

## Evidence

- Before editing, a diagnostic around the complete owner observed 64 budget computations for 32 unchanged CJK results; the once-per-plan assertion failed. The implementation performs 32. Reduction estimation changes from 96 to 32 computations.
- Thirteen synthetic cases preserve complete baseline output hashes and reduction metrics, including per-result/aggregate/both phases, ASCII/CJK/supplementary text, images, spill pointers, empty/single results, and duplicate or absent tool-call IDs. Additional original-versus-patch diagnostics preserve multi-turn frozen projections, mutations between calls and duplicate branch-ID application semantics.
- Five alternating, separate-process Node 26.7 runs with 20 warmup calls show median CPU per call of **7.701 → 3.810 ms** for below-cap CJK projection and **11.491 → 3.826 ms** for reduction estimation. With both truncation phases active, projection is **27.986 → 24.534 ms**. The below-cap fixture is 32 results, each containing `"漢字カナ한글".repeat(1500)`, with 64,000 per-result and 2,000,000 aggregate budgets. These are local synthetic measurements of the uninstrumented owner with explicit dormant-import adapters, not production latency. Peak process RSS across the runs was 114,352 → 113,936 KiB.
- **255 tests in 10 files pass on isolated Linux Node 24.19.0**, using the verified source bundle and frozen dependency graph. Coverage includes actual SQLite session recovery, sticky cache-TTL replay, Unicode budgets, context guards, preemptive compaction and provider-bound truncation. This is deterministic application-boundary proof, not an authenticated model call.
- Independent source review and isolated Codex review found no actionable P0/P1/P2 defects. Pinned formatter and `git diff --check` pass. The complete required changed check passes on the isolated Linux source bundle (12m57s), and exact-head [CI 33972991872](https://github.com/openclaw/openclaw/actions/runs/33972991872) is green. Native preparation also passes.

No permanent private-helper spy or wall-clock assertion was added; the retained failing diagnostic and before/after benchmark prove the performance premise, while existing public-boundary suites protect behavior.

The completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/139156#issuecomment-5552643832) was read in full: no findings, no pre-merge requirements, and no Rank-up moves to apply.
