### PR TITLE
fix: Windows worktrees and Git backups fail with MSYS2 Git

### DIFF
--- a/src/agents/worktrees/git.test.ts
+++ b/src/agents/worktrees/git.test.ts
@@ -1,15 +1,56 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, expectTypeOf, it } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { SpawnResult } from "../../process/exec.js";
+import * as processExec from "../../process/exec.js";
+import * as windowsCommand from "../../process/windows-command.js";
 import {
   commandError,
   findGitCheckoutRoot,
   hasSelfContainedGitMetadata,
   insideGitCheckout,
+  listGitWorktrees,
   runGit,
 } from "./git.js";
+
+it("preserves worktree identity and foreign locks from MSYS porcelain paths", async () => {
+  vi.stubGlobal("process", { ...process, platform: "win32" });
+  const success = {
+    code: 0,
+    stderr: "",
+    signal: null,
+    killed: false,
+    termination: "exit" as const,
+  };
+  try {
+    vi.spyOn(fsSync, "existsSync").mockImplementation((file) =>
+      String(file).endsWith("msys-2.0.dll"),
+    );
+    vi.spyOn(processExec, "runCommandWithTimeout").mockResolvedValue({
+      ...success,
+      stdout: "worktree /c/repo\0\0worktree /d/linked checkout\0locked other owner\0\0",
+    });
+    vi.spyOn(windowsCommand, "resolveSafeChildProcessInvocation").mockReturnValue({
+      command: "C:\\msys64\\usr\\bin\\git.exe",
+      args: [],
+      usesWindowsExitCodeShim: false,
+      windowsHide: true,
+    });
+    vi.spyOn(processExec, "runUtf8CommandWithTimeout").mockImplementation(async (argv) => ({
+      ...success,
+      stdout: argv.at(-1) === "/c/repo" ? "C:\\repo\n" : "D:\\linked checkout\n",
+    }));
+    await expect(listGitWorktrees("C:\\repo")).resolves.toEqual([
+      { path: "C:\\repo" },
+      { path: "D:\\linked checkout", lockedReason: "other owner" },
+    ]);
+  } finally {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  }
+});
 
 describe("Git checkout discovery", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);

--- a/src/agents/worktrees/git.ts
+++ b/src/agents/worktrees/git.ts
@@ -9,6 +9,7 @@ import {
   requireGitCommandBuffer,
   requireGitCommandRaw,
 } from "../../infra/git-exec.js";
+import { resolveGitPath } from "../../infra/git-path.js";
 
 export type GitResult = Awaited<ReturnType<typeof executeGitCommand>>;
 
@@ -106,8 +107,14 @@ function parseWorktreeList(output: string): WorktreeListEntry[] {
 }
 
 export async function listGitWorktrees(repoRoot: string): Promise<WorktreeListEntry[]> {
-  return parseWorktreeList(
+  const entries = parseWorktreeList(
     await requireGitRaw(repoRoot, ["worktree", "list", "--porcelain", "-z"]),
+  );
+  return await Promise.all(
+    entries.map(async (entry) => {
+      entry.path = await resolveGitPath(entry.path);
+      return entry;
+    }),
   );
 }
 

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -7,6 +7,7 @@ import { getRuntimeConfig, type OpenClawConfig } from "../../config/config.js";
 import { resolveStateDir } from "../../config/paths.js";
 import { isMissingPathError, formatErrorMessage } from "../../infra/errors.js";
 import { root as fsRoot } from "../../infra/fs-safe.js";
+import { resolveGitPath } from "../../infra/git-path.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
@@ -261,12 +262,14 @@ async function resolveRepositoryFromRealPath(
     }
     throw new WorktreeRepositoryError(`not a git checkout: ${requestedLabel}`);
   }
-  const sourceRoot = await fs.realpath(rootResult.stdout.trim());
+  const sourceRoot = await fs.realpath(await resolveGitPath(rootResult.stdout.trim()));
   const headResult = await runGit(sourceRoot, ["rev-parse", "--verify", "HEAD^{commit}"]);
   if (headResult.code !== 0) {
     throw new WorktreeRepositoryError(`git checkout has no commits: ${requestedLabel}`);
   }
-  const commonRaw = await requireGit(sourceRoot, ["rev-parse", "--git-common-dir"]);
+  const commonRaw = await resolveGitPath(
+    await requireGit(sourceRoot, ["rev-parse", "--git-common-dir"]),
+  );
   const commonDir = await fs.realpath(
     path.isAbsolute(commonRaw) ? commonRaw : path.resolve(sourceRoot, commonRaw),
   );
@@ -726,7 +729,9 @@ async function prepareSnapshotIndex(
       }
     }
   }
