### PR TITLE
fix(setup): bound inference-detect worker terminate wait

### DIFF
--- a/src/system-agent/setup-inference-detection.test.ts
+++ b/src/system-agent/setup-inference-detection.test.ts
@@ -339,6 +339,37 @@ describe("isolated setup inference detection", () => {
     }
   });
 
+  it("abandons a hung worker terminate so a later detect can start", async () => {
+    const { detectSetupInferenceIsolated } = await loadDetectionModule();
+    const terminateSpy = vi.spyOn(Worker.prototype, "terminate");
+    terminateSpy.mockImplementationOnce(() => new Promise(() => {}));
+
+    await expect(
+      detectSetupInferenceIsolated({
+        agentId: "main",
+        workerUrl: silentBlockingWorkerUrl,
+        timeoutMs: 50,
+        fallbackEnv: {},
+      }),
+    ).rejects.toThrow("AI access detection did not finish");
+
+    const fresh = detectedCodex();
+    await expect(
+      detectSetupInferenceIsolated({
+        agentId: "research",
+        workerUrl: blockingWorkerUrl,
+        workerData: {
+          blockMs: 0,
+          detection: fresh,
+          partialDetection: emptyDetection(),
+        },
+        timeoutMs: 5_000,
+        shutdownTimeoutMs: 50,
+        fallbackEnv: {},
+      }),
+    ).resolves.toEqual(fresh);
+  }, 5_000);
+
   it("returns successful worker results unchanged", async () => {
     const { detectSetupInferenceIsolated } = await loadDetectionModule();
     const detected = detectedCodex();

--- a/src/system-agent/setup-inference-detection.ts
+++ b/src/system-agent/setup-inference-detection.ts
@@ -9,6 +9,7 @@ import { resolveSetupInferenceCandidateBrandId } from "./setup-inference-brand.j
 import type { SetupInferenceDetection } from "./setup-inference.js";
 
 const SETUP_INFERENCE_DETECTION_TIMEOUT_MS = 30_000;
+const SETUP_INFERENCE_DETECTION_SHUTDOWN_TIMEOUT_MS = 2_000;
 
 const log = createSubsystemLogger("system-agent/setup-inference-detection");
 
@@ -31,6 +32,7 @@ type DetectionWorkerMessage =
 type DetectionWorkerOptions = {
   agentId?: string;
   timeoutMs?: number;
+  shutdownTimeoutMs?: number;
   workerUrl?: URL;
   workerData?: WorkerOptions["workerData"];
   fallbackEnv?: NodeJS.ProcessEnv;
@@ -54,6 +56,35 @@ function trackWorkerShutdown(worker: Worker): void {
       workerShutdown = undefined;
     }
   });
+}
+
+async function waitForWorkerShutdown(timeoutMs: number): Promise<void> {
+  if (!workerShutdown) {
+    return;
+  }
+  const pending = workerShutdown;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      pending,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs);
+        if (typeof timer === "object" && "unref" in timer) {
+          timer.unref();
+        }
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+  if (workerShutdown === pending) {
+    log.warn(
+      `Setup inference detection worker shutdown did not finish after ${timeoutMs}ms; abandoning worker.`,
+    );
+    workerShutdown = undefined;
+  }
 }
 
 function resolveDetectionWorkerUrl(currentModuleUrl = import.meta.url): URL {
@@ -219,10 +250,12 @@ export async function detectSetupInferenceIsolated(
     await inFlightDetection.promise.catch(() => undefined);
     return await detectSetupInferenceIsolated(options);
   }
-  // A native provider probe can delay Worker termination. Wait for exit before
-  // retrying so repeat UI requests neither stack threads nor reuse stale results.
+  // A native provider probe can delay Worker termination. Wait briefly, then
+  // abandon a stuck terminate so onboard / Control UI retries can start a new worker.
   if (workerShutdown) {
-    await workerShutdown;
+    await waitForWorkerShutdown(
+      options.shutdownTimeoutMs ?? SETUP_INFERENCE_DETECTION_SHUTDOWN_TIMEOUT_MS,
+    );
     return await detectSetupInferenceIsolated(options);
   }
   const current = runDetectionWorker(options);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators retrying AI access detection from onboard or Control UI could stay stuck after the 30s detect deadline. Detection itself already times out, but a later retry for a different agent waited forever on the previous worker's `terminate()` promise. A stuck native provider probe therefore blocked setup instead of showing the retryable error and letting the next detect start.

## Why This Change Was Made

`openclaw.setup.detect` still waits a short time for the previous worker to exit, then abandons a stuck terminate and starts a new worker. The detect deadline stays 30s. The shutdown wait is 2s by default so a healthy terminate can finish, and a hung terminate cannot pin onboard or Control UI.

## User Impact

After a timed-out detect, Retry in Control UI or another onboard pass can start a fresh worker instead of hanging behind the previous terminate. Operators still get the existing retryable timeout when no candidates were found.

## Evidence

Live `node` run against `detectSetupInferenceIsolated` in this worktree. `Worker.terminate` was replaced with a never-settling promise after the first detect timed out. A later detect for a different owner started after the 50ms shutdown bound and returned the fresh result.

Before (unfixed `origin/main` at `fb4e23e389c`): the same script printed the first timeout, then never printed a retry result. The process stayed parked on `await workerShutdown` until it was killed after 120s.

After:

```console
$ node --import tsx C:\Users\sebta\AppData\Local\Temp\oc-f065-proof.mjs
Step 1: first detect times out while terminate stays pending
first detect failed after 299ms: SetupInferenceDetectionTimeoutError: AI access detection did not finish after 0.05s. This Gateway may still be checking — try again.
[system-agent/setup-inference-detection] Setup inference detection timed out after 50ms; using partial signal if available.
Step 2: later detect for a different owner must start after the shutdown bound
[system-agent/setup-inference-detection] Setup inference detection worker shutdown did not finish after 50ms; abandoning worker.
retry settled after 205ms
retry workspace=/tmp/research candidates=1
OK: hung terminate did not block the later detect
```

## Real behavior proof

Behavior addressed: After a 30s-bounded detect times out, a hung worker terminate no longer blocks the next onboard or Control UI detect. The shutdown wait is bounded, then the previous worker is abandoned and a new worker starts.
Real environment tested: Windows, Node v24.19.0, OpenClaw worktree `fix/inference-detect-terminate-bound` based on `origin/main`, live `node --import tsx` calling `detectSetupInferenceIsolated`.
Exact steps or command run after this patch: `node --import tsx C:\Users\sebta\AppData\Local\Temp\oc-f065-proof.mjs`
Evidence after fix: terminal output copied below.

```console
$ node --import tsx C:\Users\sebta\AppData\Local\Temp\oc-f065-proof.mjs
Step 1: first detect times out while terminate stays pending
first detect failed after 299ms: SetupInferenceDetectionTimeoutError: AI access detection did not finish after 0.05s. This Gateway may still be checking — try again.
[system-agent/setup-inference-detection] Setup inference detection timed out after 50ms; using partial signal if available.
Step 2: later detect for a different owner must start after the shutdown bound
[system-agent/setup-inference-detection] Setup inference detection worker shutdown did not finish after 50ms; abandoning worker.
retry settled after 205ms
retry workspace=/tmp/research candidates=1
OK: hung terminate did not block the later detect
```

Observed result after fix: The first detect still times out in well under a second. The later detect for `research` starts after the shutdown bound, logs that the previous terminate was abandoned, and returns the fresh owner result in 205ms instead of waiting forever.
What was not tested: Live Control UI click-through against a real stuck native Codex or Claude probe on this host. Gateway process liveness while two workers overlap after abandon.

Related: [#110625](https://github.com/openclaw/openclaw/pull/110625) moved detect off the event loop and introduced the unbounded `workerShutdown` wait. [#121940](https://github.com/openclaw/openclaw/pull/121940) bounded the detect itself at 30s and documented waiting for worker exit before retry. [#112338](https://github.com/openclaw/openclaw/pull/112338) kept Control UI setup responsive when discovery stalls.

Resubmits [#139190](https://github.com/openclaw/openclaw/pull/139190) after GitHub refused reopen (barnacle closed it as the 21st open PR). Same fork head `fix/inference-detect-terminate-bound` (`6dc80ee`). Queue is under the 20-PR author cap again after #139142 merged.
