### PR TITLE
fix(i18n): unblock native locale refresh

### DIFF
--- a/test/scripts/apple-app-i18n.test.ts
+++ b/test/scripts/apple-app-i18n.test.ts
@@ -95,7 +95,6 @@ describe("Apple app i18n catalogs", () => {
       "Approval needed",
       "Agent: %@",
       "Connect a nearby Gateway",
-      "Direct mode supports device info, status, and notifications. Chat, Talk, and approvals still use the iPhone.",
       "Expires in %@",
       "Location Services are off in iOS Settings.",
       "Message Routing",


### PR DESCRIPTION
## What Problem This Solves

The native locale refresh in #139177 fails because an Apple catalog test still requires retired Watch explanatory text. The generator correctly removed that key after the Watch UI changed in #135808; the replacement is present in all 22 locales.

## Why This Change Was Made

Remove only the obsolete sentence from the translated-key sample. Keep the other 13 samples and every locale/value assertion. The replacement sentence already has an exact source-path extraction regression in `test/scripts/native-app-i18n.test.ts`; strict generated-catalog parity continues to cover the complete current inventory.

Replacing the sample with the new sentence would fail source-main while its checked-in catalog intentionally awaits the serialized locale refresh. Restoring the retired generated key would be incorrect. This source-only repair works on both sides of that refresh, without conditional skips or changes to the generator, parity checks, or generated files.

Related: #139177, #139035, #139141.

## User Impact

No app behavior changes. This repairs the test blocking the generated native translations, including Android's theme labels and workspace-sharing error message.

## Evidence

- The unchanged sample test fails against the exact iOS catalog from #139177 head `60829f1ab3a9e21ccd05302b5512476d99e4f5c8`, reproducing the missing retired-key failure from CI run 33974556324.
- After the one-line deletion, both complete Apple/native i18n test files pass: 43 tests against source-main's catalog and 43 against that exact refreshed iOS catalog. Each temporary catalog overlay was restored byte-for-byte; no generated files are in this patch.
- Canonical native source verification passes with no inventory change; the selected changed checks and diff validation pass.
- Root-cause/history review and independent Codex review found no actionable findings. Production delta: zero. Test delta: one line removed.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33976257961) passed. The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/139199#issuecomment-5553022796) found no correctness or security findings and no before-merge work. The normal maintainer landing gates still apply. The generated PR remains owned by the existing locale workflow; this PR does not edit or merge its branch.

The branch is in `openclaw/openclaw`, where maintainers can update it directly.
