### PR TITLE
fix(agents): preserve model errors during thinking recovery

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -21,6 +21,11 @@ to twice without rerunning those tools. Partial responses and unfinished tool
 batches do not qualify for this recovery. No additional retry configuration is
 required.
 
+Thinking-level recovery applies only when the provider identifies a reasoning or
+thinking parameter. Model/account restrictions and unrelated unsupported options
+keep their original failure classification and follow the configured fallback
+policy; OpenClaw does not retry them with thinking disabled.
+
 ## Runtime flow
 
 <Steps>

--- a/src/agents/embedded-agent-helpers/thinking.test.ts
+++ b/src/agents/embedded-agent-helpers/thinking.test.ts
@@ -13,7 +13,7 @@ describe("pickFallbackThinkingLevel", () => {
 
   it("extracts supported values from error message", () => {
     const result = pickFallbackThinkingLevel({
-      message: 'Supported values are: "high", "medium"',
+      message: 'Unsupported reasoning.effort. Supported values are: "high", "medium"',
       attempted: new Set(),
     });
     expect(result).toBe("high");
@@ -21,7 +21,7 @@ describe("pickFallbackThinkingLevel", () => {
 
   it("skips already attempted values", () => {
     const result = pickFallbackThinkingLevel({
-      message: 'Supported values are: "high", "medium"',
+      message: 'Unsupported reasoning_effort. Supported values are: "high", "medium"',
       attempted: new Set(["high"]),
     });
     expect(result).toBe("medium");
@@ -52,7 +52,7 @@ describe("pickFallbackThinkingLevel", () => {
     expect(result).toBeUndefined();
   });
 
-  it('falls back to "off" for generic not-supported messages', () => {
+  it('falls back to "off" for an explicit unsupported-thinking error', () => {
     const result = pickFallbackThinkingLevel({
       message: "thinking level not supported by this provider",
       attempted: new Set(),
@@ -68,9 +68,17 @@ describe("pickFallbackThinkingLevel", () => {
     expect(result).toBeUndefined();
   });
 
-  it("returns undefined for unrelated error messages", () => {
+  it.each([
+    "rate limit exceeded, please retry after 30 seconds",
+    "The 'unavailable-model' model is not supported when using Codex with a ChatGPT account.",
+    "The 'unavailable-thinking-model' model is not supported when using Codex with a ChatGPT account.",
+    "The 'unavailable-reasoning-effort-model' model is not supported when using Codex with a ChatGPT account.",
+    "The 'unavailable-reasoning.effort-model' model is not supported when using Codex with a ChatGPT account.",
+    "This account is not supported by the provider.",
+    'Unsupported service tier. Supported values are: "high", "low"',
+  ])("does not retry unrelated provider failures: %s", (message) => {
     const result = pickFallbackThinkingLevel({
-      message: "rate limit exceeded, please retry after 30 seconds",
+      message,
       attempted: new Set(),
     });
     expect(result).toBeUndefined();

--- a/src/agents/embedded-agent-helpers/thinking.ts
+++ b/src/agents/embedded-agent-helpers/thinking.ts
@@ -6,20 +6,15 @@ import { normalizeThinkLevel, type ThinkLevel } from "../../auto-reply/thinking.
 import { isReasoningConstraintErrorMessage } from "../failover/classify.js";
 
 function extractSupportedValues(raw: string): string[] {
-  const match =
-    raw.match(/supported values are:\s*([^\n.]+)/i) ?? raw.match(/supported values:\s*([^\n.]+)/i);
-  if (!match?.[1]) {
+  const fragment = raw.match(/supported values(?: are)?:\s*([^\n.]+)/i)?.[1];
+  if (!fragment) {
     return [];
   }
-  const fragment = match[1];
-  const quoted = Array.from(fragment.matchAll(/['"]([^'"]+)['"]/g)).map((entry) =>
-    entry[1]?.trim(),
-  );
-  if (quoted.length > 0) {
-    return normalizeStringEntries(quoted.filter((entry): entry is string => Boolean(entry)));
-  }
+  const quoted = Array.from(fragment.matchAll(/['"]([^'"]+)['"]/g), ([, value]) => value);
   return normalizeStringEntries(
-    fragment.split(/,|\band\b/gi).map((entry) => entry.replace(/^[^a-zA-Z]+|[^a-zA-Z]+$/g, "")),
+    quoted.length > 0
+      ? quoted
+      : fragment.split(/,|\band\b/gi).map((entry) => entry.replace(/^[^a-zA-Z]+|[^a-zA-Z]+$/g, "")),
   );
 }
 
@@ -28,36 +23,30 @@ export function pickFallbackThinkingLevel(params: {
   message?: string;
   attempted: Set<ThinkLevel>;
 }): ThinkLevel | undefined {
-  const raw = params.message?.trim();
-  if (!raw) {
+  const raw = params.message?.trim() ?? "";
+  const requiresReasoning = isReasoningConstraintErrorMessage(raw);
+  // Model identifiers can contain these words; require a parameter or reasoning constraint.
+  if (
+    !requiresReasoning &&
+    !/(?<![\w./-])(?:think(?:ing)?(?:[._]|\s+)(?:value|level|budget)|reasoning(?:[._]|\s+)(?:effort|level|budget))(?![\w/-]|\.[\w/-])/i.test(
+      raw,
+    )
+  ) {
     return undefined;
   }
-  // Some OpenRouter/MiniMax endpoints reject `off` entirely and require a
-  // non-zero reasoning level, so our first safe retry is `minimal`.
-  if (isReasoningConstraintErrorMessage(raw) && !params.attempted.has("minimal")) {
+  // Mandatory-reasoning endpoints need the smallest enabled level, never off.
+  if (requiresReasoning && !params.attempted.has("minimal")) {
     return "minimal";
   }
   const supported = extractSupportedValues(raw);
   if (supported.length === 0) {
-    // When the error clearly indicates the thinking level is unsupported but doesn't
-    // list supported values (e.g. OpenAI's "think value \"low\" is not supported for
-    // this model"), fall back to "off" to allow the request to succeed.
-    // This commonly happens during model fallback when switching from Anthropic
-    // (which supports thinking levels) to providers that don't.
-    if (/not supported/i.test(raw) && !params.attempted.has("off")) {
-      return "off";
-    }
-    return undefined;
+    return /not supported/i.test(raw) && !params.attempted.has("off") ? "off" : undefined;
   }
   for (const entry of supported) {
     const normalized = normalizeThinkLevel(entry);
-    if (!normalized) {
-      continue;
+    if (normalized && !params.attempted.has(normalized)) {
+      return normalized;
     }
-    if (params.attempted.has(normalized)) {
-      continue;
-    }
-    return normalized;
   }
   return undefined;
 }

--- a/src/agents/embedded-agent-runner/run/prompt-failure.test.ts
+++ b/src/agents/embedded-agent-runner/run/prompt-failure.test.ts
@@ -65,6 +65,35 @@ function makeParams(overrides: Partial<Params> = {}): Params {
 }
 
 describe("handleEmbeddedPromptFailure", () => {
+  it.each([false, true])(
+    "keeps account-restricted model errors on the model-failure path with fallback=%s",
+    async (fallbackConfigured) => {
+      const promptError = new Error(
+        "400 The 'unavailable-thinking-model' model is not supported when using Codex with a ChatGPT account.",
+      );
+      const params = makeParams({
+        promptError,
+        fallbackConfigured,
+        pluginHarnessOwnsTransport: true,
+        advanceAuthProfile: vi.fn(async () => false),
+        resolveAuthProfileFailureReason: vi.fn(() => null),
+        thinkLevel: "high",
+        attemptedThinking: new Set(["high"]),
+      });
+
+      const error = await handleEmbeddedPromptFailure(params).catch((failure: unknown) => failure);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toHaveProperty("message", promptError.message);
+      expect(params.traceAttempts).toEqual([
+        expect.objectContaining({
+          result: fallbackConfigured ? "fallback_model" : "surface_error",
+          reason: "model_not_found",
+        }),
+      ]);
+    },
+  );
+
   it.each(
     (["prompt", "compaction", "tool_execution"] as const).flatMap((phase) =>
       [false, true].map((fallbackConfigured) => ({ phase, fallbackConfigured })),


### PR DESCRIPTION
Related: #139246

<details>
<summary>Additional instructions</summary>

Maintainers can edit this branch.

</details>

## What Problem This Solves

Fixes an issue where a model rejected for the connected account was retried with thinking disabled. That unnecessary retry could replace the useful model-access error with a Codex lifecycle error, or delay configured model fallback. Unrelated provider options advertising values such as `high` and `low` could also change thinking.

## Why This Change Was Made

The shared recovery helper now requires a reasoning constraint or a named thinking/reasoning parameter before selecting a replacement level. Model names containing those words cannot authorize recovery. The same helper serves prompt failures, assistant failures, and compaction. Supported-value parsing and candidate selection are consolidated.

The completed-thread ownership repair in #139246 remains the canonical Codex lifecycle fix. This change repairs the independent retry decision that exposed it. No config, schema, protocol, or fallback-selection policy changes.

## User Impact

Model/account restrictions retain their original classification: configured defaults can advance to their existing fallback, while explicit model selections report the real failure. Genuine unsupported-thinking and mandatory-reasoning responses retain their existing recovery behavior.

## Evidence

- Captured the reported gateway sequence: accepted turn, provider account/model restriction classified `model_not_found`, incorrect `retry_thinking_level`, then misleading active-thread failure. Private identifiers and original chat contents are omitted.
- Regression tests failed before the fix for unrelated model/account/service-tier errors and model names containing thinking/reasoning terms. Prompt-boundary coverage proves both configured fallback and strict-selection behavior.
- 59 focused helper, prompt-failure, and assistant-failure tests passed; the final parser cleanup rerun passed all 16 helper tests.
- Independent Codex review is clean at P0–P2. [Live recording, screenshots, and exact request trace](https://github.com/openclaw/openclaw/pull/139295#issuecomment-5554253153) show an injected account/model restriction followed by real OpenAI fallback and same-conversation follow-up, all at high thinking. The real isolated Gateway, Codex app-server, and browser ran the exact PR source.
- Production +20/-31 (net **−11**); tests +42/-5; docs +5. Full `pnpm build` passed in Testbox, and [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33985458367) passed all 108 executed checks. Local typechecking rejected the shared dependency symlink; hosted CI supplied complete type/lint/test gates.
