### PR TITLE
fix(code-mode): reserve released slots for Swarm continuations

### DIFF
--- a/docs/tools/swarm.md
+++ b/docs/tools/swarm.md
@@ -137,7 +137,10 @@ log(message: string): void;
 Without `schema`, `agents.run()` resolves to the child's final text. With a
 JSON Schema, it resolves to the value submitted through the child's
 `structured_output` tool. A failed, killed, timed-out, or schema-invalid child
-rejects the promise with a `SwarmAgentError`. Read the exact generated
+rejects the promise with an error whose `name` is `"SwarmAgentError"` and whose
+`runId`, `status`, and `message` identify the failed child and outcome. There is
+no global `SwarmAgentError` constructor; inspect the caught error's fields.
+Spawn or bridge failures can reject with other errors. Read the exact generated
 declarations and short orchestration idioms from `API.read("agents.d.ts")`
 inside Code Mode.
 
@@ -149,8 +152,9 @@ they do not delay the script if the UI is unavailable.
 
 ### Fan out in parallel with structured results
 
-This example launches one researcher per topic, waits for all of them, then
-asks a final child to synthesize their structured reports:
+This example launches one researcher per topic, waits for every outcome, then
+asks a final child to synthesize the successful reports. Failed lanes stay in
+the result, even if synthesis also fails:
 
 ```javascript
 const reportSchema = {
@@ -167,7 +171,7 @@ const reportSchema = {
 const topics = ["authentication", "storage", "recovery"];
 phase("Independent review");
 
-const reports = await Promise.all(
+const settled = await Promise.allSettled(
   topics.map((topic) =>
     agents.run(`Review the ${topic} path. Return one finding with evidence.`, {
       label: `review-${topic}`,
@@ -178,18 +182,40 @@ const reports = await Promise.all(
   ),
 );
 
-phase("Synthesis");
-log(`Collected ${reports.length} independent reports.`);
+const reports = [];
+const failures = [];
+for (const [index, outcome] of settled.entries()) {
+  if (outcome.status === "fulfilled") {
+    reports.push({ topic: topics[index], report: outcome.value });
+  } else {
+    failures.push({ topic: topics[index], error: String(outcome.reason) });
+  }
+}
 
-return await agents.run(
-  `Reconcile these reports and explain disagreements:\n${JSON.stringify(reports)}`,
-  { label: "synthesis" },
-);
+if (reports.length === 0) return { reports, failures };
+
+phase("Synthesis");
+log(`Collected ${reports.length} reports; ${failures.length} lanes failed.`);
+
+try {
+  const synthesis = await agents.run(
+    `Reconcile these reports, explain disagreements, and disclose failed lanes:\n${JSON.stringify({ reports, failures })}`,
+    { label: "synthesis" },
+  );
+  return { synthesis, reports, failures };
+} catch (error) {
+  return { reports, failures, synthesisError: String(error) };
+}
 ```
 
-`Promise.all` is the fan-out and fan-in boundary. OpenClaw starts up to
-`maxConcurrent` children for the group and queues the rest in submission
-order.
+`Promise.allSettled` preserves partial results while waiting for every child.
+`Promise.all` rejects on the first failure and does not collect the remaining
+outcomes for you. Keep completed work and report failed lanes; do not respawn
+the batch automatically. A later provider failure can still prevent a final
+model reply, so retain the collected results for recovery.
+
+OpenClaw starts up to `maxConcurrent` children for the group and queues the rest
+in submission order.
 
 Code Mode separately bounds concurrent guest bridge calls with
 `tools.codeMode.maxPendingToolCalls` (default `16`, maximum `128`). Swarm
@@ -417,6 +443,7 @@ const tasks = [
   "Check the recovery path.",
 ];
 const launches = [];
+const failures = [];
 
 for (const [index, task] of tasks.entries()) {
   const launch = parseToolResult(
@@ -427,7 +454,8 @@ for (const [index, task] of tasks.entries()) {
     }),
   );
   if (launch.status !== "accepted") {
-    throw new Error(launch.error ?? "Collector spawn was not accepted.");
+    failures.push({ task, error: launch.error ?? "Collector spawn was not accepted." });
+    continue;
   }
   launches.push(launch);
 }
