### PR TITLE
test(ui): retain synthetic widget failure evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2691,6 +2691,19 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+      # This fixture uses synthetic documents and a mocked Gateway; exclude other UI artifacts.
+      - name: Upload synthetic widget prompt failure evidence
+        if: failure() && hashFiles('.artifacts/control-ui-e2e/control-ui-authenticated-widget-sandbox-*/widget-prompt-failure.json') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: widget-sandbox-ci-${{ strategy.job-index }}-${{ github.run_attempt }}
+          path: |
+            .artifacts/control-ui-e2e/control-ui-authenticated-widget-sandbox-*/widget-prompt-failure.json
+            .artifacts/control-ui-e2e/control-ui-authenticated-widget-sandbox-*/*.png
+            .artifacts/control-ui-e2e/control-ui-authenticated-widget-sandbox-*/*.webm
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Test browser extension bootstrap end-to-end
         if: matrix.task == 'browser-extension'
         run: pnpm test:e2e:browser-extension

--- a/.github/workflows/openclaw-repo-e2e-reusable.yml
+++ b/.github/workflows/openclaw-repo-e2e-reusable.yml
@@ -157,3 +157,16 @@ jobs:
             exit 0
           fi
           ${{ matrix.command }}
+
+      # This fixture uses synthetic documents and a mocked Gateway; exclude other UI artifacts.
+      - name: Upload synthetic widget prompt failure evidence
+        if: failure() && hashFiles('.artifacts/control-ui-e2e/control-ui-authenticated-widget-sandbox-*/widget-prompt-failure.json') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: widget-sandbox-repo-e2e-${{ strategy.job-index }}-${{ github.run_attempt }}
+          path: |
+            .artifacts/control-ui-e2e/control-ui-authenticated-widget-sandbox-*/widget-prompt-failure.json
+            .artifacts/control-ui-e2e/control-ui-authenticated-widget-sandbox-*/*.png
+            .artifacts/control-ui-e2e/control-ui-authenticated-widget-sandbox-*/*.webm
+          if-no-files-found: error
+          retention-days: 7

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -131,6 +131,7 @@ function evaluateWorkflowExpression(
     dispatchId?: string;
     draft?: boolean;
     eventName: "pull_request" | "push" | "workflow_dispatch" | "repository_dispatch" | "schedule";
+    failed?: boolean;
     env?: Record<string, string>;
     frozenTarget?: boolean;
     fileHashes?: Record<string, string>;
@@ -175,6 +176,7 @@ function evaluateWorkflowExpression(
   }
   return runInNewContext(source, {
     always: () => true,
+    failure: () => context.failed ?? false,
     cancelled: () => context.cancelled ?? false,
     // GitHub expression builtins the runner-routing clauses use.
     contains: (haystack: unknown, needle: unknown) =>
@@ -12953,6 +12955,44 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       OPENCLAW_UI_E2E_ARTIFACT_DIR: proofUpload.with.path,
     });
     expect(proofUploadIndex).toBeGreaterThan(realGatewayIndex);
+  });
+
+  it.each([
+    { failed: false, captured: false },
+    { failed: false, captured: true },
+    { failed: true, captured: false },
+    { failed: true, captured: true },
+  ])("uploads only captured synthetic widget failures: %j", ({ failed, captured }) => {
+    const artifactRoot = ".artifacts/control-ui-e2e/control-ui-authenticated-widget-sandbox-*";
+    const timeline = `${artifactRoot}/widget-prompt-failure.json`;
+    for (const job of [
+      readCiWorkflow().jobs["checks-ui-e2e"],
+      readWorkflow(".github/workflows/openclaw-repo-e2e-reusable.yml").jobs.test,
+    ]) {
+      const upload = expectDefined(
+        job.steps.find(
+          (step: WorkflowStep) => step.name === "Upload synthetic widget prompt failure evidence",
+        ),
+        "synthetic widget upload",
+      );
+      expect(
+        evaluateWorkflowExpression(`\${{ ${upload.if} }}`, {
+          eventName: "workflow_dispatch",
+          repository: "openclaw/openclaw",
+          runAttempt: 1,
+          failed,
+          fileHashes: captured ? { [timeline]: "present" } : {},
+        }),
+      ).toBe(failed && captured);
+      expect(upload.uses).toBe(UPLOAD_ARTIFACT_V7);
+      expect(upload.with.path.trim().split("\n")).toEqual([
+        timeline,
+        `${artifactRoot}/*.png`,
+        `${artifactRoot}/*.webm`,
+      ]);
+      expect(upload.with["retention-days"]).toBe(7);
+      expect(upload.with["if-no-files-found"]).toBe("error");
+    }
   });
 
   it.each([

--- a/ui/src/e2e/chat-widget-sandbox.diagnostics.test-support.ts
+++ b/ui/src/e2e/chat-widget-sandbox.diagnostics.test-support.ts
@@ -1,0 +1,104 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { BrowserContext, Page } from "playwright";
+
+/** This fixture owns only synthetic widget documents and a mocked Gateway. */
+export async function installWidgetPromptDiagnostics(context: BrowserContext): Promise<void> {
+  await context.addInitScript(() => {
+    const events: unknown[] = [];
+    Object.defineProperty(window, "openclawSyntheticWidgetTimeline", { value: events });
+    const element = (value: EventTarget | null) =>
+      value instanceof Element ? { tag: value.tagName, id: value.id.slice(0, 32) } : null;
+    const record = (kind: string, detail: Record<string, unknown> = {}) => {
+      const frame = document.querySelector(".chat-tool-card__preview-frame");
+      const rect = frame?.getBoundingClientRect();
+      if (events.length === 256) {
+        events.shift();
+      }
+      events.push({
+        at: performance.timeOrigin + performance.now(),
+        kind,
+        active: element(document.activeElement),
+        activation: navigator.userActivation.isActive,
+        frameFocused: frame ? document.activeElement === frame : null,
+        frameConnected: frame?.isConnected ?? null,
+        frameVisible: frame?.checkVisibility() ?? null,
+        frameRect: rect ? { x: rect.x, y: rect.y, width: rect.width, height: rect.height } : null,
+        ...detail,
+      });
+    };
+    for (const kind of ["pointerdown", "pointerup", "click", "focusin", "focusout"]) {
+      document.addEventListener(
+        kind,
+        (event) =>
+          record(kind, {
+            trusted: event.isTrusted,
+            target: element(event.target),
+            ...(event instanceof MouseEvent ? { x: event.clientX, y: event.clientY } : {}),
+          }),
+        true,
+      );
+    }
+    window.addEventListener("message", (event) => {
+      const type = event.data?.type;
+      if (
+        type !== "openclaw:widget-size" &&
+        type !== "openclaw:widget-prompt-offer" &&
+        type !== "openclaw:widget-bridge-ready"
+      ) {
+        return;
+      }
+      record(type, {
+        ports: event.ports.length,
+        ...(type === "openclaw:widget-size" && Number.isFinite(event.data.height)
+          ? { height: Math.min(10000, Math.max(0, event.data.height)) }
+          : {}),
+      });
+      if (type === "openclaw:widget-prompt-offer") {
+        // Observe the transferred port without starting it or changing its owner.
+        for (const port of event.ports) {
+          port.addEventListener("message", (message) => {
+            if (message.data?.type === "openclaw:widget-prompt") {
+              record("prompt-received");
+            }
+          });
+        }
+      }
+    });
+    document.addEventListener("openclaw-widget-prompt", () => record("prompt-dispatched"), true);
+  });
+}
+
+export async function retainWidgetPromptFailure(page: Page, artifactDir: string): Promise<void> {
+  const frames = await Promise.all(
+    page
+      .frames()
+      .slice(0, 8)
+      .map(async (frame, index) => {
+        try {
+          const events = await frame.evaluate(
+            () =>
+              (window as Window & { openclawSyntheticWidgetTimeline?: unknown[] })
+                .openclawSyntheticWidgetTimeline ?? [],
+          );
+          return { index, events };
+        } catch {
+          return { index, unavailable: true };
+        }
+      }),
+  );
+  // No URLs, message bodies, credentials, DOM dumps, or arbitrary page errors.
+  await writeFile(
+    path.join(artifactDir, "widget-prompt-failure.json"),
+    JSON.stringify(
+      {
+        fixture: "chat-widget-sandbox",
+        synthetic: true,
+        version: 1,
+        frames,
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/ui/src/e2e/chat-widget-sandbox.e2e.test.ts
+++ b/ui/src/e2e/chat-widget-sandbox.e2e.test.ts
@@ -20,6 +20,10 @@ import {
   defaultControlUiFeatureMethods,
   installMockGateway,
 } from "../test-helpers/control-ui-e2e.ts";
+import {
+  installWidgetPromptDiagnostics,
+  retainWidgetPromptFailure,
+} from "./chat-widget-sandbox.diagnostics.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -204,6 +208,7 @@ suite.define(() => {
       });
       expect(await authenticated.text()).toBe(html);
 
+      let completed = false;
       await suite.withPage(
         {
           viewport: { width: 1600, height: 1000 },
@@ -211,7 +216,8 @@ suite.define(() => {
           permissions: ["local-network-access"],
           recordVideo: { dir: suite.artifactDir, size: { width: 1600, height: 1000 } },
         },
-        async ({ page }) => {
+        async ({ page, context }) => {
+          await installWidgetPromptDiagnostics(context);
           const storageKey = controlUiBundledSettingsStorageKey(proxy.baseUrl);
           await page.addInitScript(
             ({ key, session }) => {
@@ -426,6 +432,12 @@ suite.define(() => {
               2,
             ),
           );
+          completed = true;
+        },
+        async ({ page }) => {
+          if (!completed) {
+            await retainWidgetPromptFailure(page, suite.artifactDir);
+          }
         },
       );
     } finally {


### PR DESCRIPTION
## What Problem This Solves

The synthetic widget sandbox E2E occasionally times out waiting for `chat.send` after a resize and Refresh click. The failed release job retained only console output, leaving no pointer, focus, or private-port timeline to distinguish a missed click from a rejected or undelivered prompt. See [the observed UI4 failure](https://github.com/openclaw/openclaw/actions/runs/33974526203/job/101329531192).

## Why This Change Was Made

The existing fixture now keeps a bounded, restricted-field event timeline and writes it before context cleanup when its scenario fails. Normal CI and reusable repository E2E upload only this synthetic fixture's failure timeline and existing PNG/WebM files, gated on both failure and timeline presence, with seven-day retention. URLs, message bodies, credentials, DOM dumps, arbitrary errors, general UI artifacts, and trace archives are excluded.

## User Impact

No application behavior changes. This improves future failure evidence; it does **not** claim to repair the intermittent failure. The original actions, assertions, security checks, and timeouts remain unchanged. Release qualification and publication remain independent of this follow-up.

## Evidence

- The unchanged original 100-file shard passed all 425 tests on Linux/Node 24.19. Eight additional focused instrumented cases also passed, so no failing causal sequence was established.
- The normal fixture passes with the final helper. A temporary, explicitly labeled injected diagnostic failure after the original flow succeeded preserved its original error, a 28,433-byte timeline across five frames, three screenshots, and finalized video. The injected throw was removed and the source byte identity verified; the normal case passed again.
- The injected timeline contains the trusted click, focused/visible iframe, private-port receipt, and host prompt event. Its field allowlist and absence of URLs, source credential, prompt body, and note text were checked. The sampled screenshot was visually inspected and contains synthetic data only.
- Workflow guards cover both owning workflows and all four failure/capture combinations, including no upload on success or absent evidence. The full workflow suite passed 445 tests with two skips; workflow lint passed.
- Full changed checks (both typecheck lanes, dead-export scans, core/scripts lint, formatting and guards) and fresh independent P2 review pass. Product runtime delta is zero; workflow metadata adds 26 lines, and tests/test support add 157 lines and remove one.
