### PR TITLE
refactor(test): consolidate OpenRouter request assertions

### DIFF
--- a/extensions/openrouter/speech-provider.test.ts
+++ b/extensions/openrouter/speech-provider.test.ts
@@ -1,4 +1,5 @@
 // Openrouter tests cover speech provider plugin behavior.
+import { requireFirstPostJsonRecordRequest } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOpenRouterSpeechProvider } from "./speech-provider.js";
 
@@ -20,30 +21,6 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importOriginal) => ({
   postJsonRequest: postJsonRequestMock,
   resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
 }));
-
-function requireOpenRouterConfigRequest(): Record<string, unknown> {
-  const [call] = resolveProviderHttpRequestConfigMock.mock.calls;
-  if (!call) {
-    throw new Error("expected OpenRouter speech config request");
-  }
-  const [request] = call;
-  if (!request || typeof request !== "object" || Array.isArray(request)) {
-    throw new Error("expected OpenRouter speech config request");
-  }
-  return request;
-}
-
-function requireOpenRouterPostRequest(): Record<string, unknown> {
-  const [call] = postJsonRequestMock.mock.calls;
-  if (!call) {
-    throw new Error("expected OpenRouter speech request");
-  }
-  const [request] = call;
-  if (!request || typeof request !== "object" || Array.isArray(request)) {
-    throw new Error("expected OpenRouter speech request");
-  }
-  return request as Record<string, unknown>;
-}
 
 function requireHeaders(value: unknown): Headers {
   if (!(value instanceof Headers)) {
@@ -137,7 +114,7 @@ describe("openrouter speech provider", () => {
     });
 
     expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledOnce();
-    expect(requireOpenRouterConfigRequest()).toEqual({
+    expect(resolveProviderHttpRequestConfigMock.mock.calls[0]?.[0]).toEqual({
       baseUrl: "https://openrouter.ai/api/v1",
       defaultBaseUrl: "https://openrouter.ai/api/v1",
       allowPrivateNetwork: false,
@@ -152,7 +129,10 @@ describe("openrouter speech provider", () => {
       transport: "http",
     });
     expect(postJsonRequestMock).toHaveBeenCalledOnce();
-    const request = requireOpenRouterPostRequest();
+    const request = requireFirstPostJsonRecordRequest(
+      postJsonRequestMock,
+      "OpenRouter speech request",
+    );
     const headers = requireHeaders(request.headers);
     expect(Object.fromEntries(headers.entries())).toEqual({
       authorization: "Bearer sk-openrouter",
@@ -205,7 +185,10 @@ describe("openrouter speech provider", () => {
       timeoutMs: 5000,
     });
 
-    const request = requireOpenRouterPostRequest();
+    const request = requireFirstPostJsonRecordRequest(
+      postJsonRequestMock,
+      "OpenRouter speech request",
+    );
     expect(request.url).toBe("https://private.example.invalid/router/v1/audio/speech");
     expect(requireHeaders(request.headers).get("authorization")).toBe(
       "Bearer synthetic-private-proxy-key",
@@ -235,7 +218,10 @@ describe("openrouter speech provider", () => {
       timeoutMs: 5000,
     });
 
-    const request = requireOpenRouterPostRequest();
+    const request = requireFirstPostJsonRecordRequest(
+      postJsonRequestMock,
+      "OpenRouter speech request",
+    );
     expect(request.url).toBe("https://speech-proxy.example.invalid/router/v1/audio/speech");
     expect(requireHeaders(request.headers).get("authorization")).toBe(
       "Bearer synthetic-private-proxy-key",


### PR DESCRIPTION
## What Problem This Solves

The OpenRouter speech tests duplicate mock-request guards even where stronger assertions or an existing shared helper already provide the same protection. This maintainer-requested cleanup removes that duplication while retaining the security and request-contract coverage.

## Why This Change Was Made

The config request is inspected directly under its existing called-once and complete-object equality assertions. POST requests use the existing SDK `requireFirstPostJsonRecordRequest`, retaining null/nonobject/array rejection. The `Headers` guard stays because the resolver and POST interfaces require that class, independently of matching header contents.

## User Impact

No user-visible behavior changes. Production code is unchanged; tests are +14/-28 lines. All eight OpenRouter cases and their assertions remain, including custom credential destinations, request fields, audio/voice results and response release. Core TTS and DeepInfra are unchanged.

## Evidence

- Complete core-TTS/OpenRouter/DeepInfra suites passed before and after: 10/8/3 cases, 21 total each, under Node 24.20.0 and pnpm 12.3.4 with normal project order.
- The normal configured Linux changed-file gate passed all selected checks, including plugin test types, three dead-export scans and lint. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33987235362): the delegated command returned 0 and its one-shot lease stopped normally.
- Managed Codex review found no actionable P0-P2 findings; the reviewed source stayed unchanged.
- The changed test, factory and shared helpers are unchanged between tested main `4e217930a68a12586f0dd215a68f714958a02970` and freshly fetched `0980b383dda216fe727f73053b48b266ed5e2bfa`.

The shared-fixtures import deliberately avoids the HTTP-mock installation barrel, which installs mocks at module load. No new test helper, SDK export, production seam or live provider behavior is introduced.
