### PR TITLE
fix(failover): defer unclassified harness-internal failures to neutral fallback

### DIFF
--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -200,13 +200,16 @@ describe("formatAssistantErrorText", () => {
   it.each([
     "Session transcript projection is rebuilding: private-session",
     "opaque-private-provider-detail",
-  ])("keeps model context without assigning an unclassified failure: %s", (raw) => {
+  ])("defers to neutral fallback without assigning an unclassified failure: %s", (raw) => {
+    // Harness-internal errors (e.g. session-store projection failures) must
+    // not attribute the failure to the provider that was never contacted.
+    // The neutral GENERIC_ASSISTANT_ERROR_TEXT fallback handles them. See #137845.
     expect(
       formatUserFacingAssistantErrorText(makeAssistantError(raw), {
         provider: "openai",
         model: "test-model",
       }),
-    ).toBe("⚠️ Agent run failed (model: openai/test-model).");
+    ).toBe(GENERIC_ASSISTANT_ERROR_TEXT);
   });
 
   it("keeps the generic last resort when no classified facts are available", () => {

--- a/src/agents/failover/assistant-request-failure-copy.test.ts
+++ b/src/agents/failover/assistant-request-failure-copy.test.ts
@@ -3,12 +3,14 @@ import { renderAssistantRequestFailureCopy } from "./assistant-request-failure-c
 
 describe("renderAssistantRequestFailureCopy", () => {
   const target = { provider: "openai", model: "test-model" };
-  const runFailure = "⚠️ Agent run failed (model: openai/test-model).";
 
   it.each([undefined, null, "unclassified", "unknown"] as const)(
-    "keeps the model as context when reason is %s",
+    "defers to neutral fallback for unclassified reason %s",
     (reason) => {
-      expect(renderAssistantRequestFailureCopy({ ...target, reason })).toBe(runFailure);
+      // Harness-internal failures must not name the provider/model even when a
+      // target is present — the provider was never contacted. See #137845.
+      expect(renderAssistantRequestFailureCopy({ ...target, reason })).toBeUndefined();
+      expect(renderAssistantRequestFailureCopy({ reason })).toBeUndefined();
     },
   );
 
@@ -23,15 +25,15 @@ describe("renderAssistantRequestFailureCopy", () => {
   );
 
   it.each([
-    [{ provider: "openai" }, "⚠️ Agent run failed (provider: openai)."],
-    [{ model: "test-model" }, "⚠️ Agent run failed (model: test-model)."],
+    [{ provider: "openai" }, undefined],
+    [{ model: "test-model" }, undefined],
     [{}, undefined],
-  ] as const)("handles partial model context %j", (facts, expected) => {
+  ] as const)("defers partial model context %j to neutral fallback", (facts, expected) => {
     expect(renderAssistantRequestFailureCopy(facts)).toBe(expected);
   });
 
   it("requires a valid HTTP status before asserting a request failure", () => {
-    expect(renderAssistantRequestFailureCopy({ ...target, status: 0 })).toBe(runFailure);
+    expect(renderAssistantRequestFailureCopy({ ...target, status: 0 })).toBeUndefined();
     expect(renderAssistantRequestFailureCopy({ ...target, status: 400 })).toBe(
       "⚠️ openai/test-model request failed (HTTP 400).",
     );
@@ -41,5 +43,21 @@ describe("renderAssistantRequestFailureCopy", () => {
     expect(renderAssistantRequestFailureCopy({ ...target, reason: "auth" })).toBe(
       "⚠️ openai/test-model request failed (authentication failed). Re-authenticate the provider and try again.",
     );
+  });
+
+  it("does not name the provider for a harness-internal error with a populated target", () => {
+    // Mirrors #137845: a session-store error like
+    // SessionTranscriptProjectionUnavailableError synthesizes a failure message
+    // that still carries the turn's active provider/model. The renderer must
+    // defer to the neutral fallback instead of attributing the failure to the
+    // provider that was never contacted.
+    expect(
+      renderAssistantRequestFailureCopy({
+        provider: "openai",
+        model: "gpt-5",
+        reason: null,
+        status: undefined,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/agents/failover/assistant-request-failure-copy.ts
+++ b/src/agents/failover/assistant-request-failure-copy.ts
@@ -50,7 +50,10 @@ export function renderAssistantRequestFailureCopy(
   const unclassified =
     !facts.reason || facts.reason === "unclassified" || facts.reason === "unknown";
   if (!reason && !status && (!target || unclassified)) {
-    return target ? `⚠️ Agent run failed (${model ? "model" : "provider"}: ${target}).` : undefined;
+    // Unclassified (harness-internal) failures must not name the provider/model
+    // even when a target is present — the provider was never contacted. Defer to
+    // the caller's GENERIC_ASSISTANT_ERROR_TEXT neutral fallback. See #137845.
+    return undefined;
   }
   const details = [reason, status].filter(Boolean);
   const summary = `⚠️ ${target ? `${target} request failed` : "LLM request failed"}${details.length > 0 ? ` (${details.join(", ")})` : ""}.`;


### PR DESCRIPTION
## What Problem This Solves

Fixes #137845.

When a turn fails from a harness-internal error — e.g. a session-store error like `SessionTranscriptProjectionUnavailableError` — `renderAssistantRequestFailureCopy()` still interpolated the turn's active provider/model as the failing target, surfacing `⚠️ {provider}/{model} request failed.` (or `⚠️ Agent run failed (model: {target}).`) to the channel even though the provider was never contacted. This misdirects users toward provider troubleshooting for failures originating inside OpenClaw.

**Root cause** (`assistant-request-failure-copy.ts:53`): a populated `target` was sufficient to render the provider/model summary, even with neither a classified `reason` nor a valid HTTP `status`. The caller's neutral fallback (`GENERIC_ASSISTANT_ERROR_TEXT = "LLM request failed."`) was bypassed.

## The Fix

One-line behavior change at `assistant-request-failure-copy.ts:53`:

```diff
- return target ? `⚠️ Agent run failed (${model ? "model" : "provider"}: ${target}).` : undefined;
+ return undefined;
```

When the failure is **unclassified** (no `reason`, or `reason` is `"unclassified"`/`"unknown"`) and has **no valid HTTP status**, return `undefined` so the caller (`formatUserFacingAssistantErrorText` → `renderAssistantRequestFailureCopy(facts) ?? GENERIC_ASSISTANT_ERROR_TEXT`) uses the neutral `LLM request failed.` fallback instead of naming the provider that was never contacted.

**Recognized provider terminals are preserved**: `empty_response` / `no_error_details` have a `reason` *key* (the value `""` is falsy but the `unclassified` flag is `false`), so they fall through to the `⚠️ {target} request failed.` summary with attribution — exactly as before.

## Evidence

### Before-fix behavior (bug)

With the old code, a harness-internal error carrying a populated target rendered a provider-named summary:

```
renderAssistantRequestFailureCopy({ provider: "openai", model: "gpt-5", reason: null, status: undefined })
// → "⚠️ Agent run failed (model: openai/gpt-5)."   ← names provider that was never contacted
```

### After-fix behavior

```
renderAssistantRequestFailureCopy({ provider: "openai", model: "gpt-5", reason: null, status: undefined })
// → undefined   ← caller falls back to GENERIC_ASSISTANT_ERROR_TEXT = "LLM request failed."
```

Recognized provider terminals keep attribution:

```
renderAssistantRequestFailureCopy({ provider: "openai", model: "test-model", reason: "empty_response" })
// → "⚠️ openai/test-model request failed."   ← unchanged
```

### Test results

- `src/agents/failover/assistant-request-failure-copy.test.ts`: **12/12 pass** (was 10; 3 updated to reflect correct behavior, 1 new test added)
- `src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts` (caller): **102/102 pass** (1 `it.each` updated to expect the neutral fallback)

Updated tests that previously codified the bug:
- `"keeps the model as context when reason is %s"` → `"defers to neutral fallback for unclassified reason %s"` (expects `undefined` for `undefined`/`null`/`"unclassified"`/`"unknown`)
- `"handles partial model context %j"` → `"defers partial model context %j to neutral fallback"` (expects `undefined` for partial provider/model without a classified reason)
- `"requires a valid HTTP status..."` — `status: 0` now expects `undefined` (was `runFailure`)
- caller `"keeps model context without assigning an unclassified failure"` → `"defers to neutral fallback without assigning an unclassified failure"` (expects `GENERIC_ASSISTANT_ERROR_TEXT`)

New test:
- `"does not name the provider for a harness-internal error with a populated target"` — mirrors the #137845 scenario (session-store error carrying provider/model, reason null).

Run locally with Node v24.15.0, vitest 4.1.11:
```
npx vitest run src/agents/failover/assistant-request-failure-copy.test.ts src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
# Test Files  2 passed (2)
#      Tests  114 passed (114)
```

Verified the fix base matches `origin/main` at `952105ddd981e3339775621a4e5c3dfedde5c9da` — only the intended lines differ.
