### PR TITLE
refactor(plugins): centralize installed-index transaction queries

### DIFF
--- a/scripts/check-kysely-guardrails.mts
+++ b/scripts/check-kysely-guardrails.mts
@@ -141,7 +141,6 @@ const rawSqliteAllowPathGroups = {
     "src/plugin-sdk/memory-core-host-engine-storage.ts",
     "src/plugins/installed-plugin-index-record-reader.ts",
     "src/plugins/installed-plugin-index-store-write.ts",
-    "src/plugins/installed-plugin-index-store.ts",
     "src/plugin-state/plugin-state-store.sqlite.ts",
     "src/tasks/task-flow-registry.store.sqlite.ts",
     "src/tasks/task-registry.store.sqlite.ts",

--- a/src/plugins/installed-plugin-index-row.ts
+++ b/src/plugins/installed-plugin-index-row.ts
@@ -5,6 +5,8 @@ import {
   type InstalledPluginIndexStoreOptions,
 } from "./installed-plugin-index-store-path.js";
 
+export const INSTALLED_PLUGIN_INDEX_STATE_KEY = "plugins.installedIndex";
+
 /** Read failures must escape before either projection can authorize recovery or rebuilding. */
 export function readPersistedInstalledPluginIndexRowSync(
   options: InstalledPluginIndexStoreOptions,
@@ -20,7 +22,7 @@ export function readPersistedInstalledPluginIndexRowSync(
       db
         .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ?")
         // SAFETY: config_machine_state.value_json is TEXT NOT NULL under STRICT.
-        .get("plugins.installedIndex") as { value_json: string } | undefined
+        .get(INSTALLED_PLUGIN_INDEX_STATE_KEY) as { value_json: string } | undefined
     );
   }, resolveInstalledPluginIndexStateDatabaseOptions(options));
 }

--- a/src/plugins/installed-plugin-index-store-write.ts
+++ b/src/plugins/installed-plugin-index-store-write.ts
@@ -1,6 +1,7 @@
 /** Writes, restores, and refreshes the installed plugin index in the state database. */
 import { existsSync } from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
