### PR TITLE
fix(memory): prevent dirty-index maintenance from delaying searches

### DIFF
--- a/docs/concepts/memory-builtin.md
+++ b/docs/concepts/memory-builtin.md
@@ -120,9 +120,26 @@ When the index identity reports an OpenClaw chunking-implementation change,
 a normal or CLI search rebuilds it before returning results. The rebuild uses
 the agent's current embedding settings; status inspection remains read-only.
 
-Search-triggered maintenance applies pending memory and session changes
-incrementally while searches remain available. A failed full rebuild retains
-its full-retry state; ordinary dirty content does not itself force a rebuild.
+Resident searches use the published index without starting ordinary source-wide
+reconciliation. File watchers and session indexing continue to apply pending
+changes. A lifecycle safety sweep recovers missed memory events and pending
+session changes: the first sweep is scheduled after 60 seconds, with subsequent
+sweeps scheduled five minutes after the previous sweep finishes. Active watcher,
+query, sync, or maintenance work defers the sweep by 30 seconds. Sustained
+activity can keep deferring it, so these intervals are not a guaranteed freshness
+deadline.
+
+Standalone CLI searches inspect source state and await any required refresh
+before reading results. This includes file additions, edits, deletions, newly
+discovered transcripts, and full retries, even when ordinary changes and a full
+retry affect different sources. Failed refreshes retain the existing stale-result
+reporting.
+
+Search-time recovery remains available for empty-index bootstrap, missing index
+identity metadata, and OpenClaw chunking-implementation changes. A failed full
+rebuild retains its full-retry state; resident searches can retry it in the
+background, while CLI searches wait for it. Ordinary dirty content does not itself
+force a rebuild.
 
 Full reindexes build a replacement in a temporary database and publish the
 memory tables atomically. Concurrent searches and status reads keep using the

--- a/extensions/memory-core/src/memory/manager-async-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.test.ts
@@ -7,34 +7,50 @@ describe("memory manager async state", () => {
     const syncMock = vi.fn(async () => {});
     await startAsyncSearchSync({
       enabled: false,
-      dirty: true,
-      sessionsDirty: false,
+      memoryFullRetryDirty: true,
+      sessionsFullRetryDirty: false,
       sync: syncMock,
       onError: vi.fn(),
     });
     expect(syncMock).not.toHaveBeenCalled();
   });
 
