### PR TITLE
test(tlon): consolidate SSE acknowledgement coverage

### DIFF
--- a/extensions/tlon/src/urbit/sse-client.test.ts
+++ b/extensions/tlon/src/urbit/sse-client.test.ts
@@ -224,14 +224,6 @@ describe("UrbitSSEClient", () => {
       expect(client.autoReconnect).toBe(false);
     });
 
-    it("stores onReconnect callback", () => {
-      const onReconnect = vi.fn();
-      const client = new UrbitSSEClient("https://example.com", "urbauth-~zod=123", {
-        onReconnect,
-      });
-      expect(client.onReconnect).toBe(onReconnect);
-    });
-
     it("clamps oversized reconnect delays", () => {
       const client = new UrbitSSEClient("https://example.com", "urbauth-~zod=123", {
         reconnectDelay: Number.MAX_SAFE_INTEGER,
@@ -563,59 +555,37 @@ describe("UrbitSSEClient", () => {
       expect(JSON.parse(body)).toEqual([{ id: expect.any(Number), action: "ack", "event-id": 20 }]);
     });
 
-    it("does not advance the ack watermark when the ack request fails", async () => {
+    it("retries a failed ack when the unacknowledged event replays", async () => {
       const mockUrbitFetch = vi.mocked(urbitFetch);
       mockUrbitFetch.mockResolvedValue({
-        response: { ok: false, status: 503 } as unknown as Response,
+        response: { ok: true, status: 204 } as unknown as Response,
         finalUrl: "https://example.com",
         release: vi.fn().mockResolvedValue(undefined),
       });
       const client = new UrbitSSEClient("https://example.com", "urbauth-~zod=123");
       client.eventHandlers.set(1, { event: vi.fn() });
 
-      await expect(
-        client.processEvent('id: 20\ndata: {"id":1,"json":{"ok":true}}'),
-      ).rejects.toThrow("Ack failed with status 503");
-      expect(
-        (client as unknown as { lastAcknowledgedEventId: number }).lastAcknowledgedEventId,
-      ).toBe(-1);
-    });
+      // A success stub makes an eager ACK fail at the no-call assertion, not in transport.
+      await client.processEvent('id: 1\ndata: {"id":1,"json":{"ok":true}}');
+      expect(mockUrbitFetch).not.toHaveBeenCalled();
 
-    it("retries a failed ack when the unacknowledged event replays", async () => {
-      const mockUrbitFetch = vi.mocked(urbitFetch);
-      mockUrbitFetch
-        .mockResolvedValueOnce({
-          response: { ok: false, status: 503 } as unknown as Response,
-          finalUrl: "https://example.com",
-          release: vi.fn().mockResolvedValue(undefined),
-        })
-        .mockResolvedValueOnce({
-          response: { ok: true, status: 204 } as unknown as Response,
-          finalUrl: "https://example.com",
-          release: vi.fn().mockResolvedValue(undefined),
-        });
-      const client = new UrbitSSEClient("https://example.com", "urbauth-~zod=123");
-      client.eventHandlers.set(1, { event: vi.fn() });
+      mockUrbitFetch.mockResolvedValueOnce({
+        response: { ok: false, status: 503 } as unknown as Response,
+        finalUrl: "https://example.com",
+        release: vi.fn().mockResolvedValue(undefined),
+      });
       const event = 'id: 20\ndata: {"id":1,"json":{"ok":true}}';
 
       await expect(client.processEvent(event)).rejects.toThrow("Ack failed with status 503");
+      expect(
+        (client as unknown as { lastAcknowledgedEventId: number }).lastAcknowledgedEventId,
+      ).toBe(-1);
       await expect(client.processEvent(event)).resolves.toBeUndefined();
 
       expect(mockUrbitFetch).toHaveBeenCalledTimes(2);
       expect(
         (client as unknown as { lastAcknowledgedEventId: number }).lastAcknowledgedEventId,
       ).toBe(20);
-    });
-
-    it("tracks lastHeardEventId and ackThreshold", () => {
-      const client = new UrbitSSEClient("https://example.com", "urbauth-~zod=123");
-
-      // Access private properties for testing
-      const lastHeardEventId = (client as unknown as { lastHeardEventId: number }).lastHeardEventId;
-      const ackThreshold = (client as unknown as { ackThreshold: number }).ackThreshold;
-
-      expect(lastHeardEventId).toBe(-1);
-      expect(ackThreshold).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

The Tlon SSE suite separately checks callback storage and private default fields, and duplicates the failed-ACK setup already exercised by replay coverage. This cleanup moves those checks toward observable behavior while retaining the important failure-state assertion.

## Why This Change Was Made

The replay case now first proves that a below-threshold event sends no ACK, then checks that a failed ACK leaves the watermark at -1 before a replay succeeds and advances it. Reconnect callback invocation remains covered elsewhere. The malformed-ID case retains the initial last-heard watermark check.

The three consolidated cases are the callback-storage identity check, the private ACK-threshold/default-field probe, and the separate failed-ACK watermark case. No other case identity or multiplicity changes. The shared-helper cleanup already landed in #139336 is preserved.

## User Impact

No production change. The sole test-file diff is +13/-43 lines. This does not change Urbit transport, acknowledgements, retries, reconnect behavior or configuration.

## Evidence

- Fresh before/after runs at main `9c068e13bd187606cac6111d60700f09ef52bd89` passed 49 baseline and 46 candidate cases across the same six complete selected suites, on Node24.20.0/pnpm12.3.4/Vitest5. All retained cases passed with no retries or added skips.
- The normal configured [Linux changed-file gate](https://github.com/openclaw/openclaw/actions/runs/33991017935) passed all 19 selected checks. Its command exited0, the owned Testbox lease completed, and the temporary source checkout was removed. A later optional portal-sync timeout is retained separately from the successful command and cleanup.
- A prior isolated threshold-zero control failed at the explicit no-call assertion. That control is evidence from base `4e217930`, not a new mutation run at `9c068e13`; the production owner is byte-identical, and it was restored before subsequent proof.
- The complete Tlon Urbit source and shared assertion helper are unchanged between the tested base and freshly fetched main `523d4c1840a7`.

Loopback transport fixtures exercise the selected suites; no live Urbit ship or production Gateway was used. No new runtime robustness claim is made.

Independent Codex subagent review found no actionable P0–P2 findings after directly inspecting the owner, callers, sibling coverage and mock semantics. Source and patch hashes remained unchanged.
