### PR TITLE
fix(codex): preserve completed ephemeral turns across disconnects

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -218,7 +218,7 @@ extensions/codex/src/app-server/sandbox-guard.ts	2
 extensions/codex/src/app-server/scheduled-app-authority.ts	5
 extensions/codex/src/app-server/session-binding.ts	2
 extensions/codex/src/app-server/shared-client.ts	3
-extensions/codex/src/app-server/side-question.ts	8
+extensions/codex/src/app-server/side-question.ts	7
 extensions/codex/src/app-server/startup-binding.ts	2
 extensions/codex/src/app-server/thread-fingerprints.ts	1
 extensions/codex/src/app-server/thread-lifecycle-run.ts	1

--- a/extensions/codex/media-understanding-provider.test.ts
+++ b/extensions/codex/media-understanding-provider.test.ts
@@ -94,7 +94,8 @@ function createFakeClient(options?: {
   onTurnStart?: () => void;
 }) {
   const notifications = new Set<(notification: CodexServerNotification) => void>();
-  const requestHandlers = new Set<(request: { method: string }) => JsonValue | undefined>();
+  type RequestHandler = Parameters<CodexAppServerClient["addRequestHandler"]>[0];
+  const requestHandlers = new Set<RequestHandler>();
   const requests: Array<{ method: string; params?: JsonValue }> = [];
   const approvalResponses: JsonValue[] = [];
   const request = vi.fn(async (method: string, params?: JsonValue) => {
@@ -124,50 +125,68 @@ function createFakeClient(options?: {
     }
     if (method === "turn/start") {
       options?.onTurnStart?.();
+      const approvals: Promise<void>[] = [];
       if (options?.approvalRequestMethod) {
         for (const handler of requestHandlers) {
-          const response = handler({ method: options.approvalRequestMethod });
-          if (response !== undefined) {
-            approvalResponses.push(response);
-          }
+          approvals.push(
+            Promise.resolve(
+              handler({
+                id: "approval-1",
+                method: options.approvalRequestMethod,
+                params: { threadId: "thread-1", turnId: "turn-1" },
+              }),
+            ).then((response) => {
+              if (response !== undefined) {
+                approvalResponses.push(response);
+              }
+            }),
+          );
         }
       }
-      if (options?.notifyError) {
-        for (const notify of notifications) {
-          notify({
-            method: "error",
-            params: {
-              threadId: "thread-1",
-              turnId: "turn-1",
-              error: {
-                message: options.notifyError,
-                codexErrorInfo: null,
-                additionalDetails: null,
+      const completeTurn = () => {
+        if (options?.notifyError) {
+          for (const notify of notifications) {
+            notify({
+              method: "error",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+                error: {
+                  message: options.notifyError,
+                  codexErrorInfo: null,
+                  additionalDetails: null,
+                },
+                willRetry: false,
               },
-              willRetry: false,
-            },
-          });
+            });
+          }
+        } else if (!options?.completeWithItems && !options?.deferTurnCompletion) {
+          for (const notify of notifications) {
+            notify({
+              method: "item/agentMessage/delta",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+                itemId: "msg-1",
+                delta: options?.responseText ?? "A red square.",
+              },
+            });
+            notify({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+                turn: turnStartResult("completed").turn,
+              },
+            });
+          }
         }
-      } else if (!options?.completeWithItems && !options?.deferTurnCompletion) {
-        for (const notify of notifications) {
-          notify({
-            method: "item/agentMessage/delta",
-            params: {
-              threadId: "thread-1",
-              turnId: "turn-1",
-              itemId: "msg-1",
-              delta: options?.responseText ?? "A red square.",
-            },
-          });
-          notify({
-            method: "turn/completed",
-            params: {
-              threadId: "thread-1",
-              turnId: "turn-1",
-              turn: turnStartResult("completed").turn,
-            },
-          });
-        }
+      };
+      // Return turn/start before waiting for keyed approvals; complete only after their replies.
+      if (approvals.length > 0) {
+        void Promise.all(approvals).then(completeTurn);
+      } else {
+        completeTurn();
       }
       return turnStartResult(
         options?.completeWithItems ? "completed" : "inProgress",
@@ -194,7 +213,7 @@ function createFakeClient(options?: {
       notifications.add(handler);
       return () => notifications.delete(handler);
     },
-    addRequestHandler(handler: (request: { method: string }) => JsonValue | undefined) {
+    addRequestHandler(handler: RequestHandler) {
       requestHandlers.add(handler);
       return () => requestHandlers.delete(handler);
     },

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -84,11 +84,6 @@ export function isAssistantCommentaryCompletionNotification(
   );
 }
 
-/** A retryable native error is not a terminal outcome for bounded operations. */
-export function isRetryableErrorNotification(value: JsonValue | undefined): boolean {
-  return isJsonObject(value) && value.willRetry === true;
-}
-
 /** Returns true for terminal app-server thread status strings. */
 export function isTerminalTurnStatus(status: string | undefined): boolean {
   return status === "completed" || status === "interrupted" || status === "failed";

--- a/extensions/codex/src/app-server/bounded-turn.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.test.ts
@@ -74,6 +74,7 @@ function createClientFactory(
     beforeRequest?: (method: string) => Promise<void>;
     modelProvider?: string;
     responseCompletions?: Array<{ responseId: string; usage: JsonValue }>;
+    preBindDeltaCount?: number;
   } = {},
 ) {
   const methods: string[] = [];
@@ -139,6 +140,17 @@ function createClientFactory(
       }
       queueMicrotask(() => {
         for (const handler of fixture.notifications) {
+          for (let index = 0; index < (options.preBindDeltaCount ?? 0); index += 1) {
+            void handler({
+              method: "item/agentMessage/delta",
+              params: {
+                threadId: "thread-finalizer",
+                turnId: "turn-finalizer",
+                itemId: "answer",
+                delta: ".",
+              },
+            });
+          }
           if (options.errorBeforeCompletion) {
             void handler({
               method: "error",
@@ -215,10 +227,142 @@ function createClientFactory(
     handleServerRequest: (serverRequest: Parameters<typeof fixture.handleServerRequest>[0]) =>
       fixture.handleServerRequest(serverRequest),
     notify: (notification: Parameters<typeof fixture.notify>[0]) => fixture.notify(notification),
+    close: fixture.close,
   };
 }
 
 describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
+  it.each(["bound notification", "queued notification", "terminal response"] as const)(
+    "keeps an accepted %s when the transport closes immediately afterward",
+    async (receipt) => {
+      const started = createDeferred<void>();
+      const declined = createDeferred<void>();
+      const sendCompletion = () => {
+        harness.send({
+          method: "item/completed",
+          params: {
+            threadId: "thread-finalizer",
+            turnId: "turn-finalizer",
+            item: { id: "first", type: "agentMessage", text: "First answer." },
+          },
+        });
+        harness.send({
+          method: "turn/completed",
+          params: { threadId: "thread-finalizer", ...completedTurnResult() },
+        });
+        harness.emitExit();
+      };
+      const harness = createClientHarness({
+        onWrite: (line, send) => {
+          const request = JSON.parse(line) as { id: number | string; method?: string };
+          if (request.id === "binding-fence") {
+            declined.resolve();
+            return;
+          }
+          const results: Record<string, unknown> = {
+            "model/list": { data: [codexModel()], nextCursor: null },
+            "config/read": { config: {}, layers: [] },
+            "configRequirements/read": { requirements: null },
+            "thread/start": threadStartResult("gpt-5.4"),
+            "mcpServerStatus/list": { data: [], nextCursor: null },
+            "turn/start":
+              receipt === "terminal response" ? completedTurnResult() : inProgressTurnResult(),
+          };
+          send({ id: request.id, result: results[request.method ?? ""] });
+          if (request.method === "turn/start") {
+            started.resolve();
+            if (receipt === "queued notification") {
+              sendCompletion();
+            } else if (receipt === "terminal response") {
+              harness.emitExit();
+            }
+          }
+        },
+      });
+      const run = runBoundedCodexAppServerTurn({
+        model: { mode: "required", id: "gpt-5.4" },
+        timeoutMs: 5_000,
+        options: { clientFactory: async () => harness.client },
+        taskLabel: "isolated completion",
+        developerInstructions: "Answer only.",
+        input: [{ type: "text", text: "Name this conversation.", text_elements: [] }],
+        requiredModalities: ["text"],
+        isolation: "configured-transport",
+      });
+      const result = expect(run).resolves.toMatchObject({
+        text: `${receipt === "terminal response" ? "" : "First answer.\n\n"}The message was sent successfully.`,
+      });
+      try {
+        await started.promise;
+        if (receipt === "bound notification") {
+          // A serviced request proves the exact turn has bound, without depending on microtask counts.
+          harness.send({
+            id: "binding-fence",
+            method: "mcpServer/elicitation/request",
+            params: { threadId: "thread-finalizer", turnId: "turn-finalizer", serverName: "forms" },
+          });
+          await declined.promise;
+          sendCompletion();
+        }
+        await result;
+      } finally {
+        harness.client.close();
+        await run.catch(() => {});
+      }
+    },
+  );
+
+  it("rejects a waiting completion when its app-server client closes", async () => {
+    const fake = createClientFactory({ completeTurn: false });
+    const controller = new AbortController();
+    let outcome: unknown;
+    const run = runBoundedCodexAppServerTurn({
+      model: { mode: "required", id: "gpt-5.4" },
+      timeoutMs: 5_000,
+      signal: controller.signal,
+      options: { clientFactory: fake.factory },
+      taskLabel: "isolated completion",
+      developerInstructions: "Name the conversation.",
+      input: [{ type: "text", text: "Help me plan a garden.", text_elements: [] }],
+      requiredModalities: ["text"],
+      isolation: "configured-transport",
+    }).catch((error: unknown) => {
+      outcome = error;
+    });
+    try {
+      await vi.waitFor(() => expect(fake.methods).toContain("turn/start"));
+      fake.close(new Error("app-server transport disconnected"));
+      await vi.waitFor(
+        () =>
+          expect(outcome).toEqual(
+            expect.objectContaining({
+              message: expect.stringContaining("closed"),
+            }),
+          ),
+        { timeout: 200 },
+      );
+    } finally {
+      controller.abort("test cleanup");
+      await run;
+    }
+  });
+
+  it("bounds turn notifications received before turn/start acknowledges", async () => {
+    const fake = createClientFactory({ preBindDeltaCount: 257 });
+    await expect(
+      runBoundedCodexAppServerTurn({
+        model: { mode: "required", id: "gpt-5.4" },
+        timeoutMs: 5_000,
+        options: { clientFactory: fake.factory },
+        taskLabel: "isolated completion",
+        developerInstructions: "Name the conversation.",
+        input: [{ type: "text", text: "Help me plan a garden.", text_elements: [] }],
+        requiredModalities: ["text"],
+        isolation: "configured-transport",
+      }),
+    ).rejects.toThrow("pre-bind notification buffer exceeded");
+  });
+
   it.each(["model/list", "mcpServerStatus/list"])(
     "does not dispatch a turn after its caller retires during %s",
     async (suspendedMethod) => {

--- a/extensions/codex/src/app-server/bounded-turn.ts
+++ b/extensions/codex/src/app-server/bounded-turn.ts
@@ -2,45 +2,34 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { AuthProfileStore } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
-import { readStringField as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
 import {
   CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS,
   closeCodexStartupClientBestEffort,
   interruptCodexTurnAndWaitBestEffort,
 } from "./attempt-client-cleanup.js";
-import {
-  isRetryableErrorNotification,
-  isTerminalTurnStatus,
-  readCodexNotificationItem,
-} from "./attempt-notifications.js";
 import type { CodexAppServerAuthRequirement, CodexAppServerPreparedAuth } from "./auth-bridge.js";
 import type { CodexAppServerClient } from "./client.js";
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
 import { createCodexElicitationResponse } from "./elicitation-response.js";
-import { CodexUsageProjection } from "./event-projector-usage.js";
+import { CodexEphemeralTurn } from "./ephemeral-turn.js";
+import type { CodexUsageProjection } from "./event-projector-usage.js";
 import { readCodexAppServerConfigOptions } from "./launch-args.js";
 import { readModelListResult } from "./models.js";
-import { readCodexNotificationTurnId } from "./notification-correlation.js";
 import { mergeCodexThreadConfigs } from "./plugin-thread-config.js";
 import {
   assertCodexThreadStartResponse,
   assertCodexTurnStartResponse,
   readCodexErrorNotification,
-  readCodexTurnCompletedNotification,
 } from "./protocol-validators.js";
-import {
-  isJsonObject,
-  type CodexServerNotification,
-  type CodexThreadItem,
-  type CodexThreadStartParams,
-  type CodexTurn,
-  type CodexTurnStartParams,
-  type CodexUserInput,
-  type JsonObject,
-  type JsonValue,
+import type {
+  CodexThreadItem,
+  CodexThreadStartParams,
+  CodexTurnStartParams,
+  CodexUserInput,
+  JsonObject,
+  JsonValue,
 } from "./protocol.js";
 import {
   isCodexAppServerStartSelectionChangedError,
@@ -304,15 +293,10 @@ async function runBoundedCodexAppServerTurnInWorkspace(
       );
     }
     params.assertCurrent?.();
-    const collector = createCodexBoundedTurnCollector(
-      thread.thread.id,
-      params.taskLabel,
-      params.allowEmptyText === true,
-    );
-    const cleanup = client.addNotificationHandler(collector.handleNotification);
-    const requestCleanup = client.addRequestHandler(
-      createCodexBoundedApprovalHandler(params.taskLabel),
-    );
+    const collector = new CodexEphemeralTurn(client, thread.thread.id, {
+      textMode: "all",
+      onRequest: createCodexBoundedApprovalHandler(params.taskLabel),
+    });
     try {
       const turn = assertCodexTurnStartResponse(
         // Inherit the admitted model and empty environment; another model/cwd
@@ -332,20 +316,37 @@ async function runBoundedCodexAppServerTurnInWorkspace(
       if (abortController.signal.aborted) {
         requestInterrupt();
       }
-      const result = await collector.collect(turn.turn, {
+      const result = await collector.wait(turn.turn, {
         signal: abortController.signal,
-        timeoutError,
+        abortError: () =>
+          resolveCodexBoundedTurnAbortError(abortController.signal, params.taskLabel, timeoutError),
       });
+      if (result.error || result.turn?.status === "failed") {
+        throw new Error(
+          (result.error
+            ? readCodexErrorNotification(result.error)?.error.message
+            : result.turn?.error?.message) ?? `codex app-server ${params.taskLabel} turn failed`,
+        );
+      }
+      if (result.turn?.status !== "completed") {
+        throw new Error(
+          `codex app-server ${params.taskLabel} turn ended with status ${result.turn?.status ?? "unknown"}`,
+        );
+      }
+      if (!result.text && !params.allowEmptyText) {
+        throw new Error(`Codex app-server ${params.taskLabel} turn returned no text.`);
+      }
       params.assertCurrent?.();
       return {
-        ...result,
+        text: result.text,
+        items: result.items,
+        usage: result.usage,
         model: modelSelection.catalogId,
         nativeSelection: { model: thread.model, modelProvider: thread.modelProvider },
       };
     } finally {
       await interruptPromise;
-      requestCleanup();
-      cleanup();
+      collector.route.release();
     }
   } catch (error) {
     if (abortController.signal.aborted) {
@@ -517,169 +518,6 @@ async function resolveCodexBoundedTurnModel(params: {
   return { catalogId: match.id, runtimeModelId: match.model };
 }
 
-function createCodexBoundedTurnCollector(
-  threadId: string,
-  taskLabel: string,
-  allowEmptyText: boolean,
-) {
-  let turnId: string | undefined;
-  let completedTurn: CodexTurn | undefined;
-  let promptError: string | undefined;
-  const usageProjection = new CodexUsageProjection();
-  const pending: CodexServerNotification[] = [];
-  const completedItems = new Map<string, CodexThreadItem>();
-  const assistantTextByItem = new Map<string, string>();
-  const assistantItemOrder: string[] = [];
-  const { promise: completion, resolve: resolveCompletion } = createDeferred<void>();
-
-  const rememberAssistantText = (itemId: string, text: string) => {
-    if (!text) {
-      return;
-    }
-    if (!assistantTextByItem.has(itemId)) {
-      assistantItemOrder.push(itemId);
-    }
-    assistantTextByItem.set(itemId, text);
-  };
-
-  const handleNotification = (notification: CodexServerNotification): void => {
-    const params = isJsonObject(notification.params) ? notification.params : undefined;
-    if (!params || readString(params, "threadId") !== threadId) {
-      return;
-    }
-    if (!turnId) {
-      pending.push(notification);
-      return;
-    }
-    if (readCodexNotificationTurnId(params) !== turnId) {
-      return;
-    }
-    if (notification.method === "item/completed") {
-      const item = readCodexNotificationItem(notification.params);
-      if (item) {
-        completedItems.set(item.id, item);
-        if (item.type === "agentMessage" && typeof item.text === "string") {
-          rememberAssistantText(item.id, item.text);
-        }
-      }
-      return;
-    }
-    if (notification.method === "item/agentMessage/delta") {
-      const itemId = readString(params, "itemId") ?? readString(params, "id") ?? "assistant";
-      const delta = readString(params, "delta") ?? "";
-      rememberAssistantText(itemId, `${assistantTextByItem.get(itemId) ?? ""}${delta}`);
-      return;
-    }
-    if (notification.method === "rawResponse/completed") {
-      usageProjection.record(params);
-      return;
-    }
-    if (notification.method === "turn/completed") {
-      completedTurn =
-        readCodexTurnCompletedNotification(notification.params)?.turn ?? completedTurn;
-      resolveCompletion();
-      return;
-    }
-    if (notification.method === "error") {
-      usageProjection.invalidateContext();
-      if (isRetryableErrorNotification(notification.params)) {
-        return;
-      }
-      promptError =
-        readCodexErrorNotification(notification.params)?.error.message ??
-        `codex app-server ${taskLabel} turn failed`;
-      resolveCompletion();
-    }
-  };
-
-  return {
-    handleNotification,
-    async collect(
-      startedTurn: CodexTurn,
-      options: { signal: AbortSignal; timeoutError: CodexBoundedTurnTimeoutError },
-    ): Promise<Omit<CodexBoundedTurnResult, "model" | "nativeSelection">> {
-      turnId = startedTurn.id;
-      if (isTerminalTurnStatus(startedTurn.status)) {
-        completedTurn = startedTurn;
-      }
-      for (const notification of pending.splice(0)) {
-        handleNotification(notification);
-      }
-      if (!completedTurn && !promptError) {
-        await waitForTurnCompletion({
-          completion,
-          signal: options.signal,
-          taskLabel,
-          timeoutError: options.timeoutError,
-        });
-      }
-      if (promptError) {
-        throw new Error(promptError);
-      }
-      if (completedTurn?.status === "failed") {
-        throw new Error(
-          completedTurn.error?.message ?? `codex app-server ${taskLabel} turn failed`,
-        );
-      }
-      if (completedTurn?.status !== "completed") {
-        throw new Error(
-          `codex app-server ${taskLabel} turn ended with status ${completedTurn?.status ?? "unknown"}`,
-        );
-      }
-      const items = collectCompletedItems(completedTurn?.items, completedItems);
-      const itemText = collectAssistantTextFromItems(items);
-      const deltaText = assistantItemOrder
-        .map((itemId) => assistantTextByItem.get(itemId)?.trim())
-        .filter((text): text is string => Boolean(text))
-        .join("\n\n")
-        .trim();
-      const text = (itemText || deltaText).trim();
-      if (!text && !allowEmptyText) {
-        throw new Error(`Codex app-server ${taskLabel} turn returned no text.`);
-      }
-      return { text, items, usage: usageProjection.usage };
-    },
-  };
-}
-
-function collectCompletedItems(
-  turnItems: CodexThreadItem[] | undefined,
-  notificationItems: Map<string, CodexThreadItem>,
-): CodexThreadItem[] {
-  const items = new Map(notificationItems);
-  for (const item of turnItems ?? []) {
-    items.set(item.id, item);
-  }
-  return [...items.values()];
-}
-
-async function waitForTurnCompletion(params: {
-  completion: Promise<void>;
-  signal: AbortSignal;
-  taskLabel: string;
-  timeoutError: CodexBoundedTurnTimeoutError;
-}): Promise<void> {
-  if (params.signal.aborted) {
-    throw resolveCodexBoundedTurnAbortError(params.signal, params.taskLabel, params.timeoutError);
-  }
-  let cleanupAbort: (() => void) | undefined;
-  try {
-    await Promise.race([
-      params.completion,
-      new Promise<never>((_, reject) => {
-        const abortListener = () =>
-          reject(
-            resolveCodexBoundedTurnAbortError(params.signal, params.taskLabel, params.timeoutError),
-          );
-        params.signal.addEventListener("abort", abortListener, { once: true });
-        cleanupAbort = () => params.signal.removeEventListener("abort", abortListener);
-      }),
-    ]);
-  } finally {
-    cleanupAbort?.();
-  }
-}
-
 function resolveCodexBoundedTurnAbortError(
   signal: AbortSignal,
   taskLabel: string,
@@ -690,13 +528,4 @@ function resolveCodexBoundedTurnAbortError(
   return signal.reason === timeoutError
     ? timeoutError
     : new Error(`codex app-server ${taskLabel} turn aborted`);
-}
-
-function collectAssistantTextFromItems(items: CodexThreadItem[] | undefined): string {
-  return (items ?? [])
-    .filter((item) => item.type === "agentMessage")
-    .map((item) => item.text.trim())
-    .filter(Boolean)
-    .join("\n\n")
-    .trim();
 }

--- a/extensions/codex/src/app-server/codex-app-server.test-fixtures.ts
+++ b/extensions/codex/src/app-server/codex-app-server.test-fixtures.ts
@@ -3,7 +3,7 @@ import type { CodexAppServerClient } from "./client.js";
 import type { CodexServerNotification, RpcRequest } from "./protocol.js";
 import { CODEX_APP_SERVER_VERSION } from "./version.js";
 
-type ServerRequestHandler = (request: RpcRequest) => unknown;
+type ServerRequestHandler = (request: RpcRequest, signal: AbortSignal) => unknown;
 type NotificationHandler = (notification: CodexServerNotification) => Promise<void> | void;
 
 export function codexTestTurnIds(threadId = "thread-1", turnId = "turn-1") {
@@ -116,16 +116,16 @@ export function createFakeCodexAppServerClient(
         [...notificationHandlers].map((handler) => Promise.resolve(handler(notification))),
       );
     },
-    async handleServerRequest(serverRequest: RpcRequest) {
+    async handleServerRequest(serverRequest: RpcRequest, signal = new AbortController().signal) {
       for (const handler of requestHandlers) {
-        const result = await handler(serverRequest);
+        const result = await handler(serverRequest, signal);
         if (result !== undefined) {
           return result;
         }
       }
       return undefined;
     },
-    close(error?: Error) {
+    close(this: void, error?: Error) {
       closeError = error;
       for (const handler of closeHandlers) {
         handler(client);

--- a/extensions/codex/src/app-server/ephemeral-turn.ts
+++ b/extensions/codex/src/app-server/ephemeral-turn.ts
@@ -1,0 +1,163 @@
+import { toStringifiedError } from "openclaw/plugin-sdk/error-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { readStringField as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isTerminalTurnStatus, readCodexNotificationItem } from "./attempt-notifications.js";
+import type { CodexAppServerClient } from "./client.js";
+import { CodexUsageProjection } from "./event-projector-usage.js";
+import { readCodexTurnCompletedNotification } from "./protocol-validators.js";
+import { isJsonObject, type CodexThreadItem, type CodexTurn, type JsonObject } from "./protocol.js";
+import { getCodexAppServerTurnRouter, type CodexThreadRouteReservation } from "./turn-router.js";
+
+type RouteHandlers = Parameters<CodexThreadRouteReservation["activate"]>[0];
+
+/** One ephemeral turn; the client router owns correlation, buffering and request lifetime. */
+export class CodexEphemeralTurn {
+  readonly route: CodexThreadRouteReservation;
+  private readonly completion = createDeferred<void>();
+  private readonly usage = new CodexUsageProjection();
+  private readonly items = new Map<string, CodexThreadItem>();
+  private readonly assistantItems = new Map<string, string>();
+  private assistantText = "";
+  private turn: CodexTurn | undefined;
+  private error: JsonObject | undefined;
+
+  constructor(
+    client: CodexAppServerClient,
+    threadId: string,
+    private readonly options: RouteHandlers & {
+      textMode: "last" | "all";
+      onAssistantMessageStart?: () => Promise<void> | void;
+    },
+  ) {
+    this.route = getCodexAppServerTurnRouter(client).reserveThread({
+      threadId,
+      ...options,
+      onNotification: async (notification, scope) => {
+        const params = isJsonObject(notification.params) ? notification.params : undefined;
+        if (params && scope.turnId) {
+          if (notification.method === "item/completed" && options.textMode === "all") {
+            const item = readCodexNotificationItem(params);
+            if (item) {
+              this.items.set(item.id, item);
+              if (item.type === "agentMessage" && item.text) {
+                this.assistantItems.set(item.id, item.text);
+              }
+            }
+          } else if (notification.method === "item/agentMessage/delta") {
+            const delta = readString(params, "delta") ?? "";
+            const itemId = readString(params, "itemId") ?? readString(params, "id") ?? "assistant";
+            const firstDelta = !this.assistantText && Boolean(delta);
+            this.assistantText += delta;
+            if (delta && options.textMode === "all") {
+              this.assistantItems.set(itemId, `${this.assistantItems.get(itemId) ?? ""}${delta}`);
+            }
+            if (firstDelta) {
+              await options.onAssistantMessageStart?.();
+            }
+          } else if (
+            notification.method === "rawResponse/completed" &&
+            options.textMode === "all"
+          ) {
+            this.usage.record(params);
+          } else if (notification.method === "turn/completed") {
+            this.turn = readCodexTurnCompletedNotification(params)?.turn ?? this.turn;
+            this.completion.resolve();
+          } else if (notification.method === "error") {
+            this.usage.invalidateContext();
+            if (params.willRetry !== true) {
+              this.error = params;
+              this.completion.resolve();
+            }
+          }
+        }
+        await options.onNotification?.(notification, scope);
+      },
+    });
+    // Reserve and arm synchronously before turn/start can emit requests or notifications.
+    this.route.armTurn();
+  }
+
+  get completed(): boolean {
+    return this.turn !== undefined;
+  }
+
+  async wait(
+    turn: CodexTurn,
+    options: {
+      signal: AbortSignal;
+      abortError: () => Error;
+      timeout?: { ms: number; error: Error };
+    },
+  ) {
+    if (isTerminalTurnStatus(turn.status)) {
+      this.turn = turn;
+      this.completion.resolve();
+    }
+    // Binding drains early notifications, including async progress callbacks;
+    // its wait belongs to the same deadline and cancellation owner as completion.
+    const completion = this.route
+      .bindTurn(turn.id, { completed: isTerminalTurnStatus(turn.status) })
+      .then(() => this.completion.promise);
+    const signals = [this.route.signal, options.signal];
+    const abortError = () =>
+      options.signal.aborted ? options.abortError() : toStringifiedError(this.route.signal.reason);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let abort = () => {};
+    try {
+      await Promise.race([
+        completion,
+        new Promise<never>((_resolve, reject) => {
+          abort = () => {
+            if (options.signal.aborted || !this.route.completed) {
+              reject(abortError());
+            }
+          };
+          // A completed route may close before projection finishes. Keep the caller's
+          // later abort observable instead of consuming it through an already-fired any().
+          for (const signal of signals) {
+            signal.addEventListener("abort", abort, { once: true });
+            if (signal.aborted) {
+              abort();
+            }
+          }
+          const timeout = options.timeout;
+          if (timeout) {
+            timer = setTimeout(() => reject(timeout.error), timeout.ms);
+            timer.unref?.();
+          }
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+      for (const signal of signals) {
+        signal.removeEventListener("abort", abort);
+      }
+    }
+    const items = new Map(this.items);
+    for (const item of this.turn?.items ?? []) {
+      items.set(item.id, item);
+    }
+    // /btw has shipped last-answer semantics; bounded media/finalizer turns join all answers.
+    const messages = (
+      this.options.textMode === "last" ? (this.turn?.items ?? []) : [...items.values()]
+    )
+      .filter((item) => item.type === "agentMessage")
+      .map((item) => item.text.trim())
+      .filter(Boolean);
+    const text =
+      this.options.textMode === "last"
+        ? messages.at(-1) || this.assistantText
+        : messages.join("\n\n") ||
+          [...this.assistantItems.values()]
+            .map((message) => message.trim())
+            .filter(Boolean)
+            .join("\n\n");
+    return {
+      turn: this.turn,
+      error: this.error,
+      items: [...items.values()],
+      text: text.trim(),
+      usage: this.usage.usage,
+    };
+  }
+}

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -999,6 +999,61 @@ describe("runCodexAppServerAttempt native lifecycle", () => {
     });
   });
 
+  it.each(["caller cancellation", "settlement deadline"] as const)(
+    "bounds pre-bind terminal projection after client closure with %s",
+    async (termination) => {
+      const projection = createDeferred<void>();
+      const onReasoningStream = vi.fn(() => projection.promise);
+      const controller = new AbortController();
+      const harness = createStartedThreadHarness(async (method) => {
+        if (method === "turn/start") {
+          vi.useFakeTimers();
+          await harness.notify({
+            method: "item/reasoning/textDelta",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              itemId: "reasoning-1",
+              delta: "thinking",
+            },
+          });
+          await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+          return turnStartResult("turn-1", "inProgress");
+        }
+        return undefined;
+      });
+      const params = makeTestParams({
+        timeoutMs: 60 * 60_000,
+        abortSignal: controller.signal,
+        onReasoningStream,
+      });
+      const settled = vi.fn();
+      const run = runCodexAppServerAttempt(params);
+      void run.then(settled, settled);
+      try {
+        await vi.waitFor(() => expect(onReasoningStream).toHaveBeenCalledOnce(), fastWait);
+        harness.close();
+        if (termination === "caller cancellation") {
+          controller.abort("caller stopped while draining");
+        } else {
+          await vi.advanceTimersByTimeAsync(TURN_TERMINAL_SETTLEMENT_TIMEOUT_MS);
+        }
+        await vi.advanceTimersByTimeAsync(TURN_FINALIZE_DRAIN_ABORT_GRACE_MS + 1);
+        vi.useRealTimers();
+        await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce(), fastWait);
+        // A closed transport cannot confirm background-terminal cleanup. That
+        // explicit failure must escape even while projection remains blocked.
+        await expect(run).rejects.toThrow("Codex cancellation could not confirm the turn stopped");
+        expect(resolveActiveEmbeddedRunSessionId(params.sessionKey!)).toBeUndefined();
+      } finally {
+        projection.resolve();
+        vi.useRealTimers();
+        controller.abort("test cleanup");
+        await run.catch(() => {});
+      }
+    },
+  );
+
   it("lets queued terminal projection finish within its settlement window", async () => {
     vi.useFakeTimers();
     const harness = createStartedThreadHarness();

--- a/extensions/codex/src/app-server/settled-turn-finalizer.native.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.native.test.ts
@@ -27,11 +27,13 @@ import {
   readCodexAppServerBinding,
   registerCodexTestSessionIdentity,
   seedCodexTestBinding,
+  testCodexAppServerBindingStore,
 } from "./session-binding.test-helpers.js";
 import * as settledContext from "./settled-turn-context.js";
 import { runCodexSettledTurnFinalization } from "./settled-turn-finalizer.js";
 import * as sharedClients from "./shared-client.js";
 import type { CodexAppServerClientFactory } from "./shared-client.js";
+import { runCodexAppServerSideQuestion } from "./side-question.js";
 import { attachSqliteSessionTarget } from "./sqlite-session.test-helpers.js";
 import { CODEX_APP_SERVER_VERSION } from "./version.js";
 
@@ -49,7 +51,7 @@ const SUMMARY = "The action completed once.";
 type NativeFixture = Awaited<ReturnType<typeof createNativeFixture>>;
 type NativeRunParams = ReturnType<typeof createNativeRunParams>;
 type Cleanup = () => Promise<void>;
-type NativePhase = "probe" | "action" | "summary" | "health";
+type NativePhase = "probe" | "action" | "side" | "hold" | "summary" | "health";
 
 async function closeNativeClient(client: CodexAppServerClient): Promise<void> {
   expect(await client.closeAndWait()).toBe(true);
@@ -64,6 +66,7 @@ async function createNativeFixture(cleanups: Cleanup[], failures: unknown[]) {
     }
   }
   const requests: Array<{ body: JsonObject; account: string | undefined }> = [];
+  let requestReceived = createDeferred<void>();
   let phase: NativePhase = "probe";
   let actionRequests = 0;
   const server = http.createServer((request, response) => {
@@ -85,6 +88,7 @@ async function createNativeFixture(cleanups: Cleanup[], failures: unknown[]) {
         }
         const account = request.headers.authorization;
         requests.push({ body: parsed, account });
+        requestReceived.resolve();
         if (account !== `Bearer ${NATIVE_KEY}` && account !== `Bearer ${HOST_KEY}`) {
           response.writeHead(401).end();
           return;
@@ -93,11 +97,18 @@ async function createNativeFixture(cleanups: Cleanup[], failures: unknown[]) {
           response.writeHead(400).end();
           return;
         }
-        if (phase === "action") {
+        if (phase === "hold") {
+          response.writeHead(200, { "Content-Type": "text/event-stream" });
+          response.write(
+            `event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id: `response-${requests.length}` } })}\n\n`,
+          );
+          return;
+        }
+        if (phase === "action" || phase === "side") {
           actionRequests += 1;
         }
         const item =
-          phase === "action"
+          phase === "action" || (phase === "side" && actionRequests === 1)
             ? actionRequests === 1
               ? {
                   type: "function_call",
@@ -115,7 +126,12 @@ async function createNativeFixture(cleanups: Cleanup[], failures: unknown[]) {
                 type: "message",
                 role: "assistant",
                 id: `answer-${requests.length}`,
-                content: [{ type: "output_text", text: phase === "summary" ? SUMMARY : "Ready." }],
+                content: [
+                  {
+                    type: "output_text",
+                    text: phase === "summary" || phase === "side" ? SUMMARY : "Ready.",
+                  },
+                ],
               };
         const events = [
           { type: "response.created", response: { id: `response-${requests.length}` } },
@@ -183,9 +199,11 @@ async function createNativeFixture(cleanups: Cleanup[], failures: unknown[]) {
     authProfileStore,
     requests,
     marker: path.join(native.cwd, "completed-actions.txt"),
+    waitForRequest: () => requestReceived.promise,
     setPhase(next: NativePhase) {
       phase = next;
       requests.length = 0;
+      requestReceived = createDeferred<void>();
       actionRequests = 0;
     },
   };
@@ -387,6 +405,223 @@ function trackSharedClient(cleanups: Cleanup[]) {
 describe.skipIf(process.platform === "win32")(
   "stock Codex settled-turn finalization ownership",
   () => {
+    it.each(["before completion", "after completion"] as const)(
+      "settles a bounded turn when the native process closes %s",
+      { timeout: 60_000 },
+      async (closure) => {
+        await withNativeFixture(async (fixture, cleanups) => {
+          const pluginConfig = {
+            ...fixture.pluginConfig,
+            appServer: { ...fixture.pluginConfig.appServer, homeScope: "agent" },
+          };
+          await writeNativeConfig(
+            fixture,
+            authBridge.resolveCodexAppServerHomeDir(fixture.agentDir),
+            "openai",
+          );
+          fixture.setPhase(closure === "before completion" ? "hold" : "probe");
+          const admittedClient = createDeferred<CodexAppServerClient>();
+          const run = runBoundedCodexAppServerTurn({
+            model: { mode: "required", id: HOST_MODEL },
+            profile: HOST_PROFILE,
+            authProfileStore: fixture.authProfileStore,
+            agentDir: fixture.agentDir,
+            timeoutMs: 15_000,
+            taskLabel: "client close proof",
+            developerInstructions: "Wait for the answer.",
+            input: [{ type: "text", text: "Start the request.", text_elements: [] }],
+            requiredModalities: ["text"],
+            isolation: "configured-transport",
+            requireNoExternalCapabilities: true,
+            options: {
+              pluginConfig,
+              clientFactory: async (options) => {
+                const client = await sharedClients.createIsolatedCodexAppServerClient({
+                  ...options,
+                  authProfileStore: fixture.authProfileStore,
+                });
+                if (closure === "after completion") {
+                  client.addNotificationHandler((notification) => {
+                    if (notification.method === "turn/completed") {
+                      // The router receives this native frame synchronously; close before
+                      // its asynchronous projections run to exercise terminal precedence.
+                      queueMicrotask(() => client.close());
+                    }
+                  });
+                }
+                admittedClient.resolve(client);
+                cleanups.push(async () => {
+                  await closeNativeClient(client);
+                  await settled;
+                });
+                return client;
+              },
+            },
+          });
+          const settled = run.then(
+            () => undefined,
+            (error: unknown) => error,
+          );
+          await Promise.race([
+            fixture.waitForRequest(),
+            settled.then((error) => {
+              throw new Error("Bounded turn ended before provider admission", { cause: error });
+            }),
+          ]);
+          const client = await admittedClient.promise;
+          if (closure === "before completion") {
+            client.close();
+            await expect(run).rejects.toThrow("closed");
+          } else {
+            await expect(run).resolves.toMatchObject({ text: "Ready." });
+            expect(client.getCloseError()).toBeDefined();
+          }
+        });
+      },
+    );
+
+    it(
+      "runs and cancels ephemeral side forks without changing the parent",
+      { timeout: 60_000 },
+      async () => {
+        await withNativeFixture(async (fixture, cleanups) => {
+          const pluginConfig = {
+            ...fixture.pluginConfig,
+            appServer: { ...fixture.pluginConfig.appServer, homeScope: "agent" },
+          };
+          await writeNativeConfig(
+            fixture,
+            authBridge.resolveCodexAppServerHomeDir(fixture.agentDir),
+            "openai",
+          );
+          const params = await createRunParams(fixture);
+          usePreparedApiKey(params, fixture.baseUrl);
+          const shared = trackSharedClient(cleanups);
+          const initialized = await runCodexAppServerAttempt(
+            { ...params, prompt: "Initialize the source." },
+            {
+              pluginConfig,
+              clientFactory: shared.factory,
+              nativeHookRelay: { enabled: false },
+            },
+          );
+          expect(initialized.terminal).toEqual({ kind: "ok" });
+          const binding = await readCodexAppServerBinding(params.sessionFile);
+          if (!binding || !params.runtimePlan) {
+            throw new Error("Missing initialized native parent");
+          }
+          const client = shared.client();
+          const before = await client.request("thread/read", {
+            threadId: binding.threadId,
+            includeTurns: true,
+          });
+          const transcriptBefore = await readVisibleSessionTranscriptMessageEntries(
+            transcriptTarget(params),
+          );
+          const closeSideHost = await bindProductionHarnessHostCapabilitiesForTest(params);
+          cleanups.push(async () => closeSideHost());
+          const side = {
+            cfg: params.config ?? {},
+            agentDir: fixture.agentDir,
+            agentId: "main",
+            provider: "openai",
+            model: NATIVE_MODEL,
+            runtimeModel: params.model,
+            question: "Record the completed action once.",
+            preparedRuntimeAuth: {
+              plan: params.runtimePlan.auth,
+              authProfileStore: fixture.authProfileStore,
+              authStorage: params.authStorage,
+              modelRegistry: params.modelRegistry,
+              resolvedApiKey: HOST_KEY,
+            },
+            sessionEntry: {
+              sessionId: params.sessionId,
+              updatedAt: 1,
+              permissionMode: "full" as const,
+            },
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            sessionFile: params.sessionFile,
+            storePath: params.sessionTarget?.storePath,
+            workspaceDir: fixture.native.cwd,
+            resolvedReasoningLevel: "off" as const,
+            isNewSession: false,
+            hostCapabilities: params.hostCapabilities,
+          };
+          const options = {
+            pluginConfig,
+            bindingStore: testCodexAppServerBindingStore,
+            nativeHookRelay: { enabled: false },
+          };
+          const calls = vi.spyOn(client, "request");
+          fixture.setPhase("side");
+          await expect(runCodexAppServerSideQuestion(side, options)).resolves.toEqual({
+            text: SUMMARY,
+          });
+          expect(await fs.readFile(fixture.marker, "utf8")).toBe("completed-once\n");
+          const forks = calls.mock.calls.filter(([method]) => method === "thread/fork");
+          expect(forks).toHaveLength(1);
+          expect(forks[0]?.[1]).toMatchObject({
+            threadId: binding.threadId,
+            ephemeral: true,
+            excludeTurns: true,
+          });
+          expect(
+            (
+              await client.request("thread/read", {
+                threadId: binding.threadId,
+                includeTurns: true,
+              })
+            ).thread.turns,
+          ).toEqual(before.thread.turns);
+          expect(
+            await readVisibleSessionTranscriptMessageEntries(transcriptTarget(params)),
+          ).toEqual(transcriptBefore);
+          expect(await readCodexAppServerBinding(params.sessionFile)).toEqual(binding);
+
+          fixture.setPhase("hold");
+          const controller = new AbortController();
+          const cancelled = runCodexAppServerSideQuestion(
+            {
+              ...side,
+              question: "Wait for cancellation.",
+              opts: { abortSignal: controller.signal },
+            },
+            options,
+          );
+          const settled = cancelled.then(
+            () => undefined,
+            (error: unknown) => error,
+          );
+          try {
+            await Promise.race([
+              fixture.waitForRequest(),
+              settled.then((error) => {
+                throw new Error("Side turn ended before provider admission", { cause: error });
+              }),
+            ]);
+            controller.abort("native side cancellation proof");
+            await expect(cancelled).rejects.toThrow("aborted");
+          } finally {
+            controller.abort("native side proof cleanup");
+            await settled;
+          }
+          expect(calls.mock.calls.filter(([method]) => method === "turn/interrupt")).toHaveLength(
+            1,
+          );
+          expect(
+            calls.mock.calls.filter(([method]) => method === "thread/unsubscribe"),
+          ).toHaveLength(2);
+          expect(client.getCloseError()).toBeUndefined();
+          fixture.setPhase("health");
+          await runNativePrompt(client, binding.threadId, "Confirm the parent still works.");
+          expect(fixture.requests).toHaveLength(1);
+          expect(await fs.readFile(fixture.marker, "utf8")).toBe("completed-once\n");
+        });
+      },
+    );
+
     it(
       "refuses supervised finalization even when different host credentials and model work",
       { timeout: 60_000 },

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1,6 +1,7 @@
 // Codex tests cover side question plugin behavior.
 import path from "node:path";
 import {
+  invokeNativeHookRelay,
   nativeHookRelayTesting,
   type NativeHookRelayRegistrationHandle,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
@@ -9,6 +10,7 @@ import {
   resetDiagnosticEventsForTest,
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
@@ -141,8 +143,11 @@ function createFakeClient(options: { completeTurn?: boolean } = {}) {
     emit: (notification: CodexServerNotification) => {
       void fixture.notify(notification);
     },
-    handleRequest: (request: Parameters<typeof fixture.handleServerRequest>[0]) =>
-      fixture.handleServerRequest(request),
+    handleRequest: (
+      request: Parameters<typeof fixture.handleServerRequest>[0],
+      signal?: AbortSignal,
+    ) => fixture.handleServerRequest(request, signal),
+    close: fixture.close,
   });
   client.request.mockImplementation(async (method: string, requestParams?: unknown) => {
     if (method === "thread/read") {
@@ -698,6 +703,77 @@ describe("runCodexAppServerSideQuestion", () => {
     },
   );
 
+  it("rejects a waiting side question when its app-server client closes", async () => {
+    const client = createFakeClient({ completeTurn: false });
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+    const controller = new AbortController();
+    let outcome: unknown;
+    const run = runCodexAppServerSideQuestion(
+      sideParams({ opts: { abortSignal: controller.signal } }),
+    ).catch((error: unknown) => {
+      outcome = error;
+    });
+    try {
+      await vi.waitFor(() =>
+        expect(client.request.mock.calls.some(([method]) => method === "turn/start")).toBe(true),
+      );
+      client.close(new Error("app-server transport disconnected"));
+      await vi.waitFor(
+        () =>
+          expect(outcome).toEqual(
+            expect.objectContaining({
+              message: expect.stringContaining("closed"),
+            }),
+          ),
+        { timeout: 200 },
+      );
+    } finally {
+      controller.abort("test cleanup");
+      await run;
+    }
+  });
+
+  it("cancels an active side tool when its app-server request is cancelled", async () => {
+    const client = createFakeClient({ completeTurn: false });
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+    let toolSignal: AbortSignal | undefined;
+    toolExecuteMock.mockImplementation((_callId: string, _args: unknown, signal?: AbortSignal) => {
+      toolSignal = signal;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(new Error("tool cancelled")), {
+          once: true,
+        });
+      });
+    });
+    const run = runCodexAppServerSideQuestion(sideParams());
+    await vi.waitFor(() =>
+      expect(client.request.mock.calls.some(([method]) => method === "turn/start")).toBe(true),
+    );
+    const requestController = new AbortController();
+    const request = client.handleRequest(
+      {
+        id: "cancelled-side-tool",
+        method: "item/tool/call",
+        params: {
+          ...codexTestTurnIds("side-thread"),
+          callId: "tool-1",
+          tool: "wiki_status",
+          arguments: {},
+        },
+      },
+      requestController.signal,
+    );
+    try {
+      await vi.waitFor(() => expect(toolSignal).toBeDefined());
+      requestController.abort(new Error("app-server request deadline"));
+      await vi.waitFor(() => expect(toolSignal?.aborted).toBe(true), { timeout: 200 });
+    } finally {
+      client.emit(turnCompleted("side-thread", "turn-1", "Finished answer."));
+      await run;
+      await request;
+    }
+  });
+
   it("forks an ephemeral side thread and returns the completed assistant text", async () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-09-02T00:30:00.000Z"));
     const client = createFakeClient();
@@ -1116,15 +1192,11 @@ describe("runCodexAppServerSideQuestion", () => {
     },
   );
 
-  it("rebinds side-question handlers when selection retry replaces the client", async () => {
+  it("routes a side question only through the client selected for its fork", async () => {
     const initialClient = createFakeClient();
     const replacementClient = createFakeClient();
     replacementClient.request.mockImplementation(async (method: string) => {
       if (method === "thread/fork") {
-        expect(initialClient.notifications).toHaveLength(1);
-        expect(initialClient.requests).toHaveLength(1);
-        expect(replacementClient.notifications).toHaveLength(2);
-        expect(replacementClient.requests).toHaveLength(2);
         return threadResult("side-thread");
       }
       if (method === "thread/inject_items") {
@@ -1132,6 +1204,7 @@ describe("runCodexAppServerSideQuestion", () => {
       }
       if (method === "turn/start") {
         queueMicrotask(() => {
+          initialClient.emit(turnCompleted("side-thread", "turn-1", "Stale client answer."));
           replacementClient.emit(agentDelta("side-thread", "turn-1", "Replacement answer."));
           replacementClient.emit(turnCompleted("side-thread", "turn-1", "Replacement answer."));
         });
@@ -1160,11 +1233,22 @@ describe("runCodexAppServerSideQuestion", () => {
       text: "Replacement answer.",
     });
 
-    // Only the physical-client runtime observers remain after side-question cleanup.
-    expect(initialClient.notifications).toHaveLength(1);
-    expect(initialClient.requests).toHaveLength(1);
-    expect(replacementClient.notifications).toHaveLength(1);
-    expect(replacementClient.requests).toHaveLength(1);
+    // A finished route cannot dispatch retained tool requests on either physical client.
+    for (const client of [initialClient, replacementClient]) {
+      await expect(
+        client.handleRequest({
+          id: "late-side-tool",
+          method: "item/tool/call",
+          params: {
+            ...codexTestTurnIds("side-thread"),
+            callId: "late-tool",
+            tool: "wiki_status",
+            arguments: {},
+          },
+        }),
+      ).resolves.toBeUndefined();
+    }
+    expect(toolExecuteMock).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -2050,6 +2134,75 @@ describe("runCodexAppServerSideQuestion", () => {
 
     expect(getSharedCodexAppServerClientMock).not.toHaveBeenCalled();
   });
+
+  it.each(["answer", "caller cancellation"] as const)(
+    "revokes native hook authority on close while projecting the final %s",
+    async (outcome) => {
+      const client = createFakeClient({ completeTurn: false });
+      getSharedCodexAppServerClientMock.mockResolvedValue(client);
+      const projecting = createDeferred<void>();
+      const finishProjection = createDeferred<void>();
+      const controller = new AbortController();
+      const run = runCodexAppServerSideQuestion(
+        sideLoopRelayParams({
+          opts: {
+            abortSignal: controller.signal,
+            onAssistantMessageStart: async () => {
+              projecting.resolve();
+              await finishProjection.promise;
+            },
+          },
+        }),
+        { nativeHookRelay: { enabled: true } },
+      );
+      let runError: unknown;
+      const settled = run.catch((error: unknown) => {
+        runError = error;
+      });
+      try {
+        await vi.waitFor(() =>
+          expect(client.request.mock.calls.some(([method]) => method === "turn/start")).toBe(true),
+        );
+        const fork = client.request.mock.calls.find(([method]) => method === "thread/fork")?.[1];
+        const relayId = extractRelayIdFromThreadConfig(
+          (fork as { config?: Record<string, unknown> }).config,
+        );
+        client.emit(agentDelta("side-thread", "turn-1", "Side answer."));
+        await projecting.promise;
+        client.emit(turnCompleted("side-thread", "turn-1", "Side answer."));
+        client.close();
+
+        await expect(
+          invokeNativeHookRelay({
+            provider: "codex",
+            relayId,
+            event: "pre_tool_use",
+            rawPayload: {
+              tool_name: "Bash",
+              tool_input: { command: "echo synthetic" },
+              tool_use_id: "late-native-tool",
+            },
+          }),
+        ).rejects.toThrow("native hook relay not found");
+        if (outcome === "caller cancellation") {
+          controller.abort("caller stopped while draining");
+          await vi.waitFor(
+            () =>
+              expect(runError).toEqual(
+                expect.objectContaining({ message: "Codex /btw was aborted." }),
+              ),
+            { timeout: 200 },
+          );
+        } else {
+          finishProjection.resolve();
+          await expect(run).resolves.toEqual({ text: "Side answer." });
+        }
+      } finally {
+        finishProjection.resolve();
+        await settled;
+      }
+    },
+  );
 
   it("installs native hook relay config for opted-in side threads", async () => {
     const client = createFakeClient();
@@ -3895,7 +4048,7 @@ describe("runCodexAppServerSideQuestion", () => {
     const client = createFakeClient();
     client.request.mockImplementation(async (method: string) => {
       if (method === "thread/fork") {
-        await client.requests[0]?.({
+        await client.handleRequest({
           id: 1,
           method: "account/chatgptAuthTokens/refresh",
         });

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -85,6 +85,7 @@ import {
 import { createCodexDynamicToolBridge, type CodexDynamicToolBridge } from "./dynamic-tools.js";
 import { routeCodexAppServerElicitationRequest } from "./elicitation-bridge.js";
 import { createCodexElicitationResponse } from "./elicitation-response.js";
+import { CodexEphemeralTurn } from "./ephemeral-turn.js";
 import { CodexNativeToolLifecycleProjector } from "./event-projector-native-tool-lifecycle.js";
 import {
   buildCodexNativeHookRelayConfig,
@@ -93,7 +94,6 @@ import {
   emitCodexNativePreToolUseFailureDiagnostic,
   type CodexNativePreToolUseFailure,
 } from "./native-hook-relay.js";
-import { isCodexNotificationForTurn } from "./notification-correlation.js";
 import {
   mergeCodexThreadConfigs,
   refreshCodexPluginAppApprovalPolicy,
@@ -102,13 +102,10 @@ import {
   assertCodexThreadForkResponse,
   assertCodexTurnStartResponse,
   readCodexDynamicToolCallParams,
-  readCodexTurn,
 } from "./protocol-validators.js";
 import {
   isJsonObject,
-  type CodexServerNotification,
   type CodexThreadForkParams,
-  type CodexTurn,
   type JsonObject,
   type JsonValue,
 } from "./protocol.js";
@@ -157,6 +154,7 @@ import {
   refreshCodexThreadPolicy,
 } from "./thread-policy.js";
 import { buildCodexTemporalAdditionalContext } from "./turn-params.js";
+import type { CodexAppServerServerRequest, CodexThreadRouteScope } from "./turn-router.js";
 import { filterCodexVisionTools } from "./vision-tools.js";
 import {
   resolveCodexWebSearchPlan,
@@ -417,10 +415,9 @@ export async function runCodexAppServerSideQuestion(
   } satisfies CodexAppServerClientOptions;
   let client = await getLeasedSharedCodexAppServerClient(clientOptions);
   const clientLease: CodexAppServerClientLease = { client };
-  const collector = new CodexSideQuestionCollector(params, () => readRecentCodexRateLimits(client));
+  let collector: CodexEphemeralTurn | undefined;
   const runAbortController = new AbortController();
   let nativeToolLifecycleProjector: CodexNativeToolLifecycleProjector | undefined;
-  const pendingNativeToolNotifications: CodexServerNotification[] = [];
   const pendingNativePreToolUseFailures: CodexNativePreToolUseFailure[] = [];
   let nativePreToolUseFailureFallbackActive = false;
   let nativeToolRunWasAbortedBeforeCleanup: boolean | undefined;
@@ -456,23 +453,6 @@ export async function runCodexAppServerSideQuestion(
     }
     flushPendingNativePreToolUseFailures();
   };
-  const handleNotification = (notification: CodexServerNotification) => {
-    collector.handleNotification(notification);
-    if (
-      notification.method !== "item/started" &&
-      notification.method !== "item/completed" &&
-      notification.method !== "rawResponseItem/completed" &&
-      notification.method !== "turn/completed"
-    ) {
-      return;
-    }
-    if (!nativeToolLifecycleProjector) {
-      pendingNativeToolNotifications.push(notification);
-      return;
-    }
-    nativeToolLifecycleProjector.handleNotification(notification);
-  };
-  let removeNotificationHandler = client.addNotificationHandler(handleNotification);
   const abortFromUpstream = () =>
     runAbortController.abort(params.opts?.abortSignal?.reason ?? "codex_side_question_abort");
   if (params.opts?.abortSignal?.aborted) {
@@ -486,8 +466,8 @@ export async function runCodexAppServerSideQuestion(
   let policyWriteUncertain = false;
   let turnId: string | undefined;
   let sandboxEnvironment: CodexSandboxExecEnvironment | undefined;
+  let sandboxDisconnectError: Error | undefined;
   let sandboxEnvironmentClient: CodexAppServerClient | undefined;
-  let removeRequestHandler: (() => void) | undefined;
   let nativeHookRelay: NativeHookRelayRegistrationHandle | undefined;
   const activeDynamicToolCalls = new Set<Promise<unknown>>();
   const releaseSandboxEnvironment = async () => {
@@ -513,7 +493,7 @@ export async function runCodexAppServerSideQuestion(
       timeoutMs: appServer.requestTimeoutMs,
       signal: runAbortController.signal,
       onExecutionDisconnect: (error) => {
-        collector.reject(error);
+        sandboxDisconnectError = error;
         embeddedAgentLog.warn(error.message);
         runAbortController.abort("client_closed");
       },
@@ -585,114 +565,114 @@ export async function runCodexAppServerSideQuestion(
         : {}),
       config: params.cfg,
     });
-    const registerRequestHandler = (targetClient: CodexAppServerClient) =>
-      targetClient.addRequestHandler(async (request) => {
-        if (!childThreadId || !turnId) {
-          return undefined;
-        }
-        if (request.method === "mcpServer/elicitation/request") {
-          const approvalResult = await routeCodexAppServerElicitationRequest({
-            requestParams: request.params,
-            paramsForRun: sideRunParams,
-            threadId: childThreadId,
-            turnId,
-            autoApproveMcpTools,
-            projectedMcpServers,
-            getActiveMcpToolCall: (serverName) =>
-              nativeToolLifecycleProjector?.getActiveMcpToolCall(serverName),
-            pluginAppPolicyContext,
-            signal: runAbortController.signal,
-          });
-          return approvalResult.kind === "handled"
-            ? approvalResult.response
-            : createCodexElicitationResponse("decline", null, {
-                message: "OpenClaw Codex side questions do not support interactive MCP input.",
-              });
-        }
-        if (request.method === "item/tool/requestUserInput") {
-          return isSideUserInputRequest(request.params, childThreadId, turnId)
-            ? emptySideUserInputResponse()
-            : undefined;
-        }
-        if (isCodexAppServerApprovalRequest(request.method)) {
-          return handleCodexAppServerApprovalRequest({
-            method: request.method,
-            requestParams: request.params,
-            paramsForRun: sideRunParams,
-            threadId: childThreadId,
-            turnId,
-            nativeHookRelay,
-            autoApprove: autoApproveMcpTools,
-            signal: runAbortController.signal,
-            onNativeToolFailureDisposition: (itemId, disposition) =>
-              nativeToolLifecycleProjector?.recordApprovalFailureDisposition(itemId, disposition),
-          });
-        }
-        if (request.method !== "item/tool/call") {
-          return undefined;
-        }
-        const call = readCodexDynamicToolCallParams(request.params);
-        if (!call || call.threadId !== childThreadId || call.turnId !== turnId) {
-          return undefined;
-        }
-        const timeoutMs = resolveDynamicToolCallTimeoutMs({
-          call,
-          config: params.cfg,
+    const handleServerRequest = async (
+      request: CodexAppServerServerRequest,
+      _scope: CodexThreadRouteScope,
+      requestSignal: AbortSignal,
+    ) => {
+      const signal = AbortSignal.any([requestSignal, runAbortController.signal]);
+      if (signal.aborted) {
+        return undefined;
+      }
+      if (!childThreadId || !turnId) {
+        return undefined;
+      }
+      if (request.method === "mcpServer/elicitation/request") {
+        const approvalResult = await routeCodexAppServerElicitationRequest({
+          requestParams: request.params,
+          paramsForRun: sideRunParams,
+          threadId: childThreadId,
+          turnId,
+          autoApproveMcpTools,
+          projectedMcpServers,
+          getActiveMcpToolCall: (serverName) =>
+            nativeToolLifecycleProjector?.getActiveMcpToolCall(serverName),
+          pluginAppPolicyContext,
+          signal,
         });
-        const toolStartedAt = Date.now();
-        const diagnosticContext = {
-          call,
-          agentId: sessionAgentId,
-          runId: sideRunParams.runId,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-        };
-        emitDynamicToolStartedDiagnostic(diagnosticContext);
-        const toolCall = handleDynamicToolCallWithTimeout({
-          call,
-          toolBridge,
-          signal: runAbortController.signal,
-          timeoutMs,
-          observeToolTerminal: sideRunParams.observeToolTerminal,
+        return approvalResult.kind === "handled"
+          ? approvalResult.response
+          : createCodexElicitationResponse("decline", null, {
+              message: "OpenClaw Codex side questions do not support interactive MCP input.",
+            });
+      }
+      if (request.method === "item/tool/requestUserInput") {
+        return isSideUserInputRequest(request.params, childThreadId, turnId)
+          ? emptySideUserInputResponse()
+          : undefined;
+      }
+      if (isCodexAppServerApprovalRequest(request.method)) {
+        return handleCodexAppServerApprovalRequest({
+          method: request.method,
+          requestParams: request.params,
+          paramsForRun: sideRunParams,
+          threadId: childThreadId,
+          turnId,
+          nativeHookRelay,
+          autoApprove: autoApproveMcpTools,
+          signal,
+          onNativeToolFailureDisposition: (itemId, disposition) =>
+            nativeToolLifecycleProjector?.recordApprovalFailureDisposition(itemId, disposition),
         });
-        activeDynamicToolCalls.add(toolCall);
-        try {
-          const response = await toolCall;
-          emitDynamicToolTerminalDiagnostic({
-            ...diagnosticContext,
-            response,
-            durationMs: Math.max(0, Date.now() - toolStartedAt),
-          });
-          return {
-            contentItems: response.contentItems,
-            success: response.success,
-          } as JsonValue;
-        } catch (error) {
-          emitDynamicToolErrorDiagnostic({
-            ...diagnosticContext,
-            durationMs: Math.max(0, Date.now() - toolStartedAt),
-            terminalReason: runAbortController.signal.aborted
-              ? resolveCodexToolAbortTerminalReason(runAbortController.signal)
-              : "failed",
-          });
-          throw error;
-        } finally {
-          activeDynamicToolCalls.delete(toolCall);
-        }
+      }
+      if (request.method !== "item/tool/call") {
+        return undefined;
+      }
+      const call = readCodexDynamicToolCallParams(request.params);
+      if (!call || call.threadId !== childThreadId || call.turnId !== turnId) {
+        return undefined;
+      }
+      const timeoutMs = resolveDynamicToolCallTimeoutMs({
+        call,
+        config: params.cfg,
       });
-    removeRequestHandler = registerRequestHandler(client);
+      const toolStartedAt = Date.now();
+      const diagnosticContext = {
+        call,
+        agentId: sessionAgentId,
+        runId: sideRunParams.runId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+      };
+      emitDynamicToolStartedDiagnostic(diagnosticContext);
+      const toolCall = handleDynamicToolCallWithTimeout({
+        call,
+        toolBridge,
+        signal,
+        timeoutMs,
+        observeToolTerminal: sideRunParams.observeToolTerminal,
+      });
+      activeDynamicToolCalls.add(toolCall);
+      try {
+        const response = await toolCall;
+        emitDynamicToolTerminalDiagnostic({
+          ...diagnosticContext,
+          response,
+          durationMs: Math.max(0, Date.now() - toolStartedAt),
+        });
+        return {
+          contentItems: response.contentItems,
+          success: response.success,
+        } as JsonValue;
+      } catch (error) {
+        emitDynamicToolErrorDiagnostic({
+          ...diagnosticContext,
+          durationMs: Math.max(0, Date.now() - toolStartedAt),
+          terminalReason: signal.aborted ? resolveCodexToolAbortTerminalReason(signal) : "failed",
+        });
+        throw error;
+      } finally {
+        activeDynamicToolCalls.delete(toolCall);
+      }
+    };
 
-    const rebindClientHandlers = (nextClient: CodexAppServerClient) => {
-      removeRequestHandler?.();
-      removeNotificationHandler();
+    const selectClient = (nextClient: CodexAppServerClient) => {
       client = nextClient;
       ensureCodexAppServerClientRuntime(client, {
         agentDir: params.agentDir,
         authProfileId: connection.requestAuthProfileId,
         config: params.cfg,
       });
-      removeNotificationHandler = client.addNotificationHandler(handleNotification);
-      removeRequestHandler = registerRequestHandler(client);
     };
 
     const serviceTier = binding.serviceTier ?? appServer.serviceTier;
@@ -849,6 +829,22 @@ export async function runCodexAppServerSideQuestion(
           }
           childThreadId = response.thread.id;
           childClient = forkClient;
+          collector = new CodexEphemeralTurn(forkClient, childThreadId, {
+            textMode: "last",
+            onRequest: handleServerRequest,
+            onAssistantMessageStart: async () => {
+              await params.opts?.onAssistantMessageStart?.();
+            },
+            onNotification: (notification) =>
+              nativeToolLifecycleProjector?.handleNotification(notification),
+          });
+          // A terminal answer may still be projecting after transport closure;
+          // native hook authority ends with the route, not that projection.
+          if (nativeHookRelay) {
+            collector.route.signal.addEventListener("abort", nativeHookRelay.unregister, {
+              once: true,
+            });
+          }
           try {
             assertCurrentBinding();
             if (
@@ -883,7 +879,7 @@ export async function runCodexAppServerSideQuestion(
           }
           return response.thread.id;
         }),
-      onClientChange: rebindClientHandlers,
+      onClientChange: selectClient,
     });
 
     const effort = usesSupervisionConnection
@@ -952,7 +948,6 @@ export async function runCodexAppServerSideQuestion(
     );
     turnId = turnResponse.turn.id;
     assertCurrent();
-    collector.setTurn(sideThreadId, turnId);
     nativeToolLifecycleProjector = new CodexNativeToolLifecycleProjector(
       { ...sideRunParams, agentId: sessionAgentId },
       sideThreadId,
@@ -965,16 +960,20 @@ export async function runCodexAppServerSideQuestion(
       nativeToolLifecycleProjector.recordPreToolUseFailure(failure);
     }
     pendingNativePreToolUseFailures.length = 0;
-    for (const notification of pendingNativeToolNotifications) {
-      nativeToolLifecycleProjector.handleNotification(notification);
+    if (!collector) {
+      throw new Error("Codex side thread route was not reserved");
     }
-    pendingNativeToolNotifications.length = 0;
-
-    let text: string;
+    let result: Awaited<ReturnType<CodexEphemeralTurn["wait"]>>;
     try {
-      text = await collector.wait({
+      result = await collector.wait(turnResponse.turn, {
         signal: runAbortController.signal,
-        timeoutMs: SIDE_QUESTION_COMPLETION_TIMEOUT_MS,
+        abortError: () => sandboxDisconnectError ?? new Error("Codex /btw was aborted."),
+        timeout: {
+          ms: SIDE_QUESTION_COMPLETION_TIMEOUT_MS,
+          error: new CodexSideQuestionTimeoutError(
+            "Codex /btw timed out waiting for the side thread to finish.",
+          ),
+        },
       });
     } catch (error) {
       if (error instanceof CodexSideQuestionTimeoutError && !runAbortController.signal.aborted) {
@@ -982,7 +981,21 @@ export async function runCodexAppServerSideQuestion(
       }
       throw error;
     }
-    const trimmed = text.trim();
+    if (result.error || result.turn?.status === "failed") {
+      throw formatCodexErrorMessage(
+        result.error ?? {
+          error: {
+            message: result.turn?.error?.message ?? null,
+            codexErrorInfo: result.turn?.error?.codexErrorInfo ?? null,
+          },
+        },
+        readRecentCodexRateLimits(client),
+      );
+    }
+    if (result.turn?.status === "interrupted") {
+      throw new Error("Codex /btw side thread was interrupted.");
+    }
+    const trimmed = result.text;
     assertCurrent();
     if (!trimmed) {
       throw new Error("Codex /btw completed without an answer.");
@@ -995,7 +1008,6 @@ export async function runCodexAppServerSideQuestion(
       const runWasAbortedBeforeCleanup = runAbortController.signal.aborted;
       nativeToolRunWasAbortedBeforeCleanup = runWasAbortedBeforeCleanup;
       params.opts?.abortSignal?.removeEventListener("abort", abortFromUpstream);
-      removeRequestHandler?.();
       // Stop dispatched side tools before cleanup waits on the app server;
       // otherwise a stuck tool can outlive the side turn that owns it.
       if (!runAbortController.signal.aborted) {
@@ -1009,14 +1021,14 @@ export async function runCodexAppServerSideQuestion(
         await cleanupCodexSideThread(childClient ?? client, {
           threadId: childThreadId,
           turnId,
-          interrupt: !collector.completed,
+          interrupt: !collector?.completed,
           timeoutMs: appServer.requestTimeoutMs,
         });
       } finally {
         if (policyWriteUncertain && childClient) {
           await retireUnsafeCodexTurnClientBestEffort(childClient, "side policy handoff");
         }
-        removeNotificationHandler();
+        collector?.route.release();
         try {
           nativeToolLifecycleProjector?.finalizeActive(runWasAbortedBeforeCleanup);
         } finally {
@@ -1440,174 +1452,6 @@ async function cleanupCodexSideThread(
   ) {
     await retireUnsafeCodexTurnClientBestEffort(client, "side thread unsubscribe");
   }
-}
-
-class CodexSideQuestionCollector {
-  private threadId: string | undefined;
-  private turnId: string | undefined;
-  private pendingNotifications: CodexServerNotification[] = [];
-  private assistantStarted = false;
-  private assistantText = "";
-  private finalText: string | undefined;
-  private terminalError: Error | undefined;
-  private settle:
-    | {
-        resolve: (text: string) => void;
-        reject: (error: Error) => void;
-      }
-    | undefined;
-  completed = false;
-
-  constructor(
-    private readonly params: AgentHarnessSideQuestionParamsV2,
-    private readonly readRecentRateLimits: () => JsonValue | undefined,
-  ) {}
-
-  setTurn(threadId: string, turnId: string): void {
-    this.threadId = threadId;
-    this.turnId = turnId;
-    const pending = this.pendingNotifications;
-    this.pendingNotifications = [];
-    for (const notification of pending) {
-      this.handleNotification(notification);
-    }
-  }
-
-  handleNotification(notification: CodexServerNotification): void {
-    const params = isJsonObject(notification.params) ? notification.params : undefined;
-    if (!params) {
-      return;
-    }
-    if (!this.threadId || !this.turnId) {
-      this.pendingNotifications.push(notification);
-      return;
-    }
-    if (!isCodexNotificationForTurn(params, this.threadId, this.turnId)) {
-      return;
-    }
-    if (notification.method === "item/agentMessage/delta") {
-      void this.appendAssistantDelta(params);
-      return;
-    }
-    if (notification.method === "turn/completed") {
-      this.completeFromTurn(params);
-      return;
-    }
-    if (notification.method === "error" && params.willRetry !== true) {
-      this.reject(formatCodexErrorMessage(params, this.readRecentRateLimits()));
-    }
-  }
-
-  wait(options: { signal?: AbortSignal; timeoutMs: number }): Promise<string> {
-    if (this.terminalError) {
-      return Promise.reject(this.terminalError);
-    }
-    if (this.completed) {
-      return Promise.resolve(this.finalText ?? this.assistantText);
-    }
-    if (options.signal?.aborted) {
-      return Promise.reject(new Error("Codex /btw was aborted."));
-    }
-    return new Promise((resolve, reject) => {
-      let timeout: ReturnType<typeof setTimeout> | undefined;
-      const cleanup = () => {
-        if (timeout) {
-          clearTimeout(timeout);
-          timeout = undefined;
-        }
-        options.signal?.removeEventListener("abort", abort);
-      };
-      const abort = () => {
-        cleanup();
-        this.settle = undefined;
-        reject(new Error("Codex /btw was aborted."));
-      };
-      timeout = setTimeout(
-        () => {
-          cleanup();
-          this.settle = undefined;
-          reject(
-            new CodexSideQuestionTimeoutError(
-              "Codex /btw timed out waiting for the side thread to finish.",
-            ),
-          );
-        },
-        Math.max(100, options.timeoutMs),
-      );
-      timeout.unref?.();
-      options.signal?.addEventListener("abort", abort, { once: true });
-      this.settle = {
-        resolve: (text) => {
-          cleanup();
-          resolve(text);
-        },
-        reject: (error) => {
-          cleanup();
-          reject(error);
-        },
-      };
-    });
-  }
-
-  private async appendAssistantDelta(params: JsonObject): Promise<void> {
-    const delta = readString(params, "delta") ?? "";
-    if (!delta) {
-      return;
-    }
-    if (!this.assistantStarted) {
-      this.assistantStarted = true;
-      await this.params.opts?.onAssistantMessageStart?.();
-    }
-    this.assistantText += delta;
-  }
-
-  private completeFromTurn(params: JsonObject): void {
-    const turn = readCodexTurn(params.turn);
-    if (!turn || turn.id !== this.turnId) {
-      return;
-    }
-    this.completed = true;
-    if (turn.status === "failed") {
-      this.reject(
-        formatCodexUsageLimitErrorMessage({
-          message: turn.error?.message,
-          codexErrorInfo: turn.error?.codexErrorInfo as JsonValue | null | undefined,
-          rateLimits: this.readRecentRateLimits(),
-        }) ??
-          turn.error?.message ??
-          "Codex /btw side thread failed.",
-      );
-      return;
-    }
-    if (turn.status === "interrupted") {
-      this.reject("Codex /btw side thread was interrupted.");
-      return;
-    }
-    const finalText = collectAssistantText(turn) || this.assistantText;
-    this.resolve(finalText);
-  }
-
-  private resolve(text: string): void {
-    this.finalText = text;
-    const settle = this.settle;
-    this.settle = undefined;
-    settle?.resolve(text);
-  }
-
-  reject(error: string | Error): void {
-    this.terminalError = error instanceof Error ? error : new Error(error);
-    const settle = this.settle;
-    this.settle = undefined;
-    settle?.reject(this.terminalError);
-  }
-}
-
-function collectAssistantText(turn: CodexTurn): string {
-  const messages = (turn.items ?? [])
-    .filter((item) => item.type === "agentMessage" && typeof item.text === "string")
-    .map((item) => item.text.trim())
-    .filter(Boolean);
-  return messages.at(-1) ?? "";
 }
 
 function formatCodexErrorMessage(params: JsonObject, rateLimits: JsonValue | undefined): Error {

--- a/extensions/codex/src/app-server/turn-router-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/turn-router-lifecycle.test.ts
@@ -397,9 +397,14 @@ describe("CodexAppServerTurnRouter lifecycle", () => {
       params: { threadId: "thread-close", turnId: "turn-close", itemId: "item-4" },
     });
     await vi.waitFor(() => expect(activeHandler).toHaveBeenCalledTimes(3));
+    harness.send({
+      method: "turn/completed",
+      params: { threadId: "thread-close", turn: { id: "turn-close", items: [] } },
+    });
     harness.process.stderr.write("fatal transport detail\n");
     harness.process.emit("exit", 17, "SIGTERM");
 
+    expect(closingRoute.completed).toBe(true);
     await expect(closingRoute.bindTurn("turn-close")).rejects.toThrow("turn router closed");
     expect(activeHandler.mock.calls[2]?.[2].aborted).toBe(true);
     expect(closingRoute.signal.aborted).toBe(true);
@@ -414,6 +419,50 @@ describe("CodexAppServerTurnRouter lifecycle", () => {
       router.reserveThread({ threadId: "thread-late", onRequest: requestHandler }),
     ).toThrow("turn router is closed");
   });
+
+  it.each(["stale completion", "explicit release", "overflow"] as const)(
+    "does not drain a closed route after %s",
+    async (reason) => {
+      vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+      const harness = createHarness();
+      const notifications = vi.fn();
+      const route = getCodexAppServerTurnRouter(harness.client).reserveThread({
+        threadId: "thread-closed",
+        onNotification: notifications,
+      });
+      route.armTurn();
+      harness.send({
+        method: "turn/completed",
+        params: {
+          threadId: route.threadId,
+          turn: { id: reason === "stale completion" ? "turn-stale" : "turn-current", items: [] },
+        },
+      });
+      if (reason === "explicit release") {
+        route.release();
+      } else if (reason === "overflow") {
+        for (let index = 0; index < 256; index += 1) {
+          harness.send({
+            method: "item/started",
+            params: { threadId: route.threadId, turnId: "turn-current" },
+          });
+        }
+      }
+      harness.client.close();
+
+      await expect(
+        route.bindTurn("turn-current", { completed: reason !== "stale completion" }),
+      ).rejects.toThrow(
+        reason === "stale completion"
+          ? "turn router closed"
+          : reason === "explicit release"
+            ? "thread route is released"
+            : "pre-bind notification buffer exceeded",
+      );
+      expect(route.signal.aborted).toBe(true);
+      expect(notifications).not.toHaveBeenCalled();
+    },
+  );
 
   it("releases dormant waiters and aborts the reservation", async () => {
     const harness = createHarness();

--- a/extensions/codex/src/app-server/turn-router.ts
+++ b/extensions/codex/src/app-server/turn-router.ts
@@ -49,9 +49,10 @@ export type CodexThreadRouteReservation = {
   readonly threadId: string;
   readonly signal: AbortSignal;
   readonly observedNativeTurnId?: string;
+  readonly completed: boolean;
   activate: (handlers: CodexThreadRouteHandlers) => Promise<void>;
   armTurn: () => void;
-  bindTurn: (turnId: string) => Promise<void>;
+  bindTurn: (turnId: string, options?: { completed?: boolean }) => Promise<void>;
   cancelTurn: () => Promise<void>;
   drain: () => Promise<void>;
   release: () => void;
@@ -132,7 +133,7 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     string,
     Set<NativeTurnCompletionWatcher>
   >();
-  private disposed = false;
+  private closeError?: Error;
 
   constructor(client: CodexAppServerClient) {
     client.addNotificationHandler((notification) => this.routeNotification(notification));
@@ -182,9 +183,12 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
       get observedNativeTurnId() {
         return route.observedNativeTurn?.id;
       },
+      get completed() {
+        return Boolean(route.turnId && route.completedNativeTurnIds.has(route.turnId));
+      },
       activate: (handlers) => this.activate(route, handlers),
       armTurn: () => this.armTurn(route),
-      bindTurn: (turnId) => this.bindTurn(route, turnId),
+      bindTurn: (turnId, bindingOptions) => this.bindTurn(route, turnId, bindingOptions),
       cancelTurn: () => this.cancelTurn(route),
       drain: () => this.drainNotifications(route),
       release: () => this.release(route),
@@ -256,13 +260,13 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
   }
 
   private dispose(cause?: Error): void {
-    if (this.disposed) {
+    if (this.closeError) {
       return;
     }
-    this.disposed = true;
     const closeError = cause
       ? new Error("codex app-server turn router closed", { cause })
       : new Error("codex app-server turn router closed");
+    this.closeError = closeError;
     for (const route of this.routes.values()) {
       this.release(route, closeError);
     }
@@ -325,27 +329,41 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     this.assertRoute(route);
   }
 
-  private async bindTurn(route: Route, turnIdInput: string): Promise<void> {
-    this.assertRoute(route);
+  private async bindTurn(
+    route: Route,
+    turnIdInput: string,
+    options?: { completed?: boolean },
+  ): Promise<void> {
+    const turnId = requireId(turnIdInput, "turn id");
+    if (
+      options?.completed &&
+      route.gate === "armed" &&
+      (!route.released || route.released === this.closeError)
+    ) {
+      route.completedNativeTurnIds.add(turnId);
+    }
+    this.assertRoute(route, route.gate === "armed" ? turnId : undefined);
     if (!route.handlers) {
       throw new Error("codex app-server thread route must be activated before binding a turn");
     }
     if (route.gate !== "armed") {
       throw new Error(`codex app-server thread route cannot bind from ${route.gate}`);
     }
-    const turnId = requireId(turnIdInput, "turn id");
     route.gate = "bound";
     route.turnId = turnId;
     this.flushNotifications(route);
     route.binding?.resolve();
     await this.waitForNotifications(route);
-    this.assertRoute(route);
+    this.assertRoute(route, turnId);
+    // Physical closure revokes requests immediately, but cannot erase a received
+    // terminal turn. Finish its accepted projections within the caller's deadline.
+    await route.notificationTail;
   }
 
   // Returns the route's serialized tail so awaiting the client's notification
   // fan-out observes queued processing, not just enqueueing.
   private routeNotification(notification: CodexServerNotification): Promise<void> | undefined {
-    if (this.disposed) {
+    if (this.closeError) {
       return undefined;
     }
     const scope = readScope(notification.params);
@@ -436,7 +454,7 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     request: CodexAppServerServerRequest,
     signal: AbortSignal = new AbortController().signal,
   ): Promise<JsonValue | undefined> {
-    if (this.disposed || signal.aborted) {
+    if (this.closeError || signal.aborted) {
       return undefined;
     }
     const scope = readScope(request.params);
@@ -576,7 +594,7 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     notification: CodexServerNotification,
     scope: CodexThreadRouteScope,
   ): void {
-    if (route.released) {
+    if (route.released && !this.canDrainClosedTurn(route, route.turnId)) {
       return;
     }
     route.notificationTail = route.notificationTail
@@ -607,7 +625,11 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
       return;
     }
     route.released = error;
-    route.pending.length = 0;
+    // Keep the bounded queue on physical close for an accepted turn/start response
+    // whose continuation has not bound yet; only exact terminal receipts can drain it.
+    if (error !== this.closeError) {
+      route.pending.length = 0;
+    }
     route.ended.resolve();
     route.activated.resolve();
     route.binding?.resolve();
@@ -619,13 +641,22 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
   }
 
   private assertActive(): void {
-    if (this.disposed) {
+    if (this.closeError) {
       throw new Error("codex app-server turn router is closed");
     }
   }
 
-  private assertRoute(route: Route): void {
-    if (route.released) {
+  private canDrainClosedTurn(route: Route, turnId: string | undefined): boolean {
+    return Boolean(
+      this.closeError &&
+      route.released === this.closeError &&
+      turnId &&
+      route.completedNativeTurnIds.has(turnId),
+    );
+  }
+
+  private assertRoute(route: Route, completedTurnId?: string): void {
+    if (route.released && !this.canDrainClosedTurn(route, completedTurnId)) {
       throw route.released;
     }
   }

--- a/extensions/codex/src/web-search-provider.test.ts
+++ b/extensions/codex/src/web-search-provider.test.ts
@@ -155,6 +155,7 @@ function createFakeClient(options?: {
     addRequestHandler() {
       return () => {};
     },
+    addCloseHandler: () => () => undefined,
   } as unknown as CodexAppServerClient;
 
   return { client, requests };


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This same-repository branch retains normal maintainer repository access.

</details>
## What Problem This Solves

Fixes an issue where Codex side questions and bounded completions kept waiting after the app-server process closed, and side tools could miss request cancellation. Their separate routing paths also accumulated unbounded notifications before turn startup finished.

## Why This Change Was Made

Both ephemeral flows now use the existing client-owned turn router and one private result collector. This removes duplicate subscriptions, rebinding, buffering and completion orchestration while preserving `/btw`'s last-answer behavior and bounded callers' combined answer/items/usage behavior. Fork identity, inherited tools and policy, authentication, capability attestation, deadlines and interrupt/unsubscribe ownership remain with their existing callers.

An exact terminal receipt survives subsequent physical closure. The router drains only its existing accepted queue for that turn; stale turns, explicit release and overflow still fail closed. Physical closure immediately revokes routed requests and native hook authority, and a later caller cancellation still stops delayed projection. The main runtime retains its own bounded settlement and cleanup failure behavior.

Production LOC: **−138** including the new helper; tests/support: **+656**; the assertion-safety allowance shrinks by one. No operator configuration, schema, protocol or public SDK surface is added.

## User Impact

A disconnected side question or completion fails promptly, request cancellation reaches its tools, and an already completed answer is preserved if the process closes immediately afterward. The parent conversation stays usable and unchanged by the side fork.

## Evidence

- Four original regressions failed on `49ecde890905fa601cafc9cfbf6ea0cfe9aab824`: side/bounded client closure, side request cancellation and bounded pre-bind overflow. The actual managed Codex process reproduced the old bounded-close timeout, then passed the corrected flow.
- Three completion/close cases pass on the old collectors, failed during consolidation, and pass with router-owned terminal draining: bound completion, queued pre-bind completion, and terminal startup response. Completed-item-only text is retained with final snapshot text.
- Real native-hook invocation was accepted after closure during delayed projection before the repair; it is now rejected. A later caller abort also ends that delayed projection.
- **151** side/bounded/router tests pass, plus **16** existing main close/projection cases and **2** exact pre-bind main deadline/cancellation cases. Main first-three lifecycle cases pass in original order on both base and candidate. The main pre-bind settlement case previously failed early with router-closed; it now reaches the existing bounded settlement and explicit cleanup failure when the closed transport cannot confirm background-terminal termination.
- The real managed Codex **0.153.4** process, isolated homes and deterministic loopback provider cover closure before/after completion and side fork → native command exactly once → cancellation → unsubscribe → subsequent parent turn. Parent history, transcript and binding remain unchanged. This is real native execution with synthetic provider responses, not an OAuth or external-model-service claim.

```sh
node scripts/run-vitest.mjs extensions/codex/src/app-server/side-question.test.ts extensions/codex/src/app-server/bounded-turn.test.ts extensions/codex/src/app-server/turn-router.test.ts extensions/codex/src/app-server/turn-router-lifecycle.test.ts
node scripts/run-vitest.mjs extensions/codex/src/app-server/settled-turn-finalizer.native.test.ts --testNamePattern 'settles a bounded turn|runs and cancels ephemeral side'
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.turn-watches.test.ts --testNamePattern 'client-close|client closes|queued terminal|blocked terminal|callback throws|native hook relay state|bounds pre-bind terminal projection'
pnpm build
```

Final validation passed: pinned changed-file gate, full build, and the six-file exact-source owner/native suite (163 tests). Independent Codex P0–P2 review found no actionable findings on the final source.

Named follow-up: an earlier expanded local run hit `SQLite session reclamation commit checkpoint expired` in an unchanged fake-time main-turn test. The first three cases subsequently passed in original order on both base and candidate. Capture worker/checkpoint timing if it recurs; this PR does not change SQLite, checkpoint semantics or timeouts.

CI fixture correction: the web-search fake now exposes the real client close-handler API. The media fake supplies request identity/scope, awaits asynchronous approval replies, and completes the turn afterward. All 23 media/search tests, changed checks and an independent P2 review pass; the permission-denial assertion and production code are unchanged.
