### PR TITLE
fix(android): reconnect secondary gateways after rapid lifecycle changes

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -2956,7 +2956,7 @@ class NodeRuntime private constructor(
 
   /** Clears setup credentials plus paired device tokens for both Android gateway roles. */
   suspend fun resetGatewaySetupAuth(stableId: String): Boolean =
-    gatewayLifecycleIntentSeq.incrementAndGet().let { intent ->
+    advanceGatewayLifecycleIntent().let { intent ->
       gatewaySwitchMutex.withLock {
         if (intent != gatewayLifecycleIntentSeq.get()) false else resetGatewaySetupAuthLocked(stableId)
       }
@@ -4545,9 +4545,13 @@ class NodeRuntime private constructor(
       if (!isCurrent()) return@synchronized null
       preferredGatewayReconnectSuppressed = false
       secondaryGatewayConnectionsEnabled = true
-      gatewayLifecycleIntent(gatewayLifecycleIntentSeq.incrementAndGet(), isCurrent).also {
-        requestBackgroundGatewayReconciliation()
-      }
+      gatewayLifecycleIntent(advanceGatewayLifecycleIntent(), isCurrent)
+    }
+
+  // Queued callers can exit before cleanup, so generation changes must request reconciliation.
+  private fun advanceGatewayLifecycleIntent(): Long =
+    gatewayLifecycleIntentSeq.incrementAndGet().also {
+      requestBackgroundGatewayReconciliation()
     }
 
   private fun gatewayLifecycleIntent(
@@ -4826,7 +4830,7 @@ class NodeRuntime private constructor(
       normalizeGatewayTlsFingerprintInput(
         prompt.fingerprintSha256 ?: manualFingerprint ?: return,
       ) ?: return
-    val intent = gatewayLifecycleIntent(gatewayLifecycleIntentSeq.incrementAndGet())
+    val intent = gatewayLifecycleIntent(advanceGatewayLifecycleIntent())
     launchGatewayLifecycle(intent) {
       if (_pendingGatewayTrust.value != prompt) return@launchGatewayLifecycle
       _pendingGatewayTrust.value = null
@@ -4839,7 +4843,7 @@ class NodeRuntime private constructor(
   fun useSystemGatewayTrustPrompt() {
     val prompt = _pendingGatewayTrust.value ?: return
     if (!prompt.systemTrustAvailable) return
-    val intent = gatewayLifecycleIntent(gatewayLifecycleIntentSeq.incrementAndGet())
+    val intent = gatewayLifecycleIntent(advanceGatewayLifecycleIntent())
     launchGatewayLifecycle(intent) {
       if (_pendingGatewayTrust.value != prompt) return@launchGatewayLifecycle
       _pendingGatewayTrust.value = null
@@ -4850,7 +4854,7 @@ class NodeRuntime private constructor(
   }
 
   fun declineGatewayTrustPrompt() {
-    val intent = gatewayLifecycleIntent(gatewayLifecycleIntentSeq.incrementAndGet())
+    val intent = gatewayLifecycleIntent(advanceGatewayLifecycleIntent())
     launchGatewayLifecycle(intent) {
       _pendingGatewayTrust.value = null
       connectingEndpointStableId = null
@@ -4940,7 +4944,7 @@ class NodeRuntime private constructor(
     synchronized(gatewayLifecycleIntentLock) {
       preferredGatewayReconnectSuppressed = true
       secondaryGatewayConnectionsEnabled = false
-      gatewayLifecycleIntentSeq.incrementAndGet()
+      advanceGatewayLifecycleIntent()
       disconnectSecondaryGatewayConnections()
       disconnect(retireRunState)
       requestBackgroundGatewayReconciliation()
@@ -4976,7 +4980,7 @@ class NodeRuntime private constructor(
     val intent =
       synchronized(gatewayLifecycleIntentLock) {
         if (!isCurrent()) return false
-        gatewayLifecycleIntent(gatewayLifecycleIntentSeq.incrementAndGet(), isCurrent)
+        gatewayLifecycleIntent(advanceGatewayLifecycleIntent(), isCurrent)
       }
     return gatewaySwitchMutex.withLock {
       if (!intent()) false else forgetGatewayLocked(stableId)

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -148,16 +148,19 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
@@ -899,6 +902,11 @@ class NodeRuntime private constructor(
   private val inlineWidgetRefreshMutex = Mutex()
   private val gatewayLifecycleIntentLock = Any()
   private val gatewayLifecycleIntentSeq = AtomicLong()
+
+  // Retain one pending request while reconciliation awaits cleanup; equal desired values can
+  // still require new work after a synchronous retirement or lifecycle invalidation.
+  // Initialize before NetworkMonitor can request work during construction.
+  private val backgroundGatewayReconciliations = Channel<Unit>(Channel.CONFLATED)
 
   private var gatewayDataGeneration = 0L
 
@@ -3001,6 +3009,7 @@ class NodeRuntime private constructor(
       true
     } finally {
       synchronized(gatewayAuthLifecycleLock) { gatewayAuthResetInProgress = false }
+      requestBackgroundGatewayReconciliation()
     }
   }
 
@@ -3027,7 +3036,8 @@ class NodeRuntime private constructor(
   private var didAutoConnect = false
 
   @Volatile private var preferredGatewayReconnectSuppressed = initialReconnectSuppressed
-  private val secondaryGatewayConnectionsEnabled = MutableStateFlow(!initialReconnectSuppressed)
+
+  @Volatile private var secondaryGatewayConnectionsEnabled = !initialReconnectSuppressed
 
   val chatSessionKey: StateFlow<String> = chat.sessionKey
   internal val chatSelectionGeneration: StateFlow<Long> = chat.selectionGeneration
@@ -3191,11 +3201,12 @@ class NodeRuntime private constructor(
           prefs.gatewayRegistry.connectedStableIds,
           prefs.gatewayRegistry.activeStableId,
           gateways,
-          combine(_isForeground, secondaryGatewayConnectionsEnabled) { foreground, enabled ->
-            foreground && enabled
-          },
+          backgroundGatewayReconciliations.consumeAsFlow().onStart { emit(Unit) },
         ) { _, _, _, _, _ -> Unit }
-          .collect { reconcileBackgroundGatewayFleet() }
+          .collect {
+            ensureActive()
+            reconcileBackgroundGatewayFleet()
+          }
       }
     } else {
       applyScreenshotFixture()
@@ -3242,6 +3253,7 @@ class NodeRuntime private constructor(
         (_isForeground.value != value).also {
           _isForeground.value = value
           if (!value) disconnectSecondaryGatewayConnections()
+          requestBackgroundGatewayReconciliation()
         }
       }
     voiceWakeManager.setForeground(value)
@@ -3370,8 +3382,12 @@ class NodeRuntime private constructor(
       entries = prefs.gatewayRegistry.entries.value,
       connectedIds = prefs.gatewayRegistry.connectedStableIds.value,
       activeId = prefs.gatewayRegistry.activeStableId.value,
-      foreground = _isForeground.value && secondaryGatewayConnectionsEnabled.value,
+      foreground = _isForeground.value && secondaryGatewayConnectionsEnabled,
     )
+
+  private fun requestBackgroundGatewayReconciliation() {
+    backgroundGatewayReconciliations.trySend(Unit)
+  }
 
   private suspend fun reconcileBackgroundGatewayFleet() =
     gatewaySwitchMutex.withLock {
@@ -3385,7 +3401,7 @@ class NodeRuntime private constructor(
             entries = entries,
             connectedIds = prefs.gatewayRegistry.connectedStableIds.value,
             activeId = prefs.gatewayRegistry.activeStableId.value,
-            foreground = _isForeground.value && secondaryGatewayConnectionsEnabled.value,
+            foreground = _isForeground.value && secondaryGatewayConnectionsEnabled,
             existingStableIds = secondaryOperatorSessions.keys.toList(),
           ) { resolveRegistryEndpoint(it) }
         synchronized(gatewayLifecycleIntentLock) {
@@ -3493,9 +3509,10 @@ class NodeRuntime private constructor(
     stableId: String,
     enabled: Boolean,
   ) = synchronized(gatewayLifecycleIntentLock) {
-    if (enabled) secondaryGatewayConnectionsEnabled.value = true
+    if (enabled) secondaryGatewayConnectionsEnabled = true
     prefs.gatewayRegistry.setConnectionEnabled(stableId, enabled)
     if (!enabled) disconnectSecondaryGatewayConnection(stableId)
+    requestBackgroundGatewayReconciliation()
   }
 
   suspend fun connectSwitchingGateway(
@@ -3537,6 +3554,7 @@ class NodeRuntime private constructor(
               prefs.gatewayRegistry.setActive(endpoint.stableId)
             }
             beginConnect(endpoint, resolveGatewayConnectAuth(endpoint, explicitAuth), intent)
+            requestBackgroundGatewayReconciliation()
             true
           }
         }
@@ -3557,6 +3575,7 @@ class NodeRuntime private constructor(
     // lifecycle intent. If any explicit connect/disconnect/switch intent already exists, stand
     // down permanently instead of overriding the user's decision with a stale auto-connect.
     if (!gatewayLifecycleIntentSeq.compareAndSet(0L, 1L)) return
+    requestBackgroundGatewayReconciliation()
     launchConnect(endpoint, explicitAuth = null, intent = gatewayLifecycleIntent(1L))
   }
 
@@ -4527,8 +4546,10 @@ class NodeRuntime private constructor(
     synchronized(gatewayLifecycleIntentLock) {
       if (!isCurrent()) return@synchronized null
       preferredGatewayReconnectSuppressed = false
-      secondaryGatewayConnectionsEnabled.value = true
-      gatewayLifecycleIntent(gatewayLifecycleIntentSeq.incrementAndGet(), isCurrent)
+      secondaryGatewayConnectionsEnabled = true
+      gatewayLifecycleIntent(gatewayLifecycleIntentSeq.incrementAndGet(), isCurrent).also {
+        requestBackgroundGatewayReconciliation()
+      }
     }
 
   private fun gatewayLifecycleIntent(
@@ -4542,7 +4563,11 @@ class NodeRuntime private constructor(
   ) {
     val guardedBlock = {
       synchronized(gatewayLifecycleIntentLock) {
-        if (isCurrent()) block()
+        try {
+          if (isCurrent()) block()
+        } finally {
+          requestBackgroundGatewayReconciliation()
+        }
       }
     }
     if (gatewaySwitchMutex.tryLock()) {
@@ -4916,10 +4941,11 @@ class NodeRuntime private constructor(
   private fun disconnectGatewayLifecycle(retireRunState: Boolean) {
     synchronized(gatewayLifecycleIntentLock) {
       preferredGatewayReconnectSuppressed = true
-      secondaryGatewayConnectionsEnabled.value = false
+      secondaryGatewayConnectionsEnabled = false
       gatewayLifecycleIntentSeq.incrementAndGet()
       disconnectSecondaryGatewayConnections()
       disconnect(retireRunState)
+      requestBackgroundGatewayReconciliation()
     }
   }
 
@@ -5040,6 +5066,7 @@ class NodeRuntime private constructor(
       true
     } finally {
       synchronized(gatewayAuthLifecycleLock) { gatewayAuthResetInProgress = false }
+      requestBackgroundGatewayReconciliation()
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -3530,37 +3530,35 @@ class NodeRuntime private constructor(
     intent: () -> Boolean,
   ): Boolean =
     gatewaySwitchMutex.withLock {
-      if (!intent()) return@withLock false
-      val currentStableId =
-        connectedEndpoint?.stableId
-          ?: connectingEndpointStableId
-          ?: prefs.gatewayRegistry.activeStableId.value
-      if (currentStableId != null && currentStableId != endpoint.stableId) {
-        disconnectAndJoin()
-      } else {
-        drainIdleGatewaySessionTails()
-      }
-      // Focus can promote a secondary operator to the primary session for the same gateway.
-      // Its accepted credentials must finish before either primary role reads them.
-      disconnectSecondaryGatewayConnection(endpoint.stableId)?.disconnectAndJoin()
-      val started =
-        synchronized(gatewayLifecycleIntentLock) {
-          if (!intent()) {
-            false
-          } else {
-            if (prefs.gatewayRegistry.entries.value
-                .any { it.stableId == endpoint.stableId }
-            ) {
-              prefs.gatewayRegistry.setActive(endpoint.stableId)
-            }
-            beginConnect(endpoint, resolveGatewayConnectAuth(endpoint, explicitAuth), intent)
-            requestBackgroundGatewayReconciliation()
-            true
-          }
+      try {
+        if (!intent()) return@withLock false
+        val currentStableId =
+          connectedEndpoint?.stableId
+            ?: connectingEndpointStableId
+            ?: prefs.gatewayRegistry.activeStableId.value
+        if (currentStableId != null && currentStableId != endpoint.stableId) {
+          disconnectAndJoin()
+        } else {
+          drainIdleGatewaySessionTails()
         }
-      if (!started) return@withLock false
-      chat.restoreSelectedGatewayOfflineState()
-      intent()
+        // Focus can promote a secondary operator to the primary session for the same gateway.
+        // Its accepted credentials must finish before either primary role reads them.
+        disconnectSecondaryGatewayConnection(endpoint.stableId)?.disconnectAndJoin()
+        synchronized(gatewayLifecycleIntentLock) {
+          if (!intent()) return@withLock false
+          if (prefs.gatewayRegistry.entries.value
+              .any { it.stableId == endpoint.stableId }
+          ) {
+            prefs.gatewayRegistry.setActive(endpoint.stableId)
+          }
+          beginConnect(endpoint, resolveGatewayConnectAuth(endpoint, explicitAuth), intent)
+        }
+        chat.restoreSelectedGatewayOfflineState()
+        intent()
+      } finally {
+        // A superseded promotion may already have retired an enabled secondary.
+        requestBackgroundGatewayReconciliation()
+      }
     }
 
   private fun autoConnectIfNeeded() {

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.gateway.DeviceAuthStore
 import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewayConnectOptions
 import ai.openclaw.app.gateway.GatewayEndpoint
+import ai.openclaw.app.gateway.GatewayRegistryEntryKind
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.GatewayTlsParams
 import ai.openclaw.app.ui.GatewayConnectConfig
@@ -694,15 +695,22 @@ class NodeForegroundServiceTest {
   @Config(shadows = [ServiceRuntimePrefsShadow::class, SessionDisconnectShadow::class, ConnectAdmissionShadow::class])
   fun focusingSecondaryKeepsItsAdmittedOperatorWhileHelloPersists() = assertReconnectDrainsAcceptedOperatorToken(GatewayTokenTransition.SecondaryFocus, holdPrimaryWriteUntilNode = true)
 
+  @Test
+  @Config(shadows = [ServiceRuntimePrefsShadow::class, SessionDisconnectShadow::class])
+  fun supersededSecondaryFocusPreservesAcceptedOperatorTokenOrder() = assertReconnectDrainsAcceptedOperatorToken(GatewayTokenTransition.SecondaryFocus, supersedeFocus = true)
+
   private enum class GatewayTokenTransition { SecondaryReenable, PrimaryReconnect, SecondaryFocus, ForegroundRoundTrip }
 
   private fun assertReconnectDrainsAcceptedOperatorToken(
     transition: GatewayTokenTransition,
     holdPrimaryWriteUntilNode: Boolean = false,
+    supersedeFocus: Boolean = false,
   ) {
     val app = RuntimeEnvironment.getApplication() as NodeApp
     app.prefs.setManualTls(false)
     val runtime = app.ensureBackgroundRuntime()
+    val viewModel = if (supersedeFocus) MainViewModel(app, app.prefs, SavedStateHandle()) else null
+    val viewModels = viewModel?.let { ViewModelStore().apply { put("secondary-focus", it) } }
     val fixture = Shadow.extract<ServiceRuntimePrefsShadow>(app)
     val tokenWrite = RuntimeReturnGate()
     val controller = Robolectric.buildService(NodeForegroundService::class.java).create()
@@ -736,12 +744,17 @@ class NodeForegroundServiceTest {
       }
     val endpoint = GatewayEndpoint.manual("127.0.0.1", gateway.port)
     app.prefs.gatewayRegistry.upsert(gatewayRegistryEntry(endpoint, null))
+    val undiscoverableId = "undiscoverable-focus-target"
+    if (supersedeFocus) {
+      app.prefs.gatewayRegistry.upsert(gatewayRegistryEntry(endpoint, null).copy(stableId = undiscoverableId, kind = GatewayRegistryEntryKind.DISCOVERED))
+    }
     val deviceId = DeviceIdentityStore.withPrefs(app, app.prefs).loadOrCreate().deviceId
     val authStore = DeviceAuthStore(app.prefs)
     authStore.saveToken(endpoint.stableId, deviceId, "operator", "synthetic-initial-token", listOf("operator.read", "operator.write"))
     assertEquals("synthetic-initial-token", fixture.operatorTokenWrites.tryReceive().getOrNull())
 
     try {
+      viewModel?.setForeground(true)
       runtime.setForeground(true)
       fixture.operatorTokenWriteGate = tokenWrite
       if (transition == GatewayTokenTransition.PrimaryReconnect) {
@@ -756,13 +769,19 @@ class NodeForegroundServiceTest {
       val drained = CompletableDeferred<Unit>()
       Shadow.extract<SessionDisconnectShadow>(first).joinStarted = drained
       val replacement =
-        if (transition == GatewayTokenTransition.SecondaryReenable || transition == GatewayTokenTransition.ForegroundRoundTrip) {
+        if (supersedeFocus || transition == GatewayTokenTransition.SecondaryReenable || transition == GatewayTokenTransition.ForegroundRoundTrip) {
           first
         } else {
           ReflectionHelpers.getField<GatewaySession>(runtime, "operatorSession")
         }
       val admitted = CompletableDeferred<Unit>()
       Shadow.extract<SessionDisconnectShadow>(replacement).connectStarted = admitted
+      val existingOperations =
+        viewModel
+          ?.let {
+            it.viewModelScope.coroutineContext.job.children
+              .toSet()
+          }.orEmpty()
       when (transition) {
         GatewayTokenTransition.SecondaryReenable -> {
           runtime.setGatewayConnectionEnabled(endpoint.stableId, false)
@@ -784,7 +803,7 @@ class NodeForegroundServiceTest {
         }
 
         GatewayTokenTransition.SecondaryFocus -> {
-          runtime.connect(endpoint)
+          if (viewModel == null) runtime.connect(endpoint) else viewModel.switchToGateway(endpoint.stableId)
         }
       }
       val completedWrites = mutableListOf<String>()
@@ -800,8 +819,21 @@ class NodeForegroundServiceTest {
           if (!waitingForOldOwner) {
             completedWrites += withTimeout(10_000) { fixture.operatorTokenWrites.receive() }
           }
+          viewModel?.let {
+            assertTrue("Promotion must join the accepted write before supersession", waitingForOldOwner)
+            it.switchToGateway(undiscoverableId)
+          }
         } finally {
           tokenWrite.release.countDown()
+        }
+        viewModel?.let {
+          val operations =
+            it.viewModelScope.coroutineContext.job.children
+              .filterNot(existingOperations::contains)
+              .toList()
+          withTimeout(10_000) { operations.joinAll() }
+          assertTrue("Superseded UI operations must finish normally", operations.none { it.isCancelled })
+          assertTrue("The selecting Activity must remain foreground", runtime.isForeground.value)
         }
         if (holdPrimaryWriteUntilNode) {
           assertTrue("Primary hello did not reach its held persistence", primaryWrite.entered.await(10, TimeUnit.SECONDS))
@@ -843,6 +875,7 @@ class NodeForegroundServiceTest {
       heldNodeHello.release.countDown()
       tokenWrite.release.countDown()
       fixture.operatorTokenWriteGate = null
+      viewModels?.clear()
       closeNodeServiceTestFixture(controller, app)
       gateway.shutdown()
     }

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -613,7 +613,13 @@ class NodeForegroundServiceTest {
 
   @Test
   @Config(shadows = [ServiceRuntimePrefsShadow::class, SessionDisconnectShadow::class])
-  fun stopRetiresSecondaryConnectionAfterAuthRead() {
+  fun stopRetiresSecondaryConnectionAfterAuthRead() = assertSecondaryAdmissionAfterStop(reenable = false)
+
+  @Test
+  @Config(shadows = [ServiceRuntimePrefsShadow::class, SessionDisconnectShadow::class])
+  fun reenablingSecondaryAfterStopRetriesItsPendingAdmission() = assertSecondaryAdmissionAfterStop(reenable = true)
+
+  private fun assertSecondaryAdmissionAfterStop(reenable: Boolean) {
     val app = RuntimeEnvironment.getApplication() as NodeApp
     app.prefs.setManualTls(false)
     val runtime = app.ensureBackgroundRuntime()
@@ -633,16 +639,25 @@ class NodeForegroundServiceTest {
       fixture.operatorTokenReadGate = authRead
       runtime.setGatewayConnectionEnabled(endpoint.stableId, true)
       assertTrue("Secondary connection did not reach its credential read", authRead.entered.await(10, TimeUnit.SECONDS))
-      NodeForegroundService.stop(app)
+      if (reenable) {
+        runtime.disconnect()
+        runtime.setGatewayConnectionEnabled(endpoint.stableId, true)
+      } else {
+        NodeForegroundService.stop(app)
+      }
       assertTrue("Stop did not finish its runtime teardown", stoppedNode.await(10, TimeUnit.SECONDS))
       assertNull(fixture.sessionConnections.poll())
 
       authRead.release.countDown()
 
-      assertNull(
-        "Stopped fleet work must not start an authenticated secondary connection",
-        fixture.sessionConnections.poll(10, TimeUnit.SECONDS),
-      )
+      val connection = fixture.sessionConnections.poll(10, TimeUnit.SECONDS)
+      if (reenable) {
+        assertNotNull("Reenabled admission must reach the session owner", connection)
+        assertEquals("operator", connection!!.role)
+        assertNotNull("Reenabled admission must reach the Gateway", gateway.takeRequest(10, TimeUnit.SECONDS))
+      } else {
+        assertNull("Stopped fleet work must not start an authenticated secondary connection", connection)
+      }
     } finally {
       authRead.release.countDown()
       fixture.operatorTokenReadGate = null
@@ -665,6 +680,10 @@ class NodeForegroundServiceTest {
 
   @Test
   @Config(shadows = [ServiceRuntimePrefsShadow::class, SessionDisconnectShadow::class])
+  fun foregroundRoundTripPreservesAcceptedOperatorTokenOrder() = assertReconnectDrainsAcceptedOperatorToken(GatewayTokenTransition.ForegroundRoundTrip)
+
+  @Test
+  @Config(shadows = [ServiceRuntimePrefsShadow::class, SessionDisconnectShadow::class])
   fun stoppedPrimaryReconnectReadsItsAcceptedOperatorToken() = assertReconnectDrainsAcceptedOperatorToken(GatewayTokenTransition.PrimaryReconnect)
 
   @Test
@@ -675,7 +694,7 @@ class NodeForegroundServiceTest {
   @Config(shadows = [ServiceRuntimePrefsShadow::class, SessionDisconnectShadow::class, ConnectAdmissionShadow::class])
   fun focusingSecondaryKeepsItsAdmittedOperatorWhileHelloPersists() = assertReconnectDrainsAcceptedOperatorToken(GatewayTokenTransition.SecondaryFocus, holdPrimaryWriteUntilNode = true)
 
-  private enum class GatewayTokenTransition { SecondaryReenable, PrimaryReconnect, SecondaryFocus }
+  private enum class GatewayTokenTransition { SecondaryReenable, PrimaryReconnect, SecondaryFocus, ForegroundRoundTrip }
 
   private fun assertReconnectDrainsAcceptedOperatorToken(
     transition: GatewayTokenTransition,
@@ -737,7 +756,7 @@ class NodeForegroundServiceTest {
       val drained = CompletableDeferred<Unit>()
       Shadow.extract<SessionDisconnectShadow>(first).joinStarted = drained
       val replacement =
-        if (transition == GatewayTokenTransition.SecondaryReenable) {
+        if (transition == GatewayTokenTransition.SecondaryReenable || transition == GatewayTokenTransition.ForegroundRoundTrip) {
           first
         } else {
           ReflectionHelpers.getField<GatewaySession>(runtime, "operatorSession")
@@ -748,6 +767,11 @@ class NodeForegroundServiceTest {
         GatewayTokenTransition.SecondaryReenable -> {
           runtime.setGatewayConnectionEnabled(endpoint.stableId, false)
           runtime.setGatewayConnectionEnabled(endpoint.stableId, true)
+        }
+
+        GatewayTokenTransition.ForegroundRoundTrip -> {
+          runtime.setForeground(false)
+          runtime.setForeground(true)
         }
 
         GatewayTokenTransition.PrimaryReconnect -> {


### PR DESCRIPTION
Closes #139310.

## What Problem This Solves

Enabled secondary Gateways could remain disconnected after rapid lifecycle changes or a superseded promotion. State observations alone could miss work after a connection had already been retired.

## Why This Change Was Made

One bounded request channel feeds the existing reconciliation collector. Lifecycle changes request work explicitly, and completion notifications cover changes made while an operation runs. A small shared helper now pairs each unconditional generation advance with its notification, so a queued caller does not depend on reaching cleanup to request reconciliation.

The existing counter, lock positions, current-state checks and session authority remain with their owners. Cold-start compare-and-set behavior and completion notifications are preserved. The old flag StateFlow/nested trigger and redundant promotion flag are removed. Production grows **29 lines** to establish the bounded work-request owner and its producers; tests add **57 lines**. The final generation helper accounts for four production lines of that total.

## User Impact

Enabled secondary connections can resume after rapid transitions and superseded promotions. Stop retains its retirement behavior, and accepted credential writes finish before replacement connections read authentication. Configuration, protocol and persistent-store contracts are unchanged.

## Evidence

- Current integrated source compiled in both Android phone flavors and passed **229 selected ordinary regressions per flavor: 458 executions, zero failures or skips**. Raw result membership was verified: no selected method was missing and no unexpected method ran.
- All **14 selected app checks passed**: 13 ran locally on the matching owned dependency graph, and all four modules' Kotlin lint ran in isolated Linux. This is a recorded split execution of the selected checks.
- Independent source review and all six managed full-PR review passes are clean. They verify notification ownership, unchanged locks/current-state checks, and absence of a new reconciliation feedback loop.
- Earlier promotion regressions retain their separate before/after evidence, including a failed prior head and a passing candidate with identical controlled bytes. Those historical results are not presented as new executions of this final source.

The new ordinary test selection uses existing Robolectric and synthetic transport fixtures. It excludes Forget, auth-reset and notification-presentation methods; this is not a full Android-suite result. The additional queued-caller notification finding is supported by source review, without a pre-fix runtime reproduction. No physical device, emulator, live-account or external-Gateway result is claimed.

Final source is based on `75c7f919`; the two affected files were unchanged by integration before the reviewed notification helper was applied. Runtime source SHA-256 is `894b0e344781f0ff57c9438028d297b6cd8fe5bdc4f1b1826fb8cce8b0f74597`. The [isolated validation workflow](https://github.com/openclaw/openclaw/actions/runs/34001580827) prepared the test environment; its link does not imply local command logs are public. All 62 exported evidence files were hash-verified before the test machine and its task keys were removed. [Corrected-head CI](https://github.com/openclaw/openclaw/actions/runs/34005639118) passed: ten jobs succeeded, 26 were skipped, and none failed. The latest exact-head ClawSweeper review has no actionable findings or rank-up requests.
