### PR TITLE
perf(replies): bound pending tool-delivery observers

### DIFF
--- a/src/auto-reply/reply/pending-tool-task-drain.ts
+++ b/src/auto-reply/reply/pending-tool-task-drain.ts
@@ -10,23 +10,13 @@ type DrainOptions = {
   onTimeout?: (message: string) => void;
 };
 
-function createIdleTimeoutPromise(timeoutMs: number): {
-  promise: Promise<"timeout">;
-  clear: () => void;
-} {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const promise = new Promise<"timeout">((resolve) => {
-    timeoutId = setTimeout(() => resolve("timeout"), timeoutMs);
-    timeoutId.unref?.();
-  });
-  return {
-    promise,
-    clear: () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    },
-  };
+type PendingTaskObserver = { settled?: (task: Promise<void>) => void };
+
+function observePendingTask(task: Promise<void>, observer: PendingTaskObserver): void {
+  // Stuck tasks retain only this detachable observer, never the active drain's
+  // task set and callbacks after its idle deadline has ended the wait.
+  const settled = () => observer.settled?.(task);
+  void task.then(settled, settled);
 }
 
 /** Waits for pending tool tasks to settle or times out to avoid session deadlock. */
@@ -42,30 +32,42 @@ export async function drainPendingToolTasks({
     return { kind: "timeout", remaining: tasks.size };
   }
 
-  while (tasks.size > 0) {
-    // Snapshot current tasks; newly added tasks are handled in later loop passes.
-    const snapshot = [...tasks];
-    const timeout = createIdleTimeoutPromise(idleTimeoutMs);
-    const outcome = await Promise.race<{ kind: "settled"; task: Promise<void> } | "timeout">([
-      timeout.promise,
-      ...snapshot.map((task) =>
-        task.then(
-          () => ({ kind: "settled" as const, task }),
-          () => ({ kind: "settled" as const, task }),
-        ),
-      ),
-    ]);
-    timeout.clear();
-
-    if (outcome === "timeout") {
-      const remaining = tasks.size;
-      onTimeout?.(
-        `pending tool tasks made no progress within ${idleTimeoutMs}ms; proceeding with ${remaining} task(s) still pending to avoid session deadlock`,
-      );
-      return { kind: "timeout", remaining };
-    }
-
-    tasks.delete(outcome.task);
+  const observed = new WeakSet<Promise<void>>();
+  const observer: PendingTaskObserver = {};
+  const outcome = await new Promise<"settled" | "timeout">((resolve) => {
+    const finish = (result: "settled" | "timeout") => {
+      observer.settled = undefined;
+      clearTimeout(timeout);
+      resolve(result);
+    };
+    const timeout = setTimeout(() => finish("timeout"), idleTimeoutMs);
+    timeout.unref?.();
+    const observeNewTasks = () => {
+      for (const task of tasks) {
+        if (!observed.has(task)) {
+          observed.add(task);
+          observePendingTask(task, observer);
+        }
+      }
+    };
+    observer.settled = (task) => {
+      observed.delete(task);
+      tasks.delete(task);
+      if (tasks.size === 0) {
+        finish("settled");
+      } else {
+        timeout.refresh();
+        observeNewTasks();
+      }
+    };
+    observeNewTasks();
+  });
+  if (outcome === "timeout") {
+    const remaining = tasks.size;
+    onTimeout?.(
+      `pending tool tasks made no progress within ${idleTimeoutMs}ms; proceeding with ${remaining} task(s) still pending to avoid session deadlock`,
+    );
+    return { kind: "timeout", remaining };
   }
 
   return { kind: "settled" };


### PR DESCRIPTION
## What Problem This Solves

Resolves avoidable allocation while final reply accounting waits for many tool-result deliveries that complete one at a time. A delayed channel delivery can queue later results behind it, making this workload reachable through ordinary serialized tool-result delivery.

## Why This Change Was Made

`src/auto-reply/reply/pending-tool-task-drain.ts` now observes each admitted task once and refreshes one idle timer, replacing repeated snapshots, settlement records, timeout promises, and `Promise.race` calls. A detachable observer clears the drain's Set and callback references at completion or timeout, preserving the caller's ownership after the barrier closes.

The producer is `src/auto-reply/reply/agent-runner-embedded-candidate.ts`; final accounting, fallback settlement, and follow-up execution share this drain owner. Existing work-scope and queue helpers were rejected because they do not provide an idle-progress barrier over an externally growing Set without changing caller contracts. Production: +43/-41 lines (net +2); tests/support: +0/-0. The small growth provides explicit observer lifetime management.

## User Impact

Tool deliveries create fewer temporary objects while preserving the 30-second idle deadline, rejection as progress, late additions, re-admission, warning text/count, unreferenced timer, and throwing warning callbacks. Subscription and timer allocation are bounded; discovering new work still scans the Set and can remain quadratic overall.

## Evidence

Paired local Node 26.8.1/macOS arm64 runs execute the actual serialized `onToolResult` closure with synthetic channel, typing, and presentation dependencies. All four delivery result digests match; this exercises the producer sequence without a running Gateway or live channel.

| 256 staggered deliveries | Before | After |
| --- | ---: | ---: |
| Input-task subscriptions | 32,896 | 256 |
| Native Timeout resources | 256 | 1 |
| Cumulative sampled allocation, bytes | 18,423,440 | 2,421,840 |
| Owner self-site sampled bytes | 7,277,648 | 16,408 |
| Workload time | 16.10 ms | 6.52 ms |

Subscription and timer counters run separately from allocation sampling. The 16 KiB sampler includes collected objects; owner self-site totals exclude native/unattributed descendants. These are cumulative sampled allocations, not retained heap. One pair under shared host load does not establish general latency or whole-Gateway savings; final heap endpoints deliberately retain fixture arrays.

Nine matching behavior controls cover empty/zero deadlines, progress/rejection/late arrival, idle reset, late completion after timeout, throwing warnings, simultaneous completion, re-admission, and warning async context. Deadline controls use an artifact-only deterministic scheduler; native timers cover async context and collection. With eight unresolved tasks retained, both versions release all eight retired Sets and callbacks after requested GCs, preserving that observed teardown property without claiming general leak absence.

The running Node timer implementation was inspected directly: refresh preserves an unreferenced handle. Bun also exposes [Timer.refresh and unref](https://bun.com/reference/globals/Timer); Bun was unavailable locally, so no Bun execution is claimed.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/pending-tool-task-drain.test.ts src/auto-reply/reply/followup-turn-execution.test.ts src/auto-reply/reply/followup-runner.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/reply/pending-tool-task-drain.ts
```

Frozen-candidate validation passed 53 tests across three suites, exact-file type-aware lint, formatting, and `git diff --check`. Changed-plan classification selected `core, coreTests`; its broad aggregate checks were not executed in this lane. Independent frozen-patch review recorded no actionable P0–P2 findings. Required exact-head hosted CI and native landing gates remain mandatory; integrated Gateway performance remains unmeasured. No product test was added solely to count implementation operations.
