### PR TITLE
fix(auth): retain selected metadata through account planning

### DIFF
--- a/docs/auth-credential-semantics.md
+++ b/docs/auth-credential-semantics.md
@@ -81,6 +81,8 @@ Do not write `type: "aws-sdk"` into the credential store; stored credentials are
 - A stored profile for that provider that is omitted from the explicit order is not silently tried later. Probe output reports it with `reasonCode: excluded_by_auth_order` and the detail `Excluded by auth.order for this provider.`
 - A valid session user pin is an explicit per-session exception: OpenClaw tries that profile first even when it is omitted from the provider order, then uses the ordered same-provider profiles as retry candidates. A cooldown or disabled window applies only to the affected profile; it does not suppress its eligible siblings.
 
+Prepared agent requests use their selected plugin metadata, configuration, workspace, and environment for auth profile eligibility, ordering, and environment credential evidence. An empty selected plugin set remains authoritative; another request’s plugin aliases cannot add profiles or change the credential owner.
+
 ## Probe target resolution
 
 - Probe targets can come from auth profiles, environment credentials, or `models.json` (result `source`: `profile`, `env`, `models.json`).

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -17,7 +17,7 @@ import {
   resolveTokenExpiryState,
   type AuthCredentialReasonCode,
 } from "./credential-state.js";
