### PR TITLE
fix(release): pin ClawHub workflow with recovery receipt lookup

### DIFF
--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -672,7 +672,7 @@ jobs:
         approve_plugins_clawhub_release,
       ]
     if: always() && github.event_name == 'workflow_dispatch' && needs.preview_plugins_clawhub.outputs.has_candidates == 'true' && needs.pack_plugins_clawhub_artifacts.result == 'success' && (inputs.dry_run == true || needs.approve_plugins_clawhub_release.result == 'success')
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@d118f17fd366e5cdc3ad9c8abcea51941b97636f # reviewed parent receipt contract
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@d5a3688fb21a283460f362e57028601801961c85 # reviewed parent receipt contract
     permissions:
       actions: read
       contents: read

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -11294,7 +11294,7 @@ promote_windows_release_assets
       "approve_plugins_clawhub_release",
     ]);
     expect(clawHubPublish.uses).toBe(
-      "openclaw/clawhub/.github/workflows/package-publish.yml@d118f17fd366e5cdc3ad9c8abcea51941b97636f",
+      "openclaw/clawhub/.github/workflows/package-publish.yml@d5a3688fb21a283460f362e57028601801961c85",
     );
     expect(clawHubPublish.permissions).toMatchObject({
       actions: "read",


### PR DESCRIPTION
## What Problem This Solves

Human ClawHub recovery stops before publication because the pinned reusable workflow looks for a parent authorization artifact named after the recovery run itself. The parent authorized the original child, so that artifact does not exist. This occurred in [recovery run 33986428916](https://github.com/openclaw/openclaw/actions/runs/33986428916).

## Why This Change Was Made

Advance the reusable workflow pin to [the upstream recovery fix](https://github.com/openclaw/clawhub/commit/d5a3688fb21a283460f362e57028601801961c85), and update the existing exact-pin assertion. This is the first workflow revision after the previous pin that resolves the protected recovery approval before choosing the parent receipt.

Automated runs retain their current child identity. Human recovery uses the approval's original authorized child run and attempt. The verifier still requires the exact parent, workflow refs and SHAs, candidate, tooling, package version and inventory; the live actor determines the authorization route. The reusable workflow's own immutable source SHA selects its client verifier.

## User Impact

Future approved recovery runs can locate the existing parent receipt. This change updates only a workflow SHA and its test assertion. It does not deploy ClawHub, publish packages, or change release sources, tags or authorization policy.

## Evidence

- 58 existing upstream client-verifier tests and 44 upstream workflow/server-authorization tests pass.
- Executing the pinned workflow's inline artifact resolver with synthetic fixtures preserves the current child for automation and selects the original approved child for human recovery. The previous pin names the current child in both cases.
- OpenClaw's 16 parent-authorization tests and its exact workflow-pin guard pass.
- The pin range leaves CLI and schema source unchanged. Its only dependency delta is the upstream test tool `skills@1.5.20`.
- Full local changed-file checks passed. Independent review is scoped-clean through P2; full recovery publication is not claimed by these fixtures.
