### PR TITLE
perf(media): reuse validated inline image encoding

### DIFF
--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -318,9 +318,10 @@ export async function extractImageContentFromSource(
 ): Promise<InputImageContent> {
   let buffer: Buffer;
   let mimeType: string | undefined;
+  let canonicalData: string | undefined;
   if (source.type === "base64") {
     rejectOversizedBase64Payload({ data: source.data, maxBytes: limits.maxBytes, label: "Image" });
-    const canonicalData = canonicalizeBase64(source.data);
+    canonicalData = canonicalizeBase64(source.data);
     if (!canonicalData) {
       throw new Error("input_image base64 source has invalid 'data' field");
     }
@@ -347,7 +348,10 @@ export async function extractImageContentFromSource(
     throw new Error(`Unsupported input_image source type: ${(source as { type: string }).type}`);
   }
   const image = await normalizeInputImageBuffer({ buffer, mimeType, limits });
-  return { type: "image", data: image.buffer.toString("base64"), mimeType: image.mimeType };
+  // Conversions replace the buffer; unchanged bytes already have validated base64.
+  const data =
+    image.buffer === buffer && canonicalData ? canonicalData : image.buffer.toString("base64");
+  return { type: "image", data, mimeType: image.mimeType };
 }
 
 /** Extracts model-visible text and images from an input_file source after MIME validation. */


### PR DESCRIPTION
## What Problem This Solves

Resolves redundant encoding when the OpenAI-compatible and OpenResponses HTTP APIs accept inline images that already use a supported format. Large images require an unnecessary second full base64 string even though normalization leaves their bytes unchanged.

## Why This Change Was Made

`extractImageContentFromSource` in `src/media/input-files.ts` carries its validated canonical base64 to the return boundary and reuses it only when `normalizeInputImageBuffer` returns the original Buffer. URL inputs and HEIC/HEIF conversions continue to encode their normalized output; all decoding, byte limits, MIME validation, and conversion checks still run.

The HTTP callers retain decoded-byte accounting and receive the same image content shape. The Anthropic inline-image sibling already preserves canonical base64 for unchanged bytes; the bytes-first image-description caller retains its normalization path. A net-neutral rewrite was rejected because it would duplicate normalization or obscure the identity decision.

Production: +6/-2 lines (net +4); tests/support: +0/-0. The added local carries an existing validated representation, with one comment documenting why Buffer identity controls reuse.

## User Impact

Supported inline images avoid one full output encode while preserving exact model-visible image data and MIME metadata. Canonicalization still handles accepted whitespace and omitted padding and rejects invalid alphabet/pad bits; size and MIME limits remain enforced. This is a behavior-preserving optimization, with no new configuration or API surface.

## Evidence

Paired Node 26.8.1/macOS arm64 runs import the actual owner with real MIME detection. All 22 observations match, including complete PNG/JPEG/WebP/GIF results, encoding variants, MIME precedence, and rejection messages. A deterministic 1536×1024 PNG contains 6,294,463 bytes and produces identical 8,392,620-character base64 in both versions. A separate instrumentation pass counts one full output encode before and zero after; removing that operation is the firm performance result.

Each process warms the owner, requests GC, retains ten large-image results, and requests GC again:

| Synthetic retained batch | Before | After |
| --- | ---: | ---: |
| Median time per call | 158.54 ms | 65.41 ms |
| External-memory delta, bytes | +77,624,017 | +18,778,791 |
| RSS delta, bytes | +82,214,912 | +31,670,272 |
| ArrayBuffer delta, bytes | 0 | 0 |

The input string and all results remain held. Separate processes, shared host load, and GC/external-memory accounting limit interpretation: these are synthetic retained-batch observations, not cumulative allocation, persistent idle heap, statistically established latency, or whole-Gateway RSS proof. No threshold assertion relies on these samples.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/media/input-files.fetch-guard.test.ts src/media/input-files.extract.test.ts packages/media-core/src/base64.test.ts
node scripts/check-changed.mjs -- src/media/input-files.ts
```

All 75 tests across three files pass before and after. The frozen candidate also passes the full selected changed-file gate, including core/core-test typechecks, targeted type-aware lint, formatting, required guards, and dead-export scans; `git diff --check` passes. Independent frozen-patch review recorded a scoped-clean result.

Existing tests cover URL cleanup/limits and HEIC/HEIF conversion using mocked dependencies; they do not prove live network requests or native HEIC conversion. No running-Gateway HTTP, live-provider, full-build, or integrated campaign result is claimed. Required exact-head hosted CI and native landing gates remain mandatory. No test-only production seam or operation-count regression test was added.
