### PR TITLE
fix(test): avoid guest exec failures on Parallels 27

### DIFF
--- a/.agents/skills/openclaw-parallels-smoke/SKILL.md
+++ b/.agents/skills/openclaw-parallels-smoke/SKILL.md
@@ -104,6 +104,33 @@ Use this skill for Parallels guest workflows and smoke interpretation. Do not lo
 
 - The Parallels smoke shell scripts should tolerate a literal bare `--` arg so `pnpm test:parallels:* -- --json` and similar forwarded invocations work without needing to call `bash scripts/e2e/...` directly.
 
+## macOS guest-command transport
+
+The macOS smoke and same-guest update lanes route guest commands through
+`scripts/e2e/parallels/parallels-exec.py`; macOS hosts need `python3` with its standard
+library. On the verified Parallels 27.0.0 (58628) Apple-silicon installation, the
+client retains SDK login-job handles through result extraction, avoiding the
+host CLI's intermittent `PrlJob_GetRetCode: Invalid argument` failure. This error
+is not proof that the guest needs reinstallation or another Tools update.
+
+Selection checks the actual `prlctl` on PATH and the installed CLI digest before
+execution. Other binaries retain ordinary `prlctl`; an SDK failure never retries
+through another transport. Root/current-user choice, raw shell-argument joining,
+stdin, stdout/stderr, and guest exit status are preserved. Callers still own shell
+quoting. Snapshot/start/stop/input/capture and Linux/Windows execution are unchanged.
+
+For an already-owned, running macOS guest, the same transport can be checked directly:
+
+```bash
+python3 -B scripts/e2e/parallels/parallels-exec.py --timeout-ms 30000 -- exec "<owned-macos-vm>" --current-user /bin/echo ready
+```
+
+Keep the outer host timeout for complete lanes; the SDK wait deadline is not proof
+of guest-process termination. This is a bounded workaround, not a supported public
+SDK integration. Revalidate ABI and live command/stdio/cleanup behavior before
+adding an installed-binary digest; remove the workaround after a vendor-fixed CLI
+is verified. Restore the original snapshot and stop the guest after ad-hoc proof.
+
 ## macOS flow
 
 - Preferred entrypoint: `pnpm test:parallels:macos`

--- a/scripts/e2e/parallels/guest-transports.ts
+++ b/scripts/e2e/parallels/guest-transports.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from "node:crypto";
 import { sleep } from "../../lib/sleep.mjs";
 import { run } from "./host-command.ts";
+import { runMacosHostCommand } from "./macos-exec.ts";
 import type { PhaseRunner } from "./phase-runner.ts";
 import { encodePowerShell, psSingleQuote } from "./powershell.ts";
 import type { CommandResult } from "./types.ts";
@@ -114,11 +115,15 @@ function appendCommandResult(phases: PhaseRunner, result: CommandResult): void {
   phases.append(result.stderr);
 }
 
