### PR TITLE
fix(heartbeat): rename misleading empty-heartbeat-file skip reason to empty-heartbeat-scratch

### DIFF
--- a/docs/automation/index.md
+++ b/docs/automation/index.md
@@ -108,7 +108,7 @@ Heartbeat is a system-owned monitor automation that runs a periodic main-session
 turn, every 30 minutes by default. It can use small monitor-scratch context to
 surface anything requiring attention without creating a detached task record or
 extending session freshness. Create separate automation jobs for work requiring
-its own schedule. Empty scratch skips as `empty-heartbeat-file`. Scheduled
+its own schedule. Empty scratch skips as `empty-heartbeat-scratch`. Scheduled
 monitor turns defer while the main queue or automation work is busy, another run
 for the same agent is active, or the target session has active or queued work.
 

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -419,7 +419,7 @@ The agent can also update its own scratch: during a heartbeat turn, `heartbeat_r
 **Migrating from HEARTBEAT.md or config-only cadence?** Run `openclaw doctor --fix`. Doctor first creates or updates the system-owned monitor rows from `agents.*.heartbeat`, then imports each agent's workspace `HEARTBEAT.md` into the monitor's scratch, converts any valid legacy `tasks:` entries into automation jobs, archives the original under the state directory (`backups/heartbeat-migration/`), and removes the file. Runtime heartbeat instructions come from database scratch only; the runtime never reads `HEARTBEAT.md`.
 </Note>
 
-If scratch exists but is effectively empty (only blank lines, Markdown/HTML comments, Markdown headings like `# Heading`, fence markers, or empty checklist stubs), OpenClaw skips the heartbeat run to save API calls. That skip is reported as `reason=empty-heartbeat-file`. If no scratch exists, the heartbeat still runs and the model decides what to do.
+If scratch exists but is effectively empty (only blank lines, Markdown/HTML comments, Markdown headings like `# Heading`, fence markers, or empty checklist stubs), OpenClaw skips the heartbeat run to save API calls. That skip is reported as `reason=empty-heartbeat-scratch`. If no scratch exists, the heartbeat still runs and the model decides what to do.
 
 Keep it tiny (short checklist or reminders) to avoid prompt bloat.
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -778,14 +778,14 @@ Look for:
 
 - Cron enabled and next wake present.
 - Job run history status (`ok`, `skipped`, `error`).
-- Heartbeat skip reasons (`quiet-hours`, `requests-in-flight`, `cron-in-progress`, `alerts-disabled`, `empty-heartbeat-file`).
+- Heartbeat skip reasons (`quiet-hours`, `requests-in-flight`, `cron-in-progress`, `alerts-disabled`, `empty-heartbeat-scratch`).
 
 <AccordionGroup>
   <Accordion title="Common signatures">
     - `cron: scheduler disabled; jobs will not run automatically` → cron disabled.
     - `cron: timer tick failed` → scheduler tick failed; check file/log/runtime errors.
     - `heartbeat skipped` with `reason=quiet-hours` → outside active hours window.
-    - `heartbeat skipped` with `reason=empty-heartbeat-file` → heartbeat monitor scratch only contains blank, comment, header, fence, or empty-checklist scaffolding, so OpenClaw skips the model call.
+    - `heartbeat skipped` with `reason=empty-heartbeat-scratch` → heartbeat monitor scratch only contains blank, comment, header, fence, or empty-checklist scaffolding, so OpenClaw skips the model call.
     - `heartbeat skipped` with `reason=no-route` → the default `owner` target has no concrete owner in `commands.ownerAllowFrom` or channel `allowFrom`, the owner cannot resolve to a DM, or no channel is configured. Explicit `last` also needs a session conversation route.
     - `heartbeat: unknown accountId` → invalid account id for heartbeat delivery target.
     - `heartbeat skipped` with `reason=dm-blocked` → heartbeat target resolved to a DM-style destination while `agents.defaults.heartbeat.directPolicy` (or per-agent override) is set to `block`.

--- a/docs/help/faq-first-run.md
+++ b/docs/help/faq-first-run.md
@@ -57,7 +57,7 @@ and troubleshooting see the main [FAQ](/help/faq).
     | Skip reason | Meaning |
     | --- | --- |
     | `quiet-hours` | Outside the configured active-hours window |
-    | `empty-heartbeat-file` | Heartbeat monitor scratch exists but only has blank, comment, header, fence, or empty-checklist scaffolding |
+    | `empty-heartbeat-scratch` | Heartbeat monitor scratch exists but only has blank, comment, header, fence, or empty-checklist scaffolding |
     | `alerts-disabled` | All heartbeat visibility is off (`showOk`, `showAlerts`, and `useIndicator` all disabled) |
 
     Older heartbeat `tasks:` blocks migrate to independently scheduled cron jobs with `openclaw doctor --fix`.

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -332,7 +332,7 @@ flowchart TD
 
     - `cron: scheduler disabled; jobs will not run automatically` → cron is disabled.
     - `heartbeat skipped` reason `quiet-hours` → outside configured active hours.
