### PR TITLE
perf(gateway): reuse node invocation idle timers

### DIFF
--- a/src/gateway/node-registry.invoke-stream.ts
+++ b/src/gateway/node-registry.invoke-stream.ts
@@ -1,4 +1,9 @@
 import {
+  getActiveDiagnosticTraceContext,
+  runWithDiagnosticTraceContext,
+  type DiagnosticTraceContext,
+} from "../infra/diagnostic-trace-context.js";
+import {
   captureGatewayRootWorkAdmissionContinuationScope,
   type GatewayRootWorkAdmissionContinuationScope,
 } from "../process/gateway-work-admission.js";
@@ -28,6 +33,7 @@ export type PendingInvoke = {
   deadlineAtMs?: number;
   hardTimer?: ReturnType<typeof setTimeout>;
   idleTimer?: ReturnType<typeof setTimeout>;
+  idleTraceContext?: DiagnosticTraceContext;
   idleTimeoutMs?: number;
   onProgress?: (chunk: string) => void;
   receivedProgress?: boolean;
@@ -304,33 +310,34 @@ export class NodeInvokeStreamController {
     if (pending.idleTimer) {
       clearTimeout(pending.idleTimer);
     }
+    pending.idleTraceContext = undefined;
     pending.removeAbortListener?.();
     pending.removeAbortListener = undefined;
     pending.admissionContinuation?.release();
     pending.admissionContinuation = undefined;
   }
 
-  private createIdleTimer(requestId: string, pending: PendingInvoke) {
-    return setTimeout(() => {
-      if (!this.takePending(requestId, pending)) {
-        return;
-      }
-      this.sendInvokeCancel(requestId, pending);
-      pending.resolve({
-        ok: false,
-        error: { code: "IDLE_TIMEOUT", message: "node invoke produced no progress" },
-      });
-    }, pending.idleTimeoutMs);
-  }
-
   private resetIdleTimer(requestId: string, pending: PendingInvoke): void {
     if (!pending.idleTimeoutMs) {
       return;
     }
-    if (pending.idleTimer) {
-      clearTimeout(pending.idleTimer);
-    }
-    pending.idleTimer = this.createIdleTimer(requestId, pending);
+    // Refresh retains the timer's first async scope; cancellation diagnostics
+    // must still belong to the latest progress frame that renewed its deadline.
+    pending.idleTraceContext = getActiveDiagnosticTraceContext();
+    pending.idleTimer =
+      pending.idleTimer?.refresh() ??
+      setTimeout(() => {
+        runWithDiagnosticTraceContext(pending.idleTraceContext, () => {
+          if (!this.takePending(requestId, pending)) {
+            return;
+          }
+          this.sendInvokeCancel(requestId, pending);
+          pending.resolve({
+            ok: false,
+            error: { code: "IDLE_TIMEOUT", message: "node invoke produced no progress" },
+          });
+        });
+      }, pending.idleTimeoutMs);
   }
 
   private sendInvokeCancel(requestId: string, pending: PendingInvoke): void {


### PR DESCRIPTION
## What Problem This Solves

Resolves repeated timer allocation while a node invocation streams progress. Each ordered chunk canceled and recreated its idle timer; the first chunk created one and immediately replaced it after delivering the callback.

## Why This Change Was Made

`NodeInvokeStreamController` in `src/gateway/node-registry.invoke-stream.ts` refreshes one live timer at the original renewal sites and folds the separate creation helper into that owner. Progress enters through the invoke-progress handler and node registry; expiry still consumes the exact pending record before the existing cancellation transport and terminal settlement.

A bare `refresh()` was rejected because Node retains the timer's initial async scope, whereas replacement captured the latest progress frame's diagnostic trace. The owner therefore keeps one immutable trace reference per pending invocation, updates it on renewal, restores it at expiry, and clears it during cleanup. Explicitly absent latest trace also overrides an earlier trace. This preserves the identified logger/payload correlation contract, without claiming equality for arbitrary AsyncLocalStorage instrumentation or introducing authority semantics. Connection identity, policy, deadline, admission, and settlement remain with their existing owners.

Production: +24/-17 lines (net +7); tests/support: +0/-0. The growth preserves diagnostic correlation while removing the creation helper and per-progress replacement timer. Existing watchdog siblings already use timer refresh; no general helper or dependency is added.

## User Impact

Streaming node calls create fewer temporary timers while preserving first-progress activation, fixed idle duration, renewal after ordered callbacks, sequence-gap handling, hard deadline, cancellation, and terminal results. Timeout diagnostics remain correlated with the latest renewal trace.

## Evidence

Paired Node 26.8.1/macOS arm64 runs import the actual controller with the same harness. Each cycle delivers 100,000 ordered synthetic chunks, hashes the complete stream, checks structured terminal values, and verifies empty pending state.

| Per 100,000-chunk cycle | Before | After |
| --- | ---: | ---: |
| Timeout resources created | 100,001 | 1 |
| Mean cumulative sampled allocation, three cycles | 60,579,661 B | 21,814,920 B |
| Mean elapsed time, three cycles | 45.92 ms | 35.30 ms |

All six cycle results and progress digests match. Separate native-timer fixtures verify replacement and explicitly absent final traces, exact cancellation frame bytes, terminal errors, cleanup, and rejection of late progress. Resource counting runs separately from allocation sampling; profiles include collected objects. The 63.99% lower sampled allocation is an owner-workload observation. One process per arm with three warmed cycles under shared load does not establish retained heap/RSS or general Gateway latency. Function-level attribution is affected by inlining and is not used for the conclusion. Reused synthetic frames and source callbacks isolate timer work; no real network/provider flow or Bun execution is claimed.

```sh
node scripts/run-vitest.mjs src/gateway/node-registry.test.ts src/gateway/node-registry-policy.test.ts src/gateway/node-registry.ws-lifecycle.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/node-registry.invoke-stream.ts
```

All 172 existing tests pass before and after, covering idle/hard deadlines, sequence gaps, duplicates, approval waiting, callback aborts, disconnects, policy, and connection ownership. Exact-file type-aware lint, formatting, and `git diff --check` pass. Changed-plan classification passed; broad local gates were not run. Independent P2 review recorded no actionable findings. Required exact-head hosted CI/native landing gates and any remaining integration proof remain mandatory.
