### PR TITLE
fix(release): avoid latest promotion while updating drafts

### DIFF
--- a/scripts/lib/release-publish-children.sh
+++ b/scripts/lib/release-publish-children.sh
@@ -794,11 +794,11 @@ create_or_update_github_release() {
         return 0
       fi
     fi
+    # Latest promotion is invalid while this existing release remains a draft.
     gh release edit "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" \
       --title "${title}" \
       --notes-file "${prepared_release_notes_file}" \
-      "${prerelease_arg}" \
-      "${latest_arg}"
+      "${prerelease_arg}"
   else
     gh release create "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" \
       --verify-tag \

--- a/test/scripts/release-publish-draft.test.ts
+++ b/test/scripts/release-publish-draft.test.ts
@@ -1,0 +1,80 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { expect, it } from "vitest";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+
+it.each([
+  { existing: "draft", distTag: "latest", command: "edit" },
+  { existing: "draft", distTag: "beta", command: "edit" },
+  { existing: "missing", distTag: "latest", command: "create" },
+  { existing: "public", distTag: "latest", command: undefined },
+])(
+  "prepares $existing release on $distTag without promoting a draft",
+  ({ existing, distTag, command }) => {
+    const root = createTempDir("release-publish-draft-");
+    const commands = join(root, "command");
+    const notes = join(root, "notes.md");
+    writeFileSync(notes, "Canonical release notes\n");
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `
+source "$OWNER_SCRIPT"
+verify_release_tag_target() { :; }
+canonical_release_body_matches() { :; }
+gh() {
+  if [[ "$1 $2" == "release view" ]]; then
+    [[ "$EXISTING" != missing ]] || return 1
+    printf '{"isDraft":%s,"body":"canonical"}\\n' "$([[ "$EXISTING" == draft ]] && echo true || echo false)"
+    return
+  fi
+  printf '%s\\n' "$@" > "$COMMAND_FILE"
+  if [[ "$2" == edit && "$EXISTING" == draft && " $* " == *" --latest "* ]]; then
+    echo 'HTTP 422: Latest release cannot be draft or prerelease.' >&2
+    return 1
+  fi
+}
+prepared_release_notes_file="$NOTES_FILE"
+create_or_update_github_release
+`,
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          PATH: process.env.PATH,
+          OWNER_SCRIPT: resolve("scripts/lib/release-publish-children.sh"),
+          EXISTING: existing,
+          COMMAND_FILE: commands,
+          NOTES_FILE: notes,
+          RUNNER_TEMP: root,
+          GITHUB_STEP_SUMMARY: join(root, "summary"),
+          GITHUB_REPOSITORY: "fixture/repository",
+          GITHUB_REF: "refs/tags/release-publish/aaaaaaaaaaaa-1",
+          PARENT_WORKFLOW_SHA: "a".repeat(40),
+          RELEASE_TAG: "v2026.9.2",
+          RELEASE_NPM_DIST_TAG: distTag,
+        },
+      },
+    );
+    expect(result.status, result.stderr).toBe(0);
+    if (!command) {
+      expect(existsSync(commands)).toBe(false);
+      return;
+    }
+    const args = readFileSync(commands, "utf8").trim().split("\n");
+    expect(args.slice(0, 3)).toEqual(["release", command, "v2026.9.2"]);
+    expect(args).toContain(notes);
+    expect(args).not.toContain("--draft=false");
+    if (command === "edit") {
+      expect(args.some((arg) => arg.startsWith("--latest"))).toBe(false);
+    } else {
+      expect(args).toContain("--draft");
+      expect(args).toContain("--latest");
+    }
+  },
+);


### PR DESCRIPTION
## What Problem This Solves

Resuming publication with an existing GitHub release draft fails before core npm dispatch. The draft update passes `--latest`, and GitHub rejects it with HTTP 422: “Latest release cannot be draft or prerelease.” This occurred in [release publication run 33984903214](https://github.com/openclaw/openclaw/actions/runs/33984903214).

## Why This Change Was Made

Omit the latest selector from the existing-release edit. Draft preparation updates its title, notes and prerelease classification; it does not promote the draft. GitHub's [release API contract](https://docs.github.com/en/rest/releases/releases#update-a-release) prohibits making drafts latest.

The previously successful draft-creation command and the existing publication finalizer remain unchanged. Canonical public releases still return before any edit, preserving their verification evidence.

## User Impact

A publication retry can update its existing draft and continue through the same verified release sequence. The release source, tags, artifacts, publication approvals and version policy are unchanged. Executable tooling is net-neutral; the change removes one argument and records the invariant beside the command.

## Evidence

- The observed GitHub failure is retained in run 33984903214; the earlier draft creation succeeded in run 33983793532.
- Four executable shell command-contract cases cover existing drafts on latest/beta, initial draft creation and the canonical public-release fast path. Before the change, both draft-edit cases fail; after it, all four pass. The stable draft case reproduces the observed 422 contract through a fixture, without mutating a real release.
- Three existing publication ownership, setup and finalization guards pass.
- The full changed-file gate passed, including test typechecking and script lint. Independent review is scoped-clean through P2.
