### PR TITLE
fix(ui): show session hover cards for local chat URLs

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -34,10 +34,12 @@ The headline owns that run's sidebar subtitle instead of heuristic live activity
 Session observation is enabled by default. Safe preamble headlines do not require a utility model; the utility model only owns richer assessments and terminal summaries. In **Settings > Appearance > Sidebar**, you can turn observation off gateway-wide, inspect the resolved small model and its provenance, or choose automatic routing, disable utility tasks, or select an explicit `agents.defaults.utilityModel`. The equivalent config controls are `gateway.controlUi.sessionObserver: false` and `agents.defaults.utilityModel: ""`.
 
 Session links in messages open inside the Control UI. This includes `agent:` keys,
-relative chat URLs, and URLs on the current origin or the Gateway's public origin
+root-relative chat URLs, and URLs on the current origin or the Gateway's public origin
 when its applied configuration is loaded. Hovering a link shows the session card
 when the session is known locally. Unknown or ambiguous session references remain
 navigable without a card; links to other origins keep normal browser behavior.
+Document-relative hrefs are never session links; file references such as
+`src/utils/foo.ts` retain workspace file handling.
 
 ## Environment identity
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -33,6 +33,12 @@ The headline owns that run's sidebar subtitle instead of heuristic live activity
 
 Session observation is enabled by default. Safe preamble headlines do not require a utility model; the utility model only owns richer assessments and terminal summaries. In **Settings > Appearance > Sidebar**, you can turn observation off gateway-wide, inspect the resolved small model and its provenance, or choose automatic routing, disable utility tasks, or select an explicit `agents.defaults.utilityModel`. The equivalent config controls are `gateway.controlUi.sessionObserver: false` and `agents.defaults.utilityModel: ""`.
 
+Session links in messages open inside the Control UI. This includes `agent:` keys,
+relative chat URLs, and URLs on the current origin or the Gateway's public origin
+when its applied configuration is loaded. Hovering a link shows the session card
+when the session is known locally. Unknown or ambiguous session references remain
+navigable without a card; links to other origins keep normal browser behavior.
+
 ## Environment identity
 
 When you run several Gateways, set `gateway.controlUi.environment` to distinguish their browser tabs and windows:

--- a/ui/src/components/markdown-links.test.ts
+++ b/ui/src/components/markdown-links.test.ts
@@ -606,6 +606,22 @@ describe("toSanitizedMarkdownHtml links", () => {
       expect(fragment.querySelector("a a")).toBeNull();
     });
 
