### PR TITLE
fix(workers): avoid session stalls behind slow cloud provisioning

### DIFF
--- a/src/gateway/worker-environments/placement-dispatch-coordinator-admission.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator-admission.test.ts
@@ -1,0 +1,167 @@
+import { setImmediate as setImmediatePromise } from "node:timers/promises";
+import { describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { coordinateWorkerPlacementDispatch } from "./placement-dispatch-coordinator.js";
+import {
+  ACTIVE_PLACEMENT,
+  admittedRecovery,
+  createCoordinatorTestService,
+  LOCAL_PLACEMENT,
+  MOVE_REQUEST,
+  PROVISIONING_PLACEMENT,
+  REQUEST,
+} from "./placement-dispatch-coordinator.test-support.js";
+import type { WorkerPlacementDispatchRequest } from "./service-contract.js";
+
+describe("worker placement maintenance admission", () => {
+  it.each(["full", "targeted", "recovery"] as const)(
+    "bounds dispatch joins to the original provider cohort before %s maintenance",
+    async (kind) => {
+      const cloudStarted = createDeferredCore();
+      const releaseCloud = createDeferredCore();
+      const releaseMac = createDeferredCore();
+      const maintenanceStarted = createDeferredCore();
+      const releaseMaintenance = createDeferredCore();
+      const dispatch = vi.fn(async (request: WorkerPlacementDispatchRequest) => {
+        if (request.sessionId === "cloud") {
+          cloudStarted.resolve();
+          await releaseCloud.promise;
+        } else if (request.sessionId === REQUEST.sessionId) {
+          await releaseMac.promise;
+        }
+        return { ...ACTIVE_PLACEMENT, ...request };
+      });
+      const maintain = async () => {
+        maintenanceStarted.resolve();
+        await releaseMaintenance.promise;
+      };
+      const service = createCoordinatorTestService({
+        dispatch,
+        reconcileActive: maintain,
+        resumeProvisioning: admittedRecovery(maintain),
+      });
+      const coordinated = coordinateWorkerPlacementDispatch(service, (_request, run) => run());
+      const cloud = coordinated.dispatch({ ...REQUEST, sessionId: "cloud" });
+      await cloudStarted.promise;
+      const maintenance =
+        kind === "recovery"
+          ? coordinated.resumeProvisioning(PROVISIONING_PLACEMENT, async () => {})
+          : coordinated.reconcileActive(kind === "targeted" ? "worker-target" : undefined);
+      const mac = coordinated.dispatch(REQUEST);
+      let callsBeforeCloudSettled: string[];
+      let late: Promise<unknown> | undefined;
+      let third: Promise<unknown> | undefined;
+      let laterMaintenance: Promise<unknown> | undefined;
+      try {
+        await setImmediatePromise();
+        callsBeforeCloudSettled = dispatch.mock.calls.map(([request]) => request.sessionId);
+        releaseCloud.resolve();
+        await cloud;
+        laterMaintenance = coordinated.reconcileActive("worker-later");
+        third = coordinated.dispatch({ ...REQUEST, sessionId: "third" });
+        await setImmediatePromise();
+        expect(dispatch.mock.calls.some(([request]) => request.sessionId === "third")).toBe(false);
+        releaseMac.resolve();
+        await maintenanceStarted.promise;
+        late = coordinated.dispatch({ ...REQUEST, sessionId: "late" });
+        await setImmediatePromise();
+        expect(dispatch.mock.calls.some(([request]) => request.sessionId === "late")).toBe(false);
+      } finally {
+        releaseCloud.resolve();
+        releaseMac.resolve();
+        releaseMaintenance.resolve();
+        await Promise.all([cloud, maintenance, mac, third, laterMaintenance, late]);
+      }
+      expect(callsBeforeCloudSettled).toEqual(["cloud", REQUEST.sessionId]);
+    },
+  );
+
+  it.each(
+    [
+      { kind: "move", order: "before" },
+      { kind: "move", order: "after" },
+      { kind: "reclaim", order: "before" },
+      { kind: "reclaim", order: "after" },
+      { kind: "destroy", order: "before" },
+      { kind: "destroy", order: "after" },
+    ].flatMap(({ kind, order }) =>
+      ["sweep", "recovery"].map((maintenanceKind) => ({ kind, order, maintenanceKind })),
+    ),
+  )(
+    "a queued $kind closes dispatch admission $order pending $maintenanceKind",
+    async ({ kind, order, maintenanceKind }) => {
+      const cloudStarted = createDeferredCore();
+      const releaseCloud = createDeferredCore();
+      const exclusiveStarted = createDeferredCore();
+      const releaseExclusive = createDeferredCore();
+      const destroyError = new Error("Provider teardown failed");
+      const dispatch = vi.fn(async (request: WorkerPlacementDispatchRequest) => {
+        if (request.sessionId === "cloud") {
+          cloudStarted.resolve();
+          await releaseCloud.promise;
+        }
+        return { ...ACTIVE_PLACEMENT, ...request };
+      });
+      const exclusive = async () => {
+        exclusiveStarted.resolve();
+        await releaseExclusive.promise;
+        return LOCAL_PLACEMENT;
+      };
+      const service = createCoordinatorTestService({
+        dispatch,
+        move: exclusive,
+        reclaim: async (_request, _authorize, _beforeDrain, serialize) => {
+          if (!serialize) {
+            throw new Error("Reclaim fixture requires the placement fence");
+          }
+          return await serialize(exclusive);
+        },
+        forceDestroyEnvironment: async () => {
+          await exclusive();
+          throw destroyError;
+        },
+        reconcileActive: async () => {},
+        resumeProvisioning: admittedRecovery(async () => {}),
+      });
+      const coordinated = coordinateWorkerPlacementDispatch(service, (_request, run) => run());
+      const maintain = () =>
+        maintenanceKind === "sweep"
+          ? coordinated.reconcileActive()
+          : coordinated.resumeProvisioning(PROVISIONING_PLACEMENT, async () => {});
+      const cloud = coordinated.dispatch({ ...REQUEST, sessionId: "cloud" });
+      await cloudStarted.promise;
+      let maintenance = order === "after" ? maintain() : undefined;
+      const hard =
+        kind === "move"
+          ? coordinated.move(MOVE_REQUEST)
+          : kind === "reclaim"
+            ? coordinated.reclaim(REQUEST)
+            : coordinated.forceDestroyEnvironment("worker-exclusive").then(
+                () => {
+                  throw new Error("Expected teardown failure");
+                },
+                (error: unknown) => expect(error).toBe(destroyError),
+              );
+      // Move admission yields before it reserves its placement fence.
+      await setImmediatePromise();
+      maintenance ??= maintain();
+      const later = coordinated.dispatch({ ...REQUEST, sessionId: "unrelated" });
+      try {
+        await setImmediatePromise();
+        expect(dispatch.mock.calls.map(([request]) => request.sessionId)).toEqual(["cloud"]);
+        releaseCloud.resolve();
+        await exclusiveStarted.promise;
+        await setImmediatePromise();
+        expect(dispatch.mock.calls.map(([request]) => request.sessionId)).toEqual(["cloud"]);
+      } finally {
+        releaseCloud.resolve();
+        releaseExclusive.resolve();
+        await Promise.all([cloud, maintenance, hard, later]);
+      }
+      expect(dispatch.mock.calls.map(([request]) => request.sessionId)).toEqual([
+        "cloud",
+        "unrelated",
+      ]);
+    },
+  );
+});

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.test-support.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.test-support.ts
@@ -1,0 +1,103 @@
+import type { WorkerDispatchPlacement } from "./placement-dispatch-failure.js";
+import type { WorkerPlacementDispatchService } from "./placement-dispatch.js";
+import type {
+  WorkerPlacementDispatchRequest,
+  WorkerPlacementMoveRequest,
+} from "./service-contract.js";
+
+type DispatchService = WorkerPlacementDispatchService;
+
+export function admittedRecovery(
+  run: (
+    placement: Parameters<DispatchService["resumeProvisioning"]>[0],
+    core: Parameters<DispatchService["resumeProvisioning"]>[1],
+  ) => Promise<void>,
+): DispatchService["resumeProvisioning"] {
+  return async (placement, core, _onTransition, admit) => {
+    if (!admit) {
+      throw new Error("Recovery fixture requires the coordinator admission owner");
+    }
+    return await admit(async (signal) => {
+      await run(placement, async () => await core(signal));
+      return undefined;
+    });
+  };
+}
+
+export function preparedReclaim(run: () => Promise<unknown>) {
+  return async (
+    _request: unknown,
+    _authorize: unknown,
+    _beforeDrain: unknown,
+    serialize: (operation: () => Promise<unknown>) => Promise<unknown>,
+  ) => await serialize(run);
+}
+
+export const REQUEST: WorkerPlacementDispatchRequest = {
+  sessionId: "session-1",
+  sessionKey: "agent:main:session-1",
+  agentId: "main",
+  profileId: "test",
+  executionMode: "worker-turn",
+};
+
+export const MOVE_REQUEST: WorkerPlacementMoveRequest = {
+  sessionId: REQUEST.sessionId,
+  sessionKey: REQUEST.sessionKey,
+  agentId: REQUEST.agentId,
+  source: { generation: 4, environmentId: "worker-source", ownerEpoch: 7 },
+  target: { kind: "gateway" },
+};
+
+export const LOCAL_PLACEMENT = {
+  ...REQUEST,
+  state: "local",
+  generation: 1,
+  turnClaim: null,
+  createdAtMs: 1,
+  updatedAtMs: 1,
+  stateChangedAtMs: 1,
+  environmentId: null,
+  activeOwnerEpoch: null,
+  workspaceBaseManifestRef: null,
+  remoteWorkspaceDir: null,
+  workerBundleHash: null,
+  lastTranscriptAckCursor: null,
+  lastLiveEventAckCursor: null,
+  recoveryError: null,
+  terminalReason: null,
+  terminalAtMs: null,
+} satisfies WorkerDispatchPlacement;
+
+export const PROVISIONING_PLACEMENT = {
+  ...LOCAL_PLACEMENT,
+  state: "provisioning",
+  sessionId: "cloud",
+  environmentId: "worker-cloud",
+} satisfies Parameters<DispatchService["resumeProvisioning"]>[0];
+
+export const ACTIVE_PLACEMENT = {
+  ...LOCAL_PLACEMENT,
+  state: "active",
+  environmentId: "worker-active",
+  activeOwnerEpoch: 1,
+  workspaceBaseManifestRef: "manifest",
+  remoteWorkspaceDir: "/worker/workspace",
+  workerBundleHash: "bundle",
+} satisfies Awaited<ReturnType<DispatchService["dispatch"]>>;
+
+export function createCoordinatorTestService(overrides: Partial<DispatchService>): DispatchService {
+  const unexpected = async (): Promise<never> => {
+    throw new Error("Unexpected placement fixture operation");
+  };
+  return {
+    dispatch: unexpected,
+    move: unexpected,
+    reclaim: unexpected,
+    forceDestroyEnvironment: unexpected,
+    reconcile: unexpected,
+    reconcileActive: unexpected,
+    resumeProvisioning: unexpected,
+    ...overrides,
+  };
+}

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
@@ -6,55 +6,16 @@ import {
 } from "../../sessions/session-lifecycle-admission.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { coordinateWorkerPlacementDispatch } from "./placement-dispatch-coordinator.js";
+import {
+  admittedRecovery,
+  MOVE_REQUEST,
+  preparedReclaim,
+  REQUEST,
+} from "./placement-dispatch-coordinator.test-support.js";
 import type { WorkerPlacementDispatchService } from "./placement-dispatch.js";
-import type {
-  WorkerPlacementDispatchRequest,
-  WorkerPlacementMoveRequest,
-} from "./service-contract.js";
+import type { WorkerPlacementDispatchRequest } from "./service-contract.js";
 
 type DispatchService = WorkerPlacementDispatchService;
-
-function admittedRecovery(
-  run: (
-    placement: Parameters<DispatchService["resumeProvisioning"]>[0],
-    core: Parameters<DispatchService["resumeProvisioning"]>[1],
-  ) => Promise<void>,
-): DispatchService["resumeProvisioning"] {
-  return async (placement, core, _onTransition, admit) => {
-    if (!admit) {
-      throw new Error("Recovery fixture requires the coordinator admission owner");
-    }
-    return await admit(async (signal) => {
-      await run(placement, async () => await core(signal));
-      return undefined;
-    });
-  };
-}
-
-function preparedReclaim(run: () => Promise<unknown>) {
-  return async (
-    _request: unknown,
-    _authorize: unknown,
-    _beforeDrain: unknown,
-    serialize: (operation: () => Promise<unknown>) => Promise<unknown>,
-  ) => await serialize(run);
-}
-
-const REQUEST: WorkerPlacementDispatchRequest = {
-  sessionId: "session-1",
-  sessionKey: "agent:main:session-1",
-  agentId: "main",
-  profileId: "test",
-  executionMode: "worker-turn",
-};
-
-const MOVE_REQUEST: WorkerPlacementMoveRequest = {
-  sessionId: REQUEST.sessionId,
-  sessionKey: REQUEST.sessionKey,
-  agentId: REQUEST.agentId,
-  source: { generation: 4, environmentId: "worker-source", ownerEpoch: 7 },
-  target: { kind: "gateway" },
-};
 
 describe("worker placement dispatch coordinator", () => {
   it.each([

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.ts
@@ -48,14 +48,14 @@ export function coordinateWorkerPlacementDispatch(
 ): WorkerPlacementDispatchService & {
   isPlacementOperationInFlight(sessionId: string): boolean;
 } {
-  type PlacementFence = { promise: Promise<void> };
+  type PlacementFence = { promise: Promise<void>; dispatchCohort: readonly symbol[] };
   type ReconciliationSweep = PlacementFence & {
     predecessor: PlacementFence | undefined;
     full: boolean;
     acceptingJoins: boolean;
     joinedRecoveries: Set<Promise<void>>;
   };
-  let activeDispatchCount = 0;
+  const activeDispatches = new Set<symbol>();
   let placementFence: PlacementFence | undefined;
   // A sweep can join an environment pass that began before the sweep. Keep its predecessor
   // separate from the fence tail so recovery waits for older exclusive work, never the sweep
@@ -63,7 +63,7 @@ export function coordinateWorkerPlacementDispatch(
   const reconciliationSweeps = new Set<ReconciliationSweep>();
   const dispatchIdleWaiters = new Set<() => void>();
   const waitForDispatchIdle = (): Promise<void> => {
-    if (activeDispatchCount === 0) {
+    if (activeDispatches.size === 0) {
       return Promise.resolve();
     }
     return new Promise<void>((resolve) => {
@@ -78,6 +78,7 @@ export function coordinateWorkerPlacementDispatch(
     const predecessor = placementFence;
     const sweep: ReconciliationSweep = {
       predecessor,
+      dispatchCohort: predecessor?.dispatchCohort ?? [...activeDispatches],
       full,
       promise: Promise.resolve(),
       acceptingJoins: true,
@@ -108,11 +109,12 @@ export function coordinateWorkerPlacementDispatch(
   const runExclusivePlacementOperation = <T>(
     operation: () => Promise<T>,
     signal?: AbortSignal,
+    joinsActiveDispatch = false,
   ): Promise<T> => {
+    const predecessor = placementFence;
     const ready = (async () => {
-      const pendingFence = placementFence;
-      if (pendingFence) {
-        await pendingFence.promise.catch(() => undefined);
+      if (predecessor) {
+        await predecessor.promise.catch(() => undefined);
       }
       await waitForDispatchIdle();
     })();
@@ -124,7 +126,12 @@ export function coordinateWorkerPlacementDispatch(
     // A canceled waiter releases its admission immediately, but its fence must still
     // carry older work forward so later requests cannot overtake the predecessor.
     const barrier = Promise.allSettled([ready, current]).then(() => undefined);
-    const exclusive: PlacementFence = { promise: barrier };
+    const exclusive: PlacementFence = {
+      promise: barrier,
+      dispatchCohort: joinsActiveDispatch
+        ? (predecessor?.dispatchCohort ?? [...activeDispatches])
+        : [],
+    };
     placementFence = exclusive;
     void barrier.then(() => {
       if (placementFence === exclusive) {
@@ -140,7 +147,9 @@ export function coordinateWorkerPlacementDispatch(
     for (;;) {
       signal?.throwIfAborted();
       const pendingFence = placementFence;
-      if (!pendingFence) {
+      // Only the original dispatch cohort keeps maintenance admission open. Later joins
+      // cannot extend it indefinitely, and hard predecessors carry an empty cohort.
+      if (!pendingFence || pendingFence.dispatchCohort.some((id) => activeDispatches.has(id))) {
         break;
       }
       await racePromiseWithAbortSignal(
@@ -148,12 +157,13 @@ export function coordinateWorkerPlacementDispatch(
         signal,
       );
     }
-    activeDispatchCount += 1;
+    const operationId = Symbol("dispatch");
+    activeDispatches.add(operationId);
     try {
       return await operation();
     } finally {
-      activeDispatchCount -= 1;
-      if (activeDispatchCount === 0) {
+      activeDispatches.delete(operationId);
+      if (activeDispatches.size === 0) {
         const waiters = [...dispatchIdleWaiters];
         dispatchIdleWaiters.clear();
         for (const resolve of waiters) {
@@ -331,14 +341,14 @@ export function coordinateWorkerPlacementDispatch(
           if (sweep.predecessor) {
             await sweep.predecessor.promise.catch(() => undefined);
           }
-          // The sweep fence blocks new dispatches. Its environment pass still joins only after
-          // dispatches admitted before that fence and older exclusive work have drained.
+          // Recovery waits for every admitted dispatch and older exclusive operation,
+          // including later dispatches admitted while the original cohort was active.
           await waitForDispatchIdle();
           await recover();
         })();
         sweep.joinedRecoveries.add(queued);
       } else {
-        queued = runExclusivePlacementOperation(recover);
+        queued = runExclusivePlacementOperation(recover, undefined, true);
       }
       void queued.catch(ready.reject);
       const tracked = trackPlacementOperation(async (report) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting or restarting a session on an available device would remain stuck behind an unrelated slow Cloud allocation after background maintenance began waiting. The web UI could stay on “Restarting session…” without advancing that device’s placement.

## Why This Change Was Made

Pending reconciliation and provisioning recovery now capture the dispatches that were already active. Unrelated dispatches can join while an original member is active; later arrivals cannot extend that original group indefinitely. Once it drains, admission closes while already-admitted work finishes, then maintenance runs exclusively. Move, Stop, and forced teardown retain their ordered exclusive barriers, including through subsequently queued maintenance.

The repair stays in the placement coordinator. It preserves captured recovery predecessors, cancellation authority, request coalescing, startup ordering, and existing provider/workspace ownership. There are no configuration, protocol, persistent-store, dependency, or timeout changes.

## User Impact

An available device can begin its session while background maintenance waits for another environment’s slow provisioning. Maintenance still makes progress after the original dispatch group finishes, and explicit lifecycle operations retain their ordering.

## Evidence

- Reproduced on a real dev Gateway: an interrupted Cloud allocation held a dispatch while a separate connected Mac restart waited without a new placement generation. Canonical reclaim drained the Cloud operation and the Mac immediately advanced. Provider cleanup subsequently completed.
- Both background entry paths reproduce against the actual coordinator: periodic placement reconciliation and independent environment provisioning recovery. Three regressions failed before the repair. Further failing/passing coverage proves later dispatches and later maintenance cannot extend the original group, and that running maintenance and hard lifecycle barriers remain exclusive.
- 183 tests across eight dispatch, cancellation, provider recovery, and teardown suites passed. The final owner suites passed 51 tests in 1.14 seconds after removing an unnecessary heavyweight fixture import.
- The complete configured Testbox core/coreTests changed gate passed: production and all core test typechecks, formatting/lint, dead exports, import cycles, and selected architecture/dependency guards. All 38,106 source entries matched before and after locally and remotely; tree `cfa2487568e35fca19cc7d179c0cff854f2a5959`. The proof lease is verified completed.
- Independent Codex P0–P2 review is clean. [Required GitHub CI](https://github.com/openclaw/openclaw/actions/runs/33981959160) passed on head `92fd37631f960cd285f8ce1f8e9cbe11aed82569`.
- Controlled candidate live overlap passed through the normal web UI, real OpenAI agent, native Crabbox local-container provider, and a real paired Mac. While the exact container still ran its configured 90-second setup sleep, a new Mac session reached active in 4.621–4.944 seconds and returned `Darwin`. A separate provider-process observation confirmed the sleep remained present after the Mac result; first observed sleep absence was over 43 seconds later. An earlier Mac sample reached active in 5.617–5.933 seconds and completed both exec and Computer calls while Cloud provisioning was pending.
- The Cloud worker then enrolled, returned `Linux`, and was reclaimed through the normal UI. Its environment is destroyed; independent provider and Docker checks confirm lease and container absence. This is actual Docker-backed provider/Mac concurrency, not remote infrastructure startup speed. The unchanged 60-second maintenance schedule elapsed multiple times during the pending dispatch; maintenance entry itself is inferred from source rather than a dedicated event. A later read-only observer timeout occurred after the overlap proof; authoritative cleanup timestamps and independent absence checks were recovered afterward. Product timeouts were unchanged.

Production delta: +10 lines. Tests/support: +231 lines, including shared fixture extraction; new admission tests use typed fixtures. No generated or lockfile changes.

This fixes coordinator queueing; it does not claim that cold infrastructure provisioning completes within ten seconds. The live AWS image-preparation attempt failed before a machine or reusable image existed.
