### PR TITLE
perf(agents): reduce small-context discovery overhead

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -764,6 +764,12 @@ truncation is required.
 
 Keep descriptions short and descriptive to minimize prompt overhead.
 
+For small context windows, the OpenClaw embedded runtime further shortens the
+descriptions in the already-admitted catalog. It retains every admitted name,
+location, and loading note, even when these exceed the description budget.
+Full skill instructions and saved snapshots are unchanged; Code Mode can still
+read every admitted skill. Native harnesses retain their own prompt policy.
+
 ## Related
 
 <CardGroup cols={2}>

--- a/docs/tools/tool-search.md
+++ b/docs/tools/tool-search.md
@@ -46,6 +46,9 @@ entry remains searchable and callable. Invalid arguments for OpenClaw-owned
 tools include a bounded expected input signature when one can be rendered, so
 the model can correct the call without another schema lookup.
 
+The deferred directory omits tools already exposed directly. They remain searchable,
+so discovery can still return their complete schemas without duplicating native guidance.
+
 The catalog can include catalog-eligible OpenClaw tools, plugin tools, MCP
 tools, and client-provided tools. The directory gives the model an idea of
 which trusted capabilities it can discover without exposing every cataloged

--- a/docs/tools/tool-search.md
+++ b/docs/tools/tool-search.md
@@ -40,6 +40,12 @@ return await openclaw.tools.call(tool.id, {
 });
 ```
 
+The directory scales with the active model's context window. When space is tight,
+descriptions shorten before tool names are omitted; every authorized catalog
+entry remains searchable and callable. Invalid arguments for OpenClaw-owned
+tools include a bounded expected input signature when one can be rendered, so
+the model can correct the call without another schema lookup.
+
 The catalog can include catalog-eligible OpenClaw tools, plugin tools, MCP
 tools, and client-provided tools. The directory gives the model an idea of
 which trusted capabilities it can discover without exposing every cataloged

--- a/docs/tools/tool-search.md
+++ b/docs/tools/tool-search.md
@@ -45,6 +45,8 @@ descriptions shorten before tool names are omitted; every authorized catalog
 entry remains searchable and callable. Invalid arguments for OpenClaw-owned
 tools include a bounded expected input signature when one can be rendered, so
 the model can correct the call without another schema lookup.
+If a call mistakes an admitted skill name for a tool ID, the error points back
+to the skill’s complete instructions instead of sending the model through tool search.
 
 The deferred directory omits tools already exposed directly. They remain searchable,
 so discovery can still return their complete schemas without duplicating native guidance.

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -119,6 +119,7 @@ import {
   TOOL_SEARCH_RAW_TOOL_NAME,
   type ToolSearchCatalogRef,
   type ToolSearchCatalogToolExecutor,
+  type ToolSearchToolContext,
 } from "./tool-search.js";
 import { AUTOMATIONS_TOOL_NAME } from "./tools/automations-tool-name.js";
 import {
@@ -370,6 +371,8 @@ type OpenClawCodingToolsOptions = {
   toolSearchCatalogExecutor?: ToolSearchCatalogToolExecutor;
   /** Runtime-local Tool Search catalog ref shared with attempt compaction. */
   toolSearchCatalogRef?: ToolSearchCatalogRef;
+  /** Already-admitted skill locations for mistaken tool-id recovery. */
+  codeModeSkills?: ToolSearchToolContext["codeModeSkills"];
   /** Limits which tool families are materialized before the shared policy pipeline runs. */
   toolConstructionPlan?: OpenClawCodingToolConstructionPlan;
   /** Ring-zero OpenClaw tool; set only by the OpenClaw agent runner. */
@@ -812,6 +815,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
           sessionId: options?.sessionId,
           runId: options?.runId,
           catalogRef: options?.toolSearchCatalogRef,
+          codeModeSkills: options?.codeModeSkills,
           abortSignal: options?.abortSignal,
           executeTool: options?.toolSearchCatalogExecutor,
         })

--- a/src/agents/code-mode-skills.ts
+++ b/src/agents/code-mode-skills.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import type { Skill } from "../skills/loading/skill-contract.js";
+import { decodeSkillXml, type Skill } from "../skills/loading/skill-contract.js";
 
 export type CodeModeSkill = {
   name: string;
@@ -14,21 +14,12 @@ export type CodeModeSkillReader = (params: {
   signal?: AbortSignal;
 }) => Promise<string>;
 
-function decodeXml(value: string): string {
-  return value
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, "&");
-}
-
 const SKILL_NAME_PATTERN = /^[ ]{4}<name>(.*)<\/name>$/mu;
 const SKILL_LOCATION_PATTERN = /^[ ]{4}<location>(.*)<\/location>$/mu;
 
 function readSkillField(block: string, pattern: RegExp): string | undefined {
   const match = pattern.exec(block)?.[1];
-  return match === undefined ? undefined : decodeXml(match);
+  return match === undefined ? undefined : decodeSkillXml(match);
 }
 
 /** Select Code Mode skills from the exact catalog rendered into this run's prompt. */

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -562,6 +562,7 @@ export function prepareEmbeddedAttemptSkills(params: {
       skillsPromptWorkspaceDir,
     });
     const skillsPrompt = resolveSkillsPrompt({
+      contextTokenBudget: params.attempt.contextTokenBudget,
       skillsSnapshot,
       entries: promptSkillEntries,
       loadEntries: createSandboxPromptEntryLoader({

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
@@ -95,15 +95,18 @@ export async function prepareEmbeddedAttemptSystemPrompt(params: {
   });
   const resolveToolSchemaDirectoryPrompt = () =>
     params.toolSearchDirectoryEnabled
-      ? buildToolSchemaDirectoryPrompt({
-          config: attempt.config,
-          runtimeConfig: params.toolSearchRuntimeConfig,
-          agentId: params.sessionAgentId,
-          sessionKey: params.sandboxSessionKey,
-          sessionId: attempt.sessionId,
-          runId: attempt.runId,
-          catalogRef: params.toolSearchCatalogRef,
-        })
+      ? buildToolSchemaDirectoryPrompt(
+          {
+            config: attempt.config,
+            runtimeConfig: params.toolSearchRuntimeConfig,
+            agentId: params.sessionAgentId,
+            sessionKey: params.sandboxSessionKey,
+            sessionId: attempt.sessionId,
+            runId: attempt.runId,
+            catalogRef: params.toolSearchCatalogRef,
+          },
+          { contextTokenBudget: attempt.contextTokenBudget },
+        )
       : undefined;
 
   const toolSchemaDirectoryPrompt = resolveToolSchemaDirectoryPrompt();

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
@@ -305,6 +305,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
             approvalReviewerDeviceId: attempt.approvalReviewerDeviceId,
             oneShotCliRun: attempt.oneShotCliRun,
             toolSearchCatalogRef,
+            codeModeSkills,
             agentDir: params.agentDir,
             preparedModelRuntime: attempt.preparedModelRuntime,
             cwd: params.effectiveCwd,

--- a/src/agents/tool-search-catalog.ts
+++ b/src/agents/tool-search-catalog.ts
@@ -45,6 +45,7 @@ function catalogEntriesFingerprint(entries: readonly ToolSearchCatalogEntry[]): 
         entry.name,
         entry.label ?? "",
         entry.description,
+        entry.directVisible === true,
         entry.source === "openclaw"
           ? stableStringify(entry.parameters)
           : untrustedSchemaFingerprint(entry.parameters),
@@ -473,8 +474,9 @@ export function applyToolCatalogCompaction(
       continue;
     }
     if (shouldCatalog(tool)) {
-      catalog.push(toCatalogEntry(tool, undefined, params.toolHookContext));
-      if (!params.isVisibleCatalogTool?.(tool)) {
+      const directVisible = params.isVisibleCatalogTool?.(tool) === true;
+      catalog.push({ ...toCatalogEntry(tool, undefined, params.toolHookContext), directVisible });
+      if (!directVisible) {
         continue;
       }
     }

--- a/src/agents/tool-search-directory.ts
+++ b/src/agents/tool-search-directory.ts
@@ -173,14 +173,16 @@ function formatToolSearchCatalogDirectory(
   mode: ToolSearchMode,
   maxChars: number,
 ): string {
-  if (entries.length === 0) {
+  const deferredEntries = entries.filter((entry) => !entry.directVisible);
+  if (deferredEntries.length === 0) {
     return "Available deferred-schema tools: none.";
   }
   const nameCounts = new Map<string, number>();
   for (const entry of entries) {
     nameCounts.set(entry.name, (nameCounts.get(entry.name) ?? 0) + 1);
   }
-  const listedEntries = entries
+  // Count collisions before excluding native tools: their lookalikes remain ambiguous.
+  const listedEntries = deferredEntries
     .filter((entry) => nameCounts.get(entry.name) === 1)
     .toSorted(
       (left, right) =>
@@ -198,7 +200,7 @@ function formatToolSearchCatalogDirectory(
   const omittedLabel = " additional tools omitted. ";
   // Each line includes its newline; three fixed separators remain outside the rows.
   let lineChars = lines.reduce((chars, line) => chars + line.length + 1, 0);
-  let omitted = entries.length - lines.length;
+  let omitted = deferredEntries.length - lines.length;
   let guidance: string;
   for (;;) {
     guidance =

--- a/src/agents/tool-search-directory.ts
+++ b/src/agents/tool-search-directory.ts
@@ -1,5 +1,6 @@
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { pruneMapToMaxSize } from "../infra/map-size.js";
 import {
   applyToolCatalogCompaction,
   collectUniqueCatalogToolNames,
@@ -71,25 +72,41 @@ export function applyToolSchemaDirectoryCatalog(params: {
 
 export function buildToolSchemaDirectoryPrompt(
   ctx: ToolSearchToolContext,
-  options?: CatalogVisibilityOptions,
+  options?: CatalogVisibilityOptions & { contextTokenBudget?: number },
 ): string {
   const config = resolveToolSearchConfig(ctx.runtimeConfig ?? ctx.config);
   const catalog = resolveCatalog(ctx);
-  const cacheKey = `${config.mode}:${options?.includeMcp === false ? "without-mcp" : "all"}`;
+  const contextTokens = options?.contextTokenBudget;
+  // At four characters per token, the listing gets 2.5% of the active window.
+  // Keep enough room for discovery instructions even in a very small window.
+  const maxChars =
+    contextTokens && Number.isFinite(contextTokens) && contextTokens > 0
+      ? Math.min(
+          MAX_TOOL_SCHEMA_DIRECTORY_PROMPT_CHARS,
+          Math.max(768, Math.floor(contextTokens / 10)),
+        )
+      : MAX_TOOL_SCHEMA_DIRECTORY_PROMPT_CHARS;
+  const cacheKey = `${config.mode}:${options?.includeMcp === false ? "without-mcp" : "all"}:${maxChars}`;
   let cachedPrompts = toolSchemaDirectoryPromptCache.get(catalog.entries);
-  const cachedPrompt = cachedPrompts?.get(cacheKey);
+  // Caller-owned filters may change in place; cached text must not bypass them.
+  const cachedPrompt = options?.allowedIds ? undefined : cachedPrompts?.get(cacheKey);
   if (cachedPrompt !== undefined) {
     return cachedPrompt;
   }
   const prompt = formatToolSearchCatalogDirectory(
     visibleCatalogEntries(catalog, options),
     config.mode,
+    maxChars,
   );
+  if (options?.allowedIds) {
+    return prompt;
+  }
   if (!cachedPrompts) {
     cachedPrompts = new Map<string, string>();
     toolSchemaDirectoryPromptCache.set(catalog.entries, cachedPrompts);
   }
   cachedPrompts.set(cacheKey, prompt);
+  pruneMapToMaxSize(cachedPrompts, 12);
   return prompt;
 }
 
@@ -118,12 +135,12 @@ export function resolveToolSearchCatalogTool(
   }
 }
 
-function compactDirectoryDescription(description: string): string {
+function compactDirectoryDescription(description: string, maxChars: number): string {
   const normalized = description.replace(/\s+/g, " ").trim();
-  if (normalized.length <= 180) {
+  if (normalized.length <= maxChars) {
     return normalized;
   }
-  return `${truncateUtf16Safe(normalized, 177).trimEnd()}...`;
+  return `${truncateUtf16Safe(normalized, maxChars - 3).trimEnd()}...`;
 }
 
 function formatToolDirectoryIdentifier(value: string | undefined): string | undefined {
@@ -131,7 +148,10 @@ function formatToolDirectoryIdentifier(value: string | undefined): string | unde
   return trimmed && TOOL_DIRECTORY_IDENTIFIER_RE.test(trimmed) ? trimmed : undefined;
 }
 
-function formatToolDirectoryEntry(entry: ToolSearchCatalogEntry): string | undefined {
+function formatToolDirectoryEntry(
+  entry: ToolSearchCatalogEntry,
+  descriptionMaxChars: number,
+): string | undefined {
   if (entry.source !== "openclaw") {
     return undefined;
   }
@@ -139,15 +159,19 @@ function formatToolDirectoryEntry(entry: ToolSearchCatalogEntry): string | undef
   if (!name) {
     return undefined;
   }
-  const description = compactDirectoryDescription(entry.description);
   const ownerName = formatToolDirectoryIdentifier(entry.sourceName);
   const owner = ownerName ? ` (${ownerName})` : "";
+  if (descriptionMaxChars === 0) {
+    return `- ${name}${owner}`;
+  }
+  const description = compactDirectoryDescription(entry.description, descriptionMaxChars);
   return `- ${name}${owner}: ${description || "No description."}`;
 }
 
 function formatToolSearchCatalogDirectory(
   entries: ToolSearchCatalogEntry[],
   mode: ToolSearchMode,
+  maxChars: number,
 ): string {
   if (entries.length === 0) {
     return "Available deferred-schema tools: none.";
@@ -156,15 +180,19 @@ function formatToolSearchCatalogDirectory(
   for (const entry of entries) {
     nameCounts.set(entry.name, (nameCounts.get(entry.name) ?? 0) + 1);
   }
-  const lines = entries
+  const listedEntries = entries
     .filter((entry) => nameCounts.get(entry.name) === 1)
     .toSorted(
       (left, right) =>
         (left.name < right.name ? -1 : left.name > right.name ? 1 : 0) ||
         (left.id < right.id ? -1 : left.id > right.id ? 1 : 0),
-    )
-    .map(formatToolDirectoryEntry)
-    .filter((line): line is string => Boolean(line));
+    );
+  let descriptionMaxChars = 180;
+  const renderRows = () =>
+    listedEntries
+      .map((entry) => formatToolDirectoryEntry(entry, descriptionMaxChars))
+      .filter((line): line is string => Boolean(line));
+  let lines = renderRows();
   const heading = "Available deferred-schema tools:";
   const notice = "Policy-approved MCP and client tools may also be discoverable through search.";
   const omittedLabel = " additional tools omitted. ";
@@ -189,11 +217,17 @@ function formatToolSearchCatalogDirectory(
     const footerChars =
       guidance.length + (omitted > 0 ? String(omitted).length + omittedLabel.length : 0);
     if (
-      heading.length + lineChars + notice.length + footerChars + 3 <=
-        MAX_TOOL_SCHEMA_DIRECTORY_PROMPT_CHARS ||
+      heading.length + lineChars + notice.length + footerChars + 3 <= maxChars ||
       lines.length === 0
     ) {
       break;
+    }
+    // Preserve capability names before dropping rows; full descriptions remain searchable.
+    if (descriptionMaxChars > 0) {
+      descriptionMaxChars = descriptionMaxChars === 180 ? 64 : 0;
+      lines = renderRows();
+      lineChars = lines.reduce((chars, line) => chars + line.length + 1, 0);
+      continue;
     }
     // SAFETY: this renderer owns the nonempty, dense formatted-line array.
     // Remove excluded rows before materializing the bounded directory.

--- a/src/agents/tool-search-recovery.ts
+++ b/src/agents/tool-search-recovery.ts
@@ -1,0 +1,122 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  normalizeStringEntries,
+  uniqueStrings,
+} from "@openclaw/normalization-core/string-normalization";
+import { levenshteinDistance } from "../shared/levenshtein-distance.js";
+import { resolveAgentToolExecutionSchema } from "./agent-tool-availability.js";
+import { compactToolInputHint } from "./tool-schema-hints.js";
+import type {
+  ToolSearchCatalogEntry,
+  ToolSearchToolContext,
+  UnknownToolErrorOptions,
+} from "./tool-search-types.js";
+
+function tokenizeLookupValue(input: string): Set<string> {
+  return new Set(normalizeStringEntries(input.toLowerCase().split(/[^a-z0-9]+/u)));
+}
+
+function scoreUnknownToolSuggestion(needle: string, entry: ToolSearchCatalogEntry): number {
+  const normalizedNeedle = needle.toLowerCase();
+  const name = entry.name.toLowerCase();
+  const id = entry.id.toLowerCase();
+  const label = (entry.label ?? "").toLowerCase();
+  const description = entry.description.toLowerCase();
+  const needleTokens = tokenizeLookupValue(needle);
+  const entryTokens = tokenizeLookupValue(
+    `${entry.name} ${entry.id} ${entry.label ?? ""} ${entry.description}`,
+  );
+  let score = 0;
+  if ((name && normalizedNeedle.includes(name)) || id.includes(normalizedNeedle)) {
+    score += 40;
+  }
+  if (name && needleTokens.has(name)) {
+    score += 40;
+  }
+  for (const token of needleTokens) {
+    if (entryTokens.has(token)) {
+      score += 12;
+    }
+  }
+  if (label.includes(normalizedNeedle) || description.includes(normalizedNeedle)) {
+    score += 8;
+  }
+  return score;
+}
+
+export type ToolLookupErrorOptions = UnknownToolErrorOptions &
+  Pick<ToolSearchToolContext, "codeModeSkills">;
+
+export function formatUnknownToolIdError(
+  needle: string,
+  entries: readonly ToolSearchCatalogEntry[],
+  options: ToolLookupErrorOptions = {},
+): string {
+  const skill = options.codeModeSkills?.find((candidate) => candidate.name === needle);
+  const canReadSkills = entries.some(
+    (entry) => entry.source === "openclaw" && entry.sourceName === "core" && entry.name === "read",
+  );
+  if (skill && canReadSkills) {
+    // Use admitted, mapped prompt locations; never load a skill as a side effect of recovery.
+    const quotedLocation = JSON.stringify(skill.location);
+    const location = quotedLocation.length <= 1_024 ? quotedLocation : "its listed location";
+    return `This id names a skill, not a callable tool. Load its complete instructions from ${location} using the skill-loading guidance in your system prompt.`;
+  }
+  const nameCounts = new Map<string, number>();
+  for (const entry of entries) {
+    nameCounts.set(entry.name, (nameCounts.get(entry.name) ?? 0) + 1);
+  }
+  const suggestions = uniqueStrings(
+    entries
+      .map((entry) => ({
+        value: options.exactIdOnly || (nameCounts.get(entry.name) ?? 0) > 1 ? entry.id : entry.name,
+        score: scoreUnknownToolSuggestion(needle, entry),
+      }))
+      .filter((candidate) => candidate.score > 0)
+      .toSorted((a, b) => b.score - a.score || a.value.localeCompare(b.value))
+      .map((candidate) => candidate.value),
+  ).slice(0, 3);
+  const recoveryText =
+    options.recoverySurface === "code-mode"
+      ? "Use openclaw.tools.search to find a tool, openclaw.tools.describe to inspect it, then openclaw.tools.call with the exact id or name."
+      : options.recoverySurface === "catalog"
+        ? "Use catalog.search to find a callable tool handle, then call the handle or use its describe method."
+        : "Use tool_search to find a tool, tool_describe to inspect it, then tool_call with the exact id or name.";
+  if (suggestions.length === 0) {
+    return `Unknown tool id: ${needle}. ${recoveryText}`;
+  }
+  return `Unknown tool id: ${needle}. Did you mean: ${suggestions.join(", ")}? ${recoveryText}`;
+}
+
+export function formatCatalogInputError(
+  entry: ToolSearchCatalogEntry,
+  errors: import("../plugins/schema-validator.js").JsonSchemaValidationError[],
+  value: unknown,
+): string {
+  const executionSchema = resolveAgentToolExecutionSchema(entry.tool, entry.parameters);
+  const schema = isRecord(executionSchema) ? executionSchema : undefined;
+  const propertyNames = isRecord(schema?.properties) ? Object.keys(schema.properties) : [];
+  const knownProperties = new Set(propertyNames);
+  const unexpectedProperties =
+    schema?.additionalProperties === false && isRecord(value)
+      ? Object.keys(value).filter((name) => !knownProperties.has(name))
+      : errors.flatMap((error) => (error.additionalProperty ? [error.additionalProperty] : []));
+  const suggestions = uniqueStrings(
+    unexpectedProperties.flatMap((unexpected) => {
+      const nearest = propertyNames
+        .map((name) => ({ name, distance: levenshteinDistance(unexpected, name) }))
+        .filter(
+          ({ distance }) => distance <= Math.min(3, Math.max(1, Math.ceil(unexpected.length / 3))),
+        )
+        .toSorted(
+          (left, right) => left.distance - right.distance || left.name.localeCompare(right.name),
+        )[0];
+      return nearest ? [nearest.name] : [];
+    }),
+  ).slice(0, 3);
+  const details = errors.map((error) => error.text).join("; ");
+  const hint = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}?` : "";
+  const input = compactToolInputHint(schema);
+  const signature = input === "unknown" ? "" : ` Expected input: ${input}.`;
+  return `Invalid arguments for tool "${entry.id}": ${details}.${hint}${signature}`;
+}

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -1,10 +1,5 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import {
-  normalizeStringEntries,
-  uniqueStrings,
-} from "@openclaw/normalization-core/string-normalization";
 import { getPluginToolMeta } from "../plugins/tool-metadata.js";
