### PR TITLE
fix(codex): keep completed replies when settlement expires

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -802,10 +802,22 @@ approvals, dynamic tools, and cancellation retain their independent deadlines.
 
 On receipt of the exact native terminal event, OpenClaw starts an absolute
 two-minute local-settlement budget before asynchronous transcript and media
-projection. Later notifications do not reset it. After separately bounded
-abort cleanup, queued projection gets a five-second drain grace. These local
-bounds still apply to unlimited runs, so blocked projection cannot keep the
-session lane occupied indefinitely.
+projection. Later notifications do not reset it. Presentation callbacks start
+in order and join at settlement without blocking native notification processing.
+If the native turn completed successfully with a complete final answer, expiry
+preserves that answer as a degraded success. OpenClaw retires unfinished
+projection and stale writes, then persists the answer through the existing
+transcript owner, preserving write ordering and hooks.
+
+The `turn.settlement_warning` trajectory event records the pending presentation
+callback, transcript/checkpoint write, or media projection stage, together with
+the elapsed time and budget. Newly persisted recovered replies also carry the
+settlement warning. Final persistence retains its best-effort policy and the
+existing five-second drain grace; if the writer remains unavailable, OpenClaw
+records `turn.settlement_persistence_unavailable` and delivers the completed
+text without leaving a stale write behind. Expiry without a native completed answer remains a timeout.
+After separately bounded abort cleanup, queued projection gets a five-second
+drain grace. These local bounds also apply to unlimited runs.
 
 Stop and execution-budget expiry interrupt the affected native attempt and
 bound cleanup before releasing its lane. A quiet turn or a local settlement

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -808,6 +808,9 @@ If the native turn completed successfully with a complete final answer, expiry
 preserves that answer as a degraded success. OpenClaw retires unfinished
 projection and stale writes, then persists the answer through the existing
 transcript owner, preserving write ordering and hooks.
+Recovered replies retain native network-result provenance even when the
+corresponding tool projection did not settle or a message-write hook replaces
+the message.
 
 The `turn.settlement_warning` trajectory event records the pending presentation
 callback, transcript/checkpoint write, or media projection stage, together with

--- a/extensions/codex/src/app-server/attempt-terminal.ts
+++ b/extensions/codex/src/app-server/attempt-terminal.ts
@@ -12,4 +12,7 @@ export type AttemptFailureSource = Extract<
   EmbeddedRunAttemptResult["terminal"],
   { kind: "failed" }
 >["source"];
+export type AttemptSettlementWarning = NonNullable<
+  Extract<EmbeddedRunAttemptResult["terminal"], { kind: "ok" }>["settlementWarning"]
+>;
 export const attemptTerminal = agentHarnessAttemptTerminal;

--- a/extensions/codex/src/app-server/event-projector-events.ts
+++ b/extensions/codex/src/app-server/event-projector-events.ts
@@ -14,6 +14,7 @@ import {
   itemName,
   itemStatus,
   itemTitle,
+  matchesCodexSnapshotTurn,
   shouldSynthesizeToolProgressForItem,
 } from "./event-projector-items.js";
 import {
@@ -390,6 +391,34 @@ export class CodexEventProjection {
         ...(suppressChannelProgress ? { suppressChannelProgress: true } : {}),
       },
     });
