### PR TITLE
fix(gateway): drain update notice work before shutdown

### DIFF
--- a/src/gateway/server-restart-sentinel-notice.test.ts
+++ b/src/gateway/server-restart-sentinel-notice.test.ts
@@ -27,6 +27,7 @@ import {
   resetGatewayWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
+import { AsyncWorkScope } from "../shared/async-work-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
@@ -254,30 +255,41 @@ describe("restart sentinel notice recovery", () => {
     expect(mocks.recoveryDeliver).not.toHaveBeenCalled();
   });
 
-  it("bounds a blocked lifecycle send to ten seconds and preserves queued recovery", async () => {
+  it("bounds a blocked lifecycle send while its work owner retains queue settlement", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const queueId = "update-run-ack:timeout";
     const started = createDeferredCore();
     const finish = createDeferredCore();
+    const work = new AsyncWorkScope();
     mocks.sendDurableMessageBatch.mockImplementationOnce(async () => {
       started.resolve();
       await finish.promise;
       return { status: "sent", results: [{ channel: "whatsapp", messageId: "late-ack" }] };
     });
     let settled = false;
-    const send = sendLifecycleNotice(queueId).finally(() => {
-      settled = true;
-    });
+    const send = work
+      .track(() => sendLifecycleNotice(queueId))
+      .finally(() => {
+        settled = true;
+      });
     await started.promise;
 
+    let drained = false;
+    let draining: Promise<void> | undefined;
     try {
       await vi.advanceTimersByTimeAsync(9_999);
       expect(settled).toBe(false);
       await vi.advanceTimersByTimeAsync(1);
       await expect(send).resolves.toBe(false);
       expect(queueStatus(queueId)).toBe("pending");
+      draining = work.drain().then(() => {
+        drained = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(drained).toBe(false);
     } finally {
       finish.resolve();
+      await (draining ?? work.drain());
       await vi.waitFor(() => expect(queueStatus(queueId)).toBe("completed"));
     }
     expect(mocks.recoveryDeliver).not.toHaveBeenCalled();
@@ -289,6 +301,7 @@ describe("restart sentinel notice recovery", () => {
     const started = createDeferredCore();
     const finish = createDeferredCore();
     const completed = createDeferredCore();
+    const work = new AsyncWorkScope();
     const result = attachOutboundDeliveryCommitHook(
       { channel: "whatsapp", messageId: "ack-before-hook-timeout" },
       async () => {
@@ -298,15 +311,23 @@ describe("restart sentinel notice recovery", () => {
       },
     );
     mocks.sendDurableMessageBatch.mockResolvedValueOnce({ status: "sent", results: [result] });
-    const send = sendLifecycleNotice(queueId);
+    const send = work.track(() => sendLifecycleNotice(queueId));
     await started.promise;
 
+    let drained = false;
+    let draining: Promise<void> | undefined;
     try {
       expect(queueStatus(queueId)).toBe("completed");
       await vi.advanceTimersByTimeAsync(10_000);
       await expect(send).resolves.toBe(true);
+      draining = work.drain().then(() => {
+        drained = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(drained).toBe(false);
     } finally {
       finish.resolve();
+      await (draining ?? work.drain());
       await completed.promise;
     }
     expect(mocks.recoveryDeliver).not.toHaveBeenCalled();

--- a/src/gateway/server-restart-sentinel-notice.ts
+++ b/src/gateway/server-restart-sentinel-notice.ts
@@ -42,6 +42,7 @@ import { resolveOutboundTarget } from "../infra/outbound/targets.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { stringifyRouteThreadId } from "../plugin-sdk/channel-route.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { trackAsyncWork } from "../shared/async-work-scope.js";
 import type { DeliveryContext } from "../utils/delivery-context.shared.js";
 import { withTimeout } from "../utils/with-timeout.js";
 
@@ -103,7 +104,7 @@ export function resolveGatewayLifecycleNoticeRoute(params: {
   };
 }
 
-/** Await one durable attempt; recovery retains failed custody without delaying shutdown. */
+/** Return bounded delivery status while managed scopes retain the complete attempt. */
 export async function sendGatewayLifecycleNotice(
   params: GatewayLifecycleNotice & {
     deps: CliDeps;
@@ -113,7 +114,8 @@ export async function sendGatewayLifecycleNotice(
   let delivered = false;
   try {
     await withTimeout(
-      (async () => {
+      // The response deadline does not end transport or commit-hook ownership.
+      trackAsyncWork(async () => {
         const queued = await enqueueGatewayLifecycleNotice(params, params.deliveryIntentId);
         if (!queued.created) {
           return;
@@ -128,7 +130,7 @@ export async function sendGatewayLifecycleNotice(
             delivered = true;
           },
         );
-      })(),
+      }),
       10_000,
       "update.run notice",
     );

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -1255,6 +1255,38 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(updateCheck.stop).toHaveBeenCalledOnce();
   });
 
+  it("joins update notices before releasing the update-check shutdown owner", async () => {
+    const notices = createDeferred();
+    const stopWatcher = vi.fn(() => notices.promise);
+    const watcherModule = await import("./update-run-watcher.js");
+    const startWatcher = vi
+      .spyOn(watcherModule, "startUpdateRunWatcher")
+      .mockReturnValue({ stop: stopWatcher });
+    const result = await startGatewayPostAttachRuntime(
+      createPostAttachParams(),
+      createPostAttachRuntimeDeps(),
+    );
+    let stopped = false;
+    const stopping = result.stopGatewayUpdateCheck().then(() => {
+      stopped = true;
+    });
+    try {
+      expect(stopWatcher).toHaveBeenCalledOnce();
+      expect(hoisted.updateCheck.stop).toHaveBeenCalledOnce();
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(stopped).toBe(false);
+      notices.resolve();
+      await stopping;
+      expect(stopped).toBe(true);
+    } finally {
+      notices.resolve();
+      await stopping;
+      startWatcher.mockRestore();
+    }
+  });
+
   it("fences update discovery immediately and joins its pending initialization", async () => {
     const initialization = createDeferred<Awaited<ReturnType<UpdateCheck["initialize"]>>>();
     const cleanup = createDeferred();

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1099,11 +1099,10 @@ function createDeferredGatewayUpdateCheck(params: {
 
   const stop = () => {
     stopped = true;
-    runWatcher?.stop();
     return (stopPromise ??= (async () => {
       // Fence immediately; a lazy factory that finishes later stops its own
       // owner below. Never join the post-ready barrier during failed startup.
-      const cleanup = owner?.stop();
+      const cleanup = Promise.all([runWatcher?.stop(), owner?.stop()]);
       await ownerReady;
       await cleanup;
       await initialization;

--- a/src/gateway/update-run-watcher.test.ts
+++ b/src/gateway/update-run-watcher.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateRunRecord } from "../infra/update-run-record.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { startUpdateRunWatcher, wakeUpdateRunWatcher } from "./update-run-watcher.js";
 
 const ledger = vi.hoisted(() => ({
@@ -28,8 +29,8 @@ beforeEach(() => {
   ledger.reads.mockClear();
   ledger.notice.mockClear();
 });
-afterEach(() => {
-  watcher?.stop();
+afterEach(async () => {
+  await watcher?.stop();
   watcher = undefined;
   vi.useRealTimers();
 });
@@ -50,6 +51,40 @@ function currentRunEvent() {
 }
 
 describe("Gateway update run watcher", () => {
+  it("joins an entered notice during shutdown and retires queued notices", async () => {
+    beginRun();
+    const notice = createDeferredCore();
+    const events: string[] = [];
+    ledger.notice.mockImplementationOnce(async () => {
+      events.push("notice-started");
+      await notice.promise;
+      events.push("notice-completed");
+    });
+    watcher = startUpdateRunWatcher({ broadcast: vi.fn(), log: { warn: vi.fn() } });
+    ledger.run = { ...ledger.run!, phase: "activating", updatedAtMs: 2 };
+    await vi.advanceTimersByTimeAsync(2_000);
+    ledger.run = {
+      ...ledger.run!,
+      phase: "finished",
+      status: "succeeded",
+      updatedAtMs: 3,
+      steps: [{ step: "notice:ack", status: "completed" }],
+    };
+    await vi.advanceTimersByTimeAsync(2_000);
+    const stopping = Promise.resolve(watcher.stop()).then(() => events.push("stopped"));
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      expect(events).toEqual(["notice-started"]);
+      notice.resolve();
+      await stopping;
+      expect(events).toEqual(["notice-started", "notice-completed", "stopped"]);
+      expect(ledger.notice).toHaveBeenCalledOnce();
+    } finally {
+      notice.resolve();
+      await stopping;
+    }
+  });
+
   it("notifies only activating and terminal phase changes, not detail revisions", async () => {
     beginRun();
     ledger.run!.steps = [{ step: "notice:ack", status: "completed" }];
@@ -103,12 +138,12 @@ describe("Gateway update run watcher", () => {
     expect(broadcast).toHaveBeenCalledTimes(3);
   });
 
-  it.each(["teardown", "deadline"] as const)("bounds a running watcher at %s", (ending) => {
+  it.each(["teardown", "deadline"] as const)("bounds a running watcher at %s", async (ending) => {
     beginRun();
     const broadcast = vi.fn();
     watcher = startUpdateRunWatcher({ broadcast, log: { warn: vi.fn() } });
     if (ending === "teardown") {
-      watcher.stop();
+      await watcher.stop();
     } else {
       vi.advanceTimersByTime(45 * 60_000);
     }

--- a/src/gateway/update-run-watcher.ts
+++ b/src/gateway/update-run-watcher.ts
@@ -1,6 +1,7 @@
 import { formatErrorMessage } from "../infra/errors.js";
 import { findActiveUpdateRun, getUpdateRun } from "../infra/update-run-ledger.js";
 import type { UpdateRunPhase } from "../infra/update-run-record.js";
+import { AsyncWorkScope } from "../shared/async-work-scope.js";
 import { GATEWAY_EVENT_UPDATE_RUN_CHANGED } from "./events.js";
 import type { GatewayBroadcastFn } from "./server-broadcast-types.js";
 
@@ -13,12 +14,12 @@ export function wakeUpdateRunWatcher(): void {
   wakeCurrentWatcher?.();
 }
 
-/** The update-check lifecycle owns polling and fences it before Gateway teardown. */
+/** The update-check lifecycle joins notices and their transport tails before Gateway teardown. */
 export function startUpdateRunWatcher(params: {
   broadcast: GatewayBroadcastFn;
   log: { warn: (message: string) => void };
-}): { stop: () => void } {
-  let stopped = false;
+}): { stop: () => Promise<void> } {
+  const work = new AsyncWorkScope();
   let timer: ReturnType<typeof setTimeout> | undefined;
   let watched:
     | { runId: string; startedAtMs: number; revision?: number; phase?: UpdateRunPhase }
@@ -26,7 +27,7 @@ export function startUpdateRunWatcher(params: {
   let notices = Promise.resolve();
 
   const poll = () => {
-    if (stopped) {
+    if (work.isClosing) {
       return;
     }
     timer = undefined;
@@ -56,19 +57,21 @@ export function startUpdateRunWatcher(params: {
           (step) => step.step === "notice:ack" && step.status === "completed",
         );
         if (run.phase === "activating" || (terminal && acknowledged)) {
-          notices = notices
-            .then(async () => {
-              if (stopped) {
-                return;
-              }
-              const { notifyUpdateRunPhase } = await import("./update-run-notice.runtime.js");
-              if (!stopped) {
-                await notifyUpdateRunPhase(run);
-              }
-            })
-            .catch((error: unknown) => {
-              params.log.warn(`update run notice failed: ${formatErrorMessage(error)}`);
-            });
+          notices = work.track(() =>
+            notices
+              .then(async () => {
+                if (work.isClosing) {
+                  return;
+                }
+                const { notifyUpdateRunPhase } = await import("./update-run-notice.runtime.js");
+                if (!work.isClosing) {
+                  await notifyUpdateRunPhase(run);
+                }
+              })
+              .catch((error: unknown) => {
+                params.log.warn(`update run notice failed: ${formatErrorMessage(error)}`);
+              }),
+          );
         }
       }
       if (terminal || expired) {
@@ -96,7 +99,6 @@ export function startUpdateRunWatcher(params: {
   wake();
   return {
     stop: () => {
-      stopped = true;
       if (timer) {
         clearTimeout(timer);
         timer = undefined;
@@ -104,6 +106,7 @@ export function startUpdateRunWatcher(params: {
       if (wakeCurrentWatcher === wake) {
         wakeCurrentWatcher = undefined;
       }
+      return work.drain();
     },
   };
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where Gateway shutdown could finish stopping the update-notification owner while an activation or final update notice was still being delivered or committing its delivery record. Later teardown could then overlap work that shutdown treated as finished, including when the notice had already reached its ten-second response deadline.

## Why This Change Was Made

The watcher now uses the existing `AsyncWorkScope` to retain its FIFO work and join entered notices during shutdown, replacing its separate stopped flag; the update-check shutdown caller joins that owner too. The lifecycle notifier tracks the original enqueue/send/commit operation **before** applying the unchanged response timeout, so a timed-out response no longer releases ownership of still-running work.

## User Impact

Gateway shutdown now waits for entered update-notice work and its cooperating delivery/commit work instead of treating polling cancellation or a response timeout as completion. Queued notices that have not entered remain fenced during shutdown. Notice content, duplicate suppression, retry limits, configuration, and stored representations are unchanged; this does not guarantee delivery through a forced process termination.

## Evidence

Candidate: `71853ed26f3c4397f97a32d8368a4b368a472896`.

Four failures were captured before the production repair in existing suites:

- Watcher stop resolved while an entered notice was blocked: **1 failed, 5 passed**.
- The existing blocked-send and delayed-after-commit cases drained their owner after the response deadline, before the original operation settled: **2 failed, 13 passed**.
- The startup caller's stop resolved while watcher stop remained pending: **1 targeted failure**.

The complete three-file replay passed on Node 24.20.0:

```sh
node scripts/run-vitest.mjs \
  src/gateway/update-run-watcher.test.ts \
  src/gateway/server-restart-sentinel-notice.test.ts \
  src/gateway/server-startup-post-attach.test.ts
```

**137 passed in 3 files; 14.95 seconds including the repository wrapper.** Only a clarifying production comment changed afterward. The tests exercise synthetic transport with real SQLite delivery-queue custody, delayed send/commit settlement, duplicate suppression, restart admission, failure/recovery behavior, the existing 45-attempt budget, and startup/stop fences. They are not a live external-channel or full process-handoff test.

Focused lint, six-file formatting, and `git diff --check` passed. Independent scoped review completed all three packets with no accepted/actionable P0–P2 findings; it was static review, not additional runtime proof.

**Ownership and size:** production **+27/−23, net +4**; tests **+97/−9, net +88**. The remaining growth expresses two distinct requirements: FIFO orders notifier calls, while the scope owns their lifetime and underlying work beyond the response deadline. Removing the duplicate stopped flag and using the existing scope avoids another queue/registry. FIFO does not establish strict platform-send ordering after a timeout.

**Dependency and tooling limits:** installed `@openclaw/fs-safe` 0.7.0 differs from required 0.8.1, but their complete `timing.js` and `timing.d.ts` were directly inspected and byte-identical. This verifies the specific non-cancelling `Promise.race` contract, not package-wide equivalence. Installed Undici 8.10.0 also differs from required 8.10.2. The local core typecheck remains failed with four `assertBeforeRename` option diagnostics at unchanged `install-package-dir.ts` sites; the full changed-file gate was only classified by dry-run, not passed. Exact-head hosted CI [33986006909](https://github.com/openclaw/openclaw/actions/runs/33986006909) subsequently passed: 107 successful jobs and 17 skipped. The final PR-wide rollup had 131 successful, 45 skipped and one neutral check, with none unfinished or failed. Native prepare verified those gates against the unchanged head; the local dependency qualifications above remain.

**Shutdown limits:** the scope abort signal is not currently forwarded into this notice's preparation/send path. Direct embedded `server.close()` can therefore wait indefinitely for a never-settling admitted transport or commit hook. Existing CLI hard-stop and managed-update parent deadlines remain intact, but forced termination is not graceful completion. Source review found no demonstrated bundled-transport cycle that requires the later channel teardown to release this work; full embedded-close, native handoff, and live-provider cancellation remain unverified.

## Embedded-close decision

Retain the joined lifetime contract in this repair. This resolves the review's requested tradeoff: an admitted notice still owns delivery/state resources until its original operation and commit hooks settle. Ending that ownership at the response timeout would reintroduce the reproduced teardown race. The existing CLI watchdog and managed-update parent deadline remain the outer process bounds; direct embedded callers do not gain a bounded-close guarantee.

Cooperative cancellation across transport preparation, adapters and commit hooks is a separate owner-contract improvement, not a timeout added around this join. No bundled teardown-dependent cycle was established in the source challenge. This choice deliberately preserves resource-lifetime correctness and does not claim live cancellation or graceful completion for permanently non-cooperating work.
