### PR TITLE
fix: unblock sessions after force-clearing stalled startup

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.agent-end-context.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.agent-end-context.test.ts
@@ -5,6 +5,7 @@ import { formatSqliteSessionFileMarker } from "openclaw/plugin-sdk/sqlite-runtim
 import { describe, expect, it, vi } from "vitest";
 import { dynamicToolBuildState } from "./dynamic-tool-build-state.js";
 import {
+  createCodexRuntimePlanFixture,
   createParams,
   createRuntimeDynamicTool,
   createStartedThreadHarness,
@@ -37,6 +38,7 @@ describe("runCodexAppServerAttempt agent-end context", () => {
         .spyOn(agentHarnessRuntime, "runAgentEndSideEffects")
         .mockImplementation(() => {});
       const params = createParams(sessionFile, workspaceDir);
+      params.runtimePlan = createCodexRuntimePlanFixture();
       const abortController = new AbortController();
       params.abortSignal = abortController.signal;
       params.sessionTarget = source;

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -24,6 +24,7 @@ import type {
 import { getAdmittedRunDelegatedAuthority } from "../../admitted-run-context.js";
 import { createAgentRunDirectAbortError } from "../../run-termination.js";
 import { withSessionPlacementTurnAdmission } from "../../session-placement-admission.js";
+import { resolveSessionPlacementTurnSettlementAssertion } from "../../session-placement-forced-terminal-settlement.js";
 import type { EmbeddedAgentRunResult } from "../types.js";
 import {
   EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
@@ -108,6 +109,7 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
   const noteLaneTaskProgress = () => {
     laneTaskProgressAtMs = Date.now();
   };
+  let assertPlacementCurrent: (() => void) | undefined;
   let activeAttemptOwner: object | undefined;
   const createAttemptControls = (input: {
     admittedRunContext: NonNullable<RunEmbeddedAgentParams["admittedRunContext"]>;
@@ -115,6 +117,8 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     initialTimeoutMs?: number;
     onAbort?: () => void;
   }) => {
+    // Awaited preflight may finish after recovery has released this lane's claim.
+    assertPlacementCurrent?.();
     const owner = {};
     activeAttemptOwner = owner;
     const lifecycleGeneration = options.getLifecycleGeneration();
@@ -187,6 +191,8 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     };
   };
   const throwIfAborted = () => {
+    // Bind only this lane's admitted claim; queued children can inherit a closed parent.
+    assertPlacementCurrent?.();
     if (!abortSignal.aborted) {
       return;
     }
@@ -312,7 +318,10 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
             runId: params.runId,
           },
           params,
-          task,
+          () => {
+            assertPlacementCurrent = resolveSessionPlacementTurnSettlementAssertion();
+            return task();
+          },
           () => {
             throwIfAborted();
             assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);

--- a/src/agents/session-placement-admission.ts
+++ b/src/agents/session-placement-admission.ts
@@ -1,3 +1,4 @@
+import { registerReplyOperationSuccessorBarrier } from "../auto-reply/reply/reply-run-registry.js";
 import type { SessionTranscriptRuntimeTarget } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createAbortError } from "../infra/abort-signal.js";
@@ -14,7 +15,11 @@ import { resolveEmbeddedRunSessionLanePolicy } from "./embedded-agent-runner/run
 import type { RunEmbeddedAgentParams } from "./embedded-agent-runner/run/params.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent-runner/types.js";
 import type { SandboxContext } from "./sandbox/types.js";
-import { resolveSessionPlacementTurnSettlementAssertion } from "./session-placement-forced-terminal-settlement.js";
+import {
+  resolveSessionPlacementForcedTerminalSettlement,
+  resolveSessionPlacementTurnSettlementAssertion,
+  withoutSessionPlacementForcedTerminalSettlement,
+} from "./session-placement-forced-terminal-settlement.js";
 import { settleRequesterAfterSessionSpawns } from "./subagents/registry/subagent-registry.js";
 
 export type LocalTurnPlacementClaim = {
@@ -101,14 +106,32 @@ export async function withSessionPlacementTurnAdmission(
   };
   // Providers may execute locally or remotely; both must release queue ownership
   // only when their actual execution path has acquired its placement claim.
-  const runAdmittedLocalTurn = () => {
+  const runAdmittedLocalTurn = async () => {
+    const settle = resolveSessionPlacementForcedTerminalSettlement();
+    const assertCurrent = resolveSessionPlacementTurnSettlementAssertion();
+    if (params.replyOperation && settle) {
+      // Preflight can stall before an embedded handle exists. The exact reply
+      // owner must release and fence its admitted claim before waking a successor.
+      registerReplyOperationSuccessorBarrier({
+        operation: params.replyOperation,
+        sessionId: claim.sessionId,
+        sessionKeys: [params.replyOperation.key],
+        start: settle,
+      });
+    }
+    assertCurrent?.();
     admitTurn();
-    return task();
+    assertCurrent?.();
+    const result = await task();
+    assertCurrent?.();
+    return result;
   };
   const provider = state.provider;
-  const result = provider
-    ? await provider.executeTurn(claim, params, runAdmittedLocalTurn, admitTurn)
-    : await runAdmittedLocalTurn();
+  const result = await withoutSessionPlacementForcedTerminalSettlement(() =>
+    provider
+      ? provider.executeTurn(claim, params, runAdmittedLocalTurn, admitTurn)
+      : runAdmittedLocalTurn(),
+  );
   if (result.meta.executionTrace?.runner === "cli") {
     settleYieldedRequesterAfterPlacementRelease(claim, result);
   }
@@ -172,9 +195,9 @@ export async function withLocalSessionPlacementTurnSettlement(
             open = false;
           }
         };
-        const result = provider
-          ? await provider.executeLocalTurn(claim, runLocal)
-          : await runLocal();
+        const result = await withoutSessionPlacementForcedTerminalSettlement(() =>
+          provider ? provider.executeLocalTurn(claim, runLocal) : runLocal(),
+        );
         settleYieldedRequesterAfterPlacementRelease(claim, result);
         return result;
       },

--- a/src/agents/session-placement-forced-terminal-settlement.ts
+++ b/src/agents/session-placement-forced-terminal-settlement.ts
@@ -1,7 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 
-// Carry exact local-turn cleanup until the embedded handle captures it; never recover by session id.
+// Carry exact local-turn cleanup to its reply and backend owners; never recover by session id.
 const forcedTerminalSettlement = resolveGlobalSingleton(
   Symbol.for("openclaw.sessionPlacementForcedTerminalSettlement"),
   () => new AsyncLocalStorage<{ settle: () => Promise<void>; assertCurrent: () => void }>(),
@@ -23,4 +23,11 @@ export function resolveSessionPlacementForcedTerminalSettlement():
 
 export function resolveSessionPlacementTurnSettlementAssertion(): (() => void) | undefined {
   return forcedTerminalSettlement.getStore()?.assertCurrent;
+}
+
+/** A new admission must acquire its own claim, never inherit its invoker's. */
+export function withoutSessionPlacementForcedTerminalSettlement<T>(
+  task: () => Promise<T>,
+): Promise<T> {
+  return forcedTerminalSettlement.exit(task);
 }

--- a/src/gateway/worker-environments/worker-turn-launcher.claim-recovery.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.claim-recovery.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { createEmbeddedRunLaneController } from "../../agents/embedded-agent-runner/run/lane-controller.js";
+import { abortAndDrainEmbeddedAgentRun } from "../../agents/embedded-agent-runner/runs.js";
+import {
+  installSessionPlacementAdmissionProvider,
+  withSessionPlacementTurnAdmission,
+  withLocalSessionPlacementTurnSettlement,
+  type SessionPlacementTurnParams,
+} from "../../agents/session-placement-admission.js";
+import { resolveSessionPlacementTurnSettlementAssertion } from "../../agents/session-placement-forced-terminal-settlement.js";
+import {
+  createReplyOperation,
+  forceClearReplyOperation,
+} from "../../auto-reply/reply/reply-run-registry.js";
+import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
+import {
+  SESSION_ID,
+  SESSION_KEY,
+  cleanupWorkerTurnLauncherTest,
+  createWorkerSessionTurnPlacementProvider,
+  placements,
+  setupWorkerTurnLauncherTest,
+  turn,
+  unusedEnvironments,
+} from "./worker-turn-launcher.test-support.js";
+
+function createLane(initialParams: SessionPlacementTurnParams) {
+  let params = initialParams;
+  let generation = getAgentEventLifecycleGeneration();
+  return createEmbeddedRunLaneController({
+    getParams: () => params,
+    setParams: (value) => {
+      params = value;
+    },
+    getLifecycleGeneration: () => generation,
+    setLifecycleGeneration: (value) => {
+      generation = value;
+    },
+    initialQueuedLifecycleGeneration: generation,
+    globalLane: "claim-recovery-global",
+    sessionLane: `claim-recovery-session:${params.sessionId}`,
+  });
+}
+
+describe("local claim recovery before backend registration", () => {
+  beforeEach(setupWorkerTurnLauncherTest);
+  afterEach(cleanupWorkerTurnLauncherTest);
+
+  it.each(["local", "standalone", "remote"] as const)(
+    "admits a queued %s child after its inherited parent claim closes",
+    async (execution) => {
+      const provider = createWorkerSessionTurnPlacementProvider({
+        environments: unusedEnvironments(),
+        placements,
+      });
+      const gate = createDeferred();
+      const localTask = vi.fn(async () => {
+        if (execution === "local") {
+          expect(placements.get(SESSION_ID)?.turnClaim?.runId).toBe("child-run");
+        }
+        return { meta: { durationMs: 1 } };
+      });
+      const remoteTask = vi.fn<typeof provider.executeTurn>(
+        async (_claim, _params, _runLocal, onAdmitted) => {
+          onAdmitted?.();
+          return { meta: { durationMs: 2 } };
+        },
+      );
+      let uninstall = installSessionPlacementAdmissionProvider(provider);
+      let child: Promise<unknown> | undefined;
+      let assertParent: (() => void) | undefined;
+      try {
+        await provider.executeLocalTurn(
+          {
+            sessionId: "parent-session",
+            sessionKey: "agent:main:parent",
+            agentId: "main",
+            runId: "parent-run",
+          },
+          async () => {
+            assertParent = resolveSessionPlacementTurnSettlementAssertion();
+            const lane = createLane(turn("child-run"));
+            child = lane.enqueueSession(async () => {
+              await gate.promise;
+              lane.throwIfAborted();
+              return lane.enqueueGlobal(localTask);
+            });
+          },
+        );
+        expect(assertParent).toBeTypeOf("function");
+        expect(assertParent).toThrow("settlement is closed");
+        if (execution !== "local") {
+          uninstall();
+          uninstall = () => {};
+        }
+        if (execution === "remote") {
+          uninstall = installSessionPlacementAdmissionProvider({
+            assertCompactionSuccessorAllowed: () => {},
+            executeLocalTurn: provider.executeLocalTurn,
+            executeTurn: remoteTask,
+          });
+        }
+        gate.resolve();
+        await expect(child).resolves.toMatchObject({
+          meta: { durationMs: execution === "remote" ? 2 : 1 },
+        });
+        expect(localTask).toHaveBeenCalledTimes(execution === "remote" ? 0 : 1);
+        expect(remoteTask).toHaveBeenCalledTimes(execution === "remote" ? 1 : 0);
+        expect(placements.get(SESSION_ID)?.turnClaim ?? null).toBeNull();
+      } finally {
+        gate.resolve();
+        await Promise.allSettled([child]);
+        uninstall();
+      }
+    },
+  );
+
+  it.each(["embedded", "CLI"] as const)(
+    "isolates standalone %s admission from a retired parent settlement",
+    async (execution) => {
+      const provider = createWorkerSessionTurnPlacementProvider({
+        environments: unusedEnvironments(),
+        placements,
+      });
+      const gate = createDeferred();
+      const task = vi.fn(async () => ({ meta: { durationMs: 1 } }));
+      let child: Promise<unknown> | undefined;
+      let assertParent: (() => void) | undefined;
+      await provider.executeLocalTurn(
+        {
+          sessionId: "parent-session",
+          sessionKey: "agent:main:parent",
+          agentId: "main",
+          runId: "parent-run",
+        },
+        async () => {
+          assertParent = resolveSessionPlacementTurnSettlementAssertion();
+          child = gate.promise.then(() => {
+            const params = turn("standalone-run");
+            return execution === "CLI"
+              ? withLocalSessionPlacementTurnSettlement(params, task)
+              : withSessionPlacementTurnAdmission(params, params, task);
+          });
+        },
+      );
+      try {
+        expect(assertParent).toThrow("settlement is closed");
+        gate.resolve();
+        await expect(child).resolves.toMatchObject({ meta: { durationMs: 1 } });
+        expect(task).toHaveBeenCalledOnce();
+      } finally {
+        gate.resolve();
+        await Promise.allSettled([child]);
+      }
+    },
+  );
+
+  it.each(["preflight", "attempt admission", "terminal result"])(
+    "releases a force-cleared reply before backend registration and fences its late %s",
+    async (stage) => {
+      const provider = createWorkerSessionTurnPlacementProvider({
+        environments: unusedEnvironments(),
+        placements,
+      });
+      const uninstall = installSessionPlacementAdmissionProvider(provider);
+      const operation = createReplyOperation({
+        sessionKey: SESSION_KEY,
+        sessionId: SESSION_ID,
+        resetTriggered: false,
+      });
+      const params = { ...turn("run-preflight"), replyOperation: operation };
+      const lane = createLane(params);
+      const started = createDeferred();
+      const resume = createDeferred();
+      const replacementStarted = createDeferred();
+      const finishReplacement = createDeferred();
+      const modelStart = vi.fn();
+      let oldRun: Promise<unknown> | undefined;
+      let replacement: Promise<unknown> | undefined;
+      try {
+        oldRun = lane.enqueueGlobal(async () => {
+          const admittedRunContext = await params.preparedRunAdmission.admit("embedded");
+          started.resolve();
+          await resume.promise;
+          if (stage === "preflight") {
+            lane.throwIfAborted();
+          } else if (stage === "attempt admission") {
+            lane.createAttemptControls({ admittedRunContext }).close();
+          }
+          modelStart();
+          return { meta: { durationMs: 1 } };
+        });
+        // Observe rejection immediately so a failing assertion still cleans up the old turn.
+        const oldOutcome = oldRun.then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+        await started.promise;
+        expect(placements.get(SESSION_ID)?.turnClaim).not.toBeNull();
+        await expect(
+          abortAndDrainEmbeddedAgentRun({
+            sessionId: SESSION_ID,
+            sessionKey: SESSION_KEY,
+            settleMs: 100,
+            forceClear: true,
+            reason: "stuck_recovery",
+          }),
+        ).resolves.toMatchObject({ forceCleared: true });
+        expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
+
+        replacement = provider.executeLocalTurn({ ...params, runId: "replacement" }, async () => {
+          replacementStarted.resolve();
+          await finishReplacement.promise;
+        });
+        await replacementStarted.promise;
+        const replacementClaim = placements.get(SESSION_ID)?.turnClaim?.claimId;
+        resume.resolve();
+        expect(await oldOutcome).toMatchObject({
+          message: "session placement turn settlement is closed",
+        });
+        expect(modelStart).toHaveBeenCalledTimes(stage === "terminal result" ? 1 : 0);
+        expect(placements.get(SESSION_ID)?.turnClaim?.claimId).toBe(replacementClaim);
+      } finally {
+        resume.resolve();
+        finishReplacement.resolve();
+        await Promise.allSettled([oldRun, replacement]);
+        operation.complete();
+        params.preparedRunAdmission.close();
+        uninstall();
+      }
+    },
+  );
+
+  it.each(["before", "during"])(
+    "does not start local work for a reply cleared %s admission",
+    async (timing) => {
+      const provider = createWorkerSessionTurnPlacementProvider({
+        environments: unusedEnvironments(),
+        placements,
+      });
+      const uninstall = installSessionPlacementAdmissionProvider(provider);
+      const operation = createReplyOperation({
+        sessionKey: SESSION_KEY,
+        sessionId: SESSION_ID,
+        resetTriggered: false,
+      });
+      const params = { ...turn("run-cleared-before-admission"), replyOperation: operation };
+      const run = vi.fn(async () => ({ meta: { durationMs: 1 } }));
+      try {
+        if (timing === "before") {
+          forceClearReplyOperation(operation);
+        }
+        await expect(
+          withSessionPlacementTurnAdmission(params, params, run, () => {
+            if (timing === "during") {
+              forceClearReplyOperation(operation);
+            }
+          }),
+        ).rejects.toThrow("settlement is closed");
+        expect(run).not.toHaveBeenCalled();
+        expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
+      } finally {
+        operation.complete();
+        uninstall();
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #139242.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users cannot get another reply after force-clearing a turn stalled in sandbox startup, before its backend run handle is registered.

## Why This Change Was Made

Bind the existing exact-claim settlement to the reply operation immediately after local admission. Keep its assertion in the admitted execution lane so abandoned startup and late results cannot execute under or release a replacement claim. Fresh child admission gets its own settlement context.

## User Impact

The next message can run after recovery. The abandoned turn cannot deliver a late answer or release its successor's claim. Existing registered-handle cleanup remains available.

## Evidence

Verified current-main baseline `676845210acb1d5eb8667ae6d0811a8e7b6f0f2b` and product candidate `a818086565a03cf767b816038574b8573ea66855` through isolated, built Gateways:

| Observation | Main | Candidate |
| --- | --- | --- |
| First sandbox startup held after durable claim, before backend handle | Observed | Observed |
| Force-clear result | `aborted=false drained=false forceCleared=true` | Same |
| Old claim after force-clear | Still held | Released |
| Next message through `chat.send` | Active-turn-claim error; no answer | New claim; exactly one answer |
| Old startup released while successor owns claim | Successor cannot acquire | Successor claim unchanged; no old model request or answer |

The fixture uses the shipped sandbox plugin interface and real SSH workspace preparation. Recovery calls the shipped `abortAndDrainAgentHarnessRun` interface used by the production recovery owner. A deterministic QA provider holds the successor response while the old startup is released. Admission, queues, SQLite claims, runtime execution, and Gateway delivery are real; no claim-store writes or restart substitute for recovery. This is isolated Gateway proof, not authenticated Telegram or native Codex-provider proof.

Controls passed: normal completion; registered backend recovery and exact release; another session's claim and answer preserved; non-forced recovery leaves an unsettled startup claim intact. The registered product control drained cooperatively; existing focused tests cover the noncooperative force-clear branch.

- Independent source-blind validation passed all 10 prewritten behavior clauses, including the old run's lifecycle generation and exactly one successful release per claim.
- Fresh AutoReview found no actionable P0/P1 issues.
- The added regression module on unchanged baseline production failed 6 cases and passed 4; the same module passes on the candidate.
- 40 focused owner tests passed across `worker-turn-launcher.test.ts` and `worker-turn-launcher.claim-recovery.test.ts`.
- Both QA runtime builds passed; all changed files passed pinned formatting and `git diff --check`.
- The earlier [test timeout](https://github.com/openclaw/openclaw/actions/runs/33983261184/job/101352246420) came from missing test setup: tools were enabled without a prepared runtime plan, causing cold real-provider loading. This PR adopts the existing reviewed [two-line fixture correction](https://github.com/openclaw/openclaw/commit/f63e26d5baba8beaa5b892ca3f8f8862a46bdb82). All three outcomes pass with unchanged assertions and timeouts; focused formatting and review pass. No check is bypassed.
- Current head `94f48f09cb3a664f9e3b81d0d4ec4c124e463fb8` adds only that test correction to the tested product candidate. Runtime, build, dependency, and provider-fixture inputs are unchanged, so the original builds and all 10 acceptance clauses retain their actual tested identities. Fresh checks and review run on the new head.

Production +50/−11 (net +39), tests +271: this extends the existing settlement owner rather than adding a new recovery mechanism or configuration. Separate follow-ups: direct CLI pre-backend claim recovery remains a pre-existing sibling gap; sandbox subprocess cancellation remains outside this repair.

AI-assisted implementation and verification.
