### PR TITLE
test(agents): give the sibling-drain completion wait a tolerance on slow runners

### DIFF
--- a/src/agents/subagents/spawn/subagent-spawn.authority.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.authority.test.ts
@@ -113,7 +113,11 @@ describe("pending spawn invocation authority", () => {
         stream: "lifecycle",
         data: { phase: "end", endedAt: Date.now() },
       });
-      await vi.waitFor(() => expect(findTaskByRunId("b")?.status).toBe("succeeded"));
+      // The lifecycle end settles through root-work admission plus SQLite persistence;
+      // on a two-CPU hosted runner that chain exceeds vi.waitFor's 1s default.
+      await vi.waitFor(() => expect(findTaskByRunId("b")?.status).toBe("succeeded"), {
+        timeout: 15_000,
+      });
       clearAgentRunContext("b");
       await settleSubagentRegistryPersistenceWork();
       expect(completedB).toMatchObject({


### PR DESCRIPTION
## What Problem This Solves

`src/agents/subagents/spawn/subagent-spawn.authority.test.ts` fails on every fork pull request today in the `checks-node-compact-small-11` shard (`agentic-agents-core-isolated`), which turns `openclaw/ci-gate` red for unrelated changes:

```
FAIL  src/agents/subagents/spawn/subagent-spawn.authority.test.ts > pending spawn invocation authority > stops a fresh spawn below a completed persistent sibling while a sibling drain remains pending
AssertionError: expected 'running' to be 'succeeded' // Object.is equality
```

The same shard passes on `main` and on repository-branch PRs. Fork PRs run this shard on two-CPU hosted runners, where the lifecycle-end completion chain (`completeSubagentRunWithRecovery` under `runWithGatewayIndependentRootWorkContinuation`, then `safeFinalizeSubagentTaskRun` and SQLite persistence) takes longer than the 1 s default `vi.waitFor` timeout on the first `it.each` case. The nested-sibling case that runs second passes in about 1.5 s.

Introduced by #138910 (the lifecycle-end emission plus the default-timeout `vi.waitFor` assertion); #138059 moved the file into the isolated shard. Maintainer analysis reproducing the failure on the parent commit without any PR code: https://github.com/openclaw/openclaw/pull/139089#issuecomment-5552515644

## Why This Change Was Made

The assertion waits on real asynchronous work owned by the registry completion runtime, so the bound is a tolerance on a timing-dependent value, not a contract. The sibling boundary test already uses the same tolerance for the same class of wait (`subagent-spawn.production-boundary.test.ts:274`, `{ timeout: 15_000 }`). The assertion itself is unchanged: the task must still settle to `succeeded`.

## User Impact

CI only. No runtime behavior changes. Fork pull requests stop failing `checks-node-compact-small-11` and `openclaw/ci-gate` on an assertion unrelated to their change, and maintainers stop needing `landpr-approve-unrelated-red` for this shard.

## Evidence

Fork PR runs from 2026-09-05 with the identical failure, all on heads that do not touch this test or the registry:

- #139089 (Browser UI), run 33970832010, job 101319169150; landed by a maintainer with an unrelated-red approval.
- #139117 (Docker), run 33970961594, job 101319504519.
- #137351 (Doctor), run 33970977504, job 101319489534.
- #139143, #138386, #137594, and a third-party fork PR (#139142) hit the same job in the same window, while `main` runs 33969885902, 33970296274, 33970630278, and 33971109206 passed the shard.

Local reproduction on a 16-core host pinned to two CPUs with two workers, before the change (same file, same assertion, same shard runner):

```
taskset -c 0,1 env OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run src/agents/subagents/spawn/subagent-spawn.authority.test.ts
FAIL  ... > stops a fresh spawn below a completed persistent sibling while a sibling drain remains pending
AssertionError: expected 'running' to be 'succeeded'
Tests  1 failed | 5 passed (6)
```

Same command after the change, on `114ceb86` (this PR head), same host, same two-CPU pin and two workers; the first case now waits about 12 s for the completion chain, the second settles in about 1.2 s, and the file passes:

```
taskset -c 0,1 env OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run src/agents/subagents/spawn/subagent-spawn.authority.test.ts
✓ |agents-core-isolated| src/agents/subagents/spawn/subagent-spawn.authority.test.ts > pending spawn invocation authority > stops a fresh spawn below a completed persistent sibling while a sibling drain remains pending 13133ms
✓ |agents-core-isolated| src/agents/subagents/spawn/subagent-spawn.authority.test.ts > pending spawn invocation authority > stops a fresh spawn below a completed persistent sibling while a nested sibling drain remains pending 1237ms
✓ |agents-core-isolated| src/agents/subagents/spawn/subagent-spawn.authority.test.ts > pending spawn invocation authority > preserves child ownership when the parent closes after registration: complete
✓ |agents-core-isolated| src/agents/subagents/spawn/subagent-spawn.authority.test.ts > pending spawn invocation authority > preserves child ownership when the parent closes after registration: abort
✓ |agents-core-isolated| src/agents/subagents/spawn/subagent-spawn.authority.test.ts > pending spawn invocation authority > preserves child ownership when the parent closes after registration: abort during registration
✓ |agents-core-isolated| src/agents/subagents/spawn/subagent-spawn.authority.test.ts > pending spawn invocation authority > cancels the task's captured row when delayed acceptance rekeys it during the drain
      Tests  6 passed (6)
   Duration  42.40s (transform 18.64s, setup 976ms, import 23.64s, tests 17.50s, environment 0ms)
```

The 12 s on the first case is dominated by lazy runtime loading on a cold worker (the run reports 23.6 s of import time across the file); the second case, on the warm worker, settles in about 1.2 s. The 15 s tolerance sits under the 120 s per-test budget (`test/vitest/vitest.timeouts.ts`, `DEFAULT_VITEST_TEST_TIMEOUT_MS`). The exact-head CI run for this PR passed the selected lanes.

Formatting: `node_modules/.bin/oxfmt --check src/agents/subagents/spawn/subagent-spawn.authority.test.ts` passes. Test-only change; no production LOC.

