### PR TITLE
fix(telegram): preserve reply context for native plugin commands

### DIFF
--- a/extensions/telegram/src/bot-native-command-dispatch.ts
+++ b/extensions/telegram/src/bot-native-command-dispatch.ts
@@ -357,6 +357,7 @@ async function resolveTelegramCommandAuth(params: {
     threadSpec,
     commandAuthorized,
     senderIsOwner: ownerAccess.senderIsOwner,
+    effectiveGroupAllow,
   };
 }
 

--- a/extensions/telegram/src/bot-native-command-plugins.test.ts
+++ b/extensions/telegram/src/bot-native-command-plugins.test.ts
@@ -600,7 +600,81 @@ describe("registerTelegramNativeCommands", () => {
     expect(commandParams.from).toBe("telegram:100");
     expect(commandParams.to).toBe("telegram:100");
     expect(commandParams.messageThreadId).toBeUndefined();
+    expect(commandParams.replyToId).toBeUndefined();
+    expect(commandParams.replyToBody).toBeUndefined();
+    expect(commandParams.replyToSender).toBeUndefined();
+    expect(commandParams.replyToIsQuote).toBeUndefined();
   });
+
+  it.each([false, true])(
+    "passes normalized reply context to the plugin handler (quote=%s)",
+    async (quoted) => {
+      const { handler } = registerPlugCommand();
+      const ctx = createPrivateCommandContext({ chatId: 100, userId: 200, match: "summarize" });
+      await handler({
+        ...ctx,
+        message: {
+          ...ctx.message,
+          reply_to_message: {
+            message_id: 41,
+            date: 1,
+            chat: ctx.message.chat,
+            from: { id: 300, is_bot: false, first_name: "Alice" },
+            text: "Original message with selected words",
+          },
+          ...(quoted ? { quote: { text: "selected words", position: 22, is_manual: true } } : {}),
+        },
+      });
+      expect(firstExecutePluginCommandParams()).toMatchObject({
+        senderId: "200",
+        args: "summarize",
+        commandBody: "/plug summarize",
+        replyToId: "41",
+        replyToBody: quoted ? "selected words" : "Original message with selected words",
+        replyToSender: "Alice",
+        replyToIsQuote: quoted ? true : undefined,
+      });
+      expect(replyAt(firstDeliverRepliesParams())).toEqual({ text: "ok" });
+    },
+  );
+
+  it.each([
+    { mode: "allowlist", sender: 300, visible: false },
+    { mode: "allowlist", sender: 200, visible: true },
+    { mode: "allowlist_quote", sender: 300, visible: true },
+    { mode: "all", sender: 300, visible: true },
+  ] as const)(
+    "preserves group reply visibility ($mode, sender=$sender)",
+    async ({ mode, sender, visible }) => {
+      const { handler } = registerPlugCommand({
+        cfg: {
+          channels: {
+            telegram: { groupPolicy: "open", groupAllowFrom: ["200"], contextVisibility: mode },
+          },
+        },
+        registerOverrides: { opts: { token: "token", groupAllowFrom: ["200"] } },
+      });
+      const ctx = createTelegramTopicCommandContext({ chatId: BOUND_FORUM_CHAT_ID, threadId: 42 });
+      await handler({
+        ...ctx,
+        message: {
+          ...ctx.message,
+          reply_to_message: {
+            message_id: 41,
+            date: 1,
+            chat: ctx.message.chat,
+            from: { id: sender, is_bot: false, first_name: "Reply author" },
+            text: "Group reply content",
+          },
+        },
+      });
+      const commandParams = firstExecutePluginCommandParams();
+      expect(commandParams.replyToId).toBe(visible ? "41" : undefined);
+      expect(commandParams.replyToBody).toBe(visible ? "Group reply content" : undefined);
+      expect(commandParams.replyToSender).toBe(visible ? "Reply author" : undefined);
+      expect(replyAt(firstDeliverRepliesParams())).toEqual({ text: "ok" });
+    },
+  );
 
   it("suppresses the fallback reply when a plugin command returns suppressReply: true", async () => {
     const { handler } = registerPlugCommand({

--- a/extensions/telegram/src/bot-native-command-plugins.ts
+++ b/extensions/telegram/src/bot-native-command-plugins.ts
@@ -2,6 +2,10 @@
 import { randomUUID } from "node:crypto";
 import type { Bot, Context } from "grammy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  resolveChannelContextVisibilityMode,
+  shouldIncludeSupplementalContext,
+} from "openclaw/plugin-sdk/context-visibility-runtime";
 import type { PluginCommandNativeCandidate } from "openclaw/plugin-sdk/plugin-command-runtime";
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import {
@@ -11,6 +15,7 @@ import {
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
+import { isSenderAllowed } from "./bot-access.js";
 import {
   prepareTelegramCommandDispatch,
   type TelegramCommandExecutorParams,
@@ -20,6 +25,7 @@ import {
   buildTelegramGroupFrom,
   buildTelegramThreadParams,
   extractTelegramForumFlag,
+  describeReplyTarget,
   resolveTelegramForumFlag,
   resolveTelegramMessageThreadSpec,
 } from "./bot/helpers.js";
@@ -177,6 +183,25 @@ export async function executeTelegramPluginCommand(
   if (!dispatch) {
     return;
   }
+  let replyTarget = describeReplyTarget(params.msg);
+  if (replyTarget && dispatch.isGroup) {
+    // Native commands must honor the same quoted-context visibility as message turns.
+    const senderAllowed =
+      !dispatch.effectiveGroupAllow?.hasEntries ||
+      isSenderAllowed({
+        allow: dispatch.effectiveGroupAllow,
+        senderId: replyTarget.senderId,
+        senderUsername: replyTarget.senderUsername,
+      });
+    const mode = resolveChannelContextVisibilityMode({
+      cfg: dispatch.runtimeCfg,
+      channel: "telegram",
+      accountId: dispatch.route.accountId,
+    });
+    if (!shouldIncludeSupplementalContext({ mode, kind: "quote", senderAllowed })) {
+      replyTarget = null;
+    }
+  }
   const targetSessionEntry = dispatch.nativeCommandRuntime.getSessionEntry({
     agentId: dispatch.route.agentId,
     sessionKey: dispatch.targetSessionKey,
@@ -232,6 +257,10 @@ export async function executeTelegramPluginCommand(
       to,
       accountId: dispatch.accountId,
       messageThreadId: dispatch.threadSpec.id,
+      replyToId: replyTarget?.id,
+      replyToBody: replyTarget?.body,
+      replyToSender: replyTarget?.sender,
+      replyToIsQuote: replyTarget?.kind === "quote" ? true : undefined,
     }),
   );
   const suppressReply =

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -57,6 +57,10 @@ export function executePluginCommand(params: {
   originatingTo?: string;
   accountId?: PluginCommandContext["accountId"];
   messageThreadId?: PluginCommandContext["messageThreadId"];
+  replyToId?: PluginCommandContext["replyToId"];
+  replyToBody?: PluginCommandContext["replyToBody"];
+  replyToSender?: PluginCommandContext["replyToSender"];
+  replyToIsQuote?: PluginCommandContext["replyToIsQuote"];
   threadParentId?: PluginCommandContext["threadParentId"];
   diagnosticsSessions?: PluginCommandContext["diagnosticsSessions"];
   diagnosticsUploadApproved?: PluginCommandContext["diagnosticsUploadApproved"];

--- a/src/plugins/plugin-command-execution.ts
+++ b/src/plugins/plugin-command-execution.ts
@@ -222,6 +222,10 @@ export async function executeRegisteredPluginCommand(
     messageThreadId: params.messageThreadId,
     threadParentId: params.threadParentId,
     diagnosticsSessions: params.diagnosticsSessions,
+    replyToId: params.replyToId,
+    replyToBody: params.replyToBody,
+    replyToSender: params.replyToSender,
+    replyToIsQuote: params.replyToIsQuote,
     runtimeContext: buildRuntimeContext(command, params, commandInvocationAbort.signal),
     ...(trustedReservedOwner && params.diagnosticsUploadApproved !== undefined
       ? { diagnosticsUploadApproved: params.diagnosticsUploadApproved }

--- a/src/plugins/plugin-command-runtime.ts
+++ b/src/plugins/plugin-command-runtime.ts
@@ -47,6 +47,10 @@ export type PluginCommandDispatchContext = Readonly<{
   originatingTo?: string;
   accountId?: PluginCommandContext["accountId"];
   messageThreadId?: PluginCommandContext["messageThreadId"];
+  replyToId?: PluginCommandContext["replyToId"];
+  replyToBody?: PluginCommandContext["replyToBody"];
+  replyToSender?: PluginCommandContext["replyToSender"];
+  replyToIsQuote?: PluginCommandContext["replyToIsQuote"];
   threadParentId?: PluginCommandContext["threadParentId"];
   diagnosticsSessions?: PluginCommandContext["diagnosticsSessions"];
   diagnosticsUploadApproved?: PluginCommandContext["diagnosticsUploadApproved"];

--- a/src/plugins/plugin-command.types.ts
+++ b/src/plugins/plugin-command.types.ts
@@ -99,6 +99,14 @@ export type PluginCommandContext = {
   accountId?: string;
   /** Thread/topic id if available */
   messageThreadId?: string | number;
+  /** Channel-provided reply target id, after context visibility checks. */
+  replyToId?: string;
+  /** Reply target text, or the selected quote when supplied by the channel. */
+  replyToBody?: string;
+  /** Display name of the reply target's sender, not the command invoker. */
+  replyToSender?: string;
+  /** True when the channel identifies a selected quote rather than a full reply. */
+  replyToIsQuote?: boolean;
   /** Parent conversation id for thread-capable channels */
   threadParentId?: string;
   /** Sensitive diagnostics-only session inventory for owner-gated commands. */


### PR DESCRIPTION
## What problem this solves

Closes #139209.

Native Telegram plugin commands lose the message they reply to before invoking the plugin handler, despite Telegram already supplying that evidence.

## Why this change was made

Use the existing Telegram reply-target normalizer and carry its optional id, body, sender, and selected-quote indicator through the existing plugin command context. Preserve existing group supplemental-context visibility rules.

## User impact

A plugin handling a replied-to native command can access the correct source message rather than infer it from command arguments. Commands without a reply retain their behavior. Delivery and native `suppressReply` handling are untouched.

## Evidence

- New regression failed on the base implementation for full replies and selected quotes.
- Tests exercise native dispatch through the registered plugin handler, distinguishing the command invoker from the reply author and the full body from selected text.
- Group allowlist visibility and existing delivery paths are covered.
- All 31 native plugin command tests passed. One independent read-only lite implementation review: PASS, with the real Telegram proof limitation below retained.
- Targeted core/Telegram type-aware lint, Telegram package typecheck, formatting, and diff whitespace checks passed.
- Live Test Server proof is unavailable in this contributor environment: the authenticated Convex CLI and both broker environment variables are absent. Per the userbot workflow, no credentials were installed or login attempted. Validation uses the existing native-command test harness; a maintainer with broker access can add real Telegram proof. Production and downstream patches are unchanged.
