### PR TITLE
fix(daemon): project native service-manager environments

### DIFF
--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -187,6 +187,12 @@ See: [Remote Gateway](/gateway/remote), [Authentication](/gateway/authentication
 
 ## Supervision and service lifecycle
 
+Native service-control commands receive only the operating-system environment
+needed for executable lookup, account identity, locale, and service-manager
+routing. They do not inherit application credentials or arbitrary shell
+variables. The Gateway payload and its installed service definition retain
+their separately configured environments.
+
 Use supervised runs for production-like reliability.
 
 <Tabs>

--- a/scripts/e2e/lib/upgrade-survivor/systemd-fixture.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/systemd-fixture.mjs
@@ -5,7 +5,8 @@ import path from "node:path";
 
 const unitName = "openclaw-gateway.service";
 const unitPath = path.join(process.env.HOME, ".config/systemd/user", unitName);
-const loadedPath = `${process.env.OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE || "/tmp/openclaw-systemctl-shim.pid"}.loaded-unit`;
+// Native clients omit fixture-only env; loaded state must follow the inspected unit.
+const loadedPath = `${unitPath}.loaded-unit`;
 const manager = "org.freedesktop.systemd1";
 const root = "/org/freedesktop/systemd1";
 const object = `${root}/unit/openclaw_2dgateway_2eservice`;

--- a/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
@@ -8,13 +8,13 @@ install_update_restart_systemctl_shim() {
 #!/usr/bin/env bash
 exec node "$(dirname "$0")/systemd-fixture.mjs" busctl "$@"
 BUSCTL
-  cat >"$shim_dir/systemctl" <<'SHIM'
-#!/usr/bin/env bash
-set -euo pipefail
-
-log_file="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG:-/tmp/openclaw-systemctl-shim.log}"
-pid_file="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE:-/tmp/openclaw-systemctl-shim.pid}"
-daemon_log="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG:-/tmp/openclaw-systemctl-shim-gateway.log}"
+  # Capture endpoint identity once; projected native clients cannot carry fixture-only env.
+  {
+    printf '#!/usr/bin/env bash\nset -euo pipefail\n'
+    printf 'log_file=%q\n' "${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG:-$shim_dir/systemctl-shim.log}"
+    printf 'pid_file=%q\n' "${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE:-$shim_dir/systemctl-shim.pid}"
+    printf 'daemon_log=%q\n' "${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG:-$shim_dir/systemctl-shim-gateway.log}"
+    cat <<'SHIM'
 supervisor_script="${pid_file}.supervisor.mjs"
 manager_script="$(dirname "$0")/systemd-fixture.mjs"
 printf '%s\n' "$*" >>"$log_file"
@@ -359,6 +359,7 @@ EXIT_STATUS
     ;;
 esac
 SHIM
+  } >"$shim_dir/systemctl"
   chmod +x "$shim_dir/systemctl" "$shim_dir/busctl"
   export PATH="$shim_dir:$PATH"
 }

--- a/src/daemon/exec-file.ts
+++ b/src/daemon/exec-file.ts
@@ -1,7 +1,8 @@
-/** Child-process wrapper used by daemon installers to preserve stdout/stderr on failure. */
+/** Native service control/inspection only; payload launchers own their full environment. */
 import { extractErrorCode } from "../infra/errors.js";
 import { createSanitizedCommandError } from "../process/exec-result.js";
 import { runCommandWithTimeout, type SpawnResult } from "../process/exec.js";
+import { resolveServiceManagerEnv } from "./service-process-env.js";
 
 export type ExecResult = Pick<SpawnResult, "stdout" | "stderr"> & {
   code: number;
@@ -25,7 +26,7 @@ export async function execFileUtf8(
     const { stdout, stderr, code, termination, signal } = await runCommandWithTimeout(
       [command, ...args],
       {
-        baseEnv: options.env,
+        baseEnv: resolveServiceManagerEnv(options.env),
         cwd: options.cwd,
         killSignal: options.killSignal,
         maxOutputBytes: 1024 * 1024,

--- a/src/daemon/launchd-lifecycle.ts
+++ b/src/daemon/launchd-lifecycle.ts
@@ -30,6 +30,7 @@ import {
 } from "./launchd-system.js";
 import { formatLine } from "./output.js";
 import { createGatewayLifecycleMutationReporter } from "./service-mutation.js";
+import { resolveServiceManagerEnv } from "./service-process-env.js";
 import type {
   GatewayServiceControlArgs,
   GatewayServiceEnv,
@@ -39,6 +40,7 @@ import type {
 const LAUNCHCTL_PROTECTED_PID_TIMEOUT_MS = 2_000;
 function readLaunchAgentPidForCleanupSync(serviceTarget: string): number {
   const probe = spawnSync("launchctl", ["print", serviceTarget], {
+    env: resolveServiceManagerEnv(),
     encoding: "utf8",
     timeout: LAUNCHCTL_PROTECTED_PID_TIMEOUT_MS,
   });

--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -53,19 +53,35 @@ async function executeHandoff(
   log: string;
 }> {
   const noWaitPid = 0;
-  const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "launchd-stub-"));
+  const stubDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "launchd-stub-")));
   try {
     const home = path.join(stubDir, "home");
     const stateDir = path.join(home, ".openclaw");
     const systemDaemonsDir = path.join(stubDir, "LaunchDaemons");
-    const handoffEnv = { HOME: home, OPENCLAW_PROFILE: "default", OPENCLAW_STATE_DIR: stateDir };
+    const handoffEnv = {
+      HOME: home,
+      OPENCLAW_PROFILE: "default",
+      OPENCLAW_STATE_DIR: stateDir,
+      BOUNDARY_SERVICE: "synthetic-service",
+    };
+    vi.stubGlobal("process", {
+      ...process,
+      env: {
+        PATH: `${stubDir}:/usr/bin:/bin`,
+        TMPDIR: stubDir,
+        BOUNDARY_PARENT: "synthetic-parent",
+      },
+    });
     const callsPath = path.join(stubDir, "launchctl.calls");
     fs.mkdirSync(path.join(stateDir, "logs"), { recursive: true });
     fs.mkdirSync(systemDaemonsDir);
     fs.writeFileSync(
       path.join(stubDir, "launchctl"),
       `#!/bin/sh
+LAUNCHCTL_CALLS_PATH="$TMPDIR/launchctl.calls"
+LAUNCHCTL_STUB_DIR="$TMPDIR"
 printf '%s\\n' "$*" >> "$LAUNCHCTL_CALLS_PATH"
+printf '%s:%s:%s\\n' "\${BOUNDARY_PARENT+present}" "\${BOUNDARY_SERVICE+present}" "\${OPENCLAW_PROFILE+present}" >> "$TMPDIR/environment.calls"
 if [ "$1" = "print" ] && [ "$2" = "system/ai.openclaw.gateway" ]; then
   ${systemOwnership === "loaded" ? "exit 0" : "printf 'Could not find service\\n' >&2; exit 113"}
 fi
@@ -89,7 +105,7 @@ ${launchctlStub}
         waitForPid: noWaitPid,
       });
     }
-    const [, args] = requireSpawnCall();
+    const [, args, options] = requireSpawnCall();
     const script = args[1]?.replaceAll(
       "/Library/LaunchDaemons",
       `'${systemDaemonsDir.replaceAll("'", "'\\''")}'`,
@@ -112,13 +128,7 @@ ${launchctlStub}
           String(noWaitPid),
         ],
         {
-          env: {
-            ...handoffEnv,
-            TMPDIR: stubDir,
-            LAUNCHCTL_CALLS_PATH: callsPath,
-            LAUNCHCTL_STUB_DIR: stubDir,
-            PATH: `${stubDir}:/usr/bin:/bin`,
-          },
+          env: options.env,
         },
       );
     } catch (error) {
@@ -129,6 +139,12 @@ ${launchctlStub}
       exitCode = code;
     }
 
+    const envCalls = fs
+      .readFileSync(path.join(stubDir, "environment.calls"), "utf8")
+      .trim()
+      .split("\n");
+    expect(envCalls.length).toBeGreaterThan(0);
+    expect(envCalls.every((call) => call === "::")).toBe(true);
     const calls = fs
       .readFileSync(callsPath, "utf8")
       .trim()
@@ -137,6 +153,7 @@ ${launchctlStub}
     const log = fs.readFileSync(path.join(stateDir, "logs", "gateway-restart.log"), "utf8");
     return { calls, exitCode, log };
   } finally {
+    vi.unstubAllGlobals();
     fs.rmSync(stubDir, { recursive: true, force: true });
   }
 }
@@ -368,7 +385,7 @@ esac`,
     expect(args[1]).not.toContain("/tmp/evil-bin");
     expect(args[1]).not.toContain("/tmp/evil.dylib");
     expect(args[1]).not.toContain("/tmp/evil-npmrc");
-    expect(options.env.OPENCLAW_PROFILE).toBe("default");
+    expect(options.env.OPENCLAW_PROFILE).toBeUndefined();
     expect(options.env.PATH).not.toBe("/tmp/evil-bin");
     expect(options.env.DYLD_INSERT_LIBRARIES).toBeUndefined();
     expect(options.env.NPM_CONFIG_GLOBALCONFIG).toBeUndefined();

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -5,11 +5,12 @@ import path from "node:path";
 import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { formatErrorMessage } from "../infra/errors.js";
-import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
+import { mergeProcessEnv } from "../infra/process-env.js";
 import { resolveLaunchAgentLabel } from "./launchd-label.js";
 import { LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS } from "./launchd-plist.js";
 import { renderSystemLaunchDaemonOwnershipShellProbe } from "./launchd-system.js";
 import { renderPosixRestartLogSetup } from "./restart-logs.js";
+import { resolveServiceManagerEnv } from "./service-process-env.js";
 
 type LaunchdRestartHandoffMode = "kickstart" | "reload" | "start-after-exit";
 type LaunchdHandoffMode = LaunchdRestartHandoffMode | "park";
@@ -31,39 +32,11 @@ const RELOAD_BOOTOUT_WAIT_DELAY_SECONDS = 1;
 const RELOAD_BOOTOUT_WAIT_COUNT = LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS + 15;
 const RELOAD_BOOTSTRAP_RETRY_COUNT = 15;
 
-type LaunchdRestartLogEnv = {
-  HOME?: string;
-  USERPROFILE?: string;
-  OPENCLAW_STATE_DIR?: string;
-  OPENCLAW_PROFILE?: string;
-};
-
 function resolveGuiDomain(): string {
   if (typeof process.getuid !== "function") {
     return "gui/501";
   }
   return `gui/${process.getuid()}`;
-}
-
-function collectStringEnvOverrides(
-  env?: Record<string, string | undefined>,
-): Record<string, string> | undefined {
-  const overrides = Object.fromEntries(
-    Object.entries(env ?? {}).filter(
-      (entry): entry is [string, string] => typeof entry[1] === "string",
-    ),
-  );
-  return Object.keys(overrides).length > 0 ? overrides : undefined;
-}
-
-function collectRestartLogEnv(env?: Record<string, string | undefined>): LaunchdRestartLogEnv {
-  const source = { ...process.env, ...env };
-  return {
-    HOME: source.HOME,
-    USERPROFILE: source.USERPROFILE,
-    OPENCLAW_STATE_DIR: source.OPENCLAW_STATE_DIR,
-    OPENCLAW_PROFILE: source.OPENCLAW_PROFILE,
-  };
 }
 
 function resolveLaunchdRestartTarget(
@@ -83,7 +56,7 @@ function resolveLaunchdRestartTarget(
 
 function buildLaunchdRestartScript(
   mode: LaunchdHandoffMode,
-  restartLogEnv: LaunchdRestartLogEnv,
+  restartLogEnv: NodeJS.ProcessEnv,
   label: string,
 ): string {
   // The detached shell waits for the caller before touching launchd so the
@@ -259,11 +232,12 @@ function scheduleDetachedLaunchdHandoff(params: {
     typeof params.waitForPid === "number" && Number.isFinite(params.waitForPid)
       ? Math.floor(params.waitForPid)
       : 0;
-  const restartLogEnv = collectRestartLogEnv(params.env);
-  const restartEnv = sanitizeHostExecEnv({
-    baseEnv: process.env,
-    overrides: collectStringEnvOverrides(params.env),
-  });
+  const restartLogEnv = { ...process.env, ...params.env };
+  // Keep the caller's executable search path: service overrides must not redirect
+  // the detached control shell's launchctl, as with the previous host sanitizer.
+  const restartEnv = resolveServiceManagerEnv(
+    mergeProcessEnv([process.env, params.env, { PATH: process.env.PATH }]),
+  );
   try {
     const child = spawn(
       "/bin/sh",

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import { PassThrough } from "node:stream";
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PortListener } from "../infra/ports-types.js";
 import { deleteTestEnvValue, setTestEnvValue, withEnvAsync } from "../test-utils/env.js";
 import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "./constants.js";
@@ -680,6 +680,8 @@ vi.mock("node:fs/promises", async () => {
   };
   return { ...wrapped, default: wrapped };
 });
+
+afterEach(() => vi.unstubAllEnvs());
 
 beforeEach(() => {
   state.launchctlCalls.length = 0;
@@ -3463,6 +3465,7 @@ describe("launchd install", () => {
   }>)(
     "protects the current service and allows $name",
     async ({ managedPidAfterCleanup, listeners }) => {
+      vi.stubEnv("BOUNDARY_PARENT_ONLY", "synthetic");
       const env = createLaunchdEnvWithGatewayPort("19002");
       if (managedPidAfterCleanup !== 4242) {
         state.printOutput = ["state = running", `pid = ${managedPidAfterCleanup}`].join("\n");
@@ -3484,6 +3487,14 @@ describe("launchd install", () => {
         expect.objectContaining({ resolveProtectedPid: expect.any(Function) }),
       );
       expect(state.cleanupProtectedPids).toEqual([managedPidAfterCleanup]);
+      expect(launchctlSpawnSync).toHaveBeenCalledWith(
+        "launchctl",
+        ["print", serviceId],
+        expect.objectContaining({
+          env: expect.not.objectContaining({ BOUNDARY_PARENT_ONLY: "synthetic" }),
+          timeout: 2_000,
+        }),
+      );
       expect(inspectPortUsage).toHaveBeenCalledWith(19002, {
         probeHosts: ["127.0.0.1"],
       });

--- a/src/daemon/schtasks-exec.test.ts
+++ b/src/daemon/schtasks-exec.test.ts
@@ -1,5 +1,5 @@
 // Windows schtasks exec tests cover scheduled task command execution.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { execSchtasks } from "./schtasks-exec.js";
 
 const runCommandWithTimeout = vi.hoisted(() => vi.fn());
@@ -12,8 +12,11 @@ beforeEach(() => {
   runCommandWithTimeout.mockReset();
 });
 
+afterEach(() => vi.unstubAllEnvs());
+
 describe("execSchtasks", () => {
   it("runs schtasks with bounded timeouts", async () => {
+    vi.stubEnv("BOUNDARY_PARENT_ONLY", "synthetic");
     runCommandWithTimeout.mockResolvedValue({
       stdout: "ok",
       stderr: "",
@@ -29,9 +32,13 @@ describe("execSchtasks", () => {
       code: 0,
     });
     expect(runCommandWithTimeout).toHaveBeenCalledWith(["schtasks", "/Query"], {
+      baseEnv: expect.any(Object),
       timeoutMs: 15_000,
       noOutputTimeoutMs: 30_000,
     });
+    expect(runCommandWithTimeout.mock.calls[0]?.[1].baseEnv).not.toHaveProperty(
+      "BOUNDARY_PARENT_ONLY",
+    );
   });
 
   it("maps a timeout into a non-zero schtasks result", async () => {

--- a/src/daemon/schtasks-exec.ts
+++ b/src/daemon/schtasks-exec.ts
@@ -1,5 +1,6 @@
 /** Executes Windows Task Scheduler commands with daemon-friendly timeouts. */
 import { runCommandWithTimeout } from "../process/exec.js";
+import { resolveServiceManagerEnv } from "./service-process-env.js";
 
 const SCHTASKS_TIMEOUT_MS = 15_000;
 const SCHTASKS_NO_OUTPUT_TIMEOUT_MS = 30_000;
@@ -9,6 +10,7 @@ export async function execSchtasks(
   args: string[],
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const result = await runCommandWithTimeout(["schtasks", ...args], {
+    baseEnv: resolveServiceManagerEnv(),
     timeoutMs: SCHTASKS_TIMEOUT_MS,
     noOutputTimeoutMs: SCHTASKS_NO_OUTPUT_TIMEOUT_MS,
   });

--- a/src/daemon/schtasks-process.ts
+++ b/src/daemon/schtasks-process.ts
@@ -14,6 +14,7 @@ import { parseCmdScriptCommandLine } from "./cmd-argv.js";
 import { NODE_SERVICE_KIND } from "./constants.js";
 import { resolveGatewayServiceProbeHosts } from "./gateway-service-probe-hosts.js";
 import { readScheduledTaskCommand } from "./schtasks-layout.js";
+import { resolveServiceManagerEnv } from "./service-process-env.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
 import type { GatewayServiceCommandConfig, GatewayServiceEnv } from "./service-types.js";
 import { WINDOWS_TASK_SUPERVISOR_FLAG } from "./windows-task-supervisor-contract.js";
@@ -275,7 +276,7 @@ export function probeProcessState(pid: number): "alive" | "missing" | "unknown" 
     const tasklist = spawnSync(
       getWindowsSystem32ExePath("tasklist.exe"),
       ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"],
-      { encoding: "utf8", timeout: 1_500, windowsHide: true },
+      { env: resolveServiceManagerEnv(), encoding: "utf8", timeout: 1_500, windowsHide: true },
     );
     if (tasklist.error || tasklist.status !== 0) {
       return "unknown";
@@ -311,6 +312,7 @@ export async function terminateGatewayProcessTree(pid: number, graceMs: number):
   }
   const taskkillPath = getWindowsSystem32ExePath("taskkill.exe");
   const graceful = spawnSync(taskkillPath, ["/T", "/PID", String(pid)], {
+    env: resolveServiceManagerEnv(),
     stdio: "ignore",
     timeout: 5_000,
     windowsHide: true,
@@ -320,6 +322,7 @@ export async function terminateGatewayProcessTree(pid: number, graceMs: number):
     return;
   }
   const forced = spawnSync(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
+    env: resolveServiceManagerEnv(),
     stdio: "ignore",
     timeout: 5_000,
     windowsHide: true,
@@ -365,7 +368,7 @@ export function readWindowsProcessSnapshot(): WindowsProcessSnapshotEntry[] | nu
       "-Command",
       "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
     ],
-    { encoding: "utf8", timeout: 5_000, windowsHide: true },
+    { env: resolveServiceManagerEnv(), encoding: "utf8", timeout: 5_000, windowsHide: true },
   );
   if (processSnapshot.error || processSnapshot.status !== 0) {
     return null;

--- a/src/daemon/schtasks-runtime.ts
+++ b/src/daemon/schtasks-runtime.ts
@@ -29,6 +29,7 @@ import {
   terminateGatewayProcessTree,
 } from "./schtasks-process.js";
 import { probeScheduledTaskExists, probeScheduledTaskState } from "./schtasks-state-probe.js";
+import { resolveServiceManagerEnv } from "./service-process-env.js";
 import {
   createServiceRuntimeInspectionFailure,
   type GatewayServiceRuntime,
@@ -158,7 +159,7 @@ export async function launchFallbackTaskScript(
       ).toString("base64"),
     ],
     {
-      env: scriptEnv,
+      env: { ...resolveServiceManagerEnv(), OPENCLAW_TASK_SCRIPT: scriptPath },
       stdio: "ignore",
       windowsHide: true,
     },

--- a/src/daemon/schtasks-state-probe.ts
+++ b/src/daemon/schtasks-state-probe.ts
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { getWindowsPowerShellExePath } from "../infra/windows-install-roots.js";
+import { resolveServiceManagerEnv } from "./service-process-env.js";
 
 type ScheduledTaskStateProbe =
   | { status: "found"; state: number | null; lastRunResult?: string; lastRunTime?: string }
@@ -34,6 +35,7 @@ export function probeScheduledTaskState(
       Buffer.from(script, "utf16le").toString("base64"),
     ],
     {
+      env: resolveServiceManagerEnv(),
       encoding: "utf8",
       timeout: timeoutMs && timeoutMs > 0 ? Math.min(timeoutMs, 5_000) : 5_000,
       windowsHide: true,

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -1,5 +1,5 @@
 // Windows schtasks startup fallback tests cover fallback startup task behavior.
-import type { ChildProcess } from "node:child_process";
+import type { ChildProcess, SpawnSyncOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -51,17 +51,31 @@ type SpawnSyncResult = {
   signal: null;
 };
 const spawnSync = vi.hoisted(() =>
-  vi.fn<(command: string, args?: readonly string[], options?: unknown) => SpawnSyncResult>(() => ({
-    pid: 0,
-    output: [null, "", ""],
-    stdout: "",
-    stderr: "",
-    status: 0,
-    signal: null,
-  })),
+  vi.fn<(command: string, args?: readonly string[], options?: SpawnSyncOptions) => SpawnSyncResult>(
+    () => ({
+      pid: 0,
+      output: [null, "", ""],
+      stdout: "",
+      stderr: "",
+      status: 0,
+      signal: null,
+    }),
+  ),
 );
 const taskProbeResponses: Array<{ status: number; stdout: string; stderr?: string }> = [];
-const taskProbe = vi.hoisted(() => vi.fn());
+const taskProbe = vi.hoisted(() =>
+  vi.fn<
+    (
+      command: string,
+      args?: readonly string[],
+      options?: SpawnSyncOptions,
+    ) => {
+      status: number;
+      stdout: string;
+      stderr?: string;
+    }
+  >(),
+);
 
 const findVerifiedGatewayListenerPidsOnPortSync = vi.hoisted(() =>
   vi.fn<(port: number) => number[]>(() => []),
@@ -80,7 +94,7 @@ vi.mock("node:child_process", async () => {
   return {
     ...actual,
     spawn,
-    spawnSync: (command: string, args?: readonly string[], options?: unknown) => {
+    spawnSync: (command: string, args?: readonly string[], options?: SpawnSyncOptions) => {
       const encoded = args?.indexOf("-EncodedCommand") ?? -1;
       if (
         encoded >= 0 &&
@@ -88,7 +102,7 @@ vi.mock("node:child_process", async () => {
           .toString("utf16le")
           .includes("Schedule.Service")
       ) {
-        return taskProbe();
+        return taskProbe(command, args, options);
       }
       return spawnSync(command, args, options);
     },
@@ -394,6 +408,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("Windows startup fallback", () => {
@@ -468,6 +483,7 @@ describe("Windows startup fallback", () => {
   });
 
   it("detaches the direct executable only after it starts", async () => {
+    vi.stubEnv("BOUNDARY_PARENT_ONLY", "synthetic");
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       await writeGatewayScript(env);
 
@@ -475,7 +491,15 @@ describe("Windows startup fallback", () => {
       expect(spawn).toHaveBeenCalledWith(
         "C:\\Program Files\\nodejs\\node.exe",
         expect.arrayContaining(["gateway", "--port", "18789"]),
-        expect.objectContaining({ detached: true, stdio: "ignore", windowsHide: true }),
+        expect.objectContaining({
+          detached: true,
+          stdio: "ignore",
+          windowsHide: true,
+          env: expect.objectContaining({
+            BOUNDARY_PARENT_ONLY: "synthetic",
+            OPENCLAW_GATEWAY_PORT: "18789",
+          }),
+        }),
       );
       expect(childUnref).toHaveBeenCalledOnce();
     });
@@ -499,6 +523,7 @@ describe("Windows startup fallback", () => {
   });
 
   it("detaches the cmd fallback only after it starts", async () => {
+    vi.stubEnv("BOUNDARY_PARENT_ONLY", "synthetic");
     await withWindowsEnv("openclaw-win-startup-", async ({ env, tmpDir }) => {
       env.OPENCLAW_STATE_DIR = path.join(tmpDir, "state & %USERPROFILE% !");
       const scriptPath = resolveTaskScriptPath(env);
@@ -520,6 +545,10 @@ describe("Windows startup fallback", () => {
       expect(command).toBe(getWindowsCmdExePath());
       expect(args).toEqual(["/d", "/s", "/v:off", "/c", '""%OPENCLAW_TASK_SCRIPT%""']);
       expect(options.env.OPENCLAW_TASK_SCRIPT).toBe(scriptPath);
+      expect(options.env.BOUNDARY_PARENT_ONLY).toBe("synthetic");
+      expect(spawnSync).toHaveBeenCalledOnce();
+      expect(spawnSync.mock.calls[0]?.[2]?.env).toMatchObject({ OPENCLAW_TASK_SCRIPT: scriptPath });
+      expect(spawnSync.mock.calls[0]?.[2]?.env).not.toHaveProperty("BOUNDARY_PARENT_ONLY");
       expect(options.detached).toBe(true);
       expect(options.stdio).toBe("ignore");
       expect(options.windowsHide).toBe(true);
@@ -529,12 +558,18 @@ describe("Windows startup fallback", () => {
   });
 
   it("uses the locale-independent task probe when a scheduled task is missing", async () => {
+    vi.stubEnv("BOUNDARY_PARENT_ONLY", "synthetic");
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       taskProbe.mockReturnValue({ status: 1, stdout: "-2147024894" });
 
       await expect(readScheduledTaskRuntime(env)).resolves.toEqual({
         status: "stopped",
         missingUnit: true,
+      });
+      expect(taskProbe).toHaveBeenCalledOnce();
+      expect(taskProbe.mock.calls[0]?.[2]).toMatchObject({
+        env: expect.not.objectContaining({ BOUNDARY_PARENT_ONLY: "synthetic" }),
+        timeout: 5_000,
       });
     });
   });

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -1,4 +1,5 @@
 // Windows schtasks stop tests cover stopping scheduled task services.
+import type { SpawnSyncOptions } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { PassThrough } from "node:stream";
@@ -33,14 +34,16 @@ type SpawnSyncResult = {
   signal: null;
 };
 const spawnSync = vi.hoisted(() =>
-  vi.fn<(command: string, args?: readonly string[]) => SpawnSyncResult>(() => ({
-    pid: 0,
-    output: [null, "-2147024891", ""],
-    stdout: "-2147024891",
-    stderr: "",
-    status: 1,
-    signal: null,
-  })),
+  vi.fn<(command: string, args?: readonly string[], options?: SpawnSyncOptions) => SpawnSyncResult>(
+    () => ({
+      pid: 0,
+      output: [null, "-2147024891", ""],
+      stdout: "-2147024891",
+      stderr: "",
+      status: 1,
+      signal: null,
+    }),
+  ),
 );
 
 vi.mock("node:child_process", async () => {
@@ -68,7 +71,8 @@ const {
   stopScheduledTask,
   suspendScheduledTaskAutoStartForUpdate,
 } = await import("./schtasks.js");
-const { resolveScheduledTaskOwnedGatewayPids } = await import("./schtasks-process.js");
+const { probeProcessState, resolveScheduledTaskOwnedGatewayPids } =
+  await import("./schtasks-process.js");
 const GATEWAY_PORT = 18789;
 const SUCCESS_RESPONSE = { code: 0, stdout: "", stderr: "" } as const;
 const INSTALLED_GATEWAY_COMMAND_LINE =
@@ -165,9 +169,49 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("Scheduled Task stop/restart cleanup", () => {
+  it.each([
+    { stdout: '"node.exe","4242","Console","1","1,024 K"', status: 0, result: "alive" },
+    { stdout: "No tasks", status: 0, result: "missing" },
+    { stdout: "", status: 1, result: "unknown" },
+  ])(
+    "keeps the tasklist fallback verdict $result with a closed environment",
+    ({ stdout, status, result }) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      vi.stubEnv("BOUNDARY_PARENT_ONLY", "synthetic");
+      // The default CIM failure reaches the independent PID-only tasklist probe.
+      spawnSync.mockReturnValueOnce({
+        pid: 0,
+        output: [],
+        stdout: "",
+        stderr: "",
+        status: 1,
+        signal: null,
+      });
+      spawnSync.mockReturnValueOnce({
+        pid: 0,
+        output: [],
+        stdout,
+        stderr: "",
+        status,
+        signal: null,
+      });
+      expect(probeProcessState(4242)).toBe(result);
+      expect(spawnSync).toHaveBeenCalledTimes(2);
+      expect(spawnSync.mock.calls[1]).toEqual([
+        expect.stringMatching(/tasklist\.exe$/i),
+        ["/FI", "PID eq 4242", "/FO", "CSV", "/NH"],
+        expect.objectContaining({
+          env: expect.not.objectContaining({ BOUNDARY_PARENT_ONLY: "synthetic" }),
+          timeout: 1_500,
+        }),
+      ]);
+    },
+  );
+
   it("suspends a task whose Settings.Enabled value uses the default", async () => {
     await withPreparedGatewayTask(async ({ env }) => {
       schtasksResponses.push(
@@ -496,12 +540,15 @@ describe("Scheduled Task stop/restart cleanup", () => {
   it.each(["gateway", "task-supervisor", "gateway-with-supervisor"])(
     "stops the exact installed Windows %s even before its port is bound",
     async (owner) => {
+      vi.stubEnv("BOUNDARY_PARENT_ONLY", "synthetic");
       await withPreparedGatewayTask(async ({ env, stdout }) => {
         vi.spyOn(process, "platform", "get").mockReturnValue("win32");
         pushSuccessfulSchtasksResponses(3);
         inspectPortUsageMock.mockResolvedValue(freePortUsage());
         let forced = false;
-        spawnSync.mockImplementation((command, args) => {
+        spawnSync.mockImplementation((command, args, options) => {
+          expect(options?.env).toBeDefined();
+          expect(options?.env).not.toHaveProperty("BOUNDARY_PARENT_ONLY");
           const executable = command.toLowerCase();
           if (executable.endsWith("taskkill.exe")) {
             const argv = Array.isArray(args) ? args.map(String) : [];

--- a/src/daemon/service-process-env.integration.test.ts
+++ b/src/daemon/service-process-env.integration.test.ts
@@ -1,0 +1,317 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withTempDir } from "../test-utils/temp-dir.js";
+import { resolveServiceManagerEnv } from "./service-process-env.js";
+import {
+  buildSystemdManagerPropertyOutput,
+  buildSystemdUnitPropertyOutput,
+} from "./service.test-helpers.js";
+
+const execFileAsync = promisify(execFile);
+
+async function runDriver(driver: string, env: NodeJS.ProcessEnv) {
+  return await execFileAsync(
+    process.execPath,
+    [
+      "--import",
+      new URL("../../scripts/tsx.mjs", import.meta.url).href,
+      "--input-type=module",
+      "-e",
+      driver,
+    ],
+    {
+      cwd: fileURLToPath(new URL("../../", import.meta.url)),
+      env,
+      timeout: 30_000,
+      maxBuffer: 1024 * 1024,
+    },
+  );
+}
+
+describe.skipIf(process.platform === "win32")("native control environment boundary", () => {
+  it.each([false, true])(
+    "keeps systemctl and busctl routing with machine fallback %s",
+    async (fallback) => {
+      await withTempDir("openclaw-manager-route-", async (temp) => {
+        const home = await fs.realpath(temp);
+        const bus = fallback ? undefined : `unix:path=${home}/bus`;
+        const source = {
+          HOME: home,
+          PATH: home,
+          USER: "target",
+          LOGNAME: "target",
+          XDG_RUNTIME_DIR: fallback ? path.join(home, "missing-runtime") : home,
+          DBUS_SESSION_BUS_ADDRESS: bus,
+          BOUNDARY_PARENT_ONLY: "synthetic-parent",
+        };
+        const callsPath = path.join(home, "calls.jsonl");
+        for (const command of ["systemctl", "busctl"]) {
+          await fs.writeFile(
+            path.join(home, command),
+            `#!${process.execPath}
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(callsPath)}, JSON.stringify({
+  command: ${JSON.stringify(command)}, args,
+  canary: Object.hasOwn(process.env, "BOUNDARY_PARENT_ONLY"),
+  native: process.env.PATH === ${JSON.stringify(home)} && process.env.USER === "target" && process.env.DBUS_SESSION_BUS_ADDRESS === ${JSON.stringify(bus)},
+}) + "\\n");
+if (${JSON.stringify(fallback ? "No medium found" : "")} && !args.includes("--machine")) {
+  console.error("Failed to connect to bus: " + ${JSON.stringify(fallback ? "No medium found" : "")}); process.exit(1);
+}
+console.log("running");
+`,
+            { mode: 0o700 },
+          );
+        }
+        const driver = `
+import assert from "node:assert/strict";
+import { execSystemctlUser, execBusctlUser } from ${JSON.stringify(new URL("./systemd-exec.ts", import.meta.url).href)};
+process.geteuid = () => 1000;
+const source = { ...process.env, XDG_RUNTIME_DIR: ${JSON.stringify(source.XDG_RUNTIME_DIR)}, DBUS_SESSION_BUS_ADDRESS: ${JSON.stringify(source.DBUS_SESSION_BUS_ADDRESS)} };
+for (const execute of [execSystemctlUser, execBusctlUser]) {
+  const result = await execute(source, ["status"], 5000);
+  assert.equal(result.code, 0);
+  assert.equal(result.termination, "exit");
+}
+`;
+        await runDriver(driver, source);
+        const calls = (await fs.readFile(callsPath, "utf8"))
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        const expectedArgs = [
+          ["--user", "status"],
+          ...(fallback ? [["--machine", "target@", "--user", "status"]] : []),
+        ];
+        expect(calls).toEqual(
+          ["systemctl", "busctl"].flatMap((command) =>
+            expectedArgs.map((args) => ({
+              command,
+              args,
+              canary: false,
+              native: true,
+            })),
+          ),
+        );
+      });
+    },
+  );
+
+  it("keeps loginctl account and sudo routing while closing both child environments", async () => {
+    await withTempDir("openclaw-linger-env-", async (temp) => {
+      const home = await fs.realpath(temp);
+      const callsPath = path.join(home, "calls.jsonl");
+      for (const command of ["loginctl", "sudo"]) {
+        await fs.writeFile(
+          path.join(home, command),
+          `#!${process.execPath}
+require("node:fs").appendFileSync(${JSON.stringify(callsPath)}, JSON.stringify({
+  command: ${JSON.stringify(command)}, args: process.argv.slice(2),
+  canary: Object.hasOwn(process.env, "BOUNDARY_PARENT_ONLY"),
+}) + "\\n");
+console.log("Linger=yes");
+`,
+          { mode: 0o700 },
+        );
+      }
+      const driver = `
+import assert from "node:assert/strict";
+import { mock } from "node:test";
+import { readSystemdUserLingerStatus, enableSystemdUserLinger } from ${JSON.stringify(new URL("./systemd-linger.ts", import.meta.url).href)};
+const realGetuid = process.getuid;
+assert.deepEqual(await readSystemdUserLingerStatus({ env: { USER: "selected" } }), { user: "selected", linger: "yes" });
+// Only the synchronous sudo decision is synthetic; logging must see the real filesystem owner.
+mock.method(process, "getuid", () => 1000, { times: 1 });
+assert.equal((await enableSystemdUserLinger({ env: { USER: "selected" }, sudoMode: "non-interactive" })).ok, true);
+assert.equal(process.getuid, realGetuid);
+mock.method(process, "getuid", () => 0, { times: 1 });
+assert.equal((await enableSystemdUserLinger({ env: {}, user: "explicit" })).ok, true);
+assert.equal(process.getuid, realGetuid);
+`;
+      await runDriver(driver, { HOME: home, PATH: home, BOUNDARY_PARENT_ONLY: "synthetic-parent" });
+      const calls = (await fs.readFile(callsPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(calls).toEqual([
+        { command: "loginctl", args: ["show-user", "selected", "-p", "Linger"], canary: false },
+        { command: "sudo", args: ["-n", "loginctl", "enable-linger", "selected"], canary: false },
+        { command: "loginctl", args: ["enable-linger", "explicit"], canary: false },
+      ]);
+    });
+  });
+
+  it("preserves effective service facts without leaking them to native children", async () => {
+    await withTempDir("openclaw-service-env-", async (temp) => {
+      const home = await fs.realpath(temp);
+      const unit = "openclaw-boundary.service";
+      const unitPath = path.join(home, ".config/systemd/user", unit);
+      const envFile = path.join(home, "service.env");
+      const callsPath = path.join(home, "calls.jsonl");
+      const env = {
+        HOME: home,
+        PATH: home,
+        USER: "boundary-user",
+        LOGNAME: "boundary-user",
+        XDG_RUNTIME_DIR: home,
+        DBUS_SESSION_BUS_ADDRESS: `unix:path=${home}/bus`,
+        DBUS_SYSTEM_BUS_ADDRESS: `unix:path=${home}/system-bus`,
+        SYSTEMD_BUS_TIMEOUT: "2s",
+        PSMODULEANALYSISCACHEPATH: path.join(home, "synthetic-module-cache"),
+        OPENCLAW_SYSTEMD_UNIT: unit,
+        OPENCLAW_STATE_DIR: path.join(home, "state"),
+        BOUNDARY_PARENT_ONLY: "synthetic-parent",
+      };
+      const inline = [
+        "BOUNDARY_INLINE=synthetic-inline",
+        "BOUNDARY_SHARED=inline-before-file",
+        "OPENCLAW_SYSTEMD_UNIT=stale-definition.service",
+        "OPENCLAW_PROFILE=default",
+      ];
+      const definition = [
+        "[Service]",
+        "ExecStart=/usr/bin/openclaw gateway run",
+        ...inline.map((entry) => `Environment=${entry}`),
+        `EnvironmentFile=${envFile}`,
+        "",
+      ].join("\n");
+      const fileContents = "BOUNDARY_FILE=synthetic-file\nBOUNDARY_SHARED=file-wins\n";
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.mkdir(env.OPENCLAW_STATE_DIR);
+      await fs.writeFile(unitPath, definition);
+      await fs.writeFile(envFile, fileContents);
+      const serviceProperties = buildSystemdManagerPropertyOutput({
+        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+        environment: inline,
+        environmentFiles: [[envFile, false]],
+      });
+      const unitProperties = buildSystemdUnitPropertyOutput({ fragmentPath: unitPath });
+      const record = `
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(callsPath)}, JSON.stringify({
+  command: path.basename(process.argv[1]), args,
+  canaries: ["BOUNDARY_PARENT_ONLY", "BOUNDARY_INLINE", "BOUNDARY_FILE", "BOUNDARY_SHARED"].map(name => Object.hasOwn(process.env, name)),
+  selectors: ["OPENCLAW_SYSTEMD_UNIT", "OPENCLAW_PROFILE", "OPENCLAW_STATE_DIR"].some(name => Object.hasOwn(process.env, name)),
+  native: ${JSON.stringify(Object.entries(env).filter(([name]) => !name.startsWith("OPENCLAW_") && !name.startsWith("BOUNDARY_")))}.every(([name, value]) => process.env[name] === value),
+  marker: process.env.OPENCLAW_CLI === "1",
+}) + "\\n");`;
+      for (const command of ["systemctl", "busctl"]) {
+        await fs.writeFile(
+          path.join(home, command),
+          `#!${process.execPath}
+const fs = require("node:fs"), path = require("node:path");
+${record}
+if (${JSON.stringify(command)} === "busctl") {
+  if (args.includes("LoadUnit")) console.log(JSON.stringify({ type: "o", data: ["/org/freedesktop/systemd1/unit/boundary"] }));
+  else if (args.includes("org.freedesktop.systemd1.Unit")) console.log(${JSON.stringify(unitProperties)});
+  else if (args.includes("org.freedesktop.systemd1.Service")) console.log(${JSON.stringify(serviceProperties)});
+  else process.exit(91);
+} else if (args.includes("status")) console.log("running");
+else process.exit(92);
+`,
+          { mode: 0o700 },
+        );
+      }
+      const driver = `
+import assert from "node:assert/strict";
+import { readSystemdServiceExecStart } from ${JSON.stringify(new URL("./systemd-service-files.ts", import.meta.url).href)};
+import { mergeGatewayServiceEnv } from ${JSON.stringify(new URL("./service-env-merge.ts", import.meta.url).href)};
+import { execSystemctlUser } from ${JSON.stringify(new URL("./systemd-exec.ts", import.meta.url).href)};
+const command = await readSystemdServiceExecStart(process.env, { requireEffective: true });
+assert.deepEqual(command.environment, {
+  BOUNDARY_INLINE: "synthetic-inline", BOUNDARY_SHARED: "file-wins", BOUNDARY_FILE: "synthetic-file",
+  OPENCLAW_SYSTEMD_UNIT: "stale-definition.service", OPENCLAW_PROFILE: "default",
+});
+assert.deepEqual(command.environmentValueSources, {
+  BOUNDARY_INLINE: "inline", BOUNDARY_SHARED: "inline-and-file", BOUNDARY_FILE: "file",
+  OPENCLAW_SYSTEMD_UNIT: "inline", OPENCLAW_PROFILE: "inline",
+});
+assert.deepEqual(command.definitionPaths, [${JSON.stringify(unitPath)}]);
+const effectiveEnv = mergeGatewayServiceEnv(process.env, command);
+assert.equal(effectiveEnv.OPENCLAW_SYSTEMD_UNIT, ${JSON.stringify(unit)});
+assert.equal(effectiveEnv.BOUNDARY_PARENT_ONLY, "synthetic-parent");
+assert.equal(effectiveEnv.BOUNDARY_FILE, "synthetic-file");
+const result = await execSystemctlUser(effectiveEnv, ["status"], 5000);
+assert.equal(result.code, 0);
+`;
+      await runDriver(driver, env);
+      expect(await fs.readFile(unitPath, "utf8")).toBe(definition);
+      expect(await fs.readFile(envFile, "utf8")).toBe(fileContents);
+      const calls = (await fs.readFile(callsPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map(
+          (line) =>
+            JSON.parse(line) as {
+              command: string;
+              args: string[];
+              canaries: boolean[];
+              selectors: boolean;
+              native: boolean;
+              marker: boolean;
+            },
+        );
+      expect(new Set(calls.map((call) => call.command))).toEqual(new Set(["busctl", "systemctl"]));
+      for (const call of calls) {
+        expect(call, `${call.command} ${call.args.join(" ")}`).toMatchObject({
+          canaries: [false, false, false, false],
+          selectors: false,
+          native: true,
+          marker: true,
+        });
+      }
+    });
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("service manager routing environment", () => {
+  it.each(["linux", "darwin", "win32"] as const)(
+    "preserves %s native routing without arbitrary namespaces",
+    (platform) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+      const source = Object.freeze({
+        PATH: "/native/bin",
+        HOME: "/native/home",
+        NO_COLOR: "",
+        DBUS_SESSION_BUS_ADDRESS: "unix:path=/bus",
+        XDG_RUNTIME_DIR: "/run/native",
+        SYSTEMD_UNIT_PATH: "/units",
+        SYSTEMD_BUS_TIMEOUT: "3s",
+        SUDO_USER: "caller",
+        SYSTEMD_PAGER: "untrusted",
+        DBUS_APPLICATION: "synthetic",
+        XDG_APPLICATION: "synthetic",
+        NODE_OPTIONS: "--inspect",
+        OPENCLAW_PROFILE: "private",
+        BOUNDARY_PARENT_ONLY: "synthetic",
+      });
+      expect(resolveServiceManagerEnv(source)).toEqual({
+        PATH: "/native/bin",
+        HOME: "/native/home",
+        NO_COLOR: "",
+        DBUS_SESSION_BUS_ADDRESS: "unix:path=/bus",
+        XDG_RUNTIME_DIR: "/run/native",
+        SYSTEMD_UNIT_PATH: "/units",
+        SYSTEMD_BUS_TIMEOUT: "3s",
+        SUDO_USER: "caller",
+      });
+    },
+  );
+
+  it("uses the parent only when the source is omitted", () => {
+    vi.stubEnv("HOME", "/parent/home");
+    expect(resolveServiceManagerEnv().HOME).toBe("/parent/home");
+    expect(resolveServiceManagerEnv({ HOME: undefined, PATH: "" })).toEqual({ PATH: "" });
+    expect(resolveServiceManagerEnv({})).toEqual({});
+  });
+});

--- a/src/daemon/service-process-env.ts
+++ b/src/daemon/service-process-env.ts
@@ -1,0 +1,35 @@
+import { mergeProcessEnv, resolveDiagnosticProcessEnv } from "../infra/process-env.js";
+
+const SERVICE_MANAGER_ENV_KEYS = new Set([
+  "TERM",
+  "COLORTERM",
+  "NO_COLOR",
+  // Linux bus/account routing, unit lookup and native client operation controls.
+  "DBUS_SESSION_BUS_ADDRESS",
+  "DBUS_SYSTEM_BUS_ADDRESS",
+  "XDG_RUNTIME_DIR",
+  "XDG_CONFIG_HOME",
+  "XDG_CONFIG_DIRS",
+  "XDG_DATA_HOME",
+  "XDG_DATA_DIRS",
+  "SYSTEMD_UNIT_PATH",
+  "SUDO_USER",
+  "SUDO_UID",
+  "SUDO_GID",
+  "SYSTEMD_OFFLINE",
+  "SYSTEMD_IN_CHROOT",
+  "SYSTEMD_BUS_TIMEOUT",
+]);
+
+/** Native controls receive OS context; service definitions and payloads keep their own env. */
+export function resolveServiceManagerEnv(
+  source: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const native = resolveDiagnosticProcessEnv(source);
+  for (const [key, value] of Object.entries(mergeProcessEnv([source]))) {
+    if (SERVICE_MANAGER_ENV_KEYS.has(process.platform === "win32" ? key.toUpperCase() : key)) {
+      native[key] = value;
+    }
+  }
+  return native;
+}

--- a/src/daemon/systemd-linger.ts
+++ b/src/daemon/systemd-linger.ts
@@ -4,8 +4,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { formatErrorMessage } from "../infra/errors.js";
-import { runCommandWithTimeout, runExec } from "../process/exec.js";
+import { execFileUtf8 } from "./exec-file.js";
 
 function resolveLoginctlUser(env: Record<string, string | undefined>): string | null {
   const fromEnv = normalizeOptionalString(env.USER) || normalizeOptionalString(env.LOGNAME);
@@ -33,22 +32,12 @@ export async function readSystemdUserLingerStatus(params: {
   if (!user) {
     return null;
   }
-  try {
-    const { stdout } = await runExec("loginctl", ["show-user", user, "-p", "Linger"], {
-      timeoutMs: 5_000,
-    });
-    const line = stdout
-      .split("\n")
-      .map((entry) => entry.trim())
-      .find((entry) => entry.startsWith("Linger="));
-    const value = normalizeOptionalLowercaseString(line?.split("=")[1]);
-    if (value === "yes" || value === "no") {
-      return { user, linger: value };
-    }
-  } catch {
-    // ignore; loginctl may be unavailable
-  }
-  return null;
+  const { stdout, code } = await execFileUtf8("loginctl", ["show-user", user, "-p", "Linger"], {
+    timeout: 5_000,
+  });
+  const line = stdout.split("\n").find((entry) => entry.trim().startsWith("Linger="));
+  const value = normalizeOptionalLowercaseString(line?.split("=")[1]);
+  return code === 0 && (value === "yes" || value === "no") ? { user, linger: value } : null;
 }
 
 /** Enables systemd user linger through loginctl, with optional sudo mode. */
@@ -68,17 +57,7 @@ export async function enableSystemdUserLinger(params: {
     needsSudo && params.sudoMode !== undefined
       ? ["sudo", ...(params.sudoMode === "non-interactive" ? ["-n"] : [])]
       : [];
-  const argv = [...sudoArgs, "loginctl", "enable-linger", user];
-  try {
-    const result = await runCommandWithTimeout(argv, { timeoutMs: 30_000 });
-    return {
-      ok: result.code === 0,
-      stdout: result.stdout,
-      stderr: result.stderr,
-      code: result.code ?? 1,
-    };
-  } catch (error) {
-    const message = formatErrorMessage(error);
-    return { ok: false, stdout: "", stderr: message, code: 1 };
-  }
+  const [command, ...args] = [...sudoArgs, "loginctl", "enable-linger", user];
+  const { stdout, stderr, code } = await execFileUtf8(command, args, { timeout: 30_000 });
+  return { ok: code === 0, stdout, stderr, code };
 }

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -309,13 +309,23 @@ function extractUpgradeSurvivorSupervisor(script: string): string {
   return source;
 }
 
-function extractUpgradeSurvivorSystemctlShim(script: string): string {
-  const match = script.match(/cat >"\$shim_dir\/systemctl" <<'SHIM'\n(?<source>[\s\S]*?)\nSHIM/u);
-  const source = match?.groups?.source;
-  if (!source) {
-    throw new Error("upgrade survivor systemctl shim source not found");
-  }
-  return source;
+function installUpgradeSurvivorSystemctlShim(
+  prefix: string,
+  env: NodeJS.ProcessEnv,
+  scriptPath = UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH,
+): string {
+  const installed = spawnSync(
+    "bash",
+    [
+      "-c",
+      'set -euo pipefail; source "$1"; install_update_restart_systemctl_shim',
+      "fixture",
+      scriptPath,
+    ],
+    { env: { PATH: process.env.PATH, ...env, npm_config_prefix: prefix }, encoding: "utf8" },
+  );
+  expect(installed.status, installed.stderr).toBe(0);
+  return join(prefix, "bin", "systemctl");
 }
 
 async function waitForProcessExit(child: ChildProcess, timeoutMs = 5_000): Promise<number | null> {
@@ -406,10 +416,15 @@ async function forEachUpgradeSurvivorSystemctlShim(
     }
     const pid = targetPid ?? Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
     writeFileSync(pidPath, `${pid}\n`);
-    const shimPath = join(workDir, "systemctl");
-    writeFileSync(shimPath, extractUpgradeSurvivorSystemctlShim(readFileSync(scriptPath, "utf8")), {
-      mode: 0o755,
-    });
+    const fixtureEnv = {
+      OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG: join(workDir, "systemctl.log"),
+      OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE: pidPath,
+    };
+    const shimPath = installUpgradeSurvivorSystemctlShim(
+      workDir,
+      { HOME: workDir, ...fixtureEnv },
+      scriptPath,
+    );
     writeExecutables(binDir, {
       awk: `#!/usr/bin/env bash
 [ "$FAKE_PROC_STAT_MODE" != "unreadable" ] || exit 1
@@ -434,8 +449,7 @@ esac
           ...process.env,
           FAKE_PROC_STAT: procStat ?? "",
           FAKE_PROC_STAT_MODE: procStat === undefined ? "unreadable" : "readable",
-          OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG: join(workDir, "systemctl.log"),
-          OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE: pidPath,
+          ...fixtureEnv,
           PATH: `${binDir}:${process.env.PATH ?? ""}`,
         },
       }).status;
@@ -4556,25 +4570,18 @@ ${storage === "wal" ? 'process.kill(process.pid, "SIGKILL");' : ""}`,
       expect(await waitForProcessExit(supervisor)).toBe(0);
       const observation = JSON.parse(readFileSync(`${logPath}.exit.json`, "utf8"));
       expect(observation.last).toMatchObject({ code: 78, signal: null });
-      const shimPath = join(workDir, "systemctl");
-      writeFileSync(
-        shimPath,
-        extractUpgradeSurvivorSystemctlShim(
-          readFileSync(UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH, "utf8"),
-        ),
-      );
-      writeFileSync(
-        join(workDir, "systemd-fixture.mjs"),
-        readFileSync("scripts/e2e/lib/upgrade-survivor/systemd-fixture.mjs"),
-      );
+      const managerEnv = {
+        HOME: join(workDir, "home"),
+        OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG: logPath,
+        OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG: join(artifacts, "systemctl-shim.log"),
+        OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE: join(workDir, "missing.pid"),
+      };
+      const shimPath = installUpgradeSurvivorSystemctlShim(workDir, managerEnv);
       const shown = spawnSync("bash", [shimPath, ...SURVIVOR_SERVICE_SHOW_ARGS], {
         encoding: "utf8",
         env: {
           ...process.env,
-          HOME: join(workDir, "home"),
-          OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG: logPath,
-          OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG: join(artifacts, "systemctl-shim.log"),
-          OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE: join(workDir, "missing.pid"),
+          ...managerEnv,
         },
       });
       expect(shown.status, shown.stderr).toBe(0);
@@ -4655,15 +4662,6 @@ ${storage === "wal" ? 'process.kill(process.pid, "SIGKILL");' : ""}`,
         join(unitDir, "openclaw-gateway.service"),
         `[Service]\nExecStart="${process.execPath}" unused\n`,
       );
-      const shimPath = join(workDir, "systemctl");
-      writeFileSync(
-        shimPath,
-        extractUpgradeSurvivorSystemctlShim(readFileSync(scriptPath, "utf8")),
-      );
-      writeFileSync(
-        join(workDir, "systemd-fixture.mjs"),
-        readFileSync("scripts/e2e/lib/upgrade-survivor/systemd-fixture.mjs"),
-      );
       const binDir = join(workDir, "bin");
       writeExecutables(binDir, {
         node: `#!/bin/sh
@@ -4681,6 +4679,7 @@ exec ${shellQuote(process.execPath)} "$@"
         OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG: join(workDir, "systemctl.log"),
         OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE: join(workDir, "supervisor.pid"),
       };
+      const shimPath = installUpgradeSurvivorSystemctlShim(workDir, fixtureEnv, scriptPath);
       const started = spawnSync("bash", [shimPath, "--user", "start", "openclaw-gateway.service"], {
         encoding: "utf8",
         env: { ...fixtureEnv, PATH: `${binDir}:${process.env.PATH ?? ""}` },
@@ -7211,7 +7210,11 @@ done
     const serviceName = "openclaw-gateway-fixture.service";
     const unitPath = join(home, ".config/systemd/user", serviceName);
     writeExecutables(binDir, {
-      busctl: readFileSync(DOCTOR_SWITCH_BUSCTL_SHIM_PATH, "utf8"),
+      // Bind fixture identity here: native manager children do not inherit OpenClaw selectors.
+      busctl: readFileSync(DOCTOR_SWITCH_BUSCTL_SHIM_PATH, "utf8").replace(
+        "process.env.OPENCLAW_SYSTEMD_UNIT",
+        JSON.stringify(serviceName),
+      ),
       "systemd-exec-start.mjs": readFileSync(DOCTOR_SWITCH_SYSTEMD_EXEC_START_PATH, "utf8"),
     });
     const env = {

--- a/test/scripts/upgrade-survivor-systemd.test.ts
+++ b/test/scripts/upgrade-survivor-systemd.test.ts
@@ -14,15 +14,22 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const owner = resolve("scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh");
 
-function fixture() {
+function fixture(customPaths = true) {
   const home = tempDirs.make("survivor-manager-");
+  const artifacts = join(home, customPaths ? "artifacts ' \" $ `" : "bin");
+  mkdirSync(artifacts, { recursive: true });
+  const paths = {
+    log: join(artifacts, "systemctl-shim.log"),
+    pid: join(artifacts, "systemctl-shim.pid"),
+    daemonLog: join(artifacts, "systemctl-shim-gateway.log"),
+  };
   const env = {
     HOME: home,
     PATH: `${home}/bin:${process.env.PATH}`,
     npm_config_prefix: home,
-    OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG: join(home, "systemctl.log"),
-    OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE: join(home, "gateway.pid"),
-    OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG: join(home, "gateway.log"),
+    OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG: customPaths ? paths.log : undefined,
+    OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE: customPaths ? paths.pid : undefined,
+    OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG: customPaths ? paths.daemonLog : undefined,
   };
   const shell = (script: string, args: string[] = []) =>
     spawnSync(
@@ -44,7 +51,7 @@ function fixture() {
     });
   const unit = join(home, ".config/systemd/user/openclaw-gateway.service");
   mkdirSync(join(home, ".config/systemd/user"), { recursive: true });
-  return { home, env, shell, systemctl, unit };
+  return { home, env, shell, systemctl, unit, paths };
 }
 
 describe.skipIf(process.platform === "win32")("survivor manager fixture", () => {
@@ -108,6 +115,13 @@ describe.skipIf(process.platform === "win32")("survivor manager fixture", () => 
       },
       environmentValueSources: { FIXTURE_VALUE: "inline-and-file" },
     });
+    const peer = fixture();
+    writeFileSync(peer.unit, buildSystemdUnit({ programArguments: ["/usr/bin/peer", "gateway"] }));
+    expect(await readSystemdServiceExecStart(peer.env, { requireEffective: true })).toMatchObject({
+      programArguments: ["/usr/bin/peer", "gateway"],
+      sourcePath: peer.unit,
+    });
+    expect(await readSystemdServiceExecStart(env, { requireEffective: true })).toEqual(command);
     const invalid = spawnSync(
       join(home, "bin/busctl"),
       ["--user", "--json=short", "call", "unsupported"],
@@ -148,7 +162,7 @@ describe.skipIf(process.platform === "win32")("survivor manager fixture", () => 
   });
 
   it("keeps the inspected service alive after the caller terminal closes and drains restart children", async () => {
-    const { home, env, shell, systemctl, unit } = fixture();
+    const { home, env, shell, systemctl, unit, paths } = fixture();
     const record = join(home, "starts.jsonl");
     const program = join(home, "gateway fixture.mjs");
     const environmentFile = join(home, "gateway.systemd.env");
@@ -180,14 +194,18 @@ setInterval(() => {}, 1000);
       }),
     );
     const records = (): Array<{ pid: number; argv: string[]; cwd: string; value: string }> => {
-      if (!existsSync(record)) return [];
+      if (!existsSync(record)) {
+        return [];
+      }
       // The restarted service appends one JSON record per line while this poller reads
       // concurrently, so a read landing mid-append sees a torn final line. Only whole
       // newline-terminated records count as observed starts; an unterminated tail is
       // dropped so the poll retries instead of throwing. Earlier lines are always
       // complete, so a parse failure there still fails the test.
       const lines = readFileSync(record, "utf8").split("\n");
-      if (lines.at(-1) !== "") lines.pop();
+      if (lines.at(-1) !== "") {
+        lines.pop();
+      }
       return lines.filter((line) => line !== "").map((line) => JSON.parse(line));
     };
     const waitForStarts = async (count: number) => {
@@ -204,7 +222,13 @@ setInterval(() => {}, 1000);
         [
           "-c",
           `import os, pty, sys
-status = pty.spawn(["bash", "-c", sys.argv[1], "fixture", sys.argv[2]], stdin_read=lambda _: b"")
+def read_terminal(fd):
+    data = os.read(fd, 1024)
+    # Python 3.9 loops after macOS EOF; use its Linux terminal-close cleanup path.
+    if not data:
+        raise OSError("terminal closed")
+    return data
+status = pty.spawn(["bash", "-c", sys.argv[1], "fixture", sys.argv[2]], master_read=read_terminal, stdin_read=lambda _: b"")
 code = os.waitstatus_to_exitcode(status)
 raise SystemExit(code if code >= 0 else 128 - code)
 `,
@@ -217,7 +241,7 @@ raise SystemExit(code if code >= 0 else 128 - code)
           timeout: 40_000,
         },
       );
-      expect(restarted.status, restarted.stderr).toBe(0);
+      expect(restarted.status, restarted.stdout + restarted.stderr).toBe(0);
       await waitForStarts(1);
       expect.soft(systemctl("is-active", "openclaw-gateway.service").status).toBe(0);
       const inspected = await readSystemdServiceExecStart(env, { requireEffective: true });
@@ -228,17 +252,12 @@ raise SystemExit(code if code >= 0 else 128 - code)
         value: inspected?.environment?.FIXTURE_VALUE,
         state: join(home, "state"),
       });
-      const previousPid = readFileSync(
-        env.OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE,
-        "utf8",
-      ).trim();
+      const previousPid = readFileSync(paths.pid, "utf8").trim();
       expect(await readSystemdServiceRuntime(env)).toMatchObject({
         status: "running",
         pid: Number(previousPid),
       });
-      const previousLines = readFileSync(env.OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG, "utf8")
-        .trim()
-        .split("\n").length;
+      const previousLines = readFileSync(paths.log, "utf8").trim().split("\n").length;
       const assertion = () =>
         shell('assert_update_restart_service_replaced "$1" "$2"', [
           previousPid,
@@ -264,10 +283,48 @@ raise SystemExit(code if code >= 0 else 128 - code)
           } catch {}
         }
       }
-      expect(existsSync(env.OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE)).toBe(false);
+      expect(existsSync(paths.pid)).toBe(false);
       const runtime = await readSystemdServiceRuntime(env);
       expect(runtime).toMatchObject({ status: "stopped" });
       expect(runtime.missingUnit).not.toBe(true);
     }
   });
+
+  it.each([true, false])(
+    "binds installation paths for direct and native clients (custom=%s)",
+    async (custom) => {
+      const { home, env, unit, paths } = fixture(custom);
+      writeFileSync(unit, buildSystemdUnit({ programArguments: ["/usr/bin/fixture", "gateway"] }));
+      writeFileSync(paths.pid, `${process.pid}\n`);
+      writeFileSync(`${paths.daemonLog}.exit.json`, JSON.stringify({ last: { code: 78 } }));
+      const driftedEnv = {
+        ...env,
+        OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG: join(home, "wrong.log"),
+        OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE: join(home, "wrong.pid"),
+        OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG: join(home, "wrong-daemon.log"),
+      };
+      const direct = spawnSync(
+        join(home, "bin/systemctl"),
+        [
+          "--user",
+          "show",
+          "openclaw-gateway.service",
+          "--property=Id,LoadState,ActiveState,SubState,Result,NRestarts,StartLimitBurst,MainPID,ExecMainStatus,ExecMainCode,KillMode,TasksCurrent,MemoryCurrent",
+        ],
+        { env: driftedEnv, encoding: "utf8" },
+      );
+      expect(direct.status, direct.stderr).toBe(0);
+      expect(direct.stdout).toContain(`MainPID=${process.pid}`);
+      expect(direct.stdout).toContain("ExecMainStatus=78");
+      expect(await readSystemdServiceRuntime(driftedEnv)).toMatchObject({
+        status: "running",
+        pid: process.pid,
+        lastExitStatus: 78,
+      });
+      expect(readFileSync(paths.log, "utf8")).toContain("--user show openclaw-gateway.service");
+      expect(existsSync(driftedEnv.OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG)).toBe(false);
+      // This is an observation-only PID fixture; never send stop to the test worker.
+      rmSync(paths.pid);
+    },
+  );
 });


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Fixes an issue where Gateway service inspection, installation, and restart commands passed application credentials and arbitrary parent environment variables to native service-manager child processes.

This is stage 1 of the #135868 split: concern D, native service-manager environment projection (decision brief §§1 and 5). It includes the source PR's coupled native-manager fixture changes needed to test that boundary.

## Why This Change Was Made

Native controls share the existing diagnostic environment projector, extended with explicit service-manager routing keys. Asynchronous commands, synchronous probes, and the detached launchd handoff use this owner. Gateway payloads and installed service definitions retain their separate environments.

The change removes duplicate native-context policy, launchd environment adapters, and linger subprocess error handling. Fixture managers bind endpoint paths at installation and keep loaded state beside their unit, so direct and projected clients observe the same fixture. Tests run the real fixture installer instead of extracting shell source.

Production is +70/−71 (net −1); tests +586/−92; tooling +10/−8; docs +6/−0. The two proposed environment test files shrink from 663 to 317 lines. No product configuration, dependency, or database changes are introduced.

## User Impact

Native service controls retain executable, account, locale, Windows profile, and Linux bus routing without receiving application-only environment values. Installed Gateway credentials and fallback payload launch environments remain intact.

## Evidence

- All 40 regular daemon files passed on macOS: 1,335 passed, 9 skipped. The same 40 files passed on Linux with Vitest 5: 1,319 passed, 25 skipped.
- Linux Vitest 5 fixture suites: 276 Docker-helper tests and 4 survivor-manager tests passed, including the three failures found by initial PR CI.
- The complete 20-file changed-check plan exited 0 on [Testbox](https://github.com/openclaw/openclaw/actions/runs/33988687375), including core/UI and root-test type graphs, core/script/root-test lint, three zero-entry dead-export scans, and repository guards. Testbox verified the pre-rebase candidate as tree `9e5b6bd209d29445fa415b34b80439e6e4fb9dea`; subsequent rebases changed none of the daemon, subprocess-environment, or fixture owners. The lease was stopped after both commands returned exit 0. The pre-fixture local changed-check plan also passed.
- Temporarily reverting the production callers reproduced all four boundary failures: parent/payload canaries appeared in native children. The fixed implementation passes those cases.
- Real macOS proof passed for native environment observation, launchctl invocation, and an isolated task-owned launchd bootstrap/payload/bootout cycle. The temporary job was removed.
- Direct macOS fixture proof passed for reload visibility, peer isolation, and quoted endpoint paths. The retained Python 3.9 PTY EOF fix was verified: the original path timed out; the corrected path exited 0.
- Independent Codex reviews of the core and coupled fixture changes are scoped-clean at P0–P2.

### Review disposition

The final-head ClawSweeper review found no actionable correctness or security defect. Its generated “Add data-model compatibility proof” checkbox is not applicable and is intentionally skipped: the relocated `.loaded-unit` file belongs solely to the synthetic systemd manager in disposable test homes. No production store, schema, or migration changes exist. The review's own “Fixture state is not a production migration” evidence confirms this; the survivor-manager tests and native fixture proof cover endpoint binding, reload visibility, and peer isolation.

### Landing status

Exact head `14e69d9d8a1a17e48e5e4de07ec744aeee47d46c` is MERGEABLE with 132 passing checks, zero failures, and zero pending checks. [CI run 33990827090, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33990827090) completed successfully. Attempt 1 hit an unrelated timing flake in `src/gateway/session-delivery-clock-jump.integration.test.ts`; the campaign lead investigated and reran the failed jobs. No assertion or gate was weakened, and the source head is unchanged.
