### PR TITLE
fix(fal): reject non-binary generated image and music downloads

### DIFF
--- a/extensions/fal/image-generation-provider.download.test.ts
+++ b/extensions/fal/image-generation-provider.download.test.ts
@@ -1,0 +1,137 @@
+// Fal tests cover generated image download response validation.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+import * as providerAuth from "openclaw/plugin-sdk/provider-auth-runtime";
+import { buildFalImageGenerationProvider } from "./image-generation-provider.js";
+
+const falApiKey = { apiKey: "fal-test-key", source: "env", mode: "api-key" } as const;
+const downloadUrl = "https://v3.fal.media/files/example/generated.png";
+
+function releasedJson(payload: unknown) {
+  return { response: Response.json(payload), release: vi.fn(async () => {}) };
+}
+
+/** Builds a download response from a real body stream, as fetch would. */
+function releasedBody(body: BodyInit, headers?: Record<string, string>) {
+  const release = vi.fn(async () => {});
+  return {
+    response: new Response(body, { status: 200, ...(headers ? { headers } : {}) }),
+    release,
+  };
+}
+
+function streamed(bytes: string, headers?: Record<string, string>) {
+  return releasedBody(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(bytes));
+        controller.close();
+      },
+    }),
+    headers,
+  );
+}
+
+describe("fal generated image download response validation", () => {
+  let provider: ReturnType<typeof buildFalImageGenerationProvider>;
+
+  beforeEach(() => {
+    provider = buildFalImageGenerationProvider();
+    fetchWithSsrFGuardMock.mockReset();
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue(falApiKey);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function generate() {
+    return provider.generateImage({
+      provider: "fal",
+      model: "fal-ai/flux/dev",
+      prompt: "draw a cat",
+      cfg: {},
+    });
+  }
+
+  function respondWith(download: ReturnType<typeof releasedBody>) {
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce(releasedJson({ images: [{ url: downloadUrl }] }))
+      .mockResolvedValueOnce(download);
+    return download;
+  }
+
+  it.each([
+    {
+      label: "a JSON error payload",
+      download: () =>
+        streamed('{"error":"quota exceeded"}', { "content-type": "application/json" }),
+    },
+    {
+      label: "a problem+json payload",
+      download: () => streamed('{"title":"gone"}', { "content-type": "application/problem+json" }),
+    },
+    {
+      label: "an HTML sign-in page",
+      download: () =>
+        streamed("<html><body>sign in</body></html>", { "content-type": "text/html" }),
+    },
+    {
+      label: "plain text",
+      download: () => streamed("not an image", { "content-type": "text/plain; charset=utf-8" }),
+    },
+    {
+      label: "an empty body under an image content type",
+      download: () => streamed("", { "content-type": "image/png" }),
+    },
+  ])("rejects a successful download that returns $label", async ({ download }) => {
+    const handle = respondWith(download());
+
+    await expect(generate()).rejects.toThrow(
+      "fal generated image download: malformed image response",
+    );
+    expect(handle.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the image/png default when the provider omits a content type", async () => {
+    respondWith(streamed("png-bytes"));
+
+    const result = await generate();
+
+    expect(result.images[0]?.mimeType).toBe("image/png");
+    expect(result.images[0]?.buffer).toEqual(Buffer.from("png-bytes"));
+  });
+
+  it("delivers a well-formed image download unchanged", async () => {
+    respondWith(streamed("png-bytes", { "content-type": "image/webp" }));
+
+    const result = await generate();
+
+    expect(result.images[0]?.mimeType).toBe("image/webp");
+    expect(result.images[0]?.buffer).toEqual(Buffer.from("png-bytes"));
+  });
+
+  it("keeps the existing byte-cap message rather than the shared reader default", async () => {
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce(releasedJson({ images: [{ url: downloadUrl }] }))
+      .mockResolvedValueOnce(streamed("too-large", { "content-type": "image/png" }));
+
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "fal-ai/flux/dev",
+        prompt: "draw a cat",
+        cfg: { agents: { defaults: { mediaMaxMb: 0.000001 } } },
+      }),
+    ).rejects.toThrow("fal generated image download exceeds 1 bytes");
+  });
+});

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -14,11 +14,11 @@ import {
   assertOkOrThrowHttpError,
   assertOkOrThrowProviderError,
   createProviderOperationDeadline,
+  readProviderBinaryResponse,
   readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   type ProviderOperationDeadline,
 } from "openclaw/plugin-sdk/provider-http";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
   buildHostnameAllowlistPolicyFromSuffixAllowlist,
   fetchWithSsrFGuard,
