### PR TITLE
fix(update): report launchd service recovery correctly after a failed update

### DIFF
--- a/src/daemon/launchd-current-service.test.ts
+++ b/src/daemon/launchd-current-service.test.ts
@@ -22,23 +22,12 @@ describe("isCurrentProcessLaunchdServiceLabel", () => {
     ).toBe(true);
   });
 
-  it("preserves label-only fallback when launchd exposes no label variables", () => {
+  it("does not treat the configured label alone as current service identity", () => {
+    // Detached update helper children inherit OPENCLAW_LAUNCHD_LABEL.
     expect(
       isCurrentProcessLaunchdServiceLabel("ai.openclaw.gateway", {
         OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
       }),
-    ).toBe(true);
-  });
-
-  it("can require service markers for label-only fallback", () => {
-    expect(
-      isCurrentProcessLaunchdServiceLabel(
-        "ai.openclaw.gateway",
-        {
-          OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
-        },
-        { allowConfiguredLabelFallback: false },
-      ),
     ).toBe(false);
   });
 

--- a/src/daemon/launchd-current-service.ts
+++ b/src/daemon/launchd-current-service.ts
@@ -1,15 +1,10 @@
 /** Detects whether the current process is running inside a launchd service label. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
-type CurrentProcessLaunchdServiceLabelOptions = {
-  allowConfiguredLabelFallback?: boolean;
-};
-
 /** Checks whether the current process appears to be running under the requested launchd label. */
 export function isCurrentProcessLaunchdServiceLabel(
   label: string,
   env: NodeJS.ProcessEnv = process.env,
-  options: CurrentProcessLaunchdServiceLabelOptions = {},
 ): boolean {
   const currentLabels = [env.LAUNCH_JOB_LABEL, env.LAUNCH_JOB_NAME, env.XPC_SERVICE_NAME].flatMap(
     (value) => {
@@ -24,17 +19,15 @@ export function isCurrentProcessLaunchdServiceLabel(
     }
   }
 
-  const configuredLabel = normalizeOptionalString(env.OPENCLAW_LAUNCHD_LABEL);
-  if (!configuredLabel || configuredLabel !== label) {
-    return false;
-  }
-  if (
+  // Detached update/restart handoffs keep OPENCLAW_LAUNCHD_LABEL as the service
+  // identity to manage while running outside the job, so the configured label
+  // alone never proves membership: a restart that trusted it would schedule a
+  // detached handoff instead of restarting and health-proving the service.
+  // Managed wrappers inject the service marker; trust it when launchd's own
+  // label variables are absent or renamed by the host environment.
+  return (
+    normalizeOptionalString(env.OPENCLAW_LAUNCHD_LABEL) === label &&
     normalizeOptionalString(env.OPENCLAW_SERVICE_MARKER) === "openclaw" &&
     Boolean(normalizeOptionalString(env.OPENCLAW_SERVICE_KIND))
-  ) {
-    // Managed wrappers inject service metadata; trust it when launchd's own
-    // label variables are absent or renamed by the host environment.
-    return true;
-  }
-  return options.allowConfiguredLabelFallback !== false && currentLabels.length === 0;
+  );
 }

--- a/src/daemon/launchd-install.ts
+++ b/src/daemon/launchd-install.ts
@@ -99,11 +99,7 @@ function currentGatewayLaunchAgentLabel(
     resolveLaunchAgentLabel(targetEnv),
     ...(configuredCurrentLabel ? [assertValidLaunchAgentLabel(configuredCurrentLabel)] : []),
   ]);
-  return [...candidates].find((label) =>
-    isCurrentProcessLaunchdServiceLabel(label, process.env, {
-      allowConfiguredLabelFallback: false,
-    }),
-  );
+  return [...candidates].find((label) => isCurrentProcessLaunchdServiceLabel(label, process.env));
 }
 
 function assertExternalLaunchAgentMutation(

--- a/src/daemon/launchd-stop.ts
+++ b/src/daemon/launchd-stop.ts
@@ -89,9 +89,7 @@ export async function stopLaunchAgent({
   const serviceTarget = `${domain}/${label}`;
   const reportMutation = createGatewayLifecycleMutationReporter(onMutation);
 
-  if (
-    isCurrentProcessLaunchdServiceLabel(label, process.env, { allowConfiguredLabelFallback: false })
-  ) {
+  if (isCurrentProcessLaunchdServiceLabel(label, process.env)) {
     throw new Error(
       `Refusing to stop LaunchAgent ${label} from inside the same launchd service; run this command from an external shell.`,
     );
@@ -172,11 +170,7 @@ export async function parkCurrentLaunchAgentForMaintenance(
   const serviceEnv = params.env ?? (process.env as GatewayServiceEnv);
   const domain = resolveLaunchAgentGuiDomain();
   const label = resolveLaunchAgentLabel(serviceEnv);
-  if (
-    !isCurrentProcessLaunchdServiceLabel(label, process.env, {
-      allowConfiguredLabelFallback: false,
-    })
-  ) {
+  if (!isCurrentProcessLaunchdServiceLabel(label, process.env)) {
     return false;
   }
   const serviceTarget = `${domain}/${label}`;

--- a/src/daemon/launchd-update-jobs.ts
+++ b/src/daemon/launchd-update-jobs.ts
@@ -260,8 +260,6 @@ export async function disableCurrentOpenClawUpdateLaunchdJob(
     env,
     // Detached handoffs preserve the configured label, so only launchd-backed
     // current-process identity may turn the ambient marker into proof.
-    trustCurrentEnvMarker: isCurrentProcessLaunchdServiceLabel(candidate.label, env, {
-      allowConfiguredLabelFallback: false,
-    }),
+    trustCurrentEnvMarker: isCurrentProcessLaunchdServiceLabel(candidate.label, env),
   });
 }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -3724,6 +3724,37 @@ describe("launchd install", () => {
     expect(state.launchctlCalls).toStrictEqual([]);
   });
 
+  it("restarts an unloaded LaunchAgent synchronously for a detached update helper that inherits only the configured label", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.serviceLoaded = false;
+    state.kickstartError = "Could not find service";
+    state.kickstartFailuresRemaining = 1;
+
+    const result = await withProcessEnv(
+      {
+        LAUNCH_JOB_LABEL: undefined,
+        LAUNCH_JOB_NAME: undefined,
+        XPC_SERVICE_NAME: undefined,
+        OPENCLAW_SERVICE_MARKER: undefined,
+        OPENCLAW_SERVICE_KIND: undefined,
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
+      },
+      async () => restartLaunchAgent(launchAgentControlFixture(env, { preserveDefinition: true })),
+    );
+
+    expect(result).toEqual({ outcome: "completed" });
+    expect(launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff).not.toHaveBeenCalled();
+    expect(launchctlCommandNames()).toEqual([
+      "enable",
+      "kickstart",
+      "enable",
+      "bootstrap",
+      "kickstart",
+    ]);
+    expect(state.kickstartFailuresRemaining).toBe(0);
+    expect(state.serviceLoaded).toBe(true);
+  });
+
   it("does not hand restart off for unrelated inherited XPC service names", async () => {
     const env = createDefaultLaunchdEnv();
 

--- a/src/infra/update-managed-service-handoff-command.test-support.ts
+++ b/src/infra/update-managed-service-handoff-command.test-support.ts
@@ -1,10 +1,40 @@
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
 import type { Readable } from "node:stream";
+import { setTimeout as sleep } from "node:timers/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { isPidAlive } from "../shared/pid-alive.js";
 import type {
   ManagedServiceManagerBoundaryResult,
   ManagedServiceManagerBoundaryOptions,
 } from "./update-managed-service-handoff-lifecycle.test-support.js";
+
+/** A LaunchAgent gateway's own environment; the handoff keeps only the label for its children. */
+export const LAUNCHD_GATEWAY_IDENTITY_ENV = {
+  OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
+  XPC_SERVICE_NAME: "ai.openclaw.gateway",
+  OPENCLAW_SERVICE_MARKER: "openclaw",
+  OPENCLAW_SERVICE_KIND: "gateway",
+} as const;
+
+/** The pre-fix CLI emulation restarts launchd after it exits; never leave that shell behind. */
+export async function awaitEmulatedRecoveryHandoffExit(statePath: string): Promise<void> {
+  const state = JSON.parse(await fs.readFile(statePath, "utf8").catch(() => "{}")) as {
+    recoveryHandoffPid?: number;
+  };
+  const pid = state.recoveryHandoffPid;
+  if (typeof pid !== "number") {
+    return;
+  }
+  const deadline = Date.now() + 6_000;
+  while (isPidAlive(pid)) {
+    if (Date.now() >= deadline) {
+      throw new Error(`emulated recovery handoff ${pid} is still running`);
+    }
+    await sleep(50);
+  }
+}
 
 export function createManagedServiceCommandFixture(params: {
   kind: "systemd" | "launchd";
@@ -14,6 +44,7 @@ export function createManagedServiceCommandFixture(params: {
   options?: ManagedServiceManagerBoundaryOptions;
 }) {
   const { kind, root, statePath, options } = params;
+  const checksServiceIdentity = kind === "launchd" && options?.recoveryChecksServiceIdentity;
   const recovery =
     kind === "systemd"
       ? { kind, unit: "openclaw-gateway.service" }
@@ -27,12 +58,39 @@ export function createManagedServiceCommandFixture(params: {
     serviceRecovery: recovery,
     recoveryCommandArgv: [
       process.execPath,
+      ...(checksServiceIdentity ? ["--input-type=module"] : []),
       "-e",
       [
+        ...(checksServiceIdentity
+          ? [
+              `import { createRequire } from "node:module";`,
+              `const require = createRequire(import.meta.url);`,
+              `const { register } = await import(${JSON.stringify(pathToFileURL(createRequire(import.meta.url).resolve("tsx/esm/api")).href)});`,
+              // The recovery command runs from the helper's temp dir; name the repo tsconfig for path aliases.
+              `register({ tsconfig: ${JSON.stringify(fileURLToPath(new URL("../../tsconfig.json", import.meta.url)))} });`,
+              `const { isCurrentProcessLaunchdServiceLabel } = await import(${JSON.stringify(new URL("../daemon/launchd-current-service.ts", import.meta.url).href)});`,
+            ]
+          : []),
         `const fs = require("node:fs");`,
         `const { spawnSync } = require("node:child_process");`,
         `const state = JSON.parse(fs.readFileSync(${JSON.stringify(statePath)}, "utf8"));`,
         `state.guardedRestart = process.argv.slice(1);`,
+        ...(checksServiceIdentity
+          ? [
+              `state.recoveryInsideService = isCurrentProcessLaunchdServiceLabel("ai.openclaw.gateway", process.env);`,
+              `state.recoveryEnv = Object.fromEntries(["LAUNCH_JOB_LABEL", "LAUNCH_JOB_NAME", "XPC_SERVICE_NAME", "OPENCLAW_SERVICE_MARKER", "OPENCLAW_SERVICE_KIND", "OPENCLAW_LAUNCHD_LABEL"].map((key) => [key, process.env[key]]));`,
+              // Reproduce the old CLI's early success while its detached restart waits for exit.
+              `if (state.recoveryInsideService) {`,
+              `  const { spawn } = require("node:child_process");`,
+              `  const child = spawn("/bin/sh", ["-c", ${JSON.stringify('attempts=0; while kill -0 "$1" 2>/dev/null && [ "$attempts" -lt 100 ]; do attempts=$((attempts + 1)); sleep 0.05; done; launchctl enable gui/501/ai.openclaw.gateway; launchctl bootstrap gui/501 "$2"')}, "openclaw-test-recovery", String(process.pid), ${JSON.stringify(path.join(root, "ai.openclaw.gateway.plist"))}], { detached: true, stdio: "ignore" });`,
+              `  state.recoveryHandoffPid = child.pid;`,
+              `  fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));`,
+              `  child.unref();`,
+              `  console.log(JSON.stringify({ action: "restart", ok: true, result: "scheduled" }));`,
+              `  process.exit(0);`,
+              `}`,
+            ]
+          : []),
         `fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));`,
         ...(options?.recoverySentinel
           ? [
@@ -78,6 +136,9 @@ export function createManagedServiceCommandFixture(params: {
                   `if (spawnSync(${JSON.stringify(kind === "systemd" ? "systemctl" : "launchctl")}, ${JSON.stringify(args)}).status !== 0) process.exit(1);`,
               )
             : [`process.exit(${options.recoveryExitCode});`]),
+        ...(checksServiceIdentity
+          ? [`console.log(JSON.stringify({ action: "restart", ok: true, result: "restarted" }));`]
+          : []),
       ].join(""),
       "--",
       "gateway",
@@ -177,6 +238,47 @@ export function registerManagedRecoveryCommandTests(
     expect(inspections.at(-1)!.startedAtMs - inspections.at(-2)!.startedAtMs).toBe(31_000);
     expect(inspections.at(-1)!.timeoutMs).toBe(5_000);
   });
+
+  itUnix(
+    "restores launchd through a synchronous installed-CLI restart when the helper inherits only the configured label",
+    async () => {
+      const { state, sentinel, log } = await runManagedServiceManagerBoundary("launchd", {
+        recoveryChecksServiceIdentity: true,
+        updaterNotification: "published",
+        updaterResult: {
+          status: "error",
+          mode: "npm",
+          reason: "global update (omit optional)",
+          recovery: { serviceRestartSafe: true, version: "1.0.0" },
+        },
+      });
+      // The guarded CLI sees the service identity without launchd's own labels or markers.
+      expect(state.recoveryEnv, log).toEqual({ OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" });
+      expect(state.guardedRestart).toEqual([
+        "gateway",
+        "restart",
+        "--preserve-definition",
+        "--json",
+      ]);
+      expect(state.recoveryInsideService, log).toBe(false);
+      expect(state).toMatchObject({ restored: true, healthProbeCount: 1 });
+      expect(log).toContain(
+        "gateway service recovery succeeded (readiness and runtime identity verified)",
+      );
+      // The updater's published reason survives; only the restore step records recovery.
+      expect(sentinel).toMatchObject({
+        payload: {
+          status: "error",
+          stats: {
+            reason: "global update (omit optional)",
+            steps: expect.arrayContaining([
+              expect.objectContaining({ name: "service-restore", log: { exitCode: 0 } }),
+            ]),
+          },
+        },
+      });
+    },
+  );
 
   itUnix.each(["systemd", "launchd"] as const)(
     "keeps %s parked when the installed CLI refuses a verified recovery restart",

--- a/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
@@ -34,6 +34,7 @@ export type ManagedServiceManagerBoundaryOptions = {
   requester?: { channel?: string; accountId?: string; senderId?: string };
   updaterExitCode?: number;
   recoveryExitCode?: number;
+  recoveryChecksServiceIdentity?: true;
   recoveryHang?: boolean;
   recoveryClockAdvanceMs?: number;
   recoverySentinel?: "retained" | "consumed" | "replaced";
@@ -173,6 +174,28 @@ export function registerManagedSystemdHandoffConvergenceTests(
       });
     },
   );
+
+  itUnix("rejects an overdue commit before its delayed deadline callback executes", async () => {
+    const { commands, parentSignal, sentinel, state } = await runManagedServiceManagerBoundary(
+      "systemd",
+      { overdueCommit: true },
+    );
+
+    expect(parentSignal).toBeNull();
+    expect(
+      commands.filter((command) => command.includes("stop openclaw-gateway.service")),
+    ).toHaveLength(0);
+    expect(
+      commands.filter((command) => command.includes("start openclaw-gateway.service")),
+    ).toHaveLength(0);
+    expect(state).toEqual({});
+    expect(sentinel).toMatchObject({
+      payload: {
+        status: "skipped",
+        stats: { reason: "managed-service-handoff-cancelled", steps: [] },
+      },
+    });
+  });
 
   itUnix(
     "fails closed when the exact systemd stop job exhausts the parent-exit deadline",

--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -27,7 +27,9 @@ import {
   MANAGED_SERVICE_UPDATE_HANDOFF_TEMP_PREFIX,
 } from "./update-managed-service-handoff-cleanup.js";
 import {
+  awaitEmulatedRecoveryHandoffExit,
   createManagedServiceCommandFixture,
+  LAUNCHD_GATEWAY_IDENTITY_ENV,
   registerManagedRecoveryCommandTests,
   registerManagedLaunchdTeardownTests,
   waitForHandoffResponse,
@@ -220,6 +222,7 @@ async function runManagedServiceManagerBoundary(
   );
   const env = {
     ...process.env,
+    ...(kind === "launchd" ? LAUNCHD_GATEWAY_IDENTITY_ENV : {}),
     OPENCLAW_STATE_DIR: root,
     OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
     PATH: `${root}${path.delimiter}${process.env.PATH ?? ""}`,
@@ -274,7 +277,8 @@ async function runManagedServiceManagerBoundary(
       env,
       meta: { handoffId: `${kind}-boundary` },
     });
-    const [, generatedArgs] = spawnMock.mock.calls.at(-1) as [string, string[]];
+    const spawnCall = spawnMock.mock.calls.at(-1) as [string, string[], { env: NodeJS.ProcessEnv }];
+    const [, generatedArgs, { env: childEnv }] = spawnCall;
     const scriptPath = generatedArgs[0];
     const generatedParamsPath = generatedArgs[1];
     if (!scriptPath || !generatedParamsPath) {
@@ -352,7 +356,7 @@ async function runManagedServiceManagerBoundary(
         outputPath: String(generated.triageContextPath),
       });
     }
-    let helperEnv: NodeJS.ProcessEnv = env;
+    let helperEnv = childEnv;
     if (options?.launchdTeardown?.clockEachCommandMs || options?.recoveryClockAdvanceMs) {
       const preloadPath = path.join(root, "launchd-clock-preload.cjs");
       await fs.writeFile(
@@ -364,7 +368,7 @@ async function runManagedServiceManagerBoundary(
           recoveryCommandArgv: commandFixture.recoveryCommandArgv,
         }),
       );
-      helperEnv = { ...env, NODE_OPTIONS: `--require ${preloadPath}` };
+      helperEnv = { ...childEnv, NODE_OPTIONS: `--require ${preloadPath}` };
     }
     const runningHelper = spawn(process.execPath, [scriptPath, paramsPath], {
       env: helperEnv,
@@ -541,6 +545,9 @@ async function runManagedServiceManagerBoundary(
     parent.stdin?.end();
     if (helper && helper.exitCode === null && helper.signalCode === null) {
       helper.kill("SIGKILL");
+    }
+    if (options?.recoveryChecksServiceIdentity) {
+      await awaitEmulatedRecoveryHandoffExit(statePath);
     }
   }
 }
@@ -882,28 +889,6 @@ describe("managed service update handoff", () => {
   registerManagedRecoveryCommandTests(runManagedServiceManagerBoundary, itUnix, expect);
 
   registerManagedUpdateHandoffTriageTests(runManagedServiceManagerBoundary, itUnix, expect);
-
-  itUnix("rejects an overdue commit before its delayed deadline callback executes", async () => {
-    const { commands, parentSignal, sentinel, state } = await runManagedServiceManagerBoundary(
-      "systemd",
-      { overdueCommit: true },
-    );
-
-    expect(parentSignal).toBeNull();
-    expect(
-      commands.filter((command) => command.includes("stop openclaw-gateway.service")),
-    ).toHaveLength(0);
-    expect(
-      commands.filter((command) => command.includes("start openclaw-gateway.service")),
-    ).toHaveLength(0);
-    expect(state).toEqual({});
-    expect(sentinel).toMatchObject({
-      payload: {
-        status: "skipped",
-        stats: { reason: "managed-service-handoff-cancelled", steps: [] },
-      },
-    });
-  });
 
   itUnix.each([
     ["cannot restart", "start-failed", { startFailed: true }],


### PR DESCRIPTION
Related: #136588 (the managed-update recovery path this fixes), #136995, #137312

## What Problem This Solves

Fixes an issue where operators updating a macOS launchd install from chat (`/update` or the gateway `update.run` tool) would see "gateway service recovery failed" in the managed update helper log and `service-restore: managed-service-handoff-restore-failed` in the Control UI "Diagnose failed update" card when the update itself failed (for example the registry returning HTTP 500 for the new tarball), even though the LaunchAgent had already restarted and stayed healthy on the previous version. The wrong verdict was also persisted in the restart sentinel, so the failure notice and triage pointed operators at a service recovery that had not failed.

## Why This Change Was Made

The detached update helper deliberately strips launchd's own labels (`LAUNCH_JOB_LABEL`, `LAUNCH_JOB_NAME`, `XPC_SERVICE_NAME`) and the service markers from the commands it runs, but keeps `OPENCLAW_LAUNCHD_LABEL` as the identity of the service to manage. Its recovery command, `openclaw gateway restart --preserve-definition --json`, decided it was running *inside* the managed gateway process tree because `isCurrentProcessLaunchdServiceLabel` still had a configured-label-only fallback for exactly that environment. The CLI therefore scheduled a detached restart handoff (which waits for the CLI itself to exit), returned `result: "scheduled"` with exit 0 and no health proof, and the helper's immediate `launchctl print` probe found no service to verify. launchd brought the service back a few seconds later on its own.

The fallback is removed. Running inside the job is now proven only by launchd's own label variables or by the managed wrapper's `OPENCLAW_SERVICE_MARKER`/`OPENCLAW_SERVICE_KIND`, which every generated LaunchAgent injects and which the stop, install, and update-job guards already required (with the comment "Detached handoffs preserve the configured label"). The recovery CLI now takes the synchronous path: enable, bootstrap, kickstart, then the existing health proof, returning `restarted`; the helper then runs its own readiness and runtime-identity verification and records the restore as successful. Accepted tradeoff: a hand-written plist that both renames launchd's variables and omits the service marker is no longer treated as "inside", matching how stop and install already treat it. Production delta is net −19 lines; no new option, seam, or fallback.

## User Impact

After a failed update on a macOS launchd install, the helper log, the chat notice, the update run's verification, and the Control UI triage card now agree with the actual service state: the previous version is running and the recovery succeeded. The triage card names the real failing step (the npm install) instead of a fictitious restore failure. Successful updates and non-launchd installs are unchanged.

## Evidence

**Regression tests (all fail on the pre-fix detection, pass after):**
- `src/daemon/launchd-current-service.test.ts`: the configured label alone is not current-service identity.
- `src/daemon/launchd.test.ts`: an unloaded LaunchAgent restarted with `--preserve-definition` from the helper's child env completes synchronously (enable → kickstart → bootstrap → kickstart) with no detached handoff. Pre-fix result: `{ outcome: "scheduled" }`.
- `src/infra/update-managed-service-handoff-lifecycle.test.ts` (via `update-managed-service-handoff-command.test-support.ts`): the real helper script now runs with the exact environment the Gateway hands it, and a recovery fixture that runs the real detection module reports `recoveryInsideService: false`, restores the service, probes health once, and records a `service-restore` step with exit 0 under the updater's preserved failure reason. Pre-fix: `recoveryInsideService: true`, helper log "gateway service recovery failed".

```
node scripts/run-vitest.mjs src/daemon/launchd-current-service.test.ts src/daemon/launchd.test.ts src/infra/update-managed-service-handoff-lifecycle.test.ts
  unit-fast 4 passed | infra 137 passed | daemon 171 passed
node scripts/run-vitest.mjs src/infra/update-managed-service-handoff-command.test.ts src/infra/update-managed-service-handoff-ownership.test.ts src/daemon/launchd-restart-handoff.test.ts src/daemon/launchd-label.test.ts src/cli/update-cli/update-command-service.integration.test.ts src/cli/daemon-cli/launchd-recovery.test.ts src/cli/daemon-cli/lifecycle.test.ts src/cli/daemon-cli/lifecycle-core.test.ts src/infra/process-respawn.test.ts src/infra/supervisor-markers.test.ts
  260 passed
node scripts/run-vitest.mjs src/infra/update-managed-service-handoff-cross-process.test.ts src/infra/update-managed-service-handoff-single-flight.test.ts
  34 passed | 1 skipped
```

oxlint on all touched files: clean. tsgo lanes `tsconfig.core.test.services.json` and `tsconfig.core.test.infra.json`: no diagnostics. Codex autoreview (P0/P1): scoped-clean.

**Live proof (macOS launchd profile install, token auth, local verdaccio):** installed 2026.9.1 built from this branch as profile `shotfix`, published a poisoned 2026.9.2 whose tarball GET returns 500, sent `/update` from the Control UI chat. Helper log after the npm failure:

```
managed update recovery command pid=93519
  "result": "restarted",
managed update recovery command exited code=0 signal=null      (23 s after start)
gateway service recovery succeeded (readiness and runtime identity verified)
```

The LaunchAgent came back on a new PID within one second of the recovery command exiting and stayed healthy for the remaining 239 s of the capture; the update run's verification recorded `serviceRunning: true, runningVersion: 2026.9.1, versionMatch: true`; the restart sentinel keeps the updater's reason `global update (omit optional)`. The same scenario on the pre-fix build (PR #136588 rig, 2026-09-03) had the recovery command exit in 3.5 s with `"result": "scheduled"` followed by "gateway service recovery failed".

Before (pre-fix build, 2026-09-03): the triage card claims `service-restore: managed-service-handoff-restore-failed` while the gateway is healthy.

![Before: triage card reports a service-restore failure although the gateway recovered](https://github.com/user-attachments/assets/079e8c17-3aae-4502-9129-c3747873ac59)

After (this branch): the failure notice says the gateway is running 2026.9.1 and the triage card names the npm install step.

![After: failure notice and triage card report the real npm failure with the service running](https://github.com/user-attachments/assets/3e0c7c41-6c35-4b20-b6b3-0887b202a7ea)

**Observed follow-ups, not addressed here:** `/update` sent from the Control UI leaves a "No reply was generated for this message" placeholder because the command returns no reply once the acknowledgement is delivered; the update report prints "version mismatch" after a successful restore because it compares the running version with the update target rather than the restored version.
