### PR TITLE
fix(ui): refresh Session Observer model catalog ownership

### DIFF
--- a/ui/src/e2e/session-observer-model-catalog-recovery.e2e.test.ts
+++ b/ui/src/e2e/session-observer-model-catalog-recovery.e2e.test.ts
@@ -17,7 +17,12 @@ const suite = createControlUiE2eSuite({
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 
 suite.define(() => {
-  it("retries an initial catalog failure and restores recovered models", async () => {
+  it.each([
+    "initial catalog failure",
+    "config.changed",
+    "chat.metadata.changed",
+    "reconnect",
+  ] as const)("refreshes the catalog after %s", async (trigger) => {
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -35,6 +40,7 @@ suite.define(() => {
       },
       async ({ page }) => {
         await page.clock.install();
+        const initiallyUnavailable = trigger === "initial catalog failure";
         const config = {
           agents: { defaults: { model: "openai/gpt-5.5" } },
           ui: { prefs: { themeMode: "dark" } },
@@ -51,12 +57,18 @@ suite.define(() => {
               valid: true,
             },
             "config.patch": { ok: true },
-            "models.list": {
-              __mockError: {
-                code: "UNAVAILABLE",
-                message: "Model catalog temporarily unavailable",
-              },
-            },
+            "models.list": initiallyUnavailable
+              ? {
+                  __mockError: {
+                    code: "UNAVAILABLE",
+                    message: "Model catalog temporarily unavailable",
+                  },
+                }
+              : {
+                  models: [
+                    { available: true, id: "old-model", name: "Old model", provider: "openai" },
+                  ],
+                },
           },
         });
 
@@ -70,6 +82,14 @@ suite.define(() => {
         const picker = section.locator("wa-select.model-picker__select");
         await picker.waitFor();
         await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(1);
+        if (initiallyUnavailable) {
+          await section.getByText("Explicit model catalog unavailable", { exact: true }).waitFor();
+        } else {
+          await picker
+            .locator("wa-option")
+            .filter({ hasText: "Old model" })
+            .waitFor({ state: "attached" });
+        }
         await pauseVirtualClock(page);
         const initialSystemInfoRequestCount = (await gateway.getRequests("system.info")).length;
         expect(initialSystemInfoRequestCount).toBeGreaterThan(0);
@@ -91,7 +111,7 @@ suite.define(() => {
           // The settings section exceeds the viewport; keep its current field scroll.
           await picker.scrollIntoViewIfNeeded();
           await writeFile(
-            path.join(suite.artifactDir, "01-initial-failure.png"),
+            path.join(suite.artifactDir, "01-before-refresh.png"),
             await takeControlUiViewportScreenshot(page, section, [picker]),
           );
           await page.evaluate(() => {
@@ -128,6 +148,11 @@ suite.define(() => {
           },
         ];
         await gateway.setMethodResponse("models.list", { models: recoveredModels });
+        if (trigger === "reconnect") {
+          await gateway.closeLatest(1006, "synthetic transient disconnect");
+        } else if (!initiallyUnavailable) {
+          await gateway.emitGatewayEvent(trigger, { agentId: "main" });
+        }
         await page.clock.runFor(10_000);
         await expect
           .poll(async () => (await gateway.getRequests("system.info")).length)
@@ -135,6 +160,9 @@ suite.define(() => {
         await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(2);
         const finalSystemInfoRequestCount = (await gateway.getRequests("system.info")).length;
         const finalRequestCount = (await gateway.getRequests("models.list")).length;
+        expect((await gateway.getRequests("models.list"))[1]?.params).toEqual(
+          initialRequest?.params,
+        );
         const finalWarningVisible = await section
           .getByText("Explicit model catalog unavailable", { exact: true })
           .isVisible()
@@ -157,8 +185,12 @@ suite.define(() => {
           });
         }
 
-        expect(initialWarningVisible).toBe(true);
-        expect(initialOptions).toEqual(["Auto (provider default)", "Disabled"]);
+        expect(initialWarningVisible).toBe(initiallyUnavailable);
+        expect(initialOptions).toEqual([
+          "Auto (provider default)",
+          "Disabled",
+          ...(initiallyUnavailable ? [] : ["Old model"]),
+        ]);
         expect(finalSystemInfoRequestCount).toBe(initialSystemInfoRequestCount + 1);
         expect(finalRequestCount).toBe(2);
         expect(finalWarningVisible).toBe(false);

--- a/ui/src/pages/config/config-page.session-observer.test.ts
+++ b/ui/src/pages/config/config-page.session-observer.test.ts
@@ -1,0 +1,237 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred as deferred } from "../../../../test/helpers/promise.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ModelCatalogEntry, ModelCatalogResult } from "../../api/types.ts";
+import type {
+  ApplicationContext,
+  ApplicationGateway,
+  ApplicationGatewaySnapshot,
+} from "../../app/context.ts";
+import * as modelCatalogStore from "../../lib/model-catalog-store.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { ConfigPage } from "./config-page.ts";
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", createStorageMock());
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("ConfigPage session observer models", () => {
+  it.each(["client", "source"] as const)(
+    "fences a pending catalog after Gateway %s replacement",
+    async (replacement) => {
+      const first = deferred<ModelCatalogResult>();
+      const second = deferred<ModelCatalogResult>();
+      vi.spyOn(modelCatalogStore, "loadModelCatalog")
+        .mockReturnValueOnce(first.promise)
+        .mockReturnValueOnce(second.promise);
+      const firstClient = {} as GatewayBrowserClient;
+      const secondClient = replacement === "client" ? ({} as GatewayBrowserClient) : firstClient;
+      const gateway = {
+        snapshot: {
+          client: firstClient,
+          phase: "connected",
+          hello: { features: { methods: ["system.info"] } },
+        },
+      } as unknown as ApplicationGateway;
+      const page = new ConfigPage();
+      page.pageId = "appearance";
+      const state = page as unknown as {
+        context: ApplicationContext;
+        systemInfoGatewaySource: ApplicationGateway;
+        systemInfo: unknown;
+        sessionObserverModels: ModelCatalogEntry[];
+        sessionObserverModelsUnavailable: boolean;
+        sessionObserverModelsTask: {
+          run: () => Promise<void>;
+          hostUpdate: () => void;
+          taskComplete: Promise<unknown>;
+        };
+      };
+      Object.defineProperty(page, "isConnected", { configurable: true, value: true });
+      state.context = {
+        gateway,
+        agentSelection: { state: { selectedId: "main" } },
+      } as ApplicationContext;
+      state.systemInfoGatewaySource = gateway;
+      state.systemInfo = {};
+
+      const firstLoad = state.sessionObserverModelsTask.run();
+      (gateway as { snapshot: ApplicationGatewaySnapshot }).snapshot = {
+        client: secondClient,
+        phase: "connected",
+        hello: { features: { methods: ["system.info"] } },
+      } as ApplicationGatewaySnapshot;
+      const nextGateway = replacement === "source" ? { ...gateway } : gateway;
+      state.context = { ...state.context, gateway: nextGateway };
+      state.systemInfoGatewaySource = nextGateway;
+      state.sessionObserverModelsTask.hostUpdate();
+      const secondLoad = state.sessionObserverModelsTask.taskComplete;
+      const currentModels = [{ id: "small", name: "Small", provider: "openai" }];
+      second.resolve({ models: currentModels });
+      await secondLoad;
+      expect(state.sessionObserverModels).toEqual(currentModels);
+
+      first.resolve({ models: [{ id: "stale", name: "Stale", provider: "old" }] });
+      await firstLoad;
+      expect(state.sessionObserverModels).toEqual(currentModels);
+      expect(modelCatalogStore.loadModelCatalog).toHaveBeenCalledTimes(2);
+      expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(1, firstClient, {
+        agentId: "main",
+        preparedOnly: true,
+        signal: expect.any(AbortSignal),
+      });
+      expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(2, secondClient, {
+        agentId: "main",
+        preparedOnly: true,
+        signal: expect.any(AbortSignal),
+      });
+    },
+  );
+
+  it("keeps same-client agent switches from restoring stale observer models", async () => {
+    const firstMain = deferred<ModelCatalogResult>();
+    const writer = deferred<ModelCatalogResult>();
+    const secondMain = deferred<ModelCatalogResult>();
+    let mainRequests = 0;
+    const request = vi.fn((_method: string, params: unknown) => {
+      const agentId = (params as { agentId?: string }).agentId;
+      if (agentId === "writer") {
+        return writer.promise;
+      }
+      mainRequests += 1;
+      return mainRequests === 1 ? firstMain.promise : secondMain.promise;
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const gateway = {
+      snapshot: { client, phase: "connected", hello: { features: { methods: ["system.info"] } } },
+    } as unknown as ApplicationGateway;
+    const selectionState = { selectedId: "main" as string | null };
+    const page = new ConfigPage();
+    page.pageId = "appearance";
+    const state = page as unknown as {
+      context: ApplicationContext;
+      systemInfoGatewaySource: ApplicationGateway;
+      systemInfo: unknown;
+      sessionObserverModels: ModelCatalogEntry[];
+      sessionObserverModelsUnavailable: boolean;
+      sessionObserverModelsTask: {
+        run: () => Promise<void>;
+        hostUpdate: () => void;
+        taskComplete: Promise<unknown>;
+      };
+    };
+    Object.defineProperty(page, "isConnected", { configurable: true, value: true });
+    state.context = {
+      gateway,
+      agentSelection: { state: selectionState },
+    } as ApplicationContext;
+    state.systemInfoGatewaySource = gateway;
+    state.systemInfo = {};
+
+    const mainLoad = state.sessionObserverModelsTask.run();
+    selectionState.selectedId = "writer";
+    state.sessionObserverModelsTask.hostUpdate();
+    const writerLoad = state.sessionObserverModelsTask.taskComplete;
+    const writerModels = [{ id: "writer-model", name: "Writer Model", provider: "openai" }];
+    writer.resolve({ models: writerModels });
+    await writerLoad;
+    expect(state.sessionObserverModels).toEqual(writerModels);
+
+    modelCatalogStore.invalidateModelCatalogCache(client);
+    selectionState.selectedId = "main";
+    state.sessionObserverModelsTask.hostUpdate();
+    const secondMainLoad = state.sessionObserverModelsTask.taskComplete;
+    const currentMainModels = [{ id: "current-main", name: "Current Main", provider: "openai" }];
+    secondMain.resolve({ models: currentMainModels });
+    await secondMainLoad;
+    firstMain.resolve({
+      models: [{ id: "stale-main", name: "Stale Main", provider: "openai" }],
+    });
+    await mainLoad;
+
+    expect(state.sessionObserverModels).toEqual(currentMainModels);
+    for (const [index, agentId] of ["main", "writer", "main"].entries()) {
+      expect(request).toHaveBeenNthCalledWith(
+        index + 1,
+        "models.list",
+        { agentId, preparedOnly: true, view: "configured" },
+        { signal: expect.any(AbortSignal) },
+      );
+    }
+
+    selectionState.selectedId = null;
+    state.sessionObserverModelsTask.hostUpdate();
+    expect(state.sessionObserverModels).toEqual([]);
+    expect(state.sessionObserverModelsUnavailable).toBe(true);
+    expect(request).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps a slow refresh through status polls and retires it on disconnect", async () => {
+    const stale = deferred<ModelCatalogResult>();
+    const original = [{ id: "original", name: "Original", provider: "openai" }];
+    const fresh = [{ id: "fresh", name: "Fresh", provider: "openai" }];
+    const signals: AbortSignal[] = [];
+    const request = vi.fn((method: string, _params: unknown, options: { signal: AbortSignal }) => {
+      if (method === "system.info") {
+        return Promise.resolve({});
+      }
+      signals.push(options.signal);
+      return signals.length === 2
+        ? stale.promise
+        : Promise.resolve({ models: signals.length === 1 ? original : fresh });
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const gateway = {
+      snapshot: { client, phase: "connected", hello: { features: { methods: ["system.info"] } } },
+    } as unknown as ApplicationGateway;
+    const page = new ConfigPage();
+    page.pageId = "appearance";
+    const state = page as unknown as {
+      context: ApplicationContext;
+      systemInfoGatewaySource: ApplicationGateway;
+      sessionObserverModels: ModelCatalogEntry[];
+      sessionObserverModelsTask: {
+        run: (args: readonly [ApplicationGateway, GatewayBrowserClient, string]) => Promise<void>;
+      };
+      systemInfoTask: {
+        run: (args: readonly [ApplicationGateway, GatewayBrowserClient]) => Promise<void>;
+      };
+    };
+    Object.defineProperty(page, "isConnected", { configurable: true, value: true });
+    state.context = {
+      gateway,
+      agentSelection: { state: { selectedId: "main" } },
+    } as ApplicationContext;
+    state.systemInfoGatewaySource = gateway;
+    const args = [gateway, client, "main"] as const;
+    await state.sessionObserverModelsTask.run(args);
+    modelCatalogStore.invalidateModelCatalogCache(client);
+    const pending = state.sessionObserverModelsTask.run(args);
+    expect(state.sessionObserverModels).toEqual(original);
+
+    for (let poll = 0; poll < 3; poll += 1) {
+      await state.systemInfoTask.run([gateway, client]);
+    }
+    expect(signals).toHaveLength(2);
+    expect(signals[1]?.aborted).toBe(false);
+    page.disconnectedCallback();
+    expect(signals[1]?.aborted).toBe(true);
+    expect(state.sessionObserverModels).toEqual([]);
+    await pending;
+
+    state.systemInfoGatewaySource = gateway;
+    await state.sessionObserverModelsTask.run(args);
+    stale.resolve({ models: original });
+    await stale.promise;
+    expect(state.sessionObserverModels).toEqual(fresh);
+    expect(signals).toHaveLength(3);
+  });
+});

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -4,19 +4,13 @@ import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred as deferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { ModelCatalogEntry, ModelCatalogResult } from "../../api/types.ts";
-import type {
-  ApplicationContext,
-  ApplicationGateway,
-  ApplicationGatewaySnapshot,
-} from "../../app/context.ts";
+import type { ApplicationContext } from "../../app/context.ts";
 import {
   changedServerUiPrefs,
   refreshProfileAppearancePrefs,
   resetServerUiPrefsSync,
 } from "../../app/server-prefs.ts";
 import { loadSettings } from "../../app/settings.ts";
-import * as modelCatalogStore from "../../lib/model-catalog-store.ts";
 import {
   installDialogPolyfill,
   nextFrame,
@@ -638,143 +632,6 @@ describe("ConfigPage camera selection", () => {
     expect(state.applySettings).toHaveBeenLastCalledWith(
       expect.objectContaining({ realtimeTalkVideoDeviceId: undefined }),
     );
-  });
-});
-
-describe("ConfigPage session observer models", () => {
-  it("lets a replacement Gateway load while the stale client is still pending", async () => {
-    const first = deferred<ModelCatalogResult>();
-    const second = deferred<ModelCatalogResult>();
-    vi.spyOn(modelCatalogStore, "loadModelCatalog")
-      .mockReturnValueOnce(first.promise)
-      .mockReturnValueOnce(second.promise);
-    const firstClient = {} as GatewayBrowserClient;
-    const secondClient = {} as GatewayBrowserClient;
-    const gateway = {
-      snapshot: { client: firstClient, phase: "connected" },
-    } as unknown as ApplicationGateway;
-    const page = new ConfigPage();
-    const state = page as unknown as {
-      context: ApplicationContext;
-      systemInfoGatewaySource: ApplicationGateway;
-      sessionObserverModels: ModelCatalogEntry[];
-      sessionObserverModelsUnavailable: boolean;
-      sessionObserverModelsClient: GatewayBrowserClient | null;
-      ensureSessionObserverModels: (
-        client: GatewayBrowserClient,
-        agentId: string | null,
-      ) => Promise<void>;
-    };
-    Object.defineProperty(page, "isConnected", { configurable: true, value: true });
-    state.context = {
-      gateway,
-      agentSelection: { state: { selectedId: "main" } },
-    } as ApplicationContext;
-    state.systemInfoGatewaySource = gateway;
-
-    const firstLoad = state.ensureSessionObserverModels(firstClient, "main");
-    (gateway as { snapshot: ApplicationGatewaySnapshot }).snapshot = {
-      client: secondClient,
-      phase: "connected",
-    } as ApplicationGatewaySnapshot;
-    const secondLoad = state.ensureSessionObserverModels(secondClient, "main");
-    const currentModels = [{ id: "small", name: "Small", provider: "openai" }];
-    second.resolve({ models: currentModels });
-    await secondLoad;
-    expect(state.sessionObserverModels).toEqual(currentModels);
-    expect(state.sessionObserverModelsClient).toBe(secondClient);
-
-    first.resolve({ models: [{ id: "stale", name: "Stale", provider: "old" }] });
-    await firstLoad;
-    expect(state.sessionObserverModels).toEqual(currentModels);
-    expect(modelCatalogStore.loadModelCatalog).toHaveBeenCalledTimes(2);
-    expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(1, firstClient, {
-      agentId: "main",
-      preparedOnly: true,
-    });
-    expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(2, secondClient, {
-      agentId: "main",
-      preparedOnly: true,
-    });
-  });
-
-  it("keeps same-client agent switches from restoring stale observer models", async () => {
-    const firstMain = deferred<ModelCatalogResult>();
-    const writer = deferred<ModelCatalogResult>();
-    const secondMain = deferred<ModelCatalogResult>();
-    let mainRequests = 0;
-    const request = vi.fn((_method: string, params: unknown) => {
-      const agentId = (params as { agentId?: string }).agentId;
-      if (agentId === "writer") {
-        return writer.promise;
-      }
-      mainRequests += 1;
-      return mainRequests === 1 ? firstMain.promise : secondMain.promise;
-    });
-    const client = { request } as unknown as GatewayBrowserClient;
-    const gateway = {
-      snapshot: { client, phase: "connected" },
-    } as unknown as ApplicationGateway;
-    const selectionState = { selectedId: "main" as string | null };
-    const page = new ConfigPage();
-    const state = page as unknown as {
-      context: ApplicationContext;
-      systemInfoGatewaySource: ApplicationGateway;
-      sessionObserverModels: ModelCatalogEntry[];
-      sessionObserverModelsUnavailable: boolean;
-      ensureSessionObserverModels: (
-        client: GatewayBrowserClient,
-        agentId: string | null,
-      ) => Promise<void>;
-    };
-    Object.defineProperty(page, "isConnected", { configurable: true, value: true });
-    state.context = {
-      gateway,
-      agentSelection: { state: selectionState },
-    } as ApplicationContext;
-    state.systemInfoGatewaySource = gateway;
-
-    const mainLoad = state.ensureSessionObserverModels(client, "main");
-    selectionState.selectedId = "writer";
-    const writerLoad = state.ensureSessionObserverModels(client, "writer");
-    const writerModels = [{ id: "writer-model", name: "Writer Model", provider: "openai" }];
-    writer.resolve({ models: writerModels });
-    await writerLoad;
-    expect(state.sessionObserverModels).toEqual(writerModels);
-
-    modelCatalogStore.invalidateModelCatalogCache(client);
-    selectionState.selectedId = "main";
-    const secondMainLoad = state.ensureSessionObserverModels(client, "main");
-    const currentMainModels = [{ id: "current-main", name: "Current Main", provider: "openai" }];
-    secondMain.resolve({ models: currentMainModels });
-    await secondMainLoad;
-    firstMain.resolve({
-      models: [{ id: "stale-main", name: "Stale Main", provider: "openai" }],
-    });
-    await mainLoad;
-
-    expect(state.sessionObserverModels).toEqual(currentMainModels);
-    expect(request).toHaveBeenNthCalledWith(1, "models.list", {
-      agentId: "main",
-      preparedOnly: true,
-      view: "configured",
-    });
-    expect(request).toHaveBeenNthCalledWith(2, "models.list", {
-      agentId: "writer",
-      preparedOnly: true,
-      view: "configured",
-    });
-    expect(request).toHaveBeenNthCalledWith(3, "models.list", {
-      agentId: "main",
-      preparedOnly: true,
-      view: "configured",
-    });
-
-    selectionState.selectedId = null;
-    await state.ensureSessionObserverModels(client, null);
-    expect(state.sessionObserverModels).toEqual([]);
-    expect(state.sessionObserverModelsUnavailable).toBe(true);
-    expect(request).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -99,6 +99,12 @@ export type { ConfigPageId } from "./config-sections.ts";
 
 type ConfigFormMode = "form" | "raw";
 type ConfigSelection = { activeSection: string | null; activeSubsection: string | null };
+type SessionObserverModelsResult = {
+  gateway: ApplicationContext["gateway"];
+  client: GatewayBrowserClient;
+  agentId: string;
+  models: ModelCatalogEntry[];
+};
 // Keys settable through this page's setSetting helper. Whether a key syncs
 // across devices is owned by app/server-prefs.ts, not by this type.
 type ConfigPageSetting =
@@ -327,13 +333,6 @@ export class ConfigPage extends OpenClawLightDomElement {
   private systemInfoGatewaySource: ApplicationContext["gateway"] | null = null;
   private systemInfoClient: GatewayBrowserClient | null = null;
   private updateStatusClient: GatewayBrowserClient | null = null;
-  private sessionObserverModelsClient: GatewayBrowserClient | null = null;
-  private sessionObserverModelsAgentId: string | null = null;
-  private sessionObserverModelsRequest: {
-    client: GatewayBrowserClient;
-    agentId: string;
-    promise: Promise<void>;
-  } | null = null;
   private readonly systemInfoPolling = new PollController(
     this,
     SESSION_OBSERVER_STATUS_POLL_INTERVAL_MS,
@@ -360,9 +359,10 @@ export class ConfigPage extends OpenClawLightDomElement {
         : initialState,
     onComplete: (systemInfo) => {
       this.systemInfo = systemInfo;
-      const client = this.systemInfoRequestClient();
-      if (client) {
-        void this.ensureSessionObserverModels(client, this.context.agentSelection.state.selectedId);
+      // Status polling must not restart a slow catalog read. Changed owners
+      // still replace pending work through the model task's reactive args.
+      if (this.sessionObserverModelsTask.status !== TaskStatus.PENDING) {
+        void this.sessionObserverModelsTask.run();
       }
     },
     onError: (error) => {
@@ -372,6 +372,40 @@ export class ConfigPage extends OpenClawLightDomElement {
         this.systemInfoPolling.stop();
       }
     },
+  });
+  private readonly sessionObserverModelsTask: Task<
+    readonly [ApplicationContext["gateway"] | null, GatewayBrowserClient | null, string | null],
+    SessionObserverModelsResult
+  > = new Task(this, {
+    args: () =>
+      [
+        this.systemInfoGatewaySource,
+        this.systemInfo ? this.systemInfoRequestClient() : null,
+        this.context?.agentSelection.state.selectedId ?? null,
+      ] as const,
+    task: async ([gateway, client, agentId], { signal }) => {
+      if (!gateway || !client || !agentId) {
+        this.resetSessionObserverModels(!agentId);
+        return initialState;
+      }
+      const previous = this.sessionObserverModelsTask.value;
+      if (
+        previous?.gateway !== gateway ||
+        previous.client !== client ||
+        previous.agentId !== agentId
+      ) {
+        this.resetSessionObserverModels();
+      }
+      // Keep same-owner options visible during refresh; the shared store owns
+      // cache freshness/coalescing and Task fences publication after retirement.
+      const { models } = await loadModelCatalog(client, { agentId, preparedOnly: true, signal });
+      return { gateway, client, agentId, models };
+    },
+    onComplete: ({ models }) => {
+      this.sessionObserverModels = models;
+      this.sessionObserverModelsUnavailable = false;
+    },
+    onError: () => this.resetSessionObserverModels(true),
   });
   private readonly hiddenSessionCatalogLabelsTask = new Task(this, {
     args: () => {
@@ -432,7 +466,6 @@ export class ConfigPage extends OpenClawLightDomElement {
     .watch(
       () => this.context?.agentSelection,
       (selection, notify) => selection.subscribe(notify),
-      (selection) => this.synchronizeSessionObserverAgent(selection.state.selectedId),
     )
     .watch(
       () => this.context?.nativeDeviceSettings ?? undefined,
@@ -758,6 +791,8 @@ export class ConfigPage extends OpenClawLightDomElement {
 
   private invalidateSystemInfoRequest() {
     void this.systemInfoTask.run([null, null]);
+    void this.sessionObserverModelsTask.run([null, null, null]);
+    this.resetSessionObserverModels();
   }
 
   private systemInfoRequestClient(): GatewayBrowserClient | null {
@@ -778,73 +813,8 @@ export class ConfigPage extends OpenClawLightDomElement {
     return gateway.client;
   }
 
-  private synchronizeSessionObserverAgent(agentId: string | null) {
-    if (
-      this.sessionObserverModelsAgentId === agentId &&
-      (agentId !== null || this.sessionObserverModelsUnavailable)
-    ) {
-      return;
-    }
-    this.resetSessionObserverModels(!agentId);
-    const client = this.systemInfoRequestClient();
-    if (this.systemInfo && client) {
-      void this.ensureSessionObserverModels(client, agentId);
-    }
-  }
-
-  private ensureSessionObserverModels(
-    client: GatewayBrowserClient,
-    agentId: string | null,
-  ): Promise<void> {
-    if (!agentId) {
-      this.resetSessionObserverModels(true);
-      return Promise.resolve();
-    }
-    if (
-      this.sessionObserverModelsClient === client &&
-      this.sessionObserverModelsAgentId === agentId
-    ) {
-      return Promise.resolve();
-    }
-    const existing = this.sessionObserverModelsRequest;
-    if (existing?.client === client && existing.agentId === agentId) {
-      return existing.promise;
-    }
-    const gatewaySource = this.systemInfoGatewaySource;
-    const isCurrent = () =>
-      this.isConnected &&
-      this.systemInfoGatewaySource === gatewaySource &&
-      this.context.gateway.snapshot.client === client &&
-      this.context.agentSelection.state.selectedId === agentId &&
-      // Agent selection can cycle A -> B -> A while the first A load is still pending.
-      this.sessionObserverModelsRequest?.promise === promise;
-    const promise = loadModelCatalog(client, { agentId, preparedOnly: true })
-      .then(({ models }) => {
-        if (isCurrent()) {
-          this.sessionObserverModels = models;
-          this.sessionObserverModelsClient = client;
-          this.sessionObserverModelsAgentId = agentId;
-          this.sessionObserverModelsUnavailable = false;
-        }
-      })
-      .catch(() => {
-        if (isCurrent()) {
-          this.resetSessionObserverModels(true);
-        }
-      })
-      .finally(() => {
-        if (this.sessionObserverModelsRequest?.promise === promise) {
-          this.sessionObserverModelsRequest = null;
-        }
-      });
-    this.sessionObserverModelsRequest = { client, agentId, promise };
-    return promise;
-  }
-
   private resetSessionObserverModels(unavailable = false) {
     this.sessionObserverModels = [];
-    this.sessionObserverModelsClient = null;
-    this.sessionObserverModelsAgentId = null;
     this.sessionObserverModelsUnavailable = unavailable;
   }
 


### PR DESCRIPTION
Closes #139270

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Fixes an issue where users of Settings → Appearance could keep seeing obsolete Session Observer model choices after catalog changes or a Gateway reconnect. Leaving the page during a slow catalog read could also make the returning page wait on that retired request.

## Why This Change Was Made

Remove the page's completed and pending catalog caches. The existing shared store owns agent-specific freshness and coalescing; a Lit task owns cancellation and stale-result fencing. Same-owner status polls preserve slow reads and existing displayed options, while a changed owner or disconnected page clears its presentation and retires the request.

This removes 30 production lines (+46/−76). Prepared-only reads, the existing cache TTL, status-poll cadence, model selection policy, and backend contracts remain unchanged.

## User Impact

The picker receives current choices after catalog invalidation, and returning to Appearance starts a current read instead of joining an abandoned page's request. A late response cannot overwrite the current list. Auto and Disabled remain available when explicit models cannot be loaded.

## Evidence

Head: `45f066c3c24e9d1636480ffaf82032d673b23c52`, based on `bdd75d44c56154a24123be1a4218647b5f6712f3`. The committed four-file patch matches the frozen, tested and reviewed tree. The separate committed-head review is clean. [Ready-state CI33984523617](https://github.com/openclaw/openclaw/actions/runs/33984523617) passed for this exact head. Its preflight checked out merge `8dca1a1dc4b7b5ac23a42b4e441a1121c88af58e`, whose parents are `9d5ebf6bc94850ea685d7e8720a865cd335d0d5b` and the PR head above; the merge parents were independently verified.

The extended browser recovery matrix fails three invalidation cases on the old code while retaining the passing initial-failure retry. All four pass after the repair. The 74 focused tests cover the canonical cache, renderer, reactive client/source and A→B→A changes, absent agent, slow-read stability, cancellation, and late results.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run ui/src/pages/config/config-page.test.ts ui/src/pages/config/config-page.session-observer.test.ts ui/src/lib/model-catalog-store.test.ts ui/src/pages/config/session-observer-settings.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-observer-model-catalog-recovery.e2e.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- ui/src/pages/config/config-page.ts ui/src/pages/config/config-page.test.ts ui/src/e2e/session-observer-model-catalog-recovery.e2e.test.ts
# Final test-file split check
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- ui/src/pages/config/config-page.test.ts ui/src/pages/config/config-page.session-observer.test.ts
```

The full changed gate passed on the production/E2E change. The observer tests were then moved into a focused sibling file to respect the line limit; all 74 tests pass after the move, and its affected changed gate and fresh P2 review also pass. Independent peer review of the final four-file tree is clean. Tests total +280/−154, net +126 including the move and focused setup; production is net −30.

Real isolated Chromium proof uses the bundled UI and synthetic Gateway data. After each configuration event, metadata event, or same-client reconnect, the next status poll now fetches and displays the changed catalog. A separately held read survives three status polls; leaving and reentering then starts a new request, and releasing the retired response cannot replace the fresh list.

Synthetic browser proof, captured from the exact recorded source/bundle inputs:

| Catalog invalidation: before | After |
| --- | --- |
| ![Obsolete catalog retained](https://github.com/user-attachments/assets/8b494276-695f-45ce-9c2a-c7f8cc8b7421) | ![Current catalog displayed](https://github.com/user-attachments/assets/280589d6-c67a-49fb-b283-d46955a5ee09) |

| Return during a pending read: before | After |
| --- | --- |
| ![Returning page waits on retired request](https://github.com/user-attachments/assets/b9721069-470e-4328-8bc6-d0bcef7d74c9) | ![Returning page displays fresh catalog](https://github.com/user-attachments/assets/f6d38986-b2bb-45b5-be7f-c1994648b6b3) |

The original full frames and request/element/client assertions are retained as evidence; these images contain only synthetic fixture data.


Before execution used a prepared checkout whose complete UI and packages trees and dependency/build inputs are identical to the audited main base. The fixture's version footer is synthetic. No live Gateway, provider, inference, operator state, backend persistence, or non-Chromium execution is claimed. Fresh bounded UI bundles were built; no full runtime build is needed for this UI owner change.

Timing limit: an already-pending read for the same owner is allowed to finish across cache invalidation. It may briefly display pre-event data, cannot repopulate the invalidated cache, and the next successful status poll refreshes it. This preserves slow-request progress.

Review follow-through: the [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/139282#issuecomment-5553970955) at this head found no defect or before-merge action and listed no rank-up moves. Its attachment retrieval failed and it inspected upstream Task source because the installed artifact was unavailable. Maintainer proof includes full inspection of all four original synthetic captures, verified public image responses, and separate inspection of installed Task1.0.3 development/production implementations and reactive-element2.1.2 ordering. No independent ClawSweeper visual-verification claim is made.
