### PR TITLE
perf(media): reduce Markdown attachment extraction allocations

### DIFF
--- a/packages/markdown-core/src/image-spans.ts
+++ b/packages/markdown-core/src/image-spans.ts
@@ -13,6 +13,8 @@ export function findMarkdownImageSpans(markdown: string): MarkdownImageSpan[] {
   md.inline.ruler.enableOnly(["image"]);
   const parseImage = expectDefined(md.inline.ruler.getRules("")[0], "Markdown image rule");
   md.configure("commonmark");
+  // The offset pass below owns inline parsing; retain block/reference normalization here.
+  md.core.ruler.disable("inline");
   // Media normalization owns URL spelling and allowlist matching, not the renderer.
   md.normalizeLink = (url) => url;
   md.validateLink = () => true;
@@ -59,11 +61,7 @@ export function findMarkdownImageSpans(markdown: string): MarkdownImageSpan[] {
   // Parse the same inline content as the renderer. Reintroducing container
   // markers can change inline HTML/code semantics and hide valid images.
   for (const block of blocks) {
-    if (
-      block.type !== "inline" ||
-      !block.map ||
-      !block.children?.some((token) => token.type === "image")
-    ) {
+    if (block.type !== "inline" || !block.map || !block.content.includes("![")) {
       continue;
     }
     source = block.content;


### PR DESCRIPTION
## What Problem This Solves

Extracting attachments from Markdown image replies creates avoidable temporary allocations, particularly when a reply contains many formatted paragraphs or images. This maintainer-requested performance change removes duplicate parsing in the image-span owner.

## Why This Change Was Made

Keep MarkdownIt's block parsing, normalization, and reference definitions, then let the existing offset-aware inline pass recognize images once. The candidate-block check uses the literal `![` introducer required by MarkdownIt's image rule. Image recognition, nested labels, literal code and escaped syntax, reference exclusions, offsets, allowlists, and media ordering retain their existing owners.

Production: +3/-5 lines (net -2). No test or dependency changes. A shared parser/cache or separate parser would introduce unnecessary state or duplicate Markdown semantics.

## User Impact

Image attachment extraction uses less temporary allocation while returning the same captions, destinations, and ordered media segments. This does not claim lower retained heap, RSS, or whole-Gateway memory use.

## Evidence

The actual image-span and media-output owners returned identical complete results across 1,193 synthetic inputs, including three extraction modes, nested labels, containers, HTML/code, references, Unicode/NUL, and LF/CRLF/CR. Serialized output SHA-256: `c98e1670d7eec5d950b53f9f4ea2c6823a6845348875059c2a10c56a05afd3b4`.

Fresh-process Node 26.8.1/macOS arm64 sampling, 4 KiB interval including collected objects, measured cumulative allocation per actual extraction call:

| Input | Before B/call | After B/call |
| --- | ---: | ---: |
| One image | 40,825 | 36,125 |
| 32 image paragraphs | 473,105 | 391,697 |
| 128 image paragraphs | 1,835,413 | 1,558,103 |
| 128 formatted paragraphs, one image | 17,125,642 | 16,064,684 |

Timing was mixed under shared host load. The sparse formatted case measured 7.62 ms before and 16.95 ms after in this pair; this is an allocation result, not a general latency claim. Plain text bypasses parsing, and fenced-image allocation was approximately unchanged.

Before and after: `node scripts/run-vitest.mjs src/media/parse.test.ts` — 127 tests pass. `node scripts/check-changed.mjs -- packages/markdown-core/src/image-spans.ts`, targeted formatting, and `git diff --check` pass. Independent managed review found no actionable P0–P2 findings. Installed MarkdownIt 15.0.1 source was checked directly for stage disabling, normalization, reference creation, image introducer/recursion, and block content. Current main and stable v2026.9.2 preserve the measured baseline owner.

The proof uses real local parser/media code with synthetic input; it is not authenticated channel delivery or integrated Gateway performance proof. No behavior-shaped test was added solely to count parser internals.

### Review follow-up

The exact-version dependency check requested in the ClawSweeper review is complete. The installed MarkdownIt **15.0.1** source map has SHA-256 `3c64d36eb4aeaa06e1e3b5ae8702ba5d964992af9356f4f27e9fc43d7701ed70`. Its extracted image, reference, and ruler sources were compared byte-for-byte with published git head `924b203442f62cea128b5f2680294697621b416d`: [image rule](https://github.com/markdown-it/markdown-it/blob/924b203442f62cea128b5f2680294697621b416d/src/rules_inline/image.ts), [reference rule](https://github.com/markdown-it/markdown-it/blob/924b203442f62cea128b5f2680294697621b416d/src/rules_block/reference.ts), and [rule manager](https://github.com/markdown-it/markdown-it/blob/924b203442f62cea128b5f2680294697621b416d/src/ruler.ts). This check used 15.0.1, not 15.0.0. The image rule requires adjacent `!` and `[` bytes and retains its nested-label/reference behavior; block parsing creates reference definitions before the disabled inline stage, and disabling that named stage is a supported ruler operation.

The review's measurement qualification is accepted and already reflected above: allocation is the supported result, the slower sparse-case timing remains visible, and no general latency or retained-memory improvement is claimed. No source change is needed for these review requests.
