### PR TITLE
fix(skills): restore pending Workshop approval buttons

### DIFF
--- a/src/agents/tools/gateway.runtime-identity.test.ts
+++ b/src/agents/tools/gateway.runtime-identity.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../../infra/agent-run-registry.js";
 import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { createOperationalRunInstanceRef } from "../admitted-run-context.js";
+import { resolveSkillWorkshopApprovalForFinalParams } from "../agent-tools.before-tool-call.approval.js";
 import {
   withGatewayToolApprovalOwner,
   withGatewayToolCallerIdentity,
@@ -598,6 +599,42 @@ describe("gateway tool runtime identity", () => {
       }
     },
   );
+
+  it.each([
+    ["apply", "allow-once"],
+    ["reject", "deny"],
+    ["quarantine", "allow-once"],
+    ["restore_collection", "deny"],
+  ] as const)("signs the Skill Workshop %s approval owner (%s)", async (action, decision) => {
+    mocks.callGateway.mockResolvedValueOnce({ id: "workshop-approval", decision });
+    const operationalRunInstance = createOperationalRunInstanceRef("workshop-run");
+    const caller = {
+      agentId: "ops",
+      sessionKey: "agent:ops:telegram:group:-1001234567890",
+      operationalRunInstance,
+      turnSourceChannel: "telegram",
+      turnSourceTo: "-1001234567890",
+      turnSourceAccountId: "default",
+    };
+    const result = await withActiveGatewayToolCallerIdentity(caller, () =>
+      resolveSkillWorkshopApprovalForFinalParams({
+        toolName: "skill_workshop",
+        params: { action },
+        ctx: { config: { skills: { workshop: { approvalPolicy: "pending" } } } },
+      }),
+    );
+
+    expect(result?.blocked).toBe(decision === "deny");
+    const call = capturedGatewayCall();
+    expect(call.method).toBe("plugin.approval.request");
+    expect(call.params).not.toHaveProperty("pluginId");
+    await expect(
+      verifyAgentRuntimeIdentityToken(call.agentRuntimeIdentityToken),
+    ).resolves.toMatchObject({
+      ...caller,
+      approvalOwnerPluginId: "workspace-skills",
+    });
+  });
 
   it.for(
     ["exec.approval.request", "plugin.approval.request"].flatMap((method) =>

--- a/src/skills/workshop/policy.test.ts
+++ b/src/skills/workshop/policy.test.ts
@@ -67,6 +67,7 @@ describe("resolveSkillWorkshopToolApproval", () => {
     });
 
     expect(result?.requireApproval).toMatchObject({
+      pluginId: "workspace-skills",
       title: "Apply Skill Workshop proposal",
       severity: "warning",
       timeoutMs: 70_000,

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -14,59 +14,42 @@ const loadPendingSkillProposalResolver = createLazyRuntimeNamedExport(
   "resolvePendingSkillProposal",
 );
 
-const SKILL_WORKSHOP_LIFECYCLE_ACTIONS = new Set([
-  "apply",
-  "reject",
-  "quarantine",
-  "restore_collection",
-]);
+const SKILL_WORKSHOP_LIFECYCLE_APPROVALS = {
+  apply: {
+    title: "Apply Skill Workshop proposal",
+    description: "Apply a pending proposal inside your agent's Workshop directory.",
+    severity: "warning",
+  },
+  reject: {
+    title: "Reject Skill Workshop proposal",
+    description: "Reject a pending Skill Workshop proposal.",
+    severity: "info",
+  },
+  quarantine: {
+    title: "Quarantine Skill Workshop proposal",
+    description: "Quarantine a pending Skill Workshop proposal.",
+    severity: "info",
+  },
+  restore_collection: {
+    title: "Restore previous skill collection",
+    description:
+      "Replace current Workshop-generated skills with the previous collection backup. Later Workshop changes may be removed.",
+    severity: "warning",
+  },
+} as const;
 // Codex dynamic tools have a 90s watchdog. Approval RPCs reserve another 10s
 // for Gateway cleanup, leaving 10s for proposal lookup and tool-call overhead.
 const SKILL_WORKSHOP_APPROVAL_TIMEOUT_MS = 70_000;
 
-type SkillWorkshopLifecycleAction = "apply" | "reject" | "quarantine" | "restore_collection";
+type SkillWorkshopLifecycleAction = keyof typeof SKILL_WORKSHOP_LIFECYCLE_APPROVALS;
 
 // Lifecycle actions mutate proposals or live skills and therefore require approval checks.
 function readLifecycleAction(params: unknown): SkillWorkshopLifecycleAction | undefined {
   const action = asNullableRecord(params)?.action;
-  if (typeof action !== "string" || !SKILL_WORKSHOP_LIFECYCLE_ACTIONS.has(action)) {
+  if (typeof action !== "string" || !Object.hasOwn(SKILL_WORKSHOP_LIFECYCLE_APPROVALS, action)) {
     return undefined;
   }
   return action as SkillWorkshopLifecycleAction;
-}
-
-function lifecycleApprovalText(action: SkillWorkshopLifecycleAction): {
-  title: string;
-  description: string;
-  severity: "info" | "warning";
-} {
-  if (action === "apply") {
-    return {
-      title: "Apply Skill Workshop proposal",
-      description: "Apply a pending proposal inside your agent's Workshop directory.",
-      severity: "warning",
-    };
-  }
-  if (action === "reject") {
-    return {
-      title: "Reject Skill Workshop proposal",
-      description: "Reject a pending Skill Workshop proposal.",
-      severity: "info",
-    };
-  }
-  if (action === "restore_collection") {
-    return {
-      title: "Restore previous skill collection",
-      description:
-        "Replace current Workshop-generated skills with the previous collection backup. Later Workshop changes may be removed.",
-      severity: "warning",
-    };
-  }
-  return {
-    title: "Quarantine Skill Workshop proposal",
-    description: "Quarantine a pending Skill Workshop proposal.",
-    severity: "info",
-  };
 }
 
 function formatBodySizeKb(content: string): string {
@@ -193,7 +176,7 @@ export async function resolveSkillWorkshopToolApproval(params: {
   if (config.approvalPolicy === "auto") {
     return undefined;
   }
-  const text = lifecycleApprovalText(action);
+  const text = SKILL_WORKSHOP_LIFECYCLE_APPROVALS[action];
   const approvalDescription =
     action === "restore_collection"
       ? { description: text.description }
@@ -206,6 +189,7 @@ export async function resolveSkillWorkshopToolApproval(params: {
         });
   return {
     requireApproval: {
+      pluginId: "workspace-skills",
       ...text,
       description: approvalDescription.description,
       timeoutMs: SKILL_WORKSHOP_APPROVAL_TIMEOUT_MS,


### PR DESCRIPTION
Closes #135291
Supersedes #135406.

## What Problem This Solves

Fixes an issue where Telegram users requesting a Skill Workshop lifecycle action received no approval buttons when `skills.workshop.approvalPolicy` was `pending`. The Gateway rejected the request before delivering the approval to the authorized owner's DM.

## Why This Change Was Made

Workshop policy now supplies its `workspace-skills` approval owner to the existing signed Gateway transport. The Gateway retains its fail-closed owner and live-run checks. Lifecycle action recognition and approval text share one table, removing duplicated policy while preserving titles, descriptions, severity, decisions, and timeout.

This maintainer takeover preserves @gaoanze888's producer-side fix from #135406, reported by @khaisis in #135291 and reproduced on 2026.9.1 by @stemkat100. The new regression verifies the owner in the signed Gateway request for apply, reject, quarantine, and restore.

## User Impact

Operators using pending Workshop approvals receive the existing decision controls in their configured Telegram DM, including when the request starts in a group. Approving lets the lifecycle action finish and produces a visible result in the originating chat. Automatic policy behavior is unchanged.

## Evidence

Verified head: `4ee7ea7e0c05711c0adaa3b745a276c8f1b0e711`.

- Four new signed-owner cases fail against the pre-fix policy, solely because the decoded identity lacks `approvalOwnerPluginId: "workspace-skills"`.
- With the candidate restored, **86 tests pass** across policy (6), signed runtime identity (33), Gateway authority (5), embedded approvals (26), and Telegram approval handler (16).
- Changed-file format/lint/type/guard checks and the full private-QA build pass on sanitized AWS Crabbox. No candidate code ran locally.
- Both independent reviews (uncommitted and committed branch) found no actionable defects. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33982325315); the repository CI watcher returned `GREEN`.
- The real Gateway fixture passes for **DM and group origins**, observing the actual private card, Allow Once/Deny controls, callback acknowledgement, recorded user decision, applied proposal receipt, final originating-chat reply, and terminal card with no buttons. Each case makes three model requests and stops its Gateway cleanly.

Crabbox validation/build: [run_c237dcb87132](https://crabbox.openclaw.ai/portal/runs/run_c237dcb87132). Its subsequent standalone fixture launch hit a syntax error before Gateway startup; the corrected fixture reused the verified candidate build in [successful run_f067cb152f81](https://crabbox.openclaw.ai/portal/runs/run_f067cb152f81). The retry rechecked the artifact SHA, clean tracked tree, toolchain pin, and absent IAM credentials. Both runs used a fresh HOME, public networking, no Tailscale, and no credential hydration.

Commands executed remotely:

```sh
CI=1 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/agents/tools/gateway.runtime-identity.test.ts -t 'signs the Skill Workshop'
CI=1 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/skills/workshop/policy.test.ts src/agents/tools/gateway.runtime-identity.test.ts src/gateway/server-methods/plugin-approval.agent-runtime.test.ts src/agents/agent-tools.before-tool-call.embedded-mode.test.ts extensions/telegram/src/approval-handler.runtime.test.ts
CI=1 node scripts/check-changed.mjs -- src/skills/workshop/policy.ts src/skills/workshop/policy.test.ts src/agents/tools/gateway.runtime-identity.test.ts
OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build
node --import tsx /tmp/pr135406-proof-design/workshop-approval-proof.mjs /work/crabbox/cbx_24d5ded707e7/fresh-pr-openclaw-openclaw-139248 .artifacts/qa-e2e/pr135406-after
```

The fixture uses `createQaGatewayChild` from `extensions/qa-lab/api.ts` with built `dist/entry.js`, fresh state, and separate unused ports. The mock provider invokes the real Workshop create/apply tools. Production policy, signing, Gateway registration, Telegram delivery, and callback handling produce the following synthetic transcript verdict:

```json
{
  "head": "4ee7ea7e0c05711c0adaa3b745a276c8f1b0e711",
  "provider": "aws",
  "lease": "cbx_24d5ded707e7",
  "run": "run_f067cb152f81",
  "runtime": "openclaw",
  "externalAPIs": "synthetic Telegram Bot API and OpenAI Responses",
  "cases": [
    {
      "origin": "dm",
      "originChatId": 1357,
      "approvalDm": 1357,
      "approvalOwner": "workspace-skills",
      "cardMessageId": 9001,
      "buttons": [
        "Allow Once",
        "Deny"
      ],
      "callbackUpdateId": 2,
      "decision": "allow-once",
      "terminalReason": "user",
      "appliedProposal": "approval-dm-proof-20260905-d40349281f",
      "finalMessageId": 9002,
      "terminalCardButtons": [],
      "providerRequests": 3,
      "gatewayCleanup": "confirmed-stopped",
      "passed": true,
      "gatewayPort": 33369
    },
    {
      "origin": "group",
      "originChatId": -1002468135790,
      "approvalDm": 1357,
      "approvalOwner": "workspace-skills",
      "cardMessageId": 9001,
      "buttons": [
        "Allow Once",
        "Deny"
      ],
      "callbackUpdateId": 2,
      "decision": "allow-once",
      "terminalReason": "user",
      "appliedProposal": "approval-group-proof-20260905-2917eb2617",
      "finalMessageId": 9003,
      "terminalCardButtons": [],
      "providerRequests": 3,
      "gatewayCleanup": "confirmed-stopped",
      "passed": true,
      "gatewayPort": 45547
    }
  ]
}
```

Proof limits: this exercises a real Gateway with the OpenClaw runtime and synthetic Telegram/model APIs. The shared Codex host-tool contract was directly inspected at pinned `rust-v0.153.4`; no live Codex-provider call is claimed. Native Telegram Test Server proof was unavailable because the Convex CLI is absent and this contributor-code lane remains secretless.

The September 5 ClawSweeper review's delivery/callback/result/terminal-card follow-up and the original PR's signed-owner regression request are now addressed by the evidence above.

`git diff --numstat` against the main baseline:

| Classification | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 27 | 43 | -16 |
| Tests | 38 | 0 | +38 |

Named follow-up: **Bind trusted-policy approvals to their registered plugin owner.** The separate registered-policy path in `src/plugins/trusted-tool-policy.ts` forwards an evaluator's optional approval owner, whereas ordinary hooks stamp the registry owner. It needs an external-plugin fixture and signed-boundary proof. No bundled production registrant was found; the core Workshop path repaired here is independent of that API.
