### PR TITLE
perf(ui): reuse active-locale duration and relative-time formatters

### DIFF
--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -30,20 +30,40 @@ type FormatRelativeTimestampOptions = {
   suffix?: boolean;
 };
 
+let localeFormatters:
+  | {
+      locale: string;
+      units: Partial<Record<DurationPart["unit"], Intl.NumberFormat>>;
+      relative?: Intl.RelativeTimeFormat;
+    }
+  | undefined;
+
+function getLocaleFormatters() {
+  const locale = i18n.getLocale();
+  // Keep one locale's closed unit set; switching languages releases the old
+  // formatters without retaining labels or subscribing to component lifetimes.
+  if (localeFormatters?.locale !== locale) {
+    localeFormatters = { locale, units: {} };
+  }
+  return localeFormatters;
+}
+
 export function formatUnit({ value, unit }: DurationPart): string {
-  return new Intl.NumberFormat(i18n.getLocale(), {
+  const formatters = getLocaleFormatters();
+  return (formatters.units[unit] ??= new Intl.NumberFormat(formatters.locale, {
     style: "unit",
     unit,
     unitDisplay: "narrow",
     maximumFractionDigits: 0,
-  }).format(value);
+  })).format(value);
 }
 
 function formatRelative(value: number, unit: RelativeTimeUnit): string {
-  return new Intl.RelativeTimeFormat(i18n.getLocale(), {
+  const formatters = getLocaleFormatters();
+  return (formatters.relative ??= new Intl.RelativeTimeFormat(formatters.locale, {
     numeric: "auto",
     style: "narrow",
-  }).format(value, unit);
+  })).format(value, unit);
 }
 
 export function formatTimeAgo(


### PR DESCRIPTION
## What Problem This Solves

Resolves repeated formatter construction when the Control UI renders relative timestamps and duration labels in chat, task rows, session navigation, and catalog entries. Values change on each render, while the active language and closed formatting options usually remain the same.

## Why This Change Was Made

`ui/src/lib/format.ts` retains one active-language set of lazy `Intl.NumberFormat` instances for seven duration units and one lazy `Intl.RelativeTimeFormat`. A call observing a different committed locale replaces the set. Shared timestamp and duration callers still calculate and format current values; rendered labels and timestamps are never cached.

The locale owner commits a language only after successful current-generation loading, so lazy comparison follows that existing boundary. Moving the machinery into the locale manager was rejected because formatter ownership belongs here; retaining construction would keep the measured cost. Production: +24/-4 lines (net +20); tests/support: +0/-0. The growth is bounded to one locale and at most eight formatter instances, without listeners, timers, component retention, or a generic cache.

## User Impact

Relative-time and duration labels reuse formatters while preserving language changes, quantities, bigint handling, rounding, precision, duration buckets, and fallback strings. Only NumberFormat/RelativeTimeFormat reuse changes. Date/time, timezone, and separately configured hovercard/turn-recap formatting remain outside this change.

## Evidence

The actual-source Node 26.8.1/macOS arm64 probe produces identical strings across 300 cases covering en → fr → de → ar → en, seven units, zero/plural/bigint values, duration boundaries, and past/future timestamps. The valid baseline uses the application's real locale compiler and asserts committed locale changes. An initial attempt could not resolve Vite's virtual locale modules; its apparent locale coverage is excluded.

After warmup, 5,000 iterations format relative age, relative timestamps, and a two-unit duration:

| Measurement | Before | After |
| --- | ---: | ---: |
| NumberFormat constructions | 10,000 | 0 |
| RelativeTimeFormat constructions | 10,000 | 0 |
| Cumulative sampled allocation | 14,756,112 B | 8,385,376 B |
| Elapsed time | 225.18 ms | 14.88 ms |

This amplified, warmed owner pair under shared load measures 43.17% lower sampled allocation. It does not establish whole-UI latency, retained heap, or RSS savings; raw post-GC/RSS values are not promoted as results.

Full production Control UI browser runs in Chromium 151.0.7922.34 with a synthetic mocked Gateway return eight exactly matching label arrays through en → fr → ar → en, including chat ages and completed-task durations; English roundtrip is exact and final runs report zero browser errors. Browser fixtures display seconds/minutes/hours/days; the owner probe covers all seven units. Both versions briefly show the previous Appearance select caption during language transitions; whether it persists after settled paint remains a named follow-up, not a confirmed regression.

Before and after, with synthetic data in the full Control UI:

| View | Before | After |
| --- | --- | --- |
| Task durations and ages | ![Task durations before](https://github.com/user-attachments/assets/77ae6581-5cf6-4eff-b5eb-0e41054cbbb9) | ![Task durations after](https://github.com/user-attachments/assets/59fb3459-942b-473f-9635-2d762847fb53) |
| Arabic relative labels | ![Arabic labels before](https://github.com/user-attachments/assets/46a934aa-fafb-4b76-9eb0-8e57724ee689) | ![Arabic labels after](https://github.com/user-attachments/assets/51bf7d13-0db7-4184-99eb-83b88385eccc) |

```sh
node scripts/run-vitest.mjs ui/src/lib/format.test.ts
pnpm ui:build
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/lib/format.ts
pnpm tsgo:ui
```

All 67 existing tests, UI build, exact-file typed lint, UI typecheck, formatting, and `git diff --check` pass. Independent P2 review recorded no actionable findings. Broad repository guards/core-test typechecking were not rerun locally; required exact-head hosted CI/native gates remain mandatory. Browser proof uses mocked data, without a live Gateway/provider or whole-UI performance measurement.
