### PR TITLE
fix(channels): keep setup choices in the selected workspace

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -142,6 +142,8 @@ One `PluginCache` starts on the first plugin metadata access, including CLI pref
 
 Plugin-aware config validation, startup auto-enable, and Gateway plugin bootstrap consume that snapshot instead of rebuilding manifest/index metadata independently. `PluginLookUpTable` is derived from the same snapshot and adds the startup plugin plan for the current runtime config.
 
+Channel setup catalogs retain the requested workspace and load-path scope, including raw plugin shadows, so trust filtering can select the appropriate installed alternative.
+
 After startup, runtime readers reuse that inventory without filesystem discovery, manifest rereads, or freshness checks. Narrow plugin selections are in-memory views of the same inventory. Changing config, account state, or an agent's run workspace does not invalidate it. Plugin installs, updates, removals, manifest edits, and discovery-root changes become visible to the runtime after a Gateway restart.
 
 Model-id normalization policies are prepared with each snapshot or narrowed view. Model selection, catalogs, and runtime normalization carry that view forward instead of rebuilding policies from its plugin list. An empty view remains authoritative and cannot inherit policies from a broader process snapshot.

--- a/src/plugins/channel-catalog-registry.test.ts
+++ b/src/plugins/channel-catalog-registry.test.ts
@@ -183,7 +183,6 @@ describe("listChannelCatalogEntries", () => {
 
     expect(
       module.listChannelCatalogEntries({
-        installRecords: {},
         discovery: {
           candidates: [createChannelCandidate({ pluginId: "package-plugin" })],
           diagnostics: [],

--- a/src/plugins/channel-catalog-registry.ts
+++ b/src/plugins/channel-catalog-registry.ts
@@ -1,10 +1,14 @@
 // Maintains channel catalog entries advertised by plugins.
 import { normalizeOptionalString as resolveOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
-import { getGatewayPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
+import {
+  getCurrentPluginMetadataSnapshotState,
+  getGatewayPluginMetadataSnapshot,
+} from "./current-plugin-metadata-state.js";
 import { discoverOpenClawPlugins, type PluginDiscoveryResult } from "./discovery.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
 import type { PluginPackageChannel, PluginPackageInstall } from "./manifest.js";
+import { resolvePluginMetadataEnvFingerprint } from "./plugin-metadata-env.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 
 export type PluginChannelCatalogEntry = {
@@ -35,22 +39,19 @@ type ChannelCatalogParams = {
 export function listChannelCatalogEntries(
   params: ChannelCatalogParams = {},
 ): PluginChannelCatalogEntry[] {
-  // Preserve the ledger-read behavior for callers supplying an exact discovery.
-  if (params.discovery) {
-    resolveInstallRecords(params);
+  // The discovery owner retains each scope and its raw shadows. A validated
+  // Gateway-wide manifest union loses both workspace scope and trust alternatives.
+  let discovery = params.discovery;
+  if (!discovery) {
+    const installRecords = resolveInstallRecords(params);
+    discovery = discoverOpenClawPlugins({
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      extraPaths: params.extraPaths,
+      ...(installRecords && Object.keys(installRecords).length > 0 ? { installRecords } : {}),
+    });
   }
-  const snapshot =
-    !params.discovery && !params.installRecords ? getGatewayPluginMetadataSnapshot() : undefined;
-  // Keep bundled owners available to callers that exclude untrusted workspace shadows.
-  const candidates = snapshot
-    ? [
-        ...snapshot.plugins,
-        ...(snapshot.bundledManifestRegistry?.plugins ?? []).filter(
-          (bundled) => snapshot.byPluginId.get(bundled.id)?.rootDir !== bundled.rootDir,
-        ),
-      ]
-    : (params.discovery ?? resolveChannelCatalogDiscovery(params)).candidates;
-  return candidates.flatMap((candidate) => {
+  return discovery.candidates.flatMap((candidate) => {
     if (params.origin && candidate.origin !== params.origin) {
       return [];
     }
@@ -58,7 +59,11 @@ export function listChannelCatalogEntries(
     if (!channel?.id) {
       return [];
     }
-    const pluginId = "id" in candidate ? candidate.id : resolveChannelCatalogPluginId(candidate);
+    const pluginId =
+      resolveOptionalString(candidate.bundledManifest?.id) ??
+      resolveOptionalString(candidate.bundledManifestId) ??
+      resolveOptionalString(candidate.packageManifest?.plugin?.id) ??
+      resolveOptionalString(candidate.idHint);
     if (!pluginId) {
       return [];
     }
@@ -78,32 +83,20 @@ export function listChannelCatalogEntries(
   });
 }
 
-function resolveChannelCatalogDiscovery(params: ChannelCatalogParams) {
-  const installRecords = resolveInstallRecords(params);
-  return discoverOpenClawPlugins({
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-    extraPaths: params.extraPaths,
-    ...(installRecords && Object.keys(installRecords).length > 0 ? { installRecords } : {}),
-  });
-}
-
-function resolveChannelCatalogPluginId(
-  candidate: PluginDiscoveryResult["candidates"][number],
-): string | undefined {
-  return (
-    resolveOptionalString(candidate.bundledManifest?.id) ??
-    resolveOptionalString(candidate.bundledManifestId) ??
-    resolveOptionalString(candidate.packageManifest?.plugin?.id) ??
-    resolveOptionalString(candidate.idHint)
-  );
-}
-
 function resolveInstallRecords(
   params: ChannelCatalogParams,
 ): Record<string, PluginInstallRecord> | undefined {
   if (params.installRecords || params.origin === "bundled") {
     return params.installRecords;
+  }
+  const snapshot = getGatewayPluginMetadataSnapshot();
+  if (
+    snapshot &&
+    getCurrentPluginMetadataSnapshotState().envFingerprint ===
+      resolvePluginMetadataEnvFingerprint(params.env)
+  ) {
+    // Ledger writes prepare the next boot; catalog reads retain this generation's package paths.
+    return snapshot.index.installRecords;
   }
   try {
     return loadInstalledPluginIndexInstallRecordsSync(params.env ? { env: params.env } : {});

--- a/src/plugins/channel-catalog-registry.workspace.test.ts
+++ b/src/plugins/channel-catalog-registry.workspace.test.ts
@@ -100,13 +100,13 @@ it("keeps channel catalog workspace and load-path scopes after Gateway publicati
     scopes.map(({ expected: _expected, ...scope }) =>
       listChannelCatalogEntries({ ...scope, env })
         .map((entry) => entry.pluginId)
-        .sort(),
+        .toSorted(),
     );
   expect(withPluginCache(createPluginCache(), read)).toEqual(
     scopes.map(({ expected }) => expected),
   );
   const snapshot = resolveConfigWidePluginMetadataSnapshot({ config, env });
-  expect(snapshot.plugins.map((plugin) => plugin.id).sort()).toEqual([
+  expect(snapshot.plugins.map((plugin) => plugin.id).toSorted()).toEqual([
     "alpha-channel",
     "beta-channel",
     "extra-channel",

--- a/src/plugins/channel-catalog-registry.workspace.test.ts
+++ b/src/plugins/channel-catalog-registry.workspace.test.ts
@@ -1,0 +1,160 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveConfigWidePluginMetadataSnapshot } from "../config/io.plugin-metadata.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
+import { listChannelCatalogEntries } from "./channel-catalog-registry.js";
+import { setGatewayPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+import { writePersistedInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
+import { createPluginCache, withPluginCache } from "./plugin-cache.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+
+const tempDirs = createTempDirTracker();
+const databasePaths = new Set<string>();
+afterEach(() => {
+  vi.restoreAllMocks();
+  clearPluginMetadataLifecycleCaches();
+  for (const databasePath of databasePaths) {
+    closeOpenClawStateDatabaseByPath(databasePath);
+  }
+  databasePaths.clear();
+  tempDirs.cleanup();
+});
+
+it("keeps the published install generation across ledger writes until restart", () => {
+  const root = tempDirs.make("openclaw-channel-ledger-");
+  const env = { HOME: root, OPENCLAW_STATE_DIR: root, OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" };
+  const initialRoot = path.join(root, "initial");
+  const replacementRoot = path.join(root, "replacement");
+  const config: OpenClawConfig = {};
+  for (const rootDir of [initialRoot, replacementRoot]) {
+    writeChannelPlugin(rootDir, "managed-channel");
+  }
+  const install = (rootDir: string, installEnv = env) => {
+    databasePaths.add(
+      writePersistedInstalledPluginIndexInstallRecordsSync(
+        { "managed-channel": { source: "path", sourcePath: rootDir, installPath: rootDir } },
+        { config, env: installEnv },
+      ),
+    );
+  };
+  install(initialRoot);
+  const snapshot = resolveConfigWidePluginMetadataSnapshot({ config, env });
+  setGatewayPluginMetadataSnapshot(snapshot, { config, env });
+  const read = () => listChannelCatalogEntries({ env }).map((entry) => entry.rootDir);
+  expect(read()).toEqual([initialRoot]);
+
+  install(replacementRoot);
+  expect(read()).toEqual([initialRoot]);
+  const foreign = tempDirs.make("openclaw-channel-foreign-ledger-");
+  const foreignEnv = { ...env, HOME: foreign, OPENCLAW_STATE_DIR: foreign };
+  install(replacementRoot, foreignEnv);
+  expect(listChannelCatalogEntries({ env: foreignEnv }).map((entry) => entry.rootDir)).toEqual([
+    replacementRoot,
+  ]);
+  clearPluginMetadataLifecycleCaches();
+  expect(read()).toEqual([replacementRoot]);
+});
+
+function writeChannelPlugin(rootDir: string, id: string): void {
+  fs.mkdirSync(rootDir, { recursive: true });
+  fs.writeFileSync(path.join(rootDir, "index.js"), "export default { register() {} };\n");
+  fs.writeFileSync(
+    path.join(rootDir, "openclaw.plugin.json"),
+    JSON.stringify({ id, channels: [id], configSchema: { type: "object", properties: {} } }),
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "package.json"),
+    JSON.stringify({
+      name: id,
+      type: "module",
+      openclaw: {
+        extensions: ["./index.js"],
+        channel: { id, name: id, description: `Synthetic ${id} channel` },
+      },
+    }),
+  );
+}
+
+it("keeps channel catalog workspace and load-path scopes after Gateway publication", () => {
+  const root = tempDirs.make("openclaw-channel-catalog-");
+  const env = { HOME: root, OPENCLAW_STATE_DIR: root, OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" };
+  const alpha = path.join(root, "alpha");
+  const beta = path.join(root, "beta");
+  const extra = path.join(root, "extra");
+  writeChannelPlugin(path.join(alpha, ".openclaw/extensions/alpha-channel"), "alpha-channel");
+  writeChannelPlugin(path.join(beta, ".openclaw/extensions/beta-channel"), "beta-channel");
+  writeChannelPlugin(extra, "extra-channel");
+  const config: OpenClawConfig = {
+    agents: { entries: { alpha: { workspace: alpha }, beta: { workspace: beta } } },
+    plugins: { load: { paths: [extra] } },
+  };
+  const scopes = [
+    { workspaceDir: alpha, expected: ["alpha-channel"] },
+    { workspaceDir: beta, expected: ["beta-channel"] },
+    { workspaceDir: alpha, extraPaths: [extra], expected: ["alpha-channel", "extra-channel"] },
+  ];
+  const read = () =>
+    scopes.map(({ expected: _expected, ...scope }) =>
+      listChannelCatalogEntries({ ...scope, env })
+        .map((entry) => entry.pluginId)
+        .sort(),
+    );
+  expect(withPluginCache(createPluginCache(), read)).toEqual(
+    scopes.map(({ expected }) => expected),
+  );
+  const snapshot = resolveConfigWidePluginMetadataSnapshot({ config, env });
+  expect(snapshot.plugins.map((plugin) => plugin.id).sort()).toEqual([
+    "alpha-channel",
+    "beta-channel",
+    "extra-channel",
+  ]);
+  setGatewayPluginMetadataSnapshot(snapshot, { config, env });
+
+  const fileReads = [
+    "existsSync",
+    "statSync",
+    "lstatSync",
+    "realpathSync",
+    "readFileSync",
+    "readdirSync",
+    "openSync",
+    "fstatSync",
+  ] as const;
+  const probes = fileReads.map((method) => vi.spyOn(fs, method));
+  expect(read()).toEqual(scopes.map(({ expected }) => expected));
+  expect(read()).toEqual(scopes.map(({ expected }) => expected));
+  expect(probes.map((probe) => probe.mock.calls.length)).toEqual(fileReads.map(() => 0));
+  vi.restoreAllMocks();
+  writeChannelPlugin(path.join(alpha, ".openclaw/extensions/late-channel"), "late-channel");
+  expect(read()).toEqual(scopes.map(({ expected }) => expected));
+  clearPluginMetadataLifecycleCaches();
+  expect(read()[0]).toEqual(["alpha-channel", "late-channel"]);
+});
+
+it("retains raw workspace shadows for catalog trust filtering after publication", () => {
+  const root = tempDirs.make("openclaw-channel-shadow-");
+  const env = { HOME: root, OPENCLAW_STATE_DIR: root, OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" };
+  const workspaceDir = path.join(root, "workspace");
+  writeChannelPlugin(path.join(root, "extensions/shadow-channel"), "shadow-channel");
+  writeChannelPlugin(
+    path.join(workspaceDir, ".openclaw/extensions/shadow-channel"),
+    "shadow-channel",
+  );
+  const config: OpenClawConfig = { agents: { entries: { alpha: { workspace: workspaceDir } } } };
+  const read = () =>
+    listChannelCatalogEntries({ workspaceDir, env }).map(({ pluginId, origin }) => ({
+      pluginId,
+      origin,
+    }));
+  const expected = [
+    { pluginId: "shadow-channel", origin: "workspace" },
+    { pluginId: "shadow-channel", origin: "global" },
+  ];
+  expect(read()).toEqual(expected);
+  const snapshot = resolveConfigWidePluginMetadataSnapshot({ config, env });
+  setGatewayPluginMetadataSnapshot(snapshot, { config, env });
+  expect(read()).toEqual(expected);
+});


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

Fixes an issue where channel setup offers plugins from another agent's workspace after Gateway startup. The same path can discard raw plugin alternatives needed when setup filters an untrusted workspace shadow.

## Why This Change Was Made

Channel catalogs now use the existing discovery cache for the requested workspace and load paths. The Gateway's combined manifest inventory is no longer substituted for raw candidates. Default install records remain pinned to the published generation in its matching environment, so a ledger update cannot introduce new package paths before restart. Explicit records and independent inspection environments retain their own inputs.

The repair removes an incorrect projection and two one-use wrappers; production code decreases by seven lines. It extracts this behavior from the larger reference work in #130706 using the existing cache owners.

## User Impact

The channel setup picker respects the selected agent workspace and keeps the alternatives needed for trust filtering. Repeated catalog reads reuse prepared filesystem facts, while restart remains the boundary for changes to the running Gateway's install inventory.

## Evidence

- Real isolated Gateway and Control UI: the Alpha owner's picker showed both Alpha and Beta workspace channels before the fix; after the fix it shows Alpha and omits Beta. Synthetic before/after screenshots and recordings are available for attachment.
- Both workspace-scope and raw-shadow regressions failed before the repair. A direct SQLite install-ledger replacement also caught and verified the boot-generation retention boundary.
- 26 focused tests pass on `9187b46e349106488d398ad415b15d5d93e0c3d0`, covering catalog scopes, shadows, retained install records, foreign environments, restart, trusted fallback, and setup discovery.
- Derived and persisted startup probes verify that the first published catalog read reuses filesystem facts; repeated reads remain cached.
- Independent Codex review found no actionable P0–P2 findings after the ledger repair. The test-only lint cleanup also received a clean focused review.
- Full `pnpm build` and the changed-file gate pass on the final committed source. The final packaged Gateway RPC replay again returns Alpha and omits Beta; the isolated Gateway then shuts down cleanly.

Validation commands:

```sh
pnpm build
node scripts/run-vitest.mjs src/plugins/channel-catalog-registry.workspace.test.ts src/plugins/channel-catalog-registry.test.ts src/commands/channel-setup/trusted-catalog.test.ts src/commands/channel-setup/discovery.test.ts
node scripts/check-changed.mjs -- src/plugins/channel-catalog-registry.ts src/plugins/channel-catalog-registry.test.ts src/plugins/channel-catalog-registry.workspace.test.ts docs/plugins/architecture.md
```

![Before: Alpha setup also offers Beta workspace channel](https://github.com/user-attachments/assets/08b8742c-e148-4104-b012-729b7724cbbe)

![After: Alpha setup excludes Beta workspace channel](https://github.com/user-attachments/assets/2e663e3b-1930-4dcf-a704-54cef62f7ad5)

https://github.com/user-attachments/assets/132eb174-cbbe-4502-9cb1-24648e1c3547