### PR TITLE
refactor(test): reuse speech request assertions

### DIFF
--- a/src/tts/openai-compatible-speech-provider.test.ts
+++ b/src/tts/openai-compatible-speech-provider.test.ts
@@ -2,6 +2,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
+import { mockFirstObjectArg } from "../test-utils/mock-call-assertions.js";
 import { createOpenAiCompatibleSpeechProvider } from "./openai-compatible-speech-provider.js";
 import { withSpeakerSelectionCompat, withSpeakerSelectionFallbackCompat } from "./speaker.js";
 import { getResolvedSpeechProviderConfig } from "./tts-provider-resolution.js";
@@ -44,18 +45,6 @@ vi.mock("openclaw/plugin-sdk/provider-http", async () => {
     resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
   };
 });
-
-function requireFirstMockArg(mock: ReturnType<typeof vi.fn>): Record<string, unknown> {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error("missing first mock call");
-  }
-  const [arg] = call;
-  if (!arg || typeof arg !== "object") {
-    throw new Error("missing first mock argument");
-  }
-  return arg as Record<string, unknown>;
-}
 
 describe("createOpenAiCompatibleSpeechProvider", () => {
   afterEach(() => {
@@ -281,14 +270,14 @@ describe("createOpenAiCompatibleSpeechProvider", () => {
     });
 
     expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledOnce();
-    const httpConfigRequest = requireFirstMockArg(resolveProviderHttpRequestConfigMock);
+    const httpConfigRequest = mockFirstObjectArg(resolveProviderHttpRequestConfigMock);
     expect(httpConfigRequest.baseUrl).toBe("https://example.test/v1");
     expect(httpConfigRequest.defaultBaseUrl).toBe("https://example.test/v1");
     expect(httpConfigRequest.provider).toBe("demo");
     expect(httpConfigRequest.capability).toBe("audio");
 
     expect(postJsonRequestMock).toHaveBeenCalledOnce();
-    const postRequest = requireFirstMockArg(postJsonRequestMock);
+    const postRequest = mockFirstObjectArg(postJsonRequestMock);
     expect(postRequest.url).toBe("https://example.test/v1/audio/speech");
     expect(postRequest.timeoutMs).toBe(1234);
     expect(postRequest.body).toStrictEqual({


### PR DESCRIPTION
## What Problem This Solves

The OpenAI-compatible speech tests duplicate the shared helper for reading a mock's first object argument. This maintainer-requested test cleanup removes that duplicate without deleting behavioral coverage.

## Why This Change Was Made

Use the existing `mockFirstObjectArg` at the two request-inspection sites. Both remain after their called-once assertion, and all field and lifecycle assertions stay unchanged. The shared helper preserves the old helper's accepted object values and missing/invalid-argument failures for these Vitest mocks.

## User Impact

No user-visible behavior change. Production code is unchanged; tests are +3/-14 lines. The target and sibling suites retain all 21 cases and 56 expectations, including voice precedence, credential destinations, request fields, malformed/empty audio rejection and awaited response release.

## Evidence

- Complete target, OpenRouter and DeepInfra suites passed before and after: 10/8/3 cases respectively, with identical ordered case inventories.
- The normal selected changed-file gate passed all 20 checks, including the core test type graph, lint and all three dead-export scans.
- Managed Codex review found no actionable P0-P2 findings; source and index remained unchanged.
- All 18 reviewed source datasets match main at `4e217930a68a12586f0dd215a68f714958a02970` relative to the tested base `0d84b12e65e1dc44d515b0c4a12195fa52b7ca9c`.

The proof above is local test evidence. Exact-head hosted CI remains required before landing; no live provider behavior is changed or claimed.
