### PR TITLE
refactor(ios): keep cron snapshot pagination consistent

### DIFF
--- a/apps/ios/Sources/Design/AgentProModels.swift
+++ b/apps/ios/Sources/Design/AgentProModels.swift
@@ -360,24 +360,60 @@ struct CronJobsListLite: Decodable {
         self.hasMore = try container.decodeIfPresent(Bool.self, forKey: .hasMore) ?? false
         self.nextOffset = try container.decodeIfPresent(Int.self, forKey: .nextOffset)
     }
-}
 
-struct CronJobsSnapshotIdentity: Equatable {
-    let total: Int?
-    let revision: String?
-}
+    @MainActor
+    static func collect(
+        maximumPageCount: Int,
+        maximumJobCount: Int,
+        fetchPage: @MainActor (Int) async -> CronJobsListLite?) async -> CronJobsListLite?
+    {
+        var jobs: [CronJob] = []
+        var seenJobIDs: Set<String> = []
+        var expectedIdentity: SnapshotIdentity?
+        var offset = 0
+        for _ in 0..<maximumPageCount {
+            guard let page = await fetchPage(offset),
+                  page.total.map({ (0...maximumJobCount).contains($0) }) ?? true
+            else { return nil }
+            let revision = page.snapshotRevision?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let identity = SnapshotIdentity(
+                total: page.total,
+                revision: revision?.isEmpty == false ? revision : nil)
+            if let expectedIdentity, identity != expectedIdentity {
+                // Each offset page is locked separately by the Gateway. Reject a changed
+                // snapshot instead of combining rows from different revisions.
+                return nil
+            }
+            expectedIdentity = identity
+            for job in page.jobs {
+                guard seenJobIDs.insert(job.id).inserted else { return nil }
+            }
+            jobs.append(contentsOf: page.jobs)
+            guard jobs.count <= maximumJobCount else { return nil }
+            if let total = identity.total {
+                guard total >= jobs.count, total != jobs.count || !page.hasMore else { return nil }
+            }
+            guard page.hasMore else {
+                return CronJobsListLite(
+                    jobs: jobs,
+                    snapshotRevision: identity.revision,
+                    total: identity.total == jobs.count ? identity.total : nil,
+                    hasMore: false,
+                    nextOffset: nil)
+            }
+            guard let nextOffset = page.nextOffset,
+                  nextOffset > offset,
+                  nextOffset <= maximumJobCount
+            else { return nil }
+            offset = nextOffset
+        }
+        return nil
+    }
 
