### PR TITLE
fix(media): prevent stale transcription models and PDF defaults

### DIFF
--- a/src/agents/tools/pdf-tool.helpers.test.ts
+++ b/src/agents/tools/pdf-tool.helpers.test.ts
@@ -1,40 +1,9 @@
 // PDF tool helper tests cover page ranges, PDF input normalization, provider
 // capability checks, and assistant text coercion.
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-
-const pdfMetadataPlugins = vi.hoisted(() => [
-  {
-    contracts: {
-      mediaUnderstandingProviders: ["anthropic", "google", "openai"],
-    },
-    mediaUnderstandingProviderMetadata: {
-      anthropic: { capabilities: ["image"], nativeDocumentInputs: ["pdf"] },
-      google: { capabilities: ["image"], nativeDocumentInputs: ["pdf"] },
-      openai: { capabilities: ["image"], nativeDocumentInputs: [] },
-    },
-  },
-]);
-
-vi.mock("../../plugins/plugin-registry.js", () => ({
-  loadPluginManifestRegistryForPluginRegistry: () => ({
-    plugins: pdfMetadataPlugins,
-    diagnostics: [],
-  }),
-  loadPluginRegistrySnapshotWithMetadata: () => ({
-    source: "derived",
-    snapshot: { plugins: [] },
-    diagnostics: [],
-  }),
-}));
-
-vi.mock("../../plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../../plugins/current-plugin-metadata-snapshot.js")>()),
-  getCurrentPluginMetadataSnapshot: () => ({
-    plugins: pdfMetadataPlugins,
-  }),
-}));
-
+import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import {
   coercePdfAssistantText,
   coercePdfModelConfig,
@@ -43,6 +12,22 @@ import {
   resolvePdfInputs,
   resolvePdfToolMaxTokens,
 } from "./pdf-tool.helpers.js";
+
+const pdfMetadataSnapshot = createPluginMetadataSnapshotFixture({
+  plugins: [
+    {
+      id: "pdf-fixture",
+      contracts: {
+        mediaUnderstandingProviders: ["anthropic", "google", "openai"],
+      },
+      mediaUnderstandingProviderMetadata: {
+        anthropic: { capabilities: ["image"], nativeDocumentInputs: ["pdf"] },
+        google: { capabilities: ["image"], nativeDocumentInputs: ["pdf"] },
+        openai: { capabilities: ["image"], nativeDocumentInputs: [] },
+      },
+    },
+  ],
+});
 
 const ANTHROPIC_PDF_MODEL = "anthropic/claude-opus-4-7";
 
@@ -109,27 +94,17 @@ describe("parsePageRange", () => {
 });
 
 describe("providerSupportsNativePdf", () => {
-  it("returns true for anthropic", () => {
-    // Native PDF support is derived from plugin metadata, not a hard-coded
-    // provider allowlist in the helper.
-    expect(providerSupportsNativePdf("anthropic")).toBe(true);
-  });
-
-  it("returns true for google", () => {
-    expect(providerSupportsNativePdf("google")).toBe(true);
-  });
-
-  it("returns false for openai", () => {
-    expect(providerSupportsNativePdf("openai")).toBe(false);
-  });
-
-  it("returns false for minimax", () => {
-    expect(providerSupportsNativePdf("minimax")).toBe(false);
-  });
-
-  it("is case-insensitive", () => {
-    expect(providerSupportsNativePdf("Anthropic")).toBe(true);
-    expect(providerSupportsNativePdf("GOOGLE")).toBe(true);
+  it.each([
+    ["anthropic", true],
+    ["google", true],
+    ["openai", false],
+    ["minimax", false],
+    ["Anthropic", true],
+    ["GOOGLE", true],
+  ] as const)("returns %s capability from its manifest: %s", (provider, supported) => {
+    withPluginMetadataSnapshotScope(pdfMetadataSnapshot, () => {
+      expect(providerSupportsNativePdf(provider)).toBe(supported);
+    });
   });
 });
 

--- a/src/media-understanding/defaults.generation.test.ts
+++ b/src/media-understanding/defaults.generation.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
+import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
+import { finalizePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import {
+  providerSupportsNativePdfDocument,
+  resolveAutoMediaKeyProviders,
+  resolveDefaultMediaModel,
+  resolveDocumentMediaModel,
+} from "./defaults.js";
+
+function createMediaSnapshot(generation: string, nativePdf: boolean) {
+  return finalizePluginMetadataSnapshot(
+    createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "media-owner",
+          contracts: { mediaUnderstandingProviders: ["media-owner", "other-owner"] },
+          mediaUnderstandingProviderMetadata: {
+            "media-owner": {
+              capabilities: ["audio", "image"],
+              defaultModels: { audio: `${generation}-audio`, image: `${generation}-image` },
+              autoPriority: { audio: nativePdf ? 1 : 3 },
+              nativeDocumentInputs: nativePdf ? ["pdf"] : [],
+              documentModels: { pdf: { textExtraction: `${generation}-text`, image: false } },
+            },
+            "other-owner": { capabilities: ["audio"], autoPriority: { audio: 2 } },
+          },
+        },
+      ],
+    }),
+  );
+}
+
+describe("media defaults generation ownership", () => {
+  it.each([false, true])("follows nested metadata scopes with config=%s", (hasConfig) => {
+    const cfg: OpenClawConfig | undefined = hasConfig ? {} : undefined;
+    const options = { config: cfg, trustConfigIdentity: true };
+    const first = createMediaSnapshot("first", true);
+    const second = createMediaSnapshot("second", false);
+    const readDefaults = () => ({
+      model: resolveDefaultMediaModel({ providerId: "media-owner", capability: "audio", cfg }),
+      order: resolveAutoMediaKeyProviders({ capability: "audio", cfg }),
+      nativePdf: providerSupportsNativePdfDocument({ providerId: "media-owner", cfg }),
+      documentModel: resolveDocumentMediaModel({
+        providerId: "media-owner",
+        document: "pdf",
+        mode: "textExtraction",
+        cfg,
+      }),
+    });
+    const firstExpected = {
+      model: "first-audio",
+      order: ["media-owner", "other-owner"],
+      nativePdf: true,
+      documentModel: "first-text",
+    };
+
+    withPluginMetadataSnapshotScope(
+      first,
+      () => {
+        expect(readDefaults()).toEqual(firstExpected);
+        withPluginMetadataSnapshotScope(
+          second,
+          () => {
+            expect(readDefaults()).toEqual({
+              model: "second-audio",
+              order: ["other-owner", "media-owner"],
+              nativePdf: false,
+              documentModel: "second-text",
+            });
+          },
+          options,
+        );
+        expect(readDefaults()).toEqual(firstExpected);
+      },
+      options,
+    );
+  });
+});