+import { safeParseJson } from "@openclaw/normalization-core/json-coercion";
 import {
   createPluginInstallRecordMap,
   inspectPluginInstallRecordMap,
@@ -10,6 +11,8 @@ import {
 } from "../config/plugin-install-record-map.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { resolveUserPath } from "../infra/home-dir.js";
+import { compileSqliteQueryBindings, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { withBundledPluginEnablementCompat } from "./bundled-compat.js";
@@ -25,15 +28,13 @@ import {
 import { resolveCompatRegistryVersion } from "./installed-plugin-index-policy.js";
 import { clearLoadInstalledPluginIndexInstallRecordsCache } from "./installed-plugin-index-record-cache.js";
 import { findForeignManagedNpmInstallRecordPluginIds } from "./installed-plugin-index-record-reader.js";
+import { INSTALLED_PLUGIN_INDEX_STATE_KEY } from "./installed-plugin-index-row.js";
 import { resolveInstalledPluginIndexStateDatabaseOptions } from "./installed-plugin-index-store-path.js";
 import {
-  INSTALLED_PLUGIN_INDEX_STATE_KEY,
-  parseInstalledPluginIndexSqliteRow,
-  readInstalledPluginIndexRow,
+  parseInstalledPluginIndex,
   readPersistedInstalledPluginIndexSync,
   resolveInstalledPluginIndexStorePath,
   type InstalledPluginIndexStoreOptions,
-  type PersistedInstalledPluginIndexValue,
 } from "./installed-plugin-index-store.js";
 import {
   extractPluginInstallRecordsFromInstalledPluginIndex,
@@ -58,6 +59,39 @@ export type InstalledPluginIndexWriteReceipt = {
   previous: InstalledPluginIndex | null;
   revision: number;
 };
+
+type InstalledPluginIndexDatabase = Pick<OpenClawStateKyselyDatabase, "config_machine_state">;
+type PersistedInstalledPluginIndexValue = { revision: number; index: unknown };
+
+function readInstalledPluginIndexRow(
+  database: DatabaseSync,
+): PersistedInstalledPluginIndexValue | undefined {
+  const { compiled, bind } = compileSqliteQueryBindings<void>(() =>
+    getNodeSqliteKysely<InstalledPluginIndexDatabase>(database)
+      .selectFrom("config_machine_state")
+      .select("value_json")
+      .where("state_key", "=", INSTALLED_PLUGIN_INDEX_STATE_KEY),
+  );
+  // sqlite-allow-raw: Compiled SQL keeps the transaction's native point-read errors.
+  // SAFETY: The compiled query selects the canonical STRICT table's TEXT column.
+  const row = database.prepare(compiled.sql).get(...bind()) as
+    | Pick<InstalledPluginIndexDatabase["config_machine_state"], "value_json">
+    | undefined;
+  if (!row) {
+    return undefined;
+  }
+  const value = safeParseJson(row.value_json);
+  if (
+    !value ||
+    typeof value !== "object" ||
+    // SAFETY: shape-checked field probe; the full value is validated below.
+    typeof (value as PersistedInstalledPluginIndexValue).revision !== "number"
+  ) {
+    return undefined;
+  }
+  // SAFETY: revision checked above; index stays unknown until parseInstalledPluginIndex.
+  return value as PersistedInstalledPluginIndexValue;
+}
 
 function assertWritableInstalledPluginIndexStoreOptions(
   options: InstalledPluginIndexStoreOptions,
@@ -124,17 +158,23 @@ function writePersistedInstalledPluginIndexRow(
     revision,
     index: persistedIndex,
   } satisfies PersistedInstalledPluginIndexValue);
-  database
-    .prepare(
-      `
-        INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
-        VALUES (?, ?, ?)
-        ON CONFLICT(state_key) DO UPDATE SET
-          value_json = excluded.value_json,
-          updated_at_ms = excluded.updated_at_ms
-      `,
-    )
-    .run(INSTALLED_PLUGIN_INDEX_STATE_KEY, valueJson, revision);
+  const { compiled, bind } = compileSqliteQueryBindings<void>(() =>
+    getNodeSqliteKysely<InstalledPluginIndexDatabase>(database)
+      .insertInto("config_machine_state")
+      .values({
+        state_key: INSTALLED_PLUGIN_INDEX_STATE_KEY,
+        value_json: valueJson,
+        updated_at_ms: revision,
+      })
+      .onConflict((conflict) =>
+        conflict.column("state_key").doUpdateSet((eb) => ({
+          value_json: eb.ref("excluded.value_json"),
+          updated_at_ms: eb.ref("excluded.updated_at_ms"),
+        })),
+      ),
+  );
+  // sqlite-allow-raw: Serialization precedes native prepare; the caller owns rollback.
+  database.prepare(compiled.sql).run(...bind());
 }
 
 function writePersistedInstalledPluginIndexToSqlite(
@@ -165,7 +205,7 @@ function writePersistedInstalledPluginIndexToSqlite(
     );
     writePersistedInstalledPluginIndexRow(db, persisted, revision);
     return {
-      previous: parseInstalledPluginIndexSqliteRow(previousRow),
+      previous: previousRow ? parseInstalledPluginIndex(previousRow.index) : null,
       revision,
     };
   }, resolveInstalledPluginIndexStateDatabaseOptions(options));
@@ -213,9 +253,13 @@ export async function restorePersistedInstalledPluginIndexIfCurrent(
         resolveNextInstalledPluginIndexRevision(currentRevision),
       );
     } else {
-      db.prepare("DELETE FROM config_machine_state WHERE state_key = ?").run(
-        INSTALLED_PLUGIN_INDEX_STATE_KEY,
+      const { compiled, bind } = compileSqliteQueryBindings<void>(() =>
+        getNodeSqliteKysely<InstalledPluginIndexDatabase>(db)
+          .deleteFrom("config_machine_state")
+          .where("state_key", "=", INSTALLED_PLUGIN_INDEX_STATE_KEY),
       );
+      // sqlite-allow-raw: Compiled SQL preserves native deletion in the leased transaction.
+      db.prepare(compiled.sql).run(...bind());
     }
     return true;
   }, resolveInstalledPluginIndexStateDatabaseOptions(storeOptions));

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -1,6 +1,4 @@
 /** Reads and parses the installed plugin index in the state database. */
