### PR TITLE
fix: recognize 2026.9.3 plugin security release context

### DIFF
--- a/scripts/lib/plugin-npm-security-scan.mts
+++ b/scripts/lib/plugin-npm-security-scan.mts
@@ -212,6 +212,7 @@ const FROZEN_RELEASE_SECURITY_INVENTORY_POLICIES = new Map<string, PluginSecurit
     },
   ],
   ["release/2026.9.2", CURRENT_SECURITY_INVENTORY_POLICY],
+  ["release/2026.9.3", CURRENT_SECURITY_INVENTORY_POLICY],
   [
     "extended-stable/2026.6.33",
     {

--- a/test/scripts/plugin-npm-security-scan.test.ts
+++ b/test/scripts/plugin-npm-security-scan.test.ts
@@ -215,11 +215,11 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
       "@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/processes.ts",
     ];
 
-    expect(resolveReviewedSourceLayout(current)?.id).toBe("current");
-    expect(resolveReviewedSourceLayout(current, "release/2026.9.1")?.id).toBe("current");
+    for (const context of ["", "release/2026.9.1", "release/2026.9.2", "release/2026.9.3"]) {
+      expect(resolveReviewedSourceLayout(current, context)?.id, context).toBe("current");
+    }
     expect(resolveReviewedSourceLayout(frozenLegacy, "release/2026.9.1")).toBeUndefined();
-    expect(resolveReviewedSourceLayout(current, "release/2026.9.2")?.id).toBe("current");
-    expect(resolveReviewedSourceLayout(current, "release/2026.9.3")).toBeUndefined();
+    expect(resolveReviewedSourceLayout(current, "release/2026.9.4")).toBeUndefined();
     expect(resolveReviewedSourceLayout(frozenLegacy)).toBeUndefined();
     expect(resolveReviewedSourceLayout(frozenLegacy, "extended-stable/2026.6.33")?.id).toBe(
       "extended-stable-2026.6.33",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Full Release Validation for `release/2026.9.3` reports an unknown plugin security layout and rejects all 51 already-reviewed critical findings. The trusted scanner did not recognize the new canonical release context.

## Why This Change Was Made

Register the exact `release/2026.9.3` context against the existing reviewed current policy. The finding inventory, counts, scanner behavior, and rejection of unregistered release contexts remain unchanged. The frozen candidate and original tooling have identical affected source; every logged finding matches the current inventory exactly.

## User Impact

Release operators can validate the frozen 2026.9.3 candidate using repaired trusted tooling without modifying candidate runtime code.

## Evidence

The existing layout regression failed before the repair specifically because `release/2026.9.3` resolved to no layout, then passed after the repair. All 16 plugin security scanner tests pass, including future/unknown-context rejection and inventory mismatch checks. Independent Codex review found no actionable P0–P2 findings.

Original failing workflow: https://github.com/openclaw/openclaw/actions/runs/33991231047/job/101373949191
