### PR TITLE
fix: stop reporting failed native broadcasts as successful

### DIFF
--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -243,6 +243,10 @@ openclaw message broadcast --targets <target...> [--channel all] [--message <tex
 Sends one payload to multiple targets. `--targets` takes a space-separated
 list. Use `--channel all` to target every configured provider.
 
+If any target fails, is suppressed, or only partially delivers, the broadcast
+exits nonzero. Text output identifies failed targets; JSON reports `ok: false`
+and retains every target's result, including failures returned by channel plugins.
+
 ## Related
 
 - [CLI reference](/cli)

--- a/src/infra/outbound/message-action-contracts.ts
+++ b/src/infra/outbound/message-action-contracts.ts
@@ -183,15 +183,11 @@ export type MessageActionResult =
       dryRun: boolean;
     };
 
-export function resolveMessageSendOutcome(
+function resolveMessageSendOutcome(
   sendResult: MessageSendResult | undefined,
   action: "Message" | "Broadcast" = "Message",
 ): { ok: true } | { ok: false; error: string; sentBeforeError?: true } {
-  if (
-    !sendResult ||
-    sendResult.deliveryStatus === undefined ||
-    sendResult.deliveryStatus === "sent"
-  ) {
+  if (sendResult?.deliveryStatus === undefined || sendResult.deliveryStatus === "sent") {
     return { ok: true };
   }
   switch (sendResult.deliveryStatus) {
@@ -214,6 +210,7 @@ export function resolveMessageSendOutcome(
 
 export function resolveMessageActionOutcome(
   result: MessageActionResult,
+  action: "Message" | "Broadcast" = "Message",
 ): ReturnType<typeof resolveMessageSendOutcome> {
   if (result.kind === "broadcast") {
     const failure = result.payload.results.find((entry) => !entry.ok);
@@ -223,7 +220,9 @@ export function resolveMessageActionOutcome(
     return { ok: true };
   }
   const outcome =
-    result.kind === "send" ? resolveMessageSendOutcome(result.sendResult) : { ok: true as const };
+    result.kind === "send"
+      ? resolveMessageSendOutcome(result.sendResult, action)
+      : { ok: true as const };
   const payload = result.payload;
   if (!outcome.ok || !isRecord(payload) || payload.ok !== false) {
     return outcome;
@@ -232,7 +231,9 @@ export function resolveMessageActionOutcome(
     [payload.error, payload.warning, payload.hint, payload.reason]
       .map(normalizeOptionalString)
       .find(Boolean) ?? `Message ${result.action} failed.`;
-  return { ok: false, error };
+  return payload.sentBeforeError === true
+    ? { ok: false, error, sentBeforeError: true }
+    : { ok: false, error };
 }
 
 export function resolveMessageActionMessageId(payload: unknown): string | undefined {

--- a/src/infra/outbound/message-action-runner.broadcast.test.ts
+++ b/src/infra/outbound/message-action-runner.broadcast.test.ts
@@ -1,0 +1,107 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { jsonResult } from "../../agents/tools/common.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
+import { formatMessageCliText } from "../../commands/message-format.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
+import { createTempHomeEnv, type TempHomeEnv } from "../../test-utils/temp-home.js";
+import { resolveMessageActionOutcome } from "./message-action-contracts.js";
+import { runMessageAction } from "./message-action-runner.js";
+
+describe("broadcast send outcomes through native actions", () => {
+  let tempHome: TempHomeEnv;
+  beforeAll(async () => {
+    tempHome = await createTempHomeEnv("openclaw-broadcast-outcomes-");
+  });
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+  afterAll(async () => {
+    await tempHome.restore();
+  });
+
+  it.each<{
+    name: string;
+    payload: Record<string, unknown>;
+    ok: boolean;
+    sentBeforeError?: true;
+  }>([
+    {
+      name: "native rejection",
+      payload: { ok: false, error: "provider rejected message" },
+      ok: false,
+    },
+    {
+      name: "native rejection before send",
+      payload: { ok: false, error: "rejected before send", sentBeforeError: false },
+      ok: false,
+    },
+    { name: "native suppression", payload: { ok: false, warning: "send suppressed" }, ok: false },
+    {
+      name: "native partial failure",
+      payload: {
+        ok: false,
+        error: "second part failed",
+        sentBeforeError: true,
+        messageId: "sent-part",
+      },
+      ok: false,
+      sentBeforeError: true,
+    },
+    { name: "native success", payload: { ok: true, messageId: "sent-native" }, ok: true },
+    { name: "legacy empty success", payload: {}, ok: true },
+    {
+      name: "nested receipt",
+      payload: { ok: true, result: { messageId: "sent-nested" } },
+      ok: true,
+    },
+  ])("preserves $name alongside a successful target", async ({ payload, ok, sentBeforeError }) => {
+    const delivered: string[] = [];
+    const plugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({ id: "broadcast-test" }),
+      messaging: { targetResolver: { looksLikeId: () => true } },
+      outbound: {
+        deliveryMode: "direct",
+        sendText: async () => {
+          throw new Error("native action bypassed");
+        },
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
+        handleAction: async ({ params }) => {
+          delivered.push(String(params.to));
+          return jsonResult(params.to === "first" ? payload : { ok: true, messageId: "sent-2" });
+        },
+      },
+    };
+    setActivePluginRegistry(createTestRegistry([{ pluginId: plugin.id, plugin, source: "test" }]));
+
+    const result = await runMessageAction({
+      cfg: {},
+      action: "broadcast",
+      params: { channel: plugin.id, targets: ["first", "second"], message: "hello" },
+    });
+
+    expect(delivered).toEqual(["first", "second"]);
+    expect(result).toMatchObject({
+      kind: "broadcast",
+      payload: {
+        results: [
+          { to: "first", ok, payload },
+          { to: "second", ok: true },
+        ],
+      },
+    });
+    expect(resolveMessageActionOutcome(result).ok).toBe(ok);
+    expect(formatMessageCliText(result)[0]).toContain(ok ? "2/2 succeeded" : "1/2 succeeded");
+    if (result.kind !== "broadcast") {
+      throw new Error("Expected broadcast result");
+    }
+    expect(result.payload.results[0]?.sentBeforeError).toBe(sentBeforeError);
+    expect(result.payload.results[0]?.payload).toBe(payload);
+  });
+});

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -24,7 +24,7 @@ import {
 import { shouldUseInternalSourceReplySink } from "./internal-source-reply.js";
 import { validateExplicitMessageAccountSelection } from "./message-account-selection.js";
 import {
-  resolveMessageSendOutcome,
+  resolveMessageActionOutcome,
   type MessageActionInput,
   type MessageActionResult,
   type ResolvedActionContext,
@@ -160,10 +160,7 @@ async function handleBroadcastAction(
         results.push({
           channel: targetChannel,
           to: resolved.to,
-          ...resolveMessageSendOutcome(
-            sendResult.kind === "send" ? sendResult.sendResult : undefined,
-            "Broadcast",
-          ),
+          ...resolveMessageActionOutcome(sendResult, "Broadcast"),
           payload: sendResult.kind === "send" ? sendResult.payload : undefined,
           result: sendResult.kind === "send" ? sendResult.sendResult : undefined,
         });


### PR DESCRIPTION
Closes #139328
Related: #122605 and #125915

## What Problem This Solves

Fixes an issue where operators broadcasting through a native channel action could see `2/2 succeeded`, JSON `ok: true`, and a successful CLI exit even when one target's plugin returned a structured send failure. Zalo is a concrete producer of the affected failure shape.

## Why This Change Was Made

Broadcast now uses the same action-outcome resolver as single-message and CLI results. Core delivery statuses retain their existing diagnostics, and native failures preserve an explicit `sentBeforeError: true` marker while leaving the original payload intact. The lower-level core-only resolver becomes private. Production code shrinks by two lines.

## User Impact

Native plugin failures count as failed broadcast targets. Operators retain each target's error and receipt details, including an explicit indication that a partial delivery already happened. Successful, legacy empty, dry-run, core, and thrown-error outcomes keep their existing behavior.

## Evidence

Local validation and exact-head CI passed.

- Before the fix, three structured native failure cases failed at the real broadcast aggregation boundary: each produced `ok: true`. Success controls passed.
- Independent review identified missing promotion of the existing partial-delivery marker. A strengthened boundary case reproduced that omission before the correction; six controls passed.
- After the correction, all 141 focused tests passed across five suites, including real runner/send-service/dispatcher integration, core delivery outcomes, text/JSON reporting, CLI parser exit status, and cleanup.
- All 29 selected repository checks passed. The follow-up independent review found no actionable P0–P2 issues.
- Rebased onto `e8fbf33b32bea82769237675b99e03355ba3a50e`; range-diff and file comparison prove the reviewed patch and all four changed files are unchanged. Submitted head: `a4484860aad6be95599daa8eca0806db6d80dd40`.

The integration uses a synthetic native channel plugin through the real runner and dispatcher; no live Zalo send is claimed. Partial-marker coverage tests the generic result contract, not an observed bundled native partial-failure producer. No gateway protocol, persistence, configuration, provider API, or dependency changes are included.

CI: [run33989738181](https://github.com/openclaw/openclaw/actions/runs/33989738181), attempt2, passed at `a4484860aad6be95599daa8eca0806db6d80dd40`. The first attempt failed one tooling authorization-fixture call-count assertion; the unchanged failed-only retry passed. No checks or authorization assertions were weakened. ClawSweeper also found no introduced defect.

Exact local commands for the final correction:

```sh
pnpm test src/infra/outbound/message-action-runner.broadcast.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts src/commands/message.test.ts src/commands/message-format.test.ts src/cli/program/message/helpers.test.ts -- --reporter=verbose --reporter=json --outputFile=.artifacts/broadcast-p2-after.json
node scripts/check-changed.mjs --base bd381bffb29df6994e78353be688d8a552e4b4bb -- docs/cli/message.md src/infra/outbound/message-action-contracts.ts src/infra/outbound/message-action-runner.ts src/infra/outbound/message-action-runner.broadcast.test.ts
```
