### PR TITLE
fix(skills): validate names in library forms

### DIFF
--- a/ui/src/e2e/skills-library.e2e.test.ts
+++ b/ui/src/e2e/skills-library.e2e.test.ts
@@ -44,6 +44,34 @@ async function expectLibraryDialogOpen(page: Page) {
   expect(await dialog.isVisible()).toBe(true);
 }
 
+async function expectSkillNameValidation(page: Page) {
+  const input = page.getByLabel("Skill name", { exact: true });
+  await input.hover();
+  await page
+    .locator("openclaw-tooltip[open] .tooltip-content")
+    .getByText("Use 1–63 lowercase letters, digits, or hyphens; start with a letter or digit.", {
+      exact: true,
+    })
+    .waitFor({ state: "visible" });
+  for (const [name, valid] of [
+    ["a", true],
+    ["0", true],
+    ["a--", true],
+    ["a".repeat(63), true],
+    ["", false],
+    ["UPPER", false],
+    ["has space", false],
+    ["under_score", false],
+    ["é", false],
+    ["-leading", false],
+  ] as const) {
+    await input.fill(name);
+    expect(await input.evaluate((element: HTMLInputElement) => element.checkValidity()), name).toBe(
+      valid,
+    );
+  }
+}
+
 suite.define(() => {
   it("keeps workspace creation for a solo shared-token admin with many channel identities", async () => {
     await suite.withPage({}, async ({ page }) => {
@@ -113,6 +141,11 @@ suite.define(() => {
       });
       await page.goto(`${suite.server.baseUrl}skills`);
       await page.getByRole("button", { name: "Create skill", exact: true }).click();
+      await expectSkillNameValidation(page);
+      await page.getByLabel("Skill name", { exact: true }).fill("a".repeat(64));
+      expect(await page.getByLabel("Skill name", { exact: true }).inputValue()).toBe(
+        "a".repeat(63),
+      );
       await page.getByLabel("Skill name", { exact: true }).fill("release-notes");
       await page.getByLabel("SKILL.md", { exact: true }).fill(own.content);
       await page.getByLabel("SKILL.md", { exact: true }).press("Control+Enter");
@@ -320,6 +353,13 @@ suite.define(() => {
       });
       await page.goto(`${suite.server.baseUrl}skills`);
       await page.getByRole("button", { name: "Import skill", exact: true }).click();
+      await expectSkillNameValidation(page);
+      await page.getByLabel("Skill name", { exact: true }).fill("a".repeat(64));
+      expect(
+        await page
+          .getByLabel("Skill name", { exact: true })
+          .evaluate((element: HTMLInputElement) => element.checkValidity()),
+      ).toBe(false);
       await page.getByLabel("Skill name", { exact: true }).fill("checklist");
       await page.locator('input[name="library-import-files"]').setInputFiles([
         { name: "SKILL.md", mimeType: "text/markdown", buffer: Buffer.from(own.content) },

--- a/ui/src/i18n/locales/en-skill-library.ts
+++ b/ui/src/i18n/locales/en-skill-library.ts
@@ -16,6 +16,7 @@ const enSkillLibrary = {
     propose: "Save workspace proposal",
     apply: "Apply to workspace",
     slug: "Skill name",
+    slugHelp: "Use 1–63 lowercase letters, digits, or hyphens; start with a letter or digit.",
     description: "Description",
     file: "File",
     newFile: "New text file path",

--- a/ui/src/pages/skills/library-view.ts
+++ b/ui/src/pages/skills/library-view.ts
@@ -274,8 +274,9 @@ function renderLibraryEditor(library: SkillLibraryController) {
           ><input
             class="settings-input"
             name="library-slug"
+            title=${t("skillLibrary.slugHelp")}
             required
-            pattern="[a-z0-9][a-z0-9-]{0,62}"
+            pattern="[a-z0-9][a-z0-9\\-]{0,62}"
             maxlength="63"
             ?disabled=${disabled}
             .value=${live(draft.slug)}
@@ -580,7 +581,8 @@ function renderLibraryImport(library: SkillLibraryController) {
             class="settings-input"
             required
             name="library-import-slug"
-            pattern="[a-z0-9][a-z0-9-]{0,62}"
+            title=${t("skillLibrary.slugHelp")}
+            pattern="[a-z0-9][a-z0-9\\-]{0,62}"
             .value=${library.importSlug}
             ?disabled=${library.busy}
             @input=${(event: Event) => {


### PR DESCRIPTION
Closes #139183

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Fixes an issue where users entering an invalid skill name in **Plugins → Skills** could submit it or advance from local import into the editor without the browser asking them to correct the name.

## Why This Change Was Made

HTML patterns compile in Unicode Sets (`v`) mode, where the unescaped literal hyphen made both existing patterns invalid. Escape that hyphen through the Lit template so native validation enforces the existing backend grammar: one to 63 lowercase letters, digits, or hyphens, starting with a lowercase letter or digit. One owner-local English help string and two title bindings explain the existing grammar through the shared tooltip. Production is +5/-2 (net +3), justified by actionable validation guidance without another validator; existing browser scenarios gain 40 test lines.

## User Impact

Invalid names are rejected at the field before save or import proceeds, and hovering the name field explains the required format. Valid names, including names with repeated or trailing hyphens and 63-character names, retain the existing behavior. Gateway validation, permissions, persistence, configuration, and public name policy are unchanged.

## Evidence

Before the production edit, the existing editor and importer browser scenarios both failed their new native-validity assertion on `UPPER`: two failed, five passed. After the repair, all seven pass in the original order.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/skills-library.e2e.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- ui/src/pages/skills/library-view.ts ui/src/e2e/skills-library.e2e.test.ts ui/src/i18n/locales/en-skill-library.ts
pnpm ui:i18n:baseline
```

The full classified changed gate passed, including core-test and UI typechecks, formatting, i18n, all three dead-export scans, lint, styles, and required guards. The keyless English-source i18n baseline passed without generated-file changes. Fresh final P2 Codex review and the independent peer review found no actionable issues. A separate direct read-only review of committed head `1e785ff709e0c64344f25e4fe7c7f512e079376f` is also verified clean; its source fingerprint matches the tested patch. [Exact-head CI33975062324](https://github.com/openclaw/openclaw/actions/runs/33975062324) completed successfully.

Independent real Chromium proof exercised both forms through the bundled Control UI with synthetic Gateway data. It covered lowercase letters, a leading digit, repeated/trailing hyphens, 63 characters, empty input, uppercase, spaces, underscores, a leading hyphen, and non-ASCII input. The editor still caps entered names at 63 characters; the importer now rejects 64 characters. Both forms visibly display the exact grammar through the existing shared tooltip. That owner temporarily clears active native titles; the tests assert the visible guidance rather than a transient attribute. Invalid editor Save emits no Gateway request after the fix, and invalid local-file import remains in its form.

The before editor's server error was explicitly mocked; this proves browser submission, not live Gateway error wording or persistence. The importer transition and native validity states were exercised directly in Chromium. No model/provider or operator state was used.

Both before/after pairs below use synthetic data. The before editor error is an explicitly mocked Gateway rejection; the before importer has already advanced to the editor. The after views show browser rejection and the shared naming hint.

| Form | Before | After |
| --- | --- | --- |
| Editor | ![Editor submits an invalid name](https://github.com/user-attachments/assets/cf6bcb98-f804-4d80-b963-f2be197d98f9) | ![Editor rejects the invalid name and shows the naming rule](https://github.com/user-attachments/assets/d2df7ac4-4f96-4805-bd3b-9cdaa7f9f11c) |
| Importer | ![Importer advances with an invalid name](https://github.com/user-attachments/assets/d61f0522-e5e9-4542-a496-69d17427281a) | ![Importer rejects the invalid name and shows the naming rule](https://github.com/user-attachments/assets/32ea53b5-b3cc-4259-83ff-f85d67e17b41) |

The [HTML pattern contract](https://html.spec.whatwg.org/multipage/input.html#the-pattern-attribute) and [skill authoring guide](https://docs.openclaw.ai/tools/creating-skills) define the unchanged behavior. Both invalid patterns also occur in stable `v2026.9.1`; runtime evidence is pinned to main `0f54c8698228fc1c7564db4e0a1a21819cba9be5`.


The [initial ClawSweeper review](https://github.com/openclaw/openclaw/pull/139184#issuecomment-5552885352) found no code or security issue. Its sole pre-merge item was independent access to the screenshots and HTML standard, which DNS failures prevented in that review environment. This is addressed: the HTML pattern contract was directly inspected, and the maintainer and implementation reviewer inspected every full-frame synthetic capture shown above. The images show both the rejected invalid input and the existing shared tooltip's naming rule; no source change was needed for that review-environment limitation.