@@ -452,22 +480,25 @@ while (pending.size > 0) {
   for (const item of batch.completed) {
     pending.delete(item.runId);
     if (item.status !== "done") {
-      const detail = [item.error, item.schemaError, item.result].find(
-        (value) => typeof value === "string" && value.trim(),
-      );
-      throw new Error(detail ?? `${item.runId}: ${item.status}`);
+      failures.push(item);
+    } else {
+      completed.push(item); // Process each result as soon as it finishes.
     }
-    completed.push(item); // Process each result as soon as it finishes.
   }
 
   for (const failure of batch.errors ?? []) {
     pending.delete(failure.runId);
-    throw new Error(`${failure.runId}: ${failure.error}`);
+    failures.push(failure);
   }
 }
 
-return completed;
+return { completed, failures };
 ```
+
+Drain the pending set before synthesizing the successful results and reporting
+failures. A rejected launch or failed child must not discard results from other
+accepted children. Keep the returned run IDs for recovery; do not repeat
+successful launches or automatically rerun failed work.
 
 Each `agents_wait` call accepts 1–1000 run ids. It returns:
 

--- a/src/agents/code-mode-controller-source.ts
+++ b/src/agents/code-mode-controller-source.ts
@@ -58,12 +58,13 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
       hostRequest(methodName, argsJson, id);
       pending.set(id, callbacks);
     };
-    if (queue && pending.size >= maxPending) queued.push(admit);
+    if (queue) queued.push(admit);
     else admit();
     return { id, promise };
   }
 
-  // Swarm queues before admission; raw tools retain all-or-nothing overflow rejection.
+  // Refill after guest continuations run so collector results can trigger ordinary
+  // tools before queued Swarm work takes their released slots.
   // Closures and stable IDs live in the bounded VM snapshot, never a second host queue.
   function drainQueuedRequests() {
     while (queued.length > 0 && pending.size < maxPending) queued.shift()();
@@ -98,7 +99,6 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
     if (!entry) return;
     pending.delete(requestId);
     entry.resolve(null);
-    drainQueuedRequests();
   }
 
   ${CODE_MODE_SWARM_CONTROLLER_SOURCE}
@@ -147,7 +147,6 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
       const error = new Error(typeof parsed === "string" ? parsed : parsed?.message ?? "nested tool failed");
       entry.reject(error);
     }
-    drainQueuedRequests();
     return true;
   }
 
@@ -337,6 +336,7 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
     json: { value: (value) => output.push({ type: "json", value: safe(value) }), enumerable: true },
     yield_control: { value: (reason) => request("yield", [reason]), enumerable: true },
     __openclawSettleBridge: { value: settle },
+    __openclawDrainQueuedRequests: { value: drainQueuedRequests },
     __openclawSerializeCatalogHandles: { value: serializeCatalogHandles },
     __openclawTakeOutput: { value: () => output.splice(0) },
     __openclawTrackRejection: {

--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -451,6 +451,7 @@ interface AgentRunOptions {
 }
 
 interface AgentsApi {
+  /** Child failures have name "SwarmAgentError", runId, status, and message; SwarmAgentError is not a global constructor. */
   run(prompt: string, options?: AgentRunOptions & { schema?: undefined }): Promise<string>;
   run<T>(prompt: string, options: AgentRunOptions & { schema: AgentJsonSchema }): Promise<T>;
 }
@@ -462,8 +463,10 @@ declare function phase(title: string): void;
 /** Publish a progress note for this swarm. */
 declare function log(message: string): void;
 
-// Fan-out: const reports = await Promise.all(prompts.map((prompt) => agents.run(prompt)));
-// Gate: while (!ready) { ready = await agents.run("Check readiness") === "ready"; }
+// Fan-out: const settled = await Promise.allSettled(prompts.map((prompt) => agents.run(prompt)));
+// Drain every accepted child before synthesis: fulfilled entries hold values, rejected entries hold reasons.
+// Keep successful results and report failed lanes. Do not respawn completed work after a partial failure.
+// Gate: for (let pass = 0; !ready && pass < 4; pass++) ready = await agents.run("Check readiness") === "ready";
 // Cycle: for (let pass = 0; pass < 3; pass++) draft = await agents.run("Improve: " + draft);
 // Schema: const fact = await agents.run<{ answer: string }>("Research", { schema: { type: "object", properties: { answer: { type: "string" } }, required: ["answer"] } });
 `;

