### PR TITLE
fix(codex): retain complete answers while previews are pending

### DIFF
--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -58,6 +58,7 @@ export class CodexAssistantProjection {
 
   constructor(
     private readonly params: EmbeddedRunAttemptParams,
+    private readonly enqueuePresentation: (callback: () => void | Promise<void>) => void,
     private readonly emitAgentEvent: (event: AgentEvent) => void,
     private readonly matchesToolProgressEcho: (text: string) => boolean,
     private readonly nextTranscriptTimestamp: () => number,
@@ -73,7 +74,7 @@ export class CodexAssistantProjection {
     }
   }
 
-  async handleAssistantDelta(params: JsonObject): Promise<void> {
+  handleAssistantDelta(params: JsonObject): void {
     const itemId = readString(params, "itemId") ?? "assistant";
     const delta = readString(params, "delta") ?? "";
     if (!delta) {
@@ -90,7 +91,7 @@ export class CodexAssistantProjection {
     }
     if (!this.assistantStarted) {
       this.assistantStarted = true;
-      await this.params.onAssistantMessageStart?.();
+      this.enqueuePresentation(() => this.params.onAssistantMessageStart?.());
     }
     this.rememberAssistantItem(itemId);
     const text = `${this.assistantTextByItem.get(itemId) ?? ""}${delta}`;
@@ -135,7 +136,7 @@ export class CodexAssistantProjection {
     // Legacy channel preview callbacks are append-oriented and do not all
     // understand replacement snapshots.
     if (knownFinalAnswer && !replaceable) {
-      await this.params.onPartialReply?.(streamPayload);
+      this.enqueuePresentation(() => this.params.onPartialReply?.(streamPayload));
     }
   }
 

--- a/extensions/codex/src/app-server/event-projector-reasoning.ts
+++ b/extensions/codex/src/app-server/event-projector-reasoning.ts
@@ -31,11 +31,12 @@ export class CodexReasoningProjection {
 
   constructor(
     private readonly params: EmbeddedRunAttemptParams,
+    private readonly enqueuePresentation: (callback: () => void | Promise<void>) => void,
     private readonly emitAgentEvent: (event: AgentEvent) => void,
     private readonly onNativePlanUpdate?: (update: NativePlanUpdate) => void | Promise<void>,
   ) {}
 
-  async handleReasoningDelta(method: ReasoningDeltaMethod, params: JsonObject): Promise<void> {
+  handleReasoningDelta(method: ReasoningDeltaMethod, params: JsonObject): void {
     const itemId = readString(params, "itemId") ?? "reasoning";
     const delta = readString(params, "delta") ?? "";
     if (!delta) {
@@ -58,10 +59,10 @@ export class CodexReasoningProjection {
       index: groupIndex,
       text: `${current?.text ?? ""}${delta}`,
     });
-    await this.params.onReasoningStream?.({
-      text: this.reasoningText(),
-      isReasoningSnapshot: true,
-    });
+    const text = this.reasoningText();
+    this.enqueuePresentation(() =>
+      this.params.onReasoningStream?.({ text, isReasoningSnapshot: true }),
+    );
   }
 
   handlePlanDelta(params: JsonObject): void {
@@ -131,12 +132,12 @@ export class CodexReasoningProjection {
     }
   }
 
-  async maybeEndReasoning(): Promise<void> {
+  maybeEndReasoning(): void {
     if (!this.reasoningStarted || this.reasoningEnded) {
       return;
     }
     this.reasoningEnded = true;
-    await this.params.onReasoningEnd?.();
+    this.enqueuePresentation(() => this.params.onReasoningEnd?.());
   }
 
   reasoningText(): string {

--- a/extensions/codex/src/app-server/event-projector.assistant.test.ts
+++ b/extensions/codex/src/app-server/event-projector.assistant.test.ts
@@ -21,6 +21,110 @@ import {
 registerCodexEventProjectorTestLifecycle();
 
 describe("CodexAppServerEventProjector assistant projection", () => {
+  it.each(["drain", "close", "abort"] as const)(
+    "retains native state while assistant start is pending, then handles %s",
+    async (finish) => {
+      const start = Promise.withResolvers<void>();
+      const controller = new AbortController();
+      const calls: string[] = [];
+      const projector = await createProjector(
+        {
+          ...(await createParams()),
+          onAssistantMessageStart: () => {
+            calls.push("start");
+            return start.promise;
+          },
+          onPartialReply: ({ text }) => {
+            calls.push(`reply:${text}`);
+          },
+          onReasoningStream: ({ text }) => {
+            calls.push(`reasoning:${text}`);
+          },
+          onReasoningEnd: () => {
+            calls.push("reasoning:end");
+          },
+        },
+        { runAbortSignal: controller.signal },
+      );
+      try {
+        await projector.handleNotification(
+          forCurrentTurn("item/started", {
+            item: { type: "agentMessage", id: "msg-1", phase: "final_answer", text: "" },
+          }),
+        );
+        await projector.handleNotification(agentMessageDelta("hel"));
+        await projector.handleNotification(agentMessageDelta("lo"));
+        for (const delta of ["first", " second"]) {
+          await projector.handleNotification(
+            forCurrentTurn("item/reasoning/textDelta", {
+              itemId: "reasoning-1",
+              delta,
+            }),
+          );
+        }
+        await projector.handleNotification(
+          turnCompleted([
+            { type: "agentMessage", id: "msg-1", phase: "final_answer", text: "hello complete" },
+          ]),
+        );
+        expect(projector.buildResult(buildEmptyToolTelemetry()).assistantTexts).toEqual([
+          "hello complete",
+        ]);
+        expect(projector.getCompletedTurnStatus()).toBe("completed");
+        expect(calls).toEqual(["start"]);
+        if (finish === "close") {
+          await projector.closeProjection();
+        } else if (finish === "abort") {
+          controller.abort();
+        }
+        start.resolve();
+        await projector.drainPresentation();
+        expect(calls).toEqual(
+          finish === "drain"
+            ? [
+                "start",
+                "reply:hel",
+                "reply:hello",
+                "reasoning:first",
+                "reasoning:first second",
+                "reasoning:end",
+              ]
+            : ["start"],
+        );
+      } finally {
+        start.resolve();
+        await projector.closeProjection();
+        await projector.drainPresentation();
+      }
+    },
+  );
+
+  it.each(["throw", "reject"] as const)(
+    "continues presentation after a callback %s",
+    async (failure) => {
+      const onPartialReply = vi.fn();
+      const projector = await createProjector({
+        ...(await createParams()),
+        onAssistantMessageStart: () => {
+          if (failure === "throw") {
+            throw new Error("presentation failed");
+          }
+          return Promise.reject(new Error("presentation failed"));
+        },
+        onPartialReply,
+      });
+      await projector.handleNotification(
+        forCurrentTurn("item/started", {
+          item: { type: "agentMessage", id: "msg-1", phase: "final_answer", text: "" },
+        }),
+      );
+      await projector.handleNotification(agentMessageDelta("hello"));
+      await projector.drainPresentation();
+      expect(onPartialReply).toHaveBeenCalledWith({ text: "hello", delta: "hello" });
+      expect(projector.buildResult(buildEmptyToolTelemetry()).assistantTexts).toEqual(["hello"]);
+    },
+  );
+
   it("projects assistant deltas and usage into embedded attempt results", async () => {
     const { onAssistantMessageStart, onPartialReply, projector } =
       await createProjectorWithAssistantHooks();
@@ -809,6 +913,7 @@ describe("CodexAppServerEventProjector assistant projection", () => {
     await projector.handleNotification(agentMessageDelta("hel", "msg-final"));
     await projector.handleNotification(agentMessageDelta("lo", "msg-final"));
 
+    await projector.drainPresentation();
     expect(onPartialReply).toHaveBeenCalledTimes(2);
     expect(onPartialReply.mock.calls.map((call) => call[0])).toEqual([
       { text: "hel", delta: "hel" },

--- a/extensions/codex/src/app-server/event-projector.reasoning.test.ts
+++ b/extensions/codex/src/app-server/event-projector.reasoning.test.ts
@@ -609,6 +609,7 @@ describe("CodexAppServerEventProjector reasoning and guardian projection", () =>
       }),
     );
 
+    await projector.drainPresentation();
     expect(onReasoningStream).toHaveBeenCalledTimes(3);
     expect(onReasoningStream).toHaveBeenNthCalledWith(1, {
       text: "Checking ",
@@ -653,6 +654,7 @@ describe("CodexAppServerEventProjector reasoning and guardian projection", () =>
       }),
     );
 
+    await projector.drainPresentation();
     expect(onReasoningStream).toHaveBeenCalledTimes(3);
     expect(onReasoningStream).toHaveBeenNthCalledWith(1, {
       text: "Second",

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -1,5 +1,6 @@
 // Codex plugin module implements event projector behavior.
 import {
+  embeddedAgentLog,
   runAgentHarnessAfterCompactionHook,
   runAgentHarnessBeforeCompactionHook,
   type AgentMessage,
@@ -67,6 +68,7 @@ export class CodexAppServerEventProjector {
   private readonly toolTranscriptProjection: CodexToolTranscriptProjection;
   private completedTurn: CodexTurn | undefined;
   private projectionClosed = false;
+  private presentationTail: Promise<void> = Promise.resolve();
   /** Structured overloads may continue once the exact settled transcript is captured. */
   settledTurnFailureFinalizationAllowed = false;
   private readonly terminalFailure = new CodexTerminalFailureProjection();
@@ -132,6 +134,7 @@ export class CodexAppServerEventProjector {
     );
     this.assistantProjection = new CodexAssistantProjection(
       params,
+      this.enqueuePresentation,
       (event) => this.emitAgentEvent(event),
       (text) => this.toolProgressProjection.matchesEcho(text),
       this.transcriptCheckpoint.nextTimestamp,
@@ -139,6 +142,7 @@ export class CodexAppServerEventProjector {
     );
     this.reasoningProjection = new CodexReasoningProjection(
       params,
+      this.enqueuePresentation,
       (event) => this.emitAgentEvent(event),
       options.onNativePlanUpdate,
     );
@@ -180,6 +184,25 @@ export class CodexAppServerEventProjector {
       this.assistantProjection.markAssistantBoundaryPersisted(itemId);
       this.pendingSteeringAssistantBoundaryItemId = undefined;
     }
+  }
+
+  // Presentation stays ordered, but cannot hold canonical native items behind a slow channel.
+  // Finalization joins accepted callbacks under the existing settlement deadline.
+  private readonly enqueuePresentation = (callback: () => void | Promise<void>): void => {
+    this.presentationTail = this.presentationTail.then(async () => {
+      if (this.projectionClosed || this.aborted || this.options.runAbortSignal?.aborted) {
+        return;
+      }
+      try {
+        await callback();
+      } catch (error) {
+        embeddedAgentLog.debug("codex app-server presentation callback failed", { error });
+      }
+    });
+  };
+
+  drainPresentation(): Promise<void> {
+    return this.presentationTail;
   }
 
   /** Fence delayed projections before the turn's final snapshot leaves its owner. */
@@ -248,11 +271,11 @@ export class CodexAppServerEventProjector {
 
     switch (notification.method) {
       case "item/agentMessage/delta":
-        await this.assistantProjection.handleAssistantDelta(params);
+        this.assistantProjection.handleAssistantDelta(params);
         break;
       case "item/reasoning/summaryTextDelta":
       case "item/reasoning/textDelta":
-        await this.reasoningProjection.handleReasoningDelta(notification.method, params);
+        this.reasoningProjection.handleReasoningDelta(notification.method, params);
         break;
       case "item/plan/delta":
         this.reasoningProjection.handlePlanDelta(params);
@@ -677,7 +700,7 @@ export class CodexAppServerEventProjector {
     }
     this.assistantProjection.finalizeAnswerCandidate(turn);
     this.activeCompactionItemIds.clear();
-    await this.reasoningProjection.maybeEndReasoning();
+    this.reasoningProjection.maybeEndReasoning();
   }
 
   private async emitSnapshotOnlyNativeToolProgress(item: CodexThreadItem): Promise<void> {

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -134,7 +134,9 @@ export async function finalizeCodexAttempt(
     clearTimeout(abortGraceTimer);
     deadlines.dispose();
   };
-  const settlement = drainNotificationQueue().then(closeProjection);
+  const settlement = drainNotificationQueue()
+    .then(() => activeProjector.drainPresentation())
+    .then(closeProjection);
   let projectionDrained = false;
   try {
     try {

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -1079,8 +1079,26 @@ describe("runCodexAppServerAttempt native lifecycle", () => {
         finalizationHookNotification("hook/completed", "completed"),
       );
       void harness.notify(makeAgentMessageDelta({ itemId: "msg-final-1", delta: "Done." }));
-      // Receipt sees the unsettled hook; its completion is still behind the first projection.
-      void harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      // Presentation may stay blocked after the queued hook completes; receipt owns its deadline.
+      void harness.notify({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            items: [
+              {
+                id: "msg-final-1",
+                type: "agentMessage",
+                phase: "final_answer",
+                text: "Done. The complete answer survives pending presentation.",
+              },
+            ],
+          },
+        },
+      });
       await vi.advanceTimersByTimeAsync(TURN_TERMINAL_SETTLEMENT_TIMEOUT_MS / 2);
       projection.resolve();
       await vi.waitFor(() => expect(onPartialReply).toHaveBeenCalledOnce(), fastWait);
@@ -1093,6 +1111,9 @@ describe("runCodexAppServerAttempt native lifecycle", () => {
       await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce(), fastWait);
       const result = await run;
       expect(readAttemptTerminal(result)).toMatchObject({ aborted: true, timedOut: true });
+      expect(result.assistantTexts).toEqual([
+        "Done. The complete answer survives pending presentation.",
+      ]);
       expect(result.codexAppServerFailure?.kind).toBe("turn_settlement_timeout");
       expect(resolveActiveEmbeddedRunSessionId(params.sessionKey!)).toBeUndefined();
     } finally {


### PR DESCRIPTION
Closes #139249

## What Problem This Solves

Fixes an issue where Codex replies lose the end of their answer when a channel preview callback stalls. Even when Codex has supplied a complete final answer, terminal settlement could return only the earlier streamed prefix.

## Why This Change Was Made

Keep assistant-start, partial-reply, and reasoning presentation callbacks ordered in a projector-owned queue, independently of canonical native notifications. Finalization joins accepted presentation under the existing receipt-anchored settlement deadline and abort grace. Callback failures are isolated, and queued callbacks cannot start after cancellation or projection closure.

Media, transcript checkpoints, native plan persistence, and async-message delivery retain their existing awaited ownership. No new configuration, timeout, protocol, or storage changes.

## User Impact

Complete native answers remain available in the result and transcript projection even if presentation stalls. Settlement timeout and cancellation still release the run and retain their existing failure classification.

## Evidence

- Extended the existing stalled-presentation lifecycle reproduction on main `925fb0c3353ce98f1c8d6d1f2c27bbb8472af095`: before the fix, expected `Done. The complete answer survives pending presentation.` but received only `Done.`; the same regression passes with the repair.
- **106/106 tests passed** across `run-attempt.turn-watches.test.ts`, `run-attempt.settlement.test.ts`, `event-projector.assistant.test.ts`, and `event-projector.reasoning.test.ts`, using `node scripts/run-vitest.mjs` with those paths.
- Added coverage for callback ordering, captured reasoning snapshots, synchronous throws, rejected promises, and queued callbacks fenced after close/abort.
- After rebasing onto main `efa4b5dfbb3`, 8/8 targeted regressions passed, including blocked-delivery timeout and user-stop cases; `git range-diff` confirmed the patch was unchanged.
- Fresh autoreview: scoped-clean, no P0–P2 findings. `git diff --check` and changed-file formatting passed.
- `node scripts/check-changed.mjs --base 925fb0c3353ce98f1c8d6d1f2c27bbb8472af095` passed the preceding guards, plugin boundaries, and 5 doctor-contract tests, then stopped before typechecking: `Declaration input escapes checkout ... shared installs and external symlinks are unsupported.` The targeted lint wrapper hits the same dependency boundary. Full typecheck/lint and subsequent changed gates are unverified locally; they are not reported as green.
- Personally inspected pinned Codex `rust-v0.153.4` (`3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`), `codex-rs/app-server/src/bespoke_event_handling.rs:1390-1420`: completion emits `last_agent_message` in the terminal summary.
- Production delta: +27 lines, needed for one ordered presentation owner, failure isolation, closure checks, and the bounded finalization join. Existing blocking presentation awaits removed. Tests counted separately.
- Proof boundary: deterministic app-server/run lifecycle tests; no live Telegram replay. This host has neither an authenticated Convex CLI nor the QA broker credential pair, so the Telegram Test Server lane is unavailable. Testbox/AWS Crabbox were not used.

Follow-up identified during sibling review: the separate `/btw` collector awaits its start callback in a detached delta handler; rejection and delayed-delta behavior without a terminal summary need separate investigation. It does not use this projector.

Maintainer edits are enabled; access through GitHub's maintainer workflow/secrets option is acceptable for this PR.