+    it.each(["", "?view=full#latest"])(
+      "captures the cleaned session URL with suffix %j before trailing CJK prose",
+      (suffix) => {
+        const href = `${location.origin}/chat/main/d0effac9${suffix}`;
+        const fragment = htmlFragment(
+          toSanitizedMarkdownHtml(`${href}重新解读`, { sessionLinks: true, fileLinks: true }),
+        );
+        const link = fragment.querySelector<HTMLAnchorElement>("a.markdown-session-link")!;
+        expect(link.getAttribute("href")).toBe(href);
+        expect(link.dataset.sessionHref).toBe(href);
+        expect(link.textContent).toBe(href);
+        expect(link.nextSibling?.nodeType).toBe(Node.TEXT_NODE);
+        expect(link.nextSibling?.textContent).toBe("重新解读");
+      },
+    );
+
     it.each([
       "https://elsewhere.example/chat/roboclaw/d0effac9",
       "[External session](https://elsewhere.example/chat/roboclaw/d0effac9)",

--- a/ui/src/components/markdown-links.test.ts
+++ b/ui/src/components/markdown-links.test.ts
@@ -587,6 +587,55 @@ describe("toSanitizedMarkdownHtml links", () => {
       expect(fragment.querySelector("a[data-session-key]")).toBeNull();
     });
 
+    it.each([
+      ["absolute href", `[Open session](${location.origin}/chat/roboclaw/d0effac9)`],
+      ["bare URL", `${location.origin}/chat/roboclaw/d0effac9`],
+      ["relative href", "[Open session](/chat/roboclaw/d0effac9)"],
+      ["literal with a file extension", "[Open session](/chat/roboclaw/d0effac9.md)"],
+      ["inline URL", `\`${location.origin}/chat/roboclaw/d0effac9\``],
+      ["inline relative URL", "`/chat/roboclaw/d0effac9`"],
+    ])("decorates host-local session URLs in %s", (_kind, input) => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml(input, { sessionLinks: true, fileLinks: true }),
+      );
+      const link = fragment.querySelector<HTMLAnchorElement>("a.markdown-session-link");
+      expect(link?.getAttribute("href")).toContain("/chat/roboclaw/d0effac9");
+      expect(link?.hasAttribute("target")).toBe(false);
+      expect(link?.hasAttribute("data-file-path")).toBe(false);
+      expect(link?.hasAttribute("data-session-key")).toBe(false);
+      expect(fragment.querySelector("a a")).toBeNull();
+    });
+
+    it.each([
+      "https://elsewhere.example/chat/roboclaw/d0effac9",
+      "[External session](https://elsewhere.example/chat/roboclaw/d0effac9)",
+      "`https://elsewhere.example/chat/roboclaw/d0effac9`",
+      "[Other page](/activity)",
+    ])("keeps other destinations undecorated: %s", (input) => {
+      const fragment = htmlFragment(toSanitizedMarkdownHtml(input, { sessionLinks: true }));
+      expect(fragment.querySelector(".markdown-session-link")).toBeNull();
+      expect(fragment.querySelector("[data-session-key]")).toBeNull();
+      if (input.startsWith("`")) {
+        expect(fragment.querySelector("a")).toBeNull();
+      }
+    });
+
+    it("keeps ordinary inline code out of session routes on a chat page", () => {
+      const previous = location.href;
+      history.replaceState(null, "", "/chat/main/d0effac9");
+      try {
+        const fragment = htmlFragment(
+          toSanitizedMarkdownHtml("`README.md` `src/chat.ts` `ordinary text`", {
+            sessionLinks: true,
+          }),
+        );
+        expect(fragment.querySelector("a")).toBeNull();
+        expect(fragment.querySelectorAll("code")).toHaveLength(3);
+      } finally {
+        history.replaceState(null, "", previous);
+      }
+    });
+
     it("keeps punctuation outside the link and rejects embedded word matches", () => {
       const fragment = htmlFragment(
         toSanitizedMarkdownHtml(`(${sessionKey}), x${sessionKey}`, { sessionLinks: true }),

--- a/ui/src/components/markdown-links.test.ts
+++ b/ui/src/components/markdown-links.test.ts
@@ -620,6 +620,29 @@ describe("toSanitizedMarkdownHtml links", () => {
       }
     });
 
+    it.each([
+      ["source", "src/utils/foo.ts", "file"],
+      ["root session", "/chat/main/cafebabe", "session"],
+      ["absolute session", `${location.origin}/chat/main/cafebabe`, "session"],
+      ["relative route", "chat/main/x", "plain"],
+    ])("classifies %s independently of the current chat route", (label, href, kind) => {
+      const previous = location.href;
+      history.replaceState(null, "", "/chat/main/d0effac9");
+      try {
+        const fragment = htmlFragment(
+          toSanitizedMarkdownHtml(`[${label}](${href})`, { sessionLinks: true, fileLinks: true }),
+        );
+        const link = fragment.querySelector<HTMLAnchorElement>("a")!;
+        expect(link.classList.contains("markdown-session-link")).toBe(kind === "session");
+        expect(link.hasAttribute("data-session-href")).toBe(kind === "session");
+        expect(link.classList.contains("markdown-file-link")).toBe(kind === "file");
+        expect(link.dataset.filePath).toBe(kind === "file" ? href : undefined);
+        expect(link.getAttribute("href")).toBe(kind === "file" ? null : href);
+      } finally {
+        history.replaceState(null, "", previous);
+      }
+    });
+
     it("keeps ordinary inline code out of session routes on a chat page", () => {
       const previous = location.href;
       history.replaceState(null, "", "/chat/main/d0effac9");

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -1,4 +1,3 @@
-import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import MarkdownIt, { type MarkdownIt as MarkdownItParser, type Token } from "markdown-it";
 import markdownItTaskLists from "markdown-it-task-lists";
 import { t } from "../i18n/index.ts";
@@ -360,7 +359,7 @@ export function createMarkdownParser(): MarkdownItParser {
         }
         if (token.type === "link_open") {
           const href = String(token.attrGet("href") ?? "");
-          if (href) {
+          if (href && !token.attrGet("data-session-href")) {
             let decodedHref = href;
             try {
               decodedHref = decodeURIComponent(href);
@@ -610,10 +609,7 @@ export function createMarkdownParser(): MarkdownItParser {
         target.title === null ? "" : ` title="${escapeMarkdownHtml(target.title)}"`;
       return `<a class="markdown-file-link" role="button" tabindex="0" data-file-path="${escapeMarkdownHtml(target.path)}" data-file-kind="${fileKindForPath(target.path)}"${lineAttribute}${titleAttribute}>${rendered}</a>`;
     }
-    const sessionKey: unknown = asOptionalRecord(tokens[index]?.meta?.sessionLink)?.sessionKey;
-    return typeof sessionKey === "string"
-      ? `<a class="markdown-session-link" role="link" tabindex="0" data-session-key="${escapeMarkdownHtml(sessionKey)}">${rendered}</a>`
-      : rendered;
+    return rendered;
   };
 
   // Message rendering allows inline data images and explicit open-only placeholders

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -340,7 +340,7 @@ export function createMarkdownParser(): MarkdownItParser {
     }
   });
 
-  markdownParser.core.ruler.after("linkify", "file-links", (state) => {
+  markdownParser.core.ruler.after("linkify-cjk-trim", "file-links", (state) => {
     const env = state.env as Partial<MarkdownRenderEnv> | undefined;
     if (env?.fileLinks !== true) {
       return;

--- a/ui/src/components/markdown-session-links.test.ts
+++ b/ui/src/components/markdown-session-links.test.ts
@@ -6,8 +6,44 @@ import {
   navigateMarkdownSession,
   type SessionLinkTarget,
 } from "./markdown-session-links.ts";
+import { toSanitizedMarkdownHtml } from "./markdown.ts";
+import { SessionLinkTitler } from "./session-link-titling.ts";
 
 describe("markdown session links", () => {
+  it.each(["", "?view=full#latest"])(
+    "resolves the cleaned session after title refresh with URL suffix %j",
+    async (suffix) => {
+      const sessionKey = "agent:main:dashboard:d0effac9-3211-4641-b993-10f619f124e6";
+      const pathname = "/chat/main/d0effac9";
+      const href = `${location.origin}${pathname}${suffix}`;
+      const host = document.createElement("div");
+      host.innerHTML = toSanitizedMarkdownHtml(`${href}重新解读`, { sessionLinks: true });
+      const anchor = host.querySelector<HTMLAnchorElement>("a")!;
+      const titler = new SessionLinkTitler(host);
+      titler.context = {
+        basePath: "",
+        sessions: {
+          state: {
+            result: {
+              sessions: [{ key: sessionKey, agentId: "main", displayName: "Research" }],
+            },
+          },
+        },
+        agents: { state: {} },
+        gateway: { snapshot: {} },
+      } as unknown as ApplicationContext;
+
+      await titler.decorate(anchor);
+      titler.refresh();
+
+      expect(anchor.dataset.sessionKey).toBe(sessionKey);
+      expect(anchor.textContent).toBe("Research");
+      expect(anchor.dataset.sessionHref).toBe(href);
+      expect(anchor.getAttribute("href")).toBe(`${pathname}${suffix}`);
+      expect(anchor.nextSibling?.textContent).toBe("重新解读");
+    },
+  );
+
   it("navigates through the canonical chat session route", () => {
     const navigate = vi.fn();
     const context = {

--- a/ui/src/components/markdown-session-links.test.ts
+++ b/ui/src/components/markdown-session-links.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ApplicationContext } from "../app/context.ts";
-import { navigateMarkdownSession, type SessionLinkTarget } from "./markdown-session-links.ts";
+import {
+  markdownSessionLinkFromEvent,
+  markdownSessionLinkFromKeyboardEvent,
+  navigateMarkdownSession,
+  type SessionLinkTarget,
+} from "./markdown-session-links.ts";
 
 describe("markdown session links", () => {
   it("navigates through the canonical chat session route", () => {
@@ -24,5 +29,63 @@ describe("markdown session links", () => {
       pathname: "/chat/roboclaw/dashboard/2139bddb-3211-4641-b993-10f619f124e6",
       search: "?__openclawSessionFacePreference=1",
     });
+  });
+  it.each([
+    ["click", "a"],
+    ["Enter", "a"],
+    [" ", "a"],
+    ["click", "code"],
+    ["Enter", "code"],
+    [" ", "code"],
+  ])("routes a public-origin URL with %s on %s before hovercard initialization", (action, tag) => {
+    const provider = Object.assign(
+      document.createElement("openclaw-session-progress-hovercard-provider"),
+      {
+        context: {
+          basePath: "/control",
+          runtimeConfig: {
+            state: {
+              configSnapshot: {
+                runtimeConfig: { gateway: { publicOrigin: "https://CHAT.example:443/" } },
+              },
+            },
+          },
+        },
+      },
+    );
+    const anchor = document.createElement(tag);
+    const href = "https://chat.example/control/chat/roboclaw/d0effac9?view=full#latest";
+    if (tag === "a") {
+      anchor.setAttribute("href", href);
+    } else {
+      anchor.dataset.sessionHref = href;
+    }
+    provider.append(anchor);
+    let resolved: SessionLinkTarget | null = null;
+    anchor.addEventListener(action === "click" ? "click" : "keydown", (event) => {
+      resolved =
+        event instanceof KeyboardEvent
+          ? markdownSessionLinkFromKeyboardEvent(event)
+          : markdownSessionLinkFromEvent(event);
+      if (event instanceof MouseEvent) {
+        event.preventDefault();
+      }
+    });
+    const event =
+      action === "click"
+        ? new MouseEvent("click", { bubbles: true, cancelable: true })
+        : new KeyboardEvent("keydown", { key: action, bubbles: true, cancelable: true });
+    anchor.dispatchEvent(event);
+    expect(resolved).toEqual({
+      namespace: "chat",
+      pathname: "/control/chat/roboclaw/d0effac9",
+      search: "?view=full",
+      hash: "#latest",
+    });
+    expect(anchor.dataset.sessionKey).toBeUndefined();
+    expect(anchor.getAttribute("href") ?? anchor.dataset.sessionHref).toBe(href);
+    if (action !== "click") {
+      expect(event.defaultPrevented).toBe(true);
+    }
   });
 });

--- a/ui/src/components/markdown-session-links.ts
+++ b/ui/src/components/markdown-session-links.ts
@@ -9,7 +9,6 @@ import type { ApplicationContext } from "../app/context.ts";
 import { sessionNavigationTarget } from "../lib/sessions/route-navigation.ts";
 import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
 import { hasMarkdownLinkBoundaries } from "./markdown-link-boundary.ts";
-import type { SessionProgressHovercardProvider } from "./session-progress-hovercard.runtime.ts";
 
 export const SESSION_LINK_SCAN_RE = /agent:[^\s<>"'`]*[^\s<>"'`.,;:!?)}\]]/g;
 
@@ -162,7 +161,7 @@ export function markdownSessionLinkFromEvent(
     return parseSessionLinkKey(sessionKey);
   }
   // Lit assigns context before the lazy provider upgrades; routing must not wait for its card.
-  const context = anchor?.closest<SessionProgressHovercardProvider>(
+  const context = anchor?.closest<HTMLElement & { context?: ApplicationContext | null }>(
     "openclaw-session-progress-hovercard-provider",
   )?.context;
   const href = anchor?.getAttribute("href") ?? anchor?.dataset.sessionHref;

--- a/ui/src/components/markdown-session-links.ts
+++ b/ui/src/components/markdown-session-links.ts
@@ -36,6 +36,9 @@ function parseSessionLinkKey(raw: string): SessionKeyTarget | null {
 }
 
 export function parseMarkdownSessionUrl(raw: string, basePath?: string, mainKey?: string) {
+  if (!/^(?:https?:\/\/|\/)/i.test(raw.trim())) {
+    return null;
+  }
   try {
     const url = new URL(raw, globalThis.location.href);
     const target = sessionRefFromPath(
@@ -93,11 +96,7 @@ export function installMarkdownSessionLinks(markdownParser: MarkdownIt, scanPatt
           linkDepth++;
         } else if (token.type === "link_close") {
           linkDepth--;
-        } else if (
-          linkDepth === 0 &&
-          token.type === "code_inline" &&
-          /^(?:agent:|https?:\/\/|\/)/i.test(token.content.trim())
-        ) {
+        } else if (linkDepth === 0 && token.type === "code_inline") {
           const open = new state.Token("link_open", "a", 1);
           if (decorate(open, token.content)) {
             children.splice(index, 1, open, token, new state.Token("link_close", "a", -1));

--- a/ui/src/components/markdown-session-links.ts
+++ b/ui/src/components/markdown-session-links.ts
@@ -55,7 +55,8 @@ export function parseMarkdownSessionUrl(raw: string, basePath?: string, mainKey?
 }
 
 export function installMarkdownSessionLinks(markdownParser: MarkdownIt, scanPattern: RegExp): void {
-  markdownParser.core.ruler.after("linkify", "session-links", (state) => {
+  // Capture cleaned hrefs before file decoration can claim session-shaped paths.
+  markdownParser.core.ruler.before("file-links", "session-links", (state) => {
     if (state.env?.sessionLinks !== true) {
       return;
     }

--- a/ui/src/components/markdown-session-links.ts
+++ b/ui/src/components/markdown-session-links.ts
@@ -1,9 +1,15 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import type { ControlUiSessionNamespace } from "@openclaw/session-url-contract";
-import type { MarkdownIt } from "markdown-it";
+import type { MarkdownIt, Token } from "markdown-it";
+import { resolveGatewayPublicOrigin } from "../../../src/config/gateway-public-origin.js";
+import { sessionRefFromPath } from "../app-session-route-paths.ts";
+import { resolveControlUiPaths } from "../app/browser.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { sessionNavigationTarget } from "../lib/sessions/route-navigation.ts";
 import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
 import { hasMarkdownLinkBoundaries } from "./markdown-link-boundary.ts";
+import type { SessionProgressHovercardProvider } from "./session-progress-hovercard.runtime.ts";
 
 export const SESSION_LINK_SCAN_RE = /agent:[^\s<>"'`]*[^\s<>"'`.,;:!?)}\]]/g;
 
@@ -19,13 +25,7 @@ type SessionPathTarget = {
   hash?: string;
 };
 
-type SessionPathParser = typeof import("../app-session-route-paths.ts").sessionRefFromPath;
-
 export type SessionLinkTarget = SessionKeyTarget | SessionPathTarget;
-
-type SessionLinkMeta = {
-  sessionKey: string;
-};
 
 function parseSessionLinkKey(raw: string): SessionKeyTarget | null {
   const sessionKey = raw.trim();
@@ -36,17 +36,53 @@ function parseSessionLinkKey(raw: string): SessionKeyTarget | null {
   return { sessionKey, agentId: parsed.agentId };
 }
 
+export function parseMarkdownSessionUrl(raw: string, basePath?: string, mainKey?: string) {
+  try {
+    const url = new URL(raw, globalThis.location.href);
+    const target = sessionRefFromPath(
+      url.pathname,
+      basePath ?? resolveControlUiPaths(globalThis.location.pathname)[0],
+      mainKey,
+    );
+    return target && (url.protocol === "http:" || url.protocol === "https:")
+      ? { url, target }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export function installMarkdownSessionLinks(markdownParser: MarkdownIt, scanPattern: RegExp): void {
   markdownParser.core.ruler.after("linkify", "session-links", (state) => {
-    const sessionLinks: unknown = state.env?.sessionLinks;
-    if (sessionLinks !== true) {
+    if (state.env?.sessionLinks !== true) {
       return;
     }
+    const decorate = (token: Token, raw: string): boolean => {
+      const key = parseSessionLinkKey(raw);
+      const path = key ? null : parseMarkdownSessionUrl(raw);
+      if (!key && !path) {
+        return false;
+      }
+      if (path) {
+        // The context-aware titler also recognizes the Gateway's configured public origin.
+        token.attrSet("data-session-href", raw);
+        if (path.url.origin !== globalThis.location.origin) {
+          return false;
+        }
+        token.attrSet("href", raw);
+      } else if (key) {
+        token.attrSet("data-session-key", key.sessionKey);
+      }
+      token.attrJoin("class", "markdown-session-link");
+      token.attrSet("role", "link");
+      token.attrSet("tabindex", "0");
+      return true;
+    };
     for (const blockToken of state.tokens) {
-      if (blockToken.type !== "inline" || !blockToken.children) {
+      const children = blockToken.children;
+      if (blockToken.type !== "inline" || !children) {
         continue;
       }
-      const children = blockToken.children;
       let linkDepth = 0;
       for (let index = 0; index < children.length; index++) {
         const token = children[index];
@@ -54,112 +90,91 @@ export function installMarkdownSessionLinks(markdownParser: MarkdownIt, scanPatt
           continue;
         }
         if (token.type === "link_open") {
-          linkDepth += 1;
-          continue;
-        }
-        if (token.type === "link_close") {
-          linkDepth = Math.max(0, linkDepth - 1);
-          continue;
-        }
-        if (linkDepth > 0) {
-          continue;
-        }
-        if (token.type === "code_inline") {
-          const target = parseSessionLinkKey(token.content);
-          if (target) {
-            token.meta = {
-              ...token.meta,
-              sessionLink: { sessionKey: target.sessionKey } satisfies SessionLinkMeta,
-            };
-          }
-          continue;
-        }
-        if (token.type !== "text") {
-          continue;
-        }
-
-        const replacements: typeof children = [];
-        let cursor = 0;
-        scanPattern.lastIndex = 0;
-        for (const match of token.content.matchAll(scanPattern)) {
-          const matchIndex = match.index;
-          const matched = match[0];
-          const matchEnd = matchIndex + matched.length;
-          if (
-            !hasMarkdownLinkBoundaries(token.content, matchIndex, matchEnd) ||
-            !parseSessionLinkKey(matched)
-          ) {
-            continue;
-          }
-          if (matchIndex > cursor) {
-            const leading = new state.Token("text", "", 0);
-            leading.content = token.content.slice(cursor, matchIndex);
-            replacements.push(leading);
-          }
+          decorate(token, String(token.attrGet("href") ?? ""));
+          linkDepth++;
+        } else if (token.type === "link_close") {
+          linkDepth--;
+        } else if (
+          linkDepth === 0 &&
+          token.type === "code_inline" &&
+          /^(?:agent:|https?:\/\/|\/)/i.test(token.content.trim())
+        ) {
           const open = new state.Token("link_open", "a", 1);
-          open.markup = "session-link";
-          open.attrSet("class", "markdown-session-link");
-          open.attrSet("role", "link");
-          open.attrSet("tabindex", "0");
-          open.attrSet("data-session-key", matched);
-          const label = new state.Token("text", "", 0);
-          label.content = matched;
-          const close = new state.Token("link_close", "a", -1);
-          close.markup = "session-link";
-          replacements.push(open, label, close);
-          cursor = matchEnd;
+          if (decorate(open, token.content)) {
+            children.splice(index, 1, open, token, new state.Token("link_close", "a", -1));
+            index += 2;
+          } else if (open.attrGet("data-session-href")) {
+            token.attrSet("data-session-href", token.content);
+          }
+        } else if (linkDepth === 0 && token.type === "text") {
+          const replacements: Token[] = [];
+          let cursor = 0;
+          const text = (content: string) => {
+            const label = new state.Token("text", "", 0);
+            label.content = content;
+            replacements.push(label);
+          };
+          for (const match of token.content.matchAll(scanPattern)) {
+            const end = match.index + match[0].length;
+            const open = new state.Token("link_open", "a", 1);
+            if (
+              !hasMarkdownLinkBoundaries(token.content, match.index, end) ||
+              !decorate(open, match[0])
+            ) {
+              continue;
+            }
+            text(token.content.slice(cursor, match.index));
+            replacements.push(open);
+            text(match[0]);
+            replacements.push(new state.Token("link_close", "a", -1));
+            cursor = end;
+          }
+          if (cursor) {
+            text(token.content.slice(cursor));
+            children.splice(index, 1, ...replacements);
+            index += replacements.length - 1;
+          }
         }
-        if (replacements.length === 0) {
-          continue;
-        }
-        if (cursor < token.content.length) {
-          const trailing = new state.Token("text", "", 0);
-          trailing.content = token.content.slice(cursor);
-          replacements.push(trailing);
-        }
-        children.splice(index, 1, ...replacements);
-        index += replacements.length - 1;
       }
     }
   });
 }
 
-export function markdownSessionLinkFromEvent(event: Event): SessionLinkTarget | null {
-  const target = event.target;
-  if (!(target instanceof Element)) {
-    return null;
-  }
-  const sessionKey = target.closest<HTMLAnchorElement>("a[data-session-key]")?.dataset.sessionKey;
-  return sessionKey ? parseSessionLinkKey(sessionKey) : null;
+export function markdownSessionPublicOrigin(
+  context?: ApplicationContext | null,
+): string | undefined {
+  const config = context?.runtimeConfig?.state.configSnapshot?.runtimeConfig;
+  return resolveGatewayPublicOrigin({
+    gateway: { publicOrigin: readNonBlankString(asOptionalRecord(config?.gateway)?.publicOrigin) },
+  });
 }
 
-export function markdownSessionHref(
+export function markdownSessionLinkFromEvent(
   event: Event,
-  parseSessionPath: SessionPathParser,
-  basePath = "",
-): SessionPathTarget | null {
-  const target = event.target;
-  if (!(target instanceof Element)) {
+  basePath?: string,
+): SessionLinkTarget | null {
+  const anchor =
+    event.target instanceof Element
+      ? event.target.closest<HTMLElement>("a, [data-session-href]")
+      : null;
+  const sessionKey = anchor?.dataset.sessionKey;
+  if (sessionKey && !anchor.dataset.sessionHref) {
+    return parseSessionLinkKey(sessionKey);
+  }
+  // Lit assigns context before the lazy provider upgrades; routing must not wait for its card.
+  const context = anchor?.closest<SessionProgressHovercardProvider>(
+    "openclaw-session-progress-hovercard-provider",
+  )?.context;
+  const href = anchor?.getAttribute("href") ?? anchor?.dataset.sessionHref;
+  const path = href ? parseMarkdownSessionUrl(href, basePath ?? context?.basePath) : null;
+  if (
+    !path ||
+    (path.url.origin !== globalThis.location.origin &&
+      path.url.origin !== markdownSessionPublicOrigin(context))
+  ) {
     return null;
   }
-  const href = target.closest<HTMLAnchorElement>("a[href]")?.getAttribute("href")?.trim();
-  const location = globalThis.location;
-  if (!href || !location) {
-    return null;
-  }
-  let url: URL;
-  try {
-    url = new URL(href, location.href);
-  } catch {
-    return null;
-  }
-  if (url.origin !== location.origin) {
-    return null;
-  }
-  const parsed = parseSessionPath(url.pathname, basePath);
-  if (!parsed) {
-    return null;
-  }
+  const { url, target: parsed } = path;
   return {
     namespace: parsed.namespace,
     pathname: url.pathname,
@@ -170,11 +185,12 @@ export function markdownSessionHref(
 
 export function markdownSessionLinkFromKeyboardEvent(
   event: KeyboardEvent,
+  basePath?: string,
 ): SessionLinkTarget | null {
   if (event.key !== "Enter" && event.key !== " ") {
     return null;
   }
-  const target = markdownSessionLinkFromEvent(event);
+  const target = markdownSessionLinkFromEvent(event, basePath);
   if (target) {
     event.preventDefault();
   }

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -1,4 +1,3 @@
-// Control UI module implements markdown behavior.
 import DOMPurify from "dompurify";
 import { CONTROL_UI_ROOT_PUBLIC_ASSETS } from "../../../src/gateway/control-ui-root-assets.js";
 import { stripUnsupportedCitationControlMarkers } from "../../../src/shared/text/citation-control-markers.js";
@@ -78,6 +77,7 @@ const allowedAttrs = [
   "data-file-path",
   "data-link-favicon-host",
   "data-session-key",
+  "data-session-href",
   "data-table-interactions",
   "type",
   "aria-expanded",

--- a/ui/src/components/session-link-titling.test.ts
+++ b/ui/src/components/session-link-titling.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { GatewaySessionRow } from "../api/types.ts";
 import type { ApplicationContext } from "../app/context.ts";
+import { toSanitizedMarkdownHtml } from "./markdown.ts";
 import { SessionLinkTitler } from "./session-link-titling.ts";
 
 const SESSION_KEY = "agent:main:research";
@@ -134,5 +135,80 @@ describe("SessionLinkTitler", () => {
     expect(seededAnchor.textContent).toBe("Research plan");
     expect(seededAnchor.title).toBe(sessionKey);
     expect(request).not.toHaveBeenCalled();
+  });
+  it.each([
+    ["bare URL", `${location.origin}/chat/main/d0effac9?view=details#latest`],
+    ["relative href", "[Contract](/chat/main/old-name-d0effac9?view=details#latest)"],
+    ["slug-only href", "[Contract](/chat/main/shared-contract?view=details#latest)"],
+    ["inline code", "`/chat/main/d0effac9?view=details#latest`"],
+    ["public URL", "https://chat.example/chat/main/d0effac9?view=details#latest"],
+    ["public inline code", "`https://chat.example/chat/main/d0effac9?view=details#latest`"],
+  ])(
+    "connects %s to the same hover identity without losing route intent",
+    async (_kind, markdown) => {
+      const key = "agent:main:dashboard:d0effac9-3211-4641-b993-10f619f124e6";
+      const row: GatewaySessionRow = {
+        key,
+        kind: "direct",
+        displayName: "Shared contract",
+        updatedAt: Date.now(),
+      };
+      const { host, titler, request } = createTitler([row]);
+      titler.context = {
+        ...sessionContext([row]),
+        runtimeConfig: {
+          state: {
+            configSnapshot: {
+              runtimeConfig: { gateway: { publicOrigin: "https://CHAT.example:443/" } },
+            },
+          },
+        },
+      } as unknown as ApplicationContext;
+      host.innerHTML = toSanitizedMarkdownHtml(markdown, { sessionLinks: true, fileLinks: true });
+      titler.connect();
+      await Promise.resolve();
+      const link = host.querySelector<HTMLAnchorElement>("a.markdown-session-link");
+      expect(link?.dataset.sessionKey).toBe(key);
+      expect(link?.textContent).toBe("Shared contract");
+      expect(link?.getAttribute("href")).toMatch(
+        /^\/chat\/main\/(?:.*d0effac9|shared-contract)\?view=details#latest$/,
+      );
+      expect(link?.hasAttribute("target")).toBe(false);
+      expect(request).not.toHaveBeenCalled();
+      titler.disconnect();
+    },
+  );
+
+  it("keeps unknown and ambiguous URLs navigable without a hover identity, then refreshes a known row", () => {
+    const key = "agent:main:dashboard:d0effac9-3211-4641-b993-10f619f124e6";
+    const rows: GatewaySessionRow[] = [];
+    const { host, titler, request } = createTitler(rows);
+    host.innerHTML = toSanitizedMarkdownHtml("[Contract](/chat/main/d0effac9)", {
+      sessionLinks: true,
+    });
+    titler.refresh();
+    const link = host.querySelector<HTMLAnchorElement>("a")!;
+    expect(link.dataset.sessionKey).toBeUndefined();
+    expect(link.getAttribute("href")).toBe("/chat/main/d0effac9");
+    rows.push({ key, kind: "direct", displayName: "Shared contract", updatedAt: Date.now() });
+    titler.refresh();
+    expect(link.dataset.sessionKey).toBe(key);
+    rows.push({ key: key.replace("3211", "4322"), kind: "direct", updatedAt: Date.now() });
+    titler.refresh();
+    expect(link.dataset.sessionKey).toBeUndefined();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("leaves remote links and code spans plain", () => {
+    const { host, titler } = createTitler();
+    host.innerHTML = toSanitizedMarkdownHtml(
+      "[Remote](https://elsewhere.example/chat/main/d0effac9) `https://elsewhere.example/chat/main/d0effac9`",
+      { sessionLinks: true },
+    );
+    titler.refresh();
+    expect(host.querySelector(".markdown-session-link")).toBeNull();
+    expect(host.querySelectorAll("a")).toHaveLength(1);
+    expect(host.querySelector("a")?.target).toBe("_blank");
+    expect(host.querySelector("code")?.parentElement?.tagName).not.toBe("A");
   });
 });

--- a/ui/src/components/session-link-titling.ts
+++ b/ui/src/components/session-link-titling.ts
@@ -1,22 +1,18 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
-import { controlUiSessionSlug } from "@openclaw/session-url-contract";
 import type { ControlUiSessionPreview } from "../../../src/gateway/control-ui-contract.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
-import type { GatewaySessionRow } from "../api/types.ts";
 import { pathForSession } from "../app-session-path-builder.ts";
-import { sessionRefFromPath, type SessionPathTarget } from "../app-session-route-paths.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import {
   areUiSessionKeysEquivalent,
-  buildAgentMainSessionKey,
-  normalizeAgentId,
   parseAgentSessionKey,
   resolveUiConfiguredMainKey,
 } from "../lib/sessions/session-key.ts";
-import { sessionKeyUuid } from "../pages/chat/route-loader-short-cache.ts";
+import { findLocalSessionReference } from "../pages/chat/route-loader-short-cache.ts";
+import { markdownSessionPublicOrigin, parseMarkdownSessionUrl } from "./markdown-session-links.ts";
 
-const SESSION_LINK_SELECTOR = "a.markdown-session-link";
+const SESSION_LINK_SELECTOR = "a.markdown-session-link, [data-session-href]";
 const SUCCESS_CACHE_MS = 5 * 60_000;
 const FAILURE_CACHE_MS = 30_000;
 const CACHE_LIMIT = 100;
@@ -52,32 +48,15 @@ function titleFromPreview(value: unknown): SessionTitle {
   };
 }
 
-function titleFromRow(row: GatewaySessionRow, target: SessionTitleTarget): SessionTitle {
-  return {
-    ...target,
-    sessionKey: row.key,
-    agentId: row.agentId ?? parseAgentSessionKey(row.key)?.agentId ?? target.agentId,
-    title: row.displayName ?? row.derivedTitle,
-  };
-}
-
 export class SessionLinkTitler {
   client: GatewayBrowserClient | null = null;
   context: ApplicationContext | null = null;
 
   private readonly cache = new Map<string, CacheEntry>();
   private readonly observer = new MutationObserver((records) => {
-    for (const record of records) {
-      for (const node of record.addedNodes) {
-        if (!(node instanceof Element)) {
-          continue;
-        }
-        if (node instanceof HTMLAnchorElement && node.matches(SESSION_LINK_SELECTOR)) {
-          void this.decorate(node);
-        }
-        for (const anchor of node.querySelectorAll<HTMLAnchorElement>(SESSION_LINK_SELECTOR)) {
-          void this.decorate(anchor);
-        }
+    for (const node of records.flatMap((record) => [...record.addedNodes])) {
+      if (node instanceof HTMLElement) {
+        this.refresh(node);
       }
     }
   });
@@ -89,8 +68,11 @@ export class SessionLinkTitler {
     this.refresh();
   }
 
-  refresh(): void {
-    for (const anchor of this.host.querySelectorAll<HTMLAnchorElement>(SESSION_LINK_SELECTOR)) {
+  refresh(root = this.host): void {
+    if (root.matches(SESSION_LINK_SELECTOR)) {
+      void this.decorate(root);
+    }
+    for (const anchor of root.querySelectorAll<HTMLElement>(SESSION_LINK_SELECTOR)) {
       void this.decorate(anchor);
     }
   }
@@ -99,8 +81,19 @@ export class SessionLinkTitler {
     this.observer.disconnect();
   }
 
-  async decorate(anchor: HTMLAnchorElement, load = false): Promise<void> {
-    const target = this.targetForAnchor(anchor);
+  async decorate(element: HTMLElement, load = false): Promise<void> {
+    const target = this.targetForAnchor(element);
+    const anchor = element instanceof HTMLAnchorElement ? element : document.createElement("a");
+    if (element !== anchor && element.classList.contains("markdown-session-link")) {
+      anchor.dataset.sessionHref = element.dataset.sessionHref;
+      anchor.setAttribute("href", element.getAttribute("href") ?? "");
+      anchor.className = "markdown-session-link";
+      element.classList.remove("markdown-session-link");
+      element.removeAttribute("href");
+      element.removeAttribute("data-session-href");
+      element.replaceWith(anchor);
+      anchor.append(element);
+    }
     if (!target) {
       return;
     }
@@ -117,73 +110,51 @@ export class SessionLinkTitler {
   }
 
   private mainKey(): string {
-    const context = this.context;
-    return context
-      ? resolveUiConfiguredMainKey({
-          agentsList: context.agents.state.agentsList,
-          hello: context.gateway.snapshot.hello,
-        })
-      : "main";
+    return resolveUiConfiguredMainKey({
+      agentsList: this.context?.agents.state.agentsList,
+      hello: this.context?.gateway.snapshot.hello,
+    });
   }
 
-  private resolveShortTarget(target: Extract<SessionPathTarget, { kind: "short" }>): string | null {
-    const rows = this.context?.sessions.state.result?.sessions ?? [];
-    for (const row of rows) {
-      const parsed = parseAgentSessionKey(row.key);
-      const uuid = sessionKeyUuid(row.key);
-      if (
-        parsed &&
-        normalizeAgentId(parsed.agentId) === normalizeAgentId(target.agentId) &&
-        uuid?.startsWith(target.shortId.toLowerCase().replaceAll("-", "")) &&
-        (!target.slugHint || controlUiSessionSlug(row.displayName) === target.slugHint)
-      ) {
-        return row.key;
-      }
-    }
-    // Short refs are ambiguous without the loaded roster, so they never reach the preview RPC.
-    return null;
-  }
-
-  private targetForAnchor(anchor: HTMLAnchorElement): SessionTitleTarget | null {
+  private targetForAnchor(anchor: HTMLElement): SessionTitleTarget | null {
     const rawKey = anchor.dataset.sessionKey?.trim();
-    if (rawKey) {
+    if (rawKey && !anchor.dataset.sessionHref) {
       const parsed = parseAgentSessionKey(rawKey);
       return parsed ? { sessionKey: rawKey, agentId: parsed.agentId, namespace: "chat" } : null;
     }
-    let url: URL;
-    try {
-      url = new URL(anchor.href, globalThis.location?.href ?? "http://localhost/");
-    } catch {
-      return null;
-    }
-    if (url.origin !== globalThis.location?.origin) {
-      return null;
-    }
-    const target = sessionRefFromPath(url.pathname, this.context?.basePath ?? "", this.mainKey());
-    if (!target) {
-      return null;
-    }
-    const sessionKey =
-      target.kind === "main"
-        ? buildAgentMainSessionKey({ agentId: target.agentId, mainKey: this.mainKey() })
-        : target.kind === "literal"
-          ? target.sessionKey
-          : this.resolveShortTarget(target);
-    return sessionKey ? { sessionKey, agentId: target.agentId, namespace: target.namespace } : null;
-  }
-
-  private findSeedRow(target: SessionTitleTarget): GatewaySessionRow | undefined {
-    return this.context?.sessions.state.result?.sessions.find((row) =>
-      areUiSessionKeysEquivalent(row.key, target.sessionKey),
+    const path = parseMarkdownSessionUrl(
+      anchor.dataset.sessionHref ?? anchor.getAttribute("href") ?? "",
+      this.context?.basePath,
+      this.mainKey(),
     );
+    if (
+      !path ||
+      (path.url.origin !== globalThis.location.origin &&
+        path.url.origin !== markdownSessionPublicOrigin(this.context))
+    ) {
+      return null;
+    }
+    // Keep URL route intent (face, query, fragment) even when its identity is cached.
+    anchor.setAttribute("href", `${path.url.pathname}${path.url.search}${path.url.hash}`);
+    anchor.classList.add("markdown-session-link");
+    anchor.removeAttribute("target");
+    anchor.removeAttribute("rel");
+    anchor.removeAttribute("data-session-key");
+    const row = findLocalSessionReference(
+      this.context?.sessions.state.result?.sessions ?? [],
+      path.target,
+      this.mainKey(),
+    );
+    return row
+      ? { sessionKey: row.key, agentId: path.target.agentId, namespace: path.target.namespace }
+      : null;
   }
 
   private setCacheEntry(key: string, entry: CacheEntry): void {
     this.cache.delete(key);
     this.cache.set(key, entry);
-    while (this.cache.size > CACHE_LIMIT) {
-      const oldest = this.cache.keys().next().value;
-      if (!oldest) {
+    for (const oldest of this.cache.keys()) {
+      if (this.cache.size <= CACHE_LIMIT) {
         break;
       }
       this.cache.delete(oldest);
@@ -197,14 +168,19 @@ export class SessionLinkTitler {
       this.setCacheEntry(target.sessionKey, cached);
       return cached;
     }
-    if (cached) {
-      this.cache.delete(target.sessionKey);
-    }
-    const row = this.findSeedRow(target);
+    this.cache.delete(target.sessionKey);
+    const row = this.context?.sessions.state.result?.sessions.find((candidate) =>
+      areUiSessionKeysEquivalent(candidate.key, target.sessionKey),
+    );
     if (!row) {
       return undefined;
     }
-    const value = titleFromRow(row, target);
+    const value: SessionTitle = {
+      ...target,
+      sessionKey: row.key,
+      agentId: row.agentId ?? parseAgentSessionKey(row.key)?.agentId ?? target.agentId,
+      title: row.displayName ?? row.derivedTitle,
+    };
     const entry = { expiresAt: now + SUCCESS_CACHE_MS, promise: Promise.resolve(value), value };
     this.setCacheEntry(target.sessionKey, entry);
     return entry;
@@ -257,7 +233,9 @@ export class SessionLinkTitler {
       this.context?.basePath,
       { displayName: title, exactKey: true, mainKey: this.mainKey() },
     );
-    if (href && anchor.getAttribute("href") !== href) {
+    anchor.dataset.sessionKey = target.sessionKey;
+    anchor.classList.add("markdown-session-link");
+    if (!anchor.dataset.sessionHref && href && anchor.getAttribute("href") !== href) {
       anchor.setAttribute("href", href);
     }
     if (!title || anchor.classList.contains("markdown-session-link--titled")) {

--- a/ui/src/components/session-progress-hovercard-target.ts
+++ b/ui/src/components/session-progress-hovercard-target.ts
@@ -1,4 +1,4 @@
-export const SESSION_PROGRESS_HOVER_LINK_SELECTOR = "a.markdown-session-link[data-session-key]";
+export const SESSION_PROGRESS_HOVER_LINK_SELECTOR = "a.markdown-session-link, [data-session-href]";
 const SESSION_PROGRESS_HOVER_SIDEBAR_SELECTOR = ".sidebar-recent-session[data-session-key]";
 export const SESSION_MENU_OPEN_EVENT = "openclaw-session-menu-open";
 const SESSION_PROGRESS_HOVER_TARGET_SELECTOR = `${SESSION_PROGRESS_HOVER_LINK_SELECTOR}, ${SESSION_PROGRESS_HOVER_SIDEBAR_SELECTOR}`;

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -203,6 +203,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   };
 
   private readonly handleSessionUpdate = () => {
+    this.sessionLinkTitler.refresh();
     if (this.open && this.hovercard.held) {
       this.showCurrent();
     }

--- a/ui/src/pages/chat/components/chat-sidebar-content.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-content.ts
@@ -1,7 +1,6 @@
 import { html, nothing } from "lit";
 import { keyed } from "lit/directives/keyed.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
-import { sessionRefFromPath } from "../../../app-session-route-paths.ts";
 import { isStaleChunkImportError } from "../../../app/stale-chunk-reload.ts";
 import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
@@ -13,7 +12,6 @@ import {
   markdownFileLinkFromKeyboardEvent,
 } from "../../../components/markdown-file-links.ts";
 import {
-  markdownSessionHref,
   markdownSessionLinkFromEvent,
   markdownSessionLinkFromKeyboardEvent,
   type SessionLinkTarget,
@@ -450,9 +448,7 @@ export function handleSidebarClick(event: MouseEvent, callbacks: SidebarNavigati
     callbacks.onOpenWorkspaceFile?.(target);
     return;
   }
-  const sessionTarget =
-    markdownSessionLinkFromEvent(event) ??
-    markdownSessionHref(event, sessionRefFromPath, callbacks.basePath);
+  const sessionTarget = markdownSessionLinkFromEvent(event, callbacks.basePath);
   if (sessionTarget && shouldHandleNavigationClick(event)) {
     event.preventDefault();
     callbacks.onOpenSessionLink?.(sessionTarget);
@@ -465,13 +461,8 @@ export function handleSidebarKeydown(event: KeyboardEvent, callbacks: SidebarNav
     callbacks.onOpenWorkspaceFile?.(target);
     return;
   }
-  const sessionTarget =
-    markdownSessionLinkFromKeyboardEvent(event) ??
-    (event.key === "Enter"
-      ? markdownSessionHref(event, sessionRefFromPath, callbacks.basePath)
-      : null);
+  const sessionTarget = markdownSessionLinkFromKeyboardEvent(event, callbacks.basePath);
   if (sessionTarget) {
-    event.preventDefault();
     callbacks.onOpenSessionLink?.(sessionTarget);
   }
 }

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1,7 +1,5 @@
-// Public chat transcript renderer and DOM shell.
 import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
-import { sessionRefFromPath } from "../../../app-session-route-paths.ts";
 import { markdownBlocks } from "../../../components/markdown-blocks.ts";
 import { handleMarkdownCodeBlockClick } from "../../../components/markdown-code-blocks.ts";
 import {
@@ -9,7 +7,6 @@ import {
   markdownFileLinkFromKeyboardEvent,
 } from "../../../components/markdown-file-links.ts";
 import {
-  markdownSessionHref,
   markdownSessionLinkFromEvent,
   markdownSessionLinkFromKeyboardEvent,
 } from "../../../components/markdown-session-links.ts";
@@ -109,13 +106,8 @@ function renderTranscriptShell(
           props.onOpenWorkspaceFile?.(target);
           return;
         }
-        const sessionTarget =
-          markdownSessionLinkFromKeyboardEvent(event) ??
-          (event.key === "Enter"
-            ? markdownSessionHref(event, sessionRefFromPath, props.basePath)
-            : null);
+        const sessionTarget = markdownSessionLinkFromKeyboardEvent(event, props.basePath);
         if (sessionTarget) {
-          event.preventDefault();
           props.onOpenSessionLink?.(sessionTarget);
           return;
         }
@@ -137,9 +129,7 @@ function renderTranscriptShell(
           props.onOpenWorkspaceFile?.(target);
           return;
         }
-        const sessionTarget =
-          markdownSessionLinkFromEvent(event) ??
-          markdownSessionHref(event, sessionRefFromPath, props.basePath);
+        const sessionTarget = markdownSessionLinkFromEvent(event, props.basePath);
         if (sessionTarget && shouldHandleNavigationClick(event)) {
           event.preventDefault();
           props.onOpenSessionLink?.(sessionTarget);

--- a/ui/src/pages/chat/route-loader-short-cache.ts
+++ b/ui/src/pages/chat/route-loader-short-cache.ts
@@ -10,7 +10,12 @@ import {
   findUiSessionRow,
   SESSION_NAVIGATION_KEY_PARAM,
 } from "../../lib/sessions/route-navigation.ts";
-import { normalizeAgentId, parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
+import {
+  areUiSessionKeysEquivalent,
+  buildAgentMainSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../../lib/sessions/session-key.ts";
 import type { SessionRouteContext as ApplicationContext } from "./route-loader-context.ts";
 
 export function sessionKeyUuid(sessionKey: string): string | null {
@@ -18,15 +23,38 @@ export function sessionKeyUuid(sessionKey: string): string | null {
   return uuid ? uuid.toLowerCase().replaceAll("-", "") : null;
 }
 
-function rowMatchesShortTarget(
-  row: GatewaySessionRow,
-  target: Extract<SessionPathTarget, { kind: "short" }>,
-): boolean {
-  const uuid = sessionKeyUuid(row.key);
-  if (!uuid || !uuid.startsWith(target.shortId.toLowerCase().replaceAll("-", ""))) {
-    return false;
+export function findLocalSessionReference(
+  rows: readonly GatewaySessionRow[],
+  target: SessionPathTarget,
+  mainKey = "main",
+): GatewaySessionRow | undefined {
+  const scoped = rows.filter(
+    (row) => parseAgentSessionKey(row.key)?.agentId === normalizeAgentId(target.agentId),
+  );
+  if (target.kind !== "short") {
+    const key =
+      target.kind === "main"
+        ? buildAgentMainSessionKey({ agentId: target.agentId, mainKey })
+        : target.sessionKey;
+    const exact = scoped.find((row) => areUiSessionKeysEquivalent(row.key, key));
+    if (exact || target.kind === "main" || !target.slugCandidate) {
+      return exact;
+    }
   }
-  return !target.slugHint || controlUiSessionSlug(row.displayName) === target.slugHint;
+  const matches = scoped.filter((row) => {
+    const uuid = sessionKeyUuid(row.key);
+    return (
+      uuid &&
+      (target.kind !== "short" || uuid.startsWith(target.shortId.toLowerCase().replaceAll("-", "")))
+    );
+  });
+  const slug = target.kind === "short" ? target.slugHint : target.slugCandidate;
+  const slugMatches = slug
+    ? matches.filter((row) => controlUiSessionSlug(row.displayName) === slug)
+    : [];
+  // A stale name can narrow a short-id tie, but only slug matches resolve a slug-only URL.
+  const narrowed = slugMatches.length || target.kind !== "short" ? slugMatches : matches;
+  return narrowed.length === 1 ? narrowed[0] : undefined;
 }
 
 type CachedShortSession = {
@@ -52,7 +80,7 @@ export function findCachedShortSession(
       }
     };
     const carried = findUiSessionRow(context, carriedKey, target.agentId);
-    if (carried && rowMatchesShortTarget(carried, target)) {
+    if (carried && findLocalSessionReference([carried], target)) {
       preserveLocationKeyForCanonicalReload();
       return { sessionKey: carried.key, row: carried };
     }


### PR DESCRIPTION
## Problem

Chat URLs pasted into messages rendered as ordinary links without the session hover card. Peter reported this for a host-local `/chat/<agent>/<short-id>` link in the Team Control UI. Raw `agent:` keys already had the session presentation.

## Solution

Recognize absolute and root-relative chat-route hrefs, linkified URLs, and inline code in the existing session decoration pass. Document-relative hrefs are excluded before URL resolution so workspace file links retain their existing handling. The context-aware titler resolves loaded sessions with the router's shared local reference resolver and supplies the hover identity. The lazy hover-card loader now recognizes URL candidates before that identity is available. Synchronous click and keyboard routing reads the already-assigned application context through a narrow host type, so navigation does not depend on the hover-card chunk or introduce a cycle through its implementation.

Reuse canonical URL grammar and Gateway public-origin normalization; preserve the original route's face, query, and fragment. Keep file-looking session route literals out of the file-link decorator. Remove duplicated URL parsing, the separate inline-code session renderer, and duplicate title-refresh traversal.

## Impact

Same-origin and root-relative session URLs receive the existing session title/card and navigate inside the Control UI. The already-loaded applied `gateway.publicOrigin` is recognized as an alias. Unloaded and ambiguous sessions remain navigable without a card; other origins retain normal browser behavior. Short IDs tolerate stale title slugs, while slug-only routes require a unique matching session. No dependencies, configuration options, schemas, or live Gateway changes.

## Evidence

- Document-relative follow-up: all 205 focused tests passed with both decorators enabled, including the four new chat-route cases. The relative file and relative route cases failed on the prior head. `node scripts/check-changed.mjs` and fresh P2 autoreview passed.

- `node scripts/run-vitest.mjs ui/src/components/markdown` — 109 tests passed.
- `node scripts/run-vitest.mjs ui/src/components/markdown-links.test.ts ui/src/components/session-link-titling.test.ts` — 119 tests passed.
- `node scripts/run-vitest.mjs ui/src/components/markdown-links.test.ts ui/src/components/markdown-session-links.test.ts ui/src/components/session-link-titling.test.ts ui/src/components/session-progress-hovercard-target.test.ts ui/src/pages/chat/components/chat-transcript-render.test.ts ui/src/pages/chat/components/chat-sidebar.test.ts ui/src/pages/chat/route-resolution-handoff.test.ts` — 220 tests passed across two routed shards (including the session-link event and router-handoff suites).
- `node scripts/run-vitest.mjs ui/src/pages/chat/route-resolution-handoff.test.ts` — 10 tests passed, including canonical reload, cold-cache, and changed-connection cases.
- Regression proof against untouched source — 11 assertions failed for missing URL decoration/hover identity, and six cold public-origin anchor/code event assertions failed separately; all pass on the repaired source.
- Mock UI on port 5187, Chromium at 1100×720, device scale 2, light mode: actual hover shows the card; clicking retains a document marker while changing the app route (no full page load). Screenshots contain only synthetic fixtures.
- A real click on a public-origin code URL dispatched the in-app route while the hovercard chunk was deliberately held unloaded. Cold public-origin anchors are covered by unit tests because the standalone mock cancels foreign-origin anchor clicks before application handlers. No live Team Gateway was accessed.
- `node scripts/check-changed.mjs` — passed, including core/UI typechecks, lint, style, i18n, formatting, and dead-export scans.
- `pnpm check:architecture` — passed after CI identified and the follow-up removed a type-only import cycle; runtime and full import graphs now both report zero cycles.
- Follow-up UI typecheck, targeted lint, seven event tests, and fresh P2 autoreview — passed.
- `git diff --check` — passed.
- Codex autoreview through P2 — scoped-clean after fixing the public-origin initialization race.
- Production LOC: **+232 −234** for the task diff. Funded by the shared parsing/resolution, inline-code renderer removal, and refresh traversal consolidation.

| Before | After |
| --- | --- |
| ![Host-local chat URL is a plain link without a session card](https://github.com/user-attachments/assets/f3924d86-1797-49e4-9362-7a5ca366f38e) | ![The same chat URL resolves to the session title and hover card](https://github.com/user-attachments/assets/149ca9bd-6e2a-4e55-ad25-2bfea3e4a997) |

Release-note: Control UI chat URLs now show session hover cards and open inside the app, including known public-origin aliases.