### PR TITLE
fix: native archive plugins fail to load when bundle metadata is present

### DIFF
--- a/src/plugins/install-package.ts
+++ b/src/plugins/install-package.ts
@@ -314,11 +314,8 @@ async function installPluginFromPackageDir(
   preparedTarget = await resolvePreparedTargetForPluginId(plugin.pluginId);
   const effectiveMode = preparedTarget.effectiveMode;
   params.onEffectiveMode?.(effectiveMode);
-  const hasBundleManifest = Boolean(runtime.detectBundleManifestFormat(params.packageDir));
   const shouldInstallRuntimeDeps =
-    plugin.hasRuntimeDependencies &&
-    !hasBundleManifest &&
-    params.installPolicyRequest?.kind === "plugin-archive";
+    plugin.hasRuntimeDependencies && params.installPolicyRequest?.kind === "plugin-archive";
 
   return await installPluginDirectoryIntoExtensions(
     copyPluginInstallTransactionRequest(params, {

--- a/src/plugins/install.archive-dependencies.test.ts
+++ b/src/plugins/install.archive-dependencies.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { installPluginFromPath } from "./install.js";
+import { createPluginCache, withPluginCache } from "./plugin-cache.js";
+import { packToArchive } from "./test-helpers/archive-fixtures.js";
+
+const tempDirs = createTempDirTracker();
+afterEach(() => {
+  vi.unstubAllEnvs();
+  tempDirs.cleanup();
+});
+
+it.each(["native", "native with a companion bundle"])(
+  "installs runnable archive dependencies for %s plugins",
+  async (format) => {
+    const rootDir = tempDirs.make("openclaw-archive-dependencies-");
+    const packageDir = path.join(rootDir, "package");
+    const stateDir = path.join(rootDir, "state");
+    const npmConfig = { userconfig: "user.npmrc", globalconfig: "global.npmrc" };
+    for (const [key, name] of Object.entries(npmConfig)) {
+      const file = path.join(rootDir, name);
+      await fs.writeFile(file, "");
+      vi.stubEnv(`npm_config_${key}`, file);
+      vi.stubEnv(`NPM_CONFIG_${key.toUpperCase()}`, file);
+    }
+    for (const [key, value] of Object.entries({
+      offline: "true",
+      cache: path.join(rootDir, "npm-cache"),
+    })) {
+      vi.stubEnv(`npm_config_${key}`, value);
+      vi.stubEnv(`NPM_CONFIG_${key.toUpperCase()}`, value);
+    }
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
+    await fs.mkdir(path.join(packageDir, "dist"), { recursive: true });
+    await fs.mkdir(path.join(packageDir, "dependency"));
+    await fs.writeFile(
+      path.join(packageDir, "dependency/package.json"),
+      JSON.stringify({ name: "archive-dependency", version: "1.0.0", main: "index.cjs" }),
+    );
+    await fs.writeFile(
+      path.join(packageDir, "dependency/index.cjs"),
+      'module.exports = "installed dependency";\n',
+    );
+    await fs.writeFile(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "native-archive",
+        version: "1.0.0",
+        openclaw: { extensions: ["./dist/index.cjs"] },
+        dependencies: { "archive-dependency": "file:./dependency" },
+      }),
+    );
+    await fs.writeFile(
+      path.join(packageDir, "openclaw.plugin.json"),
+      JSON.stringify({ id: "native-archive", configSchema: { type: "object", properties: {} } }),
+    );
+    await fs.writeFile(
+      path.join(packageDir, "dist/index.cjs"),
+      'module.exports = { id: "native-archive", register() {}, value: require("archive-dependency") };\n',
+    );
+    if (format !== "native") {
+      await fs.mkdir(path.join(packageDir, ".claude-plugin"));
+      await fs.writeFile(
+        path.join(packageDir, ".claude-plugin/plugin.json"),
+        JSON.stringify({ name: "companion-bundle" }),
+      );
+    }
+    const archivePath = await packToArchive({
+      pkgDir: packageDir,
+      outDir: rootDir,
+      outName: "native-archive.tgz",
+    });
+    const result = await withPluginCache(createPluginCache(), () =>
+      installPluginFromPath({
+        path: archivePath,
+        extensionsDir: path.join(stateDir, "extensions"),
+        config: {},
+      }),
+    );
+    expect(result.ok, JSON.stringify(result)).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.pluginId).toBe("native-archive");
+    expect(result.artifactInspection?.format).toBe("openclaw");
+    const entryPath = path.join(result.targetDir, "dist/index.cjs");
+    const require = createRequire(entryPath);
+    try {
+      const entry = require(entryPath) as { value: string };
+      expect(entry.value).toBe("installed dependency");
+    } finally {
+      for (const filename of Object.keys(require.cache)) {
+        if (filename.startsWith(`${rootDir}${path.sep}`)) {
+          delete require.cache[filename];
+        }
+      }
+    }
+  },
+);

--- a/src/plugins/install.path.test.ts
+++ b/src/plugins/install.path.test.ts
@@ -1,32 +1,16 @@
 // Covers plugin install path validation and normalization.
 import fs from "node:fs";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { runCommandWithTimeout } from "../process/exec.js";
+import { afterAll, describe, expect, it } from "vitest";
 import { installPluginFromPath, PLUGIN_INSTALL_ERROR_CODE } from "./install.js";
 import { packToArchive } from "./test-helpers/archive-fixtures.js";
 import { createSyncSuiteTempRootTracker } from "./test-helpers/fs-fixtures.js";
-import {
-  createBundleInstallFixtureFactory,
-  createDualFormatInstallFixtureFactory,
-} from "./test-helpers/install-fixtures.js";
-
-vi.mock("../process/exec.js", () => ({
-  runCommandWithTimeout: vi.fn(),
-}));
+import { createBundleInstallFixtureFactory } from "./test-helpers/install-fixtures.js";
 
 const suiteTempRootTracker = createSyncSuiteTempRootTracker("openclaw-plugin-install-path");
 const setupBundleInstallFixture = createBundleInstallFixtureFactory(
   suiteTempRootTracker.makeTempDir,
 );
-const setupDualFormatInstallFixture = createDualFormatInstallFixtureFactory(
-  suiteTempRootTracker.makeTempDir,
-);
-let dualFormatArchiveCase: {
-  nodeModulesExists: boolean;
-  result: Awaited<ReturnType<typeof installPluginFromPath>>;
-  runCalls: unknown[][];
-};
 
 function setupNativePluginInstallFixture() {
   const caseDir = suiteTempRootTracker.makeTempDir();
@@ -56,45 +40,6 @@ function setupNativePluginInstallFixture() {
 
 afterAll(() => {
   suiteTempRootTracker.cleanup();
-});
-
-beforeAll(async () => {
-  const { pluginDir, extensionsDir } = setupDualFormatInstallFixture({
-    bundleFormat: "claude",
-  });
-  const archivePath = path.join(suiteTempRootTracker.makeTempDir(), "dual-format.tgz");
-
-  await packToArchive({
-    pkgDir: pluginDir,
-    outDir: path.dirname(archivePath),
-    outName: path.basename(archivePath),
-  });
-
-  const run = vi.mocked(runCommandWithTimeout);
-  run.mockReset();
-  run.mockResolvedValue({
-    code: 0,
-    stdout: "",
-    stderr: "",
-    signal: null,
-    killed: false,
-    termination: "exit",
-  });
-
-  const result = await installPluginFromPath({
-    path: archivePath,
-    extensionsDir,
-  });
-  dualFormatArchiveCase = {
-    nodeModulesExists: result.ok && fs.existsSync(path.join(result.targetDir, "node_modules")),
-    result,
-    runCalls: [...run.mock.calls],
-  };
-});
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  vi.unstubAllEnvs();
 });
 
 describe("installPluginFromPath", () => {
@@ -224,17 +169,4 @@ describe("installPluginFromPath", () => {
       expect(fs.existsSync(path.join(result.targetDir, manifestPath))).toBe(true);
     },
   );
-
-  it("prefers native package metadata without installing dependencies for dual-format archives", async () => {
-    const { nodeModulesExists, result, runCalls } = dualFormatArchiveCase;
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) {
-      return;
-    }
-    expect(result.pluginId).toBe("native-dual");
-    expect(path.basename(result.targetDir)).toBe("native-dual");
-    expect(runCalls).toHaveLength(0);
-    expect(nodeModulesExists).toBe(false);
-  });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing a native plugin archive saw a successful installation followed by a module-not-found error when the package also shipped a compatible bundle manifest. The installer had skipped the native plugin's runtime dependencies.

## Why This Change Was Made

Native format selection already determines which installation path owns the package. Remove the later bundle check that contradicted that decision, and replace the stale mocked expectation with a real archive, offline npm, and installed-runtime regression.

## User Impact

Native archives with companion bundle manifests now install and reinstall usable dependencies. Bundle-only archives and local directory installs retain their existing behavior.

## Evidence

- Before the fix, the regression passed for a native archive and failed with `MODULE_NOT_FOUND` for its dual-format counterpart after installation reported success.
- `node scripts/run-vitest.mjs src/plugins/install.archive-dependencies.test.ts src/plugins/install.path.test.ts`: **8 passed**, including archive cancellation and bundle/path siblings.
- Full explicit-path `check-changed` gate and canonical `pnpm build` passed under Node 24.19.0.
- Freshly compiled CLI proof passed install, runtime inspection, actual dependency import, reinstall from 1.0.0 to 1.0.1, and uninstall for both package forms: **four runtime outcomes, 19 successful commands**. Fixtures, state, and npm cache were isolated and cleaned.
- Fresh managed Codex review: **scoped-clean through P2**, no findings.

Production LOC: **+1/−4 (net −3)**. Tests: **+105/−70**.
