### PR TITLE
fix(control-ui): dedupe live terminal bubble on delta history catch-up

### DIFF
--- a/ui/src/pages/chat/chat-history-cursor.test.ts
+++ b/ui/src/pages/chat/chat-history-cursor.test.ts
@@ -22,6 +22,11 @@ import {
   readChatSessionSnapshot,
   type ChatMessageCache,
 } from "./session-message-cache.ts";
+import {
+  authoritativeHistoryAppliedForRun,
+  rememberAuthoritativeTerminal,
+  rememberLiveTerminalRun,
+} from "./terminal-message-identity.ts";
 import { handleAgentEvent } from "./tool-stream.ts";
 
 function createState(handler: (params?: unknown) => unknown) {
@@ -278,6 +283,60 @@ describe("chat history cursor revalidation", () => {
     const current = getChatSessionProjection(state, readChatSessionProjectionScope(state));
     expect(current.scope.activeLeafEntryId).toBe("next-leaf");
     expect(current.runs).toBe(projection.runs);
+  });
+
+  it("prunes the live terminal bubble once an accepted delta admits its persisted reply", async () => {
+    // Reproduces: chat.final renders a run's reply as a live bubble; the
+    // session.message event that later confirms it was persisted arrives
+    // separately and can be served by an incremental delta catch-up instead
+    // of a full page load. Only the full-page path pruned the now-superseded
+    // live bubble, so the same reply rendered twice until the next reload.
+    const prompt = message("user", "Inspect the workspace", "user-1", 1);
+    const persistedReply = message("assistant", "Workspace inspected.", "assistant-1", 2);
+    const liveReply = rememberLiveTerminalRun(
+      message("assistant", "Workspace inspected.", "live-assistant-1", 1),
+      "run-1",
+    );
+    const handler = vi.fn(async () => ({
+      kind: "delta",
+      messages: [
+        {
+          sessionKey: "main",
+          message: persistedReply,
+          messageId: "assistant-1",
+          messageSeq: 2,
+        },
+      ],
+      deltaCursor: "cursor-2",
+      sessionInfo: {
+        key: "main",
+        kind: "direct",
+        sessionId: "session-cursor",
+        updatedAt: 3,
+        hasActiveRun: false,
+      },
+    }));
+    const state = createState(handler);
+    state.chatMessages = [prompt, liveReply];
+    seedCachedHistory(state, state.chatMessages, "cursor-1");
+    // Mirrors what handleSessionMessageEvent records once it learns run-1's
+    // reply was persisted as message "assistant-1" (rememberAuthoritativeTerminal
+    // in chat-state-events.ts), just before it kicks off the history reload.
+    rememberAuthoritativeTerminal({
+      event: { key: "main", runId: "run-1", hasActiveRun: false },
+      host: state,
+      matchesChat: true,
+      payload: { message: liveReply, messageId: "assistant-1" },
+      runIdBeforeApply: "run-1",
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages.map(extractText)).toEqual([
+      "Inspect the workspace",
+      "Workspace inspected.",
+    ]);
+    expect(authoritativeHistoryAppliedForRun(state, "run-1")).toBe(true);
   });
 
   it("keeps cached paint while replay updates an existing tool message in place", async () => {

--- a/ui/src/pages/chat/chat-history-hydration.ts
+++ b/ui/src/pages/chat/chat-history-hydration.ts
@@ -178,6 +178,28 @@ export async function hydrateChatHistory(
         applySessionMessagePayload(state, payload, runActive, { kind: "history-delta" });
       }
       const historyProjection = getChatSessionProjection(state);
+      // A run's persisted reply can land via this delta before the pane's live
+      // terminal bubble for that run is cleared (chat.final is a separate,
+      // unordered event). Unlike the full/page load below, this incremental
+      // merge never dropped the superseded live entry, so the same reply
+      // rendered twice until the next full reload. Prune it here too.
+      const retainedPreviousMessages = reconcileAuthoritativeTerminalHistory({
+        host: state,
+        previousMessages,
+        sessionKey,
+        visibleMessages: historyProjection.messages,
+      });
+      const supersededLiveMessages = new Set(
+        previousMessages.filter((message) => !retainedPreviousMessages.includes(message)),
+      );
+      const dedupedProjection = supersededLiveMessages.size
+        ? {
+            ...historyProjection,
+            messages: historyProjection.messages.filter(
+              (message) => !supersededLiveMessages.has(message),
+            ),
+          }
+        : historyProjection;
       if (Object.hasOwn(response.sessionInfo, "activeLeafEntryId")) {
         state.chatDisplayedLeafEntryId = response.sessionInfo.activeLeafEntryId?.trim() || null;
       }
@@ -185,8 +207,8 @@ export async function hydrateChatHistory(
       // An accepted delta advances the same transcript generation, not a branch replacement.
       // Carry ownership across its leaf advance; reseeding loses attributed pending sends and runs.
       publishChatSessionProjection(state, {
-        ...historyProjection,
-        scope: { ...historyProjection.scope, ...readChatSessionProjectionScope(state) },
+        ...dedupedProjection,
+        scope: { ...dedupedProjection.scope, ...readChatSessionProjectionScope(state) },
       });
       applyChatPendingInputs(state, response.pendingInputs, {
         receipts:


### PR DESCRIPTION
Closes #139316

## What Problem This Solves

Fixes an issue where users of the Control UI web chat would see an assistant reply rendered twice in the transcript when the chat pane received that reply's confirmation via an incremental history catch-up ("delta") instead of a full page reload. A page refresh always resolved it back to a single message, since only the full-page load path was deduplicating.

## Why This Change Was Made

The full/page history load already calls `reconcileAuthoritativeTerminalHistory` to prune a live-streamed terminal bubble once the persisted copy of the same reply is confirmed present. The delta catch-up path — the one that keeps an already-open pane in sync, and the more commonly hit of the two — merged the persisted message in but never ran that same pruning step, so the earlier live bubble was left behind alongside the newly-applied persisted one. This change applies the same reconciliation in the delta branch: after merging delta messages, it diffs the pre/post message lists through `reconcileAuthoritativeTerminalHistory` and drops any live terminal message the reconciliation marks as superseded before publishing.

No behavior changes for the full-page path; the delta branch's non-message fields (runs, scope, etc.) are untouched.

## User Impact

Assistant replies no longer render twice in the Control UI chat pane when a run's persisted reply is confirmed through routine delta sync rather than a full reload.

## Evidence

- Added a regression test (`chat-history-cursor.test.ts`: "prunes the live terminal bubble once an accepted delta admits its persisted reply") that reproduces the exact sequence: a live terminal bubble for a run, followed by a delta response admitting that run's persisted reply under the same authoritative message id.
  - Verified it **fails on the pre-fix code** with the exact duplicate: `["Inspect the workspace", "Workspace inspected.", "Workspace inspected."]`.
  - Passes with the fix: `["Inspect the workspace", "Workspace inspected."]`.
- Ran the full existing suites for the touched and adjacent files — `chat-history-cursor.test.ts`, `chat-gateway.test.ts`, `chat-thread.test.ts`, `stream-reconciliation.test.ts`, `chat-pane-session-hydration.test.ts`, `chat-pane-snapshot-hydration.test.ts` — **490/490 passing**, no regressions.
- Ran the full `ui` vitest suite locally; no failures introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
