### PR TITLE
fix(agents): keep private yield continuation out of the tool result

### DIFF
--- a/src/agents/agent-tools.runtime.test.ts
+++ b/src/agents/agent-tools.runtime.test.ts
@@ -108,9 +108,9 @@ describe("wrapToolWithAbortSignal", () => {
       runAbort.signal,
     );
 
-    await expect(wrapped.execute("call-yield", {})).resolves.toMatchObject({
-      details: { status: "yielded", message: "Turn yielded." },
-    });
+    const result = await wrapped.execute("call-yield", {});
+    expect(result).toMatchObject({ details: { status: "yielded" } });
+    expect(result).not.toHaveProperty("details.message");
     expect(beforeYield).toHaveBeenCalledOnce();
     expect(runAbort.signal.reason).toBe(handoffReason);
   });

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -44,6 +44,7 @@ import {
 } from "./tools/ask-user-tool.js";
 import { resetPendingAskUserQuestionsForTest } from "./tools/ask-user-tool.test-support.js";
 import { createSecretsTool } from "./tools/secrets-tool.js";
+import { createSessionsYieldTool } from "./tools/sessions-yield-tool.js";
 
 type ToolExecutionStartEvent = Omit<Extract<AgentEvent, { type: "tool_execution_start" }>, "type">;
 type ToolExecutionEndEvent = Omit<Extract<AgentEvent, { type: "tool_execution_end" }>, "type">;
@@ -1397,6 +1398,47 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
       hadPotentialSideEffects: true,
     });
   });
