### PR TITLE
perf(plugins): prepare provider endpoint classes once

### DIFF
--- a/src/plugins/plugin-metadata-provider-facts.ts
+++ b/src/plugins/plugin-metadata-provider-facts.ts
@@ -46,31 +46,31 @@ function prepareProviderEndpoints(value: unknown): PluginManifestProviderEndpoin
   if (!Array.isArray(value)) {
     return [];
   }
-  return value
-    .filter(isRecord)
-    .filter((endpoint) => {
-      const endpointClass = normalizeOptionalString(endpoint.endpointClass);
-      return endpointClass ? PROVIDER_ENDPOINT_CLASSES.has(endpointClass) : false;
-    })
-    .map((endpoint) => {
-      const endpointClass = normalizeOptionalString(endpoint.endpointClass)!;
-      const googleVertexRegion = normalizeOptionalString(endpoint.googleVertexRegion);
-      const googleVertexRegionHostSuffix = normalizeOptionalString(
-        endpoint.googleVertexRegionHostSuffix,
-      )?.toLowerCase();
-      return Object.assign(
-        {
-          endpointClass,
-          hosts: normalizeProviderHosts(endpoint.hosts),
-          hostSuffixes: normalizeProviderHosts(endpoint.hostSuffixes),
-          baseUrls: normalizeProviderHosts(endpoint.baseUrls)
-            .map(normalizePluginProviderBaseUrl)
-            .filter((baseUrl): baseUrl is string => baseUrl !== undefined),
-        },
-        googleVertexRegion ? { googleVertexRegion } : {},
-        googleVertexRegionHostSuffix ? { googleVertexRegionHostSuffix } : {},
-      );
+  const endpoints: PluginManifestProviderEndpoint[] = [];
+  for (const endpoint of value) {
+    if (!isRecord(endpoint)) {
+      continue;
+    }
+    const endpointClass = normalizeOptionalString(endpoint.endpointClass);
+    if (!endpointClass || !PROVIDER_ENDPOINT_CLASSES.has(endpointClass)) {
+      continue;
+    }
+    const googleVertexRegion = normalizeOptionalString(endpoint.googleVertexRegion);
+    const googleVertexRegionHostSuffix = normalizeOptionalString(
+      endpoint.googleVertexRegionHostSuffix,
+    )?.toLowerCase();
+    endpoints.push({
+      endpointClass,
+      hosts: normalizeProviderHosts(endpoint.hosts),
+      hostSuffixes: normalizeProviderHosts(endpoint.hostSuffixes),
+      baseUrls: normalizeProviderHosts(endpoint.baseUrls)
+        .map(normalizePluginProviderBaseUrl)
+        .filter((baseUrl): baseUrl is string => baseUrl !== undefined),
+      ...(googleVertexRegion ? { googleVertexRegion } : {}),
+      ...(googleVertexRegionHostSuffix ? { googleVertexRegionHostSuffix } : {}),
     });
+  }
+  return endpoints;
 }
 
 const PROVIDER_AUTH_ALIAS_ORIGIN_PRIORITY: Readonly<Record<PluginOrigin, number>> = {

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeTempDir } from "../../test/helpers/temp-dir.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection-config.js";
 import { buildConfiguredModelCatalog } from "../agents/model-selection-shared.js";
+import {
+  resolveProviderEndpoint,
+  resolveProviderRequestPolicy,
+} from "../agents/provider-attribution.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
@@ -842,18 +846,43 @@ describe("plugin metadata snapshot", () => {
     const index = makeIndex();
     const registry = makeManifestRegistry();
     const plugin = registry.plugins[0];
-    if (!plugin) {
+    const [other] = makeManifestRegistry("other").plugins;
+    if (!plugin || !other) {
       throw new Error("expected manifest plugin fixture");
     }
     plugin.cliBackends = ["DEMO-CLI"];
     plugin.setup = { cliBackends: ["Demo-CLI", "Other-CLI"] };
     plugin.providerEndpoints = [
       {
-        endpointClass: "openai-public",
-        hosts: [" API.EXAMPLE.COM "],
-        baseUrls: ["https://api.example.com/v1/"],
+        endpointClass: " openai-public ",
+        hosts: [" API.EXAMPLE.COM ", "api.example.com", " "],
+        hostSuffixes: [" .API.EXAMPLE.COM "],
+        baseUrls: [
+          "HTTPS://ROUTE.EXAMPLE.COM/V1/?debug=1#tail",
+          "route.example.com/v1/",
+          "ftp://invalid.example.com",
+          " ",
+        ],
+      },
+      { endpointClass: " ", hosts: ["ignored.example.com"] },
+      { endpointClass: "future-endpoint", hosts: ["ignored.example.com"] },
+      {
+        endpointClass: "google-vertex",
+        hostSuffixes: ["-VERTEX.EXAMPLE.COM"],
+        googleVertexRegionHostSuffix: " -VERTEX.EXAMPLE.COM ",
+      },
+      {
+        endpointClass: "google-vertex",
+        hosts: ["GLOBAL.VERTEX.EXAMPLE.COM"],
+        googleVertexRegion: " GLOBAL ",
       },
     ];
+    other.providerEndpoints = [{ endpointClass: "azure-openai", hosts: ["api.example.com"] }];
+    registry.plugins.push(other);
+    index.plugins = [...index.plugins, ...makeIndex("other").plugins];
+    const sourceEndpoints = structuredClone(
+      registry.plugins.map((entry) => entry.providerEndpoints),
+    );
     plugin.providerRequest = {
       providers: {
         demo: {
@@ -876,11 +905,72 @@ describe("plugin metadata snapshot", () => {
       ["demo-cli", ["demo"]],
       ["other-cli", ["demo"]],
     ]);
-    expect(snapshot.owners.providerEndpoints).toContainEqual({
-      endpointClass: "openai-public",
-      hosts: ["api.example.com"],
-      hostSuffixes: [],
-      baseUrls: ["https://api.example.com/v1"],
+    expect(snapshot.owners.providerEndpoints?.slice(0, 4)).toEqual([
+      {
+        endpointClass: "openai-public",
+        hosts: ["api.example.com", "api.example.com"],
+        hostSuffixes: [".api.example.com"],
+        baseUrls: ["https://route.example.com/v1", "https://route.example.com/v1"],
+      },
+      {
+        endpointClass: "google-vertex",
+        hosts: [],
+        hostSuffixes: ["-vertex.example.com"],
+        baseUrls: [],
+        googleVertexRegionHostSuffix: "-vertex.example.com",
+      },
+      {
+        endpointClass: "google-vertex",
+        hosts: ["global.vertex.example.com"],
+        hostSuffixes: [],
+        baseUrls: [],
+        googleVertexRegion: "GLOBAL",
+      },
+      {
+        endpointClass: "azure-openai",
+        hosts: ["api.example.com"],
+        hostSuffixes: [],
+        baseUrls: [],
+      },
+    ]);
+    expect(registry.plugins.map((entry) => entry.providerEndpoints)).toEqual(sourceEndpoints);
+    for (const baseUrl of ["https://api.example.com", "https://route.example.com/v1?query=1"]) {
+      expect(
+        resolveProviderRequestPolicy({
+          provider: "openai",
+          baseUrl,
+          providerMetadataOwners: snapshot.owners,
+        }),
+      ).toMatchObject({
+        endpointClass: "openai-public",
+        usesKnownNativeOpenAIEndpoint: true,
+        usesExplicitProxyLikeEndpoint: false,
+        attributionHeaders: { originator: "openclaw" },
+      });
+    }
+    expect(
+      resolveProviderEndpoint("https://us-central1-vertex.example.com", snapshot.owners),
+    ).toEqual({
+      endpointClass: "google-vertex",
+      hostname: "us-central1-vertex.example.com",
+      googleVertexRegion: "us-central1",
+    });
+    expect(resolveProviderEndpoint("https://global.vertex.example.com", snapshot.owners)).toEqual({
+      endpointClass: "google-vertex",
+      hostname: "global.vertex.example.com",
+      googleVertexRegion: "GLOBAL",
+    });
+    expect(
+      resolveProviderRequestPolicy({
+        provider: "openai",
+        baseUrl: "https://ignored.example.com",
+        providerMetadataOwners: snapshot.owners,
+      }),
+    ).toMatchObject({
+      endpointClass: "custom",
+      usesKnownNativeOpenAIEndpoint: false,
+      usesExplicitProxyLikeEndpoint: true,
+      attributionHeaders: undefined,
     });
     expect(snapshot.owners.providerRequests?.get("demo")).toEqual({
       family: "demo-family",


### PR DESCRIPTION
## What Problem This Solves

Preparing provider metadata repeatedly filters endpoint declarations and normalizes each accepted endpoint class twice. Snapshot construction and rebasing pay that redundant work before request-policy readers can use the prepared facts.

## Why This Change Was Made

Use one preparation loop and carry its accepted class into the fresh endpoint record. Keep installed declarations before official fallbacks, first-match precedence, duplicates, URL normalization, optional Vertex fields, source nonmutation, and snapshot ownership unchanged.

Production is net zero (+24/−24). The existing snapshot preservation case is expanded (+99/−9 test lines) to exercise actual endpoint and request-policy readers; no production test seam, configuration, public API, or dependency change is added.

## User Impact

No intended change to provider classification or request policy. This simplifies endpoint preparation and improves some measured component workloads. It does not establish a universal speedup, retained-memory improvement, or faster full Gateway turns.

## Evidence

On base `426ca0d50f303c7cbec46741be7ff51e99145a18`, all 255 cases in six complete owner/sibling files passed, the full 29-stage changed-file gate passed, and a normal build with maps passed. The first gate was interrupted after the supervisor's fixed one-second process census timed out; it did not report a compiler defect. The unchanged-command retry and original failure are retained separately.

The actual built metadata flow passed 17 initial and 14 projected endpoint oracles and all nine endpoint/policy readers. That runs the real manifest→index→snapshot→projection boundary, with an entry fixture that would fail if plugin runtime were eagerly executed. It is built correctness proof, not network or timing proof. Four-pass independent managed Codex review found no actionable P0–P2 defects.

The historical fixed both-order cohort retains 3,180 calls, 384 batch means, 246 comparisons and all 97 adverse observations. The small endpoint row's median improved 13.70%/13.42%. Other rows were mixed, including positive/negative order reversals; several maximum-batch tails worsened, and forward kernel peak RSS rose 19.05%. The p95 of sixteen batch means is their maximum, not an individual-request tail estimate. No numeric cutoff was preset; correctness/resource success is not a universal performance pass. Old readonly-test and forecast-reader corrections remain documented, with no favorable-data reruns.

Two isolated real OpenAI Gateway probes were also run with Node profiles. **Both scenarios failed their complete task contracts.** The first completed calculation and recall, then fetched the requested web page with HTTP 200 but paraphrased the required heading; two remaining turns were not run. The separate write/recall probe wrote and read the exact 45-byte content at `report.json` instead of the required `out/report.json`, then recalled that wrong path. A `SAVED` response is not counted as success of the requested write. These are separate observations, not a combined passing scenario.

Across those partial runs, all ten provider requests returned HTTP 200 SSE; tool events match durable results. All tracked processes closed, both loopback ports refused connections and rebound, and post-run source/build binding matched. Profiles retain idle/unmapped frames and hit-count mismatches. There is no paired live speedup claim or evidence tying the model's output-adherence failures to this endpoint refactor.

```sh
node scripts/run-vitest.mjs src/plugins/plugin-metadata-snapshot.test.ts src/plugins/official-external-provider-endpoints.test.ts src/plugins/manifest-registry.test.ts src/agents/provider-attribution.test.ts src/agents/provider-attribution.catalog-endpoints.test.ts src/agents/provider-request-config.test.ts
pnpm check:changed --timed -- src/plugins/plugin-metadata-provider-facts.ts src/plugins/plugin-metadata-snapshot.test.ts
node --import ./scripts/tsx.mjs scripts/build-all.mts
```

Historical timings stay bound to their original source/install graph; they were not relabeled as new-base measurements. Current-main comparison found no competing changes in the touched owner/snapshot/normalizer paths. Build warnings and missing maps on the actual AI package transport remain explicit limitations; worker maps are not substituted for those modules.
