### PR TITLE
fix(doctor): avoid unrelated plugin setup during migrations

### DIFF
--- a/src/commands/doctor-config-flow.canvas-migration.test.ts
+++ b/src/commands/doctor-config-flow.canvas-migration.test.ts
@@ -121,6 +121,7 @@ describe("Canvas document migration through doctor config persistence", () => {
           await writeCanvasConfig(home, customRoot, scenario === "legacy-root"),
         );
         expect(saved.plugins.entries.canvas.config.host).toEqual({ enabled: false });
+        expect(Object.keys(saved.plugins.entries)).toEqual(["canvas"]);
         expect(saved).not.toHaveProperty("canvasHost");
         expect((await readConfigFileSnapshot()).valid).toBe(true);
         if (hasDocument) {

--- a/src/commands/doctor-config-flow.gateway-bind-persistence.test.ts
+++ b/src/commands/doctor-config-flow.gateway-bind-persistence.test.ts
@@ -1,11 +1,13 @@
 // Verifies Doctor persists legacy gateway bind repairs through the real config writer.
 import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
 import { runInitialConfigWriteHealth } from "../flows/doctor-health-contribution-runners.config.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
+import { repairLegacyConfigForUpdateChannel } from "./doctor/legacy-config-repair.js";
 
 describe("Doctor gateway bind persistence", () => {
   afterEach(() => {
@@ -33,4 +35,47 @@ describe("Doctor gateway bind persistence", () => {
       });
     });
   });
+
+  it.each(["ordinary", "include", "invalid"] as const)(
+    "preserves authored plugin scope during %s update-channel repair",
+    async (scenario) => {
+      await withTempHome(async (home) => {
+        const diagnostics = {
+          otel: { enabled: true, endpoint: "http://collector.test:4317", protocol: "grpc" },
+        };
+        const configPath = await writeOpenClawConfig(home, {
+          gateway: { mode: "local", ...(scenario === "invalid" ? { port: "invalid" } : {}) },
+          diagnostics: scenario === "include" ? { $include: "diagnostics.json" } : diagnostics,
+          plugins: { entries: { canvas: { enabled: true, config: { host: { enabled: false } } } } },
+        });
+        const includePath = path.join(path.dirname(configPath), "diagnostics.json");
+        if (scenario === "include") {
+          await fs.writeFile(includePath, JSON.stringify(diagnostics));
+        }
+        const before = await fs.readFile(configPath, "utf8");
+        const result = await repairLegacyConfigForUpdateChannel({
+          configSnapshot: await readConfigFileSnapshot(),
+          jsonMode: true,
+        });
+        if (scenario === "invalid") {
+          expect(result.repaired).toBe(false);
+          expect(await fs.readFile(configPath, "utf8")).toBe(before);
+          return;
+        }
+        expect(result.repaired).toBe(true);
+        const saved = JSON.parse(await fs.readFile(configPath, "utf8"));
+        expect(Object.keys(saved.plugins.entries)).toEqual(["canvas"]);
+        expect(result.snapshot.config.diagnostics?.otel).toEqual({
+          enabled: false,
+          endpoint: "http://collector.test:4317",
+        });
+        if (scenario === "include") {
+          expect(saved.diagnostics).toEqual({ $include: "diagnostics.json" });
+          expect(JSON.parse(await fs.readFile(includePath, "utf8"))).toEqual({
+            otel: { enabled: false, endpoint: "http://collector.test:4317" },
+          });
+        }
+      });
+    },
+  );
 });

--- a/src/commands/doctor/legacy-config-repair.ts
+++ b/src/commands/doctor/legacy-config-repair.ts
@@ -1,6 +1,6 @@
 // Update-channel config repair for legacy config files before normal command startup.
 import { readConfigFileSnapshot, replaceConfigFile } from "../../config/config.js";
