### PR TITLE
refactor(process): remove unused spawn fallback controls

### DIFF
--- a/src/process/spawn-utils.test.ts
+++ b/src/process/spawn-utils.test.ts
@@ -1,68 +1,24 @@
-// Spawn utility tests cover child process setup and stream handling helpers.
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import path from "node:path";
-import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import { spawnWithFallback } from "./spawn-utils.js";
 
+type SpawnImplementation = NonNullable<Parameters<typeof spawnWithFallback>[0]["spawnImpl"]>;
+
 function createStubChild() {
   const child = new EventEmitter() as ChildProcess;
-  child.stdin = new PassThrough() as ChildProcess["stdin"];
-  child.stdout = new PassThrough() as ChildProcess["stdout"];
-  child.stderr = new PassThrough() as ChildProcess["stderr"];
-  Object.defineProperty(child, "pid", { value: 1234, configurable: true });
-  Object.defineProperty(child, "killed", { value: false, configurable: true, writable: true });
-  child.kill = vi.fn(() => true) as ChildProcess["kill"];
   queueMicrotask(() => {
     child.emit("spawn");
   });
   return child;
 }
 
-function spawnOptionsAt(
-  spawnMock: { mock: { calls: readonly unknown[][] } },
-  callIndex: number,
-): { stdio?: unknown } {
-  const call = spawnMock.mock.calls[callIndex];
-  if (!call) {
-    throw new Error(`expected spawn call ${callIndex}`);
-  }
-  const options = call[2];
-  if (typeof options !== "object" || options === null || Array.isArray(options)) {
-    throw new Error(`expected spawn call ${callIndex} options`);
-  }
-  return options;
-}
-
 describe("spawnWithFallback", () => {
-  it("does not retry a failed spawn after its caller authority expires", async () => {
-    const child = new EventEmitter() as ChildProcess;
-    const spawnMock = vi.fn(() => child);
-    let current = true;
-    const pending = spawnWithFallback({
-      argv: ["agent-cli"],
-      options: {},
-      fallbacks: [{ label: "no-detach", options: { detached: false } }],
-      spawnImpl: spawnMock,
-      assertCurrent: () => {
-        if (!current) {
-          throw new Error("Completion authority expired");
-        }
-      },
-    });
-    const rejected = expect(pending).rejects.toThrow("Completion authority expired");
-    current = false;
-    child.emit("error", Object.assign(new Error("spawn EBADF"), { code: "EBADF" }));
-
-    await rejected;
-    expect(spawnMock).toHaveBeenCalledOnce();
-  });
-
   it("retries on EBADF using fallback options", async () => {
     const spawnMock = vi
-      .fn()
+      .fn<SpawnImplementation>()
       .mockImplementationOnce(() => {
         const err = new Error("spawn EBADF");
         (err as NodeJS.ErrnoException).code = "EBADF";
@@ -73,15 +29,14 @@ describe("spawnWithFallback", () => {
     const result = await spawnWithFallback({
       argv: ["echo", "ok"],
       options: { stdio: ["pipe", "pipe", "pipe"] },
-      fallbacks: [{ label: "safe-stdin", options: { stdio: ["ignore", "pipe", "pipe"] } }],
+      fallbacks: [{ stdio: ["ignore", "pipe", "pipe"] }],
       spawnImpl: spawnMock,
     });
 
     expect(result.usedFallback).toBe(true);
-    expect(result.fallbackLabel).toBe("safe-stdin");
     expect(spawnMock).toHaveBeenCalledTimes(2);
-    expect(spawnOptionsAt(spawnMock, 0).stdio).toEqual(["pipe", "pipe", "pipe"]);
-    expect(spawnOptionsAt(spawnMock, 1).stdio).toEqual(["ignore", "pipe", "pipe"]);
+    expect(spawnMock.mock.calls[0]?.[2].stdio).toEqual(["pipe", "pipe", "pipe"]);
+    expect(spawnMock.mock.calls[1]?.[2].stdio).toEqual(["ignore", "pipe", "pipe"]);
   });
 
   it("does not retry on non-EBADF errors", async () => {
@@ -95,7 +50,7 @@ describe("spawnWithFallback", () => {
       spawnWithFallback({
         argv: ["missing"],
         options: { stdio: ["pipe", "pipe", "pipe"] },
-        fallbacks: [{ label: "safe-stdin", options: { stdio: ["ignore", "pipe", "pipe"] } }],
+        fallbacks: [{ stdio: ["ignore", "pipe", "pipe"] }],
         spawnImpl: spawnMock,
       }),
     ).rejects.toThrow(/ENOENT/);
@@ -106,21 +61,15 @@ describe("spawnWithFallback", () => {
     let current = true;
     const retired = Object.assign(new Error("request authority retired"), { code: "EBADF" });
     const firstChild = createStubChild();
-    Object.defineProperty(firstChild, "pid", { value: undefined });
     const spawnMock = vi
       .fn()
       .mockReturnValueOnce(firstChild)
       .mockImplementation(() => createStubChild());
-    const onFallback = vi.fn();
     const run = spawnWithFallback({
       argv: ["agent-cli"],
       options: {},
-      fallbacks: [
-        { label: "no-detach", options: { detached: false } },
-        { label: "ignore-stdin", options: { stdio: "ignore" } },
-      ],
+      fallbacks: [{ detached: false }, { stdio: "ignore" }],
       spawnImpl: spawnMock,
-      onFallback,
       assertCurrent: () => {
         if (!current) {
           throw retired;
@@ -133,7 +82,6 @@ describe("spawnWithFallback", () => {
 
     expect(await outcome).toEqual([{ status: "rejected", reason: retired }]);
     expect(spawnMock).toHaveBeenCalledOnce();
-    expect(onFallback).toHaveBeenCalledOnce();
   });
 
   it("rejects ENOENT from a real missing executable", async () => {

--- a/src/process/spawn-utils.ts
+++ b/src/process/spawn-utils.ts
@@ -1,32 +1,21 @@
-// Spawn utilities configure child processes and normalize spawned process handles.
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 import { expectDefined } from "@openclaw/normalization-core";
 import { toErrorObject } from "../infra/errors.js";
 
-type SpawnFallback = {
-  label: string;
-  options: SpawnOptions;
-};
-
 type SpawnWithFallbackResult = {
   child: ChildProcess;
   usedFallback: boolean;
-  fallbackLabel?: string;
 };
 
 type SpawnWithFallbackParams = {
   assertCurrent?: () => void;
   argv: string[];
   options: SpawnOptions;
-  fallbacks?: SpawnFallback[];
+  fallbacks?: SpawnOptions[];
   spawnImpl?: (command: string, args: string[], options: SpawnOptions) => ChildProcess;
-  retryCodes?: string[];
-  onFallback?: (err: unknown, fallback: SpawnFallback) => void;
 };
-
-const DEFAULT_RETRY_CODES = ["EBADF"];
 
 export function resolveCommandStdio(params: {
   hasInput: boolean;
@@ -36,10 +25,10 @@ export function resolveCommandStdio(params: {
   return [stdin, "pipe", "pipe"];
 }
 
-function shouldRetry(err: unknown, codes: string[]): boolean {
+function shouldRetry(err: unknown): boolean {
   const code =
     err && typeof err === "object" && "code" in err ? String((err as { code?: unknown }).code) : "";
-  return code.length > 0 && codes.includes(code);
+  return code === "EBADF";
 }
 
 async function spawnAndWaitForSpawn(
@@ -61,35 +50,26 @@ export async function spawnWithFallback(
   params: SpawnWithFallbackParams,
 ): Promise<SpawnWithFallbackResult> {
   const spawnImpl = params.spawnImpl ?? spawn;
-  const retryCodes = params.retryCodes ?? DEFAULT_RETRY_CODES;
   const baseOptions = { ...params.options };
   const fallbacks = params.fallbacks ?? [];
-  const attempts: Array<{ label?: string; options: SpawnOptions }> = [
-    { options: baseOptions },
-    ...fallbacks.map((fallback) => ({
-      label: fallback.label,
-      options: { ...baseOptions, ...fallback.options },
-    })),
-  ];
+  const attempts = [baseOptions, ...fallbacks.map((options) => ({ ...baseOptions, ...options }))];
 
   let lastError: unknown;
   for (const [index, attempt] of attempts.entries()) {
     // Caller revocation is not a spawn failure and cannot select a fallback.
     params.assertCurrent?.();
     try {
-      const child = await spawnAndWaitForSpawn(spawnImpl, params.argv, attempt.options);
+      const child = await spawnAndWaitForSpawn(spawnImpl, params.argv, attempt);
       return {
         child,
         usedFallback: index > 0,
-        fallbackLabel: attempt.label,
       };
     } catch (err) {
       lastError = err;
       const nextFallback = fallbacks[index];
-      if (!nextFallback || !shouldRetry(err, retryCodes)) {
+      if (!nextFallback || !shouldRetry(err)) {
         throw err;
       }
-      params.onFallback?.(err, nextFallback);
     }
   }
 

--- a/src/process/supervisor/adapters/child.test-support.ts
+++ b/src/process/supervisor/adapters/child.test-support.ts
@@ -59,7 +59,7 @@ type SpawnWithFallbackParams = {
     windowsHide?: boolean;
     windowsVerbatimArguments?: boolean;
   };
-  fallbacks?: Array<{ options?: { detached?: boolean } }>;
+  fallbacks?: Array<{ detached?: boolean }>;
 };
 
 export function firstSpawnWithFallbackParams(mock: Mock): SpawnWithFallbackParams {

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -151,7 +151,7 @@ describe("createChildAdapter", () => {
       expect(spawnArgs.fallbacks).toStrictEqual([]);
     } else {
       expect(spawnArgs.options?.detached).toBe(true);
-      expect(spawnArgs.fallbacks?.[0]?.options?.detached).toBe(false);
+      expect(spawnArgs.fallbacks?.[0]?.detached).toBe(false);
     }
 
     adapter.kill();
@@ -469,7 +469,6 @@ describe("createChildAdapter", () => {
     spawnWithFallbackMock.mockResolvedValue({
       child,
       usedFallback: true,
-      fallbackLabel: "no-detach",
     });
     const adapter = await createChildAdapter({
       argv: ["node", "-e", "setTimeout(() => {}, 1000)"],
@@ -526,7 +525,6 @@ describe("createChildAdapter", () => {
     spawnWithFallbackMock.mockResolvedValue({
       child,
       usedFallback: true,
-      fallbackLabel: "no-detach",
     });
     const adapter = await createChildAdapter({
       argv: ["node", "-e", "setTimeout(() => {}, 1000)"],

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -185,15 +185,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     assertCurrent,
     argv: [preparedSpawn.command, ...preparedSpawn.args],
     options,
-    fallbacks:
-      useDetached && params.ownedWorker === undefined
-        ? [
-            {
-              label: "no-detach",
-              options: { detached: false },
-            },
-          ]
-        : [],
+    fallbacks: useDetached && params.ownedWorker === undefined ? [{ detached: false }] : [],
   });
 
   const child = spawned.child as ChildProcessWithoutNullStreams;


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Maintainer-requested cleanup companion to stage 3 of the #135868 split (decision brief concern C: process/agent authority and cleanup certification). The spawn fallback helper carries unused policy overrides, callbacks, and labels, while its tests still build process fixtures for a readiness implementation already removed on main.

## Why This Change Was Made

Remove the private `retryCodes`, `onFallback`, and `fallbackLabel` surfaces and pass fallback spawn options directly. All three production calls were inspected: the child adapter uses only the child and `usedFallback`, and both Scheduled Task calls use only the child. None supplies a retry override or callback. There is no plugin SDK export of this helper.

Keep `usedFallback` because it prevents process-group signaling after a non-detached retry. Preserve the authority assertion outside retry handling, Node spawn readiness, error normalization, and fallback order. Remove the duplicate weaker revocation test and obsolete stream/PID/kill fixture setup; retain the EBADF-coded authority regression and real ENOENT coverage. No automatic-recovery or cleanup-certification changes are imported from #135868.

## User Impact

No intended user-visible behavior change. The private process helper and its tests have less unused surface for subsequent ownership changes to maintain.

## Evidence

Production: +7/-35, net -28 lines. Tests/support: +10/-64, net -54. Tooling/docs: unchanged.

- `node scripts/run-vitest.mjs src/process src/daemon/schtasks.startup-fallback.test.ts`: 639 passed, 62 existing platform-specific skips across three shards. Native Windows integration is not claimed from this macOS run.
- `pnpm check:import-cycles`: passed, zero runtime cycles.
- Production, full-tree, and script dead-export scans: all passed with zero entries.
- Full `node scripts/check-changed.mjs`: passed (exit 0), including all selected types, lint, dead-export scans, and repository guards.
- Independent Codex branch autoreview: scoped-clean, no actionable P0–P2 findings.

The branch was rebased onto current main after local validation; none of the five owned files changed in that main drift. The patch remained identical. Exact-head hosted CI passed on `b879c0e76f7c2ec23bc4b7cd863336fc299c1076`: [run 33988858000](https://github.com/openclaw/openclaw/actions/runs/33988858000). The native review/prepare/merge flow landed this as [befc0c24a243](https://github.com/openclaw/openclaw/commit/befc0c24a243f58da0d92a0c0bc4a6bba21c8ec3); remote merge state, main ancestry, and all five landed file contents were independently verified.

[ClawSweeper review](https://github.com/openclaw/openclaw/pull/139326#issuecomment-5554353515) found no correctness or security findings and no pre-merge actions. No rank-up changes were requested. The review independently confirmed the three production callers and the retained authority and detachment coverage.
