### PR TITLE
test(gateway): cover automation run-alias placement lifecycle

### DIFF
--- a/src/gateway/server.sessions.automation-worker-placement.test.ts
+++ b/src/gateway/server.sessions.automation-worker-placement.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, expect, test } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { loadGatewayWorkerEnvironmentStartupState } from "./server-worker-environment-startup.js";
+import { loadSessionEntry } from "./session-utils.js";
+import { writeSessionStore } from "./test-helpers.js";
+import {
+  directSessionReq,
+  sessionStoreEntry,
+  setupGatewaySessionsHandlerTestHarness,
+} from "./test/server-sessions.test-helpers.js";
+import { createWorkerInferenceDrainService } from "./worker-environments/inference-control.test-helpers.js";
+import { REQUEST } from "./worker-environments/placement-dispatch-test-fixtures.js";
+import { createHarness } from "./worker-environments/placement-dispatch-test-harness.js";
+
+// Isolated automation runs claim their placement under the hidden exact-run alias
+// `<base>:run:<sessionId>` while the stable base row keeps the same sessionId.
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+const AUTOMATION_BASE_KEY = "agent:main:cron:one-shot-job";
+const automationRunAlias = (sessionId: string) => `${AUTOMATION_BASE_KEY}:run:${sessionId}`;
+
+async function seedIdleAutomationRunPlacement(sessionId: string, placementSessionKey: string) {
+  await createSessionStoreDir();
+  await writeSessionStore({ entries: { [AUTOMATION_BASE_KEY]: sessionStoreEntry(sessionId) } });
+  const { placementStore } = await loadGatewayWorkerEnvironmentStartupState();
+  placementStore.releaseTurn(
+    placementStore.claimTurn({
+      sessionId,
+      agentId: "main",
+      sessionKey: placementSessionKey,
+      owner: { kind: "local" },
+      claimId: `${sessionId}-claim`,
+      runId: `${sessionId}-run`,
+    }),
+  );
+  expect(placementStore.get(sessionId)).toMatchObject({
+    state: "local",
+    sessionKey: placementSessionKey,
+    turnClaim: null,
+  });
+  return placementStore;
+}
+
+function requireOk(label: string, result: Awaited<ReturnType<typeof directSessionReq>>) {
+  if (!result.ok) {
+    throw new Error(`${label} failed: ${JSON.stringify(result.error)}`);
+  }
+}
+
+test("sessions.delete retires an automation's idle run-alias placement through its base key", async () => {
+  const sessionId = "sess-automation-idle-delete";
+  const placementStore = await seedIdleAutomationRunPlacement(
+    sessionId,
+    automationRunAlias(sessionId),
+  );
+
+  const deleted = await directSessionReq(
+    "sessions.delete",
+    { key: AUTOMATION_BASE_KEY },
+    { context: { workerSessionPlacementService: placementStore } },
+  );
+
+  requireOk("sessions.delete", deleted);
+  expect(deleted.payload).toMatchObject({ deleted: true });
+  expect(placementStore.get(sessionId)).toBeUndefined();
+  expect(loadSessionEntry(AUTOMATION_BASE_KEY).entry).toBeUndefined();
+});
+
+test("sessions.delete still accepts an automation's exact run-alias key", async () => {
+  const sessionId = "sess-automation-exact-alias-delete";
+  const alias = automationRunAlias(sessionId);
+  await createSessionStoreDir();
+  // A retained run row aliases the base transcript; both share the sessionId.
+  await writeSessionStore({
+    entries: {
+      [AUTOMATION_BASE_KEY]: sessionStoreEntry(sessionId),
+      [alias]: sessionStoreEntry(sessionId),
+    },
+  });
+  const { placementStore } = await loadGatewayWorkerEnvironmentStartupState();
+  placementStore.releaseTurn(
+    placementStore.claimTurn({
+      sessionId,
+      agentId: "main",
+      sessionKey: alias,
+      owner: { kind: "local" },
+      claimId: `${sessionId}-claim`,
+      runId: `${sessionId}-run`,
+    }),
+  );
+
+  const deleted = await directSessionReq(
+    "sessions.delete",
+    { key: alias },
+    { context: { workerSessionPlacementService: placementStore } },
+  );
+
+  requireOk("sessions.delete", deleted);
+  expect(deleted.payload).toMatchObject({ deleted: true });
+  expect(placementStore.get(sessionId)).toBeUndefined();
+  expect(loadSessionEntry(alias).entry).toBeUndefined();
+});
+
+test("sessions.patch archives an automation base session over its idle run-alias placement", async () => {
+  const sessionId = "sess-automation-idle-archive";
+  const placementStore = await seedIdleAutomationRunPlacement(
+    sessionId,
+    automationRunAlias(sessionId),
+  );
+
+  const archived = await directSessionReq(
+    "sessions.patch",
+    { key: AUTOMATION_BASE_KEY, archived: true, expectedSessionId: sessionId },
+    { context: { workerSessionPlacementService: placementStore } },
+  );
+
+  requireOk("sessions.patch", archived);
+  expect(loadSessionEntry(AUTOMATION_BASE_KEY).entry?.archivedAt).toEqual(expect.any(Number));
+  // Archive keeps cloud affinity; only deletion retires the placement.
+  expect(placementStore.get(sessionId)).toMatchObject({
+    state: "local",
+    sessionKey: automationRunAlias(sessionId),
+  });
+});
+
+test("sessions.delete still rejects a placement keyed to another automation's run alias", async () => {
+  const sessionId = "sess-automation-foreign-alias";
+  const foreignAlias = `agent:main:cron:other-job:run:${sessionId}`;
+  const placementStore = await seedIdleAutomationRunPlacement(sessionId, foreignAlias);
+
+  const deleted = await directSessionReq(
+    "sessions.delete",
+    { key: AUTOMATION_BASE_KEY },
+    { context: { workerSessionPlacementService: placementStore } },
+  );
+
+  expect(deleted).toMatchObject({ ok: false, error: { code: "UNAVAILABLE" } });
+  expect(deleted.error?.message).toContain("cloud worker placement identity changed");
+  expect(placementStore.get(sessionId)).toMatchObject({ sessionKey: foreignAlias });
+  expect(loadSessionEntry(AUTOMATION_BASE_KEY).entry?.sessionId).toBe(sessionId);
+});
+
+test("sessions.delete reclaims an automation's active run-alias placement before deleting", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: { [AUTOMATION_BASE_KEY]: sessionStoreEntry(REQUEST.sessionId) },
+  });
+  const { placementStore } = await loadGatewayWorkerEnvironmentStartupState();
+  const harness = createHarness(placementStore, {
+    reconcileChanged: false,
+    reconcileCommitsManifest: false,
+  });
+  // The dispatch fixture derives its environment from REQUEST.sessionId; only the key differs.
+  await harness.service.dispatch({ ...REQUEST, sessionKey: automationRunAlias(REQUEST.sessionId) });
+
+  const deleted = await directSessionReq(
+    "sessions.delete",
+    { key: AUTOMATION_BASE_KEY },
+    {
+      context: {
+        workerEnvironmentService: createWorkerInferenceDrainService(
+          () => ({ drained: Promise.resolve(), hasWork: () => false, release: () => {} }),
+          harness.environments,
+        ),
+        workerPlacementDispatchService: harness.service,
+        workerSessionPlacementService: placementStore,
+      },
+    },
+  );
+
+  requireOk("sessions.delete", deleted);
+  expect(deleted.payload).toMatchObject({ deleted: true });
+  expect(harness.environments.destroy).toHaveBeenCalledOnce();
+  expect(placementStore.get(REQUEST.sessionId)).toBeUndefined();
+  expect(loadSessionEntry(AUTOMATION_BASE_KEY).entry).toBeUndefined();
+});


