### PR TITLE
fix(desktop): restore tray stop and simplify Rust state

### DIFF
--- a/apps/ios/Resources/Licenses/str0m.txt
+++ b/apps/ios/Resources/Licenses/str0m.txt
@@ -90,7 +90,7 @@ Source: https://github.com/tokio-rs/bytes
 Declared license: MIT
 LICENSE: L016
 
-cc 1.4.4
+cc 1.4.5
 Source: https://github.com/rust-lang/cc-rs
 Declared license: MIT OR Apache-2.0
 LICENSE-APACHE: L005
@@ -260,7 +260,7 @@ Declared license: MIT/Apache-2.0
 LICENSE-APACHE: L005
 LICENSE-MIT: L044
 
-find-msvc-tools 0.1.11
+find-msvc-tools 0.1.12
 Source: https://github.com/rust-lang/cc-rs
 Declared license: MIT OR Apache-2.0
 LICENSE-APACHE: L005
@@ -292,6 +292,12 @@ Source: https://github.com/rust-random/getrandom
 Declared license: MIT OR Apache-2.0
 LICENSE-APACHE: L047
 LICENSE-MIT: L049
+
+getrandom 0.4.3
+Source: https://github.com/rust-random/getrandom
+Declared license: MIT OR Apache-2.0
+LICENSE-APACHE: L047
+LICENSE-MIT: L149
 
 ghash 0.5.1
 Source: https://github.com/RustCrypto/universal-hashes
@@ -656,7 +662,7 @@ Declared license: MIT OR Apache-2.0
 LICENSE-APACHE: L055
 LICENSE-MIT: L039
 
-syn 3.0.4
+syn 3.0.5
 Source: https://github.com/dtolnay/syn
 Declared license: MIT OR Apache-2.0
 LICENSE-APACHE: L055
@@ -12148,3 +12154,32 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+L149
+========================================================================
+Copyright (c) 2018-2026 The rust-random Project Developers
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -2,6 +2,8 @@
 
 The Linux companion is a Tauri v2 desktop shell for local and remote OpenClaw Gateways. It discovers nearby Gateways over Bonjour, installs the CLI when local setup needs it, delegates local Gateway service management to `openclaw gateway`, opens the selected Gateway's Control UI, and stays available in the system tray.
 
+The tray's **Stop Gateway** and **Restart Gateway** actions request graceful shutdown. Running work can delay completion; **Start Gateway** brings a stopped local Gateway back online.
+
 Published AMD64 AppImages are built on Ubuntu 22.04 and require glibc 2.35 or
 newer plus a `libstdc++` that provides `GLIBCXX_3.4.30`. Ubuntu 22.04 and
 Debian 12 meet that ABI floor. RHEL 9 and Rocky Linux 9 ship glibc 2.34, so

--- a/apps/linux/src-tauri/Cargo.lock
+++ b/apps/linux/src-tauri/Cargo.lock
@@ -184,7 +184,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -950,7 +950,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1093,7 +1093,7 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "vswhom",
  "winreg 0.55.0",
 ]
@@ -1221,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
@@ -1275,7 +1275,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1346,7 +1346,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2035,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.1"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2237,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2463,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -2814,9 +2814,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "open"
-version = "5.4.2"
+version = "5.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade3be4664bc1ef537ce133015f04c176b737815c2ba9fd60edf212d6e90dd55"
+checksum = "7c603ab8300cf18bc3b14146b19fe3dfcc4843ae5a400cd0e7a30b95aa366634"
 dependencies = [
  "dunce",
  "is-wsl",
@@ -2965,9 +2965,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+checksum = "6d45aeb61b4bf818e12d4205f2466f8c4748f85f4fce0146d1c03d69d753f0ad"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2975,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
+checksum = "89cc5a242e25ed4e7704d0be240f2cfbe20a8c27e7e252d94835be93d92dc39f"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2985,9 +2985,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
+checksum = "7abf21475cc3820fe4b2ca2dc2142902f67a02189f3b5b3a229f4febc01a43e5"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2998,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
+checksum = "adba4db388f687393c18c51348d44a41d870ca9df71a2c98172ea3035dc6936e"
 dependencies = [
  "pest",
 ]
@@ -3088,7 +3088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "quick-xml",
  "serde",
  "time",
@@ -3142,9 +3142,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -3339,7 +3339,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3707,7 +3707,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3742,7 +3742,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3774,7 +3774,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
@@ -4124,9 +4124,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4417,7 +4417,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-notifications"
 version = "0.5.0-rc.11"
-source = "git+https://github.com/steipete/tauri-plugin-notifications.git?rev=d20b4ff0e0e327e49fee80903478f825eac5a71a#d20b4ff0e0e327e49fee80903478f825eac5a71a"
+source = "git+https://github.com/steipete/tauri-plugin-notifications.git?rev=35d04a6af588a5d5d438da0320c7d95a877cfe14#35d04a6af588a5d5d438da0320c7d95a877cfe14"
 dependencies = [
  "log",
  "notify-rust",
@@ -4618,7 +4618,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.20",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -4633,7 +4633,7 @@ checksum = "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6"
 dependencies = [
  "dunce",
  "embed-resource",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -4706,7 +4706,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4760,9 +4760,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4798,14 +4798,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -4858,7 +4858,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -4869,11 +4869,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -4915,7 +4915,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -4926,7 +4926,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -4939,7 +4939,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.4",
@@ -5281,9 +5281,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5294,9 +5294,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5304,9 +5304,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5314,22 +5314,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -5349,9 +5349,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6124,7 +6124,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -6207,7 +6207,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -6218,7 +6218,7 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "memchr",
 ]
 
@@ -6258,7 +6258,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
  "zvariant_utils",
 ]
 
@@ -6271,6 +6271,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 3.0.4",
+ "syn 3.0.5",
  "winnow 1.0.4",
 ]

