### PR TITLE
refactor(workboard): stream card preloads and share revision checks

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1381,7 +1381,7 @@ extensions/workboard/doctor-contract-api.ts	4
 extensions/workboard/src/cli.ts	2
 extensions/workboard/src/command.ts	1
 extensions/workboard/src/gateway-helpers.ts	1
-extensions/workboard/src/sqlite-store.ts	38
+extensions/workboard/src/sqlite-store.ts	36
 extensions/workboard/src/store-automation.ts	1
 extensions/workboard/src/store-card-helpers.ts	1
 extensions/workboard/src/store-core.ts	5

--- a/extensions/workboard/src/sqlite-store-batch-read.test.ts
+++ b/extensions/workboard/src/sqlite-store-batch-read.test.ts
@@ -51,6 +51,18 @@ function fixtureCard(index: number): WorkboardCard {
     position: index,
     createdAt: 1000 + index,
     updatedAt: 2000 + index,
+    ...(index % 2
+      ? {
+          execution: {
+            id: `${id}-execution`,
+            kind: "agent-session" as const,
+            mode: "autonomous" as const,
+            status: "done" as const,
+            startedAt: 0,
+            updatedAt: 1,
+          },
+        }
+      : {}),
     events: [{ id: `${id}-event`, kind: "created", at: 1000 + index }],
     metadata: {
       attempts: [{ id: `${id}-attempt`, status: "succeeded", startedAt: 1000 + index }],
@@ -147,6 +159,105 @@ describe("workboard sqlite batch card read", () => {
       }
     });
   });
