### PR TITLE
fix(ui): link file references with line ranges, not version numbers

### DIFF
--- a/ui/src/components/markdown-file-links.ts
+++ b/ui/src/components/markdown-file-links.ts
@@ -1,22 +1,30 @@
 const HOST_LOCAL_FILE_HREF_RE =
   /^(?:~\/|\/(?:Users|home|tmp|private\/tmp|var\/folders|private\/var\/folders)\/|\/[A-Za-z]:\/|[A-Za-z]:[\\/])/;
 const FILE_SEGMENT_SOURCE = "[A-Za-z0-9_.@#+-]+";
-// Extensions start with a letter so version numbers ("1.1/1.2") are not files; ":a-b" ranges target line a.
-const FILE_EXTENSION_SOURCE = "[A-Za-z][A-Za-z0-9]{0,7}";
+// Scanned prose and code spans require a letter-led extension so version numbers ("1.1/1.2") are not
+// files; explicitly authored Markdown links keep digit-led extensions. ":a-b" ranges target line a.
+const SCANNED_EXTENSION_SOURCE = "[A-Za-z][A-Za-z0-9]{0,7}";
+const AUTHORED_EXTENSION_SOURCE = "[A-Za-z0-9]{1,8}";
 const FILE_LINE_SUFFIX_SOURCE = ":\\d{1,6}(?:[-:]\\d{1,6})?";
