### PR TITLE
improve: scan preserved cron output once

### DIFF
--- a/src/cron/command-output-summary.test.ts
+++ b/src/cron/command-output-summary.test.ts
@@ -17,6 +17,49 @@ describe("cron command output summaries", () => {
     );
   });
 
+  it.each(["\n", "\r\n"])("matches complete trimmed action lines with %j separators", (newline) => {
+    const action = "Visit https://example.com/device";
+    const stdout = `before${newline}  ${action}  ${newline}after`;
+    expect(
+      buildCronCommandSummary({
+        stdout,
+        stderr: "",
+        preservedStdoutLines: [` ${action} `, "Copy this code ABCD-EFGH"],
+      }),
+    ).toBe(`action-required output preserved:\nCopy this code ABCD-EFGH\n\n${stdout}`);
+  });
+
+  it("retains missing actions in stream order, including duplicates across streams", () => {
+    const action = "Visit https://example.com/device";
+    const stdout = `prefix ${action} suffix`;
+    expect(
+      buildCronCommandSummary({
+        stdout,
+        stderr: "warning",
+        preservedStdoutLines: [` ${action} `, action, "Copy this code ABCD-EFGH"],
+        preservedStderrLines: [action],
+      }),
+    ).toBe(
+      `action-required output preserved:\n${action}\nCopy this code ABCD-EFGH\n${action}\n\nstdout:\n${stdout}\n\nstderr:\nwarning`,
+    );
+  });
+
+  it("keeps independent preservation quotas before checking the captured tail", () => {
+    const stdoutLines = Array.from(
+      { length: 12 },
+      (_, index) => `Visit https://example.com/${index}`,
+    );
+    const stderrLine = "Copy this code ABCD-EFGH";
+    expect(
+      buildCronCommandSummary({
+        stdout: stdoutLines.join("\n"),
+        stderr: "",
+        preservedStdoutLines: [...stdoutLines, "Visit https://example.com/outside-quota"],
+        preservedStderrLines: [stderrLine],
+      }),
+    ).toBe(`action-required output preserved:\n${stderrLine}\n\n${stdoutLines.join("\n")}`);
+  });
+
   it("redacts action-required URLs and codes before external cron delivery", () => {
     const summary =
       "action-required output preserved:\nVisit https://example.com/device or www.example.com/device and enter code ABCD-EFGH\n\ncompleted";

--- a/src/cron/command-output-summary.ts
+++ b/src/cron/command-output-summary.ts
@@ -38,41 +38,36 @@ function normalizeLines(lines: string[] | undefined): string[] {
   return result;
 }
 
-function trimOutput(value: string): string | undefined {
-  return normalizeOptionalString(value);
-}
-
-function combineOutput(params: { stdout?: string; stderr?: string }): string | undefined {
-  const stdout = trimOutput(params.stdout ?? "");
-  const stderr = trimOutput(params.stderr ?? "");
-  if (stdout && stderr) {
-    return `stdout:\n${stdout}\n\nstderr:\n${stderr}`;
-  }
-  return stdout ?? stderr;
-}
-
-function containsLine(haystack: string | undefined, needle: string): boolean {
-  if (!haystack) {
-    return false;
-  }
-  return haystack.split(/\r?\n/).some((line) => line.trim() === needle.trim());
-}
-
 export function buildCronCommandSummary(params: {
   stdout: string;
   stderr: string;
   preservedStdoutLines?: string[];
   preservedStderrLines?: string[];
 }): string | undefined {
-  const tail = combineOutput({ stdout: params.stdout, stderr: params.stderr });
+  const stdout = normalizeOptionalString(params.stdout);
+  const stderr = normalizeOptionalString(params.stderr);
+  const tail = stdout && stderr ? `stdout:\n${stdout}\n\nstderr:\n${stderr}` : (stdout ?? stderr);
   const preserved = [
     ...normalizeLines(params.preservedStdoutLines),
     ...normalizeLines(params.preservedStderrLines),
-  ].filter((line) => !containsLine(tail, line));
+  ];
   if (preserved.length === 0) {
     return tail;
   }
-  const actionBlock = `action-required output preserved:\n${preserved.join("\n")}`;
+  const missing = new Set(preserved);
+  for (const line of tail?.split(/\r?\n/) ?? []) {
+    const normalized = line.trim();
+    // Check the short action list first so unrelated long lines never need hashing.
+    if (preserved.includes(normalized)) {
+      missing.delete(normalized);
+      if (missing.size === 0) {
+        return tail;
+      }
+    }
+  }
+  // Retain stream order and repeated actions from different output streams.
+  const actionLines = preserved.filter((line) => missing.has(line));
+  const actionBlock = `action-required output preserved:\n${actionLines.join("\n")}`;
   return tail ? `${actionBlock}\n\n${tail}` : actionBlock;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Cron commands with large captured output repeatedly rescanned that output for every preserved action line. With two full default output streams and 24 missing actions, building one summary split the same 32 MiB tail 24 times.

## Why This Change Was Made

The summary owner now scans the combined tail once, tracks only missing preserved actions, and returns early when all are found. The original short action list avoids hashing unrelated long lines; final filtering preserves stdout/stderr order and cross-stream duplicates. Redundant trim/combine/contains helpers are removed.

## User Impact

Large cron command summaries require less temporary work while retaining the same output, action-line quotas, complete-line matching, and external redaction. Production is 5 lines smaller; focused characterization tests add 43 lines.

## Evidence

- 18 summary and command-runner tests passed, including real child-process capture, truncated early actions, redaction, LF/CRLF, complete-line matching, duplicate actions, and independent stream quotas.
- Actual-owner output digests matched baseline. A 32 MiB/24-missing-action fixture reduced split calls from 24 to 1 and split-array entries from 6,291,528 to 262,147.
- Interleaved ABBA medians were 222.89 → 12.85 ms for that fixture; one missing action was 11.53 → 10.50 ms and one early present action was 7.21 → 7.44 ms. Small-case variation is retained rather than presented as a universal speedup.
- Formatting and diff checks passed; managed P0–P2 review was scoped-clean. These are synthetic owner/child-process proofs, not a live scheduled notification or whole-Gateway RSS result. Current-head CI is recorded separately by the publisher.
