### PR TITLE
fix(ci): consume trailer input in merge-authorization fixture

### DIFF
--- a/test/scripts/pr-crabbox-merge-bypass.test.ts
+++ b/test/scripts/pr-crabbox-merge-bypass.test.ts
@@ -412,7 +412,8 @@ else if (endpoint === "graphql" && args.includes("query=query { viewer { login }
       fetch|cat-file|merge-base) exit 0;;
       merge-tree) echo candidate-tree;;
       rev-parse) echo main-tree;;
-      -c) exit 0;;
+      # interpret-trailers drains stdin; an early close can race Node's pipe writer.
+      -c) if [ "$5" = interpret-trailers ]; then cat >/dev/null; fi;;
       *) echo "unexpected fixture git: $*" >&2; exit 19;;
     esac`,
     aws: "exit 19",
@@ -601,9 +602,9 @@ describe("Crabbox authorization before final effects", () => {
         args.includes("orgs/openclaw/memberships/maintainer"),
       );
       const requests = result.calls.filter((args) => args[0] === "pr" && args[1] === "merge");
-      expect(viewers).toHaveLength(reads);
-      expect(memberships).toHaveLength(reads);
-      expect(requests).toHaveLength(merges);
+      expect(viewers, output).toHaveLength(reads);
+      expect(memberships, output).toHaveLength(reads);
+      expect(requests, output).toHaveLength(merges);
       expect(result.calls.some((args) => args.includes("user") || args[0] === "workflow")).toBe(
         false,
       );
@@ -635,6 +636,7 @@ describe("Crabbox authorization before final effects", () => {
         expect(output).toContain("merge-verify passed for PR #131091");
         expect(
           result.calls.filter((args) => args.some((arg) => arg.includes("ref(qualifiedName:"))),
+          output,
         ).toHaveLength(2);
       }
     },


### PR DESCRIPTION
Related: #139354

## What Problem This Solves

Resolves a race in the fake Git used by the merge-authorization CI fixture. The [failed job for #139354](https://github.com/openclaw/openclaw/actions/runs/33989843032/job/101370096772) stopped with one viewer query where the fixture expected two, obscuring an earlier merge-body preparation failure. This is a separate supporting test-only repair.

## Why This Change Was Made

The fake Git's `-c` path exited immediately, including when production `merge-body.mjs` invoked `interpret-trailers` with stdin. Git's real trailer parser consumes that input. Closing the fake child early can race Node's synchronous pipe writer, producing `EPIPE` even with child status zero; production correctly rejects that I/O error through `parsed.error`.

The fixture now consumes stdin specifically for its supported `interpret-trailers` invocation, while its fake log command retains its behavior. Existing viewer, membership, merge-request, and final-observation assertions keep the same expected counts and now include captured failure output. Production trailer parsing, authorization checks, and merge behavior remain intact.

Production: +0/-0 lines; tests: +6/-4 (net +2), confined to `test/scripts/pr-crabbox-merge-bypass.test.ts`. No retry, timeout increase, broader mock, new test seam, or weakened assertion is added.

## User Impact

Maintainers get a fixture that honors Git's stdin contract and exposes useful diagnostics when authorization-path assertions fail. OpenClaw runtime behavior is unchanged, and required CI remains enforced.

## Evidence

The failed job tested GitHub's merge commit containing the newer merge-body path, using Linux x64, Node 24.19.0, and Vitest 5.0.0. The reviewed timer head used the older path; this fixture imports no timer code. The historical job did not retain the suppressed child diagnostic, so its exact syscall remains inferred. The fake-Git race and matching production-compose failure were directly reproduced separately.

Final Linux proof reads the actual patched fixture and runs the exact archived production compose helper with synthetic input:

| Operation | Original fixture | Patched fixture |
| --- | ---: | ---: |
| 1,000 stdin writes | 26 EPIPE errors | 0 errors |
| 100 production compose calls | 8 early failures | 0 failures |

All successful compose results are byte-exact `Reviewed fixture body\n`. These are bounded observations, not universal failure-rate estimates. The isolated, network-disabled Linux container used Node 24.19.0 on **arm64**, whereas historical CI was **x64**; the mechanism was reproduced without claiming an identical hosted environment. An initial probe that failed with EACCES before reaching the pipe operation is excluded.

```sh
node scripts/run-vitest.mjs test/scripts/pr-crabbox-merge-bypass.test.ts
node scripts/run-oxlint.mjs --tsconfig test/tsconfig/tsconfig.test.root.json test/scripts/pr-crabbox-merge-bypass.test.ts
```

All 37 tests pass on Vitest 5.0.0, including non-admin rejection, the successful admin request, and revoked final authority with no request. Type-aware lint, formatting, `git diff --check`, and changed-plan classification pass. Independent P2 review recorded no actionable findings. Broad local gates were not duplicated. [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/33993166030) passed for head `3ca0f6b6620b6cf50be26225451aa801bff1dd48`, and native preparation verified that same unchanged head. The required timer CI still needs a fresh run against the repaired main composition after this supporting change lands; its original failure has not been bypassed or declared green.
