### PR TITLE
fix(infra): arm worker pool idle retirement on the pool's own clock

### DIFF
--- a/src/infra/worker-task-pool.test.ts
+++ b/src/infra/worker-task-pool.test.ts
@@ -227,6 +227,23 @@ describe("worker task pool", () => {
     expect(next.threadId).not.toBe(result.threadId);
   });
 
+  it("arms idle retirement on the clock the pool was created under", async () => {
+    const pool = createPool({ workerUrl, idleTimeoutMs: 20 });
+    await pool.run({ label: "warm" }, { timeoutMs: 10_000 });
+    // Process-wide pools finish work on worker messages, which can arrive inside an
+    // unrelated test's fake-timer window; that clock must not receive the idle timer.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      await pool.run({ label: "under a fake clock" }, {});
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+    const worker = workers.at(-1);
+    assert.ok(worker);
+    await expect.poll(() => worker.threadId).toBe(-1);
+  });
+
   it("lets a headless process exit while warm workers are idle", async () => {
     const moduleUrl = new URL("./worker-task-pool.ts", import.meta.url);
     const { stdout } = await promisify(execFile)(

--- a/src/infra/worker-task-pool.ts
+++ b/src/infra/worker-task-pool.ts
@@ -44,6 +44,12 @@ export class WorkerTaskPool<Input, Output> {
   private readonly queue: Task<Input, Output>[] = [];
   private readonly maxWorkers: number;
   private closedError?: Error;
+  // Idle retirement is armed from worker messages, outside any caller's turn.
+  // Bind the clock at construction so a process-wide pool cannot land that timer
+  // on a fake or stubbed setTimeout an unrelated test installed later; on the
+  // wrong clock the worker never retires and that test's timer count is off.
+  private readonly setTimeoutFn = setTimeout;
+  private readonly clearTimeoutFn = clearTimeout;
 
   constructor(
     private readonly options: {
@@ -111,7 +117,7 @@ export class WorkerTaskPool<Input, Output> {
         slot = {};
         this.slots.add(slot);
       }
-      clearTimeout(slot.idleTimer);
+      this.clearTimeoutFn(slot.idleTimer);
       const task = this.queue.shift()!;
       slot.task = task;
       task.slot = slot;
@@ -246,13 +252,13 @@ export class WorkerTaskPool<Input, Output> {
     slot.worker?.unref();
     const idleMs = this.options.idleTimeoutMs ?? 60_000;
     if (idleMs > 0) {
-      slot.idleTimer = setTimeout(() => void this.retire(slot), idleMs);
+      slot.idleTimer = this.setTimeoutFn(() => void this.retire(slot), idleMs);
       slot.idleTimer.unref();
     }
   }
 
   private retire(slot: Slot<Input, Output>): Promise<void> {
-    clearTimeout(slot.idleTimer);
+    this.clearTimeoutFn(slot.idleTimer);
     // Retain error listeners until exit: termination can race a worker startup error.
     return (slot.retiring ??= (slot.worker?.terminate() ?? Promise.resolve()).then(() => {
       slot.worker?.removeAllListeners();


### PR DESCRIPTION
## What Problem This Solves

`src/gateway/session-observer.digest-budget.test.ts` fails on `main` in the `checks-node-compact-small-9` shard (`agentic-control-plane-runtime`, project `gateway-server`) with no code change to the session observer:

```
FAIL   gateway-server  src/gateway/session-observer.digest-budget.test.ts > session observer digest budget > disables model work when digest persistence reports a missing entry
AssertionError: expected 1 to be +0 // Object.is equality
 ❯ src/gateway/session-observer.digest-budget.test.ts:119:32
    119|     expect(vi.getTimerCount()).toBe(0);
```

Three red `main` runs today, all attempt 1, all in the same shard, between green runs on adjacent commits:

- https://github.com/openclaw/openclaw/actions/runs/33945439487/job/101250620098 (04:45 UTC, head `3a3b8538a3`)
- https://github.com/openclaw/openclaw/actions/runs/33966647789/job/101307929767 (12:39 UTC, head `994ae0c767`)
- https://github.com/openclaw/openclaw/actions/runs/33972415383/job/101323779982 (14:38 UTC, head `2f5f5de32d`)

Fork PRs hit the same assertion in `checks-node-compact-small-18`. None of the 60 failed `main` runs from 2026-09-04 contain this failure; it starts after #138669 (2026-09-05 02:10 UTC) added the process-wide session disk-budget measurement pool.

The leftover timer is not the session observer's. The observer's `MODEL_TIMEOUT_MS` abort timer is cleared in the completion's `finally` before `persistDigest` runs, and line 118 (`expect(persistDigest).toHaveBeenCalledOnce()`) passes in every failing log. The timer is `WorkerTaskPool.idle()` arming its 60 s idle-retire timer (`src/infra/worker-task-pool.ts:249`) for the session disk-budget worker (`src/config/sessions/disk-budget-runtime.ts`), reached through a worker-thread `message` event:

```
at WorkerTaskPool.idle (src/infra/worker-task-pool.ts:249:24)
at WorkerTaskPool.finish (src/infra/worker-task-pool.ts:237:14)
at WorkerTaskPool.receive (src/infra/worker-task-pool.ts:190:10)
at Worker.<anonymous> (src/infra/worker-task-pool.ts:148:57)
at Worker.emit (node:events:509:28)
at MessagePort.<anonymous> (node:internal/worker:350:14)
```

Trigger chain: `test-helpers.server-rpc.test.ts` (the file that runs immediately before `session-observer.digest-budget.test.ts` in this bin, in the same non-isolated worker: `isolate: false`, `fileParallelism: false`) writes session entries; `kickSessionEntryMaintenanceAfterWrite` schedules `runPendingMaintenance` with `setImmediate` (fire-and-forget); `enforceSessionDiskBudget` calls `measureSessionPhysicalDiskUsage`, which runs on the process-wide `WorkerTaskPool`. The worker's completion message arrives after that file finished, while the digest-budget test has `vi.useFakeTimers()` installed, so `idle()` calls the fake `setTimeout` and the idle timer lands on the test's fake clock. `vi.useRealTimers()` then discards it, so the worker also never retires.

## Why This Change Was Made

`WorkerTaskPool` now binds `setTimeout`/`clearTimeout` at construction and uses them for the idle timer (armed in `idle()`, cleared in `dispatch()` and `retire()`). Idle retirement is the pool's own lifecycle resource and fires from worker messages outside any caller's turn, so it must use the clock the pool was created under, not whatever an unrelated test installed later. Task deadline timers in `run()`/`finish()` intentionally stay on the caller's ambient clock: they are armed inside the caller's turn, and callers that fake timers expect to advance them.

A regression test creates a pool under real timers, completes a task while `vi.useFakeTimers()` is installed, asserts the fake clock received no timer, and then checks the worker still retires on real time. It fails on current `main` with the exact CI signature (`expected 1 to be +0`).

Alternatives considered: `vi.waitFor` around the digest-budget assertion would not fix this (the leftover timer is 60 s and nothing clears it); moving the disk-budget pool's teardown into the test fixtures would need a new test-only seam in production code and would not cover the other three process-wide pools (`compaction-planning-worker-runtime.ts`, `session-model-context-worker-runtime.ts`, `code-mode-worker.ts`) that share this path.

Related follow-up, not changed here: `test/vitest/vitest.gateway-server-paths.mjs` routes `src/gateway/session-observer*.test.ts` into the non-isolated `gateway-server` project because the basename contains `server`; these are fake-timer unit tests with no gateway.

## User Impact

CI only. No production behavior change: outside tests the global timer functions are never replaced, so the bound functions are the same functions. `main` and fork PRs stop failing `checks-node-compact-small-9` / `-18` on a timer the session observer does not own.

## Evidence

Local reproduction runs the exact CI bin (16 files, `agentic-control-plane-runtime`, `test/vitest/vitest.gateway-server.config.ts`) through `scripts/ci-run-node-test-shard.mts`, pinned to two CPUs with two workers, like the failing runners (`detected cores=8 ... -> workers=2`). The single file alone passes 20/20 pinned runs and the unmodified bin passed 18/18 pinned runs before the fix; the failing window is the ~5 ms between `vi.useFakeTimers()` and line 119 in the third test.

To catch the producer, a diagnostic-only copy of the digest-budget test held the fake clock open for 300 ms of real time before the assertion and dumped the fake clock, and a diagnostic log in `WorkerTaskPool.idle()` printed the worker URL and whether the ambient `setTimeout` was the fake one. Before the fix (4 runs):

```
[diag-pool] idle() arming 60000ms for .../src/config/sessions/disk-budget.worker.ts closed=false retiring=false fakeClock=true
[diag] before-wait count=0 clockTimers=0
[diag] after-300ms-real-wait count=1 clockTimers=1
[diag]   type=Timeout delay=60000 callAt=72000 createdAt=12000 func=() => void this.retire(slot)
 ×  src/gateway/session-observer.digest-budget.test.ts > session observer digest budget > disables model work when digest persistence reports a missing entry
    → expected 1 to be +0 // Object.is equality
```

Same diagnostic with this fix applied (4 runs): the worker message still lands inside the fake window (`fakeClock=true` in 2 of 4 runs) but the fake clock stays empty:

```
[diag-pool] idle() arming 60000ms for .../src/config/sessions/disk-budget.worker.ts closed=false retiring=false fakeClock=true
[diag] after-300ms-real-wait count=0 clockTimers=0
 ✓  src/gateway/session-observer.digest-budget.test.ts > session observer digest budget > disables model work when digest persistence reports a missing entry
```

Regression test on `main` (pool without the fix):

```
taskset -c 6,7 env OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run src/infra/worker-task-pool.test.ts -t "arms idle retirement"
 ×  src/infra/worker-task-pool.test.ts > worker task pool > arms idle retirement on the clock the pool was created under
    → expected 1 to be +0 // Object.is equality
```

With the fix:

```
taskset -c 2,3 env OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run src/infra/worker-task-pool.test.ts
 ✓  ... > arms idle retirement on the clock the pool was created under
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

Unmodified CI bin after the fix, pinned to two CPUs, 4 runs: 127/127 tests pass in each (one run's wrapper exited 1 because I reverted the local `pnpm-lock.yaml` drift while it was in flight, tripping the runner's `Source changed during compiled subprocess invocation` guard after all tests had passed).

Checks: `node_modules/.bin/oxfmt --check src/infra/worker-task-pool.ts src/infra/worker-task-pool.test.ts` passes; `node scripts/run-oxlint.mjs` on both files passes; `node scripts/run-tsgo-core-test-shards.mjs --changed-paths-json '["src/infra/worker-task-pool.ts","src/infra/worker-task-pool.test.ts"]'` exits 0; Codex autoreview (`--mode local --max-priority P2`) is scoped-clean.

Production LOC: +9/−3 in `src/infra/worker-task-pool.ts` (two bound fields, a four-line invariant comment, three call sites); +17 test lines.
