### PR TITLE
improve: reuse validated attachment read handles

### DIFF
--- a/src/media-understanding/attachments.cache.test.ts
+++ b/src/media-understanding/attachments.cache.test.ts
@@ -96,50 +96,71 @@ describe("media understanding attachment cache", () => {
     expect(result.mime).toBe("image/png");
   });
 
-  it("bounds bytes consumed when a local file grows after stat", async () => {
-    await withTestDir({ prefix: "openclaw-media-cache-growth-" }, async (base) => {
-      const attachmentPath = path.join(base, "growing.png");
-      await fs.writeFile(attachmentPath, PNG_1X1);
-      const maxBytes = PNG_1X1.length;
-      const open = fs.open.bind(fs);
-      let consumed = 0;
-      let grew = false;
-      const growBeforeRead = async () => {
-        if (!grew) {
-          grew = true;
-          await fs.appendFile(attachmentPath, Buffer.alloc(4096));
-        }
-      };
-      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
-        const handle = await open(...args);
-        const read = handle.read.bind(handle);
-        vi.spyOn(handle, "read").mockImplementation(async (...readArgs) => {
-          await growBeforeRead();
-          const result = await read(...readArgs);
-          consumed += result.bytesRead;
-          return result;
+  it.each(["unchanged", "growing", "read-failure"] as const)(
+    "closes one bounded local read when the file is %s",
+    async (behavior) => {
+      await withTestDir({ prefix: "openclaw-media-cache-growth-" }, async (base) => {
+        const attachmentPath = path.join(base, "growing.png");
+        await fs.writeFile(attachmentPath, PNG_1X1);
+        const maxBytes = PNG_1X1.length;
+        const open = fs.open.bind(fs);
+        let consumed = 0;
+        let opens = 0;
+        let closes = 0;
+        let grew = false;
+        const readError = new Error("synthetic read failure");
+        const growBeforeRead = async () => {
+          if (behavior === "read-failure") {
+            throw readError;
+          }
+          if (behavior === "growing" && !grew) {
+            grew = true;
+            await fs.appendFile(attachmentPath, Buffer.alloc(4096));
+          }
+        };
+        vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+          const handle = await open(...args);
+          opens += 1;
+          const close = handle.close.bind(handle);
+          vi.spyOn(handle, "close").mockImplementation(async () => {
+            closes += 1;
+            await close();
+          });
+          const read = handle.read.bind(handle);
+          vi.spyOn(handle, "read").mockImplementation(async (...readArgs) => {
+            await growBeforeRead();
+            const result = await read(...readArgs);
+            consumed += result.bytesRead;
+            return result;
+          });
+          const readFile = handle.readFile.bind(handle);
+          vi.spyOn(handle, "readFile").mockImplementation(async (...readArgs) => {
+            await growBeforeRead();
+            const result = await readFile(...readArgs);
+            consumed += result.length;
+            return result;
+          });
+          return handle;
         });
-        const readFile = handle.readFile.bind(handle);
-        vi.spyOn(handle, "readFile").mockImplementation(async (...readArgs) => {
-          await growBeforeRead();
-          const result = await readFile(...readArgs);
-          consumed += result.length;
-          return result;
+        const cache = new MediaAttachmentCache([{ index: 0, path: attachmentPath }], {
+          localPathRoots: [base],
+          includeDefaultLocalPathRoots: false,
         });
-        return handle;
-      });
-      const cache = new MediaAttachmentCache([{ index: 0, path: attachmentPath }], {
-        localPathRoots: [base],
-        includeDefaultLocalPathRoots: false,
-      });
 
-      await expect(
-        cache.getBuffer({ attachmentIndex: 0, maxBytes, timeoutMs: 1000 }),
-      ).rejects.toMatchObject({ reason: "maxBytes" });
-      expect(consumed).toBeGreaterThan(0);
-      expect(consumed).toBeLessThanOrEqual(maxBytes + 1);
-    });
-  });
+        const result = cache.getBuffer({ attachmentIndex: 0, maxBytes, timeoutMs: 1000 });
+        if (behavior === "unchanged") {
+          await expect(result).resolves.toMatchObject({ buffer: PNG_1X1 });
+        } else if (behavior === "growing") {
+          await expect(result).rejects.toMatchObject({ reason: "maxBytes" });
+        } else {
+          await expect(result).rejects.toBe(readError);
+        }
+        expect(opens).toBe(1);
+        expect(closes).toBe(opens);
+        expect(consumed).toBe(behavior === "read-failure" ? 0 : maxBytes + Number(grew));
+      });
+    },
+  );
 
   it.each(["local", "staged"] as const)(
     "enforces a zero-byte path limit for %s files",

--- a/src/media-understanding/attachments.cache.ts
+++ b/src/media-understanding/attachments.cache.ts
@@ -16,7 +16,7 @@ import { resolveStateDir } from "../config/paths.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { isAbortError } from "../infra/abort-signal.js";
 import { readFileHandleBounded } from "../infra/fs-safe-advanced.js";
-import { FsSafeError, openLocalFileSafely } from "../infra/fs-safe.js";
+import { FsSafeError, openLocalFileSafely, type OpenResult } from "../infra/fs-safe.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import {
   readRemoteMediaBuffer,
@@ -46,11 +46,6 @@ type MediaBufferResult = {
 type MediaPathResult = {
   path: string;
   cleanup?: () => Promise<void> | void;
-};
-
-type LocalReadResult = {
-  buffer: Buffer;
-  filePath: string;
 };
 
 const REMOTE_MEDIA_FETCH_RETRY: MediaFetchRetryOptions = {
@@ -263,21 +258,57 @@ export class MediaAttachmentCache {
     entry: AttachmentCacheEntry,
     params: { attachmentIndex: number; maxBytes: number },
   ): Promise<MediaBufferResult | undefined> {
-    const size = await this.ensureLocalStat(entry);
-    if (!entry.resolvedPath) {
-      return undefined;
+    let opened = await this.prepareLocalFile(entry);
+    let buffer: Buffer;
+    try {
+      if (!entry.resolvedPath) {
+        return undefined;
+      }
+      if (entry.statSize !== undefined && entry.statSize > params.maxBytes) {
+        throw new MediaUnderstandingSkipError(
+          "maxBytes",
+          `Attachment ${params.attachmentIndex + 1} exceeds maxBytes ${params.maxBytes}`,
+        );
+      }
+      opened ??= await openLocalFileSafely({ filePath: entry.resolvedPath });
+      if (opened.stat.size > params.maxBytes) {
+        throw new MediaUnderstandingSkipError(
+          "maxBytes",
+          `Attachment ${params.attachmentIndex + 1} exceeds maxBytes ${params.maxBytes}`,
+        );
+      }
+      const canonicalRoots = await this.getCanonicalLocalPathRoots();
+      if (!isInboundPathAllowed({ filePath: opened.realPath, roots: canonicalRoots })) {
+        throw new MediaUnderstandingSkipError(
+          "blocked",
+          `Attachment ${params.attachmentIndex + 1} path is outside allowed roots.`,
+        );
+      }
+      buffer = await readFileHandleBounded(opened.handle, params.maxBytes);
+    } catch (err) {
+      if (err instanceof FsSafeError) {
+        if (err.code === "too-large") {
+          throw new MediaUnderstandingSkipError(
+            "maxBytes",
+            `Attachment ${params.attachmentIndex + 1} exceeds maxBytes ${params.maxBytes}`,
+          );
+        }
+        if (err.code === "not-file" || err.code === "not-found") {
+          throw new MediaUnderstandingSkipError(
+            "empty",
+            `Attachment ${params.attachmentIndex + 1} path is not a regular file.`,
+          );
+        }
+        throw new MediaUnderstandingSkipError(
+          "blocked",
+          `Attachment ${params.attachmentIndex + 1} path is outside allowed roots.`,
+        );
+      }
+      throw err;
+    } finally {
+      await opened?.handle.close().catch(() => {});
     }
-    if (size !== undefined && size > params.maxBytes) {
-      throw new MediaUnderstandingSkipError(
-        "maxBytes",
-        `Attachment ${params.attachmentIndex + 1} exceeds maxBytes ${params.maxBytes}`,
-      );
-    }
-    const { buffer, filePath } = await this.readLocalBuffer({
-      attachmentIndex: params.attachmentIndex,
-      filePath: entry.resolvedPath,
-      maxBytes: params.maxBytes,
-    });
+    const filePath = opened.realPath;
     entry.resolvedPath = filePath;
     const classification = await classifyAttachmentBytes({
       buffer,
@@ -335,7 +366,8 @@ export class MediaAttachmentCache {
     const entry = await this.ensureEntry(params.attachmentIndex);
     if (entry.resolvedPath) {
       try {
-        const size = await this.ensureLocalStat(entry);
+        await (await this.prepareLocalFile(entry))?.handle.close().catch(() => {});
+        const size = entry.statSize;
         if (entry.resolvedPath && size !== undefined && size > params.maxBytes) {
           throw new MediaUnderstandingSkipError(
             "maxBytes",
@@ -354,7 +386,8 @@ export class MediaAttachmentCache {
 
     if (await this.activateStoreAlias(entry)) {
       try {
-        const size = await this.ensureLocalStat(entry);
+        await (await this.prepareLocalFile(entry))?.handle.close().catch(() => {});
+        const size = entry.statSize;
         if (entry.resolvedPath) {
           if (size !== undefined && size > params.maxBytes) {
             throw new MediaUnderstandingSkipError(
@@ -466,7 +499,8 @@ export class MediaAttachmentCache {
     return path.resolve(rawPath);
   }
 
-  private async ensureLocalStat(entry: AttachmentCacheEntry): Promise<number | undefined> {
+  /** Transfers a newly validated handle to the caller; cached path metadata needs no open. */
+  private async prepareLocalFile(entry: AttachmentCacheEntry): Promise<OpenResult | undefined> {
     if (!entry.resolvedPath) {
       return undefined;
     }
@@ -486,17 +520,12 @@ export class MediaAttachmentCache {
       }
     }
     if (entry.statSize !== undefined) {
-      return entry.statSize;
+      return undefined;
     }
+    let opened: OpenResult | undefined;
     try {
-      const currentPath = entry.resolvedPath;
-      const opened = await openLocalFileSafely({ filePath: currentPath });
-      let canonicalRoots: readonly string[];
-      try {
-        canonicalRoots = await this.getCanonicalLocalPathRoots();
-      } finally {
-        await opened.handle.close().catch(() => {});
-      }
+      opened = await openLocalFileSafely({ filePath: entry.resolvedPath });
+      const canonicalRoots = await this.getCanonicalLocalPathRoots();
       if (!isInboundPathAllowed({ filePath: opened.realPath, roots: canonicalRoots })) {
         entry.resolvedPath = undefined;
         if (shouldLogVerbose()) {
@@ -511,8 +540,9 @@ export class MediaAttachmentCache {
       }
       entry.resolvedPath = opened.realPath;
       entry.statSize = opened.stat.size;
-      return opened.stat.size;
+      return opened;
     } catch (err) {
+      await opened?.handle.close().catch(() => {});
       if (err instanceof MediaUnderstandingSkipError) {
         throw err;
       }
@@ -561,53 +591,5 @@ export class MediaAttachmentCache {
         ),
       ))();
     return await this.canonicalLocalPathRoots;
-  }
-
-  private async readLocalBuffer(params: {
-    attachmentIndex: number;
-    filePath: string;
-    maxBytes: number;
-  }): Promise<LocalReadResult> {
-    let opened: Awaited<ReturnType<typeof openLocalFileSafely>> | undefined;
-    try {
-      opened = await openLocalFileSafely({ filePath: params.filePath });
-      if (opened.stat.size > params.maxBytes) {
-        throw new MediaUnderstandingSkipError(
-          "maxBytes",
-          `Attachment ${params.attachmentIndex + 1} exceeds maxBytes ${params.maxBytes}`,
-        );
-      }
-      const canonicalRoots = await this.getCanonicalLocalPathRoots();
-      if (!isInboundPathAllowed({ filePath: opened.realPath, roots: canonicalRoots })) {
-        throw new MediaUnderstandingSkipError(
-          "blocked",
-          `Attachment ${params.attachmentIndex + 1} path is outside allowed roots.`,
-        );
-      }
-      const buffer = await readFileHandleBounded(opened.handle, params.maxBytes);
-      return { buffer, filePath: opened.realPath };
-    } catch (err) {
-      if (err instanceof FsSafeError) {
-        if (err.code === "too-large") {
-          throw new MediaUnderstandingSkipError(
-            "maxBytes",
-            `Attachment ${params.attachmentIndex + 1} exceeds maxBytes ${params.maxBytes}`,
-          );
-        }
-        if (err.code === "not-file" || err.code === "not-found") {
-          throw new MediaUnderstandingSkipError(
-            "empty",
-            `Attachment ${params.attachmentIndex + 1} path is not a regular file.`,
-          );
-        }
-        throw new MediaUnderstandingSkipError(
-          "blocked",
-          `Attachment ${params.attachmentIndex + 1} path is outside allowed roots.`,
-        );
-      }
-      throw err;
-    } finally {
-      await opened?.handle.close().catch(() => {});
-    }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Reading a cold local media attachment opened and closed the same file twice: once to validate its path and metadata, then again to obtain the bytes needed by the provider.

## Why This Change Was Made

The attachment cache now transfers the already validated descriptor to its bounded reader, which closes it in `finally`. Path-only consumers close it immediately; a later request for bytes still reopens a previously cached path safely. The separate cold-validation and cached-read error mappings are preserved so URL and media-store fallback behavior stays unchanged.

## User Impact

A cold local attachment needs one open/close cycle instead of two. Local-root checks, file identity/symlink checks, actual-read byte limits, MIME classification, and temporary staging cleanup remain in place. Production is 18 lines smaller; tests add 21 net lines.

## Evidence

- Eighteen synthetic real-filesystem scenarios matched baseline results and consumed-byte totals, including root escape, symlink/directory/missing input, file growth, read/open failures, cached paths, alias recovery, and byte-limit enforcement.
- Across 600 cold reads, opens and closes fell from 1,200 each to 600 each. Median time per 200 reads was 98.927 → 60.566 ms on this Mac; this is a filesystem microbenchmark, not Gateway/provider latency proof.
- Three descriptor-lifetime cases failed against original production code and passed after the change. Focused validation passed 83 tests across five files; five Windows-only cases were skipped on macOS.
- The installed `@openclaw/fs-safe` 0.8.1 contract was inspected directly: safe open validates descriptor/path identity, and bounded read consumes at most `maxBytes + 1` without closing the caller-owned handle. Formatting/diff checks and managed P0–P2 review passed. Native Windows and current-head hosted CI are not asserted by this local packet.

## Latest review disposition

Both pre-merge dependency-verification requests (P1/P2) and the identical Rank-up move in the [latest review](https://github.com/openclaw/openclaw/pull/139168#issuecomment-5553269246) are complete. Independent maintainer-side inspection of the installed, pinned `@openclaw/fs-safe` 0.8.1 implementation confirmed the required ownership contract:

- `dist/root-impl.js:80–186` (`openVerifiedLocalFile`) validates the regular file, opened descriptor identity, current path identity, and resolved canonical path identity. Failed validation closes the handle; success transfers a still-open handle. `openLocalFileSafely` at lines 455–457 returns that verified result.
- `dist/bounded-read.js:39–46` (`readFileHandleBounded`) reads from the current offset, consumes at most `maxBytes + 1`, and leaves closure to its caller. The cache closes transferred or freshly reopened handles in `finally`, closes failed preparation, and closes path-only handles immediately.
- Source identity (SHA-256): `root-impl.js` = `1d2dd3ba081d5fea1f7b73250c6c29ad591bbc4e8fac88fb1ed5ab7a4985e619`; `bounded-read.js` = `73e939b611bb80f839ee49730119ee163e7884cb17b85e8d5eb4048ca08ece80`.

The existing 18 real-filesystem scenarios have identical before/after outcomes and consumed-byte totals, with every acquired descriptor closed. Focused validation passed 83 tests; five Windows-only cases remain unexecuted on macOS. [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/33974104409) passed on exact head `9de04ff5d6ab6912fb6ddecee12014a61b73f23c`. This supplies the dependency evidence unavailable to the automated reviewer; it requires no source change or relaxation of the safety contract.
