### PR TITLE
fix(tailscale): release managed routes after Gateway crashes

### DIFF
--- a/src/infra/tailscale-parent-loss.process.test.ts
+++ b/src/infra/tailscale-parent-loss.process.test.ts
@@ -1,0 +1,78 @@
+import { fork, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const fixture = fileURLToPath(
+  new URL("../../test/fixtures/tailscale-parent-loss-fixture.mjs", import.meta.url),
+);
+
+describe.runIf(process.platform !== "win32")("Tailscale parent loss", () => {
+  it.each([false, true])(
+    "releases and reacquires the route after SIGKILL (group=%s)",
+    async (group) => {
+      const marker = path.join(tempDirs.make("tailscale-parent-loss-"), "claim.json");
+      const children: ChildProcess[] = [];
+      const claims: Array<{ pid: number; ownerPid: number; port: number }> = [];
+      const start = async (port = 0) => {
+        const child = fork(fixture, ["gateway", new URL("./tailscale.ts", import.meta.url).href], {
+          detached: true,
+          execArgv: ["--import", "tsx"],
+          stdio: ["ignore", "ignore", "pipe", "ipc"],
+          env: {
+            ...process.env,
+            OPENCLAW_TEST_TAILSCALE_BINARY: fixture,
+            OPENCLAW_TEST_ROUTE_MARKER: marker,
+            OPENCLAW_TEST_ROUTE_PORT: String(port),
+            VITEST: "true",
+          },
+        });
+        children.push(child);
+        let stderr = "";
+        child.stderr?.on("data", (chunk) => (stderr += String(chunk)));
+        const ready = await Promise.race([
+          once(child, "message"),
+          once(child, "exit").then(([code]) => {
+            throw new Error(`Gateway fixture exited (${code}): ${stderr}`);
+          }),
+        ]);
+        expect(ready[0]).toEqual({ type: "ready" });
+        const claim = JSON.parse(await readFile(marker, "utf8")) as (typeof claims)[number];
+        claims.push(claim);
+        return { child, claim };
+      };
+      try {
+        const original = await start();
+        const exit = once(original.child, "exit");
+        process.kill(group ? -original.child.pid! : original.child.pid!, "SIGKILL");
+        await exit;
+        await vi.waitFor(() => expect(() => process.kill(original.claim.pid, 0)).toThrow(), {
+          timeout: 5_000,
+        });
+        const replacement = await start(original.claim.port);
+        expect(replacement.claim.port).toBe(original.claim.port);
+        const stopped = once(replacement.child, "exit");
+        replacement.child.send("stop");
+        expect(await stopped).toEqual([0, null]);
+      } finally {
+        for (const child of children) {
+          if (child.pid && child.exitCode === null && child.signalCode === null) {
+            process.kill(-child.pid, "SIGKILL");
+          }
+        }
+        for (const claim of claims) {
+          for (const pid of [claim.pid, claim.ownerPid]) {
+            try {
+              process.kill(pid, "SIGKILL");
+            } catch {}
+          }
+        }
+      }
+    },
+    20_000,
+  );
+});

--- a/src/infra/tailscale-route-owner.worker.test.ts
+++ b/src/infra/tailscale-route-owner.worker.test.ts
@@ -70,14 +70,16 @@ describe("Tailscale route owner", () => {
     );
   });
 
