### PR TITLE
fix(config): preserve sensitivity and URL redaction metadata

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -817,6 +817,14 @@ the channel root and under `accounts.<id>`. A channel that declares its own
 wording is wrong for your provider. Provider-specific keys such as credentials,
 hosts, and webhooks still need their own hints.
 
+When multiple plugins declare the same channel, the selected plugin owns its
+schema and presentation hints. Redaction preserves `sensitive: true` and
+`tags: ["url-secret"]` declarations from every discovered owner, so credentials
+left in config stay protected after switching plugins. The `url-secret` tag
+protects credentials embedded in URLs while leaving public URLs visible.
+Setting `sensitive: false` disables name-based secret detection, but does not
+override another owner's positive declaration or URL credential protection.
+
 ## contracts reference
 
 Use `contracts` only for static capability ownership metadata that OpenClaw can read without importing the plugin runtime.

--- a/src/config/channel-config-metadata.test.ts
+++ b/src/config/channel-config-metadata.test.ts
@@ -1,7 +1,6 @@
-// Verifies channel config metadata collection stays total on untrusted manifest schemas.
-
 import { describe, expect, it } from "vitest";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import { createPluginManifestRecordFixture } from "../plugins/plugin-metadata.test-support.js";
 import { collectChannelSchemaMetadataWithOwnership } from "./channel-config-metadata.js";
 
 function createChannelSchemaRegistry(
@@ -30,6 +29,79 @@ function createChannelSchemaRegistry(
 }
 
 describe("collectChannelSchemaMetadataWithOwnership", () => {
+  it.each(
+    ["core", "plus", undefined].flatMap((selected) =>
+      [false, true].map((reverse) => ({ selected, reverse })),
+    ),
+  )(
+    "preserves every owner's sensitivity with $selected selected and reverse=$reverse",
+    ({ selected, reverse }) => {
+      const schema = {
+        type: "object",
+        properties: { core: { type: "string" }, plus: { type: "string" } },
+      };
+      const registry = {
+        diagnostics: [],
+        plugins: ["core", "plus"].map((id) =>
+          createPluginManifestRecordFixture({
+            id,
+            origin: "global",
+            channels: ["proofchat"],
+            channelConfigs: {
+              proofchat: {
+                schema,
+                label: id,
+                uiHints: {
+                  [id]: { sensitive: true, label: id },
+                  [id === "core" ? "plus" : "core"]: {
+                    sensitive: false,
+                    label: "selected presentation",
+                  },
+                  [id === "core" ? " .endpoint " : "endpoint"]: {
+                    sensitive: false,
+                    tags: id === "core" ? ["url-secret", "inactive-tag"] : ["selected-tag"],
+                    label: id,
+                  },
+                  [`accounts.*.${id}`]: { sensitive: true },
+                  [`entries[].${id}`]: { sensitive: true },
+                  [id === "core" ? " .shared " : "shared"]: { sensitive: id === "core", label: id },
+                },
+              },
+            },
+          }),
+        ),
+      };
+      if (reverse) {
+        registry.plugins.reverse();
+      }
+      const before = structuredClone(registry);
+      const owner = selected ?? registry.plugins.at(-1)?.id;
+      const channels = collectChannelSchemaMetadataWithOwnership(
+        registry,
+        selected ? new Set([selected]) : undefined,
+      );
+      expect(channels[0]).toMatchObject({ label: owner, schemaPluginId: owner });
+      expect(channels[0]?.configSchema?.properties).toMatchObject(schema.properties);
+      const hints = channels[0]?.configUiHints;
+      for (const path of [
+        "core",
+        "plus",
+        "shared",
+        "accounts.*.core",
+        "accounts.*.plus",
+        "entries[].core",
+        "entries[].plus",
+      ]) {
+        expect(hints?.[path]?.sensitive, path).toBe(true);
+      }
+      expect(hints?.endpoint).toMatchObject({ sensitive: false, label: owner });
+      expect(hints?.endpoint?.tags).toEqual(
+        owner === "core" ? ["url-secret", "inactive-tag"] : ["selected-tag", "url-secret"],
+      );
+      expect(registry).toEqual(before);
+    },
+  );
+
   // Non-bundled channel schemas are cloned and recursively walked here, before any validator
   // runs, so this producer is where a deeply nested manifest has to be contained; otherwise
   // config validation dies with a raw RangeError instead of reporting an issue. "feishu" takes

--- a/src/config/channel-config-metadata.ts
+++ b/src/config/channel-config-metadata.ts
@@ -2,6 +2,10 @@
  * Converts plugin manifest metadata into deterministic config UI metadata for docs, validation, and runtime schema.
  * When multiple plugin origins expose the same id/channel, the closest origin owns the surfaced schema.
  */
+import {
+  hasSensitiveUrlHintTag,
+  SENSITIVE_URL_HINT_TAG,
+} from "@openclaw/net-policy/redact-sensitive-url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
@@ -258,7 +262,39 @@ export function collectChannelSchemaMetadataWithOwnership(
 
   return [...byChannelId.values()]
     .toSorted((left, right) => left.id.localeCompare(right.id))
-    .map(({ originRank: _originRank, ...entry }) => entry);
+    .map(({ originRank: _originRank, ...entry }) => {
+      const configUiHints = Object.fromEntries(
+        Object.entries(entry.configUiHints ?? {}).map(([path, hint]) => [
+          path.trim().replace(/^\./, ""),
+          hint,
+        ]),
+      );
+      // Switching owners does not remove the previous owner's credentials.
+      // Keep sensitivity declarations while the selected owner supplies presentation and schema.
+      for (const record of registry.plugins) {
+        for (const [rawPath, hint] of Object.entries(
+          record.channelConfigs?.[entry.id]?.uiHints ?? {},
+        )) {
+          const path = rawPath.trim().replace(/^\./, "");
+          const sensitiveUrl = hasSensitiveUrlHintTag(hint);
+          if (!path || (hint.sensitive !== true && !sensitiveUrl)) {
+            continue;
+          }
+          const current = configUiHints[path];
+          configUiHints[path] = {
+            ...current,
+            ...(hint.sensitive === true ? { sensitive: true } : {}),
+            ...(sensitiveUrl
+              ? { tags: [...new Set([...(current?.tags ?? []), SENSITIVE_URL_HINT_TAG])] }
+              : {}),
+          };
+        }
+      }
+      if (Object.keys(configUiHints).length) {
+        entry.configUiHints = configUiHints;
+      }
+      return entry;
+    });
 }
 
 /** Collects public per-channel config UI metadata without internal schema ownership. */

--- a/src/config/redact-snapshot.restore.test.ts
+++ b/src/config/redact-snapshot.restore.test.ts
@@ -247,6 +247,39 @@ describe("restoreRedactedValues", () => {
     expect(result.humanReadableMessage).toContain("Reserved redaction sentinel");
   });
 
+  it.each<{ name: string; field: string; hints: ConfigUiHints }>([
+    {
+      name: "known URL path marked non-sensitive",
+      field: "baseUrl",
+      hints: { "channels.proofchat.baseUrl": { sensitive: false } },
+    },
+    {
+      name: "URL hint marked non-sensitive",
+      field: "endpoint",
+      hints: { "channels.proofchat.endpoint": { sensitive: false, tags: ["url-secret"] } },
+    },
+    {
+      name: "wildcard URL hint marked non-sensitive",
+      field: "endpoint",
+      hints: { "channels.proofchat.*": { sensitive: false, tags: ["url-secret"] } },
+    },
+  ])("round-trips redacted URLs with $name", ({ field, hints }) => {
+    const original = {
+      channels: { proofchat: { [field]: "https://example.test/v1?token=synthetic-query" } },
+    };
+    const redacted = redactConfigSnapshot(makeSnapshot(original), hints);
+    expect(redacted.config).toEqual({ channels: { proofchat: { [field]: REDACTED_SENTINEL } } });
+    expect(restoreRedactedValues_orig(redacted.config, original, hints)).toEqual({
+      ok: true,
+      result: original,
+    });
+    const safe = { channels: { proofchat: { [field]: "https://example.test/v1" } } };
+    expect(redactConfigSnapshot(makeSnapshot(safe), hints).config).toEqual(safe);
+    expect(
+      restoreRedactedValues_orig(redacted.config, { channels: { proofchat: {} } }, hints).ok,
+    ).toBe(false);
+  });
+
   it("restores array items using wildcard uiHints", () => {
     const hints: ConfigUiHints = {
       "channels.slack.accounts[].botToken": { sensitive: true },

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -41,10 +41,7 @@ function isWholeObjectSensitivePath(path: string): boolean {
 }
 
 function hasSensitiveUrlHintPath(hints: ConfigUiHints | undefined, paths: string[]): boolean {
-  if (!hints) {
-    return false;
-  }
-  return paths.some((path) => hasSensitiveUrlHintTag(hints[path]));
+  return paths.some((path) => hasSensitiveUrlHintTag(hints?.[path]));
 }
 
 function collectSensitiveStrings(value: unknown, values: string[]): void {
@@ -75,10 +72,7 @@ function collectSensitiveStrings(value: unknown, values: string[]): void {
 }
 
 function isExplicitlyNonSensitivePath(hints: ConfigUiHints | undefined, paths: string[]): boolean {
-  if (!hints) {
-    return false;
-  }
-  return paths.some((path) => hints[path]?.sensitive === false);
+  return paths.some((path) => hints?.[path]?.sensitive === false);
 }
 
 /**
@@ -615,44 +609,29 @@ function restoreRedactedValue(
     const candidate = context.lookup
       ? [path, wildcardPath].find((entry) => context.lookup?.has(entry))
       : undefined;
-    if (candidate) {
-      if (
-        value === REDACTED_SENTINEL &&
-        (context.hints?.[candidate]?.sensitive === true ||
-          hasSensitiveUrlHintPath(context.hints, [candidate, path, wildcardPath]) ||
-          isSensitiveUrlConfigPath(path))
-      ) {
-        result[key] = restoreOriginalValueOrThrow(orig, key, candidate, context);
-      } else if (typeof value === "object" && value !== null) {
-        const restoredSecretRef = maybeRestoreSecretRefId({
-          incoming: value,
-          original: orig[key],
-          path,
-        });
-        result[key] = restoredSecretRef.handled
-          ? restoredSecretRef.value
-          : restoreRedactedValue(value, orig[key], candidate, context);
-      } else {
-        result[key] = value;
-      }
-      continue;
-    }
-
     const hintPaths = [path, wildcardPath];
+    // Match redaction: explicit false disables name guessing, not URL credential protection.
     const canRestore =
-      !isExplicitlyNonSensitivePath(context.hints, hintPaths) &&
-      (isSensitivePath(path) ||
-        hasSensitiveUrlHintPath(context.hints, hintPaths) ||
-        isSensitiveUrlConfigPath(path));
+      (candidate
+        ? context.hints?.[candidate]?.sensitive === true
+        : !isExplicitlyNonSensitivePath(context.hints, hintPaths) && isSensitivePath(path)) ||
+      hasSensitiveUrlHintPath(context.hints, hintPaths) ||
+      isSensitiveUrlConfigPath(path);
     if (value === REDACTED_SENTINEL && canRestore) {
-      result[key] = restoreOriginalValueOrThrow(orig, key, path, context);
+      result[key] = restoreOriginalValueOrThrow(orig, key, candidate ?? path, context);
     } else if (typeof value === "object" && value !== null) {
-      const restoredSecretRef = canRestore
-        ? maybeRestoreSecretRefId({ incoming: value, original: orig[key], path })
-        : { handled: false as const };
+      const restoredSecretRef =
+        candidate || canRestore
+          ? maybeRestoreSecretRefId({ incoming: value, original: orig[key], path })
+          : { handled: false as const };
       result[key] = restoredSecretRef.handled
         ? restoredSecretRef.value
-        : restoreRedactedValue(value, orig[key], path, fallbackContext);
+        : restoreRedactedValue(
+            value,
+            orig[key],
+            candidate ?? path,
+            candidate ? context : fallbackContext,
+          );
     } else {
       result[key] = value;
     }

--- a/src/config/sensitive-paths.ts
+++ b/src/config/sensitive-paths.ts
@@ -16,12 +16,8 @@ const SENSITIVE_KEY_WHITELIST_SUFFIXES = [
   "tokencount",
   "tokenlimit",
   "tokenbudget",
-  "passwordFile",
+  "passwordfile",
 ] as const;
-
-const NORMALIZED_SENSITIVE_KEY_WHITELIST_SUFFIXES = SENSITIVE_KEY_WHITELIST_SUFFIXES.map((suffix) =>
-  normalizeLowercaseStringOrEmpty(suffix),
-);
 
 const SENSITIVE_PATTERNS = [
   /token$/i,
@@ -33,20 +29,6 @@ const SENSITIVE_PATTERNS = [
   /serviceaccount(?:ref)?$/i,
 ];
 
-function isWhitelistedSensitivePath(path: string): boolean {
-  const lowerPath = normalizeLowercaseStringOrEmpty(path);
-  return NORMALIZED_SENSITIVE_KEY_WHITELIST_SUFFIXES.some((suffix) => lowerPath.endsWith(suffix));
-}
-
-function matchesSensitivePattern(path: string): boolean {
-  return SENSITIVE_PATTERNS.some((pattern) => pattern.test(path));
-}
-
-function isLocalServiceEnvValuePath(path: string): boolean {
-  const lowerPath = normalizeLowercaseStringOrEmpty(path);
-  return lowerPath.includes("localservice.env.");
-}
-
 /**
  * Classifies config paths whose values should be redacted from UI/API output.
  *
@@ -54,9 +36,11 @@ function isLocalServiceEnvValuePath(path: string): boolean {
  * fields and raw local-service env vars get the same conservative treatment.
  */
 export function isSensitiveConfigPath(path: string): boolean {
+  const lowerPath = normalizeLowercaseStringOrEmpty(path);
   return (
     // Every local service env value is sensitive, even innocuous-looking names.
-    isLocalServiceEnvValuePath(path) ||
-    (!isWhitelistedSensitivePath(path) && matchesSensitivePattern(path))
+    lowerPath.includes("localservice.env.") ||
+    (!SENSITIVE_KEY_WHITELIST_SUFFIXES.some((suffix) => lowerPath.endsWith(suffix)) &&
+      SENSITIVE_PATTERNS.some((pattern) => pattern.test(path)))
   );
 }

--- a/src/gateway/config-get-response.test.ts
+++ b/src/gateway/config-get-response.test.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildRuntimeConfigSchemaFromRegistry } from "../config/runtime-schema.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 
 const mocks = vi.hoisted(() => ({
   appliedConfigHash: "applied-1" as string | null,
@@ -76,6 +78,61 @@ afterEach(() => {
 });
 
 describe("config.get response cache", () => {
+  it.each(["core", "plus"])(
+    "redacts retained owner credentials from every snapshot projection with %s selected",
+    async (owner) => {
+      const config: OpenClawConfig = {
+        plugins: {
+          entries: { core: { enabled: owner === "core" }, plus: { enabled: owner === "plus" } },
+        },
+        channels: {
+          proofchat: { core: "synthetic-core", plus: "synthetic-plus", visible: "public-setting" },
+        },
+      };
+      const { manifestRegistry } = createPluginMetadataSnapshotFixture({
+        plugins: ["core", "plus"].map((id) => ({
+          id,
+          origin: "config",
+          channels: ["proofchat"],
+          channelConfigs: {
+            proofchat: {
+              schema: {
+                type: "object",
+                properties: { [id]: { type: "string" } },
+              },
+              uiHints: { [id]: { sensitive: true } },
+            },
+          },
+        })),
+      });
+      mocks.readConfigFileSnapshot.mockResolvedValue(configSnapshot(config));
+      const response = await readConfigGetResponse({
+        loadUiHints: () => buildRuntimeConfigSchemaFromRegistry(manifestRegistry, config).uiHints,
+      });
+      const output = JSON.stringify(response);
+      expect(output).not.toContain("synthetic-core");
+      expect(output).not.toContain("synthetic-plus");
+      for (const field of [
+        "config",
+        "sourceConfig",
+        "runtimeConfig",
+        "parsed",
+        "resolved",
+      ] as const) {
+        expect(response[field]).toMatchObject({
+          channels: {
+            proofchat: {
+              core: "__OPENCLAW_REDACTED__",
+              plus: "__OPENCLAW_REDACTED__",
+              visible: "public-setting",
+            },
+          },
+        });
+      }
+      expect(response.raw).toContain("public-setting");
+    },
+  );
+
   it("serves identical bytes without filesystem work on an active-watcher cache hit", async () => {
     const loadUiHints = vi.fn(() => undefined);
     const first = await readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints });

--- a/src/system-agent/config-redaction.test.ts
+++ b/src/system-agent/config-redaction.test.ts
@@ -191,51 +191,61 @@ describe("isSystemAgentSensitiveConfigPathEmbedding", () => {
 });
 
 describe("redactSystemAgentConfig", () => {
-  it("refreshes sensitive hints when config selects another owner in the same metadata snapshot", () => {
-    pluginMetadata?.restore();
-    const snapshot = createPluginMetadataSnapshotFixture({
-      plugins: ["core", "plus"].map((id) => ({
-        id,
-        origin: "config",
-        channels: ["proofchat"],
-        channelConfigs: {
-          proofchat: {
-            ...(id === "plus" ? { preferOver: ["core"] } : {}),
-            schema: {
-              type: "object",
-              properties: { core: { type: "string" }, plus: { type: "string" } },
+  it.each(["plus", "core"])(
+    "redacts retained owner credentials with %s selected first",
+    (first) => {
+      pluginMetadata?.restore();
+      const snapshot = createPluginMetadataSnapshotFixture({
+        plugins: ["core", "plus"].map((id) => ({
+          id,
+          origin: "config",
+          channels: ["proofchat"],
+          channelConfigs: {
+            proofchat: {
+              ...(id === "plus" ? { preferOver: ["core"] } : {}),
+              schema: {
+                type: "object",
+                properties: { core: { type: "string" }, plus: { type: "string" } },
+              },
+              uiHints: { [id]: { sensitive: true } },
             },
-            uiHints: { [id]: { sensitive: true } },
           },
-        },
-      })),
-    });
-    const preferred: OpenClawConfig = {
-      plugins: { entries: { plus: { enabled: true } } },
-      channels: { proofchat: { plus: "synthetic-plus" } },
-    };
-    const fallback: OpenClawConfig = {
-      plugins: { entries: { plus: { enabled: false }, core: { enabled: true } } },
-      channels: { proofchat: { core: "synthetic-core" } },
-    };
-    const lease = installTemporaryCurrentPluginMetadataSnapshot(snapshot, {
-      config: preferred,
-      compatibleConfigs: [preferred, fallback],
-    });
-    try {
-      for (const [config, owner] of [
-        [preferred, "plus"],
-        [fallback, "core"],
-        [preferred, "plus"],
-      ] as const) {
-        expect(redactSystemAgentConfig(config, { config })).toMatchObject({
-          channels: { proofchat: { [owner]: "<redacted>" } },
-        });
+        })),
+      });
+      const preferred: OpenClawConfig = {
+        plugins: { entries: { plus: { enabled: true } } },
+        channels: { proofchat: { plus: "synthetic-plus", core: "synthetic-core" } },
+      };
+      const fallback: OpenClawConfig = {
+        plugins: { entries: { plus: { enabled: false }, core: { enabled: true } } },
+        channels: { proofchat: { plus: "synthetic-plus", core: "synthetic-core" } },
+      };
+      const lease = installTemporaryCurrentPluginMetadataSnapshot(snapshot, {
+        config: preferred,
+        compatibleConfigs: [preferred, fallback],
+      });
+      try {
+        const configs =
+          first === "plus" ? ([preferred, fallback] as const) : ([fallback, preferred] as const);
+        for (const config of [...configs, configs[0]]) {
+          setRuntimeConfigSnapshot(config, config);
+          expect(redactSystemAgentConfig(config, { config })).toMatchObject({
+            channels: { proofchat: { plus: "<redacted>", core: "<redacted>" } },
+          });
+          for (const owner of ["core", "plus"]) {
+            expect(
+              isSystemAgentSensitiveConfigValue(`channels.proofchat.${owner}`, "synthetic"),
+            ).toBe(true);
+            expect(redactSystemAgentConfigPath(`channels.proofchat.${owner}.synthetic`)).toBe(
+              "<redacted path>",
+            );
+          }
+        }
+      } finally {
+        lease.release();
       }
-    } finally {
-      lease.release();
-    }
-  });
+    },
+  );
 
   it("fails closed for dynamic owner secrets when the exact config is invalid", () => {
     expect(

--- a/src/system-agent/config-redaction.ts
+++ b/src/system-agent/config-redaction.ts
@@ -76,8 +76,8 @@ const invalidConfigRedactionMetadata: SystemAgentConfigRedactionMetadata = {
   ...baseConfigRedactionMetadata,
   channelIds: new Set(),
 };
-// Inventory survives config reloads; owner-specific sensitive hints do not.
-// Bind cached redaction to both snapshots so a new owner cannot inherit stale hints.
+// Inventory survives config reloads; the selected channel schemas do not.
+// Bind cached redaction to both snapshots so path classification follows the current owner.
 const metadataConfigRedaction = new WeakMap<
   PluginMetadataSnapshot,
   WeakMap<object, SystemAgentConfigRedactionMetadata>


### PR DESCRIPTION
Related: #135868

Independent side-Gateway stage 1 of 3 in the #135868 split: concern F, config sensitivity and URL redaction metadata.

## What Problem This Solves

Fixes an issue where switching the plugin that owns a channel could expose credentials retained for another owner in Gateway config responses and system-agent reads. It also fixes config saves rejecting redacted credential-bearing URLs when their UI hint says `sensitive: false`.

## Why This Change Was Made

Channel metadata collection now preserves every discovered owner's positive sensitivity and `url-secret` declarations while the selected owner still supplies the schema, labels, and other presentation. URL restoration follows the same protection rule as redaction. The existing object-restoration branches and sensitivity-classifier helpers are consolidated without changing SecretRef or wildcard behavior.

The metadata producer is the common boundary for Gateway and system-agent consumers; duplicating protection in those consumers would leave schema and write-side restoration inconsistent. The manifest documentation now explains the contract.

## User Impact

Retained channel credentials stay redacted after owner changes. Public URLs remain visible, and credential-bearing URLs survive a config read/edit/save round trip. No new configuration, storage schema, dependency, or protocol changes.

## Evidence

- Reproduced on pre-fix main: all 6 metadata owner/order cases failed; both system-agent owner-switch cases exposed the inactive synthetic credential; all 3 non-sensitive URL restoration cases failed.
- Patched owner and neighbor proof: 329 tests passed across 13 suites covering metadata/schema selection, snapshot redaction/restoration, system-agent reads, Gateway config responses, and config-method write/auth neighbors. The finalized URL suite was rerun: 61 tests passed.
- Production: +63/-64, net **-1**. Tests: +216/-44, net **+172**, which is 16 lines smaller than this concern's source-branch test delta. Docs: +8; tooling: unchanged.
- Full `node scripts/check-changed.mjs` passed, including core/test typechecking, lint, config-doc and architecture guards, and all three Knip scans with zero entries.
- Final checkpoint/revert proof kept the committed tests and restored pre-fix production: 9 intended failures and 61 passes. Restoring the candidate returned the tree to the committed bytes.
- Fresh local and committed-branch Codex reviews are scoped-clean with no accepted/actionable P0/P1 findings. ClawSweeper reviewed the initial head with no findings or requested pre-merge/rank-up changes ([review](https://github.com/openclaw/openclaw/pull/139337#issuecomment-5554390878)); the subsequent main rebase has the same stable patch ID and a fresh scoped-clean Codex review. CI passed on initial head `32b40a7a44d` ([run](https://github.com/openclaw/openclaw/actions/runs/33988342906)); exact-head CI for rebased `5dc9f6ca2d7` passed ([run](https://github.com/openclaw/openclaw/actions/runs/33988907357)).

The exact introducing commit is not established; the defects were reproduced against the task's main baseline before production changes. This PR carries only the independently useful config concern from #135868; automatic recovery and Gateway cleanup authority remain in their owning stages.
