### PR TITLE
perf(config): reduce dispatch config preparation

### DIFF
--- a/src/config/gateway-dispatch-config.test.ts
+++ b/src/config/gateway-dispatch-config.test.ts
@@ -78,6 +78,19 @@ describe("readGatewayDispatchConfig", () => {
     expect(shellEnvMocks.loadShellEnvFallback).not.toHaveBeenCalled();
   });
 
+  it("still reports broken includes in discarded config branches", () => {
+    const configPath = createTempConfig({
+      "openclaw.json5": `{
+        gateway: { port: 18888 },
+        models: { $include: "./missing-models.json5" },
+      }`,
+    });
+
+    expect(() => readGatewayDispatchConfig({ configPath, env: {} })).toThrow(
+      "Failed to read include file: ./missing-models.json5",
+    );
+  });
+
   it("loads only gateway credential shell env keys on explicit fallback", async () => {
     const configPath = createTempConfig({
       "openclaw.json5": `{

--- a/src/config/gateway-dispatch-config.ts
+++ b/src/config/gateway-dispatch-config.ts
@@ -30,31 +30,22 @@ type GatewayDispatchConfigReadOptions = {
   logger?: Pick<Console, "warn" | "error">;
 };
 
-function cloneConfigValue(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((entry) => cloneConfigValue(entry));
-  }
-  if (!isRecord(value)) {
-    return value;
-  }
-  const out: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(value)) {
-    out[key] = cloneConfigValue(child);
-  }
-  return out;
-}
-
-function projectGatewayDispatchConfig(value: unknown): OpenClawConfig {
+function resolveGatewayDispatchConfig(value: unknown, env: NodeJS.ProcessEnv): OpenClawConfig {
   if (!isRecord(value)) {
     return {};
+  }
+  if (Object.hasOwn(value, "env")) {
+    applyConfigEnvVars(value as OpenClawConfig, env);
   }
   const projected: Record<string, unknown> = {};
   for (const key of GATEWAY_DISPATCH_TOP_LEVEL_KEYS) {
     if (Object.hasOwn(value, key)) {
-      projected[key] = cloneConfigValue(value[key]);
+      projected[key] = value[key];
     }
   }
-  return projected as OpenClawConfig;
+  // Substitution owns the fresh nested containers; discarded branches need neither
+  // substitution nor another deep copy after the complete include graph is resolved.
+  return resolveConfigEnvVars(projected, env, { onMissing: () => undefined }) as OpenClawConfig;
 }
 
 // Main session keys are process-local; Gateway dispatch always sees the canonical main key.
@@ -91,13 +82,6 @@ function resolveIncludesForGatewayDispatch(
   );
 }
 
-function resolveGatewayDispatchEnvVars(config: unknown, env: NodeJS.ProcessEnv): unknown {
-  if (isRecord(config) && Object.hasOwn(config, "env")) {
-    applyConfigEnvVars(config as OpenClawConfig, env);
-  }
-  return resolveConfigEnvVars(config, env, { onMissing: () => undefined });
-}
-
 function readRawGatewayDispatchConfig(options: GatewayDispatchConfigReadOptions = {}): {
   config: OpenClawConfig;
   configPath: string;
@@ -111,9 +95,9 @@ function readRawGatewayDispatchConfig(options: GatewayDispatchConfigReadOptions 
   const raw = fs.readFileSync(configPath, "utf-8");
   const parsed = parseJsonWithJson5Fallback(raw);
   const resolvedIncludes = resolveIncludesForGatewayDispatch(parsed, configPath, env);
-  const resolvedConfig = resolveGatewayDispatchEnvVars(resolvedIncludes, env);
+  const resolvedConfig = resolveGatewayDispatchConfig(resolvedIncludes, env);
   return {
-    config: applyGatewayDispatchSessionDefaults(projectGatewayDispatchConfig(resolvedConfig)),
+    config: applyGatewayDispatchSessionDefaults(resolvedConfig),
     configPath,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

CLI-to-Gateway dispatch reads a small part of the config, but its reader substitutes environment variables throughout the entire config and then deep-copies the retained branches again. Larger model/channel catalogs therefore add preparation work even though dispatch does not use them.

## Why This Change Was Made

Resolve the complete include graph first, preserving all include failures. Then apply config environment variables, project the same six top-level branches, and let the existing substitution owner create their fresh nested containers. This removes the redundant recursive clone and its one-use wrapper.

No config keys, environment options, defaults, include rules, or public APIs change. Session normalization and the second shell-fallback read remain intact. Production **−16 lines**; one boundary preservation case adds **13 test lines**.

## User Impact

Less config preparation for larger configs, with unchanged returned values and failure visibility. This measures the complete exported file reader, not whole CLI startup, RPC latency, or Gateway turns. Small controls are mixed, so it is not a universal speedup claim.

## Evidence

The same 85 cases passed before and after across the config reader, env substitution, and include suites. The full 33-stage normal changed-file gate passed. Seven-pass independent managed Codex review found no actionable P0–P2 findings.

A fixed baseline/candidate proof ran 30 exported calls, followed once by B0/C0/C1/B1 with 18,840 complete file-reader calls and 576 batch means. Every operation checked its result and env writes; retained output digests and all 64 comparisons were independently audited. No runtime, parser, filesystem or shell mock replaced the measured reader.

| Synthetic workload | Forward median | Reverse median |
|---|---:|---:|
| 45.8 KB mostly discarded models/channels | 428.250 → 269.308 µs (−37.11%) | 450.675 → 273.314 µs (−39.35%) |
| 32 retained agents / 64 plugins | 169.529 → 150.420 µs (−11.27%) | 183.502 → 158.682 µs (−13.53%) |
| JSON5 includes, env and sibling merge | 122.797 → 118.687 µs (−3.35%) | 179.898 → 146.903 µs (−18.34%) |
| Large discarded config through async reader | 871.369 → 548.734 µs (−37.03%) | 920.871 → 596.605 µs (−35.21%) |

All **11 adverse comparisons** remain. Small JSON is +2.82%/−35.98% across orders; enabled shell fallback with both keys supplied is −4.50%/+8.89%. The retained-agent/plugin row has slower observed-first calls in both orders. Some maxima and small-control p95 values worsen. Percentiles are of 32-operation batch means; four hosts do not establish statistical confidence or a default config distribution.

The proof also verifies fresh-read mutation isolation, unchanged absent/scalar results, and the same bounded include-path/Error/ENOENT outcome for a broken include in a discarded branch. Per-call env assertions ran, but separate env snapshots for every timed call are not retained. Whole-host rosters include Node/esbuild and source-loader git/xcodebuild work, so host resource figures are not pure reader allocation or Gateway memory measurements.

```sh
node scripts/run-vitest.mjs src/config/gateway-dispatch-config.test.ts src/config/env-substitution.test.ts src/config/includes.test.ts
pnpm check:changed --timed -- src/config/gateway-dispatch-config.ts src/config/gateway-dispatch-config.test.ts
```

All observed processes and groups closed; source and dependency pins matched. The active proof-plus-timing runner budget was 14.272 seconds; separate root dispatch-to-join envelopes totaled 14.638 seconds. Those clocks are not added. No live network RPC or built CLI was run for this patch, and other campaign live results are not reused as its proof. The source-loader toolchain startup is recorded as a separate uninvestigated follow-up.
