### PR TITLE
perf(agents): prepare exact tool names once per catalog batch

### DIFF
--- a/src/agents/agent-tool-availability.test.ts
+++ b/src/agents/agent-tool-availability.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  bindAgentToolAvailability,
   finalizeAgentToolAvailability,
   markAgentToolExecutionUnavailable,
 } from "./agent-tool-availability.js";
@@ -45,6 +46,94 @@ beforeEach(() => {
     childSessionKey: "agent:main:subagent:child",
     runId: "child",
     context: "isolated",
+  });
+});
+
+describe("execution allowlist availability", () => {
+  const sparseAllow: string[] = [];
+  sparseAllow.length = 1;
+  it.each([
+    {
+      label: "aliases",
+      allow: [" BASH ", "apply-PATCH", " CRON "],
+      expected: ["exec", "apply_patch", "automations"],
+    },
+    { label: "blank names", allow: [" \t "], expected: ["", "   "] },
+    {
+      label: "literal names",
+      allow: ["write", "web_*", "*", "group:fs"],
+      expected: ["WRITE", "web_*", "*", "group:fs"],
+    },
+    { label: "empty list", allow: [], expected: [] },
+    { label: "sparse list", allow: sparseAllow, expected: [] },
+  ])("prepares callable tools from frozen $label", ({ allow, expected }) => {
+    const tools = [
+      "exec",
+      "apply_patch",
+      "automations",
+      "WRITE",
+      "read",
+      "web_fetch",
+      "web_*",
+      "*",
+      "group:fs",
+      "",
+      "   ",
+    ].map((name) => ({ name, description: name, parameters: { type: "object", properties: {} } }));
+    let callableNames: string[] = [];
+    bindAgentToolAvailability(tools[0]!, {
+      prepare: (_tool, callableTools) => {
+        callableNames = [...callableTools.keys()];
+      },
+    });
+
+    finalizeAgentToolAvailability(tools, { toolExecutionAllow: Object.freeze(allow) });
+
+    expect(callableNames).toEqual(expected);
+  });
+
+  it("reads current execution caps when restricting and rebuilding a catalog", async () => {
+    const catalogConfig = {
+      ...config,
+      tools: { toolSearch: { enabled: true, mode: "tools" as const } },
+    };
+    const catalogRef = createToolSearchCatalogRef();
+    const controls = createToolSearchTools({ config: catalogConfig, catalogRef });
+    const tool = spawnTool();
+    const params = {
+      tools: [...controls, tool, reader()],
+      config: catalogConfig,
+      catalogRef,
+      toolExecutionAllow: ["sessions_spawn", "agents_wait"],
+    };
+    const expectUnavailable = async () => {
+      await expect(tool.execute("denied", { task: "inspect", collect: true })).rejects.toThrow(
+        "Collector results are unavailable",
+      );
+      expect(tool.parameters).not.toHaveProperty("properties.collect");
+      expect(spawn).not.toHaveBeenCalled();
+    };
+    try {
+      applyToolSearchCatalog(params);
+      expect(tool.parameters).toHaveProperty("properties.collect");
+
+      params.toolExecutionAllow[1] = "read";
+      restrictToolSearchCatalog({
+        catalogRef,
+        allowedToolNames: new Set(["sessions_spawn", "agents_wait"]),
+      });
+      await expectUnavailable();
+
+      params.toolExecutionAllow[1] = "agents_wait";
+      applyToolSearchCatalog(params);
+      expect(tool.parameters).toHaveProperty("properties.collect");
+
+      params.toolExecutionAllow = ["sessions_spawn", "read"];
+      applyToolSearchCatalog(params);
+      await expectUnavailable();
+    } finally {
+      clearToolSearchCatalog({ catalogRef });
+    }
   });
 });
 

