### PR TITLE
fix(config): return the saved configuration after plugin install commits

### DIFF
--- a/src/plugins/install-record-commit.persisted-result.test.ts
+++ b/src/plugins/install-record-commit.persisted-result.test.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { commitConfigWithPendingPluginInstalls } from "./install-record-commit.js";
+
+describe("committed plugin configuration", () => {
+  it.each([false, true])(
+    "returns the persisted configuration (pending records: %s)",
+    async (pending) => {
+      await withOpenClawTestState({ label: "committed-plugin-config" }, async (state) => {
+        await state.writeConfig({ gateway: { mode: "local" } });
+        const nextConfig: OpenClawConfig = {
+          gateway: { mode: "local" },
+          ...(pending
+            ? {
+                plugins: {
+                  installs: { fixture: { source: "npm" as const, spec: "fixture@1.0.0" } },
+                },
+              }
+            : {}),
+        };
+
+        const result = await commitConfigWithPendingPluginInstalls({ nextConfig });
+        const persisted = JSON.parse(await fs.readFile(state.configPath, "utf8"));
+
+        expect(result.config).toEqual(persisted);
+        expect(result.config.meta?.lastTouchedVersion).toEqual(expect.any(String));
+        expect(result.movedInstallRecords).toBe(pending);
+        expect(result.config.plugins?.installs).toBeUndefined();
+      });
+    },
+  );
+});

--- a/src/plugins/install-record-commit.ts
+++ b/src/plugins/install-record-commit.ts
@@ -634,7 +634,7 @@ export async function commitConfigWriteWithPendingPluginInstalls(params: {
         : await params.commit(params.nextConfig);
     });
     return {
-      config: params.nextConfig,
+      config: committed ? committed.nextConfig : params.nextConfig,
       installRecords: {},
       movedInstallRecords: false,
       persistedHash: committed?.persistedHash ?? null,
@@ -663,7 +663,7 @@ export async function commitConfigWriteWithPendingPluginInstalls(params: {
     commit: params.commit,
   });
   return {
-    config: strippedConfig,
+    config: result.committed ? result.committed.nextConfig : strippedConfig,
     installRecords: result.nextInstallRecords,
     movedInstallRecords: true,
     persistedHash: result.committed?.persistedHash ?? null,

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -183,7 +183,7 @@ const replaceConfigFile = vi.hoisted(() =>
       nextConfig: OpenClawConfig;
       snapshot?: { hash?: string };
       baseHash?: string;
-    }) => ({ config: params.nextConfig }),
+    }) => ({ nextConfig: params.nextConfig }),
   ),
 );
 const resolveGatewayPort = vi.hoisted(() =>
@@ -655,7 +655,7 @@ describe("runSetupWizard", () => {
     replaceConfigFile.mockReset();
     replaceConfigFile.mockImplementation(async (params) => {
       authoredConfig = structuredClone(params.nextConfig);
-      return { config: params.nextConfig };
+      return { nextConfig: params.nextConfig };
     });
     probeGatewayReachable.mockReset();
     probeGatewayReachable.mockResolvedValue({ ok: false });
@@ -902,7 +902,7 @@ describe("runSetupWizard", () => {
       expect(params.baseHash).toBe(diskHash);
       diskConfig = structuredClone(params.nextConfig);
       diskHash = `hash-${Number(diskHash.slice(5)) + 1}`;
-      return { config: diskConfig };
+      return { nextConfig: diskConfig };
     });
     setupChannels.mockImplementationOnce(async (config) => {
       diskConfig = {
@@ -942,7 +942,7 @@ describe("runSetupWizard", () => {
       }
       diskConfig = structuredClone(params.nextConfig);
       diskHash = `committed-${writeAttempts}`;
-      return { config: diskConfig, persistedHash: diskHash };
+      return { nextConfig: diskConfig, persistedHash: diskHash };
     });
 
     await runWizard({ workspace: "/tmp/conflicting-onboarding-workspace" });
@@ -1817,7 +1817,7 @@ describe("runSetupWizard", () => {
       }
       diskConfig = structuredClone(params.nextConfig);
       diskHash = `pending-${writeAttempts + 1}`;
-      return { config: diskConfig, persistedHash: diskHash };
+      return { nextConfig: diskConfig, persistedHash: diskHash };
     });
 
     const workspaceDir = await makeCaseDir("plugin-install-migration-");
@@ -2978,7 +2978,7 @@ describe("runSetupWizard", () => {
       );
       replaceConfigFile.mockImplementation(async ({ nextConfig }) => {
         readConfigFileSnapshot.mockResolvedValue(configSnapshot(nextConfig));
-        return { config: nextConfig };
+        return { nextConfig };
       });
       applyAuthChoice.mockImplementationOnce(async (args) => ({
         config: {


### PR DESCRIPTION
## What Problem This Solves

Setup and configuration callers could receive their old draft after saving even though the returned hash described the actual committed config. Writer-added metadata was missing from the next step.

## Why This Change Was Made

Both pending-plugin transaction paths now return the config from the existing writer result, matching direct mutation. Writers that intentionally return no result retain their behavior.

## User Impact

Setup carries the saved config forward instead of a stale draft. This repairs an internal result contract; no separate UI failure or storage-format change is claimed.

## Evidence

Both real filesystem/database regressions failed before repair. All 29 transaction tests passed afterward, and 88 setup tests passed after correcting a stale fixture. The real configure command completed on both versions; read-only debugger observations showed next-step config and the next-write baseline match disk only after the fix. The pending-record branch remains covered by the database regression.

Consumers: setup and config callers receive writer-added metadata in the committed result.

Related: #136257.
