### PR TITLE
fix(slack): accept thread follow-ups before the first reply

### DIFF
--- a/docs/channels/slack/threads-and-sessions.md
+++ b/docs/channels/slack/threads-and-sessions.md
@@ -22,7 +22,7 @@ How Slack conversations map to OpenClaw sessions, and where replies land.
 - `channels.slack.thread.historyScope` default is `thread`; `thread.inheritParent` default is `false`.
 - `channels.slack.thread.initialHistoryLimit` controls how many existing thread messages are fetched when a new thread session starts (default `20`; set `0` to disable).
 - `channels.slack.implicitMentions.replyToBot` controls whether a reply to the bot's own message bypasses mention gating (default `true`).
-- `channels.slack.implicitMentions.threadParticipation` controls whether follow-ups in a thread where the bot has replied bypass mention gating (default `true`). Set it to `false` to require a new explicit mention in those follow-ups. `openclaw doctor --fix` migrates the former `channels.slack.thread.requireExplicitMention` key to this positive canonical flag.
+- `channels.slack.implicitMentions.threadParticipation` controls whether follow-ups in a thread where the bot has replied, or is still processing an accepted human request, bypass mention gating (default `true`). Active work allows same-thread follow-ups before the first reply; if it ends without a reply, that temporary participation ends too. Bot messages and control commands do not establish this temporary participation. Set it to `false` to require a new explicit mention in those follow-ups. `openclaw doctor --fix` migrates the former `channels.slack.thread.requireExplicitMention` key to this positive canonical flag.
 - Account overrides live at `channels.slack.accounts.<id>.implicitMentions`; shared defaults live at `channels.defaults.implicitMentions`.
 
 Reply threading controls:

--- a/extensions/slack/src/monitor/message-handler.inflight-pipeline.test-helpers.ts
+++ b/extensions/slack/src/monitor/message-handler.inflight-pipeline.test-helpers.ts
@@ -1,0 +1,228 @@
+import { WebClient } from "@slack/web-api";
+import type { dispatchChannelInboundTurn } from "openclaw/plugin-sdk/channel-inbound";
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { vi } from "vitest";
+import { getOptionalSlackRuntime, setSlackRuntime } from "../runtime.js";
+import { clearSlackThreadParticipationCache } from "../sent-thread-cache.js";
+import type { SlackMessageEvent } from "../types.js";
+import { createSlackMessageHandler } from "./message-handler.js";
+import {
+  createInboundSlackTestContext,
+  createSlackSessionStoreFixture,
+  createSlackTestAccount,
+} from "./message-handler/prepare.test-helpers.js";
+
+export type InflightDispatchParams = Parameters<typeof dispatchChannelInboundTurn>[0];
+type DispatchResult = Awaited<ReturnType<typeof dispatchChannelInboundTurn>>;
+type Counts = { tool: number; block: number; final: number };
+type Outcome = { queuedFinal: boolean; counts: Counts };
+
+type WireCall = {
+  method: string;
+  channel?: string;
+  threadTs?: string;
+  text?: string;
+};
+
+export type ScriptedInflightTurn = {
+  params: InflightDispatchParams;
+  finish: (text?: string) => Promise<void>;
+  fail: (error: Error) => void;
+};
+
+/** Real Slack pipeline and stores; only the agent turn and Web API responses are scripted. */
+export function createInflightSlackPipeline(params: {
+  stateDir: string;
+  threadParticipation: boolean;
+}) {
+  const sessionFixture = createSlackSessionStoreFixture("openclaw-slack-inflight-pipeline-");
+  sessionFixture.setup();
+  const { storePath } = sessionFixture.makeTmpStorePath();
+  const apiCalls: WireCall[] = [];
+  const incoming: SlackMessageEvent[] = [];
+  let outboundId = 0;
+  const api = vi.spyOn(WebClient.prototype, "apiCall").mockImplementation(async (method, args) => {
+    apiCalls.push({
+      method,
+      ...(typeof args?.channel === "string" ? { channel: args.channel } : {}),
+      ...(typeof args?.thread_ts === "string" ? { threadTs: args.thread_ts } : {}),
+      ...(typeof args?.text === "string" ? { text: args.text } : {}),
+    });
+    switch (method) {
+      case "conversations.info":
+        return {
+          ok: true,
+          channel: { id: args?.channel, name: "proof", is_channel: true, is_member: true },
+        };
+      case "users.info":
+        return {
+          ok: true,
+          user: { id: args?.user, name: "tester", real_name: "Test User", team_id: "T1" },
+        };
+      case "conversations.replies":
+        return {
+          ok: true,
+          messages: incoming.filter(
+            (message) =>
+              message.channel === args?.channel &&
+              (message.ts === args?.ts || message.thread_ts === args?.ts),
+          ),
+          has_more: false,
+        };
+      case "conversations.history":
+        return { ok: true, messages: [], has_more: false };
+      case "chat.postMessage":
+        outboundId += 1;
+        return {
+          ok: true,
+          channel: args?.channel,
+          ts: `1700000010.${String(outboundId).padStart(6, "0")}`,
+        };
+      case "agents.sessions.setStatus":
+        return { ok: true };
+      default:
+        throw new Error(`Unexpected Slack Web API method: ${method}`);
+    }
+  });
+  const client = new WebClient("xoxb-synthetic");
+  const cfg: OpenClawConfig = {
+    session: { store: storePath },
+    messages: { inbound: { debounceMs: 0 }, ackReaction: "" },
+    channels: {
+      slack: {
+        enabled: true,
+        botToken: "xoxb-synthetic",
+        replyToMode: "all",
+        streaming: { mode: "off" },
+        implicitMentions: { threadParticipation: params.threadParticipation },
+      },
+    },
+  };
+  const previousRuntime = getOptionalSlackRuntime();
+  const openKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
+    createPluginStateKeyedStoreForTests<T>("slack", {
+      ...options,
+      env: { ...options.env, OPENCLAW_STATE_DIR: params.stateDir },
+    });
+  const runtime = createPluginRuntimeMock({
+    channel: { inbound: { buildContext: buildChannelInboundEventContext } },
+    state: { openKeyedStore },
+  });
+  setSlackRuntime(runtime);
+  const persistedParticipation = openKeyedStore<{ repliedAt: number }>({
+    namespace: "slack.thread-participation",
+    maxEntries: 1000,
+  });
+  const ctx = createInboundSlackTestContext({
+    cfg,
+    appClient: client,
+    replyToMode: "all",
+    channelRuntime: runtime.channel,
+  });
+  // Exercise the real context builder and session-store fallback, not optional
+  // runtime fixture mocks; the core agent dispatcher itself is scripted below.
+  ctx.channelRuntime = undefined;
+  ctx.dispatchReplyFromConfig = undefined;
+  const runtimeErrors: unknown[] = [];
+  ctx.runtime.error = (error) => runtimeErrors.push(error);
+  const handler = createSlackMessageHandler({
+    ctx,
+    account: createSlackTestAccount(cfg.channels?.slack),
+  });
+  const turns: ScriptedInflightTurn[] = [];
+  const gates = new Set<ReturnType<typeof createDeferred<Outcome>>>();
+  const ready = new Map<string, ReturnType<typeof createDeferred<ScriptedInflightTurn>>>();
+  const completions: Promise<void>[] = [];
+  let closing = false;
+
+  const dispatchCore = async (input: InflightDispatchParams): Promise<DispatchResult> => {
+    const sid = input.ctxPayload.MessageSid;
+    if (typeof sid !== "string") {
+      throw new Error("Prepared Slack turn is missing MessageSid");
+    }
+    const outcome = createDeferred<Outcome>();
+    gates.add(outcome);
+    const counts: Counts = { tool: 0, block: 0, final: 0 };
+    const turn: ScriptedInflightTurn = {
+      params: input,
+      finish: async (text) => {
+        if (text !== undefined) {
+          const authored = { text };
+          const transform = input.dispatcherOptions?.transformReplyPayload;
+          const reply = transform ? transform(authored) : authored;
+          if (reply) {
+            await input.delivery.deliver(reply, { kind: "final" });
+            counts.final += 1;
+          }
+        }
+        outcome.resolve({ queuedFinal: counts.final > 0, counts });
+      },
+      fail: (error) => outcome.reject(error),
+    };
+    // The actual dispatch owner registered its publisher before this core seam.
+    // Release immediate debounce admission exactly when core adopts the turn.
+    await input.replyOptions?.turnAdoptionLifecycle?.onAdopted();
+    turns.push(turn);
+    ready.get(sid)?.resolve(turn);
+    if (closing) {
+      outcome.resolve({ queuedFinal: false, counts });
+    }
+    try {
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: input.ctxPayload,
+        routeSessionKey: input.route.sessionKey,
+        dispatchResult: await outcome.promise,
+      };
+    } finally {
+      gates.delete(outcome);
+    }
+  };
+
+  return {
+    ctx,
+    turns,
+    apiCalls,
+    runtimeErrors,
+    dispatchCore,
+    async receive(message: SlackMessageEvent, source: "message" | "app_mention" = "message") {
+      if (!message.ts) {
+        throw new Error("Synthetic message requires a timestamp");
+      }
+      incoming.push(message);
+      const adopted = createDeferred<ScriptedInflightTurn>();
+      ready.set(message.ts, adopted);
+      const completion = handler(message, { source, awaitDispatch: true });
+      completions.push(completion);
+      // Attach rejection handling immediately; individual assertions still await
+      // the original completion to verify failure propagation.
+      void completion.catch(() => {});
+      const turn = await Promise.race([adopted.promise, completion.then(() => undefined)]);
+      return { turn, completion };
+    },
+    async persistedParticipant(threadTs: string) {
+      return (await persistedParticipation.lookup(`default:C123:${threadTs}`)) !== undefined;
+    },
+    async close() {
+      closing = true;
+      for (const gate of gates) {
+        gate.resolve({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+      }
+      await Promise.allSettled(completions);
+      clearSlackThreadParticipationCache();
+      setSlackRuntime(previousRuntime ?? (null as never));
+      resetPluginStateStoreForTests();
+      sessionFixture.cleanup();
+      api.mockRestore();
+    },
+  };
+}

--- a/extensions/slack/src/monitor/message-handler.inflight-pipeline.test.ts
+++ b/extensions/slack/src/monitor/message-handler.inflight-pipeline.test.ts
@@ -1,0 +1,199 @@
+import { withOpenClawTestState } from "openclaw/plugin-sdk/test-state";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { clearSlackThreadParticipationCache } from "../sent-thread-cache.js";
+import type { SlackMessageEvent } from "../types.js";
+import {
+  createInflightSlackPipeline,
+  type InflightDispatchParams,
+} from "./message-handler.inflight-pipeline.test-helpers.js";
+import { getSlackSessionRuns } from "./session-run-targets.js";
+
+type Pipeline = ReturnType<typeof createInflightSlackPipeline>;
+const coreTurn = vi.hoisted(() => ({
+  run: undefined as
+    | ((params: InflightDispatchParams) => ReturnType<Pipeline["dispatchCore"]>)
+    | undefined,
+}));
+
+// Only the core agent turn is scripted. Handler/debounce, prepare, dispatch,
+// publisher registration, final sender, and state-store writes remain real.
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
+  return {
+    ...actual,
+    dispatchChannelInboundTurn: (params: InflightDispatchParams) => {
+      if (!coreTurn.run) {
+        throw new Error("Slack integrated turn fixture is not initialized");
+      }
+      return coreTurn.run(params);
+    },
+  };
+});
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/channel-inbound");
+  vi.resetModules();
+});
+
+const ROOT_TS = "1700000000.000001";
+const FOLLOWUP_TS = "1700000001.000001";
+const FINAL_TEXT = "The revised report is ready.";
+const rootMessage = (): SlackMessageEvent => ({
+  type: "message",
+  channel: "C123",
+  channel_type: "channel",
+  user: "U1",
+  ts: ROOT_TS,
+  text: "<@B1> Check the report",
+});
+const followupMessage = (overrides: Partial<SlackMessageEvent> = {}): SlackMessageEvent => ({
+  type: "message",
+  channel: "C123",
+  channel_type: "channel",
+  user: "U1",
+  ts: FOLLOWUP_TS,
+  text: "Use the revised total",
+  thread_ts: ROOT_TS,
+  parent_user_id: "U1",
+  ...overrides,
+});
+const liveRuns = (pipeline: Pipeline) =>
+  getSlackSessionRuns(pipeline.ctx, { channelId: "C123", threadTs: ROOT_TS });
+const visibleCalls = (pipeline: Pipeline) =>
+  pipeline.apiCalls.filter((call) =>
+    ["chat.postMessage", "chat.startStream", "chat.update"].includes(call.method),
+  );
+
+async function withPipeline(
+  test: (pipeline: Pipeline) => Promise<void>,
+  threadParticipation = true,
+) {
+  await withOpenClawTestState(
+    { label: "slack-inflight-pipeline", layout: "state-only" },
+    async (state) => {
+      clearSlackThreadParticipationCache();
+      const pipeline = createInflightSlackPipeline({
+        stateDir: state.stateDir,
+        threadParticipation,
+      });
+      coreTurn.run = pipeline.dispatchCore;
+      try {
+        await test(pipeline);
+      } finally {
+        await pipeline.close();
+        coreTurn.run = undefined;
+      }
+    },
+  );
+}
+
+describe("Slack handler in-flight follow-up pipeline", () => {
+  it("admits a same-thread human follow-up before first output and delivers its answer once", async () => {
+    await withPipeline(async (pipeline) => {
+      const root = await pipeline.receive(rootMessage(), "app_mention");
+      expect(root.turn).toBeDefined();
+      if (!root.turn) {
+        throw new Error("Mentioned root was not admitted");
+      }
+      expect(liveRuns(pipeline)).toHaveLength(1);
+      expect(visibleCalls(pipeline)).toEqual([]);
+      expect(await pipeline.persistedParticipant(ROOT_TS)).toBe(false);
+
+      const visibleBeforeFollowup = visibleCalls(pipeline).length;
+      const followup = await pipeline.receive(followupMessage());
+      expect(followup.turn).toBeDefined();
+      if (!followup.turn) {
+        throw new Error("In-flight follow-up was not admitted");
+      }
+      expect(followup.turn.params.ctxPayload).toMatchObject({
+        MentionSource: "implicit_thread",
+        MessageSid: FOLLOWUP_TS,
+        SessionKey: root.turn.params.ctxPayload.SessionKey,
+      });
+      expect(visibleCalls(pipeline)).toEqual([]);
+      expect(await pipeline.persistedParticipant(ROOT_TS)).toBe(false);
+      await root.turn.finish();
+      await root.completion;
+      expect(liveRuns(pipeline)).toHaveLength(1);
+      expect(liveRuns(pipeline)[0]?.isActive()).toBe(true);
+
+      await followup.turn.finish(FINAL_TEXT);
+      await followup.completion;
+      expect(visibleCalls(pipeline)).toEqual([
+        { method: "chat.postMessage", channel: "C123", threadTs: ROOT_TS, text: FINAL_TEXT },
+      ]);
+      expect(liveRuns(pipeline)).toEqual([]);
+      expect(await pipeline.persistedParticipant(ROOT_TS)).toBe(true);
+      expect(pipeline.runtimeErrors).toEqual([]);
+      if (process.env.OPENCLAW_DELIVERY_PROOF === "1") {
+        process.stdout.write(
+          `${JSON.stringify({
+            kind: "in-process Slack handler integration",
+            liveSlack: false,
+            gatewayProcess: false,
+            headSha: process.env.OPENCLAW_DELIVERY_PROOF_SHA ?? "",
+            entry: "createSlackMessageHandler",
+            harness: "extensions/slack/src/monitor/message-handler.inflight-pipeline.test.ts",
+            visibleBeforeFollowup,
+            mockedBoundaries: ["core agent turn", "Slack Web API"],
+            followup: {
+              messageSid: followup.turn.params.ctxPayload.MessageSid,
+              mentionSource: followup.turn.params.ctxPayload.MentionSource,
+            },
+            finalWireCalls: visibleCalls(pipeline),
+            remainingPublishers: liveRuns(pipeline).length,
+          })}\n`,
+        );
+      }
+    });
+  });
+
+  it.each(["other-thread", "explicit-mention-policy"])(
+    "keeps %s follow-ups gated while root work is active",
+    async (boundary) => {
+      await withPipeline(async (pipeline) => {
+        const root = await pipeline.receive(rootMessage(), "app_mention");
+        expect(root.turn).toBeDefined();
+        if (!root.turn) {
+          throw new Error("Mentioned root was not admitted");
+        }
+        expect(liveRuns(pipeline)).toHaveLength(1);
+        const followup = await pipeline.receive(
+          followupMessage(boundary === "other-thread" ? { thread_ts: "1700000000.000002" } : {}),
+        );
+        expect(followup.turn).toBeUndefined();
+        await followup.completion;
+        expect(pipeline.turns).toHaveLength(1);
+        expect(visibleCalls(pipeline)).toEqual([]);
+        await root.turn.finish();
+        await root.completion;
+        expect(liveRuns(pipeline)).toEqual([]);
+        expect(await pipeline.persistedParticipant(ROOT_TS)).toBe(false);
+      }, boundary !== "explicit-mention-policy");
+    },
+  );
+
+  it("releases a failed root without persisting participation or admitting a later unmentioned input", async () => {
+    await withPipeline(async (pipeline) => {
+      const root = await pipeline.receive(rootMessage(), "app_mention");
+      expect(root.turn).toBeDefined();
+      if (!root.turn) {
+        throw new Error("Mentioned root was not admitted");
+      }
+      expect(liveRuns(pipeline)).toHaveLength(1);
+      const failure = new Error("Synthetic agent turn failed before replying");
+      root.turn.fail(failure);
+      await expect(root.completion).rejects.toBe(failure);
+      expect(liveRuns(pipeline)).toEqual([]);
+      expect(visibleCalls(pipeline)).toEqual([]);
+      expect(await pipeline.persistedParticipant(ROOT_TS)).toBe(false);
+      clearSlackThreadParticipationCache();
+      const later = await pipeline.receive(followupMessage());
+      expect(later.turn).toBeUndefined();
+      await later.completion;
+      expect(pipeline.turns).toHaveLength(1);
+      expect(visibleCalls(pipeline)).toEqual([]);
+      expect(pipeline.runtimeErrors.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -349,6 +349,7 @@ function createPreparedSlackMessage(params?: {
   channelConfig?: Record<string, unknown> | null;
   replyToMode?: "off" | "first" | "all" | "batched";
   isDirectMessage?: boolean;
+  allowImplicitThreadReplies?: boolean;
   route?: Partial<{
     agentId: string;
     accountId: string;
@@ -409,6 +410,7 @@ function createPreparedSlackMessage(params?: {
     },
     relayIdentity: params?.relayIdentity,
     turnAdoptionLifecycle: params?.turnAdoptionLifecycle,
+    allowImplicitThreadReplies: params?.allowImplicitThreadReplies,
     eventScope: params?.eventScope,
     message,
     route: {
@@ -1290,7 +1292,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     mockedReplyThreadTs = message.ts;
     mockedSlackIsThreadReply = false;
     const prepared: Parameters<typeof dispatchPreparedSlackMessage>[0] = createPreparedSlackMessage(
-      { message, replyToMode: "first" },
+      { message, replyToMode: "first", allowImplicitThreadReplies: true },
     );
     mockedReplyOptionEvents = [
       {
@@ -1300,12 +1302,18 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
             getSlackSessionRuns(prepared.ctx, {
               channelId: message.channel,
               threadTs: message.ts,
-            }).map(({ route }) => route.sessionKey),
-          ).toEqual([prepared.route.sessionKey]);
+            }).map(({ route, allowImplicitReplies }) => ({
+              sessionKey: route.sessionKey,
+              allowImplicitReplies,
+            })),
+          ).toEqual([{ sessionKey: prepared.route.sessionKey, allowImplicitReplies: true }]);
         },
       },
     ];
     await dispatchPreparedSlackMessage(prepared);
+    expect(
+      getSlackSessionRuns(prepared.ctx, { channelId: message.channel, threadTs: message.ts }),
+    ).toEqual([]);
   });
 
   it.each([false, true])(
@@ -1313,6 +1321,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     async (executed) => {
       const prepared: Parameters<typeof dispatchPreparedSlackMessage>[0] =
         createPreparedSlackMessage({
+          allowImplicitThreadReplies: true,
           turnAdoptionLifecycle: {
             admission: "exclusive",
             onAdopted: async () => {},
@@ -1326,16 +1335,22 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
           kind: "checkpoint",
           run: async () => {
             expect(
-              getSlackSessionRuns(prepared.ctx, address).map(({ route }) => route.sessionKey),
-            ).toEqual([prepared.route.sessionKey]);
+              getSlackSessionRuns(prepared.ctx, address).map(({ route, allowImplicitReplies }) => ({
+                sessionKey: route.sessionKey,
+                allowImplicitReplies,
+              })),
+            ).toEqual([{ sessionKey: prepared.route.sessionKey, allowImplicitReplies: true }]);
             capturedReplyOptions?.turnAdoptionLifecycle?.onDeferred?.();
           },
         },
       ];
       await dispatchPreparedSlackMessage(prepared);
       expect(
-        getSlackSessionRuns(prepared.ctx, address).map(({ route }) => route.sessionKey),
-      ).toEqual([prepared.route.sessionKey]);
+        getSlackSessionRuns(prepared.ctx, address).map(({ route, allowImplicitReplies }) => ({
+          sessionKey: route.sessionKey,
+          allowImplicitReplies,
+        })),
+      ).toEqual([{ sessionKey: prepared.route.sessionKey, allowImplicitReplies: true }]);
       const endQueuedRun = executed
         ? capturedReplyOptions?.queuedDeliveryCorrelations?.[0]?.begin()
         : undefined;
@@ -2795,15 +2810,18 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     mockedReplyOptionEvents = [{ kind: "item", progressText: "working" }];
     mockedDispatchError = new Error("agent dispatch failed");
 
-    await expect(
-      dispatchPreparedSlackMessage(
-        createPreparedSlackMessage({
-          accountConfig: {
-            streaming: { mode: "progress", progress: { toolProgress: true, label: "Working" } },
-          },
-        }),
-      ),
-    ).rejects.toThrow("agent dispatch failed");
+    const prepared: Parameters<typeof dispatchPreparedSlackMessage>[0] = createPreparedSlackMessage(
+      {
+        allowImplicitThreadReplies: true,
+        accountConfig: {
+          streaming: { mode: "progress", progress: { toolProgress: true, label: "Working" } },
+        },
+      },
+    );
+    await expect(dispatchPreparedSlackMessage(prepared)).rejects.toThrow("agent dispatch failed");
+    expect(getSlackSessionRuns(prepared.ctx, { channelId: "C123", threadTs: THREAD_TS })).toEqual(
+      [],
+    );
 
     const finalEdit = requireRecord(
       requireMockCall(finalizeSlackPreviewEditMock, 0, "dispatch error card edit")[0],

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -57,6 +57,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         ...prepared.route,
         sessionKey: prepared.ctxPayload.SessionKey ?? prepared.route.sessionKey,
       },
+      { allowImplicitReplies: prepared.allowImplicitThreadReplies },
     );
   const upstreamLifecycle = prepared.turnAdoptionLifecycle;
   let releaseDeferred: (() => void) | undefined;

--- a/extensions/slack/src/monitor/message-handler/prepare.inflight-followups.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.inflight-followups.test.ts
@@ -1,0 +1,200 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import * as sessionStore from "openclaw/plugin-sdk/session-store-runtime";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSlackThreadParticipationCache,
+  hasSlackThreadParticipation,
+} from "../../sent-thread-cache.js";
+import type { SlackMessageEvent } from "../../types.js";
+import type { SlackMonitorContext } from "../context.js";
+import { registerSlackSessionRun } from "../session-run-targets.js";
+import { prepareSlackMessage } from "./prepare.js";
+import {
+  createInboundSlackTestContext,
+  createSlackSessionStoreFixture,
+  createSlackTestAccount,
+} from "./prepare.test-helpers.js";
+
+describe("Slack follow-ups before the first reply", () => {
+  const fixture = createSlackSessionStoreFixture("openclaw-slack-inflight-");
+  const rootTs = "1700000000.000001";
+  const releases: Array<() => void> = [];
+
+  beforeAll(() => fixture.setup());
+  beforeEach(() => {
+    clearSlackThreadParticipationCache();
+    const { storePath } = fixture.makeTmpStorePath();
+    vi.spyOn(sessionStore, "resolveStorePath").mockReturnValue(storePath);
+  });
+  afterEach(() => {
+    releases.splice(0).forEach((release) => release());
+    vi.restoreAllMocks();
+    clearSlackThreadParticipationCache();
+  });
+  afterAll(() => fixture.cleanup());
+
+  function createContext(
+    threadParticipation = true,
+    channelsConfig?: Parameters<typeof createInboundSlackTestContext>[0]["channelsConfig"],
+  ) {
+    const cfg: OpenClawConfig = {
+      channels: { slack: { enabled: true, implicitMentions: { threadParticipation } } },
+    };
+    const ctx = createInboundSlackTestContext({ cfg, replyToMode: "all", channelsConfig });
+    ctx.resolveUserName = async () => ({ name: "Alice" });
+    return ctx;
+  }
+
+  async function prepare(ctx: SlackMonitorContext, message: Partial<SlackMessageEvent> = {}) {
+    return prepareSlackMessage({
+      ctx,
+      account: createSlackTestAccount(),
+      message: {
+        type: "message",
+        channel: "C123",
+        channel_type: "channel",
+        user: "U1",
+        text: "Use the revised total",
+        ts: "1700000001.000001",
+        thread_ts: rootTs,
+        parent_user_id: "U1",
+        ...message,
+      },
+      opts: { source: "message" },
+    });
+  }
+
+  function begin(prepared: NonNullable<Awaited<ReturnType<typeof prepare>>>) {
+    const release = registerSlackSessionRun(
+      prepared.ctx,
+      { channelId: prepared.message.channel, threadTs: rootTs, eventScope: prepared.eventScope },
+      prepared.route,
+      { allowImplicitReplies: prepared.allowImplicitThreadReplies },
+    );
+    releases.push(release);
+    return release;
+  }
+
+  it("admits human follow-ups during accepted work without persisting a delivered reply", async () => {
+    const ctx = createContext();
+    expect(await prepare(ctx)).toBeNull();
+    const root = await prepare(ctx, {
+      text: "<@B1> Check the report",
+      ts: rootTs,
+      thread_ts: undefined,
+    });
+    expect(root).not.toBeNull();
+    if (!root) {
+      throw new Error("Expected the mentioned request to be accepted");
+    }
+    const endRoot = begin(root);
+    // Configuration reloads inherit the same Bolt app without reconnecting.
+    const reloaded = Object.create(ctx) as SlackMonitorContext;
+    reloaded.cfg = { ...ctx.cfg };
+    expect((await prepare(reloaded))?.ctxPayload.MentionSource).toBe("implicit_thread");
+
+    const followup = await prepare(ctx);
+    expect(followup?.ctxPayload.MentionSource).toBe("implicit_thread");
+    expect(hasSlackThreadParticipation("default", "C123", rootTs)).toBe(false);
+    if (!followup) {
+      throw new Error("Expected an in-flight follow-up");
+    }
+    const endFollowup = begin(followup);
+    endRoot();
+    expect((await prepare(ctx))?.ctxPayload.MentionSource).toBe("implicit_thread");
+    endFollowup();
+    expect(await prepare(ctx)).toBeNull();
+  });
+
+  it("keeps the explicit-mention policy authoritative during active work", async () => {
+    const ctx = createContext(false);
+    const root = await prepare(ctx, { text: "<@B1> Check the report" });
+    if (!root) {
+      throw new Error("Expected the mentioned request to be accepted");
+    }
+    begin(root);
+    expect(await prepare(ctx)).toBeNull();
+    expect(
+      (await prepare(ctx, { text: "<@B1> Use the revised total" }))?.ctxPayload.MentionSource,
+    ).toBe("explicit_bot");
+  });
+
+  it.each(["<@B1> /status", "<@B1> stop"])(
+    "does not open a thread for control input %s",
+    async (text) => {
+      const ctx = createContext();
+      const control = await prepare(ctx, { text });
+      if (control) {
+        begin(control);
+      }
+      expect(await prepare(ctx)).toBeNull();
+    },
+  );
+
+  it("does not lend active participation across a thread, channel, monitor, or account", async () => {
+    const ctx = createContext();
+    const root = await prepare(ctx, { text: "<@B1> Check the report" });
+    if (!root) {
+      throw new Error("Expected the mentioned request to be accepted");
+    }
+    begin(root);
+    expect(await prepare(ctx, { thread_ts: "1700000000.000999" })).toBeNull();
+    expect(await prepare(ctx, { channel: "C_OTHER" })).toBeNull();
+    releases.splice(0).forEach((release) => release());
+    begin({ ...root, eventScope: { teamId: "T_OTHER", client: ctx.app.client } });
+    expect(await prepare(ctx)).toBeNull();
+    begin(root);
+    expect(await prepare(createContext())).toBeNull();
+    const otherAccount = { ...root, route: { ...root.route, accountId: "other" } };
+    releases.splice(0).forEach((release) => release());
+    begin(otherAccount);
+    expect(await prepare(ctx)).toBeNull();
+  });
+
+  it("keeps room sender restrictions and other mentions authoritative during active work", async () => {
+    const ctx = createContext(true, { C123: { users: ["U1"], ignoreOtherMentions: true } });
+    ctx.allowFrom = ["U1"];
+    const root = await prepare(ctx, { text: "<@B1> Check the report" });
+    if (!root) {
+      throw new Error("Expected the mentioned request to be accepted");
+    }
+    begin(root);
+    expect(await prepare(ctx, { user: "U_OTHER" })).toBeNull();
+    expect(await prepare(ctx, { text: "<@U_OTHER> Check the report" })).toBeNull();
+    expect((await prepare(ctx))?.ctxPayload.MentionSource).toBe("implicit_thread");
+  });
+
+  it("does not open active participation for bots or admit them through a human run", async () => {
+    const ctx = createContext(true, { C123: { allowBots: true, users: ["U1", "U_BOT"] } });
+    const bot = await prepare(ctx, {
+      text: "<@B1> Check the report",
+      user: "U_BOT",
+      bot_id: "B_OTHER",
+    });
+    if (!bot) {
+      throw new Error("Expected the explicitly mentioned bot message to be accepted");
+    }
+    begin(bot);
+    expect(await prepare(ctx)).toBeNull();
+    const root = await prepare(ctx, { text: "<@B1> Check the report" });
+    if (!root) {
+      throw new Error("Expected the mentioned request to be accepted");
+    }
+    begin(root);
+    expect(await prepare(ctx, { user: "U_BOT", bot_id: "B_OTHER" })).toBeNull();
+    expect((await prepare(ctx))?.ctxPayload.MentionSource).toBe("implicit_thread");
+  });
+
+  it("does not let an overlapping ineligible publisher hide an accepted human turn", async () => {
+    const ctx = createContext();
+    const root = await prepare(ctx, { text: "<@B1> Check the report" });
+    if (!root) {
+      throw new Error("Expected the mentioned request to be accepted");
+    }
+    const endRoot = begin(root);
+    begin({ ...root, allowImplicitThreadReplies: false });
+    expect((await prepare(ctx))?.ctxPayload.MentionSource).toBe("implicit_thread");
+    endRoot();
+    expect(await prepare(ctx)).toBeNull();
+  });
+});

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -74,6 +74,7 @@ import type { SlackMediaResult } from "../media-types.js";
 import { escapeSlackMrkdwn } from "../mrkdwn.js";
 import { resolveSlackRoomContextHints } from "../room-context.js";
 import { sendMessageSlack } from "../send.runtime.js";
+import { getSlackSessionRuns } from "../session-run-targets.js";
 import { resolveSlackThreadStarter, type SlackThreadStarter } from "../thread.js";
 import { qualifySlackRoutePeerId } from "../workspace-routing.js";
 import {
@@ -969,12 +970,23 @@ export async function prepareSlackMessage(params: {
         ? replyToBotKinds
         : implicitMentionKindWhen(
             "bot_thread_participant",
-            await hasSlackThreadParticipationWithPersistence({
-              accountId: account.accountId,
-              channelId: message.channel,
-              threadTs: message.thread_ts,
-              teamId: opts.eventScope?.teamId,
-            }),
+            (!isBotMessage &&
+              getSlackSessionRuns(ctx, {
+                channelId: message.channel,
+                threadTs: message.thread_ts,
+                eventScope: opts.eventScope,
+              }).some(
+                (run) =>
+                  run.route.accountId === account.accountId &&
+                  run.allowImplicitReplies &&
+                  run.isActive(),
+              )) ||
+              (await hasSlackThreadParticipationWithPersistence({
+                accountId: account.accountId,
+                channelId: message.channel,
+                threadTs: message.thread_ts,
+                teamId: opts.eventScope?.teamId,
+              })),
           );
   }
 
@@ -1795,6 +1807,13 @@ export async function prepareSlackMessage(params: {
     message,
     ...(opts.relayIdentity ? { relayIdentity: opts.relayIdentity } : {}),
     eventScope: opts.eventScope,
+    allowImplicitThreadReplies:
+      isRoom &&
+      !isBotMessage &&
+      effectiveWasMentioned &&
+      !hasControlCommandInMessage &&
+      !hasAbortRequest &&
+      !isRoomEvent,
     route,
     channelConfig,
     replyTarget,

--- a/extensions/slack/src/monitor/message-handler/types.ts
+++ b/extensions/slack/src/monitor/message-handler/types.ts
@@ -36,6 +36,7 @@ export type PreparedSlackMessage = {
   sessionDisplayName?: string;
   slackMessageMetadata?: MessageMetadata;
   requireMention: boolean;
+  allowImplicitThreadReplies?: boolean;
   isDirectMessage: boolean;
   isRoomish: boolean;
   historyKey: string;

--- a/extensions/slack/src/monitor/session-run-targets.ts
+++ b/extensions/slack/src/monitor/session-run-targets.ts
@@ -12,6 +12,7 @@ type SlackSessionAddress = {
 type SlackSessionRunTarget = {
   route: ResolvedAgentRoute;
   isActive: () => boolean;
+  allowImplicitReplies: boolean;
 };
 
 export function captureSlackSessionTargetGuard(
@@ -49,6 +50,7 @@ export function registerSlackSessionRun(
   ctx: SlackMonitorContext,
   address: SlackSessionAddress,
   route: ResolvedAgentRoute,
+  options?: { allowImplicitReplies?: boolean },
 ): () => void {
   if (!address.threadTs) {
     return () => {};
@@ -58,7 +60,11 @@ export function registerSlackSessionRun(
   const key = addressKey(address);
   const targets = byAddress.get(key) ?? new Set<SlackSessionRunTarget>();
   byAddress.set(key, targets);
-  const target = { route, isActive: () => targets.has(target) };
+  const target: SlackSessionRunTarget = {
+    route,
+    isActive: () => targets.has(target),
+    allowImplicitReplies: options?.allowImplicitReplies === true,
+  };
   targets.add(target);
   return () => {
     targets.delete(target);
@@ -77,6 +83,12 @@ export function getSlackSessionRuns(
   return [...new Map(targets.map((target) => [target.route.sessionKey, target])).values()].map(
     (target) => ({
       route: target.route,
+      allowImplicitReplies: targets.some(
+        (candidate) =>
+          candidate.route.sessionKey === target.route.sessionKey &&
+          candidate.isActive() &&
+          candidate.allowImplicitReplies,
+      ),
       isActive: () =>
         targets.some(
           (candidate) =>

--- a/test/e2e/qa-lab/runtime/slack-inflight-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/slack-inflight-gateway.e2e.test.ts
@@ -1,0 +1,371 @@
+import { execFileSync } from "node:child_process";
+import { createHash, createHmac } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { startOpenClawCrablineAdapter } from "@openclaw/crabline";
+import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { createQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
+import { listSessionEntriesReadOnly } from "../../../../src/config/sessions/session-accessor.js";
+import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+import {
+  startHeldSlackModelProvider,
+  waitForSlackGatewayFact,
+  SLACK_INFLIGHT_MODEL,
+  SLACK_INFLIGHT_ROOT_TEXT,
+  SLACK_INFLIGHT_FOLLOWUP_TEXT,
+  SLACK_INFLIGHT_ROOT_REPLY,
+  SLACK_INFLIGHT_FOLLOWUP_REPLY,
+} from "./slack-inflight-gateway.fixture.js";
+
+const CHANNEL = "C12345678";
+const USER = "U12345678";
+const SOURCE_OWNERS = [
+  "extensions/slack/src/monitor/message-handler/dispatch.ts",
+  "extensions/slack/src/monitor/message-handler/prepare.ts",
+  "extensions/slack/src/monitor/message-handler/types.ts",
+  "extensions/slack/src/monitor/session-run-targets.ts",
+];
+type Post = { channel: unknown; threadTs: unknown; text: unknown };
+
+describe("Slack in-flight follow-up through an actual Gateway", () => {
+  it(
+    "accepts unmentioned thread input before the first reply and delivers the follow-up",
+    { timeout: 180_000 },
+    async () => {
+      const repoRoot = process.cwd();
+      const directory = await fs.mkdtemp(
+        path.join(await fs.realpath(os.tmpdir()), "slack-inflight-gateway-"),
+      );
+      const artifactDir = path.join(
+        repoRoot,
+        ".artifacts",
+        "slack-inflight-gateway",
+        path.basename(directory),
+      );
+      await fs.mkdir(artifactDir, { recursive: true });
+      const owner = createQaGatewayChild();
+      let adapter: Awaited<ReturnType<typeof startOpenClawCrablineAdapter>> | undefined;
+      let provider: Awaited<ReturnType<typeof startHeldSlackModelProvider>> | undefined;
+      const posts: Post[] = [];
+      const evidence: Record<string, unknown> = {
+        kind: "actual Gateway and core follow-up execution with simulated Slack/model HTTP",
+        gatewayProcess: false,
+        liveSlack: false,
+        coreDispatchMocked: false,
+        passed: false,
+        sourceHead: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+        sourceOwners: await Promise.all(
+          SOURCE_OWNERS.map(async (file) => ({
+            path: file,
+            sha256: createHash("sha256")
+              .update(await fs.readFile(path.join(repoRoot, file)))
+              .digest("hex"),
+          })),
+        ),
+      };
+      let bodyError: unknown;
+      const cleanupErrors: unknown[] = [];
+      try {
+        adapter = await startOpenClawCrablineAdapter({
+          channel: "slack",
+          recorderPath: path.join(directory, "provider.jsonl"),
+          onEvent(event) {
+            if (event.type === "api" && event.path.endsWith("/api/chat.postMessage")) {
+              const body = asNonArrayRecord(event.body);
+              posts.push({ channel: body.channel, threadTs: body.thread_ts, text: body.text });
+            }
+          },
+        });
+        const slack = adapter;
+        if (slack.manifest.provider !== "slack") {
+          throw new Error("Expected a Slack fixture");
+        }
+        const manifest = slack.manifest;
+        const auth = asNonArrayRecord(await slack.probe());
+        const botUserId = auth.user_id;
+        if (typeof botUserId !== "string") {
+          throw new Error("Slack fixture auth.test omitted the bot user id");
+        }
+        provider = await startHeldSlackModelProvider();
+        const model = provider;
+        const gateway = await owner.start({
+          repoRoot,
+          command: {
+            executablePath: process.execPath,
+            argsPrefix: [path.join(repoRoot, "openclaw.mjs")],
+            argsSuffix: ["--verbose"],
+            cwd: repoRoot,
+            usePackagedPlugins: true,
+          },
+          providerBaseUrl: model.baseUrl,
+          providerMode: "mock-openai",
+          primaryModel: SLACK_INFLIGHT_MODEL,
+          alternateModel: SLACK_INFLIGHT_MODEL,
+          controlUiEnabled: false,
+          transportBaseUrl: manifest.endpoints.apiRoot,
+          transport: {
+            requiredPluginIds: slack.requiredPluginIds,
+            createGatewayConfig: () => slack.createGatewayConfig() as OpenClawConfig,
+          },
+          runtimeEnvPatch: slack.createProviderReadinessEnv({}),
+          mutateConfig(config) {
+            return {
+              ...config,
+              logging: {
+                ...config.logging,
+                level: "debug",
+                consoleLevel: "info",
+                file: path.join(directory, "runtime.jsonl"),
+              },
+              messages: {
+                ...config.messages,
+                ackReaction: "",
+                statusReactions: { enabled: false },
+                inbound: { debounceMs: 0 },
+                queue: { mode: "followup" },
+              },
+              agents: {
+                ...config.agents,
+                defaults: { ...config.agents?.defaults, typingMode: "never" },
+              },
+              channels: {
+                ...config.channels,
+                slack: {
+                  ...config.channels?.slack,
+                  replyToMode: "all",
+                  streaming: { mode: "off" },
+                  implicitMentions: { threadParticipation: true },
+                  channels: { ...config.channels?.slack?.channels, "*": { requireMention: true } },
+                },
+              },
+            };
+          },
+        });
+        expect(gateway.pid).toEqual(expect.any(Number));
+        expect(gateway.pid).not.toBe(process.pid);
+        evidence.gatewayProcess = true;
+        evidence.gatewayPid = gateway.pid;
+        await waitForSlackGatewayFact(
+          async () => {
+            const status = asNonArrayRecord(
+              await gateway.call("channels.status", { probe: false }),
+            );
+            const accounts = asNonArrayRecord(status.channelAccounts).slack;
+            return Array.isArray(accounts) &&
+              accounts.some((account) => asNonArrayRecord(account).running === true)
+              ? true
+              : undefined;
+          },
+          "Slack HTTP plugin readiness",
+          60_000,
+        );
+
+        const deliver = async (text: string, threadId?: string) => {
+          const inbound = slack.createInbound({
+            input: {
+              conversation: { id: CHANNEL, kind: "group" },
+              senderId: USER,
+              text,
+              ...(threadId ? { threadId } : {}),
+            },
+          });
+          const seeded = await fetch(inbound.providerUrl, {
+            method: "POST",
+            headers: inbound.providerHeaders,
+            body: JSON.stringify(inbound.providerBody),
+          });
+          expect(seeded.ok).toBe(true);
+          const payload = asNonArrayRecord(await seeded.json());
+          const envelope = asNonArrayRecord(payload.event);
+          const event = asNonArrayRecord(envelope.event);
+          const body = JSON.stringify(envelope);
+          const timestamp = String(Math.floor(Date.now() / 1000));
+          const signature = createHmac("sha256", manifest.signingSecret)
+            .update(`v0:${timestamp}:${body}`)
+            .digest("hex");
+          const accepted = await fetch(`${gateway.baseUrl}/slack/events`, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "x-slack-request-timestamp": timestamp,
+              "x-slack-signature": `v0=${signature}`,
+            },
+            body,
+          });
+          expect(accepted.ok).toBe(true);
+          return event;
+        };
+        const root = await deliver(`<@${botUserId}> ${SLACK_INFLIGHT_ROOT_TEXT}`);
+        const rootTs = root.ts;
+        expect(typeof rootTs).toBe("string");
+        if (typeof rootTs !== "string") {
+          throw new Error("Root timestamp missing");
+        }
+        await waitForSlackGatewayFact(
+          () => (model.rootHeld ? true : undefined),
+          "held first actual model request",
+          60_000,
+        );
+        expect(posts).toEqual([]);
+        const sessions = listSessionEntriesReadOnly({
+          agentId: "qa",
+          env: gateway.runtimeEnv,
+          readConsistency: "latest",
+        }).filter(
+          ({ sessionKey }) =>
+            sessionKey.includes(":slack:") && sessionKey.endsWith(`:thread:${rootTs}`),
+        );
+        expect(sessions).toHaveLength(1);
+        const sessionKey = sessions[0]!.sessionKey;
+        const followup = await deliver(SLACK_INFLIGHT_FOLLOWUP_TEXT, rootTs);
+        expect(followup.thread_ts).toBe(rootTs);
+        expect(followup.ts).not.toBe(rootTs);
+        evidence.inputIds = { rootTs, followupTs: followup.ts };
+        const decision = await waitForSlackGatewayFact(async () => {
+          expect(model.rootHeld).toBe(true);
+          expect(posts).toEqual([]);
+          const history = asNonArrayRecord(
+            await gateway.call("chat.history", { sessionKey, limit: 20 }),
+          );
+          const pending = asNonArrayRecord(history.pendingInputs).items;
+          evidence.admissionObservation = {
+            rootHeld: model.rootHeld,
+            visiblePosts: posts.length,
+            pendingCount: Array.isArray(pending) ? pending.length : 0,
+            historyContainsFollowup: JSON.stringify(history.messages).includes(
+              SLACK_INFLIGHT_FOLLOWUP_TEXT,
+            ),
+          };
+          const queued = Array.isArray(pending)
+            ? pending
+                .map(asNonArrayRecord)
+                .find(
+                  (item) =>
+                    item.state === "queued" &&
+                    JSON.stringify(item.message).includes(SLACK_INFLIGHT_FOLLOWUP_TEXT),
+                )
+            : undefined;
+          if (queued) {
+            return { kind: "queued", state: queued.state, runId: queued.runId };
+          }
+          const logTail = asNonArrayRecord(
+            await gateway.call("logs.tail", { limit: 200, maxBytes: 200_000 }),
+          );
+          const lines = [
+            ...(Array.isArray(logTail.lines) ? logTail.lines : []),
+            ...gateway.logs().split("\n"),
+          ].filter((line): line is string => typeof line === "string");
+          // This producer runs after the real room mention gate, before
+          // returning the prepared input to actual core dispatch.
+          const prepared = lines.some(
+            (line) =>
+              line.includes("slack inbound:") && line.includes(`message_ts=${String(followup.ts)}`),
+          );
+          if (prepared) {
+            return { kind: "prepared", messageTs: followup.ts };
+          }
+          const rejected = lines.some(
+            (line) => line.includes(String(followup.ts)) && line.includes("missing-mention"),
+          );
+          return rejected ? { kind: "rejected", reason: "missing-mention" } : undefined;
+        }, "actual follow-up admission or explicit mention rejection");
+        evidence.beforeRelease = {
+          rootHeld: model.rootHeld,
+          visiblePosts: posts.length,
+          followupTs: followup.ts,
+          decision,
+        };
+        expect(["queued", "prepared"]).toContain(decision.kind);
+        model.releaseRoot();
+        await waitForSlackGatewayFact(
+          () => (model.requests.some((request) => request.followup) ? true : undefined),
+          "follow-up reaching the real model HTTP request",
+        );
+        await waitForSlackGatewayFact(
+          () =>
+            posts.some((post) => post.text === SLACK_INFLIGHT_FOLLOWUP_REPLY) ? true : undefined,
+          "queued answer reaching Slack HTTP",
+        );
+        expect(posts).toEqual([
+          { channel: CHANNEL, threadTs: rootTs, text: SLACK_INFLIGHT_ROOT_REPLY },
+          { channel: CHANNEL, threadTs: rootTs, text: SLACK_INFLIGHT_FOLLOWUP_REPLY },
+        ]);
+        const replies = await fetch(`${manifest.endpoints.apiRoot}conversations.replies`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${manifest.botToken}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ channel: CHANNEL, ts: rootTs }),
+        });
+        const replyState = asNonArrayRecord(await replies.json());
+        expect(replyState.ok).toBe(true);
+        const storedReplies = Array.isArray(replyState.messages)
+          ? replyState.messages
+              .map(asNonArrayRecord)
+              .filter((message) =>
+                [SLACK_INFLIGHT_ROOT_REPLY, SLACK_INFLIGHT_FOLLOWUP_REPLY].includes(
+                  String(message.text),
+                ),
+              )
+          : [];
+        expect(
+          storedReplies.map((message) => ({ threadTs: message.thread_ts, text: message.text })),
+        ).toEqual([
+          { threadTs: rootTs, text: SLACK_INFLIGHT_ROOT_REPLY },
+          { threadTs: rootTs, text: SLACK_INFLIGHT_FOLLOWUP_REPLY },
+        ]);
+        expect(model.errors).toEqual([]);
+        evidence.posts = posts;
+        evidence.modelRequests = model.requests.map(({ root: hasRoot, followup: hasFollowup }) => ({
+          route: "/v1/responses",
+          hasRoot,
+          hasFollowup,
+        }));
+        evidence.sameThreadReadback = true;
+        evidence.passed = true;
+      } catch (error) {
+        bodyError = error;
+        evidence.posts = posts;
+        evidence.modelRequests = provider?.requests.map(
+          ({ root: hasRoot, followup: hasFollowup }) => ({ hasRoot, hasFollowup }),
+        );
+      } finally {
+        for (const cleanup of [
+          () =>
+            stopQaGatewayFixture(owner, {
+              preserveToDir: path.join(artifactDir, "gateway"),
+              keepTemp: false,
+            }),
+          () => provider?.stop(),
+          () => adapter?.close(),
+          () => fs.rm(directory, { recursive: true, force: true }),
+        ]) {
+          try {
+            await cleanup();
+          } catch (error) {
+            cleanupErrors.push(error);
+          }
+        }
+        evidence.cleanupComplete = cleanupErrors.length === 0;
+        try {
+          await fs.writeFile(
+            path.join(artifactDir, "verdict.json"),
+            `${JSON.stringify(evidence, null, 2)}\n`,
+          );
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+      }
+      if (bodyError || cleanupErrors.length) {
+        throw new AggregateError(
+          [...(bodyError ? [bodyError] : []), ...cleanupErrors],
+          `Slack in-flight Gateway proof failed; evidence: ${artifactDir}`,
+        );
+      }
+    },
+  );
+});

--- a/test/e2e/qa-lab/runtime/slack-inflight-gateway.fixture.ts
+++ b/test/e2e/qa-lab/runtime/slack-inflight-gateway.fixture.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { createServer } from "node:http";
+import { setTimeout as sleep } from "node:timers/promises";
+import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
+import { writeOpenAiResponsesText } from "../../../helpers/openai-responses-sse.js";
+
+export const SLACK_INFLIGHT_MODEL = "mock-openai/gpt-5.6-luna";
+export const SLACK_INFLIGHT_ROOT_REPLY = "SLACK_INFLIGHT_ROOT_DONE";
+export const SLACK_INFLIGHT_FOLLOWUP_REPLY = "SLACK_INFLIGHT_FOLLOWUP_DONE";
+export const SLACK_INFLIGHT_ROOT_TEXT =
+  "Reply with only this exact marker: SLACK_INFLIGHT_ROOT_DONE";
+export const SLACK_INFLIGHT_FOLLOWUP_TEXT =
+  "Use the revised total. Reply with only this exact marker: SLACK_INFLIGHT_FOLLOWUP_DONE";
+
+export async function waitForSlackGatewayFact<T>(
+  read: () => Promise<T | undefined> | T | undefined,
+  label: string,
+  timeoutMs = 30_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await read();
+    if (value !== undefined) {
+      return value;
+    }
+    await sleep(50);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+// Only the external model HTTP boundary is simulated. The shared Responses
+// writer supplies the same wire protocol used by other actual-Gateway tests.
+export async function startHeldSlackModelProvider() {
+  let release!: () => void;
+  const rootGate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let released = false;
+  let rootClosed = false;
+  const requests: Array<{ input: string; model: unknown; root: boolean; followup: boolean }> = [];
+  const active = new Set<Promise<void>>();
+  const errors: string[] = [];
+  const server = createServer((request, response) => {
+    const work = (async () => {
+      if (request.method === "GET" && request.url === "/v1/models") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ data: [{ id: "gpt-5.6-luna", object: "model" }] }));
+        return;
+      }
+      assert.equal(request.method, "POST");
+      assert.equal(request.url, "/v1/responses");
+      const chunks: Buffer[] = [];
+      let bytes = 0;
+      for await (const chunk of request) {
+        const buffer = Buffer.from(chunk);
+        bytes += buffer.length;
+        assert.ok(bytes <= 16 * 1024 * 1024, "Provider request exceeded fixture bound");
+        chunks.push(buffer);
+      }
+      const body = asNonArrayRecord(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+      const input = JSON.stringify(body.input);
+      const entry = {
+        input,
+        model: body.model,
+        root: input.includes(SLACK_INFLIGHT_ROOT_TEXT),
+        followup: input.includes(SLACK_INFLIGHT_FOLLOWUP_TEXT),
+      };
+      requests.push(entry);
+      assert.ok(requests.length <= 10, "Unexpected model retry loop");
+      assert.ok(entry.root || entry.followup, "Unexpected fixture model request");
+      if (requests.length === 1) {
+        assert.ok(entry.root && !entry.followup, "Root must reach the model first");
+        response.once("close", () => {
+          rootClosed = true;
+        });
+        await rootGate;
+      }
+      if (response.destroyed) {
+        return;
+      }
+      writeOpenAiResponsesText(response, {
+        text: entry.followup ? SLACK_INFLIGHT_FOLLOWUP_REPLY : SLACK_INFLIGHT_ROOT_REPLY,
+        messageId: `msg_${randomUUID()}`,
+        responseId: `resp_${randomUUID()}`,
+      });
+    })().catch((error: unknown) => {
+      errors.push(error instanceof Error ? error.message : String(error));
+      response.destroy(error instanceof Error ? error : new Error(String(error)));
+    });
+    active.add(work);
+    void work.finally(() => active.delete(work));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    requests,
+    errors,
+    get rootHeld() {
+      return requests.length > 0 && !released && !rootClosed;
+    },
+    releaseRoot() {
+      released = true;
+      release();
+    },
+    async stop() {
+      released = true;
+      release();
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+      await Promise.all(active);
+    },
+  };
+}


### PR DESCRIPTION
Closes #139152.

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where users adding an unmentioned clarification to a Slack thread would have it skipped while an accepted, explicitly mentioned human request was still running before the bot's first reply.

## Why This Change Was Made

Use the existing active Slack publisher lifetime as temporary thread participation for accepted human requests. Queued follow-ups retain that eligibility while owned work remains; success and failure release it through the existing dispatch lifecycle. Delivered-reply participation is persisted only after actual delivery.

Existing explicit-mention settings, sender restrictions, and thread/account/monitor boundaries remain authoritative. Bot messages and control/abort inputs cannot establish temporary participation, and human work does not implicitly admit bots. No new configuration, scheduler, retry loop, or persistent store is added.

## User Impact

Users can add same-thread clarifications during accepted work before the first bot reply without repeating the mention. A thread with no delivered reply and no remaining eligible work does not stay implicitly open.

This extends the documented admission policy to accepted in-flight human work. Maintainer acceptance of that behavior remains required; no previously working release is claimed.

## Evidence

Final candidate: 9598c5da9ea5660306a874c57cb77a168759cbcf. The runtime implementation is unchanged from `135b24695aa3f163b18718034f411ff8611e9a57`; the final commit adds the actual-Gateway regression and its HTTP fixture. Executed runtime-owner and test-file hashes match this candidate.

- **357 owner/integrated tests passed**, plus **1 actual-Gateway E2E scenario**. The E2E's focused typecheck and lint pass; fresh P0-P2 review found no actionable defect.
- The complete nine-file changed-check gate and hosted CI passed on the preceding implementation head. The two new E2E files have separate focused checks, and the final head gets fresh hosted CI.
- The base includes the official subagent synchronization repair from #133808; no timeout increase was introduced.
- Before-fix evidence uses the existing in-process handler test: replacing the four changed production owners with current-main versions yields **1 failure / 3 passes** at unmentioned follow-up admission. Restoring the candidate yields **4 passes**, with exact owner hashes restored. This is not presented as a separate baseline Gateway run.

### Actual Gateway proof

Used the repository's existing `createQaGatewayChild` and Crabline Slack adapter. A real child Gateway loads the packaged Slack plugin and runs its real HTTP ingress, preparation, dispatch, core agent/session processing, and final Web API client. The external Slack API and model Responses HTTP service are controlled simulations; core dispatch is not mocked. Mention requirements are explicitly enabled, and streaming is off.

```text
1. Submit the mentioned human root through signed POST /slack/events.
2. Hold its first actual model HTTP response; visible Slack posts = 0.
3. Submit the unmentioned human follow-up to the same thread.
4. Observe its exact message timestamp in the real post-mention-gate
   preparation receipt while the model response is still held and posts = 0.
5. Release the model response.
6. Observe a second actual model HTTP request containing the follow-up text.
7. Observe one root reply and one follow-up reply, both in the same thread.
8. Read conversations.replies from the Slack simulator and verify both
   stored replies and their thread timestamps.
9. Stop the Gateway and both fixture services; cleanup completed.
```

The final fixture run passed in 68.61 seconds. The independent child PID was confirmed exited after cleanup. Public proof retains source hashes, receipt/ordering facts, request-marker booleans, reply markers, and readback results; it excludes configuration, authentication values, and full model prompts.

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/e2e/qa-lab/runtime/slack-inflight-gateway.e2e.test.ts
```

The earlier integrated tests additionally cover explicit-mention opt-out, another thread, overlapping publishers, actual persisted participation after delivery, and failure cleanup without leaving a thread implicitly open.

All messages and identifiers are synthetic. This is an isolated actual-Gateway test with simulated external HTTP services, not a real Slack workspace or live model-provider run. No production runtime was changed. Maintainer acceptance of the expanded in-flight admission policy remains open.
