### PR TITLE
fix(ci): unblock releases with different tooling package managers

### DIFF
--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -1212,7 +1212,6 @@ jobs:
         run: |
           set -euo pipefail
           install_args=(
-            --dir .release-harness
             install
             --frozen-lockfile
             --prefer-offline
@@ -1220,7 +1219,8 @@ jobs:
             --config.enable-pre-post-scripts=true
             --config.side-effects-cache=true
           )
-          pnpm "${install_args[@]}" || pnpm "${install_args[@]}"
+          # Corepack selects packageManager before pnpm processes its arguments.
+          (cd .release-harness && { pnpm "${install_args[@]}" || pnpm "${install_args[@]}"; })
           # Node resolves --import tsx from the process cwd. Point that root at
           # the trusted harness install instead of the frozen target checkout.
           ln -s .release-harness/node_modules node_modules

--- a/test/scripts/release-tooling-bootstrap.test.ts
+++ b/test/scripts/release-tooling-bootstrap.test.ts
@@ -1,0 +1,35 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, it } from "vitest";
+import { parse } from "yaml";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+
+it("installs with the tooling cwd while retaining the release source root", () => {
+  const workflow = parse(readFileSync(".github/workflows/openclaw-release-publish.yml", "utf8"));
+  const install = workflow.jobs.publish.steps.find(
+    (step: { name: string }) => step.name === "Install trusted release tooling dependencies",
+  );
+  const source = createTempDir("release-tooling-bootstrap-");
+  const tooling = join(source, ".release-harness");
+  const bin = join(source, "bin");
+  const receipt = join(source, "install-cwd");
+  mkdirSync(tooling);
+  mkdirSync(bin);
+  writeFileSync(join(bin, "pnpm"), '#!/bin/sh\npwd > "$INSTALL_CWD"\nmkdir -p node_modules\n', {
+    mode: 0o755,
+  });
+  const result = spawnSync("bash", ["-c", `${install.run}\npwd`], {
+    cwd: source,
+    encoding: "utf8",
+    env: { PATH: `${bin}:/usr/bin:/bin`, INSTALL_CWD: receipt },
+  });
+  expect(result.status, result.stderr).toBe(0);
+  expect(realpathSync(readFileSync(receipt, "utf8").trim())).toBe(realpathSync(tooling));
+  expect(realpathSync(result.stdout.trim())).toBe(realpathSync(source));
+  expect(realpathSync(join(source, "node_modules"))).toBe(
+    realpathSync(join(tooling, "node_modules")),
+  );
+});

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1152,6 +1152,7 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/release-candidate-checklist.test.ts",
         "test/scripts/release-no-push-workflow.test.ts",
         "test/scripts/release-plan-producer.test.ts",
+        "test/scripts/release-tooling-bootstrap.test.ts",
         "test/scripts/validate-release-publish-approval.test.ts",
         "test/scripts/ci-workflow-guards.test.ts",
       ],


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where OpenClaw release publication stops before publishing any packages when the frozen release and trusted tooling require different pnpm versions. [Publication run 33981169516](https://github.com/openclaw/openclaw/actions/runs/33981169516/job/101346753716) selected pnpm 12.1.0 for tooling requiring 12.3.4.

## Why This Change Was Made

Corepack resolves the package manager from the current directory before forwarding pnpm arguments. Run both existing install attempts inside the trusted harness directory, using a subshell so later planning and the dependency link still belong to the release source root. This follows the existing setup-release-harness action's ownership rule.

## User Impact

Release publication can use its independently pinned tooling without changing the frozen candidate, dependency versions, install flags, or version checks. Application behavior is unchanged. Workflow delta is +2/-2; the executable regression adds 35 test lines and its routing expectation adds one.

## Evidence

- Reproduced the original failure with real Corepack 0.35.0, a Source root requiring pnpm 12.1.0, and nested tooling requiring 12.3.4. Inspected Corepack loadSpec and executePackageManagerRequest directly.
- Executed the corrected YAML step: pnpm 12.3.4 installs successfully, the planner remains at the Source root, and its node_modules link resolves to the trusted install.
- The executable regression fails against the old YAML and passes against the fix. It checks install cwd, caller cwd, and the dependency link rather than matching shell text.
- Three publication/workflow guards and the full changed-file gate passed for the bootstrap repair; all 457 routing/bootstrap tests and fresh independent P0–P2 review passed for the final tree. The actual protected publication workflow will verify recovery after landing; no package publication is claimed by the local proof.
