### PR TITLE
fix(config): restore missing writer labels in config history

### DIFF
--- a/docs/cli/openclaw.md
+++ b/docs/cli/openclaw.md
@@ -184,6 +184,11 @@ Discovery and read-only operations are not included. Secrets never appear in
 change history; config journal records contain changed paths rather than config
 values, and value comparison uses protected fingerprints.
 
+Config-write records retain the writer's origin label when supplied. Automatic
+startup config repairs record `origin: "doctor"` even when console output and
+runtime snapshot refresh are suppressed. Existing unlabeled records are not
+backfilled.
+
 Channel, web-search, and local Gateway setup can run as hosted conversations
 until they reach a secret. The local OpenClaw TUI does not accept sensitive wizard answers
 because terminal chat input is visible. It offers `open channel wizard`

--- a/src/config/io.runtime.ts
+++ b/src/config/io.runtime.ts
@@ -329,31 +329,19 @@ export async function writeConfigFile(
   let runtimePreflightResult: unknown;
   let managedPreparedCandidates = new Map<symbol, RuntimeConfigWritePreparedCandidate>();
   const writeResult = await io.writeConfigFile(nextCfg, {
+    // Preserve caller policy and provenance; runtime-owned fields take precedence below.
+    ...options,
     baseSnapshot,
     basePluginMetadataSnapshot: baseSnapshotRead.pluginMetadataSnapshot,
-    assertConfigPathForWrite: options.assertConfigPathForWrite,
     envSnapshotForRestore: resolveWriteEnvSnapshotForPath({
       actualConfigPath: io.configPath,
       expectedConfigPath: options.expectedConfigPath,
       envSnapshotForRestore: options.envSnapshotForRestore,
     }),
     unsetPaths: resolveManagedUnsetPathsForWrite(options.unsetPaths),
-    explicitSetPaths: options.explicitSetPaths,
     explicitSetValueSource: options.explicitSetPaths
       ? (options.explicitSetValueSource ?? cfg)
       : undefined,
-    persistCanonicalAgentRoster: options.persistCanonicalAgentRoster,
-    allowedAgentRosterRemovals: options.allowedAgentRosterRemovals,
-    allowIncludeAncestorExplicitSetPaths: options.allowIncludeAncestorExplicitSetPaths,
-    afterWrite: options.afterWrite,
-    allowDestructiveWrite: options.allowDestructiveWrite,
-    allowConfigSizeDrop: options.allowConfigSizeDrop,
-    skipRuntimeSnapshotRefresh: options.skipRuntimeSnapshotRefresh,
-    skipOutputLogs: options.skipOutputLogs,
-    skipPluginValidation: options.skipPluginValidation,
-    preservedLegacyRootKeys: options.preservedLegacyRootKeys,
-    lastTouchedVersionOverride: options.lastTouchedVersionOverride,
-    beforeCommit: options.beforeCommit,
     preCommitRuntimePreflight: async (sourceConfig) => {
       // A failed canonical reread must retain the actual resolved write payload,
       // including writer metadata, rather than the caller's runtime-shaped input.

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -3398,72 +3398,99 @@ gateway: { mode: "local", port: 18789 }
     await expect(fs.readFile(configPath, "utf-8")).resolves.not.toContain("operator note");
   });
 
-  itWithHome(
-    "records capped changed paths, origin, and the latest redacted source snapshot",
-    async (home) => {
-      const configPath = configPathForHome(home);
-      const originalVars = Object.fromEntries(
-        Array.from({ length: 70 }, (_, index) => [
-          `SETTING_${index.toString().padStart(2, "0")}`,
-          "before",
-        ]),
-      );
-      const nextVars = Object.fromEntries(Object.keys(originalVars).map((key) => [key, "after"]));
-      await fs.mkdir(path.dirname(configPath), { recursive: true });
-      await fs.writeFile(
-        configPath,
-        formatConfig({ env: { vars: originalVars }, gateway: { port: 18789 } }),
-      );
-      const io = createFastConfigIO(home);
-      const snapshot = await io.readConfigFileSnapshot();
-      const nextConfig = structuredClone(snapshot.config);
-      nextConfig.env = { ...nextConfig.env, vars: nextVars };
+  for (const auditOrigin of ["doctor", "config-rpc", undefined] as const) {
+    itWithHome(
+      `records runtime write audit origin ${auditOrigin ?? "omitted"} with changed paths and snapshot hashes`,
+      async (home) => {
+        const configPath = configPathForHome(home);
+        const originalVars = Object.fromEntries(
+          Array.from({ length: 70 }, (_, index) => [
+            `SETTING_${index.toString().padStart(2, "0")}`,
+            "before",
+          ]),
+        );
+        const nextVars = Object.fromEntries(Object.keys(originalVars).map((key) => [key, "after"]));
+        await fs.mkdir(path.dirname(configPath), { recursive: true });
+        await fs.writeFile(
+          configPath,
+          formatConfig({ env: { vars: originalVars }, gateway: { port: 18789 } }),
+        );
+        const io = createFastConfigIO(home);
+        const snapshot = await io.readConfigFileSnapshot();
+        const nextConfig = structuredClone(snapshot.config);
+        nextConfig.env = { ...nextConfig.env, vars: nextVars };
 
-      const result = await io.writeConfigFile(nextConfig, { auditOrigin: "doctor" });
+        const result = await withEnvAsync(
+          {
+            OPENCLAW_CONFIG_PATH: configPath,
+            OPENCLAW_STATE_DIR: path.join(home, ".openclaw"),
+            OPENCLAW_TEST_FAST: "1",
+          },
+          () =>
+            writeConfigFile(nextConfig, {
+              baseSnapshot: snapshot,
+              expectedConfigPath: configPath,
+              auditOrigin,
+              afterWrite: { mode: "none", reason: "automatic migration" },
+              skipOutputLogs: true,
+              skipRuntimeSnapshotRefresh: true,
+            }),
+        );
 
-      const record = listConfigAuditRecordsForTests({
-        env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
-        homedir: () => home,
-      })
-        .filter((candidate) => candidate.event === "config.write")
-        .findLast((candidate) => candidate.configPath === configPath);
-      expect(record).toMatchObject({
-        event: "config.write",
-        origin: "doctor",
-        changedPathCount: 70,
-      });
-      if (!record || record.event !== "config.write") {
-        throw new Error("expected config write audit record");
-      }
-      expect(record.changedPaths).toHaveLength(64);
-      expect(record.changedPaths?.at(-1)).toBe("…+7 more");
-      expect(record.changedPaths?.slice(0, 2)).toEqual([
-        "env.vars.SETTING_00",
-        "env.vars.SETTING_01",
-      ]);
+        const record = listConfigAuditRecordsForTests({
+          env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+          homedir: () => home,
+        })
+          .filter((candidate) => candidate.event === "config.write")
+          .findLast((candidate) => candidate.configPath === configPath);
+        expect(record).toMatchObject({
+          event: "config.write",
+          configPath,
+          result: "rename",
+          previousHash: snapshot.hash,
+          nextHash: result.persistedHash,
+          // The runtime writer also records its managed plugins.installs removal.
+          changedPathCount: 71,
+        });
+        if (!record || record.event !== "config.write") {
+          throw new Error("expected config write audit record");
+        }
+        if (auditOrigin) {
+          expect(record.origin).toBe(auditOrigin);
+        } else {
+          expect(record).not.toHaveProperty("origin");
+        }
+        expect((await io.readConfigFileSnapshot()).hash).toBe(result.persistedHash);
+        expect(record.changedPaths).toHaveLength(64);
+        expect(record.changedPaths?.at(-1)).toBe("…+8 more");
+        expect(record.changedPaths?.slice(0, 2)).toEqual([
+          "env.vars.SETTING_00",
+          "env.vars.SETTING_01",
+        ]);
 
-      const slot = readConfigSnapshotAuditRecord({
-        env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
-        homedir: () => home,
-        configPath,
-      });
-      expect(slot).toMatchObject({ configPath, rawHash: result.persistedHash });
-      if (!slot) {
-        throw new Error("expected snapshot slot");
-      }
-      // The slot is diff-only, so every leaf is fingerprinted.
-      const slotVars =
-        (slot.fingerprintedAuthoredConfig as { env?: { vars?: Record<string, string> } }).env
-          ?.vars ?? {};
-      expect(Object.keys(slotVars)).toHaveLength(70);
-      for (const [name, value] of Object.entries(slotVars)) {
-        expect(value, name).toMatch(/^fp:[0-9a-f]{12}$/);
-      }
-      expect(
-        (slot.fingerprintedAuthoredConfig as { gateway?: { port?: string } }).gateway?.port,
-      ).toMatch(/^fp:[0-9a-f]{12}$/);
-    },
-  );
+        const slot = readConfigSnapshotAuditRecord({
+          env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+          homedir: () => home,
+          configPath,
+        });
+        expect(slot).toMatchObject({ configPath, rawHash: result.persistedHash });
+        if (!slot) {
+          throw new Error("expected snapshot slot");
+        }
+        // The slot is diff-only, so every leaf is fingerprinted.
+        const slotVars =
+          (slot.fingerprintedAuthoredConfig as { env?: { vars?: Record<string, string> } }).env
+            ?.vars ?? {};
+        expect(Object.keys(slotVars)).toHaveLength(70);
+        for (const [name, value] of Object.entries(slotVars)) {
+          expect(value, name).toMatch(/^fp:[0-9a-f]{12}$/);
+        }
+        expect(
+          (slot.fingerprintedAuthoredConfig as { gateway?: { port?: string } }).gateway?.port,
+        ).toMatch(/^fp:[0-9a-f]{12}$/);
+      },
+    );
+  }
 
   itWithHome(
     "journals an offline edit before a later config write replaces the snapshot slot",


### PR DESCRIPTION
Closes #139305

## What Problem This Solves

Fixes an issue where operators inspecting config-change history could not identify Doctor repairs and other labeled writes because their persisted audit records lost the writer's origin label. The config write itself succeeded, including quiet automatic startup repairs, but its provenance was absent.

## Why This Change Was Made

The runtime writer reconstructed `ConfigWriteOptions` with an incomplete field list. The lower persistence writer already recorded `options.auditOrigin`, and the mutation/Doctor callers already supplied it. Forwarding the complete options object at this shared boundary repairs the producer path rather than guessing provenance in a consumer.

Caller options spread first; runtime-owned snapshot/plugin metadata, path-filtered environment restoration, managed unsets, explicit-value source, and composed preflight still take precedence. Current main's `beforeCommit` and `persistCanonicalAgentRoster` contracts remain forwarded unchanged. Finalization, runtime snapshots, publication guards, and rollback are unchanged.

Adding just the missing field would preserve the duplication that caused this omission. The canonical forwarding approach removes 12 net production lines. No config option, SQLite schema, retention, authorization, dependency, or compatibility change is introduced. The separate include-only mutation audit path is not changed.

## User Impact

Root-config writes through the public runtime writer retain supplied Doctor, CLI, config-RPC, plugin-install, and system-agent origin labels. Unlabeled writes remain unlabeled, and existing historical records are not backfilled. Quiet output and inactive-runtime refresh suppression do not suppress provenance recording.

## Evidence

- **Red/green against main `676845210acb1d5eb8667ae6d0811a8e7b6f0f2b`:** the extended persisted-record regression fails with `expected undefined to be 'doctor'` on the exact original runtime module, then passes with this repair. The test now crosses public `writeConfigFile` rather than the factory-only path and covers `doctor`, `config-rpc`, and omitted origin, persisted file hashes, capped changed paths, and fingerprinted snapshot association.
- **Native no-mocks proof:** an isolated synthetic retired-session config runs through `commitAutomaticConfigRepair → transformConfigFile → runtime writer → SQLite`. Baseline fails for absent Doctor origin. The repaired flow records exactly one `config.write` row with `origin: "doctor"`, preserves the original `.bak` bytes, retains an inactive runtime snapshot, and matches the audit and snapshot-journal hashes to the written file. No live Gateway or operator state is used.
- **532 focused tests passed** across 14 config/Doctor files, including current main's publication-authority, roster/include, environment-preservation, preflight, canonical-reread, and rollback cases.
- **Fresh independent Codex autoreview:** scoped-clean at P0 for the integrated three-file patch; no accepted/actionable findings.
- **Changed-scope checks passed:** core and test typechecks, formatting, lint, config-doc baseline, dead-export scans, storage guards, import cycles, and the remaining selected guards. Command: `node scripts/check-changed.mjs -- src/config/io.runtime.ts src/config/io.write-config.test.ts docs/cli/openclaw.md`.

Focused regression command:

```bash
node scripts/run-vitest.mjs src/config/io.write-config.test.ts -t 'records runtime write audit origin doctor'
```

Owner and sibling proof:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/config/io.write-config.test.ts src/config/io.write-reread.test.ts src/config/io.write-prepare.test.ts src/config/io.snapshot.test.ts src/config/runtime-snapshot.test.ts src/config/io.runtime-snapshot-write.test.ts src/config/env-preserve.test.ts src/config/includes.test.ts src/config/io.audit.test.ts src/config/config-journal-snapshot.test.ts src/config/mutate.test.ts src/commands/doctor/shared/automatic-startup-config-repair.test.ts src/commands/doctor/shared/config-mutation-state.test.ts src/commands/doctor/finalize-config-flow.test.ts
```

Production LOC: +2/−14 (net −12). Tests: +91/−64 (net +27, largely table indentation). Docs: +5.

Related source-label feature: https://github.com/openclaw/openclaw/pull/111147
