### PR TITLE
fix(macos): await onboarding activation consent settlement

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -1600,17 +1600,19 @@ extension OnboardingAISetupModel {
 }
 
 extension OnboardingAISetupModel {
-    func submitManualKey() {
+    /// Captures submission synchronously; the task settles only after activation recovery finishes.
+    @discardableResult
+    func submitManualKey() -> Task<Void, Never>? {
         let key = self.manualKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let provider = selectedManualProvider, !key.isEmpty, !self.isBusy else { return }
+        guard let provider = selectedManualProvider, !key.isEmpty, !self.isBusy else { return nil }
         guard let context = beginAttemptContext() else {
             self.manualError = Self.transportFailure(
                 "No Gateway is selected. Select a Gateway, then try again.")
-            return
+            return nil
         }
         self.manualError = nil
         self.manualTesting = true
-        Task { await self.activate(.manual(key: key, provider: provider), context: context) }
+        return Task { await self.activate(.manual(key: key, provider: provider), context: context) }
     }
 
     /// A retired socket invalidates every candidate and provider record learned

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -1105,6 +1105,8 @@ struct OnboardingAISetupTests {
         [false, true])
     func `activation consent uses shared wizard`(decision: String, manual: Bool) async throws {
         let recorder = AISetupRequestRecorder()
+        let settlementGate = AISetupConfigReadGate()
+        let gateSettlement = decision == "rejected-unavailable"
         let activationAttempts = AISetupSocketGeneration()
         let cancellationFails = LockIsolated(true)
         let rejectionStatus: String? = if decision == "rejected-replaced" {
@@ -1163,6 +1165,11 @@ struct OnboardingAISetupTests {
                     case "consent":
                         let accepted = try #require(answer?["value"] as? Bool)
                         #expect(accepted == accepts)
+                        if gateSettlement {
+                            // Pass the transport's post-response check, then hold the
+                            // activation owner's final lease validation after the sheet closes.
+                            await settlementGate.armNextRead(afterReads: 1)
+                        }
                         payload = if terminalError {
                             ["done": true, "status": "error", "error": failureDetail]
                         } else if decision == "malformed-success" {
@@ -1238,25 +1245,31 @@ struct OnboardingAISetupTests {
                     methods: ["openclaw.setup.activate", "openclaw.setup.activate.start"],
                     capabilities: ["openclaw-setup-model-ref"]))
             })
-        let gateway = try makeAISetupGateway(url: #require(URL(string: "ws://example.invalid")), session: session)
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let gateway = GatewayConnection(
+            configProvider: {
+                let token = await settlementGate.snapshotToken()
+                return (url: url, token: token, password: nil)
+            },
+            sessionBox: WebSocketSessionBox(session: session))
         let model = makeAISetupModel(gateway: gateway, defaults: defaults)
         var handoffs = 0
         model.onConnected = { handoffs += 1 }
+        var activationSettled = false
         let activation = Task {
             await model.detectConnections()
             if manual {
                 model.manualProviderID = "openai-api-key"
                 model.manualKey = "fixture-key"
-                model.submitManualKey()
+                await model.submitManualKey()?.value
             }
+            activationSettled = true
         }
         defer {
             model.resetForGatewayChange()
             activation.cancel()
         }
-        for _ in 0..<400 where model.authStep == nil {
-            try await Task.sleep(nanoseconds: 5_000_000)
-        }
+        await waitForAISetupState { model.authStep != nil }
         #expect(model.authStep?.title == "Plugin capabilities")
         #expect(model.activeAuthOption?.label == (manual ? "OpenAI API key" : "Codex CLI"))
         #expect(model.activeAuthOption?.brandId == "openai")
@@ -1270,9 +1283,7 @@ struct OnboardingAISetupTests {
         }
         #expect(!model.connected)
         model.continueProviderAuth()
-        for _ in 0..<400 where model.authStep?.id != "consent" {
-            try await Task.sleep(nanoseconds: 5_000_000)
-        }
+        await waitForAISetupState { model.authStep?.id == "consent" }
         #expect(model.authStep.map(wizardStepType) == "confirm")
         #expect(!model.authConfirmation)
         let originalOwner = try #require(storedActivationOwner(defaults))
@@ -1290,9 +1301,7 @@ struct OnboardingAISetupTests {
         }
         if decision == "retry-cancel" {
             model.cancelProviderAuth()
-            for _ in 0..<400 where model.authError == nil {
-                try await Task.sleep(nanoseconds: 5_000_000)
-            }
+            await waitForAISetupState { model.authError != nil }
             #expect(model.authError != nil)
             #expect(model.authBusy)
             let retrySheet = await inspectAISetupSheet(model)
@@ -1307,11 +1316,17 @@ struct OnboardingAISetupTests {
             model.authConfirmation = accepts
             model.continueProviderAuth()
         }
-        for _ in 0..<400 where model.activeAuthOption != nil {
-            try await Task.sleep(nanoseconds: 5_000_000)
+        if gateSettlement {
+            await settlementGate.waitUntilBlocked()
+            #expect(model.activeAuthOption == nil)
+            #expect(!activationSettled)
+            if manual {
+                #expect(model.manualTesting)
+                #expect(model.manualError == nil)
+            }
+            await settlementGate.release()
         }
         await activation.value
-        await settleQueuedAISetupTasks()
         let ambiguous = ownerReplaced || decision == "malformed-success" || decision == "retry-cancel" ||
             (terminalError && rejectionStatus == nil)
         #expect(model.connected == (decision == "accept"))
@@ -1399,13 +1414,11 @@ struct OnboardingAISetupTests {
         try #require(!model.isBusy)
         if manual {
             model.manualKey = "corrected-fixture-key"
-            model.submitManualKey()
+            await model.submitManualKey()?.value
         } else {
             model.userSelect(kind: rejectionStatus == "billing" ? "claude-cli" : "codex-cli")
         }
-        for _ in 0..<400 where !model.connected {
-            try await Task.sleep(nanoseconds: 5_000_000)
-        }
+        await waitForAISetupState { model.connected }
         #expect(model.connected)
         #expect(handoffs == 1)
         #expect(pendingState(defaults) == .completed)
@@ -4790,10 +4803,7 @@ struct OnboardingAISetupTests {
         await model.detectConnections()
         if entry == "manual" {
             model.manualKey = "test-key-placeholder"
-            model.submitManualKey()
-            for _ in 0..<200 where model.manualTesting {
-                try await Task.sleep(for: .milliseconds(5))
-            }
+            await model.submitManualKey()?.value
         } else if entry == "selected" {
             await model.activate(kind: "codex-cli")
         }
@@ -5192,14 +5202,14 @@ struct OnboardingAISetupTests {
         model.manualProviderID = "openai-api-key"
         model.manualKey = "old-route-secret"
 
-        model.submitManualKey()
+        let activation = model.submitManualKey()
         #expect(model.manualTesting)
         #expect(OnboardingController.shared.busyReason == "OpenClaw is testing your AI connection.")
         model.resetForGatewayChange()
         #expect(OnboardingController.shared.busyReason == nil)
         config.setToken("route-b-token")
         routeIdentity.set("remote:id:gateway-b")
-        await settleQueuedAISetupTasks()
+        await activation?.value
 
         let requests = await recorder.snapshot()
         #expect(requests.methods == ["openclaw.setup.detect"])
@@ -5251,11 +5261,7 @@ struct OnboardingAISetupTests {
         model.manualKey = "must-not-send"
         config.switchToken(to: "token-b", afterReads: 2)
 
-        model.submitManualKey()
-        for _ in 0..<200 {
-            guard model.manualTesting else { break }
-            try? await Task.sleep(nanoseconds: 5_000_000)
-        }
+        await model.submitManualKey()?.value
 
         let requests = await recorder.snapshot()
         #expect(requests.methods == ["openclaw.setup.detect"])
@@ -5816,14 +5822,7 @@ struct OnboardingAISetupTests {
             scheduledDeadlines.append((deadline, routeIdentity))
         }
 
-        model.submitManualKey()
-        // The full suite can starve MainActor work; wait for state instead of a one-second budget.
-        for _ in 0..<2000 {
-            if !model.manualTesting, model.waitingForPendingActivationDeadline {
-                break
-            }
-            try? await Task.sleep(nanoseconds: 5_000_000)
-        }
+        await model.submitManualKey()?.value
 
         #expect(await (recorder.snapshot()).methods == [
             "openclaw.setup.detect",


### PR DESCRIPTION
Related: #138092

## What Problem This Solves

Resolves an intermittent macOS onboarding test failure after rejecting an activation capability review with a manually entered key. The hosted macos-26 job [101348865819](https://github.com/openclaw/openclaw/actions/runs/33982010453/job/101348865819) observed `isBusy == true` and no `manualError` after the wizard sheet had closed. The same head passed a later run.

## Why This Change Was Made

Closing the wizard resumes activation, whose failure settlement still awaits the current server lease before publishing the error and releasing `manualTesting`. Manual submission previously discarded that activation task, so the test awaited only submission and guessed at completion with sleeps.

Return the actual activation task from `submitManualKey()` and await it in the consent test and manual-submission siblings. Admission, key/route capture, and the busy flag remain synchronous. The consent matrix uses the existing observation helper for interactive steps and gates final lease validation to prove sheet dismissal precedes activation settlement.

## User Impact

No visual or setup-policy change. Native onboarding tests deterministically wait for the operation they started, including rejection recovery, pending-deadline handling, and stale-route fencing. No timeout increases or relaxed assertions.

## Evidence

- Deterministic pre-fix proof on the original production implementation: hold the final server-lease read after the consent sheet closes. The `rejected-unavailable`, `manual=true` case fails the premature-completion assertion and reproduces both original failures (`isBusy == true`, `manualError == nil`). The candidate case passes with the lease gate unchanged.
- In an isolated macOS 26.6 VM account with Xcode 26.5 / Swift 6.3.2, ran `cd apps/macos && swift test --build-system native --filter OnboardingAISetupTests` five consecutive times. All **109 tests passed on every run**, including the **46-case consent matrix**; durations were 24.972, 25.961, 24.759, 24.300, and 29.001 seconds. SHA256 verification bound both changed files and `Package.resolved` to this PR head. No operator Gateway or credentials were used.
- `node scripts/check-changed.mjs -- apps/macos/Sources/OpenClaw/OnboardingAISetup.swift apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift` passed after installing the repository-pinned dependencies into this worktree. The initial run found an unrelated shared-install mismatch (Vitest 4 instead of the pinned Vitest 5).
- Targeted Swift formatting and `git diff --check` passed. Independent Codex autoreview through P2 found no actionable issues.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/33989408903 (passed on this head).