+});
+
+describe("sessions_yield channel progress privacy", () => {
+  it.each(["off", "on", "full"] as const)(
+    "keeps continuation context out of %s verbosity output",
+    async (verboseLevel) => {
+      const { ctx } = createTestContext();
+      const onYield = vi.fn();
+      const args = {
+        message: "SYNTHETIC_PRIVATE_CONTINUATION_MARKER",
+        acknowledgment: "Research started; results will follow.",
+      };
+      ctx.params.onToolResult = vi.fn();
+      ctx.shouldEmitToolResult = () => verboseLevel !== "off";
+      ctx.shouldEmitToolOutput = () => verboseLevel === "full";
+      const tool = createSessionsYieldTool({
+        sessionId: ctx.params.sessionId,
+        claimYield: () => true,
+        onYield,
+      });
+      const toolCallId = "yield-private-context";
+
+      await startTool(ctx, { toolName: tool.name, toolCallId, args });
+      const result = await tool.execute(toolCallId, args);
+      await endTool(ctx, { toolName: tool.name, toolCallId, result, isError: false });
+
+      expect(onYield).toHaveBeenCalledWith(args.message, args.acknowledgment);
+      expect(ctx.emitToolSummary).toHaveBeenCalledTimes(verboseLevel === "off" ? 0 : 1);
+      expect(ctx.emitToolOutput).toHaveBeenCalledTimes(verboseLevel === "full" ? 1 : 0);
+      expect(JSON.stringify(vi.mocked(ctx.emitToolSummary).mock.calls)).not.toContain(args.message);
+      expect(JSON.stringify(vi.mocked(ctx.emitToolOutput).mock.calls)).not.toContain(args.message);
+      if (verboseLevel === "full") {
+        expect(ctx.emitToolOutput).toHaveBeenCalledWith(
+          tool.name,
+          undefined,
+          expect.stringContaining(args.acknowledgment),
+          result,
+        );
+      }
+    },
+  );
 });
 
 describe("handleToolExecutionEnd private result observer", () => {

--- a/src/agents/tools/sessions-yield-tool.test.ts
+++ b/src/agents/tools/sessions-yield-tool.test.ts
@@ -5,7 +5,6 @@ import { createSessionsYieldTool } from "./sessions-yield-tool.js";
 
 type SessionsYieldDetails = {
   status?: string;
-  message?: string;
   acknowledgment?: string;
   error?: string;
 };
@@ -31,51 +30,32 @@ describe("sessions_yield tool", () => {
     const result = await tool.execute("call-1", {});
     const details = result.details as SessionsYieldDetails;
     expect(details.status).toBe("yielded");
-    expect(details.message).toBe("Turn yielded.");
+    expect(details).not.toHaveProperty("message");
     expect(onYield).toHaveBeenCalledOnce();
     expect(onYield).toHaveBeenCalledWith("Turn yielded.", undefined);
   });
 
-  it("passes the custom message through the yield callback", async () => {
-    // The callback message becomes operator-visible scheduler context, so the
-    // tool must not replace a supplied reason with the default text.
-    const onYield = vi.fn();
-    const tool = createSessionsYieldTool({
-      sessionId: "test-session",
-      claimYield: () => true,
-      onYield,
-    });
-    const result = await tool.execute("call-1", { message: "Waiting for fact-checker" });
-    const details = result.details as SessionsYieldDetails;
-    expect(details.status).toBe("yielded");
-    expect(details.message).toBe("Waiting for fact-checker");
-    expect(onYield).toHaveBeenCalledOnce();
-    expect(onYield).toHaveBeenCalledWith("Waiting for fact-checker", undefined);
-  });
+  it.each([undefined, "Research started; results will follow."])(
+    "keeps continuation context private with acknowledgment %s",
+    async (acknowledgment) => {
+      const message = "SYNTHETIC_PRIVATE_CONTINUATION_MARKER";
+      const onYield = vi.fn();
+      const tool = createSessionsYieldTool({
+        sessionId: "test-session",
+        claimYield: () => true,
+        onYield,
+      });
+      const result = await tool.execute("call-1", { message, acknowledgment });
 
-  it("keeps private context separate from the user-facing acknowledgment", async () => {
-    const onYield = vi.fn();
-    const tool = createSessionsYieldTool({
-      sessionId: "test-session",
-      claimYield: () => true,
-      onYield,
-    });
-    const result = await tool.execute("call-1", {
-      message: "Resume after the fact-checker replies",
-      acknowledgment: "Research started; results will follow.",
-    });
-    const details = result.details as SessionsYieldDetails;
-
-    expect(details).toMatchObject({
-      status: "yielded",
-      message: "Resume after the fact-checker replies",
-      acknowledgment: "Research started; results will follow.",
-    });
-    expect(onYield).toHaveBeenCalledWith(
-      "Resume after the fact-checker replies",
-      "Research started; results will follow.",
-    );
-  });
+      expect(result.details).toEqual({
+        status: "yielded",
+        ...(acknowledgment ? { acknowledgment } : {}),
+      });
+      expect(JSON.stringify(result)).not.toContain(message);
+      expect(onYield).toHaveBeenCalledOnce();
+      expect(onYield).toHaveBeenCalledWith(message, acknowledgment);
+    },
+  );
 
   it("claims completion ownership before aborting the requester run", async () => {
     const order: string[] = [];

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -56,7 +56,6 @@ export function createSessionsYieldTool(opts?: {
       await opts.onYield(message, acknowledgment);
       return jsonResult({
         status: "yielded",
-        message,
         ...(acknowledgment ? { acknowledgment } : {}),
       });
     },

--- a/src/gateway/tool-resolution.test.ts
+++ b/src/gateway/tool-resolution.test.ts
@@ -283,7 +283,6 @@ describe("resolveGatewayScopedTools", () => {
       expect(onYield).toHaveBeenCalledWith("waiting on subagents", "I’m waiting on the subagents.");
       expect(toolResult.details).toEqual({
         status: "yielded",
-        message: "waiting on subagents",
         acknowledgment: "I’m waiting on the subagents.",
       });
     } finally {


### PR DESCRIPTION
Related: #25592 (intermediate processing output appearing in messaging channels).
Follow-up to #125106 (separate private resume context from the public waiting acknowledgment).

## What Problem This Solves

Fixes an issue where users waiting for background work could see private continuation context in their chat when full tool verbosity was enabled. The yield tool describes `message` as private, but its raw success result repeated that text.

## Why This Change Was Made

Keep the private message solely on the existing `onYield` continuation path; omit it from the tool-visible JSON result at the producer. The public `acknowledgment` and `status: "yielded"` remain unchanged, so pause detection, waiting replies, and continuation behavior retain their existing contracts. No channel-specific filtering or verbosity configuration changes are needed.

This closes the raw-result path left after the tool-summary privacy change in #125106. It does not attempt to resolve all intermediate narration covered by #25592.

## User Impact

Full verbosity can still show useful tool status and the explicitly public waiting acknowledgment without also forwarding the private resume message. Existing internal continuation context remains available.

## Evidence

- Synthetic pre-fix reproduction: the actual tool start → execute → end flow leaked `SYNTHETIC_PRIVATE_CONTINUATION_MARKER` through full-verbosity output; off/on controls passed. The producer tests also failed because the marker was included in both JSON content and result details.
- Post-fix: **247 tests passed across 6 files**, using:

```sh
node scripts/run-vitest.mjs \
  src/agents/tools/sessions-yield-tool.test.ts \
  src/agents/embedded-agent-subscribe.handlers.tools.test.ts \
  src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts \
  src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts \
  extensions/codex/src/app-server/event-projector.verbose-hooks.test.ts \
  extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts \
  --reporter=dot
```

- New coverage verifies the entire public result contains no private marker, with/without acknowledgment, and actual embedded tool progress with off/on/full verbosity. Existing sibling suites verify hidden continuation persistence, prompt settlement, and Codex verbosity/lifecycle handling.
- Producer: `src/agents/tools/sessions-yield-tool.ts`; JSON envelope owner: `src/agents/tools/tool-results.ts`. The embedded runtime stores `yieldMessage` independently in `attempt.ts`; the Codex callback carries context independently in `dynamic-tool-build.ts`. Both consume the preserved status/callback, not the removed echo.
- Codex dependency inspected directly at `openai/codex@459a79eb85400af759e9220c7bafb4429ae07516`: `codex-rs/core/src/tools/handlers/dynamic.rs:153-164,219-233` and `codex-rs/app-server/src/dynamic_tools.rs:37-53` forward returned content to model output and completed tool notifications. This is why the result producer is the correct boundary.
- `node scripts/check-changed.mjs -- src/agents/tools/sessions-yield-tool.ts src/agents/tools/sessions-yield-tool.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts`: **passed**, including formatting, core/core-test typechecks, targeted lint, import/schema guards, and security guards.
- Isolated autoreview completed **scoped-clean**, with no accepted/actionable P0/P1 findings.
- Production delta: **0 added / 1 removed**. Tests: **63 added / 41 removed**, consolidating the prior custom-message/acknowledgment cases.
- Live messaging proof was not run: this branch has not been deployed, and the active gateway was left untouched to avoid interrupting ongoing conversations. The regression instead exercises the real local producer and subscription handlers with a synthetic marker and captured output callbacks; this is not a live-channel or mock-gateway E2E claim.

No private transcripts, real continuation text, credentials, or live configuration are included.
