### PR TITLE
perf(ui): reuse unchanged transcript key snapshots

### DIFF
--- a/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
+++ b/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
@@ -432,10 +432,10 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     overlay: unknown = nothing,
     header: TranscriptHeader | null = null,
   ): TemplateResult {
-    const nextKeys = rows.map((row) => row.key);
     const rowModelChanged =
-      nextKeys.length !== this.rowKeys.length ||
-      nextKeys.some((key, index) => key !== this.rowKeys[index]);
+      rows.length !== this.rowKeys.length ||
+      rows.some((row, index) => row.key !== this.rowKeys[index]);
+    const nextKeys = rowModelChanged ? rows.map((row) => row.key) : this.rowKeys;
     const virtualizer = this.virtualizerController.getVirtualizer();
     const nextRowKeys = rowModelChanged
       ? nextKeys
@@ -637,7 +637,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     }
   }
 
-  private syncRows(nextKeys: string[]): void {
+  private syncRows(nextKeys: readonly string[]): void {
     const virtualizer = this.virtualizerController.getVirtualizer();
     const typingAdded =
       !this.rowIndexesByKey.has("presence:typing") && nextKeys.includes("presence:typing");


### PR DESCRIPTION
## What Problem This Solves

Resolves avoidable allocation when scrolling or streaming rerenders unchanged transcript rows. Every render previously created a full-history key array before discarding it when the existing immutable snapshot already matched.

## Why This Change Was Made

`ChatSessionVirtualizerHost.render` compares incoming length/order/keys directly with its retained snapshot and maps a new array only when keys change. Same-key content still renders; same-length replacement and reordering still create a fresh snapshot inside the existing MCP unmount gate.

The change preserves the current position rail, offset updates, midpoint lookup, focus, measurement and disposal owners. The rail consumes committed row indexes and current message mappings, not the discarded temporary array. No separate cache or alternate path is added. Production +4/-4 (net zero); tests unchanged.

## User Impact

Unchanged transcript renders avoid one full-history key array while preserving current messages, reader handling and the existing position-rail/MCP lifecycle. The measured result is reduced allocation; timings across the collected comparisons are mixed and do not establish general scrolling speed.

## Evidence

The final source and proof include the upstream position rail, pinned to main `06f5cce42df1175aef7473423c6b3c5e72e82250`. The actual host/Lit probe preserves content updates, committed snapshot identity, same-length reorder and disposal. Its 1,000-render loop runs under jsdom without CSS or DOM commits, so it measures owner allocation rather than layout:

| Loaded rows | Full-history maps before → after | Sampled bytes before → after | Time before → after |
| --- | ---: | ---: | ---: |
| 80 | 1,000 → 0 | 6,155,688 → 5,445,056 | 13.18 → 12.28 ms |
| 1,080 | 1,000 → 0 | 14,525,576 → 5,692,032 | 27.30 → 20.52 ms |
| 5,080 | 1,000 → 0 | 46,617,104 → 5,638,464 | 77.90 → 47.48 ms |

These are cumulative samples on Node 26.8.1/macOS arm64. An earlier frozen-source pair had slower candidate timings at 80 and 1,080 rows (13.07→16.35 and 26.07→38.24 ms), while reducing allocations. Both pairs are descriptive under shared load; no retained-heap, browser RSS, whole-UI or Gateway latency claim follows.

Eight full production Control UI scenarios in Chromium 151.0.7922.34 use synthetic mocked Gateway data and freshly built baseline/candidate bundles. Reader position/content during streaming and initialized MCP draft/focus/teardown behavior match. Ordinary history paging loads 80→1,080 canonical IDs through the real offset-80/limit-1,000 request without duplicates and preserves the reader during prepend.

The dedicated rail case crosses a 4,218 px landmark with native scroll offsets 3,788→3,792→3,788. Active markers change history-24→history-32→history-24 while all 18 rendered keys and range 29–34 remain unchanged. The same focused DOM marker and preview survive. Keyboard reveal and narrow/wide gutter handling also pass in both builds.

| Current full-UI state | Before | After |
| --- | --- | --- |
| Rail midpoint crossing and focus | ![Rail focus before](https://github.com/user-attachments/assets/a12ba58a-716f-4fcc-bae4-4903b29afe5c) | ![Rail focus after](https://github.com/user-attachments/assets/79d907a2-999a-4d5f-a701-fec9ee5956c1) |
| Initialized MCP draft/focus | ![MCP focus before](https://github.com/user-attachments/assets/b0bd77f4-3b93-4128-9b89-bea9cbe9cdb6) | ![MCP focus after](https://github.com/user-attachments/assets/16a6b42b-9dad-424d-aee9-3f76e0efff3e) |
| Streaming while reading | ![Reader before](https://github.com/user-attachments/assets/ff820309-6df2-4d2e-8379-284e24cca4c6) | ![Reader after](https://github.com/user-attachments/assets/2c5dec61-be60-4079-8e71-fceaff07e331) |

Comparison limits are explicit: one offscreen cached 168 px row versus its 120 px estimate accounts for 48 px extent variation in paging/rail captures. Initial paging baseline positioning was 210 px short of the end while the candidate was at the end; its cause remains unknown. A pre-page rail highlight was not classified because that scenario did not capture rail attributes; the dedicated rail case did and passed. No universal geometry or initial-viewport parity is claimed. Follow-up: investigate initial bottom anchoring during paginated startup if reproduced outside this fixture. The original earlier extent discrepancy remains preserved with its separate addendum; its exact differing row was not recovered retrospectively.

```sh
node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-position-rail.test.ts ui/src/pages/chat/components/chat-transcript-controller.test.ts ui/src/pages/chat/components/chat-transcript-invalidation.test.ts ui/src/pages/chat/components/chat-transcript-scroll-ownership.test.ts
pnpm ui:build
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
pnpm tsgo:ui
```

Both current-source checkouts pass all 156 focused tests and UI builds; candidate typed lint, UI typecheck, formatting and diff checks pass. Fresh independent P2 review of this composed source/proof has no findings. The changed-plan record is a dry run, not an executed broad local gate. Required exact-head hosted CI/native landing gates remain mandatory. No live provider/operator Gateway or arbitrary public transcript-permutation flow is claimed.

Additional real-Gateway verification: after the initial Canvas timeout in required CI, the exact failing merge source/tree passed the unchanged Canvas test and the original **25 tests across 14 files** on [Linux Testbox](https://github.com/openclaw/openclaw/actions/runs/33996619412). The run used Node 24.19.0 and system Chromium 144.0.7559.0; the original runner did not record its Chromium version. Both Canvas RPCs, nested heading/input/A2UI behavior, and opaque-origin assertions passed without product, test, timeout, or assertion changes. An initial diagnostic artifact-directory override caused cleanup errors; the accepted group restored the normal in-repository defaults and preserved containment checks. The original timeout was not reproduced and remains unclassified. [Required CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33992634769) then passed at the unchanged PR head.
