### PR TITLE
refactor(workboard): build typed board and subscription upserts

### DIFF
--- a/extensions/workboard/src/sqlite-store.ts
+++ b/extensions/workboard/src/sqlite-store.ts
@@ -1390,39 +1390,39 @@ class WorkboardSqliteBoardStore implements WorkboardKeyedStore<PersistedWorkboar
       throw new Error("invalid workboard board payload");
     }
     const board = value.board;
-    this.db
-      .prepare(
-        `
-          INSERT INTO workboard_boards (
-            id, name, description, icon, color, automation_job_id, default_workspace_json,
-            orchestration_json, created_at, updated_at, archived_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-          ON CONFLICT(id) DO UPDATE SET
-            name = excluded.name,
-            description = excluded.description,
-            icon = excluded.icon,
-            color = excluded.color,
-            automation_job_id = excluded.automation_job_id,
-            default_workspace_json = excluded.default_workspace_json,
-            orchestration_json = excluded.orchestration_json,
-            created_at = excluded.created_at,
-            updated_at = excluded.updated_at,
-            archived_at = excluded.archived_at
-        `,
-      )
-      .run(
-        board.id,
-        bindNull(board.name),
-        bindNull(board.description),
-        bindNull(board.icon),
-        bindNull(board.color),
-        bindNull(board.automationJobId),
-        jsonValue(board.defaultWorkspace),
-        jsonValue(board.orchestration),
-        board.createdAt,
-        board.updatedAt,
-        bindNull(board.archivedAt),
-      );
+    // Native preparation must precede payload getters and JSON serialization.
+    const { compiled, bind } = compileSqliteQueryBindings<void>((parameter) =>
+      getNodeSqliteKysely<{ workboard_boards: Row }>(this.db)
+        .insertInto("workboard_boards")
+        .values({
+          id: parameter(() => board.id),
+          name: parameter(() => bindNull(board.name)),
+          description: parameter(() => bindNull(board.description)),
+          icon: parameter(() => bindNull(board.icon)),
+          color: parameter(() => bindNull(board.color)),
+          automation_job_id: parameter(() => bindNull(board.automationJobId)),
+          default_workspace_json: parameter(() => jsonValue(board.defaultWorkspace)),
+          orchestration_json: parameter(() => jsonValue(board.orchestration)),
+          created_at: parameter(() => board.createdAt),
+          updated_at: parameter(() => board.updatedAt),
+          archived_at: parameter(() => bindNull(board.archivedAt)),
+        })
+        .onConflict((conflict) =>
+          conflict.column("id").doUpdateSet((eb) => ({
+            name: eb.ref("excluded.name"),
+            description: eb.ref("excluded.description"),
+            icon: eb.ref("excluded.icon"),
+            color: eb.ref("excluded.color"),
+            automation_job_id: eb.ref("excluded.automation_job_id"),
+            default_workspace_json: eb.ref("excluded.default_workspace_json"),
+            orchestration_json: eb.ref("excluded.orchestration_json"),
+            created_at: eb.ref("excluded.created_at"),
+            updated_at: eb.ref("excluded.updated_at"),
+            archived_at: eb.ref("excluded.archived_at"),
+          })),
+        ),
+    );
+    this.db.prepare(compiled.sql).run(...bind());
   }
 
   async lookup(key: string): Promise<PersistedWorkboardBoard | undefined> {
@@ -1493,44 +1493,43 @@ class WorkboardSqliteSubscriptionStore implements WorkboardKeyedStore<PersistedW
       throw new Error("invalid workboard notification subscription payload");
     }
     const subscription = value.subscription;
