### PR TITLE
fix(shell-env): detach the login-shell probe so it cannot stop the CLI with SIGTTOU

### DIFF
--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -171,6 +171,8 @@ before login startup files run. Bash reads `/etc/profile` and the first availabl
 profile (`~/.bash_profile`, `~/.bash_login`, or `~/.profile`); many login profiles also source
 `~/.bashrc`. Keep those files quiet and bounded because their output, long-running work, or
 failures can affect OpenClaw startup. Other shells use noninteractive login startup (`-l -c`).
+The probe runs in its own session, detached from your terminal, so startup files get no job
+control and cannot take over the terminal that runs OpenClaw.
 This interactive Bash mode is limited to explicit shell env imports; automatic executable PATH
 discovery during ordinary Gateway commands remains noninteractive.
 

--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -1,5 +1,5 @@
 // Covers shell environment fallback loading.
-import { execFileSync } from "node:child_process";
+import childProcess, { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -678,13 +678,21 @@ describe("shell env fallback", () => {
     "runs the login-shell probe in its own session",
     () => {
       const shell = "/bin/bash";
-      const home = tempDirs.make("openclaw-shell-session-");
-      fs.writeFileSync(
-        path.join(home, ".bash_profile"),
-        'export OPENCLAW_PROBE_PID=$$\nexport OPENCLAW_PROBE_SID="$(ps -o sid= -p $$)"\n',
-      );
       const env: NodeJS.ProcessEnv = { SHELL: shell };
-      const homedir = vi.spyOn(os, "homedir").mockReturnValue(home);
+      const realExec = execFileSync;
+      const probe = vi
+        .spyOn(childProcess, "execFileSync")
+        .mockImplementation((file, args, options) => {
+          expect(args).toStrictEqual(["-lic", "printf '\\0'; env -0"]);
+          return realExec(
+            file,
+            [
+              "-lic",
+              'printf \'\\0OPENCLAW_PROBE_PID=%s\\0OPENCLAW_PROBE_SID=%s\\0\' "$$" "$(ps -o sid= -p $$)"; env -0',
+            ],
+            options,
+          );
+        });
       try {
         withEtcShells([shell], () => {
           expect(
@@ -692,12 +700,13 @@ describe("shell env fallback", () => {
               enabled: true,
               env,
               expectedKeys: ["OPENCLAW_PROBE_PID", "OPENCLAW_PROBE_SID"],
+              exec: childProcess.execFileSync,
             }),
           ).toEqual({ ok: true, applied: ["OPENCLAW_PROBE_PID", "OPENCLAW_PROBE_SID"] });
         });
         expect(env.OPENCLAW_PROBE_SID?.trim()).toBe(env.OPENCLAW_PROBE_PID);
       } finally {
-        homedir.mockRestore();
+        probe.mockRestore();
       }
     },
   );

--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -674,40 +674,33 @@ describe("shell env fallback", () => {
     expect(exec).toHaveBeenCalledOnce();
   });
 
-  it("runs the login-shell probe in its own session so it cannot take over the caller's terminal", () => {
-    if (process.platform !== "linux" || !fs.existsSync("/bin/bash")) {
-      return;
-    }
-    const shell = "/bin/bash";
-    const env: NodeJS.ProcessEnv = { SHELL: shell };
-    const exec = vi.fn(
-      (file: string, args: string[], options: Parameters<typeof execFileSync>[2]) => {
-        expect(args).toStrictEqual(["-lic", "printf '\\0'; env -0"]);
-        return execFileSync(
-          file,
-          [
-            "-lic",
-            'printf \'\\0OPENCLAW_PROBE_PID=%s\\0OPENCLAW_PROBE_SID=%s\\0\' "$$" "$(ps -o sid= -p $$)"; env -0',
-          ],
-          options,
-        );
-      },
-    );
-
-    withEtcShells([shell], () => {
-      expect(
-        loadShellEnvFallback({
-          enabled: true,
-          env,
-          expectedKeys: ["OPENCLAW_PROBE_PID", "OPENCLAW_PROBE_SID"],
-          exec: exec as unknown as Parameters<typeof loadShellEnvFallback>[0]["exec"],
-        }),
-      ).toEqual({ ok: true, applied: ["OPENCLAW_PROBE_PID", "OPENCLAW_PROBE_SID"] });
-    });
-    // A session leader has no controlling terminal, so interactive bash startup cannot move
-    // the terminal's foreground process group away from the CLI (SIGTTOU on the next tcsetattr).
-    expect(env.OPENCLAW_PROBE_SID?.trim()).toBe(env.OPENCLAW_PROBE_PID);
-  });
+  it.skipIf(process.platform !== "linux" || !fs.existsSync("/bin/bash"))(
+    "runs the login-shell probe in its own session",
+    () => {
+      const shell = "/bin/bash";
+      const home = tempDirs.make("openclaw-shell-session-");
+      fs.writeFileSync(
+        path.join(home, ".bash_profile"),
+        'export OPENCLAW_PROBE_PID=$$\nexport OPENCLAW_PROBE_SID="$(ps -o sid= -p $$)"\n',
+      );
+      const env: NodeJS.ProcessEnv = { SHELL: shell };
+      const homedir = vi.spyOn(os, "homedir").mockReturnValue(home);
+      try {
+        withEtcShells([shell], () => {
+          expect(
+            loadShellEnvFallback({
+              enabled: true,
+              env,
+              expectedKeys: ["OPENCLAW_PROBE_PID", "OPENCLAW_PROBE_SID"],
+            }),
+          ).toEqual({ ok: true, applied: ["OPENCLAW_PROBE_PID", "OPENCLAW_PROBE_SID"] });
+        });
+        expect(env.OPENCLAW_PROBE_SID?.trim()).toBe(env.OPENCLAW_PROBE_PID);
+      } finally {
+        homedir.mockRestore();
+      }
+    },
+  );
 
   it("keeps Bash PATH discovery noninteractive and cached separately from env imports", () => {
     const shell = "/bin/bash";

--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -674,6 +674,41 @@ describe("shell env fallback", () => {
     expect(exec).toHaveBeenCalledOnce();
   });
 
+  it("runs the login-shell probe in its own session so it cannot take over the caller's terminal", () => {
+    if (process.platform !== "linux" || !fs.existsSync("/bin/bash")) {
+      return;
+    }
+    const shell = "/bin/bash";
+    const env: NodeJS.ProcessEnv = { SHELL: shell };
+    const exec = vi.fn(
+      (file: string, args: string[], options: Parameters<typeof execFileSync>[2]) => {
+        expect(args).toStrictEqual(["-lic", "printf '\\0'; env -0"]);
+        return execFileSync(
+          file,
+          [
+            "-lic",
+            'printf \'\\0OPENCLAW_PROBE_PID=%s\\0OPENCLAW_PROBE_SID=%s\\0\' "$$" "$(ps -o sid= -p $$)"; env -0',
+          ],
+          options,
+        );
+      },
+    );
+
+    withEtcShells([shell], () => {
+      expect(
+        loadShellEnvFallback({
+          enabled: true,
+          env,
+          expectedKeys: ["OPENCLAW_PROBE_PID", "OPENCLAW_PROBE_SID"],
+          exec: exec as unknown as Parameters<typeof loadShellEnvFallback>[0]["exec"],
+        }),
+      ).toEqual({ ok: true, applied: ["OPENCLAW_PROBE_PID", "OPENCLAW_PROBE_SID"] });
+    });
+    // A session leader has no controlling terminal, so interactive bash startup cannot move
+    // the terminal's foreground process group away from the CLI (SIGTTOU on the next tcsetattr).
+    expect(env.OPENCLAW_PROBE_SID?.trim()).toBe(env.OPENCLAW_PROBE_PID);
+  });
+
   it("keeps Bash PATH discovery noninteractive and cached separately from env imports", () => {
     const shell = "/bin/bash";
     const env: NodeJS.ProcessEnv = { SHELL: shell };

--- a/src/infra/shell-env.ts
+++ b/src/infra/shell-env.ts
@@ -99,10 +99,8 @@ function execLoginShellEnvZero(params: {
   const args = useInteractiveBash
     ? ["-lic", LOGIN_SHELL_ENV_COMMAND]
     : ["-l", "-c", LOGIN_SHELL_ENV_COMMAND];
-  // Own session: the probe must never hold the caller's controlling terminal. Interactive bash
-  // otherwise opens /dev/tty, moves the foreground process group to itself, and the CLI is
-  // stopped by SIGTTOU on its next terminal mode change (spinner, exit restore). execFileSync
-  // applies `detached` through the shared spawn option normalization; only its types omit it.
+  // Interactive Bash must not take the CLI's controlling terminal. execFileSync forwards
+  // detached to spawnSync, but its options type omits it.
   const options: ExecFileSyncOptionsWithBufferEncoding & { detached: boolean } = {
     encoding: "buffer",
     timeout: params.timeoutMs,

--- a/src/infra/shell-env.ts
+++ b/src/infra/shell-env.ts
@@ -1,5 +1,5 @@
 // Loads shell-derived environment variables for provider and command runtimes.
-import { execFileSync } from "node:child_process";
+import { type ExecFileSyncOptionsWithBufferEncoding, execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -99,14 +99,20 @@ function execLoginShellEnvZero(params: {
   const args = useInteractiveBash
     ? ["-lic", LOGIN_SHELL_ENV_COMMAND]
     : ["-l", "-c", LOGIN_SHELL_ENV_COMMAND];
-  return params.exec(params.shell, args, {
+  // Own session: the probe must never hold the caller's controlling terminal. Interactive bash
+  // otherwise opens /dev/tty, moves the foreground process group to itself, and the CLI is
+  // stopped by SIGTTOU on its next terminal mode change (spinner, exit restore). execFileSync
+  // applies `detached` through the shared spawn option normalization; only its types omit it.
+  const options: ExecFileSyncOptionsWithBufferEncoding & { detached: boolean } = {
     encoding: "buffer",
     timeout: params.timeoutMs,
     maxBuffer: DEFAULT_MAX_BUFFER_BYTES,
     env: params.env,
     windowsHide: true,
     stdio: ["ignore", "pipe", "pipe"],
-  });
+    detached: true,
+  };
+  return params.exec(params.shell, args, options);
 }
 
 function parseShellEnv(stdout: Buffer): Map<string, string> {


### PR DESCRIPTION
## What Problem This Solves

With `env.shellEnv.enabled: true`, interactive Bash can take control of the terminal during a login-shell import. Human-readable `openclaw doctor --non-interactive` then stops on kernel `SIGTTOU` when it changes terminal mode, requiring manual foreground-job recovery.

Closes #139257.

## Why This Change Was Made

Start the existing shared login-shell probe in a separate operating-system session. It cannot take the CLI's controlling terminal. Keep interactive Bash startup for explicit environment imports and noninteractive startup for executable PATH discovery.

The options retain buffer output, timeout, framing, filtering, and caching. The Windows early return is unchanged. The regression test runs real Bash with the production spawn options and imports its process/session identifiers through the production parser. Its measurement runs after startup so system profiles cannot redirect the test fixture.

## User Impact

Doctor completes and restores the terminal without requiring `fg`. Interactive startup exports remain available. JSON output stays noninteractive.

## Evidence

- Independently reproduced on current main `53e6662ed380bcf5db5592054eab54b05fd42e2b` with the built CLI, Linux, Node 24.20.0, Bash 5.2.15, synthetic state, and a real job-control pseudo-terminal. The shell probe took the foreground group; the CLI's next terminal-mode operation received kernel `SIGTTOU` and stopped.
- Candidate CLI: the probe starts a new session with no controlling terminal; Doctor retains the foreground group, changes and restores terminal modes, reports `Doctor complete.`, and exits 0 with no stops.
- `doctor --json` and `models status --json` complete. The latter reports the startup variable among imported keys. A slow startup file reaches the configured timeout while Doctor still completes.
- The new regression fails on the original owner at the session assertion; the other 32 tests pass. All 33 owner tests pass with the fix. Focused lint, formatting, assertion-safety, and file-size checks pass.
- An independent source-blind validator exercised 12 baseline/candidate CLI scenarios: human Doctor, JSON, imported keys, inherited keys, timeout, and a non-Bash shell. It found no candidate behavior failure; internal cache/lookup semantics and Windows were outside its Linux CLI interface.
- Node/libuv and Bash source contracts inspected directly. Independent code review found no actionable defects.

The built candidate uses the contributor commit plus the committed comment cleanup. The final test-only correction leaves those runtime inputs unchanged. Full updater and native macOS/Windows runs are outside this proof; the shared owner and existing Windows skip are covered by focused tests and review.

AI-assisted verification and cleanup preserve the contributor's repair and credit.
