### PR TITLE
refactor(test): reuse the Zalo mock-call assertion helper

### DIFF
--- a/extensions/zalo/src/api.test.ts
+++ b/extensions/zalo/src/api.test.ts
@@ -1,4 +1,5 @@
 // Zalo tests cover api plugin behavior.
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -72,19 +73,11 @@ function createOkFetcher() {
   return vi.fn<ZaloFetch>(async () => new Response(JSON.stringify({ ok: true, result: {} })));
 }
 
-function requireFirstFetchCall(fetcher: ReturnType<typeof createOkFetcher>, label: string) {
-  const [call] = fetcher.mock.calls;
-  if (!call) {
-    throw new Error(`expected ${label}`);
-  }
-  return call;
-}
-
 async function expectPostJsonRequest(run: (token: string, fetcher: ZaloFetch) => Promise<unknown>) {
   const fetcher = createOkFetcher();
   await run("test-token", fetcher);
   expect(fetcher).toHaveBeenCalledTimes(1);
-  const [, init] = requireFirstFetchCall(fetcher, "Zalo request");
+  const [, init] = expectDefined(fetcher.mock.calls[0], "Zalo request");
   if (!init) {
     throw new Error("expected Zalo request init");
   }
@@ -228,7 +221,7 @@ describe("Zalo API request methods", () => {
       await vi.advanceTimersByTimeAsync(25);
 
       await rejected;
-      const [, init] = requireFirstFetchCall(fetcher, "Zalo chat action request");
+      const [, init] = expectDefined(fetcher.mock.calls[0], "Zalo chat action request");
       if (!init) {
         throw new Error("expected Zalo chat action request init");
       }
@@ -268,7 +261,7 @@ describe("Zalo API request methods", () => {
       await vi.advanceTimersByTimeAsync(ZALO_DEFAULT_REQUEST_TIMEOUT_MS);
 
       await rejected;
-      const [, init] = requireFirstFetchCall(fetcher, "Zalo send request");
+      const [, init] = expectDefined(fetcher.mock.calls[0], "Zalo send request");
       if (!init?.signal) {
         throw new Error("expected Zalo send request abort signal");
       }
@@ -321,7 +314,7 @@ describe("Zalo API request methods", () => {
       await getUpdates("test-token", { timeout: 45 }, fetcher);
 
       expect(setTimeoutMock).toHaveBeenCalledWith(expect.any(Function), 50_000);
-      const [, init] = requireFirstFetchCall(fetcher, "Zalo getUpdates request");
+      const [, init] = expectDefined(fetcher.mock.calls[0], "Zalo getUpdates request");
       expect(init?.body).toBe(JSON.stringify({ timeout: "45" }));
     } finally {
       setTimeoutMock.mockRestore();
@@ -355,7 +348,7 @@ describe("Zalo API request methods", () => {
         ZALO_SEND_PHOTO_REQUEST_TIMEOUT_MS,
       );
       expect(fetcher).toHaveBeenCalledTimes(1);
-      const [, init] = requireFirstFetchCall(fetcher, "Zalo photo request");
+      const [, init] = expectDefined(fetcher.mock.calls[0], "Zalo photo request");
       expect(init?.body).toBe(
         JSON.stringify({
           chat_id: "chat-123",


### PR DESCRIPTION
## What Problem This Solves

The Zalo API tests carry a local adapter for requiring the first mock fetch call, duplicating the existing SDK assertion helper. This maintainer-requested cleanup consolidates that assertion without removing coverage.

## Why This Change Was Made

Use `expectDefined(fetcher.mock.calls[0], label)` at the five call sites and delete the local adapter. The generic SDK helper preserves the typed argument tuple and fails when the call is missing. Request-init and abort-signal guards remain explicit at their callers.

## User Impact

No user-visible behavior changes. Production code is unchanged; tests are +6/-13 lines. All 20 API cases and 35 expectations remain, including request methods, timeouts, body handling, photo URL validation, SSRF rejection and cleanup.

## Evidence

- Complete API and loopback probe suites passed before and after: 24/24 each, with identical ordered case inventories per file.
- The normal changed-file gate passed all 19 selected checks, including the plugin test type graph, all three dead-export scans and lint.
- Two-pass managed Codex review found no actionable P0-P2 issues; source and index remained unchanged.

These local checks used base `3d129595202d65d60a363dec093f20861fb2bcf3`. Current main independently removes fake timer handles in three of these tests; that change must remain intact at landing and is not included in this cleanup's LOC count. Fresh hosted CI must validate the merged candidate before landing. No live external Zalo service behavior is claimed or changed.