@@ -610,7 +610,12 @@ async function fetchImageBuffer(
     await assertOkOrThrowProviderError(response, "fal image download failed");
     const mimeType = response.headers.get("content-type")?.trim() || "image/png";
     return {
-      buffer: await readResponseWithLimit(response, maxBytes, {
+      // The download deadline above already bounds this read, so the shared
+      // reader's default idle timer stays off; only the binary-content contract
+      // is added here.
+      buffer: await readProviderBinaryResponse(response, "fal generated image download", "image", {
+        maxBytes,
+        chunkTimeoutMs: 0,
         onOverflow: ({ maxBytes: maxBytesLocal }) =>
           new Error(`fal generated image download exceeds ${maxBytesLocal} bytes`),
       }),

--- a/extensions/fal/music-generation-provider.test.ts
+++ b/extensions/fal/music-generation-provider.test.ts
@@ -152,6 +152,49 @@ describe("fal music generation provider", () => {
     ).rejects.toThrow("fal generated music download exceeds 1 bytes");
   });
 
+  it.each([
+    { label: "a JSON error payload", body: '{"error":"quota"}', contentType: "application/json" },
+    {
+      label: "a problem+json payload",
+      body: '{"title":"gone"}',
+      contentType: "application/problem+json",
+    },
+    { label: "an HTML page", body: "<html>sign in</html>", contentType: "text/html" },
+    { label: "an empty body", body: "", contentType: "audio/mpeg" },
+  ])("rejects a generated music download that returns $label", async ({ body, contentType }) => {
+    postJsonRequestMock.mockResolvedValue(
+      falMusicJsonResponse({
+        audio: { url: "https://v3b.fal.media/files/b/out.mp3", content_type: "audio/mpeg" },
+      }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                if (body) {
+                  controller.enqueue(new TextEncoder().encode(body));
+                }
+                controller.close();
+              },
+            }),
+            { headers: { "content-type": contentType } },
+          ),
+      ),
+    );
+
+    await expect(
+      buildFalMusicGenerationProvider().generateMusic({
+        provider: "fal",
+        model: "fal-ai/minimax-music/v2.6",
+        prompt: "short track",
+        cfg: {},
+      }),
+    ).rejects.toThrow("fal generated music download: malformed audio response");
+  });
+
   it("rejects MiniMax lyrics requests that also ask for instrumental output", async () => {
     await expect(
       buildFalMusicGenerationProvider().generateMusic({

--- a/extensions/fal/music-generation-provider.ts
+++ b/extensions/fal/music-generation-provider.ts
@@ -165,6 +165,7 @@ export function buildFalMusicGenerationProvider(): MusicGenerationProvider {
           provider: "fal",
           requestFailedMessage: "fal generated music download failed",
           maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
+          validateBinaryResponse: true,
         });
         const lyrics =
           typeof payload === "object" && payload && !Array.isArray(payload)

--- a/extensions/fal/music-generation-provider.ts
+++ b/extensions/fal/music-generation-provider.ts
@@ -166,6 +166,9 @@ export function buildFalMusicGenerationProvider(): MusicGenerationProvider {
           requestFailedMessage: "fal generated music download failed",
           maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "audio"),
           validateBinaryResponse: true,
+          // This download is bounded by the request deadline above; keep the
+          // shared reader's idle timer off so timing is unchanged.
+          chunkTimeoutMs: 0,
         });
         const lyrics =
           typeof payload === "object" && payload && !Array.isArray(payload)

--- a/src/music-generation/provider-assets.ts
+++ b/src/music-generation/provider-assets.ts
@@ -120,6 +120,8 @@ export async function downloadGeneratedMusicAsset(params: {
   index?: number;
   maxBytes?: number;
   validateBinaryResponse?: boolean;
+  /** Zero preserves deadline-only downloads without adding an idle timeout. */
+  chunkTimeoutMs?: number;
   includeSourceUrl?: boolean;
   fetchResponse?: GeneratedMusicResponseFactory;
 }): Promise<GeneratedMusicAsset> {
@@ -153,6 +155,7 @@ export async function downloadGeneratedMusicAsset(params: {
     const maxBytes = params.maxBytes ?? maxBytesForKind("audio");
     const readOptions = {
       maxBytes,
+      chunkTimeoutMs: params.chunkTimeoutMs,
       timeoutMs,
       onTimeout: ({ timeoutMs: bodyTimeoutMs }: { timeoutMs: number }) =>
         new Error(


### PR DESCRIPTION
Follow-up to #117339.

## What Problem This Solves

Fixes an issue where fal generated image and music downloads could return HTTP 200 with JSON, problem JSON, HTML, plain text, or an empty body and still become successful provider assets.

#117339 moved nine generated-video download owners onto `readProviderBinaryResponse` and named the remaining fal paths as separate follow-up work: *"audit fal's image and music download owners for the same binary-response contract; those paths are not changed by this generated-video repair."* This is that audit.

Both gaps are still open on `main`:

- `extensions/fal/image-generation-provider.ts:613` reads the download body with the plain bounded reader, and `:611` defaults a missing content type to `image/png`, so any HTTP 200 body is delivered as a generated image.
- `extensions/fal/music-generation-provider.ts:161` is the only caller of `downloadGeneratedMusicAsset` that leaves `validateBinaryResponse` off. Its sibling, `extensions/minimax/music-generation-provider.ts:92`, already sets it against the same helper.

The video owner in the same extension (`extensions/fal/video-generation-provider.ts:212`) is already on the validated path, so today the answer to "is a malformed 200 caught" depends on which fal capability a user happens to call.

## Why This Change Was Made

The repository already owns this contract, so this applies it rather than adding a new one. `assertProviderBinaryResponseContent` rejects `application/json`, `*+json`, and `text/*`, `readProviderBinaryResponse` additionally rejects a zero-byte body, and a missing content type is deliberately allowed through — which is what preserves fal image's existing `image/png` default.

Timing is deliberately held constant on both owners, because the shared reader otherwise applies a 30-second idle timer that neither fal path has today:

- The image reader passes `chunkTimeoutMs: 0`. That download is already bounded by the operation deadline resolved immediately above it. The fal video owner in the same extension uses the same argument for the same reason.
- `downloadGeneratedMusicAsset` now forwards an optional `chunkTimeoutMs`, mirroring `downloadGeneratedVideoAsset`, and fal passes zero. MiniMax leaves the option unspecified and keeps exactly the timing it has today. Without this, enabling validation would have made a valid audio body that pauses past 30 seconds fail inside fal's 180-second budget; the measurement for that is below.

No new configuration, no new SDK surface, and no change to error messages, filenames, MIME defaults, byte caps, overflow behaviour, or download deadlines.

## User Impact

- A malformed fal image or music download now produces a provider-labelled error instead of a corrupt asset that a channel would send.
- Well-formed downloads are unchanged, including the `image/png` default for providers that omit a content type and the existing `fal generated image download exceeds N bytes` cap message.
- Slow-but-valid downloads keep working: both fal owners keep their deadline-owned timing, with no idle timer introduced.

## Evidence

### Both changed owners, over real HTTP, before and after

A `node:http` server on `127.0.0.1` answers the fal generate request and then serves each body shape as the asset. The **real** `buildFalImageGenerationProvider().generateImage` and the **real** `downloadGeneratedMusicAsset` consume it through the real global `fetch` and real body streams. No vitest, no `Response` fixtures, no stubbed provider internals.

The single substitution is the SSRF gate: `fetchWithSsrFGuard` is replaced with a plain `fetch` by a Node `module.registerHooks` shim, because the guard rejects loopback addresses by design and fal resolves `allowPrivateNetwork: false` unconditionally (`extensions/fal/http-config.ts:40`). Everything downstream of that gate — the provider, the download owner, the reader, the socket — is production code.

`ARM: main` is the same harness with the three production files restored to `origin/main`; `ARM: branch` is this head.

```
=== ARM: main ===
--- fal image provider (real generateImage over real HTTP) ---
image /json : OK mime=application/json bytes=26 first="{\"erro" (908ms)
image /html : OK mime=text/html bytes=33 first="<html>" (18ms)
image /empty: OK mime=image/png bytes=0 first="" (31ms)
image /png  : OK mime=image/png bytes=16 first="PNG\r\n" (18ms)
--- fal music helper (real downloadGeneratedMusicAsset over real HTTP) ---
music /json : OK mime=application/json bytes=26 first="{\"erro" (18ms)
music /html : OK mime=text/html bytes=33 first="<html>" (13ms)
music /empty: OK mime=image/png bytes=0 first="" (15ms)
music /mp3  : OK mime=audio/mpeg bytes=12 first="ÿûD" (2ms)
music /slow-mp3 (main: no options): OK mime=audio/mpeg bytes=12 first="ÿûD" (31025ms)

=== ARM: branch ===
--- fal image provider (real generateImage over real HTTP) ---
image /json : ERROR fal generated image download: malformed image response (705ms)
image /html : ERROR fal generated image download: malformed image response (15ms)
image /empty: ERROR fal generated image download: malformed image response (29ms)
image /png  : OK mime=image/png bytes=16 first="PNG\r\n" (30ms)
--- fal music helper (real downloadGeneratedMusicAsset over real HTTP) ---
music /json : ERROR fal generated music download: malformed audio response (16ms)
music /html : ERROR fal generated music download: malformed audio response (13ms)
music /empty: ERROR fal generated music download: malformed audio response (16ms)
music /mp3  : OK mime=audio/mpeg bytes=12 first="ÿûD" (1ms)
music /slow-mp3 (fal: chunkTimeoutMs 0): OK mime=audio/mpeg bytes=12 first="ÿûD" (31016ms)
music /slow-mp3 (MiniMax shape: option unset): ERROR fal generated music download: response body stalled for 30000ms (30012ms)
```

Reading the two arms:

- On `main`, a fal generation call returns a **successful** asset whose bytes are `{"erro` under `mime=application/json`, or `<html` under `text/html`, or zero bytes under `image/png`. That asset is what a channel then delivers as the generated image or track.
- On this branch the same requests fail with a provider-labelled error and produce no asset, while the well-formed `/png` and `/mp3` cases are byte-identical to `main`.
- The last two music rows are the P1 from the previous review, measured. `/slow-mp3` is a valid audio body that pauses 31 seconds mid-stream and then completes. With the option unspecified — the shape this PR would have shipped without the helper forwarding — it fails at 30 seconds. With fal's `chunkTimeoutMs: 0` it succeeds at 31016ms, matching `main`'s 31025ms. So the timing regression is measured, and measured closed.

<details>
<summary>Harness (repository root, deleted before commit)</summary>

`ssrf-passthrough-hook.mjs`:

```js
import { registerHooks } from "node:module";

const GUARD = "src/infra/net/fetch-guard";
const MARK = "#ssrf-shim";

registerHooks({
  resolve(specifier, context, nextResolve) {
    if (context.parentURL?.includes(MARK)) {
      return nextResolve(specifier, context);
    }
    const resolved = nextResolve(specifier, context);
    const url = resolved.url.replaceAll("\\", "/");
    if (url.includes(GUARD) && !resolved.url.includes(MARK)) {
      return { ...resolved, url: `${resolved.url}${MARK}`, shortCircuit: true };
    }
    return resolved;
  },
  load(url, context, nextLoad) {
    if (!url.endsWith(MARK)) {
      return nextLoad(url, context);
    }
    const real = url.slice(0, -MARK.length);
    return {
      format: "module",
      shortCircuit: true,
      source: `
export * from ${JSON.stringify(real)};
export async function fetchWithSsrFGuard(params) {
  const response = await fetch(params.url, params.init ?? { method: "GET" });
  return { response, release: async () => {} };
}
`,
    };
  },
});
```

`fal-owner-probe.mts` (abridged: server routes plus the two arms):

```ts
import { createServer } from "node:http";
import type { AddressInfo } from "node:net";

const PNG = Buffer.from("89504e470d0a1a0a0000000d49484452", "hex");
const MP3 = Buffer.from("fffb90440000000000000000", "hex");

const server = createServer((req, res) => {
  const route = (req.url ?? "/").split("?")[0] ?? "/";
  if (req.method === "POST") {
    const port = (server.address() as AddressInfo).port;
    res.writeHead(200, { "content-type": "application/json" });
    res.end(
      JSON.stringify({
        images: [{ url: `http://127.0.0.1:${port}${process.env.PROBE_ASSET ?? "/png"}` }],
        audio: {
          url: `http://127.0.0.1:${port}${process.env.PROBE_ASSET ?? "/mp3"}`,
          content_type: "audio/mpeg",
          file_name: "out.mp3",
        },
      }),
    );
    return;
  }
  if (route === "/json") {
    res.writeHead(200, { "content-type": "application/json" });
    res.end(JSON.stringify({ error: "quota exceeded" }));
    return;
  }
  if (route === "/html") {
    res.writeHead(200, { "content-type": "text/html" });
    res.end("<html><body>sign in</body></html>");
    return;
  }
  if (route === "/empty") {
    res.writeHead(200, { "content-type": "image/png" });
    res.end();
    return;
  }
  if (route === "/slow-mp3") {
    res.writeHead(200, { "content-type": "audio/mpeg" });
    res.write(MP3.subarray(0, 6));
    setTimeout(() => res.end(MP3.subarray(6)), 31_000);
    return;
  }
  if (route === "/mp3") {
    res.writeHead(200, { "content-type": "audio/mpeg" });
    res.end(MP3);
    return;
  }
  res.writeHead(200, { "content-type": "image/png" });
  res.end(PNG);
});
await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
const { port } = server.address() as AddressInfo;
const base = `http://127.0.0.1:${port}`;
const isMainArm = process.env.PROBE_ARM === "main";

const { buildFalImageGenerationProvider } = await import(
  "./extensions/fal/image-generation-provider.ts"
);
const { downloadGeneratedMusicAsset } = await import("./src/music-generation/provider-assets.ts");

async function imageArm(assetPath: string) {
  process.env.PROBE_ASSET = assetPath;
  return await buildFalImageGenerationProvider().generateImage({
    provider: "fal",
    model: "fal-ai/flux/dev",
    prompt: "draw a cat",
    cfg: { models: { providers: { fal: { baseUrl: base, apiKey: "probe-key" } } } },
  });
}

async function musicArm(assetPath: string, chunkTimeoutMs?: number) {
  return await downloadGeneratedMusicAsset({
    candidate: { url: `${base}${assetPath}` },
    timeoutMs: 180_000,
    fetchFn: fetch,
    provider: "fal",
    requestFailedMessage: "fal generated music download failed",
    maxBytes: 20_000_000,
    // main's fal music owner passes neither option; this branch passes both.
    ...(isMainArm ? {} : { validateBinaryResponse: true, chunkTimeoutMs }),
  });
}
```

Run as:

```
node --import ./ssrf-passthrough-hook.mjs --import tsx ./fal-owner-probe.mts
PROBE_ARM=main node --import ./ssrf-passthrough-hook.mjs --import tsx ./fal-owner-probe.mts
```

</details>

### Regression coverage in the suites

Both suites drive the production `generateImage` / `generateMusic` implementations with real `Response` bodies backed by real streams; only the network boundary is replaced.

`extensions/fal/image-generation-provider.download.test.ts` is a new file, so the existing 1025-line image suite keeps its `max-lines` budget. It covers the four malformed content shapes plus an empty body, and three controls: the `image/png` default when the provider omits a content type, an unchanged well-formed `image/webp` download, and the existing byte-cap message.

`extensions/fal/music-generation-provider.test.ts` gains the same four malformed shapes. Its existing success case already downloads under `application/octet-stream`, which the guard passes, so that case is an untouched control.

- `test/vitest/vitest.extension-media.config.ts` over `extensions/fal`: **94 passed, 0 failed** (5 files).
- `test/vitest/vitest.unit.config.ts` over `src/music-generation/provider-assets.test.ts` (the shared helper this PR extends): **3 passed, 0 failed**.
- `test/vitest/vitest.extension-providers.config.ts` over `extensions/minimax` (the sibling caller): the music suite passes, including its own malformed-download cases. Two unrelated failures in `extensions/minimax/speech-provider.test.ts` are a Windows teardown race in my local environment — `EBUSY: resource busy or locked, unlink '...\state\openclaw.sqlite-shm'` — in a file this branch does not touch.

Mutation control — production files reverted to `origin/main`, new tests kept:

```
Test Files  2 failed (2)
     Tests  9 failed | 9 passed (18)
```

The nine failures are exactly the nine new malformed cases, each reporting `promise resolved ... instead of rejecting`; every control passes on both arms.

### Local checks

`oxlint` and `oxfmt --check` clean on the changed files. `check-assertion-safety-ratchet.mts`: OK, 4042 files, 12192 grandfathered assertions. `check-max-lines-ratchet.mts`: OK, 862 grandfathered suppressions.

`scripts/run-tsgo-core-test-shards.mjs` reports 4 errors, all in `src/infra/install-package-dir.ts` (`assertBeforeRename` missing from `MovePathWithCopyFallbackOptions`), a file this branch does not touch; that type lives in a dependency and my local install is stale. No error names any file under `extensions/fal` or `src/music-generation`. CI is authoritative for that check.

Production `git diff --numstat`: `extensions/fal/image-generation-provider.ts` +7/-2, `extensions/fal/music-generation-provider.ts` +4/-0, `src/music-generation/provider-assets.ts` +3/-0.
