### PR TITLE
refactor(sqlite): reduce repeated schema validation work

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3055,7 +3055,7 @@ src/infra/install-source-utils.ts	2
 src/infra/json-file.ts	1
 src/infra/json-utf8-bytes.ts	4
 src/infra/kysely-sync-cache-state.ts	1
-src/infra/kysely-sync.ts	9
+src/infra/kysely-sync.ts	7
 src/infra/net/fetch-guard.ts	3
 src/infra/net/form-data.ts	2
 src/infra/net/node-proxy-agent.ts	4

--- a/scripts/check-kysely-guardrails.mts
+++ b/scripts/check-kysely-guardrails.mts
@@ -37,6 +37,7 @@ const compiledRawAllowPaths = new Set(["src/infra/kysely-node-sqlite.ts"]);
 const rawSqliteAllowPathGroups = {
   "native Kysely adapter and sync execution": [
     "src/infra/kysely-node-sqlite.ts",
+    "src/infra/kysely-sync-cache-state.ts",
     "src/infra/kysely-sync.ts",
   ],
   "SQLite database lifecycle, schema, transactions, and pragmas": [

--- a/src/infra/kysely-sync-cache-state.ts
+++ b/src/infra/kysely-sync-cache-state.ts
@@ -1,9 +1,10 @@
-// Shared per-database Kysely cache state, split from kysely-sync so lifecycle
+// Shared per-database SQLite execution and Kysely cache state so lifecycle
 // owners (sqlite-transaction) can clear caches without value-loading kysely.
 // Doctor/setup closures cold-load transaction consumers; keep this file
 // independent of the Kysely value graph.
-import type { DatabaseSync } from "node:sqlite";
+import type { DatabaseSync, SQLInputValue, StatementSync } from "node:sqlite";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { pruneMapToMaxSize } from "./map-size.js";
 
 export const { kyselyByDatabase, queryErrorHandlerByDatabase } = resolveGlobalSingleton(
   Symbol.for("openclaw.sqliteKyselyCacheState"),
@@ -14,7 +15,29 @@ export const { kyselyByDatabase, queryErrorHandlerByDatabase } = resolveGlobalSi
 );
 // Cached statements retain their database. Per-instance lifecycle wrappers clear
 // both caches before close, including callers from transformed SDK module graphs.
-export const statementCacheSymbol = Symbol.for("openclaw.kyselySyncStatementCache");
+const statementCacheSymbol = Symbol.for("openclaw.kyselySyncStatementCache");
+const statementInvalidationSymbol = Symbol.for("openclaw.kyselySyncStatementInvalidation");
+const statementCacheEnabledSymbol = Symbol.for("openclaw.kyselySyncStatementCacheEnabled");
+const authorizerActiveSymbol = Symbol.for("openclaw.kyselySyncAuthorizerActive");
+// Bound SQL plus variable-size bindings to about 2 MiB per enabled database.
+// Process-wide retention scales with open handles; repeated variable SQL can enter.
+const statementCacheCapacity = 32;
+const statementCacheEntryBytes = 64 * 1024;
+
+type SqliteAuthorizer = Parameters<DatabaseSync["setAuthorizer"]>[0];
+
+type StatementCache = {
+  statements: Map<string, StatementSync>;
+  candidates: Set<string>;
+  active: WeakSet<StatementSync>;
+};
+
+type StatementCacheOwner = DatabaseSync & {
+  [statementCacheSymbol]?: StatementCache;
+  [statementInvalidationSymbol]?: true;
+  [statementCacheEnabledSymbol]?: true;
+  [authorizerActiveSymbol]?: boolean;
+};
 
 /** Register the lifecycle owner's handler for synchronous Kysely query failures. */
 export function registerNodeSqliteKyselyQueryErrorHandler(
@@ -31,4 +54,157 @@ export function clearNodeSqliteKyselyCacheForDatabase(db: DatabaseSync): void {
   delete (db as DatabaseSync & { [statementCacheSymbol]?: unknown })[statementCacheSymbol];
   kyselyByDatabase.delete(db);
   queryErrorHandlerByDatabase.delete(db);
+}
+
+export function installStatementInvalidation(owner: StatementCacheOwner): void {
+  if (owner[statementInvalidationSymbol]) {
+    return;
+  }
+  if (typeof owner.setAuthorizer === "function") {
+    const setAuthorizer = owner.setAuthorizer.bind(owner);
+    Object.defineProperty(owner, "setAuthorizer", {
+      configurable: true,
+      writable: true,
+      value(this: StatementCacheOwner, callback: SqliteAuthorizer): void {
+        setAuthorizer(callback);
+        this[authorizerActiveSymbol] = callback !== null;
+        // Authorization is decided while compiling SQL. Drop all statements
+        // after every successful transition, including removing an authorizer.
+        delete this[statementCacheSymbol];
+      },
+    });
+  }
+  if (typeof owner.deserialize === "function") {
+    const deserialize = owner.deserialize.bind(owner);
+    Object.defineProperty(owner, "deserialize", {
+      configurable: true,
+      writable: true,
+      value(this: StatementCacheOwner, ...args: Parameters<DatabaseSync["deserialize"]>): void {
+        try {
+          deserialize(...args);
+        } finally {
+          // Node finalizes all statements before attempting deserialization,
+          // including failed attempts, so no cached object remains usable.
+          delete this[statementCacheSymbol];
+        }
+      },
+    });
+  }
+  if (typeof owner.close === "function") {
+    const close = owner.close.bind(owner);
+    Object.defineProperty(owner, "close", {
+      configurable: true,
+      writable: true,
+      value(this: StatementCacheOwner): void {
+        clearNodeSqliteKyselyCacheForDatabase(this);
+        return close();
+      },
+    });
+  }
+  if (typeof owner[Symbol.dispose] === "function") {
+    const dispose = owner[Symbol.dispose].bind(owner);
+    Object.defineProperty(owner, Symbol.dispose, {
+      configurable: true,
+      writable: true,
+      value(this: StatementCacheOwner): void {
+        clearNodeSqliteKyselyCacheForDatabase(this);
+        return dispose();
+      },
+    });
+  }
+  Object.defineProperty(owner, statementInvalidationSymbol, {
+    configurable: true,
+    value: true,
+  });
+}
+
+/**
+ * Enable bounded statement caching for a lifecycle-owned database that has not
+ * installed an authorizer before this call.
+ */
+export function enableNodeSqliteKyselyStatementCache(db: DatabaseSync): void {
+  const owner: StatementCacheOwner = db;
+  installStatementInvalidation(owner);
+  owner[statementCacheEnabledSymbol] = true;
+}
+
+function queryFitsStatementCache(sql: string, parameters: readonly SQLInputValue[]): boolean {
+  let bytes = Buffer.byteLength(sql);
+  if (bytes > statementCacheEntryBytes) {
+    return false;
+  }
+  for (const parameter of parameters) {
+    if (typeof parameter === "string") {
+      bytes += Buffer.byteLength(parameter);
+    } else if (ArrayBuffer.isView(parameter)) {
+      bytes += parameter.byteLength;
+    }
+    if (bytes > statementCacheEntryBytes) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// The callback must consume the statement synchronously; active-use protection
+// ends when it returns. Only the existing database owner enables retention.
+export function executeWithCachedStatement<Result>(
+  db: DatabaseSync,
+  sql: string,
+  parameters: readonly SQLInputValue[],
+  execute: (statement: StatementSync) => Result,
+): Result {
+  const owner: StatementCacheOwner = db;
+  if (
+    !owner[statementCacheEnabledSymbol] ||
+    owner[authorizerActiveSymbol] ||
+    !queryFitsStatementCache(sql, parameters)
+  ) {
+    return execute(db.prepare(sql));
+  }
+  let cache = owner[statementCacheSymbol];
+  if (!cache) {
+    cache = {
+      statements: new Map(),
+      candidates: new Set(),
+      active: new WeakSet(),
+    };
+    Object.defineProperty(owner, statementCacheSymbol, {
+      configurable: true,
+      value: cache,
+    });
+  }
+
+  const cached = cache.statements.get(sql);
+  let statement: StatementSync;
+  if (cached && !cache.active.has(cached)) {
+    cache.statements.delete(sql);
+    cache.statements.set(sql, cached);
+    statement = cached;
+  } else {
+    // A user-defined SQLite callback can re-enter this helper synchronously.
+    // Prepare a temporary statement rather than reset the active outer query.
+    statement = db.prepare(sql);
+    if (!cached && cache.candidates.delete(sql)) {
+      cache.statements.set(sql, statement);
+      pruneMapToMaxSize(cache.statements, statementCacheCapacity);
+    } else if (!cached) {
+      // Admit only on second use so variable placeholder counts cannot fill
+      // the native statement cache with one-shot SQL strings.
+      cache.candidates.add(sql);
+      if (cache.candidates.size > statementCacheCapacity) {
+        const oldestCandidate = cache.candidates.values().next().value;
+        if (oldestCandidate !== undefined) {
+          cache.candidates.delete(oldestCandidate);
+        }
+      }
+    }
+  }
+
+  cache.active.add(statement);
+  try {
+    return execute(statement);
+  } finally {
+    cache.active.delete(statement);
+  }
 }

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -1,5 +1,5 @@
 // Adapts node:sqlite sync database calls for Kysely-style query execution.
-import type { DatabaseSync, SQLInputValue, StatementSync } from "node:sqlite";
+import type { DatabaseSync, SQLInputValue } from "node:sqlite";
 import { toUSVString } from "node:util";
 import type { Compilable, CompiledQuery, Kysely, QueryResult, RawBuilder } from "kysely";
 import {
@@ -10,39 +10,19 @@ import {
   SqliteDialect,
 } from "kysely";
 import {
-  clearNodeSqliteKyselyCacheForDatabase,
+  executeWithCachedStatement,
+  installStatementInvalidation,
   kyselyByDatabase,
   queryErrorHandlerByDatabase,
-  statementCacheSymbol,
 } from "./kysely-sync-cache-state.js";
-import { pruneMapToMaxSize } from "./map-size.js";
 
 // Sync query helpers execute compiled Kysely SQL against node:sqlite without
 // going through Kysely's async driver path.
 
-export { clearNodeSqliteKyselyCacheForDatabase } from "./kysely-sync-cache-state.js";
-const statementInvalidationSymbol = Symbol.for("openclaw.kyselySyncStatementInvalidation");
-const statementCacheEnabledSymbol = Symbol.for("openclaw.kyselySyncStatementCacheEnabled");
-const authorizerActiveSymbol = Symbol.for("openclaw.kyselySyncAuthorizerActive");
-// Bound SQL plus variable-size bindings to about 2 MiB per enabled database.
-// Process-wide retention scales with open handles; repeated variable SQL can enter.
-const statementCacheCapacity = 32;
-const statementCacheEntryBytes = 64 * 1024;
-
-type SqliteAuthorizer = Parameters<DatabaseSync["setAuthorizer"]>[0];
-
-type StatementCache = {
-  statements: Map<string, StatementSync>;
-  candidates: Set<string>;
-  active: WeakSet<StatementSync>;
-};
-
-type StatementCacheOwner = DatabaseSync & {
-  [statementCacheSymbol]?: StatementCache;
-  [statementInvalidationSymbol]?: true;
-  [statementCacheEnabledSymbol]?: true;
-  [authorizerActiveSymbol]?: boolean;
-};
+export {
+  clearNodeSqliteKyselyCacheForDatabase,
+  enableNodeSqliteKyselyStatementCache,
+} from "./kysely-sync-cache-state.js";
 
 const compileOnlySqliteDialect = new SqliteDialect({
   // The lazy database factory leaves compilation usable while direct execution fails fast.
@@ -84,158 +64,6 @@ function reportNodeSqliteKyselyQueryError(db: DatabaseSync, error: unknown): voi
   }
 }
 
-function installStatementInvalidation(owner: StatementCacheOwner): void {
-  if (owner[statementInvalidationSymbol]) {
-    return;
-  }
-  if (typeof owner.setAuthorizer === "function") {
-    const setAuthorizer = owner.setAuthorizer.bind(owner);
-    Object.defineProperty(owner, "setAuthorizer", {
-      configurable: true,
-      writable: true,
-      value(this: StatementCacheOwner, callback: SqliteAuthorizer): void {
-        setAuthorizer(callback);
-        this[authorizerActiveSymbol] = callback !== null;
-        // Authorization is decided while compiling SQL. Drop all statements
-        // after every successful transition, including removing an authorizer.
-        delete this[statementCacheSymbol];
-      },
-    });
-  }
-  if (typeof owner.deserialize === "function") {
-    const deserialize = owner.deserialize.bind(owner);
-    Object.defineProperty(owner, "deserialize", {
-      configurable: true,
-      writable: true,
-      value(this: StatementCacheOwner, ...args: Parameters<DatabaseSync["deserialize"]>): void {
-        try {
-          deserialize(...args);
-        } finally {
-          // Node finalizes all statements before attempting deserialization,
-          // including failed attempts, so no cached object remains usable.
-          delete this[statementCacheSymbol];
-        }
-      },
-    });
-  }
-  if (typeof owner.close === "function") {
-    const close = owner.close.bind(owner);
-    Object.defineProperty(owner, "close", {
-      configurable: true,
-      writable: true,
-      value(this: StatementCacheOwner): void {
-        clearNodeSqliteKyselyCacheForDatabase(this);
-        return close();
-      },
-    });
-  }
-  if (typeof owner[Symbol.dispose] === "function") {
-    const dispose = owner[Symbol.dispose].bind(owner);
-    Object.defineProperty(owner, Symbol.dispose, {
-      configurable: true,
-      writable: true,
-      value(this: StatementCacheOwner): void {
-        clearNodeSqliteKyselyCacheForDatabase(this);
-        return dispose();
-      },
-    });
-  }
-  Object.defineProperty(owner, statementInvalidationSymbol, {
-    configurable: true,
-    value: true,
-  });
-}
-
-/**
- * Enable bounded statement caching for a lifecycle-owned database that has not
- * installed an authorizer before this call.
- */
-export function enableNodeSqliteKyselyStatementCache(db: DatabaseSync): void {
-  const owner = db as StatementCacheOwner;
-  installStatementInvalidation(owner);
-  owner[statementCacheEnabledSymbol] = true;
-}
-
-function queryFitsStatementCache(sql: string, parameters: readonly SQLInputValue[]): boolean {
-  let bytes = Buffer.byteLength(sql);
-  if (bytes > statementCacheEntryBytes) {
-    return false;
-  }
-  for (const parameter of parameters) {
-    if (typeof parameter === "string") {
-      bytes += Buffer.byteLength(parameter);
-    } else if (ArrayBuffer.isView(parameter)) {
-      bytes += parameter.byteLength;
-    }
-    if (bytes > statementCacheEntryBytes) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function executeWithCachedStatement<Result>(
-  db: DatabaseSync,
-  sql: string,
-  parameters: readonly SQLInputValue[],
-  execute: (statement: StatementSync) => Result,
-): Result {
-  const owner = db as StatementCacheOwner;
-  installStatementInvalidation(owner);
-  if (
-    !owner[statementCacheEnabledSymbol] ||
-    owner[authorizerActiveSymbol] ||
-    !queryFitsStatementCache(sql, parameters)
-  ) {
-    return execute(db.prepare(sql));
-  }
-  let cache = owner[statementCacheSymbol];
-  if (!cache) {
-    cache = {
-      statements: new Map(),
-      candidates: new Set(),
-      active: new WeakSet(),
-    };
-    Object.defineProperty(owner, statementCacheSymbol, {
-      configurable: true,
-      value: cache,
-    });
-  }
-
-  const cached = cache.statements.get(sql);
-  let statement: StatementSync;
-  if (cached && !cache.active.has(cached)) {
-    cache.statements.delete(sql);
-    cache.statements.set(sql, cached);
-    statement = cached;
-  } else {
-    // A user-defined SQLite callback can re-enter this helper synchronously.
-    // Prepare a temporary statement rather than reset the active outer query.
-    statement = db.prepare(sql);
-    if (!cached && cache.candidates.delete(sql)) {
-      cache.statements.set(sql, statement);
-      pruneMapToMaxSize(cache.statements, statementCacheCapacity);
-    } else if (!cached) {
-      // Admit only on second use so variable placeholder counts cannot fill
-      // the native statement cache with one-shot SQL strings.
-      cache.candidates.add(sql);
-      if (cache.candidates.size > statementCacheCapacity) {
-        const oldestCandidate = cache.candidates.values().next().value;
-        if (oldestCandidate !== undefined) {
-          cache.candidates.delete(oldestCandidate);
-        }
-      }
-    }
-  }
-
-  cache.active.add(statement);
-  try {
-    return execute(statement);
-  } finally {
-    cache.active.delete(statement);
-  }
-}
-
 /** Execute a compiled Kysely query synchronously against node:sqlite. */
 function executeCompiledSqliteQuerySync<Row>(
   db: DatabaseSync,
@@ -243,7 +71,9 @@ function executeCompiledSqliteQuerySync<Row>(
 ): QueryResult<Row> {
   const parameters = compiledQuery.parameters as SQLInputValue[];
   try {
-    return executeWithCachedStatement(db, compiledQuery.sql, parameters, (statement) => {
+    const sql = compiledQuery.sql;
+    installStatementInvalidation(db);
+    return executeWithCachedStatement(db, sql, parameters, (statement) => {
       // SELECT already guarantees a reader; avoid allocating native column metadata
       // just to classify it. Raw SQL and other roots still need native classification.
       if (SelectQueryNode.is(compiledQuery.query) || statement.columns().length > 0) {

--- a/src/infra/sqlite-schema-contract.test.ts
+++ b/src/infra/sqlite-schema-contract.test.ts
@@ -1,6 +1,16 @@
-import { DatabaseSync } from "node:sqlite";
+import { channel } from "node:diagnostics_channel";
+import { constants, DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
-import { assertSqliteSchemaContains, collectSqliteSchemaIssues } from "./sqlite-schema-contract.js";
+import { enableNodeSqliteKyselyStatementCache } from "./kysely-sync.js";
+import {
+  assertSqliteSchemaContains,
+  collectSqliteSchemaIssues,
+  createSqliteTableContractReader,
+} from "./sqlite-schema-contract.js";
+
+const [nodeMajor = 0, nodeMinor = 0] = process.versions.node.split(".").map(Number);
+// Node added the public SQLite query diagnostic event in 26.8.0.
+const supportsQueryDiagnostics = nodeMajor > 26 || (nodeMajor === 26 && nodeMinor >= 8);
 
 const CANONICAL_SCHEMA = `
   CREATE TABLE parents (
@@ -41,7 +51,16 @@ const CANONICAL_SCHEMA = `
   END;
 `;
 
-describe("assertSqliteSchemaContains", () => {
+describe.each([false, true])("assertSqliteSchemaContains (statement cache: %s)", (cacheEnabled) => {
+  function createDatabase(schema: string): DatabaseSync {
+    const database = new DatabaseSync(":memory:");
+    if (cacheEnabled) {
+      enableNodeSqliteKyselyStatementCache(database);
+    }
+    database.exec(schema);
+    return database;
+  }
+
   it("accepts the canonical schema plus unrelated objects", () => {
     const database = createDatabase(CANONICAL_SCHEMA);
     try {
@@ -464,13 +483,91 @@ describe("assertSqliteSchemaContains", () => {
       database.close();
     }
   });
+  it.skipIf(typeof DatabaseSync.prototype.setAuthorizer !== "function")(
+    "consults a dynamic authorizer after repeated absent-table reads",
+    () => {
+      const database = createDatabase("");
+      let allow = true;
+      try {
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+          expect(createSqliteTableContractReader(database)("missing_table")).toBeUndefined();
+        }
+        database.setAuthorizer(() => (allow ? constants.SQLITE_OK : constants.SQLITE_DENY));
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+          expect(createSqliteTableContractReader(database)("missing_table")).toBeUndefined();
+        }
+        allow = false;
+        expect(() => createSqliteTableContractReader(database)("missing_table")).toThrow(
+          /not authorized/iu,
+        );
+        allow = true;
+        expect(createSqliteTableContractReader(database)("missing_table")).toBeUndefined();
+      } finally {
+        database.setAuthorizer(null);
+        database.close();
+      }
+    },
+  );
+
+  it.skipIf(!supportsQueryDiagnostics)(
+    "keeps table reads independent during same-query diagnostic reentry",
+    () => {
+      const database = createDatabase(CANONICAL_SCHEMA);
+      const queryChannel = channel("sqlite.db.query");
+      const readTable = createSqliteTableContractReader(database);
+      let reentered = false;
+      const nestedResults: Array<ReturnType<typeof readTable>> = [];
+      let nestedError: unknown;
+      const onQuery = (message: unknown) => {
+        const event = message as { database?: DatabaseSync };
+        if (reentered || event.database !== database) {
+          return;
+        }
+        reentered = true;
+        // Subscriber errors become process errors; inspect the nested outcome after delivery.
+        try {
+          nestedResults.push(readTable("missing_table"));
+        } catch (error) {
+          nestedError = error;
+        }
+      };
+      try {
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+          expect(collectSqliteSchemaIssues(database, CANONICAL_SCHEMA)).toEqual([]);
+        }
+        queryChannel.subscribe(onQuery);
+        expect(collectSqliteSchemaIssues(database, CANONICAL_SCHEMA, {}, readTable)).toEqual([]);
+        expect(reentered).toBe(true);
+        expect(nestedError).toBeUndefined();
+        expect(nestedResults).toEqual([undefined]);
+      } finally {
+        queryChannel.unsubscribe(onQuery);
+        database.close();
+      }
+    },
+  );
 });
 
-function createDatabase(schema: string): DatabaseSync {
+it("reads schema from an unenabled nonextensible database handle", () => {
   const database = new DatabaseSync(":memory:");
-  database.exec(schema);
-  return database;
-}
+  try {
+    database.exec(CANONICAL_SCHEMA);
+    Object.preventExtensions(database);
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      expect(collectSqliteSchemaIssues(database, CANONICAL_SCHEMA)).toEqual([]);
+    }
+    database.exec("DROP INDEX idx_children_parent;");
+    expect(collectSqliteSchemaIssues(database, CANONICAL_SCHEMA)).toEqual([
+      {
+        code: "missing-or-drifted-index",
+        objectName: "idx_children_parent",
+        message: "missing or drifted index idx_children_parent",
+      },
+    ]);
+  } finally {
+    database.close();
+  }
+});
 
 function schemaWithFutureColumn(declaration: string): string {
   return CANONICAL_SCHEMA.replace(

--- a/src/infra/sqlite-schema-contract.ts
+++ b/src/infra/sqlite-schema-contract.ts
@@ -1,4 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
+import { executeWithCachedStatement } from "./kysely-sync-cache-state.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import {
   createSqliteSchemaIssue,
@@ -422,9 +423,12 @@ function collectSqliteTableContract(
   database: DatabaseSync,
   tableName: string,
 ): SqliteTableContract | undefined {
-  const table = database
-    .prepare("SELECT name, sql FROM sqlite_schema WHERE type = 'table' AND name = ?")
-    .get(tableName) as SqliteSchemaRow | undefined;
+  const table = executeWithCachedStatement(
+    database,
+    "SELECT name, sql FROM sqlite_schema WHERE type = 'table' AND name = ?",
+    [tableName],
+    (statement) => statement.get(tableName),
+  ) as SqliteSchemaRow | undefined;
   if (!table) {
     return undefined;
   }
@@ -442,16 +446,17 @@ function collectSqliteTableContract(
     .map((index) => collectSqliteIndexContract(database, index))
     .toSorted(compareJson);
   const triggers = (
-    database
-      .prepare(
-        `
+    executeWithCachedStatement(
+      database,
+      `
           SELECT name, sql
           FROM sqlite_schema
           WHERE type = 'trigger' AND tbl_name = ?
           ORDER BY name
         `,
-      )
-      .all(tableName) as SqliteSchemaRow[]
+      [tableName],
+      (statement) => statement.all(tableName),
+    ) as SqliteSchemaRow[]
   ).map((trigger) => ({
     name: trigger.name,
     sql: normalizeSchemaSql(trigger.sql),
@@ -579,9 +584,12 @@ function collectSqliteIndexContract(
   database: DatabaseSync,
   index: SqliteIndexListRow,
 ): SqliteIndexContract {
-  const row = database
-    .prepare("SELECT sql FROM sqlite_schema WHERE type = 'index' AND name = ?")
-    .get(index.name) as { sql?: unknown } | undefined;
+  const row = executeWithCachedStatement(
+    database,
+    "SELECT sql FROM sqlite_schema WHERE type = 'index' AND name = ?",
+    [index.name],
+    (statement) => statement.get(index.name),
+  ) as { sql?: unknown } | undefined;
   const terms = (
     database
       .prepare(`PRAGMA index_xinfo(${quoteSqliteIdentifier(index.name)})`)


### PR DESCRIPTION
## What Problem This Solves

Repeated schema validation adds avoidable overhead to state-database operations that already hold an open connection.

## Why This Change Was Made

Reuse the existing per-database statement cache for three fixed schema reads, with its implementation in the shared SQLite execution owner. SQL, bindings, validation results, cache limits/admission, active-statement isolation, authorizer/deserialization invalidation, and close behavior remain unchanged.

Production is **+14 lines** (208 added/194 removed, largely relocation); the growth connects schema reads to the existing synchronous statement-lifetime boundary. Tests are **+97**, the guard registry **+1**, and the assertion baseline records two removed assertions. No second cache is introduced.

## User Impact

Less work for repeated schema checks on cache-enabled handles. There are no schema/version, persisted-data, configuration, or public API changes. Cache-disabled reads preserve their behavior. No Gateway-turn or universal tail/memory improvement is claimed.

## Evidence

**Current schema-v16 composition, base `5702b801`:** normal frozen install; all six owner/sibling test files passed **370 cases plus one unchanged Linux-only skip**; all **34 normal changed-gate stages** passed; one mapped normal build passed. The actual emitted owner passed fresh-open/reopen schema-v16 metadata checks, complete schema validation, read-only preflight and cleanup. Preflight preserved the closed source family's bytes/metadata and removed its snapshots; all native/adapter processes closed. Subsequent normal reopen changed ctime only, with bytes/mtime unchanged. Independent P0–P2 review completed all 11 partitions with no actionable findings.

**Historical performance cohort, schema v15 at `db2348`:** fixed B0/C0/C1/B1 order, 256 batch means, with complete results checked throughout. These measurements have not been relabeled as v16 results or rerun for a better outcome. Percentages compare candidate with baseline; negative means less time.

| Complete operation | Forward median | Reverse median |
| --- | ---: | ---: |
| R01: cache-disabled read-only control | −1.79% | +0.03% |
| R02: normal enabled schema check | −16.03% | −15.10% |
| R03: schema check + 29-query capacity control | −15.93% | −14.80% |
| R04: schema check + 32-query pressure control | −15.52% | −14.11% |

The pressure rows are synthetic controls, not an observed production query mix. All **25 adverse entries out of 110 comparisons** are retained below. Notable opposing results include read-only forward batch p95 **+48.10%**, reverse pressure-row p95 **+24.08% / +7.67%**, and sampled family RSS **+0.21% / +1.20%** despite lower kernel-child peaks. Four timing hosts do not establish fleet behavior; p95 here describes 16-cycle batch means, not individual-call latency.

<details>
<summary>All 25 adverse observations</summary>

With 16 samples, nearest-rank p95 equals the maximum; duplicate p95/maximum entries are not independent evidence. Lifecycle observations are single-host measurements. Forward compares B0/C0; reverse compares B1/C1 from the reverse execution order.

| Order | Metric | Absolute increase | Relative increase |
| --- | --- | ---: | ---: |
| Forward | R01 warm-cycle median | +0.306167 ms | +2.72% |
| Forward | R01 warm-cycle p95 | +21.029708 ms | +148.78% |
| Forward | R01 warm-cycle maximum | +21.029708 ms | +148.78% |
| Forward | R01 batch-cycle p95 | +5.511156 ms | +48.10% |
| Forward | R01 batch-cycle maximum | +5.511156 ms | +48.10% |
| Forward | R01 seed-open | +22.895501 ms | +27.19% |
| Forward | R01 query-preparation | +0.026625 ms | +59.28% |
| Forward | R01 owner-close | +1.520292 ms | +111.66% |
| Forward | R02 query-preparation | +0.000583 ms | +17.49% |
| Forward | R03 query-preparation | +0.115375 ms | +11.44% |
| Forward | R04 query-preparation | +0.012958 ms | +2.73% |
| Forward | Sampled process-family peak RSS | +983,040 B | +0.21% |
| Reverse | R01 first cycle | +0.097251 ms | +0.86% |
| Reverse | R01 batch-cycle median | +0.003430 ms | +0.03% |
| Reverse | R03 batch-cycle p95 | +2.810091 ms | +24.08% |
| Reverse | R03 batch-cycle maximum | +2.810091 ms | +24.08% |
| Reverse | R04 batch-cycle p95 | +1.049659 ms | +7.67% |
| Reverse | R04 batch-cycle maximum | +1.049659 ms | +7.67% |
| Reverse | R01 owner-close | +2.326125 ms | +341.26% |
| Reverse | R02 reopen | +0.637916 ms | +2.06% |
| Reverse | R02 query-preparation | +0.000792 ms | +25.69% |
| Reverse | R03 query-preparation | +0.051667 ms | +5.45% |
| Reverse | R04 seed-close | +0.103582 ms | +0.71% |
| Reverse | R04 owner-close | +1.407000 ms | +324.60% |
| Reverse | Sampled process-family peak RSS | +5,521,408 B | +1.20% |

</details>

The Linux initialization-failure descriptor assertion remains skipped on macOS. Existing Vite import-analysis and build EVAL/source-map/browser-externalization advisories remain recorded; no warning suppression, timeout change, or test bypass was added.


### Data-model review clarification

The schema-change warning in the automated review does not describe this diff. No table/index/trigger definitions, schema versions, migrations, or persisted values change. The three SQL SELECT texts and bindings are unchanged; only their existing prepared-statement execution owner is reused. The canonical schema and migration files are untouched. No new migration is needed.

The requested upgrade compatibility evidence is also present in the current 370-pass/one-skip run: all three existing cases passed in [openclaw-state-db.test.ts](https://github.com/openclaw/openclaw/blob/b81de9ea8abf1cea4c8fecdc48811e4f7e4560f6/src/state/openclaw-state-db.test.ts#L1526): v15 Workshop ownership migration preserves rows; a v15 database without Workshop tables upgrades to v16; and a v15 database missing a stable table remains rejected by runtime open and Doctor repair. These exercise existing migrations, not migrations introduced by this PR. The separately reported actual compiled v16 fresh-open/reopen/read-only/preflight proof also passed.

This addresses the review's compatibility-proof request; additional schema changes would be unrelated and are intentionally not added. Exact-head CI [33990278224](https://github.com/openclaw/openclaw/actions/runs/33990278224) passed.
