### PR TITLE
fix: concurrent MCP shutdown reports a spurious listener error

### DIFF
--- a/src/agents/cli-runner.before-agent-reply-cron.test.ts
+++ b/src/agents/cli-runner.before-agent-reply-cron.test.ts
@@ -841,7 +841,7 @@ describe("runCliAgent before_agent_reply seam", () => {
     const { getActiveMcpLoopbackRuntime } = await vi.importActual<
       typeof import("../gateway/mcp-http.loopback-runtime.js")
     >("../gateway/mcp-http.loopback-runtime.js");
-    const server = await mcpHttp.ensureMcpLoopbackServer();
+    await mcpHttp.ensureMcpLoopbackServer();
     const runtime = getActiveMcpLoopbackRuntime();
     if (!runtime) {
       throw new Error("expected an active MCP loopback runtime");
@@ -855,7 +855,7 @@ describe("runCliAgent before_agent_reply seam", () => {
     const openStreams = async (sessionKeys: readonly string[]) => {
       const responses = await Promise.all(
         sessionKeys.map((sessionKey) =>
-          fetch(`http://127.0.0.1:${server.port}/mcp`, {
+          fetch(`http://127.0.0.1:${runtime.port}/mcp`, {
             method: "GET",
             headers: {
               authorization: `Bearer ${runtime.ownerToken}`,
@@ -881,7 +881,7 @@ describe("runCliAgent before_agent_reply seam", () => {
     try {
       await openStreams(["agent:main:concurrent-one", "agent:main:concurrent-two"]);
 
-      const unauthorized = await fetch(`http://127.0.0.1:${server.port}/mcp`);
+      const unauthorized = await fetch(`http://127.0.0.1:${runtime.port}/mcp`);
       expect(unauthorized.status).toBe(401);
       await unauthorized.body?.cancel();
 
@@ -891,7 +891,7 @@ describe("runCliAgent before_agent_reply seam", () => {
       if (!survivingRuntime) {
         throw new Error("helper cleanup incorrectly closed the active MCP loopback server");
       }
-      expect(survivingRuntime.port).toBe(server.port);
+      expect(survivingRuntime.port).toBe(runtime.port);
       expect(survivingRuntime.ownerToken === runtime.ownerToken).toBe(true);
       const originalStreamStates = await Promise.all(
         readers.map(async (reader) => {
@@ -922,7 +922,7 @@ describe("runCliAgent before_agent_reply seam", () => {
       for (const result of await Promise.all(readers.map((reader) => reader.read()))) {
         expect(result.done).toBe(true);
       }
-      await expect(fetch(`http://127.0.0.1:${server.port}/mcp`)).rejects.toThrow();
+      await expect(fetch(`http://127.0.0.1:${runtime.port}/mcp`)).rejects.toThrow();
     } finally {
       await mcpHttp.closeMcpLoopbackServer();
       await Promise.allSettled(readers.map((reader) => reader.cancel()));

--- a/src/agents/cli-runner.test-helpers.ts
+++ b/src/agents/cli-runner.test-helpers.ts
@@ -87,9 +87,7 @@ export function createTestMcpLoopbackClientGrant(params: {
   return { token: "loopback-token", context: structuredClone(params.context) };
 }
 
-export async function createTestMcpLoopbackServer(port = 0) {
-  return { port, close: vi.fn(async () => undefined) };
-}
+export async function createTestMcpLoopbackServer(): Promise<void> {}
 
 export function buildDefaultTestCliBackend(
   params: TestCliBackendParams = {},

--- a/src/gateway/mcp-http.question-authority.test.ts
+++ b/src/gateway/mcp-http.question-authority.test.ts
@@ -35,7 +35,7 @@ import {
   revokeMcpLoopbackClientGrant,
   transferMcpLoopbackClientGrant,
 } from "./mcp-grant-store.js";
-import { ensureMcpLoopbackServer } from "./mcp-http.js";
+import { closeMcpLoopbackServer, ensureMcpLoopbackServer } from "./mcp-http.js";
 import * as toolResolution from "./tool-resolution.js";
 
 vi.mock("../plugins/hook-runner-global.js", () => ({ getGlobalHookRunner: () => null }));
@@ -152,7 +152,7 @@ async function withCliQuestionLoopback(
         };
         // Config identity is stable: tools/list must seed the same cache used by tools/call.
         setRuntimeConfigSnapshot(config);
-        const server = await ensureMcpLoopbackServer();
+        await ensureMcpLoopbackServer();
         const { getActiveMcpLoopbackRuntime } = await import("./mcp-http.loopback-runtime.js");
         const runtime = expectDefined(getActiveMcpLoopbackRuntime(), "loopback runtime");
         const toolCalls = new Set<Promise<unknown>>();
@@ -185,7 +185,7 @@ async function withCliQuestionLoopback(
           method: "tools/list" | "tools/call",
           attached = false,
         ) => {
-          const response = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+          const response = await fetch(`http://127.0.0.1:${runtime.port}/mcp`, {
             method: "POST",
             signal: requestController.signal,
             headers: {
@@ -297,7 +297,7 @@ async function withCliQuestionLoopback(
             }
           },
           () => Promise.allSettled(requests),
-          () => server.close(),
+          () => closeMcpLoopbackServer(),
           () => Promise.allSettled(toolCalls),
           () =>
             runQaGatewayFixture(

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -184,8 +184,6 @@ import {
 } from "./mcp-http.loopback-runtime.js";
 import { McpLoopbackToolCache } from "./mcp-http.runtime.js";
 
-let server: Awaited<ReturnType<typeof ensureMcpLoopbackServer>> | undefined;
-
 const MAIN_SESSION_HEADER = { "x-session-key": "agent:main:main" };
 const ANGLE_NUMBER_PROPERTY = { type: "number" };
 const SSE_TEST_READ_TIMEOUT_MS = 100;
@@ -434,12 +432,12 @@ async function sendStalledBody(params: {
 }
 
 async function startLoopbackServerForTest(port = 0) {
-  server = await ensureMcpLoopbackServer(port);
+  await ensureMcpLoopbackServer(port);
   const runtime = getActiveMcpLoopbackRuntime();
   if (!runtime) {
     throw new Error("expected active MCP loopback runtime");
   }
-  return { port: server.port, runtime };
+  return { port: runtime.port, runtime };
 }
 
 async function readMcpPayload(response: Response): Promise<McpToolResultPayload> {
@@ -452,7 +450,7 @@ async function sendLoopbackToolsList(params: {
   id?: number;
 }) {
   return sendRaw({
-    port: server?.port ?? 0,
+    port: getActiveMcpLoopbackRuntime()?.port ?? 0,
     token: params.token,
     headers: jsonHeaders(params.headers),
     body: mcpToolsListBody(params.id),
@@ -466,7 +464,7 @@ async function sendLoopbackToolCall(params: {
   headers?: Record<string, string>;
 }) {
   return sendRaw({
-    port: server?.port ?? 0,
+    port: getActiveMcpLoopbackRuntime()?.port ?? 0,
     token: params.token,
     headers: jsonHeaders(params.headers),
     body: mcpToolCallBody(params.name, params.args),
@@ -686,8 +684,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-  await server?.close();
-  server = undefined;
+  await closeMcpLoopbackServer();
   for (const admission of activeAdmissions.splice(0)) {
     admission.close();
   }
@@ -1747,8 +1744,7 @@ describe("mcp loopback server", () => {
       runtimeOwnerToken: firstServer.runtime.ownerToken,
       captureKey: "capture-stale",
     });
-    await server?.close();
-    server = undefined;
+    await closeMcpLoopbackServer();
 
     const successor = await startLoopbackServerForTest();
     expect(
@@ -3468,35 +3464,50 @@ describe("mcp loopback server", () => {
   });
 
   it("tracks the active runtime only while the server is running", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const active = getActiveMcpLoopbackRuntime();
-    expect(active?.port).toBe(server.port);
+    expect(active?.port).toBe(port);
     expect(active?.ownerToken).toMatch(/^[0-9a-f]{64}$/);
     expect(active?.nonOwnerToken).toMatch(/^[0-9a-f]{64}$/);
     expect(active?.nonOwnerToken).not.toBe(active?.ownerToken);
 
-    await server.close();
-    server = undefined;
+    await closeMcpLoopbackServer();
     expect(getActiveMcpLoopbackRuntime()).toBeUndefined();
   });
 
   it("starts the loopback server lazily and reuses the same singleton", async () => {
     expect(getActiveMcpLoopbackRuntime()).toBeUndefined();
 
-    const first = await ensureMcpLoopbackServer(0);
-    const second = await ensureMcpLoopbackServer(0);
+    const first = await startLoopbackServerForTest();
+    const second = await startLoopbackServerForTest();
 
-    expect(second).toBe(first);
+    expect(second).toEqual(first);
     expect(getActiveMcpLoopbackRuntime()?.port).toBe(first.port);
 
     await closeMcpLoopbackServer();
     expect(getActiveMcpLoopbackRuntime()).toBeUndefined();
   });
 
+  it("closes a pending startup once for concurrent shutdown callers", async () => {
+    const starting = ensureMcpLoopbackServer();
+    const closing = Promise.allSettled([closeMcpLoopbackServer(), closeMcpLoopbackServer()]);
+    try {
+      await starting;
+      expect(await closing).toEqual([
+        { status: "fulfilled", value: undefined },
+        { status: "fulfilled", value: undefined },
+      ]);
+      expect(getActiveMcpLoopbackRuntime()).toBeUndefined();
+    } finally {
+      await closing;
+      await closeMcpLoopbackServer();
+    }
+  });
+
   it("returns 401 when the bearer token is missing", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const response = await sendRaw({
-      port: server.port,
+      port,
       headers: { "content-type": "application/json" },
       body: mcpToolsListBody(),
     });
@@ -3504,10 +3515,10 @@ describe("mcp loopback server", () => {
   });
 
   it("returns 415 when the content type is not JSON", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const runtime = getActiveMcpLoopbackRuntime();
     const response = await sendRaw({
-      port: server.port,
+      port,
       token: runtime?.ownerToken,
       headers: { "content-type": "text/plain" },
       body: "{}",
@@ -3516,10 +3527,10 @@ describe("mcp loopback server", () => {
   });
 
   it("returns JSON-RPC parse errors only for invalid JSON", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const runtime = getActiveMcpLoopbackRuntime();
     const response = await sendRaw({
-      port: server.port,
+      port,
       token: runtime?.ownerToken,
       headers: { "content-type": "application/json" },
       body: "{",
@@ -3541,10 +3552,10 @@ describe("mcp loopback server", () => {
     resolveGatewayScopedToolsMock.mockImplementationOnce(() => {
       throw new Error("tool resolution exploded");
     });
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const runtime = getActiveMcpLoopbackRuntime();
     const response = await sendRaw({
-      port: server.port,
+      port,
       token: runtime?.ownerToken,
       headers: { "content-type": "application/json" },
       body: mcpToolsListBody(42),
@@ -3593,10 +3604,10 @@ describe("mcp loopback server", () => {
   });
 
   it("returns invalid request errors for malformed batch entries without resetting the request", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const runtime = getActiveMcpLoopbackRuntime();
     const response = await sendRaw({
-      port: server.port,
+      port,
       token: runtime?.ownerToken,
       headers: { "content-type": "application/json" },
       body: `[null,${mcpToolsListBody(7)}]`,
@@ -3712,10 +3723,10 @@ describe("mcp loopback server", () => {
   });
 
   it("returns 413 instead of resetting oversized request bodies", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const runtime = getActiveMcpLoopbackRuntime();
     const response = await sendRaw({
-      port: server.port,
+      port,
       token: runtime?.ownerToken,
       headers: { "content-type": "application/json" },
       body: "x".repeat(1_048_577),
@@ -3726,14 +3737,14 @@ describe("mcp loopback server", () => {
   });
 
   it("closes slow oversized request uploads after flushing 413", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const runtime = getActiveMcpLoopbackRuntime();
     if (!runtime) {
       throw new Error("expected active MCP loopback runtime");
     }
 
     const response = await sendChunkedOversizedBody({
-      port: server.port,
+      port,
       token: runtime.ownerToken,
     });
 
@@ -3748,14 +3759,14 @@ describe("mcp loopback server", () => {
     const previousTimeout = process.env.OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS;
     process.env.OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS = "20";
     try {
-      server = await ensureMcpLoopbackServer(0);
+      const { port } = await startLoopbackServerForTest();
       const runtime = getActiveMcpLoopbackRuntime();
       if (!runtime) {
         throw new Error("expected active MCP loopback runtime");
       }
 
       const response = await sendStalledBody({
-        port: server.port,
+        port,
         token: runtime.ownerToken,
       });
 
@@ -3777,7 +3788,7 @@ describe("mcp loopback server", () => {
     const previousTimeout = process.env.OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS;
     process.env.OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS = "2147483648";
     try {
-      server = await ensureMcpLoopbackServer(0);
+      const { port } = await startLoopbackServerForTest();
       const runtime = getActiveMcpLoopbackRuntime();
       if (!runtime) {
         throw new Error("expected active MCP loopback runtime");
@@ -3785,7 +3796,7 @@ describe("mcp loopback server", () => {
       const auth = runtime.ownerToken;
 
       const response = await sendStalledBody({
-        port: server.port,
+        port,
         token: auth,
         bodyAfterDelay: mcpToolsListBody(),
         delayMs: 25,
@@ -3877,9 +3888,9 @@ describe("createMcpLoopbackServerConfig", () => {
   });
 
   it("opens an auth-gated SSE stream on GET (Streamable HTTP notification channel)", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const res = await sendRaw({
-      port: server.port,
+      port,
       method: "GET",
       token: getActiveMcpLoopbackRuntime()?.ownerToken,
     });
@@ -3935,9 +3946,9 @@ describe("createMcpLoopbackServerConfig", () => {
   });
 
   it("closes active GET notification streams during loopback shutdown", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const res = await sendRaw({
-      port: server.port,
+      port,
       method: "GET",
       token: getActiveMcpLoopbackRuntime()?.ownerToken,
     });
@@ -3949,8 +3960,7 @@ describe("createMcpLoopbackServerConfig", () => {
 
     try {
       await readUntilInitialSseCommentFrame(reader);
-      const closePromise = server.close();
-      server = undefined;
+      const closePromise = closeMcpLoopbackServer();
       await expectPromiseResolvesWithin(closePromise, 500, "MCP loopback server close");
       const closed = await readStreamChunkWithTimeout(reader);
       expect(closed.done).toBe(true);
@@ -3961,7 +3971,7 @@ describe("createMcpLoopbackServerConfig", () => {
   });
 
   it("withdraws a closing runtime before drain without fencing its successor", async () => {
-    const oldServer = await ensureMcpLoopbackServer(0);
+    await ensureMcpLoopbackServer();
     const oldRuntime = getActiveMcpLoopbackRuntime();
     if (!oldRuntime) {
       throw new Error("expected old MCP loopback runtime");
@@ -3986,7 +3996,7 @@ describe("createMcpLoopbackServerConfig", () => {
       const req = request(
         {
           hostname: "127.0.0.1",
-          port: oldServer.port,
+          port: oldRuntime.port,
           path: "/mcp",
           method: "POST",
           headers: {
@@ -4059,21 +4069,21 @@ describe("createMcpLoopbackServerConfig", () => {
       clearMcpLoopbackToolCallCapture(captureKey);
       finishStalledRequest();
       await responsePromise.catch(() => undefined);
-      await (oldClose ?? oldServer.close()).catch(() => undefined);
+      await (oldClose ?? closeMcpLoopbackServer()).catch(() => undefined);
     }
   });
 
   it("rejects a GET notification channel without a bearer token (401)", async () => {
-    server = await ensureMcpLoopbackServer(0);
-    const res = await sendRaw({ port: server.port, method: "GET" });
+    const { port } = await startLoopbackServerForTest();
+    const res = await sendRaw({ port, method: "GET" });
     expect(res.status).toBe(401);
     await res.body?.cancel();
   });
 
   it("rejects a GET notification channel from a browser Origin (403)", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const res = await sendRaw({
-      port: server.port,
+      port,
       method: "GET",
       token: getActiveMcpLoopbackRuntime()?.ownerToken,
       headers: {
@@ -4085,9 +4095,9 @@ describe("createMcpLoopbackServerConfig", () => {
   });
 
   it("acknowledges DELETE session teardown with 200 (stateless no-op)", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const res = await sendRaw({
-      port: server.port,
+      port,
       method: "DELETE",
       token: getActiveMcpLoopbackRuntime()?.ownerToken,
     });
@@ -4095,9 +4105,9 @@ describe("createMcpLoopbackServerConfig", () => {
   });
 
   it("ignores Mcp-Session-Id on DELETE because loopback teardown is stateless", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const res = await sendRaw({
-      port: server.port,
+      port,
       method: "DELETE",
       token: getActiveMcpLoopbackRuntime()?.ownerToken,
       headers: { "mcp-session-id": "ignored-loopback-session" },
@@ -4106,22 +4116,22 @@ describe("createMcpLoopbackServerConfig", () => {
   });
 
   it("rejects DELETE without a bearer token (401)", async () => {
-    server = await ensureMcpLoopbackServer(0);
-    const res = await sendRaw({ port: server.port, method: "DELETE" });
+    const { port } = await startLoopbackServerForTest();
+    const res = await sendRaw({ port, method: "DELETE" });
     expect(res.status).toBe(401);
   });
 
   it("rejects unsupported methods with 405 advertising GET, POST, DELETE", async () => {
-    server = await ensureMcpLoopbackServer(0);
-    const res = await sendRaw({ port: server.port, method: "PUT" });
+    const { port } = await startLoopbackServerForTest();
+    const res = await sendRaw({ port, method: "PUT" });
     expect(res.status).toBe(405);
     expect(res.headers.get("allow")).toBe("GET, POST, DELETE");
   });
 
   it("stays stateless: POST responses advertise no Mcp-Session-Id", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const res = await sendRaw({
-      port: server.port,
+      port,
       token: getActiveMcpLoopbackRuntime()?.ownerToken,
       headers: { "content-type": "application/json", "x-session-key": "agent:main:main" },
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
@@ -4131,9 +4141,9 @@ describe("createMcpLoopbackServerConfig", () => {
   });
 
   it("rejects a browser-Origin GET before auth (403, no bearer)", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const res = await sendRaw({
-      port: server.port,
+      port,
       method: "GET",
       headers: { origin: "https://evil.example" },
     });
@@ -4142,9 +4152,9 @@ describe("createMcpLoopbackServerConfig", () => {
   });
 
   it("rejects a browser-Origin DELETE before auth (403, no bearer)", async () => {
-    server = await ensureMcpLoopbackServer(0);
+    const { port } = await startLoopbackServerForTest();
     const res = await sendRaw({
-      port: server.port,
+      port,
       method: "DELETE",
       headers: { origin: "https://evil.example" },
     });

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -58,13 +58,8 @@ import { McpLoopbackToolCache } from "./mcp-http.runtime.js";
 // bearer-token HTTP endpoint bound to 127.0.0.1. Only one active server/runtime
 // is registered per process.
 
-type McpLoopbackServer = {
-  port: number;
-  close: () => Promise<void>;
-};
-
-let activeMcpLoopbackServer: McpLoopbackServer | undefined;
-let activeMcpLoopbackServerPromise: Promise<McpLoopbackServer> | null = null;
+let closeActiveMcpLoopbackServer: (() => Promise<void>) | undefined;
+let activeMcpLoopbackServerPromise: Promise<void> | null = null;
 
 function createMcpJsonParseError(error: unknown): Error & { code: "mcp_json_parse_error" } {
   return Object.assign(new Error("MCP JSON parse error"), {
@@ -168,10 +163,7 @@ function createRequestAbortSignal(req: IncomingMessage, res: ServerResponse) {
 }
 
 /** Starts a new MCP loopback HTTP server and registers its bearer tokens. */
-async function startMcpLoopbackServer(port = 0): Promise<{
-  port: number;
-  close: () => Promise<void>;
-}> {
+async function startMcpLoopbackServer(port = 0): Promise<() => Promise<void>> {
   const ownerToken = crypto.randomBytes(32).toString("hex");
   const nonOwnerToken = crypto.randomBytes(32).toString("hex");
   const toolCache = new McpLoopbackToolCache();
@@ -520,45 +512,29 @@ async function startMcpLoopbackServer(port = 0): Promise<{
   setActiveMcpLoopbackRuntime({ port: address.port, ownerToken, nonOwnerToken });
   logDebug(`mcp loopback listening on 127.0.0.1:${address.port}`);
 
-  const server: McpLoopbackServer = {
-    port: address.port,
-    close: () => {
-      // Stop admitting this runtime's child grants before draining accepted
-      // requests. A delayed old-server close cannot revoke a successor runtime.
-      clearActiveMcpLoopbackRuntimeByOwnerToken(ownerToken);
-      revokeMcpLoopbackClientGrantsForRuntime(ownerToken);
-      unregisterGrantRevocation();
-      toolCache.clear();
-      return new Promise<void>((resolve, reject) => {
-        httpServer.close((error) => {
-          if (!error) {
-            if (activeMcpLoopbackServer === server) {
-              activeMcpLoopbackServer = undefined;
-            }
-          }
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-        closeActiveSseResponses();
-      });
-    },
+  return () => {
+    // Stop admitting this runtime's child grants before draining accepted
+    // requests. A delayed old-server close cannot revoke a successor runtime.
+    clearActiveMcpLoopbackRuntimeByOwnerToken(ownerToken);
+    revokeMcpLoopbackClientGrantsForRuntime(ownerToken);
+    unregisterGrantRevocation();
+    toolCache.clear();
+    return new Promise<void>((resolve, reject) => {
+      httpServer.close((error) => (error ? reject(error) : resolve()));
+      closeActiveSseResponses();
+    });
   };
-  return server;
 }
 
-/** Returns the active MCP loopback server or starts one if none exists. */
-export async function ensureMcpLoopbackServer(port = 0): Promise<McpLoopbackServer> {
-  if (activeMcpLoopbackServer) {
-    return activeMcpLoopbackServer;
+/** Waits for the process-owned MCP loopback server, starting one if needed. */
+export async function ensureMcpLoopbackServer(port = 0): Promise<void> {
+  if (closeActiveMcpLoopbackServer) {
+    return;
   }
   if (!activeMcpLoopbackServerPromise) {
     activeMcpLoopbackServerPromise = startMcpLoopbackServer(port)
-      .then((server) => {
-        activeMcpLoopbackServer = server;
-        return server;
+      .then((close) => {
+        closeActiveMcpLoopbackServer = close;
       })
       .finally(() => {
         activeMcpLoopbackServerPromise = null;
@@ -569,12 +545,12 @@ export async function ensureMcpLoopbackServer(port = 0): Promise<McpLoopbackServ
 
 /** Closes the active MCP loopback server if one has been started. */
 export async function closeMcpLoopbackServer(): Promise<void> {
-  const server =
-    activeMcpLoopbackServer ??
-    (activeMcpLoopbackServerPromise ? await activeMcpLoopbackServerPromise : undefined);
-  if (!server) {
-    return;
+  if (activeMcpLoopbackServerPromise) {
+    await activeMcpLoopbackServerPromise;
   }
-  activeMcpLoopbackServer = undefined;
-  await server.close();
+  // Claim after startup so concurrent shutdown waiters cannot close the same
+  // listener twice. A later call owns only the then-current server, not drains.
+  const close = closeActiveMcpLoopbackServer;
+  closeActiveMcpLoopbackServer = undefined;
+  await close?.();
 }

--- a/test/loopback-ask-user-telegram-channel.test.ts
+++ b/test/loopback-ask-user-telegram-channel.test.ts
@@ -40,7 +40,7 @@ import {
 } from "../src/config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import { resolveMcpLoopbackClientGrant } from "../src/gateway/mcp-grant-store.js";
-import { ensureMcpLoopbackServer } from "../src/gateway/mcp-http.js";
+import { closeMcpLoopbackServer, ensureMcpLoopbackServer } from "../src/gateway/mcp-http.js";
 import * as toolResolution from "../src/gateway/tool-resolution.js";
 import { closeOpenClawStateDatabaseForTest } from "../src/state/openclaw-state-db.js";
 import { runQaGatewayFixture } from "./helpers/qa-gateway-cleanup.js";
@@ -195,7 +195,7 @@ describe("loopback ask_user Telegram channel transport", () => {
               },
             };
             setRuntimeConfigSnapshot(config);
-            const server = await ensureMcpLoopbackServer();
+            await ensureMcpLoopbackServer();
             const { getActiveMcpLoopbackRuntime } =
               await import("../src/gateway/mcp-http.loopback-runtime.js");
             const runtime = expectDefined(getActiveMcpLoopbackRuntime(), "loopback runtime");
@@ -225,7 +225,7 @@ describe("loopback ask_user Telegram channel transport", () => {
             const requests: Promise<McpResponse>[] = [];
             const persist = vi.fn(async () => {});
             const request = async (token: string, method: "tools/list" | "tools/call") => {
-              const response = await fetch(`http://127.0.0.1:${server.port}/mcp`, {
+              const response = await fetch(`http://127.0.0.1:${runtime.port}/mcp`, {
                 method: "POST",
                 signal: requestController.signal,
                 headers: {
@@ -337,7 +337,7 @@ describe("loopback ask_user Telegram channel transport", () => {
                 }
               },
               () => Promise.allSettled(requests),
-              () => server.close(),
+              () => closeMcpLoopbackServer(),
               () => Promise.allSettled(toolCalls),
               () =>
                 runQaGatewayFixture(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where overlapping MCP shutdown requests can report `Server is not running` when the loopback listener is still starting.

## Why This Change Was Made

Keep shutdown under one process owner: wait for startup, then claim and clear the private close callback before invoking it. Remove the unused returned server handle and duplicate late cleanup; callers obtain readiness and existing runtime metadata instead. Production shrinks by 24 lines; tests and support grow by 8.

## User Impact

Concurrent cleanup can complete without a spurious duplicate-close error. SSE termination, accepted-request draining, successor ownership, and tool policy are preserved. No configuration, protocol, or public SDK changes.

## Evidence

- Before: full HTTP file had 114 passing tests and one regression failure, with the second shutdown rejecting `ERR_SERVER_NOT_RUNNING`. After: all 115 pass.
- 542 sibling tests across 11 files and all 29 normal changed checks pass; the normal mapped build passes.
- Actual compiled Node 26.8.1 proof passes readiness reuse, concurrent startup/shutdown, SSE closure, and successor service during/after drain: four scenarios, four HTTP requests, clean process closure.
- Independent review found no actionable P0–P2 findings. The question-authority fixture migration changes only acquisition, port lookup, and the cleanup callback; its assertions and cleanup order are preserved.

Validation used the selected base with Vitest 4.1.11; current main uses Vitest 5.0.0, so exact-head CI and final-main validation remain separate. This establishes correctness and cleanup, not a performance percentage or the cause of the older question-authority CI timeout.


### CI follow-up

The first CI run caught an existing root integration test that still consumed the removed server handle. The initial caller audit missed that `test/` consumer; this was not a Vitest upgrade or main-drift failure. Four mechanical substitutions now use readiness, the already-published runtime port, and global shutdown in the same cleanup position. Assertions, auth grants, request settlement, and the separate Telegram fixture are unchanged.

The complete Telegram loopback integration scenario passed, followed by all 32 normal changed checks including root-test typechecking. A repository-wide caller audit found no remaining real-handle consumer. A fresh independent review of the four substitutions passed; production and the previous compiled-owner proof remain unchanged. The original CI failure is retained, and refreshed-head CI is required before landing.
