### PR TITLE
fix(agents): keep fresh tool results readable under context pressure

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1822,7 +1822,7 @@ src/agents/embedded-agent-runner/thinking.ts	25
 src/agents/embedded-agent-runner/tool-call-argument-decoding.ts	5
 src/agents/embedded-agent-runner/tool-result-char-estimator.ts	9
 src/agents/embedded-agent-runner/tool-result-context-guard.ts	13
-src/agents/embedded-agent-runner/tool-result-truncation.ts	20
+src/agents/embedded-agent-runner/tool-result-truncation.ts	19
 src/agents/embedded-agent-runner/tool-schema-runtime.ts	1
 src/agents/embedded-agent-runner/transcript-rewrite.ts	2
 src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts	2

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
@@ -757,9 +757,9 @@ describe("submitEmbeddedAttemptPrompt", () => {
         isError: false,
         timestamp: 3,
       },
-      // Real dispatch pins a non-tool carrier after tool results, so the fresh
-      // batch is not trailing-protected and aggregate recovery can engage.
-      { role: "user", content: "continue", timestamp: 4 },
+      // Consumed results remain eligible when history is projected for the first time.
+      { role: "assistant", content: [{ type: "text", text: "results processed" }], timestamp: 4 },
+      { role: "user", content: "continue", timestamp: 5 },
     ] as AgentMessage[];
     activeSession.agent.streamFn = (() => undefined as never) as StreamFn;
 

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -940,7 +940,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
 
     expect(first.aggregateTruncatedCount).toBe(0);
-    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(second.aggregateTruncatedCount).toBe(0);
     expect(
       second.messages.slice(0, history.length).map((message) => JSON.stringify(message)),
     ).toEqual(frozenBytes);
@@ -948,7 +948,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
       (message): message is ToolResultMessage =>
         message.role === "toolResult" && message.toolCallId === "current",
     );
-    expect(current && getToolResultTextLength(current)).toBeLessThan(6_000);
+    expect(current && getFirstToolResultText(current)).toBe("c".repeat(6_000));
   });
 
   it("shrinks #99495 frozen bytes monotonically only under a tighter hard cap", () => {
@@ -1017,7 +1017,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(totalChars).toBeLessThanOrEqual(32_100);
   });
 
-  it("recovers from a fresh tool result before frozen history through a runtime carrier", () => {
+  it("preserves fresh tool content through a runtime carrier under frozen pressure", () => {
     const projectionState = createPromptProjectionStateForTest();
     const history: AgentMessage[] = [];
     for (let index = 0; index < 50; index++) {
@@ -1077,15 +1077,13 @@ describe("truncateOversizedToolResultsInMessages", () => {
       0,
     );
     expect(historicalResults).toEqual(firstHistoricalResults);
-    const freshNotice = freshResult ? getFirstToolResultText(freshResult) : "";
-    expect(freshNotice).not.toBe("");
-    expect(freshNotice).toContain("truncated");
-    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(freshResult && getFirstToolResultText(freshResult)).toBe(freshOutput);
+    expect(second.aggregateTruncatedCount).toBe(0);
     expect(second.aggregatePressureEngaged).toBe(true);
-    expect(totalChars).toBeLessThanOrEqual(32_100);
+    expect(totalChars).toBeLessThanOrEqual(32_000 + freshOutput.length);
   });
 
-  it("recovers from multiple fresh tool results before frozen history and queued steering", () => {
+  it("preserves fresh tool content through queued steering under frozen pressure", () => {
     const projectionState = createPromptProjectionStateForTest();
     const history: AgentMessage[] = [];
     for (let index = 0; index < 50; index++) {
@@ -1132,13 +1130,10 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
 
     expect(second.messages.slice(0, history.length)).toEqual(first.messages);
-    for (const notice of freshResults.map(getFirstToolResultText)) {
-      expect(notice).not.toBe("");
-      expect(notice).toContain("truncated");
-    }
-    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(freshResults.map(getFirstToolResultText)).toEqual(freshOutputs);
+    expect(second.aggregateTruncatedCount).toBe(0);
     expect(second.aggregatePressureEngaged).toBe(true);
-    expect(totalChars).toBeLessThanOrEqual(32_200);
+    expect(totalChars).toBeLessThanOrEqual(32_000 + 234 + 4_000);
   });
 
   it("allows aggregate overflow rather than rewriting frozen history", () => {
@@ -1194,14 +1189,13 @@ describe("truncateOversizedToolResultsInMessages", () => {
         (message) => message.role === "toolResult" && message.toolCallId.startsWith("history_"),
       ),
     ).toEqual(first.messages.filter((message) => message.role === "toolResult"));
-    expect(freshText).not.toBe("");
-    expect(freshText).toContain("truncated");
-    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(freshText).toBe(freshOutput);
+    expect(second.aggregateTruncatedCount).toBe(0);
     expect(second.aggregatePressureEngaged).toBe(true);
     expect(totalChars).toBeGreaterThan(100);
   });
 
-  it("clears an oversized fresh result before rewriting saturated frozen history", () => {
+  it("bounds an oversized fresh result without clearing it under frozen pressure", () => {
     const projectionState = createPromptProjectionStateForTest();
     const runtimeContextMessage = buildRuntimeContextCustomMessage("runtime context refresh");
     if (!runtimeContextMessage) {
@@ -1244,9 +1238,10 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
     expect(freshResult?.role).toBe("toolResult");
     expect(second.messages.slice(0, history.length)).toEqual(first.messages);
-    expect(freshText).not.toBe("");
+    expect(freshText).toContain("z".repeat(2_000));
     expect(freshText).toContain("truncated");
-    expect(totalChars).toBeLessThanOrEqual(32_100);
+    expect(freshText.length).toBeLessThanOrEqual(8_000);
+    expect(totalChars).toBeLessThanOrEqual(32_000 + 8_000);
   });
 
   it("leaves fresh trailing batches intact when only they exceed the aggregate budget", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -1208,16 +1208,14 @@ function getTrailingToolResultEntryIds(branch: ToolResultBranchEntry[]): Set<str
   const ids = new Set<string>();
   for (let index = branch.length - 1; index >= 0; index--) {
     const entry = branch[index];
-    if (entry?.type !== "message" || !entry.message) {
-      if (ids.size === 0) {
-        continue;
-      }
+    // Only an assistant response consumes tool results. Runtime context and
+    // queued steering must not make the pending batch eligible for elision.
+    if (entry?.type === "message" && entry.message?.role === "assistant") {
       break;
     }
-    if ((entry.message as { role?: string }).role !== "toolResult") {
-      break;
+    if (entry?.type === "message" && entry.message?.role === "toolResult") {
+      ids.add(entry.id);
     }
-    ids.add(entry.id);
   }
   return ids;
 }


### PR DESCRIPTION
## What Problem This Solves

Under accumulated tool-output pressure, successful file reads became truncation notices. Narrower rereads could lose their content too, preventing task completion.

## Why This Change Was Made

Protect fresh tool results until the next assistant response consumes them, even when runtime context or queued input follows. Previously sent history stays byte-identical; per-result limits and overflow recovery remain.

## User Impact

The agent receives useful fresh file content without a configuration change.

## Evidence

A real Gateway chat with the shipped read tool reproduced a 3,864-character read and 135-character reread collapsing to 69-character notices. After repair, the complete result reached the request and an independent response completed the task without rereading. Frozen results stayed unchanged across 14 requests; a separate context-limit failure recovered through compaction. Four regressions failed before the fix; 179 focused tests, lint, and build passed.

Closes #139147. Thanks @GarySiu for the reproduction and report.
