### PR TITLE
fix(telegram): preserve typing in concurrent forum topics

### DIFF
--- a/extensions/telegram/src/account-throttler.test.ts
+++ b/extensions/telegram/src/account-throttler.test.ts
@@ -1,11 +1,22 @@
 // Telegram tests cover account throttler plugin behavior.
+import { createRequire } from "node:module";
 import { Api } from "grammy";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { getOrCreateAccountThrottler } from "./account-throttler.js";
+import { asTelegramClientFetch } from "./client-fetch.js";
 import { resetTelegramAccountThrottlersForTest } from "./runtime.test-support.js";
 
-type TelegramTransform = ReturnType<typeof getOrCreateAccountThrottler>;
+type TelegramTransform = ReturnType<typeof getOrCreateAccountThrottler>["transformer"];
 type TelegramPreviousCall = Parameters<TelegramTransform>[0];
+
+const {
+  AbortController: TelegramAbortController,
+}: {
+  AbortController: new () => {
+    signal: NonNullable<Parameters<Api["sendChatAction"]>[3]>;
+    abort: () => void;
+  };
+} = createRequire(import.meta.resolve("grammy"))("abort-controller");
 
 function callLooseSendMessage(
   throttler: TelegramTransform,
@@ -47,9 +58,10 @@ describe("getOrCreateAccountThrottler", () => {
     vi.useFakeTimers();
     const sent: string[] = [];
     const api = new Api("123:typing-budget", {
-      fetch: async (input) => {
-        const url =
-          typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      buildUrl: (root, _token, method) => `${root}/${method}`,
+      fetch: asTelegramClientFetch(async (input: unknown) => {
+        assert(typeof input === "string");
+        const url = input;
         const method = url.slice(url.lastIndexOf("/") + 1);
         sent.push(method);
         return new Response(
@@ -66,9 +78,9 @@ describe("getOrCreateAccountThrottler", () => {
                   },
           }),
         );
-      },
+      }),
     });
-    api.config.use(getOrCreateAccountThrottler("typing-budget"));
+    api.config.use(getOrCreateAccountThrottler("typing-budget").transformer);
     const actions = Array.from({ length: 21 }, (_, index) =>
       api.sendChatAction(-100123, "typing", { message_thread_id: index + 1 }),
     );
@@ -88,13 +100,266 @@ describe("getOrCreateAccountThrottler", () => {
     }
   });
 
+  it("shares suspension and recovery across clients for the same token", async () => {
+    vi.useFakeTimers();
+    let sent = 0;
+    const fetch = asTelegramClientFetch(async () => {
+      sent++;
+      return new Response(
+        JSON.stringify(
+          sent <= 10
+            ? { ok: false, error_code: 401, description: "Unauthorized" }
+            : { ok: true, result: true },
+        ),
+      );
+    });
+    const first = new Api("123:shared-failures", { fetch });
+    const second = new Api("123:shared-failures", { fetch });
+    const account = getOrCreateAccountThrottler("shared-failures");
+    first.config.use(account.transformer);
+    second.config.use(getOrCreateAccountThrottler("shared-failures").transformer);
+    const attempts = Array.from({ length: 11 }, (_, index) =>
+      (index % 2 === 0 ? first : second).sendChatAction(-100123, "typing", {
+        message_thread_id: index + 1,
+      }),
+    );
+    const results = Promise.allSettled(attempts);
+    try {
+      await vi.advanceTimersByTimeAsync(600_000);
+      expect((await results).every((result) => result.status === "rejected")).toBe(true);
+      expect(sent).toBe(10);
+      expect(account.chatActions.isSuspended()).toBe(true);
+      account.chatActions.reset();
+      const recovered = second.sendChatAction(-100123, "typing", { message_thread_id: 12 });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await recovered;
+      expect(sent).toBe(11);
+    } finally {
+      await vi.advanceTimersByTimeAsync(600_000);
+      await results;
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { name: "flood wait", errorCode: 429, secondStatus: "rejected" },
+    {
+      name: "authorization backoff",
+      errorCode: 401,
+      secondStatus: "fulfilled",
+    },
+  ])("rechecks $name before sending a queued topic action", async ({ errorCode, secondStatus }) => {
+    vi.useFakeTimers();
+    const sent: number[] = [];
+    const startedAt = Date.now();
+    const api = new Api("123:queued-failure", {
+      fetch: asTelegramClientFetch(async () => {
+        sent.push(Date.now() - startedAt);
+        return new Response(
+          JSON.stringify(
+            sent.length === 1
+              ? {
+                  ok: false,
+                  error_code: errorCode,
+                  description: errorCode === 429 ? "Too Many Requests" : "Unauthorized",
+                  ...(errorCode === 429 ? { parameters: { retry_after: 20 } } : {}),
+                }
+              : { ok: true, result: true },
+          ),
+        );
+      }),
+    });
+    const account = getOrCreateAccountThrottler("queued-failure");
+    api.config.use(account.transformer);
+    const first = api.sendChatAction(-100123, "typing", { message_thread_id: 10 });
+    const second = api.sendChatAction(-100123, "typing", { message_thread_id: 20 });
+    const results = Promise.allSettled([first, second]);
+    try {
+      await vi.advanceTimersByTimeAsync(1_500);
+      expect(sent).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect((await results).map((result) => result.status)).toEqual(["rejected", secondStatus]);
+      if (secondStatus === "fulfilled") {
+        expect(sent[1]).toBeGreaterThanOrEqual(1_900);
+        const nextTopic = api.sendChatAction(-100123, "typing", { message_thread_id: 40 });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(sent).toHaveLength(2);
+        await vi.advanceTimersByTimeAsync(1_000);
+        await nextTopic;
+        const [, previousAt, nextAt] = sent;
+        assert(previousAt !== undefined && nextAt !== undefined);
+        expect(nextAt - previousAt).toBeGreaterThanOrEqual(1_000);
+      }
+      await vi.advanceTimersByTimeAsync(20_000);
+      account.chatActions.reset();
+      const recovered = api.sendChatAction(-100123, "typing", { message_thread_id: 30 });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await recovered;
+      expect(sent).toHaveLength(secondStatus === "fulfilled" ? 4 : 2);
+    } finally {
+      await vi.advanceTimersByTimeAsync(25_000);
+      await results;
+      vi.useRealTimers();
+    }
+  });
+
+  it("releases a topic action canceled during authorization backoff", async () => {
+    vi.useFakeTimers();
+    let sent = 0;
+    const api = new Api("123:canceled-backoff", {
+      fetch: asTelegramClientFetch(async () => {
+        sent++;
+        return new Response(
+          JSON.stringify(
+            sent === 1
+              ? { ok: false, error_code: 401, description: "Unauthorized" }
+              : { ok: true, result: true },
+          ),
+        );
+      }),
+    });
+    api.config.use(getOrCreateAccountThrottler("canceled-backoff").transformer);
+    const first = api.sendChatAction(-100123, "typing", { message_thread_id: 1 });
+    const failed = expect(first).rejects.toThrow("Unauthorized");
+    await vi.advanceTimersByTimeAsync(0);
+    await failed;
+    const controller = new TelegramAbortController();
+    const canceled = api.sendChatAction(
+      -100123,
+      "typing",
+      { message_thread_id: 2 },
+      controller.signal,
+    );
+    const settled = vi.fn();
+    const outcome = canceled.then(settled, settled);
+    try {
+      await vi.advanceTimersByTimeAsync(1_500);
+      controller.abort();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(settled).toHaveBeenCalledOnce();
+      expect(sent).toBe(1);
+      const recovered = api.sendChatAction(-100123, "typing", { message_thread_id: 3 });
+      await vi.advanceTimersByTimeAsync(3_000);
+      await recovered;
+      expect(sent).toBe(2);
+    } finally {
+      await vi.advanceTimersByTimeAsync(10_000);
+      await outcome;
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["group queue", "authorization queue"])(
+    "settles cancellation in the %s without releasing an active predecessor",
+    async (queue) => {
+      vi.useFakeTimers();
+      const authorization = queue === "authorization queue";
+      const held = deferred<Response>();
+      let sent = 0;
+      const api = new Api("123:queued-wait", {
+        fetch: asTelegramClientFetch(async () => {
+          sent++;
+          if (authorization && sent === 1) {
+            return new Response(
+              JSON.stringify({ ok: false, error_code: 401, description: "Unauthorized" }),
+            );
+          }
+          if (sent === (authorization ? 2 : 1)) {
+            return held.promise;
+          }
+          return new Response(JSON.stringify({ ok: true, result: true }));
+        }),
+      });
+      api.config.use(getOrCreateAccountThrottler("queued-wait").transformer);
+      if (authorization) {
+        const failed = expect(api.sendChatAction(-100123, "typing")).rejects.toThrow(
+          "Unauthorized",
+        );
+        await vi.advanceTimersByTimeAsync(0);
+        await failed;
+      }
+      const predecessor = api.sendChatAction(-100123, "typing", { message_thread_id: 1 });
+      await vi.advanceTimersByTimeAsync(authorization ? 2_200 : 0);
+      const controller = new TelegramAbortController();
+      const canceled = api.sendChatAction(
+        authorization ? -100456 : -100123,
+        "typing",
+        { message_thread_id: 2 },
+        controller.signal,
+      );
+      const settled = vi.fn();
+      const outcome = canceled.then(settled, settled);
+      const successor = api.sendChatAction(authorization ? -100789 : -100123, "typing", {
+        message_thread_id: 3,
+      });
+      try {
+        await vi.advanceTimersByTimeAsync(0);
+        controller.abort();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(settled).toHaveBeenCalledOnce();
+        expect(sent).toBe(authorization ? 2 : 1);
+        held.resolve(new Response(JSON.stringify({ ok: true, result: true })));
+        await vi.advanceTimersByTimeAsync(2_000);
+        await Promise.all([predecessor, successor]);
+        expect(sent).toBe(authorization ? 3 : 2);
+      } finally {
+        held.resolve(new Response(JSON.stringify({ ok: true, result: true })));
+        await vi.advanceTimersByTimeAsync(10_000);
+        await Promise.all([predecessor, outcome, successor]);
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("does not spend action spacing on canceled requests", async () => {
+    vi.useFakeTimers();
+    const sent: number[] = [];
+    const api = new Api("123:canceled-actions", {
+      fetch: asTelegramClientFetch(async () => {
+        sent.push(Date.now());
+        return new Response(JSON.stringify({ ok: true, result: true }));
+      }),
+    });
+    api.config.use((prev, method, payload, signal) => {
+      if (signal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+      return prev(method, payload, signal);
+    });
+    api.config.use(getOrCreateAccountThrottler("canceled-actions").transformer);
+    const first = api.sendChatAction(-100123, "typing", { message_thread_id: 1 });
+    await vi.advanceTimersByTimeAsync(0);
+    await first;
+    const controllers = Array.from({ length: 5 }, () => new TelegramAbortController());
+    const canceled = controllers.map((controller, index) =>
+      api.sendChatAction(-100123, "typing", { message_thread_id: index + 2 }, controller.signal),
+    );
+    const results = Promise.allSettled(canceled);
+    const next = api.sendChatAction(-100123, "typing", { message_thread_id: 10 });
+    try {
+      await vi.advanceTimersByTimeAsync(100);
+      controllers.forEach((controller) => controller.abort());
+      await vi.advanceTimersByTimeAsync(900);
+      expect(sent).toHaveLength(2);
+      const [firstAt, nextAt] = sent;
+      assert(firstAt !== undefined && nextAt !== undefined);
+      expect(nextAt - firstAt).toBe(1_000);
+      expect((await results).every((result) => result.status === "rejected")).toBe(true);
+      await next;
+    } finally {
+      await vi.advanceTimersByTimeAsync(10_000);
+      await Promise.all([results, next]);
+      vi.useRealTimers();
+    }
+  });
+
   it("round-robins group topic requests before entering the Telegram throttler", async () => {
     const firstGate = deferred<void>();
     const entered: string[] = [];
     const throttler = getOrCreateAccountThrottler(
       "round-robin",
       () => async (prev, method, payload, signal) => prev(method, payload, signal),
-    );
+    ).transformer;
     const prev = vi.fn(async (_method: string, payload: unknown) => {
       const request = payload as { message_thread_id?: number; text?: string };
       entered.push(`${request.message_thread_id}:${request.text}`);
@@ -141,7 +406,7 @@ describe("getOrCreateAccountThrottler", () => {
     const throttler = getOrCreateAccountThrottler(
       "edited-message",
       () => async (prev, method, payload, signal) => prev(method, payload, signal),
-    );
+    ).transformer;
     const prev = vi.fn(async (_method: string, payload: unknown) => {
       const request = payload as { message_id?: number; text?: string };
       entered.push(`${request.message_id}:${request.text}`);
@@ -186,7 +451,7 @@ describe("getOrCreateAccountThrottler", () => {
     const throttler = getOrCreateAccountThrottler(
       "direct-topic",
       () => async (prev, method, payload, signal) => prev(method, payload, signal),
-    );
+    ).transformer;
     const prev = vi.fn(async (_method: string, payload: unknown) => {
       const request = payload as { text?: string };
       entered.push(request.text ?? "");
@@ -222,7 +487,7 @@ describe("getOrCreateAccountThrottler", () => {
     const throttler = getOrCreateAccountThrottler(
       "private-chat",
       () => async (prev, method, payload, signal) => prev(method, payload, signal),
-    );
+    ).transformer;
     const prev = vi.fn(async (_method: string, payload: unknown) => {
       const request = payload as { message_thread_id?: string; text?: string };
       entered.push(`${request.message_thread_id}:${request.text}`);

--- a/extensions/telegram/src/account-throttler.test.ts
+++ b/extensions/telegram/src/account-throttler.test.ts
@@ -1,4 +1,5 @@
 // Telegram tests cover account throttler plugin behavior.
+import { Api } from "grammy";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getOrCreateAccountThrottler } from "./account-throttler.js";
 import { resetTelegramAccountThrottlersForTest } from "./runtime.test-support.js";
@@ -40,6 +41,51 @@ describe("getOrCreateAccountThrottler", () => {
 
     expect(second).toBe(first);
     expect(other).not.toBe(first);
+  });
+
+  it("preserves the group message budget while sending topic actions", async () => {
+    vi.useFakeTimers();
+    const sent: string[] = [];
+    const api = new Api("123:typing-budget", {
+      fetch: async (input) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        const method = url.slice(url.lastIndexOf("/") + 1);
+        sent.push(method);
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            result:
+              method === "sendChatAction"
+                ? true
+                : {
+                    message_id: sent.length,
+                    date: 0,
+                    chat: { id: -100123, type: "supergroup", title: "Topics" },
+                    text: "Complete",
+                  },
+          }),
+        );
+      },
+    });
+    api.config.use(getOrCreateAccountThrottler("typing-budget"));
+    const actions = Array.from({ length: 21 }, (_, index) =>
+      api.sendChatAction(-100123, "typing", { message_thread_id: index + 1 }),
+    );
+    const replies = Array.from({ length: 21 }, () => api.sendMessage(-100123, "Complete"));
+    try {
+      await vi.advanceTimersByTimeAsync(100);
+      expect(sent.filter((method) => method === "sendChatAction")).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(21_000);
+      expect(sent.filter((method) => method === "sendChatAction")).toHaveLength(21);
+      expect(sent.filter((method) => method === "sendMessage")).toHaveLength(20);
+      await vi.advanceTimersByTimeAsync(40_000);
+      expect(sent.filter((method) => method === "sendMessage")).toHaveLength(21);
+    } finally {
+      await vi.advanceTimersByTimeAsync(180_000);
+      await Promise.all([...actions, ...replies]);
+      vi.useRealTimers();
+    }
   });
 
   it("round-robins group topic requests before entering the Telegram throttler", async () => {

--- a/extensions/telegram/src/account-throttler.ts
+++ b/extensions/telegram/src/account-throttler.ts
@@ -1,6 +1,7 @@
 // Telegram plugin module implements account throttler behavior.
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { apiThrottler } from "./bot.runtime.js";
 
 type ApiThrottlerTransformer = ReturnType<typeof apiThrottler>;
@@ -16,11 +17,30 @@ type QueuedApiRequest<T> = {
   reject: (err: unknown) => void;
 };
 
-class GroupFairQueue {
+class GroupRequestScheduler {
   private readonly lanes = new Map<string, Array<QueuedApiRequest<unknown>>>();
   private laneOrder: string[] = [];
   private nextLaneIndex = 0;
   private running = false;
+  private actionTail = Promise.resolve();
+  private nextActionAtMs = 0;
+
+  enqueueAction<T>(run: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    const result = this.actionTail.then(async () => {
+      const waitMs = this.nextActionAtMs - Date.now();
+      if (waitMs > 0) {
+        await sleepWithAbort(waitMs, signal);
+      }
+      // Retain the existing peer spacing without consuming the message quota.
+      this.nextActionAtMs = Date.now() + 1_000;
+      return run();
+    });
+    this.actionTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
 
   enqueue<T>(laneKey: string, run: () => Promise<T>): Promise<T> {
     return new Promise<T>((resolve, reject) => {
@@ -143,7 +163,7 @@ function createTelegramAccountThrottler(
   createThrottler: () => ApiThrottlerTransformer = apiThrottler,
 ): ApiThrottlerTransformer {
   const baseThrottler = createThrottler();
-  const fairQueuesByChat = new Map<string, GroupFairQueue>();
+  const schedulersByChat = new Map<string, GroupRequestScheduler>();
 
   return (prev, method, payload, signal) => {
     const apiPayload = readPayload(payload);
@@ -152,14 +172,17 @@ function createTelegramAccountThrottler(
       return baseThrottler(prev, method, payload, signal);
     }
 
-    let fairQueue = fairQueuesByChat.get(groupChatKey);
-    if (!fairQueue) {
-      fairQueue = new GroupFairQueue();
-      fairQueuesByChat.set(groupChatKey, fairQueue);
+    let scheduler = schedulersByChat.get(groupChatKey);
+    if (!scheduler) {
+      scheduler = new GroupRequestScheduler();
+      schedulersByChat.set(groupChatKey, scheduler);
+    }
+    if (method === "sendChatAction") {
+      return scheduler.enqueueAction(() => prev(method, payload, signal), signal);
     }
 
     const laneKey = resolveForumLaneKey(apiPayload);
-    return fairQueue.enqueue(laneKey, () => baseThrottler(prev, method, payload, signal));
+    return scheduler.enqueue(laneKey, () => baseThrottler(prev, method, payload, signal));
   };
 }
 

--- a/extensions/telegram/src/account-throttler.ts
+++ b/extensions/telegram/src/account-throttler.ts
@@ -25,11 +25,11 @@ class GroupRequestScheduler {
   private actionTail = Promise.resolve();
   private nextActionAtMs = 0;
 
-  enqueueAction<T>(run: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+  enqueueAction<T>(run: () => Promise<T>): Promise<T> {
     const result = this.actionTail.then(async () => {
       const waitMs = this.nextActionAtMs - Date.now();
       if (waitMs > 0) {
-        await sleepWithAbort(waitMs, signal);
+        await sleepWithAbort(waitMs);
       }
       // Retain the existing peer spacing without consuming the message quota.
       this.nextActionAtMs = Date.now() + 1_000;
@@ -178,7 +178,7 @@ function createTelegramAccountThrottler(
       schedulersByChat.set(groupChatKey, scheduler);
     }
     if (method === "sendChatAction") {
-      return scheduler.enqueueAction(() => prev(method, payload, signal), signal);
+      return scheduler.enqueueAction(() => prev(method, payload, signal));
     }
 
     const laneKey = resolveForumLaneKey(apiPayload);

--- a/extensions/telegram/src/account-throttler.ts
+++ b/extensions/telegram/src/account-throttler.ts
@@ -1,10 +1,16 @@
 // Telegram plugin module implements account throttler behavior.
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
-import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
+import { logVerbose, sleepWithAbort, waitForAbortSignal } from "openclaw/plugin-sdk/runtime-env";
 import { apiThrottler } from "./bot.runtime.js";
+import { TELEGRAM_CHAT_ACTION_INTERVAL_MS } from "./chat-action-timing.js";
+import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 
 type ApiThrottlerTransformer = ReturnType<typeof apiThrottler>;
+type TelegramAccountThrottler = {
+  transformer: ApiThrottlerTransformer;
+  chatActions: ReturnType<typeof createTelegramSendChatActionHandler>;
+};
 type TelegramApiPayload = {
   chat_id?: unknown;
   direct_messages_topic_id?: unknown;
@@ -25,21 +31,44 @@ class GroupRequestScheduler {
   private actionTail = Promise.resolve();
   private nextActionAtMs = 0;
 
-  enqueueAction<T>(run: () => Promise<T>): Promise<T> {
+  enqueueAction<T>(
+    run: () => Promise<T>,
+    signal: Parameters<ApiThrottlerTransformer>[3],
+  ): Promise<T> {
+    // grammY may supply the legacy node-fetch signal; bridge only its abort event.
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    if (signal?.aborted) {
+      abort();
+    } else {
+      signal?.addEventListener("abort", abort, { once: true });
+    }
     const result = this.actionTail.then(async () => {
+      controller.signal.throwIfAborted();
       const waitMs = this.nextActionAtMs - Date.now();
       if (waitMs > 0) {
-        await sleepWithAbort(waitMs);
+        await sleepWithAbort(waitMs, controller.signal);
       }
-      // Retain the existing peer spacing without consuming the message quota.
-      this.nextActionAtMs = Date.now() + 1_000;
-      return run();
+      try {
+        return await run();
+      } finally {
+        // The final API guard can back off after this queue's wait.
+        this.nextActionAtMs = Date.now() + 1_000;
+      }
     });
     this.actionTail = result.then(
       () => undefined,
       () => undefined,
     );
-    return result;
+    return Promise.race([
+      result,
+      waitForAbortSignal(controller.signal).then(() => {
+        throw new DOMException("Chat action canceled", "AbortError");
+      }),
+    ]).finally(() => {
+      signal?.removeEventListener("abort", abort);
+      controller.abort();
+    });
   }
 
   enqueue<T>(laneKey: string, run: () => Promise<T>): Promise<T> {
@@ -117,15 +146,15 @@ class GroupRequestScheduler {
 
 const TELEGRAM_ACCOUNT_THROTTLERS_KEY = Symbol.for("openclaw.telegram.accountThrottlers");
 
-function getAccountThrottlers(): Map<string, ApiThrottlerTransformer> {
+function getAccountThrottlers(): Map<string, TelegramAccountThrottler> {
   const globalRecord = globalThis as Record<PropertyKey, unknown>;
   const existing = globalRecord[TELEGRAM_ACCOUNT_THROTTLERS_KEY] as
-    | Map<string, ApiThrottlerTransformer>
+    | Map<string, TelegramAccountThrottler>
     | undefined;
   if (existing) {
     return existing;
   }
-  const created = new Map<string, ApiThrottlerTransformer>();
+  const created = new Map<string, TelegramAccountThrottler>();
   globalRecord[TELEGRAM_ACCOUNT_THROTTLERS_KEY] = created;
   return created;
 }
@@ -161,15 +190,25 @@ function resolveForumLaneKey(payload: TelegramApiPayload): string {
 
 function createTelegramAccountThrottler(
   createThrottler: () => ApiThrottlerTransformer = apiThrottler,
-): ApiThrottlerTransformer {
+): TelegramAccountThrottler {
   const baseThrottler = createThrottler();
+  const chatActions = createTelegramSendChatActionHandler({
+    logger: (message) => logVerbose(`telegram: ${message}`),
+    minIntervalMs: TELEGRAM_CHAT_ACTION_INTERVAL_MS,
+  });
   const schedulersByChat = new Map<string, GroupRequestScheduler>();
 
-  return (prev, method, payload, signal) => {
+  const transformer: ApiThrottlerTransformer = (prev, method, payload, signal) => {
     const apiPayload = readPayload(payload);
     const groupChatKey = apiPayload ? resolveGroupChatKey(apiPayload) : undefined;
     if (!apiPayload || !groupChatKey) {
-      return baseThrottler(prev, method, payload, signal);
+      return baseThrottler(
+        (queuedMethod, queuedPayload, queuedSignal) =>
+          chatActions.apiTransformer(prev, queuedMethod, queuedPayload, queuedSignal),
+        method,
+        payload,
+        signal,
+      );
     }
 
     let scheduler = schedulersByChat.get(groupChatKey);
@@ -178,18 +217,23 @@ function createTelegramAccountThrottler(
       schedulersByChat.set(groupChatKey, scheduler);
     }
     if (method === "sendChatAction") {
-      return scheduler.enqueueAction(() => prev(method, payload, signal));
+      // Ephemeral actions must not spend message reservoirs; the shared guard honors flood waits.
+      return scheduler.enqueueAction(
+        () => chatActions.apiTransformer(prev, method, payload, signal),
+        signal,
+      );
     }
 
     const laneKey = resolveForumLaneKey(apiPayload);
     return scheduler.enqueue(laneKey, () => baseThrottler(prev, method, payload, signal));
   };
+  return { transformer, chatActions };
 }
 
 export function getOrCreateAccountThrottler(
   token: string,
   createThrottler: () => ApiThrottlerTransformer = apiThrottler,
-): ApiThrottlerTransformer {
+): TelegramAccountThrottler {
   const throttlerByToken = getAccountThrottlers();
   let throttler = throttlerByToken.get(token);
   if (!throttler) {

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -57,7 +57,6 @@ import {
   startTelegramCallbackQueryAnswer,
   takeTelegramCallbackQueryAdmissionAnswer,
 } from "./callback-query-answer-state.js";
-import { TELEGRAM_CHAT_ACTION_INTERVAL_MS } from "./chat-action-timing.js";
 import {
   asTelegramClientFetch,
   createTelegramClientFetch,
@@ -77,7 +76,7 @@ import {
   settleTelegramPollAnswerContext,
 } from "./poll-answer-context.js";
 import { formatTelegramRawUpdateForLog } from "./raw-update-log.js";
-import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
+import type { TelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 import { getTelegramSequentialConstraints } from "./sequential-key.js";
 import { createTelegramThreadBindingManager } from "./thread-bindings.js";
 
@@ -166,7 +165,16 @@ export function createTelegramBotCore(
       ? { ...(client ? { client } : {}), ...(opts.botInfo ? { botInfo: opts.botInfo } : {}) }
       : undefined;
   const bot = new botRuntime.Bot(opts.token, botConfig);
-  bot.api.config.use(getOrCreateAccountThrottler(opts.token, botRuntime.apiThrottler));
+  const accountThrottler = getOrCreateAccountThrottler(opts.token, botRuntime.apiThrottler);
+  bot.api.config.use(accountThrottler.transformer);
+  const sendChatActionHandler: TelegramSendChatActionHandler = {
+    sendChatAction: (chatId, action, threadParams) =>
+      accountThrottler.chatActions.sendChatAction(chatId, action, threadParams, () =>
+        bot.api.sendChatAction(chatId, action, threadParams),
+      ),
+    isSuspended: accountThrottler.chatActions.isSuspended,
+    reset: accountThrottler.chatActions.reset,
+  };
   // Catch all errors from bot middleware to prevent unhandled rejections
   bot.catch((err) => {
     runtime.error?.(danger(`telegram bot error: ${formatUncaughtError(err)}`));
@@ -384,17 +392,6 @@ export function createTelegramBotCore(
     }).config;
     return resolveTelegramScopedGroupConfig(turnTelegramCfg, chatId, messageThreadId);
   };
-
-  // Global sendChatAction handler with 401 backoff and transient cooldown.
-  // Created BEFORE the message processor so it can be injected into every message context.
-  // Shared across all message contexts for this account so that consecutive 401s
-  // from ANY chat are tracked together — prevents infinite retry storms.
-  const sendChatActionHandler = createTelegramSendChatActionHandler({
-    sendChatActionFn: (chatId, action, threadParams) =>
-      bot.api.sendChatAction(chatId, action, threadParams),
-    logger: (message) => logVerbose(`telegram: ${message}`),
-    minIntervalMs: TELEGRAM_CHAT_ACTION_INTERVAL_MS,
-  });
 
   const processMessage = createTelegramMessageProcessor({
     bot,

--- a/extensions/telegram/src/delivery-trace.test.ts
+++ b/extensions/telegram/src/delivery-trace.test.ts
@@ -31,7 +31,10 @@ import {
 import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
 import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
 import { resetTelegramReplyFenceForTest as resetTelegramReplyFenceForTests } from "./runtime.test-support.js";
-import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
+import {
+  createTelegramSendChatActionHandler,
+  type TelegramSendChatActionHandler,
+} from "./sendchataction-401-backoff.js";
 
 type RecordedWireCall = Parameters<WireRecorder["recordWireCall"]>[0];
 type BufferedDispatcherParams = Parameters<
@@ -205,13 +208,15 @@ async function setupTelegramTrace(recorder: WireRecorder) {
     wireFaults: [],
   };
   const api = createRecordingTelegramApi(state);
-  // Real per-account handler so typing choreography (401 backoff, cooldowns)
-  // runs the production path over the recording API.
-  const sendChatActionHandler = createTelegramSendChatActionHandler({
-    sendChatActionFn: (chatId, action, threadParams) =>
-      api.sendChatAction(chatId, action, threadParams) as Promise<true>,
-    logger: () => {},
-  });
+  const chatActions = createTelegramSendChatActionHandler({ logger: () => {} });
+  const sendChatActionHandler: TelegramSendChatActionHandler = {
+    sendChatAction: (chatId, action, threadParams) =>
+      chatActions.sendChatAction(chatId, action, threadParams, () =>
+        api.sendChatAction(chatId, action, threadParams),
+      ),
+    isSuspended: chatActions.isSuspended,
+    reset: chatActions.reset,
+  };
   // Real context construction (route, thread spec, typing cue, turn record);
   // ingress/spool stays out of scope — the context build is the delivery-side
   // boundary the dispatcher consumes.

--- a/extensions/telegram/src/send-context.ts
+++ b/extensions/telegram/src/send-context.ts
@@ -444,7 +444,7 @@ export function resolveTelegramApiContext(opts: {
     // and retries) so eviction cannot close the transport mid-operation.
     clientOptionsLease = client.lease?.();
     const bot = new Bot(token, client.clientOptions ? { client: client.clientOptions } : undefined);
-    bot.api.config.use(getOrCreateAccountThrottler(token));
+    bot.api.config.use(getOrCreateAccountThrottler(token).transformer);
     api = bot.api;
   }
   return {

--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -1,4 +1,5 @@
 // Telegram tests cover sendchataction 401 and transient backoff plugin behavior.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -67,7 +68,7 @@ describe("createTelegramSendChatActionHandler", () => {
 
   it.each([undefined, 1, 42])("keeps topic %s independent from another topic", async (threadId) => {
     let now = 1000;
-    const pending = Promise.withResolvers<true>();
+    const pending = createDeferred<true>();
     const fn = vi.fn().mockReturnValueOnce(pending.promise).mockResolvedValue(true);
     const logger = vi.fn();
     const handler = createTelegramSendChatActionHandler({
@@ -269,6 +270,141 @@ describe("createTelegramSendChatActionHandler", () => {
     now = 4000;
     await handler.sendChatAction(-100, "typing");
     expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["success", "non-transient error", "shorter flood wait", "authorization error"])(
+    "preserves a newer account cooldown after an older %s",
+    async (outcome) => {
+      let now = 1000;
+      const older = createDeferred<true>();
+      const fn = vi
+        .fn()
+        .mockReturnValueOnce(older.promise)
+        .mockRejectedValueOnce(makeTelegramError("Too Many Requests", 429, { retry_after: 20 }))
+        .mockResolvedValue(true);
+      const handler = createTelegramSendChatActionHandler({
+        sendChatActionFn: fn,
+        logger: vi.fn(),
+        now: () => now,
+      });
+      const first = handler.sendChatAction(-100, "typing", { message_thread_id: 1 });
+      await expect(
+        handler.sendChatAction(-100, "typing", { message_thread_id: 2 }),
+      ).rejects.toThrow("Too Many Requests");
+      if (outcome === "success") {
+        older.resolve(true);
+        await first;
+      } else {
+        const rejection = expect(first).rejects.toThrow();
+        older.reject(
+          outcome === "shorter flood wait"
+            ? makeTelegramError("Too Many Requests", 429, { retry_after: 1 })
+            : outcome === "authorization error"
+              ? make401Error()
+              : new Error("400 Bad Request"),
+        );
+        await rejection;
+      }
+      now = 20_999;
+      await expect(
+        handler.sendChatAction(-100, "typing", { message_thread_id: 3 }),
+      ).rejects.toThrow("transient cooldown active");
+      expect(fn).toHaveBeenCalledTimes(2);
+      now = 21_000;
+      await handler.sendChatAction(-100, "typing", { message_thread_id: 3 });
+      expect(fn).toHaveBeenCalledTimes(3);
+    },
+  );
+
+  it("does not erase newer authorization failures when an older action succeeds", async () => {
+    const older = createDeferred<true>();
+    const fn = vi.fn().mockReturnValueOnce(older.promise).mockRejectedValue(make401Error());
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger: vi.fn(),
+      maxConsecutive401: 2,
+    });
+    const first = handler.sendChatAction(-100, "typing", { message_thread_id: 1 });
+    await expect(handler.sendChatAction(-100, "typing", { message_thread_id: 2 })).rejects.toThrow(
+      "401",
+    );
+    older.resolve(true);
+    await first;
+    await expect(handler.sendChatAction(-100, "typing", { message_thread_id: 3 })).rejects.toThrow(
+      "401",
+    );
+    expect(handler.isSuspended()).toBe(true);
+  });
+
+  it("rechecks account cooldown after an authorization backoff wait", async () => {
+    const older = createDeferred<true>();
+    const backoff = createDeferred<void>();
+    const backoffStarted = createDeferred<void>();
+    const fn = vi
+      .fn()
+      .mockReturnValueOnce(older.promise)
+      .mockRejectedValueOnce(make401Error())
+      .mockResolvedValue(true);
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger: vi.fn(),
+      now: () => 1000,
+    });
+    const inFlight = handler.sendChatAction(-100, "typing", { message_thread_id: 1 });
+    await expect(handler.sendChatAction(-100, "typing", { message_thread_id: 2 })).rejects.toThrow(
+      "401",
+    );
+    mocks.sleepWithAbort.mockImplementationOnce(() => {
+      backoffStarted.resolve();
+      return backoff.promise;
+    });
+    const waiting = handler.sendChatAction(-100, "typing", { message_thread_id: 3 });
+    await backoffStarted.promise;
+    const floodFailure = expect(inFlight).rejects.toThrow("Too Many Requests");
+    older.reject(makeTelegramError("Too Many Requests", 429, { retry_after: 20 }));
+    await floodFailure;
+    const rejection = expect(waiting).rejects.toThrow("transient cooldown active");
+    backoff.resolve();
+    await rejection;
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("serializes authorization retries and uses the latest account backoff", async () => {
+    const retry = createDeferred<true>();
+    const retryStarted = createDeferred<void>();
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(make401Error())
+      .mockImplementationOnce(() => {
+        retryStarted.resolve();
+        return retry.promise;
+      })
+      .mockRejectedValue(make401Error());
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger: vi.fn(),
+      maxConsecutive401: 3,
+    });
+    await expect(handler.sendChatAction(-100, "typing", { message_thread_id: 1 })).rejects.toThrow(
+      "401",
+    );
+    mocks.sleepWithAbort.mockClear();
+    const firstFailure = expect(
+      handler.sendChatAction(-100, "typing", { message_thread_id: 2 }),
+    ).rejects.toThrow("401");
+    await retryStarted.promise;
+    const secondFailure = expect(
+      handler.sendChatAction(-100, "typing", { message_thread_id: 3 }),
+    ).rejects.toThrow("401");
+    try {
+      await Promise.resolve();
+      expect(fn).toHaveBeenCalledTimes(2);
+    } finally {
+      retry.reject(make401Error());
+      await Promise.all([firstFailure, secondFailure]);
+    }
+    expect(mocks.sleepWithAbort.mock.calls).toEqual([[1000], [2000]]);
+    expect(handler.isSuspended()).toBe(true);
   });
 
   it("resets transient counters on non-transient errors", async () => {

--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -41,7 +41,7 @@ describe("createTelegramSendChatActionHandler", () => {
     expect(handler.isSuspended()).toBe(false);
   });
 
-  it("coalesces duplicate chat actions while one for the chat is pending", async () => {
+  it("coalesces duplicate chat actions in the same forum topic while one is pending", async () => {
     let resolveSend: ((value: true) => void) | undefined;
     const send = new Promise<true>((resolve) => {
       resolveSend = resolve;
@@ -55,13 +55,33 @@ describe("createTelegramSendChatActionHandler", () => {
     });
 
     const first = handler.sendChatAction(-100, "typing", { message_thread_id: 1 });
-    await handler.sendChatAction(-100, "typing", { message_thread_id: 2 });
+    await handler.sendChatAction(-100, "typing", { message_thread_id: 1 });
 
     expect(fn).toHaveBeenCalledTimes(1);
     expect(fn).toHaveBeenCalledWith(-100, "typing", { message_thread_id: 1 });
 
     resolveSend?.(true);
     await first;
+  });
+
+  it("does not coalesce typing actions in different forum topics of the same supergroup (#138763)", async () => {
+    const fn = vi.fn().mockResolvedValue(true);
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      minIntervalMs: 4000,
+    });
+
+    await handler.sendChatAction(-100, "typing", { message_thread_id: 1 });
+    await handler.sendChatAction(-100, "typing", { message_thread_id: 2 });
+
+    // Different message_thread_id → independent coalescing keys, so both
+    // underlying sendChatActionFn calls fire instead of one suppressing the
+    // other's forum-topic typing indicator.
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(1, -100, "typing", { message_thread_id: 1 });
+    expect(fn).toHaveBeenNthCalledWith(2, -100, "typing", { message_thread_id: 2 });
   });
 
   it("coalesces recent same-chat actions after the pending send resolves", async () => {

--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -1,22 +1,54 @@
 // Telegram tests cover sendchataction 401 and transient backoff plugin behavior.
+import { Api } from "grammy";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { asTelegramClientFetch } from "./client-fetch.js";
 
 const mocks = vi.hoisted(() => ({
   sleepWithAbort: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock the runtime-exported backoff sleep that the handler actually imports.
-vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>()),
   computeBackoff: vi.fn((_policy, attempt: number) => attempt * 1000),
   sleepWithAbort: mocks.sleepWithAbort,
 }));
 
-let createTelegramSendChatActionHandler: typeof import("./sendchataction-401-backoff.js").createTelegramSendChatActionHandler;
+type Handler = import("./sendchataction-401-backoff.js").TelegramSendChatActionHandler;
+type HandlerOptions = Parameters<
+  typeof import("./sendchataction-401-backoff.js").createTelegramSendChatActionHandler
+>[0];
+let createTelegramSendChatActionHandler: (
+  params: HandlerOptions & {
+    sendChatActionFn: (...args: Parameters<Handler["sendChatAction"]>) => Promise<true>;
+  },
+) => Handler;
 
 describe("createTelegramSendChatActionHandler", () => {
   beforeAll(async () => {
-    ({ createTelegramSendChatActionHandler } = await import("./sendchataction-401-backoff.js"));
+    const { createTelegramSendChatActionHandler: createHandler } =
+      await import("./sendchataction-401-backoff.js");
+    createTelegramSendChatActionHandler = (params) => {
+      const controller = createHandler(params);
+      return {
+        ...controller,
+        sendChatAction: (chatId, action, threadParams) =>
+          controller.sendChatAction(chatId, action, threadParams, async () => {
+            const api = new Api("123:backoff", {
+              fetch: asTelegramClientFetch(
+                async () => new Response(JSON.stringify({ ok: true, result: true })),
+              ),
+            });
+            api.config.use(async (prev, method, payload, signal) => {
+              await params.sendChatActionFn(chatId, action, threadParams);
+              return prev(method, payload, signal);
+            });
+            api.config.use(controller.apiTransformer);
+            return api.sendChatAction(chatId, action, threadParams);
+          }),
+      };
+    };
   });
 
   const make401Error = () => new Error("401 Unauthorized");
@@ -403,7 +435,7 @@ describe("createTelegramSendChatActionHandler", () => {
       retry.reject(make401Error());
       await Promise.all([firstFailure, secondFailure]);
     }
-    expect(mocks.sleepWithAbort.mock.calls).toEqual([[1000], [2000]]);
+    expect(mocks.sleepWithAbort.mock.calls.map(([delay]) => delay)).toEqual([1000, 2000]);
     expect(handler.isSuspended()).toBe(true);
   });
 

--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -41,7 +41,7 @@ describe("createTelegramSendChatActionHandler", () => {
     expect(handler.isSuspended()).toBe(false);
   });
 
-  it("coalesces duplicate chat actions in the same forum topic while one is pending", async () => {
+  it.each([undefined, 1, 42])("coalesces pending actions within topic %s", async (threadId) => {
     let resolveSend: ((value: true) => void) | undefined;
     const send = new Promise<true>((resolve) => {
       resolveSend = resolve;
@@ -54,34 +54,48 @@ describe("createTelegramSendChatActionHandler", () => {
       minIntervalMs: 4000,
     });
 
-    const first = handler.sendChatAction(-100, "typing", { message_thread_id: 1 });
-    await handler.sendChatAction(-100, "typing", { message_thread_id: 1 });
+    const threadParams = threadId === undefined ? undefined : { message_thread_id: threadId };
+    const first = handler.sendChatAction(-100, "typing", threadParams);
+    await handler.sendChatAction(-100, "typing", threadParams);
 
     expect(fn).toHaveBeenCalledTimes(1);
-    expect(fn).toHaveBeenCalledWith(-100, "typing", { message_thread_id: 1 });
+    expect(fn).toHaveBeenCalledWith(-100, "typing", threadParams);
 
     resolveSend?.(true);
     await first;
   });
 
-  it("does not coalesce typing actions in different forum topics of the same supergroup (#138763)", async () => {
-    const fn = vi.fn().mockResolvedValue(true);
+  it.each([undefined, 1, 42])("keeps topic %s independent from another topic", async (threadId) => {
+    let now = 1000;
+    const pending = Promise.withResolvers<true>();
+    const fn = vi.fn().mockReturnValueOnce(pending.promise).mockResolvedValue(true);
     const logger = vi.fn();
     const handler = createTelegramSendChatActionHandler({
       sendChatActionFn: fn,
       logger,
       minIntervalMs: 4000,
+      now: () => now,
     });
 
-    await handler.sendChatAction(-100, "typing", { message_thread_id: 1 });
+    const threadParams = threadId === undefined ? undefined : { message_thread_id: threadId };
+    const first = handler.sendChatAction(-100, "typing", threadParams);
     await handler.sendChatAction(-100, "typing", { message_thread_id: 2 });
 
-    // Different message_thread_id → independent coalescing keys, so both
-    // underlying sendChatActionFn calls fire instead of one suppressing the
-    // other's forum-topic typing indicator.
     expect(fn).toHaveBeenCalledTimes(2);
-    expect(fn).toHaveBeenNthCalledWith(1, -100, "typing", { message_thread_id: 1 });
+    expect(fn).toHaveBeenNthCalledWith(1, -100, "typing", threadParams);
     expect(fn).toHaveBeenNthCalledWith(2, -100, "typing", { message_thread_id: 2 });
+    pending.resolve(true);
+    await first;
+
+    now = 4999;
+    await handler.sendChatAction(-100, "typing", threadParams);
+    await handler.sendChatAction(-100, "typing", { message_thread_id: 2 });
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    now = 5000;
+    await handler.sendChatAction(-100, "typing", threadParams);
+    await handler.sendChatAction(-100, "typing", { message_thread_id: 2 });
+    expect(fn).toHaveBeenCalledTimes(4);
   });
 
   it("coalesces recent same-chat actions after the pending send resolves", async () => {
@@ -211,13 +225,13 @@ describe("createTelegramSendChatActionHandler", () => {
       now: () => now,
     });
 
-    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow();
+    await expect(handler.sendChatAction(123, "typing", { message_thread_id: 1 })).rejects.toThrow();
     expect(logger.mock.calls.at(-1)).toEqual([
       `sendChatAction transient error (1). Cooling down ${expectedCooldownMs}ms before retry.`,
     ]);
 
     now += expectedCooldownMs - 1;
-    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow(
+    await expect(handler.sendChatAction(123, "typing", { message_thread_id: 2 })).rejects.toThrow(
       "transient cooldown active",
     );
     expect(fn).toHaveBeenCalledTimes(1);
@@ -313,8 +327,12 @@ describe("createTelegramSendChatActionHandler", () => {
     });
 
     // Different chatIds all contribute to the same failure counter
-    await expect(handler.sendChatAction(111, "typing")).rejects.toThrow("401");
-    await expect(handler.sendChatAction(222, "typing")).rejects.toThrow("401");
+    await expect(handler.sendChatAction(111, "typing", { message_thread_id: 1 })).rejects.toThrow(
+      "401",
+    );
+    await expect(handler.sendChatAction(111, "typing", { message_thread_id: 2 })).rejects.toThrow(
+      "401",
+    );
     await expect(handler.sendChatAction(333, "typing")).rejects.toThrow("401");
 
     expect(handler.isSuspended()).toBe(true);

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -101,6 +101,8 @@ function resolveChatActionThreadKeyFragment(
   if (!threadParams || typeof threadParams !== "object") {
     return "";
   }
+  // SAFETY: the guard above narrows threadParams to a non-null object; the cast
+  // only adds optional property access for grammy's Other params shape.
   const threadId = (threadParams as { message_thread_id?: unknown }).message_thread_id;
   return typeof threadId === "number" ? `:${threadId}` : "";
 }

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -89,24 +89,6 @@ function is401Error(error: unknown): boolean {
   return normalizeLowercaseStringOrEmpty(message).includes("unauthorized");
 }
 
-/**
- * Extracts a key fragment that distinguishes concurrent forum topics within
- * the same supergroup (#138763). `threadParams` carries `message_thread_id`
- * only for forum-topic typing actions; non-forum actions produce no fragment so
- * they keep coalescing per chat+action as before.
- */
-function resolveChatActionThreadKeyFragment(
-  threadParams: TelegramSendChatActionParams | undefined,
-): string {
-  if (!threadParams || typeof threadParams !== "object") {
-    return "";
-  }
-  // SAFETY: the guard above narrows threadParams to a non-null object; the cast
-  // only adds optional property access for grammy's Other params shape.
-  const threadId = (threadParams as { message_thread_id?: unknown }).message_thread_id;
-  return typeof threadId === "number" ? `:${threadId}` : "";
-}
-
 function isTransientSendChatActionError(error: unknown): boolean {
   return (
     isTelegramRateLimitError(error) ||
@@ -176,8 +158,15 @@ export function createTelegramSendChatActionHandler({
       );
     }
 
-    const threadKeyFragment = resolveChatActionThreadKeyFragment(threadParams);
-    const key = minIntervalMs > 0 ? `${String(chatId)}:${action}${threadKeyFragment}` : undefined;
+    // Include message_thread_id in the coalescing key so concurrent turns in
+    // different forum topics of the same supergroup each get their own typing
+    // indicator (#138763). Non-forum actions pass no thread id and keep
+    // coalescing per chat+action as before.
+    const threadId = threadParams?.message_thread_id;
+    const key =
+      minIntervalMs > 0
+        ? `${String(chatId)}:${action}${typeof threadId === "number" ? `:${threadId}` : ""}`
+        : undefined;
     if (key) {
       const blockedUntil = blockedUntilByKey.get(key);
       if (blockedUntil !== undefined && attemptedAt < blockedUntil) {

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -125,6 +125,8 @@ export function createTelegramSendChatActionHandler({
   let consecutiveTransientFailures = 0;
   let suspended = false;
   let transientCooldownUntilMs = 0;
+  let failureVersion = 0;
+  let authorizationRetryTail = Promise.resolve();
   const blockedUntilByKey = new Map<string, number>();
 
   const clearTransientCooldown = () => {
@@ -139,6 +141,13 @@ export function createTelegramSendChatActionHandler({
     blockedUntilByKey.clear();
   };
 
+  const assertNotCoolingDown = () => {
+    const remainingMs = transientCooldownUntilMs - now();
+    if (remainingMs > 0) {
+      throw new Error(`sendChatAction transient cooldown active for ${Math.ceil(remainingMs)}ms`);
+    }
+  };
+
   const sendChatAction = async (
     chatId: number | string,
     action: ChatAction,
@@ -149,14 +158,8 @@ export function createTelegramSendChatActionHandler({
     }
 
     const attemptedAt = now();
-    const remainingTransientCooldownMs = transientCooldownUntilMs - attemptedAt;
-    if (remainingTransientCooldownMs > 0) {
-      // Reject transient cooldown starts so channel typing guards can count the
-      // failure and stop keepalive loops instead of silently hammering Telegram.
-      throw new Error(
-        `sendChatAction transient cooldown active for ${Math.ceil(remainingTransientCooldownMs)}ms`,
-      );
-    }
+    // Reject cooldown starts so channel typing guards can stop their keepalive loops.
+    assertNotCoolingDown();
 
     const threadId = threadParams?.message_thread_id;
     const key =
@@ -171,18 +174,47 @@ export function createTelegramSendChatActionHandler({
       blockedUntilByKey.set(key, Number.POSITIVE_INFINITY);
     }
 
-    if (consecutive401Failures > 0) {
-      const backoffMs = computeBackoff(BACKOFF_POLICY, consecutive401Failures);
-      logger(
-        `sendChatAction backoff: waiting ${backoffMs}ms before retry ` +
-          `(failure ${consecutive401Failures}/${maxConsecutive401})`,
-      );
-      await sleepWithAbort(backoffMs);
-    }
-
+    let attemptFailureVersion = failureVersion;
+    let releaseAuthorizationRetry: (() => void) | undefined;
     try {
+      if (consecutive401Failures > 0) {
+        // Only one authorization retry may sleep or send for this account at a time.
+        const previousRetry = authorizationRetryTail;
+        authorizationRetryTail = new Promise<void>((resolve) => {
+          releaseAuthorizationRetry = resolve;
+        });
+        await previousRetry;
+        if (suspended) {
+          return;
+        }
+        assertNotCoolingDown();
+      }
+      let failuresBeforeBackoff = consecutive401Failures;
+      while (failuresBeforeBackoff > 0) {
+        const backoffMs = computeBackoff(BACKOFF_POLICY, failuresBeforeBackoff);
+        logger(
+          `sendChatAction backoff: waiting ${backoffMs}ms before retry ` +
+            `(failure ${consecutive401Failures}/${maxConsecutive401})`,
+        );
+        await sleepWithAbort(backoffMs);
+        // Another topic can change account state while this request backs off.
+        if (suspended) {
+          return;
+        }
+        assertNotCoolingDown();
+        // Earlier in-flight calls can add failures; repeat only for a higher failure count.
+        if (consecutive401Failures <= failuresBeforeBackoff) {
+          break;
+        }
+        failuresBeforeBackoff = consecutive401Failures;
+      }
+
+      attemptFailureVersion = failureVersion;
       await sendChatActionFn(chatId, action, threadParams);
-      // Success: reset failure counter
+      // A request admitted before a newer failure cannot establish account recovery.
+      if (attemptFailureVersion !== failureVersion) {
+        return;
+      }
       if (consecutive401Failures > 0) {
         logger(`sendChatAction recovered after ${consecutive401Failures} consecutive 401 failures`);
         consecutive401Failures = 0;
@@ -190,7 +222,10 @@ export function createTelegramSendChatActionHandler({
       clearTransientCooldown();
     } catch (error) {
       if (is401Error(error)) {
-        clearTransientCooldown();
+        if (attemptFailureVersion === failureVersion) {
+          clearTransientCooldown();
+        }
+        failureVersion++;
         consecutive401Failures++;
 
         if (consecutive401Failures >= maxConsecutive401) {
@@ -207,19 +242,24 @@ export function createTelegramSendChatActionHandler({
           );
         }
       } else if (isTransientSendChatActionError(error)) {
+        failureVersion++;
         consecutiveTransientFailures++;
         const cooldownMs = resolveTransientCooldownMs(error, consecutiveTransientFailures);
         const cooldownStartedAt = now();
         // Keep transient failures rejected through the same-chat coalesce window;
         // otherwise the next typing keepalive can look successful and reset its guard.
         const coalescingUntilMs = key ? attemptedAt + minIntervalMs : 0;
-        transientCooldownUntilMs = Math.max(cooldownStartedAt + cooldownMs, coalescingUntilMs);
+        transientCooldownUntilMs = Math.max(
+          transientCooldownUntilMs,
+          cooldownStartedAt + cooldownMs,
+          coalescingUntilMs,
+        );
         const effectiveCooldownMs = Math.max(0, transientCooldownUntilMs - cooldownStartedAt);
         logger(
           `sendChatAction transient error (${consecutiveTransientFailures}). ` +
             `Cooling down ${effectiveCooldownMs}ms before retry.`,
         );
-      } else {
+      } else if (attemptFailureVersion === failureVersion) {
         clearTransientCooldown();
       }
       throw error;
@@ -227,6 +267,7 @@ export function createTelegramSendChatActionHandler({
       if (key) {
         blockedUntilByKey.set(key, attemptedAt + minIntervalMs);
       }
+      releaseAuthorizationRetry?.();
     }
   };
 

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -158,14 +158,10 @@ export function createTelegramSendChatActionHandler({
       );
     }
 
-    // Include message_thread_id in the coalescing key so concurrent turns in
-    // different forum topics of the same supergroup each get their own typing
-    // indicator (#138763). Non-forum actions pass no thread id and keep
-    // coalescing per chat+action as before.
     const threadId = threadParams?.message_thread_id;
     const key =
       minIntervalMs > 0
-        ? `${String(chatId)}:${action}${typeof threadId === "number" ? `:${threadId}` : ""}`
+        ? `${String(chatId)}:${action}${threadId === undefined ? "" : `:${threadId}`}`
         : undefined;
     if (key) {
       const blockedUntil = blockedUntilByKey.get(key);

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -1,8 +1,9 @@
 // Telegram plugin module implements sendchataction 401 and transient backoff behavior.
-import type { Bot } from "grammy";
+import { GrammyError, type Bot, type Transformer } from "grammy";
 import {
   computeBackoff,
   sleepWithAbort,
+  waitForAbortSignal,
   type BackoffPolicy,
 } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -30,12 +31,6 @@ type ChatAction =
 
 type TelegramSendChatActionParams = Parameters<Bot["api"]["sendChatAction"]>[2];
 
-type SendChatActionFn = (
-  chatId: number | string,
-  action: ChatAction,
-  threadParams?: TelegramSendChatActionParams,
-) => Promise<true>;
-
 export type TelegramSendChatActionHandler = {
   /**
    * Send a chat action with automatic 401 backoff and transient cooldown.
@@ -51,7 +46,6 @@ export type TelegramSendChatActionHandler = {
 };
 
 type CreateTelegramSendChatActionHandlerParams = {
-  sendChatActionFn: SendChatActionFn;
   logger: TelegramSendChatActionLogger;
   maxConsecutive401?: number;
   minIntervalMs?: number;
@@ -115,12 +109,11 @@ function resolveTransientCooldownMs(error: unknown, attempt: number): number {
  * suspended until reset() is called.
  */
 export function createTelegramSendChatActionHandler({
-  sendChatActionFn,
   logger,
   maxConsecutive401 = 10,
   minIntervalMs = 0,
   now = () => Date.now(),
-}: CreateTelegramSendChatActionHandlerParams): TelegramSendChatActionHandler {
+}: CreateTelegramSendChatActionHandlerParams) {
   let consecutive401Failures = 0;
   let consecutiveTransientFailures = 0;
   let suspended = false;
@@ -151,7 +144,8 @@ export function createTelegramSendChatActionHandler({
   const sendChatAction = async (
     chatId: number | string,
     action: ChatAction,
-    threadParams?: TelegramSendChatActionParams,
+    threadParams: TelegramSendChatActionParams | undefined,
+    send: () => Promise<true>,
   ): Promise<void> => {
     if (suspended) {
       return;
@@ -174,18 +168,41 @@ export function createTelegramSendChatActionHandler({
       blockedUntilByKey.set(key, Number.POSITIVE_INFINITY);
     }
 
+    try {
+      await send();
+    } finally {
+      if (key) {
+        blockedUntilByKey.set(key, attemptedAt + minIntervalMs);
+      }
+    }
+  };
+
+  const sendWithBackoff = async <T>(send: () => Promise<T>, signal: AbortSignal): Promise<T> => {
+    signal.throwIfAborted();
+    if (suspended) {
+      throw new Error("sendChatAction suspended");
+    }
+    assertNotCoolingDown();
     let attemptFailureVersion = failureVersion;
     let releaseAuthorizationRetry: (() => void) | undefined;
     try {
       if (consecutive401Failures > 0) {
         // Only one authorization retry may sleep or send for this account at a time.
         const previousRetry = authorizationRetryTail;
-        authorizationRetryTail = new Promise<void>((resolve) => {
+        const retryFinished = new Promise<void>((resolve) => {
           releaseAuthorizationRetry = resolve;
         });
-        await previousRetry;
+        // A canceled waiter can release its node without releasing its predecessor.
+        authorizationRetryTail = previousRetry.then(() => retryFinished);
+        await Promise.race([
+          previousRetry,
+          waitForAbortSignal(signal).then(() => {
+            throw new DOMException("Chat action canceled", "AbortError");
+          }),
+        ]);
+        signal.throwIfAborted();
         if (suspended) {
-          return;
+          throw new Error("sendChatAction suspended");
         }
         assertNotCoolingDown();
       }
@@ -196,10 +213,10 @@ export function createTelegramSendChatActionHandler({
           `sendChatAction backoff: waiting ${backoffMs}ms before retry ` +
             `(failure ${consecutive401Failures}/${maxConsecutive401})`,
         );
-        await sleepWithAbort(backoffMs);
+        await sleepWithAbort(backoffMs, signal);
         // Another topic can change account state while this request backs off.
         if (suspended) {
-          return;
+          throw new Error("sendChatAction suspended");
         }
         assertNotCoolingDown();
         // Earlier in-flight calls can add failures; repeat only for a higher failure count.
@@ -210,17 +227,21 @@ export function createTelegramSendChatActionHandler({
       }
 
       attemptFailureVersion = failureVersion;
-      await sendChatActionFn(chatId, action, threadParams);
+      const result = await send();
       // A request admitted before a newer failure cannot establish account recovery.
       if (attemptFailureVersion !== failureVersion) {
-        return;
+        return result;
       }
       if (consecutive401Failures > 0) {
         logger(`sendChatAction recovered after ${consecutive401Failures} consecutive 401 failures`);
         consecutive401Failures = 0;
       }
       clearTransientCooldown();
+      return result;
     } catch (error) {
+      if (signal.aborted && error instanceof Error && error.name === "AbortError") {
+        throw error;
+      }
       if (is401Error(error)) {
         if (attemptFailureVersion === failureVersion) {
           clearTransientCooldown();
@@ -248,7 +269,7 @@ export function createTelegramSendChatActionHandler({
         const cooldownStartedAt = now();
         // Keep transient failures rejected through the same-chat coalesce window;
         // otherwise the next typing keepalive can look successful and reset its guard.
-        const coalescingUntilMs = key ? attemptedAt + minIntervalMs : 0;
+        const coalescingUntilMs = cooldownStartedAt + minIntervalMs;
         transientCooldownUntilMs = Math.max(
           transientCooldownUntilMs,
           cooldownStartedAt + cooldownMs,
@@ -264,14 +285,38 @@ export function createTelegramSendChatActionHandler({
       }
       throw error;
     } finally {
-      if (key) {
-        blockedUntilByKey.set(key, attemptedAt + minIntervalMs);
-      }
       releaseAuthorizationRetry?.();
     }
   };
 
+  // Install before the scheduler so admission runs after its final queue wait.
+  const apiTransformer: Transformer = async (prev, method, payload, signal) => {
+    if (method !== "sendChatAction") {
+      return prev(method, payload, signal);
+    }
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    if (signal?.aborted) {
+      abort();
+    } else {
+      signal?.addEventListener("abort", abort, { once: true });
+    }
+    try {
+      return await sendWithBackoff(async () => {
+        const result = await prev(method, payload, signal);
+        if (!result.ok) {
+          throw new GrammyError(`Call to '${method}' failed!`, result, method, payload);
+        }
+        return result;
+      }, controller.signal);
+    } finally {
+      signal?.removeEventListener("abort", abort);
+      controller.abort();
+    }
+  };
+
   return {
+    apiTransformer,
     sendChatAction,
     isSuspended: () => suspended,
     reset,

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -89,6 +89,22 @@ function is401Error(error: unknown): boolean {
   return normalizeLowercaseStringOrEmpty(message).includes("unauthorized");
 }
 
+/**
+ * Extracts a key fragment that distinguishes concurrent forum topics within
+ * the same supergroup (#138763). `threadParams` carries `message_thread_id`
+ * only for forum-topic typing actions; non-forum actions produce no fragment so
+ * they keep coalescing per chat+action as before.
+ */
+function resolveChatActionThreadKeyFragment(
+  threadParams: TelegramSendChatActionParams | undefined,
+): string {
+  if (!threadParams || typeof threadParams !== "object") {
+    return "";
+  }
+  const threadId = (threadParams as { message_thread_id?: unknown }).message_thread_id;
+  return typeof threadId === "number" ? `:${threadId}` : "";
+}
+
 function isTransientSendChatActionError(error: unknown): boolean {
   return (
     isTelegramRateLimitError(error) ||
@@ -158,7 +174,8 @@ export function createTelegramSendChatActionHandler({
       );
     }
 
-    const key = minIntervalMs > 0 ? `${String(chatId)}:${action}` : undefined;
+    const threadKeyFragment = resolveChatActionThreadKeyFragment(threadParams);
+    const key = minIntervalMs > 0 ? `${String(chatId)}:${action}${threadKeyFragment}` : undefined;
     if (key) {
       const blockedUntil = blockedUntilByKey.get(key);
       if (blockedUntil !== undefined && attemptedAt < blockedUntil) {


### PR DESCRIPTION
Closes #138763.

## What Problem This Solves

Concurrent turns in different Telegram forum topics could show native typing in only one topic because coalescing used the chat and action, without the topic. Separating the topics also exposed shared scheduling and failure-state problems: repeated typing exhausted the message quota, delayed completed replies, and allowed queued actions to bypass newer failures.

## Change

Include topic identity in the existing coalescing key. Keep ephemeral group actions out of message reservoirs, with paced delivery in a separate action queue. All API clients for a bot token share the same message limiter and action failure state.

Check suspension, cooldown, and authorization backoff at final dispatch, after queue waits. Older responses cannot clear newer failures. Cancellation settles queued and backing-off actions without releasing an active predecessor. No configuration change is needed.

## Evidence

Real Telegram Test Server runs use the shipped Gateway, fresh forum topics, a controlled provider, and an independent user recorder. The original baseline at `979a200bcf6a` received paired turns 397 ms apart but showed native typing only in Alpha. The final production build at `53e12bef910b` shows typing in both topics. Revision `3395348d7b9f` changes only the trace test binding and reuses that exact runtime and live evidence.

| Scenario | Before | Final candidate |
| --- | --- | --- |
| Two turns held for 50 seconds | Initial topic-only repair delayed replies until 63.148 / 64.146 s | Repeated typing in both topics; replies at 50.445 / 51.434 s |
| Queued action after a 20-second flood wait | Next request 7 ms after the error | Next request after 20.667 s; typing and replies recover |
| Older success after a six-second flood wait | Next request after 3.528 s | Next request after 6.237 s |
| Another destination during a held authorization retry | Request escaped while the earlier retry was pending | Waits for that result and the increased backoff; next request after 2.096 s |

HTTP 429 and 401 responses are explicitly injected at the Test Bot API proxy. Normal requests and native observations use real Telegram. General-topic and ordinary private-chat typing and replies recover in these runs.

- 79 focused tests, two typing API tests, and five unchanged delivery-trace goldens pass, including the real installed message limiter, topic coalescing, shared failure state, cancellation, voice cues, and recovered dispatch.
- Regressions fail on their preceding implementations. The default suspension test admits ten failed actions across two API clients, blocks the eleventh, and verifies reset/recovery.
- Targeted test and production types, type-aware lint, pinned formatting, source guards, and fresh independent code review pass.
- Complete native observations and source-blind reports are retained for review. Internal coalescing and suspension thresholds also rely on the focused tests and source review; this is not a claim of complete black-box acceptance.

Telegram can cancel a previous topic's indicator when switching topics and batch native updates. The evidence proves typing delivery to each active topic, not continuous simultaneous indicators or an immediate stop after the final reply.

Telegram's documented group and broadcast quotas describe messages. Group actions retain peer pacing and obey server-directed flood waits; no unlimited-action claim is made.

Regression provenance: PR #76951 introduced chat/action-only coalescing in `f5ad8e5b53d418e17390a75b004fcccfb5fc064a` (author VACInc; committer Ayaan Zaidi). Its parent diff was checked.

Original repair by @gaoanze888; additional repair and validation by @obviyus.
