### PR TITLE
perf(gateway): avoid redundant PR landing ancestry checks

### DIFF
--- a/src/gateway/control-ui-session-prs-landing.test.ts
+++ b/src/gateway/control-ui-session-prs-landing.test.ts
@@ -109,6 +109,7 @@ describe("resolveBranchLanding", () => {
   it("selects the newest of three related baselines via the batched path", async () => {
     // Linear chain: fork point (merge base) -> merged head 1 -> merged head 2
     // -> HEAD; the maximal published baseline is merged head 2.
+    const base = await sha("HEAD");
     await git("checkout", "-b", "feature");
     await fs.appendFile(path.join(root, "a.txt"), "two\n");
     await git("add", "a.txt");
@@ -122,6 +123,7 @@ describe("resolveBranchLanding", () => {
     await git("add", "c.txt");
     await git("commit", "-m", "follow-up");
     await git("update-ref", "refs/remotes/origin/feature", "HEAD");
+    const runGit = vi.spyOn(worktreeGit, "runGit");
 
     const landing = await resolveBranchLanding(root, {
       branch: "feature",
@@ -134,5 +136,6 @@ describe("resolveBranchLanding", () => {
 
     expect(landing.statsBase).toBe(head2);
     expect(landing.hasLandedPullRequest).toBe(true);
+    expect(runGit).not.toHaveBeenCalledWith(root, ["merge-base", "--is-ancestor", base, head2]);
   });
 });

--- a/src/gateway/control-ui-session-prs-landing.ts
+++ b/src/gateway/control-ui-session-prs-landing.ts
@@ -70,15 +70,15 @@ async function maximalCommit(root: string, candidates: readonly string[]): Promi
       .map((line) => line.trim())
       .filter(Boolean),
   );
-  if (independent.has(first)) {
-    return first;
-  }
-  for (const candidate of unique.slice(1)) {
-    if (independent.has(candidate) && (await isAncestor(root, first, candidate))) {
+  const maxima = unique.filter((candidate) => independent.has(candidate));
+  // A sole survivor is also the fallback, so probing its ancestry cannot
+  // change the choice. Keep competing survivors in their original order.
+  for (const candidate of maxima) {
+    if (candidate === first || maxima.length === 1 || (await isAncestor(root, first, candidate))) {
       return candidate;
     }
   }
-  return unique.find((candidate) => independent.has(candidate)) ?? first;
+  return maxima[0] ?? first;
 }
 
 export async function resolveBranchLanding(


### PR DESCRIPTION
## What Problem This Solves

Refreshing Control UI PR chips can launch a redundant Git ancestry check after several published baselines have already reduced to one candidate. Whether that extra check succeeds or fails, the resolver selects the same baseline.

## Why This Change Was Made

Reuse the ordered candidate intersection from the existing batch query. A sole survivor needs no further comparison; genuinely competing survivors retain their original ancestry-query order and fallback. This stays within one invocation and introduces no ancestry cache.

## User Impact

One fewer Git process in this case: the real-Git linear two-PR fixture drops from eight commands to seven, with identical branch facts. First-candidate preference, competing candidates, missing objects, and failed or unmatched batch output keep their existing behavior.

## Evidence

- The existing real-Git three-baseline regression fails on the redundant query before the change and passes afterward.
- 82 tests pass locally across landing, branch, PR-loader, and subscription suites.
- Eleven owner-level comparisons preserve all four returned fields and every retained command's order. They distinguish real replacement-ref mutation and object loss from explicitly simulated empty, unmatched, and extra stdout faults.
- Qualified Crabbox 0.49.1 / Blacksmith Testbox: the same 82 tests pass on Linux with Node 24.19.0, Execa 10.0.1, and Git 2.52.0. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33974782394); its manual payload exited 0 and the environment was verified stopped.
- Independent P2 review: no accepted or actionable findings.
- Full local changed-scope gate passed: `node scripts/check-changed.mjs -- src/gateway/control-ui-session-prs-landing.ts src/gateway/control-ui-session-prs-landing.test.ts`.

Production LOC is unchanged (+6/-6); the existing regression gains three lines. There is no configuration, schema, dependency, protocol, or visual change. The verified improvement is the removed command, not a general latency claim.
