### PR TITLE
perf(sessions): avoid discarded waits in queued store writes

### DIFF
--- a/src/shared/store-writer-queue.ts
+++ b/src/shared/store-writer-queue.ts
@@ -76,11 +76,7 @@ function getOrCreateStoreWriterQueue(
 
 async function drainStoreWriterQueue(queues: StoreWriterQueues, storePath: string): Promise<void> {
   const queue = queues.get(storePath);
-  if (!queue) {
-    return;
-  }
-  if (queue.drainPromise) {
-    await queue.drainPromise;
+  if (!queue || queue.drainPromise) {
     return;
   }
   const drain = createDeferredCore();


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary Promise work during bursts of queued session and store writes. When many writes share one key, earlier callers can already have their results while discarded internal waiters still follow the final write's drain lifetime.

## Why This Change Was Made

`src/shared/store-writer-queue.ts` now returns immediately when its private pump finds an already-owned queue. The enqueue caller discards that pump's return value; each public operation already settles through its own task promise. Real teardown callers independently join the existing `drainPromise`, so removing the redundant private wait preserves the canonical FIFO and join boundary.

Session storage, SQLite scope access, and session lifecycle admission call this generic owner. Session-state cleanup drains it before database closure and again after reconciliation. Synchronous ownership publication, reentrancy, captured caller async context, per-operation errors/results, and retirement stay with the existing queue. Replacing it with a work-scope or bounded-queue abstraction was rejected because those helpers own different contracts and add scope without removing more policy.

Production: +1/-5 lines (net -4); tests/support: +0/-0. The existing owner absorbs the optimization without a new abstraction.

## User Impact

Bursty writes allocate fewer Promise resources while preserving operation ordering, independent-key progress, early per-operation completion, teardown joins, and reuse. This changes no storage schema or persistence semantics. The measurements support reduced Promise work; they do not establish lower byte memory, RSS, or operator latency.

## Evidence

Fresh Node 26.8.1/macOS arm64 processes import the actual queue owner. The synthetic burst holds the first and last writes separately. Numeric `async_hooks` IDs count created PROMISE resources and IDs without an observed `promiseResolve`; the instrumentation neither replaces Promise nor retains resource objects.

| Burst writes | Enqueue resources before → after | Tail-held unresolved IDs before → after | Full lifecycle resources before → after |
| --- | ---: | ---: | ---: |
| 1,024 | 5,127 → 4,104 | 2,062 → 16 | 13,577 → 12,554 |
| 4,096 | 20,487 → 16,392 | 8,206 → 16 | 54,233 → 50,138 |

That removes exactly one resource per queued write after the first, approximately 20% of enqueue resources in these bursts. “Unresolved” describes hook events, not proven object retention or allocated bytes. Both arms finish with an empty queue map and one instrumented ID for the proof continuation; no timing improvement is claimed.

Complete behavior digests match for both burst sizes. Assertions cover FIFO, one active same-key writer, exact result/error identity, caller context across awaits, explicit reentrancy, ordinary nesting, independent-key progress, early caller settlement, undefined throws, teardown rejection/join, and fresh reuse. The test-only clear helper's existing behavior is also preserved: clearing rejects queued callers, but the already-owned queue can still execute pending work after release.

```sh
env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/shared/store-writer-queue.test.ts src/config/sessions/store-writer.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/shared/store-writer-queue.ts
```

Frozen-candidate validation passed seven tests across two suites, exact-file type-aware lint, formatting, and `git diff --check`. Changed-plan classification passed and selected `core, coreTests`; the complete broad local gate was not run. Independent frozen-patch review recorded no actionable P0–P2 findings. Required exact-head hosted CI and native landing gates remain mandatory. This lane provides local owner proof, not a live Gateway/provider run, full build, or integrated campaign result.