-    - `heartbeat skipped` reason `empty-heartbeat-file` → heartbeat monitor scratch contains only blank, comment, header, fence, or empty-checklist scaffolding.
+    - `heartbeat skipped` reason `empty-heartbeat-scratch` → heartbeat monitor scratch contains only blank, comment, header, fence, or empty-checklist scaffolding.
     - `heartbeat skipped` reason `alerts-disabled` → `showOk`, `showAlerts`, and `useIndicator` are all off.
     - `requests-in-flight` → main lane busy; heartbeat wake deferred.
     - `unknown accountId` → heartbeat delivery target account does not exist.

--- a/src/infra/heartbeat-runner-prompt.ts
+++ b/src/infra/heartbeat-runner-prompt.ts
@@ -45,7 +45,7 @@ export function truncateHeartbeatPreview(value: string | undefined): string | un
   return value ? truncateUtf16Safe(value, 200) : undefined;
 }
 
-type HeartbeatSkipReason = "empty-heartbeat-file" | typeof HEARTBEAT_SKIP_NO_PENDING_EVENT;
+type HeartbeatSkipReason = "empty-heartbeat-scratch" | typeof HEARTBEAT_SKIP_NO_PENDING_EVENT;
 
 type HeartbeatPreflight = HeartbeatWakePayloadFlags & {
   session: ReturnType<typeof resolveHeartbeatSessionSelection>;
@@ -181,7 +181,7 @@ export async function resolveHeartbeatPreflight(params: {
   if (isHeartbeatContentEffectivelyEmpty(heartbeatScratchContent)) {
     return {
       ...basePreflight,
-      skipReason: "empty-heartbeat-file",
+      skipReason: "empty-heartbeat-scratch",
     };
   }
   return basePreflight;

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -883,7 +883,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
         if (noise) {
           expect(await runOnce()).toMatchObject({
             status: "skipped",
-            reason: "empty-heartbeat-file",
+            reason: "empty-heartbeat-scratch",
           });
           expect(replySpy).toHaveBeenCalledTimes(1);
           expect(sendTelegram).not.toHaveBeenCalled();

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -2088,7 +2088,7 @@ tasks:
       queueCronEvent?: boolean;
       queueSystemEvent?: boolean;
       expectedStatus: "ran" | "skipped";
-      expectedSkipReason?: "empty-heartbeat-file";
+      expectedSkipReason?: "empty-heartbeat-scratch";
       expectedSendCalls: number;
       expectedReplyCalls: number;
       expectCronContext?: boolean;
@@ -2099,7 +2099,7 @@ tasks:
         name: "empty file + interval skips",
         fileState: "empty",
         expectedStatus: "skipped",
-        expectedSkipReason: "empty-heartbeat-file",
+        expectedSkipReason: "empty-heartbeat-scratch",
         expectedSendCalls: 0,
         expectedReplyCalls: 0,
       },
@@ -2107,7 +2107,7 @@ tasks:
         name: "fenced empty template + interval skips",
         fileState: "fenced-empty",
         expectedStatus: "skipped",
-        expectedSkipReason: "empty-heartbeat-file",
+        expectedSkipReason: "empty-heartbeat-scratch",
         expectedSendCalls: 0,
         expectedReplyCalls: 0,
       },


### PR DESCRIPTION
## Problem

Since heartbeat instructions migrated from the workspace `HEARTBEAT.md` into the database monitor scratch (doctor imports the file, archives it under `backups/heartbeat-migration/`, and removes it — per `docs/gateway/heartbeat.md`), the runtime never reads `HEARTBEAT.md` anymore.

However, an empty scratch still reports `heartbeat skipped: empty-heartbeat-file`. This is actively misleading: as an operator I spent a debugging session hunting for a "missing" file that the migration had deliberately deleted, before discovering the reason string refers to scratch content, not a file. The docs even have to explain the mismatch ("Empty **scratch** skips as `empty-heartbeat-file`").

## Change

- Rename the emitted skip reason `empty-heartbeat-file` → `empty-heartbeat-scratch` in `src/infra/heartbeat-runner-prompt.ts` (type + literal)
- Update the two test files asserting the literal
- Update all five docs references, which now read naturally without explaining a file/scratch mismatch

## Compatibility note

The skip reason is a machine-readable string that appears in run records and logs; anyone grepping for the old value will need to update. Happy to instead keep the old literal and only change display text if maintainers prefer strict log compatibility — but since the docs describe scratch semantics anyway, the clean rename seemed right.

Mechanical rename only; no behavior change. Relying on CI for test validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)