### PR TITLE
fix(channels): recover queued messages after timeouts

### DIFF
--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -40,7 +40,7 @@ function commitInboundForTest(ctx: MsgContext): string {
   if (claim.status !== "claimed") {
     throw new Error(`expected inbound dedupe claim, got ${claim.status}`);
   }
-  commitInboundDedupe(claim.key);
+  commitInboundDedupe(claim);
   return claim.key;
 }
 
@@ -359,7 +359,7 @@ describe("inbound dedupe", () => {
       OriginatingTo: "telegram:123",
       MessageSid: "42",
     };
-    expect(claimInboundDedupe(ctx, { inFlight: new Set() })).toEqual({
+    expect(claimInboundDedupe(ctx, { inFlight: new Map() })).toEqual({
       status: "claimed",
       key: JSON.stringify([
         "",

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -418,7 +418,9 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     };
   }
 
-  const inboundDedupeClaim = claimInboundDedupe(ctx);
+  const inboundDedupeClaim = claimInboundDedupe(ctx, {
+    owner: params.replyOptions?.turnAdoptionLifecycle,
+  });
   if (inboundDedupeClaim.status === "duplicate" || inboundDedupeClaim.status === "inflight") {
     recordProcessed("skipped", { reason: "duplicate" });
     return {
@@ -431,12 +433,12 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
   }
   const commitInboundDedupeIfClaimed = () => {
     if (inboundDedupeClaim.status === "claimed") {
-      commitInboundDedupe(inboundDedupeClaim.key);
+      commitInboundDedupe(inboundDedupeClaim);
     }
   };
   const releaseInboundDedupeIfClaimed = () => {
     if (inboundDedupeClaim.status === "claimed") {
-      releaseInboundDedupe(inboundDedupeClaim.key);
+      releaseInboundDedupe(inboundDedupeClaim);
     }
   };
   const finishReplyOperationBusyDispatch = (opts?: {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -138,9 +138,9 @@ async function dispatchReplyFromConfigInner(
       }
       if (inboundDedupeClaim.status === "claimed") {
         if (errorState.turnAdoptionState?.adopted || errorState.inboundDedupeReplayUnsafe) {
-          commitInboundDedupe(inboundDedupeClaim.key);
+          commitInboundDedupe(inboundDedupeClaim);
         } else {
-          releaseInboundDedupe(inboundDedupeClaim.key);
+          releaseInboundDedupe(inboundDedupeClaim);
         }
       }
       if (err instanceof DispatchSessionRefreshRequiredError) {

--- a/src/auto-reply/reply/inbound-dedupe.test.ts
+++ b/src/auto-reply/reply/inbound-dedupe.test.ts
@@ -2,7 +2,12 @@
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it } from "vitest";
 import type { MsgContext } from "../templating.js";
-import { claimInboundDedupe, commitInboundDedupe, resetInboundDedupe } from "./inbound-dedupe.js";
+import {
+  claimInboundDedupe,
+  commitInboundDedupe,
+  releaseOwnedInboundDedupe,
+  resetInboundDedupe,
+} from "./inbound-dedupe.js";
 
 const sharedInboundContext: MsgContext = {
   Provider: "discord",
@@ -15,13 +20,13 @@ const sharedInboundContext: MsgContext = {
   MessageSid: "msg-1",
 };
 
-function claimKey(ctx: MsgContext): string {
-  const result = claimInboundDedupe(ctx, { inFlight: new Set() });
+function claimMessage(ctx: MsgContext, owner?: object) {
+  const result = claimInboundDedupe(ctx, { owner });
   expect(result.status).toBe("claimed");
   if (result.status !== "claimed") {
     throw new Error(`expected claimed inbound dedupe result, got ${result.status}`);
   }
-  return result.key;
+  return result;
 }
 
 describe("inbound dedupe", () => {
@@ -30,9 +35,9 @@ describe("inbound dedupe", () => {
   });
 
   it("deduplicates inbound messages with equivalent numeric and string thread ids", () => {
-    expect(claimKey({ ...sharedInboundContext, MessageThreadId: 77 })).toBe(
-      claimKey({ ...sharedInboundContext, MessageThreadId: "77" }),
-    );
+    const key = claimMessage({ ...sharedInboundContext, MessageThreadId: 77 }).key;
+    resetInboundDedupe();
+    expect(claimMessage({ ...sharedInboundContext, MessageThreadId: "77" }).key).toBe(key);
   });
 
   it.each([
@@ -50,7 +55,7 @@ describe("inbound dedupe", () => {
     if (firstClaim.status !== "claimed") {
       throw new Error("expected the first command target to be admitted");
     }
-    commitInboundDedupe(firstClaim.key);
+    commitInboundDedupe(firstClaim);
 
     const secondClaim = claimInboundDedupe({
       ...firstTarget,
@@ -87,7 +92,7 @@ describe("inbound dedupe", () => {
         status: "inflight",
         key: firstClaimKey,
       });
-      inboundB.releaseInboundDedupe(firstClaimKey);
+      inboundB.releaseInboundDedupe(firstClaim);
       expect(inboundA.claimInboundDedupe(sharedInboundContext)).toEqual({
         status: "claimed",
         key: firstClaimKey,
@@ -112,20 +117,84 @@ describe("inbound dedupe", () => {
     inboundB.resetInboundDedupe();
 
     try {
-      const firstClaim = inboundA.claimInboundDedupe(sharedInboundContext);
+      const owner = {};
+      const firstClaim = inboundA.claimInboundDedupe(sharedInboundContext, { owner });
       expect(firstClaim.status).toBe("claimed");
       if (firstClaim.status !== "claimed") {
         throw new Error(`expected claimed inbound dedupe result, got ${firstClaim.status}`);
       }
       const firstClaimKey = firstClaim.key;
-      inboundA.commitInboundDedupe(firstClaimKey);
+      inboundA.commitInboundDedupe(firstClaim);
       expect(inboundB.claimInboundDedupe(sharedInboundContext)).toEqual({
         status: "duplicate",
         key: firstClaimKey,
       });
+      inboundB.releaseOwnedInboundDedupe(owner);
+      expect(inboundA.claimInboundDedupe(sharedInboundContext).status).toBe("claimed");
     } finally {
       inboundA.resetInboundDedupe();
       inboundB.resetInboundDedupe();
     }
+  });
+
+  it("frees a committed entry for its owner and never for a stale owner after recommit", () => {
+    const owner = {};
+    const firstClaim = claimMessage(sharedInboundContext, owner);
+    commitInboundDedupe(firstClaim);
+    releaseOwnedInboundDedupe(owner);
+    expect(claimInboundDedupe(sharedInboundContext).status).toBe("claimed");
+
+    // The key expired and a newer dispatch re-committed under a different
+    // owner; the abandoned owner must not free the replacement entry.
+    resetInboundDedupe();
+    const staleOwner = {};
+    const staleClaim = claimMessage(sharedInboundContext, staleOwner);
+    commitInboundDedupe(staleClaim);
+    resetInboundDedupe();
+    const currentOwner = {};
+    const currentClaim = claimMessage(sharedInboundContext, currentOwner);
+    commitInboundDedupe(currentClaim);
+    releaseOwnedInboundDedupe(staleOwner);
+    expect(claimInboundDedupe(sharedInboundContext).status).toBe("duplicate");
+    releaseOwnedInboundDedupe(currentOwner);
+    expect(claimInboundDedupe(sharedInboundContext).status).toBe("claimed");
+  });
+
+  it("fences late finalization after abandonment without releasing the retry's claim", () => {
+    const owner = {};
+    const original = claimMessage(sharedInboundContext, owner);
+    releaseOwnedInboundDedupe(owner);
+
+    const retryOwner = {};
+    const retry = claimMessage(sharedInboundContext, retryOwner);
+    commitInboundDedupe(original);
+    expect(claimInboundDedupe(sharedInboundContext).status).toBe("inflight");
+
+    commitInboundDedupe(retry);
+    commitInboundDedupe(retry);
+    releaseOwnedInboundDedupe(owner);
+    expect(claimInboundDedupe(sharedInboundContext).status).toBe("duplicate");
+
+    releaseOwnedInboundDedupe(retryOwner);
+    expect(claimInboundDedupe(sharedInboundContext).status).toBe("claimed");
+  });
+
+  it.each([
+    { name: "message", context: { MessageSid: "msg-2" } },
+    { name: "peer", context: { OriginatingTo: "channel:c2" } },
+    { name: "thread", context: { MessageThreadId: "thread-2" } },
+    { name: "account", context: { AccountId: "other-account" } },
+    { name: "channel", context: { OriginatingChannel: "telegram" } },
+    { name: "agent", context: { SessionKey: "agent:other:discord:channel:c1" } },
+  ])("does not release a different $name when an owner is abandoned", ({ context }) => {
+    const owner = {};
+    const otherContext = { ...sharedInboundContext, ...context };
+    commitInboundDedupe(claimMessage(sharedInboundContext, owner));
+    commitInboundDedupe(claimMessage(otherContext, {}));
+
+    releaseOwnedInboundDedupe(owner);
+
+    expect(claimInboundDedupe(sharedInboundContext).status).toBe("claimed");
+    expect(claimInboundDedupe(otherContext).status).toBe("duplicate");
   });
 });

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -13,6 +13,8 @@ import type { MsgContext } from "../templating.js";
 const DEFAULT_INBOUND_DEDUPE_TTL_MS = 20 * 60_000;
 const DEFAULT_INBOUND_DEDUPE_MAX = 5000;
 
+type InboundDedupeClaim = { status: "claimed"; key: string };
+
 /**
  * Keep inbound dedupe shared across bundled chunks so the same provider
  * message cannot bypass dedupe by entering through a different chunk copy.
@@ -26,14 +28,21 @@ const inboundDedupeCache: DedupeCache = resolveGlobalDedupeCache(INBOUND_DEDUPE_
 });
 const inboundDedupeInFlight = resolveGlobalSingleton(
   INBOUND_DEDUPE_INFLIGHT_KEY,
-  () => new Set<string>(),
+  () => new Map<string, InboundDedupeClaim>(),
+);
+
+// Dispatch and queue abandonment can run from different bundled chunks.
+const INBOUND_DEDUPE_OWNERSHIPS_KEY = Symbol.for("openclaw.inboundDedupeOwnerships");
+const inboundDedupeOwnerships = resolveGlobalSingleton(
+  INBOUND_DEDUPE_OWNERSHIPS_KEY,
+  () => new WeakMap<object, InboundDedupeClaim>(),
 );
 
 type InboundDedupeClaimResult =
   | { status: "invalid" }
   | { status: "duplicate"; key: string }
   | { status: "inflight"; key: string }
-  | { status: "claimed"; key: string };
+  | InboundDedupeClaim;
 
 const resolveInboundPeerId = (ctx: MsgContext) =>
   ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? ctx.SessionKey;
@@ -81,7 +90,12 @@ function buildInboundDedupeKey(ctx: MsgContext): string | null {
 
 export function claimInboundDedupe(
   ctx: MsgContext,
-  opts?: { cache?: DedupeCache; now?: number; inFlight?: Set<string> },
+  opts?: {
+    cache?: DedupeCache;
+    now?: number;
+    inFlight?: Map<string, InboundDedupeClaim>;
+    owner?: object;
+  },
 ): InboundDedupeClaimResult {
   const key = buildInboundDedupeKey(ctx);
   if (!key) {
@@ -95,23 +109,47 @@ export function claimInboundDedupe(
   if (inFlight.has(key)) {
     return { status: "inflight", key };
   }
-  inFlight.add(key);
-  return { status: "claimed", key };
+  const claim: InboundDedupeClaim = { status: "claimed", key };
+  inFlight.set(key, claim);
+  if (opts?.owner) {
+    inboundDedupeOwnerships.set(opts.owner, claim);
+  }
+  return claim;
 }
 
 export function commitInboundDedupe(
-  key: string,
-  opts?: { cache?: DedupeCache; now?: number; inFlight?: Set<string> },
+  claim: InboundDedupeClaim,
+  opts?: { cache?: DedupeCache; now?: number; inFlight?: Map<string, InboundDedupeClaim> },
 ): void {
-  const cache = opts?.cache ?? inboundDedupeCache;
-  cache.check(key, opts?.now);
   const inFlight = opts?.inFlight ?? inboundDedupeInFlight;
-  inFlight.delete(key);
+  // Abandonment or a prior commit retires this claim before a late finalizer runs.
+  if (inFlight.get(claim.key) !== claim) {
+    return;
+  }
+  const cache = opts?.cache ?? inboundDedupeCache;
+  cache.check(claim.key, opts?.now, claim);
+  inFlight.delete(claim.key);
 }
 
-export function releaseInboundDedupe(key: string, opts?: { inFlight?: Set<string> }): void {
+export function releaseInboundDedupe(
+  claim: InboundDedupeClaim,
+  opts?: { cache?: DedupeCache; inFlight?: Map<string, InboundDedupeClaim> },
+): void {
   const inFlight = opts?.inFlight ?? inboundDedupeInFlight;
-  inFlight.delete(key);
+  if (inFlight.get(claim.key) === claim) {
+    inFlight.delete(claim.key);
+  }
+  (opts?.cache ?? inboundDedupeCache).delete(claim.key, claim);
+}
+
+// A retired lifecycle must not release a newer commit of the same message key.
+export function releaseOwnedInboundDedupe(owner: object): void {
+  const claim = inboundDedupeOwnerships.get(owner);
+  if (!claim) {
+    return;
+  }
+  inboundDedupeOwnerships.delete(owner);
+  releaseInboundDedupe(claim);
 }
 
 export function resetInboundDedupe(): void {

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -2765,6 +2765,13 @@ describe("followup queue collect routing", () => {
     const controller = new AbortController();
     const onComplete = vi.fn();
 
+    const runFollowup = async (run: FollowupRun) => {
+      if (run.abortSignal?.aborted) {
+        cleaned.push(run);
+        return;
+      }
+      calls.push(run);
+    };
     enqueueFollowupRun(key, createRun({ prompt: "dropped" }), settings);
     enqueueFollowupRun(
       key,
@@ -2774,16 +2781,13 @@ describe("followup queue collect routing", () => {
         turnAdoptionLifecycle: { onAdopted: async () => {}, onSettled: onComplete },
       },
       settings,
+      "message-id",
+      runFollowup,
+      false,
     );
     controller.abort();
 
-    scheduleFollowupDrain(key, async (run) => {
-      if (run.abortSignal?.aborted) {
-        cleaned.push(run);
-        return;
-      }
-      calls.push(run);
-    });
+    scheduleFollowupDrain(key, runFollowup);
     await new Promise((resolve) => {
       setTimeout(resolve, 10);
     });
@@ -3000,7 +3004,7 @@ describe("followup queue collect routing", () => {
     enqueueFollowupRun(key, createRun({ prompt: "live followup" }), settings);
     controller.abort();
 
-    expect(onComplete).not.toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalledTimes(1);
 
     await drainRecordedQueue(key, runFollowup, done);
 

--- a/src/auto-reply/reply/queue.dedupe.test.ts
+++ b/src/auto-reply/reply/queue.dedupe.test.ts
@@ -465,56 +465,70 @@ describe("followup queue deduplication", () => {
     clearSessionQueues([key]);
   });
 
-  it("allows re-enqueueing a message compacted into a summary elision before teardown", () => {
-    const key = `test-dedup-elision-retry-${Date.now()}`;
-    const summarizeSettings: QueueSettings = {
-      mode: "collect",
-      debounceMs: 0,
-      cap: 1,
-      dropPolicy: "summarize",
-    };
-    const onAbandoned = vi.fn();
-    const first = createRun({
-      prompt: "first",
-      messageId: "m1",
-      originatingChannel: "line",
-      originatingTo: "group:G1",
-    });
-    first.turnAdoptionLifecycle = { onAdopted: () => {}, onAbandoned };
-    expect(enqueueFollowupRun(key, first, summarizeSettings)).toBe(true);
+  it.each(["teardown", "abort"] as const)(
+    "readmits a message compacted into a summary elision after %s",
+    (action) => {
+      const key = `test-dedup-elision-retry-${Date.now()}`;
+      const summarizeSettings: QueueSettings = {
+        mode: "collect",
+        debounceMs: 0,
+        cap: 1,
+        dropPolicy: "summarize",
+      };
+      const onAbandoned = vi.fn();
+      const controller = new AbortController();
+      const first = createRun({
+        prompt: "first",
+        messageId: "m1",
+        originatingChannel: "line",
+        originatingTo: "group:G1",
+      });
+      first.abortSignal = controller.signal;
+      first.turnAdoptionLifecycle = { onAdopted: () => {}, onAbandoned };
+      expect(enqueueFollowupRun(key, first, summarizeSettings)).toBe(true);
 
-    // Overflow the cap twice: the first enqueue drops `first` into the summary
-    // sources, the second compacts it into a summary elision. Compaction clones
-    // the run (createOverflowSummaryRetrySource), so from here on completion
-    // sees the clone, not the originally recorded run object.
-    for (const [prompt, messageId] of [
-      ["second", "m2"],
-      ["third", "m3"],
-    ] as const) {
-      expect(
-        enqueueFollowupRun(
-          key,
-          createRun({ prompt, messageId, originatingChannel: "line", originatingTo: "group:G1" }),
-          summarizeSettings,
-        ),
-      ).toBe(true);
-    }
+      // Overflow the cap twice: the first enqueue drops `first` into the summary
+      // sources, the second compacts it into a summary elision. Compaction clones
+      // the run (createOverflowSummaryRetrySource), so from here on completion
+      // sees the clone, not the originally recorded run object.
+      for (const [prompt, messageId] of [
+        ["second", "m2"],
+        ["third", "m3"],
+      ] as const) {
+        expect(
+          enqueueFollowupRun(
+            key,
+            createRun({ prompt, messageId, originatingChannel: "line", originatingTo: "group:G1" }),
+            summarizeSettings,
+          ),
+        ).toBe(true);
+      }
 
-    // Teardown abandons the elided run via its clone; the ingress retry for the
-    // original message id must still be re-admittable.
-    clearSessionQueues([key]);
-    expect(onAbandoned).toHaveBeenCalledTimes(1);
+      // Teardown abandons the elided run via its clone; the ingress retry for the
+      // original message id must still be re-admittable.
+      if (action === "abort") {
+        controller.abort();
+        expect(getExistingFollowupQueue(key)?.items.map((run) => run.prompt)).toEqual(["third"]);
+        expect(getExistingFollowupQueue(key)?.summarySources.map((run) => run.prompt)).toEqual([
+          "second",
+        ]);
+        expect(getExistingFollowupQueue(key)?.droppedCount).toBe(1);
+      } else {
+        clearSessionQueues([key]);
+      }
+      expect(onAbandoned).toHaveBeenCalledTimes(1);
 
-    const retry = createRun({
-      prompt: "first",
-      messageId: "m1",
-      originatingChannel: "line",
-      originatingTo: "group:G1",
-    });
-    retry.turnAdoptionLifecycle = { onAdopted: () => {} };
-    expect(enqueueFollowupRun(key, retry, summarizeSettings)).toBe(true);
-    clearSessionQueues([key]);
-  });
+      const retry = createRun({
+        prompt: "first",
+        messageId: "m1",
+        originatingChannel: "line",
+        originatingTo: "group:G1",
+      });
+      retry.turnAdoptionLifecycle = { onAdopted: () => {} };
+      expect(enqueueFollowupRun(key, retry, summarizeSettings)).toBe(true);
+      clearSessionQueues([key]);
+    },
+  );
 
   it("does not let a stale abandoned lifecycle release a newer same-id owner", async () => {
     vi.useFakeTimers();
@@ -593,7 +607,7 @@ describe("followup queue deduplication", () => {
     expect(enqueueFollowupRun(key, redelivery, collectSettings)).toBe(false);
   });
 
-  it.each(["abandoned", "adopted", "adopting", "consumed"] as const)(
+  it.each(["abandoned", "aborted", "adopted", "adopting", "consumed"] as const)(
     "preserves inbound retry eligibility after the %s disposition",
     async (disposition) => {
       const key = `test-dedup-inbound-release-${Date.now()}`;
@@ -608,7 +622,9 @@ describe("followup queue deduplication", () => {
         MessageSid: "stalled-1",
       };
       const onAbandoned = vi.fn();
+      const onSettled = vi.fn();
       const pendingAdoption = createDeferred();
+      const sourceAbort = new AbortController();
 
       const run = createRun({
         prompt: "stalled message",
@@ -616,9 +632,11 @@ describe("followup queue deduplication", () => {
         originatingChannel: "whatsapp",
         originatingTo: "whatsapp:+15550200",
       });
+      run.abortSignal = sourceAbort.signal;
       run.turnAdoptionLifecycle = {
         onAdopted: () => (disposition === "adopting" ? pendingAdoption.promise : undefined),
         onAbandoned,
+        onSettled,
       };
       const claim = claimInboundDedupe(ctx, { owner: run.turnAdoptionLifecycle });
       expect(claim.status).toBe("claimed");
@@ -631,21 +649,41 @@ describe("followup queue deduplication", () => {
 
       if (disposition === "adopted") {
         await admitFollowupRunLifecycle(run);
+        sourceAbort.abort();
+        expect(onSettled).not.toHaveBeenCalled();
       }
       const admission = disposition === "adopting" ? admitFollowupRunLifecycle(run) : undefined;
-      completeFollowupRunLifecycle(run, disposition === "consumed" ? "consumed" : undefined);
+      if (disposition === "aborted") {
+        sourceAbort.abort();
+      } else {
+        completeFollowupRunLifecycle(run, disposition === "consumed" ? "consumed" : undefined);
+      }
       if (admission) {
         expect(claimInboundDedupe(ctx).status).toBe("duplicate");
         expect(onAbandoned).not.toHaveBeenCalled();
         pendingAdoption.resolve();
         await admission;
       }
-      expect(onAbandoned).toHaveBeenCalledTimes(disposition === "abandoned" ? 1 : 0);
+      const retryable = disposition === "abandoned" || disposition === "aborted";
+      expect(onAbandoned).toHaveBeenCalledTimes(retryable ? 1 : 0);
+      expect(onSettled).toHaveBeenCalledOnce();
+      if (disposition === "aborted") {
+        expect(
+          enqueueFollowupRun(
+            key,
+            createRun({
+              prompt: "retry",
+              messageId: "stalled-1",
+              originatingChannel: "whatsapp",
+              originatingTo: "whatsapp:+15550200",
+            }),
+            collectSettings,
+          ),
+        ).toBe(true);
+      }
       clearSessionQueues([key]);
 
-      expect(claimInboundDedupe(ctx).status).toBe(
-        disposition === "abandoned" ? "claimed" : "duplicate",
-      );
+      expect(claimInboundDedupe(ctx).status).toBe(retryable ? "claimed" : "duplicate");
     },
   );
 

--- a/src/auto-reply/reply/queue.dedupe.test.ts
+++ b/src/auto-reply/reply/queue.dedupe.test.ts
@@ -2,6 +2,8 @@
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import type { MsgContext } from "../templating.js";
+import { claimInboundDedupe, commitInboundDedupe, resetInboundDedupe } from "./inbound-dedupe.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 import {
   admitFollowupRunLifecycle,
@@ -48,6 +50,7 @@ function createFollowupCollector(expectedCalls = 1): {
 describe("followup queue deduplication", () => {
   beforeEach(() => {
     resetRecentQueuedMessageIdDedupe();
+    resetInboundDedupe();
   });
 
   it("deduplicates messages with same Discord message_id", async () => {
@@ -589,6 +592,62 @@ describe("followup queue deduplication", () => {
     });
     expect(enqueueFollowupRun(key, redelivery, collectSettings)).toBe(false);
   });
+
+  it.each(["abandoned", "adopted", "adopting", "consumed"] as const)(
+    "preserves inbound retry eligibility after the %s disposition",
+    async (disposition) => {
+      const key = `test-dedup-inbound-release-${Date.now()}`;
+      const ctx: MsgContext = {
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        From: "whatsapp:+15550100",
+        To: "whatsapp:+15550200",
+        OriginatingChannel: "whatsapp",
+        OriginatingTo: "whatsapp:+15550200",
+        SessionKey: "agent:main:whatsapp:+15550200",
+        MessageSid: "stalled-1",
+      };
+      const onAbandoned = vi.fn();
+      const pendingAdoption = createDeferred();
+
+      const run = createRun({
+        prompt: "stalled message",
+        messageId: "stalled-1",
+        originatingChannel: "whatsapp",
+        originatingTo: "whatsapp:+15550200",
+      });
+      run.turnAdoptionLifecycle = {
+        onAdopted: () => (disposition === "adopting" ? pendingAdoption.promise : undefined),
+        onAbandoned,
+      };
+      const claim = claimInboundDedupe(ctx, { owner: run.turnAdoptionLifecycle });
+      expect(claim.status).toBe("claimed");
+      if (claim.status !== "claimed") {
+        throw new Error("expected the first dispatch to claim inbound dedupe");
+      }
+      expect(enqueueFollowupRun(key, run, collectSettings)).toBe(true);
+      commitInboundDedupe(claim);
+      expect(claimInboundDedupe(ctx).status).toBe("duplicate");
+
+      if (disposition === "adopted") {
+        await admitFollowupRunLifecycle(run);
+      }
+      const admission = disposition === "adopting" ? admitFollowupRunLifecycle(run) : undefined;
+      completeFollowupRunLifecycle(run, disposition === "consumed" ? "consumed" : undefined);
+      if (admission) {
+        expect(claimInboundDedupe(ctx).status).toBe("duplicate");
+        expect(onAbandoned).not.toHaveBeenCalled();
+        pendingAdoption.resolve();
+        await admission;
+      }
+      expect(onAbandoned).toHaveBeenCalledTimes(disposition === "abandoned" ? 1 : 0);
+      clearSessionQueues([key]);
+
+      expect(claimInboundDedupe(ctx).status).toBe(
+        disposition === "abandoned" ? "claimed" : "duplicate",
+      );
+    },
+  );
 
   it("can opt-in to prompt-based dedupe when message id is absent", () => {
     const key = `test-dedup-prompt-mode-${Date.now()}`;

--- a/src/auto-reply/reply/queue.in-flight.test.ts
+++ b/src/auto-reply/reply/queue.in-flight.test.ts
@@ -6,6 +6,7 @@ import {
   enqueueFollowupRun,
   FollowupRunDeferredError,
   getFollowupQueueDepth,
+  parkSteerCandidate,
   scheduleFollowupDrain,
 } from "./queue.js";
 import { createQueueTestRun as createRun } from "./queue.test-helpers.js";
@@ -34,6 +35,66 @@ describe("followup queue in-flight ownership", () => {
     debounceMs: 0,
     cap: 1,
     dropPolicy,
+  });
+
+  it("drains accepted siblings after a cancelled parked steer is consumed", async () => {
+    const key = createKey("cancelled-steer");
+    const settings = createSettings("new");
+    const controller = new AbortController();
+    const delivered: string[] = [];
+    const runFollowup = async (run: FollowupRun) => {
+      if (!run.abortSignal?.aborted) {
+        delivered.push(run.prompt);
+      }
+    };
+    const steer = createRun({ prompt: "cancelled steer" });
+    steer.abortSignal = controller.signal;
+    steer.turnAdoptionLifecycle = { onAdopted: async () => {} };
+    const parked = parkSteerCandidate(key, steer, settings, runFollowup);
+    expect(parked).toBeDefined();
+    expect(enqueueFollowupRun(key, createRun({ prompt: "ordinary sibling" }), settings)).toBe(true);
+    scheduleFollowupDrain(key, runFollowup);
+    await vi.waitFor(() => expect(getExistingFollowupQueue(key)?.draining).toBe(false));
+
+    controller.abort();
+    parked?.consume();
+
+    await vi.waitFor(() => expect(delivered).toEqual(["ordinary sibling"]));
+    await vi.waitFor(() => expect(getExistingFollowupQueue(key)).toBeUndefined());
+  });
+
+  it("cancels a parked admission while its predecessor is still undecided", async () => {
+    const key = createKey("cancelled-steer-wait");
+    const settings = createSettings("new");
+    const runFollowup = async () => {};
+    const first = parkSteerCandidate(key, createRun({ prompt: "first" }), settings, runFollowup);
+    const controller = new AbortController();
+    const secondRun = createRun({ prompt: "second" });
+    secondRun.abortSignal = controller.signal;
+    secondRun.turnAdoptionLifecycle = { onAdopted: async () => {} };
+    const second = parkSteerCandidate(key, secondRun, settings, runFollowup);
+    if (!first || !second) {
+      throw new Error("expected both steer reservations");
+    }
+    const admission = second.admit();
+    let settled = false;
+    const completion = admission.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    try {
+      controller.abort();
+      await vi.waitFor(() => expect(settled).toBe(true));
+      await expect(admission).resolves.toBe("cancelled");
+    } finally {
+      first.consume();
+      second.consume();
+      await completion;
+    }
   });
 
   it.each(["old", "summarize"] as const)(
@@ -251,61 +312,74 @@ describe("followup queue in-flight ownership", () => {
     expect(groupCompletions.map((complete) => complete.mock.calls.length)).toEqual([1, 1]);
   });
 
-  it("moves pending overflow state without replaying an active summary delivery", async () => {
-    const key = createKey("summary-recovery");
-    const settings: QueueSettings = {
-      mode: "followup",
-      debounceMs: 0,
-      cap: 1,
-      dropPolicy: "summarize",
-    };
-    const activeEntered = createDeferred();
-    const releaseZombie = createDeferred();
-    const calls: string[] = [];
-    const runFollowup = async (run: FollowupRun) => {
-      calls.push(run.prompt);
-      if (calls.length === 1) {
-        activeEntered.resolve();
-        await releaseZombie.promise;
+  it.each([false, true])(
+    "moves pending overflow state without replaying active delivery (abort pending: %s)",
+    async (abortPending) => {
+      const key = createKey("summary-recovery");
+      const settings: QueueSettings = {
+        mode: "followup",
+        debounceMs: 0,
+        cap: 1,
+        dropPolicy: "summarize",
+      };
+      const activeEntered = createDeferred();
+      const releaseZombie = createDeferred();
+      const calls: string[] = [];
+      const pendingAbort = new AbortController();
+      const pendingAbandoned = vi.fn();
+      const pending = createRun({ prompt: "summary-pending" });
+      pending.abortSignal = pendingAbort.signal;
+      pending.turnAdoptionLifecycle = { onAdopted: async () => {}, onAbandoned: pendingAbandoned };
+      const runFollowup = async (run: FollowupRun) => {
+        calls.push(run.prompt);
+        if (calls.length === 1) {
+          activeEntered.resolve();
+          await releaseZombie.promise;
+        }
+      };
+
+      try {
+        enqueueFollowupRun(
+          key,
+          createRun({ prompt: "summary-active" }),
+          settings,
+          "none",
+          undefined,
+          false,
+        );
+        enqueueFollowupRun(key, pending, settings, "none", undefined, false);
+        scheduleFollowupDrain(key, runFollowup);
+        await activeEntered.promise;
+        enqueueFollowupRun(
+          key,
+          createRun({ prompt: "item-pending" }),
+          settings,
+          "none",
+          runFollowup,
+        );
+
+        const retire = prepareStaleFollowupDrainRetirement(key);
+        expect(retire).toBeTypeOf("function");
+        retire?.();
+        if (abortPending) {
+          pendingAbort.abort();
+          expect(pendingAbandoned).toHaveBeenCalledOnce();
+        }
+        await vi.waitFor(() => expect(calls).toHaveLength(abortPending ? 2 : 3));
+
+        expect(calls[0]).toContain("summary-active");
+        if (!abortPending) {
+          expect(calls[1]).toContain("summary-pending");
+        }
+        expect(calls.at(-1)).toBe("item-pending");
+        releaseZombie.resolve();
+        await vi.waitFor(() => expect(getExistingFollowupQueue(key)).toBeUndefined());
+        expect(calls).toHaveLength(abortPending ? 2 : 3);
+      } finally {
+        releaseZombie.resolve();
       }
-    };
-
-    try {
-      enqueueFollowupRun(
-        key,
-        createRun({ prompt: "summary-active" }),
-        settings,
-        "none",
-        undefined,
-        false,
-      );
-      enqueueFollowupRun(
-        key,
-        createRun({ prompt: "summary-pending" }),
-        settings,
-        "none",
-        undefined,
-        false,
-      );
-      scheduleFollowupDrain(key, runFollowup);
-      await activeEntered.promise;
-      enqueueFollowupRun(key, createRun({ prompt: "item-pending" }), settings, "none", runFollowup);
-
-      const retire = prepareStaleFollowupDrainRetirement(key);
-      expect(retire).toBeTypeOf("function");
-      retire?.();
-      await vi.waitFor(() => expect(calls).toHaveLength(3));
-
-      expect(calls[0]).toContain("summary-active");
-      expect(calls[1]).toContain("summary-pending");
-      expect(calls[2]).toBe("item-pending");
-      releaseZombie.resolve();
-      await vi.waitFor(() => expect(getExistingFollowupQueue(key)).toBeUndefined());
-      expect(calls).toHaveLength(3);
-    } finally {
-      releaseZombie.resolve();
-    }
-  });
+    },
+  );
 
   it("rejects stale retirement after the same source enters a new drain generation", async () => {
     const key = createKey("generation-recovery");

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -153,6 +153,59 @@ export function clearFollowupDrainCallback(key: string): void {
   FOLLOWUP_RUN_CALLBACKS.delete(key);
 }
 
+export function cancelQueuedFollowupRun(
+  key: string,
+  lifecycle: NonNullable<FollowupRun["turnAdoptionLifecycle"]>,
+): void {
+  const queue = FOLLOWUP_QUEUES.get(key);
+  if (!queue) {
+    return;
+  }
+  const sources = [
+    ...new Set([
+      ...queue.items,
+      ...queue.summarySources,
+      ...queue.summaryElisions.flatMap((entry) => entry.sources),
+    ]),
+  ].filter((source) => source.turnAdoptionLifecycle === lifecycle);
+  const queuedSources = sources.filter((source) => queue.items.includes(source));
+  removeQueuedItemsByRef(queue.items, queuedSources);
+  consumeQueueSummaryDelivery(queue, { sources, droppedCount: 0 }, false);
+
+  const releaseEmptyQueue = () => {
+    if (
+      !queue.draining &&
+      queue.items.length === 0 &&
+      queue.inFlight.size === 0 &&
+      queue.droppedCount === 0 &&
+      FOLLOWUP_QUEUES.get(key) === queue
+    ) {
+      FOLLOWUP_QUEUES.delete(key);
+      clearFollowupDrainCallback(key);
+    }
+  };
+  const runFollowup = FOLLOWUP_RUN_CALLBACKS.get(key);
+  if (runFollowup) {
+    for (const source of queuedSources) {
+      if (queue.inFlight.has(source)) {
+        continue;
+      }
+      queue.inFlight.add(source);
+      void (async () => {
+        try {
+          await runFollowup(source);
+        } catch (error) {
+          defaultRuntime.error?.(`followup queue abort cleanup failed: ${String(error)}`);
+        } finally {
+          queue.inFlight.delete(source);
+          releaseEmptyQueue();
+        }
+      })();
+    }
+  }
+  releaseEmptyQueue();
+}
+
 /** Restart the drain for `key` if it is currently idle, using the stored callback. */
 export function kickFollowupDrainIfIdle(key: string): void {
   const cb = FOLLOWUP_RUN_CALLBACKS.get(key);

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -1,6 +1,7 @@
 // Enqueues follow-up reply runs and schedules queue drains.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeChatType } from "../../../channels/chat-type.js";
+import { racePromiseWithAbortSignal } from "../../../infra/abort-signal.js";
 import { logMessageQueuedWithBacklogPolicy } from "../../../logging/diagnostic-runtime.js";
 import { channelRouteDedupeKey } from "../../../plugin-sdk/channel-route.js";
 import { extractTextFromChatContent } from "../../../shared/chat-content.js";
@@ -11,6 +12,7 @@ import {
   shouldSkipQueueItem,
 } from "../../../utils/queue-helpers.js";
 import {
+  cancelQueuedFollowupRun,
   clearFollowupDrainCallback,
   createOverflowSummaryRetrySource,
   kickFollowupDrainIfIdle,
@@ -30,6 +32,7 @@ import {
   trimSummaryElisionsToCap,
 } from "./state.js";
 import {
+  bindQueuedFollowupAbort,
   completeFollowupRunLifecycle,
   isFollowupRunAborted,
   markFollowupRunEnqueued,
@@ -117,9 +120,22 @@ function appendQueueItem(params: {
   if (params.runFollowup) {
     rememberFollowupDrainCallback(params.key, params.runFollowup);
   }
+  // A stalled predecessor must not delay abandonment or block the durable retry.
+  // Parked steering retains its own cancellation and input-custody owner.
+  if (!params.run.steerPending) {
+    bindQueueAbort(params.key, params.run);
+  }
   if (params.restartIfIdle && !params.queue.draining) {
     kickFollowupDrainIfIdle(params.key);
   }
+}
+
+function bindQueueAbort(key: string, run: FollowupRun): void {
+  bindQueuedFollowupAbort(run, (lifecycle) => {
+    cancelQueuedFollowupRun(key, lifecycle);
+    reapplyDeferredOverflow(key);
+    kickFollowupDrainIfIdle(key);
+  });
 }
 
 export function enqueueFollowupRun(
@@ -311,6 +327,7 @@ function settleParkedSteerAcceptance(key: string, run: FollowupRun, accepted: bo
   if (!accepted) {
     delete run.steerPending;
     reapplyDeferredOverflow(key);
+    bindQueueAbort(key, run);
     kickFollowupDrainIfIdle(key);
   }
   return true;
@@ -409,7 +426,19 @@ export function parkSteerCandidate(
   );
   return {
     async admit() {
-      const predecessorAccepted = (await run.steerPending?.predecessor) ?? true;
+      let predecessorAccepted: boolean;
+      try {
+        // Queue replacement rebinds queueAbortSignal; the upstream owner is stable.
+        predecessorAccepted = await racePromiseWithAbortSignal(
+          run.steerPending?.predecessor ?? Promise.resolve(true),
+          run.abortSignal,
+        );
+      } catch (error) {
+        if (run.abortSignal?.aborted) {
+          return "cancelled";
+        }
+        throw error;
+      }
       if (isFollowupRunAborted(run) || !isParkedFollowupRunOwned(key, run)) {
         return "cancelled";
       }

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -43,6 +43,7 @@ import type {
   TraceLevel,
   VerboseLevel,
 } from "../directives.js";
+import { releaseOwnedInboundDedupe } from "../inbound-dedupe.js";
 import type { ReplyOperationRunState } from "../reply-operation-run-state.js";
 import { releaseRecentQueueMessageId } from "./recent-message-ids.js";
 
@@ -365,6 +366,7 @@ export function completeFollowupRunLifecycle(
         // identity so the abandonment-triggered ingress retry can re-enqueue
         // instead of being rejected as a recent duplicate and falsely completed.
         releaseRecentQueueMessageId(run);
+        releaseOwnedInboundDedupe(lifecycle);
         lifecycle.onAbandoned?.();
       }
     } finally {

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -294,8 +294,40 @@ const admittingTurnAdoptionLifecycles = new WeakMap<TurnAdoptionLifecycle, Promi
 const retiredTurnAdoptionCancellationLifecycles = new WeakSet<TurnAdoptionLifecycle>();
 const completedTurnAdoptionLifecycles = new WeakSet<TurnAdoptionLifecycle>();
 const completedTurnAdoptionLifecycleCallbacks = new WeakSet<TurnAdoptionLifecycle>();
+const queuedAbortCleanups = new WeakMap<TurnAdoptionLifecycle, () => void>();
 
 type FollowupLifecycleRun = Pick<FollowupRun, "steerPending" | "turnAdoptionLifecycle">;
+
+function clearQueuedAbort(lifecycle: TurnAdoptionLifecycle): void {
+  queuedAbortCleanups.get(lifecycle)?.();
+  queuedAbortCleanups.delete(lifecycle);
+}
+
+export function bindQueuedFollowupAbort(
+  run: FollowupRun,
+  removeFromQueue: (lifecycle: TurnAdoptionLifecycle) => void,
+): void {
+  const lifecycle = run.turnAdoptionLifecycle;
+  const signal = run.abortSignal;
+  if (
+    !lifecycle ||
+    !signal ||
+    admittedTurnAdoptionLifecycles.has(lifecycle) ||
+    completedTurnAdoptionLifecycles.has(lifecycle)
+  ) {
+    return;
+  }
+  clearQueuedAbort(lifecycle);
+  const onAbort = () => {
+    removeFromQueue(lifecycle);
+    completeFollowupRunLifecycle(run);
+  };
+  queuedAbortCleanups.set(lifecycle, () => signal.removeEventListener("abort", onAbort));
+  signal.addEventListener("abort", onAbort, { once: true });
+  if (signal.aborted) {
+    onAbort();
+  }
+}
 
 export function markFollowupRunEnqueued(run: FollowupLifecycleRun): boolean {
   const lifecycle = run.turnAdoptionLifecycle;
@@ -335,6 +367,7 @@ export async function admitFollowupRunLifecycle(run: FollowupLifecycleRun): Prom
     if (!admittedTurnAdoptionLifecycles.has(lifecycle)) {
       await lifecycle.onAdopted();
       admittedTurnAdoptionLifecycles.add(lifecycle);
+      clearQueuedAbort(lifecycle);
     }
   });
 
@@ -352,6 +385,10 @@ export function completeFollowupRunLifecycle(
 ): void {
   run.steerPending?.settle(false);
   const lifecycle = run.turnAdoptionLifecycle;
+
+  if (lifecycle) {
+    clearQueuedAbort(lifecycle);
+  }
 
   const finish = () => {
     if (!lifecycle || completedTurnAdoptionLifecycleCallbacks.has(lifecycle)) {


### PR DESCRIPTION
Closes #139341.

## What Problem This Solves

Fixes an issue where a message queued behind a busy turn could be lost after the five-minute adoption timeout. Durable ingress released it for retry, but retained duplicate-suppression state blocked processing and the retry was falsely completed with its payload cleared.

## Why This Change Was Made

Bind inbound suppression to the exact dispatch claim from the initial claim through commit and release. A retired claim cannot overwrite or release a newer retry.

Retire an ordinary pending queue source as soon as its upstream owner aborts, including after queue replacement or summary compaction. Preserve its cleanup and resume accepted siblings. Parked steering keeps its existing input-custody owner, so accepted or indeterminate input remains protected from replay.

## User Impact

Safely abandoned messages can retry with their payload intact and reach processing once. Adopted or consumed work retains suppression. Cancellation preserves other queued messages, overflow summaries, and steering continuation.

## Evidence

- Current-main baseline `4bb95eb02cede`: real Telegram Test Server DM, a held prior turn, and the default 300,000 ms watchdog. The target retried and became completed with a cleared payload, but had no provider request, transcript entry, or reply.
- Candidate `31066562f224`: both the short control and the full default 300,000 ms watchdog run retained the payload and retry history, then produced one target provider request, transcript entry, and reply. Replaying the original transport update produced no extra request. An additional baseline run releases the blocker at the actual watchdog abort and records the core committed-duplicate rejection directly.
- Focused queue, input, dispatch, steering, retry-policy, and ownership tests; formatting, type-aware lint, and growth/assertion guards. New regressions fail before the relevant repairs, including late finalization, immediate abort, and parked-steer sibling continuation.
- Independent source-blind acceptance passed all 12 required observations, including fresh default-timeout recovery, account/group independence, and an instrumented selective-release control. The control preserves an unrelated completed message while releasing the target’s old claim, then verifies target continuation and replay suppression.
- Fresh code review of the complete staged repair is clear through P2. Exact-head CI run `34010117963` is green.
- Recovery controls cover a pending photo across restart, interruption after Telegram accepted a reply, and retry-limit/dead-letter listing and resubmission after a real database lock. The limit control explicitly seeds prior retry history; it does not claim eight live failures or a day of elapsed testing.

A forced crash with an already-adopted, unfinished predecessor retained the queued target and visible retry errors but did not complete it during the capture. This PR does not claim to resolve that predecessor-recovery case.

The real-channel proof uses Telegram through the same core ingress and reply-queue owners as the reported WhatsApp path. Direct WhatsApp transport behavior is not claimed. #133248 remains a separate queue-heartbeat change.

Thanks @ruel225 for the original repair and @Jackten for the detailed report.
