### PR TITLE
fix(cron): retain run-owned pricing through finalization

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -292,6 +292,8 @@ Model-selection precedence for isolated jobs, highest first:
 
 Fast mode follows the resolved live selection. Isolated automation resolves it in this order: stored session `fastMode`, per-agent `agents.entries.*.fastModeDefault`, global `agents.defaults.fastModeDefault`, then selected-model `params.fastMode`. Auto mode uses the model's `params.fastAutoOnSeconds` cutoff, defaulting to 60 seconds.
 
+When a runtime reports token usage without a cost, automation estimates use the selected agent's local `models.json` prices and the model metadata retained for that run.
+
 If a run hits a live model-switch handoff, the scheduler retries with the switched provider/model and persists that selection (and any new auth profile) for the active run. Retries are bounded: after the initial attempt plus 2 switch retries, the scheduler aborts instead of looping.
 
 Before an isolated run starts, OpenClaw checks reachable local endpoints for configured `api: "ollama"` and `api: "openai-completions"` providers whose `baseUrl` is loopback, private-network, or `.local`. This preflight walks the job's configured fallback chain and only marks the run `skipped` once every candidate is unreachable; `--fallbacks ""` keeps that walk strict to just the primary model. A down endpoint records the run as `skipped` with a clear error instead of starting a model call. The result is cached for 5 minutes per endpoint (not per job or model), so many due jobs sharing a dead local Ollama/vLLM/SGLang/LM Studio server cost one probe instead of a request storm. Skipped preflight runs do not increment execution-error backoff; set `failureAlert.includeSkipped` to opt into repeated skip alerts.

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -229,6 +229,7 @@ export async function finalizeCronRun(params: {
       provider: providerUsed,
       model: modelUsed,
       config: prepared.cfgWithAgentDefaults,
+      agentDir: prepared.agentDir,
     });
     if (hasBillableUsage(usage)) {
       // Monetary facts do not establish token/context counters; unknown cost clears old dollars.

--- a/src/cron/isolated-agent/run.plugin-generation.test.ts
+++ b/src/cron/isolated-agent/run.plugin-generation.test.ts
@@ -1,14 +1,19 @@
 // Proves isolated cron/hook runs carry the published Gateway plugin generation
 // into embedded execution instead of rebuilding metadata per run (#125596 family).
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   getPreparedModelRuntimePluginGeneration,
   getPreparedModelRuntimeBorrowedSnapshot,
 } from "../../agents/prepared-model-runtime-generation-scope.js";
 import type { PreparedModelRuntimePluginGeneration } from "../../agents/prepared-model-runtime.types.js";
 import { createPluginMetadataSnapshot } from "../../config/plugin-auto-enable.test-helpers.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
 import { makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
@@ -19,6 +24,8 @@ import {
   loadPublishedReplyDispatchRuntimeMock,
   loadModelCatalogOwnerMock,
   resolveAgentConfigMock,
+  makeCronSession,
+  resolveCronSessionMock,
 } from "./run.test-harness.js";
 
 const preparedRuntimeMocks = {
@@ -31,6 +38,7 @@ const { PreparedModelRuntimeOwnerNotPublishedError } = await vi.importActual<
 >("../../agents/prepared-model-runtime.errors.js");
 
 const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("runCronIsolatedAgentTurn plugin generation carry", () => {
   setupRunCronIsolatedAgentTurnSuite();
@@ -141,6 +149,68 @@ describe("runCronIsolatedAgentTurn plugin generation carry", () => {
     expect(embeddedRunGeneration).toBeDefined();
   });
 
+  it("keeps the execution owner's model pricing through finalization", async () => {
+    const config = {
+      models: {
+        providers: {
+          fixture: {
+            baseUrl: "https://fixture.invalid/v1",
+            models: [
+              {
+                id: "alias",
+                name: "Alias",
+                cost: { input: 3, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    };
+    const snapshot = (model: string) =>
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "fixture",
+            providers: ["fixture"],
+            modelIdNormalization: { providers: { fixture: { aliases: { alias: model } } } },
+          },
+        ],
+      });
+    const selected = snapshot("selected");
+    const ambient = snapshot("other");
+    const cronSession = makeCronSession();
+    resolveCronSessionMock.mockReturnValue(cronSession);
+    acquirePreparedModelRuntimeMock.mockImplementation(async (input) => ({
+      snapshot: {
+        ...input,
+        metadataSnapshot: selected,
+        pluginRegistry: createEmptyPluginRegistry(),
+      },
+      pluginGeneration: {
+        pluginMetadataSnapshot: selected,
+        configuredCatalogEntries: [],
+        inlineProviderModels: [],
+      },
+      release: vi.fn(),
+    }));
+    mockRunCronFallbackPassthrough();
+    runEmbeddedAgentMock.mockResolvedValue({
+      payloads: [{ text: "done" }],
+      meta: {
+        agentMeta: {
+          provider: "fixture",
+          model: "selected",
+          usage: { input: 1_000_000, output: 0 },
+        },
+      },
+    });
+    const result = await withPluginRuntimeGenerationScope({ metadataSnapshot: ambient }, () =>
+      runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture({ cfg: config })),
+    );
+    expect(result.status).toBe("ok");
+    expect(cronSession.sessionEntry.estimatedCostUsd).toBe(3);
+  });
+
   it("rejects preparation when the published owner is unavailable", async () => {
     preparedRuntimeMocks.loadDispatchRuntime.mockRejectedValue(
       new PreparedModelRuntimeOwnerNotPublishedError("owner not published"),
@@ -150,6 +220,56 @@ describe("runCronIsolatedAgentTurn plugin generation carry", () => {
       "owner not published",
     );
     expect(preparedRuntimeMocks.acquireRuntime).not.toHaveBeenCalled();
+  });
+
+  it("estimates token-only usage from the selected agent's local model prices", async () => {
+    const root = tempDirs.make("cron-owner-pricing-");
+    const agentDir = path.join(root, "worker");
+    const mainDir = path.join(root, "main");
+    for (const [dir, input] of [
+      [agentDir, 3],
+      [mainDir, 1],
+    ] as const) {
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+        path.join(dir, "models.json"),
+        JSON.stringify({
+          providers: {
+            fixture: {
+              models: [{ id: "priced", cost: { input, output: 0, cacheRead: 0, cacheWrite: 0 } }],
+            },
+          },
+        }),
+      );
+    }
+    const config = {
+      agents: {
+        ownership: "explicit" as const,
+        entries: { main: { agentDir: mainDir }, worker: { agentDir } },
+      },
+    };
+    loadModelCatalogOwnerMock.mockResolvedValue({
+      config,
+      agentId: "worker",
+      agentDir,
+      workspaceDir: root,
+      metadataSnapshot: createPluginMetadataSnapshotFixture(),
+      modelCatalog: { entries: [], routeVariants: [] },
+    });
+    const cronSession = makeCronSession();
+    resolveCronSessionMock.mockReturnValue(cronSession);
+    mockRunCronFallbackPassthrough();
+    runEmbeddedAgentMock.mockResolvedValue({
+      payloads: [{ text: "done" }],
+      meta: {
+        agentMeta: { provider: "fixture", model: "priced", usage: { input: 1_000_000, output: 0 } },
+      },
+    });
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({ cfg: config, agentId: "worker" }),
+    );
+    expect(result.status).toBe("ok");
+    expect(cronSession.sessionEntry.estimatedCostUsd).toBe(3);
   });
 
   it("releases the prepared lease when continuation initialization fails", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,6 +1,5 @@
 import { retireSessionMcpRuntime } from "../../agents/agent-bundle-mcp-tools.js";
 import { withPreparedModelRuntimePluginGenerationScope } from "../../agents/prepared-model-runtime-generation-scope.js";
-import type { PreparedModelRuntimeLease } from "../../agents/prepared-model-runtime.types.js";
 import {
   createAgentRunRestartAbortError,
   resolveAgentRunErrorLifecycleFields,
@@ -44,10 +43,6 @@ import type { RunCronAgentTurnResult } from "./run.types.js";
 import { cleanupCronRunSessionAfterRun } from "./session-cleanup.js";
 
 const cronExecutorRuntimeLoader = createLazyImportLoader(() => import("./run-executor.runtime.js"));
-
-function isCronNestedLaneTaskTimeoutError(err: unknown): boolean {
-  return isCommandLaneTaskTimeoutError(err, CommandLane.CronNested);
-}
 
 /**
  * Release runtime references held by a completed isolated cron run.
@@ -118,300 +113,296 @@ export async function runCronIsolatedAgentTurn(
   if (!prepared.ok) {
     return { ...prepared.result, admissionDisposition: "rejected" };
   }
-  let preparedRuntimeLease: PreparedModelRuntimeLease | undefined =
-    prepared.context.preparedModelRuntimeLease;
-  const releasePreparedRuntime = () => {
-    preparedRuntimeLease?.release();
-    preparedRuntimeLease = undefined;
-  };
-  // Capture the stable run id before execution can rotate its persisted session.
-  const initialSessionId = prepared.context.cronSession.sessionEntry.sessionId;
-  const ownsRunContext = params.job.sessionTarget === "isolated";
-  let runContextOwnerToken: string | undefined;
-  let runLifecycleGeneration = admittedLifecycleGeneration;
-  let executionStarted = false;
-  const notifyExecutionStarted = (info?: {
-    lifecycleGeneration?: string;
-    isFallback?: boolean;
-    provider?: string;
-    model?: string;
-  }) => {
-    executionStarted = true;
-    if (info?.lifecycleGeneration) {
-      runLifecycleGeneration = info.lifecycleGeneration;
-    }
-    params.onExecutionStarted?.({
-      jobId: params.job.id,
-      agentId: prepared.context.agentId,
-      sessionId: prepared.context.currentRunSessionId(),
-      sessionKey: prepared.context.runSessionKey,
-      ...(info?.isFallback === true ? { isFallback: true } : {}),
-      phase: "runner_entered",
-      provider: info?.provider ?? prepared.context.liveSelection.provider,
-      model: info?.model ?? prepared.context.liveSelection.model,
-    });
-  };
-  const notifyExecutionPhase = (
-    info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
-      Partial<Omit<CronAgentExecutionPhaseUpdate, "jobId" | "phase">>,
-  ) => {
-    params.onExecutionPhase?.({
-      jobId: params.job.id,
-      agentId: prepared.context.agentId,
-      sessionId: prepared.context.currentRunSessionId(),
-      sessionKey: prepared.context.runSessionKey,
-      provider: prepared.context.liveSelection.provider,
-      model: prepared.context.liveSelection.model,
-      ...info,
-    });
-  };
-
-  const turnStartedAtMs = Date.now();
-  const messageLifecycle = (() => {
-    try {
-      const lifecycle = createDiagnosticMessageLifecycle({
-        enabled: isDiagnosticsEnabled(params.cfg),
-        sessionId: prepared.context.runSessionId,
-        sessionKey: prepared.context.runSessionKey,
-        channel: "cron",
-        source: "cron-isolated",
-        startedAtMs: turnStartedAtMs,
-        trackSessionState: true,
-      });
-      lifecycle.markProcessing();
-      return lifecycle;
-    } catch (error) {
-      releasePreparedRuntime();
-      prepared.context.sessionWorkAdmission.release();
-      throw error;
-    }
-  })();
-
-  let outcome: "completed" | "error" = "completed";
-  let outcomeError: string | undefined;
-  let cronRunSessionCleanupHandled = false;
-  // The execution owner spans fallback and interim-ack retries. Individual
-  // attempts must not retire the shared run before that execution settles.
-  const lifecycle = createAgentLifecycleTerminalBackstop({
-    runId: initialSessionId,
-    sessionKey: prepared.context.runSessionKey,
-    startedAt: turnStartedAtMs,
-    getLifecycleGeneration: () => runLifecycleGeneration,
-    resolveTerminationFields: (error) => resolveAgentRunErrorLifecycleFields(error, abortSignal),
-  });
+  const preparedRuntimeLease = prepared.context.preparedModelRuntimeLease;
+  let leaseActive = true;
+  // Accounting, delivery, and teardown use the same metadata as inference. Keep
+  // the lease open until cleanup finishes, then fence detached borrowed work.
   try {
-    assertAgentRunLifecycleGenerationCurrent(runLifecycleGeneration);
-    const existingRunContext = getAgentRunContext(initialSessionId);
-    runContextOwnerToken = claimAgentRunContext(
-      initialSessionId,
-      {
-        sessionKey:
-          ownsRunContext || !existingRunContext?.sessionKey
-            ? prepared.context.runSessionKey
-            : existingRunContext.sessionKey,
-        sessionId: initialSessionId,
-        lifecycleGeneration: runLifecycleGeneration,
-        cronRunsByJobId: new Map([
-          [params.job.id, { pacingEnabled: params.job.pacing !== undefined }],
-        ]),
-      },
-      {
-        trackOwner: true,
-        ownsContext: ownsRunContext,
-      },
-    );
-    const { executeCronRun } = await cronExecutorRuntimeLoader.load();
-    const executionParams: Parameters<typeof executeCronRun>[0] = {
-      cfg: params.cfg,
-      cfgWithAgentDefaults: prepared.context.cfgWithAgentDefaults,
-      job: params.job,
-      agentId: prepared.context.agentId,
-      agentDir: prepared.context.agentDir,
-      agentSessionKey: prepared.context.agentSessionKey,
-      runSessionKey: prepared.context.runSessionKey,
-      usesDetachedRunSession: prepared.context.usesDetachedRunSession,
-      workspaceDir: prepared.context.workspaceDir,
-      executionRoot: prepared.context.executionRoot,
-      lane: params.lane,
-      resolvedDelivery: {
-        channel: prepared.context.resolvedDelivery.channel,
-        to: prepared.context.resolvedDelivery.to,
-        accountId: prepared.context.resolvedDelivery.accountId,
-        threadId: prepared.context.resolvedDelivery.threadId,
-      },
-      resolvedDeliveryOk: prepared.context.resolvedDelivery.ok,
-      deliveryRequested: prepared.context.deliveryRequested,
-      sourceDelivery: prepared.context.sourceDelivery,
-      skillsSnapshot: prepared.context.skillsSnapshot,
-      agentPayload: prepared.context.agentPayload,
-      useSubagentFallbacks: prepared.context.useSubagentFallbacks,
-      inheritDefaultFallbacksForAgentStringModel:
-        prepared.context.inheritDefaultFallbacksForAgentStringModel,
-      modelFallbacksOverride: prepared.context.modelFallbacksOverride,
-      agentVerboseDefault: prepared.context.agentCfg?.verboseDefault,
-      liveSelection: prepared.context.liveSelection,
-      cronSession: prepared.context.cronSession,
-      commandBody: prepared.context.commandBody,
-      persistSessionEntry: prepared.context.persistSessionEntry,
-      persistRunContinuationSession: prepared.context.runContinuationSession?.sync,
-      setRunContinuationCliExecutionProvider:
-        prepared.context.runContinuationSession?.setCliExecutionProvider,
-      abortSignal,
-      lifecycle,
-      onExecutionStarted: notifyExecutionStarted,
-      onExecutionPhase: notifyExecutionPhase,
-      onLaneWait: params.onLaneWait,
-      abortReason,
-      isAborted,
-      immutableThinkLevel: prepared.context.thinkingSelection.immutableThinkLevel,
-      thinkingCatalog: prepared.context.thinkingSelection.catalog,
-      loadThinkingCatalog: prepared.context.thinkingSelection.loadThinkingCatalog,
-      timeoutMs: prepared.context.timeoutMs,
-      runTimeoutOverrideMs: prepared.context.runTimeoutOverrideMs,
-      suppressExecNotifyOnExit: prepared.context.suppressExecNotifyOnExit,
-      pluginRegistry: prepared.context.pluginRegistry,
-      executionIdentity: params.executionIdentity,
-    };
-    const runExecutionWithAdmission = () =>
-      prepared.context.sessionWorkAdmission.run(() =>
-        withAgentRunLifecycleGeneration(runLifecycleGeneration, () =>
-          withPluginRuntimeGenerationScope(
-            prepared.context.preparedModelRuntimeLease.snapshot,
-            () => executeCronRun(executionParams),
-          ),
-        ),
-      );
-    let execution: Awaited<ReturnType<typeof runExecutionWithAdmission>>;
-    try {
-      execution = await withPreparedModelRuntimePluginGenerationScope(
-        prepared.context.preparedModelRuntimeLease.pluginGeneration,
-        runExecutionWithAdmission,
-        () => preparedRuntimeLease?.snapshot,
-      );
-    } finally {
-      releasePreparedRuntime();
-    }
-    // Publish the execution fact captured before bookkeeping; cron persistence
-    // and delivery retain their separate workflow outcome.
-    lifecycle.emit("end", execution.runResult);
-    const finalized = await finalizeCronRun({
-      prepared: prepared.context,
-      execution,
-      abortReason,
-      isAborted,
-      markCronRunSessionCleanupHandled: () => {
-        cronRunSessionCleanupHandled = true;
-      },
-      // Self-deleting sessions must release before their own lifecycle mutation.
-      // Other runs retain admission through delivery and release in finally.
-      beforeSessionDelete: prepared.context.sessionWorkAdmission.release,
-    });
-    if (finalized.status === "error") {
-      outcome = "error";
-      outcomeError = finalized.error;
-    }
-    const delayMs = consumeCronNextCheckProposal(initialSessionId, params.job.id);
-    return finalized.status !== "ok" || delayMs === undefined
-      ? finalized
-      : { ...finalized, nextCheck: { delayMs } };
-  } catch (err) {
-    lifecycle.emit("error", err);
-    consumeCronNextCheckProposal(initialSessionId, params.job.id);
-    const isCronLaneTimeout = isAborted() || isCronNestedLaneTaskTimeoutError(err);
-    const error = isCronLaneTimeout ? abortReason() : normalizeCronRunErrorText(err);
-    outcome = "error";
-    outcomeError = error;
-    const admissionDisposition =
-      err instanceof CronSessionLifecycleClaimError
-        ? err.admissionDisposition
-        : err instanceof CronExecutionRootRuntimeError || !executionStarted
-          ? "rejected"
-          : undefined;
-    return prepared.context.withRunSession({
-      status: "error",
-      error,
-      executionStarted,
-      ...(admissionDisposition ? { admissionDisposition } : {}),
-      // Carry the already-resolved run model into the error/timeout row so
-      // Task-run history keeps provider/model attribution instead of looking like
-      // an un-attributed cron timeout. finalizeCronRun does the same via
-      // telemetry on the aborted path; this catch never reaches it.
-      provider: prepared.context.liveSelection.provider,
-      model: prepared.context.liveSelection.model,
-      diagnostics: mergeCronRunDiagnostics(
-        prepared.context.preflightDiagnostics,
-        createCronRunDiagnosticsFromError(
-          isCronLaneTimeout ? "cron-setup" : "agent-run",
-          isCronLaneTimeout ? error : err,
-        ),
-      ),
-    });
-  } finally {
-    releasePreparedRuntime();
-    try {
-      await prepared.context.runContinuationSession?.seal();
-    } catch (sealError) {
-      logWarn(
-        `[cron:${params.job.id}] Failed to seal run continuation during cleanup: ${String(sealError)}`,
-      );
-    }
-    // Final lifecycle events use the adopted run session when the agent persisted one.
-    const finalSessionRef = {
-      sessionId: prepared.context.currentRunSessionId(),
-      sessionKey: prepared.context.runSessionKey,
-    };
-    try {
-      messageLifecycle.markIdle(undefined, finalSessionRef);
-      messageLifecycle.markProcessed(outcome, {
-        ...finalSessionRef,
-        error: outcomeError,
-      });
-    } finally {
-      try {
-        if (!cronRunSessionCleanupHandled) {
-          await cleanupCronRunSessionAfterRun({
-            job: params.job,
-            agentSessionKey: prepared.context.agentSessionKey,
-            sessionId: prepared.context.currentRunSessionId(),
-            lifecycleRevision: prepared.context.cronSession.lifecycleRevision,
-            sessionUpdatedAt: prepared.context.cronSession.sessionEntry.updatedAt,
-            beforeDelete: prepared.context.sessionWorkAdmission.release,
-            reason: "cron-delete-after-run-finally",
+    return await withPreparedModelRuntimePluginGenerationScope(
+      preparedRuntimeLease.pluginGeneration,
+      () =>
+        withPluginRuntimeGenerationScope(preparedRuntimeLease.snapshot, async () => {
+          // Capture the stable run id before execution can rotate its persisted session.
+          const initialSessionId = prepared.context.cronSession.sessionEntry.sessionId;
+          const ownsRunContext = params.job.sessionTarget === "isolated";
+          let runContextOwnerToken: string | undefined;
+          let runLifecycleGeneration = admittedLifecycleGeneration;
+          let executionStarted = false;
+          const notifyExecutionStarted = (info?: {
+            lifecycleGeneration?: string;
+            isFallback?: boolean;
+            provider?: string;
+            model?: string;
+          }) => {
+            executionStarted = true;
+            if (info?.lifecycleGeneration) {
+              runLifecycleGeneration = info.lifecycleGeneration;
+            }
+            params.onExecutionStarted?.({
+              jobId: params.job.id,
+              agentId: prepared.context.agentId,
+              sessionId: prepared.context.currentRunSessionId(),
+              sessionKey: prepared.context.runSessionKey,
+              ...(info?.isFallback === true ? { isFallback: true } : {}),
+              phase: "runner_entered",
+              provider: info?.provider ?? prepared.context.liveSelection.provider,
+              model: info?.model ?? prepared.context.liveSelection.model,
+            });
+          };
+          const notifyExecutionPhase = (
+            info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
+              Partial<Omit<CronAgentExecutionPhaseUpdate, "jobId" | "phase">>,
+          ) => {
+            params.onExecutionPhase?.({
+              jobId: params.job.id,
+              agentId: prepared.context.agentId,
+              sessionId: prepared.context.currentRunSessionId(),
+              sessionKey: prepared.context.runSessionKey,
+              provider: prepared.context.liveSelection.provider,
+              model: prepared.context.liveSelection.model,
+              ...info,
+            });
+          };
+
+          const turnStartedAtMs = Date.now();
+          const messageLifecycle = (() => {
+            try {
+              const lifecycle = createDiagnosticMessageLifecycle({
+                enabled: isDiagnosticsEnabled(params.cfg),
+                sessionId: prepared.context.runSessionId,
+                sessionKey: prepared.context.runSessionKey,
+                channel: "cron",
+                source: "cron-isolated",
+                startedAtMs: turnStartedAtMs,
+                trackSessionState: true,
+              });
+              lifecycle.markProcessing();
+              return lifecycle;
+            } catch (error) {
+              prepared.context.sessionWorkAdmission.release();
+              throw error;
+            }
+          })();
+
+          let outcome: "completed" | "error" = "completed";
+          let outcomeError: string | undefined;
+          let cronRunSessionCleanupHandled = false;
+          // The execution owner spans fallback and interim-ack retries. Individual
+          // attempts must not retire the shared run before that execution settles.
+          const lifecycle = createAgentLifecycleTerminalBackstop({
+            runId: initialSessionId,
+            sessionKey: prepared.context.runSessionKey,
+            startedAt: turnStartedAtMs,
+            getLifecycleGeneration: () => runLifecycleGeneration,
+            resolveTerminationFields: (error) =>
+              resolveAgentRunErrorLifecycleFields(error, abortSignal),
           });
-        }
-      } finally {
-        // Release admission before exact-run alias deletion starts its own lifecycle mutation.
-        try {
           try {
-            await disposeCronRunContext({
-              sessionId: initialSessionId,
+            assertAgentRunLifecycleGenerationCurrent(runLifecycleGeneration);
+            const existingRunContext = getAgentRunContext(initialSessionId);
+            runContextOwnerToken = claimAgentRunContext(
+              initialSessionId,
+              {
+                sessionKey:
+                  ownsRunContext || !existingRunContext?.sessionKey
+                    ? prepared.context.runSessionKey
+                    : existingRunContext.sessionKey,
+                sessionId: initialSessionId,
+                lifecycleGeneration: runLifecycleGeneration,
+                cronRunsByJobId: new Map([
+                  [params.job.id, { pacingEnabled: params.job.pacing !== undefined }],
+                ]),
+              },
+              {
+                trackOwner: true,
+                ownsContext: ownsRunContext,
+              },
+            );
+            const { executeCronRun } = await cronExecutorRuntimeLoader.load();
+            const executionParams: Parameters<typeof executeCronRun>[0] = {
+              cfg: params.cfg,
+              cfgWithAgentDefaults: prepared.context.cfgWithAgentDefaults,
+              job: params.job,
+              agentId: prepared.context.agentId,
+              agentDir: prepared.context.agentDir,
+              agentSessionKey: prepared.context.agentSessionKey,
+              runSessionKey: prepared.context.runSessionKey,
+              usesDetachedRunSession: prepared.context.usesDetachedRunSession,
+              workspaceDir: prepared.context.workspaceDir,
+              executionRoot: prepared.context.executionRoot,
+              lane: params.lane,
+              resolvedDelivery: {
+                channel: prepared.context.resolvedDelivery.channel,
+                to: prepared.context.resolvedDelivery.to,
+                accountId: prepared.context.resolvedDelivery.accountId,
+                threadId: prepared.context.resolvedDelivery.threadId,
+              },
+              resolvedDeliveryOk: prepared.context.resolvedDelivery.ok,
+              deliveryRequested: prepared.context.deliveryRequested,
+              sourceDelivery: prepared.context.sourceDelivery,
+              skillsSnapshot: prepared.context.skillsSnapshot,
+              agentPayload: prepared.context.agentPayload,
+              useSubagentFallbacks: prepared.context.useSubagentFallbacks,
+              inheritDefaultFallbacksForAgentStringModel:
+                prepared.context.inheritDefaultFallbacksForAgentStringModel,
+              modelFallbacksOverride: prepared.context.modelFallbacksOverride,
+              agentVerboseDefault: prepared.context.agentCfg?.verboseDefault,
+              liveSelection: prepared.context.liveSelection,
               cronSession: prepared.context.cronSession,
-              ownsRunContext,
-              runContextOwnerToken,
+              commandBody: prepared.context.commandBody,
+              persistSessionEntry: prepared.context.persistSessionEntry,
+              persistRunContinuationSession: prepared.context.runContinuationSession?.sync,
+              setRunContinuationCliExecutionProvider:
+                prepared.context.runContinuationSession?.setCliExecutionProvider,
+              abortSignal,
+              lifecycle,
+              onExecutionStarted: notifyExecutionStarted,
+              onExecutionPhase: notifyExecutionPhase,
+              onLaneWait: params.onLaneWait,
+              abortReason,
+              isAborted,
+              immutableThinkLevel: prepared.context.thinkingSelection.immutableThinkLevel,
+              thinkingCatalog: prepared.context.thinkingSelection.catalog,
+              loadThinkingCatalog: prepared.context.thinkingSelection.loadThinkingCatalog,
+              timeoutMs: prepared.context.timeoutMs,
+              runTimeoutOverrideMs: prepared.context.runTimeoutOverrideMs,
+              suppressExecNotifyOnExit: prepared.context.suppressExecNotifyOnExit,
+              pluginRegistry: prepared.context.pluginRegistry,
+              executionIdentity: params.executionIdentity,
+            };
+            const execution = await prepared.context.sessionWorkAdmission.run(() =>
+              withAgentRunLifecycleGeneration(runLifecycleGeneration, () =>
+                executeCronRun(executionParams),
+              ),
+            );
+            // Publish the execution fact captured before bookkeeping; cron persistence
+            // and delivery retain their separate workflow outcome.
+            lifecycle.emit("end", execution.runResult);
+            const finalized = await finalizeCronRun({
+              prepared: prepared.context,
+              execution,
+              abortReason,
+              isAborted,
+              markCronRunSessionCleanupHandled: () => {
+                cronRunSessionCleanupHandled = true;
+              },
+              // Self-deleting sessions must release before their own lifecycle mutation.
+              // Other runs retain admission through delivery and release in finally.
+              beforeSessionDelete: prepared.context.sessionWorkAdmission.release,
+            });
+            if (finalized.status === "error") {
+              outcome = "error";
+              outcomeError = finalized.error;
+            }
+            const delayMs = consumeCronNextCheckProposal(initialSessionId, params.job.id);
+            return finalized.status !== "ok" || delayMs === undefined
+              ? finalized
+              : { ...finalized, nextCheck: { delayMs } };
+          } catch (err) {
+            lifecycle.emit("error", err);
+            consumeCronNextCheckProposal(initialSessionId, params.job.id);
+            const isCronLaneTimeout =
+              isAborted() || isCommandLaneTaskTimeoutError(err, CommandLane.CronNested);
+            const error = isCronLaneTimeout ? abortReason() : normalizeCronRunErrorText(err);
+            outcome = "error";
+            outcomeError = error;
+            const admissionDisposition =
+              err instanceof CronSessionLifecycleClaimError
+                ? err.admissionDisposition
+                : err instanceof CronExecutionRootRuntimeError || !executionStarted
+                  ? "rejected"
+                  : undefined;
+            return prepared.context.withRunSession({
+              status: "error",
+              error,
+              executionStarted,
+              ...(admissionDisposition ? { admissionDisposition } : {}),
+              // Carry the already-resolved run model into the error/timeout row so
+              // Task-run history keeps provider/model attribution instead of looking like
+              // an un-attributed cron timeout. finalizeCronRun does the same via
+              // telemetry on the aborted path; this catch never reaches it.
+              provider: prepared.context.liveSelection.provider,
+              model: prepared.context.liveSelection.model,
+              diagnostics: mergeCronRunDiagnostics(
+                prepared.context.preflightDiagnostics,
+                createCronRunDiagnosticsFromError(
+                  isCronLaneTimeout ? "cron-setup" : "agent-run",
+                  isCronLaneTimeout ? error : err,
+                ),
+              ),
             });
           } finally {
-            prepared.context.sessionWorkAdmission.release();
-          }
-          if (prepared.context.runContinuationSession) {
             try {
-              await removeCronRunContinuationSessionIfIdle(prepared.context.runSessionKey);
-            } catch (error) {
+              await prepared.context.runContinuationSession?.seal();
+            } catch (sealError) {
               logWarn(
-                `[cron:${params.job.id}] Failed to remove unused run continuation: ${String(error)}`,
+                `[cron:${params.job.id}] Failed to seal run continuation during cleanup: ${String(sealError)}`,
               );
             }
+            // Final lifecycle events use the adopted run session when the agent persisted one.
+            const finalSessionRef = {
+              sessionId: prepared.context.currentRunSessionId(),
+              sessionKey: prepared.context.runSessionKey,
+            };
+            try {
+              messageLifecycle.markIdle(undefined, finalSessionRef);
+              messageLifecycle.markProcessed(outcome, {
+                ...finalSessionRef,
+                error: outcomeError,
+              });
+            } finally {
+              try {
+                if (!cronRunSessionCleanupHandled) {
+                  await cleanupCronRunSessionAfterRun({
+                    job: params.job,
+                    agentSessionKey: prepared.context.agentSessionKey,
+                    sessionId: prepared.context.currentRunSessionId(),
+                    lifecycleRevision: prepared.context.cronSession.lifecycleRevision,
+                    sessionUpdatedAt: prepared.context.cronSession.sessionEntry.updatedAt,
+                    beforeDelete: prepared.context.sessionWorkAdmission.release,
+                    reason: "cron-delete-after-run-finally",
+                  });
+                }
+              } finally {
+                // Release admission before exact-run alias deletion starts its own lifecycle mutation.
+                try {
+                  try {
+                    await disposeCronRunContext({
+                      sessionId: initialSessionId,
+                      cronSession: prepared.context.cronSession,
+                      ownsRunContext,
+                      runContextOwnerToken,
+                    });
+                  } finally {
+                    prepared.context.sessionWorkAdmission.release();
+                  }
+                  if (prepared.context.runContinuationSession) {
+                    try {
+                      await removeCronRunContinuationSessionIfIdle(prepared.context.runSessionKey);
+                    } catch (error) {
+                      logWarn(
+                        `[cron:${params.job.id}] Failed to remove unused run continuation: ${String(error)}`,
+                      );
+                    }
+                  }
+                } finally {
+                  // Only run-scoped browser identities end here; persistent targets keep tracked tabs.
+                  if (prepared.context.runSessionKey !== prepared.context.agentSessionKey) {
+                    await cleanupBrowserSessionsForLifecycleEnd({
+                      cfg: prepared.context.cfgWithAgentDefaults,
+                      sessionKeys: [prepared.context.runSessionKey],
+                      onWarn: (message) => logWarn(`[cron:${params.job.id}] ${message}`),
+                    });
+                  }
+                }
+              }
+            }
           }
-        } finally {
-          // Only run-scoped browser identities end here; persistent targets keep tracked tabs.
-          if (prepared.context.runSessionKey !== prepared.context.agentSessionKey) {
-            await cleanupBrowserSessionsForLifecycleEnd({
-              cfg: prepared.context.cfgWithAgentDefaults,
-              sessionKeys: [prepared.context.runSessionKey],
-              onWarn: (message) => logWarn(`[cron:${params.job.id}] ${message}`),
-            });
-          }
-        }
-      }
-    }
+        }),
+      () => (leaseActive ? preparedRuntimeLease.snapshot : undefined),
+    );
+  } finally {
+    leaseActive = false;
+    preparedRuntimeLease.release();
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Scheduled runs that report token usage without a monetary total can lose their cost estimate in a fleet, even when the selected agent has prices in its own `models.json`. Cron's finalizer omitted the selected agent directory when resolving those prices. A separate owner-boundary regression also showed finalization using an ambient alias policy after inference had left the selected runtime's metadata scope.

This extracts the useful cron finalization repair from #130706.

## Why This Change Was Made

The existing prepared runtime now spans inference, accounting, delivery, and cleanup, with one final release that fences detached borrowing. Cost lookup receives the agent directory already selected during preparation. This keeps the repair in cron's existing owner and removes duplicated release paths.

Production LOC: +280/-288, net **-8**. Tests: +121/-1. Documentation: +2. Most of the run-file diff moves the existing body into its retained scope.

## User Impact

Token-only automation results use the scheduled agent's local model prices, and final bookkeeping uses the metadata selected for that run. The change adds no configuration, protocol, or database surface.

## Evidence

Both added regressions failed before their corresponding repairs: an explicit fleet with separate main/worker price files completed with an undefined estimate instead of the worker's $3; a different ambient alias policy also cleared the expected $3 estimate. The pricing resolver and local model files are real in these tests; inference is the existing cron runner harness.

- 159 targeted cron tests passed on the rebased candidate, covering generation/pricing, usage, diagnostics, session admission/deletion, terminal lifecycle, CLI continuity and cancellation, interim retry, Workshop execution roots, and hook outcomes.
- 29 existing prepared-runtime owner tests passed on the baseline, including superseded generation rejection and borrowed snapshot fencing.
- Fresh managed Codex autoreview on the rebased candidate: scoped-clean through P2, no actionable findings.
- Changed-scope checks (core/test types, lint, format, dead exports, architecture and state guards) passed; additional finalizer lint passed.
- Actual isolated Gateway + registered CLI backend + OpenAI Responses API: the scheduled Luna run crossed a model-config reload and completed; the Sol control completed afterward. Both returned 217 input and 11 output tokens. A worker price of $3/million input tokens produced persisted cost $0.000651, despite a separate main-agent file priced $1. Two history rows were observed and the job was removed.
- Actual isolated Gateway + stock openclaw runtime + OpenAI: Luna run completed across hot reload, followed by a successful Sol control; two history rows and job cleanup verified. This targeted rerun exited 0.
- Both live probes used the same verified pre-rebase source tree on Blacksmith Testbox [run 33989499566](https://github.com/openclaw/openclaw/actions/runs/33989499566). The CLI pricing stage passed in a command whose later stock-runtime stage initially selected liveness instead of readiness; that independent stage was corrected to wait for `/readyz` and rerun successfully. Earlier fixture attempts were corrected to use supported credential loading, declared startup activation and exact no-tools enforcement.

The rebase onto `9c068e13bd187606cac6111d60700f09ef52bd89` preserves upstream Workshop execution-root plumbing and rejection handling. The pricing/lifetime repair and its production LOC delta are unchanged; the 159-test run and fresh review cover that integration. No fresh live run on the rewritten head is claimed.

Release-note context: fix automation cost estimates for selected agents with local model pricing and retain the run's metadata through finalization.
