### PR TITLE
fix(ai): recover Responses continuations rejected under Zero Data Retention

### DIFF
--- a/docs/providers/openai/advanced.md
+++ b/docs/providers/openai/advanced.md
@@ -104,10 +104,11 @@ fallback even with explicit `agentRuntime.id: "codex"`; see
     A setup or handshake failure before request dispatch falls back to SSE; it
     is not retried or reconnected first. After dispatch, failures with an
     unknown outcome remain replay-unsafe and fail closed. The explicit server
-    rejections `previous_response_not_found` and
-    `websocket_connection_limit_reached` are safe exceptions: OpenClaw closes
-    the failed socket and retries that turn once over SSE with full history and
-    no rejected `previous_response_id`.
+    rejections `previous_response_not_found`,
+    `websocket_connection_limit_reached`, and the Zero Data Retention
+    `unsupported_parameter` rejection of `previous_response_id` are safe
+    exceptions: OpenClaw closes the failed socket and retries that turn once
+    over SSE with full history and no rejected `previous_response_id`.
 
     ```json5
     {

--- a/packages/ai/src/transports/openai-responses-client.continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.continuation.test.ts
@@ -674,39 +674,51 @@ describe("native OpenAI Responses SSE continuation", () => {
     expect(JSON.stringify(sseState.requests[1]?.input)).not.toContain('"compaction"');
   });
 
-  it("recovers a rejected continuation with full history and advances the baseline", async () => {
-    sseState.outcomes.push(
-      sdkCompletion("resp_1", "first answer"),
-      Object.assign(new Error("previous response not found"), {
-        code: "previous_response_not_found",
-        status: 400,
-      }),
-      sdkCompletion("resp_2", "second answer"),
-      sdkCompletion("resp_3", "third answer"),
-    );
-    const onPayload = (payload: Record<string, unknown>) => ({ ...payload, store: true });
-    const firstUser = userMessage("first question", 1);
-    const first = await run({ messages: [firstUser], tools: [] }, { onPayload });
-    const secondContext = {
-      messages: [firstUser, first, userMessage("second question", 2)],
-      tools: [],
-    };
-    const second = await run(secondContext, { onPayload });
-    await run(
-      {
-        messages: [...secondContext.messages, second, userMessage("third question", 3)],
+  it.each<{ rejection: string; error: { code: string; param?: string; status: number } }>([
+    {
+      rejection: "previous response not found",
+      error: { code: "previous_response_not_found", status: 400 },
+    },
+    {
+      rejection:
+        "Previous response cannot be used for this organization due to Zero Data Retention.",
+      error: { code: "unsupported_parameter", param: "previous_response_id", status: 400 },
+    },
+  ])(
+    "recovers a continuation rejected with $error.code using full history",
+    async ({ rejection, error }) => {
+      sseState.outcomes.push(
+        sdkCompletion("resp_1", "first answer"),
+        Object.assign(new Error(`400 ${rejection}`), error),
+        sdkCompletion("resp_2", "second answer"),
+        sdkCompletion("resp_3", "third answer"),
+      );
+      const onPayload = (payload: Record<string, unknown>) => ({ ...payload, store: true });
+      const firstUser = userMessage("first question", 1);
+      const first = await run({ messages: [firstUser], tools: [] }, { onPayload });
+      const secondContext = {
+        messages: [firstUser, first, userMessage("second question", 2)],
         tools: [],
-      },
-      { onPayload },
-    );
+      };
+      const second = await run(secondContext, { onPayload });
+      expect(second.stopReason).toBe("stop");
+      await run(
+        {
+          messages: [...secondContext.messages, second, userMessage("third question", 3)],
+          tools: [],
+        },
+        { onPayload },
+      );
 
-    expect(sseState.requests[1]).toMatchObject({ previous_response_id: "resp_1" });
-    expect(sseState.requests[1]?.input).toHaveLength(1);
-    expect(sseState.requests[2]).not.toHaveProperty("previous_response_id");
-    expect(sseState.requests[2]?.input).toHaveLength(3);
-    expect(sseState.requests[3]).toMatchObject({ previous_response_id: "resp_2" });
-    expect(sseState.requests[3]?.input).toHaveLength(1);
-  });
+      expect(sseState.requests).toHaveLength(4);
+      expect(sseState.requests[1]).toMatchObject({ previous_response_id: "resp_1" });
+      expect(sseState.requests[1]?.input).toHaveLength(1);
+      expect(sseState.requests[2]).not.toHaveProperty("previous_response_id");
+      expect(sseState.requests[2]?.input).toHaveLength(3);
+      expect(sseState.requests[3]).toMatchObject({ previous_response_id: "resp_2" });
+      expect(sseState.requests[3]?.input).toHaveLength(1);
+    },
+  );
 
   it("records the effective full-history compaction recovery request", async () => {
     sseState.outcomes.push(

--- a/packages/ai/src/transports/openai-responses-contracts.ts
+++ b/packages/ai/src/transports/openai-responses-contracts.ts
@@ -89,6 +89,17 @@ function readWebSocketServerError(value: unknown) {
   };
 }
 
+// A continuation reference the server refuses to honor: the response expired or never
+// existed (`previous_response_not_found`), or the organization cannot reference stored
+// responses at all (Zero Data Retention rejects the `previous_response_id` parameter).
+// Both reject before any output is accepted, so the turn resends full history instead.
+export function isPreviousResponseRejection(error: { code?: unknown; param?: unknown }): boolean {
+  return (
+    error.code === "previous_response_not_found" ||
+    (error.code === "unsupported_parameter" && error.param === "previous_response_id")
+  );
+}
+
 export function parseOpenAIResponsesWebSocketServerError(cause: unknown) {
   if (!isRecord(cause)) {
     return undefined;
@@ -103,7 +114,7 @@ export function parseOpenAIResponsesWebSocketServerError(cause: unknown) {
     return undefined;
   }
   const ErrorClass =
-    details.code === "previous_response_not_found" ||
+    isPreviousResponseRejection(details) ||
     details.code === "websocket_connection_limit_reached" ||
     details.code === "invalid_encrypted_content" ||
     details.code === "thinking_signature_invalid"

--- a/packages/ai/src/transports/openai-responses-replay-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-internal.ts
@@ -5,6 +5,7 @@ import type { OpenAIResponsesCompactionRejection } from "../provider-options.js"
 import type { createOpenAIResponsesClient } from "./openai-responses-client.js";
 import {
   DEFAULT_AZURE_OPENAI_API_VERSION,
+  isPreviousResponseRejection,
   type OpenAIResponsesRequestParams,
 } from "./openai-responses-contracts.js";
 import type { createResponsesPromptEgressObserver } from "./openai-responses-prompt-observer-internal.js";
@@ -224,7 +225,7 @@ export async function createResponsesStreamWithEncryptedContentRetry(params: {
           error &&
           typeof error === "object" &&
           typeof (error as { status?: unknown }).status === "number" &&
-          (error as { code?: unknown }).code === "previous_response_not_found"
+          isPreviousResponseRejection(error as { code?: unknown; param?: unknown })
         ) {
           const request = {
             ...(params.buildFullHistoryRequest

--- a/packages/ai/src/transports/openai-responses-websocket-client.test.ts
+++ b/packages/ai/src/transports/openai-responses-websocket-client.test.ts
@@ -536,9 +536,17 @@ describe("native OpenAI Responses WebSocket client integration", () => {
     expect(transportState.sdkRequests).toHaveLength(2);
   });
 
-  it.each(["previous_response_not_found", "websocket_connection_limit_reached"])(
-    "recovers a cached continuation rejected with %s over full-history SSE",
-    async (code) => {
+  it.each<{ code: string; param?: string; message?: string }>([
+    { code: "previous_response_not_found", param: "previous_response_id" },
+    { code: "websocket_connection_limit_reached" },
+    {
+      code: "unsupported_parameter",
+      param: "previous_response_id",
+      message: "Previous response cannot be used for this organization due to Zero Data Retention.",
+    },
+  ])(
+    "recovers a cached continuation rejected with $code over full-history SSE",
+    async ({ code, param, message: rejection }) => {
       transportState.responseBatches.push(
         [message(completedEvent("resp_1", "first answer"))],
         [
@@ -546,8 +554,8 @@ describe("native OpenAI Responses WebSocket client integration", () => {
             type: "error",
             error: wrappedSdkServerError({
               code,
-              message: `safe rejection: ${code}`,
-              param: code === "previous_response_not_found" ? "previous_response_id" : undefined,
+              message: rejection ?? `safe rejection: ${code}`,
+              param,
               status: 400,
             }),
           },


### PR DESCRIPTION
## What Problem This Solves

Closes #138954. Related: #140292 (same ZDR rejection reported against 2026.9.2). On an OpenAI organization with Zero Data Retention (ZDR), `openai/gpt-6-astra` (and any model on the direct Responses continuation path) answers the first request and then fails the tool-result continuation with:

```
status=400 code=unsupported_parameter type=invalid_request_error
message=400 Previous response cannot be used for this organization due to Zero Data Retention.
```

The user sees the generic `LLM request failed: provider rejected the request schema or tool payload.` and the tool-call workflow stops.

## Why This Change Was Made

**Root cause.** OpenClaw continues stateful Responses turns with `previous_response_id`. The continuation recovery in `packages/ai/src/transports/openai-responses-replay-internal.ts` rebuilt full history only when `error.code === "previous_response_not_found"`. A ZDR organization rejects the reference itself with `code: "unsupported_parameter"`, `param: "previous_response_id"` (structured 400 body confirmed from a public traceback in agno-agi/agno#4511; the OpenAI SDK exposes `param` on `APIError`). That shape matched neither the not-found branch nor the encrypted-content recovery, so the request hit `if (!nextAttempt) throw error;` and never recovered.

**Canonical fix.** Both transports that decide whether a rejected `previous_response_id` is safe to resend now share one classifier, `isPreviousResponseRejection({ code, param })` in `openai-responses-contracts.ts`, next to the existing WebSocket safe-retry allowlist:

- the HTTP/SSE recovery owner (`createResponsesStreamWithEncryptedContentRetry`) drops `previous_response_id` and resends the rebuilt full history as the existing `continuation-rejected` attempt;
- the WebSocket server-error parser classifies the same rejection as `OpenAIResponsesWebSocketSafeRetryError`, so the existing full-history SSE fallback handles it. Before this change the ZDR rejection over a cached WebSocket was a plain server error: the connection was marked degraded and the turn failed post-dispatch.

Classification uses the structured `code`/`param` fields only, never the message prose, and adds no organization flag or model-specific branch. The fail-closed path is unchanged: recovery still requires the attempt to have carried `previous_response_id` and a numeric status; every other error still rethrows, and post-dispatch in-stream rejections are still not replayed. Azure Responses is unaffected (no HTTP continuation, `store` stripped).

**Deliberately not in this PR (named follow-up).** After a recovered turn the continuation baseline re-arms, so a ZDR organization probes `previous_response_id` once per later turn (fast 400, no tokens consumed) and then resends full history. This matches the existing `previous_response_not_found` steady state. Remembering "this identity cannot reference stored responses" in the continuation owner would remove the probe; it touches `openai-responses-continuation.ts` state and belongs in a separate change.

## User Impact

- ZDR organizations complete tool-call round trips on `gpt-6-astra` and other direct Responses models over SSE and over cached WebSocket mode, instead of failing after the first response.
- No configuration change, no new option, no change for organizations without ZDR: `previous_response_not_found` behaves exactly as before.
- Docs: the WebSocket transport section lists the ZDR rejection among the safe server rejections.

## Evidence

Regression tests (both parametrized from the existing not-found cases):

- `packages/ai/src/transports/openai-responses-client.continuation.test.ts`: "recovers a continuation rejected with 'unsupported_parameter' using full history" (exact ZDR 400 shape).
- `packages/ai/src/transports/openai-responses-websocket-client.test.ts`: "recovers a cached continuation rejected with 'unsupported_parameter' over full-history SSE".

On pre-fix `main` (`a0980b9217e`) both fail for the intended reason, the turn errors instead of recovering:

```
× recovers a continuation rejected with 'unsupported_parameter' using full history
  AssertionError: expected 'error' to be 'stop' // Object.is equality
