### PR TITLE
improve: release captured audio cache leases directly

### DIFF
--- a/ui/src/pages/chat/components/chat-audio-waveform.test.ts
+++ b/ui/src/pages/chat/components/chat-audio-waveform.test.ts
@@ -5,6 +5,7 @@ import {
   canDecodeChatAudioWaveform,
   CHAT_AUDIO_WAVEFORM_MAX_BYTES,
   computeChatAudioWaveformPeaks,
+  retainCachedChatAudioBlob,
   shouldFetchChatAudioWaveform,
 } from "./chat-audio-waveform.ts";
 
@@ -67,7 +68,7 @@ describe("chat audio waveform", () => {
     expect(peaks).toEqual([0.25, 1]);
   });
 
-  it("declines a new Blob when all 32 cache entries are retained", () => {
+  it("enforces the entry cap until the last lease releases an evictable Blob", () => {
     const releases: Array<() => void> = [];
     for (let index = 0; index < 32; index += 1) {
       const retained = cacheAndRetainChatAudioBlob(`retained-${index}`, {
@@ -87,6 +88,26 @@ describe("chat audio waveform", () => {
         sizeBytes: 1,
       }),
     ).toBeNull();
+
+    const shared = retainCachedChatAudioBlob("retained-0");
+    expect(shared).not.toBeNull();
+    releases[0]!();
+    releases[0]!();
+    expect(
+      cacheAndRetainChatAudioBlob("retained-overflow", {
+        blobUrl: "blob:retained-overflow",
+        sizeBytes: 1,
+      }),
+    ).toBeNull();
+
+    shared!.release();
+    const replacement = cacheAndRetainChatAudioBlob("retained-after-release", {
+      blobUrl: "blob:retained-after-release",
+      sizeBytes: 1,
+    });
+    expect(replacement).not.toBeNull();
+    expect(retainCachedChatAudioBlob("retained-0")).toBeNull();
+    replacement?.release();
 
     for (const release of releases) {
       release();

--- a/ui/src/pages/chat/components/chat-audio-waveform.ts
+++ b/ui/src/pages/chat/components/chat-audio-waveform.ts
@@ -80,22 +80,6 @@ export function computeChatAudioWaveformPeaks(
   return maximum > 0 ? peaks.map((peak) => peak / maximum) : peaks;
 }
 
-function trimChatAudioBlobCache(): void {
-  while (
-    chatAudioBlobCache.size > CHAT_AUDIO_BLOB_CACHE_MAX_ENTRIES ||
-    [...chatAudioBlobCache.values()].reduce((total, entry) => total + entry.sizeBytes, 0) >
-      CHAT_AUDIO_BLOB_CACHE_MAX_BYTES
-  ) {
-    const evictable = [...chatAudioBlobCache].find(([, entry]) => entry.retainCount === 0);
-    if (!evictable) {
-      return;
-    }
-    const [cacheKey, entry] = evictable;
-    chatAudioBlobCache.delete(cacheKey);
-    URL.revokeObjectURL(entry.blobUrl);
-  }
-}
-
 function makeRoomForChatAudioBlob(sizeBytes: number): boolean {
   if (sizeBytes > CHAT_AUDIO_BLOB_CACHE_MAX_BYTES) {
     return false;
@@ -117,10 +101,10 @@ function makeRoomForChatAudioBlob(sizeBytes: number): boolean {
   return true;
 }
 
-function retainChatAudioBlobEntry(
-  cacheKey: string,
-  entry: ChatAudioBlobCacheEntry,
-): { value: CachedChatAudioBlob; release: () => void } {
+function retainChatAudioBlobEntry(entry: ChatAudioBlobCacheEntry): {
+  value: CachedChatAudioBlob;
+  release: () => void;
+} {
   entry.retainCount += 1;
   let released = false;
   return {
@@ -130,11 +114,9 @@ function retainChatAudioBlobEntry(
         return;
       }
       released = true;
-      const current = chatAudioBlobCache.get(cacheKey);
-      if (current && current.retainCount > 0) {
-        current.retainCount -= 1;
-      }
-      trimChatAudioBlobCache();
+      // Insertion enforces both cache caps and never evicts a retained entry.
+      // Release only makes this exact entry eligible for a later insertion.
+      entry.retainCount -= 1;
     },
   };
 }
@@ -148,7 +130,7 @@ export function retainCachedChatAudioBlob(
   }
   chatAudioBlobCache.delete(cacheKey);
   chatAudioBlobCache.set(cacheKey, entry);
-  return retainChatAudioBlobEntry(cacheKey, entry);
+  return retainChatAudioBlobEntry(entry);
 }
 
 export function cacheAndRetainChatAudioBlob(
@@ -168,5 +150,5 @@ export function cacheAndRetainChatAudioBlob(
   }
   const entry = { ...value, retainCount: 0 };
   chatAudioBlobCache.set(cacheKey, entry);
-  return retainChatAudioBlobEntry(cacheKey, entry);
+  return retainChatAudioBlobEntry(entry);
 }


### PR DESCRIPTION
## What Problem This Solves

Releasing each chat audio player traversed the entire waveform Blob cache to check for overflow, even though insertion already enforced both cache limits and release could only lower its retained count.

## Why This Change Was Made

The cache now releases the exact captured entry under its existing idempotence guard. Unreachable release-time trimming, a map relookup, and a redundant cache-key argument are removed. Insertion remains the sole owner of the 32-entry/48 MiB limits and only evicts entries with no active leases.

## User Impact

Shared audio playback and waveform reuse behave the same with less temporary work when players disconnect or change source. Production is 18 lines smaller; the existing lease test adds 21 net lines.

## Evidence

- 22 audio-cache/player tests passed. Six actual-owner scenarios covered both caps, duplicate insertion, shared leases, duplicate release, final-release eviction, and old released handles after key reinsertion.
- A deterministic 1,000-release probe reduced cache values-array scans from 1,000 to zero. Across 32,000 sampled releases, owner-attributed allocation was 11,993,224 → 2,568 bytes; this is approximate Node allocation sampling, not browser retained-memory measurement.
- Real Chromium before/after proof used actual Control UI audio components, native fetch/Web Audio decode, and a synthetic 12-second WAV. Both arms rendered 96 waveform bars, played and sought, coordinated shared players, kept the survivor playing after sibling removal, and remounted another player with one total waveform fetch.
- Managed P0–P2 review, formatting, and diff checks passed. Browser proof uses isolated source-component mounting, not full application boot or a live Gateway; no browser latency/RSS improvement is claimed. Current-head CI is publisher-owned.


Before/after: actual Control UI audio player, synthetic 12-second WAV, playing after seeking. These images show preserved behavior; the allocation measurement above comes from the separate owner probe.

| Before | After |
| --- | --- |
| ![Before: playing and seeked](https://github.com/user-attachments/assets/b36d8727-8195-4806-9b53-5bbb1a8cb793) | ![After: playing and seeked](https://github.com/user-attachments/assets/3b5ab7f9-480a-4439-8613-723aceef6be9) |
