### PR TITLE
perf(agents): reduce allocations during compaction planning

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -403,25 +403,6 @@ function isTurnStartEntry(entry: SessionTreeEntry): boolean {
   return message ? isTurnStartMessage(message) : false;
 }
 
-function findValidCutPoints(
-  entries: SessionTreeEntry[],
-  startIndex: number,
-  endIndex: number,
-): number[] {
-  const cutPoints: number[] = [];
-  for (let i = startIndex; i < endIndex; i++) {
-    const entry = entries[i];
-    if (!entry) {
-      continue;
-    }
-    const message = getMessageFromEntryForCompaction(entry);
-    if (message && isCutPointMessage(message)) {
-      cutPoints.push(i);
-    }
-  }
-  return cutPoints;
-}
-
 /** Find the user-visible message that starts the turn containing an entry. */
 export function findTurnStartIndex(
   entries: SessionTreeEntry[],
@@ -457,18 +438,23 @@ export function findCutPoint(
   endIndex: number,
   keepRecentTokens: number,
 ): CutPointResult {
-  const cutPoints = findValidCutPoints(entries, startIndex, endIndex);
-
-  if (cutPoints.length === 0) {
+  // Projection validates persisted custom/branch timestamps even outside the
+  // retained tail. Keep that eager validation without storing every cut point.
+  let cutIndex: number | undefined;
+  for (let i = startIndex; i < endIndex; i++) {
+    const entry = entries[i];
+    const message = entry ? getMessageFromEntryForCompaction(entry) : undefined;
+    if (message && isCutPointMessage(message)) {
+      cutIndex = i;
+    }
+  }
+  if (cutIndex === undefined) {
     return { firstKeptEntryIndex: startIndex, turnStartIndex: -1, isSplitTurn: false };
   }
   let accumulatedTokens = 0;
-  const firstCutIndex = cutPoints.at(0);
-  if (firstCutIndex === undefined) {
-    return { firstKeptEntryIndex: startIndex, turnStartIndex: -1, isSplitTurn: false };
-  }
-  let cutIndex = firstCutIndex;
 
+  // The latest valid cut also handles an oversized trailing tool result that
+  // exhausts the budget before the reverse walk reaches its preceding boundary.
   for (let i = endIndex - 1; i >= startIndex; i--) {
     const entry = entries[i];
     if (!entry) {
@@ -478,20 +464,11 @@ export function findCutPoint(
     if (!message) {
       continue;
     }
-    const messageTokens = estimateTokens(message);
-    accumulatedTokens += messageTokens;
+    if (isCutPointMessage(message)) {
+      cutIndex = i;
+    }
+    accumulatedTokens += estimateTokens(message);
     if (accumulatedTokens >= keepRecentTokens) {
-      const lastCutIndex = cutPoints.at(-1);
-      if (lastCutIndex === undefined) {
-        throw new Error("compaction cut-point list became empty during selection");
-      }
-      cutIndex = lastCutIndex;
-      for (const cutPoint of cutPoints) {
-        if (cutPoint >= i) {
-          cutIndex = cutPoint;
-          break;
-        }
-      }
       break;
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Preparing compaction for a long conversation builds a temporary array of every valid cut point and then searches that array to choose the retained history. This allocates avoidable intermediate state during automatic and manual compaction.

## Why This Change Was Made

Keep the existing eager projection pass, recording only the latest eligible index, then carry the selected index through the existing backward token walk. Keeping eager projection preserves malformed timestamp errors outside the retained tail. Initializing from the latest boundary also preserves the oversized trailing-tool-result behavior. A tail-only shortcut was rejected because it skipped that validation.

The canonical `findCutPoint` owner still controls selection; projection, token accounting, metadata rewind, split-turn handling, summary requests, and persistence callers retain their contracts. Production +17/-40 (net -23); no tests, dependencies, configuration, prompts, or schema changes.

## User Impact

Compaction preparation uses less temporary allocation while selecting the same history and producing the same summary requests. The full initial scan remains; this does not claim an O(recent-tail) algorithm, fewer indexed reads, retained-memory savings, or whole-Gateway performance improvement.

## Evidence

The final candidate matches all **50,361 complete baseline selector/preparation results**, including original-message reference positions and Set order. Both output files have SHA-256 `574d72ad7d296cd4850fb52754a5dac179cfa9b2c4e6e6d4b84201015f4f19cc`. Another 12 complete request/output cases match, and malformed custom timestamps still produce the same error through both direct selection and full preparation. Coverage includes sparse entries, budget boundaries, metadata, resets, excluded private history, split turns, and oversized trailing tool results.

Six alternating warmed baseline/candidate timing pairs and separate cumulative allocation sampling on Node 26.8.1/macOS arm64 measured:

| Workload | Before median ms | After median ms | Sampled allocation before → after | Calls sampled |
| --- | ---: | ---: | ---: | ---: |
| 20,000 entries, tiny retained tail | 0.9842 | 0.9175 | 102,243,080 → 48,787,760 B | 100 |
| 20,000 entries, all fitting | 3.1825 | 3.1992 | 145,063,272 → 128,129,144 B | 30 |
| 32-entry control | 0.002561 | 0.002158 | 16,535,264 → 11,307,384 B | 10,000 |
| Full preparation, 20,000 entries | 8.5111 | 8.2992 | 103,141,032 → 98,229,656 B | 8 |

Sampling includes collected objects and measures cumulative allocation, not retained heap. An earlier fresh-process measurement of this same final source was 21–58% slower under substantially different shared-host load. The alternating comparison addresses that concrete concern, but these small mixed timing effects do not establish a general speedup. Indexed reads remain 20,005 in both arms. Evidence from an earlier superseded tail-only prototype is excluded.

`node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction.test.ts packages/agent-core/src/harness/compaction/compaction-trailing-toolresult.test.ts packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts src/agents/sessions/agent-session-compaction.test.ts` — 90 tests pass. Exact-file type-aware lint, formatting, `git diff --check`, and changed-plan classification pass. Independent managed review is scoped-clean through P2. A duplicate local full-core run is not claimed; exact-head hosted CI and native preparation remain mandatory.

The actual local owners were exercised with synthetic history and completion responses. Native Codex compaction has separate ownership, checked directly in its source; no authenticated-provider or native-runtime performance claim is made. Existing behavioral tests cover the contract, so no implementation-shaped allocation-count test was added.
