### PR TITLE
fix(test): drain Git stdin in merge authorization fixtures

### DIFF
--- a/test/scripts/pr-crabbox-merge-bypass.test.ts
+++ b/test/scripts/pr-crabbox-merge-bypass.test.ts
@@ -323,14 +323,25 @@ describe("Crabbox admin merge bypass verifier", () => {
 
 function runProtectedShell(
   command: string,
-  { role = "admin", state = "active", denied = "", override = false, revoke = false } = {},
+  {
+    role = "admin",
+    state = "active",
+    denied = "",
+    override = false,
+    revoke = false,
+    longPreview = false,
+  } = {},
 ) {
   const root = mkdtempSync(join(tmpdir(), "pr-crabbox-protected-"));
   const bin = join(root, "bin");
   mkdirSync(bin);
   mkdirSync(join(root, ".local"));
   writeFileSync(join(root, "calls.jsonl"), "");
-  const evidence = input();
+  const evidence = {
+    ...input(),
+    // Exercise pipe backpressure during trailer parsing without changing authorization.
+    mergePreview: "Reviewed fixture body".repeat(longPreview ? 16_384 : 1),
+  };
   const reviewComments = validClawsweeperReviewCommentPages(131091, headSha);
   evidence.membership.role = role;
   evidence.membership.state = state;
@@ -362,7 +373,7 @@ else if (args[0] === "pr" && args[1] === "checks" && args.includes("--required")
 else if (args[0] === "pr" && args[1] === "merge") out("synthetic merge request accepted");
 else if (args[0] === "workflow" && args[1] === "run") { value.dispatched = true; save(); }
 else if (endpoint === "graphql" && args.some(arg => arg.includes("viewerMergeBodyText"))) {
-  out({data:{repository:{pullRequest:{...pr,viewerMergeBodyText:"Reviewed fixture body"}}}});
+  out({data:{repository:{pullRequest:{...pr,viewerMergeBodyText:value.mergePreview}}}});
 }
 else if (endpoint === "graphql" && args.some(arg => arg.includes("repository(owner:"))) {
   out({data:{repository:{...repo,ref:{target:{oid:"${mainSha}"}},pullRequest:pr}}});
@@ -412,7 +423,8 @@ else if (endpoint === "graphql" && args.includes("query=query { viewer { login }
       fetch|cat-file|merge-base) exit 0;;
       merge-tree) echo candidate-tree;;
       rev-parse) echo main-tree;;
-      -c) exit 0;;
+      # The trailer parser writes stdin; drain it before exit to avoid EPIPE.
+      -c) cat >/dev/null; exit 0;;
       *) echo "unexpected fixture git: $*" >&2; exit 19;;
     esac`,
     aws: "exit 19",
@@ -585,13 +597,14 @@ describe("Crabbox authorization before final effects", () => {
   });
 
   it.each([
-    { role: "member", revoke: false, reads: 1, merges: 0 },
-    { role: "admin", revoke: false, reads: 2, merges: 1 },
-    { role: "admin", revoke: true, reads: 2, merges: 0 },
+    { role: "member", revoke: false, reads: 1, merges: 0, longPreview: false },
+    { role: "admin", revoke: false, reads: 2, merges: 1, longPreview: false },
+    { role: "admin", revoke: false, reads: 2, merges: 1, longPreview: true },
+    { role: "admin", revoke: true, reads: 2, merges: 0, longPreview: false },
   ])(
-    "gates admin merge on $role membership (revoked=$revoke)",
-    ({ role, revoke, reads, merges }) => {
-      const result = runProtectedShell(mergeAuthorizationCommand, { role, revoke });
+    "gates admin merge on $role membership (revoked=$revoke, long preview=$longPreview)",
+    ({ role, revoke, reads, merges, longPreview }) => {
+      const result = runProtectedShell(mergeAuthorizationCommand, { role, revoke, longPreview });
       const output = result.stdout + result.stderr;
       expect(result.status, output).toBe(1);
       const viewers = result.calls.filter((args) =>
@@ -601,7 +614,7 @@ describe("Crabbox authorization before final effects", () => {
         args.includes("orgs/openclaw/memberships/maintainer"),
       );
       const requests = result.calls.filter((args) => args[0] === "pr" && args[1] === "merge");
-      expect(viewers).toHaveLength(reads);
+      expect(viewers, output).toHaveLength(reads);
       expect(memberships).toHaveLength(reads);
       expect(requests).toHaveLength(merges);
       expect(result.calls.some((args) => args.includes("user") || args[0] === "workflow")).toBe(


### PR DESCRIPTION
## Summary

The merge authorization fixture's fake Git command exited without reading stdin. The real squash-message helper supplies trailer input through `spawnSync`, so the mock could report a successful exit together with EPIPE and stop the fixture before its second authorization check. Drain that input before the mock exits; production merge and authorization code stays unchanged.

Extend the existing authorization table with a long synthetic preview that exposes pipe backpressure, and include shell output in the existing viewer-count assertion. The original membership, revocation, ordering and merge-request assertions are preserved.

## Validation

- Before the fix, the added long-preview case fails with the trailer-parsing error while the original three authorization cases pass.
- After the fix, all 46 protected-request/authorization and CI-dispatch tests pass.
- A separate probe extracts the exact Git stub from the before/after test files: the original reports status 0 plus EPIPE; the fixed stub allows the unchanged compose helper to return all 344,065 expected bytes.
- Full classified changed-file gate passed, including test-root typechecking and script/test lint.

The original small-input Linux CI failure was not reproduced locally. This repairs the independently proven mock defect; it does not claim conclusive attribution for that historical failure. All administrative and GitHub commands in these tests use task-local fakes.