-import { dedupeProfileIds, listProfilesForProvider } from "./profile-list.js";
+import { dedupeProfileIds } from "./profile-list.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
 import {
   clearExpiredCooldowns,
@@ -37,8 +37,6 @@ type AuthProfileEligibility = {
   eligible: boolean;
   reasonCode: AuthProfileEligibilityReasonCode;
 };
-
-const OPENAI_PROVIDER_ID = "openai";
 
 function isProfileProviderCompatibleWithAuthProvider(params: {
   cfg?: OpenClawConfig;
@@ -75,12 +73,8 @@ function listProfilesCompatibleWithAuthProvider(params: {
   cfg?: OpenClawConfig;
   authAliasLookupParams?: ProviderAuthAliasLookupParams;
   store: AuthProfileStore;
-  provider: string;
   providerAuthKey: string;
 }): string[] {
-  if (params.providerAuthKey !== OPENAI_PROVIDER_ID) {
-    return listProfilesForProvider(params.store, params.provider);
-  }
   return Object.entries(params.store.profiles)
     .filter(([, credential]) =>
       isProfileProviderCompatibleWithAuthProvider({
@@ -297,7 +291,6 @@ export function resolveAuthProfileOrderWithMetadata(
     cfg,
     authAliasLookupParams: params.authAliasLookupParams,
     store,
-    provider,
     providerAuthKey,
   });
   const baseOrder =

--- a/src/agents/model-auth-env.ts
+++ b/src/agents/model-auth-env.ts
@@ -6,7 +6,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getShellEnvAppliedKeys } from "../infra/shell-env.js";
 import { resolvePluginSetupProviderCore } from "../plugins/setup-registry.js";
 import { resolveLocalProviderAuthEvidence } from "../secrets/provider-auth-evidence.js";
-import type { ProviderAuthEvidence } from "../secrets/provider-env-vars.js";
+import type {
+  ProviderAuthEvidence,
+  ProviderEnvVarLookupParams,
+} from "../secrets/provider-env-vars.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import { resolveProviderEnvAuthLookupMaps } from "./model-auth-env-vars.js";
 import { GCP_VERTEX_CREDENTIALS_MARKER } from "./model-auth-markers.js";
@@ -104,7 +107,7 @@ export function resolveProviderEnvAuthEvidence(
 export function resolveProviderDirectAuthPlanningEvidence(
   provider: string,
   env: NodeJS.ProcessEnv = process.env,
-  options: EnvApiKeyLookupOptions = {},
+  options: EnvApiKeyLookupOptions & Pick<ProviderEnvVarLookupParams, "metadataSnapshot"> = {},
 ): ProviderDirectAuthPlanningEvidence | null {
   const lookupMaps =
     !options.aliasMap ||
@@ -115,6 +118,7 @@ export function resolveProviderDirectAuthPlanningEvidence(
           config: options.config,
           workspaceDir: options.workspaceDir,
           env,
+          metadataSnapshot: options.metadataSnapshot,
         })
       : undefined;
   const aliasMap = options.aliasMap ?? lookupMaps?.aliasMap ?? {};

--- a/src/agents/runtime-plan/auth.ts
+++ b/src/agents/runtime-plan/auth.ts
@@ -42,6 +42,7 @@ export function buildAgentRuntimeAuthPlan(params: {
   credentialSource?: AgentRuntimeAuthPlan["credentialSource"];
   config?: OpenClawConfig;
   workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
   metadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins">;
   providerAuthAliasesEnabled?: boolean;
   harnessId?: string;
@@ -56,6 +57,7 @@ export function buildAgentRuntimeAuthPlan(params: {
   const aliasLookupParams = {
     config: params.config,
     workspaceDir: params.workspaceDir,
+    env: params.env,
     ...(metadataSnapshot ? { metadataSnapshot } : {}),
   };
   const providerForAuth = resolveProviderIdForAuth(params.provider, aliasLookupParams);

--- a/src/agents/runtime-plan/prepare-auth.metadata.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.metadata.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { prepareAgentRuntimeAuth } from "./prepare-auth.js";
+
+function metadata(owner: string) {
+  return createPluginMetadataSnapshotFixture({
+    plugins: [{ id: owner, providerAuthAliases: { "fixture-alias": owner } }],
+  });
+}
+
+describe("prepared auth metadata ownership", () => {
+  it.each([true, false])("uses selected environment evidence (available: %s)", (available) => {
+    const snapshot = (envVar: string) =>
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "fixture-owner",
+            providers: ["fixture-provider"],
+            setup: {
+              requiresRuntime: false,
+              providers: [{ id: "fixture-provider", envVars: [envVar] }],
+            },
+          },
+        ],
+      });
+    const config = {};
+    const prepared = withPluginMetadataSnapshotScope(
+      snapshot("AMBIENT_PROVIDER_KEY"),
+      () =>
+        prepareAgentRuntimeAuth({
+          provider: "fixture-provider",
+          modelId: "model",
+          config,
+          env: available
+            ? { SELECTED_PROVIDER_KEY: "synthetic" }
+            : { AMBIENT_PROVIDER_KEY: "synthetic" },
+          metadataSnapshot: snapshot("SELECTED_PROVIDER_KEY"),
+          authProfileStore: { version: 1, profiles: {} },
+        }),
+      { config, trustConfigIdentity: true },
+    );
+
+    expect(prepared.attempts[0]?.kind).toBe(available ? "direct" : "implicit");
+    expect(prepared.plan.credentialSource).toEqual(
+      available
+        ? { kind: "direct", evidence: "environment", authorization: "ambient" }
+        : { kind: "none" },
+    );
+  });
+
+  it.each(["user", "user-link", "auto", "binding"] as const)(
+    "selects the prepared owner for %s profiles despite ambient aliases",
+    (selection) => {
+      const selected = metadata("selected-auth");
+      const ambient = metadata("ambient-auth");
+      const config: OpenClawConfig =
+        selection === "binding"
+          ? {
+              models: {
+                providers: {
+                  "fixture-alias": { baseUrl: "", models: [], apiKey: "fixture:selected" },
+                },
+              },
+            }
+          : {};
+      const prepare = () =>
+        prepareAgentRuntimeAuth({
+          provider: "fixture-alias",
+          modelId: "model",
+          config,
+          env: {},
+          metadataSnapshot: selected,
+          authProfileStore: {
+            version: 1,
+            profiles: {
+              "fixture:ambient": {
+                type: "api_key",
+                provider: "ambient-auth",
+                key: "synthetic-ambient",
+              },
+              "fixture:selected": {
+                type: "api_key",
+                provider: "selected-auth",
+                key: "synthetic-selected",
+              },
+            },
+          },
+          ...(selection === "user" || selection === "user-link"
+            ? { sessionAuthProfileId: "fixture:selected", sessionAuthProfileSource: selection }
+            : {}),
+        });
+      const prepared = withPluginMetadataSnapshotScope(ambient, prepare, {
+        config,
+        trustConfigIdentity: true,
+      });
+
+      expect(prepared.plan).toMatchObject({
+        providerForAuth: "selected-auth",
+        forwardedAuthProfileId: "fixture:selected",
+        forwardedAuthProfileCandidateIds: ["fixture:selected"],
+      });
+      expect(prepared.attempts.map((attempt) => attempt.profileId)).toEqual(["fixture:selected"]);
+    },
+  );
+
+  it("treats an empty prepared selection as authoritative", () => {
+    const config = {};
+    const prepared = withPluginMetadataSnapshotScope(
+      metadata("ambient-auth"),
+      () =>
+        prepareAgentRuntimeAuth({
+          provider: "fixture-alias",
+          modelId: "model",
+          config,
+          env: {},
+          metadataSnapshot: createPluginMetadataSnapshotFixture(),
+          authProfileStore: {
+            version: 1,
+            profiles: {
+              "fixture:exact": {
+                type: "api_key",
+                provider: "fixture-alias",
+                key: "synthetic-exact",
+              },
+              "fixture:ambient": {
+                type: "api_key",
+                provider: "ambient-auth",
+                key: "synthetic-ambient",
+              },
+            },
+          },
+        }),
+      { config, trustConfigIdentity: true },
+    );
+
+    expect(prepared.attempts.map((attempt) => attempt.profileId)).toEqual(["fixture:exact"]);
+    expect(prepared.plan.forwardedAuthProfileCandidateIds).toEqual(["fixture:exact"]);
+  });
+});

--- a/src/agents/runtime-plan/prepare-auth.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { Model } from "../../llm/types.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import type { AuthProfileStore } from "../auth-profiles.js";
 import { resolveAgentHarnessPreparedAuthSupport } from "../harness/support.js";
 import { getApiKeyForModelCore } from "../model-auth.js";
@@ -131,15 +132,15 @@ describe("prepareAgentRuntimeAuthPlan", () => {
       modelId: "model",
       env: {},
       authProfileStore: authStore({}),
-      metadataSnapshot: {
+      metadataSnapshot: createPluginMetadataSnapshotFixture({
         plugins: [
           {
             id: "alias-owner",
             origin: "bundled",
             providerAuthAliases: { "legacy-provider": "canonical-provider" },
-          } as never,
+          },
         ],
-      },
+      }),
     });
 
     expect(plan.providerForAuth).toBe("canonical-provider");

--- a/src/agents/runtime-plan/prepare-auth.ts
+++ b/src/agents/runtime-plan/prepare-auth.ts
@@ -44,7 +44,7 @@ type PrepareAgentRuntimeAuthPlanParams = {
   env?: NodeJS.ProcessEnv;
   agentDir?: string;
   workspaceDir?: string;
-  metadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins">;
+  metadataSnapshot?: PluginMetadataSnapshot;
   authProfileStore?: AuthProfileStore;
   sessionAuthProfileId?: string;
   sessionAuthProfileSource?: "auto" | "user" | "user-link";
@@ -171,17 +171,13 @@ function resolveProfile(
   };
 }
 
-type ProviderEntryProfileParams = Pick<
-  PrepareAgentRuntimeAuthPlanParams,
-  "config" | "modelId" | "provider"
-> & {
-  store: AuthProfileStore;
-};
-
 /** Applies terminal provider-entry credential policy before route selection. */
-function resolvePreparedProviderEntryApiKeyProfileReference(params: ProviderEntryProfileParams) {
+function resolvePreparedProviderEntryApiKeyProfileReference(
+  params: PrepareAgentRuntimeAuthPlanParams & { store: AuthProfileStore },
+) {
   const reference = resolveProviderEntryApiKeyProfileReference({
     cfg: params.config,
+    authAliasLookupParams: params,
     provider: params.provider,
     store: params.store,
   });
@@ -190,6 +186,7 @@ function resolvePreparedProviderEntryApiKeyProfileReference(params: ProviderEntr
   }
   const eligibility = resolveAuthProfileEligibility({
     cfg: params.config,
+    authAliasLookupParams: params,
     store: params.store,
     provider: params.provider,
     profileId: reference.profileId,
@@ -236,6 +233,7 @@ export function prepareAgentRuntimeAuth(
     const eligibility = store
       ? resolveAuthProfileEligibility({
           cfg: params.config,
+          authAliasLookupParams: params,
           store,
           provider: authProfileSelectionProvider,
           profileId: userPinnedProfileId,
@@ -261,9 +259,7 @@ export function prepareAgentRuntimeAuth(
   const providerBinding =
     harnessAllowsAuthProfileForwarding && !userPinnedProfileId && store && !configuredAwsSdkAuth
       ? resolvePreparedProviderEntryApiKeyProfileReference({
-          config: params.config,
-          modelId: params.modelId,
-          provider: params.provider,
+          ...params,
           store,
         })
       : { kind: "none" as const };
@@ -305,6 +301,7 @@ export function prepareAgentRuntimeAuth(
         }
       : resolveAuthProfileOrderWithMetadata({
           cfg: params.config,
+          authAliasLookupParams: params,
           store,
           provider: authProfileSelectionProvider,
           preferredProfile: requestedProfileId,
@@ -362,6 +359,7 @@ export function prepareAgentRuntimeAuth(
         {
           config: params.config,
           workspaceDir: params.workspaceDir,
+          metadataSnapshot: params.metadataSnapshot,
         },
       )
     : null;
@@ -470,6 +468,7 @@ export function prepareAgentRuntimeAuth(
           ? classifyProviderModelAuthSource(attempt.source)
           : { kind: "none" },
         config: params.config,
+        env: params.env,
         workspaceDir: params.workspaceDir,
         metadataSnapshot: params.metadataSnapshot,
         harnessId: params.harnessId,
@@ -533,6 +532,7 @@ export function prepareAgentRuntimeAuth(
       provider: params.provider,
       modelId: params.modelId,
       config: params.config,
+      env: params.env,
       workspaceDir: params.workspaceDir,
       metadataSnapshot: params.metadataSnapshot,
       harnessId: params.harnessId,
@@ -577,6 +577,7 @@ export function prepareAgentRuntimeAuth(
         : { kind: "none" },
       modelRoute: toPreparedRoute(route),
       config: params.config,
+      env: params.env,
       workspaceDir: params.workspaceDir,
       metadataSnapshot: params.metadataSnapshot,
       harnessId: params.harnessId,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where prepared agent requests could reject a valid pinned account, lose automatic account candidates, or miss an environment credential when another plugin metadata scope was active. An explicitly empty plugin selection could also admit profiles through an unrelated ambient alias.

Related: #130706

## Why This Change Was Made

Auth preparation now uses the selected metadata, configuration, workspace, and environment consistently for profile eligibility, per-provider account bindings, ordering, and direct environment evidence. All providers share the existing scoped credential comparison; the obsolete OpenAI-only discovery fork and scope-stripping helper type are removed. The direct-evidence path receives the complete selected snapshot so installed-plugin eligibility remains intact.

The runtime generation remains the owner of metadata during credential materialization. Existing asynchronous generation scopes carry it across planning, awaits, and provider execution; auth plans remain secret-free decisions. Environment credential values are resolved at use time, allowing rotation without changing the selected variable or auth owner.

## User Impact

Valid selected accounts and environment credentials remain usable even when plugin scopes differ. Empty selections stay authoritative. Auth class compatibility, configured order, user pins, cooldowns, and native OpenAI harness behavior retain their existing rules. No configuration or storage migration is required.

## Evidence

- Seven regressions fail against the original code and pass with the repair: user and linked-user pins, automatic profiles, provider bindings, empty metadata, and selected-versus-ambient environment evidence.
- All 222 focused and sibling tests passed across prepared auth, profile ordering, setup-provider, ambient-credential, OpenAI, provider aliases, workspace trust, and model-auth profile cases.
- Full `pnpm build` passed.
- A real credential-resolver probe crossed an async yield inside the selected runtime generation over a conflicting ambient generation. It resolved only the selected environment variable and picked up a rotated value at use time.
- Isolated Blacksmith Testbox Gateway proof exercised real Anthropic requests for pinned, automatic, provider-bound, and environment auth. The ambient-only environment control issued no provider request; an ordinary Gateway agent turn returned the expected response.
- Independent review is clean through P2. The final live run used the real credential resolver under the selected runtime generation; Gateway and Testbox cleanup are verified. Full `check:changed` passed, including core and test typechecks, lint, all three dead-export scans, and repository guards.

Production delta: +22/-22 (neutral); tests +145/-3; docs +2/-0. This is an independent owner-boundary extraction from the broader work; it does not attribute the original defect to #130706.

Verified commit: `9f32da1c4e21b5e7771c4f3b01a4c6043b1af866`; live source tree: `620e97200a3575cbfa9c8998310b2e0c070336e7`. [Authenticated Testbox proof](https://github.com/openclaw/openclaw/actions/runs/33991332686); wrapper exit 0 and lease cleanup confirmed.

CI follow-through: main already landed the fake Git stdin-consumer repair and long-preview regression in [#139427](https://github.com/openclaw/openclaw/pull/139427) (`aac24c4d96cbc1b4ebdf132df7b89f61060434bc`). This PR retains that implementation and omits the independently prepared duplicate fixture commit. No merge-authority code was changed.

Rebased candidate: `270464536ef1518ae15909084e0bc73469bec595` on frozen main `40ebdadcafa6383e1c6e63c72b1a7a320efd104a`. The entire seven-file auth patch and all postimage blobs are byte-identical to the original live-verified auth commit above; the authenticated proof is retained with its original commit/tree, not represented as a new live run. Rebased verification passed all 296 tests: 222 auth/sibling cases and 74 inherited tooling/attribution cases. Fresh review is clean through P2. Final changed checks passed (exit 0), including typechecks, all Knip scans, lint, and repository guards.

Final exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/33997213783) passed on `270464536ef1518ae15909084e0bc73469bec595`, including the required CI gate.
