### PR TITLE
refactor(agents): simplify failure recovery bookkeeping

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -213,11 +213,8 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
         extensionFactories,
       });
       await resourceLoader.reload();
-      // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
-      // compaction overrides applied in createPreparedEmbeddedAgentSettingsManager — same
-      // rehydration also restores OpenClaw runtime's auto-compaction (openclaw#75799), so re-apply
-      // both guards. effectiveModel.baseUrl matches the surrounding scope so
-      // auth-profile-injected baseUrls reach the endpoint-class detector.
+      // Reloading settings discards prepared compaction overrides and restores
+      // runtime auto-compaction, so reapply both guards after reload.
       applyAgentCompactionSettingsFromConfig({
         settingsManager,
         cfg: params.config,
@@ -456,7 +453,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
           const preMetrics = diagEnabled
             ? summarizeCompactionMessages(session.messages)
             : undefined;
-          if (diagEnabled && preMetrics) {
+          if (preMetrics) {
             log.debug(
               `[compaction-diag] start runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
                 `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
@@ -536,23 +533,18 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
                   if (trigger === "manual") {
                     return activeSession.compact(params.customInstructions);
                   }
-                  return resolveEffectiveCompactionMode(params.config) === "default"
-                    ? activeSession[agentSessionAutomaticCompaction](
-                        params.customInstructions,
-                        requestState,
-                      )
-                    : activeSession[agentSessionAutomaticCompaction](
-                        params.customInstructions,
-                        requestState,
-                        "none",
-                      );
+                  return activeSession[agentSessionAutomaticCompaction](
+                    params.customInstructions,
+                    requestState,
+                    resolveEffectiveCompactionMode(params.config) === "default"
+                      ? undefined
+                      : "none",
+                  );
                 },
                 compactionTimeoutMs,
                 {
                   abortSignal: params.abortSignal,
-                  onCancel: () => {
-                    activeSession.abortCompaction();
-                  },
+                  onCancel: () => activeSession.abortCompaction(),
                 },
               );
             } finally {
@@ -608,7 +600,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
           const postMetrics = diagEnabled
             ? summarizeCompactionMessages(session.messages)
             : undefined;
-          if (diagEnabled && preMetrics && postMetrics) {
+          if (preMetrics && postMetrics) {
             log.debug(
               `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
                 `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
@@ -685,9 +677,6 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             attempted: attemptedThinking,
           });
           if (fallbackThinking) {
-            // Near-term provider fix: when compaction hits a reasoning-mandatory
-            // endpoint with `off`, retry once with `minimal` instead of surfacing
-            // a user-visible failure.
             log.warn(
               `[compaction] request rejected for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
             );

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -1,6 +1,3 @@
-/**
- * Handles assistant-stage failover decisions during embedded-agent attempts.
- */
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { AssistantMessage } from "../../../llm/types.js";
@@ -117,10 +114,21 @@ export async function handleAssistantFailover(params: {
   const externalAbort = terminal.externalAbort || signalOwnedInterruption;
   let overloadProfileRotations = params.overloadProfileRotations;
   let decision = params.initialDecision;
-  const sameModelTransientRetry = (): AssistantFailoverOutcome => ({
+  const logDecision = (
+    action: Parameters<typeof params.logAssistantFailoverDecision>[0],
+    extra?: { status?: number },
+  ) =>
+    params.logAssistantFailoverDecision(action, {
+      ...extra,
+      retryCount: params.getTransientRetryCount(),
+      profileRotationCount: overloadProfileRotations,
+    });
+  const retryOutcome = (
+    retryKind: "profile_rotation" | "same_model_transient",
+  ): AssistantFailoverOutcome => ({
     action: "retry",
     overloadProfileRotations,
-    retryKind: "same_model_transient",
+    retryKind,
     lastRetryFailoverReason: mergeRetryFailoverReason({
       previous: params.previousRetryFailoverReason,
       failoverReason: params.failoverReason,
@@ -141,24 +149,18 @@ export async function handleAssistantFailover(params: {
     !externalAbort &&
     canRetryRateLimit &&
     transientConsultReason &&
-    (decision.action === "rotate_profile" ||
-      decision.action === "fallback_model" ||
-      decision.action === "surface_error") &&
+    decision.action !== "continue_normal" &&
     (await params.maybeRetryTransient({
       reason: transientConsultReason,
       retryAfterMs: resolveRetryAfterMs(params.lastAssistant?.errorMessage),
     }))
   ) {
-    params.logAssistantFailoverDecision("retry_same_model", {
-      retryCount: params.getTransientRetryCount(),
-      profileRotationCount: overloadProfileRotations,
-    });
-    return sameModelTransientRetry();
+    logDecision("retry_same_model");
+    return retryOutcome("same_model_transient");
   }
 
   if (decision.action === "rotate_profile") {
     const failedProfileId = params.lastProfileId;
-    const timeoutFailure = terminal.timedOut;
     const failureReason = params.assistantProfileFailureReason;
     const markFailedProfile = async () => {
       if (!failureReason) {
@@ -186,11 +188,7 @@ export async function handleAssistantFailover(params: {
           `overload profile rotation cap reached for ${sanitizeForLog(params.provider)}/${sanitizeForLog(params.modelId)} after ${overloadProfileRotations} rotations; escalating to model fallback`,
         );
         await markFailedProfile();
-        params.logAssistantFailoverDecision("fallback_model", {
-          status,
-          retryCount: params.getTransientRetryCount(),
-          profileRotationCount: overloadProfileRotations,
-        });
+        logDecision("fallback_model", { status });
         return {
           action: "throw",
           overloadProfileRotations,
@@ -224,7 +222,7 @@ export async function handleAssistantFailover(params: {
     }
 
     const markFailedProfilePromise = markFailedProfile();
-    if (timeoutFailure && !params.isProbeSession && failedProfileId) {
+    if (terminal.timedOut && !params.isProbeSession && failedProfileId) {
       const timeoutLabel = terminal.idleTimedOut ? "idle timeout (model silent)" : "timed out";
       // Only promise a next account when one was actually selected. Credentials
       // that config does not authorize are not rotation targets, so this can end
@@ -243,21 +241,8 @@ export async function handleAssistantFailover(params: {
     if (rotated) {
       // Marking the failed profile is non-blocking after rotation succeeds; the
       // retry can proceed with the next profile while the failure record settles.
-      void markFailedProfilePromise;
-      params.logAssistantFailoverDecision("rotate_profile", {
-        retryCount: params.getTransientRetryCount(),
-        profileRotationCount: overloadProfileRotations,
-      });
-      return {
-        action: "retry",
-        overloadProfileRotations,
-        retryKind: "profile_rotation",
-        lastRetryFailoverReason: mergeRetryFailoverReason({
-          previous: params.previousRetryFailoverReason,
-          failoverReason: params.failoverReason,
-          timedOut: terminal.timedOut,
-        }),
-      };
+      logDecision("rotate_profile");
+      return retryOutcome("profile_rotation");
     }
     await markFailedProfilePromise;
     decision = resolveRunFailoverDecision({
@@ -274,10 +259,7 @@ export async function handleAssistantFailover(params: {
   }
 
   if (decision.action === "surface_error") {
-    params.logAssistantFailoverDecision("surface_error", {
-      retryCount: params.getTransientRetryCount(),
-      profileRotationCount: overloadProfileRotations,
-    });
+    logDecision("surface_error");
   }
   // Surface only current provider failures; aborts, timeout payload synthesis,
   // and stale classified text retain the normal payload path.
@@ -295,11 +277,7 @@ export async function handleAssistantFailover(params: {
       resolveFailoverStatus(reason) ??
       (isTimeoutErrorMessage(message) ? 408 : undefined);
     if (decision.action === "fallback_model") {
-      params.logAssistantFailoverDecision("fallback_model", {
-        status,
-        retryCount: params.getTransientRetryCount(),
-        profileRotationCount: overloadProfileRotations,
-      });
+      logDecision("fallback_model", { status });
     }
     return {
       action: "throw",
@@ -325,10 +303,7 @@ export async function handleAssistantFailover(params: {
     };
   }
 
-  params.logAssistantFailoverDecision("continue_normal", {
-    retryCount: params.getTransientRetryCount(),
-    profileRotationCount: overloadProfileRotations,
-  });
+  logDecision("continue_normal");
   return {
     action: "continue_normal",
     overloadProfileRotations,

--- a/src/agents/embedded-agent-runner/run/assistant-failure.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.ts
@@ -216,7 +216,6 @@ export async function handleEmbeddedAssistantFailure(input: {
     ? ("unknown" as const)
     : assistantFailoverReason;
 
-  const failedProfileId = input.authProfileId;
   const logFailoverDecision = createFailoverDecisionLogger({
     stage: "assistant",
     runId: input.runParams.runId,
@@ -227,7 +226,7 @@ export async function handleEmbeddedAssistantFailure(input: {
     model: input.activeErrorContext.model,
     sourceProvider: failedAssistant?.provider ?? input.provider,
     sourceModel: failedAssistant?.model ?? input.modelId,
-    profileId: failedProfileId,
+    profileId: input.authProfileId,
     fallbackConfigured: input.fallbackConfigured,
     timedOut,
     aborted,
@@ -320,12 +319,10 @@ export async function handleEmbeddedAssistantFailure(input: {
   });
   if (outcome.action === "retry") {
     const retryTraceResult =
-      outcome.retryKind === "same_model_transient"
-        ? effectiveFailoverReason === "timeout"
-          ? "timeout"
-          : "same_model_transient"
-        : effectiveFailoverReason === "timeout"
-          ? "timeout"
+      effectiveFailoverReason === "timeout"
+        ? "timeout"
+        : outcome.retryKind === "same_model_transient"
+          ? "same_model_transient"
           : "rotate_profile";
     input.traceAttempts.push({
       provider: input.activeErrorContext.provider,

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -91,11 +91,7 @@ export async function recoverEmbeddedRunAttempt(input: {
       authRetryPending: boolean;
       codexAppServerRecoveryRetries: number;
       lastRetryFailoverReason: FailoverReason | null;
-      thinkLevel: PreparedRuntime["snapshot"] extends () => infer Snapshot
-        ? Snapshot extends { thinkLevel: infer ThinkLevel }
-          ? ThinkLevel
-          : never
-        : never;
+      thinkLevel: ReturnType<PreparedRuntime["snapshot"]>["thinkLevel"];
     }
   | { action: "proceed" }
 > {

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -65,7 +65,6 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "prompt",
-        aborted: false,
         externalAbort: false,
         fallbackConfigured: true,
         failoverFailure: true,
@@ -82,7 +81,6 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "prompt",
-        aborted: false,
         externalAbort: false,
         fallbackConfigured: true,
         failoverFailure: true,
@@ -99,7 +97,6 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "prompt",
-        aborted: false,
         externalAbort: false,
         fallbackConfigured: true,
         failoverFailure: true,
@@ -118,7 +115,6 @@ describe("resolveRunFailoverDecision", () => {
       expect(
         resolveRunFailoverDecision({
           stage: "prompt",
-          aborted: false,
           externalAbort: false,
           fallbackConfigured: true,
           failoverCode,
@@ -137,7 +133,6 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "prompt",
-        aborted: true,
         externalAbort: false,
         fallbackConfigured: true,
         failoverFailure: true,
@@ -156,7 +151,6 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "prompt",
-        aborted: true,
         externalAbort: false,
         fallbackConfigured: true,
         failoverFailure: true,
@@ -174,7 +168,6 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "prompt",
-        aborted: false,
         externalAbort: false,
         fallbackConfigured: true,
         failoverFailure: true,
@@ -192,7 +185,6 @@ describe("resolveRunFailoverDecision", () => {
       resolveRunFailoverDecision({
         stage: "prompt",
         allowFormatRetry: true,
-        aborted: false,
         externalAbort: false,
         fallbackConfigured: true,
         failoverFailure: true,
@@ -321,7 +313,6 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "prompt",
-        aborted: true,
         externalAbort: true,
         fallbackConfigured: true,
         failoverFailure: true,
@@ -615,7 +606,6 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "prompt",
-        aborted: false,
         externalAbort: false,
         fallbackConfigured: true,
         failoverFailure: true,
@@ -633,7 +623,6 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "prompt",
-        aborted: false,
         externalAbort: false,
         fallbackConfigured: true,
         failoverFailure: true,
@@ -652,7 +641,6 @@ describe("resolveRunFailoverDecision", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "prompt",
-        aborted: false,
         externalAbort: false,
         fallbackConfigured: false,
         failoverFailure: true,

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -1,38 +1,16 @@
-/**
- * Resolves retry, fallback, and terminal failover decisions for a run.
- */
 import type { AgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import type { FailoverReason } from "../../embedded-agent-helpers.js";
 import { isCliTerminalStopCode } from "../../failover-error.js";
 
-/** Failover action selected for one embedded run failure decision point. */
-type ContinueNormalDecision = { action: "continue_normal" };
 type ProfileDecision = {
   action: "rotate_profile" | "surface_error";
   reason: FailoverReason | null;
 };
 type ModelFallbackDecision = { action: "fallback_model"; reason: FailoverReason };
-type ErrorPayloadDecision = { action: "return_error_payload" };
-type RunFailoverDecision =
-  | ContinueNormalDecision
-  | ProfileDecision
-  | ModelFallbackDecision
-  | ErrorPayloadDecision;
-
-export type RetryLimitFailoverDecision = Extract<
-  RunFailoverDecision,
-  { action: "fallback_model" | "return_error_payload" }
->;
-
-type PromptFailoverDecision = Extract<
-  RunFailoverDecision,
-  { action: "rotate_profile" | "fallback_model" | "surface_error" }
->;
-
-export type AssistantFailoverDecision = Extract<
-  RunFailoverDecision,
-  { action: "continue_normal" | "rotate_profile" | "fallback_model" | "surface_error" }
->;
+export type RetryLimitFailoverDecision = ModelFallbackDecision | { action: "return_error_payload" };
+type PromptFailoverDecision = ProfileDecision | ModelFallbackDecision;
+export type AssistantFailoverDecision = PromptFailoverDecision | { action: "continue_normal" };
+type RunFailoverDecision = RetryLimitFailoverDecision | AssistantFailoverDecision;
 
 type RetryLimitDecisionParams = {
   stage: "retry_limit";
@@ -43,7 +21,6 @@ type RetryLimitDecisionParams = {
 type PromptDecisionParams = {
   stage: "prompt";
   allowFormatRetry?: boolean;
-  aborted: boolean;
   externalAbort: boolean;
   fallbackConfigured: boolean;
   failoverCode?: string;
@@ -89,9 +66,6 @@ function isTerminalFormatFailure(params: {
 }
 
 function shouldRotatePrompt(params: PromptDecisionParams): boolean {
-  if (params.timedOutByRunBudget) {
-    return false;
-  }
   return (
     params.failoverFailure &&
     params.failoverReason !== "timeout" &&
@@ -115,9 +89,6 @@ function isConcreteNonTimeoutAssistantFailure(params: AssistantDecisionParams): 
 }
 
 function shouldRotateAssistant(params: AssistantDecisionParams): boolean {
-  if (isTerminalFormatFailure(params)) {
-    return false;
-  }
   if (params.terminal.kind === "timeout" && params.terminal.source === "run_budget") {
     return false;
   }
@@ -179,21 +150,13 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
   }
 
   if (params.stage === "prompt") {
-    if (isCliTerminalStopCode(params.failoverCode)) {
-      // Plugin-harness errors can propagate arbitrary string codes through failover-error normalization;
-      // normal CLI paths are protected in model-fallback-runner instead.
-      return {
-        action: "surface_error",
-        reason: params.failoverReason,
-      };
-    }
-    if (params.externalAbort) {
-      return {
-        action: "surface_error",
-        reason: params.failoverReason,
-      };
-    }
-    if (params.timedOutByRunBudget) {
+    // Plugin harnesses can forward CLI terminal codes through failover normalization;
+    // normal CLI paths enforce the same stop in model-fallback-runner.
+    if (
+      isCliTerminalStopCode(params.failoverCode) ||
+      params.externalAbort ||
+      params.timedOutByRunBudget
+    ) {
       return {
         action: "surface_error",
         reason: params.failoverReason,
@@ -234,14 +197,9 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
   if (
     params.signalOwnedInterruption ||
     ((params.terminal.kind === "aborted" || params.terminal.kind === "timeout") &&
-      params.terminal.source === "external")
+      params.terminal.source === "external") ||
+    isTerminalFormatFailure(params)
   ) {
-    return {
-      action: "surface_error",
-      reason: params.failoverReason,
-    };
-  }
-  if (isTerminalFormatFailure(params)) {
     return {
       action: "surface_error",
       reason: params.failoverReason,

--- a/src/agents/embedded-agent-runner/run/prompt-failure.ts
+++ b/src/agents/embedded-agent-runner/run/prompt-failure.ts
@@ -9,7 +9,6 @@ import type { AuthProfileFailureReason, AuthProfileStore } from "../../auth-prof
 import {
   classifyFailoverReason,
   type FailoverReason,
-  isFailoverErrorMessage,
   parseImageSizeError,
   pickFallbackThinkingLevel,
 } from "../../embedded-agent-helpers.js";
@@ -131,9 +130,7 @@ export async function handleEmbeddedPromptFailure(input: {
         : undefined,
   };
   const normalizedPromptFailover = coerceToFailoverError(input.promptError, failoverContext);
-  const promptErrorDetails = normalizedPromptFailover
-    ? describeFailoverError(normalizedPromptFailover)
-    : describeFailoverError(input.promptError);
+  const promptErrorDetails = describeFailoverError(normalizedPromptFailover ?? input.promptError);
   if (normalizedPromptFailover?.suspend) {
     input.suspendForFailure({
       cfg: input.runParams.config,
@@ -175,9 +172,6 @@ export async function handleEmbeddedPromptFailure(input: {
     transientRateLimit:
       promptFailoverReason === "rate_limit" && isShortWindowRateLimitMessage(errorText),
   });
-  const promptFailoverFailure =
-    promptFailoverReason !== null ||
-    isFailoverErrorMessage(errorText, { provider: input.provider });
   const promptTimeoutFallbackSafe =
     input.promptErrorSource === "prompt" &&
     promptFailoverReason === "timeout" &&
@@ -201,19 +195,20 @@ export async function handleEmbeddedPromptFailure(input: {
     retryCount: input.getTransientRetryCount(),
     attemptCount: input.traceAttempts.length + 1,
   });
-  let failoverDecision = resolveRunFailoverDecision({
-    stage: "prompt",
-    aborted: input.aborted,
-    externalAbort: input.externalAbort,
-    fallbackConfigured: input.fallbackConfigured,
-    failoverCode: promptErrorDetails.code,
-    failoverFailure: promptFailoverFailure,
-    failoverReason: promptFailoverReason,
-    harnessOwnsTransport: input.pluginHarnessOwnsTransport,
-    promptTimeoutFallbackSafe,
-    timedOutByRunBudget: input.timedOutByRunBudget,
-    profileRotated: false,
-  });
+  const resolveDecision = (profileRotated: boolean) =>
+    resolveRunFailoverDecision({
+      stage: "prompt",
+      externalAbort: input.externalAbort,
+      fallbackConfigured: input.fallbackConfigured,
+      failoverCode: promptErrorDetails.code,
+      failoverFailure: promptFailoverReason !== null,
+      failoverReason: promptFailoverReason,
+      harnessOwnsTransport: input.pluginHarnessOwnsTransport,
+      promptTimeoutFallbackSafe,
+      timedOutByRunBudget: input.timedOutByRunBudget,
+      profileRotated,
+    });
+  let failoverDecision = resolveDecision(false);
   const canRetryRateLimit =
     promptFailoverReason !== "rate_limit" || isShortWindowRateLimitMessage(errorText);
   if (
@@ -221,9 +216,6 @@ export async function handleEmbeddedPromptFailure(input: {
     !input.externalAbort &&
     canRetryRateLimit &&
     promptFailoverReason &&
-    (failoverDecision.action === "rotate_profile" ||
-      failoverDecision.action === "fallback_model" ||
-      failoverDecision.action === "surface_error") &&
     (await input.maybeRetryTransient({
       reason: promptFailoverReason,
       retryAfterMs: resolveRetryAfterMs(errorText),
@@ -253,10 +245,12 @@ export async function handleEmbeddedPromptFailure(input: {
     } else {
       rotated = await input.advanceAuthProfile();
     }
+    if (!rotated) {
+      failoverDecision = resolveDecision(true);
+    }
   }
-  if (rotated) {
-    if (promptProfileFailureReason) {
-      void input
+  const markFailedProfilePromise = promptProfileFailureReason
+    ? input
         .maybeMarkAuthProfileFailure({
           profileId: failedProfileId,
           reason: promptProfileFailureReason,
@@ -264,8 +258,10 @@ export async function handleEmbeddedPromptFailure(input: {
         })
         .catch((error: unknown) => {
           log.warn(`prompt profile failure mark failed: ${String(error)}`);
-        });
-    }
+        })
+    : undefined;
+  if (rotated) {
+    // A selected replacement can retry while the failed profile's record settles.
     input.traceAttempts.push({
       provider: input.provider,
       model: input.modelId,
@@ -279,7 +275,7 @@ export async function handleEmbeddedPromptFailure(input: {
     });
     logFailoverDecision("rotate_profile", {
       retryCount: input.getTransientRetryCount(),
-      profileRotationCount: rotated ? 1 : 0,
+      profileRotationCount: 1,
     });
     return {
       action: "retry",
@@ -288,31 +284,8 @@ export async function handleEmbeddedPromptFailure(input: {
       lastRetryFailoverReason,
     };
   }
-  if (failoverDecision.action === "rotate_profile") {
-    failoverDecision = resolveRunFailoverDecision({
-      stage: "prompt",
-      aborted: input.aborted,
-      externalAbort: input.externalAbort,
-      fallbackConfigured: input.fallbackConfigured,
-      failoverCode: promptErrorDetails.code,
-      failoverFailure: promptFailoverFailure,
-      failoverReason: promptFailoverReason,
-      harnessOwnsTransport: input.pluginHarnessOwnsTransport,
-      promptTimeoutFallbackSafe,
-      timedOutByRunBudget: input.timedOutByRunBudget,
-      profileRotated: true,
-    });
-  }
-  if (promptProfileFailureReason) {
-    try {
-      await input.maybeMarkAuthProfileFailure({
-        profileId: failedProfileId,
-        reason: promptProfileFailureReason,
-        modelId: input.modelId,
-      });
-    } catch (error) {
-      log.warn(`prompt profile failure mark failed: ${String(error)}`);
-    }
+  if (markFailedProfilePromise) {
+    await markFailedProfilePromise;
   }
   const fallbackThinking = recordedTerminalStop
     ? undefined
@@ -332,7 +305,7 @@ export async function handleEmbeddedPromptFailure(input: {
     };
   }
   if (failoverDecision.action === "fallback_model") {
-    const fallbackReason = failoverDecision.reason ?? "unknown";
+    const fallbackReason = failoverDecision.reason;
     const status = resolveFailoverStatus(fallbackReason);
     input.traceAttempts.push({
       provider: input.provider,

--- a/src/agents/failover-policy.ts
+++ b/src/agents/failover-policy.ts
@@ -7,16 +7,7 @@ import type { FailoverReason } from "./embedded-agent-helpers.js";
 export function shouldAllowCooldownProbeForReason(
   reason: FailoverReason | null | undefined,
 ): boolean {
-  return (
-    reason === "rate_limit" ||
-    reason === "overloaded" ||
-    reason === "billing" ||
-    reason === "unknown" ||
-    reason === "empty_response" ||
-    reason === "no_error_details" ||
-    reason === "unclassified" ||
-    reason === "timeout"
-  );
+  return reason === "billing" || shouldUseTransientCooldownProbeSlot(reason);
 }
 
 /** Returns true when a transient failure should consume a cooldown probe slot. */


### PR DESCRIPTION
Related: #139295

<details>
<summary>Additional instructions</summary>

Maintainers can edit this branch.

</details>

## What Problem This Solves

Failure recovery carried duplicate error classification, policy argument construction, retry result construction, and logging payloads. That repetition obscured the ordering that keeps retries responsive while failed-account bookkeeping settles. This is the requested deeper cleanup following #139295.

## Why This Change Was Made

Prompt recovery now reuses its classified failure and one policy resolver, and starts failure marking through one path while preserving the existing await/nonblocking split. Assistant recovery shares retry outcomes and counter logging. Decision unions express their actual shapes directly; dead abort plumbing, duplicate conditions, conditional type extraction, and repeated cooldown eligibility are removed. Automatic compaction has one equivalent dispatch path, with its existing default policy and cancellation behavior preserved.

The separate prompt/assistant timeout rules, prepared provider-owner classification distinction, and lifecycle/cleanup guards remain intact. Failure containment stays with its current callers so warning text and timing remain stable.

## User Impact

Behavior-preserving cleanup. Retry budgets, account/model fallback, error messages, logging, failure-marking order, and compaction policies remain unchanged. No config, persistence schema, dependency, protocol, or public API changes.

Production: **121 fewer lines** across seven modules. Tests: 12 unused fixture-argument lines removed; assertions and coverage retained.

## Evidence

- Compared the old and new decision policy using the actual unchanged CLI terminal-stop classifier across **70,754 generated inputs** spanning failure reasons, terminal states, timeout/abort flags, fallback settings, and rotation state: identical results.
- Independent Codex autoreview: no actionable P0–P2 findings.
- Targeted formatting and `git diff --check` pass.
- **359 focused tests passed** across eight files, including all 183 compaction-hook cases and the account-rotation/failure-mark ordering regressions.
- Targeted lint and local architecture guards passed. Local typechecking refuses dependencies linked from another checkout; [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33990562529) passed and supplied the complete type/lint/build/test gates.