--- a/apps/linux/src-tauri/Cargo.toml
+++ b/apps/linux/src-tauri/Cargo.toml
@@ -51,11 +51,11 @@ zeroize = "1.9.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.189"
-tauri-plugin-notifications = { git = "https://github.com/steipete/tauri-plugin-notifications.git", rev = "d20b4ff0e0e327e49fee80903478f825eac5a71a" }
+tauri-plugin-notifications = { git = "https://github.com/steipete/tauri-plugin-notifications.git", rev = "35d04a6af588a5d5d438da0320c7d95a877cfe14" }
 zbus = { version = "5.19.0", default-features = false, features = ["tokio"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-tauri-plugin-notifications = { git = "https://github.com/steipete/tauri-plugin-notifications.git", rev = "d20b4ff0e0e327e49fee80903478f825eac5a71a", default-features = false }
+tauri-plugin-notifications = { git = "https://github.com/steipete/tauri-plugin-notifications.git", rev = "35d04a6af588a5d5d438da0320c7d95a877cfe14", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-tauri-plugin-notifications = { git = "https://github.com/steipete/tauri-plugin-notifications.git", rev = "d20b4ff0e0e327e49fee80903478f825eac5a71a" }
+tauri-plugin-notifications = { git = "https://github.com/steipete/tauri-plugin-notifications.git", rev = "35d04a6af588a5d5d438da0320c7d95a877cfe14" }

--- a/apps/linux/src-tauri/src/cli.rs
+++ b/apps/linux/src-tauri/src/cli.rs
@@ -111,7 +111,7 @@ impl OpenClawCli {
         })
     }
 
-    pub fn json<T, I, S>(&self, args: I) -> Result<(T, Output), CliError>
+    pub fn json<T, I, S>(&self, args: I) -> Result<T, CliError>
     where
         T: DeserializeOwned,
         I: IntoIterator<Item = S>,
@@ -126,10 +126,9 @@ impl OpenClawCli {
                 .unwrap_or_else(|| format!("OpenClaw CLI exited with {}", output.status));
             return Err(CliError::CommandFailed(message));
         }
-        let value = serde_json::from_slice(&output.stdout).map_err(|error| {
+        serde_json::from_slice(&output.stdout).map_err(|error| {
             CliError::InvalidJson(format!("OpenClaw CLI returned invalid JSON: {error}"))
-        })?;
-        Ok((value, output))
+        })
     }
 
     fn command_path(&self) -> Result<OsString, CliError> {
@@ -147,14 +146,12 @@ impl OpenClawCli {
 
 pub(crate) fn output_tail(output: &[u8]) -> Option<String> {
     let text = String::from_utf8_lossy(output);
-    let mut lines: Vec<&str> = Vec::new();
-    for line in text.lines().filter(|line| !line.trim().is_empty()) {
-        // The CLI repeats identical progress lines while waiting; one occurrence
-        // carries the same information in a user-facing failure message.
-        if lines.last() != Some(&line) {
-            lines.push(line);
-        }
-    }
+    let mut lines: Vec<&str> = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+    // Repeated progress lines carry no additional failure context.
+    lines.dedup();
     let start = lines.len().saturating_sub(12);
     let tail = &lines[start..];
     (!tail.is_empty()).then(|| tail.join("\n"))
@@ -189,6 +186,10 @@ mod tests {
 
         assert_eq!(output_tail(output.as_bytes()), Some(expected));
         assert_eq!(output_tail(b"\n  \n"), None);
+        assert_eq!(
+            output_tail(b"waiting\n\nwaiting\nfailed\nwaiting"),
+            Some("waiting\nfailed\nwaiting".into())
+        );
     }
 
     #[test]

--- a/apps/linux/src-tauri/src/discovery.rs
+++ b/apps/linux/src-tauri/src/discovery.rs
@@ -60,7 +60,7 @@ impl DiscoveredGateway {
     }
 
     fn advertises_direct_transport(&self) -> bool {
-        // The desktop has no SSH/relay transport, so match the native client's direct-selection gate.
+        // Discovery selections open direct WebViews; they cannot use the manual SSH transport.
         self.tls || self.direct_reachable || self.host.to_ascii_lowercase().ends_with(".ts.net")
     }
 

--- a/apps/linux/src-tauri/src/gateway.rs
+++ b/apps/linux/src-tauri/src/gateway.rs
@@ -124,7 +124,7 @@ struct DashboardResponse {
 }
 
 pub fn status(cli: &OpenClawCli) -> Result<GatewaySnapshot, String> {
-    let (value, _) = cli
+    let value = cli
         .json::<DaemonStatus, _, _>(["gateway", "status", "--json"])
         .map_err(|error| error.to_string())?;
     let installed = value.service.command.is_some() || value.service.loaded;
@@ -136,14 +136,14 @@ pub fn status(cli: &OpenClawCli) -> Result<GatewaySnapshot, String> {
         .unwrap_or("stopped");
     let running = runtime_status == "running";
     let reachable = value.rpc.as_ref().is_some_and(|rpc| rpc.ok);
-    let phase = if reachable {
-        "connected"
+    let (phase, status) = if reachable {
+        ("connected", "Connected")
     } else if !installed {
-        "notInstalled"
+        ("notInstalled", "Not installed")
     } else if running {
-        "reconnecting"
+        ("reconnecting", "Unavailable")
     } else {
-        "stopped"
+        ("stopped", "Stopped")
     };
     let detail = value
         .rpc
@@ -164,22 +164,12 @@ pub fn status(cli: &OpenClawCli) -> Result<GatewaySnapshot, String> {
             }
         })
         .or_else(|| (!running).then(|| format!("Gateway service is {runtime_status}.")));
-    let status = if reachable {
-        "Connected".to_string()
-    } else if !installed {
-        "Not installed".to_string()
-    } else if running {
-        "Unavailable".to_string()
-    } else {
-        "Stopped".to_string()
-    };
-
     Ok(GatewaySnapshot {
         phase,
         installed,
         running,
         reachable,
-        status,
+        status: status.to_string(),
         detail,
     })
 }
@@ -229,21 +219,20 @@ pub fn act(cli: &OpenClawCli, action: GatewayAction) -> Result<GatewaySnapshot, 
 pub fn dashboard(cli: &OpenClawCli, snapshot: GatewaySnapshot) -> Result<ReadyGateway, String> {
     // CLIs released before `dashboard --json` reject the flag without JSON output;
     // surface an upgrade path instead of a raw parse error.
-    let (response, output) =
-        match cli.json::<DashboardResponse, _, _>(["dashboard", "--json", "--no-open"]) {
-            Ok(result) => result,
-            // Older CLIs reject the app's own --json flag (prose on stdout, or a nonzero
-            // exit naming the flag); both mean the same missing integration, not a failure
-            // the user can repair in place.
-            Err(crate::cli::CliError::InvalidJson(_)) => {
-                return Err(unsupported_dashboard_integration());
-            }
-            Err(crate::cli::CliError::CommandFailed(message)) if message.contains("\"--json\"") => {
-                return Err(unsupported_dashboard_integration());
-            }
-            Err(error) => return Err(error.to_string()),
-        };
-    if response.ok && output.status.success() {
+    let response = match cli.json::<DashboardResponse, _, _>(["dashboard", "--json", "--no-open"]) {
+        Ok(result) => result,
+        // Older CLIs reject the app's own --json flag (prose on stdout, or a nonzero
+        // exit naming the flag); both mean the same missing integration, not a failure
+        // the user can repair in place.
+        Err(crate::cli::CliError::InvalidJson(_)) => {
+            return Err(unsupported_dashboard_integration());
+        }
+        Err(crate::cli::CliError::CommandFailed(message)) if message.contains("\"--json\"") => {
+            return Err(unsupported_dashboard_integration());
+        }
+        Err(error) => return Err(error.to_string()),
+    };
+    if response.ok {
         // The browser owns the one-time pairing grant; Quick Chat keeps the
         // legacy URL's shared credential and must never consume that grant.
         let shared_auth_url = response
@@ -323,10 +312,10 @@ mod dashboard_tests {
 }
 
 fn run_service_command(cli: &OpenClawCli, action: &str) -> Result<(), String> {
-    let (response, output) = cli
+    let response = cli
         .json::<CommandResponse, _, _>(["gateway", action, "--json"])
         .map_err(|error| error.to_string())?;
-    if response.ok && output.status.success() {
+    if response.ok {
         return Ok(());
     }
     Err(response

--- a/apps/linux/src-tauri/src/gateway.rs
+++ b/apps/linux/src-tauri/src/gateway.rs
@@ -312,8 +312,14 @@ mod dashboard_tests {
 }
 
 fn run_service_command(cli: &OpenClawCli, action: &str) -> Result<(), String> {
+    // A native Stop click supplies operator consent. Restart's --force would
+    // instead bypass draining and must remain unset.
     let response = cli
-        .json::<CommandResponse, _, _>(["gateway", action, "--json"])
+        .json::<CommandResponse, _, _>(
+            ["gateway", action, "--json"]
+                .into_iter()
+                .chain((action == "stop").then_some("--force")),
+        )
         .map_err(|error| error.to_string())?;
     if response.ok {
         return Ok(());

--- a/apps/linux/src-tauri/src/gateway_device_identity.rs
+++ b/apps/linux/src-tauri/src/gateway_device_identity.rs
@@ -264,17 +264,7 @@ fn build_device_auth_payload(fields: DeviceAuthPayloadFields<'_>) -> String {
 }
 
 fn normalize_metadata(value: &str) -> String {
-    value
-        .trim()
-        .chars()
-        .map(|character| {
-            if character.is_ascii_uppercase() {
-                character.to_ascii_lowercase()
-            } else {
-                character
-            }
-        })
-        .collect()
+    value.trim().to_ascii_lowercase()
 }
 
 fn non_empty_trimmed(value: Option<&str>) -> Option<&str> {

--- a/apps/linux/src-tauri/src/gateway_ws.rs
+++ b/apps/linux/src-tauri/src/gateway_ws.rs
@@ -1785,7 +1785,14 @@ mod tests {
                     r#"#!/bin/sh
 case "$*" in
   --version) echo '0.0.0-test' ;;
-  'gateway status --json') echo '{"service":{"loaded":true,"runtime":{"status":"running"}},"rpc":{"ok":true}}' ;;
+  'gateway status --json')
+    if test -f "$(dirname "$0")/stopped"; then
+      echo '{"service":{"loaded":true,"runtime":{"status":"stopped"}},"rpc":{"ok":false}}'
+    else
+      echo '{"service":{"loaded":true,"runtime":{"status":"running"}},"rpc":{"ok":true}}'
+    fi ;;
+  'gateway stop --json --force') touch "$(dirname "$0")/stopped"; echo '{"ok":true}' ;;
+  'gateway start --json'|'gateway restart --json') rm -f "$(dirname "$0")/stopped"; echo '{"ok":true}' ;;
   'dashboard --json --no-open') cat "$(dirname "$0")/dashboard.json" ;;
   *) echo 'Unexpected CLI invocation' >&2; exit 1 ;;
 esac
@@ -1818,6 +1825,23 @@ esac
                     None => std::env::remove_var("OPENCLAW_DESKTOP_CLI"),
                 }
                 let _ = fs::remove_dir_all(&self.directory);
+            }
+        }
+
+        #[test]
+        fn gateway_actions_supply_stop_consent_without_forcing_restart() {
+            let _fixture = CliFixture::new();
+            let cli = OpenClawCli::discover().expect("discover fixture CLI");
+            for action in [
+                gateway::GatewayAction::Stop,
+                gateway::GatewayAction::Start,
+                gateway::GatewayAction::Restart,
+                gateway::GatewayAction::Stop,
+            ] {
+                let snapshot = gateway::act(&cli, action).expect("CLI accepts desktop action");
+                let running = !matches!(action, gateway::GatewayAction::Stop);
+                assert_eq!(snapshot.running, running);
+                assert_eq!(snapshot.reachable, running);
             }
         }
 

--- a/apps/linux/src-tauri/src/gateway_ws.rs
+++ b/apps/linux/src-tauri/src/gateway_ws.rs
@@ -393,11 +393,8 @@ impl RequestFailure {
 
     fn tls(message: impl Into<String>) -> Self {
         Self {
-            message: message.into(),
-            disconnect: true,
-            connect_details: ConnectErrorDetails::default(),
-            connect_state: None,
             tls_failure: true,
+            ..Self::transport(message)
         }
     }
 
@@ -424,6 +421,7 @@ struct CanvasSurfaceState {
     url: Option<String>,
 }
 
+#[derive(Default)]
 struct GatewayClientInner {
     config: Mutex<Option<GatewayWsConfig>>,
     config_generation: AtomicU64,
@@ -447,55 +445,24 @@ pub struct GatewayClient {
 impl GatewayClient {
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(GatewayClientInner {
-                config: Mutex::new(None),
-                config_generation: AtomicU64::new(0),
-                commands: Mutex::new(None),
-                agents_cache: Mutex::new(None),
-                identity: Mutex::new(None),
-                canvas_surface: Mutex::new(CanvasSurfaceState::default()),
-                user_accent: Mutex::new(None),
-                connection_notice: Mutex::new(None),
-                connection_state: AtomicU64::new(GatewayConnectionState::Down as u64),
-                reconnect_paused: AtomicBool::new(false),
-                sleep_cycle_depth: AtomicU64::new(0),
-                running: AtomicBool::new(false),
-            }),
+            inner: Arc::default(),
         }
     }
 
     pub fn configure(&self, app: &AppHandle, config: GatewayWsConfig) {
-        *self
-            .inner
-            .config
-            .lock()
-            .expect("gateway config mutex poisoned") = Some(config);
-        *self
-            .inner
-            .agents_cache
-            .lock()
-            .expect("gateway agents cache mutex poisoned") = None;
-        let generation = self.inner.config_generation.fetch_add(1, Ordering::SeqCst) + 1;
-        self.set_canvas_surface_url(generation, None);
-        self.inner.reconnect_paused.store(false, Ordering::SeqCst);
-        self.set_connection_state(app, GatewayConnectionState::Down, None);
-        if let Some(commands) = self
-            .inner
-            .commands
-            .lock()
-            .expect("gateway command mutex poisoned")
-            .as_ref()
-        {
-            let _ = commands.try_send(DriverCommand::Reconfigure);
-        }
+        self.set_configuration(app, Some(config));
     }
 
     pub fn clear_configuration(&self, app: &AppHandle) {
+        self.set_configuration(app, None);
+    }
+
+    fn set_configuration(&self, app: &AppHandle, config: Option<GatewayWsConfig>) {
         *self
             .inner
             .config
             .lock()
-            .expect("gateway config mutex poisoned") = None;
+            .expect("gateway config mutex poisoned") = config;
         *self
             .inner
             .agents_cache
@@ -505,15 +472,7 @@ impl GatewayClient {
         self.set_canvas_surface_url(generation, None);
         self.inner.reconnect_paused.store(false, Ordering::SeqCst);
         self.set_connection_state(app, GatewayConnectionState::Down, None);
-        if let Some(commands) = self
-            .inner
-            .commands
-            .lock()
-            .expect("gateway command mutex poisoned")
-            .as_ref()
-        {
-            let _ = commands.try_send(DriverCommand::Reconfigure);
-        }
+        self.resume_reconnect();
     }
 
     pub fn activate(&self, app: AppHandle) {
@@ -680,21 +639,6 @@ impl GatewayClient {
     }
 
     #[cfg(target_os = "linux")]
-    pub fn route_token(&self) -> Option<String> {
-        self.inner
-            .config
-            .lock()
-            .expect("gateway config mutex poisoned")
-            .as_ref()
-            .map(|config| config.ws_url.clone())
-    }
-
-    #[cfg(target_os = "linux")]
-    pub fn is_loopback_route(&self) -> bool {
-        self.loopback_route_token().is_some()
-    }
-
-    #[cfg(target_os = "linux")]
     pub fn loopback_route_token(&self) -> Option<String> {
         self.inner
             .config
@@ -733,11 +677,12 @@ impl GatewayClient {
         // Depth, not a boolean: an older wake task ending late must not park the
         // driver while a newer sleep cycle is still active. Saturate at zero so
         // an unbalanced end can never wrap into a permanently active driver.
-        let _ = self.inner.sleep_cycle_depth.fetch_update(
-            Ordering::SeqCst,
-            Ordering::SeqCst,
-            |depth| depth.checked_sub(1),
-        );
+        let _ =
+            self.inner
+                .sleep_cycle_depth
+                .try_update(Ordering::SeqCst, Ordering::SeqCst, |depth| {
+                    depth.checked_sub(1)
+                });
     }
 
     #[cfg(target_os = "linux")]
@@ -1604,20 +1549,6 @@ struct ValidatedHello {
     canvas_surface_url: Option<String>,
 }
 
-impl ValidatedHello {
-    fn new(
-        device_token: Option<String>,
-        tick_watch_timeout: Duration,
-        canvas_surface_url: Option<String>,
-    ) -> Self {
-        Self {
-            device_token,
-            tick_watch_timeout,
-            canvas_surface_url,
-        }
-    }
-}
-
 fn gated_canvas_surface_url(
     canvas_surface_url: Option<String>,
     inline_widgets_available: bool,
@@ -1675,17 +1606,16 @@ fn validate_hello(payload: Value) -> Result<ValidatedHello, String> {
         .and_then(|policy| policy.tick_interval_ms)
         .unwrap_or(30_000)
         .max(1);
-    let issued_device_auth = hello.auth.device_token;
     let canvas_surface_url = hello
         .plugin_surface_urls
         .and_then(|surface_urls| surface_urls.get("canvas").cloned())
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
-    Ok(ValidatedHello::new(
-        issued_device_auth,
-        Duration::from_millis(tick_interval_ms).saturating_mul(2),
+    Ok(ValidatedHello {
+        device_token: hello.auth.device_token,
+        tick_watch_timeout: Duration::from_millis(tick_interval_ms).saturating_mul(2),
         canvas_surface_url,
-    ))
+    })
 }
 
 fn classify_chat_ack(ack: &ChatSendAck) -> Result<(), String> {
@@ -1700,20 +1630,15 @@ fn classify_chat_ack(ack: &ChatSendAck) -> Result<(), String> {
 
 fn ack_error_message(ack: &ChatSendAck) -> String {
     ack.message
-        .clone()
-        .or_else(|| {
-            ack.error
-                .as_ref()
-                .and_then(Value::as_str)
-                .map(ToOwned::to_owned)
-        })
+        .as_deref()
+        .or_else(|| ack.error.as_ref().and_then(Value::as_str))
         .or_else(|| {
             ack.error
                 .as_ref()
                 .and_then(|error| error.get("message"))
                 .and_then(Value::as_str)
-                .map(ToOwned::to_owned)
         })
+        .map(str::to_string)
         .unwrap_or_else(|| format!("Gateway chat.send {}.", ack.status))
 }
 

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -21,7 +21,7 @@ mod tray;
 mod updater;
 
 use cli::{CliError, OpenClawCli};
-use gateway::{GatewayAction, GatewaySnapshot};
+use gateway::{GatewayAction, GatewaySnapshot, ReadyGateway};
 use gateway_operation_queue::{GatewayOperation, GatewayOperationQueue};
 use installer::InstallChannel;
 use remote_gateway::RemoteGatewayRequest;
@@ -483,14 +483,7 @@ impl DesktopState {
                 .take();
         }
         let ready = gateway::ensure_ready(&cli)?;
-        app.state::<gateway_ws::GatewayClient>()
-            .configure(app, ready.gateway_ws.clone());
-        let navigated = self.navigate_local(app, &ready.dashboard_url, false, None, true, true)?;
-        self.update_tray(&ready.snapshot);
-        if navigated {
-            self.start_watchdog(app.clone(), cli);
-        }
-        Ok(ready.snapshot)
+        self.finish_local_connection(app, cli, ready)
     }
 
     pub fn install_cli(
@@ -541,18 +534,10 @@ impl DesktopState {
         let ready = gateway::ensure_ready(&cli).map_err(|error| {
             format!("OpenClaw is installed, but connecting to the Gateway failed: {error}")
         })?;
-        app.state::<gateway_ws::GatewayClient>()
-            .configure(app, ready.gateway_ws.clone());
-        let navigated = self
-            .navigate_local(app, &ready.dashboard_url, false, None, true, true)
+        self.finish_local_connection(app, cli, ready)
             .map_err(|error| {
                 format!("OpenClaw is installed, but opening the Gateway dashboard failed: {error}")
-            })?;
-        self.update_tray(&ready.snapshot);
-        if navigated {
-            self.start_watchdog(app.clone(), cli);
-        }
-        Ok(ready.snapshot)
+            })
     }
 
     pub fn gateway_action(
@@ -579,8 +564,17 @@ impl DesktopState {
         }
 
         let ready = gateway::dashboard(&cli, snapshot)?;
+        self.finish_local_connection(app, cli, ready)
+    }
+
+    fn finish_local_connection(
+        &self,
+        app: &AppHandle,
+        cli: OpenClawCli,
+        ready: ReadyGateway,
+    ) -> Result<GatewaySnapshot, String> {
         app.state::<gateway_ws::GatewayClient>()
-            .configure(app, ready.gateway_ws.clone());
+            .configure(app, ready.gateway_ws);
         let navigated = self.navigate_local(app, &ready.dashboard_url, false, None, true, true)?;
         self.update_tray(&ready.snapshot);
         if navigated {
@@ -650,7 +644,7 @@ impl DesktopState {
             (None, remote_gateway::normalize_gateway_url(raw)?)
         };
         remote_gateway::resolve_remote_tls_fingerprint(&mut request, &gateway_url)?;
-        let target = remote_gateway::dashboard_url(&gateway_url, None)?;
+        let target = remote_gateway::dashboard_url(&gateway_url)?;
         let script = native_auth_initialization_script(&target, &gateway_url, &request)?;
         remote_gateway::save_config_at(&remote_gateway::config_path()?, &request, &gateway_url)?;
         *active_tunnel = tunnel;
@@ -911,22 +905,6 @@ impl DesktopState {
             return Err(error);
         }
         Ok(true)
-    }
-
-    pub fn navigate_remote(&self, app: &AppHandle, target: Url) -> Result<(), String> {
-        let mut navigation = self
-            .inner
-            .navigation
-            .lock()
-            .map_err(|_| "Dashboard navigation lock is unavailable.".to_string())?;
-        let window = main_window(app)?;
-        navigation.select_remote();
-        if let Err(error) = window.navigate(target) {
-            navigation.remote_dashboard = false;
-            return Err(format!("Could not open remote Gateway: {error}"));
-        }
-        tray::show_window(app);
-        Ok(())
     }
 
     fn show_local(

--- a/apps/linux/src-tauri/src/pending_approvals.rs
+++ b/apps/linux/src-tauri/src/pending_approvals.rs
@@ -1,7 +1,6 @@
 use crate::cli::OpenClawCli;
 use serde::Deserialize;
 use std::collections::HashSet;
-use std::process::Output;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum ApprovalKind {
@@ -72,15 +71,12 @@ struct DevicePairingList {
 }
 
 pub fn fetch(cli: &OpenClawCli) -> Result<Vec<PendingApproval>, String> {
-    let (nodes, node_output) = cli
+    let nodes = cli
         .json::<Vec<NodePendingRequest>, _, _>(["nodes", "pending", "--json"])
         .map_err(|error| error.to_string())?;
-    require_success("nodes pending", &node_output)?;
-
-    let (devices, device_output) = cli
+    let devices = cli
         .json::<DevicePairingList, _, _>(["devices", "list", "--json"])
         .map_err(|error| error.to_string())?;
-    require_success("devices list", &device_output)?;
 
     let mut pending = Vec::with_capacity(nodes.len() + devices.pending.len());
     pending.extend(nodes.into_iter().map(|request| PendingApproval {
@@ -98,14 +94,6 @@ pub fn fetch(cli: &OpenClawCli) -> Result<Vec<PendingApproval>, String> {
         ]),
     }));
     Ok(pending)
-}
-
-fn require_success(command: &str, output: &Output) -> Result<(), String> {
-    if output.status.success() {
-        Ok(())
-    } else {
-        Err(format!("openclaw {command} exited with {}", output.status))
-    }
 }
 
 fn preferred_label<'a>(candidates: impl IntoIterator<Item = Option<&'a str>>) -> String {

--- a/apps/linux/src-tauri/src/quickchat.rs
+++ b/apps/linux/src-tauri/src/quickchat.rs
@@ -580,7 +580,7 @@ fn show_quickchat(app: &AppHandle) -> Result<(), String> {
 
 // Commands take the calling WebView, not WebviewWindow: once widgets are attached the
 // host becomes multi-WebView and Tauri intentionally rejects WebviewWindow command args.
-fn require_quickchat_webview(webview: &Webview) -> Result<(), String> {
+pub(crate) fn require_quickchat_webview(webview: &Webview) -> Result<(), String> {
     if webview.label() == QUICKCHAT_LABEL && webview.window().label() == QUICKCHAT_LABEL {
         Ok(())
     } else {

--- a/apps/linux/src-tauri/src/quickchat_widgets.rs
+++ b/apps/linux/src-tauri/src/quickchat_widgets.rs
@@ -1,5 +1,7 @@
 use crate::gateway_ws::GatewayClient;
-use crate::quickchat::{position_quickchat, QuickChatState, QUICKCHAT_LABEL};
+use crate::quickchat::{
+    position_quickchat, require_quickchat_webview, QuickChatState, QUICKCHAT_LABEL,
+};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
@@ -393,11 +395,7 @@ impl QuickChatWidgetState {
         if visible_count > 1 {
             return Err("Quick Chat can show only one widget at a time.".to_string());
         }
-        let current = self
-            .views
-            .lock()
-            .map_err(|_| "Quick Chat widget state is unavailable.".to_string())?
-            .clone();
+        let current = self.view_labels()?;
         let mut desired = HashSet::new();
         for (_, label, _) in &prepared {
             if !desired.insert(label.clone()) {
@@ -522,9 +520,7 @@ pub async fn quickchat_refresh_widget_surface(
     webview: Webview,
     gateway: State<'_, GatewayClient>,
 ) -> Result<Option<String>, String> {
-    if webview.label() != QUICKCHAT_LABEL || webview.window().label() != QUICKCHAT_LABEL {
-        return Err("Quick Chat command is available only to the Quick Chat webview.".to_string());
-    }
+    require_quickchat_webview(&webview)?;
     gateway.refresh_canvas_surface().await
 }
 
@@ -540,9 +536,7 @@ pub async fn quickchat_sync_widgets(
     renderer_epoch: u64,
     generation: u64,
 ) -> Result<(), String> {
-    if webview.label() != QUICKCHAT_LABEL || webview.window().label() != QUICKCHAT_LABEL {
-        return Err("Quick Chat command is available only to the Quick Chat webview.".to_string());
-    }
+    require_quickchat_webview(&webview)?;
     state
         .widget_state()
         .sync(

--- a/apps/linux/src-tauri/src/remote_gateway.rs
+++ b/apps/linux/src-tauri/src/remote_gateway.rs
@@ -4,7 +4,7 @@ use sha2::{Digest, Sha256};
 use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
-use std::net::{IpAddr, TcpListener, TcpStream, ToSocketAddrs};
+use std::net::{IpAddr, SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::thread;
@@ -703,17 +703,9 @@ pub(crate) fn start_tunnel(
         .spawn()
         .map_err(|error| format!("Could not start the SSH tunnel: {error}"))?;
     let deadline = Instant::now() + TUNNEL_READY_TIMEOUT;
+    let local_address = SocketAddr::from(([127, 0, 0, 1], local_port));
     loop {
-        if TcpStream::connect_timeout(
-            &("127.0.0.1", local_port)
-                .to_socket_addrs()
-                .map_err(|error| format!("Could not resolve local tunnel: {error}"))?
-                .next()
-                .ok_or_else(|| "Could not resolve local tunnel.".to_string())?,
-            Duration::from_millis(150),
-        )
-        .is_ok()
-        {
+        if TcpStream::connect_timeout(&local_address, Duration::from_millis(150)).is_ok() {
             let url = Url::parse(&format!("ws://127.0.0.1:{local_port}"))
                 .map_err(|_| "Could not construct local SSH tunnel URL.".to_string())?;
             return Ok((SshTunnel { child }, url));
@@ -742,7 +734,7 @@ pub(crate) fn start_tunnel(
     }
 }
 
-pub(crate) fn dashboard_url(gateway_url: &Url, token: Option<&str>) -> Result<Url, String> {
+pub(crate) fn dashboard_url(gateway_url: &Url) -> Result<Url, String> {
     let mut url = gateway_url.clone();
     let scheme = if gateway_url.scheme() == "wss" {
         "https"
@@ -751,12 +743,6 @@ pub(crate) fn dashboard_url(gateway_url: &Url, token: Option<&str>) -> Result<Ur
     };
     url.set_scheme(scheme)
         .map_err(|_| "Could not construct Gateway dashboard URL.".to_string())?;
-    if let Some(token) = token.filter(|token| !token.is_empty()) {
-        let mut fragment = Url::parse("http://localhost/")
-            .map_err(|_| "Could not prepare Gateway authentication.".to_string())?;
-        fragment.query_pairs_mut().append_pair("token", token);
-        url.set_fragment(fragment.query());
-    }
     Ok(url)
 }
 
@@ -917,20 +903,13 @@ mod tests {
     }
 
     #[test]
-    fn dashboard_auth_is_fragment_only_and_password_never_enters_url() {
+    fn dashboard_url_preserves_gateway_path_without_credentials() {
         let url = normalize_gateway_url("wss://gateway.example.com/openclaw").expect("URL");
-        let dashboard = dashboard_url(&url, Some("one+two/three=secret")).expect("dashboard");
+        let dashboard = dashboard_url(&url).expect("dashboard");
         assert_eq!(dashboard.scheme(), "https");
         assert_eq!(dashboard.path(), "/openclaw");
         assert_eq!(dashboard.query(), None);
-        assert_eq!(
-            dashboard.fragment(),
-            Some("token=one%2Btwo%2Fthree%3Dsecret")
-        );
-        assert_eq!(
-            dashboard_url(&url, None).expect("dashboard").fragment(),
-            None
-        );
+        assert_eq!(dashboard.fragment(), None);
     }
 
     #[test]

--- a/apps/linux/src-tauri/src/tray.rs
+++ b/apps/linux/src-tauri/src/tray.rs
@@ -5,7 +5,7 @@ use crate::DesktopState;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use tauri::menu::{CheckMenuItem, MenuBuilder, MenuItem, PredefinedMenuItem};
+use tauri::menu::{CheckMenuItem, MenuBuilder, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
 use tauri::{App, AppHandle, Manager};
 use tauri_plugin_autostart::ManagerExt;
@@ -29,12 +29,7 @@ pub struct TrayHandles {
     _tray: TrayIcon<tauri::Wry>,
     status: MenuItem<tauri::Wry>,
     status_line: Mutex<StatusLine>,
-    _quickchat: MenuItem<tauri::Wry>,
-    open: MenuItem<tauri::Wry>,
-    _check_updates: MenuItem<tauri::Wry>,
-    _start_at_login: CheckMenuItem<tauri::Wry>,
     quickchat_shortcut: Option<CheckMenuItem<tauri::Wry>>,
-    _global_shortcut: Option<CheckMenuItem<tauri::Wry>>,
     start: MenuItem<tauri::Wry>,
     stop: MenuItem<tauri::Wry>,
     restart: MenuItem<tauri::Wry>,
@@ -43,20 +38,6 @@ pub struct TrayHandles {
 struct StatusLine {
     gateway: String,
     pending_count: usize,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-struct ShortcutInitialState {
-    should_register: bool,
-    checked: bool,
-}
-
-fn shortcut_initial_state(marker_exists: bool) -> ShortcutInitialState {
-    let enabled = !marker_exists;
-    ShortcutInitialState {
-        should_register: enabled,
-        checked: enabled,
-    }
 }
 
 #[cfg(any(target_os = "linux", test))]
@@ -105,7 +86,6 @@ impl TrayHandles {
             status_line.pending_count = 0;
         }
         let _ = self.status.set_text(status_line.text());
-        let _ = self.open.set_enabled(true);
         let _ = self
             .start
             .set_enabled(snapshot.installed && !snapshot.running && !snapshot.reachable);
@@ -140,15 +120,6 @@ pub fn build(
         false,
         None::<&str>,
     )?;
-    let quickchat = MenuItem::with_id(app, QUICKCHAT_ID, "Quick Chat", true, None::<&str>)?;
-    let open = MenuItem::with_id(app, OPEN_ID, "Open Dashboard", true, None::<&str>)?;
-    let check_updates = MenuItem::with_id(
-        app,
-        CHECK_UPDATES_ID,
-        "Check for Updates",
-        true,
-        None::<&str>,
-    )?;
     let autostart_enabled = match app.autolaunch().is_enabled() {
         Ok(enabled) => enabled,
         Err(error) => {
@@ -164,38 +135,33 @@ pub fn build(
         autostart_enabled,
         None::<&str>,
     )?;
-    let quickchat_shortcut_initial_state = global_shortcuts_supported
-        .then(|| shortcut_initial_state(!quickchat::quickchat_shortcut_enabled(app)));
-    let quickchat_shortcut = quickchat_shortcut_initial_state
-        .as_ref()
-        .map(|initial_state| {
+    let quickchat_shortcut_enabled =
+        global_shortcuts_supported.then(|| quickchat::quickchat_shortcut_enabled(app));
+    let quickchat_shortcut = quickchat_shortcut_enabled
+        .map(|enabled| {
             CheckMenuItem::with_id(
                 app,
                 QUICKCHAT_SHORTCUT_ID,
                 "Quick Chat shortcut",
                 true,
-                initial_state.checked,
+                enabled,
                 None::<&str>,
             )
         })
         .transpose()?;
-    let global_shortcut_initial_state = global_shortcuts_supported.then(|| {
-        let shortcut_marker = global_shortcut_disabled_marker(app);
-        shortcut_initial_state(
-            shortcut_marker
-                .as_deref()
-                .is_some_and(global_shortcut_marker_exists),
-        )
+    let global_shortcut_enabled = global_shortcuts_supported.then(|| {
+        !global_shortcut_disabled_marker(app)
+            .as_deref()
+            .is_some_and(global_shortcut_marker_exists)
     });
-    let global_shortcut = global_shortcut_initial_state
-        .as_ref()
-        .map(|initial_state| {
+    let global_shortcut = global_shortcut_enabled
+        .map(|enabled| {
             CheckMenuItem::with_id(
                 app,
                 GLOBAL_SHORTCUT_ID,
                 "Enable Global Shortcut",
                 true,
-                initial_state.checked,
+                enabled,
                 None::<&str>,
             )
         })
@@ -203,18 +169,13 @@ pub fn build(
     let start = MenuItem::with_id(app, START_ID, "Start Gateway", false, None::<&str>)?;
     let stop = MenuItem::with_id(app, STOP_ID, "Stop Gateway", false, None::<&str>)?;
     let restart = MenuItem::with_id(app, RESTART_ID, "Restart Gateway", false, None::<&str>)?;
-    let quit = MenuItem::with_id(app, QUIT_ID, "Quit OpenClaw", true, None::<&str>)?;
-    let separator_one = PredefinedMenuItem::separator(app)?;
-    let separator_two = PredefinedMenuItem::separator(app)?;
-    let separator_three = PredefinedMenuItem::separator(app)?;
-    let menu_builder = MenuBuilder::new(app).items(&[
-        &status,
-        &separator_one,
-        &quickchat,
-        &open,
-        &check_updates,
-        &start_at_login,
-    ]);
+    let menu_builder = MenuBuilder::new(app)
+        .item(&status)
+        .separator()
+        .text(QUICKCHAT_ID, "Quick Chat")
+        .text(OPEN_ID, "Open Dashboard")
+        .text(CHECK_UPDATES_ID, "Check for Updates")
+        .item(&start_at_login);
     let menu_builder = if let Some(quickchat_shortcut) = quickchat_shortcut.as_ref() {
         menu_builder.item(quickchat_shortcut)
     } else {
@@ -226,14 +187,10 @@ pub fn build(
         menu_builder
     };
     let menu = menu_builder
-        .items(&[
-            &separator_two,
-            &start,
-            &stop,
-            &restart,
-            &separator_three,
-            &quit,
-        ])
+        .separator()
+        .items(&[&start, &stop, &restart])
+        .separator()
+        .text(QUIT_ID, "Quit OpenClaw")
         .build()?;
 
     // macOS draws menu bar icons from the alpha channel alone (see
@@ -243,8 +200,6 @@ pub fn build(
     let tray_icon = tauri::image::Image::from_bytes(include_bytes!("../icons/tray-template.png"))?;
     #[cfg(not(target_os = "macos"))]
     let tray_icon = tauri::image::Image::from_bytes(include_bytes!("../icons/32x32.png"))?;
-    let menu_state = state.clone();
-    let menu_start_at_login = start_at_login.clone();
     let menu_quickchat_shortcut = quickchat_shortcut.clone();
     let menu_global_shortcut = global_shortcut.clone();
     let tray_builder = TrayIconBuilder::with_id("openclaw-main")
@@ -254,8 +209,8 @@ pub fn build(
         .on_menu_event(move |app, event| {
             handle_menu(
                 app,
-                &menu_state,
-                &menu_start_at_login,
+                &state,
+                &start_at_login,
                 menu_quickchat_shortcut.as_ref(),
                 menu_global_shortcut.as_ref(),
                 event.id().as_ref(),
@@ -285,33 +240,27 @@ pub fn build(
         quickchat_preference.shortcut,
         false,
     );
-    if let (Some(initial_state), Some(quickchat_shortcut)) = (
-        quickchat_shortcut_initial_state,
-        quickchat_shortcut.as_ref(),
-    ) {
-        if initial_state.should_register {
-            if let Err(error) = app
-                .global_shortcut()
-                .register(quickchat_preference.shortcut)
-            {
-                eprintln!(
-                    "Could not register Quick Chat shortcut {}: {error}",
-                    quickchat_preference.accelerator
-                );
-                set_quickchat_shortcut_checked(quickchat_shortcut, false);
-            } else {
-                quickchat_state.set_shortcut_registered(true);
-            }
+    if let (Some(true), Some(quickchat_shortcut)) =
+        (quickchat_shortcut_enabled, quickchat_shortcut.as_ref())
+    {
+        if let Err(error) = app
+            .global_shortcut()
+            .register(quickchat_preference.shortcut)
+        {
+            eprintln!(
+                "Could not register Quick Chat shortcut {}: {error}",
+                quickchat_preference.accelerator
+            );
+            set_quickchat_shortcut_checked(quickchat_shortcut, false);
+        } else {
+            quickchat_state.set_shortcut_registered(true);
         }
     }
-    if let (Some(initial_state), Some(global_shortcut)) =
-        (global_shortcut_initial_state, global_shortcut.as_ref())
+    if let (Some(true), Some(global_shortcut)) = (global_shortcut_enabled, global_shortcut.as_ref())
     {
-        if initial_state.should_register {
-            if let Err(error) = app.global_shortcut().register(GLOBAL_SHORTCUT) {
-                eprintln!("Could not register global shortcut {GLOBAL_SHORTCUT}: {error}");
-                set_global_shortcut_checked(global_shortcut, false);
-            }
+        if let Err(error) = app.global_shortcut().register(GLOBAL_SHORTCUT) {
+            eprintln!("Could not register global shortcut {GLOBAL_SHORTCUT}: {error}");
+            set_global_shortcut_checked(global_shortcut, false);
         }
     }
 
@@ -322,12 +271,7 @@ pub fn build(
             gateway: "Checking…".to_string(),
             pending_count: 0,
         }),
-        _quickchat: quickchat,
-        open,
-        _check_updates: check_updates,
-        _start_at_login: start_at_login,
         quickchat_shortcut,
-        _global_shortcut: global_shortcut,
         start,
         stop,
         restart,
@@ -550,7 +494,7 @@ mod tests {
     }
 
     #[test]
-    fn global_shortcut_marker_disables_startup_registration() {
+    fn global_shortcut_marker_tracks_user_opt_out() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock before Unix epoch")
@@ -562,21 +506,9 @@ mod tests {
         fs::create_dir_all(&directory).expect("create test directory");
         let marker = directory.join(GLOBAL_SHORTCUT_DISABLED_MARKER);
 
-        assert_eq!(
-            shortcut_initial_state(marker.exists()),
-            ShortcutInitialState {
-                should_register: true,
-                checked: true,
-            }
-        );
+        assert!(!global_shortcut_marker_exists(&marker));
         fs::write(&marker, b"").expect("write opt-out marker");
-        assert_eq!(
-            shortcut_initial_state(marker.exists()),
-            ShortcutInitialState {
-                should_register: false,
-                checked: false,
-            }
-        );
+        assert!(global_shortcut_marker_exists(&marker));
 
         fs::remove_dir_all(directory).expect("remove test directory");
     }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingDashboardHandoffTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingDashboardHandoffTests.swift
@@ -301,11 +301,9 @@ struct OnboardingDashboardHandoffTests {
             scheduledDeadlines.append((deadline, routeIdentity))
         }
         view.aiSetup.retryFromScratch()
+        // Verification publishes its receipt before the retry continuation schedules recovery.
         for _ in 0..<200 {
-            if case .verified = OnboardingSystemAgentResumeStore.pendingState(
-                for: "local",
-                defaults: defaults)
-            {
+            if !scheduledDeadlines.isEmpty {
                 break
             }
             try? await Task.sleep(nanoseconds: 5_000_000)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -928,12 +928,14 @@ struct GatewayNodeSessionTests {
 
         try await gateway.connectForTest(testURL("wss://gateway.example.invalid"), options: options, session: session)
 
-        async let first = gateway.refreshCanvasHostUrl(replacing: nil)
-        async let second = gateway.refreshCanvasHostUrl(timeoutSeconds: 1)
-        async let third = gateway.refreshPluginSurfaceUrl(surface: "canvas", timeoutSeconds: 2)
+        async let first = gateway.refreshCanvasHostUrl(timeoutSeconds: 1)
         try await waitUntil("single surface refresh sent") {
             session.latestTask()?.sentRequestCount(method: "node.pluginSurface.refresh") == 1
         }
+        // Followers may start after the response; retain their original observation
+        // so they reuse that rotation instead of requesting another one.
+        async let second = gateway.refreshCanvasHostUrl(replacing: nil)
+        async let third = gateway.refreshPluginSurfaceUrl(surface: "canvas", replacing: nil)
         let task = try #require(session.latestTask())
         let request = try #require(task.sentRequests(method: "node.pluginSurface.refresh").first)
         let requestID = try #require(request["id"] as? String)
@@ -972,7 +974,6 @@ struct GatewayNodeSessionTests {
         let shortValue = await shortWait
         #expect(shortValue == nil)
 
-        async let joinedWait = gateway.refreshPluginSurfaceUrl(surface: "canvas", timeoutSeconds: 8)
         let task = try #require(session.latestTask())
         #expect(task.sentRequestCount(method: "node.pluginSurface.refresh") == 1)
         let request = try #require(task.sentRequests(method: "node.pluginSurface.refresh").first)
@@ -985,9 +986,7 @@ struct GatewayNodeSessionTests {
                 ],
             ])
 
-        let values = await (longWait, joinedWait)
-        #expect(values.0 == values.1)
-        #expect(values.0?.hasSuffix("/new-token") == true)
+        #expect(await longWait?.hasSuffix("/new-token") == true)
         #expect(task.sentRequestCount(method: "node.pluginSurface.refresh") == 1)
         await gateway.disconnect()
     }

--- a/apps/shared/OpenClawWatchRTC/Cargo.lock
+++ b/apps/shared/OpenClawWatchRTC/Cargo.lock
@@ -150,9 +150,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -427,7 +427,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -495,9 +495,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flagset"
@@ -736,7 +736,7 @@ name = "openclaw-watch-rtc"
 version = "0.1.0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "str0m",
 ]
 
@@ -1028,7 +1028,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1157,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1194,7 +1194,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/apps/shared/OpenClawWatchRTC/Cargo.toml
+++ b/apps/shared/OpenClawWatchRTC/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]
-getrandom = "=0.3.4"
+getrandom = "=0.4.3"
 str0m = { version = "=0.23.1", default-features = false, features = ["rust-crypto"] }
 
 [dev-dependencies]

--- a/apps/shared/OpenClawWatchRTC/src/lib.rs
+++ b/apps/shared/OpenClawWatchRTC/src/lib.rs
@@ -61,6 +61,7 @@ impl From<SocketAddr> for OpenClawRTCAddress {
 }
 
 #[repr(C)]
+#[derive(Default)]
 pub struct OpenClawRTCOutput {
     kind: u32,
     bytes: *const u8,
@@ -76,6 +77,7 @@ struct RemoteAddress {
     resolved: Vec<SocketAddr>,
 }
 
+#[derive(Default)]
 pub struct OpenClawRTC {
     rtc: Option<Rtc>,
     pending: Option<SdpPendingOffer>,
@@ -123,8 +125,14 @@ pub extern "C" fn openclaw_rtc_create() -> *mut OpenClawRTC {
             return ptr::null_mut();
         }
         let credentials = IceCreds {
-            ufrag: entropy[..8].iter().map(|byte| format!("{byte:02x}")).collect(),
-            pass: entropy[8..].iter().map(|byte| format!("{byte:02x}")).collect(),
+            ufrag: entropy[..8]
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect(),
+            pass: entropy[8..]
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect(),
         };
         let rtc = Rtc::builder()
             .set_local_ice_credentials(credentials)
@@ -136,11 +144,7 @@ pub extern "C" fn openclaw_rtc_create() -> *mut OpenClawRTC {
             .build(Instant::now());
         Box::into_raw(Box::new(OpenClawRTC {
             rtc: Some(rtc),
-            pending: None,
-            mid: None,
-            description: Vec::new(),
-            remote_addresses: Vec::new(),
-            output_bytes: Vec::new(),
+            ..OpenClawRTC::default()
         }))
     })
     .unwrap_or(ptr::null_mut())
@@ -195,7 +199,12 @@ pub unsafe extern "C" fn openclaw_rtc_remove_candidate(
             let candidate = Candidate::host(address.socket()?, Protocol::Udp).map_err(|_| -2)?;
             // Only retire ICE state after our one SDP exchange; no later SDP offer
             // is generated from direct-API mutations.
-            state.rtc.as_mut().ok_or(-1)?.direct_api().invalidate_candidate(&candidate);
+            state
+                .rtc
+                .as_mut()
+                .ok_or(-1)?
+                .direct_api()
+                .invalidate_candidate(&candidate);
             Ok(())
         })
     }
@@ -209,9 +218,15 @@ pub unsafe extern "C" fn openclaw_rtc_remote_address(
     address: *mut OpenClawRTCAddress,
 ) -> i32 {
     let (Some(state), Some(address)) = (unsafe { pointer.as_ref() }, unsafe { address.as_mut() })
-    else { return -1; };
-    if state.rtc.is_none() { return -1; }
-    let Some(value) = state.remote_addresses.get(index) else { return 1; };
+    else {
+        return -1;
+    };
+    if state.rtc.is_none() {
+        return -1;
+    }
+    let Some(value) = state.remote_addresses.get(index) else {
+        return 1;
+    };
     *address = value.address.into();
     0
 }
@@ -237,20 +252,34 @@ pub unsafe extern "C" fn openclaw_rtc_resolve_remote_address(
         operate(pointer, |state| {
             let address = address.socket()?;
             let remote = state.remote_addresses.get(index).ok_or(-2)?;
-            if !remote.address.is_ipv4() || !address.is_ipv6()
-                || remote.address.port() != address.port() {
+            if !remote.address.is_ipv4()
+                || !address.is_ipv6()
+                || remote.address.port() != address.port()
+            {
                 return Err(-2);
             }
-            if remote.resolved.contains(&address) { return Ok(()); }
-            let endpoints: HashSet<_> = state.remote_addresses.iter()
-                .flat_map(|remote| std::iter::once(remote.address).chain(remote.resolved.iter().copied()))
+            if remote.resolved.contains(&address) {
+                return Ok(());
+            }
+            let endpoints: HashSet<_> = state
+                .remote_addresses
+                .iter()
+                .flat_map(|remote| {
+                    std::iter::once(remote.address).chain(remote.resolved.iter().copied())
+                })
                 .collect();
-            if endpoints.len() >= CANDIDATE_BUDGET && !endpoints.contains(&address) { return Err(-4); }
-            let candidates = remote.candidates.iter()
+            if endpoints.len() >= CANDIDATE_BUDGET && !endpoints.contains(&address) {
+                return Err(-4);
+            }
+            let candidates = remote
+                .candidates
+                .iter()
                 .map(|candidate| resolved_candidate(candidate, address))
                 .collect::<Result<Vec<_>, _>>()?;
             let rtc = state.rtc.as_mut().ok_or(-1)?;
-            for candidate in candidates { rtc.add_remote_candidate(candidate); }
+            for candidate in candidates {
+                rtc.add_remote_candidate(candidate);
+            }
             state.remote_addresses[index].resolved.push(address);
             Ok(())
         })
@@ -282,21 +311,42 @@ pub unsafe extern "C" fn openclaw_rtc_answer(
             let answer = SdpAnswer::from_sdp_string(text).map_err(|_| -2)?;
             // RFC 8838 Appendix B permits discovering our candidates through checks only
             // for an ICE-lite peer. This single-exchange client has no trickle channel.
-            if !answer.session.ice_lite() { return Err(-3); }
-            let credentials = answer.session.ice_creds()
-                .or_else(|| answer.media_lines.iter().find_map(|media| media.ice_creds()))
+            if !answer.session.ice_lite() {
+                return Err(-3);
+            }
+            let credentials = answer
+                .session
+                .ice_creds()
+                .or_else(|| {
+                    answer
+                        .media_lines
+                        .iter()
+                        .find_map(|media| media.ice_creds())
+                })
                 .ok_or(-2)?;
             let mut remote_addresses: Vec<RemoteAddress> = Vec::new();
-            for candidate in answer.session.ice_candidates()
-                .chain(answer.media_lines.iter().flat_map(|media| media.ice_candidates())) {
+            for candidate in answer.session.ice_candidates().chain(
+                answer
+                    .media_lines
+                    .iter()
+                    .flat_map(|media| media.ice_candidates()),
+            ) {
                 if candidate.proto() != Protocol::Udp
-                    || candidate.ufrag().is_some_and(|value| value != credentials.ufrag.as_str()) {
+                    || candidate
+                        .ufrag()
+                        .is_some_and(|value| value != credentials.ufrag.as_str())
+                {
                     continue;
                 }
                 let address = candidate.addr();
                 OpenClawRTCAddress::from(address).socket()?;
-                if let Some(remote) = remote_addresses.iter_mut().find(|remote| remote.address == address) {
-                    if !remote.candidates.contains(candidate) { remote.candidates.push(candidate.clone()); }
+                if let Some(remote) = remote_addresses
+                    .iter_mut()
+                    .find(|remote| remote.address == address)
+                {
+                    if !remote.candidates.contains(candidate) {
+                        remote.candidates.push(candidate.clone());
+                    }
                 } else {
                     remote_addresses.push(RemoteAddress {
                         address,
@@ -305,9 +355,13 @@ pub unsafe extern "C" fn openclaw_rtc_answer(
                     });
                 }
             }
-            if remote_addresses.is_empty() { return Err(-3); }
+            if remote_addresses.is_empty() {
+                return Err(-3);
+            }
             // Match the pinned ICE owner's default pair budget; never truncate the answer.
-            if remote_addresses.len() > CANDIDATE_BUDGET { return Err(-4); }
+            if remote_addresses.len() > CANDIDATE_BUDGET {
+                return Err(-4);
+            }
             let pending = state.pending.take().ok_or(-1)?;
             state
                 .rtc
@@ -407,14 +461,7 @@ pub unsafe extern "C" fn openclaw_rtc_poll(
     };
     unsafe {
         operate(pointer, |state| {
-            *output = OpenClawRTCOutput {
-                kind: 0,
-                bytes: ptr::null(),
-                length: 0,
-                source: OpenClawRTCAddress::default(),
-                destination: OpenClawRTCAddress::default(),
-                time: 0,
-            };
+            *output = OpenClawRTCOutput::default();
             loop {
                 match state
                     .rtc

--- a/apps/shared/OpenClawWatchRTC/src/tests.rs
+++ b/apps/shared/OpenClawWatchRTC/src/tests.rs
@@ -126,14 +126,7 @@ impl Fixture {
 
     fn poll_client(&mut self) {
         loop {
-            let mut output = OpenClawRTCOutput {
-                kind: 0,
-                bytes: ptr::null(),
-                length: 0,
-                source: OpenClawRTCAddress::default(),
-                destination: OpenClawRTCAddress::default(),
-                time: 0,
-            };
+            let mut output = OpenClawRTCOutput::default();
             assert_eq!(unsafe { openclaw_rtc_poll(self.client.0, &mut output) }, 0);
             // Copy the borrowed payload before the next C call, matching the Swift owner.
             let bytes = if output.length == 0 {
@@ -522,14 +515,19 @@ fn ice_credentials_do_not_repeat_with_noncryptographic_rng_state() {
         assert_eq!(unsafe { openclaw_rtc_offer(client.0) }, 0);
         let mut length = 0;
         let bytes = unsafe { openclaw_rtc_description(client.0, &mut length) };
-        let text = std::str::from_utf8(unsafe { std::slice::from_raw_parts(bytes, length) }).unwrap();
+        let text =
+            std::str::from_utf8(unsafe { std::slice::from_raw_parts(bytes, length) }).unwrap();
         let offer = SdpOffer::from_sdp_string(text).unwrap();
-        offer.session.ice_creds()
+        offer
+            .session
+            .ice_creds()
             .or_else(|| offer.media_lines.iter().find_map(|media| media.ice_creds()))
             .unwrap()
     };
     let first = credentials();
     let second = credentials();
-    assert!(first.ufrag != second.ufrag && first.pass != second.pass,
-        "ICE credentials must not repeat when noncryptographic RNG state repeats");
+    assert!(
+        first.ufrag != second.ufrag && first.pass != second.pass,
+        "ICE credentials must not repeat when noncryptographic RNG state repeats"
+    );
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where choosing **Stop Gateway** in the Tauri tray returned an error while the local service kept running. Native subprocesses have no terminal, and the app omitted the CLI’s required non-interactive stop consent.

Also completes the maintainer-requested Rust cleanup: consolidate repeated connection/reconnect setup, tray state, and unused navigation/auth/routing helpers, and refresh compatible desktop and Watch RTC dependencies.

## Why This Change Was Made

Only Stop supplies the CLI’s `--force` consent flag; service shutdown remains graceful, and Restart keeps its existing drain behavior. Local connect, install, and restart now share their identical completion path. Gateway configure/clear share cache invalidation and reconnect signaling; the CLI adapter alone enforces process success before decoding JSON. Native menus own their items, Quick Chat reuses its existing WebView guard, and Watch uses derived initialization without changing its C ABI or entropy checks.

Reduces production Rust by 156 lines (+220/−376). Tests grow by four lines (+53/−49 across Rust and Swift), including the new service-action regression and repaired Swift callback wait. This includes canonical formatting that adds 56 lines to the Watch file. No new runtime setting, persistence representation, or protocol change. Existing navigation fences, TLS/identity checks, sleep generations, renderer callback ownership, and error visibility remain intact.

## User Impact

**Stop Gateway** now stops the local service and exposes the stopped screen; Start and graceful Restart continue to work. The remaining cleanup preserves desktop onboarding, connection/reconnection, Quick Chat, and Watch audio behavior. Removes repeated configuration clones and keeps state transitions in one owner. The dependency refresh includes detached-opener child reaping and TLS read batching; no claimed end-to-end latency improvement from this refactor alone.

The desktop accepts 21 compatible transitive updates and advances the notifications plugin to its narrow Swift diagnostic fix. Watch updates getrandom to 0.4.3 and three compatible build dependencies, with matching license notices. Existing networking/crypto packages already match their current stable releases.

## Evidence

- macOS desktop: `cargo test --locked --all-targets --manifest-path apps/linux/src-tauri/Cargo.toml` — 136 passed; final build has no compiler warnings. The new service-action regression fails on the pre-fix Stop invocation.
- Linux desktop on Blacksmith Testbox: 136 main Rust tests and 10 helper tests passed (one existing ignored test); baseline and candidate builds passed. Both revisions passed the real native first-run choices and two consecutive failed-local-start/retry attempts. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33979451003).
- The private-D-Bus logind integration test also passed explicitly. Native Codex activation passed: Welcome at 0.919s, local install/start to model setup at 11.191s, Gateway detection 1.819s, wizard steps 4.176s and 1.735s. The enabled guided composer showed verified `openai/gpt-5.6-sol`. Codex guided handoff completed in 13.029s. Real tray-menu events opened Quick Chat and Open Dashboard; composited Quick Chat replied with visible Done in 4.970s, then replied again in 4.083s after a 3.987s managed Gateway restart.
- Cold Ollama: `/api/ps` empty with one eligible installed 4B Instruct model; native **Choose connection → Local only → Submit** verified in 9.477s without a raw-API preload. Guided reply completed in 64.228s on CPU; `talk to agent` handed off in 458ms, and reopening reached chat.
- Actual native tray lifecycle comparison: baseline Stop rejected the non-interactive call and left its Gateway running; candidate Stop sent the required flag, completed in 1.141s, reached MainPID 0 and visible standby, and stayed stopped during the 2s watchdog observation. Start restored the service in 3.498s and Restart changed its PID in 3.965s using only `gateway restart --json`. [Lifecycle Testbox run](https://github.com/openclaw/openclaw/actions/runs/33983818257).
- Watch RTC: all 12 existing engine tests passed before and after the change, including authenticated ICE/DTLS/Opus, IPv4/IPv6/NAT64, admission, lost/late audio, and entropy cases.
- Watch release archives built for arm64 and arm64_32 devices, and arm64 and x86_64 simulators. Physical Watch radio/audio and Windows installer execution are not claimed.
- Both Rust format checks and `git diff --check` pass. The app changed gate passed on the final patch in an isolated normal checkout with pinned dependencies and Swift tools, including all 1,109 app/host tests. Final independent review found no actionable P0–P2 issues. CI then exposed a race in the existing macOS pending-verification test: the receipt preceded its deadline callback. The test now waits for the callback using the same budget and all original assertions; its focused 15-test suite and fresh independent review pass. A separate iOS CI polling failure was also diagnosed and validated locally (249 owner-suite tests). During landing, #138092 independently merged the equivalent event-wait repair into main, so the rebased branch uses that canonical fix and drops the duplicate patch. The macOS callback test moved with that refactor; its identical repair now lives in `OnboardingDashboardHandoffTests.swift`. Rust source, Cargo locks, and the CLI service contract are byte-identical to the native-tested revision. The rebased CI run then exposed a pre-existing OpenClawKit test race: a late legacy refresh caller could request a second rotation after the fixture response. The test-only repair anchors the initial timed request before starting followers with their original observed URL, and removes a redundant late join from the timeout-survival case. Mixed deadlines, one-request, survivor, result-equality and TLS-route assertions remain. Nine focused tests and ten consecutive stress repetitions of both changed cases passed. Full [CI passed on the final head](https://github.com/openclaw/openclaw/actions/runs/33989106247), including macOS/iOS tests, Watch operation tests, Android, release builds and screenshot jobs.

The notification-plugin [exact upstream diff](https://github.com/steipete/tauri-plugin-notifications/compare/d20b4ff0e0e327e49fee80903478f825eac5a71a...35d04a6af588a5d5d438da0320c7d95a877cfe14) was directly inspected: only two Swift failure-diagnostic UTF-8 conversions change in `build.rs`; runtime sources, manifest, features, build commands and target selection are unchanged. This addresses ClawSweeper’s dependency-source review request; the complete upstream patch is also included inline in the maintainer disposition comment because the reviewer environment could not retrieve it.

Dependency holds: retain updater 2.10.1 because current 2.11.0 still runs Tauri cleanup before returning Windows installer errors. Retain blocking 1.6.2 in the existing lock: identical upstream probes show 1.6.2 returns from 13 threads to 1 after 750 ms, while 1.7.0 retains all 13 after 1.5 s. The latter proves an upstream idle-retirement regression, not a measured desktop leak. No new patch, override, or manifest pin was introduced.

QA also observed the documented graceful-stop drain (315 seconds); `gateway stop --force` permits non-interactive stop and does not bypass draining. Follow-up: cancel cancellable interactive prompt waiters before drain while preserving normal reconnects and commit-locked work. This is outside the Rust refactor.

Follow-ups: revisit blocking after upstream restores idle-worker retirement; lift the updater pin only after Windows cleanup follows successful installer launch. Broader widget-state consolidation needs separate renderer-restart/native lifecycle proof; existing legacy preference/config file storage remains a separately scoped migration topic. The focused package build also reported an existing unused Bool result in ChatViewModelSessionActionTests.swift:1067; that unrelated test warning is a follow-up.

Before/after native retry proof (synthetic fixtures, both inspected):

![Before — actionable native retry screen](https://github.com/user-attachments/assets/9c712403-d750-4a09-b205-d905ac8c4b03)

![After — actionable native retry screen](https://github.com/user-attachments/assets/64079ced-b62d-4f84-8456-541c14728360)


Native Codex onboarding reached the verified model and enabled composer:

![Native Codex onboarding ready](https://github.com/user-attachments/assets/1a738d57-1b06-4aa7-928f-effd45b4be90)

![Quick Chat completed after Gateway restart](https://github.com/user-attachments/assets/82c1b30b-6993-45f7-92c7-c1ee8465665d)

![Cold Ollama setup completed a guided response](https://github.com/user-attachments/assets/cf591afd-f0ba-4ef1-9806-1cc352a690de)

Actual native tray Stop, before and after the consent fix (idle Gateway):

![Before: Stop rejected and Gateway still running](https://github.com/user-attachments/assets/7fe20741-a4c9-4fb8-8c6d-cc6bcf0b9630)

![After: Gateway stopped and native app standing by](https://github.com/user-attachments/assets/0808288e-3724-4310-86b9-f138169275b7)

Both task-owned Blacksmith Testbox leases are stopped and independently verified completed. The model proof used the normal configured workloads; the separate lifecycle comparison used an explicitly idle Gateway.
