### PR TITLE
fix(models): retain compatible catalogs after refresh failures

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -91,10 +91,11 @@ retain it without running discovery again. Aliases, policy, and runtime capabili
 use the new configuration. A successful catalog refresh replaces that inventory,
 including a successful empty account list. Metadata alone cannot refill that list;
 explicitly configured models and independent native runtime catalogs remain.
-When a provider reports failed discovery, the
-Gateway retains its last compatible inventory and reports the failed outcome while
-healthy providers update. Changes to provider, plugin, auth, environment, or
-workspace identity invalidate incompatible inventory.
+When a provider reports failed discovery, the Gateway retains its last compatible
+inventory and reports the failed outcome while healthy providers update. Without
+compatible inventory, the provider's own advisory fallback rows remain visible.
+They cannot widen a retained successful list, including an empty list. Changes to
+provider, plugin, auth, environment, or workspace identity invalidate incompatible inventory.
 
 A successful provider result takes precedence over retained rows, even when
 another credential reports failure. Catalog results describe one provider's model

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -88,8 +88,17 @@ Other selection rules:
 
 Once the Gateway has discovered a provider inventory, model-selection hot reloads
 retain it without running discovery again. Aliases, policy, and runtime capabilities
-use the new configuration. Explicit catalog refresh replaces that inventory;
-changes to its provider, plugin, auth, environment, or workspace scope invalidate it.
+use the new configuration. A successful catalog refresh replaces that inventory,
+including a successful empty account list. Metadata alone cannot refill that list;
+explicitly configured models and independent native runtime catalogs remain.
+When a provider reports failed discovery, the
+Gateway retains its last compatible inventory and reports the failed outcome while
+healthy providers update. Changes to provider, plugin, auth, environment, or
+workspace identity invalidate incompatible inventory.
+
+A successful provider result takes precedence over retained rows, even when
+another credential reports failure. Catalog results describe one provider's model
+list; OpenClaw does not guess which old models belonged to each credential.
 
 Full mechanics: [Model failover](/concepts/model-failover).
 

--- a/src/agents/model-catalog-provider-normalizer.ts
+++ b/src/agents/model-catalog-provider-normalizer.ts
@@ -1,0 +1,40 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { buildModelCatalogProviderAliasTargets } from "../model-catalog/manifest-planner.js";
+import { isManifestPluginAvailableForControlPlane } from "../plugins/manifest-contract-eligibility.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+
+/** Prepares provider aliases once for one captured catalog metadata generation. */
+export function createPreparedModelCatalogProviderNormalizer(
+  metadataSnapshot: Pick<PluginMetadataSnapshot, "index" | "plugins">,
+  config: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+): (provider: string) => string {
+  const aliases = new Map<string, string>();
+  for (const plugin of metadataSnapshot.plugins) {
+    if (
+      !isManifestPluginAvailableForControlPlane({
+        snapshot: metadataSnapshot,
+        plugin,
+        config,
+        env,
+      })
+    ) {
+      continue;
+    }
+    for (const [target, providerAliases] of buildModelCatalogProviderAliasTargets(plugin)) {
+      const canonicalProvider = normalizeProviderId(target);
+      for (const alias of providerAliases) {
+        const key = normalizeProviderId(alias);
+        // Duplicate owned aliases retain the first target in manifest order.
+        if (!aliases.has(key)) {
+          aliases.set(key, canonicalProvider);
+        }
+      }
+    }
+  }
+  return (provider) => {
+    const normalizedProvider = normalizeProviderId(provider);
+    return aliases.get(normalizedProvider) ?? normalizedProvider;
+  };
+}

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -92,8 +92,10 @@ describe("prepared model catalog builder", () => {
   });
 
   it.each(["ready", "unavailable", "auth-rejected"] as const)(
-    "does not replenish %s account inventory from metadata",
+    "preserves %s provider membership without replenishing it from metadata",
     async (status) => {
+      const entries =
+        status === "unavailable" ? [{ provider: "demo", id: "fallback", name: "Fallback" }] : [];
       mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValue([
         { provider: "demo", id: "augmentation", name: "Augmentation" },
       ]);
@@ -103,12 +105,12 @@ describe("prepared model catalog builder", () => {
           discovery: "refreshable",
           modelIds: ["manifest-only"],
         }),
-        entries: status === "ready" ? [] : [{ provider: "demo", id: "fallback", name: "Fallback" }],
+        entries,
         providerOutcomes: [{ provider: "demo", status }],
         readOnly: false,
       });
-      expect(snapshot.entries).toEqual([]);
-      expect(snapshot.routeVariants).toEqual([]);
+      expect(snapshot.entries).toMatchObject(entries);
+      expect(snapshot.routeVariants).toMatchObject(entries);
       expect(snapshot.authoritative).toBe(status === "ready");
     },
   );

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -13,7 +13,7 @@ import {
   modelSupportsDocument,
   modelSupportsVision,
 } from "./model-catalog.js";
-import type { ModelCatalogEntry } from "./model-catalog.types.js";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
 import type { ModelRegistry } from "./sessions/index.js";
 
 type AugmentModelCatalogWithProviderPlugins =
