### PR TITLE
feat(cli): accept bounded stdin prompts for model run

### DIFF
--- a/docs/cli/infer.md
+++ b/docs/cli/infer.md
@@ -157,6 +157,7 @@ Notes:
 - `model run --file` attaches image content directly to the single user message. Common formats (PNG, JPEG, WebP) work when MIME type is detected as `image/*`; unsupported or unrecognized files fail before the provider is called. Use `infer image describe` instead when you want OpenClaw's image-model routing and fallbacks rather than a direct multimodal-model probe.
 - The selected model must support image input; text-only models may reject the request at the provider layer.
 - `model run --prompt` must contain non-whitespace text; empty prompts are rejected before any provider or Gateway call.
+- Use `model run --prompt-stdin < prompt.txt` to keep prompt text out of process arguments. Stdin is read only with this flag, up to 1 MiB of UTF-8 input; empty input, read errors, and overflow fail before model dispatch. Use either `--prompt` or `--prompt-stdin`, not both. This changes only input delivery, not model routing or session behavior.
 - Local `model run` exits non-zero when the provider returns no text output, so unreachable providers and empty completions do not look like successful probes.
 - Use `model run --gateway` to test Gateway routing or agent-runtime setup while keeping the model input raw. Use `openclaw agent` or a chat surface for full agent context, tools, memory, and session transcript.
 - `--thinking adaptive` maps to the completion-runtime level `medium`; `--thinking max` maps to `max` for OpenAI models that support the native max effort, otherwise `xhigh`.

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { expectDefined } from "@openclaw/normalization-core";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -1127,6 +1128,74 @@ describe("capability cli", () => {
     expect(mocks.callGateway).not.toHaveBeenCalled();
     expect(firstJsonOutput()?.capability).toBe("model.run");
     expect(firstJsonOutput()?.transport).toBe("local");
+  });
+
+  it.each(["infer", "capability"])(
+    "reads an explicit stdin prompt through %s without prompt argv",
+    async (root) => {
+      const prompt = "synthetic-stdin-marker\nOlá 🦞\n";
+      const bytes = Buffer.from(prompt);
+      using stdin = vi
+        .spyOn(process, "stdin", "get")
+        .mockReturnValue(
+          Readable.from([bytes.subarray(0, -3), bytes.subarray(-3)]) as typeof process.stdin,
+        );
+      const argv = [root, "model", "run", "--prompt-stdin", "--local", "--json"];
+      const program = new Command().exitOverride().configureOutput({ writeErr: () => {} });
+      await registerCapabilityCli(program, ["node", "openclaw", ...argv]);
+      await program.parseAsync(argv, { from: "user" });
+
+      expect(firstCompletionCall()?.context?.messages?.[0]?.content).toBe(prompt);
+      expect(program.args.join(" ")).not.toContain("synthetic-stdin-marker");
+      expect(process.argv.join(" ")).not.toContain("synthetic-stdin-marker");
+      expect(stdin).toHaveBeenCalled();
+      expect(mocks.callGateway).not.toHaveBeenCalled();
+      expect(CAPABILITY_METADATA.find((entry) => entry.id === "model.run")?.flags).toContain(
+        "--prompt-stdin",
+      );
+    },
+  );
+
+  it.each([
+    { args: ["--prompt", "hello"], error: undefined },
+    { args: [], error: "Specify --prompt <text> or --prompt-stdin." },
+    {
+      args: ["--prompt", "hello", "--prompt-stdin"],
+      error: "Use either --prompt or --prompt-stdin, not both.",
+    },
+  ])("only reads stdin on explicit, non-conflicting input: $args", async ({ args, error }) => {
+    using stdin = vi.spyOn(process, "stdin", "get");
+    const run = runCapability("model", "run", ...args);
+    if (error) {
+      await expect(run).rejects.toThrow("exit 1");
+      expectRuntimeErrorContains(error);
+      expect(mocks.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
+    } else {
+      await run;
+      expect(firstCompletionCall()?.context?.messages?.[0]?.content).toBe("hello");
+    }
+    expect(stdin).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { text: " \n", error: "--prompt cannot be empty or whitespace-only." },
+    { text: "é".repeat(524_289), error: "--prompt-stdin exceeds 1048576 bytes." },
+    { text: undefined, error: "synthetic stdin read failure" },
+  ])("rejects invalid stdin before model dispatch: $error", async ({ text, error }) => {
+    const stream =
+      text === undefined
+        ? new Readable({
+            read() {
+              this.destroy(new Error(error));
+            },
+          })
+        : Readable.from([text]);
+    using stdin = vi.spyOn(process, "stdin", "get").mockReturnValue(stream as typeof process.stdin);
+    await expect(runCapability("model", "run", "--prompt-stdin")).rejects.toThrow("exit 1");
+    expectRuntimeErrorContains(error);
+    expect(stdin).toHaveBeenCalled();
+    expect(mocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(mocks.callGateway).not.toHaveBeenCalled();
   });
 
   it("runs local model probes through the lean completion path", async () => {

--- a/src/cli/capability-cli/metadata.ts
+++ b/src/cli/capability-cli/metadata.ts
@@ -28,6 +28,7 @@ export const CAPABILITY_METADATA: CapabilityMetadata[] = [
     transports: ["local", "gateway"],
     flags: [
       "--prompt",
+      "--prompt-stdin",
       "--file",
       "--model",
       "--thinking",

--- a/src/cli/capability-cli/model.ts
+++ b/src/cli/capability-cli/model.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { detectMime, normalizeMimeType } from "@openclaw/media-core/mime";
+import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
 import {
   normalizeOptionalString,
   normalizeStringifiedOptionalString,
@@ -53,6 +54,7 @@ import {
 } from "./shared.js";
 
 const LOCAL_MODEL_RUN_SYSTEM_PROMPT = "You are a personal assistant running inside OpenClaw.";
+const MODEL_RUN_STDIN_MAX_BYTES = 1024 * 1024;
 const HEIC_MODEL_RUN_MIMES = new Set([
   "image/heic",
   "image/heic-sequence",
@@ -457,7 +459,8 @@ export function registerModelCapabilityCommands(capability: Command): void {
   model
     .command("run")
     .description("Run a one-shot model turn")
-    .requiredOption("--prompt <text>", "Prompt text")
+    .option("--prompt <text>", "Prompt text")
+    .option("--prompt-stdin", "Read prompt text from stdin (maximum 1 MiB)", false)
     .option("--file <path>", "Image file", collectOption, [])
     .option("--model <provider/model>", "Model override")
     .option("--thinking <level>", "Thinking level override")
@@ -470,7 +473,22 @@ export function registerModelCapabilityCommands(capability: Command): void {
     .option("--json", "Output JSON", false)
     .action(async (opts, command) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
-        const prompt = requireModelRunPrompt(opts.prompt);
+        if (opts.prompt !== undefined && opts.promptStdin) {
+          throw new Error("Use either --prompt or --prompt-stdin, not both.");
+        }
+        if (opts.prompt === undefined && !opts.promptStdin) {
+          throw new Error("Specify --prompt <text> or --prompt-stdin.");
+        }
+        const promptInput = opts.promptStdin
+          ? (
+              await readByteStreamWithLimit(process.stdin, {
+                maxBytes: MODEL_RUN_STDIN_MAX_BYTES,
+                onOverflow: ({ maxBytes }) =>
+                  new Error(`--prompt-stdin exceeds ${maxBytes} bytes.`),
+              })
+            ).toString("utf8")
+          : opts.prompt;
+        const prompt = requireModelRunPrompt(promptInput);
         const thinking = normalizeModelRunThinking(opts.thinking);
         const transport = resolveTransport({
           local: Boolean(opts.local),


### PR DESCRIPTION
## What problem this solves

Closes #139208.

One-shot model prompts currently require a command-line argument. Automation cannot supply a prompt through stdin without placing it in the process argument list.

## Why this change was made

Add explicit `--prompt-stdin` at the existing model-run command owner and advertise it in capability metadata. Reuse the existing bounded byte-stream reader, with a 1 MiB limit. Reject missing, conflicting, empty, overflowing, and unreadable input before dispatch. Read stdin only when explicitly selected.

## User impact

`openclaw infer model run --local --prompt-stdin < prompt.txt` keeps the prompt out of argv. Existing `--prompt` behavior remains available. This changes input transport only: it does not change model routing, authentication, sessions, delivery, or guarantee that a provider never records a prompt.

## Evidence

- New CLI-boundary regression failed on the base implementation for both `infer` and its capability alias.
- Focused model/stdin tests cover exact UTF-8 input, absence from argv, ordinary prompt preservation, explicit input selection, overflow, whitespace, and read failures.
- Focused result: 73 passed, 134 unrelated cases skipped. Core production typecheck, targeted type-aware lint, formatting, and diff whitespace checks passed.
- One independent read-only lite review: PASS on the complete patch.
- After correcting test-only TypeScript types, the CLI test shard typecheck and all 8 directly affected stdin tests passed; runtime behavior was unchanged.
- No production deployment or downstream patch removal is part of this PR.

### Real CLI behavior proof (2026-09-07 America/Sao_Paulo)

Executed the actual PR checkout at `4fd3386c2fe6dd5e15c1b7ba15f359fffef7621e` (`agent/model-prompt-stdin`, clean tracked worktree; live PR head matched). Node v24.15.0. Built from that checkout with `node scripts/run-node.mjs infer model run --help`; build exit 0 and `dist/.buildstamp.head` matched the SHA. The command below ran from the PR checkout using its freshly built `./openclaw.mjs`, not an installed OpenClaw.

Isolated temporary state selected the configured Google model; the existing credential was loaded from a mode-0600 env file, never passed as an argument. No mocks, Gateway, production deployment, or source/test edits.

Exact command (Bash builtin printf, pipefail enabled):

```bash
printf 'Reply with exactly: stdin-proof-139221-20260907-7c92d6e1\n' | OPENCLAW_STATE_DIR=/tmp/pr139221-proof/state node --env-file=/tmp/pr139221-proof/model.env ./openclaw.mjs infer model run --local --model google/gemini-2.5-flash --prompt-stdin --json
```

Live `/proc/<pid>/cmdline` snapshots for the launcher and respawned CLI (only home-directory prefixes redacted):

```json
[
  {
    "pid": "922973",
    "argv": [
      "node",
      "--env-file=/tmp/pr139221-proof/model.env",
      "./openclaw.mjs",
      "infer",
      "model",
      "run",
      "--local",
      "--model",
      "google/gemini-2.5-flash",
      "--prompt-stdin",
      "--json"
    ],
    "markerAbsent": true,
    "promptFlagAbsent": true
  },
  {
    "pid": "922980",
    "argv": [
      "<node-v24.15.0>",
      "--disable-warning=ExperimentalWarning",
      "--env-file=/tmp/pr139221-proof/model.env",
      "<PR-worktree>/openclaw.mjs",
      "infer",
      "model",
      "run",
      "--local",
      "--model",
      "google/gemini-2.5-flash",
      "--prompt-stdin",
      "--json"
    ],
    "markerAbsent": true,
    "promptFlagAbsent": true
  }
]
```

Provider transport log, projected to non-sensitive fields:

```text
provider=google model=gemini-2.5-flash method=POST
provider=google model=gemini-2.5-flash status=200 elapsedMs=1250
```

CLI stdout:

```json
{
  "ok": true,
  "capability": "model.run",
  "transport": "local",
  "provider": "google",
  "model": "gemini-2.5-flash",
  "attempts": [],
  "outputs": [
    {
      "text": "stdin-proof-139221-20260907-7c92d6e1",
      "mediaUrl": null
    }
  ]
}
```

Exit code: **0**. The model returned the exact unique stdin marker, proving that the prompt was read and reached the real configured model. Both sampled CLI argv lists contain `--prompt-stdin`, contain neither the marker nor `--prompt`; no shell substitution was used. Endpoints, credentials and private configuration are omitted from this transcript.