× recovers a cached continuation rejected with 'unsupported_parameter' over full-history SSE
  AssertionError: expected 'error' to be 'stop' // Object.is equality
Tests  2 failed | 37 passed (39)
```

With the fix:

```sh
node scripts/run-vitest.mjs run \
  packages/ai/src/transports/openai-responses-client.continuation.test.ts \
  packages/ai/src/transports/openai-responses-websocket-client.test.ts \
  packages/ai/src/transports/openai-responses-client.continuation.integration.test.ts \
  packages/ai/src/transports/openai-responses-continuation.test.ts \
  packages/ai/src/transports/openai-responses-replay-internal.test.ts
# Test Files  5 passed (5)   Tests  83 passed (83)

node_modules/.bin/oxfmt --check <changed files>          # clean
node scripts/run-oxlint.mjs <changed .ts files>          # clean (exit 0, no diagnostics)
node scripts/run-tsgo-core-test-shards.mjs --changed-paths-json '[...]'   # 16 core graphs selected, clean (exit 0)
node --import ./scripts/tsx.mjs scripts/format-docs.mts --check           # clean
git diff --check                                                          # clean
```

Production: +14/-2 lines (4 of them the invariant comment) across `openai-responses-contracts.ts` and `openai-responses-replay-internal.ts`. Tests: two `it.each` extensions. Docs: one sentence in `docs/providers/openai.md`.

### Real-client recovery through a local fault harness

No ZDR organization is reachable, so the rejection is replayed by a scripted provider on
loopback. Everything above the socket is production code: the real `openai` SDK, the real
`createOpenAIResponsesTransportStreamFn()` executor, the real continuation owner, the real
SSE and WebSocket parsers, and the real recovery owner. Only the TCP destination is
rewritten, the same technique
`packages/ai/src/transports/openai-responses-loopback.test-support.ts` already uses so that
`isOfficialOpenAIResponsesBaseUrl` still recognizes the native endpoint. The harness runs as
a plain Node process, not under Vitest, and contains no SDK, client, or transport mock.

The harness answers request 1, rejects any request carrying `previous_response_id` with the
exact provider body, and answers the rebuilt full-history request:

```json
{"error":{"message":"Previous response cannot be used for this organization due to Zero Data Retention.","type":"invalid_request_error","param":"previous_response_id","code":"unsupported_parameter"}}
```

```sh
# same script in both checkouts; the file is gitignored under .artifacts/ and is not committed
OPENCLAW_DEBUG_MODEL_TRANSPORT=1 node --import ./scripts/tsx.mjs .artifacts/zdr-fault-harness.mts sse
OPENCLAW_DEBUG_MODEL_TRANSPORT=1 node --import ./scripts/tsx.mjs .artifacts/zdr-fault-harness.mts websocket-cached
```

Before the fix, on `main` at `676845210ac` (Node v24.18.0). Turn 2 never reaches a third
request:

```
[harness] #1 POST /v1/responses previous_response_id=<none> input_items=1 input_types=[message]
[harness] #1 -> 200 resp_1
[turn 1] stopReason=toolUse
[harness] #2 POST /v1/responses previous_response_id=resp_1 input_items=1 input_types=[function_call_output]
[harness] #2 -> 400 unsupported_parameter param=previous_response_id
[openai-transport] WARN [responses] error provider=openai api=openai-responses model=scripted-model name=Error status=400 code=unsupported_parameter type=invalid_request_error causeName=undefined causeCode=undefined message=400 Previous response cannot be used for this organization due to Zero Data Retention.
[turn 2] stopReason=error errorMessage=400 Previous response cannot be used for this organization due to Zero Data Retention.
[result] requests_served=2 FAILED
```

```
[harness] #1 ws response.create previous_response_id=<none> input_items=1 input_types=[message]
[harness] #1 -> 200 resp_1
[turn 1] stopReason=toolUse
[harness] #2 ws response.create previous_response_id=resp_1 input_items=1 input_types=[function_call_output]
[harness] #2 -> 400 unsupported_parameter param=previous_response_id
[openai-transport] WARN [responses] error provider=openai api=openai-responses model=scripted-model name=OpenAIResponsesWebSocketPostDispatchError status=undefined code=PROVIDER_POST_DISPATCH_AMBIGUITY type=undefined causeName=OpenAIResponsesWebSocketServerError causeCode=unsupported_parameter message=OpenAI Responses WebSocket failed after request dispatch; outcome is unknown
[turn 2] stopReason=error errorMessage=OpenAI Responses WebSocket failed after request dispatch; outcome is unknown
[result] requests_served=2 FAILED
```

After the fix, at `4a1230cdd47`. The rejected reference is dropped, full history is resent
over a new request, and the turn finishes with the model's answer:

```
[harness] #1 POST /v1/responses previous_response_id=<none> input_items=1 input_types=[message]
[harness] #1 -> 200 resp_1
[turn 1] stopReason=toolUse
[harness] #2 POST /v1/responses previous_response_id=resp_1 input_items=1 input_types=[function_call_output]
[harness] #2 -> 400 unsupported_parameter param=previous_response_id
[openai-transport] WARN [responses] retrying full history after rejected previous_response_id provider=openai api=openai-responses model=scripted-model
[harness] #3 POST /v1/responses previous_response_id=<none> input_items=3 input_types=[message,function_call,function_call_output]
[harness] #3 -> 200 resp_2 (full history accepted)
[turn 2] stopReason=stop errorMessage=<none>
[turn 2] answer="recorded 7"
[result] requests_served=3 RECOVERED
```

The cached WebSocket turn falls back to full-history SSE instead of degrading the
connection, so request 3 leaves over HTTP:

```
[harness] #1 ws response.create previous_response_id=<none> input_items=1 input_types=[message]
[harness] #1 -> 200 resp_1
[turn 1] stopReason=toolUse
[harness] #2 ws response.create previous_response_id=resp_1 input_items=1 input_types=[function_call_output]
[harness] #2 -> 400 unsupported_parameter param=previous_response_id
[openai-transport] [responses] websocket_fallback provider=openai api=openai-responses model=scripted-model reason=safe_server_error code=unsupported_parameter status=400 param=previous_response_id
[harness] #3 POST /v1/responses previous_response_id=<none> input_items=3 input_types=[message,function_call,function_call_output]
[harness] #3 -> 200 resp_2 (full history accepted)
[turn 2] stopReason=stop errorMessage=<none>
[turn 2] answer="recorded 7"
[result] requests_served=3 RECOVERED
```

<details>
<summary>Harness source (`.artifacts/zdr-fault-harness.mts`, gitignored, not committed)</summary>

```ts
// Local fault harness: replays the OpenAI Zero Data Retention rejection of
// `previous_response_id` over a real socket, against the real `openai` SDK and the
// real OpenClaw Responses transport. Run from a checkout root:
//   node --import ./scripts/tsx.mjs .artifacts/zdr-fault-harness.mts [sse|websocket-cached]
import { createServer } from "node:http";
import type { Context, Model } from "@openclaw/llm-core";
import OpenAI from "openai";
import { WebSocketServer } from "ws";
import { configureAiTransportHost } from "../packages/ai/src/host.js";
import { createOpenAIResponsesTransportStreamFn } from "../packages/ai/src/transports/openai-responses-client.js";

