### PR TITLE
improve: retain unchanged forwarded avatar publications

### DIFF
--- a/ui/src/pages/chat/chat-avatar-publication.test.ts
+++ b/ui/src/pages/chat/chat-avatar-publication.test.ts
@@ -1,0 +1,118 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { nothing, render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setAvatarGatewayOrigin } from "../../lib/identity-avatar-context.ts";
+import { invalidateChatAvatarCache, refreshSenderAgentAvatars } from "./chat-avatar.ts";
+import { makeChatHost } from "./chat-host.test-support.ts";
+import { createTestTranscript } from "./chat-view.test-helpers.ts";
+import * as chatMessage from "./components/chat-message.ts";
+import { renderChatThread } from "./components/chat-thread.ts";
+import {
+  installTranscriptDomMocks,
+  resetTranscriptTestDom,
+  threadProps,
+} from "./components/chat-transcript.test-support.ts";
+
+describe("forwarded avatar publication", () => {
+  beforeEach(installTranscriptDomMocks);
+  afterEach(() => {
+    setAvatarGatewayOrigin(null);
+    resetTranscriptTestDom();
+  });
+
+  it.each(["append", "reorder", "identity refresh"])(
+    "keeps settled rows idle after %s and publishes revised avatars",
+    async (change) => {
+      const now = vi.spyOn(Date, "now").mockReturnValue(60_000);
+      setAvatarGatewayOrigin("https://gateway.example.test", ["test-token"]);
+      vi.spyOn(globalThis, "fetch").mockImplementation(
+        async () =>
+          new Response(new Uint8Array([1, 2, 3]), { headers: { "content-type": "image/png" } }),
+      );
+      let imageSequence = 0;
+      let avatarRevision = 1;
+      vi.spyOn(URL, "createObjectURL").mockImplementation(() => `blob:avatar-${imageSequence++}`);
+      const messages = ["research", "planner"].map((agentId, index) => ({
+        role: "assistant",
+        content: `${agentId} report`,
+        timestamp: index + 1,
+        senderSession: { agentId, sessionKey: `agent:${agentId}:source` },
+        __openclaw: { id: `report-${agentId}` },
+      }));
+      const host = {
+        ...makeChatHost({
+          sessionKey: "agent:main:main",
+          chatMessages: messages,
+          requestHandlers: {
+            "agent.identity.get": ({ agentId }: { agentId: string }) => ({
+              agentId,
+              avatar: `/avatar/${agentId}?v=${avatarRevision}`,
+            }),
+          },
+        }),
+        agentsList: { agents: [{ id: "main" }, { id: "research" }, { id: "planner" }] },
+        senderAgentAvatars: undefined as ReadonlyMap<string, string | null> | undefined,
+        requestUpdate: vi.fn(),
+      };
+      const props = {
+        ...threadProps(`avatar-${change}`, host.sessionKey, host.chatMessages),
+        currentAgentId: "main",
+        agents: host.agentsList.agents,
+        senderAgentAvatars: host.senderAgentAvatars,
+      };
+      const transcript = createTestTranscript();
+      const container = document.body.appendChild(document.createElement("div"));
+      const rerender = () => {
+        props.messages = host.chatMessages;
+        props.senderAgentAvatars = host.senderAgentAvatars;
+        render(renderChatThread(props, transcript), container);
+      };
+      try {
+        await refreshSenderAgentAvatars(host);
+        rerender();
+        const researchRow = expectDefined(
+          container.querySelector('[data-entry-id="report-research"]'),
+          "forwarded report",
+        );
+        const image = researchRow.closest(".chat-group")?.querySelector("img");
+        expect(image?.getAttribute("src")).toBe("blob:avatar-0");
+
+        host.chatMessages =
+          change === "append"
+            ? [...messages, { role: "user", content: "Continue", timestamp: 3 }]
+            : [...messages].toReversed();
+        if (change === "identity refresh") {
+          now.mockReturnValue(120_001);
+        }
+        // Commit the transcript first, just as the pane does before its avatar refresh.
+        rerender();
+        const renderGroup = vi.spyOn(chatMessage, "renderMessageGroup");
+        host.requestUpdate.mockClear();
+        await refreshSenderAgentAvatars(host);
+        rerender();
+
+        expect(renderGroup.mock.calls.length).toBe(0);
+        expect(host.requestUpdate).not.toHaveBeenCalled();
+        expect(container.querySelector('[data-entry-id="report-research"]')).toBe(researchRow);
+        expect(image?.getAttribute("src")).toBe("blob:avatar-0");
+        expect(host.request).toHaveBeenCalledTimes(change === "identity refresh" ? 4 : 2);
+
+        avatarRevision += 1;
+        now.mockReturnValue(180_002);
+        host.chatMessages = [...host.chatMessages];
+        rerender();
+        renderGroup.mockClear();
+        await refreshSenderAgentAvatars(host);
+        rerender();
+        expect(image?.getAttribute("src")).toBe(host.senderAgentAvatars?.get("research"));
+        expect(image?.getAttribute("src")).not.toBe("blob:avatar-0");
+        expect(renderGroup.mock.calls.length).toBeGreaterThan(0);
+        expect(host.requestUpdate).toHaveBeenCalledOnce();
+      } finally {
+        render(nothing, container);
+        transcript.hostDisconnected();
+        invalidateChatAvatarCache(host);
+      }
+    },
+  );
+});

