### PR TITLE
fix(ui): keep resized Review tool cards within transcript bounds

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -1109,6 +1109,9 @@ Messages forwarded by `sessions_send` render as left-aligned speech bubbles with
 
 ## Chat message width
 
+Drag the side-panel divider to resize a task's **Review** transcript. Messages
+and expanded tool input reflow within the panel, keeping tool-card borders visible.
+
 Wide-monitor users can override the transcript width under **Settings → Chat →
 Message width**. The preference stays in that browser's local storage. Supported
 forms include plain lengths and percentages such as `960px` or `82%`, plus

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -385,6 +385,9 @@ function activityAlignmentHtml() {
   return `
     <div class="chat-thread" role="log">
       <div class="chat-thread-inner">
+        <div class="chat-group tool">
+          <div class="chat-group-messages" data-tool-column-reference>Inspecting the available tools.</div>
+        </div>
         <div class="chat-group tool chat-group--activity chat-group--with-footer">
           <div class="chat-group-messages">
             <div class="chat-activity-group is-open">
@@ -1579,10 +1582,10 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       const activityGroup = await getRect(page, ".chat-activity-group");
       const activitySummary = await getRect(page, ".chat-activity-group__summary");
       const failedSummary = await getRect(page, "[data-failed-call-row]");
-      const thread = await getRect(page, ".chat-thread-inner");
+      const toolColumn = await getRect(page, "[data-tool-column-reference]");
       expect(activitySummary.width).toBeLessThan(activityGroup.width);
       expect(failedSummary.width).toBeLessThan(activityGroup.width);
-      expect(activityGroup.left - thread.left).toBeCloseTo(51, 0);
+      expect(activityGroup.left).toBeCloseTo(toolColumn.left, 0);
       const styles = await page.evaluate(() => {
         const activity = document.querySelector<HTMLElement>(".chat-activity-group__summary")!;
         const label = activity.querySelector<HTMLElement>(".chat-activity-group__label")!;

--- a/ui/src/pages/chat/components/chat-sidebar-scroll.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-scroll.browser.test.ts
@@ -27,7 +27,7 @@ class ReadOnlyTranscriptFixture extends LitElement {
           id: "schema-call",
           name: "exec",
           arguments: {
-            code: 'const schemas = await tools.describe({ names: ["example.search", "example.read", "example.describe"] });',
+            code: `const schemas=await tools.describe({names:["example.search"]});text(schemas);const marker="${"x".repeat(510)}";`,
             description: "Get live tool schemas",
           },
         },
@@ -113,13 +113,21 @@ describe.runIf(browserMode)("chat sidebar layout", () => {
         const row = body.closest<HTMLElement>(".chat-virtual-row")!;
         const narrow = bubble.getBoundingClientRect();
         const narrowToolWidth = body.getBoundingClientRect().width;
-        for (const width of [300, 600]) {
+        for (const width of [300, 400, 600, 700]) {
           container.style.width = `${width}px`;
           await new Promise(requestAnimationFrame);
-          const bounds = body.getBoundingClientRect();
           const clip = row.getBoundingClientRect();
-          expect(bounds.left).toBeGreaterThanOrEqual(clip.left);
-          expect(bounds.right).toBeLessThanOrEqual(clip.right);
+          for (const selector of [
+            ".chat-tool-msg-body",
+            ".chat-tool-msg-summary",
+            ".chat-tool-card__block-content",
+            ".chat-tool-card__outcome",
+          ]) {
+            const bounds = panel.querySelector(selector)!.getBoundingClientRect();
+            expect(bounds.left).toBeGreaterThanOrEqual(clip.left);
+            expect(bounds.right).toBeLessThanOrEqual(clip.right);
+          }
+          expect(body.scrollWidth).toBeLessThanOrEqual(body.clientWidth);
         }
         const wide = bubble.getBoundingClientRect();
         expect(wide.width).toBeGreaterThan(narrow.width + 150);

--- a/ui/src/pages/chat/components/chat-sidebar-scroll.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-scroll.browser.test.ts
@@ -1,11 +1,71 @@
+import { html, LitElement } from "lit";
 import { describe, expect, it } from "vitest";
 import "../../../styles.css";
 import "../../../styles/chat.ts";
 import "../../../styles/chat/side-panel.css";
+import { renderReadOnlyTranscript } from "./chat-read-only-transcript.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
 import "./chat-sidebar.ts";
+import { ChatTranscriptController } from "./chat-transcript-controller.ts";
+import { threadProps } from "./chat-transcript.test-support.ts";
 
 const browserMode = "__vitest_browser__" in globalThis;
+
+class ReadOnlyTranscriptFixture extends LitElement {
+  private readonly transcript = new ChatTranscriptController(this);
+  private readonly messages = [
+    {
+      role: "user",
+      content:
+        "Inspect the available tools and report their input schemas, including required parameters and optional fields, so the review can confirm that the next step uses the correct tool contract.",
+    },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "schema-call",
+          name: "exec",
+          arguments: {
+            code: 'const schemas = await tools.describe({ names: ["example.search", "example.read", "example.describe"] });',
+            description: "Get live tool schemas",
+          },
+        },
+      ],
+    },
+    {
+      role: "toolResult",
+      toolCallId: "schema-call",
+      toolName: "exec",
+      content: [{ type: "text", text: "Schemas ready." }],
+    },
+  ];
+
+  protected override createRenderRoot() {
+    return this;
+  }
+
+  protected override render() {
+    return html`<div class="sidebar-content chat-task-detail__content">
+      <div class="chat-task-detail__transcript">
+        ${renderReadOnlyTranscript({
+          chat: {
+            ...threadProps("sidebar-resize"),
+            showToolCalls: true,
+            autoExpandToolCalls: true,
+            onRequestUpdate: () => this.requestUpdate(),
+          },
+          paneId: "sidebar-resize",
+          sessionKey: "agent:main:sidebar-resize",
+          transcript: this.transcript,
+          messages: this.messages,
+        })}
+      </div>
+    </div>`;
+  }
+}
+
+customElements.define("test-sidebar-resize-transcript", ReadOnlyTranscriptFixture);
 
 type DetailPanel = HTMLElement & {
   content: SidebarContent;
@@ -33,6 +93,44 @@ function mountDetailPanel(content: SidebarContent): {
 }
 
 describe.runIf(browserMode)("chat sidebar layout", () => {
+  it.each(["ltr", "rtl"])(
+    "reflows task messages without clipping tool borders in %s",
+    async (dir) => {
+      const container = document.createElement("div");
+      container.className = "side-panel__panel";
+      container.dir = dir;
+      container.style.cssText = "width:300px;height:600px;";
+      const panel = new ReadOnlyTranscriptFixture();
+      panel.className = "sidebar-panel chat-task-detail";
+      container.append(panel);
+      document.body.append(container);
+
+      try {
+        await panel.updateComplete;
+        await expect.poll(() => panel.querySelector(".chat-tool-msg-body")).not.toBeNull();
+        const bubble = panel.querySelector<HTMLElement>(".user .chat-bubble")!;
+        const body = panel.querySelector<HTMLElement>(".chat-tool-msg-body")!;
+        const row = body.closest<HTMLElement>(".chat-virtual-row")!;
+        const narrow = bubble.getBoundingClientRect();
+        const narrowToolWidth = body.getBoundingClientRect().width;
+        for (const width of [300, 600]) {
+          container.style.width = `${width}px`;
+          await new Promise(requestAnimationFrame);
+          const bounds = body.getBoundingClientRect();
+          const clip = row.getBoundingClientRect();
+          expect(bounds.left).toBeGreaterThanOrEqual(clip.left);
+          expect(bounds.right).toBeLessThanOrEqual(clip.right);
+        }
+        const wide = bubble.getBoundingClientRect();
+        expect(wide.width).toBeGreaterThan(narrow.width + 150);
+        expect(wide.height).toBeLessThan(narrow.height);
+        expect(body.getBoundingClientRect().width).toBeGreaterThan(narrowToolWidth + 290);
+      } finally {
+        container.remove();
+      }
+    },
+  );
+
   it("keeps long markdown scrollable inside a bounded sidebar", async () => {
     const { panel, release } = mountDetailPanel({
       kind: "markdown",

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -149,11 +149,6 @@
   display: block;
 }
 
-.chat-group.tool.chat-group--with-footer > .chat-group-messages {
-  max-width: var(--chat-message-column-max);
-  margin-inline-start: 1px;
-}
-
 .chat-group.user .chat-group-footer {
   justify-content: flex-end;
 }

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -149,6 +149,10 @@
   display: block;
 }
 
+.chat-group.tool.chat-group--with-footer > .chat-group-messages {
+  max-width: var(--chat-message-column-max);
+}
+
 .chat-group.user .chat-group-footer {
   justify-content: flex-end;
 }


### PR DESCRIPTION
## Problem

Resizing the task Review panel could leave the trailing border of an expanded TOOL INPUT card clipped. The full-width tool message column had a 1px inline margin, so its bordered body extended beyond the virtual row's paint-containment boundary. The original LTR and RTL cases fail on opposite edges by exactly 1px.

The report also described intrinsic-width expansion from a very long single-line exec input. A follow-up mock reproduction used a 603-character JavaScript line with a 510-character unbroken suffix at actual panel widths of 400px and 700px. That input wraps with both original and fixed CSS; only the border clip reproduced. This PR does not claim a separate intrinsic-overflow root cause or a stale resize-state fix.

## Solution

Remove only the optical 1px margin from the tool message column. Retain its existing maximum-width guard: it overrides the footer layout's `max-width: none` and is not redundant. The existing input block already has `min-width: 0`, `white-space: pre-wrap`, and `overflow-wrap: anywhere`; the resize handler and transcript observers remain unchanged.

Extend the real-renderer browser regression with the long single-line input at 300, 400, 600, and 700px in LTR and RTL. Check the bordered body, tool-row header, input block, and Completed footer against the virtual-row bounds, and reject horizontal overflow of the outer card body. Keep user-bubble and tool-body reflow checks. Existing responsive tests now compare activity alignment against a standard tool column rather than encoding the defective 51px offset.

## Impact

Expanded tool cards keep their full border as Review panels resize. The long-line proof confirms that the card, header, and Completed footer stay within bounds while the code wraps. At 700px, the card is 682px wide and the input block is 658px wide with `scrollWidth === clientWidth`.

No configuration, persistence, dependency, or compatibility changes. The separately reported larger overflow still needs the exact failing input or deployed-build detail to reproduce.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/sidebar-layout ui/src/pages/chat/chat-pane-board ui/src/pages/chat/components/chat-sidebar-scroll.browser.test.ts ui/src/pages/chat/chat-responsive.browser.test.ts`: 188 passed across 3 shards, including all 122 responsive browser cases.
- Original-CSS regression: 2 directional containment failures (`293 > 292`, `7 < 8`); fixed CSS: all 4 sidebar browser tests pass with the long-line fixture.
- The 3 responsive alignment cases fail against original CSS (`51` versus the standard column's `50`) and pass with the fixed CSS.
- `node .artifacts/sidebar-reflow/long-line.mjs`: passed at exact 400px and 700px panel widths, including body/header/footer/input containment and wrapping. Viewport 1280×720, light mode, scale 2, navigation sidebar collapsed so the panel's 60% fit limit permits an actual 700px width.
- `node scripts/check-changed.mjs`: passed (exit 0), including typechecking, formatting, i18n, export scans, and lint.
- `git diff --check`: passed.
- Fresh Codex autoreview with default engine, model, and priority over the complete patch: `scoped-clean`, no accepted/actionable findings.
- Production LOC: **+0 −1**. Only the overflowing margin is removed; the existing width guard is retained. Tests and docs are counted separately.

| Panel width | Before | After |
| --- | --- | --- |
| 300px | ![Before: narrow Review tool border clipped](https://github.com/user-attachments/assets/c4f0a59b-5e93-4b95-9a8f-9458748cc0ea) | ![After: narrow Review tool border visible](https://github.com/user-attachments/assets/aad13321-e28e-47df-9262-a172bf738398) |
| 600px | ![Before: widened Review tool border clipped](https://github.com/user-attachments/assets/bd61e106-d7a6-4cb2-8018-9201a2201f2a) | ![After: widened Review tool border visible](https://github.com/user-attachments/assets/433ba34c-586f-4beb-aad1-595b161e45cf) |
| 700px, 603-character single-line input | ![Original CSS: long input wraps but trailing border is clipped](https://github.com/user-attachments/assets/ec0a20ef-792a-4d61-9a96-659635ccc6ac) | ![Fixed CSS: long input wraps and full card stays inside the panel](https://github.com/user-attachments/assets/a91dc19f-5109-47a3-b81b-4976bdb837fc) |

The first CI run failed two shards on the old 51px alignment assertions; the responsive-test follow-up fixed both. A later run hit an unrelated Matrix dependency download reset and alternating failures in untouched dashboard/browser-route E2E cases. Those were recorded and left outside this patch. Latest exact head `abd9025bcdcaf3a0ff90ff9787237e11548869a4`: [CI run 33992534323](https://github.com/openclaw/openclaw/actions/runs/33992534323) completed successfully. All three UI shards, all eight UI E2E lanes, and the remaining CI jobs passed or were intentionally skipped. No rebase or merge was performed.

Release-note: Keep expanded tool-card borders within resized Review transcripts and protect long tool-input reflow.