const transport = (process.argv[2] ?? "sse") as "sse" | "websocket-cached";

// Exact provider body from the ZDR rejection reported in issue #138954.
const ZDR_REJECTION = {
  message: "Previous response cannot be used for this organization due to Zero Data Retention.",
  type: "invalid_request_error",
  param: "previous_response_id",
  code: "unsupported_parameter",
};

const tool = {
  name: "record_value",
  description: "Record the supplied value.",
  parameters: { type: "object", properties: { n: { type: "integer" } }, required: ["n"] },
};
const toolCall = {
  type: "function_call",
  id: "fc_1",
  call_id: "call_1",
  name: tool.name,
  arguments: '{"n":7}',
  status: "completed",
};
const finalMessage = {
  type: "message",
  id: "msg_done",
  role: "assistant",
  status: "completed",
  content: [{ type: "output_text", text: "recorded 7", annotations: [] }],
};
const completed = (id: string, item: unknown) => ({
  type: "response.completed",
  response: {
    id,
    status: "completed",
    output: [item],
    usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
  },
});
const toolCallEvents = [
  { type: "response.output_item.added", output_index: 0, item: { ...toolCall, arguments: "", status: "in_progress" } },
  { type: "response.function_call_arguments.delta", output_index: 0, item_id: toolCall.id, delta: toolCall.arguments },
  { type: "response.output_item.done", output_index: 0, item: toolCall },
  completed("resp_1", toolCall),
];
const finalEvents = [
  { type: "response.output_item.added", output_index: 0, item: { ...finalMessage, content: [] } },
  { type: "response.output_text.delta", output_index: 0, item_id: finalMessage.id, content_index: 0, delta: "recorded 7" },
  { type: "response.output_item.done", output_index: 0, item: finalMessage },
  completed("resp_2", finalMessage),
];

