### PR TITLE
fix(doctor): keep Workshop relocation lint read-only

### DIFF
--- a/src/commands/doctor-skill-workshop-relocation.ts
+++ b/src/commands/doctor-skill-workshop-relocation.ts
@@ -228,18 +228,12 @@ export async function readLegacyWorkshopSourceStat(workspaceDir: string, source:
   return sourceStat;
 }
 
-export async function planWorkshopRelocation(
+export function classifyWorkshopRelocation(
   records: LegacyWorkshopProposal[],
   config: OpenClawConfig,
   env: NodeJS.ProcessEnv,
   deferredSources: ReadonlySet<string> = new Set(),
-): Promise<{
-  moves: WorkshopMove[];
-  updates: WorkshopProposalUpdate[];
-  externalProposalCount: number;
-  externalProposalCountsByAgent: Record<string, number>;
-  warnings: string[];
-}> {
+) {
   const candidates = records.flatMap<WorkshopRelocationPlan>((entry) => {
     if (entry.record.status !== "pending" && entry.record.status !== "applied") {
       return [];
@@ -274,6 +268,21 @@ export async function planWorkshopRelocation(
   // Completed updates provide recovery evidence, not ownership or relocation actions.
   const external = candidates.filter(
     ({ record }) => record.status === "pending" || record.kind === "create",
+  );
+  return { candidates, external };
+}
+
+export async function planWorkshopRelocation(
+  records: LegacyWorkshopProposal[],
+  config: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+  deferredSources: ReadonlySet<string> = new Set(),
+) {
+  const { candidates, external } = classifyWorkshopRelocation(
+    records,
+    config,
+    env,
+    deferredSources,
   );
   const warnings: string[] = [];
   const deferredWorkspaces = new Set<string>();
@@ -503,12 +512,6 @@ export async function planWorkshopRelocation(
       (move) => !conflictsBySource.has(move.source) && !deferredMoveSources.has(move.source),
     ),
     updates,
-    externalProposalCount: external.length,
-    externalProposalCountsByAgent: external.reduce<Record<string, number>>((counts, plan) => {
-      const ownerAgentId = plan.ownerAgentId ?? plan.unconfiguredOwnerAgentId ?? "unknown";
-      counts[ownerAgentId] = (counts[ownerAgentId] ?? 0) + 1;
-      return counts;
-    }, {}),
     warnings,
   };
 }

--- a/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
@@ -1,0 +1,194 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
+import { importLegacySkillProposal } from "../skills/workshop/store.js";
+import type { SkillProposalRecord } from "../skills/workshop/types.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { inspectLegacySkillWorkshopMigration } from "./doctor-skill-workshop-sqlite.js";
+import {
+  createAppliedLegacyProposal,
+  seedLegacyV15ProposalRows,
+} from "./doctor-skill-workshop-sqlite.test-support.js";
+
+async function snapshotDatabase(databasePath: string) {
+  const database = openNodeSqliteDatabase(databasePath, { readOnly: true });
+  try {
+    const stat = await fs.stat(databasePath);
+    return {
+      device: stat.dev,
+      inode: stat.ino,
+      mode: stat.mode,
+      digest: createHash("sha256")
+        .update(await fs.readFile(databasePath))
+        .digest("hex"),
+      version: database.prepare("PRAGMA user_version").get(),
+      schema: database
+        .prepare("SELECT type, name, sql FROM sqlite_schema ORDER BY type, name")
+        .all(),
+    };
+  } finally {
+    database.close();
+  }
+}
+
+describe("read-only Skill Workshop migration inspection", () => {
+  it.each([
+    { version: 16, sourcePresent: true },
+    { version: 16, sourcePresent: false },
+    { version: 15, sourcePresent: true },
+    { version: 15, sourcePresent: false },
+  ])(
+    "preserves schema $version with source present=$sourcePresent",
+    async ({ version, sourcePresent }) => {
+      await withOpenClawTestState({ layout: "split" }, async (state) => {
+        const config = { agents: { entries: { main: { workspace: state.workspaceDir } } } };
+        const content =
+          "---\nname: readonly-workshop\ndescription: Preserved procedure\n---\n\n# Keep\n";
+        const legacyDir = path.join(state.workspaceDir, "skills", "readonly-workshop");
+        const record = createAppliedLegacyProposal({
+          id: "readonly-workshop-20260905-1234567890",
+          title: "Create Readonly Workshop",
+          description: "Preserved procedure",
+          content,
+          target: { skillKey: "readonly-workshop", skillDir: legacyDir },
+        });
+        const skillFile = sourcePresent
+          ? record.target.skillFile
+          : path.join(
+              resolveWorkshopSkillsDir(config, "main", state.env),
+              "readonly-workshop",
+              "SKILL.md",
+            );
+        await fs.mkdir(path.dirname(skillFile), { recursive: true });
+        await fs.writeFile(skillFile, content);
+        if (version === 15) {
+          seedLegacyV15ProposalRows(state.env, [
+            { record, workspaceDir: state.workspaceDir, claimReleasedTime: null },
+          ]);
+        } else {
+          importLegacySkillProposal({ record, ownerAgentId: "main", store: { env: state.env } });
+        }
+        closeOpenClawStateDatabaseForTest();
+        const databasePath = resolveOpenClawStateSqlitePath(state.env);
+        const seed = openNodeSqliteDatabase(databasePath);
+        try {
+          // Empty feature tables may be absent under LAZY_ADDITIVE_STATE_TABLES.
+          seed.exec(`
+          DROP TABLE skill_workshop_proposal_events;
+          DROP TABLE skill_workshop_proposal_rollbacks;
+          DROP TABLE skill_workshop_collection_reviews;
+        `);
+        } finally {
+          seed.close();
+        }
+        const before = await snapshotDatabase(databasePath);
+
+        await expect(
+          inspectLegacySkillWorkshopMigration({ config, env: state.env }),
+        ).resolves.toEqual({
+          externalProposalCount: 1,
+          externalProposalCountsByAgent: { main: 1 },
+          legacyBackupRootCount: 0,
+        });
+
+        closeOpenClawStateDatabaseForTest();
+        expect(await snapshotDatabase(databasePath)).toEqual(before);
+        expect(await fs.readFile(skillFile, "utf8")).toBe(content);
+      });
+    },
+  );
+
+  it("preserves proposal status filters, ownership precedence, and unknown owner counts", async () => {
+    await withOpenClawTestState({ layout: "split" }, async (state) => {
+      const config = {
+        agents: {
+          entries: {
+            main: { workspace: state.workspaceDir },
+            other: { workspace: path.join(state.root, "other-workspace") },
+          },
+        },
+      };
+      const cases: Array<{
+        name: string;
+        owner: string | null;
+        kind?: SkillProposalRecord["kind"];
+        status?: SkillProposalRecord["status"];
+        origin?: SkillProposalRecord["origin"];
+        owned?: boolean;
+        unknownWorkspace?: boolean;
+      }> = [
+        { name: "pending-create", owner: "MAIN", status: "pending", origin: { agentId: "other" } },
+        { name: "pending-update", owner: "main", kind: "update", status: "pending" },
+        { name: "applied-create", owner: "main" },
+        { name: "applied-update", owner: "main", kind: "update" },
+        { name: "rejected", owner: "main", status: "rejected" },
+        { name: "quarantined", owner: "main", status: "quarantined" },
+        { name: "stale", owner: "main", status: "stale" },
+        { name: "owned", owner: "main", owned: true },
+        { name: "unowned-inside", owner: null, owned: true, origin: { agentId: "main" } },
+        {
+          name: "origin-agent",
+          owner: null,
+          origin: { agentId: "other", sessionKey: "agent:main:main" },
+        },
+        { name: "origin-session", owner: null, origin: { sessionKey: "agent:other:main" } },
+        { name: "retired", owner: "retired", origin: { agentId: "main" } },
+        { name: "unknown", owner: null, unknownWorkspace: true },
+        { name: "workspace-owner", owner: null },
+      ];
+      for (const sample of cases) {
+        const root = sample.owned
+          ? resolveWorkshopSkillsDir(config, "main", state.env)
+          : path.join(
+              sample.unknownWorkspace
+                ? path.join(state.root, "unknown-workspace")
+                : state.workspaceDir,
+              "skills",
+            );
+        const record: SkillProposalRecord = {
+          ...createAppliedLegacyProposal({
+            id: `${sample.name}-20260905-1234567890`,
+            title: sample.name,
+            description: "Ownership classification",
+            content: "# Preserved\n",
+            target: { skillKey: sample.name, skillDir: path.join(root, sample.name) },
+          }),
+          kind: sample.kind ?? "create",
+          status: sample.status ?? "applied",
+          ...(sample.origin ? { origin: sample.origin } : {}),
+        };
+        importLegacySkillProposal({
+          record,
+          ownerAgentId: sample.owner ?? "main",
+          store: { env: state.env },
+        });
+      }
+      closeOpenClawStateDatabaseForTest();
+      const seed = openNodeSqliteDatabase(resolveOpenClawStateSqlitePath(state.env));
+      try {
+        for (const sample of cases.filter((entry) => entry.owner === null)) {
+          seed
+            .prepare(
+              "UPDATE skill_workshop_proposals SET owner_agent_id = NULL WHERE proposal_id = ?",
+            )
+            .run(`${sample.name}-20260905-1234567890`);
+        }
+      } finally {
+        seed.close();
+      }
+
+      await expect(
+        inspectLegacySkillWorkshopMigration({ config, env: state.env }),
+      ).resolves.toEqual({
+        externalProposalCount: 9,
+        externalProposalCountsByAgent: { main: 5, other: 2, retired: 1, unknown: 1 },
+        legacyBackupRootCount: 0,
+      });
+    });
+  });
+});

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -47,6 +47,7 @@ import {
   migrateLegacyCollectionBackups,
 } from "./doctor-skill-workshop-collection-backups.js";
 import {
+  classifyWorkshopRelocation,
   inferOwnerAgentId,
   planWorkshopRelocation,
   readLegacyWorkshopSourceStat,
@@ -130,11 +131,16 @@ export async function inspectLegacySkillWorkshopMigration(params: {
   } finally {
     database?.walMaintenance.close();
   }
-  const plan = await planWorkshopRelocation(records, params.config, env);
+  // Lint needs ownership counts, not adoption verification through writable recovery readers.
+  const { external } = classifyWorkshopRelocation(records, params.config, env);
   const backups = await listPendingLegacyCollectionBackupRoots(params.config, env);
   return {
-    externalProposalCount: plan.externalProposalCount,
-    externalProposalCountsByAgent: plan.externalProposalCountsByAgent,
+    externalProposalCount: external.length,
+    externalProposalCountsByAgent: external.reduce<Record<string, number>>((counts, plan) => {
+      const ownerAgentId = plan.ownerAgentId ?? plan.unconfiguredOwnerAgentId ?? "unknown";
+      counts[ownerAgentId] = (counts[ownerAgentId] ?? 0) + 1;
+      return counts;
+    }, {}),
     legacyBackupRootCount: backups.length,
   };
 }


### PR DESCRIPTION
Closes #139187 (Doctor lint changes Workshop state during relocation inspection).

## What Problem This Solves

Fixes an issue where operators running `doctor --lint` could initialize or migrate the shared database when an interrupted Skill Workshop relocation had already moved a skill but still referenced its old path. The command returned an ordinary warning despite those writes.

## Why This Change Was Made

Inspection now uses the same proposal-status and ownership classification as migration planning to calculate its counts. Full destination verification remains with actual migration. This preserves the existing Workshop reader's visibility, reconciliation, and recovery checks without introducing another store reader or changing the schema.

## User Impact

Operators can diagnose pending Workshop relocations without that inspection creating tables or upgrading their database. Warning counts and explicit migration behavior are preserved.

## Evidence

- Native SQLite and the real built selected lint command reproduced the baseline write; source-present controls preserved state.
- The five regression cases ran against unchanged production: exactly the two adoption cases failed; the controls and 14-row status/owner-count matrix passed.
- Current-v16 optional-table absence independently proves the defect. The v15 case reconstructs the old proposal layout using existing test support; it is not a complete historical database snapshot.
- Independent P2 review found no accepted findings. Normal commit hooks passed; the committed tree matches the reviewed candidate.
- Candidate `check:changed` passed, including core/test typechecking, all three Knip scans, type-aware lint, and repository guards.
- All 124 tests across 12 Workshop migration, Doctor lint/state-isolation, and Workshop health files passed with zero skips.
- Fresh build passed. All eight native-owner and built-CLI source/adoption cases preserved schema, version, proposal/config/skill content, and durable database/WAL bytes. The tested tree exactly matches commit `900d0f41b20f4272ec69360352e600ee90c73869`.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33975797847) passed, including the Windows checks.

The initial CLI controller's main-file-only byte criterion failed because commits remained in WAL. Its failure is retained; the qualified replay checks schema plus database/nonempty-WAL hashes, with all 11,041 baseline build files unchanged.

**Data-model compatibility (ClawSweeper follow-up):** the change touches migration orchestration filenames, but introduces no stored-data-model change. `src/state/**` and `src/skills/workshop/**` are byte-identical to the base commit: schema definitions/versions, row formats, record readers/writers, reconciliation, and bundle visibility checks are unchanged. The nine Workshop migration sibling suites passed, covering legacy import and v15-layout upgrade, interrupted relocation/apply, destination conflicts, deferred reservations, coordination/atomicity, and collection-backup preservation. The new classifier retains the same candidates for that migration flow; inspection only counts them. This compatibility evidence addresses the review’s requested confirmation.
