### PR TITLE
refactor(test): reuse the container spawn-call assertion helper

### DIFF
--- a/src/cli/container-target.test.ts
+++ b/src/cli/container-target.test.ts
@@ -1,22 +1,12 @@
 // Container target tests cover CLI container target parsing and validation.
 import type { spawnSync as nodeSpawnSync } from "node:child_process";
 import { describe, expect, it, vi } from "vitest";
+import { mockCall } from "../test-utils/mock-call-assertions.js";
 import {
   maybeRunCliInContainer,
   parseCliContainerArgs,
   resolveCliContainerTarget,
 } from "./container-target.js";
-
-function requireSpawnCall(
-  spawnSync: ReturnType<typeof vi.fn>,
-  index: number,
-): [string, string[], unknown?] {
-  const call = spawnSync.mock.calls[index];
-  if (!call) {
-    throw new Error(`Expected spawnSync call ${index}`);
-  }
-  return call as [string, string[], unknown?];
-}
 
 type SpawnResult = {
   status: number | null;
@@ -354,7 +344,7 @@ describe("maybeRunCliInContainer", () => {
       spawnSync,
     });
 
-    const podmanCall = requireSpawnCall(spawnSync, 2);
+    const podmanCall = mockCall(spawnSync, 2);
     expect(podmanCall[0]).toBe("podman");
     expect(podmanCall[1]).toContain("OPENCLAW_PROXY_URL=http://127.0.0.1:3128");
     if (podmanCall[2] === undefined) {


### PR DESCRIPTION
## What Problem This Solves

The container CLI tests duplicate the shared mock-call assertion helper with a local tuple cast. This maintainer-requested test cleanup removes that duplicate without removing coverage.

## Why This Change Was Made

Use the existing `mockCall(spawnSync, 2)` helper to inspect the third invocation. A missing call still fails immediately, and the existing options-presence check and all payload assertions remain. The shared helper returns unknown values instead of asserting an unchecked tuple shape.

## User Impact

No user-visible behavior changes. Production code is unchanged; the test diff is +2/-12 lines. All 37 test cases and 44 expectations remain, including call ordering, TTY/environment handling, proxy credential redaction, exit/signal handling, and the no-sudo checks.

## Evidence

- The complete `src/cli/container-target.test.ts` suite passed before and after the change: 37/37 each, with identical ordered case inventory.
- `node scripts/check-changed.mjs --base 3d129595202d65d60a363dec093f20861fb2bcf3 -- src/cli/container-target.test.ts` passed all 20 selected checks, including the core test type graph, lint, and all three dead-export scans.
- Managed read-only Codex review completed both passes with no actionable P0-P2 findings; the reviewed source remained unchanged.

An independently observed unused sudo-probe branch in production is excluded from this test-only change and remains a separate follow-up.
