### PR TITLE
refactor(sqlite): separate quarantine errors from migrations

### DIFF
--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -92,10 +92,10 @@ import {
 } from "./openclaw-agent-db.paths.js";
 import {
   clearOpenClawDatabaseQuarantine,
+  createOpenClawDatabaseVerificationError,
   readOpenClawDatabaseQuarantine,
 } from "./openclaw-quarantine-store.js";
 import {
-  createOpenClawDatabaseVerificationError,
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db.js";

--- a/src/state/openclaw-quarantine-store.ts
+++ b/src/state/openclaw-quarantine-store.ts
@@ -12,6 +12,7 @@ import {
   type SqliteFileGeneration,
 } from "../infra/sqlite-file-generation.js";
 import { VERSION } from "../version.js";
+import { OPENCLAW_DATABASE_SCHEMA_DOCS_URL } from "./openclaw-state-db-contract.js";
 import { resolveOpenClawStateSqliteDir } from "./openclaw-state-db.paths.js";
 
 const OPENCLAW_QUARANTINE_SCHEMA_VERSION = 2;
@@ -26,6 +27,21 @@ type OpenClawDatabaseQuarantine = {
   quarantinedAt: number;
   reason: string;
 };
+
+// Read admission needs this error without importing schema migrations.
+export function createOpenClawDatabaseVerificationError(
+  kind: "agent" | "state",
+  pathname: string,
+  storedError: string | null,
+): Error {
+  // Doctor's clearing hooks run after a full integrity assertion, so a still-
+  // corrupt file cannot be cleared directly: the file must be healthy first.
+  const error = new Error(
+    `OpenClaw ${kind} database ${pathname} is quarantined after integrity verification failed: ${storedError ?? "unknown integrity error"}. Restore the database from a backup or repair it, then run openclaw doctor --fix to clear the quarantine. See ${OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
+  );
+  error.name = "SqliteIntegrityError";
+  return error;
+}
 
 function resolveQuarantineStorePath(env: NodeJS.ProcessEnv): string {
   return path.join(resolveOpenClawStateSqliteDir(env), "openclaw-quarantine.sqlite");

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -8,9 +8,11 @@ import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
 import { createSqliteTerminalOpenLatch } from "../infra/sqlite-terminal-open-latch.js";
 import { isSqliteCorruptionError } from "../infra/sqlite-transaction.js";
 import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
-import { readOpenClawDatabaseQuarantine } from "./openclaw-quarantine-store.js";
+import {
+  createOpenClawDatabaseVerificationError,
+  readOpenClawDatabaseQuarantine,
+} from "./openclaw-quarantine-store.js";
 import type { OpenClawStateDatabase } from "./openclaw-state-db-contract.js";
-import { createOpenClawDatabaseVerificationError } from "./openclaw-state-db-maintenance.js";
 import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 
 const cachedDatabases = new Map<string, OpenClawStateDatabase>();

--- a/src/state/openclaw-state-db-maintenance.ts
+++ b/src/state/openclaw-state-db-maintenance.ts
@@ -7,7 +7,6 @@ import {
 } from "../infra/sqlite-schema-contract.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import {
-  OPENCLAW_DATABASE_SCHEMA_DOCS_URL,
   LAZY_ADDITIVE_STATE_TABLES,
   OPENCLAW_STATE_SCHEMA_VERSION,
   type OpenClawStateDatabaseOptions,
@@ -59,22 +58,6 @@ const STATE_MIGRATION_ALLOWED_MISSING_TABLES = {
   15: LAZY_ADDITIVE_STATE_TABLES,
 } as const satisfies Record<number, readonly string[]>;
 type OpenClawStateMigrationVersion = keyof typeof STATE_MIGRATION_ALLOWED_MISSING_TABLES;
-
-/** Open shared SQLite database handle plus WAL maintenance lifecycle. */
-
-export function createOpenClawDatabaseVerificationError(
-  kind: "agent" | "state",
-  pathname: string,
-  storedError: string | null,
-): Error {
-  // Doctor's clearing hooks run after a full integrity assertion, so a still-
-  // corrupt file cannot be cleared directly: the file must be healthy first.
-  const error = new Error(
-    `OpenClaw ${kind} database ${pathname} is quarantined after integrity verification failed: ${storedError ?? "unknown integrity error"}. Restore the database from a backup or repair it, then run openclaw doctor --fix to clear the quarantine. See ${OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
-  );
-  error.name = "SqliteIntegrityError";
-  return error;
-}
 
 /** Require canonical shared-state ownership without requiring the latest schema. */
 export function assertOpenClawStateDatabaseOwner(

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -111,10 +111,7 @@ export type {
   OpenClawStateDatabaseOptions,
   OpenClawStateDatabaseSchemaMigration,
 } from "./openclaw-state-db-contract.js";
-export {
-  assertOpenClawStateDatabaseForMaintenance,
-  createOpenClawDatabaseVerificationError,
-} from "./openclaw-state-db-maintenance.js";
+export { assertOpenClawStateDatabaseForMaintenance } from "./openclaw-state-db-maintenance.js";
 export { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.js";
 export { detectOpenClawStateDatabaseSchemaMigrations } from "./openclaw-state-db-schema-repair.js";
 


### PR DESCRIPTION
## What Problem This Solves

Readonly database admission imported the entire migration module just to construct a quarantine error. Cold installed-plugin row reads inherited that dependency chain, including the query compiler.

## Why This Change Was Made

Move the unchanged error factory into the existing quarantine owner, which both database openers already use. Update its two callers and remove the unused state-barrel export. Production shrinks by two lines; no new module or test-only production seam is introduced.

Error names/messages, quarantine decisions, file-generation validation, clearing, database schemas and migration behavior are unchanged.

## Evidence

- 236 existing database, readonly, corruption/recovery and Doctor tests passed; one Linux-only descriptor case was skipped on macOS.
- Full changed gate and full build passed, with zero runtime import cycles.
- Actual baseline/candidate native flows preserved shared and agent refusal messages, stored sentinel rows/timestamps, clearing, healthy reopen and generation expiration.
- Actual source-loader observation reduced cold row loads from 535 to 254 files and readonly loads from 532 to 250. Both missing-state leaf reads still return without creating state. These measurements describe source imports, not release-bundle size, latency or RSS.
- Four official CLI commands and five native seed/readback processes passed. In the recorded fixture, plugins list left pristine state absent and plugins registry materialized state through Doctor preflight. This describes that fixture, not a universal registry initialization guarantee. Existing sentinel rows and schema versions survive both commands.
- Sixteen independent P0–P2 review reports are clean. The complete moved factory body is byte-identical to its original implementation.

Synthetic state was removed. Early probe mistakes about aliases, fixture columns and whole-CLI state creation were retained and corrected in the harness; product code stayed unchanged. The separate full-index/config-machine-state import coupling remains outside this focused change.

## Review Compatibility Check

Compatibility evidence for the review's data-model checkpoint: this is a relocation of an error constructor, with no migration or stored-data change. I compared the complete diff and the moved function: its signature and body are byte-identical (SHA-256 `23260a33b1f1bcb03e7b3c50c945e12a7950c937d50bfcc69d4e915159dac119`). Quarantine schema version 2, table definitions, generation checks, migration execution, repair and clearing remain unchanged. Both admission callers retain their arguments and rejection order.

Actual baseline/candidate shared and agent database probes preserve persisted quarantine records, reasons, timestamps, refusal messages, clearing, healthy reopen and generation expiration. The 236 existing database/Doctor tests, full changed gate, full build and official CLI readback also passed. The path-based migration flag therefore does not require a new schema or migration: the requested compatibility evidence is supplied by unchanged code and the existing-store/reopen comparisons above.