+
+  it.each(["lookup", "entries"] as const)(
+    "preserves native, child, and execution error order through %s and remains reusable",
+    async (mode) => {
+      await withStores(async (dbPath) => {
+        const stores = createWorkboardSqliteStores({ dbPath });
+        const raw = new DatabaseSync(dbPath);
+        const card = fixtureCard(1);
+        card.events = [...(card.events ?? []), { id: "late-event", kind: "created", at: 1002 }];
+        const read = () =>
+          mode === "lookup" ? stores.cards.lookup(card.id) : stores.cards.entries();
+        try {
+          await stores.cards.register(card.id, { version: 1, card });
+          raw.prepare("UPDATE workboard_card_events SET kind = '' WHERE ordinal = 0").run();
+          raw
+            .prepare("UPDATE workboard_card_events SET ordinal = ? WHERE id = ?")
+            .run(9007199254740993n, "late-event");
+          await expect(read()).rejects.toMatchObject({ code: "ERR_OUT_OF_RANGE" });
+
+          raw
+            .prepare("UPDATE workboard_card_events SET ordinal = 1 WHERE id = ?")
+            .run("late-event");
+          await expect(read()).rejects.toThrow("workboard sqlite row missing kind");
+          raw
+            .prepare("UPDATE workboard_cards SET execution_mode = NULL, automation_json = '{'")
+            .run();
+          await expect(read()).rejects.toThrow(SyntaxError);
+          raw.prepare("UPDATE workboard_cards SET automation_json = NULL").run();
+          await expect(read()).rejects.toThrow("workboard sqlite row missing kind");
+          raw.prepare("UPDATE workboard_card_events SET kind = 'created'").run();
+          await expect(read()).rejects.toThrow("workboard sqlite row missing execution_mode");
+          raw.prepare("UPDATE workboard_cards SET execution_mode = 'autonomous'").run();
+
+          const expected = { version: 1, card };
+          await expect(read()).resolves.toEqual(
+            mode === "lookup" ? expected : [{ key: card.id, value: expected }],
+          );
+        } finally {
+          raw.close();
+          stores.close();
+        }
+      });
+    },
+  );
+
+  it.each([
+    { fault: "later JSON", expected: "owner_busy", revisionMatches: true, targetOnly: false },
+    { fault: "later integer", expected: "native-error", revisionMatches: true, targetOnly: false },
+    { fault: "later integer", expected: "conflict", revisionMatches: false, targetOnly: false },
+    { fault: "target integer", expected: "native-error", revisionMatches: true, targetOnly: true },
+  ] as const)(
+    "keeps claim precedence for $fault: $expected",
+    async ({ fault, expected, revisionMatches, targetOnly }) => {
+      await withStores(async (dbPath) => {
+        const stores = createWorkboardSqliteStores({ dbPath });
+        const raw = new DatabaseSync(dbPath);
+        const target = fixtureCard(2);
+        try {
+          if (!targetOnly) {
+            const busy = { ...fixtureCard(0), status: "running" as const, agentId: "slot-owner" };
+            await stores.cards.register(busy.id, { version: 1, card: busy });
+            await stores.cards.register("card-1", { version: 1, card: fixtureCard(1) });
+          }
+          await stores.cards.register(target.id, { version: 1, card: target });
+          if (fault === "later JSON") {
+            raw
+              .prepare("UPDATE workboard_cards SET automation_json = '{' WHERE id = 'card-1'")
+              .run();
+          } else {
+            raw
+              .prepare("UPDATE workboard_card_events SET ordinal = ? WHERE card_id = ?")
+              .run(9007199254740993n, targetOnly ? target.id : "card-1");
+          }
+          const before = sqliteStatements.count;
+          const claim = stores.cards.claimIfOwnerAvailable(
+            target.id,
+            { version: 1, card: { ...target, updatedAt: target.updatedAt + 1 } },
+            revisionMatches ? target.updatedAt : target.updatedAt - 1,
+            "slot-owner",
+            3000,
+          );
+          if (expected === "native-error") {
+            await expect(claim).rejects.toMatchObject({ code: "ERR_OUT_OF_RANGE" });
+          } else {
+            await expect(claim).resolves.toBe(expected);
+          }
+          if (expected === "conflict") {
+            expect(sqliteStatements.count - before).toBe(1);
+          }
+          expect(
+            raw.prepare("SELECT updated_at FROM workboard_cards WHERE id = ?").get(target.id),
+          ).toEqual({ updated_at: target.updatedAt });
+        } finally {
+          raw.close();
+          stores.close();
+        }
+      });
+    },
+  );
 
   it("reads each keyed collection once while preserving rows, binary order, and attachment joins", async () => {
     await withStores(async (dbPath) => {

--- a/extensions/workboard/src/sqlite-store.ts
+++ b/extensions/workboard/src/sqlite-store.ts
@@ -458,6 +458,11 @@ const CARD_CHILD_TABLES = [
   "workboard_card_notifications",
 ] as const;
 
+type WorkboardCardDatabase = Record<
+  (typeof CARD_CHILD_TABLES)[number] | "workboard_cards" | "workboard_worker_protocol",
+  Row
+>;
+
 /**
  * Child rows for a whole batch of cards, grouped by card id.
  *
@@ -469,7 +474,7 @@ type CardChildRows = {
   workerProtocol: Map<string, Row>;
 };
 
-function groupByCardId(rows: Row[]): Map<string, Row[]> {
+function groupByCardId(rows: Iterable<Row>): Map<string, Row[]> {
   const grouped = new Map<string, Row[]>();
   for (const row of rows) {
     const cardId = stringValue(row, "card_id");
@@ -487,18 +492,26 @@ function groupByCardId(rows: Row[]): Map<string, Row[]> {
 }
 
 function loadCardChildRows(db: DatabaseSync): CardChildRows {
+  // Group raw rows only: every preload must finish before card decoding can fail.
+  const query = getNodeSqliteKysely<WorkboardCardDatabase>(db);
   const byTable = new Map<string, Map<string, Row[]>>();
   for (const table of CARD_CHILD_TABLES) {
     // Same order the per-card query produces, so grouped buckets stay ordinal-sorted.
     byTable.set(
       table,
       groupByCardId(
-        db.prepare(`SELECT * FROM ${table} ORDER BY card_id ASC, ordinal ASC`).all() as Row[],
+        iterateSqliteQuerySync(
+          db,
+          query.selectFrom(table).selectAll().orderBy("card_id", "asc").orderBy("ordinal", "asc"),
+        ),
       ),
     );
   }
   const workerProtocol = new Map<string, Row>();
-  for (const row of db.prepare("SELECT * FROM workboard_worker_protocol").all() as Row[]) {
+  for (const row of iterateSqliteQuerySync(
+    db,
+    query.selectFrom("workboard_worker_protocol").selectAll(),
+  )) {
     const cardId = stringValue(row, "card_id");
     if (cardId) {
       workerProtocol.set(cardId, row);
@@ -521,6 +534,7 @@ function childRows(
     cached.delete(cardId);
     return rows;
   }
+  // Finish native extraction before decoding; a later row can contain the first error.
   return db
     .prepare(`SELECT * FROM ${table} WHERE card_id = ? ORDER BY ordinal ASC`)
     .all(cardId) as Row[];
@@ -848,6 +862,7 @@ function readCard(db: DatabaseSync, row: Row, preloaded?: CardChildRows): Workbo
   };
   const metadata = readMetadata(db, row, preloaded);
   const events = readEvents(db, card.id, preloaded);
+  const execution = readExecution(row);
   return {
     ...card,
     ...(stringValue(row, "notes") ? { notes: stringValue(row, "notes") } : {}),
@@ -856,7 +871,7 @@ function readCard(db: DatabaseSync, row: Row, preloaded?: CardChildRows): Workbo
     ...(stringValue(row, "run_id") ? { runId: stringValue(row, "run_id") } : {}),
     ...(stringValue(row, "task_id") ? { taskId: stringValue(row, "task_id") } : {}),
     ...(stringValue(row, "source_url") ? { sourceUrl: stringValue(row, "source_url") } : {}),
-    ...(readExecution(row) ? { execution: readExecution(row) } : {}),
+    ...(execution ? { execution } : {}),
     ...(numberValue(row, "started_at") !== undefined
       ? { startedAt: numberValue(row, "started_at") }
       : {}),
@@ -905,13 +920,7 @@ function insertChildren<T>(
 function insertCard(db: DatabaseSync, card: WorkboardCard): void {
   const execution = card.execution;
   const metadata = card.metadata;
-  const query =
-    getNodeSqliteKysely<
-      Record<
-        (typeof CARD_CHILD_TABLES)[number] | "workboard_cards" | "workboard_worker_protocol",
-        Row
-      >
-    >(db);
+  const query = getNodeSqliteKysely<WorkboardCardDatabase>(db);
   // Keep payload getters and JSON serialization after native statement preparation.
   const parent = compileSqliteQueryBindings<void>((p) =>
     query
@@ -1201,6 +1210,21 @@ function insertCard(db: DatabaseSync, card: WorkboardCard): void {
 class WorkboardSqliteCardStore implements WorkboardCardStore {
   constructor(private readonly db: DatabaseSync) {}
 
+  private matchesUpdatedAt(key: string, expectedUpdatedAt: number): boolean {
+    const { compiled, bind } = compileSqliteQueryBindings<string>((parameter) =>
+      getNodeSqliteKysely<WorkboardCardDatabase>(this.db)
+        .selectFrom("workboard_cards")
+        .select("updated_at")
+        .where(
+          "id",
+          "=",
+          parameter((value) => value),
+        ),
+    );
+    const current = this.db.prepare(compiled.sql).get(...bind(key));
+    return isRecord(current) && numberValue(current, "updated_at") === expectedUpdatedAt;
+  }
+
   private validatePayload(key: string, value: PersistedWorkboardCard): void {
     if (value.version !== 1 || value.card.id !== key) {
       throw new Error("invalid workboard card payload");
@@ -1230,10 +1254,7 @@ class WorkboardSqliteCardStore implements WorkboardCardStore {
   ): Promise<boolean> {
     this.validatePayload(key, value);
     return runSqliteImmediateTransactionSync(this.db, () => {
-      const current = this.db
-        .prepare("SELECT updated_at FROM workboard_cards WHERE id = ?")
-        .get(key);
-      if (!isRecord(current) || numberValue(current, "updated_at") !== expectedUpdatedAt) {
+      if (!this.matchesUpdatedAt(key, expectedUpdatedAt)) {
         return false;
       }
       insertCard(this.db, value.card);
@@ -1250,10 +1271,7 @@ class WorkboardSqliteCardStore implements WorkboardCardStore {
   ): Promise<WorkboardOwnerClaimResult> {
     this.validatePayload(key, value);
     return runSqliteImmediateTransactionSync(this.db, () => {
-      const current = this.db
-        .prepare("SELECT updated_at FROM workboard_cards WHERE id = ?")
-        .get(key);
-      if (!isRecord(current) || numberValue(current, "updated_at") !== expectedUpdatedAt) {
+      if (!this.matchesUpdatedAt(key, expectedUpdatedAt)) {
         return "conflict";
       }
       const rows: Row[] = this.db.prepare("SELECT * FROM workboard_cards WHERE id <> ?").all(key);
@@ -1271,10 +1289,7 @@ class WorkboardSqliteCardStore implements WorkboardCardStore {
 
   async deleteIfUpdatedAt(key: string, expectedUpdatedAt: number): Promise<boolean> {
     return runSqliteImmediateTransactionSync(this.db, () => {
-      const current = this.db
-        .prepare("SELECT updated_at FROM workboard_cards WHERE id = ?")
-        .get(key);
-      if (!isRecord(current) || numberValue(current, "updated_at") !== expectedUpdatedAt) {
+      if (!this.matchesUpdatedAt(key, expectedUpdatedAt)) {
         return false;
       }
       this.deleteCard(key);


### PR DESCRIPTION
## What Problem This Solves

Workboard batch reads materialized each complete child-table result into an array, then copied those row references into per-card groups. Conditional update, claim and delete also repeated the same authoritative revision query and numeric check.

## Why This Change Was Made

Stream the eleven child queries and worker-protocol query directly into the existing groups through the shared Kysely iterator. A private revision predicate retains native preparation, binding and exact comparison inside the existing transactions. Execution data is decoded once after metadata and events.

Parent and point reads remain eager, all thirteen batch queries and their order remain intact, and claim hydration keeps its existing scope. This preserves the distinction between native extraction errors and later card-decoding errors. No schema, stored representation, configuration, retention or concurrency policy changes.

Production grows by 15 lines; tests add 111. Sharing the existing table type and revision predicate absorbs part of the typed query construction. The assertion baseline shrinks from 38 to 36, matching the two removed casts.

## Evidence

- 190 focused tests, five Doctor contract tests, the complete changed gate, Kysely guard and full build passed with Node 24.20.0 and Vitest 5.0.0.
- Ten actual native baseline/candidate scenarios preserve complete rows, errors, query/parameter order, transaction flags, conflict precedence and reopen behavior. The eight-card batch keeps thirteen queries while native `.all()` calls fall from thirteen to one, avoiding 184 temporary child/protocol array entries over that pass. This is not a peak-memory or latency measurement.
- The existing card writer's emitted body is byte-identical after extracting its shared type alias.
- Three actual Gateway starts, three official CLI calls and 46 captured request/response frames cover cross-process updates, stale revisions, claims, point/batch equality, 72 KiB attachment bytes, restart and deletion while preserving unrelated data. Final SQLite readback confirms schema 3 and `quick_check=ok`.
- Fifteen independent P0–P2 review reports are clean; the full reports, actual controllers, source hashes and recorded build hashes were inspected before publication.

All synthetic state and owned processes were cleaned up. No provider, worker or external-channel execution is claimed. Board/subscription UPSERT mappings are a separate follow-up.

## Data-Model Compatibility

The review’s table-change warning is a path-based false positive. The complete schema/bootstrap block is byte-identical to the parent (10,048 bytes, SHA-256 `b000fa72e18cf74f11c51ccb2df341652fd0d55b91660233a65a162fa3c53a23`). There is no table, column, index, migration, schema-version or stored-format change. Existing schema-3 data was reopened through the native and real Gateway/CLI comparisons described above; no migration is needed.

## Hosted CI

CI run 33991608036 failed its tooling shard on the first attempt at the merge-authorization fixture’s viewer-count assertion. The exact failed job was rerun once; attempt 2 and its CI gate passed on the unchanged head. A separate investigation reproduced a large-input fake-Git stdin defect; its test-only repair is tracked in #139427. The original small-input Linux failure remains unattributed; no Workboard code or assertion was changed to pass CI.
