### PR TITLE
test(memory): remove ignored hybrid fixture inputs

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -73,7 +73,6 @@ describe("memory index", () => {
   it("does not prepare vector deletes after in-place reset drops a missing vector table", async () => {
     const cfg = createCfg({
       vectorEnabled: true,
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const manager = await getFreshManager(cfg);
     trackManager(manager);
@@ -91,9 +90,7 @@ describe("memory index", () => {
   });
 
   it("indexes memory files and searches", async () => {
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     const manager = await getFreshManager(cfg);
     try {
       await manager.sync({ reason: "test" });
@@ -706,11 +703,7 @@ describe("memory index", () => {
       .run("test", "keep-me", JSON.stringify({ value: "keep-me" }), 1);
     closeOpenClawAgentDatabasesForTest();
 
-    const manager = await getFreshManager(
-      createCfg({
-        hybrid: { enabled: false },
-      }),
-    );
+    const manager = await getFreshManager(createCfg({}));
     try {
       await manager.sync({ reason: "test", force: true });
       expect(manager.status().dbPath).toBe(agentDbPath);
@@ -1185,7 +1178,6 @@ describe("memory index", () => {
   it("does not full-reindex on search when existing metadata belongs to another provider", async () => {
     const oldCfg = createCfg({
       model: "old-embed",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const oldManager = await getFreshManager(oldCfg);
     await oldManager.sync({ reason: "test", force: true });
@@ -1194,7 +1186,6 @@ describe("memory index", () => {
     const nextCfg = createCfg({
       provider: "gemini",
       model: "new-embed",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const nextManager = await getFreshManager(nextCfg);
     try {
@@ -1253,7 +1244,6 @@ describe("memory index", () => {
         model: providerFixture.identityAlias.canonicalModel,
         cacheEnabled: true,
         vectorEnabled: false,
-        hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
       });
       const indexedManager = await getFreshManager(indexedCfg);
       await indexedManager.sync({ reason: "test", force: true });
@@ -1268,7 +1258,6 @@ describe("memory index", () => {
         model: configuredModel,
         cacheEnabled: true,
         vectorEnabled: false,
-        hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
       });
       const statusManager = await getFreshManager(nextCfg, "status");
       try {
@@ -1299,7 +1288,6 @@ describe("memory index", () => {
     const oldCfg = createCfg({
       provider: "ollama",
       model: "ollama-embed",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const oldManager = await getFreshManager(oldCfg);
     await oldManager.sync({ reason: "test", force: true });
@@ -1315,7 +1303,6 @@ describe("memory index", () => {
         },
       },
       model: "ollama-embed",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const statusManager = await getFreshManager(aliasCfg, "status");
     try {
@@ -1333,7 +1320,6 @@ describe("memory index", () => {
     const indexCfg = createCfg({
       provider: "gemini",
       model: "gemini-embed",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const indexManager = await getFreshManager(indexCfg);
     await indexManager.sync({ reason: "test", force: true });
@@ -1345,7 +1331,6 @@ describe("memory index", () => {
     const statusCfg = createCfg({
       provider: "gemini",
       model: "",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const statusManager = await getFreshManager(statusCfg, "status");
     try {
@@ -1359,9 +1344,7 @@ describe("memory index", () => {
   });
 
   it("rebuilds missing metadata with existing chunks before search", async () => {
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     await fs.writeFile(
       path.join(fixture.paths.memory, "2026-01-13.md"),
       "# Log\nBeta memory line.",
@@ -1406,7 +1389,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "none",
       vectorEnabled: false,
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const initial = await getFreshManager(cfg);
     await initial.sync({ reason: "test", force: true });
@@ -1429,7 +1411,6 @@ describe("memory index", () => {
   it("does not search stale provider rows after embeddings become unavailable", async () => {
     const oldCfg = createCfg({
       model: "semantic-embed",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const oldManager = await getFreshManager(oldCfg);
     await oldManager.sync({ reason: "test", force: true });
@@ -1453,7 +1434,6 @@ describe("memory index", () => {
   it("does not rebuild missing semantic metadata when embeddings are unavailable", async () => {
     const oldCfg = createCfg({
       model: "semantic-embed",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const oldManager = await getFreshManager(oldCfg);
     await oldManager.sync({ reason: "test", force: true });
@@ -2211,9 +2191,7 @@ describe("memory index", () => {
   });
 
   it("closes embedding providers when memory index managers close", async () => {
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     const manager = await getFreshManager(cfg);
 
     await manager.probeEmbeddingAvailability();
@@ -2226,9 +2204,7 @@ describe("memory index", () => {
   });
 
   it("waits for pending sync before closing embedding providers", async () => {
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     const manager = await getFreshManager(cfg);
     await manager.probeEmbeddingAvailability();
     let resolveSync: () => void = () => {};
@@ -2261,9 +2237,7 @@ describe("memory index", () => {
     providerFixture.providerInitGate = new Promise<void>((resolve) => {
       releaseProviderInit = resolve;
     });
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     const manager = await getFreshManager(cfg);
     let releaseSync: () => void = () => {};
     const syncStarted = new Promise<void>((resolve) => {

--- a/extensions/memory-core/src/memory/manager-index.test-support.ts
+++ b/extensions/memory-core/src/memory/manager-index.test-support.ts
@@ -25,7 +25,7 @@ type GetMemorySearchManager = typeof import("./index.js").getMemorySearchManager
 type ManagerConfig = Parameters<GetMemorySearchManager>[0]["cfg"];
 type ManagerResult = Awaited<ReturnType<GetMemorySearchManager>>;
 
-export type ManagerIndexFixtureConfig = {
+type ManagerIndexFixtureConfig = {
   extraPaths?: string[];
   sources?: Array<"memory" | "sessions">;
   sessionMemory?: boolean;
@@ -45,12 +45,6 @@ export type ManagerIndexFixtureConfig = {
   ftsTokenizer?: "unicode61" | "trigram";
   cacheEnabled?: boolean;
   minScore?: number;
-  hybrid?: {
-    enabled: boolean;
-    vectorWeight?: number;
-    textWeight?: number;
-    temporalDecay?: { enabled: boolean };
-  };
 };
 
 type ProviderCall = {
@@ -525,7 +519,6 @@ export function createManagerIndexFixture(deps: {
       sources: ["memory", "sessions"],
       sessionMemory: true,
       minScore: 0,
-      hybrid: { enabled: true, vectorWeight: 0.7, textWeight: 0.3 },
     });
     const manager = requireManager(await deps.getMemorySearchManager({ cfg, agentId: "main" }));
     trackManager(manager);

--- a/extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts
+++ b/extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts
@@ -29,7 +29,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "none",
       minScore: 0.35,
-      hybrid: { enabled: true },
     });
     const result = await getMemorySearchManager({ cfg, agentId: "main" });
     const manager = requireManager(result);
@@ -60,7 +59,6 @@ describe("memory index", () => {
   it.each([
     {
       name: "slug path stem",
-      config: { hybrid: { enabled: true } },
       exactFile: "project-lantern.md",
       bodyText: "Project lantern project lantern project lantern.",
       query: "project-lantern",
@@ -68,7 +66,6 @@ describe("memory index", () => {
     },
     {
       name: "dated path stem",
-      config: {},
       exactFile: "2020-01-01.md",
       bodyText: "2020 01 01 2020 01 01 2020 01 01",
       query: "2020-01-01",
@@ -79,7 +76,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "none",
       minScore: 0.35,
-      ...testCase.config,
     });
     const result = await getMemorySearchManager({ cfg, agentId: "main" });
     const manager = requireManager(result);
@@ -107,7 +103,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "none",
       minScore: 0,
-      hybrid: { enabled: true },
     });
     const result = await getMemorySearchManager({ cfg, agentId: "main" });
     const manager = requireManager(result);
@@ -135,9 +130,7 @@ describe("memory index", () => {
 
   it("bounds the merged six-term fallback candidate set", async () => {
     providerFixture.forceNoProvider = true;
-    const manager = await getPersistentManager(
-      createCfg({ provider: "none", minScore: 0, hybrid: { enabled: true } }),
-    );
+    const manager = await getPersistentManager(createCfg({ provider: "none", minScore: 0 }));
     const terms = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta"];
     for (const term of terms) {
       for (let index = 0; index < 5; index += 1) {
@@ -157,9 +150,7 @@ describe("memory index", () => {
 
   it("counts exact candidate headroom by distinct path instead of chunk", async () => {
     providerFixture.forceNoProvider = true;
-    const manager = await getPersistentManager(
-      createCfg({ provider: "none", minScore: 0, hybrid: { enabled: true } }),
-    );
+    const manager = await getPersistentManager(createCfg({ provider: "none", minScore: 0 }));
     for (let index = 0; index < 200; index += 1) {
       const dir = path.join(fixture.paths.memory, index.toString().padStart(3, "0"));
       await fs.mkdir(dir, { recursive: true });
@@ -179,7 +170,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "none",
       minScore: 0,
-      hybrid: { enabled: true },
     });
     const result = await getMemorySearchManager({ cfg, agentId: "main" });
     const manager = requireManager(result);
@@ -350,7 +340,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "none",
       minScore: 0,
-      hybrid: { enabled: true },
     });
     const result = await getMemorySearchManager({ cfg, agentId: "main" });
     const manager = requireManager(result);
@@ -393,7 +382,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "none",
       minScore: 0,
-      hybrid: { enabled: true },
     });
     const result = await getMemorySearchManager({ cfg, agentId: "main" });
     const manager = requireManager(result);
@@ -474,7 +462,6 @@ describe("memory index", () => {
         provider: "none",
         ftsTokenizer: "trigram",
         minScore: 0,
-        hybrid: { enabled: true },
       }),
     );
     if (!manager.status().fts?.available) {
@@ -496,7 +483,6 @@ describe("memory index", () => {
       createCfg({
         ftsTokenizer: "trigram",
         minScore: 0,
-        hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
       }),
     );
     if (!manager.status().fts?.available) {

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle-fallback.test.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle-fallback.test.ts
@@ -15,7 +15,6 @@ describe("memory index", () => {
   it("does not activate fallback during search when index identity is already mismatched", async () => {
     const cfg = createCfg({
       fallback: "fallback-provider",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const manager = await getPersistentManager(cfg);
 
@@ -162,7 +161,6 @@ describe("memory index", () => {
   it("reinitializes the configured provider after probe-time local degradation", async () => {
     const cfg = createCfg({
       fallback: "fallback-provider",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const manager = await getPersistentManager(cfg);
 
@@ -326,7 +324,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "openai",
       minScore: 0.35,
-      hybrid: { enabled: true },
     });
     const manager = await getFreshManager(cfg);
     try {
@@ -349,7 +346,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "openai",
       minScore: 0.35,
-      hybrid: { enabled: true },
     });
     const manager = await getFreshManager(cfg);
     try {

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle-leases.test.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle-leases.test.ts
@@ -300,7 +300,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "openai",
       fallback: "fallback-provider",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });
@@ -328,7 +327,6 @@ describe("memory index", () => {
   it("retries the optional primary after fallback initialization fails", async () => {
     const cfg = createCfg({
       fallback: "fallback-provider",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });
@@ -361,7 +359,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "openai",
       fallback: "fallback-provider",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });
@@ -387,7 +384,6 @@ describe("memory index", () => {
   it("retries an optional primary after a null fallback result", async () => {
     const cfg = createCfg({
       fallback: "fallback-provider",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });
@@ -412,7 +408,6 @@ describe("memory index", () => {
   it("keeps concurrent optional searches in FTS mode when shared fallback fails", async () => {
     const cfg = createCfg({
       fallback: "fallback-provider",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle.test.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle.test.ts
@@ -199,7 +199,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "openai",
       fallback: "fallback-provider",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });
@@ -255,7 +254,6 @@ describe("memory index", () => {
         provider: "openai",
         fallback: "fallback-provider",
         cacheEnabled: true,
-        hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
       }),
       "cli",
     );

--- a/extensions/memory-core/src/memory/manager-registry.test.ts
+++ b/extensions/memory-core/src/memory/manager-registry.test.ts
@@ -23,9 +23,7 @@ describe("memory index", () => {
     providerFixture.providerCloseGate = new Promise<void>((resolve) => {
       releaseProviderClose = resolve;
     });
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     const first = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
     trackManager(first);
     await first.probeEmbeddingAvailability();
@@ -78,9 +76,7 @@ describe("memory index", () => {
     providerFixture.providerCloseGate = new Promise<void>((resolve) => {
       releaseProviderClose = resolve;
     });
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     const first = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
     trackManager(first);
     await first.probeEmbeddingAvailability();
@@ -116,7 +112,6 @@ describe("memory index", () => {
   it("serializes concurrent acquisitions with different cache identities", async () => {
     const firstCfg = createCfg({
       model: "first-model",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const first = requireManager(await getMemorySearchManager({ cfg: firstCfg, agentId: "main" }));
     trackManager(first);
@@ -187,7 +182,6 @@ describe("memory index", () => {
   it("does not block another agent while one scope retires its manager", async () => {
     const firstCfg = createCfg({
       model: "first-model",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
     });
     const first = requireManager(await getMemorySearchManager({ cfg: firstCfg, agentId: "main" }));
     trackManager(first);
@@ -277,9 +271,7 @@ describe("memory index", () => {
   });
 
   it("declines a maintenance manager that arrives during global teardown", async () => {
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
     trackManager(manager);
     await manager.probeEmbeddingAvailability();
@@ -302,9 +294,7 @@ describe("memory index", () => {
   });
 
   it("retains a failed scoped close owner until provider retirement succeeds", async () => {
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     const first = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
     trackManager(first);
     await first.probeEmbeddingAvailability();
@@ -337,9 +327,7 @@ describe("memory index", () => {
   });
 
   it("retains a failed global close owner until provider retirement succeeds", async () => {
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     const first = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
     trackManager(first);
     await first.probeEmbeddingAvailability();
@@ -416,9 +404,7 @@ describe("memory index", () => {
 
   it("retries embedding provider close before releasing the manager", async () => {
     providerFixture.providerCloseFailuresRemaining = 1;
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     const manager = await getFreshManager(cfg);
 
     await manager.probeEmbeddingAvailability();

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -8,10 +8,7 @@ import { recordMemoryEntryOrigins } from "../memory-entry-origins.js";
 import { forgetMemoryEntries } from "../memory-forget.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import { MemoryIndexRevisionConflictError } from "./manager-db.js";
-import {
-  createManagerIndexFixture,
-  type ManagerIndexFixtureConfig,
-} from "./manager-index.test-support.js";
+import { createManagerIndexFixture } from "./manager-index.test-support.js";
 import * as knnSubprocess from "./manager-search-knn-subprocess.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
@@ -51,30 +48,18 @@ describe("memory index", () => {
     }
   }
 
-  it.each([
-    {
-      name: "zero vector weight",
-      config: {
-        hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
-      } satisfies ManagerIndexFixtureConfig,
+  it.each([0, 0.35])(
+    "finds keyword matches through default hybrid search at minimum score %s",
+    async (minScore) => {
+      await expectHybridKeywordSearchFindsMemory(createCfg({ minScore }));
     },
-    {
-      name: "minimum score exceeds text weight",
-      config: {
-        minScore: 0.35,
-        hybrid: { enabled: true, vectorWeight: 0.7, textWeight: 0.3 },
-      } satisfies ManagerIndexFixtureConfig,
-    },
-  ])("finds keyword matches via hybrid search when $name", async ({ config }) => {
-    await expectHybridKeywordSearchFindsMemory(createCfg(config));
-  });
+  );
 
   it("keeps one search generation while a concurrent reindex waits to publish", async () => {
     const manager = await getPersistentManager(
       createCfg({
         vectorEnabled: true,
         minScore: 0,
-        hybrid: { enabled: true, vectorWeight: 1, textWeight: 0 },
       }),
     );
     await manager.sync({ reason: "test" });
@@ -153,9 +138,7 @@ describe("memory index", () => {
   });
 
   it("retries transient query embedding transport failures during search", async () => {
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });
 
@@ -191,9 +174,7 @@ describe("memory index", () => {
   });
 
   it("fails search after bounded query embedding retries are exhausted", async () => {
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });
 
@@ -223,9 +204,7 @@ describe("memory index", () => {
   });
 
   it("keeps a healthy local provider active when the caller cancels search", async () => {
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
+    const cfg = createCfg({});
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });
 
@@ -272,7 +251,6 @@ describe("memory index", () => {
     const manager = await getPersistentManager(
       createCfg({
         minScore: 0,
-        hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
       }),
     );
     await manager.sync({ reason: "test" });
@@ -368,7 +346,6 @@ describe("memory index", () => {
     const manager = await getPersistentManager(
       createCfg({
         minScore: 0,
-        hybrid: { enabled: true, vectorWeight: 0.7, textWeight: 0.3 },
       }),
     );
     await manager.sync({ reason: "test" });
@@ -387,7 +364,6 @@ describe("memory index", () => {
   it("bounds per-keyword FTS fallback in provider-backed hybrid search", async () => {
     const cfg = createCfg({
       minScore: 0.35,
-      hybrid: { enabled: true, vectorWeight: 0.7, textWeight: 0.3 },
     });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });
@@ -430,7 +406,6 @@ describe("memory index", () => {
     const manager = await getPersistentManager(
       createCfg({
         minScore: 0,
-        hybrid: { enabled: true, vectorWeight: 0, textWeight: 1 },
       }),
     );
     await fs.writeFile(
@@ -489,7 +464,6 @@ describe("memory index", () => {
         provider: "none",
         rememberAcrossConversations: true,
         minScore: 0,
-        hybrid: { enabled: true, vectorWeight: 0.7, textWeight: 0.3 },
       });
       const manager = await getFreshManager(cfg);
       trackManager(manager);
@@ -524,9 +498,7 @@ describe("memory index", () => {
   });
 
   it("returns before provider or index bootstrap for a blank query", async () => {
-    const manager = await getPersistentManager(
-      createCfg({ provider: "required-provider", hybrid: { enabled: true } }),
-    );
+    const manager = await getPersistentManager(createCfg({ provider: "required-provider" }));
     providerFixture.providerCalls = [];
 
     await expect(manager.search(" \n\t ")).resolves.toStrictEqual([]);
@@ -535,9 +507,7 @@ describe("memory index", () => {
   });
 
   it("does not block querying on session reconciliation", async () => {
-    const manager = await getPersistentManager(
-      createCfg({ provider: "none", minScore: 0, hybrid: { enabled: true } }),
-    );
+    const manager = await getPersistentManager(createCfg({ provider: "none", minScore: 0 }));
     await manager.sync({ reason: "test" });
 
     let releaseSync = () => {};
@@ -581,7 +551,6 @@ describe("memory index", () => {
         sources: ["memory", "sessions"],
         sessionMemory: true,
         minScore: 0,
-        hybrid: { enabled: true },
       });
       const manager = await getPersistentManager(cfg);
       await manager.sync({ reason: "test", force: true });
@@ -691,7 +660,6 @@ describe("memory index", () => {
       provider: "none",
       sources: ["memory"],
       minScore: 0,
-      hybrid: { enabled: true },
     });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test", force: true });
@@ -781,7 +749,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "none",
       minScore: 0,
-      hybrid: { enabled: true },
     });
     const initialManager = await getFreshManager(cfg, "cli");
     await initialManager.sync({ reason: "test", force: true });
@@ -870,9 +837,7 @@ describe("memory index", () => {
   ])(
     "restores a failed maintenance generation after $name and still closes its transient manager",
     async ({ error: syncError, expectedSyncCalls }) => {
-      const manager = await getPersistentManager(
-        createCfg({ provider: "none", minScore: 0, hybrid: { enabled: true } }),
-      );
+      const manager = await getPersistentManager(createCfg({ provider: "none", minScore: 0 }));
       await manager.sync({ reason: "test" });
       const maintenance = {
         adoptReindexRetryState: vi.fn(),
@@ -926,7 +891,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       provider: "none",
       minScore: 0,
-      hybrid: { enabled: true },
     });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "baseline" });
@@ -950,9 +914,7 @@ describe("memory index", () => {
   });
 
   it("does not let a no-op sync hide a later detached failure", async () => {
-    const manager = await getPersistentManager(
-      createCfg({ provider: "none", minScore: 0, hybrid: { enabled: true } }),
-    );
+    const manager = await getPersistentManager(createCfg({ provider: "none", minScore: 0 }));
     await manager.sync({ reason: "baseline" });
     const maintenanceStarted = createDeferred<void>();
     const releaseMaintenance = createDeferred<void>();
@@ -996,7 +958,6 @@ describe("memory index", () => {
     const cfg = createCfg({
       fallback: "fallback-provider",
       minScore: 0,
-      hybrid: { enabled: true },
     });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test", force: true });
@@ -1046,9 +1007,7 @@ describe("memory index", () => {
   });
 
   it("does not let a rejected maintenance handoff abort manager teardown", async () => {
-    const manager = await getPersistentManager(
-      createCfg({ provider: "none", minScore: 0, hybrid: { enabled: true } }),
-    );
+    const manager = await getPersistentManager(createCfg({ provider: "none", minScore: 0 }));
     await manager.sync({ reason: "test" });
     Reflect.set(manager, "dirty", true);
     const syncSpy = vi


### PR DESCRIPTION
## Summary

The Memory manager fixture accepted `hybrid` settings that it never applied. Tests passed 69 ignored options, including a case labeled “zero vector weight” that actually used the built-in 0.7/0.3 weights.

Remove the unused fixture option and its arguments, make its remaining config type private, and name the two real minimum-score cases accurately. Keep both thresholds, 0 and 0.35, and all existing SQLite, ranking, watcher, and lifecycle assertions. This removes 113 lines of test/support code with no production changes.

## Validation

- All seven affected Memory suites passed together: 148 tests.
- Full classified changed gate passed, including test typechecking, five Doctor contract cases, all three unused-export scans, formatting, and lint.
- Source comparisons preserved all 562 nested assertion expressions, the config-producing function body, the concurrent batch rendezvous, and the watcher/publication sources. The gate's initial unused-type-export finding was fixed; the sole post-test type-only change emits byte-identical JavaScript.

No database schema, runtime configuration, timeout, mock behavior, or dependency changes. No new build, Gateway restart, or live-provider claim is made for this test-only cleanup.
