### PR TITLE
fix(tooling): preserve human squash credit without machine attribution

### DIFF
--- a/scripts/pr
+++ b/scripts/pr
@@ -302,7 +302,7 @@ Usage:
     --auto-merge selects pinned immediate squash for MERGEABLE/CLEAN, auto for MERGEABLE/BEHIND.
     OPENCLAW_PR_AUTO_MERGE=1 is equivalent.
     --body-file snapshots a regular UTF-8 file relative to the caller, replacing squash prose.
-    Empty files are valid. Existing source/server co-authors are always retained; queue merges reject it.
+    Empty files are valid. Human source/server co-authors are retained; known machine credit is excluded. Queue merges reject it.
     Repeated merge-run reconciles retained outcomes; it never retries an uncertain dispatch.
   scripts/pr merge-recover <PR> <OUTCOME_OID> --confirmed-operator-recovery [--replacement-head <SHA>] [--body-file <path>]
     Explicitly authorize one new attempt after inspecting the retained outcome and remote history.

--- a/scripts/pr-lib/merge-body.mjs
+++ b/scripts/pr-lib/merge-body.mjs
@@ -55,17 +55,28 @@ function trailers(body) {
   return parsed.stdout.split("\n").filter(Boolean);
 }
 
+function isMachineCredit(line) {
+  // Claude Code documents this exact machine address. Names and provider domains
+  // can identify human contributors, so neither is a safe exclusion rule.
+  return /^Co-authored-by:\s*[^<>]+<noreply@anthropic\.com>$/i.test(line);
+}
+
 function compose({ preview, source, captured }) {
   const explicit = captured !== "";
   let body = explicit
     ? Buffer.from(JSON.parse(captured).base64, "base64").toString("utf8")
     : preview;
   const original = trailers(body);
+  if (original.some(isMachineCredit)) {
+    throw new Error(
+      "Squash message contains machine co-author credit; use --body-file with a reviewed message preserving human contributors.",
+    );
+  }
   const required = [
     ...original,
     ...(explicit ? trailers(preview).filter((line) => /^Co-authored-by:/i.test(line)) : []),
     ...source.split("\n").filter(Boolean),
-  ];
+  ].filter((line) => !isMachineCredit(line));
   const missing = [...new Set(required)].filter((line) => !original.includes(line));
   // Keep explicit bytes, including CRLF and trailing blank lines. Insert new
   // credit before that suffix so all parsed trailers remain one terminal block.

