### PR TITLE
refactor(android): remove unused updater export root

### DIFF
--- a/apps/android/app/src/main/res/xml/file_paths.xml
+++ b/apps/android/app/src/main/res/xml/file_paths.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <cache-path name="apk_updates" path="updates/" />
     <cache-path name="widget_exports" path="exports/" />
     <cache-path name="workspace_files" path="workspace-files/" />
 </paths>

--- a/apps/android/app/src/test/java/ai/openclaw/app/FileProviderPathsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/FileProviderPathsTest.kt
@@ -1,0 +1,77 @@
+package ai.openclaw.app
+
+import android.app.Application
+import android.net.Uri
+import androidx.core.content.FileProvider
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowContentResolver
+import java.io.File
+import java.nio.file.Files
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36], application = Application::class)
+class FileProviderPathsTest {
+  private val application = RuntimeEnvironment.getApplication()
+  private val authority = "${application.packageName}.fileprovider"
+
+  @Before
+  fun attachManifestProvider() {
+    assertTrue(ShadowContentResolver.getProvider(Uri.parse("content://$authority")) is FileProvider)
+  }
+
+  @Test
+  fun activeExportRootsServeTheirOriginalBytes() {
+    for (root in listOf("exports", "workspace-files")) {
+      withCacheFile(root) { file ->
+        val uri = FileProvider.getUriForFile(application, authority, file)
+        val bytes = checkNotNull(application.contentResolver.openInputStream(uri)).use { it.readBytes() }
+        assertArrayEquals("synthetic $root export".toByteArray(), bytes)
+      }
+    }
+  }
+
+  @Test
+  fun retiredUpdatesCannotIssueContentUris() {
+    withCacheFile("updates") { file ->
+      assertThrows(IllegalArgumentException::class.java) {
+        FileProvider.getUriForFile(application, authority, file)
+      }
+    }
+  }
+
+  @Test
+  fun retiredUpdateUrisCannotBeResolved() {
+    withCacheFile("updates") { file ->
+      val uri = Uri.parse("content://$authority/apk_updates/${checkNotNull(file.parentFile).name}/${file.name}")
+      assertThrows(IllegalArgumentException::class.java) {
+        application.contentResolver.openInputStream(uri)?.close()
+      }
+    }
+  }
+
+  private fun withCacheFile(
+    root: String,
+    block: (File) -> Unit,
+  ) {
+    val cacheRoot = File(application.cacheDir, root)
+    val rootExisted = cacheRoot.exists()
+    check(cacheRoot.isDirectory || cacheRoot.mkdirs())
+    val directory = Files.createTempDirectory(cacheRoot.toPath(), "file-provider-").toFile()
+    try {
+      val file = File(directory, if (root == "updates") "update.apk" else "export.txt")
+      file.writeText("synthetic $root export")
+      block(file)
+    } finally {
+      check(directory.deleteRecursively())
+      if (!rootExisted) check(cacheRoot.delete())
+    }
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Android's sharing configuration still exposes a cache root for the removed in-app updater. There is no remaining producer for that root. This removes obsolete configuration, not a demonstrated vulnerability or a user-visible feature.

Related: #139141.

## Why This Change Was Made

Remove only the `apk_updates` mapping. Keep the `widget_exports` and `workspace_files` names, directories, provider authority, non-exported provider declaration, grant flags, and retention behavior unchanged.

The updater's original implementation and its last implementation before removal both wrote APK bytes through `PackageInstaller.Session` streams; neither issued FileProvider URIs. Its removal is already in stable v2026.3.8. This change does not assume that URI grants expire when a screen closes or an app upgrades.

## User Impact

No intended user-visible change. Widget clipboard exports and workspace sharing retain their existing paths. No dependency, configuration option, permission, storage schema, or migration changes.

## Evidence

- Resource-backed tests use the manifest-declared AndroidX FileProvider: both active roots serve the original bytes, while the retired root cannot issue or resolve a URI. With the original XML, the two retired-root cases fail and the active-root case passes in both Android flavors; with the cleanup, all three pass.
- 36 focused tests across Play and third-party flavors pass, covering FileProvider roots, workspace sharing and parsing, widget export, and inline-widget cleanup. All 13 selected changed checks pass, including Android lint.
- Direct AndroidX Core 1.19.0 source review covers root parsing, URI issuance/resolution, and manifest attachment. Updater history and both current export callers were inspected. Independent review and Codex review found no actionable findings.
- Production delta: one line removed. Tests: 77 lines added. No generated files changed.

Fresh committed-head Play and third-party APK builds passed. Both packaged manifests, resource tables, and compiled FileProvider mappings retain exactly the two active roots; both APK signatures verify. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33977251064) and its required gate passed.

Installed API36 proof used exact Play APK `41669de2bd5c0a665258dde8764531b4741497003d5aea0994ef59b3ed13e44f` from `ce7fdc7888dc4ad47e366cadde0065542018e250`, a real Gateway at `c748cd5714b8160f0ce0a895071f039877082f08`, and a separately signed receiving app on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/33976496120). The normal error retained the loaded preview; retry worked; first text, second same-name text, and PNG reached the same receiving Activity. It reopened all earlier URI streams and verified their distinct bytes, MIME types, permissions, and separate source/receiver UIDs. Root and independent review rehashed all 2,859 evidence files. The native run exited 0, and native/Gateway processes, ports, lease, temporary key and checkout were verified closed.

![Share failure keeps the loaded preview](https://github.com/user-attachments/assets/3ae1fc64-d9c0-4476-a9f9-b7ac09ce382e)

![Separate receiving app verifies all three retained export streams](https://github.com/user-attachments/assets/98cbd890-03b9-4ddb-ace9-ae2b4178d614)

Installed scope is workspace sharing; widget clipboard coverage here is resource-backed tests and compiled mapping inspection, not a new installed clipboard test. This does not change or certify a new retention policy, OEM matrix, or release build.

## Review dispositions

The completed review's APK/installed-proof prerequisite and rank-up move are now complete above. No source change followed review.

The review worker could not obtain dependency/history blobs; that evidence gap was resolved by direct maintainer and independent inspection, not assumed away. [AndroidX Core 1.19.0 source](https://dl.google.com/dl/android/maven2/androidx/core/core/1.19.0/core-1.19.0-sources.jar), SHA256 `dabdcce52939de70764cf967c7844da2222830d6a17ae20eefb41b2051964712`, was inspected for FileProvider root parsing, issuance, resolution and manifest attachment. The [original updater](https://github.com/openclaw/openclaw/blob/c179f71f42bcb9a3d8cc3e5da4dacdb6970189d1/apps/android/app/src/main/java/ai/openclaw/android/node/AppUpdateHandler.kt#L250) and [last pre-removal updater](https://github.com/openclaw/openclaw/blob/492fe679a703a0809be1575c65183af02a0a4182/apps/android/app/src/main/java/ai/openclaw/app/node/AppUpdateHandler.kt#L252) use `Session.openWrite`, stream copy, `fsync`, and `commit`, not FileProvider grants. Raw-parent history and the [removal commit](https://github.com/openclaw/openclaw/commit/0f9566b0b51249006f9a183b0b78bde206b707f9) were verified. No grant-expiry assumption, compatibility wrapper, or permission weakening is introduced.

The branch is in `openclaw/openclaw`, where maintainers can update it directly.
