### PR TITLE
feat(ui): add social preview links for private sessions

### DIFF
--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -152,6 +152,48 @@ keeps their panes and drafts separate, including in split view. Continuing a
 thread navigates to the adopted OpenClaw session link. The same catalog query
 also works under `/dashboard/<agentId>`.
 
+## Social previews
+
+Use **Copy → Preview link** in a session's menu to share a link with an OpenClaw
+social card. It opens a small public landing page; **Open dashboard** or
+**Open session** then takes the recipient to the normal authenticated view.
+**Copy → Session link** still copies the direct link.
+
+For example, `/share/dashboard/main/deploy-monitor-6db92d48` previews
+`/dashboard/main/deploy-monitor-6db92d48`. A configured Control UI base path
+prefixes both paths. The preview serves Open Graph metadata and a 1200 × 630 PNG
+at `/share/card.png`, without requiring JavaScript or a Gateway connection.
+
+The card shows generic OpenClaw branding, not the session's title, messages,
+dashboard widgets, or screenshots. Preview requests never look up session state,
+so the page does not reveal whether the target exists. The link itself still
+contains the session route and, for catalog sessions, the catalog routing fields.
+Treat those URLs as information you are choosing to share.
+
+### Behind a login proxy
+
+Link crawlers cannot sign in to your proxy. Allow anonymous `GET` and `HEAD`
+requests **only** to the Control UI's `/share/*` namespace (for example,
+`/openclaw/share/*` for a `/openclaw` base path). Keep the dashboard, WebSocket,
+bootstrap, API, and other routes protected. Do not grant crawlers authenticated
+access based on their User-Agent.
+
+For Cloudflare Access, use a separate application matching that public path with
+a Bypass policy; keep the existing authenticated application for the rest of the
+host. See [Cloudflare's application path rules](https://developers.cloudflare.com/cloudflare-one/access-controls/policies/app-paths/).
+This is an operator deployment step; OpenClaw does not change proxy policies.
+
+Set the existing `gateway.publicOrigin` to your external HTTP(S) origin when TLS
+terminates at the proxy, so the image and canonical URLs use the public HTTPS
+address. Without it, previews use the request's Host and direct connection
+protocol; forwarded headers are not trusted for public preview URLs.
+
+Verify both the preview URL and its `/share/card.png` return `200` without
+cookies, then check that opening the dashboard still requires login. If a chat
+app shows the login page or no image, check for proxy redirects on both preview
+requests. Ordinary dashboard URLs remain protected and do not gain crawler
+access from this feature.
+
 ## Person activity URLs
 
 Open a person's recent sessions with a readable Activity link:

--- a/packages/session-url-contract/src/share.ts
+++ b/packages/session-url-contract/src/share.ts
@@ -39,6 +39,7 @@ export const CONTROL_UI_RESERVED_ROUTE_SEGMENTS: readonly string[] = Object.free
   "profile",
   "sessions",
   "settings",
+  "share",
   "skills",
   "tasks",
   "usage",

--- a/src/gateway/control-ui-share.http.test.ts
+++ b/src/gateway/control-ui-share.http.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import { createServer } from "node:http";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { handleControlUiHttpRequest } from "./control-ui.js";
+
+describe("public Control UI previews", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  it.each(["", "/control"])("serves a private-data-free preview under %s", async (basePath) => {
+    const root = tempDirs.make("openclaw-social-preview-");
+    const cardBytes = fs.readFileSync(path.resolve("ui/public/apple-touch-icon.png"));
+    fs.writeFileSync(path.join(root, "social-card.png"), cardBytes);
+    const server = createServer((req, res) => {
+      void handleControlUiHttpRequest(req, res, {
+        basePath,
+        root: { kind: "resolved", path: root },
+        config: { gateway: { publicOrigin: "https://gateway.example.test" } },
+        auth: { mode: "token", token: "test-only-token", allowTailscale: false },
+      }).then((handled) => {
+        if (!handled) {
+          res.writeHead(404).end();
+        }
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Missing test server address");
+    }
+    const origin = `http://127.0.0.1:${address.port}${basePath}`;
+    try {
+      const route = "/share/dashboard/example/private-name";
+      const response = await fetch(`${origin}${route}?token=secret-value&draft=private-draft`);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/html");
+      const html = await response.text();
+      expect(html).toContain('<meta property="og:title" content="OpenClaw dashboard">');
+      expect(html).toContain(`content="https://gateway.example.test${basePath}/share/card.png"`);
+      expect(html).toContain(`href="${basePath}/dashboard/example/private-name"`);
+      expect(html).not.toMatch(/secret-value|private-draft|<script|openclaw-app/);
+      expect(response.headers.get("content-security-policy")).toContain("default-src 'none'");
+      expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+      const head = await fetch(`${origin}${route}`, { method: "HEAD" });
+      expect(head.status).toBe(200);
+      expect(await head.text()).toBe("");
+      expect(Number(head.headers.get("content-length"))).toBe(Buffer.byteLength(html));
+      const card = await fetch(`${origin}/share/card.png`);
+      expect(card.status).toBe(200);
+      expect(card.headers.get("content-type")).toContain("image/png");
+      const png = Buffer.from(await card.arrayBuffer());
+      expect(png.subarray(0, 8)).toEqual(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
+      expect(png).toEqual(cardBytes);
+      const catalog = await fetch(
+        `${origin}/share/chat/example?catalog=example&host=dev%3Amac&thread=a%22%3E%3Cscript%3E&token=secret-value`,
+      );
+      expect(await catalog.text()).toContain(
+        `href="${basePath}/chat/example?catalog=example&amp;host=dev%3Amac&amp;thread=a%22%3E%3Cscript%3E"`,
+      );
+      const bootstrap = await fetch(`${origin}/control-ui-config.json`);
+      expect(bootstrap.status).toBe(401);
+      const escaped = await fetch(`${origin}/share/chat/example/folder%2Ffile%20name`);
+      expect(escaped.status).toBe(200);
+      expect(await escaped.text()).toContain(
+        `href="${basePath}/chat/example/folder%2Ffile%20name"`,
+      );
+      for (const invalid of [
+        "/share",
+        "/share/api/private",
+        "/share/chat//session",
+        "/share/chat/a/~key",
+        "/share/chat/a/%FF",
+        `/share/chat/a/${"x".repeat(8192)}`,
+      ]) {
+        expect((await fetch(`${origin}${invalid}`)).status, invalid).toBe(404);
+      }
+      expect((await fetch(`${origin}${route}`, { method: "POST" })).status).toBe(404);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/src/gateway/control-ui-share.ts
+++ b/src/gateway/control-ui-share.ts
@@ -1,0 +1,95 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { TLSSocket } from "node:tls";
+import { parseControlUiSessionPath } from "@openclaw/session-url-contract/parse";
+import { escapeHtml } from "../shared/html-escape.js";
+import { isReadHttpMethod, respondNotFound } from "./control-ui-http-utils.js";
+
+/** This namespace contains only public preview documents and their static card. */
+export function isControlUiSharePath(pathname: string, basePath: string): boolean {
+  return pathname === `${basePath}/share` || pathname.startsWith(`${basePath}/share/`);
+}
+
+export function serveControlUiShareDocument(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+  basePath: string,
+  publicOrigin?: string,
+): void {
+  const targetPath = url.pathname.slice(`${basePath}/share`.length);
+  // Reuse the session URL grammar without looking up state, even existence.
+  // Preserve the encoded path: keys may contain escaped slashes or spaces.
+  const session = parseControlUiSessionPath(targetPath);
+  if (!isReadHttpMethod(req.method) || url.href.length > 8192 || !session) {
+    respondNotFound(res);
+    return;
+  }
+  let origin: string;
+  try {
+    const protocol = req.socket instanceof TLSSocket ? "https" : "http";
+    const address = new URL(publicOrigin ?? `${protocol}://${req.headers.host}`);
+    if (
+      !/^https?:$/u.test(address.protocol) ||
+      address.username ||
+      address.password ||
+      address.pathname !== "/" ||
+      address.search ||
+      address.hash
+    ) {
+      respondNotFound(res);
+      return;
+    }
+    origin = address.origin;
+  } catch {
+    respondNotFound(res);
+    return;
+  }
+  const search = new URLSearchParams();
+  const catalogRouting = ["catalog", "host", "thread"].map(
+    (key) => [key, url.searchParams.get(key)] as const,
+  );
+  if (catalogRouting.every(([, value]) => value)) {
+    for (const [key, value] of catalogRouting) {
+      if (value) {
+        search.set(key, value);
+      }
+    }
+  }
+  // Only routing fields survive. Never echo credentials, drafts, or arbitrary query text.
+  const suffix = search.size ? `?${search}` : "";
+  const target = escapeHtml(`${basePath}${targetPath}${suffix}`);
+  const canonical = escapeHtml(`${origin}${url.pathname}${suffix}`);
+  const image = escapeHtml(`${origin}${basePath}/share/card.png`);
+  const title = session.namespace === "dashboard" ? "OpenClaw dashboard" : "OpenClaw session";
+  const description = "Open this shared link in OpenClaw. Access to the session is required.";
+  const body = `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title><meta name="robots" content="noindex, nofollow">
+<meta property="og:type" content="website"><meta property="og:site_name" content="OpenClaw">
+<meta property="og:title" content="${title}"><meta property="og:description" content="${description}">
+<meta property="og:url" content="${canonical}"><meta property="og:image" content="${image}">
+<meta property="og:image:type" content="image/png"><meta property="og:image:width" content="1200"><meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="OpenClaw logo and lobster mascot">
+<meta name="twitter:card" content="summary_large_image">
+<style>
+:root{color-scheme:dark;font-family:system-ui,sans-serif;background:#0b1016;color:#f5f7fa}
+body{margin:0;min-height:100svh;display:grid;place-items:center}main{width:min(680px,calc(100% - 40px));padding:40px 0}
+img{display:block;width:100%;height:auto;border-radius:20px}h1{font-size:clamp(28px,5vw,40px);letter-spacing:-.04em;margin:28px 0 12px}
+p{color:#b2bdc9;line-height:1.6;margin:0 0 28px}a{display:inline-block;border-radius:12px;padding:14px 22px;background:#ff5c50;color:#160b0a;font-weight:700;text-decoration:none}
+a:focus-visible{outline:3px solid #fff;outline-offset:5px}
+</style></head><body><main>
+<img src="${image}" width="1200" height="630" alt="OpenClaw logo and lobster mascot">
+<h1>${title}</h1><p>${description}</p><a href="${target}">Open ${title === "OpenClaw dashboard" ? "dashboard" : "session"}</a>
+</main></body></html>`;
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.setHeader(
+    "Content-Security-Policy",
+    "default-src 'none'; img-src 'self'; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'",
+  );
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("X-Robots-Tag", "noindex, nofollow");
+  res.setHeader("Content-Length", Buffer.byteLength(body));
+  res.end(req.method === "HEAD" ? undefined : body);
+}

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -11,6 +11,7 @@ import {
   type AgentAvatarResolution,
   resolvePublicAgentAvatarSource,
 } from "../agents/identity-avatar.js";
+import { resolveGatewayPublicOrigin } from "../config/gateway-public-origin.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   matchRootFileOpenFailure,
@@ -38,6 +39,7 @@ import {
 import { extractOriginalFilename } from "../media/store.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { AVATAR_MAX_BYTES, resolveAvatarMime } from "../shared/avatar-policy.js";
+import { escapeHtml } from "../shared/html-escape.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveRuntimeServiceBuildId, resolveRuntimeServiceVersion } from "../version.js";
@@ -84,6 +86,7 @@ import {
   isControlUiApprovalDocumentPath,
   isControlUiFocusDocumentPath,
 } from "./control-ui-routing.js";
+import { isControlUiSharePath, serveControlUiShareDocument } from "./control-ui-share.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
 import {
   isControlUiFileUnmodified,
@@ -170,15 +173,6 @@ function rewriteControlUiIndexHtmlAssetHrefs(
     next = next.replaceAll(`href="${buildControlUiRootAssetPath(normalized, asset)}"`, assetHref);
   }
   return next;
-}
-
-function escapeHtmlAttribute(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll("'", "&#39;");
 }
 
 type ControlUiAvatarMeta = {
@@ -851,16 +845,16 @@ async function serveResolvedIndexHtml(
   const withBasePath = rewriteControlUiIndexHtmlAssetHrefs(body, normalizedBasePath, buildId);
   // An empty base path is authoritative for Gateway resources even when the
   // router infers a namespace. Always emit it so resources stay root-mounted.
-  const basePathAttribute = ` ${CONTROL_UI_BASE_PATH_ATTRIBUTE}="${escapeHtmlAttribute(normalizedBasePath)}"`;
+  const basePathAttribute = ` ${CONTROL_UI_BASE_PATH_ATTRIBUTE}="${escapeHtml(normalizedBasePath)}"`;
   const environmentAttributes = environment
-    ? ` ${CONTROL_UI_ENVIRONMENT_ATTRIBUTE}="${escapeHtmlAttribute(JSON.stringify(environment))}"`
+    ? ` ${CONTROL_UI_ENVIRONMENT_ATTRIBUTE}="${escapeHtml(JSON.stringify(environment))}"`
     : "";
   // Let the app initialize fail-closed without guessing whether this document
   // was served with the terminal's WASM CSP allowance.
   // The lifecycle owns bundled identity. Strip the build stamp for custom roots,
   // whose files may change independently and must keep revalidating.
   const buildAttribute = buildId
-    ? ` ${CONTROL_UI_BUILD_ID_ATTRIBUTE}="${escapeHtmlAttribute(buildId)}"`
+    ? ` ${CONTROL_UI_BUILD_ID_ATTRIBUTE}="${escapeHtml(buildId)}"`
     : "";
   const prepared = withBasePath.replace(/<html\b[^>]*>/i, (tag) =>
     tag
@@ -1035,6 +1029,11 @@ export async function handleControlUiHttpRequest(
 
   applyControlUiSecurityHeaders(res);
 
+  if (isControlUiSharePath(pathname, basePath) && pathname !== `${basePath}/share/card.png`) {
+    serveControlUiShareDocument(req, res, url, basePath, resolveGatewayPublicOrigin(opts?.config));
+    return true;
+  }
+
   if (matchesControlUiBootstrapConfigPath(pathname, basePath)) {
     let pluginFrameGrants: readonly ControlUiPluginFrameGrantAck[] = [];
     if (
@@ -1161,6 +1160,9 @@ export async function handleControlUiHttpRequest(
     isControlUiApprovalDocumentPath({ basePath, pathname }) ||
     isControlUiFocusDocumentPath({ basePath, pathname });
   const rel = (() => {
+    if (uiPath === "/share/card.png") {
+      return "social-card.png";
+    }
     if (uiPath === ROOT_PREFIX) {
       return "";
     }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -34,6 +34,7 @@ import {
   isControlUiFocusDocumentPath,
   isControlUiPluginManagerRequest,
 } from "./control-ui-routing.js";
+import { isControlUiSharePath } from "./control-ui-share.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
 import type { ControlUiRootState } from "./control-ui.js";
 import {
@@ -556,7 +557,10 @@ export function createGatewayHttpServer(opts: {
         basePath: controlUiBasePath,
         pathname: scopedRequestPath,
       });
-      addRequestStage(approvalDocument, handleStandaloneControlUiRequest);
+      addRequestStage(
+        approvalDocument || isControlUiSharePath(scopedRequestPath, controlUiRouteBasePath),
+        handleStandaloneControlUiRequest,
+      );
       addRequestStage(Boolean(nodeCapability), async () => {
         const { authorizePluginNodeCapabilityRequest } = await getPluginNodeCapabilityAuthModule();
         const ok = await authorizePluginNodeCapabilityRequest({

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -216,6 +216,35 @@ describe("gateway plugin HTTP auth boundary", () => {
     await import("./control-ui.js");
   });
 
+  test.each([true, false])(
+    "reserves public preview routes ahead of plugins (UI enabled: %s)",
+    async (controlUiEnabled) => {
+      const plugin = vi.fn(async (_req: IncomingMessage, res: ServerResponse) => {
+        res.end("plugin-owned");
+        return true;
+      });
+      await withGatewayServer({
+        prefix: "openclaw-public-preview-",
+        resolvedAuth: AUTH_TOKEN,
+        overrides: { controlUiEnabled, controlUiBasePath: "/control", handlePluginRequest: plugin },
+        run: async (server) => {
+          const response = await sendRequest(server, {
+            path: "/control/share/dashboard/example/session",
+            host: "gateway.example.test",
+          });
+          expect(response.res.statusCode).toBe(controlUiEnabled ? 200 : 404);
+          expect(response.getBody()).toContain(
+            controlUiEnabled ? 'content="OpenClaw dashboard"' : "Not Found",
+          );
+          for (const route of ["/control/share", "/control/share/api/private"]) {
+            expect((await sendRequest(server, { path: route })).res.statusCode).toBe(404);
+          }
+          expect(plugin).not.toHaveBeenCalled();
+        },
+      });
+    },
+  );
+
   test("serves unauthenticated liveness/readiness probe routes when no other route handles them", async () => {
     await withGatewayServer({
       prefix: "openclaw-plugin-http-probes-test-",

--- a/ui/config/control-ui-social-card.ts
+++ b/ui/config/control-ui-social-card.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import { PhotonImage, resize, SamplingFilter, watermark } from "@silvia-odwyer/photon-node";
+import type { Plugin } from "vite";
+
+/** Generate the public card from the existing brand artwork, without a browser or fonts. */
+export function controlUiSocialCardPlugin(): Plugin {
+  return {
+    name: "control-ui-social-card",
+    apply: "build",
+    buildStart() {
+      const pixels = Buffer.alloc(1200 * 630 * 4, Buffer.from([11, 16, 22, 255]));
+      const canvas = new PhotonImage(pixels, 1200, 630);
+      const images = [canvas];
+      try {
+        const source = PhotonImage.new_from_byteslice(
+          fs.readFileSync(new URL("../../docs/assets/openclaw-hero-dark.png", import.meta.url)),
+        );
+        images.push(source);
+        const logo = resize(source, 1060, 376, SamplingFilter.Lanczos3);
+        images.push(logo);
+        watermark(canvas, logo, 70n, 127n);
+        this.emitFile({ type: "asset", fileName: "social-card.png", source: canvas.get_bytes() });
+      } finally {
+        for (const image of images) {
+          image.free();
+        }
+      }
+    },
+  };
+}

--- a/ui/src/app-route-paths.test.ts
+++ b/ui/src/app-route-paths.test.ts
@@ -132,6 +132,7 @@ describe("Dynamic route startup bridge", () => {
     const reservedRouteSegments = [
       ...new Set([
         "focus",
+        "share",
         ...Object.values(CONTROL_UI_DOCUMENT_ROUTE_PATHS).map((path) => path.slice(1)),
         ...APP_ROUTE_IDS.flatMap((routeId) => {
           const definition = routePageSpec(routeId);

--- a/ui/src/components/session-menu-actions.ts
+++ b/ui/src/components/session-menu-actions.ts
@@ -32,6 +32,7 @@ export type SessionManagementAction =
   | { kind: "open-in"; editor: EditorId; path: string }
   | { kind: "copy-session-id" }
   | { kind: "copy-session-link" }
+  | { kind: "copy-session-preview-link" }
   | { kind: "copy-markdown" }
   | { kind: "open-new-tab" }
   | { kind: "open-new-window" }
@@ -126,6 +127,7 @@ export class SessionMenuActions {
       case "open-in":
         return batch || !state.worktreePath;
       case "copy-session-link":
+      case "copy-session-preview-link":
       case "open-new-tab":
       case "open-new-window":
         return batch || !state.navigationAllowed;
@@ -184,6 +186,7 @@ export class SessionMenuActions {
     if (
       value === "copy-session-id" ||
       value === "copy-session-link" ||
+      value === "copy-session-preview-link" ||
       value === "copy-markdown" ||
       value === "open-new-tab" ||
       value === "open-new-window" ||
@@ -508,9 +511,20 @@ export class SessionMenuActions {
     return html`
       ${
         state.navigationAllowed
-          ? this.renderItem("copy-session-link", t("sessionsView.copySessionLink"), icons.link, {
-              inline,
-            })
+          ? html`
+              ${this.renderItem(
+                "copy-session-link",
+                t("sessionsView.copySessionLink"),
+                icons.link,
+                { inline },
+              )}
+              ${this.renderItem(
+                "copy-session-preview-link",
+                t("sessionsView.copySessionPreviewLink"),
+                icons.link,
+                { inline },
+              )}
+            `
           : nothing
       }
       ${this.renderItem("copy-markdown", t("sessionsView.copyMarkdown"), icons.fileText, {

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -384,7 +384,7 @@ describe("session menu", () => {
 
     for (const [view, labels] of [
       ["open-in", ["Back", "New tab", "New window", "Cursor", "VS Code", "Windsurf", "Zed"]],
-      ["copy", ["Back", "Session link", "Conversation as Markdown", "Session ID"]],
+      ["copy", ["Back", "Session link", "Preview link", "Conversation as Markdown", "Session ID"]],
       ["assign-owner", ["Back", "Me", "Research owner"]],
       ["icon", ["Back"]],
       ["group", ["Back", "Research", "Operations", "New group"]],
@@ -553,6 +553,7 @@ describe("session menu", () => {
     expect(copyGroup.getAttribute("aria-keyshortcuts")).toBe("C");
     expect(menuItemLabels(copyGroup)).toEqual([
       "Session link",
+      "Preview link",
       "Conversation as Markdown",
       "Session ID",
     ]);
@@ -588,6 +589,7 @@ describe("session menu", () => {
     for (const kind of [
       "copy-session-id",
       "copy-session-link",
+      "copy-session-preview-link",
       "copy-markdown",
       "open-new-tab",
       "open-new-window",

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -306,6 +306,7 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
               break;
             case "copy-session-id":
             case "copy-session-link":
+            case "copy-session-preview-link":
             case "copy-markdown":
             case "open-new-tab":
             case "open-new-window":

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1286,6 +1286,7 @@ export const en: TranslationMap & {
     forkedSession: "Forked session",
     copySessionId: "Session ID",
     copySessionLink: "Session link",
+    copySessionPreviewLink: "Preview link",
     copyMarkdown: "Conversation as Markdown",
     openNewTab: "New tab",
     openNewWindow: "New window",

--- a/ui/src/lib/sessions/session-menu-navigation.test.ts
+++ b/ui/src/lib/sessions/session-menu-navigation.test.ts
@@ -61,14 +61,17 @@ afterEach(() => {
 });
 
 describe("session menu navigation actions", () => {
-  it("copies an exact session link with the stored face and deployment prefix", async () => {
+  it.each([
+    ["copy-session-link", "/control"],
+    ["copy-session-preview-link", "/control/share"],
+  ] as const)("copies %s with the stored face and deployment prefix", async (kind, basePath) => {
     const { params } = fixture();
-    await runSessionNavigationAction("copy-session-link", params);
+    await runSessionNavigationAction(kind, params);
     const copied = vi.mocked(copyToClipboard).mock.calls[0]?.[0];
     const url = new URL(copied!);
     expect(url.origin).toBe(window.location.origin);
     expect(url.pathname).toBe(
-      "/control/dashboard/research/dashboard/12345678-90ab-cdef-1234-567890abcdef",
+      `${basePath}/dashboard/research/dashboard/12345678-90ab-cdef-1234-567890abcdef`,
     );
     expect(url.search).toBe("");
     expect(url.hash).toBe("");
@@ -100,6 +103,27 @@ describe("session menu navigation actions", () => {
     await runSessionNavigationAction("copy-session-link", params);
     expect(copyToClipboard).toHaveBeenCalledWith(
       `${base}/dashboard/research/dashboard/12345678-90ab-cdef-1234-567890abcdef`,
+    );
+    await runSessionNavigationAction("copy-session-preview-link", params);
+    expect(copyToClipboard).toHaveBeenLastCalledWith(
+      `${base}/share/dashboard/research/dashboard/12345678-90ab-cdef-1234-567890abcdef`,
+    );
+  });
+
+  it("keeps the catalog target in preview links without copying connection credentials", async () => {
+    const { params } = fixture();
+    params.session = {
+      key: "agent:research:catalog:codex:dev%3Amac:thread%2F123",
+      sessionId: "catalog-session",
+    };
+    Object.assign(params.context.gateway.snapshot.hello!, {
+      controlUiUrl: "https://gateway.example.test/remote?token=secret#private",
+    });
+
+    await runSessionNavigationAction("copy-session-preview-link", params);
+
+    expect(copyToClipboard).toHaveBeenCalledWith(
+      "https://gateway.example.test/remote/share/chat/research?catalog=codex&host=dev%3Amac&thread=thread%2F123",
     );
   });
 

--- a/ui/src/lib/sessions/session-menu-navigation.ts
+++ b/ui/src/lib/sessions/session-menu-navigation.ts
@@ -1,4 +1,5 @@
 import type { GatewaySessionRow } from "../../api/types.ts";
+import { normalizeBasePath } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
 import { UI_COMMAND_EVENT } from "../../components/panel-toggle-contract.ts";
@@ -22,6 +23,7 @@ import { parseAgentSessionKey } from "./session-key.ts";
 type SessionNavigationActionKind =
   | "copy-session-id"
   | "copy-session-link"
+  | "copy-session-preview-link"
   | "copy-markdown"
   | "open-new-tab"
   | "open-new-window"
@@ -182,26 +184,28 @@ export async function runSessionNavigationAction<TRouteId extends string>(
       params.agentId,
     );
     const gateway = params.context.gateway;
+    const copyLink = kind === "copy-session-link" || kind === "copy-session-preview-link";
     // Shared links belong to the Gateway; the UI document may be a local SSH
     // tunnel or a dev server with a different mount path. New windows stay local.
-    const linkBase =
-      kind === "copy-session-link"
-        ? (gateway.snapshot.hello?.controlUiUrl ??
-          gateway.snapshot.client?.gatewayUrl ??
-          gateway.connection.gatewayUrl)
-        : undefined;
+    const linkBase = copyLink
+      ? (gateway.snapshot.hello?.controlUiUrl ??
+        gateway.snapshot.client?.gatewayUrl ??
+        gateway.connection.gatewayUrl)
+      : undefined;
     const url = new URL(linkBase || window.location.href);
     url.protocol = url.protocol.replace(/^ws/u, "http");
+    const basePath = linkBase ? url.pathname : params.context.basePath;
     const navigation = sessionNavigationTarget({
       context: params.context,
-      basePath: linkBase ? url.pathname : undefined,
+      basePath:
+        kind === "copy-session-preview-link" ? `${normalizeBasePath(basePath)}/share` : basePath,
       face,
       sessionKey: params.session.key,
       agentId: params.agentId,
       exactKey: true,
     });
     const href = new URL(navigation.href, url.origin).href;
-    if (kind === "copy-session-link") {
+    if (copyLink) {
       const copied = await copyToClipboard(href);
       showToast({ message: t(copied ? "common.copied" : "common.copyFailed") });
       return;

--- a/ui/src/pages/chat/chat-pane-session-menu.ts
+++ b/ui/src/pages/chat/chat-pane-session-menu.ts
@@ -72,6 +72,7 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
     if (
       action.kind === "copy-session-id" ||
       action.kind === "copy-session-link" ||
+      action.kind === "copy-session-preview-link" ||
       action.kind === "copy-markdown" ||
       action.kind === "open-new-tab" ||
       action.kind === "open-new-window" ||

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -322,6 +322,7 @@ describe("chat header session menu", () => {
     menu.querySelector<HTMLButtonElement>(".session-menu__icon-remove")?.click();
     for (const value of [
       "copy-session-link",
+      "copy-session-preview-link",
       "copy-markdown",
       "copy-session-id",
       "open-new-tab",
@@ -340,6 +341,7 @@ describe("chat header session menu", () => {
       [{ kind: "set-color", color: "purple" }],
       [{ kind: "reset-appearance" }],
       [{ kind: "copy-session-link" }],
+      [{ kind: "copy-session-preview-link" }],
       [{ kind: "copy-markdown" }],
       [{ kind: "copy-session-id" }],
       [{ kind: "open-new-tab" }],
@@ -549,7 +551,7 @@ describe("chat header session menu", () => {
     await menu.updateComplete;
     expect(
       Array.from(menu.querySelectorAll(":scope > wa-dropdown > wa-dropdown-item")).map(itemLabel),
-    ).toEqual(["Back", "Session link", "Conversation as Markdown", "Session ID"]);
+    ).toEqual(["Back", "Session link", "Preview link", "Conversation as Markdown", "Session ID"]);
     select(menu, "compact:back");
     await menu.updateComplete;
     select(menu, "compact:open-open-in");
@@ -689,6 +691,7 @@ describe("chat header session menu", () => {
     expect(item(menu, "Conversation as Markdown").disabled).toBe(true);
     for (const kind of [
       "copy-session-link",
+      "copy-session-preview-link",
       "copy-markdown",
       "open-new-tab",
       "open-new-window",

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -1493,6 +1493,7 @@ class SessionsPage extends OpenClawLightDomElement {
               break;
             case "copy-session-id":
             case "copy-session-link":
+            case "copy-session-preview-link":
             case "copy-markdown":
             case "open-new-tab":
             case "open-new-window":

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -18,6 +18,7 @@ import { CONTROL_UI_BUILD_ID_ATTRIBUTE } from "../src/gateway/control-ui-root-as
 import { controlUiCodeSplitting } from "./config/control-ui-chunking.ts";
 import { controlUiHoverGuardPlugin } from "./config/control-ui-hover-guard.ts";
 import { controlUiLocaleModulesPlugin } from "./config/control-ui-locales.ts";
+import { controlUiSocialCardPlugin } from "./config/control-ui-social-card.ts";
 import { normalizeControlUiBuildInfo } from "./src/build-info-normalizers.ts";
 import type { ControlUiBuildInfo } from "./src/build-info.ts";
 
@@ -614,6 +615,7 @@ export default function controlUiViteConfig(options: { outDir?: string } = {}): 
       strictPort: true,
     },
     plugins: [
+      controlUiSocialCardPlugin(),
       controlUiLocaleModulesPlugin(),
       controlUiBrowserOnlySharedModuleAliases(),
       controlUiPrecompressedAssetsPlugin(buildOutDir),


### PR DESCRIPTION
## What Problem This Solves

Private session and dashboard URLs cannot produce useful social previews when link crawlers are redirected to a login page. Simply adding metadata inside the authenticated app would not make it reachable.

## Why This Change Was Made

Adds a separate public preview document under the Control UI's `/share/` namespace. It serves generic OpenClaw Open Graph metadata and a 1200 × 630 PNG, then links to the normal authenticated session or dashboard. Preview requests never look up session state, including whether the target exists. The card is generated at build time from existing OpenClaw artwork with the existing image library; there are no new dependencies, configuration keys, database changes, or runtime image-rendering jobs.

## User Impact

**Copy → Preview link** is available in the sidebar, session list, and chat-header menus. It reuses the Gateway's public address, preserves deployment base paths, exact session keys, and catalog routing, and excludes connection credentials. **Copy → Session link** retains its existing direct-link behavior.

The preview contains no session title, messages, widget contents, or screenshot. The URL still contains its routing identifiers. Opening the session still requires normal Gateway access.

Operators using Cloudflare Access or another login proxy must expose only the preview namespace and card image, while keeping the app, WebSocket, bootstrap, and API routes protected. The existing `gateway.publicOrigin` supplies the public HTTPS origin behind TLS termination. Setup and verification are documented in `docs/web/urls.md`; this PR does not modify deployment access policies.

## Evidence

- Focused UI/navigation suite: 143 tests passed.
- Gateway HTTP/routing suite: 37 tests passed, including public preview isolation, disabled UI, and plugin route precedence.
- Real browser with a synthetic Gateway fixture: Copy → Preview link copied `/share/chat/main/preview-example`; a separate JavaScript-disabled context rendered the preview and retained `/chat/main/preview-example` as its destination.
- Real HTTP tests independently verify that private bootstrap requests return 401; the browser's Gateway fixture is mocked.
- HTTP coverage preserves encoded slashes and spaces in session keys under both root and nested mounts, using the existing session URL parser.
- `pnpm build ciArtifacts` passed, including runtime/plugin builds, SDK declaration/export checks, and the UI build. Independent P0–P2 review is clean. The full changed-file gate passed, including core/test/UI type checks, lint, and repository guards.

The initial full build was invalidated by source changes during compilation; it is not counted as a successful build. The final CI-artifact build passed on frozen sources. The first changed-file run found two implicit Promise-executor returns in the HTTP test; those were corrected, and the complete gate passed on rerun.

| Copy menu (synthetic session) | Public preview, JavaScript disabled |
| --- | --- |
| ![Copy preview link menu](https://github.com/user-attachments/assets/4e286256-1beb-4f8e-b59e-2367f35bb665) | ![Public session preview](https://github.com/user-attachments/assets/4ccb34e9-5465-47ae-a632-909a700591aa) |

Production/build delta: +156 lines; tests: +146 lines; docs: +42 lines. The growth adds the public document/card and menu action; the Gateway now reuses the shared HTML escaping helper instead of maintaining its own copy.

Focused commands:

```sh
node scripts/run-vitest.mjs src/gateway/control-ui-share.http.test.ts src/gateway/server.plugin-http-auth.test.ts
node scripts/run-vitest.mjs ui/src/lib/sessions/session-menu-navigation.test.ts ui/src/components/session-menu.test.ts ui/src/pages/chat/components/chat-header-session-menu.test.ts ui/src/app-route-paths.test.ts
pnpm build ciArtifacts
env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs
```

Live Discord/Slack/X unfurl rendering remains a deployment check: it requires the public preview path to be enabled at the proxy. Local verification exercises the HTTP responses consumed by crawlers and the browser copy/open flow.
