### PR TITLE
fix(setup): verify and save provider starter aliases correctly

### DIFF
--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -141,7 +141,7 @@ so another provider can opt in without adding provider-specific macOS code.
 The manual key/token picker uses the same provider registry. In every route,
 the provider supplies its starter model and configuration. If the starter is an
 alias, OpenClaw tests and saves the provider's canonical model name while
-preserving its selected model settings. The credential is stored only after
+preserving existing model settings that the starter does not replace. The credential is stored only after
 that live test succeeds.
 Continuing remains locked until one backend has passed, so the first agent
 chat cannot start without working inference.

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -139,8 +139,10 @@ Gateway's active text-inference provider plugins rather than a fixed app list,
 so another provider can opt in without adding provider-specific macOS code.
 
 The manual key/token picker uses the same provider registry. In every route,
-the provider supplies its starter model and configuration; OpenClaw verifies
-the credential with the same live test before storing its auth profile.
+the provider supplies its starter model and configuration. If the starter is an
+alias, OpenClaw tests and saves the provider's canonical model name while
+preserving its selected model settings. The credential is stored only after
+that live test succeeds.
 Continuing remains locked until one backend has passed, so the first agent
 chat cannot start without working inference.
 </Step>

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -10,6 +10,7 @@ import {
   resolvePrimaryStringValue,
 } from "@openclaw/normalization-core/string-coerce";
 import { modelKey } from "../shared/model-key.js";