--- a/ui/src/pages/chat/chat-avatar.ts
+++ b/ui/src/pages/chat/chat-avatar.ts
@@ -432,32 +432,22 @@ async function loadSenderAgentAvatars(host: ChatAvatarHost, agentIds: readonly s
   const roster = new Set(agents?.map((agent) => agent.id));
   // Bound forwarded-agent work independently of transcript size.
   const ids = [...new Set(agentIds)]
-    .filter((id) => id !== agentId && roster.has(id))
+    .filter((id) => host.connected && id !== agentId && roster.has(id))
     .slice(0, CHAT_AVATAR_CACHE_LIMIT - 1);
-  if (!host.connected || ids.length === 0) {
-    const references = chatAvatarReferences.get(host);
-    for (const [key, release] of references ?? []) {
-      if (key !== currentAvatarReference) {
-        release();
-        references?.delete(key);
-      }
-    }
-    if (host.senderAgentAvatars?.size) {
-      host.senderAgentAvatars = new Map();
-      host.requestUpdate?.();
-    }
-    return;
-  }
   const previousAvatars = host.senderAgentAvatars;
-  const snapshots = await Promise.all(ids.map((id) => loadChatAvatarSnapshot(host, id)));
+  // Empty/disconnected batches clear synchronously; only awaited loads need the stale fence.
+  const snapshots = ids.length
+    ? await Promise.all(ids.map((id) => loadChatAvatarSnapshot(host, id)))
+    : [];
   if (
-    !host.connected ||
-    host.client !== client ||
-    host.connectionEpoch !== epoch ||
-    host.agentsList?.agents !== agents ||
-    host.sessionKey !== sessionKey ||
-    resolveAgentIdForSession(host) !== agentId ||
-    senderAvatarRequests.get(host) !== request
+    ids.length &&
+    (!host.connected ||
+      host.client !== client ||
+      host.connectionEpoch !== epoch ||
+      host.agentsList?.agents !== agents ||
+      host.sessionKey !== sessionKey ||
+      resolveAgentIdForSession(host) !== agentId ||
+      senderAvatarRequests.get(host) !== request)
   ) {
     for (const snapshot of snapshots) {
       snapshot?.release();
@@ -471,7 +461,7 @@ async function loadSenderAgentAvatars(host: ChatAvatarHost, agentIds: readonly s
       references?.delete(key);
     }
   }
-  host.senderAgentAvatars = new Map(
+  const avatars = new Map(
     ids.map((id, index) => {
       const snapshot = snapshots[index];
       if (snapshot) {
@@ -480,7 +470,14 @@ async function loadSenderAgentAvatars(host: ChatAvatarHost, agentIds: readonly s
       return [id, snapshot ? snapshot.url : (previousAvatars?.get(id) ?? null)];
     }),
   );
-  host.requestUpdate?.();
+  // Leases and identity TTL refresh independently; unchanged URLs keep settled rows memoized.
+  if (
+    avatars.size !== (previousAvatars?.size ?? 0) ||
+    [...avatars].some(([id, url]) => previousAvatars?.get(id) !== url)
+  ) {
+    host.senderAgentAvatars = avatars;
+    host.requestUpdate?.();
+  }
 }
 
 export async function refreshChatAvatar(host: ChatAvatarHost) {


### PR DESCRIPTION
## What Problem This Solves

Appending or reordering chat messages triggered another render of settled transcript rows when forwarded-agent avatar refreshes returned the same images. The same redundant update occurred after identity metadata expired but avatar URLs stayed unchanged.

## Why This Change Was Made

The avatar loader now publishes a new sender map only when its ID-to-URL associations change. Image lease exchange and identity TTL refresh still run independently. Empty/disconnected cleanup shares the same flow while remaining synchronous, and asynchronous results retain the existing session/client/epoch/roster/request fences.

## User Impact

Unchanged forwarded-agent images no longer invalidate settled chat rows. New avatar revisions and removals still update the view, while failed image replacements retain the prior image. Production is 3 lines smaller; the rendered regression fixture adds 118 test lines.

## Evidence

- Three regression cases failed on original production source and passed after the change: append, reorder, and expired identity metadata with unchanged images. Extra row renders fell from 3/2/2 to 0/0/0. Each case then changed the image revision and verified a real update still occurred.
- 110 owner/sibling tests passed; final strengthened regression cases also passed. Managed P0–P2 review, formatting, and diff checks passed.
- Real Chromium before/after proof rendered actual transcript and avatar components with synthetic identity RPC and native PNG fetch/decode. Both arms made the same cumulative identity requests (2, 2, 2, 4, 6, 6). The candidate suppressed map publication for append/reorder/unchanged-image TTL, then published changed images and removal once each.
- This demonstrates eliminated rendering/publication work, not a measured browser memory or latency improvement. The browser fixture uses actual source components rather than full application/Gateway boot; current-head CI is publisher-owned.


Before/after: actual transcript components after an identity TTL refresh with unchanged images. Synthetic identities and PNGs are used; the candidate keeps the same rendered content while suppressing the extra avatar-map publication and host update.

| Before | After |
| --- | --- |
| ![Before: unchanged-image TTL refresh publishes](https://github.com/user-attachments/assets/680cf6ac-f2c7-4ec1-af9e-500b476c8b0e) | ![After: unchanged-image TTL refresh stays idle](https://github.com/user-attachments/assets/bd1fcd6a-f1a2-4696-aa9d-dfe7ccfede14) |
