### PR TITLE
perf(memory): reuse typed chunk publication statements

### DIFF
--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -2022,7 +2022,6 @@ describe("memory cli", () => {
           sources: ["memory"],
           store: { vector: { enabled: false } },
           cache: { enabled: false },
-          sync: { watch: false, onSessionStart: false, onSearch: false },
           query: { hybrid: { enabled: true } },
         },
       },

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
   hashText,
   INVALID_PROJECT_ANNOTATION_KEY,
@@ -553,55 +554,6 @@ describe("memory index", () => {
     }
   });
 
-  it("inherits entry-scoped annotations across oversized curated fragments", async () => {
-    await fs.writeFile(
-      path.join(fixture.paths.workspace, "MEMORY.md"),
-      [
-        "- Oversized alpha entry. <!-- trigger: oversized alpha --> <!-- importance: 8 --> <!-- project: alpha-key -->",
-        `  ${"alpha-fragment-body ".repeat(400)}`,
-        "- Global neighbor. <!-- trigger: global neighbor -->",
-      ].join("\n"),
-    );
-
-    const manager = await getFreshManager(createCfg({ provider: "none" }));
-    try {
-      const settings = Reflect.get(manager, "settings") as {
-        chunking: { tokens: number; overlap: number };
-      };
-      settings.chunking = { tokens: 64, overlap: 0 };
-      await manager.sync({ reason: "test", force: true });
-      const db = Reflect.get(manager, "db") as DatabaseSync;
-      const rows = db
-        .prepare(
-          `SELECT chunk.text, metadata.importance, metadata.triggers,
-                  metadata.project_key AS projectKey
-           FROM memory_index_chunks AS chunk
-           LEFT JOIN memory_index_chunk_recall_metadata AS metadata
-             ON metadata.chunk_id = chunk.id
-           WHERE chunk.path = 'MEMORY.md' AND chunk.source = 'memory'
-           ORDER BY chunk.start_line, chunk.id`,
-        )
-        .all() as Array<{
-        text: string;
-        importance: number | null;
-        triggers: string | null;
-        projectKey: string | null;
-      }>;
-      const fragments = rows.filter((row) => row.triggers === "oversized alpha");
-
-      expect(fragments.length).toBeGreaterThanOrEqual(2);
-      expect(fragments.every((row) => row.projectKey === "alpha-key" && row.importance === 8)).toBe(
-        true,
-      );
-      expect(rows.find((row) => row.triggers === "global neighbor")).toMatchObject({
-        projectKey: null,
-        importance: null,
-      });
-    } finally {
-      await manager.close?.();
-    }
-  });
-
   it("re-chunks unchanged files and removes stale rows when the chunking version advances", async () => {
     const curatedContent = [
       "- Alpha entry. <!-- trigger: alpha entry --> <!-- project: alpha-key -->",
@@ -702,55 +654,6 @@ describe("memory index", () => {
       expect((JSON.parse(upgradedMeta.value) as MemoryIndexMeta).chunkingVersion).toBe(
         MEMORY_CHUNKING_VERSION,
       );
-    } finally {
-      await manager.close?.();
-    }
-  });
-
-  it("keeps existing file index rows when chunk publication fails", async () => {
-    const cfg = createCfg({});
-    const manager = await getFreshManager(cfg);
-    try {
-      const db = Reflect.get(manager, "db") as DatabaseSync;
-
-      await manager.sync({ reason: "test" });
-
-      const initialSource = db
-        .prepare("SELECT hash FROM memory_index_sources WHERE path LIKE ? AND source = ?")
-        .get("%2026-01-12.md", "memory") as { hash: string } | undefined;
-      const initialChunk = db
-        .prepare("SELECT text FROM memory_index_chunks WHERE path LIKE ? AND source = ?")
-        .get("%2026-01-12.md", "memory") as { text: string } | undefined;
-      expect(initialSource?.hash).toBeTruthy();
-      expect(initialChunk?.text).toContain("Alpha memory line.");
-
-      db.exec(`
-        CREATE TRIGGER fail_chunk_publication
-        AFTER INSERT ON memory_index_chunks
-        BEGIN
-          SELECT RAISE(FAIL, 'forced chunk publication failure');
-        END;
-      `);
-      await fs.writeFile(
-        path.join(fixture.paths.memory, "2026-01-12.md"),
-        "# Log\nUpdated memory line.",
-      );
-      Reflect.set(manager, "dirty", true);
-
-      await expect(manager.sync({ reason: "test" })).rejects.toThrow(
-        "forced chunk publication failure",
-      );
-
-      expect(
-        db
-          .prepare("SELECT hash FROM memory_index_sources WHERE path LIKE ? AND source = ?")
-          .get("%2026-01-12.md", "memory"),
-      ).toEqual(initialSource);
-      expect(
-        db
-          .prepare("SELECT text FROM memory_index_chunks WHERE path LIKE ? AND source = ?")
-          .get("%2026-01-12.md", "memory"),
-      ).toEqual(initialChunk);
     } finally {
       await manager.close?.();
     }
@@ -1144,14 +1047,14 @@ describe("memory index", () => {
     }
   });
 
-  it.each([
+  it.for([
     ["success", 0, 0, { enabled: true, failures: 0, lastError: undefined }],
     ["repeated failures", 0, 2, { enabled: false, failures: 2, lastError: "failure 2" }],
     ["late failure", 1, 2, { enabled: false, failures: 2, lastError: "failure 1" }],
     ["late recovery", 1, 1, { enabled: false, failures: 0, lastError: undefined }],
   ] as const)(
     "keeps custom batches concurrent through %s",
-    async (_outcome, priorFailures, errors, expected) => {
+    async ([_outcome, priorFailures, errors, expected], { signal }) => {
       const manager = await getFreshManager(
         createCfg({ provider: "batch-test", batchEnabled: true }),
       );
@@ -1175,17 +1078,26 @@ describe("memory index", () => {
           { length: errors },
           (_, index) => new Error(`failure ${index + 1}`),
         );
-        let releaseBatchGate: (() => void) | undefined;
-        providerFixture.providerRuntimeBatchGate = new Promise((resolve) => {
-          releaseBatchGate = resolve;
-        });
+        const batchesEntered = createDeferred<void>();
+        const releaseBatchGate = createDeferred<void>();
+        providerFixture.providerRuntimeBatchGate = releaseBatchGate.promise;
+        providerFixture.providerRuntimeBatchEntered = (activeCalls) => {
+          if (activeCalls === 2) {
+            batchesEntered.resolve();
+          }
+        };
+        const abort = () => batchesEntered.reject(signal.reason);
+        signal.addEventListener("abort", abort, { once: true });
         const syncPromise = manager.sync({ reason: "test", force: true });
         try {
-          await vi.waitFor(() =>
-            expect(providerFixture.providerRuntimeMaxActiveBatchCalls).toBe(2),
-          );
+          // Provider entry owns this rendezvous; filesystem preparation has no one-second contract.
+          signal.throwIfAborted();
+          await Promise.race([batchesEntered.promise, syncPromise]);
+          expect(providerFixture.providerRuntimeMaxActiveBatchCalls).toBe(2);
         } finally {
-          releaseBatchGate?.();
+          signal.removeEventListener("abort", abort);
+          providerFixture.providerRuntimeBatchEntered = null;
+          releaseBatchGate.resolve();
           await syncPromise;
         }
         expect(manager.status().batch).toMatchObject(expected);
@@ -1341,7 +1253,6 @@ describe("memory index", () => {
         model: providerFixture.identityAlias.canonicalModel,
         cacheEnabled: true,
         vectorEnabled: false,
-        onSearch: false,
         hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
       });
       const indexedManager = await getFreshManager(indexedCfg);
@@ -1357,7 +1268,6 @@ describe("memory index", () => {
         model: configuredModel,
         cacheEnabled: true,
         vectorEnabled: false,
-        onSearch: false,
         hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
       });
       const statusManager = await getFreshManager(nextCfg, "status");

--- a/extensions/memory-core/src/memory/manager-chunk-writer.test.ts
+++ b/extensions/memory-core/src/memory/manager-chunk-writer.test.ts
@@ -1,0 +1,176 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it, vi } from "vitest";
+import { createManagerIndexFixture } from "./manager-index.test-support.js";
+
+const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
+const CHUNK_WRITE_TABLES = [
+  "memory_index_chunks",
+  "memory_index_chunk_recall_metadata",
+  "memory_index_chunk_provenance",
+];
+
+function chunkWriteTables(sqls: string[]): string[] {
+  return sqls.flatMap((sql) => {
+    const table = /^\s*INSERT INTO "?(\w+)"?\s*\(/i.exec(sql)?.[1];
+    return table && CHUNK_WRITE_TABLES.includes(table) ? [table] : [];
+  });
+}
+
+describe("memory chunk publication", () => {
+  const fixture = createManagerIndexFixture({
+    getMemorySearchManager,
+    closeAllMemorySearchManagers,
+  });
+
+  it.each(["none", "batch-wide-test"])(
+    "bounds preparations while preserving oversized entry annotations (%s)",
+    async (provider) => {
+      const memoryPath = path.join(fixture.paths.workspace, "MEMORY.md");
+      await fs.writeFile(
+        memoryPath,
+        [
+          "- Oversized alpha entry. <!-- trigger: oversized alpha --> <!-- importance: 8 --> <!-- project: alpha-key -->",
+          `  ${"alpha-fragment-body ".repeat(400)}`,
+          "- Global neighbor. <!-- trigger: global neighbor -->",
+        ].join("\n"),
+      );
+      const manager = await fixture.getFreshManager(
+        fixture.createConfig({ provider, batchEnabled: true, vectorEnabled: false }),
+        "cli",
+      );
+      try {
+        const settings = Reflect.get(manager, "settings") as {
+          chunking: { tokens: number; overlap: number };
+        };
+        settings.chunking = { tokens: 64, overlap: 0 };
+        const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+        let preparedTables: string[];
+        try {
+          await manager.sync({ reason: "test", force: true });
+          preparedTables = chunkWriteTables(prepare.mock.calls.map(([sql]) => sql));
+        } finally {
+          prepare.mockRestore();
+        }
+        const db = Reflect.get(manager, "db") as DatabaseSync;
+        const rows = db
+          .prepare(
+            `SELECT chunk.text, metadata.importance, metadata.triggers,
+                    metadata.project_key AS projectKey, provenance.origin_class AS originClass
+             FROM memory_index_chunks AS chunk
+             LEFT JOIN memory_index_chunk_recall_metadata AS metadata
+               ON metadata.chunk_id = chunk.id
+             LEFT JOIN memory_index_chunk_provenance AS provenance
+               ON provenance.chunk_id = chunk.id
+             WHERE chunk.path = 'MEMORY.md' AND chunk.source = 'memory'
+             ORDER BY chunk.start_line, chunk.id`,
+          )
+          .all();
+        const fragments = rows.filter((row) => row.triggers === "oversized alpha");
+        expect(fragments.length).toBeGreaterThanOrEqual(2);
+        expect(
+          fragments.every(
+            (row) =>
+              row.projectKey === "alpha-key" && row.importance === 8 && row.originClass === "agent",
+          ),
+        ).toBe(true);
+        expect(rows.find((row) => row.triggers === "global neighbor")).toMatchObject({
+          projectKey: null,
+          importance: null,
+        });
+        const nonemptyFiles = db
+          .prepare("SELECT DISTINCT path, source FROM memory_index_chunks")
+          .all().length;
+        for (const table of CHUNK_WRITE_TABLES) {
+          expect(
+            preparedTables.filter((prepared) => prepared === table),
+            table,
+          ).toHaveLength(nonemptyFiles);
+        }
+
+        await fs.writeFile(memoryPath, "");
+        Reflect.set(manager, "dirty", true);
+        const emptyPrepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+        try {
+          await manager.sync({ reason: "empty-replacement" });
+          expect(chunkWriteTables(emptyPrepare.mock.calls.map(([sql]) => sql))).toEqual([]);
+        } finally {
+          emptyPrepare.mockRestore();
+        }
+        expect(
+          db.prepare("SELECT id FROM memory_index_chunks WHERE path = 'MEMORY.md'").all(),
+        ).toEqual([]);
+        expect(
+          db.prepare("SELECT hash FROM memory_index_sources WHERE path = 'MEMORY.md'").get(),
+        ).toBeDefined();
+        const results = await manager.search("alpha-fragment-body", { lexicalOnly: true });
+        expect(results.map((result) => result.path)).not.toContain("MEMORY.md");
+      } finally {
+        await manager.close();
+      }
+    },
+  );
+
+  it.each(CHUNK_WRITE_TABLES)(
+    "preserves the previous index and retries after %s publication fails",
+    async (failedTable) => {
+      const manager = await fixture.getFreshManager(
+        fixture.createConfig({ cacheEnabled: true }),
+        "cli",
+      );
+      try {
+        const db = Reflect.get(manager, "db") as DatabaseSync;
+        await manager.sync({ reason: "test" });
+        const snapshot = () =>
+          [
+            "memory_index_sources",
+            ...CHUNK_WRITE_TABLES,
+            "memory_embedding_cache",
+            "memory_index_chunks_fts",
+            "memory_index_state",
+          ].map((table) => db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all());
+        const before = snapshot();
+        expect(before[1]?.some((row) => String(row.text).includes("Alpha memory line."))).toBe(
+          true,
+        );
+        db.exec(`
+          CREATE TRIGGER fail_chunk_publication
+          AFTER INSERT ON ${failedTable}
+          BEGIN
+            SELECT RAISE(FAIL, 'forced chunk publication failure');
+          END;
+        `);
+        await fs.writeFile(
+          path.join(fixture.paths.memory, "2026-01-12.md"),
+          "# Log\nUpdated memory line.",
+        );
+        Reflect.set(manager, "dirty", true);
+        const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+        try {
+          await expect(manager.sync({ reason: "test" })).rejects.toThrow(
+            "forced chunk publication failure",
+          );
+          expect(chunkWriteTables(prepare.mock.calls.map(([sql]) => sql))).toEqual(
+            CHUNK_WRITE_TABLES.slice(0, CHUNK_WRITE_TABLES.indexOf(failedTable) + 1),
+          );
+        } finally {
+          prepare.mockRestore();
+        }
+        expect(snapshot()).toEqual(before);
+
+        db.exec("DROP TRIGGER fail_chunk_publication");
+        await manager.sync({ reason: "retry" });
+        expect(
+          db
+            .prepare("SELECT text FROM memory_index_chunks WHERE path LIKE ? AND source = ?")
+            .all("%2026-01-12.md", "memory"),
+        ).toEqual([{ text: "# Log\nUpdated memory line." }]);
+        const results = await manager.search("Updated memory line", { lexicalOnly: true });
+        expect(results[0]?.snippet).toContain("Updated memory line.");
+      } finally {
+        await manager.close();
+      }
+    },
+  );
+});

--- a/extensions/memory-core/src/memory/manager-chunk-writer.ts
+++ b/extensions/memory-core/src/memory/manager-chunk-writer.ts
@@ -1,0 +1,135 @@
+import type { DatabaseSync, StatementSync } from "node:sqlite";
+import type {
+  MemoryChunk,
+  MemoryEntryProvenance,
+  MemorySource,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import {
+  compileSqliteQueryBindings,
+  getNodeSqliteKysely,
+} from "openclaw/plugin-sdk/sqlite-runtime";
+
+export type IndexedMemoryChunk = MemoryChunk & {
+  importance: number | null;
+  triggers: string | null;
+  projectKey: string | null;
+};
+
+type ChunkWrite = { id: string; chunk: IndexedMemoryChunk; embedding: number[] };
+type ChunkDatabase = {
+  memory_index_chunks: {
+    id: string;
+    path: string;
+    source: MemorySource;
+    start_line: number;
+    end_line: number;
+    hash: string;
+    model: string;
+    text: string;
+    embedding: string;
+    updated_at: number;
+  };
+  memory_index_chunk_recall_metadata: {
+    chunk_id: string;
+    importance: number | null;
+    triggers: string | null;
+    project_key: string | null;
+  };
+  memory_index_chunk_provenance: {
+    chunk_id: string;
+    origin_class: MemoryEntryProvenance["originClass"];
+    session_kind: MemoryEntryProvenance["sessionKind"];
+    observed_at: number;
+    supersedes_key: string | null;
+  };
+};
+
+export function createMemoryChunkWriter(
+  database: DatabaseSync,
+  context: { path: string; source: MemorySource; model: string; now: number },
+) {
+  const db = getNodeSqliteKysely<ChunkDatabase>(database);
+  const chunkWrite = compileSqliteQueryBindings<ChunkWrite>((parameter) =>
+    db
+      .insertInto("memory_index_chunks")
+      .values({
+        id: parameter((row) => row.id),
+        path: context.path,
+        source: context.source,
+        start_line: parameter((row) => row.chunk.startLine),
+        end_line: parameter((row) => row.chunk.endLine),
+        hash: parameter((row) => row.chunk.hash),
+        model: context.model,
+        text: parameter((row) => row.chunk.text),
+        embedding: parameter((row) => JSON.stringify(row.embedding)),
+        updated_at: context.now,
+      })
+      .onConflict((conflict) =>
+        conflict.column("id").doUpdateSet((eb) => ({
+          hash: eb.ref("excluded.hash"),
+          model: eb.ref("excluded.model"),
+          text: eb.ref("excluded.text"),
+          embedding: eb.ref("excluded.embedding"),
+          updated_at: eb.ref("excluded.updated_at"),
+        })),
+      ),
+  );
+  const recallWrite = compileSqliteQueryBindings<ChunkWrite>((parameter) =>
+    db
+      .insertInto("memory_index_chunk_recall_metadata")
+      .values({
+        chunk_id: parameter((row) => row.id),
+        importance: parameter((row) => row.chunk.importance),
+        triggers: parameter((row) => row.chunk.triggers),
+        project_key: parameter((row) => row.chunk.projectKey),
+      })
+      .onConflict((conflict) =>
+        conflict.column("chunk_id").doUpdateSet((eb) => ({
+          importance: eb.ref("excluded.importance"),
+          triggers: eb.ref("excluded.triggers"),
+          project_key: eb.ref("excluded.project_key"),
+        })),
+      ),
+  );
+  const provenanceWrite = compileSqliteQueryBindings<{
+    id: string;
+    provenance: MemoryEntryProvenance;
+  }>((parameter) =>
+    db
+      .insertInto("memory_index_chunk_provenance")
+      .values({
+        chunk_id: parameter((row) => row.id),
+        origin_class: parameter((row) => row.provenance.originClass),
+        session_kind: parameter((row) => row.provenance.sessionKind),
+        observed_at: parameter((row) => row.provenance.observedAt),
+        supersedes_key: parameter((row) => row.provenance.supersedesKey ?? null),
+      })
+      .onConflict((conflict) =>
+        conflict.column("chunk_id").doUpdateSet((eb) => ({
+          origin_class: eb.ref("excluded.origin_class"),
+          session_kind: eb.ref("excluded.session_kind"),
+          observed_at: eb.ref("excluded.observed_at"),
+          supersedes_key: eb.ref("excluded.supersedes_key"),
+        })),
+      ),
+  );
+  let chunkStatement: StatementSync | undefined;
+  let recallStatement: StatementSync | undefined;
+  let provenanceStatement: StatementSync | undefined;
+
+  // One publication owns these statements, including large embeddings. Lazy
+  // preparation keeps empty writes inert and later tables untouched on failure.
+  return (id: string, chunk: IndexedMemoryChunk, embedding: number[]): void => {
+    const row = { id, chunk, embedding };
+    (chunkStatement ??= database.prepare(chunkWrite.compiled.sql)).run(...chunkWrite.bind(row));
+    (recallStatement ??= database.prepare(recallWrite.compiled.sql)).run(...recallWrite.bind(row));
+    const provenance = chunk.provenance ?? {
+      originClass: "untrusted" as const,
+      sessionKind: "unknown" as const,
+      observedAt: context.now,
+    };
+    (provenanceStatement ??= database.prepare(provenanceWrite.compiled.sql)).run(
+      ...provenanceWrite.bind({ id, provenance }),
+    );
+  };
+}

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -17,8 +17,6 @@ import {
   chunkMarkdown,
   hashText,
   MEMORY_EMBEDDING_CACHE_TABLE,
-  MEMORY_INDEX_CHUNK_PROVENANCE_TABLE,
-  MEMORY_INDEX_CHUNK_RECALL_METADATA_TABLE,
   MEMORY_INDEX_FTS_TABLE,
   MEMORY_INDEX_VECTOR_TABLE,
   remapChunkLines,
@@ -37,6 +35,7 @@ import { hasMemorySessionTombstone } from "../memory-entry-origins.js";
 import { withMemoryWorkspaceLock } from "../memory-workspace-lock.js";
 import { readSessionResetRecallCutoffMetadata } from "../session-reset-recall-metadata.js";
 import type { EmbeddingProvider } from "./embeddings.js";
+import { createMemoryChunkWriter, type IndexedMemoryChunk } from "./manager-chunk-writer.js";
 import {
   collectMemoryCachedEmbeddings,
   loadMemoryEmbeddingCache,
@@ -98,12 +97,6 @@ function resolveEmbeddingSecondsTimeoutMs(seconds: number): number {
 }
 
 type MemoryIndexEntry = MemoryIndexWorkItem["entry"];
-
-type IndexedMemoryChunk = MemoryChunk & {
-  importance: number | null;
-  triggers: string | null;
-  projectKey: string | null;
-};
 
 type PreparedMemoryIndexEntry = {
   entry: MemoryIndexEntry;
@@ -794,68 +787,18 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           }
         }
         this.clearIndexedFileData(entry.path, source);
+        const writeChunk = createMemoryChunkWriter(this.db, {
+          path: entry.path,
+          source,
+          model,
+          now,
+        });
         for (const [i, chunk] of chunks.entries()) {
           const embedding = embeddings[i] ?? [];
           const id = hashText(
             `${source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${model}`,
           );
-          this.db
-            .prepare(
-              `INSERT INTO memory_index_chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-               ON CONFLICT(id) DO UPDATE SET
-                 hash=excluded.hash,
-                 model=excluded.model,
-                 text=excluded.text,
-                 embedding=excluded.embedding,
-                 updated_at=excluded.updated_at`,
-            )
-            .run(
-              id,
-              entry.path,
-              source,
-              chunk.startLine,
-              chunk.endLine,
-              chunk.hash,
-              model,
-              chunk.text,
-              JSON.stringify(embedding),
-              now,
-            );
-          this.db
-            .prepare(
-              `INSERT INTO ${MEMORY_INDEX_CHUNK_RECALL_METADATA_TABLE} (
-                 chunk_id, importance, triggers, project_key
-               ) VALUES (?, ?, ?, ?)
-               ON CONFLICT(chunk_id) DO UPDATE SET
-                 importance=excluded.importance,
-                 triggers=excluded.triggers,
-                 project_key=excluded.project_key`,
-            )
-            .run(id, chunk.importance, chunk.triggers, chunk.projectKey);
-          const provenance = chunk.provenance ?? {
-            originClass: "untrusted" as const,
-            sessionKind: "unknown" as const,
-            observedAt: now,
-          };
-          this.db
-            .prepare(
-              `INSERT INTO ${MEMORY_INDEX_CHUNK_PROVENANCE_TABLE} (
-                 chunk_id, origin_class, session_kind, observed_at, supersedes_key
-               ) VALUES (?, ?, ?, ?, ?)
-               ON CONFLICT(chunk_id) DO UPDATE SET
-                 origin_class=excluded.origin_class,
-                 session_kind=excluded.session_kind,
-                 observed_at=excluded.observed_at,
-                 supersedes_key=excluded.supersedes_key`,
-            )
-            .run(
-              id,
-              provenance.originClass,
-              provenance.sessionKind,
-              provenance.observedAt,
-              provenance.supersedesKey ?? null,
-            );
+          writeChunk(id, chunk, embedding);
           if (vectorReady && embedding.length > 0) {
             replaceMemoryVectorRow({
               db: this.db,

--- a/extensions/memory-core/src/memory/manager-index.test-support.ts
+++ b/extensions/memory-core/src/memory/manager-index.test-support.ts
@@ -45,7 +45,6 @@ export type ManagerIndexFixtureConfig = {
   ftsTokenizer?: "unicode61" | "trigram";
   cacheEnabled?: boolean;
   minScore?: number;
-  onSearch?: boolean;
   hybrid?: {
     enabled: boolean;
     vectorWeight?: number;
@@ -69,6 +68,7 @@ type ProviderControls = {
   embeddedBatchInputs: EmbeddingInput[][];
   providerRuntimeBatchCalls: string[][];
   providerRuntimeBatchGate: Promise<void> | null;
+  providerRuntimeBatchEntered: ((activeCalls: number) => void) | null;
   providerRuntimeBatchErrors: unknown[];
   providerRuntimeBatchFailuresRemaining: number;
   providerRuntimeActiveBatchCalls: number;
@@ -131,6 +131,7 @@ const providerState = vi.hoisted(() => ({
   embeddedBatchInputs: [] as EmbeddingInput[][],
   providerRuntimeBatchCalls: [] as string[][],
   providerRuntimeBatchGate: null as Promise<void> | null,
+  providerRuntimeBatchEntered: null as ((activeCalls: number) => void) | null,
   providerRuntimeBatchErrors: [] as unknown[],
   providerRuntimeBatchFailuresRemaining: 0,
   providerRuntimeActiveBatchCalls: 0,
@@ -335,6 +336,9 @@ vi.mock("./embeddings.js", async (importOriginal) => {
                       providerState.providerRuntimeActiveBatchCalls,
                     );
                     try {
+                      providerState.providerRuntimeBatchEntered?.(
+                        providerState.providerRuntimeActiveBatchCalls,
+                      );
                       await providerState.providerRuntimeBatchGate;
                       providerState.providerRuntimeBatchCalls.push(
                         batch.chunks.map((chunk) => chunk.text),
@@ -436,7 +440,6 @@ export function createManagerIndexFixture(deps: {
             vector: params.vectorEnabled !== undefined ? { enabled: params.vectorEnabled } : {},
           },
           remote: params.batchEnabled ? { batch: { enabled: true } } : undefined,
-          sync: params.onSearch === undefined ? undefined : { onSearch: params.onSearch },
           query: { minScore: params.minScore ?? 0 },
           cache: params.cacheEnabled ? { enabled: true } : undefined,
           extraPaths: params.extraPaths,
@@ -569,6 +572,7 @@ export function createManagerIndexFixture(deps: {
     providerState.embeddedBatchInputs = [];
     providerState.providerRuntimeBatchCalls = [];
     providerState.providerRuntimeBatchGate = null;
+    providerState.providerRuntimeBatchEntered = null;
     providerState.providerRuntimeBatchErrors = [];
     providerState.providerRuntimeBatchFailuresRemaining = 0;
     providerState.providerRuntimeActiveBatchCalls = 0;

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -536,7 +536,7 @@ describe("memory index", () => {
 
   it("does not block querying on session reconciliation", async () => {
     const manager = await getPersistentManager(
-      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
+      createCfg({ provider: "none", minScore: 0, hybrid: { enabled: true } }),
     );
     await manager.sync({ reason: "test" });
 
@@ -581,16 +581,10 @@ describe("memory index", () => {
         sources: ["memory", "sessions"],
         sessionMemory: true,
         minScore: 0,
-        onSearch: true,
         hybrid: { enabled: true },
       });
       const manager = await getPersistentManager(cfg);
       await manager.sync({ reason: "test", force: true });
-      // This fixture supplies one exact dirty generation, without later native
-      // watcher notifications adding another generation during the handoff.
-      (
-        manager as unknown as { closeNativeMemoryWatchPairs: () => void }
-      ).closeNativeMemoryWatchPairs();
       const content = "Current memory appears only after the dirty search sync.";
       if (source === "memory") {
         await fs.writeFile(path.join(fixture.paths.memory, "search-sync.md"), content);
@@ -697,7 +691,6 @@ describe("memory index", () => {
       provider: "none",
       sources: ["memory"],
       minScore: 0,
-      onSearch: true,
       hybrid: { enabled: true },
     });
     const manager = await getPersistentManager(cfg);
@@ -788,7 +781,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "none",
       minScore: 0,
-      onSearch: false,
       hybrid: { enabled: true },
     });
     const initialManager = await getFreshManager(cfg, "cli");
@@ -879,7 +871,7 @@ describe("memory index", () => {
     "restores a failed maintenance generation after $name and still closes its transient manager",
     async ({ error: syncError, expectedSyncCalls }) => {
       const manager = await getPersistentManager(
-        createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
+        createCfg({ provider: "none", minScore: 0, hybrid: { enabled: true } }),
       );
       await manager.sync({ reason: "test" });
       const maintenance = {
@@ -934,7 +926,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "none",
       minScore: 0,
-      onSearch: true,
       hybrid: { enabled: true },
     });
     const manager = await getPersistentManager(cfg);
@@ -960,7 +951,7 @@ describe("memory index", () => {
 
   it("does not let a no-op sync hide a later detached failure", async () => {
     const manager = await getPersistentManager(
-      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
+      createCfg({ provider: "none", minScore: 0, hybrid: { enabled: true } }),
     );
     await manager.sync({ reason: "baseline" });
     const maintenanceStarted = createDeferred<void>();
@@ -1005,7 +996,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       fallback: "fallback-provider",
       minScore: 0,
-      onSearch: true,
       hybrid: { enabled: true },
     });
     const manager = await getPersistentManager(cfg);
@@ -1057,7 +1047,7 @@ describe("memory index", () => {
 
   it("does not let a rejected maintenance handoff abort manager teardown", async () => {
     const manager = await getPersistentManager(
-      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
+      createCfg({ provider: "none", minScore: 0, hybrid: { enabled: true } }),
     );
     await manager.sync({ reason: "test" });
     Reflect.set(manager, "dirty", true);

--- a/extensions/memory-core/src/memory/manager-search-provenance.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-provenance.test.ts
@@ -29,7 +29,7 @@ describe("memory search provenance enrichment", () => {
       ),
     );
     const manager = await fixture.getPersistentManager(
-      fixture.createConfig({ vectorEnabled: entry.vector, minScore: 0, onSearch: false }),
+      fixture.createConfig({ vectorEnabled: entry.vector, minScore: 0 }),
     );
     await manager.sync({ reason: "test" });
     const fields = manager as unknown as { db: DatabaseSync; provider: EmbeddingProvider };

--- a/extensions/memory-core/src/memory/manager.borrowed-connection.test.ts
+++ b/extensions/memory-core/src/memory/manager.borrowed-connection.test.ts
@@ -17,8 +17,7 @@ describe("memory manager shared agent connection", () => {
     getMemorySearchManager,
     closeAllMemorySearchManagers,
   });
-  const createConfig = () =>
-    fixture.createConfig({ provider: "none", vectorEnabled: false, onSearch: false });
+  const createConfig = () => fixture.createConfig({ provider: "none", vectorEnabled: false });
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -77,7 +76,6 @@ describe("memory manager shared agent connection", () => {
         provider: "none",
         vectorEnabled: false,
         minScore: 0.1,
-        onSearch: false,
       }),
     );
 

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -135,7 +135,6 @@ describe("memory manager FTS-only reindex", () => {
           model: "",
           store,
           cache: { enabled: false },
-          sync: { watch: false, onSessionStart: false, onSearch: false },
         },
       },
       agents: {

--- a/extensions/memory-core/src/memory/manager.legacy-migration-cleanup.test.ts
+++ b/extensions/memory-core/src/memory/manager.legacy-migration-cleanup.test.ts
@@ -140,7 +140,6 @@ describe("memory legacy migration cleanup", () => {
               },
             },
             cache: { enabled: false },
-            sync: { watch: false, onSessionStart: false, onSearch: false },
             query: { hybrid: { enabled: true } },
           },
         },

--- a/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
+++ b/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
@@ -106,7 +106,6 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
           model: "",
           store,
           cache: { enabled: false },
-          sync: { watch: false, onSessionStart: false, onSearch: false },
         },
       },
       agents: {

--- a/extensions/memory-core/src/memory/test-runtime-mocks.ts
+++ b/extensions/memory-core/src/memory/test-runtime-mocks.ts
@@ -5,13 +5,29 @@ import {
   resetMemoryCoreDreamingStateForTests,
 } from "../test-helpers.js";
 
+const nativeWatchFactoryKey = Symbol.for("openclaw.test.memoryNativeWatchFactory");
+let originalNativeWatchFactory: PropertyDescriptor | undefined;
+
 // Memory indexing reads flush provenance from plugin state. Manager tests use
 // this shared setup instead of booting the full plugin runtime.
 beforeAll(async () => {
+  // Native directory watchers bypass chokidar. These manually driven fixtures
+  // must silence both event sources so host events cannot create extra sync generations.
+  originalNativeWatchFactory = Object.getOwnPropertyDescriptor(globalThis, nativeWatchFactoryKey);
+  Object.defineProperty(globalThis, nativeWatchFactoryKey, {
+    configurable: true,
+    writable: true,
+    value: createWatcherMock,
+  });
   await configureMemoryCoreDreamingStateForTests();
 });
 
 afterAll(() => {
+  if (originalNativeWatchFactory) {
+    Object.defineProperty(globalThis, nativeWatchFactoryKey, originalNativeWatchFactory);
+  } else {
+    Reflect.deleteProperty(globalThis, nativeWatchFactoryKey);
+  }
   resetMemoryCoreDreamingStateForTests();
 });
 

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -78,7 +78,6 @@ describe("memory_search real manager", () => {
     const cfg = fixture.createConfig({
       provider: "none",
       vectorEnabled: false,
-      onSearch: false,
     });
     const manager = await fixture.getFreshManager(cfg);
     await manager.sync({ reason: "cli", force: true });
@@ -114,7 +113,7 @@ describe("memory_search real manager", () => {
 
   it("preserves reindex guidance alongside wiki results after an embedding model change", async () => {
     const manager = await fixture.getFreshManager(
-      fixture.createConfig({ model: "old-embed", vectorEnabled: false, onSearch: false }),
+      fixture.createConfig({ model: "old-embed", vectorEnabled: false }),
     );
     await manager.sync({ reason: "cli", force: true });
     await manager.close();
@@ -134,7 +133,6 @@ describe("memory_search real manager", () => {
         config: fixture.createConfig({
           model: "new-embed",
           vectorEnabled: false,
-          onSearch: false,
         }),
         agentId: "main",
       });
@@ -180,7 +178,6 @@ describe("memory_search real manager", () => {
       sessionMemory: true,
       minScore: 0,
       vectorEnabled: false,
-      onSearch: true,
     });
     const sessionKey = "agent:main:telegram:direct:refresh-proof";
     await fixture.seedSessionTranscript({
@@ -428,7 +425,6 @@ describe("memory_search real manager", () => {
       sources: ["memory"],
       vectorEnabled: false,
       minScore: 0,
-      onSearch: false,
     });
     const initializedManager = await fixture.getFreshManager(cfg, "cli");
     await initializedManager.sync({ reason: "test", force: true });


### PR DESCRIPTION
## What Problem This Solves

Indexing memory files with many chunks repeats the same database preparation work for every fragment. Three ordinary chunk writes also remain outside the shared typed query helpers.

## Why This Change Was Made

A private writer owned by each file publication compiles the chunk, recall-metadata and provenance mutations with Kysely and lazily prepares each native statement once per nonempty file. It preserves the existing transaction owner, write/error order, conflict columns and stored values.

The manager fixtures now scope both native and chokidar watcher mocks, wait for actual provider entry in concurrency tests, and remove retired synchronization inputs. The fixture fixes preserve the concurrency outcomes and existing timeout values.

## User Impact

Large memory files require fewer repeated SQLite preparations. Indexed content, provenance, recall metadata, search results and rollback behavior remain unchanged relative to the current base. This PR adds no schema, migration, retention, configuration or dependency change.

Production is +143/−65 (net +78), buying typed mutations and a bounded statement lifetime; tests/support are +225/−139 (net +86).

## Evidence

Current candidate: `a2248bb8c81396ca9bf06c457f66c52505bc3a3b`, compared with `a2421a2c08c9f3a9a113c1788e8ebbef76b57ace`. The current proof runs on isolated macOS with Node 24.20.0, SQLite 3.53.4, repository-pinned pnpm 12.3.4 and Vitest 5.0.0.

The fresh composed runs passed: the original 17-file context (256 tests), original six-file context (144), temporal-ranking and real-manager tools (13), two additional fixture consumers (4), and the two affected CLI corruption cases (99 unrelated cases unselected). These executions overlap and are reported separately. The full 14-file changed gate against the current base passed in 235.8 seconds, including typechecks, unused-export checks, lint, Doctor tests and guards.

A fresh native comparison with the current base indexed 239 chunks with 3 preparations instead of 717. It verified row and conflict parity, transaction rollback/retry and error identity, `count_changes`, and closed-operation rejection. The current memory-core qaRuntime build passed in 18.8 seconds. All 12 commands through that new CLI build passed in 20.0 seconds: force, incremental and empty indexing; keyword search; synthetic version-3-to-4 metadata repair; fresh-process reopening; unrelated blob preservation; shadow cleanup; and `integrity_check=ok`.

All nine proof phases passed without retries, changed timeouts or skipped guards. All 14 candidate files and 18 integration files matched their frozen hashes before and after, and the exact candidate Git tree stayed clean. The synthetic CLI home was removed and the isolated runner lease was stopped.

The earlier writer/fixture patch received fourteen clean independent P0–P2 reports and passed isolated macOS proof under Vitest 4.1.11. Those results remain historical. Thirteen files are byte-identical after composition; the tool test retains main's two ordering assertions alongside the reviewed cleanup. The current candidate also passed twenty-one independent P0–P2 integration-review reports; all complete reports were read before publication.

Earlier local filesystem stalls, the superseded inert fixture setting, and failed preflight/gate attempts remain recorded. No timeout or guard was relaxed and no production watcher behavior changed. CLI proof uses provider `none`, without an external embedding API or production Gateway.

## Data-Model Compatibility

This changes statement preparation and query construction, not the persisted model. No schema, migration, generated database definition, version marker, embedding encoding, conflict-update set or provenance default changes. The current agent schema and all three publication-table definitions are unchanged. Native comparisons verify complete rows and row identity against the parent, including large embedding JSON, nullable recall fields, conflicts, rollback/retry and subsequent writes. The fresh CLI also exercises the existing metadata-version 3-to-4 repair, search and physical reopen while preserving unrelated blob bytes. No new migration is required.

The review's path-based data-model flag is addressed by that unchanged-source and existing-store proof. Its raw source table includes 16 lines from test-runtime-mocks.ts; that file is test support. The reviewed production/test split remains +78/+86, as the review's own metrics state.