### PR DESCRIPTION
Regression coverage for #139098. The production repair this branch originally carried landed on `main` in #138322 (`57d38f981db`), so this PR is now the gateway-boundary test suite for that rule and nothing else.

## What Problem This Solves

An isolated automation run claims its worker placement under the hidden exact-run alias `agent:<agent>:cron:<job>:run:<sessionId>` while the stable base row owns the same `sessionId`. `prepareSessionWorkerPlacementStop` (`src/gateway/worker-environments/session-placement-lifecycle.ts:234`) accepts that placement when the request addresses the alias exactly **or** its base key:

```ts
const matches = (candidate: Placement) =>
  candidate.sessionId === sessionId &&
  (candidate.sessionKey === sessionKey ||
    parseCronRunScopeSuffix(candidate.sessionKey).baseSessionKey === sessionKey) &&
  candidate.agentId === agentId;
```

Three parts of that rule have no test on `main`:

1. **Exact run-alias requests.** They depend on the `candidate.sessionKey === sessionKey` clause. Deleting that clause leaves all 40 tests of `src/gateway/server.sessions.worker-placement-lifecycle.test.ts` green — `main`'s alias cases (`sessions.delete drains agent:main:cron:placed-job|adopted-job before placement retirement`) always address the *base* key, never the alias itself. This is exactly the compatibility break ClawSweeper raised as a P1 on the earlier revision of this PR, and today nothing catches it.
2. **Idle (released-turn) alias placements** — the state #139098 actually reports, and the one cron's `deleteAfterRun` cleanup meets. `main`'s alias cases all hold an *active* turn claim.
3. **The archive sibling** (`sessions.patch archived:true`, same drain) and the **negative case** where the placement belongs to a *different* automation's run alias, which is the boundary the added `parseCronRunScopeSuffix` parse must not widen.

