### PR TITLE
fix(tailscale): guide recovery of existing foreground claims

### DIFF
--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -122,7 +122,7 @@ This compatibility path does not grant managed Tailscale semantics: `gateway.aut
 - Tailscale Serve/Funnel requires the `tailscale` CLI installed and logged in.
 - `tailscale.mode: "funnel"` refuses to start unless auth mode is `password`, to avoid public exposure.
 - OpenClaw holds Serve/Funnel as a foreground Tailscale claim. Gateway startup succeeds only after the claim is active, and stopping or losing the Gateway releases it automatically.
-- With managed ingress enabled, startup adopts a predecessor HTTPS root route on its managed port when the target is exactly `http://127.0.0.1:<configured-gateway-port>` or the equivalent `localhost` URL (with an optional trailing slash), replaces it with the dedicated managed listener, and logs the adoption. Routes to other targets, or roots sharing their port with other handlers or hostnames, remain untouched; startup reports the conflicting HTTPS port and scoped cleanup command, while Doctor leaves externally managed configuration unchanged and names the inspected port in its recovery guidance.
+- With managed ingress enabled, startup adopts a predecessor background HTTPS root route on its managed port when the target is exactly `http://127.0.0.1:<configured-gateway-port>` or the equivalent `localhost` URL (with an optional trailing slash), replaces it with the dedicated managed listener, and logs the adoption. Routes to other targets, or roots sharing their port with other handlers or hostnames, remain untouched; startup reports the conflicting HTTPS port and recovery guidance, while Doctor leaves externally managed configuration unchanged.
 - Named Tailscale Services are not supported by managed ingress because Tailscale requires them to run as persistent background routes. Existing `gateway.tailscale.serviceName` installs must run `openclaw doctor --fix`; Doctor disables managed ingress and removes the key. Inspect the retained Service route, clear it with `tailscale serve clear <service-name>`, then enable device Serve with `gateway.tailscale.mode: "serve"` if desired.
 - Older releases could advertise an externally configured default HTTPS Serve route that targeted a `gateway.bind: "lan"` listener. That route does not automatically gain trusted ingress provenance. Run `openclaw doctor` to inspect it; Doctor leaves the configuration unchanged because it cannot prove who owns the route. If you confirm the route belongs to the current Tailscale hostname and is stale from an older OpenClaw release, remove only its root handler with `tailscale serve --yes --https=443 --set-path=/ off` or `tailscale funnel --yes --https=443 --set-path=/ off`, then configure `gateway.bind: "loopback"` plus `gateway.tailscale.mode: "serve"` manually and restart the Gateway. If another service must retain ownership, leave managed Tailscale ingress off and use the explicit `trustedProxies` compatibility path above.
 - `gateway.tailscale.preserveFunnel: true` is a deprecated migration guard. It detects an externally configured `tailscale funnel` route before reapplying Serve. If that route still targets the ordinary Gateway listener, OpenClaw leaves it unchanged and warns because the route is not managed ingress. Gateway-authenticated routes work only through the explicit `trustedProxies` compatibility path above and continue to require the configured auth; plugin-authenticated webhook routes such as Google Chat and SMS keep using their own signature/auth checks. To migrate, first configure a durable `gateway.auth.password` (prefer a SecretRef) or `OPENCLAW_GATEWAY_PASSWORD`, set `gateway.auth.mode` to `password`, run `openclaw config set gateway.tailscale.mode funnel`, then `openclaw config unset gateway.tailscale.preserveFunnel`.