-import { validateConfigObjectWithPlugins } from "../../config/validation.js";
+import { validateConfigObjectRawWithPlugins } from "../../config/validation.js";
 import {
   containsAuthoredInclude,
   isSingleTopLevelIncludeMigration,
@@ -20,7 +20,7 @@ export async function repairLegacyConfigForUpdateChannel(params: {
     return { snapshot: params.configSnapshot, repaired: false };
   }
 
-  const validated = validateConfigObjectWithPlugins(migrated.config);
+  const validated = validateConfigObjectRawWithPlugins(migrated.config);
   if (!validated.ok) {
     return { snapshot: params.configSnapshot, repaired: false };
   }

--- a/src/commands/doctor/shared/invalid-plugin-config.test.ts
+++ b/src/commands/doctor/shared/invalid-plugin-config.test.ts
@@ -9,6 +9,7 @@ const validationMocks = vi.hoisted(() => ({
 
 vi.mock("../../../config/validation.js", () => ({
   validateConfigObjectWithPlugins: validationMocks.validateConfigObjectWithPlugins,
+  validateConfigObjectRawWithPlugins: validationMocks.validateConfigObjectWithPlugins,
 }));
 
 vi.mock("./legacy-config-issues.js", () => ({

--- a/src/commands/doctor/shared/legacy-config-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.ts
@@ -1,7 +1,7 @@
 // Validating legacy config migration wrapper used by doctor config flow.
 import type { LegacyConfigMigrationContext } from "../../../config/legacy.shared.js";
 import type { OpenClawConfig } from "../../../config/types.js";
-import { validateConfigObjectWithPlugins } from "../../../config/validation.js";
+import { validateConfigObjectRawWithPlugins } from "../../../config/validation.js";
 import { applyLegacyDoctorMigrations } from "./legacy-config-compat.js";
 
 /** Apply legacy migrations and validate the resulting OpenClaw config shape when possible. */
@@ -21,7 +21,9 @@ export function migrateLegacyConfig(
   const resolvedCandidate = context
     ? (applyLegacyDoctorMigrations(context.resolvedRaw, context).next ?? context.resolvedRaw)
     : next;
-  const validated = validateConfigObjectWithPlugins(resolvedCandidate);
+  // Runtime defaults create unrelated plugin entries that Doctor would then load
+  // and persist. Validate repair candidates without materializing those defaults.
+  const validated = validateConfigObjectRawWithPlugins(resolvedCandidate);
   if (!validated.ok) {
     changes.push("Migration applied; other validation issues remain — run doctor to review.");
     return { config: next as OpenClawConfig, changes, partiallyValid: true };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Doctor and update-channel config repairs persisted defaults for unrelated plugins. A config containing only Canvas grew to 84 plugin entries after a successful repair. Doctor subsequently treated those injected entries as configured migration work and loaded their setup modules, making cold migrations unnecessarily slow.

## Why This Change Was Made

Use the existing raw plugin-aware validator for migration candidates in both repair paths. Full plugin/schema validation, legacy ownership normalization, authored include handling, resolved environment references, and invalid-config refusal remain intact. Runtime snapshots still apply defaults when config is read for execution.

This repairs the producer of the expanded config instead of filtering out legitimate plugin migrations or warming tests around the unwanted work. Executable production LOC is unchanged; two explanatory comment lines and 47 test lines were added. No cache infrastructure, worker limits, shard counts, or existing cases were removed.

## User Impact

Repairs keep the configured plugin inventory and avoid loading unrelated setup code. On one idle Linux machine, the identical cold Canvas migration case fell from 50.118/49.591 seconds to 17.008/16.702 seconds in two alternating baseline/candidate pairs: about 66% less test-body time. Whole invocations fell from 59.295/57.797 seconds to 25.651/24.642 seconds. These are focused test measurements, not a claim about total CI duration.

## Evidence

- Before the fix, the Canvas inventory regression and ordinary update-channel persistence regression failed because they received 84 plugin entries instead of Canvas alone. Include-owned updates and invalid-config refusal passed as controls.
- 69 focused local checks passed across seven files, covering all Canvas migration cases, direct update repair, partial-invalid migrations, resolved/authored values, workspace ownership, and preflight state inputs.
- Controlled Linux proof used Node 24.19.0, four CPUs, 15.42 GiB RAM, identical original test bytes, private dependency copies, and fresh worker/cache directories for each invocation. The full candidate Canvas file passed all 10 cases in 35.194 seconds, with no failures, skips, leaked child processes, or OOMs.
- Independent source review and Codex autoreview through P2 found no actionable issue.
- The complete changed-file gate passed, including core/core-test typechecks, lint, all three dead-export scans, import-cycle checks, and state/schema guards.
- A separate attempt to run `legacy-config-migrate.e2e.test.ts` on the retained Testbox could not start because source sync timed out; it produced no test result. The successful Linux comparison and full Canvas proof above completed in the earlier invocation.