+import type { AgentModelEntryConfig } from "./types.agent-defaults.js";
 import type { AgentModelConfig, AgentToolModelConfig } from "./types.agents-shared.js";
 
 type AgentModelListLike = {
@@ -106,7 +107,12 @@ export function normalizeAgentModelSelectionForConfig(value: unknown): unknown {
   return next;
 }
 
-function mergeAgentModelEntryForConfig(existing: unknown, incoming: unknown): unknown {
+export function mergeAgentModelEntryForConfig(
+  existing: AgentModelEntryConfig | undefined,
+  incoming: AgentModelEntryConfig,
+): AgentModelEntryConfig;
+export function mergeAgentModelEntryForConfig(existing: unknown, incoming: unknown): unknown;
+export function mergeAgentModelEntryForConfig(existing: unknown, incoming: unknown): unknown {
   if (!isPlainRecord(existing) || !isPlainRecord(incoming)) {
     return incoming;
   }

--- a/src/system-agent/setup-inference-plan-helpers.ts
+++ b/src/system-agent/setup-inference-plan-helpers.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { findNormalizedProviderKey } from "@openclaw/model-catalog-core/provider-id";
 import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import type { AgentRunResultView } from "../agents/agent-run-result.js";
 import { listAgentEntries, resolveAmbientOwnerAgentId } from "../agents/agent-scope.js";
@@ -15,6 +16,7 @@ import {
 import { resolveProviderIdForAuth } from "../agents/provider-auth-aliases.js";
 import { buildAgentRuntimeAuthPlan } from "../agents/runtime-plan/auth.js";
 import { GEMINI_CLI_DEFAULT_MODEL_REF } from "../commands/onboard-inference.js";
+import { mergeAgentModelEntryForConfig } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderAuthResult } from "../plugins/types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -327,10 +329,11 @@ function copySelectedModelMetadata(params: {
 }): void {
   const key = params.targetModelRef;
   const defaultEntry = params.prepared.agents?.defaults?.models?.[params.modelRef];
-  // The projection owns a deep clone; only selected metadata crosses from the auth result.
+  // An alias can select an existing canonical row; unspecified settings must survive projection.
   if (defaultEntry !== undefined) {
     const defaults = ((params.target.agents ??= {}).defaults ??= {});
-    (defaults.models ??= {})[key] = structuredClone(defaultEntry);
+    const models = (defaults.models ??= {});
+    models[key] = mergeAgentModelEntryForConfig(models[key], structuredClone(defaultEntry));
   }
   const defaultAgentId = resolveAmbientOwnerAgentId(params.target, params.agentId);
   const preparedAgent = listAgentEntries(params.prepared).find(
@@ -341,25 +344,9 @@ function copySelectedModelMetadata(params: {
     ([agentId]) => normalizeAgentId(agentId) === defaultAgentId,
   )?.[1];
   if (selectedEntry !== undefined && targetAgent) {
-    (targetAgent.models ??= {})[key] = structuredClone(selectedEntry);
+    const models = (targetAgent.models ??= {});
+    models[key] = mergeAgentModelEntryForConfig(models[key], structuredClone(selectedEntry));
   }
-}
-
-function findSelectedProviderConfigKey(
-  config: OpenClawConfig,
-  providerId: string,
-): string | undefined {
-  const providers = config.models?.providers;
-  if (!providers) {
-    return undefined;
-  }
-  if (Object.hasOwn(providers, providerId)) {
-    return providerId;
-  }
-  const normalizedProvider = normalizeProviderId(providerId);
-  return Object.keys(providers).find(
-    (candidate) => normalizeProviderId(candidate) === normalizedProvider,
-  );
 }
 
 /**
@@ -393,7 +380,11 @@ export function projectManualInferenceConfig(params: {
     };
   }
 
-  const providerConfigKey = findSelectedProviderConfigKey(params.preparedConfig, params.providerId);
+  const providers = params.preparedConfig.models?.providers;
+  const providerConfigKey =
+    providers && Object.hasOwn(providers, params.providerId)
+      ? params.providerId
+      : findNormalizedProviderKey(providers, params.providerId);
   if (providerConfigKey) {
     const preparedProvider = params.preparedConfig.models?.providers?.[providerConfigKey];
     if (preparedProvider === undefined) {

--- a/src/system-agent/setup-inference-plan-helpers.ts
+++ b/src/system-agent/setup-inference-plan-helpers.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { expectDefined } from "@openclaw/normalization-core";
 import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import type { AgentRunResultView } from "../agents/agent-run-result.js";
 import { listAgentEntries, resolveAmbientOwnerAgentId } from "../agents/agent-scope.js";
@@ -289,6 +288,7 @@ export function prepareManualAuthForActivation(params: {
   profiles: ProviderAuthResult["profiles"];
   selectedProfileId: string;
   modelRef: string;
+  targetModelRef: string;
   providerId: string;
   pluginId?: string;
   agentId?: string;
@@ -322,49 +322,27 @@ function copySelectedModelMetadata(params: {
   target: OpenClawConfig;
   prepared: OpenClawConfig;
   modelRef: string;
+  targetModelRef: string;
   agentId?: string;
 }): void {
-  const preparedDefaultModels = params.prepared.agents?.defaults?.models;
-  if (preparedDefaultModels && Object.hasOwn(preparedDefaultModels, params.modelRef)) {
-    params.target.agents = {
-      ...params.target.agents,
-      defaults: {
-        ...params.target.agents?.defaults,
-        models: {
-          ...params.target.agents?.defaults?.models,
-          [params.modelRef]: structuredClone(
-            expectDefined(
-              preparedDefaultModels[params.modelRef],
-              "prepared default models entry at params.model ref",
-            ),
-          ),
-        },
-      },
-    };
+  const key = params.targetModelRef;
+  const defaultEntry = params.prepared.agents?.defaults?.models?.[params.modelRef];
+  // The projection owns a deep clone; only selected metadata crosses from the auth result.
+  if (defaultEntry !== undefined) {
+    const defaults = ((params.target.agents ??= {}).defaults ??= {});
+    (defaults.models ??= {})[key] = structuredClone(defaultEntry);
   }
-
   const defaultAgentId = resolveAmbientOwnerAgentId(params.target, params.agentId);
   const preparedAgent = listAgentEntries(params.prepared).find(
     (agent) => normalizeAgentId(agent.id) === defaultAgentId,
   );
-  if (!preparedAgent?.models || !Object.hasOwn(preparedAgent.models, params.modelRef)) {
-    return;
+  const selectedEntry = preparedAgent?.models?.[params.modelRef];
+  const targetAgent = Object.entries(params.target.agents?.entries ?? {}).find(
+    ([agentId]) => normalizeAgentId(agentId) === defaultAgentId,
+  )?.[1];
+  if (selectedEntry !== undefined && targetAgent) {
+    (targetAgent.models ??= {})[key] = structuredClone(selectedEntry);
   }
-  const targetEntryKey = Object.keys(params.target.agents?.entries ?? {}).find(
-    (agentId) => normalizeAgentId(agentId) === defaultAgentId,
-  );
-  if (!targetEntryKey || !params.target.agents?.entries?.[targetEntryKey]) {
-    return;
-  }
-  const nextEntries = structuredClone(params.target.agents.entries);
-  const targetAgent = expectDefined(nextEntries[targetEntryKey], "target agent entry");
-  targetAgent.models = {
-    ...targetAgent.models,
-    [params.modelRef]: structuredClone(
-      expectDefined(preparedAgent.models[params.modelRef], "models entry at params.model ref"),
-    ),
-  };
-  params.target.agents = { ...params.target.agents, entries: nextEntries };
 }
 
 function findSelectedProviderConfigKey(
@@ -395,6 +373,7 @@ export function projectManualInferenceConfig(params: {
   selectedProfile?: ProviderAuthResult["profiles"][number];
   selectedProfileId?: string;
   modelRef: string;
+  targetModelRef: string;
   providerId: string;
   pluginId?: string;
   agentId?: string;
@@ -445,6 +424,7 @@ export function projectManualInferenceConfig(params: {
     target: config,
     prepared: params.preparedConfig,
     modelRef: params.modelRef,
+    targetModelRef: params.targetModelRef,
     ...(params.agentId ? { agentId: params.agentId } : {}),
   });
   return config;

--- a/src/system-agent/setup-inference-plan.ts
+++ b/src/system-agent/setup-inference-plan.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveAmbientOwnerAgentId } from "../agents/agent-scope-config.js";
 import { resolveCliRuntimeCanonicalProvider } from "../agents/cli-backends.js";
 import type { CodexCliApiKeyCredential } from "../agents/cli-credentials.js";
@@ -25,7 +26,7 @@ import {
   type ProviderAuthChoiceMetadata,
 } from "../plugins/provider-auth-choices.js";
 import { resolvePluginProvidersCore } from "../plugins/providers.runtime.js";
-import type { ProviderAuthResult } from "../plugins/types.js";
+import type { ProviderAuthResult, ProviderPlugin } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createPluginCapabilityConsentPrompter } from "../wizard/plugin-capability-consent.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
@@ -59,16 +60,27 @@ function buildPreparedProviderTestPlan(params: {
   preparedConfig: OpenClawConfig;
   profiles: ProviderAuthResult["profiles"];
   selectedProfileId?: string;
+  providerPlugin?: ProviderPlugin;
   modelRef: string;
   pluginId?: string;
   routeAgentId: string;
   agentDir: string;
 }): SetupInferenceTestPlan {
   const ref = parseRef(params.modelRef);
+  // Auth starters are raw provider input; guided discovery already chose its canonical model.
+  ref.model =
+    normalizeOptionalString(
+      params.providerPlugin?.normalizeModelId?.({
+        provider: ref.provider,
+        modelId: ref.model,
+      }),
+    ) ?? ref.model;
+  const modelRef = `${ref.provider}/${ref.model}`;
   const projection = {
     baseConfig: params.cfg,
     preparedConfig: params.preparedConfig,
     modelRef: params.modelRef,
+    targetModelRef: modelRef,
     providerId: ref.provider,
     pluginId: params.pluginId,
     agentId: params.routeAgentId,
@@ -87,13 +99,13 @@ function buildPreparedProviderTestPlan(params: {
   return {
     runner: "embedded",
     ...ref,
-    modelRef: params.modelRef,
+    modelRef,
     agentDir: params.agentDir,
     config: prepared.config,
     agentId: "openclaw",
     routeAgentId: params.routeAgentId,
     ...(prepared.selectedProfileId ? { authProfileId: prepared.selectedProfileId } : {}),
-    persistModelRef: params.modelRef,
+    persistModelRef: modelRef,
     manualAuth: {
       profiles: prepared.profiles,
       runtimeConfigBase: params.cfg,
@@ -366,6 +378,7 @@ export async function buildTestPlan(params: {
           ],
           selectedProfileId: "openai:codex-cli-api-key",
           modelRef,
+          targetModelRef: modelRef,
           providerId: ref.provider,
           agentId: routeAgentId,
         });
@@ -663,6 +676,9 @@ export async function buildTestPlan(params: {
         selectedProfileId: matchingProfile?.profileId,
         modelRef,
         pluginId: resolved.provider.pluginId,
+        ...(interactive && choice.appGuidedDiscovery === true
+          ? {}
+          : { providerPlugin: resolved.provider }),
         agentDir: params.agentDir,
         routeAgentId,
       });

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -3303,21 +3303,61 @@ describe("activateSetupInference", () => {
   });
 
   it.each([
-    { name: "API-key", authKind: "api_key" as const, credentialType: "api_key" as const },
-    { name: "token", authKind: "token" as const, credentialType: "token" as const },
+    {
+      name: "API-key",
+      authKind: "api_key" as const,
+      credentialType: "api_key" as const,
+      metadata: "fresh",
+    },
+    {
+      name: "token",
+      authKind: "token" as const,
+      credentialType: "token" as const,
+      metadata: "existing",
+    },
+    {
+      name: "API-key",
+      authKind: "api_key" as const,
+      credentialType: "api_key" as const,
+      metadata: "empty starter",
+    },
   ])(
-    "uses a provider-owned $name method and persists it after a passing test",
-    async ({ authKind, credentialType }) => {
+    "uses a provider-owned $name method with $metadata metadata after a passing test",
+    async ({ authKind, credentialType, metadata }) => {
       const stateDir = await suiteTempRootTracker.make("case");
       const agentDir = path.join(stateDir, "agent");
-      const initialConfig = {
-        agents: { list: [{ id: "main", default: true, agentDir }] },
+      const selectedModel = "canonical-fixture-model";
+      const selectedModelRef = `groq/${selectedModel}`;
+      const existingDefault =
+        metadata === "fresh"
+          ? {}
+          : { streaming: true, params: { temperature: 0.7, maxTokens: 256 } };
+      const existingAgent =
+        metadata === "fresh" ? {} : { codeMode: false, params: { temperature: 0.8, topP: 0.6 } };
+      const selectedMetadata =
+        metadata === "empty starter"
+          ? {}
+          : { alias: "selected-fixture", params: { temperature: 0.2 } };
+      const selectedAgentMetadata =
+        metadata === "empty starter" ? {} : { params: { temperature: 0.3 } };
+      const initialConfig: OpenClawConfig = {
+        agents: {
+          defaults: { models: metadata === "fresh" ? {} : { [selectedModelRef]: existingDefault } },
+          list: [
+            {
+              id: "main",
+              default: true,
+              agentDir,
+              models: metadata === "fresh" ? {} : { [selectedModelRef]: existingAgent },
+            },
+          ],
+        },
         auth: {
           profiles: {
             "groq:legacy": { provider: "groq", mode: credentialType },
           },
         },
-      } satisfies OpenClawConfig;
+      };
       // Custom agent directories must be bound to their configured owner before
       // the shared per-agent database is created.
       resolveAgentDir(initialConfig, "main");
@@ -3331,9 +3371,6 @@ describe("activateSetupInference", () => {
         },
         order: { groq: ["groq:legacy"] },
       });
-      const selectedModel = "canonical-fixture-model";
-      const selectedModelRef = `groq/${selectedModel}`;
-      const selectedMetadata = { alias: "selected-fixture", params: { temperature: 0.2 } };
       const runAuth = vi.fn(async (ctx: { opts?: { token?: string } }) => ({
         profiles: [
           {
@@ -3346,7 +3383,10 @@ describe("activateSetupInference", () => {
         ],
         defaultModel: "groq/starter-fixture-alias",
         configPatch: {
-          agents: { defaults: { models: { "groq/starter-fixture-alias": selectedMetadata } } },
+          agents: {
+            defaults: { models: { "groq/starter-fixture-alias": selectedMetadata } },
+            entries: { main: { models: { "groq/starter-fixture-alias": selectedAgentMetadata } } },
+          },
         },
       }));
       const provider: ProviderPlugin = {
@@ -3445,8 +3485,25 @@ describe("activateSetupInference", () => {
           runEmbeddedAgent.mock.calls[0]?.[0].config,
           configHarness.current(),
         ]) {
-          expect(config?.agents?.defaults?.models).toEqual({
-            [selectedModelRef]: selectedMetadata,
+          expect({
+            defaults: config?.agents?.defaults?.models,
+            agent: config?.agents?.entries?.main?.models,
+          }).toEqual({
+            defaults: {
+              [selectedModelRef]: {
+                ...existingDefault,
+                ...selectedMetadata,
+                params: { ...existingDefault.params, ...selectedMetadata.params },
+              },
+            },
+            agent: {
+              [selectedModelRef]: {
+                ...existingAgent,
+                ...selectedAgentMetadata,
+                params: { ...existingAgent.params, ...selectedAgentMetadata.params },
+                agentRuntime: { id: "openclaw" },
+              },
+            },
           });
         }
         expect(readInMemoryAuthProfileStore(agentDir).profiles[activatedProfileId]).toMatchObject(

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -3212,6 +3212,9 @@ describe("activateSetupInference", () => {
       id: "local-test",
       label: "Local Test Provider",
       pluginId: "local-test",
+      normalizeModelId: () => {
+        throw new Error("Detected model is already canonical");
+      },
       auth: [
         {
           id: "local",
@@ -3328,6 +3331,9 @@ describe("activateSetupInference", () => {
         },
         order: { groq: ["groq:legacy"] },
       });
+      const selectedModel = "canonical-fixture-model";
+      const selectedModelRef = `groq/${selectedModel}`;
+      const selectedMetadata = { alias: "selected-fixture", params: { temperature: 0.2 } };
       const runAuth = vi.fn(async (ctx: { opts?: { token?: string } }) => ({
         profiles: [
           {
@@ -3338,13 +3344,20 @@ describe("activateSetupInference", () => {
                 : { type: "token" as const, provider: "groq", token: ctx.opts?.token ?? "" },
           },
         ],
-        defaultModel: "groq/llama-3.3-70b-versatile",
-        configPatch: { agents: { defaults: { models: { "groq/llama-3.3-70b-versatile": {} } } } },
+        defaultModel: "groq/starter-fixture-alias",
+        configPatch: {
+          agents: { defaults: { models: { "groq/starter-fixture-alias": selectedMetadata } } },
+        },
       }));
       const provider: ProviderPlugin = {
         id: "groq",
         label: "Groq",
         pluginId: "groq",
+        normalizeModelId({ modelId }) {
+          return modelId === "starter-fixture-alias" && this.id === "groq"
+            ? selectedModel
+            : modelId;
+        },
         auth: [
           {
             id: "api-key",
@@ -3365,7 +3378,7 @@ describe("activateSetupInference", () => {
       }));
       const runEmbeddedAgent = vi.fn(
         async (params: SuccessfulRunParams & { authProfileId?: string }) =>
-          successfulRun("groq", "llama-3.3-70b-versatile", params),
+          successfulRun("groq", selectedModel, params),
       );
       const configHarness = createConfigTransformHarness(initialConfig);
 
@@ -3382,7 +3395,7 @@ describe("activateSetupInference", () => {
           },
         });
 
-        expect(result).toMatchObject({ ok: true, modelRef: "groq/llama-3.3-70b-versatile" });
+        expect(result).toMatchObject({ ok: true, modelRef: selectedModelRef });
         expect(resolvePluginProviders).toHaveBeenCalledWith(
           expect.objectContaining({
             config: expect.objectContaining({
@@ -3408,7 +3421,7 @@ describe("activateSetupInference", () => {
           expect.objectContaining({
             agentId: "main",
             provider: "groq",
-            model: "llama-3.3-70b-versatile",
+            model: selectedModel,
             authProfileId: activatedProfileId,
             agentDir: expect.stringContaining("setup-inference-test-"),
             authProfileStateMode: "read-only",
@@ -3419,7 +3432,7 @@ describe("activateSetupInference", () => {
           plugins: { entries: { groq: { enabled: true } } },
           agents: {
             defaults: {
-              model: `groq/llama-3.3-70b-versatile@${activatedProfileId}`,
+              model: `${selectedModelRef}@${activatedProfileId}`,
             },
           },
           auth: {
@@ -3428,6 +3441,14 @@ describe("activateSetupInference", () => {
             },
           },
         });
+        for (const config of [
+          runEmbeddedAgent.mock.calls[0]?.[0].config,
+          configHarness.current(),
+        ]) {
+          expect(config?.agents?.defaults?.models).toEqual({
+            [selectedModelRef]: selectedMetadata,
+          });
+        }
         expect(readInMemoryAuthProfileStore(agentDir).profiles[activatedProfileId]).toMatchObject(
           credentialType === "api_key"
             ? { type: "api_key", provider: "groq", key: "test-groq-key" }


### PR DESCRIPTION
## What Problem This Solves

Model Setup could reject a working provider when authentication returned a starter alias: inference reported the canonical model while setup compared it against the alias. Selected model metadata also needed to follow the canonical key without deleting existing operator settings. This is a focused extraction from #130706.

## Why This Change Was Made

Use the selected provider's normalization hook during preparation, retaining its method receiver, then carry the canonical model through verification and persistence. Reuse the existing model-entry merge owner for both defaults and per-agent settings: explicit starter fields win, while unspecified fields and nested parameters survive. Guided discovery, custom setup and the Claude CLI probe/persist split retain their existing identities. Duplicate cloning and provider-key lookup are removed.

## User Impact

API-key, token and provider-login setup can verify and save provider-owned starter aliases with the intended model settings. No configuration option, protocol, model catalog or persistence schema is added. Whole PR production: +51/-58, net **-7**; tests +91/-13, net +78; docs +4/-2.

## Evidence

- Starter-alias and method-receiver failures were reproduced before their repairs. Both canonical metadata collision cases failed before the follow-up; fresh setup remained a passing control.
- Final 161 setup tests, 21 existing merge/auth helpers and one provider-auth-choice boundary test passed. Full changed checks and independent review through P2 passed.
- Normal compiled authenticated OpenAI/gpt-5.6-luna setup passed for partial and empty starter metadata. Both returned HTTP 200, retained the provider receiver, preserved canonical defaults and per-agent settings, saved the canonical profile/model and removed alias rows. Isolated state and the Testbox were cleaned up. [Final proof run](https://github.com/openclaw/openclaw/actions/runs/33991727744).
- Commit `d6d50d1d45877f57da91c275300032c7f641d642` has tree `9d7210640a8572129d5c2a8029fde1cf10486520`, exactly matching the compiled final live proof. The earlier full build and starter-alias live control also passed.
- Earlier source-only provider loading exposed a separate dependency-export problem; the compiled operator path passed. An initial Groq credential returned HTTP 401 after reaching the correct canonical model. These are recorded failures, not claimed successes.

ClawSweeper follow-through: the [canonical-settings finding](https://github.com/openclaw/openclaw/pull/139339) and both Rank-up moves are addressed by merging unspecified canonical fields/nested params and extending activation coverage to fresh, partial and empty starter metadata in both maps. No finding is deferred.