-const FILE_NAME_SOURCE = `${FILE_SEGMENT_SOURCE}\\.${FILE_EXTENSION_SOURCE}`;
-const PREFIXED_FILE_SOURCE = `(?:~\\/|\\.\\.\\/|\\.\\/|\\/)(?:${FILE_SEGMENT_SOURCE}\\/)*${FILE_NAME_SOURCE}`;
-const UNPREFIXED_FILE_SOURCE = `${FILE_SEGMENT_SOURCE}(?:\\/${FILE_SEGMENT_SOURCE})*\\/${FILE_NAME_SOURCE}`;
-const WINDOWS_ABSOLUTE_FILE_SOURCE = `[A-Za-z]:[\\\\/](?:${FILE_SEGMENT_SOURCE}[\\\\/])*${FILE_NAME_SOURCE}`;
-const MULTI_SEGMENT_FILE_SOURCE = `(?:${PREFIXED_FILE_SOURCE}|${WINDOWS_ABSOLUTE_FILE_SOURCE}|${UNPREFIXED_FILE_SOURCE})(?:${FILE_LINE_SUFFIX_SOURCE})?`;
-const BARE_FILE_WITH_LINE_SOURCE = `${FILE_SEGMENT_SOURCE}\\.${FILE_EXTENSION_SOURCE}${FILE_LINE_SUFFIX_SOURCE}`;
-const MULTI_SEGMENT_FILE_RE = new RegExp(`^${MULTI_SEGMENT_FILE_SOURCE}$`);
-const BARE_FILE_WITH_LINE_RE = new RegExp(`^${BARE_FILE_WITH_LINE_SOURCE}$`);
-const BARE_FILENAME_RE = new RegExp(`^${FILE_SEGMENT_SOURCE}\\.(${FILE_EXTENSION_SOURCE})$`, "i");
-export const MARKDOWN_FILE_LINK_SCAN_RE = new RegExp(
-  `${MULTI_SEGMENT_FILE_SOURCE}|${BARE_FILE_WITH_LINE_SOURCE}`,
-  "g",
+function fileGrammar(extension: string) {
+  const name = `${FILE_SEGMENT_SOURCE}\\.${extension}`;
+  const prefixed = `(?:~\\/|\\.\\.\\/|\\.\\/|\\/)(?:${FILE_SEGMENT_SOURCE}\\/)*${name}`;
+  const unprefixed = `${FILE_SEGMENT_SOURCE}(?:\\/${FILE_SEGMENT_SOURCE})*\\/${name}`;
+  const windowsAbsolute = `[A-Za-z]:[\\\\/](?:${FILE_SEGMENT_SOURCE}[\\\\/])*${name}`;
+  const multiSegment = `(?:${prefixed}|${windowsAbsolute}|${unprefixed})(?:${FILE_LINE_SUFFIX_SOURCE})?`;
+  const bareWithLine = `${name}${FILE_LINE_SUFFIX_SOURCE}`;
+  return {
+    scan: new RegExp(`${multiSegment}|${bareWithLine}`, "g"),
+    exact: new RegExp(`^(?:${multiSegment}|${bareWithLine})$`),
+  };
+}
+const SCANNED_FILE = fileGrammar(SCANNED_EXTENSION_SOURCE);
+const AUTHORED_FILE = fileGrammar(AUTHORED_EXTENSION_SOURCE);
+const BARE_FILENAME_RE = new RegExp(
+  `^${FILE_SEGMENT_SOURCE}\\.(${SCANNED_EXTENSION_SOURCE})$`,
+  "i",
 );
+export const MARKDOWN_FILE_LINK_SCAN_RE = SCANNED_FILE.scan;
 const FILE_LINE_SUFFIX_RE = /:(\d{1,6})(?:[-:]\d{1,6})?$/;
 const BARE_FILE_EXTENSIONS = new Set([
   "astro",
@@ -121,13 +129,11 @@ function isAllowlistedBareFilename(raw: string): boolean {
 
 export function parseMarkdownFileLinkTarget(
   raw: string,
+  options?: { authored?: boolean },
 ): { path: string; line: number | null } | null {
   const target = raw.trim();
-  if (
-    !MULTI_SEGMENT_FILE_RE.test(target) &&
-    !BARE_FILE_WITH_LINE_RE.test(target) &&
-    !isAllowlistedBareFilename(target)
-  ) {
+  const grammar = options?.authored ? AUTHORED_FILE : SCANNED_FILE;
+  if (!grammar.exact.test(target) && !isAllowlistedBareFilename(target)) {
     return null;
   }
   return splitMarkdownFileLineSuffix(target);

--- a/ui/src/components/markdown-file-links.ts
+++ b/ui/src/components/markdown-file-links.ts
@@ -1,8 +1,9 @@
 const HOST_LOCAL_FILE_HREF_RE =
   /^(?:~\/|\/(?:Users|home|tmp|private\/tmp|var\/folders|private\/var\/folders)\/|\/[A-Za-z]:\/|[A-Za-z]:[\\/])/;
 const FILE_SEGMENT_SOURCE = "[A-Za-z0-9_.@#+-]+";
-const FILE_EXTENSION_SOURCE = "[A-Za-z0-9]{1,8}";
-const FILE_LINE_SUFFIX_SOURCE = ":\\d{1,6}(?::\\d{1,6})?";
+// Extensions start with a letter so version numbers ("1.1/1.2") are not files; ":a-b" ranges target line a.
+const FILE_EXTENSION_SOURCE = "[A-Za-z][A-Za-z0-9]{0,7}";
+const FILE_LINE_SUFFIX_SOURCE = ":\\d{1,6}(?:[-:]\\d{1,6})?";
 const FILE_NAME_SOURCE = `${FILE_SEGMENT_SOURCE}\\.${FILE_EXTENSION_SOURCE}`;
 const PREFIXED_FILE_SOURCE = `(?:~\\/|\\.\\.\\/|\\.\\/|\\/)(?:${FILE_SEGMENT_SOURCE}\\/)*${FILE_NAME_SOURCE}`;
 const UNPREFIXED_FILE_SOURCE = `${FILE_SEGMENT_SOURCE}(?:\\/${FILE_SEGMENT_SOURCE})*\\/${FILE_NAME_SOURCE}`;
@@ -16,7 +17,7 @@ export const MARKDOWN_FILE_LINK_SCAN_RE = new RegExp(
   `${MULTI_SEGMENT_FILE_SOURCE}|${BARE_FILE_WITH_LINE_SOURCE}`,
   "g",
 );
-const FILE_LINE_SUFFIX_RE = /:(\d{1,6})(?::\d{1,6})?$/;
+const FILE_LINE_SUFFIX_RE = /:(\d{1,6})(?:[-:]\d{1,6})?$/;
 const BARE_FILE_EXTENSIONS = new Set([
   "astro",
   "bash",

--- a/ui/src/components/markdown-file-links.ts
+++ b/ui/src/components/markdown-file-links.ts
@@ -11,8 +11,10 @@ function fileGrammar(extension: string) {
   const prefixed = `(?:~\\/|\\.\\.\\/|\\.\\/|\\/)(?:${FILE_SEGMENT_SOURCE}\\/)*${name}`;
   const unprefixed = `${FILE_SEGMENT_SOURCE}(?:\\/${FILE_SEGMENT_SOURCE})*\\/${name}`;
   const windowsAbsolute = `[A-Za-z]:[\\\\/](?:${FILE_SEGMENT_SOURCE}[\\\\/])*${name}`;
-  const multiSegment = `(?:${prefixed}|${windowsAbsolute}|${unprefixed})(?:${FILE_LINE_SUFFIX_SOURCE})?`;
-  const bareWithLine = `${name}${FILE_LINE_SUFFIX_SOURCE}`;
+  // A reference may not stop early inside a longer token ("logs/app.log.1" must not link "logs/app.log").
+  const end = "(?!\\.?[A-Za-z0-9_])";
+  const multiSegment = `(?:${prefixed}|${windowsAbsolute}|${unprefixed})(?:${FILE_LINE_SUFFIX_SOURCE})?${end}`;
+  const bareWithLine = `${name}${FILE_LINE_SUFFIX_SOURCE}${end}`;
   return {
     scan: new RegExp(`${multiSegment}|${bareWithLine}`, "g"),
     exact: new RegExp(`^(?:${multiSegment}|${bareWithLine})$`),

--- a/ui/src/components/markdown-links.test.ts
+++ b/ui/src/components/markdown-links.test.ts
@@ -306,6 +306,17 @@ describe("toSanitizedMarkdownHtml links", () => {
       expect(link?.dataset.fileLine).toBe("26");
     });
 
+    it("does not link a shorter prefix of a numeric-suffix filename", () => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml("rotated logs/app.log.1 but see src/lib/foo.ts.", {
+          fileLinks: true,
+        }),
+      );
+      const links = [...fragment.querySelectorAll<HTMLAnchorElement>("a[data-file-path]")];
+      expect(links.map((link) => link.dataset.filePath)).toEqual(["src/lib/foo.ts"]);
+      expect(fragment.textContent).toContain("logs/app.log.1");
+    });
+
     it("does not link dotted version numbers but keeps authored digit-led extensions", () => {
       const fragment = htmlFragment(
         toSanitizedMarkdownHtml(

--- a/ui/src/components/markdown-links.test.ts
+++ b/ui/src/components/markdown-links.test.ts
@@ -306,13 +306,17 @@ describe("toSanitizedMarkdownHtml links", () => {
       expect(link?.dataset.fileLine).toBe("26");
     });
 
-    it("does not link dotted version numbers", () => {
+    it("does not link dotted version numbers but keeps authored digit-led extensions", () => {
       const fragment = htmlFragment(
-        toSanitizedMarkdownHtml("bumped 1.1/1.2 and `2026.9.2`, see v1.2/3.4", {
-          fileLinks: true,
-        }),
+        toSanitizedMarkdownHtml(
+          "bumped 1.1/1.2 and `2026.9.2`, see v1.2/3.4 [part](assets/part.3mf)",
+          {
+            fileLinks: true,
+          },
+        ),
       );
-      expect(fragment.querySelector("a[data-file-path]")).toBeNull();
+      const links = [...fragment.querySelectorAll<HTMLAnchorElement>("a[data-file-path]")];
+      expect(links.map((link) => link.dataset.filePath)).toEqual(["assets/part.3mf"]);
     });
 
     it("links Windows absolute paths", () => {

--- a/ui/src/components/markdown-links.test.ts
+++ b/ui/src/components/markdown-links.test.ts
@@ -295,6 +295,26 @@ describe("toSanitizedMarkdownHtml links", () => {
       expect(links[1]?.textContent).toBe("bar.ts:7:3");
     });
 
+    it("targets the first line of a range suffix", () => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml("`src/commands/auth-choice-options.static.ts:26-35`", {
+          fileLinks: true,
+        }),
+      );
+      const link = fragment.querySelector<HTMLAnchorElement>("a.markdown-file-link");
+      expect(link?.dataset.filePath).toBe("src/commands/auth-choice-options.static.ts");
+      expect(link?.dataset.fileLine).toBe("26");
+    });
+
+    it("does not link dotted version numbers", () => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml("bumped 1.1/1.2 and `2026.9.2`, see v1.2/3.4", {
+          fileLinks: true,
+        }),
+      );
+      expect(fragment.querySelector("a[data-file-path]")).toBeNull();
+    });
+
     it("links Windows absolute paths", () => {
       const fragment = htmlFragment(
         toSanitizedMarkdownHtml("C:/repo/src/foo.ts:42 and `D:\\work\\bar.ts`", {

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -369,7 +369,7 @@ export function createMarkdownParser(): MarkdownItParser {
             }
             if (!decodedHref.includes("://")) {
               const target =
-                parseMarkdownFileLinkTarget(decodedHref) ??
+                parseMarkdownFileLinkTarget(decodedHref, { authored: true }) ??
                 (isHostLocalMarkdownFileHref(decodedHref)
                   ? splitMarkdownFileLineSuffix(decodedHref.trim())
                   : null);


### PR DESCRIPTION
## Problem

Assistant replies in the Control UI reference code as `src/commands/auth-choice-options.static.ts:26-35` (path plus a line range). The file-link grammar only accepted `:line` and `:line:col`, so those references stayed plain inline code instead of opening the file in the sidebar.

At the same time, dotted version strings were linkified: `1.1/1.2` parsed as directory `1.1` plus file `1.2` with the numeric extension `2`, so the transcript showed a document-icon file link with a `1.1/1.2` tooltip in the middle of prose about plugin versions.

## Solution

`ui/src/components/markdown-file-links.ts`:
- File extensions must start with a letter (`[A-Za-z][A-Za-z0-9]{0,7}`), so all-numeric "paths" like `1.1/1.2`, `2026.9.2`, or `v1.2/3.4` never match.
- The line-suffix grammar accepts `:start-end` next to `:line` and `:line:col`; the first number is the target line, so a range reference opens the file at its first line.

Both the text scanner and the inline-code / explicit-link paths share these constants, so the fix applies to all three detection routes.

## Impact

- Code references with line ranges become clickable workspace file links (file opens at the range start).
- Version-like numeric paths are no longer turned into file links.
- Tradeoff: files whose extension starts with a digit (for example `.3mf`) are no longer auto-linked; none are in the conservative bare-filename allowlist, and multi-segment paths to them were never a realistic reference form in chat.

## Evidence

- New tests in `ui/src/components/markdown-links.test.ts` fail on the previous grammar (range suffix not linked, version numbers linked) and pass with the fix.
- `node scripts/run-vitest.mjs ui/src/components/markdown ui/src/styles/chat-file-link-presentation.browser.test.ts ui/src/app/browser-link-routing.test.ts`: 4 files, 134 tests passed.
- `node scripts/check-changed.mjs`: passed (lint, format, typecheck, knip lanes).
- Codex autoreview (local, P1): scoped-clean.
- Production LOC: +4 −3 in the grammar module (one explanatory comment); no rendering or CSS changes, so the visual presentation of file links is unchanged. No before/after captures for this reason.

Release-note: Control UI links code references with line ranges (`file.ts:26-35`) to the file and no longer turns dotted version numbers into file links.
