### PR TITLE
refactor(cli): reduce repeated command argument parsing

### DIFF
--- a/src/cli/argv-invocation.ts
+++ b/src/cli/argv-invocation.ts
@@ -6,7 +6,7 @@ import {
   isRootHelpInvocation,
 } from "./argv.js";
 import { resolveGatewayCatalogCommandPath } from "./gateway-run-argv.js";
-import { resolveParentAwareCommandPath } from "./parent-command-path.js";
+import { resolveCliParentCommandPath } from "./parent-command-path.js";
 
 type CliArgvInvocation = {
   argv: string[];
@@ -22,7 +22,7 @@ export function resolveCliArgvInvocation(argv: string[]): CliArgvInvocation {
     argv,
     commandPath:
       resolveGatewayCatalogCommandPath(argv) ??
-      resolveParentAwareCommandPath(argv) ??
+      resolveCliParentCommandPath(argv) ??
       getCommandPathWithRootOptions(argv, 2),
     primary: getPrimaryCommand(argv),
     hasHelpOrVersion: isHelpOrVersionInvocation(argv),

--- a/src/cli/command-path-policy.ts
+++ b/src/cli/command-path-policy.ts
@@ -8,7 +8,7 @@ import {
 } from "./command-catalog.js";
 import { matchesCommandPath } from "./command-path-matches.js";
 import { resolveGatewayCatalogCommandPath } from "./gateway-run-argv.js";
-import { resolveParentAwareCommandPath } from "./parent-command-path.js";
+import { resolveCliParentCommandPath } from "./parent-command-path.js";
 
 const DEFAULT_CLI_COMMAND_PATH_POLICY: CliCommandPathPolicy = {
   configGuard: "run",
@@ -44,7 +44,7 @@ function resolveCliCatalogCommandPath(argv: string[]): string[] {
   // Gateway `run openclaw ...` argv needs catalog routing against the embedded command path.
   const tokens =
     resolveGatewayCatalogCommandPath(argv) ??
-    resolveParentAwareCommandPath(argv) ??
+    resolveCliParentCommandPath(argv) ??
     getCommandPathWithRootOptions(argv, argv.length);
   if (tokens.length === 0) {
     return [];

--- a/src/cli/config-output-mode.ts
+++ b/src/cli/config-output-mode.ts
@@ -1,4 +1,4 @@
-import { resolveConfigParentCommandPath } from "./parent-command-path.js";
+import { resolveCliParentCommandPath } from "./parent-command-path.js";
 
 function hasFlag(argv: readonly string[], flag: string): boolean {
   for (const arg of argv.slice(2)) {
@@ -14,7 +14,7 @@ function hasFlag(argv: readonly string[], flag: string): boolean {
 
 /** Config values, paths, and schemas reserve stdout for machine-consumed output. */
 export function isConfigMachineOutput(argv: readonly string[]): boolean {
-  const subcommand = resolveConfigParentCommandPath(argv)?.[1];
+  const subcommand = resolveCliParentCommandPath(argv, "config")?.[1];
   return subcommand === "get" || subcommand === "file" || subcommand === "schema";
 }
 

--- a/src/cli/models-output-mode.ts
+++ b/src/cli/models-output-mode.ts
@@ -1,18 +1,18 @@
 import type { Command } from "commander";
 import { hasMachineOutputOption } from "./machine-output-argv.js";
-import { resolveModelsParentCommandPath } from "./parent-command-path.js";
+import { resolveCliParentCommandPath } from "./parent-command-path.js";
 
 /** Resolve the parent-command alias for `models status --json`. */
 export function isModelsStatusJsonOutput(argv: readonly string[], command?: Command): boolean {
   return (
     hasMachineOutputOption(argv, "--json", command) ||
-    (resolveModelsParentCommandPath(argv)?.length === 1 &&
+    (resolveCliParentCommandPath(argv, "models")?.length === 1 &&
       hasMachineOutputOption(argv, "--status-json", command))
   );
 }
 
 export function isModelsPlainMachineOutput(argv: readonly string[], command?: Command): boolean {
-  const commandPath = resolveModelsParentCommandPath(argv);
+  const commandPath = resolveCliParentCommandPath(argv, "models");
   return (
     commandPath !== null &&
     (hasMachineOutputOption(argv, "--plain", command) ||

--- a/src/cli/parent-command-path.ts
+++ b/src/cli/parent-command-path.ts
@@ -32,15 +32,31 @@ const UPDATE_PARENT_VALUE_FLAGS = UPDATE_OPTION_SPECS.filter(([flags]) => flags.
   ([flags]) => flags.slice(0, flags.indexOf(" ")),
 );
 
-function resolveParentCommandPath(
+type ParentCommandFlags = readonly [booleanFlags: readonly string[], valueFlags: readonly string[]];
+
+const PARENT_COMMAND_FLAGS: ReadonlyMap<string, ParentCommandFlags> = new Map([
+  ["agent", [AGENT_PARENT_BOOLEAN_FLAGS, AGENT_PARENT_VALUE_FLAGS]],
+  ["models", [MODELS_PARENT_BOOLEAN_FLAGS, MODELS_PARENT_VALUE_FLAGS]],
+  ["config", [[], ["--section"]]],
+  ["skills", [["--json"], ["--agent"]]],
+  ["channels", [[], ["--agent"]]],
+  ["update", [UPDATE_PARENT_BOOLEAN_FLAGS, UPDATE_PARENT_VALUE_FLAGS]],
+]);
+
+/** Resolve the parent commands whose options may precede a child command. */
+export function resolveCliParentCommandPath(
   argv: readonly string[],
-  command: string,
-  booleanFlags: readonly string[],
-  valueFlags: readonly string[],
+  expectedParent?: "models" | "config" | "skills",
 ): string[] | null {
-  if (getRootOptionAwareCommandPath(argv, 1)[0] !== command) {
+  const [command] = getRootOptionAwareCommandPath(argv, 1);
+  if (!command || (expectedParent && command !== expectedParent)) {
     return null;
   }
+  const flags = PARENT_COMMAND_FLAGS.get(command);
+  if (!flags) {
+    return null;
+  }
+  const [booleanFlags, valueFlags] = flags;
   const child = getCommandPositionalsWithRootOptions(argv, {
     commandPath: [command],
     booleanFlags,
@@ -49,33 +65,4 @@ function resolveParentCommandPath(
     mode: "command-path",
   })?.[0];
   return child ? [command, child] : [command];
-}
-
-export function resolveModelsParentCommandPath(argv: readonly string[]): string[] | null {
-  return resolveParentCommandPath(
-    argv,
-    "models",
-    MODELS_PARENT_BOOLEAN_FLAGS,
-    MODELS_PARENT_VALUE_FLAGS,
-  );
-}
-
-export function resolveConfigParentCommandPath(argv: readonly string[]): string[] | null {
-  return resolveParentCommandPath(argv, "config", [], ["--section"]);
-}
-
-export function resolveSkillsParentCommandPath(argv: readonly string[]): string[] | null {
-  return resolveParentCommandPath(argv, "skills", ["--json"], ["--agent"]);
-}
-
-/** Resolve the parent commands whose options may precede a child command. */
-export function resolveParentAwareCommandPath(argv: readonly string[]): string[] | null {
-  return (
-    resolveParentCommandPath(argv, "agent", AGENT_PARENT_BOOLEAN_FLAGS, AGENT_PARENT_VALUE_FLAGS) ??
-    resolveModelsParentCommandPath(argv) ??
-    resolveConfigParentCommandPath(argv) ??
-    resolveSkillsParentCommandPath(argv) ??
-    resolveParentCommandPath(argv, "channels", [], ["--agent"]) ??
-    resolveParentCommandPath(argv, "update", UPDATE_PARENT_BOOLEAN_FLAGS, UPDATE_PARENT_VALUE_FLAGS)
-  );
 }

--- a/src/cli/skills-output-mode.ts
+++ b/src/cli/skills-output-mode.ts
@@ -1,11 +1,11 @@
 import type { Command } from "commander";
 import { hasMachineOutputOption } from "./machine-output-argv.js";
-import { resolveSkillsParentCommandPath } from "./parent-command-path.js";
+import { resolveCliParentCommandPath } from "./parent-command-path.js";
 
 /** Skill verification emits JSON unless the caller explicitly requests the Markdown card. */
 export function isSkillsMachineOutput(argv: readonly string[], command?: Command): boolean {
   return (
-    resolveSkillsParentCommandPath(argv)?.[1] === "verify" &&
+    resolveCliParentCommandPath(argv, "skills")?.[1] === "verify" &&
     !hasMachineOutputOption(argv, "--card", command)
   );
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

CLI command argument preparation does unnecessary work before choosing the command path. This cleanup reduces that overhead while preserving accepted arguments and output modes.

## Why This Change Was Made

Resolve the parent command once, then apply its existing option grammar, instead of trying parent-specific parsers in sequence. Five callers use the canonical resolver; obsolete wrappers are removed. Gateway precedence, raw primary-command identity and specialized models/config/skills guards remain unchanged.

## User Impact

No visible behavior, flags, configuration or dependencies change. The six-file cleanup removes **13 net production lines** (32 added, 45 removed; tests unchanged). Measured gains concern argument preparation only and are below one microsecond per invocation, not whole-CLI startup or Gateway latency.

## Evidence

- The same ten complete test files pass before and after: **382 tests each**. The normal changed gate passes all **28 executable stages**; no redundant tests were added.
- A fixed real-module proof checks 28 literal argument cases across five operations before and after. Independent decoding verifies all **266,584 returned values**, including the four timing hosts, with no output mismatch.
- Scoped P0–P2 code review completed eight passes with no findings.

The timing hosts ran once in fixed **B0, C0, C1, B1** order. Below are changes in median per-call batch means for the actual `resolveCliArgvInvocation` function; negative means faster. Forward compares B0→C0; reverse compares B1→C1.

| Invocation | Forward | Reverse | Absolute median reduction |
| --- | ---: | ---: | ---: |
| skills | −6.96% | −6.27% | 57–67 ns |
| channels | −17.63% | −11.25% | 104–180 ns |
| update | −20.73% | −22.21% | 245–268 ns |
| other command | −14.24% | −9.15% | 75–118 ns |

Results are mixed elsewhere: agent is −1.78%/+1.36%, models −4.36%/−1.15%, config −2.63%/−2.79%, and the unchanged Gateway invocation control −2.82%/+2.97%. The separate parent-only component regresses for agent (+10.81%) and models (+0.36%) in forward order. No pooled speedup, universal threshold pass, startup, live-provider or memory improvement is claimed. Batch p95 describes 32 batch means, not individual-call p95.

All **36 adverse comparisons out of 160** are retained below. The original experiment also remains **failed**: nested process observers counted 33 identities against the preset 32 cap, including 26 observer-created `ps` children, and stopped before any candidate timing. The separate corrected experiment removed the nested observer, preserved the workload, output formats and caps, and completed once in 130.683 seconds. No partial timing from the failed run was reused. All observed processes/groups closed and measurement admission is disabled. This is bounded real-module argument proof, not a full CLI or live Gateway run.

<details>
<summary>All adverse timing observations</summary>

Positive values mean slower. `invoke` is the complete argument-invocation resolver; `parent` is the actual direct-parent component. `firstNs` is one first call; other metrics summarize batch means.

| Before → candidate | Row | Surface | Metric | Delta ns | Change |
| --- | --- | --- | --- | ---: | ---: |
| B0 → C0 | P01-agent | invoke | maxBatchMeanNs | +573.242 | +11.237% |
| B0 → C0 | P01-agent | parent | firstNs | +6417.000 | +20.399% |
| B0 → C0 | P01-agent | parent | medianBatchMeanNs | +45.895 | +10.812% |
| B0 → C0 | P01-agent | parent | p95BatchMeanNs | +44.602 | +6.733% |
| B0 → C0 | P01-agent | parent | maxBatchMeanNs | +1132.164 | +120.681% |
| B0 → C0 | P01-agent | parent | overallBatchMeanNs | +97.401 | +21.704% |
| B0 → C0 | P02-models | parent | firstNs | +7375.000 | +81.564% |
| B0 → C0 | P02-models | parent | medianBatchMeanNs | +0.980 | +0.359% |
| B0 → C0 | P02-models | parent | p95BatchMeanNs | +84.961 | +22.461% |
| B0 → C0 | P02-models | parent | maxBatchMeanNs | +3299.797 | +743.171% |
| B0 → C0 | P02-models | parent | overallBatchMeanNs | +107.085 | +36.937% |
| B0 → C0 | P03-config | invoke | maxBatchMeanNs | +91.469 | +3.777% |
| B0 → C0 | P03-config | parent | p95BatchMeanNs | +132.156 | +21.981% |
| B0 → C0 | P04-skills | parent | maxBatchMeanNs | +656.906 | +42.547% |
| B0 → C0 | P05-channels | parent | firstNs | +125.000 | +1.345% |
| B0 → C0 | P06-update | invoke | firstNs | +22583.000 | +111.290% |
| B0 → C0 | P06-update | parent | p95BatchMeanNs | +423.500 | +58.210% |
| B0 → C0 | P07-other | invoke | maxBatchMeanNs | +97.328 | +3.506% |
| B1 → C1 | P01-agent | invoke | firstNs | +15625.000 | +6.155% |
| B1 → C1 | P01-agent | invoke | medianBatchMeanNs | +20.672 | +1.359% |
| B1 → C1 | P01-agent | invoke | p95BatchMeanNs | +831.062 | +24.450% |
| B1 → C1 | P01-agent | invoke | overallBatchMeanNs | +80.679 | +4.633% |
| B1 → C1 | P02-models | invoke | p95BatchMeanNs | +1380.859 | +109.161% |
| B1 → C1 | P02-models | invoke | overallBatchMeanNs | +80.078 | +7.452% |
| B1 → C1 | P03-config | invoke | p95BatchMeanNs | +607.094 | +37.616% |
| B1 → C1 | P03-config | parent | firstNs | +1042.000 | +11.472% |
| B1 → C1 | P03-config | parent | maxBatchMeanNs | +91.141 | +5.846% |
| B1 → C1 | P04-skills | invoke | p95BatchMeanNs | +170.578 | +8.033% |
| B1 → C1 | P04-skills | invoke | maxBatchMeanNs | +479.164 | +20.921% |
| B1 → C1 | P05-channels | parent | firstNs | +1.000 | +0.010% |
| B1 → C1 | P06-update | invoke | p95BatchMeanNs | +46.219 | +1.721% |
| B1 → C1 | P06-update | invoke | maxBatchMeanNs | +259.766 | +8.508% |
| B1 → C1 | P07-other | invoke | p95BatchMeanNs | +338.867 | +13.594% |
| B1 → C1 | P07-other | invoke | maxBatchMeanNs | +1035.148 | +40.805% |
| B1 → C1 | P08-gateway | invoke | firstNs | +18959.000 | +32.501% |
| B1 → C1 | P08-gateway | invoke | medianBatchMeanNs | +26.688 | +2.973% |

</details>
