### PR TITLE
refactor(update): remove unused build-manager modes

### DIFF
--- a/src/infra/update-package-manager.test.ts
+++ b/src/infra/update-package-manager.test.ts
@@ -59,13 +59,7 @@ describe("resolveUpdateBuildManager", () => {
         }
         throw new Error(`Unexpected command ${key}`);
       };
-      const result = await resolveUpdateBuildManager(
-        runCommand,
-        root,
-        5000,
-        undefined,
-        "require-preferred",
-      );
+      const result = await resolveUpdateBuildManager(runCommand, root, 5000);
       expect(result.kind).toBe("resolved");
       if (result.kind !== "resolved") {
         throw new Error(result.reason);
@@ -92,13 +86,7 @@ describe("resolveUpdateBuildManager", () => {
       prefix = argv[3] ?? "";
       return { stdout: "", stderr: "", code: failure === "install" ? 1 : 0 };
     };
-    const result = await resolveUpdateBuildManager(
-      runCommand,
-      root,
-      5000,
-      undefined,
-      "require-preferred",
-    );
+    const result = await resolveUpdateBuildManager(runCommand, root, 5000);
     expect(result).toEqual({
       kind: "missing-required",
       preferred: "pnpm",

--- a/src/infra/update-package-manager.ts
+++ b/src/infra/update-package-manager.ts
@@ -10,8 +10,6 @@ import { applyPathPrepend } from "./path-prepend.js";
 // builds and can bootstrap pnpm when a managed checkout requires it.
 type BuildManager = "pnpm" | "bun" | "npm";
 
-type UpdatePackageManagerRequirement = "allow-fallback" | "require-preferred";
-
 type UpdatePackageManagerFailureReason =
   | "preferred-manager-unavailable"
   | "pnpm-corepack-enable-failed"
@@ -149,7 +147,6 @@ export async function resolveUpdateBuildManager(
   root: string,
   timeoutMs: number,
   baseEnv?: NodeJS.ProcessEnv,
-  requirement: UpdatePackageManagerRequirement = "allow-fallback",
 ): Promise<ResolvedBuildManager> {
   // Version selection belongs to the target checkout, including preflight and rollback.
   const runCommand: PackageManagerCommandRunner = (argv, options) =>
@@ -185,20 +182,13 @@ export async function resolveUpdateBuildManager(
           cleanup: pnpmBootstrap.cleanup,
         };
       }
-      if (requirement === "require-preferred") {
-        return { kind: "missing-required", preferred, reason: "pnpm-npm-bootstrap-failed" };
-      }
+      return { kind: "missing-required", preferred, reason: "pnpm-npm-bootstrap-failed" };
     }
 
-    if (requirement === "require-preferred") {
-      if (corepackStatus === "missing") {
-        return { kind: "missing-required", preferred, reason: "pnpm-corepack-missing" };
-      }
-      if (corepackStatus === "failed") {
-        return { kind: "missing-required", preferred, reason: "pnpm-corepack-enable-failed" };
-      }
-      return { kind: "missing-required", preferred, reason: "preferred-manager-unavailable" };
+    if (corepackStatus === "missing") {
+      return { kind: "missing-required", preferred, reason: "pnpm-corepack-missing" };
     }
+    return { kind: "missing-required", preferred, reason: "pnpm-corepack-enable-failed" };
   }
 
   for (const manager of managerPreferenceOrder(preferred)) {
@@ -215,11 +205,7 @@ export async function resolveUpdateBuildManager(
     }
   }
 
-  if (requirement === "require-preferred") {
-    return { kind: "missing-required", preferred, reason: "preferred-manager-unavailable" };
-  }
-
-  return { kind: "resolved", manager: "npm", preferred, fallback: preferred !== "npm" };
+  return { kind: "missing-required", preferred, reason: "preferred-manager-unavailable" };
 }
 
 /** Build argv for running a package-manager script. */
@@ -238,25 +224,13 @@ export function managerScriptArgs(manager: BuildManager, script: string, args: s
 
 /** Build argv for installing dependencies with a package manager. */
 export function managerInstallArgs(manager: BuildManager, opts?: { compatFallback?: boolean }) {
-  if (manager === "pnpm") {
-    return ["pnpm", "install"];
-  }
-  if (manager === "bun") {
-    return ["bun", "install"];
-  }
-  if (opts?.compatFallback) {
+  if (manager === "npm" && opts?.compatFallback) {
     return ["npm", "install", "--no-package-lock", "--legacy-peer-deps"];
   }
-  return ["npm", "install"];
+  return [manager, "install"];
 }
 
 /** Build argv for installing dependencies while skipping lifecycle scripts. */
-export function managerInstallIgnoreScriptsArgs(manager: BuildManager): string[] | null {
-  if (manager === "pnpm") {
-    return ["pnpm", "install", "--ignore-scripts"];
-  }
-  if (manager === "bun") {
-    return ["bun", "install", "--ignore-scripts"];
-  }
-  return ["npm", "install", "--ignore-scripts"];
+export function managerInstallIgnoreScriptsArgs(manager: BuildManager): string[] {
+  return [manager, "install", "--ignore-scripts"];
 }

--- a/src/infra/update-runner-git-preflight.ts
+++ b/src/infra/update-runner-git-preflight.ts
@@ -369,7 +369,6 @@ async function testPreflightCandidate(params: {
     params.worktreeDir,
     params.timeoutMs,
     params.defaultCommandEnv,
-    "require-preferred",
   );
   if (manager.kind === "missing-required") {
     params.steps.push({
@@ -384,13 +383,11 @@ async function testPreflightCandidate(params: {
   }
   try {
     const preferIgnoreScripts = shouldInstallWithoutScriptsOnWindows(manager.manager);
-    const ignoreScriptsArgv = managerInstallIgnoreScriptsArgs(manager.manager);
-    const installArgv =
-      preferIgnoreScripts && ignoreScriptsArgv
-        ? ignoreScriptsArgv
-        : managerInstallArgs(manager.manager, {
-            compatFallback: manager.fallback && manager.manager === "npm",
-          });
+    const installArgv = preferIgnoreScripts
+      ? managerInstallIgnoreScriptsArgs(manager.manager)
+      : managerInstallArgs(manager.manager, {
+          compatFallback: manager.fallback && manager.manager === "npm",
+        });
     const installName = preferIgnoreScripts ? "deps install (ignore scripts)" : "deps install";
     const installEnv = await resolveInstallEnv(
       manager.manager,

--- a/src/infra/update-runner-git-recovery.ts
+++ b/src/infra/update-runner-git-recovery.ts
@@ -61,7 +61,6 @@ export async function rebuildRolledBackGitRuntime(params: {
     params.gitRoot,
     params.timeoutMs,
     params.defaultCommandEnv,
-    "require-preferred",
   );
   if (manager.kind === "missing-required") {
     return appendFailure("manager-unavailable", manager.reason);
@@ -82,10 +81,11 @@ export async function rebuildRolledBackGitRuntime(params: {
       installEnv,
     );
     if (!installed && shouldInstallWithoutScriptsOnWindows(manager.manager)) {
-      const retryArgv = managerInstallIgnoreScriptsArgs(manager.manager);
-      installed = retryArgv
-        ? await appendStep("git rollback deps install (ignore scripts)", retryArgv, installEnv)
-        : false;
+      installed = await appendStep(
+        "git rollback deps install (ignore scripts)",
+        managerInstallIgnoreScriptsArgs(manager.manager),
+        installEnv,
+      );
     }
     if (!installed) {
       return appendFailure("deps-install-failed", "failed to restore dependencies");

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -403,7 +403,6 @@ export async function updateGitCheckout(params: {
     gitRoot,
     timeoutMs,
     defaultCommandEnv,
-    "require-preferred",
   );
   if (manager.kind === "missing-required") {
     return await rollbackError(manager.reason);
@@ -430,12 +429,14 @@ export async function updateGitCheckout(params: {
       ),
     );
     if (installStep.exitCode !== 0 && shouldInstallWithoutScriptsOnWindows(manager.manager)) {
-      const retryArgv = managerInstallIgnoreScriptsArgs(manager.manager);
-      if (retryArgv) {
-        installStep = await runStep(
-          step("deps install (ignore scripts)", retryArgv, gitRoot, installEnv),
-        );
-      }
+      installStep = await runStep(
+        step(
+          "deps install (ignore scripts)",
+          managerInstallIgnoreScriptsArgs(manager.manager),
+          gitRoot,
+          installEnv,
+        ),
+      );
     }
     if (installStep.exitCode !== 0) {
       return await rollbackError("deps-install-failed");


### PR DESCRIPTION
## What Problem This Solves

The source-update runner carries an unused permissive package-manager mode and null handling for commands that always exist. This is the maintainer-requested cleanup companion to the #135868 split, in the update neighborhood identified by concern E; it adds no automatic-recovery behavior and is independent of stages 1–5.

## Why This Change Was Made

All three production callers already select the strict build-manager mode. Remove the unused mode and keep their existing behavior as the only path. Install arguments now share their common shape, and preflight, update, and rollback use the non-null ignore-scripts command directly.

The pnpm bootstrap sequence and errors, npm/Bun fallback order, npm compatibility flags, and Windows retry conditions are preserved. No managed-service handoff internals change.

## User Impact

No user-visible behavior change. Production shrinks by 28 lines and tests by 12 lines, with all existing behavior cases retained. No configuration, schema, protocol, dependency, or baseline changes.

## Evidence

- Repository-wide caller search found only the Git update, candidate preflight, rollback rebuild, and retained package-manager tests; all selected the removed strict argument before this refactor. No public SDK, CLI, or configuration contract exposes the removed mode.
- Every branch of the ignore-scripts helper already returned an array, so the removed null paths were unreachable.
- Focused update-runner and package-manager suites: 139 cases passed in the first run; one temporary Git-fixture initialization failed before the changed resolver ran and passed on a single unchanged targeted rerun. All 140 cases have passing results.
- `node scripts/check-changed.mjs` exited 0, including core and core-test type checks, all three dead-export audits, lint, and zero runtime import cycles. An earlier standalone production/full-tree export scan hit its existing timeout; the required gate passed on the next attempt without changing limits.
- Codex autoreview: scoped-clean, no actionable P0–P2 findings.
- Judged LOC: production +27/−55 (net −28); tests +2/−14 (net −12); tooling/docs unchanged.
- ClawSweeper reviewed the final head with no findings and no pre-merge or rank-up changes requested. The final pre-landing rebase preserves all five touched files byte-for-byte. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33991296388) passed for `746362b3c71dc2adbf89e026d8945b92ed772928`; the watcher reconciled superseded Labeler/Dispatch cancellations and exited GREEN.
