### PR TITLE
refactor(update): remove redundant CLI command runner

### DIFF
--- a/src/cli/update-cli/shared.command-runner.test.ts
+++ b/src/cli/update-cli/shared.command-runner.test.ts
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { defaultRuntime } from "../../runtime.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import {
-  createGlobalCommandRunner,
   ensureGitCheckout,
   parseTimeoutMsOrExit,
   resolveGlobalManager,
@@ -40,35 +39,6 @@ describe("update CLI shared helpers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     runCommandWithTimeout.mockResolvedValue(successfulCommandResult);
-  });
-
-  it("forwards argv/options and maps exec result shape", async () => {
-    runCommandWithTimeout.mockResolvedValueOnce({
-      stdout: "out",
-      stderr: "err",
-      code: 17,
-      signal: null,
-      killed: false,
-      termination: "exit",
-    });
-    const runCommand = createGlobalCommandRunner();
-
-    const result = await runCommand(["npm", "root", "-g"], {
-      timeoutMs: 1200,
-      cwd: "/tmp/openclaw",
-      env: { OPENCLAW_TEST: "1" },
-    });
-
-    expect(runCommandWithTimeout).toHaveBeenCalledWith(["npm", "root", "-g"], {
-      timeoutMs: 1200,
-      cwd: "/tmp/openclaw",
-      env: { OPENCLAW_TEST: "1" },
-    });
-    expect(result).toEqual({
-      stdout: "out",
-      stderr: "err",
-      code: 17,
-    });
   });
 
   it("requires timeout values to be complete positive integer seconds", () => {

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -18,7 +18,6 @@ import {
   createGlobalInstallEnv,
   detectGlobalInstallManagerByPresence,
   detectGlobalInstallManagerForRoot,
-  type CommandRunner,
   type GlobalInstallManager,
 } from "../../infra/update-global.js";
 import { runStep } from "../../infra/update-runner-command.js";
@@ -392,11 +391,9 @@ export async function resolveGlobalManager(params: {
   installKind: "git" | "package" | "unknown";
   timeoutMs: number;
 }): Promise<GlobalInstallManager> {
-  const runCommand = createGlobalCommandRunner();
-
   if (params.installKind === "package") {
     const detected = await detectGlobalInstallManagerForRoot(
-      runCommand,
+      runCommandWithTimeout,
       params.root,
       params.timeoutMs,
     );
@@ -408,7 +405,10 @@ export async function resolveGlobalManager(params: {
     return detected;
   }
 
-  const byPresence = await detectGlobalInstallManagerByPresence(runCommand, params.timeoutMs);
+  const byPresence = await detectGlobalInstallManagerByPresence(
+    runCommandWithTimeout,
+    params.timeoutMs,
+  );
   return byPresence ?? "npm";
 }
 
@@ -465,12 +465,4 @@ export async function tryWriteCompletionCache(
     return "failed";
   }
   return "completed";
-}
-
-/** Adapter used by global-install detection helpers to execute bounded subprocess probes. */
-export function createGlobalCommandRunner(): CommandRunner {
-  return async (argv, options) => {
-    const res = await runCommandWithTimeout(argv, options);
-    return { stdout: res.stdout, stderr: res.stderr, code: res.code };
-  };
 }

--- a/src/cli/update-cli/update-command-git.ts
+++ b/src/cli/update-cli/update-command-git.ts
@@ -13,6 +13,7 @@ import {
 import { recordUpdateRunPhase } from "../../infra/update-run-ledger.js";
 import { readCurrentGitUpdateRecovery } from "../../infra/update-runner-git-recovery.js";
 import { runGatewayUpdate, type UpdateRunResult } from "../../infra/update-runner.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
 import { OPENCLAW_DATABASE_SCHEMA_DOCS_URL } from "../../state/openclaw-database-preflight.js";
 import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
@@ -24,7 +25,6 @@ import {
   hasSchemaRefusal,
 } from "./schema-preflight.js";
 import {
-  createGlobalCommandRunner,
   DEFAULT_PACKAGE_NAME,
   ensureGitCheckout,
   readPackageName,
@@ -192,7 +192,6 @@ export async function updateGitInstall(params: {
   let updateRoot = params.switchToGit ? resolveGitInstallDir() : params.root;
   const effectiveTimeout = params.timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS;
   const installEnv = await createGlobalInstallEnv();
-  const runCommand = createGlobalCommandRunner();
   const installTarget = params.switchToGit
     ? await resolveGlobalInstallTarget({
         manager: await resolveGlobalManager({
@@ -200,7 +199,7 @@ export async function updateGitInstall(params: {
           installKind: params.installKind,
           timeoutMs: effectiveTimeout,
         }),
-        runCommand,
+        runCommand: runCommandWithTimeout,
         timeoutMs: effectiveTimeout,
         pkgRoot: params.root,
       })
@@ -277,7 +276,7 @@ export async function updateGitInstall(params: {
       installSpec: updateRoot,
       packageName,
       packageRoot: installTarget.packageRoot,
-      runCommand,
+      runCommand: runCommandWithTimeout,
       runStep: (stepParams) => runUpdateStep({ ...stepParams, progress: params.progress }),
       timeoutMs: effectiveTimeout,
       env: installEnv,

--- a/src/cli/update-cli/update-command-package.ts
+++ b/src/cli/update-cli/update-command-package.ts
@@ -22,12 +22,12 @@ import {
   resolveUpdateDoctorExecutionPolicy,
   type UpdateRunResult,
 } from "../../infra/update-runner.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveCliName } from "../cli-name.js";
 import { createUpdateProgress } from "./progress.js";
 import {
   DEFAULT_PACKAGE_NAME,
-  createGlobalCommandRunner,
   readPackageName,
   readPackageVersion,
   resolveGlobalManager,
@@ -62,7 +62,6 @@ export async function runPackageInstallUpdate(
   params: PackageInstallUpdateParams,
 ): Promise<UpdateRunResult> {
   const installEnv = params.installEnv ?? (await createGlobalInstallEnv());
-  const runCommand = createGlobalCommandRunner();
   let installTarget = params.installTarget;
   if (!installTarget) {
     const manager = await resolveGlobalManager({
@@ -72,7 +71,7 @@ export async function runPackageInstallUpdate(
     });
     installTarget = await resolveGlobalInstallTarget({
       manager,
-      runCommand,
+      runCommand: runCommandWithTimeout,
       timeoutMs: params.timeoutMs,
       pkgRoot: params.root,
       honorPackageRoot: params.honorPackageRoot === true,
@@ -109,7 +108,7 @@ export async function runPackageInstallUpdate(
     installSpec,
     packageName,
     packageRoot: pkgRoot,
-    runCommand,
+    runCommand: runCommandWithTimeout,
     timeoutMs: params.timeoutMs,
     ...(installEnv === undefined ? {} : { env: installEnv }),
     runStep: (stepParams) =>

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -30,6 +30,7 @@ import {
 import { cleanupStaleManagedServiceUpdateHandoffs } from "../../infra/update-managed-service-handoff-cleanup.js";
 import { finishUpdateRun, recordUpdateRunPhase } from "../../infra/update-run-ledger.js";
 import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
@@ -44,7 +45,6 @@ import {
 } from "./schema-preflight.js";
 import {
   DEFAULT_PACKAGE_NAME,
-  createGlobalCommandRunner,
   normalizeTag,
   readPackageName,
   readPackageVersion,
@@ -350,7 +350,7 @@ async function updateCommandInternal(
       });
       packageInstallTarget = await resolveGlobalInstallTarget({
         manager,
-        runCommand: createGlobalCommandRunner(),
+        runCommand: runCommandWithTimeout,
         timeoutMs: updateStepTimeoutMs,
         pkgRoot: root,
         honorPackageRoot:


### PR DESCRIPTION
## What Problem This Solves

The update CLI kept a factory that created a new subprocess adapter for each package-manager probe, even though the existing process runner already satisfies those callers. This is the second cleanup companion to the maintainer-authorized #135868 split campaign (concern E, update CLI), following #139378.

## Why This Change Was Made

Pass `runCommandWithTimeout` directly to the existing manager detection and package-update helpers. Remove the stateless factory and the test that only asserted its exact property projection. The callers consume only `stdout`, `stderr`, and `code`; actual install and Doctor steps continue through their existing step runner. No source-branch feature content is extracted here.

## User Impact

No user-visible behavior changes. Package ownership, command arguments, environments, timeouts, failure diagnostics, and update recovery remain unchanged. Production shrinks by 10 lines (+13/-23), and tests shrink by 30 lines; tooling and docs are unchanged.

## Evidence

- Repository-wide caller inspection and callee tracing confirmed no consumer depends on stripping the extra subprocess result fields. The adapter is private CLI implementation, with no public SDK/config/data contract.
- Existing owner-boundary tests remain for package-manager selection/refusal, update execution, timeout validation, progress diagnostics, and transactional clone publication/rollback.
- All neighborhood suites: 559 passed, one existing skip across 29 files.
- Top-level update CLI suite: 362 passed. Combined local proof: 921 passed and one existing skip. Full `node scripts/check-changed.mjs` passed, including core/core-test types, lint, all three dead-export scans (zero entries), and runtime import cycles (zero).
- Independent Codex reviews of the pinned local patch and committed branch: no actionable P0–P2 findings. The pre-publication rebase left all touched files, immediate callees, and the dependency lock unchanged.
- No build or installed-platform trial is needed for this internal refactor: the existing shared module already loads the same process module, and no lazy-loading or published boundary changes.

- First exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/33993936261. The required pre-landing rebase preserved all touched files, immediate callees, and the lockfile byte-for-byte; CI for final head `78cdeb3edd4b` also passed: https://github.com/openclaw/openclaw/actions/runs/33994381499.
- ClawSweeper reviewed both published heads, including final `78cdeb3edd4b`, with no correctness/security findings, no before-merge changes, and no rank-up moves requested. Its conclusion matches the retained owner-boundary proof.

The final-head watcher initially stopped on an older canceled Labeler check. Its newer same-head Labeler run was skipped and replacement dispatch succeeded; the reconciled watcher finished GREEN with zero pending checks. No test failed or required a retry.