-func cronJobsSnapshotIdentity(page: CronJobsListLite, maximumCount: Int) -> CronJobsSnapshotIdentity? {
-    guard page.total.map({ (0...maximumCount).contains($0) }) ?? true else { return nil }
-    let revision = page.snapshotRevision?.trimmingCharacters(in: .whitespacesAndNewlines)
-    return CronJobsSnapshotIdentity(
-        total: page.total,
-        revision: revision?.isEmpty == false ? revision : nil)
-}
-
-func nextCronJobsListOffset(page: CronJobsListLite, currentOffset: Int) -> Int? {
-    guard page.hasMore, let nextOffset = page.nextOffset, nextOffset > currentOffset else { return nil }
-    return nextOffset
+    private struct SnapshotIdentity: Equatable {
+        let total: Int?
+        let revision: String?
+    }
 }
 
 struct DreamingStatusEnvelope: Decodable {

--- a/apps/ios/Sources/Design/AgentProTab+GatewayData.swift
+++ b/apps/ios/Sources/Design/AgentProTab+GatewayData.swift
@@ -207,13 +207,7 @@ extension AgentProTab {
     }
 
     private func requestCronJobsSnapshot() async -> CronJobsListLite? {
-        let pageLimit = 100
-        let jobLimit = 20000
-        var jobs: [CronJob] = []
-        var seenJobIDs: Set<String> = []
-        var expectedIdentity: CronJobsSnapshotIdentity?
-        var offset = 0
-        for _ in 0..<pageLimit {
+        await CronJobsListLite.collect(maximumPageCount: 100, maximumJobCount: 20000) { offset in
             guard let paramsJSON = try? Self.automationParams([
                 "includeDisabled": true,
                 "limit": 200,
@@ -221,54 +215,12 @@ extension AgentProTab {
                 "sortBy": "name",
                 "sortDir": "asc",
             ]) else { return nil }
-            guard let page = await self.requestOptional(
+            return await self.requestOptional(
                 CronJobsListLite.self,
                 method: "cron.list",
                 paramsJSON: paramsJSON,
                 timeoutSeconds: 12)
-            else { return nil }
-            guard let identity = cronJobsSnapshotIdentity(page: page, maximumCount: jobLimit) else { return nil }
-            if let expectedIdentity, identity != expectedIdentity {
-                // Offset pages are separately locked by the Gateway. Restart instead of
-                // combining pages when a concurrent mutation changes the snapshot.
-                return nil
-            }
-            expectedIdentity = identity
-            let pageJobIDs = Set(page.jobs.map(\.id))
-            guard pageJobIDs.count == page.jobs.count,
-                  seenJobIDs.isDisjoint(with: pageJobIDs)
-            else { return nil }
-            seenJobIDs.formUnion(pageJobIDs)
-            jobs.append(contentsOf: page.jobs)
-            guard jobs.count <= jobLimit else { return nil }
-            if let total = identity.total {
-                guard total >= jobs.count else { return nil }
-                if jobs.count == total {
-                    guard !page.hasMore else { return nil }
-                    return CronJobsListLite(
-                        jobs: jobs,
-                        snapshotRevision: identity.revision,
-                        total: total,
-                        hasMore: false,
-                        nextOffset: nil)
-                }
-            }
-            guard page.hasMore else {
-                return CronJobsListLite(
-                    jobs: jobs,
-                    snapshotRevision: identity.revision,
-                    total: nil,
-                    hasMore: false,
-                    nextOffset: nil)
-            }
-            guard let nextOffset = nextCronJobsListOffset(page: page, currentOffset: offset),
-                  nextOffset <= jobLimit
-            else {
-                return nil
-            }
-            offset = nextOffset
         }
-        return nil
     }
 
     func normalized(_ value: String?) -> String? {

--- a/apps/ios/Sources/RootSidebarModel.swift
+++ b/apps/ios/Sources/RootSidebarModel.swift
@@ -546,48 +546,16 @@ final class RootSidebarModel {
     }
 
     private func loadCronJobs(appModel: NodeAppModel) async -> [CronJob]? {
-        let pageLimit = 5
-        let jobLimit = 1000
-        var jobs: [CronJob] = []
-        var seenJobIDs: Set<String> = []
-        var expectedIdentity: CronJobsSnapshotIdentity?
-        var offset = 0
-        for _ in 0..<pageLimit {
+        let snapshot = await CronJobsListLite.collect(maximumPageCount: 5, maximumJobCount: 1000) { offset in
             let paramsJSON = "{\"includeDisabled\":true,\"limit\":200,\"offset\":\(offset)," +
                 "\"sortBy\":\"name\",\"sortDir\":\"asc\"}"
-            let page = await self.request(
+            return await self.request(
                 CronJobsListLite.self,
                 appModel: appModel,
                 method: "cron.list",
                 paramsJSON: paramsJSON)
-            guard let page,
-                  let identity = cronJobsSnapshotIdentity(page: page, maximumCount: jobLimit)
-            else { return nil }
-            if let expectedIdentity, identity != expectedIdentity {
-                return nil
-            }
-            expectedIdentity = identity
-            let pageJobIDs = Set(page.jobs.map(\.id))
-            guard pageJobIDs.count == page.jobs.count,
-                  seenJobIDs.isDisjoint(with: pageJobIDs)
-            else { return nil }
-            seenJobIDs.formUnion(pageJobIDs)
-            jobs.append(contentsOf: page.jobs)
-            guard jobs.count <= jobLimit else { return nil }
-            if let total = identity.total {
-                guard total >= jobs.count else { return nil }
-                if jobs.count == total {
-                    guard !page.hasMore else { return nil }
-                    return jobs
-                }
-            }
-            guard page.hasMore else { return jobs }
-            guard let nextOffset = nextCronJobsListOffset(page: page, currentOffset: offset),
-                  nextOffset <= jobLimit
-            else { return nil }
-            offset = nextOffset
         }
-        return nil
+        return snapshot?.jobs
     }
 
     private func request<T: Decodable>(

--- a/apps/ios/Tests/AgentAutomationModelsTests.swift
+++ b/apps/ios/Tests/AgentAutomationModelsTests.swift
@@ -111,10 +111,34 @@ struct AgentAutomationModelsTests {
         #expect(agentAutomationHasSemanticChanges(job: job, draft: draft))
     }
 
-    @Test func `automation pagination requires a forward offset`() {
-        let page = CronJobsListLite(jobs: [], total: 201, hasMore: true, nextOffset: 200)
-        #expect(nextCronJobsListOffset(page: page, currentOffset: 0) == 200)
-        #expect(nextCronJobsListOffset(page: page, currentOffset: 200) == nil)
+    @Test @MainActor func `cron collector preserves snapshot order and normalized revision`() async throws {
+        let collected = await Self.collectCronPages([
+            Self.cronPage(["z", "a"], total: 3, revision: " rev-1 ", hasMore: true, nextOffset: 2),
+            Self.cronPage(["m"], total: 3, revision: "rev-1\n"),
+        ], maximumPageCount: 2)
+        let snapshot = try #require(collected.snapshot)
+
+        #expect(collected.offsets == [0, 2])
+        #expect(snapshot.jobs.map(\.id) == ["z", "a", "m"])
+        #expect(snapshot.snapshotRevision == "rev-1")
+        #expect(snapshot.total == 3)
+        #expect(!snapshot.hasMore)
+        #expect(snapshot.nextOffset == nil)
+    }
+
+    @Test @MainActor func `cron collector accepts empty advancing pages and absent identity`() async throws {
+        let collected = await Self.collectCronPages([
+            Self.cronPage(revision: " \n", hasMore: true, nextOffset: 3),
+            Self.cronPage(["a"], nextOffset: 99),
+        ])
+        let snapshot = try #require(collected.snapshot)
+
+        #expect(collected.offsets == [0, 3])
+        #expect(snapshot.jobs.map(\.id) == ["a"])
+        #expect(snapshot.snapshotRevision == nil)
+        #expect(snapshot.total == nil)
+        #expect(!snapshot.hasMore)
+        #expect(snapshot.nextOffset == nil)
     }
 
     @Test func `legacy cron list defaults to a single page`() throws {
@@ -126,33 +150,99 @@ struct AgentAutomationModelsTests {
         #expect(page.nextOffset == nil)
     }
 
-    @Test func `automation pagination pins total and snapshot revision`() throws {
-        let first = try JSONDecoder().decode(
-            CronJobsListLite.self,
-            from: Data(#"{"jobs":[],"snapshotRevision":" rev-1 ","total":201,"hasMore":true,"nextOffset":200}"#.utf8))
-        let changedRevision = CronJobsListLite(
-            jobs: [],
-            snapshotRevision: "rev-2",
-            total: 201,
-            hasMore: false,
-            nextOffset: nil)
-        let changedTotal = CronJobsListLite(
-            jobs: [],
-            snapshotRevision: "rev-1",
-            total: 200,
-            hasMore: false,
-            nextOffset: nil)
+    @Test @MainActor func `cron collector rejects snapshot identity changes including missing values`() async {
+        let cases: [(name: String, firstTotal: Int?, firstRevision: String?, total: Int?, revision: String?)] = [
+            ("revision changes", 2, "rev-1", 2, "rev-2"),
+            ("revision appears", 2, nil, 2, "rev-1"),
+            ("revision disappears", 2, "rev-1", 2, nil),
+            ("total changes", 2, "rev-1", 3, "rev-1"),
+            ("total appears", nil, nil, 2, nil),
+            ("total disappears", 2, nil, nil, nil),
+        ]
+        for scenario in cases {
+            let collected = await Self.collectCronPages([
+                Self.cronPage(
+                    ["a"], total: scenario.firstTotal, revision: scenario.firstRevision,
+                    hasMore: true, nextOffset: 1),
+                Self.cronPage(["b"], total: scenario.total, revision: scenario.revision),
+            ])
+            #expect(collected.snapshot == nil, "\(scenario.name)")
+            #expect(collected.offsets == [0, 1], "\(scenario.name)")
+        }
+    }
 
-        let identity = try #require(cronJobsSnapshotIdentity(page: first, maximumCount: 20000))
-        #expect(identity == CronJobsSnapshotIdentity(total: 201, revision: "rev-1"))
-        #expect(cronJobsSnapshotIdentity(page: changedRevision, maximumCount: 20000) != identity)
-        #expect(cronJobsSnapshotIdentity(page: changedTotal, maximumCount: 20000) != identity)
+    @Test @MainActor func `cron collector rejects duplicate rows count contradictions and missing pages`() async {
+        let first = Self.cronPage(["a"], hasMore: true, nextOffset: 1)
+        let cases: [(name: String, pages: [CronJobsListLite?], offsets: [Int])] = [
+            ("duplicate within page", [Self.cronPage(["a", "a"])], [0]),
+            ("duplicate across pages", [first, Self.cronPage(["a"])], [0, 1]),
+            ("negative total", [Self.cronPage(total: -1)], [0]),
+            ("total below collected count", [Self.cronPage(["a", "b"], total: 1)], [0]),
+            ("more after exact total", [Self.cronPage(["a"], total: 1, hasMore: true, nextOffset: 1)], [0]),
+            ("page exceeds job budget", [Self.cronPage(["a", "b", "c", "d"])], [0]),
+            ("aggregate exceeds job budget", [
+                Self.cronPage(["a", "b"], hasMore: true, nextOffset: 2), Self.cronPage(["c", "d"]),
+            ], [0, 2]),
+            ("first fetch unavailable", [nil], [0]),
+            ("later fetch unavailable", [first, nil], [0, 1]),
+        ]
+        for scenario in cases {
+            let collected = await Self.collectCronPages(scenario.pages)
+            #expect(collected.snapshot == nil, "\(scenario.name)")
+            #expect(collected.offsets == scenario.offsets, "\(scenario.name)")
+        }
+    }
 
-        let legacyTerminal = try JSONDecoder().decode(
-            CronJobsListLite.self,
-            from: Data(#"{"jobs":[]}"#.utf8))
-        #expect(cronJobsSnapshotIdentity(page: legacyTerminal, maximumCount: 20000) ==
-            CronJobsSnapshotIdentity(total: nil, revision: nil))
+    @Test @MainActor func `cron collector rejects missing nonadvancing and over-budget offsets`() async {
+        let firstOffsets: [Int?] = [nil, -1, 0, 4]
+        for nextOffset in firstOffsets {
+            let collected = await Self.collectCronPages([
+                Self.cronPage(["a"], hasMore: true, nextOffset: nextOffset),
+            ])
+            #expect(collected.snapshot == nil)
+            #expect(collected.offsets == [0])
+        }
+        for nextOffset in [0, 1, 2] {
+            let collected = await Self.collectCronPages([
+                Self.cronPage(["a"], hasMore: true, nextOffset: 2),
+                Self.cronPage(["b"], hasMore: true, nextOffset: nextOffset),
+            ])
+            #expect(collected.snapshot == nil)
+            #expect(collected.offsets == [0, 2])
+        }
+    }
+
+    @Test @MainActor func `cron collector preserves terminal metadata at each caller budget`() async throws {
+        let empty = await Self.collectCronPages([Self.cronPage(total: 0)])
+        #expect(empty.offsets == [0])
+        #expect(empty.snapshot?.jobs.isEmpty == true)
+        #expect(empty.snapshot?.total == 0)
+
+        for limits in [(pages: 5, jobs: 1000), (pages: 100, jobs: 20000)] {
+            var pages: [CronJobsListLite?] = (1...limits.pages).map {
+                Self.cronPage(total: limits.jobs, hasMore: true, nextOffset: $0)
+            }
+            let exhausted = await Self.collectCronPages(
+                pages, maximumPageCount: limits.pages, maximumJobCount: limits.jobs)
+            #expect(exhausted.snapshot == nil)
+            #expect(exhausted.offsets == Array(0..<limits.pages))
+
+            pages[limits.pages - 1] = Self.cronPage(["a"], total: limits.jobs)
+            let completed = await Self.collectCronPages(
+                pages, maximumPageCount: limits.pages, maximumJobCount: limits.jobs)
+            let snapshot = try #require(completed.snapshot)
+            #expect(completed.offsets == Array(0..<limits.pages))
+            #expect(snapshot.jobs.map(\.id) == ["a"])
+            #expect(snapshot.total == nil)
+            #expect(!snapshot.hasMore)
+            #expect(snapshot.nextOffset == nil)
+
+            let oversized = await Self.collectCronPages(
+                [Self.cronPage(total: limits.jobs + 1)],
+                maximumPageCount: limits.pages, maximumJobCount: limits.jobs)
+            #expect(oversized.snapshot == nil)
+            #expect(oversized.offsets == [0])
+        }
     }
 
     @Test func `automation editor selection preserves tapped snapshot`() {
@@ -217,13 +307,47 @@ struct AgentAutomationModelsTests {
                 "presentAutomationEditor(\n                    job: job,\n                    sourceGatewayID: sourceGatewayID"))
     }
 
+    @MainActor
+    private static func collectCronPages(
+        _ pages: [CronJobsListLite?],
+        maximumPageCount: Int = 3,
+        maximumJobCount: Int = 3) async -> (snapshot: CronJobsListLite?, offsets: [Int])
+    {
+        var offsets: [Int] = []
+        let snapshot = await CronJobsListLite.collect(
+            maximumPageCount: maximumPageCount,
+            maximumJobCount: maximumJobCount)
+        { offset in
+            let index = offsets.count
+            offsets.append(offset)
+            return index < pages.count ? pages[index] : nil
+        }
+        return (snapshot, offsets)
+    }
+
+    private static func cronPage(
+        _ ids: [String] = [],
+        total: Int? = nil,
+        revision: String? = nil,
+        hasMore: Bool = false,
+        nextOffset: Int? = nil) -> CronJobsListLite
+    {
+        CronJobsListLite(
+            jobs: ids.map { Self.job(id: $0) },
+            snapshotRevision: revision,
+            total: total,
+            hasMore: hasMore,
+            nextOffset: nextOffset)
+    }
+
     private static func job(
+        id: String = "release-briefing",
         payload: AnyCodable? = nil,
         schedule: AnyCodable? = nil,
         deleteAfterRun: Bool = false) -> CronJob
     {
         CronJob(
-            id: "release-briefing",
+            id: id,
             name: "Release briefing",
             description: "Daily mobile release overview",
             enabled: true,


### PR DESCRIPTION
Closes #139322

## What Problem This Solves

The iOS sidebar and agent overview independently maintain the same cron snapshot pagination rules. Updating either copy can leave the two screens with different handling of concurrent changes, duplicate rows or incomplete results. This is maintainer-requested consolidation; no existing iOS pagination defect is claimed.

## Why This Change Was Made

Both callers now use one collector on `CronJobsListLite`. It validates the complete snapshot and preserves server order, while each caller retains its request construction, timeout, retry and publication ownership. The copied loops and free internal predicates are removed; one ID set also replaces separate per-page and accumulated duplicate checks.

Production changes are +57/−101 (**−44 lines**). Tests are +156/−32 (**+124 lines**), replacing two predicate tests with six fetch-driven tests covering 31 scenarios. The legacy decoder and 11 unrelated test bodies are unchanged.

## User Impact

Behavior remains unchanged: the sidebar permits five pages/1,000 jobs, and the overview permits 100 pages/20,000 jobs with three whole-snapshot attempts. Both retain 200-row requests and 12-second RPC timeouts. Changed snapshots and invalid or incomplete walks still return nil; existing early-terminal and empty-advancing-page behavior is preserved.

This changes no configuration, persisted data, schema, Gateway protocol or UI appearance.

## Evidence

- Existing app-hosted baseline: 85 tests passed, with zero failures or skips, using a fresh owned iOS simulator and verified signed host/test bundles.
- Final candidate simulator run: **89 tests passed**, zero failures or skips (18 automation-model tests and 71 sidebar/presentation tests). The fresh iOS simulator used verified signed app/test bundles and was deleted after execution.
- Source-extracted Swift comparison: 161,017 deterministic page sequences at both original caller budgets yielded **322,034 matching old/new comparisons**, plus 16 independent expected-result checks. It compares results and requested offsets; this is algorithm evidence, not app or network execution.
- All 13 classified apps checks passed, including Swift lint and the native schema guard. Independent peer review and all three managed Codex review partitions found no accepted P0–P2 findings.

Committed head: `104ff35ab890602543179a88eadd661fb7a4ceeb`, based on `ac53dc9687cae714e648791268573ad2e00278ea`. The commit matches the verified four-file patch SHA-256: `d9d022a9eea95a3da25b201f14d3c51f6cc34ed9ead46edad6c6af27f3469c2a`. Local execution logs, exact source manifests and algorithm comparison artifacts are retained.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33988252937) passed all nine selected jobs with no failures or reruns, including Release/test builds and iPhone, iPad and Apple Watch captures. Its actual tested merge is `67b3f985b6d0f62ca7814585b32897267b7005c1`, combining main `de2c4b1768d9babd158c49d83aa91b67eff50dbc` with this head. The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/139335#issuecomment-5554394158) has no findings or before-merge actions.
