### PR TITLE
fix(gateway): keep chat metadata responsive across auth refresh

### DIFF
--- a/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
@@ -14,6 +14,7 @@ import { getPreparedModelCatalogOwnerSnapshot } from "../agents/prepared-model-c
 import { getPreparedModelRuntimeAuthMaterializations } from "../agents/prepared-model-runtime-auth.js";
 import {
   advancePreparedModelRuntimeConfig,
+  loadPublishedGatewayReplyDispatchRuntime,
   refreshPreparedModelRuntimeSnapshots,
   registerPreparedModelRuntimePublicationListener,
 } from "../agents/prepared-model-runtime.js";
@@ -854,6 +855,71 @@ describe("gateway chat metadata lifecycle composition", () => {
     await vi.waitFor(
       async () => await expectAvailable(lifecycle, false, orderedConfig, orderedContext),
     );
+  });
+
+  it("retains a settled metadata failure during a later independent auth publication", async () => {
+    mocks.configuredAgentIds = ["main", "worker"];
+    await publishOwner();
+    const lifecycle = await createLifecycle();
+    const ownedSidecars: GatewayPostReadySidecarHandle[] = [];
+    const failure = new Error("worker auth publication failed");
+    const phases: string[] = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      phases.push(event.phase);
+    });
+    let failedDispatch: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    let healthyDispatch: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+    let metadataRead: Promise<void> | undefined;
+    try {
+      await lifecycle.attachContext(context, ownedSidecars);
+      await expectAvailable(lifecycle);
+      mocks.ensureOpenClawModelsJson.mockRejectedValueOnce(failure);
+      expect(mocks.mutationListener).toBeTypeOf("function");
+      mocks.mutationListener!({
+        agentDir: state.agentDir("worker"),
+        affectsInheritedStores: false,
+      });
+      failedDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+      await expect(failedDispatch).rejects.toBe(failure);
+      await expect(lifecycle.read({ agentId: "main" })).rejects.toBe(failure);
+      // Drain the completed publication's promise continuations before starting a new
+      // transaction; this must not exercise two components of one queued transaction.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(phases).toEqual(["invalidated", "failed"]);
+      phases.length = 0;
+
+      mocks.mutationListener!({
+        agentDir: state.agentDir("main"),
+        affectsInheritedStores: false,
+      });
+      healthyDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "main" });
+      let metadataOutcome: unknown = Symbol("pending");
+      metadataRead = lifecycle.read({ agentId: "main" }).then(
+        (value) => {
+          metadataOutcome = value;
+        },
+        (error: unknown) => {
+          metadataOutcome = error;
+        },
+      );
+      await expect(healthyDispatch).resolves.toMatchObject({ agentId: "main" });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(phases).toContain("invalidated");
+      expect(phases).not.toContain("published");
+      expect(getPreparedModelCatalogOwnerSnapshot({ agentId: "worker", config })).toBeUndefined();
+      // The healthy component can admit work, but it cannot make the failed global
+      // metadata generation ready or turn its recorded failure into an endless wait.
+      expect(metadataOutcome).toBe(failure);
+
+      await publishOwner();
+      await expectAvailable(lifecycle);
+    } finally {
+      unregister();
+      for (const sidecar of ownedSidecars) {
+        await sidecar.stop();
+      }
+      await Promise.allSettled([failedDispatch, healthyDispatch, metadataRead]);
+    }
   });
 
   it("recovers a failed catch-up when the prepared owner publishes after attachment", async () => {

--- a/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
@@ -884,7 +884,9 @@ describe("gateway chat metadata lifecycle composition", () => {
       await expect(lifecycle.read({ agentId: "main" })).rejects.toBe(failure);
       // Drain the completed publication's promise continuations before starting a new
       // transaction; this must not exercise two components of one queued transaction.
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(phases).toEqual(["invalidated", "failed"]);
       phases.length = 0;
 
@@ -903,7 +905,9 @@ describe("gateway chat metadata lifecycle composition", () => {
         },
       );
       await expect(healthyDispatch).resolves.toMatchObject({ agentId: "main" });
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(phases).toContain("invalidated");
       expect(phases).not.toContain("published");
       expect(getPreparedModelCatalogOwnerSnapshot({ agentId: "worker", config })).toBeUndefined();

--- a/src/gateway/server-chat-metadata-lifecycle.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.test.ts
@@ -77,7 +77,249 @@ function createLifecycle(minimalTestGateway: boolean, warn = vi.fn()) {
   };
 }
 
+async function createRealMetadataLifecycle(
+  options: { attach?: boolean; ownerAvailable?: boolean } = {},
+) {
+  const actual = await vi.importActual<typeof import("./server-methods/chat-metadata-runtime.js")>(
+    "./server-methods/chat-metadata-runtime.js",
+  );
+  let owner = createChatMetadataOwner(config, "before-publication");
+  let ownerAvailable = options.ownerAvailable ?? true;
+  let revision = 0;
+  let latestRefresh = Promise.resolve();
+  const buildCommands = vi.fn(async () => ({ commands: [] }));
+  mocks.createRuntime.mockImplementation(
+    (params: Parameters<typeof actual.createGatewayChatMetadataRuntime>[0]) => {
+      const runtime = actual.createGatewayChatMetadataRuntime({
+        ...params,
+        deps: {
+          getPreparedOwner: () => (ownerAvailable ? owner : undefined),
+          getPreparedAuthStore: () => ({ version: 1, profiles: {} }),
+          getAuthStoreRevision: () => revision,
+          getSkillsVersion: () => 0,
+          getPluginRegistryVersion: () => 0,
+          buildCommands,
+          buildProjection: async ({ facts }) => ({
+            modelCatalog: facts.modelCatalog.entries,
+            read: () => ({ models: facts.modelCatalog.entries }),
+            isCurrent: () => true,
+          }),
+        },
+      });
+      return {
+        ...runtime,
+        refresh: () => {
+          latestRefresh = runtime.refresh();
+          return latestRefresh;
+        },
+      };
+    },
+  );
+  const { lifecycle: pendingLifecycle, warn } = createLifecycle(false);
+  const lifecycle = await pendingLifecycle;
+  const sidecars: Array<{ stop: () => void | Promise<void> }> = [];
+  const attach = () =>
+    lifecycle.attachContext({ broadcast: vi.fn() } as unknown as GatewayRequestContext, sidecars);
+  if (options.attach !== false) {
+    await attach();
+  }
+  const modelEvent = (event: { phase: string; error?: Error }) =>
+    mocks.registerModelListener.mock.calls[0]![0](event);
+  const authEvent = () => mocks.registerAuthListener.mock.calls[0]![0]();
+  return {
+    lifecycle,
+    attach,
+    buildCommands,
+    warn,
+    modelEvent,
+    queueRefresh(stage: "queued" | "building") {
+      const entered = createDeferred();
+      const release = createDeferred();
+      if (stage === "building") {
+        buildCommands.mockImplementationOnce(async () => {
+          entered.resolve();
+          await release.promise;
+          return { commands: [] };
+        });
+      } else {
+        entered.resolve();
+      }
+      revision += 1;
+      authEvent();
+      return {
+        entered: entered.promise,
+        release: () => release.resolve(),
+        obsolete: latestRefresh,
+      };
+    },
+    replaceOwner() {
+      owner = createChatMetadataOwner(config, "after-publication");
+      ownerAvailable = true;
+      modelEvent({ phase: "published" });
+    },
+    invalidateOwner() {
+      ownerAvailable = false;
+      modelEvent({ phase: "invalidated" });
+    },
+    events: {
+      skills: () => mocks.registerSkillsListener.mock.calls[0]![0](),
+      auth: () => authEvent(),
+      catalog: () => modelEvent({ phase: "catalog-published" }),
+      owner: () => modelEvent({ phase: "invalidated" }),
+    },
+    async stop() {
+      await Promise.all(sidecars.map((sidecar) => sidecar.stop()));
+    },
+  };
+}
+
 describe("gateway chat metadata lifecycle", () => {
+  it.each(["queued", "building"] as const)(
+    "keeps readers waiting when %s metadata refresh is superseded by owner publication",
+    async (stage) => {
+      const harness = await createRealMetadataLifecycle();
+      const queued = harness.queueRefresh(stage);
+      let read: Promise<unknown> | undefined;
+      try {
+        await queued.entered;
+        harness.invalidateOwner();
+        let settled = false;
+        read = harness.lifecycle.read({ agentId: "main" }).then(
+          (value) => {
+            settled = true;
+            return value;
+          },
+          (error: unknown) => {
+            settled = true;
+            return error;
+          },
+        );
+        queued.release();
+        await queued.obsolete.catch(() => undefined);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        expect(harness.warn).not.toHaveBeenCalled();
+        expect(settled).toBe(false);
+        harness.replaceOwner();
+        await expect(read).resolves.toMatchObject({
+          models: [expect.objectContaining({ id: "after-publication" })],
+        });
+      } finally {
+        queued.release();
+        await harness.stop();
+        await read;
+      }
+    },
+  );
+
+  it.each(["skills", "auth", "catalog", "owner"] as const)(
+    "retains a terminal metadata failure through a later %s invalidation",
+    async (event) => {
+      const harness = await createRealMetadataLifecycle();
+      const failure = new Error("prepared owner publication failed");
+      let read: Promise<void> | undefined;
+      try {
+        harness.invalidateOwner();
+        harness.modelEvent({ phase: "failed", error: failure });
+        await expect(harness.lifecycle.read({ agentId: "main" })).rejects.toBe(failure);
+        harness.events[event]();
+        let outcome: unknown = Symbol("pending");
+        read = harness.lifecycle.read({ agentId: "main" }).then(
+          (value) => {
+            outcome = value;
+          },
+          (error: unknown) => {
+            outcome = error;
+          },
+        );
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        expect(outcome).toBe(failure);
+        harness.replaceOwner();
+        await expect(harness.lifecycle.read({ agentId: "main" })).resolves.toMatchObject({
+          models: [expect.objectContaining({ id: "after-publication" })],
+        });
+      } finally {
+        await harness.stop();
+        await read;
+      }
+    },
+  );
+
+  it("keeps an initial catch-up waiting when its already-published owner is replaced", async () => {
+    const harness = await createRealMetadataLifecycle({ attach: false });
+    const entered = createDeferred();
+    const release = createDeferred();
+    harness.buildCommands.mockImplementationOnce(async () => {
+      entered.resolve();
+      await release.promise;
+      return { commands: [] };
+    });
+    const attachment = harness.attach();
+    let read: Promise<unknown> | undefined;
+    try {
+      await entered.promise;
+      harness.invalidateOwner();
+      let settled = false;
+      read = harness.lifecycle.read({ agentId: "main" }).then(
+        (value) => {
+          settled = true;
+          return value;
+        },
+        (error: unknown) => {
+          settled = true;
+          return error;
+        },
+      );
+      release.resolve();
+      await attachment;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(settled).toBe(false);
+      expect(harness.warn).not.toHaveBeenCalled();
+      harness.replaceOwner();
+      await expect(read).resolves.toMatchObject({
+        models: [expect.objectContaining({ id: "after-publication" })],
+      });
+    } finally {
+      release.resolve();
+      await harness.stop();
+      await attachment;
+      await read;
+    }
+  });
+
+  it("waits for first publication after an initial missing-owner catch-up", async () => {
+    const harness = await createRealMetadataLifecycle({ attach: false, ownerAvailable: false });
+    let read: Promise<unknown> | undefined;
+    try {
+      await harness.attach();
+      await expect(harness.lifecycle.read({ agentId: "main" })).rejects.toBeInstanceOf(
+        ChatMetadataSnapshotUnavailableError,
+      );
+      harness.modelEvent({ phase: "invalidated" });
+      let settled = false;
+      read = harness.lifecycle.read({ agentId: "main" }).then(
+        (value) => {
+          settled = true;
+          return value;
+        },
+        (error: unknown) => {
+          settled = true;
+          return error;
+        },
+      );
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(settled).toBe(false);
+      harness.replaceOwner();
+      await expect(read).resolves.toMatchObject({
+        models: [expect.objectContaining({ id: "after-publication" })],
+      });
+    } finally {
+      await harness.stop();
+      await read;
+    }
+  });
+
   it("broadcasts settled metadata through the production lifecycle without a failure feedback loop", async () => {
     const actual = await vi.importActual<
       typeof import("./server-methods/chat-metadata-runtime.js")
@@ -378,7 +620,6 @@ describe("gateway chat metadata lifecycle", () => {
     authListener();
     skillsListener();
 
-    expect(mocks.invalidate).toHaveBeenCalledTimes(4);
     expect(mocks.refresh).toHaveBeenCalledOnce();
     expect(warn).not.toHaveBeenCalled();
 

--- a/src/gateway/server-chat-metadata-lifecycle.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.test.ts
@@ -168,7 +168,7 @@ async function createRealMetadataLifecycle(
       owner: () => modelEvent({ phase: "invalidated" }),
     },
     async stop() {
-      await Promise.all(sidecars.map((sidecar) => sidecar.stop()));
+      await Promise.all(sidecars.map((sidecar) => Promise.resolve(sidecar.stop())));
     },
   };
 }
@@ -196,7 +196,9 @@ describe("gateway chat metadata lifecycle", () => {
         );
         queued.release();
         await queued.obsolete.catch(() => undefined);
-        await new Promise<void>((resolve) => setImmediate(resolve));
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
 
         expect(harness.warn).not.toHaveBeenCalled();
         expect(settled).toBe(false);
@@ -232,7 +234,9 @@ describe("gateway chat metadata lifecycle", () => {
             outcome = error;
           },
         );
-        await new Promise<void>((resolve) => setImmediate(resolve));
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
 
         expect(outcome).toBe(failure);
         harness.replaceOwner();
@@ -273,7 +277,9 @@ describe("gateway chat metadata lifecycle", () => {
       );
       release.resolve();
       await attachment;
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(settled).toBe(false);
       expect(harness.warn).not.toHaveBeenCalled();
       harness.replaceOwner();
@@ -308,7 +314,9 @@ describe("gateway chat metadata lifecycle", () => {
           return error;
         },
       );
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(settled).toBe(false);
       harness.replaceOwner();
       await expect(read).resolves.toMatchObject({

--- a/src/gateway/server-chat-metadata-lifecycle.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.ts
@@ -22,7 +22,7 @@ export async function createGatewayChatMetadataLifecycle(params: {
   log: GatewayLogger;
 }) {
   let context: GatewayRequestContext | undefined;
-  let preparedModelRuntimeAvailable = false;
+  let preparedModelRuntimeState: "unobserved" | "available" | "unavailable" = "unobserved";
   let preparedModelRuntimeEventVersion = 0;
   const { ChatMetadataSnapshotUnavailableError, createGatewayChatMetadataRuntime } =
     await import("./server-methods/chat-metadata-runtime.js");
@@ -61,10 +61,10 @@ export async function createGatewayChatMetadataLifecycle(params: {
     });
   };
   const invalidateForSubordinateChange = () => {
-    runtime.invalidate();
     // Auth and skill facts are subordinate to the prepared model owner. During replacement the
     // publication event owns the one catch-up refresh after every related fact is committed.
-    if (preparedModelRuntimeAvailable) {
+    if (preparedModelRuntimeState === "available") {
+      runtime.invalidate();
       refreshLogged();
     }
   };
@@ -89,16 +89,20 @@ export async function createGatewayChatMetadataLifecycle(params: {
         }
         preparedModelRuntimeEventVersion += 1;
         if (event.phase === "invalidated") {
-          preparedModelRuntimeAvailable = false;
-          runtime.invalidate();
+          // Initial catch-up may already be building an owner published before attachment.
+          // Later invalidations preserve the existing replacement wait or terminal failure.
+          if (preparedModelRuntimeState !== "unavailable") {
+            runtime.invalidate();
+          }
+          preparedModelRuntimeState = "unavailable";
           return;
         }
         if (event.phase === "failed") {
-          preparedModelRuntimeAvailable = false;
+          preparedModelRuntimeState = "unavailable";
           runtime.fail(event.error);
           return;
         }
-        preparedModelRuntimeAvailable = true;
+        preparedModelRuntimeState = "available";
         refreshLogged();
       });
     const unregisterSkillsChange = registerSkillsChangeListener(() => {
@@ -140,7 +144,7 @@ export async function createGatewayChatMetadataLifecycle(params: {
             // A successful catch-up proves availability when publication completed before the
             // listener was registered. Do not overwrite a newer invalidation or failure event.
             if (preparedModelRuntimeEventVersion === eventVersion) {
-              preparedModelRuntimeAvailable = true;
+              preparedModelRuntimeState = "available";
             }
           },
           (error: unknown) => {
@@ -148,7 +152,7 @@ export async function createGatewayChatMetadataLifecycle(params: {
               // Capture reached a published owner before this later metadata build failed. Keep
               // stable auth/skill changes able to retry unless a newer owner event says otherwise.
               if (preparedModelRuntimeEventVersion === eventVersion) {
-                preparedModelRuntimeAvailable = true;
+                preparedModelRuntimeState = "available";
               }
               params.log.warn(`chat metadata catch-up refresh failed: ${String(error)}`);
             }

--- a/src/gateway/server-methods/chat-metadata-runtime.test.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test.ts
@@ -18,6 +18,52 @@ import {
 } from "./chat-metadata-runtime.test-support.js";
 
 describe("gateway chat metadata runtime", () => {
+  test("retains an unsuperseded preparation failure without silently retrying", async () => {
+    const failure = new Error("metadata preparation failed");
+    const beforeRefresh = vi.fn(async () => {
+      throw failure;
+    });
+    const harness = createChatMetadataHarness(undefined, { beforeRefresh });
+    try {
+      await expect(harness.runtime.refresh()).rejects.toBe(failure);
+      await expect(harness.runtime.read({ agentId: "main" })).rejects.toBe(failure);
+      expect(beforeRefresh).toHaveBeenCalledOnce();
+    } finally {
+      await harness.runtime.stop();
+    }
+  });
+
+  test("retires a superseded preparation failure while the replacement prepares fresh facts", async () => {
+    const entered = createDeferred();
+    const release = createDeferred();
+    const failure = new Error("obsolete metadata preparation failed");
+    const beforeRefresh = vi.fn(async () => {});
+    beforeRefresh.mockImplementationOnce(async () => {
+      entered.resolve();
+      await release.promise;
+      throw failure;
+    });
+    const harness = createChatMetadataHarness(undefined, { beforeRefresh });
+    const oldRefresh = harness.runtime.refresh();
+    void oldRefresh.catch(() => undefined);
+    let replacement: Promise<void> | undefined;
+    try {
+      await entered.promise;
+      harness.runtime.invalidate();
+      replacement = harness.runtime.refresh();
+      const completed = Promise.all([oldRefresh, replacement]);
+      release.resolve();
+      await expect(completed).resolves.toEqual([undefined, undefined]);
+      await expect(harness.runtime.read({ agentId: "main" })).resolves.toMatchObject({
+        models: [expect.objectContaining({ id: "first" })],
+      });
+    } finally {
+      release.resolve();
+      await harness.runtime.stop();
+      await Promise.allSettled([oldRefresh, replacement]);
+    }
+  });
+
   test("notifies once per settlement, including same-epoch recovery, without an unavailable-read loop", async () => {
     const onChanged = vi.fn();
     const harness = createChatMetadataHarness(undefined, { onChanged });
@@ -903,6 +949,7 @@ describe("gateway chat metadata runtime", () => {
     });
 
     harness.runtime.invalidate();
+    const waitingRead = harness.runtime.read({ agentId: "main" });
     const firstRefresh = harness.runtime.refresh();
     await vi.waitFor(() => expect(harness.buildCommands).toHaveBeenCalledTimes(2));
 
@@ -911,14 +958,9 @@ describe("gateway chat metadata runtime", () => {
     releaseCommands.resolve();
     await Promise.all([firstRefresh, secondRefresh]);
 
-    const timedOut = Symbol("timed out");
-    const result = await Promise.race([
-      harness.runtime.read({ agentId: "main" }),
-      new Promise<typeof timedOut>((resolve) => {
-        setTimeout(() => resolve(timedOut), 100);
-      }),
-    ]);
-    expect(result).not.toBe(timedOut);
+    await expect(waitingRead).resolves.toMatchObject({
+      models: [expect.objectContaining({ id: "first" })],
+    });
   });
 
   test("retries an unavailable owner on the next read once it is published again", async () => {

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -407,15 +407,17 @@ export function createGatewayChatMetadataRuntime(params: {
   };
 
   const runRefresh = async (version: number) => {
-    assertOpen();
-    await params.beforeRefresh?.();
-    // Ownership can change during preparation; build completion checks it again after suspension.
     if (version !== refreshVersion) {
       return;
     }
-    for (;;) {
-      const epoch = invalidationEpoch;
-      try {
+    assertOpen();
+    try {
+      await params.beforeRefresh?.();
+      if (version !== refreshVersion) {
+        return;
+      }
+      for (;;) {
+        const epoch = invalidationEpoch;
         const facts = captureGenerationFacts(deps);
         if (current && generationFactsMatch(current.facts, facts)) {
           return;
@@ -432,15 +434,14 @@ export function createGatewayChatMetadataRuntime(params: {
           current = generation;
           return;
         }
-      } catch (error) {
-        // A superseded build may fail after replacement starts; only its current epoch may fail readers.
-        if (version !== refreshVersion) {
-          return;
-        }
-        if (epoch === invalidationEpoch) {
-          throw error;
-        }
       }
+    } catch (error) {
+      // Invalidation and stop revoke old preparation, including its failures.
+      // Only the current refresh may settle the replacement's readers.
+      if (version !== refreshVersion) {
+        return;
+      }
+      throw error;
     }
   };
 
@@ -460,8 +461,7 @@ export function createGatewayChatMetadataRuntime(params: {
             return;
           }
           pending = undefined;
-          // One worker can absorb later invalidations and publish their generation. Settle the
-          // replacement owned by what it actually committed, not by the epoch that scheduled it.
+          // Only the current generation may settle its replacement wait.
           if (current?.epoch !== invalidationEpoch) {
             return;
           }
@@ -693,6 +693,8 @@ export function createGatewayChatMetadataRuntime(params: {
       return;
     }
     invalidationEpoch += 1;
+    refreshVersion += 1;
+    pending = undefined;
     current = undefined;
     lastError = undefined;
     replacement ??= createMetadataReplacement();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading chat metadata could wait indefinitely after a configured model owner failed and another owner's authentication refreshed successfully. Healthy auth publication could also produce a false `chat metadata refresh failed` warning when previously queued metadata work ran during the replacement window.

## Why This Change Was Made

Metadata invalidation now revokes obsolete refresh work while preserving its existing replacement wait and shutdown ownership. The Gateway lifecycle distinguishes an owner that has not published yet from one whose publication is pending or has failed, so subordinate changes cannot erase a recorded failure and create an unowned wait. The canonical publication event still rebuilds fresh metadata; real preparation and publication failures remain visible.

This completes the owner boundary used by #123433. It does not change configuration, persistence, protocol, dependencies, or provider policy. Production LOC: +31/-25 (net +6) for the required initial/available/unavailable distinction and refresh ownership fencing. Tests: +370/-9.

## User Impact

Chat metadata waits for the current publication and returns its result or recorded failure. Superseded background work cannot publish stale auth availability or fail a newer reader. Shutdown still joins outstanding preparation and projections.

## Evidence

- On unchanged `d3386f151859443fe9dd589d7451ffde1554afd0`, three complete suites produced exactly nine expected regression failures and 71 passing controls. The real prepared-owner composition reproduces the stranded reader after a prior worker failure followed by a successful main-only auth publication.
- On this candidate, all 88 tests in seven complete suites pass: lifecycle, runtime preparation, real prepared-owner composition, shutdown, personal accounts, native sessions, and the Gateway RPC boundary.
- Tests preserve initial missing-owner recovery, nested invalidation of an existing reader, current preparation/projection failures, stale auth fencing, failed-owner recovery, and shutdown joins. No new production test seam.
- Managed independent Codex review through P2: scoped-clean, no actionable findings. Formatting and `git diff --check` pass; the normal pre-commit hook preserves the tested source bytes.
- Uninstrumented compiled Gateway baseline: fresh and restarted synthetic QA-channel conversations each reproduced the warning; four replies and twelve metadata RPCs succeeded with both configured models available. The implicated source owners are byte-identical between that baseline and the current base. Candidate compiled Gateway replay passes: fresh and restarted cases each return two replies and five successful metadata RPCs, with both configured models available and zero refresh warnings. Full source/dist/package identity and owned shutdown checks pass. The initial complete changed gate and hosted CI found seven test-only lint errors; the follow-up normalizes Promise callbacks without changing assertions or production bytes. Fresh managed P2 review of that follow-up is scoped-clean. Final typed lint and both affected suites pass (37 tests); the complete changed gate passes in 211.945 seconds, and [exact-head CI33976332511](https://github.com/openclaw/openclaw/actions/runs/33976332511) is green on `f0ca6cd52633e367721a4c5809ff1ca5d3e4abe8`. All owned process groups were confirmed dead and proof archives downloaded and hash-verified.

Provenance: the warning predates the unrelated session-patch repair that exposed it during QA. The original introducing change is unproven; no causal attribution to that repair. The live evidence uses a real built Gateway and QA channel with a loopback synthetic provider, and does not establish production prevalence.
