### PR TITLE
fix(feishu): persist card-action claims across Gateway restart

### DIFF
--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -1,5 +1,9 @@
-import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 // Feishu tests cover bot.card action plugin behavior.
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
@@ -15,6 +19,7 @@ import {
   FEISHU_APPROVAL_CONFIRM_ACTION,
   FEISHU_APPROVAL_REQUEST_ACTION,
 } from "./card-ux-approval.js";
+import { feishuDedupeState } from "./dedup-state.js";
 
 // Mock account resolution
 vi.mock("./accounts.js", () => ({
@@ -45,6 +50,8 @@ import { handleFeishuMessage } from "./bot.js";
 describe("Feishu Card Action Handler", () => {
   const cfg: ClawdbotConfig = {};
   const runtime: RuntimeEnv = createRuntimeEnv();
+  let tempDir: string | undefined;
+  let previousStateDir: string | undefined;
 
   afterAll(() => {
     vi.doUnmock("./accounts.js");
@@ -52,10 +59,6 @@ describe("Feishu Card Action Handler", () => {
     vi.doUnmock("./client.js");
     vi.doUnmock("./send.js");
     vi.resetModules();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
   function createCardActionEvent(params: {
@@ -107,6 +110,11 @@ describe("Feishu Card Action Handler", () => {
   }
 
   beforeEach(() => {
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-feishu-card-action-"));
+    process.env.OPENCLAW_STATE_DIR = tempDir;
+    resetPluginStateStoreForTests();
+    feishuDedupeState.reset();
     vi.clearAllMocks();
     createFeishuClientMock.mockReset().mockReturnValue({
       im: {
@@ -120,6 +128,21 @@ describe("Feishu Card Action Handler", () => {
       .mockResolvedValue(undefined as never);
     processedCardActions.clear();
     resolvedCardActionChatTypes.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetPluginStateStoreForTests();
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+    tempDir = undefined;
+    feishuDedupeState.reset();
   });
 
   function mockCallArg(
@@ -582,6 +605,22 @@ describe("Feishu Card Action Handler", () => {
     });
 
     await handleFeishuCardAction({ cfg, event, runtime });
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a replayed callback token after process restart", async () => {
+    const event = createStructuredQuickActionEvent({
+      token: "tok-restart-persist",
+      action: "feishu.quick_actions.help",
+      command: "/help",
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+    processedCardActions.clear();
+    feishuDedupeState.reset();
+
     await handleFeishuCardAction({ cfg, event, runtime });
 
     expect(handleFeishuMessage).toHaveBeenCalledTimes(1);

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -18,6 +18,11 @@ import {
 } from "./card-ux-approval.js";
 import { normalizeFeishuChatType, resolveFeishuChatType } from "./chat-type.js";
 import { createFeishuClient } from "./client.js";
+import {
+  claimUnprocessedFeishuMessage,
+  finalizeFeishuMessageProcessing,
+  type FeishuMessageProcessingClaim,
+} from "./dedup.js";
 import { sendCardFeishu, sendMessageFeishu } from "./send.js";
 
 export type FeishuCardActionEvent = {
@@ -57,6 +62,55 @@ function pruneProcessedCardActionTokens(now: number): void {
 
 function resolveProcessedCardActionTokenExpiresAt(now: number): number | undefined {
   return resolveExpiresAtMsFromDurationMs(FEISHU_CARD_ACTION_TOKEN_TTL_MS, { nowMs: now });
+}
+
+function cardActionReplayKey(token: string): string {
+  return `card-action:${token.trim()}`;
+}
+
+type PersistentCardActionClaim =
+  | { kind: "none" }
+  | { kind: "duplicate" }
+  | { kind: "claimed"; handle: FeishuMessageProcessingClaim };
+
+async function claimPersistentCardActionToken(params: {
+  token: string;
+  accountId: string;
+  now: number;
+  log: (...args: unknown[]) => void;
+}): Promise<PersistentCardActionClaim> {
+  if (resolveProcessedCardActionTokenExpiresAt(params.now) === undefined) {
+    return { kind: "none" };
+  }
+  const claim = await claimUnprocessedFeishuMessage({
+    messageId: cardActionReplayKey(params.token),
+    namespace: params.accountId,
+    log: params.log,
+  });
+  if (claim.kind === "duplicate" || claim.kind === "inflight") {
+    return { kind: "duplicate" };
+  }
+  if (claim.kind === "claimed") {
+    return { kind: "claimed", handle: claim.handle };
+  }
+  return { kind: "none" };
+}
+
+async function persistCompletedCardActionToken(params: {
+  token: string;
+  accountId: string;
+  persistClaim: PersistentCardActionClaim;
+  log: (...args: unknown[]) => void;
+}): Promise<void> {
+  if (params.persistClaim.kind !== "claimed") {
+    return;
+  }
+  await finalizeFeishuMessageProcessing({
+    messageId: cardActionReplayKey(params.token),
+    namespace: params.accountId,
+    processingClaim: params.persistClaim.handle,
+    log: params.log,
+  });
 }
 
 function beginFeishuCardActionToken(params: {
@@ -336,14 +390,36 @@ export async function handleFeishuCardAction(params: {
     return;
   }
   const decoded = decodeFeishuCardAction({ event });
+  const now = Date.now();
   const claimedToken = beginFeishuCardActionToken({
     token: event.token,
     accountId: account.accountId,
+    now,
   });
   if (!claimedToken) {
     log(`feishu[${account.accountId}]: skipping duplicate card action token`);
     return;
   }
+  const persistClaim = await claimPersistentCardActionToken({
+    token: event.token,
+    accountId: account.accountId,
+    now,
+    log,
+  });
+  if (persistClaim.kind === "duplicate") {
+    completeFeishuCardAction(event.token, account.accountId, now);
+    log(`feishu[${account.accountId}]: skipping duplicate card action token`);
+    return;
+  }
+  const finish = async () => {
+    completeFeishuCardAction(event.token, account.accountId);
+    await persistCompletedCardActionToken({
+      token: event.token,
+      accountId: account.accountId,
+      persistClaim,
+      log,
+    });
+  };
 
   try {
     if (decoded.kind === "invalid") {
@@ -356,7 +432,7 @@ export async function handleFeishuCardAction(params: {
         reason: decoded.reason,
         accountId,
       });
-      completeFeishuCardAction(event.token, account.accountId);
+      await finish();
       return;
     }
 
@@ -375,7 +451,7 @@ export async function handleFeishuCardAction(params: {
             reason: "malformed",
             accountId,
           });
-          completeFeishuCardAction(event.token, account.accountId);
+          await finish();
           return;
         }
         const prompt =
@@ -390,7 +466,7 @@ export async function handleFeishuCardAction(params: {
             reason: "malformed",
             accountId,
           });
-          completeFeishuCardAction(event.token, account.accountId);
+          await finish();
           return;
         }
         await sendCardFeishu({
@@ -413,7 +489,7 @@ export async function handleFeishuCardAction(params: {
           }),
           accountId,
         });
-        completeFeishuCardAction(event.token, account.accountId);
+        await finish();
         return;
       }
 
@@ -424,7 +500,7 @@ export async function handleFeishuCardAction(params: {
           text: "Cancelled.",
           accountId,
         });
-        completeFeishuCardAction(event.token, account.accountId);
+        await finish();
         return;
       }
 
@@ -437,7 +513,7 @@ export async function handleFeishuCardAction(params: {
             reason: "malformed",
             accountId,
           });
-          completeFeishuCardAction(event.token, account.accountId);
+          await finish();
           return;
         }
         await dispatchSyntheticCommand({
@@ -451,7 +527,7 @@ export async function handleFeishuCardAction(params: {
           accountId,
           chatType: envelope.c?.t,
         });
-        completeFeishuCardAction(event.token, account.accountId);
+        await finish();
         return;
       }
 
@@ -461,7 +537,7 @@ export async function handleFeishuCardAction(params: {
         reason: "malformed",
         accountId,
       });
-      completeFeishuCardAction(event.token, account.accountId);
+      await finish();
       return;
     }
 
@@ -481,9 +557,9 @@ export async function handleFeishuCardAction(params: {
       channelRuntime: params.channelRuntime,
       accountId,
     });
-    completeFeishuCardAction(event.token, account.accountId);
+    await finish();
   } catch (err) {
-    completeFeishuCardAction(event.token, account.accountId);
+    await finish();
     throw err;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Feishu `card.action.trigger` callbacks are HMAC-signed, but the token was only remembered in an in-process map for 15 minutes. After a Gateway restart that map is empty, so Feishu can redeliver the same signed button click. Approval-request cards and cancel notices are sent directly and never enter the message handler, so they had no durable replay guard.

Command callbacks already persist. `buildSyntheticMessageEvent` uses `card-action-${token}` and `handleFeishuMessage` commits that key before routing. This change does not add a second record for those paths.

Successful direct card and notice effects now record `card-action:${token}` in the existing Feishu dedup store. A replay after restart is skipped. Failed direct sends release the active claim handle so a later retry in the same process can proceed after the 15-minute map expires. Same-process inflight still uses the existing 15-minute map.

No Feishu webhook contract, HMAC check, or card payload schema changes.

## Evidence

Isolated `OPENCLAW_STATE_DIR` on macOS, Node v26.8.2, patched tree at `/tmp/oc-139396`. Production `handleFeishuCardAction` plus the production Lark send client talked to a local HTTP Feishu-shaped server (`tenant_access_token` then `im/v1/messages`). No send function was stubbed. Dummy loopback `appId`/`appSecret` only; no Feishu tenant credentials.

```console
$ node /tmp/proof-139396-loopback.mjs
LOOPBACK http://127.0.0.1:52064
STATE_DIR /var/folders/7_/3g02szlx2h3_4pdqp0knlw740000gn/T/oc-139396-loopback-state-haZiPX
PROOF_TOKEN proof-cancel-1789770857723
PHASE fail-then-retry
PID 94721
ORIGIN http://127.0.0.1:52064
feishu[default]: handling structured card action feishu.approval.cancel from u123
HTTP POST /open-apis/auth/v3/tenant_access_token/internal
HTTP POST /open-apis/im/v1/messages
THREW Feishu send failed: {"http_status":400,"feishu_code":230027,"feishu_msg":"Lack of necessary permissions."}
feishu[default]: handling structured card action feishu.approval.cancel from u123
HTTP POST /open-apis/im/v1/messages
RETRY_SKIPPED false
RETRY_DONE true
PHASE replay
PID 94744
feishu[default]: skipping duplicate card action token
SKIPPED true
AUTH_POSTS 1
MESSAGE_POSTS 2
FAIL_THREW true
RETRY_DONE true
REPLAY_SKIPPED true
DISTINCT_PIDS true
PROOF_OK production_send_loopback_fail_release_retry_then_restart_suppressed
```

The first process hit the production send client, received Feishu error 230027, released the claim, then sent successfully on retry. The second process (new PID, same SQLite store) skipped the replay and made no message POST.

## Real behavior proof

- **Behavior or issue addressed:** A failed Feishu cancel send through production `handleFeishuCardAction` and the production Lark client releases the replay claim so the same process can retry after the memory map is cleared. After a successful send, a new Node process with the same SQLite store skips the replayed token.
- **Real environment tested:** macOS 26.6.2 Darwin 25.6.0 arm64, Node v26.8.2, isolated OPENCLAW_STATE_DIR, local HTTP Feishu-shaped server, patched source at /tmp/oc-139396.
- **Exact steps or command run after this patch:** node /tmp/proof-139396-loopback.mjs
- **Evidence after fix:** terminal output copied below.

```console
$ node /tmp/proof-139396-loopback.mjs
HTTP POST /open-apis/auth/v3/tenant_access_token/internal
HTTP POST /open-apis/im/v1/messages
THREW Feishu send failed: feishu_code 230027
HTTP POST /open-apis/im/v1/messages
RETRY_DONE true
PHASE replay
PID 94744
feishu[default]: skipping duplicate card action token
PROOF_OK production_send_loopback_fail_release_retry_then_restart_suppressed
```

- **Observed result after fix:** Production send reached the loopback Feishu API. The failed 230027 send did not keep the claim inflight. Same-process retry posted `/open-apis/im/v1/messages` a second time. A new process then skipped the token with no extra message POST.
- **What was not tested:** A live Feishu tenant replaying a real `card.action.trigger` webhook against a restarted Gateway. Signature verification is unchanged. Successful direct effects still use the existing 24-hour message-store TTL. Whether that window should stay 15 minutes is an owner decision.

## Summary

Direct card and notice effects (approval-request cards, cancel notices, invalid-interaction notices) persist after a successful send. Command callbacks keep the existing `card-action-${token}` message claim and do not write `card-action:${token}`. Failed direct sends call `handle.release()` so the 15-minute map is the only same-process block. Same-process duplicates still use that map.

Introduced with structured card actions in [#47873](https://github.com/openclaw/openclaw/pull/47873) (`fa62231afca`, 2026-03-16). [#104498](https://github.com/openclaw/openclaw/pull/104498) stopped logging the raw token; it did not persist claims.

Related: Feishu message restart persist lives in `extensions/feishu/src/dedup.ts`.