--- a/src/agents/agent-tool-availability.ts
+++ b/src/agents/agent-tool-availability.ts
@@ -1,4 +1,4 @@
-import { isToolExecutionAllowed } from "./tool-policy-shared.js";
+import { createToolExecutionMatcher } from "./tool-policy-shared.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 type ToolDefinition = Pick<AnyAgentTool, "name" | "parameters" | "description">;
@@ -55,16 +55,17 @@ export function finalizeAgentToolAvailability<T extends ToolDefinition>(
   // The caller supplies its winning definitions, including non-native shadows.
   // A missing, quarantined, or execution-denied dependency cannot enable a mode.
   const winners = new Map(tools.map((tool) => [tool.name, tool]));
-  const callableTools = new Map(
-    [...winners.values()]
-      .filter(
-        (tool) =>
-          !availabilityBindings.get(tool)?.executionDenied &&
-          (!options?.toolExecutionAllow ||
-            isToolExecutionAllowed(options.toolExecutionAllow, tool.name)),
-      )
-      .map((tool) => [tool.name, tool]),
-  );
+  const executionAllowed = options?.toolExecutionAllow
+    ? createToolExecutionMatcher(options.toolExecutionAllow)
+    : undefined;
+  const callableTools = new Map<string, T>();
+  for (const callableTool of [...winners.values()].filter(
+    (tool) =>
+      !availabilityBindings.get(tool)?.executionDenied &&
+      (!executionAllowed || executionAllowed(tool.name)),
+  )) {
+    callableTools.set(callableTool.name, callableTool);
+  }
   for (const tool of tools) {
     const binding = availabilityBindings.get(tool)?.binding;
     if (binding) {

--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
@@ -21,7 +21,10 @@ import {
 import { filterLocalModelLeanTools } from "../../local-model-lean.js";
 import { logAgentRuntimeToolDiagnostics } from "../../runtime-plan/tools.js";
 import { buildEmptyExplicitToolAllowlistError } from "../../tool-allowlist-guard.js";
-import { isToolExecutionAllowed, TOOL_EXECUTION_GATED_MESSAGE } from "../../tool-policy-shared.js";
+import {
+  createToolExecutionMatcher,
+  TOOL_EXECUTION_GATED_MESSAGE,
+} from "../../tool-policy-shared.js";
 import { filterRuntimeCompatibleTools } from "../../tool-schema-projection.js";
 import { logRuntimeToolSchemaQuarantine } from "../../tool-schema-quarantine.js";
 import { TOOL_SEARCH_CONTROL_TOOL_NAMES } from "../../tool-search-types.js";
@@ -293,8 +296,9 @@ function gateToolExecution(
   tools: readonly AnyAgentTool[],
   allowNames: readonly string[],
 ): AnyAgentTool[] {
+  const executionAllowed = createToolExecutionMatcher(allowNames);
   return tools.map((tool) =>
-    isToolExecutionAllowed(allowNames, tool.name) || TOOL_SEARCH_CONTROL_TOOL_NAMES.has(tool.name)
+    executionAllowed(tool.name) || TOOL_SEARCH_CONTROL_TOOL_NAMES.has(tool.name)
       ? tool
       : markAgentToolExecutionUnavailable(
           copyAgentToolAvailability(tool, {

--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -63,6 +63,13 @@ export function isToolExecutionAllowed(allowNames: readonly string[], toolName: 
   return allowNames.some((name) => normalizeToolPolicyName(name) === target);
 }
 
+/** Snapshot exact names for one synchronous batch; never retain this matcher across awaits. */
+export function createToolExecutionMatcher(allowNames: readonly string[]) {
+  const allowed = new Set<string>();
+  allowNames.forEach((name) => allowed.add(normalizeToolPolicyName(name)));
+  return (toolName: string) => allowed.has(normalizeToolPolicyName(toolName));
+}
+
 /** Normalizes a tool name or alias to the policy id used for matching. */
 export function normalizeToolPolicyName(name: string): string {
   const normalized = normalizeLowercaseStringOrEmpty(name);


### PR DESCRIPTION
## What Problem This Solves

Preparing a prompt tool catalog repeatedly normalizes the same execution allowlist for every tool. Larger populated allowlists pay that repeated work in both catalog gating and callable-tool preparation.

## Why This Change Was Made

Prepare exact normalized names once per synchronous batch and share that matcher through the existing owner. The matcher does not escape those synchronous operations. Later execution checks keep reading the current allowlist; no persistent cache or authority rule changes.

This also removes the intermediate callable-map tuple allocation while retaining the existing filter-before-prepare ordering. Production: +25/−13 (**+12**); tests: +89. The growth separates synchronous prepared facts from live execution checks, rather than making a retained cache serve both lifetimes.

## User Impact

No intended change to available tools, aliases, literal wildcard/group names, denied-tool metadata, winner order, or mutable-cap behavior. Populated synthetic prompt-policy workloads improve in both measurement orders. This does not establish an end-to-end Gateway or cold-start speedup.

## Evidence

- Historical baseline and candidate: 162 passing cases in eight complete owner/sibling files, including catalog callable output and cap mutation/replacement. Preservation tests pass before the refactor; this is not a failing-before bug fix.
- Fresh composition on main `426ca0d50f303c7cbec46741be7ff51e99145a18`: the same eight complete files pass all 162 current cases, and the full normal changed-file gate passes. Main changed four skill-policy case names/assertions since the historical pair; those inventories are not claimed identical. The newer refusal wording is preserved.
- Twelve-pass independent managed Codex review: no actionable P0–P2 findings. Root separately inspected owners, callers, siblings, current-main composition and dependency contracts.
- Fixed B0/C0/C1/B1 complete-operation measurements retain 4,384 operations, 512 batch means and all 195 adverse comparisons. Prompt-apply medians improve **3.55%/5.01%** with 8 names, **16.13%/20.78%** with 32, and **58.06%/59.64%** with 128. Those sizes are synthetic, not observed default frequencies.
- Opposing costs remain: the empty-cap path is **0.310/0.375 µs slower (4.32%/5.14%)**; constructor timings are mixed and some maxima worsen substantially. No allocation, retained-memory, cold-start or universal performance gain is claimed.
- The historical numerical cohort remains bound to base `8797856260efeb94b71d88029850409416d7f74c`; the operation is preserved in the current composition, but the old timings were not relabeled as a current-base cohort. Original lint failures and their corrections are retained.

Focused verification:

```sh
node scripts/run-vitest.mjs src/agents/agent-tool-availability.test.ts src/agents/tool-policy.test.ts src/agents/openclaw-tools.registration.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-tool-policy.test.ts src/agents/embedded-agent-runner/run/attempt.skills-policy.test.ts src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts src/agents/code-mode-swarm.lazy.test.ts src/agents/code-mode-swarm.test.ts
pnpm check:changed --timed -- src/agents/agent-tool-availability.test.ts src/agents/agent-tool-availability.ts src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts src/agents/tool-policy-shared.ts
```

The focused checks exercise the actual policy/catalog owner boundaries. No built CLI, live provider turn, or before/after Gateway timing was run with this patch; campaign live observations from another candidate are not reused as its proof. This bounded behavior-neutral refactor uses focused checks proportional to its unchanged contract.