-  it.runIf(process.platform !== "win32")(
-    "terminates the claim when the Gateway IPC owner disappears",
-    async () => {
+  it.runIf(process.platform !== "win32").each([false, true])(
+    "terminates the claim when the Gateway IPC owner disappears (ready=%s)",
+    async (waitForReady) => {
       const { messages, worker } = spawnRouteOwnerFixture();
       try {
-        await vi.waitFor(() => {
-          expect(messages).toContainEqual({ type: "ready" });
-        });
+        if (waitForReady) {
+          await vi.waitFor(() => {
+            expect(messages).toContainEqual({ type: "ready" });
+          });
+        }
         const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
           (resolve) => {
             worker.once("exit", (code, signal) => resolve({ code, signal }));

--- a/src/infra/tailscale-route-owner.worker.ts
+++ b/src/infra/tailscale-route-owner.worker.ts
@@ -137,8 +137,8 @@ export function runTailscaleRouteOwner(
 if (process.argv[2] === TAILSCALE_ROUTE_OWNER_ARG) {
   try {
     const owner = runTailscaleRouteOwner(parseStart(process.argv[3]));
-    // Terminal signals reach this worker with the Gateway process group. Drain the
-    // detached route child first or the HTTPS port remains claimed after Gateway exit.
+    // The owner survives a Gateway process-group kill. IPC closure releases the
+    // detached claim even when the Gateway cannot run its shutdown hooks.
     for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
       process.once(signal, owner.stop);
     }
@@ -148,6 +148,9 @@ if (process.argv[2] === TAILSCALE_ROUTE_OWNER_ARG) {
         owner.stop();
       }
     });
+    if (!process.connected) {
+      owner.stop();
+    }
     void owner.exited.then((exit) => process.exit(exit.stopping ? 0 : 1));
   } catch (error) {
     send({

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -314,7 +314,7 @@ describe("tailscale helpers", () => {
       await markerWritten;
       expect(existsSync(marker)).toBe(true);
 
-      await vi.advanceTimersToNextTimerAsync();
+      await vi.advanceTimersByTimeAsync(15_000);
 
       await expect(claimPromise).rejects.toThrow("Funnel is not enabled on your tailnet.");
     },

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -271,6 +271,7 @@ async function startTailscaleRouteOwner(argv: string[]): Promise<TailscaleRouteC
     [TAILSCALE_ROUTE_OWNER_ARG, JSON.stringify({ argv })],
     {
       execArgv,
+      detached: process.platform !== "win32",
       stdio: ["ignore", "ignore", "ignore", "ipc"],
     },
   );
@@ -278,7 +279,6 @@ async function startTailscaleRouteOwner(argv: string[]): Promise<TailscaleRouteC
   let ready = false;
   let active = false;
   let stopping = false;
-  let startupSettled = false;
   let failure: Error | undefined;
   let resolveExit!: () => void;
   const exited = new Promise<void>((resolve) => {
@@ -287,10 +287,6 @@ async function startTailscaleRouteOwner(argv: string[]): Promise<TailscaleRouteC
 
   const startup = new Promise<void>((resolve, reject) => {
     const settle = (error?: Error) => {
-      if (startupSettled) {
-        return;
-      }
-      startupSettled = true;
       clearTimeout(startupTimer);
       if (error) {
         reject(error);

--- a/test/fixtures/tailscale-parent-loss-fixture.mjs
+++ b/test/fixtures/tailscale-parent-loss-fixture.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+import net from "node:net";
+
+const [command, ...args] = process.argv.slice(2);
+if (command === "gateway") {
+  const { claimTailscaleRoute } = await import(args[0]);
+  const claim = await claimTailscaleRoute("serve", 18791, 18791, () => {});
+  process.send({ type: "ready" });
+  process.once("message", async () => {
+    await claim.stop();
+    process.exit(0);
+  });
+} else if (command === "serve" && args[0] === "status") {
+  process.stdout.write("{}");
+} else if (command === "serve") {
+  const server = net.createServer((socket) => socket.end());
+  server.listen(Number(process.env.OPENCLAW_TEST_ROUTE_PORT ?? 0), "127.0.0.1", () => {
+    writeFileSync(
+      process.env.OPENCLAW_TEST_ROUTE_MARKER,
+      JSON.stringify({ pid: process.pid, ownerPid: process.ppid, port: server.address().port }),
+    );
+    process.stdout.write("Press Ctrl+C to exit.\n");
+  });
+} else {
+  throw new Error(`Unexpected fixture command: ${command}`);
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a macOS Gateway killed during restart could leave its foreground Tailscale claimant alive. That stale claimant kept HTTPS port 443 occupied, so replacement Gateways failed to start and entered a restart loop.

Closes #126445. Supersedes #126457 with a focused repair to process ownership, preserving @PollyBot13's report and contribution.

## Why This Change Was Made

The cleanup worker now has its own POSIX process group, allowing it to observe Gateway IPC loss and terminate the foreground claimant even when the Gateway's entire process group is killed. It also handles IPC loss before its listeners are installed. Normal cleanup still waits for the claimant to exit; redundant startup Promise-settlement bookkeeping is removed.

This repairs the existing documented promise that losing the Gateway releases its managed route. It does not change launchd shutdown budgets or introduce the original PR's unreadable-timeout immediate-exit policy. It prevents new orphans; foreground claims left by pre-fix Gateways still require the operator to stop their confirmed owning process, because unrelated foreground routes cannot safely be identified from a port or process name alone.

## User Impact

A replacement Gateway can reclaim its Tailscale route after the previous Gateway is killed. Windows retains its current process behavior. No configuration, database, protocol, or dependency changes.

## Evidence

Exact head: `d42ae5d4803578c714e3c96ef4b01d605672a867`; tree `04fe99ddc4971fd5d178d8d02bc77a603bcb0950`. Both remote source checkouts had no tracked diff after their builds.

- Fresh independent Codex review: scoped-clean at P0–P2, no actionable findings. Diff-scoped deslop found no further behavior-neutral cleanup needed.
- [Exact-head CI 33983015562](https://github.com/openclaw/openclaw/actions/runs/33983015562): success; 130 passing checks, 51 intentional skips, zero pending/failing checks.
- Fresh Crabbox proof used provider `blacksmith-testbox`, lease `tbx_01m1sbvw4vd9z61aznp28td9wn`, [backing lease workflow](https://github.com/openclaw/openclaw/actions/runs/33982892355). Node 24.19.0, pnpm 12.3.4, Linux 6.6.141 x86_64. The leased command passed; lease cleanup can mark its backing workflow cancelled.
- Both revisions installed with `pnpm install --offline --frozen-lockfile` and built with `node --import ./scripts/tsx.mjs scripts/build-all.mts qaRuntime`.
- 55/55 focused Linux tests across four files passed: `node scripts/run-vitest.mjs src/infra/tailscale-parent-loss.process.test.ts src/infra/tailscale-route-owner.worker.test.ts src/infra/tailscale.test.ts src/gateway/server-tailscale.test.ts`. Prior macOS owner/process proof passed 7 tests; the pre-fix group-kill regression failed because the claimant survived.
- Production +6/-7 (net -1); tests/support +114/-7 (net +107).

### Real Gateway before/after

The probe ran the built `openclaw.mjs gateway run` CLI with isolated state/config and a synthetic PATH `tailscale` executable owning a real loopback TCP proxy. It exercised the production claim owner without `VITEST` or test-only runtime overrides. This is real Gateway/process/socket proof, not authenticated Tailscale or HTTPS proof; neither Tailscale binary was installed on the runner. It directly tests the changed POSIX ownership boundary. Local macOS process tests and the documented launchd job-group cleanup contract cover the platform-specific premise; a full native launchd Gateway run was not performed in this lane.

Before: `e09a265b11112623addd4de2167ee6b34cd82719`.
After: `d42ae5d4803578c714e3c96ef4b01d605672a867`.

The Gateway commands, from their respective checkout roots, were:

```sh
node openclaw.mjs gateway run --allow-unconfigured --port 41373 --bind loopback --tailscale serve
node openclaw.mjs gateway run --allow-unconfigured --port 36053 --bind loopback --tailscale serve
```

Each scenario killed the original Gateway's process group with SIGKILL, then launched a replacement with the same Gateway and route ports for that scenario.

| Observation | Before | After |
| --- | --- | --- |
| Initial Gateway and proxied route health | HTTP 200, `ok:true` | HTTP 200, `ok:true` |
| Original Gateway / cleanup worker group | Both PGID 9204 | Gateway PGID 12012; worker PGID 12068 |
| After group SIGKILL | Worker exited; claimant PID 9267 still alive under PPID 1 after 5,042 ms | Gateway, worker, and claimant all absent after 31 ms |
| Replacement | Exited 78 after `EADDRINUSE`; old claimant remained | Same route port 45363 reclaimed; Gateway and route healthy after 1,976 ms |
| Cleanup | All owned processes gone; neither listener remained | All owned processes gone; neither listener remained |

The temporary remote checkouts, state, configs, listeners and proof processes were removed. The command and wrapper returned success; the lease was stopped and its completed state verified. Evidence report SHA-256: `b037576f3ffeb99b24c42dcb2d8d7f6ba0ee73454b714be8b098c32f6b82a1c5`.

### Review follow-through and upgrade scope

The latest ClawSweeper review identified no code findings. Its requested real-Gateway before/after evidence and rank-up move are satisfied above. Its serialized-state flag is a false positive: the existing `{ argv }` IPC payload is unchanged; this diff changes a spawn option, removes a redundant local boolean, and handles already-closed IPC. No stored representation, schema, migration, or config changes exist. Stable `v2026.9.1` contains the same process-group mismatch; newly started upgraded Gateways use the repaired owner. The maintainer explicitly selected prevention with operator-assisted recovery for historical ambiguous claims.

Follow-up identified during review: foreground-conflict diagnostics currently suggest a background route removal command; they should distinguish foreground ownership and direct operators to stop the confirmed owning CLI. Automatic termination of ambiguous historical claims remains out of scope.
