### PR TITLE
fix(gateway): avoid slow scratch preparation when starting workers

### DIFF
--- a/src/gateway/worker-environments/bundle.ts
+++ b/src/gateway/worker-environments/bundle.ts
@@ -1,12 +1,12 @@
 import { createHash, randomUUID } from "node:crypto";
 import { createReadStream, type Dirent } from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import * as tar from "tar";
 import { resolveStateDir } from "../../config/paths.js";
 import { isExactSemverVersion, resolveNpmJsonEntries } from "../../infra/npm-registry-spec.js";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import {
   DEFAULT_WORKER_BUNDLE_ARCHIVE_LIMITS,
@@ -196,7 +196,9 @@ async function verifyPublishedNpmRelease(params: {
   runCommand?: WorkerNpmProofCommandRunner;
 }): Promise<string> {
   const runCommand = params.runCommand ?? runCommandWithTimeout;
-  const temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-worker-npm-proof-"));
+  const temporaryRoot = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-worker-npm-proof-"),
+  );
   try {
     const published = parseNpmPackageIdentity(
       unwrapNpmJsonEntry(

--- a/src/gateway/worker-environments/node-bootstrap-artifact.ts
+++ b/src/gateway/worker-environments/node-bootstrap-artifact.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
 import { constants as fsConstants, createReadStream, readFileSync } from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { valid } from "semver";
@@ -21,6 +20,7 @@ import {
   composePackagePlugins,
   type DistributionPackageManifest,
 } from "../../infra/package-plugin-composition.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import {
   DEFAULT_WORKER_BUNDLE_ARCHIVE_LIMITS,
   readWorkerBundleArchiveManifest,
@@ -459,7 +459,9 @@ export function createNodeBootstrapArtifactProvider(options: ArtifactOptions) {
       }
       prepared ??= (async () => {
         try {
-          temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-node-runtime-"));
+          temporaryRoot = await fs.mkdtemp(
+            path.join(resolvePreferredOpenClawTmpDir(), "openclaw-node-runtime-"),
+          );
           if (closed) {
             throw new Error("Node bootstrap artifact provider is closed");
           }

--- a/src/gateway/worker-environments/project-preparation.ts
+++ b/src/gateway/worker-environments/project-preparation.ts
@@ -1,9 +1,9 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import type { WorkerProvider } from "../../plugins/types.js";
 import { createProjectSeedScript } from "./project-seed-script.js";
 import {
@@ -88,7 +88,9 @@ export function createWorkerProjectPreparation(params: {
     ) {
       throw new Error("Project preparation returned an invalid staging directory");
     }
-    const temporaryRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-project-base-"));
+    const temporaryRoot = await fsp.mkdtemp(
+      path.join(resolvePreferredOpenClawTmpDir(), "openclaw-project-base-"),
+    );
     try {
       requireCurrent();
       const pack = await prepareWorkerWorkspaceGitPack({

--- a/src/gateway/worker-environments/ssh.ts
+++ b/src/gateway/worker-environments/ssh.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { normalizeScpRemoteHost } from "../../infra/scp-host.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { registerSecretValueForRedaction } from "../../logging/secret-redaction-registry.js";
 import type { WorkerSshEndpoint, WorkerSshIdentity } from "../../plugins/types.js";
 import type { CommandOptions } from "../../process/exec.js";
@@ -151,7 +151,10 @@ export async function prepareWorkerSsh(params: {
     )
     .join("");
   const temporaryDir = await fs.mkdtemp(
-    path.resolve(os.tmpdir(), params.temporaryDirectoryPrefix ?? "openclaw-worker-ssh-"),
+    path.resolve(
+      resolvePreferredOpenClawTmpDir(),
+      params.temporaryDirectoryPrefix ?? "openclaw-worker-ssh-",
+    ),
   );
   try {
     const identity = await params.resolveIdentity(params.ssh.keyRef);

--- a/src/gateway/worker-environments/workspace-accepted-sync.ts
+++ b/src/gateway/worker-environments/workspace-accepted-sync.ts
@@ -1,7 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import type { SpawnResult } from "../../process/exec.js";
 import type { WorkerWorkspaceCommand } from "./tunnel-contract.js";
 import {
@@ -224,7 +224,7 @@ function createAcceptedWorkspacePublisher(params: {
       const transferPaths = [...changed].filter((entryPath) => acceptedNodes.has(entryPath));
       if (transferPaths.length > 0) {
         const temporaryDirectory = await fs.mkdtemp(
-          path.join(os.tmpdir(), "openclaw-worker-workspace-accepted-"),
+          path.join(resolvePreferredOpenClawTmpDir(), "openclaw-worker-workspace-accepted-"),
         );
         const transferListPath = path.join(temporaryDirectory, "transfer-list");
         try {

--- a/src/gateway/worker-environments/workspace-reconcile-recovery.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-recovery.ts
@@ -1,8 +1,8 @@
 import { createHash, randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { FsSafeError, root as openFsSafeRoot } from "../../infra/fs-safe.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import {
   createStagedInputPathMatcher,
   stagedInputDirectoriesFromEntries,
@@ -147,7 +147,9 @@ export async function createWorkspacePatch(params: {
   baseEntries: WorkerWorkspaceManifestEntry[];
   appliedEntries: WorkerWorkspaceManifestEntry[];
 }): Promise<{ patch: Uint8Array; baseTree: string; basePack: Uint8Array }> {
-  const temporary = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-patch-"));
+  const temporary = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-workspace-patch-"),
+  );
   try {
     // Rollback journals have a fixed SHA-1 object-id contract. Do not inherit
     // user or process defaults that can switch temporary repositories to SHA-256.
@@ -247,7 +249,9 @@ export async function applyWorkspacePatch(params: {
   }
   // Run no-index with discovery disabled so workspace .gitattributes and
   // repository filter config cannot reinterpret authenticated patch bytes.
-  const temporary = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-no-git-"));
+  const temporary = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-no-git-"),
+  );
   try {
     await requireGit(
       params.root,
@@ -277,7 +281,9 @@ function validateJournalSnapshot(journal: WorkerWorkspaceReconciliationJournal):
 }
 
 async function createWorkspaceRecoveryPatch(params: WorkspaceRecoveryContext): Promise<Uint8Array> {
-  const temporary = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-recovery-"));
+  const temporary = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-workspace-recovery-"),
+  );
   try {
     await requireGit(temporary, ["init", "--quiet", "--object-format=sha1"]);
     await requireGit(temporary, ["index-pack", "--stdin"], params.journal.basePack);

--- a/src/gateway/worker-environments/workspace-result-staging.ts
+++ b/src/gateway/worker-environments/workspace-result-staging.ts
@@ -1,8 +1,8 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { runBestEffortCleanup } from "../../infra/non-fatal-cleanup.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { runCommandBuffered, runCommandWithTimeout } from "../../process/exec.js";
 import type { WorkerWorkspaceReconcileRequest } from "./tunnel-contract.js";
@@ -493,7 +493,9 @@ async function applyStagedWorkerWorkspaceResultWithMemo(
       changed: staged.changed,
     };
   }
-  const stagingRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-staged-result-"));
+  const stagingRoot = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-staged-result-"),
+  );
   try {
     for (const entry of staged.changedEntries) {
       const object = staged.objectsByPath.get(entry.path)!;

--- a/src/gateway/worker-environments/workspace-sync-preflight.ts
+++ b/src/gateway/worker-environments/workspace-sync-preflight.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import {
   createWorkspaceGitTransferList,
   runWorkspaceInventoryCommandToFile,
@@ -25,7 +25,7 @@ export async function preflightWorkerWorkspace(params: {
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
   const signal = params.signal ? AbortSignal.any([params.signal, timeoutSignal]) : timeoutSignal;
   const temporaryDirectory = await fs.mkdtemp(
-    path.join(os.tmpdir(), "openclaw-worker-workspace-preflight-"),
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-worker-workspace-preflight-"),
   );
   try {
     const canonicalRoot = await fs.realpath(params.localPath);

--- a/src/gateway/worker-environments/workspace-sync.ts
+++ b/src/gateway/worker-environments/workspace-sync.ts
@@ -1,8 +1,8 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { withTimeout } from "../../infra/fs-safe.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import type { CommandOptions, SpawnResult } from "../../process/exec.js";
 import { type PreparedWorkerSsh, runWorkerSshCandidates, workerSshCommandOptions } from "./ssh.js";
 import type {
@@ -241,7 +241,7 @@ export function createWorkerWorkspaceActions(
       runTask,
     });
     const temporaryDirectory = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-worker-workspace-sync-"),
+      path.join(resolvePreferredOpenClawTmpDir(), "openclaw-worker-workspace-sync-"),
     );
     try {
       const receiverContext = {
@@ -459,7 +459,7 @@ export function createWorkerWorkspaceActions(
       "Worker tunnel did not reconnect within the workspace reconciliation timeout",
     );
     const temporaryDirectory = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-worker-workspace-reconcile-"),
+      path.join(resolvePreferredOpenClawTmpDir(), "openclaw-worker-workspace-reconcile-"),
     );
     const stagingRoot = path.join(temporaryDirectory, "staging");
     const manifestRoot = path.join(temporaryDirectory, "manifests");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where starting a worker session could spend several seconds preparing local workspace scratch files on macOS before the remote worker could start.

## Why This Change Was Made

Use the existing secure OpenClaw temporary-directory owner for worker preparation, workspace transfer/recovery, bootstrap artifacts and temporary SSH identities. The same canonical workspace preflight took 12,323ms and 2,764ms with the system temp parent, versus 93ms and 100ms with the secure parent in alternating same-process measurements. Temporary-directory creation dominated; Git and inventory checks did not.

Unique temporary leaf directories, permission checks, cancellation, workspace validation, recovery journals and cleanup remain unchanged. No cache, dependency, configuration, environment variable, protocol or storage change. Moving the scratch parent repairs the producer without bypassing mutable workspace validation or adding timeout/retry workarounds.

## User Impact

Worker session preparation avoids the observed slow system scratch path. This improves one measured admission phase; it does not claim that cold cloud provisioning meets a ten-second end-to-end target.

## Evidence

- Direct canonical candidate preflight, without modifying builtins: 341/44/283/189ms. The paired before/after measurements above used the same project and process.
- 148 existing tests across 14 owner/sibling files passed: workspace eligibility, escaping links, cancellation, bounded inventories, Git transfer/recovery, SSH disposal, bootstrap artifact lifetimes, Windows secure-temp fallback, and browser-safe imports.
- Both pinned and local formatter checks passed; independent P0–P2 autoreview found no actionable defects. Mechanical refresh over main preserves the nine-file patch.
- Full canonical changed gate, exact-head CI and actual Gateway live starts passed; details below.

Production delta: +38/-21 (+17 net), from wrapping the longer existing helper invocation. Test/generated/lockfile delta: zero. No new wall-clock unit assertions or source-shape tests: actual preflight measurements establish the performance difference, while existing functional coverage verifies the preserved contracts.

Provenance: the current system-temp call sites demonstrate the bottleneck; original regression attribution is not established. Related dispatch isolation repair: https://github.com/openclaw/openclaw/pull/139251.

### Final verification and review disposition

The full canonical changed gate passed on exact f00967e8, base 967bd8a, in 887.065 seconds. All 38,158 source entries matched before/after locally and remotely (SHA-256 e9ec563854d73212d22d612c99aa834ba2eef240e44a46b831fa0f201ff35df8). The Testbox environment run is https://github.com/openclaw/openclaw/actions/runs/33991630210; its lease is confirmed completed. This includes all selected core production/test typechecks, lint, formatting, boundaries, dead-export/import-cycle guards and the macOS script contracts (604 passed, 505 existing platform skips on Linux). A final runner portal-sync deadline warning occurred after successful proof and completed cleanup; no gate failed or timeout changed.

Exact-head PR CI https://github.com/openclaw/openclaw/actions/runs/33991601179 completed successfully, including native macOS/Swift and Windows lanes.

The actual dev Gateway was built and restarted on f00967e8 using the pinned dependency installation. Three UI-created warm retained-Mac sessions reached durable active in 4.136–4.439s, 3.333–3.635s and 3.455–3.751s. All three real provider-directed executions returned Darwin; two also completed Computer screenshot capture. Agent run totals were 23/17/25s. Initial bundle-warming restart took 48.471–48.756s. These are three warm observations, not p95, a controlled end-to-end speedup, or cold-cloud proof. All temporary proof workers were reclaimed; the retained Mac was kept. Screenshots include private project context and are intentionally not uploaded publicly.

Resolved the sole merge-risk note in https://github.com/openclaw/openclaw/pull/139387#issuecomment-5554780439: personally inspected the actual installed @openclaw/fs-safe 0.8.1 dist/secure-temp-dir.js from the frozen dependency installation, not upstream main. SHA-256 is 6817edc13f6e0fb3adc2eb8d88d97c289028d9467ec4cf537d73e53419e38c1c; the prior local 0.5.5 implementation is byte-identical. The owner checks directory/symlink identity, Unix ownership/writable bits, writability/executability and post-creation validity, with its existing Windows user-scoped fallback. Fresh candidate build/live proof above uses pinned 0.8.1. No actionable review item remains; no re-review requested for this evidence-only update.
