### PR TITLE
fix(active-memory): emit info-level recall-skipped signals for silent early exits

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -491,6 +491,10 @@ describe("active-memory plugin", () => {
     vi
       .mocked(api.logger.debug)
       .mock.calls.some((call: unknown[]) => String(call[0]).includes(needle));
+  const hasInfoLine = (needle: string) =>
+    vi
+      .mocked(api.logger.info)
+      .mock.calls.some((call: unknown[]) => String(call[0]).includes(needle));
   const hasWarnLine = (needle: string) =>
     vi
       .mocked(api.logger.warn)
@@ -1707,7 +1711,17 @@ describe("active-memory plugin", () => {
 
     expectPrependContextContains(result, skippedRecallContext);
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
-    expect(hasDebugLine("active-memory: recall skipped reason=no-recall-intent")).toBe(true);
+    expect(hasInfoLine("active-memory: recall skipped reason=no-recall-intent")).toBe(true);
+  });
+
+  it("logs an info skip line when the prompt has no turn tool authority", async () => {
+    // Regression for #138561: "did not run at all" must stay distinguishable
+    // from "ran and found nothing relevant" without enabling debug.
+    const result = await runPromptBuild({ prompt: "hello" }, { toolAuthority: undefined });
+
+    expect(result).toBeUndefined();
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+    expect(hasInfoLine("active-memory: recall skipped reason=no-tool-authority")).toBe(true);
   });
 
   it("does not run deep recall when the live active-memory plugin entry is removed", async () => {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -209,9 +209,9 @@ export default definePluginEntry({
       async (event, ctx) => {
         const toolAuthority = ctx.toolAuthority;
         if (!toolAuthority) {
-          api.logger.debug?.(
-            "active-memory: recall skipped because this prompt has no turn tool authority",
-          );
+          // Info, not debug: "did not run at all" must stay distinguishable
+          // from "ran and found nothing relevant" (see #138561).
+          api.logger.info?.("active-memory: recall skipped reason=no-tool-authority");
           return undefined;
         }
         toolAuthority.assertActive();
@@ -289,6 +289,7 @@ export default definePluginEntry({
                 sessionKey: resolvedSessionKey,
                 statusLine: `${ACTIVE_MEMORY_STATUS_PREFIX} status=policy-disabled`,
               });
+              api.logger.info?.("active-memory: recall skipped reason=policy-disabled");
               toolAuthority.assertActive();
               return undefined;
             }
@@ -299,6 +300,7 @@ export default definePluginEntry({
                 sessionKey: resolvedSessionKey,
               })
             ) {
+              api.logger.info?.("active-memory: recall skipped reason=harness-session");
               return undefined;
             }
             const sessionDisabled = await isSessionActiveMemoryDisabled({
@@ -313,6 +315,7 @@ export default definePluginEntry({
                 agentId: effectiveAgentId,
                 sessionKey: resolvedSessionKey,
               });
+              api.logger.info?.("active-memory: recall skipped reason=session-disabled");
               return undefined;
             }
             const sessionContext = {
@@ -325,6 +328,7 @@ export default definePluginEntry({
                 agentId: effectiveAgentId,
                 sessionKey: resolvedSessionKey,
               });
+              api.logger.info?.("active-memory: recall skipped reason=ineligible-session");
               return undefined;
             }
             const destinationContext = {
@@ -422,6 +426,7 @@ export default definePluginEntry({
                 agentId: effectiveAgentId,
                 sessionKey: resolvedSessionKey,
               });
+              api.logger.info?.("active-memory: recall skipped reason=lane-not-allowed");
               return laneOneContext ? { prependContext: laneOneContext } : undefined;
             }
             const escalationDecision = resolveRecallEscalationDecision({
@@ -430,7 +435,7 @@ export default definePluginEntry({
               hasStrongLaneOneHit: laneOne.hasStrongHit,
             });
             if (escalationDecision !== "recall") {
-              api.logger.debug?.(`active-memory: recall skipped reason=${escalationDecision}`);
+              api.logger.info?.(`active-memory: recall skipped reason=${escalationDecision}`);
               const outcomeContext =
                 escalationDecision === "no-recall-intent"
                   ? buildRecallOutcomePrefix("skipped-no-recall-intent")


### PR DESCRIPTION
Related: #138561

## What Problem This Solves

When the `active-memory` plugin skips recall, every early exit in its `before_prompt_build` hook is silent at `info` level (debug-only or nothing at all). "The plugin did not run at all" is therefore indistinguishable from "ran and found no relevant memory" without enabling debug — exactly the blind spot that hid a two-day recall outage in #138561.

## Why This Change Was Made

Each hook early exit in `extensions/active-memory/index.ts` now emits `active-memory: recall skipped reason=<reason>` at `info` level (`no-tool-authority`, `policy-disabled`, `harness-session`, `session-disabled`, `ineligible-session`, `lane-not-allowed`, plus the escalation decision, upgraded from debug). Debug-mode visibility is preserved since info logs surface there too. No recall logic, thresholds, or dispatch behavior changes — this is the independently-defective observability half of #138561; the underlying recall-stop trigger remains undiagnosed there and is explicitly out of scope.

## User Impact

Operators watching gateway logs at `info` see one recall-skipped line with a reason per skipped prompt, instead of silence that mimics healthy no-result operation.

## Evidence

- Updated `records why default escalation skips an ordinary turn` to expect the info line; added `logs an info skip line when the prompt has no turn tool authority` regression test.
- Verified no other test pins the old debug-only lines or exact `logger.info` call arrays.
- Both edited files pass an esbuild transform check; local vitest lane cannot run in this Windows checkout (rolldown native binding failure at config load), so CI runs the full extension suite on the exact head SHA.
