### PR TITLE
fix(markdown-core): stop file:// link leak + preserve data:image images + channel allowlists

### DIFF
--- a/extensions/googlechat/src/format.ts
+++ b/extensions/googlechat/src/format.ts
@@ -305,6 +305,11 @@ function renderGoogleChatIR(ir: MarkdownIR, markers: GoogleChatMarkers): string 
         if (!href || !label) {
           return null;
         }
+        // Local-file links expose machine-local paths and have no useful Chat
+        // target; collapse to the label text instead of serializing the path.
+        if (/^file:/i.test(href)) {
+          return null;
+        }
         const labelHasStyles = ir.styles.some(
           (span) => span.start < link.end && span.end > link.start,
         );

--- a/extensions/msteams/src/format.test.ts
+++ b/extensions/msteams/src/format.test.ts
@@ -132,6 +132,11 @@ describe("formatMSTeamsMarkdown", () => {
       after: "[x](<https://host/a>)",
     },
     {
+      name: "collapses file: link destinations to their label text",
+      before: "see [config](file:///etc/config.yaml)",
+      after: "see config",
+    },
+    {
       name: "drops code language while keeping a collision-safe fence",
       before: ["````md", "```", "example", "```", "````"].join("\n"),
       after: ["````", "```", "example", "```", "````"].join("\n"),

--- a/extensions/msteams/src/format.ts
+++ b/extensions/msteams/src/format.ts
@@ -551,12 +551,19 @@ export function formatMSTeamsMarkdown(markdown: string, tableMode: MarkdownTable
     {
       styleMarkers: MSTEAMS_MARKERS,
       escapeText: (text) => text,
-      buildLink: (link) => ({
-        start: link.start,
-        end: link.end,
-        open: "[",
-        close: `](${serializeMarkdownDestination(link.href)})`,
-      }),
+      buildLink: (link) => {
+        // Local-file links expose machine-local paths and have no useful Teams
+        // target; collapse to the label text instead of serializing the path.
+        if (/^file:/i.test(link.href.trim())) {
+          return null;
+        }
+        return {
+          start: link.start,
+          end: link.end,
+          open: "[",
+          close: `](${serializeMarkdownDestination(link.href)})`,
+        };
+      },
     },
     MSTEAMS_FORMAT_CAPABILITIES,
   );

--- a/extensions/slack/src/format.test.ts
+++ b/extensions/slack/src/format.test.ts
@@ -150,6 +150,13 @@ describe("normalizeSlackOutboundText", () => {
     expect(res).toBe("• item\n  • nested");
   });
 
+  it("collapses file: link destinations to their label text", () => {
+    // Local-file links have no useful Slack target and would expose machine
+    // paths; the shared parser admits file: so the label renders as text
+    // instead of leaking raw markdown.
+    expect(normalizeSlackOutboundText("see [config](file:///etc/config.yaml)")).toBe("see config");
+  });
+
   it("handles complex message with multiple elements", () => {
     const res = normalizeSlackOutboundText(
       "**Important:** Check the _docs_ at [link](https://example.com)\n\n- first\n- second",

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -86,6 +86,13 @@ function buildSlackLink(link: MarkdownLinkSpan, text: string) {
   if (!href) {
     return null;
   }
+  // Local-file links (file://) expose machine-local paths and have no useful
+  // Slack target. The shared parser now admits file: as a link destination
+  // (see packages/markdown-core ir.ts validateLink) so the label renders as
+  // text instead of leaking raw markdown; collapse the link to its label.
+  if (/^file:/i.test(href)) {
+    return null;
+  }
   const label = text.slice(link.start, link.end);
   const trimmedLabel = label.trim();
   const comparableHref = href.startsWith("mailto:") ? href.slice("mailto:".length) : href;

--- a/packages/markdown-core/src/ir.links.test.ts
+++ b/packages/markdown-core/src/ir.links.test.ts
@@ -51,3 +51,35 @@ describe("markdownToIR link provenance", () => {
     });
   });
 });
+
+describe("markdownToIR file: and scheme handling (#137705)", () => {
+  it("parses file: links into a MarkdownLinkSpan so renderers can collapse them", () => {
+    const ir = markdownToIR("see [config](file:///etc/config.yaml)");
+
+    expect(ir.links).toEqual([{ start: 4, end: 10, href: "file:///etc/config.yaml" }]);
+    // The link reaches buildLink; a channel that returns null collapses it to
+    // the label text instead of leaking the raw markdown.
+    expect(collectRenderedLinks(ir)).toEqual([
+      { href: "file:///etc/config.yaml", label: "config", origin: "authored" },
+    ]);
+  });
+
+  it("keeps javascript: and vbscript: destinations rejected at the IR layer", () => {
+    for (const scheme of ["javascript:", "vbscript:"]) {
+      const ir = markdownToIR(`[x](${scheme}alert(1))`);
+      expect(ir.links).toEqual([]);
+      expect(collectRenderedLinks(ir)).toEqual([]);
+    }
+  });
+
+  it("admits only data:image embedded images, rejecting other data: URIs", () => {
+    // Safe embedded images reach the image handler (no link span).
+    const image = markdownToIR("![alt](data:image/png;base64,AAAA)");
+    expect(image.links).toEqual([]);
+
+    // Non-image data: URIs stay rejected at the IR layer.
+    const text = markdownToIR("[x](data:text/html,<script>)");
+    expect(text.links).toEqual([]);
+    expect(collectRenderedLinks(text)).toEqual([]);
+  });
+});

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -337,6 +337,26 @@ function createMarkdownIt(options: MarkdownParseOptions): MarkdownItParser {
     typographer: false,
   });
   md.linkify.set({ fuzzyLink: true });
+  // markdown-it's default link validator rejects `file:` destinations, so a
+  // `[label](file:///path)` link never becomes a MarkdownLinkSpan and the
+  // raw markdown leaks into channel text. Allow `file:` so the link is parsed
+  // into a span; each channel's buildLink then collapses local-file links to
+  // their label text (no clickable target, no path exposure). Script-execution
+  // schemes (`javascript:`, `vbscript:`) stay rejected, and only the safe
+  // embedded-image `data:image/(gif|png|jpeg|webp)` exception is preserved.
+  md.validateLink = (rawHref: string) => {
+    const href = rawHref.trim().toLowerCase();
+    if (/^file:/i.test(href)) {
+      return true;
+    }
+    if (/^(?:javascript|vbscript):/i.test(href)) {
+      return false;
+    }
+    if (/^data:/i.test(href)) {
+      return /^data:image\/(?:gif|png|jpeg|webp);/i.test(href);
+    }
+    return true;
+  };
   md.use(markdownItCjkFriendly);
   md.use(markdownItAssistantTranscriptRoles);
   if (options.preserveDunderIdentifiers) {


### PR DESCRIPTION
## What Problem This Solves

`markdown-it`'s default `validateLink` rejects `file:` destinations, so a `[label](file:///path)` link never becomes a `MarkdownLinkSpan`. The raw markdown leaks verbatim into channel text (Telegram/Slack/MSTeams/Google Chat), exposing the local path and breaking formatting.

Fixes #137705 (P2, outbound-formatting / local-path exposure).

## Root Cause

`packages/markdown-core/src/ir.ts` creates `MarkdownIt` without a `validateLink` override, so the default applies: `/^(vbscript|javascript|file|data):/` rejects all four. `file:` links are parsed as plain text (`[label](file:///path)` stays literal), and no `MarkdownLinkSpan` is ever produced for the renderers to collapse.

## The Fix (scoped to local files)

Two small, shared changes; **non-file schemes keep their existing rendering behavior** (addresses the compatibility concern raised in the prior review):

1. **Shared parser** (`packages/markdown-core/src/ir.ts`, +20/-0): override `md.validateLink` to **admit `file:`** so the link parses into a span, while keeping `javascript:`/`vbscript:` rejected and preserving markdown-it's safe `data:image/(gif|png|jpeg|webp)` embedded-image exception. This is the single shared owner — no per-channel validator copy.

2. **Per-channel collapse** (`extensions/{slack,msteams,googlechat}/src/format.ts`): each `buildLink` returns `null` for `file:` hrefs. When `buildLink` returns `null`, the IR renderer skips link markers and the link's **label text** renders as plain text — no clickable target, no path exposure. Each guard is ~5 lines (a comment + `if (/^file:/i.test(href)) return null;`). **No scheme allowlist is introduced** — `http(s)`, `mailto`, `ftp`, etc. continue to render exactly as before.

Telegram already collapsed `file:` links via its existing `isTelegramRichLinkHref` allowlist, so it needs no change.

## Evidence

Source-level reproduction (vitest, Node v24.15.0, on current `main`):

- **Parser admits the span**: `markdownToIR("see [config](file:///etc/config.yaml)")` → `ir.links === [{ start: 4, end: 10, href: "file:///etc/config.yaml" }]` and the link reaches `buildLink` (regression test in `ir.links.test.ts`).
- **Channel collapse**: `normalizeSlackOutboundText("see [config](file:///etc/config.yaml)")` → `"see config"` (label text only); `formatMSTeamsMarkdown("see [config](file:///etc/config.yaml)")` → `"see config"`.
- **Script-execution schemes stay rejected**: `markdownToIR("[x](javascript:alert(1))").links` → `[]` (and `vbscript:`).
- **Embedded images preserved**: `markdownToIR("![alt](data:image/png;base64,AAAA)").links` → `[]` (reaches the image handler); `markdownToIR("[x](data:text/html,<script>)").links` → `[]` (non-image `data:` still rejected).
- **Non-file schemes unchanged**: existing fixtures confirm `https://` links still render (Slack `<https://example.com|docs>`, MSTeams `[x](<https://host/a>)`).

## Verification

- `packages/markdown-core/src/` (25 files, **299/299 tests pass**) including the `ir.table-block`/`ir.table-code` code-owned-edge sentinels + image handling.
- `extensions/msteams/src/format.test.ts` (**57/57**) including the new `file:` collapse fixture.
- `extensions/slack/src/format.test.ts`: the new `file:` collapse test + all link-rendering fixtures pass (one unrelated `escapeSlackMrkdwn` fixture is stale on the local worktree's older `mrkdwn.ts`; it is unchanged by this PR and passes on `main`).
- `ir.links.test.ts` (+32): 3 new regression tests (file: span admission; javascript:/vbscript: rejection; data:image-only admission).
- `oxlint` exit 0; `oxfmt --check` clean on all 7 changed files.

## Diff scope

7 files, +89/-6. Production: `ir.ts` +20, `slack/format.ts` +7, `msteams/format.ts` +13/-6 (inline arrow → block), `googlechat/format.ts` +5. Tests: `ir.links.test.ts` +32, `slack/format.test.ts` +7, `msteams/format.test.ts` +5.
