### PR TITLE
refactor(test): simplify Moonshot catalog assertions

### DIFF
--- a/extensions/moonshot/provider-catalog.test.ts
+++ b/extensions/moonshot/provider-catalog.test.ts
@@ -10,27 +10,12 @@ import {
 type MoonshotProvider = ReturnType<typeof buildMoonshotProvider>;
 type MoonshotModel = MoonshotProvider["models"][number];
 
-function requireMoonshotModel(provider: MoonshotProvider, modelId: string): MoonshotModel {
-  const model = provider.models.find((candidate) => candidate.id === modelId);
-  if (!model) {
-    throw new Error(`expected Moonshot model ${modelId}`);
-  }
-  return model;
-}
-
 function requireFirstMoonshotModel(provider: MoonshotProvider): MoonshotModel {
   const model = provider.models[0];
   if (!model) {
     throw new Error("expected first Moonshot model");
   }
   return model;
-}
-
-function requireMoonshotCompat(model: MoonshotModel): NonNullable<MoonshotModel["compat"]> {
-  if (!model.compat) {
-    throw new Error(`expected Moonshot model ${model.id} compat`);
-  }
-  return model.compat;
 }
 
 describe("moonshot provider catalog", () => {
@@ -44,7 +29,7 @@ describe("moonshot provider catalog", () => {
       "kimi-k2.7-code",
       "kimi-k2.7-code-highspeed",
     ]);
-    expect(requireMoonshotModel(provider, "kimi-k3")).toMatchObject({
+    expect(provider.models.find((model) => model.id === "kimi-k3")).toMatchObject({
       reasoning: true,
       thinkingLevelMap: {
         off: null,
@@ -69,7 +54,7 @@ describe("moonshot provider catalog", () => {
         supportedReasoningEfforts: ["low", "high", "max"],
       },
     });
-    expect(requireMoonshotModel(provider, "kimi-k2.7-code")).toMatchObject({
+    expect(provider.models.find((model) => model.id === "kimi-k2.7-code")).toMatchObject({
       reasoning: true,
       input: ["text", "image"],
       contextWindow: 262144,
@@ -81,7 +66,7 @@ describe("moonshot provider catalog", () => {
         cacheWrite: 0,
       },
     });
-    expect(requireMoonshotModel(provider, "kimi-k2.7-code-highspeed")).toMatchObject({
+    expect(provider.models.find((model) => model.id === "kimi-k2.7-code-highspeed")).toMatchObject({
       reasoning: true,
       input: ["text", "image"],
       contextWindow: 262144,
@@ -97,17 +82,13 @@ describe("moonshot provider catalog", () => {
 
   it("opts native Moonshot baseUrls into streaming usage only inside the extension", () => {
     const defaultProvider = applyMoonshotNativeStreamingUsageCompat(buildMoonshotProvider());
-    expect(
-      requireMoonshotCompat(requireFirstMoonshotModel(defaultProvider)).supportsUsageInStreaming,
-    ).toBe(true);
+    expect(requireFirstMoonshotModel(defaultProvider).compat?.supportsUsageInStreaming).toBe(true);
 
     const cnProvider = applyMoonshotNativeStreamingUsageCompat({
       ...buildMoonshotProvider(),
       baseUrl: MOONSHOT_CN_BASE_URL,
     });
-    expect(
-      requireMoonshotCompat(requireFirstMoonshotModel(cnProvider)).supportsUsageInStreaming,
-    ).toBe(true);
+    expect(requireFirstMoonshotModel(cnProvider).compat?.supportsUsageInStreaming).toBe(true);
 
     const customProvider = applyMoonshotNativeStreamingUsageCompat({
       ...buildMoonshotProvider(),


### PR DESCRIPTION
## What Problem This Solves

Moonshot catalog tests wrap model lookup and compatibility access in local guards even though every remaining consumer immediately makes a stronger assertion. The lookup guard originally protected property dereferences that later catalog edits removed.

## Why This Change Was Made

Match each model lookup directly against the same nonempty expected record, and read the native compatibility flag under the same exact-true assertion. Missing models or flags still fail those assertions.

The first-model presence guard stays: without it, the custom-endpoint negative case could pass on an empty catalog. Its `in` assertion also stays, preserving the distinction between an absent property and a present property with an undefined value.

## User Impact

No production, model-data, configuration, SDK or public-contract change. The sole test-file diff is +5/-24 lines. Both catalog cases and every expected model ID, metadata value and compatibility assertion are retained.

## Evidence

- The complete catalog, onboarding, shared-catalog and implicit-provider suites each passed before and after: 28 cases across four files and the same three project order, on Node24.20.0/pnpm12.3.4/Vitest5.
- An external assertion-only probe using the actual installed Vitest matcher passed 16 contract checks, including missing-record rejection and the retained property-absence distinction. It imported no repository production code and added no committed test.
- The one normal configured [Linux changed-file gate](https://github.com/openclaw/openclaw/actions/runs/33991480320) passed all selected checks, including types, three dead-export scans and lint. Command0 and owned lease/staging/process cleanup are verified. The later optional portal-sync timeout is recorded separately.
- The target, catalog owner, manifest and shared catalog implementation are unchanged between tested main `9c068e13bd187606cac6111d60700f09ef52bd89` and freshly fetched `523d4c1840a7`.

No live provider call is claimed or needed for this test-only assertion cleanup. Before/after timings are correctness evidence, not a performance claim.

Independent Codex subagent review found no actionable P0–P2 findings. The source and patch hashes remained unchanged throughout review.
