### PR TITLE
perf(plugins): avoid preparing dispatch lists for hook presence checks

### DIFF
--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -243,9 +243,28 @@ type SyncHookContext<K extends SyncHookName> = Parameters<SyncHookHandler<K>>[1]
 type SyncHookMessage = PluginHookToolResultPersistEvent["message"];
 type SyncMessageHookStepResult = { message?: SyncHookMessage; block?: true };
 
-/**
- * Get hooks for a specific hook name, sorted by priority (higher first).
- */
+function isHookContextEligible(hook: PluginHookRegistration, ctx?: unknown): boolean {
+  if (hook.hookName === "reply_dispatch" && hook.eligibleDispatchKinds !== undefined) {
+    const kind =
+      typeof ctx === "object" && ctx !== null && "dispatchKind" in ctx
+        ? ctx.dispatchKind
+        : undefined;
+    // Unknown callers cannot prove exclusion from a hook, including during recovery checks.
+    return !isPluginHookReplyDispatchKind(kind) || hook.eligibleDispatchKinds.includes(kind);
+  }
+  if (hook.hookName !== "before_agent_reply" || hook.eligibleTriggers === undefined) {
+    return true;
+  }
+  const trigger =
+    typeof ctx === "object" && ctx !== null && "trigger" in ctx
+      ? (ctx as { trigger?: unknown }).trigger
+      : undefined;
+  return (
+    typeof trigger === "string" && hook.eligibleTriggers.includes(trigger as PluginHookAgentTrigger)
+  );
+}
+
+/** Get hooks for a specific hook name, sorted by priority (higher first). */
 function getHooksForName<K extends PluginHookName>(
   registry: HookRunnerRegistry,
   hookName: K,
@@ -253,30 +272,7 @@ function getHooksForName<K extends PluginHookName>(
   toolName?: string,
 ): PluginHookRegistration<K>[] {
   return (registry.typedHooks as PluginHookRegistration<K>[])
-    .filter((hook) => {
-      if (hook.hookName !== hookName) {
-        return false;
-      }
-      if (hookName === "reply_dispatch" && hook.eligibleDispatchKinds !== undefined) {
-        const kind =
-          typeof ctx === "object" && ctx !== null && "dispatchKind" in ctx
-            ? ctx.dispatchKind
-            : undefined;
-        // Unknown callers cannot prove exclusion from a hook, including during recovery checks.
-        return !isPluginHookReplyDispatchKind(kind) || hook.eligibleDispatchKinds.includes(kind);
-      }
-      if (hookName !== "before_agent_reply" || hook.eligibleTriggers === undefined) {
-        return true;
-      }
-      const trigger =
-        typeof ctx === "object" && ctx !== null && "trigger" in ctx
-          ? (ctx as { trigger?: unknown }).trigger
-          : undefined;
-      return (
-        typeof trigger === "string" &&
-        hook.eligibleTriggers.includes(trigger as PluginHookAgentTrigger)
-      );
-    })
+    .filter((hook) => hook.hookName === hookName && isHookContextEligible(hook, ctx))
     .filter((hook) => toolName === undefined || pluginToolMatcherCoversTool(hook.matcher, toolName))
     .toSorted((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
 }
@@ -1724,10 +1720,10 @@ export function createHookRunner(
     hookName: K,
     ctx?: Partial<Parameters<PluginHookHandlerMap[K]>[1]>,
   ): boolean {
-    if (ctx === undefined) {
-      return registry.typedHooks.some((hook) => hook.hookName === hookName);
-    }
-    return getHooksForName(registry, hookName, ctx).length > 0;
+    return registry.typedHooks.some(
+      (hook) =>
+        hook.hookName === hookName && (ctx === undefined || isHookContextEligible(hook, ctx)),
+    );
   }
 
   /**


### PR DESCRIPTION
## What Problem This Solves

Resolves avoidable allocation when reply admission and takeover checks ask whether a plugin hook can run. Contextual presence checks prepared and sorted complete dispatch lists, even though they needed only a boolean and actual dispatch prepared its own list afterward.

## Why This Change Was Made

`src/plugins/hooks.ts` shares its existing context-eligibility predicate between presence and dispatch; contextual `hasHooks` stops at the first eligible registration with `some`. Context-free checks retain name-only semantics. The actual dispatch selector keeps both filter passes, their evaluation order, priority comparator, and `toSorted`, preserving eligibility-before-matcher validation.

Before-reply admission, reply-dispatch takeover, and the global runner use this owner. Live registry getters continue to observe replacement, scoped composition, and late registration. An attempted in-place dispatch sort was rejected by the existing lint rule and reverted; the final measurements use the corrected source. Metadata snapshot caching was also rejected, leaving Map/Set/accessor/proxy traversal unchanged.

Production: +27/-31 lines (net -4); tests/support: +0/-0. The existing selector absorbs the change without a cache, new plugin policy, or public interface.

## User Impact

Contextual hook availability checks prepare fewer temporary lists while preserving eligible hooks, dispatch-kind decisions, priority ties, and actual invocation behavior. Actual dispatch retains its existing allocations; the unchanged context-free path has no claimed improvement.

## Evidence

The local harness imports the actual hook owner with synthetic registries. All 37 outcomes match, including missing/explicit contexts, triggers, dispatch kinds, handler ordering, registry identities, replacement, and appended registrations. Separate instrumentation over 100 contextual queries changes 200 filters plus 100 `toSorted` calls into 100 `some` calls, with zero filters/sorts; this does not imply zero total allocation.

Node 26.8.1/macOS arm64 observations:

| Registrations / query | Calls | Sampled bytes before → after | Median ms before → after |
| --- | ---: | ---: | ---: |
| 0 / empty registry | 20,000 | 7,294,792 → 2,013,472 | 0.908 → 0.454 |
| 1 / hit | 10,000 | 6,865,088 → 1,068,192 | 1.051 → 0.353 |
| 64 / hit | 6,000 | 27,343,536 → 653,656 | 10.473 → 0.169 |
| 1,024 / hit | 2,000 | 149,472,712 → 203,488 | 55.536 → 0.053 |
| 1,024 / late hit | 2,000 | 1,376,960 → 252,000 | 22.826 → 20.941 |
| 64 / absent | 6,000 | 2,123,096 → 619,152 | 4.925 → 3.681 |
| 64 / context-free control | 6,000 | 598,264 → 639,640 | 0.082 → 0.123 |

The 1 KiB cumulative sampler includes collected objects and runs separately from counters and three timing batches. The control's higher sampled bytes/time are retained. One shared-host pair establishes neither statistical latency, retained heap/RSS, whole-Gateway savings, nor actual-dispatch allocation improvement.

```sh
env OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/hooks.before-agent-reply.test.ts src/plugins/wired-hooks-reply-dispatch.test.ts src/plugins/hook-runner-global.test.ts src/plugins/hook-runner-global.compose.test.ts src/plugins/hooks.security.test.ts src/plugins/hooks.before-tool-call.test.ts src/plugins/hooks.phase-hooks.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/hooks.ts
```

The corrected final source passes 94 tests across seven files, exact-file type-aware lint, formatting, and `git diff --check`. The initial baseline command named two nonexistent tests and failed before collection; the corrected baseline passed. Changed-plan classification passed; broad local gates were not executed. Independent P2 review recorded a scoped-clean result. Required exact-head hosted CI/native landing gates remain mandatory; no live Gateway/provider or integrated performance result is claimed.
