### PR TITLE
fix(auth): keep an unset default model unchanged during login

### DIFF
--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -1138,12 +1138,17 @@ describe("modelsAuthLoginCommand", () => {
     expect(lastUpdatedConfig?.agents?.defaults?.models).toEqual(existingModels);
   });
 
-  it("keeps an existing primary when login omits --set-default and the patch recommends another", async () => {
+  it.each([
+    { name: "an absent model", model: undefined },
+    { name: "a model string", model: "openai/gpt-5.4" },
+    { name: "a primary and fallbacks", model: { primary: "openai/gpt-5.4", fallbacks: [] } },
+    { name: "fallbacks without a primary", model: { fallbacks: ["openai/gpt-5.4"] } },
+  ])("preserves $name when login omits --set-default", async ({ model }) => {
     const runtime = createRuntime();
     currentConfig = {
       agents: {
         defaults: {
-          model: { primary: "openai/gpt-5.4", fallbacks: [] },
+          ...(model === undefined ? {} : { model }),
           models: {
             "openai/gpt-5.4": {},
             "anthropic/claude-sonnet-4-6": {},
@@ -1178,10 +1183,10 @@ describe("modelsAuthLoginCommand", () => {
 
     await modelsAuthLoginCommand({ provider: "openai" }, runtime);
 
-    expect(lastUpdatedConfig?.agents?.defaults?.model).toEqual({
-      primary: "openai/gpt-5.4",
-      fallbacks: [],
-    });
+    expect(lastUpdatedConfig?.agents?.defaults?.model).toEqual(model);
+    if (model === undefined) {
+      expect(lastUpdatedConfig?.agents?.defaults).not.toHaveProperty("model");
+    }
     expect(lastUpdatedConfig?.agents?.defaults?.models).toEqual({
       "openai/gpt-5.4": {},
       "anthropic/claude-sonnet-4-6": {},

--- a/src/plugins/provider-auth-choice-helpers.ts
+++ b/src/plugins/provider-auth-choice-helpers.ts
@@ -353,25 +353,34 @@ export function applyProviderAuthConfigPatch(
 }
 
 /**
- * Restore `agents.defaults.model` after a provider auth config merge when the user did not pass
- * `--set-default`, so `applyConfig` patches cannot replace the primary without an explicit opt-in.
+ * Restore `agents.defaults.model`, including its absence, after a provider auth config merge when
+ * the user did not pass `--set-default`.
  */
 export function restorePriorAgentsDefaultsModelUnlessOptIn(params: {
   cfg: OpenClawConfig;
   priorAgentsDefaultsModel?: AgentModelConfig;
   setDefault?: boolean;
 }): OpenClawConfig {
-  if (params.setDefault || params.priorAgentsDefaultsModel === undefined) {
+  if (params.setDefault) {
     return params.cfg;
+  }
+  if (
+    params.priorAgentsDefaultsModel === undefined &&
+    params.cfg.agents?.defaults?.model === undefined
+  ) {
+    return params.cfg;
+  }
+  const defaults = { ...params.cfg.agents?.defaults };
+  if (params.priorAgentsDefaultsModel === undefined) {
+    delete defaults.model;
+  } else {
+    defaults.model = params.priorAgentsDefaultsModel;
   }
   return {
     ...params.cfg,
     agents: {
       ...params.cfg.agents,
-      defaults: {
-        ...params.cfg.agents?.defaults,
-        model: params.priorAgentsDefaultsModel,
-      },
+      defaults,
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Provider login without --set-default could choose a default when none was configured, despite reporting that the default was unchanged.

## Why This Change Was Made

The existing default-restoration owner now preserves absence as well as existing model values, removing only an unrequested choice while retaining credentials, connection settings, aliases, and unrelated config.

## User Impact

Sign-in does not choose a default. Existing defaults and fallbacks remain, and --set-default still explicitly selects the recommendation.

## Evidence

Built CLI login with a bundled plugin reproduced the unwanted default and verified its absence after repair. Separate CLI processes confirmed saved credentials. Seven fresh-state controls covered absent defaults, existing strings and fallbacks, explicit default selection, and recommendation-only login. The regression failed before repair; all 54 focused tests passed. Synthetic credentials tested persistence without live authentication or inference.

Related: #136257.