let served = 0;
// Scripted provider: reject any request that carries `previous_response_id`, answer
// full-history requests. Nothing here inspects OpenClaw state; it only reads the wire.
function classify(body: string, channel: string) {
  const request = JSON.parse(body) as Record<string, unknown>;
  const previous = request.previous_response_id as string | undefined;
  const input = Array.isArray(request.input) ? request.input : [];
  served += 1;
  console.log(
    `[harness] #${served} ${channel} previous_response_id=${previous ?? "<none>"} input_items=${input.length} ` +
      `input_types=[${input.map((item) => (item as { type?: string })?.type ?? "message").join(",")}]`,
  );
  if (previous) {
    console.log(`[harness] #${served} -> 400 ${ZDR_REJECTION.code} param=${ZDR_REJECTION.param}`);
    return { reject: true, events: [] as unknown[] };
  }
  const isRecovery = input.some((item) => (item as { type?: string })?.type === "function_call_output");
  console.log(`[harness] #${served} -> 200 ${isRecovery ? "resp_2 (full history accepted)" : "resp_1"}`);
  return { reject: false, events: isRecovery ? finalEvents : toolCallEvents };
}

const server = createServer((request, response) => {
  request.setEncoding("utf8");
  let body = "";
  request.on("data", (chunk: string) => (body += chunk));
  request.on("end", () => {
    const { reject, events } = classify(body, "POST /v1/responses");
    if (reject) {
      response.writeHead(400, { "content-type": "application/json" });
      response.end(JSON.stringify({ error: ZDR_REJECTION }));
      return;
    }
    response.writeHead(200, { "content-type": "text/event-stream" });
    for (const event of events) {
      response.write(`data: ${JSON.stringify(event)}\n\n`);
    }
    response.end();
  });
});
const sockets = new WebSocketServer({ server });
sockets.on("connection", (socket) => {
  socket.on("message", (raw) => {
    const { reject, events } = classify(raw.toString("utf8"), "ws response.create");
    if (reject) {
      socket.send(JSON.stringify({ type: "error", status: 400, error: ZDR_REJECTION }));
      return;
    }
    for (const event of events) {
      socket.send(JSON.stringify(event));
    }
  });
});
await new Promise<void>((resolve, reject) => {
  server.once("error", reject);
  server.listen(0, "127.0.0.1", resolve);
});
const address = server.address();
if (!address || typeof address === "string") {
  throw new Error("Expected a loopback TCP address");
}
console.log(`[harness] listening on http://127.0.0.1:${address.port} transport=${transport}`);