@@ -69,6 +69,7 @@ async function build(params: {
   metadataSnapshot?: PluginMetadataSnapshot;
   readOnly?: boolean;
   includeProviderPluginAugmentation?: boolean;
+  providerOutcomes?: ModelCatalogSnapshot["providerOutcomes"];
 }) {
   return await buildPreparedModelCatalogSnapshot({
     agentDir: "/tmp/model-catalog-test",
@@ -77,6 +78,7 @@ async function build(params: {
     metadataSnapshot: params.metadataSnapshot ?? metadataSnapshot,
     modelRegistry: registry(params.entries ?? []),
     readOnly: params.readOnly ?? true,
+    providerOutcomes: params.providerOutcomes,
     ...(params.includeProviderPluginAugmentation !== undefined
       ? { includeProviderPluginAugmentation: params.includeProviderPluginAugmentation }
       : {}),
@@ -88,6 +90,28 @@ describe("prepared model catalog builder", () => {
     mocks.augmentModelCatalogWithProviderPlugins.mockReset();
     mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValue([]);
   });
+
+  it.each(["ready", "unavailable", "auth-rejected"] as const)(
+    "does not replenish %s account inventory from metadata",
+    async (status) => {
+      mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValue([
+        { provider: "demo", id: "augmentation", name: "Augmentation" },
+      ]);
+      const snapshot = await build({
+        metadataSnapshot: providerManifestSnapshot({
+          provider: "demo",
+          discovery: "refreshable",
+          modelIds: ["manifest-only"],
+        }),
+        entries: status === "ready" ? [] : [{ provider: "demo", id: "fallback", name: "Fallback" }],
+        providerOutcomes: [{ provider: "demo", status }],
+        readOnly: false,
+      });
+      expect(snapshot.entries).toEqual([]);
+      expect(snapshot.routeVariants).toEqual([]);
+      expect(snapshot.authoritative).toBe(status === "ready");
+    },
+  );
 
   it("projects and sorts one lifecycle registry generation", async () => {
     const snapshot = await build({
@@ -111,6 +135,42 @@ describe("prepared model catalog builder", () => {
     expect(snapshot.entries[0]?.thinkingLevelMap).toEqual({ off: null, max: "max" });
     expect(snapshot.routeVariants).toEqual(snapshot.entries);
   });
+
+  it("keeps successful profile rows when a sibling profile cannot refresh", async () => {
+    const healthy = { provider: "demo", id: "healthy", name: "Healthy" };
+    const snapshot = await build({
+      entries: [healthy],
+      metadataSnapshot: providerManifestSnapshot({
+        provider: "demo",
+        discovery: "refreshable",
+        modelIds: ["manifest-only"],
+      }),
+      providerOutcomes: [
+        { provider: "demo", profileId: "demo:first", status: "unavailable" },
+        { provider: "demo", profileId: "demo:second", status: "ready" },
+      ],
+    });
+    expect(snapshot.entries).toMatchObject([healthy]);
+    expect(snapshot.authoritative).toBe(false);
+  });
+
+  it.each(["unowned", "disabled"] as const)(
+    "ignores %s provider-alias declarations",
+    async (kind) => {
+      const plugin = createPluginManifestRecordFixture({
+        id: "alias-owner",
+        origin: "bundled",
+        providers: kind === "unowned" ? ["unrelated"] : ["target"],
+        modelCatalog: { aliases: { source: { provider: "target" } } },
+      });
+      const snapshot = await build({
+        config: { plugins: { entries: { "alias-owner": { enabled: kind !== "disabled" } } } },
+        metadataSnapshot: createPluginMetadataSnapshotFixture({ plugins: [plugin] }),
+        entries: [{ provider: "source", id: "model", name: "Model" }],
+      });
+      expect(snapshot.entries).toMatchObject([{ provider: "source", id: "model" }]);
+    },
+  );
 
   it("keeps unranked registry rows in deterministic model-id order", async () => {
     const snapshot = await build({

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -437,14 +437,9 @@ export async function buildPreparedModelCatalogSnapshot(
       cfg,
       env,
     );
-    const providerReadiness = new Map<string, boolean>();
-    for (const outcome of params.providerOutcomes ?? []) {
-      const provider = normalizeProvider(outcome.provider);
-      providerReadiness.set(
-        provider,
-        providerReadiness.get(provider) === true || outcome.status === "ready",
-      );
-    }
+    const observedProviders = new Set(
+      params.providerOutcomes?.map((outcome) => normalizeProvider(outcome.provider)),
+    );
     const { buildShouldSuppressBuiltInModelCore } = await loadModelSuppression();
     logStage("catalog-deps-ready");
     const entries = params.modelRegistry.getAll() as DiscoveredModel[];
@@ -468,9 +463,6 @@ export async function buildPreparedModelCatalogSnapshot(
         continue;
       }
       const provider = normalizeProvider(rawProvider);
-      if (providerReadiness.get(provider) === false) {
-        continue;
-      }
       const id = normalizeModelId(provider, rawId);
       const baseUrl = normalizeOptionalString(entry?.baseUrl);
       if (shouldSuppressBuiltInModel({ provider, id, baseUrl })) {
@@ -526,7 +518,7 @@ export async function buildPreparedModelCatalogSnapshot(
       supplementalManifestPlan.rows.map((entry) => catalogEntryDedupeKey(entry.provider, entry.id)),
     );
     const runtimeDiscoveryProviders = new Set([
-      ...providerReadiness.keys(),
+      ...observedProviders,
       ...supplementalManifestPlan.entries.flatMap((entry) =>
         entry.discovery === "runtime" ? [normalizeProviderId(entry.provider)] : [],
       ),
@@ -539,7 +531,7 @@ export async function buildPreparedModelCatalogSnapshot(
     const manifestModels = declaredManifestModels.filter(
       (entry) =>
         supplementalManifestKeys.has(catalogEntryDedupeKey(entry.provider, entry.id)) &&
-        (!providerReadiness.has(entry.provider) ||
+        (!observedProviders.has(entry.provider) ||
           discoveredKeys.has(catalogEntryDedupeKey(entry.provider, entry.id))),
     );
     mergeCatalogRouteVariants(routeVariants, manifestModels);

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -20,6 +20,7 @@ import { createLazyPromise } from "../shared/lazy-promise.js";
 import { modelCatalogRowToEntry } from "./model-catalog-entry.js";
 import { modelSupportsInput as modelCatalogEntrySupportsInput } from "./model-catalog-lookup.js";
 import { assignProviderModelOrder, compareModelCatalogEntries } from "./model-catalog-order.js";
+import { createPreparedModelCatalogProviderNormalizer } from "./model-catalog-provider-normalizer.js";
 import type {
   ModelCatalogEntry,
   ModelCatalogSnapshot,
@@ -66,6 +67,7 @@ export type BuildPreparedModelCatalogParams = {
   readOnly?: boolean;
   includeProviderPluginAugmentation?: boolean;
   metadataSnapshot: PluginMetadataSnapshot;
+  providerOutcomes?: ModelCatalogSnapshot["providerOutcomes"];
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 };
@@ -84,30 +86,6 @@ const loadProviderApiKeyResolver = createLazyPromise(
 export function resetModelCatalogBuilderCacheForTest() {
   manifestModelCatalogCache = new WeakMap();
   hasLoggedModelCatalogError = false;
-}
-
-/** Prepares provider aliases once for one captured catalog metadata generation. */
-export function createPreparedModelCatalogProviderNormalizer(
-  metadataSnapshot: Pick<PluginMetadataSnapshot, "manifestRegistry">,
-): (provider: string) => string {
-  let aliases: Map<string, string> | undefined;
-  return (provider) => {
-    const normalizedProvider = normalizeProviderId(provider);
-    if (!aliases) {
-      aliases = new Map();
-      for (const plugin of metadataSnapshot.manifestRegistry.plugins) {
-        for (const [alias, target] of Object.entries(plugin.modelCatalog?.aliases ?? {})) {
-          const key = normalizeProviderId(alias);
-          const canonicalProvider = normalizeProviderId(target.provider);
-          // Duplicate aliases retain the first nonempty target in manifest order.
-          if (canonicalProvider && !aliases.has(key)) {
-            aliases.set(key, canonicalProvider);
-          }
-        }
-      }
-    }
-    return aliases.get(normalizedProvider) ?? normalizedProvider;
-  };
 }
 
 function catalogEntryDedupeKey(provider: string, id: string): string {
@@ -454,8 +432,19 @@ export async function buildPreparedModelCatalogSnapshot(
     const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({
       manifestPlugins: manifestMetadataSnapshot,
     });
-    const normalizeProvider =
-      createPreparedModelCatalogProviderNormalizer(manifestMetadataSnapshot);
+    const normalizeProvider = createPreparedModelCatalogProviderNormalizer(
+      manifestMetadataSnapshot,
+      cfg,
+      env,
+    );
+    const providerReadiness = new Map<string, boolean>();
+    for (const outcome of params.providerOutcomes ?? []) {
+      const provider = normalizeProvider(outcome.provider);
+      providerReadiness.set(
+        provider,
+        providerReadiness.get(provider) === true || outcome.status === "ready",
+      );
+    }
     const { buildShouldSuppressBuiltInModelCore } = await loadModelSuppression();
     logStage("catalog-deps-ready");
     const entries = params.modelRegistry.getAll() as DiscoveredModel[];
@@ -479,6 +468,9 @@ export async function buildPreparedModelCatalogSnapshot(
         continue;
       }
       const provider = normalizeProvider(rawProvider);
+      if (providerReadiness.get(provider) === false) {
+        continue;
+      }
       const id = normalizeModelId(provider, rawId);
       const baseUrl = normalizeOptionalString(entry?.baseUrl);
       if (shouldSuppressBuiltInModel({ provider, id, baseUrl })) {
@@ -533,15 +525,22 @@ export async function buildPreparedModelCatalogSnapshot(
     const supplementalManifestKeys = new Set(
       supplementalManifestPlan.rows.map((entry) => catalogEntryDedupeKey(entry.provider, entry.id)),
     );
-    const runtimeDiscoveryProviders = new Set(
-      supplementalManifestPlan.entries.flatMap((entry) =>
+    const runtimeDiscoveryProviders = new Set([
+      ...providerReadiness.keys(),
+      ...supplementalManifestPlan.entries.flatMap((entry) =>
         entry.discovery === "runtime" ? [normalizeProviderId(entry.provider)] : [],
       ),
-    );
+    ]);
     // Runtime declarations describe possible models, not account entitlement.
     // Only live registry or refreshed rows may publish those provider models.
-    const manifestModels = declaredManifestModels.filter((entry) =>
-      supplementalManifestKeys.has(catalogEntryDedupeKey(entry.provider, entry.id)),
+    const discoveredKeys = new Set(
+      models.map((entry) => catalogEntryDedupeKey(entry.provider, entry.id)),
+    );
+    const manifestModels = declaredManifestModels.filter(
+      (entry) =>
+        supplementalManifestKeys.has(catalogEntryDedupeKey(entry.provider, entry.id)) &&
+        (!providerReadiness.has(entry.provider) ||
+          discoveredKeys.has(catalogEntryDedupeKey(entry.provider, entry.id))),
     );
     mergeCatalogRouteVariants(routeVariants, manifestModels);
     mergeCatalogEntries(models, manifestModels);
@@ -647,7 +646,12 @@ export async function buildPreparedModelCatalogSnapshot(
 
     const snapshot = createModelCatalogSnapshot(models, routeVariants);
     logStage("complete", `entries=${snapshot.entries.length}`);
-    return snapshot;
+    return params.providerOutcomes
+      ? {
+          ...snapshot,
+          authoritative: params.providerOutcomes.every((outcome) => outcome.status === "ready"),
+        }
+      : snapshot;
   } catch (error) {
     if (!hasLoggedModelCatalogError) {
       hasLoggedModelCatalogError = true;

--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
 import type { PluginMetadataSnapshotOwnerMaps } from "../plugins/plugin-metadata-snapshot.js";
-import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import {
+  createPluginManifestRecordFixture,
+  createPluginMetadataSnapshotFixture,
+} from "../plugins/plugin-metadata.test-support.js";
 import {
   prepareProviderExternalAuthWithPlugin,
   resolveProviderSyntheticAuthWithPlugin,
@@ -13,6 +16,7 @@ import {
   resolveSyntheticAuthWithProvider,
 } from "../plugins/provider-synthetic-auth.js";
 import type { ProviderPlugin } from "../plugins/types.js";
+import { SecretSurfaceUnavailableError } from "../secrets/runtime-degraded-state.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   createOpenClawTestState,
@@ -612,6 +616,74 @@ describe("resolveImplicitProviders startup discovery scope", () => {
 
     expect(outcomes).toEqual([{ provider: "openai", status: "unavailable" }]);
   });
+
+  it.each(["timeout", "secret-unavailable"] as const)(
+    "records every selected family identity after %s without accepting late success",
+    async (failure) => {
+      const family = createProvider("family");
+      const healthy = createProvider("healthy");
+      mocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([family, healthy]);
+      const completion = Promise.withResolvers<void>();
+      let lateCatalog: Promise<void> | undefined;
+      const outcomes: Array<{ provider: string; status: string }> = [];
+      mocks.runProviderCatalog.mockImplementation((params) => {
+        if (params.provider.id === "healthy") {
+          return Promise.resolve({
+            provider: {
+              baseUrl: "https://healthy.example.test/v1",
+              models: [createTextModel("healthy-live", "Healthy live")],
+            },
+          });
+        }
+        if (failure === "secret-unavailable") {
+          return Promise.reject(
+            new SecretSurfaceUnavailableError({
+              ownerKind: "provider",
+              ownerId: "family",
+              state: "unavailable",
+              paths: ["models.providers.family.apiKey"],
+              refKeys: [],
+              reason: "fixture secret is unavailable",
+            }),
+          );
+        }
+        lateCatalog = completion.promise.then(() => {
+          params.reportCatalogOutcome?.({ provider: "family-plan", status: "ready" });
+        });
+        return lateCatalog;
+      });
+      const providers = await resolveImplicitProviders({
+        agentDir: state.agentDir(),
+        config: {},
+        env: state.env,
+        explicitProviders: {},
+        providerDiscoveryProviderIds: ["family", "family-plan", "healthy"],
+        providerDiscoveryTimeoutMs: 1,
+        pluginMetadataSnapshot: createPluginMetadataSnapshotFixture({
+          plugins: [
+            createPluginManifestRecordFixture({
+              id: "family",
+              providers: ["family", "family-plan"],
+            }),
+            createPluginManifestRecordFixture({ id: "healthy", providers: ["healthy"] }),
+          ],
+        }),
+        onProviderCatalogOutcome: (outcome) => outcomes.push(outcome),
+      });
+      const expected = [
+        { provider: "family", status: "unavailable" },
+        { provider: "family-plan", status: "unavailable" },
+      ];
+      try {
+        expect(providers?.healthy.models.map((model) => model.id)).toEqual(["healthy-live"]);
+        expect(outcomes).toEqual(expected);
+      } finally {
+        completion.resolve();
+        await lateCatalog;
+      }
+      expect(outcomes).toEqual(expected);
+    },
+  );
 
   it("rethrows non-timeout live catalog discovery failures", async () => {
     mocks.runProviderCatalog.mockRejectedValueOnce(

--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../plugins/provider-synthetic-auth.js";
 import type { ProviderPlugin } from "../plugins/types.js";
 import { SecretSurfaceUnavailableError } from "../secrets/runtime-degraded-state.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   createOpenClawTestState,
@@ -623,7 +624,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
       const family = createProvider("family");
       const healthy = createProvider("healthy");
       mocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([family, healthy]);
-      const completion = Promise.withResolvers<void>();
+      const completion = createDeferredCore();
       let lateCatalog: Promise<void> | undefined;
       const outcomes: Array<{ provider: string; status: string }> = [];
       mocks.runProviderCatalog.mockImplementation((params) => {
@@ -675,7 +676,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
         { provider: "family-plan", status: "unavailable" },
       ];
       try {
-        expect(providers?.healthy.models.map((model) => model.id)).toEqual(["healthy-live"]);
+        expect(providers?.healthy?.models.map((model) => model.id)).toEqual(["healthy-live"]);
         expect(outcomes).toEqual(expected);
       } finally {
         completion.resolve();

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -375,11 +375,20 @@ async function runProviderCatalogWithTimeout(
     `provider catalog timed out after ${timeoutMs}ms: ${params.provider.id}`,
   );
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let active = true;
+  const catalogParams = {
+    ...params,
+    reportCatalogOutcome: (outcome: ProviderCatalogOutcome) => {
+      if (active) {
+        params.reportCatalogOutcome?.(outcome);
+      }
+    },
+  };
   try {
     if (!timeoutMs) {
-      return await runProviderCatalog(params);
+      return await runProviderCatalog(catalogParams);
     }
-    const catalogRun = runProviderCatalog(params);
+    const catalogRun = runProviderCatalog(catalogParams);
     // Live discovery should not hang startup; a timeout skips this provider while
     // preserving the rest of the prepared catalog.
     return await Promise.race([
@@ -392,21 +401,20 @@ async function runProviderCatalogWithTimeout(
       }),
     ]);
   } catch (error) {
-    if (isTrustedSecretSurfaceUnavailableError(error)) {
-      params.reportCatalogOutcome?.({ provider: params.provider.id, status: "unavailable" });
-      return undefined;
+    if (!isTrustedSecretSurfaceUnavailableError(error) && error !== timeoutError) {
+      throw error;
+    }
+    for (const provider of params.providerIds ?? [params.provider.id]) {
+      params.reportCatalogOutcome?.({ provider, status: "unavailable" });
     }
     if (error === timeoutError) {
       const message = formatErrorMessage(error);
-      params.reportCatalogOutcome?.({
-        provider: params.provider.id,
-        status: "unavailable",
-      });
       log.warn(`${message}; skipping provider discovery`);
-      return undefined;
     }
-    throw error;
+    return undefined;
   } finally {
+    // A timed-out hook can still finish; its late reports no longer own this publication.
+    active = false;
     if (timer) {
       clearTimeout(timer);
     }

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -445,6 +445,12 @@ describe("prepared model catalog worker boundary", () => {
       const catalog = await fixture.snapshot.loadFullModelCatalog?.({ refresh: true });
       const fullAuth = getPreparedModelFullCatalogAuth(catalog!);
 
+      expect(fullAuth?.credentials?.[DISCOVERED_HARNESS_ID]).toEqual({
+        type: "api_key",
+        key: "discovered-native-login-not-real",
+      });
+      expect(catalog).not.toHaveProperty("credentials");
+
       if (asyncSyntheticAuth) {
         expect(
           fs
@@ -981,7 +987,7 @@ describe("prepared model catalog worker boundary", () => {
       pluginMetadataSnapshot: fixture.pluginMetadataSnapshot,
       isCurrent: fixture.isCurrent,
     });
-    const catalog = await worker.loadCatalog();
+    const { modelCatalog: catalog } = await worker.loadCatalog();
 
     expect(catalog.entries).toContainEqual(
       expect.objectContaining({

--- a/src/agents/prepared-model-catalog-worker.mismatch.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.mismatch.integration.test.ts
@@ -220,7 +220,7 @@ describe("prepared model catalog worker generation mismatch", () => {
       workerBoundary.fingerprint = undefined;
       const recovered = await worker.loadCatalog();
       expect(spawned).toHaveLength(2);
-      expect(recovered.entries).toContainEqual(
+      expect(recovered.modelCatalog.entries).toContainEqual(
         expect.objectContaining({ provider: PROVIDER_ID, id: "account-scoped-model" }),
       );
       expect(fs.readFileSync(fixture.marker, "utf8")).toBe("start\ndone\n");
@@ -275,9 +275,11 @@ describe("prepared model catalog worker generation mismatch", () => {
             expect(failure).toMatchObject({ name: "PreparedModelCatalogGenerationMismatchError" });
           }
           expect(await outcome).toMatchObject({
-            entries: expect.arrayContaining([
-              expect.objectContaining({ provider: PROVIDER_ID, id: "account-scoped-model" }),
-            ]),
+            modelCatalog: {
+              entries: expect.arrayContaining([
+                expect.objectContaining({ provider: PROVIDER_ID, id: "account-scoped-model" }),
+              ]),
+            },
           });
           await expect(worker.loadAuth({ providerIds: [PROVIDER_ID] })).resolves.toMatchObject({
             authStore: expect.objectContaining({ version: 1 }),

--- a/src/agents/prepared-model-catalog-worker.test-support.ts
+++ b/src/agents/prepared-model-catalog-worker.test-support.ts
@@ -26,7 +26,10 @@ import {
 import { preparePublishedModelCatalogOwnerIdentity } from "./prepared-model-catalog-owner.js";
 import { getPreparedModelFullCatalogAuth } from "./prepared-model-runtime-auth.js";
 import { startSerializedSnapshotBuildBatch } from "./prepared-model-runtime.build.js";
-import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.types.js";
+import type {
+  PreparedModelRuntimeOwner,
+  PreparedModelRuntimeSnapshot,
+} from "./prepared-model-runtime.types.js";
 import { writeSyntheticAuthDiscoveryFixture } from "./test-helpers/prepared-model-catalog-worker-fixture.js";
 
 export const PROVIDER_ID = "worker-catalog-fixture";
@@ -520,6 +523,7 @@ export async function expectNativeHarnessModelsPublishedFromWorker(params: {
   makeTempDir: (prefix: string) => string;
   retireAfterTest: (retire: () => void) => void;
 }): Promise<void> {
+  const inventoryOwner: Pick<PreparedModelRuntimeOwner, "catalogInventory"> = {};
   const root = params.makeTempDir("openclaw-native-model-catalog-worker-");
   const stateDir = path.join(root, "state");
   const agentDir = path.join(stateDir, "agents", "main", "agent");
@@ -606,6 +610,7 @@ export async function expectNativeHarnessModelsPublishedFromWorker(params: {
         {
           input,
           catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
+          inventoryOwner,
           isGenerationCurrent: () => current,
           isBuildCurrent: () => current,
         },
@@ -620,4 +625,19 @@ export async function expectNativeHarnessModelsPublishedFromWorker(params: {
     metadataSnapshot: build.pluginGeneration.pluginMetadataSnapshot,
     snapshot: build.snapshot,
   });
+  expect(
+    inventoryOwner.catalogInventory?.catalog.entries.some(
+      (entry) => entry.id === "configured-dynamic-model",
+    ),
+  ).toBe(false);
+  expect(
+    inventoryOwner.catalogInventory?.catalog.routeVariants.some(
+      (entry) => entry.id === "configured-dynamic-model",
+    ),
+  ).toBe(false);
+  expect(
+    inventoryOwner.catalogInventory?.catalog.staticEntries?.some(
+      (entry) => entry.id === "configured-dynamic-model",
+    ),
+  ).toBe(false);
 }

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -22,11 +22,15 @@ import {
   type PreparedModelRuntimeAuth,
   type PreparedModelRuntimeAuthScope,
 } from "./prepared-model-runtime-auth.js";
-import type { PreparedModelRuntimeAgentFacts } from "./prepared-model-runtime.catalog-contract.js";
+import type {
+  PreparedModelRuntimeAgentFacts,
+  PreparedModelRuntimeCatalogFacts,
+} from "./prepared-model-runtime.catalog-contract.js";
 import { PreparedModelRuntimePublicationSupersededError } from "./prepared-model-runtime.errors.js";
 import { fingerprintPreparedRuntimeFacts } from "./prepared-model-runtime.facts.js";
 import { markPreparedModelCatalogFull } from "./prepared-model-runtime.full-catalog.js";
 import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
+import type { AuthStorageData } from "./sessions/auth-storage.js";
 
 export type PreparedModelCatalogWorkerInput = Readonly<{
   kind: "catalog";
@@ -58,6 +62,8 @@ export type PreparedModelWorkerResult =
       kind: "catalog";
       generationFingerprint: string;
       snapshot: ModelCatalogSnapshot;
+      configuredRuntimeModels: PreparedModelRuntimeCatalogFacts["configuredRuntimeModels"];
+      credentials: Readonly<AuthStorageData>;
       authStore: AuthProfileStore;
       authModes: PreparedAgentCredentialModes;
     }>
@@ -190,7 +196,9 @@ export function createPreparedModelCatalogWorkerInput(params: {
 
 type PreparedModelCatalogWorker = Readonly<{
   loadAuth: (scope: PreparedModelRuntimeAuthScope) => Promise<PreparedModelRuntimeAuth>;
-  loadCatalog: () => Promise<ModelCatalogSnapshot>;
+  loadCatalog: () => Promise<
+    Pick<PreparedModelRuntimeCatalogFacts, "modelCatalog" | "configuredRuntimeModels">
+  >;
 }>;
 
 export function createPreparedModelCatalogWorker(
@@ -360,8 +368,9 @@ export function createPreparedModelCatalogWorker(
       setPreparedModelFullCatalogAuth(modelCatalog, {
         authStore: message.authStore,
         authModes: message.authModes,
+        credentials: message.credentials,
       });
-      return modelCatalog;
+      return { modelCatalog, configuredRuntimeModels: message.configuredRuntimeModels };
     },
     loadAuth: async ({ providerIds, profileIds }) => {
       const normalizedProviderIds = [...new Set(providerIds)].toSorted((left, right) =>

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -297,18 +297,23 @@ export async function runPreparedModelCatalogWorkerRequest(
     const facts = await prepareFullCatalogFacts(exactAgentFacts, catalogGeneration, "live", source);
     // Full discovery can publish routes absent from startup config. Pair those exact rows with
     // provider-owned synthetic auth before the catalog and auth modes cross the worker boundary.
-    const catalogCredentials = resolveSyntheticCredentials(
-      [...facts.modelCatalog.entries, ...facts.modelCatalog.routeVariants]
-        .map((entry) => entry.provider)
-        .filter((provider) => !startupProviderIds.has(normalizeProviderId(provider))),
-    );
+    const catalogCredentials = {
+      ...resolveSyntheticCredentials(
+        [...facts.modelCatalog.entries, ...facts.modelCatalog.routeVariants]
+          .map((entry) => entry.provider)
+          .filter((provider) => !startupProviderIds.has(normalizeProviderId(provider))),
+      ),
+      ...credentials,
+    };
     return {
       status: "ok",
       kind: "catalog",
       generationFingerprint,
       snapshot: facts.modelCatalog,
+      configuredRuntimeModels: facts.configuredRuntimeModels,
+      credentials: catalogCredentials,
       authStore,
-      authModes: resolveUsableAgentCredentialModes({ ...catalogCredentials, ...credentials }),
+      authModes: resolveUsableAgentCredentialModes(catalogCredentials),
     };
   } catch (error) {
     return {

--- a/src/agents/prepared-model-runtime-auth.ts
+++ b/src/agents/prepared-model-runtime-auth.ts
@@ -1,11 +1,18 @@
 import type { PreparedAgentCredentialModes } from "./agent-auth-credential-modes.js";
 import type { RuntimeAuthMaterialization } from "./auth-profiles/runtime-materializations.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import type { AuthStorageData } from "./sessions/auth-storage.js";
 
 export type PreparedModelRuntimeAuth = Readonly<{
   authStore: AuthProfileStore;
   authModes: PreparedAgentCredentialModes;
 }>;
+
+export type PreparedModelCatalogAuth = PreparedModelRuntimeAuth &
+  Readonly<{
+    /** Unobserved discovery credentials cannot authorize account-inventory retention. */
+    credentials?: Readonly<AuthStorageData>;
+  }>;
 
 export type PreparedModelRuntimeAuthScope = Readonly<{
   providerIds: readonly string[];
@@ -19,7 +26,7 @@ const authLoaderBySnapshot = new WeakMap<
   object,
   (scope: PreparedModelRuntimeAuthScope) => Promise<PreparedModelRuntimeAuth>
 >();
-const authByFullCatalog = new WeakMap<object, PreparedModelRuntimeAuth>();
+const authByFullCatalog = new WeakMap<object, PreparedModelCatalogAuth>();
 
 // Secret-bearing state stays lifecycle-owned without becoming part of the public snapshot shape.
 export function setPreparedModelRuntimeAuthStore(
@@ -35,7 +42,7 @@ export function getPreparedModelRuntimeAuthStore(snapshot: object): AuthProfileS
 
 export function setPreparedModelFullCatalogAuth(
   snapshot: object,
-  auth: PreparedModelRuntimeAuth,
+  auth: PreparedModelCatalogAuth,
 ): void {
   authByFullCatalog.set(snapshot, auth);
 }

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -1,16 +1,20 @@
 import { performance } from "node:perf_hooks";
 import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import { isDeepStrictEqual } from "node:util";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import pLimit from "p-limit";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runAbortableTimeout } from "../node-host/with-timeout.js";
+import { resolveInstalledManifestRegistryIndexFingerprint } from "../plugins/manifest-registry-installed.js";
 import { prepareModelCatalogThinkingPolicies } from "../plugins/provider-thinking.js";
+import { dedupeByKey } from "../shared/dedupe-by-key.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { resolveUsableAgentCredentialModes } from "./agent-auth-credentials.js";
 import { getPreparedRuntimeAuthMaterializations } from "./auth-profiles/runtime-materializations.js";
 import { collectConfiguredAgentHarnessRuntimes } from "./harness-runtimes.js";
 import { augmentPreparedModelCatalogWithAgentHarness } from "./harness/model-catalog.js";
+import { createPreparedModelCatalogProviderNormalizer } from "./model-catalog-provider-normalizer.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { createPreparedModelCatalogWorker } from "./prepared-model-catalog-worker.js";
 import {
@@ -27,6 +31,10 @@ import type {
   PreparedModelRuntimeCatalogFacts,
   PreparedModelRuntimeCatalogSource,
 } from "./prepared-model-runtime.catalog-contract.js";
+import {
+  modelCatalogEntryKey,
+  prepareConfiguredRuntimeFacts,
+} from "./prepared-model-runtime.configured-catalog.js";
 import { PreparedModelRuntimePublicationSupersededError } from "./prepared-model-runtime.errors.js";
 import {
   fingerprintPreparedRuntimeFacts,
@@ -36,9 +44,11 @@ import {
   prepareWorkspaceBuildGroup,
 } from "./prepared-model-runtime.facts.js";
 import {
+  isPreparedModelCatalogFull,
   markPreparedModelCatalogFull,
   materializePreparedModelCatalog,
   prepareFullCatalogFacts,
+  prepareModelCatalogPublication,
 } from "./prepared-model-runtime.full-catalog.js";
 import {
   createPreparedInboundRegistryLoader,
@@ -152,16 +162,46 @@ function groupBuildCandidates<K>(
 
 function createFullModelCatalogAccess(params: {
   agentFacts: PreparedModelRuntimeAgentFacts;
+  catalogFacts: PreparedModelRuntimeCatalogFacts;
   pluginGeneration: PreparedModelRuntimePluginGeneration;
   agentBuildCompletions: Map<string, Promise<void>>;
   isCurrent: () => boolean;
   inventoryOwner: Pick<PreparedModelRuntimeOwner, "catalogInventory">;
 }): PreparedModelRuntimeCatalogAccess {
   // Retain discovery, not the retired worker or its runtime capability projection.
-  const project = (catalog: ModelCatalogSnapshot) => {
+  const project = (
+    catalog: ModelCatalogSnapshot,
+    configuredRuntimeModels = params.catalogFacts.configuredRuntimeModels,
+  ) => {
+    const configured = prepareConfiguredRuntimeFacts({
+      agentFacts: params.agentFacts,
+      workspaceFacts: params.pluginGeneration,
+      templateModelRegistry: params.catalogFacts.templateModelRegistry,
+      configuredRuntimeModels,
+    }).modelCatalog;
+    const current = materializePreparedModelCatalog(
+      configured,
+      params.agentFacts.runtimeCapabilityModels,
+      configuredRuntimeModels,
+    );
     const projected = materializePreparedModelCatalog(
       catalog,
       params.agentFacts.runtimeCapabilityModels,
+      configuredRuntimeModels,
+    );
+    projected.entries = dedupeByKey(
+      [...projected.entries, ...current.entries],
+      modelCatalogEntryKey,
+    );
+    projected.routeVariants = dedupeByKey(
+      [...projected.routeVariants, ...current.routeVariants],
+      (entry) =>
+        JSON.stringify([
+          modelCatalogEntryKey(entry),
+          entry.api,
+          entry.baseUrl,
+          entry.nativeRuntime,
+        ]),
     );
     prepareModelCatalogThinkingPolicies({
       catalog: projected,
@@ -171,9 +211,39 @@ function createFullModelCatalogAccess(params: {
     return projected;
   };
   const inventoryKey = preparedModelInventoryKey(params.agentFacts.input);
-  const inventory = params.inventoryOwner.catalogInventory;
-  let fullCatalog = inventory?.key === inventoryKey ? project(inventory.catalog) : undefined;
-  let pending: Promise<ModelCatalogSnapshot> | undefined;
+  const normalizeProvider = createPreparedModelCatalogProviderNormalizer(
+    params.pluginGeneration.pluginMetadataSnapshot,
+    params.agentFacts.input.config,
+    params.agentFacts.env,
+  );
+  const previousInventory = params.inventoryOwner.catalogInventory;
+  const pluginFingerprint = resolveInstalledManifestRegistryIndexFingerprint(
+    params.pluginGeneration.pluginMetadataSnapshot.index,
+  );
+  let inventory =
+    previousInventory?.key === inventoryKey &&
+    previousInventory.pluginFingerprint === pluginFingerprint &&
+    isDeepStrictEqual(
+      getPreparedModelFullCatalogAuth(previousInventory.catalog)?.credentials,
+      params.agentFacts.credentials,
+    )
+      ? previousInventory
+      : undefined;
+  let fullCatalog = inventory ? project(inventory.catalog) : undefined;
+  if (fullCatalog) {
+    if (
+      params.pluginGeneration.pluginRegistry?.agentHarnesses.some(
+        ({ harness }) => harness.loadModelCatalog,
+      )
+    ) {
+      fullCatalog.authoritative = false;
+    } else {
+      markPreparedModelCatalogFull(fullCatalog);
+    }
+  }
+  let pending:
+    | { source: "inventory" | "worker"; promise: Promise<ModelCatalogSnapshot> }
+    | undefined;
   let pendingAuth:
     | {
         key: string;
@@ -226,12 +296,19 @@ function createFullModelCatalogAccess(params: {
       assertCurrent();
       return fullCatalog;
     },
-    loadFullModelCatalog: async (options) => {
+    loadFullModelCatalog: async function loadFullModelCatalog(
+      options,
+    ): Promise<ModelCatalogSnapshot> {
       assertCurrent();
-      if (!options?.refresh && fullCatalog) {
+      if (!options?.refresh && fullCatalog && isPreparedModelCatalogFull(fullCatalog)) {
         return fullCatalog;
       }
+      if (options?.refresh && pending?.source === "inventory") {
+        await pending.promise;
+        return await loadFullModelCatalog(options);
+      }
       if (!pending) {
+        const retainedCatalog = !options?.refresh ? inventory?.catalog : undefined;
         const build = runSerializedPreparedModelRuntimeTask({
           agentDir: params.agentFacts.input.agentDir,
           agentBuildCompletions: params.agentBuildCompletions,
@@ -241,41 +318,57 @@ function createFullModelCatalogAccess(params: {
               // Full inventory belongs to explicit control-plane reads. The generation queue
               // prevents a stale plan from overlapping or following a replacement build.
               assertCurrent();
-              const workerCatalog = await worker.loadCatalog();
+              const { modelCatalog: workerCatalog, configuredRuntimeModels } = retainedCatalog
+                ? {
+                    modelCatalog: retainedCatalog,
+                    configuredRuntimeModels: params.catalogFacts.configuredRuntimeModels,
+                  }
+                : await worker.loadCatalog();
               assertCurrent();
               const auth = getPreparedModelFullCatalogAuth(workerCatalog);
               if (!auth) {
                 throw new Error("prepared model catalog worker omitted its auth generation");
               }
-              // Native harness readiness is process-local. The worker can serialize discovered
-              // rows, but it cannot transfer the parent Gateway's harness observation. Reobserve
-              // through the generation-owned parent registry before publishing the full catalog.
+              const publication = prepareModelCatalogPublication(
+                workerCatalog,
+                inventory,
+                auth,
+                normalizeProvider,
+              );
+              // Provider inventory survives compatible reloads. Native rows and readiness
+              // must come from this generation's parent registry before full publication.
               const catalog = markPreparedModelCatalogFull(
                 await augmentPreparedModelCatalogWithAgentHarness({
                   input: params.agentFacts.input,
-                  snapshot: workerCatalog,
+                  snapshot: project(publication.catalog, configuredRuntimeModels),
                   pluginRegistry: params.pluginGeneration.pluginRegistry,
                   isCurrent: params.isCurrent,
                 }),
               );
               setPreparedModelFullCatalogAuth(catalog, auth);
               assertCurrent();
-              return catalog;
+              return { catalog, publication };
             }),
         });
-        pending = build
-          .then((catalog) => {
+        const promise = build
+          .then(({ catalog, publication }) => {
             assertCurrent();
-            fullCatalog = project(catalog);
-            params.inventoryOwner.catalogInventory = { catalog, key: inventoryKey };
+            inventory = {
+              ...publication,
+              key: inventoryKey,
+              pluginFingerprint,
+            };
+            params.inventoryOwner.catalogInventory = inventory;
+            fullCatalog = catalog;
             notifyPreparedModelRuntimePublication({ phase: "catalog-published" });
             return fullCatalog;
           })
           .finally(() => {
             pending = undefined;
           });
+        pending = { source: retainedCatalog ? "inventory" : "worker", promise };
       }
-      return pending;
+      return pending.promise;
     },
   };
 }
@@ -294,6 +387,7 @@ function createSnapshot(
   const modelCatalog = materializePreparedModelCatalog(
     catalogFacts.modelCatalog,
     agentFacts.runtimeCapabilityModels,
+    configuredRuntimeModels,
   );
   prepareModelCatalogThinkingPolicies({
     catalog: modelCatalog,
@@ -567,6 +661,7 @@ async function buildSnapshotBatch(
         catalogFacts,
         createFullModelCatalogAccess({
           agentFacts,
+          catalogFacts,
           pluginGeneration,
           agentBuildCompletions,
           isCurrent: candidate.isGenerationCurrent ?? (() => false),

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -233,7 +233,7 @@ function createFullModelCatalogAccess(params: {
   if (fullCatalog) {
     if (
       params.pluginGeneration.pluginRegistry?.agentHarnesses.some(
-        ({ harness }) => harness.loadModelCatalog,
+        ({ harness }) => typeof harness.loadModelCatalog === "function",
       )
     ) {
       fullCatalog.authoritative = false;

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -33,6 +33,7 @@ import {
   loadBundledProviderStaticCatalogContextModels,
 } from "./embedded-agent-runner/model.static-catalog.js";
 import { createStaticModelIdMatcher } from "./embedded-agent-runner/model.static-id.js";
+import { createPreparedModelCatalogProviderNormalizer } from "./model-catalog-provider-normalizer.js";
 import {
   buildConfiguredModelCatalog,
   parseConfiguredModelVisibilityEntries,
@@ -624,9 +625,14 @@ export async function prepareAgentCatalogSource(
   } = {},
 ): Promise<PreparedModelRuntimeCatalogSource> {
   const { env, input, providerIds } = agentFacts;
+  const normalizeProvider = createPreparedModelCatalogProviderNormalizer(
+    pluginGeneration.pluginMetadataSnapshot,
+    input.config,
+    env,
+  );
   const providerOutcomes = new Map<string, ProviderCatalogOutcome>();
   const recordProviderOutcome = (outcome: ProviderCatalogOutcome) => {
-    const provider = normalizeProviderId(outcome.provider);
+    const provider = normalizeProvider(outcome.provider);
     if (provider) {
       providerOutcomes.set(`${provider}\0${outcome.profileId ?? ""}`, { ...outcome, provider });
     }

--- a/src/agents/prepared-model-runtime.full-catalog.ts
+++ b/src/agents/prepared-model-runtime.full-catalog.ts
@@ -1,10 +1,13 @@
+import { isDeepStrictEqual } from "node:util";
 import { dedupeByKey } from "../shared/dedupe-by-key.js";
 import { discoverModels } from "./agent-model-discovery.js";
 import { loadBundledProviderStaticCatalogContextModels } from "./embedded-agent-runner/model.static-catalog.js";
+import { compareModelCatalogEntries } from "./model-catalog-order.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import {
   getPreparedModelFullCatalogAuth,
   setPreparedModelFullCatalogAuth,
+  type PreparedModelCatalogAuth,
 } from "./prepared-model-runtime-auth.js";
 import type {
   PreparedModelRuntimeAgentFacts,
@@ -15,10 +18,12 @@ import { modelCatalogEntryKey } from "./prepared-model-runtime.configured-catalo
 import { completeConfiguredRuntimeModels } from "./prepared-model-runtime.configured-completion.js";
 import {
   toStaticCatalogEntry,
+  type PreparedConfiguredRuntimeModel,
   type PreparedRuntimeCapabilityModel,
 } from "./prepared-model-runtime.configured.js";
 import { buildPreparedPluginModelCatalog } from "./prepared-model-runtime.plugin-generation.js";
 import type {
+  PreparedModelCatalogInventory,
   PreparedModelRuntimeCatalogMode,
   PreparedModelRuntimePluginGeneration,
 } from "./prepared-model-runtime.types.js";
@@ -51,6 +56,7 @@ export async function prepareFullCatalogFacts(
     agentFacts,
     catalogMode,
     modelRegistry: templateModelRegistry,
+    providerOutcomes: catalogSource?.providerOutcomes,
     pluginGeneration,
   });
   const providerStaticModels =
@@ -67,14 +73,12 @@ export async function prepareFullCatalogFacts(
     pluginGeneration,
     templateModelRegistry,
   );
-  const staticModels = [
-    ...configuredRuntimeModels.map(({ model }) => model),
-    ...providerStaticModels,
-  ];
   const providerOutcomes = catalogSource?.providerOutcomes ?? [];
   const completeModelCatalog = {
     ...modelCatalog,
-    staticEntries: dedupeByKey(staticModels, modelCatalogEntryKey).map(toStaticCatalogEntry),
+    staticEntries: dedupeByKey(providerStaticModels, modelCatalogEntryKey).map(
+      toStaticCatalogEntry,
+    ),
     ...(providerOutcomes.length > 0 ? { providerOutcomes } : {}),
   };
   if (catalogMode === "live") {
@@ -88,10 +92,109 @@ export async function prepareFullCatalogFacts(
   };
 }
 
+export function prepareModelCatalogPublication(
+  discovered: ModelCatalogSnapshot,
+  inventory: PreparedModelCatalogInventory | undefined,
+  auth: PreparedModelCatalogAuth,
+  normalizeProvider: (provider: string) => string,
+): Pick<PreparedModelCatalogInventory, "catalog" | "discoveryOrigins"> {
+  // Native observations belong to this runtime generation, not retained provider inventory.
+  const catalog: ModelCatalogSnapshot = {
+    ...discovered,
+    entries: dedupeByKey(
+      [...discovered.entries, ...discovered.routeVariants].filter((entry) => !entry.nativeRuntime),
+      modelCatalogEntryKey,
+    ),
+    routeVariants: discovered.routeVariants.filter((entry) => !entry.nativeRuntime),
+  };
+  setPreparedModelFullCatalogAuth(catalog, auth);
+  const failed = catalog.providerOutcomes?.filter((outcome) => outcome.status !== "ready") ?? [];
+  const discoveryOrigins = (catalog.providerOutcomes ?? [])
+    .filter((outcome) => outcome.status === "ready")
+    .map(({ provider, profileId }) => ({ provider: normalizeProvider(provider), profileId }));
+  if (failed.length === 0) {
+    return { catalog, discoveryOrigins };
+  }
+  const previous = inventory?.catalog;
+  const previousAuth = previous && getPreparedModelFullCatalogAuth(previous);
+  const retainedProviders = new Set(
+    failed.flatMap((outcome) => {
+      const provider = normalizeProvider(outcome.provider);
+      const previousOrigins = inventory?.discoveryOrigins.filter(
+        (candidate) => normalizeProvider(candidate.provider) === provider,
+      );
+      if (
+        discoveryOrigins.some((origin) => origin.provider === provider) ||
+        !previousAuth ||
+        !previousAuth.credentials ||
+        !auth.credentials ||
+        (outcome.profileId !== undefined &&
+          !previousOrigins?.some((candidate) => candidate.profileId === outcome.profileId)) ||
+        previousAuth.authModes[provider] !== auth.authModes[provider]
+      ) {
+        return [];
+      }
+      const providerProfiles = (value: PreparedModelCatalogAuth) =>
+        Object.fromEntries(
+          Object.entries(value.authStore.profiles).filter(
+            ([, profile]) => normalizeProvider(profile.provider) === provider,
+          ),
+        );
+      const providerCredentials = (
+        credentials: NonNullable<PreparedModelCatalogAuth["credentials"]>,
+      ) =>
+        Object.entries(credentials)
+          .filter(([candidate]) => normalizeProvider(candidate) === provider)
+          .map(([, credential]) => credential);
+      return isDeepStrictEqual(providerProfiles(previousAuth), providerProfiles(auth)) &&
+        isDeepStrictEqual(
+          providerCredentials(previousAuth.credentials),
+          providerCredentials(auth.credentials),
+        )
+        ? [provider]
+        : [];
+    }),
+  );
+  const retain = (
+    current: ModelCatalogSnapshot["entries"],
+    retained: ModelCatalogSnapshot["entries"],
+    key: (entry: ModelCatalogSnapshot["entries"][number]) => string,
+  ) =>
+    dedupeByKey(
+      [
+        ...current,
+        ...retained.filter(
+          (entry) =>
+            !entry.nativeRuntime && retainedProviders.has(normalizeProvider(entry.provider)),
+        ),
+      ],
+      key,
+    ).toSorted(compareModelCatalogEntries);
+  const published: ModelCatalogSnapshot = {
+    ...catalog,
+    entries: retain(catalog.entries, previous?.entries ?? [], modelCatalogEntryKey),
+    routeVariants: retain(catalog.routeVariants, previous?.routeVariants ?? [], (entry) =>
+      JSON.stringify([modelCatalogEntryKey(entry), entry.api, entry.baseUrl, entry.nativeRuntime]),
+    ),
+    authoritative: false,
+  };
+  setPreparedModelFullCatalogAuth(published, auth);
+  return {
+    catalog: published,
+    discoveryOrigins: [
+      ...discoveryOrigins,
+      ...(inventory?.discoveryOrigins ?? []).filter((origin) =>
+        retainedProviders.has(normalizeProvider(origin.provider)),
+      ),
+    ],
+  };
+}
+
 /** Reprojects retained inventory without carrying capabilities from a retired runtime. */
 export function materializePreparedModelCatalog(
   snapshot: ModelCatalogSnapshot,
   runtimeCapabilityModels: readonly PreparedRuntimeCapabilityModel[],
+  configuredRuntimeModels: readonly PreparedConfiguredRuntimeModel[] = [],
 ): ModelCatalogSnapshot {
   // Preserve inventory reads before capability preparation when the snapshot has accessors.
   const materialized = { ...snapshot };
@@ -126,8 +229,16 @@ export function materializePreparedModelCatalog(
     });
   materialized.entries = project(sourceEntries);
   materialized.routeVariants = project(snapshot.routeVariants);
-  if (snapshot.staticEntries) {
-    materialized.staticEntries = project(snapshot.staticEntries);
+  if (snapshot.staticEntries || configuredRuntimeModels.length > 0) {
+    materialized.staticEntries = project(
+      dedupeByKey(
+        [
+          ...configuredRuntimeModels.map(({ model }) => toStaticCatalogEntry(model)),
+          ...(snapshot.staticEntries ?? []),
+        ],
+        modelCatalogEntryKey,
+      ),
+    );
   }
   if (isPreparedModelCatalogFull(snapshot)) {
     markPreparedModelCatalogFull(materialized);

--- a/src/agents/prepared-model-runtime.full-catalog.ts
+++ b/src/agents/prepared-model-runtime.full-catalog.ts
@@ -125,6 +125,10 @@ export function prepareModelCatalogPublication(
       );
       if (
         discoveryOrigins.some((origin) => origin.provider === provider) ||
+        (!previousOrigins?.length &&
+          previous?.providerOutcomes?.some(
+            (candidate) => normalizeProvider(candidate.provider) === provider,
+          )) ||
         !previousAuth ||
         !previousAuth.credentials ||
         !auth.credentials ||
@@ -162,7 +166,7 @@ export function prepareModelCatalogPublication(
   ) =>
     dedupeByKey(
       [
-        ...current,
+        ...current.filter((entry) => !retainedProviders.has(normalizeProvider(entry.provider))),
         ...retained.filter(
           (entry) =>
             !entry.nativeRuntime && retainedProviders.has(normalizeProvider(entry.provider)),

--- a/src/agents/prepared-model-runtime.plugin-generation.ts
+++ b/src/agents/prepared-model-runtime.plugin-generation.ts
@@ -118,6 +118,7 @@ export async function buildPreparedPluginModelCatalog(params: {
   };
   catalogMode: PreparedModelRuntimeCatalogMode;
   modelRegistry: Parameters<typeof buildPreparedModelCatalogSnapshot>[0]["modelRegistry"];
+  providerOutcomes?: Parameters<typeof buildPreparedModelCatalogSnapshot>[0]["providerOutcomes"];
   pluginGeneration: PreparedModelRuntimePluginGeneration;
 }) {
   const { credentials, input } = params.agentFacts;
@@ -129,6 +130,7 @@ export async function buildPreparedPluginModelCatalog(params: {
       config: input.config,
       modelRegistry: params.modelRegistry,
       metadataSnapshot,
+      providerOutcomes: params.providerOutcomes,
       includeProviderPluginAugmentation: params.catalogMode === "live",
       ...(input.env ? { env: input.env } : {}),
       ...(input.readOnly ? { readOnly: true } : {}),

--- a/src/agents/prepared-model-runtime.scoped-catalog.ts
+++ b/src/agents/prepared-model-runtime.scoped-catalog.ts
@@ -49,13 +49,17 @@ async function prepareScopedReadOnlyModelCatalogWithMode(
     false,
     catalogMode === "live" ? { providerDiscoveryProviderIds } : {},
   );
-  const { modelCatalog } = await prepareFullCatalogFacts(
+  const { modelCatalog, configuredRuntimeModels } = await prepareFullCatalogFacts(
     agentFactsForInput,
     pluginGeneration,
     catalogMode,
     catalogSource,
   );
-  return materializePreparedModelCatalog(modelCatalog, agentFactsForInput.runtimeCapabilityModels);
+  return materializePreparedModelCatalog(
+    modelCatalog,
+    agentFactsForInput.runtimeCapabilityModels,
+    configuredRuntimeModels,
+  );
 }
 
 /** Resolves provider-scoped, secret-free auth modes without live model discovery. */

--- a/src/agents/prepared-model-runtime.scoped-refresh.test.ts
+++ b/src/agents/prepared-model-runtime.scoped-refresh.test.ts
@@ -6,11 +6,13 @@ import {
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadPreparedGatewayModelCatalogSnapshot } from "../gateway/server-model-catalog.js";
 import { refreshModelRuntimeAfterHotReload } from "../gateway/server-reload-model-runtime-scope.js";
 import { createPluginManifestRecordFixture } from "../plugins/plugin-metadata.test-support.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -114,7 +116,10 @@ describe("prepared model runtime scoped refresh", () => {
       expect(failed.entries).toMatchObject([learned, sibling]);
       expect(failed.routeVariants).toMatchObject([variant, sibling]);
       expect(failed.authoritative).toBe(false);
-      expect(failed.providerOutcomes).toEqual(snapshots[1].providerOutcomes);
+      expect(failed.providerOutcomes).toEqual([
+        { provider: "provider-a", profileId, status: "unavailable" },
+        { provider: "provider-b", status: "ready" },
+      ]);
       const failedAgain = await owner.loadFullModelCatalog!({ refresh: true });
       expect(failedAgain.entries).toMatchObject([learned, sibling]);
       const recovered = await owner.loadFullModelCatalog!({ refresh: true });
@@ -361,25 +366,26 @@ describe("prepared model runtime scoped refresh", () => {
     mocks.configuredAgentIds = ["pro"];
     const originalIndex = mocks.pluginMetadataSnapshot.index;
     mocks.pluginMetadataSnapshot.index = { ...originalIndex };
+    const configuredProvider: ModelProviderConfig = {
+      baseUrl: "https://original.example.test/v1",
+      models: [
+        {
+          id: "configured",
+          name: "Configured",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 32_000,
+          maxTokens: 4096,
+        },
+      ],
+    };
     const config: OpenClawConfig = {
       agents: { entries: { pro: {} } },
       plugins: { allow: ["demo"], entries: { demo: { enabled: true } } },
       models: {
         providers: {
-          demo: {
-            baseUrl: "https://original.example.test/v1",
-            models: [
-              {
-                id: "configured",
-                name: "Configured",
-                reasoning: false,
-                input: ["text"],
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                contextWindow: 32_000,
-                maxTokens: 4096,
-              },
-            ],
-          },
+          demo: configuredProvider,
         },
       },
     };
@@ -403,8 +409,7 @@ describe("prepared model runtime scoped refresh", () => {
                       change === "endpoint"
                         ? "https://replacement.example.test/v1"
                         : "https://original.example.test/v1",
-                    models:
-                      change === "configured-models" ? [] : config.models!.providers!.demo.models,
+                    models: change === "configured-models" ? [] : configuredProvider.models,
                   },
                 },
               },
@@ -632,8 +637,8 @@ describe("prepared model runtime scoped refresh", () => {
   });
 
   it("recomposes configured models and retires native rows on a compatible reload", async () => {
-    const nativeStarted = Promise.withResolvers<void>();
-    const releaseNative = Promise.withResolvers<void>();
+    const nativeStarted = createDeferredCore();
+    const releaseNative = createDeferredCore();
     let holdNative = false;
     mocks.resolveStaticCatalogModel.mockImplementation(({ provider, modelId }) => ({
       provider,

--- a/src/agents/prepared-model-runtime.scoped-refresh.test.ts
+++ b/src/agents/prepared-model-runtime.scoped-refresh.test.ts
@@ -5,7 +5,7 @@ import {
   getPreparedModelRuntimeMocks,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadPreparedGatewayModelCatalogSnapshot } from "../gateway/server-model-catalog.js";
@@ -70,6 +70,7 @@ describe("prepared model runtime scoped refresh", () => {
       const config: OpenClawConfig = { agents: { entries: { pro: {} } } };
       const learned = { provider: "provider-a", id: "learned", name: "Learned" };
       const variant = { ...learned, baseUrl: "https://catalog.example.test/v1" };
+      const fallback = { provider: "provider-a", id: "advisory", name: "Advisory" };
       const sibling = { provider: "provider-b", id: "new", name: "New" };
       const native = {
         provider: "provider-a",
@@ -79,6 +80,11 @@ describe("prepared model runtime scoped refresh", () => {
       };
       const snapshots: ModelCatalogSnapshot[] = [
         {
+          entries: [fallback],
+          routeVariants: [fallback],
+          providerOutcomes: [{ provider: "provider-a", profileId, status: "unavailable" }],
+        },
+        {
           entries: [native],
           routeVariants: [variant, native],
           providerOutcomes: [
@@ -86,8 +92,8 @@ describe("prepared model runtime scoped refresh", () => {
           ],
         },
         {
-          entries: [sibling],
-          routeVariants: [sibling],
+          entries: [fallback, sibling],
+          routeVariants: [fallback, sibling],
           providerOutcomes: [
             { provider: "provider-a", profileId, status: "unavailable" },
             { provider: "provider-b", status: "ready" },
@@ -105,13 +111,14 @@ describe("prepared model runtime scoped refresh", () => {
           entries: [sibling],
           routeVariants: [sibling],
           providerOutcomes: [
-            { provider: "provider-a", status: "ready" },
+            { provider: "provider-a", profileId: "provider-a:default", status: "ready" },
             { provider: "provider-b", status: "ready" },
           ],
         },
       ];
       const owner = await prepareCatalogOwner(config, snapshots);
-      await owner.loadFullModelCatalog!();
+      expect((await owner.loadFullModelCatalog!()).entries).toMatchObject([fallback]);
+      await owner.loadFullModelCatalog!({ refresh: true });
       const failed = await owner.loadFullModelCatalog!({ refresh: true });
       expect(failed.entries).toMatchObject([learned, sibling]);
       expect(failed.routeVariants).toMatchObject([variant, sibling]);
@@ -126,6 +133,12 @@ describe("prepared model runtime scoped refresh", () => {
       expect(recovered.entries).toMatchObject([sibling]);
       expect(recovered.routeVariants).toMatchObject([sibling]);
       expect(recovered.authoritative).not.toBe(false);
+      mocks.runPreparedModelCatalogWorker.mockResolvedValueOnce(snapshots[2]!);
+      expect(await owner.loadFullModelCatalog!({ refresh: true })).toMatchObject({
+        entries: [sibling],
+        routeVariants: [sibling],
+        authoritative: false,
+      });
     },
   );
 
@@ -637,6 +650,9 @@ describe("prepared model runtime scoped refresh", () => {
   });
 
   it("recomposes configured models and retires native rows on a compatible reload", async () => {
+    const { resolveAgentEffectiveModelPrimary } =
+      await vi.importActual<typeof import("./agent-scope.js")>("./agent-scope.js");
+    mocks.resolveAgentEffectiveModelPrimary.mockImplementation(resolveAgentEffectiveModelPrimary);
     const nativeStarted = createDeferredCore();
     const releaseNative = createDeferredCore();
     let holdNative = false;

--- a/src/agents/prepared-model-runtime.scoped-refresh.test.ts
+++ b/src/agents/prepared-model-runtime.scoped-refresh.test.ts
@@ -9,10 +9,14 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadPreparedGatewayModelCatalogSnapshot } from "../gateway/server-model-catalog.js";
 import { refreshModelRuntimeAfterHotReload } from "../gateway/server-reload-model-runtime-scope.js";
+import { createPluginManifestRecordFixture } from "../plugins/plugin-metadata.test-support.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
+import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
+import { buildConfiguredModelCatalog } from "./model-selection-shared.js";
 import {
   getPreparedModelRuntimeAuthStore,
   setPreparedModelFullCatalogAuth,
@@ -26,11 +30,236 @@ import {
 const mocks = getPreparedModelRuntimeMocks();
 let state: OpenClawTestState;
 
+async function prepareCatalogOwner(
+  config: OpenClawConfig,
+  catalogs: readonly ModelCatalogSnapshot[],
+) {
+  mocks.configuredAgentIds = ["pro"];
+  for (const catalog of catalogs) {
+    mocks.runPreparedModelCatalogWorker.mockResolvedValueOnce(catalog);
+  }
+  await refreshPreparedModelRuntimeSnapshots(config, {
+    gatewayLifecycle: true,
+    catalogMode: "static",
+    allowGatewaySubagentBinding: true,
+  });
+  return getPreparedModelRuntimeSnapshot({
+    config,
+    agentId: "pro",
+    agentDir: state.agentDir("pro"),
+  })!;
+}
+
 describe("prepared model runtime scoped refresh", () => {
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
     resetPreparedModelRuntimeHarness(state);
   });
+
+  it.each([undefined, "provider-a:default"])(
+    "retains failed-provider inventory and variants until authoritative recovery (%s)",
+    async (profileId) => {
+      mocks.preparedAuthStore = {
+        version: 1,
+        profiles: {
+          "provider-a:default": { type: "api_key", provider: "provider-a", key: "fixture-key" },
+        },
+      };
+      const config: OpenClawConfig = { agents: { entries: { pro: {} } } };
+      const learned = { provider: "provider-a", id: "learned", name: "Learned" };
+      const variant = { ...learned, baseUrl: "https://catalog.example.test/v1" };
+      const sibling = { provider: "provider-b", id: "new", name: "New" };
+      const native = {
+        provider: "provider-a",
+        id: "learned",
+        name: "Native",
+        nativeRuntime: "fixture-runtime",
+      };
+      const snapshots: ModelCatalogSnapshot[] = [
+        {
+          entries: [native],
+          routeVariants: [variant, native],
+          providerOutcomes: [
+            { provider: "provider-a", profileId: "provider-a:default", status: "ready" },
+          ],
+        },
+        {
+          entries: [sibling],
+          routeVariants: [sibling],
+          providerOutcomes: [
+            { provider: "provider-a", profileId, status: "unavailable" },
+            { provider: "provider-b", status: "ready" },
+          ],
+        },
+        {
+          entries: [sibling],
+          routeVariants: [sibling],
+          providerOutcomes: [
+            { provider: "provider-a", profileId: "provider-a:default", status: "unavailable" },
+            { provider: "provider-b", status: "ready" },
+          ],
+        },
+        {
+          entries: [sibling],
+          routeVariants: [sibling],
+          providerOutcomes: [
+            { provider: "provider-a", status: "ready" },
+            { provider: "provider-b", status: "ready" },
+          ],
+        },
+      ];
+      const owner = await prepareCatalogOwner(config, snapshots);
+      await owner.loadFullModelCatalog!();
+      const failed = await owner.loadFullModelCatalog!({ refresh: true });
+      expect(failed.entries).toMatchObject([learned, sibling]);
+      expect(failed.routeVariants).toMatchObject([variant, sibling]);
+      expect(failed.authoritative).toBe(false);
+      expect(failed.providerOutcomes).toEqual(snapshots[1].providerOutcomes);
+      const failedAgain = await owner.loadFullModelCatalog!({ refresh: true });
+      expect(failedAgain.entries).toMatchObject([learned, sibling]);
+      const recovered = await owner.loadFullModelCatalog!({ refresh: true });
+      expect(recovered.entries).toMatchObject([sibling]);
+      expect(recovered.routeVariants).toMatchObject([sibling]);
+      expect(recovered.authoritative).not.toBe(false);
+    },
+  );
+
+  it.each(["credential", "selected-profile", "synthetic-credential"] as const)(
+    "does not retain an account inventory after its %s changes",
+    async (change) => {
+      const config: OpenClawConfig = { agents: { entries: { pro: {} } } };
+      const learned = { provider: "demo", id: "learned", name: "Learned" };
+      const profiles = {
+        "demo:first": { type: "api_key" as const, provider: "demo", key: "first-key" },
+        "demo:second": { type: "api_key" as const, provider: "demo", key: "second-key" },
+      };
+      const previous: ModelCatalogSnapshot = {
+        entries: [learned],
+        routeVariants: [learned],
+        providerOutcomes: [
+          {
+            provider: "demo",
+            profileId: change === "synthetic-credential" ? undefined : "demo:first",
+            status: "ready",
+          },
+        ],
+      };
+      const failed: ModelCatalogSnapshot = {
+        entries: [],
+        routeVariants: [],
+        providerOutcomes: [
+          {
+            provider: "demo",
+            profileId:
+              change === "synthetic-credential"
+                ? undefined
+                : change === "credential"
+                  ? "demo:first"
+                  : "demo:second",
+            status: "unavailable",
+          },
+        ],
+      };
+      setPreparedModelFullCatalogAuth(previous, {
+        authStore: { version: 1, profiles: change === "synthetic-credential" ? {} : profiles },
+        authModes: { demo: "api_key" },
+        credentials:
+          change === "synthetic-credential"
+            ? { demo: { type: "api_key", key: "first-synthetic-key" } }
+            : {},
+      });
+      setPreparedModelFullCatalogAuth(failed, {
+        authStore: {
+          version: 1,
+          profiles:
+            change === "synthetic-credential"
+              ? {}
+              : change === "credential"
+                ? {
+                    ...profiles,
+                    "demo:first": { ...profiles["demo:first"], key: "replacement-key" },
+                  }
+                : profiles,
+        },
+        authModes: { demo: "api_key" },
+        credentials:
+          change === "synthetic-credential"
+            ? { demo: { type: "api_key", key: "second-synthetic-key" } }
+            : {},
+      });
+      const owner = await prepareCatalogOwner(config, [previous, failed]);
+      await owner.loadFullModelCatalog!();
+      expect(await owner.loadFullModelCatalog!({ refresh: true })).toMatchObject({
+        entries: [],
+        routeVariants: [],
+        authoritative: false,
+      });
+    },
+  );
+
+  it.each(["alias", "mixed-success"] as const)(
+    "publishes %s inventory without losing ownership",
+    async (scenario) => {
+      const originalManifest = mocks.pluginMetadataSnapshot.manifestRegistry;
+      const originalPlugins = mocks.pluginMetadataSnapshot.plugins;
+      if (scenario === "alias") {
+        mocks.pluginMetadataSnapshot.manifestRegistry = { ...originalManifest };
+        Object.assign(mocks.pluginMetadataSnapshot.manifestRegistry, {
+          plugins: [
+            createPluginManifestRecordFixture({
+              id: "demo",
+              providers: ["demo"],
+              origin: "bundled",
+              modelCatalog: { aliases: { "old-demo": { provider: "demo" } } },
+            }),
+          ],
+        });
+        Object.assign(mocks.pluginMetadataSnapshot, {
+          plugins: mocks.pluginMetadataSnapshot.manifestRegistry.plugins,
+        });
+      }
+      const provider = scenario === "alias" ? "old-demo" : "demo";
+      mocks.preparedAuthStore = {
+        version: 1,
+        profiles: {
+          "demo:first": { type: "api_key", provider, key: "first-fixture-key" },
+          "demo:second": { type: "api_key", provider, key: "second-fixture-key" },
+        },
+      };
+      const previous: ModelCatalogSnapshot = {
+        entries: [{ provider: "demo", id: "old", name: "Old" }],
+        routeVariants: [
+          { provider: "demo", id: "old", name: "Old", baseUrl: "https://demo.example.test/v1" },
+        ],
+        providerOutcomes: [{ provider, profileId: "demo:first", status: "ready" }],
+      };
+      const fresh = { provider: "demo", id: "fresh", name: "Fresh" };
+      const current: ModelCatalogSnapshot = {
+        entries: scenario === "alias" ? [] : [fresh],
+        routeVariants: scenario === "alias" ? [] : [fresh],
+        providerOutcomes: [
+          { provider, profileId: "demo:first", status: "unavailable" },
+          ...(scenario === "mixed-success"
+            ? [{ provider, profileId: "demo:second", status: "ready" as const }]
+            : []),
+        ],
+      };
+      const config: OpenClawConfig = { agents: { entries: { pro: {} } } };
+      try {
+        const owner = await prepareCatalogOwner(config, [previous, current]);
+        await owner.loadFullModelCatalog!();
+        const published = await owner.loadFullModelCatalog!({ refresh: true });
+        expect(published.entries).toMatchObject(scenario === "alias" ? previous.entries : [fresh]);
+        expect(published.routeVariants).toMatchObject(
+          scenario === "alias" ? previous.routeVariants : [fresh],
+        );
+        expect(published.authoritative).toBe(false);
+      } finally {
+        mocks.pluginMetadataSnapshot.manifestRegistry = originalManifest;
+        mocks.pluginMetadataSnapshot.plugins = originalPlugins;
+      }
+    },
+  );
 
   it.each([undefined, new Set(["pro"])])(
     "carries completed discovery across hot reload without rediscovery (scope: %j)",
@@ -52,6 +281,7 @@ describe("prepared model runtime scoped refresh", () => {
       const auth = {
         authModes: { "discovered-provider": "api_key" as const },
         authStore: { version: 1 as const, profiles: {} },
+        credentials: mocks.authStorage.getAll(),
       };
       setPreparedModelFullCatalogAuth(catalog, auth);
       mocks.runPreparedModelCatalogWorker.mockResolvedValueOnce(catalog);
@@ -78,6 +308,9 @@ describe("prepared model runtime scoped refresh", () => {
             defaults: {
               model: alias === "First alias" ? undefined : "discovered-provider/discovered-model",
               models: { "custom/configured": { alias } },
+              modelPolicy: {
+                allow: [alias === "First alias" ? "discovered-provider/*" : "custom/*"],
+              },
             },
           },
         };
@@ -116,6 +349,123 @@ describe("prepared model runtime scoped refresh", () => {
       expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledTimes(2);
     },
   );
+
+  it.each([
+    "endpoint",
+    "plugin",
+    "plugin-disabled",
+    "plugin-allowlist",
+    "configured-models",
+    "prepared-credential",
+  ] as const)("invalidates retained discovery after the %s identity changes", async (change) => {
+    mocks.configuredAgentIds = ["pro"];
+    const originalIndex = mocks.pluginMetadataSnapshot.index;
+    mocks.pluginMetadataSnapshot.index = { ...originalIndex };
+    const config: OpenClawConfig = {
+      agents: { entries: { pro: {} } },
+      plugins: { allow: ["demo"], entries: { demo: { enabled: true } } },
+      models: {
+        providers: {
+          demo: {
+            baseUrl: "https://original.example.test/v1",
+            models: [
+              {
+                id: "configured",
+                name: "Configured",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 32_000,
+                maxTokens: 4096,
+              },
+            ],
+          },
+        },
+      },
+    };
+    mocks.runPreparedModelCatalogWorker.mockResolvedValueOnce({
+      entries: buildConfiguredModelCatalog({ cfg: config }),
+      routeVariants: [],
+    });
+    const options = { gatewayLifecycle: true, catalogMode: "static" as const };
+    const input = { agentId: "pro", agentDir: state.agentDir("pro") };
+    try {
+      await refreshPreparedModelRuntimeSnapshots(config, options);
+      await getPreparedModelRuntimeSnapshot({ ...input, config })!.loadFullModelCatalog!();
+      let nextConfig: OpenClawConfig =
+        change === "endpoint" || change === "configured-models"
+          ? {
+              ...config,
+              models: {
+                providers: {
+                  demo: {
+                    baseUrl:
+                      change === "endpoint"
+                        ? "https://replacement.example.test/v1"
+                        : "https://original.example.test/v1",
+                    models:
+                      change === "configured-models" ? [] : config.models!.providers!.demo.models,
+                  },
+                },
+              },
+            }
+          : config;
+      if (change === "plugin") {
+        Object.assign(mocks.pluginMetadataSnapshot.index, { hostContractVersion: "replacement" });
+      }
+      if (change === "plugin-disabled") {
+        nextConfig = {
+          ...config,
+          plugins: { ...config.plugins, entries: { demo: { enabled: false } } },
+        };
+      }
+      if (change === "plugin-allowlist") {
+        nextConfig = { ...config, plugins: { ...config.plugins, allow: ["other"] } };
+      }
+      if (change === "prepared-credential") {
+        mocks.authStorage.getAll.mockReturnValue({
+          demo: { type: "api_key", key: "replacement-synthetic-credential" },
+        });
+      }
+      await refreshPreparedModelRuntimeSnapshots(nextConfig, options);
+      expect(
+        getPreparedModelRuntimeSnapshot({ ...input, config: nextConfig })!.readFullModelCatalog!(),
+      ).toBeUndefined();
+    } finally {
+      mocks.pluginMetadataSnapshot.index = originalIndex;
+    }
+  });
+
+  it("does not reuse a post-startup account catalog under the startup credentials", async () => {
+    const config: OpenClawConfig = { agents: { entries: { pro: {} } } };
+    const learned = { provider: "demo", id: "private-model", name: "Private model" };
+    const catalog: ModelCatalogSnapshot = {
+      entries: [learned],
+      routeVariants: [learned],
+      providerOutcomes: [{ provider: "demo", status: "ready" }],
+    };
+    setPreparedModelFullCatalogAuth(catalog, {
+      authStore: { version: 1, profiles: {} },
+      authModes: { demo: "api_key" },
+      credentials: { demo: { type: "api_key", key: "post-startup-key" } },
+    });
+    const owner = await prepareCatalogOwner(config, [catalog]);
+    expect((await owner.loadFullModelCatalog!()).entries).toContainEqual(
+      expect.objectContaining(learned),
+    );
+    await refreshModelRuntimeAfterHotReload({
+      config,
+      agentIds: undefined,
+      pluginMetadataSnapshot: undefined,
+    });
+    const reloaded = getPreparedModelRuntimeSnapshot({
+      config,
+      agentId: "pro",
+      agentDir: state.agentDir("pro"),
+    })!;
+    expect(reloaded.readFullModelCatalog!()).toBeUndefined();
+    expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
+  });
 
   it.each([false, true])(
     "retains catalog callbacks across scoped exec reloads (warmed: %s)",
@@ -224,10 +574,11 @@ describe("prepared model runtime scoped refresh", () => {
     setPreparedModelFullCatalogAuth(catalog, {
       authModes: { custom: "api_key" },
       authStore: { version: 1, profiles: {} },
+      credentials: mocks.authStorage.getAll(),
     });
     mocks.runPreparedModelCatalogWorker.mockResolvedValueOnce(catalog);
     const input = { agentId: "pro", agentDir: state.agentDir("pro"), config: {} };
-    for (const runtime of ["openclaw", "fixture-runtime", "openclaw"]) {
+    for (const [index, runtime] of ["openclaw", "fixture-runtime", "openclaw"].entries()) {
       const config: OpenClawConfig = {
         agents: {
           defaults: {
@@ -246,6 +597,20 @@ describe("prepared model runtime scoped refresh", () => {
       if (!snapshot.readFullModelCatalog!()) {
         await snapshot.loadFullModelCatalog!();
       }
+      if (runtime === "fixture-runtime") {
+        const failed: ModelCatalogSnapshot = {
+          entries: [],
+          routeVariants: [],
+          providerOutcomes: [{ provider: "custom", status: "unavailable" }],
+        };
+        setPreparedModelFullCatalogAuth(failed, {
+          authModes: { custom: "api_key" },
+          authStore: { version: 1, profiles: {} },
+          credentials: mocks.authStorage.getAll(),
+        });
+        mocks.runPreparedModelCatalogWorker.mockResolvedValueOnce(failed);
+        await snapshot.loadFullModelCatalog!({ refresh: true });
+      }
       const projected = await loadPreparedGatewayModelCatalogSnapshot({
         agentId: "pro",
         getConfig: () => config,
@@ -262,8 +627,164 @@ describe("prepared model runtime scoped refresh", () => {
       );
       expect(projected.authModes).toEqual({ custom: "api_key" });
       expect(projected.catalogComplete).toBe(true);
-      expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
+      expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledTimes(index === 0 ? 1 : 2);
     }
+  });
+
+  it("recomposes configured models and retires native rows on a compatible reload", async () => {
+    const nativeStarted = Promise.withResolvers<void>();
+    const releaseNative = Promise.withResolvers<void>();
+    let holdNative = false;
+    mocks.resolveStaticCatalogModel.mockImplementation(({ provider, modelId }) => ({
+      provider,
+      id: modelId,
+      name: modelId,
+      api: "openai-responses",
+      baseUrl: "https://configured.example.test/v1",
+      reasoning: false,
+      input: ["text"],
+      contextWindow: 32_000,
+      maxTokens: 4096,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    }));
+    const registry = createEmptyPluginRegistry();
+    registry.agentHarnesses.push({
+      pluginId: "fixture-native",
+      source: "fixture",
+      harness: {
+        id: "fixture-native",
+        label: "Fixture native",
+        supports: () => ({ supported: true }),
+        async runAttempt() {
+          throw new Error("catalog-only fixture");
+        },
+        async loadModelCatalog({ config: currentConfig }) {
+          if (holdNative) {
+            nativeStarted.resolve();
+            await releaseNative.promise;
+          }
+          return [
+            {
+              provider: "demo",
+              id:
+                currentConfig.agents?.defaults?.model === "demo/old-configured"
+                  ? "native-old"
+                  : "native-new",
+              name: "Native",
+              nativeRuntime: "fixture-native",
+            },
+          ];
+        },
+      },
+    });
+    mocks.loadAgentRuntimePluginRegistryHandle.mockReturnValue(registry);
+    const config: OpenClawConfig = {
+      models: {
+        providers: {
+          demo: {
+            baseUrl: "https://configured.example.test/v1",
+            models: [],
+            agentRuntime: { id: "fixture-native" },
+          },
+        },
+      },
+      agents: {
+        entries: { pro: {} },
+        defaults: {
+          model: "demo/old-configured",
+        },
+      },
+    };
+    const learned = { provider: "demo", id: "learned", name: "Learned" };
+    const native = {
+      provider: "demo",
+      id: "native-old",
+      name: "Native",
+      nativeRuntime: "fixture-native",
+    };
+    const owner = await prepareCatalogOwner(config, [
+      {
+        entries: [learned],
+        routeVariants: [learned],
+        staticEntries: [{ provider: "demo", id: "old-configured", name: "Old" }],
+      },
+    ]);
+    const initial = await owner.loadFullModelCatalog!();
+    expect(initial.entries).toContainEqual(expect.objectContaining(native));
+    const nextConfig: OpenClawConfig = {
+      ...config,
+      agents: {
+        entries: { pro: {} },
+        defaults: {
+          model: "demo/new-configured",
+        },
+      },
+    };
+    await refreshModelRuntimeAfterHotReload({
+      config: nextConfig,
+      agentIds: undefined,
+      pluginMetadataSnapshot: undefined,
+    });
+    const nextOwner = getPreparedModelRuntimeSnapshot({
+      config: nextConfig,
+      agentId: "pro",
+      agentDir: state.agentDir("pro"),
+    })!;
+    const next = nextOwner.readFullModelCatalog!()!;
+    expect(next.authoritative).toBe(false);
+    expect(next.entries.some((entry) => entry.nativeRuntime)).toBe(false);
+    expect(next.entries).toContainEqual(expect.objectContaining(learned));
+    expect(next.entries).toContainEqual(
+      expect.objectContaining({ provider: "demo", id: "new-configured" }),
+    );
+    expect(next.staticEntries?.some((entry) => entry.id === "new-configured")).toBe(true);
+    expect(next.entries.some((entry) => entry.id === "old-configured")).toBe(false);
+    holdNative = true;
+    const ordinaryRead = nextOwner.loadFullModelCatalog!();
+    await nativeStarted.promise;
+    const newlyDiscovered = { provider: "demo", id: "new-discovery", name: "New discovery" };
+    mocks.runPreparedModelCatalogWorker.mockResolvedValueOnce({
+      entries: [learned, newlyDiscovered],
+      routeVariants: [learned, newlyDiscovered],
+    });
+    const explicitRefresh = nextOwner.loadFullModelCatalog!({ refresh: true });
+    const concurrentRefresh = nextOwner.loadFullModelCatalog!({ refresh: true });
+    releaseNative.resolve();
+    await ordinaryRead;
+    const refreshed = await explicitRefresh;
+    expect((await concurrentRefresh).entries).toContainEqual(
+      expect.objectContaining(newlyDiscovered),
+    );
+    expect(refreshed.entries).toContainEqual(expect.objectContaining(newlyDiscovered));
+    expect(refreshed.authoritative).not.toBe(false);
+    expect(refreshed.entries).toContainEqual(
+      expect.objectContaining({ id: "native-new", nativeRuntime: "fixture-native" }),
+    );
+    expect(refreshed.entries.some((entry) => entry.id === "native-old")).toBe(false);
+    const retiredConfig: OpenClawConfig = {
+      ...nextConfig,
+      agents: {
+        ...nextConfig.agents,
+        defaults: {
+          ...nextConfig.agents?.defaults,
+          models: { "demo/*": { agentRuntime: { id: "openclaw" } } },
+        },
+      },
+    };
+    mocks.loadAgentRuntimePluginRegistryHandle.mockReturnValue(createEmptyPluginRegistry());
+    await refreshModelRuntimeAfterHotReload({
+      config: retiredConfig,
+      agentIds: undefined,
+      pluginMetadataSnapshot: undefined,
+    });
+    const retired = getPreparedModelRuntimeSnapshot({
+      config: retiredConfig,
+      agentId: "pro",
+      agentDir: state.agentDir("pro"),
+    })!.readFullModelCatalog!()!;
+    expect(retired.entries).toContainEqual(expect.objectContaining(learned));
+    expect(retired.entries.some((entry) => entry.nativeRuntime === "fixture-native")).toBe(false);
+    expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledTimes(2);
   });
 
   it("falls back to full refresh when an out-of-scope owner dependency changes", async () => {

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -131,7 +131,11 @@ vi.mock("../plugins/provider-public-artifacts.js", () => ({
 }));
 
 vi.mock("./prepared-model-catalog-worker.js", () => ({
-  createPreparedModelCatalogWorker: () => ({
+  createPreparedModelCatalogWorker: ({
+    agentFacts,
+  }: Parameters<
+    typeof import("./prepared-model-catalog-worker.js").createPreparedModelCatalogWorker
+  >[0]) => ({
     loadCatalog: async () => {
       const catalog = await mocks.runPreparedModelCatalogWorker();
       // Real worker replies pair every catalog with its observed auth generation.
@@ -139,7 +143,7 @@ vi.mock("./prepared-model-catalog-worker.js", () => ({
         authStore: { version: 1, profiles: {} },
         authModes: {},
       });
-      return catalog;
+      return { modelCatalog: catalog, configuredRuntimeModels: agentFacts.configuredRuntimeModels };
     },
     loadAuth: async () => ({ authStore: { version: 1, profiles: {} }, authModes: {} }),
   }),
@@ -628,13 +632,16 @@ describe("prepared model runtime Gateway catalog mode", () => {
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
     expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(2);
 
-    await expect(snapshot?.loadFullModelCatalog?.()).resolves.toEqual({
-      entries: [],
-      routeVariants: [],
+    const fullCatalog = await snapshot?.loadFullModelCatalog?.();
+    const configuredModel = { provider: "openai", id: "gpt-5.5", contextWindow: 128_000 };
+    expect(fullCatalog).toMatchObject({
+      entries: [configuredModel],
+      routeVariants: [configuredModel],
+      staticEntries: [configuredModel],
     });
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
-    expect(snapshot?.readFullModelCatalog?.()).toEqual({ entries: [], routeVariants: [] });
+    expect(snapshot?.readFullModelCatalog?.()).toBe(fullCatalog);
     expect(
       getAvailablePreparedModelCatalogSnapshot({
         agentId: "default",
@@ -642,7 +649,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
         agentDir: "/tmp/prepared-static-agent",
         workspaceDir: "/tmp/prepared-static-workspace",
       }),
-    ).toEqual({ entries: [], routeVariants: [] });
+    ).toBe(fullCatalog);
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
     expect(catalogPublicationEvents).toEqual(["catalog-published"]);
 
@@ -655,7 +662,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
     );
     expect(catalogPublicationEvents).toEqual(["catalog-published", "catalog-published"]);
     unregisterCatalogPublication();
-    expect(snapshot?.readFullModelCatalog?.()).toEqual({ entries: [], routeVariants: [] });
+    expect(snapshot?.readFullModelCatalog?.()).toEqual(fullCatalog);
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledTimes(3);
     expect(mocks.prepareStaticCatalog).toHaveBeenCalledOnce();
     expect(mocks.discoverModels).toHaveBeenCalledOnce();

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -81,6 +81,9 @@ const preparedModelRuntimeMocks = vi.hoisted(() => ({
     }),
   ),
   runtimeSyntheticAuthProviderRefs: [] as string[],
+  resolveAgentEffectiveModelPrimary: vi.fn<
+    typeof import("./agent-scope.js").resolveAgentEffectiveModelPrimary
+  >(() => undefined),
   resolveAmbientCredentials: vi.fn((..._args: unknown[]) => ({})),
   resolveStaticCatalogModel: vi.fn<StaticCatalogResolver>(() => undefined),
   warn: vi.fn(),
@@ -216,6 +219,7 @@ const agentScopeMocks = vi.hoisted(() => ({
   resolveDefaultAgentId: () => "default",
   resolveAgentConfig: (config: { agents?: { list?: Array<{ id?: string }> } }, agentId: string) =>
     config.agents?.list?.find((entry) => entry.id === agentId),
+  resolveAgentEffectiveModelPrimary: preparedModelRuntimeMocks.resolveAgentEffectiveModelPrimary,
   resolveAgentModelFallbacksOverride: () => undefined,
   resolveEffectiveModelFallbacks: () => undefined,
   resolveModelFallbackAvailability: () => ({
@@ -448,6 +452,9 @@ export function resetPreparedModelRuntimeHarness(state: OpenClawTestState): void
     routeVariants: [],
   });
   preparedModelRuntimeMocks.runtimeSyntheticAuthProviderRefs = [];
+  preparedModelRuntimeMocks.resolveAgentEffectiveModelPrimary
+    .mockReset()
+    .mockReturnValue(undefined);
   preparedModelRuntimeMocks.resolveAmbientCredentials.mockReset().mockReturnValue({});
   preparedModelRuntimeMocks.resolveStaticCatalogModel.mockReset().mockReturnValue(undefined);
   preparedModelRuntimeMocks.createStaticCatalogResolver

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -123,9 +123,13 @@ vi.mock("./prepared-model-catalog-worker.js", () => ({
           getPreparedModelFullCatalogAuth(catalog) ?? {
             authStore: preparedModelRuntimeMocks.preparedAuthStore ?? { version: 1, profiles: {} },
             authModes: {},
+            credentials: preparedModelRuntimeMocks.authStorage.getAll(),
           },
         );
-        return catalog;
+        return {
+          modelCatalog: catalog,
+          configuredRuntimeModels: factoryArgs[0].agentFacts.configuredRuntimeModels,
+        };
       },
       loadAuth: () =>
         Promise.resolve({
@@ -212,7 +216,6 @@ const agentScopeMocks = vi.hoisted(() => ({
   resolveDefaultAgentId: () => "default",
   resolveAgentConfig: (config: { agents?: { list?: Array<{ id?: string }> } }, agentId: string) =>
     config.agents?.list?.find((entry) => entry.id === agentId),
-  resolveAgentEffectiveModelPrimary: () => undefined,
   resolveAgentModelFallbacksOverride: () => undefined,
   resolveEffectiveModelFallbacks: () => undefined,
   resolveModelFallbackAvailability: () => ({

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -151,6 +151,13 @@ export type PreparedModelRuntimeBuildStats = Readonly<{
   fullCatalogConcurrencyLimit: number;
 }>;
 
+export type PreparedModelCatalogInventory = {
+  catalog: ModelCatalogSnapshot;
+  key: string;
+  pluginFingerprint: string;
+  discoveryOrigins: readonly { provider: string; profileId?: string }[];
+};
+
 export type PreparedModelRuntimeOwner = {
   input: PreparedModelRuntimeInput;
   catalogOwner: PublishedModelCatalogOwnerCandidate["catalogOwner"];
@@ -161,7 +168,7 @@ export type PreparedModelRuntimeOwner = {
   needsRefresh: boolean;
   catalogStale: boolean;
   /** Completed discovery facts; runtime capability projection belongs to each generation. */
-  catalogInventory?: { catalog: ModelCatalogSnapshot; key: string };
+  catalogInventory?: PreparedModelCatalogInventory;
   refreshError?: Error;
   snapshot?: PreparedModelRuntimeSnapshot;
   pluginGeneration?: PreparedModelRuntimePluginGeneration;

--- a/src/flows/model-picker.provider-catalog.test.ts
+++ b/src/flows/model-picker.provider-catalog.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPluginManifestRecordFixture,
+  createPluginMetadataSnapshotFixture,
+} from "../plugins/plugin-metadata.test-support.js";
 
 const mocks = vi.hoisted(() => ({
   loadPreparedModelCatalogOwnerSnapshot: vi.fn(),
@@ -12,9 +16,14 @@ vi.mock("../agents/prepared-model-catalog.js", () => ({
   loadPreparedModelCatalogSnapshot: mocks.loadPreparedModelCatalogSnapshot,
 }));
 
-vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
-  resolvePluginMetadataSnapshot: mocks.resolvePluginMetadataSnapshot,
-}));
+vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => {
+  const { rebasePluginMetadataSnapshotManifestRegistry } =
+    await importOriginal<typeof import("../plugins/plugin-metadata-snapshot.js")>();
+  return {
+    rebasePluginMetadataSnapshotManifestRegistry,
+    resolvePluginMetadataSnapshot: mocks.resolvePluginMetadataSnapshot,
+  };
+});
 
 import { loadPreferredProviderPickerCatalog } from "./model-picker.provider-catalog.js";
 
@@ -24,13 +33,16 @@ describe("loadPreferredProviderPickerCatalog", () => {
     mocks.loadPreparedModelCatalogOwnerSnapshot.mockImplementation(() => {
       throw new Error("preferred-provider browsing must not load the full catalog owner");
     });
-    mocks.resolvePluginMetadataSnapshot.mockReturnValue({
-      manifestRegistry: { plugins: [] },
-    });
+    mocks.resolvePluginMetadataSnapshot.mockReturnValue(createPluginMetadataSnapshotFixture());
   });
 
   it("loads only the canonical preferred provider through scoped live discovery", async () => {
     mocks.loadPreparedModelCatalogSnapshot.mockResolvedValue({
+      authoritative: false,
+      providerOutcomes: [
+        { provider: "nvidia", status: "unavailable" },
+        { provider: "openai", status: "ready" },
+      ],
       entries: [
         { provider: "nvidia", id: "nvidia/nemotron", name: "Nemotron" },
         { provider: "openai", id: "gpt-5.4", name: "GPT-5.4" },
@@ -59,6 +71,8 @@ describe("loadPreferredProviderPickerCatalog", () => {
         env: { NVIDIA_API_KEY: "test-nvidia-api-key" },
       }),
     ).resolves.toEqual({
+      authoritative: false,
+      providerOutcomes: [{ provider: "nvidia", status: "unavailable" }],
       entries: [{ provider: "nvidia", id: "nvidia/nemotron", name: "Nemotron" }],
       routeVariants: [
         {
@@ -83,16 +97,18 @@ describe("loadPreferredProviderPickerCatalog", () => {
   });
 
   it("canonicalizes provider aliases before scoped discovery", async () => {
-    mocks.resolvePluginMetadataSnapshot.mockReturnValue({
-      manifestRegistry: {
+    mocks.resolvePluginMetadataSnapshot.mockReturnValue(
+      createPluginMetadataSnapshotFixture({
         plugins: [
-          {
+          createPluginManifestRecordFixture({
             id: "moonshot",
+            providers: ["moonshot"],
+            origin: "bundled",
             modelCatalog: { aliases: { kimi: { provider: "moonshot" } } },
-          },
+          }),
         ],
-      },
-    });
+      }),
+    );
     mocks.loadPreparedModelCatalogSnapshot.mockResolvedValue({
       entries: [{ provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" }],
       routeVariants: [],

--- a/src/flows/model-picker.provider-catalog.ts
+++ b/src/flows/model-picker.provider-catalog.ts
@@ -1,7 +1,7 @@
 // Model picker provider choices projected from the lifecycle-owned catalog.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { resolveDefaultAgentDir } from "../agents/agent-scope.js";
-import { createPreparedModelCatalogProviderNormalizer } from "../agents/model-catalog.js";
+import { createPreparedModelCatalogProviderNormalizer } from "../agents/model-catalog-provider-normalizer.js";
 import type { ModelCatalogSnapshot } from "../agents/model-catalog.types.js";
 import { loadPreparedModelCatalogSnapshot } from "../agents/prepared-model-catalog.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -14,10 +14,14 @@ function filterProviderSnapshot(
   const matchesProvider = (entry: { provider: string }) =>
     normalizeProviderId(entry.provider) === provider;
   return {
+    ...snapshot,
     entries: snapshot.entries.filter(matchesProvider),
     routeVariants: snapshot.routeVariants.filter(matchesProvider),
     ...(snapshot.staticEntries
       ? { staticEntries: snapshot.staticEntries.filter(matchesProvider) }
+      : {}),
+    ...(snapshot.providerOutcomes
+      ? { providerOutcomes: snapshot.providerOutcomes.filter(matchesProvider) }
       : {}),
   };
 }
@@ -40,8 +44,11 @@ export async function loadPreferredProviderPickerCatalog(params: {
     env,
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
   });
-  const providerFilter =
-    createPreparedModelCatalogProviderNormalizer(metadataSnapshot)(requestedProvider);
+  const providerFilter = createPreparedModelCatalogProviderNormalizer(
+    metadataSnapshot,
+    params.cfg,
+    env,
+  )(requestedProvider);
   const snapshot = await loadPreparedModelCatalogSnapshot({
     config: params.cfg,
     agentDir: params.agentDir ?? resolveDefaultAgentDir(params.cfg, params.env),

--- a/src/model-catalog/manifest-planner.ts
+++ b/src/model-catalog/manifest-planner.ts
@@ -269,7 +269,7 @@ function buildOwnedProviderSet(plugin: ManifestModelCatalogPlugin): ReadonlySet<
   );
 }
 
-function buildModelCatalogProviderAliasTargets(
+export function buildModelCatalogProviderAliasTargets(
   plugin: ManifestModelCatalogPlugin,
 ): ReadonlyMap<string, readonly string[]> {
   const ownedProviders = buildOwnedProviderSet(plugin);
@@ -289,13 +289,10 @@ function buildModelCatalogProviderAliasTargets(
 }
 
 function buildModelCatalogProviderRefs(plugin: ManifestModelCatalogPlugin): ReadonlySet<string> {
-  const ownedProviders = buildOwnedProviderSet(plugin);
-  const refs = new Set(ownedProviders);
-  for (const [rawAlias, alias] of Object.entries(plugin.modelCatalog?.aliases ?? {})) {
-    const aliasProvider = normalizeModelCatalogProviderId(rawAlias);
-    const targetProvider = normalizeModelCatalogProviderId(alias.provider);
-    if (aliasProvider && targetProvider && ownedProviders.has(targetProvider)) {
-      refs.add(aliasProvider);
+  const refs = new Set(buildOwnedProviderSet(plugin));
+  for (const aliases of buildModelCatalogProviderAliasTargets(plugin).values()) {
+    for (const alias of aliases) {
+      refs.add(alias);
     }
   }
   return refs;

--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -417,6 +417,7 @@ describe("unit-fast vitest lane", () => {
     for (const file of [
       "src/agents/agent-command.compaction-rotation.test.ts",
       "src/agents/agent-command.embedded-maintenance.test.ts",
+      "src/agents/prepared-model-runtime.scoped-refresh.test.ts",
     ]) {
       expect(isUnitFastTestFile(file), file).toBe(false);
       expect(resolveUnitFastTestIncludePattern(file), file).toBeNull();
@@ -497,7 +498,6 @@ describe("unit-fast vitest lane", () => {
       "src/acp/translator.error-kind.test.ts",
       "src/agents/auth-profiles/oauth-refresh-error.test.ts",
       "src/agents/embedded-agent-runner/model.provider-hooks.timeout.test.ts",
-      "src/agents/prepared-model-runtime.scoped-refresh.test.ts",
       "src/agents/tools/computer-tool.context.test.ts",
       "src/agents/tools/computer-tool.schema.test.ts",
       "src/agents/tools/computer-tool.v2.test.ts",


### PR DESCRIPTION
## What Problem This Solves

A failed catalog refresh could remove learned models, while metadata could refill a successful empty account list. Reloads could also retain obsolete configured or native rows.

## Why This Change Was Made

The catalog owner retains compatible provider inventory with current failure outcomes. Successful responses replace membership, including empty results. Configured/native facts remain tied to the current runtime, and changed credentials, endpoints, or plugins invalidate incompatible inventory.

## User Impact

Outages retain usable learned choices without widening prior account membership. Healthy providers still update, and policy-only reloads apply restrictions without discovery. No configuration or schema change.

## Evidence

Real built Gateway/CLI checks with controlled endpoints covered success, outage, cold fallback, recovery, empty results, policy reload, and account/endpoint/plugin changes in one process. All 51 focused owner tests and 17 Gateway lifecycle cases passed. Provider accounts and external inference were not used.

Related: #136257. AI-assisted.
