### PR TITLE
docs: make TaskFlow skill examples runnable

### DIFF
--- a/docs/automation/taskflow.md
+++ b/docs/automation/taskflow.md
@@ -22,21 +22,28 @@ Task Flow (formerly ClawFlow) is the orchestration layer above [background tasks
 
 ### Managed mode
 
-A managed flow has a controller: plugin code that creates the flow through the plugin runtime Task Flow API with a goal and a required controller id, then drives it explicitly.
+A managed flow has a controller: plugin code that creates the flow with a goal and controller id, then drives it explicitly. A flow can track inline work without any child task.
 
-- Each step runs as a background task created under the flow; the flow's owner key and requester origin carry over to child tasks.
-- The controller advances the flow between `running`, `waiting`, and terminal states, and stores arbitrary JSON step state on the flow record.
-- Every mutation passes the flow's expected revision. A stale write is rejected as a revision conflict instead of clobbering newer state.
-- Once cancellation is requested, new child tasks are refused, and the flow finalizes as `cancelled` when no child task remains active.
+- `createManaged` creates state, not an execution. `runTask` links an existing execution; it does not launch one.
+- The controller advances between running, waiting and terminal states, retaining bounded IDs, summaries and cursors in `stateJson`.
+- State transitions (`setWaiting`, `resume`, `finish`, `fail`, `requestCancel`) require the latest expected revision. Check every result, including `finish`. `runTask` and `cancel` have separate creation/cancellation results to check.
+- Cancellation intent refuses new child links. The flow finalizes as cancelled once its active children have settled.
 
-Example: a weekly report flow that (1) gathers data, (2) generates the report, and (3) delivers it, one background task per step:
+#### Launching and linking child tasks
 
-```
-Flow: weekly-report
-  Step 1: gather-data     → task created → succeeded
-  Step 2: generate-report → task created → succeeded
-  Step 3: deliver         → task created → running
-```
+Launch ACP/subagent work through its supported runtime **before** calling `runTask`. Linking requires the existing authoritative backing task, its canonical `runId` and child session key, the correct task runtime and the same owner session as the managed flow. A copied session key or invented run ID is not authority.
+
+For Gateway-backed plugin subagents, the public path is `api.runtime.subagent.run({ completionDelivery: "current-requester", ... })` inside a real requester-bound `before_dispatch` hook handling an authenticated inbound request. The host creates the canonical subagent task and mirrored flow. Ordinary plugin runs without this setting deliberately have `not_applicable` completion delivery and cannot supply that mirrored backing. Merely binding `managedFlows.fromToolContext(ctx)` does not grant requester launch authority.
+
+Use the returned identities and current owner-visible task facts, not invented status/timing. A child can finish before linkage; `runTask` does not replay past terminal events. Do not create a running projection of completed work. See the [SDK Tasks contract](/plugins/sdk-runtime) for the launch, synchronous pre-link check, result handling and revision rules.
+
+#### Run a managed Lobster workflow
+
+For operator/agent use, the optional [Lobster tool](/tools/lobster) can execute a workflow with `flowControllerId` and `flowGoal`. It creates a managed flow, records a real approval pause as waiting, and finishes or fails from the workflow outcome. The workflow steps are not detached child task records.
+
+The tool returns envelope fields plus `flow` and `mutation` at the top level of its details. Check `mutation.applied` and use `mutation.flow`, the post-mutation record, for the next `flowExpectedRevision`. After the user's decision, resume with the returned token or approval ID and the actual flow id/revision; check cancellation through `mutation.cancelled`. Report errors and rejected updates instead of treating workflow output as proof that flow state persisted.
+
+The bundled TaskFlow skill examples route synthetic inbox/PR batches and suspend for approval without contacting external services. A workflow approval is not an arbitrary Slack-reply listener: a real controller must register that listener, persist thread correlation and resume when the matching event arrives.
 
 ### Mirrored mode
 
@@ -63,6 +70,8 @@ with a blocked outcome.
 ## Durable state and revision tracking
 
 Flow records persist in the shared SQLite state database (`~/.openclaw/state/openclaw.sqlite`, `flow_runs` table) alongside task records, so progress survives gateway restarts. Each write bumps the flow's `revision`; concurrent writers that pass a stale expected revision get a conflict and must re-read. WAL growth is bounded by SQLite autocheckpointing plus periodic passive checkpoints, with truncate checkpoints on shutdown. The legacy `flows/registry.sqlite` sidecar from older installs is imported by `openclaw doctor`.
+
+Durability covers records, not a JavaScript call stack or automatic scheduling. After restart, the owning controller reloads the flow, checks cancellation and terminal state, reconciles any child outcome, and explicitly resumes from the latest revision. Waiting metadata alone does not register a timer or event listener. Use an automation or controller-owned event handler for wakeups; never blindly replay side effects after a revision conflict.
 
 Gateway maintenance retains finished flows for 7 days, then prunes them. This
 includes `blocked` flows with `endedAt`; resumable managed `blocked` flows are

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -802,42 +802,54 @@ snapshots; OpenClaw owns all persistence and lifecycle coordination.
 
   </Accordion>
   <Accordion title="api.runtime.tasks">
-    Bind Task Flow and Task Run state to an existing OpenClaw session key or trusted tool context.
+    Bind Task Flow and Task Run state to a trusted, existing OpenClaw owner session.
 
-    - `api.runtime.tasks.managedFlows` is mutation-capable: create, advance, and cancel Task Flows.
-    - `api.runtime.tasks.flows` and `api.runtime.tasks.runs` are read-only DTO views for listing and status lookups; both expose `bindSession(...)` / `fromToolContext(...)` plus `get`, `list`, `findLatest`, and `resolve`.
+    - `managedFlows` creates and mutates managed flow records. Bind with `fromToolContext(ctx)` or `bindSession({ sessionKey, requesterOrigin })` using host-resolved context, never raw user input.
+    - `flows` and `runs` provide owner-scoped DTO lookups (`get`, `list`, `findLatest`, `resolve`). `flows` also exposes `getTaskSummary`; `runs.cancel` cancels an existing task.
+    - `managedFlows.get(flowId)` returns the record with its revision. The read-only `flows` DTO is not the revision-bearing mutation record.
 
-    Task Flow tracks durable multi-step workflow state. It is not a scheduler:
-    use Cron or `api.session.workflow.scheduleSessionTurn(...)` for future
-    wakeups, then use `managedFlows` from the scheduled turn when that work
-    needs flow state, child tasks, waits, or cancellation.
+    A skill file does not provide `api` or register a plugin. For operator/agent
+    workflows, use [managed Lobster execution](/automation/taskflow#run-a-managed-lobster-workflow).
+    The following contract is for actual plugin/controller code.
 
-    ```typescript
-    const taskFlow = api.runtime.tasks.managedFlows.fromToolContext(ctx);
+    **Launching and linking a child**
 
-    const created = taskFlow.createManaged({
-      controllerId: "my-plugin/review-batch",
-      goal: "Review new pull requests",
-    });
+    `runTask` records a link to existing work; it never launches ACP/subagent
+    execution. The backing task must already exist with the same owner,
+    canonical run/session identities and task runtime. Arbitrary IDs or a
+    `status: "running"` declaration cannot establish that authority.
 
-    const child = taskFlow.runTask({
-      flowId: created.flowId,
-      runtime: "acp",
-      childSessionKey: "agent:main:subagent:reviewer",
-      task: "Review PR #123",
-      status: "running",
-      startedAt: Date.now(),
-    });
+    1. Create a managed flow bound to the real requester session. Handle creation failure before launching work. Binding state access does not grant subagent requester authority.
+    2. Inside an active requester-bound `before_dispatch` hook for an authenticated inbound request, call `api.runtime.subagent.run` with a unique agent-qualified child session key, the task message and `completionDelivery: "current-requester"`. The Gateway captures the requester and delivery route; retain the returned canonical `runId` and `sessionKey`. Missing identities or a rejected launch are failures, not permission to fabricate a task. Ordinary runs without `current-requester` have `not_applicable` completion delivery and lack the mirrored backing needed for this link.
+    3. Immediately before linking, resolve the canonical task with the owner-bound `runs.resolve(runId)`. Verify its owner, run id, child session key and task runtime. Use its actual `sourceId`, queued/running status and available timing facts in `managedFlows.runTask`, alongside the managed flow id and task description. Do not confuse the launch result's harness/provider metadata with the task DTO's `runtime`. Keep this final read/check and `runTask` synchronous, with no intervening `await`, and check `created` before proceeding.
+    4. Observe completion through `subagent.waitForRun` and the canonical task. A bounded wait returning `pending` or an observation timeout is not a terminal child failure and does not cancel the run. Interpret results only after actual completion. On failure, record a failed/blocked flow outcome and report it; never insert a replacement child declaration to hide launch/link refusal.
+    5. Reload the managed record after awaited work. Stop for terminal state or cancellation intent; use the latest revision for the next state transition. Check every `applied` result, including `finish`/`fail`, and check `cancelled` for cancellation. On revision conflict, reread and reconcile rather than blindly retrying side effects.
 
-    const waiting = taskFlow.setWaiting({
-      flowId: created.flowId,
-      expectedRevision: created.revision,
-      currentStep: "await-human-reply",
-      waitJson: { kind: "reply", channel: "telegram" },
-    });
-    ```
+    <Warning>
+    A child can finish before step 3. `runTask` does not replay terminal events
+    that preceded linkage, so never label a completed backing task as queued or
+    running. Handle its completed result directly in the controller instead of
+    creating a stale active projection. The launch/link sequence is not atomic.
+    </Warning>
 
-    Use `bindSession({ sessionKey, requesterOrigin })` when you already have a trusted OpenClaw session key from your own binding layer. Do not bind from raw user input.
+    `completionDelivery: "current-requester"` is available only within the
+    genuine hook invocation. Do not retain that authority after the hook ends
+    or call private requester-context/registry helpers. See `api.runtime.subagent`
+    above for the public launch and wait contract. ACP linkage likewise requires
+    an existing owner-backed ACP launch, not a standalone `runTask` declaration.
+
+    **State without a child**
+
+    For inline work, use `createManaged`, then checked `setWaiting`, `resume`,
+    `finish` or `fail` transitions as appropriate; no `runTask` is needed.
+    Keep `stateJson` and `waitJson` bounded. Waiting metadata records the reason
+    and correlation, but the controller must register the real event listener.
+
+    Records persist in SQLite; arbitrary JavaScript is not replayed after
+    restart. Reload with the same trusted owner binding and explicitly resume
+    from current state. Task Flow is not a scheduler: use Automations or
+    `api.session.workflow.scheduleSessionTurn(...)` for future wakeups. See
+    [Task Flow](/automation/taskflow) for durability and cancellation.
 
   </Accordion>
   <Accordion title="api.runtime.tts">

--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -326,11 +326,23 @@ run returned. `approve` is required.
 Passing `flowControllerId` and `flowGoal` on `run` (or `flowId` and
 `flowExpectedRevision` on `resume`) drives the call through the plugin
 runtime's managed [Task Flow](/automation/taskflow) API instead of returning
-a bare envelope: OpenClaw creates or resumes a durable flow record, applies the
-Lobster envelope to it (`waiting` on approval, `succeeded`/`failed`/`cancelled` on
-completion), and returns `{ ok, envelope, flow, mutation }`. This mode requires
-a bound Task Flow runtime and is intended for plugin/controller code that needs
-durable flow state across gateway restarts, not typical ad hoc agent use.
+a bare envelope: OpenClaw creates or resumes a durable flow record and applies
+the Lobster outcome to it (`waiting` on approval, `succeeded`/`failed`/`cancelled`
+on completion). The tool returns the envelope fields at the top level, alongside
+`flow` and `mutation`. Check `mutation.applied` for a successful state transition
+and carry forward **`mutation.flow.revision`**; top-level `flow` is the snapshot
+from before that transition. Cancellation instead reports `mutation.cancelled`.
+A workflow error is surfaced as a tool error after an attempted flow failure;
+inspect the persisted flow rather than assuming the failure write succeeded.
+
+This mode requires a non-sandboxed tool context with a bound session. It records
+a managed flow, not detached ACP/subagent tasks for each shell step. Flow state
+persists in OpenClaw SQLite; Lobster's approval checkpoint is separate and must
+also remain available for resume. After a restart, the controller must inspect
+the latest flow and explicitly resume it with the matching approval token or ID.
+Neither Task Flow nor a skill automatically replays arbitrary JavaScript. See
+[Task Flow](/automation/taskflow) for the runnable examples and child-linking
+contract.
 
 ## Output envelope
 

--- a/skills/taskflow-inbox-triage/SKILL.md
+++ b/skills/taskflow-inbox-triage/SKILL.md
@@ -1,119 +1,44 @@
 ---
 name: taskflow-inbox-triage
-description: "Example TaskFlow pattern for inbox triage, intent routing, waiting on replies, and later summaries."
+description: "Preview synthetic inbox routing with a real TaskFlow approval pause, and identify the adapters needed for live triage."
 metadata: { "openclaw": { "emoji": "📥" } }
 ---
 
 # TaskFlow inbox triage
 
-This is a concrete example of how to think about TaskFlow without turning the core runtime into a DSL.
+Use `skills/taskflow/examples/inbox-triage.lobster` through the managed Lobster run/approval/resume procedure in `skills/taskflow/SKILL.md`. The default batch is synthetic and already classified. The workflow routes all items into `business`, `personal` and `later` ID lists, suspends for actual approval, then returns those lists without sending anything.
 
-## Goal
+## Input and result
 
-Triage inbox items with one owner flow:
-
-- business -> post to Slack and wait for reply
-- personal -> notify the owner now
-- everything else -> keep for end-of-day summary
-
-## Pattern
-
-1. Create one flow for the inbox batch.
-2. Run one detached task to classify new items.
-3. Persist the routing state in `stateJson`.
-4. Move to `waiting` only when an outside reply is required.
-5. Resume the flow when classification or human input completes.
-6. Finish when the batch has been routed.
-
-## Suggested `stateJson` shape
+Each item has a nonempty `id` (at most 80 characters) and `route` (`business`, `personal` or `later`). The batch is capped at 20 items. Invalid input fails visibly; an empty batch yields three empty lists. Override the defaults with `argsJson` on the initial run, for example:
 
 ```json
 {
-  "businessThreads": [],
-  "personalItems": [],
-  "eodSummary": []
+  "items": [
+    { "id": "demo-business-1", "route": "business" },
+    { "id": "demo-personal-1", "route": "personal" },
+    { "id": "demo-later-1", "route": "later" },
+    { "id": "demo-business-2", "route": "business" }
+  ]
 }
 ```
 
-Suggested `waitJson` when blocked on Slack:
+Pass this object serialized as the `argsJson` string. Use synthetic IDs when trying the example. Approval confirms the preview only; it does not authorize or perform real delivery.
 
-```json
-{
-  "kind": "reply",
-  "channel": "slack",
-  "threadKey": "slack:thread-1"
-}
-```
+## Connect real inbox work explicitly
 
-## Minimal runtime calls
+A real controller needs an inbox reader and classifier that produce the bounded input above, plus adapters for these routes:
 
-```ts
-const taskFlow = api.runtime.tasks.managedFlows.fromToolContext(ctx);
+| Route      | Real controller responsibility                                                                                    |
+| ---------- | ----------------------------------------------------------------------------------------------------------------- |
+| `business` | Post through an authorized Slack adapter, persist the returned thread ID, then wait for a correlated human reply. |
+| `personal` | Notify the owner through an authorized channel adapter and record the delivery outcome.                           |
+| `later`    | Retain a bounded summary reference for an explicitly scheduled end-of-day run.                                    |
 
-const created = taskFlow.createManaged({
-  controllerId: "my-plugin/inbox-triage",
-  goal: "triage inbox",
-  currentStep: "classify",
-  stateJson: {
-    businessThreads: [],
-    personalItems: [],
-    eodSummary: [],
-  },
-});
+These adapters are **not supplied** by the example. Classify every item before routing it; do not decide a mixed batch from its first element. Use a directly available classification tool or a real adapter, not an assumed embedded `openclaw.invoke` bridge. Keep approvals before real side effects.
 
-const child = taskFlow.runTask({
-  flowId: created.flowId,
-  runtime: "acp",
-  childSessionKey: "agent:main:subagent:classifier",
-  task: "Classify inbox messages",
-  status: "running",
-  startedAt: Date.now(),
-  lastEventAt: Date.now(),
-});
+For business replies, the controller registers the event listener, calls `setWaiting` with bounded thread correlation in `waitJson`, and resumes only after the matching reply arrives. A Lobster approval token, echoed waiting JSON or a `setWaiting` call alone does not install that listener. Embedded Lobster input/`ask` requests are not supported.
 
-if (!child.created) {
-  throw new Error(child.reason);
-}
+If classification uses detached work, launch it through the [public requester-bound plugin path](https://docs.openclaw.ai/plugins/sdk-runtime) before linking it with `runTask`. Wait for actual completion before interpreting results; `pending` or an observation timeout is not terminal failure. On failure, record a failed/blocked flow outcome and report it. Do not synthesize a child after launch or linkage is refused.
 
-const waiting = taskFlow.setWaiting({
-  flowId: created.flowId,
-  expectedRevision: created.revision,
-  currentStep: "await_business_reply",
-  stateJson: {
-    businessThreads: ["slack:thread-1"],
-    personalItems: [],
-    eodSummary: [],
-  },
-  waitJson: {
-    kind: "reply",
-    channel: "slack",
-    threadKey: "slack:thread-1",
-  },
-});
-
-if (!waiting.applied) {
-  throw new Error(waiting.code);
-}
-
-const resumed = taskFlow.resume({
-  flowId: waiting.flow.flowId,
-  expectedRevision: waiting.flow.revision,
-  status: "running",
-  currentStep: "route_items",
-  stateJson: waiting.flow.stateJson,
-});
-
-if (!resumed.applied) {
-  throw new Error(resumed.code);
-}
-
-taskFlow.finish({
-  flowId: resumed.flow.flowId,
-  expectedRevision: resumed.flow.revision,
-  stateJson: resumed.flow.stateJson,
-});
-```
-
-## Related example
-
-- `skills/taskflow/examples/inbox-triage.lobster`
+Persist only the IDs, small summaries and cursor needed to continue. After restart or a revision conflict, reload the owner-bound flow and reconcile before applying the next transition. Check every mutation, including `finish`; do not report success from an unchecked result. See [Task Flow](https://docs.openclaw.ai/automation/taskflow) for controller-driven resumption and cancellation.

--- a/skills/taskflow/SKILL.md
+++ b/skills/taskflow/SKILL.md
@@ -1,155 +1,51 @@
 ---
 name: taskflow
-description: "Coordinate multi-step detached tasks as one durable TaskFlow job with owner context, state, waits, and child tasks."
+description: "Run approval-gated workflows with durable TaskFlow state; distinguish workflow execution from linking real detached tasks."
 metadata: { "openclaw": { "emoji": "🪝" } }
 ---
 
 # TaskFlow
 
-Use TaskFlow when a job needs to outlive one prompt or one detached run, but you still want one owner session, one return context, and one place to inspect or resume the work.
+Use a managed TaskFlow for multi-step work with one owner, bounded state and explicit waits. A single detached ACP/subagent run with deliverable completion gets a mirrored flow automatically; it does not need a second managed flow.
 
-## When to use it
+## Run a workflow
 
-- Multi-step background work with one owner
-- Work that waits on detached ACP or subagent tasks
-- Jobs that may need to emit one clear update back to the owner
-- Jobs that need small persisted state between steps
-- Plugin or tool work that must survive restarts and revision conflicts cleanly
+Use the available `lobster` tool in a non-sandboxed session with the Lobster plugin installed, activated and allowed. This skill is guidance, not plugin registration: it does not provide an `api` object or a task-launch tool.
 
-## What TaskFlow owns
+The examples require Node on the Gateway host and use synthetic, already-classified data. They route every item, pause for approval, then return the routing result. They do not read mail, send messages, modify PRs or launch detached children. Paths below assume the Gateway working directory is the repository root; otherwise use the example file's absolute path.
 
-- flow identity
-- owner session and requester origin
-- `currentStep`, `stateJson`, and `waitJson`
-- linked child tasks and their parent flow id
-- finish, fail, cancel, waiting, and blocked state
-- revision tracking for conflict-safe mutations
-
-It does **not** own branching or business logic. Put that in Lobster, acpx, or the calling code.
-
-## Current runtime shape
-
-Canonical plugin/runtime entrypoint:
-
-- `api.runtime.tasks.managedFlows` is mutation-capable: create, advance, and cancel Task Flows.
-- `api.runtime.tasks.flows` is the read-only DTO view for listing and status lookups (`get`, `list`, `findLatest`, `resolve`, `getTaskSummary`).
-
-Binding:
-
-- `api.runtime.tasks.managedFlows.fromToolContext(ctx)` when you already have trusted tool context with `sessionKey`
-- `api.runtime.tasks.managedFlows.bindSession({ sessionKey, requesterOrigin })` when your binding layer already resolved the session and delivery context
-
-Managed-flow lifecycle:
-
-1. `createManaged(...)`
-2. `runTask(...)`
-3. `setWaiting(...)` when waiting on a person or an external system
-4. `resume(...)` when work can continue
-5. `finish(...)` or `fail(...)`
-6. `requestCancel(...)` or `cancel(...)` when the whole job should stop
-
-## Design constraints
-
-- Use **managed** TaskFlows when your code owns the orchestration.
-- One-task **mirrored** flows are created by core runtime for detached ACP/subagent work; this skill is mainly about managed flows.
-- Treat `stateJson` as the persisted state bag. There is no separate `setFlowOutput` or `appendFlowOutput` API.
-- Every mutating method after creation is revision-checked. Carry forward the latest `flow.revision` after each successful mutation.
-- `runTask(...)` links the child task to the flow. Use it instead of manually creating detached tasks when you want parent orchestration.
-- A linked child reaching a terminal state does not finish a managed flow. Compare
-  its result with the flow goal, schedule the next in-scope step, and call
-  `finish(...)` only after the goal's acceptance condition is verified.
-- Persist explicit acceptance state in `stateJson` for terminal-outcome workflows.
-  For example, a PR-landing flow should remain running or waiting through review
-  and CI, and finish only after the hosting service reports the PR as merged.
-
-## Example shape
-
-```ts
-const taskFlow = api.runtime.tasks.managedFlows.fromToolContext(ctx);
-
-const created = taskFlow.createManaged({
-  controllerId: "my-plugin/inbox-triage",
-  goal: "triage inbox",
-  currentStep: "classify",
-  stateJson: {
-    businessThreads: [],
-    personalItems: [],
-    eodSummary: [],
-  },
-});
-
-const classify = taskFlow.runTask({
-  flowId: created.flowId,
-  runtime: "acp",
-  childSessionKey: "agent:main:subagent:classifier",
-  runId: "inbox-classify-1",
-  task: "Classify inbox messages",
-  status: "running",
-  startedAt: Date.now(),
-  lastEventAt: Date.now(),
-});
-
-if (!classify.created) {
-  throw new Error(classify.reason);
+```json
+{
+  "action": "run",
+  "pipeline": "skills/taskflow/examples/inbox-triage.lobster",
+  "flowControllerId": "lobster/inbox-triage",
+  "flowGoal": "Review synthetic inbox routing",
+  "maxStdoutBytes": 8192
 }
-
-const waiting = taskFlow.setWaiting({
-  flowId: created.flowId,
-  expectedRevision: created.revision,
-  currentStep: "await_business_reply",
-  stateJson: {
-    businessThreads: ["slack:thread-1"],
-    personalItems: [],
-    eodSummary: [],
-  },
-  waitJson: {
-    kind: "reply",
-    channel: "slack",
-    threadKey: "slack:thread-1",
-  },
-});
-
-if (!waiting.applied) {
-  throw new Error(waiting.code);
-}
-
-const resumed = taskFlow.resume({
-  flowId: waiting.flow.flowId,
-  expectedRevision: waiting.flow.revision,
-  status: "running",
-  currentStep: "finalize",
-  stateJson: waiting.flow.stateJson,
-});
-
-if (!resumed.applied) {
-  throw new Error(resumed.code);
-}
-
-taskFlow.finish({
-  flowId: resumed.flow.flowId,
-  expectedRevision: resumed.flow.revision,
-  stateJson: resumed.flow.stateJson,
-});
 ```
 
-## Keep conditionals above the runtime
+For PR intake, use `skills/taskflow/examples/pr-intake.lobster` and controller `lobster/pr-intake` instead. Its intents are `close`, `request_changes`, `refactor` and `maintainer_review`; no GitHub actions occur.
 
-Use the flow runtime for state and task linkage. Keep decisions in the authoring layer:
+## Approve and resume
 
-- `business` -> post to Slack and wait
-- `personal` -> notify the owner now
-- `later` -> append to an end-of-day summary bucket
+Read the tool result's `details` (also rendered as JSON text). It contains `status`, `requiresApproval`, `flow` and `mutation` directly, not a nested `envelope`.
 
-## Operational pattern
+1. For a non-cancelled result, require `mutation.applied === true`. Otherwise report its `code` and stop; workflow success alone does not prove the flow update persisted.
+2. For `needs_approval`, present `requiresApproval.prompt` and `items`, then wait for the user's decision.
+3. In the same owner session, build a separate `action: "resume"` call with the returned `resumeToken` as `token` (or the returned `approvalId`), `flowId` from `mutation.flow.flowId`, `flowExpectedRevision` from `mutation.flow.revision`, and `approve` set to the user's decision. Keep `maxStdoutBytes: 8192` on resume.
 
-- Store only the minimum state needed to resume.
-- Put human-readable wait reasons in `blockedSummary` or structured wait metadata in `waitJson`.
-- Use `getTaskSummary(flowId)` on `api.runtime.tasks.flows` when the orchestrator needs a compact health view of child work.
-- Use `requestCancel(...)` when a caller wants the flow to stop scheduling immediately.
-- Use `cancel(...)` when you also want active linked child tasks cancelled.
+Use the **post-mutation** revision, not the older top-level `flow.revision`. Set `approve: false` only when the user declines. On approval, check the new `mutation.applied` and flow status; on cancellation, check `mutation.cancelled`. Report errors, rejected mutations and pending cancellations rather than claiming completion. Do not blindly retry side effects after a revision conflict: reload and reconcile first.
 
-## Examples
+## Complete the goal
 
-- See `skills/taskflow/examples/inbox-triage.lobster`
-- See `skills/taskflow/examples/pr-intake.lobster`
-- See `skills/taskflow-inbox-triage/SKILL.md` for a concrete routing pattern
+A linked child reaching a terminal state does not finish a managed flow. Compare its result with the flow goal, schedule the next in-scope step, and call `finish(...)` only after the goal's acceptance condition is verified.
+
+Persist explicit acceptance state in `stateJson` for terminal-outcome workflows. For example, a PR-landing flow should remain running or waiting through review and CI, and finish only after the hosting service reports the PR as merged.
+
+## Durable state is not a scheduler
+
+TaskFlow records persist in SQLite. Controllers must reload the latest record and explicitly resume; arbitrary JavaScript and in-flight work are not replayed. Lobster approval pauses are not listeners for Slack replies. Keep persisted state to bounded IDs, route summaries and cursors, not full messages or histories.
+
+Plugin authors use `api.runtime.tasks.managedFlows`; `flows` and `runs` provide owner-scoped lookups. `runTask` links an **already launched, authoritative** ACP/subagent execution with matching owner and canonical run/session IDs; it never launches one. Do not invent IDs, timestamps or backing records. See the [plugin launch/link contract](https://docs.openclaw.ai/plugins/sdk-runtime) and [Task Flow](https://docs.openclaw.ai/automation/taskflow).
+
+For inbox routing and real-adapter requirements, read `skills/taskflow-inbox-triage/SKILL.md`. For tool setup, see [Lobster](https://docs.openclaw.ai/tools/lobster).

--- a/skills/taskflow/examples/inbox-triage.lobster
+++ b/skills/taskflow/examples/inbox-triage.lobster
@@ -1,33 +1,32 @@
-# Illustrative Lobster authoring example for a TaskFlow-style inbox triage job.
-# Swap the placeholder commands for your own tools or scripts.
-
+# Runnable synthetic preview. Requires Node; no mailbox or messaging adapters.
+# Approval pauses this workflow, not a listener for an arbitrary Slack reply.
 name: inbox-triage
+args:
+  items:
+    default:
+      - { id: demo-business-1, route: business }
+      - { id: demo-personal-1, route: personal }
+      - { id: demo-later-1, route: later }
+      - { id: demo-business-2, route: business }
 steps:
-  - id: fetch
-    command: gog.gmail.search --query 'newer_than:1d' --max 20
-
-  - id: classify
+  - id: review
     command: >-
-      openclaw.invoke --tool llm-task --action json --args-json
-      '{"prompt":"Classify each inbox item as business, personal, or later. Return one JSON object per item with route and summary.","thinking":"low","schema":{"type":"object","properties":{"items":{"type":"array"}},"required":["items"],"additionalProperties":false}}'
-    stdin: $fetch.stdout
+      node -e '
+      const { items } = JSON.parse(process.env.LOBSTER_ARGS_JSON);
+      if (!Array.isArray(items) || items.length > 20) throw new Error("Expected at most 20 synthetic items");
+      const routes = { business: [], personal: [], later: [] };
+      for (const item of items) {
+        if (!item || typeof item.id !== "string" || !item.id.trim() || item.id.length > 80 ||
+            typeof item.route !== "string" || !Object.hasOwn(routes, item.route)) {
+          throw new Error("Each item needs an id and a business, personal or later route");
+        }
+        routes[item.route].push(item.id);
+      }
+      process.stdout.write(JSON.stringify({ synthetic: true, routes }));'
+    approval:
+      prompt: "Approve this synthetic inbox routing? No messages will be sent."
 
-  - id: post_business
-    command: slack-route --bucket business
-    stdin: $classify.stdout
-    condition: $classify.json.items[0].route == "business"
-
-  - id: wait_for_business_reply
-    command: echo '{"status":"waiting","reason":"slack_reply"}'
-    condition: $classify.json.items[0].route == "business"
-
-  - id: notify_personal
-    command: >-
-      openclaw.invoke --tool message --action send --args-json
-      '{"provider":"telegram","to":"owner-thread","content":"Personal inbox item needs attention."}'
-    condition: $classify.json.items[0].route == "personal"
-
-  - id: stash_for_eod
-    command: summary-append --bucket eod
-    stdin: $classify.stdout
-    condition: $classify.json.items[0].route == "later"
+  - id: result
+    command: node -e 'process.stdout.write(require("node:fs").readFileSync(0))'
+    stdin: $review.stdout
+    condition: $review.approved

--- a/skills/taskflow/examples/pr-intake.lobster
+++ b/skills/taskflow/examples/pr-intake.lobster
@@ -1,32 +1,32 @@
-# Illustrative Lobster authoring example for a TaskFlow-style PR intake lane.
-# Replace the placeholder commands with repo-specific tooling.
-
+# Runnable synthetic preview. Requires Node; no GitHub reads or mutations.
 name: pr-intake
+args:
+  items:
+    default:
+      - { id: demo-pr-1, intent: close }
+      - { id: demo-pr-2, intent: request_changes }
+      - { id: demo-pr-3, intent: refactor }
+      - { id: demo-pr-4, intent: maintainer_review }
+      - { id: demo-pr-5, intent: refactor }
 steps:
-  - id: fetch
-    command: gh pr list --repo owner/repo --state open --json number,title,body,headRefName
-
-  - id: classify
+  - id: review
     command: >-
-      openclaw.invoke --tool llm-task --action json --args-json
-      '{"prompt":"Classify each PR as close, request_changes, refactor, or maintainer_review. Return intent and recommended next action.","thinking":"low","schema":{"type":"object","properties":{"items":{"type":"array"}},"required":["items"],"additionalProperties":false}}'
-    stdin: $fetch.stdout
+      node -e '
+      const { items } = JSON.parse(process.env.LOBSTER_ARGS_JSON);
+      if (!Array.isArray(items) || items.length > 20) throw new Error("Expected at most 20 synthetic items");
+      const routes = { close: [], request_changes: [], refactor: [], maintainer_review: [] };
+      for (const item of items) {
+        if (!item || typeof item.id !== "string" || !item.id.trim() || item.id.length > 80 ||
+            typeof item.intent !== "string" || !Object.hasOwn(routes, item.intent)) {
+          throw new Error("Each item needs an id and a close, request_changes, refactor or maintainer_review intent");
+        }
+        routes[item.intent].push(item.id);
+      }
+      process.stdout.write(JSON.stringify({ synthetic: true, routes }));'
+    approval:
+      prompt: "Approve this synthetic PR routing? No GitHub actions will be performed."
 
-  - id: close_low_signal
-    command: pr-close-low-signal
-    stdin: $classify.stdout
-    condition: $classify.json.items[0].nextAction == "close"
-
-  - id: request_changes
-    command: pr-request-changes
-    stdin: $classify.stdout
-    condition: $classify.json.items[0].nextAction == "request_changes"
-
-  - id: refactor_branch
-    command: pr-refactor-branch
-    stdin: $classify.stdout
-    condition: $classify.json.items[0].nextAction == "refactor"
-
-  - id: escalate
-    command: echo '{"status":"notify","target":"maintainer"}'
-    condition: $classify.json.items[0].nextAction == "maintainer_review"
+  - id: result
+    command: node -e 'process.stdout.write(require("node:fs").readFileSync(0))'
+    stdin: $review.stdout
+    condition: $review.approved


### PR DESCRIPTION
Related: #125647 (the earlier TaskFlow runtime-alias correction).
Context: https://x.com/TriadDarren/status/2095205848062595143

<details>
<summary>Additional instructions</summary>

Maintainer edits are available: this is a branch in the main repository.

</details>

## What Problem This Solves

Fixes an issue where users following the bundled TaskFlow skills would immediately hit `Task backing ownership could not be verified.` instead of starting the described work. The inbox skill omitted a run ID; the general skill invented one. Neither launched an authoritative child.

The linked Lobster recipes also mixed placeholder shell commands with an unavailable embedded invocation bridge, routed a whole batch from its first item, and printed waiting JSON instead of actually suspending.

## Why This Change Was Made

`runTask` links existing owner-verified execution; it is not a launcher. Keep that runtime boundary intact and repair the authoring layer instead: use the existing managed Lobster run/approval/resume path for executable examples, and document the separate public requester-bound subagent launch/link contract for plugin authors.

Both examples now route bounded synthetic, already-classified batches, stop at a real approval gate and return the complete result after resumption. No mailbox, Slack or GitHub adapters are implied or supplied. The SDK/TaskFlow/Lobster docs explain checked outcomes, the post-mutation revision, late-link limitations, real SQLite durability and explicit controller resumption rather than automatic JavaScript replay.

The refresh preserves current main's separate Lobster installation instructions and its goal-acceptance guidance: a child completing is not the same as finishing the flow's goal, and a PR-landing flow remains active through review/CI until the hosting service confirms the merge.

## User Impact

Users get examples that run without external accounts or side effects, rather than recipes that fabricate child execution. Every input item is accounted for, invalid or oversized input fails visibly, and declining approval cancels the workflow. Plugin authors can distinguish creating flow state, launching a child and linking its authoritative task.

No runtime, ownership guard, public API, configuration, dependency, or SQLite schema changes. No files are deleted. Actual inbox delivery and PR actions remain separate adapters/controllers, not capabilities removed by this patch.

Documentation: https://docs.openclaw.ai/automation/taskflow, https://docs.openclaw.ai/plugins/sdk-runtime, https://docs.openclaw.ai/tools/lobster.

## Evidence

### Before and after

- Executed both original skill snippets through the production managed-flow runtime in isolated SQLite: both returned `created:false` with the ownership-verification reason, unchanged parent revision 0, and zero phantom task rows. The same guard and recipes were present in stable `v2026.8.2` and the original investigation baseline `f92a12c5813fb880ed6a05c4a728fd5f4ccc5473`.
- Executed both repaired files through public Lobster plugin registration/tool invocation, the real embedded Lobster package and production TaskFlow storage. Mixed, empty and maximum-size batches, actual approval, denial, invalid input and oversized input passed. A new process reopened SQLite, rejected stale revisions and resumed both workflows. Deliberately faulting the already-completed first step in proof-owned copies confirmed that resumption did not rerun it.
- A real dist-backed Gateway on that baseline handled authenticated incoming dispatch, the genuine `before_dispatch` hook and public `subagent.run`. Both successful and failed children were launched and linked with `created:true`. Bounded waits remained nonterminal; real runtime settlement updated both canonical and managed rows. Clean Gateway process restart preserved the completed child, human-wait flow and failed flow; explicit resume, revision conflict and finish passed. SQLite integrity was `ok` and all proof servers stopped.

Compact Gateway verdict (synthetic transport/model; real admission, authority, task registry and SQLite):

```json
{
  "status": "PASS",
  "sourceSha": "f92a12c5813fb880ed6a05c4a728fd5f4ccc5473",
  "successfulChild": { "linked": true, "canonical": "succeeded", "managed": "succeeded" },
  "failedChild": { "linked": true, "canonical": "failed", "managed": "failed" },
  "boundedWait": "nonterminal timeout; no cancellation",
  "restart": { "clean": true, "restoredRevision": 2, "resumedRevision": 3, "finishedRevision": 4 },
  "staleWrite": "revision_conflict",
  "sqliteIntegrity": "ok"
}
```

This proves completed-child persistence and explicitly invoked controller continuation, not live-child survival, automatic JavaScript replay, or delivery to a real channel. Source-loader attempts were inconclusive; the final dist-backed proof superseded them. Fixture authentication and model-response selection were corrected before the passing run; no production guard or timeout was weakened.

### Landing refresh

Rebased onto current main `911d7d5b0c107f7274f2415ca9655dcc6105f0e8`, preserving the newer installation and goal-acceptance guidance. On PR head `209b2c9126140c014c218252ed35879fb5f10dd5`, both actual recipe files passed the public-tool/fresh-process exercise again, including mixed/empty/maximum batches, decline, invalid/oversized input, owner isolation, stale revisions and resumed output. Current-tooling formatting, MDX (752 files), internal links (8,036 checked, zero broken), glossary checks and `git diff --check` passed. Fresh independent Codex review of the repair was scoped-clean at P0; the rebase retained upstream guidance without changing executable recipe bytes.

### Focused checks

The original repair passed 133 focused tests (59 TaskFlow and 74 Lobster), Markdown-scoped changed checks, MDX validation, internal-link validation, i18n glossary validation and formatting:

```bash
node scripts/run-vitest.mjs src/plugins/runtime/runtime-taskflow.test.ts src/tasks/task-executor.test.ts src/tasks/task-flow-registry.test.ts src/tasks/task-flow-registry.store.test.ts src/tasks/task-flow-registry.e2e.test.ts
```

```bash
node scripts/run-vitest.mjs extensions/lobster
```

```bash
node scripts/check-changed.mjs -- skills/taskflow/SKILL.md skills/taskflow-inbox-triage/SKILL.md docs/automation/taskflow.md docs/plugins/sdk-runtime.md docs/tools/lobster.md
```

```bash
pnpm docs:check-mdx
```

```bash
pnpm docs:check-links
```

```bash
pnpm docs:check-i18n-glossary
```

```bash
git diff --check
```

The executable examples were exercised separately because the original changed-scope classifier treated `.lobster` as unknown and selected unrelated production lanes. No classifier or baseline was changed. No new tracked tests were added: the production guard already has owner-boundary coverage, while the documentation repair was verified by executing the actual examples rather than adding brittle Markdown string assertions. Task-local probe scripts/logs were retained for maintainer inspection and are not committed artifacts.

Production runtime LOC: +0/-0. Tracked tests/test support: +0/-0. The patch only changes seven documentation/example files.