-function cleanupPosixGuestScript(phases: PhaseRunner, transportArgs: string[]): void {
+function cleanupPosixGuestScript(
+  phases: PhaseRunner,
+  transportArgs: string[],
+  runCommand: typeof run = run,
+): void {
   try {
     appendCommandResult(
       phases,
-      run("prlctl", transportArgs, {
+      runCommand("prlctl", transportArgs, {
         check: false,
         quiet: true,
         timeoutMs: POSIX_GUEST_SCRIPT_CLEANUP_TIMEOUT_MS,
@@ -823,7 +828,7 @@ export class MacosGuest {
   }
 
   run(args: string[], options: PosixGuestOptions = {}): CommandResult {
-    const result = run("prlctl", this.transportArgs(args, options.env), {
+    const result = runMacosHostCommand("prlctl", this.transportArgs(args, options.env), {
       check: false,
       input: options.input,
       quiet: true,
@@ -844,7 +849,11 @@ export class MacosGuest {
       });
       return this.exec(["/bin/bash", scriptPath], { env });
     } finally {
-      cleanupPosixGuestScript(this.phases, this.transportArgs(["/bin/rm", "-f", scriptPath]));
+      cleanupPosixGuestScript(
+        this.phases,
+        this.transportArgs(["/bin/rm", "-f", scriptPath]),
+        runMacosHostCommand,
+      );
     }
   }
 
@@ -861,6 +870,7 @@ export class MacosGuest {
       label,
       script,
       timeoutMs: remainingTimeoutMs ?? timeoutMs ?? 30 * 60_000,
+      runCommand: runMacosHostCommand,
       transportArgs: (args) => this.transportArgs(args, env),
     });
   }

--- a/scripts/e2e/parallels/macos-exec.ts
+++ b/scripts/e2e/parallels/macos-exec.ts
@@ -1,0 +1,42 @@
+import { fileURLToPath } from "node:url";
+import { clampTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { run } from "./host-command.ts";
+import type { CommandResult, RunOptions } from "./types.ts";
+
+export function resolveMacosPrlctlInvocation(
+  command: string,
+  args: string[],
+  timeoutMs?: number,
+): { command: string; args: string[] } {
+  if (
+    command !== "prlctl" ||
+    args[0] !== "exec" ||
+    process.platform !== "darwin" ||
+    process.arch !== "arm64"
+  ) {
+    return { command, args };
+  }
+  // Select before execution: an SDK failure must never replay a guest command.
+  // The client verifies the installed binary; other versions retain prlctl.
+  const timeoutArgs =
+    timeoutMs === undefined ? [] : ["--timeout-ms", String(clampTimerTimeoutMs(timeoutMs) ?? 1)];
+  return {
+    command: "python3",
+    args: [
+      "-B",
+      fileURLToPath(new URL("./parallels-exec.py", import.meta.url)),
+      ...timeoutArgs,
+      "--",
+      ...args,
+    ],
+  };
+}
+
+export function runMacosHostCommand(
+  command: string,
+  args: string[],
+  options: RunOptions = {},
+): CommandResult {
+  const invocation = resolveMacosPrlctlInvocation(command, args, options.timeoutMs);
+  return run(invocation.command, invocation.args, options);
+}

--- a/scripts/e2e/parallels/macos-smoke.ts
+++ b/scripts/e2e/parallels/macos-smoke.ts
@@ -25,7 +25,6 @@ import {
   resolveLatestVersion,
   resolveProviderAuth,
   resolveSnapshot,
-  run,
   say,
   shouldSkipSnapshotRestore,
   shellQuote,
@@ -44,6 +43,7 @@ import {
 import { MacosGuest } from "./guest-transports.ts";
 import { runSmokeLane, type SmokeLane, type SmokeLaneStatus } from "./lane-runner.ts";
 import { MacosDiscordSmoke } from "./macos-discord.ts";
+import { runMacosHostCommand as run } from "./macos-exec.ts";
 import { resolveMacosVmName, waitForVmStatus } from "./parallels-vm.ts";
 import { PhaseRunner } from "./phase-runner.ts";
 import {

--- a/scripts/e2e/parallels/npm-update-smoke.ts
+++ b/scripts/e2e/parallels/npm-update-smoke.ts
@@ -49,6 +49,7 @@ import {
   type ProviderAuth,
 } from "./common.ts";
 import { runWindowsBackgroundPowerShell } from "./guest-transports.ts";
+import { resolveMacosPrlctlInvocation, runMacosHostCommand } from "./macos-exec.ts";
 import { linuxUpdateScript, macosUpdateScript, windowsUpdateScript } from "./npm-update-scripts.ts";
 import { ensureVmRunning, resolveMacosVmName, resolveUbuntuVmName } from "./parallels-vm.ts";
 import { runParallelsPrerequisiteEval } from "./provider-auth-prerequisite.mjs";
@@ -1176,9 +1177,9 @@ export class NpmUpdateSmoke {
       this.macosVm,
       script,
       "openclaw-parallels-npm-update-macos",
-      { execArgs: macosUpdateExec.execArgs, mode: "700" },
+      { execArgs: macosUpdateExec.execArgs, mode: "700", runCommand: runMacosHostCommand },
     );
-    run(
+    runMacosHostCommand(
       "prlctl",
       ["exec", this.macosVm, "/usr/sbin/chown", macosUpdateExec.ownerUser, scriptPath],
       {
@@ -1186,9 +1187,14 @@ export class NpmUpdateSmoke {
       },
     );
     try {
-      const status = await this.runStreamingToJobLog(
+      const invocation = resolveMacosPrlctlInvocation(
         "prlctl",
         ["exec", this.macosVm, ...macosUpdateExec.execArgs, "/bin/bash", scriptPath],
+        timeoutMs,
+      );
+      const status = await this.runStreamingToJobLog(
+        invocation.command,
+        invocation.args,
         timeoutMs,
         ctx,
       );
@@ -1196,18 +1202,22 @@ export class NpmUpdateSmoke {
         throw new Error(`macOS update command failed with exit code ${status}`);
       }
     } finally {
-      this.removeGuestScript(this.macosVm, scriptPath);
+      this.removeGuestScript(this.macosVm, scriptPath, runMacosHostCommand);
     }
   }
 
   private resolveMacosUpdateExec(ctx: UpdateJobContext): MacosUpdateExec {
     const guestPath =
       "/opt/homebrew/bin:/opt/homebrew/opt/node/bin:/usr/local/bin:/usr/local/sbin:/opt/homebrew/sbin:/usr/bin:/bin:/usr/sbin:/sbin";
-    const currentUser = run("prlctl", ["exec", this.macosVm, "--current-user", "whoami"], {
-      check: false,
-      quiet: true,
-      timeoutMs: 45_000,
-    });
+    const currentUser = runMacosHostCommand(
+      "prlctl",
+      ["exec", this.macosVm, "--current-user", "whoami"],
+      {
+        check: false,
+        quiet: true,
+        timeoutMs: 45_000,
+      },
+    );
     const user = currentUser.stdout.trim().replaceAll("\r", "").split("\n").at(-1) ?? "";
     if (currentUser.status === 0 && /^[A-Za-z0-9._-]+$/.test(user)) {
       return {
@@ -1244,11 +1254,15 @@ export class NpmUpdateSmoke {
 
   private resolveMacosDesktopUser(): string {
     const consoleUser =
-      run("prlctl", ["exec", this.macosVm, "/usr/bin/stat", "-f", "%Su", "/dev/console"], {
-        check: false,
-        quiet: true,
-        timeoutMs: 30_000,
-      })
+      runMacosHostCommand(
+        "prlctl",
+        ["exec", this.macosVm, "/usr/bin/stat", "-f", "%Su", "/dev/console"],
+        {
+          check: false,
+          quiet: true,
+          timeoutMs: 30_000,
+        },
+      )
         .stdout.trim()
         .replaceAll("\r", "")
         .split("\n")
@@ -1260,7 +1274,7 @@ export class NpmUpdateSmoke {
     ) {
       return consoleUser;
     }
-    const users = run(
+    const users = runMacosHostCommand(
       "prlctl",
       ["exec", this.macosVm, "/usr/bin/dscl", ".", "-list", "/Users", "NFSHomeDirectory"],
       { check: false, quiet: true, timeoutMs: 30_000 },
@@ -1282,7 +1296,7 @@ export class NpmUpdateSmoke {
   }
 
   private resolveMacosDesktopHome(user: string): string {
-    const output = run(
+    const output = runMacosHostCommand(
       "prlctl",
       ["exec", this.macosVm, "/usr/bin/dscl", ".", "-read", `/Users/${user}`, "NFSHomeDirectory"],
       { check: false, quiet: true, timeoutMs: 30_000 },
@@ -1344,12 +1358,13 @@ export class NpmUpdateSmoke {
     vm: string,
     script: string,
     prefix: string,
-    options: { execArgs?: string[]; mode?: "700" | "755" } = {},
+    options: { execArgs?: string[]; mode?: "700" | "755"; runCommand?: typeof run } = {},
   ): string {
+    const runCommand = options.runCommand ?? run;
     const execArgs = options.execArgs ?? [];
     const mode = options.mode ?? "755";
     const scriptPath = `/tmp/${prefix}-${randomUUID()}.sh`;
-    const write = run("prlctl", ["exec", vm, ...execArgs, "/usr/bin/tee", scriptPath], {
+    const write = runCommand("prlctl", ["exec", vm, ...execArgs, "/usr/bin/tee", scriptPath], {
       check: false,
       input: script,
       quiet: true,
@@ -1359,24 +1374,28 @@ export class NpmUpdateSmoke {
       throw new Error(`failed to write guest script ${scriptPath}: ${write.stderr.trim()}`);
     }
     try {
-      const chmod = run("prlctl", ["exec", vm, ...execArgs, "/bin/chmod", mode, scriptPath], {
-        check: false,
-        quiet: true,
-        timeoutMs: 30_000,
-      });
+      const chmod = runCommand(
+        "prlctl",
+        ["exec", vm, ...execArgs, "/bin/chmod", mode, scriptPath],
+        {
+          check: false,
+          quiet: true,
+          timeoutMs: 30_000,
+        },
+      );
       if (chmod.status !== 0) {
         throw new Error(`failed to chmod guest script ${scriptPath}: ${chmod.stderr.trim()}`);
       }
     } catch (error) {
-      this.removeGuestScript(vm, scriptPath);
+      this.removeGuestScript(vm, scriptPath, runCommand);
       throw error;
     }
     return scriptPath;
   }
 
-  private removeGuestScript(vm: string, scriptPath: string): void {
+  private removeGuestScript(vm: string, scriptPath: string, runCommand: typeof run = run): void {
     try {
-      run("prlctl", ["exec", vm, "/bin/rm", "-f", scriptPath], {
+      runCommand("prlctl", ["exec", vm, "/bin/rm", "-f", scriptPath], {
         check: false,
         quiet: true,
         timeoutMs: 30_000,

--- a/scripts/e2e/parallels/parallels-exec.py
+++ b/scripts/e2e/parallels/parallels-exec.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Run Parallels smoke commands with the verified 27.0.0 guest-exec ABI.
+
+Usage: parallels-exec.py [--timeout-ms N] -- exec VM [--current-user] COMMAND...
+Like prlctl, COMMAND arguments are joined with spaces; callers own shell quoting,
+including when passing one already-quoted shell command. Stdin is guest data.
+Other hosts/binaries use ordinary prlctl, selected before any guest execution.
+This is a bounded installed-binary workaround, not a supported public SDK client.
+"""
+from __future__ import annotations
+
+import argparse
+import ctypes as C
+from contextlib import ExitStack
+import hashlib
+import math
+import os
+from pathlib import Path
+import platform
+import shutil
+import sys
+import time
+
+APP = Path("/Applications/Parallels Desktop.app/Contents")
+# This digest identifies the verified 27.0.0 CLI and its installed SDK ABI.
+CLI_HASH = "759030a682c31ae71878ab71f1bf1560957ff89308c9de621d1b9bee4b9fcd80"
+DEFAULT_TIMEOUT_MS = 1_800_000
+MAX_TIMEOUT_MS = (1 << 31) - 1
+CLEANUP_TIMEOUT_MS = 5_000
+# Public session selectors, not credentials; host/VM ownership still applies.
+PRIVILEGED = b"531582ac-3dce-446f-8c26-dd7e3384dcf4"
+CURRENT_USER = b"4a5533a7-31c6-4d7a-a400-1f330dc57a9d"
+# PrlCommandsFlags.h: PACF_MAX=10, UUID=1<<(10+1), NAME=1<<(10+2).
+# GetVmConfig searches UUID first, then name when both flags are supplied.
+VM_SEARCH_FLAGS = (1 << 11) | (1 << 12)
+H, R, U, S, I = C.c_void_p, C.c_int, C.c_uint32, C.c_char_p, C.c_int
+HP = C.POINTER(H)
+
+
+def checked(code: int | None, operation: str) -> None:
+    if code:
+        raise RuntimeError(f"{operation}: SDK error 0x{code & 0xffffffff:08x}")
+
+
+def uses_verified_sdk() -> bool:
+    if platform.system() != "Darwin" or platform.machine() != "arm64":
+        return False
+    selected = shutil.which("prlctl")
+    if selected is None:
+        return False
+    try:
+        # Honor PATH-selected fakes/custom installs. The standard prlctl symlink
+        # resolves to this bundle's parallels_wrapper, not its native CLI binary.
+        if Path(selected).resolve(strict=True) not in {
+            APP / "MacOS/prlctl",
+            APP / "MacOS/parallels_wrapper",
+        }:
+            return False
+        digest = hashlib.sha256((APP / "MacOS/prlctl").read_bytes()).hexdigest()
+    except OSError:
+        return False
+    return digest == CLI_HASH
+
+
+class GuestSdk:
+    def __init__(self, deadline: float):
+        library = APP / "Frameworks/ParallelsVirtualizationSDK.framework/Versions/11/libprl_sdk.11.dylib"
+        self.api = C.CDLL(str(library))
+        self.deadline = deadline
+        self.resources = ExitStack()
+        self.cleanup_error: Exception | None = None
+        self.exit_code: int | None = None
+        signatures = {
+            "PrlApi_InitEx": (R, [U, I, U, U]),
+            "PrlApi_Deinit": (R, []),
+            "PrlHandle_Free": (R, [H]),
+            "PrlSrv_Create": (R, [HP]),
+            "PrlLoginParams_Create": (R, [HP]),
+            "PrlLoginParams_SetFlags": (R, [H, U]),
+            "PrlSrv_LoginLocalWithParams": (H, [H, H]),
+            "PrlSrv_Logoff": (H, [H]),
+            "PrlSrv_GetVmConfig": (H, [H, S, U]),
+            "PrlVm_TerminalConnect": (H, [H, U]),
+            "PrlVm_TerminalDisconnect": (R, [H]),
+            "PrlVm_LoginInGuest": (H, [H, S, S, U]),
+            "PrlVmGuest_Logout": (H, [H, U]),
+            "PrlApi_CreateStringsList": (R, [HP]),
+            "PrlVmGuest_RunProgram": (H, [H, S, H, H, U, I, I, I]),
+            "PrlJob_Wait": (R, [H, U]),
+            "PrlJob_GetRetCode": (R, [H, C.POINTER(R)]),
+            "PrlJob_GetResult": (R, [H, HP]),
+            "PrlResult_GetParam": (R, [H, HP]),
+            "PrlJob_GetEvent": (R, [H, HP]),
+            # Verified binary ABI uses an integer event-parameter identifier.
+            "PrlEvent_GetParamByName": (R, [H, U, HP]),
+            "PrlEvtPrm_ToUint32": (R, [H, C.POINTER(U)]),
+        }
+        for name, (result_type, argument_types) in signatures.items():
+            function = getattr(self.api, name)
+            function.restype = result_type
+            function.argtypes = argument_types
+
+    def __enter__(self):
+        checked(self.api.PrlApi_InitEx(0xb0000, 0, 0, 0), "InitEx")
+        self.resources.callback(self.cleanup, self.api.PrlApi_Deinit)
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        # Cleanup gets one bounded reserve even after the command budget expires.
+        # The host process watchdog remains the outer hard cap.
+        self.deadline = time.monotonic() + CLEANUP_TIMEOUT_MS / 1000
+        self.resources.close()
+        if self.cleanup_error is not None:
+            if exc_type is not None or self.exit_code not in (None, 0):
+                print(f"[parallels-exec] cleanup failed: {self.cleanup_error}", file=sys.stderr)
+            else:
+                raise self.cleanup_error
+        return False
+
+    def cleanup(self, function, *args):
+        try:
+            checked(function(*args), function.__name__)
+        except Exception as error:
+            # All remaining releases must run, without replacing the primary error.
+            if self.cleanup_error is None:
+                self.cleanup_error = error
+
+    def own(self, handle):
+        if not handle:
+            raise RuntimeError("SDK returned an invalid handle")
+        self.resources.callback(self.cleanup, self.api.PrlHandle_Free, handle)
+        return handle
+
+    def output(self, function, *args):
+        handle = H()
+        checked(function(*args, C.byref(handle)), function.__name__)
+        return self.own(handle.value)
+
+    def remaining_timeout_ms(self):
+        remaining_ms = math.ceil((self.deadline - time.monotonic()) * 1000)
+        if remaining_ms <= 0:
+            raise TimeoutError("SDK command budget exhausted")
+        return min(remaining_ms, MAX_TIMEOUT_MS)
+
+    def wait(self, job):
+        checked(self.api.PrlJob_Wait(job, self.remaining_timeout_ms()), "PrlJob_Wait")
+        result = R()
+        checked(self.api.PrlJob_GetRetCode(job, C.byref(result)), "PrlJob_GetRetCode")
+        checked(result.value, "job operation")
+
+    def finish(self, job):
+        self.wait(self.own(job))
+
+    def result(self, job):
+        # Retain the job through completion and result extraction. Releasing it
+        # before Wait/GetRetCode is the affected CLI's ownership defect.
+        self.finish(job)
+        result = self.output(self.api.PrlJob_GetResult, job)
+        return self.output(self.api.PrlResult_GetParam, result)
+
+    def cleanup_job(self, function, *args):
+        job = function(*args)
+        if not job:
+            raise RuntimeError("SDK returned an invalid cleanup job")
+        try:
+            self.wait(job)
+        finally:
+            checked(self.api.PrlHandle_Free(job), "PrlHandle_Free")
+
+    def connect(self, vm_name: str):
+        server = self.output(self.api.PrlSrv_Create)
+        login = self.output(self.api.PrlLoginParams_Create)
+        checked(self.api.PrlLoginParams_SetFlags(login, 4), "LoginParams_SetFlags")
+        self.finish(self.api.PrlSrv_LoginLocalWithParams(server, login))
+        self.resources.callback(self.cleanup, self.cleanup_job, self.api.PrlSrv_Logoff, server)
+        vm = self.result(self.api.PrlSrv_GetVmConfig(server, vm_name.encode(), VM_SEARCH_FLAGS))
+        self.finish(self.api.PrlVm_TerminalConnect(vm, 0))
+        self.resources.callback(self.cleanup, self.api.PrlVm_TerminalDisconnect, vm)
+        return vm
+
+    def login_guest(self, vm, current_user: bool):
+        selector = CURRENT_USER if current_user else PRIVILEGED
+        guest = self.result(self.api.PrlVm_LoginInGuest(vm, selector, None, 0))
+        self.resources.callback(self.cleanup, self.cleanup_job, self.api.PrlVmGuest_Logout, guest, 0)
+        return guest
+
+    def run(self, guest, command: str, current_user: bool):
+        args = self.output(self.api.PrlApi_CreateStringsList)
+        env = self.output(self.api.PrlApi_CreateStringsList)
+        # Preserve the verified CLI shell/streaming flags and untouched stdin.
+        flags = 0xb808 | (0x20000 if current_user else 0)
+        self.remaining_timeout_ms()
+        job = self.api.PrlVmGuest_RunProgram(guest, command.encode(), args, env, flags, 0, 1, 2)
+        self.finish(job)
+        event = self.output(self.api.PrlJob_GetEvent, job)
+        parameter = self.output(self.api.PrlEvent_GetParamByName, event, 0x13e)
+        exit_code = U()
+        checked(self.api.PrlEvtPrm_ToUint32(parameter, C.byref(exit_code)), "exit code")
+        self.exit_code = exit_code.value
+        return self.exit_code
+
+
+class Arguments(argparse.ArgumentParser):
+    def error(self, message):
+        # Unsupported auth input may contain credentials; do not echo argv.
+        raise ValueError("invalid wrapper arguments; use --timeout-ms N -- exec VM COMMAND...")
+
+
+def main() -> int:
+    try:
+        parser = Arguments(description=__doc__)
+        parser.add_argument("--timeout-ms", type=int, default=DEFAULT_TIMEOUT_MS)
+        parser.add_argument("prlctl_args", nargs=argparse.REMAINDER)
+        options = parser.parse_args()
+        if not 1 <= options.timeout_ms <= MAX_TIMEOUT_MS:
+            raise ValueError(f"timeout-ms must be between 1 and {MAX_TIMEOUT_MS}")
+        argv = options.prlctl_args
+        if argv[:1] == ["--"]:
+            argv = argv[1:]
+        deadline = time.monotonic() + options.timeout_ms / 1000
+        if not uses_verified_sdk():
+            os.execvp("prlctl", ["prlctl", *argv])
+            raise RuntimeError("prlctl exec unexpectedly returned")
+        if len(argv) < 3 or argv[0] != "exec":
+            raise ValueError("SDK route supports only exec VM [--current-user] COMMAND...")
+        vm_name, command_args = argv[1], argv[2:]
+        if not vm_name or vm_name.startswith("-"):
+            raise ValueError("SDK route requires a VM name or UUID before command options")
+        current_user = command_args[:1] == ["--current-user"]
+        if current_user:
+            command_args = command_args[1:]
+        if not command_args or command_args[0].startswith("-"):
+            raise ValueError("SDK route requires a command; only --current-user is supported")
+        with GuestSdk(deadline) as sdk:
+            vm = sdk.connect(vm_name)
+            guest = sdk.login_guest(vm, current_user)
+            return sdk.run(guest, " ".join(command_args), current_user)
+    except KeyboardInterrupt:
+        print("[parallels-exec] interrupted", file=sys.stderr)
+        code = 130
+    except Exception as error:
+        print(f"[parallels-exec] {error}", file=sys.stderr)
+        code = 125
+    print(f"[parallels-exec] FAILED (exit {code})", file=sys.stderr)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scripts/parallels-exec.test.py
+++ b/test/scripts/parallels-exec.test.py
@@ -1,0 +1,429 @@
+"""Deterministic installed-ABI boundary tests; never load Parallels or contact a VM."""
+from __future__ import annotations
+
+from contextlib import ExitStack, redirect_stderr
+import importlib.util
+import io
+import os
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+CLIENT_PATH = Path(__file__).resolve().parents[2] / "scripts/e2e/parallels/parallels-exec.py"
+spec = importlib.util.spec_from_file_location("parallels_exec", CLIENT_PATH)
+client = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(client)
+
+# Independent constants from the verified installation and official SDK docs.
+VERIFIED_HASH = "759030a682c31ae71878ab71f1bf1560957ff89308c9de621d1b9bee4b9fcd80"
+PRIVILEGED = b"531582ac-3dce-446f-8c26-dd7e3384dcf4"
+CURRENT_USER = b"4a5533a7-31c6-4d7a-a400-1f330dc57a9d"
+
+
+class ExecReplaced(BaseException):
+    """A successful execvp replaces the process rather than returning."""
+
+
+class FakeSdk:
+    """Enforce live-handle ownership at the external C API boundary."""
+
+    def __init__(self, exit_code=0, failure=None, stream=False):
+        self.exit_code = exit_code
+        self.failure = failure
+        self.stream = stream
+        self.now = 100.0
+        self.handles = {}
+        self.freed = []
+        self.events = []
+        self.functions = {}
+        self.next_handle = 1
+        self.initialized = False
+
+    def __getattr__(self, name):
+        if not name.startswith("Prl"):
+            raise AttributeError(name)
+        if name not in self.functions:
+            function = Mock(side_effect=lambda *args: self.call(name, args))
+            function.__name__ = name
+            self.functions[name] = function
+        return self.functions[name]
+
+    def create(self, kind, operation=None):
+        handle = self.next_handle
+        self.next_handle += 1
+        self.handles[handle] = {"kind": kind, "operation": operation, "waited": False}
+        return handle
+
+    def live(self, handle, kind=None):
+        assert handle in self.handles, f"unowned handle {handle}"
+        assert handle not in self.freed, f"released handle {handle}"
+        value = self.handles[handle]
+        if kind is not None:
+            assert value["kind"] == kind, (value, kind)
+        return value
+
+    def output(self, pointer, kind, operation=None):
+        pointer._obj.value = self.create(kind, operation)
+        return 0
+
+    def completed(self, handle):
+        job = self.live(handle, "job")
+        assert job["waited"], "job queried before successful wait"
+        return job["operation"]
+
+    def call(self, name, args):
+        self.events.append((name, args))
+        if name == "PrlApi_InitEx":
+            if self.failure == "init":
+                return 1
+            self.initialized = True
+            return 0
+        assert self.initialized, "API used outside initialized lifetime"
+        if name == "PrlApi_Deinit":
+            assert set(self.freed) == set(self.handles), "handles leaked at deinit"
+            self.initialized = False
+            return 0
+        if name == "PrlHandle_Free":
+            self.live(args[0])
+            self.freed.append(args[0])
+            return 0
+        if name == "PrlSrv_Create":
+            return self.output(args[0], "server")
+        if name == "PrlLoginParams_Create":
+            return self.output(args[0], "login")
+        if name == "PrlLoginParams_SetFlags":
+            self.live(args[0], "login")
+            assert args[1] == 4
+            return 0
+        if name == "PrlSrv_LoginLocalWithParams":
+            self.live(args[0], "server")
+            self.live(args[1], "login")
+            return self.create("job", "host-login")
+        if name == "PrlSrv_GetVmConfig":
+            self.live(args[0], "server")
+            assert args[2] == 0x1800, "must search UUID then name"
+            return self.create("job", "vm")
+        if name == "PrlVm_TerminalConnect":
+            self.live(args[0], "vm")
+            return self.create("job", "terminal")
+        if name == "PrlVm_LoginInGuest":
+            self.live(args[0], "vm")
+            assert args[1] in (PRIVILEGED, CURRENT_USER)
+            assert args[2:] == (None, 0)
+            return self.create("job", "guest")
+        if name == "PrlApi_CreateStringsList":
+            return self.output(args[0], "strings")
+        if name == "PrlVmGuest_RunProgram":
+            self.live(args[0], "guest")
+            self.live(args[2], "strings")
+            self.live(args[3], "strings")
+            assert args[4] in (0xb808, 0x2b808)
+            assert args[5:] == (0, 1, 2)
+            if self.stream:
+                while chunk := os.read(args[5], 65536):
+                    os.write(args[6], chunk)
+                os.write(args[7], b"guest-stderr\n")
+            return self.create("job", "run")
+        if name == "PrlJob_Wait":
+            job = self.live(args[0], "job")
+            assert 1 <= args[1] <= (1 << 31) - 1
+            self.now += 0.25
+            if self.failure == "wait-" + job["operation"]:
+                return 1
+            job["waited"] = True
+            return 0
+        if name == "PrlJob_GetRetCode":
+            operation = self.completed(args[0])
+            args[1]._obj.value = int(self.failure == operation)
+            return 0
+        if name == "PrlJob_GetResult":
+            operation = self.completed(args[0])
+            if self.failure == "result-" + operation:
+                return 1
+            return self.output(args[1], "result", operation)
+        if name == "PrlResult_GetParam":
+            result = self.live(args[0], "result")
+            if self.failure == "param-" + result["operation"]:
+                return 1
+            return self.output(args[1], result["operation"])
+        if name == "PrlJob_GetEvent":
+            assert self.completed(args[0]) == "run"
+            return self.output(args[1], "event")
+        if name == "PrlEvent_GetParamByName":
+            self.live(args[0], "event")
+            assert args[1] == 0x13e
+            return self.output(args[2], "parameter")
+        if name == "PrlEvtPrm_ToUint32":
+            self.live(args[0], "parameter")
+            args[1]._obj.value = self.exit_code
+            return 0
+        if name == "PrlVmGuest_Logout":
+            self.live(args[0], "guest")
+            return self.create("job", "logout")
+        if name == "PrlVm_TerminalDisconnect":
+            self.live(args[0], "vm")
+            return int(self.failure == "disconnect")
+        if name == "PrlSrv_Logoff":
+            self.live(args[0], "server")
+            return self.create("job", "logoff")
+        raise AssertionError(f"unexpected SDK call {name}")
+
+    def calls(self, name):
+        return [args for event, args in self.events if event == name]
+
+    def assert_released(self, test):
+        test.assertEqual(len(self.freed), len(set(self.freed)))
+        test.assertEqual(set(self.freed), set(self.handles))
+        test.assertFalse(self.initialized)
+
+
+def boundaries(
+    fake, argv, system="Darwin", machine="arm64", digest=VERIFIED_HASH,
+    selected="/usr/local/bin/prlctl",
+    resolved="/Applications/Parallels Desktop.app/Contents/MacOS/parallels_wrapper",
+):
+    stack = ExitStack()
+    stack.enter_context(patch.object(sys, "argv", [str(CLIENT_PATH), *argv]))
+    stack.enter_context(patch.object(client.platform, "system", return_value=system))
+    stack.enter_context(patch.object(client.platform, "machine", return_value=machine))
+    stack.enter_context(patch.object(client.shutil, "which", return_value=selected))
+    stack.enter_context(patch.object(Path, "resolve", return_value=Path(resolved)))
+    stack.enter_context(patch.object(Path, "read_bytes", return_value=b"synthetic CLI"))
+    stack.enter_context(patch.object(client.hashlib, "sha256", return_value=Mock(hexdigest=lambda: digest)))
+    stack.enter_context(patch.object(client.C, "CDLL", return_value=fake))
+    stack.enter_context(patch.object(client.time, "monotonic", side_effect=lambda: fake.now))
+    stack.enter_context(patch.object(client.os, "execvp", side_effect=ExecReplaced))
+    return stack
+
+
+class ParallelsExecTests(unittest.TestCase):
+    def invoke(self, fake, args=None):
+        error = io.StringIO()
+        with boundaries(fake, args or ["--", "exec", "Synthetic VM", "/bin/true"]):
+            with redirect_stderr(error):
+                code = client.main()
+            client.os.execvp.assert_not_called()
+        return code, error.getvalue()
+
+    def test_retains_every_handle_through_its_last_use_and_releases_once(self):
+        fake = FakeSdk()
+        self.assertEqual(self.invoke(fake), (0, ""))
+        fake.assert_released(self)
+        names = [name for name, _ in fake.events]
+        self.assertLess(names.index("PrlVmGuest_Logout"), names.index("PrlVm_TerminalDisconnect"))
+        self.assertLess(names.index("PrlVm_TerminalDisconnect"), names.index("PrlSrv_Logoff"))
+        self.assertEqual(names[-1], "PrlApi_Deinit")
+        for owner, logout in [("guest", "PrlVmGuest_Logout"), ("vm", "PrlVm_TerminalDisconnect"), ("server", "PrlSrv_Logoff")]:
+            handle = next(key for key, value in fake.handles.items() if value["kind"] == owner)
+            free_index = next(i for i, event in enumerate(fake.events) if event == ("PrlHandle_Free", (handle,)))
+            self.assertLess(names.index(logout), free_index)
+
+    def test_root_current_user_and_name_uuid_lookup(self):
+        for vm in ["Synthetic VM", "{11111111-2222-3333-4444-555555555555}"]:
+            for current in [False, True]:
+                with self.subTest(vm=vm, current=current):
+                    fake = FakeSdk()
+                    args = ["--", "exec", vm, *(["--current-user"] if current else []), "whoami"]
+                    self.assertEqual(self.invoke(fake, args), (0, ""))
+                    self.assertEqual(fake.calls("PrlSrv_GetVmConfig")[0][1:], (vm.encode(), 0x1800))
+                    self.assertEqual(fake.calls("PrlVm_LoginInGuest")[0][1], CURRENT_USER if current else PRIVILEGED)
+                    self.assertEqual(fake.calls("PrlVmGuest_RunProgram")[0][4], 0x2b808 if current else 0xb808)
+                    fake.assert_released(self)
+
+    def test_preserves_prlctl_raw_shell_argument_semantics(self):
+        cases = [
+            (["/bin/sh -c 'printf \"quoted value\"; exit 7'"], b"/bin/sh -c 'printf \"quoted value\"; exit 7'"),
+            (["/bin/printf", "'%s\\n'", "'two words'", "''", "'$HOME;literal'", "'café'"], b"/bin/printf '%s\\n' 'two words' '' '$HOME;literal' 'caf\xc3\xa9'"),
+            (["/bin/echo", "", "already\\ escaped"], b"/bin/echo  already\\ escaped"),
+        ]
+        for args, expected in cases:
+            with self.subTest(args=args):
+                fake = FakeSdk()
+                self.assertEqual(self.invoke(fake, ["--", "exec", "VM", *args]), (0, ""))
+                self.assertEqual(fake.calls("PrlVmGuest_RunProgram")[0][1], expected)
+
+    def test_passes_binary_stdin_and_separate_output_exit_through_process(self):
+        code = """import runpy, sys
+fixture = runpy.run_path(sys.argv.pop(1))
+fake = fixture['FakeSdk'](exit_code=7, stream=True)
+with fixture['boundaries'](fake, ['--', 'exec', 'Synthetic VM', '/bin/cat']):
+    raise SystemExit(fixture['client'].main())
+"""
+        payload = b"first line\n\x00\xfflast line\n"
+        result = subprocess.run(
+            [sys.executable, "-B", "-c", code, str(Path(__file__).resolve())],
+            input=payload, capture_output=True, timeout=10, check=False,
+        )
+        self.assertEqual(result.returncode, 7)
+        self.assertEqual(result.stdout, payload)
+        self.assertEqual(result.stderr, b"guest-stderr\n")
+
+    def test_unsupported_hosts_or_hash_exec_original_arguments_without_sdk(self):
+        argv = ["exec", "VM with spaces", "--user", "synthetic-user", "/bin/sh -c 'echo ready'"]
+        for system, machine, digest in [("Linux", "arm64", VERIFIED_HASH), ("Darwin", "x86_64", VERIFIED_HASH), ("Darwin", "arm64", "unrecognized")]:
+            with self.subTest(system=system, machine=machine, digest=digest):
+                fake = FakeSdk()
+                with boundaries(fake, ["--timeout-ms", "1000", "--", *argv], system, machine, digest):
+                    with self.assertRaises(ExecReplaced):
+                        client.main()
+                    client.os.execvp.assert_called_once_with("prlctl", ["prlctl", *argv])
+                    client.C.CDLL.assert_not_called()
+                self.assertEqual(fake.events, [])
+
+    def test_custom_or_missing_path_selection_never_loads_default_bundle_sdk(self):
+        argv = ["exec", "Synthetic VM", "--current-user", "/bin/sh -c 'echo ready'"]
+        for selected, resolved in [
+            ("/tmp/synthetic-bin/prlctl", "/tmp/synthetic-bin/prlctl"),
+            ("/usr/local/bin/prlctl", "/opt/custom-parallels/prlctl"),
+            (None, "/Applications/Parallels Desktop.app/Contents/MacOS/parallels_wrapper"),
+        ]:
+            with self.subTest(selected=selected, resolved=resolved):
+                fake = FakeSdk()
+                with boundaries(fake, ["--", *argv], selected=selected, resolved=resolved):
+                    with self.assertRaises(ExecReplaced):
+                        client.main()
+                    client.os.execvp.assert_called_once_with("prlctl", ["prlctl", *argv])
+                    client.C.CDLL.assert_not_called()
+                    Path.read_bytes.assert_not_called()
+                    if selected is None:
+                        Path.resolve.assert_not_called()
+                self.assertEqual(fake.events, [])
+
+    def test_selected_default_cli_or_wrapper_can_use_verified_sdk(self):
+        for executable in ["prlctl", "parallels_wrapper"]:
+            with self.subTest(executable=executable):
+                resolved = f"/Applications/Parallels Desktop.app/Contents/MacOS/{executable}"
+                fake = FakeSdk()
+                with boundaries(fake, ["--", "exec", "VM", "true"], resolved=resolved):
+                    self.assertEqual(client.main(), 0)
+                    client.shutil.which.assert_called_once_with("prlctl")
+                    Path.resolve.assert_called_once_with(strict=True)
+                    client.os.execvp.assert_not_called()
+                fake.assert_released(self)
+
+    def test_missing_cli_uses_prlctl_before_sdk(self):
+        fake = FakeSdk()
+        with boundaries(fake, ["--", "exec", "VM", "true"]):
+            with patch.object(Path, "read_bytes", side_effect=FileNotFoundError):
+                with self.assertRaises(ExecReplaced):
+                    client.main()
+                client.C.CDLL.assert_not_called()
+                client.os.execvp.assert_called_once_with("prlctl", ["prlctl", "exec", "VM", "true"])
+
+    def test_sdk_load_failure_never_falls_back(self):
+        fake = FakeSdk()
+        error = io.StringIO()
+        with boundaries(fake, ["--", "exec", "VM", "true"]):
+            with patch.object(client.C, "CDLL", side_effect=OSError("SDK unavailable")):
+                with redirect_stderr(error):
+                    self.assertEqual(client.main(), 125)
+                client.os.execvp.assert_not_called()
+        self.assertIn("SDK unavailable", error.getvalue())
+        self.assertTrue(error.getvalue().endswith("[parallels-exec] FAILED (exit 125)\n"))
+
+    def test_rejects_unsupported_auth_before_sdk_without_echoing_values(self):
+        for argv in [
+            ["exec", "VM", "--user", "synthetic-secret"],
+            ["exec", "--user", "synthetic-secret", "true"],
+            ["exec", "VM", "--current-user", "--password", "synthetic-secret"],
+            ["exec", "VM", "--current-user"],
+            ["start", "VM"],
+        ]:
+            with self.subTest(argv=argv):
+                fake = FakeSdk()
+                error = io.StringIO()
+                with boundaries(fake, ["--", *argv]):
+                    with redirect_stderr(error):
+                        self.assertEqual(client.main(), 125)
+                    client.C.CDLL.assert_not_called()
+                    client.os.execvp.assert_not_called()
+                self.assertNotIn("synthetic-secret", error.getvalue())
+                self.assertTrue(error.getvalue().endswith("[parallels-exec] FAILED (exit 125)\n"))
+
+    def test_partial_acquisition_failures_release_only_owned_resources(self):
+        for failure in ["init", "host-login", "vm", "result-vm", "param-vm", "terminal", "guest", "result-guest", "param-guest"]:
+            with self.subTest(failure=failure):
+                fake = FakeSdk(failure=failure)
+                self.assertEqual(self.invoke(fake)[0], 125)
+                self.assertEqual(fake.calls("PrlVmGuest_RunProgram"), [])
+                fake.assert_released(self)
+                self.assertEqual(fake.calls("PrlVmGuest_Logout"), [])
+
+    def test_command_error_or_wait_failure_never_replays(self):
+        for failure in ["run", "wait-run"]:
+            with self.subTest(failure=failure):
+                fake = FakeSdk(failure=failure)
+                code, error = self.invoke(fake)
+                self.assertEqual(code, 125)
+                self.assertIn("SDK error", error)
+                self.assertEqual(len(fake.calls("PrlVmGuest_RunProgram")), 1)
+                self.assertEqual(fake.calls("PrlJob_GetEvent"), [])
+                fake.assert_released(self)
+
+    def test_guest_nonzero_and_cleanup_failure_precedence(self):
+        for exit_code in [0, 7]:
+            for failure in [None, "logout", "disconnect", "logoff"]:
+                with self.subTest(exit_code=exit_code, failure=failure):
+                    fake = FakeSdk(exit_code=exit_code, failure=failure)
+                    code, error = self.invoke(fake)
+                    self.assertEqual(code, exit_code if exit_code or failure is None else 125)
+                    if failure and exit_code:
+                        self.assertIn("cleanup failed", error)
+                        self.assertNotIn("FAILED (exit 125)", error)
+                    elif failure:
+                        self.assertTrue(error.endswith("[parallels-exec] FAILED (exit 125)\n"))
+                    else:
+                        self.assertEqual(error, "")
+                    fake.assert_released(self)
+
+    def test_original_sdk_error_survives_cleanup_failure(self):
+        fake = FakeSdk(failure="run")
+        original_call = fake.call
+
+        def with_cleanup_failure(name, args):
+            if name == "PrlVm_TerminalDisconnect":
+                original_call(name, args)
+                return 2
+            return original_call(name, args)
+
+        # Substitute behavior only in the external C API fake, not client methods.
+        fake.call = with_cleanup_failure
+        code, error = self.invoke(fake)
+        self.assertEqual(code, 125)
+        self.assertIn("cleanup failed: PrlVm_TerminalDisconnect: SDK error 0x00000002", error)
+        self.assertIn("[parallels-exec] job operation: SDK error 0x00000001", error)
+        fake.assert_released(self)
+
+    def test_waits_share_monotonic_budget_and_cleanup_uses_bounded_reserve(self):
+        fake = FakeSdk()
+        self.assertEqual(self.invoke(fake), (0, ""))
+        waits = fake.calls("PrlJob_Wait")
+        command_waits = [timeout for handle, timeout in waits if fake.handles[handle]["operation"] not in ("logout", "logoff")]
+        cleanup_waits = [timeout for handle, timeout in waits if fake.handles[handle]["operation"] in ("logout", "logoff")]
+        self.assertEqual(command_waits, [1_800_000, 1_799_750, 1_799_500, 1_799_250, 1_799_000])
+        self.assertEqual(cleanup_waits, [5000, 4750])
+
+    def test_exhausted_budget_does_not_launch_command_and_still_cleans_up(self):
+        fake = FakeSdk()
+        code, error = self.invoke(fake, ["--timeout-ms", "1000", "--", "exec", "VM", "true"])
+        self.assertEqual(code, 125)
+        self.assertIn("budget exhausted", error)
+        self.assertEqual(fake.calls("PrlVmGuest_RunProgram"), [])
+        self.assertEqual(len(fake.calls("PrlVmGuest_Logout")), 1)
+        fake.assert_released(self)
+
+    def test_timeout_bounds_are_checked_before_side_effects(self):
+        for timeout in ["0", "-1", "2147483648", "not-a-number"]:
+            with self.subTest(timeout=timeout):
+                fake = FakeSdk()
+                self.assertEqual(self.invoke(fake, ["--timeout-ms", timeout, "--", "exec", "VM", "true"])[0], 125)
+                self.assertEqual(fake.events, [])
+        fake = FakeSdk()
+        self.assertEqual(self.invoke(fake, ["--timeout-ms", "2147483647", "--", "exec", "VM", "true"]), (0, ""))
+        self.assertEqual(fake.calls("PrlJob_Wait")[0][1], 2147483647)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/scripts/parallels-exec.test.ts
+++ b/test/scripts/parallels-exec.test.ts
@@ -1,0 +1,82 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveMacosPrlctlInvocation,
+  runMacosHostCommand,
+} from "../../scripts/e2e/parallels/macos-exec.ts";
+
+const host = vi.hoisted(() => ({ run: vi.fn() }));
+vi.mock("../../scripts/e2e/parallels/host-command.ts", () => host);
+
+function useHost(platform: NodeJS.Platform, arch = "arm64") {
+  vi.stubGlobal("process", { ...process, platform, arch });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("macOS Parallels execution boundary", () => {
+  it("preserves VM, command arguments, stdin, and the caller budget without replay", () => {
+    useHost("darwin");
+    const args = ["exec", "Synthetic VM", "--current-user", "/bin/sh -c 'exit 7'"];
+    const options = { check: false, input: "guest input\n", timeoutMs: 45_000 };
+    const result = { status: 7, stdout: "executed once\n", stderr: "guest error\n" };
+    host.run.mockReturnValue(result);
+
+    expect(runMacosHostCommand("prlctl", args, options)).toBe(result);
+    expect(host.run).toHaveBeenCalledExactlyOnceWith(
+      "python3",
+      [
+        "-B",
+        fileURLToPath(new URL("../../scripts/e2e/parallels/parallels-exec.py", import.meta.url)),
+        "--timeout-ms",
+        "45000",
+        "--",
+        ...args,
+      ],
+      options,
+    );
+  });
+
+  it.each([
+    ["linux", "arm64", "prlctl", ["exec", "Linux VM", "true"]],
+    ["win32", "x64", "prlctl", ["exec", "Windows VM", "whoami"]],
+    ["darwin", "x64", "prlctl", ["exec", "Intel VM", "true"]],
+    ["darwin", "arm64", "prlctl", ["snapshot-switch", "VM", "--id", "snapshot"]],
+    ["darwin", "arm64", "prlctl", ["capture", "VM", "--file", "proof.png"]],
+    ["darwin", "arm64", "git", ["rev-parse", "HEAD"]],
+  ] as const)("leaves %s/%s %s %j unchanged", (platform, arch, command, args) => {
+    useHost(platform, arch);
+    expect(resolveMacosPrlctlInvocation(command, [...args], 1000)).toEqual({
+      command,
+      args,
+    });
+  });
+
+  it("propagates a transport timeout without running a second client", () => {
+    useHost("darwin");
+    const error = new Error("transport timed out after output");
+    host.run.mockImplementationOnce(() => {
+      throw error;
+    });
+    expect(() => runMacosHostCommand("prlctl", ["exec", "VM", "true"])).toThrow(error);
+    expect(host.run).toHaveBeenCalledTimes(1);
+  });
+});
+
+it.skipIf(process.platform === "win32")(
+  "enforces SDK ownership, stdio, selection, and cleanup contracts without a real VM",
+  () => {
+    const fixture = fileURLToPath(new URL("./parallels-exec.test.py", import.meta.url));
+    const result = spawnSync("python3", ["-B", fixture], {
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toMatch(/\nOK\n/u);
+  },
+);

--- a/test/scripts/parallels-npm-update-smoke.test.ts
+++ b/test/scripts/parallels-npm-update-smoke.test.ts
@@ -432,13 +432,17 @@ exit 1
     expect(log.match(/^cleanup$/gm)).toHaveLength(1);
   });
 
-  it("uses one macOS guest identity to write and execute update scripts", async () => {
-    const root = tempDirs.make("openclaw-parallels-npm-update-");
-    const logPath = path.join(root, "prlctl.log");
-    const prlctlPath = path.join(root, "prlctl");
-    writeFileSync(
-      prlctlPath,
-      `#!/usr/bin/env bash
+  it.each([0, 7])(
+    "uses one macOS guest identity through upload, streamed exit %i, and cleanup",
+    async (exitCode) => {
+      const root = tempDirs.make("openclaw-parallels-npm-update-");
+      const logPath = path.join(root, "prlctl.log");
+      const runArgsPath = path.join(root, "run-args");
+      const uploadedScriptPath = path.join(root, "uploaded-script");
+      const prlctlPath = path.join(root, "prlctl");
+      writeFileSync(
+        prlctlPath,
+        `#!/usr/bin/env bash
 set -euo pipefail
 log_path=${JSON.stringify(logPath)}
 printf '%s\\n' "$*" >>"$log_path"
@@ -448,7 +452,7 @@ if [[ "$args" == *" --current-user whoami "* ]]; then
   exit 0
 fi
 if [[ "$args" == *" /usr/bin/tee /tmp/openclaw-parallels-npm-update-macos-"* ]]; then
-  cat >/dev/null
+  cat >${JSON.stringify(uploadedScriptPath)}
   exit 0
 fi
 if [[ "$args" == *" /bin/chmod 700 /tmp/openclaw-parallels-npm-update-macos-"* ]]; then
@@ -457,62 +461,86 @@ fi
 if [[ "$args" == *" /usr/sbin/chown desktop-user /tmp/openclaw-parallels-npm-update-macos-"* ]]; then
   exit 0
 fi
+if [[ "$args" == *" /bin/bash /tmp/openclaw-parallels-npm-update-macos-"* ]]; then
+  printf '%s\\0' "$@" >${JSON.stringify(runArgsPath)}
+  printf 'update-output\\n'
+  printf 'update-diagnostic\\n' >&2
+  exit ${exitCode}
+fi
 if [[ "$args" == *" /bin/rm -f /tmp/openclaw-parallels-npm-update-macos-"* ]]; then
   exit 0
 fi
 exit 1
 `,
-    );
-    chmodSync(prlctlPath, 0o755);
+      );
+      chmodSync(prlctlPath, 0o755);
+      const output: string[] = [];
 
-    await withEnvAsync(
-      {
-        OPENAI_API_KEY: "test-key",
-        PATH: `${root}${path.delimiter}${process.env.PATH ?? ""}`,
-      },
-      async () => {
-        const smoke = new NpmUpdateSmoke({
-          ...TEST_AUTH,
-          dependencyTarballs: [],
-          registryPackageTarballs: [],
-          json: false,
-          packageSpec: "openclaw@latest",
-          platforms: new Set<Platform>(["macos"]),
-          provider: "openai",
-          updateTarget: "local-main",
-        });
-        const stream = vi.fn().mockResolvedValue(0);
-        Reflect.set(smoke, "runStreamingToJobLog", stream);
-        const guestMacos = Reflect.get(smoke, "guestMacos") as (
-          script: string,
-          timeoutMs: number,
-          ctx: { append: (chunk: string) => void },
-        ) => Promise<void>;
-        const ctx = { append: vi.fn() };
+      await withEnvAsync(
+        {
+          OPENAI_API_KEY: "test-key",
+          PATH: `${root}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+        async () => {
+          const smoke = new NpmUpdateSmoke({
+            ...TEST_AUTH,
+            dependencyTarballs: [],
+            registryPackageTarballs: [],
+            json: false,
+            packageSpec: "openclaw@latest",
+            platforms: new Set<Platform>(["macos"]),
+            provider: "openai",
+            updateTarget: "local-main",
+          });
+          const guestMacos = Reflect.get(smoke, "guestMacos") as (
+            script: string,
+            timeoutMs: number,
+            ctx: {
+              append: (chunk: string | Uint8Array) => void;
+              logPath: string;
+              signal: AbortSignal;
+            },
+          ) => Promise<void>;
+          const result = guestMacos.call(smoke, "echo update", 30_000, {
+            append: (chunk) =>
+              output.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8")),
+            logPath: path.join(root, "update.log"),
+            signal: new AbortController().signal,
+          });
+          if (exitCode === 0) {
+            await expect(result).resolves.toBeUndefined();
+          } else {
+            await expect(result).rejects.toThrow(
+              `macOS update command failed with exit code ${exitCode}`,
+            );
+          }
+        },
+      );
 
-        await guestMacos.call(smoke, "echo update", 30_000, ctx);
-
-        const call = stream.mock.calls.at(0);
-        expect(call?.[0]).toBe("prlctl");
-        expect(call?.[1]).toEqual([
-          "exec",
-          "macOS Tahoe",
-          "--current-user",
-          "/usr/bin/env",
-          expect.stringMatching(/^PATH=/),
-          "/bin/bash",
-          expect.stringMatching(/^\/tmp\/openclaw-parallels-npm-update-macos-/),
-        ]);
-      },
-    );
-
-    const log = readFileSync(logPath, "utf8");
-    expect(log).toContain("--current-user whoami");
-    expect(log).toContain("--current-user /usr/bin/env PATH=");
-    expect(log).toContain("/usr/bin/tee /tmp/openclaw-parallels-npm-update-macos-");
-    expect(log).toContain("/bin/chmod 700 /tmp/openclaw-parallels-npm-update-macos-");
-    expect(log).toContain("/usr/sbin/chown desktop-user");
-  });
+      expect(readFileSync(runArgsPath, "utf8").split("\0").slice(0, -1)).toEqual([
+        "exec",
+        "macOS Tahoe",
+        "--current-user",
+        "/usr/bin/env",
+        expect.stringMatching(/^PATH=/),
+        "/bin/bash",
+        expect.stringMatching(/^\/tmp\/openclaw-parallels-npm-update-macos-/),
+      ]);
+      expect(readFileSync(uploadedScriptPath, "utf8")).toBe("echo update");
+      expect(output.join("")).toContain("update-output\n");
+      expect(output.join("")).toContain("update-diagnostic\n");
+      const log = readFileSync(logPath, "utf8");
+      expect(log).toContain("--current-user whoami");
+      expect(log).toContain("--current-user /usr/bin/env PATH=");
+      expect(log).toContain("/usr/bin/tee /tmp/openclaw-parallels-npm-update-macos-");
+      expect(log).toContain("/bin/chmod 700 /tmp/openclaw-parallels-npm-update-macos-");
+      expect(log).toContain("/usr/sbin/chown desktop-user");
+      expect(log.match(/\/bin\/bash \/tmp\/openclaw-parallels-npm-update-macos-/g)).toHaveLength(1);
+      expect(log.trim().split("\n").at(-1)).toMatch(
+        /^exec macOS Tahoe \/bin\/rm -f \/tmp\/openclaw-parallels-npm-update-macos-/,
+      );
+    },
+  );
 
   it("has a one-command beta validation mode with fresh target coverage", () => {
     const script = readFileSync(SCRIPT_PATH, "utf8");
@@ -1406,16 +1434,6 @@ exit 7
         );
       },
     );
-  });
-
-  it("writes macOS update scripts through the desktop user transport", () => {
-    const script = readFileSync(SCRIPT_PATH, "utf8");
-
-    expect(script).toContain("const macosUpdateExec = this.resolveMacosUpdateExec(ctx)");
-    expect(script).toContain('{ execArgs: macosUpdateExec.execArgs, mode: "700" }');
-    expect(script).toContain('["exec", vm, ...execArgs, "/usr/bin/tee", scriptPath]');
-    expect(script).toContain('["exec", vm, ...execArgs, "/bin/chmod", mode, scriptPath]');
-    expect(script).toContain("ownerUser: user");
   });
 
   it("scrubs future plugin entries before invoking old same-guest updaters", () => {


### PR DESCRIPTION
Closes #139303
Related: #136157 (native browser-sidebar proof was blocked by this transport failure).

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled through this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where maintainers running macOS Parallels smoke checks intermittently lose guest-command execution on Parallels Desktop 27.0.0, even though the guest is running and its Tools are installed. The resulting `PrlJob_GetRetCode: Invalid argument` errors can block native proof and install/update validation.

This is test infrastructure only, not an OpenClaw runtime defect.

## Why This Change Was Made

The affected host CLI releases its guest-login job before reading its result. The macOS harness now selects a narrowly guarded client of the same installed SDK that retains every owned handle through its final use. Selection happens before execution: only the verified Apple-silicon default installation/digest is eligible, custom or other binaries retain their existing `prlctl` path, and a failed SDK attempt never replays a command through another transport.

The same macOS execution boundary covers readiness/user probes, uploads, normal commands, background setup/poll/cleanup, and streamed same-guest updates. It preserves the existing caller-selected root/current-user/sudo context, raw shell-argument contract, stdin, separate stdout/stderr, nonzero guest exit codes, monotonic command budget, and bounded cleanup. Lifecycle, input, capture, Linux, and Windows operations remain unchanged.

Python uses its standard library only. No vendor binary patch, host service restart, guest reinstall, SSH provisioning, package dependency, product configuration, or persistent store change is introduced. The SDK is no longer a supported public integration, so this remains a verified-binary workaround to retire after a vendor-fixed CLI is proven.

## User Impact

No end-user runtime behavior changes. Maintainers can use the existing macOS smoke entrypoints without timing-based command retries or modifications to their Parallels installation. The owning smoke skill documents automatic selection, the direct diagnostic command, quoting/timeout semantics, and removal criteria.

Production runtime LOC: **0**. Test tooling: **+351/-31 (net +320)**, primarily the dependency-free native-ABI client and its owner routing. Tests: **+596/-67 (net +529)**. Guidance: **+27/-0**. The existing macOS update test now exercises the real streaming executable boundary for success and exit 7; a redundant source-string assertion was removed.

## Evidence

- Refreshed head: `6c268554814ac4916f11784af67dd6f8637030ab`, rebased onto the landed fixture repair `9532052c47d87c2d2ea3eb7161bf49b7b8d18d52`. All nine PR-owned files remain **byte-identical** to the live-proven head below; no VM rerun is claimed for this mechanical refresh.
- Original-order verification of the shared CI fixture repair: `node scripts/run-vitest.mjs src/skills/lifecycle/clawhub.test.ts` (**117 passed**), followed on the same filesystem by `node scripts/run-vitest.mjs src/agents/sandbox/browser.create.test.ts` (**27 passed**), then the six-file Parallels/planner/inventory suite below (**214 passed**). No shared-directory deletion, hash weakening, or sandbox runtime change was used.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs test/scripts/ci-node-test-plan.test.ts test/scripts/type-suppression-inventory.test.ts test/scripts/parallels-exec.test.ts test/scripts/parallels-npm-update-smoke.test.ts test/scripts/parallels-smoke-model.test.ts test/scripts/parallels-phase-runner.test.ts` — **214 tests passed** on the refreshed tree, including both formerly failing shared guards.
- Scoped `node scripts/check-changed.mjs -- <all nine PR paths>` — **passed** after aligning the checkout's installed Node types with its refreshed lockfile. Fresh independent Codex review through **P2** is **scoped-clean**.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs test/scripts/parallels-exec.test.ts test/scripts/parallels-smoke-model.test.ts test/scripts/parallels-npm-update-smoke.test.ts test/scripts/parallels-phase-runner.test.ts` — **168 tests passed**. The selected suite also runs **17 deterministic Python SDK-boundary tests**, including positive handle ownership, binary stdin, output separation, partial acquisition, cleanup precedence, timeout exhaustion, custom-PATH isolation, and no replay.
- `node scripts/check-changed.mjs` — **passed** after changing the host-command declaration to the explicit repository-style function signature. Formatting, script/test-root types, lint, and relevant guards are green.
- Fresh independent Codex autoreview, local diff through **P2** — **scoped-clean**, no accepted/actionable findings.
- Earlier investigation on a disposable macOS 26.6 (25G72) guest under host/Tools 27.0.0: the correctly owned prototype completed **20/20** commands and preserved stderr/nonzero exit/current-user behavior. VM-scoped typing produced a sentinel and visible Terminal output, independently verified by host capture. These are prototype results, not a claim about a full OpenClaw install/update run.
- **Fresh candidate live proof passed** against commit `0540db6a7b2387b7349b9a905314dda7a10aad5e` after pristine restore and Tools update to 27.0.0: root/current-user and UUID/name lookup; multiline UTF-8 plus NUL stdin; existing shell quoting; separate stdout/stderr and exit 7 with exactly one execution; `MacosGuest` uploads/scripts/cleanup via current-user and sudo; background setup/poll/log drain/cleanup; streamed output/exit; **20 consecutive retained-job commands**; VM-scoped typing with a guest-file sentinel and independently inspected host capture showing `PARALLELS AUTOMATION OK`.
- **Cleanup verified at the end of native proof:** source guest restored to its exact original snapshot and stopped; snapshot inventory unchanged; all other VM inventory entries unchanged relative to the run's approved baseline. The obsolete proof VM was stopped only after explicit operator approval. No VM operations were performed for the mechanical branch refresh.

Initial candidate proof encountered the host's active-VM limit. The source was restored/stopped with unrelated inventory unchanged; one obsolete proof VM was then gracefully stopped only after explicit operator permission. A subsequent temporary startup probe timed out; direct fresh running comparisons passed without adding speculative SDK initialization calls or increasing production timeouts. The extended driver also caught its own incorrect macOS `printf` path; correcting that temporary driver produced the complete passing run above. The reviewed repository patch did not change during these reruns.

Not claimed: a full package install/update or live model/channel run, live coverage of other Parallels versions, or guest process-tree termination from an SDK wait timeout alone. Those are outside this command-transport repair's proof scope.

### Current landing status

The original [81-job CI failure](https://github.com/openclaw/openclaw/actions/runs/33994352472) is resolved by current main's compatible tooling-tail packing, and the shifted suppression inventory was separately repaired by [#139747](https://github.com/openclaw/openclaw/pull/139747). This branch has been refreshed with those main changes; the combined planner and Parallels tests pass at the unchanged 80-job cap. There is no remaining dependency on #139412 or its former release hold. The repository's normal scope detector does not select native-i18n for this nine-file diff.

[CI run 34018326798](https://github.com/openclaw/openclaw/actions/runs/34018326798) exposed cross-shard filesystem contamination: a ClawHub fixture wrote a shared workspace that the browser fixture then discovered as a skill mount. The producer and browser fixtures were independently repaired on main by [#139894](https://github.com/openclaw/openclaw/pull/139894), and this branch now includes that exact main fix. The ordered 117 + 27 test replay and all 214 scoped regressions pass. [Exact-head CI run 34021526877](https://github.com/openclaw/openclaw/actions/runs/34021526877) is **successful** for `6c268554814ac4916f11784af67dd6f8637030ab`, and every required check is green. No cap increase, suppression relaxation, omitted coverage, or product-runtime modification has been introduced in this PR.

The documented verified-installation ABI tradeoff remains accepted as recorded in the maintainer decision comment. The mechanically refreshed Parallels patch has a fresh scoped-clean independent review.
