### PR TITLE
fix: preserve tool errors when summary recovery fails

### DIFF
--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -103,6 +103,21 @@ function settledFailedAttempt(): EmbeddedRunAttemptWithReceiptEvidence {
   return { ...attempt, successfulNestedToolNames: ["memory_search"] };
 }
 
+function settledSuccessfulAttempt(): EmbeddedRunAttemptWithReceiptEvidence {
+  const attempt = settledFailedAttempt();
+  attempt.terminal = { kind: "ok" };
+  attempt.lastToolError = undefined;
+  for (const tool of attempt.toolMetas) {
+    tool.isError = false;
+  }
+  for (const message of attempt.messagesSnapshot) {
+    if (message.role === "toolResult") {
+      message.isError = false;
+    }
+  }
+  return attempt;
+}
+
 let admittedRunContext: AdmittedRunContext;
 
 function finalizationInput(attempt: ReturnType<typeof settledFailedAttempt>) {
@@ -391,6 +406,56 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
     });
   });
 
+  it("keeps a failed command followed by NO_REPLY out of summary recovery", async () => {
+    const attempt = settledFailedAttempt();
+    const assistant = buildEmbeddedRunnerAssistant({
+      content: [{ type: "text", text: SILENT_REPLY_TOKEN }],
+    });
+    attempt.terminal = { kind: "ok" };
+    attempt.assistantTexts = [SILENT_REPLY_TOKEN];
+    attempt.messagesSnapshot.push(assistant);
+    attempt.lastAssistant = assistant;
+    attempt.currentAttemptAssistant = assistant;
+    attempt.currentAttemptCompletedAssistant = assistant;
+    attempt.lastToolError = { toolName: "exec", error: "Command exited with code 127" };
+
+    const result = await prepareTerminalWithSettledTurnFinalization(finalizationInput(attempt));
+
+    expect(backendMocks.runSettledFinalization).not.toHaveBeenCalled();
+    expect(result.finalizationOutcome).toBe("not-attempted");
+    expect(result.prepared.finalAssistantRawText).toBe(SILENT_REPLY_TOKEN);
+    expect(result.prepared.payloadsWithToolMedia).toEqual([
+      expect.objectContaining({ text: expect.stringContaining("failed"), isError: true }),
+    ]);
+  });
+
+  it.each(["empty", "failed"] as const)(
+    "preserves the command failure when summary recovery is %s",
+    async (outcome) => {
+      const attempt = settledFailedAttempt();
+      attempt.terminal = { kind: "ok" };
+      attempt.lastToolError = { toolName: "exec", error: "Command exited with code 127" };
+      if (outcome === "empty") {
+        backendMocks.runSettledFinalization.mockResolvedValue({
+          outcome: "empty",
+          result: { assistant: buildEmbeddedRunnerAssistant({ content: [] }) },
+        });
+      } else {
+        backendMocks.runSettledFinalization.mockRejectedValue(new Error("finalizer unavailable"));
+      }
+
+      const result = await prepareTerminalWithSettledTurnFinalization(finalizationInput(attempt));
+
+      expect(backendMocks.runSettledFinalization).toHaveBeenCalled();
+      expect(result.finalizationOutcome).toBe("failed");
+      expect(result.attempt).toBe(attempt);
+      expect(result.prepared.payloadsWithToolMedia).toEqual([
+        expect.objectContaining({ text: expect.stringContaining("failed"), isError: true }),
+      ]);
+      expect(transcriptMocks.appendAssistantMirrorMessageByIdentity).not.toHaveBeenCalled();
+    },
+  );
+
   it("preserves runtime context and model selection through isolated finalization", async () => {
     const runtimeModelSelection = { provider: "openai", model: "native-selected-model" };
     const attempt = {
@@ -532,7 +597,7 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
   );
 
   it("persists fallback with the queue signal after the original attempt aborts", async () => {
-    const attempt = settledFailedAttempt();
+    const attempt = settledSuccessfulAttempt();
     const emptyAssistant = buildEmbeddedRunnerAssistant({
       content: [{ type: "text", text: "" }],
     });
@@ -618,16 +683,16 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
     const result = await prepareTerminalWithSettledTurnFinalization(input);
 
     expect(backendMocks.runSettledFinalization).toHaveBeenCalledTimes(2);
-    expect(result.finalizationOutcome).toBe("completed-empty");
     expect(transcriptMocks.appendAssistantMirrorMessageByIdentity).not.toHaveBeenCalled();
-    expect(result.attempt.assistantTexts).toEqual([""]);
+    expect(result.finalizationOutcome).toBe("failed");
+    expect(result.attempt).toBe(attempt);
     expect(result.attempt.toolMetas).toBe(attempt.toolMetas);
     expect(result.prepared.payloadsWithToolMedia).not.toEqual([
       expect.objectContaining({ text: SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT }),
     ]);
   });
 
-  it("closes failed finalizer controls before delivering a host fallback", async () => {
+  it("closes failed finalizer controls while retaining the original failure", async () => {
     vi.useFakeTimers();
     const attempt = settledFailedAttempt();
     const input = finalizationInput(attempt);
@@ -644,11 +709,10 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
     expect(input.finalization.abortSignal.aborted).toBe(false);
     expect(backendMocks.runSettledFinalization).toHaveBeenCalledOnce();
     expect(result.finalizationOutcome).toBe("failed");
-    expect(result.attempt).not.toBe(attempt);
+    expect(result.attempt).toBe(attempt);
     expect(result.prepared.payloadsWithToolMedia).toEqual([
-      expect.objectContaining({ text: SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT }),
+      expect.objectContaining({ text: expect.stringContaining("failed"), isError: true }),
     ]);
-    expect(result.prepared.payloadsWithToolMedia?.[0]?.isError).not.toBe(true);
     expect(result.prepared.failureSignal).toEqual({
       kind: "execution_denied",
       source: "tool",
@@ -658,8 +722,8 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
       fatalForCron: true,
     });
     expect(result.attempt).toMatchObject({
-      assistantTexts: [SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT],
-      replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+      assistantTexts: [],
+      replayMetadata: attempt.replayMetadata,
       toolMetas: attempt.toolMetas,
     });
   });
@@ -698,7 +762,7 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
   );
 
   it("preserves cancellation while fallback transcript persistence is pending", async () => {
-    const attempt = settledFailedAttempt();
+    const attempt = settledSuccessfulAttempt();
     const input = finalizationInput(attempt);
     const controller = new AbortController();
     input.finalization.abortSignal = controller.signal;
@@ -753,7 +817,7 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
   });
 
   it("does not construct a fallback after its transcript writer is superseded", async () => {
-    const attempt = settledFailedAttempt();
+    const attempt = settledSuccessfulAttempt();
     const input = finalizationInput(attempt);
     input.finalization.preparedAttempt.sessionKey = "agent:main:settled";
     input.finalization.preparedAttempt.agentId = "main";
@@ -783,7 +847,7 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
   });
 
   it("uses a fresh session's committed writer fence for fallback persistence", async () => {
-    const attempt = settledFailedAttempt();
+    const attempt = settledSuccessfulAttempt();
     const input = finalizationInput(attempt);
     input.finalization.preparedAttempt.sessionKey = "agent:main:settled";
     input.finalization.preparedAttempt.agentId = "main";
@@ -824,7 +888,7 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
   });
 
   it("does not construct a fallback after its fenced session entry is removed", async () => {
-    const attempt = settledFailedAttempt();
+    const attempt = settledSuccessfulAttempt();
     const input = finalizationInput(attempt);
     input.finalization.preparedAttempt.sessionKey = "agent:main:settled";
     input.finalization.preparedAttempt.agentId = "main";

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -128,9 +128,10 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
 
   const runParams = input.terminalBase.runParams;
   const errorContext = input.terminalBase.activeErrorContext;
-  // Silent helper runs may consume a real finalizer answer internally, but a
-  // host fallback would turn their semantic failure into synthetic success.
-  const terminalFallbackAllowed = input.finalization.preparedAttempt.silentExpected !== true;
+  // A host summary cannot replace a tool failure. Keep its original warning
+  // when recovery produces no answer, including for silent helper runs.
+  const terminalFallbackAllowed =
+    input.finalization.preparedAttempt.silentExpected !== true && !initial.attempt.lastToolError;
   log.warn(
     `settled post-tool turn lacked a final answer: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
       `provider=${errorContext.provider}/${errorContext.model} — running isolated finalization`,
@@ -170,7 +171,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
     if (finalization.outcome === "empty") {
       log.warn(
         `settled-turn finalization completed without a visible answer: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
-          `provider=${errorContext.provider}/${errorContext.model} attempts=${finalizationAttempt}/${MAX_EMPTY_SETTLED_FINALIZATION_ATTEMPTS} — ${terminalFallbackAllowed ? "using terminal fallback reply" : "preserving silent helper failure"}`,
+          `provider=${errorContext.provider}/${errorContext.model} attempts=${finalizationAttempt}/${MAX_EMPTY_SETTLED_FINALIZATION_ATTEMPTS} — ${terminalFallbackAllowed ? "using terminal fallback reply" : "preserving original failure"}`,
       );
     }
   } catch (error) {
@@ -188,22 +189,22 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
     }
     log.warn(
       `settled-turn finalization failed: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
-        `provider=${errorContext.provider}/${errorContext.model} error=${formatErrorMessage(error)} — ${terminalFallbackAllowed ? "using terminal fallback reply" : "preserving silent helper failure"}`,
+        `provider=${errorContext.provider}/${errorContext.model} error=${formatErrorMessage(error)} — ${terminalFallbackAllowed ? "using terminal fallback reply" : "preserving original failure"}`,
     );
   }
+  if (finalizationOutcome !== "answered" && input.finalization.abortSignal.aborted) {
+    log.warn(
+      `settled-turn finalization was cancelled before terminal delivery: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
+        `provider=${errorContext.provider}/${errorContext.model} — preserving cancellation`,
+    );
+    return {
+      ...initial,
+      prepared,
+      lastRunPromptUsage,
+      finalizationOutcome: "failed" as const,
+    };
+  }
   if (finalizationOutcome !== "answered" && terminalFallbackAllowed) {
-    if (input.finalization.abortSignal.aborted) {
-      log.warn(
-        `settled-turn fallback was cancelled before transcript persistence: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
-          `provider=${errorContext.provider}/${errorContext.model} — preserving cancellation`,
-      );
-      return {
-        ...initial,
-        prepared,
-        lastRunPromptUsage,
-        finalizationOutcome: "failed" as const,
-      };
-    }
     const transcriptIdempotencyKey = await persistSettledToolFallbackTranscript({
       attempt: input.finalization.preparedAttempt,
       abortSignal: input.finalization.abortSignal,
@@ -231,22 +232,29 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       transcriptIdempotencyKey,
     });
   }
-  // Isolated finalization owns a fresh terminal, never the original abort signal.
-  const terminalState: EmbeddedRunTerminalState = {
-    outcome: resolveEmbeddedRunAttemptTerminalOutcome({
-      attempt,
-      assistant: attempt.currentAttemptAssistant,
-    }),
-    signalOwnedInterruption: false,
-  };
+  // Only an actual recovery replaces a failed tool turn's terminal ownership.
+  const completion =
+    finalizationOutcome !== "answered" && initial.attempt.lastToolError
+      ? initial
+      : {
+          attempt,
+          attemptAssistant: attempt.currentAttemptAssistant,
+          currentAttemptCompletedAssistant: attempt.currentAttemptCompletedAssistant,
+          terminalState: {
+            outcome: resolveEmbeddedRunAttemptTerminalOutcome({
+              attempt,
+              assistant: attempt.currentAttemptAssistant,
+            }),
+            signalOwnedInterruption: false,
+          },
+          attemptCompactionCount: 0,
+          sessionIdUsed: attempt.sessionIdUsed,
+          sessionFileUsed: attempt.sessionFileUsed,
+        };
   const finalizedPrepared = prepareEmbeddedRunTerminal({
     ...input.terminalBase,
-    attempt,
-    currentAttemptCompletedAssistant: attempt.currentAttemptCompletedAssistant,
-    sessionIdUsed: attempt.sessionIdUsed,
-    sessionFileUsed: attempt.sessionFileUsed,
+    ...completion,
     lastRunPromptUsage,
-    terminalState,
   });
   // The isolated finalizer cannot call a message tool. Its answer is
   // host-owned recovery output and must cross that source-reply suppression.
@@ -263,17 +271,15 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
     terminalToolFailure: settledTerminalToolFailure,
   };
   return {
-    attempt,
-    attemptAssistant: attempt.currentAttemptAssistant,
-    currentAttemptCompletedAssistant: attempt.currentAttemptCompletedAssistant,
-    terminalState,
-    attemptCompactionCount: 0,
-    sessionIdUsed: attempt.sessionIdUsed,
-    sessionFileUsed: attempt.sessionFileUsed,
+    ...completion,
     prepared,
     lastRunPromptUsage,
     finalizationOutcome:
-      finalizationOutcome === "empty" ? ("completed-empty" as const) : finalizationOutcome,
+      completion === initial
+        ? ("failed" as const)
+        : finalizationOutcome === "empty"
+          ? ("completed-empty" as const)
+          : finalizationOutcome,
   };
 }
 

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.unavailable.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.unavailable.test.ts
@@ -30,12 +30,13 @@ describe("unavailable finalization through the real core backend", () => {
   afterEach(() => admission.close());
 
   it.each([
-    { terminal: "ok", context: "unavailable" },
-    { terminal: "failed", context: "unavailable" },
-    { terminal: "failed", context: "openclaw-transcript" },
+    { terminal: "ok", context: "unavailable", toolFailed: false },
+    { terminal: "failed", context: "unavailable", toolFailed: false },
+    { terminal: "failed", context: "openclaw-transcript", toolFailed: false },
+    { terminal: "ok", context: "unavailable", toolFailed: true },
   ] as const)(
-    "persists one honest fallback without replaying completed work ($terminal/$context)",
-    async ({ terminal, context }) => {
+    "preserves settled work when finalization is unavailable ($terminal/$context/toolFailed=$toolFailed)",
+    async ({ terminal, context, toolFailed }) => {
       const admittedRunContext = await admission.admit("embedded");
       const assistant = buildEmbeddedRunnerAssistant({
         provider: "openai",
@@ -61,7 +62,7 @@ describe("unavailable finalization through the real core backend", () => {
             toolCallId: "completed-command",
             toolName: "exec",
             content: [{ type: "text", text: "completed-once" }],
-            isError: false,
+            isError: toolFailed,
             timestamp: 3,
           },
         ],
@@ -69,6 +70,9 @@ describe("unavailable finalization through the real core backend", () => {
         itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
         replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
         currentAttemptReplayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+        lastToolError: toolFailed
+          ? { toolName: "exec", error: "Command exited with code 127" }
+          : undefined,
       });
       attempt.settledTurnFinalizationContext =
         context === "unavailable"
@@ -119,6 +123,14 @@ describe("unavailable finalization through the real core backend", () => {
       expect(runAttempt).not.toHaveBeenCalled();
       expect(result.finalizationOutcome).toBe("failed");
       expect(result.prepared.failureSignal).toBeUndefined();
+      if (toolFailed) {
+        expect(result.attempt).toBe(attempt);
+        expect(result.prepared.payloadsWithToolMedia).toEqual([
+          expect.objectContaining({ text: expect.stringContaining("failed"), isError: true }),
+        ]);
+        expect(await readVisibleSessionTranscriptMessageEntries(target)).toEqual(prefix);
+        return;
+      }
       expect(result.prepared.payloadsWithToolMedia?.[0]?.isError).not.toBe(true);
       expect(result.prepared.payloadsWithToolMedia).toEqual([
         expect.objectContaining({ text: FALLBACK }),


### PR DESCRIPTION
Related: #139253 — failed cron command followed by `NO_REPLY` reports a fallback as success.

<details>
<summary>Additional instructions</summary>

This PR uses an upstream branch that maintainers can push to.

</details>

## What Problem This Solves

Fixes an issue where users running a tool that fails would receive a generic non-error reply when the assistant produced no final answer and summary recovery also returned empty or threw.

The exact `NO_REPLY` case reported in #139253 is already addressed on main by #137775, which removed tool-error suppression. This PR covers the remaining case where no final answer was authored and unsuccessful recovery overwrites the original tool failure.

## Why This Change Was Made

The settled-turn finalization owner now retains the original failed completion and passes it through normal terminal preparation when recovery produces no answer. This preserves error delivery, terminal and replay state, accumulated usage, and provider-failure bookkeeping without appending a misleading fallback to the transcript.

Actual recovered answers and the existing fallback for successful tool runs retain their behavior. Production changes are +44/-38 lines (net +6); the growth preserves original completion ownership through the shared preparation path. Tests are +95/-19 lines (net +76). No configuration, schema, dependency, or public protocol changes.

## User Impact

Unsuccessful summary recovery preserves the failed completion and its error state. The existing delivery layer decides whether to present a tool warning or a provider error. Completed actions are not replayed and no generic fallback is appended for the failed tool.

## Evidence

I ran the same isolated Gateway/native Codex scenario on the exact parent `3e4becea5e2ce38ede69e8ecf5302805ecbfc09c` and head `d335dfd8d1e8771215494c4e506aa7230457d1a3` on personal Cloudflare Crabbox, with Node 24.15.0, pnpm 12.3.4, the pinned Codex 0.153.4 binary, and live `openai/gpt-5.6-luna` responses.

The live model executed a real command that recorded one execution, printed a diagnostic, and exited 127. After the execution marker existed, an HTTP/SSE proxy deliberately returned `503 server_is_overloaded` for continuation and summary requests. The channel was the synthetic `qa-channel` plugin and HTTP bus; the Gateway and native Codex processes were real. No model completion or tool result was fabricated. The proxy explicitly rejected WebSocket probes with 426 to select HTTP/SSE.

| Observed result | Parent | PR head |
| --- | --- | --- |
| Real command executions / exit | 1 / 127 | 1 / 127 |
| Native authored final answer | None | None |
| Recovery | Attempted, failed on injected overload | Attempted, failed on injected overload |
| Channel reply | Generic “The tool run finished, but no final summary was produced…” | “⚠️ Selected model is at capacity. Try a different model, or wait and retry.” |
| Channel error flag | Absent | `isError: true` |
| Generic fallback in canonical SQLite transcript | 1 | 0 |
| Original failed tool result persisted | Yes | Yes |

Each failed-chat run recorded one successful live provider POST, five injected continuation failures, and five injected summary failures. Gateway finalization timestamps bracket the summary requests. Native command-completion records, the execution marker, and the canonical transcript agree on one failed execution. Channel reply IDs match the observed Gateway run IDs. The same no-fallback assertion failed on the parent and passed on the head.

Both revisions passed a live successful-command control: one execution with exit 0, two successful provider POSTs, and a success reply without injected failures.

The head's isolated cron check recorded `status: error`, `error/summary: ⚠️ Bash failed`, one failed execution, and no fallback transcript entry. It did not announce a normal completion, matching the existing fatal structured-error policy. Its summary context was unavailable; the direct-chat comparison above separately proves a real summary transport failure.

Supporting checks: the independent baseline/head contract and focused finalization, recovery, transport and cron suites produced 87 passing head tests. Exact-head CI also passed: https://github.com/openclaw/openclaw/actions/runs/33986584643. A fresh full QA-enabled head build passed; the baseline used the source-owned runtime-only build and did not generate declarations. All final Gateway process trees were confirmed stopped without cleanup errors, and the Cloudflare lease was stopped.

Earlier unsuccessful proof-driver attempts are retained in the evidence package: one incorrectly expected a cron announce despite existing suppression, and another expected the literal tool-warning wording instead of the capacity-error presentation. Neither is counted as a passing delivery proof.

Remaining scope: this is not Telegram Test Server evidence, and it does not establish full resolution of the original cron/NO_REPLY incident. The exact NO_REPLY case is separately handled by #137775. No Telegram screenshot or video was captured, and no production runtime was changed.