@@ -139,6 +139,24 @@ This compatibility path does not grant managed Tailscale semantics: `gateway.aut
 - Funnel requires Tailscale v1.38.3+, MagicDNS, HTTPS enabled, and a funnel node attribute.
 - Funnel only supports ports `443`, `8443`, and `10000` over TLS.
 - Funnel on macOS requires the open-source Tailscale app variant.
+
+## Recover an orphaned foreground claim
+
+Older Gateways could leave a foreground Tailscale claim running after a forced
+shutdown. Updating prevents new orphans but does not remove existing claims.
+
+If startup reports an occupied HTTPS port, run `tailscale serve status --json`.
+Check `Foreground` for the reported session, hostname, path, and proxy target.
+On macOS or Linux, inspect candidate CLI processes with
+`ps -axo pid,ppid,args | grep '[t]ailscale'`. Confirm which process created that
+route before stopping it with `kill -TERM <confirmed-pid>`. Tailscale status does
+not report the claimant PID; a backend listener PID or an orphaned parent alone
+does not prove ownership. If another application owns the claim, leave it alone
+and keep OpenClaw managed ingress off until you resolve the conflict.
+
+Verify that the foreground session disappears from `tailscale serve status
+--json`, then restart the Gateway. `tailscale serve --https=443 --set-path=/ off`
+removes a background Web handler; it does not release a foreground claim.
 
 ## Browser control (remote Gateway + local browser)
 

--- a/src/gateway/server-tailscale-upgrade.test.ts
+++ b/src/gateway/server-tailscale-upgrade.test.ts
@@ -63,6 +63,11 @@ describe("managed Tailscale upgrade", () => {
   });
 
   it.each([
+    [
+      "foreground claim",
+      { Foreground: { "fixture-session": legacyRoute(false, 8096) } },
+      /Foreground session fixture-session.*fixture\.tailnet\.ts\.net:443[\s\S]*stop the confirmed owning process/,
+    ],
     ["foreign target", legacyRoute(false, 8096)],
     [
       "foreign sibling hostname",
@@ -90,7 +95,7 @@ describe("managed Tailscale upgrade", () => {
         },
       },
     ],
-  ])("does not modify a %s", async (_label, config) => {
+  ])("does not modify a %s", async (_label, config, recovery = "--https=443 --set-path=/ off") => {
     const env = captureEnv([
       "OPENCLAW_TEST_TAILSCALE_BINARY",
       "OPENCLAW_TEST_TAILSCALE_FIXTURE_MARKER",
@@ -106,7 +111,7 @@ describe("managed Tailscale upgrade", () => {
       logTailscale: { info: () => undefined, warn: () => undefined },
     });
     try {
-      await expect(exposure).rejects.toThrow("--https=443 --set-path=/ off");
+      await expect(exposure).rejects.toThrow(recovery);
       expect(await readFile(marker, "utf8")).toBe(before);
     } finally {
       await exposure.then(

--- a/src/gateway/server-tailscale-upgrade.test.ts
+++ b/src/gateway/server-tailscale-upgrade.test.ts
@@ -95,7 +95,7 @@ describe("managed Tailscale upgrade", () => {
         },
       },
     ],
-  ])("does not modify a %s", async (_label, config, recovery = "--https=443 --set-path=/ off") => {
+  ])("does not modify a %s", async (_label, config, recovery = /--https=443 --set-path=\/ off/) => {
     const env = captureEnv([
       "OPENCLAW_TEST_TAILSCALE_BINARY",
       "OPENCLAW_TEST_TAILSCALE_FIXTURE_MARKER",

--- a/src/infra/tailscale-route-ownership-error.ts
+++ b/src/infra/tailscale-route-ownership-error.ts
@@ -1,5 +1,6 @@
 import { safeParseJsonRecord } from "@openclaw/normalization-core/json-coercion";
 import { asNullableObjectRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
 const TAILSCALE_ROUTE_OWNERSHIP_CONFLICT_CODE = "TAILSCALE_ROUTE_OWNERSHIP_CONFLICT";
 
@@ -21,7 +22,7 @@ export class TailscaleRouteOwnershipConflictError extends Error {
     const [mount, handler] =
       Object.entries(readRecord(readRecord(server)?.Handlers) ?? {})[0] ?? [];
     const route = host
-      ? `https://${host}${mount ?? ""} -> ${readRecord(handler)?.Proxy ?? "non-proxy handler"}`
+      ? `https://${host}${mount ?? ""} -> ${normalizeOptionalString(readRecord(handler)?.Proxy) ?? "non-proxy handler"}`
       : `HTTPS port ${port}`;
     super(
       `Tailscale HTTPS port ${port} is already owned by a route whose ownership OpenClaw cannot prove; it was not modified. ` +

--- a/src/infra/tailscale-route-ownership-error.ts
+++ b/src/infra/tailscale-route-ownership-error.ts
@@ -1,3 +1,4 @@
+import { safeParseJsonRecord } from "@openclaw/normalization-core/json-coercion";
 import { asNullableObjectRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 
 const TAILSCALE_ROUTE_OWNERSHIP_CONFLICT_CODE = "TAILSCALE_ROUTE_OWNERSHIP_CONFLICT";
@@ -5,12 +6,30 @@ const TAILSCALE_ROUTE_OWNERSHIP_CONFLICT_CODE = "TAILSCALE_ROUTE_OWNERSHIP_CONFL
 export class TailscaleRouteOwnershipConflictError extends Error {
   readonly code = TAILSCALE_ROUTE_OWNERSHIP_CONFLICT_CODE;
 
-  constructor(port = 443) {
+  constructor(port = 443, serveStatus = "{}") {
+    const status = safeParseJsonRecord(
+      serveStatus.slice(serveStatus.indexOf("{"), serveStatus.lastIndexOf("}") + 1),
+    );
+    const [session, config] =
+      Object.entries(readRecord(status?.Foreground) ?? {}).find(
+        ([, entry]) => readRecord(readRecord(entry)?.TCP)?.[String(port)],
+      ) ?? [];
+    const [host, server] =
+      Object.entries(readRecord(readRecord(config)?.Web) ?? {}).find(([hostPort]) =>
+        hostPort.endsWith(`:${port}`),
+      ) ?? [];
+    const [mount, handler] =
+      Object.entries(readRecord(readRecord(server)?.Handlers) ?? {})[0] ?? [];
+    const route = host
+      ? `https://${host}${mount ?? ""} -> ${readRecord(handler)?.Proxy ?? "non-proxy handler"}`
+      : `HTTPS port ${port}`;
     super(
       `Tailscale HTTPS port ${port} is already owned by a route whose ownership OpenClaw cannot prove; it was not modified. ` +
-        "Inspect `tailscale serve status`. If the route belongs to the current Tailscale hostname and is stale from an older OpenClaw release, remove its root handler with " +
-        `\`tailscale serve --yes --https=${port} --set-path=/ off\`, then restart the Gateway. ` +
-        "Otherwise disable managed Tailscale ingress or reconfigure the route before restarting.",
+        (session
+          ? `Foreground session ${session} (${route.slice(0, 512)}). Inspect \`tailscale serve status --json\` and stop the confirmed owning process, then restart the Gateway. Tailscale status does not report the claimant PID; \`serve off\` does not release foreground claims. `
+          : "Inspect `tailscale serve status`. If the route belongs to the current Tailscale hostname and is stale from an older OpenClaw release, remove its background root handler with " +
+            `\`tailscale serve --yes --https=${port} --set-path=/ off\`, then restart the Gateway. ` +
+            "Otherwise disable managed Tailscale ingress or reconfigure the route before restarting."),
     );
     this.name = "TailscaleRouteOwnershipConflictError";
   }

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, symlinkSync, watch } from "node:fs";
+import { symlinkSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 // Covers Tailscale whois, Serve, and Funnel helpers.
@@ -55,7 +55,6 @@ describe("tailscale helpers", () => {
   beforeEach(() => {
     envSnapshot = captureEnv([
       "OPENCLAW_TEST_TAILSCALE_BINARY",
-      "OPENCLAW_TEST_TAILSCALE_FIXTURE_MARKER",
       "OPENCLAW_TEST_TAILSCALE_SUDO_FIXTURE_MODE",
       "NODE_ENV",
       "PATH",
@@ -292,31 +291,14 @@ describe("tailscale helpers", () => {
   it.runIf(process.platform !== "win32")(
     "preserves route diagnostics when startup readiness times out",
     async () => {
-      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
       const fixture = fileURLToPath(
         new URL("../../test/fixtures/tailscale-foreground-fixture.mjs", import.meta.url),
       );
-      const fixtureDir = tempDirs.make("openclaw-tailscale-fixture-");
-      const marker = path.join(fixtureDir, "started");
       process.env.OPENCLAW_TEST_TAILSCALE_BINARY = fixture;
-      process.env.OPENCLAW_TEST_TAILSCALE_FIXTURE_MARKER = marker;
 
-      const markerWritten = new Promise<void>((resolve) => {
-        const watcher = watch(fixtureDir, (_event, filename) => {
-          if (`${filename}` === "started") {
-            watcher.close();
-            resolve();
-          }
-        });
-      });
-      const claimPromise = claimTailscaleRoute("funnel", 18790, 18790, vi.fn());
-      void claimPromise.catch(() => undefined);
-      await markerWritten;
-      expect(existsSync(marker)).toBe(true);
-
-      await vi.advanceTimersByTimeAsync(15_000);
-
-      await expect(claimPromise).rejects.toThrow("Funnel is not enabled on your tailnet.");
+      await expect(claimTailscaleRoute("funnel", 18790, 18790, vi.fn())).rejects.toThrow(
+        "Funnel is not enabled on your tailnet.",
+      );
     },
   );
 

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -231,12 +231,12 @@ type TailscaleRouteOwnerFailure = Pick<
   "code" | "stdout" | "stderr"
 >;
 
-function routeClaimError(message: TailscaleRouteOwnerFailure): Error {
+function routeClaimError(message: TailscaleRouteOwnerFailure, serveStatus: string): Error {
   const conflict = /listener already exists for port (\d+)/i.exec(
     `${message.stderr}\n${message.stdout}`,
   );
   if (conflict) {
-    return new TailscaleRouteOwnershipConflictError(Number(conflict[1]));
+    return new TailscaleRouteOwnershipConflictError(Number(conflict[1]), serveStatus);
   }
   const detail = [message.stderr.trim(), message.stdout.trim()].find(Boolean);
   return Object.assign(new Error(detail || "Tailscale route owner exited before claiming route"), {
@@ -263,7 +263,10 @@ function waitWithTimeout(promise: Promise<void>, timeoutMs: number): Promise<boo
   });
 }
 
-async function startTailscaleRouteOwner(argv: string[]): Promise<TailscaleRouteClaim> {
+async function startTailscaleRouteOwner(
+  argv: string[],
+  serveStatus: string,
+): Promise<TailscaleRouteClaim> {
   const workerUrl = resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.tailscaleRouteOwner);
   const execArgv = workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : undefined;
   const worker = fork(
@@ -322,11 +325,14 @@ async function startTailscaleRouteOwner(argv: string[]): Promise<TailscaleRouteC
         ) {
           return;
         }
-        failure = routeClaimError({
-          code: event.code,
-          stdout: event.stdout,
-          stderr: event.stderr,
-        });
+        failure = routeClaimError(
+          {
+            code: event.code,
+            stdout: event.stdout,
+            stderr: event.stderr,
+          },
+          serveStatus,
+        );
         if (!ready) {
           settle(failure);
         }
@@ -400,7 +406,10 @@ export async function claimTailscaleRoute(
       await exec(["serve", "--yes", "--https=443", "--set-path=/", "off"]);
       adopted = true;
     }
-    return startTailscaleRouteOwner([bin, ...prefix, mode, "--yes", "--bg=false", `${target}`]);
+    return startTailscaleRouteOwner(
+      [bin, ...prefix, mode, "--yes", "--bg=false", `${target}`],
+      stdout,
+    );
   };
   let claim: TailscaleRouteClaim;
   try {

--- a/test/fixtures/tailscale-foreground-fixture.mjs
+++ b/test/fixtures/tailscale-foreground-fixture.mjs
@@ -17,9 +17,5 @@ if (JSON.stringify(args) === JSON.stringify(serveArgs)) {
   process.stdout.write("Press Ctrl+C to exit.\n");
 } else {
   process.stderr.write("Funnel is not enabled on your tailnet.\n");
-  const marker = process.env.OPENCLAW_TEST_TAILSCALE_FIXTURE_MARKER;
-  if (marker) {
-    await import("node:fs/promises").then(({ writeFile }) => writeFile(marker, "ready"));
-  }
 }
 setInterval(() => {}, 1000);

--- a/test/fixtures/tailscale-legacy-route-fixture.mjs
+++ b/test/fixtures/tailscale-legacy-route-fixture.mjs
@@ -40,7 +40,7 @@ if (
 if (JSON.stringify(args) === JSON.stringify([mode, "--yes", "--bg=false", "19000"])) {
   const state = await readFile(marker, "utf8");
   const status = JSON.parse(state);
-  if (status.TCP?.["443"]) {
+  if ([status, ...Object.values(status.Foreground ?? {})].some((config) => config.TCP?.["443"])) {
     process.stderr.write("listener already exists for port 443\n");
     process.exit(1);
   }


### PR DESCRIPTION
Related: #126445 (Tailscale orphan crash loop), #126457, and #139261.

## What Problem This Solves

Fixes an issue where a Gateway blocked by an existing foreground Tailscale claim recommends `serve ... off`, a command that only removes background Web handlers and cannot release that claim. Operators recovering an orphan left by a pre-fix Gateway need to identify and stop its confirmed owning process.

## Why This Change Was Made

Foreground conflicts now identify the observed session and route and direct the operator to stop only a confirmed owning process. The already-read status snapshot supplies the diagnostic; Tailscale does not expose the claiming CLI PID, and this change does not infer process ownership. Existing background-route guidance remains scoped to a confirmed stale route.

The prevention repair landed in #139261 while this follow-up was in progress. This PR completes its named recovery-guidance follow-up and documents the one-time manual recovery. It also removes a fake-clock/filesystem-marker test handshake that stalled validation, retaining the real startup-timeout and original-error assertion.

## User Impact

Operators can distinguish a foreground claim from a background handler and follow the appropriate recovery steps. Historical claims remain untouched until their owner confirms and stops them. See [the Tailscale guide](https://docs.openclaw.ai/gateway/tailscale#recover-an-orphaned-foreground-claim).

Thanks to @PollyBot13 for the original report and contribution in #126445 and #126457; the contributor trailer is preserved here and in #139261. No automatic orphan reclamation, shutdown-timeout policy, or persistence design is introduced.

## Evidence

Exact head: `5d4fa89057e94ddbc4bf28b243856cd71eb14611`. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33984935246) is green. Fresh branch autoreview is scoped-clean at P0–P2. The final Crabbox five-file test run and full `node scripts/check-changed.mjs` completed successfully on this exact source.

- The new Gateway foreground-conflict regression failed before the error change by receiving the ineffective background `off` command, and passed afterward with session/route/process-stop guidance. Existing background adoption and independent-route cases passed: 22 Gateway tests.
- The five Tailscale owner/helper/Gateway/upgrade files passed 63 tests on Crabbox on the final head. Final-head local Gateway upgrade coverage passed 8 cases. Initial CI caught a default matcher type mismatch and unvalidated proxy interpolation; both are corrected and exact-head CI is green.
- The readiness-timeout test previously stalled for 120 seconds while its fake clock awaited a filesystem marker. The simplified test exercises the real 15-second timeout and preserved diagnostic, with no timeout change or test-only production seam.
- Local `node scripts/check-changed.mjs` passed initial guards, formatting, dependency/boundary checks, and the TypeScript graph boundary, then stopped because declaration inputs resolve outside this dependency-less worktree. Local process runs also encountered missing files in the shared `tsx`/`zod` installation. Prepared remote dependencies are used for complete proof.
- Real authenticated Tailscale proof is unavailable locally: Tailscale 1.102.3 and tailscaled are installed, but read-only status reports `BackendState=Stopped`, `SelfOnline=false`. No operator daemon, route, Gateway, or state was changed. The approved fallback is process/socket and Gateway-owner tests. #139261 separately records real built-Gateway before/after proof on Crabbox with a synthetic TCP claimant; it is not authenticated Tailscale proof.
- Upstream Tailscale 1.102.3 source at `53a0d659afa51835dd7a9283873cca44261454f8`: `cmd/tailscale/cli/serve_v2.go:490-548,1529-1585` and `ipn/ipnlocal/serve.go:425-433` establish foreground watch ownership and background-only handler removal.
- Original #126457 ClawSweeper rank-up move about loaded-timeout policy/managed-update bootout: skipped because the approved prevention and this diagnostic follow-up do not implement that timeout policy.

Production LOC: +42/-13 (net +29). Tests/support: +12/-29 (net -17). Docs: +19/-1. Growth is the explicitly requested missing recovery path: port-scoped session/route extraction and carrying existing status into the error owner. The prevention in #139261 separately removed one production line. No new config/env option, schema, protocol, or external call.

NO-FOLLOW-UP: this completes the prevention PR's named recovery follow-up and removes the nearby fragile test handshake; no further owner refactor earns its scope here.


### Final remote proof transcript

Provider `blacksmith-testbox`, lease `tbx_01m1se3ea3ycw0epbexgc8hs58`; [backing workflow](https://github.com/openclaw/openclaw/actions/runs/33984935515). The wrapper verified source `5d4fa89057e94ddbc4bf28b243856cd71eb14611`, raw tree `af21d3b07eb4252b45509e65260e8ccdd69ff548` before execution.

```text
node scripts/run-vitest.mjs src/infra/tailscale-parent-loss.process.test.ts src/infra/tailscale-route-owner.worker.test.ts src/infra/tailscale.test.ts src/gateway/server-tailscale.test.ts src/gateway/server-tailscale-upgrade.test.ts
Gateway: 2 files, 22 tests passed
Infra: 3 files, 41 tests passed
PID SIGKILL -> claim released -> same-port replacement: passed
Process-group SIGKILL -> claim released -> same-port replacement: passed
Foreground conflict -> session/route/process-stop guidance, state unchanged: passed
Readiness timeout -> original diagnostic preserved: passed (15,018 ms)
node scripts/check-changed.mjs
Production and all core test typechecks: passed
Dead-export scans: 0 entries
Core/scripts lint, schema, database, loader, cycle, webhook and pairing guards: passed
Remote command exit=0; wrapper exit=0; runStatus=succeeded
```

The combined remote payload took 18m11s after source synchronization. The provider's external portal sync timed out after successful execution; this did not change the command/wrapper success. The lease was stopped after proof. Initial CI failures were corrected, then [final exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33984935246) passed. The latest ClawSweeper review had no findings or rank-up moves; fresh final branch autoreview was scoped-clean at P0–P2.