-    this.db
-      .prepare(
-        `
-          INSERT INTO workboard_notification_subscriptions (
-            id, board_id, card_id, session_key, run_id, target, event_kinds_json,
-            last_event_at, last_event_id, last_event_sequence, delivered_event_ids_json,
-            created_at, updated_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-          ON CONFLICT(id) DO UPDATE SET
-            board_id = excluded.board_id,
-            card_id = excluded.card_id,
-            session_key = excluded.session_key,
-            run_id = excluded.run_id,
-            target = excluded.target,
-            event_kinds_json = excluded.event_kinds_json,
-            last_event_at = excluded.last_event_at,
-            last_event_id = excluded.last_event_id,
-            last_event_sequence = excluded.last_event_sequence,
-            delivered_event_ids_json = excluded.delivered_event_ids_json,
-            created_at = excluded.created_at,
-            updated_at = excluded.updated_at
-        `,
-      )
-      .run(
-        subscription.id,
-        subscription.boardId,
-        bindNull(subscription.cardId),
-        bindNull(subscription.sessionKey),
-        bindNull(subscription.runId),
-        bindNull(subscription.target),
-        jsonValue(subscription.eventKinds),
-        bindNull(subscription.lastEventAt),
-        bindNull(subscription.lastEventId),
-        bindNull(subscription.lastEventSequence),
-        jsonValue(subscription.deliveredEventIds),
-        subscription.createdAt,
-        subscription.updatedAt,
-      );
+    // Cursor fields must bind NULL when omitted, after native preparation succeeds.
+    const { compiled, bind } = compileSqliteQueryBindings<void>((parameter) =>
+      getNodeSqliteKysely<{ workboard_notification_subscriptions: Row }>(this.db)
+        .insertInto("workboard_notification_subscriptions")
+        .values({
+          id: parameter(() => subscription.id),
+          board_id: parameter(() => subscription.boardId),
+          card_id: parameter(() => bindNull(subscription.cardId)),
+          session_key: parameter(() => bindNull(subscription.sessionKey)),
+          run_id: parameter(() => bindNull(subscription.runId)),
+          target: parameter(() => bindNull(subscription.target)),
+          event_kinds_json: parameter(() => jsonValue(subscription.eventKinds)),
+          last_event_at: parameter(() => bindNull(subscription.lastEventAt)),
+          last_event_id: parameter(() => bindNull(subscription.lastEventId)),
+          last_event_sequence: parameter(() => bindNull(subscription.lastEventSequence)),
+          delivered_event_ids_json: parameter(() => jsonValue(subscription.deliveredEventIds)),
+          created_at: parameter(() => subscription.createdAt),
+          updated_at: parameter(() => subscription.updatedAt),
+        })
+        .onConflict((conflict) =>
+          conflict.column("id").doUpdateSet((eb) => ({
+            board_id: eb.ref("excluded.board_id"),
+            card_id: eb.ref("excluded.card_id"),
+            session_key: eb.ref("excluded.session_key"),
+            run_id: eb.ref("excluded.run_id"),
+            target: eb.ref("excluded.target"),
+            event_kinds_json: eb.ref("excluded.event_kinds_json"),
+            last_event_at: eb.ref("excluded.last_event_at"),
+            last_event_id: eb.ref("excluded.last_event_id"),
+            last_event_sequence: eb.ref("excluded.last_event_sequence"),
+            delivered_event_ids_json: eb.ref("excluded.delivered_event_ids_json"),
+            created_at: eb.ref("excluded.created_at"),
+            updated_at: eb.ref("excluded.updated_at"),
+          })),
+        ),
+    );
+    this.db.prepare(compiled.sql).run(...bind());
   }
 
   async lookup(key: string): Promise<PersistedWorkboardNotificationSubscription | undefined> {


### PR DESCRIPTION
Workboard board metadata and notification subscriptions still used handwritten UPSERT strings. Build both mutations with the existing Kysely compile/bind helper while leaving native statement execution with the Workboard SQLite owner.

The mappings keep validation, preparation-before-payload evaluation, parameter and conflict-update ordering, created-at behavior, rowids, and NULL clearing unchanged. In particular, advancing from a sequenced notification to an unsequenced one still clears both the old sequence and legacy delivered-event IDs. Schema declarations, migrations, connection policy, transaction ownership, and public interfaces are unchanged. Production delta is 70 additions / 71 deletions; no permanent test scaffolding or new abstraction.

Validation passed: 184 existing Workboard tests across six store, SQLite, Gateway, CLI, and lifecycle files; full changed gate including both extension typechecks, five doctor-contract tests, three dead-export scans and lint/import guards; explicit Kysely guard. Seventeen full-owner native baseline/candidate scenarios compare complete rows, native errors, binding/getter order, rollback/retry, 72 KiB JSON, count_changes, NULL clearing and physical reopen.

A fresh qaRuntime build and separate UI build passed. The final synthetic real flow passed 18 Gateway RPCs and two real CLI calls across three cleanly stopped/restarted Gateway generations, preserving board metadata and durable cursor clearing. An initial run reached successful mutations but exceeded the smoke controller’s 30-second shutdown bound while startup UI asset work drained; that failed attempt is retained. Preparing UI assets before the final run resolved the incomplete fixture, and the original shutdown bound remained unchanged. This is runtime proof, not a full release build or provider/channel test. No user-visible behavior change is intended.

Fifteen independent P0–P2 review reports are clean. The full reports, actual proof controllers, all 17 complete native case comparisons, and all 7,113 recorded runtime artifact hashes were verified before publication.

## Data-Model Compatibility

The review’s table-change warning is a path-based false positive. The complete schema/bootstrap block is byte-identical to the parent (10,048 bytes, SHA-256 `b000fa72e18cf74f11c51ccb2df341652fd0d55b91660233a65a162fa3c53a23`). There is no table, column, index, migration, schema-version or stored-format change. Existing schema-3 data was reopened through the native and real Gateway/CLI comparisons described above; no migration is needed.