// Route only the TCP destination. Native-endpoint eligibility, the SDK, the request
// bytes, and the SSE/WebSocket parsers stay real. Same technique the repository's own
// loopback integration test uses.
const buildURL = OpenAI.prototype.buildURL;
OpenAI.prototype.buildURL = function (this: OpenAI, path, query, baseURL) {
  const url = new URL(buildURL.call(this, path, query, baseURL));
  if (url.origin !== "https://api.openai.com") {
    return url.href;
  }
  url.protocol = "http:";
  url.hostname = "127.0.0.1";
  url.port = String(address.port);
  return url.href;
};

configureAiTransportHost({
  logDebug: (subsystem, payload) => console.log(`[${subsystem}] ${payload().message}`),
  logInfo: (subsystem, message) => console.log(`[${subsystem}] ${message}`),
  logWarn: (subsystem, message) => console.log(`[${subsystem}] WARN ${message}`),
});

const model = {
  id: "scripted-model",
  name: "Scripted Model",
  api: "openai-responses",
  provider: "openai",
  baseUrl: "https://api.openai.com/v1",
  reasoning: false,
  input: ["text"],
  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
  contextWindow: 8192,
  maxTokens: 256,
} satisfies Model<"openai-responses">;

const streamFn = createOpenAIResponsesTransportStreamFn();
const run = async (messages: Context["messages"]) => {
  const stream = await streamFn(
    model,
    { messages, tools: [tool] },
    {
      apiKey: "sk-test-zdr-harness",
      sessionId: `zdr-fault-${transport}`,
      transport,
      onPayload: (payload) => ({ ...(payload as Record<string, unknown>), store: true }),
    },
  );
  return stream.result();
};

