### PR TITLE
fix(ui): hide author avatars in subagent transcripts

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -505,6 +505,7 @@ are Gateway settings and remain available in every browser.
 
 <AccordionGroup>
   <Accordion title="Chat and Talk">
+    - Subagent transcripts hide author avatars in both the main chat view and task details; sender names remain visible.
     - Chat with the model via Gateway WS (`chat.history`, `chat.send`, `chat.abort`, `chat.inject`). Archived sessions keep the composer disabled and show a banner with an **Unarchive** action before the conversation can continue.
     - Opening or refreshing chat requests up to 80 recent messages. Each background warming pass reads at most two inactive sessions sequentially, with up to 20 messages per session, after presented chat loads finish. Automatic warming waits for a visible conversation on the current page; dashboard-only views still warm the session you hover or keyboard-focus. Scrolling back requests up to 1,000 older messages per page and prefetches the next page. Per-message text caps and response-byte limits can reduce these counts.
     - A previous run's error banner clears when Chat adopts a new run or history confirms a newer successful run. Retiring the banner does not erase recorded diagnostics. A late error from the same run can remain visible beside its delivered answer; reconnecting or refreshing metadata alone does not establish recovery.

--- a/scripts/control-ui-mock-background-tasks.ts
+++ b/scripts/control-ui-mock-background-tasks.ts
@@ -1,5 +1,11 @@
 function historyMessage(role: "assistant" | "user", text: string, timestamp: number) {
-  return { content: [{ type: "text", text }], role, timestamp };
+  return {
+    content: [{ type: "text", text }],
+    role,
+    timestamp,
+    __openclaw:
+      role === "user" ? { senderId: "mock-operator", senderName: "Riley Example" } : undefined,
+  };
 }
 
 function finishedTask(n: number, now: number) {

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -94,7 +94,7 @@ type RenderMessageGroupOptions = Omit<
     /** Routing for peer sender names; absent leaves them plain text. */
     personActivity?: PersonActivityRouting;
     userAvatar?: string | null;
-    showAvatarGutter?: boolean;
+    avatarPlacement?: "gutter" | "footer" | "none";
     showAssistantAvatar?: boolean;
     contextWindow?: number | null;
     onReply?: (target: MessageReplyTarget) => void;
@@ -353,27 +353,18 @@ export function renderMessageGroupContent(group: MessageGroup, opts: RenderMessa
 
 export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroupOptions) {
   const normalizedRole = normalizeRoleForGrouping(group.role);
-  const isWorkspaceConflict = group.messages.every((item) =>
-    Boolean(workspaceResultConflictFromTranscript(item.message)),
-  );
   const assistantName = opts.assistantName ?? "Assistant";
   const isPeerGroup = normalizedRole === "user" && isPeerSenderGroup(group, opts.userId);
   const isForwarded = normalizedRole === "assistant" && hasForwardedSource(group);
   const sourceSessionKey = group.senderSession?.sessionKey;
   const who = resolveMessageGroupSenderLabel(group, opts);
   const roleClass =
-    normalizedRole === "user"
-      ? "user"
-      : normalizedRole === "assistant"
-        ? "assistant"
-        : normalizedRole === "tool"
-          ? "tool"
-          : isWorkspaceConflict
-            ? "workspace-conflict"
-            : "other";
-  const showAvatarGutter = opts.showAvatarGutter !== false;
-  const assistantAvatarIdentity = { name: assistantName, avatar: opts.assistantAvatar ?? null };
-  const persistUserIdentity = normalizedRole === "user" && showAvatarGutter;
+    normalizedRole === "user" || normalizedRole === "assistant" || normalizedRole === "tool"
+      ? normalizedRole
+      : group.messages.every((item) => workspaceResultConflictFromTranscript(item.message))
+        ? "workspace-conflict"
+        : "other";
+  const avatarPlacement = opts.avatarPlacement ?? "gutter";
 
   // Aggregate usage/cost/model across all messages in the group
   const meta = extractGroupMeta(group, opts.contextWindow ?? null);
@@ -453,17 +444,14 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
     >
       ${
         normalizedRole !== "tool" &&
-        showAvatarGutter &&
+        avatarPlacement === "gutter" &&
         (isForwarded || normalizedRole !== "assistant" || opts.showAssistantAvatar !== false)
           ? isForwarded
             ? renderForwardedAvatar(group.senderSession?.agentId, opts)
             : renderChatAvatar(
                 group.role,
-                assistantAvatarIdentity,
-                {
-                  name: opts.userName ?? null,
-                  avatar: opts.userAvatar ?? null,
-                },
+                { name: assistantName, avatar: opts.assistantAvatar ?? null },
+                { name: opts.userName ?? null, avatar: opts.userAvatar ?? null },
                 opts.resourceBasePath,
                 group.sender,
               )
@@ -532,13 +520,15 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
           ? nothing
           : html`<div
               class="chat-group-footer ${
-                persistUserIdentity ? "chat-group-footer--persistent-identity" : ""
+                normalizedRole === "user" && avatarPlacement !== "footer"
+                  ? "chat-group-footer--persistent-identity"
+                  : ""
               }${sendFailure ? " chat-group-footer--send-failure" : ""}"
             >
               <div class="chat-group-footer__meta">
                 ${isPeerGroup ? nothing : userFooterActions}
                 ${
-                  normalizedRole === "user" && !showAvatarGutter
+                  normalizedRole === "user" && avatarPlacement === "footer"
                     ? renderChatAuthorAvatar(group.sender)
                     : nothing
                 }

--- a/ui/src/pages/chat/components/chat-message.subagent.test.ts
+++ b/ui/src/pages/chat/components/chat-message.subagent.test.ts
@@ -1,0 +1,66 @@
+import { render } from "lit";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import type { GatewaySessionRow } from "../../../api/types.ts";
+import { createTestTranscript } from "../chat-view.test-helpers.ts";
+import { renderChatThread } from "./chat-thread.ts";
+import {
+  flushDeferredRowPrune,
+  installTranscriptDomMocks,
+  resetTranscriptTestDom,
+  threadProps,
+} from "./chat-transcript.test-support.ts";
+
+beforeEach(installTranscriptDomMocks);
+afterEach(resetTranscriptTestDom);
+
+it.each([{ classification: "subagent" as const }, { spawnedBy: "agent:main:parent" }])(
+  "removes author avatars when spawn metadata arrives: %j",
+  async (metadata) => {
+    const props = threadProps("spawn-metadata", "agent:main:opaque-child", [
+      { role: "user", content: "Inspect the workspace", timestamp: 1_000 },
+      { role: "assistant", content: "Workspace inspected", timestamp: 2_000 },
+    ]);
+    props.userId = "viewer";
+    props.userName = "Example User";
+    const row: GatewaySessionRow = {
+      key: props.sessionKey,
+      kind: "direct",
+      updatedAt: 1_000,
+      parentSessionKey: "agent:main:parent",
+    };
+    props.selectedSession = row;
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const rerender = async () => {
+      render(renderChatThread(props, transcript), container);
+      transcript.hostUpdated();
+      await flushDeferredRowPrune();
+    };
+    await rerender();
+    transcript.hostConnected();
+    // Navigation ancestry alone also describes human-created forks.
+    expect(container.querySelector(".chat-avatar.user")).not.toBeNull();
+    props.selectedSession = { ...row, ...metadata };
+    await rerender();
+    expect(container.querySelector(".chat-avatar, .chat-author-avatar")).toBeNull();
+    expect(container.querySelector(".chat-sender-name")?.textContent).toContain("Example User");
+    expect(container.textContent).toContain("Workspace inspected");
+    transcript.hostDisconnected();
+  },
+);
+
+it("hides avatars for a subagent key before its session row loads", async () => {
+  const props = threadProps("spawn-key", "agent:main:subagent:child");
+  props.userId = "viewer";
+  props.userName = "Example User";
+  const transcript = createTestTranscript();
+  const container = document.body.appendChild(document.createElement("div"));
+  render(renderChatThread(props, transcript), container);
+  transcript.hostUpdated();
+  transcript.hostConnected();
+  await flushDeferredRowPrune();
+  expect(container.querySelectorAll(".chat-group").length).toBeGreaterThan(0);
+  expect(container.querySelector(".chat-avatar, .chat-author-avatar")).toBeNull();
+  expect(container.querySelector(".chat-sender-name")?.textContent).toContain("Example User");
+  transcript.hostDisconnected();
+});

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2019,7 +2019,7 @@ describe("grouped chat rendering", () => {
         messages: [createMessageEntry("attributed-user-message", message)],
       });
 
-      render(renderTestMessageGroup(group, { ...viewer, showAvatarGutter: true }), container);
+      render(renderTestMessageGroup(group, { ...viewer, avatarPlacement: "gutter" }), container);
 
       expect(
         container.querySelector<HTMLElement>(".chat-group.user .chat-sender-name")?.textContent,
@@ -2397,43 +2397,51 @@ describe("grouped chat rendering", () => {
     expect(container.textContent).not.toContain("Guardian warning");
   });
 
-  it("renders a compact author avatar when the gutter is hidden", async () => {
-    const container = document.createElement("div");
-    render(
-      renderMessageGroup(
-        createMessageGroup({ role: "user", content: "hello", timestamp: 1000 }, "user", {
-          key: "attributed-user",
-          senderLabel: "Alice Example",
-          sender: { id: "profile_123", name: "Alice Example" },
-          messages: [
-            {
-              key: "attributed-message",
-              message: { role: "user", content: "hello", timestamp: 1000 },
-            },
-          ],
-          timestamp: 1000,
-        }),
-        {
-          showReasoning: true,
-          showToolCalls: true,
-          assistantName: "OpenClaw",
-          showAvatarGutter: false,
-        },
-      ),
-      container,
-    );
-
-    expect(container.querySelector(".chat-avatar.user")).toBeNull();
-    expect(container.querySelector(".chat-group-persistent-author")).toBeNull();
-    await vi.waitFor(() => {
-      expect(container.querySelector(".chat-author-avatar__initials")?.textContent?.trim()).toBe(
-        "AE",
+  it.each(["footer", "none"] as const)(
+    "renders user author identity with %s avatars",
+    async (avatarPlacement) => {
+      const container = document.createElement("div");
+      render(
+        renderMessageGroup(
+          createMessageGroup({ role: "user", content: "hello", timestamp: 1000 }, "user", {
+            key: "attributed-user",
+            senderLabel: "Alice Example",
+            sender: { id: "profile_123", name: "Alice Example" },
+            messages: [
+              {
+                key: "attributed-message",
+                message: { role: "user", content: "hello", timestamp: 1000 },
+              },
+            ],
+            timestamp: 1000,
+          }),
+          {
+            showReasoning: true,
+            showToolCalls: true,
+            assistantName: "OpenClaw",
+            avatarPlacement,
+          },
+        ),
+        container,
       );
-    });
-    expect(container.querySelector(".chat-author-avatar")?.getAttribute("title")).toBe(
-      "Alice Example",
-    );
-  });
+
+      expect(container.querySelector(".chat-avatar.user")).toBeNull();
+      expect(container.querySelector(".chat-group-persistent-author")).toBeNull();
+      expect(container.querySelector(".chat-sender-name")?.textContent).toContain("Alice Example");
+      if (avatarPlacement === "none") {
+        expect(container.querySelector(".chat-author-avatar")).toBeNull();
+        return;
+      }
+      await vi.waitFor(() => {
+        expect(container.querySelector(".chat-author-avatar__initials")?.textContent?.trim()).toBe(
+          "AE",
+        );
+      });
+      expect(container.querySelector(".chat-author-avatar")?.getAttribute("title")).toBe(
+        "Alice Example",
+      );
+    },
+  );
 
   it("falls back to initials when a user avatar image fails", async () => {
     const container = document.createElement("div");
@@ -2451,7 +2459,7 @@ describe("grouped chat rendering", () => {
         showReasoning: true,
         showToolCalls: true,
         assistantName: "OpenClaw",
-        showAvatarGutter: false,
+        avatarPlacement: "footer",
       }),
       container,
     );

--- a/ui/src/pages/chat/components/chat-read-only-transcript.ts
+++ b/ui/src/pages/chat/components/chat-read-only-transcript.ts
@@ -35,6 +35,7 @@ export function renderReadOnlyTranscript(params: {
       userId: chat.userId,
       userName: chat.userName,
       userAvatar: chat.userAvatar,
+      avatarPlacement: chat.avatarPlacement,
       // Peer authors link to their Activity feed here exactly as in the live transcript.
       personActivity: chat.personActivity,
       basePath: chat.basePath,

--- a/ui/src/pages/chat/components/chat-task-detail.test.ts
+++ b/ui/src/pages/chat/components/chat-task-detail.test.ts
@@ -248,6 +248,8 @@ describe("task detail panel", () => {
     const chat = {
       ...threadProps("pane-1", host.sessionKey),
       selectedSession: parentRow,
+      userId: "viewer",
+      userName: "Example User",
       sessions,
     };
     const transcript = createTestTranscript();
@@ -274,6 +276,8 @@ describe("task detail panel", () => {
     await flushDeferredRowPrune();
 
     expect(container.textContent).not.toContain("Archived by Parent Owner");
+    expect(container.querySelector(".chat-avatar, .chat-author-avatar")).toBeNull();
+    expect(container.querySelector(".chat-sender-name")?.textContent).toContain("Example User");
     if (expected) {
       expect(container.textContent).toContain(expected);
     } else {

--- a/ui/src/pages/chat/components/chat-task-detail.ts
+++ b/ui/src/pages/chat/components/chat-task-detail.ts
@@ -183,7 +183,11 @@ function renderTaskTranscript(params: {
   return html`<div class="sidebar-content chat-task-detail__content">
     <div class="chat-task-detail__transcript">
       ${renderReadOnlyTranscript({
-        chat: { ...params.chat, selectedSession },
+        chat: {
+          ...params.chat,
+          selectedSession,
+          avatarPlacement: params.task.runtime === "subagent" ? "none" : undefined,
+        },
         messages: load.messages,
         paneId: `${params.chat.paneId}:task-sidebar`,
         sessionKey: params.sessionKey,

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -116,6 +116,7 @@ export type ChatThreadProps = ChatSendStatusActions & {
   userId?: string | null;
   userName?: string | null;
   userAvatar?: string | null;
+  avatarPlacement?: "none";
   basePath?: string;
   resourceBasePath?: string;
   fullMessageAgentId?: string;

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -232,7 +232,10 @@ export function projectChatTranscript(
   const isEmpty =
     chatItems.length === 0 && !props.loading && !hasRealtimeTalkConversation && !hasTypingActors;
   transcript.setContentReady(!props.loading);
-  // Capped lists may omit the selected row; global scope precedes key classification.
+  // 1:1 exchanges do not need an avatar gutter; group threads keep it to identify
+  // multiple voices. The capped sessions list may omit the selected row, so absent
+  // or unknown rows classify by key, with global aliases taking precedence.
+  // senderLabels are not a signal: gateway sanitization also labels 1:1 channel DMs.
   const rowKind = activeSession?.kind;
   const sessionKind =
     rowKind && rowKind !== "unknown"
@@ -240,7 +243,10 @@ export function projectChatTranscript(
       : isGlobalAliasKey
         ? "global"
         : classifySessionKind(props.sessionKey);
-  // Shared and forwarded conversations keep identity chrome even in direct sessions.
+  // Only agent-solo kinds qualify. Global sessions aggregate inbound contexts,
+  // including groups/channels; identity-resolving gateways also share sessions
+  // between people, so both keep avatars. A forwarded cross-session message adds
+  // another voice to a direct exchange and restores identity chrome.
   const hasForwardedGroups = chatItems.some(
     (item) => item.kind === "group" && hasForwardedSource(item),
   );
@@ -248,6 +254,7 @@ export function projectChatTranscript(
     (sessionKind === "direct" || sessionKind === "cron" || sessionKind === "spawn-child") &&
     !props.userId &&
     !hasForwardedGroups;
+  // Precedence: explicit prop, subagent classification/spawnedBy/key → none, direct → footer, else gutter.
   const avatarPlacement =
     props.avatarPlacement ??
     (activeSession?.classification === "subagent" ||

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -8,6 +8,7 @@ import { extractTextCached } from "../../../lib/chat/message-extract.ts";
 import { formatSessionArchiveReason } from "../../../lib/sessions/session-archive-reason.ts";
 import {
   isUiGlobalScopeConfigured,
+  isSubagentSessionKey,
   parseAgentSessionKey,
   resolveUiGlobalAliasAgentId,
 } from "../../../lib/sessions/session-key.ts";
@@ -231,12 +232,7 @@ export function projectChatTranscript(
   const isEmpty =
     chatItems.length === 0 && !props.loading && !hasRealtimeTalkConversation && !hasTypingActors;
   transcript.setContentReady(!props.loading);
-  // 1:1 sessions drop the avatar gutter entirely; group threads keep avatars
-  // as the always-visible identity marker. The canonical session kind decides;
-  // the sessions list is capped, so absent/unknown rows classify by key:
-  // global aliases first, then the same core key-shape helper the gateway
-  // uses. Message senderLabels are not a signal here: gateway sanitization
-  // labels 1:1 channel DM rows too.
+  // Capped lists may omit the selected row; global scope precedes key classification.
   const rowKind = activeSession?.kind;
   const sessionKind =
     rowKind && rowKind !== "unknown"
@@ -244,13 +240,7 @@ export function projectChatTranscript(
       : isGlobalAliasKey
         ? "global"
         : classifySessionKind(props.sessionKey);
-  // Only agent-solo kinds qualify: "global" aggregates every inbound context
-  // under session.scope="global" (including group/channel senders), so it
-  // keeps avatars like "group" and "unknown" do. An identity-resolving gateway
-  // (multi-user trusted proxy) also keeps them: several people share these
-  // sessions, so the author marker is signal, not decoration.
-  // A forwarded cross-session message is another voice in the room: the thread
-  // stops rendering as a compact direct exchange and identity chrome returns.
+  // Shared and forwarded conversations keep identity chrome even in direct sessions.
   const hasForwardedGroups = chatItems.some(
     (item) => item.kind === "group" && hasForwardedSource(item),
   );
@@ -258,6 +248,15 @@ export function projectChatTranscript(
     (sessionKind === "direct" || sessionKind === "cron" || sessionKind === "spawn-child") &&
     !props.userId &&
     !hasForwardedGroups;
+  const avatarPlacement =
+    props.avatarPlacement ??
+    (activeSession?.classification === "subagent" ||
+    activeSession?.spawnedBy ||
+    isSubagentSessionKey(props.sessionKey)
+      ? "none"
+      : isDirectThread
+        ? "footer"
+        : "gutter");
   const showLoadingSkeleton = props.loading && chatItems.length === 0 && !hasTypingActors;
   const threadContextWindow =
     activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null;
@@ -345,7 +344,7 @@ export function projectChatTranscript(
       onDiscardQueuedMessage: props.onDiscardQueuedMessage,
       queuedMessageAction: props.queuedMessageAction,
       personActivity: props.personActivity,
-      showAvatarGutter: !isDirectThread,
+      avatarPlacement,
       contextWindow: threadContextWindow,
       resolveReplyPreview,
       onResolveReply: props.replyMessageAccess?.request,
@@ -643,9 +642,8 @@ export function projectChatTranscript(
     JSON.stringify([...latestBrowserTabs]),
     props.sessionKey,
     props.presented,
-    // Session activity/title patches do not change settled rows. Their visible
-    // session facts (gutter, reasoning, context window, recap) own invalidation.
-    isDirectThread,
+    // Invalidate settled rows when spawn metadata arrives, not on activity/title patches.
+    avatarPlacement,
     props.boardProvider,
     props.boardProvider?.canPinWidgets,
     props.boardProvider?.canPinMcpApps,


### PR DESCRIPTION
## Problem

Opening a subagent in task details or the main chat view could show the human operator's avatar beside the parent agent's spawn prompt. The renderer only supported gutter avatars or compact footer avatars, so hiding the gutter could not hide both.

## Solution

Replace the placement boolean with one `avatarPlacement` option (`gutter`, `footer`, or `none`). The shared transcript projection selects `none` for subagent classification, spawn ownership, or a subagent session key. Task details explicitly carry `none` when the task runtime is a subagent, including when its session row is absent. Avatar placement participates in row-cache invalidation when metadata arrives.

Keep sender-name rendering and persistent user-name visibility. Simplify redundant role branches and identity temporaries in the same renderer. Add a synthetic author to the existing task mock so both views reproduce the problem.

## Impact

Subagent transcripts show no author avatars for any role in either view. Sender names remain visible. Navigation-parent metadata alone does not suppress avatars on user-created forks. Composer behavior, Gateway storage, and public API contracts are unchanged.

## Evidence

- Current-head [CI run 33991207398](https://github.com/openclaw/openclaw/actions/runs/33991207398) passed on `781b2c8e5eb52f8156693196594488674b407546`; the exact-head repository watcher returned `GREEN`.

- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message ui/src/pages/chat/components/chat-task-detail ui/src/pages/chat/chat-thread`: 6 files, 513 tests passed.
- Additional focused validation: 11 transcript render-cache tests passed; the three metadata-arrival and missing-row regressions are included in the 513-test run above.
- Regression proof on the original renderer: 7 failures, all caused by author avatars remaining in subagent transcripts.
- `node scripts/check-changed.mjs`: passed (exit 0), including all typecheck, guard, dead-export, formatting, and scoped lint lanes.
- `git diff --check`: passed. The 513 focused tests, complete changed-file gate, and default Codex autoreview were rerun successfully for the comment follow-up.
- Previous-head hosted CI on `4c2128fff7136dfeab008bfb8faceaa49db14dd0`: completed with [UI E2E shard 1/7 failing](https://github.com/openclaw/openclaw/actions/runs/33990311427/job/101371370714), leaving `openclaw/ci-gate` red. The shard passed 251 tests and failed two: `board-a2ui.e2e.test.ts:221` timed out waiting for `board.event` after a dashboard widget click; `browser-route-handoff.e2e.test.ts:184` timed out waiting for ordinary main-session live tool output. Neither test exercises a subagent transcript, and this patch preserves ordinary-session rendering. Those failures were recorded without expanding this patch’s scope; no CI jobs were rerun. The follow-up head passed CI as recorded above.
- Playwright, 1100×720, scale 2, light theme: 1 → 0 author avatars in each view; after captures assert sender-footer opacity 1 without hovering.
- Task production LOC: **+50 −43**, including the mock fixture and restored explanatory comments. The follow-up adds seven comment lines without changing runtime code or cutting other comments. The message-group renderer simplification remains +14 −24.
- Independent source review: sender-footer persistence finding fixed; no remaining actionable findings. Default Codex autoreview returned `scoped-clean` with no accepted/actionable findings at its P0 threshold.

| View | Before | After |
| --- | --- | --- |
| Subagent task details | ![Before: author avatar in task details](https://github.com/user-attachments/assets/c1972c7a-6512-42d5-b735-400a477cb4be) | ![After: task details keep names without avatars](https://github.com/user-attachments/assets/68266632-5c3c-42cd-97d3-c148335e0c35) |
| Main subagent session | ![Before: author avatar in main subagent view](https://github.com/user-attachments/assets/291ff1fb-a010-494f-90a5-c3d2d063b70a) | ![After: main subagent view keeps names without avatars](https://github.com/user-attachments/assets/331b6ee6-0dc4-4a7b-af98-c2038ae3e049) |

Release-note: Hide author avatars in subagent task details and main chat views while preserving sender names.


