### PR TITLE
fix(ui): keep activity labels visible and unify row typography

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -807,6 +807,8 @@ They are generated separately from the agent's work, so a title is not a complet
 status or a report of tool access. Existing titles and manual names are left
 unchanged; click a title to rename it.
 
+Collapsed tool rows keep the tool label visible and truncate long summaries with an ellipsis. Tool and subagent activity rows use the same text size and weight. Running subagents show **Subagent** beside an animated indicator; terminal rows show **Subagent finished**, **Subagent failed**, or **Subagent cancelled**.
+
 Chat error banners, including cloud runner failures, show short messages in full. Use **Copy error** beside **Details** in the header to copy the complete diagnostic received by the UI, even while collapsed. **Details** appears only when the complete diagnostic adds information beyond the preview, such as additional lines or text shortened for the preview; repeated lines and whitespace-only differences do not add details. Open it to read and select the complete diagnostic. The disclosure works with Enter or Space; the expanded text wraps long lines and can be scrolled with the keyboard. Copying does not open or close the details, and neither copying nor expanding an error retries the failed operation. Retry and other recovery actions remain separate from the disclosure.
 
 <AccordionGroup>

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1355,6 +1355,21 @@ function buildScrollableChatHistory(baseTime: number): unknown[] {
       "Refactored the render guard and reran the suite; all 12 tests pass.",
       workTurnBase + 172_000,
     ),
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "mock-work-yield",
+          name: "yield",
+          arguments: {
+            message:
+              "Waiting for the two visible implementation owners; resume on progress/completion to coordinate shared review and verification.",
+          },
+        },
+      ],
+      timestamp: workTurnBase + 173_000,
+    },
   );
 
   return messages;

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5829,7 +5829,7 @@ export const en: TranslationMap & {
       outputPending: "No output yet.",
       subagentActivity: {
         label: "Subagent activity",
-        working: "Subagent working",
+        running: "Subagent",
         finished: "Subagent finished",
         failed: "Subagent failed",
         cancelled: "Subagent cancelled",

--- a/ui/src/pages/chat/background-tasks.e2e.test.ts
+++ b/ui/src/pages/chat/background-tasks.e2e.test.ts
@@ -654,7 +654,9 @@ suite.define(() => {
         expect(await activity.locator(".chat-diffstat").count()).toBe(0);
         expect(await detailPanel.locator(".chat-diffstat__add").textContent()).toBe("+14");
         expect(await detailPanel.locator(".chat-diffstat__del").textContent()).toBe("-3");
-        expect(await secondRow.textContent()).toContain("Subagent working");
+        expect(await secondRow.locator(".chat-subagent-activity__label").textContent()).toBe(
+          "Subagent",
+        );
         expect(await secondRow.textContent()).toContain("Checking tool card rendering");
         await writeFile(
           path.join(activityDir, "02-one-subagent-finished.png"),

--- a/ui/src/pages/chat/components/chat-subagent-activity.test.ts
+++ b/ui/src/pages/chat/components/chat-subagent-activity.test.ts
@@ -111,6 +111,7 @@ describe("subagent activity rows", () => {
       '[data-subagent-task-id="clickable-subagent"]',
     );
     expect(row?.tagName).toBe("BUTTON");
+    expect(row?.querySelector(".chat-subagent-activity__label")?.textContent).toBe("Subagent");
     expect(row?.getAttribute("aria-label")).toBe("Open subagent details for Map codebase");
     row?.click();
     expect(onOpenTaskDetail).toHaveBeenCalledWith(task);

--- a/ui/src/pages/chat/components/chat-subagent-activity.ts
+++ b/ui/src/pages/chat/components/chat-subagent-activity.ts
@@ -69,7 +69,7 @@ export function deriveSubagentActivity(params: {
 
 function subagentActivityLabel(task: TaskSummary): string {
   if (isActiveTask(task)) {
-    return t("chat.backgroundTasks.subagentActivity.working");
+    return t("chat.backgroundTasks.subagentActivity.running");
   }
   if (task.status === "cancelled") {
     return t("chat.backgroundTasks.subagentActivity.cancelled");

--- a/ui/src/pages/chat/components/chat-tool-cards.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.browser.test.ts
@@ -1,0 +1,56 @@
+import { html, nothing, render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "../../../styles.css";
+import "../../../styles/chat.ts";
+import { renderToolCard } from "./chat-tool-cards.ts";
+
+let container: HTMLDivElement | undefined;
+afterEach(() => {
+  if (container) {
+    render(nothing, container);
+    container.remove();
+    container = undefined;
+  }
+});
+
+describe.runIf("__vitest_browser__" in globalThis)("narrow tool activity rows", () => {
+  it("truncates long progress receipts while keeping short tool labels intact", () => {
+    container = document.body.appendChild(document.createElement("div"));
+    container.style.width = "220px";
+    const step = "Verify the implementation and report the result. ".repeat(12).slice(0, 512);
+    const options = { messageKey: "narrow", expanded: false, onToggleExpanded: vi.fn() };
+    render(
+      html`
+        ${renderToolCard(
+          {
+            id: "receipt",
+            name: "progress_card",
+            args: { plan: [{ step, status: "completed" }] },
+            completed: true,
+          },
+          options,
+        )}
+        ${renderToolCard(
+          { id: "yield", name: "yield", args: { message: step }, completed: true },
+          options,
+        )}
+      `,
+      container,
+    );
+
+    const receipt = container.querySelector<HTMLElement>('[role="status"]')!;
+    const text = receipt.querySelector<HTMLElement>(":scope > span:last-child")!;
+    expect(receipt.textContent).toContain(step);
+    expect(receipt.clientWidth).toBeGreaterThan(0);
+    expect(receipt.scrollWidth).toBe(receipt.clientWidth);
+    expect(container.scrollWidth).toBe(container.clientWidth);
+    expect(text.scrollWidth).toBeGreaterThan(text.clientWidth);
+    expect(getComputedStyle(text).textOverflow).toBe("ellipsis");
+
+    const label = Array.from(
+      container.querySelectorAll<HTMLElement>(".chat-tool-msg-summary__label"),
+    ).find((element) => element.textContent === "Yield")!;
+    expect(label).toBeDefined();
+    expect(label.scrollWidth).toBe(label.clientWidth);
+  });
+});

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -312,7 +312,7 @@ function renderProgressCardReceipt(card: ToolCard, outcome: ToolCardOutcome) {
   return html`<div class="chat-tool-msg-collapse chat-progress-card-receipt">
     <div class="chat-tool-msg-summary chat-tool-row" role="status">
       <span class="chat-tool-msg-summary__icon">${renderToolIcon("listChecks")}</span>
-      <span class="chat-tool-msg-summary__label">${label}</span>
+      <span class="chat-progress-card-receipt__text">${label}</span>
     </div>
   </div>`;
 }

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -759,9 +759,6 @@ openclaw-chat-sidebar-region,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: var(--control-ui-text-sm);
-  font-weight: 550;
-  line-height: 1.25;
 }
 
 /* Live-run indicator: replaces the old status pill for running rows. */

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -759,6 +759,9 @@ openclaw-chat-sidebar-region,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: var(--control-ui-text-sm);
+  font-weight: 550;
+  line-height: 1.25;
 }
 
 /* Live-run indicator: replaces the old status pill for running rows. */

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -70,21 +70,25 @@
 }
 
 .chat-tool-msg-summary,
-.chat-activity-group__summary {
-  --chat-tool-activity-color: color-mix(in srgb, var(--muted) 88%, transparent);
-
+.chat-activity-group__summary,
+.chat-subagent-activity__row,
+.chat-tasks-rail__task-title {
+  font-family: inherit;
   font-size: calc(var(--control-ui-text-sm) + 1px);
   font-weight: 400;
   line-height: 1.5;
+}
+
+.chat-tool-msg-summary,
+.chat-activity-group__summary {
+  --chat-tool-activity-color: color-mix(in srgb, var(--muted) 88%, transparent);
+
   color: var(--chat-tool-activity-color);
 }
 
 .chat-tool-msg-summary :where(span, code, button),
 .chat-activity-group__summary :where(span, code, button) {
-  font-family: inherit;
-  font-size: inherit;
-  font-weight: inherit;
-  line-height: inherit;
+  font: inherit;
   letter-spacing: inherit;
 }
 
@@ -158,7 +162,6 @@
   border: 0;
   background: transparent;
   color: inherit;
-  font: inherit;
   text-decoration: underline;
   text-decoration-color: color-mix(in srgb, currentColor 18%, transparent);
   text-underline-offset: 2px;
@@ -230,32 +233,29 @@
   stroke-linejoin: round;
 }
 
-/* Collapsed rows stay on one line; measured overflow gets a fade while the
-   complete value remains available in the expanded detail. */
+/* Labels stay intact; only the following summary truncates. */
 .chat-tool-msg-summary__label {
-  flex: 0 1 auto;
+  flex: none;
+  white-space: nowrap;
+}
+
+.chat-tool-msg-summary__names,
+.chat-tool-msg-summary__preview,
+.chat-subagent-activity__snippet {
   min-width: 0;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
-  font: inherit;
-  color: inherit;
 }
 
 .chat-tool-msg-summary__names,
 .chat-tool-msg-summary__preview {
-  flex: 0 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  font: inherit;
   color: color-mix(in srgb, var(--muted) 82%, var(--text) 18%);
 }
 
 /* ── Kind-aware tool rows ── */
 .chat-tool-row__prompt {
   flex-shrink: 0;
-  font: inherit;
-  color: inherit;
 }
 
 .chat-tool-row__title {
@@ -263,7 +263,6 @@
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
-  font: inherit;
   color: var(--text);
 }
 
@@ -277,8 +276,6 @@
 
 .chat-tool-row__verb {
   flex-shrink: 0;
-  font: inherit;
-  color: inherit;
 }
 
 .chat-tool-row__target {
@@ -286,8 +283,6 @@
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
-  font: inherit;
-  color: inherit;
 }
 
 .chat-tool-row__detail {
@@ -295,8 +290,6 @@
   min-width: 24px;
   overflow: hidden;
   white-space: nowrap;
-  font: inherit;
-  color: inherit;
 }
 
 .chat-tool-row--running .chat-tool-msg-summary__icon {
@@ -1286,7 +1279,6 @@ openclaw-tooltip.chat-tasks-status__preview {
   gap: 7px;
   min-height: 22px;
   color: var(--muted);
-  font-size: var(--control-ui-text-xs);
 }
 
 .chat-subagent-activity__row--interactive {
@@ -1295,7 +1287,6 @@ openclaw-tooltip.chat-tasks-status__preview {
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  font: inherit;
   text-align: left;
   cursor: var(--cursor-action);
   transition:
@@ -1336,14 +1327,6 @@ openclaw-tooltip.chat-tasks-status__preview {
 
 .chat-subagent-activity__label {
   color: var(--text);
-  font-weight: 600;
-  white-space: nowrap;
-}
-
-.chat-subagent-activity__snippet {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -71,8 +71,7 @@
 
 .chat-tool-msg-summary,
 .chat-activity-group__summary,
-.chat-subagent-activity__row,
-.chat-tasks-rail__task-title {
+.chat-subagent-activity__row {
   font-family: inherit;
   font-size: calc(var(--control-ui-text-sm) + 1px);
   font-weight: 400;

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -240,6 +240,7 @@
 
 .chat-tool-msg-summary__names,
 .chat-tool-msg-summary__preview,
+.chat-progress-card-receipt__text,
 .chat-subagent-activity__snippet {
   min-width: 0;
   overflow: hidden;


### PR DESCRIPTION
## Problem

Collapsed Yield rows clip the tool label when a long waiting message competes for width. Running subagent rows below them also use larger, heavier text and repeat a running state already conveyed by the animated indicator.

## Solution

Make the tool label non-shrinking and give the following summary ellipsis overflow. Consolidate the typography for tool summaries, activity groups, and inline subagents; remove the interactive subagent font reset and redundant descendant font rules. Share the summary/snippet truncation rule. Progress receipts use a separate shrinkable text span so long step descriptions truncate without inheriting the protected short-label rule.

Rename the running subagent translation key and render “Subagent.” Missing locale translations fall back to English until the normal translation refresh; completed, failed, and cancelled wording stays unchanged. Extend the existing mock history with a long Yield call and document the row behavior.

## Impact

Tool labels stay readable, long summaries truncate, and activity rows share one text size and weight. Task details and terminal labels keep their existing behavior. No runtime, protocol, configuration, or storage contract changes.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-tool-cards ui/src/pages/chat/components/chat-subagent-activity`: 128 unit tests plus 1 Chromium regression passed across 7 files. The new rendered-label assertion failed on the original “Subagent working” text.
- `pnpm ui:i18n:baseline`: passed; no baseline changes.
- `git diff --check`: passed.
- Codex autoreview: initial changes passed at the default P0 threshold; the receipt follow-up passed through P2 with no accepted/actionable findings.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/pages/chat/background-tasks.e2e.test.ts -t 'streams two subagent activity rows and retains final diff chips'`: 1 passed; 3 unrelated cases excluded by the filter.
- `node scripts/check-changed.mjs`: passed (exit 0), including core-test/UI/script typechecks, i18n, dead-export scans, UI styles, and lint. The separately updated E2E assertion also passed targeted formatting and oxlint.
- Chromium mock UI at 1100×720, scale 2, light theme: Yield label grows from 28px for 30px of text to its full 30px; summary overflow changes from clip to ellipsis; subagent labels change from 14px/600 to the tool row’s 13px/400.
- Production LOC: +38 −40 (net −2), including 15 mock-fixture lines; funded by consolidating nearby typography and truncation rules. Counts exclude tests and docs and use the branch merge base, since main advanced independently.

The Chromium regression renders a 512-byte receipt step and a Yield row in a 220px container. It failed before the receipt fix with 3141px of scrollable receipt content, and now proves bounded receipt overflow, ellipsis, and an intact short tool label.

| Before | After |
| --- | --- |
| ![Clipped Yield label and mismatched subagent text](https://github.com/user-attachments/assets/bb09af20-286f-497f-b394-ce82b60d5921) | ![Intact Yield label, ellipsis, and consistent Subagent rows](https://github.com/user-attachments/assets/beeff413-7ccd-4321-9169-916b15af265f) |
| ![Long progress receipt overflows a 220px row](https://github.com/user-attachments/assets/ea2bd870-8153-4ddb-b941-ee86acab833a) | ![Long receipt truncates while Yield stays intact](https://github.com/user-attachments/assets/1f5999a0-ad3b-46a6-ada2-88f325b99017) |

Release-note: Keep tool labels visible, truncate long progress receipts, unify transcript activity typography, and simplify running subagent labels.