--- a/src/media-understanding/defaults.test.ts
+++ b/src/media-understanding/defaults.test.ts
@@ -79,31 +79,16 @@ const mediaMetadataPlugins = vi.hoisted(() => [
   },
 ]);
 
-vi.mock("../plugins/plugin-registry.js", () => ({
-  loadPluginManifestRegistryForPluginRegistry: () => ({
-    plugins: mediaMetadataPlugins,
-    diagnostics: [],
-  }),
-  loadPluginRegistrySnapshotWithMetadata: () => ({
-    source: "derived",
-    snapshot: { plugins: [] },
-    diagnostics: [],
-  }),
-}));
-
-vi.mock("../plugins/manifest-contract-eligibility.js", () => ({
-  loadManifestMetadataSnapshot: () => ({
-    index: { plugins: [] },
-    plugins: mediaMetadataPlugins,
-  }),
-}));
-
-vi.mock("../plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../plugins/current-plugin-metadata-snapshot.js")>()),
-  getCurrentPluginMetadataSnapshot: () => ({
-    plugins: mediaMetadataPlugins,
-  }),
-}));
+vi.mock("../plugins/manifest-contract-eligibility.js", () => {
+  const manifestRegistry = { plugins: mediaMetadataPlugins, diagnostics: [] };
+  return {
+    loadManifestMetadataSnapshot: () => ({
+      index: { plugins: [] },
+      plugins: mediaMetadataPlugins,
+      manifestRegistry,
+    }),
+  };
+});
 
 import {
   providerSupportsNativePdfDocument,

--- a/src/media-understanding/defaults.ts
+++ b/src/media-understanding/defaults.ts
@@ -6,9 +6,7 @@ import {
   normalizeMediaExecutionProviderId,
   normalizeMediaProviderId,
 } from "../../packages/media-understanding-common/src/provider-id.js";
-import { resolveRuntimeConfigCacheKey } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.js";
-import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { buildMediaUnderstandingManifestMetadataRegistry } from "./manifest-metadata.js";
 import {
   resolveAutoMediaKeyProvidersFromRegistry,
@@ -26,40 +24,6 @@ export {
   DEFAULT_VIDEO_MAX_BASE64_BYTES,
   MIN_AUDIO_FILE_BYTES,
 } from "./defaults.constants.js";
-
-let defaultRegistryCache: Map<string, MediaUnderstandingProvider> | null = null;
-const configRegistryCache = new Map<string, Map<string, MediaUnderstandingProvider>>();
-const MAX_CONFIG_REGISTRY_CACHE_ENTRIES = 32;
-
-function cacheConfigRegistry(
-  key: string,
-  registry: Map<string, MediaUnderstandingProvider>,
-): Map<string, MediaUnderstandingProvider> {
-  // Config snapshots are process-stable enough for bounded reuse; cap entries so
-  // tests and multi-workspace runs cannot grow this cache without limit.
-  if (
-    !configRegistryCache.has(key) &&
-    configRegistryCache.size >= MAX_CONFIG_REGISTRY_CACHE_ENTRIES
-  ) {
-    pruneMapToMaxSize(configRegistryCache, MAX_CONFIG_REGISTRY_CACHE_ENTRIES - 1);
-  }
-  configRegistryCache.set(key, registry);
-  return registry;
-}
-
-function resolveDefaultRegistry(cfg?: OpenClawConfig, workspaceDir?: string) {
-  if (!cfg) {
-    defaultRegistryCache ??= buildMediaUnderstandingManifestMetadataRegistry();
-    return defaultRegistryCache;
-  }
-  const cacheKey = `${resolveRuntimeConfigCacheKey(cfg)}:${workspaceDir ?? ""}`;
-  const cached = configRegistryCache.get(cacheKey);
-  if (cached) {
-    return cached;
-  }
-  const registry = buildMediaUnderstandingManifestMetadataRegistry(cfg, workspaceDir);
-  return cacheConfigRegistry(cacheKey, registry);
-}
 
 function resolveConfiguredImageProviderModel(params: {
   cfg?: OpenClawConfig;
@@ -154,7 +118,8 @@ export function resolveDefaultMediaModel(params: {
     }
   }
   const registry =
-    params.providerRegistry ?? resolveDefaultRegistry(params.cfg, params.workspaceDir);
+    params.providerRegistry ??
+    buildMediaUnderstandingManifestMetadataRegistry(params.cfg, params.workspaceDir);
   return resolveDefaultMediaModelFromRegistry({
     providerId: params.providerId,
     capability: params.capability,
@@ -170,7 +135,8 @@ export function resolveAutoMediaKeyProviders(params: {
   providerRegistry?: Map<string, MediaUnderstandingProvider>;
 }): string[] {
   const registry =
-    params.providerRegistry ?? resolveDefaultRegistry(params.cfg, params.workspaceDir);
+    params.providerRegistry ??
+    buildMediaUnderstandingManifestMetadataRegistry(params.cfg, params.workspaceDir);
   const prioritized = resolveAutoMediaKeyProvidersFromRegistry({
     capability: params.capability,
     providerRegistry: registry,
@@ -192,7 +158,8 @@ export function providerSupportsNativePdfDocument(params: {
   providerRegistry?: Map<string, MediaUnderstandingProvider>;
 }): boolean {
   const registry =
-    params.providerRegistry ?? resolveDefaultRegistry(params.cfg, params.workspaceDir);
+    params.providerRegistry ??
+    buildMediaUnderstandingManifestMetadataRegistry(params.cfg, params.workspaceDir);
   const provider = registry.get(normalizeMediaProviderId(params.providerId));
   return provider?.nativeDocumentInputs?.includes("pdf") ?? false;
 }
@@ -207,7 +174,8 @@ export function resolveDocumentMediaModel(params: {
   providerRegistry?: Map<string, MediaUnderstandingProvider>;
 }): string | false | undefined {
   const registry =
-    params.providerRegistry ?? resolveDefaultRegistry(params.cfg, params.workspaceDir);
+    params.providerRegistry ??
+    buildMediaUnderstandingManifestMetadataRegistry(params.cfg, params.workspaceDir);
   const provider = registry.get(normalizeMediaProviderId(params.providerId));
   const value = provider?.documentModels?.[params.document]?.[params.mode];
   if (value === false) {

--- a/src/media-understanding/manifest-metadata.ts
+++ b/src/media-understanding/manifest-metadata.ts
@@ -3,19 +3,31 @@
 import { normalizeMediaProviderId } from "../../packages/media-understanding-common/src/provider-id.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { MediaUnderstandingProvider } from "./types.js";
+
+// Defaults follow the selected immutable manifest generation, including retained
+// owners. Configured model overrides remain outside this projection.
+const registriesByManifest = new WeakMap<
+  PluginManifestRegistry,
+  Map<string, MediaUnderstandingProvider>
+>();
 
 /** Builds a media provider registry from trusted manifest metadata without loading plugin code. */
 export function buildMediaUnderstandingManifestMetadataRegistry(
   cfg?: OpenClawConfig,
   workspaceDir?: string,
 ): Map<string, MediaUnderstandingProvider> {
-  const registry = new Map<string, MediaUnderstandingProvider>();
   const snapshot = loadManifestMetadataSnapshot({
     config: cfg,
     env: process.env,
     ...(workspaceDir ? { workspaceDir } : {}),
   });
+  const cached = registriesByManifest.get(snapshot.manifestRegistry);
+  if (cached) {
+    return cached;
+  }
+  const registry = new Map<string, MediaUnderstandingProvider>();
   for (const plugin of snapshot.plugins) {
     // Metadata only counts when the manifest also declares the provider contract.
     const declaredProviders = new Set(
@@ -42,5 +54,6 @@ export function buildMediaUnderstandingManifestMetadataRegistry(
       });
     }
   }
+  registriesByManifest.set(snapshot.manifestRegistry, registry);
   return registry;
 }


### PR DESCRIPTION
## What Problem This Solves

Media defaults could come from a different metadata generation when the config was unchanged. After a lookup under owner A, nested owner B inherited A's transcription model, provider order, and PDF hints. Returning to retained owner A happened to keep A's values, masking the ownership error. This extracts the focused media cache repair from #130706.

## Why This Change Was Made

The defaults layer kept a process-wide default registry and a separate config-fingerprint cache, neither keyed by the selected manifest owner. Delete both caches and memoize the manifest-only projection by its immutable registry identity. Existing snapshot selection remains authoritative; configured image overrides and explicit provider registries retain their precedence.

Production LOC is +22/-41 (net -19). Tests are +91/-25 (net +66), including removal of obsolete broad mocks. No config, protocol, schema, or provider API changes. The documented boot-inventory and isolated-operation ownership contract already describes the intended behavior; this restores it without adding metadata refresh polling.

## User Impact

Media operations use the selected generation's defaults, including retained nested operations. Models, automatic provider ordering, and PDF support/extraction hints stay together. An operation no longer inherits defaults from a prior owner solely because both used the same config.

## Evidence

- The new no-mock generation regression failed 2/2 cases before the repair, covering configured and configless lookups through all four default projections.
- A live local HTTP transcription probe loaded two real temporary plugin manifests, read a 32,044-byte WAV through the production attachment cache, and executed the production media provider path. Baseline owner order A/B/A transmitted models A/A/A; candidate transmitted A/B/A and returned corresponding transcription/model results. The fixture server and temporary plugin/config/audio/state were cleaned.
- After the full build, `openclaw infer audio transcribe --agent main --file <isolated WAV> --json` loaded a real synthetic plugin, sent the expected default model to its loopback HTTP provider, and returned the expected user-visible transcript. This is controlled local-provider proof, not an authenticated remote-provider claim. Hashes of 8,508 runtime module files plus the launcher/package metadata were unchanged across this final proof.
- `node scripts/run-vitest.mjs src/media-understanding/defaults.generation.test.ts src/media-understanding/defaults.test.ts src/media-understanding/runner.auto-audio.test.ts src/media-understanding/runner.video.test.ts src/agents/tools/pdf-tool.test.ts`: 95 tests passed.
- `pnpm build`: passed, including declarations, CLI bootstrap imports, native control-plane loads, SDK exports, and Control UI budgets.
- `node scripts/check-changed.mjs -- src/media-understanding/defaults.ts src/media-understanding/manifest-metadata.ts src/media-understanding/defaults.test.ts src/media-understanding/defaults.generation.test.ts`: passed, including core/test typechecks, all Knip scans, lint, and zero runtime import cycles.
- Fresh managed autoreview through P2: scoped-clean, no actionable findings. Parent independently inspected the changed owner and caller contracts with no additional finding.

Candidate commit: aa67a633415e69b5871f224cac51f2aa146feea7. Candidate source tree: c126af6d74c530cd00780573db55890156600d2b. Local runtime digest: 9c74ac6adc52c390773fc7297e5536fd1800f046952953020e08e0a0bfc94aeb.


CI follow-through: the first hosted run exposed an incomplete PDF test snapshot. Commit `385c0111626` replaces its broad module mocks with the existing complete metadata fixture and real scoped owner; all 25 PDF helper tests, changed checks and independent P2 review pass. This follow-up changes tests only (-25 lines); the production live proof above remains unchanged. Final production delta is -19 and test delta is +41.