-import { levenshteinDistance } from "../shared/levenshtein-distance.js";
 import { resolveAgentToolExecutionSchema } from "./agent-tool-availability.js";
 import {
   finalizeToolTerminalPresentation,
@@ -21,7 +16,6 @@ import {
   isTrustedToolExecutionPreflightError,
   protectNetworkToolExecutionError,
 } from "./tool-result-error.js";
-import { compactToolInputHint } from "./tool-schema-hints.js";
 import {
   compactToolSearchCatalogEntry,
   prepareToolSearchCatalogExecutionTool,
@@ -37,6 +31,11 @@ import {
   tokenizeDocument,
   tokenizeQuery,
 } from "./tool-search-ranking.js";
+import {
+  formatCatalogInputError,
+  formatUnknownToolIdError,
+  type ToolLookupErrorOptions,
+} from "./tool-search-recovery.js";
 import { readToolSearchLimit } from "./tool-search-request.js";
 import { snapshotToolSearchTargetTranscriptResult } from "./tool-search-transcript.js";
 import type {
@@ -79,74 +78,10 @@ function toolSearchEntryText(entry: ToolSearchCatalogEntry, parameterText?: stri
     .join(" ");
 }
 
-function tokenizeLookupValue(input: string): Set<string> {
-  return new Set(normalizeStringEntries(input.toLowerCase().split(/[^a-z0-9]+/u)));
-}
-
-function scoreUnknownToolSuggestion(needle: string, entry: ToolSearchCatalogEntry): number {
-  const normalizedNeedle = needle.toLowerCase();
-  const name = entry.name.toLowerCase();
-  const id = entry.id.toLowerCase();
-  const label = (entry.label ?? "").toLowerCase();
-  const description = entry.description.toLowerCase();
-  const needleTokens = tokenizeLookupValue(needle);
-  const entryTokens = tokenizeLookupValue(
-    `${entry.name} ${entry.id} ${entry.label ?? ""} ${entry.description}`,
-  );
-  let score = 0;
-  if ((name && normalizedNeedle.includes(name)) || id.includes(normalizedNeedle)) {
-    score += 40;
-  }
-  if (name && needleTokens.has(name)) {
-    score += 40;
-  }
-  for (const token of needleTokens) {
-    if (entryTokens.has(token)) {
-      score += 12;
-    }
-  }
-  if (label.includes(normalizedNeedle) || description.includes(normalizedNeedle)) {
-    score += 8;
-  }
-  return score;
-}
-
-function formatUnknownToolIdError(
-  needle: string,
-  entries: readonly ToolSearchCatalogEntry[],
-  options: UnknownToolErrorOptions = {},
-): string {
-  const nameCounts = new Map<string, number>();
-  for (const entry of entries) {
-    nameCounts.set(entry.name, (nameCounts.get(entry.name) ?? 0) + 1);
-  }
-  const suggestions = uniqueStrings(
-    entries
-      .map((entry) => ({
-        value: options.exactIdOnly || (nameCounts.get(entry.name) ?? 0) > 1 ? entry.id : entry.name,
-        score: scoreUnknownToolSuggestion(needle, entry),
-      }))
-      .filter((candidate) => candidate.score > 0)
-      .toSorted((a, b) => b.score - a.score || a.value.localeCompare(b.value))
-      .map((candidate) => candidate.value),
-  ).slice(0, 3);
-  const recoveryText =
-    options.recoverySurface === "code-mode"
-      ? "Use openclaw.tools.search to find a tool, openclaw.tools.describe to inspect it, then openclaw.tools.call with the exact id or name."
-      : options.recoverySurface === "catalog"
-        ? "Use catalog.search to find a callable tool handle, then call the handle or use its describe method."
-        : "Use tool_search to find a tool, tool_describe to inspect it, then tool_call with the exact id or name.";
-  if (suggestions.length === 0) {
-    return `Unknown tool id: ${needle}. ${recoveryText}`;
-  }
-  return `Unknown tool id: ${needle}. Did you mean: ${suggestions.join(", ")}? ${recoveryText}`;
-}
-
 function findEntry(
   catalog: ToolSearchCatalogSession,
   id: string,
-  options?: CatalogVisibilityOptions,
-  errorOptions?: UnknownToolErrorOptions,
+  options?: CatalogVisibilityOptions & ToolLookupErrorOptions,
 ): ToolSearchCatalogEntry {
   const needle = id.trim();
   const entries = visibleCatalogEntries(catalog, options);
@@ -160,7 +95,7 @@ function findEntry(
   }
   const namedEntry = namedEntries[0];
   if (!namedEntry) {
-    throw new ToolInputError(formatUnknownToolIdError(needle, entries, errorOptions));
+    throw new ToolInputError(formatUnknownToolIdError(needle, entries, options));
   }
   return namedEntry;
 }
@@ -168,7 +103,7 @@ function findEntry(
 function findEntryByExactId(
   catalog: ToolSearchCatalogSession,
   id: string,
-  errorOptions: UnknownToolErrorOptions = {},
+  errorOptions: ToolLookupErrorOptions = {},
 ): ToolSearchCatalogEntry {
   const needle = id.trim();
   const entry = catalog.entries.find((candidate) => candidate.id === needle);
@@ -352,39 +287,6 @@ async function validateCatalogSchemaValue(
   }
 }
 
-function formatCatalogInputError(
-  entry: ToolSearchCatalogEntry,
-  errors: import("../plugins/schema-validator.js").JsonSchemaValidationError[],
-  value: unknown,
-): string {
-  const executionSchema = resolveAgentToolExecutionSchema(entry.tool, entry.parameters);
-  const schema = isRecord(executionSchema) ? executionSchema : undefined;
-  const propertyNames = isRecord(schema?.properties) ? Object.keys(schema.properties) : [];
-  const knownProperties = new Set(propertyNames);
-  const unexpectedProperties =
-    schema?.additionalProperties === false && isRecord(value)
-      ? Object.keys(value).filter((name) => !knownProperties.has(name))
-      : errors.flatMap((error) => (error.additionalProperty ? [error.additionalProperty] : []));
-  const suggestions = uniqueStrings(
-    unexpectedProperties.flatMap((unexpected) => {
-      const nearest = propertyNames
-        .map((name) => ({ name, distance: levenshteinDistance(unexpected, name) }))
-        .filter(
-          ({ distance }) => distance <= Math.min(3, Math.max(1, Math.ceil(unexpected.length / 3))),
-        )
-        .toSorted(
-          (left, right) => left.distance - right.distance || left.name.localeCompare(right.name),
-        )[0];
-      return nearest ? [nearest.name] : [];
-    }),
-  ).slice(0, 3);
-  const details = errors.map((error) => error.text).join("; ");
-  const hint = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}?` : "";
-  const input = compactToolInputHint(schema);
-  const signature = input === "unknown" ? "" : ` Expected input: ${input}.`;
-  return `Invalid arguments for tool "${entry.id}": ${details}.${hint}${signature}`;
-}
-
 async function assertCatalogInputMatchesSchema(
   entry: ToolSearchCatalogEntry,
   value: unknown,
@@ -526,12 +428,19 @@ export class ToolSearchRuntime {
   describe = async (id: string, options?: CatalogVisibilityOptions & UnknownToolErrorOptions) => {
     const catalog = resolveCatalog(this.ctx);
     catalog.describeCount += 1;
-    return describeEntry(findEntry(catalog, id, options, options));
+    return describeEntry(
+      findEntry(catalog, id, { ...options, codeModeSkills: this.ctx.codeModeSkills }),
+    );
   };
 
   call = async (id: string, input?: unknown, options?: ToolSearchCallOptions) => {
     const catalog = resolveCatalog(this.ctx);
-    return await this.callEntry(catalog, findEntry(catalog, id, options, options), input, options);
+    return await this.callEntry(
+      catalog,
+      findEntry(catalog, id, { ...options, codeModeSkills: this.ctx.codeModeSkills }),
+      input,
+      options,
+    );
   };
 
   callExactId = async (
@@ -545,7 +454,12 @@ export class ToolSearchRuntime {
     },
   ) => {
     const catalog = resolveCatalog(this.ctx);
-    return await this.callEntry(catalog, findEntryByExactId(catalog, id, options), input, options);
+    return await this.callEntry(
+      catalog,
+      findEntryByExactId(catalog, id, { ...options, codeModeSkills: this.ctx.codeModeSkills }),
+      input,
+      options,
+    );
   };
 
   callValue = async (id: string, input?: unknown, options?: ToolSearchCallOptions) =>

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -21,6 +21,7 @@ import {
   isTrustedToolExecutionPreflightError,
   protectNetworkToolExecutionError,
 } from "./tool-result-error.js";
+import { compactToolInputHint } from "./tool-schema-hints.js";
 import {
   compactToolSearchCatalogEntry,
   prepareToolSearchCatalogExecutionTool,
@@ -356,7 +357,8 @@ function formatCatalogInputError(
   errors: import("../plugins/schema-validator.js").JsonSchemaValidationError[],
   value: unknown,
 ): string {
-  const schema = isRecord(entry.parameters) ? entry.parameters : undefined;
+  const executionSchema = resolveAgentToolExecutionSchema(entry.tool, entry.parameters);
+  const schema = isRecord(executionSchema) ? executionSchema : undefined;
   const propertyNames = isRecord(schema?.properties) ? Object.keys(schema.properties) : [];
   const knownProperties = new Set(propertyNames);
   const unexpectedProperties =
@@ -378,7 +380,9 @@ function formatCatalogInputError(
   ).slice(0, 3);
   const details = errors.map((error) => error.text).join("; ");
   const hint = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(", ")}?` : "";
-  return `Invalid arguments for tool "${entry.id}": ${details}.${hint}`;
+  const input = compactToolInputHint(schema);
+  const signature = input === "unknown" ? "" : ` Expected input: ${input}.`;
+  return `Invalid arguments for tool "${entry.id}": ${details}.${hint}${signature}`;
 }
 
 async function assertCatalogInputMatchesSchema(

--- a/src/agents/tool-search-types.ts
+++ b/src/agents/tool-search-types.ts
@@ -107,6 +107,8 @@ export type ToolSearchCatalogEntry = {
   name: string;
   label?: string;
   description: string;
+  /** Recorded when the catalog owner also exposes this tool in the native surface. */
+  directVisible?: boolean;
   parameters?: unknown;
   outputSchema?: TSchema;
   tool: CatalogTool;

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -1097,6 +1097,47 @@ describe("Tool Search", () => {
     expect(directory.length).toBeLessThanOrEqual(testing.maxToolSchemaDirectoryPromptChars);
   });
 
+  it.each(["tools", "directory"] as const)(
+    "lists only deferred tools while keeping direct tools searchable in %s mode",
+    async (mode) => {
+      const catalogRef = createToolSearchCatalogRef();
+      const config = { tools: { toolSearch: { enabled: true, mode } } };
+      const read = fakeTool("read", "Read a workspace file");
+      const status = fakeTool("session_status", "Inspect the current session");
+      const tools = [...createToolSearchTools({ config, catalogRef }), read, status];
+      const apply = mode === "directory" ? applyToolSchemaDirectoryCatalog : applyToolSearchCatalog;
+      const ctx = { config, catalogRef };
+      const first = apply({ ...ctx, tools });
+      expect(first.tools).toContain(read);
+      expect(first.tools).not.toContain(status);
+      expect(buildToolSchemaDirectoryPrompt(ctx)).not.toContain("- read (core)");
+      expect(buildToolSchemaDirectoryPrompt(ctx)).toContain("- session_status (core)");
+      const runtime = new ToolSearchRuntime(ctx, resolveToolSearchConfig(config));
+      expect(await runtime.search("read", { limit: 1 })).toEqual([
+        expect.objectContaining({ name: "read" }),
+      ]);
+      expect(await runtime.call("openclaw:core:read", { value: "file.txt" })).toEqual(
+        expect.objectContaining({
+          result: expect.objectContaining({
+            details: { name: "read", input: { value: "file.txt" } },
+          }),
+        }),
+      );
+
+      // Same tools, different native surface: a cached deferred row must disappear.
+      const direct = apply({ ...ctx, tools, directToolNames: ["session_status"] });
+      expect(direct.tools).toContain(status);
+      expect(buildToolSchemaDirectoryPrompt(ctx)).toBe("Available deferred-schema tools: none.");
+      apply({ ...ctx, tools });
+      expect(buildToolSchemaDirectoryPrompt(ctx)).toContain("- session_status (core)");
+
+      const lookalike = pluginTool("read", "Unrelated plugin reader");
+      apply({ ...ctx, tools: [...tools, lookalike] });
+      expect(buildToolSchemaDirectoryPrompt(ctx)).not.toContain("- read (");
+      expect(await runtime.search("read", { limit: 5 })).toHaveLength(2);
+    },
+  );
+
   it("keeps the capability directory byte-stable across catalog insertion orders", () => {
     const config = { tools: { toolSearch: true } } as never;
     const buildDirectory = (reverse: boolean) => {

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -2824,7 +2824,7 @@ describe("Tool Search", () => {
 
   it.each(["code", "tools", "directory"] as const)(
     "bounds the %s capability directory and keeps omitted tools searchable",
-    (mode) => {
+    async (mode) => {
       const catalogRef = createToolSearchCatalogRef();
       const config = { tools: { toolSearch: { enabled: true, mode } } } as never;
       const catalogTools = Array.from({ length: 200 }, (_, index) =>
@@ -2846,9 +2846,12 @@ describe("Tool Search", () => {
         applyToolSearchCatalog({ tools, config, catalogRef });
       }
 
-      const directory = buildToolSchemaDirectoryPrompt({ config, catalogRef });
+      const directory = buildToolSchemaDirectoryPrompt(
+        { config, catalogRef },
+        { contextTokenBudget: 32_768 },
+      );
 
-      expect(directory.length).toBeLessThanOrEqual(testing.maxToolSchemaDirectoryPromptChars);
+      expect(directory.length).toBeLessThanOrEqual(3_276);
       expect(directory).toContain("- fake_directory_tool_000");
       expect(directory).not.toContain("- fake_directory_tool_199");
       expect(directory).toContain("additional tools omitted");
@@ -2868,6 +2871,13 @@ describe("Tool Search", () => {
         expect(directory).not.toContain("Call tool_call");
         expect(directory).not.toContain("Call a unique deferred tool name directly");
       }
+      const runtime = new ToolSearchRuntime(
+        { config, catalogRef },
+        resolveToolSearchConfig(config),
+      );
+      expect(await runtime.search("fake_directory_tool_199", { limit: 1 })).toEqual([
+        expect.objectContaining({ name: "fake_directory_tool_199" }),
+      ]);
     },
   );
 
@@ -2876,7 +2886,7 @@ describe("Tool Search", () => {
     { mode: "tools" as const, descriptionChars: 144, longerDescriptions: 10 },
     { mode: "directory" as const, descriptionChars: 145, longerDescriptions: 25 },
   ])(
-    "keeps the exact capability directory boundary in $mode mode",
+    "shortens descriptions only beyond the exact directory boundary in $mode mode",
     ({ mode, descriptionChars, longerDescriptions }) => {
       const render = (overflow: boolean) => {
         const catalogRef = createToolSearchCatalogRef();
@@ -2910,8 +2920,9 @@ describe("Tool Search", () => {
       const overflow = render(true);
       expect(overflow.length).toBeLessThanOrEqual(18_000);
       expect(overflow).toContain("- boundary_098 (fake-catalog):");
-      expect(overflow).not.toContain("- boundary_099");
-      expect(overflow).toContain("1 additional tools omitted.");
+      expect(overflow).toContain("- boundary_099 (fake-catalog):");
+      expect(overflow).not.toContain("additional tools omitted");
+      expect(overflow).toContain(`${"x".repeat(61)}...`);
     },
   );
 
@@ -4529,3 +4540,90 @@ describe("Tool Search", () => {
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
+
+function createCatalog(count = 40) {
+  const config = { tools: { toolSearch: { enabled: true, mode: "tools" as const } } };
+  const entries = Array.from({ length: count }, (_, index) => {
+    const name = `capability_${String(index).padStart(2, "0")}`;
+    const tool = {
+      name,
+      label: name,
+      description: `Inspect the archive for ${name}. ${"Preserve complete source records. ".repeat(6)}`,
+      parameters: Type.Object({ target: Type.String(), limit: Type.Optional(Type.Integer()) }),
+      execute: vi.fn(async () => jsonResult({ completed: true })),
+    };
+    return {
+      id: `openclaw:archive:${name}`,
+      name,
+      description: tool.description,
+      source: "openclaw" as const,
+      sourceName: "archive",
+      parameters: tool.parameters,
+      tool,
+    };
+  });
+  const catalogRef: ToolSearchCatalogRef = {
+    current: {
+      entries,
+      counterScope: "budget-test",
+      searchCount: 0,
+      describeCount: 0,
+      callCount: 0,
+    },
+  };
+  return { config, catalogRef, entries };
+}
+
+describe("context-sized tool discovery", () => {
+  it("shortens descriptions before names and keeps the complete executable catalog", async () => {
+    const ctx = createCatalog();
+    const full = buildToolSchemaDirectoryPrompt(ctx);
+    const small = buildToolSchemaDirectoryPrompt(ctx, { contextTokenBudget: 32_768 });
+    expect(small.length).toBeLessThanOrEqual(3_276);
+    expect(small.length).toBeLessThan(full.length / 2);
+    for (const entry of ctx.entries) {
+      expect(small).toContain(entry.name);
+    }
+    expect(buildToolSchemaDirectoryPrompt(ctx)).toBe(full);
+    expect(buildToolSchemaDirectoryPrompt(ctx, { contextTokenBudget: 32_768 })).toBe(small);
+    const runtime = new ToolSearchRuntime(ctx, resolveToolSearchConfig(ctx.config));
+    const last = expectDefined(ctx.entries.at(-1), "last catalog entry");
+    expect(await runtime.search(last.name, { limit: 1 })).toEqual([
+      expect.objectContaining({ id: last.id }),
+    ]);
+    await runtime.call(last.id, { target: "archive" });
+    expect(last.tool.execute).toHaveBeenCalledOnce();
+  });
+
+  it("does not reuse directory text across changing authorization filters", () => {
+    const ctx = createCatalog(2);
+    const firstEntry = expectDefined(ctx.entries[0], "first catalog entry");
+    const secondEntry = expectDefined(ctx.entries[1], "second catalog entry");
+    const first = new Set([firstEntry.id]);
+    const second = new Set([secondEntry.id]);
+    const firstPrompt = buildToolSchemaDirectoryPrompt(ctx, { allowedIds: first });
+    const secondPrompt = buildToolSchemaDirectoryPrompt(ctx, { allowedIds: second });
+    expect(firstPrompt).toContain(firstEntry.name);
+    expect(firstPrompt).not.toContain(secondEntry.name);
+    expect(secondPrompt).toContain(secondEntry.name);
+    expect(secondPrompt).not.toContain(firstEntry.name);
+    first.clear();
+    expect(buildToolSchemaDirectoryPrompt(ctx, { allowedIds: first })).not.toContain(
+      firstEntry.name,
+    );
+  });
+
+  it("returns the expected input shape with a validation error before executing", async () => {
+    const ctx = createCatalog(1);
+    const entry = expectDefined(ctx.entries[0], "catalog entry");
+    const runtime = new ToolSearchRuntime(ctx, resolveToolSearchConfig(ctx.config), {
+      validateInput: true,
+    });
+    await expect(runtime.call(entry.id, { limit: 2 })).rejects.toThrow(
+      "Expected input: { target: string; limit?: number /* integer */ }",
+    );
+    expect(entry.tool.execute).not.toHaveBeenCalled();
+    await runtime.call(entry.id, { target: "archive", limit: 2 });
+    expect(entry.tool.execute).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -3762,6 +3762,44 @@ describe("Tool Search", () => {
     ).rejects.toThrow("Did you mean: openclaw:first-plugin:write, openclaw:second-plugin:write?");
   });
 
+  it.each(["call", "callExactId", "describe"] as const)(
+    "redirects mistaken skill IDs to admitted instructions during %s",
+    async (operation) => {
+      const catalogRef = createToolSearchCatalogRef();
+      registerHeadlessToolSearchCatalog({ catalogRef, tools: [fakeTool("read", "Read a file")] });
+      const reader = vi.fn();
+      const codeModeSkills = [
+        {
+          name: "ledger-audit",
+          description: "Audit the ledger",
+          location: "/workspace/skills/ledger-audit/SKILL.md",
+          source: { filePath: "/private-host/skills/ledger-audit/SKILL.md" },
+          reader,
+        },
+      ];
+      const runtime = new ToolSearchRuntime(
+        { catalogRef, codeModeSkills },
+        resolveToolSearchConfig(),
+      );
+      await expect(runtime[operation]("ledger-audit")).rejects.toThrow(
+        'Load its complete instructions from "/workspace/skills/ledger-audit/SKILL.md"',
+      );
+      expect(reader).not.toHaveBeenCalled();
+      const withoutSkill = new ToolSearchRuntime({ catalogRef }, resolveToolSearchConfig());
+      await expect(withoutSkill[operation]("ledger-audit")).rejects.toThrow("Unknown tool id");
+      registerHeadlessToolSearchCatalog({ catalogRef, tools: [fakeTool("exec", "Run a command")] });
+      await expect(runtime[operation]("ledger-audit")).rejects.toThrow("Unknown tool id");
+      registerHeadlessToolSearchCatalog({
+        catalogRef,
+        tools: [fakeTool("ledger-audit", "Real tool")],
+      });
+      expect(await runtime.call("ledger-audit", {})).toHaveProperty(
+        "result.details.name",
+        "ledger-audit",
+      );
+    },
+  );
+
   it("keeps raw Tool Search recovery guidance when no suggestion matches", async () => {
     const callTool = fakeTool(TOOL_CALL_RAW_TOOL_NAME, "call");
     const searchTool = fakeTool(TOOL_SEARCH_RAW_TOOL_NAME, "search");

--- a/src/gateway/session-observer.digest-budget.test.ts
+++ b/src/gateway/session-observer.digest-budget.test.ts
@@ -109,18 +109,41 @@ describe("session observer digest budget", () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     const persistDigest = vi.fn(async () => null);
-    const harness = createHarness({ persistDigest });
+    // Shared Gateway workers can have unrelated timers; assert this observer's cleanup.
+    const ownedTimers = new Set<ReturnType<typeof setTimeout>>();
+    const setTimeoutFn = Object.assign((callback: () => void, delay?: number) => {
+      const timer = setTimeout(() => {
+        ownedTimers.delete(timer);
+        callback();
+      }, delay);
+      ownedTimers.add(timer);
+      return timer;
+    }, setTimeout);
+    const clearTimeoutFn: typeof clearTimeout = (timer) => {
+      if (timer && typeof timer === "object") {
+        ownedTimers.delete(timer);
+      }
+      clearTimeout(timer);
+    };
+    const unrelated = vi.fn();
+    const unrelatedTimer = setTimeout(unrelated, 60_000);
+    const harness = createHarness({ persistDigest, setTimeoutFn, clearTimeoutFn });
     startAndAddToolNotes(harness.observer);
 
     await vi.advanceTimersByTimeAsync(12_000);
     await flushObserver();
     expect(harness.completeModel).toHaveBeenCalledOnce();
     expect(persistDigest).toHaveBeenCalledOnce();
-    expect(vi.getTimerCount()).toBe(0);
+    expect(ownedTimers.size).toBe(0);
 
     startAndAddToolNotes(harness.observer, { count: 4 });
     await vi.advanceTimersByTimeAsync(24_000);
     expect(harness.completeModel).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(24_000);
+    expect(unrelated).toHaveBeenCalledOnce();
+    expect(harness.completeModel).toHaveBeenCalledOnce();
+    expect(ownedTimers.size).toBe(0);
     harness.observer.dispose();
+    clearTimeout(unrelatedTimer);
   });
 });

--- a/src/gateway/session-observer.test-utils.ts
+++ b/src/gateway/session-observer.test-utils.ts
@@ -84,6 +84,8 @@ export async function flushObserver(): Promise<void> {
 }
 
 export function createHarness(options?: {
+  setTimeoutFn?: SessionObserverDeps["setTimeoutFn"];
+  clearTimeoutFn?: SessionObserverDeps["clearTimeoutFn"];
   subscribe?: boolean;
   broadSubscribe?: boolean;
   visible?: boolean;
@@ -118,6 +120,8 @@ export function createHarness(options?: {
   const readSession =
     options?.readSession ?? vi.fn(() => ({ sessionId: "session-id", updatedAt: 0 }));
   const observer = createSessionObserver({
+    setTimeoutFn: options?.setTimeoutFn,
+    clearTimeoutFn: options?.clearTimeoutFn,
     getConfig: () => options?.config ?? cfg,
     subscribers,
     sessionEventSubscribers,

--- a/src/skills/loading/skill-contract.ts
+++ b/src/skills/loading/skill-contract.ts
@@ -30,6 +30,15 @@ export function escapeSkillXml(str: string): string {
     .replace(/'/g, "&apos;");
 }
 
+export function decodeSkillXml(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
 export const COMPACT_DESCRIPTION_MAX_CHARS = 220;
 const SKILL_FRONTMATTER_BLOCK = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/u;
 const SKILL_TITLE_HEADING = /^#\s+(.+?)\s*#*\s*$/mu;
@@ -58,6 +67,47 @@ function truncateSkillDescription(description: string, maxChars: number): string
     return truncateUtf16Safe(normalized, maxChars);
   }
   return `${truncateUtf16Safe(normalized, maxChars - 3).trimEnd()}...`;
+}
+
+/** Project descriptions for a model without changing admitted identities or loading instructions. */
+export function compactSkillsPromptForContext(prompt: string, contextTokenBudget?: number): string {
+  if (!contextTokenBudget || !Number.isFinite(contextTokenBudget) || contextTokenBudget <= 0) {
+    return prompt;
+  }
+  const targetChars = Math.floor(contextTokenBudget / 5);
+  if (prompt.length <= targetChars) {
+    return prompt;
+  }
+  const start = prompt.indexOf("<available_skills>");
+  const end = prompt.indexOf("</available_skills>", start);
+  if (start < 0 || end < start) {
+    return prompt;
+  }
+  const catalog = prompt.slice(start, end);
+  const render = (maxChars: number) =>
+    prompt.slice(0, start) +
+    catalog.replace(
+      /<description>([\s\S]*?)<\/description>/gu,
+      (_match, description: string) =>
+        `<description>${escapeSkillXml(truncateSkillDescription(decodeSkillXml(description), maxChars))}</description>`,
+    ) +
+    prompt.slice(end);
+  // Names, mapped locations and loading notes are an identity floor, not optional prose.
+  // Keep a short matching description even when that floor exceeds the model's share.
+  let lo = 64;
+  let hi = COMPACT_DESCRIPTION_MAX_CHARS;
+  let result = render(lo);
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    const candidate = render(mid);
+    if (candidate.length <= targetChars) {
+      result = candidate;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return result.length < prompt.length ? result : prompt;
 }
 
 /**

--- a/src/skills/loading/workspace-skill-prompt-resolution.test.ts
+++ b/src/skills/loading/workspace-skill-prompt-resolution.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readCodeModeSkill, resolveCodeModeSkills } from "../../agents/code-mode-skills.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { createCanonicalFixtureSkill } from "../test-support/test-helpers.js";
@@ -45,6 +46,47 @@ function createEntry(name: string): SkillEntry {
 }
 
 describe("resolveSkillsPrompt", () => {
+  it.each([8_192, 32_768])(
+    "compacts descriptions at %i tokens without changing admitted skill resources",
+    async (contextTokenBudget) => {
+      const entries = Array.from({ length: 24 }, (_, index) => {
+        const entry = createEntry(`skill-${index}`);
+        entry.skill.description = `Inspect records & preserve <identifiers>. ${"Detailed matching guidance. ".repeat(10)}`;
+        entry.skill.locationNote = "Load the complete instruction file at this location.";
+        entry.skill.readContent = `${"Complete instruction body. ".repeat(300)}END_${index}`;
+        return entry;
+      });
+      const snapshot = buildSkillSnapshot("/tmp/openclaw", { entries });
+      const original = snapshot.prompt.trim();
+      const projected = resolveSkillsPrompt({
+        workspaceDir: "/tmp/openclaw",
+        skillsSnapshot: snapshot,
+        contextTokenBudget,
+      });
+      expect(projected.length).toBeLessThan(original.length);
+      const omitDescriptions = (prompt: string) =>
+        prompt.replace(/<description>[\s\S]*?<\/description>/gu, "");
+      expect(omitDescriptions(projected)).toBe(omitDescriptions(original));
+      expect(projected).toContain("&amp; preserve &lt;identifiers&gt;");
+      expect(snapshot.prompt.trim()).toBe(original);
+      expect(resolveSkillsPrompt({ workspaceDir: "/tmp/openclaw", skillsSnapshot: snapshot })).toBe(
+        original,
+      );
+      const resources = resolveCodeModeSkills({
+        skillsPrompt: projected,
+        candidates: snapshot.resolvedSkills!,
+      });
+      expect(resources.map((skill) => skill.name)).toEqual(
+        snapshot.resolvedSkills!.map((skill) => skill.name),
+      );
+      for (const resource of resources) {
+        expect(await readCodeModeSkill(resource)).toBe(
+          entries.find((entry) => entry.skill.name === resource.name)!.skill.readContent,
+        );
+      }
+    },
+  );
+
   it("prefers snapshot prompt when available", () => {
     const prompt = resolveSkillsPrompt({
       skillsSnapshot: { prompt: "SNAPSHOT", skills: [] },

--- a/src/skills/loading/workspace-skill-prompt.ts
+++ b/src/skills/loading/workspace-skill-prompt.ts
@@ -8,7 +8,7 @@ import type { SkillEligibilityContext, SkillEntry, SkillSnapshot } from "../type
 import { WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION } from "../types.js";
 import { hasUnavailableSkillSecretOwners, isSkillSecretOwnerUnavailable } from "./config.js";
 import { resolveSkillKey } from "./frontmatter.js";
-import { escapeSkillXml, type Skill } from "./skill-contract.js";
+import { compactSkillsPromptForContext, escapeSkillXml, type Skill } from "./skill-contract.js";
 import { compactPromptSkills } from "./skill-paths.js";
 import { prepareSkillsForPrompt } from "./skill-prompt-limits.js";
 import { resolveWorkspaceSkillPromptEntries } from "./workspace-skill-loader.js";
@@ -85,6 +85,7 @@ export function buildSkillSnapshot(
 }
 
 type ResolveSkillsPromptParams = {
+  contextTokenBudget?: number;
   skillsSnapshot?: SkillSnapshot;
   entries?: SkillEntry[];
   config?: OpenClawConfig;
@@ -127,7 +128,7 @@ function rebuildAfterUnsafeSnapshot(
   return buildSkillsPromptFromEntries(params, entries);
 }
 
-export function resolveSkillsPrompt(params: ResolveSkillsPromptParams): string {
+function resolveSkillsPromptCatalog(params: ResolveSkillsPromptParams): string {
   const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
   if (params.skillsSnapshot && !snapshotPrompt) {
     return "";
@@ -197,4 +198,11 @@ export function resolveSkillsPrompt(params: ResolveSkillsPromptParams): string {
     return `${snapshotPrompt.slice(0, bodyStart)}${filteredBody}${tail}${snapshotPrompt.slice(catalogEnd)}`.trim();
   }
   return buildSkillsPromptFromEntries(params, params.entries);
+}
+
+export function resolveSkillsPrompt(params: ResolveSkillsPromptParams): string {
+  return compactSkillsPromptForContext(
+    resolveSkillsPromptCatalog(params),
+    params.contextTokenBudget,
+  );
 }


### PR DESCRIPTION
Related: #138850.

## What Problem This Solves

Small-context embedded agents spend too much input on always-present discovery text. The directory also describes directly available primitives as deferred, and a mistaken skill name passed as a tool ID sends the model through more tool searches instead of to its instructions. Invalid arguments require another schema lookup when the error omits the expected shape.

## Why This Change Was Made

Use the prepared context budget to shorten tool and skill descriptions. Shorten descriptions before omitting tool names; preserve every admitted skill identity, mapped location, loading note and complete instruction body. Search and execution retain the complete authorized catalog. Record native visibility at catalog assembly and omit those entries only from deferred presentation, preserving name-collision handling and searchable native primitives.

Cache keys include the budget, remain bounded, and avoid reuse under mutable visibility filters. Invalid trusted-tool arguments include the existing bounded execution-schema hint. A failed lookup matching an admitted skill points to its bounded mapped instruction location while a core reader is available. Real tool lookup wins; error recovery performs no read or execution. Recovery formatting has one focused module rather than a larger runtime-file limit.

## User Impact

Less always-present discovery text and fewer unnecessary searches after mistaken skill calls. No operator option, model selection, dependency, schema, saved skill snapshot or native harness policy changes. Explicit settings retain ownership.

A bounded CI repair scopes an observer cleanup assertion to its own timers through existing timer dependencies. It retains no-rebilling coverage and proves an unrelated timer still fires; production observer behavior is unchanged.

## Evidence

Baseline: `8637d26b73b3a8af65ecebd309d401c979a16813`.
Candidate: `5fb8587a336237141c200874cf5b11bda754b49b`.

Live trials use pinned Ollama 0.33.3, Qwen3.5 Q4_K_M, generated 32K settings, automatic Tool Search, thinking off, and native `truncate: false` / `shift: false`. Config and fixtures remain unchanged. Full skill reads are checked in the canonical transcript and first subsequent native request. Failed trials remain recorded.

| 4B CLI measurement | Baseline | Candidate |
| --- | ---: | ---: |
| CPU first request input | 10,771 tokens | 9,756 tokens |
| CPU cold read | 121.703 s | 112.933 s |
| CPU warm read | 9.273 s | 12.188 s |
| CPU skill task | 51.061 s / 4 calls | 25.742 s / 2 calls |
| CPU discovery | 39.623 s | 37.990 s |
| CPU strict task outcomes | 4/4 | 4/4 |
| Metal cold read, median | 13.215 s | 12.447 s |
| Metal warm read, median | 4.219 s | 3.665 s |
| Metal skill task, median | 6.792 s | 5.363 s |
| Metal strict task outcomes | 10/12 | 10/12 |

CPU: four cores, about 15.4 GiB RAM, Node 24.19.0, zero VRAM offload. Metal: M3 Ultra, Node 26.8.1, verified Metal offload. Each source pair uses the same environment. Metal has three fixture-seed pairs in AB/BA/AB order; medians include failed attempts. Cold means a new model-server process; OS caches and host load are uncontrolled. No TTFT or statistical-significance claim. Observed task RSS remained approximately 5.45 GiB on CPU and 6.5 GiB on Metal for both 4B arms.

Results are mixed beyond the targeted gains: warm CPU time increased in the one pair, Metal 4B had different failures with equal total successes, and 9B scored 7/12 versus 6/12. Failures include missing reads, incorrect paths and exact-format mistakes. Raw-generation tracing confirms an observed missing leading slash was emitted by 9B before parsing. Model defaults and path handling are unchanged; this PR does not claim a general model-quality improvement.

**Real Tauri chat:** one unchanged native shell connected to separate source-pinned Gateways. Both returned the exact verification word after reading the full long skill. Baseline made an invalid call, three searches, then a read. Candidate made the invalid call, received skill-loading guidance, then read. The app reports 3m 40s versus 2m 34s, and 264 versus 117 output tokens. This proves native chat; onboarding was exercised through the CLI.

The UI observer initially timed out because it assumed an ARIA log with unflattened message ancestors. Direct screenshot inspection confirms both exact answers and completed footers. WebKit exposes paragraph/footer siblings in a section. The corrected observer was checked against all 30 saved actual captures, rejecting pre-send frames and detecting completed frames. Original timeout reports remain intact; no product UI change was needed.

Before:
![Baseline native skill task](https://github.com/user-attachments/assets/964f85a3-4b2c-4189-ab2f-aa3014c36b3a)

After:
![Candidate native skill task](https://github.com/user-attachments/assets/cf5dd9f4-ca42-4efe-b77e-7010fe5f1102)

CPU: [Testbox run 33985470285](https://github.com/openclaw/openclaw/actions/runs/33985470285), lease `tbx_01m1seq65ea8fba3ebw6gxygj8`. Native: [Testbox run 33987015915](https://github.com/openclaw/openclaw/actions/runs/33987015915), lease `tbx_01m1sgf0qy77dzh0zgesdpfw35`. Owned model/Gateway/UI processes drained with zero observed survivors. Both leases were stopped; their workflow cancellation reflects lease cleanup. CPU command exited zero; native observer exited nonzero as explained above.

Validation: 225 Tool Search/runtime tests, four Code Mode skill tests, nineteen setup tests, 108 grouped observer tests, and earlier skill-format/admission coverage. Relevant directory/cache/error and skill-budget regressions fail before repair. The observer reproduction has zero owned timers while its former global assertion fails on an unrelated timer. Changed-scope checks, builds and independent P0–P2 review pass. [Exact-head CI is green](https://github.com/openclaw/openclaw/actions/runs/33985417816); the earlier observer assertion failure was repaired rather than bypassed.

Commands included `node scripts/run-vitest.mjs src/agents/tool-search.test.ts src/agents/tool-search-runtime.test.ts`, the Code Mode skill/setup and grouped observer suites, `node scripts/check-changed.mjs` with the eight changed recovery/observer paths, `pnpm build qaRuntime` locally and `pnpm build ciArtifacts` for native proof. Live tasks use supported noninteractive Ollama onboarding and `agent --local --agent main --session-key <isolated-session> --message-file <fixture-prompt> --json`; Tauri drives the visible composer against the real Gateway.

Production +283/-145 (net +138), tests/support +254/-8, docs +17. Raw counts include the existing formatter move. Remaining growth implements context-aware presentation and actionable recovery while preserving admission and execution ownership.
