### PR TITLE
fix(auto-reply): trust versioned stale token totals at a safety factor in the compaction gate

### DIFF
--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -147,14 +147,18 @@ function resolveMaintenanceGateState<
   // stale total at a safety factor so the gate keeps its eyes instead of
   // going blind and silently skipping compaction (#138871). We reach this
   // branch only when resolveFreshSessionTotalTokens already returned
-  // undefined (totalTokensFresh !== true or version mismatch), so the total
-  // is genuinely stale. The 0.8 discount biases toward the real-world
-  // ceiling of a still-growing transcript rather than over-trusting a
-  // frozen snapshot; it also mitigates legacy cumulative-CLI totals that
-  // historically over-count retries.
-  const staleFallbackTotalTokens = Math.floor(
-    (resolveSessionTotalTokens(params.entry) ?? 0) * STALE_TOTAL_TOKENS_SAFETY_FACTOR,
-  );
+  // undefined, but we further require totalTokensFresh === false so that
+  // *fresh-but-unversioned* legacy entries (totalTokensFresh === true with
+  // no version) are still ignored — they are not stale. The 0.8 discount
+  // biases toward the real-world ceiling of a still-growing transcript
+  // rather than over-trusting a frozen snapshot; it also mitigates legacy
+  // cumulative-CLI totals that historically over-count retries.
+  const staleFallbackTotalTokens =
+    params.entry.totalTokensFresh === false
+      ? Math.floor(
+          (resolveSessionTotalTokens(params.entry) ?? 0) * STALE_TOTAL_TOKENS_SAFETY_FACTOR,
+        )
+      : 0;
   const totalTokens = freshOrProjectedTotalTokens ?? staleFallbackTotalTokens;
   if (!totalTokens || totalTokens <= 0) {
     return null;

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -14,7 +14,6 @@ import {
 import {
   resolveFreshSessionTotalTokens,
   resolveSessionTotalTokens,
-  SESSION_TOTAL_TOKENS_VERSION,
   type SessionEntry,
 } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -143,21 +142,19 @@ function resolveMaintenanceGateState<
 
   const freshOrProjectedTotalTokens =
     resolvePositiveTokenCount(params.tokenCount) ?? resolveFreshSessionTotalTokens(params.entry);
-  // Last-resort fallback: when no projected token count and no fresh total are
-  // available (provider outage → usage stale), trust a *versioned* stale
-  // persisted total at a safety factor so the gate keeps its eyes instead of
-  // going blind and silently skipping compaction (#138871). Only versioned
-  // totals (totalTokensVersion === SESSION_TOTAL_TOKENS_VERSION) qualify —
-  // unversioned legacy cumulative CLI totals remain ignored because they
-  // historically over-count retries and are not comparable to a fresh
-  // context snapshot. The discount biases toward the real-world ceiling of a
-  // still-growing transcript rather than over-trusting a frozen snapshot.
-  const staleFallbackTotalTokens =
-    params.entry.totalTokensVersion === SESSION_TOTAL_TOKENS_VERSION
-      ? Math.floor(
-          (resolveSessionTotalTokens(params.entry) ?? 0) * STALE_TOTAL_TOKENS_SAFETY_FACTOR,
-        )
-      : 0;
+  // Last-resort fallback: when no projected token count and no fresh total
+  // are available (provider outage → usage stale), trust the persisted
+  // stale total at a safety factor so the gate keeps its eyes instead of
+  // going blind and silently skipping compaction (#138871). We reach this
+  // branch only when resolveFreshSessionTotalTokens already returned
+  // undefined (totalTokensFresh !== true or version mismatch), so the total
+  // is genuinely stale. The 0.8 discount biases toward the real-world
+  // ceiling of a still-growing transcript rather than over-trusting a
+  // frozen snapshot; it also mitigates legacy cumulative-CLI totals that
+  // historically over-count retries.
+  const staleFallbackTotalTokens = Math.floor(
+    (resolveSessionTotalTokens(params.entry) ?? 0) * STALE_TOTAL_TOKENS_SAFETY_FACTOR,
+  );
   const totalTokens = freshOrProjectedTotalTokens ?? staleFallbackTotalTokens;
   if (!totalTokens || totalTokens <= 0) {
     return null;

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -11,8 +11,25 @@ import {
   resolveMergedModelProviderConfig,
   resolveMergedModelProviderModels,
 } from "../../config/model-provider-config.js";
-import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions.js";
+import {
+  resolveFreshSessionTotalTokens,
+  resolveSessionTotalTokens,
+  SESSION_TOTAL_TOKENS_VERSION,
+  type SessionEntry,
+} from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+/**
+ * Safety factor applied to stale persisted token totals when they fall back to
+ * the compaction gate. When neither a projected token count nor a fresh total
+ * is available (e.g. during a provider outage where no recent usage landed),
+ * the last persisted total is the only signal the gate has. Scaling it down
+ * keeps the gate from going blind while remaining conservative — a stale
+ * total tends to under-count a still-growing transcript, so the discount
+ * biases toward the real-world ceiling rather than over-trusting a frozen
+ * snapshot.
+ */
+const STALE_TOTAL_TOKENS_SAFETY_FACTOR = 0.8;
 
 export function resolveMemoryFlushContextWindowTokens(params: {
   modelId?: string;
@@ -124,8 +141,24 @@ function resolveMaintenanceGateState<
     return null;
   }
 
-  const totalTokens =
+  const freshOrProjectedTotalTokens =
     resolvePositiveTokenCount(params.tokenCount) ?? resolveFreshSessionTotalTokens(params.entry);
+  // Last-resort fallback: when no projected token count and no fresh total are
+  // available (provider outage → usage stale), trust a *versioned* stale
+  // persisted total at a safety factor so the gate keeps its eyes instead of
+  // going blind and silently skipping compaction (#138871). Only versioned
+  // totals (totalTokensVersion === SESSION_TOTAL_TOKENS_VERSION) qualify —
+  // unversioned legacy cumulative CLI totals remain ignored because they
+  // historically over-count retries and are not comparable to a fresh
+  // context snapshot. The discount biases toward the real-world ceiling of a
+  // still-growing transcript rather than over-trusting a frozen snapshot.
+  const staleFallbackTotalTokens =
+    params.entry.totalTokensVersion === SESSION_TOTAL_TOKENS_VERSION
+      ? Math.floor(
+          (resolveSessionTotalTokens(params.entry) ?? 0) * STALE_TOTAL_TOKENS_SAFETY_FACTOR,
+        )
+      : 0;
+  const totalTokens = freshOrProjectedTotalTokens ?? staleFallbackTotalTokens;
   if (!totalTokens || totalTokens <= 0) {
     return null;
   }

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -423,11 +423,11 @@ describe("shouldRunPreflightCompaction", () => {
     ).toBe(false);
   });
 
-  it("triggers from a versioned stale persisted total at the safety factor during a provider outage", () => {
-    // #138871: with no fresh total and no projected count, a *versioned* stale
-    // persisted total (478k, version 1, fresh=false — a frozen snapshot from
-    // before the outage) * 0.8 = 382k still clears the 140k threshold, so the
-    // gate no longer goes blind during provider outages.
+  it("triggers from a stale persisted total at the safety factor during a provider outage", () => {
+    // #138871: with no fresh total and no projected count, a stale persisted
+    // total (478k, version 1, fresh=false — a frozen snapshot from before
+    // the outage) * 0.8 = 382k still clears the 140k threshold, so the gate
+    // no longer goes blind during provider outages.
     expect(
       shouldRunPreflightCompaction({
         entry: { totalTokens: 478_000, totalTokensFresh: false, totalTokensVersion: 1 },
@@ -436,16 +436,18 @@ describe("shouldRunPreflightCompaction", () => {
     ).toBe(true);
   });
 
-  it("ignores unversioned legacy cumulative totals even when they cross the threshold", () => {
-    // Legacy CLI cumulative totals (no totalTokensVersion) historically
-    // over-count retries and are not comparable to a fresh context snapshot;
-    // the stale fallback does not apply to them.
+  it("triggers from an unversioned stale persisted total at the safety factor", () => {
+    // After #138871 the stale fallback no longer requires a version match —
+    // persistSessionUsageUpdate clears totalTokensVersion during ordinary
+    // increments, so gating on the version would make the fallback dead code
+    // in production. An unversioned stale total (478k) * 0.8 = 382k still
+    // clears the 140k threshold, so the gate keeps its eyes during outages.
     expect(
       shouldRunPreflightCompaction({
         entry: { totalTokens: 478_000, totalTokensFresh: false },
         threshold: 140_000,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("does not trigger when no persisted total is available", () => {

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -413,10 +413,57 @@ describe("shouldRunMemoryFlush", () => {
 });
 
 describe("shouldRunPreflightCompaction", () => {
-  it("ignores stale cached totals when no projected token count is provided", () => {
+  it("does not trigger when a stale cached total stays under the threshold after the safety factor", () => {
+    // Stale 96k * 0.8 = 76.8k < 93k threshold → gate stays closed.
     expect(
       shouldRunPreflightCompaction({
-        entry: { totalTokens: 96_000, totalTokensFresh: false },
+        entry: { totalTokens: 96_000, totalTokensFresh: false, totalTokensVersion: 1 },
+        threshold: 93_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("triggers from a versioned stale persisted total at the safety factor during a provider outage", () => {
+    // #138871: with no fresh total and no projected count, a *versioned* stale
+    // persisted total (478k, version 1, fresh=false — a frozen snapshot from
+    // before the outage) * 0.8 = 382k still clears the 140k threshold, so the
+    // gate no longer goes blind during provider outages.
+    expect(
+      shouldRunPreflightCompaction({
+        entry: { totalTokens: 478_000, totalTokensFresh: false, totalTokensVersion: 1 },
+        threshold: 140_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores unversioned legacy cumulative totals even when they cross the threshold", () => {
+    // Legacy CLI cumulative totals (no totalTokensVersion) historically
+    // over-count retries and are not comparable to a fresh context snapshot;
+    // the stale fallback does not apply to them.
+    expect(
+      shouldRunPreflightCompaction({
+        entry: { totalTokens: 478_000, totalTokensFresh: false },
+        threshold: 140_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not trigger when no persisted total is available", () => {
+    expect(
+      shouldRunPreflightCompaction({
+        entry: { totalTokens: undefined, totalTokensFresh: false, totalTokensVersion: 1 },
+        threshold: 93_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("prefers a fresh total over the stale fallback", () => {
+    // Fresh total 10 wins over the stale 478k fallback (which at 0.8 would
+    // have been 382k and crossed the 93k threshold). Because fresh wins, the
+    // gate uses 10, which stays under the threshold.
+    expect(
+      shouldRunPreflightCompaction({
+        entry: { totalTokens: 10, totalTokensFresh: true, totalTokensVersion: 1 },
         threshold: 93_000,
       }),
     ).toBe(false);

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -450,6 +450,19 @@ describe("shouldRunPreflightCompaction", () => {
     ).toBe(true);
   });
 
+  it("ignores fresh-but-unversioned legacy entries", () => {
+    // Legacy entries marked totalTokensFresh === true but without a version
+    // are not stale — they are simply unversioned. The stale fallback must
+    // not fire for them (agent-runner-memory.test.ts covers this at the
+    // integration level).
+    expect(
+      shouldRunPreflightCompaction({
+        entry: { totalTokens: 478_000, totalTokensFresh: true },
+        threshold: 140_000,
+      }),
+    ).toBe(false);
+  });
+
   it("does not trigger when no persisted total is available", () => {
     expect(
       shouldRunPreflightCompaction({


### PR DESCRIPTION
## What Problem This Solves

Closes #138871 (P2, diamond lobster, bot-endorsed queueable-fix+fix-shape-clear+source-repro).

During provider outages, `resolveFreshSessionTotalTokens` returns `undefined` (no fresh total), and the compaction gate goes blind — sessions balloon past their context window with `compactionCount=0` until a manual `/compact`.

## Root Cause

`resolveMaintenanceGateState` in `src/auto-reply/reply/memory-flush.ts` had no last-resort fallback for stale persisted totals. When `resolveFreshSessionTotalTokens` returns `undefined` (outage → `totalTokensFresh=false`), `tokenCountForCompaction` resolves `undefined` → the gate returns `null` → compaction silently skipped.

## Fix

Trust the stale persisted total at a **0.8 safety factor** as the gate's last-resort fallback, gated on `totalTokensFresh === false` (genuinely stale):

```ts
const staleFallbackTotalTokens =
  params.entry.totalTokensFresh === false
    ? Math.floor(
        (resolveSessionTotalTokens(params.entry) ?? 0) * STALE_TOTAL_TOKENS_SAFETY_FACTOR,
      )
    : 0;
const totalTokens = freshOrProjectedTotalTokens ?? staleFallbackTotalTokens;
```

### Why `totalTokensFresh === false` (not version match)

ClawSweeper identified a P0 merge risk with the initial version-gated approach: `persistSessionUsageUpdate` clears `totalTokensVersion` to `undefined` during ordinary token increments (`session-entry-projection.ts:117`) and compaction deletes it (`sqlite-transcript-write.ts:283`). A `totalTokensVersion === SESSION_TOTAL_TOKENS_VERSION` check would make the fallback dead code in the exact outage scenario it was designed for.

The refined `totalTokensFresh === false` gate:
- **Stale + any version**: fallback fires (the outage scenario — `persistSessionUsageUpdate` sets `totalTokensFresh = false`)
- **Fresh + unversioned (legacy)**: fallback does NOT fire (not stale — `totalTokensFresh === true`)
- **Undefined (truly legacy)**: fallback does NOT fire (conservative)

The 0.8 discount biases toward the real-world ceiling of a still-growing transcript rather than over-trusting a frozen snapshot; it also mitigates legacy cumulative-CLI totals that historically over-count retries.

## Evidence

- CI: **162 success, 0 failures** on head `ca30e700f0` ✅
- `reply-state.test.ts`: 6 cases covering (1) stale total under threshold → no trigger, (2) stale total over threshold → triggers at 0.8x, (3) unversioned stale total → triggers, (4) fresh-but-unversioned → does NOT trigger, (5) no persisted total → no trigger, (6) fresh total wins over stale fallback.
- `agent-runner-memory.test.ts`: "ignores unversioned fresh state and legacy CLI usage on the first upgraded turn" passes — `totalTokensFresh: true` without version does not trigger the fallback.
- All pre-existing compaction/flush tests pass.

## Files Changed

1. `src/auto-reply/reply/memory-flush.ts` (+25/-3): stale-total fallback at 0.8 safety factor in `resolveMaintenanceGateState`, gated on `totalTokensFresh === false`
2. `src/auto-reply/reply/reply-state.test.ts` (+55/-8): replaced codified-bug assertion with 6 cases
