### PR TITLE
fix(whatsapp): stop leaking responsePrefix template into inbound body

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/message-line.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/message-line.ts
@@ -36,10 +36,12 @@ export function buildInboundLine(params: {
   visibleReplyTo?: WhatsAppReplyContext | null;
 }) {
   const { cfg, msg, agentId, previousTimestamp, envelope } = params;
-  // WhatsApp inbound prefix: channels.whatsapp.responsePrefix > identity/defaults.
+  // WhatsApp inbound prefix: identity name only. responsePrefix is an
+  // outbound template ({provider}/{model}) that has no value at inbound
+  // time — applying it raw leaked the literal template into the agent body.
   const messagePrefix = resolveMessagePrefix(cfg, agentId, {
-    configured: cfg.channels?.whatsapp?.responsePrefix,
     hasAllowFrom: (cfg.channels?.whatsapp?.allowFrom?.length ?? 0) > 0,
+    fallback: "",
   });
   const admission = requireWhatsAppInboundAdmission(msg);
   const conversationId = admission.conversation.id;

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -811,9 +811,9 @@ describe("buildInboundLine", () => {
     expect(line).toContain("[/Replying]");
   });
 
-  it("applies the WhatsApp responsePrefix when configured", () => {
+  it("does not leak the WhatsApp responsePrefix template into the inbound body", () => {
     const line = buildInboundLine({
-      cfg: makeInboundCfg("[PFX]"),
+      cfg: makeInboundCfg("[{provider}/{model} | think:{think}]"),
       agentId: "main",
       msg: createDirectMessage({
         admission: {
@@ -827,7 +827,12 @@ describe("buildInboundLine", () => {
       envelope: { includeTimestamp: false },
     });
 
-    expect(line).toContain("[PFX] ping");
+    // The responsePrefix is an outbound-only template; the inbound body
+    // must be the sender's plain message.
+    expect(line).not.toContain("{provider}");
+    expect(line).not.toContain("{model}");
+    expect(line).not.toContain("{think}");
+    expect(line).toContain("ping");
   });
 
   it("normalizes direct from labels by stripping whatsapp: prefix", () => {


### PR DESCRIPTION
## What Problem This Solves

Closes #138779

`channels.whatsapp.responsePrefix` is an **outbound** template (e.g. `[{provider}/{model} | think:{think}]`) rendered with the selected model when the reply is sent. But `buildInboundLine` in `extensions/whatsapp/src/auto-reply/monitor/message-line.ts` was passing it as the `configured` prefix for the **inbound** line — the message coming FROM the user.

At inbound time the provider/model/think values aren't known yet, so the template was prepended **raw** (literal `{provider}/{model}/{think}`) to every inbound WhatsApp message. The agent saw the template ahead of every message, and it leaked into replies and history.

## Root Cause

`buildInboundLine` called `resolveMessagePrefix(cfg, agentId, { configured: cfg.channels?.whatsapp?.responsePrefix, ... })`. `resolveMessagePrefix` returns the `configured` value verbatim if set — it's a plain string passthrough, no template rendering. The raw template string was concatenated into the inbound body before the envelope wrapper.

## Fix

`buildInboundLine` now calls `resolveMessagePrefix` **without** the `configured` option and with `fallback: ""`. This means:
- The `responsePrefix` template is never applied to inbound messages.
- The agent identity name prefix (`[BotName]`) is still used when configured (it's a static string, not a template).
- The `[openclaw]` fallback is suppressed (empty string) so inbound bodies are clean.

`responsePrefix` remains an outbound-only concept, rendered when the reply is sent with the selected model.

## Evidence

**Before (buggy):** Inbound line with `responsePrefix = "[{provider}/{model} | think:{think}]"`:
```
[{provider}/{model} | think:{think}] ping
```
The model sees the literal template.

**After (fixed):** Same config, same inbound message:
```
ping
```
The inbound body is the sender's plain message.

**Test updated:** The existing test `"applies the WhatsApp responsePrefix when configured"` was **codifying the bug** — it asserted `line.toContain("[PFX] ping")`. It has been replaced with `"does not leak the WhatsApp responsePrefix template into the inbound body"` which uses the real-world template `[{provider}/{model} | think:{think}]` and asserts:
- `line` does NOT contain `{provider}`
- `line` does NOT contain `{model}`
- `line` does NOT contain `{think}`
- `line` DOES contain `ping` (the sender's body is preserved)

**Files changed:**
- `extensions/whatsapp/src/auto-reply/monitor/message-line.ts` (+4/-2): removed `configured` option, added `fallback: ""`, updated comment
- `extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts` (+8/-3): replaced bug-codifying test with regression guard
