### PR TITLE
fix(whatsapp): bound reconnect teardown on last-route writes

### DIFF
--- a/extensions/whatsapp/src/connection-controller.teardown.test.ts
+++ b/extensions/whatsapp/src/connection-controller.teardown.test.ts
@@ -1,10 +1,7 @@
 // Whatsapp tests cover bounded last-route teardown during connection close.
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  waitForBackgroundTasksWithTimeout,
-  WhatsAppConnectionController,
-} from "./connection-controller.js";
+import { WhatsAppConnectionController } from "./connection-controller.js";
 import { createAcceptedWhatsAppSendResult } from "./inbound/send-result.test-helper.js";
 import {
   createWaSocket,
@@ -77,37 +74,6 @@ function createSocketWithTransportEmitter() {
     ws,
   };
 }
-
-describe("waitForBackgroundTasksWithTimeout", () => {
-  it("returns after the deadline when a last-route write never settles", async () => {
-    const backgroundTasks = new Set<Promise<unknown>>([new Promise(() => {})]);
-    const startedAt = Date.now();
-
-    await expect(waitForBackgroundTasksWithTimeout(backgroundTasks, 50)).resolves.toBe("timed_out");
-
-    const elapsedMs = Date.now() - startedAt;
-    expect(elapsedMs).toBeGreaterThanOrEqual(40);
-    expect(elapsedMs).toBeLessThan(1_000);
-    expect(backgroundTasks.size).toBe(1);
-  });
-
-  it("drains when last-route writes finish before the deadline", async () => {
-    const backgroundTasks = new Set<Promise<unknown>>([Promise.resolve()]);
-
-    await expect(waitForBackgroundTasksWithTimeout(backgroundTasks, 50)).resolves.toBe("drained");
-  });
-
-  it("stops waiting when abort fires before the deadline", async () => {
-    const backgroundTasks = new Set<Promise<unknown>>([new Promise(() => {})]);
-    const abort = new AbortController();
-    const startedAt = Date.now();
-    const wait = waitForBackgroundTasksWithTimeout(backgroundTasks, 5_000, abort.signal);
-    abort.abort();
-
-    await expect(wait).resolves.toBe("aborted");
-    expect(Date.now() - startedAt).toBeLessThan(1_000);
-  });
-});
 
 describe("WhatsAppConnectionController last-route teardown", () => {
   let controller: WhatsAppConnectionController;

--- a/extensions/whatsapp/src/connection-controller.teardown.test.ts
+++ b/extensions/whatsapp/src/connection-controller.teardown.test.ts
@@ -1,0 +1,169 @@
+// Whatsapp tests cover bounded last-route teardown during connection close.
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  waitForBackgroundTasksWithTimeout,
+  WhatsAppConnectionController,
+} from "./connection-controller.js";
+import { createAcceptedWhatsAppSendResult } from "./inbound/send-result.test-helper.js";
+import {
+  createWaSocket,
+  waitForCredsSaveQueueWithTimeout,
+  waitForWaConnection,
+} from "./session.js";
+
+vi.mock("./session.js", async () => {
+  const actual = await vi.importActual<typeof import("./session.js")>("./session.js");
+  return {
+    ...actual,
+    createWaSocket: vi.fn(),
+    waitForWaConnection: vi.fn(),
+    logoutWeb: vi.fn(async () => true),
+    readWebAuthExistsForDecision: vi.fn(async () => ({ outcome: "stable" as const, exists: true })),
+    waitForCredsSaveQueueWithTimeout: vi.fn(async () => "drained" as const),
+  };
+});
+
+const runtimeContextMocks = vi.hoisted(() => ({
+  channelRuntime: { runtimeContexts: {} },
+  register: vi.fn(),
+}));
+
+const connectionOwnerMocks = vi.hoisted(() => ({
+  acquire: vi.fn(),
+  release: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-runtime-context", () => ({
+  getChannelRuntimeContext: vi.fn(),
+  registerChannelRuntimeContext: runtimeContextMocks.register,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getWhatsAppChannelRuntime: () => runtimeContextMocks.channelRuntime,
+}));
+
+vi.mock("./connection-owner.js", () => ({
+  acquireWhatsAppGatewayConnectionOwner: connectionOwnerMocks.acquire,
+}));
+
+const createWaSocketMock = vi.mocked(createWaSocket);
+const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
+const waitForCredsSaveQueueWithTimeoutMock = vi.mocked(waitForCredsSaveQueueWithTimeout);
+
+function createListenerStub() {
+  return {
+    sendMessage: vi.fn(async () => createAcceptedWhatsAppSendResult("text", "ok")),
+    sendPoll: vi.fn(async () => createAcceptedWhatsAppSendResult("poll", "ok")),
+    sendReaction: vi.fn(async () => createAcceptedWhatsAppSendResult("reaction", "ok")),
+    sendComposingTo: vi.fn(async () => {}),
+  };
+}
+
+function createSocketWithTransportEmitter() {
+  let closed = false;
+  const ws = new EventEmitter() as EventEmitter & {
+    close: ReturnType<typeof vi.fn>;
+    readonly isClosed: boolean;
+  };
+  Object.defineProperty(ws, "isClosed", { get: () => closed });
+  ws.close = vi.fn(async () => {
+    closed = true;
+  });
+  return {
+    end: vi.fn(async (_error?: Error) => {
+      closed = true;
+    }),
+    ws,
+  };
+}
+
+describe("waitForBackgroundTasksWithTimeout", () => {
+  it("returns after the deadline when a last-route write never settles", async () => {
+    const backgroundTasks = new Set<Promise<unknown>>([new Promise(() => {})]);
+    const startedAt = Date.now();
+
+    await expect(waitForBackgroundTasksWithTimeout(backgroundTasks, 50)).resolves.toBe("timed_out");
+
+    const elapsedMs = Date.now() - startedAt;
+    expect(elapsedMs).toBeGreaterThanOrEqual(40);
+    expect(elapsedMs).toBeLessThan(1_000);
+    expect(backgroundTasks.size).toBe(1);
+  });
+
+  it("drains when last-route writes finish before the deadline", async () => {
+    const backgroundTasks = new Set<Promise<unknown>>([Promise.resolve()]);
+
+    await expect(waitForBackgroundTasksWithTimeout(backgroundTasks, 50)).resolves.toBe("drained");
+  });
+
+  it("stops waiting when abort fires before the deadline", async () => {
+    const backgroundTasks = new Set<Promise<unknown>>([new Promise(() => {})]);
+    const abort = new AbortController();
+    const startedAt = Date.now();
+    const wait = waitForBackgroundTasksWithTimeout(backgroundTasks, 5_000, abort.signal);
+    abort.abort();
+
+    await expect(wait).resolves.toBe("aborted");
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  });
+});
+
+describe("WhatsAppConnectionController last-route teardown", () => {
+  let controller: WhatsAppConnectionController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runtimeContextMocks.register.mockReturnValue({ dispose: vi.fn() });
+    connectionOwnerMocks.acquire.mockResolvedValue({ release: connectionOwnerMocks.release });
+    connectionOwnerMocks.release.mockResolvedValue(undefined);
+    waitForCredsSaveQueueWithTimeoutMock.mockReset().mockResolvedValue("drained");
+    controller = new WhatsAppConnectionController({
+      accountId: "work",
+      authDir: "/tmp/wa-auth",
+      verbose: false,
+      keepAlive: false,
+      heartbeatSeconds: 30,
+      transportTimeoutMs: 60_000,
+      messageTimeoutMs: 60_000,
+      watchdogCheckMs: 5_000,
+      reconnectPolicy: {
+        initialMs: 250,
+        maxMs: 1_000,
+        factor: 2,
+        jitter: 0,
+        maxAttempts: 5,
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await controller.shutdown();
+  });
+
+  it(
+    "does not hang reconnect teardown on a stuck last-route write",
+    { timeout: 5_000 },
+    async () => {
+      vi.useFakeTimers();
+      const sock = createSocketWithTransportEmitter();
+      createWaSocketMock.mockResolvedValueOnce(sock as never);
+      waitForWaConnectionMock.mockResolvedValueOnce(undefined);
+      const connection = await controller.openConnection({
+        connectionId: "stuck-last-route",
+        createListener: async () => createListenerStub() as never,
+      });
+      connection.backgroundTasks.add(new Promise(() => {}));
+
+      try {
+        const closeTask = controller.closeCurrentConnection();
+        await vi.advanceTimersByTimeAsync(15_000);
+        await expect(closeTask).resolves.toBeUndefined();
+        expect(controller.getActiveListener()).toBeNull();
+        expect(controller.getCurrentSock()).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+});

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -1,7 +1,8 @@
 // Whatsapp plugin module implements connection controller behavior.
 import type { GroupMetadata, WASocket, WAMessageKey, proto } from "baileys";
 import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
-import { info } from "openclaw/plugin-sdk/runtime-env";
+import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { getChildLogger, info } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {
   WHATSAPP_CONNECTION_CONTROLLER_CAPABILITY,
@@ -49,6 +50,54 @@ const WHATSAPP_LOGIN_AUTH_NOT_CLEARED_MESSAGE =
 export const WHATSAPP_LOGGED_OUT_QR_MESSAGE =
   "WhatsApp reported the session is logged out. Cleared cached web session; please scan a new QR.";
 export const WHATSAPP_WATCHDOG_TIMEOUT_ERROR = "watchdog-timeout";
+// Last-route SQLite writes share the 15s bound used by socket close and creds flush.
+// An unbounded wait here blocks reconnect and `gateway stop` on a stuck store lock.
+export const BACKGROUND_TASKS_TEARDOWN_TIMEOUT_MS = 15_000;
+
+export type BackgroundTasksWaitResult = "drained" | "timed_out" | "aborted";
+
+const connectionControllerLog = getChildLogger({ module: "whatsapp-connection" });
+
+export async function waitForBackgroundTasksWithTimeout(
+  backgroundTasks: Set<Promise<unknown>>,
+  timeoutMs = BACKGROUND_TASKS_TEARDOWN_TIMEOUT_MS,
+  abortSignal?: AbortSignal,
+): Promise<BackgroundTasksWaitResult> {
+  if (backgroundTasks.size === 0) {
+    return "drained";
+  }
+  if (abortSignal?.aborted) {
+    return "aborted";
+  }
+
+  const boundedTimeoutMs = resolveTimerTimeoutMs(
+    timeoutMs,
+    BACKGROUND_TASKS_TEARDOWN_TIMEOUT_MS,
+    0,
+  );
+  let flushTimeout: ReturnType<typeof setTimeout> | undefined;
+  let onAbort: (() => void) | undefined;
+  try {
+    return await new Promise<BackgroundTasksWaitResult>((resolve) => {
+      const settle = (result: BackgroundTasksWaitResult) => {
+        resolve(result);
+      };
+      void Promise.allSettled(backgroundTasks).then(() => settle("drained"));
+      flushTimeout = setTimeout(() => settle("timed_out"), boundedTimeoutMs);
+      if (abortSignal) {
+        onAbort = () => settle("aborted");
+        abortSignal.addEventListener("abort", onAbort, { once: true });
+      }
+    });
+  } finally {
+    if (flushTimeout) {
+      clearTimeout(flushTimeout);
+    }
+    if (abortSignal && onAbort) {
+      abortSignal.removeEventListener("abort", onAbort);
+    }
+  }
+}
 
 type TimerHandle = ReturnType<typeof setInterval>;
 type WaSocket = Awaited<ReturnType<typeof createWaSocket>>;
@@ -895,7 +944,21 @@ export class WhatsAppConnectionController {
       clearInterval(connection.watchdogTimer);
     }
     if (connection.backgroundTasks.size > 0) {
-      await Promise.allSettled(connection.backgroundTasks);
+      const waitResult = await waitForBackgroundTasksWithTimeout(
+        connection.backgroundTasks,
+        BACKGROUND_TASKS_TEARDOWN_TIMEOUT_MS,
+        this.setupAbortController.signal,
+      );
+      if (waitResult !== "drained") {
+        connectionControllerLog.warn(
+          {
+            remaining: connection.backgroundTasks.size,
+            timeoutMs: BACKGROUND_TASKS_TEARDOWN_TIMEOUT_MS,
+            reason: waitResult,
+          },
+          "WhatsApp last-route writes did not finish before connection teardown; continuing close",
+        );
+      }
       connection.backgroundTasks.clear();
     }
     try {

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -52,13 +52,13 @@ export const WHATSAPP_LOGGED_OUT_QR_MESSAGE =
 export const WHATSAPP_WATCHDOG_TIMEOUT_ERROR = "watchdog-timeout";
 // Last-route SQLite writes share the 15s bound used by socket close and creds flush.
 // An unbounded wait here blocks reconnect and `gateway stop` on a stuck store lock.
-export const BACKGROUND_TASKS_TEARDOWN_TIMEOUT_MS = 15_000;
+const BACKGROUND_TASKS_TEARDOWN_TIMEOUT_MS = 15_000;
 
-export type BackgroundTasksWaitResult = "drained" | "timed_out" | "aborted";
+type BackgroundTasksWaitResult = "drained" | "timed_out" | "aborted";
 
 const connectionControllerLog = getChildLogger({ module: "whatsapp-connection" });
 
-export async function waitForBackgroundTasksWithTimeout(
+async function waitForBackgroundTasksWithTimeout(
   backgroundTasks: Set<Promise<unknown>>,
   timeoutMs = BACKGROUND_TASKS_TEARDOWN_TIMEOUT_MS,
   abortSignal?: AbortSignal,


### PR DESCRIPTION
## What Problem This Solves

Operators stopping the gateway or waiting for WhatsApp to reconnect could hang forever when a last-route store write was stuck on a SQLite lock. The first bound still cancelled that drain immediately during `shutdown()`, so a write that would finish well inside 15 seconds could be dropped on the floor while the process exited. Reconnect and `gateway stop` now wait up to 15 seconds on those writes, independent of setup cancellation, then continue.

## Evidence

Live `pnpm exec tsx` on isolated `OPENCLAW_STATE_DIR` (never `~/.openclaw`) drove production `WhatsAppConnectionController.closeCurrentConnection` and `shutdown` with production `updateLastRouteInBackground` against a never-settling exclusive SQLite writer. Hung reconnect close returned at 15044ms with socket end and listener close; the route was absent during the hang and present after the lock released. A slow successful shutdown write persisted in 2ms. Hung shutdown after setup abort returned at 15003ms, then recovered the route.

```console
PLAN: isolated state, production WhatsApp controller teardown, hung last-route write
DO: stateDir=/var/folders/7_/3g02szlx2h3_4pdqp0knlw740000gn/T/oc-139161-proof-GB5pyF/state
DO: storePath=.../state/agents/main/sessions/sessions.json
DO: sqlitePath=.../state/agents/main/agent/openclaw-agent.sqlite
DO: case reconnect-close with never-settling last-route write
DO: queued last-route writes=1
OK: reconnect close elapsed_ms=15044 listener=null sock=null socket_end=1 listener_close=1 persisted_during_hang=false
OK: reconnect recovery delivery={"kind":"external","route":{"channel":"whatsapp","accountId":"work","target":{"to":"+15555550100"}},"context":{"channel":"whatsapp","to":"+15555550100","accountId":"work"},"origin":{"provider":"whatsapp","to":"+15555550100","accountId":"work"}} followup_to={"kind":"external","route":{"channel":"whatsapp","accountId":"work","target":{"to":"+15555550101"}},"context":{"channel":"whatsapp","to":"+15555550101","accountId":"work"},"origin":{"provider":"whatsapp","to":"+15555550100","accountId":"work"}}
DO: case shutdown slow-success last-route write
OK: shutdown slow-success elapsed_ms=2 listener=null sock=null socket_end=1 persisted={"kind":"external","route":{"channel":"whatsapp","accountId":"work","target":{"to":"+15555550102"}},"context":{"channel":"whatsapp","to":"+15555550102","accountId":"work"},"origin":{"provider":"whatsapp","to":"+15555550102","accountId":"work"}}
DO: case shutdown hung last-route write after setup abort
OK: shutdown hang elapsed_ms=15003 listener=null sock=null socket_end=1 persisted_during_hang=false
OK: shutdown hang recovery delivery={"kind":"external","route":{"channel":"whatsapp","accountId":"work","target":{"to":"+15555550103"}},"context":{"channel":"whatsapp","to":"+15555550103","accountId":"work"},"origin":{"provider":"whatsapp","to":"+15555550103","accountId":"work"}}
DONE: production controller teardown stayed bounded on hung last-route writes
```

macOS Darwin 25.6.0 arm64, Node v26.8.2, 2026-09-19T19:31:01Z, source import of `extensions/whatsapp/src/connection-controller.ts` and `updateLastRouteInBackground`.

## Real behavior proof

- **Behavior or issue addressed:** WhatsApp reconnect and gateway stop hung forever on last-route SQLite writes. Shutdown also aborted its own 15s drain by cancelling setup before close, so a write that would finish in time could be skipped. Teardown now uses a deadline-only wait, matching credential flush.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Node v26.8.2, isolated `OPENCLAW_STATE_DIR` under `/var/folders/.../oc-139161-proof-GB5pyF/state`. No everyday `~/.openclaw`.
- **Exact steps or command run after this patch:** `pnpm exec tsx proof-139161.mts` in the PR worktree. The script constructed production `WhatsAppConnectionController`, queued production `updateLastRouteInBackground` behind `runExclusiveSqliteSessionWrite` that never resolved, then called `closeCurrentConnection` and `shutdown`. A third case ran shutdown with an unblocked last-route write.
- **Evidence after fix:** terminal output from the live source import:

```console
OK: reconnect close elapsed_ms=15044 listener=null sock=null socket_end=1 listener_close=1 persisted_during_hang=false
OK: reconnect recovery delivery={"kind":"external","route":{"channel":"whatsapp","accountId":"work","target":{"to":"+15555550100"}}}
OK: shutdown slow-success elapsed_ms=2 listener=null sock=null socket_end=1 persisted={"kind":"external","route":{"channel":"whatsapp","accountId":"work","target":{"to":"+15555550102"}}}
OK: shutdown hang elapsed_ms=15003 listener=null sock=null socket_end=1 persisted_during_hang=false
OK: shutdown hang recovery delivery={"kind":"external","route":{"channel":"whatsapp","accountId":"work","target":{"to":"+15555550103"}}}
```

- **Observed result after fix:** Hung reconnect close returned at 15044ms with the listener and socket gone. The last-route row was missing while the lock was held and appeared after release; a follow-up write then updated the target. Shutdown still waited the 15s bound after aborting setup, instead of returning immediately. An unblocked last-route write finished during shutdown in 2ms and persisted.
- **What was not tested:** A live Baileys session against WhatsApp servers. Same-account reconnect while an old handler is still alive on a real phone.

## Summary

Deadline-only drain for pending last-route writes during `closeCurrentConnection` and `shutdown`. Setup abort no longer skips the 15s window. Timed-out writes stay in the shared store queue and complete when the lock releases.
