### PR TITLE
fix(codex): show unknown context usage instead of stale counts after native compaction

### DIFF
--- a/extensions/codex/src/app-server/compact.native.test.ts
+++ b/extensions/codex/src/app-server/compact.native.test.ts
@@ -1,0 +1,321 @@
+// Native regression proof: the manual-compaction producer records the
+// post-compaction usage boundary from a REAL codex app-server compaction.
+//
+// The pinned @openai/codex 0.153.4 binary runs with an isolated CODEX_HOME and
+// a loopback model provider; the production manual-compaction path
+// (compact.ts maybeCompactCodexAppServerSession) drives a real
+// thread/compact/start and consumes the real notification stream. Codex's
+// recompute zeroes the input/output split and reports the estimated compacted
+// context in totalTokens; the changed boundary normalization must record that
+// recomputed total as the available contextUsage (never a zero prompt count),
+// so transcript-derived session usage cannot resurrect the stale pre-compaction
+// count after compaction.
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ensureCodexAppServerClientRuntime,
+  retainCodexAppServerLiveThread,
+} from "./client-runtime.js";
+import { maybeCompactCodexAppServerSession } from "./compact.js";
+import * as compactionActivity from "./context-compaction-activity.js";
+import type { CodexCompactionUsageAfter } from "./context-compaction-activity.js";
+import { resolveCodexCompactionContextUsageAfter } from "./event-projector-usage.js";
+import { createCodexNativeTestState } from "./native-app-server.test-support.js";
+import { isJsonObject, type JsonObject } from "./protocol.js";
+import {
+  registerCodexTestSessionIdentity,
+  resetCodexTestBindingStore,
+  seedCodexTestBinding,
+  testCodexAppServerBindingStore,
+} from "./session-binding.test-helpers.js";
+import { createIsolatedCodexAppServerClient } from "./shared-client.js";
+import { CODEX_APP_SERVER_VERSION } from "./version.js";
+
+vi.unmock("node:child_process");
+
+let tempRoot: string;
+
+beforeEach(async () => {
+  resetCodexTestBindingStore();
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-compact-"));
+});
+
+afterEach(async () => {
+  // The app-server child can still be draining its CODEX_HOME after close.
+  await fs
+    .rm(tempRoot, { recursive: true, force: true, maxRetries: 8, retryDelay: 250 })
+    .catch(() => fs.rm(tempRoot, { recursive: true, force: true, maxRetries: 8, retryDelay: 500 }));
+});
+
+describe("native codex compaction usage boundary", () => {
+  it(
+    "records the recomputed context total from a real native compaction",
+    { timeout: 180_000 },
+    async (context) => {
+      const native = await createCodexNativeTestState(tempRoot);
+      for (const [name, value] of Object.entries(native.env)) {
+        if (value !== undefined) {
+          vi.stubEnv(name, value);
+        }
+      }
+      const agentDir = path.join(tempRoot, "agent");
+      const server = http.createServer((request, response) => {
+        let body = "";
+        request.setEncoding("utf8");
+        request.on("data", (chunk: string) => (body += chunk));
+        request.on("end", () => {
+          if (request.url !== "/v1/responses" || request.method !== "POST") {
+            response.writeHead(404).end();
+            return;
+          }
+          let parsed: JsonObject;
+          try {
+            parsed = JSON.parse(body) as JsonObject;
+          } catch {
+            response.writeHead(400).end();
+            return;
+          }
+          const events = [
+            { type: "response.created", response: { id: "native-compact-response" } },
+            {
+              type: "response.output_item.done",
+              item: {
+                type: "message",
+                role: "assistant",
+                id: "native-compact-answer",
+                content: [{ type: "output_text", text: "Completion." }],
+              },
+            },
+            {
+              type: "response.completed",
+              response: {
+                id: "native-compact-response",
+                usage: { input_tokens: 1_000, output_tokens: 10, total_tokens: 1_010 },
+              },
+            },
+          ];
+          response.writeHead(200, { "Content-Type": "text/event-stream" });
+          response.end(
+            events
+              .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+              .join(""),
+          );
+          void parsed;
+        });
+      });
+      context.onTestFinished(async () => {
+        server.closeAllConnections();
+        if (server.listening) {
+          await new Promise<void>((resolve) => {
+            server.close(() => resolve());
+          });
+        }
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("missing loopback provider address");
+      }
+      await fs.writeFile(
+        path.join(native.codexHome, "config.toml"),
+        [
+          'model="gpt-5.6-luna"',
+          'model_provider="native-compact-fixture"',
+          'cli_auth_credentials_store="ephemeral"',
+          'web_search="disabled"',
+          'approval_policy="never"',
+          'sandbox_mode="workspace-write"',
+          "allow_login_shell=false",
+          "model_context_window=4096",
+          "[features]",
+          "shell_snapshot=false",
+          "[analytics]",
+          "enabled=false",
+          "[feedback]",
+          "enabled=false",
+          "[model_providers.native-compact-fixture]",
+          'name="Native compaction provider"',
+          `base_url="http://127.0.0.1:${address.port}/v1"`,
+          'wire_api="responses"',
+          "requires_openai_auth=false",
+          "supports_websockets=false",
+          "request_max_retries=0",
+          "stream_max_retries=0",
+        ].join("\n"),
+      );
+      const childEnv = Object.fromEntries(
+        Object.entries(native.env).filter(
+          (entry): entry is [string, string] => entry[1] !== undefined,
+        ),
+      );
+      const startOptions = {
+        transport: "stdio" as const,
+        command: native.command,
+        commandSource: "config" as const,
+        args: ["app-server"],
+        cwd: native.cwd,
+        headers: {},
+        env: childEnv,
+        clearEnv: Object.keys(process.env).filter((key) => !(key in childEnv)),
+      };
+      const client = await createIsolatedCodexAppServerClient({
+        startOptions,
+        agentDir,
+        authProfileId: null,
+        config: {},
+        timeoutMs: 30_000,
+      });
+      context.onTestFinished(async () => {
+        await client.closeAndWait().catch(() => {});
+      });
+      expect(client.getRuntimeIdentity()?.serverVersion).toBe(CODEX_APP_SERVER_VERSION);
+      ensureCodexAppServerClientRuntime(client, { agentDir });
+      const thread = (await client.request(
+        "thread/start",
+        {
+          cwd: native.cwd,
+          model: "gpt-5.6-luna",
+          modelProvider: "native-compact-fixture",
+          approvalPolicy: "never",
+          approvalsReviewer: "user",
+          sandbox: "workspace-write",
+          ephemeral: true,
+        },
+        { timeoutMs: 60_000 },
+      )) as { thread: { id: string } };
+      const threadId = thread.thread.id;
+      // Seed synthetic history so the compaction recompute has a real
+      // pre-compaction context to replace.
+      for (let i = 0; i < 6; i += 1) {
+        await client.request(
+          "thread/inject_items",
+          {
+            threadId,
+            items: [
+              {
+                type: "message",
+                role: "user",
+                content: [{ type: "input_text", text: `Synthetic user message ${i}.` }],
+              },
+              {
+                type: "message",
+                role: "assistant",
+                content: [{ type: "output_text", text: `Synthetic assistant reply ${i}.` }],
+              },
+            ],
+          },
+          { timeoutMs: 60_000 },
+        );
+      }
+      // A live session owns the thread; compaction keeps that ownership.
+      expect(await retainCodexAppServerLiveThread(client, threadId)).toBe(true);
+      const sessionFile = path.join(tempRoot, "session.jsonl");
+      const sessionKey = "agent:main:session-1";
+      registerCodexTestSessionIdentity(sessionFile, "session-1", sessionKey);
+      seedCodexTestBinding(sessionFile, { threadId, cwd: native.cwd });
+      const persistActivity = vi.spyOn(compactionActivity, "persistCodexContextCompactionActivity");
+      // Record the raw compaction-window tokenUsage notifications.
+      let compactionOpen = false;
+      const windowLastSnapshots: Array<JsonObject | undefined> = [];
+      const removeHandler = client.addNotificationHandler((notification) => {
+        const params = notification.params;
+        if (!isJsonObject(params)) {
+          return;
+        }
+        if (notification.method === "item/started") {
+          const item = params.item;
+          if (isJsonObject(item) && item.type === "contextCompaction") {
+            compactionOpen = true;
+          }
+          return;
+        }
+        if (notification.method === "thread/tokenUsage/updated" && compactionOpen) {
+          const tokenUsage = params.tokenUsage;
+          const last =
+            isJsonObject(tokenUsage) && isJsonObject(tokenUsage.last)
+              ? (tokenUsage.last as JsonObject)
+              : undefined;
+          windowLastSnapshots.push(last);
+          return;
+        }
+        if (notification.method === "item/completed") {
+          const item = params.item;
+          if (isJsonObject(item) && item.type === "contextCompaction") {
+            compactionOpen = false;
+          }
+        }
+      });
+      context.onTestFinished(removeHandler);
+
+      const result = await maybeCompactCodexAppServerSession(
+        {
+          sessionId: "session-1",
+          sessionKey,
+          sessionFile,
+          workspaceDir: native.cwd,
+          trigger: "manual",
+        },
+        {
+          bindingStore: testCodexAppServerBindingStore,
+          clientFactory: async () => client,
+        },
+      );
+      expect(result).toMatchObject({ ok: true, compacted: true });
+      const tokensAfter = (result as { result?: { tokensAfter?: number } }).result?.tokensAfter;
+      const persistArgs = persistActivity.mock.calls.map(
+        (call) => call[0] as { threadId?: string; usageAfter?: unknown },
+      );
+      expect(persistArgs).toHaveLength(1);
+      const usageAfter = persistArgs[0]?.usageAfter as CodexCompactionUsageAfter | undefined;
+      expect(usageAfter).toMatchObject({
+        state: "available",
+        promptTokens: expect.any(Number),
+        totalTokens: expect.any(Number),
+      });
+      const availableUsageAfter = usageAfter?.state === "available" ? usageAfter : undefined;
+      expect(availableUsageAfter?.promptTokens).toBeGreaterThan(0);
+      expect(availableUsageAfter?.totalTokens).toBeGreaterThan(0);
+      // The outward tokensAfter result and the persisted boundary share one
+      // source of truth (the compaction-window snapshot).
+      expect(tokensAfter).toBe(availableUsageAfter?.totalTokens);
+      // The real stream must contain the codex recompute payload this fix
+      // normalizes: a zeroed input/output split with a positive totalTokens
+      // estimate of the compacted context.
+      const zeroInputRecompute = windowLastSnapshots.find(
+        (last) =>
+          last !== undefined &&
+          typeof last.totalTokens === "number" &&
+          last.totalTokens > 0 &&
+          (last.inputTokens === 0 || last.inputTokens === undefined) &&
+          last.outputTokens === 0,
+      );
+      expect(zeroInputRecompute).toBeDefined();
+      // The recorded boundary equals resolve() over the last reliable
+      // compaction-window snapshot; a zero prompt count is never recorded as a
+      // positive boundary (transcript readers require a positive prompt side).
+      const expected = windowLastSnapshots.reduce<CodexCompactionUsageAfter | undefined>(
+        (latest, last) => {
+          if (!last) {
+            return latest;
+          }
+          const snapshot = {
+            ...(typeof last.totalTokens === "number" && last.totalTokens > 0
+              ? { activeContextTokens: Math.floor(last.totalTokens) }
+              : {}),
+            ...(typeof last.inputTokens === "number" && last.inputTokens > 0
+              ? { promptTokens: Math.floor(last.inputTokens) }
+              : {}),
+          };
+          return resolveCodexCompactionContextUsageAfter(snapshot) ?? latest;
+        },
+        undefined,
+      );
+      expect(expected).toEqual(availableUsageAfter);
+    },
+  );
+});

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -17,6 +17,7 @@ import {
 import { CodexAppServerRpcError, type CodexAppServerClient } from "./client.js";
 import { maybeCompactCodexAppServerSession as maybeCompactCodexAppServerSessionImpl } from "./compact.js";
 import { resolveCodexSupervisionAppServerRuntimeOptions } from "./config.js";
+import * as compactionActivity from "./context-compaction-activity.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
 import type { CodexServerNotification } from "./protocol.js";
 import { createSandboxContext } from "./sandbox-exec-server.test-helpers.js";
@@ -1445,6 +1446,203 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(result.compacted).toBe(true);
     expect(result.result?.tokensAfter).toBe(321);
     expect(compactDetails(result).signal).toBe("thread/compact/start");
+  });
+
+  it("records an available usage boundary when the app-server reports a post-compaction count", async () => {
+    const fake = createFakeCodexClient({ autoCompleteCompaction: false });
+    setCodexAppServerClientFactoryForTest(async () => fake.client);
+    const sessionFile = await writeTestBinding();
+    const persistActivity = vi.spyOn(compactionActivity, "persistCodexContextCompactionActivity");
+    try {
+      const pendingResult = startCompaction(sessionFile);
+      await vi.waitFor(() => {
+        expect(fake.request).toHaveBeenCalledWith(
+          "thread/compact/start",
+          { threadId: "thread-1" },
+          { assertCurrent: expect.any(Function) },
+        );
+      });
+      await flushAsyncTasks();
+      fake.emit({
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { id: "compact-item-1", type: "contextCompaction" },
+        },
+      });
+      fake.emit({
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          tokenUsage: {
+            last: { inputTokens: 800, outputTokens: 200, totalTokens: 1_000 },
+          },
+        },
+      });
+      fake.emit({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { id: "compact-item-1", type: "contextCompaction" },
+        },
+      });
+      await flushAsyncTasks();
+      fake.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turn: { id: "turn-1", threadId: "thread-1", status: "completed" },
+        },
+      });
+      const result = requireCompactResult(await pendingResult);
+
+      expect(result.ok).toBe(true);
+      expect(result.compacted).toBe(true);
+      expect(result.result?.tokensAfter).toBe(1_000);
+      expect(persistActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "compact-item-1",
+          usageAfter: { state: "available", promptTokens: 800, totalTokens: 1_000 },
+        }),
+      );
+    } finally {
+      persistActivity.mockRestore();
+    }
+  });
+
+  it("records the recomputed context total when the app-server reports a zero-input recompute", async () => {
+    // Codex recompute_token_usage (pinned @openai/codex 0.153.4) zeroes the
+    // input/output split and reports the estimated compacted context size in
+    // totalTokens. A zero prompt count is not a coherent boundary: mapping it
+    // through verbatim would leave the stale pre-compaction total in place.
+    const fake = createFakeCodexClient({ autoCompleteCompaction: false });
+    setCodexAppServerClientFactoryForTest(async () => fake.client);
+    const sessionFile = await writeTestBinding();
+    const persistActivity = vi.spyOn(compactionActivity, "persistCodexContextCompactionActivity");
+    try {
+      const pendingResult = startCompaction(sessionFile);
+      await vi.waitFor(() => {
+        expect(fake.request).toHaveBeenCalledWith(
+          "thread/compact/start",
+          { threadId: "thread-1" },
+          { assertCurrent: expect.any(Function) },
+        );
+      });
+      await flushAsyncTasks();
+      fake.emit({
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { id: "compact-item-1", type: "contextCompaction" },
+        },
+      });
+      fake.emit({
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          tokenUsage: {
+            last: { inputTokens: 0, outputTokens: 0, totalTokens: 1_000 },
+          },
+        },
+      });
+      fake.emit({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { id: "compact-item-1", type: "contextCompaction" },
+        },
+      });
+      await flushAsyncTasks();
+      fake.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turn: { id: "turn-1", threadId: "thread-1", status: "completed" },
+        },
+      });
+      const result = requireCompactResult(await pendingResult);
+
+      expect(result.ok).toBe(true);
+      expect(result.compacted).toBe(true);
+      expect(result.result?.tokensAfter).toBe(1_000);
+      expect(persistActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "compact-item-1",
+          // The recomputed active-context total becomes the prompt side so the
+          // transcript boundary replaces (not ignores) the stale count.
+          usageAfter: { state: "available", promptTokens: 1_000, totalTokens: 1_000 },
+        }),
+      );
+    } finally {
+      persistActivity.mockRestore();
+    }
+  });
+
+  it("records an unavailable usage boundary when the app-server reports no post-compaction count", async () => {
+    const fake = createFakeCodexClient({ autoCompleteCompaction: false });
+    setCodexAppServerClientFactoryForTest(async () => fake.client);
+    const sessionFile = await writeTestBinding();
+    const persistActivity = vi.spyOn(compactionActivity, "persistCodexContextCompactionActivity");
+    try {
+      const pendingResult = startCompaction(sessionFile);
+      await vi.waitFor(() => {
+        expect(fake.request).toHaveBeenCalledWith(
+          "thread/compact/start",
+          { threadId: "thread-1" },
+          { assertCurrent: expect.any(Function) },
+        );
+      });
+      await flushAsyncTasks();
+      fake.emit({
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { id: "compact-item-1", type: "contextCompaction" },
+        },
+      });
+      fake.emit({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { id: "compact-item-1", type: "contextCompaction" },
+        },
+      });
+      await flushAsyncTasks();
+      fake.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turn: { id: "turn-1", threadId: "thread-1", status: "completed" },
+        },
+      });
+      const result = requireCompactResult(await pendingResult);
+
+      expect(result.ok).toBe(true);
+      expect(result.compacted).toBe(true);
+      expect(result.result?.tokensAfter).toBeUndefined();
+      expect(persistActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "compact-item-1",
+          usageAfter: { state: "unavailable" },
+        }),
+      );
+    } finally {
+      persistActivity.mockRestore();
+    }
   });
 
   it("lets terminal interruption win after the compaction item completes", async () => {

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -32,8 +32,14 @@ import {
   isCodexAppServerPrewriteRequestCancellationError,
   type CodexAppServerClient,
 } from "./client.js";
-import { persistCodexContextCompactionActivity } from "./context-compaction-activity.js";
-import { readCodexThreadContextSnapshot } from "./event-projector-usage.js";
+import {
+  persistCodexContextCompactionActivity,
+  type CodexCompactionUsageAfter,
+} from "./context-compaction-activity.js";
+import {
+  readCodexThreadContextSnapshot,
+  resolveCodexCompactionContextUsageAfter,
+} from "./event-projector-usage.js";
 import {
   readCodexNotificationThreadId,
   readCodexNotificationTurnId,
@@ -75,7 +81,13 @@ type CodexAppServerCompactOptions = {
 };
 
 type CodexNativeCompactionCompletion =
-  | { completed: true; turnId?: string; itemId?: string; tokensAfter?: number }
+  | {
+      completed: true;
+      turnId?: string;
+      itemId?: string;
+      tokensAfter?: number;
+      contextUsageAfter: CodexCompactionUsageAfter;
+    }
   | { completed: false; reason: string };
 
 function watchCodexNativeCompactionCompletion(params: {
@@ -95,7 +107,7 @@ function watchCodexNativeCompactionCompletion(params: {
   let compactionTurnId: string | undefined;
   let compactionItemId: string | undefined;
   let compactionItemCompleted = false;
-  let tokensAfter: number | undefined;
+  let contextUsageAfter: CodexCompactionUsageAfter | undefined;
   const { promise: completion, resolve: resolveCompletion } =
     createDeferred<CodexNativeCompactionCompletion>();
   let removeNotificationHandler = () => {};
@@ -115,13 +127,20 @@ function watchCodexNativeCompactionCompletion(params: {
     clearTimeout(interruptGraceTimeout);
     resolveCompletion(result);
   };
-  const complete = () =>
+  const complete = () => {
+    // The app-server only emits thread/tokenUsage/updated after a successful
+    // recompute; its absence means the post-compaction count is unknown.
+    const usageAfter: CodexCompactionUsageAfter = contextUsageAfter ?? { state: "unavailable" };
     finish({
       completed: true,
       ...(compactionTurnId ? { turnId: compactionTurnId } : {}),
       ...(compactionItemId ? { itemId: compactionItemId } : {}),
-      ...(tokensAfter !== undefined ? { tokensAfter } : {}),
+      // tokensAfter derives from the same boundary snapshot; one source of
+      // truth avoids parallel accounting state that can drift apart.
+      ...(usageAfter.state === "available" ? { tokensAfter: usageAfter.totalTokens } : {}),
+      contextUsageAfter: usageAfter,
     });
+  };
   const fail = (reason: string) => finish({ completed: false, reason });
   const retireUnconfirmed = (reason: string) => {
     if (settled || retirementStarted) {
@@ -236,8 +255,14 @@ function watchCodexNativeCompactionCompletion(params: {
       return;
     }
     if (notification.method === "thread/tokenUsage/updated") {
-      tokensAfter =
-        readCodexThreadContextSnapshot(notification.params).activeContextTokens ?? tokensAfter;
+      // The last reliable snapshot wins: an event without a trustworthy
+      // active-context count (missing, zeroed, or non-finite) must not clobber
+      // an already-observed recompute boundary.
+      const snapshot = readCodexThreadContextSnapshot(notification.params);
+      const usageAfter = resolveCodexCompactionContextUsageAfter(snapshot);
+      if (usageAfter !== undefined) {
+        contextUsageAfter = usageAfter;
+      }
       return;
     }
     const item = readCodexNotificationItem(notification.params);
@@ -832,6 +857,7 @@ async function compactCodexNativeThread(
               turnId: completion.turnId,
               itemId: completion.itemId,
               timestamp: Date.now(),
+              usageAfter: completion.contextUsageAfter,
             });
           }
           assertCurrent();

--- a/extensions/codex/src/app-server/context-compaction-activity.test.ts
+++ b/extensions/codex/src/app-server/context-compaction-activity.test.ts
@@ -66,4 +66,93 @@ describe("persistCodexContextCompactionActivity", () => {
       },
     });
   });
+
+  it("records an available post-compaction usage boundary when the app-server reported a count", async () => {
+    appendMessage.mockImplementationOnce(async (params: { message: unknown }) => ({
+      appended: true,
+      message: params.message,
+      messageId: "activity-message",
+    }));
+    const params = {
+      runId: "run-1",
+      sessionTarget: {
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:dashboard:session-1",
+        storePath: "/state/openclaw-agent.sqlite",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "compact-1",
+      timestamp: 123,
+      usageAfter: { state: "available", promptTokens: 80, totalTokens: 100 },
+    } as Parameters<typeof persistCodexContextCompactionActivity>[0];
+
+    await persistCodexContextCompactionActivity(params);
+
+    expect(appendMessage.mock.calls[0]?.[0]?.message).toMatchObject({
+      role: "custom",
+      customType: "openclaw.context-compaction",
+      usage: {
+        contextUsage: { state: "available", promptTokens: 80, totalTokens: 100 },
+      },
+    });
+  });
+
+  it("records an explicit unavailable boundary when the post-compaction count is unknown", async () => {
+    appendMessage.mockImplementationOnce(async (params: { message: unknown }) => ({
+      appended: true,
+      message: params.message,
+      messageId: "activity-message",
+    }));
+    const params = {
+      sessionTarget: {
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:dashboard:session-1",
+        storePath: "/state/openclaw-agent.sqlite",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "compact-1",
+      timestamp: 123,
+      usageAfter: { state: "unavailable" },
+    } as Parameters<typeof persistCodexContextCompactionActivity>[0];
+
+    await persistCodexContextCompactionActivity(params);
+
+    expect(appendMessage.mock.calls[0]?.[0]?.message).toMatchObject({
+      role: "custom",
+      customType: "openclaw.context-compaction",
+      usage: {
+        contextUsage: { state: "unavailable" },
+      },
+    });
+  });
+
+  it("omits the usage boundary when none was supplied", async () => {
+    appendMessage.mockImplementationOnce(async (params: { message: unknown }) => ({
+      appended: true,
+      message: params.message,
+      messageId: "activity-message",
+    }));
+    const params = {
+      sessionTarget: {
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:dashboard:session-1",
+        storePath: "/state/openclaw-agent.sqlite",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "compact-1",
+      timestamp: 123,
+    } as Parameters<typeof persistCodexContextCompactionActivity>[0];
+
+    await persistCodexContextCompactionActivity(params);
+
+    const message = appendMessage.mock.calls[0]?.[0]?.message as Record<string, unknown>;
+    expect(message.role).toBe("custom");
+    expect(message).not.toHaveProperty("usage");
+  });
 });

--- a/extensions/codex/src/app-server/context-compaction-activity.ts
+++ b/extensions/codex/src/app-server/context-compaction-activity.ts
@@ -10,6 +10,19 @@ import {
 
 const CONTEXT_COMPACTION_CUSTOM_TYPE = "openclaw.context-compaction";
 
+/**
+ * Post-compaction context accounting observed by the native compaction producer.
+ *
+ * `available` records a reliable app-server snapshot (contextUsage is the
+ * transcript boundary readers already understand); `unavailable` explicitly
+ * marks usage as unknown so transcript fallback cannot resurrect the stale
+ * pre-compaction count. Billing history is unaffected: this representation
+ * carries no input/output/cache/cost buckets.
+ */
+export type CodexCompactionUsageAfter =
+  | { state: "available"; promptTokens: number; totalTokens: number }
+  | { state: "unavailable" };
+
 export async function persistCodexContextCompactionActivity(params: {
   sessionTarget?: EmbeddedRunAttemptParams["sessionTarget"];
   config?: EmbeddedRunAttemptParams["config"];
@@ -19,6 +32,8 @@ export async function persistCodexContextCompactionActivity(params: {
   turnId: string;
   itemId: string;
   timestamp: number;
+  /** Post-compaction context usage; omitted only when no accounting boundary is needed. */
+  usageAfter?: CodexCompactionUsageAfter;
 }): Promise<void> {
   const target = params.sessionTarget;
   if (!target?.sessionId || !target.sessionKey || !target.storePath) {
@@ -39,6 +54,10 @@ export async function persistCodexContextCompactionActivity(params: {
       itemId: params.itemId,
       ...(params.runId ? { runId: params.runId } : {}),
     },
+    // Carried in the normalized usage shape so transcript-derived readers treat
+    // this marker as an accounting boundary (available replaces the context
+    // count, unavailable clears it until a later valid snapshot).
+    ...(params.usageAfter ? { usage: { contextUsage: params.usageAfter } } : {}),
     __openclaw: { itemId: params.itemId, ...(params.runId ? { runId: params.runId } : {}) },
     timestamp: params.timestamp,
     idempotencyKey: activityId,

--- a/extensions/codex/src/app-server/event-projector-usage.ts
+++ b/extensions/codex/src/app-server/event-projector-usage.ts
@@ -3,6 +3,7 @@ import {
   asSafeIntegerInRange,
   readStringField as readString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { CodexCompactionUsageAfter } from "./context-compaction-activity.js";
 import { isJsonObject, type JsonObject } from "./protocol.js";
 
 function readTokenCount(record: JsonObject, key: string): number | undefined {
@@ -43,6 +44,48 @@ export function readCodexThreadContextSnapshot(params: JsonObject): {
     ...(modelContextWindow && modelContextWindow > 0 ? { modelContextWindow } : {}),
     ...(inputTokens !== undefined ? { promptTokens: inputTokens } : {}),
     ...(reasoningOutputTokens !== undefined ? { reasoningOutputTokens } : {}),
+  };
+}
+
+/**
+ * Resolves the post-compaction usage boundary from a codex thread context
+ * snapshot. Returns `undefined` only when the snapshot carries no reliable
+ * active-context count (callers then record explicit `unavailable`).
+ *
+ * Codex recomputes usage when a compaction item completes: the app-server
+ * zeroes the input/output split (`inputTokens: 0`, `outputTokens: 0`) and
+ * reports the estimated compacted context size in `totalTokens`. A zero prompt
+ * count is not a real prompt-side measurement, so it is discarded and the
+ * recomputed active-context total is recorded as the prompt side instead.
+ * Recording zero verbatim would make downstream readers reject the boundary
+ * (they require a positive prompt count) and leave the stale pre-compaction
+ * total marked fresh in transcript fallback.
+ */
+export function resolveCodexCompactionContextUsageAfter(
+  snapshot: Pick<
+    ReturnType<typeof readCodexThreadContextSnapshot>,
+    "activeContextTokens" | "promptTokens"
+  >,
+): CodexCompactionUsageAfter | undefined {
+  const totalTokens = snapshot.activeContextTokens;
+  if (typeof totalTokens !== "number" || !Number.isFinite(totalTokens) || totalTokens <= 0) {
+    return undefined;
+  }
+  const promptTokens = snapshot.promptTokens;
+  const hasCoherentPrompt =
+    typeof promptTokens === "number" &&
+    Number.isFinite(promptTokens) &&
+    promptTokens > 0 &&
+    promptTokens <= totalTokens;
+  return {
+    state: "available" as const,
+    // Prefer the provider-reported prompt side; fall back to the active-context
+    // total when the breakdown omits input tokens or zeroes them during the
+    // compaction recompute. Either value is a genuine post-compaction snapshot
+    // and strictly better than stale pre-compaction usage in transcript
+    // fallback.
+    promptTokens: Math.floor(hasCoherentPrompt ? promptTokens : totalTokens),
+    totalTokens: Math.floor(totalTokens),
   };
 }
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -8,7 +8,10 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { readStringField as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
-import { persistCodexContextCompactionActivity } from "./context-compaction-activity.js";
+import {
+  persistCodexContextCompactionActivity,
+  type CodexCompactionUsageAfter,
+} from "./context-compaction-activity.js";
 import { CodexAssistantProjection } from "./event-projector-assistant.js";
 import { CodexAsyncDeliveryProjection } from "./event-projector-async-delivery.js";
 import { CodexProjectionDiagnostics } from "./event-projector-diagnostics.js";
@@ -31,7 +34,10 @@ import { buildCodexSteeringMessagesSnapshot } from "./event-projector-snapshot.j
 import { CodexTerminalFailureProjection } from "./event-projector-terminal-failure.js";
 import { CodexToolProgressProjection } from "./event-projector-tool-progress.js";
 import { CodexToolTranscriptProjection } from "./event-projector-tool-transcript.js";
-import { CodexUsageProjection } from "./event-projector-usage.js";
+import {
+  CodexUsageProjection,
+  resolveCodexCompactionContextUsageAfter,
+} from "./event-projector-usage.js";
 import { readCodexErrorNotificationMessage, readItem } from "./event-projector-values.js";
 import type { CodexNativePreToolUseFailure } from "./native-hook-relay.js";
 import {
@@ -76,6 +82,7 @@ export class CodexAppServerEventProjector {
   private contextTokensSource: "runtime" | "runtime-configured" | "resolved" | undefined;
   private readonly usageProjection = new CodexUsageProjection();
   private completedCompactionCount = 0;
+  private compactionWindowContextUsageAfter: CodexCompactionUsageAfter | undefined;
   private pendingSteeringAssistantBoundaryItemId: string | undefined;
 
   constructor(
@@ -291,6 +298,11 @@ export class CodexAppServerEventProjector {
         break;
       case "thread/tokenUsage/updated": {
         const data = this.usageProjection.recordThread(params);
+        if (this.isCompacting()) {
+          const usageAfter = resolveCodexCompactionContextUsageAfter(data);
+          this.compactionWindowContextUsageAfter =
+            usageAfter ?? this.compactionWindowContextUsageAfter;
+        }
         if (data.modelContextWindow !== undefined) {
           this.contextTokens = data.modelContextWindow;
           // Retain an authored cap so its removal cannot make a constrained
@@ -453,6 +465,7 @@ export class CodexAppServerEventProjector {
         return;
       }
       this.activeCompactionItemIds.add(itemId);
+      this.compactionWindowContextUsageAfter = undefined;
       const messages = await this.toolTranscriptProjection.readMirroredSessionMessages(
         this.options.runAbortSignal,
       );
@@ -555,6 +568,7 @@ export class CodexAppServerEventProjector {
         turnId: this.turnId,
         itemId,
         timestamp: this.transcriptCheckpoint.nextTimestamp(),
+        usageAfter: this.compactionWindowContextUsageAfter ?? { state: "unavailable" },
       });
       if (!this.isCompactionProjectionActive()) {
         return;

--- a/extensions/codex/src/app-server/event-projector.usage.test.ts
+++ b/extensions/codex/src/app-server/event-projector.usage.test.ts
@@ -4,6 +4,7 @@ import {
   onAgentEvent,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { createAdmittedHostCapabilityTestFixture } from "openclaw/plugin-sdk/plugin-test-runtime";
+import * as compactionActivity from "./context-compaction-activity.js";
 import {
   describe,
   registerCodexEventProjectorTestLifecycle,
@@ -577,5 +578,83 @@ describe("CodexAppServerEventProjector usage projection", () => {
 
     expect(result.assistantTexts).toEqual(["OK from raw"]);
     expect(result.lastAssistant?.content).toEqual([{ type: "text", text: "OK from raw" }]);
+  });
+
+  it("records an unavailable usage boundary after automatic compaction without a post-compaction count", async () => {
+    const persistActivity = vi.spyOn(compactionActivity, "persistCodexContextCompactionActivity");
+    try {
+      const projector = await createProjector();
+      const compaction = { item: { type: "contextCompaction", id: "compact-auto-1" } };
+      await projector.handleNotification(forCurrentTurn("item/started", compaction));
+      await projector.handleNotification(forCurrentTurn("item/completed", compaction));
+
+      expect(persistActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          itemId: "compact-auto-1",
+          usageAfter: { state: "unavailable" },
+        }),
+      );
+    } finally {
+      persistActivity.mockRestore();
+    }
+  });
+
+  it("records the app-server's available count observed during automatic compaction", async () => {
+    const persistActivity = vi.spyOn(compactionActivity, "persistCodexContextCompactionActivity");
+    try {
+      const projector = await createProjector();
+      const compaction = { item: { type: "contextCompaction", id: "compact-auto-2" } };
+      await projector.handleNotification(forCurrentTurn("item/started", compaction));
+      await projector.handleNotification(
+        forCurrentTurn("thread/tokenUsage/updated", {
+          tokenUsage: {
+            last: {
+              totalTokens: 2_000,
+              inputTokens: 1_800,
+              outputTokens: 200,
+              cachedInputTokens: 300,
+            },
+          },
+        }),
+      );
+      await projector.handleNotification(forCurrentTurn("item/completed", compaction));
+
+      expect(persistActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          itemId: "compact-auto-2",
+          usageAfter: { state: "available", promptTokens: 1_800, totalTokens: 2_000 },
+        }),
+      );
+    } finally {
+      persistActivity.mockRestore();
+    }
+  });
+
+  it("records the recomputed context total after automatic compaction reports a zero-input recompute", async () => {
+    const persistActivity = vi.spyOn(compactionActivity, "persistCodexContextCompactionActivity");
+    try {
+      const projector = await createProjector();
+      const compaction = { item: { type: "contextCompaction", id: "compact-auto-3" } };
+      await projector.handleNotification(forCurrentTurn("item/started", compaction));
+      await projector.handleNotification(
+        forCurrentTurn("thread/tokenUsage/updated", {
+          tokenUsage: {
+            last: { inputTokens: 0, outputTokens: 0, totalTokens: 2_500 },
+          },
+        }),
+      );
+      await projector.handleNotification(forCurrentTurn("item/completed", compaction));
+
+      expect(persistActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          itemId: "compact-auto-3",
+          // Codex recompute zeroes the input split; the recomputed context
+          // total must be recorded as the prompt side of the boundary.
+          usageAfter: { state: "available", promptTokens: 2_500, totalTokens: 2_500 },
+        }),
+      );
+    } finally {
+      persistActivity.mockRestore();
+    }
   });
 });

--- a/src/gateway/session-transcript-derived-readers.test.ts
+++ b/src/gateway/session-transcript-derived-readers.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { aggregateSessionTranscriptUsage } from "./session-transcript-derived-readers.js";
+
+const COMPACTION_MARKER_TYPE = "openclaw.context-compaction";
+
+function compactionMarker(usage: unknown): Record<string, unknown> {
+  return {
+    role: "custom",
+    customType: COMPACTION_MARKER_TYPE,
+    content: "Context compacted",
+    display: true,
+    excludeFromContext: true,
+    ...(usage !== undefined ? { usage } : {}),
+  };
+}
+
+function assistantUsage(params: {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  totalTokens?: number;
+  promptTokens?: number;
+}): Record<string, unknown> {
+  const usage = {
+    ...(params.input !== undefined ? { input: params.input } : {}),
+    ...(params.output !== undefined ? { output: params.output } : {}),
+    ...(params.cacheRead !== undefined ? { cacheRead: params.cacheRead } : {}),
+    ...(params.totalTokens !== undefined ? { totalTokens: params.totalTokens } : {}),
+    ...(params.promptTokens !== undefined
+      ? {
+          contextUsage: {
+            state: "available",
+            promptTokens: params.promptTokens,
+            totalTokens: params.totalTokens ?? params.promptTokens,
+          },
+        }
+      : {}),
+  };
+  return {
+    role: "assistant",
+    provider: "openai",
+    model: "codex/gpt-5.4",
+    usage,
+  };
+}
+
+describe("aggregateSessionTranscriptUsage compaction boundary", () => {
+  it("keeps a native compaction marker without a count from resurrecting pre-compaction usage", () => {
+    const aggregate = aggregateSessionTranscriptUsage([
+      assistantUsage({ input: 40_000, output: 10_000, totalTokens: 60_000, promptTokens: 50_000 }),
+      compactionMarker({ contextUsage: { state: "unavailable" } }),
+    ]);
+
+    expect(aggregate?.contextUsage).toEqual({ state: "unavailable" });
+    expect(aggregate?.totalTokens).toBeUndefined();
+    expect(aggregate?.totalTokensFresh).toBeUndefined();
+    // Billing history survives the boundary.
+    expect(aggregate?.inputTokens).toBe(40_000);
+    expect(aggregate?.outputTokens).toBe(10_000);
+  });
+
+  it("records an available post-compaction count supplied by the app-server", () => {
+    const aggregate = aggregateSessionTranscriptUsage([
+      assistantUsage({ input: 40_000, output: 10_000, totalTokens: 60_000, promptTokens: 50_000 }),
+      compactionMarker({
+        contextUsage: { state: "available", promptTokens: 800, totalTokens: 1_000 },
+      }),
+    ]);
+
+    expect(aggregate?.contextUsage).toEqual({
+      state: "available",
+      promptTokens: 800,
+      totalTokens: 1_000,
+    });
+    expect(aggregate?.totalTokens).toBe(800);
+    expect(aggregate?.totalTokensFresh).toBe(true);
+  });
+
+  it("replaces the pre-compaction total with the recomputed context total recorded at the compaction boundary", () => {
+    const aggregate = aggregateSessionTranscriptUsage([
+      assistantUsage({ input: 40_000, output: 10_000, totalTokens: 60_000, promptTokens: 50_000 }),
+      // Producer-normalized recompute payload: Codex reports the estimated
+      // compacted context (1_000) as both sides of an available boundary after
+      // zeroing the input/output split of the recompute snapshot.
+      compactionMarker({
+        contextUsage: { state: "available", promptTokens: 1_000, totalTokens: 1_000 },
+      }),
+    ]);
+
+    expect(aggregate?.contextUsage).toEqual({
+      state: "available",
+      promptTokens: 1_000,
+      totalTokens: 1_000,
+    });
+    // The recomputed post-compaction total replaces the stale fresh count
+    // instead of leaving the pre-compaction 50_000 in place.
+    expect(aggregate?.totalTokens).toBe(1_000);
+    expect(aggregate?.totalTokensFresh).toBe(true);
+    // Billing history survives the boundary.
+    expect(aggregate?.inputTokens).toBe(40_000);
+    expect(aggregate?.outputTokens).toBe(10_000);
+  });
+
+  it("lets a genuinely later valid snapshot restore usage after an unavailable boundary", () => {
+    const aggregate = aggregateSessionTranscriptUsage([
+      assistantUsage({ input: 40_000, output: 10_000, totalTokens: 60_000, promptTokens: 50_000 }),
+      compactionMarker({ contextUsage: { state: "unavailable" } }),
+      assistantUsage({ input: 15_000, output: 2_000, totalTokens: 20_000, promptTokens: 18_000 }),
+    ]);
+
+    expect(aggregate?.contextUsage).toEqual({
+      state: "available",
+      promptTokens: 18_000,
+      totalTokens: 20_000,
+    });
+    expect(aggregate?.totalTokens).toBe(18_000);
+    expect(aggregate?.totalTokensFresh).toBe(true);
+  });
+
+  it("ignores a marker that carries no usage boundary", () => {
+    const aggregate = aggregateSessionTranscriptUsage([
+      assistantUsage({ input: 40_000, output: 10_000, totalTokens: 60_000, promptTokens: 50_000 }),
+      compactionMarker(undefined),
+    ]);
+
+    // Legacy markers without a boundary keep the last pre-compaction snapshot.
+    expect(aggregate?.totalTokens).toBe(50_000);
+    expect(aggregate?.totalTokensFresh).toBe(true);
+  });
+});


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #66263

## What Problem This Solves

Fixes an issue where users running native Codex sessions see misleading context usage after Codex app-server compaction. When the app-server completes compaction without reporting a reliable post-compaction token count, OpenClaw can fall back to stale transcript-derived usage and display the pre-compaction count as current context usage — making compaction look ineffective or reporting confusing context percentages in session status and /status output.

- **Related:** #66251 (parent tracker); cumulative projection tracked separately in #64669; #65503 (observed context inflation).

## Why This Change Was Made

Record the post-compaction usage boundary at the native compaction completion point (the shared manual/automatic compaction activity marker) using the existing normalized usage representation. If the app-server reports a count via `thread/tokenUsage/updated` during the compaction turn/item, the marker carries an `available` contextUsage snapshot that replaces the transcript-derived count. If no count is reported, the marker carries an explicit `unavailable` contextUsage so transcript fallback clears the stale pre-compaction total instead of presenting it as fresh.

Codex recomputes usage when the compaction item completes: the pinned app-server (0.153.4) zeroes the input/output split (`inputTokens: 0`, `outputTokens: 0`) and reports the estimated compacted context size in `totalTokens`. The boundary normalization therefore treats a zero prompt count as an artifact of that recompute and records the recomputed active-context total as the prompt side of the `available` boundary. Keeping zero verbatim would make transcript readers reject the boundary (they require a positive prompt count) and leave the stale pre-compaction total marked fresh after compaction.

- **Intended outcome:** after native compaction, Gateway session rows and transcript-derived usage either show the app-server's post-compaction count or an explicit unknown state — never the pre-compaction count.
- **Out of scope:** cumulative app-server token projection (#64669), UI layout, context-engine compaction paths.
- **Highest-risk area:** automatic compaction projection (event projector) must not attribute a pre-compaction token-usage event to the post-compaction boundary; the manual-compaction watcher must not keep parallel accounting state that can drift.
- **How is that risk mitigated?** only `thread/tokenUsage/updated` events observed while a contextCompaction item is active are treated as the post-compaction recompute; every compaction marker without such an event is written as explicit `unavailable`; the last reliable recompute snapshot wins and drives both the boundary and the outward `tokensAfter` result from one source of truth.

## User Impact

Session status and /status after native Codex compaction no longer show stale pre-compaction context usage as fresh: either the reported post-compaction count is shown, or usage is displayed as unknown until the next valid snapshot. Long-running Codex sessions give reliable signals about whether compaction succeeded and whether the session is safe to continue.

## Evidence

### Real native compaction proof (new in this revision)

A new committed, non-live native regression test (`extensions/codex/src/app-server/compact.native.test.ts`) boots the **real pinned @openai/codex 0.153.4 binary** with an isolated `CODEX_HOME` and a loopback model provider, then drives the **production manual-compaction path** (`maybeCompactCodexAppServerSession` in `compact.ts`) through a real `thread/compact/start`. The app-server performs a real native compaction; the changed watcher consumes the real notification stream and records the boundary.

Observed real run (terminal excerpt):

```text
app-server version: 0.153.4
notification item/started contextCompaction "01a07340-..."
compaction-window thread/tokenUsage/updated {"totalTokens":1010,"inputTokens":1000,...,"outputTokens":10,...}   # pre-compaction snapshot
compaction-window thread/tokenUsage/updated {"totalTokens":5049,"inputTokens":0,...,"outputTokens":0,...}       # codex recompute payload
notification item/completed contextCompaction "01a07340-..."
compact result ok/compacted/tokensAfter: {"ok":true,"compacted":true,"result":{...,"tokensAfter":5049,...}}
persistCodexContextCompactionActivity calls: [{"threadId":"01a07340-...","turnId":"01a07340-...","itemId":"01a07340-...","usageAfter":{"state":"available","promptTokens":5049,"totalTokens":5049}}]
zero-input recompute observed on real stream: {"totalTokens":5049,"inputTokens":0,"outputTokens":0}
expected boundary from real window: {"state":"available","promptTokens":5049,"totalTokens":5049}
```

Hard assertions in the test (all pass): the real stream contains codex's zero-input recompute payload (`inputTokens: 0`, `outputTokens: 0`, positive `totalTokens`); the recorded boundary is `available` with positive `promptTokens`/`totalTokens` (never a zero prompt count); the outward `tokensAfter` equals the persisted boundary total; and the recorded boundary equals `resolveCodexCompactionContextUsageAfter` over the last reliable compaction-window snapshot.

This is **real native execution with synthetic provider responses** (isolated homes + deterministic loopback provider), not an OAuth or external-model-service claim — the same standard as the repo's other non-live real-binary native tests (`thread-lifecycle.native.test.ts`, `settled-turn-finalizer.native.test.ts`; see merged #139228).

- **Real environment tested:** real `codex app-server` 0.153.4 process (pinned `@openai/codex`), isolated `CODEX_HOME`, real thread with seeded context, real `thread/compact/start` native compaction, production watcher/persist code path; model responses served by a loopback provider (`requires_openai_auth=false`, no credentials used).
- **Exact steps or commands run after this patch:**
  ```bash
  # New real-native regression proof (real app-server compaction, 1 test)
  node scripts/run-vitest.mjs run extensions/codex/src/app-server/compact.native.test.ts
  # Existing deterministic behavior tests (aggregate boundary + marker + producers)
  node scripts/run-vitest.mjs run \
    src/gateway/session-transcript-derived-readers.test.ts \
    extensions/codex/src/app-server/context-compaction-activity.test.ts \
    extensions/codex/src/app-server/compact.test.ts \
    extensions/codex/src/app-server/compact.native.test.ts \
    extensions/codex/src/app-server/event-projector.usage.test.ts
  # Type checks
  pnpm tsgo:core && pnpm tsgo:extensions:test
  ```
- **Evidence after fix:**
  ```text
  compact.native.test.ts                1 passed (REAL app-server native compaction)
    - real zero-input recompute payload observed on the real notification stream
    - recorded boundary: available {promptTokens:5049, totalTokens:5049}; tokensAfter:5049
    - recorded boundary == resolve(last real window snapshot); never a zero prompt count
  session-transcript-derived-readers.test.ts  5 passed (compaction boundary x5)
  context-compaction-activity.test.ts         4 passed (usageAfter available/unavailable/omitted)
  compact.test.ts + event-projector.usage.test.ts  85 passed
    - 2 new cases: available/unavailable usage boundary after manual compaction
    - 2 new cases: available/unavailable usage boundary after automatic compaction
    - 2 NEW cases: zero-input recompute payload (inputTokens:0, outputTokens:0,
      totalTokens:>0) through BOTH producers records the recomputed context
      total as the boundary prompt side
  session-transcript-derived-readers.test.ts  1 NEW case: recompute boundary
    replaces the stale pre-compaction total instead of leaving it fresh
  validate.sh (changed files): oxfmt + oxlint + tests + tsgo:core 全部通过
  tsgo:core / tsgo:extensions:test: exit 0
  ```
  Key behavioral assertions covered:
  - `aggregateSessionTranscriptUsage compaction boundary > keeps a native compaction marker without a count from resurrecting pre-compaction usage` — marker with `contextUsage: {state:"unavailable"}` clears `totalTokens`/`totalTokensFresh` while billing (`inputTokens`/`outputTokens`) survives.
  - `... > records an available post-compaction count supplied by the app-server` — marker with an available snapshot sets `totalTokens`/fresh.
  - `... > replaces the pre-compaction total with the recomputed context total recorded at the compaction boundary` — an earlier 50,000-token count is replaced by the recomputed 1,000-token boundary, not left fresh.
  - `... > lets a genuinely later valid snapshot restore usage after an unavailable boundary`.
  - `compact.test.ts > records an available/unavailable usage boundary when the app-server reports [no] post-compaction count` — persisted activity marker receives `usageAfter` derived from the compaction-turn `thread/tokenUsage/updated` event or `{state:"unavailable"}` when absent.
  - `compact.test.ts > records the recomputed context total when the app-server reports a zero-input recompute` — the exact Codex recompute payload (`last: {inputTokens:0, outputTokens:0, totalTokens:1_000}`) is persisted as `{state:"available", promptTokens:1_000, totalTokens:1_000}`. Pre-fix this assertion fails (the marker carried `promptTokens:0`, which transcript readers reject, leaving the stale pre-compaction total fresh); post-fix it passes.
  - `event-projector.usage.test.ts > records the recomputed context total after automatic compaction reports a zero-input recompute` — same payload through the automatic-compaction projection path (RED pre-fix / GREEN post-fix).
  - `compact.native.test.ts` (real binary) — the same normalization is now asserted against the real app-server's own recompute payload.
- **Observed result after fix:** `validate.sh` on all changed files green (oxfmt + oxlint + tests + tsgo:core); `tsgo:extensions:test` exit 0; the real-native test passes against the pinned app-server binary; the two zero-input recompute producer tests were run RED against the pre-fix helper (observed `promptTokens: 0` in the persisted boundary) and pass GREEN after the fix.
- **Before evidence:** prior to this change the compaction activity marker carried no usage field, so `aggregateSessionTranscriptUsage` retained the last pre-compaction assistant total through the marker and Gateway session rows presented it as fresh (`totalTokensFresh: true`) after compaction without a reported count. The first review revision additionally accepted Codex's recompute `promptTokens: 0` verbatim, so the boundary did not replace the stale total either. On a real app-server the recompute payload is exactly the zero-input shape this revision normalizes (observed in the native run above: `inputTokens:0, outputTokens:0, totalTokens:5049`).
- **What was not tested:** an external live model service / OAuth-backed Codex session (no credentials in this environment); the model provider is a loopback OpenAI-compatible stub. Gateway transcript-aggregation semantics over the recorded marker are deterministic and covered by the included derived-reader cases, which consume the exact marker shape the real run produces (`custom` `openclaw.context-compaction` message with `usage.contextUsage: {state:"available", promptTokens, totalTokens}`).
- **Proof tier:** L2 (real app-server binary + real native compaction + production producer code path; model responses synthetic via loopback provider, per repo native-test convention). Deterministic unit/integration coverage retained for aggregation semantics.
- **Proof limitations:** no live external-model session; the real native run proves producer-side behavior (recording the recomputed boundary) on the actual app-server, and the reader cases prove the aggregation consequence for that exact boundary.
- **Review state:** Awaiting CI + review (this revision adds the real native compaction proof requested in the last ClawSweeper review cycle; live-session proof against an external model service is out of reach in this environment and is left to CI/maintainer review).
