### PR TITLE
fix(cli): reject non-decimal gateway suspend --wait strings

### DIFF
--- a/src/cli/gateway-cli/suspend-cli.test.ts
+++ b/src/cli/gateway-cli/suspend-cli.test.ts
@@ -67,6 +67,20 @@ describe("gateway suspend CLI", () => {
     },
   );
 
+  it.each(["0x10", "0b101", "0o17"])(
+    "rejects non-decimal wait literal %j before acquiring a lease",
+    async (waitSeconds) => {
+      const callGateway = vi.fn(async () => readyResult);
+
+      // Number("0x10") would coerce to 16 s; the strict parser must reject a
+      // radix-literal --wait so it cannot silently suspend for the wrong time.
+      await expect(
+        runGatewaySuspend({ rpcOpts: {}, waitSeconds }, { callGateway, runtime: createRuntime() }),
+      ).rejects.toThrow("--wait must be a non-negative number of seconds");
+      expect(callGateway).not.toHaveBeenCalled();
+    },
+  );
+
   it.each([
     {
       name: "default gateway",

--- a/src/cli/gateway-cli/suspend-cli.ts
+++ b/src/cli/gateway-cli/suspend-cli.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { parseStrictFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import type {
   GatewaySuspendPrepareResult,
   GatewaySuspendResumeResult,
@@ -25,7 +26,11 @@ function parseWaitMs(value: string | number | undefined): number | undefined {
   if (value === undefined) {
     return undefined;
   }
-  const seconds = typeof value === "number" ? value : Number(value.trim() || Number.NaN);
+  const seconds =
+    typeof value === "number" ? value : (parseStrictFiniteNumber(value) ?? Number.NaN);
+  // parseStrictFiniteNumber (unlike Number) rejects JS radix literals, so
+  // --wait 0x10 / 0b101 / 0o17 fail here instead of silently suspending for
+  // a non-decimal seconds value; decimal/exponent seconds still parse.
   if (!Number.isFinite(seconds) || seconds < 0) {
     throw new Error("--wait must be a non-negative number of seconds");
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw gateway suspend --wait` silently accepted JavaScript radix-literal strings as seconds. Because the flag value is parsed with `Number()`, `--wait 0x10` suspends for 16 seconds, `--wait 0b101` for 5 seconds, and `--wait 0o17` for 15 seconds instead of rejecting the value, so an operator could unintentionally wait far longer (or a scripted value could be misread) than the advertised --wait window implied.

## Why This Change Was Made

`--wait <seconds>` is an external, operator-supplied CLI flag and its contract is a plain decimal "number of seconds". `Number()` accepts JS numeric-literal prefixes that are not valid decimal seconds, but the existing guard only rejected non-finite/negative values, so radix literals flowed through as a different duration. The change parses the string with the project-standard strict parser `parseStrictFiniteNumber`. It keeps every currently accepted decimal and exponent form (`0`, `"0"`, `" 0 "`, `"0.25"`, `"1e1"`) and only fails-fast on radix-prefixed/blank/invalid literals, surfacing the existing error instead of mis-parsing. No other behavior changes.

## User Impact

Operators get a clear `--wait must be a non-negative number of seconds` error for a non-decimal `--wait` value instead of the Gateway silently waiting an unexpected amount of time. Decimal and exponent `--wait` durations behave exactly as before. No config, environment, or migration surface changes.

## Evidence

### 1. Real behavior proof — the registered CLI command, real argv path

The unit suite below replaces the Gateway RPC boundary, so it cannot show what the
*command* does with a radix literal. This proof drives the **actual registered
`gateway suspend` command through Commander argv parsing** — the same entry point an
operator uses — and prints before/after behavior for both revisions of `parseWaitMs`
in a single run. Only the Gateway RPC itself is stubbed (a real Gateway cannot be
suspended on this host); argv parsing, option typing, and the CLI's own validation are
the production path.

`proof-139234-gateway-suspend-wait.mts`, run with Node v22:

```
$ node --import tsx proof-139234-gateway-suspend-wait.mts

=== openclaw gateway suspend --wait <value> : real argv path ===
(Commander parsing + the CLI's own wait validation; Gateway RPC stubbed)

case                 value    PRE-FIX (main)                                 POST-FIX (PR head)
--------------------------------------------------------------------------------------------------------------------------------
decimal seconds      30       ACCEPTED -> gateway.suspend.prepare waitMs=30000 (30 s) ACCEPTED -> gateway.suspend.prepare waitMs=30000 (30 s)
fractional seconds   1.5      ACCEPTED -> gateway.suspend.prepare waitMs=1500 (1.5 s) ACCEPTED -> gateway.suspend.prepare waitMs=1500 (1.5 s)
hex literal          0x10     ACCEPTED -> gateway.suspend.prepare waitMs=16000 (16 s) REJECTED -> "--wait must be a non-negative number of seconds"
binary literal       0b101    ACCEPTED -> gateway.suspend.prepare waitMs=5000 (5 s) REJECTED -> "--wait must be a non-negative number of seconds"
octal literal        0o17     ACCEPTED -> gateway.suspend.prepare waitMs=15000 (15 s) REJECTED -> "--wait must be a non-negative number of seconds"
exponent literal     1e3      ACCEPTED -> gateway.suspend.prepare waitMs=1000000 (1000 s) ACCEPTED -> gateway.suspend.prepare waitMs=1000000 (1000 s)
non-numeric text     soon     REJECTED -> "--wait must be a non-negative number of seconds" REJECTED -> "--wait must be a non-negative number of seconds"

=== verdict ===
radix literals accepted before fix: 3/3  (defect: silent 16/5/15 s)
radix literals accepted after fix:  0/3  (expected 0)
decimal + fractional still accepted after fix: true
pre-fix accepted 6/7, post-fix accepted 3/7

RESULT: radix rejected=true, decimal preserved=true -> PASS
```

Reading of the transcript:

- **Before the fix, the command did not reject a radix literal.** `--wait 0x10` reached
  `gateway.suspend.prepare` with `waitMs=16000`, i.e. the operator asked for one value and
  the Gateway was told to wait 16 s. `0b101` → 5000 ms and `0o17` → 15000 ms the same way.
  This is the reported defect, reproduced through the real command.
- **After the fix, all three radix literals are rejected** by the existing error, before any
  RPC is issued.
- **No regression:** decimal (`30`) and fractional (`1.5`) durations still reach
  `gateway.suspend.prepare` with unchanged `waitMs`; the exponent form `1e3` is still accepted,
  matching the PR's stated compatibility scope.

### 2. Focused regression suite on the PR head

```
$ node scripts/run-vitest.mjs src/cli/gateway-cli/suspend-cli.test.ts --reporter=dot

 Test Files  1 passed (1)
      Tests  21 passed (21)
```

The added rows assert the radix literals throw `--wait must be a non-negative number of seconds`
and that `callGateway` is **not** invoked, so no lease is acquired for a rejected value.

### 3. Static checks

- `npx oxlint` on the changed files: 0 errors / 0 warnings.
- Change is a pure string-parse swap in one owner (`src/cli/gateway-cli/suspend-cli.ts`) plus
  colocated tests; no `CHANGELOG.md` or CODEOWNERS-restricted path touched.

### Environment note

Contributor desktop environment (Windows, Node v22). The Gateway RPC boundary is substituted in
both the suite and the proof script; everything above it — Commander argv parsing, the option
value's runtime type, and the CLI's own wait validation — is the production path. PR-first
(no issue tracked).
