### PR TITLE
fix(browser): recover Chrome relay target identities

### DIFF
--- a/extensions/browser/src/browser/extension-relay/relay-bootstrap.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bootstrap.integration.test.ts
@@ -20,9 +20,9 @@ afterEach(async () => {
 it.each(["owned", "borrowed"] as const)(
   "repairs the %s relay after initial attach loss and delayed frame-tree publication",
   async (ownership) => {
-    const frameTreeHeld = createDeferred<void>();
-    const releaseFrameTree = createDeferred<void>();
-    const laterCommand = createDeferred<void>();
+    let frameTreeHeld = createDeferred<void>();
+    let releaseFrameTree = createDeferred<void>();
+    let laterCommand = createDeferred<void>();
     const methods = new WeakMap<object, { method?: string; checks: number }>();
     const realm = vm.createContext({});
     const objects = new Map<string, unknown>();
@@ -132,13 +132,21 @@ it.each(["owned", "borrowed"] as const)(
         ]);
         expect(attachAttempts).toBe(2);
 
+        frameTreeHeld = createDeferred<void>();
+        releaseFrameTree = createDeferred<void>();
+        laterCommand = createDeferred<void>();
         extension.send(JSON.stringify({ type: "detached", tabId: 1, reason: "renderer replaced" }));
         await new Promise<void>((resolve) => {
           setImmediate(resolve);
         });
-        await expect(profile.listTabs()).resolves.toEqual([
+        const recovered = expect(profile.listTabs()).resolves.toEqual([
           expect.objectContaining({ targetId: "fixture-target" }),
         ]);
+        void recovered.catch(() => {});
+        await frameTreeHeld.promise;
+        await laterCommand.promise;
+        releaseFrameTree.resolve();
+        await recovered;
         expect(attachAttempts).toBe(3);
 
         const abort = new AbortController();

--- a/extensions/browser/src/browser/extension-relay/relay-bootstrap.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bootstrap.integration.test.ts
@@ -18,7 +18,7 @@ afterEach(async () => {
 });
 
 it.each(["owned", "borrowed"] as const)(
-  "evaluates after tabs when the %s relay delays the frame-tree post-access reply",
+  "repairs the %s relay after initial attach loss and delayed frame-tree publication",
   async (ownership) => {
     const frameTreeHeld = createDeferred<void>();
     const releaseFrameTree = createDeferred<void>();
@@ -27,6 +27,7 @@ it.each(["owned", "borrowed"] as const)(
     const realm = vm.createContext({});
     const objects = new Map<string, unknown>();
     const evaluated: unknown[] = [];
+    let attachAttempts = 0;
     let send: (message: Record<string, unknown>) => void;
     const event = (context: Record<string, unknown>) =>
       send({
@@ -116,7 +117,7 @@ it.each(["owned", "borrowed"] as const)(
       navigateTab: async () => {},
     });
     await withConnectedDaemon(
-      async () => {
+      async ({ extension }) => {
         await startBrowserControlServiceFromConfig();
         const ctx = createBrowserControlContext();
         expect(ctx.state().extensionRelays?.get("chrome")?.ownership).toBe(ownership);
@@ -129,6 +130,17 @@ it.each(["owned", "borrowed"] as const)(
         await expect(listing).resolves.toEqual([
           expect.objectContaining({ targetId: "fixture-target" }),
         ]);
+        expect(attachAttempts).toBe(2);
+
+        extension.send(JSON.stringify({ type: "detached", tabId: 1, reason: "renderer replaced" }));
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        await expect(profile.listTabs()).resolves.toEqual([
+          expect.objectContaining({ targetId: "fixture-target" }),
+        ]);
+        expect(attachAttempts).toBe(3);
+
         const abort = new AbortController();
         const evaluation = executeActViaPlaywright({
           cdpUrl: profile.profile.cdpUrl,
@@ -160,7 +172,19 @@ it.each(["owned", "borrowed"] as const)(
         : undefined,
       (command, reply) => {
         send = reply;
-        void handler(command);
+        if (command.type === "attach" && attachAttempts++ === 0) {
+          reply({
+            type: "error",
+            seq: command.seq,
+            message: "tab generation changed during initial auto-attach",
+          });
+          return true;
+        }
+        if (command.type === "cdp") {
+          void handler(command);
+          return true;
+        }
+        return false;
       },
     );
   },

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.enumeration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.enumeration.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it } from "vitest";
 import { ExtensionRelayBridge } from "./relay-bridge.js";
 import {
@@ -7,8 +8,60 @@ import {
   sendHello,
   wireExtension,
 } from "./relay-bridge.test-support.js";
+import type { RelayToExtensionMessage } from "./relay-protocol.js";
 
 describe("ExtensionRelayBridge target enumeration", () => {
+  it("includes a tab discovered while another native attachment is pending", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const firstAttach = createDeferred<RelayToExtensionMessage>();
+    const nextStep = createDeferred<Record<string, unknown>>();
+    const extension = wireExtension(bridge, (message) => {
+      if (message.type !== "attach") {
+        return replyFor(message);
+      }
+      if (message.tabId === 1) {
+        firstAttach.resolve(message);
+      } else {
+        nextStep.resolve(message);
+      }
+      return null;
+    });
+    sendHello(extension.handlers);
+    const client = new FakeSocket();
+    const send = client.send.bind(client);
+    client.send = (data) => {
+      send(data);
+      nextStep.resolve(JSON.parse(data));
+    };
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(JSON.stringify({ id: 1, method: "Target.getTargets" }));
+    const first = await firstAttach.promise;
+    extension.handlers.onMessage(
+      JSON.stringify({
+        type: "tabs",
+        tabs: [
+          { tabId: 1, url: "https://one.example", title: "One", active: true },
+          { tabId: 2, url: "https://two.example", title: "Two", active: false },
+        ],
+      }),
+    );
+    extension.handlers.onMessage(JSON.stringify(replyFor(first)));
+    const second = await nextStep.promise;
+    expect(second).toMatchObject({ type: "attach", tabId: 2 });
+    extension.handlers.onMessage(
+      JSON.stringify({ type: "result", seq: second.seq, result: { targetId: "target-2" } }),
+    );
+    await flush();
+    expect(client.frames().find((frame) => frame.id === 1)).toMatchObject({
+      result: {
+        targetInfos: [
+          expect.objectContaining({ targetId: "target-1" }),
+          expect.objectContaining({ targetId: "target-2" }),
+        ],
+      },
+    });
+  });
+
   it("repairs reconnect attach without undoing a later explicit detach", async () => {
     const bridge = new ExtensionRelayBridge();
     const initialSocket = new FakeSocket();
@@ -108,9 +161,17 @@ describe("ExtensionRelayBridge target enumeration", () => {
     });
   });
 
-  it("resolves inventory identities without attaching a discovery-only client", async () => {
+  it("refreshes native identities without attaching a discovery-only client", async () => {
     const bridge = new ExtensionRelayBridge();
-    const extension = wireExtension(bridge);
+    let targetId = "target-1";
+    let unavailable = false;
+    const extension = wireExtension(bridge, (message) =>
+      message.type === "attach"
+        ? unavailable
+          ? { type: "error", seq: message.seq, message: "native target unavailable" }
+          : { type: "result", seq: message.seq, result: { targetId } }
+        : replyFor(message),
+    );
     sendHello(extension.handlers);
     const client = new FakeSocket();
     const cdp = bridge.attachCdpClientSocket(client);
@@ -125,6 +186,50 @@ describe("ExtensionRelayBridge target enumeration", () => {
       },
     });
     expect(client.frames().some((frame) => frame.method === "Target.attachedToTarget")).toBe(false);
+
+    targetId = "replacement-target";
+    cdp.onMessage(JSON.stringify({ id: 2, method: "Target.getTargets" }));
+    await flush();
+
+    expect(client.frames().find((frame) => frame.id === 2)).toMatchObject({
+      result: {
+        targetInfos: [expect.objectContaining({ targetId: "replacement-target", attached: false })],
+      },
+    });
+    expect(client.frames().some((frame) => frame.method === "Target.attachedToTarget")).toBe(false);
+
+    unavailable = true;
+    cdp.onMessage(JSON.stringify({ id: 3, method: "Target.getTargets" }));
+    await flush();
+    expect(client.frames().find((frame) => frame.id === 3)).toMatchObject({
+      error: { message: "Target identities are unavailable" },
+    });
+  });
+
+  it("rejects discovery when the previous native retirement fails", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const retirement = createDeferred<Extract<RelayToExtensionMessage, { type: "detach" }>>();
+    const extension = wireExtension(bridge, (message) => {
+      if (message.type === "detach") {
+        retirement.resolve(message);
+        return null;
+      }
+      return replyFor(message);
+    });
+    sendHello(extension.handlers);
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(JSON.stringify({ id: 1, method: "Target.getTargets" }));
+    const detach = await retirement.promise;
+    cdp.onMessage(JSON.stringify({ id: 2, method: "Target.getTargets" }));
+    extension.handlers.onMessage(
+      JSON.stringify({ type: "error", seq: detach.seq, message: "native detach failed" }),
+    );
+    await flush();
+
+    expect(client.frames().find((frame) => frame.id === 2)).toMatchObject({
+      error: { message: "Target identities are unavailable" },
+    });
   });
 
   it("repairs a failed initial auto-attach before Target.getTargets", async () => {

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.enumeration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.enumeration.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import { ExtensionRelayBridge } from "./relay-bridge.js";
+import {
+  FakeSocket,
+  flush,
+  replyFor,
+  sendHello,
+  wireExtension,
+} from "./relay-bridge.test-support.js";
+
+describe("ExtensionRelayBridge target enumeration", () => {
+  it("repairs reconnect attach without undoing a later explicit detach", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const initialSocket = new FakeSocket();
+    const initial = bridge.attachExtensionSocket(initialSocket);
+    sendHello(initial);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    expect(initialSocket.frames().filter((frame) => frame.type === "attach")).toHaveLength(1);
+
+    const replacement = wireExtension(bridge);
+    sendHello(replacement.handlers);
+    await flush();
+
+    expect(replacement.socket.frames().filter((frame) => frame.type === "attach")).toEqual([
+      expect.objectContaining({ tabId: 1 }),
+    ]);
+    cdp.onMessage(JSON.stringify({ id: 2, method: "Target.getTargets" }));
+    await flush();
+    expect(client.frames().find((frame) => frame.id === 2)?.result).toMatchObject({
+      targetInfos: [expect.objectContaining({ targetId: "target-1" })],
+    });
+
+    const peer = new FakeSocket();
+    const peerCdp = bridge.attachCdpClientSocket(peer);
+    peerCdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    await flush();
+    const attached = client
+      .frames()
+      .findLast((frame) => frame.method === "Target.attachedToTarget");
+    const sessionId = (attached?.params as { sessionId?: string } | undefined)?.sessionId;
+    expect(typeof sessionId).toBe("string");
+    cdp.onMessage(
+      JSON.stringify({ id: 3, method: "Target.detachFromTarget", params: { sessionId } }),
+    );
+    await flush();
+    const attachedEventCount = client
+      .frames()
+      .filter((frame) => frame.method === "Target.attachedToTarget").length;
+    const peerAttachedEventCount = peer
+      .frames()
+      .filter((frame) => frame.method === "Target.attachedToTarget").length;
+    const afterDetach = wireExtension(bridge);
+    sendHello(afterDetach.handlers, [
+      { tabId: 1, url: "https://example.com", title: "Updated", active: true },
+    ]);
+    await flush();
+
+    expect(afterDetach.socket.frames().filter((frame) => frame.type === "attach")).toHaveLength(1);
+    expect(
+      client.frames().filter((frame) => frame.method === "Target.attachedToTarget"),
+    ).toHaveLength(attachedEventCount);
+    expect(
+      peer.frames().filter((frame) => frame.method === "Target.attachedToTarget"),
+    ).toHaveLength(peerAttachedEventCount + 1);
+    cdp.onMessage(JSON.stringify({ id: 4, method: "Target.getTargets" }));
+    await flush();
+    expect(afterDetach.socket.frames().filter((frame) => frame.type === "attach")).toHaveLength(1);
+    expect(client.frames().find((frame) => frame.id === 4)?.result).toMatchObject({
+      targetInfos: [expect.objectContaining({ targetId: "target-1", attached: true })],
+    });
+    expect(
+      client.frames().filter((frame) => frame.method === "Target.attachedToTarget"),
+    ).toHaveLength(attachedEventCount);
+
+    afterDetach.handlers.onMessage(JSON.stringify({ type: "tabs", tabs: [] }));
+    afterDetach.handlers.onMessage(
+      JSON.stringify({
+        type: "tabs",
+        tabs: [{ tabId: 1, url: "https://reused.example", title: "Reused", active: true }],
+      }),
+    );
+    await flush();
+    expect(
+      client.frames().filter((frame) => frame.method === "Target.attachedToTarget"),
+    ).toHaveLength(attachedEventCount + 1);
+  });
+
+  it("does not project a disconnected zero-tab extension as authoritative empty", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const extension = wireExtension(bridge);
+    sendHello(extension.handlers, []);
+    extension.handlers.onClose();
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+
+    cdp.onMessage(JSON.stringify({ id: 1, method: "Target.getTargets" }));
+    await flush();
+
+    expect(client.frames().find((frame) => frame.id === 1)).toMatchObject({
+      error: { message: expect.stringMatching(/extension.*disconnected/i) },
+    });
+  });
+
+  it("resolves inventory identities without attaching a discovery-only client", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const extension = wireExtension(bridge);
+    sendHello(extension.handlers);
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+
+    cdp.onMessage(JSON.stringify({ id: 1, method: "Target.getTargets" }));
+    await flush();
+
+    expect(extension.socket.frames().filter((frame) => frame.type === "attach")).toHaveLength(1);
+    expect(client.frames().find((frame) => frame.id === 1)).toMatchObject({
+      result: {
+        targetInfos: [expect.objectContaining({ targetId: "target-1", attached: false })],
+      },
+    });
+    expect(client.frames().some((frame) => frame.method === "Target.attachedToTarget")).toBe(false);
+  });
+
+  it("repairs a failed initial auto-attach before Target.getTargets", async () => {
+    const bridge = new ExtensionRelayBridge();
+    let attachAttempts = 0;
+    const extension = wireExtension(bridge, (message) => {
+      if (message.type === "attach" && attachAttempts++ === 0) {
+        return { type: "error", seq: message.seq, message: "tab generation changed" };
+      }
+      return replyFor(message);
+    });
+    sendHello(extension.handlers);
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+
+    cdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    await flush();
+    expect(client.frames().find((frame) => frame.id === 1)?.error).toBeUndefined();
+    expect(client.frames().some((frame) => frame.method === "Target.attachedToTarget")).toBe(false);
+
+    cdp.onMessage(JSON.stringify({ id: 2, method: "Target.getTargets" }));
+    await flush();
+
+    expect(extension.socket.frames().filter((frame) => frame.type === "attach")).toHaveLength(2);
+    expect(client.frames().find((frame) => frame.id === 2)).toMatchObject({
+      result: { targetInfos: [expect.objectContaining({ targetId: "target-1" })] },
+    });
+    expect(client.frames().some((frame) => frame.method === "Target.attachedToTarget")).toBe(true);
+  });
+
+  it("publishes a shared recovered attachment to every waiting auto-attach client", async () => {
+    const bridge = new ExtensionRelayBridge();
+    let attachAttempts = 0;
+    const extension = wireExtension(bridge, (message) => {
+      if (message.type === "attach" && attachAttempts++ === 0) {
+        return { type: "error", seq: message.seq, message: "first client lost its claim" };
+      }
+      return replyFor(message);
+    });
+    sendHello(extension.handlers);
+    const first = new FakeSocket();
+    const firstCdp = bridge.attachCdpClientSocket(first);
+    firstCdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    await flush();
+
+    const second = new FakeSocket();
+    const secondCdp = bridge.attachCdpClientSocket(second);
+    secondCdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    await flush();
+    expect(second.frames().some((frame) => frame.method === "Target.attachedToTarget")).toBe(true);
+    expect(first.frames().some((frame) => frame.method === "Target.attachedToTarget")).toBe(true);
+    const firstAttachedEventCount = first
+      .frames()
+      .filter((frame) => frame.method === "Target.attachedToTarget").length;
+
+    firstCdp.onMessage(JSON.stringify({ id: 2, method: "Target.getTargets" }));
+    await flush();
+
+    expect(extension.socket.frames().filter((frame) => frame.type === "attach")).toHaveLength(2);
+    expect(first.frames().find((frame) => frame.id === 2)?.error).toBeUndefined();
+    expect(
+      first.frames().filter((frame) => frame.method === "Target.attachedToTarget"),
+    ).toHaveLength(firstAttachedEventCount);
+  });
+
+  it("does not project a mixed target list when identity repair fails", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const extension = wireExtension(bridge, (message) =>
+      message.type === "attach" && message.tabId === 2
+        ? { type: "error", seq: message.seq, message: "tab became unavailable" }
+        : replyFor(message),
+    );
+    sendHello(extension.handlers);
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    await flush();
+    cdp.onMessage(
+      JSON.stringify({ id: 2, method: "Target.setAutoAttach", params: { autoAttach: false } }),
+    );
+    extension.handlers.onMessage(
+      JSON.stringify({
+        type: "tabs",
+        tabs: [
+          { tabId: 1, url: "https://one.example", title: "One", active: true },
+          { tabId: 2, url: "https://two.example", title: "Two", active: false },
+        ],
+      }),
+    );
+    await flush();
+
+    cdp.onMessage(JSON.stringify({ id: 3, method: "Target.getTargets" }));
+    await flush();
+
+    expect(client.frames().find((frame) => frame.id === 3)).toMatchObject({
+      error: { message: expect.stringMatching(/target identit.*unavailable/i) },
+    });
+  });
+});

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -8,6 +8,7 @@ import {
   sendHello,
   defaultTabs,
   flush,
+  replyFor,
 } from "./relay-bridge.test-support.js";
 import type { RelayToExtensionMessage } from "./relay-protocol.js";
 
@@ -539,103 +540,6 @@ describe("ExtensionRelayBridge", () => {
     expect(bridge.extensionConnected).toBe(false);
   });
 
-  it("repairs reconnect attach without undoing a later explicit detach", async () => {
-    const bridge = new ExtensionRelayBridge();
-    const initialSocket = new FakeSocket();
-    const initial = bridge.attachExtensionSocket(initialSocket);
-    sendHello(initial);
-
-    const client = new FakeSocket();
-    const cdp = bridge.attachCdpClientSocket(client);
-    cdp.onMessage(
-      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
-    );
-    expect(initialSocket.frames().filter((frame) => frame.type === "attach")).toHaveLength(1);
-
-    const replacement = wireExtension(bridge);
-    sendHello(replacement.handlers);
-    await flush();
-
-    expect(replacement.socket.frames().filter((frame) => frame.type === "attach")).toEqual([
-      expect.objectContaining({ tabId: 1 }),
-    ]);
-    cdp.onMessage(JSON.stringify({ id: 2, method: "Target.getTargets" }));
-    await flush();
-    expect(client.frames().find((frame) => frame.id === 2)?.result).toMatchObject({
-      targetInfos: [expect.objectContaining({ targetId: "target-1" })],
-    });
-
-    const attached = client
-      .frames()
-      .findLast((frame) => frame.method === "Target.attachedToTarget");
-    const sessionId = (attached?.params as { sessionId?: string } | undefined)?.sessionId;
-    expect(typeof sessionId).toBe("string");
-    cdp.onMessage(
-      JSON.stringify({ id: 3, method: "Target.detachFromTarget", params: { sessionId } }),
-    );
-    await flush();
-    const afterDetach = wireExtension(bridge);
-    sendHello(afterDetach.handlers, [
-      { tabId: 1, url: "https://example.com", title: "Updated", active: true },
-    ]);
-    await flush();
-
-    expect(afterDetach.socket.frames().filter((frame) => frame.type === "attach")).toHaveLength(0);
-    cdp.onMessage(JSON.stringify({ id: 4, method: "Target.getTargets" }));
-    await flush();
-    expect(client.frames().find((frame) => frame.id === 4)).toMatchObject({
-      error: { message: expect.stringMatching(/target identit.*unavailable/i) },
-    });
-  });
-
-  it("does not project a disconnected zero-tab extension as authoritative empty", async () => {
-    const bridge = new ExtensionRelayBridge();
-    const extension = wireExtension(bridge);
-    sendHello(extension.handlers, []);
-    extension.handlers.onClose();
-    const client = new FakeSocket();
-    const cdp = bridge.attachCdpClientSocket(client);
-
-    cdp.onMessage(JSON.stringify({ id: 1, method: "Target.getTargets" }));
-    await flush();
-
-    expect(client.frames().find((frame) => frame.id === 1)).toMatchObject({
-      error: { message: expect.stringMatching(/extension.*disconnected/i) },
-    });
-  });
-
-  it("does not project a mixed attached target list as authoritative", async () => {
-    const bridge = new ExtensionRelayBridge();
-    const extension = wireExtension(bridge);
-    sendHello(extension.handlers);
-    const client = new FakeSocket();
-    const cdp = bridge.attachCdpClientSocket(client);
-    cdp.onMessage(
-      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
-    );
-    await flush();
-    cdp.onMessage(
-      JSON.stringify({ id: 2, method: "Target.setAutoAttach", params: { autoAttach: false } }),
-    );
-    extension.handlers.onMessage(
-      JSON.stringify({
-        type: "tabs",
-        tabs: [
-          { tabId: 1, url: "https://one.example", title: "One", active: true },
-          { tabId: 2, url: "https://two.example", title: "Two", active: false },
-        ],
-      }),
-    );
-    await flush();
-
-    cdp.onMessage(JSON.stringify({ id: 3, method: "Target.getTargets" }));
-    await flush();
-
-    expect(client.frames().find((frame) => frame.id === 3)).toMatchObject({
-      error: { message: expect.stringMatching(/target identit.*unavailable/i) },
-    });
-  });
-
   it("reports malformed CDP client JSON instead of leaving the client waiting", () => {
     const bridge = new ExtensionRelayBridge();
     const client = new FakeSocket();
@@ -908,6 +812,35 @@ describe("ExtensionRelayBridge", () => {
     expect(bridge.devtoolsTargetDescriptors()[0]).toMatchObject({ id: "target-1", type: "page" });
   });
 
+  it("rejects a stale cached identity when detached-target repair fails", async () => {
+    const bridge = new ExtensionRelayBridge();
+    let attachAttempts = 0;
+    const extension = wireExtension(bridge, (message) => {
+      if (message.type === "attach" && attachAttempts++ > 0) {
+        return { type: "error", seq: message.seq, message: "replacement target unavailable" };
+      }
+      return replyFor(message);
+    });
+    sendHello(extension.handlers);
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    await flush();
+    extension.handlers.onMessage(
+      JSON.stringify({ type: "detached", tabId: 1, reason: "renderer replaced" }),
+    );
+
+    cdp.onMessage(JSON.stringify({ id: 2, method: "Target.getTargets" }));
+    await flush();
+
+    expect(extension.socket.frames().filter((frame) => frame.type === "attach")).toHaveLength(2);
+    expect(client.frames().find((frame) => frame.id === 2)).toMatchObject({
+      error: { message: expect.stringMatching(/target identit.*unavailable/i) },
+    });
+  });
+
   it("keeps operation identity on the same granted tab across renderer reattachment", async () => {
     const bridge = new ExtensionRelayBridge();
     try {
@@ -928,7 +861,8 @@ describe("ExtensionRelayBridge", () => {
         });
       };
       sendHello(extension.handlers);
-      const cdp = bridge.attachCdpClientSocket(new FakeSocket());
+      const client = new FakeSocket();
+      const cdp = bridge.attachCdpClientSocket(client);
       cdp.onMessage(
         JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
       );
@@ -941,11 +875,10 @@ describe("ExtensionRelayBridge", () => {
       );
       expect(resolveTarget?.()).toBeUndefined();
       targetId = "replacement-target";
-      cdp.onMessage(
-        JSON.stringify({ id: 2, method: "Target.setAutoAttach", params: { autoAttach: true } }),
-      );
+      cdp.onMessage(JSON.stringify({ id: 2, method: "Target.getTargets" }));
       await flush();
 
+      expect(client.frames().find((frame) => frame.id === 2)?.error).toBeUndefined();
       expect(resolveTarget?.()).toBe("replacement-target");
     } finally {
       bridge.dispose();

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -65,6 +65,8 @@ type TabState = {
 type CdpClientState = RelaySessionClient & {
   socket: BridgeSocket;
   autoAttach: boolean;
+  /** Root auto-attach tabs this client explicitly detached while discovery stays enabled. */
+  detachedTabs: Set<number>;
   creating: Set<Promise<void>>;
 };
 
@@ -426,6 +428,9 @@ export class ExtensionRelayBridge {
       if (!nextIds.has(tabId)) {
         this.sessions.retireTab(tabId);
         this.tabs.delete(tabId);
+        for (const client of this.clients) {
+          client.detachedTabs.delete(tabId);
+        }
       }
     }
     for (const info of tabs) {
@@ -438,13 +443,15 @@ export class ExtensionRelayBridge {
       }
       if (shouldAutoAttach && shouldAttach) {
         for (const client of this.clients) {
-          if (!client.autoAttach) {
+          if (!client.autoAttach || client.detachedTabs.has(info.tabId)) {
             continue;
           }
           void this.withAttachedTab(client, info.tabId, (attached) => {
-            if (client.autoAttach) {
-              this.announceAttachedTab(info.tabId, attached, [client]);
-            }
+            this.announceAttachedTab(
+              info.tabId,
+              attached,
+              this.autoAttachRecipients(info.tabId, attached.sessionId),
+            );
           }).catch((err: unknown) =>
             log.warn(`auto-attach of accessible tab ${info.tabId} failed: ${String(err)}`),
           );
@@ -589,16 +596,61 @@ export class ExtensionRelayBridge {
     };
   }
 
-  private enumerateTargetInfos():
+  private autoAttachRecipients(tabId: number, sessionId?: string): CdpClientState[] {
+    return [...this.clients].filter(
+      (candidate) =>
+        candidate.autoAttach &&
+        !candidate.detachedTabs.has(tabId) &&
+        (!sessionId || !candidate.sessions.has(sessionId)),
+    );
+  }
+
+  private async enumerateTargetInfos(client: CdpClientState): Promise<
     | { status: "available"; targetInfos: Record<string, unknown>[] }
     | {
         status: "unavailable";
         reason: "extension-disconnected" | "target-identity-unresolved";
-      } {
+      }
+  > {
     if (!this.extensionConnected) {
       return { status: "unavailable", reason: "extension-disconnected" };
     }
-    if ([...this.tabs.values()].some((tab) => !tab.target)) {
+    // Reconcile cached physical roots before inventory: Playwright creates Pages
+    // only from attachment events, and a native detach keeps only a stale identity.
+    for (const [tabId, tab] of this.tabs) {
+      if (tab.target?.sessionId) {
+        this.announceAttachedTab(
+          tabId,
+          { targetId: tab.target.id, sessionId: tab.target.sessionId },
+          this.autoAttachRecipients(tabId, tab.target.sessionId),
+        );
+      }
+    }
+    await Promise.allSettled(
+      [...this.tabs]
+        .filter(
+          ([tabId, tab]) =>
+            !tab.target || (!tab.target.sessionId && this.autoAttachRecipients(tabId).length > 0),
+        )
+        .map(([tabId]) =>
+          this.withAttachedTab(client, tabId, (attached) => {
+            this.announceAttachedTab(
+              tabId,
+              attached,
+              this.autoAttachRecipients(tabId, attached.sessionId),
+            );
+          }),
+        ),
+    );
+    if (!this.extensionConnected) {
+      return { status: "unavailable", reason: "extension-disconnected" };
+    }
+    if (
+      [...this.tabs].some(
+        ([tabId, tab]) =>
+          !tab.target || (!tab.target.sessionId && this.autoAttachRecipients(tabId).length > 0),
+      )
+    ) {
       return { status: "unavailable", reason: "target-identity-unresolved" };
     }
     const targetInfos = [...this.tabs.values()].map((tab) =>
@@ -639,6 +691,7 @@ export class ExtensionRelayBridge {
     const client: CdpClientState = {
       socket,
       autoAttach: false,
+      detachedTabs: new Set(),
       sessions: new Map(),
       creating: new Set(),
     };
@@ -1026,7 +1079,7 @@ export class ExtensionRelayBridge {
         return;
       }
       case "Target.getTargets": {
-        const enumeration = this.enumerateTargetInfos();
+        const enumeration = await this.enumerateTargetInfos(client);
         if (enumeration.status === "unavailable") {
           const message =
             enumeration.reason === "extension-disconnected"
@@ -1048,12 +1101,15 @@ export class ExtensionRelayBridge {
         const autoAttach = request.params?.autoAttach !== false;
         client.autoAttach = autoAttach;
         if (autoAttach) {
+          client.detachedTabs.clear();
           const attachResults = await Promise.allSettled(
             [...this.tabs.keys()].map((tabId) =>
               this.withAttachedTab(client, tabId, (attached) => {
-                if (client.autoAttach) {
-                  this.announceAttachedTab(tabId, attached, [client]);
-                }
+                this.announceAttachedTab(
+                  tabId,
+                  attached,
+                  this.autoAttachRecipients(tabId, attached.sessionId),
+                );
               }),
             ),
           );
@@ -1114,6 +1170,9 @@ export class ExtensionRelayBridge {
           if (!sessionId || !session) {
             this.respondError(client, request, `Session not found: ${String(sessionId)}`, -32001);
             return;
+          }
+          if (!session.parent && session.id === session.physical.rootSessionId) {
+            client.detachedTabs.add(session.physical.tabId);
           }
           await this.sessions.detach(client, sessionId);
         }

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -615,47 +615,41 @@ export class ExtensionRelayBridge {
     if (!this.extensionConnected) {
       return { status: "unavailable", reason: "extension-disconnected" };
     }
-    // Reconcile cached physical roots before inventory: Playwright creates Pages
-    // only from attachment events, and a native detach keeps only a stale identity.
-    for (const [tabId, tab] of this.tabs) {
-      if (tab.target?.sessionId) {
-        this.announceAttachedTab(
-          tabId,
-          { targetId: tab.target.id, sessionId: tab.target.sessionId },
-          this.autoAttachRecipients(tabId, tab.target.sessionId),
-        );
+    // Tabs can arrive while Chrome attaches the previous batch. Visit each tab
+    // generation once; a failed acquisition still rejects the complete inventory.
+    const identities = new Map<TabState, string | undefined>();
+    while (this.extensionConnected) {
+      const pending = [...this.tabs].filter(([, tab]) => !identities.has(tab));
+      if (pending.length === 0) {
+        break;
       }
-    }
-    await Promise.allSettled(
-      [...this.tabs]
-        .filter(
-          ([tabId, tab]) =>
-            !tab.target || (!tab.target.sessionId && this.autoAttachRecipients(tabId).length > 0),
-        )
-        .map(([tabId]) =>
+      for (const [, tab] of pending) {
+        identities.set(tab, undefined);
+      }
+      await Promise.allSettled(
+        pending.map(([tabId, tab]) =>
           this.withAttachedTab(client, tabId, (attached) => {
             this.announceAttachedTab(
               tabId,
               attached,
               this.autoAttachRecipients(tabId, attached.sessionId),
             );
+            identities.set(tab, attached.targetId);
           }),
         ),
-    );
+      );
+    }
     if (!this.extensionConnected) {
       return { status: "unavailable", reason: "extension-disconnected" };
     }
-    if (
-      [...this.tabs].some(
-        ([tabId, tab]) =>
-          !tab.target || (!tab.target.sessionId && this.autoAttachRecipients(tabId).length > 0),
-      )
-    ) {
-      return { status: "unavailable", reason: "target-identity-unresolved" };
+    const targetInfos: Record<string, unknown>[] = [];
+    for (const [tabId, tab] of this.tabs) {
+      const targetId = identities.get(tab);
+      if (!targetId || (!tab.target?.sessionId && this.autoAttachRecipients(tabId).length > 0)) {
+        return { status: "unavailable", reason: "target-identity-unresolved" };
+      }
+      targetInfos.push(this.targetInfoForTab(tab, targetId));
     }
-    const targetInfos = [...this.tabs.values()].map((tab) =>
-      this.targetInfoForTab(tab, tab.target?.id ?? ""),
-    );
     return { status: "available", targetInfos };
   }
 

--- a/extensions/browser/src/browser/extension-relay/relay-coexistence.test-support.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-coexistence.test-support.ts
@@ -100,10 +100,10 @@ export async function withConnectedDaemon(
     stateDir: string,
     config: object,
   ) => Promise<{ stop: () => void; done: Promise<unknown> }>,
-  handleCdpCommand?: (
+  handleExtensionCommand?: (
     command: Record<string, unknown>,
     send: (message: Record<string, unknown>) => void,
-  ) => void,
+  ) => boolean,
 ) {
   await withTempDir("relay-coexistence-", async (dir) => {
     const stateDir = await fs.realpath(dir);
@@ -168,8 +168,9 @@ export async function withConnectedDaemon(
               extension.send(JSON.stringify({ type: "pong" }));
               return;
             }
-            if (command.type === "cdp" && handleCdpCommand) {
-              handleCdpCommand(command, (message) => extension.send(JSON.stringify(message)));
+            const send = (message: Record<string, unknown>) =>
+              extension.send(JSON.stringify(message));
+            if (handleExtensionCommand?.(command, send)) {
               return;
             }
             if (command.type === "detach" && detachHeld) {

--- a/extensions/browser/src/browser/extension-relay/relay-targets.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-targets.test.ts
@@ -194,7 +194,8 @@ describe("pending tab acquisition claims", () => {
     f.release();
     expect.soft((await c.response(request)).error).toBeDefined();
     await peer.response(pending);
-    expect.soft(c.attached()).toHaveLength(1);
+    expect.soft(c.attached()).toHaveLength(2);
+    expect(c.attached()[1]).toMatchObject({ targetInfo: { targetId: "target-2" } });
     expect(peer.attached()).toHaveLength(1);
     expect(peer.attached()[0]).toMatchObject({ targetInfo: { targetId: "target-2" } });
     expect(f.commands("detach")).toEqual([]);

--- a/extensions/browser/src/browser/pw-session-actions.ts
+++ b/extensions/browser/src/browser/pw-session-actions.ts
@@ -1,3 +1,4 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { Browser, Page, Response } from "playwright-core";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
@@ -10,6 +11,7 @@ import {
   withCdpSocket,
 } from "./cdp.helpers.js";
 import { AX_REF_PATTERN, normalizeCdpWsUrl } from "./cdp.js";
+import { DEFAULT_BROWSER_ACTION_TIMEOUT_MS } from "./constants.js";
 import {
   withBrowserNavigationPolicy,
   assertBrowserNavigationAllowed,
@@ -278,7 +280,7 @@ async function withPlaywrightSafeReadReconnect<T>(
   opts: {
     cdpUrl: string;
     ssrfPolicy?: SsrFPolicy;
-    attempt?: { cancelled: boolean };
+    signal: AbortSignal;
   },
   run: (browser: Browser) => Promise<T>,
 ): Promise<T> {
@@ -286,11 +288,11 @@ async function withPlaywrightSafeReadReconnect<T>(
   try {
     return await run(connected.browser);
   } catch (err) {
-    if (!isRecoverablePlaywrightDisconnectError(err) || opts.attempt?.cancelled) {
+    if (!isRecoverablePlaywrightDisconnectError(err) || opts.signal.aborted) {
       throw err;
     }
     evictStalePlaywrightBrowserConnection(opts.cdpUrl, connected.browser);
-    if (opts.attempt?.cancelled) {
+    if (opts.signal.aborted) {
       throw err;
     }
     const retry = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
@@ -304,86 +306,118 @@ async function readPagesViaPlaywright(
     ssrfPolicy?: SsrFPolicy;
     requireCompleteTargetList?: boolean;
   },
-  attempt?: { cancelled: boolean },
+  signal: AbortSignal,
 ): Promise<PlaywrightPageEnumeration> {
   return await withPlaywrightSafeReadReconnect(
-    { cdpUrl: opts.cdpUrl, ssrfPolicy: opts.ssrfPolicy, attempt },
+    { cdpUrl: opts.cdpUrl, ssrfPolicy: opts.ssrfPolicy, signal },
     async (browser) => {
-      let remainingTargetIds: Set<string> | undefined;
-      if (opts.requireCompleteTargetList) {
-        const session = await browser.newBrowserCDPSession();
-        try {
-          const result = await session.send("Target.getTargets");
-          if (!Array.isArray(result.targetInfos)) {
-            throw new Error("Browser target enumeration was unavailable.");
+      signal.throwIfAborted();
+      const contexts = opts.requireCompleteTargetList ? browser.contexts() : [];
+      let publication = createDeferred<void>();
+      const wake = () => publication.resolve();
+      let disconnected = false;
+      const onDisconnected = () => {
+        disconnected = true;
+        wake();
+      };
+      // CDP discovery can finish before Playwright initializes and publishes each Page.
+      // Subscribe before discovery so publication during either read cannot be lost.
+      for (const context of contexts) {
+        context.on("page", wake);
+      }
+      browser.on("disconnected", onDisconnected);
+      signal.addEventListener("abort", wake, { once: true });
+      try {
+        let nativeTargetIds: Set<string> | undefined;
+        if (opts.requireCompleteTargetList) {
+          const session = await browser.newBrowserCDPSession();
+          try {
+            const result = await session.send("Target.getTargets");
+            if (!Array.isArray(result.targetInfos)) {
+              throw new Error("Browser target enumeration was unavailable.");
+            }
+            nativeTargetIds = new Set(
+              result.targetInfos
+                .filter(
+                  (info) => info.type === "page" && !isBlockedTarget(opts.cdpUrl, info.targetId),
+                )
+                .map((info) => info.targetId),
+            );
+          } finally {
+            await session.detach().catch(() => {});
           }
-          remainingTargetIds = new Set(
-            result.targetInfos
-              .filter(
-                (info) => info.type === "page" && !isBlockedTarget(opts.cdpUrl, info.targetId),
-              )
-              .map((info) => info.targetId),
-          );
-        } finally {
-          await session.detach().catch(() => {});
         }
+        for (;;) {
+          publication = createDeferred<void>();
+          signal.throwIfAborted();
+          if (disconnected) {
+            throw new Error("Browser disconnected during page enumeration.");
+          }
+          const remainingTargetIds = nativeTargetIds ? new Set(nativeTargetIds) : undefined;
+          const pages = await getAllPages(browser);
+          const candidatePages = pages.filter((page) => !isBlockedPageRef(opts.cdpUrl, page));
+          const pageResults = await Promise.all(
+            candidatePages.map(async (page) => {
+              let targetInfo: Awaited<ReturnType<typeof pageTargetInfo>>;
+              try {
+                targetInfo = await pageTargetInfo(page);
+              } catch (err) {
+                if (isRecoverablePlaywrightDisconnectError(err)) {
+                  throw err;
+                }
+                targetInfo = null;
+              }
+              if (!targetInfo) {
+                return { status: "unresolved" as const };
+              }
+              if (isBlockedTarget(opts.cdpUrl, targetInfo.targetId)) {
+                return { status: "blocked" as const };
+              }
+              let url = "";
+              try {
+                url = page.url();
+              } catch (err) {
+                if (isRecoverablePlaywrightDisconnectError(err)) {
+                  throw err;
+                }
+              }
+              return {
+                status: "available" as const,
+                page: {
+                  targetId: targetInfo.targetId,
+                  title: targetInfo.title,
+                  url,
+                  type: "page" as const,
+                },
+              };
+            }),
+          );
+          // Keep page order and native snapshot identities. A quarantined Page reference
+          // cannot identify a missing native target without exposing its metadata.
+          const resolvedPages = pageResults.flatMap((result) =>
+            result.status === "available" &&
+            (!remainingTargetIds || remainingTargetIds.delete(result.page.targetId))
+              ? [result.page]
+              : [],
+          );
+          if (
+            (opts.requireCompleteTargetList || resolvedPages.length === 0) &&
+            pageResults.some((result) => result.status === "unresolved")
+          ) {
+            return { status: "unavailable", reason: "target-identity-unresolved" };
+          }
+          if (!remainingTargetIds?.size) {
+            return { status: "available", pages: resolvedPages };
+          }
+          await publication.promise;
+        }
+      } finally {
+        for (const context of contexts) {
+          context.off("page", wake);
+        }
+        browser.off("disconnected", onDisconnected);
+        signal.removeEventListener("abort", wake);
       }
-      const pages = await getAllPages(browser);
-      const candidatePages = pages.filter((page) => !isBlockedPageRef(opts.cdpUrl, page));
-      const pageResults = await Promise.all(
-        candidatePages.map(async (page) => {
-          let targetInfo: Awaited<ReturnType<typeof pageTargetInfo>>;
-          try {
-            targetInfo = await pageTargetInfo(page);
-          } catch (err) {
-            if (isRecoverablePlaywrightDisconnectError(err)) {
-              throw err;
-            }
-            targetInfo = null;
-          }
-          if (!targetInfo) {
-            return { status: "unresolved" as const };
-          }
-          if (isBlockedTarget(opts.cdpUrl, targetInfo.targetId)) {
-            return { status: "blocked" as const };
-          }
-          let url = "";
-          try {
-            url = page.url();
-          } catch (err) {
-            if (isRecoverablePlaywrightDisconnectError(err)) {
-              throw err;
-            }
-          }
-          return {
-            status: "available" as const,
-            page: {
-              targetId: targetInfo.targetId,
-              title: targetInfo.title,
-              url,
-              type: "page" as const,
-            },
-          };
-        }),
-      );
-      // Promise.all preserves candidate order and still propagates recoverable disconnects
-      // to the outer reconnect path when any per-page task rejects.
-      // Native discovery can lead Page publication. Consume only projected IDs from that
-      // snapshot; a quarantined Page reference alone cannot identify a missing native target.
-      const resolvedPages = pageResults.flatMap((result) =>
-        result.status === "available" &&
-        (!remainingTargetIds || remainingTargetIds.delete(result.page.targetId))
-          ? [result.page]
-          : [],
-      );
-      if (
-        (remainingTargetIds && remainingTargetIds.size > 0) ||
-        ((opts.requireCompleteTargetList || resolvedPages.length === 0) &&
-          pageResults.some((result) => result.status === "unresolved"))
-      ) {
-        return { status: "unavailable", reason: "target-identity-unresolved" };
-      }
-      return { status: "available", pages: resolvedPages };
     },
   );
 }
@@ -410,60 +444,41 @@ export async function listPagesViaPlaywright(opts: {
   const timeoutMs =
     typeof opts.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
       ? Math.max(1, Math.floor(opts.timeoutMs))
-      : undefined;
+      : opts.requireCompleteTargetList
+        ? DEFAULT_BROWSER_ACTION_TIMEOUT_MS
+        : undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
-  let timeoutError: Error | undefined;
-  const attempt = { cancelled: false };
-  const operations: Array<Promise<PlaywrightPageEnumeration>> = [
-    readPagesViaPlaywright(opts, attempt),
-  ];
-  if (timeoutMs !== undefined) {
-    operations.push(
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(() => {
-          attempt.cancelled = true;
-          timeoutError = new Error(`Playwright page enumeration timed out after ${timeoutMs}ms`);
-          reject(timeoutError);
-        }, timeoutMs);
-        timer.unref?.();
-      }),
+  const controller = new AbortController();
+  const cancelled = createDeferred<never>();
+  const onCancelled = () => cancelled.reject(controller.signal.reason);
+  controller.signal.addEventListener("abort", onCancelled, { once: true });
+  const onAbort = () =>
+    controller.abort(
+      opts.signal?.reason instanceof Error
+        ? opts.signal.reason
+        : new Error("Playwright page enumeration was aborted."),
     );
+  opts.signal?.addEventListener("abort", onAbort, { once: true });
+  if (opts.signal?.aborted) {
+    onAbort();
   }
-  let abortError: Error | undefined;
-  let abortListener: (() => void) | undefined;
-  const signal = opts.signal;
-  if (signal) {
-    operations.push(
-      new Promise<never>((_, reject) => {
-        if (signal.aborted) {
-          attempt.cancelled = true;
-          abortError =
-            signal.reason instanceof Error
-              ? signal.reason
-              : new Error("Playwright page enumeration was aborted.");
-          reject(abortError);
-          return;
-        }
-        abortListener = () => {
-          attempt.cancelled = true;
-          abortError =
-            signal.reason instanceof Error
-              ? signal.reason
-              : new Error("Playwright page enumeration was aborted.");
-          reject(abortError);
-        };
-        signal.addEventListener("abort", abortListener, { once: true });
-      }),
-    );
+  if (timeoutMs !== undefined) {
+    timer = setTimeout(() => {
+      controller.abort(new Error(`Playwright page enumeration timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    timer.unref?.();
   }
   try {
-    const enumeration = await Promise.race(operations);
+    const enumeration = await Promise.race([
+      readPagesViaPlaywright(opts, controller.signal),
+      cancelled.promise,
+    ]);
     if (enumeration.status === "unavailable") {
       throw new Error("Playwright page target identities are temporarily unavailable.");
     }
     return enumeration.pages;
   } catch (err) {
-    if (err === timeoutError || err === abortError) {
+    if (controller.signal.aborted && err === controller.signal.reason) {
       await forceDisconnectPlaywrightForTarget({
         cdpUrl: opts.cdpUrl,
         ssrfPolicy: opts.ssrfPolicy,
@@ -475,9 +490,8 @@ export async function listPagesViaPlaywright(opts: {
     if (timer) {
       clearTimeout(timer);
     }
-    if (abortListener && signal) {
-      signal.removeEventListener("abort", abortListener);
-    }
+    opts.signal?.removeEventListener("abort", onAbort);
+    controller.signal.removeEventListener("abort", onCancelled);
   }
 }
 

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -80,7 +80,7 @@ function installBrowserMocks() {
   const mainFrame = {};
   const contextOn = vi.fn();
   const browserEvents = new EventEmitter();
-  const browserOn = vi.spyOn(browserEvents, "on");
+  const browserOn = vi.fn(browserEvents.on.bind(browserEvents));
   const browserClose = vi.fn(async () => {});
   const sessionSend = vi.fn(async (method: string) => {
     if (method === "Target.getTargetInfo") {
@@ -115,10 +115,12 @@ function installBrowserMocks() {
     mainFrame: () => mainFrame,
   } as unknown as import("playwright-core").Page;
 
-  const browser = Object.assign(browserEvents, {
+  const browser = {
     contexts: () => [context],
+    on: browserOn,
+    off: browserEvents.off.bind(browserEvents),
     close: browserClose,
-  }) as import("playwright-core").Browser;
+  } as unknown as import("playwright-core").Browser;
 
   connectOverCdpSpy.mockResolvedValue(browser);
   getChromeWebSocketEndpointSpy.mockResolvedValue(null);

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -1,4 +1,5 @@
 // Browser tests cover pw session.create page.navigation guard plugin behavior.
+import { EventEmitter } from "node:events";
 import { chromium } from "playwright-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
@@ -78,7 +79,8 @@ function installBrowserMocks() {
   });
   const mainFrame = {};
   const contextOn = vi.fn();
-  const browserOn = vi.fn();
+  const browserEvents = new EventEmitter();
+  const browserOn = vi.spyOn(browserEvents, "on");
   const browserClose = vi.fn(async () => {});
   const sessionSend = vi.fn(async (method: string) => {
     if (method === "Target.getTargetInfo") {
@@ -113,11 +115,10 @@ function installBrowserMocks() {
     mainFrame: () => mainFrame,
   } as unknown as import("playwright-core").Page;
 
-  const browser = {
+  const browser = Object.assign(browserEvents, {
     contexts: () => [context],
-    on: browserOn,
     close: browserClose,
-  } as unknown as import("playwright-core").Browser;
+  }) as import("playwright-core").Browser;
 
   connectOverCdpSpy.mockResolvedValue(browser);
   getChromeWebSocketEndpointSpy.mockResolvedValue(null);

--- a/extensions/browser/src/browser/pw-session.enumeration.test.ts
+++ b/extensions/browser/src/browser/pw-session.enumeration.test.ts
@@ -200,6 +200,51 @@ describe("pw-session page enumeration", () => {
     await unavailable;
   });
 
+  it("observes pages published while complete target inventory is resolving", async () => {
+    const cdpUrl = "http://127.0.0.1:9222";
+    const fixture = makePageEnumerationBrowser([
+      {
+        targetId: "RECOVERED",
+        title: "Recovered",
+        url: "https://recovered.example",
+      },
+    ]);
+    let published = false;
+    const context = fixture.browser.contexts()[0]!;
+    vi.spyOn(context, "pages").mockImplementation(() => (published ? fixture.pages : []));
+    Object.assign(fixture.browser, {
+      newBrowserCDPSession: vi.fn(async () => ({
+        send: vi.fn(async () => {
+          published = true;
+          return {
+            targetInfos: [
+              {
+                targetId: "RECOVERED",
+                type: "page",
+                title: "Recovered",
+                url: "https://recovered.example",
+              },
+            ],
+          };
+        }),
+        detach: vi.fn(async () => {}),
+      })),
+    });
+    connectOverCdpSpy.mockResolvedValue(fixture.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await expect(
+      listPagesViaPlaywright({ cdpUrl, requireCompleteTargetList: true }),
+    ).resolves.toEqual([
+      {
+        targetId: "RECOVERED",
+        title: "Recovered",
+        url: "https://recovered.example",
+        type: "page",
+      },
+    ]);
+  });
+
   it("rejects an unavailable complete target enumeration even with zero cached pages", async () => {
     const fixture = makeEmptyBrowser();
     const detach = vi.fn(async () => {});

--- a/extensions/browser/src/browser/pw-session.enumeration.test.ts
+++ b/extensions/browser/src/browser/pw-session.enumeration.test.ts
@@ -27,6 +27,8 @@ function makePageEnumerationBrowser(
 ): BrowserMockBundle & {
   pages: import("playwright-core").Page[];
   newCDPSession: ReturnType<typeof vi.fn>;
+  contextEvents: EventEmitter;
+  browserEvents: EventEmitter;
 } {
   const browserClose = vi.fn(async () => {});
   const specByPage = new WeakMap<import("playwright-core").Page, (typeof specs)[number]>();
@@ -56,12 +58,18 @@ function makePageEnumerationBrowser(
       detach: vi.fn(spec.detach ?? (async () => {})),
     };
   });
-  const context = Object.assign(new EventEmitter(), {
+  const contextEvents = new EventEmitter();
+  const browserEvents = new EventEmitter();
+  const context = {
     pages: () => pages,
+    on: contextEvents.on.bind(contextEvents),
+    off: contextEvents.off.bind(contextEvents),
     newCDPSession,
-  }) as import("playwright-core").BrowserContext;
-  const browser = Object.assign(new EventEmitter(), {
+  } as unknown as import("playwright-core").BrowserContext;
+  const browser = {
     contexts: () => [context],
+    on: browserEvents.on.bind(browserEvents),
+    off: browserEvents.off.bind(browserEvents),
     close: browserClose,
     newBrowserCDPSession: vi.fn(async () => ({
       send: vi.fn(async () => ({
@@ -69,9 +77,9 @@ function makePageEnumerationBrowser(
       })),
       detach: vi.fn(async () => {}),
     })),
-  }) as import("playwright-core").Browser;
+  } as unknown as import("playwright-core").Browser;
 
-  return { browser, browserClose, pages, newCDPSession };
+  return { browser, browserClose, pages, newCDPSession, contextEvents, browserEvents };
 }
 
 describe("pw-session page enumeration", () => {
@@ -236,7 +244,7 @@ describe("pw-session page enumeration", () => {
       );
       const publish = () => {
         published = true;
-        context.emit("page", fixture.pages[1]);
+        fixture.contextEvents.emit("page", fixture.pages[1]);
       };
       const inventoryRead = vi.fn(async () => {
         if (timing === "during discovery") {
@@ -289,8 +297,8 @@ describe("pw-session page enumeration", () => {
       expect(inventoryRead).toHaveBeenCalledOnce();
       expect(connectOverCdpSpy).toHaveBeenCalledOnce();
       expect(fixture.browserClose).not.toHaveBeenCalled();
-      expect(context.listenerCount("page")).toBe(1);
-      expect(fixture.browser.listenerCount("disconnected")).toBe(1);
+      expect(fixture.contextEvents.listenerCount("page")).toBe(1);
+      expect(fixture.browserEvents.listenerCount("disconnected")).toBe(1);
     },
   );
 
@@ -509,8 +517,8 @@ describe("pw-session page enumeration", () => {
     expect(detach).toHaveBeenCalledTimes(requireCompleteTargetList ? 1 : 0);
     expect(connectOverCdpSpy).toHaveBeenCalledOnce();
     expect(fixture.browserClose).toHaveBeenCalledTimes(testCase.waitsForPublication ? 1 : 0);
-    expect(fixture.browser.contexts()[0]!.listenerCount("page")).toBe(1);
-    expect(fixture.browser.listenerCount("disconnected")).toBe(
+    expect(fixture.contextEvents.listenerCount("page")).toBe(1);
+    expect(fixture.browserEvents.listenerCount("disconnected")).toBe(
       testCase.waitsForPublication ? 0 : 1,
     );
     if (blockedPage) {
@@ -555,13 +563,13 @@ describe("pw-session page enumeration", () => {
     if (stop === "abort") {
       controller.abort(new Error("cancelled publication"));
     } else {
-      fixture.browser.emit("disconnected");
+      fixture.browserEvents.emit("disconnected");
     }
     await result;
-    context.emit("page", fixture.pages[0]);
+    fixture.contextEvents.emit("page", fixture.pages[0]);
     expect(fixture.newCDPSession).not.toHaveBeenCalled();
-    expect(context.listenerCount("page")).toBe(1);
-    expect(fixture.browser.listenerCount("disconnected")).toBe(stop === "abort" ? 0 : 1);
+    expect(fixture.contextEvents.listenerCount("page")).toBe(1);
+    expect(fixture.browserEvents.listenerCount("disconnected")).toBe(stop === "abort" ? 0 : 1);
     expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
     expect(connectOverCdpSpy).toHaveBeenCalledTimes(stop === "abort" ? 1 : 2);
     expect(successor.browserClose).not.toHaveBeenCalled();

--- a/extensions/browser/src/browser/pw-session.enumeration.test.ts
+++ b/extensions/browser/src/browser/pw-session.enumeration.test.ts
@@ -1,7 +1,8 @@
+import { EventEmitter, getEventListeners } from "node:events";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it, vi } from "vitest";
 import {
   type BrowserMockBundle,
-  makeEmptyBrowser,
   setupPwSessionConnectionTest,
 } from "./pw-session.connection.test-support.js";
 
@@ -55,17 +56,20 @@ function makePageEnumerationBrowser(
       detach: vi.fn(spec.detach ?? (async () => {})),
     };
   });
-  const context = {
+  const context = Object.assign(new EventEmitter(), {
     pages: () => pages,
-    on: vi.fn(),
     newCDPSession,
-  } as unknown as import("playwright-core").BrowserContext;
-  const browser = {
+  }) as import("playwright-core").BrowserContext;
+  const browser = Object.assign(new EventEmitter(), {
     contexts: () => [context],
-    on: vi.fn(),
-    off: vi.fn(),
     close: browserClose,
-  } as unknown as import("playwright-core").Browser;
+    newBrowserCDPSession: vi.fn(async () => ({
+      send: vi.fn(async () => ({
+        targetInfos: specs.map((spec) => ({ targetId: spec.targetId, type: "page" })),
+      })),
+      detach: vi.fn(async () => {}),
+    })),
+  }) as import("playwright-core").Browser;
 
   return { browser, browserClose, pages, newCDPSession };
 }
@@ -200,53 +204,98 @@ describe("pw-session page enumeration", () => {
     await unavailable;
   });
 
-  it("observes pages published while complete target inventory is resolving", async () => {
-    const cdpUrl = "http://127.0.0.1:9222";
-    const fixture = makePageEnumerationBrowser([
-      {
-        targetId: "RECOVERED",
-        title: "Recovered",
-        url: "https://recovered.example",
-      },
-    ]);
-    let published = false;
-    const context = fixture.browser.contexts()[0]!;
-    vi.spyOn(context, "pages").mockImplementation(() => (published ? fixture.pages : []));
-    Object.assign(fixture.browser, {
-      newBrowserCDPSession: vi.fn(async () => ({
-        send: vi.fn(async () => {
-          published = true;
-          return {
-            targetInfos: [
-              {
-                targetId: "RECOVERED",
-                type: "page",
-                title: "Recovered",
-                url: "https://recovered.example",
-              },
-            ],
-          };
-        }),
-        detach: vi.fn(async () => {}),
-      })),
-    });
-    connectOverCdpSpy.mockResolvedValue(fixture.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+  it.each(["during discovery", "after discovery", "during metadata"] as const)(
+    "observes pages published %s without repeating the complete target inventory",
+    async (timing) => {
+      const cdpUrl = "http://127.0.0.1:9222";
+      const metadataRead = createDeferred<void>();
+      const releaseMetadata = createDeferred<void>();
+      const fixture = makePageEnumerationBrowser([
+        {
+          targetId: "EXISTING",
+          title: "Existing",
+          url: "https://existing.example",
+          readTargetInfo: async () => {
+            metadataRead.resolve();
+            if (timing === "during metadata") {
+              await releaseMetadata.promise;
+            }
+            return { targetInfo: { targetId: "EXISTING", title: "Existing" } };
+          },
+        },
+        {
+          targetId: "RECOVERED",
+          title: "Recovered",
+          url: "https://recovered.example",
+        },
+      ]);
+      let published = false;
+      const context = fixture.browser.contexts()[0]!;
+      vi.spyOn(context, "pages").mockImplementation(() =>
+        published ? fixture.pages : fixture.pages.slice(0, 1),
+      );
+      const publish = () => {
+        published = true;
+        context.emit("page", fixture.pages[1]);
+      };
+      const inventoryRead = vi.fn(async () => {
+        if (timing === "during discovery") {
+          publish();
+        }
+        return {
+          targetInfos: [
+            { targetId: "EXISTING", type: "page" },
+            { targetId: "RECOVERED", type: "page", title: "native title" },
+          ],
+        };
+      });
+      Object.assign(fixture.browser, {
+        newBrowserCDPSession: vi.fn(async () => ({
+          send: inventoryRead,
+          detach: vi.fn(async () => {}),
+        })),
+      });
+      connectOverCdpSpy.mockResolvedValue(fixture.browser);
+      getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
-    await expect(
-      listPagesViaPlaywright({ cdpUrl, requireCompleteTargetList: true }),
-    ).resolves.toEqual([
-      {
-        targetId: "RECOVERED",
-        title: "Recovered",
-        url: "https://recovered.example",
-        type: "page",
-      },
-    ]);
-  });
+      const listing = listPagesViaPlaywright({ cdpUrl, requireCompleteTargetList: true });
+      const listed = expect(listing).resolves.toEqual([
+        {
+          targetId: "EXISTING",
+          title: "Existing",
+          url: "https://existing.example",
+          type: "page",
+        },
+        {
+          targetId: "RECOVERED",
+          title: "Recovered",
+          url: "https://recovered.example",
+          type: "page",
+        },
+      ]);
+      void listed.catch(() => {});
+      await metadataRead.promise;
+      if (timing === "after discovery") {
+        // Let the first page read finish before the recovered Page exists.
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+      }
+      if (timing !== "during discovery") {
+        publish();
+        releaseMetadata.resolve();
+      }
+      await listed;
+      expect(inventoryRead).toHaveBeenCalledOnce();
+      expect(connectOverCdpSpy).toHaveBeenCalledOnce();
+      expect(fixture.browserClose).not.toHaveBeenCalled();
+      expect(context.listenerCount("page")).toBe(1);
+      expect(fixture.browser.listenerCount("disconnected")).toBe(1);
+    },
+  );
 
   it("rejects an unavailable complete target enumeration even with zero cached pages", async () => {
-    const fixture = makeEmptyBrowser();
+    const fixture = makePageEnumerationBrowser([]);
     const detach = vi.fn(async () => {});
     const browser = Object.assign(fixture.browser, {
       newBrowserCDPSession: vi.fn(async () => ({
@@ -277,15 +326,23 @@ describe("pw-session page enumeration", () => {
     blockedId?: string;
     blockedPageId?: string;
     complete?: boolean;
+    waitsForPublication?: boolean;
     expected: string[] | null;
   }>([
     {
       name: "native page not yet published",
       nativeIds: ["A", "B"],
       pageIds: ["A"],
+      waitsForPublication: true,
       expected: null,
     },
-    { name: "no published pages yet", nativeIds: ["A"], pageIds: [], expected: null },
+    {
+      name: "no published pages yet",
+      nativeIds: ["A"],
+      pageIds: [],
+      waitsForPublication: true,
+      expected: null,
+    },
     {
       name: "unresolved page metadata",
       nativeIds: ["A", "B"],
@@ -311,6 +368,7 @@ describe("pw-session page enumeration", () => {
       name: "equal counts with different identities",
       nativeIds: ["A", "B"],
       pageIds: ["A", "STALE"],
+      waitsForPublication: true,
       expected: null,
     },
     {
@@ -354,6 +412,7 @@ describe("pw-session page enumeration", () => {
       pageIds: ["A", "B"],
       blockedPageId: "B",
       unresolvedId: "B",
+      waitsForPublication: true,
       expected: null,
     },
     {
@@ -379,6 +438,7 @@ describe("pw-session page enumeration", () => {
       expected: ["A"],
     },
   ])("enforces enumeration completeness: $name", async (testCase) => {
+    vi.useFakeTimers();
     const cdpUrl = "http://127.0.0.1:9222";
     const fixture = makePageEnumerationBrowser(
       testCase.pageIds.map((targetId) => ({
@@ -426,9 +486,15 @@ describe("pw-session page enumeration", () => {
     }
 
     const requireCompleteTargetList = testCase.complete ?? true;
-    const listing = listPagesViaPlaywright({ cdpUrl, requireCompleteTargetList });
+    const listing = listPagesViaPlaywright({ cdpUrl, requireCompleteTargetList, timeoutMs: 100 });
     if (testCase.expected === null) {
-      await expect(listing).rejects.toThrow(/target identities.*unavailable/i);
+      const rejected = expect(listing).rejects.toThrow(
+        testCase.waitsForPublication
+          ? "Playwright page enumeration timed out after 100ms"
+          : /target identities.*unavailable/i,
+      );
+      await vi.advanceTimersByTimeAsync(100);
+      await rejected;
     } else {
       await expect(listing).resolves.toEqual(
         testCase.expected.map((targetId) => ({
@@ -442,10 +508,63 @@ describe("pw-session page enumeration", () => {
     expect(inventoryRead).toHaveBeenCalledTimes(requireCompleteTargetList ? 1 : 0);
     expect(detach).toHaveBeenCalledTimes(requireCompleteTargetList ? 1 : 0);
     expect(connectOverCdpSpy).toHaveBeenCalledOnce();
-    expect(fixture.browserClose).not.toHaveBeenCalled();
+    expect(fixture.browserClose).toHaveBeenCalledTimes(testCase.waitsForPublication ? 1 : 0);
+    expect(fixture.browser.contexts()[0]!.listenerCount("page")).toBe(1);
+    expect(fixture.browser.listenerCount("disconnected")).toBe(
+      testCase.waitsForPublication ? 0 : 1,
+    );
     if (blockedPage) {
       expect(fixture.newCDPSession).not.toHaveBeenCalledWith(blockedPage);
     }
+  });
+
+  it.each(["abort", "disconnect"] as const)("releases a publication wait on %s", async (stop) => {
+    const specs = [{ targetId: "A", title: "A", url: "https://a.example/" }];
+    const fixture = makePageEnumerationBrowser(specs);
+    const context = fixture.browser.contexts()[0]!;
+    vi.spyOn(context, "pages").mockReturnValue([]);
+    const inventoryRead = createDeferred<void>();
+    Object.assign(fixture.browser, {
+      newBrowserCDPSession: vi.fn(async () => ({
+        send: vi.fn(async () => {
+          inventoryRead.resolve();
+          return { targetInfos: [{ targetId: "A", type: "page" }] };
+        }),
+        detach: vi.fn(async () => {}),
+      })),
+    });
+    const successor = makePageEnumerationBrowser(specs);
+    connectOverCdpSpy.mockResolvedValueOnce(fixture.browser).mockResolvedValue(successor.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    const controller = new AbortController();
+    const listing = listPagesViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      requireCompleteTargetList: true,
+      signal: controller.signal,
+    });
+    const result =
+      stop === "abort"
+        ? expect(listing).rejects.toThrow("cancelled publication")
+        : expect(listing).resolves.toEqual([{ ...specs[0], type: "page" }]);
+    void result.catch(() => {});
+    await inventoryRead.promise;
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    if (stop === "abort") {
+      controller.abort(new Error("cancelled publication"));
+    } else {
+      fixture.browser.emit("disconnected");
+    }
+    await result;
+    context.emit("page", fixture.pages[0]);
+    expect(fixture.newCDPSession).not.toHaveBeenCalled();
+    expect(context.listenerCount("page")).toBe(1);
+    expect(fixture.browser.listenerCount("disconnected")).toBe(stop === "abort" ? 0 : 1);
+    expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(stop === "abort" ? 1 : 2);
+    expect(successor.browserClose).not.toHaveBeenCalled();
   });
 
   it("aborts enumeration without a timeout and retires its connection", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Chrome extension users could not list or reuse allowed tabs after an initial attachment race or renderer detach, even though the extension remained connected. A tab created during recovery could also make the complete listing fail.

## Why This Change Was Made

The relay resolves each inventory through its existing generation-bound attachment owner and includes tabs reported while attachment is pending. Only identities confirmed for that request can enter its result, so failed acquisition or cleanup cannot expose an old cached identity. Recovered roots reach every eligible client while explicit detach remains scoped to the client that requested it.

Tab listing also waits for Playwright to publish recovered pages within the existing request deadline. Native inventory remains complete, and existing page/target quarantine checks and cancellation cleanup remain in place.

## User Impact

Users can list and evaluate allowed tabs after transient attachment loss without restarting the Gateway, extension, or browser. Browser-internal and extension pages stay excluded. An unrecoverable target still produces an error instead of a partial or fabricated inventory.

## Evidence

- Reproduced on main at `837e0b20f479f4fa060bd7a2d50112e279103fb8` with real Chrome 152 and the matching unpacked extension: a released native attachment conflict left the same relay client unable to enumerate; a genuine Chrome `target_closed` renderer event left an allowed tab detached and the normal `browser tabs` command failed.
- On `a0901cda018759b63fd158fde37ede6474bcf1a9`, both loss sequences recover. The first tab-list call after renderer detach succeeds, and normal CLI evaluation returns the recovered page's content.
- A real native-attachment barrier test confirms that the same enumeration includes a tab created while recovery is pending, using the existing command deadlines.
- 336 focused tests pass across 23 files, covering relay lifecycle, enumeration, connection cleanup, client detach, discovery-only refresh, failed acquisition, and failed native retirement. New regressions fail on the prior implementation.
- Fresh source-blind acceptance passed all ten clauses, including real Pause/Allow retirement and reuse of the same physical tab, client-specific detach, and disconnected/incomplete-inventory errors.
- Final head `abe2a02af73655d40c6de1e074591766e34757db` adds only test-fixture corrections after CI exposed missing event cleanup and misuse of non-public event methods. The 74 tests in both affected files and the full extension-test type check pass. Production and live proof inputs are unchanged from the validated `a0901cda` runtime.
- Changed-scope typed lint, pinned formatting, line-count and assertion-safety ratchets pass. Independent source reviews are clean.

Original report and repair by @esqandil; the contributor's commit and credit are preserved.
