### PR TITLE
fix(agents): name Gateway storage failures in run-failure copy

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -267,6 +267,21 @@ Related:
 - [Local models](/gateway/local-models)
 - [OpenAI-compatible endpoints](/gateway/configuration-reference#openai-compatible-endpoints)
 
+## Agent run failed with a storage error
+
+An error naming the **Gateway state database** identifies a storage failure observed during the run. The chat banner, recorded assistant error, and `embedded_run_agent_end` log show the same diagnosis. Provider response bodies remain redacted.
+
+| SQLite message                                     | Next step                                                                                                      |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `database is locked` or `database table is locked` | Retry. If it repeats, check Gateway logs and concurrent storage maintenance.                                   |
+| `database or disk is full`                         | Free disk space on the Gateway host, then retry.                                                               |
+| `attempt to write a readonly database`             | Check the Gateway service user's storage permissions and filesystem mount mode.                                |
+| `disk I/O error`                                   | Check storage health and filesystem access before retrying. This message alone does not prove disk exhaustion. |
+
+A transcript writer ownership error means the run lost its session write claim. Retry in the current session and inspect Gateway logs if it recurs. Storage failures do not trigger provider credential rotation or automatic replay of the run.
+
+Use `openclaw logs --follow` to correlate the run with storage activity. SQLite can contend between connections or worker threads in one Gateway process; seeing only one process with the database open does not rule out contention. See [database concurrency notes](/reference/database-schemas#integrity-checks). Avoid full database compaction while runs are active.
+
 ## No replies
 
 If channels are up but nothing answers, check routing and policy before reconnecting anything.

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -541,6 +541,10 @@ Memory search and maintenance managers borrow the verified per-agent connection.
 
 The shared cache targets 64 handles, but live borrows, synchronous transactions, and incognito state are not evicted. After owners release them, the next new connection trims idle handles back to that target.
 
+Concurrent runs normally share the cached writer for an agent database on the main thread. Workers and diagnostics can open additional connections to the same file; the connection count is operation-dependent. Canonical agent connections set SQLite's busy timeout before use. A timeout cannot resolve a worker holding a write transaction while waiting for a blocked main thread: synchronous transcript appends do not join the asynchronous session write queue. Transaction callbacks must finish synchronously, and a competing writer must not depend on the main event loop to release its lock.
+
+Periodic agent maintenance uses passive WAL checkpoints and bounded incremental vacuum. Session reclamation currently has a separate worker write connection and post-commit truncating checkpoints and vacuum; it can contend with active transcript writers. Full compaction belongs to offline Doctor maintenance. Run errors naming the Gateway state database retain a safe SQLite diagnosis; see [storage failure troubleshooting](/gateway/troubleshooting#agent-run-failed-with-a-storage-error).
+
 Quarantine decisions live only in a dedicated `openclaw-quarantine.sqlite` store, so they survive damage to the databases being quarantined. Verification results are logged.
 
 Background verification errors retain the original name and message and append bounded Node `code` and SQLite `errcode` values from up to eight cause-chain nodes. These diagnostics do not change the verdict: I/O failures remain inconclusive, while proven corruption is reconfirmed by the database owner before quarantine. A generic `disk I/O error` (`errcode=10`) does not establish disk exhaustion.

--- a/src/agents/embedded-agent-helpers/error-text.ts
+++ b/src/agents/embedded-agent-helpers/error-text.ts
@@ -1,5 +1,6 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { classifyGatewayStorageFailure } from "../../infra/sqlite-error-diagnostics.js";
 import type { AssistantMessage } from "../../llm/types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
@@ -18,7 +19,6 @@ import {
   isTimeoutErrorMessage,
 } from "../failover/classify.js";
 import type { PreparedProviderFailoverOwner } from "../failover/provider-patterns.js";
-import type { FailoverReason } from "../failover/signal.js";
 import {
   AUTH_INVALID_TOKEN_USER_TEXT,
   formatBillingErrorMessage,
@@ -41,6 +41,30 @@ export const GENERIC_ASSISTANT_ERROR_TEXT = "LLM request failed.";
 export const SYNTHESIZED_TIMEOUT_ERROR_TEXT = "LLM request timed out.";
 const MODEL_NOT_FOUND_USER_TEXT =
   "The selected model was not found by the provider. Check the model id or choose a different model.";
+const RUNTIME_FAILURE_COPY: Partial<
+  Record<ReturnType<typeof classifyProviderRuntimeFailureKind>, string>
+> = {
+  auth_refresh: "Authentication refresh failed. Re-authenticate this provider and try again.",
+  refresh_contention:
+    "Authentication refresh is already in progress elsewhere and this attempt timed out waiting for it. Retry in a moment.",
+  refresh_timeout:
+    "Authentication refresh timed out before the provider completed. Retry in a moment; re-authenticate only if it keeps failing.",
+  callback_timeout:
+    "Browser OAuth did not complete before manual fallback kicked in. Retry the login flow and paste the redirect URL if prompted.",
+  callback_validation:
+    "Browser OAuth returned an invalid or incomplete callback. Retry the login flow and make sure the full redirect URL is pasted if prompted.",
+  auth_scope:
+    "Authentication is missing the required OpenAI ChatGPT scopes. Re-run OpenAI login and try again.",
+  auth_html:
+    "Authentication failed at the provider. Re-authenticate and verify your provider credentials and account access.",
+  auth_invalid_token: AUTH_INVALID_TOKEN_USER_TEXT,
+  upstream_html:
+    "The provider returned an HTML error page instead of an API response. This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. Retry in a moment or check provider status.",
+  proxy: "LLM request failed: proxy or tunnel configuration blocked the provider request.",
+  tls_certificate:
+    "LLM request failed: TLS certificate validation rejected the provider endpoint. Check the endpoint hostname, proxy, and local certificate trust.",
+  model_not_found: MODEL_NOT_FOUND_USER_TEXT,
+};
 const TOOL_CALL_INPUT_MISSING_RE =
   /tool_(?:use|call)\.(?:input|arguments).*?(?:field required|required)/i;
 const TOOL_CALL_INPUT_PATH_RE =
@@ -55,17 +79,8 @@ type AssistantErrorTextOptions = {
   /** Credential auth mode; OAuth/token billing copy omits API-key language (#80877). */
   authMode?: string;
 };
-type ClassifiedAssistantErrorFacts = {
-  provider?: string;
-  model?: string;
-  providerRuntimeFailureKind: ReturnType<typeof classifyProviderRuntimeFailureKind>;
-  reason: FailoverReason | null;
-  status?: number;
-};
-function classifyAssistantErrorFacts(
-  msg: AssistantMessage,
-  opts?: AssistantErrorTextOptions,
-): ClassifiedAssistantErrorFacts {
+type ClassifiedAssistantErrorFacts = ReturnType<typeof classifyAssistantErrorFacts>;
+function classifyAssistantErrorFacts(msg: AssistantMessage, opts?: AssistantErrorTextOptions) {
   const signal = buildAssistantFailoverSignal(msg, {
     provider: opts?.providerOwner?.id ?? opts?.provider,
   });
@@ -80,10 +95,11 @@ function classifyAssistantErrorFacts(
       classification?.kind === "reason"
         ? classification.reason
         : classification
-          ? "context_overflow"
+          ? ("context_overflow" as const)
           : null,
     status: signal.status ?? extractErrorHttpStatus(signal.message ?? "")?.code,
     providerRuntimeFailureKind: classifyProviderRuntimeFailureKind(signal, { providerPlugin }),
+    storageFailure: classifyGatewayStorageFailure(msg),
   };
 }
 function isMissingToolCallInputError(raw: string): boolean {
@@ -107,6 +123,9 @@ export function formatAssistantErrorText(
   }
   const formatCopy = renderFormatErrorCopy(raw);
   const classifiedFacts = facts ?? classifyAssistantErrorFacts(msg, opts);
+  if (classifiedFacts.storageFailure) {
+    return renderAssistantRequestFailureCopy(classifiedFacts);
+  }
   const {
     reason: failoverReason,
     status: formatStatus,
@@ -135,66 +154,9 @@ export function formatAssistantErrorText(
   if (diskSpaceCopy) {
     return diskSpaceCopy;
   }
-  if (providerRuntimeFailureKind === "auth_refresh") {
-    return "Authentication refresh failed. Re-authenticate this provider and try again.";
-  }
-  if (providerRuntimeFailureKind === "refresh_contention") {
-    return (
-      "Authentication refresh is already in progress elsewhere and this attempt " +
-      "timed out waiting for it. Retry in a moment."
-    );
-  }
-  if (providerRuntimeFailureKind === "refresh_timeout") {
-    return (
-      "Authentication refresh timed out before the provider completed. " +
-      "Retry in a moment; re-authenticate only if it keeps failing."
-    );
-  }
-  if (providerRuntimeFailureKind === "callback_timeout") {
-    return (
-      "Browser OAuth did not complete before manual fallback kicked in. " +
-      "Retry the login flow and paste the redirect URL if prompted."
-    );
-  }
-  if (providerRuntimeFailureKind === "callback_validation") {
-    return (
-      "Browser OAuth returned an invalid or incomplete callback. " +
-      "Retry the login flow and make sure the full redirect URL is pasted if prompted."
-    );
-  }
-  if (providerRuntimeFailureKind === "auth_scope") {
-    return (
-      "Authentication is missing the required OpenAI ChatGPT scopes. " +
-      "Re-run OpenAI login and try again."
-    );
-  }
-  if (providerRuntimeFailureKind === "auth_html") {
-    return (
-      "Authentication failed at the provider. " +
-      "Re-authenticate and verify your provider credentials and account access."
-    );
-  }
-  if (providerRuntimeFailureKind === "auth_invalid_token") {
-    return AUTH_INVALID_TOKEN_USER_TEXT;
-  }
-  if (providerRuntimeFailureKind === "upstream_html") {
-    return (
-      "The provider returned an HTML error page instead of an API response. " +
-      "This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. " +
-      "Retry in a moment or check provider status."
-    );
-  }
-  if (providerRuntimeFailureKind === "proxy") {
-    return "LLM request failed: proxy or tunnel configuration blocked the provider request.";
-  }
-  if (providerRuntimeFailureKind === "tls_certificate") {
-    return (
-      "LLM request failed: TLS certificate validation rejected the provider endpoint. " +
-      "Check the endpoint hostname, proxy, and local certificate trust."
-    );
-  }
-  if (providerRuntimeFailureKind === "model_not_found") {
-    return MODEL_NOT_FOUND_USER_TEXT;
+  const runtimeCopy = RUNTIME_FAILURE_COPY[providerRuntimeFailureKind];
+  if (runtimeCopy) {
+    return runtimeCopy;
   }
   if (failoverReason === "billing") {
     return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model, opts?.authMode);

--- a/src/agents/embedded-agent-helpers/provider-runtime-failure.ts
+++ b/src/agents/embedded-agent-helpers/provider-runtime-failure.ts
@@ -1,4 +1,5 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { classifyGatewayStorageFailure } from "../../infra/sqlite-error-diagnostics.js";
 import { extractLeadingHttpStatus } from "../../shared/assistant-error-format.js";
 import { extractHttpResponseBody } from "../../shared/http-error-response.js";
 import { classifyOAuthRefreshFailure } from "../auth-profiles/oauth-refresh-failure.js";
@@ -14,6 +15,7 @@ import { matchesFormatErrorPattern, isTimeoutErrorMessage } from "../failover/me
 import type { PreparedProviderFailoverOwner } from "../failover/provider-patterns.js";
 import type { FailoverSignal } from "../failover/signal.js";
 export type ProviderRuntimeFailureKind =
+  | "gateway_storage"
   | "auth_scope"
   | "auth_refresh"
   | "refresh_timeout"
@@ -168,6 +170,9 @@ export function classifyProviderRuntimeFailureKind(
   opts?: { providerPlugin?: PreparedProviderFailoverOwner | null },
 ): ProviderRuntimeFailureKind {
   const normalizedSignal = typeof signal === "string" ? { message: signal } : signal;
+  if (classifyGatewayStorageFailure(normalizedSignal)) {
+    return "gateway_storage";
+  }
   const message = normalizedSignal.message?.trim() ?? "";
   const status = inferSignalStatus(normalizedSignal);
   const hasStructuredErrorSignal = Boolean(normalizedSignal.code || normalizedSignal.errorType);

--- a/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
@@ -272,7 +272,7 @@ describe("handleEmbeddedAssistantFailure", () => {
       assistantProfileFailureReason: null,
       emptyErrorRetries: 0,
     });
-    expect(fixture.input.maybeRetryTransient).not.toHaveBeenCalled();
+    expect(fixture.input.failover.maybeRetryTransient).not.toHaveBeenCalled();
     expect(fixture.advanceAuthProfile).not.toHaveBeenCalled();
     expect(fixture.maybeMarkAuthProfileFailure).not.toHaveBeenCalled();
   });

--- a/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
@@ -258,6 +258,24 @@ async function streamIncompleteMistralResponseOverLoopback() {
 }
 
 describe("handleEmbeddedAssistantFailure", () => {
+  it("surfaces storage failure without replaying the run or rotating credentials", async () => {
+    const fixture = makeExhaustedCredentialFailureInput();
+    fixture.input.attemptAssistant = buildEmbeddedRunnerAssistant({
+      provider: "mock",
+      model: "model",
+      stopReason: "error",
+      errorMessage: "database is locked",
+    });
+    fixture.input.emptyErrorRetries = 0;
+    expect(await handleEmbeddedAssistantFailure(fixture.input)).toMatchObject({
+      action: "proceed",
+      assistantProfileFailureReason: null,
+      emptyErrorRetries: 0,
+    });
+    expect(fixture.input.maybeRetryTransient).not.toHaveBeenCalled();
+    expect(fixture.advanceAuthProfile).not.toHaveBeenCalled();
+    expect(fixture.maybeMarkAuthProfileFailure).not.toHaveBeenCalled();
+  });
   beforeEach(() => {
     providerRuntimeMocks.classifyProviderFailoverSignalWithPlugin.mockReset();
   });

--- a/src/agents/embedded-agent-runner/run/assistant-failure.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.ts
@@ -1,5 +1,6 @@
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
+import { classifyGatewayStorageFailure } from "../../../infra/sqlite-error-diagnostics.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import { isTerminalAssistantError } from "../../../llm/utils/retry.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
@@ -96,6 +97,9 @@ export async function handleEmbeddedAssistantFailure(input: {
   // may drive retries, profile health, or failure copy.
   const failedAssistant =
     input.attemptAssistant?.stopReason === "error" ? input.attemptAssistant : undefined;
+  if (classifyGatewayStorageFailure(failedAssistant)) {
+    return buildOutcome(input, { action: "proceed", assistantProfileFailureReason: null });
+  }
   const {
     aborted,
     externalAbort: projectedExternalAbort,

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -233,6 +233,22 @@ describe("handleAgentEnd", () => {
     });
   });
 
+  it("names storage errors in the terminal event and run log", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(
+      { role: "assistant", stopReason: "error", errorMessage: "database is locked", content: [] },
+      { onAgentEvent },
+    );
+    await handleAgentEnd(ctx);
+    const error =
+      "⚠️ Agent run failed: the Gateway state database was busy (SQLite: database is locked). Retry; if it repeats, check Gateway storage health.";
+    expect(firstWarnMeta(ctx)).toMatchObject({ error, rawErrorPreview: "database is locked" });
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: expect.objectContaining({ phase: "error", error }),
+    });
+  });
+
   it("suppresses raw assistant error messages in user-facing lifecycle events", async () => {
     // Canary text proves provider error strings are sanitized before lifecycle
     // events reach channel integrations.

--- a/src/agents/failover/assistant-request-failure-copy.test.ts
+++ b/src/agents/failover/assistant-request-failure-copy.test.ts
@@ -1,9 +1,62 @@
 import { describe, expect, it } from "vitest";
+import { classifyGatewayStorageFailure } from "../../infra/sqlite-error-diagnostics.js";
+import { formatUserFacingAssistantErrorText } from "../embedded-agent-helpers/error-text.js";
+import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
 import { renderAssistantRequestFailureCopy } from "./assistant-request-failure-copy.js";
 
 describe("renderAssistantRequestFailureCopy", () => {
   const target = { provider: "openai", model: "test-model" };
   const runFailure = "⚠️ Agent run failed (model: openai/test-model).";
+
+  it.each([
+    [{ errcode: 261 }, "SQLITE_BUSY"],
+    [{ errcode: 13, message: "database is locked" }, "SQLITE_FULL"],
+    [{ errstr: "attempt to write a readonly database" }, "SQLITE_READONLY"],
+    [{ errorCode: "SQLITE_IOERR_WRITE", errorMessage: "PRIVATE_CANARY" }, "SQLITE_IOERR"],
+    [{ code: "SQLITE_LOCKED_SHAREDCACHE" }, "SQLITE_LOCKED"],
+    [
+      { errorMessage: "session writer claim changed before transcript persistence" },
+      "transcript_writer_fenced",
+    ],
+  ] as const)("classifies storage facts %j", (error, expected) => {
+    expect(classifyGatewayStorageFailure(error)).toBe(expected);
+    expect(
+      renderAssistantRequestFailureCopy({ storageFailure: classifyGatewayStorageFailure(error) }),
+    ).not.toContain("PRIVATE_CANARY");
+  });
+
+  it.each([
+    ["database is locked", "was busy", "Retry; if it repeats, check Gateway storage health."],
+    ["database or disk is full", "was full", "Free disk space on the Gateway host and retry."],
+    [
+      "attempt to write a readonly database",
+      "was read-only",
+      "Check Gateway storage permissions and retry.",
+    ],
+    [
+      "disk I/O error",
+      "had an I/O error",
+      "Check Gateway storage health and filesystem access before retrying.",
+    ],
+  ])(
+    "names the internal storage failure %s without provider attribution",
+    (errorMessage, detail, nextStep) => {
+      expect(
+        formatUserFacingAssistantErrorText(
+          makeAssistantMessageFixture({ ...target, errorMessage }),
+        ),
+      ).toBe(
+        `⚠️ Agent run failed: the Gateway state database ${detail} (SQLite: ${errorMessage}). ${nextStep}`,
+      );
+    },
+  );
+
+  it("keeps provider bodies containing SQLite text redacted", () => {
+    const errorMessage = '{"error":{"message":"database is locked PRIVATE_CANARY"}}';
+    expect(
+      formatUserFacingAssistantErrorText(makeAssistantMessageFixture({ ...target, errorMessage })),
+    ).toBe(runFailure);
+  });
 
   it.each([undefined, null, "unclassified", "unknown"] as const)(
     "keeps the model as context when reason is %s",

--- a/src/agents/failover/assistant-request-failure-copy.ts
+++ b/src/agents/failover/assistant-request-failure-copy.ts
@@ -1,3 +1,4 @@
+import type { GatewayStorageFailure } from "../../infra/sqlite-error-diagnostics.js";
 import type { FailoverReason } from "./signal.js";
 
 type AssistantRequestFailureCopyFacts = {
@@ -5,6 +6,22 @@ type AssistantRequestFailureCopyFacts = {
   model?: string;
   reason?: FailoverReason | null;
   status?: number;
+  storageFailure?: GatewayStorageFailure;
+};
+
+const STORAGE_FAILURE_COPY: Record<GatewayStorageFailure, string> = {
+  SQLITE_BUSY:
+    "the Gateway state database was busy (SQLite: database is locked). Retry; if it repeats, check Gateway storage health.",
+  SQLITE_LOCKED:
+    "the Gateway state database was locked (SQLite: database table is locked). Retry; if it repeats, check Gateway storage health.",
+  SQLITE_FULL:
+    "the Gateway state database was full (SQLite: database or disk is full). Free disk space on the Gateway host and retry.",
+  SQLITE_READONLY:
+    "the Gateway state database was read-only (SQLite: attempt to write a readonly database). Check Gateway storage permissions and retry.",
+  SQLITE_IOERR:
+    "the Gateway state database had an I/O error (SQLite: disk I/O error). Check Gateway storage health and filesystem access before retrying.",
+  transcript_writer_fenced:
+    "the transcript writer no longer owned this session. Retry in the current session; if it repeats, check Gateway logs.",
 };
 
 const ASSISTANT_REQUEST_FAILURE_REASON = {
@@ -30,6 +47,9 @@ const ASSISTANT_REQUEST_FAILURE_REASON = {
 export function renderAssistantRequestFailureCopy(
   facts: AssistantRequestFailureCopyFacts,
 ): string | undefined {
+  if (facts.storageFailure) {
+    return `⚠️ Agent run failed: ${STORAGE_FAILURE_COPY[facts.storageFailure]}`;
+  }
   const provider = facts.provider?.trim();
   const model = facts.model?.trim();
   const target = provider && model ? `${provider}/${model}` : provider || model;

--- a/src/gateway/chat-display-projection.core.ts
+++ b/src/gateway/chat-display-projection.core.ts
@@ -1,8 +1,10 @@
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty as normalizeErrorSignal } from "@openclaw/normalization-core/string-coerce";
+import { renderAssistantRequestFailureCopy } from "../agents/failover/assistant-request-failure-copy.js";
 import { isContextOverflowError } from "../agents/failover/classify.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { readTranscriptSenderIdentity } from "../chat/sender-identity.js";
+import { classifyGatewayStorageFailure } from "../infra/sqlite-error-diagnostics.js";
 import {
   readNestedToolActivity,
   nestedToolActivityContent,
@@ -136,6 +138,7 @@ function isContextOverflowAssistantError(message: Record<string, unknown>): bool
 function getAssistantErrorFallbackText(message: Record<string, unknown>): string {
   return (
     formatProviderRefusalText(message) ??
+    renderAssistantRequestFailureCopy({ storageFailure: classifyGatewayStorageFailure(message) }) ??
     (isContextOverflowAssistantError(message)
       ? GATEWAY_ASSISTANT_CONTEXT_OVERFLOW_FALLBACK_TEXT
       : GATEWAY_ASSISTANT_ERROR_FALLBACK_TEXT)

--- a/src/gateway/chat-display-projection.provider-owner.test.ts
+++ b/src/gateway/chat-display-projection.provider-owner.test.ts
@@ -19,3 +19,21 @@ it("projects recorded errors without discovering unrelated provider policy", () 
   });
   expect(classifyProviderFailoverSignalWithPlugin).not.toHaveBeenCalled();
 });
+
+it("projects the persisted storage failure with actionable copy", () => {
+  expect(
+    projectChatDisplayMessage({
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "database is locked",
+      content: [],
+    }),
+  ).toMatchObject({
+    content: [
+      {
+        type: "text",
+        text: "⚠️ Agent run failed: the Gateway state database was busy (SQLite: database is locked). Retry; if it repeats, check Gateway storage health.",
+      },
+    ],
+  });
+});

--- a/src/infra/sqlite-error-diagnostics.ts
+++ b/src/infra/sqlite-error-diagnostics.ts
@@ -1,6 +1,39 @@
 import { extractErrorCode } from "@openclaw/normalization-core/error-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 
+const STORAGE_ERRORS = [
+  ["SQLITE_BUSY", "database is locked", 5],
+  ["SQLITE_LOCKED", "database table is locked", 6],
+  ["SQLITE_READONLY", "attempt to write a readonly database", 8],
+  ["SQLITE_IOERR", "disk I/O error", 10],
+  ["SQLITE_FULL", "database or disk is full", 13],
+  ["transcript_writer_fenced", "session writer claim changed before transcript persistence", -1],
+] as const;
+export type GatewayStorageFailure = (typeof STORAGE_ERRORS)[number][0];
+
+/** Classify native errors before flattening; legacy rows require exact known messages. */
+export function classifyGatewayStorageFailure(error: unknown): GatewayStorageFailure | undefined {
+  const fields = typeof error === "string" ? { message: error } : isRecord(error) ? error : {};
+  const code = fields.errorCode ?? fields.code;
+  const nativeCode = fields.errcode;
+  const primaryCode =
+    typeof nativeCode === "number" && Number.isInteger(nativeCode) && nativeCode >= 0
+      ? nativeCode & 0xff
+      : undefined;
+  const typed = STORAGE_ERRORS.find(
+    ([name, , number]) =>
+      primaryCode === number ||
+      (typeof code === "string" &&
+        (code === name || (name.startsWith("SQLITE_") && code.startsWith(`${name}_`)))),
+  );
+  return (typed ??
+    STORAGE_ERRORS.find(([, message]) =>
+      [fields.errstr, fields.errorMessage, fields.message].some(
+        (value) => typeof value === "string" && value.trim() === message,
+      ),
+    ))?.[0];
+}
+
 export function formatSqliteErrorCodeSuffix(error: unknown): string {
   const details = new Set<string>();
   // Preserve native codes through wrappers without exposing cause prose or metadata.

--- a/src/llm/stream.sync-host.test.ts
+++ b/src/llm/stream.sync-host.test.ts
@@ -73,5 +73,17 @@ describe("LLM synchronous stream transport host", () => {
       message,
     ]);
     expect(providerStream).toHaveBeenCalledTimes(2);
+
+    providerStream.mockImplementation(() => {
+      throw Object.assign(new Error("private native detail"), {
+        code: "ERR_SQLITE_ERROR",
+        errcode: 5,
+      });
+    });
+    await expect(stream(boundModel, { messages: [] }).result()).resolves.toMatchObject({
+      stopReason: "error",
+      errorCode: "SQLITE_BUSY",
+      errorMessage: "private native detail",
+    });
   });
 });

--- a/src/llm/stream.ts
+++ b/src/llm/stream.ts
@@ -4,6 +4,7 @@
 // before any caller imports the stream API.
 import { defaultApiRegistry, defaultLlmRuntime } from "@openclaw/ai/internal/runtime";
 import { registerBuiltInApiProviders } from "@openclaw/ai/providers";
+import { classifyGatewayStorageFailure } from "../infra/sqlite-error-diagnostics.js";
 import { getModelLlmRuntime } from "./model-runtime-binding.js";
 import "./ai-transport-host.js";
 import type {
@@ -47,6 +48,7 @@ function createRuntimeHostErrorMessage(model: Model, error: unknown): AssistantM
     },
     stopReason: "error",
     errorMessage: error instanceof Error ? error.message : String(error),
+    errorCode: classifyGatewayStorageFailure(error),
     timestamp: Date.now(),
   };
 }

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -2120,8 +2120,10 @@ describe("handleChatGatewayEvent", () => {
     expect(state.chatRunError).toEqual({ summary: "Error: raw gateway error", runId: "run-1" });
   });
 
-  it("keeps error emoji in live run state for the WebUI presentation owner", () => {
-    const diagnostic = "⚠️ 🛠️ Exec failed (exit 1): command failed.";
+  it.each([
+    "⚠️ 🛠️ Exec failed (exit 1): command failed.",
+    "⚠️ Agent run failed: the Gateway state database was busy (SQLite: database is locked). Retry; if it repeats, check Gateway storage health.",
+  ])("preserves actionable server guidance in live run state: %s", (diagnostic) => {
     const state = createState({ sessionKey: "main", chatRunId: "run-1" });
 
     expect(


### PR DESCRIPTION
## Problem

Chat runs ending with an internal SQLite error displayed only `⚠️ Agent run failed (model: …).`, leaving operators without a cause or next step. The persisted assistant error could contain `database is locked` with empty content and no error code, while both the live failure copy and history projection hid that diagnosis.

## Solution

Classify native SQLite codes before runtime errors are flattened, and recognize exact known SQLite messages in legacy assistant rows. Render fixed storage guidance through the shared failure-copy owner so the chat banner, persisted-row display projection, and lifecycle log name the same failure. Preserve the existing redacted raw-error preview and keep arbitrary provider bodies out of the user-facing copy.

Recognized storage failures terminate without automatic run replay or provider credential rotation. Consolidate the existing repetitive runtime-copy branches into a lookup without changing their wording or precedence. This PR does not change database schema, writer ownership, busy timeouts, or configuration.

## Impact

Operators now see the storage cause and an actionable next step for busy/locked, full, read-only, I/O, and transcript writer ownership failures. The existing banner's Details control reveals the full guidance when the summary is truncated. Existing recorded error rows gain the same display guidance without rewriting transcript bytes.

Production LOC: **+102 −73 (net +29)**. The +29 exception to the neutral-LOC budget is explicitly approved: this adds a new Gateway storage failure classification that reaches the banner, persisted-row projection, and lifecycle log. Consolidating the existing runtime-copy branches partially funds it (the formatter is net −38 lines); the remaining growth carries the classification and typed error through those boundaries. Tests: **+121 −2 (net +119)**. Docs: **+19 −0**.

## Evidence

- Before the fix, the four new SQLite copy cases failed with the original generic model-failure text; 12 existing cases passed.
- `node scripts/run-vitest.mjs src/agents/failover src/agents/embedded-agent-runner/run/assistant-failure src/gateway/chat-display-projection ui/src/pages/chat/chat-gateway src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts src/agents/embedded-agent-helpers/error-text src/llm/stream.sync-host.test.ts` — 345 passing test executions across six shards.
- `node scripts/run-vitest.mjs src/agents/failover/*.test.ts src/gateway/chat-display-projection.provider-owner.test.ts` — 882 passing test executions across three shards. Explicit file expansion covers failover tests skipped by the directory filter above.
- `node scripts/check-changed.mjs` — passed, including core/test typechecking, formatting, lint, and repository guards.
- `pnpm docs:list` and `git diff --check` — passed.
- Codex autoreview through P2 — scoped-clean, no accepted/actionable findings.
- Synthetic mock chat error events, viewport 1100×720, light mode, device scale 2; inspected before/after captures below. No live Gateway validation was performed.

| Before | After (Details expanded) |
| --- | --- |
| ![Generic run failure before](https://github.com/user-attachments/assets/87a6c01f-c8e4-400a-842d-bc28f5fcaf62) | ![Specific Gateway storage failure after](https://github.com/user-attachments/assets/d4296c3b-3b56-4c0f-979b-b20cfdb75455) |

## Follow-up: reclamation lock cycle

An isolated probe reproduced a synchronous transcript append failing with `database is locked` at the existing 5000 ms busy timeout.
The owner chain is `session-manager-persistence.ts` → synchronous transcript append → canonical writer, competing with `session-accessor.sqlite-archive.worker.ts` → reclamation → `session-accessor.sqlite-reclamation-commit.ts`.
Reclamation holds `BEGIN IMMEDIATE` while waiting for main-thread commit authorization; the synchronous append blocks that main thread waiting for the same write lock.
The append failed, then reclamation reported expired commit authorization; this proves a reachable cycle, not attribution of historical runs or a large-database checkpoint failure.
Reclamation also performs separate post-commit truncating checkpoints and unbounded incremental vacuum, which need bounded maintenance ownership.
The proposed design keeps archive preparation off-thread but commits reclamation through the existing canonical writer with synchronous authority validation and bounded page maintenance.
That persistent-store concurrency change requires explicit maintainer approval, including a decision on bounded deletion latency, and is intentionally not implemented here.

Release-note: Show actionable Gateway storage failure reasons in chat run errors, recorded assistant error displays, and lifecycle logs without exposing provider response bodies.
