### PR TITLE
fix(llama-cpp): allow fresh binary validation on macOS 26

### DIFF
--- a/extensions/llama-cpp/src/llama-server-install.test.ts
+++ b/extensions/llama-cpp/src/llama-server-install.test.ts
@@ -115,7 +115,6 @@ function installWriteFileThroughWrite(handle: FileHandle): void {
       }
       offset += bytesWritten;
     }
-    // SAFETY: the stub reuses the real FileHandle write signature; only call sequencing is overridden.
   }) as typeof handle.writeFile;
 }
 
@@ -234,7 +233,6 @@ describe("downloadVerifiedFile", () => {
         firstWrite = false;
         writes.push(result.bytesWritten);
         return result;
-        // SAFETY: the stub reuses the real FileHandle write signature; only call sequencing is overridden.
       }) as typeof handle.write;
       installWriteFileThroughWrite(handle);
     });
@@ -269,7 +267,6 @@ describe("downloadVerifiedFile", () => {
     injectFileHandle((handle) => {
       handle.write = vi.fn(async () => {
         throw new Error("injected write failure");
-        // SAFETY: the stub reuses the real FileHandle write signature; only call sequencing is overridden.
       }) as typeof handle.write;
       installWriteFileThroughWrite(handle);
     });
@@ -338,28 +335,28 @@ describe("ensureLlamaServerInstalled", () => {
     );
   });
 
-  it("retries a timed-out first exec with a wider budget (macOS 26 security scan)", async () => {
-    // Regression for #138672: macOS 26 blocks the first exec of a freshly
-    // downloaded unsigned binary for ~35-40s while syspolicyd evaluates it, so
-    // the 15s cap killed the version check before setup could finish. The
-    // evaluation is cached per binary hash, so the retry succeeds.
-    const command = await createInstalledServer();
-    const calls: Array<number | undefined> = [];
+  it("uses the wider version timeout only for a freshly extracted CPU ZIP", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "llama-cpu-install-")));
+    tempRoots.push(root);
+    mocks.resolveLlamaCppDataDir.mockReturnValue(root);
+    const source = selectLlamaServerAsset("win32", "arm64", { kind: "cpu" });
+    const serverBytes = await new JSZip()
+      .file(source.executable, "server")
+      .generateAsync({ type: "nodebuffer" });
+    const asset: LlamaServerAsset = {
+      ...source,
+      sha256: createHash("sha256").update(serverBytes).digest("hex"),
+    };
+    mockDownload(serverBytes);
+    const calls: Array<{ command: string; args: string[]; timeout?: number }> = [];
     mocks.execFile.mockImplementation(
       (
-        _command: string,
-        _args: string[],
+        command: string,
+        args: string[],
         options: { timeout?: number },
         callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
       ) => {
-        calls.push(options.timeout);
-        if (calls.length === 1) {
-          const error = new Error(`Command failed: ${command} --version`) as ExecFileException;
-          error.killed = true;
-          error.signal = "SIGTERM";
-          callback(error, "", "");
-          return;
-        }
+        calls.push({ command, args, timeout: options.timeout });
         callback(
           null,
           `version: 0.1.0-dev (build ${LLAMA_SERVER_BUILD}, commit ${LLAMA_SERVER_COMMIT.slice(0, 9)})`,
@@ -368,53 +365,62 @@ describe("ensureLlamaServerInstalled", () => {
       },
     );
 
-    await expect(ensureLlamaServerInstalled()).resolves.toMatchObject({ command });
-    expect(calls).toEqual([15_000, 120_000]);
+    const { command } = resolveManagedLlamaServerPaths(asset);
+    await expect(ensureLlamaServerInstalled({ asset })).resolves.toMatchObject({ command });
+    await expect(ensureLlamaServerInstalled({ asset })).resolves.toMatchObject({ command });
+
+    expect(
+      calls.map((call) => ({
+        published: call.command === command,
+        args: call.args,
+        timeout: call.timeout,
+      })),
+    ).toEqual([
+      { published: false, args: ["--version"], timeout: 120_000 },
+      { published: true, args: ["--version"], timeout: 15_000 },
+      { published: true, args: ["--version"], timeout: 15_000 },
+    ]);
+    expect(await fs.readFile(command, "utf8")).toBe("server");
+    expect((await fs.readdir(root)).every((entry) => !entry.startsWith("."))).toBe(true);
   });
 
-  it("does not retry exec failures that are not timeouts", async () => {
-    const command = await createInstalledServer();
-    let calls = 0;
-    mocks.execFile.mockImplementation(
-      (
-        _command: string,
-        _args: string[],
-        _options: unknown,
-        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
-      ) => {
-        calls += 1;
-        const error = new Error(`spawn ${command} ENOENT`) as ExecFileException;
-        error.code = "ENOENT";
-        callback(error, "", "");
-      },
-    );
-
-    await expect(ensureLlamaServerInstalled()).rejects.toThrow();
-    expect(calls).toBe(1);
-  });
-
-  it("does not retry after the caller aborts", async () => {
-    await createInstalledServer();
-    const calls: Array<number | undefined> = [];
+  it("aborts fresh validation and removes the unpublished CPU ZIP files", async () => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "llama-cpu-abort-")));
+    tempRoots.push(root);
+    mocks.resolveLlamaCppDataDir.mockReturnValue(root);
+    const source = selectLlamaServerAsset("win32", "arm64", { kind: "cpu" });
+    const serverBytes = await new JSZip()
+      .file(source.executable, "server")
+      .generateAsync({ type: "nodebuffer" });
+    const asset: LlamaServerAsset = {
+      ...source,
+      sha256: createHash("sha256").update(serverBytes).digest("hex"),
+    };
+    mockDownload(serverBytes);
     const controller = new AbortController();
+    const timeouts: Array<number | undefined> = [];
     mocks.execFile.mockImplementation(
       (
-        _command: string,
+        command: string,
         _args: string[],
         options: { timeout?: number },
         callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
       ) => {
-        calls.push(options.timeout);
+        timeouts.push(options.timeout);
         controller.abort();
-        const error = new Error("timeout") as ExecFileException;
-        error.killed = true;
-        error.signal = "SIGTERM";
+        const error = new Error("The operation was aborted") as ExecFileException;
+        error.cmd = `${command} --version`;
         callback(error, "", "");
       },
     );
 
-    await expect(ensureLlamaServerInstalled({ signal: controller.signal })).rejects.toThrow();
-    expect(calls).toEqual([15_000]);
+    const { command } = resolveManagedLlamaServerPaths(asset);
+    await expect(
+      ensureLlamaServerInstalled({ asset, signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(timeouts).toEqual([120_000]);
+    await expect(fs.stat(command)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await fs.readdir(root)).toEqual([]);
   });
 
   it.each(["ready", "corrupt-runtime", "missing-runtime", "no-device", "cancelled"] as const)(
@@ -461,13 +467,15 @@ describe("ensureLlamaServerInstalled", () => {
         return { response: new Response(new Uint8Array(payload)), release };
       });
       const validatedFiles: string[][] = [];
+      const commandCalls: Array<{ args: string[]; timeout?: number }> = [];
       mocks.execFile.mockImplementation(
         (
           command: string,
           args: string[],
-          _options: unknown,
+          options: { timeout?: number },
           callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
         ) => {
+          commandCalls.push({ args, timeout: options.timeout });
           void fs.readdir(path.dirname(command)).then((files) => {
             validatedFiles.push(files);
             const stdout =
@@ -499,6 +507,12 @@ describe("ensureLlamaServerInstalled", () => {
         expect(
           validatedFiles.every((files) => runtime.files.every((file) => files.includes(file))),
         ).toBe(true);
+        expect(commandCalls).toEqual([
+          { args: ["--version"], timeout: 120_000 },
+          { args: ["--list-devices"], timeout: 15_000 },
+          { args: ["--version"], timeout: 15_000 },
+          { args: ["--list-devices"], timeout: 15_000 },
+        ]);
       } else {
         const expected = {
           "corrupt-runtime": /SHA-256 mismatch/u,
@@ -508,6 +522,14 @@ describe("ensureLlamaServerInstalled", () => {
         }[outcome];
         await expect(result).rejects.toThrow(expected);
         await expect(fs.stat(command)).rejects.toMatchObject({ code: "ENOENT" });
+        if (outcome === "no-device") {
+          expect(commandCalls).toEqual([
+            { args: ["--version"], timeout: 120_000 },
+            { args: ["--list-devices"], timeout: 15_000 },
+          ]);
+        } else {
+          expect(commandCalls).toEqual([]);
+        }
       }
       expect((await fs.readdir(root)).every((entry) => !entry.startsWith("."))).toBe(true);
       expect(

--- a/extensions/llama-cpp/src/llama-server-install.test.ts
+++ b/extensions/llama-cpp/src/llama-server-install.test.ts
@@ -115,6 +115,7 @@ function installWriteFileThroughWrite(handle: FileHandle): void {
       }
       offset += bytesWritten;
     }
+    // SAFETY: the stub reuses the real FileHandle write signature; only call sequencing is overridden.
   }) as typeof handle.writeFile;
 }
 
@@ -233,6 +234,7 @@ describe("downloadVerifiedFile", () => {
         firstWrite = false;
         writes.push(result.bytesWritten);
         return result;
+        // SAFETY: the stub reuses the real FileHandle write signature; only call sequencing is overridden.
       }) as typeof handle.write;
       installWriteFileThroughWrite(handle);
     });
@@ -267,6 +269,7 @@ describe("downloadVerifiedFile", () => {
     injectFileHandle((handle) => {
       handle.write = vi.fn(async () => {
         throw new Error("injected write failure");
+        // SAFETY: the stub reuses the real FileHandle write signature; only call sequencing is overridden.
       }) as typeof handle.write;
       installWriteFileThroughWrite(handle);
     });
@@ -333,6 +336,85 @@ describe("ensureLlamaServerInstalled", () => {
     await expect(ensureLlamaServerInstalled()).rejects.toThrow(
       `expected b${LLAMA_SERVER_BUILD} (${LLAMA_SERVER_COMMIT.slice(0, 9)})`,
     );
+  });
+
+  it("retries a timed-out first exec with a wider budget (macOS 26 security scan)", async () => {
+    // Regression for #138672: macOS 26 blocks the first exec of a freshly
+    // downloaded unsigned binary for ~35-40s while syspolicyd evaluates it, so
+    // the 15s cap killed the version check before setup could finish. The
+    // evaluation is cached per binary hash, so the retry succeeds.
+    const command = await createInstalledServer();
+    const calls: Array<number | undefined> = [];
+    mocks.execFile.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        options: { timeout?: number },
+        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+      ) => {
+        calls.push(options.timeout);
+        if (calls.length === 1) {
+          const error = new Error(`Command failed: ${command} --version`) as ExecFileException;
+          error.killed = true;
+          error.signal = "SIGTERM";
+          callback(error, "", "");
+          return;
+        }
+        callback(
+          null,
+          `version: 0.1.0-dev (build ${LLAMA_SERVER_BUILD}, commit ${LLAMA_SERVER_COMMIT.slice(0, 9)})`,
+          "",
+        );
+      },
+    );
+
+    await expect(ensureLlamaServerInstalled()).resolves.toMatchObject({ command });
+    expect(calls).toEqual([15_000, 120_000]);
+  });
+
+  it("does not retry exec failures that are not timeouts", async () => {
+    const command = await createInstalledServer();
+    let calls = 0;
+    mocks.execFile.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+      ) => {
+        calls += 1;
+        const error = new Error(`spawn ${command} ENOENT`) as ExecFileException;
+        error.code = "ENOENT";
+        callback(error, "", "");
+      },
+    );
+
+    await expect(ensureLlamaServerInstalled()).rejects.toThrow();
+    expect(calls).toBe(1);
+  });
+
+  it("does not retry after the caller aborts", async () => {
+    await createInstalledServer();
+    const calls: Array<number | undefined> = [];
+    const controller = new AbortController();
+    mocks.execFile.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        options: { timeout?: number },
+        callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+      ) => {
+        calls.push(options.timeout);
+        controller.abort();
+        const error = new Error("timeout") as ExecFileException;
+        error.killed = true;
+        error.signal = "SIGTERM";
+        callback(error, "", "");
+      },
+    );
+
+    await expect(ensureLlamaServerInstalled({ signal: controller.signal })).rejects.toThrow();
+    expect(calls).toEqual([15_000]);
   });
 
   it.each(["ready", "corrupt-runtime", "missing-runtime", "no-device", "cancelled"] as const)(

--- a/extensions/llama-cpp/src/llama-server-install.ts
+++ b/extensions/llama-cpp/src/llama-server-install.ts
@@ -28,11 +28,10 @@ export {
 
 const DOWNLOAD_TIMEOUT_MS = 30 * 60_000;
 const VERSION_TIMEOUT_MS = 15_000;
-// macOS 26 blocks the first exec of a freshly downloaded unsigned binary for
-// ~35-40s while syspolicyd evaluates it (see #138672). The evaluation is
-// cached per binary hash, so retrying the same command with a wider budget
-// succeeds; the steady-state timeout stays fast for genuinely broken systems.
-const VERSION_RETRY_TIMEOUT_MS = 120_000;
+// Freshly extracted macOS binaries can spend tens of seconds in Gatekeeper
+// evaluation. Keep this wider budget at the pre-publication version check;
+// reused, post-publication, and CUDA probes retain the fast default.
+const FRESH_VERSION_TIMEOUT_MS = 120_000;
 
 export type LlamaDownloadProgress = (status: {
   downloadedSize: number;
@@ -241,40 +240,26 @@ export async function downloadVerifiedFile(params: {
   }
 }
 
-function isExecTimeoutError(error: unknown): boolean {
-  // SAFETY: runServerCommand wraps execFile failures with the original error as cause; only timeout kills set killed+SIGTERM.
-  const cause = (error as { cause?: { killed?: boolean; signal?: string } }).cause;
-  return cause?.killed === true && cause?.signal === "SIGTERM";
-}
-
 async function runServerCommand(
   command: string,
   args: string[],
   signal?: AbortSignal,
+  timeoutMs = VERSION_TIMEOUT_MS,
 ): Promise<string> {
-  const attempt = (timeoutMs: number) =>
-    new Promise<string>((resolve, reject) => {
-      execFile(
-        command,
-        args,
-        { timeout: timeoutMs, signal, windowsHide: true },
-        (error, stdout, stderr) => {
-          if (error) {
-            reject(new Error(error.message, { cause: error }));
-          } else {
-            resolve(`${stdout}${stderr}`.trim());
-          }
-        },
-      );
-    });
-  try {
-    return await attempt(VERSION_TIMEOUT_MS);
-  } catch (error) {
-    if (!isExecTimeoutError(error) || signal?.aborted) {
-      throw error;
-    }
-    return await attempt(VERSION_RETRY_TIMEOUT_MS);
-  }
+  return await new Promise((resolve, reject) => {
+    execFile(
+      command,
+      args,
+      { timeout: timeoutMs, signal, windowsHide: true },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(error.message, { cause: error }));
+        } else {
+          resolve(`${stdout}${stderr}`.trim());
+        }
+      },
+    );
+  });
 }
 
 function formatRuntimeDependencyError(error: unknown): Error {
@@ -298,10 +283,11 @@ async function validateInstalledServer(
   command: string,
   asset: LlamaServerAsset,
   signal?: AbortSignal,
+  versionTimeoutMs = VERSION_TIMEOUT_MS,
 ): Promise<void> {
   let version: string;
   try {
-    version = await runServerCommand(command, ["--version"], signal);
+    version = await runServerCommand(command, ["--version"], signal, versionTimeoutMs);
   } catch (error) {
     signal?.throwIfAborted();
     throw formatRuntimeDependencyError(error);
@@ -396,7 +382,12 @@ async function installLlamaServer(
     }
     options.signal?.throwIfAborted();
     await fsp.chmod(extractedCommand, 0o755);
-    await validateInstalledServer(extractedCommand, asset, options.signal);
+    await validateInstalledServer(
+      extractedCommand,
+      asset,
+      options.signal,
+      FRESH_VERSION_TIMEOUT_MS,
+    );
     await fsp.mkdir(path.dirname(installDir), { recursive: true });
     options.signal?.throwIfAborted();
     await fsp.rm(installDir, { recursive: true, force: true });

--- a/extensions/llama-cpp/src/llama-server-install.ts
+++ b/extensions/llama-cpp/src/llama-server-install.ts
@@ -28,6 +28,11 @@ export {
 
 const DOWNLOAD_TIMEOUT_MS = 30 * 60_000;
 const VERSION_TIMEOUT_MS = 15_000;
+// macOS 26 blocks the first exec of a freshly downloaded unsigned binary for
+// ~35-40s while syspolicyd evaluates it (see #138672). The evaluation is
+// cached per binary hash, so retrying the same command with a wider budget
+// succeeds; the steady-state timeout stays fast for genuinely broken systems.
+const VERSION_RETRY_TIMEOUT_MS = 120_000;
 
 export type LlamaDownloadProgress = (status: {
   downloadedSize: number;
@@ -236,25 +241,40 @@ export async function downloadVerifiedFile(params: {
   }
 }
 
+function isExecTimeoutError(error: unknown): boolean {
+  // SAFETY: runServerCommand wraps execFile failures with the original error as cause; only timeout kills set killed+SIGTERM.
+  const cause = (error as { cause?: { killed?: boolean; signal?: string } }).cause;
+  return cause?.killed === true && cause?.signal === "SIGTERM";
+}
+
 async function runServerCommand(
   command: string,
   args: string[],
   signal?: AbortSignal,
 ): Promise<string> {
-  return await new Promise((resolve, reject) => {
-    execFile(
-      command,
-      args,
-      { timeout: VERSION_TIMEOUT_MS, signal, windowsHide: true },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(error.message, { cause: error }));
-        } else {
-          resolve(`${stdout}${stderr}`.trim());
-        }
-      },
-    );
-  });
+  const attempt = (timeoutMs: number) =>
+    new Promise<string>((resolve, reject) => {
+      execFile(
+        command,
+        args,
+        { timeout: timeoutMs, signal, windowsHide: true },
+        (error, stdout, stderr) => {
+          if (error) {
+            reject(new Error(error.message, { cause: error }));
+          } else {
+            resolve(`${stdout}${stderr}`.trim());
+          }
+        },
+      );
+    });
+  try {
+    return await attempt(VERSION_TIMEOUT_MS);
+  } catch (error) {
+    if (!isExecTimeoutError(error) || signal?.aborted) {
+      throw error;
+    }
+    return await attempt(VERSION_RETRY_TIMEOUT_MS);
+  }
 }
 
 function formatRuntimeDependencyError(error: unknown): Error {


### PR DESCRIPTION
Closes #138672

## Summary

- allow one freshly extracted, unpublished `llama-server --version` probe up to 120 seconds so macOS 26 can finish Gatekeeper evaluation
- keep reused and post-publication `--version` probes, plus CUDA `--list-devices`, at the existing 15-second timeout
- keep the command runner to one cancellable `execFile` call; remove the retry and timeout-error classifier
- cover fresh CPU ZIP publication/reuse, abort cleanup, and CUDA timeout routing

## Root cause and owner

The managed llama.cpp installer validated a newly extracted binary with the same 15-second budget used for steady-state checks. On macOS 26, first execution can remain blocked while the OS evaluates that new binary, so setup removed the unpublished extraction before validation could complete. The installer owns this boundary: only its pre-publication version check receives the cold-start budget.

## Verification

- focused installer, extractor, managed-server, and setup tests: 105 passed
- post-fix installer regression suite: 24 passed
- `scripts/check-changed.mjs` for both changed files: passed
- formatting, diff check, production/test typechecks, extension lint, boundary/dead-export/import-cycle checks: passed

Native macOS 26.6.2 ARM64 proof used an isolated state and model cache with the pinned server and default managed embedding model:

```json
{
  "freshManagedPrepareMs": 22510,
  "startupMs": 272,
  "healthStatus": 200,
  "embeddingStatus": 200,
  "embeddingDimensions": 768,
  "embeddingMs": 7796,
  "publishedVersionMs": 7199,
  "publishedVersionBudgetMs": 15000,
  "reuseValidationMs": 44,
  "reuseValidationBudgetMs": 15000,
  "freshValidationBudgetMs": 120000,
  "versionMatched": true,
  "samePublishedCommand": true,
  "childExitCode": 0
}
```

The spawned server exited cleanly and the task-owned state/cache was removed after the proof.

## Credit

Original diagnosis, reproduction, and implementation by @waterundman. Maintainer refinement narrows the longer timeout to the fresh extraction boundary and preserves the contributor commit in this PR.

---

This contribution was prepared with AI assistance (WorkBuddy agent, user-driven), disclosed per the repository's contribution guidance.
