### PR TITLE
improve: reuse snapshotted web search result rows

### DIFF
--- a/src/agents/tools/web-search-output.ts
+++ b/src/agents/tools/web-search-output.ts
@@ -278,9 +278,7 @@ export function normalizeWebSearchOutput(params: {
 
   // A results branch requires conforming rows; anything else is preserved as
   // raw so nonstandard external payloads are never silently gutted.
-  // Array.from densifies holes into undefined so sparse arrays cannot slip
-  // past row conformance and serialize as null rows.
-  const rows = Array.isArray(result.results) ? Array.from(result.results) : undefined;
+  const rows = Array.isArray(result.results) ? result.results : undefined;
   const conformingRows = rows?.every(
     (entry): entry is Record<string, unknown> =>
       isRecord(entry) &&


### PR DESCRIPTION
## What Problem This Solves

Every web-search result list was copied a second time during normalization, including large provider payloads that would ultimately be reduced to ten results or returned through the raw-output branch.

## Why This Change Was Made

The normalizer now reuses the result array in its existing JSON snapshot. That snapshot already isolates provider data and converts sparse holes to explicit nulls, so the extra `Array.from` and its obsolete comment are unnecessary. All rows are still validated before result truncation; error precedence, untrusted-content wrapping, and output budgets remain unchanged.

## User Impact

Web-search output remains identical while avoiding one full result-array allocation per call. Production is 2 lines smaller; tests are unchanged. The benefit is modest for ordinary result counts and more visible for large payloads.

## Evidence

- Nine actual-owner before/after cases matched after normalizing only random envelope IDs: dense and sparse arrays, malformed tail rows, error precedence, getters, circular input, and bigint input.
- 79 tests across web-search output/security/cancellation suites passed before and after. Formatting and diff checks passed; managed P0–P2 review was scoped-clean with no findings.
- Owner-attributed `Array.from` samples dropped from about 2.4 MB to zero across 30 calls with 10,000 rows. For five-row results the saved sample was about 33 KB across 500 calls; total allocation noise exceeded that saving.
- Timings were mixed, so this change makes no general latency, retained-heap, RSS, or whole-Gateway memory claim. No provider API or request behavior changed; this packet's proof is local owner execution, not a separate live-provider run. Current-head CI is recorded separately by the publisher.