## Why This Change Was Made

The fix belongs where it already is: the shared stop owner. #138322 landed a byte-identical `matches()` predicate and reclaim key on `main` after this PR was opened, so the production diff here is dropped rather than duplicated, and the branch rebases to the regression suite alone.

The tests are colocated at the boundary that owns the rule — the real `sessions.delete` / `sessions.patch` handlers over a real SQLite placement store, plus the real dispatch harness for the active-cloud case — because the defect was only observable through the handler drain, not through the helper in isolation.

## User Impact

None on its own: behavior is identical to current `main`. The suite fences the alias-ownership rule so a later tightening of `matches()` cannot silently re-break exact-run lifecycle requests, or re-break deletion and archival of automation sessions the way #139098 reported.

## Evidence

New file `src/gateway/server.sessions.automation-worker-placement.test.ts` (+180, 5 tests). `node scripts/run-vitest.mjs src/gateway/server.sessions.automation-worker-placement.test.ts` on this branch:

```
 ✓ sessions.delete retires an automation's idle run-alias placement through its base key 48474ms
 ✓ sessions.delete still accepts an automation's exact run-alias key 3915ms
 ✓ sessions.patch archives an automation base session over its idle run-alias placement 1382ms
 ✓ sessions.delete still rejects a placement keyed to another automation's run alias 532ms
 ✓ sessions.delete reclaims an automation's active run-alias placement before deleting 3392ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

**Mutation proof that the coverage is not decorative.** Removing the `candidate.sessionKey === sessionKey ||` clause from `session-placement-lifecycle.ts` and running the new file together with `src/gateway/server.sessions.worker-placement-lifecycle.test.ts`:

```
 × sessions.delete still accepts an automation's exact run-alias key
   → sessions.delete failed: {"code":"UNAVAILABLE","message":"Session agent:main:cron:one-shot-job:run:sess-automation-exact-alias-delete could not safely stop before deletion: … cloud worker placement identity changed. Retry after active work or worker recovery finishes.","retryable":true}
 Test Files  1 failed | 1 passed (2)
      Tests  1 failed | 40 passed (41)
