### PR TITLE
fix(agents): derive compaction targets after runtime admission

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1730,7 +1730,7 @@ src/agents/embedded-agent-runner/cache-ttl.ts	2
 src/agents/embedded-agent-runner/cli-backend-dispatch-transcript.ts	7
 src/agents/embedded-agent-runner/cli-backend-dispatch.ts	1
 src/agents/embedded-agent-runner/compact.hooks.harness.ts	8
-src/agents/embedded-agent-runner/compact.queued.ts	3
+src/agents/embedded-agent-runner/compact.queued.ts	2
 src/agents/embedded-agent-runner/compaction-diagnostics.ts	5
 src/agents/embedded-agent-runner/compaction-hooks.ts	1
 src/agents/embedded-agent-runner/compaction-session-agent.ts	7

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -110,6 +110,8 @@ The built-in OpenClaw runtime starts compaction with the active session model. S
 
 Bare configured aliases resolve to their canonical provider and model before compaction starts. If a bare value matches both an alias and a configured literal model ID, the literal model ID wins. An unmatched bare value remains a model ID on the active provider.
 
+If Gateway configuration reloads while compaction is waiting to start, compaction uses the newly loaded context engine and model settings together. Its requested workspace and transcript stay the same.
+
 This works with local models too, for example a second Ollama model dedicated to summarization:
 
 ```json

--- a/src/agents/embedded-agent-runner.cache.live.test.ts
+++ b/src/agents/embedded-agent-runner.cache.live.test.ts
@@ -1335,6 +1335,14 @@ describeCacheLive("embedded agent runner prompt caching (live)", () => {
       "preserves cache-safe shaping across compaction followup turns",
       async () => {
         const sessionId = `${ANTHROPIC_SESSION_ID}-compaction`;
+        const { workspaceDir } = buildRunnerSessionPaths(sessionId);
+        await fs.mkdir(workspaceDir, { recursive: true });
+        // Extra system context sits after the cache boundary. Workspace context must
+        // make the marked prefix exceed Haiku 4.5's 4,096-token cache minimum.
+        await fs.writeFile(
+          path.join(workspaceDir, "AGENTS.md"),
+          buildStableCachePrefix("anthropic-compaction", 96),
+        );
         await runEmbeddedCacheProbe({
           ...fixture,
           cacheRetention: "short",

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -10,6 +10,10 @@ import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { clearAgentHarnesses } from "../harness/registry.js";
 import type { AgentHarness } from "../harness/types.js";
 import type { ModelAuthMode } from "../model-auth.js";
+import type {
+  PreparedModelRuntimeInput,
+  PreparedModelRuntimeLeaseOptions,
+} from "../prepared-model-runtime.types.js";
 import type { AgentRuntimePlan, BuildAgentRuntimePlanParams } from "../runtime-plan/types.js";
 import {
   agentSessionAutomaticCompaction,
@@ -451,7 +455,7 @@ const emptyPluginMetadataSnapshot: PluginMetadataSnapshot = {
 };
 
 export const acquireAgentRunPreparedModelRuntimeMock = vi.fn(
-  async (input: Record<string, unknown>) => ({
+  async (input: PreparedModelRuntimeInput, _options?: PreparedModelRuntimeLeaseOptions) => ({
     snapshot: {
       agentId: input.agentId,
       agentDir: input.agentDir,
@@ -465,7 +469,7 @@ export const acquireAgentRunPreparedModelRuntimeMock = vi.fn(
     release: vi.fn(),
   }),
 );
-export const getCurrentPluginMetadataSnapshotMock: Mock<
+const getCurrentPluginMetadataSnapshotMock: Mock<
   typeof import("../../plugins/current-plugin-metadata-snapshot.js").getCurrentPluginMetadataSnapshot
 > = vi.fn(() => emptyPluginMetadataSnapshot);
 

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -14,8 +14,10 @@ import {
   patchSessionEntryCore,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { delegateCompactionToRuntime } from "../../context-engine/delegate.js";
 import type { ContextEngine } from "../../context-engine/types.js";
+import { racePromiseWithAbortSignal } from "../../infra/abort-signal.js";
 import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import {
   requireActivePluginRegistry,
@@ -40,7 +42,6 @@ import { SettingsManager } from "../sessions/settings-manager.js";
 import {
   acquireAgentRunPreparedModelRuntimeMock,
   attemptServerEndpointCompactionMock,
-  getCurrentPluginMetadataSnapshotMock,
   applyExtraParamsToAgentMock,
   applyAgentCompactionSettingsFromConfigMock,
   buildEmbeddedExtensionFactoriesMock,
@@ -188,6 +189,17 @@ function mockCallArg(mock: ReturnType<typeof vi.fn>, callIndex = 0, argIndex = 0
     throw new Error(`Expected mock call ${callIndex}`);
   }
   return call[argIndex];
+}
+
+function plannedCompactionPluginSelections(
+  config: OpenClawConfig,
+  metadataSnapshot = createPluginMetadataSnapshotFixture({ plugins: [] }),
+) {
+  const derive = expectDefined(
+    acquireAgentRunPreparedModelRuntimeMock.mock.calls[0]?.[1]?.deriveRuntimePluginSelections,
+    "admitted compaction selection recipe",
+  );
+  return derive({ config, metadataSnapshot });
 }
 
 function findMockCall(mock: ReturnType<typeof vi.fn>, predicate: (arg: unknown[]) => boolean) {
@@ -664,6 +676,41 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     );
   });
 
+  it("cancels direct compaction while prepared runtime admission is waiting", async () => {
+    const controller = new AbortController();
+    const started = createDeferred();
+    const resume = createDeferred();
+    const acquire = expectDefined(
+      acquireAgentRunPreparedModelRuntimeMock.getMockImplementation(),
+      "prepared runtime acquisition",
+    );
+    acquireAgentRunPreparedModelRuntimeMock.mockImplementationOnce(async (input, options) => {
+      started.resolve();
+      await racePromiseWithAbortSignal(resume.promise, options?.abortSignal);
+      return await acquire(input, options);
+    });
+    const pending = compactEmbeddedAgentSessionDirect(
+      wrappedCompactionArgs({ abortSignal: controller.signal }),
+    );
+    const stopped = pending.then(
+      () => "completed",
+      (error: unknown) => error,
+    );
+    try {
+      await started.promise;
+      const reason = new Error("direct compaction cancelled during admission");
+      controller.abort(reason);
+      // Releasing admission after cancellation must never enter model/session preparation.
+      resume.resolve();
+      expect(await stopped).toMatchObject({ name: "AbortError", cause: reason });
+      expect(resolveModelAsyncMock).not.toHaveBeenCalled();
+      expect(createAgentSessionMock).not.toHaveBeenCalled();
+    } finally {
+      resume.resolve();
+      await stopped;
+    }
+  });
+
   it("refreshes the delegated watchdog before post-compaction hooks", async () => {
     const compactionTimeoutReset = vi.fn();
     hookRunner.hasHooks.mockImplementation((name?: string) => name === "after_compaction");
@@ -1059,7 +1106,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
     });
 
-    expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
+    expect(mockCallArg(acquireAgentRunPreparedModelRuntimeMock)).toEqual(
       expect.objectContaining({ config: {}, workspaceDir: join(TEST_WORKSPACE_DIR, "workspace") }),
     );
   });
@@ -1093,7 +1140,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     );
 
     expect(result.ok).toBe(true);
-    expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
+    expect(mockCallArg(acquireAgentRunPreparedModelRuntimeMock)).toEqual(
       expect.objectContaining({ agentId: "marie-clawndo" }),
     );
   });
@@ -1116,7 +1163,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       allowGatewaySubagentBinding: true,
     });
 
-    expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
+    expect(mockCallArg(acquireAgentRunPreparedModelRuntimeMock)).toEqual(
       expect.objectContaining({
         config: {},
         workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
@@ -1168,6 +1215,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       const { snapshot } = await acquireAgentRunPreparedModelRuntimeMock({
         config,
         agentId: "marketing",
+        agentDir: TEST_WORKSPACE_DIR,
         workspaceDir: TEST_WORKSPACE_DIR,
       });
 
@@ -2078,36 +2126,46 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
   });
 
   it("plans runtime plugins for the canonical model behind a fallback alias", async () => {
+    const config = {
+      agents: {
+        defaults: { models: { "anthropic/claude-fallback": { alias: "summary-backup" } } },
+      },
+    };
     const result = await compactEmbeddedAgentSessionDirect({
       ...wrappedCompactionArgs({ provider: "openai", model: "gpt-primary" }),
       agentHarnessId: "codex",
       modelFallbacksOverride: ["summary-backup"],
-      config: {
-        agents: {
-          defaults: {
-            models: {
-              "anthropic/claude-fallback": { alias: "summary-backup" },
-            },
-          },
-        },
-      } as never,
+      config,
     });
 
     expect(result.ok).toBe(true);
-    expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
+    expect(plannedCompactionPluginSelections(config)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider: "anthropic",
+          modelId: "claude-fallback",
+          runtime: "codex",
+        }),
+      ]),
+    );
+    const admittedConfig = {
+      agents: {
+        defaults: {
+          ...config.agents.defaults,
+          compaction: { model: "anthropic/reloaded-summary" },
+        },
+      },
+    };
+    expect(plannedCompactionPluginSelections(admittedConfig)).toContainEqual(
       expect.objectContaining({
-        runtimePluginSelections: expect.arrayContaining([
-          expect.objectContaining({
-            provider: "anthropic",
-            modelId: "claude-fallback",
-            runtime: "codex",
-          }),
-        ]),
+        provider: "anthropic",
+        modelId: "reloaded-summary",
+        runtime: "codex",
       }),
     );
   });
 
-  it("plans direct compaction from the requested workspace metadata without ambient discovery", async () => {
+  it("plans direct compaction with the admitted workspace manifest policy", async () => {
     const metadataSnapshot = {
       ...createPluginMetadataSnapshotFixture({
         plugins: [
@@ -2130,10 +2188,6 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       }),
       configFingerprint: "workspace-compaction-normalization",
     };
-    getCurrentPluginMetadataSnapshotMock.mockImplementation((params) =>
-      params?.workspaceDir === TEST_WORKSPACE_DIR ? metadataSnapshot : undefined,
-    );
-
     const result = await compactEmbeddedAgentSessionDirect({
       ...wrappedCompactionArgs({ provider: "openai", model: "gpt-primary" }),
       agentHarnessId: "codex",
@@ -2142,23 +2196,14 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     });
 
     expect(result.ok, JSON.stringify(result)).toBe(true);
-    expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        runtimePluginSelections: expect.arrayContaining([
-          expect.objectContaining({
-            provider: "anthropic",
-            modelId: "claude-modern",
-            runtime: "codex",
-          }),
-        ]),
-      }),
-    );
-    expect(getCurrentPluginMetadataSnapshotMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        config: {},
-        workspaceDir: TEST_WORKSPACE_DIR,
-        allowWorkspaceScopedSnapshot: true,
-      }),
+    expect(plannedCompactionPluginSelections({}, metadataSnapshot)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider: "anthropic",
+          modelId: "claude-modern",
+          runtime: "codex",
+        }),
+      ]),
     );
   });
 
@@ -3469,7 +3514,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     );
     let hostActive = true;
     acquireAgentRunPreparedModelRuntimeMock.mockImplementationOnce((async (
-      input: Record<string, unknown>,
+      input: Parameters<typeof acquireAgentRunPreparedModelRuntimeMock>[0],
     ) => {
       admissionStarted.resolve(undefined);
       await releaseAdmission.promise;
@@ -3597,22 +3642,6 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     }
   });
 
-  it("uses the acquired gateway runtime generation for queued tiered model resolution", async () => {
-    await compactEmbeddedAgentSession(
-      wrappedCompactionArgs({
-        allowGatewaySubagentBinding: true,
-        provider: "openai",
-        model: "gpt-5.5",
-      }),
-    );
-
-    const snapshot = await acquiredPreparedModelRuntime();
-    expect(mockCallArg(resolveModelAsyncMock, 0, 4)).toMatchObject({
-      preparedModelRuntime: snapshot,
-      skipAgentDiscovery: true,
-    });
-  });
-
   it("does not require an implicit default owner for queued compaction", async () => {
     await upsertSessionEntryCore(
       {
@@ -3652,7 +3681,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     expect(result.ok).toBe(true);
     expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "marie-clawndo" }),
-      { abortSignal: undefined },
+      expect.objectContaining({ abortSignal: undefined }),
     );
   });
 

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -78,6 +78,7 @@ import type { EmbeddedAgentCompactResult } from "./types.js";
 
 type QueuedCompactionParams = CompactEmbeddedAgentSessionParams & {
   sessionTarget: SessionTranscriptRuntimeTarget;
+  sandbox?: SandboxContext | null;
 };
 
 function lockedCompactionRuntimeFailure(runtime?: string): EmbeddedAgentCompactResult {
@@ -113,23 +114,6 @@ function resolveManualCompactionActiveRunSessionId(
     (isEmbeddedAgentRunHandleActive(params.sessionId) ? params.sessionId : undefined) ??
     (params.sessionKey ? resolveActiveEmbeddedRunHandleSessionId(params.sessionKey) : undefined) ??
     resolveActiveEmbeddedRunHandleSessionIdBySessionFile(params.sessionFile)
-  );
-}
-
-function shouldDeferOwningContextEngineBudgetCompaction(params: {
-  compactParams: CompactEmbeddedAgentSessionParams;
-  contextEngine: ContextEngine;
-}): boolean {
-  // Request-time budget compaction for context-engine-owned transcripts can
-  // spend the whole reply preflight budget. Only defer engines that explicitly
-  // advertise background turn maintenance, leaving native/current-session
-  // harness compaction synchronous.
-  return (
-    params.compactParams.deferOwningContextEngineCompaction === true &&
-    params.compactParams.trigger === "budget" &&
-    params.contextEngine.info.ownsCompaction === true &&
-    params.contextEngine.info.turnMaintenanceMode === "background" &&
-    typeof params.contextEngine.maintain === "function"
   );
 }
 
@@ -345,11 +329,8 @@ async function compactEmbeddedAgentSessionImpl(
   });
   const agentDir = params.agentDir ?? resolveAgentDir(params.config ?? {}, agentIds.sessionAgentId);
   const resolvedWorkspaceDir = resolveUserPath(params.workspaceDir);
-  const placementParams = params as CompactEmbeddedAgentSessionParams & {
-    sandbox?: SandboxContext | null;
-  };
   const placementSandbox =
-    placementParams.sandbox === undefined
+    params.sandbox === undefined
       ? await resolveSessionPlacementSandbox({
           agentId: runtimeTarget.agentId,
           config: params.config,
@@ -359,14 +340,14 @@ async function compactEmbeddedAgentSessionImpl(
         })
       : null;
   assertQueuedCompactionPreparationActive(params, host);
-  const preparedParams = placementSandbox ? { ...params, sandbox: placementSandbox } : params;
-  const runtimeSelection = resolveCompactionRuntimeSelection({
-    ...preparedParams,
-    modelId: preparedParams.model,
-    boundHarnessRuntime: preparedParams.agentHarnessId,
-    preparedRuntimePlan: preparedParams.runtimePlan,
-    selectedHarnessRuntime: resolveSessionPinnedHarnessId(preparedParams.sessionEntry),
-  });
+  const requestedSelection = {
+    ...params,
+    modelId: params.model,
+    boundHarnessRuntime: params.agentHarnessId,
+    preparedRuntimePlan: params.runtimePlan,
+    selectedHarnessRuntime: resolveSessionPinnedHarnessId(params.sessionEntry),
+  };
+  const runtimeSelection = resolveCompactionRuntimeSelection(requestedSelection);
   // Native control operations reuse the backend's existing authenticated session.
   // Run them before generic model preparation so subscription-only CLI sessions do
   // not incorrectly require an OpenClaw model API credential.
@@ -391,23 +372,44 @@ async function compactEmbeddedAgentSessionImpl(
       agentDir,
       workspaceDir: resolvedWorkspaceDir,
       ...(params.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
-      runtimePluginSelections: [
-        {
-          provider: runtimeSelection.provider,
-          modelId: runtimeSelection.modelId,
-          ...(runtimeSelection.selectedHarnessRuntime
-            ? { runtime: runtimeSelection.selectedHarnessRuntime }
-            : {}),
-          agentId: agentIds.sessionAgentId,
-        },
-      ],
     },
-    { abortSignal: params.abortSignal },
+    {
+      abortSignal: params.abortSignal,
+      deriveRuntimePluginSelections: ({ config, metadataSnapshot }) => {
+        const selected = resolveCompactionRuntimeSelection({
+          ...requestedSelection,
+          config: projectCodexHostTranscriptBytePreflightConfig(
+            config,
+            Boolean(host.transcriptBytePreflightHarness),
+          ),
+          manifestPlugins: metadataSnapshot,
+          allowPluginNormalization: false,
+        });
+        return [
+          {
+            provider: selected.provider,
+            modelId: selected.modelId,
+            runtime: selected.selectedHarnessRuntime,
+            agentId: agentIds.sessionAgentId,
+          },
+        ];
+      },
+    },
   );
+  // Admission can replace config and agent storage while preserving the requested workspace.
+  const preparedParams = {
+    ...params,
+    ...(placementSandbox ? { sandbox: placementSandbox } : {}),
+    config: projectCodexHostTranscriptBytePreflightConfig(
+      lease.snapshot.config,
+      Boolean(host.transcriptBytePreflightHarness),
+    ),
+    agentDir: lease.snapshot.agentDir,
+  };
   const run = async () => {
     ensureContextEnginesInitialized();
-    const contextEngine = await resolveContextEngine(params.config, {
-      agentDir,
+    const contextEngine = await resolveContextEngine(preparedParams.config, {
+      agentDir: preparedParams.agentDir,
       workspaceDir: resolvedWorkspaceDir,
     });
     let disposeContextEngineOnExit = true;
@@ -420,7 +422,7 @@ async function compactEmbeddedAgentSessionImpl(
         expectedEntry,
         host,
         contextEngine,
-        agentDir,
+        preparedParams.agentDir,
         resolvedWorkspaceDir,
         lease.snapshot,
         contextEngineSessionKey,
@@ -667,11 +669,14 @@ async function compactResolvedContextEngine(
     return createQueuedCompactionAbortedResult();
   }
   host.assertActive?.();
+  // Budget maintenance may outlive reply preflight only when its engine owns
+  // the transcript and explicitly supports background turn maintenance.
   if (
-    shouldDeferOwningContextEngineBudgetCompaction({
-      compactParams: preparedParams,
-      contextEngine,
-    })
+    preparedParams.deferOwningContextEngineCompaction === true &&
+    preparedParams.trigger === "budget" &&
+    contextEngineOwnsCompaction &&
+    contextEngine.info.turnMaintenanceMode === "background" &&
+    typeof contextEngine.maintain === "function"
   ) {
     const deferredResult = await deferOwningContextEngineBudgetCompaction({
       compactParams: preparedParams,

--- a/src/agents/embedded-agent-runner/compact.runtime-generation.test.ts
+++ b/src/agents/embedded-agent-runner/compact.runtime-generation.test.ts
@@ -1,0 +1,101 @@
+import { realpath } from "node:fs/promises";
+import { join } from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  acquireAgentRunPreparedModelRuntimeMock,
+  contextEngineCompactMock,
+  loadCompactHooksHarness,
+  resetCompactHooksHarnessMocks,
+  resolveContextEngineMock,
+  resolveModelAsyncMock,
+} from "./compact.hooks.harness.js";
+
+const { compactEmbeddedAgentSession } = await loadCompactHooksHarness();
+const [{ upsertSessionEntryCore }, { closeOpenClawAgentDatabasesForTest }] = await Promise.all([
+  import("../../config/sessions/session-accessor.js"),
+  import("../../state/openclaw-agent-db.js"),
+]);
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    cleanup();
+  }),
+);
+
+it("uses the admitted config and agent storage throughout queued compaction", async () => {
+  const workspaceDir = await realpath(tempDirs.make("openclaw-compaction-generation-"));
+  resetCompactHooksHarnessMocks(workspaceDir);
+  const sessionTarget = {
+    agentId: "main",
+    sessionId: "compaction-generation",
+    sessionKey: "agent:main:compaction-generation",
+    storePath: join(workspaceDir, "sessions.sqlite"),
+  };
+  await upsertSessionEntryCore(sessionTarget, { sessionId: sessionTarget.sessionId, updatedAt: 1 });
+  const admittedAgentDir = join(workspaceDir, "admitted-agent");
+  const requestedConfig = {
+    agents: { defaults: { compaction: { model: "openai/requested-model" } } },
+  };
+  const admittedConfig = {
+    agents: { defaults: { compaction: { model: "openai/admitted-model" } } },
+  };
+  const acquire = expectDefined(
+    acquireAgentRunPreparedModelRuntimeMock.getMockImplementation(),
+    "prepared runtime acquisition",
+  );
+  acquireAgentRunPreparedModelRuntimeMock.mockImplementationOnce(async (input) =>
+    acquire({ ...input, config: admittedConfig, agentDir: admittedAgentDir }),
+  );
+
+  const result = await compactEmbeddedAgentSession({
+    ...sessionTarget,
+    sessionTarget,
+    sessionFile: sessionTarget.sessionKey,
+    workspaceDir,
+    allowGatewaySubagentBinding: true,
+    provider: "openai",
+    model: "gpt-5.6-luna",
+    config: requestedConfig,
+    enqueue: async (task) => await task(),
+  });
+
+  expect(result).toMatchObject({ ok: true, compacted: true });
+  const { snapshot, release } = await expectDefined(
+    acquireAgentRunPreparedModelRuntimeMock.mock.results[0]?.value,
+    "admitted runtime lease",
+  );
+  const derive = expectDefined(
+    acquireAgentRunPreparedModelRuntimeMock.mock.calls[0]?.[1]?.deriveRuntimePluginSelections,
+    "admitted compaction selection recipe",
+  );
+  expect(
+    derive({ config: admittedConfig, metadataSnapshot: snapshot.metadataSnapshot }),
+  ).toMatchObject([{ provider: "openai", modelId: "admitted-model", agentId: "main" }]);
+  expect(resolveContextEngineMock).toHaveBeenCalledWith(admittedConfig, {
+    agentDir: admittedAgentDir,
+    workspaceDir,
+  });
+  expect(resolveModelAsyncMock).toHaveBeenCalledWith(
+    "openai",
+    "admitted-model",
+    admittedAgentDir,
+    admittedConfig,
+    expect.objectContaining({ preparedModelRuntime: snapshot, skipAgentDiscovery: true }),
+  );
+  expect(contextEngineCompactMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      runtimeContext: expect.objectContaining({
+        config: admittedConfig,
+        agentDir: admittedAgentDir,
+        workspaceDir,
+        provider: "openai",
+        model: "admitted-model",
+        sessionTarget,
+      }),
+    }),
+  );
+  expect(release).toHaveBeenCalledOnce();
+  expect(requestedConfig.agents.defaults.compaction.model).toBe("openai/requested-model");
+});

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -6,7 +6,6 @@ import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor
 import { projectPublicSessionEntry } from "../../config/sessions/session-entry-projection.js";
 import { isAbortError } from "../../infra/abort-signal.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
 import { resolveSessionPinnedHarnessId } from "../../sessions/agent-harness-session-key.js";
 import { resolveUserPath } from "../../utils.js";
@@ -332,71 +331,67 @@ export async function compactEmbeddedAgentSessionDirect(
   ) {
     return lockedHarnessCompactionFailure(lockedHarnessRuntime);
   }
-  const pluginPlanCompactionTarget = resolveEmbeddedCompactionTarget({
-    config: requestedParams.config,
-    provider: requestedParams.provider,
-    modelId: requestedParams.model,
-    authProfileId: requestedParams.authProfileId,
-    modelSelectionLocked: requestedParams.modelSelectionLocked,
-    defaultProvider: DEFAULT_PROVIDER,
-    defaultModel: DEFAULT_MODEL,
-  });
-  const currentPluginMetadataSnapshot = getCurrentPluginMetadataSnapshot({
-    config: requestedParams.config ?? {},
-    workspaceDir: requestedWorkspaceDir,
-    env: process.env,
-    allowWorkspaceScopedSnapshot: true,
-  });
-  const pluginPlanCandidates = resolveModelCandidateChain({
-    cfg: requestedParams.config,
-    agentId: requestedAgentIds.sessionAgentId,
-    manifestPlugins: currentPluginMetadataSnapshot ?? [],
-    provider: pluginPlanCompactionTarget.provider ?? DEFAULT_PROVIDER,
-    model: pluginPlanCompactionTarget.model ?? DEFAULT_MODEL,
-    requestedRouteResolution: "resolved",
-    fallbacksOverride: transcriptBytePreflightAuthority
-      ? []
-      : resolveCompactionFallbacksOverride(requestedParams),
-  });
-  const runtimePluginSelections = [
+  const preparedModelRuntimeLease = await acquireAgentRunPreparedModelRuntime(
     {
-      provider: runtimeSelection.provider,
-      modelId: runtimeSelection.modelId,
-      ...(runtimeSelection.selectedHarnessRuntime
-        ? { runtime: runtimeSelection.selectedHarnessRuntime }
-        : {}),
+      config: requestedParams.config ?? {},
       agentId: requestedAgentIds.sessionAgentId,
+      agentDir: requestedAgentDir,
+      workspaceDir: requestedWorkspaceDir,
+      preserveWorkspaceDirOnRefresh: requestedWorkspaceDir !== canonicalWorkspaceDir,
+      ...(requestedParams.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
     },
-    ...pluginPlanCandidates
-      .filter(
-        (candidate) =>
-          candidate.provider !== runtimeSelection.provider ||
-          candidate.model !== runtimeSelection.modelId,
-      )
-      .map((candidate) =>
-        runtimeSelection.boundHarnessRuntime
-          ? {
+    {
+      abortSignal: requestedParams.abortSignal,
+      deriveRuntimePluginSelections: ({ config: admittedConfig, metadataSnapshot }) => {
+        const config = projectCodexHostTranscriptBytePreflightConfig(
+          admittedConfig,
+          Boolean(transcriptBytePreflightAuthority),
+        );
+        const selected = resolveCompactionRuntimeSelection({
+          ...requestedParams,
+          config,
+          modelId: requestedParams.model,
+          boundHarnessRuntime: requestedParams.agentHarnessId,
+          preparedRuntimePlan: requestedParams.runtimePlan,
+          manifestPlugins: metadataSnapshot,
+          allowPluginNormalization: false,
+        });
+        const pluginPlanCandidates = resolveModelCandidateChain({
+          cfg: config,
+          agentId: requestedAgentIds.sessionAgentId,
+          manifestPlugins: metadataSnapshot,
+          allowPluginNormalization: false,
+          provider: selected.provider,
+          model: selected.modelId,
+          requestedRouteResolution: "resolved",
+          fallbacksOverride: transcriptBytePreflightAuthority
+            ? []
+            : resolveCompactionFallbacksOverride({ ...requestedParams, config }),
+        });
+        return [
+          {
+            provider: selected.provider,
+            modelId: selected.modelId,
+            ...(selected.selectedHarnessRuntime
+              ? { runtime: selected.selectedHarnessRuntime }
+              : {}),
+            agentId: requestedAgentIds.sessionAgentId,
+          },
+          ...pluginPlanCandidates
+            .filter(
+              (candidate) =>
+                candidate.provider !== selected.provider || candidate.model !== selected.modelId,
+            )
+            .map((candidate) => ({
               provider: candidate.provider,
               modelId: candidate.model,
-              runtime: runtimeSelection.boundHarnessRuntime,
+              runtime: selected.boundHarnessRuntime,
               agentId: requestedAgentIds.sessionAgentId,
-            }
-          : {
-              provider: candidate.provider,
-              modelId: candidate.model,
-              agentId: requestedAgentIds.sessionAgentId,
-            },
-      ),
-  ];
-  const preparedModelRuntimeLease = await acquireAgentRunPreparedModelRuntime({
-    config: requestedParams.config ?? {},
-    agentId: requestedAgentIds.sessionAgentId,
-    agentDir: requestedAgentDir,
-    workspaceDir: requestedWorkspaceDir,
-    preserveWorkspaceDirOnRefresh: requestedWorkspaceDir !== canonicalWorkspaceDir,
-    ...(requestedParams.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
-    runtimePluginSelections,
-  });
+            })),
+        ];
+      },
+    },
+  );
   try {
     const preparedModelRuntimeOwnerSnapshot = preparedModelRuntimeLease.snapshot;
     const preparedConfig =

--- a/src/agents/embedded-agent-runner/compaction-runtime-admission.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-admission.test.ts
@@ -1,0 +1,200 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, afterEach, beforeEach, expect, it } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { loadAndActivateRootPluginRegistry } from "../../plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../../plugins/loader.test-fixtures.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  getPreparedModelRuntimeSnapshot,
+  refreshPreparedModelRuntimeSnapshots,
+} from "../prepared-model-runtime.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "../prepared-model-runtime.test-support.js";
+import { resolveCompactionRuntimeSelection } from "./compaction-runtime-preparation.js";
+
+let state: OpenClawTestState;
+beforeEach(async () => {
+  resetPreparedModelRuntimeSnapshotsForTest();
+  state = await createOpenClawTestState({ label: "compaction-provider-owner" });
+  useNoBundledPlugins();
+});
+afterEach(async () => {
+  resetPreparedModelRuntimeSnapshotsForTest();
+  resetPluginLoaderTestStateForTest();
+  await state.cleanup();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+it.each([
+  { nextProvider: "summary-new", locked: false },
+  { nextProvider: "summary-new", locked: false, alias: true },
+  { nextProvider: "summary-new", locked: false, mutate: "input" },
+  { nextProvider: "summary-new", locked: false, mutate: "recipe" },
+  { nextProvider: undefined, locked: false },
+  { nextProvider: "summary-new", locked: true },
+])(
+  "prepares compaction owners after reload (next=$nextProvider, locked=$locked, alias=$alias, mutate=$mutate)",
+  async ({ nextProvider, locked, alias, mutate }) => {
+    const ids = ["caller-provider", "requested-extra", "summary-old", "summary-new"];
+    const pluginPaths = await Promise.all(
+      ids.map(async (id) => {
+        const plugin = writePlugin({
+          id,
+          body: `module.exports = {
+            id: ${JSON.stringify(id)},
+            register(api) {
+              api.registerProvider({ id: ${JSON.stringify(id)}, label: ${JSON.stringify(id)}, auth: [] });
+            },
+          };`,
+        });
+        await fs.writeFile(
+          path.join(plugin.dir, "openclaw.plugin.json"),
+          JSON.stringify({
+            id,
+            providers: [id],
+            configSchema: { type: "object", properties: {}, additionalProperties: false },
+            modelIdNormalization: { providers: { [id]: { aliases: { legacy: "model" } } } },
+          }),
+        );
+        return plugin.dir;
+      }),
+    );
+    const gatewayWorkspace = state.workspaceDir;
+    const requestWorkspace = path.join(state.root, "requested-workspace");
+    const agentDir = state.agentDir("main");
+    await fs.mkdir(requestWorkspace, { recursive: true });
+    const config = (summaryProvider?: string): OpenClawConfig => ({
+      agents: {
+        ownership: "explicit",
+        entries: { main: { agentDir, workspace: gatewayWorkspace } },
+        defaults: {
+          model: "caller-provider/model",
+          models: { "summary-new/legacy": { alias: "summary-alias" } },
+          ...(summaryProvider
+            ? {
+                compaction: {
+                  model:
+                    alias && summaryProvider === "summary-new"
+                      ? "summary-alias"
+                      : `${summaryProvider}/model`,
+                },
+              }
+            : {}),
+        },
+      },
+      plugins: { allow: ids, load: { paths: pluginPaths }, slots: { memory: "none" } },
+    });
+    const previousConfig = config("summary-old");
+    const committedConfig = config(nextProvider);
+    loadAndActivateRootPluginRegistry({
+      config: previousConfig,
+      workspaceDir: gatewayWorkspace,
+      onlyPluginIds: ["caller-provider"],
+      cache: false,
+    });
+    const publication = { gatewayLifecycle: true, catalogMode: "static" as const };
+    await refreshPreparedModelRuntimeSnapshots(previousConfig, publication);
+    const requested = { provider: "caller-provider", modelId: "model", runtime: "openclaw" };
+    const extra = { ...requested, provider: "requested-extra" };
+    const input = {
+      config: previousConfig,
+      agentId: "main",
+      agentDir,
+      workspaceDir: requestWorkspace,
+      runtimePluginSelections: [requested, extra],
+    };
+    const previous = await acquireAgentRunPreparedModelRuntime({
+      ...input,
+      runtimePluginSelections: [requested, extra, { ...requested, provider: "summary-old" }],
+    });
+    const resumePublication = createDeferred();
+    const publishing = refreshPreparedModelRuntimeSnapshots(async () => {
+      await resumePublication.promise;
+      return committedConfig;
+    }, publication);
+    const admissionOptions = {
+      deriveRuntimePluginSelections: ({
+        config: admittedConfig,
+        metadataSnapshot,
+      }: {
+        config: OpenClawConfig;
+        metadataSnapshot: PluginMetadataSnapshot;
+      }) => {
+        const selection = resolveCompactionRuntimeSelection({
+          ...requested,
+          config: admittedConfig,
+          modelSelectionLocked: locked,
+          manifestPlugins: metadataSnapshot,
+          allowPluginNormalization: false,
+        });
+        return [{ provider: selection.provider, modelId: selection.modelId, runtime: "openclaw" }];
+      },
+    };
+    const pending = acquireAgentRunPreparedModelRuntime(input, admissionOptions);
+    const derive = admissionOptions.deriveRuntimePluginSelections;
+    if (mutate === "input") {
+      extra.provider = "summary-old";
+    } else if (mutate === "recipe") {
+      admissionOptions.deriveRuntimePluginSelections = () => [
+        { ...requested, provider: "summary-old" },
+      ];
+    }
+    try {
+      resumePublication.resolve();
+      await publishing;
+      const lease = await pending;
+      extra.provider = "requested-extra";
+      admissionOptions.deriveRuntimePluginSelections = derive;
+      try {
+        const providers = lease.snapshot.pluginRegistry?.providers.map(
+          ({ provider }) => provider.id,
+        );
+        expect(lease.snapshot.config).toBe(committedConfig);
+        expect(lease.snapshot.workspaceDir).toBe(requestWorkspace);
+        expect(providers).toEqual(
+          !locked && nextProvider
+            ? ["caller-provider", "requested-extra", nextProvider]
+            : ["caller-provider", "requested-extra"],
+        );
+        const expectedSelections = [requested, extra];
+        if (!locked && nextProvider) {
+          expectedSelections.push({ ...requested, provider: nextProvider });
+        }
+        expect(
+          getPreparedModelRuntimeSnapshot({
+            ...input,
+            config: committedConfig,
+            runtimePluginSelections: expectedSelections,
+          }),
+        ).toBe(lease.snapshot);
+        const repeated = await acquireAgentRunPreparedModelRuntime(input, admissionOptions);
+        expect(repeated.snapshot).toBe(lease.snapshot);
+        repeated.release();
+        expect(
+          previous.snapshot.pluginRegistry?.providers.map(({ provider }) => provider.id),
+        ).toEqual(["caller-provider", "requested-extra", "summary-old"]);
+      } finally {
+        lease.release();
+      }
+    } finally {
+      resumePublication.resolve();
+      await publishing;
+      await pending.then(
+        (lease) => lease.release(),
+        () => {},
+      );
+      previous.release();
+    }
+  },
+);

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.ts
@@ -13,6 +13,7 @@ import {
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_PROVIDER } from "../defaults.js";
 import { splitTrailingAuthProfile } from "../model-ref-profile.js";
+import type { ModelManifestNormalizationContext } from "../model-ref-shared.js";
 import {
   buildModelAliasIndex,
   inferUniqueProviderFromConfiguredModels,
@@ -111,6 +112,8 @@ export function resolveEmbeddedCompactionTarget(params: {
   modelSelectionLocked?: boolean;
   defaultProvider?: string;
   defaultModel?: string;
+  allowPluginNormalization?: boolean;
+  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
 }): {
   provider: string | undefined;
   runtimeProvider?: string;
@@ -126,34 +129,6 @@ export function resolveEmbeddedCompactionTarget(params: {
   const override = params.modelSelectionLocked
     ? undefined
     : params.config?.agents?.defaults?.compaction?.model?.trim();
-  const resolveTargetProviders = (
-    targetProvider: string | undefined,
-    authProfileId: string | undefined,
-  ) => {
-    if (!targetProvider) {
-      return {};
-    }
-    const selectedHarnessRuntime = normalizeOptionalAgentRuntimeId(params.harnessRuntime);
-    // Compaction follows the concrete session or prepared-plan owner. Provider
-    // defaults choose new runs; they cannot move an existing transcript.
-    const useNativeHarnessRuntime =
-      selectedHarnessRuntime !== undefined &&
-      selectedHarnessRuntime !== "openclaw" &&
-      !isDefaultAgentRuntimeId(selectedHarnessRuntime);
-    const harnessRuntime = useNativeHarnessRuntime ? selectedHarnessRuntime : "openclaw";
-    const runtimeProvider = resolveSelectedOpenAIRuntimeProvider({
-      provider: targetProvider,
-      harnessRuntime: harnessRuntime ?? undefined,
-      authProfileId,
-      config: params.config,
-    });
-    const routedRuntimeProvider = runtimeProvider === targetProvider ? undefined : runtimeProvider;
-    return {
-      runtimeProvider: routedRuntimeProvider,
-      contextProvider: useNativeHarnessRuntime ? routedRuntimeProvider : undefined,
-      ...(useNativeHarnessRuntime ? { nativeHarnessCompaction: true } : {}),
-    };
-  };
   const assembleTarget = (targetProvider: string | undefined, targetModel: string | undefined) => {
     // A provider switch cannot inherit credentials selected for the session's
     // original provider; all target paths share that boundary.
@@ -161,7 +136,7 @@ export function resolveEmbeddedCompactionTarget(params: {
       targetProvider !== provider ? undefined : (params.authProfileId ?? undefined);
     return {
       provider: targetProvider,
-      ...resolveTargetProviders(targetProvider, authProfileId),
+      ...resolveCompactionTargetRuntime(targetProvider, params.harnessRuntime),
       model: targetModel,
       authProfileId,
     };
@@ -201,12 +176,40 @@ export function resolveEmbeddedCompactionTarget(params: {
   const alias = listModelAliasCandidates(config).some(
     ({ alias: candidate }) => normalizeCompactionConfigKey(candidate) === aliasKey,
   )
-    ? buildModelAliasIndex({ cfg: config, defaultProvider }).byAlias.get(aliasKey)
+    ? buildModelAliasIndex({
+        cfg: config,
+        defaultProvider,
+        allowPluginNormalization: params.allowPluginNormalization,
+        manifestPlugins: params.manifestPlugins,
+      }).byAlias.get(aliasKey)
     : undefined;
   if (alias) {
     return assembleTarget(alias.ref.provider, alias.ref.model);
   }
   return assembleTarget(provider, override);
+}
+
+/** Binds harness ownership without repeating model or alias selection. */
+export function resolveCompactionTargetRuntime(
+  provider: string | undefined,
+  harnessRuntime?: string | null,
+) {
+  if (!provider) {
+    return {};
+  }
+  const selectedHarnessRuntime = normalizeOptionalAgentRuntimeId(harnessRuntime);
+  // Provider defaults choose new runs; they cannot move an existing transcript.
+  const useNativeHarnessRuntime =
+    selectedHarnessRuntime !== undefined &&
+    selectedHarnessRuntime !== "openclaw" &&
+    !isDefaultAgentRuntimeId(selectedHarnessRuntime);
+  const runtimeProvider = resolveSelectedOpenAIRuntimeProvider({ provider });
+  const routedRuntimeProvider = runtimeProvider === provider ? undefined : runtimeProvider;
+  return {
+    runtimeProvider: routedRuntimeProvider,
+    contextProvider: useNativeHarnessRuntime ? routedRuntimeProvider : undefined,
+    ...(useNativeHarnessRuntime ? { nativeHarnessCompaction: true } : {}),
+  };
 }
 
 function normalizeCompactionConfigKey(value: string): string {

--- a/src/agents/embedded-agent-runner/compaction-runtime-preparation.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-preparation.ts
@@ -15,6 +15,7 @@ import {
   ensureAuthProfileStore,
   ensureAuthProfileStoreWithoutExternalProfiles,
 } from "../model-auth.js";
+import type { ModelManifestNormalizationContext } from "../model-ref-shared.js";
 import { isOpenAIProvider } from "../openai-routing.js";
 import {
   providerUsesCredentialScopedModelMetadata,
@@ -28,6 +29,7 @@ import {
 import type { AgentRuntimeAuthPlan, AgentRuntimePlan } from "../runtime-plan/types.js";
 import {
   resolveCompactionHarnessRuntime,
+  resolveCompactionTargetRuntime,
   resolveEmbeddedCompactionTarget,
 } from "./compaction-runtime-context.js";
 
@@ -68,6 +70,8 @@ export function resolveCompactionRuntimeSelection(params: {
   preparedRuntimePlan?: AgentRuntimePlan;
   runtimeAuthPlan?: AgentRuntimeAuthPlan;
   selectedHarnessRuntime?: string;
+  allowPluginNormalization?: boolean;
+  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
 }) {
   const runtimePolicySessionKey = params.sandboxSessionKey ?? params.sessionKey ?? undefined;
   const runtimePolicyAgentId =
@@ -83,6 +87,8 @@ export function resolveCompactionRuntimeSelection(params: {
     modelSelectionLocked: params.modelSelectionLocked,
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
+    allowPluginNormalization: params.allowPluginNormalization,
+    manifestPlugins: params.manifestPlugins,
   });
   const policyProvider = policyTarget.provider ?? DEFAULT_PROVIDER;
   const policyModelId = policyTarget.model ?? DEFAULT_MODEL;
@@ -109,16 +115,10 @@ export function resolveCompactionRuntimeSelection(params: {
       provider: policyProvider,
       modelId: policyModelId,
     });
-  const target = resolveEmbeddedCompactionTarget({
-    config: params.config,
-    provider: params.provider,
-    modelId: params.modelId,
-    authProfileId: params.authProfileId,
-    harnessRuntime: selectedHarnessRuntime,
-    modelSelectionLocked: params.modelSelectionLocked,
-    defaultProvider: DEFAULT_PROVIDER,
-    defaultModel: DEFAULT_MODEL,
-  });
+  const target = {
+    ...policyTarget,
+    ...resolveCompactionTargetRuntime(policyTarget.provider, selectedHarnessRuntime),
+  };
   const provider = target.provider ?? DEFAULT_PROVIDER;
   const modelId = target.model ?? DEFAULT_MODEL;
   const selectedRuntime = normalizeOptionalAgentRuntimeId(selectedHarnessRuntime);

--- a/src/agents/model-fallback-candidates.ts
+++ b/src/agents/model-fallback-candidates.ts
@@ -44,6 +44,18 @@ const MAX_FALLBACK_CANDIDATE_CACHE_ENTRIES = 256;
 const fallbackCandidateCache = new Map<string, ModelFallbackCandidate[]>();
 const log = createSubsystemLogger("model-selection");
 
+type ModelCandidateChainParams = ModelManifestNormalizationContext & {
+  cfg: OpenClawConfig | undefined;
+  agentId?: string;
+  provider: string;
+  model: string;
+  /** An explicit list, including empty, replaces the configured model fallbacks. */
+  fallbacksOverride?: string[];
+  requestedRouteResolution?: ModelFallbackRouteResolution;
+  /** Pure admission planning may use manifest policy without entering provider runtime hooks. */
+  allowPluginNormalization?: boolean;
+};
+
 function createModelCandidateCollector(): {
   candidates: ModelFallbackCandidate[];
   addCandidate: (
@@ -147,15 +159,7 @@ export function resolveImageFallbackDefaultProvider(cfg: OpenClawConfig | undefi
 }
 
 export function resolveModelCandidateChain(
-  params: {
-    cfg: OpenClawConfig | undefined;
-    agentId?: string;
-    provider: string;
-    model: string;
-    /** Optional explicit fallbacks list; when provided (even empty), replaces agents.defaults.model.fallbacks. */
-    fallbacksOverride?: string[];
-    requestedRouteResolution?: ModelFallbackRouteResolution;
-  } & ModelManifestNormalizationContext,
+  params: ModelCandidateChainParams,
 ): ModelFallbackCandidate[] {
   const cacheKey = resolveFallbackCandidateCacheKey(params);
   if (cacheKey) {
@@ -181,16 +185,7 @@ function cloneModelCandidate(candidate: ModelFallbackCandidate): ModelFallbackCa
   };
 }
 
-function resolveFallbackCandidateCacheKey(
-  params: {
-    cfg: OpenClawConfig | undefined;
-    agentId?: string;
-    provider: string;
-    model: string;
-    fallbacksOverride?: string[];
-    requestedRouteResolution?: ModelFallbackRouteResolution;
-  } & ModelManifestNormalizationContext,
-): string | null {
+function resolveFallbackCandidateCacheKey(params: ModelCandidateChainParams): string | null {
   if (params.manifestPlugins) {
     return null;
   }
@@ -228,6 +223,7 @@ function resolveFallbackCandidateCacheKey(
     provider: params.provider,
     model: params.model,
     requestedRouteResolution: params.requestedRouteResolution,
+    allowPluginNormalization: params.allowPluginNormalization,
     fallbacksOverride: params.fallbacksOverride,
     agentsDefaultsModel: params.cfg?.agents?.defaults?.model,
     agentsDefaultsModels: params.cfg?.agents?.defaults?.models,
@@ -261,14 +257,7 @@ function resolveFallbackCandidateModelProviderCacheParts(cfg: OpenClawConfig | u
 }
 
 function resolveFallbackCandidatesUncached(
-  params: {
-    cfg: OpenClawConfig | undefined;
-    agentId?: string;
-    provider: string;
-    model: string;
-    fallbacksOverride?: string[];
-    requestedRouteResolution?: ModelFallbackRouteResolution;
-  } & ModelManifestNormalizationContext,
+  params: ModelCandidateChainParams,
 ): ModelFallbackCandidate[] {
   const primary = params.cfg
     ? resolveConfiguredModelRef({
@@ -286,14 +275,17 @@ function resolveFallbackCandidatesUncached(
   const modelRaw = normalizeOptionalString(params.model) || defaultModel;
   const normalizeCandidateRef = (provider: string, model: string) =>
     normalizeModelRef(provider, model, {
-      allowPluginNormalization: allowsPluginModelNormalization({
-        cfg: params.cfg,
-        provider,
-        model,
-      }),
+      allowPluginNormalization:
+        params.allowPluginNormalization !== false &&
+        allowsPluginModelNormalization({
+          cfg: params.cfg,
+          provider,
+          model,
+        }),
       manifestPlugins: params.manifestPlugins,
     });
-  const allowPluginModelAliases = params.cfg?.plugins?.enabled !== false;
+  const allowPluginModelAliases =
+    params.allowPluginNormalization !== false && params.cfg?.plugins?.enabled !== false;
   const normalizedPrimary = normalizeCandidateRef(providerRaw, modelRaw);
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg ?? {},
@@ -322,11 +314,13 @@ function resolveFallbackCandidatesUncached(
         model: modelRaw,
         defaultProvider,
         aliasIndex,
-        allowPluginNormalization: allowsPluginModelNormalization({
-          cfg: params.cfg,
-          provider: providerRaw,
-          model: modelRaw,
-        }),
+        allowPluginNormalization:
+          params.allowPluginNormalization !== false &&
+          allowsPluginModelNormalization({
+            cfg: params.cfg,
+            provider: providerRaw,
+            model: modelRaw,
+          }),
         manifestPlugins: params.manifestPlugins,
       }) ?? normalizedPrimary;
   }

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -3334,6 +3334,33 @@ describe("runWithModelFallback", () => {
     ]);
   });
 
+  it("plans requested and fallback routes without provider runtime hooks when normalization is disabled", () => {
+    const normalize = providerModelNormalizationMock.normalizeProviderModelIdWithRuntime;
+    normalize.mockImplementation(() => {
+      throw new Error("runtime hook entered pure planning");
+    });
+    expect(
+      testing.resolveFallbackCandidates({
+        cfg: makeCfg({
+          agents: {
+            defaults: {
+              model: { primary: "custom/primary", fallbacks: ["custom/fallback"] },
+              models: { "custom/fallback": { alias: "other" } },
+            },
+          },
+        }),
+        provider: "custom",
+        model: "primary",
+        requestedRouteResolution: "resolved",
+        allowPluginNormalization: false,
+      }),
+    ).toEqual([
+      { provider: "custom", model: "primary" },
+      { provider: "custom", model: "fallback" },
+    ]);
+    expect(normalize).not.toHaveBeenCalled();
+  });
+
   it("treats normalized default refs as primary and keeps configured fallback chain", () => {
     const cfg = makeCfg({
       agents: {

--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -1,6 +1,7 @@
 /** Agent-run lease admission for lifecycle-owned prepared model runtimes. */
 import { createAbortError, racePromiseWithAbortSignal } from "../infra/abort-signal.js";
-import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
+import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import { getPreparedModelRuntimeBorrowedSnapshot } from "./prepared-model-runtime-generation-scope.js";
 import {
@@ -25,7 +26,7 @@ import {
   preparedPluginGenerationReusesBase,
   preparedPluginGenerationSupportsSelections,
 } from "./prepared-model-runtime.plugin-generation.js";
-import type { PreparedModelRuntimeCatalogMode } from "./prepared-model-runtime.types.js";
+import type { PreparedModelRuntimeLeaseOptions } from "./prepared-model-runtime.types.js";
 
 type PreparedModelRuntimeLeaseContext = {
   owners: Map<string, PreparedModelRuntimeOwner>;
@@ -86,34 +87,18 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
   rawInput: PreparedModelRuntimeInput,
   provenance: "run" | "ephemeral",
   context: PreparedModelRuntimeLeaseContext,
-  options: {
-    retainIdleRunOwner?: boolean;
-    catalogMode?: PreparedModelRuntimeCatalogMode;
-    pluginGeneration?: PreparedModelRuntimeOwner["pluginGeneration"];
-    pluginMetadataSnapshot?: PluginMetadataSnapshot;
-    abortSignal?: AbortSignal;
-  } = {},
+  options: PreparedModelRuntimeLeaseOptions = {},
 ): Promise<PreparedModelRuntimeLease> {
-  let normalizedInput = normalizePreparedModelRuntimeInput({
+  const deriveSelections = options.deriveRuntimePluginSelections;
+  // Caller choices belong to this invocation; only config-derived choices may change after a wait.
+  const requestedSelections = deriveSelections
+    ? structuredClone(rawInput.runtimePluginSelections ?? [])
+    : [];
+  let input = normalizePreparedModelRuntimeInput({
     ...rawInput,
     preserveWorkspaceDirOnRefresh:
       rawInput.preserveWorkspaceDirOnRefresh ?? rawInput.workspaceDir !== undefined,
   });
-  if (
-    provenance === "run" &&
-    context.getGatewayLifecycleActive() &&
-    !options.pluginGeneration &&
-    !context.getPendingReplacement()
-  ) {
-    try {
-      normalizedInput = rebindInputToCommittedConfiguredOwner(context.owners, normalizedInput);
-    } catch (error) {
-      if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
-        throw error;
-      }
-    }
-  }
-  let input = normalizedInput;
   let key = ownerKey(input);
   let owner: PreparedModelRuntimeOwner;
   let snapshot: PreparedModelRuntimeSnapshot;
@@ -129,12 +114,68 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
       if (context.getPendingReplacement()) {
         continue;
       }
-      if (provenance === "run" && !options.pluginGeneration) {
-        input = rebindInputToCommittedConfiguredOwner(context.owners, input);
-        key = ownerKey(input);
-      }
-      continue;
+      throwIfLeaseAdmissionAborted(options.abortSignal);
     }
+    if (
+      provenance === "run" &&
+      !options.pluginGeneration &&
+      (replacement || context.getGatewayLifecycleActive())
+    ) {
+      try {
+        input = rebindInputToCommittedConfiguredOwner(context.owners, input);
+      } catch (error) {
+        if (replacement || !(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
+          throw error;
+        }
+        const existing = context.owners.get(ownerKey(input));
+        const staleDynamicOwner =
+          existing?.needsRefresh &&
+          !existing.pending &&
+          (existing.provenance === "run" || existing.provenance === "ephemeral");
+        if (!existing || staleDynamicOwner) {
+          const canActivateConfiglessSetup =
+            input.agentId !== undefined && isReservedSystemAgentId(input.agentId);
+          const configuredOwner = resolveConfiguredOwnerPublication(context.owners, input);
+          if (configuredOwner.matches || !canActivateConfiglessSetup) {
+            if (configuredOwner.pending) {
+              await racePromiseWithAbortSignal(configuredOwner.pending, options.abortSignal);
+              continue;
+            }
+            throw error;
+          }
+          // Reserved setup may borrow the configless Gateway before its first owner exists.
+        }
+      }
+    }
+    // Recipes run after config admission. Never carry a derived owner into a later rebind.
+    let pluginMetadataSnapshot = options.pluginMetadataSnapshot;
+    if (deriveSelections) {
+      pluginMetadataSnapshot =
+        options.pluginGeneration?.pluginMetadataSnapshot ??
+        pluginMetadataSnapshot ??
+        resolvePluginMetadataSnapshot({
+          config: input.config,
+          env: input.env,
+          workspaceDir: input.workspaceDir,
+          allowWorkspaceScopedCurrent: true,
+        });
+      const metadataSnapshot = pluginMetadataSnapshot;
+      input = withPluginMetadataSnapshotScope(
+        metadataSnapshot,
+        () => {
+          const derived = deriveSelections({
+            config: input.config,
+            metadataSnapshot,
+          });
+          return normalizePreparedModelRuntimeInput({
+            ...input,
+            runtimePluginSelections: [...requestedSelections, ...derived],
+          });
+        },
+        { trustConfigIdentity: true },
+      );
+    }
+    key = ownerKey(input);
     if (provenance === "run" && context.getGatewayLifecycleActive() && options.pluginGeneration) {
       const configuredOwner = resolveConfiguredOwner(context.owners, input);
       if (configuredOwner?.pending) {
@@ -180,47 +221,11 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
         );
       }
     }
-    let existing = context.owners.get(key);
-    let staleDynamicOwner =
+    const existing = context.owners.get(key);
+    const staleDynamicOwner =
       existing?.needsRefresh &&
       !existing.pending &&
       (existing.provenance === "run" || existing.provenance === "ephemeral");
-    if (
-      context.getGatewayLifecycleActive() &&
-      provenance === "run" &&
-      !options.pluginGeneration &&
-      (!existing || staleDynamicOwner)
-    ) {
-      // Dynamic workspaces still inherit the committed agent/config generation. Only their
-      // explicitly pinned workspace may differ from the configured owner. A stale leased owner
-      // can share this key, so rebase its input before publishing a replacement generation.
-      try {
-        input = rebindInputToCommittedConfiguredOwner(context.owners, input);
-        key = ownerKey(input);
-        existing = context.owners.get(key);
-        staleDynamicOwner =
-          existing?.needsRefresh &&
-          !existing.pending &&
-          (existing.provenance === "run" || existing.provenance === "ephemeral");
-      } catch (error) {
-        if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
-          throw error;
-        }
-        const canActivateConfiglessSetup =
-          input.agentId !== undefined && isReservedSystemAgentId(input.agentId);
-        const configuredOwner = resolveConfiguredOwnerPublication(context.owners, input);
-        if (configuredOwner.matches || !canActivateConfiglessSetup) {
-          const pending = configuredOwner.pending;
-          if (pending) {
-            await racePromiseWithAbortSignal(pending, options.abortSignal);
-            continue;
-          }
-          throw error;
-        }
-        // First-run Model Setup uses the reserved system-agent identity before a configless gateway
-        // has an owner to rebind. Keep ordinary agent runs fail-closed at this ownership boundary.
-      }
-    }
     // A static owner cannot satisfy explicit live discovery; publish a new exact generation.
     const ownerGenerationChanged =
       (options.pluginGeneration !== undefined &&
@@ -269,7 +274,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
           provenance,
           options.catalogMode,
           options.pluginGeneration,
-          options.pluginMetadataSnapshot,
+          pluginMetadataSnapshot,
         );
         // Publication installs its exact owner synchronously before exposing the pending promise.
         const publishingOwner = context.owners.get(key);

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -11,7 +11,10 @@ import {
   resolveAgentWorkspaceDir,
 } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
-import { resolveSelectedAgentHarnessRuntime } from "./harness/runtime-plugin-load-plan.js";
+import {
+  resolveSelectedAgentHarnessRuntime,
+  type AgentHarnessPluginSelection,
+} from "./harness/runtime-plugin-load-plan.js";
 import { resolveLegacyInheritedAuthDir } from "./legacy-inherited-auth-dir.js";
 import { resolveModelCandidateChain } from "./model-fallback-candidates.js";
 import {
@@ -293,17 +296,18 @@ export function normalizePreparedModelRuntimeInput(
   );
   const workspaceDir = normalizeOptionalDir(input.workspaceDir);
   const env = input.env ? Object.freeze({ ...input.env }) : undefined;
-  const runtimePluginSelections = input.runtimePluginSelections
-    ? Object.freeze(
-        [...input.runtimePluginSelections]
-          .map((selection) => {
-            const runtime = resolveSelectedAgentHarnessRuntime(selection, input.config);
-            const { agentId: _agentId, ...normalized } = selection;
-            return Object.freeze({ ...normalized, runtime });
-          })
-          .toSorted((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right))),
-      )
-    : undefined;
+  const selections = new Map<string, AgentHarnessPluginSelection>();
+  for (const selection of input.runtimePluginSelections ?? []) {
+    const runtime = resolveSelectedAgentHarnessRuntime(selection, input.config);
+    const { agentId: _agentId, ...normalized } = selection;
+    const entry = Object.freeze({ ...normalized, runtime });
+    selections.set(JSON.stringify(entry), entry);
+  }
+  const runtimePluginSelections = Object.freeze(
+    [...selections]
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([, entry]) => entry),
+  );
   return {
     ...rest,
     agentDir: path.resolve(input.agentDir),

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -2,7 +2,6 @@
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { registerRuntimeAuthProfileStoreMutationListener } from "./auth-profiles/runtime-snapshots.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import {
@@ -52,7 +51,10 @@ import {
   resolveSafeRefreshAgentIds,
   updateOwnersForScopedRefresh,
 } from "./prepared-model-runtime.refresh-scope.js";
-import type { PreparedModelRuntimeCatalogMode } from "./prepared-model-runtime.types.js";
+import type {
+  PreparedModelRuntimeCatalogMode,
+  PreparedModelRuntimeLeaseOptions,
+} from "./prepared-model-runtime.types.js";
 import { PreparedReplyDispatchPublicationOwner } from "./prepared-reply-dispatch-runtime.js";
 export {
   PreparedModelRuntimeOwnerNotPublishedError,
@@ -296,13 +298,7 @@ const preparedModelRuntimeLeaseContext = {
 /** Acquires a run generation from configured facts; full catalog discovery is explicit. */
 export async function acquireAgentRunPreparedModelRuntime(
   rawInput: PreparedModelRuntimeInput,
-  options: {
-    retainIdleRunOwner?: boolean;
-    catalogMode?: PreparedModelRuntimeCatalogMode;
-    pluginGeneration?: PreparedModelRuntimeOwner["pluginGeneration"];
-    pluginMetadataSnapshot?: PluginMetadataSnapshot;
-    abortSignal?: AbortSignal;
-  } = {},
+  options: PreparedModelRuntimeLeaseOptions = {},
 ): Promise<PreparedModelRuntimeLease> {
   return await acquirePreparedModelRuntimeLeaseFromOwners(
     rawInput,

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -109,6 +109,19 @@ export type PreparedModelRuntimeLease = Readonly<{
   release: () => void;
 }>;
 
+export type PreparedModelRuntimeLeaseOptions = {
+  retainIdleRunOwner?: boolean;
+  catalogMode?: PreparedModelRuntimeCatalogMode;
+  pluginGeneration?: PreparedModelRuntimePluginGeneration;
+  pluginMetadataSnapshot?: PluginMetadataSnapshot;
+  abortSignal?: AbortSignal;
+  /** Pure planning against admitted facts; requested selections remain explicit and additive. */
+  deriveRuntimePluginSelections?: (context: {
+    config: OpenClawConfig;
+    metadataSnapshot: PluginMetadataSnapshot;
+  }) => readonly AgentHarnessPluginSelection[];
+};
+
 export type PreparedModelRuntimePublicationOptions = {
   force?: boolean;
   provenance?: PreparedModelRuntimeOwner["provenance"];


### PR DESCRIPTION
## What Problem This Solves

Compaction waiting through a Gateway configuration reload could use the new prepared runtime with the old context-engine settings and agent directory. A provider switch was worse: the admitted config selected the new summary provider while the prepared registry still held the old one.

## Why This Change Was Made

This change derives compaction provider/harness selections at the runtime admission owner, after config rebinding and before registry construction, then carries that same admitted config and agent directory through queued compaction. Explicit caller choices are captured before waiting; existing leases keep their generation. The request still owns its workspace, transcript, cancellation and native harness fences. Direct compaction now forwards its abort signal into admission. Shared fallback planning honors the existing runtime-normalization control so the admission recipe uses manifest policy without invoking provider hooks.

Duplicate target resolution, rebinding, parameter signatures and a one-use maintenance predicate are removed. Production adds 288/deletes 273, net +15 for the generic admission recipe boundary; tests/test support are net +369. The larger extraction targets an overall production decrease. No configuration, database or protocol surface is added.

## Evidence

Validation: 348 fallback/compaction tests passed, with actual loader/refresh/acquire cases for aliases, provider replacement/removal, locks, explicit choices, input mutation and retained leases. Config/agentDir, registry selection, pure fallback planning and direct cancellation each have failing-before/passing-after evidence. The final cancellation test uses the same abort primitive as admission and verifies its original cause plus no model/session preparation. Independent review found no actionable P0–P2 issues.

Real Anthropic Haiku 4.5 proof passed: priming, aliased manual compaction, expected followup, cacheRead=4,909, cacheWrite=8,250, input=10, and unchanged cache-policy equality. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33990771422) stopped cleanly. Production source for that proof is tree `48fe57e60acb853c1b97f228b262587de84612f2`; later edits only clean up test support. Live proof covers one provider; reload transitions use actual in-process provider fixtures.

The live run also exposed a pre-existing fixture error. Baseline and candidate both had stable marked prefixes of only 1,496/1,471 tokens, below [Haiku 4.5's 4,096-token cache minimum](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#cache-limitations). The long filler was after the cache boundary. Eight test-only lines now supply deterministic workspace context before that boundary; the cache-read and policy assertions are unchanged.

Complete changed checks and full `pnpm build` passed, including core/test typechecks, lint, dead exports, repository guards, plugin declarations/artifacts and Control UI budgets.

Related: #130706. Verified commit: `30c3712fe8231587939ef7ab69b7874719342464`.