--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -348,7 +348,6 @@ prepare_squash_merge_body() {
   source_trailers=$(git -c trailer.separators=: -c trailer.co-authored-by.key=Co-authored-by log --reverse \
     --no-show-signature --no-notes --no-color --no-decorate --encoding=UTF-8 \
     --format='%(trailers:key=Co-authored-by,only,unfold)' "$PR_MAIN_SHA..$source_head") || return 1
-  [ -n "$source_trailers" ] || [ -n "$captured" ] || return 0
 
   local repo_nwo preview
   repo_nwo=$(gh repo view --json nameWithOwner --jq .nameWithOwner) || return 1
@@ -357,9 +356,16 @@ prepare_squash_merge_body() {
     -f owner="${repo_nwo%/*}" -f name="${repo_nwo#*/}" -F number="$pr") || return 1
   if ! printf '%s\n' "$preview" | jq -e --arg head "$PREP_HEAD_SHA" '
     .data.repository.pullRequest | .headRefOid == $head and
-      (.viewerMergeBodyText | type == "string") and .isMergeQueueEnabled == false
+      (.viewerMergeBodyText | type == "string") and (.isMergeQueueEnabled | type == "boolean")
   ' >/dev/null; then
-    echo "Cannot preserve squash credit: require a current-head message from a non-queue PR. Refresh prepare evidence and check the merge queue policy." >&2
+    echo "Cannot preserve squash credit: require a current-head preview. Refresh prepare evidence and check the merge queue policy." >&2
+    return 1
+  fi
+
+  local queue_enabled
+  queue_enabled=$(printf '%s\n' "$preview" | jq -r '.data.repository.pullRequest.isMergeQueueEnabled') || return 1
+  if [ "$queue_enabled" = true ] && { [ -n "$source_trailers" ] || [ -n "$captured" ]; }; then
+    echo "Cannot preserve squash credit: body overrides require a non-queue PR." >&2
     return 1
   fi
 
@@ -368,6 +374,11 @@ prepare_squash_merge_body() {
   printf '%s\n' "$preview" | jq -c --arg source "$source_trailers" --arg captured "$captured" '
     {preview:.data.repository.pullRequest.viewerMergeBodyText,source:$source,captured:$captured}
   ' | node "${BASH_SOURCE[0]%/*}/merge-body.mjs" compose > "$body_file" || return 1
+  # Queue admission cannot accept an override, but its preview still needs validation.
+  if [ "$queue_enabled" = true ]; then
+    rm -f "$body_file" || return 1
+    return 0
+  fi
   printf '%s\n' "$body_file"
 }
 

--- a/test/scripts/pr-crabbox-merge-bypass.test.ts
+++ b/test/scripts/pr-crabbox-merge-bypass.test.ts
@@ -361,6 +361,9 @@ else if (args[0] === "pr" && args[1] === "checks" && args.includes("--required")
 } else if (args[0] === "pr" && args[1] === "view") out(args.includes("--jq") ? pr.headRefOid : pr);
 else if (args[0] === "pr" && args[1] === "merge") out("synthetic merge request accepted");
 else if (args[0] === "workflow" && args[1] === "run") { value.dispatched = true; save(); }
+else if (endpoint === "graphql" && args.some(arg => arg.includes("viewerMergeBodyText"))) {
+  out({data:{repository:{pullRequest:{...pr,viewerMergeBodyText:"Reviewed fixture body"}}}});
+}
 else if (endpoint === "graphql" && args.some(arg => arg.includes("repository(owner:"))) {
   out({data:{repository:{...repo,ref:{target:{oid:"${mainSha}"}},pullRequest:pr}}});
 } else if (endpoint === "user") out(args[args.indexOf("--jq")+1] === ".login" ? "relay-reader" : {login:"relay-reader"});
@@ -615,6 +618,8 @@ describe("Crabbox authorization before final effects", () => {
           "--admin",
           "--match-head-commit",
           headSha,
+          "--body-file",
+          expect.any(String),
         ]);
         expect(result.calls.indexOf(requests[0]!)).toBeGreaterThan(
           result.calls.indexOf(memberships[1]!),
@@ -629,7 +634,7 @@ describe("Crabbox authorization before final effects", () => {
       if (revoke) {
         expect(output).toContain("merge-verify passed for PR #131091");
         expect(
-          result.calls.filter((args) => args.some((arg) => arg.includes("repository(owner:"))),
+          result.calls.filter((args) => args.some((arg) => arg.includes("ref(qualifiedName:"))),
         ).toHaveLength(2);
       }
     },

--- a/test/scripts/pr-main-refresh.test-support.ts
+++ b/test/scripts/pr-main-refresh.test-support.ts
@@ -347,8 +347,10 @@ if (args[0] === 'pr' && args[1] === 'view') {
   }
   const parent = runGit(['-C', origin, 'rev-parse', 'refs/heads/main']);
   const tree = runGit(['-C', origin, 'merge-tree', '--write-tree', parent, control.metadata.headRefOid]);
+  const bodyIndex = args.indexOf('--body-file');
+  const body = bodyIndex < 0 ? '' : readFileSync(args[bodyIndex + 1], 'utf8');
   const landed = runGit(['-C', origin, '-c', 'user.name=Fixture', '-c',
-    'user.email=fixture@example.invalid', 'commit-tree', tree, '-p', parent], 'Fixture squash\\n');
+    'user.email=fixture@example.invalid', 'commit-tree', tree, '-p', parent], 'Fixture squash\\n\\n' + body);
   runGit(['-C', origin, 'update-ref', 'refs/heads/main', landed, parent]);
   control.metadata.state = 'MERGED';
   control.metadata.mergeCommit = { oid: landed };
@@ -392,6 +394,12 @@ if (args[0] === 'pr' && args[1] === 'view') {
         process.exit(1);
       }
       value = { data: { viewer: { login: 'fixture' } } };
+    } else if (args.some(arg => arg.includes('viewerMergeBodyText'))) {
+      value = { data: { repository: { pullRequest: {
+        headRefOid: control.metadata.headRefOid,
+        isMergeQueueEnabled: control.metadata.isMergeQueueEnabled,
+        viewerMergeBodyText: 'Reviewed fixture body',
+      } } } };
     } else if (args.some(arg => arg.includes('ref(qualifiedName:'))) {
       value = { data: { repository: {
         id: 'fixture-repo', nameWithOwner: 'fixture/repo', url: 'https://github.com/fixture/repo',

--- a/test/scripts/pr-merge-hosted.test.ts
+++ b/test/scripts/pr-merge-hosted.test.ts
@@ -183,7 +183,12 @@ describePosix("native hosted merge handoff", () => {
       "--squash",
       "--match-head-commit",
       f.head,
+      "--body-file",
+      expect.any(String),
     ]);
+    expect(f.git(f.origin, "log", "-1", "--format=%B", "main")).toBe(
+      "Fixture squash\n\nReviewed fixture body",
+    );
     expect(
       JSON.parse(f.git(f.canonical, "show", "refs/openclaw/pr-merge-outcomes/42:outcome.json")),
     ).toMatchObject({ head: f.head, route: "immediate", phase: "complete" });

--- a/test/scripts/pr-merge-outcome.test.ts
+++ b/test/scripts/pr-merge-outcome.test.ts
@@ -1426,7 +1426,7 @@ describePosix("native merge outcome with real Git and supervised lock recovery",
     const run = f.run();
     expect(run.status, run.output).toBe(0);
     expect(f.record().phase).toBe("complete");
-    expect(f.state().reads).toBe(5);
+    expect(f.state().observationReads).toBe(5);
     expect(f.state().settlementSleeps).toEqual([]);
     expect(f.state().mutations).toBe(1);
     expect(f.state().posts).toBe(1);

--- a/test/scripts/pr-merge.test.ts
+++ b/test/scripts/pr-merge.test.ts
@@ -176,6 +176,62 @@ file=$(prepare_squash_merge_body 123 "$snapshot")
 }
 
 describePosix("native squash attribution", () => {
+  it.each([
+    "Co-authored-by: Claude <noreply@anthropic.com>",
+    "co-authored-by: Claude <NOREPLY@ANTHROPIC.COM>",
+    "Co-Authored-By: Claude\n <noreply@anthropic.com>",
+  ])("omits imported machine credit while preserving human credit: %j", (machineCredit) => {
+    const humanCredit = [
+      "Co-authored-by: Claude <claude@example.com>",
+      "Co-authored-by: Human <person@anthropic.com>",
+      "Co-authored-by: Other <noreply@anthropic.com.example.org>",
+    ].join("\n");
+    const server = "Co-authored-by: Server <server@example.com>";
+    const result = prepareBody({
+      sourceMessages: [
+        `Repair\n\n${machineCredit}\n${humanCredit}`,
+        `Follow-up\n\n${machineCredit}`,
+      ],
+      previewBody: `Server description\n\n${machineCredit}\n${server}`,
+      overrideBody: `Reviewed correction.\r\n\r\n${server}\r\n\r\n`,
+      configuredTrailer: true,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe(`Reviewed correction.\r\n\r\n${server}\n${humanCredit}\r\n\r\n`);
+    expect(result.trailerCommandCalled).toBe(false);
+  });
+
+  it.each([undefined, "Reviewed correction.\n\nCo-authored-by: Claude <noreply@anthropic.com>\n"])(
+    "requires a reviewed body when the chosen message contains machine credit: %j",
+    (overrideBody) => {
+      const machineCredit = "Co-authored-by: Claude <noreply@anthropic.com>";
+      const result = prepareBody({
+        sourceMessages: [`Repair\n\n${machineCredit}`],
+        previewBody: `Server description\n\n${machineCredit}`,
+        overrideBody,
+      });
+      expect(result.status).toBe(1);
+      expect(result.mergeBody).toBeNull();
+      expect(result.stderr).toContain("--body-file");
+    },
+  );
+
+  it("rejects machine credit present only in the default server preview", () => {
+    const result = prepareBody({
+      sourceMessages: ["Repair"],
+      previewBody: "Server description\n\nCo-authored-by: Claude <noreply@anthropic.com>",
+    });
+    expect(result.status).toBe(1);
+    expect(result.mergeBody).toBeNull();
+    expect(result.stderr).toContain("--body-file");
+  });
+
+  it("keeps queue admission without a body override or source trailers", () => {
+    const result = prepareBody({ sourceMessages: ["Repair"], previewQueue: true });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBeNull();
+  });
+
   it("replaces obsolete closing prose while preserving operator, server and source credit", () => {
     const source = "Co-authored-by: Source <source@example.com>";
     const server = "Co-authored-by: Server <server@example.com>";


### PR DESCRIPTION
Related: #125906

## What Problem This Solves

Fixes an issue where maintainers supplying a reviewed squash message would have machine co-author attribution restored from contributor commits or GitHub's preview. That prevented landing a reviewed contributor repair while preserving its ancestry and human credit.

## Why This Change Was Made

The native composer excludes the exact machine address documented by [Claude Code's attribution settings](https://code.claude.com/docs/en/settings#attribution-settings) from imported credit. It preserves human names, human addresses, and explicit message bytes; it rejects a selected message that still contains machine attribution and directs the maintainer to a reviewed `--body-file`.

Default previews now receive the same validation even when source commits have no trailers. Queue admission without an override remains available after validation; source-credit and explicit-body overrides remain unavailable for queues. Contributor ancestry, review, CI, pinned-head, lock, and uncertain-outcome protections remain intact.

Maintainer decision on the review risk: retain the mandatory preview gate. An unavailable or machine-attributed default preview must stop before dispatch; non-queue callers can supply a reviewed correction with `--body-file`. Queue admission requires a clean preview because it cannot accept an override. The previous skip would leave machine attribution unchecked, so retaining it would defeat this repair.

## User Impact

Maintainers can finish contributor PRs using the native landing workflow while crediting their human contributors. There is no runtime or end-user behavior change. This is a tooling prerequisite discovered while preparing #125906, not a performance fix itself.

## Evidence

- Before the composer repair: five new cases failed and 29 existing cases passed. A separate default-preview regression then failed while 35 cases passed before its owner repair.
- `node scripts/run-vitest.mjs test/scripts/pr-merge.test.ts test/scripts/pr-wrappers.test.ts`: 99 passed.
- `node scripts/run-vitest.mjs test/scripts/pr-merge-outcome.test.ts -- -t 'snapshots corrected|explicit body admission|reconciles uncertain dispatch|with forward main during final receipt observation'`: 12 selected cases passed; 233 outside the selected scope.
- The real Git/shell fixtures cover imported source and server credit, case and folded trailers, duplicate credit, human names and provider-domain addresses, explicit CRLF bytes, configured trailer-command nonexecution, queue admission, body snapshots, and uncertain-dispatch recovery. GitHub responses are mocked; no production merge was used as a test.
- The local changed-file gate passed formatting and its preliminary guards, then stopped at the declaration-isolation boundary because this linked worktree uses shared dependencies. That guard remained intact; exact-head hosted CI with checkout-private dependencies completed the remaining type/lint verification.
- [Initial exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33983167233) found five fixture failures caused by the new preview request. The shared fixtures now answer that explicit request and carry the reviewed body into the synthetic landed commit. Read-count assertions use merge-state observations, retaining both admin membership checks and single-dispatch/no-retry assertions. The five failing cases plus the non-admin control pass in a focused six-test rerun.
- Fresh automated P0–P2 review and an independent source recheck of the fixture follow-up found no actionable findings. [Exact-head CI33985106754](https://github.com/openclaw/openclaw/actions/runs/33985106754) passed at `990d17c14a95d0d03a69f01a2ff50472edc3b7db`.
- Tooling LOC: +27/-5 (net +22); original regression tests: +56; follow-up tests and shared fixture: +21/-3. Growth implements the identity exclusion and mandatory preview validation at the existing owner, retaining its queue contract.

Focused CI-repair command (six selected cases passed):

```sh
node scripts/run-vitest.mjs test/scripts/pr-main-refresh.test.ts test/scripts/pr-merge-hosted.test.ts test/scripts/pr-merge-outcome.test.ts test/scripts/pr-crabbox-merge-bypass.test.ts -- -t 'completes supervised merge|dispatches once with the exact prepared head|reconciles a merged receipt without waiting|gates admin merge on'
```
