### PR TITLE
test(ui): wait for the selected catalog pane before checking authors

### DIFF
--- a/ui/src/e2e/external-session-catalogs.e2e.test.ts
+++ b/ui/src/e2e/external-session-catalogs.e2e.test.ts
@@ -100,6 +100,17 @@ suite.define(() => {
         await page.goto(`${suite.server.baseUrl}chat`);
         for (const catalogId of catalogIds) {
           await page.getByText(`${catalogId} shared transcript`, { exact: true }).click();
+          // Every catalog has the same transcript; wait for the clicked pane before reading it.
+          await page.waitForFunction(
+            (expectedSessionKey) =>
+              [
+                ...document.querySelectorAll("openclaw-chat-pane.chat-pane-cache__pane--visible"),
+              ].some(
+                (pane) =>
+                  (pane as HTMLElement & { sessionKey?: string }).sessionKey === expectedSessionKey,
+              ),
+            `agent:main:catalog:${catalogId}:gateway:shared`,
+          );
           const pane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible");
           const message = pane
             .locator(".chat-group.user")


### PR DESCRIPTION
## What Problem This Solves

The external-catalog author E2E selects three retained panes that contain identical transcript text and avatar bytes. Waiting for that shared content alone does not establish that navigation reached the selected catalog.

## Why This Change Was Made

Wait for the intended visible pane's session key before reading its transcript, following the existing `navigateToControlUiSession` readiness contract. All author, avatar, unknown-author, and Activity-link assertions remain intact. No timeout, retry, or production behavior changes.

## User Impact

Test-only readiness cleanup: the checks explicitly inspect the requested external transcript.

## Evidence

Related: #138900. Its [original UI shard failure](https://github.com/openclaw/openclaw/actions/runs/33981558251/job/101347667007) observed zero uploader-profile links during a Beam-to-Claude switch. The exact CI interleaving was not reproduced locally; this PR does not claim a product defect or conclusively explain that failure.

The unchanged local Riley/Morgan cases reported passes, but their runner later exited through its existing no-output watchdog. A separate browser replay against the unchanged production UI passed 30 original and 30 synchronized navigation/assertion sets under CPU throttling. Formatting and independent Codex review passed. Current-head CI remains the clean full-run gate.

Production delta: 0. Test delta: +11 lines.