```

One failure, and it is the new test: every existing lifecycle test stays green through that regression.

**Stated proof gap.** Reverting the second half of #138322's change (`reclaim({ …, sessionKey: expected.sessionKey })` back to the request key) fails nothing — 41/41 still pass. That line is only observable on dispatch reclaim's idempotent already-reclaimed short-circuit (`src/gateway/worker-environments/placement-reclaim.ts:76`), which `prepareSessionWorkerPlacementStop` cannot reach for a non-active placement (it returns early). This suite does not fence that line, and I did not add a contrived race to pretend otherwise. What the active-cloud test does fence is the `matches(reclaimed)` recheck after a real drain, the only place an alias-keyed *cloud* placement is validated.

**Checks:** `node scripts/check-changed.mjs` — see the revision note below. Diff is one new test file; no production, docs, config, or schema surface.

<details>
<summary>Live proof of the underlying repair (captured on this branch before #138322 landed the same fix)</summary>

Session-owned dev Gateway from this worktree's `dist`, isolated `OPENCLAW_STATE_DIR`/config/HOME, free port, mock provider on loopback, `sessionTarget: isolated` one-shot jobs. Before: cron's own `deleteAfterRun` cleanup, `openclaw sessions delete … --yes`, and the Control UI Delete flow were all rejected with `cloud worker placement identity changed`, and `worker_session_placements` kept `{state: "local", session_key: "agent:main:cron:<job>:run:<sessionId>"}`. After: `res ✓ sessions.delete`, the placement row and base session row are both gone, and the gateway log contains zero `identity changed` rejections.

Before the fix — Control UI rejects the delete and the row stays:

![Control UI rejects deleting the automation session before the fix](https://github.com/user-attachments/assets/53b881b9-639c-4cfa-9137-33b4c7c6584b)

https://github.com/user-attachments/assets/6fe79f77-1b3f-495c-9991-51402c18e152

After the fix — the same flow deletes the session and the list is empty:

![Control UI shows no active sessions after deleting the automation session](https://github.com/user-attachments/assets/08f0575d-f330-4d67-875b-4d24d3d66673)

https://github.com/user-attachments/assets/86e38314-2947-4aa6-bf58-5f5fd71a93ae

</details>

## Rebase onto main (`e93c36f4a14`)

`origin/main` moved 800 commits past the old merge base and the branch was conflicting. Both prior commits conflicted in `src/gateway/worker-environments/session-placement-lifecycle.ts` for one reason: **#138322 (`57d38f981db`, "fix(cron): retire removed sessions through the gateway lifecycle") already landed this PR's exact production change.** Verified line by line — main's `matches()` predicate and its `reclaim({ …, sessionKey: expected.sessionKey })` are byte-identical to this branch's; only my longer comment differed.

Resolution: take main's version of the production file whole (zero production diff), keep the regression tests, and squash to one commit. Re-applying my comment wording on a file another contributor just landed would be pure churn.

**This PR no longer closes #139098** — #138322 does, on `main` today. The `Closes` link is dropped so merging this suite does not claim a repair it no longer contains.

## Revision `d2f2710e7c8`

- Rebased onto `main` at `e93c36f4a14`; production diff dropped as superseded by #138322; two commits squashed into one `test(gateway):` commit; PR title and body rewritten to match.
- **ClawSweeper P1 "Preserve exact run-alias matches when accepting base ownership": fixed and now fenced.** The fix shipped in the previous revision (`9217d6cd1ec`) and is on `main` via #138322; the latest ClawSweeper review of `9217d6cd1ec` confirms it ("The prior exact-alias blocker is addressed", Findings: None). This revision adds the missing guard: `sessions.delete still accepts an automation's exact run-alias key` fails on a tree with that clause removed, with the exact `identity changed` error, while all 40 existing lifecycle tests pass — proof quoted above.
- The one remaining ClawSweeper "before merge" item is a stated reviewer limitation (linked media and an omitted body section were unreachable from the review environment, and missing historical blobs blocked introduction attribution), not a code finding. The media are GitHub `user-attachments` links, still embedded above; the runtime transcripts they illustrate are summarized inline.
- Proof run for this revision: focused suite 5/5 pass; mutation run 1 failed / 40 passed as quoted; `node scripts/check-changed.mjs` exit 0 (oxfmt, oxlint, tsgo `gateway-root` core test graph, dependency/patch/wrapper/coercion/deprecated-API guards, Knip dead-export scans all pass); `autoreview --mode branch --base origin/main --engine codex --model gpt-6-astra --thinking high` reports `scoped-clean: no accepted/actionable findings`, `patch is correct (0.98)`.
