### PR TITLE
refactor(test): preserve typed Tlon mock-call assertions

### DIFF
--- a/extensions/tlon/src/urbit/sse-client.test.ts
+++ b/extensions/tlon/src/urbit/sse-client.test.ts
@@ -1,5 +1,6 @@
 // Tlon tests cover sse client plugin behavior.
 import { Readable } from "node:stream";
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ensureUrbitChannelOpen } from "./channel-ops.js";
@@ -17,14 +18,6 @@ vi.mock("./channel-ops.js", () => ({
   pokeUrbitChannel: vi.fn().mockResolvedValue(undefined),
   scryUrbitPath: vi.fn().mockResolvedValue({}),
 }));
-
-function requireFirstMockCall(calls: readonly unknown[][], label: string): unknown[] {
-  const call = calls.at(0);
-  if (!call) {
-    throw new Error(`Expected ${label} call`);
-  }
-  return call;
-}
 
 describe("UrbitSSEClient", () => {
   beforeEach(() => {
@@ -56,9 +49,7 @@ describe("UrbitSSEClient", () => {
       });
 
       expect(mockUrbitFetch).toHaveBeenCalledTimes(1);
-      const callArgs = requireFirstMockCall(mockUrbitFetch.mock.calls, "urbit fetch")[0] as
-        | Parameters<typeof urbitFetch>[0]
-        | undefined;
+      const [callArgs] = expectDefined(mockUrbitFetch.mock.calls.at(0), "urbit fetch call");
       if (!callArgs) {
         throw new Error("Expected urbit fetch arguments");
       }
@@ -303,9 +294,7 @@ describe("UrbitSSEClient", () => {
 
       expect(client.channelId).toBe(channelId);
       expect(onReconnect).toHaveBeenCalledOnce();
-      const callArgs = requireFirstMockCall(mockUrbitFetch.mock.calls, "stream reconnect")[0] as
-        | Parameters<typeof urbitFetch>[0]
-        | undefined;
+      const [callArgs] = expectDefined(mockUrbitFetch.mock.calls.at(0), "stream reconnect call");
       expect(callArgs?.path).toBe(`/~/channel/${channelId}`);
       expect(callArgs?.init?.method).toBe("GET");
       expect(client.reconnectAttempts).toBe(0);


### PR DESCRIPTION
## What Problem This Solves

The Tlon SSE tests erase typed mock-call tuples in a local lookup helper, then cast two results back to the fetch function's parameters. This maintainer-requested cleanup removes that round trip without deleting coverage.

## Why This Change Was Made

Use the existing SDK `expectDefined` guard on the first recorded call and destructure its typed argument tuple. Missing calls still fail with context. The subscription argument guard and reconnect field assertions remain unchanged.

## User Impact

No user-visible behavior change. Production code is unchanged; tests are +3/-14 lines. All 32 SSE cases and 81 expectations remain, including subscription requests, same-channel replay, durable admission before ACK, failed-ACK retry, stream bounds, UTF-8 handling and cleanup.

## Evidence

- Complete selected runs passed before and after: 32 SSE cases, two reconnect-close cases and four normalization-helper cases, with identical ordered inventories. The normalization cases cover their own implementation and are not presented as direct SDK guard coverage.
- The normal selected local changed-file gate passed all 19 checks, including plugin test types, all three dead-export scans and lint.
- Two-pass managed Codex review found no actionable P0-P2 issues; source and index stayed unchanged.
- The target, runtime owners and SDK guard still match the tested baseline on main at `4e217930a68a12586f0dd215a68f714958a02970`. Current tooling and lockfiles have advanced, so the local checks remain proof for base `185ca0df6328de3b27a56de083a0a8e9df2a0871`; fresh hosted CI is required before landing.

No live Tlon service behavior is changed or claimed. A separate test-value follow-up is outside this helper-only patch.