-  const commonDir = await requireGit(record.repoRoot, ["rev-parse", "--git-common-dir"]);
+  const commonDir = await resolveGitPath(
+    await requireGit(record.repoRoot, ["rev-parse", "--git-common-dir"]),
+  );
   requireWorktreeDiskSpace(
     [
       { path: path.resolve(record.repoRoot, commonDir), bytes: 2 * gitBytes + metadataBytes },

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -15,6 +15,7 @@ import { ScheduledTaskAutoStartRecoveryError } from "../daemon/schtasks-update-r
 import { readGatewayServiceState, resolveGatewayService } from "../daemon/service.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { resolveGitPath } from "../infra/git-path.js";
 import type { UpdateRecovery } from "../infra/update-recovery.js";
 import { UPDATE_RUNNER_TIMEOUT_MS } from "../infra/update-runner-command.js";
 import { runGatewayUpdate } from "../infra/update-runner.js";
@@ -47,7 +48,7 @@ async function detectOpenClawGitCheckout(root: string): Promise<"git" | "not-git
     }
     return "unknown";
   }
-  const gitRoot = res.stdout.trim();
+  const gitRoot = await resolveGitPath(res.stdout.trim(), { timeoutMs: 5000 });
   return (await resolveComparablePath(gitRoot)) === (await resolveComparablePath(root))
     ? "git"
     : "not-git";

--- a/src/gateway/github-publication-git-index.ts
+++ b/src/gateway/github-publication-git-index.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveGitPath } from "../infra/git-path.js";
 import { GitHubPublicationWorkspaceChangedError } from "./github-publication-failure.js";
 
 type GitCommandOptions = { cwd?: string; env?: NodeJS.ProcessEnv; input?: string };
