### PR TITLE
refactor(test): preserve typed Nextcloud comparison calls

### DIFF
--- a/extensions/nextcloud-talk/src/core.test.ts
+++ b/extensions/nextcloud-talk/src/core.test.ts
@@ -1,4 +1,5 @@
 // Nextcloud Talk tests cover core plugin behavior.
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { describe, expect, it, vi } from "vitest";
 import {
   looksLikeNextcloudTalkTargetId,
@@ -12,14 +13,6 @@ import {
   generateNextcloudTalkSignature,
   verifyNextcloudTalkSignature,
 } from "./signature.js";
-
-function requireFirstTimingSafeEqualCall(mock: ReturnType<typeof vi.fn>): [unknown, unknown] {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error("expected timingSafeEqual call");
-  }
-  return call as [unknown, unknown];
-}
 
 describe("nextcloud talk core", () => {
   it("marks ambiguous room-token session routes as best-effort", () => {
@@ -176,7 +169,8 @@ describe("nextcloud talk core", () => {
   });
 
   it("still runs timingSafeEqual when the supplied signature length mismatches", async () => {
-    const timingSafeEqualMock = vi.fn();
+    const timingSafeEqualMock =
+      vi.fn<(left: NodeJS.ArrayBufferView, right: NodeJS.ArrayBufferView) => void>();
 
     vi.resetModules();
     vi.doMock("node:crypto", async (importOriginal) => {
@@ -212,7 +206,10 @@ describe("nextcloud talk core", () => {
       ).toBe(false);
 
       expect(timingSafeEqualMock).toHaveBeenCalledOnce();
-      const [leftBuffer, rightBuffer] = requireFirstTimingSafeEqualCall(timingSafeEqualMock);
+      const [leftBuffer, rightBuffer] = expectDefined(
+        timingSafeEqualMock.mock.calls[0],
+        "timingSafeEqual call",
+      );
       expect(Buffer.isBuffer(leftBuffer)).toBe(true);
       expect(Buffer.isBuffer(rightBuffer)).toBe(true);
       if (!Buffer.isBuffer(leftBuffer) || !Buffer.isBuffer(rightBuffer)) {


### PR DESCRIPTION
## What Problem This Solves

A Nextcloud Talk regression test reads an untyped mock-call array through a local tuple cast. The existing SDK assertion helper can retain the recorded argument types and the same missing-call check without a separate wrapper.

## Why This Change Was Made

Give the observer the parameter types already used by its unchanged real-crypto forwarding callback, then use `expectDefined` on the recorded call. No new helper, SDK export or production seam is added. Production delta is zero; tests are +7/-10 lines.

## User Impact

No production or public-contract change. The unequal-signature-length regression remains intact: real crypto forwarding, false verification result, exactly one comparison, both Buffer checks, runtime narrowing, equal lengths and module cleanup are unchanged. All eight plugin cases remain.

## Evidence

- The complete Nextcloud Talk core suite and shared comparator suite passed before and after: 8 + 9 = 17 cases each, in normal project order on Node24.20.0/pnpm12.3.4.
- The normal configured Linux changed-file gate passed all selected type, lint, formatting and structural checks. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33988979707) completed its command with exit0 and stopped its lease normally. An optional later portal-sync timeout is retained separately; it did not affect the command result or verified cleanup.
- Managed Codex review found no actionable P0–P2 findings in the test-only change. Its first dry run rejected unchanged comparator source filenames; those files were excluded without renaming or retransmission. The reviewer explicitly found the changed test, callers, assertion helper and mock types sufficient, and made no review claim about the excluded comparator implementation.
- The target, signature caller, comparator and SDK helper bytes are unchanged from tested base4e217930 through freshly fetched main8c5a0983c18a.

This is assertion cleanup, not a timing measurement or a production security fix. No test case or assertion is removed.