+  }
+
+  async emitSnapshotOnlyNativeToolProgress(params: {
+    item: CodexThreadItem;
+    activeItemIds: Set<string>;
+    completedItemIds: Set<string>;
+    isActive: () => boolean;
+  }): Promise<void> {
+    const { item, activeItemIds, completedItemIds, isActive } = params;
+    if (
+      !shouldSynthesizeToolProgressForItem(item) ||
+      !matchesCodexSnapshotTurn(item, this.turnId) ||
+      completedItemIds.has(item.id) ||
+      itemStatus(item) === "running"
+    ) {
+      return;
+    }
+    if (!activeItemIds.has(item.id)) {
+      this.emitStandardItemEvent({ phase: "start", item });
+      await this.emitNormalizedToolItemEvent({ phase: "start", item });
+    }
+    if (!isActive()) {
+      return;
+    }
+    activeItemIds.delete(item.id);
+    this.emitStandardItemEvent({ phase: "end", item });
+    await this.emitNormalizedToolItemEvent({ phase: "result", item });
+    completedItemIds.add(item.id);
   }
 
   async emitNormalizedToolItemEvent(params: {

--- a/extensions/codex/src/app-server/event-projector-result.ts
+++ b/extensions/codex/src/app-server/event-projector-result.ts
@@ -43,6 +43,7 @@ type CodexAttemptResultInput = {
   turnId: string;
   upstreamUserText: string | undefined;
   completedTurn: CodexTurn | undefined;
+  turnTainted: boolean;
   promptError: unknown;
   promptErrorSource: AttemptFailureSource | null;
   providerRefusal: CodexProviderRefusal | undefined;
@@ -161,6 +162,7 @@ export function buildCodexAttemptResult(
     commentaryMessages,
     toolMessages: input.toolTranscriptProjection.transcriptMessages,
     lastAssistant,
+    turnTainted: input.turnTainted,
   });
   const turnFailed = input.completedTurn?.status === "failed";
   const promptError = input.providerRefusal

--- a/extensions/codex/src/app-server/event-projector-settlement.ts
+++ b/extensions/codex/src/app-server/event-projector-settlement.ts
@@ -1,0 +1,91 @@
+import {
+  embeddedAgentLog,
+  type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { CodexTurn } from "./protocol.js";
+
+type PresentationStage =
+  | "onAssistantMessageStart"
+  | "onPartialReply"
+  | "onReasoningStream"
+  | "onReasoningEnd";
+
+export class CodexProjectionSettlement {
+  readonly params: EmbeddedRunAttemptParams;
+  terminalReceipt: CodexTurn | undefined;
+  private stage: string | undefined;
+  private readonly pending = new Map<Promise<void>, PresentationStage>();
+
+  constructor(params: EmbeddedRunAttemptParams, isActive: () => boolean) {
+    const detach = <Args extends unknown[]>(
+      stage: PresentationStage,
+      callback: ((...args: Args) => unknown) | undefined,
+    ): ((...args: Args) => void) | undefined =>
+      callback
+        ? (...args) => {
+            if (!isActive()) {
+              return;
+            }
+            // Reserve before invocation so reentrant callbacks retain source order.
+            // Only presentation detaches; the terminal owner joins these promises.
+            const completion = createDeferred<void>();
+            this.pending.set(completion.promise, stage);
+            const settled = () => {
+              this.pending.delete(completion.promise);
+              completion.resolve();
+            };
+            const failed = (error: unknown) => {
+              embeddedAgentLog.warn(`codex app-server ${stage} callback failed: ${String(error)}`);
+              settled();
+            };
+            try {
+              void Promise.resolve(callback(...args)).then(settled, failed);
+            } catch (error) {
+              failed(error);
+            }
+          }
+        : undefined;
+    this.params = {
+      ...params,
+      onAssistantMessageStart: detach("onAssistantMessageStart", params.onAssistantMessageStart),
+      onPartialReply: detach("onPartialReply", params.onPartialReply),
+      onReasoningStream: detach("onReasoningStream", params.onReasoningStream),
+      onReasoningEnd: detach("onReasoningEnd", params.onReasoningEnd),
+    };
+  }
+
+  get pendingStage(): string | undefined {
+    return this.stage ?? this.pending.values().next().value;
+  }
+
+  get completedAnswer() {
+    const turn = this.terminalReceipt;
+    // Codex 0.153.0 turn/completed carries the last assistant item as a summary.
+    const answer = turn?.items?.findLast(
+      (item) =>
+        item.type === "agentMessage" &&
+        item.phase !== "commentary" &&
+        item.delivery !== "async" &&
+        typeof item.text === "string" &&
+        item.text.trim().length > 0,
+    );
+    return turn?.status === "completed" && answer ? { turn, answer } : undefined;
+  }
+
+  async project<T>(stage: string, project: () => Promise<T>): Promise<T> {
+    const previous = this.stage;
+    this.stage = stage;
+    try {
+      return await project();
+    } finally {
+      this.stage = previous;
+    }
+  }
+
+  async drain(): Promise<void> {
+    while (this.pending.size > 0) {
+      await Promise.all(this.pending.keys());
+    }
+  }
+}

--- a/extensions/codex/src/app-server/event-projector-settlement.ts
+++ b/extensions/codex/src/app-server/event-projector-settlement.ts
@@ -14,6 +14,7 @@ type PresentationStage =
 export class CodexProjectionSettlement {
   readonly params: EmbeddedRunAttemptParams;
   terminalReceipt: CodexTurn | undefined;
+  turnTainted = false;
   private stage: string | undefined;
   private readonly pending = new Map<Promise<void>, PresentationStage>();
 

--- a/extensions/codex/src/app-server/event-projector-snapshot.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.ts
@@ -21,6 +21,7 @@ export function buildCodexMessagesSnapshot(params: {
   assistantMessages?: ReadonlyArray<{ itemId: string; message: AssistantMessage }>;
   toolMessages: readonly AgentMessage[];
   lastAssistant: AssistantMessage | undefined;
+  turnTainted?: boolean;
 }): AgentMessage[] {
   const messages = promptSnapshot(params.runParams, params.turnId, params.upstreamUserText);
   if (params.reasoningText) {
@@ -53,7 +54,10 @@ export function buildCodexMessagesSnapshot(params: {
   );
   messages.push(...visibleWorkMessages);
   if (params.lastAssistant) {
-    messages.push(attachCodexMirrorIdentity(params.lastAssistant, `${params.turnId}:assistant`));
+    const assistant = applyCodexTranscriptTaint(params.lastAssistant, {
+      tainted: params.turnTainted === true,
+    });
+    messages.push(attachCodexMirrorIdentity(assistant, `${params.turnId}:assistant`));
   }
   const taint = { tainted: false };
   return messages.map((message) =>

--- a/extensions/codex/src/app-server/event-projector.media.test.ts
+++ b/extensions/codex/src/app-server/event-projector.media.test.ts
@@ -18,6 +18,7 @@ import {
   turnCompleted,
   type EmbeddedRunAttemptParams,
 } from "./event-projector.test-harness.js";
+import type { CodexRemoteWorkspaceFileReader } from "./remote-workspace-media.js";
 
 registerCodexEventProjectorTestLifecycle();
 
@@ -119,11 +120,15 @@ describe("CodexAppServerEventProjector media projection", () => {
   });
 
   it("fetches saved-path-only remote images over the bounded Codex command protocol", async () => {
-    const readRemoteWorkspaceFile = vi.fn(async () => ({ dataBase64: tinyPngBase64 }));
+    const readRemoteWorkspaceFile = vi.fn<CodexRemoteWorkspaceFileReader>(async () => ({
+      dataBase64: tinyPngBase64,
+    }));
+    const runAbort = new AbortController();
     const projector = await createProjector(undefined, {
       remoteWorkspaceRoot: "/remote/codex-workspace",
       readRemoteWorkspaceFile,
       remoteWorkspaceRequestTimeoutMs: 90_000,
+      runAbortSignal: runAbort.signal,
     });
     const savedPath = "/remote/codex-home/generated_images/session-1/ig_saved_only.png";
 
@@ -143,7 +148,7 @@ describe("CodexAppServerEventProjector media projection", () => {
     expect(readRemoteWorkspaceFile).toHaveBeenCalledWith({
       path: savedPath,
       maxBytes: expect.any(Number),
-      signal: undefined,
+      signal: expect.any(AbortSignal),
       timeoutMs: 90_000,
     });
     expect(result.toolMediaUrls).toHaveLength(1);
@@ -151,13 +156,17 @@ describe("CodexAppServerEventProjector media projection", () => {
     await expect(fs.readFile(result.toolMediaUrls?.[0] ?? "")).resolves.toEqual(
       Buffer.from(tinyPngBase64, "base64"),
     );
+    const signal = readRemoteWorkspaceFile.mock.calls[0]?.[0].signal;
+    expect(signal?.aborted).toBe(false);
+    runAbort.abort();
+    expect(signal?.aborted).toBe(true);
   });
 
   it.each([false, true])(
     "fences direct tool-result callbacks after blocked media when projection closed=%s",
     async (closed) => {
       const media = createDeferred<{ dataBase64: string }>();
-      const readRemoteWorkspaceFile = vi.fn(() => media.promise);
+      const readRemoteWorkspaceFile = vi.fn<CodexRemoteWorkspaceFileReader>(() => media.promise);
       const onToolResult = vi.fn();
       const projector = await createProjector(
         { ...(await createParams()), verboseLevel: "full", onToolResult },
@@ -190,10 +199,13 @@ describe("CodexAppServerEventProjector media projection", () => {
       );
       try {
         await vi.waitFor(() => expect(readRemoteWorkspaceFile).toHaveBeenCalledOnce());
+        const signal = readRemoteWorkspaceFile.mock.calls[0]?.[0].signal;
+        expect(signal?.aborted === true).toBe(false);
         expect(onToolResult).not.toHaveBeenCalled();
         if (closed) {
           await projector.closeProjection();
         }
+        expect(signal?.aborted === true).toBe(closed);
         media.resolve({ dataBase64: tinyPngBase64 });
         await pending;
         if (closed) {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -27,6 +27,7 @@ import {
   buildCodexAttemptResult,
   type CodexAppServerToolTelemetry,
 } from "./event-projector-result.js";
+import { CodexProjectionSettlement } from "./event-projector-settlement.js";
 import { buildCodexSteeringMessagesSnapshot } from "./event-projector-snapshot.js";
 import { CodexTerminalFailureProjection } from "./event-projector-terminal-failure.js";
 import { CodexToolProgressProjection } from "./event-projector-tool-progress.js";
@@ -56,6 +57,7 @@ export class CodexAppServerEventProjector {
   private readonly asyncDeliveryProjection: CodexAsyncDeliveryProjection;
   private readonly assistantProjection: CodexAssistantProjection;
   private readonly reasoningProjection: CodexReasoningProjection;
+  readonly settlement: CodexProjectionSettlement;
   private readonly activeItemIds = new Set<string>();
   private readonly completedItemIds = new Set<string>();
   private readonly activeCompactionItemIds = new Set<string>();
@@ -84,6 +86,7 @@ export class CodexAppServerEventProjector {
     private readonly turnId: string,
     private readonly options: CodexAppServerEventProjectorOptions = {},
   ) {
+    this.settlement = new CodexProjectionSettlement(params, () => !this.projectionClosed);
     this.transcriptCheckpoint = new CodexTranscriptCheckpoint(params, threadId, turnId);
     this.asyncDeliveryProjection = new CodexAsyncDeliveryProjection(
       params,
@@ -131,14 +134,14 @@ export class CodexAppServerEventProjector {
       options.onNativeToolResultRecorded,
     );
     this.assistantProjection = new CodexAssistantProjection(
-      params,
+      this.settlement.params,
       (event) => this.emitAgentEvent(event),
       (text) => this.toolProgressProjection.matchesEcho(text),
       this.transcriptCheckpoint.nextTimestamp,
       this.transcriptCheckpoint.enqueueCommentary,
     );
     this.reasoningProjection = new CodexReasoningProjection(
-      params,
+      this.settlement.params,
       (event) => this.emitAgentEvent(event),
       options.onNativePlanUpdate,
     );
@@ -146,6 +149,21 @@ export class CodexAppServerEventProjector {
 
   getCompletedTurnStatus(): CodexTurn["status"] | undefined {
     return this.completedTurn?.status;
+  }
+
+  /** Native completion owns the answer independently of unfinished host projection. */
+  recoverCompletedAnswer(): boolean {
+    const completed = this.settlement.completedAnswer;
+    if (!completed || this.aborted || this.terminalFailure.promptError) {
+      return false;
+    }
+    // Retire accepted writes before the enriched final enters the same mirror owner.
+    this.projectionClosed = true;
+    this.transcriptCheckpoint.abandon();
+    this.completedTurn = completed.turn;
+    this.assistantProjection.recordSnapshotItem(completed.answer);
+    this.assistantProjection.finalizeAnswerCandidate(completed.turn);
+    return true;
   }
 
   getActiveMcpToolCall(serverName: string) {
@@ -185,7 +203,9 @@ export class CodexAppServerEventProjector {
   /** Fence delayed projections before the turn's final snapshot leaves its owner. */
   closeProjection(): Promise<void> {
     this.projectionClosed = true;
-    return this.transcriptCheckpoint.flush(true);
+    return this.settlement.project("transcript/checkpoint", () =>
+      this.transcriptCheckpoint.flush(true),
+    );
   }
 
   /** Resolves the shared model-order position for a native tool item. */
@@ -262,11 +282,9 @@ export class CodexAppServerEventProjector {
         break;
       case "item/started":
         await this.handleItemStarted(params);
-        await this.transcriptCheckpoint.flush();
         break;
       case "item/completed":
         await this.handleItemCompleted(params);
-        await this.transcriptCheckpoint.flush();
         break;
       case "item/commandExecution/outputDelta":
         this.toolProgressProjection.handleOutputDelta(params, "bash");
@@ -311,7 +329,6 @@ export class CodexAppServerEventProjector {
         break;
       case "rawResponseItem/completed":
         await this.handleRawResponseItemCompleted(params);
-        await this.transcriptCheckpoint.flush();
         break;
       case "model/rerouted":
         this.eventProjection.handleModelRerouted(params);
@@ -350,6 +367,14 @@ export class CodexAppServerEventProjector {
       default:
         this.diagnostics.warnUnknownEvent(notification, params);
         break;
+    }
+    if (
+      !this.projectionClosed &&
+      ["item/started", "item/completed", "rawResponseItem/completed"].includes(notification.method)
+    ) {
+      await this.settlement.project("transcript/checkpoint", () =>
+        this.transcriptCheckpoint.flush(),
+      );
     }
   }
 
@@ -517,7 +542,9 @@ export class CodexAppServerEventProjector {
       return;
     }
     this.reasoningProjection.recordItem(item);
-    await this.generatedMediaProjection.recordNative(item);
+    await this.settlement.project("media_projection", () =>
+      this.generatedMediaProjection.recordNative(item),
+    );
     if (this.projectionClosed) {
       return;
     }
@@ -645,7 +672,9 @@ export class CodexAppServerEventProjector {
         return;
       }
       this.reasoningProjection.recordItem(item);
-      await this.generatedMediaProjection.recordNative(item);
+      await this.settlement.project("media_projection", () =>
+        this.generatedMediaProjection.recordNative(item),
+      );
       if (this.projectionClosed) {
         return;
       }
@@ -712,7 +741,9 @@ export class CodexAppServerEventProjector {
     // Project protocol state before media persistence yields. Notifications may overlap,
     // so delayed image I/O must not consume assistant-echo state from a newer item.
     this.assistantProjection.handleRawResponseItemCompleted(item, this.activeItemIds);
-    await this.generatedMediaProjection.recordRaw(item);
+    await this.settlement.project("media_projection", () =>
+      this.generatedMediaProjection.recordRaw(item),
+    );
   }
 
   private emitAgentEvent(

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -14,10 +14,8 @@ import { CodexAsyncDeliveryProjection } from "./event-projector-async-delivery.j
 import { CodexProjectionDiagnostics } from "./event-projector-diagnostics.js";
 import { CodexEventProjection, emitCodexAgentEvent } from "./event-projector-events.js";
 import {
-  itemStatus,
   matchesCodexSnapshotTurn,
   shouldClearTerminalPresentationForNativeItem,
-  shouldSynthesizeToolProgressForItem,
 } from "./event-projector-items.js";
 import { CodexGeneratedMediaProjection } from "./event-projector-media.js";
 import { CodexNativeToolLifecycleProjector } from "./event-projector-native-tool-lifecycle.js";
@@ -401,7 +399,6 @@ export class CodexAppServerEventProjector {
       synthesizedMissingToolResultError: this.synthesizedMissingToolResultError,
       recordSynthesizedMissingToolResultError: (error) => {
         this.synthesizedMissingToolResultError = error;
-        this.terminalFailure.promptErrorSource ??= "prompt";
       },
       aborted: this.aborted,
       contextTokens: this.contextTokens,
@@ -687,7 +684,12 @@ export class CodexAppServerEventProjector {
       }
       this.toolProgressProjection.recordToolMeta(item);
       this.toolProgressProjection.rememberCommandAggregateOutputEcho(item);
-      await this.emitSnapshotOnlyNativeToolProgress(item);
+      await this.eventProjection.emitSnapshotOnlyNativeToolProgress({
+        item,
+        activeItemIds: this.activeItemIds,
+        completedItemIds: this.completedItemIds,
+        isActive: () => !this.projectionClosed,
+      });
       if (this.projectionClosed) {
         return;
       }
@@ -714,29 +716,6 @@ export class CodexAppServerEventProjector {
     this.assistantProjection.finalizeAnswerCandidate(turn);
     this.activeCompactionItemIds.clear();
     await this.reasoningProjection.maybeEndReasoning();
-  }
-
-  private async emitSnapshotOnlyNativeToolProgress(item: CodexThreadItem): Promise<void> {
-    if (
-      !shouldSynthesizeToolProgressForItem(item) ||
-      !matchesCodexSnapshotTurn(item, this.turnId) ||
-      this.completedItemIds.has(item.id) ||
-      itemStatus(item) === "running"
-    ) {
-      return;
-    }
-    const wasStarted = this.activeItemIds.has(item.id);
-    if (!wasStarted) {
-      this.eventProjection.emitStandardItemEvent({ phase: "start", item });
-      await this.eventProjection.emitNormalizedToolItemEvent({ phase: "start", item });
-    }
-    if (this.projectionClosed) {
-      return;
-    }
-    this.activeItemIds.delete(item.id);
-    this.eventProjection.emitStandardItemEvent({ phase: "end", item });
-    await this.eventProjection.emitNormalizedToolItemEvent({ phase: "result", item });
-    this.completedItemIds.add(item.id);
   }
 
   private async handleRawResponseItemCompleted(params: JsonObject): Promise<void> {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -68,7 +68,7 @@ export class CodexAppServerEventProjector {
   private readonly toolProgressProjection: CodexToolProgressProjection;
   private readonly toolTranscriptProjection: CodexToolTranscriptProjection;
   private completedTurn: CodexTurn | undefined;
-  private projectionClosed = false;
+  private readonly projectionController = new AbortController();
   /** Structured overloads may continue once the exact settled transcript is captured. */
   settledTurnFailureFinalizationAllowed = false;
   private readonly terminalFailure = new CodexTerminalFailureProjection();
@@ -109,7 +109,9 @@ export class CodexAppServerEventProjector {
       remoteWorkspaceRoot: options.remoteWorkspaceRoot,
       readFile: options.readRemoteWorkspaceFile,
       requestTimeoutMs: options.remoteWorkspaceRequestTimeoutMs,
-      signal: options.runAbortSignal,
+      signal: options.runAbortSignal
+        ? AbortSignal.any([options.runAbortSignal, this.projectionController.signal])
+        : this.projectionController.signal,
     });
     this.toolProgressProjection = new CodexToolProgressProjection(params);
     this.toolTranscriptProjection = new CodexToolTranscriptProjection(
@@ -151,6 +153,10 @@ export class CodexAppServerEventProjector {
     return this.completedTurn?.status;
   }
 
+  private get projectionClosed(): boolean {
+    return this.projectionController.signal.aborted;
+  }
+
   /** Native completion owns the answer independently of unfinished host projection. */
   recoverCompletedAnswer(): boolean {
     const completed = this.settlement.completedAnswer;
@@ -158,7 +164,7 @@ export class CodexAppServerEventProjector {
       return false;
     }
     // Retire accepted writes before the enriched final enters the same mirror owner.
-    this.projectionClosed = true;
+    this.projectionController.abort();
     this.transcriptCheckpoint.abandon();
     this.completedTurn = completed.turn;
     this.assistantProjection.recordSnapshotItem(completed.answer);
@@ -202,7 +208,7 @@ export class CodexAppServerEventProjector {
 
   /** Fence delayed projections before the turn's final snapshot leaves its owner. */
   closeProjection(): Promise<void> {
-    this.projectionClosed = true;
+    this.projectionController.abort();
     return this.settlement.project("transcript/checkpoint", () =>
       this.transcriptCheckpoint.flush(true),
     );
@@ -388,6 +394,7 @@ export class CodexAppServerEventProjector {
       turnId: this.turnId,
       upstreamUserText: this.options.upstreamUserText,
       completedTurn: this.completedTurn,
+      turnTainted: this.settlement.turnTainted,
       promptError: this.terminalFailure.promptError,
       promptErrorSource: this.terminalFailure.promptErrorSource,
       providerRefusal: this.terminalFailure.providerRefusal,

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -214,6 +214,7 @@ export function activateCodexAttemptTurn(
     },
   );
   if (isTerminalTurnStatus(turn.turn.status)) {
+    projectorRef.current.settlement.terminalReceipt = turn.turn;
     state.terminalTurnNotificationQueued = true;
     deadlines.beginSettlement(Date.now());
   }

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -389,7 +389,8 @@ export async function finalizeCodexAttempt(
       });
     };
     try {
-      if (projectionDrained && settlementPhase === "active") {
+      // Canceling retired media can drain the queue; that cannot reopen ordinary settlement.
+      if (projectionDrained && settlementPhase === "active" && !state.settlementWarning) {
         mirrorOutcome = await Promise.race([
           mirrorFinal(),
           drainGraceElapsed.promise.then(() => unavailableMirror),

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -90,7 +90,7 @@ export async function finalizeCodexAttempt(
     assertCodexBindingMayBeReplaced(resourceState.thread, operation);
     return true;
   };
-  const { state, completion, deadlines } = turnRuntime;
+  const { state, completion, deadlines, settlementExpired } = turnRuntime;
   const { emitLifecycleTerminal, buildLifecycleTerminalMeta } = lifecycle;
   const { drainNotificationQueue } = notifications;
   const { codexModelCallDiagnostics } = requestRuntime;
@@ -103,23 +103,23 @@ export async function finalizeCodexAttempt(
     notifyUserMessagePersisted,
   } = activeTurn;
   await completion;
-  const abortGraceElapsed = createDeferred<void>();
+  const drainGraceElapsed = createDeferred<void>();
   let settlementPhase: "active" | "expired" | "closed" = "active";
-  let abortGraceTimer: ReturnType<typeof setTimeout> | undefined;
-  const beginAbortGrace = () => {
-    if (settlementPhase !== "active") {
+  let drainGraceTimer: ReturnType<typeof setTimeout> | undefined;
+  const beginDrainGrace = () => {
+    if (settlementPhase !== "active" || drainGraceTimer) {
       return;
     }
-    abortGraceTimer = setTimeout(() => {
+    drainGraceTimer = setTimeout(() => {
       settlementPhase = "expired";
-      abortGraceElapsed.resolve();
+      drainGraceElapsed.resolve();
     }, TURN_FINALIZE_DRAIN_ABORT_GRACE_MS);
-    abortGraceTimer.unref?.();
+    drainGraceTimer.unref?.();
   };
   const abortListener = addAbortListener(runAbortController.signal, () => {
     // Abort may first arrive after native completion. Its authoritative cleanup
     // must finish before projection gets the full five-second drain grace.
-    void state.abortCleanup.then(beginAbortGrace, beginAbortGrace);
+    void state.abortCleanup.then(beginDrainGrace, beginDrainGrace);
   });
   const closeProjection = () => {
     state.projectionClosed = true;
@@ -131,10 +131,16 @@ export async function finalizeCodexAttempt(
     }
     settlementPhase = "closed";
     abortListener[Symbol.dispose]();
-    clearTimeout(abortGraceTimer);
+    clearTimeout(drainGraceTimer);
     deadlines.dispose();
   };
-  const settlement = drainNotificationQueue().then(closeProjection);
+  const settlement = drainNotificationQueue().then(async () => {
+    await closeProjection();
+    await activeProjector.settlement.drain();
+  });
+  const degradedSettlement = settlementExpired.then(() => {
+    beginDrainGrace();
+  });
   let projectionDrained = false;
   try {
     try {
@@ -142,7 +148,8 @@ export async function finalizeCodexAttempt(
       // Both remain under the original receipt-anchored settlement deadline.
       projectionDrained = await Promise.race([
         settlement.then(() => true),
-        abortGraceElapsed.promise.then(() => false),
+        drainGraceElapsed.promise.then(() => false),
+        degradedSettlement.then(() => false),
       ]);
       if (runAbortController.signal.aborted) {
         await state.abortCleanup;
@@ -163,14 +170,13 @@ export async function finalizeCodexAttempt(
       (!resourceState.executionDisconnectError &&
         (projectedTerminal.aborted ||
           (runAbortController.signal.aborted && !state.clientClosedAbort)));
-    let enrichedPromptError =
+    const currentPromptError = (fallback: unknown) =>
       resourceState.executionDisconnectError ??
       state.clientClosedPromptError ??
-      (state.timeout?.kind === "settlement"
-        ? "codex app-server terminal settlement timed out"
-        : state.timeout?.kind === "execution"
-          ? "codex app-server execution budget timed out"
-          : projectedTerminal.promptError);
+      (state.timeout
+        ? `codex app-server ${state.timeout.kind === "execution" ? "execution budget" : "terminal settlement"} timed out`
+        : fallback);
+    let enrichedPromptError = currentPromptError(projectedTerminal.promptError);
     const enrichedPromptErrorMessage =
       typeof enrichedPromptError === "string"
         ? enrichedPromptError
@@ -242,14 +248,7 @@ export async function finalizeCodexAttempt(
     const projectTerminalOutcome = () => {
       const effectiveTimedOut = state.timeout !== undefined;
       const clientClosedPromptErrorForFinal = state.clientClosedPromptError;
-      const finalPromptError =
-        resourceState.executionDisconnectError ??
-        clientClosedPromptErrorForFinal ??
-        (state.timeout?.kind === "settlement"
-          ? "codex app-server terminal settlement timed out"
-          : state.timeout?.kind === "execution"
-            ? "codex app-server execution budget timed out"
-            : enrichedPromptError);
+      const finalPromptError = currentPromptError(enrichedPromptError);
       const finalPromptErrorSource =
         effectiveTimedOut || clientClosedPromptErrorForFinal
           ? "prompt"
@@ -310,6 +309,7 @@ export async function finalizeCodexAttempt(
       const attemptSucceeded =
         turnSucceeded && result.agentHarnessResultClassification === undefined;
       result.terminal = attemptTerminal.normalize({
+        settlementWarning: state.settlementWarning,
         timedOut: effectiveTimedOut,
         aborted: finalAborted,
         promptError: finalPromptError,
@@ -351,41 +351,65 @@ export async function finalizeCodexAttempt(
     };
     // Message-write hooks see the enriched native outcome. The same projection
     // runs after the bounded mirror join if Stop or the deadline arrives there.
-    const mirrorTerminal = projectTerminalOutcome();
+    projectTerminalOutcome();
     type MirrorOutcome = Awaited<ReturnType<typeof codexTranscriptMirrorRuntime.mirrorBestEffort>>;
     const unavailableMirror: MirrorOutcome = {
       assistantTranscriptOwned: false,
       mirroredMessages: [],
     };
     let mirrorOutcome = unavailableMirror;
+    const mirrorFinal = () => {
+      const warning = state.settlementWarning;
+      const mirrorTerminal = projectTerminalOutcome();
+      state.pendingSettlementStage = "transcript/mirror";
+      return codexTranscriptMirrorRuntime.mirrorBestEffort({
+        assertWriteCurrent: () => {
+          // Expiry replaces this exact pending write; it cannot borrow the degraded final's owner.
+          if (settlementPhase !== "active" || state.settlementWarning !== warning) {
+            throw new Error("Codex transcript settlement is no longer active");
+          }
+          const current = projectTerminalOutcome();
+          if (
+            current.finalAborted !== mirrorTerminal.finalAborted ||
+            current.effectiveTimedOut !== mirrorTerminal.effectiveTimedOut ||
+            current.finalPromptError !== mirrorTerminal.finalPromptError
+          ) {
+            throw new Error("Codex transcript terminal outcome changed before write");
+          }
+        },
+        params,
+        settlementWarning: warning,
+        agentId: sessionAgentId,
+        notifyUserMessagePersisted,
+        result,
+        sessionKey: contextSessionKey,
+        cwd: effectiveCwd,
+        threadId: resourceState.thread.threadId,
+        turnId: activeTurnId,
+      });
+    };
     try {
       if (projectionDrained && settlementPhase === "active") {
         mirrorOutcome = await Promise.race([
-          codexTranscriptMirrorRuntime.mirrorBestEffort({
-            assertWriteCurrent: () => {
-              if (settlementPhase !== "active") {
-                throw new Error("Codex transcript settlement is no longer active");
-              }
-              const current = projectTerminalOutcome();
-              if (
-                current.finalAborted !== mirrorTerminal.finalAborted ||
-                current.effectiveTimedOut !== mirrorTerminal.effectiveTimedOut ||
-                current.finalPromptError !== mirrorTerminal.finalPromptError
-              ) {
-                throw new Error("Codex transcript terminal outcome changed before write");
-              }
-            },
-            params,
-            agentId: sessionAgentId,
-            notifyUserMessagePersisted,
-            result,
-            sessionKey: contextSessionKey,
-            cwd: effectiveCwd,
+          mirrorFinal(),
+          drainGraceElapsed.promise.then(() => unavailableMirror),
+          degradedSettlement.then(() => unavailableMirror),
+        ]);
+      }
+      if (state.settlementWarning && !runAbortController.signal.aborted) {
+        // Preserve transcript ordering and hooks. Only the retired projection is abandoned;
+        // the completed answer, with its warning, uses the existing final transcript owner.
+        mirrorOutcome = await Promise.race([
+          mirrorFinal(),
+          drainGraceElapsed.promise.then(() => unavailableMirror),
+        ]);
+        if (mirrorOutcome === unavailableMirror) {
+          trajectoryRecorder?.recordEvent("turn.settlement_persistence_unavailable", {
+            pendingStage: "transcript/mirror",
             threadId: resourceState.thread.threadId,
             turnId: activeTurnId,
-          }),
-          abortGraceElapsed.promise.then(() => unavailableMirror),
-        ]);
+          });
+        }
       }
       if (runAbortController.signal.aborted) {
         await state.abortCleanup;

--- a/extensions/codex/src/app-server/run-attempt-notification-controller.ts
+++ b/extensions/codex/src/app-server/run-attempt-notification-controller.ts
@@ -210,6 +210,8 @@ export function createCodexAttemptNotificationController(
       }
       const nativeItem = readCodexNotificationItem(notification.params);
       if (nativeItem?.type === "webSearch") {
+        // Native result provenance must survive an abandoned transcript projection.
+        projector.settlement.turnTainted ||= notification.method === "item/completed";
         projector.recordNativeToolOutcome(nativeItem);
       }
     }

--- a/extensions/codex/src/app-server/run-attempt-notification-controller.ts
+++ b/extensions/codex/src/app-server/run-attempt-notification-controller.ts
@@ -195,6 +195,10 @@ export function createCodexAttemptNotificationController(
     }
     projector.recordMcpToolCallReceipt(notification);
     if (isTerminalTurnNotificationForTurn(notification, turnId)) {
+      const completed = readCodexTurnCompletedNotification(notification.params);
+      if (completed) {
+        projector.settlement.terminalReceipt = completed.turn;
+      }
       state.terminalTurnNotificationQueued = true;
       steeringQueueRef.current?.sealAdmission();
       deadlines.beginSettlement(receivedAtMs);

--- a/extensions/codex/src/app-server/run-attempt-turn-state.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-state.ts
@@ -10,6 +10,7 @@ import {
   type CodexAttemptTimeout,
 } from "./attempt-deadlines.js";
 import { createCodexSteeringQueue } from "./attempt-steering.js";
+import type { AttemptSettlementWarning } from "./attempt-terminal.js";
 import {
   resolveCodexNativeHookRelayTtlMs,
   CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS,
@@ -48,6 +49,8 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
     // this marker remains the user-interrupt hint until Codex exposes abortReason.
     sawCodexInterruptMarker: false,
     timeout: undefined as CodexAttemptTimeout | undefined,
+    settlementWarning: undefined as AttemptSettlementWarning | undefined,
+    pendingSettlementStage: undefined as string | undefined,
     clientClosedPromptError: undefined as string | undefined,
     clientClosedDiagnostic: undefined as string | undefined,
     clientClosedAbort: false,
@@ -69,6 +72,7 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
     currentTurnHadNonTerminalDynamicToolResult: false,
   };
   const { promise: completion, resolve: resolveCompletion } = createDeferred<void>();
+  const settlementExpired = createDeferred<void>();
   const pendingOpenClawDynamicToolCompletionIds = new Set<string>();
   // One execution promise per call id prevents duplicate delivery from
   // repeating non-idempotent computer input while the attempt remains active.
@@ -150,6 +154,30 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
     signal: runAbortController.signal,
     onDeadlineChanged: params.onAttemptDeadlineChanged,
     onTimeout: (timeout) => {
+      const pendingStage =
+        state.pendingSettlementStage ??
+        projectorRef.current?.settlement.pendingStage ??
+        "notification_queue";
+      if (timeout.kind === "settlement" && projectorRef.current?.recoverCompletedAnswer()) {
+        state.settlementWarning = {
+          pendingStage,
+          elapsedMs: timeout.elapsedMs,
+          timeoutMs: timeout.timeoutMs,
+        };
+        state.projectionClosed = true;
+        trajectoryRecorder?.recordEvent("turn.settlement_warning", {
+          threadId: resourceState.thread.threadId,
+          turnId: turnIdRef.current,
+          ...state.settlementWarning,
+        });
+        embeddedAgentLog.warn(
+          "codex app-server retaining completed answer after settlement expiry",
+          state.settlementWarning,
+        );
+        completeTurn();
+        settlementExpired.resolve();
+        return;
+      }
       state.timeout = timeout;
       projectorRef.current?.markTimedOut();
       const error = new Error(
@@ -161,6 +189,7 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
         threadId: resourceState.thread.threadId,
         turnId: turnIdRef.current,
         ...timeout,
+        pendingStage,
       };
       trajectoryRecorder?.recordEvent(`turn.${timeout.kind}_timeout`, fields);
       embeddedAgentLog.warn(error.message, fields);
@@ -171,6 +200,7 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
   return {
     state,
     completion,
+    settlementExpired: settlementExpired.promise,
     pendingOpenClawDynamicToolCompletionIds,
     openClawDynamicToolExecutions,
     activeTurnItemIds,

--- a/extensions/codex/src/app-server/run-attempt-turn-state.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-state.ts
@@ -49,7 +49,9 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
     // this marker remains the user-interrupt hint until Codex exposes abortReason.
     sawCodexInterruptMarker: false,
     timeout: undefined as CodexAttemptTimeout | undefined,
+    // SAFETY: Only the correlated completed-answer deadline fills this initially empty slot.
     settlementWarning: undefined as AttemptSettlementWarning | undefined,
+    // SAFETY: Finalization fills this initially empty slot while its transcript mirror is pending.
     pendingSettlementStage: undefined as string | undefined,
     clientClosedPromptError: undefined as string | undefined,
     clientClosedDiagnostic: undefined as string | undefined,

--- a/extensions/codex/src/app-server/run-attempt.settlement.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.settlement.test.ts
@@ -45,7 +45,102 @@ describe("Codex app-server terminal settlement", () => {
     resetSharedCodexAppServerClientForTests();
   });
 
-  it("bounds post-terminal projection and joins late abort cleanup without stopping a shared sibling", async () => {
+  it.each([
+    { stage: "onAssistantMessageStart", nativeCompleted: true },
+    { stage: "onPartialReply", nativeCompleted: true },
+    { stage: "onReasoningStream", nativeCompleted: true },
+    { stage: "onReasoningEnd", nativeCompleted: true },
+    { stage: "onReasoningStream", nativeCompleted: false },
+  ] as const)(
+    "settles held $stage with native completion: $nativeCompleted",
+    async ({ stage, nativeCompleted }) => {
+      const held = createDeferred<void>();
+      const callback = vi.fn(() => held.promise);
+      const onAttemptTimeout = vi.fn();
+      const harness = createStartedThreadHarness();
+      const params = {
+        ...createTestParams(),
+        [stage]: callback,
+        onAttemptTimeout,
+        timeoutMs: TURN_TERMINAL_SETTLEMENT_TIMEOUT_MS,
+      };
+      vi.useFakeTimers();
+      const run = runCodexAppServerAttempt(params);
+      const settled = vi.fn();
+      void run.then(settled, settled);
+      try {
+        await harness.waitForMethod("turn/start");
+        const assistantStage = stage === "onAssistantMessageStart" || stage === "onPartialReply";
+        if (assistantStage) {
+          await harness.notify({
+            method: "item/started",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              item: { id: "answer", type: "agentMessage", phase: "final_answer", text: "" },
+            },
+          });
+        }
+        void harness.notify({
+          method: assistantStage ? "item/agentMessage/delta" : "item/reasoning/textDelta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: assistantStage ? "answer" : "reasoning-1",
+            delta: assistantStage ? "Completed answer." : "Finishing the answer.",
+          },
+        });
+        if (nativeCompleted) {
+          void harness.notify(
+            turnCompleted({
+              id: "turn-1",
+              status: "completed",
+              items: [
+                {
+                  id: "answer",
+                  type: "agentMessage",
+                  phase: "final_answer",
+                  text: "Completed answer.",
+                },
+              ],
+            }),
+          );
+        }
+        await vi.waitFor(() => expect(callback).toHaveBeenCalledOnce(), fastWait);
+        await vi.advanceTimersByTimeAsync(TURN_TERMINAL_SETTLEMENT_TIMEOUT_MS);
+        await vi.advanceTimersByTimeAsync(TURN_FINALIZE_DRAIN_ABORT_GRACE_MS);
+        await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce(), {
+          interval: 100,
+          timeout: 15_000,
+        });
+        vi.useRealTimers();
+        const result = await run;
+        if (nativeCompleted) {
+          expect(result.terminal).toEqual({
+            kind: "ok",
+            settlementWarning: {
+              pendingStage: stage,
+              elapsedMs: TURN_TERMINAL_SETTLEMENT_TIMEOUT_MS,
+              timeoutMs: TURN_TERMINAL_SETTLEMENT_TIMEOUT_MS,
+            },
+          });
+          expect(result.assistantTexts).toEqual(["Completed answer."]);
+          expect(result.lastAssistant?.stopReason).toBe("stop");
+          expect(result.codexAppServerFailure).toBeUndefined();
+          expect(onAttemptTimeout).not.toHaveBeenCalled();
+        } else {
+          expect(readAttemptTerminal(result)).toMatchObject({ timedOut: true, aborted: true });
+          expect(onAttemptTimeout).toHaveBeenCalledOnce();
+        }
+      } finally {
+        held.resolve();
+        vi.useRealTimers();
+        await run;
+      }
+    },
+  );
+
+  it("preserves a completed reply through degraded settlement without stopping a shared sibling", async () => {
     const physical = createClientHarness();
     const startClient = vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(physical.client);
     const projection = createDeferred<void>();
@@ -152,34 +247,17 @@ describe("Codex app-server terminal settlement", () => {
       );
       expect(onAttemptTimeout).not.toHaveBeenCalled();
       await vi.advanceTimersByTimeAsync(1);
-      expect(onAttemptTimeout).toHaveBeenCalledExactlyOnceWith(
-        expect.objectContaining({ message: "codex app-server terminal settlement timed out" }),
-      );
-
-      const list = await waitForHarnessRequest(physical, "thread/backgroundTerminals/list");
-      expect(wireRequests().some(({ method }) => method === "turn/interrupt")).toBe(false);
-      await vi.advanceTimersByTimeAsync(4_000);
-      expect(firstSettled).not.toHaveBeenCalled();
-      expect(wireRequests().some(({ method }) => method === "thread/unsubscribe")).toBe(false);
-      physical.send({ id: list.id, result: { data: [], nextCursor: null } });
-      await vi.advanceTimersByTimeAsync(0);
-
-      // Native cleanup consumed four seconds. Projection gets its own
-      // full grace after cleanup, rather than spending it on cleanup RPCs.
-      await vi.advanceTimersByTimeAsync(TURN_FINALIZE_DRAIN_ABORT_GRACE_MS - 1);
-      expect(firstSettled).not.toHaveBeenCalled();
-      expect(wireRequests().some(({ method }) => method === "thread/unsubscribe")).toBe(false);
-      await vi.advanceTimersByTimeAsync(1);
-      const unsubscribe = await waitForHarnessRequest(physical, "thread/unsubscribe");
-      physical.send({ id: unsubscribe.id, result: {} });
+      expect(onAttemptTimeout).not.toHaveBeenCalled();
+      await vi.waitFor(() => expect(firstSettled).toHaveBeenCalledOnce(), fastWait);
       const result = await firstRun;
       expect(readAttemptTerminal(result)).toMatchObject({
-        aborted: true,
-        timedOut: true,
-        promptError: "codex app-server terminal settlement timed out",
+        aborted: false,
+        timedOut: false,
+        promptError: null,
+        settlementWarning: { pendingStage: "onReasoningStream" },
       });
-      expect(result.codexAppServerFailure?.kind).toBe("turn_settlement_timeout");
-      expect(result.promptTimeoutOutcome).toMatchObject({ replayInvalid: true });
+      expect(result.codexAppServerFailure).toBeUndefined();
+      expect(result.promptTimeoutOutcome).toBeUndefined();
       expect(result.assistantTexts).toEqual(["Completed work remains visible."]);
       expect(
         wireRequests()
@@ -190,7 +268,7 @@ describe("Codex app-server terminal settlement", () => {
               method === "thread/unsubscribe",
           )
           .map(({ params }) => params?.threadId),
-      ).toEqual(["thread-settlement", "thread-settlement"]);
+      ).toEqual([]);
       expect(physical.stdinDestroyed).toBe(false);
       expect(resolveActiveEmbeddedRunSessionId(firstParams.sessionKey)).toBeUndefined();
       expect(resolveActiveEmbeddedRunSessionId(siblingParams.sessionKey)).toBe(
@@ -228,8 +306,9 @@ describe("Codex app-server terminal settlement", () => {
   });
 
   it.each([
-    { boundary: "callback", termination: "timeout", release: "after cutoff" },
-    { boundary: "checkpoint", termination: "timeout", release: "after cutoff" },
+    { boundary: "callback", termination: "timeout", release: "during recovery" },
+    { boundary: "checkpoint", termination: "timeout", release: "during recovery" },
+    { boundary: "final", termination: "timeout", release: "during recovery" },
     { boundary: "final", termination: "timeout", release: "after cutoff" },
     { boundary: "checkpoint", termination: "abort", release: "after cutoff" },
     { boundary: "final", termination: "abort", release: "after cutoff" },
@@ -303,6 +382,11 @@ describe("Codex app-server terminal settlement", () => {
       params.abortSignal = abort.signal;
       params.onAttemptTimeout = onAttemptTimeout;
       params.onAgentEvent = onAgentEvent;
+      // Whole-message preparation must not erase the terminal owner's warning.
+      params.prepareAssistantTranscriptMessage = (message) => ({
+        ...message,
+        __openclaw: undefined,
+      });
       params.timeoutMs = 60 * 60_000;
       vi.useFakeTimers();
       const settled = vi.fn();
@@ -364,9 +448,7 @@ describe("Codex app-server terminal settlement", () => {
           await vi.advanceTimersByTimeAsync(
             receivedAt + TURN_TERMINAL_SETTLEMENT_TIMEOUT_MS - Date.now(),
           );
-          expect(onAttemptTimeout).toHaveBeenCalledExactlyOnceWith(
-            expect.objectContaining({ message: "codex app-server terminal settlement timed out" }),
-          );
+          expect(onAttemptTimeout).not.toHaveBeenCalled();
         } else if (boundary === "publication") {
           await vi.waitFor(() => expect(publishedTerminal).toHaveBeenCalledOnce(), fastWait);
         } else {
@@ -374,32 +456,43 @@ describe("Codex app-server terminal settlement", () => {
         }
         if (release === "after cutoff") {
           await vi.advanceTimersByTimeAsync(TURN_FINALIZE_DRAIN_ABORT_GRACE_MS);
-        } else {
+        } else if (release === "during recovery") {
+          await vi.advanceTimersByTimeAsync(1);
+        }
+        if (release !== "after cutoff") {
+          // The replacement final still queues behind the authoritative writer.
           checkpoint.resolve();
           await Promise.allSettled(checkpointWrites);
         }
         await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce(), fastWait);
         const result = await run;
         expect(readAttemptTerminal(result)).toMatchObject({
-          aborted: true,
-          timedOut: termination === "timeout",
-          promptError:
-            termination === "timeout" ? "codex app-server terminal settlement timed out" : null,
+          aborted: termination === "abort",
+          timedOut: false,
+          promptError: null,
         });
-        expect(result.codexAppServerFailure?.kind).toBe(
-          termination === "timeout" ? "turn_settlement_timeout" : undefined,
-        );
+        expect(result.codexAppServerFailure).toBeUndefined();
         if (termination === "timeout") {
-          expect(result.promptTimeoutOutcome).toMatchObject({ replayInvalid: true });
-        } else {
-          expect(onAttemptTimeout).not.toHaveBeenCalled();
+          expect(result.terminal).toMatchObject({
+            kind: "ok",
+            settlementWarning: {
+              pendingStage: boundary === "final" ? "transcript/mirror" : "transcript/checkpoint",
+              timeoutMs: TURN_TERMINAL_SETTLEMENT_TIMEOUT_MS,
+            },
+          });
         }
+        expect(result.promptTimeoutOutcome).toBeUndefined();
+        expect(onAttemptTimeout).not.toHaveBeenCalled();
         expect(result.assistantTexts).toEqual(["Completed before checkpoint."]);
-        expect(result.lastAssistant?.stopReason).toBe("aborted");
+        expect(result.lastAssistant?.stopReason).toBe(termination === "abort" ? "aborted" : "stop");
         expect(result.attemptUsage).toMatchObject({ input: 3, output: 7, cacheRead: 2, total: 12 });
-        expect(result.attemptUsage?.contextUsage).toEqual({ state: "unavailable" });
+        if (termination === "abort") {
+          expect(result.attemptUsage?.contextUsage).toEqual({ state: "unavailable" });
+        }
         const assistantCommitted =
-          boundary === "publication" || (boundary === "checkpoint" && release === "during grace");
+          (termination === "timeout" && release === "during recovery") ||
+          boundary === "publication" ||
+          (boundary === "checkpoint" && release === "during grace");
         expect(
           onAgentEvent.mock.calls.filter(
             ([event]) =>
@@ -408,7 +501,7 @@ describe("Codex app-server terminal settlement", () => {
           ),
         ).toHaveLength(1);
         expect(resolveActiveEmbeddedRunSessionId(transcriptTarget.sessionKey)).toBeUndefined();
-        if (release !== "after cutoff" || (boundary === "final" && termination === "abort")) {
+        if (termination === "timeout" || release !== "after cutoff" || boundary === "final") {
           checkpoint.resolve();
           await Promise.allSettled(checkpointWrites);
           const events = await readSessionTranscriptEvents(transcriptTarget);
@@ -425,11 +518,23 @@ describe("Codex app-server terminal settlement", () => {
               expect.objectContaining({
                 id: result.contextEngineTerminalAnchor?.entryId,
                 message: expect.objectContaining({
-                  stopReason: boundary === "publication" ? "stop" : "aborted",
+                  stopReason:
+                    termination === "timeout" || boundary === "publication" ? "stop" : "aborted",
                   idempotencyKey: result.assistantTranscriptIdempotencyKey,
                 }),
               }),
             ]);
+            if (termination === "timeout") {
+              expect(assistantRows[0]).toMatchObject({
+                message: {
+                  __openclaw: {
+                    settlementWarning: expect.objectContaining({
+                      timeoutMs: TURN_TERMINAL_SETTLEMENT_TIMEOUT_MS,
+                    }),
+                  },
+                },
+              });
+            }
             if (boundary === "publication") {
               expect(publishedTerminal).toHaveBeenCalledExactlyOnceWith(
                 expect.objectContaining({ messageId: result.contextEngineTerminalAnchor?.entryId }),
@@ -450,7 +555,7 @@ describe("Codex app-server terminal settlement", () => {
           expect(result.assistantTranscriptIdempotencyKey).toBeUndefined();
           expect(result.contextEngineTerminalAnchor).toBeUndefined();
         }
-        if (boundary === "final" && termination === "abort" && release === "after cutoff") {
+        if (boundary === "final" && release === "after cutoff") {
           const nextHarness = createStartedThreadHarness(
             async (method) => {
               if (method === "thread/resume") {

--- a/extensions/codex/src/app-server/run-attempt.settlement.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.settlement.test.ts
@@ -16,7 +16,7 @@ import {
 } from "./attempt-timeouts.js";
 import { CodexAppServerClient } from "./client.js";
 import { isJsonObject } from "./protocol.js";
-import { turnCompleted } from "./protocol.test-helpers.js";
+import { itemNotification, turnCompleted } from "./protocol.test-helpers.js";
 import {
   createNativeRunParams,
   createStartedThreadHarness,
@@ -318,6 +318,7 @@ describe("Codex app-server terminal settlement", () => {
   ] as const)(
     "settles $termination at $boundary with writer release $release",
     async ({ boundary, termination, release }) => {
+      const queuedNetworkResult = boundary === "checkpoint" && termination === "timeout";
       const params = createTestParams();
       await attachSqliteSessionTarget(
         params,
@@ -413,25 +414,39 @@ describe("Codex app-server terminal settlement", () => {
             },
           },
         });
+        const completedCommand = {
+          id: "checkpoint-command",
+          type: "commandExecution",
+          command: "echo saved",
+          cwd: params.workspaceDir,
+          commandActions: [],
+          processId: null,
+          source: "agent",
+          status: "completed",
+          aggregatedOutput: "saved",
+          exitCode: 0,
+          durationMs: 1,
+        };
+        if (queuedNetworkResult) {
+          void harness.notify(itemNotification("item/completed", completedCommand));
+          await vi.waitFor(() => expect(checkpointMirror).toHaveBeenCalledOnce(), fastWait);
+          void harness.notify(
+            itemNotification("item/completed", {
+              id: "queued-search",
+              type: "webSearch",
+              query: "synthetic network result",
+              action: { type: "search", query: "synthetic network result" },
+              results: null,
+            }),
+          );
+        }
         const receivedAt = Date.now();
-        await harness.notify(
+        void harness.notify(
           turnCompleted({
             id: "turn-1",
             status: "completed",
             items: [
-              {
-                id: "checkpoint-command",
-                type: "commandExecution",
-                command: "echo saved",
-                cwd: params.workspaceDir,
-                commandActions: [],
-                processId: null,
-                source: "agent",
-                status: "completed",
-                aggregatedOutput: "saved",
-                exitCode: 0,
-                durationMs: 1,
-              },
+              ...(queuedNetworkResult ? [] : [completedCommand]),
               {
                 id: "checkpoint-answer",
                 type: "agentMessage",
@@ -534,6 +549,11 @@ describe("Codex app-server terminal settlement", () => {
                   },
                 },
               });
+              if (queuedNetworkResult) {
+                expect(assistantRows[0]).toMatchObject({
+                  message: { __openclaw: { turnTainted: true } },
+                });
+              }
             }
             if (boundary === "publication") {
               expect(publishedTerminal).toHaveBeenCalledExactlyOnceWith(

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -79,6 +79,7 @@ export function recordCodexTrajectoryCompletion(
     yieldDetected: params.yieldDetected ?? false,
     aborted: terminal.aborted,
     promptError: normalizeCodexTrajectoryError(terminal.promptError),
+    ...(terminal.settlementWarning ? { settlementWarning: terminal.settlementWarning } : {}),
     usage: params.result.attemptUsage,
     assistantTexts: params.result.assistantTexts,
     messagesSnapshot: params.result.messagesSnapshot,

--- a/extensions/codex/src/app-server/transcript-checkpoint.ts
+++ b/extensions/codex/src/app-server/transcript-checkpoint.ts
@@ -22,6 +22,7 @@ export class CodexTranscriptCheckpoint {
   private writing = Promise.resolve();
   private tainted = false;
   private closed = false;
+  private abandoned = false;
 
   constructor(
     private readonly params: EmbeddedRunAttemptParamsV2,
@@ -61,6 +62,11 @@ export class CodexTranscriptCheckpoint {
     }
   };
 
+  abandon(): void {
+    this.closed = this.abandoned = true;
+    this.pending.length = 0;
+  }
+
   flush(close = false): Promise<void> {
     if (this.closed) {
       return this.writing;
@@ -88,6 +94,11 @@ export class CodexTranscriptCheckpoint {
       });
       try {
         await codexTranscriptMirrorRuntime.mirror({
+          assertWriteCurrent: () => {
+            if (this.abandoned) {
+              throw new Error("Codex transcript checkpoint was retired before write");
+            }
+          },
           ...this.params.sessionTarget,
           sessionId: this.params.sessionId,
           cwd: this.params.workspaceDir,

--- a/extensions/codex/src/app-server/transcript-mirror-attestation.ts
+++ b/extensions/codex/src/app-server/transcript-mirror-attestation.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { AttemptSettlementWarning } from "./attempt-terminal.js";
 import { readUpstreamUserText } from "./upstream-prompt-provenance.js";
 
 type MirroredAgentMessage = Extract<AgentMessage, { role: "user" | "assistant" | "toolResult" }>;
@@ -50,6 +51,7 @@ export function attachCodexMirrorRunId<T extends AgentMessage>(
   message: T,
   runId: string,
   terminal = false,
+  settlementWarning?: AttemptSettlementWarning,
 ): T {
   const existing = CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
   const metadata = asOptionalRecord(existing) ?? {};
@@ -60,6 +62,7 @@ export function attachCodexMirrorRunId<T extends AgentMessage>(
       ...current,
       runId,
       ...(terminal ? { runTerminal: true } : {}),
+      ...(terminal && settlementWarning ? { settlementWarning } : {}),
     },
   } as T; // SAFETY: AgentMessage variants permit provider metadata at runtime; preserve T.
 }

--- a/extensions/codex/src/app-server/transcript-mirror-attestation.ts
+++ b/extensions/codex/src/app-server/transcript-mirror-attestation.ts
@@ -2,9 +2,29 @@ import { createHash } from "node:crypto";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { AttemptSettlementWarning } from "./attempt-terminal.js";
-import { readUpstreamUserText } from "./upstream-prompt-provenance.js";
+import type { CodexAsyncAssistantMessage } from "./event-projector-assistant-message.js";
+import { readMirrorIdentity, readUpstreamUserText } from "./upstream-prompt-provenance.js";
 
-type MirroredAgentMessage = Extract<AgentMessage, { role: "user" | "assistant" | "toolResult" }>;
+export type MirroredAgentMessage = Extract<
+  AgentMessage,
+  { role: "user" | "assistant" | "toolResult" }
+> &
+  Partial<Pick<CodexAsyncAssistantMessage, "openclawAsyncDelivery">>;
+
+export function isMirroredAgentMessage(message: AgentMessage): message is MirroredAgentMessage {
+  return message.role === "user" || message.role === "assistant" || message.role === "toolResult";
+}
+
+export function buildCodexMirrorDedupeIdentity(message: MirroredAgentMessage): string {
+  const identity = readMirrorIdentity(message);
+  if (identity) {
+    return identity;
+  }
+  // Untagged callers dedupe role/content within their idempotency scope.
+  // Volatile metadata must not change that identity on a reordered retry.
+  const payload = JSON.stringify({ role: message.role, content: message.content });
+  return `${message.role}:${createHash("sha256").update(payload).digest("hex").slice(0, 16)}`;
+}
 
 const MIRROR_ORIGIN_META_KEY = "mirrorOrigin" as const;
 const MIRROR_SOURCE_FINGERPRINT_META_KEY = "mirrorSourceFingerprint" as const;

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -17,7 +17,7 @@ import {
   type SessionTranscriptWriteLockParams,
 } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import type { AttemptSettlementWarning, EmbeddedRunAttemptResult } from "./attempt-terminal.js";
 import type { CodexAsyncAssistantMessage } from "./event-projector-assistant-message.js";
 import type { CodexAsyncDeliverySettlement } from "./event-projector-options.js";
 import type { CodexThread } from "./protocol.js";
@@ -114,6 +114,7 @@ export async function importCodexThreadHistoryToTranscript(params: {
 
 async function mirrorBestEffort(params: {
   assertWriteCurrent?: () => void;
+  settlementWarning?: AttemptSettlementWarning;
   params: EmbeddedRunAttemptParams;
   agentId?: string;
   notifyUserMessagePersisted: UserMessagePersistenceNotifier;
@@ -157,6 +158,7 @@ async function mirrorBestEffort(params: {
       terminalAssistantOwner: {
         mirrorIdentity: `${params.turnId}:assistant`,
         runId: params.params.runId,
+        settlementWarning: params.settlementWarning,
       },
       prepareAssistantTranscriptMessage: params.params.prepareAssistantTranscriptMessage,
       config: params.params.config,
@@ -344,7 +346,11 @@ async function mirror(params: {
   idempotencyScope?: string;
   runId?: string;
   runMirrorIdentityPrefix?: string;
-  terminalAssistantOwner?: { mirrorIdentity: string; runId: string };
+  terminalAssistantOwner?: {
+    mirrorIdentity: string;
+    runId: string;
+    settlementWarning?: AttemptSettlementWarning;
+  };
   prepareAssistantTranscriptMessage?: EmbeddedRunAttemptParams["prepareAssistantTranscriptMessage"];
   config?: SessionTranscriptWriteLockParams["config"];
   skipBeforeMessageWriteHooks?: boolean;
@@ -416,7 +422,12 @@ async function mirror(params: {
         );
         const ownedMessage =
           ownsRun && params.runId
-            ? attachCodexMirrorRunId(message, params.runId, ownsTerminal)
+            ? attachCodexMirrorRunId(
+                message,
+                params.runId,
+                ownsTerminal,
+                terminalOwner?.settlementWarning,
+              )
             : message;
         const transcriptMessage = {
           ...attachCodexMirrorAttestation(ownedMessage, sourceFingerprint),
@@ -495,7 +506,12 @@ async function mirror(params: {
           messageToAppend = attachCodexMirrorIdentity(messageToAppend, mirrorIdentity);
         }
         if (ownsRun && params.runId) {
-          messageToAppend = attachCodexMirrorRunId(messageToAppend, params.runId, ownsTerminal);
+          messageToAppend = attachCodexMirrorRunId(
+            messageToAppend,
+            params.runId,
+            ownsTerminal,
+            terminalOwner?.settlementWarning,
+          );
         }
         if (message.role === "assistant" && message.openclawAsyncDelivery) {
           // Async delivery ownership is provider-authored. Whole-message hooks may

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import {
   deliverAgentHarnessUserInputPrompt,
   embeddedAgentLog,
@@ -18,7 +17,6 @@ import {
 } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { AttemptSettlementWarning, EmbeddedRunAttemptResult } from "./attempt-terminal.js";
-import type { CodexAsyncAssistantMessage } from "./event-projector-assistant-message.js";
 import type { CodexAsyncDeliverySettlement } from "./event-projector-options.js";
 import type { CodexThread } from "./protocol.js";
 import {
@@ -29,8 +27,11 @@ import {
   applyCodexTranscriptTaint,
   attachCodexMirrorAttestation,
   attachCodexMirrorRunId,
+  buildCodexMirrorDedupeIdentity,
   fingerprintCodexMirrorSourceMessage,
+  isMirroredAgentMessage,
   readCodexMirrorSourceFingerprint,
+  type MirroredAgentMessage,
 } from "./transcript-mirror-attestation.js";
 import {
   attachCodexMirrorIdentity,
@@ -46,8 +47,6 @@ import {
 export { buildCodexUserPromptMessage };
 export { projectBoundedCodexThreadHistory };
 
-type MirroredAgentMessage = Extract<AgentMessage, { role: "user" | "assistant" | "toolResult" }> &
-  Partial<Pick<CodexAsyncAssistantMessage, "openclawAsyncDelivery">>;
 type MirroredUserMessage = Extract<AgentMessage, { role: "user" }>;
 type MirroredUserMessageReceipt = {
   anchor: TranscriptEntryAnchor;
@@ -62,10 +61,6 @@ type CodexAppServerTranscriptMirrorResult = {
   messagesPresent: MirroredAgentMessage[];
   userMessageReceipts: MirroredUserMessageReceipt[];
 };
-
-function isMirroredAgentMessage(message: AgentMessage): message is MirroredAgentMessage {
-  return message.role === "user" || message.role === "assistant" || message.role === "toolResult";
-}
 
 function readMirroredAssistantText(message: MirroredAgentMessage | undefined): string | undefined {
   if (message?.role !== "assistant") {
@@ -318,23 +313,6 @@ export async function mirrorPromptAtTurnStartBestEffort(params: {
   }
 }
 
-// Fallback content fingerprint for callers that did not tag the message
-// with a stable mirror identity. Only role and content participate; volatile
-// metadata (timestamps, usage, etc.) is intentionally excluded so the
-// fingerprint survives snapshot reordering inside a fixed scope. Distinct
-// same-content turns are still distinguished by the caller's idempotency
-// scope when callers route through this fallback.
-function fingerprintMirrorMessageContent(message: MirroredAgentMessage): string {
-  const payload = JSON.stringify({ role: message.role, content: message.content });
-  return createHash("sha256").update(payload).digest("hex").slice(0, 16);
-}
-
-function buildMirrorDedupeIdentity(message: MirroredAgentMessage): string {
-  return (
-    readMirrorIdentity(message) || `${message.role}:${fingerprintMirrorMessageContent(message)}`
-  );
-}
-
 async function mirror(params: {
   assertCurrent?: () => void;
   assertWriteCurrent?: () => void;
@@ -368,7 +346,7 @@ async function mirror(params: {
   }
 
   const candidates = messages.map((message) => {
-    const dedupeIdentity = buildMirrorDedupeIdentity(message);
+    const dedupeIdentity = buildCodexMirrorDedupeIdentity(message);
     const sourceFingerprint = fingerprintCodexMirrorSourceMessage(message);
     const sourceUserIdempotencyKey =
       message.role === "user"

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -26,6 +26,7 @@ import {
   type CodexThreadHistoryImportResult,
 } from "./transcript-history-projection.js";
 import {
+  applyCodexTranscriptTaint,
   attachCodexMirrorAttestation,
   attachCodexMirrorRunId,
   fingerprintCodexMirrorSourceMessage,
@@ -409,7 +410,9 @@ async function mirror(params: {
         idempotencyKeys: candidateIdempotencyKeys,
       });
       assertWritable();
+      const taint = { tainted: false };
       for (const { dedupeIdentity, idempotencyKey, message, sourceFingerprint } of candidates) {
+        const sourceMessage = applyCodexTranscriptTaint(message, taint);
         const mirrorIdentity = readMirrorIdentity(message);
         const ownsRun = Boolean(
           params.runId &&
@@ -423,12 +426,12 @@ async function mirror(params: {
         const ownedMessage =
           ownsRun && params.runId
             ? attachCodexMirrorRunId(
-                message,
+                sourceMessage,
                 params.runId,
                 ownsTerminal,
                 terminalOwner?.settlementWarning,
               )
-            : message;
+            : sourceMessage;
         const transcriptMessage = {
           ...attachCodexMirrorAttestation(ownedMessage, sourceFingerprint),
           ...(idempotencyKey ? { idempotencyKey } : {}),
@@ -520,6 +523,8 @@ async function mirror(params: {
             openclawAsyncDelivery: { itemId: message.openclawAsyncDelivery.itemId },
           });
         }
+        // Whole-message hooks can replace metadata, but cannot erase source-owned taint.
+        messageToAppend = applyCodexTranscriptTaint(messageToAppend, taint);
         messageToAppend = projectAgentHarnessTranscriptMessageForDisplay({
           hidden: (message as { display?: boolean }).display === false,
           message: messageToAppend,

--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -150,6 +150,7 @@ export async function runTelegramDispatchTurn(turn: Turn) {
           replyOptions: {
             skillFilter: context.skillFilter,
             disableBlockStreaming: turn.disableBlockStreaming,
+            preserveProgressCallbackStartOrder: true,
             abortSignal: turn.turnAdoptionLifecycle?.abortSignal,
             turnAdoptionLifecycle: turn.turnAdoptionLifecycle
               ? {

--- a/src/agents/agent-run-terminal-outcome.test.ts
+++ b/src/agents/agent-run-terminal-outcome.test.ts
@@ -451,6 +451,54 @@ describe("agent run terminal outcome", () => {
 });
 
 describe("agent run attempt terminal", () => {
+  it("preserves a degraded completion through normalization, merging, and projection", () => {
+    const settlementWarning = {
+      pendingStage: "onPartialReply",
+      elapsedMs: 120_000,
+      timeoutMs: 120_000,
+    };
+    const degraded = normalizeAgentRunAttemptTerminal({ settlementWarning });
+    expect(degraded).toEqual({ kind: "ok", settlementWarning });
+    for (const [current, incoming] of [
+      [{ kind: "ok" }, degraded],
+      [degraded, { kind: "ok" }],
+    ] as const) {
+      const terminal = mergeAgentRunAttemptTerminal(current, incoming);
+      expect(projectAgentRunAttemptTerminal(terminal)).toMatchObject({
+        settlementWarning,
+        aborted: false,
+        failed: false,
+        interrupted: false,
+        timedOut: false,
+        promptError: null,
+      });
+    }
+  });
+
+  it.each([
+    { promptError: "provider failed", expected: "failed" },
+    { externalAbort: true, expected: "aborted" },
+    { timedOut: true, expected: "timeout" },
+  ])("keeps $expected precedence over a settlement warning", ({ expected, ...input }) => {
+    const degraded = {
+      kind: "ok",
+      settlementWarning: { pendingStage: "checkpoint", elapsedMs: 120_000, timeoutMs: 120_000 },
+    } as const;
+    const terminal = normalizeAgentRunAttemptTerminal({
+      ...input,
+      settlementWarning: degraded.settlementWarning,
+    });
+    expect(terminal.kind).toBe(expected);
+    for (const [current, incoming] of [
+      [terminal, degraded],
+      [degraded, terminal],
+    ] as const) {
+      const merged = mergeAgentRunAttemptTerminal(current, incoming);
+      expect(merged.kind).toBe(expected);
+      expect(projectAgentRunAttemptTerminal(merged).settlementWarning).toBeUndefined();
+    }
+  });
+
   it.each([
     {
       label: "external abort",

--- a/src/agents/agent-run-terminal-outcome.ts
+++ b/src/agents/agent-run-terminal-outcome.ts
@@ -42,9 +42,14 @@ type AgentRunAttemptFailure = {
 
 type AgentRunAttemptTimeoutObservation = "compaction" | "tool_execution";
 type AgentRunAttemptTimeoutSource = "runtime" | "run_budget" | "idle" | "external";
+type AgentRunAttemptSettlementWarning = {
+  pendingStage: string;
+  elapsedMs: number;
+  timeoutMs: number;
+};
 
 export type AgentRunAttemptTerminal =
-  | { kind: "ok" }
+  | { kind: "ok"; settlementWarning?: AgentRunAttemptSettlementWarning }
   | {
       kind: "aborted";
       source: "runtime" | "external" | "yield_cleanup";
@@ -74,6 +79,7 @@ export type AgentRunAttemptTerminal =
     };
 
 type LegacyAgentRunAttemptTerminalInput = {
+  settlementWarning?: AgentRunAttemptSettlementWarning;
   aborted?: boolean;
   externalAbort?: boolean;
   idleTimedOut?: boolean;
@@ -204,33 +210,10 @@ export function mergeAgentRunAttemptTerminal(
   incoming: AgentRunAttemptTerminal,
 ): AgentRunAttemptTerminal {
   if (incoming.kind === "ok") {
-    return current;
+    // A later plain completion must not erase the first recorded settlement warning.
+    return current.kind === "ok" && !current.settlementWarning ? incoming : current;
   }
   const failure = getAgentRunAttemptFailure(incoming) ?? getAgentRunAttemptFailure(current);
-  if (
-    incoming.kind === "timeout" &&
-    incoming.source === "observation" &&
-    current.kind !== "timeout"
-  ) {
-    return current.kind === "ok"
-      ? withAgentRunAttemptFailure(incoming, failure)
-      : withAgentRunAttemptFailure(
-          withAgentRunAttemptTimeoutObservation(current, incoming.phase),
-          failure,
-        );
-  }
-  if (
-    current.kind === "timeout" &&
-    current.source === "observation" &&
-    incoming.kind !== "timeout"
-  ) {
-    return incoming.kind === "failed" || incoming.kind === "aborted"
-      ? withAgentRunAttemptFailure(
-          withAgentRunAttemptTimeoutObservation(incoming, current.phase),
-          failure,
-        )
-      : withAgentRunAttemptFailure(incoming, failure);
-  }
   if (current.kind === "timeout" && incoming.kind === "timeout") {
     const phase =
       ATTEMPT_TIMEOUT_PHASE_RANK[incoming.phase] > ATTEMPT_TIMEOUT_PHASE_RANK[current.phase]
@@ -327,18 +310,17 @@ export function mergeAgentRunAttemptTerminal(
     }
     return withAgentRunAttemptFailure(selected, failure);
   }
-  const selected =
-    ATTEMPT_TERMINAL_KIND_RANK[incoming.kind] >= ATTEMPT_TERMINAL_KIND_RANK[current.kind]
-      ? incoming
-      : current;
-  return withAgentRunAttemptFailure(selected, failure);
+  return withAgentRunAttemptFailure(incoming, failure);
 }
 
 /** Normalizes the shipped harness result shape at the Plugin SDK boundary. */
 export function normalizeAgentRunAttemptTerminal(
   input: LegacyAgentRunAttemptTerminalInput,
 ): AgentRunAttemptTerminal {
-  let terminal: AgentRunAttemptTerminal = { kind: "ok" };
+  let terminal: AgentRunAttemptTerminal = {
+    kind: "ok",
+    ...(input.settlementWarning && { settlementWarning: input.settlementWarning }),
+  };
   if (input.aborted || input.externalAbort) {
     terminal = mergeAgentRunAttemptTerminal(terminal, {
       kind: "aborted",
@@ -385,6 +367,8 @@ export function projectAgentRunAttemptTerminal(terminal: AgentRunAttemptTerminal
     (terminal.kind === "aborted" || terminal.kind === "timeout") && terminal.source === "external";
   const timedOut = terminal.kind === "timeout" && terminal.source !== "observation";
   return {
+    ...(terminal.kind === "ok" &&
+      terminal.settlementWarning && { settlementWarning: terminal.settlementWarning }),
     aborted:
       (terminal.kind === "aborted" && terminal.source !== "yield_cleanup") ||
       (terminal.kind === "timeout" &&

--- a/src/auto-reply/reply/agent-runner-presentation.test.ts
+++ b/src/auto-reply/reply/agent-runner-presentation.test.ts
@@ -1,6 +1,7 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { sanitizeUserFacingText } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import {
   HEARTBEAT_TOKEN,
@@ -13,6 +14,7 @@ import {
 import type { ReplyPayload } from "../types.js";
 import type { AgentTurnParams } from "./agent-runner-execution.types.js";
 import { createAgentTurnPresentation } from "./agent-runner-presentation.js";
+import { createReplyOperation } from "./reply-run-registry.operation.js";
 
 function normalizeStreamingTextReference(
   payload: ReplyPayload,
@@ -50,13 +52,19 @@ function normalizeStreamingTextReference(
 }
 
 function createPresentation(
-  options: { isHeartbeat?: boolean; silentExpected?: boolean; conversationContext?: string } = {},
+  options: {
+    isHeartbeat?: boolean;
+    silentExpected?: boolean;
+    conversationContext?: string;
+    replyOperation?: AgentTurnParams["replyOperation"];
+  } = {},
 ) {
   const turn = {
     followupRun: { run: { silentExpected: options.silentExpected === true } },
     isHeartbeat: options.isHeartbeat === true,
     sessionCtx: { agentText: options.conversationContext },
     opts: undefined,
+    replyOperation: options.replyOperation,
   } as unknown as AgentTurnParams;
   return createAgentTurnPresentation({
     turn,
@@ -80,6 +88,38 @@ function cumulativePrefixes(text: string, seed: number): string[] {
 }
 
 describe("agent runner streaming presentation", () => {
+  it.each(["active", "committed", "completed"] as const)(
+    "fences delayed typing when the reply operation is %s",
+    async (ending) => {
+      const replyOperation = createReplyOperation({
+        sessionKey: `agent:main:typing-${ending}`,
+        sessionId: `typing-${ending}`,
+        resetTriggered: false,
+      });
+      replyOperation.setPhase("running");
+      const typing = createDeferredCore();
+      const onPresentation = vi.fn(() => true);
+      const presentation = createPresentation({ replyOperation });
+      const pending = presentation.presentWithTyping(typing.promise, onPresentation);
+      try {
+        expect(onPresentation).not.toHaveBeenCalled();
+        if (ending === "committed") {
+          replyOperation.freezeAbort();
+        } else if (ending === "completed") {
+          replyOperation.complete();
+        }
+        expect(replyOperation.abortSignal.aborted).toBe(false);
+        typing.resolve();
+        await pending;
+        expect(onPresentation).toHaveBeenCalledTimes(ending === "active" ? 1 : 0);
+      } finally {
+        typing.resolve();
+        await pending;
+        replyOperation.complete();
+      }
+    },
+  );
+
   it("redacts copied inbound prompts before streamed XML cleanup", () => {
     const conversationContext = [
       "[Chat messages since your last reply - for context]",

--- a/src/auto-reply/reply/agent-runner-presentation.ts
+++ b/src/auto-reply/reply/agent-runner-presentation.ts
@@ -15,6 +15,7 @@ import type { ReplyPayload } from "../types.js";
 import type { AgentTurnParams } from "./agent-runner-execution.types.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import type { ReplyMediaContext } from "./reply-media-paths.js";
+import { hasCommittedReplyOperationOutcome } from "./reply-run-registry.js";
 
 type AgentTurnPresentation = {
   classifyStreamingPartial: (payload: ReplyPayload) => { text?: string; skip: boolean };
@@ -104,6 +105,17 @@ export function createAgentTurnPresentation(params: {
   ) => {
     if (!preserveProgressCallbackStartOrder) {
       await typingPromise;
+      const operation = params.turn.replyOperation;
+      // Successful settlement keeps delivery alive; delayed typing must not
+      // reopen presentation after this operation has committed its final answer.
+      if (
+        operation &&
+        (operation.abortSignal.aborted ||
+          operation.result ||
+          hasCommittedReplyOperationOutcome(operation))
+      ) {
+        return false;
+      }
       return await startPresentation();
     }
     let presentationPromise: boolean | void | Promise<boolean | void>;


### PR DESCRIPTION
Closes #139173

## What Problem This Solves

Fixes an issue where users would lose a completed Codex answer and receive a timeout error when host projection failed to settle within 120 seconds. Reported by @KirDE, with independent corroboration from [SRB]drizzy.

## Why This Change Was Made

The settlement owner previously converted every expiry into timeout/abort, even after receiving a correlated successful native completion and complete final assistant text. That evidence now produces a successful attempt with a settlement warning naming the pending callback, checkpoint/transcript write, or media stage and elapsed time. The canonical terminal normalizer retains the warning; explicit cancellation and expiry before native completion retain their existing precedence. The two-minute budget is unchanged.

The Codex projection owner fences retired writes, cancels abandoned media reads, and persists the recovered answer with its warning through the existing transcript mirror. Its existing five-second drain grace bounds recovery persistence. If the writer remains unavailable, the existing best-effort policy records `turn.settlement_persistence_unavailable` and delivers the answer; it does not claim successful persistence or create a second store. Native network provenance survives an abandoned projection and whole-message hooks.

Presentation callbacks start independently of native processing and join at settlement. Telegram uses the existing callback start-order contract. The shared presentation owner also checks the exact reply operation after delayed typing, preventing late callbacks from reopening a completed reply. Steering consumption, tool acknowledgments, checkpoint order, compaction hooks, and stale-write fencing remain authoritative.

## User Impact

Completed Codex answers reach the channel even when host projection stalls. Operators get a named settlement diagnostic instead of an unexplained timeout. No configuration, environment, database schema, protocol version, or dependency changes are required.

## Evidence

Direct Codex `rust-v0.153.0` inspection (`41e22fee981a63b3698df7ed36bad393cda24715`): [completion emission and assistant summary](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/app-server/src/bespoke_event_handling.rs#L1392), [completed versus failed status](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/app-server/src/bespoke_event_handling.rs#L1578), and [notification shape](https://github.com/openai/codex/blob/41e22fee981a63b3698df7ed36bad393cda24715/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L509). The currently pinned 0.153.4 has identical completion and turn/item protocol sources ([current emission](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/app-server/src/bespoke_event_handling.rs#L1392)). Recovery keys on the received v2 notification, not a rollout `task_complete` record.

The existing settlement suite failed before the fix for completed-answer recovery. Additional pre-fix failures prove lost native network provenance, an uncanceled media read, and late typing callbacks after committed/completed operations; the active-operation control passed. The settlement suite also retains pre-completion timeout, explicit cancellation, bounded persistence, and late-write cases.

Final exact-head Crabbox proof used `blacksmith-testbox`, lease `tbx_01m1sna3hh0bkjtnbkczxq6zv5`, [Testbox run 33991227476](https://github.com/openclaw/openclaw/actions/runs/33991227476), Node 24.19.0. The wrapper verified source `7b53eb2d87469b08281809b58d8907adad5be999` and tree `8eb2c1658b9a4ba7414477b46c1b6041257868b9`. Full changed checks, the six settlement/native-thread-cleanup/native-finalization/transcript-mirror/presentation/execution-progress suites, and the full CLI build passed. [Exact-head CI run 33991164411](https://github.com/openclaw/openclaw/actions/runs/33991164411) is green. Full-branch independent review found no actionable P0/P1 defects.

The real isolated Gateway ran a synthetic Codex app-server replay and Crabline Telegram transport: completed image item → blocked media read → completed web search and final answer item → native `turn/completed` → settlement expiry → accepted final send → release media after 125 seconds. The complete closed recorder was independently checked for accepted sends, later errors/deletes/media, and unchanged assistant transcript rows. Sanitized live-proof transcript:

```json
{
  "status": "pass",
  "kind": "mock-gateway",
  "sourceRevision": "7b53eb2d87469b08281809b58d8907adad5be999",
  "acceptedFinals": 1,
  "terminalRequestAt": 1788643055118,
  "elapsedAfterNativeCompletionMs": 120410,
  "mediaReleasedAfterNativeCompletionMs": 125058,
  "assistantRows": 1,
  "pendingStage": "media_projection",
  "elapsedMs": 120000,
  "timeoutMs": 120000,
  "retainedNetworkProvenance": true,
  "transcriptUnchangedAfterRelease": true,
  "acceptedErrorMessages": 0,
  "lateDeletes": 0,
  "lateMediaSends": 0,
  "cleanupErrors": []
}
```

This is mock-gateway/channel proof, not Telegram Test Server or real-model inference. The remote shell had no Convex CLI or configured broker pair. The original incidents' precise blocking operation remains unknown; the new pending-stage fact makes subsequent reports attributable. Initial CI found two max-lines overflows. Snapshot progress now lives in its existing event owner, mirror identity helpers live in the attestation owner, and redundant prompt attribution was removed; final lint and all other gates pass.

Production/test LOC from `git diff --numstat`: production +398/-156 (net +242), tests +294/-69 (net +225), docs +19/-4 (net +15). Production growth is the missing-recovery-path exception: the old timeout path had no owner for named pending stages, detached presentation joins, completed-answer adoption with native provenance, or bounded replacement persistence. The change removes duplicate terminal merging and consolidates final-mirror invocation. Reducing it to a success flag would drop required ownership and diagnostics.

NO-FOLLOW-UP: the meaningful presentation and settlement ownership repairs are absorbed here; the follow-up audit found no further concrete, bounded simplification.

ClawSweeper rank-up disposition: live Telegram Test Server evidence is skipped because neither the authenticated Convex CLI nor the broker pair is available in the task environments. The maintainer-approved validation scope allows the deterministic mock-Gateway replay when that transport is infeasible. The original incidents' unknown blocking stage remains an explicit diagnostic limitation, not a claim that every stall was reproduced; completed-answer recovery is intentionally independent of identifying that stage. No concrete correctness finding was raised in the completed review.
