### PR TITLE
fix: preserve indentation in Discord and session messages

### DIFF
--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -50,6 +50,10 @@ Every action accepts: `--channel <name>`, `--account <id>`, `--json`,
 `--dry-run`, `--verbose`. Actions that take a destination also accept
 `-t, --target <dest>`.
 
+Discord message bodies, captions, poll context, and component text retain
+meaningful whitespace before channel formatting and chunking. Existing
+empty-message validation still applies.
+
 Local message actions run the loaded plugins' shutdown hooks before exiting, including
 after an action fails. Cleanup has a 2.5-second overall budget and does not change
 the action's exit status. `message read` skips these shutdown hooks.

--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -51,8 +51,8 @@ Every action accepts: `--channel <name>`, `--account <id>`, `--json`,
 `-t, --target <dest>`.
 
 Discord message bodies, captions, poll context, and component text retain
-meaningful whitespace before channel formatting and chunking. Existing
-empty-message validation still applies.
+leading indentation. Existing empty-message validation still applies.
+Ordinary message and caption delivery still trims trailing whitespace.
 
 Local message actions run the loaded plugins' shutdown hooks before exiting, including
 after an action fails. Cleanup has a 2.5-second overall budget and does not change

--- a/extensions/discord/src/components.parse.ts
+++ b/extensions/discord/src/components.parse.ts
@@ -3,6 +3,7 @@ import { ButtonStyle, TextInputStyle } from "discord-api-types/v10";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
+  readNonBlankString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type {
   DiscordComponentBlock,
@@ -35,19 +36,16 @@ function requireObject(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function readRequiredString(
-  value: unknown,
-  label: string,
-  opts?: { allowEmpty?: boolean },
-): string {
+// Body whitespace carries Markdown; control labels still use trimmed values.
+function readRequiredString(value: unknown, label: string, trim = true): string {
   if (typeof value !== "string") {
     throw new Error(`${label} must be a string`);
   }
   const trimmed = value.trim();
-  if (!opts?.allowEmpty && !trimmed) {
+  if (!trimmed) {
     throw new Error(`${label} cannot be empty`);
   }
-  return opts?.allowEmpty ? value : trimmed;
+  return trim ? trimmed : value;
 }
 
 function readOptionalCallbackDataKind(
@@ -295,13 +293,13 @@ function parseComponentBlock(raw: unknown, label: string): DiscordComponentBlock
     case "text":
       return {
         type: "text",
-        text: readRequiredString(obj.text, `${label}.text`),
+        text: readRequiredString(obj.text, `${label}.text`, false),
       };
     case "section": {
-      const text = normalizeOptionalString(obj.text);
+      const text = readNonBlankString(obj.text);
       const textsRaw = obj.texts;
       const texts = Array.isArray(textsRaw)
-        ? textsRaw.map((entry, idx) => readRequiredString(entry, `${label}.texts[${idx}]`))
+        ? textsRaw.map((entry, idx) => readRequiredString(entry, `${label}.texts[${idx}]`, false))
         : undefined;
       if (!text && (!texts || texts.length === 0)) {
         throw new Error(`${label}.text or ${label}.texts is required for section blocks`);
@@ -443,7 +441,7 @@ export function readDiscordComponentSpec(raw: unknown): DiscordComponentMessageS
     };
   }
   return {
-    text: normalizeOptionalString(obj.text),
+    text: readNonBlankString(obj.text),
     reusable: typeof obj.reusable === "boolean" ? obj.reusable : undefined,
     container:
       typeof obj.container === "object" && obj.container && !Array.isArray(obj.container)

--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -304,6 +304,106 @@ describe("discord components", () => {
     ).toThrow("components.modal.fields[0].minValues/maxValues");
   });
 
+  it.each([
+    {
+      label: "top-level text",
+      raw: { text: "    body  " },
+      expected: [{ type: 10, content: "    body  " }],
+    },
+    {
+      label: "text block",
+      raw: { blocks: [{ type: "text", text: "    body  " }] },
+      expected: [{ type: 10, content: "    body  " }],
+    },
+    {
+      label: "section text",
+      raw: {
+        blocks: [
+          {
+            type: "section",
+            text: "    body  ",
+            accessory: {
+              type: "button",
+              button: { label: " Read ", style: "link", url: "https://example.com" },
+            },
+          },
+        ],
+      },
+      expected: [
+        {
+          type: 9,
+          components: [{ type: 10, content: "    body  " }],
+          accessory: { label: "Read" },
+        },
+      ],
+    },
+    {
+      label: "section texts",
+      raw: {
+        blocks: [
+          {
+            type: "section",
+            texts: ["    first  ", "    second  "],
+            accessory: {
+              type: "button",
+              button: { label: " Read ", style: "link", url: "https://example.com" },
+            },
+          },
+        ],
+      },
+      expected: [
+        {
+          type: 9,
+          components: [
+            { type: 10, content: "    first  " },
+            { type: 10, content: "    second  " },
+          ],
+          accessory: { label: "Read" },
+        },
+      ],
+    },
+  ])("preserves $label whitespace through parsing and serialization", ({ raw, expected }) => {
+    const spec = readDiscordComponentSpec(raw);
+    if (!spec) {
+      throw new Error("Expected component spec to be parsed");
+    }
+    expect(buildDiscordComponentMessage({ spec }).components[0]?.serialize()).toMatchObject({
+      type: 17,
+      components: expected,
+    });
+  });
+
+  it.each([
+    {
+      raw: { blocks: [{ type: "text", text: " \n\t " }] },
+      error: "components.blocks[0].text cannot be empty",
+    },
+    {
+      raw: { blocks: [{ type: "text", text: 1 }] },
+      error: "components.blocks[0].text must be a string",
+    },
+    {
+      raw: { blocks: [{ type: "section", texts: [" \n\t "] }] },
+      error: "components.blocks[0].texts[0] cannot be empty",
+    },
+  ])("retains required component body validation: $error", ({ raw, error }) => {
+    expect(() => readDiscordComponentSpec(raw)).toThrow(error);
+  });
+
+  it("keeps optional blank component text absent", () => {
+    const spec = readDiscordComponentSpec({
+      text: " \n\t ",
+      blocks: [{ type: "text", text: "fallback" }],
+    });
+    if (!spec) {
+      throw new Error("Expected component spec to be parsed");
+    }
+    expect(buildDiscordComponentMessage({ spec }).components[0]?.serialize()).toMatchObject({
+      type: 17,
+      components: [{ type: 10, content: "fallback" }],
+    });
+  });
+
   it("parses stringified component specs from MCP object transports", () => {
     const raw = JSON.stringify({ blocks: [{ type: "text", text: "Choose" }] });
 

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -412,6 +412,42 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
     ]);
   });
 
+  it.each([
+    {
+      label: "indented top-level text",
+      spec: { text: "    body  " },
+      expected: "    body  ",
+    },
+    {
+      label: "distinct Markdown after exact duplicate removal",
+      spec: {
+        text: "    code",
+        blocks: [
+          { type: "text", text: "    code" },
+          { type: "text", text: "code" },
+        ],
+      },
+      expected: "    code\n\ncode",
+    },
+    {
+      label: "blank-only text",
+      spec: { text: " \n\t " },
+      expected: "",
+    },
+  ] satisfies Array<{
+    label: string;
+    spec: Parameters<typeof sendDiscordComponentMessage>[1];
+    expected: string;
+  }>)("preserves $label through the classic file downgrade", async ({ spec, expected }) => {
+    await sendDiscordComponentMessage("channel:chan-1", spec, {
+      cfg: DISCORD_TEST_CFG,
+      token: "t",
+      mediaUrl: "https://example.com/report.pdf",
+    });
+    expect(sendMessageDiscordMock).toHaveBeenCalledOnce();
+    expect(readMockCall(sendMessageDiscordMock, 0)[1]).toBe(expected);
+  });
+
   it("forwards first-chunk reply fanout through classic media downgrades", async () => {
     await sendDiscordComponentMessage(
       "channel:chan-1",

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -7,7 +7,7 @@ import type { OutboundMediaAccess } from "openclaw/plugin-sdk/media-runtime";
 import { loadOutboundMediaFromUrl } from "openclaw/plugin-sdk/outbound-media";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import type { ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
-import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { hasNonEmptyString, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { registerDiscordComponentEntries } from "./components-registry.js";
 import {
   buildDiscordComponentMessage,
@@ -128,25 +128,11 @@ function getClassicDiscordMessageDecision(
 }
 
 function collapseClassicComponentText(spec: DiscordComponentMessageSpec): string {
-  const parts: string[] = [];
-  const addPart = (value: string | undefined) => {
-    if (typeof value !== "string") {
-      return;
-    }
-    const trimmed = value.trim();
-    if (!trimmed || parts.includes(trimmed)) {
-      return;
-    }
-    parts.push(trimmed);
-  };
-
-  addPart(spec.text);
-  for (const block of spec.blocks ?? []) {
-    if (block.type === "text") {
-      addPart(block.text);
-    }
-  }
-  return parts.join("\n\n");
+  const parts = [
+    spec.text,
+    ...(spec.blocks ?? []).flatMap((block) => (block.type === "text" ? [block.text] : [])),
+  ];
+  return uniqueStrings(parts.filter(hasNonEmptyString)).join("\n\n");
 }
 
 type DiscordComponentSendOpts = {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -72,6 +72,7 @@ import {
   describeSessionsSendTool,
   SESSIONS_SEND_TOOL_DISPLAY_SUMMARY,
 } from "../tool-description-presets.js";
+import { ToolInputError } from "../tool-input-error.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNonNegativeIntegerParam, readToolStringParam } from "./common.js";
 import {
@@ -184,8 +185,8 @@ function normalizeSessionsSendArguments(args: unknown): Record<string, unknown> 
 
   if (typeof params.message !== "string" || !params.message.trim()) {
     for (const alias of SESSIONS_SEND_MESSAGE_ALIASES) {
-      const value = readToolStringParam(params, alias);
-      if (value) {
+      const value = readToolStringParam(params, alias, { trim: false });
+      if (value?.trim()) {
         params.message = stripFormattedReasoningMessage(value);
         break;
       }
@@ -516,7 +517,10 @@ export function createSessionsSendTool(opts?: {
       const promptedAt = Date.now();
       const params = normalizeSessionsSendArguments(args);
       const gatewayCall = opts?.callGateway ?? callAgentToolGatewayRequest;
-      const message = readToolStringParam(params, "message", { required: true });
+      const message = readToolStringParam(params, "message", { required: true, trim: false });
+      if (!message.trim()) {
+        throw new ToolInputError("message required");
+      }
       const timeoutSeconds = readNonNegativeIntegerParam(params, "timeoutSeconds") ?? 30;
       const {
         cfg,

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -1013,6 +1013,36 @@ describe("sessions_send gating", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { name: "canonical message", args: { message: "    indented body" } },
+    { name: "formatted text alias", args: { text: "Thinking\n_summary_\n    indented body" } },
+    { name: "snake-case alias", args: { send_message: "    indented body" } },
+    { name: "blank earlier alias", args: { SendMessage: " \n\t ", text: "    indented body" } },
+  ])("forwards substantive indentation through $name", async ({ args }) => {
+    callGatewayMock.mockResolvedValue({ runId: "body-whitespace" });
+    const result = await createMainSessionsSendTool().execute("body-whitespace", {
+      sessionKey: MAIN_AGENT_SESSION_KEY,
+      timeoutSeconds: 0,
+      ...args,
+    });
+    expect(requireDetails(result).status).toBe("accepted");
+    const call = callGatewayMock.mock.calls.find(([request]) => request.method === "agent");
+    const request = requireRecord(call?.[0], "agent request");
+    const forwarded = requireRecord(request.params, "agent params");
+    expect(forwarded.message).toMatch(/\n {4}indented body$/u);
+  });
+
+  it.each(["", " \n\t "])("rejects blank message %j before forwarding", async (message) => {
+    await expect(
+      createMainSessionsSendTool().execute("blank-body", {
+        sessionKey: MAIN_AGENT_SESSION_KEY,
+        message,
+        timeoutSeconds: 0,
+      }),
+    ).rejects.toThrow("message required");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
   it.each([1.5, -1, "1sec"])("rejects invalid timeoutSeconds value %s", async (timeoutSeconds) => {
     const tool = createMainSessionsSendTool();
 

--- a/src/gateway/chat-display-projection.forwarded.test.ts
+++ b/src/gateway/chat-display-projection.forwarded.test.ts
@@ -74,4 +74,28 @@ describe("forwarded session attribution", () => {
       ]);
     }
   });
+  it("retains forwarded code indentation through both history transports", () => {
+    const body = "\n    indented body\n\n";
+    const provenance = {
+      kind: "inter_session" as const,
+      sourceTool: "sessions_send",
+      sourceSessionKey: "agent:helper:main",
+    };
+    const message = {
+      role: "user",
+      provenance,
+      content: annotateInterSessionPromptText(body, provenance),
+    };
+    for (const messages of projectHistoryTransports(message)) {
+      expect(messages).toStrictEqual([
+        {
+          role: "assistant",
+          provenance,
+          content: body,
+          senderLabel: "Forwarded from helper",
+          senderSession: { sessionKey: "agent:helper:main", agentId: "helper" },
+        },
+      ]);
+    }
+  });
 });

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -16,6 +16,7 @@ import {
 } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { buildAgentRunTerminalReplySnapshot } from "../agents/agent-run-terminal-reply.js";
+import type { AgentCommandGatewayIngressOpts } from "../agents/command/types.js";
 import { testing as agentStepTesting } from "../agents/tools/agent-step.test-support.js";
 import { runSessionsSendA2AFlow } from "../agents/tools/sessions-send-tool.a2a.js";
 import {
@@ -218,9 +219,13 @@ describe("sessions_send gateway loopback", () => {
   });
 
   it("returns reply when lifecycle ends before agent.wait", async () => {
-    const spy = agentCommandMock as unknown as Mock<(opts: unknown) => Promise<void>>;
-    spy.mockImplementation(async (opts: unknown) =>
-      emitLifecycleAssistantReply({
+    const body = "    const first = 1;\n        const second = 2;";
+    const spy = agentCommandMock as unknown as Mock<
+      (opts: AgentCommandGatewayIngressOpts) => Promise<void>
+    >;
+    spy.mockImplementation(async (opts) => {
+      await opts.userTurnTranscriptRecorder?.persistApproved();
+      await emitLifecycleAssistantReply({
         opts,
         defaultSessionId: "main",
         includeTimestamp: true,
@@ -233,24 +238,45 @@ describe("sessions_send gateway loopback", () => {
           }
           return "pong";
         },
-      }),
-    );
+      });
+    });
 
     const tool = getSessionsSendTool();
 
     const result = await tool.execute("call-loopback", {
       sessionKey: "main",
-      message: "ping",
+      message: body,
       timeoutSeconds: 5,
     });
     expectSessionsSendDetails(result, { reply: "pong", sessionKey: "main" });
 
-    const firstCall = spy.mock.calls.at(0)?.[0] as
-      | { lane?: string; inputProvenance?: { kind?: string; sourceTool?: string } }
-      | undefined;
+    const firstCall = spy.mock.calls.at(0)?.[0];
     expect(firstCall?.lane).toMatch(/^nested(?::|$)/);
     expect(firstCall?.inputProvenance?.kind).toBe("inter_session");
     expect(firstCall?.inputProvenance?.sourceTool).toBe("sessions_send");
+    expect(firstCall?.runId).toBeTypeOf("string");
+    expect(result.details).toMatchObject({ runId: firstCall?.runId });
+    expect(firstCall?.userTurnTranscriptRecorder?.hasPersisted()).toBe(true);
+
+    const { callGateway } = await import("./call.js");
+    const history = await callGateway<{ messages?: unknown[] }>({
+      method: "chat.history",
+      params: { sessionKey: "main", limit: 10 },
+      timeoutMs: 5_000,
+    });
+    // Observe both receiving and persisted body failures before ending the case.
+    expect.soft(firstCall?.message?.split("\n").slice(-2).join("\n")).toBe(body);
+    expect.soft(history.messages).toContainEqual(
+      expect.objectContaining({
+        role: "assistant",
+        idempotencyKey: `${firstCall?.runId}:user`,
+        content: body,
+        provenance: expect.objectContaining({
+          kind: "inter_session",
+          sourceTool: "sessions_send",
+        }),
+      }),
+    );
   });
 
   it.each([

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -161,6 +161,8 @@ beforeAll(async () => {
   process.env.OPENCLAW_GATEWAY_PORT = String(gatewayPort);
   process.env.OPENCLAW_GATEWAY_TOKEN = gatewayToken;
   server = await startTestGatewayServer(gatewayPort);
+  // Prepare the real history handler before the RPC deadline starts.
+  await import("./server-methods/chat.js");
 });
 
 beforeEach(async () => {

--- a/src/infra/outbound/message-action-execution.poll.test.ts
+++ b/src/infra/outbound/message-action-execution.poll.test.ts
@@ -159,6 +159,24 @@ describe("executeMessagePoll", () => {
     });
   });
 
+  it.each([
+    { message: "    poll body  ", expected: "    poll body  " },
+    { message: " \n\t ", expected: "" },
+    { message: undefined, expected: undefined },
+  ])("preserves meaningful poll message whitespace: $expected", async ({ message, expected }) => {
+    const { call } = await runPollAction({
+      actionParams: {
+        target: "poller:123",
+        message,
+        pollQuestion: " Lunch? ",
+        pollOption: [" Pizza ", " Sushi "],
+      },
+    });
+    expect(call.content).toBe(expected);
+    expect(call.poll.question).toBe("Lunch?");
+    expect(call.poll.options).toEqual(["Pizza", "Sushi"]);
+  });
+
   it.each([0, -1, 1.5, "1.5", "soon"])(
     "rejects invalid pollDurationHours value %s",
     async (pollDurationHours) => {

--- a/src/infra/outbound/message-action-execution.ts
+++ b/src/infra/outbound/message-action-execution.ts
@@ -465,6 +465,10 @@ export async function executeMessagePoll(ctx: ResolvedActionContext): Promise<Me
       if (options.length < 2) {
         throw new Error("pollOption requires at least two values");
       }
+      let content = readToolStringParam(params, "message", { allowEmpty: true, trim: false });
+      if (content !== undefined && !content.trim()) {
+        content = "";
+      }
       const allowMultiselect = readBooleanParam(params, "pollMulti") ?? false;
       const durationHours = readPositiveIntegerParam(params, "pollDurationHours", {
         message: "pollDurationHours must be a positive integer",
@@ -473,7 +477,7 @@ export async function executeMessagePoll(ctx: ResolvedActionContext): Promise<Me
       return {
         to,
         question,
-        content: readToolStringParam(params, "message", { allowEmpty: true }) ?? undefined,
+        content,
         options,
         maxSelections: resolvePollMaxSelections(options.length, allowMultiselect),
         durationHours: durationHours ?? undefined,

--- a/src/infra/outbound/message-action-send.ts
+++ b/src/infra/outbound/message-action-send.ts
@@ -110,7 +110,7 @@ export async function buildMessagePayload(params: {
     typeof rawLocation === "string" && normalizeOptionalString(rawLocation) === undefined
       ? undefined
       : normalizeOutboundLocation(rawLocation);
-  const caption = readToolStringParam(actionParams, "caption", { allowEmpty: true }) ?? "";
+  const caption = readToolStringParam(actionParams, "caption", { trim: false }) ?? "";
   const voiceText = readToolStringParam(actionParams, "voiceText");
   const voiceProvider = readToolStringParam(actionParams, "voiceProvider");
   const voiceId = readToolStringParam(actionParams, "voiceId");
@@ -118,12 +118,13 @@ export async function buildMessagePayload(params: {
     readToolStringParam(actionParams, "message", {
       required: !hasMediaHint && !hasPresentation && !hasInteractive && !location && !voiceText,
       allowEmpty: true,
+      trim: false,
     }) ?? "";
   if (message.includes("\\n")) {
     message = message.replaceAll("\\n", "\n");
   }
-  if (!message.trim() && caption.trim()) {
-    message = caption;
+  if (!message.trim()) {
+    message = caption.trim() ? caption : "";
   }
 
   const parsed = parseInlineDirectives(message, {

--- a/src/infra/outbound/message-action-send.validation.test.ts
+++ b/src/infra/outbound/message-action-send.validation.test.ts
@@ -1,6 +1,7 @@
 // Covers send validation for target/channel mismatches, configured channel
 // availability, and explicit target requirements.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelOutboundContext } from "../../channels/plugins/outbound.types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
@@ -365,6 +366,47 @@ describe("message body alias normalization", () => {
     });
 
     expect(result.kind).toBe("send");
+  });
+
+  it.each([
+    { name: "canonical message", body: { message: "    indented body" } },
+    { name: "reasoning tag alias", body: { text: "<think>private</think>    indented body" } },
+    {
+      name: "mixed reasoning preamble alias",
+      body: { text: "<think>private</think>\nThinking\n_summary_\n    indented body" },
+    },
+    {
+      name: "blank earlier alias",
+      body: { SendMessage: " \n\t ", content: "    indented body", text: "not selected" },
+    },
+    { name: "caption fallback", body: { message: "", caption: "    indented body" } },
+  ])("delivers code indentation through $name", async ({ body }) => {
+    const sentText: string[] = [];
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "workspace",
+          source: "test",
+          plugin: {
+            ...workspaceTestPlugin,
+            outbound: {
+              ...workspaceTestPlugin.outbound,
+              sendText: async (ctx: ChannelOutboundContext) => {
+                sentText.push(ctx.text);
+                return { channel: "workspace", messageId: "body-whitespace" };
+              },
+            },
+          },
+        },
+      ]),
+    );
+    const result = await runMessageAction({
+      cfg: workspaceConfig,
+      action: "send",
+      params: { channel: "workspace", target: "#C12345678", ...body },
+    });
+    expect(result.kind).toBe("send");
+    expect(sentText).toEqual(["    indented body"]);
   });
 
   it("does not overwrite an explicit message with an alias", async () => {

--- a/src/sessions/input-provenance.test.ts
+++ b/src/sessions/input-provenance.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   annotateInterSessionPromptText,
+  INTER_SESSION_PROMPT_PREFIX_BASE,
   isAgentMediatedCompletionSourceTool,
   shouldPreserveUserFacingSessionStateForInputProvenance,
   stripInterSessionPromptPrefixForDisplay,
@@ -78,6 +79,24 @@ describe("stripInterSessionPromptPrefixForDisplay", () => {
     });
 
     expect(stripInterSessionPromptPrefixForDisplay(marked)).toBe("forwarded report");
+  });
+});
+
+describe("inter-session body whitespace", () => {
+  it("round-trips the body's own blank lines and code indentation", () => {
+    const body = "\n    first line\n      second line\n\n";
+    const marked = annotateInterSessionPromptText(body, {
+      kind: "inter_session",
+      sourceTool: "sessions_send",
+    });
+    expect(stripInterSessionPromptPrefixForDisplay(marked)).toBe(body);
+  });
+
+  it.each([
+    [`${INTER_SESSION_PROMPT_PREFIX_BASE}\n\n    code`, "\n    code"],
+    [`${INTER_SESSION_PROMPT_PREFIX_BASE}    code`, "    code"],
+  ])("preserves body bytes when the generated explanation is absent: %j", (input, body) => {
+    expect(stripInterSessionPromptPrefixForDisplay(input)).toBe(body);
   });
 });
 

--- a/src/sessions/input-provenance.ts
+++ b/src/sessions/input-provenance.ts
@@ -149,31 +149,20 @@ function buildInterSessionPromptPrefix(inputProvenance: InputProvenance | undefi
   return [header, INTER_SESSION_PROMPT_EXPLANATION].join("\n");
 }
 
-function removeFirstInterSessionPromptPrefix(text: string): string {
+export function stripInterSessionPromptPrefixForDisplay(text: string): string {
   const index = text.indexOf(INTER_SESSION_PROMPT_PREFIX_BASE);
   if (index === -1) {
     return text;
   }
   const headerEnd = text.indexOf("\n", index);
-  if (headerEnd === -1) {
-    return [
-      text.slice(0, index).trimEnd(),
-      text.slice(index + INTER_SESSION_PROMPT_PREFIX_BASE.length).trimStart(),
-    ]
-      .filter(Boolean)
-      .join("\n");
+  const bodyStart =
+    headerEnd === -1 ? index + INTER_SESSION_PROMPT_PREFIX_BASE.length : headerEnd + 1;
+  let body = text.slice(bodyStart);
+  if (headerEnd !== -1 && body.startsWith(INTER_SESSION_PROMPT_EXPLANATION)) {
+    // Only the generated explanation owns a following separator newline.
+    body = body.slice(INTER_SESSION_PROMPT_EXPLANATION.length).replace(/^\r?\n/u, "");
   }
-  const explanationStart = headerEnd + 1;
-  const explanationEnd = text.startsWith(INTER_SESSION_PROMPT_EXPLANATION, explanationStart)
-    ? explanationStart + INTER_SESSION_PROMPT_EXPLANATION.length
-    : explanationStart;
-  return [text.slice(0, index).trimEnd(), text.slice(explanationEnd).trimStart()]
-    .filter(Boolean)
-    .join("\n");
-}
-
-export function stripInterSessionPromptPrefixForDisplay(text: string): string {
-  return removeFirstInterSessionPromptPrefix(text);
+  return [text.slice(0, index).trimEnd(), body].filter(Boolean).join("\n");
 }
 
 // Idempotently moves the generated provenance envelope to the top of prompt
@@ -192,6 +181,6 @@ export function annotateInterSessionPromptText(
   if (text === prefix || text.startsWith(`${prefix}\n`)) {
     return text;
   }
-  const body = removeFirstInterSessionPromptPrefix(text);
+  const body = stripInterSessionPromptPrefixForDisplay(text);
   return `${prefix}\n${body}`;
 }

--- a/src/shared/text/formatted-reasoning-message.test.ts
+++ b/src/shared/text/formatted-reasoning-message.test.ts
@@ -20,7 +20,7 @@ describe("stripFormattedReasoningMessage", () => {
     "removes only the %s preamble and normalizes answer line endings",
     (header) => {
       const input = `\u00a0${header} \t\r\n\r\n _summary_ \r\n_more_\r\n Answer😀\r\r\n_keep this_\r\nlast \r\n`;
-      expect(stripFormattedReasoningMessage(input)).toBe("Answer😀\r\n_keep this_\nlast");
+      expect(stripFormattedReasoningMessage(input)).toBe(" Answer😀\r\n_keep this_\nlast ");
     },
   );
 
@@ -33,6 +33,24 @@ describe("stripFormattedReasoningMessage", () => {
     ["<thinking>outer<internal>private", ""],
     ["Use `<think>literal</think>` exactly.", "Use `<think>literal</think>` exactly."],
   ])("keeps tag privacy and distinct header rules: %j", (input, expected) => {
+    expect(stripFormattedReasoningMessage(input)).toBe(expected);
+  });
+  it.each([
+    ["<think>private</think>    const value = 1;", "    const value = 1;"],
+    ["<final>    const value = 1;</final>", "    const value = 1;"],
+    ["<think>private</think> \n\t ", ""],
+    [
+      "\nThinking\n_summary_\nUse `<think>literal</think>` exactly.",
+      "\nThinking\n_summary_\nUse `<think>literal</think>` exactly.",
+    ],
+    ["Thinking...\n_summary_\n\n    const value = 1;", "    const value = 1;"],
+    ["Reasoning:\n_summary_\n\tconst value = 1;", "\tconst value = 1;"],
+    ["<think>private</think>\nThinking\n_summary_\n    const value = 1;", "    const value = 1;"],
+    [
+      "Thinking\n_summary_\n\n    first line\n      second line\n\n",
+      "    first line\n      second line",
+    ],
+  ])("preserves substantive code indentation after a preamble: %j", (input, expected) => {
     expect(stripFormattedReasoningMessage(input)).toBe(expected);
   });
 });

--- a/src/shared/text/formatted-reasoning-message.ts
+++ b/src/shared/text/formatted-reasoning-message.ts
@@ -3,20 +3,22 @@ import { stripReasoningTagsFromText } from "./reasoning-tags.js";
 
 /** Strip provider-formatted Reasoning/Thinking preambles from visible text. */
 export function stripFormattedReasoningMessage(text: string): string {
-  const stripped = stripReasoningTagsFromText(text);
-  const firstNewline = stripped.indexOf("\n");
-  const prefix = (firstNewline === -1 ? stripped : stripped.slice(0, firstNewline)).trim();
+  const stripped = stripReasoningTagsFromText(text, { trim: "none" });
+  // Removed tags may leave blank lines before a preamble; untouched text keeps its boundary.
+  const preamble = stripped === text ? stripped : stripped.trimStart();
+  const firstNewline = preamble.indexOf("\n");
+  const prefix = (firstNewline === -1 ? preamble : preamble.slice(0, firstNewline)).trim();
   const thinking = /^Thinking\.{0,3}$/u.test(prefix);
   if (prefix !== "Reasoning:" && !thinking) {
-    return stripped;
+    return preamble ? stripped : "";
   }
 
-  let offset = firstNewline === -1 ? stripped.length : firstNewline + 1;
+  let offset = firstNewline === -1 ? preamble.length : firstNewline + 1;
   let hasSummary = false;
-  while (offset < stripped.length) {
-    const newline = stripped.indexOf("\n", offset);
-    const end = newline === -1 ? stripped.length : newline;
-    const line = stripped.slice(offset, end).trim();
+  while (offset < preamble.length) {
+    const newline = preamble.indexOf("\n", offset);
+    const end = newline === -1 ? preamble.length : newline;
+    const line = preamble.slice(offset, end).trim();
     const isSummary = line.length >= 2 && line.startsWith("_") && line.endsWith("_");
     if (line && !isSummary) {
       break;
@@ -24,7 +26,9 @@ export function stripFormattedReasoningMessage(text: string): string {
     hasSummary ||= isSummary;
     offset = end + 1;
   }
-  // Thinking needs an italic summary. Normalize CRLF only when removing a preamble;
-  // ordinary messages retain their original bytes, including bare carriage returns.
-  return thinking && !hasSummary ? stripped : stripped.slice(offset).replace(/\r\n/g, "\n").trim();
+  // Thinking needs an italic summary. Normalize CRLF and remove trailing newlines
+  // only after a preamble; preserve the remaining body indentation.
+  return thinking && !hasSummary
+    ? stripped
+    : preamble.slice(offset).replace(/\r\n/g, "\n").replace(/\n+$/u, "");
 }

--- a/test/e2e/qa-lab/plugins/discord-show-widget-contextual-presenter.e2e.test.ts
+++ b/test/e2e/qa-lab/plugins/discord-show-widget-contextual-presenter.e2e.test.ts
@@ -291,7 +291,7 @@ describe("Discord show_widget contextual presenter process proof", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
   it(
-    "preserves component attachment filenames through the public Gateway message action",
+    "preserves message bodies and component attachment filenames through the public Gateway message action",
     { timeout: 180_000 },
     async () => {
       const head = execFileSync("git", ["rev-parse", "HEAD"], {
@@ -355,23 +355,8 @@ describe("Discord show_widget contextual presenter process proof", () => {
           OPENCLAW_SKIP_CHANNELS: "1",
         },
       });
-      const media = path.join(gateway.workspaceDir, "source.pdf");
-      const bytes = Buffer.from("%PDF-1.4\nDiscord attachment filename proof\n%%EOF\n");
-      await writeFile(media, bytes);
-      const cases = [
-        { label: "declared", declared: true, expected: "report.pdf" },
-        { label: "blank override", declared: true, filename: "  ", expected: "report.pdf" },
-        {
-          label: "explicit override",
-          declared: true,
-          filename: " operator.pdf ",
-          expected: "operator.pdf",
-        },
-        { label: "media-derived", declared: false, expected: "source.pdf" },
-        { label: "components V2", declared: true, v2: true, expected: "report.pdf" },
-      ];
-      for (const testCase of cases) {
-        const before = discord.requests.filter((request) => request.method === "POST").length;
+      const invokeAction = async (label: string, args: JsonRecord) => {
+        const before = discord.requests.length;
         const response = await fetch(`${gateway.baseUrl}/tools/invoke`, {
           method: "POST",
           signal: AbortSignal.timeout(20_000),
@@ -389,20 +374,35 @@ describe("Discord show_widget contextual presenter process proof", () => {
               action: "send",
               channel: "discord",
               target: `channel:${DISCORD_CHANNEL_ID}`,
-              message: `Attachment proof: ${testCase.label}`,
-              media,
-              filename: testCase.filename,
-              components: {
-                blocks: testCase.declared
-                  ? [{ type: "file", file: "attachment://report.pdf" }]
-                  : [],
-                ...(testCase.v2 ? { container: { accentColor: 0x123456 } } : {}),
-              },
+              ...args,
             },
           }),
         });
         const result = (await response.json()) as JsonRecord;
         expect(response.status, JSON.stringify(result)).toBe(200);
+        expect(result).toMatchObject({ ok: true });
+        expect(result).not.toHaveProperty("result.isError", true);
+        const writes = discord.requests
+          .slice(before)
+          .filter((request) => request.method === "POST" || request.method === "PATCH");
+        expect(
+          writes.map(({ method, pathname }) => ({ method, pathname })),
+          label,
+        ).toEqual([
+          { method: "POST", pathname: `/api/v10/channels/${DISCORD_CHANNEL_ID}/messages` },
+        ]);
+        process.stdout.write(
+          `${JSON.stringify({
+            proof: "gateway-discord-message-action",
+            action: args.action ?? "send",
+            case: label,
+            writes,
+          })}\n`,
+        );
+        return { result, writes };
+      };
+      const invokeMessage = async (label: string, args: JsonRecord) => {
+        const { result, writes } = await invokeAction(label, args);
         expect(result).toMatchObject({
           ok: true,
           result: {
@@ -418,10 +418,33 @@ describe("Discord show_widget contextual presenter process proof", () => {
             },
           },
         });
-        const posts = discord.requests.filter((request) => request.method === "POST");
-        expect(posts, testCase.label).toHaveLength(before + 1);
-        const post = posts.at(-1);
-        expect(post?.pathname).toBe(`/api/v10/channels/${DISCORD_CHANNEL_ID}/messages`);
+        return writes[0];
+      };
+      const media = path.join(gateway.workspaceDir, "source.pdf");
+      const bytes = Buffer.from("%PDF-1.4\nDiscord attachment filename proof\n%%EOF\n");
+      await writeFile(media, bytes);
+      const cases = [
+        { label: "declared", declared: true, expected: "report.pdf" },
+        { label: "blank override", declared: true, filename: "  ", expected: "report.pdf" },
+        {
+          label: "explicit override",
+          declared: true,
+          filename: " operator.pdf ",
+          expected: "operator.pdf",
+        },
+        { label: "media-derived", declared: false, expected: "source.pdf" },
+        { label: "components V2", declared: true, v2: true, expected: "report.pdf" },
+      ];
+      for (const testCase of cases) {
+        const post = await invokeMessage(testCase.label, {
+          message: `Attachment proof: ${testCase.label}`,
+          media,
+          filename: testCase.filename,
+          components: {
+            blocks: testCase.declared ? [{ type: "file", file: "attachment://report.pdf" }] : [],
+            ...(testCase.v2 ? { container: { accentColor: 0x123456 } } : {}),
+          },
+        });
         expect(post?.files).toEqual([
           {
             field: "files[0]",
@@ -444,6 +467,149 @@ describe("Discord show_widget contextual presenter process proof", () => {
           })}\n`,
         );
       }
+
+      for (const testCase of [
+        {
+          label: "canonical body",
+          args: { message: "    canonical body" },
+          expected: "    canonical body",
+        },
+        {
+          label: "raw reasoning tag alias",
+          args: { text: "<think>private</think>    tag body" },
+          expected: "    tag body",
+        },
+        {
+          label: "mixed reasoning preamble alias",
+          args: { text: "<think>private</think>\nThinking\n_summary_\n    mixed body" },
+          expected: "    mixed body",
+        },
+        {
+          label: "fenced literal tag control",
+          args: { message: "```\n    <think>literal</think>\n```" },
+          expected: "```\n    <think>literal</think>\n```",
+        },
+      ]) {
+        const post = await invokeMessage(testCase.label, testCase.args);
+        expect(post?.files, testCase.label).toBeUndefined();
+        process.stdout.write(
+          `${JSON.stringify({
+            proof: "gateway-message-action-to-discord-text",
+            case: testCase.label,
+            content: post?.body?.content,
+          })}\n`,
+        );
+        expect.soft(post?.body?.content, testCase.label).toBe(testCase.expected);
+      }
+
+      const caption = await invokeMessage("caption fallback", {
+        message: " \n ",
+        caption: "    caption body  ",
+        media,
+      });
+      expect(caption?.files).toEqual([
+        {
+          field: "files[0]",
+          name: "source.pdf",
+          type: "application/pdf",
+          base64: bytes.toString("base64"),
+        },
+      ]);
+      expect.soft(caption?.body?.content).toBe("    caption body  ");
+
+      const classic = await invokeMessage("classic component file body", {
+        message: "    classic component body  ",
+        media,
+        components: { blocks: [{ type: "file", file: "attachment://report.pdf" }] },
+      });
+      expect(classic?.files).toEqual([
+        {
+          field: "files[0]",
+          name: "report.pdf",
+          type: "application/pdf",
+          base64: bytes.toString("base64"),
+        },
+      ]);
+      expect.soft(classic?.body?.content).toBe("    classic component body  ");
+
+      const componentText = await invokeMessage("explicit Components V2 body fields", {
+        message: "fallback",
+        components: {
+          text: "    top-level body  ",
+          container: { accentColor: 0x123456 },
+          blocks: [
+            { type: "text", text: "    text-block body  " },
+            {
+              type: "section",
+              text: "    section body  ",
+              accessory: {
+                type: "button",
+                button: { label: " Read ", style: "link", url: "https://example.com/section" },
+              },
+            },
+            {
+              type: "section",
+              texts: ["    first body  ", "    second body  "],
+              accessory: {
+                type: "button",
+                button: { label: " Read ", style: "link", url: "https://example.com/texts" },
+              },
+            },
+          ],
+        },
+      });
+      expect(componentText?.body?.flags).toBe(DISCORD_COMPONENTS_V2_FLAG);
+      expect.soft(componentText?.body?.components).toMatchObject([
+        {
+          type: 17,
+          components: [
+            { type: 10, content: "    top-level body  " },
+            { type: 10, content: "    text-block body  " },
+            {
+              type: 9,
+              components: [{ type: 10, content: "    section body  " }],
+              accessory: { label: "Read" },
+            },
+            {
+              type: 9,
+              components: [
+                { type: 10, content: "    first body  " },
+                { type: 10, content: "    second body  " },
+              ],
+              accessory: { label: "Read" },
+            },
+          ],
+        },
+      ]);
+
+      const poll = await invokeAction("poll", {
+        action: "poll",
+        message: "    poll body  ",
+        pollQuestion: " Lunch? ",
+        pollOption: [" Pizza ", " Sushi "],
+        pollDurationHours: 2,
+        silent: true,
+      });
+      expect(poll.result).toMatchObject({
+        result: {
+          details: {
+            channel: "discord",
+            via: "direct",
+            result: { messageId: DISCORD_MESSAGE_ID },
+          },
+        },
+      });
+      expect(poll.writes[0]?.body).toMatchObject({
+        flags: (1 << 12) | (1 << 2),
+        poll: {
+          question: { text: "Lunch?" },
+          answers: [{ poll_media: { text: "Pizza" } }, { poll_media: { text: "Sushi" } }],
+          duration: 2,
+          allow_multiselect: false,
+          layout_type: 1,
+        },
+      });
+      expect.soft(poll.writes[0]?.body?.content).toBe("    poll body  ");
     },
   );
 

--- a/test/e2e/qa-lab/plugins/discord-show-widget-contextual-presenter.e2e.test.ts
+++ b/test/e2e/qa-lab/plugins/discord-show-widget-contextual-presenter.e2e.test.ts
@@ -291,7 +291,7 @@ describe("Discord show_widget contextual presenter process proof", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
   it(
-    "preserves message bodies and component attachment filenames through the public Gateway message action",
+    "preserves component attachment filenames through the public Gateway message action",
     { timeout: 180_000 },
     async () => {
       const head = execFileSync("git", ["rev-parse", "HEAD"], {

--- a/test/e2e/qa-lab/plugins/discord-show-widget-contextual-presenter.e2e.test.ts
+++ b/test/e2e/qa-lab/plugins/discord-show-widget-contextual-presenter.e2e.test.ts
@@ -515,7 +515,8 @@ describe("Discord show_widget contextual presenter process proof", () => {
           base64: bytes.toString("base64"),
         },
       ]);
-      expect.soft(caption?.body?.content).toBe("    caption body  ");
+      // Core reply normalization trims the suffix before Discord delivery.
+      expect.soft(caption?.body?.content).toBe("    caption body");
 
       const classic = await invokeMessage("classic component file body", {
         message: "    classic component body  ",
@@ -530,7 +531,7 @@ describe("Discord show_widget contextual presenter process proof", () => {
           base64: bytes.toString("base64"),
         },
       ]);
-      expect.soft(classic?.body?.content).toBe("    classic component body  ");
+      expect.soft(classic?.body?.content).toBe("    classic component body");
 
       const componentText = await invokeMessage("explicit Components V2 body fields", {
         message: "fallback",


### PR DESCRIPTION
Closes #121351
Supersedes #121484. Thanks @ruel225 for the original repair and @yifanxiong272 for the report.

## What Problem This Solves

Fixes an issue where indented Markdown loses its leading spaces after reasoning-preamble cleanup, message sending, or inter-session forwarding. Discord captions, poll context, and component text could trim that indentation again before delivery.

## Why This Change Was Made

Preserve substantive text at the parsing and projection owners while retaining blank-message rejection, reasoning removal, and trimmed control labels. The current reasoning scanner and CRLF behavior stay intact. Provenance stripping and classic Discord text composition share fewer paths; production changes by **+56/−70 (net −14)**.

This maintainer-owned continuation retains the original contributor's credit and leaves the contributor's commit ancestry intact.

## User Impact

Indented code survives the corrected reasoning, session-send/display, and Discord message paths. Ordinary message and caption delivery still removes trailing whitespace under the existing parser contract. Explicit Components V2 text and poll context keep their own whitespace behavior.

## Evidence

- The issue's exact input now returns `"    const value = 1;"`. The reported main snapshot was inspected directly: its final `.trim()` removes that indentation.
- Baseline owner regressions failed for lost indentation. The baseline Gateway/Discord fixture captured 13 HTTP actions; seven formatting cases lost boundary whitespace while attachment and fenced-tag controls remained intact.
- **462 focused owner/sibling tests pass** on the refreshed candidate. The initial two Gateway runs hit the new history observation's five-second deadline. Passing phase probes measured 2.4–3.2 seconds of first-use handler loading and 12–14 ms of history work. The fixture now prepares the real chat family during setup; authentication, dispatch, payload assertions, and the five-second RPC deadline remain unchanged. This is fixture stability evidence, not a production cold-start performance claim.
- The complete production repair passed a six-part independent review. The suffix expectation/docs correction and final fixture preparation each received fresh P0–P2 review with no actionable findings. The full production patch passed its 38-check repair gate before the mechanical main refresh; subsequent correction gates and the normal final build passed after the refresh. Exact-head CI remains the landing gate.
- A normal clean build passed at `56fbdf48244a5c0eb886a613593b782da05489b3`; all three build revision stamps match that commit. The complete two-case Gateway/Discord transport fixture passed with zero failures/skips. It covers all 13 message actions plus real widget routing, mismatched-context rejection, and the inline path.
- Current-main compatibility was rechecked at `aaf39fdb067b70c69d1f339b90b2a4d872134eba`: production owners and inspected callers/callees are unchanged; the unrelated A2A mock-tail update in the shared test merges cleanly.

```json
{"head":"56fbdf48244a5c0eb886a613593b782da05489b3","tests":2,"passed":2,"failed":0,"skipped":0,"httpActions":13,"transport":"real isolated Gateway and Discord plugin with local mock REST"}
```

The HTTP recorder observed `"    canonical body"`, `"    tag body"`, `"    mixed body"`, and indented caption/component/poll content after the fix; their baseline counterparts were unindented. Attachment filenames, bytes, normalized control labels and fenced literal tags remained correct.

Transport command: `pnpm test:e2e:gateway test/e2e/qa-lab/plugins/discord-show-widget-contextual-presenter.e2e.test.ts --reporter=verbose --reporter=json --outputFile=<report.json>`.

This is synthetic Gateway/transport proof, not authenticated Discord delivery or live-model proof. The original PR's Telegram Test Server rank-up suggestion is not claimed complete; this uses the repository's accepted mock-Gateway proof path for the changed Discord surface. Unchanged Slack/Telegram adapters and separate presentation/transcript-mirror trimming remain outside the demonstrated scope. Current published head: `c3f53e7310fc7aa75af7543df4171d1196e1ad18`. [CI33993566863](https://github.com/openclaw/openclaw/actions/runs/33993566863) passed on attempt1, including build-artifacts and the required gate. The only change from the built and fully transport-tested head `56fbdf48244a5c0eb886a613593b782da05489b3` restores the original CI-selected test name; setup, assertions, timeout, and production code are unchanged. CI run 33992111598 failed because the expanded test title no longer matched its exact filter/report check. The correction received a clean independent P0–P2 review. A local filtered retry selected the correct test but timed out at its existing 180-second limit before HTTP observations; this is retained as failed evidence. Fresh hosted CI subsequently passed the named transport case and its exact report validator.

Fresh CI transport artifact: 1 selected case passed, zero failed, the separate widget case excluded by the filter; 13 real Gateway-to-mock-REST actions preserved expected content. Build revision `9c740448e6865a90863eba9f42160564dd5e2d89` is GitHub’s test merge with verified parents main `5c7a2e92b179ac99ed4d968ffc0842607333a08a` and PR head `c3f53e7310fc7aa75af7543df4171d1196e1ad18`.
