### PR TITLE
perf(replies): skip wrapper projection for ordinary text

### DIFF
--- a/src/infra/outbound/protocol-scaffolding.ts
+++ b/src/infra/outbound/protocol-scaffolding.ts
@@ -67,6 +67,10 @@ function isPromptDataTagLine(line: string, kind: "open" | "close"): boolean {
 }
 
 function unwrapPromptDataWrapperLines(text: string): string {
+  // Both removable tag forms contain "<", including headers followed by an opener.
+  if (!text.includes("<")) {
+    return text;
+  }
   const lines = text.split(/\r?\n/);
   let changed = false;
   const output: string[] = [];


### PR DESCRIPTION
## What Problem This Solves

Resolves avoidable allocation when ordinary multiline replies pass through outbound formatting. Wrapper cleanup previously split and inspected every line even when the text could not contain either removable wrapper tag.

## Why This Change Was Made

The private wrapper helper in `src/infra/outbound/protocol-scaffolding.ts` returns immediately when text contains no ASCII `<`. Both removal branches require that character; trimming and lowercasing cannot introduce it. Inputs that might contain wrappers retain the existing parser, and the enclosing sanitizer still performs runtime-context and bracket-style tool-call cleanup.

Recursive payload normalization and the plain-text renderer share this owner. Delivery preparation still normalizes before/after adapter transformations and retains subsequent hook/adapter checks. Skipping the complete sanitizer was rejected because other cleanup does not require angle brackets. Existing downstream helpers already use necessary-syntax checks; no new parser or sanitizer policy is introduced.

Production: +4/-0 lines (net +4); tests/support: +0/-0. The local guard removes line-count-dependent arrays, strings, and callbacks while retaining one canonical wrapper path.

## User Impact

Ordinary replies require less temporary formatting work. Wrapper removal, fences/examples, runtime notices, payload suppression, callback inputs, and recursive object ownership remain unchanged. Markup-containing inputs still use the existing path.

## Evidence

The actual formatter produces byte-identical scaffolding, plain-text, and Markdown outputs for 1,944 inputs: 5,832 full-output comparisons. Cases include line endings, Unicode whitespace, malformed/nested wrappers, headers, case/spacing near-matches, and fences. Additional controls preserve no-angle tool-call/runtime-notice cleanup, channel payloads, suppression, callbacks, and clean/nested/sibling reference identity. Separate instrumentation over five ordinary-text calls records five line projections before and zero after.

Warmed Node 26.8.1/macOS arm64 A/B/B/A runs use the exact baseline owner snapshot with relative imports rebound to identical dependencies, and the actual candidate module. Means below cover two observations per arm; every full output hash matches.

| Cohort | Calls | Sampled owner bytes before → after | Mean ms before → after |
| --- | ---: | ---: | ---: |
| Ordinary, 1,032 chars | 1,500 | 44,786,788 → 590,692 | 18.226 → 5.455 |
| Ordinary, 67,200 chars | 100 | 193,928,968 → 41,020 | 72.839 → 22.096 |
| Ordinary, 1,056,000 chars | 6 | 180,836,780 → 0 sampled | 83.091 → 22.487 |
| Angle markup, 67,213 chars | 50 | 96,282,536 → 96,558,468 | 41.989 → 39.984 |
| Wrappers, 67,301 chars | 50 | 104,127,336 → 104,376,248 | 37.424 → 34.010 |

Timing runs separately from the 16 KiB cumulative sampler, which includes collected objects. Exported-owner subtree totals avoid misleading private-frame attribution after inlining. Zero samples do not mean zero allocation. Controls retain work and slightly higher sampled allocation; the first angle-control candidate timing was slower. Two observations per arm under shared load do not establish statistical latency, retained heap/RSS, or whole-Gateway savings.

```sh
node scripts/run-vitest.mjs src/infra/outbound/sanitize-text.test.ts src/infra/outbound/payloads.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/outbound/protocol-scaffolding.ts
```

All 160 tests across two files pass before and after; exact-file typed lint, formatting, and `git diff --check` pass. Changed-plan classification passed, but broad local typechecks/build/guards were not executed. Independent P2 review recorded no actionable findings. Required exact-head hosted CI/native landing gates remain mandatory; live/integrated Gateway proof is separate. No implementation-shaped product test was added.
