### PR TITLE
fix: load GitHub connections without a default agent

### DIFF
--- a/docs/concepts/user-model.md
+++ b/docs/concepts/user-model.md
@@ -47,7 +47,7 @@ Turning **Git co-author credit** off stops attribution for future runs. It does 
 
 ## GitHub connections
 
-Open **Settings → Profile → GitHub connections** to connect **My GitHub** without changing the shared **System GitHub** account. Both accounts and their connection status remain visible together. Connecting a credential does not change your verified GitHub sign-in identity, display name, avatar, Git co-author credit preference, or OpenClaw permissions.
+Open **Settings → Profile → GitHub connections** to connect **My GitHub** without changing the shared **System GitHub** account. Both accounts and their connection status remain visible together. Viewing these connections does not require selecting an agent or configuring a default agent. Connecting a credential does not change your verified GitHub sign-in identity, display name, avatar, Git co-author credit preference, or OpenClaw permissions.
 
 My GitHub requires an authenticated, durable Gateway profile, including the local owner profile. An identified operator with `operator.read` can manage only their own connection, even without administrative or general write access. Shared-secret devices using the owner profile share that connection; use per-person sign-in for a team. System and per-agent connection changes still require `operator.admin`.
 

--- a/src/agents/github-tool-identity.ts
+++ b/src/agents/github-tool-identity.ts
@@ -72,29 +72,29 @@ export function resolveConfiguredGitHubToolIdentity(params: {
     : params.config.tools?.github;
 }
 
-function resolveGitHubToolIdentity(params: {
-  config: OpenClawConfig;
-  agentId: string;
-  env?: NodeJS.ProcessEnv;
-}) {
-  const agentOverride = resolveAgentConfig(params.config, params.agentId)?.tools?.github;
-  const config = agentOverride ?? params.config.tools?.github;
-  if (!config) {
-    return { source: "system-detected" as const };
-  }
-  const source: "agent-override" | "system-configured" = agentOverride
-    ? "agent-override"
-    : "system-configured";
-  return {
-    source,
-    config,
-    profileDir: resolveManagedGitHubProfileDir({
-      agentId: params.agentId,
-      env: params.env,
-      scope: source === "agent-override" ? "agent" : "system",
-      profileId: config.profileId,
-    }),
-  };
+function resolveSystemGitHubToolIdentity(
+  params: Pick<GitHubIdentityPreparation, "config" | "env">,
+) {
+  const config = params.config.tools?.github;
+  return config
+    ? {
+        source: "system-configured" as const,
+        config,
+        profileDir: resolveManagedGitHubProfileDir({
+          agentId: "",
+          scope: "system",
+          profileId: config.profileId,
+          env: params.env,
+        }),
+      }
+    : { source: "system-detected" as const };
+}
+
+function resolveGitHubToolIdentity(params: GitHubIdentityPreparation) {
+  return (
+    resolveScopedGitHubToolIdentity({ ...params, scope: "agent" }) ??
+    resolveSystemGitHubToolIdentity(params)
+  );
 }
 
 function resolveScopedGitHubToolIdentity(params: {
@@ -102,22 +102,23 @@ function resolveScopedGitHubToolIdentity(params: {
   agentId: string;
   scope: "system" | "agent";
   env?: NodeJS.ProcessEnv;
-}): ResolvedGitHubToolIdentity | undefined {
-  const config = resolveConfiguredGitHubToolIdentity(params);
-  if (!config) {
-    return params.scope === "system" ? { source: "system-detected" as const } : undefined;
+}) {
+  if (params.scope === "system") {
+    return resolveSystemGitHubToolIdentity(params);
   }
-  const source = params.scope === "system" ? "system-configured" : "agent-override";
-  return {
-    source,
-    config,
-    profileDir: resolveManagedGitHubProfileDir({
-      agentId: params.agentId,
-      env: params.env,
-      scope: params.scope,
-      profileId: config.profileId,
-    }),
-  };
+  const config = resolveConfiguredGitHubToolIdentity(params);
+  return config
+    ? {
+        source: "agent-override" as const,
+        config,
+        profileDir: resolveManagedGitHubProfileDir({
+          agentId: params.agentId,
+          env: params.env,
+          scope: "agent",
+          profileId: config.profileId,
+        }),
+      }
+    : undefined;
 }
 
 type ResolvedGitHubToolIdentity = ReturnType<typeof resolveGitHubToolIdentity>;
@@ -172,12 +173,9 @@ export function managedGitHubIdentityEnvironment(params: {
 }
 
 /** Prepares the non-secret child overlay and store exclusions once per agent run. */
-export function prepareGitHubToolEnvironment(params: {
-  config: OpenClawConfig;
-  agentId: string;
-  sourceConfig?: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-}): PreparedGitHubToolEnvironment {
+export function prepareGitHubToolEnvironment(
+  params: GitHubIdentityPreparation,
+): PreparedGitHubToolEnvironment {
   const identity = resolveGitHubToolIdentity(params);
   const managedLocalIdentity = identity.source !== "system-detected";
   const previewToken =
@@ -333,7 +331,8 @@ export async function resolveGitHubToolIdentityStatus(params: {
     ...params,
     scope: params.selectedScope,
   });
-  const effective = await resolveGitHubIdentityFacts({ ...params, identity: effectiveIdentity });
+  const probe = { cwd: resolveAgentWorkspaceDir(params.config, params.agentId), env: params.env };
+  const effective = await resolveGitHubIdentityFacts({ ...probe, identity: effectiveIdentity });
   const selectedMatchesEffective =
     selectedIdentity?.source === effectiveIdentity.source &&
     (selectedIdentity?.source === "system-detected" ||
@@ -343,7 +342,7 @@ export async function resolveGitHubToolIdentityStatus(params: {
     ? null
     : selectedMatchesEffective
       ? effective
-      : await resolveGitHubIdentityFacts({ ...params, identity: selectedIdentity });
+      : await resolveGitHubIdentityFacts({ ...probe, identity: selectedIdentity });
   return {
     agentId: params.agentId,
     selectedScope: params.selectedScope,
@@ -356,9 +355,19 @@ export async function resolveGitHubToolIdentityStatus(params: {
   };
 }
 
+export async function resolveSystemGitHubIdentityStatus(
+  params: Pick<GitHubIdentityPreparation, "config" | "env">,
+): Promise<GitHubIdentityFacts> {
+  // Profile settings have no agent owner. Probe the shared identity outside agent workspaces.
+  return resolveGitHubIdentityFacts({
+    identity: resolveSystemGitHubToolIdentity(params),
+    cwd: resolveStateDir(params.env),
+    env: params.env,
+  });
+}
+
 async function resolveGitHubIdentityFacts(params: {
-  config: OpenClawConfig;
-  agentId: string;
+  cwd: string;
   identity: ResolvedGitHubToolIdentity;
   env?: NodeJS.ProcessEnv;
 }): Promise<GitHubIdentityFacts> {
@@ -372,10 +381,9 @@ async function resolveGitHubIdentityFacts(params: {
   const token = managed
     ? await readManagedGitHubToken(identity.profileDir)
     : await readNativeGitHubToken(probeEnv);
-  const workspaceDir = resolveAgentWorkspaceDir(params.config, params.agentId);
   const [probe, author] = await Promise.all([
     token ? verifyGitHubCredential(token) : undefined,
-    readGitAuthor(probeEnv, workspaceDir),
+    readGitAuthor(probeEnv, params.cwd),
   ]);
   const account = probe?.status === "available" ? probe.account : null;
   const credentialState =

--- a/src/gateway/server-methods/users-github.test.ts
+++ b/src/gateway/server-methods/users-github.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   prepareGitHubToolEnvironment,
   resolveManagedGitHubProfileDir,
+  writeManagedGitHubProfileFiles,
 } from "../../agents/github-tool-identity.js";
 import { cleanupRetiredManagedGitHubProfiles } from "../../agents/github-tool-profile-cleanup.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -217,6 +218,48 @@ afterEach(async () => {
 });
 
 describe("personal GitHub through authenticated Gateway RPC", () => {
+  it.each(["native", "managed"] as const)(
+    "reads personal and %s system status without selecting an agent",
+    async (systemKind) => {
+      const profileId = "ghp_12121212121212121212121212121212";
+      config.agents = {
+        entries: {
+          alpha: {
+            workspace: state.path("alpha-workspace"),
+            tools: { github: { profileId: "ghp_34343434343434343434343434343434" } },
+          },
+          beta: { workspace: state.path("beta-workspace") },
+        },
+      };
+      if (systemKind === "managed") {
+        config.tools = { github: { profileId } };
+        await writeManagedGitHubProfileFiles(
+          resolveManagedGitHubProfileDir({ scope: "system", agentId: "", profileId }),
+          { login: "system-bot", token: "synthetic-native" },
+        );
+      }
+      await connect();
+      network.verify.mockClear();
+      const response = await rpc(alice, "users.github.status");
+      expect(response.mock.calls[0]?.[0]).toBe(true);
+      expect(response.mock.calls[0]?.[1]).toMatchObject({
+        personal: { state: "connected", account: { login: "personal-alice" } },
+        system: {
+          source: systemKind === "managed" ? "system-configured" : "system-detected",
+          credentialState: "available",
+          account: { login: "system-bot" },
+        },
+      });
+      expect(network.verify.mock.calls.map(([token]) => token)).toEqual([
+        "synthetic-native",
+        tokens.accessToken,
+      ]);
+      const gitProbes = network.command.mock.calls.filter(([argv]) => argv[0] === "git");
+      expect(gitProbes).toHaveLength(1);
+      expect(gitProbes[0]?.[1]?.cwd).toBe(state.stateDir);
+    },
+  );
+
   it("rejects a missing GitHub CLI before creating personal authorization state", async () => {
     network.assertCli.mockImplementationOnce(() => {
       throw new GitHubCliUnavailableError();

--- a/src/gateway/server-methods/users-github.ts
+++ b/src/gateway/server-methods/users-github.ts
@@ -7,8 +7,7 @@ import {
   validateUsersGitHubAuthorizeCancelParams,
   validateUsersGitHubDisconnectParams,
 } from "../../../packages/gateway-protocol/src/index.js";
-import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { resolveGitHubToolIdentityStatus } from "../../agents/github-tool-identity.js";
+import { resolveSystemGitHubIdentityStatus } from "../../agents/github-tool-identity.js";
 import type { PersonalGitHubAction } from "../github-personal-oauth.js";
 import { preparePersonalGitHubAction } from "./github-personal-authorization.js";
 import type {
@@ -60,13 +59,11 @@ export const usersGitHubHandlers: GatewayRequestHandlers = {
     (options) =>
       runPersonalGitHub(options, "My GitHub is unavailable.", async (action, service) => {
         const config = options.context.getRuntimeConfig();
-        const system = await resolveGitHubToolIdentityStatus({
+        const system = await resolveSystemGitHubIdentityStatus({
           config,
-          agentId: resolveDefaultAgentId(config),
-          selectedScope: "system",
         });
         const personal = await service.status(action);
-        return { personal, system: system.selected.identity };
+        return { personal, system };
       }),
   ),
   "users.github.authorize.start": defineValidatedGatewayMethod(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where **Settings → Profile → GitHub connections** fails to load on a Gateway with multiple agents and no default agent. The personal status API takes no agent selection, yet tried to resolve one before reading either account.

Related: #138724. Found during live validation of #138900; this repair applies independently to current main and stable 2026.9.1.

## Why This Change Was Made

System GitHub status now resolves the shared account directly and reads Git author facts from the Gateway state directory. The same system identity resolver serves existing agent-aware selection, so native/managed credential precedence remains canonical. Agent tools retain their selected/effective account distinction and workspace-specific author facts. Personal authentication, current-role checks, OAuth, persistence, and protocol shapes are unchanged.

## User Impact

People can view and connect My GitHub without selecting an agent or changing the agent roster. Status no longer probes an unrelated agent override or requires its workspace.

## Evidence

- Before: a real authenticated two-profile Gateway returned the multiple-agents/no-explicit-owner error for `users.github.status {}` before any OAuth grant.
- Regression: both native and managed system account cases failed before the patch; the other 46 personal RPC cases passed. After the patch, all 90 personal RPC, shared-tool, and identity tests passed. The new cases also reject probing an agent override or using its workspace.
- Candidate live verification passed through a real source Gateway and WebSocket: two explicitly owned agents, no default, fresh state/home, persistent Control UI client, registered loopback Origin, normal token/device admission. `users.github.status {}` returned personal disconnected and native system unavailable in 287 ms. Gateway shutdown completed cleanly in 103 ms; no OAuth grant or agent workspace was needed.
- Formatting and focused lint passed; independent Codex review found no actionable P0–P2 issues.
- Local aggregate checks could not complete: the current-main pnpm 12.3.4 bootstrap hits its minimum-release-age gate, and declaration checking rejects the shared dependency bridge. These guards were preserved; current-head CI owns the remaining full checks.

Production change: +61/-56, net +5 lines. This adds an explicit system status owner while consolidating identity selection and parameter types. Tests add 43 lines; docs clarify that profile connections need no agent selection. No schema, configuration, or protocol changes.
