### PR TITLE
fix(commands): preserve selected agent when stopping global sessions

### DIFF
--- a/src/auto-reply/reply/abort.target-owner.test.ts
+++ b/src/auto-reply/reply/abort.target-owner.test.ts
@@ -89,6 +89,74 @@ async function setupStop() {
 }
 
 describe.each(["fast", "command"] as const)("%s Stop current owner", (pathKind) => {
+  it("stops the selected agent's global session in an explicit roster", async () => {
+    const state = await setupStop();
+    const agentId = "selected";
+    const globalKey = "global";
+    const storePath = path.join(
+      state.params.workspaceDir,
+      "agents",
+      agentId,
+      "sessions",
+      "sessions.json",
+    );
+    const cfg = {
+      ...state.cfg,
+      agents: { ownership: "explicit" as const, entries: { other: {}, [agentId]: {} } },
+      session: {
+        scope: "global" as const,
+        store: path.join(
+          state.params.workspaceDir,
+          "agents",
+          "{agentId}",
+          "sessions",
+          "sessions.json",
+        ),
+      },
+    };
+    const scope = { agentId, storePath, sessionKey: globalKey };
+    await replaceSessionEntry(scope, state.entry);
+    const ctx = { ...state.ctx, AgentId: agentId, CommandTargetSessionKey: globalKey };
+    const isCommandTargetCurrent = () =>
+      loadSessionEntry(scope)?.sessionId === state.entry.sessionId;
+    const operation = createReplyOperation({
+      sessionKey: globalKey,
+      sessionId: state.entry.sessionId,
+      resetTriggered: false,
+    });
+    operation.attachBackend({ kind: "embedded", cancel: () => {}, isStreaming: () => true });
+    try {
+      const result = await (pathKind === "fast"
+        ? tryFastAbortFromMessage({ cfg, ctx, isCommandTargetCurrent })
+        : handleStopCommand(
+            {
+              ...state.params,
+              cfg,
+              ctx,
+              agentId,
+              sessionKey: globalKey,
+              sessionStore: { [globalKey]: state.entry },
+              storePath,
+              opts: { isCommandTargetCurrent },
+            },
+            true,
+          ));
+      expect(operation.abortSignal.aborted).toBe(true);
+      expect(result).toMatchObject(
+        pathKind === "fast"
+          ? { handled: true, aborted: true }
+          : { shouldContinue: false, reply: { text: "⚙️ Agent was aborted." } },
+      );
+      expect(loadSessionEntry(scope)).toMatchObject({
+        sessionId: state.entry.sessionId,
+        abortedLastRun: true,
+      });
+    } finally {
+      operation.complete();
+      clearSessionQueues([globalKey]);
+    }
+  });
+
   it("does not reclaim a conversation reassigned after abort preparation", async () => {
     const state = await setupStop();
     const nextKey = `${sessionKey}:thread:123.456`;

--- a/src/auto-reply/reply/commands-session-abort.ts
+++ b/src/auto-reply/reply/commands-session-abort.ts
@@ -38,30 +38,15 @@ function resolveAbortTarget(params: {
 }): AbortTarget {
   const targetSessionKey =
     normalizeOptionalString(params.ctx.CommandTargetSessionKey) || params.sessionKey;
-  const { entry, key } = resolveCommandSessionEntryForKey(params.sessionStore, targetSessionKey);
-  if (entry && key) {
-    return {
-      entry,
-      key,
-      sessionId: replyRunRegistry.resolveSessionId(key) ?? entry.sessionId,
-    };
-  }
-  if (
-    params.sessionEntry &&
-    params.sessionKey &&
-    (!targetSessionKey || targetSessionKey === params.sessionKey)
-  ) {
-    return {
-      entry: params.sessionEntry,
-      key: params.sessionKey,
-      sessionId:
-        replyRunRegistry.resolveSessionId(params.sessionKey) ?? params.sessionEntry.sessionId,
-    };
-  }
+  const resolved = resolveCommandSessionEntryForKey(params.sessionStore, targetSessionKey);
+  const entry =
+    resolved.entry ??
+    (targetSessionKey && targetSessionKey === params.sessionKey ? params.sessionEntry : undefined);
+  const key = resolved.key ?? targetSessionKey;
   return {
-    entry: undefined,
-    key: targetSessionKey,
-    sessionId: targetSessionKey ? replyRunRegistry.resolveSessionId(targetSessionKey) : undefined,
+    entry,
+    key,
+    sessionId: (key ? replyRunRegistry.resolveSessionId(key) : undefined) ?? entry?.sessionId,
   };
 }
 
@@ -165,6 +150,7 @@ export const handleStopCommand: CommandHandler = async (params, allowTextCommand
   const { stopped, failed } = await stopSubagentsForRequester({
     cfg: params.cfg,
     requesterSessionKey: abortTarget.key ?? params.sessionKey,
+    requesterAgentId: params.agentId,
     beforeKill: async () => {
       abortOutcome = await applyAbortTarget({
         ...buildAbortTargetApplyParams(params, abortTarget),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where native `/stop` handling throws before cancelling the selected agent's `global` session in an explicit multi-agent configuration. The command already resolved the agent, but child-cancellation preparation discarded it and tried to infer it again from the unqualified key.

## Why This Change Was Made

Carry the prepared agent through the existing cancellation owner, preserving qualified-key precedence and owner checks. Consolidate repeated target/session-ID projection so canonical stored targets, current-session fallback and missing-target behavior use one result path.

## User Impact

Native stop commands cancel the selected global session and record its abort state instead of failing with an agent-selection error. The working fast-abort sibling remains unchanged. This does not claim that all ordinary channel `/stop` dispatches failed: those can use the already-correct fast path first.

Production LOC: **9 added / 23 removed, net −14**. Tests: **68 added**. No config, schema, stored representation, protocol, provider, or SDK change.

## Evidence

The existing owner test now shares one real global-session case across fast and command paths, with a private canonical store layout and two explicitly configured agents. It checks cancellation, the selected session ID, and persisted abort state.

- Original production code: **1 failed / 9 passed**. Only the ordinary command case throws `AgentSelectionRequiredError` before cancellation; fast abort and existing generation/queue controls pass.
- Repaired code: **50 passed** across the three relevant suites, including missing-target, finalizing, rejected-command, child-failure, replacement-owner and queue controls.

```sh
node scripts/run-vitest.mjs src/auto-reply/reply/abort.target-owner.test.ts src/auto-reply/reply/commands-stop-target.test.ts src/auto-reply/reply/abort.test.ts
node_modules/.bin/oxfmt --check src/auto-reply/reply/commands-session-abort.ts src/auto-reply/reply/abort.target-owner.test.ts
git diff --check
```

A separate standalone Node 24.20.0 probe calls the actual public `getReplyFromConfig` facade outside Vitest/fast-test mode. With a real private SQLite row and reply operation (counting test backend), a synthetic native `/stop` returns the exact abort acknowledgement, invokes cancellation once, preserves the selected session ID and persists `abortedLastRun=true`. Fetch/socket guards observe zero network attempts; private state and operation are cleaned up. This is real public-entry/SQLite behavior, not live provider or channel delivery, and it does not claim native provider cancellation.

The final regression was also rerun against the exact original production bytes; those bytes were restored to the reviewed candidate before the final green run. Fresh independent Codex review completed both source/context packets with no actionable P0–P2 findings. Normal commit hooks passed.

Full local aggregate validation is pending: old local pnpm self-bootstrap is blocked by the repository's seven-day maturity policy for its newly pinned version. No cooldown or dependency override was changed. No channel/UI video is claimed; the isolated public-entry proof covers the affected native embedding path, while exact-dependency Gateway/channel setup is unavailable locally. Exact-head hosted CI [33984005912](https://github.com/openclaw/openclaw/actions/runs/33984005912) succeeded: 107 checks passed and 17 skipped. Native prepare verified hosted gates against the unchanged committed head.

## Separate follow-ups

Exploratory arbitrary-local-key probes uncovered an initialization canonicalization mismatch that is unchanged from stable; they are preserved as failures, not used as the successful proof or claimed fixed here. The no-target fast-abort owner omission also predates stable and remains a separate source-only follow-up. Neither is counted as this regression.

Exact committed head: `448a0f6c484d1f07ff446f642f6bfa4134f23db0`.
