### PR TITLE
fix(ui): keep uploaded images visible during worktree startup

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -1217,6 +1217,8 @@ This keeps media rendering compatible with browser-native media elements without
 
 Uploaded and local chat image previews rendered with native image elements keep an already-loaded image visible during temporary connection or metadata-renewal failures. Retention applies only to that mounted image; it does not extend its media ticket or authorize fresh reads. An explicit missing or access-denied response, or a change to the source, credentials, or access scope, clears the retained image.
 
+Uploaded images also stay visible while a new session's workspace or worktree details arrive. Media access is rechecked in the background without replacing the loaded preview with a loading card.
+
 Generated images under `/api/chat/media/outgoing/...` use the same capability
 principle through `artifacts.download`. The authenticated WebSocket request
 authorizes the transcript artifact and returns a short-lived URL. The HTTP media

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -454,7 +454,7 @@ suite.define(() => {
     });
   });
 
-  it("reconciles an image-bearing initial prompt into one user row", async () => {
+  it("keeps an initial image visible through worktree hydration and canonical history", async () => {
     await withNewSessionPage(async (page) => {
       const sessionKey = "agent:main:single-image-prompt";
       const runId = "initial-image-send";
@@ -578,6 +578,43 @@ suite.define(() => {
         expect((await captureThumbnail()).equals(initialPixels)).toBe(true);
         expect(await userRow.locator('[aria-busy="true"]').count()).toBe(0);
         await captureUiProof(suite, page, "initial-image-metadata-loading.png");
+
+        const worktreeSession = {
+          key: sessionKey,
+          sessionId: "single-image-prompt",
+          displayName: "Image handoff worktree",
+          kind: "direct",
+          updatedAt: Date.now(),
+          activeRunIds: [runId],
+          hasActiveRun: true,
+          status: "running",
+          permissionMode: "workspace",
+          sessionRoot: "/workspace/image-handoff",
+          spawnedCwd: "/workspace/image-handoff",
+          worktree: {
+            id: "image-handoff-worktree",
+            branch: "image-handoff",
+            repoRoot: "/workspace/project",
+          },
+        };
+        await gateway.setMethodResponse("sessions.list", {
+          ...createdSessionListResult(sessionKey),
+          sessions: [worktreeSession],
+        });
+        await gateway.emitGatewayEvent("sessions.changed", {
+          sessionKey,
+          sessionId: worktreeSession.sessionId,
+          reason: "project",
+          session: worktreeSession,
+        });
+        await pollLocatorText(page.locator(".chat-pane__session-title-text")).toBe(
+          worktreeSession.displayName,
+        );
+        await captureUiProof(suite, page, "initial-image-worktree-metadata-loading.png");
+        expect(await userImage.getAttribute("data-initial-image-node")).toBe("true");
+        expect(await userImage.getAttribute("src")).toBe(initialImageSrc);
+        expect((await captureThumbnail()).equals(initialPixels)).toBe(true);
+        expect(await userRow.locator('[aria-busy="true"]').count()).toBe(0);
 
         await gateway.resolveDeferred("chat.startup");
 

--- a/ui/src/pages/chat/components/chat-message-images.ts
+++ b/ui/src/pages/chat/components/chat-message-images.ts
@@ -370,6 +370,7 @@ function openMessageImage(
 class MessageImagesDirective extends Directive {
   private slots: { image: ImageBlock; key: symbol }[] = [];
   private scope = "";
+  private policyKey: string | undefined;
   private canonicalMessageKey: string | undefined;
   private localSubmission = false;
 
@@ -380,7 +381,6 @@ class MessageImagesDirective extends Directive {
       opts?.resourceBasePath,
       opts?.sessionKey,
       opts?.agentId,
-      opts?.policyKey,
     ]);
     // Custody keeps local ownership; imported history must end it even when
     // the outer row reuses the same submission key.
@@ -412,9 +412,19 @@ class MessageImagesDirective extends Directive {
           : slot?.image.factIndex === undefined
             ? slot?.key
             : undefined;
-      return { image, key: (continuing && previous) || Symbol("image-slot") };
+      // Workspace hydration does not replace uploaded pixels. Their resource
+      // still rechecks access; filesystem images discard the old presentation.
+      const preservePresentation =
+        this.policyKey === opts?.policyKey ||
+        isInlineImageSource(image.url) ||
+        isCanonicalInboundMediaSource(image.url);
+      return {
+        image,
+        key: (continuing && preservePresentation && previous) || Symbol("image-slot"),
+      };
     });
     this.scope = scope;
+    this.policyKey = opts?.policyKey;
     this.canonicalMessageKey = opts?.canonicalMessageKey;
     this.localSubmission =
       localSubmission &&

--- a/ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts
@@ -265,6 +265,44 @@ describe("canonical image presentation handoff", () => {
     },
   );
 
+  it.each(["inline", "metadata", "loaded"] as const)(
+    "keeps the displayed %s upload when the session workspace arrives",
+    async (stage) => {
+      const fixture = await createCanonicalImageTranscript(undefined, undefined, "initial receipt");
+      if (stage !== "inline") {
+        fixture.publish();
+      }
+      if (stage === "loaded") {
+        fixture.requests[0]?.resolve(mediaMetadataResponse(true, "before-workspace"));
+        await flushDeferredRowPrune();
+        fixture.displayed[0]?.dispatchEvent(new Event("load"));
+      }
+
+      fixture.props.selectedSession = {
+        key: fixture.props.sessionKey,
+        kind: "direct",
+        permissionMode: "workspace",
+        sessionRoot: "/worktrees/image-upload",
+        spawnedCwd: "/worktrees/image-upload",
+      };
+      fixture.renderPane();
+      expectSameImageNodes(fixture.images(), fixture.displayed);
+      expect(fixture.container.querySelector('[aria-busy="true"]')).toBeNull();
+
+      if (stage === "inline") {
+        fixture.publish();
+        expectSameImageNodes(fixture.images(), fixture.displayed);
+      } else {
+        expect(fixture.requests).toHaveLength(2);
+      }
+      // The retained pixels do not suppress the new policy's access check.
+      fixture.requests.at(-1)?.resolve(mediaMetadataResponse(false));
+      await flushDeferredRowPrune();
+      expect(fixture.images()).toHaveLength(0);
+      expect(fixture.container.textContent).toContain("Attachment removed");
+    },
+  );
+
   it.each([
     {
       name: "different canonical ID with identical text and send key",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users uploading an image into a new chat would see the already-loaded preview replaced by a loading card when the session's worktree details arrived.

## Why This Change Was Made

Workspace and permission metadata was part of the entire image gallery's identity, so hydrating the session recreated its image elements. Preserve mounted inline and inbound uploads across those updates while retaining policy-triggered metadata revalidation. Filesystem previews still reset on policy changes, and explicit access denial or changed credentials/session identity still clears retained images.

The production change adds ten net lines to separate gallery identity from per-image workspace invalidation. Regression coverage extends the existing new-session browser flow and checks inline, pending-metadata, and fully loaded uploads.

## User Impact

Uploaded images stay visible through worktree startup and canonical history loading, without flashing a loading placeholder or losing their layout.

## Evidence

- Reproduced before the fix: all three focused workspace-hydration cases failed, and the new-session browser flow displayed the loading card shown below.
- 59 focused tests passed across the transcript media-handoff and invalidation suites, including access denial, credential rotation, source replacement, and filesystem permission changes.
- Both new-session and ordinary chat image handoff E2E scenarios passed. Assertions preserve the original image node, source/pixels, and absence of a loading card.
- Verified the current renderer in Chrome with a synthetic upload and delayed metadata, including removal after explicit access denial.
- Required `check:changed` gates passed in an isolated checkout with an owned dependency install; all four edited files were verified byte-identical to this patch.
- Independent review found no actionable P0–P2 findings. Inspected synthetic screenshots and recordings.

### Before

![Uploaded image replaced by a loading card after worktree hydration](https://github.com/user-attachments/assets/59ad6717-abdb-4f8b-99e7-7d6c13e1c83f)

### After

![Uploaded image remains visible after worktree hydration](https://github.com/user-attachments/assets/0661a5c8-ab02-40c5-b682-4fc2907f0d01)
