### PR TITLE
fix(diagnostics): preserve graceful Gateway shutdown in install E2E

### DIFF
--- a/extensions/diagnostics-prometheus/src/install-runtime.e2e.test.ts
+++ b/extensions/diagnostics-prometheus/src/install-runtime.e2e.test.ts
@@ -1,5 +1,6 @@
 // Proves the external Prometheus plugin's managed install and trusted runtime boundary.
 import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
@@ -254,7 +255,9 @@ async function waitForGateway(params: {
 }
 
 describe("diagnostics-prometheus managed install runtime", () => {
-  it("installs the exact official package and exports metrics at Gateway startup", async () => {
+  it("installs the exact official package and exports metrics at Gateway startup", async ({
+    signal,
+  }) => {
     const workspace = await tempWorkspace({
       rootDir: resolvePreferredOpenClawTmpDir(),
       prefix: "openclaw-prometheus-install-",
@@ -355,6 +358,9 @@ describe("diagnostics-prometheus managed install runtime", () => {
       },
     );
     children.push(gateway);
+    const gatewayClosed = once(gateway, "close", { signal });
+    // Setup can fail before this waiter is awaited; afterEach still owns forced cleanup.
+    void gatewayClosed.catch(() => {});
     await gatewayLogHandle.close();
     await waitForGateway({ child: gateway, logPath: gatewayLog, port: gatewayPort });
 
@@ -439,8 +445,20 @@ describe("diagnostics-prometheus managed install runtime", () => {
     expect(gatewayLogs).not.toContain(
       "diagnostics-prometheus: internal diagnostics capability unavailable",
     );
-    await stopChildProcess(gateway, 5_000);
-    expect(gateway.exitCode).toBe(0);
-    expect(gateway.signalCode).toBeNull();
+    try {
+      // Graceful stop drains legitimate startup work; the forced reaper is cleanup only.
+      expect(gateway.kill("SIGTERM")).toBe(true);
+      await gatewayClosed;
+      expect(gateway.exitCode).toBe(0);
+      expect(gateway.signalCode).toBeNull();
+    } catch (cause) {
+      const termination = { exitCode: gateway.exitCode, signalCode: gateway.signalCode };
+      // Snapshot termination before reading the log that afterEach will remove.
+      const shutdownLogs = await fs.readFile(gatewayLog, "utf8");
+      throw new Error(
+        `Gateway shutdown failed: ${JSON.stringify(termination)}\n${shutdownLogs.slice(-8_000)}`,
+        { cause },
+      );
+    }
   }, 300_000);
 });


### PR DESCRIPTION
Related: #138249

## What Problem This Solves

The Prometheus managed-install E2E sometimes killed a healthy Gateway while it drained startup work, then failed its graceful-exit assertion. Its cleanup helper escalates to SIGKILL after five seconds; that emergency cleanup deadline is not the Gateway's graceful-shutdown contract.

## Why This Change Was Made

Pre-arm the child close observer, bind it to Vitest's existing test timeout/cancellation signal, and send SIGTERM directly for the graceful-shutdown proof. Keep the exact exit-code-zero and null-signal assertions, all install/metrics checks, and the existing five-second forced reaper in `afterEach`.

Shutdown failures now include the captured exit code, signal, and bounded post-stop Gateway logs before fixture cleanup removes them. No test timeout, Gateway policy, or Control UI configuration changes.

## User Impact

Maintainers retain meaningful graceful-shutdown coverage without racing an emergency reaper against legitimate startup work. Production behavior is unchanged. This main-only follow-up is separate from the frozen release candidate.

## Evidence

- Natural main reproduction captured SIGTERM followed by the cleanup helper's SIGKILL at 5,002ms, with actual exit `null`/`SIGKILL` while the Gateway drained startup work.
- A separately labeled, non-qualifying cold-assets observation identified the exact owner as `startup:sidecars.control-ui-assets`. The owner released naturally after its build, then the Gateway exited zero with no signal. This was not a product deadlock or a retrospective explanation of the original release-CI event.
- Node 24.19 process-level checks passed for normal close, retained early close, abort listener cleanup, and abort/exit races using the existing forced-cleanup helper.
- Independent managed review through P2 found no actionable findings.
- Qualifying cold-assets E2E passed with the real Gateway, unchanged startup configuration, and no signal mutation: SIGTERM to exit zero/null signal in 4,883ms. All managed-install and metrics assertions passed.
- Deliberately injected SIGKILL failed the unchanged clean-exit contract as expected and retained the signal plus post-stop Gateway logs. This negative diagnostic check is distinct from the natural reproduction.
- Full classified changed gate passed on the unchanged patch, including extension-test typecheck, lint, formatter, boundaries, and dead-code scans. Exact-head [CI passed](https://github.com/openclaw/openclaw/actions/runs/33981430461) for `a3726dbf12396eb058dce8a2a37c102a73f5dfdf`.
- One test file: +22/−4; production and tooling unchanged.

Fresh ClawSweeper review found no actionable defects or before-merge actions. The real-flow evidence above was executed independently; ClawSweeper reviewed source and reported evidence without rerunning it.