-  it("reports and settles background search sync failures", async () => {
+  it("reports and settles full session retry failures", async () => {
     const syncError = new Error("sync failed");
     const onError = vi.fn();
+    const syncMock = vi.fn(async () => {
+      throw syncError;
+    });
 
     await expect(
       startAsyncSearchSync({
         enabled: true,
-        dirty: false,
-        sessionsDirty: true,
-        sync: vi.fn(async () => {
-          throw syncError;
-        }),
+        memoryFullRetryDirty: false,
+        sessionsFullRetryDirty: true,
+        sync: syncMock,
         onError,
       }),
     ).resolves.toBeUndefined();
 
     await vi.waitFor(() => expect(onError).toHaveBeenCalledWith(syncError));
+    expect(syncMock).toHaveBeenCalledExactlyOnceWith({ reason: "search" });
   });
 
-  it("waits for ordinary dirty sync", async () => {
+  it("does not start search maintenance without a full-retry flag", async () => {
+    const syncMock = vi.fn(async () => {});
+
+    await startAsyncSearchSync({
+      enabled: true,
+      memoryFullRetryDirty: false,
+      sessionsFullRetryDirty: false,
+      sync: syncMock,
+      onError: vi.fn(),
+    });
+
+    expect(syncMock).not.toHaveBeenCalled();
+  });
+
+  it("waits for full memory retry sync", async () => {
     let releaseSync = () => {};
     const pendingSync = new Promise<void>((resolve) => {
       releaseSync = () => resolve();
@@ -45,8 +61,8 @@ describe("memory manager async state", () => {
     const searchSync = Promise.resolve(
       startAsyncSearchSync({
         enabled: true,
-        dirty: true,
-        sessionsDirty: false,
+        memoryFullRetryDirty: true,
+        sessionsFullRetryDirty: false,
         sync: syncMock,
         onError: vi.fn(),
       }),

--- a/extensions/memory-core/src/memory/manager-async-state.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.ts
@@ -1,12 +1,12 @@
 // Memory Core plugin module implements manager async state behavior.
 export function startAsyncSearchSync(params: {
   enabled: boolean;
-  dirty: boolean;
-  sessionsDirty: boolean;
+  memoryFullRetryDirty: boolean;
+  sessionsFullRetryDirty: boolean;
   sync: (params: { reason: string }) => Promise<void>;
   onError: (err: unknown) => void;
 }): Promise<void> | void {
-  if (!params.enabled || (!params.dirty && !params.sessionsDirty)) {
+  if (!params.enabled || (!params.memoryFullRetryDirty && !params.sessionsFullRetryDirty)) {
     return;
   }
   try {

--- a/extensions/memory-core/src/memory/manager-background-maintenance.test.ts
+++ b/extensions/memory-core/src/memory/manager-background-maintenance.test.ts
@@ -1,0 +1,420 @@
+// Memory Core tests cover background reconciliation and full-retry maintenance.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { describe, expect, it, vi } from "vitest";
+import { createManagerIndexFixture } from "./manager-index.test-support.js";
+import * as managerSourceState from "./manager-source-state.js";
+
+const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
+const { MemoryIndexManager } = await import("./manager.js");
+
+describe("memory index background maintenance", () => {
+  const fixture = createManagerIndexFixture({
+    getMemorySearchManager,
+    closeAllMemorySearchManagers,
+  });
+  const { provider: providerFixture } = fixture;
+  const {
+    createConfig: createCfg,
+    getPersistentManager,
+    seedSessionTranscript: seedMemoryIndexSessionTranscript,
+  } = fixture;
+
+  function pauseNextMemorySourceInspection() {
+    const inspectionStarted = createDeferred<void>();
+    const releaseInspection = createDeferred<void>();
+    const inspectMemorySourceState = managerSourceState.inspectMemorySourceState;
+    const inspectSpy = vi
+      .spyOn(managerSourceState, "inspectMemorySourceState")
+      .mockImplementationOnce(async (params) => {
+        const inspection = await inspectMemorySourceState(params);
+        inspectionStarted.resolve();
+        await releaseInspection.promise;
+        return inspection;
+      });
+    return { inspectionStarted, releaseInspection, inspectSpy };
+  }
+
+  it("recovers memory source drift without a watcher event or search-owned maintenance", async () => {
+    providerFixture.forceNoProvider = true;
+    const manager = await getPersistentManager(
+      createCfg({
+        provider: "none",
+        sources: ["memory"],
+        minScore: 0,
+        hybrid: { enabled: true },
+      }),
+    );
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      closeNativeMemoryWatchPairs: () => void;
+      watchTimer: NodeJS.Timeout | null;
+      lifecycleSafetySweepTimer: NodeJS.Timeout | null;
+      lifecycleSafetySweep: Promise<void> | null;
+      startLifecycleSafetySweep: () => void;
+      syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
+    };
+    fields.closeNativeMemoryWatchPairs();
+    if (fields.watchTimer) {
+      clearTimeout(fields.watchTimer);
+      fields.watchTimer = null;
+    }
+    if (fields.lifecycleSafetySweepTimer) {
+      clearTimeout(fields.lifecycleSafetySweepTimer);
+      fields.lifecycleSafetySweepTimer = null;
+    }
+    await fs.writeFile(
+      path.join(fixture.paths.memory, "missed-watcher.md"),
+      "Missed watcher lifecycle canary is ORBIT-729.",
+    );
+    const syncSpy = vi.spyOn(manager, "sync");
+    const backgroundSync = vi.spyOn(fields, "syncPublishedIndexInBackground");
+
+    fields.startLifecycleSafetySweep();
+    const pendingSweep = fields.lifecycleSafetySweep;
+    expect(pendingSweep).not.toBeNull();
+    await pendingSweep;
+
+    expect(syncSpy).toHaveBeenCalledExactlyOnceWith({ reason: "sweep" });
+    expect(backgroundSync).not.toHaveBeenCalled();
+    await expect(
+      manager.search("Missed watcher lifecycle canary ORBIT-729", {
+        lexicalOnly: true,
+        minScore: 0,
+      }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "memory/missed-watcher.md",
+          snippet: expect.stringContaining("ORBIT-729"),
+        }),
+      ]),
+    );
+  });
+
+  it("retries ordinary session dirtiness from a sessions-only manager lifecycle", async () => {
+    providerFixture.forceNoProvider = true;
+    const manager = await getPersistentManager(
+      createCfg({
+        provider: "none",
+        sources: ["sessions"],
+        sessionMemory: true,
+        minScore: 0,
+        hybrid: { enabled: true },
+      }),
+    );
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      dirty: boolean;
+      memoryFullRetryDirty: boolean;
+      sessionsDirty: boolean;
+      sessionsFullRetryDirty: boolean;
+      sessionsReconcileDirty: boolean;
+      sessionsDirtyFiles: Set<string>;
+      lifecycleSafetySweepTimer: NodeJS.Timeout | null;
+      lifecycleSafetySweep: Promise<void> | null;
+      ensureLifecycleSafetySweep: (delayMs: number) => void;
+      syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
+    };
+    if (fields.lifecycleSafetySweepTimer) {
+      clearTimeout(fields.lifecycleSafetySweepTimer);
+      fields.lifecycleSafetySweepTimer = null;
+    }
+    expect(manager.status().sources).toEqual(["sessions"]);
+    fields.dirty = false;
+    fields.memoryFullRetryDirty = false;
+    fields.sessionsDirty = true;
+    fields.sessionsFullRetryDirty = false;
+    fields.sessionsReconcileDirty = false;
+    fields.sessionsDirtyFiles.clear();
+    const syncStarted = createDeferred<void>();
+    const releaseSync = createDeferred<void>();
+    const syncSpy = vi.spyOn(manager, "sync").mockImplementation(async () => {
+      syncStarted.resolve();
+      await releaseSync.promise;
+    });
+    const fullRetrySync = vi.spyOn(fields, "syncPublishedIndexInBackground");
+
+    let pendingSweep: Promise<void> | null = null;
+    try {
+      fields.ensureLifecycleSafetySweep(0);
+      await syncStarted.promise;
+      pendingSweep = fields.lifecycleSafetySweep;
+      expect(pendingSweep).not.toBeNull();
+      expect(syncSpy).toHaveBeenCalledExactlyOnceWith({ reason: "sweep" });
+      expect(fullRetrySync).not.toHaveBeenCalled();
+    } finally {
+      releaseSync.resolve();
+      await pendingSweep;
+    }
+  });
+
+  it("defers reconciliation when a watcher timer arrives during source inspection", async () => {
+    providerFixture.forceNoProvider = true;
+    const manager = await getPersistentManager(
+      createCfg({
+        provider: "none",
+        sources: ["memory"],
+        minScore: 0,
+        hybrid: { enabled: true },
+      }),
+    );
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      dirty: boolean;
+      watchTimer: NodeJS.Timeout | null;
+      lifecycleSafetySweepTimer: NodeJS.Timeout | null;
+      lifecycleSafetySweep: Promise<void> | null;
+      startLifecycleSafetySweep: () => void;
+      syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
+    };
+    if (fields.lifecycleSafetySweepTimer) {
+      clearTimeout(fields.lifecycleSafetySweepTimer);
+      fields.lifecycleSafetySweepTimer = null;
+    }
+    vi.useFakeTimers();
+    const syncSpy = vi.spyOn(manager, "sync").mockResolvedValue(undefined);
+    const fullRetrySync = vi.spyOn(fields, "syncPublishedIndexInBackground");
+    const { inspectionStarted, releaseInspection, inspectSpy } = pauseNextMemorySourceInspection();
+    let pendingSweep: Promise<void> | null = null;
+
+    try {
+      fields.startLifecycleSafetySweep();
+      pendingSweep = fields.lifecycleSafetySweep;
+      expect(pendingSweep).not.toBeNull();
+      await inspectionStarted.promise;
+
+      fields.dirty = true;
+      fields.watchTimer = setTimeout(() => {
+        fields.watchTimer = null;
+      }, 60_000);
+      releaseInspection.resolve();
+      await pendingSweep;
+
+      expect(inspectSpy).toHaveBeenCalledTimes(1);
+      expect(syncSpy).not.toHaveBeenCalled();
+      expect(fullRetrySync).not.toHaveBeenCalled();
+      expect(fields.lifecycleSafetySweepTimer).not.toBeNull();
+
+      if (fields.watchTimer) {
+        clearTimeout(fields.watchTimer);
+        fields.watchTimer = null;
+      }
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(syncSpy).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await fields.lifecycleSafetySweep;
+      expect(syncSpy).toHaveBeenCalledExactlyOnceWith({ reason: "sweep" });
+      expect(fullRetrySync).not.toHaveBeenCalled();
+    } finally {
+      releaseInspection.resolve();
+      await pendingSweep;
+      if (fields.watchTimer) {
+        clearTimeout(fields.watchTimer);
+        fields.watchTimer = null;
+      }
+      if (fields.lifecycleSafetySweepTimer) {
+        clearTimeout(fields.lifecycleSafetySweepTimer);
+        fields.lifecycleSafetySweepTimer = null;
+      }
+      inspectSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("routes a full retry that arrives during source inspection through published maintenance", async () => {
+    providerFixture.forceNoProvider = true;
+    const manager = await getPersistentManager(
+      createCfg({
+        provider: "none",
+        sources: ["memory"],
+        minScore: 0,
+        hybrid: { enabled: true },
+      }),
+    );
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      dirty: boolean;
+      memoryFullRetryDirty: boolean;
+      lifecycleSafetySweepTimer: NodeJS.Timeout | null;
+      lifecycleSafetySweep: Promise<void> | null;
+      startLifecycleSafetySweep: () => void;
+      syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
+    };
+    if (fields.lifecycleSafetySweepTimer) {
+      clearTimeout(fields.lifecycleSafetySweepTimer);
+      fields.lifecycleSafetySweepTimer = null;
+    }
+    const syncSpy = vi.spyOn(manager, "sync").mockResolvedValue(undefined);
+    const fullRetrySync = vi
+      .spyOn(fields, "syncPublishedIndexInBackground")
+      .mockResolvedValue(undefined);
+    const { inspectionStarted, releaseInspection, inspectSpy } = pauseNextMemorySourceInspection();
+    let pendingSweep: Promise<void> | null = null;
+
+    try {
+      fields.startLifecycleSafetySweep();
+      pendingSweep = fields.lifecycleSafetySweep;
+      expect(pendingSweep).not.toBeNull();
+      await inspectionStarted.promise;
+
+      fields.dirty = true;
+      fields.memoryFullRetryDirty = true;
+      releaseInspection.resolve();
+      await pendingSweep;
+
+      expect(inspectSpy).toHaveBeenCalledTimes(1);
+      expect(fullRetrySync).toHaveBeenCalledExactlyOnceWith({ reason: "sweep" });
+      expect(syncSpy).not.toHaveBeenCalled();
+    } finally {
+      releaseInspection.resolve();
+      await pendingSweep;
+      inspectSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    { name: "full memory retry", source: "memory", fullRetry: true },
+    { name: "full session retry", source: "sessions", fullRetry: true },
+  ] as const)(
+    "keeps search usable while maintenance syncs $name",
+    async ({ source, fullRetry }) => {
+      providerFixture.forceNoProvider = true;
+      const cfg = createCfg({
+        provider: "none",
+        sources: ["memory", "sessions"],
+        sessionMemory: true,
+        minScore: 0,
+        onSearch: true,
+        hybrid: { enabled: true },
+      });
+      const manager = await getPersistentManager(cfg);
+      await manager.sync({ reason: "test", force: true });
+      // This fixture supplies one exact dirty generation, without later native
+      // watcher notifications adding another generation during the handoff.
+      (
+        manager as unknown as { closeNativeMemoryWatchPairs: () => void }
+      ).closeNativeMemoryWatchPairs();
+      const content = "Current memory appears only after the dirty search sync.";
+      if (source === "memory") {
+        await fs.writeFile(path.join(fixture.paths.memory, "search-sync.md"), content);
+      } else {
+        await seedMemoryIndexSessionTranscript({
+          sessionId: "search-sync",
+          messages: [{ role: "assistant", timestamp: Date.now(), content }],
+        });
+      }
+      const servingFields = manager as unknown as {
+        dirty: boolean;
+        memoryFullRetryDirty: boolean;
+        sessionsDirty: boolean;
+        sessionsFullRetryDirty: boolean;
+        sessionsDirtyFiles: Set<string>;
+        listSessionCorpusEntries: () => Promise<Array<{ sessionFile: string }>>;
+        awaitManagerIdle: () => Promise<void>;
+      };
+      // A full session retry deliberately coexists with ordinary memory dirtiness.
+      // Its search-time handoff must not pull the memory source into maintenance.
+      servingFields.dirty = true;
+      servingFields.memoryFullRetryDirty = source === "memory" && fullRetry;
+      servingFields.sessionsDirty = source === "sessions";
+      servingFields.sessionsFullRetryDirty = source === "sessions" && fullRetry;
+      if (source === "sessions") {
+        const entries = await servingFields.listSessionCorpusEntries();
+        expect(entries).toHaveLength(1);
+        servingFields.sessionsDirtyFiles = new Set(entries.map((entry) => entry.sessionFile));
+      }
+
+      const maintenanceReady = createDeferred<void>();
+      const releaseMaintenance = createDeferred<void>();
+      const originalGet = MemoryIndexManager.get.bind(MemoryIndexManager);
+      let maintenanceClosed = false;
+      let maintenanceFields:
+        | {
+            runInPlaceReindex: (params: unknown) => Promise<void>;
+            syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
+            syncArchiveFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
+          }
+        | undefined;
+      const getSpy = vi.spyOn(MemoryIndexManager, "get").mockImplementation(async (params) => {
+        const acquired = await originalGet(params);
+        if (params.purpose !== "maintenance" || !acquired) {
+          return acquired;
+        }
+        const closeMaintenance = acquired.close.bind(acquired);
+        vi.spyOn(acquired, "close").mockImplementation(async () => {
+          await closeMaintenance();
+          maintenanceClosed = true;
+        });
+        const fields = acquired as unknown as NonNullable<typeof maintenanceFields>;
+        maintenanceFields = fields;
+        vi.spyOn(fields, "runInPlaceReindex");
+        const sourceSync = source === "memory" ? "syncMemoryFiles" : "syncArchiveFiles";
+        const syncSource = fields[sourceSync].bind(acquired);
+        if (source === "sessions") {
+          vi.spyOn(fields, "syncMemoryFiles");
+        }
+        vi.spyOn(fields, sourceSync).mockImplementation(async (syncParams) => {
+          // Memory full retries publish a completed shadow generation atomically, so
+          // hold after its write. Session retries write to the live generation, so
+          // hold before the write to prove reads stay on the published state.
+          if (source === "sessions") {
+            maintenanceReady.resolve();
+            await releaseMaintenance.promise;
+            return await syncSource(syncParams);
+          }
+          const result = await syncSource(syncParams);
+          maintenanceReady.resolve();
+          await releaseMaintenance.promise;
+          return result;
+        });
+        return acquired;
+      });
+
+      try {
+        const firstSearch = manager.search("zebra", { maxResults: 5, minScore: 0 });
+        await maintenanceReady.promise;
+        expect(manager.status()).toMatchObject({ dirty: true });
+        expect(maintenanceFields!.runInPlaceReindex).toHaveBeenCalledTimes(
+          source === "memory" ? 1 : 0,
+        );
+        const sourceSync =
+          maintenanceFields![source === "memory" ? "syncMemoryFiles" : "syncArchiveFiles"];
+        expect(sourceSync).toHaveBeenCalledTimes(1);
+        expect(sourceSync).toHaveBeenCalledWith(
+          expect.objectContaining({ needsFullReindex: fullRetry }),
+        );
+        if (source === "sessions") {
+          expect(maintenanceFields!.syncMemoryFiles).not.toHaveBeenCalled();
+        }
+
+        const publishedResults = await firstSearch;
+        expect(publishedResults.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+        await expect(
+          manager.search("current dirty search sync", { maxResults: 5, minScore: 0 }),
+        ).resolves.toEqual([]);
+
+        releaseMaintenance.resolve();
+        await servingFields.awaitManagerIdle();
+        expect(manager.status().dirty).toBe(source === "sessions");
+
+        const refreshedResults = await manager.search("current dirty search sync", {
+          maxResults: 5,
+          minScore: 0,
+        });
+        expect(refreshedResults).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ source, snippet: expect.stringContaining(content) }),
+          ]),
+        );
+        expect(maintenanceClosed).toBe(true);
+      } finally {
+        releaseMaintenance.resolve();
+        await servingFields.awaitManagerIdle();
+        getSpy.mockRestore();
+      }
+    },
+  );
+});

--- a/extensions/memory-core/src/memory/manager-lifecycle-ops.ts
+++ b/extensions/memory-core/src/memory/manager-lifecycle-ops.ts
@@ -81,7 +81,8 @@ export abstract class MemoryManagerLifecycleOps extends MemoryKeywordRetrieval {
             settings: this.settings,
             concurrency: this.getIndexConcurrency(),
           });
-          this.sourceInspections.set("memory", inspection);
+          // Lifecycle drift checks must not opt interactive status calls into
+          // explicit diagnostics and their storage payload scans.
           if (inspection.dirty) {
             this.dirty = true;
           }

--- a/extensions/memory-core/src/memory/manager-lifecycle-ops.ts
+++ b/extensions/memory-core/src/memory/manager-lifecycle-ops.ts
@@ -1,0 +1,128 @@
+// Memory Core plugin module owns lifecycle reconciliation outside interactive search.
+import { createSubsystemLogger } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { MemoryKeywordRetrieval } from "./manager-keyword-retrieval.js";
+import { inspectMemorySourceState } from "./manager-source-state.js";
+
+const log = createSubsystemLogger("memory");
+const MEMORY_LIFECYCLE_BUSY_RETRY_DELAY_MS = 30_000;
+const MEMORY_LIFECYCLE_INITIAL_RECONCILE_DELAY_MS = 60_000;
+const MEMORY_LIFECYCLE_SAFETY_SWEEP_INTERVAL_MS = 5 * 60_000;
+
+export abstract class MemoryManagerLifecycleOps extends MemoryKeywordRetrieval {
+  private lifecycleSafetySweepTimer: NodeJS.Timeout | null = null;
+  private lifecycleSafetySweep: Promise<void> | null = null;
+
+  protected abstract hasPublishedSyncInFlight(): boolean;
+
+  protected ensureInitialLifecycleSafetySweep(): void {
+    this.ensureLifecycleSafetySweep(MEMORY_LIFECYCLE_INITIAL_RECONCILE_DELAY_MS);
+  }
+
+  protected clearLifecycleSafetySweepTimer(): void {
+    if (!this.lifecycleSafetySweepTimer) {
+      return;
+    }
+    clearTimeout(this.lifecycleSafetySweepTimer);
+    this.lifecycleSafetySweepTimer = null;
+  }
+
+  private ensureLifecycleSafetySweep(delayMs = MEMORY_LIFECYCLE_SAFETY_SWEEP_INTERVAL_MS): void {
+    const canInspectMemory = this.sources.has("memory") && this.settings.sync.watch;
+    const canRetrySessions = this.sources.has("sessions");
+    if (
+      this.closing ||
+      this.closed ||
+      this.purpose !== "default" ||
+      (!canInspectMemory && !canRetrySessions) ||
+      this.lifecycleSafetySweepTimer ||
+      this.lifecycleSafetySweep
+    ) {
+      return;
+    }
+    this.lifecycleSafetySweepTimer = setTimeout(() => {
+      this.lifecycleSafetySweepTimer = null;
+      this.startLifecycleSafetySweep();
+    }, delayMs);
+  }
+
+  private hasConflictingLifecycleWork(allowCurrentSweep = false): boolean {
+    return (
+      this.watchTimer !== null ||
+      this.watchSyncSettling ||
+      this.activeManagerOperations > 0 ||
+      this.activeBackgroundMaintenance.size > (allowCurrentSweep ? 1 : 0) ||
+      this.hasPublishedSyncInFlight()
+    );
+  }
+
+  private startLifecycleSafetySweep(): void {
+    if (this.closing || this.closed || this.lifecycleSafetySweep) {
+      return;
+    }
+    if (this.hasConflictingLifecycleWork()) {
+      this.ensureLifecycleSafetySweep(MEMORY_LIFECYCLE_BUSY_RETRY_DELAY_MS);
+      return;
+    }
+
+    let nextSweepDelayMs = MEMORY_LIFECYCLE_SAFETY_SWEEP_INTERVAL_MS;
+    const trackedSweep = (async () => {
+      try {
+        const canInspectMemory = this.sources.has("memory") && this.settings.sync.watch;
+        if (
+          canInspectMemory &&
+          !this.dirty &&
+          !this.sessionsDirty &&
+          !this.memoryFullRetryDirty &&
+          !this.sessionsFullRetryDirty
+        ) {
+          const inspection = await inspectMemorySourceState({
+            db: this.db,
+            workspaceDir: this.workspaceDir,
+            settings: this.settings,
+            concurrency: this.getIndexConcurrency(),
+          });
+          this.sourceInspections.set("memory", inspection);
+          if (inspection.dirty) {
+            this.dirty = true;
+          }
+        }
+
+        if (this.closing || this.closed) {
+          return;
+        }
+        if (this.hasConflictingLifecycleWork(true)) {
+          nextSweepDelayMs = MEMORY_LIFECYCLE_BUSY_RETRY_DELAY_MS;
+          return;
+        }
+
+        const hasFullRetry = this.memoryFullRetryDirty || this.sessionsFullRetryDirty;
+        if (!this.dirty && !this.sessionsDirty && !hasFullRetry) {
+          return;
+        }
+        if (hasFullRetry) {
+          await this.syncPublishedIndexInBackground({ reason: "sweep" });
+          if (
+            (this.dirty || this.sessionsDirty) &&
+            !this.memoryFullRetryDirty &&
+            !this.sessionsFullRetryDirty
+          ) {
+            await this.sync({ reason: "sweep" });
+          }
+          return;
+        }
+        await this.sync({ reason: "sweep" });
+      } catch (err) {
+        log.warn(`memory lifecycle safety sweep failed: ${String(err)}`);
+      }
+    })().finally(() => {
+      this.activeBackgroundMaintenance.delete(trackedSweep);
+      if (this.lifecycleSafetySweep === trackedSweep) {
+        this.lifecycleSafetySweep = null;
+      }
+      this.ensureLifecycleSafetySweep(nextSweepDelayMs);
+    });
+
+    this.lifecycleSafetySweep = trackedSweep;
+    this.activeBackgroundMaintenance.add(trackedSweep);
+  }
+}

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
@@ -121,7 +121,7 @@ export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps 
   protected abstract closing: boolean;
   protected abstract activeManagerOperations: number;
   protected abstract managerIdleWaiters: Set<() => void>;
-  protected abstract activeBackgroundSearchSyncs: Set<Promise<void>>;
+  protected abstract activeBackgroundMaintenance: Set<Promise<void>>;
   protected abstract indexIdentityDirty: boolean;
   protected abstract indexIdentityState: MemoryIndexIdentityState;
   protected abstract syncAdmitted(
@@ -545,8 +545,8 @@ export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps 
     // CLI request teardown must not wait after a published search result is ready;
     // its detached task owns a separate maintenance manager. Persistent managers
     // still drain maintenance before closing shared resources.
-    while (this.purpose !== "cli" && this.activeBackgroundSearchSyncs.size > 0) {
-      await Promise.all(Array.from(this.activeBackgroundSearchSyncs));
+    while (this.purpose !== "cli" && this.activeBackgroundMaintenance.size > 0) {
+      await Promise.all(Array.from(this.activeBackgroundMaintenance));
     }
   }
 

--- a/extensions/memory-core/src/memory/manager-reads.test.ts
+++ b/extensions/memory-core/src/memory/manager-reads.test.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
 import { deleteSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { describe, expect, it, vi } from "vitest";
+import { executeMemorySearchToolQuery } from "../memory-search-tool-query.js";
 import { createManagerIndexFixture } from "./manager-index.test-support.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
@@ -153,6 +154,36 @@ describe("memory manager reads", () => {
       ).toHaveLength(1);
     } finally {
       syncReads.restore();
+    }
+  });
+
+  it("keeps tool queries out of storage diagnostics after a clean lifecycle sweep", async () => {
+    fixture.provider.forceNoProvider = true;
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const cfg = fixture.createConfig({ provider: "none", sources: ["memory"], cacheEnabled: true });
+    const manager = await fixture.getFreshManager(cfg);
+    await manager.sync({ reason: "test" });
+    expect(manager.status().dirty).toBe(false);
+    await vi.advanceTimersByTimeAsync(60_000);
+    await (Reflect.get(manager, "lifecycleSafetySweep") as Promise<void> | null);
+
+    const observation = observeReads(Reflect.get(manager, "db") as DatabaseSync);
+    try {
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const result = await executeMemorySearchToolQuery({
+          initialManager: { manager },
+          refreshManager: async () => null,
+          query: { text: "zebra", resultLimit: 5, minScore: 0, defaultSources: ["memory"] },
+          visibility: { cfg, agentId: "main", sandboxed: false },
+          signal: new AbortController().signal,
+        });
+        expect(result.rawResults.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+        expect(result.status.storage).toBeUndefined();
+      }
+      expect(observation.reads.filter(({ sql }) => /\blength\s*\(/i.test(sql))).toHaveLength(0);
+    } finally {
+      observation.restore();
+      vi.useRealTimers();
     }
   });
 });

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -709,88 +709,94 @@ describe("memory index", () => {
     }
   });
 
-  it("keeps transient CLI search off the serving manager write path", async () => {
+  it("refreshes added, edited, and deleted memory files before each standalone CLI search", async () => {
+    providerFixture.forceNoProvider = true;
+    const cfg = createCfg({ provider: "none", sources: ["memory"], minScore: 0 });
+    const initialManager = await getFreshManager(cfg, "cli");
+    await initialManager.sync({ reason: "test" });
+    await initialManager.close();
+    const file = path.join(fixture.paths.memory, "cli-refresh.md");
+    for (const content of ["quartz", "cobalt", null]) {
+      if (content === null) {
+        await fs.unlink(file);
+      } else {
+        await fs.writeFile(file, `${content} standalone memory refresh.`);
+      }
+      const manager = await getFreshManager(cfg, "cli", true);
+      try {
+        const results = await manager.search(content ?? "cobalt", { minScore: 0 });
+        expect(results.some((entry) => entry.path === "memory/cli-refresh.md")).toBe(
+          content !== null,
+        );
+        if (content === "cobalt") {
+          expect(await manager.search("quartz", { minScore: 0 })).toEqual([]);
+        }
+        expect(manager.status().dirty).toBe(false);
+      } finally {
+        await manager.close();
+      }
+    }
+  });
+
+  it("refreshes newly discovered session transcripts before standalone CLI search", async () => {
     providerFixture.forceNoProvider = true;
     const cfg = createCfg({
       provider: "none",
+      sources: ["memory", "sessions"],
+      sessionMemory: true,
       minScore: 0,
-      onSearch: false,
-      hybrid: { enabled: true },
     });
     const initialManager = await getFreshManager(cfg, "cli");
-    await initialManager.sync({ reason: "test", force: true });
-    await initialManager.close?.();
-    await fs.writeFile(
-      path.join(fixture.paths.memory, "cli-refresh.md"),
-      "Content published after transient CLI maintenance.",
-    );
-
-    const manager = await getFreshManager(cfg, "cli", true);
-    const servingFields = manager as unknown as {
-      syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
-    };
-    Reflect.set(manager, "dirty", true);
-    Reflect.set(manager, "memoryFullRetryDirty", true);
-    const servingSync = vi.spyOn(servingFields, "syncMemoryFiles");
-    const maintenanceReady = createDeferred<void>();
-    const releaseMaintenance = createDeferred<void>();
-    let closePromise: Promise<void> | undefined;
-    let maintenanceClosed = false;
-    const originalGet = MemoryIndexManager.get.bind(MemoryIndexManager);
-    const getSpy = vi.spyOn(MemoryIndexManager, "get").mockImplementation(async (params) => {
-      const acquired = await originalGet(params);
-      if (params.purpose !== "maintenance" || !acquired) {
-        return acquired;
-      }
-      const closeMaintenance = acquired.close.bind(acquired);
-      vi.spyOn(acquired, "close").mockImplementation(async () => {
-        await closeMaintenance();
-        maintenanceClosed = true;
-      });
-      const fields = acquired as unknown as {
-        syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
-      };
-      const syncMemoryFiles = fields.syncMemoryFiles.bind(acquired);
-      vi.spyOn(fields, "syncMemoryFiles").mockImplementation(async (syncParams) => {
-        const result = await syncMemoryFiles(syncParams);
-        maintenanceReady.resolve();
-        await releaseMaintenance.promise;
-        return result;
-      });
-      return acquired;
+    await initialManager.sync({ reason: "test" });
+    await initialManager.close();
+    await seedMemoryIndexSessionTranscript({
+      sessionId: "cli-fresh-transcript",
+      messages: [{ role: "user", timestamp: Date.now(), content: "cinnabar transcript discovery" }],
     });
-
-    try {
-      const search = manager.search("zebra", {
-        maxResults: 5,
-        minScore: 0,
-        sessionKey: "agent:main:cli:memory-search",
-      });
-      await vi.waitFor(() =>
-        expect(getSpy).toHaveBeenCalledWith(expect.objectContaining({ purpose: "maintenance" })),
-      );
-      await maintenanceReady.promise;
-      const results = await search;
-
-      expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
-      expect(servingSync).not.toHaveBeenCalled();
-      if (typeof manager.close !== "function") {
-        throw new Error("Expected CLI memory manager close support");
-      }
-      closePromise = manager.close();
-      let closeSettled = false;
-      void closePromise.then(() => {
-        closeSettled = true;
-      });
-      await vi.waitFor(() => expect(closeSettled).toBe(true));
-      expect(maintenanceClosed).toBe(false);
-    } finally {
-      releaseMaintenance.resolve();
-      await closePromise;
-      getSpy.mockRestore();
-      await manager.close?.();
-    }
+    const manager = await getFreshManager(cfg, "cli", true);
+    const results = await manager.search("cinnabar", { minScore: 0 });
+    expect(
+      results.some((entry) => entry.source === "sessions" && entry.snippet.includes("cinnabar")),
+    ).toBe(true);
+    expect(manager.status().dirty).toBe(false);
   });
+
+  it.each(["memory", "sessions"] as const)(
+    "refreshes ordinary CLI changes alongside a %s full retry",
+    async (fullRetrySource) => {
+      providerFixture.forceNoProvider = true;
+      const cfg = createCfg({
+        provider: "none",
+        sources: ["memory", "sessions"],
+        sessionMemory: true,
+        minScore: 0,
+      });
+      const initialManager = await getFreshManager(cfg, "cli");
+      await initialManager.sync({ reason: "test" });
+      await initialManager.close();
+      await fs.writeFile(path.join(fixture.paths.memory, "cli-mixed.md"), "cobalt mixed refresh");
+      await seedMemoryIndexSessionTranscript({
+        sessionId: "cli-mixed-transcript",
+        messages: [{ role: "user", timestamp: Date.now(), content: "cinnabar mixed refresh" }],
+      });
+      const manager = await getFreshManager(cfg, "cli", true);
+      Reflect.set(
+        manager,
+        fullRetrySource === "memory" ? "memoryFullRetryDirty" : "sessionsFullRetryDirty",
+        true,
+      );
+      const ordinaryQuery = fullRetrySource === "memory" ? "cinnabar" : "cobalt";
+      try {
+        const results = await manager.search(ordinaryQuery, { minScore: 0 });
+        expect(results.some((entry) => entry.snippet.includes(ordinaryQuery))).toBe(true);
+        expect(manager.status().dirty).toBe(false);
+      } finally {
+        const pending = Reflect.get(manager, "activeBackgroundMaintenance") as Set<Promise<void>>;
+        await Promise.allSettled(pending);
+        await manager.close();
+      }
+    },
+  );
 
   it.each([
     {

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -534,162 +534,88 @@ describe("memory index", () => {
     expect(providerFixture.providerCalls).toHaveLength(0);
   });
 
-  it("does not block querying on session reconciliation", async () => {
-    const manager = await getPersistentManager(
-      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
-    );
-    await manager.sync({ reason: "test" });
-
-    let releaseSync = () => {};
-    const pendingSync = new Promise<void>((resolve) => {
-      releaseSync = () => resolve();
-    });
-    const backgroundSync = vi
-      .spyOn(
-        manager as unknown as {
-          syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
-        },
-        "syncPublishedIndexInBackground",
-      )
-      .mockImplementation(async () => await pendingSync);
-
-    Reflect.set(manager, "dirty", false);
-    Reflect.set(manager, "sessionsDirty", true);
-
-    const searchPromise = manager.search("zebra", {
-      maxResults: 5,
-      minScore: 0,
-    });
-    await vi.waitFor(() => expect(backgroundSync).toHaveBeenCalledWith({ reason: "search" }));
-
-    const results = await searchPromise;
-    expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
-    releaseSync();
-    await pendingSync;
-  });
-
   it.each([
-    { name: "dirty memory", source: "memory", fullRetry: false },
-    { name: "one dirty session", source: "sessions", fullRetry: false },
-    { name: "full memory retry", source: "memory", fullRetry: true },
+    { name: "ordinary memory", memoryDirty: true, sessionsDirty: false },
+    { name: "ordinary session", memoryDirty: false, sessionsDirty: true },
   ] as const)(
-    "keeps search usable while maintenance syncs $name",
-    async ({ source, fullRetry }) => {
-      providerFixture.forceNoProvider = true;
-      const cfg = createCfg({
-        provider: "none",
-        sources: ["memory", "sessions"],
-        sessionMemory: true,
-        minScore: 0,
-        onSearch: true,
-        hybrid: { enabled: true },
-      });
-      const manager = await getPersistentManager(cfg);
-      await manager.sync({ reason: "test", force: true });
-      // This fixture supplies one exact dirty generation, without later native
-      // watcher notifications adding another generation during the handoff.
-      (
-        manager as unknown as { closeNativeMemoryWatchPairs: () => void }
-      ).closeNativeMemoryWatchPairs();
-      const content = "Current memory appears only after the dirty search sync.";
-      if (source === "memory") {
-        await fs.writeFile(path.join(fixture.paths.memory, "search-sync.md"), content);
-      } else {
-        await seedMemoryIndexSessionTranscript({
-          sessionId: "search-sync",
-          messages: [{ role: "assistant", timestamp: Date.now(), content }],
-        });
-      }
-      const servingFields = manager as unknown as {
+    "keeps $name reconciliation out of interactive search",
+    async ({ memoryDirty, sessionsDirty }) => {
+      const manager = await getPersistentManager(
+        createCfg({
+          provider: "none",
+          sources: ["memory", "sessions"],
+          sessionMemory: true,
+          minScore: 0,
+          onSearch: true,
+          hybrid: { enabled: true },
+        }),
+      );
+      await manager.sync({ reason: "test" });
+
+      const fields = manager as unknown as {
         dirty: boolean;
         memoryFullRetryDirty: boolean;
         sessionsDirty: boolean;
-        sessionsDirtyFiles: Set<string>;
-        listSessionCorpusEntries: () => Promise<Array<{ sessionFile: string }>>;
-        awaitManagerIdle: () => Promise<void>;
+        sessionsFullRetryDirty: boolean;
+        syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
       };
-      servingFields.dirty = source === "memory";
-      servingFields.memoryFullRetryDirty = fullRetry;
-      servingFields.sessionsDirty = source === "sessions";
-      if (source === "sessions") {
-        const entries = await servingFields.listSessionCorpusEntries();
-        expect(entries).toHaveLength(1);
-        servingFields.sessionsDirtyFiles = new Set(entries.map((entry) => entry.sessionFile));
-      }
+      const backgroundSync = vi.spyOn(fields, "syncPublishedIndexInBackground");
 
-      const maintenanceReady = createDeferred<void>();
-      const releaseMaintenance = createDeferred<void>();
-      const originalGet = MemoryIndexManager.get.bind(MemoryIndexManager);
-      let maintenanceClosed = false;
-      let maintenanceFields:
-        | {
-            runInPlaceReindex: (params: unknown) => Promise<void>;
-            syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
-            syncArchiveFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
-          }
-        | undefined;
-      const getSpy = vi.spyOn(MemoryIndexManager, "get").mockImplementation(async (params) => {
-        const acquired = await originalGet(params);
-        if (params.purpose !== "maintenance" || !acquired) {
-          return acquired;
-        }
-        const closeMaintenance = acquired.close.bind(acquired);
-        vi.spyOn(acquired, "close").mockImplementation(async () => {
-          await closeMaintenance();
-          maintenanceClosed = true;
-        });
-        const fields = acquired as unknown as NonNullable<typeof maintenanceFields>;
-        maintenanceFields = fields;
-        vi.spyOn(fields, "runInPlaceReindex");
-        const sourceSync = source === "memory" ? "syncMemoryFiles" : "syncArchiveFiles";
-        const syncSource = fields[sourceSync].bind(acquired);
-        vi.spyOn(fields, sourceSync).mockImplementation(async (syncParams) => {
-          // Full retries hold completed shadow writes; incremental sync holds before
-          // its live writes so both cases prove reads remain available during work.
-          const result = fullRetry ? await syncSource(syncParams) : undefined;
-          maintenanceReady.resolve();
-          await releaseMaintenance.promise;
-          return fullRetry ? result : await syncSource(syncParams);
-        });
-        return acquired;
+      fields.dirty = memoryDirty;
+      fields.memoryFullRetryDirty = false;
+      fields.sessionsDirty = sessionsDirty;
+      fields.sessionsFullRetryDirty = false;
+
+      const results = await manager.search("zebra", {
+        maxResults: 5,
+        minScore: 0,
       });
 
-      try {
-        const firstSearch = manager.search("zebra", { maxResults: 5, minScore: 0 });
-        await maintenanceReady.promise;
-        expect(manager.status()).toMatchObject({ dirty: true });
-        expect(maintenanceFields!.runInPlaceReindex).toHaveBeenCalledTimes(fullRetry ? 1 : 0);
-        expect(
-          maintenanceFields![source === "memory" ? "syncMemoryFiles" : "syncArchiveFiles"],
-        ).toHaveBeenCalledWith(expect.objectContaining({ needsFullReindex: fullRetry }));
-
-        const publishedResults = await firstSearch;
-        expect(publishedResults.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
-        await expect(
-          manager.search("current dirty search sync", { maxResults: 5, minScore: 0 }),
-        ).resolves.toEqual([]);
-
-        releaseMaintenance.resolve();
-        await servingFields.awaitManagerIdle();
-        expect(manager.status().dirty).toBe(false);
-
-        const refreshedResults = await manager.search("current dirty search sync", {
-          maxResults: 5,
-          minScore: 0,
-        });
-        expect(refreshedResults).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ source, snippet: expect.stringContaining(content) }),
-          ]),
-        );
-        expect(maintenanceClosed).toBe(true);
-      } finally {
-        releaseMaintenance.resolve();
-        await servingFields.awaitManagerIdle();
-        getSpy.mockRestore();
-      }
+      expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+      expect(backgroundSync).not.toHaveBeenCalled();
+      expect(manager.status()).toMatchObject({ dirty: true });
     },
   );
+
+  it("does not let session-start search trigger ordinary memory maintenance", async () => {
+    const manager = await getPersistentManager(
+      createCfg({ provider: "none", minScore: 0, onSearch: false, hybrid: { enabled: true } }),
+    );
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      closeNativeMemoryWatchPairs: () => void;
+      dirty: boolean;
+      memoryFullRetryDirty: boolean;
+      sessionsDirty: boolean;
+      sessionsFullRetryDirty: boolean;
+      sessionsReconcileDirty: boolean;
+      sessionsDirtyFiles: Set<string>;
+      sessionWarm: Set<string>;
+      settings: { sync: { onSearch: boolean; onSessionStart: boolean } };
+      syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
+    };
+    fields.closeNativeMemoryWatchPairs();
+    fields.settings.sync.onSearch = false;
+    fields.settings.sync.onSessionStart = true;
+    fields.dirty = true;
+    fields.memoryFullRetryDirty = false;
+    fields.sessionsDirty = false;
+    fields.sessionsFullRetryDirty = false;
+    fields.sessionsReconcileDirty = false;
+    fields.sessionsDirtyFiles.clear();
+    const backgroundSync = vi.spyOn(fields, "syncPublishedIndexInBackground");
+    const sessionKey = "agent:main:test:ordinary-dirty";
+
+    const results = await manager.search("zebra", {
+      lexicalOnly: true,
+      minScore: 0,
+      sessionKey,
+    });
+
+    expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+    expect(fields.sessionWarm).toContain(sessionKey);
+    expect(backgroundSync).not.toHaveBeenCalled();
+  });
 
   it("rebuilds automatic maintenance from the revision after a concurrent memory purge", async () => {
     providerFixture.forceNoProvider = true;
@@ -803,6 +729,8 @@ describe("memory index", () => {
     const servingFields = manager as unknown as {
       syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
     };
+    Reflect.set(manager, "dirty", true);
+    Reflect.set(manager, "memoryFullRetryDirty", true);
     const servingSync = vi.spyOn(servingFields, "syncMemoryFiles");
     const maintenanceReady = createDeferred<void>();
     const releaseMaintenance = createDeferred<void>();
@@ -976,6 +904,7 @@ describe("memory index", () => {
     };
     const getSpy = vi.spyOn(MemoryIndexManager, "get").mockResolvedValue(maintenance as never);
     Reflect.set(manager, "dirty", true);
+    Reflect.set(manager, "memoryFullRetryDirty", true);
     const detachedSync = (
       manager as unknown as {
         syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
@@ -1061,6 +990,7 @@ describe("memory index", () => {
     );
     await manager.sync({ reason: "test" });
     Reflect.set(manager, "dirty", true);
+    Reflect.set(manager, "memoryFullRetryDirty", true);
     const syncSpy = vi
       .spyOn(
         manager as unknown as {

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -21,7 +21,8 @@ import {
 import { applyImportanceMultiplier } from "./importance.js";
 import { startAsyncSearchSync } from "./manager-async-state.js";
 import { acquireMemoryIndexReadGeneration } from "./manager-index-generation-lease.js";
-import { MemoryKeywordRetrieval, type KeywordSearchHit } from "./manager-keyword-retrieval.js";
+import type { KeywordSearchHit } from "./manager-keyword-retrieval.js";
+import { MemoryManagerLifecycleOps } from "./manager-lifecycle-ops.js";
 import { runVectorKnnInSubprocess } from "./manager-search-knn-subprocess.js";
 import { resolveMemorySearchPreflight } from "./manager-search-preflight.js";
 import { resolveExactPathSpecificity, searchVector } from "./manager-search.js";
@@ -34,7 +35,7 @@ const FTS_TABLE = MEMORY_INDEX_FTS_TABLE;
 const log = createSubsystemLogger("memory");
 type MemoryIndexSearchOptions = NonNullable<Parameters<MemorySearchManager["search"]>[1]>;
 
-export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
+export abstract class MemorySearchOrchestration extends MemoryManagerLifecycleOps {
   protected abstract sessionWarm: Set<string>;
 
   protected claimSessionWarmSync(sessionKey?: string): boolean {
@@ -216,8 +217,8 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
       }
       const backgroundSearchSync = startAsyncSearchSync({
         enabled: searchSyncEnabled,
-        dirty: this.dirty,
-        sessionsDirty: this.sessionsDirty,
+        memoryFullRetryDirty: this.memoryFullRetryDirty,
+        sessionsFullRetryDirty: this.sessionsFullRetryDirty,
         sync: async (params) => await this.syncPublishedIndexInBackground(params),
         onError: (err) => {
           log.warn(`memory sync failed (search): ${String(err)}`);
@@ -225,9 +226,9 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
       });
       if (backgroundSearchSync) {
         const trackedSearchSync = backgroundSearchSync.finally(() => {
-          this.activeBackgroundSearchSyncs.delete(trackedSearchSync);
+          this.activeBackgroundMaintenance.delete(trackedSearchSync);
         });
-        this.activeBackgroundSearchSyncs.add(trackedSearchSync);
+        this.activeBackgroundMaintenance.add(trackedSearchSync);
       }
       // Bootstrap and identity repair may publish a new generation. Acquire the
       // read lease only after those writers finish so first search cannot wait on itself.

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -215,8 +215,23 @@ export abstract class MemorySearchOrchestration extends MemoryManagerLifecycleOp
       if (repairedIndexIdentity.status !== "valid") {
         return [];
       }
+      if (
+        this.purpose === "cli" &&
+        searchSyncEnabled &&
+        (this.dirty ||
+          this.sessionsDirty ||
+          this.memoryFullRetryDirty ||
+          this.sessionsFullRetryDirty)
+      ) {
+        // Standalone CLI managers have no watcher or lifecycle sweep to consume
+        // source drift. Finish their admitted refresh before taking a read lease,
+        // including ordinary changes alongside either source's full retry.
+        await this.syncAdmitted({ reason: "search" }).catch((err: unknown) => {
+          log.warn(`memory sync failed (cli-search): ${formatErrorMessage(err)}`);
+        });
+      }
       const backgroundSearchSync = startAsyncSearchSync({
-        enabled: searchSyncEnabled,
+        enabled: searchSyncEnabled && this.purpose === "default",
         memoryFullRetryDirty: this.memoryFullRetryDirty,
         sessionsFullRetryDirty: this.sessionsFullRetryDirty,
         sync: async (params) => await this.syncPublishedIndexInBackground(params),

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -133,6 +133,7 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
   protected providerKey: string | null = null;
   protected watcher: FSWatcher | null = null;
   protected watchTimer: NodeJS.Timeout | null = null;
+  protected watchSyncSettling = false;
   protected sessionWatchTimer: NodeJS.Timeout | null = null;
   protected sessionUnsubscribe: (() => void) | null = null;
   protected fallbackReason?: string;
@@ -210,12 +211,25 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
     };
   }
 
-  protected takeReindexRetryStateForMaintenance(): MemoryReindexRetryState {
-    const snapshot = this.snapshotReindexRetryState();
-    // The detached generation owns only the state observed here. New watcher or
-    // session events remain dirty on this manager and trigger a later generation.
-    this.clearMemoryRetryState();
-    this.clearSessionRetryState();
+  protected takeFullReindexRetryStateForMaintenance(): MemoryReindexRetryState {
+    const takeMemory = this.memoryFullRetryDirty;
+    const takeSessions = this.sessionsFullRetryDirty;
+    const snapshot: MemoryReindexRetryState = {
+      dirty: takeMemory,
+      memoryFullRetryDirty: takeMemory,
+      sessionsDirty: takeSessions,
+      sessionsFullRetryDirty: takeSessions,
+      sessionsReconcileDirty: takeSessions && this.sessionsReconcileDirty,
+      sessionsDirtyFiles: takeSessions ? new Set(this.sessionsDirtyFiles) : new Set(),
+    };
+    // Search may recover failed full rebuilds, but ordinary memory and session
+    // dirtiness stays with the lifecycle owner. New events also remain here.
+    if (takeMemory) {
+      this.clearMemoryRetryState();
+    }
+    if (takeSessions) {
+      this.clearSessionRetryState();
+    }
     return snapshot;
   }
 

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -767,19 +767,24 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     this.watchTimer = setTimeout(() => {
       this.watchTimer = null;
       runDetachedMemorySync(async () => {
-        if (this.closed) {
-          return;
-        }
-        if (!(await settleMemoryWatchEventPaths(this.pendingWatchPaths))) {
-          if (!this.closed) {
-            this.scheduleWatchSync();
+        this.watchSyncSettling = true;
+        try {
+          if (this.closed) {
+            return;
           }
-          return;
+          if (!(await settleMemoryWatchEventPaths(this.pendingWatchPaths))) {
+            if (!this.closed) {
+              this.scheduleWatchSync();
+            }
+            return;
+          }
+          if (this.closed) {
+            return;
+          }
+          await this.sync({ reason: "watch" });
+        } finally {
+          this.watchSyncSettling = false;
         }
-        if (this.closed) {
-          return;
-        }
-        await this.sync({ reason: "watch" });
       }, "watch");
     }, this.settings.sync.watchDebounceMs);
   }

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -100,7 +100,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
   protected closing = false;
   protected activeManagerOperations = 0;
   protected managerIdleWaiters = new Set<() => void>();
-  protected activeBackgroundSearchSyncs = new Set<Promise<void>>();
+  protected activeBackgroundMaintenance = new Set<Promise<void>>();
   protected providerUnavailableReason?: string;
   protected override providerLifecycle: MemoryProviderLifecycleState;
   protected batch: {
@@ -263,6 +263,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       if (!transient) {
         runInMemoryBackgroundContext(() => {
           this.ensureWatcher();
+          this.ensureInitialLifecycleSafetySweep();
           this.ensureSessionListener();
           this.ensureIntervalSync();
           this.ensureSessionStartupCatchup();
@@ -279,6 +280,10 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       throw new Error("Memory status managers are read-only");
     }
     return await this.withPublishedDatabase(() => this.syncPublished(params));
+  }
+
+  protected override hasPublishedSyncInFlight(): boolean {
+    return this.syncing !== null;
   }
 
   adoptReindexRetryState(snapshot: MemoryReindexRetryState): void {
@@ -307,7 +312,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       async () =>
         await runMemorySearchMaintenance({
           reason: params.reason,
-          takeDirtyGeneration: () => this.takeReindexRetryStateForMaintenance(),
+          takeDirtyGeneration: () => this.takeFullReindexRetryStateForMaintenance(),
           restoreDirtyGeneration: (generation) => this.restoreReindexRetryState(generation),
           acquireManager: async () =>
             await MemoryIndexManager.get({
@@ -520,7 +525,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
         this.dirty ||
         this.sessionsDirty ||
         this.indexIdentityDirty ||
-        this.activeBackgroundSearchSyncs.size > 0,
+        this.activeBackgroundMaintenance.size > 0,
       lastSyncError: this.syncOutcomes.lastError,
       workspaceDir: this.workspaceDir,
       dbPath: this.settings.store.databasePath,
@@ -621,6 +626,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
 
   private async closeOnce(): Promise<void> {
     this.closing = true;
+    this.clearLifecycleSafetySweepTimer();
     this.queuedArchiveFiles.clear();
     this.queuedSessions.clear();
     this.queuedForce = false;

--- a/extensions/memory-core/src/memory/manager.watch-lifecycle.test.ts
+++ b/extensions/memory-core/src/memory/manager.watch-lifecycle.test.ts
@@ -1,0 +1,270 @@
+// Memory Core tests cover watcher-to-lifecycle maintenance handoff and teardown.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type {
+  MemorySearchConfig,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const BUILT_IN_WATCH_DEBOUNCE_MS = 1_500;
+const LIFECYCLE_INITIAL_RECONCILE_DELAY_MS = 60_000;
+const LIFECYCLE_SAFETY_SWEEP_INTERVAL_MS = 5 * 60_000;
+const originalWatcherStateDir = process.env.OPENCLAW_STATE_DIR;
+
+function setWatcherStateDir(stateDir: string): void {
+  Reflect.set(process.env, "OPENCLAW_STATE_DIR", stateDir);
+}
+
+function restoreWatcherStateDir(): void {
+  if (originalWatcherStateDir === undefined) {
+    Reflect.deleteProperty(process.env, "OPENCLAW_STATE_DIR");
+  } else {
+    Reflect.set(process.env, "OPENCLAW_STATE_DIR", originalWatcherStateDir);
+  }
+}
+
+vi.mock("./sqlite-vec.js", () => ({
+  loadSqliteVecExtension: async () => ({ ok: false, error: "sqlite-vec disabled in tests" }),
+}));
+
+vi.mock("./embeddings.js", () => ({
+  resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
+    providerId === "local" ? "local" : "remote",
+  resolveEmbeddingProviderIndexIdentity: () => undefined,
+  createEmbeddingProvider: async () => ({
+    requestedProvider: "openai",
+    provider: {
+      id: "mock",
+      model: "mock-embed",
+      embed: async () => [1, 0],
+      embedBatch: async (texts: string[]) => texts.map(() => [1, 0]),
+    },
+  }),
+}));
+
+import { clearEmbeddingProviders as clearRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
+import type { MemoryIndexManager } from "./manager.js";
+import { createMemoryWatchTestHarness } from "./manager.watcher-test-support.js";
+import { isolateMemoryManagerTestConfig } from "./test-config-helpers.js";
+
+const watcherHarness = createMemoryWatchTestHarness();
+const { createdNativeWatchers } = watcherHarness;
+
+describe("memory watcher lifecycle", () => {
+  let manager: MemoryIndexManager | null = null;
+  let workspaceDir = "";
+  let extraDir = "";
+  let originalPlatform: NodeJS.Platform;
+
+  beforeEach(() => {
+    watcherHarness.install();
+    originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    vi.clearAllMocks();
+    clearRegistry();
+    watcherHarness.reset();
+  });
+
+  afterAll(() => {
+    watcherHarness.uninstall();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    watcherHarness.reset();
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await closeAllMemorySearchManagers();
+    clearRegistry();
+    restoreWatcherStateDir();
+    closeOpenClawAgentDatabasesForTest();
+    resetPluginStateStoreForTests();
+    if (workspaceDir) {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+      workspaceDir = "";
+      extraDir = "";
+    }
+  });
+
+  async function setupWatcherWorkspace(seedFile: { name: string; contents: string }) {
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-watch-"));
+    setWatcherStateDir(path.join(workspaceDir, "state"));
+    extraDir = path.join(workspaceDir, "extra");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.mkdir(extraDir, { recursive: true });
+    await fs.writeFile(path.join(extraDir, seedFile.name), seedFile.contents);
+  }
+
+  function createWatcherConfig(overrides?: Partial<MemorySearchConfig>): OpenClawConfig {
+    return isolateMemoryManagerTestConfig({
+      memory: {
+        search: {
+          provider: "openai",
+          model: "mock-embed",
+          rememberAcrossConversations: false,
+          sources: ["memory"],
+          store: { vector: { enabled: false } },
+          query: { minScore: 0 },
+          extraPaths: [extraDir],
+          ...overrides,
+        },
+      },
+      agents: { entries: { main: { workspace: workspaceDir } } },
+    });
+  }
+
+  async function expectWatcherManager(cfg: OpenClawConfig, agentId = "main") {
+    const result = await getMemorySearchManager({ cfg, agentId });
+    if (!result.manager) {
+      throw new Error("manager missing");
+    }
+    expect(result.manager.status().backend).toBe("builtin");
+    expect(result.manager.status().sources).toEqual(["memory"]);
+    manager = result.manager as unknown as MemoryIndexManager;
+    return manager;
+  }
+
+  async function waitForLifecycleSafetySweep(activeManager: MemoryIndexManager): Promise<void> {
+    const pending = Reflect.get(activeManager, "lifecycleSafetySweep") as Promise<void> | null;
+    await pending;
+  }
+
+  it("reconciles initial dirty state outside interactive search", async () => {
+    vi.useFakeTimers();
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    const activeManager = await expectWatcherManager(createWatcherConfig());
+    const syncSpy = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
+
+    await vi.advanceTimersByTimeAsync(LIFECYCLE_INITIAL_RECONCILE_DELAY_MS - 1);
+    expect(syncSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await waitForLifecycleSafetySweep(activeManager);
+    expect(syncSpy).toHaveBeenCalledExactlyOnceWith({ reason: "sweep" });
+  });
+
+  it("lets an in-flight watcher settle before lifecycle reconciliation", async () => {
+    vi.useFakeTimers();
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    const activeManager = await expectWatcherManager(createWatcherConfig());
+    const extraWatcher = createdNativeWatchers.find(
+      (watcher) => watcher.dir === extraDir && watcher.recursive,
+    );
+    expect(extraWatcher).toBeDefined();
+    const startupWatchTimer = Reflect.get(activeManager, "watchTimer") as NodeJS.Timeout | null;
+    if (startupWatchTimer) {
+      clearTimeout(startupWatchTimer);
+      Reflect.set(activeManager, "watchTimer", null);
+    }
+    const syncSpy = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
+
+    await vi.advanceTimersByTimeAsync(
+      LIFECYCLE_INITIAL_RECONCILE_DELAY_MS - BUILT_IN_WATCH_DEBOUNCE_MS - 50,
+    );
+    extraWatcher?.emit("rename", "late.md");
+    await fs.writeFile(path.join(extraDir, "late.md"), "late but stable");
+    await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS + 50);
+
+    expect(Reflect.get(activeManager, "watchSyncSettling")).toBe(true);
+    expect(syncSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(syncSpy).toHaveBeenCalledExactlyOnceWith({ reason: "watch" });
+  });
+
+  it("keeps full-retry recovery on the canonical maintenance path", async () => {
+    vi.useFakeTimers();
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    const activeManager = await expectWatcherManager(createWatcherConfig());
+    Reflect.set(activeManager, "dirty", true);
+    Reflect.set(activeManager, "memoryFullRetryDirty", true);
+    const directSync = vi.spyOn(activeManager, "sync");
+    const fullRetrySync = vi
+      .spyOn(
+        activeManager as unknown as {
+          syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
+        },
+        "syncPublishedIndexInBackground",
+      )
+      .mockResolvedValue(undefined);
+
+    await vi.advanceTimersByTimeAsync(LIFECYCLE_INITIAL_RECONCILE_DELAY_MS);
+    await waitForLifecycleSafetySweep(activeManager);
+
+    expect(fullRetrySync).toHaveBeenCalledExactlyOnceWith({ reason: "sweep" });
+    expect(directSync).not.toHaveBeenCalled();
+  });
+
+  it("cancels a queued lifecycle sweep during close", async () => {
+    vi.useFakeTimers();
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    const activeManager = await expectWatcherManager(createWatcherConfig());
+    const syncSpy = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
+
+    await activeManager.close();
+    manager = null;
+    expect(Reflect.get(activeManager, "lifecycleSafetySweepTimer")).toBeNull();
+    await vi.advanceTimersByTimeAsync(LIFECYCLE_SAFETY_SWEEP_INTERVAL_MS);
+
+    expect(syncSpy).not.toHaveBeenCalled();
+  });
+
+  it("waits for an in-flight lifecycle sweep before closing resources", async () => {
+    vi.useFakeTimers();
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    const activeManager = await expectWatcherManager(createWatcherConfig());
+    let releaseSync = () => {};
+    const pendingSync = new Promise<void>((resolve) => {
+      releaseSync = () => resolve();
+    });
+    const syncSpy = vi.spyOn(activeManager, "sync").mockImplementation(async () => {
+      await pendingSync;
+    });
+    const closeFields = activeManager as unknown as {
+      closeNativeMemoryWatchPairs: () => void;
+    };
+    const closeNativeMemoryWatchPairs = closeFields.closeNativeMemoryWatchPairs.bind(activeManager);
+    let syncReleased = false;
+    const resourceCloseOrder: string[] = [];
+    const resourceCloseSpy = vi
+      .spyOn(closeFields, "closeNativeMemoryWatchPairs")
+      .mockImplementation(() => {
+        resourceCloseOrder.push(syncReleased ? "after-sync-release" : "before-sync-release");
+        closeNativeMemoryWatchPairs();
+      });
+
+    let closeSettled = false;
+    let closePromise: Promise<void> | null = null;
+    try {
+      await vi.advanceTimersByTimeAsync(LIFECYCLE_INITIAL_RECONCILE_DELAY_MS);
+      expect(syncSpy).toHaveBeenCalledExactlyOnceWith({ reason: "sweep" });
+
+      closePromise = activeManager.close().then(() => {
+        closeSettled = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(closeSettled).toBe(false);
+      expect(resourceCloseSpy).not.toHaveBeenCalled();
+    } finally {
+      syncReleased = true;
+      releaseSync();
+      if (closePromise) {
+        await closePromise;
+        manager = null;
+      }
+    }
+
+    expect(resourceCloseSpy).toHaveBeenCalledTimes(1);
+    expect(resourceCloseOrder).toEqual(["after-sync-release"]);
+    await vi.advanceTimersByTimeAsync(LIFECYCLE_SAFETY_SWEEP_INTERVAL_MS);
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -15,116 +15,7 @@ type WatchIgnoredFn = (watchPath: string, stats?: { isDirectory?: () => boolean 
 
 const BUILT_IN_WATCH_DEBOUNCE_MS = 1_500;
 
-const {
-  createdChokidarWatchers,
-  createdNativeWatchers,
-  memoryLoggerWarn,
-  watchMock,
-  nativeWatchMock,
-  nativeWatchMockFailingDir,
-} = vi.hoisted(() => {
-  // Symbols are also declared at module top-level (CHOKIDAR_FACTORY_KEY,
-  // NATIVE_FACTORY_KEY) but vi.hoisted runs before those declarations
-  // execute, so we resolve the same Symbol.for keys inline here.
-  const chokidarKey = Symbol.for("openclaw.test.memoryWatchFactory");
-  const nativeKey = Symbol.for("openclaw.test.memoryNativeWatchFactory");
-  type ChokidarEvent = "add" | "change" | "unlink" | "unlinkDir" | "error" | "ready";
-  type ChokidarCallback = (...args: unknown[]) => void;
-  function createMockChokidarWatcher() {
-    const handlers = new Map<ChokidarEvent, ChokidarCallback[]>();
-    const onceHandlers = new Map<ChokidarEvent, ChokidarCallback[]>();
-    const watcher = {
-      watchedEntries: {} as Record<string, string[]>,
-      on: vi.fn((event: ChokidarEvent, callback: ChokidarCallback) => {
-        handlers.set(event, [...(handlers.get(event) ?? []), callback]);
-        return watcher;
-      }),
-      once: vi.fn((event: ChokidarEvent, callback: ChokidarCallback) => {
-        onceHandlers.set(event, [...(onceHandlers.get(event) ?? []), callback]);
-        return watcher;
-      }),
-      add: vi.fn((_path: string | string[]) => watcher),
-      close: vi.fn(async () => undefined),
-      getWatched: vi.fn(() => watcher.watchedEntries),
-      emit: (event: ChokidarEvent, ...args: unknown[]) => {
-        for (const callback of handlers.get(event) ?? []) {
-          callback(...args);
-        }
-        const callbacks = onceHandlers.get(event) ?? [];
-        onceHandlers.delete(event);
-        for (const callback of callbacks) {
-          callback(...args);
-        }
-      },
-    };
-    return watcher;
-  }
-
-  type NativeEvent = "error";
-  type NativeCallback = (eventType: string, filename: string | null) => void;
-  type NativeErrorCallback = (err: Error) => void;
-  function createMockNativeWatcher(
-    dir: string,
-    options: { recursive?: boolean },
-    listener: NativeCallback,
-  ) {
-    const errorHandlers: NativeErrorCallback[] = [];
-    const watcher = {
-      dir,
-      options,
-      recursive: options.recursive === true,
-      listener,
-      on: vi.fn((event: NativeEvent, callback: NativeErrorCallback) => {
-        if (event === "error") {
-          errorHandlers.push(callback);
-        }
-        return watcher;
-      }),
-      close: vi.fn(() => undefined),
-      emit: (eventType: string, filename: string | null) => {
-        listener(eventType, filename);
-      },
-      emitError: (err: Error) => {
-        for (const handler of errorHandlers) {
-          handler(err);
-        }
-      },
-    };
-    return watcher;
-  }
-
-  const chokidarWatchers: Array<ReturnType<typeof createMockChokidarWatcher>> = [];
-  const nativeWatchers: Array<ReturnType<typeof createMockNativeWatcher>> = [];
-  const failingDir = { current: null as string | null };
-
-  const result = {
-    createdChokidarWatchers: chokidarWatchers,
-    createdNativeWatchers: nativeWatchers,
-    memoryLoggerWarn: vi.fn(),
-    watchMock: vi.fn(() => {
-      const watcher = createMockChokidarWatcher();
-      chokidarWatchers.push(watcher);
-      return watcher;
-    }),
-    nativeWatchMock: vi.fn(
-      (dir: string, options: { recursive?: boolean }, listener: NativeCallback) => {
-        if (failingDir.current && dir === failingDir.current) {
-          throw new Error("simulated native fs.watch creation failure");
-        }
-        const watcher = createMockNativeWatcher(dir, options, listener);
-        nativeWatchers.push(watcher);
-        return watcher;
-      },
-    ),
-    nativeWatchMockFailingDir: failingDir,
-  };
-  (globalThis as Record<PropertyKey, unknown>)[chokidarKey] = result.watchMock;
-  (globalThis as Record<PropertyKey, unknown>)[nativeKey] = result.nativeWatchMock;
-  return result;
-});
-
-const CHOKIDAR_FACTORY_KEY = Symbol.for("openclaw.test.memoryWatchFactory");
-const NATIVE_FACTORY_KEY = Symbol.for("openclaw.test.memoryNativeWatchFactory");
+const memoryLoggerWarn = vi.hoisted(() => vi.fn());
 const originalWatcherStateDir = process.env.OPENCLAW_STATE_DIR;
 
 function setWatcherStateDir(stateDir: string): void {
@@ -173,7 +64,17 @@ vi.mock("./embeddings.js", () => ({
 import { clearEmbeddingProviders as clearRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
 import type { MemoryIndexManager } from "./manager.js";
+import { createMemoryWatchTestHarness } from "./manager.watcher-test-support.js";
 import { isolateMemoryManagerTestConfig } from "./test-config-helpers.js";
+
+const watcherHarness = createMemoryWatchTestHarness();
+const {
+  createdChokidarWatchers,
+  createdNativeWatchers,
+  nativeWatchMockFailingDir,
+  watchMock,
+  nativeWatchMock,
+} = watcherHarness;
 
 describe("memory watcher config", () => {
   let manager: MemoryIndexManager | null = null;
@@ -182,6 +83,7 @@ describe("memory watcher config", () => {
   let originalPlatform: NodeJS.Platform;
 
   beforeEach(async () => {
+    watcherHarness.install();
     originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
     vi.clearAllMocks();
@@ -190,18 +92,13 @@ describe("memory watcher config", () => {
   });
 
   afterAll(() => {
-    Reflect.deleteProperty(globalThis, CHOKIDAR_FACTORY_KEY);
-    Reflect.deleteProperty(globalThis, NATIVE_FACTORY_KEY);
+    watcherHarness.uninstall();
   });
 
   afterEach(async () => {
     vi.useRealTimers();
     Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
-    watchMock.mockClear();
-    nativeWatchMock.mockClear();
-    createdChokidarWatchers.length = 0;
-    createdNativeWatchers.length = 0;
-    nativeWatchMockFailingDir.current = null;
+    watcherHarness.reset();
     if (manager) {
       await manager.close();
       manager = null;
@@ -235,6 +132,8 @@ describe("memory watcher config", () => {
         search: {
           provider: "openai",
           model: "mock-embed",
+          rememberAcrossConversations: false,
+          sources: ["memory"],
           store: { vector: { enabled: false } },
           query: { minScore: 0 },
           extraPaths: [extraDir],
@@ -251,8 +150,13 @@ describe("memory watcher config", () => {
       throw new Error("manager missing");
     }
     expect(result.manager.status().backend).toBe("builtin");
-    expect(result.manager.status().sources).toContain("memory");
+    expect(result.manager.status().sources).toEqual(["memory"]);
     manager = result.manager as unknown as MemoryIndexManager;
+    const timer = Reflect.get(manager, "lifecycleSafetySweepTimer") as NodeJS.Timeout | null;
+    if (timer) {
+      clearTimeout(timer);
+      Reflect.set(manager, "lifecycleSafetySweepTimer", null);
+    }
     return manager;
   }
 

--- a/extensions/memory-core/src/memory/manager.watcher-filesystem.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-filesystem.test.ts
@@ -14,6 +14,8 @@ import {
 } from "../test-helpers.js";
 import { MemoryIndexManager } from "./manager.js";
 
+const TEST_WATCH_DEBOUNCE_MS = 250;
+
 function activeFilesystemWatchers() {
   return process.getActiveResourcesInfo().filter((resource) => resource === "FSEventWrap").length;
 }
@@ -40,7 +42,7 @@ describe("memory watchers on the real filesystem", () => {
       const originalSetTimeout = globalThis.setTimeout;
       const timerObserver = vi.spyOn(globalThis, "setTimeout").mockImplementation((...args) => {
         // Observe the real startup pressure check and filesystem debounce timers.
-        if (args[1] === 10_000 || args[1] === 1500) {
+        if (args[1] === 10_000 || args[1] === TEST_WATCH_DEBOUNCE_MS) {
           timerContexts.push({
             turn: turnContext.getStore(),
             pendingInput: pendingInputContext.getStore(),
@@ -81,6 +83,11 @@ describe("memory watchers on the real filesystem", () => {
           throw new Error("memory manager unavailable");
         }
         const activeManager = manager;
+        // The maintained default is asserted by memory-search.test.ts. Keep this
+        // real-filesystem lifecycle test fast while exercising the same debounce path.
+        (
+          activeManager as unknown as { settings: { sync: { watchDebounceMs: number } } }
+        ).settings.sync.watchDebounceMs = TEST_WATCH_DEBOUNCE_MS;
         await activeManager.sync({ reason: "test-initial-index" });
         expect(activeManager.status().fts?.available).toBe(true);
         expect(activeFilesystemWatchers()).toBeGreaterThan(initialWatchers);

--- a/extensions/memory-core/src/memory/manager.watcher-test-support.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-test-support.ts
@@ -1,0 +1,114 @@
+import { vi } from "vitest";
+
+type ChokidarEvent = "add" | "change" | "unlink" | "unlinkDir" | "error" | "ready";
+type ChokidarCallback = (...args: unknown[]) => void;
+type NativeEvent = "error";
+type NativeCallback = (eventType: string, filename: string | null) => void;
+type NativeErrorCallback = (err: Error) => void;
+
+const CHOKIDAR_FACTORY_KEY = Symbol.for("openclaw.test.memoryWatchFactory");
+const NATIVE_FACTORY_KEY = Symbol.for("openclaw.test.memoryNativeWatchFactory");
+
+function createMockChokidarWatcher() {
+  const handlers = new Map<ChokidarEvent, ChokidarCallback[]>();
+  const onceHandlers = new Map<ChokidarEvent, ChokidarCallback[]>();
+  const watcher = {
+    watchedEntries: {} as Record<string, string[]>,
+    on: vi.fn((event: ChokidarEvent, callback: ChokidarCallback) => {
+      handlers.set(event, [...(handlers.get(event) ?? []), callback]);
+      return watcher;
+    }),
+    once: vi.fn((event: ChokidarEvent, callback: ChokidarCallback) => {
+      onceHandlers.set(event, [...(onceHandlers.get(event) ?? []), callback]);
+      return watcher;
+    }),
+    add: vi.fn((_path: string | string[]) => watcher),
+    close: vi.fn(async () => undefined),
+    getWatched: vi.fn(() => watcher.watchedEntries),
+    emit: (event: ChokidarEvent, ...args: unknown[]) => {
+      for (const callback of handlers.get(event) ?? []) {
+        callback(...args);
+      }
+      const callbacks = onceHandlers.get(event) ?? [];
+      onceHandlers.delete(event);
+      for (const callback of callbacks) {
+        callback(...args);
+      }
+    },
+  };
+  return watcher;
+}
+
+function createMockNativeWatcher(
+  dir: string,
+  options: { recursive?: boolean },
+  listener: NativeCallback,
+) {
+  const errorHandlers: NativeErrorCallback[] = [];
+  const watcher = {
+    dir,
+    options,
+    recursive: options.recursive === true,
+    listener,
+    on: vi.fn((event: NativeEvent, callback: NativeErrorCallback) => {
+      if (event === "error") {
+        errorHandlers.push(callback);
+      }
+      return watcher;
+    }),
+    close: vi.fn(() => undefined),
+    emit: (eventType: string, filename: string | null) => {
+      listener(eventType, filename);
+    },
+    emitError: (err: Error) => {
+      for (const handler of errorHandlers) {
+        handler(err);
+      }
+    },
+  };
+  return watcher;
+}
+
+export function createMemoryWatchTestHarness() {
+  const createdChokidarWatchers: Array<ReturnType<typeof createMockChokidarWatcher>> = [];
+  const createdNativeWatchers: Array<ReturnType<typeof createMockNativeWatcher>> = [];
+  const nativeWatchMockFailingDir = { current: null as string | null };
+  const watchMock = vi.fn(() => {
+    const watcher = createMockChokidarWatcher();
+    createdChokidarWatchers.push(watcher);
+    return watcher;
+  });
+  const nativeWatchMock = vi.fn(
+    (dir: string, options: { recursive?: boolean }, listener: NativeCallback) => {
+      if (nativeWatchMockFailingDir.current && dir === nativeWatchMockFailingDir.current) {
+        throw new Error("simulated native fs.watch creation failure");
+      }
+      const watcher = createMockNativeWatcher(dir, options, listener);
+      createdNativeWatchers.push(watcher);
+      return watcher;
+    },
+  );
+
+  return {
+    createdChokidarWatchers,
+    createdNativeWatchers,
+    nativeWatchMockFailingDir,
+    watchMock,
+    nativeWatchMock,
+    install() {
+      (globalThis as Record<PropertyKey, unknown>)[CHOKIDAR_FACTORY_KEY] = watchMock;
+      (globalThis as Record<PropertyKey, unknown>)[NATIVE_FACTORY_KEY] = nativeWatchMock;
+    },
+    reset() {
+      watchMock.mockClear();
+      nativeWatchMock.mockClear();
+      createdChokidarWatchers.length = 0;
+      createdNativeWatchers.length = 0;
+      nativeWatchMockFailingDir.current = null;
+    },
+    uninstall() {
+      Reflect.deleteProperty(globalThis, CHOKIDAR_FACTORY_KEY);
+      Reflect.deleteProperty(globalThis, NATIVE_FACTORY_KEY);
+    },
+  };
+}


### PR DESCRIPTION
Related: #137366

This remains a draft for the resident scheduling decision requested in the issue. It does not assume the issue's `clawsweeper:no-new-fix-pr`, `clawsweeper:needs-maintainer-review`, or `clawsweeper:needs-product-decision` restrictions have been lifted. Maintainer edits are enabled.

## What Problem This Solves

Searching an already indexed memory corpus can start ordinary source-wide reconciliation whenever memory files or session transcripts have marked the index dirty. Retrieval then competes with maintenance for CPU, SQLite and embedding capacity even though a usable published index exists. This is distinct from the forced-rebuild behavior addressed by #136064.

Ordinary reconciliation moves to the resident manager's lifecycle. Standalone CLI searches retain automatic freshness: when source inspection detects drift, admitted refresh completes before acquiring the search read lease, including mixed ordinary changes and full-retry state. Empty-index bootstrap, unsafe-identity repair and resident detached full-retry recovery remain available.

## Why This Change Was Made

The resident manager schedules initial reconciliation after 60 seconds and a missed-event safety sweep every five minutes, with a 30-second retry when watcher, query, sync or maintenance work is active. The sweep reuses the existing source inspector and sync admission. Its observations stay local: they do not activate explicit storage diagnostics on subsequent `memory_search` status calls.

Native watcher debounce remains 1.5 seconds. Session indexing, explicit indexing, revision-conflict recovery, provider fallback and teardown retain their existing owners. Full-retry handoffs take only full-retry state, leaving ordinary dirtiness with the resident owner. Closing cancels pending sweeps and drains in-flight lifecycle work before releasing resources.

The cumulative production delta is +203/-33 lines (net +170); tests and support are +1041/-343, and documentation is +20/-3 across 16 files in total. No config keys, schema, serialization formats or index identity versions change.

## User Impact

- Resident interactive searches against a valid published index do not start ordinary source-wide maintenance. Watcher updates continue to refresh the index.
- Missed memory watcher events and session dirtiness have lifecycle recovery. Busy periods can defer reconciliation; five minutes is a scheduling interval, not a guaranteed freshness deadline.
- A standalone CLI search refreshes newly discovered files/transcripts and file edits/deletions before returning results. It also awaits any required full retry, so one source's recovery cannot hide another source's ordinary changes. A CLI command can consequently wait for recovery; failed refreshes retain the existing stale-result reporting. Resident full-retry recovery remains detached.
- Routine tool queries remain count-only after a clean sweep; explicit diagnostic requests retain storage details.
- The builtin-memory documentation describes resident sweeps, busy deferral without a guaranteed freshness deadline, synchronous CLI refresh, and exceptional search-time recovery.

## Evidence

The revision addresses both actionable findings from the review of `a6ceeb2008452b8501aa2856035a4ceff1d409e7`. Three regression tests failed before the production edit for the reported reasons, then passed afterward: post-sweep tool storage diagnostics, standalone CLI file freshness, and newly discovered session transcript freshness. The file test covers addition, replacement and deletion across fresh CLI managers. Independent review then identified mixed-source retry states; two additional cases reproduced missed ordinary results alongside memory/session full retries before that edge case was corrected.

Current candidate validation on native Windows, Node 24.16.0 and repository-pinned pnpm 12.3.4:

| Check | Result |
| --- | --- |
| Five owner test files: manager reads, search orchestration, lifecycle, upgrade and async state | 44/44 passed |
| Doctor declaration and closure contracts selected by the changed gate | 5/5 passed |
| Isolated acceptance using real files, SQLite, native watchers and real timers | 1/1 passed; 1,001 files, actual completed clean sweep, then 20 real tool queries |
| Post-sweep query measurements in that acceptance run | 121.47 ms total for 20 queries; zero storage payload scans |
| Watcher freshness and teardown in that run | New file searchable after 1.93 seconds; watcher count returned to its initial value |
| Extension production and test type checks | Both passed |
| Formatting and typed lint on the code revision | Passed; all 16 PR files pass formatting, and the documentation correction passes the MDX check |
| Fresh independent review of final production code and regression coverage | Scoped clean at P0/P1; one subsequent test-only iterable simplification satisfied lint without changing behavior |

The upstream review of `8015b98982edbb04f5a86f6df32e699136e6c2cf` confirms both earlier P1 findings are resolved and the supplied behavior proof is sufficient. The subsequent documentation-only commit addresses its remaining P3 freshness-description finding; production code and tests are unchanged from that reviewed head. It makes no change to the outstanding resident scheduling decision.

The upgrade tests reopen an index with prior chunking metadata, verify both resident and CLI repair, preserve read-only status inspection, and retain configuration-mismatch behavior. Source comparison confirms the schema and config owners are unchanged. This is focused compatibility proof, not a full historical release migration matrix.

The aggregate changed gate reaches an unrelated Knip finding for `scripts/crabbox-wrapper-providers.mts:canonicalProviderName`. That function has actual production consumers in `scripts/crabbox-wrapper.mts`; the provider module, consumer, checker and script-scan config match current upstream `0afd8f031a6640bfa46048dfe7a80d26af986649`. The script scan excludes extension workspaces. No export or suppression was removed to make the gate green. This existing script export-analysis discrepancy remains a named follow-up; the aggregate is not reported as passing.

Earlier preserved Windows before/after proof showed the unmodified baseline starting maintenance once during 20 searches and the candidate starting it zero times. Historical macOS/Linux simulations on Windows failed POSIX permission checks on NTFS, including a pinned upstream control. Native Linux/macOS and the issue's large real-session workload remain unverified. The local measurements do not establish elimination of the originally reported whole-tool timeout.

## Remaining Maintainer Decisions

The CLI freshness regression is repaired; no manual-index CLI policy approval is requested. The resident sweep scheduling policy still needs maintainer acceptance. The inherited interval scheduler remains inactive because resolved `intervalMinutes` is zero; consolidating or retiring that existing internal contract is a separate maintenance choice, not a second active timer in this candidate.

The PR remains a draft. Local proof does not replace exact-head platform CI or maintainer approval.