let exitCode = 0;
try {
  const user = { role: "user" as const, content: "Record 7.", timestamp: 1 };
  const first = await run([user]);
  console.log(`[turn 1] stopReason=${first.stopReason}`);
  const call = first.content.find((block) => block.type === "toolCall");
  if (!call) {
    throw new Error("Expected a tool call on turn 1");
  }
  const second = await run([
    user,
    first,
    {
      role: "toolResult" as const,
      toolCallId: call.id,
      toolName: call.name,
      content: [{ type: "text" as const, text: "ok" }],
      isError: false,
      timestamp: 2,
    },
  ]);
  const text = second.content
    .filter((block) => block.type === "text")
    .map((block) => block.text)
    .join("");
  console.log(`[turn 2] stopReason=${second.stopReason} errorMessage=${second.errorMessage ?? "<none>"}`);
  console.log(`[turn 2] answer=${JSON.stringify(text)}`);
  console.log(`[result] requests_served=${served} ${second.stopReason === "stop" ? "RECOVERED" : "FAILED"}`);
  exitCode = second.stopReason === "stop" ? 0 : 1;
} catch (error) {
  console.log(`[result] threw: ${error instanceof Error ? error.message : String(error)}`);
  exitCode = 1;
}
sockets.close();
server.close();
server.closeAllConnections();
process.exit(exitCode);
```

</details>

Proof gap: no ZDR-enabled OpenAI organization is available to me, so the 400 is replayed by a local scripted provider rather than produced by a real ZDR org, and the exercised model is a scripted stand-in rather than `gpt-6-astra`. Everything else in the recovered round trip is production: the exact provider body (`code`, `param`, `type`, message) reported in the issue and in agno-agi/agno#4511 crosses a real socket, is parsed by the real `openai` SDK, and is classified and recovered by the shipped transport owner. What remains unproven is that a real ZDR organization emits exactly this body; that shape comes from the issue report and the public traceback.
