### PR TITLE
refactor(agents): reuse owned tool projection arrays

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
@@ -4,6 +4,7 @@ import {
   makeRegistry,
 } from "../../../config/plugin-auto-enable.test-helpers.js";
 import { setPluginToolMeta } from "../../../plugins/tool-metadata.js";
+import { createStubTool } from "../../test-helpers/agent-tool-stubs.js";
 import { attachToolAllowlistIntersection } from "../../tool-policy.js";
 
 const mocks = vi.hoisted(() => ({
@@ -24,7 +25,7 @@ vi.mock("../../agent-bundle-mcp-tools.js", () => ({
 }));
 
 vi.mock("../../runtime-plan/tools.js", () => ({
-  normalizeAgentRuntimeTools: vi.fn(({ tools }: { tools: unknown[] }) => tools),
+  normalizeAgentRuntimeTools: vi.fn(({ tools }: { tools: unknown[] }) => [...tools]),
 }));
 
 vi.mock("../../local-model-lean.js", () => ({
@@ -372,6 +373,52 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
       version: 1,
       source: "final-executable-surface",
     });
+  });
+
+  it("refreshes retained tools and capability captures from each schema projection", async () => {
+    const { filterRuntimeCompatibleTools } = await vi.importActual<
+      typeof import("../../tool-schema-projection.js")
+    >("../../tool-schema-projection.js");
+    mocks.filterRuntimeCompatibleTools.mockImplementation(filterRuntimeCompatibleTools);
+    const first = createStubTool("core_first");
+    const bundled = createStubTool("server__read");
+    const bundledSchema = { type: "object" };
+    bundled.parameters = bundledSchema;
+    setPluginToolMeta(bundled, { pluginId: "bundle-mcp", optional: false });
+    const core = [first];
+    const inherited = ["initial"];
+    const input = createInput(inherited, core);
+    const creatorTools = input.preparedToolBase.cronCreatorToolAllowlist;
+    input.preparedToolBase.cronCreatorToolAllowlistCaptureRef = {};
+    mocks.acquireSessionMcpRuntime.mockResolvedValue({ runtime: {}, releaseLease: () => {} });
+    mocks.materializeBundleMcpToolsForRun.mockResolvedValue({ tools: [bundled] });
+
+    const result = await prepareEmbeddedAttemptBundleTools(input);
+    const retained = result.uncompactedEffectiveTools;
+    expect(retained.map((tool) => tool.name)).toEqual(["core_first", "server__read"]);
+    expect(core).toEqual([first]);
+
+    const second = createStubTool("core_second");
+    core.splice(0, core.length, second);
+    bundledSchema.type = "array";
+    result.refreshTools();
+
+    expect(retained.map((tool) => tool.name)).toEqual(["core_second"]);
+    expect(core).toEqual([second]);
+    expect(inherited).toEqual(["core_second"]);
+    expect(creatorTools).toEqual([{ name: "core_second" }]);
+
+    core.splice(0, core.length, first);
+    bundledSchema.type = "object";
+    result.refreshTools();
+
+    expect(retained.map((tool) => tool.name)).toEqual(["core_first", "server__read"]);
+    expect(core).toEqual([first]);
+    expect(inherited).toEqual(["core_first", "server__read"]);
+    expect(creatorTools).toEqual([
+      { name: "core_first" },
+      { name: "server__read", pluginId: "bundle-mcp" },
+    ]);
   });
 
   it("disposes prepared bundle runtimes when later policy setup fails", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -241,7 +241,7 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
       });
       return schemaProjection.tools;
     };
-    const uncompactedEffectiveTools = [...projectTools(tools)];
+    const uncompactedEffectiveTools = projectTools(tools);
     return {
       bundleLspRuntime,
       bundleMcpRuntime,

--- a/src/agents/harness/tool-surface-bridge.ts
+++ b/src/agents/harness/tool-surface-bridge.ts
@@ -143,8 +143,7 @@ export function createAgentHarnessToolSurfaceRuntimeCore(params: {
           sessionKey: params.sessionKey,
           preserveToolNames,
         });
-    const uncompactedProjection = filterRuntimeCompatibleTools(projectedUncompactedTools);
-    let effectiveTools = [...uncompactedProjection.tools];
+    let effectiveTools = filterRuntimeCompatibleTools(projectedUncompactedTools).tools;
     const codeModeTools = codeModeControlsEnabled
       ? createCodeModeTools({
           config: params.config,
@@ -184,7 +183,7 @@ export function createAgentHarnessToolSurfaceRuntimeCore(params: {
           sessionKey: params.sessionKey,
           preserveToolNames,
         });
-    effectiveTools = [...filterRuntimeCompatibleTools(projectedCompactedTools).tools];
+    effectiveTools = filterRuntimeCompatibleTools(projectedCompactedTools).tools;
     if (!compacted.catalogRegistered) {
       finalizeAgentToolAvailability(effectiveTools);
     }


### PR DESCRIPTION
## What Problem This Solves

Simplifies tool preparation in the native runtime and shared harness bridge, where unnecessary intermediate arrays obscure the distinction between private projections and retained refresh views.

## Why This Change Was Made

Reuse the schema projector's freshly owned arrays at three handoffs instead of immediately copying them. Source-entry snapshots, both schema passes, independent prompt baselines, and in-place refresh of the published tool array remain unchanged.

## User Impact

No user-visible behavior change. This is a small ownership cleanup, not a demonstrated general latency or memory improvement. Production is **−1 LOC**; preservation coverage is **+47 test LOC**.

## Evidence

- **85 tests passed before and after** across the bridge, bundle preparation, schema projection, and prompt-policy suites. The full **29-stage changed gate passed** after a retained formatting failure was corrected.
- Independent code review completed eight passes with no actionable P0–P2 findings. The source/consumer review judged the three copies redundant and the retained-refresh test useful.
- A fixed B0/C0/C1/B1 comparison completed **58,268 operations and 896 batch means**. Ordinary primary medians were mixed: direct bridge **−3.53%/+0.72%**, bundle preparation **−1.05%/+1.03%** (forward/reverse). Prepare-plus-refresh medians were **−1.27%/−0.83%**, with worse p95 batch means in both orders. All **1,906 comparisons and 942 adverse outcomes** are retained; no threshold-pass claim is made.
- The original apparatus failed its 4 MiB runtime allocation on normal SQLite WAL state. That failure is preserved; the corrected apparatus retained it within the **same combined 64 MiB cap**, with unchanged workload and native time/RSS/process limits. SQLite and logging behavior were not changed. Normal quarantine logs, including the logger's explicit 66-record queue-drop marker per numeric phase, are retained.

<details>
<summary>Focused validation commands</summary>

```sh
node scripts/run-vitest.mjs \
  src/agents/harness/tool-surface-bridge.test.ts \
  src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts \
  src/agents/tool-schema-projection.test.ts \
  src/agents/embedded-agent-runner/run/attempt-prompt-tool-policy.test.ts

node scripts/check-changed.mjs -- \
  src/agents/harness/tool-surface-bridge.ts \
  src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts \
  src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
```

The added test uses the real schema projector to preserve retained views and cron/inherited capability captures across two refresh generations. It passes on both variants and is not a claimed bug reproduction. No import or package boundary changed; no live-provider, Gateway-turn, or cold-start improvement is claimed.

</details>
