### PR TITLE
perf(sessions): reduce allocations when navigating transcripts

### DIFF
--- a/src/config/sessions/session-entry-navigation.ts
+++ b/src/config/sessions/session-entry-navigation.ts
@@ -191,13 +191,13 @@ export class SessionEntryNavigation<T extends SessionNavigationEntry> {
   }
 
   protected resolveCanonicalParentId(parentId: string | null): string | null {
-    const seen = new Set<string>();
+    let seen: Set<string> | undefined;
     let currentId = parentId;
     while (currentId && !this.byId.has(currentId)) {
-      if (seen.has(currentId)) {
+      if (seen?.has(currentId)) {
         return null;
       }
-      seen.add(currentId);
+      (seen ??= new Set()).add(currentId);
       currentId = this.opaqueParentsById.get(currentId) ?? null;
     }
     return currentId;

--- a/src/config/sessions/transcript-tree.ts
+++ b/src/config/sessions/transcript-tree.ts
@@ -138,17 +138,17 @@ function resolveCanonicalParentId<T>(
   parentId: string | null,
   byId: Pick<ReadonlyMap<string, SessionTranscriptTreeNode<T>>, "get">,
 ): string | null {
-  const seen = new Set<string>();
+  let seen: Set<string> | undefined;
   let currentId = parentId;
   while (currentId !== null) {
-    if (seen.has(currentId)) {
+    if (seen?.has(currentId)) {
       return currentId;
     }
-    seen.add(currentId);
     const parent = byId.get(currentId);
     if (!parent || !isSessionTranscriptLeafControl(parent.entry)) {
       return currentId;
     }
+    (seen ??= new Set()).add(currentId);
     // Leaf controls are omitted from selected paths, so descendants must point
     // through the marker to its normalized visible parent.
     currentId = parent.parentId;


### PR DESCRIPTION
## What Problem This Solves

Reading or navigating long session transcripts allocates a cycle-detection Set for each ordinary parent, even when no indirect ancestry needs traversal. This creates avoidable temporary allocation during branch and context selection.

## Why This Change Was Made

Initialize each resolver's visited Set only when following an opaque parent or a leaf-control parent. Both resolver owners retain their existing cycle results, map lookup order, input access behavior, and branch-level cycle protection. The change does not alter storage, schema, projections, configuration, or public interfaces.

Production: +6/-6 lines (net zero); no test changes. A broader leaf-free shortcut was rejected because it skipped observable parent access/error behavior at the exported context boundary.

## User Impact

Ordinary transcript navigation creates fewer short-lived objects while preserving selected history, reset boundaries, side branches, opaque records, and parent normalization. This is not a retained-memory or whole-Gateway savings claim.

## Evidence

The actual navigation and transcript-tree owners produced identical complete values, message references, input immutability, Map traces, accessor traces, and throwing-accessor results across eleven canonical/opaque/cyclic/leaf/reset/side-append scenarios. At 20,000 entries, separately instrumented construction counts changed from 20,001 to 1 for branch traversal, 20,002 to 2 for tree/ordinary selection, and 20,003 to 3 for leaf selection.

Fresh-process Node 26.8.1/macOS arm64 cumulative allocation sampling, including collected objects:

| 20,000-entry operation | Before B/op | After B/op |
| --- | ---: | ---: |
| Branch | 4,920,732 | 1,849,489 |
| Tree | 17,180,499 | 14,246,902 |
| Selector | 17,234,328 | 14,153,324 |
| Leaf selector | 21,079,382 | 18,095,230 |

All eight small/large workload result hashes match. Timing was mixed under shared host load: branch traversal improved from 1.98 to 1.44 ms, while tree/selector/leaf workloads increased from 9.98/10.47/15.26 to 14.87/20.58/21.27 ms. No general latency improvement is claimed. The deterministic result is removal of unnecessary Sets, with sampled allocation lower in every cohort.

`node scripts/run-vitest.mjs src/config/sessions/transcript-tree.test.ts src/agents/sessions/session-manager-codec.test.ts src/agents/sessions/session-manager.test.ts src/gateway/github-publication-transcript.test.ts` — 73 tests pass. `node scripts/check-changed.mjs -- src/config/sessions/session-entry-navigation.ts src/config/sessions/transcript-tree.ts`, formatting, and `git diff --check` pass. Independent managed review found no actionable P0–P2 findings. Current main and stable v2026.9.2 retain the measured baseline owners.

Proof runs actual local owners on synthetic transcript records. Integrated Gateway performance remains a separate measurement; no source-shaped Set-count test is added to the product suite.
