### PR TITLE
fix: preserve complete Codex replies when previews stall

### DIFF
--- a/extensions/codex/src/app-server/event-projector-presentation.ts
+++ b/extensions/codex/src/app-server/event-projector-presentation.ts
@@ -1,0 +1,58 @@
+import {
+  embeddedAgentLog,
+  type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { redactCodexEventKind } from "./event-projector-diagnostics.js";
+
+export class CodexPresentationCallbacks {
+  private readonly pending = new Set<Promise<void>>();
+  readonly params: EmbeddedRunAttemptParams;
+
+  constructor(
+    params: EmbeddedRunAttemptParams,
+    private readonly isClosed: () => boolean | undefined,
+  ) {
+    this.params = {
+      ...params,
+      onAssistantMessageStart: this.track(params.onAssistantMessageStart),
+      onPartialReply: this.track(params.onPartialReply),
+      onReasoningStream: this.track(params.onReasoningStream),
+      onReasoningEnd: this.track(params.onReasoningEnd),
+    };
+  }
+
+  private track<Args extends unknown[]>(
+    callback: ((...args: Args) => unknown) | undefined,
+  ): ((...args: Args) => void) | undefined {
+    if (!callback) {
+      return undefined;
+    }
+    return (...args) => {
+      if (this.isClosed()) {
+        return;
+      }
+      // Invoke in native event order, but let channel owners coalesce previews
+      // while transport is pending. Settlement owns every accepted callback.
+      const pending = (async () => {
+        try {
+          await callback(...args);
+        } catch (error) {
+          if (!this.isClosed()) {
+            embeddedAgentLog.warn("codex app-server presentation callback failed", {
+              runId: this.params.runId,
+              error: redactCodexEventKind(String(error)).slice(0, 500),
+            });
+          }
+        }
+      })();
+      this.pending.add(pending);
+      void pending.then(() => this.pending.delete(pending));
+    };
+  }
+
+  async drain(): Promise<void> {
+    while (this.pending.size > 0) {
+      await Promise.all(this.pending);
+    }
+  }
+}

--- a/extensions/codex/src/app-server/event-projector.presentation.test.ts
+++ b/extensions/codex/src/app-server/event-projector.presentation.test.ts
@@ -1,0 +1,105 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import {
+  describe,
+  registerCodexEventProjectorTestLifecycle,
+  expect,
+  it,
+  vi,
+  createParams,
+  createProjector,
+  buildEmptyToolTelemetry,
+  readAttemptTerminal,
+  embeddedAgentLog,
+  forCurrentTurn,
+  agentMessageDelta,
+  turnCompleted,
+} from "./event-projector.test-harness.js";
+
+registerCodexEventProjectorTestLifecycle();
+
+describe("CodexAppServerEventProjector presentation settlement", () => {
+  it.each(["released", "closed", "aborted", "rejected"] as const)(
+    "projects the complete answer while presentation settlement is %s",
+    async (ending) => {
+      const gate = createDeferred<void>();
+      const abortController = new AbortController();
+      const delivered: string[] = [];
+      const failure = new Error("presentation failed");
+      const warning = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+      const projector = await createProjector(
+        {
+          ...(await createParams()),
+          onAssistantMessageStart: async () => {
+            delivered.push("start");
+            await gate.promise;
+          },
+          onPartialReply: ({ text }) => {
+            delivered.push(text ?? "");
+          },
+          onReasoningStream: () => {
+            delivered.push("reasoning");
+          },
+          onReasoningEnd: () => {
+            delivered.push("reasoning-end");
+          },
+        },
+        { runAbortSignal: abortController.signal },
+      );
+      try {
+        await projector.handleNotification(
+          forCurrentTurn("item/started", {
+            item: { type: "agentMessage", id: "msg-1", phase: "final_answer", text: "" },
+          }),
+        );
+        await projector.handleNotification(agentMessageDelta("hel"));
+        await projector.handleNotification(
+          forCurrentTurn("item/reasoning/textDelta", {
+            itemId: "reasoning-1",
+            delta: "thinking",
+          }),
+        );
+        await projector.handleNotification(agentMessageDelta("lo"));
+        await projector.handleNotification(
+          turnCompleted([
+            { type: "agentMessage", id: "msg-1", phase: "final_answer", text: "hello, complete" },
+          ]),
+        );
+        expect(projector.getCompletedTurnStatus()).toBe("completed");
+        expect(projector.buildResult(buildEmptyToolTelemetry()).assistantTexts).toEqual([
+          "hello, complete",
+        ]);
+        expect(delivered).toEqual(["start", "hel", "reasoning", "hello", "reasoning-end"]);
+        if (ending === "closed") {
+          await projector.closeProjection();
+        } else if (ending === "aborted") {
+          abortController.abort();
+        }
+        if (ending === "rejected") {
+          gate.reject(failure);
+        } else {
+          gate.resolve();
+        }
+        await projector.presentation.drain();
+        if (ending === "closed" || ending === "aborted") {
+          await projector.handleNotification(agentMessageDelta("late"));
+          await projector.presentation.drain();
+        }
+        expect(delivered).toEqual(["start", "hel", "reasoning", "hello", "reasoning-end"]);
+        if (ending === "rejected") {
+          expect(
+            readAttemptTerminal(projector.buildResult(buildEmptyToolTelemetry())).promptError,
+          ).toBeNull();
+          expect(projector.getCompletedTurnStatus()).toBe("completed");
+          expect(warning).toHaveBeenCalledWith(
+            "codex app-server presentation callback failed",
+            expect.objectContaining({ error: "Error: presentation failed" }),
+          );
+        }
+      } finally {
+        gate.resolve();
+        await projector.presentation.drain();
+        await projector.closeProjection();
+      }
+    },
+  );
+});

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -22,6 +22,7 @@ import {
 import { CodexGeneratedMediaProjection } from "./event-projector-media.js";
 import { CodexNativeToolLifecycleProjector } from "./event-projector-native-tool-lifecycle.js";
 import type { CodexAppServerEventProjectorOptions } from "./event-projector-options.js";
+import { CodexPresentationCallbacks } from "./event-projector-presentation.js";
 import { CodexReasoningProjection } from "./event-projector-reasoning.js";
 import {
   buildCodexAttemptResult,
@@ -67,6 +68,7 @@ export class CodexAppServerEventProjector {
   private readonly toolTranscriptProjection: CodexToolTranscriptProjection;
   private completedTurn: CodexTurn | undefined;
   private projectionClosed = false;
+  readonly presentation: CodexPresentationCallbacks;
   /** Structured overloads may continue once the exact settled transcript is captured. */
   settledTurnFailureFinalizationAllowed = false;
   private readonly terminalFailure = new CodexTerminalFailureProjection();
@@ -130,15 +132,19 @@ export class CodexAppServerEventProjector {
       this.toolTranscriptProjection,
       options.onNativeToolResultRecorded,
     );
-    this.assistantProjection = new CodexAssistantProjection(
+    this.presentation = new CodexPresentationCallbacks(
       params,
+      () => this.projectionClosed || options.runAbortSignal?.aborted,
+    );
+    this.assistantProjection = new CodexAssistantProjection(
+      this.presentation.params,
       (event) => this.emitAgentEvent(event),
       (text) => this.toolProgressProjection.matchesEcho(text),
       this.transcriptCheckpoint.nextTimestamp,
       this.transcriptCheckpoint.enqueueCommentary,
     );
     this.reasoningProjection = new CodexReasoningProjection(
-      params,
+      this.presentation.params,
       (event) => this.emitAgentEvent(event),
       options.onNativePlanUpdate,
     );

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -134,7 +134,9 @@ export async function finalizeCodexAttempt(
     clearTimeout(abortGraceTimer);
     deadlines.dispose();
   };
-  const settlement = drainNotificationQueue().then(closeProjection);
+  const settlement = drainNotificationQueue()
+    .then(() => activeProjector.presentation.drain())
+    .then(closeProjection);
   let projectionDrained = false;
   try {
     try {

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -1079,6 +1079,7 @@ describe("runCodexAppServerAttempt native lifecycle", () => {
         finalizationHookNotification("hook/completed", "completed"),
       );
       void harness.notify(makeAgentMessageDelta({ itemId: "msg-final-1", delta: "Done." }));
+      void harness.notify(completedAssistant("msg-final-1", "Done. The complete answer."));
       // Receipt sees the unsettled hook; its completion is still behind the first projection.
       void harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
       await vi.advanceTimersByTimeAsync(TURN_TERMINAL_SETTLEMENT_TIMEOUT_MS / 2);
@@ -1094,6 +1095,7 @@ describe("runCodexAppServerAttempt native lifecycle", () => {
       const result = await run;
       expect(readAttemptTerminal(result)).toMatchObject({ aborted: true, timedOut: true });
       expect(result.codexAppServerFailure?.kind).toBe("turn_settlement_timeout");
+      expect(result.assistantTexts).toEqual(["Done. The complete answer."]);
       expect(resolveActiveEmbeddedRunSessionId(params.sessionKey!)).toBeUndefined();
     } finally {
       projection.resolve();

--- a/extensions/telegram/src/bot-message-dispatch.draft-backpressure.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-backpressure.test.ts
@@ -1,0 +1,67 @@
+import { setImmediate } from "node:timers/promises";
+import { expect, it, vi } from "vitest";
+import {
+  createBot,
+  createContext,
+  createTelegramDraftStream,
+  describeTelegramDispatch,
+  dispatchReplyWithBufferedBlockDispatcher,
+  dispatchWithContext,
+} from "./bot-message-dispatch.test-harness.js";
+
+describeTelegramDispatch("Telegram cumulative draft backpressure", () => {
+  it("coalesces concurrent partial callbacks while the provider holds the first preview", async () => {
+    const { createTelegramDraftStream: createRealDraftStream } =
+      await vi.importActual<typeof import("./draft-stream.js")>("./draft-stream.js");
+    createTelegramDraftStream.mockImplementation((params) =>
+      createRealDraftStream({ ...params, throttleMs: 0, minInitialChars: 0 }),
+    );
+    const bot = createBot();
+    const sendMessage = vi.spyOn(bot.api, "sendMessage");
+    const editMessageText = vi.spyOn(bot.api, "editMessageText");
+    let releaseSend!: () => void;
+    const heldSend = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    sendMessage.mockImplementationOnce(async () => {
+      await heldSend;
+      return {
+        message_id: 1001,
+        message_thread_id: 777,
+      } as Awaited<ReturnType<typeof bot.api.sendMessage>>;
+    });
+    const finalText = "Hele svaret er ferdig, inkludert den siste delen.";
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ replyOptions, dispatcherOptions }) => {
+        const partial = replyOptions?.onPartialReply;
+        expect(partial).toBeTypeOf("function");
+        const pending = [
+          Promise.resolve(partial?.({ text: "Første del av et svar som fortsetter." })),
+        ];
+        await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledOnce());
+        // Native callbacks start in source order without waiting for provider I/O.
+        // The channel owns coalescing and must not turn every delta into an edit.
+        for (let index = 0; index < 40; index += 1) {
+          pending.push(Promise.resolve(partial?.({ text: `Mellomliggende svar ${index}.` })));
+        }
+        pending.push(Promise.resolve(partial?.({ text: finalText })));
+        await setImmediate();
+        expect(sendMessage).toHaveBeenCalledOnce();
+        expect(editMessageText).not.toHaveBeenCalled();
+
+        releaseSend();
+        await Promise.all(pending);
+        await dispatcherOptions.deliver({ text: finalText }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    try {
+      await dispatchWithContext({ context: createContext(), bot });
+      expect(sendMessage).toHaveBeenCalledOnce();
+      expect(editMessageText).toHaveBeenCalledOnce();
+      expect(editMessageText.mock.calls[0]?.[2]).toBe(finalText);
+    } finally {
+      releaseSend();
+    }
+  });
+});


### PR DESCRIPTION
Closes #139249 (complete native answer blocked by pending preview). Related: #84516; its upstream-silence case remains outside this fix.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users receive an incomplete Codex reply when a streaming preview stalls, even though Codex has already completed the full answer.

## Why This Change Was Made

Start presentation callbacks in native event order, but join them during terminal settlement so a slow channel cannot block authoritative completion from being processed. Preserve the existing settlement deadline, cancellation fencing, and channel-owned preview coalescing; contain presentation failures without replaying the model turn.

## User Impact

The complete native answer remains available when a preview is slow or fails. Ordinary completion still waits for accepted presentation work.

## Evidence

- On pristine main `84b79be0d1f`, the complete-answer regression fails; after repair, all 143 focused tests pass.
- `node scripts/check-changed.mjs --base 84b79be0d1f`, the QA-enabled build, and independent structured review (P0) passed.
- Real isolated Gateway + native Codex + Telegram plugin, with local mock APIs: held the HTTP response at a 1,235-character preview; native completion produced 3,703 characters while held. After release, the exact final text was delivered in one send and one edit, the session settled successfully, and owned services stopped. This exercises the changed path; the owner regression supplies pre-fix discrimination.
- Inspected the pinned [Codex 0.153.4 completion contract](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/app-server/src/bespoke_event_handling.rs#L1398).

Production net +66 lines; tests +174. The new presentation owner tracks and joins callbacks independently of native events; existing SDK callbacks expose no reusable lifecycle owner. No public contract changes.

AI-assisted implementation and review.
