### PR TITLE
fix: migrate workspace setup early and expose channel startup errors

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -326,7 +326,8 @@ the container normally.
 
 `openclaw doctor --fix` is the only owner for persistent file-to-SQLite migrations. It validates and claims each recognized source, writes and verifies canonical rows, records a migration receipt, then removes the retired source. Runtime code does not perform lazy imports or fallback reads.
 
-For legacy workspace setup files, an existing canonical SQLite setup record wins,
+Doctor imports recognized legacy workspace setup files during preflight, before
+Workshop migration accesses workspace state. An existing canonical SQLite setup record wins,
 including milestones that are absent in SQLite. Doctor does not replay stale
 milestones over it. Before removing a validated setup file or interrupted claim,
 Doctor preserves its exact bytes beside the original as

--- a/docs/cli/health.md
+++ b/docs/cli/health.md
@@ -33,6 +33,7 @@ openclaw health --debug
 - Without `--verbose`, the Gateway can return a cached snapshot (fresh for up to 60 seconds and unchanged from live channel runtime state) and refresh it in the background for the next caller.
 - `--verbose` forces a live probe (per-channel account probes), prints Gateway connection details, and expands human-readable output across all configured accounts and agents instead of just the default agent.
 - An unconfigured preferred account does not hide probe results from other active accounts. Ordinary output still follows the default agent's account bindings; `--verbose` includes all accounts.
+- Unhealthy channel lines include the recorded startup error when available, so a stopped channel reports its failure cause alongside its state.
 - `--json` always returns the full snapshot: channels, per-account probes, plugin load state, context-engine quarantine state, model-pricing cache state, event-loop health, delivery-queue warnings, and per-agent session stores.
 - Session ages in text and JSON use the Gateway's clock.
 - Heartbeat intervals in text show the resolved cadence without rounding away milliseconds; week units are retained for long intervals.

