### PR TITLE
refactor(terminal): replay wrapped prefixes in one pass

### DIFF
--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -201,22 +201,6 @@ function applySgrSequence(active: Map<SgrCategory, string>, value: string): void
   }
 }
 
-type ActiveSgr = { close: string; open: string };
-
-function activeSgrAfter(tokens: readonly AnsiToken[]): ActiveSgr[] {
-  const active = new Map<SgrCategory, string>();
-  for (const token of tokens) {
-    if (token.kind === "ansi") {
-      applySgrSequence(active, token.value);
-    }
-  }
-  return SGR_CATEGORIES.flatMap(({ category, reset }) => {
-    const open = active.get(category);
-    const parsed = open ? parseSgrSequence(open) : undefined;
-    return open && parsed ? [{ close: sgrSequence(parsed.introducer, String(reset)), open }] : [];
-  });
-}
-
 type Osc8Link = { params: string; uri: string };
 
 function parseOsc8Sequence(value: string): Osc8Link | undefined {
@@ -252,20 +236,6 @@ function parseOsc8Sequence(value: string): Osc8Link | undefined {
   };
 }
 
-function activeOsc8After(tokens: readonly AnsiToken[]): Osc8Link | undefined {
-  let active: Osc8Link | undefined;
-  for (const token of tokens) {
-    if (token.kind !== "ansi") {
-      continue;
-    }
-    const link = parseOsc8Sequence(token.value);
-    if (link) {
-      active = link.uri === "" ? undefined : link;
-    }
-  }
-  return active;
-}
-
 function wrapLine(text: string, width: number): string[] {
   if (width <= 0) {
     return [text];
@@ -286,8 +256,6 @@ function wrapLine(text: string, width: number): string[] {
   let bufVisible = 0;
   let lastBreakIndex: number | null = null;
 
-  const bufToString = (slice?: AnsiToken[]) => (slice ?? buf).map((t) => t.value).join("");
-
   const pushLine = (value: string) => {
     const cleaned = value.replace(/\s+$/, "");
     if (visibleWidth(cleaned) === 0) {
@@ -303,14 +271,33 @@ function wrapLine(text: string, width: number): string[] {
     // Keep the suffix in its buffer: long zero-width runs can exceed the argument
     // limit of a spread-based copy even when their visible width is small.
     const left = breakAt == null || breakAt <= 0 ? buf : buf.splice(0, breakAt);
-    const activeSgr = activeSgrAfter(left);
-    const activeOsc8 = activeOsc8After(left);
+    // Only the emitted prefix determines continuation state; the buffered suffix
+    // belongs to the next line.
+    const content: string[] = [];
+    const sgr = new Map<SgrCategory, string>();
+    let activeOsc8: Osc8Link | undefined;
+    for (const token of left) {
+      content.push(token.value);
+      if (token.kind !== "ansi") {
+        continue;
+      }
+      applySgrSequence(sgr, token.value);
+      const link = parseOsc8Sequence(token.value);
+      if (link) {
+        activeOsc8 = link.uri === "" ? undefined : link;
+      }
+    }
+    const activeSgr = SGR_CATEGORIES.flatMap(({ category, reset }) => {
+      const open = sgr.get(category);
+      const parsed = open ? parseSgrSequence(open) : undefined;
+      return open && parsed ? [{ close: sgrSequence(parsed.introducer, String(reset)), open }] : [];
+    });
     const closeOsc8 = activeOsc8 ? `${ESC}]8;;${BEL}` : "";
     const openOsc8 = activeOsc8 ? `${ESC}]8;${activeOsc8.params};${activeOsc8.uri}${BEL}` : "";
     const closeSgr = activeSgr.map((state) => state.close).join("");
 
+    pushLine(`${content.join("")}${closeOsc8}${closeSgr}`);
     if (breakAt == null || breakAt <= 0) {
-      pushLine(`${bufToString()}${closeOsc8}${closeSgr}`);
       buf.length = 0;
       if (openOsc8) {
         buf.push({ kind: "ansi", value: openOsc8, width: 0 });
@@ -323,7 +310,6 @@ function wrapLine(text: string, width: number): string[] {
       return;
     }
 
-    pushLine(`${bufToString(left)}${closeOsc8}${closeSgr}`);
     if (openOsc8) {
       buf.unshift({ kind: "ansi", value: openOsc8, width: 0 });
     }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Wrapped terminal cells traversed the same emitted prefix separately to collect text, reconstruct SGR styles, and reconstruct OSC-8 links. Two single-use helpers duplicated the replay structure.

## Why This Change Was Made

Collect token values and update both continuation states in one local pass, then join the values once. The emitted prefix remains the sole owner of continuation state; buffered suffixes, style category order, and close/reopen ordering retain their existing behavior.

## User Impact

The same table output with fewer token traversals and **14 fewer production lines**. Wrapping, colors, links, Unicode widths, tabs/newlines and large-buffer handling retain their existing contracts.

## Evidence

- The unchanged three-file suite passed **164 cases before and 164 after**: 81 table, 77 ANSI and 6 skills-formatting cases. Complete case inventories match; no assertions changed.
- The full normal changed-code gate passed. Seven managed review passes found no actionable P0–P2 issue; an independent reviewer checked the full owner/caller/parser boundary and recomputed the numerical results.
- Fixed B0/C0/C1/B1 source-render study: **3,192 total calls**, including a 24-call output proof; **384 batch means**. Complete strings, UTF-8 bytes/hashes and line widths match across all six workloads. The timed operation includes rendering plus UTF-8/hash consumption.

| Workload | Forward median change | Reverse median change |
|---|---:|---:|
| Plugin-like table, width 120 | −3.40% | −2.65% |
| Unicode skills-like table | −1.67% | −2.46% |
| Dense ANSI control tail | −1.20% | −0.98% |
| Fitting ASCII | +5.68% | −3.01% |
| Plugin-like table, width 80 | −1.16% | +0.24% |
| Unchanged no-border control | +2.19% | +12.17% |

All **2,196 metric comparisons, including 897 adverse-direction values**, remain recorded. Dense-control batch tails worsened in both orders, and first-call/memory results were mixed. These modest component gains support the local simplification; they do not establish a general CLI/Gateway latency or memory improvement. Actual terminal-emulator behavior was not part of this source-render comparison.

Current-main composition at `426ca0d50f303c7cbec46741be7ff51e99145a18` is clean and the relevant table/parser/test owners are unchanged from the measured base. Production **+22/−36**, tests unchanged. No dependency, public API, configuration or intended visual-output change.
