### PR TITLE
fix(agents): authorize overrides with destination model rules

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -609,6 +609,10 @@ snapshots; OpenClaw owns all persistence and lifecycle coordination.
     `plugins.entries.<id>.subagent.allowedModels` can restrict overrides to
     canonical `provider/model` targets. The same policy applies to `complete`;
     request-scoped calls retain their authenticated client's override authority.
+    The check uses the destination agent's model configuration, including exact
+    configured model IDs, and applies to the plugin's initial override. Configured
+    defaults, operator-installed model routing hooks, and automatic model fallbacks
+    retain their own selection policies.
 
     `toolsAlsoAllow` adds exact, uniquely owned tools registered by the calling plugin to the worker's normal tool surface. The runtime rejects core tools and names shared with another plugin. Profiles and operator tool policies still apply, including explicit allowlists and denies.
 

--- a/src/gateway/server-plugin-subagent-runtime.overrides.test.ts
+++ b/src/gateway/server-plugin-subagent-runtime.overrides.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  normalizeAgentCommandModelRef,
+  parseAgentCommandModelRef,
+} from "../agents/command/model-ref.js";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withPluginRuntimePluginIdScope } from "../plugins/runtime/gateway-request-scope.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
+import {
+  createGatewaySubagentRuntime,
+  resolvePluginSubagentOverridePolicies,
+} from "./server-plugin-subagent-runtime.js";
+
+const dispatch = vi.hoisted(() =>
+  vi.fn(
+    async (
+      _method: string,
+      _params: Record<string, unknown>,
+      _options?: { sessionMutationCommitGuard?: () => void },
+    ) => ({ runId: "override-run" }),
+  ),
+);
+const normalization = vi.hoisted(() => ({ chainedAlias: false }));
+vi.mock("./server-plugin-in-process-dispatch.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./server-plugin-in-process-dispatch.js")>()),
+  dispatchGatewayMethodInProcess: dispatch,
+}));
+vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
+  normalizeProviderModelIdWithRuntime: (params: {
+    provider: string;
+    context: { modelId: string };
+  }) =>
+    params.provider !== "fixture"
+      ? undefined
+      : params.context.modelId === "literal"
+        ? "permitted"
+        : normalization.chainedAlias && params.context.modelId === "permitted"
+          ? "different"
+          : undefined,
+}));
+
+let config: OpenClawConfig;
+
+beforeEach(() => {
+  dispatch.mockClear();
+  normalization.chainedAlias = false;
+  config = {
+    agents: { entries: { worker: { model: "fixture/literal" } } },
+    models: {
+      providers: {
+        fixture: {
+          baseUrl: "https://fixture.invalid/v1",
+          models: [
+            {
+              id: "literal",
+              name: "Literal",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              maxTokens: 8192,
+            },
+          ],
+        },
+      },
+    },
+    plugins: {
+      entries: {
+        "override-fixture": {
+          subagent: { allowModelOverride: true, allowedModels: ["fixture/permitted"] },
+        },
+      },
+    },
+  };
+  setRuntimeConfigSnapshot(config);
+});
+
+afterEach(() => {
+  resetConfigRuntimeState();
+  vi.restoreAllMocks();
+});
+
+function run(override: { provider?: string; model?: string }) {
+  const context = { getRuntimeConfig: () => config } as GatewayRequestContext;
+  const runtime = createGatewaySubagentRuntime(
+    () => context,
+    resolvePluginSubagentOverridePolicies(config),
+  );
+  return withPluginRuntimePluginIdScope("override-fixture", () =>
+    runtime.run({
+      sessionKey: "agent:worker:subagent:override",
+      message: "Use the selected model",
+      ...override,
+    }),
+  );
+}
+
+describe("plugin subagent initial override policy", () => {
+  it.each([{ provider: "fixture", model: "literal" }, { model: "fixture/literal" }])(
+    "checks the exact configured execution target for %j",
+    async (override) => {
+      // An operator-authored model row intentionally bypasses the provider's runtime alias.
+      expect(normalizeAgentCommandModelRef(config, "fixture", "literal", {})).toEqual({
+        provider: "fixture",
+        model: "literal",
+      });
+      await expect(run(override)).rejects.toThrow(/not allowlisted/u);
+      expect(dispatch).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { override: { provider: "fixture", model: "literal" }, chainedAlias: false },
+    { override: { model: "fixture/literal" }, chainedAlias: false },
+    { override: { provider: "fixture", model: "literal" }, chainedAlias: true },
+    { override: { model: "fixture/literal" }, chainedAlias: true },
+  ])(
+    "preserves command selection for $override with chained aliases=$chainedAlias",
+    async ({ override, chainedAlias }) => {
+      config.models!.providers!.fixture!.models = [];
+      normalization.chainedAlias = chainedAlias;
+      await expect(run(override)).resolves.toMatchObject({ runId: "override-run" });
+      const request = dispatch.mock.calls[0]?.[1];
+      expect(request).toMatchObject(override);
+      const model = request?.model as string;
+      const selected = request?.provider
+        ? normalizeAgentCommandModelRef(config, request.provider as string, model, {})
+        : parseAgentCommandModelRef(config, "worker", model, "", {});
+      expect(selected).toEqual({ provider: "fixture", model: "permitted" });
+    },
+  );
+
+  it("allows an explicitly permitted configured literal without applying its runtime alias", async () => {
+    config.plugins!.entries!["override-fixture"]!.subagent!.allowedModels = ["fixture/literal"];
+    await expect(run({ provider: "fixture", model: "literal" })).resolves.toMatchObject({
+      runId: "override-run",
+    });
+    expect(dispatch.mock.calls[0]?.[1]).toMatchObject({ provider: "fixture", model: "literal" });
+  });
+
+  it("rejects a replaced configuration before admitting its prepared override", async () => {
+    config.models!.providers!.fixture!.models = [];
+    const pending = run({ provider: "fixture", model: "literal" });
+    config = { ...config };
+    await expect(pending).rejects.toThrow(/configuration changed before admission/u);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-plugin-subagent-runtime.test.ts
+++ b/src/gateway/server-plugin-subagent-runtime.test.ts
@@ -238,6 +238,12 @@ describe("plugin background completions", () => {
       allowed: false,
     },
     {
+      name: "auth profile outside allowlist",
+      subagent: { allowModelOverride: true, allowedModels: ["test-provider/override"] },
+      model: "test-provider/override@other-profile",
+      allowed: false,
+    },
+    {
       name: "invalid allowlist",
       subagent: { allowModelOverride: true, allowedModels: ["not-a-model-ref"] },
       model: "test-provider/override",

--- a/src/gateway/server-plugin-subagent-runtime.ts
+++ b/src/gateway/server-plugin-subagent-runtime.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
+import { expectDefined } from "@openclaw/normalization-core";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
-import { normalizeModelRef } from "../agents/model-ref-shared.js";
-import { parseModelRef } from "../agents/model-selection-normalize.js";
+import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
+import type { ModelRef } from "../agents/model-ref-shared.js";
 import type { AgentWaitResult } from "../agents/run-wait.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
@@ -19,28 +20,10 @@ import { ADMIN_SCOPE } from "./operator-scopes.js";
 import type { GatewayContextResolver, GatewayRequestOptions } from "./server-methods/types.js";
 import {
   dispatchGatewayMethodInProcess,
+  getInProcessGatewayRequestContext,
   prepareInProcessAgentExecution,
 } from "./server-plugin-in-process-dispatch.js";
 import { resolvePluginSubagentToolsAlsoAllow } from "./server-plugin-runtime-client.js";
-
-function resolvePluginSubagentRequestedModelRef(params: {
-  provider?: string;
-  model?: string;
-}): string | null {
-  if (params.provider && params.model) {
-    const normalizedRequest = normalizeModelRef(params.provider, params.model);
-    return `${normalizedRequest.provider}/${normalizedRequest.model}`;
-  }
-  const rawModel = params.model?.trim();
-  if (!rawModel || !rawModel.includes("/")) {
-    return null;
-  }
-  const parsed = parseModelRef(rawModel, "");
-  if (!parsed?.provider || !parsed.model) {
-    return null;
-  }
-  return `${parsed.provider}/${parsed.model}`;
-}
 
 function normalizePluginSubagentRunRuntime(
   value: unknown,
@@ -89,56 +72,53 @@ export function resolvePluginSubagentOverridePolicies(
   return policies;
 }
 
-function authorizeFallbackModelOverride(params: {
+function resolveFallbackModelOverridePolicy(params: {
   policies: PluginSubagentOverridePolicies;
   pluginId?: string;
   provider?: string;
   model?: string;
-}): { allowed: true } | { allowed: false; reason: string } {
+}): PluginSubagentOverridePolicy | undefined {
   const pluginId = params.pluginId?.trim();
   if (!pluginId) {
-    return {
-      allowed: false,
-      reason: "provider/model override requires plugin identity in fallback subagent runs.",
-    };
+    throw new Error("provider/model override requires plugin identity in fallback subagent runs.");
   }
   const policy = params.policies[pluginId];
   if (!policy?.allowModelOverride) {
-    return {
-      allowed: false,
-      reason:
-        `plugin "${pluginId}" is not trusted for fallback provider/model override requests. ` +
+    throw new Error(
+      `plugin "${pluginId}" is not trusted for fallback provider/model override requests. ` +
         "See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-subagent and search for: " +
         "plugins.entries.<id>.subagent.allowModelOverride",
-    };
+    );
   }
   if (policy.allowAny) {
-    return { allowed: true };
+    return undefined;
   }
   if (policy.configured && policy.models.size === 0) {
-    return {
-      allowed: false,
-      reason: `plugin "${pluginId}" configured subagent.allowedModels, but none of the entries normalized to a valid provider/model target.`,
-    };
+    throw new Error(
+      `plugin "${pluginId}" configured subagent.allowedModels, but none of the entries normalized to a valid provider/model target.`,
+    );
   }
   if (policy.models.size === 0) {
-    return { allowed: true };
+    return undefined;
   }
-  const requestedModelRef = resolvePluginSubagentRequestedModelRef(params);
-  if (!requestedModelRef) {
-    return {
-      allowed: false,
-      reason:
-        "fallback provider/model overrides that use an allowlist must resolve to a canonical provider/model target.",
-    };
+  if (!params.model?.trim() || (!params.provider && !params.model.includes("/"))) {
+    throw new Error(
+      "fallback provider/model overrides that use an allowlist must resolve to a canonical provider/model target.",
+    );
   }
-  if (policy.models.has(requestedModelRef)) {
-    return { allowed: true };
+  return policy;
+}
+
+function assertPluginSubagentModelAllowed(
+  policy: PluginSubagentOverridePolicy | undefined,
+  selection: ModelRef,
+  pluginId: string | undefined,
+  authProfileId?: string,
+): void {
+  const modelRef = `${selection.provider}/${selection.model}${authProfileId ? `@${authProfileId}` : ""}`;
+  if (policy && !policy.models.has(modelRef)) {
+    throw new Error(`model override "${modelRef}" is not allowlisted for plugin "${pluginId}".`);
   }
-  return {
-    allowed: false,
-    reason: `model override "${requestedModelRef}" is not allowlisted for plugin "${pluginId}".`,
-  };
 }
 
 function hasAdminScope(client: GatewayRequestOptions["client"] | undefined): boolean {
@@ -179,23 +159,21 @@ export function createGatewaySubagentRuntime(
     const hasRequestScopeClient = Boolean(scope?.client);
     let allowOverride = hasRequestScopeClient && canClientUseModelOverride(scope?.client ?? null);
     let allowSyntheticModelOverride = false;
+    let policy: PluginSubagentOverridePolicy | undefined;
     if (overrideRequested && !allowOverride && !hasRequestScopeClient) {
-      const fallbackAuth = authorizeFallbackModelOverride({
+      policy = resolveFallbackModelOverridePolicy({
         policies: overridePolicies,
         pluginId: scope?.pluginId,
         provider: params.provider,
         model: params.model,
       });
-      if (!fallbackAuth.allowed) {
-        throw new Error(fallbackAuth.reason);
-      }
       allowOverride = true;
       allowSyntheticModelOverride = true;
     }
     if (overrideRequested && !allowOverride) {
       throw new Error("provider/model override is not authorized for this plugin subagent run.");
     }
-    return { allowOverride, allowSyntheticModelOverride };
+    return { allowOverride, allowSyntheticModelOverride, policy };
   };
   const getSessionMessages: PluginRuntime["subagent"]["getSessionMessages"] = async (params) => {
     const scope = getPluginRuntimeGatewayRequestScope();
@@ -271,7 +249,7 @@ export function createGatewaySubagentRuntime(
           await execution.authorize();
           assertCurrent();
           signal.throwIfAborted();
-          authorizeModelOverride(params);
+          const { policy } = authorizeModelOverride(params);
           const cfg = execution.context.getRuntimeConfig();
           const agentId = resolveConfiguredAgentId(cfg, params.agentId);
           const selection = resolveSimpleCompletionSelectionForAgent({
@@ -282,6 +260,12 @@ export function createGatewaySubagentRuntime(
           if (!selection) {
             throw new Error(`No model configured for agent ${agentId}.`);
           }
+          assertPluginSubagentModelAllowed(
+            policy,
+            { provider: selection.provider, model: selection.modelId },
+            pluginId,
+            selection.profileId,
+          );
           const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 30_000);
           const runSignal = AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]);
           // Hold capacity through runtime cleanup; a response-only abort race would
@@ -321,7 +305,8 @@ export function createGatewaySubagentRuntime(
         { abortSignal: signals.length ? AbortSignal.any(signals) : undefined },
       );
     },
-    async run(params) {
+    async run(request) {
+      const params = { ...request };
       if (params.disableTools === true && (params.toolsAlsoAllow?.length ?? 0) > 0) {
         throw new Error("Tool-free plugin subagent runs cannot request additive tools.");
       }
@@ -337,7 +322,57 @@ export function createGatewaySubagentRuntime(
         pluginId,
         toolsAlsoAllow: params.toolsAlsoAllow,
       });
-      const { allowOverride, allowSyntheticModelOverride } = authorizeModelOverride(params);
+      const { allowOverride, allowSyntheticModelOverride, policy } = authorizeModelOverride(params);
+      let sessionMutationCommitGuard: (() => void) | undefined;
+      if (policy) {
+        const context = getInProcessGatewayRequestContext(resolveGatewayContext);
+        if (!context) {
+          throw new Error("Plugin model override requires a live Gateway binding.");
+        }
+        const cfg = context.getRuntimeConfig();
+        sessionMutationCommitGuard = () => {
+          runtimeLifetime?.throwIfAborted();
+          if (
+            getInProcessGatewayRequestContext(resolveGatewayContext) !== context ||
+            context.getRuntimeConfig() !== cfg
+          ) {
+            throw new Error(
+              "Plugin model override configuration changed before admission. Retry the run.",
+            );
+          }
+        };
+        const [modelRefs, agentScope, metadata] = await Promise.all([
+          import("../agents/command/model-ref.js"),
+          import("../agents/agent-scope.js"),
+          import("../plugins/plugin-metadata-snapshot.js"),
+        ]);
+        sessionMutationCommitGuard();
+        const model = expectDefined(params.model, "authorized model override");
+        const agentId = agentScope.resolveSessionAgentId({
+          config: cfg,
+          sessionKey: params.sessionKey,
+        });
+        const manifestPlugins =
+          cfg.plugins?.enabled === false
+            ? []
+            : metadata.resolvePluginMetadataSnapshot({
+                config: cfg,
+                env: process.env,
+                workspaceDir: agentScope.resolveAgentWorkspaceDir(cfg, agentId),
+              });
+        const selection = params.provider
+          ? modelRefs.normalizeAgentCommandModelRef(cfg, params.provider, model, {
+              manifestPlugins,
+            })
+          : modelRefs.parseAgentCommandModelRef(cfg, agentId, model, "", { manifestPlugins });
+        if (!selection) {
+          throw new Error("Invalid model override.");
+        }
+        const authProfileId = params.provider ? undefined : splitTrailingAuthProfile(model).profile;
+        assertPluginSubagentModelAllowed(policy, selection, pluginId, authProfileId);
+        // The command owns parsing. Replacing its input with this result would
+        // apply non-idempotent provider aliases again; retain the authorized syntax.
+      }
       const payload = await dispatchGatewayMethodInProcess<{
         runId?: string;
         sessionKey?: string;
@@ -360,6 +395,7 @@ export function createGatewaySubagentRuntime(
         },
         {
           allowSyntheticModelOverride,
+          sessionMutationCommitGuard,
           agentRunTracking: "plugin_subagent",
           ...(!scope?.client ? { operatorRoleActor: { kind: "system" as const } } : {}),
           ...(pluginId ? { pluginRuntimeOwnerId: pluginId } : {}),

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -281,7 +281,11 @@ function createTestLog() {
 }
 
 function createTestContext(label: string): GatewayRequestContext {
-  return bindTestAgentTurns({ label } as unknown as GatewayRequestContext);
+  const config = {};
+  return bindTestAgentTurns({
+    label,
+    getRuntimeConfig: () => config,
+  } as unknown as GatewayRequestContext);
 }
 
 function bindTestAgentTurns(context: GatewayRequestContext): GatewayRequestContext {


### PR DESCRIPTION
Related: #130706.

## What Problem This Solves

Fixes an issue where a background plugin subagent's model override could pass its allowlist check under different normalization rules from the destination agent. A provider hook could authorize an alias as an allowed model while the command correctly preserved a different, exactly configured model ID.

## Why This Change Was Made

Use the destination agent's existing command-selection rules for finite override checks and retain the original request syntax, so an already normalized alias is not normalized again. The existing admission guard fences configuration replacement. Queued completions check their resolved model and profile through the same finite policy.

## User Impact

Plugin model restrictions apply to the initial override that the destination will resolve. Configured defaults, operator model-routing hooks, authenticated request authority, and normal fallback behavior retain their existing policies. Configuration replacement before admission produces a visible retry instruction.

## Evidence

- Two regressions failed before the repair: both explicit provider/model and model-only requests passed authorization for the wrong configured target. The same cases pass after the repair.
- 119 focused tests pass, covering exact configured IDs, aliases, profiles, configuration replacement, and completion policy.
- Full `pnpm build` and the changed-scope checks passed. Fresh independent autoreview through P2 found no actionable findings; the parent also inspected the resolver, dispatch and admission boundaries.
- A built isolated Gateway with a local fixture provider verified denial before dispatch; allowed and static-alias overrides; the configured default; an operator hook changing the model; and default-model fallback. Terminal run receipts and actual provider requests agree. An explicit pinned-model failure preserved the existing no-fallback behavior. The owned Gateway and ports were cleaned up.
- Runtime-only alias handling exposed a separate pre-existing packaged normalization-bridge defect, tracked in the remaining #130706 work. The live alias control for this cut uses a declared static manifest alias.

Production: +95/-59, net +36. Tests: +159/-1, net +158. Documentation: +4. The production growth supplies destination configuration/metadata capture and an admission lifetime fence, while removing the ambient resolver and redundant authorization-result adapters. No new configuration option, protocol field, schema, or dependency.

Verified commit: 408803196eeab912b10dfb71c5d9509286aeb2e4.

## Maintainer disposition of compatibility risk

Retain the documented authorization correction identified in [ClawSweeper’s review](https://github.com/openclaw/openclaw/pull/139368#issuecomment-5554747280). A finite plugin allowlist does not authorize a different exactly configured model merely because an ambient alias maps it onto an allowed name. Callers must request an allowed destination model, or the operator can deliberately authorize that model through the existing policy. A configuration replacement before admission invalidates the checked selection and returns an explicit retry instruction.

This is the intended repair within the maintainer-requested #130706 extraction. The verified controls preserve configured defaults, operator-owned routing hooks, ACP availability and automatic fallback policy. No compatibility shim should retain the incorrect acceptance path. The review has no actionable source finding or additional Rank-up moves.