--- a/src/commands/doctor-skill-workshop-workspace.test.ts
+++ b/src/commands/doctor-skill-workshop-workspace.test.ts
@@ -194,9 +194,16 @@ describe("Workshop relocation and workspace survival", () => {
 
       await autoMigrateLegacyState(migrationInput);
 
-      await expect(fs.readFile(fixture.created.target.skillFile, "utf8")).resolves.toBe(
-        fixture.content,
-      );
+      const preflightSkillFile = doctorOnlyStateMigrations
+        ? path.join(fixture.destination, "SKILL.md")
+        : fixture.created.target.skillFile;
+      await expect(fs.readFile(preflightSkillFile, "utf8")).resolves.toBe(fixture.content);
+      if (doctorOnlyStateMigrations) {
+        await expect(fs.access(fixture.created.target.skillFile)).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+        await expect(fs.access(marker)).rejects.toMatchObject({ code: "ENOENT" });
+      }
       expect(readWorkspaceStateSnapshot(fixture.workspaceDir).attestation).toBeUndefined();
       const detected = await detectLegacyStateMigrations({
         ...migrationInput,

--- a/src/commands/health-format.test.ts
+++ b/src/commands/health-format.test.ts
@@ -84,6 +84,26 @@ function createMultiAccountHealthSummary(
 }
 
 describe("formatHealthChannelLines", () => {
+  it.each([false, true])("keeps the named startup error with terminal controls=%s", (controls) => {
+    const error = "Legacy exec approvals exist at /tmp/synthetic/exec-approvals.json.";
+    const summary = createHealthSummary({
+      channels: {
+        telegram: {
+          accountId: "default",
+          configured: true,
+          running: false,
+          healthState: "not-running",
+          lastError: controls ? `\u001b[31m${error}\u001b[0m\n` : error,
+        },
+      },
+      channelOrder: ["telegram"],
+      channelLabels: { telegram: "Telegram" },
+    });
+    expect(formatHealthChannelLines(summary)).toEqual([
+      `Telegram: not-running (${error}${controls ? "\\n" : ""})`,
+    ]);
+  });
+
   it("formats per-account probe timings", () => {
     const summary = createHealthSummary({
       channels: {

--- a/src/commands/health-format.ts
+++ b/src/commands/health-format.ts
@@ -213,7 +213,11 @@ export const formatHealthChannelLines = (
             ? "not linked"
             : null;
     if (preProbeState) {
-      lines.push(`${label}: ${preProbeState}`);
+      const error =
+        typeof selectedSummary.lastError === "string"
+          ? sanitizeTerminalText(selectedSummary.lastError)
+          : "";
+      lines.push(`${label}: ${preProbeState}${error ? ` (${error})` : ""}`);
       continue;
     }
 

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -1011,7 +1011,6 @@ function buildLegacyStateMigrationSteps(
 
   const doctorFinalSteps: LegacyStateMigrationStep[] = isDoctor
     ? [
-        ownerStep(detected.workspace, migrateLegacyWorkspaceState),
         ownerStep(detected.webPush, migrateLegacyWebPush),
         ownerStep(detected.nodeHost, migrateLegacyNodeHostConfig),
         ownerStep(detected.subagentRegistry, migrateLegacySubagentRegistry),
@@ -1021,6 +1020,7 @@ function buildLegacyStateMigrationSteps(
 
   const finalSteps: LegacyStateMigrationStep[] = [
     ownerStep(detected.restartSentinel, migrateLegacyRestartSentinel),
+    ownerStep(detected.workspace, migrateLegacyWorkspaceState),
     ...doctorFinalSteps,
     {
       // Workspace evidence must be canonical before a Workshop move can retire

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -7,6 +7,8 @@ import { DatabaseSync } from "node:sqlite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { readAcpSessionMetaForEntry } from "../acp/runtime/session-meta.js";
 import { AgentSelectionRequiredError, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { assertWorkspaceStateMigrationReady } from "../agents/workspace-legacy-state.js";
+import { readWorkspaceStateSnapshot } from "../agents/workspace-state-store.js";
 import { createChannelIngressQueue } from "../channels/message/ingress-queue.js";
 import * as channelRegistry from "../channels/plugins/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -790,6 +792,39 @@ afterAll(async () => {
 });
 
 describe("state migrations", () => {
+  it("migrates workspace setup during Doctor preflight before runtime consumers", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const workspaceDir = path.join(root, "workspace");
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: { default: true, workspace: workspaceDir } } },
+    };
+    const sourcePath = path.join(workspaceDir, ".openclaw", "workspace-state.json");
+    const completedAt = "2026-07-15T10:01:00.000Z";
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, JSON.stringify({ version: 1, setupCompletedAt: completedAt }));
+    const assertReady = () =>
+      assertWorkspaceStateMigrationReady({ workspaceDirs: [workspaceDir], env });
+
+    await autoMigrateLegacyState({ cfg, env, homedir: () => root });
+    expect(assertReady).toThrow("Legacy workspace setup state requires migration");
+
+    const repaired = await autoMigrateLegacyState({
+      cfg,
+      env,
+      homedir: () => root,
+      doctorOnlyStateMigrations: true,
+    });
+
+    expect(repaired.warnings).toEqual([]);
+    expect(assertReady).not.toThrow();
+    expect(fsSync.existsSync(sourcePath)).toBe(false);
+    expect(readWorkspaceStateSnapshot(workspaceDir, { env }).setup.setupCompletedAt).toBe(
+      completedAt,
+    );
+  });
+
   let detectionCase: Awaited<ReturnType<typeof detectLegacyStateMigrations>> & {
     stateDir: string;
     env: NodeJS.ProcessEnv;


### PR DESCRIPTION
Related: #135755

## What Problem This Solves

Fixes an issue where Doctor repair could leave valid legacy workspace setup state unmigrated before Workshop accessed it, sending users back to Doctor. Also restores the named channel startup error in `openclaw health`: a configured Telegram account now reports `Telegram: not-running (Legacy exec approvals exist at <path>...)` instead of only `Telegram: not-running`. These address reproducible parts of upgrade-recovery loops reported by community members on Discord.

## Why This Change Was Made

In `src/infra/state-migrations.doctor.ts`, explicit Doctor preflight detects workspace sources but builds the automatic-mode graph, which previously excluded the workspace migration before Workshop consumers. Move the existing migration step ahead of those consumers; the unchanged detector continues to exclude ordinary runtime imports.

In `src/commands/health-format.ts`, the unhealthy-state branch returned before displaying the account's `lastError`. Append that existing fact after sanitizing terminal controls. Configuration state and startup failure remain distinct facts.

Enabling the entire Doctor graph would broaden unrelated migration behavior. Catching the workspace error in Workshop would leave its source stranded. Inferring configuration from a failed channel start would repeat the original status mistake. Neither a new migration registry nor a new health field is necessary.

## User Impact

Explicit Doctor repair imports supported workspace setup files before their consumers and preserves completion timestamps. Health output explains why a channel is stopped, while existing healthy, unconfigured, multi-account, and probe behavior remains covered.

The maintainer-approved scope is exactly these two repairs. The previous draft hold has been resolved; the broader rejected-state recovery work remains separate.

## Evidence

Head: daf971b13a4154e3531af1d5564e5d75170ed30c

- `node scripts/run-vitest.mjs src/commands/health-format.test.ts`: 42 passed. The original implementation failed the named-startup-error regression; the retained change passes plain-text and terminal-control cases.
- `node scripts/run-vitest.mjs src/infra/state-migrations.test.ts -t 'migrates workspace setup during Doctor preflight'`: 1 passed. This regression failed on the original owner at its post-repair readiness assertion and passes after moving the existing migration step.
- `node scripts/run-vitest.mjs src/commands/doctor-skill-workshop-workspace.test.ts`: 12 passed. The explicit-preflight case now verifies immediate relocation, preserved skill content, and legacy-marker cleanup; ordinary startup retains the old location.
- Earlier focused workspace-migration and breaker coverage: 49 passed. Exec migration owner: 71 passed; real CLI Doctor exec-migration process: 1 passed. These are supporting evidence, not workspace-specific full Gateway startup proof.
- `pnpm check:changed`: passed (exit 0) for the two production repairs. The subsequent test-only correction also runs `pnpm check:changed -- src/commands/doctor-skill-workshop-workspace.test.ts` (passed, exit 0).
- `git diff --check`: clean.
- Independent Codex review: scoped-clean; no actionable P0–P2 findings.

Whole-PR production delta against the frozen base: +6/-2, net +4 (within the approved +5 cap). Tests: +65/-3 (net +62). Docs: +3/-1. The existing workspace migration from #135755 remains unchanged.

CI: the initial run [33993182373](https://github.com/openclaw/openclaw/actions/runs/33993182373) failed one stale Workshop test expectation that required explicit Doctor preflight to leave the skill unmigrated. That expectation is corrected with stronger destination/content/cleanup assertions; replacement-head CI [33994181381](https://github.com/openclaw/openclaw/actions/runs/33994181381) is green on daf971b13a4154e3531af1d5564e5d75170ed30c (124 jobs completed, no failures). Full Gateway/Telegram live proof is not claimed.

## Follow-up

Fail-closed Doctor completion for unsupported canonical workspace versions and unreadable/conflicting exec policy is a separate change pending a LOC/scope decision. The saved candidate measured production +149/-94 (net +55); it is excluded from this PR. Unknown-version state is not discarded and execution policy is not inferred. No follow-up PR is part of this work.