--- a/src/agents/code-mode-swarm.fanout.test.ts
+++ b/src/agents/code-mode-swarm.fanout.test.ts
@@ -7,19 +7,21 @@ afterEach(resetCodeModeTestState);
 
 describe("Swarm pipeline backpressure", () => {
   it.each([
-    { limit: 1, count: 3, partial: false },
-    { limit: 2, count: 6, partial: false },
-    { limit: 16, count: 20, partial: false },
-    { limit: 3, count: 6, partial: true },
+    { limit: 1, count: 3, partial: false, followup: false },
+    { limit: 2, count: 6, partial: false, followup: false },
+    { limit: 16, count: 20, partial: false, followup: false },
+    { limit: 3, count: 6, partial: true, followup: false },
+    { limit: 16, count: 30, partial: true, followup: true },
   ])(
-    "accounts for $count items with $limit slots and partial settlement $partial",
-    async ({ limit, count, partial }) => {
+    "accounts for $count items with $limit slots, partial settlement $partial and follow-up tools $followup",
+    async ({ limit, count, partial, followup }) => {
       const config = resolveCodeModeConfig({
         tools: { codeMode: { enabled: true, maxPendingToolCalls: limit } },
       });
       const source = `
       const outcomes = await Promise.allSettled(Array.from({ length: ${count} }, async (_, index) => {
         const next = await agents.run("first-" + index, { phase: "First" });
+        if (${followup}) await progress({ value: index });
         return await agents.run(next, { phase: "Second" });
       }));
       return outcomes.map(outcome => outcome.status === "fulfilled"
@@ -31,7 +33,7 @@ describe("Swarm pipeline backpressure", () => {
           kind: "exec",
           source,
           config,
-          catalog: [],
+          catalog: [{ callableName: "progress", name: "progress", source: "openclaw" }],
           apiFiles: [],
           namespaces: [],
           swarmEnabled: true,
@@ -40,9 +42,10 @@ describe("Swarm pipeline backpressure", () => {
       );
       const collectors = new Map<string, string>();
       const spawnedPrompts: string[] = [];
+      const progressItems: unknown[] = [];
       // Drive real worker snapshots with controlled child results; this tests request
       // admission and resumption, not a mock of the guest's Promise implementation.
-      for (let round = 0; result.status === "waiting" && round < count * 6; round++) {
+      for (let round = 0; result.status === "waiting" && round < count * 8; round++) {
         expect(result.pendingRequests.length).toBeGreaterThan(0);
         expect(result.pendingRequests.length).toBeLessThanOrEqual(limit);
         const frontier = partial ? result.pendingRequests.slice(-1) : result.pendingRequests;
@@ -60,6 +63,10 @@ describe("Swarm pipeline backpressure", () => {
             collectors.set(runId, prompt);
             spawnedPrompts.push(prompt);
             value = { status: "accepted", runId };
+          } else if (request.method === "callValue") {
+            expect(request.args[0]).toBe("progress");
+            progressItems.push(request.args[1]);
+            value = { recorded: true };
           } else {
             expect(request.method).toBe("agentWait");
             const runId = request.args[0];
@@ -98,6 +105,13 @@ describe("Swarm pipeline backpressure", () => {
       );
       expect(spawnedPrompts).toHaveLength(count * 2 - 1);
       expect(new Set(spawnedPrompts).size).toBe(spawnedPrompts.length);
+      const expectedProgress = followup
+        ? Array.from({ length: count }, (_, value) => ({ value })).filter(
+            ({ value }) => value !== 1,
+          )
+        : [];
+      expect(progressItems).toHaveLength(expectedProgress.length);
+      expect(progressItems).toEqual(expect.arrayContaining(expectedProgress));
     },
   );
 

--- a/src/agents/code-mode-swarm.test.ts
+++ b/src/agents/code-mode-swarm.test.ts
@@ -416,8 +416,7 @@ describe("Code Mode swarm guest", () => {
     const { apiFiles: files } = createCodeModeNamespaceRuntime();
 
     expect(files.map((file) => file.path)).toEqual(["agents.d.ts"]);
-    expect(files[0]?.content).toContain("Promise.all");
-    expect(files[0]?.content).toContain("while (!ready)");
+    expect(files[0]?.content).toContain("Promise.allSettled");
     expect(files[0]?.content).toContain("schema: AgentJsonSchema");
   });
 });

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -362,6 +362,9 @@ async function runVmExecution(params: {
     if (params.bridge.admissionFailure) {
       throw params.bridge.admissionFailure;
     }
+    params.vm.global
+      .getProp("__openclawDrainQueuedRequests")
+      .consume((drain) => params.vm.callFunction(drain, params.vm.undefined).dispose());
     output = takeOutput(params.vm);
     const resultHandle = params.vm.global.getProp("__openclawResult");
     try {


### PR DESCRIPTION
Closes #139407

## What Problem This Solves

A Swarm pipeline that updates progress after a child finishes can fail with `too many pending code mode tool calls`, even though that child just released a bridge slot. The failure interrupts collection and synthesis while other accepted children continue running.

## Why This Change Was Made

The guest used to refill queued Swarm requests synchronously inside bridge settlement. That happened before QuickJS ran the completed child's promise continuation, so queued work took the freed slot before its dependent ordinary tool call could use it.

Queued Swarm requests now enter the bridge after the guest's pending microtasks drain. The existing queue, stable request IDs, snapshot ownership, configured limit, and cancellation path remain the owners. Raw over-cap frontiers still fail before dispatching their admitted prefix; no limit increase or second queue is added.

The accompanying recovery guidance uses `Promise.allSettled`, bounded decision loops, and complete pending-result draining. Successful reports remain available if a child or synthesis fails. This is a connected documentation improvement, not a claim that every failed production script lacked a catch.

## User Impact

Collector completion callbacks can issue ordinary progress/tool calls while queued Swarm work continues. Partial failures remain explicit and successful work need not be repeated. Provider availability and independent storage failures remain separate concerns.

Production delta: +6 lines, for one worker-owned queue-drain call and bounded model guidance. Tests: net +13 lines; docs: net +31. No new configuration, dependency, storage schema, retention policy, or public tool arguments.

## Evidence

- A real QuickJS worker regression with 30 collectors, 16 bridge slots, incremental settlement, mixed outcomes, and ordinary follow-up tools fails on original main with the exact overflow error. The six pre-existing fan-out cases pass.
- After repair, **103 tests across five selected files pass**, covering mixed pipelines, raw-frontier rejection without side effects, typed results, cancellation, catalog closure, snapshot resume, and worker lifecycle.
- Directly inspected QuickJS-WASI 3.5.0 `executePendingJobs`: it drains the guest's promise-reaction queue before returning. The candidate drains queued host requests afterward.
- Independent Codex review is scoped-clean through P2. Post-commit hook verification confirms the reviewed source bytes are unchanged.
- Full local build passed. [Exact-head CI 33993601901](https://github.com/openclaw/openclaw/actions/runs/33993601901) passed on `13079433769573eece2e3fcba9d80adf72aa52ae`. The duplicate local changed-check run was deliberately stopped after CI completed the remaining gates; it is not counted as passing.
- Pinned dependency proof: the official QuickJS-WASI 3.5.0 tarball passed its registry SHA-512 check; its JavaScript and WASM bytes match the installed package used by the tests.

```sh
node scripts/run-vitest.mjs src/agents/code-mode-swarm.fanout.test.ts src/agents/code-mode.bridge.test.ts src/agents/code-mode-swarm.test.ts src/agents/code-mode-worker-lifecycle.test.ts src/agents/code-mode.bridge.lifecycle.test.ts
pnpm build
OPENCLAW_TESTBOX=0 node scripts/check-changed.mjs -- docs/tools/swarm.md src/agents/code-mode-controller-source.ts src/agents/code-mode.worker.ts src/agents/code-mode-namespaces.ts src/agents/code-mode-swarm.fanout.test.ts src/agents/code-mode-swarm.test.ts
```

Proof uses the real Code Mode VM/bridge with controlled collector completions; it does not claim a new live-provider run. The initial post-fix batch caught an obsolete test expectation for the removed unbounded `while` example; that assertion was removed and the suite rerun successfully.