-import type { DatabaseSync } from "node:sqlite";
-import { safeParseJson } from "@openclaw/normalization-core/json-coercion";
 import { z } from "zod";
 import {
   parsePluginInstallRecordMap,
@@ -24,8 +22,6 @@ export {
 } from "./installed-plugin-index-store-path.js";
 
 const StringArraySchema = z.array(z.string());
-// Shared with installed-plugin-index-store-write.ts.
-export const INSTALLED_PLUGIN_INDEX_STATE_KEY = "plugins.installedIndex";
 
 const InstalledPluginIndexStartupSchema = z.object({
   sidecar: z.boolean(),
@@ -154,49 +150,6 @@ export function parseInstalledPluginIndex(value: unknown): InstalledPluginIndex 
     ),
     diagnostics: parsed.diagnostics,
   };
-}
-
-// Shared with installed-plugin-index-store-write.ts.
-export type PersistedInstalledPluginIndexValue = {
-  revision: number;
-  index: unknown;
-};
-
-// Shared with installed-plugin-index-store-write.ts.
-export function parseInstalledPluginIndexSqliteRow(
-  value: PersistedInstalledPluginIndexValue | undefined,
-): InstalledPluginIndex | null {
-  return value ? parseInstalledPluginIndex(value.index) : null;
-}
-
-// Shared with installed-plugin-index-store-write.ts.
-export function readInstalledPluginIndexRow(
-  database: DatabaseSync,
-): PersistedInstalledPluginIndexValue | undefined {
-  const row = database
-    .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ?")
-    // SAFETY: config_machine_state.value_json is TEXT NOT NULL under STRICT.
-    .get(INSTALLED_PLUGIN_INDEX_STATE_KEY) as { value_json: string } | undefined;
-  return parsePersistedInstalledPluginIndexRow(row);
-}
-
-function parsePersistedInstalledPluginIndexRow(
-  row: { value_json: string } | undefined,
-): PersistedInstalledPluginIndexValue | undefined {
-  if (!row) {
-    return undefined;
-  }
-  const value = safeParseJson(row.value_json);
-  if (
-    !value ||
-    typeof value !== "object" ||
-    // SAFETY: shape-checked field probe; the full value is validated below.
-    typeof (value as PersistedInstalledPluginIndexValue).revision !== "number"
-  ) {
-    return undefined;
-  }
-  // SAFETY: revision checked above; index stays unknown until parseInstalledPluginIndex.
-  return value as PersistedInstalledPluginIndexValue;
 }
 
 export async function readPersistedInstalledPluginIndex(


### PR DESCRIPTION
## What Problem This Solves

Installed-plugin index transactions kept their row reader and parser exported from the metadata-read module, with ordinary SQL split between two owners and the state key defined twice.

## Why This Change Was Made

The writer now owns its private predecessor/current-row decoder and compiles SELECT, UPSERT, and DELETE queries against the generated state schema. Both paths share the key through the existing lightweight row module. The redundant parser wrapper and obsolete raw-SQL allowance are removed.

Native `.get()`/`.run()`, exact transaction handles, serialization-before-prepare, lease/read ordering, monotonic revisions, rollback and cache invalidation are preserved. Production code shrinks by one line; the guard allowance shrinks by one entry.

## User Impact

Plugin registry refresh, installation metadata, conditional compensation and running Gateway inventory keep their existing behavior. SQLite schemas, stored representations, public SDK/config surfaces and retention policies are unchanged.

## Evidence

- 62 tests across four existing persistence/read-state/install-record suites passed, including two-process failed-config compensation.
- 19 actual native baseline/candidate cases matched complete rows, errors and operation order, covering 75,602-byte JSON, stale leases, trigger/prepare/authorizer failures, rollback/retry and reopen.
- Cold source-loader module sets stayed identical; the installed-index writer remains absent from both metadata-read entrypoints.
- Full changed gate, explicit Kysely guard and full `pnpm build` passed.
- Six fresh built CLI processes performed registry refresh/read/list before and after a synthetic plugin version change. Every registry result was fresh, the revision advanced, and the disabled plugin runtime was never activated. A final fresh SQLite process verified the unchanged persisted row after the cold reads; all owned synthetic homes were cleaned up.

Live proof covers the actual CLI and fresh-process SQLite flow. Existing tests cover running-Gateway inventory pinning; this change does not claim a new live Gateway restart test or a measured startup performance improvement.

Four independent P0–P2 review reports are clean.