@@ -108,7 +109,10 @@ export async function recoverGitHubPublicationBranchAndIndex(params: {
   const rawIndexPath = await params.run(["git", "rev-parse", "--git-path", "index"], {
     cwd: params.cwd,
   });
-  const indexPath = path.resolve(params.cwd, rawIndexPath);
+  const indexPath = path.resolve(
+    params.cwd,
+    await resolveGitPath(rawIndexPath, { cwd: params.cwd, timeoutMs: 60_000 }),
+  );
   const lockPath = `${indexPath}.lock`;
   const recoveryPath = publicationRecoveryPath(indexPath, params.requestId);
   if (!(await pathExists(recoveryPath))) {
@@ -201,7 +205,10 @@ export async function updateGitHubPublicationBranchAndIndex(params: {
     const rawIndexPath = await params.run(["git", "rev-parse", "--git-path", "index"], {
       cwd: params.cwd,
     });
-    const indexPath = path.resolve(params.cwd, rawIndexPath);
+    const indexPath = path.resolve(
+      params.cwd,
+      await resolveGitPath(rawIndexPath, { cwd: params.cwd, timeoutMs: 60_000 }),
+    );
     lockPath = `${indexPath}.lock`;
     recoveryPath = publicationRecoveryPath(indexPath, params.requestId);
     const gitEnv = {

--- a/src/gateway/github-publication-git-transport.ts
+++ b/src/gateway/github-publication-git-transport.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveGitPath } from "../infra/git-path.js";
 import { runCommandBuffered } from "../process/exec.js";
 import { githubPublicationUnsafeConfigArgs } from "./github-publication-base.js";
 
@@ -102,7 +103,10 @@ export async function assertSafeGitPublicationWorkspace(
     throw new Error("GitHub publication workspace has unsupported Git replacement metadata.");
   }
   const grafts = await readOptionalAttributeFile(
-    path.resolve(cwd, graftPath.stdout.toString("utf8").trim()),
+    path.resolve(
+      cwd,
+      await resolveGitPath(graftPath.stdout.toString("utf8").trim(), { cwd, timeoutMs: 60_000 }),
+    ),
   );
   if (grafts && grafts.length > 0) {
     throw new Error("GitHub publication workspace has unsupported Git replacement metadata.");
@@ -187,13 +191,18 @@ async function assertGitHubPublicationTreeHasNoFilters(
     throw new Error("GitHub publication workspace attributes could not be verified.");
   }
   const paths = [
-    path.resolve(cwd, infoPath.stdout.toString("utf8").trim()),
+    path.resolve(
+      cwd,
+      await resolveGitPath(infoPath.stdout.toString("utf8").trim(), { cwd, timeoutMs: 60_000 }),
+    ),
     ...attributeFiles.flatMap((result) =>
       result.stdout.length > 0 ? [result.stdout.toString("utf8").trim()] : [],
     ),
   ];
   for (const file of paths) {
-    const contents = await readOptionalAttributeFile(file);
+    const contents = await readOptionalAttributeFile(
+      await resolveGitPath(file, { cwd, timeoutMs: 60_000 }),
+    );
     if (contents) {
       assertNoGitFilterAttributes(contents);
     }

--- a/src/gateway/worker-environments/node-worker-workspace-fallback.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-fallback.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveGitPath } from "../../infra/git-path.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { runCommandWithTimeout, type SpawnResult } from "../../process/exec.js";
 import type {
@@ -146,7 +147,11 @@ async function inspectEligibleOrigin(localPath: string): Promise<OriginInspectio
     const canonicalPath = await fs.realpath(localPath);
     let root: string;
     try {
-      root = await fs.realpath(await localGit(canonicalPath, ["rev-parse", "--show-toplevel"]));
+      root = await fs.realpath(
+        await resolveGitPath(await localGit(canonicalPath, ["rev-parse", "--show-toplevel"]), {
+          timeoutMs: GIT_TIMEOUT_MS,
+        }),
+      );
     } catch {
       return { kind: "fallback", reason: "not-git-workspace" };
     }

--- a/src/gateway/worker-environments/workspace-git-base.ts
+++ b/src/gateway/worker-environments/workspace-git-base.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { commandError, requireGit, runGit } from "../../agents/worktrees/git.js";
+import { resolveGitPath } from "../../infra/git-path.js";
 import { hasNodeErrorCode } from "../../infra/path-guards.js";
 import { workerSshCommandOptions } from "./ssh.js";
 import {
@@ -41,7 +42,10 @@ export async function prepareWorkerProjectSnapshot(params: {
     env: workerSshCommandOptions({ timeoutMs: GIT_TIMEOUT_MS }).baseEnv,
   };
   const gitRoot = await fsp.realpath(
-    await requireGit(root, ["rev-parse", "--show-toplevel"], options),
+    await resolveGitPath(
+      await requireGit(root, ["rev-parse", "--show-toplevel"], options),
+      options,
+    ),
   );
   if (gitRoot !== root) {
     throw new Error("Worker git workspace sync requires the managed worktree root");
@@ -58,7 +62,10 @@ export async function prepareWorkerProjectSnapshot(params: {
     throw new Error("Worker workspace Git base is not a commit id");
   }
   const commonDir = await fsp.realpath(
-    await requireGit(root, ["rev-parse", "--path-format=absolute", "--git-common-dir"], options),
+    await resolveGitPath(
+      await requireGit(root, ["rev-parse", "--path-format=absolute", "--git-common-dir"], options),
+      options,
+    ),
   );
   params.signal?.throwIfAborted();
   // Linked session worktrees share the repository cache; their pinned commits and

--- a/src/gateway/worker-environments/workspace-result-git.ts
+++ b/src/gateway/worker-environments/workspace-result-git.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveGitPath } from "../../infra/git-path.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
@@ -49,7 +50,12 @@ export async function withWorkspaceResultRefMutation<T>(
   operation: () => Promise<T>,
 ): Promise<T> {
   const common = await requireWorkspaceResultGit(root, ["rev-parse", "--git-common-dir"]);
-  const commonDir = await fs.realpath(path.resolve(root, common));
+  const commonDir = await fs.realpath(
+    path.resolve(
+      root,
+      await resolveGitPath(common, { timeoutMs: WORKSPACE_RESULT_GIT_TIMEOUT_MS }),
+    ),
+  );
   // Linked worktrees share packed-refs. Even deleting a loose ref locks that
   // shared file, so distinct environment/worktree keys cannot protect it.
   return await refOperations.enqueue(commonDir, operation);

--- a/src/gateway/worker-environments/workspace-sync-helpers.ts
+++ b/src/gateway/worker-environments/workspace-sync-helpers.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { resolveGitPath } from "../../infra/git-path.js";
 import { redactSensitiveText } from "../../logging/redact.js";
 import type { CommandOptions, SpawnResult } from "../../process/exec.js";
 import { WORKER_BUNDLE_RSYNC_RECEIVER_PATH } from "../../shared/worker-bundle-hash.js";
@@ -288,7 +289,7 @@ export async function probeWorkspaceGitMode(params: {
   if (workerWorkspaceCommandSucceeded(gitBaseResult)) {
     return {
       mode: "git",
-      gitRoot: gitRootResult.stdout.trim(),
+      gitRoot: await resolveGitPath(gitRootResult.stdout.trim(), params.commandOptions),
       baseCommit: gitBaseResult.stdout.trim(),
     };
   }

--- a/src/gateway/worker-environments/workspace-sync-inventory.ts
+++ b/src/gateway/worker-environments/workspace-sync-inventory.ts
@@ -10,6 +10,7 @@ import {
   stagedInputPathDirectory,
   STAGED_INPUT_GIT_PATHSPEC,
 } from "../../media/staged-inputs.js";
+import { resolveCommandEnv } from "../../process/exec.js";
 import { killProcessTree } from "../../process/kill-tree.js";
 import { workerSshCommandOptions } from "./ssh.js";
 import { isPortableRootContainedSymlink } from "./workspace-actual-manifest.js";
@@ -268,7 +269,10 @@ export async function runWorkspaceInventoryCommandToFile(params: {
     params.signal.throwIfAborted();
     const boundedOutput = params.maxOutputBytes !== undefined;
     const child = spawn(command, args, {
-      env: workerSshCommandOptions({ timeoutMs: params.timeoutMs }).baseEnv,
+      env: resolveCommandEnv({
+        argv: params.argv,
+        baseEnv: workerSshCommandOptions({ timeoutMs: params.timeoutMs }).baseEnv,
+      }),
       stdio: [input?.fd ?? "ignore", boundedOutput ? "pipe" : output.fd, "pipe"],
       ...(process.platform !== "win32" ? { detached: true } : {}),
       windowsHide: true,

--- a/src/gateway/worker-environments/workspace-sync-preflight.ts
+++ b/src/gateway/worker-environments/workspace-sync-preflight.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveGitPath } from "../../infra/git-path.js";
+import { workerSshCommandOptions } from "./ssh.js";
 import {
   createWorkspaceGitTransferList,
   runWorkspaceInventoryCommandToFile,
@@ -49,7 +51,15 @@ export async function preflightWorkerWorkspace(params: {
       readBoundedGitValue(gitRootPath),
       readBoundedGitValue(baseCommitPath),
     ]);
-    if ((await fs.realpath(reportedRoot)) !== canonicalRoot) {
+    if (
+      (await fs.realpath(
+        await resolveGitPath(reportedRoot, {
+          baseEnv: workerSshCommandOptions({ timeoutMs }).baseEnv,
+          signal,
+          timeoutMs,
+        }),
+      )) !== canonicalRoot
+    ) {
       throw workspaceInventoryError(
         "Cloud worker dispatch requires the canonical managed Git worktree root",
       );

--- a/src/infra/dev-install-branch.ts
+++ b/src/infra/dev-install-branch.ts
@@ -4,6 +4,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { runCommandWithTimeout } from "../process/exec.js";
+import { resolveGitPath } from "./git-path.js";
 import { resolveOpenClawPackageRoot } from "./openclaw-root.js";
 
 const GIT_TIMEOUT_MS = 3000;
@@ -30,7 +31,7 @@ async function detectDevInstallGitBranch(params: {
   // itself a git toplevel counts as a source checkout. A package install
   // nested inside an unrelated repo must not surface that repo's branch.
   const rootReal = await fs.realpath(root).catch(() => root);
-  const top = topRes.stdout.trim();
+  const top = await resolveGitPath(topRes.stdout.trim(), { timeoutMs: GIT_TIMEOUT_MS });
   if (!top || path.resolve(top) !== path.resolve(rootReal)) {
     return null;
   }

--- a/src/infra/git-path.test.ts
+++ b/src/infra/git-path.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import { afterEach, expect, it, vi } from "vitest";
+import * as exec from "../process/exec.js";
+import * as windowsCommand from "../process/windows-command.js";
+import { resolveGitPath } from "./git-path.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it.each([
+  ["darwin", "/c/Users/operator/repo"],
+  ["linux", "/work/repo"],
+  ["win32", "C:\\c\\Users\\operator\\repo"],
+  ["win32", "D:/repo"],
+  ["win32", "//server/share/repo"],
+  ["win32", "\\\\server\\share\\repo"],
+  ["win32", "../repo/.git"],
+  ["win32", ".git"],
+])("preserves %s native or relative path %s", async (platform, value) => {
+  vi.stubGlobal("process", { ...process, platform });
+  const convert = vi.spyOn(exec, "runUtf8CommandWithTimeout");
+  await expect(resolveGitPath(value)).resolves.toBe(value);
+  expect(convert).not.toHaveBeenCalled();
+});
+
+it.each([
+  ["/c/Users/operator/repo", "C:\\Users\\operator\\repo"],
+  ["/cygdrive/d/repo", "D:\\repo"],
+  ["/projects/测试 repo ", "E:\\mounted\\测试 repo "],
+])("uses the selected Git installation's mount mapping for %s", async (value, nativePath) => {
+  vi.stubGlobal("process", { ...process, platform: "win32" });
+  vi.spyOn(fs, "existsSync").mockImplementation((file) => String(file).endsWith("msys-2.0.dll"));
+  const resolve = vi.spyOn(windowsCommand, "resolveSafeChildProcessInvocation").mockReturnValue({
+    command: "D:\\MSYS installation\\usr\\bin\\git.exe",
+    args: [],
+    usesWindowsExitCodeShim: false,
+    windowsHide: true,
+  });
+  const convert = vi.spyOn(exec, "runUtf8CommandWithTimeout").mockResolvedValue({
+    stdout: `${nativePath}\r\n`,
+    stderr: "",
+    code: 0,
+    signal: null,
+    killed: false,
+    termination: "exit",
+  });
+  const options = { env: { Path: "D:\\MSYS installation\\usr\\bin" }, cwd: "D:\\launcher" };
+  await expect(resolveGitPath(value, options)).resolves.toBe(nativePath);
+  expect(resolve).toHaveBeenCalledWith(expect.objectContaining({ cwd: options.cwd }));
+  expect(convert).toHaveBeenCalledWith(
+    ["D:\\MSYS installation\\usr\\bin\\cygpath.exe", "-w", "-C", "UTF8", "--", value],
+    { ...options, timeoutMs: 10_000 },
+  );
+  convert.mockResolvedValueOnce({
+    stdout: "",
+    stderr: "cygpath: invalid path",
+    code: 1,
+    signal: null,
+    killed: false,
+    termination: "exit",
+  });
+  await expect(resolveGitPath(value, options)).rejects.toThrow("cygpath: invalid path");
+});
+
+it("preserves native Git drive-rooted paths without invoking cygpath", async () => {
+  vi.stubGlobal("process", { ...process, platform: "win32" });
+  vi.spyOn(fs, "existsSync").mockReturnValue(false);
+  vi.spyOn(windowsCommand, "resolveSafeChildProcessInvocation").mockReturnValue({
+    command: "C:\\Program Files\\Git\\cmd\\git.exe",
+    args: [],
+    usesWindowsExitCodeShim: false,
+    windowsHide: true,
+  });
+  const convert = vi.spyOn(exec, "runUtf8CommandWithTimeout");
+  await expect(resolveGitPath("/foo/attributes")).resolves.toBe("/foo/attributes");
+  expect(convert).not.toHaveBeenCalled();
+});
+
+it("does not look for a converter next to cmd.exe for a Git wrapper", async () => {
+  vi.stubGlobal("process", { ...process, platform: "win32" });
+  vi.spyOn(windowsCommand, "resolveSafeChildProcessInvocation").mockReturnValue({
+    command: "C:\\Windows\\System32\\cmd.exe",
+    args: [],
+    usesWindowsExitCodeShim: true,
+    windowsHide: true,
+  });
+  const convert = vi.spyOn(exec, "runUtf8CommandWithTimeout");
+  await expect(resolveGitPath("/foo/attributes")).resolves.toBe("/foo/attributes");
+  expect(convert).not.toHaveBeenCalled();
+});

--- a/src/infra/git-path.ts
+++ b/src/infra/git-path.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createCommandError } from "../process/command-error.js";
+import { resolveCommandEnv } from "../process/exec-spawn.js";
+import { runUtf8CommandWithTimeout, type CommandOptions } from "../process/exec.js";
+import { resolveSafeChildProcessInvocation } from "../process/windows-command.js";
+
+/** Convert a Git filesystem-path field before native filesystem access. */
+export async function resolveGitPath(
+  value: string,
+  options: Pick<CommandOptions, "baseEnv" | "env" | "cwd" | "timeoutMs" | "signal"> = {},
+): Promise<string> {
+  if (process.platform !== "win32" || !value.startsWith("/") || value.startsWith("//")) {
+    return value;
+  }
+  // MSYS/Cygwin mounts belong to the selected Git installation. A drive-letter
+  // rewrite misses custom mounts; a PATH lookup can select another cygpath.
+  const invocation = resolveSafeChildProcessInvocation({
+    argv: ["git"],
+    cwd: options.cwd,
+    env: resolveCommandEnv({ argv: ["git"], baseEnv: options.baseEnv, env: options.env }),
+  });
+  const directory = path.win32.dirname(invocation.command);
+  // Native Git can also emit drive-rooted /paths (for example attributesFile).
+  // Only the MSYS/Cygwin installation layout gives those paths POSIX semantics.
+  if (
+    invocation.usesWindowsExitCodeShim ||
+    !["msys-2.0.dll", "cygwin1.dll"].some((dll) => fs.existsSync(path.win32.join(directory, dll)))
+  ) {
+    return value;
+  }
+  const converter = path.win32.join(directory, "cygpath.exe");
+  const result = await runUtf8CommandWithTimeout([converter, "-w", "-C", "UTF8", "--", value], {
+    ...options,
+    timeoutMs: options.timeoutMs ?? 10_000,
+  });
+  if (result.code !== 0) {
+    throw createCommandError("cygpath", result, { timeoutMs: options.timeoutMs ?? 10_000 });
+  }
+  // Remove only the converter's line ending, preserving porcelain path spaces.
+  return result.stdout.replace(/\r?\n$/, "");
+}

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -8,6 +8,7 @@ import {
   resolvePnpmNodeModulesRoot,
 } from "./detect-package-manager.js";
 import { executeGitCommand, GIT_TIMEOUT_MS } from "./git-exec.js";
+import { resolveGitPath } from "./git-path.js";
 import { compareOpenClawReleaseVersions } from "./npm-registry-spec.js";
 import { compareValidSemver, normalizeLegacyDotBetaVersion } from "./semver.js";
 import {
@@ -249,7 +250,10 @@ export async function resolveUpdateInstallKind(
     timeoutMs: 4000,
   });
   options.signal?.throwIfAborted();
-  const gitRoot = result?.code === 0 ? result.stdout.trim() : "";
+  const gitRoot =
+    result?.code === 0
+      ? await resolveGitPath(result.stdout.trim(), { signal: options.signal, timeoutMs: 4000 })
+      : "";
   return gitRoot && updateInstallRootsMatch(gitRoot, root) ? "git" : "package";
 }
 

--- a/src/infra/update-install-root.ts
+++ b/src/infra/update-install-root.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { resolveGitPath } from "./git-path.js";
 import type { CommandRunner } from "./update-runner-types.js";
 
 /** Resolve the canonical identity of an update checkout/install root. */
@@ -25,7 +26,8 @@ export async function resolveGitRoot(
     const result = await runCommand(["git", "-C", dir, "rev-parse", "--show-toplevel"], {
       timeoutMs,
     }).catch(() => null);
-    const root = result?.code === 0 ? result.stdout.trim() : "";
+    const root =
+      result?.code === 0 ? await resolveGitPath(result.stdout.trim(), { timeoutMs }) : "";
     // A launcher may live inside an unrelated checkout (for example nvm).
     // Keep probing until the Git root owns the discovered OpenClaw package.
     if (root && (!packageRoot || updateInstallRootsMatch(root, packageRoot))) {

--- a/src/process/exec-spawn.ts
+++ b/src/process/exec-spawn.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import process from "node:process";
 import { execa, type Options as ExecaOptions, type ResultPromise } from "execa";
 import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
-import { mergeProcessEnv } from "../infra/process-env.js";
+import { mergeProcessEnv, resolveEnvironmentValue } from "../infra/process-env.js";
 import { resolveSafeChildProcessInvocation } from "./windows-command.js";
 
 export const COMMAND_PROCESS_TREE_KILL_GRACE_MS = 300;
@@ -81,7 +81,18 @@ export function resolveCommandEnv(params: {
     return false;
   })();
 
-  const resolvedEnv = mergeProcessEnv([baseEnv, params.env], platform);
+  let resolvedEnv = mergeProcessEnv([baseEnv, params.env], platform);
+  if (platform === "win32") {
+    // A native parent otherwise lets MSYS/Cygwin expand literal argv, including
+    // Git's HEAD^{commit}. Explicit shells still own expansion of their scripts.
+    const literalArgvEnv = Object.fromEntries(
+      ["MSYS", "CYGWIN"].map((name) => {
+        const value = resolveEnvironmentValue(resolvedEnv, name, platform) ?? "";
+        return [name, /(?:^|\s)noglob$/i.test(value) ? value : `${value} noglob`.trim()];
+      }),
+    );
+    resolvedEnv = mergeProcessEnv([resolvedEnv, literalArgvEnv], platform);
+  }
   if (shouldSuppressNpmFund) {
     if (resolvedEnv.NPM_CONFIG_FUND == null) {
       resolvedEnv.NPM_CONFIG_FUND = "false";

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -103,6 +103,28 @@ describe("runCommandWithTimeout", () => {
     expect(resolved.PATH).toBe("/override/bin");
   });
 
+  it("keeps native argv literal for MSYS/Cygwin without losing other runtime options", () => {
+    const baseEnv = {
+      msys: 'glob error_start="C:/debug tools/debugger.exe"',
+      CYGWIN: "winsymlinks:native",
+    };
+    const windows = resolveCommandEnv({
+      argv: ["git", "rev-parse", "HEAD^{commit}"],
+      platform: "win32",
+      baseEnv,
+    });
+    expect(windows.MSYS).toBe(`${baseEnv.msys} noglob`);
+    expect(windows.msys).toBeUndefined();
+    expect(windows.CYGWIN).toBe("winsymlinks:native noglob");
+    expect(resolveCommandEnv({ argv: ["git"], platform: "win32", baseEnv: windows })).toEqual(
+      windows,
+    );
+    const posix = resolveCommandEnv({ argv: ["git"], platform: "linux", baseEnv });
+    expect(posix.msys).toBe(baseEnv.msys);
+    expect(posix.CYGWIN).toBe(baseEnv.CYGWIN);
+    expect(baseEnv.msys).not.toContain("noglob");
+  });
+
   it("does not restore parent variables excluded from the child environment", async () => {
     const key = "OPENCLAW_EXECA_PARENT_ONLY_TEST";
     const previous = process.env[key];

--- a/src/projects/project-registry.ts
+++ b/src/projects/project-registry.ts
@@ -6,6 +6,7 @@ import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope.js
 import { insideGitCheckout, runGit } from "../agents/worktrees/git.js";
 import { slugifyWorktreeTitle } from "../agents/worktrees/name.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveGitPath } from "../infra/git-path.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -221,7 +222,7 @@ export async function resolveProjectCheckout(projectPath: string): Promise<{
   if (rootResult.code !== 0) {
     throw new ProjectCheckoutError(`project path is not a git checkout: ${projectPath}`);
   }
-  const repoRoot = await fs.realpath(rootResult.stdout.trim()).catch(() => {
+  const repoRoot = await fs.realpath(await resolveGitPath(rootResult.stdout.trim())).catch(() => {
     throw new ProjectCheckoutError(`project checkout root is unavailable: ${projectPath}`);
   });
   const headResult = await runGit(repoRoot, ["rev-parse", "--verify", "HEAD^{commit}"]);

--- a/src/sessions/session-diff.ts
+++ b/src/sessions/session-diff.ts
@@ -11,6 +11,7 @@ import type {
 import { gitEnvironment, runGit } from "../agents/worktrees/git.js";
 import type { SessionDiffBaseline } from "../config/sessions/types.js";
 import { GIT_TIMEOUT_MS } from "../infra/git-exec.js";
+import { resolveGitPath } from "../infra/git-path.js";
 import { runCommandBuffered } from "../process/exec.js";
 import {
   loadSessionDiffBranchMetadata,
@@ -78,7 +79,7 @@ async function loadCheckoutRevision(
     }
     const lines = result.stdout.replace(/\n$/, "").split("\n");
     const head = result.code === 0 ? lines.pop() : undefined;
-    const root = lines.join("\n");
+    const root = await resolveGitPath(lines.join("\n"));
     if (!root) {
       return undefined;
     }

--- a/src/snapshot/git-backup.paths.test.ts
+++ b/src/snapshot/git-backup.paths.test.ts
@@ -1,0 +1,56 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import { afterEach, expect, it, vi } from "vitest";
+import * as exec from "../process/exec.js";
+import * as windowsCommand from "../process/windows-command.js";
+import { readGitBackupLog } from "./git-backup.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it("reads backup history when MSYS Git returns a Unix repository root", async () => {
+  vi.stubGlobal("process", { ...process, platform: "win32" });
+  vi.spyOn(fsSync, "existsSync").mockImplementation((file) =>
+    String(file).endsWith("msys-2.0.dll"),
+  );
+  const repository = "C:\\Users\\operator\\backup";
+  const success = {
+    code: 0,
+    stderr: "",
+    signal: null,
+    killed: false,
+    termination: "exit" as const,
+  };
+  vi.spyOn(exec, "runCommandWithTimeout").mockImplementation(async (argv) => ({
+    ...success,
+    stdout: argv.includes("--show-toplevel")
+      ? "/c/Users/operator/backup\n"
+      : argv.includes("symbolic-ref")
+        ? "refs/heads/main\n"
+        : argv.includes("log")
+          ? "abc123\t2026-09-01T00:00:00Z\topenclaw backup\n"
+          : "",
+  }));
+  vi.spyOn(windowsCommand, "resolveSafeChildProcessInvocation").mockReturnValue({
+    command: "C:\\msys64\\usr\\bin\\git.exe",
+    args: [],
+    usesWindowsExitCodeShim: false,
+    windowsHide: true,
+  });
+  vi.spyOn(exec, "runUtf8CommandWithTimeout").mockResolvedValue({
+    ...success,
+    stdout: `${repository}\n`,
+  });
+  vi.spyOn(fs, "realpath").mockImplementation(async (value) => {
+    if (value !== repository) {
+      throw Object.assign(new Error(`ENOENT: ${String(value)}`), { code: "ENOENT" });
+    }
+    return repository;
+  });
+
+  await expect(readGitBackupLog({ repositoryPath: repository, limit: 5 })).resolves.toEqual([
+    { commit: "abc123", date: "2026-09-01T00:00:00Z", message: "openclaw backup" },
+  ]);
+});

--- a/src/snapshot/git-backup.ts
+++ b/src/snapshot/git-backup.ts
@@ -9,6 +9,7 @@ import {
   requireGitCommand as requireGit,
   requireGitCommandBuffer as requireGitBuffer,
 } from "../infra/git-exec.js";
+import { resolveGitPath } from "../infra/git-path.js";
 import { formatCommandOutput, formatCommandResult } from "../process/command-error.js";
 import { BACKUP_RUN_ERROR_MAX_LENGTH } from "../state/backup-run-records.contract.js";
 import {
@@ -113,7 +114,7 @@ function gitBackupRepositoryPrivacyRemediation(repositoryPath: string, cause: un
 async function assertGitRepository(repositoryPath: string, env?: NodeJS.ProcessEnv): Promise<void> {
   const topLevel = await requireGit(repositoryPath, ["rev-parse", "--show-toplevel"], { env });
   const [canonicalTopLevel, canonicalRepository] = await Promise.all([
-    fs.realpath(topLevel),
+    resolveGitPath(topLevel, { env }).then((nativePath) => fs.realpath(nativePath)),
     fs.realpath(repositoryPath),
   ]);
   if (canonicalTopLevel !== canonicalRepository) {


### PR DESCRIPTION
Fixes #139185. Related: #139266.

## What Problem This Solves

Fixes an issue where Windows users could not discover managed worktree branches or use Git backups when PATH selected MSYS2 Git. Git returned POSIX paths that native filesystem calls resolved to a nonexistent doubled-drive directory.

## Why This Change Was Made

Convert path-typed Git output through the selected MSYS/Cygwin installation's `cygpath` before native filesystem access. The shared boundary covers repository roots, common directories, porcelain worktree records, and sibling Git path consumers; native Git, UNC paths, relative paths, and raw Git output retain their existing semantics.

A real MSYS2 run also exposed a second failure: native-process startup expands braces in `HEAD^{commit}` to `HEAD^commit`. The child-process environment now preserves literal argv with `noglob`, including the worker inventory's direct-spawn path, while retaining existing runtime options.

#139266 appeared while this repair was being validated. Its drive-prefix conversion addresses the reported spelling, but does not address the observed revision-argument failure or installation-specific mount translation. This PR includes process-level evidence for the complete repair.

## User Impact

Windows operators can keep MSYS2 Git on PATH and use branch discovery and Git backups. Backup privacy/ACL checks remain enforced. The report's separate initial privacy error occurs before Git and is not claimed to have the same cause.

## Evidence

- [Real Windows + MSYS2 before/after run](https://github.com/NianJiuZst/openclaw/actions/runs/33982808451): baseline `3e4becea5e2c` reproduced `ENOENT ... D:\c\Users\...` and `HEAD^{commit}` returned exit 128. Candidate `7c352e061550` passed all five fixture tests: branch discovery/canonical linked-checkout identity, foreign locks, backup history, private backup initialization with real ACL checks, and native Git rooted-path preservation. No mocked Git or filesystem. The temporary proof workflow is outside this PR.
- Local focused suite: 26 files, 424 passed, 54 platform-dependent skips. The final mechanical porcelain mapping cleanup was rerun separately: 5 passed. Worker inventory coverage: 30 passed; its final environment wiring was added after the Windows candidate above.
- Regression tests were observed failing before the path and literal-argv repairs.
- Formatting, lint, core type checking, and fresh P0–P2 autoreview: passed. The broader changed-file checks passed their type/test-type, boundary, coercion, deprecation, and dead-export gates; a map-spread lint finding was fixed and all changed files rechecked.
- Windows proof invokes the real service/backup owners in a headless fixture; no full Gateway/Control UI recording was captured. Upstream PR CI is separate from this proof.

The conversion supports the standard colocated MSYS/Cygwin Git/runtime/cygpath layout. Production delta: +125 lines; tests: +211. Growth establishes one installation-aware conversion boundary and the literal-argv contract, then routes existing consumers through them; it adds no operator configuration or storage schema.

Named follow-up: resolve persisted MSYS Git administration pointers in native diagnostic/onboarding readers (`git-root`, `git-commit`, and `onboarding-plugin-install`). Those historical file pointers need original-writer/runtime proof; converting them with today's PATH-selected Git would conflate a different contract with subprocess output.
